### PR TITLE
Live update stack item cards

### DIFF
--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -112,6 +112,18 @@ export default class CardService extends Service {
     return card as CardDef;
   }
 
+  async reloadModel(card: CardDef): Promise<CardDef> {
+    await this.apiModule.loaded;
+    let json = await this.fetchJSON(card.id);
+    if (!isSingleCardDocument(json)) {
+      throw new Error(
+        `bug: server returned a non card document for ${card.id}:
+        ${JSON.stringify(json, null, 2)}`,
+      );
+    }
+    return await this.api.updateFromSerialized<typeof CardDef>(card, json);
+  }
+
   async loadModel(url: URL): Promise<CardDef> {
     let index = this.indexCards.get(url.href);
     if (index) {

--- a/packages/host/app/services/code-service.ts
+++ b/packages/host/app/services/code-service.ts
@@ -6,8 +6,8 @@ import window from 'ember-window-mock';
 export default class CodeService extends Service {
   @tracked recentFiles = new TrackedArray<string>([]);
 
-  constructor() {
-    super();
+  constructor(properties: object) {
+    super(properties);
 
     let recentFilesString = window.localStorage.getItem('recent-files');
 

--- a/packages/host/app/services/code-service.ts
+++ b/packages/host/app/services/code-service.ts
@@ -6,8 +6,8 @@ import window from 'ember-window-mock';
 export default class CodeService extends Service {
   @tracked recentFiles = new TrackedArray<string>([]);
 
-  constructor(properties: object) {
-    super(properties);
+  constructor() {
+    super();
 
     let recentFilesString = window.localStorage.getItem('recent-files');
 

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -80,7 +80,10 @@ export async function waitForSyntaxHighlighting(
       );
       return finalHighlightedToken;
     },
-    { timeoutMessage: `timed out waiting for \`${textContent}\` token` },
+    {
+      timeout: 10000, // need to wait for monaco to load
+      timeoutMessage: `timed out waiting for \`${textContent}\` token`,
+    },
   );
 
   await waitUntil(


### PR DESCRIPTION
This solves an issue where a card was updated in code mode, but interact mode never reflects the change since it is not paying attention to the SSE events that indicate the card has been updated.

![stack-item-live](https://github.com/cardstack/boxel/assets/61075/42c5e8d3-3f53-42c6-aa15-b1acc2ccb678)

