### PR TITLE
host: Add delay for Percy index card snapshot

### DIFF
--- a/packages/host/tests/acceptance/operator-mode-test.ts
+++ b/packages/host/tests/acceptance/operator-mode-test.ts
@@ -254,6 +254,9 @@ module('Acceptance | operator mode tests', function (hooks) {
       assert.dom('[data-test-operator-mode-stack]').exists();
       assert.dom('[data-test-stack-card-index="0"]').exists(); // Index card opens in the stack
 
+      await waitFor(
+        '[data-test-cards-grid-item="http://test-realm/test/Pet/mango"]',
+      );
       await percySnapshot(assert);
 
       // In the URL, operatorModeEnabled is set to true and operatorModeState is set to the current stack


### PR DESCRIPTION
This should prevent spurious diffs like [this](https://percy.io/Cardstack-1/-cardstack-host/builds/29719547/changed/1648152351?browser=firefox&browser_ids=48%2C49&subcategories=unreviewed%2Cchanges_requested&viewLayout=overlay&viewMode=new&width=1280&widths=1280). Is there a better way, like linking into the Ember test waiter system?