### PR TITLE
refactoring to address loader deadlock

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,8 @@ module.exports = {
     '@typescript-eslint/ban-ts-comment': 'off',
     '@typescript-eslint/ban-types': 'off',
     '@typescript-eslint/prefer-as-const': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-unused-vars': [
       'error',
       { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -548,13 +548,15 @@ module('Integration | operator-mode', function (hooks) {
     );
     assert.dom('[data-test-person]').isNotVisible();
     assert.dom('[data-test-add-card-button]').isVisible();
-    
+
     await click('[data-test-add-card-button]');
     assert.dom('[data-test-card-catalog-modal]').isVisible();
 
     await waitFor(`[data-test-select="${testRealmURL}Person/fadhlan"]`);
     await click(`[data-test-select="${testRealmURL}Person/fadhlan"]`);
-    assert.dom(`[data-test-stack-card="${testRealmURL}Person/fadhlan"]`).isVisible();
+    assert
+      .dom(`[data-test-stack-card="${testRealmURL}Person/fadhlan"]`)
+      .isVisible();
   });
 
   test('displays cards on cards-grid', async function (assert) {
@@ -770,7 +772,7 @@ module('Integration | operator-mode', function (hooks) {
     await waitFor(`[data-test-card-catalog-item="${testRealmURL}Author/2"]`);
     await click(`[data-test-select="${testRealmURL}Author/2"]`);
 
-    await waitFor(`[data-test-author="R2-D2"]`);
+    await waitFor(`.operator-mode [data-test-author="R2-D2"]`);
     assert.dom('[data-test-field="authorBio"]').containsText('R2-D2');
   });
 
@@ -799,9 +801,11 @@ module('Integration | operator-mode', function (hooks) {
     assert.dom('[data-test-field="authorBio"]').containsText('R2-D2');
 
     await click('[data-test-save-button]');
-    await waitFor('[data-test-blog-post-isolated]');
+    await waitFor('.operator-mode [data-test-blog-post-isolated]');
 
-    assert.dom('[data-test-blog-post-isolated]').hasText('Beginnings by R2-D2');
+    assert
+      .dom('.operator-mode [data-test-blog-post-isolated]')
+      .hasText('Beginnings by R2-D2');
   });
 
   test('can create a new card to populate a linksTo field', async function (assert) {
@@ -843,8 +847,12 @@ module('Integration | operator-mode', function (hooks) {
     assert.dom('[data-test-field="authorBio"]').containsText('Alice');
 
     await click('[data-test-stack-card-index="0"] [data-test-save-button]');
-    await waitFor('[data-test-blog-post-isolated] [data-test-author="Alice"]');
-    assert.dom('[data-test-blog-post-isolated]').hasText('Beginnings by Alice');
+    await waitFor(
+      '.operator-mode [data-test-blog-post-isolated] [data-test-author="Alice"]'
+    );
+    assert
+      .dom('.operator-mode [data-test-blog-post-isolated]')
+      .hasText('Beginnings by Alice');
   });
 
   test('can remove the link for a linksTo field', async function (assert) {
@@ -865,9 +873,9 @@ module('Integration | operator-mode', function (hooks) {
     await click('[data-test-field="authorBio"] [data-test-remove-card]');
     await click('[data-test-save-button]');
 
-    await waitFor('[data-test-blog-post-isolated]');
+    await waitFor('.operator-mode [data-test-blog-post-isolated]');
     assert
-      .dom('[data-test-blog-post-isolated]')
+      .dom('.operator-mode [data-test-blog-post-isolated]')
       .hasText('Outer Space Journey by');
   });
 

--- a/packages/realm-server/fastboot.ts
+++ b/packages/realm-server/fastboot.ts
@@ -6,7 +6,6 @@ import {
   type IndexRunner,
   type RunnerOpts,
 } from '@cardstack/runtime-common/search-index';
-import { Loader } from '@cardstack/runtime-common';
 
 const appName = '@cardstack/host';
 export async function makeFastBootIndexRunner(
@@ -15,8 +14,6 @@ export async function makeFastBootIndexRunner(
 ): Promise<{ getRunner: IndexRunner; distPath: string }> {
   let fastboot: FastBootInstance;
   let distPath: string;
-
-  // TODO can we get rid of the duplicate globals code?
   if (typeof dist === 'string') {
     distPath = dist;
     fastboot = new FastBoot({
@@ -30,8 +27,6 @@ export async function makeFastBootIndexRunner(
           btoa,
           getRunnerOpts,
           _logDefinitions: (globalThis as any)._logDefinitions,
-          getUrlMappings: () => Loader.getLoader().getURLMappings(),
-          getUrlHandlers: () => Loader.getLoader().getURLHandlers(),
         });
       },
     }) as FastBootInstance;
@@ -47,8 +42,6 @@ export async function makeFastBootIndexRunner(
           btoa,
           getRunnerOpts,
           _logDefinitions: (globalThis as any)._logDefinitions,
-          getUrlMappings: () => Loader.getLoader().getURLMappings(),
-          getUrlHandlers: () => Loader.getLoader().getURLHandlers(),
         });
       }
     ));

--- a/packages/realm-server/fastboot.ts
+++ b/packages/realm-server/fastboot.ts
@@ -6,6 +6,7 @@ import {
   type IndexRunner,
   type RunnerOpts,
 } from '@cardstack/runtime-common/search-index';
+import { Loader } from '@cardstack/runtime-common';
 
 const appName = '@cardstack/host';
 export async function makeFastBootIndexRunner(
@@ -14,6 +15,8 @@ export async function makeFastBootIndexRunner(
 ): Promise<{ getRunner: IndexRunner; distPath: string }> {
   let fastboot: FastBootInstance;
   let distPath: string;
+
+  // TODO can we get rid of the duplicate globals code?
   if (typeof dist === 'string') {
     distPath = dist;
     fastboot = new FastBoot({
@@ -27,6 +30,8 @@ export async function makeFastBootIndexRunner(
           btoa,
           getRunnerOpts,
           _logDefinitions: (globalThis as any)._logDefinitions,
+          getUrlMappings: () => Loader.getLoader().getURLMappings(),
+          getUrlHandlers: () => Loader.getLoader().getURLHandlers(),
         });
       },
     }) as FastBootInstance;
@@ -42,6 +47,8 @@ export async function makeFastBootIndexRunner(
           btoa,
           getRunnerOpts,
           _logDefinitions: (globalThis as any)._logDefinitions,
+          getUrlMappings: () => Loader.getLoader().getURLMappings(),
+          getUrlHandlers: () => Loader.getLoader().getURLHandlers(),
         });
       }
     ));

--- a/packages/realm-server/tests/loader-test.ts
+++ b/packages/realm-server/tests/loader-test.ts
@@ -1,4 +1,4 @@
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { Loader } from '@cardstack/runtime-common';
 import { dirSync, setGracefulCleanup } from 'tmp';
 import { createRealm } from './helpers';
@@ -40,7 +40,7 @@ module('loader', function (hooks) {
     assert.strictEqual(bModule.b(), 'bc', 'module executed successfully');
   });
 
-  skip('can resolve a import deadlock', async function (assert) {
+  test('can resolve a import deadlock', async function (assert) {
     let loader = new Loader();
     loader.addURLMapping(
       new URL(baseRealm.url),


### PR DESCRIPTION
Results of working with @habdelra on the loader deadlock issue, this isn't done but we think we've figured out how to restructure the states to solve the problem.

[UPDATE - hassan]
This is done now. I had to introduce one more new loader state, from the pairing work that I originally did with Ed to break cycles: `registered-completing-deps`. 

Also there were a bunch of flaky operator mode tests that were getting in the way. There is an isolated-renderer component that is rendered off the screen that is used for indexing that the test selectors were inadvertently picking up and occasionally failing because of the timing difference between what the isolated renderer was rendering and what was actually meant to be tested.