### PR TITLE
Move into the working dir for swapping waypoint files

### DIFF
--- a/.github/workflows/waypoint-build.yml
+++ b/.github/workflows/waypoint-build.yml
@@ -52,7 +52,9 @@ jobs:
             echo "AWS_ROLE_ARN=arn:aws:iam::120317779495:role/waypoint" >> $GITHUB_ENV
             echo "WAYPOINT_SERVER_ADDR=${{ secrets.PRODUCTION_WAYPOINT_SERVER_ADDR }}" >> $GITHUB_ENV
             echo "WAYPOINT_SERVER_TOKEN=${{ secrets.PRODUCTION_WAYPOINT_SERVER_TOKEN }}" >> $GITHUB_ENV
+            cd ${{ inputs.working-directory }}
             cp waypoint.prod.hcl waypoint.hcl
+            cd -
           elif [ "$INPUT_ENVIRONMENT" = "staging" ]; then
             echo "AWS_ROLE_ARN=arn:aws:iam::680542703984:role/waypoint" >> $GITHUB_ENV
             echo "WAYPOINT_SERVER_ADDR=${{ secrets.STAGING_WAYPOINT_SERVER_ADDR }}" >> $GITHUB_ENV


### PR DESCRIPTION
Otherwise the AI bot for production uses the waypoint configuration file for staging as it's copying the one at the root dir.

Possible suggestion - we .gitignore waypoint.hcl and have explicit waypoint.staging.hcl and waypoint.prod.hcl, that way unless there's an explicit copying of a file the deployment will fail as there's no file rather than going ahead but with the wrong config.