### PR TITLE
Use the correct realm for the file tree and show base realm image assets

### DIFF
--- a/packages/base/.realm.json
+++ b/packages/base/.realm.json
@@ -1,3 +1,5 @@
 {
-  "name": "Base Workspace"
+  "name": "Base Workspace",
+  "backgroundURL": "https://images.unsplash.com/photo-1560780552-ba54683cb263",
+  "iconURL": "https://i.postimg.cc/d0B9qMvy/icon.png"
 }

--- a/packages/host/app/components/operator-mode/code-mode.gts
+++ b/packages/host/app/components/operator-mode/code-mode.gts
@@ -4,7 +4,6 @@ import { service } from '@ember/service';
 import { action } from '@ember/object';
 import MonacoService from '@cardstack/host/services/monaco-service';
 import { htmlSafe } from '@ember/template';
-import ENV from '@cardstack/host/config/environment';
 import FileTree from '../editor/file-tree';
 import { eq } from '@cardstack/boxel-ui/helpers/truth-helpers';
 import { on } from '@ember/modifier';
@@ -36,7 +35,6 @@ import { task, restartableTask, timeout } from 'ember-concurrency';
 import perform from 'ember-concurrency/helpers/perform';
 import { registerDestructor } from '@ember/destroyable';
 import CardURLBar from '@cardstack/host/components/operator-mode/card-url-bar';
-const { ownRealmURL } = ENV;
 import CardPreviewPanel from '@cardstack/host/components/operator-mode/card-preview-panel';
 import { CardDef } from 'https://cardstack.com/base/card-api';
 import { use, resource } from 'ember-resources';
@@ -454,19 +452,21 @@ export default class CodeMode extends Component<Signature> {
                   File Browser</button>
               </header>
               <section class='inner-container__content'>
-                {{#if (eq this.fileView 'inheritance')}}
-                  <section class='inner-container__content'>
-                    <CardInheritancePanel
-                      @cardInstance={{this.cardResource.value}}
-                      @openFile={{this.openFile}}
-                      @realmInfo={{this.realmInfo}}
-                      @realmIconURL={{this.realmIconURL}}
-                      @importedModule={{this.importedModule}}
-                      data-test-card-inheritance-panel
-                    />
-                  </section>
-                {{else}}
-                  <FileTree @url={{ownRealmURL}} />
+                {{#if this.isReady}}
+                  {{#if (eq this.fileView 'inheritance')}}
+                    <section class='inner-container__content'>
+                      <CardInheritancePanel
+                        @cardInstance={{this.cardResource.value}}
+                        @openFile={{this.openFile}}
+                        @realmInfo={{this.realmInfo}}
+                        @realmIconURL={{this.realmIconURL}}
+                        @importedModule={{this.importedModule}}
+                        data-test-card-inheritance-panel
+                      />
+                    </section>
+                  {{else}}
+                    <FileTree @url={{this.readyFile.realmURL}} />
+                  {{/if}}
                 {{/if}}
               </section>
             </div>

--- a/packages/host/app/resources/file.ts
+++ b/packages/host/app/resources/file.ts
@@ -36,7 +36,7 @@ export interface Ready {
   name: string;
   url: string;
   lastModified: string | undefined;
-  realmURL: string | undefined;
+  realmURL: string;
   write(content: string, flushLoader?: boolean): void;
 }
 

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { visit, click, waitFor } from '@ember/test-helpers';
+import { visit, click, waitFor, find, waitUntil } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { baseRealm } from '@cardstack/runtime-common';
 import {
@@ -137,21 +137,22 @@ module('Acceptance | code mode tests', function (hooks) {
   });
 
   test('defaults to inheritance view and can toggle to file view', async function (assert) {
-    let codeModeStateParam = stringify({
+    let operatorModeStateParam = stringify({
       stacks: [
         [
           {
-            id: 'http://test-realm/test/index',
+            id: 'http://test-realm/test/Person/1',
             format: 'isolated',
           },
         ],
       ],
       submode: 'code',
+      codePath: `http://test-realm/test/Person/1.json`,
     })!;
 
     await visit(
       `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
-        codeModeStateParam,
+        operatorModeStateParam,
       )}`,
     );
 
@@ -160,6 +161,8 @@ module('Acceptance | code mode tests', function (hooks) {
       .hasAttribute('aria-label', 'Inheritance');
     assert.dom('[data-test-inheritance-toggle]').hasClass('active');
     assert.dom('[data-test-file-browser-toggle]').doesNotHaveClass('active');
+
+    await waitUntil(() => find('[data-test-card-inheritance-panel]'));
 
     assert.dom('[data-test-card-inheritance-panel]').exists();
     assert.dom('[data-test-file]').doesNotExist();
@@ -183,13 +186,14 @@ module('Acceptance | code mode tests', function (hooks) {
       stacks: [
         [
           {
-            id: 'http://test-realm/test/index',
+            id: 'http://test-realm/test/Person/1',
             format: 'isolated',
           },
         ],
       ],
       submode: 'code',
       fileView: 'browser',
+      codePath: `http://test-realm/test/Person/1.json`,
     })!;
 
     await visit(
@@ -197,6 +201,7 @@ module('Acceptance | code mode tests', function (hooks) {
         codeModeStateParam,
       )}`,
     );
+
     await waitFor('[data-test-file]');
 
     assert
@@ -226,12 +231,14 @@ module('Acceptance | code mode tests', function (hooks) {
       stacks: [
         [
           {
-            id: 'http://test-realm/test/index',
+            id: 'http://test-realm/test/Person/1',
             format: 'isolated',
           },
         ],
       ],
       submode: 'code',
+      fileView: 'browser',
+      codePath: `http://test-realm/test/Person/1.json`,
     })!;
 
     await visit(
@@ -239,11 +246,12 @@ module('Acceptance | code mode tests', function (hooks) {
         codeModeStateParam,
       )}`,
     );
-    await click('[data-test-file-browser-toggle]');
-    await waitFor('[data-test-file]');
+
+    await waitFor('[data-test-file="person.gts"]');
 
     await click('[data-test-file="person.gts"]');
 
+    await waitFor('[data-test-file="person.gts"]');
     assert.dom('[data-test-file="person.gts"]').hasClass('selected');
 
     await click('[data-test-directory="Person/"]');
@@ -257,13 +265,14 @@ module('Acceptance | code mode tests', function (hooks) {
       stacks: [
         [
           {
-            id: 'http://test-realm/test/index',
+            id: 'http://test-realm/test/Person/1',
             format: 'isolated',
           },
         ],
       ],
       submode: 'code',
       fileView: 'browser',
+      codePath: `http://test-realm/test/Person/1.json`,
       openDirs: ['Person/'],
     })!;
 


### PR DESCRIPTION
Previously, the code mode for a file from a base realm was showing no background, broken icon and incorrect file list:

<img width="1267" alt="image" src="https://github.com/cardstack/boxel/assets/273660/a7fa1544-3470-4da3-963e-83f83e8418b7">

This adds the background and the icon, and shows the file tree related to the file's realm:

<img width="773" alt="image" src="https://github.com/cardstack/boxel/assets/273660/d042ba54-2cb9-4d2c-8cd7-ffde6e9e444c">

<img width="635" alt="image" src="https://github.com/cardstack/boxel/assets/273660/d3f3a16c-70f1-40ba-9195-cb56e3a55140">

