### PR TITLE
Handle query params in rootRealmRedirect

### DIFF
--- a/packages/realm-server/middleware/index.ts
+++ b/packages/realm-server/middleware/index.ts
@@ -94,13 +94,18 @@ export function rootRealmRedirect(
 ): (ctxt: Koa.Context, next: Koa.Next) => void {
   return (ctxt: Koa.Context, next: Koa.Next) => {
     let url = fullRequestURL(ctxt);
+
+    let realmUrlWithoutQueryParams = url.href.split('?')[0];
     if (
-      !url.href.endsWith('/') &&
+      !realmUrlWithoutQueryParams.endsWith('/') &&
       realms.find(
-        (r) => Loader.reverseResolution(`${url.href}/`).href === r.url
+        (r) =>
+          Loader.reverseResolution(`${realmUrlWithoutQueryParams}/`).href ===
+          r.url
       )
     ) {
-      ctxt.redirect(`${url.href}/`);
+      url.pathname = `${url.pathname}/`;
+      ctxt.redirect(`${url.href}`); // Adding a trailing slash to the URL one line above will update the href
       return;
     }
     return next();

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -17,7 +17,11 @@ import {
 } from '@cardstack/runtime-common';
 import { stringify } from 'qs';
 import { Query } from '@cardstack/runtime-common/query';
-import { setupCardLogs, setupBaseRealmServer, runTestRealmServer } from './helpers';
+import {
+  setupCardLogs,
+  setupBaseRealmServer,
+  runTestRealmServer,
+} from './helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 import eventSource from 'eventsource';
 
@@ -70,13 +74,21 @@ module('Realm Server', function (hooks) {
   hooks.beforeEach(async function () {
     dir = dirSync();
     copySync(join(__dirname, 'cards'), dir.name);
-    
-    testRealmServer = await runTestRealmServer(dir.name, undefined, testRealmURL);
+
+    testRealmServer = await runTestRealmServer(
+      dir.name,
+      undefined,
+      testRealmURL
+    );
     request = supertest(testRealmServer);
 
-    testRealmServer2 = await runTestRealmServer(dir.name, undefined, testRealm2URL);
+    testRealmServer2 = await runTestRealmServer(
+      dir.name,
+      undefined,
+      testRealm2URL
+    );
   });
-  
+
   hooks.afterEach(function () {
     testRealmServer.close();
     testRealmServer2.close();
@@ -104,10 +116,10 @@ module('Realm Server', function (hooks) {
             name: 'Person',
           },
           realmInfo: {
-            "name": "Test Realm",
-            "backgroundURL": null
+            name: 'Test Realm',
+            backgroundURL: null,
           },
-          realmURL: "http://127.0.0.1:4444/",
+          realmURL: 'http://127.0.0.1:4444/',
         },
         links: {
           self: `${testRealmHref}person-1`,
@@ -501,7 +513,9 @@ module('Realm Server', function (hooks) {
 
 module('Realm Server serving from root', function (hooks) {
   let testRealmServer: Server;
+
   let request: SuperTest<Test>;
+
   let dir: DirResult;
   setupCardLogs(
     hooks,
@@ -514,7 +528,11 @@ module('Realm Server serving from root', function (hooks) {
     dir = dirSync();
     copySync(join(__dirname, 'cards'), dir.name);
 
-    testRealmServer = await runTestRealmServer(dir.name, undefined, testRealmURL);
+    testRealmServer = await runTestRealmServer(
+      dir.name,
+      undefined,
+      testRealmURL
+    );
     request = supertest(testRealmServer);
   });
 
@@ -669,5 +687,43 @@ module('Realm Server serving from root', function (hooks) {
       },
       'the directory response is correct'
     );
+  });
+});
+
+module('Realm Server serving from a subdirectory', function (hooks) {
+  let testRealmServer: Server;
+
+  let request: SuperTest<Test>;
+
+  let dir: DirResult;
+  setupCardLogs(
+    hooks,
+    async () => await Loader.import(`${baseRealm.url}card-api`)
+  );
+
+  setupBaseRealmServer(hooks);
+
+  hooks.beforeEach(async function () {
+    dir = dirSync();
+    copySync(join(__dirname, 'cards'), dir.name);
+
+    testRealmServer = await runTestRealmServer(
+      dir.name,
+      undefined,
+      new URL('http://127.0.0.1:4446/demo/')
+    );
+
+    request = supertest(testRealmServer);
+  });
+
+  hooks.afterEach(function () {
+    testRealmServer.close();
+  });
+
+  test('serves a subdirectory GET request that results in redirect', async function (assert) {
+    let response = await request.get('/demo');
+
+    assert.strictEqual(response.status, 302, 'HTTP 302 status');
+    assert.ok(response.headers['location'], 'http://127.0.0.1:4446/demo/');
   });
 });

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -726,4 +726,16 @@ module('Realm Server serving from a subdirectory', function (hooks) {
     assert.strictEqual(response.status, 302, 'HTTP 302 status');
     assert.ok(response.headers['location'], 'http://127.0.0.1:4446/demo/');
   });
+
+  test('redirection keeps query params intact', async function (assert) {
+    let response = await request.get(
+      '/demo?operatorModeState=operatorModeEnabled=true&operatorModeState=%7B%22stacks%22%3A%5B%7B%22items%22%3A%5B%7B%22card%22%3A%7B%22id%22%3A%22http%3A%2F%2Flocalhost%3A4204%2Findex%22%7D%2C%22format%22%3A%22isolated%22%7D%5D%7D%5D%7D'
+    );
+
+    assert.strictEqual(response.status, 302, 'HTTP 302 status');
+    assert.ok(
+      response.headers['location'],
+      'http://127.0.0.1:4446/demo/?operatorModeEnabled=true&operatorModeState=%7B%22stacks%22%3A%5B%7B%22items%22%3A%5B%7B%22card%22%3A%7B%22id%22%3A%22http%3A%2F%2Flocalhost%3A4204%2Findex%22%7D%2C%22format%22%3A%22isolated%22%7D%5D%7D%5D%7D'
+    );
+  });
 });


### PR DESCRIPTION
This PR attempts to fix the URL redirection in one of the realm server's middlewares (`rootRealmRedirect`).

The problem was observed on staging where the operator mode crashes when you open a link with operator mode state, for example: https://realms-staging.stack.cards/demo/?operatorModeEnabled=true&operatorModeState=%7B%22stacks%22%3A%5B%7B%22items%22%3A%5B%7B%22card%22%3A%7B%22id%22%3A%22https%3A%2F%2Frealms-staging.stack.cards%2Fdemo%2Findex%22%7D%2C%22format%22%3A%22isolated%22%7D%5D%7D%5D%7D

What happens is that when you click on this link, a redirection to the following URL will happen (notice the trailing `/` at the end of the link):
https://realms-staging.stack.cards/demo/?operatorModeEnabled=true&operatorModeState=%7B%22stacks%22%3A%5B%7B%22items%22%3A%5B%7B%22card%22%3A%7B%22id%22%3A%22https%3A%2F%2Frealms-staging.stack.cards%2Fdemo%2Findex%22%7D%2C%22format%22%3A%22isolated%22%7D%5D%7D%5D%7D/

The host app then thinks the `/` is a part of the `operatorModeState` query parameter and the app will crash trying to parse `operatorModeState` into a JavaScript object. I think it is wrong the middleware is adding characters to the end of the URL because it messes up query params in case they exist.

The fix in this PR is that the `/` gets added to the path segment of the URL (and not to the end of the url–which is wrong when there are query params present like in the case above). 

This fixes the bug for me locally (i.e. visiting http://localhost:4204/?operatorModeEnabled=true&operatorModeState=%7B%22stacks%22%3A%5B%7B%22items%22%3A%5B%7B%22card%22%3A%7B%22id%22%3A%22http%3A%2F%2Flocalhost%3A4204%2Findex%22%7D%2C%22format%22%3A%22isolated%22%7D%5D%7D%5D%7D resulted in the described problem but now it opens fine).

I'm now trying to write a test for this but getting `Error: ECONNREFUSED: Connection refused` with the newly added test. So I'm looking into that, if anyone has any tips that would be great. 

Edit: solved the above. 