### PR TITLE
Live query refactor

### DIFF
--- a/packages/base/cards-grid.gts
+++ b/packages/base/cards-grid.gts
@@ -196,7 +196,7 @@ class Isolated extends Component<typeof CardsGrid> {
       async (ready: Promise<void> | undefined) => {
         if (this.args.context?.actions) {
           this.args.context.actions.doWithStableScroll(
-            this.args.model,
+            this.args.model as CardDef,
             async () => {
               await ready;
             },

--- a/packages/base/cards-grid.gts
+++ b/packages/base/cards-grid.gts
@@ -15,12 +15,10 @@ import { AddButton, Tooltip } from '@cardstack/boxel-ui';
 import {
   chooseCard,
   catalogEntryRef,
-  getCards,
+  getLiveCards,
   baseRealm,
   cardTypeDisplayName,
-  subscribeToRealm,
 } from '@cardstack/runtime-common';
-import { registerDestructor } from '@ember/destroyable';
 import { tracked } from '@glimmer/tracking';
 import { type CatalogEntry } from './catalog-entry';
 import StringField from './string';
@@ -58,7 +56,7 @@ class Isolated extends Component<typeof CardsGrid> {
             </div>
           </li>
         {{else}}
-          {{#if this.request.isLoading}}
+          {{#if this.liveQuery.isLoading}}
             Loading...
           {{else}}
             <p>No cards available</p>
@@ -159,62 +157,14 @@ class Isolated extends Component<typeof CardsGrid> {
   </template>
 
   @tracked
-  private declare request: {
+  private declare liveQuery: {
     instances: CardDef[];
     isLoading: boolean;
-    ready: Promise<void>;
   };
-  @tracked staleInstances: CardDef[] = [];
-  private subscription: { url: string; unsubscribe: () => void } | undefined;
 
   constructor(owner: unknown, args: any) {
     super(owner, args);
-    this.refresh();
-
-    let url = `${this.args.model[realmURL]}_message`;
-    this.subscription = {
-      url,
-      unsubscribe: subscribeToRealm(url, ({ type }) => {
-        // we are only interested in index events
-        if (type !== 'index') {
-          return;
-        }
-        // we show stale instances during a live refresh while we are
-        // waiting for the new instances to arrive--this eliminates the flash
-        // while we wait
-        this.staleInstances = [...(this.instances ?? [])];
-
-        if (this.args.context?.actions) {
-          this.args.context?.actions?.doWithStableScroll(
-            this.args.model as CardDef,
-            async () => {
-              this.refresh();
-              await this.request.ready;
-            },
-          );
-        } else {
-          this.refresh();
-        }
-      }),
-    };
-    registerDestructor(this, () => {
-      if (this.subscription) {
-        this.subscription.unsubscribe();
-      }
-    });
-  }
-
-  get instances() {
-    if (!this.request) {
-      return;
-    }
-    return this.request.isLoading
-      ? this.staleInstances
-      : this.request.instances;
-  }
-
-  private refresh() {
-    this.request = getCards(
+    this.liveQuery = getLiveCards(
       {
         filter: {
           not: {
@@ -243,7 +193,24 @@ class Isolated extends Component<typeof CardsGrid> {
         ],
       },
       this.args.model[realmURL] ? [this.args.model[realmURL].href] : undefined,
+      async (ready: Promise<void> | undefined) => {
+        if (this.args.context?.actions) {
+          this.args.context.actions.doWithStableScroll(
+            this.args.model,
+            async () => {
+              await ready;
+            },
+          );
+        }
+      },
     );
+  }
+
+  get instances() {
+    if (!this.liveQuery) {
+      return;
+    }
+    return this.liveQuery.instances;
   }
 
   @action

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -40,6 +40,7 @@ import CodeMode from '@cardstack/host/components/operator-mode/code-mode';
 import ENV from '@cardstack/host/config/environment';
 
 import {
+  getLiveSearchResults,
   getSearchResults,
   type Search,
 } from '@cardstack/host/resources/search';
@@ -137,6 +138,20 @@ export default class OperatorModeContainer extends Component<Signature> {
       this,
       () => query,
       realms ? () => realms : undefined,
+    );
+  }
+
+  @action
+  getLiveCards(
+    query: Query,
+    realms?: string[],
+    doWhileRefreshing?: (ready: Promise<void> | undefined) => Promise<void>,
+  ): Search {
+    return getLiveSearchResults(
+      this,
+      () => query,
+      realms ? () => realms : undefined,
+      doWhileRefreshing ? () => doWhileRefreshing : undefined,
     );
   }
 

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -74,7 +74,7 @@ export class Search extends Resource<Args> {
 
           this.search.perform(query);
           if (doWhileRefreshing) {
-            doWhileRefreshing(this.ready);
+            this.doWhileRefreshing.perform(doWhileRefreshing);
           }
         }),
       }));
@@ -94,6 +94,14 @@ export class Search extends Resource<Args> {
   get instancesByRealm() {
     return this.isLoading ? this.staleInstancesByRealm : this._instancesByRealm;
   }
+
+  private doWhileRefreshing = restartableTask(
+    async (
+      doWhileRefreshing: (ready: Promise<void> | undefined) => Promise<void>,
+    ) => {
+      await doWhileRefreshing(this.ready);
+    },
+  );
 
   private search = restartableTask(async (query: Query) => {
     this._instances = flatMap(

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -1,3 +1,5 @@
+import { registerDestructor } from '@ember/destroyable';
+
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
@@ -5,7 +7,7 @@ import { restartableTask } from 'ember-concurrency';
 import { Resource } from 'ember-resources';
 import flatMap from 'lodash/flatMap';
 
-import { baseRealm } from '@cardstack/runtime-common';
+import { baseRealm, subscribeToRealm } from '@cardstack/runtime-common';
 
 import type { Query } from '@cardstack/runtime-common/query';
 
@@ -21,6 +23,8 @@ interface Args {
   named: {
     query: Query;
     realms?: string[];
+    isLive?: true;
+    doWhileRefreshing?: (ready: Promise<void> | undefined) => Promise<void>;
   };
 }
 
@@ -29,20 +33,18 @@ interface Args {
 const { otherRealmURLs } = ENV;
 
 export class Search extends Resource<Args> {
-  @tracked instances: CardDef[] = [];
-  @tracked instancesByRealm: RealmCards[] = [];
-  @service declare cardService: CardService;
-  ready: Promise<void> | undefined;
+  @service private declare cardService: CardService;
+  @tracked private _instances: CardDef[] = [];
+  @tracked private _instancesByRealm: RealmCards[] = [];
+  @tracked private staleInstances: CardDef[] = [];
+  @tracked private staleInstancesByRealm: RealmCards[] = [];
+  @tracked private realmsToSearch: string[] = [];
+  private ready: Promise<void> | undefined;
+  private subscriptions: { url: string; unsubscribe: () => void }[] = [];
 
   modify(_positional: never[], named: Args['named']) {
-    let { query, realms } = named;
-    this.ready = this.search.perform(query, realms);
-  }
-
-  private search = restartableTask(async (query: Query, realms?: string[]) => {
-    // until we have realm index rollup, search all the realms as separate
-    // queries that we merge together
-    let realmsToSearch = realms ?? [
+    let { query, realms, isLive, doWhileRefreshing } = named;
+    this.realmsToSearch = realms ?? [
       ...new Set(
         realms ?? [
           this.cardService.defaultURL.href,
@@ -51,23 +53,66 @@ export class Search extends Resource<Args> {
         ],
       ),
     ];
-    this.instances = flatMap(
+    this.ready = this.search.perform(query);
+
+    if (isLive) {
+      // TODO this triggers a new search against all realms if any single realm
+      // updates. Make this more precise where we only search the updated realm
+      // instead of all realms.
+      this.subscriptions = this.realmsToSearch.map((realm) => ({
+        url: `${realm}_message`,
+        unsubscribe: subscribeToRealm(`${realm}_message`, ({ type }) => {
+          // we are only interested in index events
+          if (type !== 'index') {
+            return;
+          }
+          // we show stale instances during a live refresh while we are
+          // waiting for the new instances to arrive--this eliminates the flash
+          // while we wait
+          this.staleInstances = [...(this.instances ?? [])];
+          this.staleInstancesByRealm = [...(this._instancesByRealm ?? [])];
+
+          this.search.perform(query);
+          if (doWhileRefreshing) {
+            doWhileRefreshing(this.ready);
+          }
+        }),
+      }));
+
+      registerDestructor(this, () => {
+        for (let subscription of this.subscriptions) {
+          subscription.unsubscribe();
+        }
+      });
+    }
+  }
+
+  get instances() {
+    return this.isLoading ? this.staleInstances : this._instances;
+  }
+
+  get instancesByRealm() {
+    return this.isLoading ? this.staleInstancesByRealm : this._instancesByRealm;
+  }
+
+  private search = restartableTask(async (query: Query) => {
+    this._instances = flatMap(
       await Promise.all(
         // use a Set since the default URL may actually be the base realm
-        realmsToSearch.map(
+        this.realmsToSearch.map(
           async (realm) => await this.cardService.search(query, new URL(realm)),
         ),
       ),
     );
 
-    let realmsWithCards = realmsToSearch
+    let realmsWithCards = this.realmsToSearch
       .map((url) => {
-        let cards = this.instances.filter((card) => card.id.startsWith(url));
+        let cards = this._instances.filter((card) => card.id.startsWith(url));
         return { url, cards };
       })
       .filter((r) => r.cards.length > 0);
 
-    this.instancesByRealm = await Promise.all(
+    this._instancesByRealm = await Promise.all(
       realmsWithCards.map(async ({ url, cards }) => {
         let realmInfo = await this.cardService.getRealmInfo(cards[0]);
         if (!realmInfo) {
@@ -92,6 +137,26 @@ export function getSearchResults(
     named: {
       query: query(),
       realms: realms ? realms() : undefined,
+    },
+  })) as Search;
+}
+
+// A new search is triggered whenever the index updates. Consumers of this
+// function that render their cards using {{#each}} should make sure to use the
+// "key" field: {{#each #this.results.instances key="id" as |instance|}} in
+// order to keep the results stable between refreshes.
+export function getLiveSearchResults(
+  parent: object,
+  query: () => Query,
+  realms?: () => string[],
+  doWhileRefreshing?: () => (ready: Promise<void> | undefined) => Promise<void>,
+) {
+  return Search.from(parent, () => ({
+    named: {
+      isLive: true,
+      query: query(),
+      realms: realms ? realms() : undefined,
+      doWhileRefreshing: doWhileRefreshing ? doWhileRefreshing() : undefined,
     },
   })) as Search;
 }

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -166,12 +166,30 @@ export interface CardSearch {
     ready: Promise<void>;
     isLoading: boolean;
   };
+  getLiveCards(
+    query: Query,
+    realms?: string[],
+    doWhileRefreshing?: (ready: Promise<void> | undefined) => Promise<void>,
+  ): {
+    instances: CardDef[];
+    isLoading: boolean;
+  };
 }
 
 export function getCards(query: Query, realms?: string[]) {
   let here = globalThis as any;
   let finder: CardSearch = here._CARDSTACK_CARD_SEARCH;
   return finder?.getCards(query, realms);
+}
+
+export function getLiveCards(
+  query: Query,
+  realms?: string[],
+  doWhileRefreshing?: (ready: Promise<void> | undefined) => Promise<void>,
+) {
+  let here = globalThis as any;
+  let finder: CardSearch = here._CARDSTACK_CARD_SEARCH;
+  return finder?.getLiveCards(query, realms, doWhileRefreshing);
 }
 
 export interface CardCreator {


### PR DESCRIPTION
This is the first part of refactoring live cards. First I am refactoring live queries which is this PR. In this PR we introduce a sibling to `@cardstack/runtime-common#getCards()` which is `getLiveCards()`. The next step will be refactoring the retrieval of a single card instance to be live (e.g. something like `loadLiveModel()` from the card service....)