### PR TITLE
reintroduce logging

### DIFF
--- a/packages/boxel-motion/addon/services/animations.ts
+++ b/packages/boxel-motion/addon/services/animations.ts
@@ -80,6 +80,7 @@ export default class AnimationsService extends Service {
     this.clearChanges();
 
     this.animationParticipantManager.snapshotAfterRender();
+    this.animationParticipantManager.log();
 
     let { sprites, animators } =
       this.animationParticipantManager.createAnimatorsAndSprites();


### PR DESCRIPTION
<img width="500" alt="Logging of the interruptions demo, shows a tree with different labeled contexts (marked with 🥡) and sprites (marked with 🥠), along with a map of label to AnimationParticipant" src="https://user-images.githubusercontent.com/39579264/203492440-fefd33ce-a2bc-4250-afb5-3bf2b9cbe705.png">
