### PR TITLE
host: Add application global outside of production

### DIFF
--- a/packages/host/app/instance-initializers/export-application-global.ts
+++ b/packages/host/app/instance-initializers/export-application-global.ts
@@ -1,0 +1,21 @@
+import ApplicationInstance from '@ember/application/instance';
+import config from '@cardstack/host/config/environment';
+
+export function initialize(appInstance: ApplicationInstance): void {
+  if (config.environment !== 'production' && typeof window !== 'undefined') {
+    let globalName = config.modulePrefix;
+    let global = window as any;
+
+    if (!global[globalName]) {
+      global[globalName] = appInstance;
+
+      appInstance.willDestroy = function () {
+        delete global[globalName];
+      };
+    }
+  }
+}
+
+export default {
+  initialize,
+};


### PR DESCRIPTION
This is a DX improvement to access the application in the Javascript console with `window['@cardstack/host']`, in development and test environments only. The implementation is a simplified version of [deprecated addon code](https://github.com/ember-cli/ember-export-application-global/blob/master/app/initializers/export-application-global.js).