### PR TITLE
Fix embroider build on CI (JOBS=1)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,6 +78,8 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build host dist/ for fastboot
         run: pnpm build
+        env:
+          JOBS: 1
         working-directory: packages/host
       - name: Start realm servers
         run: pnpm start:all &
@@ -100,6 +102,8 @@ jobs:
         working-directory: packages/matrix
       - name: Build host dist/ for fastboot
         run: pnpm build
+        env:
+          JOBS: 1
         working-directory: packages/host
       - name: Start realm servers
         run: pnpm start:all &
@@ -123,6 +127,8 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build host dist/ for fastboot
         run: pnpm build
+        env:
+          JOBS: 1
         working-directory: packages/host
       - name: Start base realm server
         run: pnpm start:all &


### PR DESCRIPTION
It uses JOBS=1(brocolli thing) env var that removes the parallelism of the build. Fix only specifies this in the ember build in CI for test. 