### PR TITLE
cs-6053-cs-6053-stop-using-json-endsWith-only

### DIFF
--- a/packages/host/app/components/operator-mode/code-mode.gts
+++ b/packages/host/app/components/operator-mode/code-mode.gts
@@ -421,7 +421,7 @@ export default class CodeMode extends Component<Signature> {
   @use private importedModule = resource(() => {
     if (isReady(this.openFile.current)) {
       let f: Ready = this.openFile.current;
-      if (isCardDocument(f.content)) {
+      if (f.url.endsWith('.json') && isCardDocument(f.content)) {
         let ref = identifyCard(this.card?.constructor);
         if (ref !== undefined) {
           return importResource(this, () => moduleFrom(ref as CodeRef));

--- a/packages/host/app/components/operator-mode/code-mode.gts
+++ b/packages/host/app/components/operator-mode/code-mode.gts
@@ -421,7 +421,7 @@ export default class CodeMode extends Component<Signature> {
   @use private importedModule = resource(() => {
     if (isReady(this.openFile.current)) {
       let f: Ready = this.openFile.current;
-      if (f.url.endsWith('.json')) {
+      if (isCardDocument(f.content)) {
         let ref = identifyCard(this.card?.constructor);
         if (ref !== undefined) {
           return importResource(this, () => moduleFrom(ref as CodeRef));

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -15,7 +15,11 @@ import { or } from '@cardstack/boxel-ui/helpers/truth-helpers';
 
 import { type RealmInfo } from '@cardstack/runtime-common';
 
-import { hasExecutableExtension, getPlural } from '@cardstack/runtime-common';
+import {
+  hasExecutableExtension,
+  getPlural,
+  isCardDocument,
+} from '@cardstack/runtime-common';
 
 import { type Ready } from '@cardstack/host/resources/file';
 
@@ -80,7 +84,7 @@ export default class DetailPanel extends Component<Signature> {
 
   get isCardInstance() {
     return (
-      this.args.readyFile.url.endsWith('.json') &&
+      isCardDocument(this.args.readyFile.content) &&
       this.args.cardInstance !== undefined
     );
   }

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -84,6 +84,7 @@ export default class DetailPanel extends Component<Signature> {
 
   get isCardInstance() {
     return (
+      this.isJSON &&
       isCardDocument(this.args.readyFile.content) &&
       this.args.cardInstance !== undefined
     );


### PR DESCRIPTION
Actually I think this ticket says "stop using json endsWith and start using isCardDocument" is misleading. We need to check for **BOTH**. So this PR adds `isCardDocument` to stuff that is only relying on `endsWith('.json')`