### PR TITLE
Add missing dependency date-fns

### DIFF
--- a/packages/realm-server/package.json
+++ b/packages/realm-server/package.json
@@ -24,6 +24,7 @@
     "@types/supertest": "^2.0.12",
     "@types/tmp": "^0.2.3",
     "@types/yargs": "^17.0.10",
+    "date-fns": "^2.28.0",
     "eventsource": "^2.0.2",
     "fastboot": "^4.1.0",
     "flat": "^5.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -992,6 +992,7 @@ importers:
       '@types/supertest': ^2.0.12
       '@types/tmp': ^0.2.3
       '@types/yargs': ^17.0.10
+      date-fns: ^2.28.0
       eventsource: ^2.0.2
       fastboot: ^4.1.0
       flat: ^5.0.2
@@ -1040,6 +1041,7 @@ importers:
       '@types/supertest': 2.0.12
       '@types/tmp': 0.2.3
       '@types/yargs': 17.0.13
+      date-fns: 2.29.3
       eventsource: 2.0.2
       fastboot: 4.1.0_kizxbxhfcldguz4jcwonfduu2y
       flat: 5.0.2
@@ -1393,6 +1395,7 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/core/7.21.0:
     resolution: {integrity: sha512-PuxUbxcW6ZYe656yL3EAhpy7qXKq0DmYsrJLpbB8XrsCP9Nm+XCg9XFMb5vIDliPD7+U/+M+QJlH17XOcB7eXA==}
@@ -1655,6 +1658,7 @@ packages:
       '@babel/types': 7.21.2
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/helper-module-transforms/7.21.2:
     resolution: {integrity: sha512-79yj2AR4U/Oqq/WOV7Lx6hUjau1Zfo4cI+JLAVYeMV5XIlbOhmjEk5ulbTc9fMpmlojzZHkUUxAiK+UKn+hNQQ==}
@@ -1782,6 +1786,7 @@ packages:
       '@babel/types': 7.21.2
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/helpers/7.21.0:
     resolution: {integrity: sha512-XXve0CBtOW0pd7MRzzmoyuSj0e3SEzj8pgyFxnTT1NJZL38BD1MK7yYrm8yefRPIDvNNe14xR4FdbHwpInD4rA==}
@@ -2043,7 +2048,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.2_supports-color@8.1.1
+      '@babel/core': 7.20.2
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.20.2
 
@@ -2133,7 +2138,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.2_supports-color@8.1.1
+      '@babel/core': 7.20.2
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
       '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.20.2
@@ -2379,7 +2384,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.2_supports-color@8.1.1
+      '@babel/core': 7.20.2
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.21.0:
@@ -2447,7 +2452,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.20.2_supports-color@8.1.1
+      '@babel/core': 7.20.2
       '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.21.0:
@@ -3517,6 +3522,7 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/traverse/7.21.2:
     resolution: {integrity: sha512-ts5FFU/dSUPS13tv8XiEObDu9K+iagEKME9kAbaP7r0Y9KtZJZ+NGndDvWoRAYNpeWafbpFeki3q9QoMD6gxyw==}
@@ -10400,6 +10406,7 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 8.1.1
+    dev: true
 
   /decamelize/1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
@@ -14478,6 +14485,16 @@ packages:
     dependencies:
       tabbable: 5.3.3
 
+  /follow-redirects/1.15.2:
+    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dev: true
+
   /follow-redirects/1.15.2_debug@4.3.2:
     resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
     engines: {node: '>=4.0'}
@@ -15500,7 +15517,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.2_debug@4.3.2
+      follow-redirects: 1.15.2
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug


### PR DESCRIPTION
I came across this when attempting to run demo-cards in vscode debugger. Here is the launch [command](https://github.com/cardstack/boxel/blob/e771d7e69d01481d7214f60d33b19086a887592b/.vscode/launch.json#L90-L112). Here is the command ran on the terminal 

<img width="1434" alt="Screenshot 2023-05-23 at 11 09 07" src="https://github.com/cardstack/boxel/assets/8165111/534c821f-79ba-40f0-86b8-5bf02a7dac72">

Here is the [import](https://github.com/cardstack/boxel/blob/e771d7e69d01481d7214f60d33b19086a887592b/packages/realm-server/lib/externals.ts#L7) into the realm externals 

Tho this seemed to be fine when running `pnpm start:all` 

