### PR TITLE
Irrelevant change to trigger CI builds on main

### DIFF
--- a/packages/host/README.md
+++ b/packages/host/README.md
@@ -52,3 +52,4 @@ Specify what it takes to deploy your app.
 - Development Browser Extensions
   - [ember inspector for chrome](https://chrome.google.com/webstore/detail/ember-inspector/bmdblncegkenkacieihfhpjfppoconhi)
   - [ember inspector for firefox](https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/)
+


### PR DESCRIPTION
I'm seeing search failures in CI, but not locally, on a PR that has nothing to do with search. This is to very clearly make an irrelevant change to see if host tests fail.