### PR TITLE
Fix cannot close edit view after saving

### DIFF
--- a/packages/host/app/components/operator-mode.gts
+++ b/packages/host/app/components/operator-mode.gts
@@ -116,8 +116,8 @@ export default class OperatorMode extends Component<Signature> {
     await this.saveCardFieldValues(card);
     let updatedCard = await this.write.perform(card);
 
-    if (updatedCard && request) {
-      request.fulfill(updatedCard);
+    if (updatedCard) {
+      request?.fulfill(updatedCard);
       let index = this.stack.indexOf(item);
       this.stack[index] = {
         card: updatedCard,


### PR DESCRIPTION
While verifying this [ticket](https://linear.app/cardstack/issue/CS-5440/stack-ux-creating-new-blog-post-from-publishing-packet-card#comment-e85717a5), I encountered a minor bug where I am unable to return to the isolated view after clicking the save button in the edit view of operator mode.