### PR TITLE
Add missing overlay buttons on linked field in demo cards

### DIFF
--- a/packages/demo-cards/author.gts
+++ b/packages/demo-cards/author.gts
@@ -25,6 +25,7 @@ export class Author extends Card {
       <CardContainer
         class='demo-card'
         @displayBoundaries={{true}}
+        {{! @glint-ignore  Argument of type 'unknown' is not assignable to parameter of type 'Element'}}
         ...attributes
       >
         <@fields.firstName />

--- a/packages/demo-cards/author.gts
+++ b/packages/demo-cards/author.gts
@@ -6,6 +6,7 @@ import {
   field,
   contains,
 } from 'https://cardstack.com/base/card-api';
+import { CardContainer } from '@cardstack/boxel-ui';
 
 export class Author extends Card {
   static displayName = 'Author Bio';
@@ -21,7 +22,14 @@ export class Author extends Card {
 
   static embedded = class Embedded extends Component<typeof this> {
     <template>
-      <@fields.firstName /> <@fields.lastName />
+      <CardContainer
+        class='demo-card'
+        @displayBoundaries={{true}}
+        ...attributes
+      >
+        <@fields.firstName />
+        <@fields.lastName />
+      </CardContainer>
     </template>
   };
 }

--- a/packages/demo-cards/friend.gts
+++ b/packages/demo-cards/friend.gts
@@ -29,6 +29,7 @@ export class Friend extends Card {
       <CardContainer
         class='demo-card'
         @displayBoundaries={{true}}
+        {{! @glint-ignore  Argument of type 'unknown' is not assignable to parameter of type 'Element'}}
         ...attributes
       >
         <@fields.firstName />

--- a/packages/demo-cards/friend.gts
+++ b/packages/demo-cards/friend.gts
@@ -7,6 +7,7 @@ import {
 } from 'https://cardstack.com/base/card-api';
 import IntegerCard from 'https://cardstack.com/base/integer';
 import StringCard from 'https://cardstack.com/base/string';
+import { CardContainer } from '@cardstack/boxel-ui';
 
 export class Friend extends Card {
   static displayName = 'Friend';
@@ -25,7 +26,13 @@ export class Friend extends Card {
   });
   static embedded = class Embedded extends Component<typeof this> {
     <template>
-      <@fields.firstName />
+      <CardContainer
+        class='demo-card'
+        @displayBoundaries={{true}}
+        ...attributes
+      >
+        <@fields.firstName />
+      </CardContainer>
     </template>
   };
 }

--- a/packages/host/app/components/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode-overlays.gts
@@ -97,8 +97,8 @@ export default class OperatorModeOverlays extends Component<Signature> {
 
     // Places the button in the top right of the linksTo card
     return {
-      x: delta + cardElementRect.width - 60, // x starts at the left edge of the operator mode stack
-      y: cardElementRect.y + 10,
+      x: delta + cardElementRect.width - 65, // x starts at the left edge of the operator mode stack
+      y: cardElementRect.y,
     };
   }
 

--- a/packages/host/app/modifiers/links-to-card-component-modifier.ts
+++ b/packages/host/app/modifiers/links-to-card-component-modifier.ts
@@ -13,14 +13,19 @@ export default class LinksToCardComponentModifier extends Modifier<Signature> {
     element: HTMLElement,
     [card, context]: Signature['Args']['Positional']
   ) {
-    if (context.optional.fieldType === 'linksTo') {
-      (context.renderedIn as any)?.registerLinkedCardElement(
-        element,
-        card,
-        context
-      );
+    if (context.optional.fieldType !== 'linksTo') {
+      return;
     }
 
+    if (!card) {
+      return; // Empty linked card. Don't render the "Open" button because there is nothing to open.
+    }
+
+    (context.renderedIn as any)?.registerLinkedCardElement(
+      element,
+      card,
+      context
+    );
     registerDestructor(this, () => {
       (context.renderedIn as any)?.unregisterLinkedCardElement(card);
     });

--- a/packages/host/app/styles/app.css
+++ b/packages/host/app/styles/app.css
@@ -539,6 +539,8 @@ nav > .directory-level {
   position: absolute;
   border: none;
   width: auto;
+  margin-top: var(--boxel-sp);
+  margin-right: var(--boxel-sp);
 }
 
 .freestyle-search-sheet-example-container {


### PR DESCRIPTION
Previously, the "Open" buttons in demo cards did not show up in cases of embedded "author" and "friend". They show up now: 

<img width="726" alt="image" src="https://github.com/cardstack/boxel/assets/273660/27f7804e-da46-4e2c-82e2-bbcd9ab273ec">

<img width="741" alt="image" src="https://github.com/cardstack/boxel/assets/273660/8bc50b7b-f433-4f22-81e9-d03dcac5f51a">


This was due to missing `...attributes` which I added to demo cards where necessary. 

Adding `...attributes` allows for the `LinksToCardComponentModifier` to be applied on linked card elements, which registers the element in operator mode so that we know where to place the overlayed "Open" buttons. 