### PR TITLE
Accept urls in both string and object form when loading card model

### DIFF
--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -124,7 +124,11 @@ export default class CardService extends Service {
     return await this.api.updateFromSerialized<typeof CardDef>(card, json);
   }
 
-  async loadModel(url: URL): Promise<CardDef> {
+  async loadModel(url: URL | string): Promise<CardDef> {
+    if (typeof url === 'string') {
+      url = new URL(url);
+    }
+
     let index = this.indexCards.get(url.href);
     if (index) {
       return index;
@@ -138,11 +142,7 @@ export default class CardService extends Service {
         ${JSON.stringify(json, null, 2)}`,
       );
     }
-    let card = await this.createFromSerialized(
-      json.data,
-      json,
-      typeof url === 'string' ? new URL(url) : url,
-    );
+    let card = await this.createFromSerialized(json.data, json, url);
     if (this.isIndexCard(card)) {
       this.indexCards.set(url.href, card);
     }


### PR DESCRIPTION
This PR fixes a sneaky error in `loadModel` in card service. I discovered this when I was fixing a bug in code mode where the index card showed up in preview instead of some other card that I wanted it to show (more context about this bug [here](https://linear.app/cardstack/issue/CS-5971/going-to-code-mode-from-a-card-opened-on-a-stack-will-have-index-card)).

The issue was that the `cardResource` was passing a `string` type instead of `URL` type (it is unexpected to me that TypeScript allowed that), and the `loadModel` was trying to operate on `url.href` which was `undefined`. Then the logic would return the index card in that case.

My solution is to explicitly allow this method to accept both types of the URL (`string`, `URL`) and ensure that it operates on the `URL` type in its logic. 