### PR TITLE
containsMany primitive field within another field

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -565,11 +565,21 @@ class ContainsMany<FieldT extends FieldDefConstructor>
       fieldName,
       useIndexBasedKey in this.card,
     ) as unknown as Box<BaseDef[]>;
+
+    let renderFormat: Format | undefined = undefined;
+    if (
+      format === 'edit' &&
+      'isFieldDef' in model.value.constructor &&
+      model.value.constructor.isFieldDef
+    ) {
+      renderFormat = 'embedded';
+    }
+
     return getContainsManyComponent({
       model,
       arrayField,
       field: this,
-      format,
+      format: renderFormat ?? format,
       cardTypeFor,
     });
   }
@@ -1645,7 +1655,7 @@ class FieldDefEditTemplate extends GlimmerComponent<{
   };
 }> {
   <template>
-    <div class='default-card-template'>
+    <div class='field-def-edit-template'>
       {{#each-in @fields as |key Field|}}
         {{#unless (eq key 'id')}}
           <FieldContainer
@@ -1660,9 +1670,19 @@ class FieldDefEditTemplate extends GlimmerComponent<{
       {{/each-in}}
     </div>
     <style>
-      .default-card-template {
+      .field-def-edit-template {
         display: grid;
         gap: var(--boxel-sp-lg);
+      }
+      .field-def-edit-template :deep(.containsMany-field) {
+        padding: var(--boxel-sp-xs);
+        border: 1px solid var(--boxel-form-control-border-color);
+        border-radius: var(--boxel-form-control-border-radius);
+      }
+      .field-def-edit-template :deep(.containsMany-field.empty::after) {
+        display: block;
+        content: 'None';
+        color: var(--boxel-450);
       }
     </style>
   </template>
@@ -2786,13 +2806,6 @@ export class Box<T> {
     });
     this.prevChildren = newChildren;
     return newChildren;
-  }
-
-  get isNested(): boolean {
-    return (
-      'containingBox' in this.state &&
-      this.state.containingBox.state.type !== 'root'
-    );
   }
 }
 

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -2787,6 +2787,13 @@ export class Box<T> {
     this.prevChildren = newChildren;
     return newChildren;
   }
+
+  get isNested(): boolean {
+    return (
+      'containingBox' in this.state &&
+      this.state.containingBox.state.type !== 'root'
+    );
+  }
 }
 
 type ElementType<T> = T extends (infer V)[] ? V : never;

--- a/packages/base/cards-grid.gts
+++ b/packages/base/cards-grid.gts
@@ -82,7 +82,7 @@ class Isolated extends Component<typeof CardsGrid> {
     <style>
       .cards-grid {
         --grid-card-text-thumbnail-height: 6.25rem;
-        --grid-card-label-color: #919191;
+        --grid-card-label-color: var(--boxel-450);
         --grid-card-width: 10.125rem;
         --grid-card-height: 15.125rem;
 

--- a/packages/base/contains-many-component.gts
+++ b/packages/base/contains-many-component.gts
@@ -29,71 +29,50 @@ interface Signature {
 
 class ContainsManyEditor extends GlimmerComponent<Signature> {
   <template>
-    <div
-      class={{if this.isReadOnly 'read-only-contains-many-editor'}}
-      data-test-contains-many={{@field.name}}
-    >
+    <div data-test-contains-many={{@field.name}}>
       {{#if @arrayField.children.length}}
         <ul class='list'>
           {{#each @arrayField.children as |boxedElement i|}}
-            <li class={{unless this.isReadOnly 'editor'}} data-test-item={{i}}>
+            <li class='editor' data-test-item={{i}}>
               {{#let
                 (getBoxComponent
-                  (@cardTypeFor @field boxedElement)
-                  (if this.isReadOnly 'embedded' @format)
-                  boxedElement
-                  @field
+                  (@cardTypeFor @field boxedElement) @format boxedElement @field
                 )
                 as |Item|
               }}
                 <Item />
               {{/let}}
-              {{#unless this.isReadOnly}}
-                <div class='remove-button-container'>
-                  <IconButton
-                    @icon='icon-trash'
-                    @width='20px'
-                    @height='20px'
-                    class='remove'
-                    {{on 'click' (fn this.remove i)}}
-                    data-test-remove={{i}}
-                    aria-label='Remove'
-                  />
-                </div>
-              {{/unless}}
+              <div class='remove-button-container'>
+                <IconButton
+                  @icon='icon-trash'
+                  @width='20px'
+                  @height='20px'
+                  class='remove'
+                  {{on 'click' (fn this.remove i)}}
+                  data-test-remove={{i}}
+                  aria-label='Remove'
+                />
+              </div>
             </li>
           {{/each}}
         </ul>
-      {{else if this.isReadOnly}}
-        <span class='empty'>None</span>
       {{/if}}
-      {{#unless this.isReadOnly}}
-        <AddButton
-          class='add-new'
-          @variant='full-width'
-          {{on 'click' this.add}}
-          data-test-add-new
-        >
-          Add
-          {{getPlural @field.card.displayName}}
-        </AddButton>
-      {{/unless}}
+      <AddButton
+        class='add-new'
+        @variant='full-width'
+        {{on 'click' this.add}}
+        data-test-add-new
+      >
+        Add
+        {{getPlural @field.card.displayName}}
+      </AddButton>
     </div>
     <style>
-      .read-only-contains-many-editor {
-        padding: var(--boxel-sp-xs);
-        border: 1px solid var(--boxel-form-control-border-color);
-        border-radius: var(--boxel-form-control-border-radius);
-      }
       .list {
         list-style: none;
         padding: 0;
-        margin: 0;
+        margin: 0 0 var(--boxel-sp);
       }
-      .empty {
-        color: var(--boxel-450);
-      }
-
       .editor {
         position: relative;
         cursor: pointer;
@@ -117,19 +96,8 @@ class ContainsManyEditor extends GlimmerComponent<Signature> {
       .remove:hover {
         --icon-color: var(--boxel-error-200);
       }
-      .list + .add-new {
-        margin-top: var(--boxel-sp);
-      }
     </style>
   </template>
-
-  get isReadOnly() {
-    return (
-      this.args.arrayField.isNested &&
-      this.args.field.card &&
-      primitive in this.args.field.card
-    );
-  }
 
   add = () => {
     // TODO probably each field card should have the ability to say what a new item should be

--- a/packages/base/contains-many-component.gts
+++ b/packages/base/contains-many-component.gts
@@ -29,53 +29,81 @@ interface Signature {
 
 class ContainsManyEditor extends GlimmerComponent<Signature> {
   <template>
-    <div data-test-contains-many={{this.args.field.name}}>
-      {{#if @arrayField.children.length}}
-        <ul class='list'>
-          {{#each @arrayField.children as |boxedElement i|}}
-            <li class='editor' data-test-item={{i}}>
-              {{#let
-                (getBoxComponent
-                  (this.args.cardTypeFor @field boxedElement)
-                  @format
-                  boxedElement
-                  @field
-                )
-                as |Item|
-              }}
-                <Item />
-              {{/let}}
-              <div class='remove-button-container'>
-                <IconButton
-                  @icon='icon-trash'
-                  @width='20px'
-                  @height='20px'
-                  class='remove'
-                  {{on 'click' (fn this.remove i)}}
-                  data-test-remove={{i}}
-                  aria-label='Remove'
-                />
-              </div>
-            </li>
-          {{/each}}
-        </ul>
-      {{/if}}
-      <AddButton
-        class='add-new'
-        @variant='full-width'
-        {{on 'click' this.add}}
-        data-test-add-new
+    {{#if this.isPrimitive}}
+      <div
+        class='primitive-contains-many-editor'
+        data-test-contains-many={{@field.name}}
       >
-        Add
-        {{getPlural @field.card.displayName}}
-      </AddButton>
-    </div>
+        {{#if @arrayField.children.length}}
+          <ul class='list'>
+            {{#each @arrayField.value as |val i|}}
+              <li data-test-item={{i}}>
+                {{val}}
+              </li>
+            {{/each}}
+          </ul>
+        {{else}}
+          <div class='empty'>None</div>
+        {{/if}}
+      </div>
+    {{else}}
+      <div data-test-contains-many={{@field.name}}>
+        {{#if @arrayField.children.length}}
+          <ul class='list'>
+            {{#each @arrayField.children as |boxedElement i|}}
+              <li class='editor' data-test-item={{i}}>
+                {{#let
+                  (getBoxComponent
+                    (this.args.cardTypeFor @field boxedElement)
+                    @format
+                    boxedElement
+                    @field
+                  )
+                  as |Item|
+                }}
+                  <Item />
+                {{/let}}
+                <div class='remove-button-container'>
+                  <IconButton
+                    @icon='icon-trash'
+                    @width='20px'
+                    @height='20px'
+                    class='remove'
+                    {{on 'click' (fn this.remove i)}}
+                    data-test-remove={{i}}
+                    aria-label='Remove'
+                  />
+                </div>
+              </li>
+            {{/each}}
+          </ul>
+        {{/if}}
+        <AddButton
+          class='add-new'
+          @variant='full-width'
+          {{on 'click' this.add}}
+          data-test-add-new
+        >
+          Add
+          {{getPlural @field.card.displayName}}
+        </AddButton>
+      </div>
+    {{/if}}
     <style>
+      .primitive-contains-many-editor {
+        padding: var(--boxel-sp-xs);
+        border: 1px solid var(--boxel-form-control-border-color);
+        border-radius: var(--boxel-form-control-border-radius);
+      }
       .list {
         list-style: none;
         padding: 0;
-        margin: 0 0 var(--boxel-sp);
+        margin: 0;
       }
+      .empty {
+        color: var(--boxel-450);
+      }
+
       .editor {
         position: relative;
         cursor: pointer;
@@ -101,6 +129,10 @@ class ContainsManyEditor extends GlimmerComponent<Signature> {
       }
     </style>
   </template>
+
+  get isPrimitive() {
+    return this.args.field.card && primitive in this.args.field.card;
+  }
 
   add = () => {
     // TODO probably each field card should have the ability to say what a new item should be

--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -226,7 +226,12 @@ export function getPluralViewComponent(
   );
   let defaultComponent = class PluralView extends GlimmerComponent {
     <template>
-      <ul class='plural-field'>
+      <div
+        class='plural-field
+          {{field.fieldType}}-field
+          {{unless model.children.length "empty"}}'
+        data-test-plural-view={{field.fieldType}}
+      >
         {{#each model.children as |child i|}}
           {{#let
             (getBoxComponent
@@ -234,20 +239,14 @@ export function getPluralViewComponent(
             )
             as |Item|
           }}
-            <li data-test-plural-view-item={{i}}>
+            <div data-test-plural-view-item={{i}}>
               <Item />
-            </li>
+            </div>
           {{/let}}
         {{/each}}
-      </ul>
+      </div>
       <style>
-        .plural-field {
-          list-style: none;
-          padding: 0;
-          margin: 0;
-        }
-
-        .plural-field > li + li {
+        .linksToMany-field > div + div {
           margin-top: var(--boxel-sp);
         }
       </style>

--- a/packages/boxel-ui/addon/components/field-container/index.gts
+++ b/packages/boxel-ui/addon/components/field-container/index.gts
@@ -63,6 +63,7 @@ const FieldContainer: TemplateOnlyComponent<Signature> = <template>
 
     .vertical {
       grid-template-rows: auto 1fr;
+      gap: var(--boxel-sp-xxs) 0;
     }
     .vertical .label {
       --boxel-label-font: 700 var(--boxel-font-xs);

--- a/packages/boxel-ui/addon/styles/variables.css
+++ b/packages/boxel-ui/addon/styles/variables.css
@@ -86,6 +86,7 @@
   --boxel-200: #e8e8e8;
   --boxel-300: #d1d1d1;
   --boxel-400: #afafb7;
+  --boxel-450: #919191;
   --boxel-500: #5a586a;
   --boxel-600: #413e4e;
   --boxel-700: #272330;

--- a/packages/drafts-realm/CatalogEntry/12.json
+++ b/packages/drafts-realm/CatalogEntry/12.json
@@ -24,6 +24,7 @@
           },
           "email": null
         },
+        "namesInvited": [],
         "guest": {
           "name": null,
           "additionalNames": []

--- a/packages/drafts-realm/CatalogEntry/12.json
+++ b/packages/drafts-realm/CatalogEntry/12.json
@@ -15,6 +15,19 @@
           "area": null,
           "number": null
         },
+        "emergencyContact": {
+          "name": null,
+          "phoneNumber": {
+            "country": null,
+            "area": null,
+            "number": null
+          },
+          "email": null
+        },
+        "guest": {
+          "name": null,
+          "additionalNames": []
+        },
         "description": null,
         "thumbnailURL": null
       }

--- a/packages/drafts-realm/ContactCard/1.json
+++ b/packages/drafts-realm/ContactCard/1.json
@@ -17,6 +17,14 @@
         },
         "email": "mama@leonesons.com"
       },
+      "guest": {
+        "name": "Mama Leone",
+        "additionalNames": [
+          "Felicity Shaw",
+          "Grant Kingston",
+          "Valerie Storm"
+        ]
+      },
       "description": null,
       "thumbnailURL": null
     },

--- a/packages/drafts-realm/ContactCard/1.json
+++ b/packages/drafts-realm/ContactCard/1.json
@@ -17,6 +17,7 @@
         },
         "email": "mama@leonesons.com"
       },
+      "namesInvited": [],
       "guest": {
         "name": "Mama Leone",
         "additionalNames": [

--- a/packages/drafts-realm/contact-card.gts
+++ b/packages/drafts-realm/contact-card.gts
@@ -32,6 +32,12 @@ export class EmergencyContactField extends FieldDef {
 class Guest extends FieldDef {
   @field name = contains(StringField);
   @field additionalNames = containsMany(StringField);
+
+  static embedded = class Embedded extends Component<typeof this> {
+    <template>
+      <@fields.name />
+    </template>
+  };
 }
 
 export class ContactCard extends CardDef {

--- a/packages/drafts-realm/contact-card.gts
+++ b/packages/drafts-realm/contact-card.gts
@@ -1,5 +1,5 @@
-import StringCard from 'https://cardstack.com/base/string';
-import NumberCard from 'https://cardstack.com/base/number';
+import StringField from 'https://cardstack.com/base/string';
+import NumberField from 'https://cardstack.com/base/number';
 import {
   Component,
   CardDef,
@@ -9,33 +9,42 @@ import {
   containsMany,
 } from 'https://cardstack.com/base/card-api';
 
-export class PhoneCard extends FieldDef {
-  @field country = contains(NumberCard);
-  @field area = contains(NumberCard);
-  @field number = contains(NumberCard);
+export class PhoneField extends FieldDef {
+  @field country = contains(NumberField);
+  @field area = contains(NumberField);
+  @field number = contains(NumberField);
 }
 
-export class EmergencyContactCard extends FieldDef {
-  @field name = contains(StringCard);
-  @field phoneNumber = contains(PhoneCard);
-  @field email = contains(StringCard);
+export class EmergencyContactField extends FieldDef {
+  @field name = contains(StringField);
+  @field phoneNumber = contains(PhoneField);
+  @field email = contains(StringField);
+
+  static embedded = class Embedded extends Component<typeof this> {
+    <template>
+      <@fields.name />
+      <@fields.phoneNumber />
+      <@fields.email />
+    </template>
+  };
 }
 
 class Guest extends FieldDef {
-  @field name = contains(StringCard);
-  @field additionalNames = containsMany(StringCard);
+  @field name = contains(StringField);
+  @field additionalNames = containsMany(StringField);
 }
 
 export class ContactCard extends CardDef {
   static displayName = 'Contact';
-  @field name = contains(StringCard);
-  @field phone = contains(PhoneCard);
-  @field emergencyContact = contains(EmergencyContactCard);
+  @field name = contains(StringField);
+  @field phone = contains(PhoneField);
+  @field emergencyContact = contains(EmergencyContactField);
+  @field namesInvited = containsMany(StringField);
   @field guest = contains(Guest);
   // @field aliases;
   // @field vendor;
   // @field vendors;
-  @field title = contains(StringCard, {
+  @field title = contains(StringField, {
     computeVia: function (this: ContactCard) {
       return this.name;
     },
@@ -45,6 +54,9 @@ export class ContactCard extends CardDef {
     <template>
       <@fields.name />
       <@fields.phone />
+      <@fields.emergencyContact />
+      <@fields.namesInvited />
+      <@fields.guest />
     </template>
   };
 }

--- a/packages/drafts-realm/contact-card.gts
+++ b/packages/drafts-realm/contact-card.gts
@@ -6,6 +6,7 @@ import {
   FieldDef,
   field,
   contains,
+  containsMany,
 } from 'https://cardstack.com/base/card-api';
 
 export class PhoneCard extends FieldDef {
@@ -20,13 +21,18 @@ export class EmergencyContactCard extends FieldDef {
   @field email = contains(StringCard);
 }
 
+class Guest extends FieldDef {
+  @field name = contains(StringCard);
+  @field additionalNames = containsMany(StringCard);
+}
+
 export class ContactCard extends CardDef {
   static displayName = 'Contact';
   @field name = contains(StringCard);
   @field phone = contains(PhoneCard);
   @field emergencyContact = contains(EmergencyContactCard);
+  @field guest = contains(Guest);
   // @field aliases;
-  // @field guests;
   // @field vendor;
   // @field vendors;
   @field title = contains(StringCard, {

--- a/packages/host/app/components/operator-mode/definition-container/base.gts
+++ b/packages/host/app/components/operator-mode/definition-container/base.gts
@@ -74,7 +74,7 @@ export class BaseDefinitionContainer extends Component<BaseSignature> {
         background-color: var(--boxel-100);
       }
       .banner-title {
-        color: #919191;
+        color: var(--boxel-450);
         font-size: var(--boxel-font-size-sm);
         font-weight: 200;
         letter-spacing: var(--boxel-lsp-xxl);
@@ -170,7 +170,7 @@ export class Active extends Component<ActiveSignature> {
         align-self: flex-start;
       }
       .info-footer .message {
-        color: #919191;
+        color: var(--boxel-450);
         font-weight: 200;
       }
     </style>

--- a/packages/host/app/components/search-sheet/search-result/index.gts
+++ b/packages/host/app/components/search-sheet/search-result/index.gts
@@ -60,7 +60,7 @@ export default class SearchResult extends Component<Signature> {
       .search-result__display-name {
         margin: 0;
         font: 500 var(--boxel-font-xs);
-        color: #919191;
+        color: var(--boxel-450);
       }
       .search-result:not(.is-compact) .search-result__realm-name {
         display: block;

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -29,6 +29,7 @@ import BoxelInput from '@cardstack/boxel-ui/components/input';
 import type LoaderService from '@cardstack/host/services/loader-service';
 import { shimExternals } from '@cardstack/host/lib/externals';
 import format from 'date-fns/format';
+import percySnapshot from '@percy/ember';
 
 let cardApi: typeof import('https://cardstack.com/base/card-api');
 let string: typeof import('https://cardstack.com/base/string');
@@ -1802,6 +1803,7 @@ module('Integration | card-basics', function (hooks) {
     });
 
     await renderCard(loader, card, 'edit');
+    await percySnapshot(assert);
 
     assert.dom('[data-test-field-component-card]').exists();
     assert
@@ -1825,27 +1827,24 @@ module('Integration | card-basics', function (hooks) {
       .dom(
         '[data-test-field="guest"] [data-test-contains-many="additionalNames"]',
       )
-      .containsText('Felicity Shaw Grant Kingston Valerie Storm');
+      .doesNotExist('edit template is not rendered');
     assert
       .dom(
-        '[data-test-field="guest"] [data-test-contains-many="additionalNames"] input',
+        '[data-test-field="guest"] [data-test-plural-view="containsMany"] [data-test-plural-view-item]',
       )
-      .doesNotExist(
-        'containsMany string field inside another field is not editable',
-      );
-    assert.dom('[data-test-field="guest"] [data-test-remove]').doesNotExist();
-    assert.dom('[data-test-field="guest"] [data-test-add-new]').doesNotExist();
+      .exists({ count: 3 });
+    assert
+      .dom('[data-test-field="guest"] [data-test-plural-view="containsMany"]')
+      .containsText('Felicity Shaw Grant Kingston Valerie Storm');
 
     assert
       .dom('[data-test-field="bannedGuest"] [data-test-add-new]')
-      .doesNotExist(
-        'empty containsMany string field inside another field does NOT have an add button',
-      );
+      .doesNotExist('edit');
     assert
       .dom(
-        '[data-test-field="bannedGuest"] [data-test-contains-many="additionalNames"]',
+        '[data-test-field="bannedGuest"] [data-test-plural-view="containsMany"] [data-test-plural-view-item]',
       )
-      .containsText('None');
+      .doesNotExist();
   });
 
   test('can get a queryable value for a field', async function (assert) {

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -1764,6 +1764,90 @@ module('Integration | card-basics', function (hooks) {
       .hasText('2022-05-01 2021-05-30');
   });
 
+  test('primitive containsMany field inside another field is read-only', async function (assert) {
+    let { field, contains, containsMany, CardDef, FieldDef, Component } =
+      cardApi;
+    let { default: StringField } = string;
+
+    class Guest extends FieldDef {
+      @field name = contains(StringField);
+      @field additionalNames = containsMany(StringField);
+    }
+
+    class ContactCard extends CardDef {
+      static displayName = 'Contact';
+      @field name = contains(StringField);
+      @field nickname = contains(StringField);
+      @field vip = containsMany(StringField);
+      @field banned = containsMany(StringField);
+      @field guest = contains(Guest);
+      @field bannedGuest = contains(Guest);
+
+      static embedded = class Embedded extends Component<typeof this> {
+        <template>
+          <@fields.name />
+          <@fields.vip />
+          <@fields.guest />
+        </template>
+      };
+    }
+
+    let card = new ContactCard({
+      name: 'Marcelius Wilde',
+      vip: ['Cornelius Wilde', 'Dominique Wilde', 'Esmeralda Wilde'],
+      guest: new Guest({
+        name: 'Mama Leone',
+        additionalNames: ['Felicity Shaw', 'Grant Kingston', 'Valerie Storm'],
+      }),
+    });
+
+    await renderCard(loader, card, 'edit');
+
+    assert.dom('[data-test-field-component-card]').exists();
+    assert
+      .dom('[data-test-contains-many="vip"] [data-test-item]')
+      .exists({ count: 3 });
+    assert
+      .dom('[data-test-contains-many="vip"] [data-test-item="0"] input')
+      .hasValue('Cornelius Wilde');
+    assert.dom('[data-test-field="nickname"] input').hasNoValue();
+    assert
+      .dom('[data-test-contains-many="banned"] [data-test-item]')
+      .doesNotExist();
+    assert
+      .dom('[data-test-contains-many="banned"] [data-test-add-new]')
+      .exists('empty containsMany string field has an add button');
+
+    assert
+      .dom('[data-test-field="guest"] [data-test-field="name"] input')
+      .hasValue('Mama Leone');
+    assert
+      .dom(
+        '[data-test-field="guest"] [data-test-contains-many="additionalNames"]',
+      )
+      .containsText('Felicity Shaw Grant Kingston Valerie Storm');
+    assert
+      .dom(
+        '[data-test-field="guest"] [data-test-contains-many="additionalNames"] input',
+      )
+      .doesNotExist(
+        'containsMany string field inside another field is not editable',
+      );
+    assert.dom('[data-test-field="guest"] [data-test-remove]').doesNotExist();
+    assert.dom('[data-test-field="guest"] [data-test-add-new]').doesNotExist();
+
+    assert
+      .dom('[data-test-field="bannedGuest"] [data-test-add-new]')
+      .doesNotExist(
+        'empty containsMany string field inside another field does NOT have an add button',
+      );
+    assert
+      .dom(
+        '[data-test-field="bannedGuest"] [data-test-contains-many="additionalNames"]',
+      )
+      .containsText('None');
+  });
+
   test('can get a queryable value for a field', async function (assert) {
     let { FieldDef, getQueryableValue } = cardApi;
 


### PR DESCRIPTION
CS-6016

- regular containsMany primitive field remains as is, meaning that it is editable
- however, when containsMany primitive field is inside a contained card is not editable, which is the change I made in this PR

My initial approach was to update the `contains-many-editor`, which is the edit template for containsMany fields. Later I realized that changing the render mode to `embedded` instead of `edit` when it's time to render that field accomplishes the goal and is consistent with how we're handling computed fields in edit mode, for example. 

The part I'm not too crazy about is that I had to write the styles in field-def editor using `deep` instead of in plural-view component because we only want to style the containsMany field if its containing field is in edit mode.

<img width="862" alt="containsmany-primitive-inside-field" src="https://github.com/cardstack/boxel/assets/16160806/80cce2ab-e94e-4cbd-b4e0-084f9a2c9924">