### PR TITLE
ci: Change ai-bot Dockerfile and waypoint configuration [CS-5936]

### DIFF
--- a/.github/workflows/build-host.yml
+++ b/.github/workflows/build-host.yml
@@ -26,11 +26,13 @@ jobs:
             echo "OTHER_REALM_URLS=https://realms.cardstack.com/published/" >> $GITHUB_ENV
             echo "RESOLVED_BASE_REALM_URL=https://realms.cardstack.com/base/" >> $GITHUB_ENV
             echo "MATRIX_URL=https://matrix.cardstack.com" >> $GITHUB_ENV
+            echo "EXPERIMENTAL_AI_ENABLED=true" >> $GITHUB_ENV
           elif [ "$INPUT_ENVIRONMENT" = "staging" ]; then
             echo "OWN_REALM_URL=https://realms-staging.stack.cards/drafts/" >> $GITHUB_ENV
             echo "OTHER_REALM_URLS=https://realms-staging.stack.cards/published/" >> $GITHUB_ENV
             echo "RESOLVED_BASE_REALM_URL=https://realms-staging.stack.cards/base/" >> $GITHUB_ENV
             echo "MATRIX_URL=https://matrix-staging.stack.cards" >> $GITHUB_ENV
+            echo "EXPERIMENTAL_AI_ENABLED=true" >> $GITHUB_ENV
           else
             echo "unrecognized environment"
             exit 1;

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -223,7 +223,6 @@ jobs:
 
   deploy-ai-bot:
     name: Deploy ai-bot to staging
-    if: false
     needs: [build-ai-bot]
     uses: ./.github/workflows/waypoint-deploy.yml
     secrets: inherit

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,7 +170,7 @@ jobs:
     uses: ./.github/workflows/build-host.yml
     secrets: inherit
     with:
-      environment: 'staging'
+      environment: "staging"
 
   build-realm-server:
     name: Build realm-server
@@ -179,8 +179,8 @@ jobs:
     uses: ./.github/workflows/waypoint-build.yml
     secrets: inherit
     with:
-      app: 'realm-demo'
-      environment: 'staging'
+      app: "realm-demo"
+      environment: "staging"
       restore-mtime: true
 
   build-ai-bot:
@@ -190,8 +190,9 @@ jobs:
     uses: ./.github/workflows/waypoint-build.yml
     secrets: inherit
     with:
-      app: 'boxel-ai-bot'
-      environment: 'staging'
+      app: "boxel-ai-bot"
+      environment: "staging"
+      working-directory: "packages/ai-bot"
 
   deploy-host:
     name: Deploy host
@@ -204,7 +205,7 @@ jobs:
     uses: ./.github/workflows/deploy-host.yml
     secrets: inherit
     with:
-      environment: 'staging'
+      environment: "staging"
 
   deploy-realm-server:
     name: Deploy realm server to staging
@@ -217,8 +218,8 @@ jobs:
     uses: ./.github/workflows/waypoint-deploy.yml
     secrets: inherit
     with:
-      app: 'realm-demo'
-      environment: 'staging'
+      app: "realm-demo"
+      environment: "staging"
 
   deploy-ai-bot:
     name: Deploy ai-bot to staging
@@ -227,5 +228,6 @@ jobs:
     uses: ./.github/workflows/waypoint-deploy.yml
     secrets: inherit
     with:
-      app: 'boxel-ai-bot'
-      environment: 'staging'
+      app: "boxel-ai-bot"
+      environment: "staging"
+      working-directory: "packages/ai-bot"

--- a/.github/workflows/manual-aibot.yml
+++ b/.github/workflows/manual-aibot.yml
@@ -23,7 +23,6 @@ jobs:
       working-directory: "packages/ai-bot"
 
   deploy:
-    if: false
     name: Deploy
     needs: [build]
     uses: ./.github/workflows/waypoint-deploy.yml

--- a/.github/workflows/manual-aibot.yml
+++ b/.github/workflows/manual-aibot.yml
@@ -18,14 +18,16 @@ jobs:
     uses: ./.github/workflows/waypoint-build.yml
     secrets: inherit
     with:
-      app: 'boxel-ai-bot'
+      app: "boxel-ai-bot"
       environment: ${{ inputs.environment }}
+      working-directory: "packages/ai-bot"
 
   deploy:
+    if: false
     name: Deploy
     needs: [build]
     uses: ./.github/workflows/waypoint-deploy.yml
     secrets: inherit
     with:
-      app: 'boxel-ai-bot'
+      app: "boxel-ai-bot"
       environment: ${{ inputs.environment }}

--- a/.github/workflows/manual-aibot.yml
+++ b/.github/workflows/manual-aibot.yml
@@ -31,3 +31,4 @@ jobs:
     with:
       app: "boxel-ai-bot"
       environment: ${{ inputs.environment }}
+      working-directory: "packages/ai-bot"

--- a/packages/ai-bot/Dockerfile
+++ b/packages/ai-bot/Dockerfile
@@ -1,21 +1,10 @@
-# syntax=docker/dockerfile:1
-
 FROM node:18.6.0-slim
-WORKDIR /ai-bot
-
-RUN apt-get update && apt-get install -y ca-certificates
-
+ARG CI=1
+RUN apt-get update && apt-get install -y python3 build-essential
 RUN npm install -g pnpm@8.5.1
+WORKDIR /boxel
+COPY . .
+RUN pnpm install --frozen-lockfile
 
-COPY pnpm-lock.yaml ./
-
-COPY patches/ ./patches
-COPY vendor/ ./vendor
-
-ADD . ./
-
-RUN CI=1 pnpm fetch
-RUN CI=1 pnpm install -r --offline
-
-
-CMD pnpm --filter "./packages/ai-bot" start
+WORKDIR /boxel/packages/ai-bot
+ENTRYPOINT ["pnpm", "start"]

--- a/packages/ai-bot/waypoint.hcl
+++ b/packages/ai-bot/waypoint.hcl
@@ -1,0 +1,41 @@
+project = "cardstack"
+
+app "boxel-ai-bot" {
+  build {
+    use "docker" {
+      context = "../../"
+    }
+
+    registry {
+      use "aws-ecr" {
+        region     = "us-east-1"
+        repository = "boxel-ai-bot-staging"
+        tag        = "latest"
+      }
+    }
+  }
+
+  deploy {
+    use "aws-ecs" {
+      count               = 1
+      cpu                 = 256
+      memory              = 512
+      cluster             = "staging"
+      subnets             = ["subnet-03791d3b2b429e0cf", "subnet-068197c72e4e1fad2"]
+      task_role_name      = "boxel-ai-bot-staging-ecs-task"
+      execution_role_name = "boxel-ai-bot-staging-ecs-task-execution"
+      security_group_ids  = ["sg-026f518a4e82d8a44"]
+      region              = "us-east-1"
+
+      secrets = {
+        BOXEL_AIBOT_USERNAME = "arn:aws:ssm:us-east-1:680542703984:parameter/staging/aibot/matrix/username"
+        BOXEL_AIBOT_PASSWORD = "arn:aws:ssm:us-east-1:680542703984:parameter/staging/aibot/matrix/password"
+        OPENAI_API_KEY       = "arn:aws:ssm:us-east-1:680542703984:parameter/staging/aibot/openai/apikey"
+      }
+    }
+  }
+
+  url {
+    auto_hostname = false
+  }
+}

--- a/packages/ai-bot/waypoint.hcl
+++ b/packages/ai-bot/waypoint.hcl
@@ -21,11 +21,13 @@ app "boxel-ai-bot" {
       cpu                 = 256
       memory              = 512
       cluster             = "staging"
-      subnets             = ["subnet-03791d3b2b429e0cf", "subnet-068197c72e4e1fad2"]
       task_role_name      = "boxel-ai-bot-staging-ecs-task"
       execution_role_name = "boxel-ai-bot-staging-ecs-task-execution"
       security_group_ids  = ["sg-026f518a4e82d8a44"]
       region              = "us-east-1"
+      disable_alb         = true
+
+      subnets = ["subnet-03791d3b2b429e0cf", "subnet-068197c72e4e1fad2"]
 
       secrets = {
         MATRIX_URL           = "arn:aws:ssm:us-east-1:680542703984:parameter/staging/aibot/matrix/host"

--- a/packages/ai-bot/waypoint.hcl
+++ b/packages/ai-bot/waypoint.hcl
@@ -28,6 +28,7 @@ app "boxel-ai-bot" {
       region              = "us-east-1"
 
       secrets = {
+        MATRIX_URL           = "arn:aws:ssm:us-east-1:680542703984:parameter/staging/aibot/matrix/host"
         BOXEL_AIBOT_USERNAME = "arn:aws:ssm:us-east-1:680542703984:parameter/staging/aibot/matrix/username"
         BOXEL_AIBOT_PASSWORD = "arn:aws:ssm:us-east-1:680542703984:parameter/staging/aibot/matrix/password"
         OPENAI_API_KEY       = "arn:aws:ssm:us-east-1:680542703984:parameter/staging/aibot/openai/apikey"

--- a/packages/ai-bot/waypoint.prod.hcl
+++ b/packages/ai-bot/waypoint.prod.hcl
@@ -34,6 +34,7 @@ app "boxel-ai-bot" {
       region              = "us-east-1"
 
       secrets = {
+        MATRIX_URL           = "arn:aws:ssm:us-east-1:120317779495:parameter/production/aibot/matrix/host"
         BOXEL_AIBOT_USERNAME = "arn:aws:ssm:us-east-1:120317779495:parameter/production/aibot/matrix/username"
         BOXEL_AIBOT_PASSWORD = "arn:aws:ssm:us-east-1:120317779495:parameter/production/aibot/matrix/password"
         OPENAI_API_KEY       = "arn:aws:ssm:us-east-1:120317779495:parameter/production/aibot/openai/apikey"

--- a/packages/ai-bot/waypoint.prod.hcl
+++ b/packages/ai-bot/waypoint.prod.hcl
@@ -17,21 +17,21 @@ app "boxel-ai-bot" {
 
   deploy {
     use "aws-ecs" {
-      count   = 1
-      cpu     = 256
-      memory  = 512
-      cluster = "production"
+      count               = 1
+      cpu                 = 256
+      memory              = 512
+      cluster             = "production"
+      task_role_name      = "boxel-ai-bot-production-ecs-task"
+      execution_role_name = "boxel-ai-bot-production-ecs-task-execution"
+      security_group_ids  = ["sg-0e54d5c1e42f8ef20"]
+      region              = "us-east-1"
+      disable_alb         = true
 
       subnets = [
         "subnet-0464e7c634d7d2bb8",
         "subnet-0a03d794786fca955",
         "subnet-0e7de528f9d7cd414",
       ]
-
-      task_role_name      = "boxel-ai-bot-production-ecs-task"
-      execution_role_name = "boxel-ai-bot-production-ecs-task-execution"
-      security_group_ids  = ["sg-0e54d5c1e42f8ef20"]
-      region              = "us-east-1"
 
       secrets = {
         MATRIX_URL           = "arn:aws:ssm:us-east-1:120317779495:parameter/production/aibot/matrix/host"

--- a/packages/ai-bot/waypoint.prod.hcl
+++ b/packages/ai-bot/waypoint.prod.hcl
@@ -1,0 +1,47 @@
+project = "cardstack"
+
+app "boxel-ai-bot" {
+  build {
+    use "docker" {
+      context = "../../"
+    }
+
+    registry {
+      use "aws-ecr" {
+        region     = "us-east-1"
+        repository = "boxel-ai-bot-production"
+        tag        = "latest"
+      }
+    }
+  }
+
+  deploy {
+    use "aws-ecs" {
+      count   = 1
+      cpu     = 256
+      memory  = 512
+      cluster = "production"
+
+      subnets = [
+        "subnet-0464e7c634d7d2bb8",
+        "subnet-0a03d794786fca955",
+        "subnet-0e7de528f9d7cd414",
+      ]
+
+      task_role_name      = "boxel-ai-bot-production-ecs-task"
+      execution_role_name = "boxel-ai-bot-production-ecs-task-execution"
+      security_group_ids  = ["sg-0e54d5c1e42f8ef20"]
+      region              = "us-east-1"
+
+      secrets = {
+        BOXEL_AIBOT_USERNAME = "arn:aws:ssm:us-east-1:120317779495:parameter/production/aibot/matrix/username"
+        BOXEL_AIBOT_PASSWORD = "arn:aws:ssm:us-east-1:120317779495:parameter/production/aibot/matrix/password"
+        OPENAI_API_KEY       = "arn:aws:ssm:us-east-1:120317779495:parameter/production/aibot/openai/apikey"
+      }
+    }
+  }
+
+  url {
+    auto_hostname = false
+  }
+}

--- a/waypoint.hcl
+++ b/waypoint.hcl
@@ -25,7 +25,7 @@ app "realm-demo" {
     use "aws-ecs" {
       region              = "us-east-1"
       memory              = 4096
-      cpu                 = 2048 # 2 vCPU's
+      cpu                 = 2048                                                     # 2 vCPU's
       cluster             = "realm-demo-staging"
       count               = 1
       subnets             = ["subnet-099d721ad678d073a", "subnet-0d1196fa815f3d057"]
@@ -48,51 +48,6 @@ app "realm-demo" {
     hook {
       when    = "after"
       command = ["node", "./scripts/waypoint-ecs-add-efs.mjs", "realm-demo", "realm-server-storage", "fs-07b96c537c8c42381", "fsap-05f6f7e465f171f43", "/persistent"]
-    }
-  }
-
-  url {
-    auto_hostname = false
-  }
-}
-
-
-app "boxel-ai-bot" {
-  path = "./packages/ai-bot"
-
-  build {
-    use "docker" {
-      context = "./"
-    }
-
-    registry {
-      use "aws-ecr" {
-        region     = "us-east-1"
-        repository = "boxel-ai-bot-staging"
-        tag        = "latest"
-      }
-    }
-  }
-
-  deploy {
-    use "aws-ecs" {
-      count               = 1
-      cpu                 = 256
-      memory              = 512
-      cluster             = "staging"
-      subnets             = ["subnet-03791d3b2b429e0cf", "subnet-068197c72e4e1fad2"]
-      task_role_name      = "boxel-ai-bot-staging-ecs-task"
-      execution_role_name = "boxel-ai-bot-staging-ecs-task-execution"
-      security_group_ids  = ["sg-026f518a4e82d8a44"]
-      region              = "us-east-1"
-      disable_alb         = true
-
-      secrets = {
-        MATRIX_URL           = "arn:aws:ssm:us-east-1:680542703984:parameter/staging/aibot/matrix/host"
-        BOXEL_AIBOT_USERNAME = "arn:aws:ssm:us-east-1:680542703984:parameter/staging/aibot/matrix/username"
-        BOXEL_AIBOT_PASSWORD = "arn:aws:ssm:us-east-1:680542703984:parameter/staging/aibot/matrix/password"
-        OPENAI_API_KEY       = "arn:aws:ssm:us-east-1:680542703984:parameter/staging/aibot/openai/apikey"
-      }
     }
   }
 

--- a/waypoint.prod.hcl
+++ b/waypoint.prod.hcl
@@ -25,7 +25,7 @@ app "realm-demo" {
     use "aws-ecs" {
       region              = "us-east-1"
       memory              = 4096
-      cpu                 = 2048 # 2 vCPU's
+      cpu                 = 2048                                                     # 2 vCPU's
       cluster             = "realm-demo-production"
       count               = 1
       subnets             = ["subnet-06c640c2bc3b46c6a", "subnet-0ca4ab0b29849bfff"]
@@ -48,56 +48,6 @@ app "realm-demo" {
     hook {
       when    = "after"
       command = ["node", "./scripts/waypoint-ecs-add-efs.mjs", "realm-demo", "realm-server-storage", "fs-01beb05ea57cb4894", "fsap-0e1180270a9526966", "/persistent"]
-    }
-  }
-
-  url {
-    auto_hostname = false
-  }
-}
-
-app "boxel-ai-bot" {
-  path = "./packages/ai-bot"
-
-  build {
-    use "docker" {
-      context = "./"
-    }
-    
-    registry {
-      use "aws-ecr" {
-        region     = "us-east-1"
-        repository = "boxel-ai-bot-production"
-        tag        = "latest"
-      }
-    }
-  }
-
-  deploy {
-    use "aws-ecs" {
-      count   = 1
-      cpu     = 256
-      memory  = 512
-      cluster = "production"
-      disable_alb = true
-
-      subnets = [
-        "subnet-0464e7c634d7d2bb8",
-        "subnet-0a03d794786fca955",
-        "subnet-0e7de528f9d7cd414",
-      ]
-
-      task_role_name      = "boxel-ai-bot-production-ecs-task"
-      execution_role_name = "boxel-ai-bot-production-ecs-task-execution"
-      security_group_ids  = ["sg-0e54d5c1e42f8ef20"]
-      region              = "us-east-1"
-
-      secrets = {
-        MATRIX_URL           = "arn:aws:ssm:us-east-1:120317779495:parameter/production/aibot/matrix/host"
-        BOXEL_AIBOT_USERNAME = "arn:aws:ssm:us-east-1:120317779495:parameter/production/aibot/matrix/username"
-        BOXEL_AIBOT_PASSWORD = "arn:aws:ssm:us-east-1:120317779495:parameter/production/aibot/matrix/password"
-        OPENAI_API_KEY       = "arn:aws:ssm:us-east-1:120317779495:parameter/production/aibot/openai/apikey"
-      }
     }
   }
 


### PR DESCRIPTION
This PR changes and fixes a few things:
- Move ai-bot waypoint configuration into its own file in the same directory as the package (prevent creating a big and lengthy `waypoint.hcl` with dozens of apps configurations in it)
- Update and simplify the Dockerfile (The `fetch` step and multiple copy steps are removed. They are useful for caching, but we have yet to enable caching for our docker builds)
- Enable the deploy step for `ai-bot`
- Fixes the workflows that previously prevent the build and deploy steps to work properly

Sample working workflow run: https://github.com/cardstack/boxel/actions/runs/6047796471