### PR TITLE
transaction_id is not present when computing messages of a room card

### DIFF
--- a/packages/base/room.gts
+++ b/packages/base/room.gts
@@ -23,11 +23,11 @@ import {
   type CardRef,
 } from '@cardstack/runtime-common';
 
-type CardEventData = {
+type VersionData = {
   eventId: string;
   serverTimeOrigin: number;
 };
-const cardVersions = new Map<Card, CardEventData>();
+const cardVersions = new Map<Card, VersionData>();
 
 // this is so we can have triple equals equivalent room member cards
 function upsertRoomMember({

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -320,8 +320,10 @@ export default class Room extends Component<RoomArgs> {
       } else {
         let latestInstanceVer = getVersion(latestInstance)!;
         let cardVer = getVersion(card)!;
-        if (cardVer > latestInstanceVer) {
-          accumulator.set(card.id, card);
+        if (latestInstanceVer !== undefined && cardVer !== undefined) {
+          if (cardVer > latestInstanceVer) {
+            accumulator.set(card.id, card);
+          }
         }
       }
       return accumulator;


### PR DESCRIPTION
**Behaviour**
I cannot see a message pop up in my chat thread after selecting a card and clicking `send`, particularly **WITHOUT** the ai-bot. However, the messages do appear after a refresh.


https://github.com/cardstack/boxel/assets/8165111/ffa59e84-9ca1-4160-82f3-fd98547623ac



**Problem**
The issue is that when loading the base `RoomCard`, we are expecting `event.unsigned.transaction_id` to be present.  `unsigned.transaction_id` is typically is a custom data block that is imputed by client (or app service). It make sense a refresh works because the messages are loaded via `allRoomMessages` which doesn't expect `unsigned.transaction_id` to be present

In addition, you would see `currentCards=2` if you sent 2  versions of `Person` card

**Solution**
I made changes by essentially changing 

```
type VersionData = {
  eventId: string;
  serverTimeOrigin: number;
};
const cardVersions = new Map<Card, VersionData>();
```

that way we don't rely on `event.unsigned.transactio_id` which supposed to be sent by the client.

**New Behaviour**

The new behaviour is that you would see `currentCards=1` if you sent two or more versions of `Person` card in the room. I'm not sure if this is the desired outcome. 
