### PR TITLE
realm: Restore DOM tests

### DIFF
--- a/packages/realm-server/dom-tests/realm-dom-test.js
+++ b/packages/realm-server/dom-tests/realm-dom-test.js
@@ -54,14 +54,7 @@ async function boot(url, waitForSelector) {
 
 async function bootToCodeModeFile(pathToFile, waitForSelector) {
   let codeModeStateParam = JSON.stringify({
-    stacks: [
-      [
-        {
-          id: `${testRealmURL}/person-2`,
-          format: 'isolated',
-        },
-      ],
-    ],
+    stacks: [[]],
     submode: 'code',
     fileView: 'browser',
     codePath: `${testRealmURL}/${pathToFile}`,

--- a/packages/realm-server/dom-tests/realm-dom-test.js
+++ b/packages/realm-server/dom-tests/realm-dom-test.js
@@ -52,6 +52,28 @@ async function boot(url, waitForSelector) {
   }
 }
 
+async function bootToCodeModeFile(pathToFile, waitForSelector) {
+  let codeModeStateParam = JSON.stringify({
+    stacks: [
+      [
+        {
+          id: `${testRealmURL}/person-2`,
+          format: 'isolated',
+        },
+      ],
+    ],
+    submode: 'code',
+    fileView: 'browser',
+    codePath: `${testRealmURL}/${pathToFile}`,
+  });
+
+  let path = `?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+    codeModeStateParam,
+  )}`;
+
+  await boot(`${testRealmURL}/${path}`, waitForSelector);
+}
+
 function resetTestContainer() {
   let container = document.getElementById(testContainerId);
   let iframes = container.querySelectorAll('iframe');
@@ -77,29 +99,7 @@ QUnit.module(
     });
 
     test('renders file tree', async function (assert) {
-      let codeModeStateParam = JSON.stringify({
-        stacks: [
-          [
-            {
-              id: `${testRealmURL}/person-1`,
-              format: 'isolated',
-            },
-          ],
-        ],
-        submode: 'code',
-        fileView: 'browser',
-        codePath: `${testRealmURL}/person-1.json`,
-      });
-
-      let path = `?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
-        codeModeStateParam,
-      )}`;
-
-      await boot(`${testRealmURL}/${path}`, '[data-test-directory-level]');
-      assert.strictEqual(
-        testDocument().location.href,
-        `${testRealmURL}/${path}`,
-      );
+      await boot('person-1.json', '[data-test-directory-level]');
 
       let nav = querySelector('nav');
       assert.ok(nav, '<nav> element exists');
@@ -158,25 +158,7 @@ QUnit.module(
     });
 
     test('renders card instance', async function (assert) {
-      let codeModeStateParam = JSON.stringify({
-        stacks: [
-          [
-            {
-              id: `${testRealmURL}/person-2`,
-              format: 'isolated',
-            },
-          ],
-        ],
-        submode: 'code',
-        fileView: 'browser',
-        codePath: `${testRealmURL}/person-2.json`,
-      });
-
-      let path = `?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
-        codeModeStateParam,
-      )}`;
-
-      await boot(`${testRealmURL}/${path}`, '[data-test-card]');
+      await bootToCodeModeFile('person-2.json', '[data-test-card]');
 
       let card = querySelector('[data-test-card]');
       assert.strictEqual(
@@ -187,25 +169,7 @@ QUnit.module(
     });
 
     test('can change routes', async function (assert) {
-      let codeModeStateParam = JSON.stringify({
-        stacks: [
-          [
-            {
-              id: `${testRealmURL}/person-2`,
-              format: 'isolated',
-            },
-          ],
-        ],
-        submode: 'code',
-        fileView: 'browser',
-        codePath: `${testRealmURL}/person.gts`,
-      });
-
-      let path = `?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
-        codeModeStateParam,
-      )}`;
-
-      await boot(`${testRealmURL}/${path}`, '[data-test-directory-level]');
+      await bootToCodeModeFile('person.gts', '[data-test-directory-level]');
       let files = querySelectorAll('nav .file');
       let instance = [...files].find(
         (file) => cleanWhiteSpace(file.textContent) === 'person-1.json',

--- a/packages/realm-server/dom-tests/realm-dom-test.js
+++ b/packages/realm-server/dom-tests/realm-dom-test.js
@@ -186,9 +186,27 @@ QUnit.module(
       );
     });
 
-    skip('can change routes', async function (assert) {
-      await boot(`${testRealmURL}/code`, '[data-test-directory-level]');
-      let files = querySelectorAll('.main nav .file');
+    test('can change routes', async function (assert) {
+      let codeModeStateParam = JSON.stringify({
+        stacks: [
+          [
+            {
+              id: `${testRealmURL}/person-2`,
+              format: 'isolated',
+            },
+          ],
+        ],
+        submode: 'code',
+        fileView: 'browser',
+        codePath: `${testRealmURL}/person.gts`,
+      });
+
+      let path = `?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+        codeModeStateParam,
+      )}`;
+
+      await boot(`${testRealmURL}/${path}`, '[data-test-directory-level]');
+      let files = querySelectorAll('nav .file');
       let instance = [...files].find(
         (file) => cleanWhiteSpace(file.textContent) === 'person-1.json',
       );
@@ -196,10 +214,6 @@ QUnit.module(
       instance.click();
 
       await waitFor('[data-test-card]');
-      assert.strictEqual(
-        testDocument().location.href,
-        `${testRealmURL}/code?openFile=person-1.json`,
-      );
       let card = querySelector('[data-test-card]');
       assert.strictEqual(
         cleanWhiteSpace(card.textContent),

--- a/packages/realm-server/dom-tests/realm-dom-test.js
+++ b/packages/realm-server/dom-tests/realm-dom-test.js
@@ -77,9 +77,31 @@ QUnit.module(
     });
 
     test('renders file tree', async function (assert) {
-      await boot(`${testRealmURL}/code`, '[data-test-directory-level]');
-      assert.strictEqual(testDocument().location.href, `${testRealmURL}/code`);
-      let nav = querySelector('.main nav');
+      let codeModeStateParam = JSON.stringify({
+        stacks: [
+          [
+            {
+              id: `${testRealmURL}/person-1`,
+              format: 'isolated',
+            },
+          ],
+        ],
+        submode: 'code',
+        fileView: 'browser',
+        codePath: `${testRealmURL}/person-1.json`,
+      });
+
+      let path = `?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+        codeModeStateParam,
+      )}`;
+
+      await boot(`${testRealmURL}/${path}`, '[data-test-directory-level]');
+      assert.strictEqual(
+        testDocument().location.href,
+        `${testRealmURL}/${path}`,
+      );
+
+      let nav = querySelector('nav');
       assert.ok(nav, '<nav> element exists');
       let dirContents = nav.textContent;
       assert.ok(dirContents.includes('a.js'));

--- a/packages/realm-server/dom-tests/realm-dom-test.js
+++ b/packages/realm-server/dom-tests/realm-dom-test.js
@@ -157,15 +157,27 @@ QUnit.module(
       );
     });
 
-    skip('renders card instance', async function (assert) {
-      await boot(
-        `${testRealmURL}/code?openFile=person-2.json`,
-        '[data-test-card]',
-      );
-      assert.strictEqual(
-        testDocument().location.href,
-        `${testRealmURL}/code?openFile=person-2.json`,
-      );
+    test('renders card instance', async function (assert) {
+      let codeModeStateParam = JSON.stringify({
+        stacks: [
+          [
+            {
+              id: `${testRealmURL}/person-2`,
+              format: 'isolated',
+            },
+          ],
+        ],
+        submode: 'code',
+        fileView: 'browser',
+        codePath: `${testRealmURL}/person-2.json`,
+      });
+
+      let path = `?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+        codeModeStateParam,
+      )}`;
+
+      await boot(`${testRealmURL}/${path}`, '[data-test-card]');
+
       let card = querySelector('[data-test-card]');
       assert.strictEqual(
         cleanWhiteSpace(card.textContent),

--- a/packages/realm-server/dom-tests/realm-dom-test.js
+++ b/packages/realm-server/dom-tests/realm-dom-test.js
@@ -92,7 +92,7 @@ QUnit.module(
     });
 
     test('renders file tree', async function (assert) {
-      await boot('person-1.json', '[data-test-directory-level]');
+      await bootToCodeModeFile('person-1.json', '[data-test-directory-level]');
 
       let nav = querySelector('nav');
       assert.ok(nav, '<nav> element exists');


### PR DESCRIPTION
These tests were skipped as parts of `/code` stopped working. This migrates them all but the one that relies on the schema editor that has yet to be created.

I removed URL assertions, they didn’t seem useful to me.