### PR TITLE
Added more resilience for card errors in matrix rooms

### DIFF
--- a/packages/base/room.gts
+++ b/packages/base/room.gts
@@ -343,7 +343,10 @@ export class RoomField extends FieldDef {
   static getAttachedCard(id: string) {
     return attachedCards.get(id);
   }
-  static setAttachedCard(id: string, cardPromise: Promise<CardDef>) {
+  static setAttachedCard(
+    id: string,
+    cardPromise: Promise<CardDef | MatrixCardError>,
+  ) {
     attachedCards.set(id, cardPromise);
   }
 

--- a/packages/base/room.gts
+++ b/packages/base/room.gts
@@ -23,12 +23,14 @@ import {
   Loader,
   SupportedMimeType,
   Deferred,
+  isMatrixCardError,
   type LooseSingleCardDocument,
   type SingleCardDocument,
   type CodeRef,
+  type MatrixCardError,
 } from '@cardstack/runtime-common';
 
-const attachedCards = new Map<string, Promise<CardDef>>();
+const attachedCards = new Map<string, Promise<CardDef | MatrixCardError>>();
 
 // this is so we can have triple equals equivalent room member cards
 function upsertRoomMember({
@@ -186,12 +188,27 @@ class EmbeddedMessageField extends Component<typeof MessageField> {
       {{{@model.formattedMessage}}}
 
       {{#if this.attachedCard}}
-        <this.cardComponent />
+        {{#if this.cardError}}
+          <div data-test-card-error class='error'>
+            Error: cannot render card
+            {{this.cardError.id}}:
+            {{this.cardError.error.message}}
+          </div>
+        {{else}}
+          <this.cardComponent />
+        {{/if}}
       {{/if}}
     </BoxelMessage>
+
+    <style>
+      .error {
+        color: var(--boxel-danger);
+        font-weight: 'bold';
+      }
+    </style>
   </template>
 
-  @tracked attachedCard: CardDef | undefined;
+  @tracked attachedCard: CardDef | MatrixCardError | undefined;
 
   constructor(owner: unknown, args: any) {
     super(owner, args);
@@ -206,13 +223,20 @@ class EmbeddedMessageField extends Component<typeof MessageField> {
   }
 
   get cardComponent() {
-    if (!this.attachedCard) {
+    if (!this.attachedCard || isMatrixCardError(this.attachedCard)) {
       return;
     }
     return this.attachedCard.constructor.getComponent(
       this.attachedCard,
       'isolated',
     );
+  }
+
+  get cardError() {
+    if (isMatrixCardError(this.attachedCard)) {
+      return this.attachedCard;
+    }
+    return;
   }
 
   loadAttachedCard = restartableTask(async () => {
@@ -224,30 +248,44 @@ class EmbeddedMessageField extends Component<typeof MessageField> {
       this.attachedCard = await cached;
       return;
     }
-    let deferred = new Deferred<CardDef>();
+    let deferred = new Deferred<CardDef | MatrixCardError>();
     attachedCards.set(this.args.model.attachedCardId, deferred.promise);
-    let response = await fetch(this.args.model.attachedCardId, {
-      headers: { Accept: SupportedMimeType.CardJson },
-    });
-    if (!response.ok) {
-      throw new Error(
-        `status: ${response.status} -
+    let cardOrError: CardDef | MatrixCardError;
+    let doc: SingleCardDocument | undefined;
+    try {
+      let response = await fetch(this.args.model.attachedCardId, {
+        headers: { Accept: SupportedMimeType.CardJson },
+      });
+      if (!response.ok) {
+        throw new Error(
+          `status: ${response.status} -
         ${response.statusText}. ${await response.text()}`,
+        );
+      }
+      doc = await response.json();
+      if (!doc) {
+        throw new Error(
+          `No document exists for ${this.args.model.attachedCardId}`,
+        );
+      }
+      let loader = Loader.getLoaderFor(createFromSerialized);
+      if (!loader) {
+        throw new Error('Could not obtain a loader');
+      }
+      cardOrError = await createFromSerialized<typeof CardDef>(
+        doc.data,
+        doc,
+        new URL(doc.data.id),
+        loader,
       );
+    } catch (error: any) {
+      cardOrError = {
+        id: this.args.model.attachedCardId,
+        error,
+      } as MatrixCardError;
     }
-    let doc: SingleCardDocument = await response.json();
-    let loader = Loader.getLoaderFor(createFromSerialized);
-    if (!loader) {
-      throw new Error('Could not obtain a loader');
-    }
-    let card = await createFromSerialized<typeof CardDef>(
-      doc.data,
-      doc,
-      new URL(doc.data.id),
-      loader,
-    );
-    this.attachedCard = card;
-    deferred.fulfill(card);
+    this.attachedCard = cardOrError;
+    deferred.fulfill(cardOrError);
   });
 }
 

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -15,6 +15,7 @@ import {
 import { getRoom } from '../../resources/room';
 import { TrackedMap } from 'tracked-built-ins';
 import {
+  isMatrixCardError,
   chooseCard,
   baseCardRef,
   catalogEntryRef,
@@ -84,7 +85,17 @@ export default class Room extends Component<RoomArgs> {
     {{/if}}
 
     {{#if this.objective}}
-      <div class='room__objective'> <this.objectiveComponent /> </div>
+      <div class='room__objective'>
+        {{#if this.objectiveError}}
+          <div data-test-objective-error class='error'>
+            Error: cannot render card
+            {{this.objectiveError.id}}:
+            {{this.objectiveError.error.message}}
+          </div>
+        {{else}}
+          <this.objectiveComponent />
+        {{/if}}
+      </div>
     {{/if}}
 
     <div
@@ -262,6 +273,11 @@ export default class Room extends Component<RoomArgs> {
       .invite-btn {
         margin-top: var(--boxel-sp-xs);
       }
+
+      .error {
+        color: var(--boxel-danger);
+        font-weight: 'bold';
+      }
     </style>
   </template>
 
@@ -297,6 +313,13 @@ export default class Room extends Component<RoomArgs> {
 
   private get objective() {
     return this.matrixService.roomObjectives.get(this.args.roomId);
+  }
+
+  private get objectiveError() {
+    if (isMatrixCardError(this.objective)) {
+      return this.objective;
+    }
+    return;
   }
 
   private patchCard = (cardId: string, attributes: any) => {
@@ -350,7 +373,7 @@ export default class Room extends Component<RoomArgs> {
   }
 
   private get objectiveComponent() {
-    if (this.objective) {
+    if (this.objective && !isMatrixCardError(this.objective)) {
       return this.objective.constructor.getComponent(
         this.objective,
         'embedded',

--- a/packages/host/app/lib/matrix-handlers/index.ts
+++ b/packages/host/app/lib/matrix-handlers/index.ts
@@ -11,7 +11,12 @@ import type {
 } from 'https://cardstack.com/base/room';
 import type { RoomObjectiveField } from 'https://cardstack.com/base/room-objective';
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
-import { type LooseCardResource, baseRealm } from '@cardstack/runtime-common';
+import {
+  type LooseCardResource,
+  type MatrixCardError,
+  baseRealm,
+  isMatrixCardError,
+} from '@cardstack/runtime-common';
 import type LoaderService from '../../services/loader-service';
 
 export * as Membership from './membership';
@@ -40,7 +45,7 @@ export interface EventSendingContext {
 }
 
 export interface Context extends EventSendingContext {
-  roomObjectives: Map<string, RoomObjectiveField>;
+  roomObjectives: Map<string, RoomObjectiveField | MatrixCardError>;
   flushTimeline: Promise<void> | undefined;
   flushMembership: Promise<void> | undefined;
   roomMembershipQueue: { event: MatrixEvent; member: RoomMember }[];
@@ -106,7 +111,7 @@ export async function addRoomEvent(context: EventSendingContext, event: Event) {
 export async function recomputeRoomObjective(context: Context, roomId: string) {
   let room = await context.rooms.get(roomId);
   let objective = context.roomObjectives.get(roomId);
-  if (objective && room) {
+  if (objective && room && !isMatrixCardError(objective)) {
     objective.room = room;
   }
 }

--- a/packages/host/app/resources/attached-cards.ts
+++ b/packages/host/app/resources/attached-cards.ts
@@ -5,6 +5,7 @@ import { service } from '@ember/service';
 import type CardService from '../services/card-service';
 import { type RoomField } from 'https://cardstack.com/base/room';
 import type { CardDef } from 'https://cardstack.com/base/card-api';
+import { MatrixCardError } from '@cardstack/runtime-common';
 
 interface Args {
   named: { room: RoomField | undefined; ids: string[] };
@@ -12,7 +13,7 @@ interface Args {
 
 export class AttachedCards extends Resource<Args> {
   @service declare cardService: CardService;
-  @tracked instances: CardDef[] = [];
+  @tracked instances: (CardDef | MatrixCardError)[] = [];
 
   modify(_positional: never[], named: Args['named']) {
     let { room, ids } = named;
@@ -27,7 +28,7 @@ export class AttachedCards extends Resource<Args> {
       }
       let RoomFieldClazz = Reflect.getPrototypeOf(room)!
         .constructor as typeof RoomField;
-      let pendingCards: Promise<CardDef>[] = [];
+      let pendingCards: Promise<CardDef | MatrixCardError>[] = [];
       for (let id of ids) {
         let pendingCard = RoomFieldClazz.getAttachedCard(id);
         if (!pendingCard) {

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -19,6 +19,7 @@ import ENV from '@cardstack/host/config/environment';
 import {
   type LooseSingleCardDocument,
   type CodeRef,
+  type MatrixCardError,
   sanitizeHtml,
 } from '@cardstack/runtime-common';
 import type LoaderService from './loader-service';
@@ -42,7 +43,8 @@ export default class MatrixService extends Service {
   @tracked private _client: MatrixClient | undefined;
 
   rooms: TrackedMap<string, Promise<RoomField>> = new TrackedMap();
-  roomObjectives: TrackedMap<string, RoomObjectiveField> = new TrackedMap();
+  roomObjectives: TrackedMap<string, RoomObjectiveField | MatrixCardError> =
+    new TrackedMap();
   flushTimeline: Promise<void> | undefined;
   flushMembership: Promise<void> | undefined;
   roomMembershipQueue: { event: MatrixEvent; member: RoomMember }[] = [];

--- a/packages/host/tests/helpers/mock-matrix-service.ts
+++ b/packages/host/tests/helpers/mock-matrix-service.ts
@@ -4,6 +4,7 @@ import { addRoomEvent } from '@cardstack/host/lib/matrix-handlers';
 import type LoaderService from '@cardstack/host/services/loader-service';
 import type { RoomField } from 'https://cardstack.com/base/room';
 import type { RoomObjectiveField } from 'https://cardstack.com/base/room-objective';
+import { type MatrixCardError } from '@cardstack/runtime-common';
 
 let cardApi: typeof import('https://cardstack.com/base/card-api');
 
@@ -21,7 +22,8 @@ export class MockMatrixService extends Service {
   cardAPI!: typeof cardApi;
   // These will be empty in the tests, but we need to define them to satisfy the interface
   rooms: TrackedMap<string, Promise<RoomField>> = new TrackedMap();
-  roomObjectives: TrackedMap<string, RoomObjectiveField> = new TrackedMap();
+  roomObjectives: TrackedMap<string, RoomObjectiveField | MatrixCardError> =
+    new TrackedMap();
 
   async start(_auth?: any) {}
 

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -752,6 +752,104 @@ module('Integration | operator-mode', function (hooks) {
     assert.dom('[data-test-person]').hasText('Fadhlan');
   });
 
+  test('it can handle an error in a card attached to a matrix message', async function (assert) {
+    this.owner.register('service:matrixService', MockMatrixService);
+    let matrixService = this.owner.lookup(
+      'service:matrixService',
+    ) as MockMatrixService;
+    matrixService.cardAPI = cardApi;
+    await setCardInOperatorModeState(`${testRealmURL}Person/fadhlan`);
+    let operatorModeStateService = this.owner.lookup(
+      'service:operator-mode-state-service',
+    ) as OperatorModeStateService;
+
+    await operatorModeStateService.restore({
+      stacks: [[]],
+    });
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template>
+          <OperatorMode @onClose={{noop}} />
+          <CardPrerender />
+        </template>
+      },
+    );
+
+    await click('[data-test-open-chat]');
+    matrixService.createAndJoinRoom('testroom');
+    addRoomEvent(matrixService, {
+      event_id: 'event1',
+      room_id: 'testroom',
+      state_key: 'state',
+      type: 'm.room.message',
+      origin_server_ts: Date.now(),
+      content: {
+        body: 'card with error',
+        formatted_body: 'card with error',
+        msgtype: 'org.boxel.card',
+        instance: {
+          data: {
+            id: 'http://this-is-not-a-real-card.com',
+            type: 'card',
+            attributes: {
+              firstName: 'Boom',
+            },
+            meta: {
+              adoptsFrom: {
+                module: 'http://not-a-real-card.com',
+                name: 'Boom',
+              },
+            },
+          },
+        },
+      },
+    });
+    await waitFor('[data-test-enter-room="test_a"]');
+    await click('[data-test-enter-room="test_a"]');
+    await waitFor('[data-test-card-error]');
+    assert
+      .dom('[data-test-card-error]')
+      .hasText(
+        'Error: cannot render card http://this-is-not-a-real-card.com: Failed to fetch',
+      );
+  });
+
+  test('it can handle an error in a room objective card', async function (assert) {
+    this.owner.register('service:matrixService', MockMatrixService);
+    let matrixService = this.owner.lookup(
+      'service:matrixService',
+    ) as MockMatrixService;
+    matrixService.roomObjectives.set('testroom', {
+      error: new Error('error rendering room objective'),
+    });
+    matrixService.cardAPI = cardApi;
+    await setCardInOperatorModeState(`${testRealmURL}Person/fadhlan`);
+    let operatorModeStateService = this.owner.lookup(
+      'service:operator-mode-state-service',
+    ) as OperatorModeStateService;
+
+    await operatorModeStateService.restore({
+      stacks: [[]],
+    });
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template>
+          <OperatorMode @onClose={{noop}} />
+          <CardPrerender />
+        </template>
+      },
+    );
+
+    await click('[data-test-open-chat]');
+    matrixService.createAndJoinRoom('testroom');
+    await waitFor('[data-test-enter-room="test_a"]');
+    await click('[data-test-enter-room="test_a"]');
+    await waitFor('[data-test-objective-error]');
+    assert
+      .dom('[data-test-objective-error]')
+      .hasText('Error: cannot render card : error rendering room objective');
+  });
+
   test('it loads a card and renders its isolated view', async function (assert) {
     await setCardInOperatorModeState(`${testRealmURL}Person/fadhlan`);
     await renderComponent(

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -105,6 +105,21 @@ export const maxLinkDepth = 5;
 export const assetsDir = '__boxel/';
 export const boxelUIAssetsDir = '@cardstack/boxel-ui/';
 
+export interface MatrixCardError {
+  id?: string;
+  error: Error;
+}
+
+export function isMatrixCardError(
+  maybeError: any,
+): maybeError is MatrixCardError {
+  return (
+    typeof maybeError === 'object' &&
+    'error' in maybeError &&
+    maybeError.error instanceof Error
+  );
+}
+
 export type CreateNewCard = (
   ref: CodeRef,
   relativeTo: URL | undefined,


### PR DESCRIPTION
This handles the situation where we run into an error running  a card in a matrix room. instead of just throwing with an uncaught error, we'll show a message that the card was not able to be rendered and continue rendering other messages in the room.