### PR TITLE
Move Module Cache outside of resource

### DIFF
--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -192,7 +192,7 @@ export default class DetailPanel extends Component<Signature> {
               <ClickableModuleDefinitionContainer
                 @fileURL={{this.cardType.type.module}}
                 @name={{this.cardType.type.displayName}}
-                @fileExtension={{this.cardType.type.moduleMeta.extension}}
+                @fileExtension={{this.cardType.type.moduleInfo.extension}}
                 @onSelectDefinition={{this.updateCodePath}}
                 @url={{this.cardType.type.module}}
               />
@@ -200,7 +200,7 @@ export default class DetailPanel extends Component<Signature> {
               <ModuleDefinitionContainer
                 @fileURL={{this.cardType.type.module}}
                 @name={{this.cardType.type.displayName}}
-                @fileExtension={{this.cardType.type.moduleMeta.extension}}
+                @fileExtension={{this.cardType.type.moduleInfo.extension}}
                 @infoText={{this.lastModified.value}}
                 @isActive={{true}}
                 @actions={{array
@@ -221,7 +221,7 @@ export default class DetailPanel extends Component<Signature> {
                 <ClickableModuleDefinitionContainer
                   @fileURL={{this.cardType.type.super.module}}
                   @name={{this.cardType.type.super.displayName}}
-                  @fileExtension={{this.cardType.type.super.moduleMeta.extension}}
+                  @fileExtension={{this.cardType.type.super.moduleInfo.extension}}
                   @onSelectDefinition={{this.updateCodePath}}
                   @url={{this.cardType.type.super.module}}
                 />

--- a/packages/host/app/services/realm-info-service.ts
+++ b/packages/host/app/services/realm-info-service.ts
@@ -14,9 +14,7 @@ export default class RealmInfoService extends Service {
       return this.cachedRealmURLsForFileURL.get(fileURL)!;
     }
 
-    let response = await this.loaderService.loader.fetch(fileURL, {
-      headers: { Accept: SupportedMimeType.CardSource },
-    });
+    let response = await this.loaderService.loader.fetch(fileURL);
     let realmURL = response.headers.get('x-boxel-realm-url');
 
     if (!realmURL) {


### PR DESCRIPTION
This PR moves cache into service rather than residing in the resource

The original motive of this is so that other resources can consume this if needed. Here is the comment https://github.com/cardstack/boxel/pull/656#discussion_r1335956291


