### PR TITLE
Fix issue where recent cards are halfway down the screen from search results in an opened SearchSheet

### DIFF
--- a/packages/host/app/components/search-sheet/index.gts
+++ b/packages/host/app/components/search-sheet/index.gts
@@ -400,11 +400,11 @@ export default class SearchSheet extends Component<Signature> {
         display: flex;
         flex-direction: column;
         width: 100%;
-        height: 100%;
       }
       .prompt .search-result-section {
         flex-direction: row;
         align-items: center;
+        height: 100%;
       }
 
       .search-result-section .boxel-label {


### PR DESCRIPTION
Before 

![image](https://github.com/cardstack/boxel/assets/353/f445086d-5b67-4fe4-9ae7-3ce7948c1eda)

After

![image](https://github.com/cardstack/boxel/assets/353/85a3f356-428f-480e-a94f-576c60b4a2a7)
