### PR TITLE
Operator mode styling improvements

### DIFF
--- a/packages/base/cards-grid.gts
+++ b/packages/base/cards-grid.gts
@@ -16,7 +16,7 @@ import { fn } from '@ember/helper';
 
 class Isolated extends Component<typeof CardsGrid> {
   <template>
-    <CardContainer class='cards-grid'>
+    <div class='cards-grid'>
       <ul class='cards-grid__cards'>
         {{#each this.request.instances as |card|}}
           <li
@@ -61,7 +61,7 @@ class Isolated extends Component<typeof CardsGrid> {
           data-test-create-new-card-button
         />
       {{/if}}
-    </CardContainer>
+    </div>
   </template>
 
   @tracked request?: {

--- a/packages/boxel-ui/addon/components/header/index.gts
+++ b/packages/boxel-ui/addon/components/header/index.gts
@@ -30,7 +30,7 @@ const Header: TemplateOnlyComponent<Signature> = <template>
     ...attributes
   >
     {{#if (or @label @title)}}
-      <div>
+      <div data-test-boxel-header-title>
         {{#if @label}}<Label
             data-test-boxel-header-label
           >{{@label}}</Label>{{/if}}

--- a/packages/boxel-ui/addon/styles/components/header.css
+++ b/packages/boxel-ui/addon/styles/components/header.css
@@ -2,6 +2,7 @@
 in the gts template when css-encapsulation is enabled */
 
 .boxel-header {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -29,6 +30,9 @@ in the gts template when css-encapsulation is enabled */
   background-color: var(--boxel-highlight);
 }
 .boxel-header__content {
+  position: absolute;
+  top: 0;
+  right: 0;
   display: flex;
   align-items: center;
 }

--- a/packages/host/app/components/code-link.gts
+++ b/packages/host/app/components/code-link.gts
@@ -9,7 +9,7 @@ export default class CodeLink extends Component<Signature> {
   <template>
     {{! template-lint-disable no-inline-styles }}
     <footer
-      style='text-align:center;margin:1em auto;padding-bottom:50px'
+      style='text-align:center;margin:0 auto;padding-bottom:1em'
       data-test-moved
     >The card code editor has moved to
       <LinkTo @route='code' class='link' data-test-code-link>/code</LinkTo>

--- a/packages/host/app/components/operator-mode.gts
+++ b/packages/host/app/components/operator-mode.gts
@@ -9,7 +9,13 @@ import type CardService from '../services/card-service';
 // import getValueFromWeakMap from '../helpers/get-value-from-weakmap';
 import { eq, not } from '@cardstack/boxel-ui/helpers/truth-helpers';
 import cn from '@cardstack/boxel-ui/helpers/cn';
-import { IconButton, Modal, Header, CardContainer } from '@cardstack/boxel-ui';
+import {
+  IconButton,
+  Modal,
+  Header,
+  CardContainer,
+  Button,
+} from '@cardstack/boxel-ui';
 import SearchSheet, {
   SearchSheetMode,
 } from '@cardstack/host/components/search-sheet';
@@ -339,27 +345,31 @@ export default class OperatorMode extends Component<Signature> {
                 @format={{item.format}}
                 @context={{this.context}}
               />
+              {{#if (eq item.format 'edit')}}
+                <footer class='operator-mode-card-stack__card__footer'>
+                  <Button
+                    @kind='secondary-light'
+                    @size='tall'
+                    class='operator-mode-card-stack__card__footer-button'
+                    {{on 'click' (fn this.cancel item)}}
+                    aria-label='Cancel'
+                    data-test-cancel-button
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    @kind='primary'
+                    @size='tall'
+                    class='operator-mode-card-stack__card__footer-button'
+                    {{on 'click' (fn this.save item)}}
+                    aria-label='Save'
+                    data-test-save-button
+                  >
+                    Save
+                  </Button>
+                </footer>
+              {{/if}}
             </CardContainer>
-            {{#if (eq item.format 'edit')}}
-              <div class='operator-mode-card-stack__card__footer'>
-                <button
-                  class='operator-mode-card-stack__card__footer-button light-button'
-                  {{on 'click' (fn this.cancel item)}}
-                  aria-label='Cancel'
-                  data-test-cancel-button
-                >
-                  Cancel
-                </button>
-                <button
-                  class='operator-mode-card-stack__card__footer-button'
-                  {{on 'click' (fn this.save item)}}
-                  aria-label='Save'
-                  data-test-save-button
-                >
-                  Save
-                </button>
-              </div>
-            {{/if}}
           </div>
         {{/each}}
       </div>

--- a/packages/host/app/components/operator-mode.gts
+++ b/packages/host/app/components/operator-mode.gts
@@ -271,12 +271,12 @@ export default class OperatorMode extends Component<Signature> {
     let invertedIndex = stack.length - index - 1;
 
     let widthReductionPercent = 5; // Every new card on the stack is 5% wider than the previous one
-    let offsetPx = 65; // Every new card on the stack is 65px lower than the previous one
+    let offsetPx = 40; // Every new card on the stack is 40px lower than the previous one
 
     return htmlSafe(`
       width: ${100 - invertedIndex * widthReductionPercent}%;
       z-index: ${stack.length - invertedIndex};
-      margin-top: calc(${offsetPx}px * ${index + 1});
+      padding-top: calc(${offsetPx}px * ${index});
       `);
   }
 
@@ -300,17 +300,15 @@ export default class OperatorMode extends Component<Signature> {
 
         {{#each this.stack as |item i|}}
           <div
-            class='operator-mode-card-stack__card'
+            class='operator-mode-card-stack__item'
             data-test-stack-card-index={{i}}
             data-test-stack-card={{item.card.id}}
             style={{this.styleForStackedCard this.stack i}}
           >
             <CardContainer
               class={{cn
-                'operator-mode-card-stack__card__item'
-                operator-mode-card-stack__card__item_edit=(eq
-                  item.format 'edit'
-                )
+                'operator-mode-card-stack__card'
+                operator-mode-card-stack__card--edit=(eq item.format 'edit')
               }}
             >
               <Header
@@ -340,11 +338,13 @@ export default class OperatorMode extends Component<Signature> {
                   />
                 </:actions>
               </Header>
-              <Preview
-                @card={{item.card}}
-                @format={{item.format}}
-                @context={{this.context}}
-              />
+              <div class='operator-mode-card-stack__card__content'>
+                <Preview
+                  @card={{item.card}}
+                  @format={{item.format}}
+                  @context={{this.context}}
+                />
+              </div>
               {{#if (eq item.format 'edit')}}
                 <footer class='operator-mode-card-stack__card__footer'>
                   <Button

--- a/packages/host/app/components/operator-mode.gts
+++ b/packages/host/app/components/operator-mode.gts
@@ -9,7 +9,7 @@ import type CardService from '../services/card-service';
 // import getValueFromWeakMap from '../helpers/get-value-from-weakmap';
 import { eq, not } from '@cardstack/boxel-ui/helpers/truth-helpers';
 import cn from '@cardstack/boxel-ui/helpers/cn';
-import { IconButton, Modal } from '@cardstack/boxel-ui';
+import { IconButton, Modal, Header, CardContainer } from '@cardstack/boxel-ui';
 import SearchSheet, {
   SearchSheetMode,
 } from '@cardstack/host/components/search-sheet';
@@ -299,7 +299,7 @@ export default class OperatorMode extends Component<Signature> {
             data-test-stack-card={{item.card.id}}
             style={{this.styleForStackedCard this.stack i}}
           >
-            <div
+            <CardContainer
               class={{cn
                 'operator-mode-card-stack__card__item'
                 operator-mode-card-stack__card__item_edit=(eq
@@ -307,38 +307,39 @@ export default class OperatorMode extends Component<Signature> {
                 )
               }}
             >
+              <Header
+                @title={{cardTypeDisplayName item.card}}
+                class='operator-mode-card-stack__card__header'
+              >
+                <:actions>
+                  {{#if (not (eq item.format 'edit'))}}
+                    <IconButton
+                      @icon='icon-horizontal-three-dots'
+                      @width='20px'
+                      @height='20px'
+                      class='icon-button'
+                      aria-label='Edit'
+                      {{on 'click' (fn this.edit item i)}}
+                      data-test-edit-button
+                    />
+                  {{/if}}
+                  <IconButton
+                    @icon='icon-x'
+                    @width='20px'
+                    @height='20px'
+                    class='icon-button'
+                    aria-label='Close'
+                    {{on 'click' (fn this.close item)}}
+                    data-test-close-button
+                  />
+                </:actions>
+              </Header>
               <Preview
                 @card={{item.card}}
                 @format={{item.format}}
                 @context={{this.context}}
               />
-            </div>
-            <div class='operator-mode-card-stack__card__header'>
-              <div
-                class='operator-mode-card-stack__card__header__type'
-                data-type-display-name
-              >{{cardTypeDisplayName item.card}}</div>
-              {{#if (not (eq item.format 'edit'))}}
-                <IconButton
-                  @icon='icon-horizontal-three-dots'
-                  @width='20px'
-                  @height='20px'
-                  class='icon-button'
-                  aria-label='Edit'
-                  {{on 'click' (fn this.edit item i)}}
-                  data-test-edit-button
-                />
-              {{/if}}
-              <IconButton
-                @icon='icon-x'
-                @width='20px'
-                @height='20px'
-                class='icon-button'
-                aria-label='Close'
-                {{on 'click' (fn this.close item)}}
-                data-test-close-button
-              />
-            </div>
+            </CardContainer>
             {{#if (eq item.format 'edit')}}
               <div class='operator-mode-card-stack__card__footer'>
                 <button

--- a/packages/host/app/styles/app.css
+++ b/packages/host/app/styles/app.css
@@ -376,7 +376,7 @@ nav>.directory-level {
 
   position: relative;
   max-width: 70rem;
-  padding: var(--boxel-sp-xxxl) var(--boxel-sp-xl);
+  padding: var(--boxel-sp-xl);
   margin: 0 auto;
 }
 .cards-grid__cards {
@@ -458,27 +458,6 @@ nav>.directory-level {
 
 .operator-mode-card-stack__card {
   position: relative;
-}
-
-.operator-mode-card-stack__card__header {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  padding: var(--boxel-sp-xs);
-
-  display: flex;
-  flex-direction: row;
-}
-
-.operator-mode-card-stack__card__header__type {
-  flex-grow: 1;
-  font: var(--boxel-font-lg);
-}
-
-.operator-mode-card-stack__card__header-item {
-  cursor: pointer;
-  margin-right: 10px;
 }
 
 .operator-mode-card-stack__card__item {

--- a/packages/host/app/styles/app.css
+++ b/packages/host/app/styles/app.css
@@ -376,7 +376,6 @@ nav>.directory-level {
 
   position: relative;
   max-width: 70rem;
-  padding: var(--boxel-sp-xl);
   margin: 0 auto;
 }
 .cards-grid__cards {
@@ -392,9 +391,9 @@ nav>.directory-level {
   cursor: pointer;
 }
 .cards-grid__add-button {
-  position: absolute;
-  right: var(--boxel-sp);
-  bottom: var(--boxel-sp);
+  position: sticky;
+  left: 100%;
+  bottom: 5px;
 }
 .grid-card {
   width: var(--grid-card-width);
@@ -456,26 +455,51 @@ nav>.directory-level {
   align-items: flex-start;
 }
 
+.operator-mode-card-stack {
+  position: relative;
+  height: calc(100% - var(--search-sheet-closed-height));
+  width: 100%;
+  max-width: 50rem;
+  padding-top: var(--boxel-sp-xxl);
+  display: flex;
+  justify-content: center;
+  overflow: hidden;
+  z-index: 0;
+}
+
+.operator-mode-card-stack__item {
+  justify-self: center;
+  position: absolute;
+  width: 89%;
+  height: inherit;
+  z-index: 0;
+  overflow: hidden;
+}
+
 .operator-mode-card-stack__card {
   position: relative;
+  height: 100%;
+  display: grid;
+  grid-template-rows: 7.5rem auto;
+  box-shadow:0 15px 30px 0 rgb(0 0 0 / 35%);
 }
 
-.operator-mode-card-stack__card__item {
-  position: relative;
+.operator-mode-card-stack__card__content {
+  padding: var(--boxel-sp);
+  overflow: auto;
 }
 
-.operator-mode-card-stack__card__item > .boxel-card-container {
-  padding-top: var(--boxel-sp-xxxl);
-}
-
-.operator-mode-card-stack__card__item_edit > .boxel-card-container {
-  padding-bottom: var(--boxel-sp-xxxl);
+.operator-mode-card-stack__card--edit .operator-mode-card-stack__card__content {
+  padding-bottom: 5rem; /* footer height */
 }
 
 .operator-mode-card-stack__card__footer {
+  position: absolute;
+  bottom: 0;
+  right: 0;
   display: flex;
   justify-content: flex-end;
-  padding: var(--boxel-sp-xl);
+  padding: var(--boxel-sp);
 }
 
 .operator-mode-card-stack__card__footer-button + .operator-mode-card-stack__card__footer-button {
@@ -623,27 +647,6 @@ nav>.directory-level {
 
 .search-input__input:focus {
   outline: none;
-}
-
-/* stacked cards */
-.operator-mode-card-stack {
-  position: relative;
-  height: calc(100% - var(--search-sheet-closed-height));
-  width: 100%;
-  max-width: 50rem;
-  display: flex;
-  justify-content: center;
-  overflow: auto;
-  z-index: 0;
-}
-
-.operator-mode-card-stack__card {
-  justify-self: center;
-  position: absolute;
-  width: 89%;
-  z-index: 0;
-  overflow: hidden;
-  box-shadow:0 15px 30px 0 rgb(0 0 0 / 35%);
 }
 
 /* matrix spike */

--- a/packages/host/app/styles/app.css
+++ b/packages/host/app/styles/app.css
@@ -473,44 +473,13 @@ nav>.directory-level {
 }
 
 .operator-mode-card-stack__card__footer {
-  position: absolute;
-  bottom: 0;
-  right: 0;
-  padding: 12px;
-
   display: flex;
-  flex-direction: row;
-
-  z-index: 99;
+  justify-content: flex-end;
+  padding: var(--boxel-sp-xl);
 }
 
-.operator-mode-card-stack__card__footer-button {
-  --button-bg: var(--boxel-teal);
-  --text-color: var(--boxel-light);
-
-  cursor: pointer;
-  width: 95px;
-  margin-right: 10px;
-  padding: var(--boxel-sp-xxxs);
-
-  background-color: var(--button-bg);
-  color: var(--text-color);
-  font-size: var(--boxel-font-size-sm);
-  font-weight: 500;
-
-  border: none;
-  border-radius: var(--boxel-border-radius-lg);
-}
-
-.light-button {
-  --button-bg: var(--boxel-light);
-  --text-color: var(--boxel-dark);
-
-  border: var(--boxel-border)
-}
-
-.operator-mode-card-stack__card__footer-button:hover {
-  --button-bg: var(--boxel-purple-300);
+.operator-mode-card-stack__card__footer-button + .operator-mode-card-stack__card__footer-button {
+  margin-left: var(--boxel-sp-xs);
 }
 
 .operator-mode-overlayed-button {

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -455,18 +455,16 @@ module('Integration | operator-mode', function (hooks) {
     );
 
     await waitFor('[data-test-person]');
-    assert.dom('[data-type-display-name]').hasText('Person');
+    assert.dom('[data-test-boxel-header-title]').hasText('Person');
     assert.dom('[data-test-person]').hasText('Fadhlan');
     assert.dom('[data-test-first-letter-of-the-name]').hasText('F');
     assert.dom('[data-test-city]').hasText('Bandung');
     assert.dom('[data-test-country]').hasText('Indonesia');
-    assert.dom('.operator-mode-card-stack__card').exists({ count: 1 });
+    assert.dom('[data-test-stack-card]').exists({ count: 1 });
     await waitFor('[data-test-cardstack-operator-mode-overlay-button]');
     await click('[data-test-cardstack-operator-mode-overlay-button]');
-    assert.dom('.operator-mode-card-stack__card').exists({ count: 2 });
-    assert
-      .dom('.operator-mode-card-stack__card:nth-of-type(2)')
-      .includesText('Mango');
+    assert.dom('[data-test-stack-card]').exists({ count: 2 });
+    assert.dom('[data-test-stack-card-index="1"]').includesText('Mango');
   });
 
   test("it doesn't change the field value if user clicks cancel in edit view", async function (assert) {
@@ -635,7 +633,7 @@ module('Integration | operator-mode', function (hooks) {
 
     assert.dom(`[data-test-stack-card-index="1"]`).exists(); // Opens card on the stack
     assert
-      .dom(`[data-test-stack-card-index="1"] [data-type-display-name]`)
+      .dom(`[data-test-stack-card-index="1"] [data-test-boxel-header-title]`)
       .includesText('Person');
 
     await click('[data-test-stack-card-index="1"] [data-test-close-button]');


### PR DESCRIPTION
card scrolling and operator mode card chrome improvements: no transparent background issue, headers and buttons are fixed

<img width="936" alt="cards-grid" src="https://github.com/cardstack/boxel/assets/16160806/be90bd16-404d-45d6-9ea7-064eb6999618">

<img width="935" alt="custom-template-edit" src="https://github.com/cardstack/boxel/assets/16160806/40cfd97d-49a1-4be8-90ad-70fb3d79411b">

<img width="929" alt="edit-view" src="https://github.com/cardstack/boxel/assets/16160806/58d7b384-827e-442a-961a-0d9b9d4a69b7">
