### PR TITLE
Wrap long strings without spaces in Boxel::Field values

### DIFF
--- a/packages/boxel-ui/addon/components/field-container/index.gts
+++ b/packages/boxel-ui/addon/components/field-container/index.gts
@@ -58,6 +58,7 @@ const FieldContainer: TemplateOnlyComponent<Signature> = <template>
 
       display: grid;
       gap: var(--boxel-sp-xs) 0;
+      overflow-wrap: anywhere;
     }
 
     .vertical {


### PR DESCRIPTION
Before:

![image](https://github.com/cardstack/boxel/assets/353/3878d182-6207-4dcc-b4d9-3289957b0a70)

After:

![image](https://github.com/cardstack/boxel/assets/353/a6a809ea-f035-4bff-8c55-2a17e9bb3610)
