### PR TITLE
Prevent contained fields from containing themselves

### DIFF
--- a/packages/base/room-objective.gts
+++ b/packages/base/room-objective.gts
@@ -57,7 +57,7 @@ export class RoomObjectiveCard extends Card {
       let desiredMessages = this.room.messages.filter((m) =>
         m.message.match(/^[\W_b]*[Hh][Ee][Ll][Ll][Oo][\W_\b]*$/)
       );
-      return desiredMessages.map((m) => m.author);
+      return [...new Set(desiredMessages.map((m) => m.author))];
     },
   });
   @field usersThatNeedToCompleteTask = containsMany(RoomMemberCard, {

--- a/packages/base/room.gts
+++ b/packages/base/room.gts
@@ -56,7 +56,11 @@ function upsertRoomMember({
     return member;
   }
   if (!member) {
-    member = new RoomMemberCard({ id: userId, userId });
+    member = new RoomMemberCard({
+      id: userId,
+      userId,
+      roomId: roomCard.roomId,
+    });
     roomMembers.set(userId, member);
   }
   if (displayName) {
@@ -69,10 +73,7 @@ function upsertRoomMember({
     member.membershipDateTime = new Date(membershipTs);
   }
   if (membershipInitiator) {
-    member.membershipInitiator = upsertRoomMember({
-      roomCard,
-      userId: membershipInitiator,
-    });
+    member.membershipInitiator = membershipInitiator;
   }
   return member;
 }
@@ -138,10 +139,11 @@ class RoomMembershipCard extends CardBase {
 
 export class RoomMemberCard extends Card {
   @field userId = contains(StringCard);
+  @field roomId = contains(StringCard);
   @field displayName = contains(StringCard);
   @field membership = contains(RoomMembershipCard);
   @field membershipDateTime = contains(DateTimeCard);
-  @field membershipInitiator = contains(() => RoomMemberCard);
+  @field membershipInitiator = contains(StringCard);
   @field name = contains(StringCard, {
     computeVia: function (this: RoomMemberCard) {
       return this.displayName ?? this.userId.split(':')[0].substring(1);

--- a/packages/demo-cards/booking.gts
+++ b/packages/demo-cards/booking.gts
@@ -15,7 +15,7 @@ export class Booking extends Card {
   @field venue = contains(StringCard);
   @field startTime = contains(DateTimeCard);
   @field endTime = contains(DateTimeCard);
-  @field hosts = containsMany(() => Person);
+  @field hosts = containsMany(Person);
   @field sponsors = containsMany(StringCard);
 
   static embedded = class Embedded extends Component<typeof this> {

--- a/packages/demo-cards/claim-list.gts
+++ b/packages/demo-cards/claim-list.gts
@@ -12,7 +12,7 @@ import { Claim } from './claim';
 export class ClaimList extends Card {
   static displayName = 'List of Claims';
   @field description = contains(StringCard);
-  @field claims = linksToMany(() => Claim);
+  @field claims = linksToMany(Claim);
   @field title = contains(StringCard, {
     computeVia: function (this: ClaimList) {
       return this.constructor.displayName;

--- a/packages/demo-cards/claim.gts
+++ b/packages/demo-cards/claim.gts
@@ -333,7 +333,7 @@ export class Claim extends Card {
   @field explanation = contains(StringCard);
   @field signature = contains(StringCard);
   @field encoding = contains(StringCard);
-  @field chain = linksTo(() => Chain);
+  @field chain = linksTo(Chain);
   @field title = contains(StringCard, {
     computeVia: function (this: Claim) {
       return `Claim for ${this.safeAddress}`;

--- a/packages/demo-cards/friends.gts
+++ b/packages/demo-cards/friends.gts
@@ -11,7 +11,7 @@ import { Friend } from './friend';
 export class Friends extends Card {
   static displayName = 'Friends';
   @field firstName = contains(StringCard);
-  @field friends = linksToMany(() => Friend);
+  @field friends = linksToMany(Friend);
   @field title = contains(StringCard, {
     computeVia: function (this: Friends) {
       return this.firstName;

--- a/packages/demo-cards/person.gts
+++ b/packages/demo-cards/person.gts
@@ -15,7 +15,7 @@ export class Person extends Card {
   @field lastName = contains(StringCard);
   @field isCool = contains(BooleanCard);
   @field isHuman = contains(BooleanCard);
-  @field pet = linksTo(() => Pet);
+  @field pet = linksTo(Pet);
   @field title = contains(StringCard, {
     computeVia: function (this: Person) {
       return [this.firstName, this.lastName].filter(Boolean).join(' ');

--- a/packages/demo-cards/pet.gts
+++ b/packages/demo-cards/pet.gts
@@ -7,7 +7,6 @@ import {
 import BooleanCard from 'https://cardstack.com/base/boolean';
 import NumberCard from 'https://cardstack.com/base/number';
 import StringCard from 'https://cardstack.com/base/string';
-import { Booking } from './booking';
 
 export class Pet extends Card {
   static displayName = 'Pet';
@@ -16,7 +15,6 @@ export class Pet extends Card {
   @field favoriteTreat = contains(StringCard);
   @field cutenessRating = contains(NumberCard);
   @field sleepsOnTheCouch = contains(BooleanCard);
-  @field appointment = contains(() => Booking);
   @field title = contains(StringCard, {
     computeVia: function (this: Pet) {
       return this.firstName;

--- a/packages/demo-cards/transaction.gts
+++ b/packages/demo-cards/transaction.gts
@@ -21,7 +21,7 @@ export class Transaction extends Card {
   @field from = contains(EthereumAddressCard);
   @field to = contains(EthereumAddressCard);
   @field memo = contains(StringCard);
-  @field chain = linksTo(() => Chain);
+  @field chain = linksTo(Chain);
   @field gasUsed = contains(NumberCard);
   @field effectiveGasPrice = contains(NumberCard);
   @field blockExplorerLink = contains(StringCard, {

--- a/packages/host/app/components/card-catalog-modal.gts
+++ b/packages/host/app/components/card-catalog-modal.gts
@@ -6,10 +6,7 @@ import { action } from '@ember/object';
 import { htmlSafe } from '@ember/template';
 import { registerDestructor } from '@ember/destroyable';
 import { enqueueTask, restartableTask } from 'ember-concurrency';
-import type {
-  CardBase,
-  CardContext,
-} from 'https://cardstack.com/base/card-api';
+import type { Card, CardContext } from 'https://cardstack.com/base/card-api';
 import type { Query } from '@cardstack/runtime-common/query';
 import { createNewCard, type CardRef } from '@cardstack/runtime-common';
 import { Deferred } from '@cardstack/runtime-common/deferred';
@@ -251,12 +248,12 @@ export default class CardCatalogModal extends Component<Signature> {
   @tracked currentRequest:
     | {
         search: Search;
-        deferred: Deferred<CardBase | undefined>;
+        deferred: Deferred<Card | undefined>;
         opts?: { offerToCreate?: CardRef };
       }
     | undefined = undefined;
   @tracked zIndex = 20;
-  @tracked selectedCard?: CardBase = undefined;
+  @tracked selectedCard?: Card = undefined;
   @tracked cardURL = '';
   @tracked hasCardURLError = false;
   @service declare cardService: CardService;
@@ -289,7 +286,7 @@ export default class CardCatalogModal extends Component<Signature> {
   }
 
   // This is part of our public API for runtime-common to invoke the card chooser
-  async chooseCard<T extends CardBase>(
+  async chooseCard<T extends Card>(
     query: Query,
     opts?: { offerToCreate?: CardRef }
   ): Promise<undefined | T> {
@@ -298,7 +295,7 @@ export default class CardCatalogModal extends Component<Signature> {
   }
 
   private _chooseCard = enqueueTask(
-    async <T extends CardBase>(
+    async <T extends Card>(
       query: Query,
       opts: { offerToCreate?: CardRef } = {}
     ) => {
@@ -376,7 +373,7 @@ export default class CardCatalogModal extends Component<Signature> {
     }
   }
 
-  @action toggleSelect(card?: CardBase): void {
+  @action toggleSelect(card?: Card): void {
     this.cardURL = '';
     if (this.selectedCard?.id === card?.id) {
       this.selectedCard = undefined;
@@ -385,7 +382,7 @@ export default class CardCatalogModal extends Component<Signature> {
     this.selectedCard = card;
   }
 
-  @action pick(card?: CardBase) {
+  @action pick(card?: Card) {
     if (this.currentRequest) {
       this.currentRequest.deferred.fulfill(card);
       this.currentRequest = undefined;

--- a/packages/host/app/components/matrix/rooms-manager.gts
+++ b/packages/host/app/components/matrix/rooms-manager.gts
@@ -18,7 +18,10 @@ import {
 import { isMatrixError } from '@cardstack/host/lib/matrix-utils';
 import { LinkTo } from '@ember/routing';
 import { eventDebounceMs } from '@cardstack/host/lib/matrix-utils';
-import { getRoomCard, RoomCardResource } from '@cardstack/host/resources/room-card';
+import {
+  getRoomCard,
+  RoomCardResource,
+} from '@cardstack/host/resources/room-card';
 import { TrackedMap } from 'tracked-built-ins';
 import RouterService from '@ember/routing/router-service';
 import type MatrixService from '@cardstack/host/services/matrix-service';
@@ -79,16 +82,15 @@ export default class RoomsManager extends Component {
       <div class='room-list' data-test-invites-list>
         <h3>Invites</h3>
         {{#each this.sortedInvites as |invite|}}
-          <div
-            class='room'
-            data-test-invited-room={{invite.room.name}}
-          >
+          <div class='room' data-test-invited-room={{invite.room.name}}>
             <span class='room-item'>
               {{invite.room.name}}
               (from:
               <span
-                data-test-invite-sender={{invite.member.membershipInitiator.displayName}}
-              >{{invite.member.membershipInitiator.displayName}})</span>
+                data-test-invite-sender={{niceName
+                  invite.member.membershipInitiator
+                }}
+              >{{niceName invite.member.membershipInitiator}})</span>
             </span>
             <Button
               data-test-decline-room-btn={{invite.room.name}}
@@ -109,10 +111,7 @@ export default class RoomsManager extends Component {
       <div class='room-list' data-test-rooms-list>
         <h3>Rooms</h3>
         {{#each this.sortedJoinedRooms as |joined|}}
-          <div
-            class='room'
-            data-test-joined-room={{joined.room.name}}
-          >
+          <div class='room' data-test-joined-room={{joined.room.name}}>
             <span class='room-item'>
               <LinkTo
                 class='link'
@@ -327,6 +326,10 @@ export default class RoomsManager extends Component {
     this.newRoomInvite = [];
     this.isCreateRoomMode = false;
   }
+}
+
+function niceName(userId: string): string {
+  return userId.split(':')[0].substring(1);
 }
 
 declare module '@glint/environment-ember-loose/registry' {

--- a/packages/host/tests/integration/components/serialization-test.gts
+++ b/packages/host/tests/integration/components/serialization-test.gts
@@ -17,6 +17,7 @@ import {
 } from '@cardstack/runtime-common';
 import { fillIn, RenderingTestContext } from '@ember/test-helpers';
 import { shimExternals } from '@cardstack/host/lib/externals';
+import { type Card as CardType } from 'https://cardstack.com/base/card-api';
 
 let cardApi: typeof import('https://cardstack.com/base/card-api');
 let cardRef: typeof import('https://cardstack.com/base/card-ref');
@@ -120,11 +121,11 @@ module('Integration | serialization', function (hooks) {
         },
       },
     };
-    let savedCard = await createFromSerialized(
+    let savedCard = (await createFromSerialized(
       resource,
       { data: resource },
       undefined
-    );
+    )) as CardType;
 
     assert.strictEqual(
       savedCard.id,

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -64,7 +64,7 @@ import { Router, SupportedMimeType } from './router';
 import { parseQueryString } from './query';
 //@ts-ignore service worker can't handle this
 import type { Readable } from 'stream';
-import { CardBase } from 'https://cardstack.com/base/card-api';
+import { type Card } from 'https://cardstack.com/base/card-api';
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
 import type { LoaderType } from 'https://cardstack.com/base/card-api';
 import { createResponse } from './create-response';
@@ -829,14 +829,9 @@ export class Realm {
     let api = await this.searchIndex.loader.import<typeof CardAPI>(
       'https://cardstack.com/base/card-api'
     );
-    let card: CardBase = await api.createFromSerialized(
-      doc.data,
-      doc,
-      relativeTo,
-      {
-        loader: this.searchIndex.loader as unknown as LoaderType,
-      }
-    );
+    let card = (await api.createFromSerialized(doc.data, doc, relativeTo, {
+      loader: this.searchIndex.loader as unknown as LoaderType,
+    })) as Card;
     let data: LooseSingleCardDocument = api.serializeCard(card); // this strips out computeds
     delete data.data.id; // the ID is derived from the filename, so we don't serialize it on disk
     delete data.included;


### PR DESCRIPTION
This prevents `contained` fields from using thunks in order to contain themselves. This way we can statically prevent containment cycles, which was previously only a policy and now is enforced in code. This PR also cleans up containment cycles in our demo cards as well as in the `RoomMemberCard`. Additionally unnecessary thunks were cleaned up as well as some remaining `Card` vs `CardBase` cleanup.