### PR TITLE
Room Objectives

### DIFF
--- a/packages/base/room-objective.gts
+++ b/packages/base/room-objective.gts
@@ -1,5 +1,4 @@
 import { contains, containsMany, field, Component, Card } from './card-api';
-import IntegerCard from './integer';
 import BooleanCard from './boolean';
 import { RoomCard, RoomMemberCard } from './room';
 
@@ -11,9 +10,9 @@ class View extends Component<typeof RoomObjectiveCard> {
       <div>
         <strong data-test-objective-progress>
           Completed
-          {{@model.completedMilestones}}
+          {{this.completedMilestones}}
           of
-          {{@model.totalMilestones}}
+          {{this.totalMilestones}}
           ({{this.progressPercentage}}%)
         </strong>
       </div>
@@ -34,28 +33,25 @@ class View extends Component<typeof RoomObjectiveCard> {
       .sort()
       .join(', ');
   }
-
-  get progressPercentage() {
-    return Math.floor(
-      (this.args.model.completedMilestones! /
-        this.args.model.totalMilestones!) *
-        100
+  get completedUserCount() {
+    return this.args.model.usersThatFinishedTask!.length;
+  }
+  get completedMilestones() {
+    return this.args.model.usersThatFinishedTask!.length;
+  }
+  get totalMilestones() {
+    return (
+      this.args.model.usersThatFinishedTask!.length +
+      this.args.model.usersThatNeedToCompleteTask!.length
     );
+  }
+  get progressPercentage() {
+    return Math.floor((this.completedMilestones / this.totalMilestones) * 100);
   }
 }
 
 export class RoomObjectiveCard extends Card {
   @field room = contains(RoomCard);
-  @field totalMilestones = contains(IntegerCard, {
-    computeVia: function (this: RoomObjectiveCard) {
-      return this.room.joinedMembers.length;
-    },
-  });
-  @field completedMilestones = contains(IntegerCard, {
-    computeVia: function (this: RoomObjectiveCard) {
-      return this.usersThatFinishedTask.length;
-    },
-  });
   @field usersThatFinishedTask = containsMany(RoomMemberCard, {
     computeVia: function (this: RoomObjectiveCard) {
       let desiredMessages = this.room.messages.filter((m) =>
@@ -73,7 +69,7 @@ export class RoomObjectiveCard extends Card {
   });
   @field isComplete = contains(BooleanCard, {
     computeVia: function (this: RoomObjectiveCard) {
-      return this.completedMilestones === this.totalMilestones;
+      return this.usersThatNeedToCompleteTask.length === 0;
     },
   });
 

--- a/packages/base/room-objective.gts
+++ b/packages/base/room-objective.gts
@@ -1,0 +1,30 @@
+import { contains, containsMany, field, Component, Card } from './card-api';
+import IntegerCard from './integer';
+import { RoomCard, RoomMemberCard } from './room';
+
+export class RoomObjectiveCard extends Card {
+  @field room = contains(RoomCard);
+  @field totalMilestones = contains(IntegerCard, {
+    computeVia: function (this: RoomObjectiveCard) {},
+  });
+  @field completedMilestones = contains(IntegerCard, {
+    computeVia: function (this: RoomObjectiveCard) {},
+  });
+  @field usersThatFinishedTask = containsMany(RoomMemberCard, {
+    computeVia: function (this: RoomObjectiveCard) {},
+  });
+  @field usersThatNeedToCompleteTask = containsMany(RoomMemberCard, {
+    computeVia: function (this: RoomObjectiveCard) {},
+  });
+
+  static embedded = class Embedded extends Component<typeof this> {
+    <template>
+      <div>
+        Completed
+        {{@model.completedMilestones}}
+        of
+        {{@model.totalMilestones}}
+      </div>
+    </template>
+  };
+}

--- a/packages/base/room-objective.gts
+++ b/packages/base/room-objective.gts
@@ -5,7 +5,7 @@ import { RoomCard, RoomMemberCard } from './room';
 class View extends Component<typeof RoomObjectiveCard> {
   <template>
     <div data-test-objective>
-      <h3>Objective: Make sure that all room members greet eachother by saying
+      <h3>Objective: Make sure that all room members greet each other by saying
         "Hello"</h3>
       <div>
         <strong data-test-objective-progress>

--- a/packages/base/room-objective.gts
+++ b/packages/base/room-objective.gts
@@ -1,30 +1,83 @@
 import { contains, containsMany, field, Component, Card } from './card-api';
 import IntegerCard from './integer';
+import BooleanCard from './boolean';
 import { RoomCard, RoomMemberCard } from './room';
+
+class View extends Component<typeof RoomObjectiveCard> {
+  <template>
+    <div data-test-objective>
+      <h3>Objective: Make sure that all room members greet eachother by saying
+        "Hello"</h3>
+      <div>
+        <strong data-test-objective-progress>
+          Completed
+          {{@model.completedMilestones}}
+          of
+          {{@model.totalMilestones}}
+          ({{this.progressPercentage}}%)
+        </strong>
+      </div>
+      <div>
+        {{#if @model.isComplete}}
+          <strong data-test-objective-is-complete>The objective is completed</strong>
+        {{else}}
+          The following users need to complete the task:
+          <strong data-test-objective-remaining>{{this.remainingUsers}}</strong>
+        {{/if}}
+      </div>
+    </div>
+  </template>
+
+  get remainingUsers() {
+    return this.args.model
+      .usersThatNeedToCompleteTask!.map((u) => u.displayName)
+      .sort()
+      .join(', ');
+  }
+
+  get progressPercentage() {
+    return Math.floor(
+      (this.args.model.completedMilestones! /
+        this.args.model.totalMilestones!) *
+        100
+    );
+  }
+}
 
 export class RoomObjectiveCard extends Card {
   @field room = contains(RoomCard);
   @field totalMilestones = contains(IntegerCard, {
-    computeVia: function (this: RoomObjectiveCard) {},
+    computeVia: function (this: RoomObjectiveCard) {
+      return this.room.joinedMembers.length;
+    },
   });
   @field completedMilestones = contains(IntegerCard, {
-    computeVia: function (this: RoomObjectiveCard) {},
+    computeVia: function (this: RoomObjectiveCard) {
+      return this.usersThatFinishedTask.length;
+    },
   });
   @field usersThatFinishedTask = containsMany(RoomMemberCard, {
-    computeVia: function (this: RoomObjectiveCard) {},
+    computeVia: function (this: RoomObjectiveCard) {
+      let desiredMessages = this.room.messages.filter((m) =>
+        m.message.match(/^[\W_b]*[Hh][Ee][Ll][Ll][Oo][\W_\b]*$/)
+      );
+      return desiredMessages.map((m) => m.author);
+    },
   });
   @field usersThatNeedToCompleteTask = containsMany(RoomMemberCard, {
-    computeVia: function (this: RoomObjectiveCard) {},
+    computeVia: function (this: RoomObjectiveCard) {
+      let allUsers = this.room.joinedMembers;
+      let completedUserIds = this.usersThatFinishedTask.map((u) => u.userId);
+      return allUsers.filter((u) => !completedUserIds.includes(u.userId));
+    },
+  });
+  @field isComplete = contains(BooleanCard, {
+    computeVia: function (this: RoomObjectiveCard) {
+      return this.completedMilestones === this.totalMilestones;
+    },
   });
 
-  static embedded = class Embedded extends Component<typeof this> {
-    <template>
-      <div>
-        Completed
-        {{@model.completedMilestones}}
-        of
-        {{@model.totalMilestones}}
-      </div>
-    </template>
-  };
+  static embedded = class Embedded extends View {};
+  static isolated = class Embedded extends View {};
+  static edit = class Embedded extends View {};
 }

--- a/packages/base/room.gts
+++ b/packages/base/room.gts
@@ -17,7 +17,10 @@ import { BoxelMessage } from '@cardstack/boxel-ui';
 import cssVar from '@cardstack/boxel-ui/helpers/css-var';
 import { formatRFC3339 } from 'date-fns';
 import Modifier from 'ember-modifier';
-import { type LooseSingleCardDocument } from '@cardstack/runtime-common';
+import {
+  type LooseSingleCardDocument,
+  type CardRef,
+} from '@cardstack/runtime-common';
 
 // this is so we can have triple equals equivalent attached cards in messages
 const attachedCards = new Map<string, Promise<Card>>();
@@ -139,6 +142,11 @@ export class RoomMemberCard extends Card {
   @field membership = contains(RoomMembershipCard);
   @field membershipDateTime = contains(DateTimeCard);
   @field membershipInitiator = contains(() => RoomMemberCard);
+  @field name = contains(StringCard, {
+    computeVia: function (this: RoomMemberCard) {
+      return this.displayName ?? this.userId.split(':')[0].substring(1);
+    },
+  });
   static embedded = class Embedded extends RoomMemberView {};
   static isolated = class Isolated extends RoomMemberView {};
   // The edit template is meant to be read-only, this field card is not mutable
@@ -363,11 +371,16 @@ export class RoomCard extends Card {
           continue;
         }
 
+        let author = upsertRoomMember({ roomCard: this, userId: event.sender });
+        let formattedMessage =
+          event.content.msgtype === 'org.boxel.objective'
+            ? `<em>${author.name} has set the room objectives</em>`
+            : event.content.formatted_body;
         let cardArgs = {
-          author: upsertRoomMember({ roomCard: this, userId: event.sender }),
+          author,
           created: new Date(event.origin_server_ts),
           message: event.content.body,
-          formattedMessage: event.content.formatted_body,
+          formattedMessage,
           index,
           attachedCard: null,
         };
@@ -534,10 +547,26 @@ interface CardMessageEvent extends BaseMatrixEvent {
   };
 }
 
+interface ObjectiveEvent extends BaseMatrixEvent {
+  type: 'm.room.message';
+  content: {
+    msgtype: 'org.boxel.objective';
+    body: string;
+    ref: CardRef;
+  };
+  unsigned: {
+    age: number;
+    transaction_id: string;
+    prev_content?: any;
+    prev_sender?: string;
+  };
+}
+
 export type MatrixEvent =
   | RoomCreateEvent
   | MessageEvent
   | CardMessageEvent
+  | ObjectiveEvent
   | RoomNameEvent
   | RoomTopicEvent
   | InviteEvent

--- a/packages/base/types/room-objective.json
+++ b/packages/base/types/room-objective.json
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "title": "Room Objective",
+      "description": "A room objective used to get all the members of the room to say \"Hello\".",
+      "ref": {
+        "module": "https://cardstack.com/base/room-objective",
+        "name": "RoomObjectiveCard"
+      }
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "https://cardstack.com/base/catalog-entry",
+        "name": "CatalogEntry"
+      }
+    }
+  }
+}

--- a/packages/host/app/components/room.gts
+++ b/packages/host/app/components/room.gts
@@ -102,6 +102,9 @@ export default class Room extends Component<RoomArgs> {
         <Button data-test-remove-card-btn {{on 'click' this.removeCard}}>Remove
           Card</Button>
       {{else}}
+        {{#if this.canSetObjective}}
+          <Button data-test-set-objective-btn>Set Objective</Button>
+        {{/if}}
         <Button
           data-test-choose-card-btn
           @disabled={{this.doChooseCard.isRunning}}
@@ -172,6 +175,11 @@ export default class Room extends Component<RoomArgs> {
 
   private get cardtoSend() {
     return this.cardsToSend.get(this.args.roomId);
+  }
+
+  private get canSetObjective() {
+    // TODO also take into consideration whether the room already has an objective
+    return this.matrixService.canSetObjective(this.args.roomId);
   }
 
   private get cardToSendComponent() {

--- a/packages/host/app/lib/matrix-handlers/index.ts
+++ b/packages/host/app/lib/matrix-handlers/index.ts
@@ -34,7 +34,6 @@ export type Event = Partial<IEvent>;
 
 export interface Context {
   roomCards: Map<string, Promise<RoomCard>>;
-  // TODO collapse this into the RoomCard
   roomObjectives: Map<string, RoomObjectiveCard>;
   flushTimeline: Promise<void> | undefined;
   flushMembership: Promise<void> | undefined;
@@ -99,7 +98,7 @@ export async function addRoomEvent(context: Context, event: Event) {
 // changes, the consuming card's computeds will not automatically recompute. To
 // work around that, we are performing the assignment of the interior card to
 // the consuming card again which will trigger the consuming card's computeds to
-// pick up the interior card's updated fields. In the case the consuming card is
+// pick up the interior card's updated fields. In this case the consuming card is
 // the RoomObjectiveCard and the interior card is the RoomCard.
 export async function recomputeRoomObjective(context: Context, roomId: string) {
   let roomCard = await context.roomCards.get(roomId);

--- a/packages/host/app/lib/matrix-handlers/index.ts
+++ b/packages/host/app/lib/matrix-handlers/index.ts
@@ -93,3 +93,18 @@ export async function addRoomEvent(context: Context, event: Event) {
     ];
   }
 }
+
+// our reactive system doesn't cascade "up" through our consumers. meaning that
+// when a card's contained field is another card and the interior card's field
+// changes, the consuming card's computeds will not automatically recompute. To
+// work around that, we are performing the assignment of the interior card to
+// the consuming card again which will trigger the consuming card's computeds to
+// pick up the interior card's updated fields. In the case the consuming card is
+// the RoomObjectiveCard and the interior card is the RoomCard.
+export async function recomputeRoomObjective(context: Context, roomId: string) {
+  let roomCard = await context.roomCards.get(roomId);
+  let objective = context.roomObjectives.get(roomId);
+  if (objective && roomCard) {
+    objective.room = roomCard;
+  }
+}

--- a/packages/host/app/lib/matrix-handlers/index.ts
+++ b/packages/host/app/lib/matrix-handlers/index.ts
@@ -8,6 +8,7 @@ import type {
   RoomCard,
   MatrixEvent as DiscreteMatrixEvent,
 } from 'https://cardstack.com/base/room';
+import type { RoomObjectiveCard } from 'https://cardstack.com/base/room-objective';
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
 import { type LooseCardResource, baseRealm } from '@cardstack/runtime-common';
 import type * as MatrixSDK from 'matrix-js-sdk';
@@ -33,6 +34,7 @@ export type Event = Partial<IEvent>;
 
 export interface Context {
   roomCards: Map<string, Promise<RoomCard>>;
+  roomObjectives: Map<string, Promise<RoomObjectiveCard>>;
   flushTimeline: Promise<void> | undefined;
   flushMembership: Promise<void> | undefined;
   roomMembershipQueue: { event: MatrixEvent; member: RoomMember }[];

--- a/packages/host/app/lib/matrix-handlers/index.ts
+++ b/packages/host/app/lib/matrix-handlers/index.ts
@@ -34,7 +34,8 @@ export type Event = Partial<IEvent>;
 
 export interface Context {
   roomCards: Map<string, Promise<RoomCard>>;
-  roomObjectives: Map<string, Promise<RoomObjectiveCard>>;
+  // TODO collapse this into the RoomCard
+  roomObjectives: Map<string, RoomObjectiveCard>;
   flushTimeline: Promise<void> | undefined;
   flushMembership: Promise<void> | undefined;
   roomMembershipQueue: { event: MatrixEvent; member: RoomMember }[];

--- a/packages/host/app/lib/matrix-handlers/membership.ts
+++ b/packages/host/app/lib/matrix-handlers/membership.ts
@@ -1,7 +1,7 @@
 import debounce from 'lodash/debounce';
 import { type MatrixEvent, type RoomMember } from 'matrix-js-sdk';
 import type { MatrixEvent as DiscreteMatrixEvent } from 'https://cardstack.com/base/room';
-import { type Context, addRoomEvent } from './index';
+import { type Context, addRoomEvent, recomputeRoomObjective } from './index';
 import { eventDebounceMs } from '../matrix-utils';
 
 export function onMembership(context: Context) {
@@ -81,12 +81,8 @@ async function drainMembership(context: Context) {
         }
       }
     }
-    // TODO DRY this
-    let roomCard = await context.roomCards.get(roomId);
-    let objective = context.roomObjectives.get(roomId);
-    if (objective && roomCard) {
-      objective.room = roomCard;
-    }
+
+    await recomputeRoomObjective(context, roomId);
   }
 
   eventsDrained!();

--- a/packages/host/app/lib/matrix-handlers/membership.ts
+++ b/packages/host/app/lib/matrix-handlers/membership.ts
@@ -81,6 +81,12 @@ async function drainMembership(context: Context) {
         }
       }
     }
+    // TODO DRY this
+    let roomCard = await context.roomCards.get(roomId);
+    let objective = context.roomObjectives.get(roomId);
+    if (objective && roomCard) {
+      objective.room = roomCard;
+    }
   }
 
   eventsDrained!();

--- a/packages/host/app/lib/matrix-handlers/timeline.ts
+++ b/packages/host/app/lib/matrix-handlers/timeline.ts
@@ -68,6 +68,13 @@ async function processDecryptedEvent(context: Context, event: Event) {
     }
   }
 
+  // TODO DRY this
+  let roomCard = await context.roomCards.get(roomId);
+  let objective = context.roomObjectives.get(roomId);
+  if (objective && roomCard) {
+    objective.room = roomCard;
+  }
+
   let room = context.client.getRoom(roomId);
   if (!room) {
     throw new Error(

--- a/packages/host/app/lib/matrix-handlers/timeline.ts
+++ b/packages/host/app/lib/matrix-handlers/timeline.ts
@@ -1,6 +1,11 @@
 import debounce from 'lodash/debounce';
 import { type MatrixEvent } from 'matrix-js-sdk';
-import { type Context, type Event, addRoomEvent } from './index';
+import {
+  type Context,
+  type Event,
+  addRoomEvent,
+  recomputeRoomObjective,
+} from './index';
 import { eventDebounceMs } from '../matrix-utils';
 import { type MatrixEvent as DiscreteMatrixEvent } from 'https://cardstack.com/base/room';
 import { type RoomObjectiveCard } from 'https://cardstack.com/base/room-objective';
@@ -68,12 +73,7 @@ async function processDecryptedEvent(context: Context, event: Event) {
     }
   }
 
-  // TODO DRY this
-  let roomCard = await context.roomCards.get(roomId);
-  let objective = context.roomObjectives.get(roomId);
-  if (objective && roomCard) {
-    objective.room = roomCard;
-  }
+  await recomputeRoomObjective(context, roomId);
 
   let room = context.client.getRoom(roomId);
   if (!room) {

--- a/packages/host/app/lib/matrix-handlers/timeline.ts
+++ b/packages/host/app/lib/matrix-handlers/timeline.ts
@@ -2,6 +2,9 @@ import debounce from 'lodash/debounce';
 import { type MatrixEvent } from 'matrix-js-sdk';
 import { type Context, type Event, addRoomEvent } from './index';
 import { eventDebounceMs } from '../matrix-utils';
+import { type MatrixEvent as DiscreteMatrixEvent } from 'https://cardstack.com/base/room';
+import { type RoomObjectiveCard } from 'https://cardstack.com/base/room-objective';
+import { type LooseSingleCardDocument } from '@cardstack/runtime-common';
 
 export function onTimeline(context: Context) {
   return (e: MatrixEvent) => {
@@ -33,12 +36,36 @@ async function drainTimeline(context: Context) {
 
 async function processDecryptedEvent(context: Context, event: Event) {
   await addRoomEvent(context, event);
-
   let { room_id: roomId } = event;
   if (!roomId) {
     throw new Error(
       `bug: roomId is undefined for event ${JSON.stringify(event, null, 2)}`
     );
+  }
+  let discreteEvent = event as DiscreteMatrixEvent;
+  if (
+    discreteEvent.type === 'm.room.message' &&
+    discreteEvent.content.msgtype === 'org.boxel.objective'
+  ) {
+    let objective = await context.roomObjectives.get(roomId);
+    if (!objective) {
+      let doc = {
+        data: {
+          meta: {
+            adoptsFrom: discreteEvent.content.ref,
+          },
+        },
+      } as LooseSingleCardDocument;
+      let roomCard = await context.roomCards.get(roomId);
+      if (!roomCard) {
+        throw new Error(`could not get room card for room '${roomId}'`);
+      }
+      objective = await context.cardAPI.createFromSerialized<
+        typeof RoomObjectiveCard
+      >(doc.data, doc, undefined);
+      objective.room = roomCard;
+      context.roomObjectives.set(roomId, objective);
+    }
   }
 
   let room = context.client.getRoom(roomId);

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -40,8 +40,7 @@ export default class MatrixService extends Service {
   @tracked private _client: MatrixClient | undefined;
 
   roomCards: TrackedMap<string, Promise<RoomCard>> = new TrackedMap();
-  roomObjectives: TrackedMap<string, Promise<RoomObjectiveCard>> =
-    new TrackedMap();
+  roomObjectives: TrackedMap<string, RoomObjectiveCard> = new TrackedMap();
   flushTimeline: Promise<void> | undefined;
   flushMembership: Promise<void> | undefined;
   roomMembershipQueue: { event: MatrixEvent; member: RoomMember }[] = [];

--- a/packages/host/tests/integration/components/file-tree-test.gts
+++ b/packages/host/tests/integration/components/file-tree-test.gts
@@ -148,7 +148,7 @@ module('Integration | file-tree', function (hooks) {
 
     assert
       .dom('[data-test-card-catalog] li')
-      .exists({ count: 2 }, 'number of catalog items is correct');
+      .exists({ count: 3 }, 'number of catalog items is correct');
     assert
       .dom(
         `[data-test-card-catalog] [data-test-card-catalog-item="${testRealmURL}person-entry"]`

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -664,7 +664,7 @@ module('Integration | operator-mode', function (hooks) {
     await waitFor(
       `[data-test-card-catalog-item="${testRealmURL}CatalogEntry/publishing-packet"]`
     );
-    assert.dom('[data-test-card-catalog-item]').exists({ count: 1 });
+    assert.dom('[data-test-card-catalog-item]').exists({ count: 2 });
 
     await click(
       `[data-test-select="${testRealmURL}CatalogEntry/publishing-packet"]`
@@ -724,7 +724,7 @@ module('Integration | operator-mode', function (hooks) {
     await waitFor(
       `[data-test-card-catalog-item="${testRealmURL}CatalogEntry/publishing-packet"]`
     );
-    assert.dom('[data-test-card-catalog-item]').exists({ count: 1 });
+    assert.dom('[data-test-card-catalog-item]').exists({ count: 2 });
 
     await click(
       `[data-test-select="${testRealmURL}CatalogEntry/publishing-packet"]`

--- a/packages/host/tests/integration/components/schema-test.gts
+++ b/packages/host/tests/integration/components/schema-test.gts
@@ -793,7 +793,7 @@ module('Integration | schema', function (hooks) {
     assert.dom(`[data-test-select="${testRealmURL}pet"]`).exists();
     assert
       .dom('[data-test-select]')
-      .exists({ count: 1 }, 'primitive fields are not shown');
+      .exists({ count: 2 }, 'primitive fields are not shown');
 
     await click(`[data-test-select="${testRealmURL}pet"]`);
     await waitFor('[data-test-field="pet"]');
@@ -1055,7 +1055,7 @@ module('Integration | schema', function (hooks) {
     assert.dom(`[data-test-select="${testRealmURL}pet"]`).exists();
     assert
       .dom('[data-test-select]')
-      .exists({ count: 1 }, 'primitive fields are not shown');
+      .exists({ count: 2 }, 'primitive fields are not shown');
 
     await click(`[data-test-select="${testRealmURL}pet"]`);
     await waitFor('[data-test-field="pets"]');
@@ -1150,7 +1150,7 @@ module('Integration | schema', function (hooks) {
     assert.dom(`[data-test-select="${testRealmURL}person"]`).exists();
     assert
       .dom('[data-test-select]')
-      .exists({ count: 1 }, 'primitive fields are not shown');
+      .exists({ count: 2 }, 'primitive fields are not shown');
 
     await click(`[data-test-select="${testRealmURL}person"]`);
     await waitFor('[data-test-field="friends"]');

--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -61,6 +61,12 @@ export async function openRoom(page: Page, roomName: string) {
   await page.locator(`[data-test-enter-room="${roomName}"]`).click();
 }
 
+export async function setObjective(page: Page, objectiveURI: string) {
+  await page.locator(`[data-test-set-objective-btn]`).click();
+  await page.locator(`[data-test-select="${objectiveURI}"]`).click();
+  await expect(page.locator(`[data-test-objective]`)).toHaveCount(1);
+}
+
 export async function sendMessage(
   page: Page,
   message: string | undefined,

--- a/packages/matrix/tests/objectives.spec.ts
+++ b/packages/matrix/tests/objectives.spec.ts
@@ -1,0 +1,173 @@
+import { expect, test } from '@playwright/test';
+import {
+  synapseStart,
+  synapseStop,
+  registerUser,
+  type SynapseInstance,
+} from '../docker/synapse';
+import {
+  login,
+  logout,
+  createRoom,
+  assertMessages,
+  openRoom,
+  setObjective,
+  sendMessage,
+  joinRoom,
+} from '../helpers';
+
+test.describe('Room objectives', () => {
+  let synapse: SynapseInstance;
+  test.beforeEach(async () => {
+    synapse = await synapseStart();
+    await registerUser(synapse, 'user1', 'pass');
+    await registerUser(synapse, 'user2', 'pass');
+  });
+
+  test.afterEach(async () => {
+    await synapseStop(synapse.synapseId);
+  });
+
+  test('room creator can set a room objective', async ({ page }) => {
+    await login(page, 'user1', 'pass');
+    await createRoom(page, { name: 'Room 1' });
+    await openRoom(page, 'Room 1');
+
+    await setObjective(page, 'https://cardstack.com/base/types/room-objective');
+    await expect(page.locator(`[data-test-objective]`)).toContainText(
+      'Objective: Make sure that all room members greet each other by saying "Hello"'
+    );
+    await assertMessages(page, [
+      { from: 'user1', message: 'user1 has set the room objectives' },
+    ]);
+    await expect(
+      page.locator(`[data-test-set-objective-btn]`),
+      'The set objective button does not appear after an objective has been set'
+    ).toHaveCount(0);
+  });
+
+  test('non-room creator cannot set a room objective', async ({ page }) => {
+    await login(page, 'user1', 'pass');
+    await createRoom(page, { name: 'Room 1', invites: ['user2'] });
+    await logout(page);
+    await login(page, 'user2', 'pass');
+    await joinRoom(page, 'Room 1');
+    await openRoom(page, 'Room 1');
+
+    await expect(
+      page.locator(`[data-test-set-objective-btn]`),
+      'The set objective button does not appear'
+    ).toHaveCount(0);
+  });
+
+  test('room objective updates milestones as they are completed', async ({
+    page,
+  }) => {
+    await login(page, 'user1', 'pass');
+    await createRoom(page, { name: 'Room 1', invites: ['user2'] });
+    await openRoom(page, 'Room 1');
+    await setObjective(page, 'https://cardstack.com/base/types/room-objective');
+
+    await logout(page);
+    await login(page, 'user2', 'pass');
+    await joinRoom(page, 'Room 1');
+    await openRoom(page, 'Room 1');
+
+    await sendMessage(page, `I'm not saying Hello yet...`);
+    await expect(page.locator(`[data-test-objective-progress]`)).toContainText(
+      `Completed 0 of 2 (0%)`
+    );
+    await expect(page.locator(`[data-test-objective-remaining]`)).toContainText(
+      `user1, user2`
+    );
+
+    await sendMessage(page, `_Hello_`);
+    await expect(page.locator(`[data-test-objective-progress]`)).toContainText(
+      `Completed 1 of 2 (50%)`
+    );
+    await expect(page.locator(`[data-test-objective-remaining]`)).toContainText(
+      `user1`
+    );
+  });
+
+  test('room objective updates milestones as members join the room', async ({
+    page,
+  }) => {
+    await login(page, 'user1', 'pass');
+    await createRoom(page, { name: 'Room 1', invites: ['user2'] });
+    await openRoom(page, 'Room 1');
+
+    await setObjective(page, 'https://cardstack.com/base/types/room-objective');
+    await expect(page.locator(`[data-test-objective-progress]`)).toContainText(
+      `Completed 0 of 1 (0%)`
+    );
+    await expect(page.locator(`[data-test-objective-remaining]`)).toContainText(
+      `user1`
+    );
+
+    await logout(page);
+    await login(page, 'user2', 'pass');
+    await joinRoom(page, 'Room 1');
+    await openRoom(page, 'Room 1');
+
+    await expect(page.locator(`[data-test-objective-progress]`)).toContainText(
+      `Completed 0 of 2 (0%)`
+    );
+    await expect(page.locator(`[data-test-objective-remaining]`)).toContainText(
+      `user1, user2`
+    );
+  });
+
+  test('room objective can be completed', async ({ page }) => {
+    await login(page, 'user1', 'pass');
+    await createRoom(page, { name: 'Room 1' });
+    await openRoom(page, 'Room 1');
+
+    await setObjective(page, 'https://cardstack.com/base/types/room-objective');
+    await sendMessage(page, `hello!`);
+
+    await expect(page.locator(`[data-test-objective-progress]`)).toContainText(
+      `Completed 1 of 1 (100%)`
+    );
+    await expect(
+      page.locator(`[data-test-objective-is-complete]`)
+    ).toContainText('The objective is completed');
+  });
+
+  test('completed room objective can be uncompleted if a new member joins the room', async ({
+    page,
+  }) => {
+    await login(page, 'user1', 'pass');
+    await createRoom(page, { name: 'Room 1', invites: ['user2'] });
+    await openRoom(page, 'Room 1');
+
+    await setObjective(page, 'https://cardstack.com/base/types/room-objective');
+    await sendMessage(page, `hello`);
+    await expect(
+      page.locator(`[data-test-objective-is-complete]`)
+    ).toContainText('The objective is completed');
+
+    await logout(page);
+    await login(page, 'user2', 'pass');
+    await joinRoom(page, 'Room 1');
+    await openRoom(page, 'Room 1');
+
+    await expect(page.locator(`[data-test-objective-progress]`)).toContainText(
+      `Completed 1 of 2 (50%)`
+    );
+    await expect(page.locator(`[data-test-objective-remaining]`)).toContainText(
+      `user2`
+    );
+    await expect(page.locator(`[data-test-objective-is-complete]`)).toHaveCount(
+      0
+    );
+
+    await sendMessage(page, `Hello`);
+    await expect(page.locator(`[data-test-objective-progress]`)).toContainText(
+      `Completed 2 of 2 (100%)`
+    );
+    await expect(
+      page.locator(`[data-test-objective-is-complete]`)
+    ).toContainText('The objective is completed');
+  });
+});


### PR DESCRIPTION
This PR add support for room objectives. The idea is that the creator of the room is permitted to choose a room objective card type (there is only 1 right now, and we don't really have an adoption chain yet for this since it's unclear what all fields we'll want in all room cards). I have provided a sample room objective card where the objective of the room is to get all the room members to say "Hello"  (markdown alternatives supported as well). The Room objective card live updates with the progress towards the objective with a percentage of completed milestones as well as indicating the room members that still need to greet each other.


https://github.com/cardstack/boxel/assets/61075/d612e0b3-504d-427c-8ff6-1f841a97e405

