### PR TITLE
Use RealmPaths in operator mode actions to construct the correct absolute url

### DIFF
--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -21,6 +21,7 @@ import {
   type CardRef,
   LooseSingleCardDocument,
 } from '@cardstack/runtime-common';
+import { RealmPaths } from '@cardstack/runtime-common/paths';
 import type LoaderService from '@cardstack/host/services/loader-service';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
@@ -233,10 +234,12 @@ export default class OperatorModeContainer extends Component<Signature> {
         let doc: LooseSingleCardDocument = opts?.doc ?? {
           data: { meta: { adoptsFrom: ref } },
         };
+        // using RealmPaths API to correct for the trailing `/`
+        let realmPath = new RealmPaths(relativeTo ?? here.cardService.defaultURL);
         let newCard = await here.cardService.createFromSerialized(
           doc.data,
           doc,
-          relativeTo ?? here.cardService.defaultURL
+          new URL(realmPath.url)
         );
         let newItem: StackItem = {
           card: newCard,


### PR DESCRIPTION
I noticed a regression where we couldn't create new cards while in operator mode (locally and on staging). RealmPaths api helps us adjust for the correct number of trailing `/` in the end of given realm url and fixes the bug.

<img width="514" alt="url-2" src="https://github.com/cardstack/boxel/assets/16160806/31ed2bad-2a00-42cf-8e4b-58a10194f1ed">
