### PR TITLE
host: Add branch name truncation for previews

### DIFF
--- a/.github/actions/deploy-ember-preview/action.yml
+++ b/.github/actions/deploy-ember-preview/action.yml
@@ -28,7 +28,7 @@ runs:
 
     - name: Convert branch name to subdomain-compatible form
       shell: bash
-      run: echo "PR_BRANCH_NAME=`echo ${RAW_PR_BRANCH_NAME} | tr _ - | tr '[:upper:]' '[:lower:]' | sed -e 's/-$//' | sed -e 's/[^a-z0-9\-]//g'`" >> $GITHUB_ENV
+      run: echo "PR_BRANCH_NAME=`echo ${RAW_PR_BRANCH_NAME} | tr _ - | tr '[:upper:]' '[:lower:]' | sed -e 's/-$//' | sed -e 's/[^a-z0-9\-]//g' | cut -c1-60`" >> $GITHUB_ENV
 
     - name: Deploy preview
       shell: bash


### PR DESCRIPTION
This ensures the subdomain used for the preview deployment doesn’t exceed the maximum length of 63 characters, which is causing PRs [like this](https://github.com/cardstack/boxel/pull/523) to have broken previews.

You can see the truncation exercised in [this PR](https://github.com/cardstack/boxel/pull/526) which links to [this deployment](https://hosttruncate-preview-subdomains-here-are-some-extra-words-th.boxel-host-preview.stack.cards/). (The 404 indicates unrelated problems, the brokenness fixed looks like [this](https://cs-5801-when-there-are-2-stacks-that-are-from-different-realms-we.boxel-host-preview.stack.cards/).)
