### PR TITLE
Removed sprite interruption fix

### DIFF
--- a/addon/addon/models/sprite-tree.ts
+++ b/addon/addon/models/sprite-tree.ts
@@ -255,6 +255,9 @@ export class SpriteTreeNode {
 export default class SpriteTree {
   contextModel = undefined;
   spriteModel = undefined;
+  freshlyAdded: Set<ISpriteModifier> = new Set();
+  freshlyRemoved: Set<ISpriteModifier> = new Set();
+  interruptedRemoved: Set<ISpriteModifier> = new Set();
   isContext() {
     return false;
   }
@@ -390,18 +393,21 @@ export default class SpriteTree {
       );
     }
 
+    this.freshlyAdded.add(spriteModifier);
+
     return resultNode;
   }
-  removeSpriteModifier(spriteModifer: ISpriteModifier): void {
-    let node = this.lookupNodeByElement(spriteModifer.element);
+  removeSpriteModifier(spriteModifier: ISpriteModifier): void {
+    let node = this.lookupNodeByElement(spriteModifier.element);
     if (node) {
       node.parent?.removeChild(node);
       if (node.isSprite()) {
         // TODO: we might need to do some cleanup? This is currently a WeakMap but..
         // situation where this matters is SpriteModifier hanging around when it should be removed
         this.freshlyRemovedToNode.set(node.spriteModel, node);
+        this.freshlyRemoved.add(spriteModifier);
       }
-      this.nodesByElement.delete(spriteModifer.element);
+      this.nodesByElement.delete(spriteModifier.element);
     }
   }
   lookupNodeByElement(element: Element): SpriteTreeNode | undefined {

--- a/addon/addon/models/sprite-tree.ts
+++ b/addon/addon/models/sprite-tree.ts
@@ -1,7 +1,7 @@
 import { assert } from '@ember/debug';
 import { CopiedCSS } from '../utils/measurement';
 import { formatTreeString, TreeNode } from '../utils/format-tree';
-import Sprite from './sprite';
+import Sprite, { SpriteIdentifier } from './sprite';
 import { Changeset } from './changeset';
 
 export interface IContext {
@@ -343,6 +343,26 @@ export default class SpriteTree {
       resultNode = existingNode;
     } else {
       let parentNode = this.findParentNode(spriteModifier.element);
+      let identifier = new SpriteIdentifier(
+        spriteModifier.id,
+        spriteModifier.role
+      );
+      let matchingRemovedItem = (
+        parentNode?.freshlyRemovedChildren
+          ? [...parentNode.freshlyRemovedChildren]
+          : []
+      ).find((v) => {
+        return (
+          v.isSprite() &&
+          new SpriteIdentifier(v.spriteModel.id, v.spriteModel.role).equals(
+            identifier
+          )
+        );
+      });
+
+      if (matchingRemovedItem) {
+        parentNode?.freshlyRemovedChildren.delete(matchingRemovedItem);
+      }
       let node = new SpriteTreeNode(
         spriteModifier,
         SpriteTreeNodeType.Sprite,

--- a/addon/addon/models/sprite-tree.ts
+++ b/addon/addon/models/sprite-tree.ts
@@ -207,9 +207,21 @@ export class SpriteTreeNode {
     return result;
   }
 
+  /**
+   * Deletes the node from its parent's freshlyRemovedChildren set
+   */
+  delete() {
+    assert(
+      'May have called delete on a root node of the sprite tree',
+      this.parent instanceof SpriteTreeNode
+    );
+    this.parent.freshlyRemovedChildren.delete(this);
+  }
+
   addChild(childNode: SpriteTreeNode): void {
     this.children.add(childNode);
   }
+
   removeChild(childNode: SpriteTreeNode): void {
     this.children.delete(childNode);
     this.freshlyRemovedChildren.add(childNode);

--- a/addon/addon/models/sprite-tree.ts
+++ b/addon/addon/models/sprite-tree.ts
@@ -362,21 +362,23 @@ export default class SpriteTree {
         spriteModifier.id,
         spriteModifier.role
       );
-      let matchingRemovedItem = (
-        parentNode?.freshlyRemovedChildren
-          ? [...parentNode.freshlyRemovedChildren]
-          : []
-      ).find((v) => {
-        return (
-          v.isSprite() &&
-          new SpriteIdentifier(v.spriteModel.id, v.spriteModel.role).equals(
-            identifier
-          )
-        );
-      });
+      let matchingRemovedItems: SpriteTreeNode[] = [];
 
-      if (matchingRemovedItem) {
-        parentNode?.freshlyRemovedChildren.delete(matchingRemovedItem);
+      for (let item of this.interruptedRemoved) {
+        if (new SpriteIdentifier(item.id, item.role).equals(identifier)) {
+          matchingRemovedItems.push(this.freshlyRemovedToNode.get(item)!);
+        }
+      }
+
+      assert(
+        'Multiple matching interrupted removed items found while adding a new sprite',
+        matchingRemovedItems.length <= 1
+      );
+
+      if (matchingRemovedItems.length === 1) {
+        let removedNode = matchingRemovedItems[0]!;
+        removedNode.delete();
+        this.interruptedRemoved.delete(removedNode.spriteModel!);
       }
       let node = new SpriteTreeNode(
         spriteModifier,

--- a/addon/addon/services/animations.ts
+++ b/addon/addon/services/animations.ts
@@ -196,24 +196,26 @@ export default class AnimationsService extends Service {
       let contextNode = this.spriteTree.lookupNodeByElement(
         context.element
       ) as SpriteTreeNode;
-      for (let item of contextNode.freshlyRemovedChildren) {
-        if (item.isSprite()) {
-          let identifier = new SpriteIdentifier(
-            item.spriteModel.id,
-            item.spriteModel.role
-          ).toString();
-          if (
-            !(
-              context.orphans.has(identifier) &&
-              this.intermediateSprites.get(identifier)
-            )
-          ) {
-            item.delete();
-          } else {
-            this.interruptedRemoved.add(item.spriteModel);
-          }
+      for (let {
+        isRemoved,
+        node,
+        spriteModifier,
+      } of contextNode.getSpriteDescendants()) {
+        if (!isRemoved) continue;
+
+        let identifier = new SpriteIdentifier(
+          spriteModifier.id,
+          spriteModifier.role
+        ).toString();
+        if (
+          !(
+            context.orphans.has(identifier) &&
+            this.intermediateSprites.get(identifier)
+          )
+        ) {
+          node.delete();
         } else {
-          item.delete();
+          this.interruptedRemoved.add(spriteModifier);
         }
       }
     }

--- a/addon/addon/services/animations.ts
+++ b/addon/addon/services/animations.ts
@@ -208,12 +208,12 @@ export default class AnimationsService extends Service {
               this.intermediateSprites.get(identifier)
             )
           ) {
-            (item.parent as SpriteTreeNode).freshlyRemovedChildren.delete(item);
+            item.delete();
           } else {
             this.interruptedRemoved.add(item.spriteModel);
           }
         } else {
-          (item.parent as SpriteTreeNode).freshlyRemovedChildren.delete(item);
+          item.delete();
         }
       }
     }


### PR DESCRIPTION
See removed-sprite-interruption for demo that this fixes (click remove, then click remove again or click increment - the animation should resume. on the base branch this should break and leave an orphan dangling, you can tell by seeing its red outline). This implements the approach used in https://github.com/cardstack/animations-experiment/pull/73 (recycle a removed sprite if its exit animation is not complete).