### PR TITLE
Convert remaining motions & fix demos

### DIFF
--- a/app/controllers/boxel.ts
+++ b/app/controllers/boxel.ts
@@ -6,8 +6,9 @@ import { tracked } from '@glimmer/tracking';
 import Changeset from 'animations/models/changeset';
 import { inject as service } from '@ember/service';
 import AnimationsService from '../services/animations';
+import SpringBehavior from 'animations/behaviors/spring';
 
-const FADE_DURATION = 500;
+const FADE_DURATION = 300;
 const TRANSLATE_DURATION = 1000;
 
 class Participant {
@@ -67,6 +68,15 @@ const ISOLATING_INTENT = 'isolating-card';
 const UNISOLATING_INTENT = 'unisolating-card';
 const SORTING_INTENT = 'sorting-cards';
 
+const SORT_SPRING_BEHAVIOR = new SpringBehavior({
+  damping: 12,
+});
+const SPRING_BEHAVIOR = new SpringBehavior({
+  restDisplacementThreshold: 1,
+  restVelocityThreshold: 0.3,
+  damping: 50,
+});
+
 class BoxelController extends Controller {
   @tracked isCardIsolated = false;
   models = [piaMidina, luke, alex];
@@ -106,7 +116,7 @@ class BoxelController extends Controller {
     for (let cardSprite of cardSprites) {
       cardSprite.setupAnimation('position', {
         duration: TRANSLATE_DURATION,
-        easing: 'ease-in-out',
+        behavior: SORT_SPRING_BEHAVIOR,
       });
       cardSprite.setupAnimation('style', {
         property: 'boxShadow',
@@ -131,11 +141,11 @@ class BoxelController extends Controller {
 
       cardSprite.setupAnimation('size', {
         duration: TRANSLATE_DURATION,
-        easing: 'ease-in-out',
+        behavior: SPRING_BEHAVIOR,
       });
       cardSprite.setupAnimation('position', {
         duration: TRANSLATE_DURATION,
-        easing: 'ease-in-out',
+        behavior: SPRING_BEHAVIOR,
       });
       let cardAnimation = cardSprite.startAnimation();
       await cardAnimation.finished;
@@ -182,11 +192,11 @@ class BoxelController extends Controller {
 
       cardSprite.counterpart.setupAnimation('position', {
         duration: TRANSLATE_DURATION,
-        easing: 'ease-in-out',
+        behavior: SPRING_BEHAVIOR,
       });
       cardSprite.counterpart.setupAnimation('size', {
         duration: TRANSLATE_DURATION,
-        easing: 'ease-in-out',
+        behavior: SPRING_BEHAVIOR,
       });
       let cardAnimation = cardSprite.counterpart.startAnimation();
       await cardAnimation.finished;

--- a/app/models/sprite-animation.ts
+++ b/app/models/sprite-animation.ts
@@ -1,4 +1,4 @@
-import Sprite from './sprite';
+import Sprite, { SpriteType } from './sprite';
 
 export class SpriteAnimation {
   animation: Animation;
@@ -12,6 +12,16 @@ export class SpriteAnimation {
       keyframes,
       keyframeAnimationOptions
     );
+
+    if (sprite.type === SpriteType.Removed && keyframes.length) {
+      let lastKeyframe: Keyframe = keyframes[keyframes.length - 1];
+      for (let [property, value] of Object.entries(lastKeyframe)) {
+        // TODO: fix typescript issue, lib.dom.d.ts seems to only accept numbers here
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        sprite.element.style[property] = value;
+      }
+    }
   }
 
   get finished(): Promise<Animation> {

--- a/app/models/sprite.ts
+++ b/app/models/sprite.ts
@@ -177,9 +177,12 @@ export default class Sprite {
       let result: Keyframe[] = [];
       for (let i = 0; i < count; i++) {
         // TODO: this merge algorithm is too naïve, it implies we can have only 1 of each CSS property or it will be overridden
+        // we copy the final frame of a motion if there is another motion that takes longer
         result.push({
-          ...previousKeyframes?.[i],
-          ...motion.keyframes?.[i],
+          ...(previousKeyframes?.[i] ??
+            previousKeyframes[previousKeyframes.length - 1]),
+          ...(motion.keyframes?.[i] ??
+            motion.keyframes[motion.keyframes.length - 1]),
         });
       }
       return result;

--- a/app/models/sprite.ts
+++ b/app/models/sprite.ts
@@ -13,6 +13,7 @@ import { Opacity, OpacityOptions } from 'animations/motions/opacity';
 import { Move, MoveOptions } from '../motions/move';
 import { Resize, ResizeOptions } from '../motions/resize';
 import { CssMotion, CssMotionOptions } from '../motions/css-motion';
+import { FPS } from 'animations/behaviors/base';
 
 class SpriteIdentifier {
   id: string | null;
@@ -169,20 +170,30 @@ export default class Sprite {
   }: {
     time?: number;
   } = {}): SpriteAnimation {
-    let motion = this.motions.find((motion) => motion instanceof Move);
+    let keyframes = this.motions.reduce((previousKeyframes, motion) => {
+      motion.applyBehavior(time);
 
-    // TODO only implemented for Move for now
-    if (!motion || !(motion instanceof Move)) {
-      throw new Error('fail');
-    }
+      let count = Math.max(previousKeyframes.length, motion.keyframes.length);
+      let result: Keyframe[] = [];
+      for (let i = 0; i < count; i++) {
+        // TODO: this merge algorithm is too naïve, it implies we can have only 1 of each CSS property or it will be overridden
+        result.push({
+          ...previousKeyframes?.[i],
+          ...motion.keyframes?.[i],
+        });
+      }
+      return result;
+    }, [] as Keyframe[]);
 
-    motion.applyBehaviour(time);
+    // calculate "real" duration based on amount of keyframes at the given FPS
+    let duration = Math.max(0, (keyframes.length - 1) / FPS);
 
-    return new SpriteAnimation(
-      this,
-      motion.keyframes,
-      motion.keyframeAnimationOptions
-    );
+    let keyframeAnimationOptions = {
+      easing: 'linear',
+      duration,
+    };
+
+    return new SpriteAnimation(this, keyframes, keyframeAnimationOptions);
   }
 }
 

--- a/app/motions/base.ts
+++ b/app/motions/base.ts
@@ -8,12 +8,11 @@ export interface BaseOptions {
 
 export interface KeyframeProvider {
   keyframes: Keyframe[];
-  keyframeAnimationOptions: KeyframeAnimationOptions;
 }
 
 export default abstract class Motion<T extends BaseOptions = BaseOptions>
   implements KeyframeProvider {
   constructor(readonly sprite: Sprite, readonly opts: Partial<T> = {}) {}
   abstract get keyframes(): Keyframe[];
-  abstract get keyframeAnimationOptions(): KeyframeAnimationOptions;
+  abstract applyBehavior(time?: number): void;
 }

--- a/app/motions/css-motion.ts
+++ b/app/motions/css-motion.ts
@@ -60,4 +60,7 @@ export class CssMotion extends Motion<CssMotionOptions> {
       easing: this.opts.easing,
     };
   }
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  applyBehavior(): void {}
 }

--- a/app/motions/move.ts
+++ b/app/motions/move.ts
@@ -3,7 +3,7 @@ import Sprite, { SpriteType } from '../models/sprite';
 import { BoundsDelta } from '../models/context-aware-bounds';
 import SpringBehavior from 'animations/behaviors/spring';
 import BaseValue from 'animations/value';
-import Behavior, { FPS } from 'animations/behaviors/base';
+import Behavior from 'animations/behaviors/base';
 import { BoundsVelocity } from 'animations/utils/measurement';
 
 const DEFAULT_DURATION = 300;
@@ -39,25 +39,6 @@ export class Move extends Motion<MoveOptions> {
     this.duration = opts.duration ?? DEFAULT_DURATION;
     this.x = new BaseValue('x', this.startPosition.x);
     this.y = new BaseValue('y', this.startPosition.y);
-  }
-
-  applyBehaviour(time?: number): void {
-    this.x.applyBehavior(
-      this.behavior,
-      this.endPosition.x,
-      this.duration,
-      this.opts.delay,
-      time,
-      (this.opts.velocity?.x ?? 0) / -1000 // the behaviors take velocity in units per ms instead of per second
-    );
-    this.y.applyBehavior(
-      this.behavior,
-      this.endPosition.y,
-      this.duration,
-      this.opts.delay,
-      time,
-      (this.opts.velocity?.y ?? 0) / -1000
-    );
   }
 
   get startPosition(): Position {
@@ -106,14 +87,22 @@ export class Move extends Motion<MoveOptions> {
     return keyframes;
   }
 
-  get keyframeAnimationOptions(): KeyframeAnimationOptions {
-    // calculate "real" duration based on amount of keyframes at the given FPS
-    let duration = (this.keyframes.length - 1) / FPS;
-
-    return {
-      duration,
-      // we always pass linear here as we precalculate the easings
-      easing: 'linear',
-    };
+  applyBehavior(time?: number): void {
+    this.x.applyBehavior(
+      this.behavior,
+      this.endPosition.x,
+      this.duration,
+      this.opts.delay,
+      time,
+      (this.opts.velocity?.x ?? 0) / -1000 // TODO: the behaviors take velocity in units per ms instead of per second
+    );
+    this.y.applyBehavior(
+      this.behavior,
+      this.endPosition.y,
+      this.duration,
+      this.opts.delay,
+      time,
+      (this.opts.velocity?.y ?? 0) / -1000
+    );
   }
 }

--- a/app/motions/opacity.ts
+++ b/app/motions/opacity.ts
@@ -1,7 +1,11 @@
 import Motion, { BaseOptions } from './base';
 import Sprite from '../models/sprite';
+import LinearBehavior from 'animations/behaviors/linear';
+import BaseValue from 'animations/value';
+import Behavior from 'animations/behaviors/base';
 
 const DEFAULT_DURATION = 300;
+const DEFAULT_BEHAVIOR = LinearBehavior;
 
 function safeParseInt(val: string | undefined) {
   return val == undefined ? undefined : parseInt(val);
@@ -9,11 +13,20 @@ function safeParseInt(val: string | undefined) {
 export interface OpacityOptions extends BaseOptions {
   from?: number;
   to?: number;
+  behavior?: Behavior;
 }
 
 export class Opacity extends Motion<OpacityOptions> {
+  behavior: Behavior;
+  duration: number;
+  value: BaseValue;
+
   constructor(sprite: Sprite, opts: Partial<OpacityOptions>) {
     super(sprite, opts);
+
+    this.behavior = opts.behavior || new DEFAULT_BEHAVIOR();
+    this.duration = opts.duration ?? DEFAULT_DURATION;
+    this.value = new BaseValue('opacity', this.from);
   }
 
   get from(): number {
@@ -31,14 +44,25 @@ export class Opacity extends Motion<OpacityOptions> {
   }
 
   get keyframes(): Keyframe[] {
-    return [{ opacity: this.from }, { opacity: this.to }];
+    let frames = this.value.frames;
+
+    let keyframes = [];
+    for (let frame of frames) {
+      keyframes.push({
+        opacity: `${frame.value ?? 0}`,
+      });
+    }
+
+    return keyframes;
   }
 
-  get keyframeAnimationOptions(): KeyframeAnimationOptions {
-    return {
-      delay: this.opts.delay,
-      duration: this.opts.duration ?? DEFAULT_DURATION,
-      easing: this.opts.easing,
-    };
+  applyBehavior(time?: number): void {
+    this.value.applyBehavior(
+      this.behavior,
+      this.to,
+      this.duration,
+      this.opts.delay,
+      time
+    );
   }
 }

--- a/app/motions/resize.ts
+++ b/app/motions/resize.ts
@@ -1,13 +1,20 @@
 import Motion, { BaseOptions } from './base';
 import Sprite from '../models/sprite';
+import Behavior from 'animations/behaviors/base';
+import { BoundsVelocity } from 'animations/utils/measurement';
+import BaseValue from 'animations/value';
+import SpringBehavior from 'animations/behaviors/spring';
 
 const DEFAULT_DURATION = 300;
+const DEFAULT_BEHAVIOR = SpringBehavior;
 
 export interface ResizeOptions extends BaseOptions {
   startWidth: number;
   startHeight: number;
   endWidth: number;
   endHeight: number;
+  behavior: Behavior;
+  velocity: BoundsVelocity;
 }
 
 interface Size {
@@ -16,8 +23,18 @@ interface Size {
 }
 
 export class Resize extends Motion<ResizeOptions> {
+  behavior: Behavior;
+  duration: number;
+  height: BaseValue;
+  width: BaseValue;
+
   constructor(sprite: Sprite, opts: Partial<ResizeOptions>) {
     super(sprite, opts);
+
+    this.behavior = opts.behavior || new DEFAULT_BEHAVIOR();
+    this.duration = opts.duration ?? DEFAULT_DURATION;
+    this.width = new BaseValue('width', this.startSize.width);
+    this.height = new BaseValue('height', this.startSize.height);
   }
 
   get startSize(): Size {
@@ -37,19 +54,46 @@ export class Resize extends Motion<ResizeOptions> {
   }
 
   get keyframes(): Keyframe[] {
-    let { startSize, endSize } = this;
-    return [
-      { width: `${startSize.width}px`, height: `${startSize.height}px` },
-      { width: `${endSize.width}px`, height: `${endSize.height}px` },
-    ];
+    let widthFrames = this.width.frames;
+    let heightFrames = this.height.frames;
+
+    let count = Math.max(widthFrames.length, heightFrames.length);
+
+    let keyframes = [];
+    for (let i = 0; i < count; i++) {
+      let width =
+        widthFrames[i]?.value ??
+        widthFrames[widthFrames.length - 1]?.value ??
+        0;
+      let height =
+        heightFrames[i]?.value ??
+        heightFrames[heightFrames.length - 1]?.value ??
+        0;
+      keyframes.push({
+        width: `${width}px`,
+        height: `${height}px`,
+      });
+    }
+
+    return keyframes;
   }
 
-  get keyframeAnimationOptions(): KeyframeAnimationOptions {
-    let { opts } = this;
-    return {
-      delay: opts.delay,
-      duration: opts.duration ?? DEFAULT_DURATION,
-      easing: opts.easing,
-    };
+  applyBehavior(time?: number): void {
+    this.width.applyBehavior(
+      this.behavior,
+      this.endSize.width,
+      this.duration,
+      this.opts.delay,
+      time,
+      (this.opts.velocity?.width ?? 0) / -1000 // TODO: the behaviors take velocity in units per ms instead of per second
+    );
+    this.height.applyBehavior(
+      this.behavior,
+      this.endSize.height,
+      this.duration,
+      this.opts.delay,
+      time,
+      (this.opts.velocity?.height ?? 0) / -1000
+    );
   }
 }

--- a/app/templates/list-detail.hbs
+++ b/app/templates/list-detail.hbs
@@ -7,7 +7,7 @@
     {{#unless this.selectedPerson}}
       <ul class="person-list" {{sprite role="list"}}>
         {{#each this.people as |person|}}
-          <li> 
+          <li>
             <span {{sprite role="person-name" id=(concat "person:" person.id)}} class="inline-block font-bold">
               {{person.name}}
             </span>
@@ -17,7 +17,7 @@
             <button
               type="button"
               class="border px-2 rounded-lg text-sm"
-              {{sprite}}
+              {{sprite role="person-button"}}
               {{on 'click' (fn (mut this.selectedPerson) person)}}
             >
               Details &gt;

--- a/app/transitions/list-detail.ts
+++ b/app/transitions/list-detail.ts
@@ -1,18 +1,20 @@
 import { assert } from '@ember/debug';
 import { SpriteType } from 'animations/models/sprite';
 import Changeset from '../models/changeset';
+import LinearBehavior from 'animations/behaviors/linear';
 
 // FADE OUT : ----------
 // TRANSLATE:     ----------
 // FADE IN  :          ----------
 
 // const FADE_OUT_START = 0;
-const FADE_OUT_DURATION = 1000;
-const TRANSLATE_DURATION = 1000;
+const FADE_OUT_DURATION = 400;
+const TRANSLATE_DURATION = 600;
 const TRANSLATE_START = 400;
-const FADE_IN_DURATION = 1000;
+const FADE_IN_DURATION = 100;
 const FADE_IN_START = 900;
 // const TOTAL_DURATION = FADE_IN_START + FADE_IN_DURATION;
+const LINEAR_BEHAVIOR = new LinearBehavior();
 
 export default function listTransition(changeset: Changeset): Promise<void> {
   let { context, insertedSprites, keptSprites, removedSprites } = changeset;
@@ -75,10 +77,12 @@ export default function listTransition(changeset: Changeset): Promise<void> {
         endY: 0,
         delay: TRANSLATE_START,
         duration: TRANSLATE_DURATION,
+        behavior: LINEAR_BEHAVIOR,
       });
       keptSprite.counterpart.setupAnimation('size', {
         delay: TRANSLATE_START,
         duration: TRANSLATE_DURATION,
+        behavior: LINEAR_BEHAVIOR,
       });
       let animation = keptSprite.counterpart.startAnimation();
       animations.push(animation);
@@ -147,6 +151,7 @@ export default function listTransition(changeset: Changeset): Promise<void> {
         endY: 0,
         delay: TRANSLATE_START,
         duration: TRANSLATE_DURATION,
+        behavior: LINEAR_BEHAVIOR,
       });
       keptSprite.counterpart.setupAnimation('style', {
         property: 'fontSize',


### PR DESCRIPTION
This converts the remaining motions to the new system & fixes the demo's to work mostly properly. A couple of the demo's have some issues that were already present and are likely caused by the orchestration (i.e. interruption) rather than the low level primitives.

TODO:
- [x] Fix list-detail demo
- [x] Fix removed sprites popping back in after their animation is finished