### PR TITLE
Fix embroider build on CI (max-old-space-size)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,6 +78,8 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build host dist/ for fastboot
         run: pnpm build
+        env:
+          NODE_OPTIONS: --max_old_space_size=4096
         working-directory: packages/host
       - name: Start realm servers
         run: pnpm start:all &
@@ -100,6 +102,8 @@ jobs:
         working-directory: packages/matrix
       - name: Build host dist/ for fastboot
         run: pnpm build
+        env:
+          NODE_OPTIONS: --max_old_space_size=4096
         working-directory: packages/host
       - name: Start realm servers
         run: pnpm start:all &
@@ -123,6 +127,8 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build host dist/ for fastboot
         run: pnpm build
+        env:
+          NODE_OPTIONS: --max_old_space_size=4096
         working-directory: packages/host
       - name: Start base realm server
         run: pnpm start:all &


### PR DESCRIPTION
I just fixed this into the CI test workflows rather than the package.json. 