### PR TITLE
Orchestration fixes for Wait & Static behaviors

### DIFF
--- a/packages/boxel-motion-demo-app/app/controllers/motion-study.ts
+++ b/packages/boxel-motion-demo-app/app/controllers/motion-study.ts
@@ -143,6 +143,7 @@ export default class MotionStudy extends Controller {
           {
             type: 'parallel',
             animations: [
+              moveAllCardsToMidground,
               moveClosingCardContentToForeground,
               fadeOutClosingCardContent,
             ],

--- a/packages/boxel-motion/addon/models/orchestration.ts
+++ b/packages/boxel-motion/addon/models/orchestration.ts
@@ -43,7 +43,8 @@ export class OrchestrationMatrix {
         fragmentsByColumn[rowFragment.startColumn] =
           fragmentsByColumn[rowFragment.startColumn] ?? [];
         fragmentsByColumn[rowFragment.startColumn]!.push(rowFragment);
-        if (rowFragment.frames[0]) {
+        // don't backfill static frames, they're intended to only be set for their duration
+        if (rowFragment.static === false && rowFragment.frames[0]) {
           baseFrames.push(rowFragment.frames[0] as Frame);
         }
       }

--- a/packages/boxel-motion/addon/models/orchestration.ts
+++ b/packages/boxel-motion/addon/models/orchestration.ts
@@ -1,5 +1,7 @@
 import Behavior from '@cardstack/boxel-motion/behaviors/base';
 
+import StaticBehavior from '@cardstack/boxel-motion/behaviors/static';
+import WaitBehavior from '@cardstack/boxel-motion/behaviors/wait';
 import Sprite, {
   MotionOptions,
   MotionProperty,
@@ -12,6 +14,7 @@ import { Frame } from '@cardstack/boxel-motion/value/simple-frame';
 interface RowFragment {
   startColumn: number;
   frames: Frame[];
+  static: boolean;
 }
 
 export class OrchestrationMatrix {
@@ -163,21 +166,35 @@ export class OrchestrationMatrix {
     let maxLength = 0;
     for (let sprite of motionDefinition.sprites) {
       let rowFragments: RowFragment[] = [];
-      for (let property in properties) {
-        let options = properties[property as MotionProperty];
 
-        if (options === undefined) {
-          throw Error('Options cannot be undefined');
-        }
-
-        let frames = generateFrames(sprite, property, options, timing);
-
-        if (frames) {
+      if (timing.behavior instanceof WaitBehavior) {
+        let frames = generateFrames(sprite, 'wait', {}, timing);
+        if (frames?.length) {
           rowFragments.push({
             frames,
             startColumn: 0,
+            static: false,
           });
           maxLength = Math.max(frames.length, maxLength);
+        }
+      } else {
+        for (let property in properties) {
+          let options = properties[property as MotionProperty];
+
+          if (options === undefined) {
+            throw Error('Options cannot be undefined');
+          }
+
+          let frames = generateFrames(sprite, property, options, timing);
+
+          if (frames?.length) {
+            rowFragments.push({
+              frames,
+              startColumn: 0,
+              static: timing.behavior instanceof StaticBehavior,
+            });
+            maxLength = Math.max(frames.length, maxLength);
+          }
         }
       }
       rows.set(sprite, rowFragments);

--- a/packages/boxel-motion/addon/models/orchestration.ts
+++ b/packages/boxel-motion/addon/models/orchestration.ts
@@ -174,7 +174,7 @@ export class OrchestrationMatrix {
           rowFragments.push({
             frames,
             startColumn: 0,
-            static: false,
+            static: true,
           });
           maxLength = Math.max(frames.length, maxLength);
         }

--- a/packages/boxel-motion/addon/utils/generate-frames.ts
+++ b/packages/boxel-motion/addon/utils/generate-frames.ts
@@ -63,18 +63,27 @@ export default function generateFrames(
   // TODO: this is temporary, since we likely won't require to pass a behavior to generateFrames since we'll assign defaults
   let timing = timingArg as MotionTiming;
 
-  if (typeof options !== 'object' || timing.behavior instanceof WaitBehavior) {
+  if (timing.behavior instanceof WaitBehavior) {
     if (!timing.duration) {
-      throw new Error('Static behavior requires a duration');
+      throw new Error('Wait behavior requires a duration');
     }
 
-    // TODO: use a "static" behavior
-    if (property === 'wait') {
-      let generator = new WaitBehavior().getFrames({
-        duration: timing.duration,
-      });
+    let generator = new WaitBehavior().getFrames({
+      duration: timing.duration,
+    });
 
-      return resolveFrameGenerator(normalizedProperty, generator);
+    return resolveFrameGenerator(normalizedProperty, generator);
+  }
+
+  if (typeof options !== 'object') {
+    if (!(timing.behavior instanceof StaticBehavior)) {
+      throw new Error(
+        'Behavior must be StaticBehavior when passing a Value instead of MotionOptions'
+      );
+    }
+
+    if (!timing.duration) {
+      throw new Error('Static behavior requires a duration');
     }
 
     // todo maybe throw error if options is not numeric or string

--- a/packages/boxel-motion/addon/utils/generate-frames.ts
+++ b/packages/boxel-motion/addon/utils/generate-frames.ts
@@ -96,6 +96,12 @@ export default function generateFrames(
       to = sprite.final[dasherize(normalizedProperty)] as Value;
     }
 
+    // TODO: this is naïve as we may be getting from/to defined in
+    //  different manners, but it should catch most things for now.
+    if (from === to) {
+      return [];
+    }
+
     if (
       numberValueType.test(from) ||
       (typeof from === 'string' && from.split(' ').length === 1)
@@ -112,6 +118,7 @@ export default function generateFrames(
       if (!color.test(to)) {
         throw new Error('From is a color, but to is not');
       }
+      // TODO: guard against from/to being different color types of color definitions (RGBA, HSLA etc.)
 
       let fromParts = color.parse(from);
       let toParts = color.parse(to);


### PR DESCRIPTION
This PR contains:
- small early exit for frame generation when from/to are equal so we don't pollute the orchestration matrix with empty rows (this does not change the keyframe output, it just makes it easier to debug the matrix).
- fix WaitBehavior (and clean up StaticBehavior related code), this was not working yet in the intended way apparently.
- don't backfill frames generated by a StaticBehavior, since they're only meant to be set for the duration of the definition.