### PR TITLE
Fix issue preventing the removal of items in contains-many fields

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -728,7 +728,7 @@ export class Card {
             if (isNotLoadedValue(rawValue)) {
               return [fieldName, { id: rawValue.reference }];
             }
-              return [fieldName, getQueryableValue(field!.card, value[fieldName], [value,...stack])];
+              return [fieldName, getQueryableValue(field!, value[fieldName], [value,...stack])];
           }
         )
       );
@@ -830,7 +830,25 @@ export function isSaved(instance: Card): boolean {
   return instance[isSavedInstance] === true;
 }
 
-export function getQueryableValue(fieldCard: typeof Card, value: any, stack: Card[] = []): any {
+export function getQueryableValue(field: Field<typeof Card>, value: any, stack?: Card[]): any;
+export function getQueryableValue(fieldCard: typeof Card, value: any, stack?: Card[]): any;
+export function getQueryableValue(fieldOrCard: Field<typeof Card> | typeof Card, value: any, stack: Card[] = []): any {
+  let fieldCard: typeof Card;
+  let field: Field<typeof Card> | undefined;
+  if ('baseCard' in fieldOrCard) {
+    fieldCard = fieldOrCard;
+  } else {
+    field = fieldOrCard;
+    fieldCard = fieldOrCard.card;
+  }
+
+  // Need to replace the WatchedArray proxy with an actual array because the
+  // WatchedArray proxy is not structuredClone-able, and hence cannot be
+  // communicated over the postMessage boundary between worker and DOM.
+  if (field?.fieldType === 'containsMany') {
+    value = [...value];
+  }
+
   if ((primitive in fieldCard)) {
     let result = (fieldCard as any)[queryableValue](value);
     assertScalar(result, fieldCard);

--- a/packages/demo-cards/Booking/1.json
+++ b/packages/demo-cards/Booking/1.json
@@ -1,0 +1,47 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "title": "Gore Mountain Ski Trip",
+      "venue": "Gore Mountain",
+      "startTime": "2023-02-18T10:00:00.000Z",
+      "endTime": "2023-02-19T02:00:00.000Z",
+      "hosts": [
+        {
+          "firstName": "Hassan",
+          "lastName": "Abdel-Rahman",
+          "isCool": false,
+          "isHuman": false
+        },
+        {
+          "firstName": "Mango",
+          "lastName": "Abdel-Rahman",
+          "isCool": false,
+          "isHuman": false
+        }
+      ],
+      "sponsors": [
+        "Burton",
+        "Spy Optics"
+      ]
+    },
+    "relationships": {
+      "hosts.0.pet": {
+        "links": {
+          "self": null
+        }
+      },
+      "hosts.1.pet": {
+        "links": {
+          "self": null
+        }
+      }
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "http://local-realm/booking",
+        "name": "Booking"
+      }
+    }
+  }
+}

--- a/packages/demo-cards/CatalogEntry/7.json
+++ b/packages/demo-cards/CatalogEntry/7.json
@@ -1,0 +1,35 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "title": "Booking from http://local-realm/booking",
+      "description": "Catalog entry for Booking from http://local-realm/booking",
+      "ref": {
+        "module": "http://local-realm/booking",
+        "name": "Booking"
+      },
+      "demo": {
+        "title": null,
+        "venue": null,
+        "startTime": null,
+        "endTime": null,
+        "hosts": [],
+        "sponsors": []
+      }
+    },
+    "meta": {
+      "fields": {
+        "demo": {
+          "adoptsFrom": {
+            "module": "http://local-realm/booking",
+            "name": "Booking"
+          }
+        }
+      },
+      "adoptsFrom": {
+        "module": "https://cardstack.com/base/catalog-entry",
+        "name": "CatalogEntry"
+      }
+    }
+  }
+}

--- a/packages/demo-cards/booking.gts
+++ b/packages/demo-cards/booking.gts
@@ -1,0 +1,22 @@
+
+import { contains, containsMany, field, Component, Card } from 'https://cardstack.com/base/card-api';
+import StringCard from 'https://cardstack.com/base/string';
+import DateTimeCard from 'https://cardstack.com/base/datetime';
+import { Person } from './person';
+
+export class Booking extends Card {
+  @field title = contains(StringCard);
+  @field venue = contains(StringCard);
+  @field startTime = contains(DateTimeCard);
+  @field endTime = contains(DateTimeCard);
+  @field hosts = containsMany(Person);
+  @field sponsors = containsMany(StringCard);
+
+  static embedded = class Embedded extends Component<typeof this> {
+    <template>
+      <h2><@fields.title/></h2>
+      <div><@fields.startTime/> to <@fields.endTime/></div>
+      <div>Hosted by: <@fields.hosts/></div>
+    </template>
+  }
+}

--- a/packages/host/tests/cards/booking.gts
+++ b/packages/host/tests/cards/booking.gts
@@ -1,0 +1,22 @@
+
+import { contains, containsMany, field, Component, Card } from 'https://cardstack.com/base/card-api';
+import StringCard from 'https://cardstack.com/base/string';
+import DateTimeCard from 'https://cardstack.com/base/datetime';
+import { Person } from './person';
+
+export class Booking extends Card {
+  @field title = contains(StringCard);
+  @field venue = contains(StringCard);
+  @field startTime = contains(DateTimeCard);
+  @field endTime = contains(DateTimeCard);
+  @field hosts = containsMany(Person);
+  @field sponsors = containsMany(StringCard);
+
+  static embedded = class Embedded extends Component<typeof this> {
+    <template>
+      <h2><@fields.title/></h2>
+      <div><@fields.startTime/> to <@fields.endTime/></div>
+      <div>Hosted by: <@fields.hosts/></div>
+    </template>
+  }
+}

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -26,6 +26,7 @@ import {
   type DirectoryEntryRelationship,
 } from "./index";
 import merge from "lodash/merge";
+import mergeWith from "lodash/mergeWith";
 import qs from "qs";
 import cloneDeep from "lodash/cloneDeep";
 import {
@@ -490,7 +491,16 @@ export class Realm {
     delete (patch as any).data.meta;
     delete (patch as any).data.type;
 
-    let card = merge({}, originalClone, patch);
+    let card = mergeWith(
+      originalClone,
+      patch,
+      (_objectValue: any, sourceValue: any) => {
+        // a patched array should overwrite the original array instead of merging
+        // into an original array, otherwise we won't be able to remove items in
+        // the original array
+        return Array.isArray(sourceValue) ? sourceValue : undefined;
+      }
+    );
     delete (card as any).data.id; // don't write the ID to the file
     let path: LocalPath = `${localPath}.json`;
     let { lastModified } = await this.write(


### PR DESCRIPTION
Also fixes a bug where the searchdoc could not be communicated across the `postMessage` boundary due to `WatchedArray`'s (our deserialized array proxy) not being `structuredClone`-able.