### PR TITLE
Changes schema-analysis-plugin to have proper order of LHS (In This File) panel

### DIFF
--- a/packages/host/app/components/operator-mode/code-mode.gts
+++ b/packages/host/app/components/operator-mode/code-mode.gts
@@ -42,7 +42,7 @@ import {
 import {
   ModuleSyntax,
   type PossibleCardClass,
-  type Export,
+  type BaseDeclaration,
 } from '@cardstack/runtime-common/module-syntax';
 
 import RecentFiles from '@cardstack/host/components/editor/recent-files';
@@ -136,7 +136,7 @@ const cardEditorSaveTimes = new Map<string, number>();
 // - exported function or class
 // - exported card or field
 // - unexported card or field
-export type Element = (CardOrField & Partial<PossibleCardClass>) | Export;
+export type Element = (CardOrField & Partial<PossibleCardClass>) | BaseDeclaration;
 
 export interface CardOrField {
   cardType: CardType;
@@ -425,7 +425,7 @@ export default class CodeMode extends Component<Signature> {
                     cardOrField,
                   } as CardOrField & Partial<PossibleCardClass>;
                 }
-                return value as Export;
+                return value as BaseDeclaration;
               });
             }
             state.value = elements;

--- a/packages/host/app/components/operator-mode/code-mode.gts
+++ b/packages/host/app/components/operator-mode/code-mode.gts
@@ -41,7 +41,7 @@ import {
 } from '@cardstack/runtime-common';
 import {
   ModuleSyntax,
-  type PossibleCardClass,
+  type PossibleCardOrFieldClass,
   type BaseDeclaration,
 } from '@cardstack/runtime-common/module-syntax';
 
@@ -136,7 +136,10 @@ const cardEditorSaveTimes = new Map<string, number>();
 // - exported function or class
 // - exported card or field
 // - unexported card or field
-export type Element = (CardOrField & Partial<PossibleCardClass>) | BaseDeclaration;
+// This element (in code mode) is extended to include the cardType and cardOrField
+export type Element =
+  | (CardOrField & Partial<PossibleCardOrFieldClass>)
+  | BaseDeclaration;
 
 export interface CardOrField {
   cardType: CardType;
@@ -145,7 +148,7 @@ export interface CardOrField {
 
 export function isCardOrFieldElement(
   element: Element,
-): element is CardOrField & Partial<PossibleCardClass> {
+): element is CardOrField & Partial<PossibleCardOrFieldClass> {
   return (
     (element as CardOrField).cardType !== undefined &&
     (element as CardOrField).cardOrField !== undefined
@@ -423,7 +426,7 @@ export default class CodeMode extends Component<Signature> {
                       () => cardOrField as typeof BaseDef,
                     ),
                     cardOrField,
-                  } as CardOrField & Partial<PossibleCardClass>;
+                  } as CardOrField & Partial<PossibleCardOrFieldClass>;
                 }
                 return value as BaseDeclaration;
               });

--- a/packages/host/app/components/operator-mode/code-mode.gts
+++ b/packages/host/app/components/operator-mode/code-mode.gts
@@ -43,6 +43,7 @@ import {
   ModuleSyntax,
   type PossibleCardOrFieldClass,
   type BaseDeclaration,
+  type ElementDeclaration,
 } from '@cardstack/runtime-common/module-syntax';
 
 import RecentFiles from '@cardstack/host/components/editor/recent-files';
@@ -413,23 +414,24 @@ export default class CodeMode extends Component<Signature> {
                 this.openFile.current.content,
               );
 
-              let values = moduleSyntax.elements();
-              elements = values.map((value) => {
-                let cardOrField = cardsOrFields.find(
-                  (c) => c.name === value.localName,
-                );
-                if (cardOrField !== undefined) {
-                  return {
-                    ...value,
-                    cardType: getCardType(
-                      this,
-                      () => cardOrField as typeof BaseDef,
-                    ),
-                    cardOrField,
-                  } as CardOrField & Partial<PossibleCardOrFieldClass>;
-                }
-                return value as BaseDeclaration;
-              });
+              elements = moduleSyntax.elements.map(
+                (value: ElementDeclaration) => {
+                  let cardOrField = cardsOrFields.find(
+                    (c) => c.name === value.localName,
+                  );
+                  if (cardOrField !== undefined) {
+                    return {
+                      ...value,
+                      cardType: getCardType(
+                        this,
+                        () => cardOrField as typeof BaseDef,
+                      ),
+                      cardOrField,
+                    } as CardOrField & Partial<PossibleCardOrFieldClass>;
+                  }
+                  return value as BaseDeclaration;
+                },
+              );
             }
             state.value = elements;
           }

--- a/packages/realm-server/tests/module-syntax-test.ts
+++ b/packages/realm-server/tests/module-syntax-test.ts
@@ -72,7 +72,7 @@ module('module-syntax', function () {
       `,
     );
 
-    let card = mod.possibleCards.find((c) => c.exportedAs === 'Person');
+    let card = mod.possibleCardsOrFields.find((c) => c.exportedAs === 'Person');
     let field = card!.possibleFields.get('age');
     assert.ok(field, 'new field was added to syntax');
     assert.deepEqual(
@@ -253,7 +253,7 @@ module('module-syntax', function () {
         }
       `,
     );
-    let card = mod.possibleCards.find((c) => c.exportedAs === 'Person');
+    let card = mod.possibleCardsOrFields.find((c) => c.exportedAs === 'Person');
     let field = card!.possibleFields.get('aliases');
     assert.ok(field, 'new field was added to syntax');
     assert.deepEqual(
@@ -309,7 +309,7 @@ module('module-syntax', function () {
         }
       `,
     );
-    let card = mod.possibleCards.find((c) => c.exportedAs === 'Person');
+    let card = mod.possibleCardsOrFields.find((c) => c.exportedAs === 'Person');
     let field = card!.possibleFields.get('pet');
     assert.ok(field, 'new field was added to syntax');
     assert.deepEqual(
@@ -355,7 +355,7 @@ module('module-syntax', function () {
         }
       `,
     );
-    let card = mod.possibleCards.find((c) => c.exportedAs === 'Person');
+    let card = mod.possibleCardsOrFields.find((c) => c.exportedAs === 'Person');
     let field = card!.possibleFields.get('friend');
     assert.ok(field, 'new field was added to syntax');
     assert.deepEqual(
@@ -466,7 +466,7 @@ module('module-syntax', function () {
       `,
     );
 
-    let card = mod.possibleCards.find((c) => c.exportedAs === 'Person');
+    let card = mod.possibleCardsOrFields.find((c) => c.exportedAs === 'Person');
     let field = card!.possibleFields.get('firstName');
     assert.strictEqual(field, undefined, 'field does not exist in syntax');
   });
@@ -518,7 +518,7 @@ module('module-syntax', function () {
       `,
     );
 
-    let card = mod.possibleCards.find((c) => c.exportedAs === 'Friend');
+    let card = mod.possibleCardsOrFields.find((c) => c.exportedAs === 'Friend');
     let field = card!.possibleFields.get('friend');
     assert.strictEqual(field, undefined, 'field does not exist in syntax');
   });

--- a/packages/runtime-common/module-syntax.ts
+++ b/packages/runtime-common/module-syntax.ts
@@ -28,11 +28,10 @@ import type { types as t } from '@babel/core';
 import type { NodePath } from '@babel/traverse';
 import type { FieldType } from 'https://cardstack.com/base/card-api';
 
-export type { PossibleCardOrFieldClass, BaseDeclaration };
+export type { PossibleCardOrFieldClass, ElementDeclaration, BaseDeclaration };
 
 export class ModuleSyntax {
   declare possibleCardsOrFields: PossibleCardOrFieldClass[];
-
   declare elements: ElementDeclaration[];
   private declare ast: t.File;
 

--- a/packages/runtime-common/module-syntax.ts
+++ b/packages/runtime-common/module-syntax.ts
@@ -3,8 +3,9 @@ import * as Babel from '@babel/core';
 import {
   schemaAnalysisPlugin,
   Options,
-  PossibleCardClass,
-  Export,
+  type PossibleCardClass,
+  type ModuleDeclaration,
+  type BaseDeclaration,
 } from './schema-analysis-plugin';
 import {
   removeFieldPlugin,
@@ -27,12 +28,11 @@ import type { types as t } from '@babel/core';
 import type { NodePath } from '@babel/traverse';
 import type { FieldType } from 'https://cardstack.com/base/card-api';
 
-export type { PossibleCardClass, Export };
-import { unionWith } from 'lodash';
+export type { PossibleCardClass, BaseDeclaration };
 
 export class ModuleSyntax {
   declare possibleCards: PossibleCardClass[];
-  declare exports: Export[];
+  declare moduleDeclarations: ModuleDeclaration[];
   private declare ast: t.File;
 
   constructor(src: string) {
@@ -42,7 +42,7 @@ export class ModuleSyntax {
   private analyze(src: string) {
     let moduleAnalysis: Options = {
       possibleCards: [],
-      exports: [],
+      moduleDeclarations: [],
     };
     let preprocessedSrc = preprocessTemplateTags(src);
 
@@ -58,20 +58,11 @@ export class ModuleSyntax {
     });
     this.ast = r!.ast!;
     this.possibleCards = moduleAnalysis.possibleCards;
-    this.exports = moduleAnalysis.exports;
+    this.moduleDeclarations = moduleAnalysis.moduleDeclarations;
   }
 
-  elements(): (PossibleCardClass | Export)[] {
-    const compareByLocalName = (
-      a: PossibleCardClass | Export,
-      b: PossibleCardClass | Export,
-    ) => {
-      const aLocalName = 'localName' in a ? a.localName : undefined;
-      const bLocalName = 'localName' in b ? b.localName : undefined;
-
-      return aLocalName === bLocalName;
-    };
-    return unionWith(this.possibleCards, this.exports, compareByLocalName);
+  elements(): ModuleDeclaration[] {
+    return this.moduleDeclarations;
   }
 
   code(): string {

--- a/packages/runtime-common/remove-field-plugin.ts
+++ b/packages/runtime-common/remove-field-plugin.ts
@@ -1,5 +1,5 @@
 import type {
-  PossibleCardClass,
+  PossibleCardOrFieldClass,
   PossibleField,
 } from './schema-analysis-plugin';
 import { types as t } from '@babel/core';
@@ -11,7 +11,7 @@ interface State {
 }
 
 export interface Options {
-  card: PossibleCardClass;
+  card: PossibleCardOrFieldClass;
   field: PossibleField;
 }
 export function removeFieldPlugin() {

--- a/packages/runtime-common/schema-analysis-plugin.ts
+++ b/packages/runtime-common/schema-analysis-plugin.ts
@@ -48,22 +48,24 @@ export interface Options {
 export function schemaAnalysisPlugin(_babel: typeof Babel) {
   return {
     visitor: {
-      'FunctionDeclaration|ClassDeclaration': {
+      Declaration: {
         enter(
           path: NodePath<t.ClassDeclaration> | NodePath<t.FunctionDeclaration>,
           state: State,
         ) {
-          let localName = path.node.id ? path.node.id.name : undefined;
-          if (t.isExportDeclaration(path.parentPath)) {
-            state.opts.moduleDeclarations.push({
-              localName,
-              exportedAs: getExportedAs(path, localName),
-              path,
-            });
-          } else if (t.isClassDeclaration(path)) {
-            let maybeCard = lookForCard(path, state);
-            if (maybeCard) {
-              state.opts.moduleDeclarations.push(maybeCard);
+          if (t.isClassDeclaration(path) || t.isFunctionDeclaration(path)) {
+            let localName = path.node.id ? path.node.id.name : undefined;
+            if (t.isExportDeclaration(path.parentPath)) {
+              state.opts.moduleDeclarations.push({
+                localName,
+                exportedAs: getExportedAs(path, localName),
+                path,
+              });
+            } else if (t.isClassDeclaration(path)) {
+              let maybeCard = lookForCard(path, state);
+              if (maybeCard) {
+                state.opts.moduleDeclarations.push(maybeCard);
+              }
             }
           }
         },


### PR DESCRIPTION
**Changes of work cs-6082 so that list of elements on LHS will have order conforming to how it appears in the source**
 I was making things unnecessarily complicated by consolidating 2 variables in module syntax. This consolidates everything to 1. 

ie `ModuleDeclaration` can b 
- exported function or class
- exported or unexported card or field (PossibleCardClass)

**Mni refactor of schema analysis pugin**
- stop using `insideCard`. From my understanding, `insideCard` is used as a way to traverse decorator fields after a class which is a card is captured. But the issue is that they were being used in separate visitors. This means when I wanted to add an additional visitor of my own to capture stuff that go "in this file" panel, I would risk depdending on `insideCard` state. The solution I have is to just perform a nested traversal of the decorators within the visitor that captures the class which is a card.

~Note: Within the schema-analysis tool. There is some mutating of state going on particularly when traversing the field decorators within a card. In doing so populating possibleFields of a card. I didn't want to touch this so much to maintain backward compatibility of whatever is consuming module syntax. I made a ticket for this https://linear.app/cardstack/issue/CS-6096/refactor-schema-analysis-plugin~