### PR TITLE
Tidier rules

### DIFF
--- a/addon/addon/components/animation-context/index.ts
+++ b/addon/addon/components/animation-context/index.ts
@@ -9,7 +9,8 @@ import { action } from '@ember/object';
 import AnimationsService from 'animations-experiment/services/animations';
 import { assert } from '@ember/debug';
 import { getDocumentPosition } from 'animations-experiment/utils/measurement';
-import { IContext } from 'animations-experiment/models/sprite-tree';
+import { IContext, Rule } from 'animations-experiment/models/sprite-tree';
+import { AnimationDefinition } from 'animations-experiment/models/transition-runner';
 
 const { VOLATILE_TAG, consumeTag } =
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -18,7 +19,10 @@ const { VOLATILE_TAG, consumeTag } =
 
 interface AnimationContextArgs {
   id: string | undefined;
-  use: ((changeset: Changeset) => Promise<void>) | undefined;
+  use:
+    | ((changeset: Changeset) => Promise<void | AnimationDefinition>)
+    | undefined;
+  rules: Rule[] | undefined;
 }
 
 export default class AnimationContextComponent
@@ -77,7 +81,7 @@ export default class AnimationContextComponent
   }
 
   shouldAnimate(): boolean {
-    return Boolean(this.args.use && this.isStable);
+    return Boolean((this.args.use || this.args.rules) && this.isStable);
   }
 
   hasOrphan(sprite: Sprite): boolean {

--- a/addon/addon/models/sprite-tree.ts
+++ b/addon/addon/models/sprite-tree.ts
@@ -3,6 +3,14 @@ import { CopiedCSS } from '../utils/measurement';
 import { formatTreeString, TreeNode } from '../utils/format-tree';
 import Sprite, { SpriteIdentifier, SpriteType } from './sprite';
 import { Changeset } from './changeset';
+import { AnimationDefinition } from 'animations-experiment/models/transition-runner';
+
+export interface Rule {
+  match(unallocatedItems: Sprite[]): {
+    remaining: Sprite[];
+    claimed: AnimationDefinition[];
+  };
+}
 
 export interface IContext {
   id: string | undefined;
@@ -22,8 +30,11 @@ export interface IContext {
   appendOrphan(spriteOrElement: Sprite): void;
   clearOrphans(): void;
   args: {
-    use?(changeset: Changeset): Promise<void>;
+    use:
+      | ((changeset: Changeset) => Promise<void | AnimationDefinition>)
+      | undefined;
     id?: string;
+    rules: Rule[] | undefined;
   };
 }
 

--- a/addon/addon/models/sprite-tree.ts
+++ b/addon/addon/models/sprite-tree.ts
@@ -30,11 +30,11 @@ export interface IContext {
   appendOrphan(spriteOrElement: Sprite): void;
   clearOrphans(): void;
   args: {
-    use:
+    use?:
       | ((changeset: Changeset) => Promise<void | AnimationDefinition>)
       | undefined;
     id?: string;
-    rules: Rule[] | undefined;
+    rules?: Rule[] | undefined;
   };
 }
 

--- a/addon/addon/models/transition-runner.ts
+++ b/addon/addon/models/transition-runner.ts
@@ -1,10 +1,6 @@
 import { task } from 'ember-concurrency';
 import { Changeset } from '../models/changeset';
-import Sprite, {
-  MotionOptions,
-  MotionProperty,
-  SpriteType,
-} from '../models/sprite';
+import Sprite, { MotionOptions, MotionProperty } from '../models/sprite';
 import { assert } from '@ember/debug';
 import { IContext } from './sprite-tree';
 import { SpriteAnimation } from 'animations-experiment/models/sprite-animation';
@@ -47,16 +43,21 @@ export default class TransitionRunner {
     this.animationContext = animationContext;
   }
 
-  setupAnimations(definition: AnimationDefinition): SpriteAnimation[] {
-    let timeline = definition.timeline;
-    assert('No timeline present in AnimationDefinition', Boolean(timeline));
-    assert(
-      'Timeline can have either a sequence or a parallel definition, not both',
-      !(timeline.sequence && timeline.parallel)
-    );
-
-    let orchestrationMatrix = OrchestrationMatrix.fromTimeline(timeline);
+  setupAnimations(definitions: AnimationDefinition[]): SpriteAnimation[] {
     let result: SpriteAnimation[] = [];
+
+    let orchestrationMatrix = new OrchestrationMatrix();
+    for (let definition of definitions) {
+      let timeline = definition.timeline;
+      assert('No timeline present in AnimationDefinition', Boolean(timeline));
+      assert(
+        'Timeline can have either a sequence or a parallel definition, not both',
+        !(timeline.sequence && timeline.parallel)
+      );
+
+      orchestrationMatrix.add(0, OrchestrationMatrix.fromTimeline(timeline));
+    }
+
     for (let [sprite, keyframes] of orchestrationMatrix
       .getKeyframes((prev, incoming) => {
         return Object.assign({}, prev, ...incoming);
@@ -76,6 +77,7 @@ export default class TransitionRunner {
 
       result.push(animation);
     }
+
     return result;
   }
 
@@ -90,58 +92,44 @@ export default class TransitionRunner {
     //playUnrelatedAnimations();
 
     if (animationContext.shouldAnimate()) {
-      this.logChangeset(changeset, animationContext); // For debugging
-      let animationDefinition = animationContext.args.use?.(changeset) as
-        | AnimationDefinition
-        | undefined;
+      try {
+        let animationDefinitions = [];
+        if (animationContext.args.use instanceof Function) {
+          // Note: some use() calls are async and return a Promise.
+          // yielding this is currently incorrect (I think), because we probably don't want to
+          // allow delaying animations by deferring the returning of an AnimationDefinition
+          // TODO: Convert all current demos to use AnimationDefinition
+          let animationDefinition: AnimationDefinition | undefined =
+            (yield animationContext.args.use?.(changeset)) as
+              | AnimationDefinition
+              | undefined;
 
-      if (animationDefinition) {
-        // TODO: compile animation
-        let animations = this.setupAnimations(animationDefinition);
-        let promises = animations.map((animation) => animation.finished);
-
-        animations.forEach((a) => {
-          a.play();
-        });
-
-        try {
-          yield Promise.resolve(Promise.all(promises));
-        } catch (error) {
-          console.error(error);
-          throw error;
+          if (animationDefinition) {
+            animationDefinitions.push(animationDefinition);
+          }
         }
+
+        animationDefinitions = [
+          ...changeset.animationDefinitions,
+          ...animationDefinitions,
+        ];
+
+        if (animationDefinitions.length) {
+          let animations = this.setupAnimations(animationDefinitions);
+          let promises = animations.map((animation) => animation.finished);
+
+          animations.forEach((a) => {
+            a.play();
+          });
+
+          yield Promise.all(promises);
+        }
+      } catch (error) {
+        console.error(error);
+        throw error;
       }
+
       animationContext.clearOrphans();
     }
-  }
-
-  private logChangeset(changeset: Changeset, animationContext: IContext): void {
-    let contextId = animationContext.args.id;
-    function row(type: SpriteType, sprite: Sprite) {
-      return {
-        intent: changeset.intent,
-        context: contextId,
-        type,
-        spriteRole: sprite.role,
-        spriteId: sprite.id,
-        initialBounds: sprite.initialBounds
-          ? JSON.stringify(sprite.initialBounds)
-          : null,
-        finalBounds: sprite.finalBounds
-          ? JSON.stringify(sprite.finalBounds)
-          : null,
-      };
-    }
-    let tableRows = [];
-    for (let type of [
-      SpriteType.Inserted,
-      SpriteType.Removed,
-      SpriteType.Kept,
-    ]) {
-      for (let sprite of changeset.spritesFor({ type })) {
-        tableRows.push(row(type, sprite));
-      }
-    }
-    console.table(tableRows);
   }
 }

--- a/demo-app/app/templates/simple-orchestration.hbs
+++ b/demo-app/app/templates/simple-orchestration.hbs
@@ -2,12 +2,10 @@
 {{!-- template-lint-disable style-concatenation --}}
 <button type="button" {{on "click" this.toggleMove}}>Move</button>
 
-<AnimationContext @use={{this.sequence}}>
+<AnimationContext @use={{this.use}} @rules={{this.rules}}>
   <div {{sprite id="foo1"}} style="width: 50px; height: 50px; background: red; margin-left: {{this.leftPosition}};"></div>
-</AnimationContext>
 
 <br>
 
-<AnimationContext @use={{this.parallel}}>
   <div {{sprite id="foo2"}} style="width: 50px; height: 50px; background: red; margin-left: {{this.leftPosition}};"></div>
 </AnimationContext>


### PR DESCRIPTION
Rules implementation, split off from #107
- [ ] test that `ChangesetBuilder` can create changesets with correct `AnimationDefinition`s by matching sprites against rules
- [ ] test that `ChangesetBuilder` can create changesets with correct (remaining) sprites after matching rules
- [ ] test that `TransitionRunner` can handle `@use` and additional `AnimationDefinition`s correctly