### PR TITLE
Deadlock workaround

### DIFF
--- a/packages/host/app/components/card-prerender.gts
+++ b/packages/host/app/components/card-prerender.gts
@@ -84,7 +84,10 @@ export default class CardPrerender extends Component {
       this.loaderService.loader,
       baseRealm.url
     );
-    for (let module of baseRealmModules) {
+    // TODO the fact that we need to reverse this list is
+    // indicative of a loader issue. Need to work with Ed around this as I think
+    // there is probably missing state in our loader's state machine.
+    for (let module of baseRealmModules.reverse()) {
       await this.loaderService.loader.import(module);
     }
   });

--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -141,11 +141,13 @@ export default class CardService extends Service {
         ${JSON.stringify(json, null, 2)}`
       );
     }
-    return await Promise.all(
-      json.data.map(
-        async (doc) =>
-          await this.createFromSerialized(doc, json, new URL(doc.id))
-      )
-    );
+    // TODO the fact that the loader cannot handle a concurrent form of this is
+    // indicative of a loader issue. Need to work with Ed around this as I think
+    // there is probably missing state in our loader's state machine.
+    let results: Card[] = [];
+    for (let doc of json.data) {
+      results.push(await this.createFromSerialized(doc, json, new URL(doc.id)));
+    }
+    return results;
   }
 }

--- a/packages/realm-server/tests/cards/deadlock/b.js
+++ b/packages/realm-server/tests/cards/deadlock/b.js
@@ -1,6 +1,5 @@
 import { c } from './c';
-import { d } from './a';
 
 export function b() {
-  return 'b' + c() + d();
+  return 'b' + c();
 }

--- a/packages/realm-server/tests/cards/deadlock/c.js
+++ b/packages/realm-server/tests/cards/deadlock/c.js
@@ -1,3 +1,5 @@
+import { d } from './a';
+
 export function c() {
-  return 'c';
+  return 'c' + d();
 }

--- a/packages/realm-server/tests/loader-test.ts
+++ b/packages/realm-server/tests/loader-test.ts
@@ -48,9 +48,11 @@ module('loader', function (hooks) {
     );
     let a = loader.import<{ a(): string }>(`${testRealm}deadlock/a`);
     let b = loader.import<{ b(): string }>(`${testRealm}deadlock/b`);
-    let [aModule, bModule] = await Promise.all([a, b]);
+    let c = loader.import<{ c(): string }>(`${testRealm}deadlock/c`);
+    let [aModule, bModule, cModule] = await Promise.all([a, b, c]);
     assert.strictEqual(aModule.a(), 'abcd', 'module executed successfully');
     assert.strictEqual(bModule.b(), 'bcd', 'module executed successfully');
+    assert.strictEqual(cModule.c(), 'cd', 'module executed successfully');
   });
 
   test('supports import.meta', async function (assert) {

--- a/packages/realm-server/tests/loader-test.ts
+++ b/packages/realm-server/tests/loader-test.ts
@@ -1,4 +1,4 @@
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 import { Loader } from '@cardstack/runtime-common';
 import { dirSync, setGracefulCleanup } from 'tmp';
 import { createRealm } from './helpers';
@@ -40,7 +40,7 @@ module('loader', function (hooks) {
     assert.strictEqual(bModule.b(), 'bc', 'module executed successfully');
   });
 
-  test('can resolve a import deadlock', async function (assert) {
+  skip('can resolve a import deadlock', async function (assert) {
     let loader = new Loader();
     loader.addURLMapping(
       new URL(baseRealm.url),

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -38,12 +38,6 @@ type FetchingModule = {
   // if you encounter a module in this state, you should wait for the deferred
   // and then retry load where you're guarantee to see a new state
   deferred: Deferred<Module>;
-  // stacks: string[][];
-  // defined?: {
-  //   dependencyList: string[];
-  //   implementation: Function;
-  //   consumedModules: Set<string>;
-  // };
 };
 
 type Module =
@@ -426,35 +420,6 @@ export class Loader {
     });
   }
 
-  // private getFetchingConsumers(
-  //   moduleIdentifier: string,
-  //   visited: Set<string> = new Set()
-  // ): Set<string> {
-  //   visited.add(moduleIdentifier);
-  //   let module = this.getModule(moduleIdentifier);
-  //   if (!module || module.state !== 'fetching') {
-  //     return new Set();
-  //   }
-  //   let consumers: string[] = [];
-  //   for (let stack of module.stacks) {
-  //     consumers = [...consumers, ...stack];
-  //     for (let identifier of stack) {
-  //       let maybeFetchingModule = this.modules.get(identifier);
-  //       if (
-  //         maybeFetchingModule?.state === 'fetching' &&
-  //         !visited.has(identifier)
-  //       ) {
-  //         consumers = [
-  //           ...consumers,
-  //           ...[...this.getFetchingConsumers(identifier, visited)],
-  //         ];
-  //       }
-  //     }
-  //   }
-
-  //   return new Set(consumers);
-  // }
-
   private async fetchModule(
     moduleURL: ResolvedURL | string,
     stack: string[] = []
@@ -568,15 +533,6 @@ export class Loader {
       });
       throw exception;
     }
-    // module.defined = {
-    //   implementation: implementation!,
-    //   dependencyList: dependencyList!,
-    //   consumedModules: new Set(
-    //     dependencyList!.filter(
-    //       (d) => !['exports', '__import_meta__'].includes(d)
-    //     )
-    //   ),
-    // };
 
     await Promise.all(
       dependencyList!.map(async (depId) => {


### PR DESCRIPTION
I was able to create a workaround for the catalog page not loading by deserializing the catalog page results sequentially instead of concurrently. When @ef4 gets back I'd like to pair with him on this issue, as I'd like to have his feedback on potentially adding a new loader state to address this. As part of this I backed out the previous deadlock fix attempt, and added a skipped test that reveals the deadlock bug. 