### PR TITLE
Experiment with `runAnimations` utility pattern

### DIFF
--- a/app/components/motion-card/styles.css
+++ b/app/components/motion-card/styles.css
@@ -5,14 +5,22 @@
   flex-direction: column;
   border: 2px solid black;
   overflow: hidden;
+  position: relative;
 }
 
 .content {
-  padding: 15px 25px;
+  padding: 40px 50px;
+  color: #fff;
+}
+
+.content p {
+  font-size: 16px;
 }
 
 .footer {
-  margin-top: auto;
+  position: absolute;
+  left: 0;
+  bottom: 0;
   width: 100%;
   height: 50px;
   background: white;

--- a/app/controllers/interruption.ts
+++ b/app/controllers/interruption.ts
@@ -1,70 +1,16 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
 import Changeset from '../models/changeset';
-import { assert } from '@ember/debug';
-import SpringBehavior from 'animations/behaviors/spring';
 import magicMove from '../transitions/magic-move';
+import runAnimations from 'animations/utils/run-animations';
 
-const BALL_SPEED_PX_PER_MS = 0.05;
 class InterruptionController extends Controller {
   @tracked ballGoWhere = 'A';
   animationOriginPosition: DOMRect | null = null;
 
-  @action
-  magicMoveBall(changeset: Changeset): Promise<void> {
-    return magicMove(changeset);
-  }
-
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-  @action moveBall(spriteId: string, changeset: Changeset) {
-    let ballSprite = changeset.spriteFor({ id: spriteId });
-    assert('ballSprite is present', ballSprite);
-    let activeAnimations = ballSprite.element.getAnimations(); // TODO: this is not supported in Safari
-    let initialBounds;
-    let initialVelocity;
-    let time;
-    if (activeAnimations.length) {
-      let activeAnimation = activeAnimations[0];
-      activeAnimation.pause();
-      ballSprite.lockStyles(this.animationOriginPosition);
-      time = activeAnimation.currentTime;
-      // TODO: extract actual precalculated velocity instead of guesstimating
-      let bounds = ballSprite.captureAnimatingBounds(changeset.context.element);
-      initialBounds = bounds.relativeToContext;
-      initialVelocity = bounds.velocity;
-      ballSprite.unlockStyles();
-      activeAnimation.cancel();
-    } else {
-      assert(
-        'kept sprite should always have initialBounds & finalBounds',
-        ballSprite.initialBounds
-      );
-      initialBounds = ballSprite.initialBounds.relativeToContext;
-    }
-    assert(
-      'kept sprite should always have finalBounds',
-      ballSprite.finalBounds
-    );
-    let finalBounds = ballSprite.finalBounds.relativeToContext;
-    this.animationOriginPosition = finalBounds;
-    let deltaX = finalBounds.left - initialBounds.left;
-    let deltaY = finalBounds.top - initialBounds.top;
-    let duration = (deltaX ** 2 + deltaY ** 2) ** 0.5 / BALL_SPEED_PX_PER_MS;
-    let velocity = initialVelocity;
-    ballSprite.setupAnimation('position', {
-      startX: -deltaX,
-      startY: -deltaY,
-      duration,
-      velocity,
-      behavior: new SpringBehavior({ overshootClamping: true, damping: 100 }),
-    });
-    return (
-      ballSprite
-        .startAnimation({ time: time ?? undefined })
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        .finished.catch(() => {})
-    ); // promise rejects when animation is prematurely canceled
+  async transition(changeset: Changeset): Promise<void> {
+    magicMove(changeset);
+    await runAnimations(changeset);
   }
 }
 

--- a/app/controllers/interruption.ts
+++ b/app/controllers/interruption.ts
@@ -3,13 +3,16 @@ import { tracked } from '@glimmer/tracking';
 import Changeset from '../models/changeset';
 import magicMove from '../transitions/magic-move';
 import runAnimations from 'animations/utils/run-animations';
+import SpringBehavior from 'animations/behaviors/spring';
 
 class InterruptionController extends Controller {
   @tracked ballGoWhere = 'A';
   animationOriginPosition: DOMRect | null = null;
 
   async transition(changeset: Changeset): Promise<void> {
-    magicMove(changeset);
+    magicMove(changeset, {
+      behavior: new SpringBehavior({ overshootClamping: true, damping: 100 }),
+    });
     await runAnimations(changeset);
   }
 }

--- a/app/controllers/interruption.ts
+++ b/app/controllers/interruption.ts
@@ -11,7 +11,7 @@ class InterruptionController extends Controller {
 
   async transition(changeset: Changeset): Promise<void> {
     magicMove(changeset, {
-      behavior: new SpringBehavior({ overshootClamping: true, damping: 100 }),
+      behavior: new SpringBehavior({ overshootClamping: false, damping: 11 }),
     });
 
     await runAnimations([...changeset.keptSprites]);

--- a/app/controllers/interruption.ts
+++ b/app/controllers/interruption.ts
@@ -13,7 +13,8 @@ class InterruptionController extends Controller {
     magicMove(changeset, {
       behavior: new SpringBehavior({ overshootClamping: true, damping: 100 }),
     });
-    await runAnimations(changeset);
+
+    await runAnimations([...changeset.keptSprites]);
   }
 }
 

--- a/app/controllers/motion-study.ts
+++ b/app/controllers/motion-study.ts
@@ -3,9 +3,10 @@ import Changeset from 'animations/models/changeset';
 import magicMove from 'animations/transitions/magic-move';
 import { SpriteType } from 'animations/models/sprite';
 import fade from 'animations/transitions/fade';
+import runAnimations from 'animations/utils/run-animations';
 
 export default class MotionStudy extends Controller {
-  async transition(changeset: Changeset) {
+  async transition(changeset: Changeset): Promise<void> {
     let { context } = changeset;
 
     let removedCardContentSprites = changeset.spritesFor({
@@ -14,15 +15,13 @@ export default class MotionStudy extends Controller {
     });
 
     if (removedCardContentSprites.size) {
-      await fade({
+      fade({
         context,
         insertedSprites: new Set(),
         removedSprites: removedCardContentSprites,
         keptSprites: new Set(),
       } as Changeset);
     }
-
-    let animations = [];
 
     let removedCardSprites = changeset.spritesFor({
       role: 'card',
@@ -38,14 +37,13 @@ export default class MotionStudy extends Controller {
       role: 'card',
       type: SpriteType.Kept,
     });
-    animations.push(
-      magicMove({
-        context,
-        insertedSprites: new Set(),
-        removedSprites: new Set(),
-        keptSprites: cardSprites,
-      } as Changeset)
-    );
+
+    magicMove({
+      context,
+      insertedSprites: new Set(),
+      removedSprites: new Set(),
+      keptSprites: cardSprites,
+    } as Changeset);
 
     let cardContentSprites = changeset.spritesFor({
       role: 'card-content',
@@ -55,16 +53,18 @@ export default class MotionStudy extends Controller {
       s.element.style.opacity = '0';
     });
 
-    await Promise.all(animations);
+    await runAnimations(changeset);
 
     removedCardSprites.forEach((r) => r.hide());
 
-    await fade({
+    fade({
       context,
       insertedSprites: cardContentSprites,
       removedSprites: new Set(),
       keptSprites: new Set(),
     } as Changeset);
+
+    await runAnimations(changeset);
 
     cardContentSprites.forEach((s) => {
       s.element.style.removeProperty('opacity');

--- a/app/controllers/motion-study.ts
+++ b/app/controllers/motion-study.ts
@@ -4,10 +4,19 @@ import magicMove from 'animations/transitions/magic-move';
 import { SpriteType } from 'animations/models/sprite';
 import fade from 'animations/transitions/fade';
 import runAnimations from 'animations/utils/run-animations';
+import SpringBehavior from 'animations/behaviors/spring';
 
 export default class MotionStudy extends Controller {
   async transition(changeset: Changeset): Promise<void> {
     let { context } = changeset;
+
+    let behavior = new SpringBehavior({
+      overshootClamping: false,
+      stiffness: 100,
+      damping: 15,
+    });
+    //let moveDuration = 1000;
+    let fadeDuration = 300;
 
     let removedCardContentSprites = changeset.spritesFor({
       role: 'card-content',
@@ -15,12 +24,17 @@ export default class MotionStudy extends Controller {
     });
 
     if (removedCardContentSprites.size) {
-      fade({
-        context,
-        insertedSprites: new Set(),
-        removedSprites: removedCardContentSprites,
-        keptSprites: new Set(),
-      } as Changeset);
+      fade(
+        {
+          context,
+          insertedSprites: new Set(),
+          removedSprites: removedCardContentSprites,
+          keptSprites: new Set(),
+        } as Changeset,
+        {
+          duration: fadeDuration,
+        }
+      );
     }
 
     let removedCardSprites = changeset.spritesFor({
@@ -38,12 +52,18 @@ export default class MotionStudy extends Controller {
       type: SpriteType.Kept,
     });
 
-    magicMove({
-      context,
-      insertedSprites: new Set(),
-      removedSprites: new Set(),
-      keptSprites: cardSprites,
-    } as Changeset);
+    magicMove(
+      {
+        context,
+        insertedSprites: new Set(),
+        removedSprites: new Set(),
+        keptSprites: cardSprites,
+      } as Changeset,
+      {
+        behavior,
+        //duration: moveDuration,
+      }
+    );
 
     let cardContentSprites = changeset.spritesFor({
       role: 'card-content',
@@ -57,12 +77,17 @@ export default class MotionStudy extends Controller {
 
     removedCardSprites.forEach((r) => r.hide());
 
-    fade({
-      context,
-      insertedSprites: cardContentSprites,
-      removedSprites: new Set(),
-      keptSprites: new Set(),
-    } as Changeset);
+    fade(
+      {
+        context,
+        insertedSprites: cardContentSprites,
+        removedSprites: new Set(),
+        keptSprites: new Set(),
+      } as Changeset,
+      {
+        duration: fadeDuration,
+      }
+    );
 
     await runAnimations(changeset);
 

--- a/app/controllers/routes.ts
+++ b/app/controllers/routes.ts
@@ -14,7 +14,7 @@ const springBehavior = new SpringBehavior({
 
 export default class RoutesController extends Controller {
   async transition(changeset: Changeset): Promise<void> {
-    let { removedSprites, keptSprites, context } = changeset;
+    let { removedSprites, keptSprites, insertedSprites, context } = changeset;
 
     assert('Context must always have currentBounds', context.currentBounds);
 
@@ -108,6 +108,10 @@ export default class RoutesController extends Controller {
       });
     }
 
-    await runAnimations(changeset);
+    await runAnimations([
+      ...removedSprites,
+      ...keptSprites,
+      ...insertedSprites,
+    ]);
   }
 }

--- a/app/controllers/routes.ts
+++ b/app/controllers/routes.ts
@@ -5,6 +5,7 @@ import LinearBehavior from 'animations/behaviors/linear';
 import magicMove from 'animations/transitions/magic-move';
 import { assert } from '@ember/debug';
 import ContextAwareBounds from 'animations/models/context-aware-bounds';
+import runAnimations from 'animations/utils/run-animations';
 
 const SPEED_PX_PER_MS = 0.25;
 
@@ -81,12 +82,7 @@ export default class RoutesController extends Controller {
         });
       }
 
-      let animations: Promise<void | Animation>[] = [
-        magicMove(changeset),
-        ...[...removedSprites].map((s) => s.startAnimation().finished),
-      ];
-
-      await Promise.all(animations);
+      magicMove(changeset);
     } else {
       let removedSprite = changeset.spriteFor({ type: SpriteType.Removed });
       let insertedSprite = changeset.spriteFor({ type: SpriteType.Inserted });
@@ -116,13 +112,8 @@ export default class RoutesController extends Controller {
         behavior: new LinearBehavior(),
         duration: durationI,
       });
-
-      let animations = [
-        removedSprite.startAnimation().finished,
-        insertedSprite.startAnimation().finished,
-      ];
-
-      await Promise.all(animations);
     }
+
+    await runAnimations(changeset);
   }
 }

--- a/app/models/changeset.ts
+++ b/app/models/changeset.ts
@@ -174,9 +174,10 @@ export default class Changeset {
           is.identifier.equals(sprite.identifier)
         );
 
+        // If more than 1 matching IntermediateSprite is found, we warn but also guess the last one is correct
         if (interruptedSprites.length > 1) {
           console.warn(
-            `${interruptedSprites.length} matching interruptedSprites found`,
+            `${interruptedSprites.length} matching interruptedSprites found where 1 was expected`,
             interruptedSprites
           );
         }

--- a/app/models/sprite-animation.ts
+++ b/app/models/sprite-animation.ts
@@ -1,5 +1,8 @@
 import Sprite from './sprite';
 
+/**
+ * Animates a sprite. By default, the animation is paused and must be started manually by calling `play()`.
+ */
 export class SpriteAnimation {
   animation: Animation;
 
@@ -12,6 +15,7 @@ export class SpriteAnimation {
       keyframes,
       keyframeAnimationOptions
     );
+    this.animation.pause();
 
     // TODO: we likely don't need this anymore now that we measure beforehand
     /*if (sprite.type === SpriteType.Removed && keyframes.length) {
@@ -24,6 +28,10 @@ export class SpriteAnimation {
         console.log(property, value);
       }
     }*/
+  }
+
+  play(): void {
+    this.animation.play();
   }
 
   get finished(): Promise<Animation> {

--- a/app/models/sprite.ts
+++ b/app/models/sprite.ts
@@ -15,6 +15,8 @@ import { Resize, ResizeOptions } from '../motions/resize';
 import { CssMotion, CssMotionOptions } from '../motions/css-motion';
 import { FPS } from 'animations/behaviors/base';
 import { assert } from '@ember/debug';
+import SpringBehavior from 'animations/behaviors/spring';
+import LinearBehavior from 'animations/behaviors/linear';
 
 class SpriteIdentifier {
   id: string | null;
@@ -158,6 +160,21 @@ export default class Sprite {
       OpacityOptions | MoveOptions | ResizeOptions | CssMotionOptions
     >
   ): void {
+    // TODO: this applies to any "non-Tween" based behavior, currently only Spring
+    assert(
+      'Passing a duration is not necessary when using a Spring behavior',
+      (opts.duration === undefined &&
+        opts.behavior instanceof SpringBehavior) ||
+        !(opts.behavior instanceof SpringBehavior)
+    );
+    // TODO: this applies to any "Tween" based behavior, currently only Linear
+    assert(
+      'You must pass a duration when using a Linear behavior',
+      (opts.duration !== undefined &&
+        opts.behavior instanceof LinearBehavior) ||
+        !(opts.behavior instanceof LinearBehavior)
+    );
+
     switch (property) {
       case 'opacity':
         this.motions.push(new Opacity(this, opts));

--- a/app/models/sprite.ts
+++ b/app/models/sprite.ts
@@ -177,11 +177,15 @@ export default class Sprite {
     }
   }
 
-  startAnimation({
+  compileAnimation({
     time,
   }: {
     time?: number;
-  } = {}): SpriteAnimation {
+  } = {}): SpriteAnimation | undefined {
+    if (!this.motions.length) {
+      return;
+    }
+
     assert('Hidden sprite cannot be animated', !this.hidden);
     let keyframes = this.motions.reduce((previousKeyframes, motion) => {
       motion.applyBehavior(time);
@@ -210,6 +214,19 @@ export default class Sprite {
     };
 
     return new SpriteAnimation(this, keyframes, keyframeAnimationOptions);
+  }
+
+  startAnimation({
+    time,
+  }: {
+    time?: number;
+  } = {}): SpriteAnimation {
+    console.warn(
+      'Calling Sprite.startAnimation is deprecated, please use the runAnimations util.'
+    );
+    let spriteAnimation = this.compileAnimation({ time }) as SpriteAnimation;
+    spriteAnimation.play();
+    return spriteAnimation;
   }
 }
 

--- a/app/models/sprite.ts
+++ b/app/models/sprite.ts
@@ -152,6 +152,7 @@ export default class Sprite {
     this.element.style.opacity = '0';
     this.element.setAttribute('data-sprite-hidden', 'true');
     this.element.getAnimations().forEach((a) => a.cancel());
+    this.motions = [];
   }
 
   setupAnimation(
@@ -221,6 +222,9 @@ export default class Sprite {
       }
       return result;
     }, [] as Keyframe[]);
+
+    // We can clear these as we've compiled them already.
+    this.motions = [];
 
     // calculate "real" duration based on amount of keyframes at the given FPS
     let duration = Math.max(0, (keyframes.length - 1) / FPS);

--- a/app/services/animations.ts
+++ b/app/services/animations.ts
@@ -31,7 +31,7 @@ export default class AnimationsService extends Service {
   eligibleContexts: Set<AnimationContext> = new Set();
   intent: string | undefined;
   currentChangesets: Changeset[] = [];
-  intermediateSprites: WeakMap<AnimationContext, Sprite[]> = new WeakMap();
+  intermediateSprites: WeakMap<AnimationContext, Set<Sprite>> = new WeakMap();
 
   registerContext(context: AnimationContext): void {
     this.spriteTree.addAnimationContext(context);
@@ -127,7 +127,7 @@ export default class AnimationsService extends Service {
       }
     }
 
-    let intermediateSprites: Sprite[] = [];
+    let intermediateSprites: Set<Sprite> = new Set();
     for (let spriteModifier of spriteModifiers) {
       let sprite = SpriteFactory.createIntermediateSprite(spriteModifier);
 
@@ -138,7 +138,7 @@ export default class AnimationsService extends Service {
       sprite.initialBounds = bounds;
       sprite.initialComputedStyle = styles;
       sprite.element.getAnimations().forEach((a) => a.cancel());
-      intermediateSprites.push(sprite);
+      intermediateSprites.add(sprite);
     }
 
     assert(

--- a/app/styles/motion-study/details.css
+++ b/app/styles/motion-study/details.css
@@ -3,7 +3,7 @@
 }
 
 .card {
-  height: 100vh;
+  height: calc(100vh - 50px);
 }
 
 .title {

--- a/app/styles/motion-study/index.css
+++ b/app/styles/motion-study/index.css
@@ -1,8 +1,8 @@
 .grid {
   display: grid;
   grid-auto-rows: 200px;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: calc(50% - 25px) calc(50% - 25px);
   grid-gap: 50px;
 
-  padding: 50px;
+  padding: 100px;
 }

--- a/app/templates/interruption.hbs
+++ b/app/templates/interruption.hbs
@@ -7,7 +7,7 @@
     <p class='mt-4 text-lg'>
       Click one of the four targets to initiate a transition of the circle to the target.
     </p>
-    <AnimationContext @use={{this.magicMoveBall}} class="mt-8 h-64 w-64 m-auto">
+    <AnimationContext @use={{this.transition}} class="mt-8 h-64 w-64 m-auto">
       <div class="bg-grey-lightest relative h-64 w-64">
         <button
           type="button"
@@ -53,7 +53,7 @@
     </AnimationContext>
 
     <p>Different approach</p>
-    <AnimationContext @use={{this.magicMoveBall}} class="mt-8 h-64 w-64 m-auto">
+    <AnimationContext @use={{this.transition}} class="mt-8 h-64 w-64 m-auto">
       <div class="bg-grey-lightest relative h-64 w-64">
         <button
           type="button"

--- a/app/templates/interruption.hbs
+++ b/app/templates/interruption.hbs
@@ -7,6 +7,8 @@
     <p class='mt-4 text-lg'>
       Click one of the four targets to initiate a transition of the circle to the target.
     </p>
+
+    <p class="text-lg mt-16">1 ball sprite</p>
     <AnimationContext @use={{this.transition}} class="mt-8 h-64 w-64 m-auto">
       <div class="bg-grey-lightest relative h-64 w-64">
         <button
@@ -20,7 +22,7 @@
         </button>
         <button
           style="top: 0; right: 0"
-          class="absolute rounded-full w-16 h-16 border-2 p-2 cursor-pointer focus:outline-none focus:shadow-outline"
+          class="absolute rounded-full w-12 h-12 border-2 p-2 cursor-pointer focus:outline-none focus:shadow-outline"
           type="button"
           {{on 'click' (fn (mut this.ballGoWhere) 'B')}}
           {{on-key 'b'}}
@@ -47,12 +49,12 @@
         </button>
         <div
           {{sprite id="single-ball"}}
-          class="absolute rounded-full bg-red w-10 h-10 ball-position-{{this.ballGoWhere}}"
+          class="absolute rounded-full bg-red w-10 h-10 opacity-75 z-10 ball-position-{{this.ballGoWhere}}"
         ></div>
       </div>
     </AnimationContext>
 
-    <p>Different approach</p>
+    <p class="text-lg mt-16">4 ball sprites</p>
     <AnimationContext @use={{this.transition}} class="mt-8 h-64 w-64 m-auto">
       <div class="bg-grey-lightest relative h-64 w-64">
         <button
@@ -65,14 +67,14 @@
           {{#if (eq this.ballGoWhere 'A')}}
             <div
               {{sprite id="ball"}}
-              class="absolute pin rounded-full bg-red w-full h-full ball"
+              class="absolute pin rounded-full bg-red w-full h-full opacity-75 z-10 ball"
             ></div>
           {{/if}}
           A
         </button>
         <button
           style="top: 0; right: 0"
-          class="absolute rounded-full w-16 h-16 border-2 p-2 cursor-pointer focus:outline-none focus:shadow-outline"
+          class="absolute rounded-full w-24 h-24 border-2 p-2 cursor-pointer focus:outline-none focus:shadow-outline"
           type="button"
           {{on 'click' (fn (mut this.ballGoWhere) 'B')}}
           {{on-key 'b'}}
@@ -80,14 +82,14 @@
           {{#if (eq this.ballGoWhere 'B')}}
             <div
               {{sprite id="ball"}}
-              class="absolute pin rounded-full bg-red w-full h-full ball"
+              class="absolute pin rounded-full bg-red w-full h-full opacity-75 z-10 ball"
             ></div>
           {{/if}}
           B
         </button>
         <button
           style="bottom: 0; left: 0"
-          class="absolute rounded-full w-12 h-12 border-2 p-2 cursor-pointer focus:outline-none focus:shadow-outline"
+          class="absolute rounded-full w-24 h-12 border-2 p-2 cursor-pointer focus:outline-none focus:shadow-outline"
           type="button"
           {{on 'click' (fn (mut this.ballGoWhere) 'C')}}
           {{on-key 'c'}}
@@ -95,14 +97,14 @@
           {{#if (eq this.ballGoWhere 'C')}}
             <div
               {{sprite id="ball"}}
-              class="absolute pin rounded-full bg-red w-full h-full ball"
+              class="absolute pin rounded-full bg-red w-full h-full opacity-75 z-10 ball"
             ></div>
           {{/if}}
           C
         </button>
         <button
           style="bottom: 0; right: 0"
-          class="absolute rounded-full w-12 h-12 border-2 p-2 cursor-pointer focus:outline-none focus:shadow-outline"
+          class="absolute rounded-full w-12 h-24 border-2 p-2 cursor-pointer focus:outline-none focus:shadow-outline"
           type="button"
           {{on 'click' (fn (mut this.ballGoWhere) 'D')}}
           {{on-key 'd'}}
@@ -110,7 +112,7 @@
           {{#if (eq this.ballGoWhere 'D')}}
             <div
               {{sprite id="ball"}}
-              class="absolute pin rounded-full bg-red w-full h-full ball"
+              class="absolute pin rounded-full bg-red w-full h-full opacity-75 z-10 ball"
             ></div>
           {{/if}}
           D

--- a/app/templates/motion-study/details.hbs
+++ b/app/templates/motion-study/details.hbs
@@ -1,5 +1,8 @@
 <div local-class="container">
   <MotionCard local-class="card" @identifier={{@model}}>
-    <h2 local-class="title">Details</h2>
+    <h2 local-class="title">Card Title</h2>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
   </MotionCard>
 </div>

--- a/app/transitions/fade.ts
+++ b/app/transitions/fade.ts
@@ -1,5 +1,4 @@
 import Changeset from '../models/changeset';
-import { SpriteAnimation } from '../models/sprite-animation';
 
 /**
   Fades inserted, removed, and kept sprites.
@@ -15,12 +14,10 @@ export default async function ({
   insertedSprites,
   keptSprites,
 }: Changeset): Promise<void> {
-  let animations: SpriteAnimation[] = [];
   for (let s of [...removedSprites]) {
     context.appendOrphan(s);
     s.lockStyles();
     s.setupAnimation('opacity', { to: 0 });
-    animations.push(s.startAnimation());
   }
 
   // TODO: if we get keptSprites of some things
@@ -28,8 +25,5 @@ export default async function ({
   // keep them around after all.
   for (let s of [...insertedSprites, ...keptSprites]) {
     s.setupAnimation('opacity', { from: 0 });
-    animations.push(s.startAnimation());
   }
-
-  await Promise.all(animations.map((a) => a.finished));
 }

--- a/app/transitions/fade.ts
+++ b/app/transitions/fade.ts
@@ -1,4 +1,5 @@
 import Changeset from '../models/changeset';
+import { TransitionOptions } from 'animations/transitions/magic-move';
 
 /**
   Fades inserted, removed, and kept sprites.
@@ -6,24 +7,22 @@ import Changeset from '../models/changeset';
   @function fade
   @export default
 */
-// const FADE_DURATION = 1500;
+export default async function (
+  { context, removedSprites, insertedSprites, keptSprites }: Changeset,
+  options: TransitionOptions = {}
+): Promise<void> {
+  let { behavior, duration } = options;
 
-export default async function ({
-  context,
-  removedSprites,
-  insertedSprites,
-  keptSprites,
-}: Changeset): Promise<void> {
   for (let s of [...removedSprites]) {
     context.appendOrphan(s);
     s.lockStyles();
-    s.setupAnimation('opacity', { to: 0 });
+    s.setupAnimation('opacity', { to: 0, behavior, duration });
   }
 
   // TODO: if we get keptSprites of some things
   // were fading out and then we should get interrupted and decide to
   // keep them around after all.
   for (let s of [...insertedSprites, ...keptSprites]) {
-    s.setupAnimation('opacity', { from: 0 });
+    s.setupAnimation('opacity', { from: 0, behavior, duration });
   }
 }

--- a/app/transitions/magic-move.ts
+++ b/app/transitions/magic-move.ts
@@ -7,6 +7,7 @@ import Behavior from 'animations/behaviors/base';
 export type TransitionOptions = {
   behavior?: Behavior;
   duration?: number;
+  delay?: number;
 };
 
 /**
@@ -20,7 +21,7 @@ export default function (
   options: TransitionOptions = {}
 ): void {
   let { keptSprites } = changeset;
-  let { behavior = new LinearBehavior(), duration } = options;
+  let { behavior = new LinearBehavior(), duration, delay } = options;
 
   for (let s of keptSprites) {
     assert(
@@ -65,6 +66,7 @@ export default function (
         duration,
         velocity,
         behavior,
+        delay,
       });
     }
 
@@ -79,6 +81,7 @@ export default function (
         duration,
         velocity,
         behavior,
+        delay,
       });
     }
 

--- a/app/transitions/magic-move.ts
+++ b/app/transitions/magic-move.ts
@@ -1,5 +1,4 @@
 import Changeset, { SpritesForArgs } from '../models/changeset';
-import { SpriteAnimation } from '../models/sprite-animation';
 import { assert } from '@ember/debug';
 import SpringBehavior from 'animations/behaviors/spring';
 import LinearBehavior from 'animations/behaviors/linear';
@@ -14,17 +13,12 @@ const SPEED_PX_PER_MS = 0.25;
   @function magicMove
   @export default
 */
-export default async function (
-  changeset: Changeset,
-  opts?: SpritesForArgs
-): Promise<void> {
+export default function (changeset: Changeset, opts?: SpritesForArgs): void {
   let { keptSprites } = changeset;
 
   if (opts) {
     keptSprites = changeset.spritesFor({ ...opts, type: SpriteType.Kept });
   }
-
-  let animations: SpriteAnimation[] = [];
 
   for (let s of keptSprites) {
     assert(
@@ -91,9 +85,5 @@ export default async function (
         property: 'backgroundColor',
         from: initialStyles['backgroundColor'],
       });*/
-
-    animations.push(s.startAnimation({ time: time ?? undefined }));
   }
-
-  await Promise.all(animations.map((a) => a.finished));
 }

--- a/app/utils/run-animations.ts
+++ b/app/utils/run-animations.ts
@@ -1,20 +1,19 @@
 import { SpriteAnimation } from 'animations/models/sprite-animation';
-import Changeset from 'animations/models/changeset';
+import Sprite from 'animations/models/sprite';
 
 /**
  * Utility to compile & run all animations that were setup for a given changeset.
  *
- * @param changeset
+ * @param sprites
  * @param time
  */
 export default async function runAnimations(
-  changeset: Changeset,
+  sprites: Sprite[],
   time?: number
 ): Promise<Animation[]> {
-  let { keptSprites, insertedSprites, removedSprites } = changeset;
   let animations: SpriteAnimation[] = [];
   let promises = [];
-  for (let sprite of [...keptSprites, ...insertedSprites, ...removedSprites]) {
+  for (let sprite of sprites) {
     let animation = sprite.compileAnimation({ time });
     if (animation) {
       animations.push(animation);

--- a/app/utils/run-animations.ts
+++ b/app/utils/run-animations.ts
@@ -1,0 +1,30 @@
+import { SpriteAnimation } from 'animations/models/sprite-animation';
+import Changeset from 'animations/models/changeset';
+
+/**
+ * Utility to compile & run all animations that were setup for a given changeset.
+ *
+ * @param changeset
+ * @param time
+ */
+export default async function runAnimations(
+  changeset: Changeset,
+  time?: number
+): Promise<Animation[]> {
+  let { keptSprites, insertedSprites, removedSprites } = changeset;
+  let animations: SpriteAnimation[] = [];
+  let promises = [];
+  for (let sprite of [...keptSprites, ...insertedSprites, ...removedSprites]) {
+    let animation = sprite.compileAnimation({ time });
+    if (animation) {
+      animations.push(animation);
+      promises.push(animation.finished);
+    }
+  }
+
+  animations.forEach((a) => {
+    a.play();
+  });
+
+  return Promise.all(promises);
+}


### PR DESCRIPTION
This cleans up the orchestration flow a little bit. What we're aiming for will likely not be this but at least we're batching the actual web animations now to play together. Theoretically, in the old situation, if a `Sprite.startAnimation()` call takes more than a frame the animations may be out of sync. This prevents that.