### PR TITLE
host: Add to timeout for unreliable test

### DIFF
--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -2019,7 +2019,7 @@ module('Integration | operator-mode', function (hooks) {
 
     await fillIn(`[data-test-search-input] input`, `pet`);
     assert.dom(`[data-test-search-input] input`).hasValue('pet');
-    await waitFor('[data-test-card-catalog-item]', { timeout: 2000, count: 2 });
+    await waitFor('[data-test-card-catalog-item]', { timeout: 3000, count: 2 });
     await click(`[data-test-select="${testRealmURL}CatalogEntry/pet-room"]`);
     assert
       .dom(
@@ -2036,7 +2036,7 @@ module('Integration | operator-mode', function (hooks) {
       .doesNotExist('no cards are added');
 
     await click(`[data-test-create-new-card-button]`);
-    await waitFor('[data-test-card-catalog-item]', { timeout: 2000 });
+    await waitFor('[data-test-card-catalog-item]', { timeout: 3000 });
     assert
       .dom(`[data-test-search-input] input`)
       .hasNoValue('Card picker state is reset');

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -2019,7 +2019,7 @@ module('Integration | operator-mode', function (hooks) {
 
     await fillIn(`[data-test-search-input] input`, `pet`);
     assert.dom(`[data-test-search-input] input`).hasValue('pet');
-    await waitFor('[data-test-card-catalog-item]', { count: 2 });
+    await waitFor('[data-test-card-catalog-item]', { timeout: 2000, count: 2 });
     await click(`[data-test-select="${testRealmURL}CatalogEntry/pet-room"]`);
     assert
       .dom(
@@ -2036,7 +2036,7 @@ module('Integration | operator-mode', function (hooks) {
       .doesNotExist('no cards are added');
 
     await click(`[data-test-create-new-card-button]`);
-    await waitFor('[data-test-card-catalog-item]');
+    await waitFor('[data-test-card-catalog-item]', { timeout: 2000 });
     assert
       .dom(`[data-test-search-input] input`)
       .hasNoValue('Card picker state is reset');


### PR DESCRIPTION
I actually just saw this fail locally too but it did [earlier on `main`](https://github.com/cardstack/boxel/actions/runs/6252896720/job/16977158880#step:7:1762), this is a targeted fix that extends the relevant timeouts:

<img width="876" alt="✖ Boxel Tests 2023-09-20 22-30-00" src="https://github.com/cardstack/boxel/assets/43280/7f1c4bfa-ec49-4f77-894d-90570b2a5920">
