### PR TITLE
Fix display names in inheritance chain

### DIFF
--- a/packages/base/date.gts
+++ b/packages/base/date.gts
@@ -27,6 +27,7 @@ export default class DateField extends FieldDef {
   static [serialize](date: Date) {
     return format(date, dateFormat);
   }
+  static displayName = 'Date';
 
   static async [deserialize]<T extends BaseDefConstructor>(
     this: T,

--- a/packages/drafts-realm/invoice-packet.gts
+++ b/packages/drafts-realm/invoice-packet.gts
@@ -19,6 +19,7 @@ import { TokenField, CurrencyField } from './asset';
 import GlimmerComponent from '@glimmer/component';
 
 class Details extends FieldDef {
+  static displayName = 'Details';
   @field invoiceNo = contains(StringCard);
   @field invoiceDate = contains(DateCard);
   @field dueDate = contains(DateCard);
@@ -120,6 +121,7 @@ class DetailsFieldsContainer extends GlimmerComponent<GenericContainerSignature>
 }
 
 class LineItem extends FieldDef {
+  static displayName = 'LineItem';
   @field name = contains(StringCard);
   @field quantity = contains(NumberCard);
   @field amount = contains(NumberCard);
@@ -198,6 +200,7 @@ class LineItem extends FieldDef {
 }
 
 class Note extends FieldDef {
+  static displayName = 'Note';
   @field text = contains(TextAreaCard);
   @field authorName = contains(StringCard); /* computed */
   @field authorImage = contains(StringCard); /* computed */

--- a/packages/drafts-realm/payment-method.gts
+++ b/packages/drafts-realm/payment-method.gts
@@ -45,7 +45,7 @@ class CryptoPayment extends FieldDef {
 }
 
 class WireTransfer extends FieldDef {
-  static displayName = 'WireTransfer';
+  static displayName = 'Payment Method';
   @field currency = linksTo(Currency); // dropdown
   @field iban = contains(StringCard); // IBAN format
   @field bic = contains(StringCard); // BIC format
@@ -89,6 +89,7 @@ class EditPaymentMethod extends Component<typeof PaymentMethod> {
   </template>
 }
 export class PaymentMethod extends FieldDef {
+  static displayName = 'PaymentMethod';
   @field type = contains(StringCard); // dropdown
   @field cryptoPayment = contains(CryptoPayment);
   @field wireTransfer = contains(WireTransfer);

--- a/packages/drafts-realm/payment-method.gts
+++ b/packages/drafts-realm/payment-method.gts
@@ -45,6 +45,7 @@ class CryptoPayment extends FieldDef {
 }
 
 class WireTransfer extends FieldDef {
+  static displayName = 'WireTransfer';
   @field currency = linksTo(Currency); // dropdown
   @field iban = contains(StringCard); // IBAN format
   @field bic = contains(StringCard); // BIC format

--- a/packages/drafts-realm/vendor.gts
+++ b/packages/drafts-realm/vendor.gts
@@ -98,6 +98,7 @@ class ContactMethod extends FieldDef {
 }
 
 export class Vendor extends CardDef {
+  static displayName = 'Vendor';
   @field vendor = contains(VendorDetails); // required
   @field contact = contains(Contact); // required
   @field contactMethod = containsMany(ContactMethod);

--- a/packages/drafts-realm/vendor.gts
+++ b/packages/drafts-realm/vendor.gts
@@ -57,6 +57,7 @@ class VendorDetails extends FieldDef {
 }
 
 class Contact extends FieldDef {
+  static displayName = 'Contact';
   @field fullName = contains(StringCard);
   @field preferredName = contains(StringCard);
   @field jobTitle = contains(StringCard);
@@ -86,6 +87,7 @@ class Contact extends FieldDef {
 }
 
 class ContactMethod extends FieldDef {
+  static displayName = 'ContactMethod';
   @field platform = contains(StringCard); // Dropdown (Telegram, Discord, Facebook, LinkedIn, Twitter)
   @field username = contains(StringCard);
   static embedded = class Embedded extends Component<typeof this> {

--- a/packages/host/app/components/operator-mode/card-schema-editor.gts
+++ b/packages/host/app/components/operator-mode/card-schema-editor.gts
@@ -6,13 +6,15 @@ import Component from '@glimmer/component';
 
 import { gt } from '@cardstack/boxel-ui/helpers/truth-helpers';
 
-import { internalKeyFor, getPlural } from '@cardstack/runtime-common';
-import { isCodeRef, type CodeRef } from '@cardstack/runtime-common/code-ref';
+import { getPlural } from '@cardstack/runtime-common';
 
 import type { ModuleSyntax } from '@cardstack/runtime-common/module-syntax';
 
 import RealmInfoProvider from '@cardstack/host/components/operator-mode/realm-info-provider';
-import { type Type } from '@cardstack/host/resources/card-type';
+import {
+  type Type,
+  type CodeRefType,
+} from '@cardstack/host/resources/card-type';
 
 import type { Ready } from '@cardstack/host/resources/file';
 import type CardService from '@cardstack/host/services/card-service';
@@ -253,11 +255,8 @@ export default class CardSchemaEditor extends Component<Signature> {
     return calculateTotalOwnFields(this.args.card, this.args.cardType);
   }
 
-  fieldCardDisplayName(card: Type | CodeRef): string {
-    if (isCodeRef(card)) {
-      return internalKeyFor(card, undefined);
-    }
-    return card.displayName;
+  fieldCardDisplayName(fieldCard: Type | CodeRefType): string {
+    return fieldCard.displayName;
   }
 
   fieldModuleURL(field: Type['fields'][0]) {

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -113,7 +113,6 @@ export default class DetailPanel extends Component<Signature> {
     if (!this.args.elements) {
       return [];
     }
-    console.log(this.args.elements);
     return this.args.elements.map((el) => {
       const isSelected = this.args.selectedElement === el;
       return selectorItemFunc(

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -113,6 +113,7 @@ export default class DetailPanel extends Component<Signature> {
     if (!this.args.elements) {
       return [];
     }
+    console.log(this.args.elements);
     return this.args.elements.map((el) => {
       const isSelected = this.args.selectedElement === el;
       return selectorItemFunc(

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -99,6 +99,37 @@ const employeeCardSource = `
   }
 `;
 
+const friendCardSource = `
+  import { contains, linksTo, field, CardDef, Component } from "https://cardstack.com/base/card-api";
+  import StringCard from "https://cardstack.com/base/string";
+
+  export class Friend extends CardDef {
+    static displayName = 'Friend';
+    @field name = contains(StringCard);
+    @field friend = linksTo(() => Friend);
+    @field title = contains(StringCard, {
+      computeVia: function (this: Person) {
+        return name;
+      },
+    });
+    static isolated = class Isolated extends Component<typeof this> {
+      <template>
+        <div data-test-person>
+          <p>First name: <@fields.firstName /></p>
+          <p>Last name: <@fields.lastName /></p>
+          <p>Title: <@fields.title /></p>
+        </div>
+        <style>
+          div {
+            color: green;
+            content: '';
+          }
+        </style>
+      </template>
+    };
+  }
+`;
+
 module('Acceptance | code mode tests', function (hooks) {
   let realm: Realm;
   let adapter: TestRealmAdapter;
@@ -121,6 +152,7 @@ module('Acceptance | code mode tests', function (hooks) {
       'index.gts': indexCardSource,
       'pet-person.gts': personCardSource,
       'person.gts': personCardSource,
+      'friend.gts': friendCardSource,
       'employee.gts': employeeCardSource,
       'person-entry.json': {
         data: {
@@ -1052,6 +1084,31 @@ module('Acceptance | code mode tests', function (hooks) {
         `[data-test-card-schema="Card"] [data-test-field-name="title"] [data-test-realm-icon-url]`,
       )
       .hasAttribute('data-test-realm-icon-url', realm2IconUrl);
+  });
+
+  test('shows displayName of CardResource when field contains itself', async function (assert) {
+    let operatorModeStateParam = stringify({
+      stacks: [],
+      submode: 'code',
+      codePath: `${testRealmURL}friend.gts`,
+    })!;
+
+    await visit(
+      `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+        operatorModeStateParam,
+      )}`,
+    );
+
+    await waitFor('[data-test-card-schema]');
+
+    assert
+      .dom('[data-test-card-schema-navigational-button]')
+      .containsText('Friend');
+    assert
+      .dom(
+        `[data-test-card-schema="Friend"] [data-test-field-name="name"] [data-test-card-display-name="String"]`,
+      )
+      .exists();
   });
 
   test('card type and fields are clickable and navigate to the correct file', async function (assert) {


### PR DESCRIPTION
Ticket: CS-6086

**Issues and Solutions:**
- The field referred to itself would display the URL of the module instead of the `displayName`. To address this issue, I introduced `CodeRefType`, which is `CodeRef` with the `displayName` included.

Before:
![Screenshot 2023-10-05 at 19 35 14](https://github.com/cardstack/boxel/assets/12637010/f66cb95d-f2e5-4b56-a5b5-46d9968af3de)
After:

![Screenshot 2023-10-05 at 19 37 44](https://github.com/cardstack/boxel/assets/12637010/54ecfde2-51d9-476e-a907-7dd9933f88e8)


- Some `FieldDef` didn't define `displayName` so it would display "Field". I simply defined the `displayName` to fix it.

Before:
![Screenshot 2023-10-05 at 19 35 21](https://github.com/cardstack/boxel/assets/12637010/e62e0c0e-017b-4414-ac1d-61f353b08983)

After:
![Screenshot 2023-10-05 at 19 38 25](https://github.com/cardstack/boxel/assets/12637010/82826717-9eb4-4988-8454-492d97746571)

