### PR TITLE
Orphan handling fix

### DIFF
--- a/addon/addon/components/animation-context/index.hbs
+++ b/addon/addon/components/animation-context/index.hbs
@@ -1,5 +1,5 @@
 {{this.renderDetector}}
 <div class="animation-context" {{did-insert this.didInsertEl}} ...attributes>
-  <div {{did-insert this.didInsertOrphansEl}}></div> {{!-- JS appends and removes here --}}
+  <div {{did-insert this.didInsertOrphansEl}} data-animation-context-orphan-element="true"></div> {{!-- JS appends and removes here --}}
   {{yield this}}
 </div>

--- a/addon/addon/components/animation-context/index.ts
+++ b/addon/addon/components/animation-context/index.ts
@@ -72,30 +72,42 @@ export default class AnimationContextComponent extends Component<AnimationContex
     return Boolean(this.args.use && this.isStable);
   }
 
-  hasOrphan(spriteOrElement: Sprite | HTMLElement): boolean {
-    let { orphansElement } = this;
-    if (spriteOrElement instanceof Sprite) {
-      return spriteOrElement.element.parentElement === orphansElement;
-    } else {
-      return spriteOrElement.parentElement === orphansElement;
+  hasOrphan(spriteOrElement: Sprite): boolean {
+    let { orphansElement } = this as { orphansElement: HTMLElement };
+
+    for (let orphan of orphansElement.children) {
+      if (!(orphan instanceof HTMLElement)) continue;
+      if (
+        orphan.dataset['orphanSpriteId'] ===
+        spriteOrElement.identifier.toString()
+      ) {
+        return true;
+      }
     }
+
+    return false;
   }
 
-  appendOrphan(spriteOrElement: Sprite | HTMLElement): void {
-    let { orphansElement } = this;
-    if (spriteOrElement instanceof Sprite) {
-      orphansElement?.appendChild(spriteOrElement.element);
-    } else {
-      orphansElement?.appendChild(spriteOrElement);
-    }
+  appendOrphan(spriteOrElement: Sprite): void {
+    let { orphansElement } = this as { orphansElement: HTMLElement };
+
+    orphansElement.appendChild(spriteOrElement.element);
+    spriteOrElement.element.dataset['orphanSpriteId'] =
+      spriteOrElement.identifier.toString();
   }
 
-  removeOrphan(spriteOrElement: Sprite | HTMLElement): void {
-    let { orphansElement } = this;
-    if (spriteOrElement instanceof Sprite) {
-      orphansElement?.removeChild(spriteOrElement.element);
-    } else {
-      orphansElement?.removeChild(spriteOrElement);
+  removeOrphan(spriteOrElement: Sprite): void {
+    let { orphansElement } = this as { orphansElement: HTMLElement };
+
+    for (let orphan of orphansElement.children) {
+      if (!(orphan instanceof HTMLElement)) continue;
+      if (
+        orphan.dataset['orphanSpriteId'] ===
+        spriteOrElement.identifier.toString()
+      ) {
+        console.log('removing matching orphan');
+        orphansElement.removeChild(orphan);
+      }
     }
   }
 

--- a/addon/addon/components/animation-context/index.ts
+++ b/addon/addon/components/animation-context/index.ts
@@ -82,8 +82,14 @@ export default class AnimationContextComponent extends Component<AnimationContex
     let { orphansElement } = this as { orphansElement: HTMLElement };
 
     // TODO:
-    // - add a map of orphans on a higher level than the animation context
-    // - assert that an orphan is not appended in two places
+    // - add a map of orphans on a higher level than the animation context and use it for this assertion
+    assert(
+      'Element is appended in multiple different orphan elements',
+      spriteOrElement.element.parentElement === orphansElement ||
+        !spriteOrElement.element.parentElement?.dataset[
+          'animationContextOrphanElement'
+        ]
+    );
 
     orphansElement.appendChild(spriteOrElement.element);
 

--- a/addon/addon/components/animation-context/index.ts
+++ b/addon/addon/components/animation-context/index.ts
@@ -81,7 +81,12 @@ export default class AnimationContextComponent extends Component<AnimationContex
   appendOrphan(spriteOrElement: Sprite): void {
     let { orphansElement } = this as { orphansElement: HTMLElement };
 
+    // TODO:
+    // - add a map of orphans on a higher level than the animation context
+    // - assert that an orphan is not appended in two places
+
     orphansElement.appendChild(spriteOrElement.element);
+
     this.orphans.set(
       spriteOrElement.identifier.toString(),
       spriteOrElement.element
@@ -92,7 +97,6 @@ export default class AnimationContextComponent extends Component<AnimationContex
     let identifier = spriteOrElement.identifier.toString();
     let element = this.orphans.get(identifier);
     if (element) {
-      console.log('removing orphan', identifier);
       this.orphansElement!.removeChild(element);
       this.orphans.delete(identifier);
     } else {

--- a/addon/addon/components/animation-context/index.ts
+++ b/addon/addon/components/animation-context/index.ts
@@ -74,33 +74,28 @@ export default class AnimationContextComponent extends Component<AnimationContex
     return Boolean(this.args.use && this.isStable);
   }
 
-  hasOrphan(spriteOrElement: Sprite): boolean {
-    return this.orphans.has(spriteOrElement.identifier.toString());
+  hasOrphan(sprite: Sprite): boolean {
+    return this.orphans.has(sprite.identifier.toString());
   }
 
-  appendOrphan(spriteOrElement: Sprite): void {
+  appendOrphan(sprite: Sprite): void {
     let { orphansElement } = this as { orphansElement: HTMLElement };
 
     // TODO:
     // - add a map of orphans on a higher level than the animation context and use it for this assertion
     assert(
       'Element is appended in multiple different orphan elements',
-      spriteOrElement.element.parentElement === orphansElement ||
-        !spriteOrElement.element.parentElement?.dataset[
-          'animationContextOrphanElement'
-        ]
+      sprite.element.parentElement === orphansElement ||
+        !sprite.element.parentElement?.dataset['animationContextOrphanElement']
     );
 
-    orphansElement.appendChild(spriteOrElement.element);
+    orphansElement.appendChild(sprite.element);
 
-    this.orphans.set(
-      spriteOrElement.identifier.toString(),
-      spriteOrElement.element
-    );
+    this.orphans.set(sprite.identifier.toString(), sprite.element);
   }
 
-  removeOrphan(spriteOrElement: Sprite): void {
-    let identifier = spriteOrElement.identifier.toString();
+  removeOrphan(sprite: Sprite): void {
+    let identifier = sprite.identifier.toString();
     let element = this.orphans.get(identifier);
     if (element) {
       this.orphansElement!.removeChild(element);

--- a/demo-app/app/components/accordion/panel/index.ts
+++ b/demo-app/app/components/accordion/panel/index.ts
@@ -7,26 +7,6 @@ import runAnimations from 'animations-experiment/utils/run-animations';
 //import LinearBehavior from 'animations-experiment/behaviors/linear';
 import SpringBehavior from 'animations-experiment/behaviors/spring';
 
-// hasOrphan does not work. We cannot compare orphan parents properly
-// We probably need to mark orphan elements with data attributes
-// one from the sprite identifier
-// one as a custom identifier, this is more for the cloning side of things
-// And check for matching based on that
-// We also should probably have a good way to clean up orphans that no longer belong to a context
-// If a changeset passed to a context does not have a sprite matching an orphan, should we remove it?
-//   - probably not. removed sprites will not appear again in the changeset
-// If the same changeset has a non-removed sprite that matches the orphan, should we remove it?
-//   - yes, unless the user is doing cloning things.
-// If another changeset has a non-removed sprite that matches the orphan, should we remove it?
-//   - unsure
-// Should we differentiate opt-in non-removed orphans from removed sprite orphans?
-//   - at first glance, yes.
-// Who should be responsible for this cleanup?
-//   - user first. then when we're clearer about what needs to happen, library
-// Is that a user concern or a library concern?
-// An orphan should be removed if any context has a matching non-removed sprite
-// It's up to the context of that changeset to decide whether or not a replacement orphan is set up
-
 export default class AccordionPanel extends Component {
   @action async resizePanels(changeset: Changeset) {
     let behavior = new SpringBehavior({ overshootClamping: true });
@@ -74,7 +54,6 @@ export default class AccordionPanel extends Component {
     }
 
     if (nonOrphanPanel) {
-      console.log('kept panel', nonOrphanPanel);
       if (context.hasOrphan(nonOrphanPanel)) {
         context.removeOrphan(nonOrphanPanel);
       }

--- a/demo-app/app/components/accordion/panel/index.ts
+++ b/demo-app/app/components/accordion/panel/index.ts
@@ -7,6 +7,26 @@ import runAnimations from 'animations-experiment/utils/run-animations';
 //import LinearBehavior from 'animations-experiment/behaviors/linear';
 import SpringBehavior from 'animations-experiment/behaviors/spring';
 
+// hasOrphan does not work. We cannot compare orphan parents properly
+// We probably need to mark orphan elements with data attributes
+// one from the sprite identifier
+// one as a custom identifier, this is more for the cloning side of things
+// And check for matching based on that
+// We also should probably have a good way to clean up orphans that no longer belong to a context
+// If a changeset passed to a context does not have a sprite matching an orphan, should we remove it?
+//   - probably not. removed sprites will not appear again in the changeset
+// If the same changeset has a non-removed sprite that matches the orphan, should we remove it?
+//   - yes, unless the user is doing cloning things.
+// If another changeset has a non-removed sprite that matches the orphan, should we remove it?
+//   - unsure
+// Should we differentiate opt-in non-removed orphans from removed sprite orphans?
+//   - at first glance, yes.
+// Who should be responsible for this cleanup?
+//   - user first. then when we're clearer about what needs to happen, library
+// Is that a user concern or a library concern?
+// An orphan should be removed if any context has a matching non-removed sprite
+// It's up to the context of that changeset to decide whether or not a replacement orphan is set up
+
 export default class AccordionPanel extends Component {
   @action async resizePanels(changeset: Changeset) {
     let behavior = new SpringBehavior({ overshootClamping: true });
@@ -35,6 +55,28 @@ export default class AccordionPanel extends Component {
 
         // TODO: something is weird here when interrupting an interruped animation
         hiddenPanel.lockStyles();
+      }
+    }
+
+    let nonOrphanPanel: Sprite | undefined;
+    let keptPanelContentGroup = changeset.spritesFor({
+      type: SpriteType.Kept,
+      role: 'accordion-panel-content',
+    });
+    let insertedPanelContentGroup = changeset.spritesFor({
+      type: SpriteType.Inserted,
+      role: 'accordion-panel-content',
+    });
+    if (keptPanelContentGroup.size) {
+      nonOrphanPanel = [...keptPanelContentGroup][0];
+    } else if (insertedPanelContentGroup.size) {
+      nonOrphanPanel = [...insertedPanelContentGroup][0];
+    }
+
+    if (nonOrphanPanel) {
+      console.log('kept panel', nonOrphanPanel);
+      if (context.hasOrphan(nonOrphanPanel)) {
+        context.removeOrphan(nonOrphanPanel);
       }
     }
 

--- a/demo-app/app/components/home-reno/index.ts
+++ b/demo-app/app/components/home-reno/index.ts
@@ -68,7 +68,7 @@ export default class HomeReno extends Component {
     ];
     let keptSprite = keptCompactCards.find((sprite) => sprite.counterpart);
     if (keptSprite) {
-      changeset.context.appendOrphan(keptSprite.counterpart!.element);
+      changeset.context.appendOrphan(keptSprite.counterpart!);
       keptSprite.counterpart!.lockStyles();
       keptSprite.element.style.visibility = 'hidden';
       keptSprite.counterpart!.element.style.zIndex = '1';


### PR DESCRIPTION
Previously, we checked whether sprites had the orphan as a parent element. This should not work. This PR uses a `orphanSpriteId` data attribute to connect an orphan to a sprite and allow proper identification and operations on orphans based on sprite.

Follow-up investigation: If an orphan is used in an animation, should its corresponding removed sprite be kept in `freshlyRemovedChildren`?