### PR TITLE
Update design of the "Add Field" button in schema editor

### DIFF
--- a/packages/host/app/components/operator-mode/card-schema-editor.gts
+++ b/packages/host/app/components/operator-mode/card-schema-editor.gts
@@ -8,6 +8,14 @@ import { tracked } from '@glimmer/tracking';
 import { DropdownButton } from '@cardstack/boxel-ui/components';
 import { gt, menuDivider, menuItem } from '@cardstack/boxel-ui/helpers';
 
+import {
+  ArrowTopLeft,
+  IconLink,
+  ThreeDotsHorizontal,
+  Warning as WarningIcon,
+  IconPlus,
+} from '@cardstack/boxel-ui/icons';
+
 import { getPlural } from '@cardstack/runtime-common';
 
 import type { ModuleSyntax } from '@cardstack/runtime-common/module-syntax';
@@ -16,17 +24,12 @@ import AddFieldModal from '@cardstack/host/components/operator-mode/add-field-mo
 import RealmIcon from '@cardstack/host/components/operator-mode/realm-icon';
 import RealmInfoProvider from '@cardstack/host/components/operator-mode/realm-info-provider';
 import RemoveFieldModal from '@cardstack/host/components/operator-mode/remove-field-modal';
+
 import {
   type Type,
   type CodeRefType,
   type FieldOfType,
 } from '@cardstack/host/resources/card-type';
-import {
-  ArrowTopLeft,
-  IconLink,
-  ThreeDotsHorizontal,
-  Warning as WarningIcon,
-} from '@cardstack/boxel-ui/icons';
 
 import type { Ready } from '@cardstack/host/resources/file';
 import type CardService from '@cardstack/host/services/card-service';
@@ -225,11 +228,35 @@ export default class CardSchemaEditor extends Component<Signature> {
       }
 
       .add-field-button {
+        --icon-color: var(--boxel-highlight);
         background-color: transparent;
-        border: none;
         color: var(--boxel-highlight);
         font-size: var(--boxel-font-sm);
         font-weight: 600;
+        width: 100%;
+        height: 56px;
+        padding: var(--boxel-sp-xs);
+        border-radius: var(--boxel-border-radius);
+        border: 1px solid var(--boxel-500);
+        display: flex;
+      }
+
+      .add-field-button > span {
+        display: flex;
+        margin: auto;
+      }
+
+      .add-field-button > span > span {
+        margin-top: 1px;
+      }
+
+      .add-field-button > span > svg {
+        margin-right: var(--boxel-sp-xxxs);
+      }
+
+      .add-field-button:hover {
+        border: 1px solid var(--boxel-highlight);
+        background-color: var(--boxel-100);
       }
 
       .overriding-field {
@@ -425,7 +452,10 @@ export default class CardSchemaEditor extends Component<Signature> {
           data-test-add-field-button
           {{on 'click' this.toggleAddFieldModal}}
         >
-          + Add a field
+          <span>
+            <IconPlus width='20px' height='20px' role='presentation' />
+            <span>Add a field</span>
+          </span>
         </button>
 
         {{#if this.addFieldModalShown}}

--- a/packages/host/app/components/operator-mode/card-schema-editor.gts
+++ b/packages/host/app/components/operator-mode/card-schema-editor.gts
@@ -238,19 +238,17 @@ export default class CardSchemaEditor extends Component<Signature> {
         padding: var(--boxel-sp-xs);
         border-radius: var(--boxel-border-radius);
         border: 1px solid var(--boxel-500);
+        margin: auto;
+        align-items: center;
+        justify-content: center;
         display: flex;
       }
 
       .add-field-button > span {
-        display: flex;
-        margin: auto;
-      }
-
-      .add-field-button > span > span {
         margin-top: 1px;
       }
 
-      .add-field-button > span > svg {
+      .add-field-button > svg {
         margin-right: var(--boxel-sp-xxxs);
       }
 
@@ -452,9 +450,9 @@ export default class CardSchemaEditor extends Component<Signature> {
           data-test-add-field-button
           {{on 'click' this.toggleAddFieldModal}}
         >
+          <IconPlus width='20px' height='20px' role='presentation' />
           <span>
-            <IconPlus width='20px' height='20px' role='presentation' />
-            <span>Add a field</span>
+            Add a field
           </span>
         </button>
 


### PR DESCRIPTION
Before:
<img width="516" alt="image" src="https://github.com/cardstack/boxel/assets/273660/40441ff5-87f6-44b9-afa0-eaa525414175">

After:
<img width="549" alt="image" src="https://github.com/cardstack/boxel/assets/273660/c051734c-41e2-4dc7-9cea-8b0e230babf8">

Hover:
<img width="540" alt="image" src="https://github.com/cardstack/boxel/assets/273660/715da08b-28f0-4cfc-abd8-376d108d2fdd">

I followed this design below. There are subtle color mismatches because I was trying to use our color variables.

<img width="357" alt="image" src="https://github.com/cardstack/boxel/assets/273660/0f163733-5c14-48c0-a2d5-77e3aab2429b">
