### PR TITLE
Disable unneeded updateKeyframes calls in motion constructors

### DIFF
--- a/app/motions/move.ts
+++ b/app/motions/move.ts
@@ -41,7 +41,7 @@ export class Move extends Motion<MoveOptions> {
     this.duration = opts.duration ?? DEFAULT_DURATION;
     this.x = new BaseValue('x', this.startPosition.x);
     this.y = new BaseValue('y', this.startPosition.y);
-    this.updateKeyframes();
+    //this.updateKeyframes();
   }
 
   get startPosition(): Position {

--- a/app/motions/opacity.ts
+++ b/app/motions/opacity.ts
@@ -29,7 +29,7 @@ export class Opacity extends Motion<OpacityOptions> {
     this.duration = opts.duration ?? DEFAULT_DURATION;
     this.value = new BaseValue('opacity', this.from);
 
-    this.updateKeyframes();
+    //this.updateKeyframes();
   }
 
   get from(): number {

--- a/app/motions/resize.ts
+++ b/app/motions/resize.ts
@@ -36,7 +36,7 @@ export class Resize extends Motion<ResizeOptions> {
     this.duration = opts.duration ?? DEFAULT_DURATION;
     this.width = new BaseValue('width', this.startSize.width);
     this.height = new BaseValue('height', this.startSize.height);
-    this.updateKeyframes();
+    //this.updateKeyframes();
   }
 
   get startSize(): Size {


### PR DESCRIPTION
Right now we don't need this as the underlying Value instances don't apply a behaviour in their constructor anyway, so we're doing unneeded work. We can clean up the code a bit at a later date.