### PR TITLE
Interruption fixes

### DIFF
--- a/app/models/changeset.ts
+++ b/app/models/changeset.ts
@@ -214,11 +214,6 @@ export default class Changeset {
             return;
           }
 
-          if (!sprite.initialBounds?.parent) {
-            assert('sprite should always have initialBounds');
-            return;
-          }
-
           if (sprite.counterpart) {
             assert(
               'sprite counterpart should always have initialBounds',
@@ -233,6 +228,15 @@ export default class Changeset {
             sprite.initialComputedStyle =
               interruptedSprite.initialComputedStyle;
           } else {
+            // TODO: check if we want to support this in this way as this case may only happen if the final state is the same as before the interruption.
+            // If we have an inserted sprite with a matching intermediate sprite we are animating the same SpriteModifier
+            //  This makes it a KeptSprite without a counterpart.
+            if (sprite.type === SpriteType.Inserted) {
+              sprite.type = SpriteType.Kept;
+              this.insertedSprites.delete(sprite);
+              this.keptSprites.add(sprite);
+            }
+
             sprite.initialBounds = interruptedSprite.initialBounds;
             sprite.initialComputedStyle =
               interruptedSprite.initialComputedStyle;

--- a/app/models/changeset.ts
+++ b/app/models/changeset.ts
@@ -170,9 +170,28 @@ export default class Changeset {
         ...this.removedSprites,
         ...this.keptSprites,
       ]) {
-        let interruptedSprites = [...intermediateSprites].filter((is) =>
-          is.identifier.equals(sprite.identifier)
-        );
+        // TODO: this is kind of a weird spot to handle cancelling/resuming animations... Find a better one.
+        let interruptedSprites = [...intermediateSprites].filter((is) => {
+          if (is.identifier.equals(sprite.identifier)) {
+            if (is.element.getAnimations().length) {
+              console.warn(
+                `Cancelling existing animations for interrupted sprite`,
+                sprite.identifier
+              );
+              is.element.getAnimations().forEach((a) => a.cancel());
+            }
+            return true;
+          } else {
+            if (is.element.getAnimations().length) {
+              console.warn(
+                `Keeping animations for sprite because sprite was not interrupted`,
+                sprite.identifier
+              );
+              is.element.getAnimations().forEach((a) => a.play());
+            }
+            return false;
+          }
+        });
 
         // If more than 1 matching IntermediateSprite is found, we warn but also guess the last one is correct
         if (interruptedSprites.length > 1) {

--- a/app/models/sprite.ts
+++ b/app/models/sprite.ts
@@ -96,17 +96,27 @@ export default class Sprite {
     return this.type === SpriteType.Removed && this.hidden;
   }
 
-  captureAnimatingBounds(contextElement: HTMLElement): ContextAwareBounds {
+  /**
+   * @param contextElement
+   * @param playAnimations - Whether or not to modify animation play state while measuring.
+   */
+  captureAnimatingBounds(
+    contextElement: HTMLElement,
+    playAnimations?: boolean
+  ): ContextAwareBounds {
     let result = new ContextAwareBounds({
       element: getDocumentPosition(this.element, {
         withAnimations: true,
+        playAnimations,
       }),
       contextElement: getDocumentPosition(contextElement, {
         withAnimations: true,
+        playAnimations,
       }),
     });
     let priorElementBounds = getDocumentPosition(this.element, {
       withAnimationOffset: -100,
+      playAnimations,
     });
 
     // TODO: extract actual precalculated velocity instead of guesstimating

--- a/app/services/animations.ts
+++ b/app/services/animations.ts
@@ -135,7 +135,7 @@ export default class AnimationsService extends Service {
       // progress after we did our measurements.
       sprite.element.getAnimations().forEach((a) => a.pause());
       // TODO: we could leave these measurements to the SpriteFactory as they are unique to the SpriteType
-      let bounds = sprite.captureAnimatingBounds(context.element);
+      let bounds = sprite.captureAnimatingBounds(context.element, false);
       let styles = copyComputedStyle(sprite.element);
       sprite.initialBounds = bounds;
       sprite.initialComputedStyle = styles;

--- a/app/services/animations.ts
+++ b/app/services/animations.ts
@@ -131,13 +131,15 @@ export default class AnimationsService extends Service {
     for (let spriteModifier of spriteModifiers) {
       let sprite = SpriteFactory.createIntermediateSprite(spriteModifier);
 
+      // We cannot know which animations we need to cancel until afterRender, so we will pause them so they don't
+      // progress after we did our measurements.
+      sprite.element.getAnimations().forEach((a) => a.pause());
       // TODO: we could leave these measurements to the SpriteFactory as they are unique to the SpriteType
       let bounds = sprite.captureAnimatingBounds(context.element);
-      let styles = copyComputedStyle(sprite.element); // TODO: check if we need to pause the animation, is so we want to integrate this with captureAnimatingBounds to only pause/play once.
-      // console.log(styles['background-color']);
+      let styles = copyComputedStyle(sprite.element);
       sprite.initialBounds = bounds;
       sprite.initialComputedStyle = styles;
-      sprite.element.getAnimations().forEach((a) => a.cancel());
+
       intermediateSprites.add(sprite);
     }
 


### PR DESCRIPTION
This:
- Handles a couple of edge cases in interruptions that we weren't handling correctly
- Only cancels running animations for sprites that we detect as interrupted (meaning the user is expected to handle a new animation for them) instead of cancelling animations on all sprites every render
- Triggers measurements for all contexts on the first renderDetector call to fix a bug @Aierie saw in the Accordion demo where there are multiple sibling AnimationContexts (we need to optimize this further, but it seems fine for now).  