### PR TITLE
host: Fix recent files truncation test flakiness

### DIFF
--- a/packages/host/tests/acceptance/code-submode/recent-files-test.ts
+++ b/packages/host/tests/acceptance/code-submode/recent-files-test.ts
@@ -428,10 +428,15 @@ module('Acceptance | code submode | recent files tests', function (hooks) {
 
     await percySnapshot(assert);
 
-    assert.dom('[data-test-recent-file]').exists({ count: 99 });
+    assert
+      .dom('[data-test-recent-file]:nth-child(1)')
+      .containsText('file-0.txt');
+
+    assert
+      .dom('[data-test-recent-file]:nth-child(99)')
+      .containsText('file-98.txt');
 
     await click('[data-test-file="index.json"]');
-    assert.dom('[data-test-recent-file]').exists({ count: 100 });
 
     assert
       .dom('[data-test-recent-file]:nth-child(1)')


### PR DESCRIPTION
This changes to assert first- and last-rendered recent file instead of length, which was behaving differently in isolation.

I was able to reliably reproduce the flakiness by running with this regex test filter, after this change the flakiness disappeared: `http://localhost:4200/tests?filter=%2Frecent%20files%2F`