### PR TITLE
ui: Fix centre for loading indicator

### DIFF
--- a/packages/boxel-ui/addon/components/loading-indicator/index.gts
+++ b/packages/boxel-ui/addon/components/loading-indicator/index.gts
@@ -31,7 +31,7 @@ const LoadingIndicator: TemplateOnlyComponent<Signature> = <template>
       Only animate if the user has not said that they want reduced motion
     */
     @media (prefers-reduced-motion: no-preference) {
-      .boxel-loading-indicator {
+      .boxel-loading-indicator :deep(svg) {
         animation: spin 6000ms linear infinite;
       }
     }


### PR DESCRIPTION
Without this the loading indicator spins about a point slightly off its centre:

![screencast 2023-09-07 18-10-28](https://github.com/cardstack/boxel/assets/43280/b806f869-0671-4cc9-9c5d-f30412e1ad07)
