### PR TITLE
host: Add Percy delay for card rendering

### DIFF
--- a/packages/host/tests/acceptance/basic-test.ts
+++ b/packages/host/tests/acceptance/basic-test.ts
@@ -252,6 +252,8 @@ module('Acceptance | basic tests', function (hooks) {
 
     // Syntax highlighting is breadth-first, this is the latest and deepest token
     await waitForSyntaxHighlighting("''", 'rgb(163, 21, 21)');
+    await waitFor('[data-test-boxel-card-container] [data-test-description]');
+
     await percySnapshot(assert);
   });
 


### PR DESCRIPTION
This should prevent spurious diffs like [this](https://percy.io/Cardstack-1/-cardstack-host/builds/29860602/changed/1654695911?browser=firefox&browser_ids=48%2C49&subcategories=unreviewed%2Cchanges_requested&viewLayout=side-by-side&viewMode=new&width=1280&widths=1280).