### PR TITLE
All card models are now live

### DIFF
--- a/packages/host/app/components/editor/go.gts
+++ b/packages/host/app/components/editor/go.gts
@@ -346,7 +346,7 @@ export default class Go extends Component<Signature> {
 
   private loadCard = restartableTask(async (url: URL) => {
     await this.withTestWaiters(async () => {
-      this.card = await this.cardService.loadStaticModel(url);
+      this.card = await this.cardService.loadModel(this, url);
     });
   });
 

--- a/packages/host/app/components/operator-mode/code-mode.gts
+++ b/packages/host/app/components/operator-mode/code-mode.gts
@@ -436,7 +436,7 @@ export default class CodeMode extends Component<Signature> {
   }
 
   private loadLiveCard = restartableTask(async (url: URL) => {
-    let card = await this.cardService.loadLiveModel(this, url);
+    let card = await this.cardService.loadModel(this, url);
     if (card !== this.card) {
       if (this.card) {
         this.cardService.unsubscribe(this.card, this.onCardChange);

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -67,7 +67,6 @@ import type CardService from '../../services/card-service';
 import type LoaderService from '../../services/loader-service';
 
 import type MatrixService from '../../services/matrix-service';
-import type MessageService from '../../services/message-service';
 import type OperatorModeStateService from '../../services/operator-mode-state-service';
 
 const waiter = buildWaiter('operator-mode-container:write-waiter');
@@ -105,7 +104,6 @@ const stackItemStableScrolls = new WeakMap<
 export default class OperatorModeContainer extends Component<Signature> {
   @service declare loaderService: LoaderService;
   @service declare cardService: CardService;
-  @service declare messageService: MessageService;
   @service declare operatorModeStateService: OperatorModeStateService;
   @service declare matrixService: MatrixService;
   @service declare recentFilesService: RecentFilesService;
@@ -118,8 +116,6 @@ export default class OperatorModeContainer extends Component<Signature> {
 
   constructor(owner: Owner, args: Signature['Args']) {
     super(owner, args);
-
-    this.messageService.register();
     (globalThis as any)._CARDSTACK_CARD_SEARCH = this;
     this.constructRecentCards.perform();
     registerDestructor(this, () => {

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -259,7 +259,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
   private calculateLastSavedMsg() {
     this.lastSavedMsg =
       this.lastSaved != null
-        ? `Saved ${(formatDistanceToNow(this.lastSaved), { addSuffix: true })}`
+        ? `Saved ${formatDistanceToNow(this.lastSaved, { addSuffix: true })}`
         : undefined;
   }
 

--- a/packages/host/app/resources/attached-cards.ts
+++ b/packages/host/app/resources/attached-cards.ts
@@ -36,7 +36,7 @@ export class AttachedCards extends Resource<Args> {
       for (let id of ids) {
         let pendingCard = RoomFieldClazz.getAttachedCard(id);
         if (!pendingCard) {
-          pendingCard = this.cardService.loadStaticModel(new URL(id));
+          pendingCard = this.cardService.loadModel(this, new URL(id));
           RoomFieldClazz.setAttachedCard(id, pendingCard);
         }
         pendingCards.push(pendingCard);

--- a/packages/host/app/routes/card.gts
+++ b/packages/host/app/routes/card.gts
@@ -62,7 +62,7 @@ export default class RenderCard extends Route<Model | null> {
       : new URL('./', ownRealmURL);
 
     try {
-      let model = await this.cardService.loadStaticModel(url);
+      let model = await this.cardService.loadModel(this, url);
 
       if (operatorModeEnabled) {
         let operatorModeStateObject = JSON.parse(operatorModeState);

--- a/packages/host/tests/acceptance/operator-mode-test.ts
+++ b/packages/host/tests/acceptance/operator-mode-test.ts
@@ -928,6 +928,7 @@ module('Acceptance | operator mode tests', function (hooks) {
   });
 
   test<TestContextWithSSE>('stack item live updates when index changes', async function (assert) {
+    assert.expect(3);
     let expectedEvents = [
       {
         type: 'index',
@@ -947,10 +948,6 @@ module('Acceptance | operator mode tests', function (hooks) {
         ],
       ],
     })!;
-    let operatorModeStateService = this.owner.lookup(
-      'service:operator-mode-state-service',
-    ) as OperatorModeStateService;
-
     await visit(
       `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
         operatorModeStateParam,
@@ -984,7 +981,14 @@ module('Acceptance | operator mode tests', function (hooks) {
         );
       },
     );
-    await waitUntil(() => operatorModeStateService.reloadItem.isIdle);
+    await waitUntil(
+      () =>
+        document
+          .querySelector(
+            '[data-test-operator-mode-stack="0"] [data-test-person]',
+          )
+          ?.textContent?.includes('FadhlanXXX'),
+    );
     assert
       .dom('[data-test-operator-mode-stack="0"] [data-test-person]')
       .hasText('FadhlanXXX');


### PR DESCRIPTION
IT'S ALIIIIIIIIVVVEEEEEE!!!!!

All card models returned from the card service are live models (we already have a bunch of tests for various consumers of this service to assert that they are live back when these had bespoke live card implementations--we'll just rely on those to assert models are live now since it's all the same machinery)

![live-cards](https://github.com/cardstack/boxel/assets/61075/9df0c11c-5506-4d4a-95e2-a4cd67ed6cbf)
