### PR TITLE
Cleanup global menu with simple styles that wrap the items instead of compressing them

### DIFF
--- a/demo-app/app/styles/application.css
+++ b/demo-app/app/styles/application.css
@@ -1,0 +1,13 @@
+.menu {
+  padding: 15px;
+}
+
+.menu > li {
+  display: inline-block;
+  margin: 0 10px 5px;
+  padding: 0;
+}
+
+.menu > li > a {
+  display: block;
+}

--- a/demo-app/app/templates/application.hbs
+++ b/demo-app/app/templates/application.hbs
@@ -1,53 +1,53 @@
 {{page-title "Animations"}}
 
-<ul class="list-reset flex">
-  <li class="mr-3">
-    <LinkTo @route="index" class="inline-block border border-white rounded hover:border-grey-lighter text-blue hover:bg-grey-lighter py-1 px-3">
+<ul local-class="menu">
+  <li>
+    <LinkTo @route="index">
       Basics
     </LinkTo>
   </li>
-  <li class="mr-3">
-    <LinkTo @route="list-detail" class="inline-block border border-white rounded hover:border-grey-lighter text-blue hover:bg-grey-lighter py-1 px-3">
+  <li>
+    <LinkTo @route="list-detail">
       List Detail
     </LinkTo>
   </li>
-  <li class="mr-3">
-    <LinkTo @route="ea-demos" class="inline-block border border-white rounded hover:border-grey-lighter text-blue hover:bg-grey-lighter py-1 px-3">
+  <li>
+    <LinkTo @route="ea-demos">
       e-animated Demos
     </LinkTo>
   </li>
-  <li class="mr-3">
-    <LinkTo @route="interruption" class="inline-block border border-white rounded hover:border-grey-lighter text-blue hover:bg-grey-lighter py-1 px-3">
+  <li>
+    <LinkTo @route="interruption">
       Interruptions
     </LinkTo>
   </li>
-  <li class="mr-3">
-    <LinkTo @route="boxel" class="inline-block border border-white rounded hover:border-grey-lighter text-blue hover:bg-grey-lighter py-1 px-3">
+  <li>
+    <LinkTo @route="boxel">
       Boxel Demos
     </LinkTo>
   </li>
-  <li class="mr-3">
-    <LinkTo @route="routes" class="inline-block border border-white rounded hover:border-grey-lighter text-blue hover:bg-grey-lighter py-1 px-3">
+  <li>
+    <LinkTo @route="routes">
       Route Transition
     </LinkTo>
   </li>
-  <li class="mr-3">
-    <LinkTo @route="motion-study" class="inline-block border border-white rounded hover:border-grey-lighter text-blue hover:bg-grey-lighter py-1 px-3">
+  <li>
+    <LinkTo @route="motion-study">
       Motion Study
     </LinkTo>
   </li>
-  <li class="mr-3">
-    <LinkTo @route="accordion" class="inline-block border border-white rounded hover:border-grey-lighter text-blue hover:bg-grey-lighter py-1 px-3">
+  <li>
+    <LinkTo @route="accordion">
       Accordion
     </LinkTo>
   </li>
-  <li class="mr-3">
-    <LinkTo @route="nested-contexts" class="inline-block border border-white rounded hover:border-grey-lighter text-blue hover:bg-grey-lighter py-1 px-3">
+  <li>
+    <LinkTo @route="nested-contexts">
       Nested Contexts
     </LinkTo>
   </li>
-  <li class="mr-3">
-    <LinkTo @route="context-selection" class="inline-block border border-white rounded hover:border-grey-lighter text-blue hover:bg-grey-lighter py-1 px-3">
+  <li>
+    <LinkTo @route="context-selection">
       Context Selection
     </LinkTo>
   </li>


### PR DESCRIPTION


<img width="875" alt="Screenshot 2022-06-15 at 16 14 28" src="https://user-images.githubusercontent.com/334789/173849208-9a220691-e10f-4f60-8481-2ade5b338849.png">
