### PR TITLE
Add background URL to realm info

### DIFF
--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -6,6 +6,7 @@ import {
   LooseSingleCardDocument,
   baseRealm,
   createResponse,
+  RealmInfo,
 } from '@cardstack/runtime-common';
 import GlimmerComponent from '@glimmer/component';
 import { type TestContext, visit } from '@ember/test-helpers';
@@ -52,7 +53,10 @@ export interface Dir {
 }
 
 export const testRealmURL = `http://test-realm/test/`;
-export const testRealmName = `Test Realm`;
+export const testRealmInfo: RealmInfo = {
+  name: 'Unnamed Workspace',
+  backgroundURL: null,
+};
 
 export interface CardDocFiles {
   [filename: string]: LooseSingleCardDocument;

--- a/packages/host/tests/integration/realm-test.ts
+++ b/packages/host/tests/integration/realm-test.ts
@@ -8,6 +8,7 @@ import {
   TestRealm,
   TestRealmAdapter,
   testRealmURL,
+  testRealmInfo,
   setupCardLogs,
   setupLocalIndexing,
 } from '../helpers';
@@ -127,9 +128,7 @@ module('Integration | realm', function (hooks) {
           lastModified: adapter.lastModified.get(
             `${testRealmURL}dir/empty.json`
           ),
-          realmInfo: {
-            name: 'Unnamed Workspace',
-          },
+          realmInfo: testRealmInfo,
           realmURL: testRealmURL,
         },
         links: {
@@ -217,9 +216,7 @@ module('Integration | realm', function (hooks) {
           lastModified: adapter.lastModified.get(
             `${testRealmURL}dir/mango.json`
           ),
-          realmInfo: {
-            name: 'Unnamed Workspace',
-          },
+          realmInfo: testRealmInfo,
           realmURL: testRealmURL,
         },
         links: {
@@ -242,9 +239,7 @@ module('Integration | realm', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}dir/owner.json`
             ),
-            realmInfo: {
-              name: 'Unnamed Workspace',
-            },
+            realmInfo: testRealmInfo,
             realmURL: testRealmURL,
           },
           links: {
@@ -319,9 +314,7 @@ module('Integration | realm', function (hooks) {
           lastModified: adapter.lastModified.get(
             `${testRealmURL}dir/mango.json`
           ),
-          realmInfo: {
-            name: 'Unnamed Workspace',
-          },
+          realmInfo: testRealmInfo,
           realmURL: testRealmURL,
         },
         links: {
@@ -342,6 +335,7 @@ module('Integration | realm', function (hooks) {
               name: 'Person',
             },
             realmInfo: {
+              ...testRealmInfo,
               name: 'Test Workspace',
             },
             realmURL: 'http://localhost:4202/test/',
@@ -623,9 +617,7 @@ module('Integration | realm', function (hooks) {
             name: 'Pet',
           },
           lastModified: adapter.lastModified.get(`${testRealmURL}Pet/1.json`),
-          realmInfo: {
-            name: 'Unnamed Workspace',
-          },
+          realmInfo: testRealmInfo,
           realmURL: testRealmURL,
         },
         links: {
@@ -648,9 +640,7 @@ module('Integration | realm', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}dir/owner.json`
             ),
-            realmInfo: {
-              name: 'Unnamed Workspace',
-            },
+            realmInfo: testRealmInfo,
             realmURL: testRealmURL,
           },
           links: {
@@ -908,9 +898,7 @@ module('Integration | realm', function (hooks) {
           lastModified: adapter.lastModified.get(
             `${testRealmURL}ski-trip.json`
           ),
-          realmInfo: {
-            name: 'Unnamed Workspace',
-          },
+          realmInfo: testRealmInfo,
           realmURL: testRealmURL,
         },
       },
@@ -1060,7 +1048,7 @@ module('Integration | realm', function (hooks) {
             name: 'PetPerson',
           },
           lastModified: adapter.lastModified.get(`${testRealmURL}jackie.json`),
-          realmInfo: { name: 'Unnamed Workspace' },
+          realmInfo: testRealmInfo,
           realmURL: testRealmURL,
         },
       },
@@ -1078,7 +1066,7 @@ module('Integration | realm', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}dir/friend.json`
             ),
-            realmInfo: { name: 'Unnamed Workspace' },
+            realmInfo: testRealmInfo,
             realmURL: testRealmURL,
           },
         },
@@ -1096,7 +1084,7 @@ module('Integration | realm', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}dir/van-gogh.json`
             ),
-            realmInfo: { name: 'Unnamed Workspace' },
+            realmInfo: testRealmInfo,
             realmURL: testRealmURL,
           },
         },
@@ -1250,7 +1238,7 @@ module('Integration | realm', function (hooks) {
           name: 'PetPerson',
         },
         lastModified: adapter.lastModified.get(`${testRealmURL}jackie.json`),
-        realmInfo: { name: 'Unnamed Workspace' },
+        realmInfo: testRealmInfo,
         realmURL: testRealmURL,
       },
     });
@@ -1353,7 +1341,7 @@ module('Integration | realm', function (hooks) {
           name: 'PetPerson',
         },
         lastModified: adapter.lastModified.get(`${testRealmURL}jackie.json`),
-        realmInfo: { name: 'Unnamed Workspace' },
+        realmInfo: testRealmInfo,
         realmURL: testRealmURL,
       },
     });
@@ -1447,7 +1435,7 @@ module('Integration | realm', function (hooks) {
           name: 'PetPerson',
         },
         lastModified: adapter.lastModified.get(`${testRealmURL}jackie.json`),
-        realmInfo: { name: 'Unnamed Workspace' },
+        realmInfo: testRealmInfo,
         realmURL: testRealmURL,
       },
     });
@@ -1563,7 +1551,7 @@ module('Integration | realm', function (hooks) {
           name: 'PetPerson',
         },
         lastModified: adapter.lastModified.get(`${testRealmURL}jackie.json`),
-        realmInfo: { name: 'Unnamed Workspace' },
+        realmInfo: testRealmInfo,
         realmURL: testRealmURL,
       },
     });
@@ -1693,7 +1681,7 @@ module('Integration | realm', function (hooks) {
           name: 'PetPerson',
         },
         lastModified: adapter.lastModified.get(`${testRealmURL}jackie.json`),
-        realmInfo: { name: 'Unnamed Workspace' },
+        realmInfo: testRealmInfo,
         realmURL: testRealmURL,
       },
     });
@@ -1814,9 +1802,7 @@ module('Integration | realm', function (hooks) {
           lastModified: adapter.lastModified.get(
             `${testRealmURL}dir/mango.json`
           ),
-          realmInfo: {
-            name: 'Unnamed Workspace',
-          },
+          realmInfo: testRealmInfo,
           realmURL: testRealmURL,
         },
         links: {
@@ -1839,9 +1825,7 @@ module('Integration | realm', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}dir/mariko.json`
             ),
-            realmInfo: {
-              name: 'Unnamed Workspace',
-            },
+            realmInfo: testRealmInfo,
             realmURL: testRealmURL,
           },
           links: {
@@ -2320,9 +2304,7 @@ module('Integration | realm', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}dir/mango.json`
             ),
-            realmInfo: {
-              name: 'Unnamed Workspace',
-            },
+            realmInfo: testRealmInfo,
             realmURL: testRealmURL,
           },
           links: {
@@ -2344,9 +2326,7 @@ module('Integration | realm', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}dir/mariko.json`
             ),
-            realmInfo: {
-              name: 'Unnamed Workspace',
-            },
+            realmInfo: testRealmInfo,
             realmURL: testRealmURL,
           },
           links: {
@@ -2378,9 +2358,7 @@ module('Integration | realm', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}dir/vanGogh.json`
             ),
-            realmInfo: {
-              name: 'Unnamed Workspace',
-            },
+            realmInfo: testRealmInfo,
             realmURL: testRealmURL,
           },
           links: {
@@ -2401,7 +2379,7 @@ module('Integration | realm', function (hooks) {
               module: 'http://localhost:4202/test/person',
               name: 'Person',
             },
-            realmInfo: { name: 'Test Workspace' },
+            realmInfo: { ...testRealmInfo, name: 'Test Workspace' },
             realmURL: 'http://localhost:4202/test/',
           },
           links: {
@@ -2561,7 +2539,8 @@ posts/ignore-me.gts
     let realm = await TestRealm.create(
       {
         '.realm.json': `{
-          "name": "Example Workspace"
+          "name": "Example Workspace",
+          "backgroundURL": "https://example-background-url.com"
         }`,
       },
       this.owner
@@ -2583,6 +2562,7 @@ posts/ignore-me.gts
           type: 'realm-info',
           attributes: {
             name: 'Example Workspace',
+            backgroundURL: 'https://example-background-url.com',
           },
         },
       },
@@ -2607,9 +2587,7 @@ posts/ignore-me.gts
         data: {
           id: testRealmURL,
           type: 'realm-info',
-          attributes: {
-            name: 'Unnamed Workspace',
-          },
+          attributes: testRealmInfo,
         },
       },
       '/_info response is correct'
@@ -2638,9 +2616,7 @@ posts/ignore-me.gts
         data: {
           id: testRealmURL,
           type: 'realm-info',
-          attributes: {
-            name: 'Unnamed Workspace',
-          },
+          attributes: testRealmInfo,
         },
       },
       '/_info response is correct'

--- a/packages/host/tests/integration/search-index-test.ts
+++ b/packages/host/tests/integration/search-index-test.ts
@@ -3,6 +3,7 @@ import {
   TestRealm,
   TestRealmAdapter,
   testRealmURL,
+  testRealmInfo,
   cleanWhiteSpace,
   trimCardContainer,
   setupCardLogs,
@@ -71,9 +72,7 @@ module('Integration | search-index', function (hooks) {
             name: 'Card',
           },
           lastModified: adapter.lastModified.get(`${testRealmURL}empty.json`),
-          realmInfo: {
-            name: 'Unnamed Workspace',
-          },
+          realmInfo: testRealmInfo,
           realmURL: 'http://test-realm/test/',
         },
         links: {
@@ -169,9 +168,7 @@ module('Integration | search-index', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}Pet/mango.json`
             ),
-            realmInfo: {
-              name: 'Unnamed Workspace',
-            },
+            realmInfo: testRealmInfo,
             realmURL: 'http://test-realm/test/',
           },
         });
@@ -248,9 +245,7 @@ module('Integration | search-index', function (hooks) {
           lastModified: adapter.lastModified.get(
             `${testRealmURL}Pet/mango.json`
           ),
-          realmInfo: {
-            name: 'Unnamed Workspace',
-          },
+          realmInfo: testRealmInfo,
           realmURL: 'http://test-realm/test/',
         },
       });
@@ -326,9 +321,7 @@ module('Integration | search-index', function (hooks) {
           lastModified: adapter.lastModified.get(
             `${testRealmURL}Pet/mango.json`
           ),
-          realmInfo: {
-            name: 'Unnamed Workspace',
-          },
+          realmInfo: testRealmInfo,
           realmURL: 'http://test-realm/test/',
         },
       });
@@ -420,9 +413,7 @@ module('Integration | search-index', function (hooks) {
           lastModified: adapter.lastModified.get(
             `${testRealmURL}person-catalog-entry.json`
           ),
-          realmInfo: {
-            name: 'Unnamed Workspace',
-          },
+          realmInfo: testRealmInfo,
           realmURL: 'http://test-realm/test/',
         },
       });
@@ -916,9 +907,7 @@ module('Integration | search-index', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}jackie.json`
             ),
-            realmInfo: {
-              name: 'Unnamed Workspace',
-            },
+            realmInfo: testRealmInfo,
             realmURL: 'http://test-realm/test/',
           },
           relationships: {
@@ -1064,9 +1053,7 @@ module('Integration | search-index', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}Vendor/vendor1.json`
             ),
-            realmInfo: {
-              name: 'Unnamed Workspace',
-            },
+            realmInfo: testRealmInfo,
             realmURL: 'http://test-realm/test/',
           },
         },
@@ -1091,9 +1078,7 @@ module('Integration | search-index', function (hooks) {
               lastModified: adapter.lastModified.get(
                 `${testRealmURL}Chain/1.json`
               ),
-              realmInfo: {
-                name: 'Unnamed Workspace',
-              },
+              realmInfo: testRealmInfo,
               realmURL: 'http://test-realm/test/',
             },
           },
@@ -1116,9 +1101,7 @@ module('Integration | search-index', function (hooks) {
               lastModified: adapter.lastModified.get(
                 `${testRealmURL}Chain/2.json`
               ),
-              realmInfo: {
-                name: 'Unnamed Workspace',
-              },
+              realmInfo: testRealmInfo,
               realmURL: 'http://test-realm/test/',
             },
           },
@@ -1370,9 +1353,7 @@ module('Integration | search-index', function (hooks) {
           lastModified: adapter.lastModified.get(
             `${testRealmURL}PetPerson/hassan.json`
           ),
-          realmInfo: {
-            name: 'Unnamed Workspace',
-          },
+          realmInfo: testRealmInfo,
           realmURL: 'http://test-realm/test/',
         },
       });
@@ -1388,9 +1369,7 @@ module('Integration | search-index', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}Pet/mango.json`
             ),
-            realmInfo: {
-              name: 'Unnamed Workspace',
-            },
+            realmInfo: testRealmInfo,
             realmURL: 'http://test-realm/test/',
           },
         },
@@ -1405,9 +1384,7 @@ module('Integration | search-index', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}Pet/vanGogh.json`
             ),
-            realmInfo: {
-              name: 'Unnamed Workspace',
-            },
+            realmInfo: testRealmInfo,
             realmURL: 'http://test-realm/test/',
           },
         },
@@ -1488,9 +1465,7 @@ module('Integration | search-index', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}PetPerson/burcu.json`
             ),
-            realmInfo: {
-              name: 'Unnamed Workspace',
-            },
+            realmInfo: testRealmInfo,
             realmURL: 'http://test-realm/test/',
           },
         },
@@ -1631,9 +1606,7 @@ module('Integration | search-index', function (hooks) {
           lastModified: adapter.lastModified.get(
             `${testRealmURL}pet-person-catalog-entry.json`
           ),
-          realmInfo: {
-            name: 'Unnamed Workspace',
-          },
+          realmInfo: testRealmInfo,
           realmURL: 'http://test-realm/test/',
         },
       });
@@ -1650,9 +1623,7 @@ module('Integration | search-index', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}Pet/mango.json`
             ),
-            realmInfo: {
-              name: 'Unnamed Workspace',
-            },
+            realmInfo: testRealmInfo,
             realmURL: 'http://test-realm/test/',
           },
         },
@@ -1667,9 +1638,7 @@ module('Integration | search-index', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}Pet/vanGogh.json`
             ),
-            realmInfo: {
-              name: 'Unnamed Workspace',
-            },
+            realmInfo: testRealmInfo,
             realmURL: 'http://test-realm/test/',
           },
         },
@@ -1815,9 +1784,7 @@ module('Integration | search-index', function (hooks) {
           lastModified: adapter.lastModified.get(
             `${testRealmURL}Friend/hassan.json`
           ),
-          realmInfo: {
-            name: 'Unnamed Workspace',
-          },
+          realmInfo: testRealmInfo,
           realmURL: 'http://test-realm/test/',
         },
       });
@@ -1933,9 +1900,7 @@ module('Integration | search-index', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}Friend/hassan.json`
             ),
-            realmInfo: {
-              name: 'Unnamed Workspace',
-            },
+            realmInfo: testRealmInfo,
             realmURL: 'http://test-realm/test/',
           },
         },
@@ -1967,9 +1932,7 @@ module('Integration | search-index', function (hooks) {
               lastModified: adapter.lastModified.get(
                 `${testRealmURL}Friend/mango.json`
               ),
-              realmInfo: {
-                name: 'Unnamed Workspace',
-              },
+              realmInfo: testRealmInfo,
               realmURL: 'http://test-realm/test/',
             },
           },
@@ -2035,9 +1998,7 @@ module('Integration | search-index', function (hooks) {
             lastModified: adapter.lastModified.get(
               `${testRealmURL}Friend/mango.json`
             ),
-            realmInfo: {
-              name: 'Unnamed Workspace',
-            },
+            realmInfo: testRealmInfo,
             realmURL: 'http://test-realm/test/',
           },
         },
@@ -2069,9 +2030,7 @@ module('Integration | search-index', function (hooks) {
               lastModified: adapter.lastModified.get(
                 `${testRealmURL}Friend/hassan.json`
               ),
-              realmInfo: {
-                name: 'Unnamed Workspace',
-              },
+              realmInfo: testRealmInfo,
               realmURL: 'http://test-realm/test/',
             },
           },
@@ -2171,9 +2130,7 @@ module('Integration | search-index', function (hooks) {
           meta: {
             adoptsFrom: friendsRef,
             lastModified: adapter.lastModified.get(`${hassanID}.json`),
-            realmInfo: {
-              name: 'Unnamed Workspace',
-            },
+            realmInfo: testRealmInfo,
             realmURL: 'http://test-realm/test/',
           },
         },
@@ -2197,9 +2154,7 @@ module('Integration | search-index', function (hooks) {
             meta: {
               adoptsFrom: friendsRef,
               lastModified: adapter.lastModified.get(`${mangoID}.json`),
-              realmInfo: {
-                name: 'Unnamed Workspace',
-              },
+              realmInfo: testRealmInfo,
               realmURL: 'http://test-realm/test/',
             },
           },
@@ -2220,9 +2175,7 @@ module('Integration | search-index', function (hooks) {
             meta: {
               adoptsFrom: friendsRef,
               lastModified: adapter.lastModified.get(`${vanGoghID}.json`),
-              realmInfo: {
-                name: 'Unnamed Workspace',
-              },
+              realmInfo: testRealmInfo,
               realmURL: 'http://test-realm/test/',
             },
           },
@@ -2282,9 +2235,7 @@ module('Integration | search-index', function (hooks) {
           meta: {
             adoptsFrom: friendsRef,
             lastModified: adapter.lastModified.get(`${mangoID}.json`),
-            realmInfo: {
-              name: 'Unnamed Workspace',
-            },
+            realmInfo: testRealmInfo,
             realmURL: 'http://test-realm/test/',
           },
         },
@@ -2314,9 +2265,7 @@ module('Integration | search-index', function (hooks) {
             meta: {
               adoptsFrom: friendsRef,
               lastModified: adapter.lastModified.get(`${hassanID}.json`),
-              realmInfo: {
-                name: 'Unnamed Workspace',
-              },
+              realmInfo: testRealmInfo,
               realmURL: 'http://test-realm/test/',
             },
           },
@@ -2337,9 +2286,7 @@ module('Integration | search-index', function (hooks) {
             meta: {
               adoptsFrom: friendsRef,
               lastModified: adapter.lastModified.get(`${vanGoghID}.json`),
-              realmInfo: {
-                name: 'Unnamed Workspace',
-              },
+              realmInfo: testRealmInfo,
               realmURL: 'http://test-realm/test/',
             },
           },
@@ -2400,9 +2347,7 @@ module('Integration | search-index', function (hooks) {
           meta: {
             adoptsFrom: friendsRef,
             lastModified: adapter.lastModified.get(`${vanGoghID}.json`),
-            realmInfo: {
-              name: 'Unnamed Workspace',
-            },
+            realmInfo: testRealmInfo,
             realmURL: 'http://test-realm/test/',
           },
         },
@@ -2432,9 +2377,7 @@ module('Integration | search-index', function (hooks) {
             meta: {
               adoptsFrom: friendsRef,
               lastModified: adapter.lastModified.get(`${hassanID}.json`),
-              realmInfo: {
-                name: 'Unnamed Workspace',
-              },
+              realmInfo: testRealmInfo,
               realmURL: 'http://test-realm/test/',
             },
           },
@@ -2455,9 +2398,7 @@ module('Integration | search-index', function (hooks) {
             meta: {
               adoptsFrom: friendsRef,
               lastModified: adapter.lastModified.get(`${mangoID}.json`),
-              realmInfo: {
-                name: 'Unnamed Workspace',
-              },
+              realmInfo: testRealmInfo,
               realmURL: 'http://test-realm/test/',
             },
           },

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -104,7 +104,8 @@ module('Realm Server', function (hooks) {
             name: 'Person',
           },
           realmInfo: {
-            "name": "Test Realm"
+            "name": "Test Realm",
+            "backgroundURL": null
           },
           realmURL: "http://127.0.0.1:4444/",
         },
@@ -423,6 +424,7 @@ module('Realm Server', function (hooks) {
           type: 'realm-info',
           attributes: {
             name: 'Test Realm',
+            backgroundURL: null,
           },
         },
       },

--- a/packages/runtime-common/card-document.ts
+++ b/packages/runtime-common/card-document.ts
@@ -1,4 +1,5 @@
 import { type CardRef, isCardRef } from './card-ref';
+import { RealmInfo } from './realm';
 
 export type Saved = string;
 export type Unsaved = string | undefined;
@@ -25,10 +26,6 @@ export type Relationship = {
   data?: ResourceID | ResourceID[] | null;
   meta?: Record<string, any>;
 };
-
-export type RealmInfo = {
-  name: string;
-}
 
 export interface CardResource<Identity extends Unsaved = Saved> {
   id: Identity;

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -64,6 +64,7 @@ export type {
   RealmAdapter,
   FileRef,
   ResponseWithNodeStream,
+  RealmInfo,
 } from './realm';
 
 import type { Saved } from './card-document';
@@ -78,7 +79,6 @@ export type {
   CardDocument,
   CardFields,
   SingleCardDocument,
-  RealmInfo,
   Relationship,
   Meta,
 } from './card-document';

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -67,6 +67,11 @@ import type { LoaderType } from 'https://cardstack.com/base/card-api';
 import { createResponse } from './create-response';
 import { mergeRelationships } from './merge-relationships';
 
+export type RealmInfo = {
+  name: string;
+  backgroundURL: string | null;
+}
+
 export interface FileRef {
   path: LocalPath;
   content: ReadableStream<Uint8Array> | Readable | Uint8Array | string;
@@ -793,13 +798,15 @@ export class Realm {
     let fileURL = this.paths.fileURL(`.realm.json`);
     let localPath: LocalPath = this.paths.local(fileURL);
     let realmConfig = await this.readFileAsText(localPath);
-    let name = 'Unnamed Workspace';
+    let realmInfo: RealmInfo = {
+      name: 'Unnamed Workspace',
+      backgroundURL: null,
+    }
     if (realmConfig) {
       try {
         let realmConfigJson = JSON.parse(realmConfig.content);
-        if (realmConfigJson.name) {
-          name = realmConfigJson.name;
-        }
+        realmInfo.name = realmConfigJson.name ?? realmInfo.name;
+        realmInfo.backgroundURL = realmConfigJson.backgroundURL ?? realmInfo.backgroundURL;
       } catch (e) {
         this.#log.warn(`failed to parse realm config: ${e}`);
       }
@@ -808,9 +815,7 @@ export class Realm {
       data: {
         id: this.paths.url.toString(),
         type: 'realm-info',
-        attributes: {
-          name,
-        },
+        attributes: realmInfo,
       },
     };
     return createResponse(JSON.stringify(doc, null, 2), {


### PR DESCRIPTION
The following is a JSON response example of realm info API.

```
{
    "data": {
        "id": "http://localhost:4204/",
        "type": "realm-info",
        "attributes": {
            "name": "Demo Workspace",
            "backgroundURL": "https://twitter.com/cardstack/header_photo"
        }
    }
}
```