### PR TITLE
host: Fix realm URLs for preview deployments

### DIFF
--- a/.github/workflows/build-host.yml
+++ b/.github/workflows/build-host.yml
@@ -22,11 +22,11 @@ jobs:
           INPUT_ENVIRONMENT: ${{ inputs.environment }}
         run: |
           if [ "$INPUT_ENVIRONMENT" = "production" ]; then
-            echo "OWN_REALM_URL=https://realms.cardstack.com/demo/" >> $GITHUB_ENV
+            echo "OWN_REALM_URL=https://realms.cardstack.com/drafts/" >> $GITHUB_ENV
             echo "RESOLVED_BASE_REALM_URL=https://realms.cardstack.com/base/" >> $GITHUB_ENV
             echo "MATRIX_URL=https://matrix.cardstack.com" >> $GITHUB_ENV
           elif [ "$INPUT_ENVIRONMENT" = "staging" ]; then
-            echo "OWN_REALM_URL=https://realms-staging.stack.cards/demo/" >> $GITHUB_ENV
+            echo "OWN_REALM_URL=https://realms-staging.stack.cards/drafts/" >> $GITHUB_ENV
             echo "RESOLVED_BASE_REALM_URL=https://realms-staging.stack.cards/base/" >> $GITHUB_ENV
             echo "MATRIX_URL=https://matrix-staging.stack.cards" >> $GITHUB_ENV
           else


### PR DESCRIPTION
This should fix preview deployments which are currently pointing to a non-existent realm.