### PR TITLE
new demo: prune and graft

### DIFF
--- a/packages/boxel-motion-demo-app/app/controllers/prune-and-graft.ts
+++ b/packages/boxel-motion-demo-app/app/controllers/prune-and-graft.ts
@@ -1,0 +1,84 @@
+import SpringBehavior from '@cardstack/boxel-motion/behaviors/spring';
+import StaticBehavior from '@cardstack/boxel-motion/behaviors/static';
+import TweenBehavior from '@cardstack/boxel-motion/behaviors/tween';
+import { Changeset } from '@cardstack/boxel-motion/models/animator';
+import { AnimationDefinition } from '@cardstack/boxel-motion/models/orchestration';
+import { SpriteType } from '@cardstack/boxel-motion/models/sprite';
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+
+export default class PruneAndGraft extends Controller {
+  @tracked show = true;
+  @tracked ping = false;
+  @tracked extra = false;
+
+  get showExtra() {
+    return this.show === false && this.extra === true;
+  }
+
+  transition(changeset: Changeset): AnimationDefinition {
+    let innerNoContextRemoved = changeset.spritesFor({
+      id: 'inner-no-context',
+      type: SpriteType.Removed,
+    });
+    let extra = changeset.spritesFor({
+      id: 'extra',
+      type: SpriteType.Kept,
+    });
+
+    return {
+      timeline: {
+        type: 'parallel',
+        animations: [
+          ...(innerNoContextRemoved.size
+            ? [
+                {
+                  sprites: innerNoContextRemoved,
+                  properties: {
+                    translateY: {
+                      to: `120px`,
+                    },
+                  },
+                  timing: {
+                    behavior: new TweenBehavior(),
+                    duration: 9000,
+                  },
+                },
+              ]
+            : []),
+          ...(extra.size
+            ? [
+                {
+                  sprites: extra,
+                  properties: {
+                    translateY: {},
+                    translateX: {},
+                  },
+                  timing: {
+                    behavior: new SpringBehavior(),
+                  },
+                },
+                {
+                  sprites: new Set([extra.values().next().value.counterpart]),
+                  properties: {
+                    opacity: 0,
+                  },
+                  timing: {
+                    behavior: new StaticBehavior(),
+                    duration: 9000,
+                  },
+                },
+              ]
+            : []),
+        ],
+      },
+    };
+  }
+}
+
+// DO NOT DELETE: this is how TypeScript knows how to look up your controllers.
+declare module '@ember/controller' {
+  interface Registry {
+    'prune-and-graft': PruneAndGraft;
+  }
+}

--- a/packages/boxel-motion-demo-app/app/controllers/prune-and-graft.ts
+++ b/packages/boxel-motion-demo-app/app/controllers/prune-and-graft.ts
@@ -59,7 +59,9 @@ export default class PruneAndGraft extends Controller {
                   },
                 },
                 {
-                  sprites: new Set([extra.values().next().value.counterpart]),
+                  sprites: new Set(
+                    [extra.values().next().value.counterpart].filter((v) => v)
+                  ),
                   properties: {
                     opacity: 0,
                   },

--- a/packages/boxel-motion-demo-app/app/controllers/simple-orchestration.ts
+++ b/packages/boxel-motion-demo-app/app/controllers/simple-orchestration.ts
@@ -48,7 +48,7 @@ export default class SimpleOrchestration extends Controller {
           {
             sprites: keptSprites,
             properties: {
-              position: {},
+              translateX: {},
             },
             timing: {
               behavior: new SpringBehavior(),
@@ -69,7 +69,7 @@ export default class SimpleOrchestration extends Controller {
           {
             sprites: keptSprites,
             properties: {
-              position: {},
+              translateX: {},
             },
             timing: {
               behavior: new TweenBehavior(),

--- a/packages/boxel-motion-demo-app/app/router.js
+++ b/packages/boxel-motion-demo-app/app/router.js
@@ -8,6 +8,7 @@ export default class Router extends EmberRouter {
 
 Router.map(function () {
   this.route('interruption');
+  this.route('prune-and-graft');
   this.route('routes', function () {
     this.route('other');
   });

--- a/packages/boxel-motion-demo-app/app/styles/prune-and-graft.css
+++ b/packages/boxel-motion-demo-app/app/styles/prune-and-graft.css
@@ -1,0 +1,27 @@
+.page {
+  padding: 25px;
+}
+
+.context {
+  margin-top: 25px;
+}
+
+.outer {
+  padding: 25px;
+  border: 2px solid #000;
+  width: 50%;
+}
+
+.inner {
+  padding: 25px;
+  border: 2px solid #000;
+  width: 50%;
+}
+
+.outer.right {
+  margin-left: 50%;
+}
+
+.inner.right {
+  margin-left: 50%;
+}

--- a/packages/boxel-motion-demo-app/app/templates/application.hbs
+++ b/packages/boxel-motion-demo-app/app/templates/application.hbs
@@ -51,6 +51,16 @@
       In-Out
     </LinkTo>
   </li>
+  <li>
+    <LinkTo @route="simple-orchestration">
+      Orchestration
+    </LinkTo>
+  </li>
+  <li>
+    <LinkTo @route="prune-and-graft">
+      Prune And Graft
+    </LinkTo>
+  </li>
 </ul>
 
 {{outlet}}

--- a/packages/boxel-motion-demo-app/app/templates/prune-and-graft.hbs
+++ b/packages/boxel-motion-demo-app/app/templates/prune-and-graft.hbs
@@ -1,0 +1,24 @@
+<div local-class="page">
+  <button type="button" {{on "click" (fn (mut this.show) (not this.show))}}>Show</button>
+  <br>
+  <button type="button" {{on "click" (fn (mut this.extra) (not this.extra))}}>Extra</button>
+  <br>
+  <button type="button" {{on "click" (fn (mut this.ping) (not this.ping))}}>Just render</button>
+
+  <div>
+    <AnimationContext @use={{this.transition}} local-class="context">
+      {{#if this.showExtra}}
+        <div {{sprite id="extra"}} data-kept="true">Extra</div>
+      {{/if}}
+      {{#if this.show}}
+        <div {{sprite id="outer-no-context"}} local-class="outer">
+          Outer Sprite
+          <div {{sprite id="inner-no-context"}} local-class="inner">
+            Inner Sprite
+            <div {{sprite id="extra"}} data-remove="true">Extra</div>
+          </div>
+        </div>
+      {{/if}}
+    </AnimationContext>
+  </div>
+</div>


### PR DESCRIPTION
Adds a demo that shows that we can animate a removed sprite, and then later match a child of that removed sprite that isn't itself animated. (Click show, then extra).

This PR also:
- demonstrates a bug when we handle a non-natural kept sprite that has an inserted sprite as its parent. (Click show twice)
- adds link for simple-orchestration demo