### PR TITLE
prevent overlaid UI from overflowing outside stack item boundary

### DIFF
--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -535,6 +535,10 @@ export default class OperatorModeStackItem extends Component<Signature> {
         margin-bottom: var(--stack-card-footer-height);
       }
 
+      .card {
+        overflow: hidden;
+      }
+
       .buried .card {
         background-color: var(--boxel-200);
         grid-template-rows: var(--buried-operator-mode-header-height) auto;


### PR DESCRIPTION
BEFORE:
![image](https://github.com/cardstack/boxel/assets/61075/73717017-1f81-4d72-9183-332a651f9a4a)


AFTER:
![image](https://github.com/cardstack/boxel/assets/61075/75b989a8-60f6-49d7-9a5a-c768b3b0fa3b)

