### PR TITLE
Change priorities in route pattern matching for card route

### DIFF
--- a/packages/host/app/router.ts
+++ b/packages/host/app/router.ts
@@ -27,7 +27,7 @@ Router.map(function () {
       this.route('register');
       this.route('room', { path: `/room/:id` });
     });
-    this.route('card', { path });
+
     this.route('code', { path: `${path}/code` });
   }
 });

--- a/packages/host/app/router.ts
+++ b/packages/host/app/router.ts
@@ -13,6 +13,8 @@ Router.map(function () {
   this.route('freestyle', { path: '/_freestyle' });
   this.route('indexer', { path: '/indexer/:id' });
   this.route('acceptance-test-setup');
+  this.route('card', { path: '/*path' });
+
   if (!path || hostsOwnAssets) {
     this.route('chat', function () {
       this.route('register');
@@ -28,5 +30,4 @@ Router.map(function () {
     this.route('card', { path });
     this.route('code', { path: `${path}/code` });
   }
-  this.route('card', { path: '/*path' });
 });


### PR DESCRIPTION
Where there are multiple realms available, for example in staging, where we have base and demo, and you go to /demo and see the index card, and want to open it in operator mode, the following error happens:

<img width="2142" alt="image" src="https://github.com/cardstack/boxel/assets/273660/4030f8e3-6732-478e-89e6-8450b3e970ac">

This started happening after we introduced operator mode stack state persistence using query params.

It looks like the bug is that the change in operator mode query params causes the route to reload (because we have the `refreshRoute` for those params enabled), and the router thinks we are in `this.route('card', { path: '/*path' });` route while `this.route('card', { path });` should take precedence over that one. 

This change in routing seems to fix the situation.

I have tested the following scenarios - cards open successfully and one can enter operator mode from there **without errors**:

1. host-url/realm-name/ (opens index card in the specified realm, i.e. http://localhost:4200/demo)
2. host-url/ (opens index card in the default realm - i.e. http://localhost:4200)
3. host-url/realm-name/Person/1 (opens Person card in the specified realm, i.e. http://localhost:4200/demo/Person/1)
4. host-url/Person/1 (opens Person card in the default realm, i.e. http://localhost:4200/Person/1)