### PR TITLE
Get index card for root request of realms hosted in a subdirectory

### DIFF
--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -640,10 +640,13 @@ export class Realm {
   }
 
   private async getCard(request: Request): Promise<Response> {
+    let realmRootPath = new URL(request.url).pathname.replace('/', ''); // Could be '', 'base',...
     let localPath = this.paths.local(request.url);
-    if (localPath === '') {
+
+    if (localPath === realmRootPath) {
       localPath = 'index';
     }
+
     let url = this.paths.fileURL(localPath);
     let maybeError = await this.#searchIndex.card(url, { loadLinks: true });
     if (!maybeError) {


### PR DESCRIPTION
Solving the bug where index card fails to render in realms hosted in a  subdirectory, for example: https://realms-staging.stack.cards/base/