### PR TITLE
Basic list of card's whole inheritance chain in schema editor

### DIFF
--- a/packages/base/big-integer.gts
+++ b/packages/base/big-integer.gts
@@ -59,6 +59,7 @@ class Edit extends Component<typeof BigIntegerField> {
 }
 
 export default class BigIntegerField extends FieldDef {
+  static displayName = 'BigInteger';
   static [primitive]: bigint;
   static [serialize](val: bigint) {
     return _serialize(val);

--- a/packages/base/boolean.gts
+++ b/packages/base/boolean.gts
@@ -29,6 +29,7 @@ class View extends Component<typeof BooleanField> {
 }
 
 export default class BooleanField extends FieldDef {
+  static displayName = 'Boolean';
   static [primitive]: boolean;
   static [useIndexBasedKey]: never;
   static [serialize](val: any) {

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -1709,6 +1709,7 @@ class IDField extends FieldDef {
 }
 
 export class StringField extends FieldDef {
+  static displayName = 'String';
   static [primitive]: string;
   static [useIndexBasedKey]: never;
   static embedded = class Embedded extends Component<typeof this> {

--- a/packages/base/datetime.gts
+++ b/packages/base/datetime.gts
@@ -26,6 +26,7 @@ const Format = new Intl.DateTimeFormat('en-US', {
 const datetimeFormat = `yyyy-MM-dd'T'HH:mm`;
 
 export default class DatetimeField extends FieldDef {
+  static displayName = 'DateTime';
   static [primitive]: Date;
   static [serialize](date: Date) {
     return date.toISOString();

--- a/packages/base/ethereum-address.gts
+++ b/packages/base/ethereum-address.gts
@@ -65,6 +65,7 @@ function _serialize(val: string): string {
 }
 
 export default class EthereumAddressField extends FieldDef {
+  static displayName = 'EthereumAddress';
   static [primitive]: string;
   static [useIndexBasedKey]: never;
   static [serialize](val: string) {

--- a/packages/base/markdown.gts
+++ b/packages/base/markdown.gts
@@ -13,6 +13,7 @@ function toHtml(markdown: string | null) {
 }
 
 export default class MarkdownField extends FieldDef {
+  static displayName = 'Markdown';
   static [primitive]: string;
   static [useIndexBasedKey]: never;
 

--- a/packages/base/number.gts
+++ b/packages/base/number.gts
@@ -49,6 +49,7 @@ function _serialize(val: number): string {
 }
 
 export default class NumberField extends FieldDef {
+  static displayName = 'Number';
   static [primitive]: number;
   static [useIndexBasedKey]: never;
   static async [deserialize]<T extends BaseDefConstructor>(

--- a/packages/base/room-objective.gts
+++ b/packages/base/room-objective.gts
@@ -51,6 +51,7 @@ class View extends Component<typeof RoomObjectiveField> {
 }
 
 export class RoomObjectiveField extends FieldDef {
+  static displayName = 'RoomObjective';
   @field room = contains(RoomField);
   @field usersThatFinishedTask = containsMany(RoomMemberField, {
     computeVia: function (this: RoomObjectiveField) {

--- a/packages/base/room.gts
+++ b/packages/base/room.gts
@@ -338,6 +338,7 @@ const roomMemberCache = new WeakMap<RoomField, Map<string, RoomMemberField>>();
 const roomStateCache = new WeakMap<RoomField, RoomState>();
 
 export class RoomField extends FieldDef {
+  static displayName = 'Room';
   // This can be used  to get the attached `cardInstance` like:
   //   Reflect.getProtypeOf(roomFieldInstance).constructor.getAttachedCard(cardInstance);
   static getAttachedCard(id: string) {

--- a/packages/base/text-area.gts
+++ b/packages/base/text-area.gts
@@ -3,6 +3,7 @@ import StringField from './string';
 import { BoxelInput } from '@cardstack/boxel-ui';
 
 export default class TextAreaCard extends StringField {
+  static displayName = 'TextArea';
   static edit = class Edit extends Component<typeof this> {
     <template>
       <BoxelInput

--- a/packages/host/app/components/operator-mode/card-adoption-chain.gts
+++ b/packages/host/app/components/operator-mode/card-adoption-chain.gts
@@ -1,0 +1,117 @@
+import Component from '@glimmer/component';
+//@ts-ignore cached not available yet in definitely typed
+import { cached } from '@glimmer/tracking';
+import { ModuleSyntax } from '@cardstack/runtime-common/module-syntax';
+import { loadCard } from '@cardstack/runtime-common/code-ref';
+import type { Ready } from '@cardstack/host/resources/file';
+import type { BaseDef } from 'https://cardstack.com/base/card-api';
+import CardSchemaEditor from '@cardstack/host/components/operator-mode/card-schema-editor';
+import LoaderService from '@cardstack/host/services/loader-service';
+import { service } from '@ember/service';
+import { getCardType } from '@cardstack/host/resources/card-type';
+import { tracked } from '@glimmer/tracking';
+import { type Type } from '@cardstack/host/resources/card-type';
+
+interface Signature {
+  Args: {
+    file: Ready;
+    importedModule: Record<string, any>;
+  };
+}
+
+export default class CardAdoptionChain extends Component<Signature> {
+  <template>
+    <style>
+      .card-adoption-chain {
+        height: 100%;
+        background-color: var(--boxel-200);
+        padding: var(--boxel-sp);
+        overflow-y: auto;
+      }
+    </style>
+
+    <div class='card-adoption-chain'>
+      <h3>Schema Editor</h3>
+
+      {{#each this.cardInheritanceChain as |data|}}
+        <CardSchemaEditor
+          @card={{data.card}}
+          @cardType={{data.cardType}}
+          @file={{@file}}
+          @moduleSyntax={{this.moduleSyntax}}
+        />
+      {{/each}}
+    </div>
+  </template>
+
+  @service declare loaderService: LoaderService;
+  @tracked cardInheritanceChain: {
+    cardType: Type;
+    card: any;
+  }[] = [];
+
+  constructor(owner: unknown, args: Signature['Args']) {
+    super(owner, args);
+    this.loadInheritanceChain();
+  }
+
+  @cached
+  get moduleSyntax() {
+    return new ModuleSyntax(this.args.file.content);
+  }
+
+  async loadInheritanceChain() {
+    let fileUrl = this.args.file.url;
+    let module = this.args.importedModule;
+
+    let card = cardsFromModule(module)[0]; // TODO: this must come from the export selection in the left column
+    let cardTypeResource = getCardType(this, () => card);
+    await cardTypeResource.ready;
+
+    let cardType = cardTypeResource.type;
+    if (!cardType) {
+      throw new Error(
+        `Bug: should never get here because we waited for it to be ready`,
+      );
+    }
+
+    // Chain goes from most specific to least specific
+    let cardInheritanceChain = [
+      {
+        cardType,
+        card,
+      },
+    ];
+
+    while (cardType.super) {
+      cardType = cardType.super;
+
+      let superCard = await loadCard(cardType.codeRef, {
+        loader: this.loaderService.loader,
+        relativeTo: new URL(fileUrl), // because the module can be relative
+      });
+
+      cardInheritanceChain.push({
+        cardType,
+        card: superCard,
+      });
+    }
+
+    this.cardInheritanceChain = cardInheritanceChain;
+
+    // TODO: module export must come from the export selection in the left column - above where we get the card
+    // TODO: base card should be showing title - is that a bug? Bug in syntax analysis?
+    // TODO: Base unites fields and cards - should we even show it? Discuss with the team
+    // TODO: For realm icons - need to make a separate request to .gts and extract the header (just  a normal fetch request)
+    // TODO: Make a ticket for globally cached realm assets
+  }
+}
+
+function cardsFromModule(
+  module: Record<string, any>,
+  _never?: never,
+): (typeof BaseDef)[] {
+  return Object.values(module).filter(
+    (maybeCard) => typeof maybeCard === 'function' && 'baseDef' in maybeCard,
+  );
+}

--- a/packages/host/app/components/operator-mode/card-adoption-chain.gts
+++ b/packages/host/app/components/operator-mode/card-adoption-chain.gts
@@ -11,6 +11,7 @@ import { service } from '@ember/service';
 import { getCardType } from '@cardstack/host/resources/card-type';
 import { tracked } from '@glimmer/tracking';
 import { type Type } from '@cardstack/host/resources/card-type';
+import { restartableTask } from 'ember-concurrency';
 
 interface Signature {
   Args: {
@@ -52,7 +53,7 @@ export default class CardAdoptionChain extends Component<Signature> {
 
   constructor(owner: unknown, args: Signature['Args']) {
     super(owner, args);
-    this.loadInheritanceChain();
+    this.loadInheritanceChain.perform();
   }
 
   @cached
@@ -60,7 +61,7 @@ export default class CardAdoptionChain extends Component<Signature> {
     return new ModuleSyntax(this.args.file.content);
   }
 
-  async loadInheritanceChain() {
+  loadInheritanceChain = restartableTask(async () => {
     let fileUrl = this.args.file.url;
     let module = this.args.importedModule;
 

--- a/packages/host/app/components/operator-mode/card-adoption-chain.gts
+++ b/packages/host/app/components/operator-mode/card-adoption-chain.gts
@@ -99,13 +99,7 @@ export default class CardAdoptionChain extends Component<Signature> {
     }
 
     this.cardInheritanceChain = cardInheritanceChain;
-
-    // TODO: module export must come from the export selection in the left column - above where we get the card
-    // TODO: base card should be showing title - is that a bug? Bug in syntax analysis?
-    // TODO: Base unites fields and cards - should we even show it? Discuss with the team
-    // TODO: For realm icons - need to make a separate request to .gts and extract the header (just  a normal fetch request)
-    // TODO: Make a ticket for globally cached realm assets
-  }
+  });
 }
 
 function cardsFromModule(

--- a/packages/host/app/components/operator-mode/card-schema-editor.gts
+++ b/packages/host/app/components/operator-mode/card-schema-editor.gts
@@ -1,0 +1,163 @@
+import Component from '@glimmer/component';
+import { internalKeyFor } from '@cardstack/runtime-common';
+import { isCodeRef, type CodeRef } from '@cardstack/runtime-common/code-ref';
+import { type Type } from '@cardstack/host/resources/card-type';
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+
+import type LoaderService from '@cardstack/host/services/loader-service';
+import type CardService from '@cardstack/host/services/card-service';
+import type { ModuleSyntax } from '@cardstack/runtime-common/module-syntax';
+import type { Ready } from '@cardstack/host/resources/file';
+import type { BaseDef } from 'https://cardstack.com/base/card-api';
+import { capitalize } from '@ember/string';
+
+interface Signature {
+  Args: {
+    card: typeof BaseDef;
+    file: Ready;
+    cardType: Type;
+    moduleSyntax: ModuleSyntax;
+  };
+}
+
+export default class CardSchemaEditor extends Component<Signature> {
+  <template>
+    <style>
+      .schema-editor-container {
+        margin-top: var(--boxel-sp);
+      }
+
+      .schema {
+        display: grid;
+        gap: var(--boxel-sp);
+        padding: var(--boxel-sp);
+      }
+
+      .pill {
+        border: 1px solid gray;
+        display: inline-block;
+        padding: var(--boxel-sp-xxxs) var(--boxel-sp-xs);
+        border-radius: 8px;
+        background-color: white;
+        font-weight: 600;
+      }
+
+      .realm-icon {
+        margin-right: var(--boxel-sp-xxxs);
+      }
+
+      .card-field {
+        background-color: white;
+      }
+
+      .card-field {
+        margin-bottom: var(--boxel-sp-xs);
+        padding: var(--boxel-sp);
+        border-radius: var(--boxel-border-radius);
+        display: flex;
+      }
+
+      .card-fields {
+        margin-top: var(--boxel-sp);
+      }
+
+      .left {
+        display: flex;
+        margin-top: auto;
+        margin-bottom: auto;
+        flex-direction: column;
+      }
+
+      .right {
+        margin-left: auto;
+        margin-top: auto;
+        margin-bottom: auto;
+      }
+
+      .field-name {
+        font-size: var(--boxel-font-size);
+      }
+
+      .field-type {
+        color: #949494;
+      }
+    </style>
+
+    <div
+      class='schema-editor-container'
+      data-test-card-schema={{@cardType.displayName}}
+    >
+      <div class='pill'>
+        <span class='realm-icon'>
+          🟦
+        </span>
+        {{@cardType.displayName}}
+      </div>
+
+      <div class='card-fields'>
+        {{#each @cardType.fields as |field|}}
+          {{#if (this.isOwnField field.name)}}
+            <div class='card-field' data-test-field-name={{field.name}}>
+              <div class='left'>
+                <div class='field-name'>
+                  {{field.name}}
+                </div>
+                <div class='field-type'>
+                  {{field.type}}
+                </div>
+              </div>
+              <div class='right'>
+
+                <div class='pill'>
+                  <span class='realm-icon'>
+                    🟪
+                  </span>
+                  {{#let
+                    (capitalize (this.cleanupCardType (cardId field.card)))
+                    as |cardType|
+                  }}
+                    <span data-test-card-type={{cardType}}>{{cardType}}</span>
+                  {{/let}}
+                </div>
+              </div>
+            </div>
+          {{/if}}
+        {{/each}}
+      </div>
+    </div>
+  </template>
+
+  @service declare loaderService: LoaderService;
+  @service declare cardService: CardService;
+
+  cleanupCardType(value: string) {
+    let path = new URL(value).pathname; // Examples of pathname: "/base/string/default", "/drafts/pet/Pet"
+
+    if (path.endsWith('/default')) {
+      path = path.slice(0, -'/default'.length);
+    }
+
+    let cardType = path.split('/').pop();
+    if (!cardType) {
+      throw new Error(`Could not parse card type from ${value}`);
+    } else {
+      return cardType;
+    }
+  }
+
+  @action
+  isOwnField(fieldName: string): boolean {
+    return Object.keys(
+      Object.getOwnPropertyDescriptors(this.args.card.prototype),
+    ).includes(fieldName);
+  }
+}
+
+function cardId(card: Type | CodeRef): string {
+  if (isCodeRef(card)) {
+    return internalKeyFor(card, undefined);
+  } else {
+    return card.id;
+  }
+}

--- a/packages/host/app/components/operator-mode/card-schema-editor.gts
+++ b/packages/host/app/components/operator-mode/card-schema-editor.gts
@@ -10,7 +10,6 @@ import type CardService from '@cardstack/host/services/card-service';
 import type { ModuleSyntax } from '@cardstack/runtime-common/module-syntax';
 import type { Ready } from '@cardstack/host/resources/file';
 import type { BaseDef } from 'https://cardstack.com/base/card-api';
-import { capitalize } from '@ember/string';
 
 interface Signature {
   Args: {

--- a/packages/host/app/components/operator-mode/card-schema-editor.gts
+++ b/packages/host/app/components/operator-mode/card-schema-editor.gts
@@ -114,10 +114,12 @@ export default class CardSchemaEditor extends Component<Signature> {
                     🟪
                   </span>
                   {{#let
-                    (capitalize (this.cleanupCardType (cardId field.card)))
-                    as |cardType|
+                    (this.fieldCardDisplayName field.card)
+                    as |cardDisplayName|
                   }}
-                    <span data-test-card-type={{cardType}}>{{cardType}}</span>
+                    <span
+                      data-test-card-display-name={{cardDisplayName}}
+                    >{{cardDisplayName}}</span>
                   {{/let}}
                 </div>
               </div>
@@ -131,33 +133,17 @@ export default class CardSchemaEditor extends Component<Signature> {
   @service declare loaderService: LoaderService;
   @service declare cardService: CardService;
 
-  cleanupCardType(value: string) {
-    let path = new URL(value).pathname; // Examples of pathname: "/base/string/default", "/drafts/pet/Pet"
-
-    if (path.endsWith('/default')) {
-      path = path.slice(0, -'/default'.length);
-    }
-
-    let cardType = path.split('/').pop();
-    if (!cardType) {
-      throw new Error(`Could not parse card type from ${value}`);
-    } else {
-      return cardType;
-    }
-  }
-
   @action
   isOwnField(fieldName: string): boolean {
     return Object.keys(
       Object.getOwnPropertyDescriptors(this.args.card.prototype),
     ).includes(fieldName);
   }
-}
 
-function cardId(card: Type | CodeRef): string {
-  if (isCodeRef(card)) {
-    return internalKeyFor(card, undefined);
-  } else {
-    return card.id;
+  fieldCardDisplayName(card: Type | CodeRef): string {
+    if (isCodeRef(card)) {
+      return internalKeyFor(card, undefined);
+    }
+    return card.displayName;
   }
 }

--- a/packages/host/app/components/operator-mode/code-mode.gts
+++ b/packages/host/app/components/operator-mode/code-mode.gts
@@ -474,11 +474,20 @@ export default class CodeMode extends Component<Signature> {
     }
   }
 
-  get isInstance() {
-    return (
-      isReady(this.openFile.current) &&
-      this.openFile.current.name.endsWith('.json')
-    );
+  get isCardInstance() {
+    if (
+      !isReady(this.openFile.current) ||
+      !this.openFile.current.name.endsWith('.json')
+    ) {
+      return false;
+    }
+
+    try {
+      let cardDoc = JSON.parse(this.readyFile.content);
+      return isCardDocument(cardDoc);
+    } catch (e) {
+      throw new Error('Unparsable JSON file');
+    }
   }
 
   <template>
@@ -615,7 +624,7 @@ export default class CodeMode extends Component<Signature> {
           >
             <div class='inner-container'>
               {{#if this.isReady}}
-                {{#if this.isInstance}}
+                {{#if this.isCardInstance}}
                   {{#if this.cardResource.value}}
                     <CardPreviewPanel
                       @card={{this.cardResource.value}}

--- a/packages/host/app/components/operator-mode/code-mode.gts
+++ b/packages/host/app/components/operator-mode/code-mode.gts
@@ -64,6 +64,7 @@ import type { MonacoSDK } from '@cardstack/host/services/monaco-service';
 import type { FileView } from '@cardstack/host/services/operator-mode-state-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 import { adoptionChainResource } from '@cardstack/host/resources/adoption-chain';
+import CardAdoptionChain from '@cardstack/host/components/operator-mode/card-adoption-chain';
 
 interface Signature {
   Args: {
@@ -473,6 +474,13 @@ export default class CodeMode extends Component<Signature> {
     }
   }
 
+  get isInstance() {
+    return (
+      isReady(this.openFile.current) &&
+      this.openFile.current.name.endsWith('.json')
+    );
+  }
+
   <template>
     <div class='code-mode-background' style={{this.backgroundURLStyle}}></div>
     <CardURLBar
@@ -606,14 +614,26 @@ export default class CodeMode extends Component<Signature> {
             @panelGroupApi={{pg.api}}
           >
             <div class='inner-container'>
-              {{#if this.cardResource.value}}
-                <CardPreviewPanel
-                  @card={{this.cardResource.value}}
-                  @realmIconURL={{this.realmIconURL}}
-                  data-test-card-resource-loaded
-                />
-              {{else if this.cardResource.error}}
-                {{this.cardResource.error.message}}
+              {{#if this.isReady}}
+                {{#if this.isInstance}}
+                  {{#if this.cardResource.value}}
+                    <CardPreviewPanel
+                      @card={{this.cardResource.value}}
+                      @realmIconURL={{this.realmIconURL}}
+                      data-test-card-resource-loaded
+                    />
+
+                  {{else if this.cardResource.error}}
+                    {{this.cardResource.error.message}}
+                  {{/if}}
+                {{else}}
+                  {{#if this.importedModule.module}}
+                    <CardAdoptionChain
+                      @file={{this.readyFile}}
+                      @importedModule={{this.importedModule.module}}
+                    />
+                  {{/if}}
+                {{/if}}
               {{/if}}
             </div>
           </ResizablePanel>

--- a/packages/host/app/components/operator-mode/code-mode.gts
+++ b/packages/host/app/components/operator-mode/code-mode.gts
@@ -556,22 +556,6 @@ export default class CodeMode extends Component<Signature> {
     }
   }
 
-  get isCardInstance() {
-    if (
-      !isReady(this.openFile.current) ||
-      !this.openFile.current.name.endsWith('.json')
-    ) {
-      return false;
-    }
-
-    try {
-      let cardDoc = JSON.parse(this.readyFile.content);
-      return isCardDocument(cardDoc);
-    } catch (e) {
-      throw new Error('Unparsable JSON file');
-    }
-  }
-
   private async withTestWaiters<T>(cb: () => Promise<T>) {
     let token = waiter.beginAsync();
     try {

--- a/packages/host/app/components/operator-mode/code-mode.gts
+++ b/packages/host/app/components/operator-mode/code-mode.gts
@@ -26,7 +26,6 @@ import {
   identifyCard,
   moduleFrom,
   hasExecutableExtension,
-  isCardDocument,
 } from '@cardstack/runtime-common';
 
 import {

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -724,28 +724,28 @@ module('Acceptance | code mode tests', function (hooks) {
 
     assert
       .dom(
-        `[data-test-card-schema="Person"] [data-test-field-name="firstName"] [data-test-card-type="String"]`,
+        `[data-test-card-schema="Person"] [data-test-field-name="firstName"] [data-test-card-display-name="String"]`,
       )
       .exists();
     assert
       .dom(
-        `[data-test-card-schema="Person"] [data-test-field-name="lastName"] [data-test-card-type="String"]`,
+        `[data-test-card-schema="Person"] [data-test-field-name="lastName"] [data-test-card-display-name="String"]`,
       )
       .exists();
 
     assert
       .dom(
-        `[data-test-card-schema="Card"] [data-test-field-name="title"] [data-test-card-type="String"]`,
+        `[data-test-card-schema="Card"] [data-test-field-name="title"] [data-test-card-display-name="String"]`,
       )
       .exists();
     assert
       .dom(
-        `[data-test-card-schema="Card"] [data-test-field-name="description"] [data-test-card-type="String"]`,
+        `[data-test-card-schema="Card"] [data-test-field-name="description"] [data-test-card-display-name="String"]`,
       )
       .exists();
     assert
       .dom(
-        `[data-test-card-schema="Card"] [data-test-field-name="thumbnailURL"] [data-test-card-type="String"]`,
+        `[data-test-card-schema="Card"] [data-test-field-name="thumbnailURL"] [data-test-card-display-name="String"]`,
       )
       .exists();
 

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -42,6 +42,7 @@ const personCardSource = `
   import StringCard from "https://cardstack.com/base/string";
 
   export class Person extends CardDef {
+    static displayName = 'Person';
     @field firstName = contains(StringCard);
     @field lastName = contains(StringCard);
     @field title = contains(StringCard, {
@@ -702,6 +703,53 @@ module('Acceptance | code mode tests', function (hooks) {
     assert
       .dom(`[data-test-recent-file]:first-child`)
       .containsText('person.gts');
+  });
+
+  test('schema editor lists the inheritance chain', async function (assert) {
+    let operatorModeStateParam = stringify({
+      stacks: [],
+      submode: 'code',
+      codePath: `${testRealmURL}person.gts`,
+    })!;
+
+    await visit(
+      `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+        operatorModeStateParam,
+      )}`,
+    );
+
+    await waitFor('[data-test-card-schema]');
+
+    assert.dom('[data-test-card-schema]').exists({ count: 3 });
+
+    assert
+      .dom(
+        `[data-test-card-schema="Person"] [data-test-field-name="firstName"] [data-test-card-type="String"]`,
+      )
+      .exists();
+    assert
+      .dom(
+        `[data-test-card-schema="Person"] [data-test-field-name="lastName"] [data-test-card-type="String"]`,
+      )
+      .exists();
+
+    assert
+      .dom(
+        `[data-test-card-schema="Card"] [data-test-field-name="title"] [data-test-card-type="String"]`,
+      )
+      .exists();
+    assert
+      .dom(
+        `[data-test-card-schema="Card"] [data-test-field-name="description"] [data-test-card-type="String"]`,
+      )
+      .exists();
+    assert
+      .dom(
+        `[data-test-card-schema="Card"] [data-test-field-name="thumbnailURL"] [data-test-card-type="String"]`,
+      )
+      .exists();
+
+    assert.dom(`[data-test-card-schema="Base"]`).exists();
   });
 });
 

--- a/packages/host/tests/acceptance/operator-mode-test.ts
+++ b/packages/host/tests/acceptance/operator-mode-test.ts
@@ -906,6 +906,9 @@ module('Acceptance | operator mode tests', function (hooks) {
       assert
         .dom('[data-test-code-mode-card-preview-body ] .edit-card')
         .exists();
+
+      // Only preview is shown in the right column when viewing an instance, no schema editor
+      assert.dom('[data-test-card-schema]').doesNotExist();
     });
   });
 


### PR DESCRIPTION
This PR introduces a very basic and crude list of inheritance chain of a selected module export (card). My reason for submitting a PR for this in such an early phase is because I think this is possibly a good foundation to build upon and there are many subtasks to implement from here on – we could split the work of porting the functionality from our old `/code` route, i.e. manipulating fields, adding, deleting, writing, showing realm assets and style the field relationships.

This is how it looks like (in the right column, when a card definition (.gts file) is chosen in the left menu):

<img width="1057" alt="image" src="https://github.com/cardstack/boxel/assets/273660/aaa51285-b4c7-43aa-b7be-dd6b9ab3824f">

This is the design that should be followed:

<img width="301" alt="image" src="https://github.com/cardstack/boxel/assets/273660/f41fd99f-19d3-4bb7-8b6c-fffe42fb0cb2">

As you see, we are missing elements, such as field counts, realm icons, relationship icons, clickable code buttons, placing it into an accordion, etc. There are also TODO items in the inheritance chain data method–I'll make subtickets for all this so we can parallelize work in the schema editor feature. 


