### PR TITLE
host: Add component subdirectories

### DIFF
--- a/packages/host/app/components/card-editor.gts
+++ b/packages/host/app/components/card-editor.gts
@@ -4,10 +4,10 @@ import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { restartableTask } from 'ember-concurrency';
 import { service } from '@ember/service';
-import type CardService from '../services/card-service';
+import type CardService from '@cardstack/host/services/card-service';
 import type { Card, Format } from 'https://cardstack.com/base/card-api';
 import FormatPicker from './format-picker';
-import Preview from './preview';
+import Preview from '@cardstack/host/components/preview';
 import Button from '@cardstack/boxel-ui/components/button';
 
 interface Signature {

--- a/packages/host/app/components/card-editor.gts
+++ b/packages/host/app/components/card-editor.gts
@@ -4,10 +4,10 @@ import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { restartableTask } from 'ember-concurrency';
 import { service } from '@ember/service';
-import type CardService from '@cardstack/host/services/card-service';
+import type CardService from '../services/card-service';
 import type { Card, Format } from 'https://cardstack.com/base/card-api';
 import FormatPicker from './format-picker';
-import Preview from '@cardstack/host/components/preview';
+import Preview from './preview';
 import Button from '@cardstack/boxel-ui/components/button';
 
 interface Signature {

--- a/packages/host/app/components/editor/catalog-entry-editor.gts
+++ b/packages/host/app/components/editor/catalog-entry-editor.gts
@@ -12,9 +12,9 @@ import { LinkTo } from '@ember/routing';
 import { service } from '@ember/service';
 //@ts-ignore glint does not think this is consumed-but it is consumed in the template
 import { hash } from '@ember/helper';
-import { getSearchResults } from '../resources/search';
-import type CardService from '../services/card-service';
-import CardEditor from './card-editor';
+import { getSearchResults } from '@cardstack/host/resources/search';
+import type CardService from '@cardstack/host/services/card-service';
+import CardEditor from '@cardstack/host/components/card-editor';
 import { type Card } from 'https://cardstack.com/base/card-api';
 import { Button, CardContainer } from '@cardstack/boxel-ui';
 

--- a/packages/host/app/components/editor/code-link.gts
+++ b/packages/host/app/components/editor/code-link.gts
@@ -25,6 +25,6 @@ export default class CodeLink extends Component<Signature> {
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry {
-    CodeLink: typeof CodeLink;
+    'Editor::CodeLink': typeof CodeLink;
   }
 }

--- a/packages/host/app/components/editor/directory.gts
+++ b/packages/host/app/components/editor/directory.gts
@@ -5,7 +5,7 @@ import { action } from '@ember/object';
 import { on } from '@ember/modifier';
 import { fn } from '@ember/helper';
 import { eq } from '@cardstack/boxel-ui/helpers/truth-helpers';
-import { directory } from '../resources/directory';
+import { directory } from '@cardstack/host/resources/directory';
 import { concat } from '@ember/helper';
 
 interface Args {

--- a/packages/host/app/components/editor/file-tree.gts
+++ b/packages/host/app/components/editor/file-tree.gts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { restartableTask } from 'ember-concurrency';
 import type RouterService from '@ember/routing/router-service';
-import type LoaderService from '../services/loader-service';
+import type LoaderService from '@cardstack/host/services/loader-service';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { CatalogEntry } from 'https://cardstack.com/base/catalog-entry';

--- a/packages/host/app/components/editor/go.gts
+++ b/packages/host/app/components/editor/go.gts
@@ -13,18 +13,18 @@ import {
   logger,
 } from '@cardstack/runtime-common';
 import { RealmPaths } from '@cardstack/runtime-common/paths';
-import type LoaderService from '../services/loader-service';
-import type CardService from '../services/card-service';
-import type { FileResource } from '../resources/file';
-import CardEditor from './card-editor';
+import type LoaderService from '@cardstack/host/services/loader-service';
+import type CardService from '@cardstack/host/services/card-service';
+import type { FileResource } from '@cardstack/host/resources/file';
+import CardEditor from '@cardstack/host/components/card-editor';
 import Module from './module';
 import FileTree from './file-tree';
 import {
   getLangFromFileExtension,
   extendMonacoLanguage,
   languageConfigs,
-} from '../utils/editor-language';
-import monacoModifier from '../modifiers/monaco';
+} from '@cardstack/host/utils/editor-language';
+import monacoModifier from '@cardstack/host/modifiers/monaco';
 import type * as monaco from 'monaco-editor';
 import type { Card } from 'https://cardstack.com/base/card-api';
 import ENV from '@cardstack/host/config/environment';
@@ -103,36 +103,12 @@ export default class Go extends Component<Signature> {
       {{/if}}
     </div>
     <style>
-      .main {
-        position: relative;
-        display: grid;
-        grid-template-columns: 15rem 1fr 1fr;
-        min-height: 100vh;
-      }
-
-      .main-column {
-        padding: var(--boxel-sp);
-      }
-
-      .main-column > * + * {
-        margin-top: var(--boxel-sp);
-      }
-
-      .editor-column {
-        display: flex;
-        flex-direction: column;
-      }
-
-      .editor-menu {
-        list-style-type: none;
-        padding: 0;
-        display: flex;
-        gap: var(--boxel-sp-sm);
-      }
-
-      .editor-container {
-        flex: 1;
-      }
+      .main { position: relative; display: grid; grid-template-columns: 15rem
+      1fr 1fr; min-height: 100vh; } .main-column { padding: var(--boxel-sp); }
+      .main-column > * + * { margin-top: var(--boxel-sp); } .editor-column {
+      display: flex; flex-direction: column; } .editor-menu { list-style-type:
+      none; padding: 0; display: flex; gap: var(--boxel-sp-sm); }
+      .editor-container { flex: 1; }
     </style>
   </template>
 
@@ -280,6 +256,6 @@ function isRunnable(filename: string): boolean {
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry {
-    Go: typeof Go;
+    'Editor::Go': typeof Go;
   }
 }

--- a/packages/host/app/components/editor/go.gts
+++ b/packages/host/app/components/editor/go.gts
@@ -103,12 +103,36 @@ export default class Go extends Component<Signature> {
       {{/if}}
     </div>
     <style>
-      .main { position: relative; display: grid; grid-template-columns: 15rem
-      1fr 1fr; min-height: 100vh; } .main-column { padding: var(--boxel-sp); }
-      .main-column > * + * { margin-top: var(--boxel-sp); } .editor-column {
-      display: flex; flex-direction: column; } .editor-menu { list-style-type:
-      none; padding: 0; display: flex; gap: var(--boxel-sp-sm); }
-      .editor-container { flex: 1; }
+      .main {
+          position: relative;
+          display: grid;
+          grid-template-columns: 15rem 1fr 1fr;
+          min-height: 100vh;
+        }
+
+        .main-column {
+          padding: var(--boxel-sp);
+        }
+
+        .main-column > * + * {
+          margin-top: var(--boxel-sp);
+        }
+
+        .editor-column {
+          display: flex;
+          flex-direction: column;
+        }
+
+        .editor-menu {
+          list-style-type: none;
+          padding: 0;
+          display: flex;
+          gap: var(--boxel-sp-sm);
+        }
+
+        .editor-container {
+          flex: 1;
+        }
     </style>
   </template>
 

--- a/packages/host/app/components/editor/import-module.gts
+++ b/packages/host/app/components/editor/import-module.gts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
-import { importResource } from '../resources/import';
+import { importResource } from '@cardstack/host/resources/import';
 import { service } from '@ember/service';
-import LoaderService from '../services/loader-service';
+import LoaderService from '@cardstack/host/services/loader-service';
 
 export interface Signature {
   Args: { url: string };

--- a/packages/host/app/components/editor/module.gts
+++ b/packages/host/app/components/editor/module.gts
@@ -4,7 +4,7 @@ import ImportModule from './import-module';
 //@ts-ignore cached not available yet in definitely typed
 import { cached } from '@glimmer/tracking';
 import { ModuleSyntax } from '@cardstack/runtime-common/module-syntax';
-import type { FileResource } from '../resources/file';
+import type { FileResource } from '@cardstack/host/resources/file';
 import type { Card } from 'https://cardstack.com/base/card-api';
 
 interface Signature {

--- a/packages/host/app/components/editor/schema.gts
+++ b/packages/host/app/components/editor/schema.gts
@@ -7,12 +7,12 @@ import {
   moduleFrom,
 } from '@cardstack/runtime-common';
 import { isCardRef, type CardRef } from '@cardstack/runtime-common/card-ref';
-import { getCardType, type Type } from '../resources/card-type';
+import { getCardType, type Type } from '@cardstack/host/resources/card-type';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
-import { eq } from '../helpers/truth-helpers';
+import { eq } from '@cardstack/host/helpers/truth-helpers';
 import { RealmPaths } from '@cardstack/runtime-common/paths';
 //@ts-ignore cached not available yet in definitely typed
 import { cached, tracked } from '@glimmer/tracking';
@@ -22,10 +22,10 @@ import { hash } from '@ember/helper';
 import CatalogEntryEditor from './catalog-entry-editor';
 import { restartableTask } from 'ember-concurrency';
 import Modifier from 'ember-modifier';
-import type LoaderService from '../services/loader-service';
-import type CardService from '../services/card-service';
+import type LoaderService from '@cardstack/host/services/loader-service';
+import type CardService from '@cardstack/host/services/card-service';
 import type { ModuleSyntax } from '@cardstack/runtime-common/module-syntax';
-import type { FileResource } from '../resources/file';
+import type { FileResource } from '@cardstack/host/resources/file';
 import type { CatalogEntry } from 'https://cardstack.com/base/catalog-entry';
 import type { Card, FieldType } from 'https://cardstack.com/base/card-api';
 import {

--- a/packages/host/app/components/format-picker.gts
+++ b/packages/host/app/components/format-picker.gts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { on } from '@ember/modifier';
 import { fn } from '@ember/helper';
-import { eq } from '../helpers/truth-helpers';
+import { eq } from '@cardstack/host/helpers/truth-helpers';
 import type { Format } from 'https://cardstack.com/base/card-api';
 
 interface Signature {

--- a/packages/host/app/components/format-picker.gts
+++ b/packages/host/app/components/format-picker.gts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { on } from '@ember/modifier';
 import { fn } from '@ember/helper';
-import { eq } from '@cardstack/host/helpers/truth-helpers';
+import { eq } from '../helpers/truth-helpers';
 import type { Format } from 'https://cardstack.com/base/card-api';
 
 interface Signature {

--- a/packages/host/app/components/matrix/login.gts
+++ b/packages/host/app/components/matrix/login.gts
@@ -11,8 +11,8 @@ import {
   FieldContainer,
   LoadingIndicator,
 } from '@cardstack/boxel-ui';
-import { isMatrixError } from '../lib/matrix-utils';
-import type MatrixService from '../services/matrix-service';
+import { isMatrixError } from '@cardstack/host/lib/matrix-utils';
+import type MatrixService from '@cardstack/host/services/matrix-service';
 import { type IAuthData } from 'matrix-js-sdk';
 
 const TRUE = true;
@@ -114,6 +114,6 @@ export default class Login extends Component {
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Login {
-    Login: typeof Login;
+    'Matrix::Login': typeof Login;
   }
 }

--- a/packages/host/app/components/matrix/register-user.gts
+++ b/packages/host/app/components/matrix/register-user.gts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { on } from '@ember/modifier';
-import { eq } from '../helpers/truth-helpers';
+import { eq } from '@cardstack/host/helpers/truth-helpers';
 import { tracked } from '@glimmer/tracking';
 import { type IAuthData } from 'matrix-js-sdk';
 import { restartableTask } from 'ember-concurrency';
@@ -14,9 +14,9 @@ import {
   Button,
   FieldContainer,
 } from '@cardstack/boxel-ui';
-import { isMatrixError } from '../lib/matrix-utils';
+import { isMatrixError } from '@cardstack/host/lib/matrix-utils';
 import difference from 'lodash/difference';
-import type MatrixService from '../services/matrix-service';
+import type MatrixService from '@cardstack/host/services/matrix-service';
 
 const TRUE = true;
 const MATRIX_REGISTRATION_TYPES = {
@@ -362,6 +362,6 @@ function isRegistrationFlows(
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface RegisterUser {
-    RegisterUser: typeof RegisterUser;
+    'Matrix::RegisterUser': typeof RegisterUser;
   }
 }

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -4,7 +4,7 @@ import { action } from '@ember/object';
 import { on } from '@ember/modifier';
 //@ts-expect-error the types don't recognize the cached export
 import { tracked, cached } from '@glimmer/tracking';
-import { not, and } from '../helpers/truth-helpers';
+import { not, and } from '@cardstack/host/helpers/truth-helpers';
 import { restartableTask } from 'ember-concurrency';
 import {
   BoxelHeader,
@@ -13,16 +13,16 @@ import {
   FieldContainer,
   Button,
 } from '@cardstack/boxel-ui';
-import { getRoomCard } from '../resources/room-card';
+import { getRoomCard } from '@cardstack/host/resources/room-card';
 import { TrackedMap } from 'tracked-built-ins';
 import {
   chooseCard,
   baseCardRef,
   catalogEntryRef,
 } from '@cardstack/runtime-common';
-import type MatrixService from '../services/matrix-service';
+import type MatrixService from '@cardstack/host/services/matrix-service';
 import { type Card } from 'https://cardstack.com/base/card-api';
-import type CardService from '../services/card-service';
+import type CardService from '@cardstack/host/services/card-service';
 import { type CatalogEntry } from 'https://cardstack.com/base/catalog-entry';
 
 const TRUE = true;
@@ -398,6 +398,6 @@ export default class Room extends Component<RoomArgs> {
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Room {
-    Room: typeof Room;
+    'Matrix::Room': typeof Room;
   }
 }

--- a/packages/host/app/components/matrix/rooms-manager.gts
+++ b/packages/host/app/components/matrix/rooms-manager.gts
@@ -5,7 +5,7 @@ import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 //@ts-expect-error the types don't recognize the cached export
 import { tracked, cached } from '@glimmer/tracking';
-import { not, eq } from '../helpers/truth-helpers';
+import { not, eq } from '@cardstack/host/helpers/truth-helpers';
 import { restartableTask, timeout } from 'ember-concurrency';
 import {
   BoxelHeader,
@@ -15,13 +15,13 @@ import {
   Button,
   FieldContainer,
 } from '@cardstack/boxel-ui';
-import { isMatrixError } from '../lib/matrix-utils';
+import { isMatrixError } from '@cardstack/host/lib/matrix-utils';
 import { LinkTo } from '@ember/routing';
-import { eventDebounceMs } from '../lib/matrix-utils';
-import { getRoomCard, RoomCardResource } from '../resources/room-card';
+import { eventDebounceMs } from '@cardstack/host/lib/matrix-utils';
+import { getRoomCard, RoomCardResource } from '@cardstack/host/resources/room-card';
 import { TrackedMap } from 'tracked-built-ins';
 import RouterService from '@ember/routing/router-service';
-import type MatrixService from '../services/matrix-service';
+import type MatrixService from '@cardstack/host/services/matrix-service';
 import type { RoomCard, RoomMemberCard } from 'https://cardstack.com/base/room';
 
 const TRUE = true;
@@ -331,6 +331,6 @@ export default class RoomsManager extends Component {
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface RoomsManager {
-    RoomsManager: typeof RoomsManager;
+    'Matrix::RoomsManager': typeof RoomsManager;
   }
 }

--- a/packages/host/app/components/matrix/user-profile.gts
+++ b/packages/host/app/components/matrix/user-profile.gts
@@ -11,8 +11,8 @@ import {
 } from '@cardstack/boxel-ui';
 import { dropTask, restartableTask } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
-import { not } from '../helpers/truth-helpers';
-import type MatrixService from '../services/matrix-service';
+import { not } from '@cardstack/host/helpers/truth-helpers';
+import type MatrixService from '@cardstack/host/services/matrix-service';
 
 const TRUE = true;
 
@@ -140,6 +140,6 @@ export default class UserProfile extends Component {
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface UserProfile {
-    UserProfile: typeof UserProfile;
+    'Matrix::UserProfile': typeof UserProfile;
   }
 }

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -5,8 +5,7 @@ import { action } from '@ember/object';
 import { fn } from '@ember/helper';
 import { trackedFunction } from 'ember-resources/util/function';
 import CardCatalogModal from '@cardstack/host/components/card-catalog-modal';
-import type CardService from '../services/card-service';
-// import getValueFromWeakMap from '../helpers/get-value-from-weakmap';
+import type CardService from '@cardstack/host/services/card-service';
 import { eq } from '@cardstack/boxel-ui/helpers/truth-helpers';
 import {
   Modal,
@@ -23,17 +22,17 @@ import {
   type CardRef,
   LooseSingleCardDocument,
 } from '@cardstack/runtime-common';
-import type LoaderService from '../services/loader-service';
+import type LoaderService from '@cardstack/host/services/loader-service';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { htmlSafe, SafeString } from '@ember/template';
 import { registerDestructor } from '@ember/destroyable';
 import type { Query } from '@cardstack/runtime-common/query';
-import { getSearchResults, type Search } from '../resources/search';
+import { getSearchResults, type Search } from '@cardstack/host/resources/search';
 import { svgJar } from '@cardstack/boxel-ui/helpers/svg-jar';
 import perform from 'ember-concurrency/helpers/perform';
 import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
-import OperatorModeStackItem from '@cardstack/host/components/operator-mode-stack-item';
+import OperatorModeStackItem from './stack-item';
 
 interface Signature {
   Args: {
@@ -56,7 +55,7 @@ export type StackItem = {
   isLinkedCard?: boolean;
 };
 
-export default class OperatorMode extends Component<Signature> {
+export default class OperatorModeContainer extends Component<Signature> {
   //A variable to store value of card field
   //before in edit mode.
   cardFieldValues: WeakMap<Card, Map<string, any>> = new WeakMap<
@@ -419,6 +418,6 @@ export default class OperatorMode extends Component<Signature> {
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry {
-    OperatorMode: typeof OperatorMode;
+    'OperatorMode::Container': typeof OperatorModeContainer;
   }
 }

--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -2,12 +2,7 @@ import Component from '@glimmer/component';
 import { fn } from '@ember/helper';
 import { Card } from 'https://cardstack.com/base/card-api';
 import { on } from '@ember/modifier';
-import {
-  StackItem,
-} from '@cardstack/host/components/operator-mode';
-import {
-  RenderedLinksToCard,
-} from '@cardstack/host/components/operator-mode-stack-item';
+import StackItem, { RenderedLinksToCard } from './stack-item';
 import { action } from '@ember/object';
 import { velcro } from 'ember-velcro';
 

--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -2,7 +2,8 @@ import Component from '@glimmer/component';
 import { fn } from '@ember/helper';
 import { Card } from 'https://cardstack.com/base/card-api';
 import { on } from '@ember/modifier';
-import StackItem, { RenderedLinksToCard } from './stack-item';
+import { StackItem } from './container';
+import { RenderedLinksToCard } from './stack-item';
 import { action } from '@ember/object';
 import { velcro } from 'ember-velcro';
 

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -1,9 +1,9 @@
 import Component from '@glimmer/component';
 import { on } from '@ember/modifier';
 import { Card, CardContext } from 'https://cardstack.com/base/card-api';
-import Preview from './preview';
+import Preview from '@cardstack/host/components/preview';
 import { fn, array } from '@ember/helper';
-import type CardService from '../services/card-service';
+import type CardService from '@cardstack/host/services/card-service';
 import { eq } from '@cardstack/boxel-ui/helpers/truth-helpers';
 import optional from '@cardstack/boxel-ui/helpers/optional';
 import cn from '@cardstack/boxel-ui/helpers/cn';
@@ -17,7 +17,7 @@ import {
   type Actions,
   cardTypeDisplayName,
 } from '@cardstack/runtime-common';
-import type LoaderService from '../services/loader-service';
+import type LoaderService from '@cardstack/host/services/loader-service';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { TrackedArray } from 'tracked-built-ins';
@@ -27,8 +27,8 @@ import { SafeString } from '@ember/template';
 import BoxelDropdown from '@cardstack/boxel-ui/components/dropdown';
 import BoxelMenu from '@cardstack/boxel-ui/components/menu';
 import menuItem from '@cardstack/boxel-ui/helpers/menu-item';
-import { StackItem } from '@cardstack/host/components/operator-mode';
-import OperatorModeOverlays from '@cardstack/host/components/operator-mode-overlays';
+import { StackItem } from '@cardstack/host/components/operator-mode/container';
+import OperatorModeOverlays from '@cardstack/host/components/operator-mode/overlays';
 
 interface Signature {
   Args: {

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -2,7 +2,7 @@ import {
   OperatorModeState,
   Stack,
   StackItem,
-} from '@cardstack/host/components/operator-mode';
+} from '@cardstack/host/components/operator-mode/container';
 import Service from '@ember/service';
 import type CardService from '../services/card-service';
 import { TrackedArray, TrackedObject } from 'tracked-built-ins';

--- a/packages/host/app/templates/card-error.hbs
+++ b/packages/host/app/templates/card-error.hbs
@@ -3,4 +3,4 @@
   @message={{this.model.message}}
 />
 
-<CodeLink />
+<Editor::CodeLink />

--- a/packages/host/app/templates/card.hbs
+++ b/packages/host/app/templates/card.hbs
@@ -2,7 +2,7 @@
   <this.getIsolatedComponent />
 </div>
 
-<CodeLink />
+<Editor::CodeLink />
 
 {{on-key 'Ctrl+.' this.toggleOperatorMode}}
 

--- a/packages/host/app/templates/card.hbs
+++ b/packages/host/app/templates/card.hbs
@@ -8,7 +8,7 @@
 
 {{#if this.operatorModeEnabled}}
   {{#if this.model}}
-    <OperatorMode
+    <OperatorMode::Container
       @onClose={{this.closeOperatorMode}}
     />
   {{/if}}

--- a/packages/host/app/templates/chat.hbs
+++ b/packages/host/app/templates/chat.hbs
@@ -6,8 +6,8 @@
 <h1>Matrix Spike</h1>
 
 {{#if this.isLoggedIn}}
-  <UserProfile/>
-  <RoomsManager/>
+  <Matrix::UserProfile/>
+  <Matrix::RoomsManager/>
 {{/if}}
 
 {{outlet}}

--- a/packages/host/app/templates/chat/index.hbs
+++ b/packages/host/app/templates/chat/index.hbs
@@ -1,5 +1,5 @@
 {{#unless this.isLoggedIn}}
-  <Login />
+  <Matrix::Login />
   <LinkTo
     @route="chat.register"
     class="link"

--- a/packages/host/app/templates/chat/register.hbs
+++ b/packages/host/app/templates/chat/register.hbs
@@ -1,1 +1,1 @@
-  <RegisterUser/>
+  <Matrix::RegisterUser/>

--- a/packages/host/app/templates/chat/room.hbs
+++ b/packages/host/app/templates/chat/room.hbs
@@ -1,1 +1,1 @@
-<Room @roomId={{this.model.roomId}} />
+<Matrix::Room @roomId={{this.model.roomId}} />

--- a/packages/host/app/templates/code.hbs
+++ b/packages/host/app/templates/code.hbs
@@ -4,7 +4,7 @@
   <CardCatalogModal />
   <CreateCardModal />
 
-  <Go
+  <Editor::Go
     @path={{this.model.path}}
     @openFile={{this.model.openFile}}
     @openDirs={{this.model.openDirs}}

--- a/packages/host/tests/integration/components/catalog-entry-editor-test.gts
+++ b/packages/host/tests/integration/components/catalog-entry-editor-test.gts
@@ -5,7 +5,7 @@ import { Loader } from '@cardstack/runtime-common/loader';
 import { Realm } from '@cardstack/runtime-common/realm';
 import { setupRenderingTest } from 'ember-qunit';
 import { renderComponent } from '../../helpers/render-component';
-import CatalogEntryEditor from '@cardstack/host/components/catalog-entry-editor';
+import CatalogEntryEditor from '@cardstack/host/components/editor/catalog-entry-editor';
 import {
   TestRealm,
   TestRealmAdapter,

--- a/packages/host/tests/integration/components/file-tree-test.gts
+++ b/packages/host/tests/integration/components/file-tree-test.gts
@@ -15,7 +15,7 @@ import {
 import CreateCardModal from '@cardstack/host/components/create-card-modal';
 import CardCatalogModal from '@cardstack/host/components/card-catalog-modal';
 import CardPrerender from '@cardstack/host/components/card-prerender';
-import FileTree from '@cardstack/host/components/file-tree';
+import FileTree from '@cardstack/host/components/editor/file-tree';
 import { waitUntil, waitFor, fillIn, click } from '@ember/test-helpers';
 import type LoaderService from '@cardstack/host/services/loader-service';
 import { shimExternals } from '@cardstack/host/lib/externals';

--- a/packages/host/tests/integration/components/go-test.gts
+++ b/packages/host/tests/integration/components/go-test.gts
@@ -7,7 +7,7 @@ import {
   setupOnerror,
   waitUntil,
 } from '@ember/test-helpers';
-import Go from '@cardstack/host/components/go';
+import Go from '@cardstack/host/components/editor/go';
 import { Loader } from '@cardstack/runtime-common/loader';
 import { Realm } from '@cardstack/runtime-common/realm';
 import { baseRealm } from '@cardstack/runtime-common';

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -4,7 +4,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { baseRealm, cardTypeDisplayName } from '@cardstack/runtime-common';
 import { Realm } from '@cardstack/runtime-common/realm';
 import { Loader } from '@cardstack/runtime-common/loader';
-import OperatorMode from '@cardstack/host/components/operator-mode';
+import OperatorMode from '@cardstack/host/components/operator-mode/container';
 import CardPrerender from '@cardstack/host/components/card-prerender';
 import { Card } from 'https://cardstack.com/base/card-api';
 import { renderComponent } from '../../helpers/render-component';

--- a/packages/host/tests/integration/components/schema-test.gts
+++ b/packages/host/tests/integration/components/schema-test.gts
@@ -3,7 +3,7 @@ import { waitFor, fillIn, click } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 import { setupRenderingTest } from 'ember-qunit';
 import { renderComponent } from '../../helpers/render-component';
-import Module from '@cardstack/host/components/module';
+import Module from '@cardstack/host/components/editor/module';
 import { Loader } from '@cardstack/runtime-common/loader';
 import { baseRealm } from '@cardstack/runtime-common';
 import {


### PR DESCRIPTION
This groups some components into functional subdirectories: `editor`, `matrix`, and `operator-mode`. Wherever it made sense I changed relative imports to absolute ones, I kept component imports relative when they were in the same directory.