### PR TITLE
Fix unidentified domain issue

### DIFF
--- a/packages/host/app/components/operator-mode/code-mode.gts
+++ b/packages/host/app/components/operator-mode/code-mode.gts
@@ -668,11 +668,11 @@ export default class CodeMode extends Component<Signature> {
 
   onStateChange(state: FileResource['state']) {
     this.userHasDismissedURLError = false;
-    if (state === 'not-found') {
+    if (state === 'ready') {
+      this.loadFileError = null;
+    } else {
       this.loadFileError = 'This resource does not exist';
       this.setFileView('browser');
-    } else if (state === 'ready') {
-      this.loadFileError = null;
     }
   }
 

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -1417,6 +1417,43 @@ module('Acceptance | code mode tests', function (hooks) {
 
     await percySnapshot(assert);
   });
+
+  test('can handle error when user puts unidentified domain in card URL bar', async function (assert) {
+    let codeModeStateParam = stringify({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}Person/1`,
+            format: 'isolated',
+          },
+        ],
+      ],
+      submode: 'code',
+      fileView: 'browser',
+      codePath: `${testRealmURL}Person/1.json`,
+      openDirs: { [testRealmURL]: ['Person/'] },
+    })!;
+
+    await visit(
+      `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+        codeModeStateParam,
+      )}`,
+    );
+
+    await fillIn(
+      '[data-test-card-url-bar-input]',
+      `http://unknown-domain.com/test/mango.png`,
+    );
+    await triggerKeyEvent(
+      '[data-test-card-url-bar-input]',
+      'keypress',
+      'Enter',
+    );
+    await waitFor('[data-test-card-url-bar-error]');
+    assert
+      .dom('[data-test-card-url-bar-error]')
+      .containsText('This resource does not exist');
+  });
 });
 
 async function elementIsVisible(element: Element) {

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -833,7 +833,7 @@ module('Integration | operator-mode', function (hooks) {
     assert
       .dom('[data-test-card-error]')
       .hasText(
-        'Error: cannot render card http://this-is-not-a-real-card.com: Failed to fetch',
+        'Error: cannot render card http://this-is-not-a-real-card.com: status: 500 - Failed to fetch.',
       );
   });
 


### PR DESCRIPTION
Ticket: CS-6116

In this PR, I addressed the issue related to the unidentified domain by incorporating a catch statement within the `fetch` function of the loader. This issue arose from our previous practice of throwing an error when a fetch failed. Now, I catch the error and return a `Response` instead.

https://github.com/cardstack/boxel/assets/12637010/a486ec6e-116b-492a-a05c-0e2fc3cf104c

