### PR TITLE
clean up orphans each render, before animating

### DIFF
--- a/packages/boxel-motion/addon/models/transition-runner.ts
+++ b/packages/boxel-motion/addon/models/transition-runner.ts
@@ -98,9 +98,6 @@ export default class TransitionRunner {
         let promises = animations.map((animation) => animation.finished);
 
         animations.forEach((a) => {
-          if (this.animationContext.hasOrphan(a.sprite)) {
-            this.animationContext.removeOrphan(a.sprite);
-          }
           if (a.sprite.type === SpriteType.Removed) {
             this.animationContext.appendOrphan(a.sprite);
             a.sprite.lockStyles();
@@ -115,7 +112,6 @@ export default class TransitionRunner {
           throw error;
         }
       }
-      animationContext.clearOrphans();
     }
   }
 


### PR DESCRIPTION
This way of cleanup handles most short-duration transitions. Longer transitions still have a possibility of keeping a clone/orphan around for a long time, obstructing user from interacting with areas covered by the clone/orphan.