### PR TITLE
Include realm information in the card meta

### DIFF
--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -73,7 +73,7 @@ export class CurrentRun {
   #entrySetter: EntrySetter;
   #renderCard: RenderCard;
   #realmURL: URL;
-  #realmInfo: RealmInfo;
+  #realmInfo?: RealmInfo;
   readonly stats: Stats = {
     instancesIndexed: 0,
     instanceErrors: 0,

--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -367,10 +367,13 @@ export class CurrentRun {
 
       //Get realm info
       if (!this.#realmInfo) {
-        let realmInfoResponse = await this.loader.fetch(`${this.realmURL}_info`, { headers: { Accept: SupportedMimeType.RealmInfo }});
-        this.#realmInfo = (await realmInfoResponse.json())?.data?.attributes;  
+        let realmInfoResponse = await this.loader.fetch(
+          `${this.realmURL}_info`,
+          { headers: { Accept: SupportedMimeType.RealmInfo } }
+        );
+        this.#realmInfo = (await realmInfoResponse.json())?.data?.attributes;
       }
-      
+
       // prepare the document for index serialization
       Object.values(data.data.relationships ?? {}).forEach(
         (rel) => delete (rel as Relationship).data
@@ -378,7 +381,11 @@ export class CurrentRun {
       doc = merge(data, {
         data: {
           id: instanceURL.href,
-          meta: { lastModified: lastModified, realmInfo: this.#realmInfo, realmURL: this.realmURL.href },
+          meta: {
+            lastModified: lastModified,
+            realmInfo: this.#realmInfo,
+            realmURL: this.realmURL.href,
+          },
         },
       }) as SingleCardDocument;
       searchData = await api.searchDoc(card);

--- a/packages/host/tests/cards/.realm.json
+++ b/packages/host/tests/cards/.realm.json
@@ -1,0 +1,3 @@
+{
+  "name": "Test Workspace"
+}

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -45,6 +45,7 @@ export interface Dir {
 }
 
 export const testRealmURL = `http://test-realm/test/`;
+export const testRealmName = `Test Realm`;
 
 export interface CardDocFiles {
   [filename: string]: LooseSingleCardDocument;

--- a/packages/host/tests/integration/realm-test.ts
+++ b/packages/host/tests/integration/realm-test.ts
@@ -127,6 +127,10 @@ module('Integration | realm', function (hooks) {
           lastModified: adapter.lastModified.get(
             `${testRealmURL}dir/empty.json`
           ),
+          realmInfo: {
+            name: "Unnamed Workspace"
+          },
+          realmURL: testRealmURL,
         },
         links: {
           self: `${testRealmURL}dir/empty`,
@@ -213,6 +217,10 @@ module('Integration | realm', function (hooks) {
           lastModified: adapter.lastModified.get(
             `${testRealmURL}dir/mango.json`
           ),
+          realmInfo: {
+            name: 'Unnamed Workspace',
+          },
+          realmURL: testRealmURL,
         },
         links: {
           self: `${testRealmURL}dir/mango`,
@@ -234,6 +242,10 @@ module('Integration | realm', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}dir/owner.json`
             ),
+            realmInfo: {
+              name: 'Unnamed Workspace',
+            },
+            realmURL: testRealmURL,
           },
           links: {
             self: `${testRealmURL}dir/owner`,
@@ -307,6 +319,10 @@ module('Integration | realm', function (hooks) {
           lastModified: adapter.lastModified.get(
             `${testRealmURL}dir/mango.json`
           ),
+          realmInfo: {
+            name: "Unnamed Workspace"
+          },
+          realmURL: testRealmURL,
         },
         links: {
           self: `${testRealmURL}dir/mango`,
@@ -325,6 +341,10 @@ module('Integration | realm', function (hooks) {
               module: 'http://localhost:4202/test/person',
               name: 'Person',
             },
+            realmInfo: {
+              name: 'Test Workspace',
+            },
+            realmURL: 'http://localhost:4202/test/',
           },
           links: {
             self: `http://localhost:4202/test/hassan`,
@@ -603,6 +623,10 @@ module('Integration | realm', function (hooks) {
             name: 'Pet',
           },
           lastModified: adapter.lastModified.get(`${testRealmURL}Pet/1.json`),
+          realmInfo: {
+            name: "Unnamed Workspace"
+          },
+          realmURL: testRealmURL,
         },
         links: {
           self: `${testRealmURL}Pet/1`,
@@ -624,6 +648,10 @@ module('Integration | realm', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}dir/owner.json`
             ),
+            realmInfo: {
+              name: "Unnamed Workspace"
+            },
+            realmURL: testRealmURL,
           },
           links: {
             self: `${testRealmURL}dir/owner`,
@@ -880,6 +908,10 @@ module('Integration | realm', function (hooks) {
           lastModified: adapter.lastModified.get(
             `${testRealmURL}ski-trip.json`
           ),
+          realmInfo: {
+            name: "Unnamed Workspace"
+          },
+          realmURL: testRealmURL,
         },
       },
     });
@@ -1028,6 +1060,10 @@ module('Integration | realm', function (hooks) {
           lastModified: adapter.lastModified.get(
             `${testRealmURL}dir/mango.json`
           ),
+          realmInfo: {
+            name: "Unnamed Workspace"
+          },
+          realmURL: testRealmURL,
         },
         links: {
           self: `${testRealmURL}dir/mango`,
@@ -1049,6 +1085,10 @@ module('Integration | realm', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}dir/mariko.json`
             ),
+            realmInfo: {
+            name: "Unnamed Workspace"
+          },
+            realmURL: testRealmURL,
           },
           links: {
             self: `${testRealmURL}dir/mariko`,
@@ -1526,6 +1566,10 @@ module('Integration | realm', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}dir/mango.json`
             ),
+            realmInfo: {
+              name: "Unnamed Workspace"
+            },
+            realmURL: testRealmURL,
           },
           links: {
             self: `${testRealmURL}dir/mango`,
@@ -1546,6 +1590,10 @@ module('Integration | realm', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}dir/mariko.json`
             ),
+            realmInfo: {
+              name: "Unnamed Workspace"
+            },
+            realmURL: testRealmURL,
           },
           links: {
             self: `${testRealmURL}dir/mariko`,
@@ -1576,6 +1624,10 @@ module('Integration | realm', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}dir/vanGogh.json`
             ),
+            realmInfo: {
+              name: "Unnamed Workspace"
+            },
+            realmURL: testRealmURL,
           },
           links: {
             self: `${testRealmURL}dir/vanGogh`,
@@ -1595,6 +1647,8 @@ module('Integration | realm', function (hooks) {
               module: 'http://localhost:4202/test/person',
               name: 'Person',
             },
+            realmInfo: { name: 'Test Workspace' },
+            realmURL: 'http://localhost:4202/test/',
           },
           links: {
             self: `http://localhost:4202/test/hassan`,

--- a/packages/host/tests/integration/realm-test.ts
+++ b/packages/host/tests/integration/realm-test.ts
@@ -128,7 +128,7 @@ module('Integration | realm', function (hooks) {
             `${testRealmURL}dir/empty.json`
           ),
           realmInfo: {
-            name: "Unnamed Workspace"
+            name: 'Unnamed Workspace',
           },
           realmURL: testRealmURL,
         },
@@ -320,7 +320,7 @@ module('Integration | realm', function (hooks) {
             `${testRealmURL}dir/mango.json`
           ),
           realmInfo: {
-            name: "Unnamed Workspace"
+            name: 'Unnamed Workspace',
           },
           realmURL: testRealmURL,
         },
@@ -624,7 +624,7 @@ module('Integration | realm', function (hooks) {
           },
           lastModified: adapter.lastModified.get(`${testRealmURL}Pet/1.json`),
           realmInfo: {
-            name: "Unnamed Workspace"
+            name: 'Unnamed Workspace',
           },
           realmURL: testRealmURL,
         },
@@ -649,7 +649,7 @@ module('Integration | realm', function (hooks) {
               `${testRealmURL}dir/owner.json`
             ),
             realmInfo: {
-              name: "Unnamed Workspace"
+              name: 'Unnamed Workspace',
             },
             realmURL: testRealmURL,
           },
@@ -909,7 +909,7 @@ module('Integration | realm', function (hooks) {
             `${testRealmURL}ski-trip.json`
           ),
           realmInfo: {
-            name: "Unnamed Workspace"
+            name: 'Unnamed Workspace',
           },
           realmURL: testRealmURL,
         },
@@ -1061,7 +1061,7 @@ module('Integration | realm', function (hooks) {
             `${testRealmURL}dir/mango.json`
           ),
           realmInfo: {
-            name: "Unnamed Workspace"
+            name: 'Unnamed Workspace',
           },
           realmURL: testRealmURL,
         },
@@ -1086,8 +1086,8 @@ module('Integration | realm', function (hooks) {
               `${testRealmURL}dir/mariko.json`
             ),
             realmInfo: {
-            name: "Unnamed Workspace"
-          },
+              name: 'Unnamed Workspace',
+            },
             realmURL: testRealmURL,
           },
           links: {
@@ -1567,7 +1567,7 @@ module('Integration | realm', function (hooks) {
               `${testRealmURL}dir/mango.json`
             ),
             realmInfo: {
-              name: "Unnamed Workspace"
+              name: 'Unnamed Workspace',
             },
             realmURL: testRealmURL,
           },
@@ -1591,7 +1591,7 @@ module('Integration | realm', function (hooks) {
               `${testRealmURL}dir/mariko.json`
             ),
             realmInfo: {
-              name: "Unnamed Workspace"
+              name: 'Unnamed Workspace',
             },
             realmURL: testRealmURL,
           },
@@ -1625,7 +1625,7 @@ module('Integration | realm', function (hooks) {
               `${testRealmURL}dir/vanGogh.json`
             ),
             realmInfo: {
-              name: "Unnamed Workspace"
+              name: 'Unnamed Workspace',
             },
             realmURL: testRealmURL,
           },

--- a/packages/host/tests/integration/search-index-test.ts
+++ b/packages/host/tests/integration/search-index-test.ts
@@ -70,6 +70,10 @@ module('Integration | search-index', function (hooks) {
             name: 'Card',
           },
           lastModified: adapter.lastModified.get(`${testRealmURL}empty.json`),
+          realmInfo: {
+            name: 'Unnamed Workspace',
+          },
+          realmURL: 'http://test-realm/test/',
         },
         links: {
           self: `${testRealmURL}empty`,
@@ -164,6 +168,10 @@ module('Integration | search-index', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}Pet/mango.json`
             ),
+            realmInfo: {
+              name: 'Unnamed Workspace',
+            },
+            realmURL: 'http://test-realm/test/',
           },
         });
       } else {
@@ -239,6 +247,10 @@ module('Integration | search-index', function (hooks) {
           lastModified: adapter.lastModified.get(
             `${testRealmURL}Pet/mango.json`
           ),
+          realmInfo: {
+            name: 'Unnamed Workspace',
+          },
+          realmURL: 'http://test-realm/test/',
         },
       });
     } else {
@@ -313,6 +325,10 @@ module('Integration | search-index', function (hooks) {
           lastModified: adapter.lastModified.get(
             `${testRealmURL}Pet/mango.json`
           ),
+          realmInfo: {
+            name: 'Unnamed Workspace',
+          },
+          realmURL: 'http://test-realm/test/',
         },
       });
     } else {
@@ -402,6 +418,10 @@ module('Integration | search-index', function (hooks) {
           lastModified: adapter.lastModified.get(
             `${testRealmURL}person-catalog-entry.json`
           ),
+          realmInfo: {
+            name: 'Unnamed Workspace',
+          },
+          realmURL: 'http://test-realm/test/',
         },
       });
     } else {
@@ -894,6 +914,10 @@ module('Integration | search-index', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}jackie.json`
             ),
+            realmInfo: {
+              name: 'Unnamed Workspace',
+            },
+            realmURL: 'http://test-realm/test/',
           },
           relationships: {
             'appointment.contact.pet': {
@@ -1038,6 +1062,10 @@ module('Integration | search-index', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}Vendor/vendor1.json`
             ),
+            realmInfo: {
+              name: 'Unnamed Workspace',
+            },
+            realmURL: 'http://test-realm/test/',
           },
         },
         included: [
@@ -1061,6 +1089,10 @@ module('Integration | search-index', function (hooks) {
               lastModified: adapter.lastModified.get(
                 `${testRealmURL}Chain/1.json`
               ),
+              realmInfo: {
+                name: 'Unnamed Workspace',
+              },
+              realmURL: 'http://test-realm/test/',
             },
           },
           {
@@ -1082,6 +1114,10 @@ module('Integration | search-index', function (hooks) {
               lastModified: adapter.lastModified.get(
                 `${testRealmURL}Chain/2.json`
               ),
+              realmInfo: {
+                name: 'Unnamed Workspace',
+              },
+              realmURL: 'http://test-realm/test/',
             },
           },
         ],
@@ -1326,6 +1362,10 @@ module('Integration | search-index', function (hooks) {
           lastModified: adapter.lastModified.get(
             `${testRealmURL}PetPerson/hassan.json`
           ),
+          realmInfo: {
+            name: 'Unnamed Workspace',
+          },
+          realmURL: 'http://test-realm/test/',
         },
       });
       assert.deepEqual(hassan.doc.included, [
@@ -1340,6 +1380,10 @@ module('Integration | search-index', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}Pet/mango.json`
             ),
+            realmInfo: {
+              name: 'Unnamed Workspace',
+            },
+            realmURL: 'http://test-realm/test/',
           },
         },
         {
@@ -1353,6 +1397,10 @@ module('Integration | search-index', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}Pet/vanGogh.json`
             ),
+            realmInfo: {
+              name: 'Unnamed Workspace',
+            },
+            realmURL: 'http://test-realm/test/',
           },
         },
       ]);
@@ -1427,6 +1475,10 @@ module('Integration | search-index', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}PetPerson/burcu.json`
             ),
+            realmInfo: {
+              name: 'Unnamed Workspace',
+            },
+            realmURL: 'http://test-realm/test/',
           },
         },
       });
@@ -1562,6 +1614,10 @@ module('Integration | search-index', function (hooks) {
           lastModified: adapter.lastModified.get(
             `${testRealmURL}pet-person-catalog-entry.json`
           ),
+          realmInfo: {
+            name: 'Unnamed Workspace',
+          },
+          realmURL: 'http://test-realm/test/',
         },
       });
 
@@ -1577,6 +1633,10 @@ module('Integration | search-index', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}Pet/mango.json`
             ),
+            realmInfo: {
+              name: 'Unnamed Workspace',
+            },
+            realmURL: 'http://test-realm/test/',
           },
         },
         {
@@ -1590,6 +1650,10 @@ module('Integration | search-index', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}Pet/vanGogh.json`
             ),
+            realmInfo: {
+              name: 'Unnamed Workspace',
+            },
+            realmURL: 'http://test-realm/test/',
           },
         },
       ]);
@@ -1732,6 +1796,10 @@ module('Integration | search-index', function (hooks) {
           lastModified: adapter.lastModified.get(
             `${testRealmURL}Friend/hassan.json`
           ),
+          realmInfo: {
+            name: 'Unnamed Workspace',
+          },
+          realmURL: 'http://test-realm/test/',
         },
       });
     } else {
@@ -1846,6 +1914,10 @@ module('Integration | search-index', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}Friend/hassan.json`
             ),
+            realmInfo: {
+              name: 'Unnamed Workspace',
+            },
+            realmURL: 'http://test-realm/test/',
           },
         },
         included: [
@@ -1876,6 +1948,10 @@ module('Integration | search-index', function (hooks) {
               lastModified: adapter.lastModified.get(
                 `${testRealmURL}Friend/mango.json`
               ),
+              realmInfo: {
+                name: 'Unnamed Workspace',
+              },
+              realmURL: 'http://test-realm/test/',
             },
           },
         ],
@@ -1940,6 +2016,10 @@ module('Integration | search-index', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}Friend/mango.json`
             ),
+            realmInfo: {
+              name: 'Unnamed Workspace',
+            },
+            realmURL: 'http://test-realm/test/',
           },
         },
         included: [
@@ -1970,6 +2050,10 @@ module('Integration | search-index', function (hooks) {
               lastModified: adapter.lastModified.get(
                 `${testRealmURL}Friend/hassan.json`
               ),
+              realmInfo: {
+                name: 'Unnamed Workspace',
+              },
+              realmURL: 'http://test-realm/test/',
             },
           },
         ],
@@ -2068,6 +2152,10 @@ module('Integration | search-index', function (hooks) {
           meta: {
             adoptsFrom: friendsRef,
             lastModified: adapter.lastModified.get(`${hassanID}.json`),
+            realmInfo: {
+              name: 'Unnamed Workspace',
+            },
+            realmURL: 'http://test-realm/test/',
           },
         },
         'hassan doc.data is correct'
@@ -2090,6 +2178,10 @@ module('Integration | search-index', function (hooks) {
             meta: {
               adoptsFrom: friendsRef,
               lastModified: adapter.lastModified.get(`${mangoID}.json`),
+              realmInfo: {
+                name: 'Unnamed Workspace',
+              },
+              realmURL: 'http://test-realm/test/',
             },
           },
           {
@@ -2109,6 +2201,10 @@ module('Integration | search-index', function (hooks) {
             meta: {
               adoptsFrom: friendsRef,
               lastModified: adapter.lastModified.get(`${vanGoghID}.json`),
+              realmInfo: {
+                name: 'Unnamed Workspace',
+              },
+              realmURL: 'http://test-realm/test/',
             },
           },
         ],
@@ -2167,6 +2263,10 @@ module('Integration | search-index', function (hooks) {
           meta: {
             adoptsFrom: friendsRef,
             lastModified: adapter.lastModified.get(`${mangoID}.json`),
+            realmInfo: {
+              name: 'Unnamed Workspace',
+            },
+            realmURL: 'http://test-realm/test/',
           },
         },
         'mango doc.data is correct'
@@ -2195,6 +2295,10 @@ module('Integration | search-index', function (hooks) {
             meta: {
               adoptsFrom: friendsRef,
               lastModified: adapter.lastModified.get(`${hassanID}.json`),
+              realmInfo: {
+                name: 'Unnamed Workspace',
+              },
+              realmURL: 'http://test-realm/test/',
             },
           },
           {
@@ -2214,6 +2318,10 @@ module('Integration | search-index', function (hooks) {
             meta: {
               adoptsFrom: friendsRef,
               lastModified: adapter.lastModified.get(`${vanGoghID}.json`),
+              realmInfo: {
+                name: 'Unnamed Workspace',
+              },
+              realmURL: 'http://test-realm/test/',
             },
           },
         ],
@@ -2273,6 +2381,10 @@ module('Integration | search-index', function (hooks) {
           meta: {
             adoptsFrom: friendsRef,
             lastModified: adapter.lastModified.get(`${vanGoghID}.json`),
+            realmInfo: {
+              name: 'Unnamed Workspace',
+            },
+            realmURL: 'http://test-realm/test/',
           },
         },
         'vanGogh doc.data is correct'
@@ -2301,6 +2413,10 @@ module('Integration | search-index', function (hooks) {
             meta: {
               adoptsFrom: friendsRef,
               lastModified: adapter.lastModified.get(`${hassanID}.json`),
+              realmInfo: {
+                name: 'Unnamed Workspace',
+              },
+              realmURL: 'http://test-realm/test/',
             },
           },
           {
@@ -2320,6 +2436,10 @@ module('Integration | search-index', function (hooks) {
             meta: {
               adoptsFrom: friendsRef,
               lastModified: adapter.lastModified.get(`${mangoID}.json`),
+              realmInfo: {
+                name: 'Unnamed Workspace',
+              },
+              realmURL: 'http://test-realm/test/',
             },
           },
         ],

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -103,6 +103,10 @@ module('Realm Server', function (hooks) {
             module: `${testRealmURL}person`,
             name: 'Person',
           },
+          realmInfo: {
+            "name": "Test Realm"
+          },
+          realmURL: "http://127.0.0.1:4444/",
         },
         links: {
           self: `${testRealmHref}person-1`,

--- a/packages/runtime-common/card-document.ts
+++ b/packages/runtime-common/card-document.ts
@@ -26,6 +26,10 @@ export type Relationship = {
   meta?: Record<string, any>;
 };
 
+export type RealmInfo = {
+  name: string;
+}
+
 export interface CardResource<Identity extends Unsaved = Saved> {
   id: Identity;
   type: 'card';
@@ -35,6 +39,8 @@ export interface CardResource<Identity extends Unsaved = Saved> {
   };
   meta: Meta & {
     lastModified?: number;
+    realmInfo?: RealmInfo;
+    realmURL?: string;
   };
   links?: {
     self?: string;

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -78,6 +78,7 @@ export type {
   CardDocument,
   CardFields,
   SingleCardDocument,
+  RealmInfo,
   Relationship,
   Meta,
 } from './card-document';


### PR DESCRIPTION
As discussed, we need to have realm info in the card meta so we can use it in the catalog entry card. Here is an example of a card JSON response.

```
{
    "data": {
        "type": "card",
        "id": "http://localhost:4202/test/hassan",
        "attributes": {
            "firstName": "Hassan",
            "lastName": "Abdel-Rahman"
        },
        "meta": {
            "adoptsFrom": {
                "module": "http://localhost:4202/test/person",
                "name": "Person"
            },
            "lastModified": 1675338397168,
            "realmInfo": {
                "name": "Test Workspace"
            },
            "realmURL": "http://localhost:4202/test/"
        },
        "links": {
            "self": "http://localhost:4202/test/hassan"
        }
    }
}

```