### PR TITLE
boxel: Fix timezone sensitive tests 

### DIFF
--- a/packages/base/date.gts
+++ b/packages/base/date.gts
@@ -14,7 +14,7 @@ import { BoxelInput } from '@cardstack/boxel-ui';
 
 // The Intl API is supported in all modern browsers. In older ones, we polyfill
 // it in the application route at app startup.
-const Format = new Intl.DateTimeFormat('us-EN', {
+const Format = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
   month: 'short',
   day: 'numeric',

--- a/packages/base/datetime.gts
+++ b/packages/base/datetime.gts
@@ -14,7 +14,7 @@ import { BoxelInput } from '@cardstack/boxel-ui';
 
 // The Intl API is supported in all modern browsers. In older ones, we polyfill
 // it in the application route at app startup.
-const Format = new Intl.DateTimeFormat('us-EN', {
+const Format = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
   month: 'short',
   day: 'numeric',

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -21,6 +21,7 @@ import type {
 } from 'https://cardstack.com/base/card-api';
 import BoxelInput from '@cardstack/boxel-ui/components/input';
 import { shimExternals } from '@cardstack/host/lib/externals';
+import format from 'date-fns/format';
 
 let cardApi: typeof import('https://cardstack.com/base/card-api');
 let string: typeof import('https://cardstack.com/base/string');
@@ -1179,8 +1180,9 @@ module('Integration | card-basics', function (hooks) {
     let { field, containsMany, Card, Component } = cardApi;
     let { default: DateCard } = date;
     let { default: DatetimeCard } = datetime;
+
     function toDateString(date: Date | null) {
-      return date instanceof Date ? date.toISOString().split('T')[0] : null;
+      return date instanceof Date ? format(date, 'yyyy-MM-dd') : null;
     }
 
     class Person extends Card {


### PR DESCRIPTION
This fixes a considerable amount of failing tests when I run it on my machine with Central Europe locality. For example:

<img width="712" alt="image" src="https://user-images.githubusercontent.com/273660/230580067-71c9a8de-838d-4bfd-9b7d-6d4d9dc54b84.png">

I spent some time trying to fix this by adding strict date formatting - by replacing occurrences of `< @fields.dateField />` with something like `{{format @model.dateField ...}}` but then I discovered we already enforce locality using `Intl.DateTimeFormat`, and I noticed the locality code is wrong. Probably it just uses the local one in case it doesn't recognize the one given in the args. Now tests should pass in any locality. 