### PR TITLE
prevent guest mode from reloading new card

### DIFF
--- a/packages/host/app/components/preview.gts
+++ b/packages/host/app/components/preview.gts
@@ -29,3 +29,9 @@ export default class Preview extends Component<Signature> {
     );
   }
 }
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    Preview: typeof Preview;
+  }
+}

--- a/packages/host/app/controllers/card.ts
+++ b/packages/host/app/controllers/card.ts
@@ -33,14 +33,6 @@ export default class CardController extends Controller {
     });
   }
 
-  get getIsolatedComponent() {
-    if (this.model) {
-      return this.model.constructor.getComponent(this.model, 'isolated');
-    }
-
-    return null;
-  }
-
   getCards(query: Query, realms?: string[]): Search {
     return getSearchResults(
       this,

--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -25,11 +25,10 @@ import ENV from '@cardstack/host/config/environment';
 export type CardSaveSubscriber = (json: SingleCardDocument) => void;
 const { ownRealmURL } = ENV;
 
-const indexCards: Map<string, Card> = new Map();
-
 export default class CardService extends Service {
   @service declare loaderService: LoaderService;
   private subscriber: CardSaveSubscriber | undefined;
+  private indexCards: Map<string, Card> = new Map();
 
   private apiModule = importResource(
     this,
@@ -112,7 +111,7 @@ export default class CardService extends Service {
   }
 
   async loadModel(url: URL): Promise<Card> {
-    let index = indexCards.get(url.href);
+    let index = this.indexCards.get(url.href);
     if (index) {
       return index;
     }
@@ -131,7 +130,7 @@ export default class CardService extends Service {
       typeof url === 'string' ? new URL(url) : url,
     );
     if (this.isIndexCard(card)) {
-      indexCards.set(url.href, card);
+      this.indexCards.set(url.href, card);
     }
     return card;
   }

--- a/packages/host/app/templates/card.hbs
+++ b/packages/host/app/templates/card.hbs
@@ -1,5 +1,9 @@
 <div class='card-isolated-component'>
-  <this.getIsolatedComponent />
+  {{#if this.model}}
+    <Preview @card={{this.model}} @format="isolated"/>
+  {{else}}
+    <div>ERROR: cannot load card</div>
+  {{/if}}
 </div>
 
 <Editor::CodeLink />


### PR DESCRIPTION
This PR prevents the grid from having to be reinstantiated when you move into guest mode. 

previously this would happen: 
![screencast 2023-08-14 16-29-51](https://github.com/cardstack/boxel/assets/61075/5e3f738f-344c-45a1-9eb8-4d1651ee30a1)


This change caches the index card instance in the card service (as well as using our Preview component to render in guest mode) which means that we render the guest mode using the same model when we toggle back to it instead of making a whole new index card model. (the live query should take care of any underlying index updates)

This now looks like this:
![grid](https://github.com/cardstack/boxel/assets/61075/51e60fec-0d93-4e95-b831-6f6466159647)

it would be nice if when you switch back into operator mode we could see the same behavior--however, operator mode uses 4 layers of component construction that I'm unsure how to optimize (container, stack, stack-item, and preview components). but i think this is a nice halfway solution.
