### PR TITLE
fixes issue where we assume that the CardService.defaultURL is not a resolved URL (despite its type)

### DIFF
--- a/packages/host/app/components/directory.gts
+++ b/packages/host/app/components/directory.gts
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import type RouterService from '@ember/routing/router-service';
 import type CardService from '../services/card-service';
+import type LoaderService from '../services/loader-service';
 import { action } from '@ember/object';
 import { on } from '@ember/modifier';
 import { fn } from '@ember/helper';
@@ -51,10 +52,13 @@ export default class Directory extends Component<Args> {
   listing = directory(this, () => this.args.url, () => this.args.openDirs, () => this.args.polling);
   @service declare router: RouterService;
   @service declare cardService: CardService;
+  @service declare loaderService: LoaderService;
 
   @cached
   get realmPath() {
-    return new RealmPaths(this.cardService.defaultURL.href);
+    // this.cardService.defaultURL is a resolved URL. we need to reverse the
+    // resolution in order to compare it to the directory entries.
+    return new RealmPaths(this.loaderService.loader.reverseResolution(this.cardService.defaultURL));
   }
 
   @action

--- a/packages/host/app/resources/directory.ts
+++ b/packages/host/app/resources/directory.ts
@@ -6,7 +6,7 @@ import { restartableTask } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
 import type { Relationship } from '@cardstack/runtime-common';
 import { RealmPaths } from '@cardstack/runtime-common/paths';
-import LoaderService from '../services/loader-service';
+import type LoaderService from '../services/loader-service';
 
 interface Args {
   named: {


### PR DESCRIPTION
The real solution here is to not leak loader resolution outside of the loader. I'll push this quick fix now so it unblocks @backspace . But I have a deeper fix to stop leaking loader resolution in the works as well.