### PR TITLE
Add overlaid header for "contains" and "links to" embedded card

### DIFF
--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -71,23 +71,23 @@ export default class OperatorModeOverlays extends Component<Signature> {
             <IconButton
               {{! @glint-ignore (glint thinks toggleSelect is not in this scope but it actually is - we check for it in the condition above) }}
               {{on 'click' (fn @toggleSelect card)}}
-              {{on 'mouseenter' (fn this.setCurrentlyHoverCard renderedCard)}}
-              {{on 'mouseleave' (fn this.setCurrentlyHoverCard null)}}
+              {{on 'mouseenter' (fn this.setCurrentlyHoveredCard renderedCard)}}
+              {{on 'mouseleave' (fn this.setCurrentlyHoveredCard null)}}
               class='hover-button select'
               @icon={{if isSelected 'icon-circle-selected' 'icon-circle'}}
               aria-label='select card'
               data-test-overlay-select={{card.id}}
             />
             <IconButton
-              {{on 'mouseenter' (fn this.setCurrentlyHoverCard renderedCard)}}
-              {{on 'mouseleave' (fn this.setCurrentlyHoverCard null)}}
+              {{on 'mouseenter' (fn this.setCurrentlyHoveredCard renderedCard)}}
+              {{on 'mouseleave' (fn this.setCurrentlyHoveredCard null)}}
               class='hover-button preview'
               @icon='eye'
               aria-label='preview card'
             />
             <IconButton
-              {{on 'mouseenter' (fn this.setCurrentlyHoverCard renderedCard)}}
-              {{on 'mouseleave' (fn this.setCurrentlyHoverCard null)}}
+              {{on 'mouseenter' (fn this.setCurrentlyHoveredCard renderedCard)}}
+              {{on 'mouseleave' (fn this.setCurrentlyHoveredCard null)}}
               class='hover-button more-actions'
               @icon='more-actions'
               aria-label='more actions'
@@ -216,7 +216,7 @@ export default class OperatorModeOverlays extends Component<Signature> {
     return renderedCards;
   }
 
-  setCurrentlyHoverCard = (
+  setCurrentlyHoveredCard = (
     renderedCard: RenderedCardForOverlayActions | null
   ) => {
     this.currentlyHoveredCard = renderedCard;

--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
-import { RenderedLinksToCard } from './stack-item';
+import { RenderedCardForOverlayActions } from './stack-item';
 import { velcro } from 'ember-velcro';
 import { Actions } from '@cardstack/runtime-common';
 import { IconButton } from '@cardstack/boxel-ui';
@@ -12,11 +12,13 @@ import type { MiddlewareState } from '@floating-ui/dom';
 import type { Card } from 'https://cardstack.com/base/card-api';
 import { tracked } from '@glimmer/tracking';
 import { TrackedWeakMap } from 'tracked-built-ins';
-import { eq } from '@cardstack/boxel-ui/helpers/truth-helpers';
+import { cardTypeDisplayName } from '@cardstack/runtime-common';
+import { and, eq, not } from '@cardstack/host/helpers/truth-helpers';
+import { bool } from '@cardstack/boxel-ui/helpers/truth-helpers';
 
 interface Signature {
   Args: {
-    renderedLinksToCards: RenderedLinksToCard[];
+    renderedCardsForOverlayActions: RenderedCardForOverlayActions[];
     publicAPI: Actions;
     toggleSelect?: (card: Card) => void;
     selectedCards?: TrackedArray<Card>;
@@ -24,16 +26,47 @@ interface Signature {
 }
 
 export default class OperatorModeOverlays extends Component<Signature> {
+  isEmbeddedCard(renderedCard: RenderedCardForOverlayActions) {
+    return (
+      renderedCard.fieldType === 'contains' ||
+      renderedCard.fieldType === 'linksTo'
+    );
+  }
+
   <template>
-    {{#each this.renderedCardWithEvents as |renderedCard|}}
-      {{#let renderedCard.card (this.isSelected renderedCard.card) as |card isSelected|}}
+    {{#each this.renderedCardsForOverlayActionsWithEvents as |renderedCard|}}
+      {{#let
+        renderedCard.card (this.isSelected renderedCard.card)
+        as |card isSelected|
+      }}
         <div
-          class={{cn 'actions-overlay' selected=isSelected hovered=(eq this.currentlyHoveredCard renderedCard)}}
+          class={{cn
+            'actions-overlay'
+            selected=isSelected
+            hovered=(eq this.currentlyHoveredCard renderedCard)
+          }}
           {{velcro renderedCard.element middleware=(Array this.offset)}}
           data-test-overlay-selected={{if isSelected card.id}}
         >
-          {{!-- Add mouseenter and mouseleave events to each button, so we can maintain the hover effect. --}}
-          {{#if @toggleSelect}}
+          {{! Add mouseenter and mouseleave events to each button, so we can maintain the hover effect. }}
+          {{#if (this.isEmbeddedCard renderedCard)}}
+            <div class='overlay-embedded-card-header' data-test-overlay-header>
+              <div class='header-title'>
+                {{! TODO: Icon for linksTo field type }}
+                {{#if (eq renderedCard.fieldType 'contains')}}
+                  <span class='icon'>
+                    ⮑
+                  </span>
+                {{/if}}
+
+                {{cardTypeDisplayName card}}
+              </div>
+            </div>
+          {{/if}}
+
+          {{#if
+            (and (bool @toggleSelect) (not (this.isEmbeddedCard renderedCard)))
+          }}
             <IconButton
               {{on 'click' (fn @toggleSelect card)}}
               {{on 'mouseenter' (fn this.setCurrentlyHoverCard renderedCard)}}
@@ -43,25 +76,28 @@ export default class OperatorModeOverlays extends Component<Signature> {
               aria-label='select card'
               data-test-overlay-select={{card.id}}
             />
+            <IconButton
+              {{on 'mouseenter' (fn this.setCurrentlyHoverCard renderedCard)}}
+              {{on 'mouseleave' (fn this.setCurrentlyHoverCard null)}}
+              class='hover-button preview'
+              @icon='eye'
+              aria-label='preview card'
+            />
+            <IconButton
+              {{on 'mouseenter' (fn this.setCurrentlyHoverCard renderedCard)}}
+              {{on 'mouseleave' (fn this.setCurrentlyHoverCard null)}}
+              class='hover-button more-actions'
+              @icon='more-actions'
+              aria-label='more actions'
+            />
           {{/if}}
-          <IconButton
-            {{on 'mouseenter' (fn this.setCurrentlyHoverCard renderedCard)}}
-            {{on 'mouseleave' (fn this.setCurrentlyHoverCard null)}}
-            class='hover-button preview'
-            @icon='eye'
-            aria-label='preview card'
-          />
-          <IconButton
-            {{on 'mouseenter' (fn this.setCurrentlyHoverCard renderedCard)}}
-            {{on 'mouseleave' (fn this.setCurrentlyHoverCard null)}}
-            class='hover-button more-actions'
-            @icon='more-actions'
-            aria-label='more actions'
-          />
         </div>
       {{/let}}
     {{/each}}
     <style>
+      :global(:root) {
+        --overlay-embedded-card-header-height: 44px;
+      }
       .actions-overlay {
         border-radius: var(--boxel-border-radius);
         pointer-events: none;
@@ -102,11 +138,36 @@ export default class OperatorModeOverlays extends Component<Signature> {
       .hover-button > svg {
         height: 100%;
       }
+      .overlay-embedded-card-header {
+        background: var(--boxel-light-100);
+        height: var(--overlay-embedded-card-header-height);
+      }
+      .icon-button:hover {
+        --icon-bg: var(--boxel-teal);
+        --icon-border: none;
+        --icon-color: var(--boxel-teal);
+        background: var(--boxel-light);
+      }
+      .header-title {
+        display: inline-block;
+        margin: 0;
+        padding: 13px;
+        color: var(--boxel-label-color);
+        font: 700 var(--boxel-font-sm);
+        letter-spacing: var(--boxel-lsp-sm);
+      }
+      .header-title > .icon {
+        margin-right: var(--boxel-sp-xxxs);
+      }
+
     </style>
   </template>
 
-  @tracked currentlyHoveredCard: RenderedLinksToCard | null = null;
-  areEventsRegistered = new TrackedWeakMap<RenderedLinksToCard, boolean>();
+  @tracked currentlyHoveredCard: RenderedCardForOverlayActions | null = null;
+  areEventsRegistered = new TrackedWeakMap<
+    RenderedCardForOverlayActions,
+    boolean
+  >();
 
   offset = {
     name: 'offset',
@@ -125,15 +186,15 @@ export default class OperatorModeOverlays extends Component<Signature> {
     },
   };
 
-  // Pointer events of this overlay component 
+  // Pointer events of this overlay component
   // will prevent pointer events on rendered cards.
   // This might cause broken functionality in rendered cards,
   // such as the inability to scroll through cards in the cards-grid.
   // Therefore, we have decided to disable pointer events for this overlay component,
   // and instead, we register events directly to the rendered cards.
   // This way, we can maintain the same behavior of hovering and clicking.
-  get renderedCardWithEvents() {
-    let renderedCards = this.args.renderedLinksToCards;
+  get renderedCardsForOverlayActionsWithEvents() {
+    let renderedCards = this.args.renderedCardsForOverlayActions;
     for (const renderedCard of renderedCards) {
       if (this.areEventsRegistered.get(renderedCard)) continue;
       renderedCard.element.addEventListener(
@@ -153,7 +214,9 @@ export default class OperatorModeOverlays extends Component<Signature> {
     return renderedCards;
   }
 
-  setCurrentlyHoverCard = (renderedCard: RenderedLinksToCard | null) => {
+  setCurrentlyHoverCard = (
+    renderedCard: RenderedCardForOverlayActions | null
+  ) => {
     this.currentlyHoveredCard = renderedCard;
   };
 

--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -188,13 +188,12 @@ export default class OperatorModeOverlays extends Component<Signature> {
     },
   };
 
-  // Pointer events of this overlay component
-  // will prevent pointer events on rendered cards.
-  // This might cause broken functionality in rendered cards,
-  // such as the inability to scroll through cards in the cards-grid.
-  // Therefore, we have decided to disable pointer events for this overlay component,
-  // and instead, we register events directly to the rendered cards.
-  // This way, we can maintain the same behavior of hovering and clicking.
+  // Since we put absolutely positined overlays containing operator mode actions on top of the rendered cards,
+  // we are running into a problem where the overlays are interfering with scrolling of the container that holds the rendered cards.
+  // That means scrolling stops when the cursor gets over the overlay, which is a bug. We solved this problem by disabling pointer
+  // events on the overlay. However, that prevents the browser from detecting hover state, which is needed to show the operator mode actions, and
+  // click event, needed to open the card. To solve this, we add event listeners to the rendered cards underneath the overlay, and use those to
+  // detect hover state and click event.
   get renderedCardsForOverlayActionsWithEvents() {
     let renderedCards = this.args.renderedCardsForOverlayActions;
     for (const renderedCard of renderedCards) {

--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -47,6 +47,7 @@ export default class OperatorModeOverlays extends Component<Signature> {
           }}
           {{velcro renderedCard.element middleware=(Array this.offset)}}
           data-test-overlay-selected={{if isSelected card.id}}
+          data-test-overlay-card-display-name={{cardTypeDisplayName card}}
         >
           {{! Add mouseenter and mouseleave events to each button, so we can maintain the hover effect. }}
           {{#if (this.isEmbeddedCard renderedCard)}}

--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -68,6 +68,7 @@ export default class OperatorModeOverlays extends Component<Signature> {
             (and (bool @toggleSelect) (not (this.isEmbeddedCard renderedCard)))
           }}
             <IconButton
+              {{! @glint-ignore (glint thinks toggleSelect is not in this scope but it actually is - we check for it in the condition above) }}
               {{on 'click' (fn @toggleSelect card)}}
               {{on 'mouseenter' (fn this.setCurrentlyHoverCard renderedCard)}}
               {{on 'mouseleave' (fn this.setCurrentlyHoverCard null)}}

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -53,9 +53,10 @@ interface Signature {
   };
 }
 
-export interface RenderedLinksToCard {
+export interface RenderedCardForOverlayActions {
   element: HTMLElement;
   card: Card;
+  fieldType: FieldType | undefined;
 }
 
 export default class OperatorModeStackItem extends Component<Signature> {
@@ -69,20 +70,22 @@ export default class OperatorModeStackItem extends Component<Signature> {
     fieldType: FieldType | undefined;
   }>();
 
-  get renderedLinksToCards(): RenderedLinksToCard[] {
+  get renderedCardsForOverlayActions(): RenderedCardForOverlayActions[] {
     return (
       this.cardTracker.elements
         .filter((entry) => {
           return (
             entry.meta.format === 'data' ||
             entry.meta.fieldType === 'linksTo' ||
-            entry.meta.fieldType === 'linksToMany'
+            entry.meta.fieldType === 'linksToMany' ||
+            entry.meta.fieldType === 'contains'
           );
         })
         // this mapping could probably be eliminated or simplified if we refactor OperatorModeOverlays to accept our type
         .map((entry) => ({
           element: entry.element,
           card: entry.meta.card,
+          fieldType: entry.meta.fieldType,
         }))
     );
   }
@@ -182,8 +185,12 @@ export default class OperatorModeStackItem extends Component<Signature> {
           style={{cssVar
             boxel-header-icon-width='30px'
             boxel-header-icon-height='30px'
-            boxel-header-text-size=(if this.isHoverOnRealmIcon 'var(--boxel-font)' 'var(--boxel-font-lg)')
-            boxel-header-text-color=(if this.isHoverOnRealmIcon 'var(--boxel-teal)' 'var(--boxel-dark)')
+            boxel-header-text-size=(if
+              this.isHoverOnRealmIcon 'var(--boxel-font)' 'var(--boxel-font-lg)'
+            )
+            boxel-header-text-color=(if
+              this.isHoverOnRealmIcon 'var(--boxel-teal)' 'var(--boxel-dark)'
+            )
             boxel-header-padding='var(--boxel-sp-xs) var(--boxel-sp)'
             boxel-header-action-padding='var(--boxel-sp-xs) var(--boxel-sp)'
           }}
@@ -191,8 +198,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
         >
           <:actions>
             {{#if (eq @item.format 'isolated')}}
-              <Tooltip
-                @placement='top'>
+              <Tooltip @placement='top'>
                 <:trigger>
                   <IconButton
                     @icon='icon-pencil'
@@ -209,8 +215,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
                 </:content>
               </Tooltip>
             {{else}}
-              <Tooltip
-                @placement='top'>
+              <Tooltip @placement='top'>
                 <:trigger>
                   <IconButton
                     @icon='icon-pencil'
@@ -230,18 +235,17 @@ export default class OperatorModeStackItem extends Component<Signature> {
             <div>
               <BoxelDropdown>
                 <:trigger as |bindings|>
-                  <Tooltip
-                    @placement='top'>
+                  <Tooltip @placement='top'>
                     <:trigger>
                       <IconButton
-                          @icon='icon-horizontal-three-dots'
-                          @width='20px'
-                          @height='20px'
-                          class='icon-button'
-                          aria-label='Options'
-                          data-test-more-options-button
-                          {{bindings}}
-                        />
+                        @icon='icon-horizontal-three-dots'
+                        @width='20px'
+                        @height='20px'
+                        class='icon-button'
+                        aria-label='Options'
+                        data-test-more-options-button
+                        {{bindings}}
+                      />
                     </:trigger>
                     <:content>
                       More Options
@@ -270,13 +274,12 @@ export default class OperatorModeStackItem extends Component<Signature> {
                           icon='icon-link'
                         )
                       )
-                  }}
-                />
+                    }}
+                  />
                 </:content>
               </BoxelDropdown>
             </div>
-            <Tooltip
-              @placement='top'>
+            <Tooltip @placement='top'>
               <:trigger>
                 <IconButton
                   @icon='icon-x'
@@ -301,7 +304,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
             @context={{this.context}}
           />
           <OperatorModeOverlays
-            @renderedLinksToCards={{this.renderedLinksToCards}}
+            @renderedCardsForOverlayActions={{this.renderedCardsForOverlayActions}}
             @publicAPI={{@publicAPI}}
             @toggleSelect={{this.toggleSelect}}
             @selectedCards={{this.selectedCards}}
@@ -355,7 +358,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
       }
 
       .card {
-        position: relative; 
+        position: relative;
         height: 100%;
         display: grid;
         grid-template-rows: 3.5rem auto;
@@ -472,6 +475,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
       .icon-save:hover {
         --icon-bg: var(--boxel-dark);
       }
+
     </style>
   </template>
 }

--- a/packages/host/app/components/operator-mode/stack.gts
+++ b/packages/host/app/components/operator-mode/stack.gts
@@ -60,6 +60,13 @@ export default class OperatorModeStack extends Component<Signature> {
         margin-left: var(--boxel-sp-xs);
         margin-right: var(--boxel-sp-xs);
       }
+
+      :global(.operator-mode-stack .embedded-card) {
+        padding-top: calc(
+          var(--overlay-embedded-card-header-height) + var(--boxel-sp-lg)
+        );
+      }
+
     </style>
   </template>
 }

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -141,12 +141,14 @@ module('Integration | operator-mode', function (hooks) {
           @field country = contains(StringCard);
           static embedded = class Embedded extends Component<typeof this> {
             <template>
-              <h3 data-test-city={{@model.city}}>
-                <@fields.city/>
-              </h3>
-              <h3 data-test-country={{@model.country}}>
-                <@fields.country/>
-              </h3>
+              <div data-test-address>
+                <h3 data-test-city={{@model.city}}>
+                  <@fields.city/>
+                </h3>
+                <h3 data-test-country={{@model.country}}>
+                  <@fields.country/>
+                </h3>
+              </div>
             </template>
           }
 
@@ -1553,7 +1555,7 @@ module('Integration | operator-mode', function (hooks) {
       )
       .includesText('Address');
 
-    await click('[data-test-overlay-card-display-name="Address"] button');
+    await click('[data-test-address]');
 
     assert.dom('[data-test-stack-card-index]').exists({ count: 2 });
     assert

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -1535,4 +1535,29 @@ module('Integration | operator-mode', function (hooks) {
     await click('[data-test-boxel-menu-item-text="Copy Card URL"]');
     assert.dom('[data-test-boxel-menu-item]').doesNotExist();
   });
+
+  test(`composite "contains one" field has an overlay header and click on the contains card will open it on the stack`, async function (assert) {
+    await setCardInOperatorModeState(`${testRealmURL}Person/burcu`);
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template>
+          <OperatorMode @onClose={{noop}} />
+          <CardPrerender />
+        </template>
+      }
+    );
+
+    assert
+      .dom(
+        '[data-test-overlay-card-display-name="Address"] [data-test-overlay-header]'
+      )
+      .includesText('Address');
+
+    await click('[data-test-overlay-card-display-name="Address"] button');
+    await this.pauseTest();
+    assert.dom('[data-test-stack-card-index]').exists({ count: 2 });
+    assert
+      .dom('[data-test-stack-card-index="1"] [data-test-boxel-header-title]')
+      .includesText('Address');
+  });
 });

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -1554,7 +1554,7 @@ module('Integration | operator-mode', function (hooks) {
       .includesText('Address');
 
     await click('[data-test-overlay-card-display-name="Address"] button');
-    await this.pauseTest();
+
     assert.dom('[data-test-stack-card-index]').exists({ count: 2 });
     assert
       .dom('[data-test-stack-card-index="1"] [data-test-boxel-header-title]')


### PR DESCRIPTION
This is a preparatory PR for many of the [Reskinning relationship fields](https://linear.app/cardstack/issue/CS-5767/reskinning-relationship-fields) tickets. 

It introduces an overlaid header for "contains" and "links to" embedded cards which will be used to add actions buttons in later implementations.

Before:
<img width="755" alt="image" src="https://github.com/cardstack/boxel/assets/273660/1d25894e-3cca-48d2-b08c-e0b76f4a305d">

After:
<img width="825" alt="image" src="https://github.com/cardstack/boxel/assets/273660/15315b67-de34-4075-8092-86c9d5149d00">

Both cards are clickable and clicking on them will open them on top of the stack. 

Below image is taken from the new design which introduces buttons for edit, options, (and preview and trash). So this PR makes room for the edit and options button which will be added later. 

<img width="1038" alt="image" src="https://github.com/cardstack/boxel/assets/273660/88a07736-377c-4052-b2dc-d10f1ec0760b">
