### PR TITLE
Refactor types

### DIFF
--- a/addon/addon/components/animation-context/index.ts
+++ b/addon/addon/components/animation-context/index.ts
@@ -10,6 +10,7 @@ import { action } from '@ember/object';
 import AnimationsService from 'animations-experiment/services/animations';
 import { assert } from '@ember/debug';
 import { getDocumentPosition } from 'animations-experiment/utils/measurement';
+import { ContextModel } from 'animations-experiment/models/sprite-tree';
 
 const { VOLATILE_TAG, consumeTag } =
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -21,7 +22,10 @@ interface AnimationContextArgs {
   use: ((changeset: Changeset) => Promise<void>) | undefined;
 }
 
-export default class AnimationContextComponent extends Component<AnimationContextArgs> {
+export default class AnimationContextComponent
+  extends Component<AnimationContextArgs>
+  implements ContextModel
+{
   @service declare animations: AnimationsService;
   @reads('args.id') id: string | undefined;
 

--- a/addon/addon/components/animation-context/index.ts
+++ b/addon/addon/components/animation-context/index.ts
@@ -10,7 +10,7 @@ import { action } from '@ember/object';
 import AnimationsService from 'animations-experiment/services/animations';
 import { assert } from '@ember/debug';
 import { getDocumentPosition } from 'animations-experiment/utils/measurement';
-import { ContextModel } from 'animations-experiment/models/sprite-tree';
+import { Context } from 'animations-experiment/models/sprite-tree';
 
 const { VOLATILE_TAG, consumeTag } =
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -24,7 +24,7 @@ interface AnimationContextArgs {
 
 export default class AnimationContextComponent
   extends Component<AnimationContextArgs>
-  implements ContextModel
+  implements Context
 {
   @service declare animations: AnimationsService;
   @reads('args.id') id: string | undefined;

--- a/addon/addon/models/changeset.ts
+++ b/addon/addon/models/changeset.ts
@@ -1,6 +1,6 @@
 import Sprite, { SpriteType } from './sprite';
 import { assert } from '@ember/debug';
-import { ContextModel } from './sprite-tree';
+import { Context } from './sprite-tree';
 
 export type SpritesForArgs = {
   type?: SpriteType | undefined;
@@ -27,13 +27,13 @@ function union<T>(...sets: Set<T>[]): Set<T> {
 }
 
 export default class Changeset {
-  context: ContextModel;
+  context: Context;
   intent: string | undefined;
   insertedSprites: Set<Sprite> = new Set();
   removedSprites: Set<Sprite> = new Set();
   keptSprites: Set<Sprite> = new Set();
 
-  constructor(animationContext: ContextModel, intent: string | undefined) {
+  constructor(animationContext: Context, intent: string | undefined) {
     this.context = animationContext;
     this.intent = intent;
   }

--- a/addon/addon/models/changeset.ts
+++ b/addon/addon/models/changeset.ts
@@ -1,6 +1,6 @@
 import Sprite, { SpriteType } from './sprite';
-import AnimationContext from '../components/animation-context';
 import { assert } from '@ember/debug';
+import { ContextModel } from './sprite-tree';
 
 export type SpritesForArgs = {
   type?: SpriteType | undefined;
@@ -27,13 +27,13 @@ function union<T>(...sets: Set<T>[]): Set<T> {
 }
 
 export default class Changeset {
-  context: AnimationContext;
+  context: ContextModel;
   intent: string | undefined;
   insertedSprites: Set<Sprite> = new Set();
   removedSprites: Set<Sprite> = new Set();
   keptSprites: Set<Sprite> = new Set();
 
-  constructor(animationContext: AnimationContext, intent: string | undefined) {
+  constructor(animationContext: ContextModel, intent: string | undefined) {
     this.context = animationContext;
     this.intent = intent;
   }

--- a/addon/addon/models/sprite-tree.ts
+++ b/addon/addon/models/sprite-tree.ts
@@ -185,7 +185,8 @@ export class SpriteTreeNode {
       text += `🥡${contextId ? ` ${contextId}` : ''} `;
     }
     if (this.isSprite) {
-      let spriteId = (this as { spriteModel: SpriteStateTracker }).spriteModel.id;
+      let spriteId = (this as { spriteModel: SpriteStateTracker }).spriteModel
+        .id;
       text += `🥠${spriteId ? ` ${spriteId}` : ''}`;
     }
     let extra = isRemoved ? '❌' : undefined;
@@ -215,7 +216,8 @@ export default class SpriteTree {
     | { item: Context; type: 'CONTEXT' }
     | { item: SpriteStateTracker; type: 'SPRITE' }
   )[] = [];
-  freshlyRemovedToNode: WeakMap<SpriteStateTracker, SpriteTreeNode> = new WeakMap();
+  freshlyRemovedToNode: WeakMap<SpriteStateTracker, SpriteTreeNode> =
+    new WeakMap();
 
   addPendingAnimationContext(item: Context) {
     this._pendingAdditions.push({ item, type: 'CONTEXT' });
@@ -410,7 +412,10 @@ export default class SpriteTree {
     return null;
   }
 
-  findStableSharedAncestor(spriteA: SpriteStateTracker, spriteB: SpriteStateTracker) {
+  findStableSharedAncestor(
+    spriteA: SpriteStateTracker,
+    spriteB: SpriteStateTracker
+  ) {
     let ancestorsOfKeptSprite = this.nodesByElement
       .get(spriteA.element)
       ?.ancestors.filter((v) => v.contextModel?.isStable);

--- a/addon/addon/models/transition-runner.ts
+++ b/addon/addon/models/transition-runner.ts
@@ -2,13 +2,13 @@ import { task } from 'ember-concurrency';
 import Changeset from '../models/changeset';
 import Sprite, { SpriteType } from '../models/sprite';
 import { assert } from '@ember/debug';
-import { ContextModel } from './sprite-tree';
+import { Context } from './sprite-tree';
 
 export default class TransitionRunner {
-  animationContext: ContextModel;
+  animationContext: Context;
   intent: string | undefined;
 
-  constructor(animationContext: ContextModel) {
+  constructor(animationContext: Context) {
     this.animationContext = animationContext;
   }
 
@@ -37,7 +37,7 @@ export default class TransitionRunner {
 
   private logChangeset(
     changeset: Changeset,
-    animationContext: ContextModel
+    animationContext: Context
   ): void {
     let contextId = animationContext.args.id;
     function row(type: SpriteType, sprite: Sprite) {

--- a/addon/addon/models/transition-runner.ts
+++ b/addon/addon/models/transition-runner.ts
@@ -35,10 +35,7 @@ export default class TransitionRunner {
     }
   }
 
-  private logChangeset(
-    changeset: Changeset,
-    animationContext: Context
-  ): void {
+  private logChangeset(changeset: Changeset, animationContext: Context): void {
     let contextId = animationContext.args.id;
     function row(type: SpriteType, sprite: Sprite) {
       return {

--- a/addon/addon/models/transition-runner.ts
+++ b/addon/addon/models/transition-runner.ts
@@ -1,14 +1,14 @@
-import AnimationContext from 'animations-experiment/components/animation-context';
 import { task } from 'ember-concurrency';
 import Changeset from '../models/changeset';
 import Sprite, { SpriteType } from '../models/sprite';
 import { assert } from '@ember/debug';
+import { ContextModel } from './sprite-tree';
 
 export default class TransitionRunner {
-  animationContext: AnimationContext;
+  animationContext: ContextModel;
   intent: string | undefined;
 
-  constructor(animationContext: AnimationContext) {
+  constructor(animationContext: ContextModel) {
     this.animationContext = animationContext;
   }
 
@@ -37,7 +37,7 @@ export default class TransitionRunner {
 
   private logChangeset(
     changeset: Changeset,
-    animationContext: AnimationContext
+    animationContext: ContextModel
   ): void {
     let contextId = animationContext.args.id;
     function row(type: SpriteType, sprite: Sprite) {

--- a/test-app/tests/unit/models/sprite-snapshot-node-builder-test.ts
+++ b/test-app/tests/unit/models/sprite-snapshot-node-builder-test.ts
@@ -1,23 +1,18 @@
 import { module, test } from 'qunit';
-import SpriteTree from 'animations-experiment/models/sprite-tree';
-import AnimationContextComponent from 'animations-experiment/components/animation-context';
+import SpriteTree, {
+  ContextModel,
+  SpriteModel,
+} from 'animations-experiment/models/sprite-tree';
 import {
   SpriteSnapshotNode,
   SpriteSnapshotNodeBuilder,
 } from 'animations-experiment/models/sprite-snapshot-node-builder';
-import SpriteModifier from 'animations-experiment/modifiers/sprite';
-import { SpriteIdentifier } from 'animations-experiment/models/sprite';
+import Sprite, { SpriteIdentifier } from 'animations-experiment/models/sprite';
 import { IntermediateSprite } from 'animations-experiment/services/animations';
 import { CopiedCSS } from 'animations-experiment/utils/measurement';
 import ContextAwareBounds from 'animations-experiment/models/context-aware-bounds';
 
-class MockAnimationContext
-  implements
-    Pick<
-      AnimationContextComponent,
-      'element' | 'isStable' | 'isInitialRenderCompleted'
-    >
-{
+class MockAnimationContext implements ContextModel {
   id: string | undefined;
   element: HTMLElement;
   isAnimationContext = true;
@@ -26,6 +21,7 @@ class MockAnimationContext
   lastBounds: DOMRect | undefined = undefined;
   currentBounds = new DOMRect(0, 0, 0, 0);
   nextBounds = new DOMRect(0, 0, 0, 0);
+  args = {};
 
   constructor(
     parentEl: HTMLElement | null = null,
@@ -37,6 +33,26 @@ class MockAnimationContext
       parentEl.appendChild(this.element);
     }
     this.id = id;
+  }
+
+  shouldAnimate(): boolean {
+    throw new Error('Method not implemented.');
+  }
+
+  hasOrphan(_sprite: Sprite): boolean {
+    throw new Error('Method not implemented.');
+  }
+
+  removeOrphan(_sprite: Sprite): void {
+    throw new Error('Method not implemented.');
+  }
+
+  appendOrphan(_sprite: Sprite): void {
+    throw new Error('Method not implemented.');
+  }
+
+  clearOrphans(): void {
+    throw new Error('Method not implemented.');
   }
 
   captureSnapshot() {
@@ -65,7 +81,7 @@ class MockAnimationContext
   }
 }
 
-class MockSpriteModifier implements Partial<SpriteModifier> {
+class MockSpriteModifier implements SpriteModel {
   element: HTMLElement;
   id: string;
   lastBounds: DOMRect | undefined = undefined;
@@ -83,6 +99,9 @@ class MockSpriteModifier implements Partial<SpriteModifier> {
       parentEl.appendChild(this.element);
     }
   }
+  role: string | null = null;
+  lastComputedStyle: CopiedCSS | undefined;
+  currentComputedStyle: CopiedCSS | undefined;
 
   willTransformInto(domrect: DOMRect) {
     this.nextBounds = domrect;
@@ -166,7 +185,7 @@ module('Unit | Util | SpriteSnapshotNodeBuilder', function () {
     ]) {
       if (item instanceof MockSpriteModifier) {
         spriteTree.addPendingSpriteModifier(item);
-      } else {
+      } else if (item instanceof MockAnimationContext) {
         spriteTree.addPendingAnimationContext(item);
       }
     }
@@ -175,20 +194,17 @@ module('Unit | Util | SpriteSnapshotNodeBuilder', function () {
 
     let spriteSnapshotNodeBuilder = new SpriteSnapshotNodeBuilder(
       spriteTree,
-      new Set([
-        stableContext1,
-        stableContext2,
-      ]) as unknown as Set<AnimationContextComponent>,
-      new Set([freshlyAddedSprite]) as unknown as Set<SpriteModifier>,
-      new Set([freshlyRemovedSprite]) as unknown as Set<SpriteModifier>,
+      new Set([stableContext1, stableContext2]),
+      new Set([freshlyAddedSprite]),
+      new Set([freshlyRemovedSprite]),
       new Map()
     );
 
     let context1Node = spriteSnapshotNodeBuilder.contextToNode.get(
-      stableContext1 as unknown as AnimationContextComponent
+      stableContext1
     ) as SpriteSnapshotNode;
     let context2Node = spriteSnapshotNodeBuilder.contextToNode.get(
-      stableContext2 as unknown as AnimationContextComponent
+      stableContext2
     ) as SpriteSnapshotNode;
 
     assert.equal(
@@ -311,7 +327,7 @@ module('Unit | Util | SpriteSnapshotNodeBuilder', function () {
     ]) {
       if (item instanceof MockSpriteModifier) {
         spriteTree.addPendingSpriteModifier(item);
-      } else {
+      } else if (item instanceof MockAnimationContext) {
         spriteTree.addPendingAnimationContext(item);
       }
     }
@@ -319,20 +335,17 @@ module('Unit | Util | SpriteSnapshotNodeBuilder', function () {
 
     let spriteSnapshotNodeBuilder = new SpriteSnapshotNodeBuilder(
       spriteTree,
-      new Set([
-        movedContext,
-        unmovedContext,
-      ]) as unknown as Set<AnimationContextComponent>,
-      new Set([freshlyAddedSprite]) as unknown as Set<SpriteModifier>,
-      new Set() as unknown as Set<SpriteModifier>,
+      new Set([movedContext, unmovedContext]),
+      new Set([freshlyAddedSprite]),
+      new Set(),
       new Map()
     );
 
     let movedContextNode = spriteSnapshotNodeBuilder.contextToNode.get(
-      movedContext as unknown as AnimationContextComponent
+      movedContext
     ) as SpriteSnapshotNode;
     let unmovedContextNode = spriteSnapshotNodeBuilder.contextToNode.get(
-      unmovedContext as unknown as AnimationContextComponent
+      unmovedContext
     ) as SpriteSnapshotNode;
 
     assert.ok(
@@ -398,25 +411,18 @@ module('Unit | Util | SpriteSnapshotNodeBuilder', function () {
 
     let spriteSnapshotNodeBuilder = new SpriteSnapshotNodeBuilder(
       spriteTree,
-      new Set([
-        stableContext,
-        unstableContext,
-      ]) as unknown as Set<AnimationContextComponent>,
-      new Set() as unknown as Set<SpriteModifier>,
-      new Set() as unknown as Set<SpriteModifier>,
+      new Set([stableContext, unstableContext]),
+      new Set(),
+      new Set(),
       new Map()
     );
 
     assert.ok(
-      spriteSnapshotNodeBuilder.contextToNode.get(
-        stableContext as unknown as AnimationContextComponent
-      ),
+      spriteSnapshotNodeBuilder.contextToNode.get(stableContext),
       'Stable context is in the contextToNode map'
     );
     assert.notOk(
-      spriteSnapshotNodeBuilder.contextToNode.get(
-        unstableContext as unknown as AnimationContextComponent
-      ),
+      spriteSnapshotNodeBuilder.contextToNode.get(unstableContext),
       'Stable context is not in the contextToNode map'
     );
     assert.equal(
@@ -465,20 +471,17 @@ module('Unit | Util | SpriteSnapshotNodeBuilder', function () {
 
     let spriteSnapshotTree = new SpriteSnapshotNodeBuilder(
       spriteTree,
-      new Set([
-        outerContext,
-        innerContext,
-      ]) as unknown as Set<AnimationContextComponent>,
-      new Set([freshlyAddedSprite]) as unknown as Set<SpriteModifier>,
-      new Set([freshlyRemovedSprite]) as unknown as Set<SpriteModifier>,
+      new Set([outerContext, innerContext]),
+      new Set([freshlyAddedSprite]),
+      new Set([freshlyRemovedSprite]),
       new Map()
     );
 
     let outerContextNode = spriteSnapshotTree.contextToNode.get(
-      outerContext as unknown as AnimationContextComponent
+      outerContext
     ) as SpriteSnapshotNode;
     let innerContextNode = spriteSnapshotTree.contextToNode.get(
-      innerContext as unknown as AnimationContextComponent
+      innerContext
     ) as SpriteSnapshotNode;
     assert.ok(
       outerContextNode.insertedSprites.size === 0 &&
@@ -574,12 +577,9 @@ module('Unit | Util | SpriteSnapshotNodeBuilder', function () {
 
     let spriteSnapshotTree = new SpriteSnapshotNodeBuilder(
       spriteTree,
-      new Set([
-        outerContext,
-        innerContext,
-      ]) as unknown as Set<AnimationContextComponent>,
-      new Set([]) as unknown as Set<SpriteModifier>,
-      new Set([freshlyRemovedSprite]) as unknown as Set<SpriteModifier>,
+      new Set([outerContext, innerContext]),
+      new Set([]),
+      new Set([freshlyRemovedSprite]),
       new Map<string, IntermediateSprite>([
         [
           new SpriteIdentifier(
@@ -587,7 +587,7 @@ module('Unit | Util | SpriteSnapshotNodeBuilder', function () {
             null
           ).toString(),
           {
-            modifier: spriteFromPreviousRender as unknown as SpriteModifier,
+            modifier: spriteFromPreviousRender,
             intermediateBounds: spriteFromPreviousRenderNextDOMRect,
             intermediateStyles: {} as CopiedCSS,
           } as IntermediateSprite,
@@ -595,8 +595,7 @@ module('Unit | Util | SpriteSnapshotNodeBuilder', function () {
         [
           new SpriteIdentifier('modifier-control', null).toString(),
           {
-            modifier:
-              controlSpriteFromPreviousRender as unknown as SpriteModifier,
+            modifier: controlSpriteFromPreviousRender,
             intermediateBounds: new DOMRect(),
             intermediateStyles: {} as CopiedCSS,
           } as IntermediateSprite,
@@ -605,10 +604,10 @@ module('Unit | Util | SpriteSnapshotNodeBuilder', function () {
     );
 
     let outerContextNode = spriteSnapshotTree.contextToNode.get(
-      outerContext as unknown as AnimationContextComponent
+      outerContext
     ) as SpriteSnapshotNode;
     let innerContextNode = spriteSnapshotTree.contextToNode.get(
-      innerContext as unknown as AnimationContextComponent
+      innerContext
     ) as SpriteSnapshotNode;
     assert.ok(
       outerContextNode.insertedSprites.size === 0 &&

--- a/test-app/tests/unit/models/sprite-snapshot-node-builder-test.ts
+++ b/test-app/tests/unit/models/sprite-snapshot-node-builder-test.ts
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import SpriteTree, {
-  ContextModel,
-  SpriteModel,
+  Context,
+  SpriteStateTracker,
 } from 'animations-experiment/models/sprite-tree';
 import {
   SpriteSnapshotNode,
@@ -12,7 +12,7 @@ import { IntermediateSprite } from 'animations-experiment/services/animations';
 import { CopiedCSS } from 'animations-experiment/utils/measurement';
 import ContextAwareBounds from 'animations-experiment/models/context-aware-bounds';
 
-class MockAnimationContext implements ContextModel {
+class MockAnimationContext implements Context {
   id: string | undefined;
   element: HTMLElement;
   isAnimationContext = true;
@@ -81,7 +81,7 @@ class MockAnimationContext implements ContextModel {
   }
 }
 
-class MockSpriteModifier implements SpriteModel {
+class MockSpriteModifier implements SpriteStateTracker {
   element: HTMLElement;
   id: string;
   lastBounds: DOMRect | undefined = undefined;

--- a/test-app/tests/unit/models/sprite-tree-test.ts
+++ b/test-app/tests/unit/models/sprite-tree-test.ts
@@ -2,13 +2,13 @@
 import Sprite from 'animations-experiment/models/sprite';
 import { CopiedCSS } from 'animations-experiment/utils/measurement';
 import SpriteTree, {
-  ContextModel,
-  SpriteModel,
+  Context,
+  SpriteStateTracker,
   SpriteTreeNode,
 } from 'animations-experiment/models/sprite-tree';
 import { module, test } from 'qunit';
 
-class MockAnimationContext implements ContextModel {
+class MockAnimationContext implements Context {
   id: string | undefined;
   element: HTMLElement;
   isAnimationContext = true;
@@ -51,7 +51,7 @@ class MockAnimationContext implements ContextModel {
   }
 }
 
-class MockSpriteModifier implements SpriteModel {
+class MockSpriteModifier implements SpriteStateTracker {
   element: HTMLElement;
   id: string;
   constructor(
@@ -320,10 +320,10 @@ module('Unit | Models | SpriteTree', function (hooks) {
     });
   });
   module('with two context nodes, each with a sprite', function (hooks) {
-    let context1: ContextModel,
-      context2: ContextModel,
-      sprite1: SpriteModel,
-      sprite2: SpriteModel;
+    let context1: Context,
+      context2: Context,
+      sprite1: SpriteStateTracker,
+      sprite2: SpriteStateTracker;
     hooks.beforeEach(function () {
       context1 = new MockAnimationContext();
       context2 = new MockAnimationContext();
@@ -687,7 +687,7 @@ module('Unit | Models | SpriteTree', function (hooks) {
       assert.ok(
         grandchildSpriteNode.isSprite &&
           !grandchildSpriteNode.isContext &&
-          (grandchildSpriteNode as { spriteModel: SpriteModel }).spriteModel
+          (grandchildSpriteNode as { spriteModel: SpriteStateTracker }).spriteModel
             .id === 'grandchild-sprite',
         'The grandchild sprite node is correct'
       );

--- a/test-app/tests/unit/models/sprite-tree-test.ts
+++ b/test-app/tests/unit/models/sprite-tree-test.ts
@@ -687,8 +687,8 @@ module('Unit | Models | SpriteTree', function (hooks) {
       assert.ok(
         grandchildSpriteNode.isSprite &&
           !grandchildSpriteNode.isContext &&
-          (grandchildSpriteNode as { spriteModel: SpriteStateTracker }).spriteModel
-            .id === 'grandchild-sprite',
+          (grandchildSpriteNode as { spriteModel: SpriteStateTracker })
+            .spriteModel.id === 'grandchild-sprite',
         'The grandchild sprite node is correct'
       );
     });

--- a/test-app/tests/unit/models/sprite-tree-test.ts
+++ b/test-app/tests/unit/models/sprite-tree-test.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import Sprite from 'animations-experiment/models/sprite';
+import { CopiedCSS } from 'animations-experiment/utils/measurement';
 import SpriteTree, {
   ContextModel,
   SpriteModel,
@@ -8,28 +10,54 @@ import { module, test } from 'qunit';
 
 class MockAnimationContext implements ContextModel {
   id: string | undefined;
-  element: Element;
+  element: HTMLElement;
   isAnimationContext = true;
   constructor(
-    parentEl: Element | null = null,
+    parentEl: HTMLElement | null = null,
     id: string | undefined = undefined,
-    element: Element | null = null
+    element: HTMLElement | null = null
   ) {
     this.element = element ?? document.createElement('div');
     if (parentEl) {
       parentEl.appendChild(this.element);
     }
     this.id = id;
+  }
+  currentBounds?: DOMRect | undefined;
+  lastBounds?: DOMRect | undefined;
+  isInitialRenderCompleted = false;
+  isStable = false;
+  args = {};
+
+  captureSnapshot(
+    opts?: { withAnimations: boolean; playAnimations: boolean } | undefined
+  ): void {
+    throw new Error('Method not implemented.');
+  }
+  shouldAnimate(): boolean {
+    throw new Error('Method not implemented.');
+  }
+  hasOrphan(sprite: Sprite): boolean {
+    throw new Error('Method not implemented.');
+  }
+  removeOrphan(sprite: Sprite): void {
+    throw new Error('Method not implemented.');
+  }
+  appendOrphan(sprite: Sprite): void {
+    throw new Error('Method not implemented.');
+  }
+  clearOrphans(): void {
+    throw new Error('Method not implemented.');
   }
 }
 
 class MockSpriteModifier implements SpriteModel {
-  element: Element;
+  element: HTMLElement;
   id: string;
   constructor(
-    parentEl: Element | null = null,
+    parentEl: HTMLElement | null = null,
     id = 'Mock',
-    element: Element | null = null
+    element: HTMLElement | null = null
   ) {
     this.element = element ?? document.createElement('div');
     this.id = id;
@@ -37,6 +65,16 @@ class MockSpriteModifier implements SpriteModel {
       parentEl.appendChild(this.element);
     }
   }
+  role: string | null = null;
+  currentBounds?: DOMRect | undefined;
+  lastBounds?: DOMRect | undefined;
+  captureSnapshot(
+    opts?: { withAnimations: boolean; playAnimations: boolean } | undefined
+  ): void {
+    throw new Error('Method not implemented.');
+  }
+  lastComputedStyle: CopiedCSS | undefined;
+  currentComputedStyle: CopiedCSS | undefined;
 }
 
 module('Unit | Models | SpriteTree', function (hooks) {
@@ -289,8 +327,8 @@ module('Unit | Models | SpriteTree', function (hooks) {
     hooks.beforeEach(function () {
       context1 = new MockAnimationContext();
       context2 = new MockAnimationContext();
-      sprite1 = new MockSpriteModifier(context1.element);
-      sprite2 = new MockSpriteModifier(context2.element);
+      sprite1 = new MockSpriteModifier(context1.element as HTMLElement);
+      sprite2 = new MockSpriteModifier(context2.element as HTMLElement);
       subject.addAnimationContext(context1);
       subject.addAnimationContext(context2);
       subject.addSpriteModifier(sprite1);
@@ -649,8 +687,8 @@ module('Unit | Models | SpriteTree', function (hooks) {
       assert.ok(
         grandchildSpriteNode.isSprite &&
           !grandchildSpriteNode.isContext &&
-          (grandchildSpriteNode.spriteModel as MockAnimationContext).id ===
-            'grandchild-sprite',
+          (grandchildSpriteNode as { spriteModel: SpriteModel }).spriteModel
+            .id === 'grandchild-sprite',
         'The grandchild sprite node is correct'
       );
     });

--- a/test-app/tests/unit/util/filter-to-context-test.ts
+++ b/test-app/tests/unit/util/filter-to-context-test.ts
@@ -1,13 +1,13 @@
 import { module, test } from 'qunit';
 import SpriteTree, {
-  ContextModel,
-  SpriteModel,
+  Context,
+  SpriteStateTracker,
 } from 'animations-experiment/models/sprite-tree';
 import { filterToContext } from 'animations-experiment/models/sprite-snapshot-node-builder';
 import { CopiedCSS } from 'animations-experiment/utils/measurement';
 import Sprite from 'animations-experiment/models/sprite';
 
-class MockAnimationContext implements ContextModel {
+class MockAnimationContext implements Context {
   id: string | undefined;
   element: HTMLElement;
   isAnimationContext = true;
@@ -35,13 +35,13 @@ class MockAnimationContext implements ContextModel {
   shouldAnimate(): boolean {
     throw new Error('Method not implemented.');
   }
-  hasOrphan(spriteOrElement: HTMLElement | Sprite): boolean {
+  hasOrphan(sprite: Sprite): boolean {
     throw new Error('Method not implemented.');
   }
-  removeOrphan(spriteOrElement: HTMLElement | Sprite): void {
+  removeOrphan(sprite: Sprite): void {
     throw new Error('Method not implemented.');
   }
-  appendOrphan(spriteOrElement: HTMLElement | Sprite): void {
+  appendOrphan(sprite: Sprite): void {
     throw new Error('Method not implemented.');
   }
   clearOrphans(): void {
@@ -60,7 +60,7 @@ class MockAnimationContext implements ContextModel {
   }
 }
 
-class MockSpriteModifier implements SpriteModel {
+class MockSpriteModifier implements SpriteStateTracker {
   element: HTMLElement;
   id: string;
   constructor(

--- a/test-app/tests/unit/util/filter-to-context-test.ts
+++ b/test-app/tests/unit/util/filter-to-context-test.ts
@@ -1,14 +1,13 @@
 import { module, test } from 'qunit';
 import SpriteTree, {
+  ContextModel,
   SpriteModel,
 } from 'animations-experiment/models/sprite-tree';
 import { filterToContext } from 'animations-experiment/models/sprite-snapshot-node-builder';
-import AnimationContextComponent from 'animations-experiment/components/animation-context';
-import SpriteModifier from 'animations-experiment/modifiers/sprite';
+import { CopiedCSS } from 'animations-experiment/utils/measurement';
+import Sprite from 'animations-experiment/models/sprite';
 
-class MockAnimationContext
-  implements Pick<AnimationContextComponent, 'element' | 'isStable'>
-{
+class MockAnimationContext implements ContextModel {
   id: string | undefined;
   element: HTMLElement;
   isAnimationContext = true;
@@ -25,6 +24,30 @@ class MockAnimationContext
     }
     this.id = id;
   }
+  currentBounds?: DOMRect | undefined;
+  lastBounds?: DOMRect | undefined;
+  isInitialRenderCompleted = false;
+  captureSnapshot(
+    opts?: { withAnimations: boolean; playAnimations: boolean } | undefined
+  ): void {
+    throw new Error('Method not implemented.');
+  }
+  shouldAnimate(): boolean {
+    throw new Error('Method not implemented.');
+  }
+  hasOrphan(spriteOrElement: HTMLElement | Sprite): boolean {
+    throw new Error('Method not implemented.');
+  }
+  removeOrphan(spriteOrElement: HTMLElement | Sprite): void {
+    throw new Error('Method not implemented.');
+  }
+  appendOrphan(spriteOrElement: HTMLElement | Sprite): void {
+    throw new Error('Method not implemented.');
+  }
+  clearOrphans(): void {
+    throw new Error('Method not implemented.');
+  }
+  args = {};
 
   stable() {
     this.isStable = true;
@@ -51,6 +74,16 @@ class MockSpriteModifier implements SpriteModel {
       parentEl.appendChild(this.element);
     }
   }
+  role: string | null = null;
+  currentBounds?: DOMRect | undefined;
+  lastBounds?: DOMRect | undefined;
+  captureSnapshot(
+    opts?: { withAnimations: boolean; playAnimations: boolean } | undefined
+  ): void {
+    throw new Error('Method not implemented.');
+  }
+  lastComputedStyle: CopiedCSS | undefined;
+  currentComputedStyle: CopiedCSS | undefined;
 }
 
 function nestEachInPrevious(
@@ -100,18 +133,14 @@ module('Unit | Util | filterToContext', function () {
       if (item instanceof MockSpriteModifier) {
         tree.addPendingSpriteModifier(item);
         sprites.push(item);
-      } else {
+      } else if (item instanceof MockAnimationContext) {
         tree.addPendingAnimationContext(item);
       }
     }
 
     tree.flushPendingAdditions();
 
-    let descendants = filterToContext(
-      tree,
-      targetContext as unknown as AnimationContextComponent,
-      new Set(sprites) as unknown as Set<SpriteModifier>
-    );
+    let descendants = filterToContext(tree, targetContext, new Set(sprites));
 
     assert.deepEqual([...descendants].map((v) => v.id).sort(), [
       'included-1',
@@ -156,18 +185,14 @@ module('Unit | Util | filterToContext', function () {
       if (item instanceof MockSpriteModifier) {
         tree.addPendingSpriteModifier(item);
         sprites.push(item);
-      } else {
+      } else if (item instanceof MockAnimationContext) {
         tree.addPendingAnimationContext(item);
       }
     }
 
     tree.flushPendingAdditions();
 
-    let descendants = filterToContext(
-      tree,
-      targetContext as unknown as AnimationContextComponent,
-      new Set(sprites) as unknown as Set<SpriteModifier>
-    );
+    let descendants = filterToContext(tree, targetContext, new Set(sprites));
 
     assert.deepEqual([...descendants].map((v) => v.id).sort(), [
       'included-1',
@@ -212,11 +237,7 @@ module('Unit | Util | filterToContext', function () {
 
     tree.flushPendingAdditions();
 
-    let descendants = filterToContext(
-      tree,
-      targetContext as unknown as AnimationContextComponent,
-      new Set(sprites) as unknown as Set<SpriteModifier>
-    );
+    let descendants = filterToContext(tree, targetContext, new Set(sprites));
 
     assert.deepEqual(
       [...descendants].map((v) => v.id),


### PR DESCRIPTION
Current type setup requires type assertions in many places. 

If we declare appropriate interfaces for `SpriteModel` and `ContextModel`, and ensure that `AnimationContext`, `SpriteModifier`, and their associated mocks conform to these interfaces, we can significantly reduce the type assertions needed.