### PR TITLE
host: Add filtering of non-URL recent files in storage

### DIFF
--- a/packages/host/app/services/recent-files-service.ts
+++ b/packages/host/app/services/recent-files-service.ts
@@ -13,7 +13,22 @@ export default class RecentFilesService extends Service {
 
     if (recentFilesString) {
       try {
-        this.recentFiles = new TrackedArray(JSON.parse(recentFilesString));
+        this.recentFiles = new TrackedArray(
+          JSON.parse(recentFilesString).reduce(function (
+            recentFiles: string[],
+            fileString: string,
+          ) {
+            try {
+              new URL(fileString);
+              recentFiles.push(fileString);
+            } catch (e) {
+              console.log(
+                `Ignoring non-URL recent file from storage: ${fileString}`,
+              );
+            }
+            return recentFiles;
+          }, []),
+        );
       } catch (e) {
         console.log('Error restoring recent files', e);
       }

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -384,7 +384,11 @@ module('Acceptance | code mode tests', function (hooks) {
     let otherRealmCardUrl = 'http://example.com/other-realm-card.json';
     window.localStorage.setItem(
       'recent-files',
-      JSON.stringify([`${testRealmURL}index.json`, otherRealmCardUrl]),
+      JSON.stringify([
+        `${testRealmURL}index.json`,
+        otherRealmCardUrl,
+        'a-non-url-to-ignore',
+      ]),
     );
 
     let codeModeStateParam = stringify({


### PR DESCRIPTION
I found the UI crashing when I had non-URL entries in `localStorage['recent-files']`, a relic of when they were non realm-aware. That should no longer happen but this should be resilient regardless.