### PR TITLE
Add navigatable buttons to cards and fields in schema editor

### DIFF
--- a/packages/host/app/components/operator-mode/card-schema-editor.gts
+++ b/packages/host/app/components/operator-mode/card-schema-editor.gts
@@ -55,6 +55,10 @@ export default class CardSchemaEditor extends Component<Signature> {
         display: inline-flex;
       }
 
+      .pill:hover {
+        background-color: var(--boxel-100);
+      }
+
       .pill > div {
         display: flex;
       }

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -148,6 +148,7 @@ export default class DetailPanel extends Component<Signature> {
                 @title={{@readyFile.name}}
                 @hasBackground={{true}}
                 class='header'
+                data-test-current-module-name={{@readyFile.name}}
               />
               <Selector
                 @class='in-this-file-menu'


### PR DESCRIPTION
<img width="724" alt="image" src="https://github.com/cardstack/boxel/assets/273660/973a4e0b-e3dc-417b-8585-5404693559b7">

The click will lead to opening the card or field's code module in the code editor. 