### PR TITLE
Loader Deadlock fix

### DIFF
--- a/packages/host/app/components/card-prerender.gts
+++ b/packages/host/app/components/card-prerender.gts
@@ -84,9 +84,9 @@ export default class CardPrerender extends Component {
       this.loaderService.loader,
       baseRealm.url
     );
-    await Promise.all(
-      baseRealmModules.map((m) => this.loaderService.loader.import(m))
-    );
+    for (let module of baseRealmModules) {
+      await this.loaderService.loader.import(module);
+    }
   });
 
   private doRegistration = enqueueTask(async () => {

--- a/packages/host/app/components/card-prerender.gts
+++ b/packages/host/app/components/card-prerender.gts
@@ -84,11 +84,9 @@ export default class CardPrerender extends Component {
       this.loaderService.loader,
       baseRealm.url
     );
-    // TODO the need to perform this reverse reveals that there is a bug in
-    // our loader around dependency consumption, please investigate more!
-    for (let module of baseRealmModules.reverse()) {
-      await this.loaderService.loader.import(module);
-    }
+    await Promise.all(
+      baseRealmModules.map((m) => this.loaderService.loader.import(m))
+    );
   });
 
   private doRegistration = enqueueTask(async () => {

--- a/packages/realm-server/tests/cards/deadlock/a.js
+++ b/packages/realm-server/tests/cards/deadlock/a.js
@@ -1,0 +1,9 @@
+import { b } from './b';
+
+export function d() {
+  return 'd';
+}
+
+export function a() {
+  return 'a' + b();
+}

--- a/packages/realm-server/tests/cards/deadlock/b.js
+++ b/packages/realm-server/tests/cards/deadlock/b.js
@@ -1,0 +1,6 @@
+import { c } from './c';
+import { d } from './a';
+
+export function b() {
+  return 'b' + c() + d();
+}

--- a/packages/realm-server/tests/cards/deadlock/c.js
+++ b/packages/realm-server/tests/cards/deadlock/c.js
@@ -1,0 +1,3 @@
+export function c() {
+  return 'c';
+}

--- a/packages/realm-server/tests/loader-test.ts
+++ b/packages/realm-server/tests/loader-test.ts
@@ -40,6 +40,19 @@ module('loader', function (hooks) {
     assert.strictEqual(bModule.b(), 'bc', 'module executed successfully');
   });
 
+  test('can resolve a import deadlock', async function (assert) {
+    let loader = new Loader();
+    loader.addURLMapping(
+      new URL(baseRealm.url),
+      new URL('http://localhost:4201/base/')
+    );
+    let a = loader.import<{ a(): string }>(`${testRealm}deadlock/a`);
+    let b = loader.import<{ b(): string }>(`${testRealm}deadlock/b`);
+    let [aModule, bModule] = await Promise.all([a, b]);
+    assert.strictEqual(aModule.a(), 'abcd', 'module executed successfully');
+    assert.strictEqual(bModule.b(), 'bcd', 'module executed successfully');
+  });
+
   test('supports import.meta', async function (assert) {
     let loader = new Loader();
     let realm = await createRealm(

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -574,6 +574,14 @@ module('Realm Server serving from root', function (hooks) {
                 kind: 'file',
               },
             },
+            'deadlock/': {
+              links: {
+                related: `${testRealmHref}deadlock/`,
+              },
+              meta: {
+                kind: 'directory',
+              },
+            },
             'dir/': {
               links: {
                 related: `${testRealmHref}dir/`,


### PR DESCRIPTION
There is an issue in our loader were a deadlock can arise. Specifically if two imports are are issued at exactly the same time where they both consume each other. I added logic to break these deadlocks, as well as to remove the shared module cache (it was problematic). Instead, we'll fallback to the shared transpilation cache for shared module performance improvement (since transpilation is the slowest part of the module import)