### PR TITLE
Fix too many redirects error when running base realm at root

### DIFF
--- a/packages/host/app/config/environment.d.ts
+++ b/packages/host/app/config/environment.d.ts
@@ -17,4 +17,5 @@ declare const config: {
   hostsOwnAssets: boolean;
   realmsServed?: string[];
   logLevels: string;
+  resolvedOwnRealmURL: string;
 };

--- a/packages/host/app/router.ts
+++ b/packages/host/app/router.ts
@@ -1,13 +1,20 @@
 import EmberRouter from '@ember/routing/router';
 import config from '@cardstack/host/config/environment';
-const { ownRealmURL, hostsOwnAssets } = config;
+const { ownRealmURL, resolvedOwnRealmURL, hostsOwnAssets } = config;
 
 export default class Router extends EmberRouter {
   location = config.locationType;
   rootURL = config.rootURL;
 }
 
-let path = new URL(ownRealmURL).pathname.replace(/\/$/, '');
+// When resolvedOwnRealmURL is available, that is actually the path in the browser.
+// It will not be available when running in fastboot.
+// When paths of resolvedOwnRealmURL and ownRealmURL are not symmetrical,
+// that means that means the resolvedOwnRealmURL should be used instead of ownRealmURL.
+let path = new URL(resolvedOwnRealmURL ?? ownRealmURL).pathname.replace(
+  /\/$/,
+  ''
+);
 
 Router.map(function () {
   this.route('freestyle', { path: '/_freestyle' });

--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -32,6 +32,10 @@ module.exports = function (environment) {
     hostsOwnAssets: true,
     resolvedBaseRealmURL:
       process.env.RESOLVED_BASE_REALM_URL || 'http://localhost:4201/base/',
+    resolvedOwnRealmURL:
+      environment === 'test'
+        ? 'http://test-realm/test/'
+        : process.env.OWN_REALM_URL || 'http://localhost:4200/',
   };
 
   if (environment === 'development') {

--- a/packages/realm-server/middleware/index.ts
+++ b/packages/realm-server/middleware/index.ts
@@ -79,8 +79,11 @@ export function assetRedirect(
         `./${ctxt.path.slice(assetsDir.length + 1)}`,
         assetsURL
       ).href;
-      ctxt.redirect(redirectURL);
-      return;
+
+      if (redirectURL !== ctxt.href) {
+        ctxt.redirect(redirectURL);
+        return;
+      }
     }
     return next();
   };

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -319,8 +319,9 @@ export class Realm {
       (_match, g1, g2, g3) => {
         let config = JSON.parse(decodeURIComponent(g2));
         config = merge({}, config, {
-          ownRealmURL: this.url,
+          ownRealmURL: this.url, // unresolved url
           resolvedBaseRealmURL,
+          resolvedOwnRealmURL: this.#searchIndex.loader.resolve(this.url).href,
           hostsOwnAssets: !isNode,
           realmsServed: opts?.realmsServed,
         });


### PR DESCRIPTION
When running `pnpm start:base:root`, the app failed to load due to assets being stuck in a redirect loop. 

The solution is to prevent redirection when asset url is already correct. 

This alone didn't fully fix problems as the app was still failing to load - this time, the index card. The solution is to introduce the resolved realm url in the router logic so that it enters the condition where the index card is fetched. 

This is the result of yesterday's pairing with @habdelra - thanks!! 