### PR TITLE
Implement arbitrarily-nested orchestration

### DIFF
--- a/addon/addon/models/orchestration-matrix.ts
+++ b/addon/addon/models/orchestration-matrix.ts
@@ -150,7 +150,7 @@ export class OrchestrationMatrix {
     let timelineMatrix = OrchestrationMatrix.empty();
     let submatrices = [];
     // maxLength is for anchoring to the end. not using yet
-    let maxLength = 0;
+    // let maxLength = 0;
     for (let item of timeline.parallel) {
       let submatrix: OrchestrationMatrix;
       if ((item as SequentialAnimationTimeline).sequence) {
@@ -167,7 +167,7 @@ export class OrchestrationMatrix {
         );
       }
 
-      maxLength = Math.max(maxLength, submatrix.totalColumns);
+      // maxLength = Math.max(maxLength, submatrix.totalColumns);
       submatrices.push(submatrix);
     }
 

--- a/addon/addon/models/orchestration-matrix.ts
+++ b/addon/addon/models/orchestration-matrix.ts
@@ -1,0 +1,207 @@
+import { Frame } from 'animations-experiment/behaviors/base';
+import Sprite, { MotionProperty } from './sprite';
+import {
+  MotionDefinition,
+  ParallelAnimationTimeline,
+  SequentialAnimationTimeline,
+} from './transition-runner';
+
+interface RowFragment {
+  startColumn: number;
+  frames: Frame[];
+}
+
+export class OrchestrationMatrix {
+  constructor(
+    // This isn't ordered yet, but can be ordered if necessary
+    public rows = new Map<Sprite, RowFragment[]>(),
+    public totalColumns = 0
+  ) {}
+
+  // TODO: if we want to handle cascading effects, we'll need a way of iterating over this column-by-column,
+  // in order of sprites from higher level in DOM to lower level, modifying scoped variables per-sprite
+  // TODO: this can probably become a generator if we want?
+  getKeyframes(
+    constructKeyframe: (
+      previousKeyframe: Partial<Keyframe>,
+      frames: Frame[] // frame order may be relevant
+    ) => Keyframe
+  ) {
+    let result: Map<Sprite, Keyframe[]> = new Map();
+    for (let [sprite, rowFragments] of this.rows) {
+      // convenience so we do less operations to determine active fragments
+      let fragmentsByColumn: Record<number, RowFragment[]> = {};
+      // examine assumptions - what exactly is the frame?
+      let baseKeyframe = {};
+      for (let rowFragment of rowFragments) {
+        fragmentsByColumn[rowFragment.startColumn] =
+          fragmentsByColumn[rowFragment.startColumn] ?? [];
+        fragmentsByColumn[rowFragment.startColumn]!.push(rowFragment);
+        baseKeyframe = Object.assign({}, rowFragment.frames[0], baseKeyframe);
+      }
+
+      let activeFragments: RowFragment[] = [];
+      let keyframesForSprite: Keyframe[] = [];
+      let previousKeyframe = baseKeyframe;
+      for (let i = 0; i < this.totalColumns; i++) {
+        if (fragmentsByColumn[i]) {
+          activeFragments = activeFragments.concat(
+            fragmentsByColumn[i] as RowFragment[]
+          );
+        }
+
+        let needsRemoval = false;
+        let frames: Frame[] = [];
+        for (let fragment of activeFragments) {
+          let frame = fragment.frames.shift();
+          if (frame) frames.push(frame);
+          else needsRemoval = true;
+        }
+        let newKeyframe = constructKeyframe(previousKeyframe, frames);
+        keyframesForSprite.push(newKeyframe);
+        previousKeyframe = newKeyframe;
+
+        if (needsRemoval) {
+          activeFragments = activeFragments.filter(
+            (rowFragment) => rowFragment.frames.length
+          );
+        }
+      }
+
+      result.set(sprite, keyframesForSprite);
+    }
+    return result;
+  }
+
+  add(col: number, matrix: OrchestrationMatrix) {
+    for (let [sprite, rowFragments] of matrix.rows) {
+      let incomingFragments = rowFragments.map((rowFragment) => {
+        return {
+          ...rowFragment,
+          startColumn: rowFragment.startColumn + col,
+        };
+      });
+      let existingFragments = this.rows.get(sprite);
+      let newFragments = existingFragments
+        ? existingFragments.concat(incomingFragments)
+        : incomingFragments;
+      this.rows.set(sprite, newFragments);
+    }
+
+    this.totalColumns = Math.max(this.totalColumns, matrix.totalColumns + col);
+  }
+
+  static empty() {
+    return new OrchestrationMatrix();
+  }
+
+  static fromTimeline(
+    timeline: SequentialAnimationTimeline | ParallelAnimationTimeline
+  ) {
+    if ((timeline as SequentialAnimationTimeline).sequence) {
+      return OrchestrationMatrix.fromSequentialTimeline(
+        timeline as SequentialAnimationTimeline
+      );
+    } else if ((timeline as ParallelAnimationTimeline).parallel) {
+      return OrchestrationMatrix.fromParallelTimeline(
+        timeline as ParallelAnimationTimeline
+      );
+    } else {
+      throw new Error(
+        'Expected a timeline that was sequential or parallel, got neither'
+      );
+    }
+  }
+
+  static fromSequentialTimeline(
+    timeline: SequentialAnimationTimeline
+  ): OrchestrationMatrix {
+    let timelineMatrix = OrchestrationMatrix.empty();
+    let submatrices = [];
+    for (let item of timeline.sequence) {
+      let submatrix: OrchestrationMatrix;
+      if ((item as SequentialAnimationTimeline).sequence) {
+        submatrix = OrchestrationMatrix.fromSequentialTimeline(
+          item as SequentialAnimationTimeline
+        );
+      } else if ((item as ParallelAnimationTimeline).parallel) {
+        submatrix = OrchestrationMatrix.fromParallelTimeline(
+          item as ParallelAnimationTimeline
+        );
+      } else {
+        submatrix = OrchestrationMatrix.fromMotionDefinition(
+          item as MotionDefinition
+        );
+      }
+
+      submatrices.push(submatrix);
+    }
+
+    for (let submatrix of submatrices) {
+      timelineMatrix.add(timelineMatrix.totalColumns, submatrix);
+    }
+
+    return timelineMatrix;
+  }
+
+  static fromParallelTimeline(
+    timeline: ParallelAnimationTimeline
+  ): OrchestrationMatrix {
+    let timelineMatrix = OrchestrationMatrix.empty();
+    let submatrices = [];
+    // maxLength is for anchoring to the end. not using yet
+    let maxLength = 0;
+    for (let item of timeline.parallel) {
+      let submatrix: OrchestrationMatrix;
+      if ((item as SequentialAnimationTimeline).sequence) {
+        submatrix = OrchestrationMatrix.fromSequentialTimeline(
+          item as SequentialAnimationTimeline
+        );
+      } else if ((item as ParallelAnimationTimeline).parallel) {
+        submatrix = OrchestrationMatrix.fromParallelTimeline(
+          item as ParallelAnimationTimeline
+        );
+      } else {
+        submatrix = OrchestrationMatrix.fromMotionDefinition(
+          item as MotionDefinition
+        );
+      }
+
+      maxLength = Math.max(maxLength, submatrix.totalColumns);
+      submatrices.push(submatrix);
+    }
+
+    for (let submatrix of submatrices) {
+      timelineMatrix.add(0, submatrix);
+    }
+    return timelineMatrix;
+  }
+
+  static fromMotionDefinition(motionDefinition: MotionDefinition) {
+    let properties = motionDefinition.properties;
+    let timing = motionDefinition.timing;
+    let rows = new Map<Sprite, RowFragment[]>();
+    let maxLength = 0;
+    for (let sprite of motionDefinition.sprites) {
+      let rowFragments: RowFragment[] = [];
+      for (let property in properties) {
+        let options = properties[property as MotionProperty];
+        sprite.setupAnimation(property as MotionProperty, {
+          ...options,
+          ...timing,
+        });
+        let { keyframes } = sprite.compileCurrentAnimations() ?? {};
+        if (keyframes) {
+          rowFragments.push({
+            frames: keyframes as Frame[],
+            startColumn: 0,
+          });
+          maxLength = Math.max(keyframes.length, maxLength);
+        }
+      }
+      rows.set(sprite, rowFragments);
+    }
+
+    return new OrchestrationMatrix(rows, maxLength);
+  }
+}

--- a/addon/addon/models/transition-runner.ts
+++ b/addon/addon/models/transition-runner.ts
@@ -66,6 +66,8 @@ export default class TransitionRunner {
               sprite.setupAnimation(property as MotionProperty, {
                 ...options,
                 ...animation.timing,
+                // This relies on delay being implemented with no-op frames
+                // If it's not, then we'll end up having overlapping effects from animation keyframes
                 delay: delay + (animation.timing?.delay ?? 0),
               });
             }

--- a/addon/addon/models/transition-runner.ts
+++ b/addon/addon/models/transition-runner.ts
@@ -9,14 +9,22 @@ import { assert } from '@ember/debug';
 import { IContext } from './sprite-tree';
 import { SpriteAnimation } from 'animations-experiment/models/sprite-animation';
 import Behavior, { FPS } from 'animations-experiment/behaviors/base';
+import { OrchestrationMatrix } from './orchestration-matrix';
 
 export interface AnimationDefinition {
   timeline: AnimationTimeline;
 }
 
-export interface AnimationTimeline {
-  sequence?: MotionDefinition[];
-  parallel?: MotionDefinition[];
+export type AnimationTimeline =
+  | SequentialAnimationTimeline
+  | ParallelAnimationTimeline;
+export interface SequentialAnimationTimeline {
+  sequence: (MotionDefinition | AnimationTimeline)[];
+  parallel: never;
+}
+export interface ParallelAnimationTimeline {
+  parallel: (MotionDefinition | AnimationTimeline)[];
+  sequence: never;
 }
 
 export interface MotionDefinition {
@@ -47,71 +55,28 @@ export default class TransitionRunner {
       !(timeline.sequence && timeline.parallel)
     );
 
-    let keyframesPerSprite = new Map<Sprite, Keyframe[]>();
+    let orchestrationMatrix = OrchestrationMatrix.fromTimeline(timeline);
+    let result: SpriteAnimation[] = [];
+    for (let [sprite, keyframes] of orchestrationMatrix
+      .getKeyframes((prev, incoming) => {
+        return Object.assign({}, prev, ...incoming);
+      })
+      .entries()) {
+      let duration = Math.max(0, (keyframes.length - 1) / FPS);
+      let keyframeAnimationOptions = {
+        easing: 'linear',
+        duration,
+      };
 
-    if (timeline.sequence) {
-      for (let animation of timeline.sequence) {
-        assert(
-          'No sprites present on the animation definition',
-          Boolean(animation.sprites?.size)
-        );
-        animation.sprites.forEach((sprite: Sprite) => {
-          let keyframesForSprite = keyframesPerSprite.get(sprite);
-          let delay = keyframesForSprite
-            ? Math.max(0, (keyframesForSprite.length - 1) / FPS)
-            : 0;
+      let animation = new SpriteAnimation(
+        sprite,
+        keyframes,
+        keyframeAnimationOptions
+      );
 
-          Object.entries(animation.properties).forEach(
-            ([property, options]) => {
-              sprite.setupAnimation(property as MotionProperty, {
-                ...options,
-                ...animation.timing,
-                // This relies on delay being implemented with no-op frames
-                // If it's not, then we'll end up having overlapping effects from animation keyframes
-                delay: delay + (animation.timing?.delay ?? 0),
-              });
-            }
-          );
-          // we pass the previous keyframes so the last values (if any) can be taken as a starting point if necessary
-          // and/or velocity can be transferred
-          let { keyframes } = sprite.compileCurrentAnimations() ?? {};
-
-          if (keyframes?.length) {
-            if (!keyframesPerSprite.has(sprite)) {
-              keyframesPerSprite.set(sprite, keyframes);
-            } else {
-              let mergedKeyframes = keyframes.map((newKeyframe, index) => {
-                let existingKeyframe = keyframesPerSprite.get(sprite)?.[index];
-
-                // we let the existing keyframe override the new keyframe, because if we animated it already earlier
-                // in the sequence the property will already be in the keyframe.
-                return {
-                  ...newKeyframe,
-                  ...existingKeyframe,
-                };
-              });
-
-              keyframesPerSprite.set(sprite, mergedKeyframes);
-            }
-          }
-        });
-      }
-    } else if (timeline.parallel) {
-      // TODO
+      result.push(animation);
     }
-
-    return [...keyframesPerSprite.entries()].map(
-      ([sprite, keyframes]: [Sprite, Keyframe[]]) => {
-        // calculate "real" duration based on amount of keyframes at the given FPS
-        let duration = Math.max(0, (keyframes.length - 1) / FPS);
-        let keyframeAnimationOptions = {
-          easing: 'linear',
-          duration,
-        };
-
-        return new SpriteAnimation(sprite, keyframes, keyframeAnimationOptions);
-      }
-    );
+    return result;
   }
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types

--- a/addon/addon/models/transition-runner.ts
+++ b/addon/addon/models/transition-runner.ts
@@ -30,7 +30,7 @@ export interface ParallelAnimationTimeline {
 export interface MotionDefinition {
   sprites: Set<Sprite>;
   properties: {
-    [k in MotionProperty]: MotionOptions | {};
+    [k in MotionProperty]: MotionOptions | Record<string, never>;
   };
   timing: {
     behavior: Behavior;

--- a/demo-app/app/controllers/simple-orchestration.ts
+++ b/demo-app/app/controllers/simple-orchestration.ts
@@ -67,11 +67,11 @@ export default class SimpleOrchestration extends Controller {
           {
             sprites: keptSprites,
             properties: {
-              opacity: { to: 0.5 },
+              opacity: { from: 1, to: 0.1 },
             },
             timing: {
               behavior: new LinearBehavior(),
-              duration: 300,
+              duration: 1200,
             },
           },
           {
@@ -80,7 +80,8 @@ export default class SimpleOrchestration extends Controller {
               position: {},
             },
             timing: {
-              behavior: new SpringBehavior(),
+              behavior: new LinearBehavior(),
+              duration: 1200,
             },
           },
         ],

--- a/demo-app/app/controllers/simple-orchestration.ts
+++ b/demo-app/app/controllers/simple-orchestration.ts
@@ -6,7 +6,7 @@ import { AnimationDefinition } from 'animations-experiment/models/transition-run
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
-export default class Sequence extends Controller {
+export default class SimpleOrchestration extends Controller {
   @tracked leftPosition = '0px';
 
   @action
@@ -18,7 +18,7 @@ export default class Sequence extends Controller {
     }
   }
 
-  transition(changeset: Changeset): AnimationDefinition {
+  sequence(changeset: Changeset): AnimationDefinition {
     let { keptSprites } = changeset;
 
     return {
@@ -57,11 +57,41 @@ export default class Sequence extends Controller {
       },
     } as unknown as AnimationDefinition;
   }
+
+  parallel(changeset: Changeset): AnimationDefinition {
+    let { keptSprites } = changeset;
+
+    return {
+      timeline: {
+        parallel: [
+          {
+            sprites: keptSprites,
+            properties: {
+              opacity: { to: 0.5 },
+            },
+            timing: {
+              behavior: new LinearBehavior(),
+              duration: 300,
+            },
+          },
+          {
+            sprites: keptSprites,
+            properties: {
+              position: {},
+            },
+            timing: {
+              behavior: new SpringBehavior(),
+            },
+          },
+        ],
+      },
+    } as unknown as AnimationDefinition;
+  }
 }
 
 // DO NOT DELETE: this is how TypeScript knows how to look up your controllers.
 declare module '@ember/controller' {
   interface Registry {
-    sequence: Sequence;
+    'simple-orchestration': SimpleOrchestration;
   }
 }

--- a/demo-app/app/controllers/simple-orchestration.ts
+++ b/demo-app/app/controllers/simple-orchestration.ts
@@ -41,7 +41,7 @@ export default class SimpleOrchestration extends Controller {
             },
             timing: {
               behavior: new LinearBehavior(),
-              duration: 300,
+              duration: 500,
             },
           },
           {
@@ -67,22 +67,35 @@ export default class SimpleOrchestration extends Controller {
           {
             sprites: keptSprites,
             properties: {
-              opacity: { from: 1, to: 0.1 },
-            },
-            timing: {
-              behavior: new LinearBehavior(),
-              duration: 1200,
-            },
-          },
-          {
-            sprites: keptSprites,
-            properties: {
               position: {},
             },
             timing: {
               behavior: new LinearBehavior(),
-              duration: 1200,
+              duration: 2400,
             },
+          },
+          {
+            sequence: [
+              {
+                sprites: keptSprites,
+                properties: {
+                  opacity: { from: 1, to: 0.1 },
+                },
+                timing: {
+                  behavior: new SpringBehavior(),
+                },
+              },
+              {
+                sprites: keptSprites,
+                properties: {
+                  opacity: { to: 1, from: 0.1 },
+                },
+                timing: {
+                  behavior: new LinearBehavior(),
+                  duration: 1200,
+                },
+              },
+            ],
           },
         ],
       },

--- a/demo-app/app/router.js
+++ b/demo-app/app/router.js
@@ -20,5 +20,5 @@ Router.map(function () {
   this.route('context-selection');
   this.route('nested-sprites');
   this.route('removed-sprite-interruption');
-  this.route('sequence');
+  this.route('simple-orchestration');
 });

--- a/demo-app/app/routes/sequence.ts
+++ b/demo-app/app/routes/sequence.ts
@@ -1,7 +1,0 @@
-import Route from '@ember/routing/route';
-
-export default class Sequence extends Route.extend({
-  // anything which *must* be merged to prototype here
-}) {
-  // normal class body definition here
-}

--- a/demo-app/app/routes/simple-orchestration.ts
+++ b/demo-app/app/routes/simple-orchestration.ts
@@ -1,0 +1,5 @@
+import Route from '@ember/routing/route';
+
+export default class Sequence extends Route {
+  // normal class body definition here
+}

--- a/demo-app/app/templates/sequence.hbs
+++ b/demo-app/app/templates/sequence.hbs
@@ -1,5 +1,0 @@
-<button type="button" {{on "click" this.toggleMove}}>Move</button>
-
-<AnimationContext @use={{this.transition}}>
-  <div {{sprite id="foo"}} style="width: 50px; height: 50px; background: red; margin-left: {{this.leftPosition}};"></div>
-</AnimationContext>

--- a/demo-app/app/templates/simple-orchestration.hbs
+++ b/demo-app/app/templates/simple-orchestration.hbs
@@ -1,3 +1,5 @@
+{{!-- template-lint-disable no-inline-styles --}}
+{{!-- template-lint-disable style-concatenation --}}
 <button type="button" {{on "click" this.toggleMove}}>Move</button>
 
 <AnimationContext @use={{this.sequence}}>

--- a/demo-app/app/templates/simple-orchestration.hbs
+++ b/demo-app/app/templates/simple-orchestration.hbs
@@ -1,0 +1,11 @@
+<button type="button" {{on "click" this.toggleMove}}>Move</button>
+
+<AnimationContext @use={{this.sequence}}>
+  <div {{sprite id="foo1"}} style="width: 50px; height: 50px; background: red; margin-left: {{this.leftPosition}};"></div>
+</AnimationContext>
+
+<br>
+
+<AnimationContext @use={{this.parallel}}>
+  <div {{sprite id="foo2"}} style="width: 50px; height: 50px; background: red; margin-left: {{this.leftPosition}};"></div>
+</AnimationContext>


### PR DESCRIPTION
This uses an `OrchestrationMatrix` to implement arbitrarily-nested orchestration. `OrchestrationMatrix` is similar to a sparse matrix. Its properties are as follows:

```
// total number of keyframes it should expect to output
totalColumns: number;
// each sprite has a row of its own. Note that sprite order should not matter (yet)
rows: Map<Sprite, RowFragment[]>; 

interface RowFragment {
  // The column at which this fragment starts
  startColumn: number;
  // The frames that make up this fragment
  frames: Frame[];
}
```

`OrchestrationMatrix` can be added to each other, to form a bigger `OrchestrationMatrix`. This allows arbitrary frames to be added at different timings, relative to other frames. It also ties in with the vision of being able to globally calculate frames in one shot and perform corrections for scale-based resizing (though that would require keyframe creation changes).

Once the `OrchestrationMatrix` is built from a timeline, we can get keyframes for each sprite by calling `OrchestrationMatrix.getKeyframes`, which requires passing of the function that creates a keyframe given a previous keyframe and a bunch of incoming frames. `OrchestrationMatrix.getKeyframes` currently mutates `RowFragment.frames` , since this is easier than doing a calculation to check whether a `RowFragment` should be dropped - though it is possible to modify this implementation rather easily. 