### PR TITLE
Sprite anchor spike

### DIFF
--- a/addon/addon/components/animation-context/index.ts
+++ b/addon/addon/components/animation-context/index.ts
@@ -30,6 +30,7 @@ export default class AnimationContextComponent extends Component<AnimationContex
   lastBounds: DOMRect | undefined;
   currentBounds: DOMRect | undefined;
   isInitialRenderCompleted = false;
+  isAnchor = true;
 
   get isStable() {
     return (

--- a/addon/addon/models/sprite-snapshot-node-builder.ts
+++ b/addon/addon/models/sprite-snapshot-node-builder.ts
@@ -80,9 +80,9 @@ export class SpriteSnapshotNode {
       assert(
         'kept sprite should have lastBounds and currentBounds',
         spriteModifier.lastBounds &&
-        context.lastBounds &&
-        spriteModifier.currentBounds &&
-        context.currentBounds
+          context.lastBounds &&
+          spriteModifier.currentBounds &&
+          context.currentBounds
       );
 
       if (intermediateSprite) {
@@ -220,7 +220,7 @@ export class SpriteSnapshotNodeBuilder {
           playAnimations: false,
         });
 
-        let closestAnchor = this.spriteTree.closestAnchor(spriteModifier);
+        let closestAnchor = this.spriteTree.closestAnchor(spriteModifier) ?? context;
         // TODO: what about refactoring away checkForChanges and simply treating all leftover sprites in the SpriteTree as KeptSprites
         if (
           !freshlyAdded.has(spriteModifier) &&

--- a/addon/addon/models/sprite-tree.ts
+++ b/addon/addon/models/sprite-tree.ts
@@ -42,8 +42,9 @@ export class SpriteTreeNode {
 
   get isAnchor() {
     return Boolean(
-      (this.contextModel as AnimationContext)?.isAnchor ||
-      (this.spriteModel as SpriteModifier)?.isAnchor
+      ((this.contextModel as AnimationContext)?.isStable &&
+        (this.contextModel as AnimationContext)?.isAnchor) ||
+        (this.spriteModel as SpriteModifier)?.isAnchor
     );
   }
 
@@ -278,7 +279,8 @@ export default class SpriteTree {
 
     if (!resultNode.parent.isContext) {
       console.error(
-        `Sprite "${(spriteModifier as SpriteModifier).id
+        `Sprite "${
+          (spriteModifier as SpriteModifier).id
         }" cannot have another Sprite as a direct parent. An extra AnimationContext will need to be added.`
       );
     }
@@ -300,10 +302,12 @@ export default class SpriteTree {
   lookupNodeByElement(element: Element): SpriteTreeNode | undefined {
     return this.nodesByElement.get(element);
   }
-  closestAnchor(modifier: SpriteModifier): {
-    currentBounds?: DOMRect;
-    lastBounds?: DOMRect;
-  } {
+  closestAnchor(modifier: SpriteModifier):
+    | {
+        currentBounds?: DOMRect;
+        lastBounds?: DOMRect;
+      }
+    | undefined {
     let node = this.lookupNodeByElement(modifier.element);
     let parent = node?.parent;
     while (parent) {
@@ -322,7 +326,6 @@ export default class SpriteTree {
       }
       parent = (parent as SpriteTreeNode).parent;
     }
-    throw new Error(`Could not find anchor for sprite modifier ${modifier.id}`);
   }
   descendantsOf(
     model: SpriteTreeModel,

--- a/addon/addon/modifiers/sprite.ts
+++ b/addon/addon/modifiers/sprite.ts
@@ -15,7 +15,7 @@ interface SpriteModifierArgs {
   named: {
     id: string | null;
     role: string | null;
-    isAnchor: boolean;
+    isAnchor?: boolean;
   };
 }
 
@@ -26,7 +26,7 @@ export default class SpriteModifier extends Modifier<SpriteModifierArgs> {
   currentBounds: DOMRect | undefined;
   lastComputedStyle: CopiedCSS | undefined;
   currentComputedStyle: CopiedCSS | undefined;
-  isAnchor = false;
+  isAnchor = true;
 
   alreadyTracked = false;
 
@@ -36,7 +36,7 @@ export default class SpriteModifier extends Modifier<SpriteModifierArgs> {
     console.log(this.args.named.id, this.args.named.isAnchor);
     this.id = this.args.named.id;
     this.role = this.args.named.role;
-    this.isAnchor = this.args.named.isAnchor;
+    this.isAnchor = this.args.named.isAnchor ?? true;
     this.animations.registerSpriteModifier(this);
     this.captureSnapshot();
   }

--- a/addon/addon/modifiers/sprite.ts
+++ b/addon/addon/modifiers/sprite.ts
@@ -15,6 +15,7 @@ interface SpriteModifierArgs {
   named: {
     id: string | null;
     role: string | null;
+    isAnchor: boolean;
   };
 }
 
@@ -25,14 +26,17 @@ export default class SpriteModifier extends Modifier<SpriteModifierArgs> {
   currentBounds: DOMRect | undefined;
   lastComputedStyle: CopiedCSS | undefined;
   currentComputedStyle: CopiedCSS | undefined;
+  isAnchor = false;
 
   alreadyTracked = false;
 
   @service declare animations: AnimationsService;
 
   didReceiveArguments(): void {
+    console.log(this.args.named.id, this.args.named.isAnchor);
     this.id = this.args.named.id;
     this.role = this.args.named.role;
+    this.isAnchor = this.args.named.isAnchor;
     this.animations.registerSpriteModifier(this);
     this.captureSnapshot();
   }

--- a/addon/addon/services/animations.ts
+++ b/addon/addon/services/animations.ts
@@ -97,10 +97,13 @@ export default class AnimationsService extends Service {
         `${animations.length} animations found in DOM, ${playing} were playing.`
       );
 
+      let animationsToCancel: Animation[] = [];
       for (let context of this.eligibleContexts) {
         // We can't schedule this, if we don't deal with it immediately the animations will already be gone
-        this.willTransition(context);
+        animationsToCancel = animationsToCancel.concat(this.willTransition(context));
       }
+
+      animationsToCancel.forEach((a) => a.cancel());
       scheduleOnce('afterRender', this, this.maybeTransition);
     }
   }
@@ -131,6 +134,8 @@ export default class AnimationsService extends Service {
     // We do not care about "stableness of contexts here".
     // For intermediate sprites it is good enough to measure direct children only.
 
+    let animationsToCancel: Animation[] = [];
+
     let contextNode = this.spriteTree.lookupNodeByElement(
       context.element
     ) as SpriteTreeNode;
@@ -141,7 +146,8 @@ export default class AnimationsService extends Service {
     ]) {
       let spriteModifier = node.spriteModel as SpriteModifier;
       if (spriteModifier) {
-        let animations = node.spriteModel?.element.getAnimations();
+        let animations = node.spriteModel?.element.getAnimations() ?? [];
+        animationsToCancel = animationsToCancel.concat(animations);
         if (animations?.length) {
           spriteModifier.captureSnapshot({
             withAnimations: true,
@@ -165,17 +171,17 @@ export default class AnimationsService extends Service {
             intermediateStyles:
               spriteModifier.currentComputedStyle as CopiedCSS,
           });
-
-          // TODO: this may not be the best spot for this
-          animations.forEach((a) => a.cancel());
         } else {
           spriteModifier.captureSnapshot();
         }
       }
     }
+
+    return animationsToCancel;
   }
 
-  willTransition(context: AnimationContext): void {
+  willTransition(context: AnimationContext): Animation[] {
+    let animationsToCancel: Animation[] = [];
     // TODO: what about intents
     // TODO: it might be possible to only measure if we know something changed since last we measured.
 
@@ -185,12 +191,14 @@ export default class AnimationsService extends Service {
     // The element check is there because the renderDetector may fire this before the actual element exists.
     if (context.element) {
       context.captureSnapshot();
-      this.createIntermediateSpritesForContext(context);
+      animationsToCancel = this.createIntermediateSpritesForContext(context);
       let contextNode = this.spriteTree.lookupNodeByElement(
         context.element
       ) as SpriteTreeNode;
       contextNode.freshlyRemovedChildren.clear();
     }
+
+    return animationsToCancel;
   }
 
   async maybeTransition(): Promise<TaskInstance<void>> {

--- a/demo-app/app/templates/nested-sprites.hbs
+++ b/demo-app/app/templates/nested-sprites.hbs
@@ -12,7 +12,7 @@
   </AnimationContext>
 
   <AnimationContext @use={{this.transition}} local-class="context">
-    <div {{sprite id="outer-no-context"}} local-class="outer {{if this.moveOuter "right"}}">
+    <div {{sprite id="outer-no-context" isAnchor=true}} local-class="outer {{if this.moveOuter "right"}}">
       Outer Sprite
       <div {{sprite id="inner-no-context"}} local-class="inner {{if this.moveInner "right"}}">Inner Sprite</div>
     </div>

--- a/demo-app/app/templates/nested-sprites.hbs
+++ b/demo-app/app/templates/nested-sprites.hbs
@@ -12,7 +12,7 @@
   </AnimationContext>
 
   <AnimationContext @use={{this.transition}} local-class="context">
-    <div {{sprite id="outer-no-context" isAnchor=true}} local-class="outer {{if this.moveOuter "right"}}">
+    <div {{sprite id="outer-no-context"}} local-class="outer {{if this.moveOuter "right"}}">
       Outer Sprite
       <div {{sprite id="inner-no-context"}} local-class="inner {{if this.moveInner "right"}}">Inner Sprite</div>
     </div>


### PR DESCRIPTION
This uses `isAnchor` to make the user able to opt in to change detection being done relative to another sprite. Purpose of API change to avoid having to specify animation contexts just to prevent "changes" of natural kept sprites that are due to movement of a parent sprite, since this has implications on complexity of orchestration. Measurements are still made relative to the controlling context - this seems important for orchestration, `isAnchor` just helps with reducing "false positives" in change detection. 

Thinking about next steps: 
- Tree traversal (top down) with scoped state that stores the closest anchor for each scope would be better, maybe?
- If the metadata API we choose to use handles grouping, might be related to this.
- This works better if we provide all sprites in a context in the changeset, not just those which are "freshly changed", because users can still dig for a specific sprite if they know they need it.