### PR TITLE
Add realm icon in the links-to card in overlaid header in operator mode

### DIFF
--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -126,6 +126,14 @@ export default class OperatorModeOverlays extends Component<Signature> {
               </div>
 
             </div>
+
+            <IconButton
+              {{on 'mouseenter' (fn this.setCurrentlyHoveredCard renderedCard)}}
+              {{on 'mouseleave' (fn this.setCurrentlyHoveredCard null)}}
+              class='hover-button hover-button-embedded-card preview'
+              @icon='eye'
+              aria-label='preview card'
+            />
           {{/if}}
 
           {{#if
@@ -180,8 +188,8 @@ export default class OperatorModeOverlays extends Component<Signature> {
         height: 30px;
         pointer-events: auto;
       }
-      .hovered > .hover-button:not(:disabled),
-      .hovered > .hover-button.select {
+      .hovered .hover-button:not(:disabled),
+      .hovered .hover-button.select {
         display: block;
       }
       .hover-button:not(:disabled):hover {
@@ -199,6 +207,14 @@ export default class OperatorModeOverlays extends Component<Signature> {
       .hover-button.more-actions {
         bottom: 0;
         right: 0;
+      }
+      .hover-button.hover-button-embedded-card {
+        left: calc(100% - var(--boxel-sp-xl));
+        top: calc(
+          (100% - var(--overlay-embedded-card-header-height)) / 2 +
+            var(--overlay-embedded-card-header-height) - 1em
+        );
+        position: absolute;
       }
       .hover-button > svg {
         height: 100%;

--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -70,7 +70,10 @@ export default class OperatorModeOverlays extends Component<Signature> {
                     {{svgJar 'icon-turn-down-right' width='22px' height='18px'}}
                   {{else}}
                     {{#let (load (this.getRealmInfo card)) as |result|}}
-                      <img src={{result.value.iconURL}} />
+                      <img
+                        src={{result.value.iconURL}}
+                        alt="Card's realm icon"
+                      />
                     {{/let}}
                   {{/if}}
                 </div>

--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -19,6 +19,10 @@ import { svgJar } from '@cardstack/boxel-ui/helpers/svg-jar';
 import BoxelMenu from '@cardstack/boxel-ui/components/menu';
 import menuItem from '@cardstack/boxel-ui/helpers/menu-item';
 
+import { service } from '@ember/service';
+import CardService from '@cardstack/host/services/card-service';
+import { load } from 'ember-async-data';
+
 interface Signature {
   Args: {
     renderedCardsForOverlayActions: RenderedCardForOverlayActions[];
@@ -29,11 +33,17 @@ interface Signature {
 }
 
 export default class OperatorModeOverlays extends Component<Signature> {
+  @service declare cardService: CardService;
+
   isEmbeddedCard(renderedCard: RenderedCardForOverlayActions) {
     return (
       renderedCard.fieldType === 'contains' ||
       renderedCard.fieldType === 'linksTo'
     );
+  }
+
+  @action async getRealmInfo(card: Card) {
+    return this.cardService.getRealmInfo(card);
   }
 
   <template>
@@ -52,17 +62,18 @@ export default class OperatorModeOverlays extends Component<Signature> {
           data-test-overlay-selected={{if isSelected card.id}}
           data-test-overlay-card-display-name={{cardTypeDisplayName card}}
         >
-          {{! Add mouseenter and mouseleave events to each button, so we can maintain the hover effect. }}
           {{#if (this.isEmbeddedCard renderedCard)}}
             <div class='overlay-embedded-card-header' data-test-overlay-header>
-
-              {{! TODO: Icon for linksTo field type }}
               <div class='header-title'>
-                {{#if (eq renderedCard.fieldType 'contains')}}
-                  <div class='header-icon'>
+                <div class='header-icon'>
+                  {{#if (eq renderedCard.fieldType 'contains')}}
                     {{svgJar 'icon-turn-down-right' width='22px' height='18px'}}
-                  </div>
-                {{/if}}
+                  {{else}}
+                    {{#let (load (this.getRealmInfo card)) as |result|}}
+                      <img src={{result.value.iconURL}} />
+                    {{/let}}
+                  {{/if}}
+                </div>
                 <div class='header-text'>
                   {{cardTypeDisplayName card}}
                 </div>

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -168,5 +168,8 @@
     "paths": [
       "lib/setup-ast-transforms"
     ]
+  },
+  "dependencies": {
+    "ember-async-data": "^1.0.1"
   }
 }

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -1782,4 +1782,27 @@ module('Integration | operator-mode', function (hooks) {
       .dom('[data-test-stack-card-index="1"] [data-test-boxel-header-title]')
       .includesText('Address');
   });
+
+  test(`"links to" field has an overlay header and click on the contains card will open it on the stack`, async function (assert) {
+    await setCardInOperatorModeState(`${testRealmURL}BlogPost/1`);
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template>
+          <OperatorMode @onClose={{noop}} />
+          <CardPrerender />
+        </template>
+      }
+    );
+
+    // Linked cards have the realm's icon in the overlaid header title
+    assert
+      .dom('[data-test-overlay-card-display-name="Author"] .header-icon img')
+      .hasAttribute('src', 'https://example-icon.test');
+
+    await click('[data-test-author');
+    assert.dom('[data-test-stack-card-index]').exists({ count: 2 });
+    assert
+      .dom('[data-test-stack-card-index="1"] [data-test-boxel-header-title]')
+      .includesText('Author');
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -856,6 +856,9 @@ importers:
       '@glint/environment-ember-loose':
         specifier: ^1.0.0
         version: 1.0.2(@glimmer/component@1.1.2)(@glint/template@1.0.2)(ember-cli-htmlbars@6.2.0)(ember-modifier@4.1.0)
+      ember-async-data:
+        specifier: ^1.0.1
+        version: 1.0.1(ember-source@4.12.0)
     devDependencies:
       '@babel/core':
         specifier: ^7.17.8
@@ -4273,7 +4276,6 @@ packages:
       semver: 7.3.8
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@embroider/addon-shim@0.50.2:
     resolution: {integrity: sha512-a+pFlXZPovcCNFo05HxXBW9ole43mPyFZnkhvZlLF0f1sHEn9j0sD1Ld2BM/NCERmHcYz9eXQnX1FPNLCDoGEA==}
@@ -11725,6 +11727,18 @@ packages:
       - supports-color
       - webpack
     dev: true
+
+  /ember-async-data@1.0.1(ember-source@4.12.0):
+    resolution: {integrity: sha512-R9nBxCZ9WDPMJpuGBODs8wV1PHXUbkSbrzVmL34R4aOWbx237yLBllJghQOwfJs1+D72wdzgxg/+J3DY43xz3g==}
+    peerDependencies:
+      ember-source: ^4.8.4
+    dependencies:
+      '@ember/test-waiters': 3.0.2
+      '@embroider/addon-shim': 1.8.5
+      ember-source: 4.12.0(@babel/core@7.20.2)(@glimmer/component@1.1.2)(@glint/template@1.0.2)(webpack@5.84.0)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /ember-auto-import@1.12.2:
     resolution: {integrity: sha512-gLqML2k77AuUiXxWNon1FSzuG1DV7PEPpCLCU5aJvf6fdL6rmFfElsZRh+8ELEB/qP9dT+LHjNEunVzd2dYc8A==}


### PR DESCRIPTION
This PR adds the realm's icon to the overlaid header of a links-to relationship. See the image below. For contrast, the contained card has a different icon (the arrow). 

<img width="763" alt="image" src="https://github.com/cardstack/boxel/assets/273660/16ab8418-93d4-4463-8778-20708f76d168">
