### PR TITLE
saveCardDocument is sending a post when it shud be a patch

### DIFF
--- a/packages/host/app/components/editor/go.gts
+++ b/packages/host/app/components/editor/go.gts
@@ -226,7 +226,13 @@ export default class Go extends Component<Signature> {
     );
 
     try {
-      await this.cardService.saveCardDocument(json, url);
+      let doc = this.cardService.reverseFileSerialization(json, url.href);
+      let card = await this.cardService.createFromSerialized(
+        doc.data,
+        doc,
+        url,
+      );
+      await this.cardService.saveModel(card);
       await this.loadCard.perform(url);
     } catch (e) {
       console.log('Failed to save single card document', e);

--- a/packages/host/app/components/editor/go.gts
+++ b/packages/host/app/components/editor/go.gts
@@ -237,8 +237,13 @@ export default class Go extends Component<Signature> {
       );
       return;
     }
-    await this.cardService.saveModel(card);
-    await this.loadCard.perform(url);
+
+    try {
+      await this.cardService.saveModel(card);
+      await this.loadCard.perform(url);
+    } catch (e) {
+      console.error('Failed to save single card document', e);
+    }
   }
 
   @cached

--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -319,4 +319,14 @@ export default class CardService extends Service {
   ) {
     this.api.subscribeToChanges(card, subscriber);
   }
+
+  reverseFileSerialization(
+    json: LooseSingleCardDocument,
+    id: string,
+  ): SingleCardDocument {
+    return {
+      ...json,
+      data: { ...json.data, id, type: json.data.type || 'card' },
+    };
+  }
 }

--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -156,10 +156,8 @@ export default class CardService extends Service {
     });
     // send doc over the wire with absolute URL's. The realm server will convert
     // to relative URL's as it serializes the cards
-    let json = await this.saveCardDocument(
-      doc,
-      card.id ? new URL(card.id) : undefined,
-    );
+    let realmUrl = await this.getRealmURL(card);
+    let json = await this.saveCardDocument(doc, realmUrl);
 
     // in order to preserve object equality with the unsaved card instance we
     // should always use updateFromSerialized()--this way a newly created
@@ -172,13 +170,12 @@ export default class CardService extends Service {
     return result;
   }
 
-  async saveCardDocument(
+  private async saveCardDocument(
     doc: LooseSingleCardDocument,
-    url?: URL,
+    realmUrl?: URL,
   ): Promise<SingleCardDocument> {
     let isSaved = !!doc.data.id;
-    url = url ?? this.defaultURL;
-    let json = await this.fetchJSON(url, {
+    let json = await this.fetchJSON(realmUrl ?? this.defaultURL, {
       method: isSaved ? 'PATCH' : 'POST',
       body: JSON.stringify(doc, null, 2),
     });


### PR DESCRIPTION

https://github.com/cardstack/boxel/assets/8165111/f43d6d7b-ab02-4843-b3e8-ced294081072





It seems that all json files opened in the editor has an ID. So we want to fetch with `doc.data.id` available
 https://github.com/cardstack/boxel/blob/5d98e0110e9ee8ff5f623dec61c9d9dc94b92b5e/packages/host/app/services/card-service.ts#L166