### PR TITLE
Prepare for operator mode persistence: extract stack manipulation to a new service

### DIFF
--- a/packages/base/links-to-editor.gts
+++ b/packages/base/links-to-editor.gts
@@ -101,7 +101,9 @@ class LinksToEditor extends GlimmerComponent<Signature> {
   private createCard = restartableTask(async () => {
     let type = identifyCard(this.args.field.card) ?? baseCardRef;
     let newCard: Card | undefined =
-      await this.args.context?.actions?.createCard(type, undefined);
+      await this.args.context?.actions?.createCard(type, undefined, {
+        isLinkedCard: true,
+      });
     if (newCard) {
       this.args.model.value = newCard;
     }

--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -111,7 +111,9 @@ class LinksToManyEditor extends GlimmerComponent<Signature> {
     let cards = (this.args.model.value as any)[this.args.field.name];
     let type = identifyCard(this.args.field.card) ?? baseCardRef;
     let newCard: Card | undefined =
-      await this.args.context?.actions?.createCard(type, undefined);
+      await this.args.context?.actions?.createCard(type, undefined, {
+        isLinkedCard: true,
+      });
     if (newCard) {
       cards = [...cards, newCard];
       (this.args.model.value as any)[this.args.field.name] = cards;

--- a/packages/host/app/components/operator-mode.gts
+++ b/packages/host/app/components/operator-mode.gts
@@ -43,6 +43,7 @@ import type { Query } from '@cardstack/runtime-common/query';
 import { getSearchResults, type Search } from '../resources/search';
 import { svgJar } from '@cardstack/boxel-ui/helpers/svg-jar';
 import perform from 'ember-concurrency/helpers/perform';
+import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 interface Signature {
   Args: {
@@ -51,10 +52,19 @@ interface Signature {
   };
 }
 
+export type OperatorModeState = {
+  stacks: Stack[];
+};
+
+export type Stack = {
+  items: StackItem[];
+};
+
 export type StackItem = {
   card: Card;
   format: Format;
   request?: Deferred<Card>;
+  isLinkedCard?: boolean;
 };
 
 export interface RenderedLinksToCard {
@@ -65,7 +75,6 @@ export interface RenderedLinksToCard {
 }
 
 export default class OperatorMode extends Component<Signature> {
-  stack: TrackedArray<StackItem>;
   //A variable to store value of card field
   //before in edit mode.
   cardFieldValues: WeakMap<Card, Map<string, any>> = new WeakMap<
@@ -74,6 +83,7 @@ export default class OperatorMode extends Component<Signature> {
   >();
   @service declare loaderService: LoaderService;
   @service declare cardService: CardService;
+  @service declare operatorModeStateService: OperatorModeStateService;
   @tracked searchSheetMode: SearchSheetMode = SearchSheetMode.Closed;
 
   constructor(owner: unknown, args: any) {
@@ -82,14 +92,21 @@ export default class OperatorMode extends Component<Signature> {
     (globalThis as any)._CARDSTACK_CARD_SEARCH = this;
     registerDestructor(this, () => {
       delete (globalThis as any)._CARDSTACK_CARD_SEARCH;
+      this.operatorModeStateService.clearStack();
     });
 
-    this.stack = new TrackedArray([
-      {
+    // afterRender to prevent recomputation errors
+    schedule('afterRender', () => {
+      this.addToStack({
         card: this.args.firstCardInStack,
         format: 'isolated',
-      },
-    ]);
+      });
+    });
+  }
+
+  get stack() {
+    // We return the first one until we start supporting 2 stacks
+    return this.operatorModeStateService.state.stacks[0].items;
   }
 
   @action
@@ -108,57 +125,56 @@ export default class OperatorMode extends Component<Signature> {
   }
 
   @action addToStack(item: StackItem) {
-    this.stack.push(item);
+    this.operatorModeStateService.addItemToStack(item);
   }
 
   @action async edit(item: StackItem) {
     await this.saveCardFieldValues(item.card);
-    let newItem = this.setItem(item, 'edit', new Deferred());
-    this.stack = this.stack;
-
-    let updatedCard = await newItem.request?.promise;
-    if (updatedCard) {
-      this.addToStack({
-        card: updatedCard,
-        format: 'isolated',
-      });
-    }
+    this.updateItem(item, 'edit', new Deferred());
   }
 
-  @action setItem(item: StackItem, format: Format, request?: Deferred<Card>) {
-    let el = this.stack.find((stackItem) => stackItem.card.id === item.card.id);
-    if (!el) {
-      throw new Error(`${item.card} was not found in stack`);
-    }
-    let index = this.stack.indexOf(el);
+  @action updateItem(
+    item: StackItem,
+    format: Format,
+    request?: Deferred<Card>
+  ) {
     let newItem = {
       card: item.card,
       format,
       request,
     };
-    this.stack[index] = newItem;
+
+    this.operatorModeStateService.replaceItemInStack(item, newItem);
     return newItem;
   }
 
   @action async close(item: StackItem) {
     await this.rollbackCardFieldValues(item.card);
-    let index = this.stack.indexOf(item);
-    this.stack.splice(index);
+
+    this.operatorModeStateService.removeItemFromStack(item);
   }
 
   @action async cancel(item: StackItem) {
     await this.rollbackCardFieldValues(item.card);
-    this.setItem(item, 'isolated');
+    this.updateItem(item, 'isolated');
   }
 
   @action async save(item: StackItem) {
-    let { card, request } = item;
+    let { card, request, isLinkedCard } = item;
     await this.saveCardFieldValues(card);
     let updatedCard = await this.write.perform(card);
 
     if (updatedCard) {
       request?.fulfill(updatedCard);
-      this.stack.splice(this.stack.indexOf(item));
+
+      if (isLinkedCard) {
+        this.close(item); // closes the 'create new card' editor for linked card fields
+      } else {
+        this.operatorModeStateService.replaceItemInStack(item, {
+          card: updatedCard,
+          format: 'isolated',
+        });
+      }
     }
   }
 
@@ -192,7 +208,10 @@ export default class OperatorMode extends Component<Signature> {
   private publicAPI: Actions = {
     createCard: async (
       ref: CardRef,
-      relativeTo: URL | undefined
+      relativeTo: URL | undefined,
+      opts?: {
+        isLinkedCard?: boolean;
+      }
     ): Promise<Card | undefined> => {
       let doc = { data: { meta: { adoptsFrom: ref } } };
       let newCard = await this.cardService.createFromSerialized(
@@ -205,6 +224,7 @@ export default class OperatorMode extends Component<Signature> {
         card: newCard,
         format: 'edit',
         request: new Deferred(),
+        isLinkedCard: opts?.isLinkedCard,
       };
       this.addToStack(newItem);
       return await newItem.request?.promise;

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -1,0 +1,58 @@
+import {
+  OperatorModeState,
+  StackItem,
+} from '@cardstack/host/components/operator-mode';
+import Service from '@ember/service';
+
+import { TrackedArray, TrackedObject } from 'tracked-built-ins';
+
+export default class OperatorModeStateService extends Service {
+  // @ts-ignore Property 'state' has no initializer and is not definitely assigned in the constructor.
+  // ts complains that state is not initialized, but it fails to understand
+  // that this.restore() sets it
+  state: OperatorModeState;
+
+  constructor(owner: object) {
+    super(owner);
+
+    this.restore();
+  }
+
+  restore() {
+    // TODO: Implement restoration from query param in the URL
+
+    this.state = new TrackedObject({
+      stacks: [
+        {
+          items: new TrackedArray([]),
+        },
+      ],
+    });
+  }
+
+  addItemToStack(item: StackItem, stackIndex = 0) {
+    this.state.stacks[stackIndex].items.push(item);
+    this.persist();
+  }
+
+  removeItemFromStack(item: StackItem, stackIndex = 0) {
+    let itemIndex = this.state.stacks[stackIndex].items.indexOf(item);
+    this.state.stacks[stackIndex].items.splice(itemIndex);
+    this.persist();
+  }
+
+  replaceItemInStack(item: StackItem, newItem: StackItem, stackIndex = 0) {
+    let itemIndex = this.state.stacks[stackIndex].items.indexOf(item);
+    this.state.stacks[stackIndex].items.splice(itemIndex, 1, newItem);
+    this.persist();
+  }
+
+  clearStack(stackIndex = 0) {
+    this.state.stacks[stackIndex].items.splice(0);
+    this.persist();
+  }
+
+  persist() {
+    // TODO: Implement persisting state to query param in the URL
+  }
+}

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -155,7 +155,8 @@ export async function createNewCard<T extends Card>(
 export interface Actions {
   createCard: (
     ref: CardRef,
-    relativeTo: URL | undefined
+    relativeTo: URL | undefined,
+    opts?: { isLinkedCard?: boolean }
   ) => Promise<Card | undefined>;
   viewCard: (card: Card) => void;
   // more CRUD ops to come...


### PR DESCRIPTION
This is a bite-sized PR as a first step towards persisting operator mode stack state to a query param in the URL so that the state can survive page refresh and the user is able to make use of the "back" button. 

I decided make a smaller PR first to get some early feedback and to prevent future merge conflicts in operator mode component, which is receiving many updates recently. The work that follows will be mostly done in the newly introduced operator mode state service.

This PR:

1. Extracts stack manipulation from operator mode component to a new service (operator mode state)
2. Changes data flow so that the operator mode component reads stack state from the new service
3. Adds stubs for restoring state on init, and persisting state on every manipulation of items in the stack

The operations are already covered with tests so I didn't add any new ones.
