### PR TITLE
ui: Fix spurious type errors when building

### DIFF
--- a/packages/boxel-ui/ember-cli-build.js
+++ b/packages/boxel-ui/ember-cli-build.js
@@ -10,6 +10,9 @@ const { GlimmerScopedCSSWebpackPlugin } = require('glimmer-scoped-css/webpack');
 
 module.exports = function (defaults) {
   const app = new EmberAddon(defaults, {
+    'ember-cli-babel': {
+      enableTypeScriptTransform: true,
+    },
     vendorFiles: { 'jquery.js': null, 'app-shims.js': null },
   });
 

--- a/packages/boxel-ui/index.js
+++ b/packages/boxel-ui/index.js
@@ -3,6 +3,11 @@ const { installScopedCSS } = require('glimmer-scoped-css');
 
 module.exports = {
   name: require('./package').name,
+  options: {
+    'ember-cli-babel': {
+      enableTypeScriptTransform: true,
+    },
+  },
   isDevelopingAddon() {
     return true;
   },

--- a/packages/boxel-ui/package.json
+++ b/packages/boxel-ui/package.json
@@ -32,7 +32,6 @@
     "ember-auto-import": "^2.6.3",
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.2.0",
-    "ember-cli-typescript": "^5.2.1",
     "ember-composable-helpers": "^5.0.0",
     "ember-focus-trap": "^1.0.1",
     "ember-load-initializers": "^2.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -626,9 +626,6 @@ importers:
       ember-cli-htmlbars:
         specifier: ^6.2.0
         version: 6.2.0
-      ember-cli-typescript:
-        specifier: ^5.2.1
-        version: 5.2.1
       ember-composable-helpers:
         specifier: ^5.0.0
         version: 5.0.0
@@ -2260,7 +2257,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.0(supports-color@8.1.1)
-      '@babel/helper-create-class-features-plugin': 7.20.2(@babel/core@7.21.0)
+      '@babel/helper-create-class-features-plugin': 7.21.8(@babel/core@7.21.0)
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
@@ -6998,6 +6995,7 @@ packages:
       make-dir: 3.1.0
       schema-utils: 2.7.1
       webpack: 5.75.0
+    dev: false
 
   /babel-loader@8.3.0(@babel/core@7.21.0)(webpack@5.84.0):
     resolution: {integrity: sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==}
@@ -10475,6 +10473,7 @@ packages:
       - '@glint/template'
       - supports-color
       - webpack
+    dev: false
 
   /ember-auto-import@2.6.3(@glint/template@1.0.2)(webpack@5.84.0):
     resolution: {integrity: sha512-uLhrRDJYWCRvQ4JQ1e64XlSrqAKSd6PXaJ9ZsZI6Tlms9T4DtQFxNXasqji2ZRJBVrxEoLCRYX3RTldsQ0vNGQ==}
@@ -11567,7 +11566,7 @@ packages:
       '@embroider/addon-shim': 1.8.5
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-string-utils: 1.1.0
-      ember-source: 4.12.0(@babel/core@7.20.2)(@glimmer/component@1.1.2)(@glint/template@1.0.2)(webpack@5.75.0)
+      ember-source: 4.12.0(@babel/core@7.20.2)(@glimmer/component@1.1.2)(@glint/template@1.0.2)(webpack@5.84.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11836,6 +11835,7 @@ packages:
       - '@glint/template'
       - supports-color
       - webpack
+    dev: false
 
   /ember-source@4.12.0(@babel/core@7.20.2)(@glimmer/component@1.1.2)(@glint/template@1.0.2)(webpack@5.84.0):
     resolution: {integrity: sha512-h0lV902A4Mny2eiqXPy15uXXoCc7BnUegE4axLAy4IoxEkJ1o5h0aLJFiB4Tzb1htx8vgHjJz//Y5Jig7NSDTw==}
@@ -22320,7 +22320,7 @@ packages:
       ember-cli-htmlbars: 6.2.0
       ember-compatibility-helpers: 1.2.6(@babel/core@7.20.2)
       ember-destroyable-polyfill: 2.0.3(@babel/core@7.20.2)
-      ember-source: 4.12.0(@babel/core@7.20.2)(@glimmer/component@1.1.2)(@glint/template@1.0.2)(webpack@5.75.0)
+      ember-source: 4.12.0(@babel/core@7.20.2)(@glimmer/component@1.1.2)(@glint/template@1.0.2)(webpack@5.84.0)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color


### PR DESCRIPTION
This moves to using `ember-cli-babel` to build Typescript instead of `ember-cli-typescript`, whose use of `tsc` was producing confusing type errors like [this](https://github.com/cardstack/boxel/actions/runs/5247979061/jobs/9478860871#step:5:51).