### PR TITLE
common: Fix wording of codeEqual assertion message

### DIFF
--- a/packages/runtime-common/helpers/code-equality-assertion.ts
+++ b/packages/runtime-common/helpers/code-equality-assertion.ts
@@ -72,7 +72,7 @@ function codeEqual(
   this: Assert,
   actual: string,
   expected: string,
-  message = 'code is not equal.'
+  message = 'code should be equal'
 ) {
   let parsedActual = standardize(actual)!;
   let parsedExpected = standardize(expected)!;


### PR DESCRIPTION
This is tweak to address the mild dissonance I experienced from seeing `code is not equal.` where it actually was:

<img width="664" alt="✖ RuntimeSpike Tests 2023-03-15 13-03-23" src="https://user-images.githubusercontent.com/43280/225386056-0f7c19d6-990d-4a29-9b28-dd73c696663c.png">
