### PR TITLE
hooks - orchestrator applies delays

### DIFF
--- a/addon/addon/models/sprite-tree.ts
+++ b/addon/addon/models/sprite-tree.ts
@@ -3,6 +3,7 @@ import { CopiedCSS } from '../utils/measurement';
 import { formatTreeString, TreeNode } from '../utils/format-tree';
 import Sprite, { SpriteIdentifier } from './sprite';
 import { Changeset } from './changeset';
+import { Orchestrator } from 'animations-experiment/services/animations';
 
 export interface IContext {
   id: string | undefined;
@@ -22,7 +23,7 @@ export interface IContext {
   appendOrphan(spriteOrElement: Sprite): void;
   clearOrphans(): void;
   args: {
-    use?(changeset: Changeset): Promise<void>;
+    use?(changeset: Changeset, orchestrator?: Orchestrator): Promise<void>;
     id?: string;
   };
 }
@@ -181,6 +182,32 @@ export class SpriteTreeNode {
         throw new Error(
           'Sprite tree node that is not child or context encountered'
         );
+      }
+    }
+
+    return result;
+  }
+
+  getContextDescendants(
+    opts: {
+      deep: boolean;
+    } = { deep: true }
+  ): {
+    node: SpriteTreeNode;
+  }[] {
+    let result: {
+      node: SpriteTreeNode;
+    }[] = [];
+
+    for (let child of this.children) {
+      child
+        .getContextDescendants({ deep: opts.deep })
+        .forEach((c) => result.push(c));
+
+      if (child.isContext()) {
+        result.push({
+          node: child,
+        });
       }
     }
 

--- a/addon/addon/models/transition-runner.ts
+++ b/addon/addon/models/transition-runner.ts
@@ -3,6 +3,7 @@ import { Changeset } from '../models/changeset';
 import Sprite, { SpriteType } from '../models/sprite';
 import { assert } from '@ember/debug';
 import { IContext } from './sprite-tree';
+import { Orchestrator } from 'animations-experiment/services/animations';
 
 export default class TransitionRunner {
   animationContext: IContext;
@@ -13,7 +14,7 @@ export default class TransitionRunner {
   }
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-  @task *maybeTransitionTask(changeset: Changeset) {
+  @task *maybeTransitionTask(changeset: Changeset, orchestrator: Orchestrator) {
     assert('No changeset was passed to the TransitionRunner', !!changeset);
 
     let { animationContext } = this;
@@ -24,7 +25,7 @@ export default class TransitionRunner {
 
     if (animationContext.shouldAnimate()) {
       this.logChangeset(changeset, animationContext); // For debugging
-      let animation = animationContext.args.use?.(changeset);
+      let animation = animationContext.args.use?.(changeset, orchestrator);
       try {
         yield Promise.resolve(animation);
       } catch (error) {

--- a/demo-app/app/controllers/nested-sprites.ts
+++ b/demo-app/app/controllers/nested-sprites.ts
@@ -1,15 +1,36 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
+import { Orchestrator } from 'animations-experiment/services/animations';
 import { Changeset } from 'animations-experiment/models/changeset';
-import magicMove from 'animations-experiment/transitions/magic-move';
 import runAnimations from 'animations-experiment/utils/run-animations';
+import LinearBehavior from 'animations-experiment/behaviors/linear';
 
 export default class NestedSprites extends Controller {
-  @tracked moveOuter = false;
-  @tracked moveInner = true;
+  @tracked move = false;
 
-  async transition(changeset: Changeset) {
-    magicMove(changeset, { duration: 5000 });
+  async transition(changeset: Changeset, orchestrator: Orchestrator) {
+    orchestrator.setTimingForContext(changeset.context, {
+      match: 'inner',
+      delay: 1500,
+      duration: 500,
+    });
+
+    for (let sprite of changeset.keptSprites) {
+      orchestrator.animate(changeset.context, sprite, 'position', {
+        behavior: new LinearBehavior(),
+        duration: 5000,
+      });
+    }
+    await runAnimations([...changeset.keptSprites]);
+  }
+
+  async innerTransition(changeset: Changeset, orchestrator: Orchestrator) {
+    for (let sprite of changeset.keptSprites) {
+      orchestrator.animate(changeset.context, sprite, 'position', {
+        behavior: new LinearBehavior(),
+        duration: 500,
+      });
+    }
     await runAnimations([...changeset.keptSprites]);
   }
 }

--- a/demo-app/app/templates/nested-sprites.hbs
+++ b/demo-app/app/templates/nested-sprites.hbs
@@ -1,20 +1,12 @@
 <div local-class="page">
-  <button type="button" {{on "click" (fn (mut this.moveOuter) (not this.moveOuter))}}>Move Outer</button>
-  <button type="button" {{on "click" (fn (mut this.moveInner) (not this.moveInner))}}>Move Inner</button>
+  <button type="button" {{on "click" (fn (mut this.move) (not this.move))}}>Move</button>
 
   <AnimationContext @use={{this.transition}} local-class="context">
-    <div {{sprite id="outer"}} local-class="outer {{if this.moveOuter "right"}}">
+    <div {{sprite id="outer"}} local-class="outer {{if this.move "right"}}">
       Outer Sprite
-      <AnimationContext @use={{this.transition}} local-class="context">
-        <div {{sprite id="inner"}} local-class="inner {{if this.moveInner "right"}}">Inner Sprite</div>
+      <AnimationContext @use={{this.innerTransition}} @id="inner" local-class="context">
+        <div {{sprite id="inner"}} local-class="inner {{if this.move "right"}}">Inner Sprite</div>
       </AnimationContext>
-    </div>
-  </AnimationContext>
-
-  <AnimationContext @use={{this.transition}} local-class="context">
-    <div {{sprite id="outer-no-context"}} local-class="outer {{if this.moveOuter "right"}}">
-      Outer Sprite
-      <div {{sprite id="inner-no-context"}} local-class="inner {{if this.moveInner "right"}}">Inner Sprite</div>
     </div>
   </AnimationContext>
 </div>


### PR DESCRIPTION
Not applying duration here - I don't see a way to apply duration well.

## Why no duration enforcement?
- If we provide an interface to setup animations for all sprites that a context wants to animate, we could try and "compress" the time down to the duration specified, but that runs the risk of animating certain things too quickly (<100ms, animation not perceived by user).
- If we simply provide the duration, we can't really prevent a context's use of animations that run too long. If we enforce it by cutting an animation short, we might cause jank.

## Other problems
- Orchestrating this way won't work when we're working with an unstable context (animating an inserted sprite/a non-natural kept sprite), since the unstable context has no opportunity to animate. 
- Hooks could also call hooks - which could result in total animation time that is over the generally accepted limit of 500ms.
- What if two contexts want to affect the same descendant?