### PR TITLE
Display 5 cards at a time for each realm in catalog

### DIFF
--- a/packages/host/tests/integration/components/schema-test.gts
+++ b/packages/host/tests/integration/components/schema-test.gts
@@ -457,14 +457,47 @@ module('Integration | schema', function (hooks) {
       .exists({ count: 2 });
     assert
       .dom(
+        '[data-test-card-catalog] [data-test-realm="Base Workspace"] [data-test-results-count]'
+      )
+      .hasText('12 results');
+    assert
+      .dom(
         '[data-test-card-catalog] [data-test-realm="Base Workspace"] [data-test-card-catalog-item]'
       )
-      .exists({ count: 12 });
+      .exists({ count: 5 }, 'first 5 base realm cards are displayed');
+
+    await click(
+      '[data-test-realm="Base Workspace"] [data-test-show-more-cards]'
+    );
+    assert
+      .dom(
+        '[data-test-card-catalog] [data-test-realm="Base Workspace"] [data-test-card-catalog-item]'
+      )
+      .exists({ count: 10 }, '5 more base realm cards are displayed');
+
+    await click(
+      '[data-test-realm="Base Workspace"] [data-test-show-more-cards]'
+    );
+    assert
+      .dom(
+        '[data-test-card-catalog] [data-test-realm="Base Workspace"] [data-test-card-catalog-item]'
+      )
+      .exists({ count: 12 }, 'all base realm cards are displayed');
+
+    assert
+      .dom(
+        '[data-test-card-catalog] [data-test-realm="Unnamed Workspace"] [data-test-results-count]'
+      )
+      .hasText('1 result');
     assert
       .dom(
         '[data-test-card-catalog] [data-test-realm="Unnamed Workspace"] [data-test-card-catalog-item]'
       )
       .exists({ count: 1 });
+    assert
+      .dom('[data-test-realm="Unnamed Workspace"] [data-test-show-more-cards]')
+      .doesNotExist();
+
     assert
       .dom(
         `[data-test-card-catalog] [data-test-card-catalog-item="${testRealmURL}person-entry"]`
@@ -580,7 +613,9 @@ module('Integration | schema', function (hooks) {
     assert
       .dom('[data-test-card-catalog-modal] [data-test-boxel-header-title]')
       .containsText('Choose a CatalogEntry card');
-
+    await click(
+      '[data-test-realm="Base Workspace"] [data-test-show-more-cards]'
+    );
     await click(`[data-test-select="${baseRealm.url}fields/string-field"]`);
     await click('[data-test-card-catalog-go-button]');
     await waitFor('[data-test-field="aliases"]');


### PR DESCRIPTION
This is a UI-only change. Clicking on the "Show more cards" button reveals 5 more cards each time.

Next step: There're places where we can extract components from the card-catalog-modal template.

<img width="1082" alt="card-catalog-show-more" src="https://github.com/cardstack/boxel/assets/16160806/f4168f39-df0f-4a9f-a001-3e1e515ee49f">
