### PR TITLE
Add createResponse utility and use it

### DIFF
--- a/packages/host/app/services/loader-service.ts
+++ b/packages/host/app/services/loader-service.ts
@@ -1,7 +1,7 @@
 import Service, { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { Loader } from '@cardstack/runtime-common/loader';
-import { baseRealm } from '@cardstack/runtime-common';
+import { baseRealm, createResponse } from '@cardstack/runtime-common';
 
 export default class LoaderService extends Service {
   @service declare fastboot: { isFastBoot: boolean };
@@ -50,11 +50,10 @@ export default class LoaderService extends Service {
               (!init || !init.method || init.method.toUpperCase() === 'GET')
             ) {
               return Promise.resolve(
-                new Response(cachedJSONAPI, {
+                createResponse(cachedJSONAPI, {
                   status: 200,
                   headers: {
                     'content-type': 'application/vnd.api+json',
-                    vary: 'Accept',
                   },
                 })
               );

--- a/packages/runtime-common/create-response.ts
+++ b/packages/runtime-common/create-response.ts
@@ -1,0 +1,12 @@
+export function createResponse(
+  body?: BodyInit | null | undefined,
+  init?: ResponseInit | undefined
+): Response {
+  return new Response(body, {
+    ...init,
+    headers: {
+      ...init?.headers,
+      vary: "Accept",
+    },
+  });
+}

--- a/packages/runtime-common/error.ts
+++ b/packages/runtime-common/error.ts
@@ -1,4 +1,5 @@
 import { getReasonPhrase } from "http-status-codes";
+import { createResponse } from "./create-response";
 export interface ErrorDetails {
   status?: number;
   title?: string;
@@ -136,11 +137,14 @@ export function serializableError(err: any): any {
 }
 
 export function responseWithError(error: CardError): Response {
-  return new Response(JSON.stringify({ errors: [serializableError(error)] }), {
-    status: error.status,
-    statusText: error.title,
-    headers: { "content-type": "application/vnd.api+json" },
-  });
+  return createResponse(
+    JSON.stringify({ errors: [serializableError(error)] }),
+    {
+      status: error.status,
+      statusText: error.title,
+      headers: { "content-type": "application/vnd.api+json" },
+    }
+  );
 }
 
 export function methodNotAllowed(request: Request): Response {

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -46,6 +46,7 @@ export { RealmPaths };
 export { NotLoaded, isNotLoadedError } from "./not-loaded";
 
 export const executableExtensions = [".js", ".gjs", ".ts", ".gts"];
+export { createResponse } from "./create-response";
 
 // From https://github.com/iliakan/detect-node
 export const isNode =
@@ -84,6 +85,7 @@ export const externalsMap: Map<string, string[]> = new Map([
       "identifyCard",
       "loadCard",
       "humanReadable",
+      "createResponse",
     ],
   ],
   [


### PR DESCRIPTION
This is the surface-level refactor to replace `new Response` with `createResponse` function, which adds the `vary` header. This is to make sure the header always gets added.