### PR TITLE
host: Fix component constructor types

### DIFF
--- a/packages/host/app/components/card-catalog/modal.gts
+++ b/packages/host/app/components/card-catalog/modal.gts
@@ -5,6 +5,7 @@ import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { registerDestructor } from '@ember/destroyable';
+import type Owner from '@ember/owner';
 import { task } from 'ember-concurrency';
 import debounce from 'lodash/debounce';
 import type { CardDef, CardContext } from 'https://cardstack.com/base/card-api';
@@ -195,7 +196,7 @@ export default class CardCatalogModal extends Component<Signature> {
   @service declare cardService: CardService;
   @service declare loaderService: LoaderService;
 
-  constructor(owner: unknown, args: {}) {
+  constructor(owner: Owner, args: {}) {
     super(owner, args);
     (globalThis as any)._CARDSTACK_CARD_CHOOSER = this;
     registerDestructor(this, () => {

--- a/packages/host/app/components/card-prerender.gts
+++ b/packages/host/app/components/card-prerender.gts
@@ -15,6 +15,7 @@ import type RenderService from '../services/render-service';
 import type LoaderService from '../services/loader-service';
 import type LocalIndexer from '../services/local-indexer';
 import type { LocalPath } from '@cardstack/runtime-common/paths';
+import type Owner from '@ember/owner';
 
 // This component is used in a node/Fastboot context to perform
 // server-side rendering for indexing as well as by the TestRealm
@@ -25,7 +26,7 @@ export default class CardPrerender extends Component {
   @service declare fastboot: { isFastBoot: boolean };
   @service declare localIndexer: LocalIndexer;
 
-  constructor(owner: unknown, args: any) {
+  constructor(owner: Owner, args: any) {
     super(owner, args);
     if (this.fastboot.isFastBoot) {
       try {

--- a/packages/host/app/components/card-prerender.gts
+++ b/packages/host/app/components/card-prerender.gts
@@ -26,7 +26,7 @@ export default class CardPrerender extends Component {
   @service declare fastboot: { isFastBoot: boolean };
   @service declare localIndexer: LocalIndexer;
 
-  constructor(owner: Owner, args: any) {
+  constructor(owner: Owner, args: {}) {
     super(owner, args);
     if (this.fastboot.isFastBoot) {
       try {

--- a/packages/host/app/components/create-card-modal.gts
+++ b/packages/host/app/components/create-card-modal.gts
@@ -10,6 +10,7 @@ import { registerDestructor } from '@ember/destroyable';
 import { Deferred } from '@cardstack/runtime-common/deferred';
 import { enqueueTask } from 'ember-concurrency';
 import { service } from '@ember/service';
+import type Owner from '@ember/owner';
 import type CardService from '../services/card-service';
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 import CardEditor from './card-editor';
@@ -42,7 +43,7 @@ export default class CreateCardModal extends Component {
     | undefined = undefined;
   @tracked zIndex = 20;
 
-  constructor(owner: unknown, args: {}) {
+  constructor(owner: Owner, args: {}) {
     super(owner, args);
     (globalThis as any)._CARDSTACK_CREATE_NEW_CARD = this;
     registerDestructor(this, () => {

--- a/packages/host/app/components/editor/go.gts
+++ b/packages/host/app/components/editor/go.gts
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { on } from '@ember/modifier';
 import { restartableTask, timeout } from 'ember-concurrency';
+import type Owner from '@ember/owner';
 import { service } from '@ember/service';
 //@ts-ignore cached not available yet in definitely typed
 import { cached } from '@glimmer/tracking';
@@ -164,7 +165,7 @@ export default class Go extends Component<Signature> {
   // note this is only subscribed to events from our own realm
   private subscription: { url: string; unsubscribe: () => void } | undefined;
 
-  constructor(owner: unknown, args: Signature['Args']) {
+  constructor(owner: Owner, args: Signature['Args']) {
     super(owner, args);
     let url = `${this.cardService.defaultURL}_message`;
     this.subscription = {

--- a/packages/host/app/components/matrix/chat-sidebar.gts
+++ b/packages/host/app/components/matrix/chat-sidebar.gts
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { action } from '@ember/object';
+import type Owner from '@ember/owner';
 import { on } from '@ember/modifier';
 import UserProfile from './user-profile';
 import Login from './login';
@@ -96,7 +97,7 @@ export default class ChatSidebar extends Component<Args> {
   @service declare matrixService: MatrixService;
   @tracked isRegistrationMode = false;
 
-  constructor(owner: unknown, args: any) {
+  constructor(owner: Owner, args: any) {
     super(owner, args);
     this.loadMatrix.perform();
   }

--- a/packages/host/app/components/matrix/chat-sidebar.gts
+++ b/packages/host/app/components/matrix/chat-sidebar.gts
@@ -97,7 +97,7 @@ export default class ChatSidebar extends Component<Args> {
   @service declare matrixService: MatrixService;
   @tracked isRegistrationMode = false;
 
-  constructor(owner: Owner, args: any) {
+  constructor(owner: Owner, args: Args['Args']) {
     super(owner, args);
     this.loadMatrix.perform();
   }

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { action } from '@ember/object';
+import type Owner from '@ember/owner';
 import { on } from '@ember/modifier';
 //@ts-expect-error the types don't recognize the cached export
 import { tracked, cached } from '@glimmer/tracking';
@@ -294,7 +295,7 @@ export default class Room extends Component<RoomArgs> {
     new TrackedMap();
   private roomResource = getRoom(this, () => this.args.roomId);
 
-  constructor(owner: unknown, args: any) {
+  constructor(owner: Owner, args: any) {
     super(owner, args);
     this.doMatrixEventFlush.perform();
 

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -295,7 +295,7 @@ export default class Room extends Component<RoomArgs> {
     new TrackedMap();
   private roomResource = getRoom(this, () => this.args.roomId);
 
-  constructor(owner: Owner, args: any) {
+  constructor(owner: Owner, args: RoomArgs['Args']) {
     super(owner, args);
     this.doMatrixEventFlush.perform();
 

--- a/packages/host/app/components/matrix/rooms-manager.gts
+++ b/packages/host/app/components/matrix/rooms-manager.gts
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { action } from '@ember/object';
+import type Owner from '@ember/owner';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 //@ts-expect-error the types don't recognize the cached export
@@ -230,7 +231,7 @@ export default class RoomsManager extends Component {
   @tracked private currentRoomId: string | undefined;
   private currentRoomResource = getRoom(this, () => this.currentRoomId);
 
-  constructor(owner: unknown, args: any) {
+  constructor(owner: Owner, args: any) {
     super(owner, args);
     this.loadRooms.perform();
   }

--- a/packages/host/app/components/matrix/rooms-manager.gts
+++ b/packages/host/app/components/matrix/rooms-manager.gts
@@ -231,7 +231,7 @@ export default class RoomsManager extends Component {
   @tracked private currentRoomId: string | undefined;
   private currentRoomResource = getRoom(this, () => this.currentRoomId);
 
-  constructor(owner: Owner, args: any) {
+  constructor(owner: Owner, args: {}) {
     super(owner, args);
     this.loadRooms.perform();
   }

--- a/packages/host/app/components/matrix/user-profile.gts
+++ b/packages/host/app/components/matrix/user-profile.gts
@@ -88,7 +88,7 @@ export default class UserProfile extends Component {
   @tracked private isEditMode = false;
   @tracked private displayName: string | undefined;
 
-  constructor(owner: Owner, args: any) {
+  constructor(owner: Owner, args: {}) {
     super(owner, args);
     if (!this.matrixService.isLoggedIn) {
       throw new Error(

--- a/packages/host/app/components/matrix/user-profile.gts
+++ b/packages/host/app/components/matrix/user-profile.gts
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import type Owner from '@ember/owner';
 import {
   Button,
   FieldContainer,
@@ -87,7 +88,7 @@ export default class UserProfile extends Component {
   @tracked private isEditMode = false;
   @tracked private displayName: string | undefined;
 
-  constructor(owner: unknown, args: any) {
+  constructor(owner: Owner, args: any) {
     super(owner, args);
     if (!this.matrixService.isLoggedIn) {
       throw new Error(

--- a/packages/host/app/components/operator-mode/code-mode.gts
+++ b/packages/host/app/components/operator-mode/code-mode.gts
@@ -5,6 +5,7 @@ import { registerDestructor } from '@ember/destroyable';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import type Owner from '@ember/owner';
 import { service } from '@ember/service';
 import { htmlSafe } from '@ember/template';
 import { task, restartableTask, timeout } from 'ember-concurrency';
@@ -123,8 +124,8 @@ export default class CodeMode extends Component<Signature> {
   // the realm is the same
   private cachedRealmInfo: RealmInfo | null = null;
 
-  constructor(args: any, owner: any) {
-    super(args, owner);
+  constructor(owner: Owner, args: Signature['Args']) {
+    super(owner, args);
     this.panelWidths = localStorage.getItem(CodeModePanelWidths)
       ? // @ts-ignore Type 'null' is not assignable to type 'string'
         JSON.parse(localStorage.getItem(CodeModePanelWidths))

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { on } from '@ember/modifier';
 import { CardDef, Format } from 'https://cardstack.com/base/card-api';
 import { action } from '@ember/object';
+import type Owner from '@ember/owner';
 import { fn } from '@ember/helper';
 import { trackedFunction } from 'ember-resources/util/function';
 import CardCatalogModal from '../card-catalog/modal';
@@ -95,7 +96,7 @@ export default class OperatorModeContainer extends Component<Signature> {
 
   private deleteModal: DeleteModal | undefined;
 
-  constructor(owner: unknown, args: any) {
+  constructor(owner: Owner, args: any) {
     super(owner, args);
 
     this.messageService.register();

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -96,7 +96,7 @@ export default class OperatorModeContainer extends Component<Signature> {
 
   private deleteModal: DeleteModal | undefined;
 
-  constructor(owner: Owner, args: any) {
+  constructor(owner: Owner, args: Signature['Args']) {
     super(owner, args);
 
     this.messageService.register();

--- a/packages/host/app/components/operator-mode/copy-button.gts
+++ b/packages/host/app/components/operator-mode/copy-button.gts
@@ -96,7 +96,7 @@ export default class OperatorModeContainer extends Component<Signature> {
     </style>
   </template>
 
-  constructor(owner: Owner, args: any) {
+  constructor(owner: Owner, args: Signature['Args']) {
     super(owner, args);
     this.loadCardService.perform();
   }

--- a/packages/host/app/components/operator-mode/copy-button.gts
+++ b/packages/host/app/components/operator-mode/copy-button.gts
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { on } from '@ember/modifier';
+import type Owner from '@ember/owner';
 import { fn } from '@ember/helper';
 import { svgJar } from '@cardstack/boxel-ui/helpers/svg-jar';
 import { eq, gt, and } from '@cardstack/boxel-ui/helpers/truth-helpers';
@@ -95,7 +96,7 @@ export default class OperatorModeContainer extends Component<Signature> {
     </style>
   </template>
 
-  constructor(owner: unknown, args: any) {
+  constructor(owner: Owner, args: any) {
     super(owner, args);
     this.loadCardService.perform();
   }

--- a/packages/host/app/components/operator-mode/delete-modal.gts
+++ b/packages/host/app/components/operator-mode/delete-modal.gts
@@ -5,6 +5,7 @@ import { Deferred } from '@cardstack/runtime-common';
 import { on } from '@ember/modifier';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
+import type Owner from '@ember/owner';
 import { Modal, BoxelButton } from '@cardstack/boxel-ui';
 import cssVar from '@cardstack/boxel-ui/helpers/css-var';
 import type { CardDef } from 'https://cardstack.com/base/card-api';
@@ -89,7 +90,7 @@ export default class DeleteModal extends Component<Signature> {
     </style>
   </template>
 
-  constructor(owner: unknown, args: any) {
+  constructor(owner: Owner, args: any) {
     super(owner, args);
     this.args.onCreate(this);
   }

--- a/packages/host/app/components/operator-mode/delete-modal.gts
+++ b/packages/host/app/components/operator-mode/delete-modal.gts
@@ -90,7 +90,7 @@ export default class DeleteModal extends Component<Signature> {
     </style>
   </template>
 
-  constructor(owner: Owner, args: any) {
+  constructor(owner: Owner, args: Signature['Args']) {
     super(owner, args);
     this.args.onCreate(this);
   }

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import type Owner from '@ember/owner';
 import type {
   CardDef,
   Format,
@@ -91,7 +92,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
     fieldName: string | undefined;
   }>();
 
-  constructor(owner: unknown, args: any) {
+  constructor(owner: Owner, args: any) {
     super(owner, args);
     this.subscribeToCard.perform();
     this.subscribedCard = this.card;

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -92,7 +92,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
     fieldName: string | undefined;
   }>();
 
-  constructor(owner: Owner, args: any) {
+  constructor(owner: Owner, args: Signature['Args']) {
     super(owner, args);
     this.subscribeToCard.perform();
     this.subscribedCard = this.card;


### PR DESCRIPTION
I copypasted a component constructor with `args, owner` instead of `owner, args`, which caused problems, and I figured we should use the proper types when available.