### PR TITLE
Type updates

### DIFF
--- a/addon/addon/components/animation-context/index.ts
+++ b/addon/addon/components/animation-context/index.ts
@@ -10,6 +10,7 @@ import AnimationsService from '@cardstack/boxel-motion/services/animations';
 import { assert } from '@ember/debug';
 import { getDocumentPosition } from '@cardstack/boxel-motion/utils/measurement';
 import { IContext } from '@cardstack/boxel-motion/models/sprite-tree';
+import { AnimationDefinition } from '@cardstack/boxel-motion/models/orchestration';
 
 const { VOLATILE_TAG, consumeTag } =
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -17,8 +18,13 @@ const { VOLATILE_TAG, consumeTag } =
   Ember.__loader.require('@glimmer/validator');
 
 interface AnimationContextArgs {
-  id: string | undefined;
-  use: ((changeset: Changeset) => Promise<void>) | undefined;
+  Args: {
+    id?: string;
+    use: ((changeset: Changeset) => AnimationDefinition) | undefined;
+  };
+  Blocks: {
+    default: [];
+  };
 }
 
 export default class AnimationContextComponent

--- a/addon/addon/models/sprite-tree.ts
+++ b/addon/addon/models/sprite-tree.ts
@@ -3,6 +3,7 @@ import { CopiedCSS } from '../utils/measurement';
 import { formatTreeString, TreeNode } from '../utils/format-tree';
 import Sprite, { SpriteIdentifier, SpriteType } from './sprite';
 import { Changeset } from './changeset';
+import { AnimationDefinition } from './orchestration';
 
 export interface IContext {
   id: string | undefined;
@@ -22,7 +23,7 @@ export interface IContext {
   appendOrphan(spriteOrElement: Sprite): void;
   clearOrphans(): void;
   args: {
-    use?(changeset: Changeset): Promise<void>;
+    use?(changeset: Changeset): AnimationDefinition;
     id?: string;
   };
 }

--- a/addon/addon/modifiers/sprite.ts
+++ b/addon/addon/modifiers/sprite.ts
@@ -11,10 +11,11 @@ import { once } from '@ember/runloop';
 import AnimationsService from '../services/animations';
 
 interface SpriteModifierArgs {
-  positional: [];
-  named: {
-    id: string | null;
-    role: string | null;
+  Args: {
+    Named: {
+      id?: string;
+      role?: string;
+    };
   };
 }
 
@@ -31,8 +32,8 @@ export default class SpriteModifier extends Modifier<SpriteModifierArgs> {
   @service declare animations: AnimationsService;
 
   didReceiveArguments(): void {
-    this.id = this.args.named.id;
-    this.role = this.args.named.role;
+    this.id = this.args.named.id ?? null;
+    this.role = this.args.named.role ?? null;
     this.animations.registerSpriteModifier(this);
     this.captureSnapshot();
   }


### PR DESCRIPTION
These were the minimal changes we needed to get things to typecheck sensibly in runtime-spike.

I think these component signatures were so far not really being used anywhere, which is why they were so far off.