### PR TITLE
ui: Fix how resizable panel handles are hidden

### DIFF
--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
@@ -15,6 +15,7 @@ export type PanelContext = {
 interface Signature {
   Args: {
     defaultLength: string;
+    hideHandle: boolean;
     isLastPanel: (panelId: number) => boolean;
     length?: string;
     minLength?: string;
@@ -58,7 +59,7 @@ export default class Panel extends Component<Signature> {
       <div class='separator-{{@orientation}}' ...attributes>
         <button
           id={{this.resizeHandlerId}}
-          class='resize-handler {{@orientation}}'
+          class='resize-handler {{@orientation}} {{if @hideHandle "hidden"}}'
           aria-label={{this.resizeHandlerId}}
           {{on 'mousedown' @onResizeHandlerMouseDown}}
           {{on 'dblclick' @onResizeHandlerDblClick}}
@@ -68,8 +69,6 @@ export default class Panel extends Component<Signature> {
     <style>
       .boxel-panel {
         --resizable-panel-length: '300px;';
-
-        container-type: inline-size;
       }
 
       .boxel-panel.horizontal {
@@ -135,16 +134,8 @@ export default class Panel extends Component<Signature> {
         cursor: row-resize;
       }
 
-      @container (width <= 30px) {
-        .resize-handler.vertical {
-          visibility: hidden;
-        }
-      }
-
-      @container (height <= 30px) {
-        .resize-handler.horizontal {
-          visibility: hidden;
-        }
+      .resize-handler.hidden {
+        visibility: hidden;
       }
 
       .arrow {


### PR DESCRIPTION
The use of container queries to hide handles was creating a containment context that restricted the new field modal and background to the width of the panel:

![image](https://github.com/cardstack/boxel/assets/43280/d1d5bc77-b8a5-4dab-b10e-9e8c3a049c84)

One option to address this would be to render the modal and overlay elsewhere in the DOM but this caused stacking problems because operator mode is implemented as a modal and the application has an overall lack of modal management. While I vastly prefer the declarative elegance of container queries to decide when handles should be hidden, since the implementation already includes a resize observer, this amends it to detect when the panel group container has dropped below the threshold width and hide the handles:

![screencast 2023-10-26 12-15-30](https://github.com/cardstack/boxel/assets/43280/3fc38ffc-2bef-46dd-a8c5-ccf213369ad7)

Removing the `container-type` CSS property restores the modal and overlay to full-width:

<img width="1498" alt="Boxel 2023-10-26 12-17-48" src="https://github.com/cardstack/boxel/assets/43280/08e98787-d6e8-4901-9f8b-414d877f1c2e">
