### PR TITLE
Add integration test for AI modifications

### DIFF
--- a/packages/base/room.gts
+++ b/packages/base/room.gts
@@ -379,7 +379,6 @@ export class RoomCard extends Card {
         let update = false;
         if (event.content['m.relates_to']?.rel_type === 'm.replace') {
           event_id = event.content['m.relates_to'].event_id;
-          console.log('Updating', event_id);
           update = true;
         }
         if (cache.has(event_id) && !update) {
@@ -398,7 +397,7 @@ export class RoomCard extends Card {
           formattedMessage,
           index,
           attachedCard: null,
-          command: null
+          command: null,
         };
         if (event.content.msgtype === 'org.boxel.command') {
           cardArgs['command'] = event.content.command;
@@ -421,7 +420,6 @@ export class RoomCard extends Card {
             cardVersions.set(attachedCard, event.unsigned.transaction_id);
           }
         } else {
-          console.log('Setting new messages with ', event_id, cardArgs);
           newMessages.set(event_id, new MessageCard(cardArgs));
         }
 
@@ -457,6 +455,8 @@ export class RoomCard extends Card {
   static edit = class Edit extends Component<typeof this> {
     <template>
       <div>Cannot edit room card</div>
+
+
     </template>
   };
 }
@@ -569,7 +569,6 @@ interface CommandEvent extends BaseMatrixEvent {
     prev_sender?: string;
   };
 }
-
 
 interface CardMessageEvent extends BaseMatrixEvent {
   type: 'm.room.message';

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -48,6 +48,7 @@ interface CommandArgs {
 class CommandMessage extends Component<CommandArgs> {
   <template>
     <Button
+      data-test-command-apply
       {{on 'click' this.clicked}}
       {{on 'mouseenter' this.mouseEnter}}
       {{on 'mouseleave' this.mouseLeave}}

--- a/packages/host/app/components/matrix/rooms-manager.gts
+++ b/packages/host/app/components/matrix/rooms-manager.gts
@@ -296,14 +296,14 @@ export default class RoomsManager extends Component<Args> {
         continue;
       }
       let joinedMember = resource.roomCard.joinedMembers.find(
-        (m) => this.matrixService.client.getUserId() === m.userId
+        (m) => this.matrixService.userId === m.userId
       );
       if (joinedMember) {
         rooms.joined.push({ room: resource.roomCard, member: joinedMember });
         continue;
       }
       let invitedMember = resource.roomCard.invitedMembers.find(
-        (m) => this.matrixService.client.getUserId() === m.userId
+        (m) => this.matrixService.userId === m.userId
       );
       if (invitedMember) {
         rooms.invited.push({ room: resource.roomCard, member: invitedMember });

--- a/packages/host/app/components/matrix/user-profile.gts
+++ b/packages/host/app/components/matrix/user-profile.gts
@@ -99,7 +99,7 @@ export default class UserProfile extends Component {
   }
 
   private get userId() {
-    return this.matrixService.client.getUserId()!; // This component only renders when we are logged in, so we'll always have a userId
+    return this.matrixService.userId!; // This component only renders when we are logged in, so we'll always have a userId
   }
 
   private get showLoading() {

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -618,13 +618,7 @@ module('Integration | operator-mode', function (hooks) {
     assert.dom('[data-test-stack-card-index="1"]').includesText('Mango');
   });
 
-  test('it previews changes to the card in the stack', async function (assert) {
-    /*
-    Need to add:
-    * Getting a room
-    * Opening(?) a room
-    * Looking at the stuff there.
-    */
+  test('it allows chat commands to change cards in the stack', async function (assert) {
     this.owner.register('service:matrixService', MockMatrixService);
     let matrixService = (this.owner.lookup('service:matrixService') as MockMatrixService);
     matrixService.cardAPI = cardApi;
@@ -678,7 +672,6 @@ module('Integration | operator-mode', function (hooks) {
     };
     addRoomEvent(matrixService, messageObject);
 
-    // create roomcard? Set events?
     messageObject = {
       event_id: "event1",
       room_id: "testroom",
@@ -700,9 +693,17 @@ module('Integration | operator-mode', function (hooks) {
      
     };
     addRoomEvent(matrixService, messageObject);
-    //debugger;
+
+    await waitFor('[data-test-enter-room="test_a"]');
+    await click('[data-test-enter-room="test_a"]');
+
+    await waitFor('[data-test-command-apply]');
+    await click('[data-test-command-apply]');
+
     await pauseTest();
-    //await
+    await waitFor('[data-test-person="Dave"]');
+    assert.dom('[data-test-person]').hasText('Dave');
+
   });
 
   test("it doesn't change the field value if user clicks cancel in edit view", async function (assert) {

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -700,7 +700,8 @@ module('Integration | operator-mode', function (hooks) {
     await waitFor('[data-test-command-apply]');
     await click('[data-test-command-apply]');
 
-    await pauseTest();
+    // pausing here and clicking does work
+    //await pauseTest();
     await waitFor('[data-test-person="Dave"]');
     assert.dom('[data-test-person]').hasText('Dave');
 


### PR DESCRIPTION
This adds a mocked client and service for matrix, and a test that creates a room with a patch message in. 

Issues:

The test successfully navigates to the room, the room contains the right button and the waitFor and clicks of the apply button succeed. When the test is paused you can see the data has not changed, but when you manually click the button in the paused state the change succeeds.

I think there's either:

* A typo/similar I'm not spotting
* Something else I should be waiting for
* Something I'm misunderstanding about the test setup