### PR TITLE
Fix stack-item header bug

### DIFF
--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -121,8 +121,8 @@ export default class OperatorModeStackItem extends Component<Signature> {
     return htmlSafe(`
       width: ${100 - invertedIndex * widthReductionPercent}%;
       z-index: ${itemsOnStackCount - invertedIndex};
-      padding-top: calc(${offsetPx}px * ${this.args.index});
-    `);
+      margin-top: calc(${offsetPx}px * ${this.args.index});
+    `); // using margin-top instead of padding-top to hide scrolled content from view
   }
 
   get isBuried() {


### PR DESCRIPTION
Previously, the scrolled content of the topmost stack item was visible above the buried stack item header.