### PR TITLE
restore shadows to buried tab headers

### DIFF
--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -496,11 +496,6 @@ export default class OperatorModeStackItem extends Component<Signature> {
         pointer-events: none;
       }
 
-      .item.buried {
-        /* prevents the buried card's box shadows from bleeding thru */
-        overflow: hidden;
-      }
-
       .card {
         position: relative;
         height: 100%;


### PR DESCRIPTION
restores shadows to buried tab headers

![image](https://github.com/cardstack/boxel/assets/61075/6dfed0c0-db65-4419-8ab4-40ba4d99c48f)
