### PR TITLE
Fix visual bug with 'short' cards

### DIFF
--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -362,11 +362,11 @@ export default class OperatorModeStackItem extends Component<Signature> {
         overflow: auto;
       }
 
-      .content > .boxel-card-container.boundaries {
+      :global(.content > .boxel-card-container.boundaries) {
         box-shadow: none;
       }
 
-      .content > .boxel-card-container > header {
+      :global(.content > .boxel-card-container > header) {
         display: none;
       }
 


### PR DESCRIPTION
Before:
![Screenshot 2023-07-20 at 10 43 14](https://github.com/cardstack/boxel/assets/12637010/bec769e5-bcd6-4c3d-9f42-3e4e2e9c5b31)

After:
![Screenshot 2023-07-20 at 10 44 33](https://github.com/cardstack/boxel/assets/12637010/eaa7dc6d-e366-4558-b7c4-f35a3a0937c8)
