### PR TITLE
base: Add type imports for Ember packages

### DIFF
--- a/packages/base/types/@cardstack/base/index.d.ts
+++ b/packages/base/types/@cardstack/base/index.d.ts
@@ -1,0 +1,4 @@
+import 'ember-source/types';
+import 'ember-source/types/preview';
+
+export {};

--- a/packages/host/app/lib/externals.ts
+++ b/packages/host/app/lib/externals.ts
@@ -69,7 +69,6 @@ export function shimExternals(loader: Loader) {
   loader.shimModule('@ember/destroyable', emberDestroyable);
   loader.shimModule('marked', marked);
   loader.shimModule('ethers', ethers);
-  // FIXME is this correct?
   loader.shimModule('ember-source/types', { default: class {} });
   loader.shimModule('ember-source/types/preview', { default: class {} });
 }

--- a/packages/host/app/lib/externals.ts
+++ b/packages/host/app/lib/externals.ts
@@ -69,4 +69,7 @@ export function shimExternals(loader: Loader) {
   loader.shimModule('@ember/destroyable', emberDestroyable);
   loader.shimModule('marked', marked);
   loader.shimModule('ethers', ethers);
+  // FIXME is this correct?
+  loader.shimModule('ember-source/types', { default: class {} });
+  loader.shimModule('ember-source/types/preview', { default: class {} });
 }


### PR DESCRIPTION
This fixes type errors like this:

![boxel-motion 2023-10-10 15-59-11](https://github.com/cardstack/boxel/assets/43280/2ad17941-da22-4eeb-af7a-6a5111f7af31)
