### PR TITLE
"Remove a field" feature in schema editor

### DIFF
--- a/packages/host/app/components/operator-mode/card-schema-editor.gts
+++ b/packages/host/app/components/operator-mode/card-schema-editor.gts
@@ -6,21 +6,20 @@ import Component from '@glimmer/component';
 
 import { tracked } from '@glimmer/tracking';
 
-import { restartableTask } from 'ember-concurrency';
-
 import { DropdownButton } from '@cardstack/boxel-ui';
 import menuDivider from '@cardstack/boxel-ui/helpers/menu-divider';
 import menuItem from '@cardstack/boxel-ui/helpers/menu-item';
 import { svgJar } from '@cardstack/boxel-ui/helpers/svg-jar';
 import { gt } from '@cardstack/boxel-ui/helpers/truth-helpers';
 
-import { getPlural, identifyCard } from '@cardstack/runtime-common';
+import { getPlural } from '@cardstack/runtime-common';
 
 import type { ModuleSyntax } from '@cardstack/runtime-common/module-syntax';
 
 import AddFieldModal from '@cardstack/host/components/operator-mode/add-field-modal';
 import RealmIcon from '@cardstack/host/components/operator-mode/realm-icon';
 import RealmInfoProvider from '@cardstack/host/components/operator-mode/realm-info-provider';
+import RemoveFieldModal from '@cardstack/host/components/operator-mode/remove-field-modal';
 import {
   type Type,
   type CodeRefType,
@@ -406,9 +405,8 @@ export default class CardSchemaEditor extends Component<Signature> {
                           (menuDivider)
                           (menuItem
                             'Remove Field'
-                            (fn this.removeField field)
+                            (fn this.toggleRemoveFieldModalShown field)
                             dangerous=true
-                            disabled=false
                           )
                         }}
                       />
@@ -439,6 +437,17 @@ export default class CardSchemaEditor extends Component<Signature> {
           />
         {{/if}}
       {{/if}}
+
+      {{#if this.removeFieldModalShown}}
+        <RemoveFieldModal
+          @file={{@file}}
+          @card={{@card}}
+          @field={{this.fieldForRemoval}}
+          @moduleSyntax={{@moduleSyntax}}
+          @onClose={{this.toggleRemoveFieldModalShown}}
+          data-test-remove-field-modal
+        />
+      {{/if}}
     </div>
   </template>
 
@@ -447,8 +456,16 @@ export default class CardSchemaEditor extends Component<Signature> {
   @service declare operatorModeStateService: OperatorModeStateService;
 
   @tracked addFieldModalShown = false;
+  @tracked removeFieldModalShown = false;
+  @tracked private _fieldForRemoval?: FieldOfType = undefined;
+
   @action toggleAddFieldModal() {
     this.addFieldModalShown = !this.addFieldModalShown;
+  }
+
+  @action toggleRemoveFieldModalShown(field?: FieldOfType) {
+    this._fieldForRemoval = field;
+    this.removeFieldModalShown = !this.removeFieldModalShown;
   }
 
   @action openCardDefinition(moduleURL: string) {
@@ -458,21 +475,6 @@ export default class CardSchemaEditor extends Component<Signature> {
   @action
   isOwnField(fieldName: string): boolean {
     return isOwnField(this.args.card, fieldName);
-  }
-
-  @action
-  removeField(field: FieldOfType) {
-    let identifiedCard = identifyCard(this.args.card) as {
-      module: string;
-      name: string;
-    };
-
-    this.args.moduleSyntax.removeField(
-      { type: 'exportedName', name: identifiedCard.name },
-      field.name,
-    );
-
-    this.writeTask.perform(this.args.moduleSyntax.code());
   }
 
   @action
@@ -554,7 +556,11 @@ export default class CardSchemaEditor extends Component<Signature> {
     });
   }
 
-  private writeTask = restartableTask(async (src: string) => {
-    await this.args.file.write(src, true);
-  });
+  get fieldForRemoval(): FieldOfType {
+    if (!this._fieldForRemoval) {
+      throw new Error('fieldForRemoval should be set');
+    }
+
+    return this._fieldForRemoval;
+  }
 }

--- a/packages/host/app/components/operator-mode/remove-field-modal.gts
+++ b/packages/host/app/components/operator-mode/remove-field-modal.gts
@@ -1,0 +1,130 @@
+import { on } from '@ember/modifier';
+import Component from '@glimmer/component';
+
+import { restartableTask } from 'ember-concurrency';
+import perform from 'ember-concurrency/helpers/perform';
+
+import { BoxelButton, Modal } from '@cardstack/boxel-ui';
+
+import cssVar from '@cardstack/boxel-ui/helpers/css-var';
+
+import { identifyCard } from '@cardstack/runtime-common';
+
+import type { ModuleSyntax } from '@cardstack/runtime-common/module-syntax';
+
+import { FieldOfType } from '@cardstack/host/resources/card-type';
+import { Ready } from '@cardstack/host/resources/file';
+
+import { BaseDef } from 'https://cardstack.com/base/card-api';
+
+interface Signature {
+  Args: {
+    card: typeof BaseDef;
+    file: Ready;
+    moduleSyntax: ModuleSyntax;
+    field: FieldOfType;
+    onClose: () => void;
+  };
+  Element: HTMLElement;
+}
+
+export default class RemoveFieldModal extends Component<Signature> {
+  private removeFieldTask = restartableTask(async () => {
+    let { field, card, file, moduleSyntax } = this.args;
+    let identifiedCard = identifyCard(card) as {
+      module: string;
+      name: string;
+    };
+
+    this.args.moduleSyntax.removeField(
+      { type: 'exportedName', name: identifiedCard.name },
+      field.name,
+    );
+
+    await file.write(moduleSyntax.code(), true);
+    this.args.onClose();
+  });
+
+  <template>
+    <Modal
+      @layer='urgent'
+      @size='x-small'
+      @isOpen={{true}}
+      @onClose={{@onClose}}
+      style={{cssVar boxel-modal-offset-top='40vh'}}
+      data-test-remove-field-modal
+    >
+      <div class='delete'>
+        <div class='content'>Remove a field</div>
+
+        <div class='content'>
+          Are you sure you want to remove the
+          <b>{{@field.name}}</b>
+          field from the
+          <b>{{@card.displayName}}</b>
+          card?
+        </div>
+
+        <div class='content disclaimer'>This action is not reversible.</div>
+
+        <div class='buttons'>
+          <BoxelButton
+            @size='tall'
+            @kind='secondary-light'
+            @disabled={{this.removeFieldTask.isRunning}}
+            {{on 'click' @onClose}}
+            data-test-cancel-remove-field-button
+          >
+            Cancel
+          </BoxelButton>
+
+          <BoxelButton
+            @size='tall'
+            @kind='danger'
+            @loading={{this.removeFieldTask.isRunning}}
+            @disabled={{this.removeFieldTask.isRunning}}
+            {{on 'click' (perform this.removeFieldTask)}}
+            data-test-remove-field-button
+          >
+            {{#if this.removeFieldTask.isRunning}}
+              Removing…
+            {{else}}
+              Remove
+            {{/if}}
+          </BoxelButton>
+        </div>
+      </div>
+    </Modal>
+
+    <style>
+      .content {
+        width: 100%;
+        font-size: var(--boxel-font-size);
+        text-align: center;
+        margin-top: var(--boxel-sp);
+      }
+      .content:first-child {
+        margin-top: 0;
+      }
+      .disclaimer {
+        color: var(--boxel-danger);
+        font-size: var(--boxel-font-size-xs);
+      }
+      .delete {
+        padding: var(--boxel-sp-lg) var(--boxel-sp-xl) var(--boxel-sp);
+        background-color: white;
+        border-radius: var(--boxel-border-radius-xl);
+        box-shadow: var(--boxel-deep-box-shadow);
+      }
+      .buttons {
+        margin-top: var(--boxel-sp-lg);
+        display: flex;
+        justify-content: center;
+        width: 100%;
+      }
+      button:first-child {
+        margin-right: var(--boxel-sp-xs);
+      }
+    </style>
+  </template>
+}

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -1656,7 +1656,21 @@ module('Acceptance | code mode tests', function (hooks) {
 
     await click('[data-test-boxel-menu-item-text="Remove Field"]');
 
+    assert.dom('[data-test-remove-field-modal]').exists();
+
+    // Test closing the modal works (cancel removing a field)
+    await click('[data-test-cancel-remove-field-button]');
+    assert.dom('[data-test-remove-field-modal]').doesNotExist();
+
+    // Open the modal again
+    await click(
+      '[data-test-card-schema="Person"] [data-test-field-name="firstName"] [data-test-schema-editor-field-contextual-button]',
+    );
+    await click('[data-test-boxel-menu-item-text="Remove Field"]');
+
+    await click('[data-test-remove-field-button]');
     await waitFor('[data-test-card-schema]');
+
     assert
       .dom('[data-test-card-schema="Person"] [data-test-total-fields]')
       .containsText('+ 4 Fields'); // One field less

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -29,6 +29,7 @@ import {
   testRealmURL,
   sourceFetchRedirectHandle,
   sourceFetchReturnUrlHandle,
+  getMonacoContent,
 } from '../helpers';
 
 const indexCardSource = `
@@ -1453,6 +1454,51 @@ module('Acceptance | code mode tests', function (hooks) {
     assert
       .dom('[data-test-card-url-bar-error]')
       .containsText('This resource does not exist');
+  });
+
+  test('deleting a field from schema editor', async function (assert) {
+    let operatorModeStateParam = stringify({
+      stacks: [],
+      submode: 'code',
+      codePath: `${testRealmURL}person.gts`,
+    })!;
+
+    await visit(
+      `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+        operatorModeStateParam,
+      )}`,
+    );
+
+    await waitFor('[data-test-card-schema]');
+
+    await click(
+      '[data-test-card-schema="Person"] [data-test-field-name="firstName"] [data-test-schema-editor-field-contextual-button]',
+    );
+
+    assert
+      .dom('[data-test-card-schema="Person"] [data-test-total-fields]')
+      .containsText('+ 5 Fields');
+
+    assert.true(
+      getMonacoContent().includes('firstName = contains(StringCard)'),
+    );
+
+    await click('[data-test-boxel-menu-item-text="Remove Field"]');
+
+    await waitFor('[data-test-card-schema]');
+    assert
+      .dom('[data-test-card-schema="Person"] [data-test-total-fields]')
+      .containsText('+ 4 Fields'); // One field less
+
+    assert.false(
+      getMonacoContent().includes('firstName = contains(StringCard)'),
+    );
+
+    assert
+      .dom(
+        `[data-test-card-schema="Person"] [data-test-field-name="firstName"]`,
+      )
+      .doesNotExist();
   });
 });
 


### PR DESCRIPTION
This PR adds the ability to remove a field, from the schema editor.

<img width="295" alt="image" src="https://github.com/cardstack/boxel/assets/273660/cd77596c-3024-4c77-95f3-bf8cf62388ce">

However, this creates a problem where loading an existing instance will produce an error about a missing field. This will be addressed in a different ticket. 

<img width="437" alt="image" src="https://github.com/cardstack/boxel/assets/273660/93586486-bc8c-4490-933f-21db898c17c7">

In our meeting, we concluded the warning message is sufficient for developer preview but we should not error when there are extra fields in a card instance. During serialization, we should trace the shape of the card definition instead of the card instance. This will come in another PR. 

