### PR TITLE
Use the correct realm url when opening a file from the file browser in code mode

### DIFF
--- a/packages/host/app/components/editor/directory.gts
+++ b/packages/host/app/components/editor/directory.gts
@@ -130,9 +130,7 @@ export default class Directory extends Component<Args> {
 
   @action
   openFile(entryPath: LocalPath) {
-    let fileUrl = new RealmPaths(this.cardService.defaultURL).fileURL(
-      entryPath,
-    );
+    let fileUrl = new RealmPaths(this.args.realmURL).fileURL(entryPath);
     this.operatorModeStateService.updateCodePath(fileUrl);
   }
 


### PR DESCRIPTION
This fixes a bug where if for example a base realm file is opened, and you click on another file in the file browser, it will attempt to load the file from an incorrect realm. 

Here is how the bug looks like: 

Viewing a base realm file
<img width="707" alt="image" src="https://github.com/cardstack/boxel/assets/273660/624616da-49ec-4e27-bbd8-166d8d883700">

After clicking on another file in base realm file browser - it will try to open it in drafts realm which is wrong:
<img width="801" alt="image" src="https://github.com/cardstack/boxel/assets/273660/a69e451f-edda-4674-b169-b8d5f76cc222">

After the fix, the file will open in the correct realm, without errors. 
