### PR TITLE
Add /_info route to realm server

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,5 +23,9 @@ module.exports = {
     '@typescript-eslint/ban-ts-comment': 'off',
     '@typescript-eslint/ban-types': 'off',
     '@typescript-eslint/prefer-as-const': 'off',
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+    ],
   },
 };

--- a/packages/host/tests/integration/search-index-test.ts
+++ b/packages/host/tests/integration/search-index-test.ts
@@ -2487,7 +2487,7 @@ posts/please-ignore-me.json
     }
   });
 
-  test('search index ignored .realm.json file', async function (assert) {
+  test('search index ignores .realm.json file', async function (assert) {
     let realm = await TestRealm.create(
       {
         '.realm.json': `{ name: 'Example Workspace' }`,
@@ -2500,6 +2500,12 @@ posts/please-ignore-me.json
     let indexer = realm.searchIndex;
     let card = await indexer.card(new URL(`${testRealmURL}post`));
     assert.ok(card, 'instance exists');
+    let instance = await indexer.card(new URL(`${testRealmURL}.realm.json`));
+    assert.strictEqual(
+      instance,
+      undefined,
+      'instance does not exist because file is ignored'
+    );
   });
 
   test("incremental indexing doesn't process ignored files", async function (assert) {

--- a/packages/host/tests/integration/search-index-test.ts
+++ b/packages/host/tests/integration/search-index-test.ts
@@ -2487,6 +2487,21 @@ posts/please-ignore-me.json
     }
   });
 
+  test('search index ignored .realm.json file', async function (assert) {
+    let realm = await TestRealm.create(
+      {
+        '.realm.json': `{ name: 'Example Workspace' }`,
+        'post.json': { data: { meta: { adoptsFrom: baseCardRef } } },
+      },
+      this.owner
+    );
+
+    await realm.ready;
+    let indexer = realm.searchIndex;
+    let card = await indexer.card(new URL(`${testRealmURL}post`));
+    assert.ok(card, 'instance exists');
+  });
+
   test("incremental indexing doesn't process ignored files", async function (assert) {
     let realm = await TestRealm.create(
       {

--- a/packages/realm-server/tests/cards/.realm.json
+++ b/packages/realm-server/tests/cards/.realm.json
@@ -1,0 +1,3 @@
+{
+  "name": "Test Realm"
+}

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -408,6 +408,28 @@ module('Realm Server', function (hooks) {
     );
   });
 
+  test('serves a /_info GET request', async function (assert) {
+    let response = await request
+      .get(`/_info`)
+      .set('Accept', 'application/vnd.api+json');
+
+    assert.strictEqual(response.status, 200, 'HTTP 200 status');
+    let json = response.body;
+    assert.deepEqual(
+      json,
+      {
+        data: {
+          id: testRealmHref,
+          type: 'realm-info',
+          attributes: {
+            name: 'Test Realm',
+          },
+        },
+      },
+      '/_info response is correct'
+    );
+  });
+
   test('can dynamically load a card definition from own realm', async function (assert) {
     let loader = Loader.createLoaderFromGlobal();
     let ref = {
@@ -518,6 +540,14 @@ module('Realm Server serving from root', function (hooks) {
           id: testRealmHref,
           type: 'directory',
           relationships: {
+            '.realm.json': {
+              links: {
+                related: 'http://127.0.0.1:4444/.realm.json',
+              },
+              meta: {
+                kind: 'file',
+              },
+            },
             'a.js': {
               links: {
                 related: `${testRealmHref}a.js`,

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -540,14 +540,6 @@ module('Realm Server serving from root', function (hooks) {
           id: testRealmHref,
           type: 'directory',
           relationships: {
-            '.realm.json': {
-              links: {
-                related: 'http://127.0.0.1:4444/.realm.json',
-              },
-              meta: {
-                kind: 'file',
-              },
-            },
             'a.js': {
               links: {
                 related: `${testRealmHref}a.js`,

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -805,7 +805,6 @@ export class Realm {
     });
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   private async realmInfo(_request: Request): Promise<Response> {
     let fileURL = this.paths.fileURL(`.realm.json`);
     let localPath: LocalPath = this.paths.local(fileURL);
@@ -831,7 +830,7 @@ export class Realm {
       },
     };
     return createResponse(JSON.stringify(doc, null, 2), {
-      headers: { 'content-type': SupportedMimeType.CardJson },
+      headers: { 'content-type': SupportedMimeType.RealmInfo },
     });
   }
 

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -187,6 +187,7 @@ export class Realm {
         SupportedMimeType.CardJson,
         this.patchCard.bind(this)
       )
+      .get('/_info', SupportedMimeType.RealmInfo, this.realmInfo.bind(this))
       .get('/_search', SupportedMimeType.CardJson, this.search.bind(this))
       .get(
         '/|/.+(?<!.json)',
@@ -799,6 +800,36 @@ export class Realm {
       parseQueryString(new URL(request.url).search.slice(1)),
       { loadLinks: true }
     );
+    return createResponse(JSON.stringify(doc, null, 2), {
+      headers: { 'content-type': SupportedMimeType.CardJson },
+    });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  private async realmInfo(_request: Request): Promise<Response> {
+    let fileURL = this.paths.fileURL(`.realm.json`);
+    let localPath: LocalPath = this.paths.local(fileURL);
+    let realmConfig = await this.readFileAsText(localPath);
+    let name = 'Unnamed Workspace';
+    if (realmConfig) {
+      try {
+        let realmConfigJson = JSON.parse(realmConfig.content);
+        if (realmConfigJson.name) {
+          name = realmConfigJson.name;
+        }
+      } catch (e) {
+        this.#log.warn(`failed to parse realm config: ${e}`);
+      }
+    }
+    let doc = {
+      data: {
+        id: this.paths.url.toString(),
+        type: 'realm-info',
+        attributes: {
+          name,
+        },
+      },
+    };
     return createResponse(JSON.stringify(doc, null, 2), {
       headers: { 'content-type': SupportedMimeType.CardJson },
     });

--- a/packages/runtime-common/router.ts
+++ b/packages/runtime-common/router.ts
@@ -8,6 +8,7 @@ export enum SupportedMimeType {
   CardJson = 'application/vnd.card+json',
   CardSource = 'application/vnd.card+source',
   DirectoryListing = 'application/vnd.api+json',
+  RealmInfo = 'application/vnd.api+json',
   EventStream = 'text/event-stream',
   HTML = 'text/html',
 }

--- a/packages/runtime-common/search-index.ts
+++ b/packages/runtime-common/search-index.ts
@@ -755,6 +755,9 @@ export function isIgnored(
   if (url.href === realmURL.href) {
     return false; // you can't ignore the entire realm
   }
+  if (url.href === realmURL.href + '.realm.json') {
+    return true;
+  }
   if (ignoreMap.size === 0) {
     return false;
   }


### PR DESCRIPTION
- Returns JSON-API doc with realm metadata (name for now) that is configured via a .realm.json file at the root of the realm