### PR TITLE
Avoid caching card data in browsers

### DIFF
--- a/packages/runtime-common/router.ts
+++ b/packages/runtime-common/router.ts
@@ -20,7 +20,7 @@ function isHTTPMethod(method: unknown): method is Method {
   return ['GET', 'POST', 'PATCH', 'DELETE'].includes(method);
 }
 
-function extractSupportedMimeType(
+export function extractSupportedMimeType(
   rawAcceptHeader: null | string | [string]
 ): SupportedMimeType | undefined {
   if (!rawAcceptHeader) {


### PR DESCRIPTION
We are experiencing an issue where some responses from the realm server, for example the index card, get cached in the browser even when the data returned by the API changes (or better said would change if the API was actually called). This means stale data until the browser clears its cache.

Here is an example of fetching the index card: 

This keeps getting read from cache, even when the related data in the realm server changes:

<img width="945" alt="image" src="https://github.com/cardstack/boxel/assets/273660/19094c80-0c33-4ab9-bdc2-c8363a0eaf4f">

After the change, there is no caching anymore. Data is fresh from the realm index:
<img width="1006" alt="image" src="https://github.com/cardstack/boxel/assets/273660/67565920-0663-41a6-bd0f-9d4a5417615f">
