### PR TITLE
Explain rationale behind "isUsed" field option

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -81,7 +81,12 @@ type Setter = { setters: { [fieldName: string]: Setter } } & ((
 
 interface Options {
   computeVia?: string | (() => unknown);
-  isUsed?: true; // TODO this is a workaround for a bug that needs researching
+  // there exists cards that we only ever run in the host without
+  // the isolated renderer (RoomCard), which means that we cannot
+  // use the rendering mechanism to tell if a card is used or not,
+  // in which case we need to tell the runtime that a card is
+  // explictly being used.
+  isUsed?: true;
 }
 
 interface NotLoadedValue {
@@ -215,7 +220,12 @@ export interface Field<
   name: string;
   fieldType: FieldType;
   computeVia: undefined | string | (() => unknown);
-  isUsed?: undefined | true; // TODO this is a workaround for a bug that needs researching
+  // there exists cards that we only ever run in the host without
+  // the isolated renderer (RoomCard), which means that we cannot
+  // use the rendering mechanism to tell if a card is used or not,
+  // in which case we need to tell the runtime that a card is
+  // explictly being used.
+  isUsed?: undefined | true;
   serialize(
     value: any,
     doc: JSONAPISingleResourceDocument,

--- a/packages/base/room.gts
+++ b/packages/base/room.gts
@@ -343,7 +343,10 @@ export class RoomCard extends Card {
   });
 
   @field messages = containsMany(MessageCard, {
-    isUsed: true, // TODO we should not have to set this--need to research this issue
+    // since we are rendering this card without the isolated renderer, we cannot use
+    // the rendering mechanism to test if a field is used or not, so we explicitely
+    // tell the card runtime that this field is being used
+    isUsed: true,
     computeVia: async function (this: RoomCard) {
       let cache = messageCache.get(this);
       if (!cache) {


### PR DESCRIPTION
The Room Card that we use for matrix is unique in that we don't actually run it in the indexer with the isolated renderer that let's us know which fields are used or not--which means that there is not a "safe" place to test this card to see which fields are used, which results in our async computeds returning `NotReady` errors when we try to render this card. Instead it is more like our integration tests in which we actually tell the runtime to recompute all the fields, as opposed to only recomputing the "used fields" (we have  a special `recomputeAllFields: true` option that we use in our tests). The `isUsed` field option that we have provided is a more precise version of that that let's you specify specific fields that should always be recomputed as opposed to only recomputing "used" fields.

This PR provides some comments explaining the rationale for this approach 