### PR TITLE
host: Fix overlapping double icons in pill

### DIFF
--- a/packages/host/app/components/operator-mode/card-schema-editor.gts
+++ b/packages/host/app/components/operator-mode/card-schema-editor.gts
@@ -147,7 +147,7 @@ export default class CardSchemaEditor extends Component<Signature> {
         align-items: center;
         height: 20px;
 
-        margin-right: var(--boxel-sp-xxxs);
+        margin-right: var(--boxel-sp-xxxxxs);
       }
 
       .field-name {

--- a/packages/host/app/components/pill.gts
+++ b/packages/host/app/components/pill.gts
@@ -5,8 +5,8 @@ export interface PillSignature {
     inert?: boolean;
   };
   Blocks: {
-    icon: [];
     default: [];
+    icon: [];
   };
   Element: HTMLButtonElement | HTMLDivElement;
 }
@@ -54,7 +54,6 @@ export default class Pill extends Component<PillSignature> {
         margin-block: 0;
         margin-inline: 0;
         margin-right: var(--boxel-sp-xxxxxs);
-        width: 20px;
         height: 20px;
       }
     </style>

--- a/packages/host/app/components/pill.gts
+++ b/packages/host/app/components/pill.gts
@@ -54,6 +54,9 @@ export default class Pill extends Component<PillSignature> {
         margin-block: 0;
         margin-inline: 0;
         margin-right: var(--boxel-sp-xxxxxs);
+      }
+
+      .icon > :deep(*) {
         height: 20px;
       }
     </style>


### PR DESCRIPTION
This was an oversight in #748, see it [in situ](https://hostpill-double-icon-cs-6117.boxel-host-preview.stack.cards/?operatorModeEnabled=true&operatorModeState=%7B%22codePath%22%3A%22https%3A%2F%2Frealms-staging.stack.cards%2Fdrafts%2Ftransaction.gts%22%2C%22codeSelection%22%3A%7B%22codeRef%22%3A%7B%22module%22%3A%22https%3A%2F%2Fcardstack.com%2Fbase%2Fcards-grid%22%2C%22name%22%3A%22CardsGrid%22%7D%7D%2C%22fileView%22%3A%22browser%22%2C%22openDirs%22%3A%7B%22https%3A%2F%2Frealms-staging.stack.cards%2Fdrafts%2F%22%3A%5B%22Transaction%2F%22%5D%7D%2C%22stacks%22%3A%5B%5B%7B%22format%22%3A%22isolated%22%2C%22id%22%3A%22https%3A%2F%2Frealms-staging.stack.cards%2Fdrafts%2Findex%22%7D%5D%5D%2C%22submode%22%3A%22code%22%7D). It also adds an interface sorting autofix.

Before:

![image](https://github.com/cardstack/boxel/assets/43280/981be301-856a-4ec0-b95a-cf9259cce5b3)

After:

<img width="146" alt="Boxel 2023-10-30 16-30-34" src="https://github.com/cardstack/boxel/assets/43280/588616d0-28c9-4704-a293-72098a4e9fdd">

The failing `host` test is unrelated, document in 6201.
