### PR TITLE
Freshly removed sprites + orphans not handled correctly when interrupted

### DIFF
--- a/addon/addon/models/TODO.md
+++ b/addon/addon/models/TODO.md
@@ -1,0 +1,11 @@
+1. Make contexts have a map of modifiers that have orphans (id: sprite). we can't do id: modifier because modifiers don't show up in changesets. We need to enforce uniqueness of identifiers for this to work
+2. From the map, exclude removed sprite modifiers that have orphans that are being used from being removed from the sprite tree. We may need to define a "wait" for this to work properly in some cases.
+3. Add these removed sprite modifiers into a new Set that we pass to SpriteSnapshotNodeBuilder, this set is handled the same way as freshlyRemoved (debugging purposes) 
+
+Measure on an orphan?
+
+- Orphan moving to a different context?
+
+
+Assume sprite modifier internals are private API for now
+SpriteModifierModel

--- a/addon/addon/models/sprite-snapshot-node-builder.ts
+++ b/addon/addon/models/sprite-snapshot-node-builder.ts
@@ -204,9 +204,9 @@ export class SpriteSnapshotNodeBuilder {
     for (let context of contexts) {
       context.captureSnapshot();
       let contextNode = this.spriteTree.lookupNodeByElement(context.element);
-      let contextChildren: SpriteModifier[] = [...(contextNode?.children ?? [])]
-        .map((c) => c.spriteModel as SpriteModifier)
-        .filter(Boolean);
+      let contextChildren: SpriteModifier[] = contextNode?.allChildSprites({
+        includeFreshlyRemoved: false,
+      }) as SpriteModifier[];
 
       for (let spriteModifier of contextChildren) {
         spriteModifier.captureSnapshot({
@@ -240,14 +240,17 @@ export class SpriteSnapshotNodeBuilder {
       if (context.isStable) {
         let spriteSnapshotNode = new SpriteSnapshotNode(context);
 
-        let spriteModifiersForContext = filterToContext(
-          this.spriteTree,
-          context,
-          spriteModifiers,
-          {
+        let spriteModifiersForContext = new Set<SpriteModifier>();
+        spriteTree
+          .lookupNodeByElement(context.element)!
+          .allChildSprites({
             includeFreshlyRemoved: true,
-          }
-        );
+          })
+          .forEach((s) => {
+            if (spriteModifiers.has(s as SpriteModifier)) {
+              spriteModifiersForContext.add(s as SpriteModifier);
+            }
+          });
 
         // add the sprites with counterparts here, if necessary
         if (contextToKeptSpriteModifierMap.has(context)) {

--- a/addon/addon/models/sprite-tree.ts
+++ b/addon/addon/models/sprite-tree.ts
@@ -32,6 +32,18 @@ export class SpriteTreeNode {
   children: Set<SpriteTreeNode> = new Set();
   freshlyRemovedChildren: Set<SpriteTreeNode> = new Set();
 
+  get freshlyRemovedDescendants() {
+    let result = new Set(this.freshlyRemovedChildren);
+
+    for (let child of this.children) {
+      for (let item of child.freshlyRemovedDescendants) {
+        result.add(item);
+      }
+    }
+
+    return result;
+  }
+
   get isContext() {
     return Boolean(this.contextModel);
   }

--- a/addon/addon/models/sprite-tree.ts
+++ b/addon/addon/models/sprite-tree.ts
@@ -86,14 +86,31 @@ export class SpriteTreeNode {
       }
 
       if (
-        (child.isSprite ||
-          (child.isContext &&
-            !(child.contextModel as AnimationContextComponent).isStable)) &&
-        child.children?.size
+        child.isSprite ||
+        (child.isContext &&
+          !(child.contextModel as AnimationContextComponent).isStable)
       ) {
         child
           .allChildSprites({ includeFreshlyRemoved })
           .forEach((c) => result.push(c));
+      }
+    }
+
+    if (includeFreshlyRemoved) {
+      for (let child of this.freshlyRemovedChildren) {
+        if (child.isSprite) {
+          result.push(child.spriteModel as SpriteModel);
+        }
+
+        if (
+          child.isSprite ||
+          (child.isContext &&
+            !(child.contextModel as AnimationContextComponent).isStable)
+        ) {
+          child
+            .allChildSprites({ includeFreshlyRemoved })
+            .forEach((c) => result.push(c));
+        }
       }
     }
 

--- a/addon/addon/services/animations.ts
+++ b/addon/addon/services/animations.ts
@@ -39,6 +39,7 @@ export default class AnimationsService extends Service {
   spriteTree = new SpriteTree();
   freshlyAdded: Set<SpriteModifier> = new Set();
   freshlyRemoved: Set<SpriteModifier> = new Set();
+  interruptedRemoved: Set<SpriteModifier> = new Set();
   eligibleContexts: Set<AnimationContext> = new Set();
   intent: string | undefined;
   intermediateSprites: Map<string, IntermediateSprite> = new Map();
@@ -211,7 +212,7 @@ export default class AnimationsService extends Service {
           ) {
             (item.parent as SpriteTreeNode).freshlyRemovedChildren.delete(item);
           } else {
-            this.freshlyRemoved.add(item.spriteModel as SpriteModifier);
+            this.interruptedRemoved.add(item.spriteModel as SpriteModifier);
           }
         } else {
           (item.parent as SpriteTreeNode).freshlyRemovedChildren.delete(item);
@@ -248,7 +249,7 @@ export default class AnimationsService extends Service {
       this.spriteTree,
       this.eligibleContexts,
       this.freshlyAdded,
-      this.freshlyRemoved,
+      new Set([...this.freshlyRemoved, ...this.interruptedRemoved]),
       this.intermediateSprites
     );
 
@@ -256,6 +257,7 @@ export default class AnimationsService extends Service {
     // correct starting point for the next run even if an interruption happens.
     this.freshlyAdded.clear();
     this.freshlyRemoved.clear();
+    this.interruptedRemoved.clear();
     this.intermediateSprites = new Map();
     this.runningAnimations = new Map();
     this.intent = undefined;

--- a/addon/addon/services/animations.ts
+++ b/addon/addon/services/animations.ts
@@ -197,7 +197,7 @@ export default class AnimationsService extends Service {
       let contextNode = this.spriteTree.lookupNodeByElement(
         context.element
       ) as SpriteTreeNode;
-      for (let item of contextNode.freshlyRemovedChildren) {
+      for (let item of contextNode.freshlyRemovedDescendants) {
         if (item.isSprite) {
           let identifier = new SpriteIdentifier(
             (item.spriteModel as unknown as SpriteModifier).id,
@@ -209,12 +209,12 @@ export default class AnimationsService extends Service {
               this.intermediateSprites.get(identifier)
             )
           ) {
-            contextNode.freshlyRemovedChildren.delete(item);
+            (item.parent as SpriteTreeNode).freshlyRemovedChildren.delete(item);
           } else {
             this.freshlyRemoved.add(item.spriteModel as SpriteModifier);
           }
         } else {
-          contextNode.freshlyRemovedChildren.delete(item);
+          (item.parent as SpriteTreeNode).freshlyRemovedChildren.delete(item);
         }
       }
     }

--- a/addon/addon/services/animations.ts
+++ b/addon/addon/services/animations.ts
@@ -22,10 +22,7 @@ import {
   restartableTask,
   TaskInstance,
 } from 'ember-concurrency';
-import {
-  filterToContext,
-  SpriteSnapshotNodeBuilder,
-} from 'animations-experiment/models/sprite-snapshot-node-builder';
+import { SpriteSnapshotNodeBuilder } from 'animations-experiment/models/sprite-snapshot-node-builder';
 
 export type AnimateFunction = (
   sprite: Sprite,
@@ -146,13 +143,12 @@ export default class AnimationsService extends Service {
       context.element
     ) as SpriteTreeNode;
 
-    for (let node of [
-      ...contextNode.freshlyRemovedChildren,
-      ...contextNode.children,
-    ]) {
-      let spriteModifier = node.spriteModel as SpriteModifier;
+    for (let node of contextNode.allChildSprites({
+      includeFreshlyRemoved: true,
+    })) {
+      let spriteModifier = node as SpriteModifier;
       if (spriteModifier) {
-        let animations = node.spriteModel?.element.getAnimations() ?? [];
+        let animations = spriteModifier.element.getAnimations() ?? [];
         animationsToCancel = animationsToCancel.concat(animations);
         if (animations?.length) {
           spriteModifier.captureSnapshot({

--- a/addon/addon/services/animations.ts
+++ b/addon/addon/services/animations.ts
@@ -201,7 +201,26 @@ export default class AnimationsService extends Service {
       let contextNode = this.spriteTree.lookupNodeByElement(
         context.element
       ) as SpriteTreeNode;
-      contextNode.freshlyRemovedChildren.clear();
+      for (let item of contextNode.freshlyRemovedChildren) {
+        if (item.isSprite) {
+          let identifier = new SpriteIdentifier(
+            (item.spriteModel as unknown as SpriteModifier).id,
+            (item.spriteModel as unknown as SpriteModifier).role
+          ).toString();
+          if (
+            !(
+              context.orphans.has(identifier) &&
+              this.intermediateSprites.get(identifier)
+            )
+          ) {
+            contextNode.freshlyRemovedChildren.delete(item);
+          } else {
+            this.freshlyRemoved.add(item.spriteModel as SpriteModifier);
+          }
+        } else {
+          contextNode.freshlyRemovedChildren.delete(item);
+        }
+      }
     }
 
     return animationsToCancel;

--- a/demo-app/app/controllers/double-render.ts
+++ b/demo-app/app/controllers/double-render.ts
@@ -1,0 +1,84 @@
+import Controller from '@ember/controller';
+import Sprite, { SpriteType } from 'animations-experiment/models/sprite';
+import Changeset from 'animations-experiment/models/changeset';
+import magicMove from 'animations-experiment/transitions/magic-move';
+import { assert } from '@ember/debug';
+import ContextAwareBounds from 'animations-experiment/models/context-aware-bounds';
+import runAnimations from 'animations-experiment/utils/run-animations';
+import SpringBehavior from 'animations-experiment/behaviors/spring';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import LinearBehavior from 'animations-experiment/behaviors/linear';
+
+export default class DoubleRenderController extends Controller {
+  @tracked count = 0;
+  @tracked isShowing = true;
+
+  @action
+  hide() {
+    this.isShowing = false;
+  }
+
+  @action
+  show() {
+    this.isShowing = true;
+  }
+
+  @action
+  increment() {
+    this.count += 1;
+  }
+
+  async transition(changeset: Changeset): Promise<void> {
+    let { removedSprites, keptSprites, insertedSprites } = changeset;
+    let duration = 3000;
+
+    removedSprites.forEach((sprite) => {
+      if (changeset.context.hasOrphan(sprite)) {
+        changeset.context.removeOrphan(sprite);
+      }
+      console.log('handling removed sprite');
+      changeset.context.appendOrphan(sprite);
+      sprite.lockStyles();
+      sprite.setupAnimation('position', {
+        startY: 0,
+        startX: 0,
+        endY: -200,
+        endX: 0,
+        behavior: new LinearBehavior(),
+        duration,
+      });
+    });
+
+    insertedSprites.forEach((sprite) => {
+      if (changeset.context.hasOrphan(sprite)) {
+        changeset.context.removeOrphan(sprite);
+      }
+      sprite.setupAnimation('position', {
+        startY: -200,
+        behavior: new LinearBehavior(),
+        duration,
+      });
+    });
+
+    keptSprites.forEach((sprite) => {
+      if (changeset.context.hasOrphan(sprite)) {
+        changeset.context.removeOrphan(sprite);
+      }
+      sprite.setupAnimation('position', {
+        startY: sprite.initialBounds?.relativeToContext.y,
+        endY: sprite.finalBounds?.relativeToContext.y,
+        behavior: new LinearBehavior(),
+        duration,
+      });
+    });
+
+    await runAnimations([
+      ...removedSprites,
+      ...keptSprites,
+      ...insertedSprites,
+    ]);
+
+    console.log('done animating');
+  }
+}

--- a/demo-app/app/router.js
+++ b/demo-app/app/router.js
@@ -21,4 +21,5 @@ Router.map(function () {
   this.route('nested-contexts');
   this.route('context-selection');
   this.route('nested-sprites');
+  this.route('double-render');
 });

--- a/demo-app/app/styles/double-render.css
+++ b/demo-app/app/styles/double-render.css
@@ -1,0 +1,3 @@
+.double-render [data-orphan-sprite-id] {
+  outline: 4px solid red !important;
+}

--- a/demo-app/app/styles/double-render.css
+++ b/demo-app/app/styles/double-render.css
@@ -1,3 +1,3 @@
-.double-render [data-orphan-sprite-id] {
+.double-render > div:first-child > * {
   outline: 4px solid red !important;
 }

--- a/demo-app/app/templates/application.hbs
+++ b/demo-app/app/templates/application.hbs
@@ -56,6 +56,11 @@
       Context Selection
     </LinkTo>
   </li>
+  <li>
+    <LinkTo @route="double-render">
+      Double Render
+    </LinkTo>
+  </li>
 </ul>
 
 {{outlet}}

--- a/demo-app/app/templates/double-render.hbs
+++ b/demo-app/app/templates/double-render.hbs
@@ -1,0 +1,23 @@
+<div style="padding: 12px;">
+  <AnimationContext @use={{this.transition}} @id="double-render-demo" style="width: 200px; height: 220px; border-radius: 8px; border: 1px solid black; position: relative;" local-class="double-render">
+    {{#if this.isShowing}}
+      <div {{sprite id="item"}} style="background: #faa; width: 180px; height: 180px; border-radius: 8px; margin: 4px auto; display: flex; align-items: center; justify-content: center; text-align: center;">
+        Item
+      </div>
+    {{/if}}
+    <div style="position: absolute; left: 50%; bottom: 0; transform: translateX(-50%)">
+      {{this.count}}
+    </div>
+  </AnimationContext>
+  <div style="padding: 12px 0px; display: flex; gap: 4px;">
+    <button type="button" {{on "click" this.increment}} style="border: 1px solid black; background: #eee;">
+      Increment
+    </button>
+    <button type="button" {{on "click" this.hide}} style="border: 1px solid black; background: #eee;">
+      Remove
+    </button>
+    <button type="button" {{on "click" this.show}} style="border: 1px solid black; background: #eee;">
+      Insert
+    </button>
+  </div>
+</div>


### PR DESCRIPTION
This is to demonstrate a problem where interruptions of animations of a removed sprite will not allow the animation to continue because the removed sprite is removed from the animations service and the sprite tree. It also shows a problem with cleanup of a removed sprite's orphan when the animation is interrupted.