### PR TITLE
host: Update preview workflow for new action API

### DIFF
--- a/.github/workflows/pr-boxel-host.yml
+++ b/.github/workflows/pr-boxel-host.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     # github.event.pull_request.head.repo.full_name == github.repository: true if pr is from the original repo, false if it's from a fork
     # github.head_ref: the branch that the pull request is from. only appears on pull_request events
-    if: github.event.pull_request.head.repo.full_name == github.repository && github.head_ref && needs.check-if-requires-preview.outputs.boxel-host-files-changed.any_modified == 'true'
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.head_ref && needs.check-if-requires-preview.outputs.boxel-host-files-changed == 'true'
     needs: check-if-requires-preview
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pr-boxel-host.yml
+++ b/.github/workflows/pr-boxel-host.yml
@@ -29,14 +29,14 @@ jobs:
         uses: tj-actions/changed-files@v39
         with:
           files: |
-            ^packages/host
+            packages/host/**
 
   deploy-host-preview-staging:
     name: Deploy a boxel-host staging preview to S3
     runs-on: ubuntu-latest
     # github.event.pull_request.head.repo.full_name == github.repository: true if pr is from the original repo, false if it's from a fork
     # github.head_ref: the branch that the pull request is from. only appears on pull_request events
-    if: github.event.pull_request.head.repo.full_name == github.repository && github.head_ref && needs.check-if-requires-preview.outputs.boxel-host-files-changed == 'true'
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.head_ref && needs.check-if-requires-preview.outputs.boxel-host-files-changed.any_modified == 'true'
     needs: check-if-requires-preview
     steps:
       - uses: actions/checkout@v3

--- a/packages/host/README.md
+++ b/packages/host/README.md
@@ -1,7 +1,7 @@
 # @cardstack/host
 
 This README outlines the details of collaborating on this Ember application.
-A short introduction of this app could easily go here.
+A short introduction of this app could easily go here. Hey!
 
 ## Prerequisites
 

--- a/packages/host/README.md
+++ b/packages/host/README.md
@@ -1,7 +1,7 @@
 # @cardstack/host
 
 This README outlines the details of collaborating on this Ember application.
-A short introduction of this app could easily go here. Hey!
+A short introduction of this app could easily go here.
 
 ## Prerequisites
 


### PR DESCRIPTION
I noticed that recent PRs in `host` were not getting preview deployments; there was an interface change in [v13](https://github.com/tj-actions/changed-files#migration-guide-) of `tj-actions/changed-files`. You can see that this worked [here](https://github.com/cardstack/boxel/actions/runs/6126572528/job/16630835776?pr=620) when I made a now-removed superfluous change in `packages/host` and previews were deployed.

The test failure in `host` is [intermittently present on `main`](https://github.com/cardstack/boxel/actions/runs/6123612939/job/16624396516#step:6:359).