### PR TITLE
Code mode auto save message

### DIFF
--- a/packages/boxel-ui/addon/styles/variables.css
+++ b/packages/boxel-ui/addon/styles/variables.css
@@ -86,6 +86,7 @@
   --boxel-200: #e8e8e8;
   --boxel-300: #d1d1d1;
   --boxel-400: #afafb7;
+  --boxel-450: #919191;
   --boxel-500: #5a586a;
   --boxel-600: #413e4e;
   --boxel-700: #272330;

--- a/packages/boxel-ui/public/assets/check-mark-teal.svg
+++ b/packages/boxel-ui/public/assets/check-mark-teal.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20"><g stroke="rgba(0,0,0,0.1)" stroke-width="1"><path d="M12.727,6l-6,6L4,9.273" transform="translate(6 7) translate(-4 -6)" fill="none" stroke="var(--icon-color, #03c4bf)" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/></g></svg>

--- a/packages/boxel-ui/public/assets/check-mark-teal.svg
+++ b/packages/boxel-ui/public/assets/check-mark-teal.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20"><g stroke="rgba(0,0,0,0.1)" stroke-width="1"><path d="M12.727,6l-6,6L4,9.273" transform="translate(6 7) translate(-4 -6)" fill="none" stroke="var(--icon-color, #03c4bf)" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/></g></svg>

--- a/packages/host/app/components/operator-mode/card-inheritance-panel.gts
+++ b/packages/host/app/components/operator-mode/card-inheritance-panel.gts
@@ -8,7 +8,7 @@ import {
   ClickableModuleDefinitionContainer,
 } from './definition-container';
 import { Ready } from '@cardstack/host/resources/file';
-// @ts-expect-error chaged doesn't have type yet
+// @ts-expect-error cached doesn't have type yet
 import { tracked, cached } from '@glimmer/tracking';
 import moment from 'moment';
 import { type AdoptionChainResource } from '@cardstack/host/resources/adoption-chain';

--- a/packages/host/app/components/operator-mode/card-inheritance-panel.gts
+++ b/packages/host/app/components/operator-mode/card-inheritance-panel.gts
@@ -36,7 +36,6 @@ export default class CardInheritancePanel extends Component<Args> {
 
   constructor(owner: unknown, args: any) {
     super(owner, args);
-    this.calculateLastModified();
     this.refreshSaveMsg = setInterval(
       () => this.calculateLastModified(),
       10 * 1000,

--- a/packages/host/app/components/operator-mode/card-inheritance-panel.gts
+++ b/packages/host/app/components/operator-mode/card-inheritance-panel.gts
@@ -10,12 +10,11 @@ import {
 import { Ready } from '@cardstack/host/resources/file';
 // @ts-expect-error cached doesn't have type yet
 import { tracked, cached } from '@glimmer/tracking';
-import moment from 'moment';
 import { type AdoptionChainResource } from '@cardstack/host/resources/adoption-chain';
 import { hash, array } from '@ember/helper';
+import { lastModifiedDate } from '../../resources/last-modified-date';
 import type OperatorModeStateService from '../../services/operator-mode-state-service';
 import { action } from '@ember/object';
-import { registerDestructor } from '@ember/destroyable';
 
 interface Args {
   Element: HTMLElement;
@@ -31,19 +30,7 @@ interface Args {
 
 export default class CardInheritancePanel extends Component<Args> {
   @service private declare operatorModeStateService: OperatorModeStateService;
-  @tracked private lastModified: string | undefined;
-  private refreshSaveMsg: number | undefined;
-
-  constructor(owner: unknown, args: any) {
-    super(owner, args);
-    this.refreshSaveMsg = setInterval(
-      () => this.calculateLastModified(),
-      10 * 1000,
-    ) as unknown as number;
-    registerDestructor(this, () => {
-      clearInterval(this.refreshSaveMsg);
-    });
-  }
+  private lastModified = lastModifiedDate(this, () => this.args.readyFile);
 
   @action
   updateCodePath(url: URL | undefined) {
@@ -56,30 +43,6 @@ export default class CardInheritancePanel extends Component<Args> {
     return this.args.adoptionChain?.types;
   }
 
-  @cached
-  get lastModifiedConsumer() {
-    this.args.readyFile.lastModified;
-    this.calculateLastModified();
-    return;
-  }
-
-  private calculateLastModified() {
-    if (this.args.readyFile.lastModified != undefined) {
-      if (
-        Date.now() / 1000 - moment(this.args.readyFile.lastModified).unix() <
-        10
-      ) {
-        this.lastModified = 'Last saved just now';
-      } else {
-        this.lastModified = `Last saved ${moment(
-          this.args.readyFile.lastModified,
-        ).fromNow()}`;
-      }
-    } else {
-      this.lastModified = undefined;
-    }
-  }
-
   private get fileExtension() {
     if (!this.args.cardInstance) {
       return '.' + this.args.readyFile.url.split('.').pop() || '';
@@ -90,9 +53,6 @@ export default class CardInheritancePanel extends Component<Args> {
 
   <template>
     <div class='container' ...attributes>
-      {{! this consumes the last modified date so we can recalcuate it when it invalidates}}
-      {{this.lastModifiedConsumer}}
-
       {{#if @cardInstance}}
         {{! JSON case when visting, eg Author/1.json }}
         {{#each this.adoptionChainTypes as |t|}}
@@ -101,7 +61,7 @@ export default class CardInheritancePanel extends Component<Args> {
             @fileExtension='.JSON'
             @realmInfo={{@realmInfo}}
             @realmIconURL={{@realmIconURL}}
-            @infoText={{this.lastModified}}
+            @infoText={{this.lastModified.value}}
             @actions={{array
               (hash label='Delete' handler=@delete icon='icon-trash')
             }}
@@ -125,7 +85,7 @@ export default class CardInheritancePanel extends Component<Args> {
             @fileExtension={{this.fileExtension}}
             @realmInfo={{@realmInfo}}
             @realmIconURL={{@realmIconURL}}
-            @infoText={{this.lastModified}}
+            @infoText={{this.lastModified.value}}
             @isActive={{true}}
             @actions={{array
               (hash label='Delete' handler=@delete icon='icon-trash')

--- a/packages/host/app/components/operator-mode/card-inheritance-panel.gts
+++ b/packages/host/app/components/operator-mode/card-inheritance-panel.gts
@@ -77,6 +77,7 @@ export default class CardInheritancePanel extends Component<Args> {
             @fileExtension={{this.fileExtension}}
             @realmInfo={{@realmInfo}}
             @realmIconURL={{@realmIconURL}}
+            @infoText={{this.lastModified}}
             @isActive={{true}}
             @actions={{array
               (hash label='Delete' handler=@delete icon='icon-trash')
@@ -105,9 +106,7 @@ export default class CardInheritancePanel extends Component<Args> {
 
   get lastModified() {
     if (this.args.readyFile.lastModified != undefined) {
-      return `Last saved was ${moment(
-        this.args.readyFile.lastModified,
-      ).fromNow()}`;
+      return `Last saved ${moment(this.args.readyFile.lastModified).fromNow()}`;
     }
     return;
   }

--- a/packages/host/app/components/operator-mode/code-mode.gts
+++ b/packages/host/app/components/operator-mode/code-mode.gts
@@ -436,7 +436,9 @@ export default class CodeMode extends Component<Signature> {
   });
 
   private saveCard = restartableTask(async (card: CardDef) => {
-    await this.cardService.saveModel(card);
+    // these saves can happen so fast that we'll make sure to wait at
+    // least 500ms for human consumption
+    await all([this.cardService.saveModel(card), timeout(500)]);
   });
 
   private contentChangedTask = restartableTask(async (content: string) => {
@@ -524,7 +526,9 @@ export default class CodeMode extends Component<Signature> {
     }
 
     try {
-      await this.cardService.saveModel(card);
+      // these saves can happen so fast that we'll make sure to wait at
+      // least 500ms for human consumption
+      await all([this.cardService.saveModel(card), timeout(500)]);
       await this.maybeReloadCard.perform(card.id);
     } catch (e) {
       console.error('Failed to save single card document', e);

--- a/packages/host/app/components/operator-mode/code-mode.gts
+++ b/packages/host/app/components/operator-mode/code-mode.gts
@@ -728,7 +728,7 @@ export default class CodeMode extends Component<Signature> {
                     <span class='saved-msg'>
                       Saved
                     </span>
-                    {{svgJar 'check-mark-teal' width='27' height='27'}}
+                    {{svgJar 'check-mark' width='27' height='27'}}
                   {{/if}}
                 </div>
               {{else if this.isLoading}}
@@ -921,6 +921,7 @@ export default class CodeMode extends Component<Signature> {
       }
 
       .save-indicator {
+        --icon-color: var(--boxel-highlight);
         position: absolute;
         display: flex;
         align-items: center;

--- a/packages/host/app/components/operator-mode/code-mode.gts
+++ b/packages/host/app/components/operator-mode/code-mode.gts
@@ -719,7 +719,11 @@ export default class CodeMode extends Component<Signature> {
                     <span class='saving-msg'>
                       Now Saving
                     </span>
-                    <LoadingIndicator />
+                    <span class='save-spinner'>
+                      <span class='save-spinner-inner'>
+                        <LoadingIndicator />
+                      </span>
+                    </span>
                   {{else}}
                     <span class='saved-msg'>
                       Saved
@@ -936,6 +940,15 @@ export default class CodeMode extends Component<Signature> {
       .save-indicator.visible {
         transform: translateX(0px);
         transition-delay: 0s;
+      }
+      .save-spinner {
+        display: inline-block;
+        position: relative;
+      }
+      .save-spinner-inner {
+        display: inline-block;
+        position: absolute;
+        top: -7px;
       }
       .saving-msg {
         margin-right: var(--boxel-sp-sm);

--- a/packages/host/app/components/operator-mode/definition-container/base.gts
+++ b/packages/host/app/components/operator-mode/definition-container/base.gts
@@ -169,9 +169,13 @@ export class Active extends Component<ActiveSignature> {
         gap: var(--boxel-sp-xs);
         align-self: flex-start;
       }
+      .info-footer {
+        margin-top: var(--boxel-sp-sm);
+      }
       .info-footer .message {
-        color: #919191;
-        font-weight: 200;
+        color: var(--boxel-450);
+        font: var(--boxel-font-xs);
+        font-weight: 500;
       }
     </style>
   </template>

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -249,7 +249,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
   private calculateLastSavedMsg() {
     this.lastSavedMsg =
       this.lastSaved != null
-        ? `Saved ${formatDistanceToNow(this.lastSaved)} ago`
+        ? `Saved ${(formatDistanceToNow(this.lastSaved), { addSuffix: true })}`
         : undefined;
   }
 

--- a/packages/host/app/resources/file.ts
+++ b/packages/host/app/resources/file.ts
@@ -43,6 +43,7 @@ export interface Ready {
   lastModified: string | undefined;
   realmURL: string;
   write(content: string, flushLoader?: boolean): void;
+  isWriting?: boolean;
 }
 
 export type FileResource = Loading | ServerError | NotFound | Ready;
@@ -71,6 +72,10 @@ class _FileResource extends Resource<Args> {
         this.subscription = undefined;
       }
     });
+  }
+
+  get isWriting() {
+    return this.writeTask.isRunning;
   }
 
   private setSubscription(

--- a/packages/host/app/resources/last-modified-date.ts
+++ b/packages/host/app/resources/last-modified-date.ts
@@ -1,0 +1,55 @@
+import { Resource } from 'ember-resources';
+import { tracked } from '@glimmer/tracking';
+import { formatDistanceToNow, parse } from 'date-fns';
+import { Ready as ReadyFile } from '@cardstack/host/resources/file';
+import { registerDestructor } from '@ember/destroyable';
+
+interface Args {
+  named: { file: ReadyFile };
+}
+
+export class LastModifiedDateResource extends Resource<Args> {
+  @tracked value: string | undefined;
+  private refresh: number | undefined;
+
+  modify(_positional: never[], named: Args['named']) {
+    this.calculate(named.file);
+    if (!this.refresh) {
+      this.refresh = setInterval(
+        () => this.calculate(named.file),
+        10 * 1000,
+      ) as unknown as number;
+      registerDestructor(this, () => {
+        clearInterval(this.refresh);
+      });
+    }
+  }
+
+  private calculate(file: ReadyFile) {
+    if (file.lastModified != undefined) {
+      // This is RFC-7321 format which is the last modified date format used in HTTP headers
+      let date = parse(
+        file.lastModified.replace(/ GMT$/, 'Z'),
+        'EEE, dd MMM yyyy HH:mm:ssX',
+        new Date(),
+      );
+      if (Date.now() - date.getTime() < 10 * 1000) {
+        this.value = 'Last saved just now';
+      } else {
+        this.value = `Last saved ${formatDistanceToNow(date, {
+          addSuffix: true,
+        })}`;
+      }
+    } else {
+      this.value = undefined;
+    }
+  }
+}
+
+export function lastModifiedDate(parent: object, file: () => ReadyFile) {
+  return LastModifiedDateResource.from(parent, () => ({
+    named: {
+      file: file(),
+    },
+  }));
+}

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -615,7 +615,7 @@ module('Acceptance | code mode tests', function (hooks) {
       .dom(
         '[data-test-card-instance-definition] [data-test-definition-info-text]',
       )
-      .includesText('Last saved was a few seconds ago');
+      .includesText('Last saved just now');
 
     assert.dom('[data-test-card-instance-definition]').hasClass('active');
   });

--- a/packages/host/tests/acceptance/operator-mode-test.ts
+++ b/packages/host/tests/acceptance/operator-mode-test.ts
@@ -1253,7 +1253,7 @@ module('Acceptance | operator mode tests', function (hooks) {
   });
 
   test<TestContextWithSave>('unsaved changes made in card editor are saved when switching out of code mode', async function (assert) {
-    assert.expect(2); // the test waiters permit a normal auto-save to sneak in. the 2nd save is the save on close.
+    assert.expect(1);
 
     let operatorModeStateParam = stringify({
       stacks: [

--- a/packages/host/tests/acceptance/operator-mode-test.ts
+++ b/packages/host/tests/acceptance/operator-mode-test.ts
@@ -1195,7 +1195,6 @@ module('Acceptance | operator mode tests', function (hooks) {
       JSON.stringify(expected, null, 2),
       'monaco content has updated',
     );
-    await percySnapshot(assert);
   });
 
   test<TestContextWithSave>('non-card instance change made in monaco editor is auto-saved', async function (assert) {

--- a/packages/host/tests/acceptance/operator-mode-test.ts
+++ b/packages/host/tests/acceptance/operator-mode-test.ts
@@ -1195,6 +1195,7 @@ module('Acceptance | operator mode tests', function (hooks) {
       JSON.stringify(expected, null, 2),
       'monaco content has updated',
     );
+    await percySnapshot(assert);
   });
 
   test<TestContextWithSave>('non-card instance change made in monaco editor is auto-saved', async function (assert) {
@@ -1221,6 +1222,8 @@ module('Acceptance | operator mode tests', function (hooks) {
     setMonacoContent('Hello Mars');
 
     await waitFor('[data-test-save-idle]');
+
+    await percySnapshot(assert);
   });
 
   test<TestContextWithSave>('unsaved changes made in monaco editor are saved when switching out of code mode', async function (assert) {
@@ -1387,6 +1390,8 @@ module('Acceptance | operator mode tests', function (hooks) {
         await waitFor('[data-test-save-idle]');
       },
     );
+
+    await percySnapshot(assert);
 
     let fileRef = await adapter.openFile('pet.gts');
     if (!fileRef) {


### PR DESCRIPTION
This add an auto-save message to code mode, as well as make the "last saved" message live update. The test waiters make this very hard to since it's an interstitial state masked by the test waiters. Maybe percy can see it?

![last-saved-message](https://github.com/cardstack/boxel/assets/61075/7bb598f8-e414-480d-b569-33f2439cc904)


