### PR TITLE
Fix linksToMany in handleNotLoaded

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -1211,16 +1211,12 @@ class LinksToMany<FieldT extends CardConstructor>
       for (let field of deserialized.get(this.name)) {
         if (isNotLoadedValue(field)) {
           // replace the not-loaded values with the loaded cards
-          if (instance.id == 'http://localhost:4202/Friends/1') {
-            debugger;
-          }
-          values.push(fieldValues.find((v) => v.id === field.reference)! as T);
-          // values.push(
-          //   fieldValues.find(
-          //     (v) =>
-          //       v.id === new URL(field.reference, instance[relativeTo]).href
-          //   )! as T
-          // );
+          values.push(
+            fieldValues.find(
+              (v) =>
+                v.id === new URL(field.reference, instance[relativeTo]).href
+            )! as T
+          );
         } else {
           // keep existing loaded cards
           values.push(field);

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -1211,7 +1211,16 @@ class LinksToMany<FieldT extends CardConstructor>
       for (let field of deserialized.get(this.name)) {
         if (isNotLoadedValue(field)) {
           // replace the not-loaded values with the loaded cards
+          if (instance.id == 'http://localhost:4202/Friends/1') {
+            debugger;
+          }
           values.push(fieldValues.find((v) => v.id === field.reference)! as T);
+          // values.push(
+          //   fieldValues.find(
+          //     (v) =>
+          //       v.id === new URL(field.reference, instance[relativeTo]).href
+          //   )! as T
+          // );
         } else {
           // keep existing loaded cards
           values.push(field);

--- a/packages/demo-cards/CatalogEntry/10.json
+++ b/packages/demo-cards/CatalogEntry/10.json
@@ -1,0 +1,42 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "title": "Friends from ../friends",
+      "description": "Catalog entry for Friends from ../friends",
+      "ref": {
+        "module": "../friends",
+        "name": "Friends"
+      },
+      "demo": {
+        "firstName": "Mike Wazowski"
+      }
+    },
+    "relationships": {
+      "demo.friends.0": {
+        "links": {
+          "self": "../Friend/2"
+        }
+      },
+      "demo.friends.1": {
+        "links": {
+          "self": "../Friend/1"
+        }
+      }
+    },
+    "meta": {
+      "fields": {
+        "demo": {
+          "adoptsFrom": {
+            "module": "../friends",
+            "name": "Friends"
+          }
+        }
+      },
+      "adoptsFrom": {
+        "module": "https://cardstack.com/base/catalog-entry",
+        "name": "CatalogEntry"
+      }
+    }
+  }
+}

--- a/packages/demo-cards/Friends/1.json
+++ b/packages/demo-cards/Friends/1.json
@@ -1,0 +1,26 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "firstName": "Mike Wazowski"
+    },
+    "relationships": {
+      "friends.0": {
+        "links": {
+          "self": "../Friend/1"
+        }
+      },
+      "friends.1": {
+        "links": {
+          "self": "../Friend/2"
+        }
+      }
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../friends",
+        "name": "Friends"
+      }
+    }
+  }
+}

--- a/packages/demo-cards/friends.gts
+++ b/packages/demo-cards/friends.gts
@@ -6,11 +6,12 @@ import {
   Component,
 } from 'https://cardstack.com/base/card-api';
 import StringCard from 'https://cardstack.com/base/string';
+import { Friend } from './friend';
 
 export class Friends extends Card {
   static displayName = 'Friends';
   @field firstName = contains(StringCard);
-  @field friends = linksToMany(() => Friends);
+  @field friends = linksToMany(() => Friend);
   @field title = contains(StringCard, {
     computeVia: function (this: Friends) {
       return this.firstName;

--- a/packages/demo-cards/friends.gts
+++ b/packages/demo-cards/friends.gts
@@ -1,4 +1,3 @@
-import { FieldContainer } from '@cardstack/boxel-ui';
 import {
   contains,
   linksToMany,

--- a/packages/demo-cards/friends.gts
+++ b/packages/demo-cards/friends.gts
@@ -1,3 +1,4 @@
+import { FieldContainer } from '@cardstack/boxel-ui';
 import {
   contains,
   linksToMany,
@@ -20,8 +21,10 @@ export class Friends extends Card {
   static embedded = class Embedded extends Component<typeof this> {
     <template>
       <div class='demo-card'>
-        Name:
         <@fields.firstName />
+        has
+        {{@model.friends.length}}
+        friends
       </div>
     </template>
   };


### PR DESCRIPTION
[CS-5627](https://linear.app/cardstack/issue/CS-5627/error-when-using-linkstomany-and-relative-path)

When starting the realm-server or running the host. We will get the error

```
 Encountered error rendering HTML for card: Reflect.getPrototypeOf called on non-object
```

linksToMany handles not loaded cards wrongly. 

In particular, this is a `Friends` card that I just added has `linksToMany` field to  2 different `Friend` card. But when one or both the `Friend` cards are not loaded, this error occurs

## Problem
The main issue in replacing unloaded values with loaded cards in the return array. We compare the reference of the loaded values with the id of the loaded cards. 

## Solution 
I use the relativeTo card instance (Friends). `instance[relativeTo='http://localhost:4202/Friends/1.json'` to inform what the URL of the newly loaded card should be



Possibly related ideas: [CS-5173](https://linear.app/cardstack/issue/CS-5173/serialize-card-json-using-relative-urls-when-possible)