### PR TITLE
Support for relative linksTo and card-refs and ability to update card instance via monaco

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -42,6 +42,7 @@ export const useIndexBasedKey = Symbol('cardstack-use-index-based-key');
 export const fieldDecorator = Symbol('cardstack-field-decorator');
 export const fieldType = Symbol('cardstack-field-type');
 export const queryableValue = Symbol('cardstack-queryable-value');
+export const relativeTo = Symbol('cardstack-relative-to');
 // intentionally not exporting this so that the outside world
 // cannot mark a card as being saved
 const isSavedInstance = Symbol('cardstack-is-saved-instance');
@@ -183,7 +184,8 @@ export interface Field<CardT extends CardConstructor> {
     relationships: JSONAPIResource["relationships"] | undefined,
     fieldMeta: CardFields[string] | undefined,
     identityContext: IdentityContext | undefined,
-    instancePromise: Promise<Card>
+    instancePromise: Promise<Card>,
+    relativeTo: URL | undefined
   ): Promise<any>;
   emptyValue(instance: Card): any;
   validate(instance: Card, value: any): void;
@@ -315,7 +317,8 @@ class ContainsMany<FieldT extends CardConstructor> implements Field<FieldT> {
     relationships: JSONAPIResource["relationships"] | undefined,
     fieldMeta: CardFields[string] | undefined,
     _identityContext: undefined,
-    instancePromise: Promise<Card>
+    instancePromise: Promise<Card>,
+    relativeTo: URL | undefined
   ): Promise<CardInstanceType<FieldT>[]> {
     if (!Array.isArray(value)) {
       throw new Error(`Expected array for field value ${this.name}`);
@@ -328,7 +331,7 @@ class ContainsMany<FieldT extends CardConstructor> implements Field<FieldT> {
       () => instancePromise.then(instance => logger.log(recompute(instance))),
       await Promise.all(value.map(async (entry, index) => {
         if (primitive in this.card) {
-          return this.card[deserialize](entry, doc);
+          return this.card[deserialize](entry, relativeTo, doc);
         } else {
           let meta = metas[index];
           let resource: LooseCardResource = {
@@ -345,7 +348,7 @@ class ContainsMany<FieldT extends CardConstructor> implements Field<FieldT> {
                 })
               );
           }
-          return (await cardClassFromResource(resource, this.card))[deserialize](resource, doc);
+          return (await cardClassFromResource(resource, this.card, relativeTo))[deserialize](resource, relativeTo, doc);
         }
       }))
     );
@@ -431,10 +434,13 @@ class Contains<CardT extends CardConstructor> implements Field<CardT> {
     value: any,
     doc: CardDocument,
     relationships: JSONAPIResource["relationships"] | undefined,
-    fieldMeta: CardFields[string] | undefined
+    fieldMeta: CardFields[string] | undefined,
+    _identityContext: undefined,
+    _instancePromise: Promise<Card>,
+    relativeTo: URL | undefined
   ): Promise<CardInstanceType<CardT>> {
     if (primitive in this.card) {
-      return this.card[deserialize](value, doc);
+      return this.card[deserialize](value, relativeTo, doc);
     }
     if (fieldMeta && Array.isArray(fieldMeta)) {
       throw new Error(`fieldMeta for contains field '${this.name}' is an array: ${JSON.stringify(fieldMeta, null, 2)}`);
@@ -453,7 +459,7 @@ class Contains<CardT extends CardConstructor> implements Field<CardT> {
           )
         );
     }
-    return (await cardClassFromResource(resource, this.card))[deserialize](resource, doc);
+    return (await cardClassFromResource(resource, this.card, relativeTo))[deserialize](resource, relativeTo, doc);
   }
 
   emptyValue(_instance: Card) {
@@ -566,7 +572,9 @@ class LinksTo<CardT extends CardConstructor> implements Field<CardT> {
     doc: CardDocument,
     _relationships: undefined,
     _fieldMeta: undefined,
-    identityContext: IdentityContext
+    identityContext: IdentityContext,
+    _instancePromise: Promise<Card>,
+    relativeTo: URL | undefined
   ): Promise<CardInstanceType<CardT> | null | NotLoadedValue> {
     if (!isRelationship(value)) {
       throw new Error(`linkTo field '${this.name}' cannot deserialize non-relationship value ${JSON.stringify(value)}`);
@@ -585,7 +593,7 @@ class LinksTo<CardT extends CardConstructor> implements Field<CardT> {
         reference: value.links.self
       };
     }
-    return (await cardClassFromResource(resource, this.card))[deserialize](resource, doc, identityContext);
+    return (await cardClassFromResource(resource, this.card, relativeTo))[deserialize](resource, relativeTo, doc, identityContext);
   }
 
   emptyValue(_instance: Card) {
@@ -669,6 +677,7 @@ export class Card {
   // typescript considers everything a valid card.
   [isBaseCard] = true;
   [isSavedInstance] = false;
+  [relativeTo]: URL | undefined = undefined;
   declare ["constructor"]: CardConstructor;
   static baseCard: undefined; // like isBaseCard, but for the class itself
   static data?: Record<string, any>;
@@ -712,12 +721,18 @@ export class Card {
     }
   }
 
-  static async [deserialize]<T extends CardConstructor>(this: T, data: any, doc?: CardDocument, identityContext?: IdentityContext): Promise<CardInstanceType<T>> {
+  static async [deserialize]<T extends CardConstructor>(
+    this: T,
+    data: any,
+    relativeTo: URL | undefined,
+    doc?: CardDocument,
+    identityContext?: IdentityContext
+  ): Promise<CardInstanceType<T>> {
     if (primitive in this) {
       // primitive cards can override this as need be
       return data;
     }
-    return _createFromSerialized(this, data, doc, identityContext);
+    return _createFromSerialized(this, data, doc,  relativeTo, identityContext);
   }
 
   static getComponent(card: Card, format: Format, opts?: ComponentOptions) {
@@ -869,6 +884,7 @@ async function getDeserializedValue<CardT extends CardConstructor>({
   modelPromise,
   doc,
   identityContext,
+  relativeTo
 }: {
   card: CardT;
   fieldName: string;
@@ -877,12 +893,13 @@ async function getDeserializedValue<CardT extends CardConstructor>({
   modelPromise: Promise<Card>;
   doc: LooseSingleCardDocument | CardDocument;
   identityContext: IdentityContext;
+  relativeTo: URL | undefined;
 }): Promise<any> {
   let field = getField(card, fieldName);
   if (!field) {
     throw new Error(`could not find field ${fieldName} in card ${card.name}`);
   }
-  let result = await field.deserialize(value, doc, resource.relationships, resource.meta.fields?.[fieldName], identityContext, modelPromise);
+  let result = await field.deserialize(value, doc, resource.relationships, resource.meta.fields?.[fieldName], identityContext, modelPromise, relativeTo);
   return result;
 }
 
@@ -940,7 +957,7 @@ export async function createFromSerialized<T extends CardConstructor>(
   if (!card) {
     throw new Error(`could not find card: '${humanReadable(adoptsFrom)}'`);
   }
-  return await _createFromSerialized(card as T, resource as any, doc, identityContext);
+  return await _createFromSerialized(card as T, resource as any, doc, relativeTo, identityContext);
 }
 
 export async function updateFromSerialized<T extends CardConstructor>(
@@ -955,10 +972,11 @@ async function _createFromSerialized<T extends CardConstructor>(
   card: T,
   data: T extends { [primitive]: infer P } ? P : LooseCardResource,
   doc: LooseSingleCardDocument | CardDocument | undefined,
+  _relativeTo: URL | undefined,
   identityContext: IdentityContext = new IdentityContext(),
 ): Promise<CardInstanceType<T>> {
   if (primitive in card) {
-    return card[deserialize](data);
+    return card[deserialize](data, _relativeTo);
   }
   let resource: LooseCardResource | undefined;
   if (isCardResource(data)) {
@@ -981,6 +999,7 @@ async function _createFromSerialized<T extends CardConstructor>(
   }
   if (!instance) {
     instance = new card({id: resource.id }) as CardInstanceType<T>;
+    instance[relativeTo] = _relativeTo;
   }
   identityContexts.set(instance, identityContext);
   return await _updateFromSerialized(instance, resource, doc, identityContext);
@@ -1022,6 +1041,7 @@ async function _updateFromSerialized<T extends CardConstructor>(
             modelPromise: deferred.promise,
             doc,
             identityContext,
+            relativeTo: instance[relativeTo]
           })
         ];
       }
@@ -1069,14 +1089,14 @@ function makeMetaForField(meta: Partial<Meta> | undefined, fieldName: string, fa
   };
 }
 
-async function cardClassFromResource<CardT extends CardConstructor>(resource: LooseCardResource | undefined, fallback: CardT): Promise<CardT> {
+async function cardClassFromResource<CardT extends CardConstructor>(resource: LooseCardResource | undefined, fallback: CardT, relativeTo: URL | undefined): Promise<CardT> {
   let cardIdentity = identifyCard(fallback);
   if (!cardIdentity) {
     throw new Error(`bug: could not determine identity for card '${fallback.name}'`);
   }
   if (resource && !isEqual(resource.meta.adoptsFrom, cardIdentity)) {
     let loader = Loader.getLoaderFor(fallback);
-    let card: typeof Card | undefined = await loadCard(resource.meta.adoptsFrom, { loader });
+    let card: typeof Card | undefined = await loadCard(resource.meta.adoptsFrom, { loader, relativeTo });
     if (!card) {
       throw new Error(`could not find card: '${humanReadable(resource.meta.adoptsFrom)}'`);
     }
@@ -1222,7 +1242,7 @@ async function getIfReady<T extends Card, K extends keyof T>(
         if (!field) {
           throw new Error(`the field '${fieldName as string} does not exist in card ${card.name}'`);
         }
-        let fieldValue = await loadMissingField(card, field, e, identityContext);
+        let fieldValue = await loadMissingField(card, field, e, identityContext, instance[relativeTo]);
         deserialized.set(fieldName as string, fieldValue);
         result = fieldValue as T[K];
       }
@@ -1246,11 +1266,13 @@ async function loadMissingField(
   field: Field<typeof Card>,
   notLoaded: NotLoadedValue | NotLoaded,
   identityContext: IdentityContext,
+  relativeTo: URL | undefined
 ): Promise<Card> {
   if (field.fieldType !== "linksTo") {
     throw new Error(`cannot load missing field for non-linksTo field ${card.name}.${field.name}`);
   }
-  let { reference } = notLoaded;
+  let { reference: maybeRelativeReference } = notLoaded;
+  let reference = new URL(maybeRelativeReference, relativeTo).href;
   let loader = Loader.getLoaderFor(createFromSerialized);
   let response = await loader.fetch(reference, { headers: { 'Accept': 'application/vnd.api+json' } });
   if (!response.ok) {

--- a/packages/base/catalog-entry.gts
+++ b/packages/base/catalog-entry.gts
@@ -1,4 +1,4 @@
-import { contains, field, Component, Card, primitive } from './card-api';
+import { contains, field, Component, Card, primitive, relativeTo } from './card-api';
 import StringCard from './string';
 import BooleanCard from './boolean';
 import CardRefCard from './card-ref';
@@ -21,7 +21,7 @@ export class CatalogEntry extends Card {
   @field description = contains(StringCard);
   @field ref = contains(CardRefCard);
   @field isPrimitive = contains(BooleanCard, { computeVia: async function(this: CatalogEntry) {
-    let card: typeof Card | undefined = await loadCard(this.ref);
+    let card: typeof Card | undefined = await loadCard(this.ref, { relativeTo: this[relativeTo]});
     if (!card) {
       throw new Error(`Could not load card '${this.ref.name}'`);
     }

--- a/packages/demo-cards/CatalogEntry/1.json
+++ b/packages/demo-cards/CatalogEntry/1.json
@@ -5,7 +5,7 @@
       "title": "Person",
       "description": "Catalog entry for Person card",
       "ref": {
-        "module": "http://local-realm/person",
+        "module": "/person",
         "name": "Person"
       },
       "demo": {

--- a/packages/demo-cards/CatalogEntry/1.json
+++ b/packages/demo-cards/CatalogEntry/1.json
@@ -18,7 +18,7 @@
     "relationships": {
       "demo.pet": {
         "links": {
-          "self": "http://local-realm/Pet/1"
+          "self": "/Pet/1"
         }
       }
     },
@@ -26,7 +26,7 @@
       "fields": {
         "demo": {
           "adoptsFrom": {
-            "module": "http://local-realm/person",
+            "module": "/person",
             "name": "Person"
           }
         }

--- a/packages/demo-cards/CatalogEntry/2.json
+++ b/packages/demo-cards/CatalogEntry/2.json
@@ -4,7 +4,7 @@
       "title": "Pet",
       "description": "Catalog entry for Pet card",
       "ref": {
-        "module": "http://local-realm/pet",
+        "module": "/pet",
         "name": "Pet"
       },
       "demo": {
@@ -20,7 +20,7 @@
       "fields": {
         "demo": {
           "adoptsFrom": {
-            "module": "http://local-realm/pet",
+            "module": "/pet",
             "name": "Pet"
           }
         }

--- a/packages/demo-cards/CatalogEntry/3.json
+++ b/packages/demo-cards/CatalogEntry/3.json
@@ -2,10 +2,10 @@
   "data": {
     "type": "card",
     "attributes": {
-      "title": "Chain from http://local-realm/chain",
-      "description": "Catalog entry for Chain from http://local-realm/chain",
+      "title": "Chain from /chain",
+      "description": "Catalog entry for Chain from /chain",
       "ref": {
-        "module": "http://local-realm/chain",
+        "module": "/chain",
         "name": "Chain"
       },
       "demo": {
@@ -16,7 +16,7 @@
       "fields": {
         "demo": {
           "adoptsFrom": {
-            "module": "http://local-realm/chain",
+            "module": "/chain",
             "name": "Chain"
           }
         }

--- a/packages/demo-cards/CatalogEntry/4.json
+++ b/packages/demo-cards/CatalogEntry/4.json
@@ -2,24 +2,24 @@
   "data": {
     "type": "card",
     "attributes": {
-      "title": "Token from http://local-realm/asset",
-      "description": "Catalog entry for Token from http://local-realm/asset",
+      "title": "Token from /asset",
+      "description": "Catalog entry for Token from /asset",
       "ref": {
-        "module": "http://local-realm/asset",
+        "module": "/asset",
         "name": "Token"
       },
       "demo": {
         "address": "eth:0x514910771af9ca656af840dff83e8264ecf986ca",
         "name": "ChainLink Token",
         "symbol": "LINK",
-        "logoURL": "http://local-realm/invoice-assets/currency-link.png"
+        "logoURL": "/invoice-assets/currency-link.png"
       }
     },
     "meta": {
       "fields": {
         "demo": {
           "adoptsFrom": {
-            "module": "http://local-realm/asset",
+            "module": "/asset",
             "name": "Token"
           }
         }

--- a/packages/demo-cards/CatalogEntry/5.json
+++ b/packages/demo-cards/CatalogEntry/5.json
@@ -2,10 +2,10 @@
   "data": {
     "type": "card",
     "attributes": {
-      "title": "InvoicePacket from http://local-realm/invoice-packet",
-      "description": "Catalog entry for InvoicePacket from http://local-realm/invoice-packet",
+      "title": "InvoicePacket from /invoice-packet",
+      "description": "Catalog entry for InvoicePacket from /invoice-packet",
       "ref": {
-        "module": "http://local-realm/invoice-packet",
+        "module": "/invoice-packet",
         "name": "InvoicePacket"
       },
       "demo": {
@@ -32,7 +32,7 @@
       "fields": {
         "demo": {
           "adoptsFrom": {
-            "module": "http://local-realm/invoice-packet",
+            "module": "/invoice-packet",
             "name": "InvoicePacket"
           }
         }

--- a/packages/demo-cards/CatalogEntry/6.json
+++ b/packages/demo-cards/CatalogEntry/6.json
@@ -2,10 +2,10 @@
   "data": {
     "type": "card",
     "attributes": {
-      "title": "Friend from http://local-realm/friend",
-      "description": "Catalog entry for Friend from http://local-realm/friend",
+      "title": "Friend from /friend",
+      "description": "Catalog entry for Friend from /friend",
       "ref": {
-        "module": "http://local-realm/friend",
+        "module": "/friend",
         "name": "Friend"
       },
       "demo": {
@@ -23,7 +23,7 @@
       "fields": {
         "demo": {
           "adoptsFrom": {
-            "module": "http://local-realm/friend",
+            "module": "/friend",
             "name": "Friend"
           }
         }

--- a/packages/demo-cards/Chain/1.json
+++ b/packages/demo-cards/Chain/1.json
@@ -6,7 +6,7 @@
     },
     "meta": {
       "adoptsFrom": {
-        "module": "http://local-realm/chain",
+        "module": "/chain",
         "name": "Chain"
       }
     }

--- a/packages/demo-cards/Chain/2.json
+++ b/packages/demo-cards/Chain/2.json
@@ -6,7 +6,7 @@
     },
     "meta": {
       "adoptsFrom": {
-        "module": "http://local-realm/chain",
+        "module": "/chain",
         "name": "Chain"
       }
     }

--- a/packages/demo-cards/Chain/3.json
+++ b/packages/demo-cards/Chain/3.json
@@ -6,7 +6,7 @@
     },
     "meta": {
       "adoptsFrom": {
-        "module": "http://local-realm/chain",
+        "module": "/chain",
         "name": "Chain"
       }
     }

--- a/packages/demo-cards/Currency/1.json
+++ b/packages/demo-cards/Currency/1.json
@@ -5,11 +5,11 @@
       "sign": "$",
       "name": "U.S. Dollar",
       "symbol": "USD",
-      "logoURL": "http://local-realm/invoice-assets/currency-usd.png"
+      "logoURL": "/invoice-assets/currency-usd.png"
     },
     "meta": {
       "adoptsFrom": {
-        "module": "http://local-realm/asset",
+        "module": "/asset",
         "name": "Currency"
       }
     }

--- a/packages/demo-cards/Friend/1.json
+++ b/packages/demo-cards/Friend/1.json
@@ -7,13 +7,13 @@
     "relationships": {
       "friend": {
         "links": {
-          "self": "http://local-realm/Friend/2"
+          "self": "/Friend/2"
         }
       }
     },
     "meta": {
       "adoptsFrom": {
-        "module": "http://local-realm/friend",
+        "module": "/friend",
         "name": "Friend"
       }
     }

--- a/packages/demo-cards/Friend/2.json
+++ b/packages/demo-cards/Friend/2.json
@@ -13,7 +13,7 @@
     },
     "meta": {
       "adoptsFrom": {
-        "module": "http://local-realm/friend",
+        "module": "/friend",
         "name": "Friend"
       }
     }

--- a/packages/demo-cards/InvoicePacket/1.json
+++ b/packages/demo-cards/InvoicePacket/1.json
@@ -4,7 +4,7 @@
     "relationships": {
       "vendor": {
         "links": {
-          "self": "http://local-realm/Vendor/1"
+          "self": "/Vendor/1"
         }
       }
     },
@@ -48,7 +48,7 @@
     },
     "meta": {
       "adoptsFrom": {
-        "module": "http://local-realm/invoice-packet",
+        "module": "/invoice-packet",
         "name": "InvoicePacket"
       }
     }

--- a/packages/demo-cards/Person/1.json
+++ b/packages/demo-cards/Person/1.json
@@ -10,13 +10,13 @@
     "relationships": {
       "pet": {
         "links": {
-          "self": "http://local-realm/Pet/2"
+          "self": "/Pet/2"
         }
       }
     },
     "meta": {
       "adoptsFrom": {
-        "module": "http://local-realm/person",
+        "module": "/person",
         "name": "Person"
       }
     }

--- a/packages/demo-cards/Pet/1.json
+++ b/packages/demo-cards/Pet/1.json
@@ -1,16 +1,18 @@
 {
   "data": {
+    "type": "card",
     "attributes": {
       "firstName": "Peachy",
       "favoriteToy": "ball of yarn",
-      "sleepsOnTheCouch": false
+      "favoriteTreat": null,
+      "cutenessRating": null,
+      "sleepsOnTheCouch": true
     },
     "meta": {
       "adoptsFrom": {
-        "module": "/pet",
+        "module": "http://local-realm/pet",
         "name": "Pet"
       }
-    },
-    "type": "card"
+    }
   }
 }

--- a/packages/demo-cards/Pet/1.json
+++ b/packages/demo-cards/Pet/1.json
@@ -7,7 +7,7 @@
     },
     "meta": {
       "adoptsFrom": {
-        "module": "http://local-realm/pet",
+        "module": "/pet",
         "name": "Pet"
       }
     },

--- a/packages/demo-cards/Pet/2.json
+++ b/packages/demo-cards/Pet/2.json
@@ -10,7 +10,7 @@
     },
     "meta": {
       "adoptsFrom": {
-        "module": "http://local-realm/pet",
+        "module": "/pet",
         "name": "Pet"
       }
     }

--- a/packages/demo-cards/Pet/3.json
+++ b/packages/demo-cards/Pet/3.json
@@ -10,7 +10,7 @@
     },
     "meta": {
       "adoptsFrom": {
-        "module": "http://local-realm/pet",
+        "module": "/pet",
         "name": "Pet"
       }
     }

--- a/packages/demo-cards/Post/1.json
+++ b/packages/demo-cards/Post/1.json
@@ -13,7 +13,7 @@
     },
     "meta": {
       "adoptsFrom": {
-        "module": "http://local-realm/post.gts",
+        "module": "/post.gts",
         "name": "Post"
       }
     }

--- a/packages/demo-cards/Post/2.json
+++ b/packages/demo-cards/Post/2.json
@@ -12,13 +12,13 @@
     },
     "meta": {
       "adoptsFrom": {
-        "module": "http://local-realm/post",
+        "module": "/post",
         "name": "Post"
       },
       "fields": {
         "author": {
           "adoptsFrom": {
-            "module": "http://local-realm/employee",
+            "module": "/employee",
             "name": "Employee"
           }
         }

--- a/packages/demo-cards/Token/1.json
+++ b/packages/demo-cards/Token/1.json
@@ -5,11 +5,11 @@
       "address": "eth:0x514910771af9ca656af840dff83e8264ecf986ca",
       "name": "ChainLink Token",
       "symbol": "LINK",
-      "logoURL": "http://local-realm/invoice-assets/currency-link.png"
+      "logoURL": "/invoice-assets/currency-link.png"
     },
     "meta": {
       "adoptsFrom": {
-        "module": "http://local-realm/asset",
+        "module": "/asset",
         "name": "Token"
       }
     }

--- a/packages/demo-cards/Token/2.json
+++ b/packages/demo-cards/Token/2.json
@@ -5,11 +5,11 @@
       "address": "eth:0x6b175474e89094c44da98b954eedeac495271d0f",
       "name": "Dai Stablecoin",
       "symbol": "DAI",
-      "logoURL": "http://local-realm/invoice-assets/currency-dai.png"
+      "logoURL": "/invoice-assets/currency-dai.png"
     },
     "meta": {
       "adoptsFrom": {
-        "module": "http://local-realm/asset",
+        "module": "/asset",
         "name": "Token"
       }
     }

--- a/packages/demo-cards/Token/3.json
+++ b/packages/demo-cards/Token/3.json
@@ -5,11 +5,11 @@
       "address": "matic:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
       "name": "USD Coin",
       "symbol": "USDC",
-      "logoURL": "http://local-realm/invoice-assets/currency-usdc.png"
+      "logoURL": "/invoice-assets/currency-usdc.png"
     },
     "meta": {
       "adoptsFrom": {
-        "module": "http://local-realm/asset",
+        "module": "/asset",
         "name": "Token"
       }
     }

--- a/packages/demo-cards/Vendor/1.json
+++ b/packages/demo-cards/Vendor/1.json
@@ -5,7 +5,7 @@
       "vendor": {
         "name": "Smart Contract",
         "description": "SmartContract is the leading provider of secure and reliable open-source oracle solutions, enabling smart contracts to access anything outside their native blockchain, such off-chain data feeds, web APIs, and traditional bank payments. We are dedicated to the development and integration of Chainlink as the standard decentralized oracle framework used by smart contracts across numerous blockchains. We empower the Chainlink community and build world-class Chainlink-based solutions for large enterprises such as Google and Oracle, as well as leading smart contract development teams such as Synthetix, Loopring, Aave, OpenLaw, Conflux, Polkadot and many more.",
-        "logoURL": "http://local-realm/invoice-assets/vendor-logo-smart-contract.png",
+        "logoURL": "/invoice-assets/vendor-logo-smart-contract.png",
         "email": "finance@smartcontract.com",
         "cardXYZ": "smartcontractinc"
       },
@@ -83,12 +83,12 @@
     "relationships": {
       "preferredPaymentMethod.cryptoPayment.chain": {
         "links": {
-          "self": "http://local-realm/Chain/1"
+          "self": "/Chain/1"
         }
       },
       "preferredPaymentMethod.cryptoPayment.token": {
         "links": {
-          "self": "http://local-realm/Token/1"
+          "self": "/Token/1"
         }
       },
       "preferredPaymentMethod.wireTransfer.currency": {
@@ -108,17 +108,17 @@
       },
       "alternatePaymentMethod.0.wireTransfer.currency": {
         "links": {
-          "self": "http://local-realm/Currency/1"
+          "self": "/Currency/1"
         }
       },
       "alternatePaymentMethod.1.cryptoPayment.chain": {
         "links": {
-          "self": "http://local-realm/Chain/1"
+          "self": "/Chain/1"
         }
       },
       "alternatePaymentMethod.1.cryptoPayment.token": {
         "links": {
-          "self": "http://local-realm/Token/2"
+          "self": "/Token/2"
         }
       },
       "alternatePaymentMethod.1.wireTransfer.currency": {
@@ -128,12 +128,12 @@
       },
       "alternatePaymentMethod.2.cryptoPayment.chain": {
         "links": {
-          "self": "http://local-realm/Chain/2"
+          "self": "/Chain/2"
         }
       },
       "alternatePaymentMethod.2.cryptoPayment.token": {
         "links": {
-          "self": "http://local-realm/Token/3"
+          "self": "/Token/3"
         }
       },
       "alternatePaymentMethod.2.wireTransfer.currency": {
@@ -144,7 +144,7 @@
     },
     "meta": {
       "adoptsFrom": {
-        "module": "http://local-realm/vendor",
+        "module": "/vendor",
         "name": "Vendor"
       }
     }

--- a/packages/demo-cards/Vendor/2.json
+++ b/packages/demo-cards/Vendor/2.json
@@ -5,7 +5,7 @@
       "vendor": {
         "name": "Best Bakery",
         "description": null,
-        "logoURL": "http://local-realm/invoice-assets/vendor-logo-best-bakery.png",
+        "logoURL": "/invoice-assets/vendor-logo-best-bakery.png",
         "email": "contact@bestbakery.com",
         "cardXYZ": null
       },
@@ -31,7 +31,7 @@
     },
     "meta": {
       "adoptsFrom": {
-        "module": "http://local-realm/vendor",
+        "module": "/vendor",
         "name": "Vendor"
       }
     }

--- a/packages/demo-cards/asset.gts
+++ b/packages/demo-cards/asset.gts
@@ -34,6 +34,11 @@ class Asset extends Card {
     <template>
       <CardContainer {{attachStyles styles}}>
         {{#if @model.logoURL}}
+          {{!-- 
+            TODO: we need a better solution for images--this approach relies 
+            on absolute URL's and just doesn't work in a multi-environment system,
+            i.e. there is no value you can put here that will work in dev and staging 
+          --}}
           <img src={{@model.logoURL}} width="20" height="20"/>
         {{/if}}
         <div class="payment-method__currency"><@fields.symbol/></div>

--- a/packages/demo-cards/invoice-packet.gts
+++ b/packages/demo-cards/invoice-packet.gts
@@ -268,6 +268,11 @@ class InvoiceTemplate extends Component<typeof InvoicePacket> {
                 <FieldContainer @label="Alternate Payment Methods" @vertical={{true}}>
                   <div>
                     {{#each @model.alternatePayment as |payment|}}
+                      {{!-- 
+                        TODO: we need a better solution for images--this approach relies 
+                        on absolute URL's and just doesn't work in a multi-environment system,
+                        i.e. there is no value you can put here that will work in dev and staging 
+                      --}}
                       <div class="payment-method__item">{{#if payment.logoURL}}<img src={{payment.logoURL}}>{{/if}} {{payment.symbol}}</div>
                       <div class="payment-methods__bal">{{balanceInCurrency @model.balanceDue payment}}</div>
                     {{/each}}

--- a/packages/demo-cards/vendor.gts
+++ b/packages/demo-cards/vendor.gts
@@ -98,6 +98,11 @@ export class Vendor extends Card {
           <@fields.mailingAddress/>
           <@fields.vendor.email/>
         </div>
+        {{!-- 
+          TODO: we need a better solution for images--this approach relies 
+          on absolute URL's and just doesn't work in a multi-environment system,
+          i.e. there is no value you can put here that will work in dev and staging 
+        --}}
         <img src={{@model.vendor.logoURL}} />
       </CardContainer>
     </template>

--- a/packages/host/app/components/catalog-entry-editor.gts
+++ b/packages/host/app/components/catalog-entry-editor.gts
@@ -88,7 +88,7 @@ export default class CatalogEntryEditor extends Component<Signature> {
         }
       }
     };
-    this.newEntry = await this.cardService.createFromSerialized(resource, { data: resource });
+    this.newEntry = await this.cardService.createFromSerialized(resource, { data: resource }, this.cardService.defaultURL);
   }
 
   @action

--- a/packages/host/app/components/create-card-modal.gts
+++ b/packages/host/app/components/create-card-modal.gts
@@ -68,7 +68,7 @@ export default class CreateCardModal extends Component {
   @enqueueTask private async _create<T extends Card>(ref: CardRef): Promise<undefined | T> {
     let doc = { data: { meta: { adoptsFrom: ref }}};
     this.currentRequest = {
-      card: await this.cardService.createFromSerialized(doc.data, doc),
+      card: await this.cardService.createFromSerialized(doc.data, doc, this.cardService.defaultURL),
       deferred: new Deferred(),
     };
     let card = await this.currentRequest.deferred.promise;

--- a/packages/host/app/services/render-service.ts
+++ b/packages/host/app/services/render-service.ts
@@ -28,7 +28,7 @@ export default class RenderService extends Service {
   ): Promise<string> {
     this.renderError = undefined;
     this.loaderService.setStaticResponses(staticResponses);
-    let card = await this.cardService.loadModel(url, { absoluteURL: true });
+    let card = await this.cardService.loadModel(url);
     if (!card) {
       throw new Error(`card ${url.href} not found`);
     }


### PR DESCRIPTION
This PR includes a fix to support relative linksTo and card-ref URL's such that our demo content can work in both local dev and in hosted staging. Note that we don't have a real solution for images. the current image approach requires aboslute URL's so there isn't a way to make our images appear in both local and in staging. Future work will occur to make binary data first class citizens in the framework.

For the relative support, we were always requiring a `relativeTo` param for deserializing cards which we used to resolve the card's module URL, but then throw away. This update actually preserves the `relativeTo` param that we provide during deserialization in a new symbol within the card instance. the linksTo field deserializer can now utilize this value, as well as any consumers of card-ref fields (like catalog-entry cards).

This PR also includes support to be able to edit the card instance json in the monaco editor (which until now was only able to edit source files).