### PR TITLE
runtime: Add support for scoped CSS

### DIFF
--- a/packages/host/tests/acceptance/basic-test.ts
+++ b/packages/host/tests/acceptance/basic-test.ts
@@ -57,6 +57,11 @@ const personCardSource = `
           <p>Last name: <@fields.lastName /></p>
           <p>Title: <@fields.title /></p>
         </div>
+        <style>
+          div {
+            color: green;
+          }
+        </style>
       </template>
     };
   }
@@ -209,6 +214,13 @@ module('Acceptance | basic tests', function (hooks) {
         },
       },
     });
+
+    assert.dom('[data-test-person]').hasStyle(
+      {
+        color: 'rgb(0, 128, 0)',
+      },
+      'expected scoped CSS to apply to card instance'
+    );
   });
 
   test('Can view a card schema', async function (assert) {

--- a/packages/host/tests/acceptance/basic-test.ts
+++ b/packages/host/tests/acceptance/basic-test.ts
@@ -220,7 +220,7 @@ module('Acceptance | basic tests', function (hooks) {
       {
         color: 'rgb(0, 128, 0)',
       },
-      'expected scoped CSS to apply to card instance'
+      'expected scoped CSS to apply to card instance',
     );
   });
 

--- a/packages/host/tests/acceptance/basic-test.ts
+++ b/packages/host/tests/acceptance/basic-test.ts
@@ -60,6 +60,7 @@ const personCardSource = `
         <style>
           div {
             color: green;
+            content: '';
           }
         </style>
       </template>

--- a/packages/host/tests/integration/card-prerender-test.gts
+++ b/packages/host/tests/integration/card-prerender-test.gts
@@ -14,12 +14,9 @@ import {
 import { RenderingTestContext } from '@ember/test-helpers';
 import type LoaderService from '@cardstack/host/services/loader-service';
 import { setupRenderingTest } from 'ember-qunit';
+import stripScopedCSSAttributes from '@cardstack/runtime-common/helpers/strip-scoped-css-attributes';
 
 let loader: Loader;
-
-function stripScopedCSSAttributes(htmlString: string) {
-  return htmlString.replace(/ data-scopedcss-[0-9a-f]{10}/g, '');
-}
 
 module('Integration | card-prerender', function (hooks) {
   let adapter: TestRealmAdapter;

--- a/packages/host/tests/integration/card-prerender-test.gts
+++ b/packages/host/tests/integration/card-prerender-test.gts
@@ -17,6 +17,10 @@ import { setupRenderingTest } from 'ember-qunit';
 
 let loader: Loader;
 
+function stripScopedCSSAttributes(htmlString: string) {
+  return htmlString.replace(/ data-scopedcss-[0-9a-f]{10}/g, '');
+}
+
 module('Integration | card-prerender', function (hooks) {
   let adapter: TestRealmAdapter;
   let realm: Realm;
@@ -91,7 +95,7 @@ module('Integration | card-prerender', function (hooks) {
         new URL(`${testRealmURL}Pet/mango`),
       );
       assert.strictEqual(
-        trimCardContainer(entry!.html!),
+        trimCardContainer(stripScopedCSSAttributes(entry!.html!)),
         cleanWhiteSpace(`<h3> Mango </h3>`),
         'the pre-rendered HTML is correct',
       );
@@ -101,7 +105,7 @@ module('Integration | card-prerender', function (hooks) {
         new URL(`${testRealmURL}Pet/vangogh`),
       );
       assert.strictEqual(
-        trimCardContainer(entry!.html!),
+        trimCardContainer(stripScopedCSSAttributes(entry!.html!)),
         cleanWhiteSpace(`<h3> Van Gogh </h3>`),
         'the pre-rendered HTML is correct',
       );

--- a/packages/host/tests/integration/realm-test.ts
+++ b/packages/host/tests/integration/realm-test.ts
@@ -21,16 +21,9 @@ import { shimExternals } from '@cardstack/host/lib/externals';
 import { Deferred } from '@cardstack/runtime-common/deferred';
 import { RenderingTestContext } from '@ember/test-helpers';
 import type LoaderService from '@cardstack/host/services/loader-service';
+import stripScopedCSSGlimmerAttributes from '@cardstack/runtime-common/helpers/strip-scoped-css-glimmer-attributes';
 
 let loader: Loader;
-
-function stripScopedCSSGlimmerAttributes(htmlString: string) {
-  let attributeArray = `\\[(14|24),\\\\"data\\-scopedcss\\-[0-9a-f]{10}\\\\",\\\\"\\\\"\\]`;
-  let double = new RegExp(`\\[${attributeArray}\\]`, 'g');
-  let single = new RegExp(`${attributeArray},`, 'g');
-
-  return htmlString.replace(double, 'null').replace(single, '');
-}
 
 module('Integration | realm', function (hooks) {
   setupRenderingTest(hooks);

--- a/packages/host/tests/integration/realm-test.ts
+++ b/packages/host/tests/integration/realm-test.ts
@@ -24,6 +24,14 @@ import type LoaderService from '@cardstack/host/services/loader-service';
 
 let loader: Loader;
 
+function stripScopedCSSGlimmerAttributes(htmlString: string) {
+  let attributeArray = `\\[(14|24),\\\\"data\\-scopedcss\\-[0-9a-f]{10}\\\\",\\\\"\\\\"\\]`;
+  let double = new RegExp(`\\[${attributeArray}\\]`, 'g');
+  let single = new RegExp(`${attributeArray},`, 'g');
+
+  return htmlString.replace(double, 'null').replace(single, '');
+}
+
 module('Integration | realm', function (hooks) {
   setupRenderingTest(hooks);
 
@@ -2190,7 +2198,11 @@ module('Integration | realm', function (hooks) {
     let response = await realm.handle(new Request(`${testRealmURL}dir/person`));
     assert.strictEqual(response.status, 200, 'HTTP 200 status code');
     let compiledJS = await response.text();
-    assert.codeEqual(compiledJS, compiledCard(), 'compiled card is correct');
+    assert.codeEqual(
+      stripScopedCSSGlimmerAttributes(compiledJS),
+      compiledCard(),
+      'compiled card is correct',
+    );
   });
 
   test('realm can serve compiled js file when requested with file extension ', async function (assert) {
@@ -2207,7 +2219,11 @@ module('Integration | realm', function (hooks) {
     );
     assert.strictEqual(response.status, 200, 'HTTP 200 status code');
     let compiledJS = await response.text();
-    assert.codeEqual(compiledJS, compiledCard(), 'compiled card is correct');
+    assert.codeEqual(
+      stripScopedCSSGlimmerAttributes(compiledJS),
+      compiledCard(),
+      'compiled card is correct',
+    );
   });
 
   test('realm can serve file asset (not card source, not js, not JSON-API)', async function (assert) {

--- a/packages/host/tests/integration/search-index-test.ts
+++ b/packages/host/tests/integration/search-index-test.ts
@@ -28,6 +28,10 @@ const testModuleRealm = 'http://localhost:4202/test/';
 
 let loader: Loader;
 
+function stripScopedCSSAttributes(htmlString: string) {
+  return htmlString.replace(/ data-scopedcss-[0-9a-f]{10}/g, '');
+}
+
 module('Integration | search-index', function (hooks) {
   setupRenderingTest(hooks);
 
@@ -513,7 +517,7 @@ module('Integration | search-index', function (hooks) {
             (await indexer.searchEntry(new URL(`${testRealmURL}vangogh`))) ??
             {};
           assert.strictEqual(
-            trimCardContainer(html!),
+            trimCardContainer(stripScopedCSSAttributes(html!)),
             cleanWhiteSpace(`<h1> Van Gogh </h1>`),
           );
         } else {
@@ -570,7 +574,7 @@ module('Integration | search-index', function (hooks) {
             (await indexer.searchEntry(new URL(`${testRealmURL}vangogh`))) ??
             {};
           assert.strictEqual(
-            trimCardContainer(html!),
+            trimCardContainer(stripScopedCSSAttributes(html!)),
             cleanWhiteSpace(`<h1> Van Gogh </h1>`),
           );
         } else {
@@ -685,7 +689,7 @@ module('Integration | search-index', function (hooks) {
           new URL(`${testRealmURL}working-van-gogh`),
         )) ?? {};
       assert.strictEqual(
-        trimCardContainer(html!),
+        trimCardContainer(stripScopedCSSAttributes(html!)),
         cleanWhiteSpace(`<h1> Van Gogh </h1>`),
       );
     } else {
@@ -803,7 +807,7 @@ module('Integration | search-index', function (hooks) {
           new URL(`${testRealmURL}working-vangogh`),
         )) ?? {};
       assert.strictEqual(
-        trimCardContainer(html!),
+        trimCardContainer(stripScopedCSSAttributes(html!)),
         cleanWhiteSpace(`<h1> Van Gogh </h1>`),
       );
     } else {

--- a/packages/host/tests/integration/search-index-test.ts
+++ b/packages/host/tests/integration/search-index-test.ts
@@ -22,15 +22,12 @@ import {
 import { RenderingTestContext } from '@ember/test-helpers';
 import type LoaderService from '@cardstack/host/services/loader-service';
 import { Loader } from '@cardstack/runtime-common/loader';
+import stripScopedCSSAttributes from '@cardstack/runtime-common/helpers/strip-scoped-css-attributes';
 
 const paths = new RealmPaths(testRealmURL);
 const testModuleRealm = 'http://localhost:4202/test/';
 
 let loader: Loader;
-
-function stripScopedCSSAttributes(htmlString: string) {
-  return htmlString.replace(/ data-scopedcss-[0-9a-f]{10}/g, '');
-}
 
 module('Integration | search-index', function (hooks) {
   setupRenderingTest(hooks);

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -19,6 +19,10 @@ function cleanWhiteSpace(text: string) {
   return text.replace(/\s+/g, ' ').trim();
 }
 
+function stripScopedCSSAttributes(htmlString: string) {
+  return htmlString.replace(/ data-scopedcss-[0-9a-f]{10}/g, '');
+}
+
 function trimCardContainer(text: string) {
   return cleanWhiteSpace(text).replace(
     /<div .*? data-test-field-component-card> (.*?) <\/div> <\/div>/,
@@ -209,7 +213,7 @@ module('indexing', function (hooks) {
       new URL(`${testRealm}mango`)
     );
     assert.strictEqual(
-      trimCardContainer(entry!.html!),
+      trimCardContainer(stripScopedCSSAttributes(entry!.html!)),
       cleanWhiteSpace(`<h1> Mango </h1>`),
       'pre-rendered html is correct'
     );
@@ -237,8 +241,8 @@ module('indexing', function (hooks) {
             new URL(`${testRealm}vangogh`)
           )) ?? {};
         assert.strictEqual(
-          trimCardContainer(html!),
-          cleanWhiteSpace(`<h1> Van Gogh </h1>`)
+          trimCardContainer(stripScopedCSSAttributes(html!)),
+          cleanWhiteSpace(`<h1> Van Gogh </h1>`),
         );
       } else {
         assert.ok(

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -14,13 +14,10 @@ import {
 } from './helpers';
 import isEqual from 'lodash/isEqual';
 import { shimExternals } from '../lib/externals';
+import stripScopedCSSAttributes from '@cardstack/runtime-common/helpers/strip-scoped-css-attributes';
 
 function cleanWhiteSpace(text: string) {
   return text.replace(/\s+/g, ' ').trim();
-}
-
-function stripScopedCSSAttributes(htmlString: string) {
-  return htmlString.replace(/ data-scopedcss-[0-9a-f]{10}/g, '');
 }
 
 function trimCardContainer(text: string) {

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -27,6 +27,7 @@ import '@cardstack/runtime-common/helpers/code-equality-assertion';
 import eventSource from 'eventsource';
 import { shimExternals } from '../lib/externals';
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
+import stripScopedCSSGlimmerAttributes from '@cardstack/runtime-common/helpers/strip-scoped-css-glimmer-attributes';
 
 setGracefulCleanup();
 const testRealmURL = new URL('http://127.0.0.1:4444/');
@@ -35,14 +36,6 @@ const testRealmHref = testRealmURL.href;
 const testRealm2Href = testRealm2URL.href;
 const distDir = resolve(join(__dirname, '..', '..', 'host', 'dist'));
 console.log(`using host dist dir: ${distDir}`);
-
-function stripScopedCSSGlimmerAttributes(htmlString: string) {
-  let attributeArray = `\\[(14|24),\\\\"data\\-scopedcss\\-[0-9a-f]{10}\\\\",\\\\"\\\\"\\]`;
-  let double = new RegExp(`\\[${attributeArray}\\]`, 'g');
-  let single = new RegExp(`${attributeArray},`, 'g');
-
-  return htmlString.replace(double, 'null').replace(single, '');
-}
 
 module('Realm Server', function (hooks) {
   let testRealmServer: Server;

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -36,6 +36,14 @@ const testRealm2Href = testRealm2URL.href;
 const distDir = resolve(join(__dirname, '..', '..', 'host', 'dist'));
 console.log(`using host dist dir: ${distDir}`);
 
+function stripScopedCSSGlimmerAttributes(htmlString: string) {
+  let attributeArray = `\\[(14|24),\\\\"data\\-scopedcss\\-[0-9a-f]{10}\\\\",\\\\"\\\\"\\]`;
+  let double = new RegExp(`\\[${attributeArray}\\]`, 'g');
+  let single = new RegExp(`${attributeArray},`, 'g');
+
+  return htmlString.replace(double, 'null').replace(single, '');
+}
+
 module('Realm Server', function (hooks) {
   let testRealmServer: Server;
   let testRealmServer2: Server;
@@ -366,7 +374,9 @@ module('Realm Server', function (hooks) {
     let moduleAbsolutePath = resolve(join(__dirname, '..', 'person.gts'));
 
     // Remove platform-dependent id, from https://github.com/emberjs/babel-plugin-ember-template-compilation/blob/d67cca121cfb3bbf5327682b17ed3f2d5a5af528/__tests__/tests.ts#LL1430C1-L1431C1
-    body = body.replace(/"id":\s"[^"]+"/, '"id": "<id>"');
+    body = stripScopedCSSGlimmerAttributes(
+      body.replace(/"id":\s"[^"]+"/, '"id": "<id>"'),
+    );
 
     assert.codeEqual(
       body,

--- a/packages/runtime-common/helpers/strip-scoped-css-attributes.ts
+++ b/packages/runtime-common/helpers/strip-scoped-css-attributes.ts
@@ -1,0 +1,3 @@
+export default function stripScopedCSSAttributes(htmlString: string) {
+  return htmlString.replace(/ data-scopedcss-[0-9a-f]{10}/g, '');
+}

--- a/packages/runtime-common/helpers/strip-scoped-css-glimmer-attributes.ts
+++ b/packages/runtime-common/helpers/strip-scoped-css-glimmer-attributes.ts
@@ -1,0 +1,7 @@
+export default function stripScopedCSSGlimmerAttributes(compiledTemplateString: string) {
+  let attributeArray = `\\[(14|24),\\\\"data\\-scopedcss\\-[0-9a-f]{10}\\\\",\\\\"\\\\"\\]`;
+  let double = new RegExp(`\\[${attributeArray}\\]`, 'g');
+  let single = new RegExp(`${attributeArray},`, 'g');
+
+  return compiledTemplateString.replace(double, 'null').replace(single, '');
+}

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -826,13 +826,11 @@ function isEvaluatable(
 async function maybeHandleScopedCSSRequest(req: Request) {
   if (isScopedCSSRequest(req.url)) {
     if (isFastBoot) {
-      console.log('not decoding css in fastboot');
-      return Promise.resolve(new Response('console.log("skipped css")'));
+      return Promise.resolve(new Response('// skipped scoped CSS'));
     } else {
       let decodedCSS = decodeScopedCSSRequest(req.url);
       return Promise.resolve(
         new Response(`
-          console.log(\`glimmer scoped css! hey ${decodedCSS}\`);
           let styleNode = document.createElement('style');
           let styleText = document.createTextNode(\`${decodedCSS}\`);
           styleNode.appendChild(styleText);

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -6,6 +6,8 @@ import { RealmPaths } from './paths';
 import { CardError } from './error';
 import flatMap from 'lodash/flatMap';
 import { type RunnerOpts } from './search-index';
+import { decodeScopedCSSRequest, isScopedCSSRequest } from 'glimmer-scoped-css';
+import jsEscapeString from 'js-string-escape';
 
 const isFastBoot = typeof (globalThis as any).FastBoot !== 'undefined';
 
@@ -115,7 +117,7 @@ export type RequestHandler = (req: Request) => Promise<Response | null>;
 export class Loader {
   private log = logger('loader');
   private modules = new Map<string, Module>();
-  private urlHandlers: RequestHandler[] = [];
+  private urlHandlers: RequestHandler[] = [maybeHandleScopedCSSRequest];
 
   // use a tuple array instead of a map so that we can support reversing
   // different resolutions back to the same URL. the resolution that we apply
@@ -797,4 +799,26 @@ function isEvaluatable(
     return false;
   }
   return stateOrder[module.state] >= stateOrder['registered-completing-deps'];
+}
+
+async function maybeHandleScopedCSSRequest(req: Request) {
+  if (isScopedCSSRequest(req.url)) {
+    if (isFastBoot) {
+      return Promise.resolve(new Response('// skipped scoped CSS'));
+    } else {
+      let decodedCSS = decodeScopedCSSRequest(req.url);
+      return Promise.resolve(
+        new Response(`
+          let styleNode = document.createElement('style');
+          let styleText = document.createTextNode('${jsEscapeString(
+            decodedCSS
+          )}');
+          styleNode.appendChild(styleText);
+          document.body.appendChild(styleNode);
+        `)
+      );
+    }
+  } else {
+    return Promise.resolve(null);
+  }
 }

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -827,7 +827,7 @@ function isEvaluatable(
 async function maybeHandleScopedCSSRequest(req: Request) {
   if (isScopedCSSRequest(req.url)) {
     if (isFastBoot) {
-      return Promise.resolve(new Response('// skipped scoped CSS'));
+      return Promise.resolve(new Response('', { status: 204 }));
     } else {
       let decodedCSS = decodeScopedCSSRequest(req.url);
       return Promise.resolve(

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -132,6 +132,7 @@ export class Loader {
     { module: string; name: string }
   >();
   private consumptionCache = new WeakMap<object, string[]>();
+  private static loaders = new WeakMap<Function, Loader>();
 
   static cloneLoader(loader: Loader): Loader {
     let clone = new Loader();
@@ -212,6 +213,20 @@ export class Loader {
   identify(value: unknown): { module: string; name: string } | undefined {
     if (typeof value === 'function') {
       return this.identities.get(value);
+    } else {
+      return undefined;
+    }
+  }
+
+  static identify(
+    value: unknown
+  ): { module: string; name: string } | undefined {
+    if (typeof value !== 'function') {
+      return undefined;
+    }
+    let loader = Loader.loaders.get(value);
+    if (loader) {
+      return loader.identify(value);
     } else {
       return undefined;
     }
@@ -544,6 +559,7 @@ export class Loader {
               : moduleIdentifier,
             name: property,
           });
+          Loader.loaders.set(value, this);
         }
         return value;
       },

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -210,14 +210,6 @@ export class Loader {
     return [];
   }
 
-  identify(value: unknown): { module: string; name: string } | undefined {
-    if (typeof value === 'function') {
-      return this.identities.get(value);
-    } else {
-      return undefined;
-    }
-  }
-
   static identify(
     value: unknown
   ): { module: string; name: string } | undefined {
@@ -230,6 +222,21 @@ export class Loader {
     } else {
       return undefined;
     }
+  }
+
+  identify(value: unknown): { module: string; name: string } | undefined {
+    if (typeof value === 'function') {
+      return this.identities.get(value);
+    } else {
+      return undefined;
+    }
+  }
+
+  static getLoaderFor(value: unknown): Loader | undefined {
+    if (typeof value === 'function') {
+      return Loader.loaders.get(value);
+    }
+    return undefined;
   }
 
   async import<T extends object>(moduleIdentifier: string): Promise<T> {

--- a/packages/runtime-common/package.json
+++ b/packages/runtime-common/package.json
@@ -30,6 +30,7 @@
     "ember-concurrency-async-plugin": "workspace:*",
     "ember-source": "~4.12.0",
     "flat": "^5.0.2",
+    "glimmer-scoped-css": "^0.3.2",
     "http-status-codes": "^2.2.0",
     "ignore": "^5.2.0",
     "js-string-escape": "^1.0.1",

--- a/packages/runtime-common/package.json
+++ b/packages/runtime-common/package.json
@@ -32,6 +32,7 @@
     "flat": "^5.0.2",
     "http-status-codes": "^2.2.0",
     "ignore": "^5.2.0",
+    "js-string-escape": "^1.0.1",
     "json-typescript": "^1.1.2",
     "lodash": "^4.17.21",
     "loglevel": "^1.8.1",
@@ -44,6 +45,7 @@
   "devDependencies": {
     "@babel/core": "^7.17.8",
     "@types/dompurify": "^3.0.2",
+    "@types/js-string-escape": "^1.0.1",
     "@types/qunit": "^2.11.3",
     "dompurify": "^3.0.3",
     "ember-cli-htmlbars": "^6.2.0"

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -67,9 +67,9 @@ import { parseQueryString } from './query';
 import type { Readable } from 'stream';
 import { type Card } from 'https://cardstack.com/base/card-api';
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
-import type { LoaderType } from 'https://cardstack.com/base/card-api';
 import { createResponse } from './create-response';
 import { mergeRelationships } from './merge-relationships';
+import type { LoaderType } from 'https://cardstack.com/base/card-api';
 import scopedCSSTransform from 'glimmer-scoped-css/ast-transform';
 
 export type RealmInfo = {

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -47,6 +47,7 @@ import * as babel from '@babel/core';
 import makeEmberTemplatePlugin from 'babel-plugin-ember-template-compilation/browser';
 import type { Options as EmberTemplatePluginOptions } from 'babel-plugin-ember-template-compilation/src/plugin';
 import type { EmberTemplateCompiler } from 'babel-plugin-ember-template-compilation/src/ember-template-compiler';
+import type { ExtendedPluginBuilder } from 'babel-plugin-ember-template-compilation/src/js-utils';
 //@ts-ignore no types are available
 import * as etc from 'ember-source/dist/ember-template-compiler';
 import { loaderPlugin } from './loader-plugin';
@@ -457,7 +458,7 @@ export class Realm {
 
     let templateOptions: EmberTemplatePluginOptions = {
       compiler: etc as unknown as EmberTemplateCompiler,
-      transforms: [scopedCSSTransform],
+      transforms: [scopedCSSTransform as ExtendedPluginBuilder],
     };
 
     let src = babel.transformSync(content, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,7 +91,7 @@ importers:
         version: 1.0.3
       prettier:
         specifier: github:cardstack/prettier#glimmer-style-tag-in-template-support
-        version: github.com/cardstack/prettier/1f8ff0292cd3a8538475448e3b11eee7cc64eeed
+        version: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
       prettier-plugin-ember-template-tag:
         specifier: ^1.0.0
         version: 1.0.0(prettier@3.1.0-dev)
@@ -258,7 +258,7 @@ importers:
         version: 4.1.5
       prettier:
         specifier: github:cardstack/prettier#glimmer-style-tag-in-template-support
-        version: github.com/cardstack/prettier/1f8ff0292cd3a8538475448e3b11eee7cc64eeed
+        version: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
       typescript:
         specifier: ^5.1.6
         version: 5.1.6
@@ -433,7 +433,7 @@ importers:
         version: 8.0.1
       prettier:
         specifier: github:cardstack/prettier#glimmer-style-tag-in-template-support
-        version: github.com/cardstack/prettier/1f8ff0292cd3a8538475448e3b11eee7cc64eeed
+        version: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
       qunit:
         specifier: ^2.19.4
         version: 2.19.4
@@ -599,7 +599,7 @@ importers:
         version: 4.7.0
       prettier:
         specifier: github:cardstack/prettier#glimmer-style-tag-in-template-support
-        version: github.com/cardstack/prettier/1f8ff0292cd3a8538475448e3b11eee7cc64eeed
+        version: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
       qunit:
         specifier: ^2.19.4
         version: 2.19.4
@@ -828,7 +828,7 @@ importers:
         version: 4.7.0
       prettier:
         specifier: github:cardstack/prettier#glimmer-style-tag-in-template-support
-        version: github.com/cardstack/prettier/1f8ff0292cd3a8538475448e3b11eee7cc64eeed
+        version: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
       prettier-plugin-ember-template-tag:
         specifier: ^1.0.0
         version: 1.0.0(prettier@3.1.0-dev)
@@ -1171,7 +1171,7 @@ importers:
         version: 1.0.1
       prettier:
         specifier: github:cardstack/prettier#glimmer-style-tag-in-template-support
-        version: github.com/cardstack/prettier/1f8ff0292cd3a8538475448e3b11eee7cc64eeed
+        version: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
       qs:
         specifier: ^6.10.5
         version: 6.11.0
@@ -1350,7 +1350,7 @@ importers:
         version: 4.1.5
       prettier:
         specifier: github:cardstack/prettier#glimmer-style-tag-in-template-support
-        version: github.com/cardstack/prettier/1f8ff0292cd3a8538475448e3b11eee7cc64eeed
+        version: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
       prettier-plugin-ember-template-tag:
         specifier: ^1.0.0
         version: 1.0.0(prettier@3.1.0-dev)
@@ -1471,6 +1471,9 @@ importers:
       flat:
         specifier: ^5.0.2
         version: 5.0.2
+      glimmer-scoped-css:
+        specifier: ^0.3.2
+        version: 0.3.2
       http-status-codes:
         specifier: ^2.2.0
         version: 2.2.0
@@ -1685,7 +1688,7 @@ importers:
         version: 4.1.5
       prettier:
         specifier: github:cardstack/prettier#glimmer-style-tag-in-template-support
-        version: github.com/cardstack/prettier/1f8ff0292cd3a8538475448e3b11eee7cc64eeed
+        version: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
       qunit:
         specifier: ^2.14.0
         version: 2.19.3
@@ -8370,6 +8373,7 @@ packages:
       make-dir: 3.1.0
       schema-utils: 2.7.1
       webpack: 5.75.0
+    dev: false
 
   /babel-loader@8.3.0(@babel/core@7.21.0)(webpack@5.84.0):
     resolution: {integrity: sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==}
@@ -12219,6 +12223,7 @@ packages:
       - '@glint/template'
       - supports-color
       - webpack
+    dev: false
 
   /ember-auto-import@2.6.3(@glint/template@1.0.2)(webpack@5.84.0):
     resolution: {integrity: sha512-uLhrRDJYWCRvQ4JQ1e64XlSrqAKSd6PXaJ9ZsZI6Tlms9T4DtQFxNXasqji2ZRJBVrxEoLCRYX3RTldsQ0vNGQ==}
@@ -13416,7 +13421,7 @@ packages:
       '@embroider/addon-shim': 1.8.5
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-string-utils: 1.1.0
-      ember-source: 4.12.0(@babel/core@7.20.2)(@glimmer/component@1.1.2)(@glint/template@1.0.2)(webpack@5.75.0)
+      ember-source: 4.12.0(@babel/core@7.20.2)(@glimmer/component@1.1.2)(@glint/template@1.0.2)(webpack@5.84.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -13692,6 +13697,7 @@ packages:
       - '@glint/template'
       - supports-color
       - webpack
+    dev: false
 
   /ember-source@4.12.0(@babel/core@7.20.2)(@glimmer/component@1.1.2)(@glint/template@1.0.2)(webpack@5.84.0):
     resolution: {integrity: sha512-h0lV902A4Mny2eiqXPy15uXXoCc7BnUegE4axLAy4IoxEkJ1o5h0aLJFiB4Tzb1htx8vgHjJz//Y5Jig7NSDTw==}
@@ -14563,7 +14569,7 @@ packages:
     dependencies:
       eslint: 7.32.0
       eslint-config-prettier: 7.2.0(eslint@7.32.0)
-      prettier: github.com/cardstack/prettier/1f8ff0292cd3a8538475448e3b11eee7cc64eeed
+      prettier: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
       prettier-linter-helpers: 1.0.0
     dev: true
 
@@ -14583,7 +14589,7 @@ packages:
     dependencies:
       eslint: 7.32.0
       eslint-config-prettier: 8.5.0(eslint@7.32.0)
-      prettier: github.com/cardstack/prettier/1f8ff0292cd3a8538475448e3b11eee7cc64eeed
+      prettier: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
       prettier-linter-helpers: 1.0.0
       synckit: 0.8.5
     dev: true
@@ -14604,7 +14610,7 @@ packages:
     dependencies:
       eslint: 8.41.0
       eslint-config-prettier: 8.8.0(eslint@8.41.0)
-      prettier: github.com/cardstack/prettier/1f8ff0292cd3a8538475448e3b11eee7cc64eeed
+      prettier: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
       prettier-linter-helpers: 1.0.0
       synckit: 0.8.5
     dev: true
@@ -16466,6 +16472,17 @@ packages:
       js-string-escape: 1.0.1
       postcss: 8.4.23
       postcss-selector-parser: 6.0.12
+      super-fast-md5: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  /glimmer-scoped-css@0.3.2:
+    resolution: {integrity: sha512-DW8LyfbH1XUMgswPxXJOl3b/bMNZ6UjbYeWSoiALHFRsIeTZgf0oYgSrzxTX/QArMvuLn42O2UbZ9trwZRD6LQ==}
+    dependencies:
+      '@embroider/addon-shim': 1.8.5
+      js-string-escape: 1.0.1
+      postcss: 8.4.25
+      postcss-selector-parser: 6.0.13
       super-fast-md5: 1.0.1
     transitivePeerDependencies:
       - supports-color
@@ -21255,7 +21272,7 @@ packages:
       '@glimmer/syntax': 0.84.3
       ember-cli-htmlbars: 6.2.0
       ember-template-imports: 3.4.2
-      prettier: github.com/cardstack/prettier/1f8ff0292cd3a8538475448e3b11eee7cc64eeed
+      prettier: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -22002,7 +22019,7 @@ packages:
       '@babel/core': 7.21.0(supports-color@8.1.1)
       '@babel/plugin-syntax-decorators': 7.21.0(@babel/core@7.21.0)
       '@babel/plugin-transform-typescript': 7.20.2(@babel/core@7.21.0)
-      prettier: github.com/cardstack/prettier/1f8ff0292cd3a8538475448e3b11eee7cc64eeed
+      prettier: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
     transitivePeerDependencies:
       - '@angular/core'
       - supports-color
@@ -23397,7 +23414,7 @@ packages:
       prettier: '>=3.0.0'
       stylelint: '>=15.8.0'
     dependencies:
-      prettier: github.com/cardstack/prettier/1f8ff0292cd3a8538475448e3b11eee7cc64eeed
+      prettier: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
       prettier-linter-helpers: 1.0.0
       stylelint: 15.10.2
     dev: true
@@ -26366,6 +26383,7 @@ packages:
       ember-concurrency-async-plugin: link:vendor/ember-concurrency-async-plugin
       ember-source: 4.12.0(@babel/core@7.20.2)(@glimmer/component@1.1.2)(@glint/template@1.0.2)(webpack@5.84.0)
       flat: 5.0.2
+      glimmer-scoped-css: 0.3.2
       http-status-codes: 2.2.0
       ignore: 5.2.4
       js-string-escape: 1.0.1
@@ -26407,8 +26425,8 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  github.com/cardstack/prettier/1f8ff0292cd3a8538475448e3b11eee7cc64eeed:
-    resolution: {tarball: https://codeload.github.com/cardstack/prettier/tar.gz/1f8ff0292cd3a8538475448e3b11eee7cc64eeed}
+  github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6:
+    resolution: {tarball: https://codeload.github.com/cardstack/prettier/tar.gz/60eccfdc598d682a931d3c569ffb0c4f92ef5db6}
     name: prettier
     version: 3.1.0-dev
     engines: {node: '>=16'}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1477,6 +1477,9 @@ importers:
       ignore:
         specifier: ^5.2.0
         version: 5.2.0
+      js-string-escape:
+        specifier: ^1.0.1
+        version: 1.0.1
       json-typescript:
         specifier: ^1.1.2
         version: 1.1.2
@@ -1508,6 +1511,9 @@ importers:
       '@types/dompurify':
         specifier: ^3.0.2
         version: 3.0.2
+      '@types/js-string-escape':
+        specifier: ^1.0.1
+        version: 1.0.1
       '@types/qunit':
         specifier: ^2.11.3
         version: 2.19.3
@@ -6515,6 +6521,10 @@ packages:
 
   /@types/js-levenshtein@1.1.1:
     resolution: {integrity: sha512-qC4bCqYGy1y/NP7dDVr7KJarn+PbX1nSpwA7JXdu0HxT3QYjO8MJ+cntENtHFVy2dRAyBV23OZ6MxsW1AM1L8g==}
+    dev: true
+
+  /@types/js-string-escape@1.0.1:
+    resolution: {integrity: sha512-s3Tz/P+u4X78n0TdgNR0l9Yu1jyH2dRwofi/DqGLpbbjiuIs0n6W8W4XfUI6+9K0lPK1fF4KHA5HcqtOsy1V0Q==}
     dev: true
 
   /@types/jsdom@21.1.1:
@@ -26310,6 +26320,7 @@ packages:
     resolution: {directory: packages/base, type: directory}
     id: file:packages/base
     name: '@cardstack/base'
+    version: 1.0.0
     peerDependencies:
       ember-source: ~4.12.0
     dependencies:
@@ -26321,6 +26332,7 @@ packages:
     resolution: {directory: packages/runtime-common, type: directory}
     id: file:packages/runtime-common
     name: '@cardstack/runtime-common'
+    version: 1.0.0
     peerDependencies:
       '@babel/core': ^7.17.8
       ember-cli-htmlbars: ^6.2.0
@@ -26356,6 +26368,7 @@ packages:
       flat: 5.0.2
       http-status-codes: 2.2.0
       ignore: 5.2.4
+      js-string-escape: 1.0.1
       json-typescript: 1.1.2
       lodash: 4.17.21
       loglevel: 1.8.1
@@ -26376,6 +26389,7 @@ packages:
     resolution: {directory: vendor/ember-template-imports, type: directory}
     id: file:vendor/ember-template-imports
     name: '@cardstack/ember-template-imports'
+    version: 2.0.1
     engines: {node: 12.* || >= 14}
     peerDependencies:
       ember-cli-htmlbars: ^6.0.0


### PR DESCRIPTION
This updates the realm’s template compiler to use the `glimmer-scoped-css`’s AST transform. It also adds a loader URL handler that catches the addon’s custom import statements, which look like this:

```
./person.gts.CiAgICAgICAgICBkaXZbZGF0YS1zY29wZWRjc3MtYTYxNTc2YjRkNF0gewogICAgICAgICAgICBjb2xvcjogZ3JlZW47CiAgICAgICAgICAgIGNvbnRlbnQ6ICcnOwogICAgICAgICAgfQogICAgICAgIA%3D%3D.glimmer-scoped.css
```

and converts them into DOM-manipulation Javascript to insert the decoded CSS in a `style` element.

It’s a naïve implementation with no tracking of what has been inserted, nor cleanup.