### PR TITLE
Fix tests when asserting content in code editor

### DIFF
--- a/packages/host/app/resources/file.ts
+++ b/packages/host/app/resources/file.ts
@@ -181,7 +181,9 @@ class _FileResource extends Resource<Args> {
       size,
       url: response.url,
       write(content: string, flushLoader?: true) {
-        self.writing = self.writeTask.perform(this, content, flushLoader);
+        self.writing = self.writeTask
+          .unlinked() // If the component which performs this task from within another task is destroyed, for example the "add field" modal, we want this task to continue running
+          .perform(this, content, flushLoader);
         return self.writing;
       },
     });

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -1621,6 +1621,7 @@ module('Acceptance | code mode tests', function (hooks) {
       getMonacoContent().includes(
         'luckyNumbers = containsMany(BigIntegerCard)',
       ),
+      "code editor contains line 'luckyNumbers = containsMany(BigIntegerCard)'",
     );
 
     // Field is a card descending from CardDef (cardinality: one)
@@ -1648,6 +1649,7 @@ module('Acceptance | code mode tests', function (hooks) {
 
     assert.ok(
       getMonacoContent().includes('favPerson = linksTo(() => Person);'),
+      "code editor contains line 'favPerson = linksTo(() => Person);'",
     );
 
     // Field is a card descending from CardDef (cardinality: many)

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -1565,6 +1565,7 @@ module('Acceptance | code mode tests', function (hooks) {
 
   test<TestContextWithSSE>('adding a field from schema editor - cardinality test', async function (assert) {
     assert.expect(9);
+    let waitForOpts = { timeout: 2000 }; // Helps mitigating flaky tests since Writing to a file + reflecting that in the UI can be a bit slow
     let expectedEvents = [
       {
         type: 'index',
@@ -1608,6 +1609,7 @@ module('Acceptance | code mode tests', function (hooks) {
 
     await waitFor(
       '[data-test-card-schema="Person"] [data-test-field-name="luckyNumbers"] [data-test-card-display-name="BigInteger"]',
+      waitForOpts,
     );
     assert
       .dom(
@@ -1636,6 +1638,7 @@ module('Acceptance | code mode tests', function (hooks) {
     await saveField(this, assert, expectedEvents);
     await waitFor(
       '[data-test-card-schema="Person"] [data-test-field-name="favPerson"] [data-test-card-display-name="Person"]',
+      waitForOpts,
     );
     assert
       .dom(
@@ -1651,7 +1654,10 @@ module('Acceptance | code mode tests', function (hooks) {
     await waitFor('[data-test-add-field-button]');
     await click('[data-test-add-field-button]');
     await click('[data-test-choose-card-button]');
-    await waitFor('[data-test-select="http://test-realm/test/person-entry"]');
+    await waitFor(
+      '[data-test-select="http://test-realm/test/person-entry"]',
+      waitForOpts,
+    );
     await click('[data-test-select="http://test-realm/test/person-entry"]');
     await click('[data-test-card-catalog-go-button]');
     await fillIn('[data-test-field-name-input]', 'favPeople');
@@ -1659,6 +1665,7 @@ module('Acceptance | code mode tests', function (hooks) {
     await saveField(this, assert, expectedEvents);
     await waitFor(
       '[data-test-card-schema="Person"] [data-test-field-name="favPeople"] [data-test-card-display-name="Person"]',
+      waitForOpts,
     );
     assert
       .dom(


### PR DESCRIPTION
We are currently seeing main failing because of flakiness of these tests.

For me locally, a combination of these adjustments helped to get the test passing reliably after passing only randomly.
