### PR TITLE
Persist operator mode stack in a query param

### DIFF
--- a/packages/host/app/components/operator-mode.gts
+++ b/packages/host/app/components/operator-mode.gts
@@ -48,7 +48,6 @@ import OperatorModeStateService from '@cardstack/host/services/operator-mode-sta
 interface Signature {
   Args: {
     onClose: () => void;
-    updateOperatorModeStateQueryParams: () => void;
   };
 }
 
@@ -93,7 +92,6 @@ export default class OperatorMode extends Component<Signature> {
     registerDestructor(this, () => {
       delete (globalThis as any)._CARDSTACK_CARD_SEARCH;
       this.operatorModeStateService.clearStack();
-      this.args.updateOperatorModeStateQueryParams();
     });
   }
 
@@ -119,8 +117,6 @@ export default class OperatorMode extends Component<Signature> {
 
   @action addToStack(item: StackItem) {
     this.operatorModeStateService.addItemToStack(item);
-
-    this.args.updateOperatorModeStateQueryParams();
   }
 
   @action async edit(item: StackItem) {
@@ -148,7 +144,6 @@ export default class OperatorMode extends Component<Signature> {
     await this.rollbackCardFieldValues(item.card);
 
     this.operatorModeStateService.removeItemFromStack(item);
-    this.args.updateOperatorModeStateQueryParams();
   }
 
   @action async cancel(item: StackItem) {
@@ -177,7 +172,6 @@ export default class OperatorMode extends Component<Signature> {
 
   replaceItemInStack(item: StackItem, newItem: StackItem) {
     this.operatorModeStateService.replaceItemInStack(item, newItem);
-    this.args.updateOperatorModeStateQueryParams();
   }
 
   private write = restartableTask(async (card: Card) => {

--- a/packages/host/app/components/operator-mode.gts
+++ b/packages/host/app/components/operator-mode.gts
@@ -23,7 +23,6 @@ import SearchSheet, {
 import { restartableTask } from 'ember-concurrency';
 import {
   Deferred,
-  identifyCard,
   baseCardRef,
   chooseCard,
   type Actions,

--- a/packages/host/app/controllers/card.ts
+++ b/packages/host/app/controllers/card.ts
@@ -10,13 +10,20 @@ import { Model } from '@cardstack/host/routes/card';
 import { registerDestructor } from '@ember/destroyable';
 import type { Query } from '@cardstack/runtime-common/query';
 import { getSearchResults, type Search } from '../resources/search';
+import OperatorModeStateService, {
+  SerializedState as OperatorModeSerializedState,
+} from '@cardstack/host/services/operator-mode-state-service';
 
 export default class CardController extends Controller {
+  queryParams = ['operatorModeState', 'operatorModeEnabled'];
+
   isolatedCardComponent: ComponentLike | undefined;
   withPreventDefault = withPreventDefault;
   @service declare router: RouterService;
   @tracked operatorModeEnabled = false;
   @tracked model: Model | undefined;
+  @tracked operatorModeState: string | null = null;
+  @service declare operatorModeStateService: OperatorModeStateService;
 
   constructor(args: any) {
     super(args);
@@ -41,10 +48,32 @@ export default class CardController extends Controller {
   @action
   toggleOperatorMode() {
     this.operatorModeEnabled = !this.operatorModeEnabled;
+
+    if (this.operatorModeEnabled) {
+      // When entering operator mode, put the current card on the stack
+      this.operatorModeState = JSON.stringify({
+        stacks: [
+          {
+            items: [
+              {
+                card: { id: this.model!.id },
+                format: 'isolated',
+              },
+            ],
+          },
+        ],
+      } as OperatorModeSerializedState);
+    } else {
+      this.operatorModeState = null;
+    }
   }
 
   @action
   closeOperatorMode() {
     this.operatorModeEnabled = false;
+  }
+
+  @action updateOperatorModeStateQueryParams() {
+    this.operatorModeState = this.operatorModeStateService.serialize();
   }
 }

--- a/packages/host/app/controllers/card.ts
+++ b/packages/host/app/controllers/card.ts
@@ -72,8 +72,4 @@ export default class CardController extends Controller {
   closeOperatorMode() {
     this.operatorModeEnabled = false;
   }
-
-  @action updateOperatorModeStateQueryParams() {
-    this.operatorModeState = this.operatorModeStateService.serialize();
-  }
 }

--- a/packages/host/app/routes/card.gts
+++ b/packages/host/app/routes/card.gts
@@ -15,7 +15,7 @@ export type Model = Card | null;
 export default class RenderCard extends Route<Model | null> {
   queryParams = {
     operatorModeState: {
-      refreshModel: false, // Since false is default, this isn't strictly necessary, but it's good to be explicit here: operatorModeState is just an output of the state in the url and is used to restore the state on app boot
+      refreshModel: true, // Enabled so that back-forward navigation works in operator mode
     },
     operatorModeEnabled: {
       refreshModel: true,

--- a/packages/host/app/routes/card.gts
+++ b/packages/host/app/routes/card.gts
@@ -15,7 +15,7 @@ export type Model = Card | null;
 export default class RenderCard extends Route<Model | null> {
   queryParams = {
     operatorModeState: {
-      refreshModel: true,
+      refreshModel: false, // Since false is default, this isn't strictly necessary, but it's good to be explicit here: operatorModeState is just an output of the state in the url and is used to restore the state on app boot
     },
     operatorModeEnabled: {
       refreshModel: true,

--- a/packages/host/app/routes/card.gts
+++ b/packages/host/app/routes/card.gts
@@ -5,6 +5,7 @@ import { parse } from 'qs';
 import type CardService from '../services/card-service';
 import type RouterService from '@ember/routing/router-service';
 import { Card } from 'https://cardstack.com/base/card-api';
+import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 const { ownRealmURL } = ENV;
 const rootPath = new URL(ownRealmURL).pathname.replace(/^\//, '');
@@ -12,8 +13,18 @@ const rootPath = new URL(ownRealmURL).pathname.replace(/^\//, '');
 export type Model = Card | null;
 
 export default class RenderCard extends Route<Model | null> {
+  queryParams = {
+    operatorModeState: {
+      refreshModel: true,
+    },
+    operatorModeEnabled: {
+      refreshModel: true,
+    },
+  };
+
   @service declare cardService: CardService;
   @service declare router: RouterService;
+  @service declare operatorModeStateService: OperatorModeStateService;
 
   beforeModel(transition: any) {
     let queryParams = parse(
@@ -34,15 +45,27 @@ export default class RenderCard extends Route<Model | null> {
     }
   }
 
-  async model(params: { path: string }): Promise<Model> {
-    let { path } = params;
+  async model(params: {
+    path: string;
+    operatorModeState: string;
+    operatorModeEnabled: boolean;
+  }): Promise<Model> {
+    let { path, operatorModeState, operatorModeEnabled } = params;
     path = path || '';
     let url = path
       ? new URL(`/${path}`, ownRealmURL)
       : new URL('./', ownRealmURL);
 
     try {
-      return await this.cardService.loadModel(url);
+      let model = await this.cardService.loadModel(url);
+
+      if (operatorModeEnabled) {
+        let operatorModeStateObject = JSON.parse(operatorModeState);
+
+        await this.operatorModeStateService.restore(operatorModeStateObject);
+      }
+
+      return model;
     } catch (e) {
       (e as any).failureLoadingIndexCard = url.href === ownRealmURL;
       throw e;

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -53,13 +53,14 @@ export default class OperatorModeStateService extends Service {
   }
 
   persist() {
-    let cardController = getOwner(this).lookup('controller:card') as any;
+    let cardController = getOwner(this)!.lookup('controller:card') as any;
     if (!cardController) {
       throw new Error(
         'OperatorModeStateService must be used in the context of a CardController'
       );
     }
 
+    // Setting this property will trigger a query param update on the controller, which will reload the route
     cardController.operatorModeState = this.serialize();
   }
 

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -1,58 +1,100 @@
 import {
   OperatorModeState,
+  Stack,
   StackItem,
 } from '@cardstack/host/components/operator-mode';
 import Service from '@ember/service';
-
+import type CardService from '../services/card-service';
 import { TrackedArray, TrackedObject } from 'tracked-built-ins';
+import { service } from '@ember/service';
+
+import { tracked } from '@glimmer/tracking';
+
+// Below types form a raw POJO representation of operator mode state
+type SerializedItem = { card: { id: string }; format: 'isolated' | 'edit' };
+type SerializedStack = { items: SerializedItem[] };
+export type SerializedState = { stacks: SerializedStack[] };
 
 export default class OperatorModeStateService extends Service {
-  // @ts-ignore Property 'state' has no initializer and is not definitely assigned in the constructor.
-  // ts complains that state is not initialized, but it fails to understand
-  // that this.restore() sets it
-  state: OperatorModeState;
+  @tracked state: OperatorModeState = new TrackedObject({
+    stacks: new TrackedArray([]),
+  });
 
-  constructor(owner: object) {
-    super(owner);
+  @service declare cardService: CardService;
 
-    this.restore();
-  }
-
-  restore() {
-    // TODO: Implement restoration from query param in the URL
-
-    this.state = new TrackedObject({
-      stacks: [
-        {
-          items: new TrackedArray([]),
-        },
-      ],
-    });
+  async restore(rawState: any) {
+    this.state = await this.deserialize(rawState);
   }
 
   addItemToStack(item: StackItem, stackIndex = 0) {
     this.state.stacks[stackIndex].items.push(item);
-    this.persist();
   }
 
   removeItemFromStack(item: StackItem, stackIndex = 0) {
     let itemIndex = this.state.stacks[stackIndex].items.indexOf(item);
     this.state.stacks[stackIndex].items.splice(itemIndex);
-    this.persist();
   }
 
   replaceItemInStack(item: StackItem, newItem: StackItem, stackIndex = 0) {
     let itemIndex = this.state.stacks[stackIndex].items.indexOf(item);
     this.state.stacks[stackIndex].items.splice(itemIndex, 1, newItem);
-    this.persist();
   }
 
   clearStack(stackIndex = 0) {
     this.state.stacks[stackIndex].items.splice(0);
-    this.persist();
   }
 
-  persist() {
-    // TODO: Implement persisting state to query param in the URL
+  // Serialized POJO version of state, with only cards that have been saved.
+  // The state can have cards that have not been saved yet, for example when
+  // clicking on "Crate New" in linked card editor. Here we want to draw a boundary
+  // between navigatable states in the query parameter
+  rawStateWithSavedCardsOnly() {
+    let state: SerializedState = { stacks: [] };
+
+    for (let stack of this.state.stacks) {
+      let _stack: SerializedStack = { items: [] };
+
+      for (let item of stack.items) {
+        let cardId = item.card.id;
+        let card = { id: cardId };
+
+        if (cardId) {
+          if (item.format === 'isolated' || item.format === 'edit') {
+            _stack.items.push({ card, format: item.format });
+          } else {
+            throw new Error(`Unknown format for card on stack ${item.format}`);
+          }
+        }
+      }
+
+      state.stacks.push(_stack);
+    }
+
+    return state;
+  }
+
+  // Stringified JSON version of state, with only cards that have been saved, used for URL query param
+  serialize(): string {
+    return JSON.stringify(this.rawStateWithSavedCardsOnly());
+  }
+
+  // Deserialize a stringified JSON version of OperatorModeState into a Glimmer tracked object
+  // so that templates can react to changes in stacks and their items
+  async deserialize(rawState: SerializedState): Promise<OperatorModeState> {
+    let newState: OperatorModeState = new TrackedObject({
+      stacks: [],
+    });
+
+    for (let stack of rawState.stacks) {
+      let newStack: Stack = { items: new TrackedArray([]) };
+      for (let item of stack.items) {
+        let cardUrl = new URL(item.card.id);
+        let card = await this.cardService.loadModel(cardUrl);
+        newStack.items.push({ card, format: item.format });
+      }
+      newState.stacks.push(newStack);
+    }
+
+    return newState;
   }
 }

--- a/packages/host/app/templates/card.hbs
+++ b/packages/host/app/templates/card.hbs
@@ -5,13 +5,10 @@
 {{on-key 'Ctrl+.' this.toggleOperatorMode}}
 
 {{#if this.operatorModeEnabled}}
-  {{!-- TODO: Rather than a dedicated argument for the first card
-  in the stack, refactor this so that there will be a state that
-  reflects the whole stack --}}
   {{#if this.model}}
     <OperatorMode
-      @firstCardInStack={{this.model}}
       @onClose={{this.closeOperatorMode}}
+      @updateOperatorModeStateQueryParams={{this.updateOperatorModeStateQueryParams}}
     />
   {{/if}}
 {{/if}}

--- a/packages/host/app/templates/card.hbs
+++ b/packages/host/app/templates/card.hbs
@@ -8,7 +8,6 @@
   {{#if this.model}}
     <OperatorMode
       @onClose={{this.closeOperatorMode}}
-      @updateOperatorModeStateQueryParams={{this.updateOperatorModeStateQueryParams}}
     />
   {{/if}}
 {{/if}}

--- a/packages/host/tests/acceptance/operator-mode-test.ts
+++ b/packages/host/tests/acceptance/operator-mode-test.ts
@@ -1,0 +1,317 @@
+import { module, test } from 'qunit';
+import { visit, currentURL, click, triggerEvent } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { Loader } from '@cardstack/runtime-common/loader';
+import { baseRealm } from '@cardstack/runtime-common';
+import {
+  TestRealm,
+  TestRealmAdapter,
+  setupLocalIndexing,
+  setupMockMessageService,
+  testRealmURL,
+} from '../helpers';
+import { Realm } from '@cardstack/runtime-common/realm';
+import { shimExternals } from '@cardstack/host/lib/externals';
+import type LoaderService from '@cardstack/host/services/loader-service';
+
+module('Acceptance | basic tests', function (hooks) {
+  let realm: Realm;
+  let adapter: TestRealmAdapter;
+
+  setupApplicationTest(hooks);
+  setupLocalIndexing(hooks);
+  setupMockMessageService(hooks);
+
+  hooks.beforeEach(async function () {
+    Loader.addURLMapping(
+      new URL(baseRealm.url),
+      new URL('http://localhost:4201/base/')
+    );
+    shimExternals();
+    adapter = new TestRealmAdapter({
+      'pet.gts': `
+        import { contains, field, Component, Card } from "https://cardstack.com/base/card-api";
+        import StringCard from "https://cardstack.com/base/string";
+
+        export class Pet extends Card {
+          static displayName = 'Pet';
+          @field name = contains(StringCard);
+          @field title = contains(StringCard, {
+            computeVia: function (this: Pet) {
+              return this.name;
+            },
+          });
+          static embedded = class Embedded extends Component<typeof this> {
+            <template>
+              <div ...attributes>
+                <h3 data-test-pet={{@model.name}}>
+                  <@fields.name/>
+                </h3>
+              </div>
+            </template>
+          }
+        }
+      `,
+      'address.gts': `
+        import { contains, field, Component, Card } from "https://cardstack.com/base/card-api";
+        import StringCard from "https://cardstack.com/base/string";
+        import { FieldContainer } from '@cardstack/boxel-ui';
+
+        export class Address extends Card {
+          static displayName = 'Address';
+          @field city = contains(StringCard);
+          @field country = contains(StringCard);
+          static embedded = class Embedded extends Component<typeof this> {
+            <template>
+              <h3 data-test-city={{@model.city}}>
+                <@fields.city/>
+              </h3>
+              <h3 data-test-country={{@model.country}}>
+                <@fields.country/>
+              </h3>
+            </template>
+          }
+
+          static edit = class Edit extends Component<typeof this> {
+            <template>
+              <FieldContainer @label='city' @tag='label' data-test-boxel-input-city>
+                <@fields.city />
+              </FieldContainer>
+              <FieldContainer @label='country' @tag='label' data-test-boxel-input-country>
+                <@fields.country />
+              </FieldContainer>
+            </template>
+          };
+        }
+      `,
+      'person.gts': `
+        import { contains, linksTo, field, Component, Card, linksToMany } from "https://cardstack.com/base/card-api";
+        import StringCard from "https://cardstack.com/base/string";
+        import { Pet } from "./pet";
+        import { Address } from "./address";
+
+        export class Person extends Card {
+          static displayName = 'Person';
+          @field firstName = contains(StringCard);
+          @field pet = linksTo(Pet);
+          @field friends = linksToMany(Pet);
+          @field firstLetterOfTheName = contains(StringCard, {
+            computeVia: function (this: Chain) {
+              return this.firstName[0];
+            },
+          });
+          @field title = contains(StringCard, {
+            computeVia: function (this: Person) {
+              return this.firstName;
+            },
+          });
+          @field address = contains(Address);
+          static isolated = class Isolated extends Component<typeof this> {
+            <template>
+              <h2 data-test-person={{@model.firstName}}>
+                <@fields.firstName/>
+              </h2>
+              <p data-test-first-letter-of-the-name={{@model.firstLetterOfTheName}}>
+                <@fields.firstLetterOfTheName/>
+              </p>
+              Pet: <@fields.pet/>
+              Friends: <@fields.friends/>
+              Address: <@fields.address/>
+            </template>
+          }
+        }
+      `,
+      'Pet/mango.json': {
+        data: {
+          type: 'card',
+          id: `${testRealmURL}Pet/mango`,
+          attributes: {
+            name: 'Mango',
+          },
+          meta: {
+            adoptsFrom: {
+              module: `${testRealmURL}pet`,
+              name: 'Pet',
+            },
+          },
+        },
+      },
+
+      'Person/fadhlan.json': {
+        data: {
+          type: 'card',
+          id: `${testRealmURL}Person/fadhlan`,
+          attributes: {
+            firstName: 'Fadhlan',
+            address: {
+              city: 'Bandung',
+              country: 'Indonesia',
+            },
+          },
+          relationships: {
+            pet: {
+              links: {
+                self: `${testRealmURL}Pet/mango`,
+              },
+            },
+          },
+          meta: {
+            adoptsFrom: {
+              module: `${testRealmURL}person`,
+              name: 'Person',
+            },
+          },
+        },
+      },
+      'grid.json': {
+        data: {
+          type: 'card',
+          attributes: {},
+          meta: {
+            adoptsFrom: {
+              module: 'https://cardstack.com/base/cards-grid',
+              name: 'CardsGrid',
+            },
+          },
+        },
+      },
+      'index.json': {
+        data: {
+          type: 'card',
+          attributes: {},
+          meta: {
+            adoptsFrom: {
+              module: 'https://cardstack.com/base/cards-grid',
+              name: 'CardsGrid',
+            },
+          },
+        },
+      },
+    });
+
+    realm = await TestRealm.createWithAdapter(adapter, this.owner, {
+      isAcceptanceTest: true,
+    });
+
+    let loader = (this.owner.lookup('service:loader-service') as LoaderService)
+      .loader;
+    loader.registerURLHandler(new URL(realm.url), realm.handle.bind(realm));
+    await realm.ready;
+  });
+
+  test('visiting index card and entering operator mode', async function (assert) {
+    await visit('/');
+
+    assert.strictEqual(currentURL(), '/');
+
+    // Enter operator mode
+    await triggerEvent(document.body, 'keydown', {
+      code: 'Key.',
+      key: '.',
+      ctrlKey: true,
+    });
+
+    assert.dom('.operator-mode-card-stack').exists();
+    assert.dom('[data-test-stack-card-index="0"]').exists(); // Index card opens in the stack
+
+    // In the URL, operatorModeEnabled is set to true and operatorModeState is set to the current stack
+    assert.strictEqual(
+      currentURL(),
+      `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+        JSON.stringify({
+          stacks: [
+            {
+              items: [
+                {
+                  card: { id: 'http://test-realm/test/index' },
+                  format: 'isolated',
+                },
+              ],
+            },
+          ],
+        })
+      )}`
+    );
+  });
+
+  test('restoring the stack from query param', async function (assert) {
+    let operatorModeStateParam = JSON.stringify({
+      stacks: [
+        {
+          items: [
+            {
+              card: { id: 'http://test-realm/test/Person/fadhlan' },
+              format: 'isolated',
+            },
+            {
+              card: { id: 'http://test-realm/test/Pet/mango' },
+              format: 'isolated',
+            },
+          ],
+        },
+      ],
+    });
+
+    await visit(
+      `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+        operatorModeStateParam
+      )}`
+    );
+
+    assert
+      .dom('[data-test-stack-card-index="0"] [data-test-boxel-header-title]')
+      .includesText('Person');
+
+    assert
+      .dom('[data-test-stack-card-index="1"] [data-test-boxel-header-title]')
+      .includesText('Pet');
+
+    // Remove the dog from the stack
+    await click('[data-test-stack-card-index="1"] [data-test-close-button]');
+
+    // The stack should be updated in the URL
+    assert.strictEqual(
+      currentURL(),
+      `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+        JSON.stringify({
+          stacks: [
+            {
+              items: [
+                {
+                  card: { id: 'http://test-realm/test/Person/fadhlan' },
+                  format: 'isolated',
+                },
+              ],
+            },
+          ],
+        })
+      )}`
+    );
+
+    // Add the dog back to the stack (via overlayed linked card button)
+    await click('[data-test-cardstack-operator-mode-overlay-button]');
+
+    // The stack should be reflected in the URL
+    assert.strictEqual(
+      currentURL(),
+      `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+        JSON.stringify({
+          stacks: [
+            {
+              items: [
+                {
+                  card: { id: 'http://test-realm/test/Person/fadhlan' },
+                  format: 'isolated',
+                },
+                {
+                  card: { id: 'http://test-realm/test/Pet/mango' },
+                  format: 'isolated',
+                },
+              ],
+            },
+          ],
+        })
+      )}`
+    );
+  });
+});

--- a/packages/host/tests/acceptance/operator-mode-test.ts
+++ b/packages/host/tests/acceptance/operator-mode-test.ts
@@ -313,5 +313,55 @@ module('Acceptance | basic tests', function (hooks) {
         })
       )}`
     );
+
+    // Click Edit on the top card
+    await click('[data-test-stack-card-index="1"] [data-test-edit-button]');
+
+    // The edit format should be reflected in the URL
+    assert.strictEqual(
+      currentURL(),
+      `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+        JSON.stringify({
+          stacks: [
+            {
+              items: [
+                {
+                  card: { id: 'http://test-realm/test/Person/fadhlan' },
+                  format: 'isolated',
+                },
+                {
+                  card: { id: 'http://test-realm/test/Pet/mango' },
+                  format: 'edit',
+                },
+              ],
+            },
+          ],
+        })
+      )}`
+    );
+  });
+
+  test('restoring the stack from query param when card is in edit format', async function (assert) {
+    let operatorModeStateParam = JSON.stringify({
+      stacks: [
+        {
+          items: [
+            {
+              card: { id: 'http://test-realm/test/Person/fadhlan' },
+              format: 'edit',
+            },
+          ],
+        },
+      ],
+    });
+
+    await visit(
+      `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+        operatorModeStateParam
+      )}`
+    );
+
+    assert.dom('[data-test-field="firstName"] input').exists(); // Existence of an input field means it is in edit mode
+    assert.dom('[data-test-save-button]').exists(); // Existence of save button means it is in edit mode
   });
 });


### PR DESCRIPTION
This PR introduces a subset of our goal to be able to persist current operator mode work so that:

1. The work in operator mode is recoverable (unsaved state does not disappear) and can survive a page refresh 
2. There is back-forward navigation
3. The link is shareable 

What this PR specifically achieves is:

1. Ability to recover the stacked cards that **are saved**, by using a query parameter (`operatorModeState`)
- The unsaved cards, for example when trying to create a new card from a linked field (an unsaved card in edit mode will appear on top of the stack), will not be persisted in the URL. This means the unsaved (I mean new + unsaved) cards will be discarded when refreshing or navigating away. 
3. Recovering cards on page refresh, and when navigating back-forward

So this means this is more of a narrowed down navigational recovery feature compared to full unsaved data recovery. On yesterday's call we discussed these are probably two different things and one belongs to the url while the other one to local storage. One of the ideas was that the url should be shareable (without local storage references), and if there exists local storage state related to that, the restoration process will take that into the account as well. 

Here's how the query params looks like:
<img width="845" alt="image" src="https://github.com/cardstack/boxel/assets/273660/d98bbdb9-42b2-451c-b7cb-8bf0d0aa7485">

When decoded, the query params look like this:
`http://localhost:4200/?operatorModeEnabled=true&operatorModeState={"stacks":[{"items":[{"card":{"id":"http://localhost:4204/index"},"format":"isolated"},{"card":{"id":"http://localhost:4204/Person/1"},"format":"isolated"},{"card":{"id":"http://localhost:4204/Pet/4"},"format":"isolated"}]}]}`


What is introduced here could be a good starting point to build the rest of the features on top of it, and for discussion:

1. How far do we want to go with persisting unsaved data

- The thing that is currently very challenging is persisting and recovering the linkage between saved and unsaved cards, or many unsaved cards (because linked unsaved cards have no references between them until they get saved) 
- If we want to persist unsaved state when there are unsaved linked cards, then we need to figure out (rethink?) how to make promises work across the chain of unsaved instances of linked cards


TODO: 
- [x] Tests
