### PR TITLE
Add Exported Functions and Classes to LHS (In This File)  Panel

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -1611,6 +1611,10 @@ export function isCard(card: any): card is CardDef {
   return isCardOrField(card) && !('isFieldDef' in card.constructor);
 }
 
+export function isFieldDef(field: any): field is FieldDef {
+  return isCardOrField(field) && 'isFieldDef' in field.constructor;
+}
+
 export function isCompoundField(card: any) {
   return (
     isCardOrField(card) &&

--- a/packages/drafts-realm/asset.gts
+++ b/packages/drafts-realm/asset.gts
@@ -18,7 +18,7 @@ let EXCHANGE_RATES: Record<string, number> = {
 };
 
 class Asset extends CardDef {
-  static displayName = 'Asset';
+  static displayName = 'Asset Card (Local)';
   @field name = contains(StringCard);
   @field symbol = contains(StringCard);
   @field logoURL = contains(StringCard);
@@ -63,8 +63,8 @@ class Asset extends CardDef {
   };
 }
 
-class AssetField extends FieldDef {
-  static displayName = 'Asset';
+export class AssetField extends FieldDef {
+  static displayName = 'Asset Field (Exported)';
   @field name = contains(StringCard);
   @field symbol = contains(StringCard);
   @field logoURL = contains(StringCard);
@@ -111,22 +111,27 @@ class AssetField extends FieldDef {
 
 // For fiat money
 export class Currency extends Asset {
-  static displayName = 'Currency Card Type With Very Very Long Display Name';
+  static displayName = 'Currency Card Extends Asset Card (Exported)';
   @field sign = contains(StringCard); // $, €, £, ¥, ₽, ₿ etc.
 }
 
 export class CurrencyField extends AssetField {
-  static displayName = 'Currency Card Type With Very Very Long Display Name';
+  static displayName = 'Currency Field Extends Asset Field (Exported)';
   @field sign = contains(StringCard); // $, €, £, ¥, ₽, ₿ etc.
 }
 
 // For crypto
 export class Token extends Asset {
-  static displayName = 'Token';
+  static displayName = 'Token Card Extends Asset Card (Exported)';
   @field address = contains(StringCard);
 }
 
 export class TokenField extends AssetField {
-  static displayName = 'Token';
+  static displayName = 'Token Field Extends Asset Field (Exported)';
   @field address = contains(StringCard);
 }
+
+export class ParentClass {}
+export class ChildClass extends ParentClass {}
+
+export function someRandomFunction() {}

--- a/packages/drafts-realm/asset.gts
+++ b/packages/drafts-realm/asset.gts
@@ -18,7 +18,7 @@ let EXCHANGE_RATES: Record<string, number> = {
 };
 
 class Asset extends CardDef {
-  static displayName = 'Asset Card (Local)';
+  static displayName = 'Asset';
   @field name = contains(StringCard);
   @field symbol = contains(StringCard);
   @field logoURL = contains(StringCard);
@@ -63,8 +63,8 @@ class Asset extends CardDef {
   };
 }
 
-export class AssetField extends FieldDef {
-  static displayName = 'Asset Field (Exported)';
+class AssetField extends FieldDef {
+  static displayName = 'Asset';
   @field name = contains(StringCard);
   @field symbol = contains(StringCard);
   @field logoURL = contains(StringCard);
@@ -111,27 +111,22 @@ export class AssetField extends FieldDef {
 
 // For fiat money
 export class Currency extends Asset {
-  static displayName = 'Currency Card Extends Asset Card (Exported)';
+  static displayName = 'Currency Card Type With Very Very Long Display Name';
   @field sign = contains(StringCard); // $, €, £, ¥, ₽, ₿ etc.
 }
 
 export class CurrencyField extends AssetField {
-  static displayName = 'Currency Field Extends Asset Field (Exported)';
+  static displayName = 'Currency Card Type With Very Very Long Display Name';
   @field sign = contains(StringCard); // $, €, £, ¥, ₽, ₿ etc.
 }
 
 // For crypto
 export class Token extends Asset {
-  static displayName = 'Token Card Extends Asset Card (Exported)';
+  static displayName = 'Token';
   @field address = contains(StringCard);
 }
 
 export class TokenField extends AssetField {
-  static displayName = 'Token Field Extends Asset Field (Exported)';
+  static displayName = 'Token';
   @field address = contains(StringCard);
 }
-
-export class ParentClass {}
-export class ChildClass extends ParentClass {}
-
-export function someRandomFunction() {}

--- a/packages/drafts-realm/in-this-file.gts
+++ b/packages/drafts-realm/in-this-file.gts
@@ -11,6 +11,7 @@ export const exportedVar = 'exported var';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const localVar = 'local var';
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 class LocalClass {}
 export class ExportedClass {}
 

--- a/packages/drafts-realm/in-this-file.gts
+++ b/packages/drafts-realm/in-this-file.gts
@@ -10,13 +10,13 @@ export const exportedVar = 'exported var';
 
 // @ts-ignore
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const _localVar = 'local var';
+const localVar = 'local var';
 
-class _LocalClass {}
+class LocalClass {}
 
 export class ExportedClass {}
 
-export class ExportedClassInheritLocalClass extends _LocalClass {}
+export class ExportedClassInheritLocalClass extends LocalClass {}
 
 // @ts-ignore
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -24,7 +24,7 @@ function _localFunction() {}
 
 export function exportedFunction() {}
 
-export { _LocalClass as AClassWithExportName };
+export { LocalClass as AClassWithExportName };
 
 class LocalCard extends CardDef {
   static displayName = 'local card';

--- a/packages/drafts-realm/in-this-file.gts
+++ b/packages/drafts-realm/in-this-file.gts
@@ -20,7 +20,7 @@ export class ExportedClassInheritLocalClass extends LocalClass {}
 
 // @ts-ignore
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-function _localFunction() {}
+function localFunction() {}
 
 export function exportedFunction() {}
 

--- a/packages/drafts-realm/in-this-file.gts
+++ b/packages/drafts-realm/in-this-file.gts
@@ -1,0 +1,50 @@
+import {
+  contains,
+  field,
+  CardDef,
+  FieldDef,
+} from 'https://cardstack.com/base/card-api';
+import StringCard from 'https://cardstack.com/base/string';
+
+export const exportedVar = 'exported var';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const localVar = 'local var';
+
+class LocalClass {}
+export class ExportedClass {}
+
+export class ExportedClassInheritLocalClass extends LocalClass {}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function localFunction() {}
+export function exportedFunction() {}
+
+export { LocalClass as AClassWithExportName };
+
+class LocalCard extends CardDef {
+  static displayName = 'local card';
+}
+
+export class ExportedCard extends CardDef {
+  static displayName = 'exported card';
+  @field someString = contains(StringCard);
+}
+
+export class ExportedCardInheritLocalCard extends LocalCard {
+  static displayName = 'exported card extends local card';
+}
+
+class LocalField extends FieldDef {
+  static displayName = 'local field';
+}
+export class ExportedField extends FieldDef {
+  static displayName = 'exported field';
+  @field someString = contains(StringCard);
+}
+
+export class ExportedFieldInheritLocalField extends LocalField {
+  static displayName = 'exported field extends local field';
+}
+
+export default class DefaultClass {}

--- a/packages/drafts-realm/in-this-file.gts
+++ b/packages/drafts-realm/in-this-file.gts
@@ -8,20 +8,23 @@ import StringCard from 'https://cardstack.com/base/string';
 
 export const exportedVar = 'exported var';
 
+// @ts-ignore
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const localVar = 'local var';
+const _localVar = 'local var';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-class LocalClass {}
+class _LocalClass {}
+
 export class ExportedClass {}
 
-export class ExportedClassInheritLocalClass extends LocalClass {}
+export class ExportedClassInheritLocalClass extends _LocalClass {}
 
+// @ts-ignore
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-function localFunction() {}
+function _localFunction() {}
+
 export function exportedFunction() {}
 
-export { LocalClass as AClassWithExportName };
+export { _LocalClass as AClassWithExportName };
 
 class LocalCard extends CardDef {
   static displayName = 'local card';

--- a/packages/host/app/components/operator-mode/code-mode.gts
+++ b/packages/host/app/components/operator-mode/code-mode.gts
@@ -426,7 +426,6 @@ export default class CodeMode extends Component<Signature> {
               isCardDocumentString(this.openFile.current.content)
             ) {
               let cardOrField = cardsOrFields[0];
-              console.log(cardOrField);
               elements = [
                 {
                   cardType: getCardType(
@@ -436,7 +435,6 @@ export default class CodeMode extends Component<Signature> {
                   cardOrField,
                 } as CardOrFieldObject,
               ];
-              console.log(elements);
             } else {
               //gts case
               await this.importedModule.loaded;

--- a/packages/host/app/components/operator-mode/code-mode.gts
+++ b/packages/host/app/components/operator-mode/code-mode.gts
@@ -42,8 +42,8 @@ import {
 import {
   ModuleSyntax,
   PossibleCardClass,
-  ExportedClass,
-  ExportedFunction,
+  ClassExport,
+  FunctionExport,
 } from '@cardstack/runtime-common/module-syntax';
 import { isCardDef, isFieldDef } from '@cardstack/runtime-common/code-ref';
 
@@ -152,8 +152,8 @@ export interface CardOrField {
 export enum ElementType {
   Card = 'card',
   Field = 'field',
-  ExportedFunction = 'function',
-  ExportedClass = 'class',
+  FunctionExport = 'function',
+  ClassExport = 'class',
   Unknown = 'unknown',
 }
 // an element should be (an item of focus within a module)
@@ -170,13 +170,13 @@ interface CardElement {
 }
 
 interface ExportedFunctionElement {
-  type: ElementType.ExportedFunction;
-  value: ExportedFunction;
+  type: ElementType.FunctionExport;
+  value: FunctionExport;
 }
 
 interface ExportedClassElement {
-  type: ElementType.ExportedClass;
-  value: ExportedClass;
+  type: ElementType.ClassExport;
+  value: ClassExport;
 }
 interface UnknownElement {
   type: ElementType.Unknown;

--- a/packages/host/app/components/operator-mode/code-mode.gts
+++ b/packages/host/app/components/operator-mode/code-mode.gts
@@ -30,13 +30,10 @@ import { eq, and } from '@cardstack/boxel-ui/helpers/truth-helpers';
 import {
   type RealmInfo,
   type SingleCardDocument,
-  type CodeRef,
   RealmPaths,
   logger,
   isCardDocumentString,
   isSingleCardDocument,
-  identifyCard,
-  moduleFrom,
   hasExecutableExtension,
 } from '@cardstack/runtime-common';
 import {

--- a/packages/host/app/components/operator-mode/code-mode.gts
+++ b/packages/host/app/components/operator-mode/code-mode.gts
@@ -356,7 +356,6 @@ export default class CodeMode extends Component<Signature> {
     return state;
   });
 
-  // this should only be for gts files
   @use private elements = resource(({ on }) => {
     on.cleanup(() => {
       this.selectedElement = undefined;

--- a/packages/host/app/components/operator-mode/code-mode.gts
+++ b/packages/host/app/components/operator-mode/code-mode.gts
@@ -549,7 +549,7 @@ export default class CodeMode extends Component<Signature> {
     }
   }
 
-  private get selectedCardOrFieldInFile() {
+  private get selectedCardOrField() {
     if (this.selectedElementInFile) {
       if (isCardOrFieldElement(this.selectedElementInFile)) {
         return this.selectedElementInFile;
@@ -559,7 +559,7 @@ export default class CodeMode extends Component<Signature> {
   }
 
   @action
-  private selectElementInFile(el: Element) {
+  private selectElement(el: Element) {
     this.selectedElement = el;
   }
 
@@ -847,7 +847,7 @@ export default class CodeMode extends Component<Signature> {
                       @realmInfo={{this.realmInfo}}
                       @selectedElement={{this.selectedElementInFile}}
                       @elements={{this.elementsInFile}}
-                      @selectElement={{this.selectElementInFile}}
+                      @selectElement={{this.selectElement}}
                       @delete={{this.delete}}
                       data-test-card-inheritance-panel
                     />
@@ -930,11 +930,11 @@ export default class CodeMode extends Component<Signature> {
                     @realmIconURL={{this.realmIconURL}}
                     data-test-card-resource-loaded
                   />
-                {{else if this.selectedCardOrFieldInFile}}
+                {{else if this.selectedCardOrField}}
                   <SchemaEditorColumn
                     @file={{this.readyFile}}
-                    @card={{this.selectedCardOrFieldInFile.cardOrField}}
-                    @cardTypeResource={{this.selectedCardOrFieldInFile.cardType}}
+                    @card={{this.selectedCardOrField.cardOrField}}
+                    @cardTypeResource={{this.selectedCardOrField.cardType}}
                   />
                 {{else if this.schemaEditorIncompatible}}
                   <div

--- a/packages/host/app/components/operator-mode/definition-container/index.gts
+++ b/packages/host/app/components/operator-mode/definition-container/index.gts
@@ -28,7 +28,7 @@ export class FileDefinitionContainer extends Component<FileSignature> {
     </BaseDefinitionContainer>
   </template>
 }
-interface ModuleArgs extends Omit<BaseArgs, 'title'>, ActiveArgs {}
+interface ModuleArgs extends BaseArgs, ActiveArgs {}
 
 interface ModuleSignature {
   Element: HTMLElement;
@@ -38,7 +38,7 @@ interface ModuleSignature {
 export class ModuleDefinitionContainer extends Component<ModuleSignature> {
   <template>
     <BaseDefinitionContainer
-      @title='Card Definition'
+      @title={{@title}}
       @name={{@name}}
       @fileExtension={{@fileExtension}}
       @isActive={{@isActive}}
@@ -79,7 +79,7 @@ export class InstanceDefinitionContainer extends Component<InstanceSignature> {
 }
 
 interface ClickableModuleArgs
-  extends Omit<BaseArgs, 'title' | 'infoText' | 'isActive'>,
+  extends Omit<BaseArgs, 'infoText' | 'isActive'>,
     ClickableArgs {}
 
 interface ClickableModuleSignature {
@@ -95,7 +95,7 @@ export class ClickableModuleDefinitionContainer extends Component<ClickableModul
       data-test-definition-container
     >
       <BaseDefinitionContainer
-        @title='Card Definition'
+        @title={{@title}}
         @name={{@name}}
         @fileExtension={{@fileExtension}}
         @isActive={{false}}

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -400,5 +400,5 @@ const resolveElementName = (el: Element) => {
   if (isCardOrFieldElement(el)) {
     localName = el.cardOrField.displayName;
   }
-  return localName ?? '??';
+  return localName ?? '[No Name Found]';
 };

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -43,12 +43,15 @@ import type OperatorModeStateService from '../../services/operator-mode-state-se
 
 import { isCardDef, isFieldDef } from '@cardstack/runtime-common/code-ref';
 
+import { type CardType } from '@cardstack/host/resources/card-type';
+
 interface Signature {
   Element: HTMLElement;
   Args: {
     realmInfo: RealmInfo | null;
     readyFile: Ready;
     cardInstance: CardDef | undefined;
+    cardInstanceType: CardType | undefined;
     selectedElement?: Element;
     elements: Element[];
     selectElement: (el: Element) => void;
@@ -234,11 +237,11 @@ export default class DetailPanel extends Component<Signature> {
               </div>
               <ClickableModuleDefinitionContainer
                 @title={{'Card Definition'}}
-                @fileURL={{this.cardType.type.module}}
-                @name={{this.cardType.type.displayName}}
-                @fileExtension={{this.cardType.type.moduleInfo.extension}}
+                @fileURL={{this.args.cardInstanceType.type.module}}
+                @name={{this.args.cardInstanceType.type.displayName}}
+                @fileExtension={{this.args.cardInstanceType.type.moduleInfo.extension}}
                 @onSelectDefinition={{this.updateCodePath}}
-                @url={{this.cardType.type.module}}
+                @url={{this.args.cardInstanceType.type.module}}
               />
 
             {{else if this.isField}}

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -200,6 +200,7 @@ export default class DetailPanel extends Component<Signature> {
               <Selector
                 @class='in-this-file-menu'
                 @items={{this.buildSelectorItems}}
+                data-test-in-this-file-selector
               />
             </CardContainer>
           </div>

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -213,75 +213,74 @@ export default class DetailPanel extends Component<Signature> {
                 @url={{this.cardType.type.module}}
               />
 
-              {{else if this.isField}}
-                {{#let 'Field Definition' as |definitionTitle|}}
-                  <ModuleDefinitionContainer
-                    @title={{definitionTitle}}
-                    @fileURL={{this.cardType.type.module}}
-                    @name={{this.cardType.type.displayName}}
-                    @fileExtension={{this.cardType.type.moduleInfo.extension}}
-                    @infoText={{this.lastModified.value}}
-                    @isActive={{true}}
-                    @actions={{array
-                      (hash label='Delete' handler=@delete icon='icon-trash')
+            {{else if this.isField}}
+              {{#let 'Field Definition' as |definitionTitle|}}
+                <ModuleDefinitionContainer
+                  @title={{definitionTitle}}
+                  @fileURL={{this.cardType.type.module}}
+                  @name={{this.cardType.type.displayName}}
+                  @fileExtension={{this.cardType.type.moduleInfo.extension}}
+                  @infoText={{this.lastModified.value}}
+                  @isActive={{true}}
+                  @actions={{array
+                    (hash label='Delete' handler=@delete icon='icon-trash')
+                  }}
+                />
+                {{#if this.cardType.type.super}}
+                  <div class='chain'>
+                    {{svgJar
+                      'icon-inherit'
+                      class='chain-icon'
+                      width='24px'
+                      height='24px'
+                      role='presentation'
                     }}
-                  />
-                  {{#if this.cardType.type.super}}
-                    <div class='chain'>
-                      {{svgJar
-                        'icon-inherit'
-                        class='chain-icon'
-                        width='24px'
-                        height='24px'
-                        role='presentation'
-                      }}
-                      Inherits from
-                    </div>
-                    <ClickableModuleDefinitionContainer
-                      @title={{definitionTitle}}
-                      @fileURL={{this.cardType.type.super.module}}
-                      @name={{this.cardType.type.super.displayName}}
-                      @fileExtension={{this.cardType.type.super.moduleInfo.extension}}
-                      @onSelectDefinition={{this.updateCodePath}}
-                      @url={{this.cardType.type.super.module}}
-                    />
-                  {{/if}}
-                {{/let}}
-              {{else if this.isCard}}
-                {{#let 'Card Definition' as |definitionTitle|}}
-                  <ModuleDefinitionContainer
+                    Inherits from
+                  </div>
+                  <ClickableModuleDefinitionContainer
                     @title={{definitionTitle}}
-                    @fileURL={{this.cardType.type.module}}
-                    @name={{this.cardType.type.displayName}}
-                    @fileExtension={{this.cardType.type.moduleInfo.extension}}
-                    @infoText={{this.lastModified.value}}
-                    @isActive={{true}}
-                    @actions={{array
-                      (hash label='Delete' handler=@delete icon='icon-trash')
-                    }}
+                    @fileURL={{this.cardType.type.super.module}}
+                    @name={{this.cardType.type.super.displayName}}
+                    @fileExtension={{this.cardType.type.super.moduleInfo.extension}}
+                    @onSelectDefinition={{this.updateCodePath}}
+                    @url={{this.cardType.type.super.module}}
                   />
-                  {{#if this.cardType.type.super}}
-                    <div class='chain'>
-                      {{svgJar
-                        'icon-inherit'
-                        class='chain-icon'
-                        width='24px'
-                        height='24px'
-                        role='presentation'
-                      }}
-                      Inherits from
-                    </div>
-                    <ClickableModuleDefinitionContainer
-                      @title={{definitionTitle}}
-                      @fileURL={{this.cardType.type.super.module}}
-                      @name={{this.cardType.type.super.displayName}}
-                      @fileExtension={{this.cardType.type.super.moduleInfo.extension}}
-                      @onSelectDefinition={{this.updateCodePath}}
-                      @url={{this.cardType.type.super.module}}
-                    />
-                  {{/if}}
-                {{/let}}
-              {{/if}}
+                {{/if}}
+              {{/let}}
+            {{else if this.isCard}}
+              {{#let 'Card Definition' as |definitionTitle|}}
+                <ModuleDefinitionContainer
+                  @title={{definitionTitle}}
+                  @fileURL={{this.cardType.type.module}}
+                  @name={{this.cardType.type.displayName}}
+                  @fileExtension={{this.cardType.type.moduleInfo.extension}}
+                  @infoText={{this.lastModified.value}}
+                  @isActive={{true}}
+                  @actions={{array
+                    (hash label='Delete' handler=@delete icon='icon-trash')
+                  }}
+                />
+                {{#if this.cardType.type.super}}
+                  <div class='chain'>
+                    {{svgJar
+                      'icon-inherit'
+                      class='chain-icon'
+                      width='24px'
+                      height='24px'
+                      role='presentation'
+                    }}
+                    Inherits from
+                  </div>
+                  <ClickableModuleDefinitionContainer
+                    @title={{definitionTitle}}
+                    @fileURL={{this.cardType.type.super.module}}
+                    @name={{this.cardType.type.super.displayName}}
+                    @fileExtension={{this.cardType.type.super.moduleInfo.extension}}
+                    @onSelectDefinition={{this.updateCodePath}}
+                    @url={{this.cardType.type.super.module}}
+                  />
+                {{/if}}
+              {{/let}}
             {{/if}}
           </div>
         {{else}}
@@ -358,10 +357,5 @@ export default class DetailPanel extends Component<Signature> {
         --icon-color: var(--boxel-dark);
       }
     </style>
-
-
-
-
-
   </template>
 }

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -187,7 +187,7 @@ export default class DetailPanel extends Component<Signature> {
               <span class='number-items'>{{this.numberOfElementsInFileString}}
               </span>
             </div>
-            <CardContainer>
+            <CardContainer class='in-this-file-card-container'>
               <Header
                 @title={{@readyFile.name}}
                 @hasBackground={{true}}
@@ -339,6 +339,10 @@ export default class DetailPanel extends Component<Signature> {
         --boxel-header-background-color: var(--boxel-100);
         --boxel-header-text-color: var(--boxel-dark);
         --boxel-header-max-width: none;
+      }
+      .in-this-file-card-container {
+        overflow: hidden;
+        overflow-wrap: anywhere;
       }
       .in-this-file-panel-banner {
         display: flex;

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -152,14 +152,9 @@ export default class DetailPanel extends Component<Signature> {
     }
     return this.args.elements.map((el) => {
       const isSelected = this.args.selectedElement === el;
-      let localName =
-        (isCardOrFieldElement(el)
-          ? el.cardOrField.displayName
-          : el.localName) ?? '??';
-      // let exportedName = el.exportedAs ?? '??';
       return selectorItemFunc(
         [
-          localName,
+          resolveElementName(el),
           () => {
             this.args.selectElement(el);
           },
@@ -395,3 +390,11 @@ export default class DetailPanel extends Component<Signature> {
     </style>
   </template>
 }
+
+const resolveElementName = (el: Element) => {
+  let localName: string | undefined = el.localName;
+  if (isCardOrFieldElement(el)) {
+    localName = el.cardOrField.displayName;
+  }
+  return localName;
+};

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -237,11 +237,11 @@ export default class DetailPanel extends Component<Signature> {
               </div>
               <ClickableModuleDefinitionContainer
                 @title={{'Card Definition'}}
-                @fileURL={{this.args.cardInstanceType.type.module}}
-                @name={{this.args.cardInstanceType.type.displayName}}
-                @fileExtension={{this.args.cardInstanceType.type.moduleInfo.extension}}
+                @fileURL={{@cardInstanceType.type.module}}
+                @name={{@cardInstanceType.type.displayName}}
+                @fileExtension={{@cardInstanceType.type.moduleInfo.extension}}
                 @onSelectDefinition={{this.updateCodePath}}
-                @url={{this.args.cardInstanceType.type.module}}
+                @url={{@cardInstanceType.type.module}}
               />
 
             {{else if this.isField}}

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -11,7 +11,7 @@ import { CardContainer, LoadingIndicator, Header } from '@cardstack/boxel-ui';
 
 import { svgJar } from '@cardstack/boxel-ui/helpers/svg-jar';
 
-import { or } from '@cardstack/boxel-ui/helpers/truth-helpers';
+import { or, and } from '@cardstack/boxel-ui/helpers/truth-helpers';
 
 import { type RealmInfo } from '@cardstack/runtime-common';
 
@@ -164,8 +164,12 @@ export default class DetailPanel extends Component<Signature> {
     });
   }
 
+  get numberOfElementsGreaterThanZero() {
+    return this.args.elements.length > 0;
+  }
+
   get numberOfElementsInFileString() {
-    let numberOfElements = this.args.elements?.length || 0;
+    let numberOfElements = this.args.elements.length || 0;
     return `${numberOfElements} ${getPlural('item', numberOfElements)}`;
   }
 
@@ -176,7 +180,7 @@ export default class DetailPanel extends Component<Signature> {
           <LoadingIndicator />
         </div>
       {{else}}
-        {{#if this.isModule}}
+        {{#if (and this.isModule this.numberOfElementsGreaterThanZero)}}
           <div class='in-this-file-panel'>
             <div class='in-this-file-panel-banner'>
               <header class='panel-header' aria-label='In This File Header'>

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -396,5 +396,5 @@ const resolveElementName = (el: Element) => {
   if (isCardOrFieldElement(el)) {
     localName = el.cardOrField.displayName;
   }
-  return localName;
+  return localName ?? '??';
 };

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -180,7 +180,11 @@ export default class DetailPanel extends Component<Signature> {
 
         {{#if (or this.isCardInstance this.isCard this.isField)}}
           <div class='inheritance-panel'>
-            <header class='panel-header' aria-label='Inheritance Panel Header'>
+            <header
+              class='panel-header'
+              aria-label='Inheritance Panel Header'
+              data-test-inheritance-panel-header
+            >
               Card Inheritance
             </header>
             {{#if this.isCardInstance}}

--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -26,7 +26,7 @@ import {
 import {
   loadCard,
   identifyCard,
-  isCard,
+  isBaseDef,
   moduleFrom,
 } from '@cardstack/runtime-common/code-ref';
 import { Deferred } from '@cardstack/runtime-common/deferred';
@@ -326,7 +326,7 @@ export class CurrentRun {
     }
 
     let refs = Object.values(module)
-      .filter((maybeCard) => isCard(maybeCard))
+      .filter((maybeCard) => isBaseDef(maybeCard))
       .map((card) => identifyCard(card))
       .filter(Boolean) as CodeRef[];
     for (let ref of refs) {

--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -342,10 +342,6 @@ export default class CardService extends Service {
     return this.api.primitive in card;
   }
 
-  isCard(maybeCard: any): maybeCard is CardDef {
-    return this.api.isCard(maybeCard);
-  }
-
   isIndexCard(maybeIndexCard: any): maybeIndexCard is CardDef {
     if (!(maybeIndexCard instanceof this.api.CardDef)) {
       return false;

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -140,6 +140,7 @@ const inThisFileSource = `
 
   export class ExportedFieldInheritLocalField extends LocalField {
     static displayName = 'exported field extends local field';
+  }
 `;
 
 const friendCardSource = `
@@ -855,6 +856,7 @@ module('Acceptance | code mode tests', function (hooks) {
 
     await waitFor('[data-test-card-inheritance-panel]');
     await waitFor('[data-test-current-module-name]');
+    await waitFor('[data-test-in-this-file-selector]');
     //default is the 1st index
     let elementName = 'ExportedClass';
     assert.dom('[data-test-boxel-selector-item]').exists({ count: 8 });
@@ -872,7 +874,10 @@ module('Acceptance | code mode tests', function (hooks) {
       'exported field',
       'exported field extends local field',
     ];
-    expectedElementNames.forEach((elementName, index) => {
+    expectedElementNames.forEach(async (elementName, index) => {
+      await waitFor(
+        `[data-test-boxel-selector-item]:nth-of-type(${index + 1})`,
+      );
       assert
         .dom(`[data-test-boxel-selector-item]:nth-of-type(${index + 1})`)
         .hasText(elementName);

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -825,54 +825,70 @@ module('Acceptance | code mode tests', function (hooks) {
     await waitFor('[data-test-card-inheritance-panel]');
     await waitFor('[data-test-current-module-name]');
     //default is the 1st index
-    let itemName = 'LocalCard';
+    let elementName = 'ExportedClass';
     assert.dom('[data-test-boxel-selector-item]').exists({ count: 8 });
     assert
       .dom('[data-test-boxel-selector-item]:nth-of-type(1)')
-      .hasText(itemName);
-    assert.dom('[data-test-boxel-selector-item-selected]').hasText(itemName);
+      .hasText(elementName);
+    // elements must be ordered by the way they appear in the source code
+    const expectedElementNames = [
+      'ExportedClass',
+      'exportedFunction',
+      'LocalCard', //TODO: CS-6009 will probably change this
+      'exported card',
+      'exported card extends local card',
+      'LocalField', //TODO: CS-6009 will probably change this
+      'exported field',
+      'exported card extends local card',
+    ];
+    expectedElementNames.forEach((elementName, index) => {
+      assert
+        .dom(`[data-test-boxel-selector-item]:nth-of-type(${index + 1})`)
+        .hasText(elementName);
+    });
+    assert.dom('[data-test-boxel-selector-item-selected]').hasText(elementName);
     assert.dom('[data-test-inheritance-panel-header]').doesNotExist();
     // clicking on a card
-    itemName = 'exported card';
-    await click(`[data-test-boxel-selector-item-text="${itemName}"]`);
-    assert.dom('[data-test-boxel-selector-item-selected]').hasText(itemName);
+    elementName = 'exported card';
+    await click(`[data-test-boxel-selector-item-text="${elementName}"]`);
+    assert.dom('[data-test-boxel-selector-item-selected]').hasText(elementName);
     await waitFor('[data-test-card-module-definition]');
     assert.dom('[data-test-inheritance-panel-header]').exists();
     assert.dom('[data-test-card-module-definition]').exists();
     assert.dom('[data-test-definition-header]').includesText('Card Definition');
-    assert.dom('[data-test-card-module-definition]').includesText(itemName);
+    assert.dom('[data-test-card-module-definition]').includesText(elementName);
     await waitFor('[data-test-card-schema]');
     assert.dom('[data-test-card-schema]').exists({ count: 3 });
     assert
       .dom(
-        `[data-test-card-schema="${itemName}"] [data-test-field-name="someString"] [data-test-card-display-name="String"]`,
+        `[data-test-card-schema="${elementName}"] [data-test-field-name="someString"] [data-test-card-display-name="String"]`,
       )
       .exists();
     assert.dom(`[data-test-card-schema=Card]`).exists();
     // clicking on a field
-    itemName = 'exported field';
-    await click(`[data-test-boxel-selector-item-text="${itemName}"]`);
-    assert.dom('[data-test-boxel-selector-item-selected]').hasText(itemName);
+    elementName = 'exported field';
+    await click(`[data-test-boxel-selector-item-text="${elementName}"]`);
+    assert.dom('[data-test-boxel-selector-item-selected]').hasText(elementName);
     await waitFor('[data-test-card-module-definition]');
     assert.dom('[data-test-inheritance-panel-header]').exists();
     assert
       .dom('[data-test-definition-header]')
       .includesText('Field Definition');
-    assert.dom('[data-test-card-module-definition]').includesText(itemName);
+    assert.dom('[data-test-card-module-definition]').includesText(elementName);
     await waitFor('[data-test-card-schema]');
     assert.dom('[data-test-card-schema]').exists({ count: 3 });
     //TODO: CS-6093 will fix this
     // assert
     //   .dom(
-    //     `[data-test-card-schema="${itemName}"] [data-test-field-name="someString"] [data-test-card-display-name="String"]`,
+    //     `[data-test-card-schema="${elementName}"] [data-test-field-name="someString"] [data-test-card-display-name="String"]`,
     //   )
     //   .exists();
     // assert.dom(`[data-test-card-schema=Card]`).exists();
 
     // clicking on an exported function
-    itemName = 'exportedFunction';
-    await click(`[data-test-boxel-selector-item-text="${itemName}"]`);
-    assert.dom('[data-test-boxel-selector-item-selected]').hasText(itemName);
+    elementName = 'exportedFunction';
+    await click(`[data-test-boxel-selector-item-text="${elementName}"]`);
+    assert.dom('[data-test-boxel-selector-item-selected]').hasText(elementName);
     assert.dom('[data-test-inheritance-panel-header]').doesNotExist();
     assert.dom('[data-test-card-module-definition]').doesNotExist();
     assert.dom('[data-test-schema-editor-incompatible]').exists();

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -139,7 +139,7 @@ const inThisFileSource = `
   }
 
   export class ExportedFieldInheritLocalField extends LocalField {
-    static displayName = 'exported card extends local card';
+    static displayName = 'exported field extends local field';
 `;
 
 const friendCardSource = `
@@ -870,7 +870,7 @@ module('Acceptance | code mode tests', function (hooks) {
       'exported card extends local card',
       'LocalField', //TODO: CS-6009 will probably change this
       'exported field',
-      'exported card extends local card',
+      'exported field extends local field',
     ];
     expectedElementNames.forEach((elementName, index) => {
       assert

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -868,7 +868,7 @@ module('Acceptance | code mode tests', function (hooks) {
     await waitFor('[data-test-current-module-name]');
     await waitFor('[data-test-in-this-file-selector]');
     //default is the 1st index
-    let elementName = 'ExportedClass';
+    let elementName = 'LocalClass';
     assert
       .dom('[data-test-boxel-selector-item]:nth-of-type(1)')
       .hasText(elementName);

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -859,7 +859,6 @@ module('Acceptance | code mode tests', function (hooks) {
     await waitFor('[data-test-in-this-file-selector]');
     //default is the 1st index
     let elementName = 'ExportedClass';
-    assert.dom('[data-test-boxel-selector-item]').exists({ count: 8 });
     assert
       .dom('[data-test-boxel-selector-item]:nth-of-type(1)')
       .hasText(elementName);
@@ -882,6 +881,7 @@ module('Acceptance | code mode tests', function (hooks) {
         .dom(`[data-test-boxel-selector-item]:nth-of-type(${index + 1})`)
         .hasText(elementName);
     });
+    assert.dom('[data-test-boxel-selector-item]').exists({ count: 8 });
     assert.dom('[data-test-boxel-selector-item-selected]').hasText(elementName);
     assert.dom('[data-test-inheritance-panel-header]').doesNotExist();
     // clicking on a card

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -109,13 +109,20 @@ const inThisFileSource = `
   import StringCard from 'https://cardstack.com/base/string';
 
   export const exportedVar = 'exported var';
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const localVar = 'local var';
 
   class LocalClass {}
   export class ExportedClass {}
 
+  export class ExportedClassInheritLocalClass extends LocalClass {}
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   function localFunction() {}
   export function exportedFunction() {}
+
+  export { LocalClass as AClassWithExportName };
 
   class LocalCard extends CardDef {
     static displayName = 'local card';
@@ -866,7 +873,9 @@ module('Acceptance | code mode tests', function (hooks) {
       .hasText(elementName);
     // elements must be ordered by the way they appear in the source code
     const expectedElementNames = [
+      'LocalClass',
       'ExportedClass',
+      'ExportedClassInheritLocalClass',
       'exportedFunction',
       'LocalCard', //TODO: CS-6009 will probably change this
       'exported card',

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -131,7 +131,7 @@ const inThisFileSource = `
   }
 
   class LocalField extends FieldDef {
-    displayName = 'local field';
+    static displayName = 'local field';
   }
   export class ExportedField extends FieldDef {
     static displayName = 'exported field';

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -894,7 +894,7 @@ module('Acceptance | code mode tests', function (hooks) {
         .dom(`[data-test-boxel-selector-item]:nth-of-type(${index + 1})`)
         .hasText(elementName);
     });
-    assert.dom('[data-test-boxel-selector-item]').exists({ count: 9 });
+    assert.dom('[data-test-boxel-selector-item]').exists({ count: 11 });
     assert.dom('[data-test-boxel-selector-item-selected]').hasText(elementName);
     assert.dom('[data-test-inheritance-panel-header]').doesNotExist();
     // clicking on a card

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -105,7 +105,6 @@ const inThisFileSource = `
     field,
     CardDef,
     FieldDef,
-    Component,
   } from 'https://cardstack.com/base/card-api';
   import StringCard from 'https://cardstack.com/base/string';
 

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -141,6 +141,8 @@ const inThisFileSource = `
   export class ExportedFieldInheritLocalField extends LocalField {
     static displayName = 'exported field extends local field';
   }
+
+  export default class DefaultClass {}
 `;
 
 const friendCardSource = `
@@ -872,6 +874,7 @@ module('Acceptance | code mode tests', function (hooks) {
       'LocalField', //TODO: CS-6009 will probably change this
       'exported field',
       'exported field extends local field',
+      'DefaultClass',
     ];
     expectedElementNames.forEach(async (elementName, index) => {
       await waitFor(
@@ -881,7 +884,7 @@ module('Acceptance | code mode tests', function (hooks) {
         .dom(`[data-test-boxel-selector-item]:nth-of-type(${index + 1})`)
         .hasText(elementName);
     });
-    assert.dom('[data-test-boxel-selector-item]').exists({ count: 8 });
+    assert.dom('[data-test-boxel-selector-item]').exists({ count: 9 });
     assert.dom('[data-test-boxel-selector-item-selected]').hasText(elementName);
     assert.dom('[data-test-inheritance-panel-header]').doesNotExist();
     // clicking on a card

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -1277,12 +1277,12 @@ module('Acceptance | code mode tests', function (hooks) {
 
     // Click on card definition button
     await click(
-      '[data-test-card-schema="Employee"] [data-test-card-schema-navigational-button]',
+      '[data-test-card-schema="Person"] [data-test-card-schema-navigational-button]',
     );
 
-    await waitFor('[data-test-current-module-name]');
+    await waitFor('[data-test-current-module-name="person.gts"]');
 
-    assert.dom('[data-test-current-module-name]').hasText('employee.gts');
+    assert.dom('[data-test-current-module-name]').hasText('person.gts');
 
     // Go back so that we can test clicking on a field definition button
     await visit(
@@ -1299,8 +1299,9 @@ module('Acceptance | code mode tests', function (hooks) {
       '[data-test-card-schema="Employee"] [data-test-field-name="department"] [data-test-card-display-name="String"]',
     );
 
-    await waitFor('[data-test-current-module-name]');
-    assert.dom('[data-test-current-module-name]').hasText('string.ts');
+    // TODO: CS-6110
+    // await waitFor('[data-test-current-module-name="string.ts"]');
+    // assert.dom('[data-test-current-module-name]').hasText('string.ts');
   });
 
   test('code mode handles binary files', async function (assert) {

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -113,6 +113,7 @@ const inThisFileSource = `
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const localVar = 'local var';
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   class LocalClass {}
   export class ExportedClass {}
 

--- a/packages/realm-server/tests/module-syntax-test.ts
+++ b/packages/realm-server/tests/module-syntax-test.ts
@@ -72,7 +72,7 @@ module('module-syntax', function () {
       `,
     );
 
-    let card = mod.possibleCards.find((c) => c.exportedAs === 'Person');
+    let card = mod.possibleCardsOrFields.find((c) => c.exportedAs === 'Person');
     let field = card!.possibleFields.get('age');
     assert.ok(field, 'new field was added to syntax');
     assert.deepEqual(
@@ -253,7 +253,7 @@ module('module-syntax', function () {
         }
       `,
     );
-    let card = mod.possibleCards.find((c) => c.exportedAs === 'Person');
+    let card = mod.possibleCardsOrFields.find((c) => c.exportedAs === 'Person');
     let field = card!.possibleFields.get('aliases');
     assert.ok(field, 'new field was added to syntax');
     assert.deepEqual(
@@ -309,7 +309,7 @@ module('module-syntax', function () {
         }
       `,
     );
-    let card = mod.possibleCards.find((c) => c.exportedAs === 'Person');
+    let card = mod.possibleCardsOrFields.find((c) => c.exportedAs === 'Person');
     let field = card!.possibleFields.get('pet');
     assert.ok(field, 'new field was added to syntax');
     assert.deepEqual(
@@ -355,7 +355,7 @@ module('module-syntax', function () {
         }
       `,
     );
-    let card = mod.possibleCards.find((c) => c.exportedAs === 'Person');
+    let card = mod.possibleCardsOrFields.find((c) => c.exportedAs === 'Person');
     let field = card!.possibleFields.get('friend');
     assert.ok(field, 'new field was added to syntax');
     assert.deepEqual(
@@ -466,7 +466,7 @@ module('module-syntax', function () {
       `,
     );
 
-    let card = mod.possibleCards.find((c) => c.exportedAs === 'Person');
+    let card = mod.possibleCardsOrFields.find((c) => c.exportedAs === 'Person');
     let field = card!.possibleFields.get('firstName');
     assert.strictEqual(field, undefined, 'field does not exist in syntax');
   });
@@ -518,7 +518,7 @@ module('module-syntax', function () {
       `,
     );
 
-    let card = mod.possibleCards.find((c) => c.exportedAs === 'Friend');
+    let card = mod.possibleCardsOrFields.find((c) => c.exportedAs === 'Friend');
     let field = card!.possibleFields.get('friend');
     assert.strictEqual(field, undefined, 'field does not exist in syntax');
   });

--- a/packages/runtime-common/module-syntax.ts
+++ b/packages/runtime-common/module-syntax.ts
@@ -4,10 +4,6 @@ import {
   schemaAnalysisPlugin,
   Options,
   PossibleCardClass,
-  ClassReference,
-  ExternalReference,
-  ClassExport,
-  FunctionExport,
   Export,
 } from './schema-analysis-plugin';
 import {
@@ -31,14 +27,7 @@ import type { types as t } from '@babel/core';
 import type { NodePath } from '@babel/traverse';
 import type { FieldType } from 'https://cardstack.com/base/card-api';
 
-export type {
-  ClassReference,
-  ExternalReference,
-  PossibleCardClass,
-  FunctionExport,
-  ClassExport,
-  Export,
-};
+export type { PossibleCardClass, Export };
 import { unionWith } from 'lodash';
 
 export class ModuleSyntax {
@@ -82,7 +71,6 @@ export class ModuleSyntax {
 
       return aLocalName === bLocalName;
     };
-    debugger;
     return unionWith(this.possibleCards, this.exports, compareByLocalName);
   }
 

--- a/packages/runtime-common/module-syntax.ts
+++ b/packages/runtime-common/module-syntax.ts
@@ -6,8 +6,9 @@ import {
   PossibleCardClass,
   ClassReference,
   ExternalReference,
-  ExportedClass,
-  ExportedFunction,
+  ClassExport,
+  FunctionExport,
+  Export,
 } from './schema-analysis-plugin';
 import {
   removeFieldPlugin,
@@ -34,14 +35,15 @@ export type {
   ClassReference,
   ExternalReference,
   PossibleCardClass,
-  ExportedClass,
-  ExportedFunction,
+  FunctionExport,
+  ClassExport,
+  Export,
 };
 import { unionWith } from 'lodash';
 
 export class ModuleSyntax {
   declare possibleCards: PossibleCardClass[];
-  declare exports: (ExportedClass | ExportedFunction)[];
+  declare exports: Export[];
   private declare ast: t.File;
 
   constructor(src: string) {
@@ -70,21 +72,17 @@ export class ModuleSyntax {
     this.exports = moduleAnalysis.exports;
   }
 
-  elements(): (PossibleCardClass | Exports)[] {
-    // Create a custom comparison function to determine equality based on localName
+  elements(): (PossibleCardClass | Export)[] {
     const compareByLocalName = (
-      a: PossibleCardClass | Exports,
-      b: PossibleCardClass | Exports,
+      a: PossibleCardClass | Export,
+      b: PossibleCardClass | Export,
     ) => {
-      // Extract localName from elements
       const aLocalName = 'localName' in a ? a.localName : undefined;
       const bLocalName = 'localName' in b ? b.localName : undefined;
 
-      // Compare local names for equality, prioritizing PossibleCardClass instances
       return aLocalName === bLocalName;
     };
-
-    // Use _.unionWith to combine and deduplicate the arrays, prioritizing PossibleCardClass instances
+    debugger;
     return unionWith(this.possibleCards, this.exports, compareByLocalName);
   }
 

--- a/packages/runtime-common/remove-field-plugin.ts
+++ b/packages/runtime-common/remove-field-plugin.ts
@@ -1,5 +1,5 @@
 import type {
-  PossibleCardClass,
+  PossibleCardOrFieldClass,
   PossibleField,
 } from './schema-analysis-plugin';
 import { types as t } from '@babel/core';
@@ -11,7 +11,7 @@ interface State {
 }
 
 export interface Options {
-  card: PossibleCardClass;
+  card: PossibleCardOrFieldClass;
   field: PossibleField;
 }
 export function removeFieldPlugin() {

--- a/packages/runtime-common/schema-analysis-plugin.ts
+++ b/packages/runtime-common/schema-analysis-plugin.ts
@@ -38,13 +38,15 @@ export interface PossibleField {
   path: NodePath<t.ClassProperty>;
 }
 
-export interface ExportedClass extends Base {}
+export interface ClassExport extends Base {}
 
-export interface ExportedFunction extends Base {}
+export interface FunctionExport extends Base {}
+
+export type Export = ClassExport | FunctionExport;
 
 export interface Options {
   possibleCards: PossibleCardClass[];
-  exports: Exports[];
+  exports: Export[];
 }
 
 export function schemaAnalysisPlugin(_babel: typeof Babel) {

--- a/packages/runtime-common/schema-analysis-plugin.ts
+++ b/packages/runtime-common/schema-analysis-plugin.ts
@@ -20,15 +20,18 @@ export interface InternalReference {
 
 export type ClassReference = ExternalReference | InternalReference;
 
-export interface Base {
+export type Export = {
   localName: string | undefined;
   exportedAs: string | undefined;
-  path: NodePath<t.ClassDeclaration> | NodePath<t.ExportNamedDeclaration>;
-}
+  path: NodePath<t.ExportDeclaration>;
+};
 
-export interface PossibleCardClass extends Base {
+export interface PossibleCardClass {
   super: ClassReference;
   possibleFields: Map<string, PossibleField>;
+  localName: string | undefined;
+  exportedAs: string | undefined;
+  path: NodePath<t.ClassDeclaration>;
 }
 
 export interface PossibleField {
@@ -38,14 +41,8 @@ export interface PossibleField {
   path: NodePath<t.ClassProperty>;
 }
 
-export interface ClassExport extends Base {}
-
-export interface FunctionExport extends Base {}
-
-export type Export = ClassExport | FunctionExport;
-
 export interface Options {
-  possibleCards: PossibleCardClass[];
+  possibleCards: PossibleCardClass[]; //cards may not be exports
   exports: Export[];
 }
 

--- a/packages/runtime-common/schema-analysis-plugin.ts
+++ b/packages/runtime-common/schema-analysis-plugin.ts
@@ -256,7 +256,6 @@ function makeClassReference(
 
   if (binding?.path.isClassDeclaration()) {
     let superClassNode = binding.path.node;
-    // only specific to finding cards
     let superClassIndex = state.opts.possibleCards.findIndex(
       (card) => card.path.node === superClassNode,
     );

--- a/packages/runtime-common/schema-analysis-plugin.ts
+++ b/packages/runtime-common/schema-analysis-plugin.ts
@@ -4,6 +4,7 @@ import type { NodePath, Scope } from '@babel/traverse';
 
 interface State {
   opts: Options;
+  insideCard: boolean;
 }
 
 export interface ExternalReference {
@@ -52,12 +53,21 @@ export interface Options {
 export function schemaAnalysisPlugin(_babel: typeof Babel) {
   return {
     visitor: {
-      Declaration: {
-        enter(
-          path: NodePath<t.ClassDeclaration> | NodePath<t.FunctionDeclaration>,
-          state: State,
-        ) {
-          if (t.isClassDeclaration(path) || t.isFunctionDeclaration(path)) {
+      FunctionDeclaration: {
+        enter(path: NodePath<t.FunctionDeclaration>, state: State) {
+          let localName = path.node.id ? path.node.id.name : undefined;
+          if (t.isExportDeclaration(path.parentPath)) {
+            state.opts.elements.push({
+              localName,
+              exportedAs: getExportedAs(path, localName),
+              path,
+            });
+          }
+        },
+      },
+      ClassDeclaration: {
+        enter(path: NodePath<t.ClassDeclaration>, state: State) {
+          if (!path.node.superClass) {
             let localName = path.node.id ? path.node.id.name : undefined;
             if (t.isExportDeclaration(path.parentPath)) {
               state.opts.elements.push({
@@ -65,112 +75,142 @@ export function schemaAnalysisPlugin(_babel: typeof Babel) {
                 exportedAs: getExportedAs(path, localName),
                 path,
               });
-            } else if (t.isClassDeclaration(path)) {
-              let maybeCard = lookForCard(path, state);
-              if (maybeCard) {
-                state.opts.elements.push(maybeCard);
+            }
+            return;
+          }
+
+          let sc = path.get('superClass');
+          if (sc.isReferencedIdentifier()) {
+            let classRef = makeClassReference(path.scope, sc.node.name, state);
+            if (classRef) {
+              state.insideCard = true;
+              let localName = path.node.id ? path.node.id.name : undefined;
+
+              let possibleCardOrField = {
+                super: classRef,
+                localName,
+                path,
+                possibleFields: new Map(),
+                exportedAs: getExportedAs(path, localName),
+              };
+              state.opts.possibleCardsOrFields.push(possibleCardOrField);
+              state.opts.elements.push(possibleCardOrField);
+            } else {
+              if (t.isExportDeclaration(path.parentPath)) {
+                let localName = path.node.id ? path.node.id.name : undefined;
+                state.opts.elements.push({
+                  localName,
+                  exportedAs: getExportedAs(path, localName),
+                  path,
+                });
               }
+            }
+          } else {
+            if (t.isExportDeclaration(path.parentPath)) {
+              let localName = path.node.id ? path.node.id.name : undefined;
+              state.opts.elements.push({
+                localName,
+                exportedAs: getExportedAs(path, localName),
+                path,
+              });
             }
           }
         },
-      },
-      ClassDeclaration: {
-        enter(path: NodePath<t.ClassDeclaration>, state: State) {
-          let maybeCard = lookForCard(path, state);
-          if (maybeCard) {
-            state.opts.possibleCardsOrFields.push(maybeCard);
-            maybeCard.path.traverse({
-              Decorator: {
-                enter(path: NodePath<t.Decorator>) {
-                  let expression = path.get('expression');
-                  if (!expression.isIdentifier()) {
-                    return;
-                  }
-                  let decoratorInfo = getNamedImportInfo(
-                    path.scope,
-                    expression.node.name,
-                  );
-                  if (!decoratorInfo) {
-                    return; // our @field decorator must originate from a named import
-                  }
 
-                  let maybeClassProperty = path.parentPath;
-                  if (
-                    !maybeClassProperty.isClassProperty() ||
-                    maybeClassProperty.node.key.type !== 'Identifier'
-                  ) {
-                    return;
-                  }
-
-                  let maybeCallExpression = maybeClassProperty.node.value;
-                  if (
-                    maybeCallExpression?.type !== 'CallExpression' ||
-                    maybeCallExpression.arguments.length === 0
-                  ) {
-                    return; // our field type function (e.g. contains()) must have at least one argument (the field card)
-                  }
-
-                  let maybeFieldTypeFunction = maybeCallExpression.callee;
-                  if (maybeFieldTypeFunction.type !== 'Identifier') {
-                    return;
-                  }
-
-                  let fieldTypeInfo = getNamedImportInfo(
-                    path.scope,
-                    maybeFieldTypeFunction.name,
-                  );
-                  if (!fieldTypeInfo) {
-                    return; // our field type function (e.g. contains()) must originate from a named import
-                  }
-
-                  let [maybeFieldCard] = maybeCallExpression.arguments; // note that the 2nd argument is the computeVia
-                  let maybeFieldCardName;
-                  if (maybeFieldCard.type !== 'Identifier') {
-                    if (
-                      maybeFieldCard.type === 'ArrowFunctionExpression' &&
-                      maybeFieldCard.body.type === 'Identifier'
-                    ) {
-                      maybeFieldCardName = maybeFieldCard.body.name;
-                    } else {
-                      return;
-                    }
-                  } else {
-                    maybeFieldCardName = maybeFieldCard.name;
-                  }
-
-                  let fieldCard = makeClassReference(
-                    path.scope,
-                    maybeFieldCardName,
-                    state,
-                  );
-                  if (!fieldCard) {
-                    return; // the first argument to our field type function must be a card reference
-                  }
-
-                  let possibleField: PossibleField = {
-                    card: fieldCard,
-                    path: maybeClassProperty,
-                    type: {
-                      type: 'external',
-                      module: getName(fieldTypeInfo.declaration.node.source),
-                      name: getName(fieldTypeInfo.specifier.node.imported),
-                    },
-                    decorator: {
-                      type: 'external',
-                      module: getName(decoratorInfo.declaration.node.source),
-                      name: getName(decoratorInfo.specifier.node.imported),
-                    },
-                  };
-                  // the card that contains this field will always be the last card that
-                  // was added to possibleCardsOrFields
-                  let [card] = state.opts.possibleCardsOrFields.slice(-1);
-                  let fieldName = maybeClassProperty.node.key.name;
-                  card.possibleFields.set(fieldName, possibleField);
-                },
-              },
-            });
-          }
+        exit(_path: NodePath<t.ClassDeclaration>, state: State) {
+          state.insideCard = false;
         },
+      },
+
+      Decorator(path: NodePath<t.Decorator>, state: State) {
+        if (!state.insideCard) {
+          return;
+        }
+
+        let expression = path.get('expression');
+        if (!expression.isIdentifier()) {
+          return;
+        }
+        let decoratorInfo = getNamedImportInfo(
+          path.scope,
+          expression.node.name,
+        );
+        if (!decoratorInfo) {
+          return; // our @field decorator must originate from a named import
+        }
+
+        let maybeClassProperty = path.parentPath;
+        if (
+          !maybeClassProperty.isClassProperty() ||
+          maybeClassProperty.node.key.type !== 'Identifier'
+        ) {
+          return;
+        }
+
+        let maybeCallExpression = maybeClassProperty.node.value;
+        if (
+          maybeCallExpression?.type !== 'CallExpression' ||
+          maybeCallExpression.arguments.length === 0
+        ) {
+          return; // our field type function (e.g. contains()) must have at least one argument (the field card)
+        }
+
+        let maybeFieldTypeFunction = maybeCallExpression.callee;
+        if (maybeFieldTypeFunction.type !== 'Identifier') {
+          return;
+        }
+
+        let fieldTypeInfo = getNamedImportInfo(
+          path.scope,
+          maybeFieldTypeFunction.name,
+        );
+        if (!fieldTypeInfo) {
+          return; // our field type function (e.g. contains()) must originate from a named import
+        }
+
+        let [maybeFieldCard] = maybeCallExpression.arguments; // note that the 2nd argument is the computeVia
+        let maybeFieldCardName;
+        if (maybeFieldCard.type !== 'Identifier') {
+          if (
+            maybeFieldCard.type === 'ArrowFunctionExpression' &&
+            maybeFieldCard.body.type === 'Identifier'
+          ) {
+            maybeFieldCardName = maybeFieldCard.body.name;
+          } else {
+            return;
+          }
+        } else {
+          maybeFieldCardName = maybeFieldCard.name;
+        }
+
+        let fieldCard = makeClassReference(
+          path.scope,
+          maybeFieldCardName,
+          state,
+        );
+        if (!fieldCard) {
+          return; // the first argument to our field type function must be a card reference
+        }
+
+        let possibleField: PossibleField = {
+          card: fieldCard,
+          path: maybeClassProperty,
+          type: {
+            type: 'external',
+            module: getName(fieldTypeInfo.declaration.node.source),
+            name: getName(fieldTypeInfo.specifier.node.imported),
+          },
+          decorator: {
+            type: 'external',
+            module: getName(decoratorInfo.declaration.node.source),
+            name: getName(decoratorInfo.specifier.node.imported),
+          },
+        };
+        // the card that contains this field will always be the last card that
+        // was added to possibleCardsOrFields
+        let [card] = state.opts.possibleCardsOrFields.slice(-1);
+        let fieldName = maybeClassProperty.node.key.name;
+        card.possibleFields.set(fieldName, possibleField);
       },
     },
   };
@@ -189,28 +229,6 @@ class CompilerError extends Error {
       this.stack = new Error(message).stack;
     }
   }
-}
-
-function lookForCard(path: NodePath<t.ClassDeclaration>, state: State) {
-  if (!path.node.superClass) {
-    return;
-  }
-
-  let sc = path.get('superClass');
-  if (sc.isReferencedIdentifier()) {
-    let classRef = makeClassReference(path.scope, sc.node.name, state);
-    if (classRef) {
-      let localName = path.node.id ? path.node.id.name : undefined;
-      return {
-        super: classRef,
-        localName,
-        path,
-        possibleFields: new Map(),
-        exportedAs: getExportedAs(path, localName),
-      };
-    }
-  }
-  return;
 }
 
 function getExportedAs(


### PR DESCRIPTION
Most of the logic is here but I made a slight change https://github.com/cardstack/boxel/pull/708 that affects the ast and data that this PR consumes

The purpose of this PR is to 
- add exported functions and classes to the LHS panel
- enable field treatment on the LHS. ie show "Field Definition" rather than "Card Definition"

https://github.com/cardstack/boxel/assets/8165111/ea5d988f-873d-4eaa-8131-5932735992cd

There are some things not considered yet
- ~named exports altho this information is available~
- ~default export. Somehow glint doesn't allow me to write a default export~
- non exported cards




