### PR TITLE
Add high-level support for most transform properties

### DIFF
--- a/packages/boxel-motion/addon/models/transition-runner.ts
+++ b/packages/boxel-motion/addon/models/transition-runner.ts
@@ -17,9 +17,24 @@ function constructKeyframe(
 ) {
   let keyframe: Keyframe = {};
 
+  // This combines the individual transform properties that we support
+  // into a single transform property in the specified order.
   let transformValues: { [k: string]: string[] } = {
+    perspective: [],
     translateX: [],
     translateY: [],
+    translateZ: [],
+    rotate: [],
+    rotateX: [],
+    rotateY: [],
+    rotateZ: [],
+    scale: [],
+    scaleX: [],
+    scaleY: [],
+    scaleZ: [],
+    skew: [],
+    skewX: [],
+    skewY: [],
   };
   let transformTemplate = new Set(Object.keys(transformValues));
   frames.forEach((frame) => {

--- a/packages/boxel-motion/addon/utils/generate-frames.ts
+++ b/packages/boxel-motion/addon/utils/generate-frames.ts
@@ -29,6 +29,7 @@ export function normalizeProperty(property: string): string {
   let propertyMap = new Map([
     ['x', 'translateX'],
     ['y', 'translateY'],
+    ['z', 'translateZ'],
   ]);
   return propertyMap.get(property) ?? property;
 }


### PR DESCRIPTION
Haven't broadly tested these, but in theory this should be enough to support these properties for explicit animation. We don't decompose all of them yet, so `KeptSprite` "magic" animations probably don't work in all cases yet.