### PR TITLE
Saving new card spawned from linked field in-place

### DIFF
--- a/packages/base/links-to-editor.gts
+++ b/packages/base/links-to-editor.gts
@@ -101,7 +101,9 @@ class LinksToEditor extends GlimmerComponent<Signature> {
   private createCard = restartableTask(async () => {
     let type = identifyCard(this.args.field.card) ?? baseCardRef;
     let newCard: Card | undefined =
-      await this.args.context?.actions?.createCard(type, undefined);
+      await this.args.context?.actions?.createCard(type, undefined, {
+        isLinkedCard: true,
+      });
     if (newCard) {
       this.args.model.value = newCard;
     }

--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -111,7 +111,9 @@ class LinksToManyEditor extends GlimmerComponent<Signature> {
     let cards = (this.args.model.value as any)[this.args.field.name];
     let type = identifyCard(this.args.field.card) ?? baseCardRef;
     let newCard: Card | undefined =
-      await this.args.context?.actions?.createCard(type, undefined);
+      await this.args.context?.actions?.createCard(type, undefined, {
+        isLinkedCard: true,
+      });
     if (newCard) {
       cards = [...cards, newCard];
       (this.args.model.value as any)[this.args.field.name] = cards;

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -694,8 +694,6 @@ module('Integration | operator-mode', function (hooks) {
     );
 
     await click('[data-test-stack-card-index="3"] [data-test-save-button]');
-    await waitFor(`[data-test-stack-card="${testRealmURL}Author/3"]`);
-    await click('[data-test-stack-card-index="3"] [data-test-close-button]');
     await waitUntil(
       () => !document.querySelector('[data-test-stack-card-index="3"]')
     );
@@ -709,8 +707,6 @@ module('Integration | operator-mode', function (hooks) {
       'Mad As a Hatter'
     );
     await click('[data-test-stack-card-index="2"] [data-test-save-button]');
-    await waitFor(`[data-test-stack-card="${testRealmURL}BlogPost/3"]`);
-    await click('[data-test-stack-card-index="2"] [data-test-close-button]');
     await waitUntil(
       () => !document.querySelector('[data-test-stack-card-index="2"]')
     );
@@ -825,8 +821,6 @@ module('Integration | operator-mode', function (hooks) {
     );
 
     await click('[data-test-stack-card-index="1"] [data-test-save-button]');
-    await waitFor(`[data-test-stack-card="${testRealmURL}Author/3"]`);
-    await click('[data-test-stack-card-index="1"] [data-test-close-button]');
     await waitUntil(
       () => !document.querySelector('[data-test-stack-card-index="1"]')
     );
@@ -966,9 +960,6 @@ module('Integration | operator-mode', function (hooks) {
       'Woodster'
     );
     await click('[data-test-stack-card-index="1"] [data-test-save-button]');
-    await waitFor(`[data-test-stack-card="${testRealmURL}Pet/1"]`);
-    await click('[data-test-stack-card-index="1"] [data-test-close-button]');
-
     await waitUntil(
       () => !document.querySelector('[data-test-stack-card-index="1"]')
     );
@@ -999,9 +990,6 @@ module('Integration | operator-mode', function (hooks) {
       'Woodster'
     );
     await click('[data-test-stack-card-index="1"] [data-test-save-button]');
-    await waitFor(`[data-test-stack-card="${testRealmURL}Pet/1"]`);
-    await click('[data-test-stack-card-index="1"] [data-test-close-button]');
-
     await waitUntil(
       () => !document.querySelector('[data-test-stack-card-index="1"]')
     );

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -155,7 +155,8 @@ export async function createNewCard<T extends Card>(
 export interface Actions {
   createCard: (
     ref: CardRef,
-    relativeTo: URL | undefined
+    relativeTo: URL | undefined,
+    opts?: { isLinkedCard?: boolean }
   ) => Promise<Card | undefined>;
   // more CRUD ops to come...
 }


### PR DESCRIPTION
This change I made with the optional `isLinkedField` lets the operator mode know to close the new card editor window when a card is created from linksTo or linksToMany fields. I'm open to trying any alternate approaches if anyone has a better idea.