### PR TITLE
Only recomputes the field with computeVia function

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -2073,25 +2073,31 @@ export async function recompute(
     );
     do {
       for (let fieldName of [...pendingFields]) {
-        let value = await getIfReady(
-          model,
-          fieldName as keyof T,
-          undefined,
-          opts
-        );
-        if (!isNotReadyValue(value) && !isStaleValue(value)) {
-          pendingFields.delete(fieldName);
-          if (recomputePromises.get(card) !== recomputePromise) {
-            return;
-          }
-          if (Array.isArray(value)) {
-            for (let item of value) {
-              if (item && isCard(item) && !stack.includes(item)) {
-                await _loadModel(item, [item, ...stack]);
-              }
+        let field = getField(
+          Reflect.getPrototypeOf(model)!.constructor as typeof Card,
+          fieldName as string
+        ) as Field;
+        if (field.computeVia) {
+          let value = await getIfReady(
+            model,
+            fieldName as keyof T,
+            undefined,
+            opts
+          );
+          if (!isNotReadyValue(value) && !isStaleValue(value)) {
+            pendingFields.delete(fieldName);
+            if (recomputePromises.get(card) !== recomputePromise) {
+              return;
             }
-          } else if (isCard(value) && !stack.includes(value)) {
-            await _loadModel(value, [value, ...stack]);
+            if (Array.isArray(value)) {
+              for (let item of value) {
+                if (item && isCard(item) && !stack.includes(item)) {
+                  await _loadModel(item, [item, ...stack]);
+                }
+              }
+            } else if (isCard(value) && !stack.includes(value)) {
+              await _loadModel(value, [value, ...stack]);
+            }
           }
         }
       }

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -2073,28 +2073,28 @@ export async function recompute(
     );
     do {
       for (let fieldName of [...pendingFields]) {
-          let value = await getIfReady(
-            model,
-            fieldName as keyof T,
-            undefined,
-            opts
-          );
-          if (!isNotReadyValue(value) && !isStaleValue(value)) {
-            pendingFields.delete(fieldName);
-            if (recomputePromises.get(card) !== recomputePromise) {
-              return;
-            }
-            if (Array.isArray(value)) {
-              for (let item of value) {
-                if (item && isCard(item) && !stack.includes(item)) {
-                  await _loadModel(item, [item, ...stack]);
-                }
+        let value = await getIfReady(
+          model,
+          fieldName as keyof T,
+          undefined,
+          opts
+        );
+        if (!isNotReadyValue(value) && !isStaleValue(value)) {
+          pendingFields.delete(fieldName);
+          if (recomputePromises.get(card) !== recomputePromise) {
+            return;
+          }
+          if (Array.isArray(value)) {
+            for (let item of value) {
+              if (item && isCard(item) && !stack.includes(item)) {
+                await _loadModel(item, [item, ...stack]);
               }
-            } else if (isCard(value) && !stack.includes(value)) {
-              await _loadModel(value, [value, ...stack]);
             }
+          } else if (isCard(value) && !stack.includes(value)) {
+            await _loadModel(value, [value, ...stack]);
           }
         }
+      }
       // TODO should we have a timeout?
     } while (pendingFields.size > 0);
   }

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -2150,11 +2150,8 @@ export async function getIfReady<T extends Card, K extends keyof T>(
     //if it is not an async function. 
     //This ensures that other functions are not executed 
     //by the runtime before this function is finished.
-    if (typeof compute === 'function' && compute.constructor.name === 'AsyncFunction') {
-      result = await compute();
-    } else {
-      result = compute() as T[K];
-    }
+    let computeResult = compute();
+    result = computeResult instanceof Promise ? await computeResult : computeResult;
   } catch (e: any) {
     if (isNotLoadedError(e)) {
       let card = Reflect.getPrototypeOf(instance)!.constructor as typeof Card;

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -2177,7 +2177,7 @@ export async function getIfReady<T extends Card, K extends keyof T>(
   }
 
   //Only update the value of computed field.
-  if (field.computeVia) {
+  if (field?.computeVia) {
     deserialized.set(fieldName as string, result);
   }
   return result;


### PR DESCRIPTION
Ticket: CS-5557

Previously, we recompute all fields (non-computed and computed fields) after setting the value to a field. This causes a race condition because the field's value in the data bucket will be updated in two places asynchronously in the setter property of the field and recompute function. 

This PR fixes that issue by recomputing only the field with computeVia.