### PR TITLE
realm: Reduce size of Docker image

### DIFF
--- a/.github/actions/deploy-realm-server/action.yml
+++ b/.github/actions/deploy-realm-server/action.yml
@@ -39,14 +39,6 @@ runs:
     - uses: pnpm/action-setup@v2
       with:
         version: ${{ inputs.pnpm_version }}
-
-    - name: Remove unused packages
-      shell: bash
-      run: |
-        rm -rf packages/boxel-motion
-        rm -rf packages/boxel-motion-demo-app
-        rm -rf packages/boxel-motion-test-app
-
     - uses: actions/setup-node@v3
       with:
         node-version: ${{ inputs.node_version }}

--- a/.github/actions/deploy-realm-server/action.yml
+++ b/.github/actions/deploy-realm-server/action.yml
@@ -39,6 +39,14 @@ runs:
     - uses: pnpm/action-setup@v2
       with:
         version: ${{ inputs.pnpm_version }}
+
+    - name: Remove unused packages
+      shell: bash
+      run: |
+        rm -rf packages/boxel-motion
+        rm -rf packages/boxel-motion-demo-app
+        rm -rf packages/boxel-motion-test-app
+
     - uses: actions/setup-node@v3
       with:
         node-version: ${{ inputs.node_version }}

--- a/packages/realm-server/Dockerfile
+++ b/packages/realm-server/Dockerfile
@@ -6,7 +6,7 @@ ENV realm_server_script=$realm_server_script
 
 WORKDIR /realm-server
 
-RUN curl -f https://get.pnpm.io/v6.16.js | node - add --global pnpm
+RUN wget -qO /bin/pnpm "https://github.com/pnpm/pnpm/releases/latest/download/pnpm-linuxstatic-x64" && chmod +x /bin/pnpm
 
 COPY pnpm-lock.yaml ./
 

--- a/packages/realm-server/Dockerfile
+++ b/packages/realm-server/Dockerfile
@@ -17,7 +17,7 @@ COPY vendor/ ./vendor
 ADD . ./
 
 RUN pnpm fetch
-RUN pnpm install -r --prefer-offline
+RUN pnpm install -r --offline
 
 EXPOSE 3000
 

--- a/packages/realm-server/Dockerfile
+++ b/packages/realm-server/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM node:18
+FROM node:18-alpine
 ARG realm_server_script
 ENV realm_server_script=$realm_server_script
 

--- a/packages/realm-server/Dockerfile
+++ b/packages/realm-server/Dockerfile
@@ -7,7 +7,7 @@ ENV realm_server_script=$realm_server_script
 WORKDIR /realm-server
 
 # Required for pnpm to install Node on Alpine
-RUN apk install build-base libc6-compat gcompat
+RUN apk add build-base libc6-compat gcompat
 RUN wget -qO /bin/pnpm "https://github.com/pnpm/pnpm/releases/latest/download/pnpm-linuxstatic-x64" && chmod +x /bin/pnpm
 
 COPY pnpm-lock.yaml ./

--- a/packages/realm-server/Dockerfile
+++ b/packages/realm-server/Dockerfile
@@ -6,6 +6,8 @@ ENV realm_server_script=$realm_server_script
 
 WORKDIR /realm-server
 
+# Required for pnpm to install Node on Alpine
+RUN apk install build-base libc6-compat gcompat
 RUN wget -qO /bin/pnpm "https://github.com/pnpm/pnpm/releases/latest/download/pnpm-linuxstatic-x64" && chmod +x /bin/pnpm
 
 COPY pnpm-lock.yaml ./

--- a/packages/realm-server/Dockerfile
+++ b/packages/realm-server/Dockerfile
@@ -16,7 +16,7 @@ COPY vendor/ ./vendor
 ADD . ./
 
 RUN pnpm fetch
-RUN pnpm install -r --offline
+RUN pnpm install -r --prefer-offline
 
 EXPOSE 3000
 

--- a/packages/realm-server/Dockerfile
+++ b/packages/realm-server/Dockerfile
@@ -1,14 +1,13 @@
 # syntax=docker/dockerfile:1
 
-FROM node:18-alpine
+FROM node:18-slim
 ARG realm_server_script
 ENV realm_server_script=$realm_server_script
 
 WORKDIR /realm-server
 
-# Required for pnpm to install Node on Alpine
-RUN apk add build-base libc6-compat gcompat
-RUN wget -qO /bin/pnpm "https://github.com/pnpm/pnpm/releases/latest/download/pnpm-linuxstatic-x64" && chmod +x /bin/pnpm
+RUN apt-get update && apt-get install -y ca-certificates curl
+RUN curl -f https://get.pnpm.io/v6.16.js | node - add --global pnpm
 
 COPY pnpm-lock.yaml ./
 


### PR DESCRIPTION
Changing to the `slim` Node image results in a ≈40% (270MB) reduction in image size. (It doesn’t include `curl` which we use to install `pnpm`).

I experimented with steps that removed unused packages but that only resulted in a ≈2MB reduction and didn’t seem worth the maintenance overhead.