### PR TITLE
Fix stacks position when card chooser modal is opened

### DIFF
--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -531,6 +531,9 @@ export default class OperatorModeContainer extends Component<Signature> {
         --operator-mode-bg-color: #686283;
         --boxel-modal-max-width: 100%;
       }
+      :global(.operator-mode .boxel-modal__inner) {
+        display: block;
+      }
       .operator-mode > div {
         align-items: flex-start;
       }


### PR DESCRIPTION
Before:

https://github.com/cardstack/boxel/assets/12637010/6b636e0c-29ee-4502-8fb2-6395169c8573

After:

https://github.com/cardstack/boxel/assets/12637010/d95bdcf2-6df2-4214-94eb-cc1a00ad7aca

