### PR TITLE
Add support for Nodes to be both a Context as well as a Sprite in the SpriteTree

### DIFF
--- a/addon/addon/services/animations.ts
+++ b/addon/addon/services/animations.ts
@@ -148,7 +148,7 @@ export default class AnimationsService extends Service {
     )?.children;
     if (contextNodeChildren) {
       for (let child of contextNodeChildren) {
-        if (child.nodeType === SpriteTreeNodeType.Sprite) {
+        if (child.nodeType.has(SpriteTreeNodeType.Sprite)) {
           spriteModifiers.add(child.model as SpriteModifier);
         }
       }

--- a/addon/addon/services/animations.ts
+++ b/addon/addon/services/animations.ts
@@ -2,7 +2,7 @@ import Service from '@ember/service';
 
 import AnimationContext from '../components/animation-context';
 import SpriteModifier from '../modifiers/sprite';
-import SpriteTree, { SpriteTreeNodeType } from '../models/sprite-tree';
+import SpriteTree from '../models/sprite-tree';
 import TransitionRunner from '../models/transition-runner';
 import { scheduleOnce } from '@ember/runloop';
 import { taskFor } from 'ember-concurrency-ts';
@@ -148,8 +148,8 @@ export default class AnimationsService extends Service {
     )?.children;
     if (contextNodeChildren) {
       for (let child of contextNodeChildren) {
-        if (child.nodeType.has(SpriteTreeNodeType.Sprite)) {
-          spriteModifiers.add(child.model as SpriteModifier);
+        if (child.isSprite) {
+          spriteModifiers.add(child.spriteModel as SpriteModifier);
         }
       }
     }


### PR DESCRIPTION
This fixes the SpriteTree from not being able to handle AnimationContext as a Sprite, which we do want to allow.

Note: When an element is removed it removes the entire Node from the tree. As conditional modifiers are not a thing, this should be good enough as an approach. Otherwise we could think of just removing the type from the Node if there is more than one.