### PR TITLE
host: Add eslint-plugin-qunit-dom

### DIFF
--- a/packages/host/.eslintrc.js
+++ b/packages/host/.eslintrc.js
@@ -19,6 +19,7 @@ module.exports = {
     'plugin:ember/recommended',
     'plugin:@typescript-eslint/recommended',
     'plugin:prettier/recommended',
+    'plugin:qunit-dom/recommended',
   ],
   env: {
     browser: true,

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -119,6 +119,7 @@
     "eslint-plugin-n": "^15.7.0",
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-qunit": "^7.3.4",
+    "eslint-plugin-qunit-dom": "mainmatter/eslint-plugin-qunit-dom#d66c841",
     "ethers": "^6.6.2",
     "fast-json-stable-stringify": "^2.1.0",
     "flat": "^5.0.2",

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -186,8 +186,6 @@ module('Acceptance | code mode tests', function (hooks) {
 
     assert.dom('[data-test-inheritance-placeholder]').doesNotExist();
     assert.dom('[data-test-file]').exists();
-
-    assert.dom('[data-test-file]');
   });
 
   test('can navigate file tree, file view mode is persisted in query parameter', async function (assert) {

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -186,6 +186,8 @@ module('Acceptance | code mode tests', function (hooks) {
 
     assert.dom('[data-test-inheritance-placeholder]').doesNotExist();
     assert.dom('[data-test-file]').exists();
+
+    assert.dom('[data-test-file]');
   });
 
   test('can navigate file tree, file view mode is persisted in query parameter', async function (assert) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1144,6 +1144,9 @@ importers:
       eslint-plugin-qunit:
         specifier: ^7.3.4
         version: 7.3.4(eslint@8.41.0)
+      eslint-plugin-qunit-dom:
+        specifier: mainmatter/eslint-plugin-qunit-dom#d66c841
+        version: github.com/mainmatter/eslint-plugin-qunit-dom/d66c841(eslint@8.41.0)
       ethers:
         specifier: ^6.6.2
         version: 6.6.2
@@ -26605,6 +26608,18 @@ packages:
       - '@babel/core'
       - supports-color
     dev: false
+
+  github.com/mainmatter/eslint-plugin-qunit-dom/d66c841(eslint@8.41.0):
+    resolution: {tarball: https://codeload.github.com/mainmatter/eslint-plugin-qunit-dom/tar.gz/d66c841}
+    id: github.com/mainmatter/eslint-plugin-qunit-dom/d66c841
+    name: eslint-plugin-qunit-dom
+    version: 0.2.0
+    engines: {node: 12.* || 14.* || >= 16.*}
+    peerDependencies:
+      eslint: ^7.11.0 || ^8.0.0
+    dependencies:
+      eslint: 8.41.0
+    dev: true
 
 settings:
   autoInstallPeers: true


### PR DESCRIPTION
This makes `assert.dom` calls without an assertion a lint error. You can see it fail [here](https://github.com/cardstack/boxel/actions/runs/6175724872/job/16763186075?pr=636#step:8:26) deliberately:

```
[lint:js]   190:5  error  use at least one assertion on assert.dom(...)  qunit-dom/require-assertion
```

The `require-assertion` rule has autofix:

![screencast 2023-09-13 12-27-36](https://github.com/cardstack/boxel/assets/43280/c3c31755-79a0-428e-8f60-b50b28b8af2e)


The maintainers of `eslint-plugin-qunit-dom` merged the PR I made to add this but haven’t made a release, so this specifies a SHA instead.