### PR TITLE
Use the selected export in the schema editor

### DIFF
--- a/packages/host/app/components/operator-mode/card-adoption-chain.gts
+++ b/packages/host/app/components/operator-mode/card-adoption-chain.gts
@@ -11,8 +11,8 @@ import { loadCard } from '@cardstack/runtime-common/code-ref';
 import { ModuleSyntax } from '@cardstack/runtime-common/module-syntax';
 
 import CardSchemaEditor from '@cardstack/host/components/operator-mode/card-schema-editor';
-import { getCardType } from '@cardstack/host/resources/card-type';
-import { type Type } from '@cardstack/host/resources/card-type';
+
+import { type CardType, type Type } from '@cardstack/host/resources/card-type';
 import type { Ready } from '@cardstack/host/resources/file';
 
 import LoaderService from '@cardstack/host/services/loader-service';
@@ -22,7 +22,8 @@ import type { BaseDef } from 'https://cardstack.com/base/card-api';
 interface Signature {
   Args: {
     file: Ready;
-    importedModule: Record<string, any>;
+    cardTypeResource?: CardType;
+    card: typeof BaseDef;
   };
 }
 
@@ -69,17 +70,13 @@ export default class CardAdoptionChain extends Component<Signature> {
 
   loadInheritanceChain = restartableTask(async () => {
     let fileUrl = this.args.file.url;
-    let module = this.args.importedModule;
+    let { card, cardTypeResource } = this.args;
 
-    let card = cardsFromModule(module)[0]; // TODO: this must come from the export selection in the left column
-    let cardTypeResource = getCardType(this, () => card);
-    await cardTypeResource.ready;
+    await cardTypeResource!.ready;
+    let cardType = cardTypeResource!.type;
 
-    let cardType = cardTypeResource.type;
     if (!cardType) {
-      throw new Error(
-        `Bug: should never get here because we waited for it to be ready`,
-      );
+      throw new Error('Card type not found');
     }
 
     // Chain goes from most specific to least specific
@@ -106,13 +103,4 @@ export default class CardAdoptionChain extends Component<Signature> {
 
     this.cardInheritanceChain = cardInheritanceChain;
   });
-}
-
-function cardsFromModule(
-  module: Record<string, any>,
-  _never?: never,
-): (typeof BaseDef)[] {
-  return Object.values(module).filter(
-    (maybeCard) => typeof maybeCard === 'function' && 'baseDef' in maybeCard,
-  );
 }

--- a/packages/host/app/components/operator-mode/code-mode.gts
+++ b/packages/host/app/components/operator-mode/code-mode.gts
@@ -893,10 +893,11 @@ export default class CodeMode extends Component<Signature> {
                     @realmIconURL={{this.realmIconURL}}
                     data-test-card-resource-loaded
                   />
-                {{else if this.importedModule.module}}
+                {{else if this.selectedElementInFile}}
                   <CardAdoptionChain
                     @file={{this.readyFile}}
-                    @importedModule={{this.importedModule.module}}
+                    @card={{this.selectedElementInFile.card}}
+                    @cardTypeResource={{this.selectedElementInFile.cardType}}
                   />
                 {{else if this.schemaEditorIncompatible}}
                   <div

--- a/packages/host/app/components/operator-mode/schema-editor-column.gts
+++ b/packages/host/app/components/operator-mode/schema-editor-column.gts
@@ -8,13 +8,17 @@ import { svgJar } from '@cardstack/boxel-ui/helpers/svg-jar';
 import { eq } from '@cardstack/boxel-ui/helpers/truth-helpers';
 
 import CardAdoptionChain from '@cardstack/host/components/operator-mode/card-adoption-chain';
+import { CardType } from '@cardstack/host/resources/card-type';
 import { Ready } from '@cardstack/host/resources/file';
+
+import { BaseDef } from 'https://cardstack.com/base/card-api';
 
 interface Signature {
   Element: HTMLElement;
   Args: {
     file: Ready;
-    importedModule: object;
+    cardTypeResource?: CardType;
+    card: typeof BaseDef;
   };
 }
 
@@ -54,7 +58,8 @@ export default class SchemaEditorColumn extends Component<Signature> {
         <div class='accordion-item-content'>
           <CardAdoptionChain
             @file={{@file}}
-            @importedModule={{@importedModule}}
+            @card={{@card}}
+            @cardTypeResource={{@cardTypeResource}}
           />
         </div>
       </div>


### PR DESCRIPTION
For schema editor, make sure to use the currently selected export in the inspector in the left column. Previously it just took the first card from the loaded module which is correct when there is only one export but not when there are multiple exports in a card definition.