### PR TITLE
Trigger a host preview deploy when boxel-ui changes too

### DIFF
--- a/.github/workflows/pr-boxel-host.yml
+++ b/.github/workflows/pr-boxel-host.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           files: |
             packages/host/**
+            packages/boxel-ui/**
 
   deploy-host-preview-staging:
     name: Deploy a boxel-host staging preview to S3


### PR DESCRIPTION
This is a suggestion to deploy a PR preview also when boxel-ui changes.

Context: I was trying to test this PR https://github.com/cardstack/boxel/pull/763 (which only has a boxel-ui change) in a preview link but I discovered there was no deployed preview. I think it makes sense to deploy a host preview in this case too. 