### PR TITLE
Follow up refactor on saving new card

### DIFF
--- a/packages/base/cards-grid.gts
+++ b/packages/base/cards-grid.gts
@@ -98,7 +98,7 @@ class Isolated extends Component<typeof CardsGrid> {
   }
 
   @action openCard(card: Card) {
-    this.args.context?.optional?.openCard(card);
+    this.args.context?.actions?.viewCard(card);
   }
 
   private createCard = restartableTask(async () => {
@@ -112,10 +112,14 @@ class Isolated extends Component<typeof CardsGrid> {
       return;
     }
 
-    await this.args.context?.actions?.createCard?.(
+    let newCard = await this.args.context?.actions?.createCard?.(
       card.ref,
       this.args.model[relativeTo]
     );
+
+    if (newCard) {
+      this.openCard(newCard);
+    }
   });
 }
 

--- a/packages/base/links-to-editor.gts
+++ b/packages/base/links-to-editor.gts
@@ -101,9 +101,7 @@ class LinksToEditor extends GlimmerComponent<Signature> {
   private createCard = restartableTask(async () => {
     let type = identifyCard(this.args.field.card) ?? baseCardRef;
     let newCard: Card | undefined =
-      await this.args.context?.actions?.createCard(type, undefined, {
-        isLinkedCard: true,
-      });
+      await this.args.context?.actions?.createCard(type, undefined);
     if (newCard) {
       this.args.model.value = newCard;
     }

--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -111,9 +111,7 @@ class LinksToManyEditor extends GlimmerComponent<Signature> {
     let cards = (this.args.model.value as any)[this.args.field.name];
     let type = identifyCard(this.args.field.card) ?? baseCardRef;
     let newCard: Card | undefined =
-      await this.args.context?.actions?.createCard(type, undefined, {
-        isLinkedCard: true,
-      });
+      await this.args.context?.actions?.createCard(type, undefined);
     if (newCard) {
       cards = [...cards, newCard];
       (this.args.model.value as any)[this.args.field.name] = cards;

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -155,9 +155,9 @@ export async function createNewCard<T extends Card>(
 export interface Actions {
   createCard: (
     ref: CardRef,
-    relativeTo: URL | undefined,
-    opts?: { isLinkedCard?: boolean }
+    relativeTo: URL | undefined
   ) => Promise<Card | undefined>;
+  viewCard: (card: Card) => void;
   // more CRUD ops to come...
 }
 


### PR DESCRIPTION
Made changes according to the code review: Removed options from createCard action, added viewCard instead. This is a follow up on [this commit](https://github.com/cardstack/boxel/commit/4bba130e8ff050fff7eac45a46e28f59244fbce8#diff-a861157ee32a3547cb105c10da71990b689df69098feb9265e46a49e769a978e).

Realized the `context.optional.openCard` method did the same thing as my new `viewCard` method in actions. It makes sense to have it in actions, so I removed the `openCard` method (fyi @jurgenwerk ). We can use `context.actions.viewCard` instead.

Rest is refactor to make existing functionalities work.