### PR TITLE
remove unnecessary code interfering with build

### DIFF
--- a/packages/boxel-ui/addon/helpers/element.ts
+++ b/packages/boxel-ui/addon/helpers/element.ts
@@ -1,6 +1,5 @@
 /* eslint-disable ember/no-classic-components */
 import EmberComponent from '@ember/component';
-import { ensureSafeComponent } from '@embroider/util';
 import { ComponentLike } from '@glint/template';
 
 interface Signature<T extends keyof HTMLElementTagNameMap> {
@@ -11,10 +10,7 @@ interface Signature<T extends keyof HTMLElementTagNameMap> {
 export default function element<T extends keyof HTMLElementTagNameMap>(
   tagName: T | undefined
 ): ComponentLike<Signature<T>> {
-  return ensureSafeComponent(
-    class DynamicElement extends EmberComponent<Signature<T>> {
-      tagName = (tagName ?? ('div' as T)) as string;
-    },
-    undefined
-  ) as ComponentLike<Signature<T>>;
+  return class DynamicElement extends EmberComponent<Signature<T>> {
+    tagName = (tagName ?? ('div' as T)) as string;
+  };
 }

--- a/packages/boxel-ui/package.json
+++ b/packages/boxel-ui/package.json
@@ -46,7 +46,6 @@
     "@ember/test-helpers": "^2.8.1",
     "@embroider/compat": "^1.8.3",
     "@embroider/macros": "^1.10.0",
-    "@embroider/util": "^1.9.0",
     "@embroider/webpack": "^1.5.0",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -515,7 +515,6 @@ importers:
       '@ember/test-helpers': ^2.8.1
       '@embroider/compat': ^1.8.3
       '@embroider/macros': ^1.10.0
-      '@embroider/util': ^1.9.0
       '@embroider/webpack': ^1.5.0
       '@glimmer/component': ^1.1.2
       '@glimmer/tracking': ^1.1.2
@@ -611,7 +610,6 @@ importers:
       '@ember/test-helpers': 2.8.1_mjl3znqfqz4o673rlet2hb3jru
       '@embroider/compat': 1.9.0
       '@embroider/macros': 1.10.0
-      '@embroider/util': 1.9.0_ember-source@4.6.0
       '@embroider/webpack': 1.9.0_webpack@5.75.0
       '@glimmer/component': 1.1.2_@babel+core@7.20.2
       '@glimmer/tracking': 1.1.2
@@ -5381,7 +5379,7 @@ packages:
   /@types/ember__controller/4.0.3:
     resolution: {integrity: sha512-7+Lpgcsa/gjGZtUN0JfQoLzUStCT68p8o6t1e4LBXyC+a5DHg2NJYFZ0U3f8F8TgQJcgtFoUAuv8p77XY6FxwQ==}
     dependencies:
-      '@types/ember__object': 4.0.5_@babel+core@7.20.2
+      '@types/ember__object': 4.0.5
     dev: true
 
   /@types/ember__controller/4.0.3_@babel+core@7.20.2:
@@ -7148,7 +7146,7 @@ packages:
       '@babel/core': ^7.0.0
       webpack: '>=2'
     dependencies:
-      '@babel/core': 7.20.2_supports-color@8.1.1
+      '@babel/core': 7.20.2
       find-cache-dir: 3.3.2
       loader-utils: 2.0.4
       make-dir: 3.1.0
@@ -8982,7 +8980,7 @@ packages:
       mississippi: 3.0.0
       mkdirp: 0.5.6
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1_bluebird@3.7.2
+      promise-inflight: 1.0.1
       rimraf: 2.7.1
       ssri: 6.0.2
       unique-filename: 1.1.1
@@ -12558,7 +12556,7 @@ packages:
       '@ember/test-helpers':
         optional: true
     dependencies:
-      '@ember/test-helpers': 2.8.1_c3ll764h35tb7zumth7bce2v2e
+      '@ember/test-helpers': 2.8.1_mjl3znqfqz4o673rlet2hb3jru
       '@embroider/addon-shim': 1.8.3
       ember-destroyable-polyfill: 2.0.3_@babel+core@7.20.2
       ember-modifier: 3.2.7_@babel+core@7.20.2
@@ -18981,17 +18979,6 @@ packages:
     peerDependenciesMeta:
       bluebird:
         optional: true
-    dev: true
-
-  /promise-inflight/1.0.1_bluebird@3.7.2:
-    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
-    peerDependencies:
-      bluebird: '*'
-    peerDependenciesMeta:
-      bluebird:
-        optional: true
-    dependencies:
-      bluebird: 3.7.2
     dev: true
 
   /promise-map-series/0.2.3:


### PR DESCRIPTION
the build was breaking because `@embroider/util` was being used in the addon but set as a devDependency so it was never exported--it was just working up til now by coincidence. But moreover, we don't actually need `ensureSafeComponent` anymore.