### PR TITLE
Display default file-tree even if url is not found

### DIFF
--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -507,4 +507,36 @@ module('Acceptance | code mode tests', function (hooks) {
       .dom('[data-test-card-url-bar-realm-info]')
       .containsText('in Test Workspace B');
   });
+
+  test('not-found state displays default realm info', async function (assert) {
+    let operatorModeStateParam = stringify({
+      stacks: [],
+      submode: 'code',
+      codePath: `${testRealmURL}perso`, // purposely misspelled
+    })!;
+
+    await visit(
+      `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+        operatorModeStateParam,
+      )}`,
+    );
+
+    await waitFor('[data-test-file]');
+
+    assert.dom('[data-test-file]').exists();
+    assert.dom('[data-test-file-browser-toggle]').hasClass('active');
+    assert.dom('[data-test-card-inheritance-panel]').doesNotExist();
+    assert
+      .dom('[data-test-file-view-header]')
+      .hasAttribute('aria-label', 'File Browser');
+    assert.dom('[data-test-inheritance-toggle]').isDisabled();
+
+    assert.dom('[data-test-empty-code-mode]').doesNotExist();
+    assert
+      .dom('[data-test-card-url-bar-input]')
+      .hasValue(`${testRealmURL}perso`);
+    assert
+      .dom('[data-test-card-url-bar-realm-info]')
+      .containsText('in Test Workspace B');
+  });
 });


### PR DESCRIPTION
Continue displaying file tree if url is not found and related clean-up

<img width="1494" alt="incorrect-url" src="https://github.com/cardstack/boxel/assets/16160806/624ca8cf-a97b-42ff-b2e8-db1ebfeae8fe">
