### PR TITLE
Add Edit and Options buttons in embedded cards header in operator mode

### DIFF
--- a/packages/boxel-ui/addon/components/icon-button/index.gts
+++ b/packages/boxel-ui/addon/components/icon-button/index.gts
@@ -32,19 +32,18 @@ class IconButton extends Component<Signature> {
 
   <template>
     <button
-      class={{cn
-        (if @variant (concat @variant))
-        @class
-      }}
+      class={{cn (if @variant (concat @variant)) @class}}
       {{on 'mouseenter' this.onMouseEnterButton}}
       {{on 'mouseleave' this.onMouseLeaveButton}}
       ...attributes
     >
+      {{! Using inline style attribute because targeting the svg using <style> does not work - css scoping works incorrectly }}
       {{#if @icon}}
         {{svgJar
           @icon
           width=(if @width @width '16px')
           height=(if @height @height '16px')
+          style='margin: auto; display: block;'
         }}
       {{/if}}
     </button>
@@ -82,10 +81,6 @@ class IconButton extends Component<Signature> {
         background-color: var(--boxel-purple-800);
       }
 
-      button > svg {
-        display: block;
-        margin: auto;
-      }
     </style>
   </template>
 }

--- a/packages/boxel-ui/addon/components/icon-button/index.gts
+++ b/packages/boxel-ui/addon/components/icon-button/index.gts
@@ -43,7 +43,7 @@ class IconButton extends Component<Signature> {
           @icon
           width=(if @width @width '16px')
           height=(if @height @height '16px')
-          style='margin: auto; display: block;'
+          style='margin: auto;'
         }}
       {{/if}}
     </button>

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -311,7 +311,7 @@ export default class OperatorModeContainer extends Component<Signature> {
         here.addToStack(newItem);
         return await newItem.request?.promise;
       },
-      viewCard: async (card: Card) => {
+      viewCard: async (card: Card, format: Format = 'isolated') => {
         let itemsCount = here.stacks[stackIndex].length;
 
         let currentCardOnStack = here.getCard(
@@ -331,7 +331,7 @@ export default class OperatorModeContainer extends Component<Signature> {
               type: 'contained',
               fieldOfIndex: currentIndex++,
               fieldName,
-              format: 'isolated',
+              format,
               stackIndex,
             });
           }
@@ -339,7 +339,7 @@ export default class OperatorModeContainer extends Component<Signature> {
           here.addToStack({
             type: 'card',
             card,
-            format: 'isolated',
+            format,
             stackIndex,
           });
         }

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -60,6 +60,7 @@ export interface RenderedCardForOverlayActions {
   element: HTMLElement;
   card: Card;
   fieldType: FieldType | undefined;
+  stackItem: StackItem;
 }
 
 export default class OperatorModeStackItem extends Component<Signature> {
@@ -89,6 +90,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
           element: entry.element,
           card: entry.meta.card,
           fieldType: entry.meta.fieldType,
+          stackItem: this.args.item,
         }))
     );
   }

--- a/packages/host/app/components/operator-mode/stack.gts
+++ b/packages/host/app/components/operator-mode/stack.gts
@@ -61,7 +61,14 @@ export default class OperatorModeStack extends Component<Signature> {
         margin-right: var(--boxel-sp-xs);
       }
 
+      /* Add some padding to accomodate for overlaid header for embedded cards in operator mode */
       :global(.operator-mode-stack .embedded-card) {
+        padding-top: calc(
+          var(--overlay-embedded-card-header-height) + var(--boxel-sp-lg)
+        );
+      }
+      /* This is repeated for the edit-card because specifying multiple selectors in :global don't work */
+      :global(.operator-mode-stack .edit-card) {
         padding-top: calc(
           var(--overlay-embedded-card-header-height) + var(--boxel-sp-lg)
         );

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -913,6 +913,48 @@ module('Integration | operator-mode', function (hooks) {
       );
   });
 
+  test('contained card action headers', async function (assert) {
+    await setCardInOperatorModeState(`${testRealmURL}Person/fadhlan`);
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template>
+          <OperatorMode @onClose={{noop}} />
+          <CardPrerender />
+        </template>
+      }
+    );
+
+    await waitFor('[data-test-person]');
+
+    assert
+      .dom('[data-test-embedded-card-edit-button]')
+      .doesNotExist(
+        "Contained card header has no 'edit' button when parent card is not in edit mode"
+      );
+
+    await click('[data-test-edit-button]');
+
+    await click(
+      '[data-test-overlay-card-display-name="Address"] [data-test-embedded-card-edit-button]'
+    );
+
+    assert
+      .dom(`[data-test-stack-card-index="1"] .card.edit`)
+      .exists('Address card opened in edit mode');
+
+    await click('[data-test-stack-card-index="1"] [data-test-close-button]');
+    await click(
+      '[data-test-overlay-card-display-name="Address"] [data-test-embedded-card-options-button]'
+    );
+    await click('[data-test-boxel-menu-item-text="View card"]');
+
+    assert
+      .dom(`[data-test-stack-card-index="1"]`)
+      .exists(
+        'Address card opened in view mode after clicking on View Card in options menu'
+      );
+  });
+
   test('can edit a nested contained card field', async function (assert) {
     await setCardInOperatorModeState(`${testRealmURL}Person/fadhlan`);
     await renderComponent(

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -93,7 +93,11 @@ export {
 } from './card-document';
 export { sanitizeHtml } from './dompurify';
 
-import type { Card, CardBase } from 'https://cardstack.com/base/card-api';
+import type {
+  Card,
+  CardBase,
+  Format,
+} from 'https://cardstack.com/base/card-api';
 
 export const maxLinkDepth = 5;
 export const assetsDir = '__boxel/';
@@ -164,7 +168,7 @@ export interface Actions {
     relativeTo: URL | undefined,
     opts?: { isLinkedCard?: boolean; doc?: LooseSingleCardDocument }
   ) => Promise<Card | undefined>;
-  viewCard: (card: Card) => void;
+  viewCard: (card: Card, format?: Format) => void;
   createCardDirectly: (
     doc: LooseSingleCardDocument,
     relativeTo: URL | undefined


### PR DESCRIPTION
This adds edit and options button to the embedded card in operator mode.

Edit button shows up only when the parent card is in edit mode. Clicking it will open the card in edit mode. 

The options menu has a "View card" option. Clicking it will open the contained card in view mode. 

<img width="1001" alt="image" src="https://github.com/cardstack/boxel/assets/273660/c93946f3-5c9f-40da-b2fa-18ecf52acf27">

<img width="746" alt="image" src="https://github.com/cardstack/boxel/assets/273660/8e0f3c8a-e444-40bf-a730-5269cb786006">

