### PR TITLE
ui: Hide resize handles in narrow panels

### DIFF
--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
@@ -301,7 +301,7 @@ export default class ResizablePanelGroup extends Component<Signature> {
     let panelLengths = [];
     for (let index = 1; index <= this.listPanelContext.size; index++) {
       let panelEl = panelGroupEl.querySelector(
-        `[id='${index}'].boxel-panel-${this.args.orientation}`,
+        `[id='${index}'].boxel-panel.${this.args.orientation}`,
       ) as HTMLElement;
       if (!panelEl) {
         console.error(

--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
@@ -35,7 +35,7 @@ export default class Panel extends Component<Signature> {
   <template>
     <div
       id={{this.id}}
-      class='boxel-panel-{{@orientation}}'
+      class='boxel-panel {{@orientation}}'
       style={{if
         (eq @orientation 'horizontal')
         (cssVars
@@ -66,16 +66,20 @@ export default class Panel extends Component<Signature> {
       </div>
     {{/unless}}
     <style>
-      .boxel-panel-horizontal {
-        --boxel-panel-width: '300px';
+      .boxel-panel {
+        --resizable-panel-length: '300px;';
+      }
+
+      .boxel-panel.horizontal {
+        --boxel-panel-width: var(--resizable-panel-length);
         --boxel-panel-min-width: 'none';
 
         width: var(--boxel-panel-width);
         min-width: var(--boxel-panel-min-width);
       }
 
-      .boxel-panel-vertical {
-        --boxel-panel-height: '300px';
+      .boxel-panel.vertical {
+        --boxel-panel-height: var(--resizable-panel-length);
         --boxel-panel-min-height: 'none';
 
         height: var(--boxel-panel-height);

--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
@@ -103,6 +103,9 @@ export default class Panel extends Component<Signature> {
       }
 
       .resize-handler {
+        width: var(--boxel-panel-resize-handler-width);
+        height: var(--boxel-panel-resize-handler-height);
+
         border: none;
         border-radius: var(--boxel-border-radius-xl);
         padding: 0;
@@ -114,16 +117,10 @@ export default class Panel extends Component<Signature> {
 
       .resize-handler.horizontal {
         cursor: col-resize;
-
-        height: var(--boxel-panel-resize-handler-height);
-        width: var(--boxel-panel-resize-handler-width);
       }
 
       .resize-handler.vertical {
         cursor: row-resize;
-
-        width: var(--boxel-panel-resize-handler-width);
-        height: var(--boxel-panel-resize-handler-height);
       }
 
       .arrow {

--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
@@ -68,6 +68,8 @@ export default class Panel extends Component<Signature> {
     <style>
       .boxel-panel {
         --resizable-panel-length: '300px;';
+
+        container-type: inline-size;
       }
 
       .boxel-panel.horizontal {
@@ -125,6 +127,18 @@ export default class Panel extends Component<Signature> {
 
       .resize-handler.vertical {
         cursor: row-resize;
+      }
+
+      @container (width <= 30px) {
+        .resize-handler.vertical {
+          visibility: hidden;
+        }
+      }
+
+      @container (height <= 30px) {
+        .resize-handler.horizontal {
+          visibility: hidden;
+        }
       }
 
       .arrow {


### PR DESCRIPTION
This fixes [this bug](https://github.com/cardstack/boxel/pull/727#issuecomment-1775299734). Before when the nested panel was zero-width its handle still showed:

![image](https://github.com/cardstack/boxel/assets/43280/9bcb5d64-5ef6-4c93-9120-6c1c526b7de7)

Now there‘s a container query that hides the handles when the container is below 30px, an arbitrary choice that looked good to me:

![screencast 2023-10-23 14-00-15](https://github.com/cardstack/boxel/assets/43280/a4013d24-5d97-4d35-a15c-adf1637d8ef7)

I hoped to make it a multiple of the handle breadth but variables aren’t allowed in container queries! 😞