### PR TITLE
Create acceptance tests

### DIFF
--- a/packages/host/app/components/directory.gts
+++ b/packages/host/app/components/directory.gts
@@ -24,6 +24,7 @@ export default class Directory extends Component<Args> {
         {{#let (concat @relativePath entry.name) as |entryPath|}}
           {{#if (eq entry.kind 'file')}}
             <div
+              data-test-file={{entryPath}}
               role='button'
               {{on 'click' (fn this.openFile entryPath)}}
               class='file {{if (eq entryPath @openFile) "selected"}}'
@@ -32,6 +33,7 @@ export default class Directory extends Component<Args> {
             </div>
           {{else}}
             <div
+              data-test-directory={{entryPath}}
               role='button'
               {{on 'click' (fn this.toggleDirectory entryPath)}}
               class='directory

--- a/packages/host/app/routes/code.ts
+++ b/packages/host/app/routes/code.ts
@@ -66,12 +66,17 @@ export default class Index extends Route<Model> {
       );
       return { path, openFile, openDirs, isFastBoot };
     }
+    let responseURL: URL | undefined;
     // The server may have responded with a redirect which we need to pay
     // attention to. As part of responding to us, the server will hand us a
     // resolved URL in response.url. We need to reverse that resolution in order
-    // to see if we have been given a redirect.
-    let responseURL = this.loaderService.loader.reverseResolution(response.url);
-    if (responseURL.href !== url) {
+    // to see if we have been given a redirect. (note that when the response is
+    // a short-circuited response because our realm lives in the DOM, i.e. tests,
+    // then there is no response.url)
+    if (response.url) {
+      responseURL = this.loaderService.loader.reverseResolution(response.url);
+    }
+    if (responseURL && responseURL.href !== url) {
       this.router.transitionTo('code', {
         queryParams: { path: realmPath.local(responseURL), openDirs },
       });

--- a/packages/host/app/templates/index.hbs
+++ b/packages/host/app/templates/index.hbs
@@ -1,8 +1,9 @@
 {{!-- TODO remove this after we have real content for this template --}}
 {{!-- template-lint-disable no-inline-styles --}}
-<p style="text-align:center;margin:5em auto;">The card code editor has moved to
+<p style="text-align:center;margin:5em auto;" data-test-moved>The card code editor has moved to
   <LinkTo
     @route="code"
     style="color:aqua;font-weight:bold;font-style:italic"
+    data-test-code-link
   >/code</LinkTo>
 </p>

--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -26,10 +26,12 @@ module.exports = function (environment) {
     },
 
     // the fields below may be rewritten by the realm server
-    ownRealmURL: process.env.OWN_REALM_URL || 'http://localhost:4200/', // this should be provided as an *unresolved* URL
+    ownRealmURL:
+      environment === 'test'
+        ? 'http://test-realm/test/'
+        : process.env.OWN_REALM_URL || 'http://localhost:4200/', // this should be provided as an *unresolved* URL
     hostsOwnAssets: true,
-    isLocalRealm:
-      environment === 'test' ? true : process.env.HOST_LOCAL_REALM === 'true',
+    isLocalRealm: process.env.HOST_LOCAL_REALM === 'true',
     resolvedBaseRealmURL:
       process.env.RESOLVED_BASE_REALM_URL || 'http://localhost:4201/base/',
   };

--- a/packages/host/tests/acceptance/basic-test.ts
+++ b/packages/host/tests/acceptance/basic-test.ts
@@ -197,9 +197,8 @@ module('Acceptance | basic tests', function (hooks) {
     await fillIn('[data-test-field="firstName"] input', 'Mango');
     await fillIn('[data-test-field="lastName"] input', 'Abdel-Rahman');
     await click('[data-test-save-card]');
-    await waitUntil(() => !document.querySelector('[data-test-saving]'));
+    await waitUntil(() => currentURL() === '/code?path=Person%2F2.json');
 
-    assert.strictEqual(currentURL(), '/code?path=Person%2F2.json');
     await click('[data-test-directory="Person/"]');
     await waitFor('[data-test-file="Person/2.json"]');
     assert

--- a/packages/host/tests/acceptance/basic-test.ts
+++ b/packages/host/tests/acceptance/basic-test.ts
@@ -1,0 +1,98 @@
+import { module, test } from 'qunit';
+import { visit, currentURL, click, waitFor } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { Loader } from '@cardstack/runtime-common/loader';
+import { baseRealm } from '@cardstack/runtime-common';
+import {
+  TestRealm,
+  TestRealmAdapter,
+  setupMockLocalRealm,
+  setupMockMessageService,
+} from '../helpers';
+import { Realm } from '@cardstack/runtime-common/realm';
+import { shimExternals } from '@cardstack/host/lib/externals';
+import type LoaderService from '@cardstack/host/services/loader-service';
+
+module('Acceptance | foo', function (hooks) {
+  let realm: Realm;
+  let adapter: TestRealmAdapter;
+
+  setupApplicationTest(hooks);
+  setupMockLocalRealm(hooks);
+  setupMockMessageService(hooks);
+
+  hooks.beforeEach(async function () {
+    // this seeds the loader used during index which obtains url mappings
+    // from the global loader
+    Loader.addURLMapping(
+      new URL(baseRealm.url),
+      new URL('http://localhost:4201/base/')
+    );
+    shimExternals();
+    adapter = new TestRealmAdapter({
+      'person.gts': `
+        import { contains, field, Card } from "https://cardstack.com/base/card-api";
+        import StringCard from "https://cardstack.com/base/string";
+
+        export class Person extends Card {
+          @field firstName = contains(StringCard);
+          @field lastName = contains(StringCard);
+        }
+      `,
+      'Person/1.json': {
+        data: {
+          type: 'card',
+          attributes: {
+            firstName: 'Hassan',
+            lastName: 'Abdel-Rahman',
+          },
+          meta: {
+            adoptsFrom: {
+              module: '../person',
+              name: 'Person',
+            },
+          },
+        },
+      },
+    });
+    realm = await TestRealm.createWithAdapter(adapter, this.owner, {
+      isAcceptanceTest: true,
+    });
+
+    let loader = (this.owner.lookup('service:loader-service') as LoaderService)
+      .loader;
+    loader.registerURLHandler(new URL(realm.url), realm.handle.bind(realm));
+    await realm.ready;
+  });
+
+  test('visiting /', async function (assert) {
+    await visit('/');
+
+    assert.strictEqual(currentURL(), '/');
+    assert
+      .dom('[data-test-moved]')
+      .containsText('The card code editor has moved to /code');
+    await click('[data-test-code-link]');
+    assert.strictEqual(currentURL(), '/code');
+  });
+
+  test('Can expand/collapse directories file tree', async function (assert) {
+    await visit('/code');
+    await waitFor('[data-test-file]');
+    assert
+      .dom('[data-test-directory="Person/"]')
+      .exists('Person/ directory entry is rendered');
+    assert
+      .dom('[data-test-file="person.gts"]')
+      .exists('person.gts file entry is rendered');
+    await click('[data-test-directory="Person/"]');
+    await waitFor('[data-test-file="Person/1.json"]');
+    assert
+      .dom('[data-test-file="Person/1.json"]')
+      .exists('Person/1.json file entry is rendered');
+    await click('[data-test-directory="Person/"]');
+    assert
+      .dom('[data-test-file="Person/1.json"]')
+      .doesNotExist('Person/1.json file entry is not rendered');
+  });
+});

--- a/packages/host/tests/acceptance/basic-test.ts
+++ b/packages/host/tests/acceptance/basic-test.ts
@@ -1,5 +1,12 @@
 import { module, test } from 'qunit';
-import { visit, currentURL, click, waitFor } from '@ember/test-helpers';
+import {
+  visit,
+  currentURL,
+  click,
+  waitFor,
+  fillIn,
+  waitUntil,
+} from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { Loader } from '@cardstack/runtime-common/loader';
 import { baseRealm } from '@cardstack/runtime-common';
@@ -8,12 +15,27 @@ import {
   TestRealmAdapter,
   setupMockLocalRealm,
   setupMockMessageService,
+  testRealmURL,
 } from '../helpers';
 import { Realm } from '@cardstack/runtime-common/realm';
 import { shimExternals } from '@cardstack/host/lib/externals';
 import type LoaderService from '@cardstack/host/services/loader-service';
 
-module('Acceptance | foo', function (hooks) {
+function getMonacoContent(): string {
+  return (window as any).monaco.editor.getModels()[0].getValue();
+}
+
+const personCardSource = `
+  import { contains, field, Card } from "https://cardstack.com/base/card-api";
+  import StringCard from "https://cardstack.com/base/string";
+
+  export class Person extends Card {
+    @field firstName = contains(StringCard);
+    @field lastName = contains(StringCard);
+  }
+`;
+
+module('Acceptance | basic tests', function (hooks) {
   let realm: Realm;
   let adapter: TestRealmAdapter;
 
@@ -30,15 +52,26 @@ module('Acceptance | foo', function (hooks) {
     );
     shimExternals();
     adapter = new TestRealmAdapter({
-      'person.gts': `
-        import { contains, field, Card } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
-
-        export class Person extends Card {
-          @field firstName = contains(StringCard);
-          @field lastName = contains(StringCard);
-        }
-      `,
+      'person.gts': personCardSource,
+      'person-entry.json': {
+        data: {
+          type: 'card',
+          attributes: {
+            title: 'Person',
+            description: 'Catalog entry',
+            ref: {
+              module: `./person`,
+              name: 'Person',
+            },
+          },
+          meta: {
+            adoptsFrom: {
+              module: `${baseRealm.url}catalog-entry`,
+              name: 'CatalogEntry',
+            },
+          },
+        },
+      },
       'Person/1.json': {
         data: {
           type: 'card',
@@ -94,5 +127,124 @@ module('Acceptance | foo', function (hooks) {
     assert
       .dom('[data-test-file="Person/1.json"]')
       .doesNotExist('Person/1.json file entry is not rendered');
+  });
+
+  test('Can view a card instance', async function (assert) {
+    await visit('/code');
+    await waitFor('[data-test-file]');
+    await click('[data-test-directory="Person/"]');
+    await waitFor('[data-test-file="Person/1.json"]');
+
+    await click('[data-test-file="Person/1.json"]');
+    assert.strictEqual(
+      currentURL(),
+      '/code?openDirs=Person%2F&path=Person%2F1.json'
+    );
+    assert
+      .dom('[data-test-file="Person/1.json"]')
+      .exists('Person/1.json file entry is rendered');
+    assert
+      .dom('[data-test-boxel-card-container]')
+      .containsText('Hassan Abdel-Rahman');
+    assert.deepEqual(JSON.parse(getMonacoContent()), {
+      data: {
+        type: 'card',
+        attributes: {
+          firstName: 'Hassan',
+          lastName: 'Abdel-Rahman',
+        },
+        meta: {
+          adoptsFrom: {
+            module: `../person`,
+            name: 'Person',
+          },
+        },
+      },
+    });
+  });
+
+  test('Can view a card schema', async function (assert) {
+    await visit('/code');
+    await waitFor('[data-test-file]');
+    await click('[data-test-file="person.gts"]');
+    await waitFor('[data-test-card-id]');
+
+    assert.strictEqual(currentURL(), '/code?path=person.gts');
+    assert
+      .dom('[data-test-card-id]')
+      .containsText(`${testRealmURL}person/Person`);
+    assert
+      .dom('[data-test-adopts-from]')
+      .containsText(`${baseRealm.url}card-api/Card`);
+    assert.dom('[data-test-field="firstName"]').exists();
+    assert.dom('[data-test-field="lastName"]').exists();
+    assert.strictEqual(
+      getMonacoContent(),
+      personCardSource,
+      'the monaco content is correct'
+    );
+  });
+
+  test('can create a new card', async function (assert) {
+    await visit('/code');
+    await click('[data-test-create-new-card-button]');
+    await waitFor('[data-test-card-catalog-modal] [data-test-ref]');
+
+    await click(`[data-test-select="${testRealmURL}person-entry"]`);
+    await waitFor(`[data-test-create-new-card="Person"]`);
+    await waitFor(`[data-test-field="firstName"] input`);
+
+    await fillIn('[data-test-field="firstName"] input', 'Mango');
+    await fillIn('[data-test-field="lastName"] input', 'Abdel-Rahman');
+    await click('[data-test-save-card]');
+    await waitUntil(() => !document.querySelector('[data-test-saving]'));
+
+    assert.strictEqual(currentURL(), '/code?path=Person%2F2.json');
+    await click('[data-test-directory="Person/"]');
+    await waitFor('[data-test-file="Person/2.json"]');
+    assert
+      .dom('[data-test-file="Person/2.json"]')
+      .exists('Person/2.json file entry is rendered');
+    assert
+      .dom('[data-test-boxel-card-container]')
+      .containsText('Mango Abdel-Rahman');
+    assert.deepEqual(JSON.parse(getMonacoContent()), {
+      data: {
+        type: 'card',
+        attributes: {
+          firstName: 'Mango',
+          lastName: 'Abdel-Rahman',
+        },
+        meta: {
+          adoptsFrom: {
+            module: `${testRealmURL}person`,
+            name: 'Person',
+          },
+        },
+      },
+    });
+    let fileRef = await adapter.openFile('Person/2.json');
+    if (!fileRef) {
+      throw new Error('file not found');
+    }
+    assert.deepEqual(
+      JSON.parse(fileRef.content as string),
+      {
+        data: {
+          type: 'card',
+          attributes: {
+            firstName: 'Mango',
+            lastName: 'Abdel-Rahman',
+          },
+          meta: {
+            adoptsFrom: {
+              module: `${testRealmURL}person`,
+              name: 'Person',
+            },
+          },
+        },
+      },
+      'file contents are correct'
+    );
   });
 });

--- a/packages/host/tests/integration/components/go-test.gts
+++ b/packages/host/tests/integration/components/go-test.gts
@@ -19,13 +19,13 @@ import {
   testRealmURL,
   setupCardLogs,
   setupMockLocalRealm,
+  setupMockMessageService,
 } from '../../helpers';
 import moment from 'moment';
 import CardPrerender from '@cardstack/host/components/card-prerender';
 import type * as monaco from 'monaco-editor';
 import type { LocalPath } from '@cardstack/runtime-common/paths';
 import { shimExternals } from '@cardstack/host/lib/externals';
-import Service from '@ember/service';
 
 const cardContent = `
 import { contains, field, Card, linksTo } from "https://cardstack.com/base/card-api";
@@ -36,12 +36,6 @@ export class Person extends Card {
   @field friend = linksTo(() => Person);
 }
 `;
-
-class MockMessageService extends Service {
-  subscribe() {
-    return () => {};
-  }
-}
 
 class FailingTestRealmAdapter extends TestRealmAdapter {
   writeCalled = false;
@@ -66,13 +60,13 @@ module('Integration | Component | go', function (hooks) {
 
   setupRenderingTest(hooks);
   setupMockLocalRealm(hooks);
+  setupMockMessageService(hooks);
   setupCardLogs(
     hooks,
     async () => await Loader.import(`${baseRealm.url}card-api`)
   );
 
   hooks.beforeEach(async function () {
-    this.owner.register('service:message-service', MockMessageService);
     Loader.addURLMapping(
       new URL(baseRealm.url),
       new URL('http://localhost:4201/base/')

--- a/packages/host/tests/integration/realm-test.ts
+++ b/packages/host/tests/integration/realm-test.ts
@@ -346,7 +346,9 @@ module('Integration | realm', function (hooks) {
         },
       },
       this.owner,
-      `${testRealmURL}root/`
+      {
+        realmURL: `${testRealmURL}root/`,
+      }
     );
     await realm.ready;
     {


### PR DESCRIPTION
This PR adds some basic sample happy path acceptance tests that includes both static tests (non-realm altering tests), and mutation tests (realm altering tests). As well as it provides an example of how to make assertions on the backing realm files