### PR TITLE
sort by DOM order before adding items to the tree

### DIFF
--- a/addon/addon/models/sprite-tree.ts
+++ b/addon/addon/models/sprite-tree.ts
@@ -126,6 +126,40 @@ export default class SpriteTree {
 
   nodesByElement = new WeakMap<Element, SpriteTreeNode>();
   rootNodes: Set<SpriteTreeNode> = new Set();
+  _pendingAdditions: (
+    | { item: ContextModel; type: 'CONTEXT' }
+    | { item: SpriteModel; type: 'SPRITE' }
+  )[] = [];
+
+  addPendingAnimationContext(item: ContextModel) {
+    this._pendingAdditions.push({ item, type: 'CONTEXT' });
+  }
+
+  addPendingSpriteModifier(item: SpriteModel) {
+    this._pendingAdditions.push({ item, type: 'SPRITE' });
+  }
+
+  flushPendingAdditions() {
+    this._pendingAdditions.sort((a, b) =>
+      a.item.element.compareDocumentPosition(b.item.element) &
+      Node.DOCUMENT_POSITION_FOLLOWING
+        ? -1
+        : 1
+    );
+
+    for (let { item, type } of this._pendingAdditions) {
+      if (type === 'CONTEXT') {
+        this.addAnimationContext(item);
+      } else if (type === 'SPRITE') {
+        this.addSpriteModifier(item);
+      } else {
+        throw new Error('unexpected pending addition');
+      }
+    }
+
+    this._pendingAdditions = [];
+  }
+
   addAnimationContext(context: ContextModel): SpriteTreeNode {
     let existingNode = this.nodesByElement.get(context.element);
 

--- a/addon/addon/models/sprite-tree.ts
+++ b/addon/addon/models/sprite-tree.ts
@@ -140,12 +140,20 @@ export default class SpriteTree {
   }
 
   flushPendingAdditions() {
-    this._pendingAdditions.sort((a, b) =>
-      a.item.element.compareDocumentPosition(b.item.element) &
-      Node.DOCUMENT_POSITION_FOLLOWING
-        ? -1
-        : 1
-    );
+    // sort by document position because parents must always be added before children
+    this._pendingAdditions.sort((a, b) => {
+      let bitmask = a.item.element.compareDocumentPosition(b.item.element);
+
+      assert(
+        'Document position is not implementation-specific or disconnected',
+        !(
+          bitmask & Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC ||
+          bitmask & Node.DOCUMENT_POSITION_DISCONNECTED
+        )
+      );
+
+      return bitmask & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1;
+    });
 
     for (let { item, type } of this._pendingAdditions) {
       if (type === 'CONTEXT') {

--- a/addon/addon/services/animations.ts
+++ b/addon/addon/services/animations.ts
@@ -35,7 +35,7 @@ export default class AnimationsService extends Service {
   runningAnimations: Map<string, Set<Animation>> = new Map();
 
   registerContext(context: AnimationContext): void {
-    this.spriteTree.addAnimationContext(context);
+    this.spriteTree.addPendingAnimationContext(context);
   }
 
   unregisterContext(context: AnimationContext): void {
@@ -44,7 +44,7 @@ export default class AnimationsService extends Service {
   }
 
   registerSpriteModifier(spriteModifier: SpriteModifier): void {
-    this.spriteTree.addSpriteModifier(spriteModifier);
+    this.spriteTree.addPendingSpriteModifier(spriteModifier);
     this.freshlyAdded.add(spriteModifier);
   }
 
@@ -178,6 +178,8 @@ export default class AnimationsService extends Service {
   }
 
   async maybeTransition(): Promise<TaskInstance<void>> {
+    this.spriteTree.flushPendingAdditions();
+
     return taskFor(this.maybeTransitionTask)
       .perform()
       .catch((error) => {


### PR DESCRIPTION
This prevents the bug described in [CS-4062](https://linear.app/cardstack/issue/CS-4062/ensure-that-sprite-tree-represents-dom-hierarchy-correctly), where incorrect sprite tree structure prevents transitions from being applied.

