### PR TITLE
Wait until realm is finished indexing before trying to fetch a card

### DIFF
--- a/packages/host/app/components/in-local-realm.gts
+++ b/packages/host/app/components/in-local-realm.gts
@@ -54,8 +54,9 @@ export default class InLocalRealm extends Component<Signature> {
   }
 
   @action
-  openRealm() {
-    this.localRealm.chooseDirectory(() => this.router.refresh());
+  async openRealm() {
+    await this.localRealm.chooseDirectory();
+    await this.router.refresh();
   }
 
   @action

--- a/packages/host/app/controllers/card.ts
+++ b/packages/host/app/controllers/card.ts
@@ -19,11 +19,8 @@ export default class CardController extends Controller {
   @tracked model: Model | undefined;
 
   get getIsolatedComponent() {
-    if (this.model && this.model.card) {
-      return this.model.card.constructor.getComponent(
-        this.model.card,
-        'isolated'
-      );
+    if (this.model) {
+      return this.model.constructor.getComponent(this.model, 'isolated');
     }
 
     return null;

--- a/packages/host/app/controllers/card.ts
+++ b/packages/host/app/controllers/card.ts
@@ -7,18 +7,26 @@ import { action } from '@ember/object';
 
 import { tracked } from '@glimmer/tracking';
 const { isLocalRealm } = ENV;
+import { ComponentLike } from '@glint/template';
+import { Model } from '@cardstack/host/routes/card';
 
 export default class CardController extends Controller {
   isLocalRealm = isLocalRealm;
-  model: any;
+  isolatedCardComponent: ComponentLike | undefined;
   withPreventDefault = withPreventDefault;
   @service declare router: RouterService;
   @tracked operatorModeEnabled = false;
+  @tracked model: Model | undefined;
 
   get getIsolatedComponent() {
-    return this.model.card
-      ? this.model.card.constructor.getComponent(this.model.card, 'isolated')
-      : this.model.component;
+    if (this.model && this.model.card) {
+      return this.model.card.constructor.getComponent(
+        this.model.card,
+        'isolated'
+      );
+    }
+
+    return null;
   }
 
   @action

--- a/packages/host/app/routes/card.gts
+++ b/packages/host/app/routes/card.gts
@@ -10,9 +10,7 @@ import { Card } from 'https://cardstack.com/base/card-api';
 const { ownRealmURL, isLocalRealm } = ENV;
 const rootPath = new URL(ownRealmURL).pathname.replace(/^\//, '');
 
-export interface Model {
-  card: Card;
-}
+export type Model = Card | null;
 
 export default class RenderCard extends Route<Model | null> {
   @service declare cardService: CardService;
@@ -38,7 +36,7 @@ export default class RenderCard extends Route<Model | null> {
     }
   }
 
-  async model(params: { path: string }): Promise<Model | null> {
+  async model(params: { path: string }): Promise<Model> {
     let { path } = params;
     path = path || '';
     let url = path
@@ -59,8 +57,7 @@ export default class RenderCard extends Route<Model | null> {
     }
 
     try {
-      let card = await this.cardService.loadModel(url);
-      return { card };
+      return await this.cardService.loadModel(url);
     } catch (e) {
       (e as any).failureLoadingIndexCard = url.href === ownRealmURL;
       throw e;

--- a/packages/host/app/services/local-realm.ts
+++ b/packages/host/app/services/local-realm.ts
@@ -271,8 +271,8 @@ export default class LocalRealm extends Service {
     return url;
   }
 
-  chooseDirectory(cb?: () => void): void {
-    this.openDirectory.perform(cb);
+  async chooseDirectory(): Promise<void> {
+    await this.openDirectory.perform();
   }
 
   close(): void {
@@ -290,7 +290,7 @@ export default class LocalRealm extends Service {
     };
   }
 
-  private openDirectory = restartableTask(async (cb?: () => void) => {
+  private openDirectory = restartableTask(async () => {
     let handle = await showDirectoryPicker();
 
     // write a sacrificial file in order to prompt the browser to ask the user
@@ -329,9 +329,6 @@ export default class LocalRealm extends Service {
       adapter,
     };
 
-    if (cb) {
-      cb();
-    }
     send(this.state.worker, { type: 'waitForRealmReadiness' });
   });
 

--- a/packages/host/app/templates/card.hbs
+++ b/packages/host/app/templates/card.hbs
@@ -2,7 +2,8 @@
 {{#if this.isLocalRealm}}
   <InLocalRealm as |realm|>
     {{#if realm.connected}}
-      <this.getIsolatedComponent/>
+      <this.getIsolatedComponent />
+
       <LocalRealmFooter
         @connected={{realm.connected}}
         @close={{realm.close}}
@@ -23,16 +24,18 @@
     {{/if}}
   </InLocalRealm>
 {{else}}
-<this.getIsolatedComponent />
+  <this.getIsolatedComponent />
 {{/if}}
 
 <CodeLink />
 
 {{on-key '.' this.toggleOperatorMode}}
 
-{{#if this.operatorModeEnabled}}
+{{#if this.operatorModeEnabled }}
   {{!-- TODO: Rather than a dedicated argument for the first card in the stack, refactor this so that there will be a state that reflects the whole stack --}}
-  <OperatorMode @firstCardInStack={{this.model.card}} />
+  {{#if this.model.card}}
+    <OperatorMode @firstCardInStack={{this.model.card}} />
+  {{/if}}
 {{/if}}
 
 {{outlet}}

--- a/packages/host/app/templates/card.hbs
+++ b/packages/host/app/templates/card.hbs
@@ -33,8 +33,8 @@
 
 {{#if this.operatorModeEnabled }}
   {{!-- TODO: Rather than a dedicated argument for the first card in the stack, refactor this so that there will be a state that reflects the whole stack --}}
-  {{#if this.model.card}}
-    <OperatorMode @firstCardInStack={{this.model.card}} />
+  {{#if this.model}}
+    <OperatorMode @firstCardInStack={{this.model}} />
   {{/if}}
 {{/if}}
 

--- a/packages/worker/src/fetch.ts
+++ b/packages/worker/src/fetch.ts
@@ -10,6 +10,12 @@ export class FetchHandler {
 
   constructor(private livenessWatcher?: { alive: boolean }) {}
 
+  async waitForReadiness() {
+    if (this.realm) {
+      await this.realm.ready;
+    }
+  }
+
   addRealm(realm: Realm) {
     this.realm = realm;
   }

--- a/packages/worker/src/message-handler.ts
+++ b/packages/worker/src/message-handler.ts
@@ -40,7 +40,7 @@ export class MessageHandler {
     );
   }
 
-  handle(event: ExtendableMessageEvent) {
+  async handle(event: ExtendableMessageEvent) {
     let { data, source } = event;
     if (!isClientMessage(data) || !source) {
       return;
@@ -66,6 +66,14 @@ export class MessageHandler {
               type: 'setDirectoryHandleAcknowledged',
             });
           }
+        }
+        return;
+      case 'waitForRealmReadiness':
+        {
+          await this.fetchHandler.waitForReadiness();
+          send(source, {
+            type: 'realmReady',
+          });
         }
         return;
       case 'setEntry':

--- a/packages/worker/src/messages.ts
+++ b/packages/worker/src/messages.ts
@@ -56,18 +56,30 @@ export interface IncrementalCompleted {
   state: SerializableRunState;
 }
 
+export interface waitForRealmReadiness {
+  type: 'waitForRealmReadiness';
+}
+
+export interface realmReady {
+  type: 'realmReady';
+}
+
 export type ClientMessage =
   | RequestDirectoryHandle
   | SetDirectoryHandle
   | SetEntry
   | FromScratchCompleted
-  | IncrementalCompleted;
+  | IncrementalCompleted
+  | waitForRealmReadiness;
+
 export type WorkerMessage =
   | DirectoryHandleResponse
   | SetDirectoryHandleAcknowledged
   | SetEntryAcknowledged
   | StartFromScratchIndex
-  | StartIncrementalIndex;
+  | StartIncrementalIndex
+  | realmReady;
+
 export type Message = ClientMessage | WorkerMessage;
 
 function isMessageLike(
@@ -86,6 +98,8 @@ export function isClientMessage(message: unknown): message is ClientMessage {
     return false;
   }
   switch (message.type) {
+    case 'waitForRealmReadiness':
+      return true;
     case 'getRunStateRequest':
     case 'requestDirectoryHandle':
       return 'realmsServed' in message && Array.isArray(message.realmsServed);
@@ -146,6 +160,8 @@ export function isWorkerMessage(message: unknown): message is WorkerMessage {
         typeof message.operation === 'string' &&
         ['update', 'delete'].includes(message.operation)
       );
+    case 'realmReady':
+      return true;
     default:
       return false;
   }


### PR DESCRIPTION
This is a fix for the issue that happened when the index route tried to load the card when the realm was still performing indexing. This situation happened immediately after registering a new worker and connecting the local realm, which resulted in an error like this:

<img width="529" alt="image" src="https://user-images.githubusercontent.com/273660/235889297-1349dda4-4d8e-4866-9a38-c07fc53b905a.png">

Refreshing the model programatically after a couple of seconds (via ember console) loaded the model successfully which indicated fetching does succeed after indexing is done.

The solution in this PR adds new communication between the worker and the realm where an indication of finished indexing is sent from the worker. Then we wait for that before trying to fetch the card, which solves the described issue.
