### PR TITLE
Refactor ResizablePanelGroup to use contextual components pattern

### DIFF
--- a/packages/boxel-ui/addon/components/resizable-panel-group/index.gts
+++ b/packages/boxel-ui/addon/components/resizable-panel-group/index.gts
@@ -1,22 +1,15 @@
 import Component from '@glimmer/component';
-import { hash } from '@ember/helper';
 import { action } from '@ember/object';
 import { registerDestructor } from '@ember/destroyable';
 import { TrackedMap } from 'tracked-built-ins';
 import didResizeModifier from 'ember-resize-modifier/modifiers/did-resize';
+import ResizablePanel from './panel';
+import { WithBoundArgs } from '@glint/template';
 
 export type PanelContext = {
   width: string;
   defaultWidth: string;
   minWidth?: string;
-};
-
-export type PanelGroupApi = {
-  registerPanel: (context: PanelContext) => number;
-  panelContext: (panelId: number) => PanelContext | undefined;
-  isLastPanel: (panelId: number) => boolean;
-  onResizeHandlerMouseDown: (event: MouseEvent) => void;
-  onResizeHandlerDblClick: (event: MouseEvent) => void;
 };
 
 interface Signature {
@@ -25,7 +18,16 @@ interface Signature {
     onListPanelContextChange?: (listPanelContext: PanelContext[]) => void;
   };
   Blocks: {
-    default: [{ api: PanelGroupApi }];
+    default: [
+      WithBoundArgs<
+        typeof ResizablePanel,
+        | 'registerPanel'
+        | 'panelContext'
+        | 'isLastPanel'
+        | 'onResizeHandlerMouseDown'
+        | 'onResizeHandlerDblClick'
+      >,
+    ];
   };
 }
 
@@ -37,14 +39,13 @@ export default class ResizablePanelGroup extends Component<Signature> {
       ...attributes
     >
       {{yield
-        (hash
-          api=(hash
-            registerPanel=this.registerPanel
-            panelContext=this.panelContext
-            isLastPanel=this.isLastPanel
-            onResizeHandlerMouseDown=this.onResizeHandlerMouseDown
-            onResizeHandlerDblClick=this.onResizeHandlerDblClick
-          )
+        (component
+          ResizablePanel
+          registerPanel=this.registerPanel
+          panelContext=this.panelContext
+          isLastPanel=this.isLastPanel
+          onResizeHandlerMouseDown=this.onResizeHandlerMouseDown
+          onResizeHandlerDblClick=this.onResizeHandlerDblClick
         )
       }}
     </div>

--- a/packages/boxel-ui/addon/components/resizable-panel-group/usage.gts
+++ b/packages/boxel-ui/addon/components/resizable-panel-group/usage.gts
@@ -2,8 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { fn } from '@ember/helper';
 import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
-import ResizablePanelGroup from './resizable-panel-group';
-import ResizablePanel from './resizable-panel';
+import ResizablePanelGroup from './index';
 import cssVar from '@cardstack/boxel-ui/helpers/css-var';
 import {
   cssVariable,
@@ -27,11 +26,10 @@ export default class ResizablePanelUsage extends Component {
   <template>
     <FreestyleUsage @name='ThreadMessage'>
       <:example>
-        <ResizablePanelGroup as |pg|>
+        <ResizablePanelGroup as |ResizablePanel|>
           <ResizablePanel
             @defaultWidth={{this.panel1DefaultWidth}}
             @minWidth={{this.panel1MinWidth}}
-            @panelGroupApi={{pg.api}}
             style={{cssVar
               boxel-panel-resize-handler-height=this.boxelPanelResizeHandlerHeight.value
               boxel-panel-resize-handler-background-color=this.boxelPanelResizeHandlerBackgroundColor.value
@@ -42,7 +40,6 @@ export default class ResizablePanelUsage extends Component {
           <ResizablePanel
             @defaultWidth={{this.panel2DefaultWidth}}
             @minWidth={{this.panel2MinWidth}}
-            @panelGroupApi={{pg.api}}
             style={{cssVar
               boxel-panel-resize-handler-height=this.boxelPanelResizeHandlerHeight.value
               boxel-panel-resize-handler-background-color=this.boxelPanelResizeHandlerBackgroundColor.value
@@ -53,7 +50,6 @@ export default class ResizablePanelUsage extends Component {
           <ResizablePanel
             @defaultWidth={{this.panel3DefaultWidth}}
             @minWidth={{this.panel3MinWidth}}
-            @panelGroupApi={{pg.api}}
             style={{cssVar
               boxel-panel-resize-handler-height=this.boxelPanelResizeHandlerHeight.value
               boxel-panel-resize-handler-background-color=this.boxelPanelResizeHandlerBackgroundColor.value

--- a/packages/boxel-ui/addon/index.ts
+++ b/packages/boxel-ui/addon/index.ts
@@ -22,8 +22,7 @@ import BoxelButton from './components/button';
 import Tooltip from './components/tooltip';
 import ResizablePanelGroup, {
   PanelContext,
-} from './components/resizable-panel/resizable-panel-group';
-import ResizablePanel from './components/resizable-panel/resizable-panel';
+} from './components/resizable-panel-group';
 
 export {
   AddButton,
@@ -49,5 +48,4 @@ export {
   Tooltip,
   ResizablePanelGroup,
   PanelContext,
-  ResizablePanel,
 };

--- a/packages/boxel-ui/tests/dummy/app/controllers/index.js
+++ b/packages/boxel-ui/tests/dummy/app/controllers/index.js
@@ -16,7 +16,7 @@ import ModalUsage from '@cardstack/boxel-ui/components/modal/usage';
 import MenuUsage from '@cardstack/boxel-ui/components/menu/usage';
 import DropdownUsage from '@cardstack/boxel-ui/components/dropdown/usage';
 import TooltipUsage from '@cardstack/boxel-ui/components/tooltip/usage';
-import ResizablePanelUsage from '@cardstack/boxel-ui/components/resizable-panel/usage';
+import ResizablePanelGroupUsage from '@cardstack/boxel-ui/components/resizable-panel-group/usage';
 
 export default class IndexController extends FreestyleController {
   constructor() {
@@ -39,7 +39,7 @@ export default class IndexController extends FreestyleController {
       ['Boxel::Menu', MenuUsage],
       ['Boxel::Dropdown', DropdownUsage],
       ['Boxel::Tooltip', TooltipUsage],
-      ['Boxel::ResizablePanel', ResizablePanelUsage],
+      ['Boxel::ResizablePanel', ResizablePanelGroupUsage],
     ].map(([name, c]) => {
       return {
         title: name,

--- a/packages/host/app/components/operator-mode/code-mode.gts
+++ b/packages/host/app/components/operator-mode/code-mode.gts
@@ -33,7 +33,6 @@ import {
   LoadingIndicator,
   Button,
   ResizablePanelGroup,
-  ResizablePanel,
   PanelContext,
 } from '@cardstack/boxel-ui';
 import cn from '@cardstack/boxel-ui/helpers/cn';
@@ -591,12 +590,11 @@ export default class CodeMode extends Component<Signature> {
       <ResizablePanelGroup
         @onListPanelContextChange={{this.onListPanelContextChange}}
         class='columns'
-        as |pg|
+        as |ResizablePanel|
       >
         <ResizablePanel
           @defaultWidth={{defaultPanelWidths.leftPanel}}
           @width='var(--operator-mode-left-column)'
-          @panelGroupApi={{pg.api}}
         >
           <div class='column'>
             {{! Move each container and styles to separate component }}
@@ -681,7 +679,6 @@ export default class CodeMode extends Component<Signature> {
             @defaultWidth={{defaultPanelWidths.codeEditorPanel}}
             @width={{this.panelWidths.codeEditorPanel}}
             @minWidth='300px'
-            @panelGroupApi={{pg.api}}
           >
             <div class='inner-container'>
               {{#if this.isReady}}
@@ -705,7 +702,6 @@ export default class CodeMode extends Component<Signature> {
           <ResizablePanel
             @defaultWidth={{defaultPanelWidths.rightPanel}}
             @width={{this.panelWidths.rightPanel}}
-            @panelGroupApi={{pg.api}}
           >
             <div class='inner-container'>
               {{#if this.cardIsLoaded}}
@@ -728,7 +724,6 @@ export default class CodeMode extends Component<Signature> {
           <ResizablePanel
             @defaultWidth={{defaultPanelWidths.emptyCodeModePanel}}
             @width={{this.panelWidths.emptyCodeModePanel}}
-            @panelGroupApi={{pg.api}}
           >
             <div
               class='inner-container inner-container--empty'


### PR DESCRIPTION
@FadhlanR this is a pattern often used in Ember apps. I think it is a small but nice improvement to your resizable panels implementation. 