### PR TITLE
host: Add trailing slashes for realm server URLs

### DIFF
--- a/.github/actions/deploy-boxel-host/action.yml
+++ b/.github/actions/deploy-boxel-host/action.yml
@@ -30,13 +30,13 @@ runs:
           echo "AWS_ROLE_ARN=arn:aws:iam::120317779495:role/boxel-host" >> $GITHUB_ENV
           echo "AWS_S3_BUCKET=cardstack-boxel-host-production" >> $GITHUB_ENV
           echo "AWS_CLOUDFRONT_DISTRIBUTION=E2DDEHLJXF5LQ8" >> $GITHUB_ENV
-          echo "DEMO_REALM_URL=https://realm-demo.cardstack.com" >> $GITHUB_ENV
+          echo "DEMO_REALM_URL=https://realm-demo.cardstack.com/" >> $GITHUB_ENV
         elif [ "$INPUT_ENVIRONMENT" = "staging" ]; then
           echo "AWS_REGION=us-east-1" >> $GITHUB_ENV
           echo "AWS_ROLE_ARN=arn:aws:iam::680542703984:role/boxel-host" >> $GITHUB_ENV
           echo "AWS_S3_BUCKET=cardstack-boxel-host-staging" >> $GITHUB_ENV
           echo "AWS_CLOUDFRONT_DISTRIBUTION=E35TXLK9HIMESQ" >> $GITHUB_ENV
-          echo "DEMO_REALM_URL=https://realm-demo-staging.stack.cards" >> $GITHUB_ENV
+          echo "DEMO_REALM_URL=https://realm-demo-staging.stack.cards/" >> $GITHUB_ENV
         else
           echo "unrecognized environment"
           exit 1;

--- a/.github/workflows/pr-boxel-host.yml
+++ b/.github/workflows/pr-boxel-host.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Deploy boxel-host preview
         uses: ./.github/actions/deploy-ember-preview
         env:
-          DEMO_REALM_URL: https://realm-demo-staging.stack.cards
+          DEMO_REALM_URL: https://realm-demo-staging.stack.cards/
           S3_PREVIEW_BUCKET_NAME: boxel-host-preview.stack.cards
           AWS_S3_BUCKET: boxel-host-preview.stack.cards
           AWS_REGION: us-east-1
@@ -106,7 +106,7 @@ jobs:
       - name: Deploy boxel-host preview
         uses: ./.github/actions/deploy-ember-preview
         env:
-          DEMO_REALM_URL: https://realm-demo.cardstack.com
+          DEMO_REALM_URL: https://realm-demo.cardstack.com/
           S3_PREVIEW_BUCKET_NAME: boxel-host-preview.cardstack.com
           AWS_S3_BUCKET: boxel-host-preview.cardstack.com
           AWS_REGION: us-east-1


### PR DESCRIPTION
Fixes this error:

<img width="496" alt="RuntimeSpike 2023-01-18 13-55-18" src="https://user-images.githubusercontent.com/43280/213281331-8839ae88-8583-4bcb-b8c0-877366ebed73.png">

This branch is deployed to [staging](https://boxel-host-staging.stack.cards/), which no longer has the error (but is broken for other reasons).