### PR TITLE
Change workflow branch specifier

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [$default-branch]
+    branches: [main]
   pull_request:
 
 env:


### PR DESCRIPTION
Actions haven’t been running on main:
https://github.com/cardstack/boxel-motion/actions?query=branch%3Amain

It appears `[$default-branch]` is meant to be used in workflow templates, it gets replaced when the workflow is generated:
https://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization#creating-a-starter-workflow