### PR TITLE
host: Add recent files acceptance test

### DIFF
--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -1,4 +1,4 @@
-import { module, skip, test } from 'qunit';
+import { module, test } from 'qunit';
 import { visit, click, waitFor, waitUntil, find } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { baseRealm } from '@cardstack/runtime-common';
@@ -293,7 +293,7 @@ module('Acceptance | code mode tests', function (hooks) {
     assert.dom('[data-test-directory="Person/"] .icon').hasClass('open');
   });
 
-  skip('recent file links are shown', async function (assert) {
+  test('recent file links are shown', async function (assert) {
     let otherRealmCardUrl = 'http://example.com/other-realm-card.json';
     window.localStorage.setItem(
       'recent-files',


### PR DESCRIPTION
This was failing in CI but not locally so I turned it off before merging #619. Now that #645 is merged, which makes the file tree more stable, it passes in CI.