### PR TITLE
Highlight active file in base realm

### DIFF
--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -16,6 +16,7 @@ import { RealmPaths } from '@cardstack/runtime-common/paths';
 import { Submode } from '@cardstack/host/components/submode-switcher';
 import { file, isReady, FileResource } from '@cardstack/host/resources/file';
 import { maybe } from '@cardstack/host/resources/maybe';
+import type LoaderService from '@cardstack/host/services/loader-service';
 import type MessageService from '@cardstack/host/services/message-service';
 import type RealmInfoService from '@cardstack/host/services/realm-info-service';
 import type RecentFilesService from '@cardstack/host/services/recent-files-service';
@@ -83,6 +84,7 @@ export default class OperatorModeStateService extends Service {
   private cachedRealmURL: URL | null = null;
 
   @service declare cardService: CardService;
+  @service declare loaderService: LoaderService;
   @service declare messageService: MessageService;
   @service declare recentFilesService: RecentFilesService;
   @service declare realmInfoService: RealmInfoService;
@@ -232,11 +234,12 @@ export default class OperatorModeStateService extends Service {
 
   get codePathRelativeToRealm() {
     if (this.state.codePath && this.realmURL) {
-      let realmPath = new RealmPaths(this.realmURL);
+      let resolvedRealmURL = this.loaderService.loader.resolve(this.realmURL);
+      let resolvedRealmPath = new RealmPaths(resolvedRealmURL);
 
-      if (realmPath.inRealm(this.state.codePath)) {
+      if (resolvedRealmPath.inRealm(this.state.codePath)) {
         try {
-          return realmPath.local(this.state.codePath!);
+          return resolvedRealmPath.local(this.state.codePath!);
         } catch (err: any) {
           if (err.status === 404) {
             return undefined;

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -233,13 +233,12 @@ export default class OperatorModeStateService extends Service {
   }
 
   get codePathRelativeToRealm() {
-    if (this.state.codePath && this.realmURL) {
-      let resolvedRealmURL = this.loaderService.loader.resolve(this.realmURL);
-      let resolvedRealmPath = new RealmPaths(resolvedRealmURL);
+    if (this.state.codePath && this.resolvedRealmURL) {
+      let realmPath = new RealmPaths(this.resolvedRealmURL);
 
-      if (resolvedRealmPath.inRealm(this.state.codePath)) {
+      if (realmPath.inRealm(this.state.codePath)) {
         try {
-          return resolvedRealmPath.local(this.state.codePath!);
+          return realmPath.local(this.state.codePath!);
         } catch (err: any) {
           if (err.status === 404) {
             return undefined;
@@ -516,6 +515,10 @@ export default class OperatorModeStateService extends Service {
     }
 
     return this.cardService.defaultURL;
+  }
+
+  get resolvedRealmURL() {
+    return this.loaderService.loader.resolve(this.realmURL);
   }
 
   subscribeToOpenFileStateChanges(subscriber: OpenFileSubscriber) {

--- a/packages/host/app/services/recent-files-service.ts
+++ b/packages/host/app/services/recent-files-service.ts
@@ -44,7 +44,7 @@ export default class RecentFilesService extends Service {
   }
 
   addRecentFileUrl(url: string) {
-    let realmURL = this.operatorModeStateService.realmURL;
+    let realmURL = this.operatorModeStateService.resolvedRealmURL;
 
     if (realmURL) {
       let realmPaths = new RealmPaths(new URL(realmURL));

--- a/packages/host/tests/acceptance/code-submode/file-tree-test.ts
+++ b/packages/host/tests/acceptance/code-submode/file-tree-test.ts
@@ -2,7 +2,6 @@ import {
   visit,
   click,
   waitFor,
-  waitUntil,
   find,
   fillIn,
   triggerKeyEvent,
@@ -648,12 +647,7 @@ module('Acceptance | code submode tests', function (hooks) {
     await waitFor('[data-test-file="cards-grid.gts"]');
 
     await click('[data-test-file="cards-grid.gts"]');
-    await waitUntil(
-      () =>
-        document
-          .querySelector(`[data-test-file="cards-grid.gts"]`)
-          ?.className.includes('selected'),
-    );
+    await waitFor('[data-test-file="cards-grid.gts"].selected');
     assert.dom('[data-test-file="cards-grid.gts"]').hasClass('selected');
   });
 });

--- a/packages/host/tests/acceptance/code-submode/file-tree-test.ts
+++ b/packages/host/tests/acceptance/code-submode/file-tree-test.ts
@@ -2,6 +2,7 @@ import {
   visit,
   click,
   waitFor,
+  waitUntil,
   find,
   fillIn,
   triggerKeyEvent,
@@ -591,6 +592,39 @@ module('Acceptance | code submode tests', function (hooks) {
       await elementIsVisible(fileToOpenElement),
       'expected near-bottom file to be visible after opening it',
     );
+  });
+
+  test('can open files in base realm', async function (assert) {
+    let codeModeStateParam = stringify({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}Person/1`,
+            format: 'isolated',
+          },
+        ],
+      ],
+      submode: 'code',
+      fileView: 'browser',
+      codePath: `http://localhost:4201/base/cards-grid.gts`,
+    })!;
+
+    await visit(
+      `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+        codeModeStateParam,
+      )}`,
+    );
+
+    await waitFor('[data-test-file="cards-grid.gts"]');
+
+    await click('[data-test-file="cards-grid.gts"]');
+    await waitUntil(
+      () =>
+        document
+          .querySelector(`[data-test-file="cards-grid.gts"]`)
+          ?.className.includes('selected'),
+    );
+    assert.dom('[data-test-file="cards-grid.gts"]').hasClass('selected');
   });
 });
 

--- a/packages/host/tests/acceptance/code-submode/recent-files-test.ts
+++ b/packages/host/tests/acceptance/code-submode/recent-files-test.ts
@@ -2,7 +2,6 @@ import {
   visit,
   click,
   waitFor,
-  waitUntil,
   fillIn,
   triggerKeyEvent,
 } from '@ember/test-helpers';
@@ -557,12 +556,7 @@ module('Acceptance | code submode | recent files tests', function (hooks) {
 
     await waitFor('[data-test-file="field-component.gts"]');
     await click('[data-test-file="field-component.gts"]');
-    await waitUntil(
-      () =>
-        document
-          .querySelector(`[data-test-file="field-component.gts"]`)
-          ?.className.includes('selected'),
-    );
+    await waitFor('[data-test-file="field-component.gts"].selected');
     assert
       .dom('[data-test-recent-file]:nth-child(1)')
       .containsText('field-component.gts');

--- a/packages/host/tests/acceptance/code-submode/recent-files-test.ts
+++ b/packages/host/tests/acceptance/code-submode/recent-files-test.ts
@@ -2,6 +2,7 @@ import {
   visit,
   click,
   waitFor,
+  waitUntil,
   fillIn,
   triggerKeyEvent,
 } from '@ember/test-helpers';
@@ -508,5 +509,77 @@ module('Acceptance | code submode | recent files tests', function (hooks) {
     assert
       .dom(`[data-test-recent-file]:first-child`)
       .containsText('person.gts');
+  });
+
+  test('displays recent files in base realm', async function (assert) {
+    window.localStorage.setItem(
+      'recent-files',
+      JSON.stringify([
+        ['https://cardstack.com/base/', 'code-ref.gts'],
+        ['https://cardstack.com/base/', 'catalog-entry.gts'],
+        'a-non-url-to-ignore',
+      ]),
+    );
+
+    let codeModeStateParam = stringify({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}Person/1`,
+            format: 'isolated',
+          },
+        ],
+      ],
+      submode: 'code',
+      codePath: `http://localhost:4201/base/code-ref.gts`,
+      fileView: 'browser',
+      openDirs: {},
+    })!;
+
+    await visit(
+      `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+        codeModeStateParam,
+      )}`,
+    );
+    await waitFor('[data-test-file]');
+    await waitFor('[data-test-directory]');
+
+    assert.dom('[data-test-recent-file]').exists({ count: 2 });
+
+    assert
+      .dom('[data-test-recent-file]:nth-child(1) [data-test-realm-icon-url]')
+      .hasAttribute('src', 'https://i.postimg.cc/d0B9qMvy/icon.png')
+      .hasAttribute('alt', 'Icon for realm Base Workspace');
+
+    assert
+      .dom('[data-test-recent-file]:nth-child(2) [data-test-realm-icon-url]')
+      .hasAttribute('src', 'https://i.postimg.cc/d0B9qMvy/icon.png');
+
+    await waitFor('[data-test-file="field-component.gts"]');
+    await click('[data-test-file="field-component.gts"]');
+    await waitUntil(
+      () =>
+        document
+          .querySelector(`[data-test-file="field-component.gts"]`)
+          ?.className.includes('selected'),
+    );
+    assert
+      .dom('[data-test-recent-file]:nth-child(1)')
+      .containsText('field-component.gts');
+    assert
+      .dom('[data-test-recent-file]:nth-child(2)')
+      .containsText('code-ref.gts');
+    assert
+      .dom('[data-test-recent-file]:nth-child(3)')
+      .containsText('catalog-entry.gts');
+
+    assert.deepEqual(
+      JSON.parse(window.localStorage.getItem('recent-files') || '[]'),
+      [
+        ['https://cardstack.com/base/', 'field-component.gts'],
+        ['https://cardstack.com/base/', 'code-ref.gts'],
+        ['https://cardstack.com/base/', 'catalog-entry.gts'],
+      ],
+    );
   });
 });


### PR DESCRIPTION
Fixes the issue where the active file in the base realm wasn't highlighted (Ticket: CS-6188). The problem was due to a mismatch between the realm URL returned by the base realm (`https://cardstack.com/base`) and the URL used in the code path (`http://localhost:4201/base`). Resolved using `Loader.resolve()`.