### PR TITLE
Update linksTo field editor's add and create actions

### DIFF
--- a/packages/base/links-to-editor.gts
+++ b/packages/base/links-to-editor.gts
@@ -18,7 +18,7 @@ import {
   identifyCard,
 } from '@cardstack/runtime-common';
 import type { ComponentLike } from '@glint/template';
-import { Button, IconButton } from '@cardstack/boxel-ui';
+import { AddButton, IconButton } from '@cardstack/boxel-ui';
 
 interface Signature {
   Args: {
@@ -32,14 +32,15 @@ class LinksToEditor extends GlimmerComponent<Signature> {
   <template>
     <div class='links-to-editor'>
       {{#if this.isEmpty}}
-        <Button @size='small' {{on 'click' this.choose}} data-test-choose-card>
-          Choose
-        </Button>
-        {{#if @context.actions.createCard}}
-          <Button @size='small' {{on 'click' this.create}} data-test-create-new>
-            Create New
-          </Button>
-        {{/if}}
+        <AddButton
+          class='add-new'
+          @variant='full-width'
+          {{on 'click' this.add}}
+          data-test-add-new
+        >
+          Add
+          {{@field.card.displayName}}
+        </AddButton>
       {{else}}
         <this.linkedCard />
         <div class='remove-button-container'>
@@ -79,7 +80,7 @@ class LinksToEditor extends GlimmerComponent<Signature> {
     </style>
   </template>
 
-  choose = () => {
+  add = () => {
     (this.chooseCard as unknown as Descriptor<any, any[]>).perform();
   };
 
@@ -114,9 +115,13 @@ class LinksToEditor extends GlimmerComponent<Signature> {
 
   private chooseCard = restartableTask(async () => {
     let type = identifyCard(this.args.field.card) ?? baseCardRef;
-    let chosenCard: CardDef | undefined = this.args.context?.actions?.createCard
-      ? await chooseCard({ filter: { type } })
-      : await chooseCard({ filter: { type } }, { offerToCreate: type });
+    let chosenCard: CardDef | undefined = await chooseCard(
+      { filter: { type } },
+      {
+        offerToCreate: type,
+        createNewCard: this.args.context?.actions?.createCard,
+      },
+    );
     if (chosenCard) {
       this.args.model.value = chosenCard;
     }

--- a/packages/boxel-ui/addon/helpers/truth-helpers.ts
+++ b/packages/boxel-ui/addon/helpers/truth-helpers.ts
@@ -10,7 +10,7 @@ export function gt<T>(a: T, b: T): boolean {
   return a > b;
 }
 
-export function and<T>(...args: [T | any, T | any, ...T[]]): boolean {
+export function and<T>(...args: [T, T, ...T[]]): boolean {
   for (let i = 0; i < args.length; i++) {
     if (!args[i] || args[i] === false) {
       return false;

--- a/packages/boxel-ui/addon/helpers/truth-helpers.ts
+++ b/packages/boxel-ui/addon/helpers/truth-helpers.ts
@@ -10,7 +10,7 @@ export function gt<T>(a: T, b: T): boolean {
   return a > b;
 }
 
-export function and<T>(...args: [T, T, ...T[]]): boolean {
+export function and<T>(...args: [T | any, T | any, ...T[]]): boolean {
   for (let i = 0; i < args.length; i++) {
     if (!args[i] || args[i] === false) {
       return false;

--- a/packages/host/app/components/card-catalog/modal.gts
+++ b/packages/host/app/components/card-catalog/modal.gts
@@ -16,7 +16,7 @@ import {
 } from '@cardstack/runtime-common';
 import type { Query, Filter } from '@cardstack/runtime-common/query';
 import { Button, SearchInput } from '@cardstack/boxel-ui';
-import { and, eq, not } from '@cardstack/boxel-ui/helpers/truth-helpers';
+import { and, bool, eq, not } from '@cardstack/boxel-ui/helpers/truth-helpers';
 import { svgJar } from '@cardstack/boxel-ui/helpers/svg-jar';
 import type CardService from '../../services/card-service';
 import type LoaderService from '../../services/loader-service';
@@ -68,7 +68,7 @@ const DEFAULT_CHOOOSE_CARD_TITLE = 'Choose a Card';
 
 export default class CardCatalogModal extends Component<Signature> {
   <template>
-    {{#if (and this.state.request (not this.state.dismissModal))}}
+    {{#if (and (bool this.state.request) (not this.state.dismissModal))}}
       <ModalContainer
         @title={{this.state.chooseCardTitle}}
         @onClose={{fn this.pick undefined}}
@@ -254,7 +254,7 @@ export default class CardCatalogModal extends Component<Signature> {
     this.onSearchFieldUpdated();
   }
 
-  private resetstateState() {
+  private resetState() {
     this.state.searchKey = '';
     this.state.searchResults = this.availableRealms;
     this.state.cardURL = '';
@@ -308,13 +308,9 @@ export default class CardCatalogModal extends Component<Signature> {
 
   @action
   setSearchKey(searchKey: string) {
-    if (!this.state) {
-      return;
-    }
-
     this.state.searchKey = searchKey;
     if (!this.state.searchKey) {
-      this.resetstateState();
+      this.resetState();
     } else {
       this.debouncedSearchFieldUpdate();
     }
@@ -323,18 +319,12 @@ export default class CardCatalogModal extends Component<Signature> {
   debouncedSearchFieldUpdate = debounce(() => this.onSearchFieldUpdated(), 500);
 
   @action setCardURL(cardURL: string) {
-    if (!this.state) {
-      return;
-    }
-
     this.state.selectedCard = undefined;
     this.state.cardURL = cardURL;
   }
 
   @action setSelectedCard(card: CardDef | undefined) {
-    if (this.state) {
-      this.state.selectedCard = card;
-    }
+    this.state.selectedCard = card;
   }
 
   @action
@@ -347,7 +337,7 @@ export default class CardCatalogModal extends Component<Signature> {
   @action
   onSearchFieldUpdated() {
     if (!this.state.searchKey && !this.state.selectedRealms.length) {
-      return this.resetstateState();
+      return this.resetState();
     }
     let results: RealmCards[] = [];
     for (let { url, realmInfo, cards } of this.displayedRealms) {
@@ -365,15 +355,10 @@ export default class CardCatalogModal extends Component<Signature> {
         });
       }
     }
-    if (this.state) {
-      this.state.searchResults = results;
-    }
+    this.state.searchResults = results;
   }
 
   @action toggleSelect(card?: CardDef): void {
-    if (!this.state) {
-      return;
-    }
     this.state.cardURL = '';
     if (this.state.selectedCard?.id === card?.id) {
       this.state.selectedCard = undefined;

--- a/packages/host/tests/integration/components/card-copy-test.gts
+++ b/packages/host/tests/integration/components/card-copy-test.gts
@@ -90,14 +90,14 @@ module('Integration | card-copy', function (hooks) {
 
       let stacks = [
         leftCards.map((url) => ({
-          type: 'card' as 'card',
+          type: 'card' as const,
           id: url,
-          format: 'isolated' as 'isolated',
+          format: 'isolated' as const,
         })),
         rightCards.map((url) => ({
-          type: 'card' as 'card',
+          type: 'card' as const,
           id: url,
-          format: 'isolated' as 'isolated',
+          format: 'isolated' as const,
         })),
       ].filter((a) => a.length > 0);
       await operatorModeStateService.restore({ stacks });

--- a/packages/host/tests/integration/components/card-delete-test.gts
+++ b/packages/host/tests/integration/components/card-delete-test.gts
@@ -84,14 +84,14 @@ module('Integration | card-delete', function (hooks) {
 
       let stacks = [
         leftCards.map((url) => ({
-          type: 'card' as 'card',
+          type: 'card' as const,
           id: url,
-          format: 'isolated' as 'isolated',
+          format: 'isolated' as const,
         })),
         rightCards.map((url) => ({
-          type: 'card' as 'card',
+          type: 'card' as const,
           id: url,
-          format: 'isolated' as 'isolated',
+          format: 'isolated' as const,
         })),
       ].filter((a) => a.length > 0);
       await operatorModeStateService.restore({ stacks });

--- a/packages/host/tests/integration/components/card-editor-test.gts
+++ b/packages/host/tests/integration/components/card-editor-test.gts
@@ -363,7 +363,7 @@ module('Integration | card-editor', function (hooks) {
     assert.dom('[data-test-pet="Mango"]').containsText('Mango');
 
     await click('[data-test-remove-card]');
-    await click('[data-test-choose-card]');
+    await click('[data-test-add-new]');
     await waitFor(
       '[data-test-card-catalog-modal] [data-test-card-catalog-item]',
     );
@@ -400,10 +400,10 @@ module('Integration | card-editor', function (hooks) {
       },
     );
 
-    assert.dom('[data-test-choose-card]').exists();
+    assert.dom('[data-test-add-new]').exists();
     assert.dom('button[data-test-remove-card]').doesNotExist();
 
-    await click('[data-test-choose-card]');
+    await click('[data-test-add-new]');
     assert
       .dom('[data-test-card-catalog-modal] [data-test-boxel-header-title]')
       .containsText('Choose a Pet card');
@@ -435,13 +435,13 @@ module('Integration | card-editor', function (hooks) {
     );
 
     assert.dom('[data-test-pet="Mango"]').containsText('Mango');
-    assert.dom('[data-test-choose-card]').doesNotExist();
+    assert.dom('[data-test-add-new]').doesNotExist();
 
     await click('[data-test-remove-card]');
 
     assert.dom('[data-test-pet="Mango"]').doesNotExist();
     assert.dom('button[data-test-remove-card]').doesNotExist();
-    assert.dom('[data-test-choose-card]').exists();
+    assert.dom('[data-test-add-new]').exists();
   });
 
   test('can create a new card to populate a linksTo field', async function (assert) {
@@ -457,7 +457,7 @@ module('Integration | card-editor', function (hooks) {
       },
     );
 
-    await click('[data-test-choose-card]');
+    await click('[data-test-add-new]');
     await waitFor('[data-test-card-catalog-create-new-button]');
     await click('[data-test-card-catalog-create-new-button]');
     await waitFor('[data-test-create-new-card="Pet"]');

--- a/packages/host/tests/integration/components/catalog-entry-editor-test.gts
+++ b/packages/host/tests/integration/components/catalog-entry-editor-test.gts
@@ -804,12 +804,12 @@ module('Integration | catalog-entry-editor', function (hooks) {
     await click('[data-test-catalog-entry-publish]');
     await waitFor('[data-test-ref]');
 
-    await click('[data-test-add-new]');
+    await click('[data-test-field="lineItems"] [data-test-add-new]');
     await fillIn('[data-test-field="name"] input', 'Keyboard');
     await fillIn('[data-test-field="quantity"] input', '2');
     await fillIn('[data-test-field="price"] input', '150');
 
-    await click('[data-test-choose-card]');
+    await click('[data-test-field="vendor"] [data-test-add-new]');
     await waitFor('[data-test-card-catalog-modal]');
     await waitFor('[data-test-card-catalog-create-new-button]');
 

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -983,6 +983,13 @@ module('Integration | operator-mode', function (hooks) {
       .dom('[data-test-stack-card-index="2"] [data-test-field="authorBio"]')
       .exists();
 
+    // Update the blog post card first to trigger auto-save.
+    // This allows us to simulate a scenario where the non-top item in the card-catalog-modal stack is saved before the top item.
+    await fillIn(
+      '[data-test-stack-card-index="2"] [data-test-field="title"] [data-test-boxel-input]',
+      'Mad As a Hatter',
+    );
+
     await click(
       '[data-test-stack-card-index="2"] [data-test-field="authorBio"] [data-test-add-new]',
     );
@@ -1013,10 +1020,6 @@ module('Integration | operator-mode', function (hooks) {
       .dom('[data-test-stack-card-index="2"] [data-test-field="authorBio"]')
       .containsText('Alice Enwunder');
 
-    await fillIn(
-      '[data-test-stack-card-index="2"] [data-test-field="title"] [data-test-boxel-input]',
-      'Mad As a Hatter',
-    );
     await click('[data-test-stack-card-index="2"] [data-test-close-button]');
     await waitFor('[data-test-stack-card-index="2"]', { count: 0 });
     await waitFor(

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -973,7 +973,9 @@ module('Integration | operator-mode', function (hooks) {
       .dom('[data-test-stack-card-index="1"] [data-test-field="blogPost"]')
       .exists();
 
-    await click('[data-test-create-new]');
+    await click('[data-test-add-new]');
+    await waitFor(`[data-test-card-catalog-modal]`);
+    await click(`[data-test-card-catalog-create-new-button]`);
 
     await waitFor(`[data-test-stack-card-index="2"]`);
     assert.dom('[data-test-stack-card-index]').exists({ count: 3 });
@@ -982,8 +984,11 @@ module('Integration | operator-mode', function (hooks) {
       .exists();
 
     await click(
-      '[data-test-stack-card-index="2"] [data-test-field="authorBio"] [data-test-create-new]',
+      '[data-test-stack-card-index="2"] [data-test-field="authorBio"] [data-test-add-new]',
     );
+    await waitFor(`[data-test-card-catalog-modal]`);
+    await click(`[data-test-card-catalog-create-new-button]`);
+
     await waitFor(`[data-test-stack-card-index="3"]`);
 
     assert
@@ -1053,15 +1058,17 @@ module('Integration | operator-mode', function (hooks) {
 
     await waitFor(`[data-test-stack-card="${testRealmURL}BlogPost/1"]`);
     await click('[data-test-edit-button]');
+
     assert.dom('[data-test-field="authorBio"]').containsText('Alien Bob');
-    assert.dom('[data-test-choose-card]').doesNotExist();
-    assert.dom('[data-test-create-new]').doesNotExist();
+    assert.dom('[data-test-add-new]').doesNotExist();
 
     await click('[data-test-remove-card]');
-    assert.dom('[data-test-choose-card]').exists();
-    assert.dom('[data-test-create-new]').exists();
+    assert.dom('[data-test-add-new]').exists();
+    await click('[data-test-add-new]');
+    await waitFor(`[data-test-card-catalog-modal]`);
+    await click(`[data-test-card-catalog-create-new-button]`);
 
-    await click('[data-test-choose-card]');
+    await click('[data-test-add-new]');
     await waitFor(`[data-test-card-catalog-item="${testRealmURL}Author/2"]`);
     await click(`[data-test-select="${testRealmURL}Author/2"]`);
     assert
@@ -1097,10 +1104,9 @@ module('Integration | operator-mode', function (hooks) {
 
     await waitFor(`[data-test-stack-card="${testRealmURL}BlogPost/2"]`);
     await click('[data-test-edit-button]');
-    assert.dom('[data-test-choose-card]').exists();
-    assert.dom('[data-test-create-new]').exists();
+    assert.dom('[data-test-add-new]').exists();
 
-    await click('[data-test-choose-card]');
+    await click('[data-test-add-new]');
     await waitFor(`[data-test-card-catalog-item="${testRealmURL}Author/2"]`);
     await click(`[data-test-select="${testRealmURL}Author/2"]`);
     await click('[data-test-card-catalog-go-button]');
@@ -1129,10 +1135,11 @@ module('Integration | operator-mode', function (hooks) {
 
     await waitFor(`[data-test-stack-card="${testRealmURL}BlogPost/2"]`);
     await click('[data-test-edit-button]');
-    assert.dom('[data-test-choose-card]').exists();
-    assert.dom('[data-test-create-new]').exists();
+    assert.dom('[data-test-add-new]').exists();
 
-    await click('[data-test-create-new]');
+    await click('[data-test-add-new]');
+    await waitFor(`[data-test-card-catalog-modal]`);
+    await click(`[data-test-card-catalog-create-new-button]`);
     await waitFor('[data-test-stack-card-index="1"]');
 
     assert
@@ -1149,8 +1156,7 @@ module('Integration | operator-mode', function (hooks) {
 
     await click('[data-test-stack-card-index="1"] [data-test-close-button]');
     await waitFor('[data-test-stack-card-index="1"]', { count: 0 });
-    assert.dom('[data-test-choose-card]').doesNotExist();
-    assert.dom('[data-test-create-new]').doesNotExist();
+    assert.dom('[data-test-add-new]').doesNotExist();
     assert.dom('[data-test-field="authorBio"]').containsText('Alice');
 
     await click('[data-test-stack-card-index="0"] [data-test-edit-button]');
@@ -1526,7 +1532,6 @@ module('Integration | operator-mode', function (hooks) {
     assert.dom(`[data-test-search-label]`).containsText('Searching for "Ma"');
 
     await waitFor(`[data-test-search-sheet-search-result]`);
-    // Keep in mind that any test data created drafts or published realms will show up here too...
     assert
       .dom(`[data-test-search-result-label]`)
       .containsText('2 Results for "Ma"');
@@ -1741,7 +1746,7 @@ module('Integration | operator-mode', function (hooks) {
       `[data-test-stack-card="${testRealmURL}BlogPost/2"] [data-test-edit-button]`,
     );
     await waitFor(`[data-test-field="authorBio"]`);
-    await click('[data-test-choose-card]');
+    await click('[data-test-add-new]');
 
     await waitFor('[data-test-card-catalog-item]');
     assert
@@ -1903,7 +1908,7 @@ module('Integration | operator-mode', function (hooks) {
 
     await fillIn(`[data-test-search-input] input`, `pet`);
     assert.dom(`[data-test-search-input] input`).hasValue('pet');
-    await waitFor('[data-test-card-catalog-item]');
+    await waitFor('[data-test-card-catalog-item]', { count: 2 });
     await click(`[data-test-select="${testRealmURL}CatalogEntry/pet-room"]`);
     assert
       .dom(
@@ -1939,7 +1944,7 @@ module('Integration | operator-mode', function (hooks) {
     );
     await waitFor(`[data-test-stack-card="${testRealmURL}BlogPost/2"]`);
     await click('[data-test-edit-button]');
-    await click(`[data-test-field="authorBio"] [data-test-choose-card]`);
+    await click(`[data-test-field="authorBio"] [data-test-add-new]`);
 
     await waitFor('[data-test-card-catalog-modal]');
     await waitFor('[data-test-card-catalog-item]', { count: 3 });
@@ -1957,10 +1962,10 @@ module('Integration | operator-mode', function (hooks) {
     await waitFor('[data-test-card-catalog]', { count: 0 });
 
     assert
-      .dom(`[data-test-field="authorBio"] [data-test-choose-card]`)
+      .dom(`[data-test-field="authorBio"] [data-test-add-new]`)
       .exists('no card is chosen');
 
-    await click(`[data-test-field="authorBio"] [data-test-choose-card]`);
+    await click(`[data-test-field="authorBio"] [data-test-add-new]`);
     assert
       .dom(`[data-test-search-input] input`)
       .hasNoValue('Field picker state is reset');
@@ -2254,8 +2259,6 @@ module('Integration | operator-mode', function (hooks) {
       'keypress',
       'Enter',
     );
-
-    await waitFor('[data-test-card-url-bar-error]');
     assert.dom('[data-test-card-url-bar-error]').hasText('File is not found');
 
     await fillIn('[data-test-card-url-bar-input]', `Wrong URL`);


### PR DESCRIPTION
In this PR, I have added the `AddButton` component to the `linksTo` field, exclusively when the card is in the `edit` view. However, during the implementation process, I encountered an issue related to nesting card creations. The previous version of the `card-catalog-modal` was limited in its ability to handle multiple requests simultaneously, preventing the smooth execution of nested card creation.

To address this issue, I have proposed a solution: the introduction of a `stateStack` to the `card-catalog-modal`. This modification allows us to effectively manage nesting card creations, ensuring the handling of multiple requests.

https://github.com/cardstack/boxel/assets/12637010/64d41150-a77d-460f-9168-68feebd440a1


