### PR TITLE
Update realm icon

### DIFF
--- a/packages/host/app/components/operator-mode/card-url-bar.gts
+++ b/packages/host/app/components/operator-mode/card-url-bar.gts
@@ -25,6 +25,7 @@ interface Signature {
     userHasDismissedError: boolean; // user driven state that indicates if we should show error message
     resetLoadFileError: () => void; // callback to reset upstream error state -- perform on keypress
     dismissURLError: () => void; // callback allow user to dismiss the error message
+    realmURL: string;
   };
 }
 
@@ -37,7 +38,7 @@ export default class CardURLBar extends Component<Signature> {
       ...attributes
     >
       <div class='realm-info' data-test-card-url-bar-realm-info>
-        <RealmInfoProvider @realmURL={{this.realmURL}}>
+        <RealmInfoProvider @realmURL={{@realmURL}}>
           <:ready as |realmInfo|>
             <div class='realm-icon'>
               <img src={{realmInfo.iconURL}} alt='realm-icon' />
@@ -201,16 +202,5 @@ export default class CardURLBar extends Component<Signature> {
     return this.operatorModeStateService.state.codePath
       ? this.operatorModeStateService.state.codePath.toString()
       : null;
-  }
-
-  private get realmURL() {
-    let url;
-    if (this.codePath) {
-      url = this.cardService.getRealmURLFor(new URL(this.codePath))?.toString();
-    }
-    if (!url) {
-      url = this.cardService.defaultURL.toString();
-    }
-    return url;
   }
 }

--- a/packages/host/app/components/operator-mode/card-url-bar.gts
+++ b/packages/host/app/components/operator-mode/card-url-bar.gts
@@ -11,6 +11,7 @@ import URLBarResource, {
 } from '@cardstack/host/resources/url-bar';
 
 import type OperatorModeStateService from '../../services/operator-mode-state-service';
+import type CardService from '../../services/card-service';
 import RealmInfoProvider from '@cardstack/host/components/operator-mode/realm-info-provider';
 
 interface Signature {
@@ -36,7 +37,10 @@ export default class CardURLBar extends Component<Signature> {
       ...attributes
     >
       <div class='realm-info' data-test-card-url-bar-realm-info>
-        <RealmInfoProvider @fileURL={{this.codePath}}>
+        <RealmInfoProvider
+          @realmURL={{this.realmURL}}
+          @returnUnknownRealmIfError={{true}}
+        >
           <:ready as |realmInfo|>
             <div class='realm-icon'>
               <img src={{realmInfo.iconURL}} alt='realm-icon' />
@@ -185,6 +189,7 @@ export default class CardURLBar extends Component<Signature> {
   </template>
 
   @service private declare operatorModeStateService: OperatorModeStateService;
+  @service private declare cardService: CardService;
 
   private urlBar: URLBarResource = urlBarResource(this, () => ({
     getValue: () => this.codePath,
@@ -198,6 +203,17 @@ export default class CardURLBar extends Component<Signature> {
   private get codePath() {
     return this.operatorModeStateService.state.codePath
       ? this.operatorModeStateService.state.codePath.toString()
-      : '';
+      : null;
+  }
+
+  private get realmURL() {
+    let url;
+    if (this.codePath) {
+      url = this.cardService.getRealmURLFor(new URL(this.codePath))?.toString();
+    }
+    if (!url) {
+      url = this.cardService.defaultURL.toString();
+    }
+    return url;
   }
 }

--- a/packages/host/app/components/operator-mode/card-url-bar.gts
+++ b/packages/host/app/components/operator-mode/card-url-bar.gts
@@ -47,12 +47,6 @@ export default class CardURLBar extends Component<Signature> {
             </div>
             <span>in {{realmInfo.name}}</span>
           </:ready>
-          <:error>
-            <div class='realm-icon'>
-              <img src='' alt='realm-icon' />
-            </div>
-            <span>in Unknown Workspace</span>
-          </:error>
         </RealmInfoProvider>
       </div>
       <div class='input'>

--- a/packages/host/app/components/operator-mode/card-url-bar.gts
+++ b/packages/host/app/components/operator-mode/card-url-bar.gts
@@ -47,7 +47,7 @@ export default class CardURLBar extends Component<Signature> {
           </:ready>
           <:error>
             <div class='realm-icon'>
-              <img src='' alt='realm-icon' />
+              {{svgJar 'icon-circle' width='22px' height='22px'}}
             </div>
             <span>in Unknown Workspace</span>
           </:error>
@@ -121,6 +121,8 @@ export default class CardURLBar extends Component<Signature> {
 
         border: 1px solid var(--boxel-light);
         border-radius: 4px;
+
+        --icon-color: var(--boxel-light);
       }
       .realm-icon img {
         width: 20px;

--- a/packages/host/app/components/operator-mode/card-url-bar.gts
+++ b/packages/host/app/components/operator-mode/card-url-bar.gts
@@ -6,13 +6,12 @@ import { svgJar } from '@cardstack/boxel-ui/helpers/svg-jar';
 import { and, bool, not } from '@cardstack/boxel-ui/helpers/truth-helpers';
 import { on } from '@ember/modifier';
 
-import { type RealmInfo } from '@cardstack/runtime-common';
-
 import URLBarResource, {
   urlBarResource,
 } from '@cardstack/host/resources/url-bar';
 
 import type OperatorModeStateService from '../../services/operator-mode-state-service';
+import RealmInfoProvider from '@cardstack/host/components/operator-mode/realm-info-provider';
 
 interface Signature {
   Element: HTMLElement;
@@ -25,7 +24,6 @@ interface Signature {
     userHasDismissedError: boolean; // user driven state that indicates if we should show error message
     resetLoadFileError: () => void; // callback to reset upstream error state -- perform on keypress
     dismissURLError: () => void; // callback allow user to dismiss the error message
-    realmInfo: RealmInfo | null;
   };
 }
 
@@ -38,11 +36,20 @@ export default class CardURLBar extends Component<Signature> {
       ...attributes
     >
       <div class='realm-info' data-test-card-url-bar-realm-info>
-        <div class='realm-icon'>
-          <img src={{this.realmIcon}} alt='realm-icon' />
-        </div>
-        <span>in
-          {{if this.realmName this.realmName 'Unknown Workspace'}}</span>
+        <RealmInfoProvider @fileURL={{this.codePath}}>
+          <:ready as |realmInfo|>
+            <div class='realm-icon'>
+              <img src={{realmInfo.iconURL}} alt='realm-icon' />
+            </div>
+            <span>in {{realmInfo.name}}</span>
+          </:ready>
+          <:error>
+            <div class='realm-icon'>
+              <img src='' alt='realm-icon' />
+            </div>
+            <span>in Unknown Workspace</span>
+          </:error>
+        </RealmInfoProvider>
       </div>
       <div class='input'>
         {{svgJar 'icon-globe' width='22px' height='22px'}}
@@ -191,14 +198,6 @@ export default class CardURLBar extends Component<Signature> {
   private get codePath() {
     return this.operatorModeStateService.state.codePath
       ? this.operatorModeStateService.state.codePath.toString()
-      : null;
-  }
-
-  private get realmIcon() {
-    return this.args.realmInfo?.iconURL;
-  }
-
-  private get realmName() {
-    return this.args.realmInfo?.name;
+      : '';
   }
 }

--- a/packages/host/app/components/operator-mode/card-url-bar.gts
+++ b/packages/host/app/components/operator-mode/card-url-bar.gts
@@ -37,16 +37,19 @@ export default class CardURLBar extends Component<Signature> {
       ...attributes
     >
       <div class='realm-info' data-test-card-url-bar-realm-info>
-        <RealmInfoProvider
-          @realmURL={{this.realmURL}}
-          @returnUnknownRealmIfError={{true}}
-        >
+        <RealmInfoProvider @realmURL={{this.realmURL}}>
           <:ready as |realmInfo|>
             <div class='realm-icon'>
               <img src={{realmInfo.iconURL}} alt='realm-icon' />
             </div>
             <span>in {{realmInfo.name}}</span>
           </:ready>
+          <:error>
+            <div class='realm-icon'>
+              <img src='' alt='realm-icon' />
+            </div>
+            <span>in Unknown Workspace</span>
+          </:error>
         </RealmInfoProvider>
       </div>
       <div class='input'>

--- a/packages/host/app/components/operator-mode/code-mode.gts
+++ b/packages/host/app/components/operator-mode/code-mode.gts
@@ -737,6 +737,7 @@ export default class CodeMode extends Component<Signature> {
       @resetLoadFileError={{this.resetLoadFileError}}
       @userHasDismissedError={{this.userHasDismissedURLError}}
       @dismissURLError={{this.dismissURLError}}
+      @realmURL={{this.realmURL}}
       class='card-url-bar'
     />
     <div

--- a/packages/host/app/components/operator-mode/code-mode.gts
+++ b/packages/host/app/components/operator-mode/code-mode.gts
@@ -737,7 +737,6 @@ export default class CodeMode extends Component<Signature> {
       @resetLoadFileError={{this.resetLoadFileError}}
       @userHasDismissedError={{this.userHasDismissedURLError}}
       @dismissURLError={{this.dismissURLError}}
-      @realmInfo={{this.realmInfo}}
       class='card-url-bar'
     />
     <div

--- a/packages/host/app/components/operator-mode/realm-info-provider.gts
+++ b/packages/host/app/components/operator-mode/realm-info-provider.gts
@@ -15,13 +15,11 @@ const waiter = buildWaiter('realm-info-provider:load-waiter');
 interface RealmURLArg {
   realmURL: string;
   fileURL?: never;
-  returnUnknownRealmIfError?: boolean;
 }
 
 interface FileURLArg {
   fileURL: string;
   realmURL?: never;
-  returnUnknownRealmIfError?: boolean;
 }
 
 export interface Signature {
@@ -62,13 +60,6 @@ export default class RealmInfoProvider extends Component<Signature> {
 
           state.value = realmInfo;
         } catch (error: any) {
-          if (this.args.returnUnknownRealmIfError) {
-            state.value = {
-              name: 'Unknown Workspace',
-              iconURL: '',
-              backgroundURL: '',
-            };
-          }
           state.error = error;
         } finally {
           state.isLoading = false;

--- a/packages/host/app/components/operator-mode/realm-info-provider.gts
+++ b/packages/host/app/components/operator-mode/realm-info-provider.gts
@@ -15,11 +15,13 @@ const waiter = buildWaiter('realm-info-provider:load-waiter');
 interface RealmURLArg {
   realmURL: string;
   fileURL?: never;
+  returnUnknownRealmIfError?: boolean;
 }
 
 interface FileURLArg {
   fileURL: string;
   realmURL?: never;
+  returnUnknownRealmIfError?: boolean;
 }
 
 export interface Signature {
@@ -60,6 +62,13 @@ export default class RealmInfoProvider extends Component<Signature> {
 
           state.value = realmInfo;
         } catch (error: any) {
+          if (this.args.returnUnknownRealmIfError) {
+            state.value = {
+              name: 'Unknown Workspace',
+              iconURL: '',
+              backgroundURL: '',
+            };
+          }
           state.error = error;
         } finally {
           state.isLoading = false;

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -15,7 +15,6 @@ import { formatDistanceToNow } from 'date-fns';
 import { task, restartableTask, timeout } from 'ember-concurrency';
 import perform from 'ember-concurrency/helpers/perform';
 import Modifier from 'ember-modifier';
-import { trackedFunction } from 'ember-resources/util/function';
 
 import { TrackedArray } from 'tracked-built-ins';
 
@@ -50,6 +49,7 @@ import { type StackItem } from './container';
 import OperatorModeOverlays from './overlays';
 
 import type CardService from '../../services/card-service';
+import RealmInfoProvider from '@cardstack/host/components/operator-mode/realm-info-provider';
 
 interface Signature {
   Args: {
@@ -180,23 +180,9 @@ export default class OperatorModeStackItem extends Component<Signature> {
     await navigator.clipboard.writeText(this.card.id);
   });
 
-  fetchRealmInfo = trackedFunction(
-    this,
-    async () => await this.cardService.getRealmInfo(this.card),
-  );
-
   clearSelections = () => {
     this.selectedCards.splice(0, this.selectedCards.length);
   };
-
-  @cached
-  get iconURL() {
-    return this.fetchRealmInfo.value?.iconURL;
-  }
-
-  get realmName() {
-    return this.fetchRealmInfo.value?.name;
-  }
 
   get cardIdentifier() {
     return this.args.item.card.id;
@@ -207,17 +193,10 @@ export default class OperatorModeStackItem extends Component<Signature> {
     this.isHoverOnRealmIcon = !this.isHoverOnRealmIcon;
   }
 
-  get headerIcon() {
-    return {
-      URL: this.iconURL,
-      onMouseEnter: this.hoverOnRealmIcon,
-      onMouseLeave: this.hoverOnRealmIcon,
-    };
-  }
-
-  get headerTitle() {
-    return this.isHoverOnRealmIcon && this.realmName
-      ? `In ${this.realmName}`
+  @action
+  headerTitle(realmName: string) {
+    return this.isHoverOnRealmIcon && realmName
+      ? `In ${realmName}`
       : cardTypeDisplayName(this.card);
   }
 
@@ -288,147 +267,157 @@ export default class OperatorModeStackItem extends Component<Signature> {
       style={{this.styleForStackedCard}}
     >
       <CardContainer class={{cn 'card' edit=(eq @item.format 'edit')}}>
-        <Header
-          @title={{this.headerTitle}}
-          class={{cn 'header' header--icon-hovered=this.isHoverOnRealmIcon}}
-          {{on
-            'click'
-            (optional (if this.isBuried (fn @dismissStackedCardsAbove @index)))
-          }}
-          data-test-stack-card-header
-        >
-          <:icon>
-            {{#if this.headerIcon.URL}}
-              <img
-                class='header-icon'
-                src={{this.headerIcon.URL}}
-                data-test-boxel-header-icon={{this.headerIcon.URL}}
-                alt=''
-                role='presentation'
-                {{on 'mouseenter' this.headerIcon.onMouseEnter}}
-                {{on 'mouseleave' this.headerIcon.onMouseLeave}}
-              />
-            {{/if}}
-          </:icon>
-          <:actions>
-            {{#if (eq @item.format 'isolated')}}
-              <Tooltip @placement='top'>
-                <:trigger>
-                  <IconButton
-                    @icon='icon-pencil'
-                    @width='24px'
-                    @height='24px'
-                    class='icon-button'
-                    aria-label='Edit'
-                    {{on 'click' (fn @edit @item)}}
-                    data-test-edit-button
-                  />
-                </:trigger>
-                <:content>
-                  Edit
-                </:content>
-              </Tooltip>
-            {{else}}
-              <Tooltip @placement='top'>
-                <:trigger>
-                  <IconButton
-                    @icon='icon-pencil'
-                    @width='24px'
-                    @height='24px'
-                    class='icon-save'
-                    aria-label='Finish Editing'
-                    {{on 'click' (fn @save @item true)}}
-                    data-test-edit-button
-                  />
-                </:trigger>
-                <:content>
-                  Finish Editing
-                </:content>
-              </Tooltip>
-            {{/if}}
-            <div>
-              <BoxelDropdown>
-                <:trigger as |bindings|>
+        <RealmInfoProvider @fileURL={{this.card.id}}>
+          <:ready as |realmInfo|>
+            <Header
+              @title={{this.headerTitle realmInfo.name}}
+              class={{cn 'header' header--icon-hovered=this.isHoverOnRealmIcon}}
+              {{on
+                'click'
+                (optional
+                  (if this.isBuried (fn @dismissStackedCardsAbove @index))
+                )
+              }}
+              data-test-stack-card-header
+            >
+              <:icon>
+                <img
+                  class='header-icon'
+                  src={{realmInfo.iconURL}}
+                  data-test-boxel-header-icon={{realmInfo.iconURL}}
+                  alt=''
+                  role='presentation'
+                  {{on 'mouseenter' this.hoverOnRealmIcon}}
+                  {{on 'mouseleave' this.hoverOnRealmIcon}}
+                />
+              </:icon>
+              <:actions>
+                {{#if (eq @item.format 'isolated')}}
                   <Tooltip @placement='top'>
                     <:trigger>
                       <IconButton
-                        @icon='three-dots-horizontal'
-                        @width='20px'
-                        @height='20px'
+                        @icon='icon-pencil'
+                        @width='24px'
+                        @height='24px'
                         class='icon-button'
-                        aria-label='Options'
-                        data-test-more-options-button
-                        {{bindings}}
+                        aria-label='Edit'
+                        {{on 'click' (fn @edit @item)}}
+                        data-test-edit-button
                       />
                     </:trigger>
                     <:content>
-                      More Options
+                      Edit
                     </:content>
                   </Tooltip>
-                </:trigger>
-                <:content as |dd|>
-                  <BoxelMenu
-                    @closeMenu={{dd.close}}
-                    @items={{if
-                      (eq @item.format 'edit')
-                      (array
-                        (menuItem
-                          'Copy Card URL'
-                          (perform this.copyToClipboard)
-                          icon='icon-link'
-                        )
-                        (menuItem
-                          'Delete'
-                          (fn @delete this.card)
-                          icon='icon-trash'
-                          dangerous=true
-                        )
-                      )
-                      (array
-                        (menuItem
-                          'Copy Card URL'
-                          (perform this.copyToClipboard)
-                          icon='icon-link'
-                        )
-                        (menuItem
-                          'Delete'
-                          (fn @delete this.card)
-                          icon='icon-trash'
-                          dangerous=true
-                        )
-                      )
-                    }}
-                  />
-                </:content>
-              </BoxelDropdown>
+                {{else}}
+                  <Tooltip @placement='top'>
+                    <:trigger>
+                      <IconButton
+                        @icon='icon-pencil'
+                        @width='24px'
+                        @height='24px'
+                        class='icon-save'
+                        aria-label='Finish Editing'
+                        {{on 'click' (fn @save @item true)}}
+                        data-test-edit-button
+                      />
+                    </:trigger>
+                    <:content>
+                      Finish Editing
+                    </:content>
+                  </Tooltip>
+                {{/if}}
+                <div>
+                  <BoxelDropdown>
+                    <:trigger as |bindings|>
+                      <Tooltip @placement='top'>
+                        <:trigger>
+                          <IconButton
+                            @icon='three-dots-horizontal'
+                            @width='20px'
+                            @height='20px'
+                            class='icon-button'
+                            aria-label='Options'
+                            data-test-more-options-button
+                            {{bindings}}
+                          />
+                        </:trigger>
+                        <:content>
+                          More Options
+                        </:content>
+                      </Tooltip>
+                    </:trigger>
+                    <:content as |dd|>
+                      <BoxelMenu
+                        @closeMenu={{dd.close}}
+                        @items={{if
+                          (eq @item.format 'edit')
+                          (array
+                            (menuItem
+                              'Copy Card URL'
+                              (perform this.copyToClipboard)
+                              icon='icon-link'
+                            )
+                            (menuItem
+                              'Delete'
+                              (fn @delete this.card)
+                              icon='icon-trash'
+                              dangerous=true
+                            )
+                          )
+                          (array
+                            (menuItem
+                              'Copy Card URL'
+                              (perform this.copyToClipboard)
+                              icon='icon-link'
+                            )
+                            (menuItem
+                              'Delete'
+                              (fn @delete this.card)
+                              icon='icon-trash'
+                              dangerous=true
+                            )
+                          )
+                        }}
+                      />
+                    </:content>
+                  </BoxelDropdown>
+                </div>
+                <Tooltip @placement='top'>
+                  <:trigger>
+                    <IconButton
+                      @icon='icon-x'
+                      @width='20px'
+                      @height='20px'
+                      class='icon-button'
+                      aria-label='Close'
+                      {{on 'click' (fn @close @item)}}
+                      data-test-close-button
+                    />
+                  </:trigger>
+                  <:content>
+                    {{if (eq @item.format 'isolated') 'Close' 'Cancel & Close'}}
+                  </:content>
+                </Tooltip>
+              </:actions>
+              <:detail>
+                <div class='save-indicator'>
+                  {{#if this.isSaving}}
+                    Saving…
+                  {{else if this.lastSavedMsg}}
+                    {{this.lastSavedMsg}}
+                  {{/if}}
+                </div>
+              </:detail>
+            </Header>
+          </:ready>
+          <:error>
+            <div class='realm-icon'>
+              <img src='' alt='realm-icon' />
             </div>
-            <Tooltip @placement='top'>
-              <:trigger>
-                <IconButton
-                  @icon='icon-x'
-                  @width='20px'
-                  @height='20px'
-                  class='icon-button'
-                  aria-label='Close'
-                  {{on 'click' (fn @close @item)}}
-                  data-test-close-button
-                />
-              </:trigger>
-              <:content>
-                {{if (eq @item.format 'isolated') 'Close' 'Cancel & Close'}}
-              </:content>
-            </Tooltip>
-          </:actions>
-          <:detail>
-            <div class='save-indicator'>
-              {{#if this.isSaving}}
-                Saving…
-              {{else if this.lastSavedMsg}}
-                {{this.lastSavedMsg}}
-              {{/if}}
-            </div>
-          </:detail>
-        </Header>
+            <span>in Unknown Workspace</span>
+          </:error>
+        </RealmInfoProvider>
         <div class='content' {{ContentElement onSetup=this.setupContentEl}}>
           <Preview
             @card={{this.card}}
@@ -467,6 +456,11 @@ export default class OperatorModeStackItem extends Component<Signature> {
       .header-icon {
         border: 1px solid rgba(0, 0, 0, 0.15);
         border-radius: 7px;
+      }
+
+      .edit .header-icon {
+        background: var(--boxel-light);
+        border: 1px solid var(--boxel-light);
       }
 
       .header--icon-hovered {

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -267,7 +267,10 @@ export default class OperatorModeStackItem extends Component<Signature> {
       style={{this.styleForStackedCard}}
     >
       <CardContainer class={{cn 'card' edit=(eq @item.format 'edit')}}>
-        <RealmInfoProvider @fileURL={{this.card.id}}>
+        <RealmInfoProvider
+          @realmURL={{this.card.id}}
+          @returnUnknownRealmIfError={{true}}
+        >
           <:ready as |realmInfo|>
             <Header
               @title={{this.headerTitle realmInfo.name}}
@@ -411,12 +414,6 @@ export default class OperatorModeStackItem extends Component<Signature> {
               </:detail>
             </Header>
           </:ready>
-          <:error>
-            <div class='realm-icon'>
-              <img src='' alt='realm-icon' />
-            </div>
-            <span>in Unknown Workspace</span>
-          </:error>
         </RealmInfoProvider>
         <div class='content' {{ContentElement onSetup=this.setupContentEl}}>
           <Preview


### PR DESCRIPTION
This PR is made to update the styling of the realm icon in the stack item's header of operator mode when the stack item is on edit view. But I also refactored the way we load the realm info by utilizing `RealmInfoProvider`.

Screenshots:

- In stack item of operator mode when edit view.

<img width="242" alt="Screenshot 2023-10-02 at 19 14 55" src="https://github.com/cardstack/boxel/assets/12637010/d5a7ebf0-e28d-4e6b-857c-19e8a0e1c395">

- In stack item of operator mode when isolated view.

<img width="256" alt="Screenshot 2023-10-02 at 19 15 01" src="https://github.com/cardstack/boxel/assets/12637010/602fa6e6-0ead-45a5-863f-81dd10a3e52b">

- in card URL Bar.

<img width="183" alt="Screenshot 2023-10-02 at 19 15 06" src="https://github.com/cardstack/boxel/assets/12637010/ba53e5d6-cf6c-4394-9b93-59b9e142e964">
