### PR TITLE
ci: Change lint to proceed despite failures

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,18 +22,24 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
       - name: Lint Boxel Motion
+        # This addition to each step causes the job to proceed even if one lint job fails so we can see all errors
+        if: always()
         run: pnpm run lint
         working-directory: packages/boxel-motion
       - name: Lint Boxel Motion Test App
+        if: always()
         run: pnpm run lint
         working-directory: packages/boxel-motion-test-app
       - name: Lint Boxel Motion Demo App
+        if: always()
         run: pnpm run lint
         working-directory: packages/boxel-motion-demo-app
       - name: Lint Host
+        if: always()
         run: pnpm run lint
         working-directory: packages/host
       - name: Lint Realm Server
+        if: always()
         run: pnpm run lint
         working-directory: packages/realm-server
   boxel-motion-test:


### PR DESCRIPTION
This is a developer experience improvement I’ve extracted from #337 because it’s nice to see all lint errors at once instead of early failure.