### PR TITLE
Bug. Local card with no relationship with exported card should not be displayed in LHS panel

### DIFF
--- a/packages/drafts-realm/in-this-file.gts
+++ b/packages/drafts-realm/in-this-file.gts
@@ -51,4 +51,10 @@ export class ExportedFieldInheritLocalField extends LocalField {
   static displayName = 'exported field extends local field';
 }
 
+// @ts-ignore
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+class LocalCardWithoutExportRelationship extends CardDef {
+  static displayName = 'local card but without export relationship';
+}
+
 export default class DefaultClass {}

--- a/packages/host/tests/acceptance/code-mode-test.ts
+++ b/packages/host/tests/acceptance/code-mode-test.ts
@@ -154,6 +154,10 @@ const inThisFileSource = `
     static displayName = 'exported field extends local field';
   }
 
+  class LocalCardWithoutExportRelationship extends CardDef {
+    static displayName = 'local card but without export relationship';
+  }
+  
   export default class DefaultClass {}
 `;
 


### PR DESCRIPTION
```

class LocalCardWithoutExportRelationship extends CardDef {
  static displayName = 'local card but without export relationship';
}
```

This particular example should not be listed as a class in the LHS panel. Since it doesn't have any relationship with an exported card or field

https://github.com/cardstack/boxel/assets/8165111/77b871f4-d560-4eca-b216-a6ecd9ac83bd


