### PR TITLE
Not-loaded linked field error

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -865,9 +865,7 @@ class LinksTo<CardT extends CardConstructor> implements Field<CardT> {
     e: NotLoaded,
     opts?: RecomputeOptions
   ): Promise<CardInstanceType<CardT> | undefined> {
-    let result: CardInstanceType<CardT> | undefined;
     let deserialized = getDataBucket(instance as CardBase);
-
     let identityContext =
       identityContexts.get(instance as CardBase) ?? new IdentityContext();
     // taking advantage of the identityMap regardless of whether loadFields is set
@@ -879,17 +877,17 @@ class LinksTo<CardT extends CardConstructor> implements Field<CardT> {
     }
 
     if (opts?.loadFields) {
-      let fieldValue = await this.loadMissingField(
+      fieldValue = await this.loadMissingField(
         instance,
         e,
         identityContext,
         instance[relativeTo]
       );
       deserialized.set(this.name, fieldValue);
-      result = fieldValue as CardInstanceType<CardT>;
+      return fieldValue as CardInstanceType<CardT>;
     }
 
-    return result;
+    return;
   }
 
   private async loadMissingField(
@@ -2214,10 +2212,10 @@ export async function getIfReady<T extends CardBase, K extends keyof T>(
       let card = Reflect.getPrototypeOf(instance)!
         .constructor as typeof CardBase;
       let field: Field = getField(card, fieldName as string)!;
-      return field.handleNotLoadedError(instance, e, opts) as
-        | T[K]
-        | T[K][]
-        | undefined;
+      return (await field.handleNotLoadedError(instance, e, {
+        loadFields: true,
+        ...opts,
+      })) as T[K] | T[K][] | undefined;
     } else if (isNotReadyError(e)) {
       let { instance: depModel, computeVia, fieldName: depField } = e;
       let nestedCompute =

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -2212,10 +2212,10 @@ export async function getIfReady<T extends CardBase, K extends keyof T>(
       let card = Reflect.getPrototypeOf(instance)!
         .constructor as typeof CardBase;
       let field: Field = getField(card, fieldName as string)!;
-      return (await field.handleNotLoadedError(instance, e, {
-        loadFields: true,
-        ...opts,
-      })) as T[K] | T[K][] | undefined;
+      return (await field.handleNotLoadedError(instance, e, opts)) as
+        | T[K]
+        | T[K][]
+        | undefined;
     } else if (isNotReadyError(e)) {
       let { instance: depModel, computeVia, fieldName: depField } = e;
       let nestedCompute =

--- a/packages/demo-cards/CatalogEntry/8.json
+++ b/packages/demo-cards/CatalogEntry/8.json
@@ -2,10 +2,10 @@
   "data": {
     "type": "card",
     "attributes": {
-      "title": "PublishingPacket from http://localhost:4200/publishing-packet",
-      "description": "Catalog entry for PublishingPacket from http://localhost:4200/publishing-packet",
+      "title": "PublishingPacket from ../publishing-packet",
+      "description": "Catalog entry for PublishingPacket from ../publishing-packet",
       "ref": {
-        "module": "http://localhost:4200/publishing-packet",
+        "module": "../publishing-packet",
         "name": "PublishingPacket"
       },
       "demo": {
@@ -15,7 +15,7 @@
     "relationships": {
       "demo.blogPost": {
         "links": {
-          "self": "http://localhost:4200/BlogPost/1"
+          "self": "../BlogPost/1"
         }
       }
     },
@@ -23,7 +23,7 @@
       "fields": {
         "demo": {
           "adoptsFrom": {
-            "module": "http://localhost:4200/publishing-packet",
+            "module": "../publishing-packet",
             "name": "PublishingPacket"
           }
         }

--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -81,7 +81,10 @@ export default class CardService extends Service {
     // being able to inform us of which fields are used or not at this point.
     // (this is something that the card compiler could optimize for us in the
     // future)
-    await this.api.recompute(card, { recomputeAllFields: true });
+    await this.api.recompute(card, {
+      recomputeAllFields: true,
+      loadFields: true,
+    });
     return card as Card;
   }
 

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -328,43 +328,6 @@ module('Integration | operator-mode', function (hooks) {
           @field socialBlurb = contains(TextAreaCard);
         }
       `,
-      'Author/1.json': {
-        data: {
-          type: 'card',
-          attributes: {
-            firstName: 'Alien',
-            lastName: 'Bob',
-          },
-          meta: {
-            adoptsFrom: {
-              module: '../author',
-              name: 'Author',
-            },
-          },
-        },
-      },
-      'BlogPost/1.json': {
-        data: {
-          type: 'card',
-          attributes: {
-            title: 'Outer Space Journey',
-            body: 'Hello world',
-          },
-          relationships: {
-            authorBio: {
-              links: {
-                self: '../Author/1',
-              },
-            },
-          },
-          meta: {
-            adoptsFrom: {
-              module: '../blog-post',
-              name: 'BlogPost',
-            },
-          },
-        },
-      },
       'CatalogEntry/publishing-packet.json': {
         data: {
           type: 'card',
@@ -402,6 +365,28 @@ module('Integration | operator-mode', function (hooks) {
           },
         },
       },
+      'BlogPost/1.json': {
+        data: {
+          type: 'card',
+          attributes: {
+            title: 'Outer Space Journey',
+            body: 'Hello world',
+          },
+          relationships: {
+            authorBio: {
+              links: {
+                self: '../Author/1',
+              },
+            },
+          },
+          meta: {
+            adoptsFrom: {
+              module: '../blog-post',
+              name: 'BlogPost',
+            },
+          },
+        },
+      },
       'BlogPost/2.json': {
         data: {
           type: 'card',
@@ -419,6 +404,21 @@ module('Integration | operator-mode', function (hooks) {
             adoptsFrom: {
               module: '../blog-post',
               name: 'BlogPost',
+            },
+          },
+        },
+      },
+      'Author/1.json': {
+        data: {
+          type: 'card',
+          attributes: {
+            firstName: 'Alien',
+            lastName: 'Bob',
+          },
+          meta: {
+            adoptsFrom: {
+              module: '../author',
+              name: 'Author',
             },
           },
         },

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -328,6 +328,43 @@ module('Integration | operator-mode', function (hooks) {
           @field socialBlurb = contains(TextAreaCard);
         }
       `,
+      'Author/1.json': {
+        data: {
+          type: 'card',
+          attributes: {
+            firstName: 'Alien',
+            lastName: 'Bob',
+          },
+          meta: {
+            adoptsFrom: {
+              module: '../author',
+              name: 'Author',
+            },
+          },
+        },
+      },
+      'BlogPost/1.json': {
+        data: {
+          type: 'card',
+          attributes: {
+            title: 'Outer Space Journey',
+            body: 'Hello world',
+          },
+          relationships: {
+            authorBio: {
+              links: {
+                self: '../Author/1',
+              },
+            },
+          },
+          meta: {
+            adoptsFrom: {
+              module: '../blog-post',
+              name: 'BlogPost',
+            },
+          },
+        },
+      },
       'CatalogEntry/publishing-packet.json': {
         data: {
           type: 'card',
@@ -365,28 +402,6 @@ module('Integration | operator-mode', function (hooks) {
           },
         },
       },
-      'BlogPost/1.json': {
-        data: {
-          type: 'card',
-          attributes: {
-            title: 'Outer Space Journey',
-            body: 'Hello world',
-          },
-          relationships: {
-            authorBio: {
-              links: {
-                self: '../Author/1',
-              },
-            },
-          },
-          meta: {
-            adoptsFrom: {
-              module: '../blog-post',
-              name: 'BlogPost',
-            },
-          },
-        },
-      },
       'BlogPost/2.json': {
         data: {
           type: 'card',
@@ -404,21 +419,6 @@ module('Integration | operator-mode', function (hooks) {
             adoptsFrom: {
               module: '../blog-post',
               name: 'BlogPost',
-            },
-          },
-        },
-      },
-      'Author/1.json': {
-        data: {
-          type: 'card',
-          attributes: {
-            firstName: 'Alien',
-            lastName: 'Bob',
-          },
-          meta: {
-            adoptsFrom: {
-              module: '../author',
-              name: 'Author',
             },
           },
         },


### PR DESCRIPTION
@tintinthong The change I made (passing in `loadFields: true`) resolved the not-loaded field error we were seeing on the catalog entry for publishing packet. But I wasn't able to reproduce the error we see in the browser in the tests.

- I'm not sure if the check for `loadFields` option is really needed in `handleNotLoadedError` for `LinksTo` field, but taking it out made logging very loud when running tests.
- Loud error messages (but not real errors?) about not-found linksTo field cards is also why I changed the order in operator-mode-tests.