### PR TITLE
Fix selection overlay ui issues

### DIFF
--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -28,10 +28,11 @@ export default class OperatorModeOverlays extends Component<Signature> {
     {{#each this.renderedCardWithEvents as |renderedCard|}}
       {{#let renderedCard.card (this.isSelected renderedCard.card) as |card isSelected|}}
         <div
-          class={{cn 'actions-overlay' selected=isSelected hovered=(getValueFromWeakMap this.isHoverOnCards renderedCard)}}
+          class={{cn 'actions-overlay' selected=isSelected hovered=(getValueFromWeakMap this.isHoverOnCard renderedCard)}}
           {{velcro renderedCard.element middleware=(Array this.offset)}}
           data-test-overlay-selected={{if isSelected card.id}}
         >
+          {{!-- Add mouseenter and mouseleave events to each button, so we can maintain the hover effect. --}}
           {{#if @toggleSelect}}
             <IconButton
               {{on 'click' (fn @toggleSelect card)}}
@@ -104,7 +105,7 @@ export default class OperatorModeOverlays extends Component<Signature> {
     </style>
   </template>
 
-  @tracked isHoverOnCards = new TrackedWeakMap<RenderedLinksToCard, boolean>();
+  @tracked isHoverOnCard = new TrackedWeakMap<RenderedLinksToCard, boolean>();
   isEventsRegistered = new TrackedWeakMap<RenderedLinksToCard, boolean>();
 
   offset = {
@@ -124,15 +125,18 @@ export default class OperatorModeOverlays extends Component<Signature> {
     },
   };
 
+  // Since we disable pointer events of this overlay component,
+  // we register events on the underlying rendered card.
+  // This ensures that we can maintain the same hover and click effects.
   get renderedCardWithEvents() {
     let renderedCards = this.args.renderedLinksToCards;
     for (const renderedCard of renderedCards) {
       if (this.isEventsRegistered.get(renderedCard)) continue;
       renderedCard.element.addEventListener('mouseenter', (_e: MouseEvent) =>
-        this.isHoverOnCards.set(renderedCard, true)
+        this.isHoverOnCard.set(renderedCard, true)
       );
       renderedCard.element.addEventListener('mouseleave', (_e: MouseEvent) =>
-        this.isHoverOnCards.set(renderedCard, false)
+        this.isHoverOnCard.set(renderedCard, false)
       );
       renderedCard.element.addEventListener('click', (_e: MouseEvent) =>
         this.openOrSelectCard(renderedCard.card)
@@ -144,7 +148,7 @@ export default class OperatorModeOverlays extends Component<Signature> {
   }
 
   setHoverOnCards = (renderedCard: RenderedLinksToCard, status: boolean) => {
-    this.isHoverOnCards.set(renderedCard, status);
+    this.isHoverOnCard.set(renderedCard, status);
   };
 
   @action openOrSelectCard(card: Card) {

--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -125,9 +125,13 @@ export default class OperatorModeOverlays extends Component<Signature> {
     },
   };
 
-  // Since we disable pointer events of this overlay component,
-  // we register events on the underlying rendered card.
-  // This ensures that we can maintain the same hover and click effects.
+  // Pointer events of this overlay component 
+  // will prevent pointer events on rendered cards.
+  // This might cause broken functionality in rendered cards,
+  // such as the inability to scroll through cards in the cards-grid.
+  // Therefore, we have decided to disable pointer events for this overlay component,
+  // and instead, we register events directly to the rendered cards.
+  // This way, we can maintain the same behavior of hovering and clicking.
   get renderedCardWithEvents() {
     let renderedCards = this.args.renderedLinksToCards;
     for (const renderedCard of renderedCards) {

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -305,6 +305,11 @@ export default class OperatorModeStackItem extends Component<Signature> {
         --buried-operator-mode-header-height: 2.5rem;
       }
 
+      .header {
+        z-index: 1;
+        background: var(--boxel-light);
+      }
+
       .item {
         justify-self: center;
         position: absolute;

--- a/packages/host/tests/acceptance/operator-mode-test.ts
+++ b/packages/host/tests/acceptance/operator-mode-test.ts
@@ -1,5 +1,11 @@
 import { module, test } from 'qunit';
-import { visit, currentURL, click, triggerEvent } from '@ember/test-helpers';
+import {
+  visit,
+  currentURL,
+  click,
+  triggerEvent,
+  waitFor,
+} from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { Loader } from '@cardstack/runtime-common/loader';
 import { baseRealm } from '@cardstack/runtime-common';
@@ -293,8 +299,8 @@ module('Acceptance | operator mode tests', function (hooks) {
         )}`
       );
 
-      // Add the dog back to the stack (via overlayed linked card button)
-      await click('[data-test-overlay-button]');
+      await waitFor('[data-test-pet="Mango"]');
+      await click('[data-test-pet="Mango"]');
 
       // The stack should be reflected in the URL
       assert.strictEqual(

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -543,8 +543,8 @@ module('Integration | operator-mode', function (hooks) {
     assert.dom('[data-test-city]').hasText('Bandung');
     assert.dom('[data-test-country]').hasText('Indonesia');
     assert.dom('[data-test-stack-card]').exists({ count: 1 });
-    await waitFor('[data-test-overlay-button]');
-    await click('[data-test-overlay-button]');
+    await waitFor('[data-test-pet="Mango"]');
+    await click('[data-test-pet="Mango"]');
     assert.dom('[data-test-stack-card]').exists({ count: 2 });
     assert.dom('[data-test-stack-card-index="1"]').includesText('Mango');
   });
@@ -740,7 +740,7 @@ module('Integration | operator-mode', function (hooks) {
     assert.dom(`[data-test-stack-card-index="0"]`).exists();
 
     await waitFor(`[data-test-cards-grid-item]`);
-    await click(`[data-test-overlay-button="${testRealmURL}Person/burcu"]`);
+    await click(`[data-test-cards-grid-item="${testRealmURL}Person/burcu"]`);
 
     assert.dom(`[data-test-stack-card-index="1"]`).exists(); // Opens card on the stack
     assert
@@ -1166,12 +1166,12 @@ module('Integration | operator-mode', function (hooks) {
     );
     await waitFor(`[data-test-stack-card="${testRealmURL}grid"]`);
     await waitFor(`[data-test-cards-grid-item]`);
-    await click(`[data-test-overlay-button="${testRealmURL}Person/fadhlan"]`);
+    await click(`[data-test-cards-grid-item="${testRealmURL}Person/fadhlan"]`);
     assert.dom(`[data-test-stack-card-index="1"]`).exists();
     await waitFor('[data-test-person]');
 
-    await waitFor('[data-test-overlay-button]');
-    await click('[data-test-overlay-button]');
+    await waitFor('[data-test-cards-grid-item]');
+    await click('[data-test-cards-grid-item]');
     assert.dom(`[data-test-stack-card-index="2"]`).exists();
     await click('[data-test-stack-card-index="0"] [data-test-boxel-header]');
     assert.dom(`[data-test-stack-card-index="2"]`).doesNotExist();
@@ -1193,7 +1193,7 @@ module('Integration | operator-mode', function (hooks) {
     assert.dom(`[data-test-stack-card-header]`).containsText(realmName);
 
     await waitFor(`[data-test-cards-grid-item]`);
-    await click(`[data-test-overlay-button="${testRealmURL}Person/fadhlan"]`);
+    await click(`[data-test-cards-grid-item="${testRealmURL}Person/fadhlan"]`);
     assert.dom(`[data-test-stack-card-index="1"]`).exists();
     let personCard = await loadCard(`${testRealmURL}Person/fadhlan`);
     assert
@@ -1220,7 +1220,7 @@ module('Integration | operator-mode', function (hooks) {
     assert.dom(`[data-test-stack-card-header]`).containsText(realmName);
 
     await waitFor(`[data-test-cards-grid-item]`);
-    await click(`[data-test-overlay-button="${testRealmURL}Person/fadhlan"]`);
+    await click(`[data-test-cards-grid-item="${testRealmURL}Person/fadhlan"]`);
     assert.dom(`[data-test-stack-card-index="1"]`).exists();
     let personCard = await loadCard(`${testRealmURL}Person/fadhlan`);
     assert
@@ -1238,7 +1238,7 @@ module('Integration | operator-mode', function (hooks) {
     await click(`[data-test-stack-card-index="1"] [data-test-close-button]`);
 
     await waitFor(`[data-test-cards-grid-item]`);
-    await click(`[data-test-overlay-button="${testRealmURL}Person/burcu"]`);
+    await click(`[data-test-cards-grid-item="${testRealmURL}Person/burcu"]`);
     assert.dom(`[data-test-stack-card-index="1"]`).exists();
 
     await focus(`[data-test-search-input]`);
@@ -1270,7 +1270,7 @@ module('Integration | operator-mode', function (hooks) {
 
     await waitFor(`[data-test-cards-grid-item]`);
     for (let i = 1; i <= 11; i++) {
-      await click(`[data-test-overlay-button="${testRealmURL}Person/${i}"]`);
+      await click(`[data-test-cards-grid-item="${testRealmURL}Person/${i}"]`);
       await click(`[data-test-stack-card-index="1"] [data-test-close-button]`);
     }
 
@@ -1481,19 +1481,19 @@ module('Integration | operator-mode', function (hooks) {
     assert.dom('[data-test-overlay-selected]').exists({ count: 1 });
 
     await click(`[data-test-overlay-select="${testRealmURL}Pet/jackie"]`);
-    await click(`[data-test-overlay-button="${testRealmURL}Author/1"]`);
-    await click(`[data-test-overlay-button="${testRealmURL}BlogPost/2"]`);
+    await click(`[data-test-cards-grid-item="${testRealmURL}Author/1"]`);
+    await click(`[data-test-cards-grid-item="${testRealmURL}BlogPost/2"]`);
     assert.dom('[data-test-overlay-selected]').exists({ count: 4 });
 
-    await click(`[data-test-overlay-button="${testRealmURL}Pet/jackie"]`);
+    await click(`[data-test-cards-grid-item="${testRealmURL}Pet/jackie"]`);
     assert.dom('[data-test-overlay-selected]').exists({ count: 3 });
 
-    await click(`[data-test-overlay-button="${testRealmURL}Person/fadhlan"]`);
-    await click(`[data-test-overlay-button="${testRealmURL}BlogPost/2"]`);
+    await click(`[data-test-cards-grid-item="${testRealmURL}Person/fadhlan"]`);
+    await click(`[data-test-cards-grid-item="${testRealmURL}BlogPost/2"]`);
     await click(`[data-test-overlay-select="${testRealmURL}Author/1"]`);
     assert.dom('[data-test-overlay-selected]').doesNotExist();
 
-    await click(`[data-test-overlay-button="${testRealmURL}Person/fadhlan"]`);
+    await click(`[data-test-cards-grid-item="${testRealmURL}Person/fadhlan"]`);
     assert.dom(`[data-test-stack-card-index="1"]`).exists();
   });
 


### PR DESCRIPTION
**Issues**
1. Can't scroll cards-grid when hovering over an overlay.
2. Selection remains visible outside of the cards-grid container.

**Solution**
1. The scrolling issue happens because hovering over an overlay activates the pointer events of the overlay, which blocks the pointer events of the cards-grid, preventing us from scrolling through the cards grid. I fixed it by disabling the pointer events of the overlay and adding `mouseenter`, `mouseleave`, and `click` events to the card elements instead. With this solution, the overlay element will appear when hovering over the card, and we can scroll through the cards-grid. This solution is not perfect since the same issue remains when hovering over small icons in the overlay component. However, considering that the icons are small, I think we can ignore this problem.
2. I fixed the second issue by changing the position of the overlay component to `absolute`.


https://github.com/cardstack/boxel/assets/12637010/dd74ed8c-bbb9-477a-b740-8c3f32bb1e98

