### PR TITLE
add missing box shadows

### DIFF
--- a/packages/boxel-ui/addon/styles/variables.css
+++ b/packages/boxel-ui/addon/styles/variables.css
@@ -62,6 +62,7 @@
   --boxel-box-shadow-hover: 0 3px 10px rgb(0 0 0 / 15%);
   --boxel-outline-color: var(--boxel-blue);
   --boxel-outline: 2px solid var(--boxel-outline-color);
+  --boxel-deep-box-shadow: 0 15px 30px 0 rgba(0, 0, 0, 0.35);
 
   /* Container sizes */
   --boxel-xxs-container: 15.625rem; /* 250px */

--- a/packages/host/app/components/modal-container.gts
+++ b/packages/host/app/components/modal-container.gts
@@ -53,6 +53,7 @@ export default class ModalContainer extends Component<Signature> {
         height: 100%;
         display: grid;
         grid-template-rows: auto 1fr auto;
+        box-shadow: var(--boxel-deep-box-shadow);
       }
 
       .dialog-box__header {

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -863,6 +863,7 @@ export default class OperatorModeContainer extends Component<Signature> {
         border-radius: 50%;
         background-color: var(--boxel-light-100);
         border-color: transparent;
+        box-shadow: var(--boxel-deep-box-shadow);
       }
       .add-card-to-neighbor-stack:hover,
       .add-card-to-neighbor-stack--active {
@@ -912,7 +913,7 @@ export default class OperatorModeContainer extends Component<Signature> {
         border-radius: var(--boxel-border-radius);
         background-color: var(--boxel-light-100);
         border: solid 1px var(--boxel-border-color);
-        box-shadow: var(--boxel-box-shadow);
+        box-shadow: var(--boxel-deep-box-shadow);
       }
       .chat-btn:hover {
         --icon-color: var(--boxel-highlight);

--- a/packages/host/app/components/operator-mode/delete-modal.gts
+++ b/packages/host/app/components/operator-mode/delete-modal.gts
@@ -75,7 +75,7 @@ export default class DeleteModal extends Component<Signature> {
         padding: var(--boxel-sp-lg) var(--boxel-sp-xl) var(--boxel-sp);
         background-color: white;
         border-radius: var(--boxel-border-radius-xl);
-        box-shadow: 0 15px 30px 0 rgba(0, 0, 0, 0.35);
+        box-shadow: var(--boxel-deep-box-shadow);
       }
       .buttons {
         margin-top: var(--boxel-sp-lg);

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -515,7 +515,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
         height: 100%;
         display: grid;
         grid-template-rows: 3.5rem auto;
-        box-shadow: 0 15px 30px 0 rgb(0 0 0 / 35%);
+        box-shadow: var(--boxel-deep-box-shadow);
         pointer-events: auto;
       }
 


### PR DESCRIPTION
Adds missing box shadows to add stack buttons and card chooser dialog per the specifications in the UI design (https://linear.app/cardstack/issue/CS-5893/missing-box-shadow-for-add-stack-buttons and https://linear.app/cardstack/issue/CS-5892/missing-box-shadow-for-card-chooser-dialog). 

also creates css variable for box shadows.

added button box shadows
![Screenshot from 2023-08-18 12-45-43](https://github.com/cardstack/boxel/assets/61075/5524f1de-4df5-4063-9120-c6e4231ef1cf)

added modal box shadow
![image](https://github.com/cardstack/boxel/assets/61075/f0f7866b-2c9d-4604-97a9-9462ded79688)
