### PR TITLE
Add concurrency control for realm index updates

### DIFF
--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -890,7 +890,7 @@ module('Integration | operator-mode', function (hooks) {
     await waitFor('[data-test-card-error]');
     assert
       .dom('[data-test-card-error]')
-      .hasText(
+      .includesText(
         'Error: cannot render card http://this-is-not-a-real-card.com: status: 500 - Failed to fetch.',
       );
   });
@@ -2674,30 +2674,30 @@ module('Integration | operator-mode', function (hooks) {
 
     assert.dom('[data-test-field="trips"] [data-test-add-new]').exists();
     await click('[data-test-links-to-many="countries"] [data-test-add-new]');
-    await waitFor(`[data-test-card-catalog-item="${testRealmURL}Country/japan"]`);
+    await waitFor(
+      `[data-test-card-catalog-item="${testRealmURL}Country/japan"]`,
+    );
     await click(`[data-test-select="${testRealmURL}Country/japan"]`);
     await click('[data-test-card-catalog-go-button]');
 
     await waitUntil(() => !document.querySelector('[card-catalog-modal]'));
-    assert.dom('[data-test-pill-item]').exists({ count: 1});
-    assert
-      .dom('[data-test-field="trips"]')
-      .containsText('Japan');
+    assert.dom('[data-test-pill-item]').exists({ count: 1 });
+    assert.dom('[data-test-field="trips"]').containsText('Japan');
 
     await click('[data-test-links-to-many="countries"] [data-test-add-new]');
-    await waitFor(`[data-test-card-catalog-item="${testRealmURL}Country/united-states"]`);
+    await waitFor(
+      `[data-test-card-catalog-item="${testRealmURL}Country/united-states"]`,
+    );
     await click(`[data-test-select="${testRealmURL}Country/united-states"]`);
     await click('[data-test-card-catalog-go-button]');
 
     await waitUntil(() => !document.querySelector('[card-catalog-modal]'));
-    assert.dom('[data-test-pill-item]').exists({ count: 2});
-    assert
-      .dom('[data-test-field="trips"]')
-      .containsText('Japan United States');
-  
+    assert.dom('[data-test-pill-item]').exists({ count: 2 });
+    assert.dom('[data-test-field="trips"]').containsText('Japan United States');
+
     await click('[data-test-pill-item] [data-test-remove-card]');
-    assert.dom('[data-test-pill-item]').exists({ count: 1});
+    assert.dom('[data-test-pill-item]').exists({ count: 1 });
     await click('[data-test-pill-item] [data-test-remove-card]');
-    assert.dom('[data-test-pill-item]').exists({ count: 0});
+    assert.dom('[data-test-pill-item]').exists({ count: 0 });
   });
 });

--- a/packages/host/tests/integration/realm-test.ts
+++ b/packages/host/tests/integration/realm-test.ts
@@ -401,7 +401,7 @@ module('Integration | realm', function (hooks) {
     ];
     await this.expectEvents(assert, realm, adapter, expected, async () => {
       {
-        let response = await realm.handle(
+        let response = realm.handle(
           new Request(testRealmURL, {
             method: 'POST',
             headers: {
@@ -424,8 +424,14 @@ module('Integration | realm', function (hooks) {
             ),
           }),
         );
-        assert.strictEqual(response.status, 201, 'successful http status');
-        let json = await response.json();
+        await realm.flushOperations();
+
+        assert.strictEqual(
+          (await response).status,
+          201,
+          'successful http status',
+        );
+        let json = await (await response).json();
         if (isSingleCardDocument(json)) {
           assert.strictEqual(
             json.data.id,
@@ -473,7 +479,7 @@ module('Integration | realm', function (hooks) {
 
       // create second file
       {
-        let response = await realm.handle(
+        let response = realm.handle(
           new Request(testRealmURL, {
             method: 'POST',
             headers: {
@@ -496,8 +502,13 @@ module('Integration | realm', function (hooks) {
             ),
           }),
         );
-        assert.strictEqual(response.status, 201, 'successful http status');
-        let json = await response.json();
+        await realm.flushOperations();
+        assert.strictEqual(
+          (await response).status,
+          201,
+          'successful http status',
+        );
+        let json = await (await response).json();
         if (isSingleCardDocument(json)) {
           assert.strictEqual(
             json.data.id,
@@ -705,7 +716,7 @@ module('Integration | realm', function (hooks) {
       adapter,
       expected,
       async () => {
-        return await realm.handle(
+        let response = realm.handle(
           new Request(`${testRealmURL}dir/card`, {
             method: 'PATCH',
             headers: {
@@ -731,6 +742,8 @@ module('Integration | realm', function (hooks) {
             ),
           }),
         );
+        await realm.flushOperations();
+        return await response;
       },
     );
     assert.strictEqual(response.status, 200, 'successful http status');
@@ -1972,7 +1985,7 @@ module('Integration | realm', function (hooks) {
       adapter,
       expected,
       async () => {
-        return await realm.handle(
+        let response = realm.handle(
           new Request(`${testRealmURL}cards/2`, {
             method: 'DELETE',
             headers: {
@@ -1980,6 +1993,8 @@ module('Integration | realm', function (hooks) {
             },
           }),
         );
+        await realm.flushOperations();
+        return await response;
       },
     );
     assert.strictEqual(response.status, 204, 'status was 204');
@@ -2086,7 +2101,7 @@ module('Integration | realm', function (hooks) {
         adapter,
         expected,
         async () => {
-          return await realm.handle(
+          let response = realm.handle(
             new Request(`${testRealmURL}dir/person.gts`, {
               method: 'POST',
               headers: {
@@ -2095,6 +2110,8 @@ module('Integration | realm', function (hooks) {
               body: cardSrc,
             }),
           );
+          await realm.flushOperations();
+          return await response;
         },
       );
 
@@ -2148,16 +2165,17 @@ module('Integration | realm', function (hooks) {
       adapter,
       expected,
       async () => {
-        let response = await realm.handle(
+        let response = realm.handle(
           new Request(`${testRealmURL}person`, {
             headers: {
               Accept: 'application/vnd.card+source',
             },
           }),
         );
-        assert.strictEqual(response.status, 302, 'file exists');
+        await realm.flushOperations();
+        assert.strictEqual((await response).status, 302, 'file exists');
 
-        return await realm.handle(
+        response = realm.handle(
           new Request(`${testRealmURL}person`, {
             method: 'DELETE',
             headers: {
@@ -2165,6 +2183,8 @@ module('Integration | realm', function (hooks) {
             },
           }),
         );
+        await realm.flushOperations();
+        return await response;
       },
     );
     assert.strictEqual(response.status, 204, 'file is deleted');

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -508,8 +508,12 @@ export class Loader {
       }
       return await getNativeFetch()(this.asResolvedRequest(urlOrRequest, init));
     } catch (err: any) {
-      this.log.error(`fetch failed for ${urlOrRequest}`, err);
-      return new Response(new Blob(), {
+      let url =
+        urlOrRequest instanceof Request
+          ? urlOrRequest.url
+          : String(urlOrRequest);
+      this.log.error(`fetch failed for ${url}`, err);
+      return new Response(`fetch failed for ${url}`, {
         status: 500,
         statusText: err.message,
       });

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -408,6 +408,18 @@ export class Realm {
     return { isTracked: false, url };
   }
 
+  // this is used by tests to manipulate the realm directly
+  async delete(path: LocalPath): Promise<void> {
+    let deferred = new Deferred<void>();
+    this.#operationQueue.push({
+      type: 'delete',
+      path,
+      deferred,
+    });
+    this.drainOperations();
+    return deferred.promise;
+  }
+
   async #delete(path: LocalPath): Promise<void> {
     await this.trackOwnWrite(path, { isDelete: true });
     await this.#adapter.remove(path);

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -175,6 +175,25 @@ interface MessageEvent {
   id?: string;
 }
 
+type Operation = WriteOperation | DeleteOperation;
+
+interface WriteResult {
+  lastModified: number;
+}
+
+interface WriteOperation {
+  type: 'write';
+  path: LocalPath;
+  contents: string;
+  deferred: Deferred<WriteResult>;
+}
+
+interface DeleteOperation {
+  type: 'delete';
+  path: LocalPath;
+  deferred: Deferred<void>;
+}
+
 export class Realm {
   #startedUp = new Deferred<void>();
   #searchIndex: SearchIndex;
@@ -189,6 +208,8 @@ export class Realm {
   #updateItems: UpdateItem[] = [];
   #flushUpdateEvents: Promise<void> | undefined;
   #recentWrites: Map<string, number> = new Map();
+  #flushOperations: Promise<void> | undefined;
+  #operationQueue: Operation[] = [];
   readonly paths: RealmPaths;
 
   get url(): string {
@@ -282,10 +303,36 @@ export class Realm {
     return this.#flushUpdateEvents;
   }
 
-  async write(
-    path: LocalPath,
-    contents: string,
-  ): Promise<{ lastModified: number }> {
+  async flushOperations() {
+    return this.#flushOperations;
+  }
+
+  // in order to prevent issues with concurrent index manipulation clobbering
+  // each other we use a queue of operations to mutate realm state. We should
+  // remove this queue when we move to a pg backed index
+  private async drainOperations() {
+    await this.#flushOperations;
+
+    let operationsDrained: () => void;
+    this.#flushOperations = new Promise<void>(
+      (res) => (operationsDrained = res),
+    );
+    let operations = [...this.#operationQueue];
+    this.#operationQueue = [];
+    for (let operation of operations) {
+      if (operation.type === 'write') {
+        let result = await this.write(operation.path, operation.contents);
+        operation.deferred.fulfill(result);
+      } else {
+        await this.delete(operation.path);
+        operation.deferred.fulfill();
+      }
+    }
+
+    operationsDrained!();
+  }
+
+  private async write(path: LocalPath, contents: string): Promise<WriteResult> {
     await this.trackOwnWrite(path);
     let results = await this.#adapter.write(path, contents);
     await this.#searchIndex.update(this.paths.fileURL(path), {
@@ -348,7 +395,7 @@ export class Realm {
     return { isTracked: false, url };
   }
 
-  async delete(path: LocalPath): Promise<void> {
+  private async delete(path: LocalPath): Promise<void> {
     await this.trackOwnWrite(path, { isDelete: true });
     await this.#adapter.remove(path);
     await this.#searchIndex.update(this.paths.fileURL(path), {
@@ -533,10 +580,15 @@ export class Realm {
   }
 
   private async upsertCardSource(request: Request): Promise<Response> {
-    let { lastModified } = await this.write(
-      this.paths.local(request.url),
-      await request.text(),
-    );
+    let deferred = new Deferred<WriteResult>();
+    this.#operationQueue.push({
+      type: 'write',
+      path: this.paths.local(request.url),
+      contents: await request.text(),
+      deferred,
+    });
+    this.drainOperations();
+    let { lastModified } = await deferred.promise;
     return createResponse(this.url, null, {
       status: 204,
       headers: { 'last-modified': formatRFC7231(lastModified) },
@@ -573,7 +625,14 @@ export class Realm {
     if (!handle) {
       return notFound(this.url, request, `${localName} not found`);
     }
-    await this.delete(handle.path);
+    let deferred = new Deferred<void>();
+    this.#operationQueue.push({
+      type: 'delete',
+      path: handle.path,
+      deferred,
+    });
+    this.drainOperations();
+    await deferred.promise;
     return createResponse(this.url, null, { status: 204 });
   }
 
@@ -694,9 +753,11 @@ export class Realm {
     let pathname = `${dirName}${++index}.json`;
     let fileURL = this.paths.fileURL(pathname);
     let localPath: LocalPath = this.paths.local(fileURL);
-    let { lastModified } = await this.write(
-      localPath,
-      JSON.stringify(
+    let deferred = new Deferred<WriteResult>();
+    this.#operationQueue.push({
+      type: 'write',
+      path: localPath,
+      contents: JSON.stringify(
         await this.fileSerialization(
           merge(json, { data: { meta: { realmURL: this.url } } }),
           fileURL,
@@ -704,7 +765,11 @@ export class Realm {
         null,
         2,
       ),
-    );
+
+      deferred,
+    });
+    this.drainOperations();
+    let { lastModified } = await deferred.promise;
     let newURL = fileURL.href.replace(/\.json$/, '');
     let entry = await this.#searchIndex.card(new URL(newURL), {
       loadLinks: true,
@@ -786,9 +851,11 @@ export class Realm {
 
     delete (card as any).data.id; // don't write the ID to the file
     let path: LocalPath = `${localPath}.json`;
-    let { lastModified } = await this.write(
+    let deferred = new Deferred<WriteResult>();
+    this.#operationQueue.push({
+      type: 'write',
       path,
-      JSON.stringify(
+      contents: JSON.stringify(
         await this.fileSerialization(
           merge(card, { data: { meta: { realmURL: this.url } } }),
           url,
@@ -796,7 +863,10 @@ export class Realm {
         null,
         2,
       ),
-    );
+      deferred,
+    });
+    this.drainOperations();
+    let { lastModified } = await deferred.promise;
     let instanceURL = url.href.replace(/\.json$/, '');
     let entry = await this.#searchIndex.card(new URL(instanceURL), {
       loadLinks: true,
@@ -866,8 +936,15 @@ export class Realm {
     if (!result) {
       return notFound(this.url, request);
     }
-    let localPath = this.paths.local(url) + '.json';
-    await this.delete(localPath);
+    let path = this.paths.local(url) + '.json';
+    let deferred = new Deferred<void>();
+    this.#operationQueue.push({
+      type: 'delete',
+      path,
+      deferred,
+    });
+    this.drainOperations();
+    await deferred.promise;
     return createResponse(this.url, null, { status: 204 });
   }
 


### PR DESCRIPTION
One of the issues we were encountering (cs-6179) came down to the realm not being able to handle concurrent mutations to the index effectively. essentially the async index operations would clobber one another and one of the operations would "lose". This is a rather unique challenge that we have because we are not using a system that has transactional control to manage our server state (like postgres). I updated our `Realm` to create a queue of operations and process them one at a time. This code can be removed when we switch to using a pg based index

Also, I saw that we were using a node-ism in our `Realm` module which is supposed to be isomorphic. The node code actually was not even necessary so i removed it.