### PR TITLE
Fixes #CS-5354 catalog entry editor support for relative references

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -519,7 +519,7 @@ class Contains<CardT extends CardConstructor> implements Field<CardT, any> {
 
   queryableValue(instance: any, stack: Card[]): any {
     if (primitive in this.card) {
-      let result = this.card[queryableValue](instance);
+      let result = this.card[queryableValue](instance, stack);
       assertScalar(result, this.card);
       return result;
     }

--- a/packages/base/card-ref.gts
+++ b/packages/base/card-ref.gts
@@ -7,6 +7,7 @@ import {
   Card,
   CardConstructor,
   CardInstanceType,
+  relativeTo,
 } from './card-api';
 
 class BaseView extends Component<typeof CardRefCard> {
@@ -34,9 +35,14 @@ export default class CardRefCard extends Card {
   ): Promise<CardInstanceType<T>> {
     return { ...cardRef } as CardInstanceType<T>; // return a new object so that the model cannot be mutated from the outside
   }
-  static [queryableValue](cardRef: CardId | undefined) {
+  static [queryableValue](cardRef: CardId | undefined, stack: Card[] = []) {
     if (cardRef) {
-      return `${cardRef.module}/${cardRef.name}`; // this assumes the module is an absolute reference
+      // if a stack is passed in, use the containing card to resolve relative references
+      let moduleHref =
+        stack.length > 0
+          ? new URL(cardRef.module, stack[0][relativeTo]).href
+          : cardRef.module;
+      return `${moduleHref}/${cardRef.name}`;
     }
     return undefined;
   }

--- a/packages/host/app/components/catalog-entry-editor.gts
+++ b/packages/host/app/components/catalog-entry-editor.gts
@@ -56,6 +56,8 @@ export default class CatalogEntryEditor extends Component<Signature> {
             />
           </div>
         </CardContainer>
+      {{else if this.catalogEntry.isSearching}}
+        <div>Loading...</div>
       {{else}}
         <button
           {{on 'click' this.createEntry}}

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -23,6 +23,10 @@ export class Search extends Resource<Args> {
     this.search.perform(query);
   }
 
+  get isSearching() {
+    return this.search.isRunning;
+  }
+
   private search = restartableTask(async (query: Query) => {
     // until we have realm index rollup, search all the realms as separate
     // queries that we merge together


### PR DESCRIPTION
the queryable value for card-refs assumed absolute references. Updated this to be able to use the `relativeTo` symbol