### PR TITLE
Introduce realm info provider component for loading realm assets

### DIFF
--- a/packages/host/app/components/operator-mode/card-schema-editor.gts
+++ b/packages/host/app/components/operator-mode/card-schema-editor.gts
@@ -35,12 +35,20 @@ export default class CardSchemaEditor extends Component<Signature> {
       }
 
       .pill {
-        border: 1px solid gray;
-        display: inline-block;
+        border: 1px solid var(--boxel-400);
         padding: var(--boxel-sp-xxxs) var(--boxel-sp-xs);
         border-radius: 8px;
         background-color: white;
         font-weight: 600;
+        display: inline-flex;
+      }
+
+      .pill > div {
+        display: flex;
+      }
+
+      .pill > div > span {
+        margin: auto;
       }
 
       .realm-icon {
@@ -84,8 +92,8 @@ export default class CardSchemaEditor extends Component<Signature> {
       }
 
       .realm-icon > img {
-        height: 25px;
-        width: 25px;
+        height: 20px;
+        width: 20px;
       }
     </style>
 
@@ -94,14 +102,22 @@ export default class CardSchemaEditor extends Component<Signature> {
       data-test-card-schema={{@cardType.displayName}}
     >
       <div class='pill'>
-        <span class='realm-icon'>
-          <RealmInfoProvider @fileUrl='http://localhost:4201/drafts/asset'>
+        <div class='realm-icon'>
+          <RealmInfoProvider @fileUrl={{@cardType.module}}>
             <:ready as |realmInfo|>
-              <img src={{realmInfo.iconURL}} alt='Realm icon' />
+              <img
+                src={{realmInfo.iconURL}}
+                alt='Realm icon'
+                data-test-realm-icon-url={{realmInfo.iconURL}}
+              />
             </:ready>
           </RealmInfoProvider>
-        </span>
-        {{@cardType.displayName}}
+        </div>
+        <div>
+          <span>
+            {{@cardType.displayName}}
+          </span>
+        </div>
       </div>
 
       <div class='card-fields'>
@@ -117,19 +133,30 @@ export default class CardSchemaEditor extends Component<Signature> {
                 </div>
               </div>
               <div class='right'>
-
                 <div class='pill'>
-                  <span class='realm-icon'>
-                    🟪
-                  </span>
-                  {{#let
-                    (this.fieldCardDisplayName field.card)
-                    as |cardDisplayName|
-                  }}
-                    <span
-                      data-test-card-display-name={{cardDisplayName}}
-                    >{{cardDisplayName}}</span>
-                  {{/let}}
+                  <div class='realm-icon'>
+                    <RealmInfoProvider @fileUrl={{this.fieldModuleUrl field}}>
+                      <:ready as |realmInfo|>
+                        <img
+                          src={{realmInfo.iconURL}}
+                          alt='Realm icon'
+                          data-test-realm-icon-url={{realmInfo.iconURL}}
+                        />
+                      </:ready>
+                    </RealmInfoProvider>
+                  </div>
+                  <div>
+                    <span>
+                      {{#let
+                        (this.fieldCardDisplayName field.card)
+                        as |cardDisplayName|
+                      }}
+                        <span
+                          data-test-card-display-name={{cardDisplayName}}
+                        >{{cardDisplayName}}</span>
+                      {{/let}}
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -154,5 +181,9 @@ export default class CardSchemaEditor extends Component<Signature> {
       return internalKeyFor(card, undefined);
     }
     return card.displayName;
+  }
+
+  fieldModuleUrl(field: Type['fields'][0]) {
+    return (field.card as Type).module;
   }
 }

--- a/packages/host/app/components/operator-mode/card-schema-editor.gts
+++ b/packages/host/app/components/operator-mode/card-schema-editor.gts
@@ -103,7 +103,7 @@ export default class CardSchemaEditor extends Component<Signature> {
     >
       <div class='pill'>
         <div class='realm-icon'>
-          <RealmInfoProvider @fileUrl={{@cardType.module}}>
+          <RealmInfoProvider @fileURL={{@cardType.module}}>
             <:ready as |realmInfo|>
               <img
                 src={{realmInfo.iconURL}}
@@ -135,7 +135,7 @@ export default class CardSchemaEditor extends Component<Signature> {
               <div class='right'>
                 <div class='pill'>
                   <div class='realm-icon'>
-                    <RealmInfoProvider @fileUrl={{this.fieldModuleUrl field}}>
+                    <RealmInfoProvider @fileURL={{this.fieldModuleURL field}}>
                       <:ready as |realmInfo|>
                         <img
                           src={{realmInfo.iconURL}}
@@ -183,7 +183,7 @@ export default class CardSchemaEditor extends Component<Signature> {
     return card.displayName;
   }
 
-  fieldModuleUrl(field: Type['fields'][0]) {
+  fieldModuleURL(field: Type['fields'][0]) {
     return (field.card as Type).module;
   }
 }

--- a/packages/host/app/components/operator-mode/card-schema-editor.gts
+++ b/packages/host/app/components/operator-mode/card-schema-editor.gts
@@ -10,6 +10,7 @@ import type CardService from '@cardstack/host/services/card-service';
 import type { ModuleSyntax } from '@cardstack/runtime-common/module-syntax';
 import type { Ready } from '@cardstack/host/resources/file';
 import type { BaseDef } from 'https://cardstack.com/base/card-api';
+import RealmInfoProvider from '@cardstack/host/components/operator-mode/realm-info-provider';
 
 interface Signature {
   Args: {
@@ -81,6 +82,11 @@ export default class CardSchemaEditor extends Component<Signature> {
       .field-type {
         color: #949494;
       }
+
+      .realm-icon > img {
+        height: 25px;
+        width: 25px;
+      }
     </style>
 
     <div
@@ -89,7 +95,11 @@ export default class CardSchemaEditor extends Component<Signature> {
     >
       <div class='pill'>
         <span class='realm-icon'>
-          🟦
+          <RealmInfoProvider @fileUrl='http://localhost:4201/drafts/asset'>
+            <:ready as |realmInfo|>
+              <img src={{realmInfo.iconURL}} alt='Realm icon' />
+            </:ready>
+          </RealmInfoProvider>
         </span>
         {{@cardType.displayName}}
       </div>

--- a/packages/host/app/components/operator-mode/realm-info-provider.gts
+++ b/packages/host/app/components/operator-mode/realm-info-provider.gts
@@ -7,7 +7,7 @@ import { TrackedObject } from 'tracked-built-ins';
 import type RealmInfoService from '@cardstack/host/services/realm-info-service';
 
 export interface Signature {
-  Args: { fileUrl: string };
+  Args: { realmUrl?: string; fileUrl?: string };
   Blocks: {
     ready: [RealmInfo];
     error: [Error];
@@ -40,9 +40,10 @@ export default class RealmInfoProvider extends Component<Signature> {
         state.isLoading = true;
 
         try {
-          let realmInfo = await this.realmInfoService.fetchRealmInfo(
-            this.args.fileUrl,
-          );
+          let realmInfo = await this.realmInfoService.fetchRealmInfo({
+            realmUrl: this.args.realmUrl,
+            fileUrl: this.args.fileUrl,
+          });
 
           state.value = realmInfo;
         } catch (error: any) {
@@ -60,8 +61,7 @@ export default class RealmInfoProvider extends Component<Signature> {
   <template>
     {{#if this.realmInfoResource.value}}
       {{yield this.realmInfoResource.value to='ready'}}
-    {{/if}}
-    {{#if this.realmInfoResource.error}}
+    {{else if this.realmInfoResource.error}}
       {{yield this.realmInfoResource.error to='error'}}
     {{/if}}
   </template>

--- a/packages/host/app/components/operator-mode/realm-info-provider.gts
+++ b/packages/host/app/components/operator-mode/realm-info-provider.gts
@@ -7,7 +7,7 @@ import { TrackedObject } from 'tracked-built-ins';
 import type RealmInfoService from '@cardstack/host/services/realm-info-service';
 
 export interface Signature {
-  Args: { realmUrl?: string; fileUrl?: string };
+  Args: { realmURL?: string; fileURL?: string };
   Blocks: {
     ready: [RealmInfo];
     error: [Error];
@@ -18,7 +18,7 @@ export default class RealmInfoProvider extends Component<Signature> {
   @service declare realmInfoService: RealmInfoService;
 
   @use private realmInfoResource = resource(() => {
-    if (!this.args.fileUrl) {
+    if (!this.args.fileURL) {
       return new TrackedObject({
         error: null,
         isLoading: false,
@@ -41,8 +41,8 @@ export default class RealmInfoProvider extends Component<Signature> {
 
         try {
           let realmInfo = await this.realmInfoService.fetchRealmInfo({
-            realmUrl: this.args.realmUrl,
-            fileUrl: this.args.fileUrl,
+            realmURL: this.args.realmURL,
+            fileURL: this.args.fileURL,
           });
 
           state.value = realmInfo;

--- a/packages/host/app/components/operator-mode/realm-info-provider.gts
+++ b/packages/host/app/components/operator-mode/realm-info-provider.gts
@@ -1,0 +1,68 @@
+import Component from '@glimmer/component';
+
+import { service } from '@ember/service';
+import { use, resource } from 'ember-resources';
+import { type RealmInfo } from '@cardstack/runtime-common';
+import { TrackedObject } from 'tracked-built-ins';
+import type RealmInfoService from '@cardstack/host/services/realm-info-service';
+
+export interface Signature {
+  Args: { fileUrl: string };
+  Blocks: {
+    ready: [RealmInfo];
+    error: [Error];
+  };
+}
+
+export default class RealmInfoProvider extends Component<Signature> {
+  @service declare realmInfoService: RealmInfoService;
+
+  @use private realmInfoResource = resource(() => {
+    if (!this.args.fileUrl) {
+      return new TrackedObject({
+        error: null,
+        isLoading: false,
+        value: null,
+        load: () => Promise<void>,
+      });
+    }
+
+    const state: {
+      isLoading: boolean;
+      value: RealmInfo | null;
+      error: Error | undefined;
+      load: () => Promise<void>;
+    } = new TrackedObject({
+      isLoading: true,
+      value: null,
+      error: undefined,
+      load: async () => {
+        state.isLoading = true;
+
+        try {
+          let realmInfo = await this.realmInfoService.fetchRealmInfo(
+            this.args.fileUrl,
+          );
+
+          state.value = realmInfo;
+        } catch (error: any) {
+          state.error = error;
+        } finally {
+          state.isLoading = false;
+        }
+      },
+    });
+
+    state.load();
+    return state;
+  });
+
+  <template>
+    {{#if this.realmInfoResource.value}}
+      {{yield this.realmInfoResource.value to='ready'}}
+    {{/if}}
+    {{#if this.realmInfoResource.error}}
+      {{yield this.realmInfoResource.error to='error'}}
+    {{/if}}
+  </template>
+}

--- a/packages/host/app/services/realm-info-service.ts
+++ b/packages/host/app/services/realm-info-service.ts
@@ -1,0 +1,39 @@
+import LoaderService from '@cardstack/host/services/loader-service';
+import Service from '@ember/service';
+import { RealmInfo, SupportedMimeType } from '@cardstack/runtime-common';
+import { service } from '@ember/service';
+
+export default class RecentFilesService extends Service {
+  @service declare loaderService: LoaderService;
+  cachedRealmInfos: Map<string, RealmInfo> = new Map();
+
+  async fetchRealmUrl(fileUrl: string): Promise<string> {
+    let response = await this.loaderService.loader.fetch(fileUrl);
+    let realmURL = response.headers.get('x-boxel-realm-url');
+
+    if (!realmURL) {
+      throw new Error(
+        'Could not find realm URL in response headers (x-boxel-realm-url)',
+      );
+    }
+
+    return realmURL;
+  }
+
+  async fetchRealmInfo(fileUrl: string): Promise<RealmInfo> {
+    if (this.cachedRealmInfos.has(fileUrl)) {
+      return this.cachedRealmInfos.get(fileUrl)!;
+    }
+
+    let realmUrl = await this.fetchRealmUrl(fileUrl);
+
+    let realmInfoResponse = await this.loaderService.loader.fetch(
+      `${realmUrl}_info`,
+      { headers: { Accept: SupportedMimeType.RealmInfo } },
+    );
+
+    let realmInfo = (await realmInfoResponse.json())?.data?.attributes;
+
+    return realmInfo;
+  }
+}

--- a/packages/host/app/services/realm-info-service.ts
+++ b/packages/host/app/services/realm-info-service.ts
@@ -5,9 +5,14 @@ import { service } from '@ember/service';
 
 export default class RecentFilesService extends Service {
   @service declare loaderService: LoaderService;
-  cachedRealmInfos: Map<string, RealmInfo> = new Map();
+  cachedRealmUrlsForFileUrl: Map<string, string> = new Map(); // Has the file url already been resolved to a realm url?
+  cachedRealmInfos: Map<string, RealmInfo> = new Map(); // Has the realm url already been rosolved to a realm info?
 
   async fetchRealmUrl(fileUrl: string): Promise<string> {
+    if (this.cachedRealmUrlsForFileUrl.has(fileUrl)) {
+      return this.cachedRealmUrlsForFileUrl.get(fileUrl)!;
+    }
+
     let response = await this.loaderService.loader.fetch(fileUrl);
     let realmURL = response.headers.get('x-boxel-realm-url');
 
@@ -17,23 +22,35 @@ export default class RecentFilesService extends Service {
       );
     }
 
+    this.cachedRealmUrlsForFileUrl.set(fileUrl, realmURL);
+
     return realmURL;
   }
 
-  async fetchRealmInfo(fileUrl: string): Promise<RealmInfo> {
-    if (this.cachedRealmInfos.has(fileUrl)) {
-      return this.cachedRealmInfos.get(fileUrl)!;
+  // When realmUrl is provided, it will fetch realm info from that url, otherwise it will first
+  // try to fetch the realm url from the file url
+  async fetchRealmInfo(params: {
+    realmUrl?: string;
+    fileUrl?: string;
+  }): Promise<RealmInfo> {
+    let { realmUrl, fileUrl } = params;
+    if (!realmUrl && !fileUrl) {
+      throw new Error("Must provide either 'realmUrl' or 'fileUrl'");
     }
 
-    let realmUrl = await this.fetchRealmUrl(fileUrl);
+    realmUrl = realmUrl ? realmUrl : await this.fetchRealmUrl(fileUrl!);
 
-    let realmInfoResponse = await this.loaderService.loader.fetch(
-      `${realmUrl}_info`,
-      { headers: { Accept: SupportedMimeType.RealmInfo } },
-    );
+    if (this.cachedRealmInfos.has(realmUrl)) {
+      return this.cachedRealmInfos.get(realmUrl)!;
+    } else {
+      let realmInfoResponse = await this.loaderService.loader.fetch(
+        `${realmUrl}_info`,
+        { headers: { Accept: SupportedMimeType.RealmInfo } },
+      );
 
-    let realmInfo = (await realmInfoResponse.json())?.data?.attributes;
-
-    return realmInfo;
+      let realmInfo = (await realmInfoResponse.json())?.data?.attributes;
+      this.cachedRealmInfos.set(realmUrl, realmInfo);
+      return realmInfo;
+    }
   }
 }

--- a/packages/host/app/services/realm-info-service.ts
+++ b/packages/host/app/services/realm-info-service.ts
@@ -5,15 +5,15 @@ import { service } from '@ember/service';
 
 export default class RecentFilesService extends Service {
   @service declare loaderService: LoaderService;
-  cachedRealmUrlsForFileUrl: Map<string, string> = new Map(); // Has the file url already been resolved to a realm url?
+  cachedRealmURLsForFileURL: Map<string, string> = new Map(); // Has the file url already been resolved to a realm url?
   cachedRealmInfos: Map<string, RealmInfo> = new Map(); // Has the realm url already been resolved to a realm info?
 
-  async fetchRealmUrl(fileUrl: string): Promise<string> {
-    if (this.cachedRealmUrlsForFileUrl.has(fileUrl)) {
-      return this.cachedRealmUrlsForFileUrl.get(fileUrl)!;
+  async fetchRealmURL(fileURL: string): Promise<string> {
+    if (this.cachedRealmURLsForFileURL.has(fileURL)) {
+      return this.cachedRealmURLsForFileURL.get(fileURL)!;
     }
 
-    let response = await this.loaderService.loader.fetch(fileUrl);
+    let response = await this.loaderService.loader.fetch(fileURL);
     let realmURL = response.headers.get('x-boxel-realm-url');
 
     if (!realmURL) {
@@ -22,7 +22,7 @@ export default class RecentFilesService extends Service {
       );
     }
 
-    this.cachedRealmUrlsForFileUrl.set(fileUrl, realmURL);
+    this.cachedRealmURLsForFileURL.set(fileURL, realmURL);
 
     return realmURL;
   }
@@ -30,26 +30,26 @@ export default class RecentFilesService extends Service {
   // When realmUrl is provided, it will fetch realm info from that url, otherwise it will first
   // try to fetch the realm url from the file url
   async fetchRealmInfo(params: {
-    realmUrl?: string;
-    fileUrl?: string;
+    realmURL?: string;
+    fileURL?: string;
   }): Promise<RealmInfo> {
-    let { realmUrl, fileUrl } = params;
-    if (!realmUrl && !fileUrl) {
+    let { realmURL, fileURL } = params;
+    if (!realmURL && !fileURL) {
       throw new Error("Must provide either 'realmUrl' or 'fileUrl'");
     }
 
-    realmUrl = realmUrl ? realmUrl : await this.fetchRealmUrl(fileUrl!);
+    realmURL = realmURL ? realmURL : await this.fetchRealmURL(fileURL!);
 
-    if (this.cachedRealmInfos.has(realmUrl)) {
-      return this.cachedRealmInfos.get(realmUrl)!;
+    if (this.cachedRealmInfos.has(realmURL)) {
+      return this.cachedRealmInfos.get(realmURL)!;
     } else {
       let realmInfoResponse = await this.loaderService.loader.fetch(
-        `${realmUrl}_info`,
+        `${realmURL}_info`,
         { headers: { Accept: SupportedMimeType.RealmInfo } },
       );
 
       let realmInfo = (await realmInfoResponse.json())?.data?.attributes;
-      this.cachedRealmInfos.set(realmUrl, realmInfo);
+      this.cachedRealmInfos.set(realmURL, realmInfo);
       return realmInfo;
     }
   }

--- a/packages/host/app/services/realm-info-service.ts
+++ b/packages/host/app/services/realm-info-service.ts
@@ -6,7 +6,7 @@ import { service } from '@ember/service';
 export default class RecentFilesService extends Service {
   @service declare loaderService: LoaderService;
   cachedRealmUrlsForFileUrl: Map<string, string> = new Map(); // Has the file url already been resolved to a realm url?
-  cachedRealmInfos: Map<string, RealmInfo> = new Map(); // Has the realm url already been rosolved to a realm info?
+  cachedRealmInfos: Map<string, RealmInfo> = new Map(); // Has the realm url already been resolved to a realm info?
 
   async fetchRealmUrl(fileUrl: string): Promise<string> {
     if (this.cachedRealmUrlsForFileUrl.has(fileUrl)) {

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -836,6 +836,36 @@ module('Acceptance | code mode tests', function (hooks) {
       .exists();
 
     assert.dom(`[data-test-card-schema="Base"]`).exists();
+
+    // Check that realm icons in the schema editor are correct (card and its fields)
+
+    let realm1IconUrl = 'https://i.postimg.cc/L8yXRvws/icon.png';
+    let realm2IconUrl = 'https://i.postimg.cc/d0B9qMvy/icon.png';
+
+    assert
+      .dom(`[data-test-card-schema="Person"] [data-test-realm-icon-url]`)
+      .hasAttribute('data-test-realm-icon-url', realm1IconUrl);
+
+    await waitFor(
+      '[data-test-card-schema="Person"] [data-test-field-name="firstName"] [data-test-realm-icon-url]',
+    );
+
+    assert
+      .dom(
+        `[data-test-card-schema="Person"] [data-test-field-name="firstName"] [data-test-realm-icon-url]`,
+      )
+      .hasAttribute('data-test-realm-icon-url', realm2IconUrl);
+
+    await waitFor('[data-test-card-schema="Card"] [data-test-realm-icon-url]');
+    assert
+      .dom(`[data-test-card-schema="Card"] [data-test-realm-icon-url]`)
+      .hasAttribute('data-test-realm-icon-url', realm2IconUrl);
+
+    assert
+      .dom(
+        `[data-test-card-schema="Card"] [data-test-field-name="title"] [data-test-realm-icon-url]`,
+      )
+      .hasAttribute('data-test-realm-icon-url', realm2IconUrl);
   });
 });
 


### PR DESCRIPTION
We now have realm icons in the schema editor instead of placeholders:
<img width="760" alt="image" src="https://github.com/cardstack/boxel/assets/273660/cc2e035f-7459-4bf1-b59f-f0d0faf96393">

I made a reusable realm info provider component - it can take a realm url or a file url. If only file url is provided, it will try to make a simple fetch request and extract the `x-boxel-realm-url` header, and after that fetch the realm iinfo. It also supports providing the realm url directly in case it is already known - in that case it will skip the realm url resolution part. 

The values are cached so that same requests are likely not repeated. 