### PR TITLE
Disable `copy card url` menu action for contained cards

### DIFF
--- a/packages/boxel-ui/addon/components/menu/index.gts
+++ b/packages/boxel-ui/addon/components/menu/index.gts
@@ -23,10 +23,10 @@ class MenuItemRenderer extends Component<{
     return this.args.menuItem as MenuItem;
   }
   <template>
-    {{#if (eq @menuItem.type "divider")}}
-      {{yield to="divider"}}
+    {{#if (eq @menuItem.type 'divider')}}
+      {{yield to='divider'}}
     {{else}}
-      {{yield this.asMenuItem to="item"}}
+      {{yield this.asMenuItem to='item'}}
     {{/if}}
   </template>
 }
@@ -57,18 +57,21 @@ export default class Menu extends Component<Signature> {
 
   <template>
     {{! template-lint-disable no-invalid-role }}
-    <ul role="menu" class={{cn "boxel-menu" @class}} ...attributes>
+    <ul role='menu' class={{cn 'boxel-menu' @class}} ...attributes>
       {{#if @items}}
         {{#each (compact @items) as |menuItem|}}
           <MenuItemRenderer @menuItem={{menuItem}}>
             <:divider>
-              <hr class="boxel-menu__separator" data-test-boxel-menu-separator />
+              <hr
+                class='boxel-menu__separator'
+                data-test-boxel-menu-separator
+              />
             </:divider>
             <:item as |menuItem|>
               <li
-                role="none"
+                role='none'
                 class={{cn
-                  "boxel-menu__item"
+                  'boxel-menu__item'
                   @itemClass
                   boxel-menu__item--dangerous=menuItem.dangerous
                   boxel-menu__item--has-icon=menuItem.icon
@@ -77,20 +80,21 @@ export default class Menu extends Component<Signature> {
                 }}
                 data-test-boxel-menu-item
               >
-                {{!-- template-lint-disable require-context-role --}}
+                {{! template-lint-disable require-context-role }}
                 <div
-                  class="boxel-menu__item__content"
-                  role="menuitem"
-                  href="#"
+                  class='boxel-menu__item__content'
+                  role='menuitem'
+                  href='#'
                   data-test-boxel-menu-item-text={{menuItem.text}}
                   tabindex={{menuItem.tabindex}}
-                  {{on "click" (fn this.invokeMenuItemAction menuItem.action)}}
+                  {{on 'click' (fn this.invokeMenuItemAction menuItem.action)}}
+                  disabled={{menuItem.disabled}}
                 >
                   {{#if menuItem.icon}}
                     {{svgJar
                       menuItem.icon
-                      width="16"
-                      height="16"
+                      width='16'
+                      height='16'
                       data-test-boxel-menu-item-icon=true
                     }}
                   {{/if}}
@@ -141,14 +145,14 @@ export default class Menu extends Component<Signature> {
       .boxel-menu__item > .boxel-menu__item__content {
         width: max-content;
         padding: var(--boxel-sp-xs) var(--boxel-sp);
-        
+
         display: flex;
         align-items: center;
         gap: 10px;
       }
 
       .boxel-menu__item--disabled .boxel-menu__item__content {
-        cursor: default;
+        pointer-events: none;
       }
 
       .boxel-menu__item > .boxel-menu__item__content:hover {
@@ -176,6 +180,7 @@ export default class Menu extends Component<Signature> {
         height: 0;
         border-bottom: 1px solid var(--boxel-purple-300);
       }
+
     </style>
   </template>
 }

--- a/packages/boxel-ui/tests/dummy/app/controllers/index.js
+++ b/packages/boxel-ui/tests/dummy/app/controllers/index.js
@@ -9,6 +9,7 @@ import InputValidationStateUsage from '@cardstack/boxel-ui/components/input/vali
 import LoadingIndicatorUsage from '@cardstack/boxel-ui/components/loading-indicator/usage';
 import MessageUsage from '@cardstack/boxel-ui/components/message/usage';
 import ModalUsage from '@cardstack/boxel-ui/components/modal/usage';
+import MenuUsage from '@cardstack/boxel-ui/components/menu/usage';
 import DropdownUsage from '@cardstack/boxel-ui/components/dropdown/usage';
 import TooltipUsage from '@cardstack/boxel-ui/components/tooltip/usage';
 
@@ -26,6 +27,7 @@ export default class IndexController extends FreestyleController {
       ['Boxel::LoadingIndicator', LoadingIndicatorUsage],
       ['Boxel::Modal', ModalUsage],
       ['Boxel::Message', MessageUsage],
+      ['Boxel::Menu', MenuUsage],
       ['Boxel::Dropdown', DropdownUsage],
       ['Boxel::Tooltip', TooltipUsage],
     ].map(([name, c]) => {

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -131,10 +131,12 @@ export default class OperatorModeStackItem extends Component<Signature> {
   }
 
   @action async copyToClipboard(cardUrl: string) {
+    if (!cardUrl) {
+      return;
+    }
     if (config.environment === 'test') {
       return; // navigator.clipboard is not available in test environment
     }
-
     await navigator.clipboard.writeText(cardUrl);
   }
 
@@ -305,6 +307,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
                           'Copy Card URL'
                           (fn this.copyToClipboard this.card.id)
                           icon='icon-link'
+                          disabled=(eq @item.type 'contained')
                         )
                         (menuItem
                           'Delete' (fn @delete @item @index) icon='icon-trash'
@@ -315,6 +318,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
                           'Copy Card URL'
                           (fn this.copyToClipboard this.card.id)
                           icon='icon-link'
+                          disabled=(eq @item.type 'contained')
                         )
                       )
                     }}

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -220,7 +220,7 @@ module('Integration | operator-mode', function (hooks) {
               </p>
               Pet: <@fields.pet/>
               Friends: <@fields.friends/>
-              Address: <@fields.address/>
+              <div data-test-addresses>Address: <@fields.address/></div>
             </template>
           }
         }
@@ -1756,6 +1756,25 @@ module('Integration | operator-mode', function (hooks) {
     await click('[data-test-more-options-button]');
     await click('[data-test-boxel-menu-item-text="Copy Card URL"]');
     assert.dom('[data-test-boxel-menu-item]').doesNotExist();
+
+    await click(
+      '[data-test-addresses] > [data-test-boxel-card-container] > [data-test-field-component-card]'
+    );
+
+    await waitFor(
+      `[data-test-stack-card='${testRealmURL}Person/burcu/address']`
+    );
+    await click(
+      `[data-test-stack-card='${testRealmURL}Person/burcu/address'] [data-test-more-options-button]`
+    );
+    assert
+      .dom('[data-test-boxel-menu-item-text="Copy Card URL"]')
+      .hasAttribute('disabled');
+
+    await click(`[data-test-boxel-menu-item]`);
+    assert
+      .dom('[data-test-boxel-menu-item]')
+      .exists('can not copy url of a contained card');
   });
 
   test(`composite "contains one" field has an overlay header and click on the contains card will open it on the stack`, async function (assert) {


### PR DESCRIPTION
<img width="785" alt="disabled-copy-card-url" src="https://github.com/cardstack/boxel/assets/16160806/d6b45ade-d922-4062-bfca-d6f68ec8b88e">
