### PR TITLE
host: Add test report and failure checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,6 +94,11 @@ jobs:
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_HOST }}
         working-directory: packages/host
+      - name: Publish test results
+        uses: EnricoMi/publish-unit-test-result-action@v2.9.0
+        if: always()
+        with:
+          junit_files: junit/host.xml
 
   matrix-client-test:
     name: Matrix Client Tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,8 +6,10 @@ on:
   pull_request:
 
 permissions:
+  checks: write
   contents: read
   id-token: write
+  pull-requests: write
 
 jobs:
   lint:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 *.log
 .tmp
 .dist
+/junit

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -142,6 +142,8 @@
     "safe-stable-stringify": "^2.4.3",
     "start-server-and-test": "^1.14.0",
     "stream-browserify": "^3.0.0",
+    "testem": "3.10.1",
+    "testem-multi-reporter": "^1.2.0",
     "tracked-built-ins": "^3.1.1",
     "typescript": "^5.1.6",
     "webpack": "^5.78.0"

--- a/packages/host/testem.js
+++ b/packages/host/testem.js
@@ -1,6 +1,11 @@
 'use strict';
 
-module.exports = {
+const MultiReporter = require('testem-multi-reporter');
+const TapReporter = require('testem/lib/reporters/tap_reporter');
+const XunitReporter = require('testem/lib/reporters/xunit_reporter');
+const fs = require('fs');
+
+const config = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
   launch_in_ci: ['Chrome'],
@@ -21,3 +26,28 @@ module.exports = {
     },
   },
 };
+
+if (process.env.CI) {
+  fs.mkdirSync('../../junit');
+
+  const reporters = [
+    {
+      ReporterClass: TapReporter,
+      args: [false, null, { get: () => false }],
+    },
+    {
+      ReporterClass: XunitReporter,
+      args: [
+        false,
+        fs.createWriteStream('../../junit/host.xml'),
+        { get: () => false },
+      ],
+    },
+  ];
+
+  const multiReporter = new MultiReporter({ reporters });
+
+  config.reporter = multiReporter;
+}
+
+module.exports = config;

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -1,4 +1,4 @@
-import { module, test, todo } from 'qunit';
+import { module, skip, test } from 'qunit';
 import { visit, click, waitFor, waitUntil, find } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { baseRealm } from '@cardstack/runtime-common';
@@ -293,7 +293,7 @@ module('Acceptance | code mode tests', function (hooks) {
     assert.dom('[data-test-directory="Person/"] .icon').hasClass('open');
   });
 
-  todo('recent file links are shown', async function (assert) {
+  skip('recent file links are shown', async function (assert) {
     let otherRealmCardUrl = 'http://example.com/other-realm-card.json';
     window.localStorage.setItem(
       'recent-files',

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -291,6 +291,8 @@ module('Acceptance | code mode tests', function (hooks) {
     await waitFor('[data-test-file]');
 
     assert.dom('[data-test-directory="Person/"] .icon').hasClass('open');
+
+    assert.ok(false, 'this should fail');
   });
 
   todo('recent file links are shown', async function (assert) {

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -291,8 +291,6 @@ module('Acceptance | code mode tests', function (hooks) {
     await waitFor('[data-test-file]');
 
     assert.dom('[data-test-directory="Person/"] .icon').hasClass('open');
-
-    assert.ok(false, 'this should fail');
   });
 
   todo('recent file links are shown', async function (assert) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1213,6 +1213,12 @@ importers:
       stream-browserify:
         specifier: ^3.0.0
         version: 3.0.0
+      testem:
+        specifier: 3.10.1
+        version: 3.10.1(lodash@4.17.21)
+      testem-multi-reporter:
+        specifier: ^1.2.0
+        version: 1.2.0
       tracked-built-ins:
         specifier: ^3.1.1
         version: 3.1.1
@@ -10937,6 +10943,7 @@ packages:
   /consolidate@0.16.0(lodash@4.17.21)(mustache@4.2.0):
     resolution: {integrity: sha512-Nhl1wzCslqXYTJVDyJCu3ODohy9OfBMB5uD2BiBTzd7w+QY0lBzafkR8y8755yMYHAaMD4NuzbAw03/xzfw+eQ==}
     engines: {node: '>= 0.10.0'}
+    deprecated: Please upgrade to consolidate v1.0.0+ as it has been modernized with several long-awaited fixes implemented. Maintenance is supported by Forward Email at https://forwardemail.net ; follow/watch https://github.com/ladjs/consolidate for updates and release changelog
     peerDependencies:
       arc-templates: ^0.5.3
       atpl: '>=0.7.6'
@@ -12941,7 +12948,7 @@ packages:
       sort-package-json: 1.57.0
       symlink-or-copy: 1.3.1
       temp: 0.9.4
-      testem: 3.9.0
+      testem: 3.10.1(lodash@4.17.21)
       tiny-lr: 2.0.0
       tree-sync: 2.1.0
       uuid: 8.3.2
@@ -23854,101 +23861,12 @@ packages:
       commander: 2.20.3
       source-map-support: 0.5.21
 
-  /testem@3.10.1(lodash@4.17.21):
-    resolution: {integrity: sha512-42c4e7qlAelwMd8O3ogtVGRbgbr6fJnX6H51ACOIG1V1IjsKPlcQtxPyOwaL4iikH22Dfh+EyIuJnMG4yxieBQ==}
-    engines: {node: '>= 7.*'}
-    hasBin: true
-    dependencies:
-      '@xmldom/xmldom': 0.8.6
-      backbone: 1.4.1
-      bluebird: 3.7.2
-      charm: 1.0.2
-      commander: 2.20.3
-      compression: 1.7.4
-      consolidate: 0.16.0(lodash@4.17.21)(mustache@4.2.0)
-      execa: 1.0.0
-      express: 4.18.2
-      fireworm: 0.7.2
-      glob: 7.2.3
-      http-proxy: 1.18.1
-      js-yaml: 3.14.1
-      lodash.assignin: 4.2.0
-      lodash.castarray: 4.4.0
-      lodash.clonedeep: 4.5.0
-      lodash.find: 4.6.0
-      lodash.uniqby: 4.7.0
-      mkdirp: 1.0.4
-      mustache: 4.2.0
-      node-notifier: 10.0.1
-      npmlog: 6.0.2
-      printf: 0.6.1
-      rimraf: 3.0.2
-      socket.io: 4.5.3
-      spawn-args: 0.2.0
-      styled_string: 0.0.1
-      tap-parser: 7.0.0
-      tmp: 0.0.33
-    transitivePeerDependencies:
-      - arc-templates
-      - atpl
-      - babel-core
-      - bracket-template
-      - bufferutil
-      - coffee-script
-      - debug
-      - dot
-      - dust
-      - dustjs-helpers
-      - dustjs-linkedin
-      - eco
-      - ect
-      - ejs
-      - haml-coffee
-      - hamlet
-      - hamljs
-      - handlebars
-      - hogan.js
-      - htmling
-      - jade
-      - jazz
-      - jqtpl
-      - just
-      - liquid-node
-      - liquor
-      - lodash
-      - marko
-      - mote
-      - nunjucks
-      - plates
-      - pug
-      - qejs
-      - ractive
-      - razor-tmpl
-      - react
-      - react-dom
-      - slm
-      - squirrelly
-      - supports-color
-      - swig
-      - swig-templates
-      - teacup
-      - templayed
-      - then-jade
-      - then-pug
-      - tinyliquid
-      - toffee
-      - twig
-      - twing
-      - underscore
-      - utf-8-validate
-      - vash
-      - velocityjs
-      - walrus
-      - whiskers
+  /testem-multi-reporter@1.2.0:
+    resolution: {integrity: sha512-ttIds/wpU0njpRBQsDl+tcPOy8jvafad6MCEIy21+BpNEcpCBZWrYuNva8TtxaZcoLuFTW0B8FsWl6XuJfH3rQ==}
     dev: true
 
-  /testem@3.9.0:
-    resolution: {integrity: sha512-YTxCYKj0cc8uUSKEziJtSC5T/pw4fQnY0ZXNOyvAFgrijfsN9NxmncJZOHLhPgFOuhbRd5i+DBQxw0Cpe0SEFg==}
+  /testem@3.10.1(lodash@4.17.21):
+    resolution: {integrity: sha512-42c4e7qlAelwMd8O3ogtVGRbgbr6fJnX6H51ACOIG1V1IjsKPlcQtxPyOwaL4iikH22Dfh+EyIuJnMG4yxieBQ==}
     engines: {node: '>= 7.*'}
     hasBin: true
     dependencies:


### PR DESCRIPTION
This adds another reporter for `host` and a Github Action to surface its output as a “check” so test failures are more immediately discoverable, you can see an example failure [here](https://github.com/cardstack/boxel/runs/16762778852) when I added a deliberately-failing assertion.

<img width="705" alt="boxel@a0319e5 2023-09-13 12-23-26" src="https://github.com/cardstack/boxel/assets/43280/5befb64c-3c85-4aab-af3d-2ce507d43a74">

The action posts a [comment](https://github.com/cardstack/boxel/pull/635#issuecomment-1717978795) summarising the result of the tests. Subsequent pushes only update the comment vs posting a new one, but this can be turned off altogether if we find it annoying.