### PR TITLE
Toggle the arrow in the dropdown when selecting a submode

### DIFF
--- a/packages/host/app/components/submode-switcher.gts
+++ b/packages/host/app/components/submode-switcher.gts
@@ -38,7 +38,14 @@ export default class SubmodeSwitcher extends Component<Signature> {
               height='18px'
             }}
             {{capitalize @submode}}
-            <div class='arrow-icon'>
+            <div
+              class='arrow-icon'
+              data-test-submode-arrow-direction={{if
+                this.isExpanded
+                'up'
+                'down'
+              }}
+            >
               {{svgJar
                 (if this.isExpanded 'dropdown-arrow-up' 'dropdown-arrow-down')
                 width='22px'
@@ -127,12 +134,22 @@ export default class SubmodeSwitcher extends Component<Signature> {
     this.isExpanded = !this.isExpanded;
   }
 
+  @action onSubmodeSelect(submode: Submode) {
+    this.isExpanded = false;
+    this.args.onSubmodeSelect(submode);
+  }
+
   get buildMenuItems(): MenuItem[] {
     return Object.values(Submode)
       .filter((submode) => submode !== this.args.submode)
       .map((submode) =>
         menuItemFunc(
-          [capitalize(submode), () => this.args.onSubmodeSelect(submode)],
+          [
+            capitalize(submode),
+            () => {
+              this.onSubmodeSelect(submode);
+            },
+          ],
           {
             icon: this.submodeIcons[submode],
           },

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -2151,10 +2151,12 @@ module('Integration | operator-mode', function (hooks) {
 
     await click('[data-test-boxel-menu-item-text="Code"]');
     assert.dom('[data-test-submode-switcher]').hasText('Code');
+    assert.dom('[data-test-submode-arrow-direction="down"]').exists();
 
     await click('[data-test-submode-switcher] > [data-test-boxel-button]');
     await click('[data-test-boxel-menu-item-text="Interact"]');
     assert.dom('[data-test-submode-switcher]').hasText('Interact');
+    assert.dom('[data-test-submode-arrow-direction="down"]').exists();
   });
 
   test(`card url bar shows realm info of valid URL`, async function (assert) {


### PR DESCRIPTION
This fixes a bug with the arrow in the submode switcher that gets stuck on selection while it should change its direction.


Before (observe the arrow on the right):

https://github.com/cardstack/boxel/assets/273660/db228ade-2171-4309-bf25-36725bad0510

After:

https://github.com/cardstack/boxel/assets/273660/398a135d-bdb2-43dc-8ee4-36510d3bf837

