### PR TITLE
prevent UI from scrolling up when chat room open

### DIFF
--- a/packages/host/app/components/search-sheet/index.gts
+++ b/packages/host/app/components/search-sheet/index.gts
@@ -336,6 +336,10 @@ export default class SearchSheet extends Component<Signature> {
         width: var(--search-sheet-closed-width);
       }
 
+      .search-sheet.closed .search-sheet-content {
+        display: none;
+      }
+
       .prompt {
         height: var(--search-sheet-prompt-height);
       }


### PR DESCRIPTION
This prevents the UI from scrolling up when the chat room is open (screenshot below of this bug).  

This issue stems from the `.scrollIntoView()` that we use to show the last chat item. This is a native browser API. The quirk with it is that it doesn't respect `overflow:hidden`, so if a DOM item is potentially scrollable, the browser will scroll it even if it has an `overflow:hidden` style. The DOM item that is being scrolled in this case the is operator mode `<dialog>` element (you can see this by changing it's `overflow:hidden` to `overflow:auto`. In this case the search sheet result content was is actually effecting the DOM geometry when the search sheet is closed. Instead of relying on `overflow:hidden` to not show these result, I'm actually using `display:none` to hide the results which prevent the non-displayed search results from effecting the geometry of its DOM ancestors

![image](https://github.com/cardstack/boxel/assets/61075/c8dff455-cd08-4ffd-a7c2-da5e6bf13b60)
