### PR TITLE
Add support for multiple stacks in operator mode 

### DIFF
--- a/packages/host/.eslintrc.js
+++ b/packages/host/.eslintrc.js
@@ -73,5 +73,14 @@ module.exports = {
         'qunit/no-conditional-assertions': 'off',
       },
     },
+    {
+      // typescript-eslint recommends turning off no-undef for Typescript files since
+      // Typescript will better analyse that:
+      // https://github.com/typescript-eslint/typescript-eslint/blob/5b0e577f2552e8b2c53a3fb22edc9d219589b937/docs/linting/Troubleshooting.mdx#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors
+      files: ['**/*.ts', '**/*.gts'],
+      rules: {
+        'no-undef': 'off',
+      },
+    },
   ],
 };

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -294,6 +294,7 @@ export default class OperatorModeContainer extends Component<Signature> {
     }
   });
 
+  // For now use the background from the 1st stack, but eventually, each stack to have its own background URL
   fetchBackgroundImageURL = trackedFunction(this, async () => {
     let mostBottomCard = this.stacks[0]?.items[0]?.card;
     let realmInfoSymbol = await this.cardService.realmInfoSymbol();

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -6,6 +6,7 @@ import { fn } from '@ember/helper';
 import { trackedFunction } from 'ember-resources/util/function';
 import CardCatalogModal from '@cardstack/host/components/card-catalog-modal';
 import type CardService from '@cardstack/host/services/card-service';
+
 import { eq } from '@cardstack/boxel-ui/helpers/truth-helpers';
 import { Modal } from '@cardstack/boxel-ui';
 import SearchSheet, {
@@ -23,7 +24,7 @@ import {
 import type LoaderService from '@cardstack/host/services/loader-service';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import { htmlSafe, SafeString } from '@ember/template';
+
 import { registerDestructor } from '@ember/destroyable';
 import type { Query } from '@cardstack/runtime-common/query';
 import {
@@ -33,7 +34,8 @@ import {
 import { svgJar } from '@cardstack/boxel-ui/helpers/svg-jar';
 import perform from 'ember-concurrency/helpers/perform';
 import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
-import OperatorModeStackItem from './stack-item';
+
+import OperatorModeStack from '@cardstack/host/components/operator-mode/stack';
 
 interface Signature {
   Args: {
@@ -54,11 +56,11 @@ export type StackItem = {
   format: Format;
   request?: Deferred<Card>;
   isLinkedCard?: boolean;
+  stackIndex: number;
 };
 
 export default class OperatorModeContainer extends Component<Signature> {
-  //A variable to store value of card field
-  //before in edit mode.
+  // In this map we store the field values of cards that are being edited so that we can restore them if the user cancels the edit
   cardFieldValues: WeakMap<Card, Map<string, any>> = new WeakMap<
     Card,
     Map<string, any>
@@ -74,13 +76,12 @@ export default class OperatorModeContainer extends Component<Signature> {
     (globalThis as any)._CARDSTACK_CARD_SEARCH = this;
     registerDestructor(this, () => {
       delete (globalThis as any)._CARDSTACK_CARD_SEARCH;
-      this.operatorModeStateService.clearStack();
+      this.operatorModeStateService.clearStacks();
     });
   }
 
-  get stack() {
-    // We return the first one until we start supporting 2 stacks
-    return this.operatorModeStateService.state?.stacks[0]?.items;
+  get stacks() {
+    return this.operatorModeStateService.state?.stacks ?? [];
   }
 
   @action
@@ -124,6 +125,7 @@ export default class OperatorModeContainer extends Component<Signature> {
       card: item.card,
       format,
       request,
+      stackIndex: item.stackIndex,
     };
 
     this.replaceItemInStack(item, newItem);
@@ -156,12 +158,13 @@ export default class OperatorModeContainer extends Component<Signature> {
         this.replaceItemInStack(item, {
           card: updatedCard,
           format: 'isolated',
+          stackIndex: item.stackIndex,
         });
       }
     }
   }
 
-  //TODO: Implement remove card function
+  // TODO: Implement remove card function
   @action async delete(item: StackItem) {
     await this.close(item);
   }
@@ -197,55 +200,62 @@ export default class OperatorModeContainer extends Component<Signature> {
     }
   }
 
-  private publicAPI: Actions = {
-    createCard: async (
-      ref: CardRef,
-      relativeTo: URL | undefined,
-      opts?: {
-        isLinkedCard?: boolean;
-        doc?: LooseSingleCardDocument; // fill in card data with values
-      }
-    ): Promise<Card | undefined> => {
-      // prefers optional doc to be passed in
-      // use case: to populate default values in a create modal
-      let doc: LooseSingleCardDocument = opts?.doc ?? {
-        data: { meta: { adoptsFrom: ref } },
-      };
-      let newCard = await this.cardService.createFromSerialized(
-        doc.data,
-        doc,
-        relativeTo ?? this.cardService.defaultURL
-      );
-      let newItem: StackItem = {
-        card: newCard,
-        format: 'edit',
-        request: new Deferred(),
-        isLinkedCard: opts?.isLinkedCard,
-      };
-      this.addToStack(newItem);
-      return await newItem.request?.promise;
-    },
-    viewCard: (card: Card) => {
-      return this.addToStack({ card, format: 'isolated' });
-    },
-    createCardDirectly: async (
-      doc: LooseSingleCardDocument,
-      relativeTo: URL | undefined
-    ): Promise<void> => {
-      let newCard = await this.cardService.createFromSerialized(
-        doc.data,
-        doc,
-        relativeTo ?? this.cardService.defaultURL
-      );
-      await this.cardService.saveModel(newCard);
-      let newItem: StackItem = {
-        card: newCard,
-        format: 'isolated',
-      };
-      this.addToStack(newItem);
-      return;
-    },
-  };
+  // The public API is wrapped in a closure so that whatever calls its methods
+  // in the context of operator-mode, the methods can be aware of which stack to deal with (via stackIndex), i.e.
+  // to which stack the cards will be added to, or from which stack the cards will be removed from.
+  private publicAPI(here: OperatorModeContainer, stackIndex: number): Actions {
+    return {
+      createCard: async (
+        ref: CardRef,
+        relativeTo: URL | undefined,
+        opts?: {
+          isLinkedCard?: boolean;
+          doc?: LooseSingleCardDocument; // fill in card data with values
+        }
+      ): Promise<Card | undefined> => {
+        // prefers optional doc to be passed in
+        // use case: to populate default values in a create modal
+        let doc: LooseSingleCardDocument = opts?.doc ?? {
+          data: { meta: { adoptsFrom: ref } },
+        };
+        let newCard = await here.cardService.createFromSerialized(
+          doc.data,
+          doc,
+          relativeTo ?? here.cardService.defaultURL
+        );
+        let newItem: StackItem = {
+          card: newCard,
+          format: 'edit',
+          request: new Deferred(),
+          isLinkedCard: opts?.isLinkedCard,
+          stackIndex,
+        };
+        here.addToStack(newItem);
+        return await newItem.request?.promise;
+      },
+      viewCard: (card: Card) => {
+        return here.addToStack({ card, format: 'isolated', stackIndex });
+      },
+      createCardDirectly: async (
+        doc: LooseSingleCardDocument,
+        relativeTo: URL | undefined
+      ): Promise<void> => {
+        let newCard = await here.cardService.createFromSerialized(
+          doc.data,
+          doc,
+          relativeTo ?? here.cardService.defaultURL
+        );
+        await here.cardService.saveModel(newCard);
+        let newItem: StackItem = {
+          card: newCard,
+          format: 'isolated',
+          stackIndex,
+        };
+        here.addToStack(newItem);
+        return;
+      },
+    };
+  }
 
   private async rollbackCardFieldValues(card: Card) {
     let fields = await this.cardService.getFields(card);
@@ -268,20 +278,6 @@ export default class OperatorModeContainer extends Component<Signature> {
     }
   }
 
-  @action
-  styleForStackedCard(index: number): SafeString {
-    let invertedIndex = this.stack.length - index - 1;
-
-    let widthReductionPercent = 5; // Every new card on the stack is 5% wider than the previous one
-    let offsetPx = 40; // Every new card on the stack is 40px lower than the previous one
-
-    return htmlSafe(`
-      width: ${100 - invertedIndex * widthReductionPercent}%;
-      z-index: ${this.stack.length - invertedIndex};
-      padding-top: calc(${offsetPx}px * ${index});
-    `);
-  }
-
   addCard = restartableTask(async () => {
     let type = baseCardRef;
     let chosenCard: Card | undefined = await chooseCard({
@@ -292,26 +288,14 @@ export default class OperatorModeContainer extends Component<Signature> {
       let newItem: StackItem = {
         card: chosenCard,
         format: 'isolated',
+        stackIndex: 0, // This is called when there are no cards in the stack left, so we can assume the stackIndex is 0
       };
       this.addToStack(newItem);
     }
   });
 
-  @action
-  isBuried(stackIndex: number) {
-    return stackIndex + 1 < this.stack.length;
-  }
-
-  @action
-  async dismissStackedCardsAbove(stackIndex: number) {
-    for (let i = this.stack.length - 1; i > stackIndex; i--) {
-      let stackItem = this.stack[i];
-      await this.close(stackItem);
-    }
-  }
-
   fetchBackgroundImageURL = trackedFunction(this, async () => {
-    let mostBottomCard = this.stack?.[0]?.card;
+    let mostBottomCard = this.stacks[0]?.items[0]?.card;
     let realmInfoSymbol = await this.cardService.realmInfoSymbol();
     // @ts-ignore allows using Symbol as an index
     return mostBottomCard?.[realmInfoSymbol]?.backgroundURL;
@@ -319,6 +303,14 @@ export default class OperatorModeContainer extends Component<Signature> {
 
   get backgroundImageURL() {
     return this.fetchBackgroundImageURL.value ?? '';
+  }
+
+  get allStackItems() {
+    return (
+      this.operatorModeStateService.state?.stacks
+        .map((stack) => stack.items)
+        .flat() ?? []
+    );
   }
 
   <template>
@@ -333,12 +325,12 @@ export default class OperatorModeContainer extends Component<Signature> {
 
       <CardCatalogModal />
 
-      {{#if (eq this.stack.length 0)}}
+      {{#if (eq this.allStackItems.length 0)}}
         <div class='no-cards'>
-          <p class='add-card-title'>Add a card to get
-            started</p>
-          {{! Cannot find an svg icon with plus in the box
-          that we can fill the color of the plus and the box. }}
+          <p class='add-card-title'>
+            Add a card to get started
+          </p>
+
           <button
             class='add-card-button icon-button'
             {{on 'click' (fn (perform this.addCard))}}
@@ -348,42 +340,40 @@ export default class OperatorModeContainer extends Component<Signature> {
           </button>
         </div>
       {{else}}
-        <div class='card-stack' data-test-card-stack>
-          {{#each this.stack as |item i|}}
-            <OperatorModeStackItem
-              @item={{item}}
-              @index={{i}}
-              @publicAPI={{this.publicAPI}}
-              @addToStack={{this.addToStack}}
-              @dismissStackedCardsAbove={{this.dismissStackedCardsAbove}}
-              @isBuried={{this.isBuried}}
-              @close={{this.close}}
-              @cancel={{this.cancel}}
-              @edit={{this.edit}}
-              @delete={{this.delete}}
-              @save={{this.save}}
-              @styleForStackedCard={{this.styleForStackedCard}}
-            />
-          {{/each}}
-        </div>
+        {{#each this.stacks as |stack stackIndex|}}
+          {{! Argument of type 'unknown' is not assignable to parameter of type 'Element'. (this is because of class='operator-mode-stack') }}
+          {{! @glint-ignore }}
+          <OperatorModeStack
+            data-test-operator-mode-stack={{stackIndex}}
+            class='operator-mode-stack'
+            @stackItems={{stack.items}}
+            @stackIndex={{stackIndex}}
+            @publicAPI={{this.publicAPI this stackIndex}}
+            @close={{this.close}}
+            @cancel={{this.cancel}}
+            @edit={{this.edit}}
+            @delete={{this.delete}}
+            @save={{this.save}}
+          />
+        {{/each}}
       {{/if}}
+
       <SearchSheet
         @mode={{this.searchSheetMode}}
         @onCancel={{this.onCancelSearchSheet}}
         @onFocus={{this.onFocusSearchInput}}
       />
     </Modal>
+
     <style>
       :global(:root) {
         --operator-mode-bg-color: #686283;
       }
-
       .operator-mode > div {
         align-items: flex-start;
       }
-  
       .no-cards {
-        height: calc(100% - var(--search-sheet-closed-height));
+        height: calc(100% -var(--search-sheet-closed-height));
         width: 100%;
         max-width: 50rem;
         display: flex;
@@ -391,12 +381,10 @@ export default class OperatorModeContainer extends Component<Signature> {
         justify-content: center;
         align-items: center;
       }
-
       .add-card-title {
         color: var(--boxel-light);
         font: var(--boxel-font-lg);
       }
-
       .add-card-button {
         height: 350px;
         width: 200px;
@@ -405,21 +393,8 @@ export default class OperatorModeContainer extends Component<Signature> {
         border: none;
         border-radius: var(--boxel-border-radius);
       }
-
       .add-card-button:hover {
         background: var(--boxel-dark-teal);
-      }
-
-      .card-stack {
-        position: relative;
-        height: calc(100% - var(--search-sheet-closed-height));
-        width: 100%;
-        max-width: 50rem;
-        padding-top: var(--boxel-sp-xxl);
-        display: flex;
-        justify-content: center;
-        overflow: hidden;
-        z-index: 0;
       }
     </style>
   </template>

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -342,8 +342,6 @@ export default class OperatorModeContainer extends Component<Signature> {
         </div>
       {{else}}
         {{#each this.stacks as |stack stackIndex|}}
-          {{! Argument of type 'unknown' is not assignable to parameter of type 'Element'. (this is because of class='operator-mode-stack') }}
-          {{! @glint-ignore }}
           <OperatorModeStack
             data-test-operator-mode-stack={{stackIndex}}
             class='operator-mode-stack'

--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -1,16 +1,14 @@
 import Component from '@glimmer/component';
 import { fn } from '@ember/helper';
-import { Card } from 'https://cardstack.com/base/card-api';
 import { on } from '@ember/modifier';
-import { StackItem } from './container';
 import { RenderedLinksToCard } from './stack-item';
-import { action } from '@ember/object';
 import { velcro } from 'ember-velcro';
+import { Actions } from '@cardstack/runtime-common';
 
 interface Signature {
   Args: {
     renderedLinksToCards: RenderedLinksToCard[];
-    addToStack: (stackItem: StackItem) => void;
+    publicAPI: Actions;
   };
 }
 
@@ -21,7 +19,7 @@ export default class OperatorModeOverlays extends Component<Signature> {
   <template>
     {{#each @renderedLinksToCards as |renderedCard|}}
       <button
-        {{on 'click' (fn this.addToStack renderedCard.card)}}
+        {{on 'click' (fn @publicAPI.viewCard renderedCard.card)}}
         class='button'
         data-test-cardstack-operator-mode-overlay-button
         {{velcro renderedCard.element middleware=(Array this.offset)}}
@@ -30,20 +28,9 @@ export default class OperatorModeOverlays extends Component<Signature> {
       </button>
     {{/each}}
     <style>
-      .button {
-        position: absolute;
-        border: none;
-        width: auto;
-      }
+      .button { position: absolute; border: none; width: auto; }
     </style>
   </template>
-
-  @action addToStack(card: Card) {
-    this.args.addToStack({
-      card,
-      format: 'isolated',
-    });
-  }
 
   offset = {
     name: 'offset',

--- a/packages/host/app/components/operator-mode/stack.gts
+++ b/packages/host/app/components/operator-mode/stack.gts
@@ -1,0 +1,62 @@
+import Component from '@glimmer/component';
+import { Actions } from '@cardstack/runtime-common';
+import { StackItem } from '@cardstack/host/components/operator-mode/container';
+import OperatorModeStackItem from '@cardstack/host/components/operator-mode/stack-item';
+import { action } from '@ember/object';
+
+interface Signature {
+  Args: {
+    stackItems: StackItem[];
+    stackIndex: number;
+    publicAPI: Actions;
+    close: (stackItem: StackItem) => void;
+    cancel: (stackItem: StackItem) => void;
+    edit: (stackItem: StackItem) => void;
+    delete: (stackItem: StackItem) => void;
+    save: (stackItem: StackItem) => void;
+  };
+}
+
+export default class OperatorModeStack extends Component<Signature> {
+  @action
+  async dismissStackedCardsAbove(itemIndex: number) {
+    for (let i = this.args.stackItems.length - 1; i > itemIndex; i--) {
+      this.args.close(this.args.stackItems[i]);
+    }
+  }
+
+  <template>
+    {{! Argument of type 'unknown' is not assignable to parameter of type 'Element'. (this is because of ...attributes) }}
+    {{! @glint-ignore}}
+    <div ...attributes>
+      {{#each @stackItems as |item i|}}
+        <OperatorModeStackItem
+          @item={{item}}
+          @index={{i}}
+          @stackItems={{@stackItems}}
+          @publicAPI={{@publicAPI}}
+          @dismissStackedCardsAbove={{this.dismissStackedCardsAbove}}
+          @close={{@close}}
+          @cancel={{@cancel}}
+          @edit={{@edit}}
+          @delete={{@delete}}
+          @save={{@save}}
+        />
+      {{/each}}
+    </div>
+
+    <style>
+      .operator-mode-stack {
+        height: calc(100% - var(--search-sheet-closed-height));
+        position: relative;
+        width: 100%;
+        max-width: 50rem;
+        padding-top: var(--boxel-sp-xxl);
+        display: flex;
+        justify-content: center;
+        overflow: hidden;
+        z-index: 0;
+      }
+    </style>
+  </template>
+}

--- a/packages/host/app/components/operator-mode/stack.gts
+++ b/packages/host/app/components/operator-mode/stack.gts
@@ -5,7 +5,9 @@ import OperatorModeStackItem from '@cardstack/host/components/operator-mode/stac
 import { action } from '@ember/object';
 
 interface Signature {
+  Element: HTMLElement;
   Args: {
+    tag?: keyof HTMLElementTagNameMap;
     stackItems: StackItem[];
     stackIndex: number;
     publicAPI: Actions;
@@ -15,6 +17,7 @@ interface Signature {
     delete: (stackItem: StackItem) => void;
     save: (stackItem: StackItem) => void;
   };
+  Blocks: {};
 }
 
 export default class OperatorModeStack extends Component<Signature> {
@@ -26,8 +29,6 @@ export default class OperatorModeStack extends Component<Signature> {
   }
 
   <template>
-    {{! Argument of type 'unknown' is not assignable to parameter of type 'Element'. (this is because of ...attributes) }}
-    {{! @glint-ignore}}
     <div ...attributes>
       {{#each @stackItems as |item i|}}
         <OperatorModeStackItem

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -66,9 +66,7 @@ export default class OperatorModeStateService extends Service {
   }
 
   clearStacks() {
-    this.state = new TrackedObject({
-      stacks: new TrackedArray([]),
-    });
+    this.state.stacks.splice(0);
     this.schedulePersist();
   }
 

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -33,26 +33,42 @@ export default class OperatorModeStateService extends Service {
     this.state = await this.deserialize(rawState);
   }
 
-  addItemToStack(item: StackItem, stackIndex = 0) {
+  addItemToStack(item: StackItem) {
+    let stackIndex = item.stackIndex;
+    if (!this.state.stacks[stackIndex]) {
+      this.state.stacks[stackIndex] = new TrackedObject({
+        items: new TrackedArray([]),
+      });
+    }
     this.state.stacks[stackIndex].items.push(item);
     this.addRecentCards(item.card);
     this.schedulePersist();
   }
 
-  removeItemFromStack(item: StackItem, stackIndex = 0) {
+  removeItemFromStack(item: StackItem) {
+    let stackIndex = item.stackIndex;
     let itemIndex = this.state.stacks[stackIndex].items.indexOf(item);
     this.state.stacks[stackIndex].items.splice(itemIndex);
+
+    // If the additional stack is now empty, remove it from the state
+    if (this.state.stacks[stackIndex].items.length === 0 && stackIndex !== 0) {
+      this.state.stacks.splice(stackIndex);
+    }
+
     this.schedulePersist();
   }
 
-  replaceItemInStack(item: StackItem, newItem: StackItem, stackIndex = 0) {
+  replaceItemInStack(item: StackItem, newItem: StackItem) {
+    let stackIndex = item.stackIndex;
     let itemIndex = this.state.stacks[stackIndex].items.indexOf(item);
     this.state.stacks[stackIndex].items.splice(itemIndex, 1, newItem);
     this.schedulePersist();
   }
 
-  clearStack(stackIndex = 0) {
-    this.state.stacks[stackIndex].items.splice(0);
+  clearStacks() {
+    this.state = new TrackedObject({
+      stacks: new TrackedArray([]),
+    });
     this.schedulePersist();
   }
 
@@ -117,14 +133,16 @@ export default class OperatorModeStateService extends Service {
       stacks: [],
     });
 
+    let stackIndex = 0;
     for (let stack of rawState.stacks) {
       let newStack: Stack = { items: new TrackedArray([]) };
       for (let item of stack.items) {
         let cardUrl = new URL(item.card.id);
         let card = await this.cardService.loadModel(cardUrl);
-        newStack.items.push({ card, format: item.format });
+        newStack.items.push({ card, format: item.format, stackIndex });
       }
       newState.stacks.push(newStack);
+      stackIndex++;
     }
 
     return newState;

--- a/packages/host/tests/acceptance/operator-mode-test.ts
+++ b/packages/host/tests/acceptance/operator-mode-test.ts
@@ -14,7 +14,7 @@ import { Realm } from '@cardstack/runtime-common/realm';
 import { shimExternals } from '@cardstack/host/lib/externals';
 import type LoaderService from '@cardstack/host/services/loader-service';
 
-module('Acceptance | basic tests', function (hooks) {
+module('Acceptance | operator mode tests', function (hooks) {
   let realm: Realm;
   let adapter: TestRealmAdapter;
 
@@ -211,7 +211,7 @@ module('Acceptance | basic tests', function (hooks) {
       ctrlKey: true,
     });
 
-    assert.dom('[data-test-card-stack]').exists();
+    assert.dom('[data-test-operator-mode-stack]').exists();
     assert.dom('[data-test-stack-card-index="0"]').exists(); // Index card opens in the stack
 
     // In the URL, operatorModeEnabled is set to true and operatorModeState is set to the current stack
@@ -364,5 +364,76 @@ module('Acceptance | basic tests', function (hooks) {
 
     assert.dom('[data-test-field="firstName"] input').exists(); // Existence of an input field means it is in edit mode
     assert.dom('[data-test-save-button]').exists(); // Existence of save button means it is in edit mode
+  });
+
+  module('2 stacks', function () {
+    test('restoring the stacks from query param', async function (assert) {
+      let operatorModeStateParam = JSON.stringify({
+        stacks: [
+          {
+            items: [
+              {
+                card: { id: 'http://test-realm/test/Person/fadhlan' },
+                format: 'isolated',
+              },
+            ],
+          },
+          {
+            items: [
+              {
+                card: { id: 'http://test-realm/test/Pet/mango' },
+                format: 'isolated',
+              },
+            ],
+          },
+        ],
+      });
+
+      await visit(
+        `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+          operatorModeStateParam
+        )}`
+      );
+
+      assert.dom('[data-test-operator-mode-stack]').exists({ count: 2 });
+      assert.dom('[data-test-operator-mode-stack="0"]').includesText('Fadhlan');
+      assert.dom('[data-test-operator-mode-stack="1"]').includesText('Mango');
+
+      // Close the card in the 2nd stack
+      await click(
+        '[data-test-operator-mode-stack="1"] [data-test-close-button]'
+      );
+      assert.dom('[data-test-operator-mode-stack="0"]').exists();
+
+      // 2nd stack is removed, 1st stack remains
+      assert.dom('[data-test-operator-mode-stack="1"]').doesNotExist();
+      assert.dom('[data-test-operator-mode-stack="0"]').includesText('Fadhlan');
+
+      // The stack should be updated in the URL
+      assert.strictEqual(
+        currentURL(),
+        `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+          JSON.stringify({
+            stacks: [
+              {
+                items: [
+                  {
+                    card: { id: 'http://test-realm/test/Person/fadhlan' },
+                    format: 'isolated',
+                  },
+                ],
+              },
+            ],
+          })
+        )}`
+      );
+
+      // Close the last card in the last stack that is left - should get the empty state
+      await click(
+        '[data-test-operator-mode-stack="0"] [data-test-close-button]'
+      );
+
+      assert.dom('.no-cards').includesText('Add a card to get started');
+    });
   });
 });


### PR DESCRIPTION
This is preparatory work for when we'll support 2 stacks of cards. There is now a new stack component, but the data manipulation logic remains in the container component so that the data can flow down into stack components. Now one can operate on cards in each of the stacks independently. 

<img width="1618" alt="image" src="https://github.com/cardstack/boxel/assets/273660/91c30d98-1868-4ed4-8c2e-fabac41b9c2e">
