### PR TITLE
Added mock message service to go component tests

### DIFF
--- a/packages/host/tests/integration/components/go-test.gts
+++ b/packages/host/tests/integration/components/go-test.gts
@@ -25,6 +25,7 @@ import CardPrerender from '@cardstack/host/components/card-prerender';
 import type * as monaco from 'monaco-editor';
 import type { LocalPath } from '@cardstack/runtime-common/paths';
 import { shimExternals } from '@cardstack/host/lib/externals';
+import Service from '@ember/service';
 
 const cardContent = `
 import { contains, field, Card, linksTo } from "https://cardstack.com/base/card-api";
@@ -35,6 +36,12 @@ export class Person extends Card {
   @field friend = linksTo(() => Person);
 }
 `;
+
+class MockMessageService extends Service {
+  subscribe() {
+    return () => {};
+  }
+}
 
 class FailingTestRealmAdapter extends TestRealmAdapter {
   writeCalled = false;
@@ -65,6 +72,7 @@ module('Integration | Component | go', function (hooks) {
   );
 
   hooks.beforeEach(async function () {
+    this.owner.register('service:message-service', MockMessageService);
     Loader.addURLMapping(
       new URL(baseRealm.url),
       new URL('http://localhost:4201/base/')


### PR DESCRIPTION
I was encountering issues with the go component tests because the message subscription that the file resource was attempting failed (because there is not an actual http server listening at the test realm URL). These go tests don't actually require the message service (and there are host tests that explicitly test that infrastructure elsewhere). To work around this I mocked out the message service for these tests.