### PR TITLE
Don't rerender the whole stack on every stack item change

### DIFF
--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -475,22 +475,19 @@ export default class OperatorModeContainer extends Component<Signature> {
       // In case, that the search was accessed directly without clicking right and left buttons,
       // the rightmost stack will be REPLACED by the selection
       let numberOfStacks = this.operatorModeStateService.numberOfStacks();
+      let stackIndex = numberOfStacks - 1;
       if (numberOfStacks > 0) {
         //there will always be 1 stack
         let stack = this.operatorModeStateService.rightMostStack();
         if (stack) {
           let bottomMostItem = stack[0];
           if (bottomMostItem) {
-            let stackItem: CardStackItem = {
+            this.operatorModeStateService.clearStackAndAdd(stackIndex, {
               type: 'card',
               card,
               format: 'isolated',
-              stackIndex: numberOfStacks - 1, //rightMost stack index
-            };
-            this.operatorModeStateService.trimStackAndAdd(
-              bottomMostItem,
-              stackItem
-            );
+              stackIndex,
+            });
           }
         }
       }

--- a/packages/host/app/routes/card.gts
+++ b/packages/host/app/routes/card.gts
@@ -62,6 +62,16 @@ export default class RenderCard extends Route<Model | null> {
       if (operatorModeEnabled) {
         let operatorModeStateObject = JSON.parse(operatorModeState);
 
+        if (this.operatorModeStateService.serialize() === operatorModeState) {
+          // If the operator mode state in the query param is the same as the one we have in memory,
+          // we don't want to restore it again, because it will lead to rerendering of the stack items, which can
+          // bring various annoyances, e.g reloading of the items in the index card.
+          // We will reach this point when the user manipulates the stack and the operator state service will set the
+          // query param, which will trigger a refresh of the model, which will call the model hook again.
+          // The model refresh happens automatically because we have operatorModeState: { refreshModel: true } in the queryParams.
+          // We have that because we want to support back-forward navigation in operator mode.
+          return model;
+        }
         await this.operatorModeStateService.restore(operatorModeStateObject);
       }
 

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -138,7 +138,7 @@ export default class OperatorModeStateService extends Service {
   }
 
   shiftStack(stack: StackItem[], destinationIndex: number) {
-    let stackItemsCopy = stack.slice(); // The actions in the loop are mutating the stack items, so we need to make a copy to make sure to iterate over all items from the original stack
+    let stackItemsCopy = [...stack]; // The actions in the loop are mutating the stack items, so we need to make a copy to make sure to iterate over all items from the original stack
 
     stackItemsCopy.forEach((item) => {
       this.popItemFromStack(item.stackIndex);


### PR DESCRIPTION
This PR removes the rerendering of the whole stack on every stack change. We noticed that because the index card reloads the items when closing the items on top of it. So this change gets rid of that annoyance too.

Previously (see how it reloads the index card items for no good reason):

https://github.com/cardstack/boxel/assets/273660/c4e5efa0-0248-4b91-8176-d27127caa2b8

After the change:

https://github.com/cardstack/boxel/assets/273660/9112e7d3-e915-405b-8961-d43040f260e1


