### PR TITLE
Service worker is undefined bug

### DIFF
--- a/packages/worker/src/main.ts
+++ b/packages/worker/src/main.ts
@@ -68,7 +68,7 @@ worker.addEventListener('install', () => {
 worker.addEventListener('activate', () => {
   // takes over when there is *no* existing service worker
   worker.clients.claim();
-  log.info('activating service worker');
+  log.info('Activating service worker');
 });
 
 worker.addEventListener('fetch', (event: FetchEvent) => {

--- a/packages/worker/src/main.ts
+++ b/packages/worker/src/main.ts
@@ -61,11 +61,17 @@ let runnerOptsMgr = new RunnerOptionsManager();
 })();
 
 worker.addEventListener('install', () => {
+  console.log('installing service worker...');
   // force moving on to activation even if another service worker had control
-  worker.skipWaiting();
+  // TODO: explore why network request gets stuck in pending state when 'update on reload' is enabled in dev tools (this happens only if there's an open directory)
+  // we may enable skipWaiting if we can figure out the above
+  // currently, enabling skipWaiting is causing inconsistent behavior in the browser (only if there's an open directory)
+  // this means, we need to close all open tabs and open a new tab to get the newest service worker
+  // worker.skipWaiting();
 });
 
 worker.addEventListener('activate', () => {
+  console.log('activating service worker...');
   // takes over when there is *no* existing service worker
   worker.clients.claim();
   log.info('activating service worker');

--- a/packages/worker/src/main.ts
+++ b/packages/worker/src/main.ts
@@ -61,17 +61,11 @@ let runnerOptsMgr = new RunnerOptionsManager();
 })();
 
 worker.addEventListener('install', () => {
-  console.log('installing service worker...');
   // force moving on to activation even if another service worker had control
-  // TODO: explore why network request gets stuck in pending state when 'update on reload' is enabled in dev tools (this happens only if there's an open directory)
-  // we may enable skipWaiting if we can figure out the above
-  // currently, enabling skipWaiting is causing inconsistent behavior in the browser (only if there's an open directory)
-  // this means, we need to close all open tabs and open a new tab to get the newest service worker
-  // worker.skipWaiting();
+  worker.skipWaiting();
 });
 
 worker.addEventListener('activate', () => {
-  console.log('activating service worker...');
   // takes over when there is *no* existing service worker
   worker.clients.claim();
   log.info('activating service worker');

--- a/packages/worker/src/messages.ts
+++ b/packages/worker/src/messages.ts
@@ -157,5 +157,8 @@ interface Destination {
 }
 
 export function send(destination: Destination, message: Message): void {
+  if (!destination) {
+    throw new Error('client or worker message sent with no destination');
+  }
   destination.postMessage(message);
 }


### PR DESCRIPTION
Ticket: [CS-5406](https://linear.app/cardstack/issue/CS-5406/service-worker-is-sometimes-undefined-when-starting-up-app)

There are a couple of reasons the service worker can be undefined, and those were simple to handle. It is in places where we assumed there would definitely be a service worker and used `!` to let typescript know, but that wasn't right.

However, when I handled those, another DX problem reared its head: Whenever there's a new worker installed, Service Worker API's `worker.skipWaiting()` is supposed to let the new worker to take over. This works fine when there's no directory handle, but it does not always work when there's a local realm open and the app sometimes displays strange behavior when it's stuck in this in-between state, until the new worker takes over. There doesn't seem to be a way to enforce `skipWaiting` other than forcing some page reloads.

Update: Team didn't like the reload idea, so this PR is back to WIP. I added more console logging, which will provide more info to the developer, but this does not seem sufficient because sometimes the app get in a state where either:

1-  the fetch is stuck in pending state until it eventually times out. We can currently replicate this behavior in main branch by opening a directory, enabling `Update on reload` for service worker in Application tab in dev tools, and refreshing the page. Resolving this issue would also resolve the issue where `skipWaiting` in our code doesn't work.

2- I don't know if this happens in main, but in this PR every once in a while after I make changes in Worker package, I come across this situation where all the fetches fail until I refresh the page:
<img width="1185" alt="fetch-fail" src="https://user-images.githubusercontent.com/16160806/234913418-65343fec-7bde-4af8-9c96-6573b5ca5df0.png">