### PR TITLE
host: Fix test setup from scoped CSS import

### DIFF
--- a/packages/host/tests/integration/components/go-test.gts
+++ b/packages/host/tests/integration/components/go-test.gts
@@ -117,7 +117,6 @@ module('Integration | Component | go', function (hooks) {
     ) as MonacoService;
     mockOpenFiles = new OpenFiles(new CodeController());
     await realm.ready;
-    setupLoaderWithHandler(loader, realm, moduleMap);
   });
 
   setupCardLogs(


### PR DESCRIPTION
This addresses [this failure](https://github.com/cardstack/boxel/actions/runs/5892879778/job/15983164504#step:6:692) as [discussed](https://discord.com/channels/584043165066199050/900021750367129641/1141763297025204234). I approved the spurious [Percy diffs](https://percy.io/Cardstack-1/-cardstack-host/builds/29696641/changed/1646869827?browser=firefox&browser_ids=38%2C39&subcategories=unreviewed%2Cchanges_requested&viewLayout=overlay&viewMode=new&width=1280&widths=1280) that arose from me merging to `main` without new snapshots:

<img width="169" alt="host dashboard | Percy 2023-08-17 13-04-28" src="https://github.com/cardstack/boxel/assets/43280/23f7040b-0931-4a31-ac14-e3c2025bec3c">