### PR TITLE
Add highlight to monaco based upon selection of LHS

### DIFF
--- a/packages/host/app/components/operator-mode/code-mode.gts
+++ b/packages/host/app/components/operator-mode/code-mode.gts
@@ -792,6 +792,7 @@ export default class CodeMode extends Component<Signature> {
                       contentChanged=(perform this.contentChangedTask)
                       monacoSDK=this.monacoSDK
                       language=this.language
+                      selectedDeclaration=this.selectedDeclaration
                     }}
                   ></div>
                 {{/if}}

--- a/packages/host/app/components/operator-mode/code-mode.gts
+++ b/packages/host/app/components/operator-mode/code-mode.gts
@@ -895,6 +895,10 @@ export default class CodeMode extends Component<Signature> {
         );
       }
 
+      :global(.custom-monaco-highlight) {
+        background-color: var(--boxel-200);
+      }
+
       .code-mode {
         height: 100%;
         max-height: 100vh;

--- a/packages/host/app/modifiers/monaco.ts
+++ b/packages/host/app/modifiers/monaco.ts
@@ -32,6 +32,7 @@ export default class Monaco extends Modifier<Signature> {
   private editor: MonacoSDK.editor.IStandaloneCodeEditor | undefined;
   private lastLanguage: string | undefined;
   private lastContent: string | undefined;
+  private decorationIds: string[] = [];
 
   modify(
     element: HTMLElement,
@@ -58,7 +59,21 @@ export default class Monaco extends Modifier<Signature> {
       if (loc) {
         let { start, end } = loc;
         let range = new Range(start.line, start.column, end.line, end.column);
-        this.editor!.setSelection(range);
+        if (this.decorationIds.length > 0) {
+          this.editor!.deltaDecorations(this.decorationIds, []);
+        }
+        this.decorationIds = this.editor!.deltaDecorations(
+          [],
+          [
+            {
+              range,
+              options: {
+                className: 'custom-monaco-highlight',
+              },
+            },
+          ],
+        );
+        console.log(this.decorationIds);
       }
     } else {
       let editorOptions: MonacoSDK.editor.IStandaloneEditorConstructionOptions =


### PR DESCRIPTION
This PR just covers one-sided highlighting -- click declaration on LHS and code is highlighted. I used --boxel-200 (a light gray) so the highlights are not jarring

Currently, these are decorator highlights , meaning the highlights will remain while you focus or edit the file. If we want the highlights to go away, we might want to consider using selection. Opinions?

https://github.com/cardstack/boxel/assets/8165111/63510655-9c4d-45fb-8280-8145d46c3fbb

