### PR TITLE
ci: Add linting for yaml

### DIFF
--- a/.github/.yamllint.yml
+++ b/.github/.yamllint.yml
@@ -4,7 +4,7 @@ rules:
   line-length: disable
   document-start: disable
   quoted-strings:
-    quote-type: double
+    quote-type: single
     required: false
   truthy:
     check-keys: false

--- a/.github/.yamllint.yml
+++ b/.github/.yamllint.yml
@@ -3,5 +3,7 @@ extends: default
 rules:
   line-length: disable
   document-start: disable
+  quoted-strings:
+    quote-type: double
   truthy:
     check-keys: false

--- a/.github/.yamllint.yml
+++ b/.github/.yamllint.yml
@@ -5,5 +5,6 @@ rules:
   document-start: disable
   quoted-strings:
     quote-type: double
+    required: false
   truthy:
     check-keys: false

--- a/.github/.yamllint.yml
+++ b/.github/.yamllint.yml
@@ -3,3 +3,5 @@ extends: default
 rules:
   line-length: disable
   document-start: disable
+  truthy:
+    check-keys: false

--- a/.github/.yamllint.yml
+++ b/.github/.yamllint.yml
@@ -4,7 +4,7 @@ rules:
   line-length: disable
   document-start: disable
   quoted-strings:
-    quote-type: single
+    quote-type: double
     required: false
   truthy:
     check-keys: false

--- a/.github/.yamllint.yml
+++ b/.github/.yamllint.yml
@@ -1,8 +1,5 @@
 extends: default
 
-ignore:
-  - pnpm-lock.yaml
-
 rules:
   line-length: disable
   document-start: disable

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -13,6 +13,6 @@ jobs:
       - uses: actions/checkout@v2.4.0
       - uses: ibiqlik/action-yamllint@v3.1
         with:
-          config_file: ".github/yamllint.yml"
+          config_file: ".github/.yamllint.yml"
           file_or_dir: ".github"
           strict: true

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -1,0 +1,16 @@
+name: YAML Lint
+
+on:
+  pull_request:
+    paths:
+      - "**.yml"
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.4.0
+      - uses: ibiqlik/action-yamllint@v3.1
+        with:
+          strict: true

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -13,4 +13,6 @@ jobs:
       - uses: actions/checkout@v2.4.0
       - uses: ibiqlik/action-yamllint@v3.1
         with:
+          config_file: ".github/yamllint.yml"
+          file_or_dir: ".github"
           strict: true

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,1 @@
+extends: default

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,5 +1,8 @@
 extends: default
 
+ignore:
+  - pnpm-lock.yaml
+
 rules:
   line-length: disable
   document-start: disable

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,1 +1,5 @@
 extends: default
+
+rules:
+  line-length: disable
+  document-start: disable


### PR DESCRIPTION
Add basic linting for YAML. Currently the only noticeable enforced rule is "double quotes only". We can add more rules as we discover more conflicts.

Sidenote:
I am using [coc-yaml](https://github.com/neoclide/coc-yaml) in my vim for the autoformatting. It is a fork of [vscode-yaml](https://github.com/redhat-developer/vscode-yaml).