### PR TITLE
Display more granular schema editor incompatibility message

### DIFF
--- a/packages/boxel-ui/addon/src/components/loading-indicator/index.gts
+++ b/packages/boxel-ui/addon/src/components/loading-indicator/index.gts
@@ -11,7 +11,11 @@ interface Signature {
 }
 
 const LoadingIndicator: TemplateOnlyComponent<Signature> = <template>
-  <div class='boxel-loading-indicator' ...attributes>
+  <div
+    class='boxel-loading-indicator'
+    data-test-loading-indicator
+    ...attributes
+  >
     <LoadingIndicatorIcon
       style={{cssVar icon-color=(if @color @color '#000')}}
       role='presentation'

--- a/packages/host/app/components/operator-mode/code-mode.gts
+++ b/packages/host/app/components/operator-mode/code-mode.gts
@@ -823,7 +823,7 @@ export default class CodeMode extends Component<Signature> {
                     class='incompatible-schema-editor'
                     data-test-schema-editor-incompatible-file
                   >
-                    Schema Editor cannot be used with this type of file.
+                    Schema Editor cannot be used with this file type.
                   </div>
                 {{else if
                   (and this.isValidSchemaFile this.schemaEditorIncompatibleItem)

--- a/packages/host/app/components/operator-mode/code-mode.gts
+++ b/packages/host/app/components/operator-mode/code-mode.gts
@@ -207,11 +207,24 @@ export default class CodeMode extends Component<Signature> {
     return this.maybeMonacoSDK && isReady(this.currentOpenFile);
   }
 
-  private get schemaEditorIncompatible() {
-    return this.readyFile.isBinary || this.isNonCardJson;
+  private get schemaEditorIncompatibleFile() {
+    return (
+      this.readyFile.isBinary || this.isNonCardJson || !this.isValidSchemaFile
+    );
   }
 
-  private isNonCardJson() {
+  private get isValidSchemaFile() {
+    return this.declarations.some((d) => isCardOrFieldDeclaration(d));
+  }
+
+  private get schemaEditorIncompatibleItem() {
+    if (!this.selectedDeclaration) {
+      return;
+    }
+    return !isCardOrFieldDeclaration(this.selectedDeclaration);
+  }
+
+  private get isNonCardJson() {
     return (
       this.readyFile.name.endsWith('.json') &&
       !isCardDocumentString(this.readyFile.content)
@@ -805,14 +818,30 @@ export default class CodeMode extends Component<Signature> {
                     @card={{this.selectedCardOrField.cardOrField}}
                     @cardTypeResource={{this.selectedCardOrField.cardType}}
                   />
-                {{else if this.schemaEditorIncompatible}}
+                {{else if this.schemaEditorIncompatibleFile}}
                   <div
                     class='incompatible-schema-editor'
-                    data-test-schema-editor-incompatible
-                  >Schema Editor cannot be used with this file type</div>
+                    data-test-schema-editor-incompatible-file
+                  >
+                    Schema Editor cannot be used with this type of file.
+                  </div>
+                {{else if
+                  (and this.isValidSchemaFile this.schemaEditorIncompatibleItem)
+                }}
+                  <div
+                    class='incompatible-schema-editor'
+                    data-test-schema-editor-incompatible-item
+                  >
+                    Schema Editor cannot be used for selected
+                    {{this.selectedDeclaration.type}}
+                    "{{this.selectedDeclaration.localName}}".</div>
                 {{else if this.cardError}}
                   {{this.cardError.message}}
                 {{/if}}
+              {{else if this.isLoading}}
+                <div class='loading'>
+                  <LoadingIndicator />
+                </div>
               {{/if}}
             </div>
           </ResizablePanel>


### PR DESCRIPTION
[CS-6121]

If there are no `Card` or `Field` types in the file, the message is still: `Schema Editor cannot be used with this file type.`

If there are `Card` or `Field` types, but an incompatible type is selected, message is more granular. Sample message:`Schema Editor cannot be used for selected class "Isolated".`

Incompatible type selected in compatible file (granular message):
<img width="1881" alt="incompatible-type" src="https://github.com/cardstack/boxel/assets/16160806/c19cc7c4-0d82-42df-8f4c-4ea2a5ec3c4a">
Same file as above, compatible type selected:
<img width="1876" alt="compatible-type" src="https://github.com/cardstack/boxel/assets/16160806/0e949779-5a00-4a57-9027-4d66b2c8e64f">

Different file with no compatible types:
<img width="1710" alt="no-comp-type" src="https://github.com/cardstack/boxel/assets/16160806/52df7d9a-afd9-4c7f-b4aa-02c84f7a15ec">

