### PR TITLE
realm: Change deployment to use pnpm@7 for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,8 @@
     "prettier-plugin-ember-template-tag": "^0.3.2",
     "hcl2-parser": "^1.0.3",
     "typescript": "^4.6.3"
+  },
+  "engines": {
+    "pnpm": "^7"
   }
 }

--- a/packages/realm-server/Dockerfile
+++ b/packages/realm-server/Dockerfile
@@ -7,7 +7,7 @@ ENV realm_server_script=$realm_server_script
 WORKDIR /realm-server
 
 RUN apt-get update && apt-get install -y ca-certificates curl unzip
-RUN curl -f https://get.pnpm.io/v6.16.js | node - add --global pnpm
+RUN npm install -g pnpm@7
 
 COPY pnpm-lock.yaml ./
 


### PR DESCRIPTION
Since pnpm 8 was released realm server deployments have been failing. This hardcodes the version used for the Docker build to the same major as the one specified in the deployment action. It also adds an engine specification so we can more easily migrate everyone when we update.

The pnpm documentation for [Docker setup](https://pnpm.io/cli/fetch) and [standalone installs of a particular version](https://pnpm.io/installation#installing-a-specific-version) are mutually incompatible but it deployed successfully using `npm install -g`.