### PR TITLE
Refactor to make Loader.resolve() private

### DIFF
--- a/packages/host/app/components/directory.gts
+++ b/packages/host/app/components/directory.gts
@@ -56,9 +56,7 @@ export default class Directory extends Component<Args> {
 
   @cached
   get realmPath() {
-    // this.cardService.defaultURL is a resolved URL. we need to reverse the
-    // resolution in order to compare it to the directory entries.
-    return new RealmPaths(this.loaderService.loader.reverseResolution(this.cardService.defaultURL));
+    return new RealmPaths(this.cardService.defaultURL);
   }
 
   @action

--- a/packages/host/app/resources/directory.ts
+++ b/packages/host/app/resources/directory.ts
@@ -35,9 +35,7 @@ export class DirectoryResource extends Resource<Args> {
       if (!named.url.endsWith('/')) {
         throw new Error(`A directory URL must end with a "/"`);
       }
-      this.realmPath = new RealmPaths(
-        this.loaderService.loader.reverseResolution(named.url)
-      );
+      this.realmPath = new RealmPaths(named.url);
       this.url = named.url;
       taskFor(this.readdir).perform();
     }

--- a/packages/host/app/routes/index.ts
+++ b/packages/host/app/routes/index.ts
@@ -70,10 +70,15 @@ export default class Index extends Route<Model> {
       );
       return { path, openFile, polling, openDirs, isFastBoot };
     }
-    if (response.url !== url) {
+    // The server may have responded with a redirect which we need to pay
+    // attention to. As part of responding to us, the server will hand us a
+    // resolved URL in response.url. We need to reverse that resolution in order
+    // to see if we have been given a redirect.
+    let responseURL = this.loaderService.loader.reverseResolution(response.url);
+    if (responseURL.href !== url) {
       this.router.transitionTo('application', {
         queryParams: {
-          path: realmPath.local(new URL(response.url)),
+          path: realmPath.local(responseURL),
           polling,
           openDirs,
         },

--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -9,7 +9,6 @@ import {
   type CardDocument,
   type LooseSingleCardDocument,
 } from '@cardstack/runtime-common';
-import type { ResolvedURL } from '@cardstack/runtime-common/loader';
 import type { Query } from '@cardstack/runtime-common/query';
 import { importResource } from '../resources/import';
 import type { Card } from 'https://cardstack.com/base/card-api';
@@ -45,10 +44,10 @@ export default class CardService extends Service {
     return this.apiModule.module as typeof CardAPI;
   }
 
-  get defaultURL(): ResolvedURL {
-    return this.loaderService.loader.resolve(
-      demoRealmURL ?? this.localRealm.url
-    );
+  // Note that this should be the unresolved URL and that we need to rely on our
+  // fetch to do any URL resolution.
+  get defaultURL(): URL {
+    return demoRealmURL ? new URL(demoRealmURL) : this.localRealm.url;
   }
 
   private async fetchJSON(
@@ -125,7 +124,7 @@ export default class CardService extends Service {
     return await this.createFromSerialized(json.data, json);
   }
 
-  async search(query: Query, realmURL: ResolvedURL): Promise<Card[]> {
+  async search(query: Query, realmURL: URL): Promise<Card[]> {
     let json = await this.fetchJSON(`${realmURL}_search?${stringify(query)}`);
     if (!isCardCollectionDocument(json)) {
       throw new Error(

--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -24,6 +24,7 @@ module.exports = function (environment) {
     'ember-cli-mirage': {
       enabled: false,
     },
+    // This should be provided as an *unresolved* URL
     demoRealmURL: process.env.DEMO_REALM_URL,
   };
 

--- a/packages/runtime-common/paths.ts
+++ b/packages/runtime-common/paths.ts
@@ -17,7 +17,10 @@ export class RealmPaths {
     // this.#realm has a trailing slash.
     let local = url.href.slice(this.url.length);
 
+    // this will remove any trailing slashes
     local = local.replace(/\/+$/, "");
+
+    // the LocalPath has no leading nor trailing slashes
     return local;
   }
 


### PR DESCRIPTION
also fix issues resolving directories (vs module identifiers), which is probably why the Loader.resolve() started getting used outside of the loader module. This PR allows the host to serve the base realm and fixes the issues around listing the base realm subdirectory contents.