### PR TITLE
Add a specific figure for how many deployments to retain

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,7 +170,7 @@ jobs:
     uses: ./.github/workflows/build-host.yml
     secrets: inherit
     with:
-      environment: "staging"
+      environment: 'staging'
 
   build-realm-server:
     name: Build realm-server
@@ -179,8 +179,8 @@ jobs:
     uses: ./.github/workflows/waypoint-build.yml
     secrets: inherit
     with:
-      app: "realm-demo"
-      environment: "staging"
+      app: 'realm-demo'
+      environment: 'staging'
       restore-mtime: true
 
   build-ai-bot:
@@ -190,9 +190,9 @@ jobs:
     uses: ./.github/workflows/waypoint-build.yml
     secrets: inherit
     with:
-      app: "boxel-ai-bot"
-      environment: "staging"
-      working-directory: "packages/ai-bot"
+      app: 'boxel-ai-bot'
+      environment: 'staging'
+      working-directory: 'packages/ai-bot'
 
   deploy-host:
     name: Deploy host
@@ -205,7 +205,7 @@ jobs:
     uses: ./.github/workflows/deploy-host.yml
     secrets: inherit
     with:
-      environment: "staging"
+      environment: 'staging'
 
   deploy-realm-server:
     name: Deploy realm server to staging
@@ -218,8 +218,9 @@ jobs:
     uses: ./.github/workflows/waypoint-deploy.yml
     secrets: inherit
     with:
-      app: "realm-demo"
-      environment: "staging"
+      app: 'realm-demo'
+      environment: 'staging'
+      keep_previous: '1'
 
   deploy-ai-bot:
     name: Deploy ai-bot to staging
@@ -227,6 +228,7 @@ jobs:
     uses: ./.github/workflows/waypoint-deploy.yml
     secrets: inherit
     with:
-      app: "boxel-ai-bot"
-      environment: "staging"
-      working-directory: "packages/ai-bot"
+      app: 'boxel-ai-bot'
+      environment: 'staging'
+      working-directory: 'packages/ai-bot'
+      keep_previous: '0'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -220,7 +220,6 @@ jobs:
     with:
       app: 'realm-demo'
       environment: 'staging'
-      keep_previous: '1'
 
   deploy-ai-bot:
     name: Deploy ai-bot to staging
@@ -231,4 +230,4 @@ jobs:
       app: 'boxel-ai-bot'
       environment: 'staging'
       working-directory: 'packages/ai-bot'
-      keep_previous: '0'
+      retain: '0'

--- a/.github/workflows/manual-aibot.yml
+++ b/.github/workflows/manual-aibot.yml
@@ -18,9 +18,9 @@ jobs:
     uses: ./.github/workflows/waypoint-build.yml
     secrets: inherit
     with:
-      app: "boxel-ai-bot"
+      app: 'boxel-ai-bot'
       environment: ${{ inputs.environment }}
-      working-directory: "packages/ai-bot"
+      working-directory: 'packages/ai-bot'
 
   deploy:
     name: Deploy
@@ -28,6 +28,7 @@ jobs:
     uses: ./.github/workflows/waypoint-deploy.yml
     secrets: inherit
     with:
-      app: "boxel-ai-bot"
+      app: 'boxel-ai-bot'
       environment: ${{ inputs.environment }}
-      working-directory: "packages/ai-bot"
+      working-directory: 'packages/ai-bot'
+      keep_previous: '0'

--- a/.github/workflows/manual-aibot.yml
+++ b/.github/workflows/manual-aibot.yml
@@ -31,4 +31,4 @@ jobs:
       app: 'boxel-ai-bot'
       environment: ${{ inputs.environment }}
       working-directory: 'packages/ai-bot'
-      keep_previous: '0'
+      retain: '0'

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -45,3 +45,4 @@ jobs:
     with:
       app: 'realm-demo'
       environment: ${{ inputs.environment }}
+      keep_previous: '1'

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -45,4 +45,3 @@ jobs:
     with:
       app: 'realm-demo'
       environment: ${{ inputs.environment }}
-      keep_previous: '1'

--- a/.github/workflows/waypoint-deploy.yml
+++ b/.github/workflows/waypoint-deploy.yml
@@ -8,11 +8,11 @@ on:
         type: string
       retain:
         required: false
-        default: "1"
+        default: '1'
         type: string
       waypoint_version:
         required: false
-        default: "0.11.3"
+        default: '0.11.3'
         type: string
       environment:
         required: true
@@ -20,7 +20,7 @@ on:
       working-directory:
         required: false
         type: string
-        default: "."
+        default: '.'
 
 jobs:
   deploy:
@@ -62,10 +62,10 @@ jobs:
           version: ${{ inputs.waypoint_version }}
 
       - name: Deploy app
-        run: waypoint deploy -app=${{ inputs.app }} -plain -local
+        run: waypoint deploy -app=${{ inputs.app }} -plain -local -prune-retain=${{ inputs.keep_previous }}}
         working-directory: ${{ inputs.working-directory }}
         env:
-          WAYPOINT_SERVER_TLS: "1"
+          WAYPOINT_SERVER_TLS: '1'
 
       - name: Send notification to Discord
         uses: ./.github/actions/discord-notification-deploy
@@ -74,4 +74,4 @@ jobs:
           status: ${{ github.action_status }}
           environment: ${{ inputs.environment }}
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
-          is_ecs: "true"
+          is_ecs: 'true'

--- a/.github/workflows/waypoint-deploy.yml
+++ b/.github/workflows/waypoint-deploy.yml
@@ -62,7 +62,7 @@ jobs:
           version: ${{ inputs.waypoint_version }}
 
       - name: Deploy app
-        run: waypoint deploy -app=${{ inputs.app }} -plain -local -prune-retain=${{ inputs.retain }}}
+        run: waypoint deploy -app=${{ inputs.app }} -plain -local -prune-retain=${{ inputs.retain }}
         working-directory: ${{ inputs.working-directory }}
         env:
           WAYPOINT_SERVER_TLS: '1'

--- a/.github/workflows/waypoint-deploy.yml
+++ b/.github/workflows/waypoint-deploy.yml
@@ -62,7 +62,7 @@ jobs:
           version: ${{ inputs.waypoint_version }}
 
       - name: Deploy app
-        run: waypoint deploy -app=${{ inputs.app }} -plain -local -prune-retain=${{ inputs.keep_previous }}}
+        run: waypoint deploy -app=${{ inputs.app }} -plain -local -prune-retain=${{ inputs.retain }}}
         working-directory: ${{ inputs.working-directory }}
         env:
           WAYPOINT_SERVER_TLS: '1'


### PR DESCRIPTION
This is to stop there being two different aibot services running at the same time (at least in the long term, right now I'm not concerned with two overlapping for a short time or there being a gap).

Prune retain doesn't seem to be settable in the .hcl files otherwise I'd have done it there. Also if there's a syntax for optional overriding that would be good, but explicit seemed like a reasonable approach.

Side note - would be good to get the single/double quotes into the prettier config/figure out why mine is picking single quotes - with prettier enabled in vscode it's always changing the quotes.