### PR TITLE
Fix test using a mock redirected response

### DIFF
--- a/packages/host/app/resources/file.ts
+++ b/packages/host/app/resources/file.ts
@@ -9,7 +9,6 @@ import type MessageService from '../services/message-service';
 import type CardService from '@cardstack/host/services/card-service';
 import type RecentFilesService from '@cardstack/host/services/recent-files-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
-import config from '@cardstack/host/config/environment';
 
 const log = logger('resource:file');
 
@@ -154,24 +153,14 @@ class _FileResource extends Resource<Args> {
 
     let content = await response.text();
     let self = this;
-    // Inside test, The loader occasionally doesn't do a network request and creates Response object manually
-    // This means that reading response.url will give url = '' and we cannot manually alter the url in Response
-    // The below condition is a workaround
-    // TODO: CS-5982
-    let url: string;
-    if (config.environment === 'test') {
-      url = response.url === '' ? this._url : response.url;
-    } else {
-      url = response.url;
-    }
 
     this.updateState({
       state: 'ready',
       lastModified,
       realmURL,
       content,
-      name: url.split('/').pop()!,
-      url: url,
+      name: response.url.split('/').pop()!,
+      url: response.url,
       write(content: string, flushLoader?: true) {
         self.writeTask.perform(this, content, flushLoader);
       },

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -16,6 +16,7 @@ import {
   setupLocalIndexing,
   setupMockMessageService,
   testRealmURL,
+  sourceFetchRedirectHandle,
 } from '../helpers';
 import stringify from 'safe-stable-stringify';
 import { Realm } from '@cardstack/runtime-common/realm';
@@ -170,7 +171,9 @@ module('Acceptance | code mode tests', function (hooks) {
 
     realm = await TestRealm.createWithAdapter(adapter, loader, this.owner, {
       isAcceptanceTest: true,
-      manualRedirect: true,
+      overridingHandlers: [
+        (req: Request) => sourceFetchRedirectHandle(req, adapter),
+      ],
     });
     await realm.ready;
   });

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -170,6 +170,7 @@ module('Acceptance | code mode tests', function (hooks) {
 
     realm = await TestRealm.createWithAdapter(adapter, loader, this.owner, {
       isAcceptanceTest: true,
+      manualRedirect: true,
     });
     await realm.ready;
   });

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -17,6 +17,7 @@ import {
   setupMockMessageService,
   testRealmURL,
   sourceFetchRedirectHandle,
+  sourceFetchReturnUrlHandle,
 } from '../helpers';
 import stringify from 'safe-stable-stringify';
 import { Realm } from '@cardstack/runtime-common/realm';
@@ -172,7 +173,12 @@ module('Acceptance | code mode tests', function (hooks) {
     realm = await TestRealm.createWithAdapter(adapter, loader, this.owner, {
       isAcceptanceTest: true,
       overridingHandlers: [
-        (req: Request) => sourceFetchRedirectHandle(req, adapter),
+        async (req: Request) => {
+          return sourceFetchRedirectHandle(req, adapter);
+        },
+        async (req: Request) => {
+          return sourceFetchReturnUrlHandle(req, realm.maybeHandle.bind(realm));
+        },
       ],
     });
     await realm.ready;

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -174,7 +174,7 @@ module('Acceptance | code mode tests', function (hooks) {
       isAcceptanceTest: true,
       overridingHandlers: [
         async (req: Request) => {
-          return sourceFetchRedirectHandle(req, adapter);
+          return sourceFetchRedirectHandle(req, adapter, testRealmURL);
         },
         async (req: Request) => {
           return sourceFetchReturnUrlHandle(req, realm.maybeHandle.bind(realm));

--- a/packages/host/tests/acceptance/operator-mode-test.ts
+++ b/packages/host/tests/acceptance/operator-mode-test.ts
@@ -260,6 +260,7 @@ module('Acceptance | operator mode tests', function (hooks) {
 
     realm = await TestRealm.createWithAdapter(adapter, loader, this.owner, {
       isAcceptanceTest: true,
+      manualRedirect: true,
     });
     await realm.ready;
   });

--- a/packages/host/tests/acceptance/operator-mode-test.ts
+++ b/packages/host/tests/acceptance/operator-mode-test.ts
@@ -23,6 +23,7 @@ import {
   waitForSyntaxHighlighting,
   type TestContextWithSSE,
   type TestContextWithSave,
+  sourceFetchRedirectHandle,
 } from '../helpers';
 import { type LooseSingleCardDocument } from '@cardstack/runtime-common';
 import stringify from 'safe-stable-stringify';
@@ -260,7 +261,9 @@ module('Acceptance | operator mode tests', function (hooks) {
 
     realm = await TestRealm.createWithAdapter(adapter, loader, this.owner, {
       isAcceptanceTest: true,
-      manualRedirect: true,
+      overridingHandlers: [
+        (req: Request) => sourceFetchRedirectHandle(req, adapter),
+      ],
     });
     await realm.ready;
   });

--- a/packages/host/tests/acceptance/operator-mode-test.ts
+++ b/packages/host/tests/acceptance/operator-mode-test.ts
@@ -264,7 +264,7 @@ module('Acceptance | operator mode tests', function (hooks) {
       isAcceptanceTest: true,
       overridingHandlers: [
         async (req: Request) => {
-          return sourceFetchRedirectHandle(req, adapter);
+          return sourceFetchRedirectHandle(req, adapter, testRealmURL);
         },
         async (req: Request) => {
           return sourceFetchReturnUrlHandle(req, realm.maybeHandle.bind(realm));

--- a/packages/host/tests/acceptance/operator-mode-test.ts
+++ b/packages/host/tests/acceptance/operator-mode-test.ts
@@ -24,6 +24,7 @@ import {
   type TestContextWithSSE,
   type TestContextWithSave,
   sourceFetchRedirectHandle,
+  sourceFetchReturnUrlHandle,
 } from '../helpers';
 import { type LooseSingleCardDocument } from '@cardstack/runtime-common';
 import stringify from 'safe-stable-stringify';
@@ -262,7 +263,12 @@ module('Acceptance | operator mode tests', function (hooks) {
     realm = await TestRealm.createWithAdapter(adapter, loader, this.owner, {
       isAcceptanceTest: true,
       overridingHandlers: [
-        (req: Request) => sourceFetchRedirectHandle(req, adapter),
+        async (req: Request) => {
+          return sourceFetchRedirectHandle(req, adapter);
+        },
+        async (req: Request) => {
+          return sourceFetchReturnUrlHandle(req, realm.maybeHandle.bind(realm));
+        },
       ],
     });
     await realm.ready;

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -707,7 +707,7 @@ export async function sourceFetchReturnUrlHandle(
 export async function sourceFetchRedirectHandle(
   request: Request,
   adapter: RealmAdapter,
-  realmURL: string = testRealmURL,
+  realmURL: string,
 ) {
   let urlParts = new URL(request.url).pathname.split('.');
   if (

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -11,7 +11,6 @@ import {
   executableExtensions,
   SupportedMimeType,
 } from '@cardstack/runtime-common';
-import { notFound } from '@cardstack/runtime-common/error';
 import { getFileWithFallbacks } from '@cardstack/runtime-common/stream';
 import GlimmerComponent from '@glimmer/component';
 import { type TestContext, visit } from '@ember/test-helpers';

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -707,13 +707,14 @@ export async function sourceFetchReturnUrlHandle(
 export async function sourceFetchRedirectHandle(
   request: Request,
   adapter: RealmAdapter,
+  realmURL: string = testRealmURL,
 ) {
   let urlParts = new URL(request.url).pathname.split('.');
   if (
     isCardSourceFetch(request) &&
     urlParts.length === 1 //has no extension
   ) {
-    const realmPaths = new RealmPaths(testRealmURL);
+    const realmPaths = new RealmPaths(realmURL);
     const localPath = realmPaths.local(request.url);
     const ref = await getFileWithFallbacks(
       localPath,
@@ -731,7 +732,7 @@ export async function sourceFetchRedirectHandle(
         ref.content instanceof Uint8Array ||
         typeof ref.content === 'string')
     ) {
-      let r = createResponse(testRealmURL, ref.content, {
+      let r = createResponse(realmURL, ref.content, {
         headers: {
           'last-modified': formatRFC7231(ref.lastModified),
         },

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -394,16 +394,11 @@ function makeRealm(
   if (manualRedirect) {
     let handler = async (req: Request) => {
       let urlParts = req.url.split('.');
-      let maybeExtension =
-        urlParts.length > 1 ? '.' + urlParts.pop() : undefined;
-      const hasExtension = maybeExtension
-        ? ['.json', ...executableExtensions].includes(maybeExtension)
-        : false;
       if (
         req.method === 'GET' &&
         req.headers.get('Accept') === SupportedMimeType.CardSource &&
-        !hasExtension &&
-        req.url.includes(testRealmURL)
+        req.url.includes(testRealmURL) &&
+        urlParts.length === 1 //has no extension
       ) {
         let r = await manualRedirectHandle(req, adapter);
         return r as Response;

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -708,7 +708,7 @@ export async function sourceFetchRedirectHandle(
   request: Request,
   adapter: RealmAdapter,
 ) {
-  let urlParts = request.url.split('.');
+  let urlParts = new URL(request.url).pathname.split('.');
   if (
     isCardSourceFetch(request) &&
     urlParts.length === 1 //has no extension

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -505,12 +505,10 @@ export class TestRealmAdapter implements RealmAdapter {
         throw new Error(`tried to use file as directory`);
       }
       this.#lastModified.set(this.#paths.fileURL(path).href, now);
-      content = typeof content === 'string' ? content : JSON.stringify(content);
-      dir[last] = content;
-      // for handling redirects
-      let [lastWithoutExtension, extension] = last.split('.');
-      if (executableExtensions.includes(extension)) {
-        dir[lastWithoutExtension] = content;
+      if (typeof content === 'string') {
+        dir[last] = content;
+      } else {
+        dir[last] = JSON.stringify(content);
       }
     }
   }

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -393,7 +393,9 @@ function makeRealm(
   }
   if (manualRedirect) {
     let handler = async (req: Request) => {
-      let maybeExtension = '.' + req.url.split('.').pop();
+      let urlParts = req.url.split('.');
+      let maybeExtension =
+        urlParts.length > 1 ? '.' + urlParts.pop() : undefined;
       const hasExtension = maybeExtension
         ? ['.json', ...executableExtensions].includes(maybeExtension)
         : false;
@@ -401,8 +403,7 @@ function makeRealm(
         req.method === 'GET' &&
         req.headers.get('Accept') === SupportedMimeType.CardSource &&
         !hasExtension &&
-        req.url.includes(testRealmURL) &&
-        req.url.split('.').length === 2
+        req.url.includes(testRealmURL)
       ) {
         let r = await manualRedirectHandle(req, adapter);
         return r as Response;

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -11,6 +11,7 @@ import {
   executableExtensions,
   SupportedMimeType,
 } from '@cardstack/runtime-common';
+import { notFound } from '@cardstack/runtime-common/error';
 import { getFileWithFallbacks } from '@cardstack/runtime-common/stream';
 import GlimmerComponent from '@glimmer/component';
 import { type TestContext, visit } from '@ember/test-helpers';
@@ -452,6 +453,11 @@ async function manualRedirectHandle(request: Request, adapter: RealmAdapter) {
     adapter.openFile.bind(adapter),
     executableExtensions,
   );
+  let maybeExtension = ref?.path.split('.').pop();
+  let responseUrl = maybeExtension
+    ? `${request.url}.${maybeExtension}`
+    : request.url;
+
   if (
     ref &&
     (ref.content instanceof ReadableStream ||
@@ -463,7 +469,7 @@ async function manualRedirectHandle(request: Request, adapter: RealmAdapter) {
         'last-modified': formatRFC7231(ref.lastModified),
       },
     });
-    return new MockRedirectedResponse(r.body, r, request.url + '.gts');
+    return new MockRedirectedResponse(r.body, r, responseUrl);
   }
   return null;
 }

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -622,7 +622,9 @@ module('Integration | operator-mode', function (hooks) {
       '.realm.json': `{ "name": "${realmName}", "iconURL": "https://example-icon.test" }`,
       ...Object.fromEntries(personCards),
     });
-    realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
+    realm = await TestRealm.createWithAdapter(adapter, loader, this.owner, {
+      manualRedirect: true,
+    });
     await realm.ready;
 
     setCardInOperatorModeState = async (cardURL: string) => {

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -627,7 +627,7 @@ module('Integration | operator-mode', function (hooks) {
     realm = await TestRealm.createWithAdapter(adapter, loader, this.owner, {
       overridingHandlers: [
         async (req: Request) => {
-          return sourceFetchRedirectHandle(req, adapter);
+          return sourceFetchRedirectHandle(req, adapter, testRealmURL);
         },
         async (req: Request) => {
           return sourceFetchReturnUrlHandle(req, realm.maybeHandle.bind(realm));

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -17,6 +17,7 @@ import {
   TestRealmAdapter,
   TestRealm,
   type TestContextWithSave,
+  sourceFetchRedirectHandle,
 } from '../../helpers';
 import { MockMatrixService } from '../../helpers/mock-matrix-service';
 import {
@@ -623,7 +624,9 @@ module('Integration | operator-mode', function (hooks) {
       ...Object.fromEntries(personCards),
     });
     realm = await TestRealm.createWithAdapter(adapter, loader, this.owner, {
-      manualRedirect: true,
+      overridingHandlers: [
+        (req: Request) => sourceFetchRedirectHandle(req, adapter),
+      ],
     });
     await realm.ready;
 

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -18,6 +18,7 @@ import {
   TestRealm,
   type TestContextWithSave,
   sourceFetchRedirectHandle,
+  sourceFetchReturnUrlHandle,
 } from '../../helpers';
 import { MockMatrixService } from '../../helpers/mock-matrix-service';
 import {
@@ -625,7 +626,12 @@ module('Integration | operator-mode', function (hooks) {
     });
     realm = await TestRealm.createWithAdapter(adapter, loader, this.owner, {
       overridingHandlers: [
-        (req: Request) => sourceFetchRedirectHandle(req, adapter),
+        async (req: Request) => {
+          return sourceFetchRedirectHandle(req, adapter);
+        },
+        async (req: Request) => {
+          return sourceFetchReturnUrlHandle(req, realm.maybeHandle.bind(realm));
+        },
       ],
     });
     await realm.ready;

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -152,8 +152,8 @@ export class Loader {
     this.urlHandlers.push(handler);
   }
 
-  setURLHandlers(handlers: RequestHandler[]) {
-    this.urlHandlers = handlers;
+  prependURLHandlers(handlers: RequestHandler[]) {
+    this.urlHandlers = [...handlers, ...this.urlHandlers];
   }
 
   shimModule(moduleIdentifier: string, module: Record<string, any>) {


### PR DESCRIPTION
This wud complete [CS-5982](https://linear.app/cardstack/issue/CS-5982/file-resource-cant-handle-returned-realm-response-in-test)


2 issues
- source fetching without an extension returns a 302, eg `person`. We usually rely on native fetch to follow this response, but since we use `realm.maybeHandle` in test our app just gets a 302
- source fetching with an extension doesn't return a response.url in host test, eg `person.gts` rather it returns `response.url =''`

**Solution**

create overriding url handlers that
- create a mock response that allows us to mutate return response.url. `Response` object doesn't allow this
- if we expect a redirect, just return the redirected response

There are ofcourse assumptions about how the handler overrides the request. I tried my best to restrict as much as possible and if the handler doesn't pick up the request just pass it along to its handlers set previously 

