### PR TITLE
Simplify KeptSprite matching algorithm

### DIFF
--- a/addon/addon/models/sprite-snapshot-node-builder.ts
+++ b/addon/addon/models/sprite-snapshot-node-builder.ts
@@ -343,6 +343,7 @@ export class SpriteSnapshotNodeBuilder {
         classifiedInsertedSpriteModifiers.delete(insertedSpriteModifier);
 
         // a matching IntermediateSprite always wins from a RemovedSprite counterpart
+        // as it is more up-to-date (mid-animation interruption).
         let counterpartSpriteModifier =
           intermediateSprite?.modifier ?? removedSpriteModifier;
 

--- a/addon/addon/models/sprite-snapshot-node-builder.ts
+++ b/addon/addon/models/sprite-snapshot-node-builder.ts
@@ -307,8 +307,6 @@ export class SpriteSnapshotNodeBuilder {
 
     // Classify non-natural KeptSprites
     for (let insertedSpriteModifier of classifiedInsertedSpriteModifiers) {
-      let counterpartSpriteModifier: SpriteModifier | undefined;
-
       // find a suitable RemovedSprite counterpart if any
       let removedSpriteModifiers = [...classifiedRemovedSpriteModifiers].filter(
         (removedSpriteModifier) =>
@@ -345,11 +343,9 @@ export class SpriteSnapshotNodeBuilder {
         classifiedInsertedSpriteModifiers.delete(insertedSpriteModifier);
 
         // a matching IntermediateSprite always wins from a RemovedSprite counterpart
-        counterpartSpriteModifier =
+        let counterpartSpriteModifier =
           intermediateSprite?.modifier ?? removedSpriteModifier;
-      }
 
-      if (counterpartSpriteModifier) {
         // Find a stable shared ancestor AnimationContext
         let sharedContext = this.spriteTree.findStableSharedAncestor(
           insertedSpriteModifier,


### PR DESCRIPTION
This significantly simplifies our KeptSprite matching algorithm and should make it more robust against mistakes too. We could refactor this a bit further to prevent the SpriteIdentifiers from being created on the fly all the time.