### PR TITLE
Make dedicated space for footer

### DIFF
--- a/packages/host/app/styles/app.css
+++ b/packages/host/app/styles/app.css
@@ -3,6 +3,7 @@
   --operator-mode-bg-color: #686283;
   --grid-card-text-thumbnail-height: 6.25rem;
   --grid-card-label-color: #919191;
+  --stack-card-footer-height: 80px;
 }
 
 /* Go template */
@@ -519,7 +520,7 @@ nav > .directory-level {
 }
 
 .operator-mode-card-stack__card--edit .operator-mode-card-stack__card__content {
-  padding-bottom: 5rem; /* footer height */
+  margin-bottom: var(--stack-card-footer-height)
 }
 
 .operator-mode-card-stack__card__footer {
@@ -529,6 +530,12 @@ nav > .directory-level {
   display: flex;
   justify-content: flex-end;
   padding: var(--boxel-sp);
+  width: 100%;
+  background: white;
+  height: var(--stack-card-footer-height);
+  border-top: 1px solid var(--boxel-300);
+  border-bottom-left-radius: var(--boxel-border-radius);
+  border-bottom-right-radius: var(--boxel-border-radius);
 }
 
 .operator-mode-card-stack__card__footer-button + .operator-mode-card-stack__card__footer-button {


### PR DESCRIPTION
This PR fixes situations where the buttons in the footer fall out of place when there is little space, like so:

<img width="311" alt="image" src="https://github.com/cardstack/boxel/assets/273660/3e158c6b-a97f-45d3-9431-5ede84269db8">

It introduces a dedicated space for the footer, with specified height, so that the content above does not interfere with it.

<img width="813" alt="image" src="https://github.com/cardstack/boxel/assets/273660/8bbfb642-b769-402e-8320-c8c084b45081">



