### PR TITLE
Update to Typescript 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "hcl2-parser": "^1.0.3",
     "prettier": "^2.7.1",
     "prettier-plugin-ember-template-tag": "^0.3.2",
-    "typescript": "^4.6.3"
+    "typescript": "^5.1.6"
   },
   "engines": {
     "pnpm": "^8"

--- a/packages/ai-bot/package.json
+++ b/packages/ai-bot/package.json
@@ -3,7 +3,7 @@
     "devDependencies": {
         "matrix-js-sdk": "^25.0.0",
         "ts-node": "^10.9.1",
-        "typescript": "^4.5.2",
+        "typescript": "^5.1.6",
         "openai": "4.0.0-beta.4"
     },
     "scripts": {

--- a/packages/boxel-motion-demo-app/package.json
+++ b/packages/boxel-motion-demo-app/package.json
@@ -81,7 +81,7 @@
     "qunit": "^2.19.4",
     "qunit-dom": "^2.0.0",
     "tracked-built-ins": "^3.1.1",
-    "typescript": "^4.7.4",
+    "typescript": "^5.1.6",
     "webpack": "^5.78.0"
   },
   "peerDependencies": {

--- a/packages/boxel-motion-test-app/package.json
+++ b/packages/boxel-motion-test-app/package.json
@@ -83,7 +83,7 @@
     "stylelint-config-standard": "^32.0.0",
     "stylelint-prettier": "^3.0.0",
     "tracked-built-ins": "^3.1.1",
-    "typescript": "^4.6.4",
+    "typescript": "^5.1.6",
     "webpack": "^5.78.0"
   },
   "peerDependencies": {

--- a/packages/boxel-motion/addon/utils/measurement.ts
+++ b/packages/boxel-motion/addon/utils/measurement.ts
@@ -19,10 +19,12 @@ function runWithoutAnimations(playAnimations: boolean) {
     let currentTimes: number[] = [];
     animations.forEach((a) => {
       a.pause();
-      currentTimes.push(a.currentTime || 0);
+      currentTimes.push((a.currentTime as number) || 0);
       let timing = a.effect && a.effect.getComputedTiming();
       if (timing) {
-        a.currentTime = (timing.delay || 0) + (timing.activeDuration || 0);
+        a.currentTime =
+          ((timing.delay as number) || 0) +
+          ((timing.activeDuration as number) || 0);
       }
     });
     let result = f();
@@ -61,10 +63,10 @@ function runWithAnimationOffset(offset: number, playAnimations: boolean) {
     let currentTimes: number[] = [];
     animations.forEach((a) => {
       a.pause();
-      currentTimes.push(a.currentTime || 0);
+      currentTimes.push((a.currentTime as number) || 0);
       let timing = a.effect && a.effect.getComputedTiming();
       if (timing) {
-        a.currentTime = (timing.localTime || 0) + offset;
+        a.currentTime = ((timing.localTime as number) || 0) + offset;
       }
     });
     let result = f();

--- a/packages/boxel-motion/package.json
+++ b/packages/boxel-motion/package.json
@@ -57,7 +57,7 @@
     "eslint-plugin-qunit": "^7.2.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.6.1",
-    "typescript": "^4.7.0",
+    "typescript": "^5.1.6",
     "webpack": "^5.70.0"
   },
   "peerDependencies": {

--- a/packages/boxel-ui/package.json
+++ b/packages/boxel-ui/package.json
@@ -99,7 +99,7 @@
     "prettier-plugin-ember-template-tag": "^0.3.2",
     "qunit": "^2.19.4",
     "qunit-dom": "^2.0.0",
-    "typescript": "^4.7.4",
+    "typescript": "^5.1.6",
     "webpack": "^5.78.0"
   },
   "peerDependencies": {

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -140,7 +140,7 @@
     "start-server-and-test": "^1.14.0",
     "stream-browserify": "^3.0.0",
     "tracked-built-ins": "^3.1.1",
-    "typescript": "^4.6.3",
+    "typescript": "^5.1.6",
     "webpack": "^5.78.0"
   },
   "peerDependencies": {

--- a/packages/matrix/package.json
+++ b/packages/matrix/package.json
@@ -9,7 +9,7 @@
     "fs-extra": "^10.1.0",
     "start-server-and-test": "^1.14.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.5.2"
+    "typescript": "^5.1.6"
   },
   "scripts": {
     "start:synapse": "mkdir -p ./synapse-data/db && SYNAPSE_DATA_DIR=./synapse-data ts-node --transpileOnly ./scripts/synapse.ts start",

--- a/packages/realm-server/package.json
+++ b/packages/realm-server/package.json
@@ -49,7 +49,7 @@
     "testem": "^3.10.1",
     "tmp": "^0.2.1",
     "ts-node": "^10.9.1",
-    "typescript": "^4.5.2",
+    "typescript": "^5.1.6",
     "typescript-memoize": "^1.1.1",
     "yargs": "^17.5.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,7 +45,7 @@ importers:
         version: 1.1.2
       '@glint/core':
         specifier: ^1.0.0
-        version: 1.0.2(typescript@4.9.3)
+        version: 1.0.2(typescript@5.1.6)
       '@glint/environment-ember-loose':
         specifier: ^1.0.0
         version: 1.0.2(@glimmer/component@1.1.2)(@glint/template@1.0.2)(ember-cli-htmlbars@6.2.0)(ember-modifier@4.1.0)
@@ -54,10 +54,10 @@ importers:
         version: 1.0.2(@glint/environment-ember-loose@1.0.2)(@glint/template@1.0.2)(ember-template-imports@3.4.0)
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.17.0
-        version: 5.43.0(@typescript-eslint/parser@5.43.0)(eslint@7.32.0)(typescript@4.9.3)
+        version: 5.43.0(@typescript-eslint/parser@5.43.0)(eslint@7.32.0)(typescript@5.1.6)
       '@typescript-eslint/parser':
         specifier: ^5.17.0
-        version: 5.43.0(eslint@7.32.0)(typescript@4.9.3)
+        version: 5.43.0(eslint@7.32.0)(typescript@5.1.6)
       ember-cli-htmlbars:
         specifier: ^6.2.0
         version: 6.2.0
@@ -92,8 +92,8 @@ importers:
         specifier: ^0.3.2
         version: 0.3.2
       typescript:
-        specifier: ^4.6.3
-        version: 4.9.3
+        specifier: ^5.1.6
+        version: 5.1.6
 
   packages/ai-bot:
     devDependencies:
@@ -105,10 +105,10 @@ importers:
         version: 4.0.0-beta.4
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@types/node@18.15.13)(typescript@4.9.3)
+        version: 10.9.1(@types/node@18.15.13)(typescript@5.1.6)
       typescript:
-        specifier: ^4.5.2
-        version: 4.9.3
+        specifier: ^5.1.6
+        version: 5.1.6
 
   packages/base:
     dependencies:
@@ -203,7 +203,7 @@ importers:
         version: 7.20.2
       '@glint/core':
         specifier: ^1.0.0
-        version: 1.0.2(typescript@4.9.3)
+        version: 1.0.2(typescript@5.1.6)
       '@glint/environment-ember-template-imports':
         specifier: ^1.0.0
         version: 1.0.2(@glint/environment-ember-loose@1.0.2)(@glint/template@1.0.2)(ember-template-imports@3.4.0)
@@ -221,10 +221,10 @@ importers:
         version: 4.0.4
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.21.0
-        version: 5.43.0(@typescript-eslint/parser@5.43.0)(eslint@7.32.0)(typescript@4.9.3)
+        version: 5.43.0(@typescript-eslint/parser@5.43.0)(eslint@7.32.0)(typescript@5.1.6)
       '@typescript-eslint/parser':
         specifier: ^5.21.0
-        version: 5.43.0(eslint@7.32.0)(typescript@4.9.3)
+        version: 5.43.0(eslint@7.32.0)(typescript@5.1.6)
       ember-template-imports:
         specifier: ^3.0.1
         version: 3.4.0(ember-cli-htmlbars@6.2.0)
@@ -256,8 +256,8 @@ importers:
         specifier: github:ef4/prettier#8c4a6ad
         version: github.com/ef4/prettier/8c4a6ad
       typescript:
-        specifier: ^4.7.0
-        version: 4.9.3
+        specifier: ^5.1.6
+        version: 5.1.6
       webpack:
         specifier: ^5.70.0
         version: 5.75.0
@@ -297,7 +297,7 @@ importers:
         version: 1.1.2
       '@glint/core':
         specifier: ^1.0.0
-        version: 1.0.2(typescript@4.9.3)
+        version: 1.0.2(typescript@5.1.6)
       '@glint/environment-ember-template-imports':
         specifier: ^1.0.0
         version: 1.0.2(@glint/environment-ember-loose@1.0.2)(@glint/template@1.0.2)(ember-template-imports@3.4.0)
@@ -315,10 +315,10 @@ importers:
         version: 4.0.4
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.33.1
-        version: 5.43.0(@typescript-eslint/parser@5.43.0)(eslint@8.41.0)(typescript@4.9.3)
+        version: 5.43.0(@typescript-eslint/parser@5.43.0)(eslint@8.41.0)(typescript@5.1.6)
       '@typescript-eslint/parser':
         specifier: ^5.33.1
-        version: 5.43.0(eslint@8.41.0)(typescript@4.9.3)
+        version: 5.43.0(eslint@8.41.0)(typescript@5.1.6)
       broccoli-asset-rev:
         specifier: ^3.0.0
         version: 3.0.0
@@ -440,8 +440,8 @@ importers:
         specifier: ^3.1.1
         version: 3.1.1
       typescript:
-        specifier: ^4.7.4
-        version: 4.9.3
+        specifier: ^5.1.6
+        version: 5.1.6
       webpack:
         specifier: ^5.78.0
         version: 5.84.0
@@ -484,7 +484,7 @@ importers:
         version: 1.1.2
       '@glint/core':
         specifier: ^1.0.0
-        version: 1.0.2(typescript@4.9.3)
+        version: 1.0.2(typescript@5.1.6)
       '@glint/environment-ember-template-imports':
         specifier: ^1.0.0
         version: 1.0.2(@glint/environment-ember-loose@1.0.2)(@glint/template@1.0.2)(ember-template-imports@3.4.0)
@@ -499,10 +499,10 @@ importers:
         version: 4.0.4
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.21.0
-        version: 5.43.0(@typescript-eslint/parser@5.43.0)(eslint@8.41.0)(typescript@4.9.3)
+        version: 5.43.0(@typescript-eslint/parser@5.43.0)(eslint@8.41.0)(typescript@5.1.6)
       '@typescript-eslint/parser':
         specifier: ^5.21.0
-        version: 5.43.0(eslint@8.41.0)(typescript@4.9.3)
+        version: 5.43.0(eslint@8.41.0)(typescript@5.1.6)
       broccoli-asset-rev:
         specifier: ^3.0.0
         version: 3.0.0
@@ -615,8 +615,8 @@ importers:
         specifier: ^3.1.1
         version: 3.1.1
       typescript:
-        specifier: ^4.6.4
-        version: 4.9.3
+        specifier: ^5.1.6
+        version: 5.1.6
       webpack:
         specifier: ^5.78.0
         version: 5.84.0
@@ -716,7 +716,7 @@ importers:
         version: 1.1.2
       '@glint/core':
         specifier: ^1.0.0
-        version: 1.0.2(typescript@4.9.3)
+        version: 1.0.2(typescript@5.1.6)
       '@glint/environment-ember-template-imports':
         specifier: ^1.0.0
         version: 1.0.2(@glint/environment-ember-loose@1.0.2)(@glint/template@1.0.2)(ember-template-imports@3.4.0)
@@ -737,10 +737,10 @@ importers:
         version: 4.0.4
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.21.0
-        version: 5.43.0(@typescript-eslint/parser@5.43.0)(eslint@8.41.0)(typescript@4.9.3)
+        version: 5.43.0(@typescript-eslint/parser@5.43.0)(eslint@8.41.0)(typescript@5.1.6)
       '@typescript-eslint/parser':
         specifier: ^5.21.0
-        version: 5.43.0(eslint@8.41.0)(typescript@4.9.3)
+        version: 5.43.0(eslint@8.41.0)(typescript@5.1.6)
       broccoli-asset-rev:
         specifier: ^3.0.0
         version: 3.0.0
@@ -835,8 +835,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       typescript:
-        specifier: ^4.7.4
-        version: 4.9.3
+        specifier: ^5.1.6
+        version: 5.1.6
       webpack:
         specifier: ^5.78.0
         version: 5.84.0
@@ -845,7 +845,7 @@ importers:
     devDependencies:
       '@cardstack/cardpay-sdk':
         specifier: ^1.0.53
-        version: 1.0.53(@babel/core@7.21.0)(typescript@4.9.3)
+        version: 1.0.53(@babel/core@7.21.0)(typescript@5.1.6)
       '@types/lodash':
         specifier: ^4.14.182
         version: 4.14.189
@@ -915,7 +915,7 @@ importers:
         version: 1.1.2
       '@glint/core':
         specifier: ^1.0.0
-        version: 1.0.2(typescript@4.9.3)
+        version: 1.0.2(typescript@5.1.6)
       '@glint/environment-ember-template-imports':
         specifier: ^1.0.0
         version: 1.0.2(@glint/environment-ember-loose@1.0.2)(@glint/template@1.0.2)(ember-template-imports@3.4.0)
@@ -966,10 +966,10 @@ importers:
         version: 4.0.4
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.17.0
-        version: 5.43.0(@typescript-eslint/parser@5.43.0)(eslint@8.41.0)(typescript@4.9.3)
+        version: 5.43.0(@typescript-eslint/parser@5.43.0)(eslint@8.41.0)(typescript@5.1.6)
       '@typescript-eslint/parser':
         specifier: ^5.17.0
-        version: 5.43.0(eslint@8.41.0)(typescript@4.9.3)
+        version: 5.43.0(eslint@8.41.0)(typescript@5.1.6)
       broccoli-asset-rev:
         specifier: ^3.0.0
         version: 3.0.0
@@ -1190,8 +1190,8 @@ importers:
         specifier: ^3.1.1
         version: 3.1.1
       typescript:
-        specifier: ^4.6.3
-        version: 4.9.3
+        specifier: ^5.1.6
+        version: 5.1.6
       webpack:
         specifier: ^5.78.0
         version: 5.84.0
@@ -1220,10 +1220,10 @@ importers:
         version: 1.14.0
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@types/node@18.11.9)(typescript@4.9.3)
+        version: 10.9.1(@types/node@18.11.9)(typescript@5.1.6)
       typescript:
-        specifier: ^4.5.2
-        version: 4.9.3
+        specifier: ^5.1.6
+        version: 5.1.6
     dependenciesMeta:
       '@cardstack/runtime-common':
         injected: true
@@ -1373,10 +1373,10 @@ importers:
         version: 0.2.1
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@types/node@18.11.9)(typescript@4.9.3)
+        version: 10.9.1(@types/node@18.11.9)(typescript@5.1.6)
       typescript:
-        specifier: ^4.5.2
-        version: 4.9.3
+        specifier: ^5.1.6
+        version: 5.1.6
       typescript-memoize:
         specifier: ^1.1.1
         version: 1.1.1
@@ -1585,10 +1585,10 @@ importers:
         version: 4.0.1
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.5.0
-        version: 5.43.0(@typescript-eslint/parser@5.43.0)(eslint@7.32.0)(typescript@4.9.3)
+        version: 5.43.0(@typescript-eslint/parser@5.43.0)(eslint@7.32.0)(typescript@5.1.6)
       '@typescript-eslint/parser':
         specifier: ^5.5.0
-        version: 5.43.0(eslint@7.32.0)(typescript@4.9.3)
+        version: 5.43.0(eslint@7.32.0)(typescript@5.1.6)
       babel-eslint:
         specifier: ^10.1.0
         version: 10.1.0(eslint@7.32.0)
@@ -1689,8 +1689,8 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0(release-it@14.14.3)
       typescript:
-        specifier: ^4.5.2
-        version: 4.9.3
+        specifier: ^5.1.6
+        version: 5.1.6
       webpack:
         specifier: ^5.64.4
         version: 5.75.0
@@ -4026,7 +4026,7 @@ packages:
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
 
-  /@cardstack/cardpay-sdk@1.0.53(@babel/core@7.21.0)(typescript@4.9.3):
+  /@cardstack/cardpay-sdk@1.0.53(@babel/core@7.21.0)(typescript@5.1.6):
     resolution: {integrity: sha512-EmEqIc98X1vSON5L6adPswoXrECv4GTscy+YWchkTxx8a99iOBpAwc+ovKhiUns97KOBXjIplvC+FidXXpdSww==}
     engines: {node: ^14.0.0 || ^18.0.0}
     requiresBuild: true
@@ -4056,7 +4056,7 @@ packages:
       fs-extra: 10.1.0
       glob: 7.2.3
       lodash: 4.17.21
-      msw: 0.48.3(typescript@4.9.3)
+      msw: 0.48.3(typescript@5.1.6)
       semver: 7.3.8
       url-parse: 1.5.10
       uuid: 9.0.0
@@ -5245,7 +5245,7 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
 
-  /@glint/core@1.0.2(typescript@4.9.3):
+  /@glint/core@1.0.2(typescript@5.1.6):
     resolution: {integrity: sha512-0bVt/lT/NurpD8nBG9RTPKYlcpg51UDGCKgLoBEFOiTXv3aCSxAVKPud1IYaitGBKE0C+s5pl2PHkgptotVS+w==}
     hasBin: true
     peerDependencies:
@@ -5255,7 +5255,7 @@ packages:
       escape-string-regexp: 4.0.0
       semver: 7.3.8
       silent-error: 1.1.1
-      typescript: 4.9.3
+      typescript: 5.1.6
       uuid: 8.3.2
       vscode-languageserver: 8.0.2
       vscode-languageserver-textdocument: 1.0.7
@@ -6546,7 +6546,7 @@ packages:
     dev: true
     optional: true
 
-  /@typescript-eslint/eslint-plugin@5.43.0(@typescript-eslint/parser@5.43.0)(eslint@7.32.0)(typescript@4.9.3):
+  /@typescript-eslint/eslint-plugin@5.43.0(@typescript-eslint/parser@5.43.0)(eslint@7.32.0)(typescript@5.1.6):
     resolution: {integrity: sha512-wNPzG+eDR6+hhW4yobEmpR36jrqqQv1vxBq5LJO3fBAktjkvekfr4BRl+3Fn1CM/A+s8/EiGUbOMDoYqWdbtXA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -6557,23 +6557,23 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.43.0(eslint@7.32.0)(typescript@4.9.3)
+      '@typescript-eslint/parser': 5.43.0(eslint@7.32.0)(typescript@5.1.6)
       '@typescript-eslint/scope-manager': 5.43.0
-      '@typescript-eslint/type-utils': 5.43.0(eslint@7.32.0)(typescript@4.9.3)
-      '@typescript-eslint/utils': 5.43.0(eslint@7.32.0)(typescript@4.9.3)
+      '@typescript-eslint/type-utils': 5.43.0(eslint@7.32.0)(typescript@5.1.6)
+      '@typescript-eslint/utils': 5.43.0(eslint@7.32.0)(typescript@5.1.6)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 7.32.0
       ignore: 5.2.0
       natural-compare-lite: 1.4.0
       regexpp: 3.2.0
       semver: 7.3.8
-      tsutils: 3.21.0(typescript@4.9.3)
-      typescript: 4.9.3
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin@5.43.0(@typescript-eslint/parser@5.43.0)(eslint@8.41.0)(typescript@4.9.3):
+  /@typescript-eslint/eslint-plugin@5.43.0(@typescript-eslint/parser@5.43.0)(eslint@8.41.0)(typescript@5.1.6):
     resolution: {integrity: sha512-wNPzG+eDR6+hhW4yobEmpR36jrqqQv1vxBq5LJO3fBAktjkvekfr4BRl+3Fn1CM/A+s8/EiGUbOMDoYqWdbtXA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -6584,23 +6584,23 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.43.0(eslint@8.41.0)(typescript@4.9.3)
+      '@typescript-eslint/parser': 5.43.0(eslint@8.41.0)(typescript@5.1.6)
       '@typescript-eslint/scope-manager': 5.43.0
-      '@typescript-eslint/type-utils': 5.43.0(eslint@8.41.0)(typescript@4.9.3)
-      '@typescript-eslint/utils': 5.43.0(eslint@8.41.0)(typescript@4.9.3)
+      '@typescript-eslint/type-utils': 5.43.0(eslint@8.41.0)(typescript@5.1.6)
+      '@typescript-eslint/utils': 5.43.0(eslint@8.41.0)(typescript@5.1.6)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.41.0
       ignore: 5.2.0
       natural-compare-lite: 1.4.0
       regexpp: 3.2.0
       semver: 7.3.8
-      tsutils: 3.21.0(typescript@4.9.3)
-      typescript: 4.9.3
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.43.0(eslint@7.32.0)(typescript@4.9.3):
+  /@typescript-eslint/parser@5.43.0(eslint@7.32.0)(typescript@5.1.6):
     resolution: {integrity: sha512-2iHUK2Lh7PwNUlhFxxLI2haSDNyXvebBO9izhjhMoDC+S3XI9qt2DGFUsiJ89m2k7gGYch2aEpYqV5F/+nwZug==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -6612,15 +6612,15 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.43.0
       '@typescript-eslint/types': 5.43.0
-      '@typescript-eslint/typescript-estree': 5.43.0(typescript@4.9.3)
+      '@typescript-eslint/typescript-estree': 5.43.0(typescript@5.1.6)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 7.32.0
-      typescript: 4.9.3
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.43.0(eslint@8.41.0)(typescript@4.9.3):
+  /@typescript-eslint/parser@5.43.0(eslint@8.41.0)(typescript@5.1.6):
     resolution: {integrity: sha512-2iHUK2Lh7PwNUlhFxxLI2haSDNyXvebBO9izhjhMoDC+S3XI9qt2DGFUsiJ89m2k7gGYch2aEpYqV5F/+nwZug==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -6632,10 +6632,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.43.0
       '@typescript-eslint/types': 5.43.0
-      '@typescript-eslint/typescript-estree': 5.43.0(typescript@4.9.3)
+      '@typescript-eslint/typescript-estree': 5.43.0(typescript@5.1.6)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.41.0
-      typescript: 4.9.3
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6648,7 +6648,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.43.0
     dev: true
 
-  /@typescript-eslint/type-utils@5.43.0(eslint@7.32.0)(typescript@4.9.3):
+  /@typescript-eslint/type-utils@5.43.0(eslint@7.32.0)(typescript@5.1.6):
     resolution: {integrity: sha512-K21f+KY2/VvYggLf5Pk4tgBOPs2otTaIHy2zjclo7UZGLyFH86VfUOm5iq+OtDtxq/Zwu2I3ujDBykVW4Xtmtg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -6658,17 +6658,17 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.43.0(typescript@4.9.3)
-      '@typescript-eslint/utils': 5.43.0(eslint@7.32.0)(typescript@4.9.3)
+      '@typescript-eslint/typescript-estree': 5.43.0(typescript@5.1.6)
+      '@typescript-eslint/utils': 5.43.0(eslint@7.32.0)(typescript@5.1.6)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 7.32.0
-      tsutils: 3.21.0(typescript@4.9.3)
-      typescript: 4.9.3
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/type-utils@5.43.0(eslint@8.41.0)(typescript@4.9.3):
+  /@typescript-eslint/type-utils@5.43.0(eslint@8.41.0)(typescript@5.1.6):
     resolution: {integrity: sha512-K21f+KY2/VvYggLf5Pk4tgBOPs2otTaIHy2zjclo7UZGLyFH86VfUOm5iq+OtDtxq/Zwu2I3ujDBykVW4Xtmtg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -6678,12 +6678,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.43.0(typescript@4.9.3)
-      '@typescript-eslint/utils': 5.43.0(eslint@8.41.0)(typescript@4.9.3)
+      '@typescript-eslint/typescript-estree': 5.43.0(typescript@5.1.6)
+      '@typescript-eslint/utils': 5.43.0(eslint@8.41.0)(typescript@5.1.6)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.41.0
-      tsutils: 3.21.0(typescript@4.9.3)
-      typescript: 4.9.3
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6697,7 +6697,7 @@ packages:
     resolution: {integrity: sha512-M4iRh4AG1ChrOL6Y+mETEKGeDnT7Sparn6fhZ5LtVJF1909D5O4uqK+C5NPbLmpfZ0XIIxCdwzKiijpZUOvOug==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  /@typescript-eslint/typescript-estree@5.43.0(typescript@4.9.3):
+  /@typescript-eslint/typescript-estree@5.43.0(typescript@5.1.6):
     resolution: {integrity: sha512-BZ1WVe+QQ+igWal2tDbNg1j2HWUkAa+CVqdU79L4HP9izQY6CNhXfkNwd1SS4+sSZAP/EthI1uiCSY/+H0pROg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -6712,8 +6712,8 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
-      tsutils: 3.21.0(typescript@4.9.3)
-      typescript: 4.9.3
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6738,7 +6738,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/utils@5.43.0(eslint@7.32.0)(typescript@4.9.3):
+  /@typescript-eslint/utils@5.43.0(eslint@7.32.0)(typescript@5.1.6):
     resolution: {integrity: sha512-8nVpA6yX0sCjf7v/NDfeaOlyaIIqL7OaIGOWSPFqUKK59Gnumd3Wa+2l8oAaYO2lk0sO+SbWFWRSvhu8gLGv4A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -6748,7 +6748,7 @@ packages:
       '@types/semver': 7.3.13
       '@typescript-eslint/scope-manager': 5.43.0
       '@typescript-eslint/types': 5.43.0
-      '@typescript-eslint/typescript-estree': 5.43.0(typescript@4.9.3)
+      '@typescript-eslint/typescript-estree': 5.43.0(typescript@5.1.6)
       eslint: 7.32.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0(eslint@7.32.0)
@@ -6758,7 +6758,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils@5.43.0(eslint@8.41.0)(typescript@4.9.3):
+  /@typescript-eslint/utils@5.43.0(eslint@8.41.0)(typescript@5.1.6):
     resolution: {integrity: sha512-8nVpA6yX0sCjf7v/NDfeaOlyaIIqL7OaIGOWSPFqUKK59Gnumd3Wa+2l8oAaYO2lk0sO+SbWFWRSvhu8gLGv4A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -6768,7 +6768,7 @@ packages:
       '@types/semver': 7.3.13
       '@typescript-eslint/scope-manager': 5.43.0
       '@typescript-eslint/types': 5.43.0
-      '@typescript-eslint/typescript-estree': 5.43.0(typescript@4.9.3)
+      '@typescript-eslint/typescript-estree': 5.43.0(typescript@5.1.6)
       eslint: 8.41.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0(eslint@8.41.0)
@@ -14076,7 +14076,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.43.0(eslint@7.32.0)(typescript@4.9.3)
+      '@typescript-eslint/parser': 5.43.0(eslint@7.32.0)(typescript@5.1.6)
       debug: 3.2.7
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.6
@@ -14156,7 +14156,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.43.0(eslint@7.32.0)(typescript@4.9.3)
+      '@typescript-eslint/parser': 5.43.0(eslint@7.32.0)(typescript@5.1.6)
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       debug: 2.6.9(supports-color@8.1.1)
@@ -19424,7 +19424,7 @@ packages:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
     dev: true
 
-  /msw@0.48.3(typescript@4.9.3):
+  /msw@0.48.3(typescript@5.1.6):
     resolution: {integrity: sha512-8ENBcX7JVWPA5v9WTeOnCWCMOVtyBiXZyD/0+AKlhOysJRB1ZdBAcMGLIiQ2/VpQ2lC0Yd7SFKg9aviAQSVeaw==}
     engines: {node: '>=14'}
     hasBin: true
@@ -19453,7 +19453,7 @@ packages:
       path-to-regexp: 6.2.1
       strict-event-emitter: 0.2.8
       type-fest: 2.19.0
-      typescript: 4.9.3
+      typescript: 5.1.6
       yargs: 17.7.2
     transitivePeerDependencies:
       - encoding
@@ -23840,7 +23840,7 @@ packages:
   /trough@1.0.5:
     resolution: {integrity: sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==}
 
-  /ts-node@10.9.1(@types/node@18.11.9)(typescript@4.9.3):
+  /ts-node@10.9.1(@types/node@18.11.9)(typescript@5.1.6):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -23866,12 +23866,12 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 4.9.3
+      typescript: 5.1.6
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true
 
-  /ts-node@10.9.1(@types/node@18.15.13)(typescript@4.9.3):
+  /ts-node@10.9.1(@types/node@18.15.13)(typescript@5.1.6):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -23897,7 +23897,7 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 4.9.3
+      typescript: 5.1.6
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true
@@ -23931,16 +23931,6 @@ packages:
     engines: {node: '>=0.6.x'}
     dev: true
 
-  /tsutils@3.21.0(typescript@4.9.3):
-    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-    dependencies:
-      tslib: 1.14.1
-      typescript: 4.9.3
-    dev: true
-
   /tsutils@3.21.0(typescript@5.0.2):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
@@ -23949,6 +23939,16 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 5.0.2
+
+  /tsutils@3.21.0(typescript@5.1.6):
+    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
+    engines: {node: '>= 6'}
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+    dependencies:
+      tslib: 1.14.1
+      typescript: 5.1.6
+    dev: true
 
   /tty-browserify@0.0.0:
     resolution: {integrity: sha512-JVa5ijo+j/sOoHGjw0sxw734b1LhBkQ3bvUGNdxnVXDCX81Yx7TFgnZygxrIIWn23hbfTaMYLwRmAxFyDuFmIw==}
@@ -24060,16 +24060,16 @@ packages:
   /typescript-memoize@1.1.1:
     resolution: {integrity: sha512-GQ90TcKpIH4XxYTI2F98yEQYZgjNMOGPpOgdjIBhaLaWji5HPWlRnZ4AeA1hfBxtY7bCGDJsqDDHk/KaHOl5bA==}
 
-  /typescript@4.9.3:
-    resolution: {integrity: sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
-    dev: true
-
   /typescript@5.0.2:
     resolution: {integrity: sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==}
     engines: {node: '>=12.20'}
     hasBin: true
+
+  /typescript@5.1.6:
+    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: true
 
   /uc.micro@1.0.6:
     resolution: {integrity: sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==}

--- a/vendor/ember-template-imports/package.json
+++ b/vendor/ember-template-imports/package.json
@@ -85,7 +85,7 @@
     "qunit-dom": "^1.6.0",
     "release-it": "^14.2.1",
     "release-it-lerna-changelog": "^3.1.0",
-    "typescript": "^4.5.2",
+    "typescript": "^5.1.6",
     "webpack": "^5.64.4"
   },
   "engines": {


### PR DESCRIPTION
This has been a near-seamless update with the exception of the casting I commented on.

The Percy diffs are [outstanding on `main`](https://percy.io/Cardstack-1/-cardstack-host/builds/29493580), unrelated to this PR.