### PR TITLE
host: Add last-saved recovery from errors

### DIFF
--- a/packages/host/app/components/go.gts
+++ b/packages/host/app/components/go.gts
@@ -67,13 +67,13 @@ export default class Go extends Component<Signature> {
             <li>
               {{#if this.contentChangedTask.isRunning}}
                 <span data-test-saving>⟳ Saving…</span>
-              {{else if this.contentChangedTask.last.isError}}
+              {{else if this.contentChangedTask.lastComplete.isError}}
                 <span data-test-save-error>✘</span>
               {{else}}
                 <span data-test-saved>✔</span>
               {{/if}}
             </li>
-            {{#if this.contentChangedTask.lastErrored}}
+            {{#if this.contentChangedTask.last.isError}}
               <li data-test-failed-to-save>Failed to save</li>
             {{else if this.openFile.lastModified}}
               <li data-test-last-edit>Last edit was


### PR DESCRIPTION
Before this the last-saved message would always show an error even if a save had subsequently succeeded:

![screencast 2023-03-22 10-09-22](https://user-images.githubusercontent.com/43280/227302436-93462c71-c4a7-4089-aeac-1048cd6815e4.gif)
