### PR TITLE
Improved Index card deserialization error handling

### DIFF
--- a/packages/drafts-realm/chain.gts
+++ b/packages/drafts-realm/chain.gts
@@ -24,11 +24,17 @@ export class Chain extends CardDef {
   @field name = contains(StringCard); // dropdown
   @field chainId = contains(NumberCard, {
     computeVia: function (this: Chain) {
+      if (!this.name) {
+        return;
+      }
       return CHAIN_IDS[this.name];
     },
   });
   @field blockExplorer = contains(StringCard, {
     computeVia: function (this: Chain) {
+      if (!this.name) {
+        return;
+      }
       return BLOCK_EXPLORER_URLS[CHAIN_IDS[this.name]];
     },
   });

--- a/packages/drafts-realm/transaction.gts
+++ b/packages/drafts-realm/transaction.gts
@@ -28,11 +28,17 @@ export class Transaction extends CardDef {
   @field effectiveGasPrice = contains(BigIntegerCard);
   @field blockExplorerLink = contains(StringCard, {
     computeVia: function (this: Transaction) {
+      if (!this.chain) {
+        return;
+      }
       return `${this.chain.blockExplorer}/tx/${this.transactionHash}`;
     },
   });
   @field title = contains(StringCard, {
     computeVia: function (this: Transaction) {
+      if (!this.transactionHash) {
+        return;
+      }
       return `Txn ${this.transactionHash}`;
     },
   });

--- a/packages/host/app/components/card-error.gts
+++ b/packages/host/app/components/card-error.gts
@@ -1,23 +1,29 @@
+import { eq } from '@cardstack/boxel-ui/helpers';
 import Component from '@glimmer/component';
 
 interface Signature {
   Args: {
-    isIndexCard: boolean;
+    type: 'index' | 'stack' | 'card';
     message: any;
+    operatorModeState?: string;
   };
 }
 
 export default class CardError extends Component<Signature> {
   <template>
     <div data-card-error class='container'>
-      {{#if @isIndexCard}}
+      {{#if (eq @type 'index')}}
         <b>Cannot load index card.</b>
+      {{else if (eq @type 'stack')}}
+        <b>Cannot load stack.</b>
       {{else}}
         <b>Cannot load card.</b>
       {{/if}}
-      <pre class='error'>
-        {{@message}}
-      </pre>
+      <pre class='error'>{{@message}}</pre>
+
+      {{#if @operatorModeState}}
+        <pre class='error'>Operator mode state: {{@operatorModeState}}</pre>
+      {{/if}}
     </div>
     <style>
       .container {

--- a/packages/host/app/routes/card.gts
+++ b/packages/host/app/routes/card.gts
@@ -85,7 +85,12 @@ export default class RenderCard extends Route<Model | null> {
 
       return model;
     } catch (e) {
-      (e as any).failureLoadingIndexCard = url.href === ownRealmURL;
+      (e as any).loadType = params.operatorModeEnabled
+        ? 'stack'
+        : url.href === ownRealmURL
+        ? 'index'
+        : 'card';
+      (e as any).operatorModeState = params.operatorModeState;
       throw e;
     }
   }

--- a/packages/host/app/templates/card-error.hbs
+++ b/packages/host/app/templates/card-error.hbs
@@ -1,6 +1,8 @@
 <CardError
-  @isIndexCard={{this.model.failureLoadingIndexCard}}
+  @type={{this.model.loadType}}
   @message={{this.model.message}}
+  @operatorModeState={{this.model.operatorModeState}}
+
 />
 
 <Editor::CodeLink />

--- a/packages/host/tests/acceptance/operator-mode-test.ts
+++ b/packages/host/tests/acceptance/operator-mode-test.ts
@@ -167,6 +167,47 @@ module('Acceptance | operator mode tests', function (hooks) {
           }
         }
       `,
+      'boom-field.gts': `
+        import {
+          FieldDef,
+          Component,
+          primitive,
+          deserialize,
+          BaseDefConstructor,
+          BaseInstanceType,
+        } from 'https://cardstack.com/base/card-api';
+
+        export class BoomField extends FieldDef {
+          static [primitive]: string;
+          static async [deserialize]<T extends BaseDefConstructor>(
+            this: T,
+            value: any,
+          ): Promise<BaseInstanceType<T>> {
+            throw new Error('Boom!');
+          }
+          static embedded = class Embedded extends Component<typeof this> {
+            <template>
+              {{@model}}
+            </template>
+          };
+        }
+      `,
+      'boom-person.gts': `
+        import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
+        import StringCard from "https://cardstack.com/base/string";
+        import { BoomField } from "./boom-field";
+
+        export class BoomPerson extends CardDef {
+          static displayName = 'Boom Person';
+          @field firstName = contains(StringCard);
+          @field boom = contains(BoomField);
+          @field title = contains(StringCard, {
+            computeVia: function (this: BoomPerson) {
+              return this.firstName;
+            },
+          });
+        }
+      `,
       'README.txt': `Hello World`,
       'person-entry.json': {
         data: {
@@ -242,6 +283,19 @@ module('Acceptance | operator mode tests', function (hooks) {
           },
         },
       },
+      'boom.json': {
+        data: {
+          attributes: {
+            firstName: 'Boom!',
+          },
+          meta: {
+            adoptsFrom: {
+              module: './boom-person',
+              name: 'BoomPerson',
+            },
+          },
+        },
+      },
       'grid.json': {
         data: {
           type: 'card',
@@ -307,6 +361,20 @@ module('Acceptance | operator mode tests', function (hooks) {
     assert.dom('[data-test-stack-card-index="0"]').exists(); // Index card opens in the stack
 
     await waitFor(`[data-test-cards-grid-item="${testRealmURL}Pet/mango"]`);
+    assert
+      .dom(`[data-test-cards-grid-item="${testRealmURL}Pet/mango"]`)
+      .exists();
+    assert
+      .dom(`[data-test-cards-grid-item="${testRealmURL}Pet/vangogh"]`)
+      .exists();
+    assert
+      .dom(`[data-test-cards-grid-item="${testRealmURL}Person/fadhlan"]`)
+      .exists();
+    // this asserts that cards that throw errors during search
+    // query deserialization (boom.json) are handled gracefully
+    assert
+      .dom(`[data-test-cards-grid-item="${testRealmURL}boom"]`)
+      .doesNotExist('card with deserialization errors is skipped');
     await percySnapshot(assert);
 
     assert.operatorModeParametersMatch(currentURL(), {


### PR DESCRIPTION
This addresses ticket CS-6164. The issue was ultimately about empty field handling in the Transaction and Chain draft cards. But as part of this I also added tests for errors encountered during search result deserialization (which wasn't broken--but it wasn't tested), as well as implementing a TODO item to concurrently deserialize search results. as well as some more precise error description on our card error route.