### PR TITLE
host: Add name for second snapshot in a test

### DIFF
--- a/packages/host/tests/integration/components/card-delete-test.gts
+++ b/packages/host/tests/integration/components/card-delete-test.gts
@@ -212,7 +212,9 @@ module('Integration | card-delete', function (hooks) {
         assert
           .dom(`[data-test-delete-modal="${testRealmURL}Pet/mango"]`)
           .containsText('Delete the card Mango?');
-        await percySnapshot(assert);
+        await percySnapshot(
+          'Integration | card-delete | can delete a card from the index card stack item, modal',
+        );
         await click('[data-test-confirm-delete-button]');
       },
     );


### PR DESCRIPTION
This should fix [this CI failure](https://github.com/cardstack/boxel/actions/runs/5904843764/job/16017772861?pr=547#step:6:563).