### PR TITLE
Add dropdown context menu to schema editor fields

### DIFF
--- a/packages/boxel-ui/addon/components/dropdown-button/index.gts
+++ b/packages/boxel-ui/addon/components/dropdown-button/index.gts
@@ -12,6 +12,7 @@ interface Signature {
     icon: string;
     label: string;
     class?: string;
+    contentClass?: string;
     noHoverStyle?: boolean;
     size?: number;
     iconSize?: number;
@@ -27,7 +28,7 @@ interface Signature {
 }
 
 const DropdownButton: TemplateOnlyComponent<Signature> = <template>
-  <BoxelDropdown>
+  <BoxelDropdown @contentClass={{@contentClass}}>
     <:trigger as |bindings|>
       <button
         {{bindings}}

--- a/packages/boxel-ui/addon/components/dropdown-button/index.gts
+++ b/packages/boxel-ui/addon/components/dropdown-button/index.gts
@@ -13,7 +13,6 @@ interface Signature {
     label: string;
     class?: string;
     contentClass?: string;
-    noHoverStyle?: boolean;
     size?: number;
     iconSize?: number;
   };

--- a/packages/boxel-ui/addon/components/dropdown-button/index.gts
+++ b/packages/boxel-ui/addon/components/dropdown-button/index.gts
@@ -1,0 +1,92 @@
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
+import { type WithBoundArgs } from '@glint/template';
+import { hash } from '@ember/helper';
+import BoxelDropdown from '../dropdown';
+import BoxelMenu from '../menu';
+import cn from '@cardstack/boxel-ui/helpers/cn';
+import { svgJar } from '@cardstack/boxel-ui/helpers/svg-jar';
+
+interface Signature {
+  Element: HTMLButtonElement;
+  Args: {
+    icon: string;
+    label: string;
+    class?: string;
+    noHoverStyle?: boolean;
+    size?: number;
+    iconSize?: number;
+  };
+  Blocks: {
+    default: [
+      {
+        Menu: WithBoundArgs<typeof BoxelMenu, 'closeMenu'>;
+        close: () => void;
+      },
+    ];
+  };
+}
+
+const DropdownButton: TemplateOnlyComponent<Signature> = <template>
+  <BoxelDropdown>
+    <:trigger as |bindings|>
+      <button
+        {{bindings}}
+        class={{cn
+          'boxel-dropdown-button'
+          'boxel-dropdown-button__reset'
+          'boxel-dropdown-button__trigger'
+          @class
+        }}
+        aria-label={{@label}}
+        data-test-boxel-dropdown-button
+        ...attributes
+      >
+        {{#if @icon}}
+          {{svgJar
+            @icon
+            width=(if @iconSize @iconSize 16)
+            height=(if @iconSize @iconSize 16)
+          }}
+        {{/if}}
+      </button>
+    </:trigger>
+    <:content as |dd|>
+      {{yield
+        (hash Menu=(component BoxelMenu closeMenu=dd.close) close=dd.close)
+      }}
+    </:content>
+  </BoxelDropdown>
+  <style>
+    @layer {
+      /* Remove all default user-agent styles while keeping specificity low */
+      :where(.boxel-dropdown-button__reset) {
+        all: unset;
+      }
+
+      .boxel-dropdown-button__trigger {
+        --dropdown-button-size: 30px;
+
+        width: var(--dropdown-button-size);
+        height: var(--dropdown-button-size);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .boxel-dropdown-button__trigger:hover:not(
+          .boxel-dropdown-button--no-hover
+        ) {
+        --icon-color: var(--boxel-highlight);
+        cursor: pointer;
+      }
+
+      .boxel-dropdown-button__trigger > svg {
+        display: block;
+        height: 100%;
+        margin: auto;
+      }
+    }
+  </style>
+</template>;
+
+export default DropdownButton;

--- a/packages/boxel-ui/addon/components/dropdown-button/usage.gts
+++ b/packages/boxel-ui/addon/components/dropdown-button/usage.gts
@@ -1,0 +1,82 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
+import BoxelDropdownButton from './index';
+import { fn, array } from '@ember/helper';
+import menuItem from '@cardstack/boxel-ui/helpers/menu-item';
+import menuDivider from '@cardstack/boxel-ui/helpers/menu-divider';
+
+export default class DropdownButtonUsageComponent extends Component {
+  @tracked label = 'Label';
+  @tracked icon: string = 'three-dots-horizontal';
+  @tracked size = 30;
+  @tracked iconSize = 16;
+
+  @action log(message: string): void {
+    // eslint-disable-next-line no-console
+    console.log(message);
+  }
+
+  <template>
+    <FreestyleUsage @name='DropdownButton'>
+      <:example>
+        <BoxelDropdownButton
+          @label={{this.label}}
+          @icon={{this.icon}}
+          @size={{this.size}}
+          @iconSize={{this.iconSize}}
+          as |ddb|
+        >
+          <ddb.Menu
+            @items={{array
+              (menuItem 'Duplicate' (fn this.log 'Duplicate menu item clicked'))
+              (menuItem 'Share' (fn this.log 'Share menu item clicked'))
+              (menuDivider)
+              (menuItem
+                'Remove' (fn this.log 'Remove menu item clicked') dangerous=true
+              )
+            }}
+          />
+        </BoxelDropdownButton>
+      </:example>
+      <:api as |Args|>
+        <Args.String
+          @name='button'
+          @description='the name to use as the aria-label and added on the trigger element as a css class. If @icon is not specified, this value is also used to specify an svg to use.'
+          @value={{this.label}}
+          @required={{true}}
+          @onInput={{fn (mut this.label)}}
+        />
+        <Args.String
+          @name='icon'
+          @description='the name of the svg to show'
+          @value={{this.icon}}
+          @required={{true}}
+          @onInput={{fn (mut this.icon)}}
+        />
+        <Args.Number
+          @name='size'
+          @description='the size of the button'
+          @value={{this.size}}
+          @defaultValue={{30}}
+          @min={{20}}
+          @max={{80}}
+          @onInput={{fn (mut this.size)}}
+        />
+        <Args.Number
+          @name='iconSize'
+          @description='the size of the icon'
+          @value={{this.iconSize}}
+          @defaultValue={{16}}
+          @min={{8}}
+          @max={{36}}
+          @onInput={{fn (mut this.iconSize)}}
+        />
+        <Args.Yield
+          @description="The provided block is rendered when the button is triggered. Yields a 'Menu' component (instance of Boxel::Menu that is preconfigured with @closeMenu defined) and the 'dropdown' object documented in Boxel::Dropdown"
+        />
+      </:api>
+    </FreestyleUsage>
+  </template>
+}

--- a/packages/boxel-ui/addon/components/dropdown-button/usage.gts
+++ b/packages/boxel-ui/addon/components/dropdown-button/usage.gts
@@ -9,7 +9,7 @@ import menuDivider from '@cardstack/boxel-ui/helpers/menu-divider';
 
 export default class DropdownButtonUsageComponent extends Component {
   @tracked label = 'Label';
-  @tracked icon: string = 'three-dots-horizontal';
+  @tracked icon = 'three-dots-horizontal';
   @tracked size = 30;
   @tracked iconSize = 16;
 

--- a/packages/boxel-ui/addon/components/dropdown/index.gts
+++ b/packages/boxel-ui/addon/components/dropdown/index.gts
@@ -108,12 +108,26 @@ class BoxelDropdown extends Component<Signature> {
           box-shadow: 0 5px 15px 0 rgb(0 0 0 / 25%);
         }
 
-        .boxel-dropdown__content.ember-basic-dropdown-content--below.ember-basic-dropdown--transitioning-in {
-          animation: drop-fade-below var(0.2s ease);
+        @media (prefers-reduced-motion: no-preference) {
+          .boxel-dropdown__content.ember-basic-dropdown-content--below.ember-basic-dropdown--transitioned-in {
+            animation: drop-fade-below var(--boxel-transition);
+          }
+
+          .boxel-dropdown__content.ember-basic-dropdown-content--below.ember-basic-dropdown--transitioning-out {
+            animation: drop-fade-below var(--boxel-transition) reverse;
+          }
         }
 
-        .boxel-dropdown__content.ember-basic-dropdown-content--below.ember-basic-dropdown--transitioning-out {
-          animation: drop-fade-below var(0.2s ease) reverse;
+        @keyframes drop-fade-below {
+          0% {
+            opacity: 0;
+            transform: translateY(-20px);
+          }
+
+          100% {
+            opacity: 1;
+            transform: translateY(0);
+          }
         }
       }
     </style>

--- a/packages/boxel-ui/addon/components/menu/index.gts
+++ b/packages/boxel-ui/addon/components/menu/index.gts
@@ -161,11 +161,11 @@ export default class Menu extends Component<Signature> {
           color: var(--boxel-menu-selected-font-color);
         }
 
-        .boxel-menu__item--selected:hover {
+        .boxel-menu__item--selected:not(.boxel-menu__item--disabled):hover {
           color: var(--boxel-menu-selected-hover-font-color);
         }
 
-        .boxel-menu__item:hover {
+        .boxel-menu__item:not(.boxel-menu__item--disabled):hover {
           background-color: var(--boxel-menu-current-color);
           cursor: pointer;
         }

--- a/packages/boxel-ui/addon/index.ts
+++ b/packages/boxel-ui/addon/index.ts
@@ -8,6 +8,7 @@ import BoxelHeader from './components/header';
 import BoxelMessage from './components/message';
 import Button from './components/button';
 import CardContainer from './components/card-container';
+import DropdownButton from './components/dropdown-button';
 import FieldContainer from './components/field-container';
 import GridContainer from './components/grid-container';
 import Header from './components/header';
@@ -34,6 +35,7 @@ export {
   BoxelInputValidationState,
   Button,
   CardContainer,
+  DropdownButton,
   FieldContainer,
   GridContainer,
   Header,

--- a/packages/boxel-ui/tests/dummy/app/controllers/index.js
+++ b/packages/boxel-ui/tests/dummy/app/controllers/index.js
@@ -2,6 +2,7 @@ import FreestyleController from 'ember-freestyle/controllers/freestyle';
 import AccordionUsage from '@cardstack/boxel-ui/components/accordion/usage';
 import AddButtonUsage from '@cardstack/boxel-ui/components/add-button/usage';
 import CardContainerUsage from '@cardstack/boxel-ui/components/card-container/usage';
+import DropdownButtonUsage from '@cardstack/boxel-ui/components/dropdown-button/usage';
 import FieldContainerUsage from '@cardstack/boxel-ui/components/field-container/usage';
 import GridContainerUsage from '@cardstack/boxel-ui/components/grid-container/usage';
 import HeaderUsage from '@cardstack/boxel-ui/components/header/usage';
@@ -25,6 +26,8 @@ export default class IndexController extends FreestyleController {
       ['Boxel::Accordion', AccordionUsage],
       ['Boxel::AddButton', AddButtonUsage],
       ['Boxel::CardContainer', CardContainerUsage],
+      ['Boxel::Dropdown', DropdownUsage],
+      ['Boxel::DropdownButton', DropdownButtonUsage],
       ['Boxel::FieldContainer', FieldContainerUsage],
       ['Boxel::GridContainer', GridContainerUsage],
       ['Boxel::Header', HeaderUsage],
@@ -37,7 +40,6 @@ export default class IndexController extends FreestyleController {
       ['Boxel::Modal', ModalUsage],
       ['Boxel::Message', MessageUsage],
       ['Boxel::Menu', MenuUsage],
-      ['Boxel::Dropdown', DropdownUsage],
       ['Boxel::Tooltip', TooltipUsage],
       ['Boxel::ResizablePanel', ResizablePanelGroupUsage],
     ].map(([name, c]) => {

--- a/packages/host/app/components/operator-mode/card-schema-editor.gts
+++ b/packages/host/app/components/operator-mode/card-schema-editor.gts
@@ -1,9 +1,12 @@
-import { fn } from '@ember/helper';
+import { fn, array } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
+import { DropdownButton } from '@cardstack/boxel-ui';
+import menuItem from '@cardstack/boxel-ui/helpers/menu-item';
+import menuDivider from '@cardstack/boxel-ui/helpers/menu-divider';
 import { gt } from '@cardstack/boxel-ui/helpers/truth-helpers';
 
 import { internalKeyFor, getPlural } from '@cardstack/runtime-common';
@@ -53,12 +56,13 @@ export default class CardSchemaEditor extends Component<Signature> {
       }
 
       .pill {
-        border: 1px solid var(--boxel-400);
-        padding: var(--boxel-sp-xxxs) var(--boxel-sp-xs);
-        border-radius: 8px;
-        background-color: white;
-        font-weight: 600;
         display: inline-flex;
+        padding: var(--boxel-sp-xxxs) var(--boxel-sp-xs);
+        background-color: var(--boxel-light);
+        border: 1px solid var(--boxel-400);
+        border-radius: var(--boxel-border-radius-sm);
+        font: 700 var(--boxel-font-sm);
+        letter-spacing: var(--boxel-lsp-xs);
       }
 
       .pill:hover {
@@ -69,48 +73,49 @@ export default class CardSchemaEditor extends Component<Signature> {
         display: flex;
       }
 
-      .pill > div > span {
-        margin: auto;
-      }
-
       .realm-icon {
         margin-right: var(--boxel-sp-xxxs);
       }
 
       .card-field {
-        background-color: white;
-      }
-
-      .card-field {
-        margin-bottom: var(--boxel-sp-xs);
-        padding: var(--boxel-sp);
-        border-radius: var(--boxel-border-radius);
         display: flex;
+        align-items: center;
+        justify-content: space-between;
+        flex-wrap: wrap;
+        gap: var(--boxel-sp-xxs);
+        margin-bottom: var(--boxel-sp-xs);
+        padding: var(--boxel-sp-xs) 0 var(--boxel-sp-xs) var(--boxel-sp-xs);
+        border-radius: var(--boxel-border-radius);
+        background-color: var(--boxel-light);
       }
 
       .card-fields {
         margin-top: var(--boxel-sp);
       }
 
+      .context-menu-trigger {
+        rotate: 90deg;
+      }
+
       .left {
         display: flex;
-        margin-top: auto;
-        margin-bottom: auto;
         flex-direction: column;
       }
 
       .right {
-        margin-left: auto;
-        margin-top: auto;
-        margin-bottom: auto;
+        display: flex;
+        align-items: center;
       }
 
       .field-name {
-        font-size: var(--boxel-font-size);
+        font: 500 var(--boxel-font-sm);
+        letter-spacing: var(--boxel-lsp-xs);
       }
 
       .field-type {
-        color: #949494;
+        color: var(--boxel-450);
+        font: 500 var(--boxel-font-xs);
+        letter-spacing: var(--boxel-lsp-xs);
       }
 
       .realm-icon > img {
@@ -227,6 +232,22 @@ export default class CardSchemaEditor extends Component<Signature> {
                       </span>
                     </div>
                   </button>
+                  <DropdownButton
+                    @icon='three-dots-horizontal'
+                    @label='field options'
+                    class='context-menu-trigger'
+                    as |dd|
+                  >
+                    <dd.Menu
+                      @items={{array
+                        (menuItem 'Edit Field Name' (fn this.noop))
+                        (menuItem 'Choose Field Type' (fn this.noop))
+                        (menuItem 'Allow Multiple Fields' (fn this.noop))
+                        (menuDivider)
+                        (menuItem 'Remove Field' (fn this.noop) dangerous=true)
+                      }}
+                    />
+                  </DropdownButton>
                 {{/let}}
               </div>
             </div>
@@ -247,6 +268,11 @@ export default class CardSchemaEditor extends Component<Signature> {
   @action
   isOwnField(fieldName: string): boolean {
     return isOwnField(this.args.card, fieldName);
+  }
+
+  @action
+  noop() {
+    return;
   }
 
   get totalOwnFields() {

--- a/packages/host/app/components/operator-mode/card-schema-editor.gts
+++ b/packages/host/app/components/operator-mode/card-schema-editor.gts
@@ -283,14 +283,12 @@ export default class CardSchemaEditor extends Component<Signature> {
                       class='context-menu-list'
                       @items={{array
                         (menuItem
-                          'Edit Field Name'
-                          (fn this.editFieldName)
-                          disabled=true
+                          'Edit Field Name' this.editFieldName disabled=true
                         )
                         (menuDivider)
                         (menuItem
                           'Remove Field'
-                          (fn this.removeField)
+                          this.removeField
                           dangerous=true
                           disabled=true
                         )

--- a/packages/host/app/components/operator-mode/card-schema-editor.gts
+++ b/packages/host/app/components/operator-mode/card-schema-editor.gts
@@ -8,6 +8,7 @@ import { DropdownButton } from '@cardstack/boxel-ui';
 import menuItem from '@cardstack/boxel-ui/helpers/menu-item';
 import menuDivider from '@cardstack/boxel-ui/helpers/menu-divider';
 import { gt } from '@cardstack/boxel-ui/helpers/truth-helpers';
+import { svgJar } from '@cardstack/boxel-ui/helpers/svg-jar';
 
 import { internalKeyFor, getPlural } from '@cardstack/runtime-common';
 import { isCodeRef, type CodeRef } from '@cardstack/runtime-common/code-ref';
@@ -93,8 +94,33 @@ export default class CardSchemaEditor extends Component<Signature> {
         margin-top: var(--boxel-sp);
       }
 
+      :global(.context-menu) {
+        width: 13.5rem;
+      }
+
       .context-menu-trigger {
         rotate: 90deg;
+      }
+
+      .context-menu-list {
+        --boxel-menu-item-content-padding: var(--boxel-sp-xs) var(--boxel-sp-sm);
+        border-top-right-radius: 0;
+        border-top-left-radius: 0;
+      }
+
+      .warning-box {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--boxel-sp-xxxs);
+        padding: var(--boxel-sp-sm);
+        background-color: var(--boxel-warning-100);
+        border-top-right-radius: inherit;
+        border-top-left-radius: inherit;
+      }
+
+      .warning {
+        margin: 0;
       }
 
       .left {
@@ -235,16 +261,43 @@ export default class CardSchemaEditor extends Component<Signature> {
                   <DropdownButton
                     @icon='three-dots-horizontal'
                     @label='field options'
+                    @contentClass='context-menu'
                     class='context-menu-trigger'
                     as |dd|
                   >
+                    <div class='warning-box'>
+                      <p class='warning'>
+                        These actions will break compatibility with existing
+                        card instances.
+                      </p>
+                      <span class='warning-icon'>
+                        {{svgJar
+                          'warning'
+                          width='20'
+                          height='20'
+                          role='presentation'
+                        }}
+                      </span>
+                    </div>
                     <dd.Menu
+                      class='context-menu-list'
                       @items={{array
-                        (menuItem 'Edit Field Name' (fn this.noop))
-                        (menuItem 'Choose Field Type' (fn this.noop))
-                        (menuItem 'Allow Multiple Fields' (fn this.noop))
+                        (menuItem
+                          'Edit Field Name' (fn this.noop) disabled=true
+                        )
+                        (menuItem
+                          'Choose Field Type' (fn this.noop) disabled=true
+                        )
+                        (menuItem
+                          'Allow Multiple Fields' (fn this.noop) disabled=true
+                        )
                         (menuDivider)
-                        (menuItem 'Remove Field' (fn this.noop) dangerous=true)
+                        (menuItem
+                          'Remove Field'
+                          (fn this.noop)
+                          dangerous=true
+                          disabled=true
+                        )
                       }}
                     />
                   </DropdownButton>

--- a/packages/host/app/components/operator-mode/card-schema-editor.gts
+++ b/packages/host/app/components/operator-mode/card-schema-editor.gts
@@ -283,18 +283,14 @@ export default class CardSchemaEditor extends Component<Signature> {
                       class='context-menu-list'
                       @items={{array
                         (menuItem
-                          'Edit Field Name' (fn this.noop) disabled=true
-                        )
-                        (menuItem
-                          'Choose Field Type' (fn this.noop) disabled=true
-                        )
-                        (menuItem
-                          'Allow Multiple Fields' (fn this.noop) disabled=true
+                          'Edit Field Name'
+                          (fn this.editFieldName)
+                          disabled=true
                         )
                         (menuDivider)
                         (menuItem
                           'Remove Field'
-                          (fn this.noop)
+                          (fn this.removeField)
                           dangerous=true
                           disabled=true
                         )
@@ -324,7 +320,14 @@ export default class CardSchemaEditor extends Component<Signature> {
   }
 
   @action
-  noop() {
+  removeField() {
+    // TODO: implement
+    return;
+  }
+
+  @action
+  editFieldName() {
+    // TODO: implement
     return;
   }
 


### PR DESCRIPTION
- Updated Boxel UI components with `DropdownButton` component from old Boxel package
- Added the button on schema editor and added a context menu with disabled options (there are separate tickets for each)
- Looks like this when items are not disabled:

<img width="310" alt="contextmenu" src="https://github.com/cardstack/boxel/assets/16160806/1d01f710-c1ba-4231-bfb5-c75240f50604">