### PR TITLE
Consolidate host builds into a single build with runtime public asset path determination

### DIFF
--- a/.github/actions/deploy-boxel-host/action.yml
+++ b/.github/actions/deploy-boxel-host/action.yml
@@ -61,21 +61,6 @@ runs:
         role-to-assume: ${{ env.AWS_ROLE_ARN }}
         aws-region: us-east-1
 
-    # using an explicit build step as build to support realm hosting is actually
-    # different than the build for s3/cloudfront hosted app.
-    # - name: Build host app for realm hosting
-    #   shell: bash
-    #   run: pnpm build:boxel-host
-    # - name: Make realm hosted app dist zip
-    #   shell: bash
-    #   run: zip -r dist.zip ./dist
-    #   working-directory: packages/host
-    # - name: Copy host dist zip to s3
-    #   shell: bash
-    #   run: |
-    #     aws s3 cp ./dist.zip "s3://${{ env.AWS_S3_BUCKET }}/boxel_dist/dist.zip" --cache-control=no-cache
-    #   working-directory: packages/host
-
     - name: Deploy
       shell: bash
       run: pnpm deploy:boxel-host ${{ inputs.environment }} --verbose

--- a/.github/actions/deploy-boxel-host/action.yml
+++ b/.github/actions/deploy-boxel-host/action.yml
@@ -63,18 +63,18 @@ runs:
 
     # using an explicit build step as build to support realm hosting is actually
     # different than the build for s3/cloudfront hosted app.
-    - name: Build host app for realm hosting
-      shell: bash
-      run: pnpm build:boxel-host
-    - name: Make realm hosted app dist zip
-      shell: bash
-      run: zip -r dist.zip ./dist
-      working-directory: packages/host
-    - name: Copy host dist zip to s3
-      shell: bash
-      run: |
-        aws s3 cp ./dist.zip "s3://${{ env.AWS_S3_BUCKET }}/boxel_dist/dist.zip" --cache-control=no-cache
-      working-directory: packages/host
+    # - name: Build host app for realm hosting
+    #   shell: bash
+    #   run: pnpm build:boxel-host
+    # - name: Make realm hosted app dist zip
+    #   shell: bash
+    #   run: zip -r dist.zip ./dist
+    #   working-directory: packages/host
+    # - name: Copy host dist zip to s3
+    #   shell: bash
+    #   run: |
+    #     aws s3 cp ./dist.zip "s3://${{ env.AWS_S3_BUCKET }}/boxel_dist/dist.zip" --cache-control=no-cache
+    #   working-directory: packages/host
 
     - name: Deploy
       shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,7 +81,7 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
       - name: Build host dist/ for fastboot
-        run: pnpm build:ember-cli-hosted
+        run: pnpm build
         working-directory: packages/host
       - name: Start realm servers
         run: pnpm start:all &

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ In order to run the ember-cli hosted app:
 
 The app is available at http://localhost:4200. Click on the button to connect to your Local Realm, and then select the "cards/" folder within this project. Click "Allow" on the popups that ask for the ability to read and write to the local file system.
 
-> Note that the ember build for the ember-cli hosted app is not compatible with a realm server hosted model. If you wish to visit a realm server URL directly to view its app then you must use the "Realm server Hosted App" instructions described in the following section.
 ### Realm server Hosted App
 In order to run the realm server hosted app:
 
@@ -81,7 +80,7 @@ To run the `packages/realm-server/` workspace tests start:
 Run `pnpm test` in the `packages/realm-server/` workspace to run the realm tests
 
 ### Realm Server DOM tests
-This test suite contains acceptance tests for asserting that the Realm server is capable of hosting its own app. These tests require that the host be built with the ability to support realm based hosting. To run these tests in the browser execute the following in the `packages/realm-server` workspace:
+This test suite contains acceptance tests for asserting that the Realm server is capable of hosting its own app. To run these tests in the browser execute the following in the `packages/realm-server` workspace:
 
 1. `pnpm start:test-container`
 2. `pnpm start:all`

--- a/packages/host/app/app.ts
+++ b/packages/host/app/app.ts
@@ -1,3 +1,4 @@
+import './lib/public-path'; // this should be first
 import Application from '@ember/application';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';

--- a/packages/host/app/lib/public-path.ts
+++ b/packages/host/app/lib/public-path.ts
@@ -1,0 +1,6 @@
+import config from '@cardstack/host/config/environment';
+
+const { isBaseRealmHosting } = config;
+
+// @ts-expect-error this is consumed by webpack to set the public asset path at runtime
+__webpack_public_path__ = isBaseRealmHosting ? '/base/__boxel/' : '/';

--- a/packages/host/app/lib/public-path.ts
+++ b/packages/host/app/lib/public-path.ts
@@ -1,6 +1,8 @@
 import config from '@cardstack/host/config/environment';
+import { baseRealm, assetsDir } from '@cardstack/runtime-common';
 
 const { isBaseRealmHosting } = config;
+let assetPathname = new URL(`${baseRealm.url}${assetsDir}`).pathname;
 
 // @ts-expect-error this is consumed by webpack to set the public asset path at runtime
-__webpack_public_path__ = isBaseRealmHosting ? '/base/__boxel/' : '/';
+__webpack_public_path__ = isBaseRealmHosting ? assetPathname : '/';

--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -24,14 +24,14 @@ module.exports = function (environment) {
     'ember-cli-mirage': {
       enabled: false,
     },
-    // This should be provided as an *unresolved* URL
-    ownRealmURL: process.env.OWN_REALM_URL || 'http://localhost:4200/',
-    isBaseRealmHosting: process.env.BASE_REALM_HOSTING_DISABLED !== 'true',
-    // this may be rewritten by the realm server
-    isLocalRealm:
-      environment === 'test' ? true : process.env.HOST_LOCAL_REALM === 'true',
     resolvedBaseRealmURL:
       process.env.RESOLVED_BASE_REALM_URL || 'http://localhost:4201/base/',
+
+    // the fields below may be rewritten by the realm server
+    ownRealmURL: process.env.OWN_REALM_URL || 'http://localhost:4200/', // this should be provided as an *unresolved* URL
+    isBaseRealmHosting: false,
+    isLocalRealm:
+      environment === 'test' ? true : process.env.HOST_LOCAL_REALM === 'true',
   };
 
   if (environment === 'development') {

--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -24,14 +24,14 @@ module.exports = function (environment) {
     'ember-cli-mirage': {
       enabled: false,
     },
-    resolvedBaseRealmURL:
-      process.env.RESOLVED_BASE_REALM_URL || 'http://localhost:4201/base/',
 
     // the fields below may be rewritten by the realm server
     ownRealmURL: process.env.OWN_REALM_URL || 'http://localhost:4200/', // this should be provided as an *unresolved* URL
     isBaseRealmHosting: false,
     isLocalRealm:
       environment === 'test' ? true : process.env.HOST_LOCAL_REALM === 'true',
+    resolvedBaseRealmURL:
+      process.env.RESOLVED_BASE_REALM_URL || 'http://localhost:4201/base/',
   };
 
   if (environment === 'development') {

--- a/packages/host/ember-cli-build.js
+++ b/packages/host/ember-cli-build.js
@@ -6,8 +6,6 @@ const { Webpack } = require('@embroider/webpack');
 const webpack = require('webpack');
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
 
-const isBaseRealmHosting = process.env.BASE_REALM_HOSTING_DISABLED !== 'true';
-
 module.exports = function (defaults) {
   let app = new EmberApp(defaults, {
     'ember-cli-babel': {
@@ -54,7 +52,6 @@ module.exports = function (defaults) {
           },
         },
       },
-      ...(isBaseRealmHosting ? { publicAssetURL: `/base/__boxel/` } : {}),
     },
   });
 };

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -12,7 +12,6 @@
   },
   "scripts": {
     "build": "ember build",
-    "build:ember-cli-hosted": "BASE_REALM_HOSTING_DISABLED=true ember build",
     "build:production": "NODE_OPTIONS='--max-old-space-size=4096' ember build --environment=production",
     "lint": "npm-run-all --aggregate-output --continue-on-error --parallel \"lint:!(fix)\"",
     "lint:fix": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*:fix",
@@ -21,7 +20,7 @@
     "lint:js": "eslint . --cache --ext ts,js",
     "lint:js:fix": "eslint . --fix",
     "lint:glint": "glint",
-    "start": "FASTBOOT_DISABLED=true HOST_LOCAL_REALM=true BASE_REALM_HOSTING_DISABLED=true ember serve",
+    "start": "FASTBOOT_DISABLED=true HOST_LOCAL_REALM=true ember serve",
     "start:build": "FASTBOOT_DISABLED=true ember build --watch",
     "test": "npm-run-all lint test:*",
     "test:wait-for-servers": "NODE_NO_WARNINGS=1 start-server-and-test 'pnpm run wait' 'http-get://localhost:4201/base/fields/boolean-field?acceptHeader=application%2Fvnd.api%2Bjson' 'pnpm run wait' 'http-get://localhost:4202/test/hassan?acceptHeader=application%2Fvnd.api%2Bjson' 'ember-test-pre-built'",

--- a/packages/realm-server/package.json
+++ b/packages/realm-server/package.json
@@ -35,7 +35,7 @@
     "yargs": "^17.5.1"
   },
   "scripts": {
-    "fetch-dist": "ts-node --transpileOnly fetch-dist",
+    "fetch-dist": "ts-node --transpileOnly ./scripts/fetch-dist",
     "fetch-dist:staging": "pnpm fetch-dist --url https://boxel-host-staging.stack.cards/ --logLevel debug",
     "fetch-dist:production": "pnpm fetch-dist --url https://boxel-host.cardstack.com/ --logLevel debug",
     "test": "NODE_NO_WARNINGS=1 qunit --require ts-node/register/transpile-only tests/index.ts",

--- a/packages/realm-server/scripts/fetch-dist.ts
+++ b/packages/realm-server/scripts/fetch-dist.ts
@@ -35,7 +35,17 @@ if (!url.endsWith('/')) {
 }
 
 (async () => {
-  let zipUrl = `${url}boxel_dist/dist.zip`;
+  let indirectionUrl = `${url}fastboot-deploy-info.json`;
+
+  log.debug(`Fetching deployment info from ${indirectionUrl}`);
+  let response = await fetch(indirectionUrl);
+
+  let json = await response.json();
+
+  log.debug(`JSON response: ${JSON.stringify(json, null, 2)}`);
+  let key = json.key;
+
+  let zipUrl = `${url}${key}`;
   log.info(`Fetching zip from ${zipUrl}`);
 
   let zipResponse = await fetch(zipUrl);

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -9,6 +9,7 @@ import log from 'loglevel';
 let requestLog = log.getLogger('realm:requests');
 let assetPathname = new URL(`${baseRealm.url}${assetsDir}`).pathname;
 let monacoLanguages = ['css', 'json', 'ts', 'html'];
+let monacoFonts = ['ade705761eb7e702770d.ttf'];
 
 export interface RealmConfig {
   realmURL: string;
@@ -131,6 +132,20 @@ export function createRealmServer(realms: Realm[], opts?: Options) {
         res.end();
         return;
       }
+
+      // monaco fonts are hardcoded to load from the root of the origin, this is
+      // where we deal with those
+      if (monacoFonts.map((f) => `/${f}`).includes(req.url)) {
+        let redirectURL = Loader.resolve(
+          new URL(`.${req.url}`, `${baseRealm.url}${assetsDir}`)
+        ).href;
+        res.writeHead(302, {
+          Location: redirectURL,
+        });
+        res.end();
+        return;
+      }
+
       // requests for the root of the realm without a trailing slash aren't
       // technically inside the realm (as the realm includes the trailing '/').
       // So issue a redirect in those scenarios.

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -299,13 +299,16 @@ export class Realm {
         config = merge({}, config, {
           ownRealmURL: opts?.localRealmURL ?? this.url,
           resolvedBaseRealmURL,
-          isLocalRealm: opts?.hostLocalRealm,
+          isLocalRealm: Boolean(opts?.hostLocalRealm),
           isBaseRealmHosting: true,
           realmsServed: opts?.realmsServed,
         });
         return `${g1}${encodeURIComponent(JSON.stringify(config))}${g3}`;
       }
     );
+
+    // set the static public asset paths in index.html
+    indexHTML = indexHTML.replace(/(src|href)="/g, '$1="/base/__boxel');
 
     // This setting relaxes the document.domain (by eliminating the port) so
     // that we can do cross origin scripting in order to perform test assertions


### PR DESCRIPTION
The key here is that we can't just add this assignment in a `<script>` tag in the realm rewritten `index.html` that is divorced from the webpack build. Webpack actually needs to discover this assignment at build time and then compile it in its own way in order to support runtime public asset path configuration. This means the `__webpack_public_path__` assignment needs to be set in the actual ember app itself and not something that is rewritten by the realm server.