### PR TITLE
Added missing box shadows to code mode

### DIFF
--- a/packages/boxel-ui/addon/components/resizable-panel/resizable-panel.gts
+++ b/packages/boxel-ui/addon/components/resizable-panel/resizable-panel.gts
@@ -50,8 +50,6 @@ export default class Panel extends Component<Signature> {
 
         width: var(--boxel-panel-width);
         min-width: var(--boxel-panel-min-width);
-
-        overflow: hidden;
       }
       .separator {
         display: flex;

--- a/packages/host/app/components/operator-mode/code-mode.gts
+++ b/packages/host/app/components/operator-mode/code-mode.gts
@@ -552,6 +552,7 @@ export default class CodeMode extends Component<Signature> {
         flex-direction: column;
         background-color: var(--boxel-light);
         border-radius: var(--boxel-border-radius-xl);
+        box-shadow: var(--boxel-deep-box-shadow);
         overflow: hidden;
       }
       .inner-container__header {


### PR DESCRIPTION
We are missing box shadows around the panels in code mode. according to the designs, the panels get box shadow treatments.
![Screenshot from 2023-09-07 11-58-10](https://github.com/cardstack/boxel/assets/61075/c5af8dea-5458-40bb-a74d-daf2de036219)
