### PR TITLE
Realm root URL should return the "index card" of the realm

### DIFF
--- a/packages/demo-cards/cards-grid.gts
+++ b/packages/demo-cards/cards-grid.gts
@@ -1,0 +1,9 @@
+import { Component, Card } from 'https://cardstack.com/base/card-api';
+
+export class CardsGrid extends Card {
+  static isolated = class Isolated extends Component<typeof this> {
+    <template>
+      This cards-grid instance should become even better.
+    </template>
+  };
+}

--- a/packages/demo-cards/index.json
+++ b/packages/demo-cards/index.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {},
+    "meta": {
+      "adoptsFrom": {
+        "module": "./cards-grid",
+        "name": "CardsGrid"
+      }
+    }
+  }
+}

--- a/packages/host/app/components/code-link.gts
+++ b/packages/host/app/components/code-link.gts
@@ -1,0 +1,26 @@
+import Component from '@glimmer/component';
+import { LinkTo } from '@ember/routing';
+
+interface Signature {
+  Args: {};
+}
+
+export default class CodeLink extends Component<Signature> {
+  <template>
+    {{! template-lint-disable no-inline-styles }}
+    <p style='text-align:center;margin:5em auto;' data-test-moved>The card code
+      editor has moved to
+      <LinkTo
+        @route='code'
+        style='color:aqua;font-weight:bold;font-style:italic'
+        data-test-code-link
+      >/code</LinkTo>
+    </p>
+  </template>
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    CodeLink: typeof CodeLink;
+  }
+}

--- a/packages/host/app/router.ts
+++ b/packages/host/app/router.ts
@@ -11,10 +11,12 @@ let path = new URL(ownRealmURL).pathname.replace(/\/$/, '');
 
 Router.map(function () {
   this.route('indexer', { path: '/indexer/:id' });
+  this.route('acceptance-test-setup');
   if (!path || hostsOwnAssets) {
+    this.route('card', { path: '' });
     this.route('code');
   } else {
-    this.route('index', { path });
+    this.route('card', { path });
     this.route('code', { path: `${path}/code` });
   }
   this.route('card', { path: '/*path' });

--- a/packages/host/app/routes/card.ts
+++ b/packages/host/app/routes/card.ts
@@ -35,8 +35,13 @@ export default class RenderCard extends Route<
 
   async model(params: { path: string }) {
     let { path } = params;
-    let url = new URL(`/${path}`, ownRealmURL);
-    let instance = await this.cardService.loadModel(url);
-    return instance.constructor.getComponent(instance, 'isolated');
+    let url = new URL(`/${path || ''}`, ownRealmURL);
+    try {
+      let instance = await this.cardService.loadModel(url);
+      return instance.constructor.getComponent(instance, 'isolated');
+    } catch (e) {
+      (e as any).failureLoadingIndexCard = url.href === ownRealmURL;
+      throw e;
+    }
   }
 }

--- a/packages/host/app/templates/card-error.hbs
+++ b/packages/host/app/templates/card-error.hbs
@@ -1,8 +1,14 @@
 {{!-- template-lint-disable no-inline-styles --}}
 <div data-card-error style="margin: 5em">
-  <b>Cannot load card</b>
+  {{!-- @glint-ignore glint doesn't understand the type for the error template's model --}}
+  {{#if this.model.failureLoadingIndexCard}}
+    <b>Cannot load index card.</b>
+  {{else}}
+    <b>Cannot load card.</b>
+  {{/if}}
   <pre style="overflow-x: auto; white-space: pre-wrap; word-wrap: break-word;">
   {{!-- @glint-ignore glint doesn't understand the type for the error template's model --}}
   {{this.model.message}}
   </pre>
 </div>
+<CodeLink />

--- a/packages/host/app/templates/card.hbs
+++ b/packages/host/app/templates/card.hbs
@@ -1,1 +1,2 @@
 <this.model/>
+<CodeLink />

--- a/packages/host/app/templates/index.hbs
+++ b/packages/host/app/templates/index.hbs
@@ -1,9 +1,4 @@
-{{!-- TODO remove this after we have real content for this template --}}
-{{!-- template-lint-disable no-inline-styles --}}
-<p style="text-align:center;margin:5em auto;" data-test-moved>The card code editor has moved to
-  <LinkTo
-    @route="code"
-    style="color:aqua;font-weight:bold;font-style:italic"
-    data-test-code-link
-  >/code</LinkTo>
+<p>
+  Default Index Route<br>
+  (Probably should never see this.)
 </p>

--- a/packages/host/tests/acceptance/basic-test.ts
+++ b/packages/host/tests/acceptance/basic-test.ts
@@ -25,6 +25,20 @@ function getMonacoContent(): string {
   return (window as any).monaco.editor.getModels()[0].getValue();
 }
 
+const indexCardSource = `
+  import { Card, Component } from "https://cardstack.com/base/card-api";
+
+  export class Index extends Card {
+    static isolated = class Isolated extends Component<typeof this> {
+      <template>
+        <div data-test-index-card>
+          Hello, world!
+        </div>
+      </template>
+    };
+  }
+`;
+
 const personCardSource = `
   import { contains, field, Card } from "https://cardstack.com/base/card-api";
   import StringCard from "https://cardstack.com/base/string";
@@ -52,6 +66,7 @@ module('Acceptance | basic tests', function (hooks) {
     );
     shimExternals();
     adapter = new TestRealmAdapter({
+      'index.gts': indexCardSource,
       'person.gts': personCardSource,
       'person-entry.json': {
         data: {
@@ -68,6 +83,18 @@ module('Acceptance | basic tests', function (hooks) {
             adoptsFrom: {
               module: `${baseRealm.url}catalog-entry`,
               name: 'CatalogEntry',
+            },
+          },
+        },
+      },
+      'index.json': {
+        data: {
+          type: 'card',
+          attributes: {},
+          meta: {
+            adoptsFrom: {
+              module: './index',
+              name: 'Index',
             },
           },
         },
@@ -98,10 +125,22 @@ module('Acceptance | basic tests', function (hooks) {
     await realm.ready;
   });
 
-  test('visiting /', async function (assert) {
+  test('visiting / (there is no realm here)', async function (assert) {
     await visit('/');
 
     assert.strictEqual(currentURL(), '/');
+    assert
+      .dom('[data-test-moved]')
+      .containsText('The card code editor has moved to /code');
+    await click('[data-test-code-link]');
+    assert.strictEqual(currentURL(), '/code');
+  });
+
+  test('visiting realm root', async function (assert) {
+    await visit('/test/');
+
+    assert.strictEqual(currentURL(), '/test/');
+    assert.dom('[data-test-index-card]').containsText('Hello, world');
     assert
       .dom('[data-test-moved]')
       .containsText('The card code editor has moved to /code');

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -80,7 +80,7 @@ export const TestRealm = {
     opts?: Options
   ): Promise<Realm> {
     if (opts?.isAcceptanceTest) {
-      await visit('/');
+      await visit('/acceptance-test-setup');
     } else {
       await makeRenderer();
     }

--- a/packages/realm-server/node-realm.ts
+++ b/packages/realm-server/node-realm.ts
@@ -83,7 +83,11 @@ export class NodeAdapter implements RealmAdapter {
     if (!existsSync(absolutePath)) {
       return undefined;
     }
-    let { mtime } = statSync(absolutePath);
+    let stat = statSync(absolutePath);
+    // Case-insensitive file systems need this check
+    if (stat.isDirectory()) {
+      return undefined;
+    }
     let lazyStream: ReadStream;
     return {
       path,
@@ -96,7 +100,7 @@ export class NodeAdapter implements RealmAdapter {
         }
         return lazyStream;
       },
-      lastModified: mtime.getTime(),
+      lastModified: stat.mtime.getTime(),
     };
   }
 

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -187,13 +187,9 @@ export class Realm {
         SupportedMimeType.CardJson,
         this.patchCard.bind(this)
       )
+      .get('/_search', SupportedMimeType.CardJson, this.search.bind(this))
       .get(
-        '/_search',
-        SupportedMimeType.CardJson,
-        this.search.bind(this)
-      )
-      .get(
-        '/.+(?<!.json)',
+        '/|/.+(?<!.json)',
         SupportedMimeType.CardJson,
         this.getCard.bind(this)
       )
@@ -208,7 +204,7 @@ export class Realm {
         this.upsertCardSource.bind(this)
       )
       .get(
-        '/.+',
+        '/.*',
         SupportedMimeType.CardSource,
         this.getCardSourceOrRedirect.bind(this)
       )
@@ -227,11 +223,7 @@ export class Realm {
         SupportedMimeType.DirectoryListing,
         this.getDirectoryListing.bind(this)
       )
-      .get(
-        '/.*',
-        SupportedMimeType.HTML,
-        this.respondWithHTML.bind(this)
-      );
+      .get('/.*', SupportedMimeType.HTML, this.respondWithHTML.bind(this));
 
     this.#deferStartup = opts?.deferStartUp ?? false;
     if (!opts?.deferStartUp) {
@@ -662,6 +654,9 @@ export class Realm {
 
   private async getCard(request: Request): Promise<Response> {
     let localPath = this.paths.local(request.url);
+    if (localPath === '') {
+      localPath = 'index';
+    }
     let url = this.paths.fileURL(localPath);
     let maybeError = await this.#searchIndex.card(url, { loadLinks: true });
     if (!maybeError) {


### PR DESCRIPTION
Note that an error will be shown when using ember-cli hosted app if local realm is not open yet. There is an issue to address this separately.