### PR TITLE
Can open recent card when stack is empty

### DIFF
--- a/packages/host/app/components/card-catalog/modal.gts
+++ b/packages/host/app/components/card-catalog/modal.gts
@@ -64,7 +64,7 @@ type Request = {
   search: Search;
   deferred: Deferred<CardDef | undefined>;
   opts?: {
-    offerToCreate?: { ref: CodeRef, relativeTo: URL | undefined };
+    offerToCreate?: { ref: CodeRef; relativeTo: URL | undefined };
     createNewCard?: CreateNewCard;
   };
 };
@@ -136,7 +136,7 @@ export default class CardCatalogModal extends Component<Signature> {
                   class='create-new-button'
                   {{on
                     'click'
-                    (fn 
+                    (fn
                       this.createNew
                       this.state.request.opts.offerToCreate.ref
                       this.state.request.opts.offerToCreate.relativeTo
@@ -304,7 +304,10 @@ export default class CardCatalogModal extends Component<Signature> {
   private _chooseCard = task(
     async <T extends CardDef>(
       query: Query,
-      opts: { offerToCreate?: { ref: CodeRef; relativeTo: URL | undefined }; multiSelect?: boolean } = {},
+      opts: {
+        offerToCreate?: { ref: CodeRef; relativeTo: URL | undefined };
+        multiSelect?: boolean;
+      } = {},
     ) => {
       this.stateId++;
       let title = chooseCardTitle(query.filter, opts?.multiSelect);
@@ -369,12 +372,12 @@ export default class CardCatalogModal extends Component<Signature> {
     }
     let results: RealmCards[] = [];
     for (let { url, realmInfo, cards } of this.displayedRealms) {
-      let filteredCards = cards.filter((c) =>
-        c.title
-          .trim()
+      let filteredCards = cards.filter((c) => {
+        return c.title
+          ?.trim()
           .toLowerCase()
-          .includes(this.state.searchKey.trim().toLowerCase()),
-      );
+          .includes(this.state.searchKey.trim().toLowerCase());
+      });
       if (filteredCards.length) {
         results.push({
           url,
@@ -416,23 +419,32 @@ export default class CardCatalogModal extends Component<Signature> {
     this.createNewTask.perform(ref, relativeTo);
   }
 
-  createNewTask = task(async (ref: CodeRef, relativeTo: URL | undefined /* this should be the catalog entry ID */) => {
-    let newCard;
-    this.state.dismissModal = true;
+  createNewTask = task(
+    async (
+      ref: CodeRef,
+      relativeTo: URL | undefined /* this should be the catalog entry ID */,
+    ) => {
+      let newCard;
+      this.state.dismissModal = true;
 
-    // We need to store the current state in a variable
-    // because there is a possibility that in createNewCard,
-    // users will open the card catalog modal and insert a new state into the stack.
-    let currentState = this.state;
-    if (this.state.request.opts?.createNewCard) {
-      newCard = await this.state.request.opts?.createNewCard(ref, relativeTo, {
-        isLinkedCard: true,
-      });
-    } else {
-      newCard = await createNewCard(ref, relativeTo);
-    }
-    this.pick(newCard, currentState);
-  });
+      // We need to store the current state in a variable
+      // because there is a possibility that in createNewCard,
+      // users will open the card catalog modal and insert a new state into the stack.
+      let currentState = this.state;
+      if (this.state.request.opts?.createNewCard) {
+        newCard = await this.state.request.opts?.createNewCard(
+          ref,
+          relativeTo,
+          {
+            isLinkedCard: true,
+          },
+        );
+      } else {
+        newCard = await createNewCard(ref, relativeTo);
+      }
+      this.pick(newCard, currentState);
+    },
+  );
 }
 
 function chooseCardTitle(

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -661,7 +661,10 @@ export default class OperatorModeContainer extends Component<Signature> {
       let stackIndex = numberOfStacks - 1;
       let stack: Stack | undefined;
 
-      if (numberOfStacks === 0) {
+      if (
+        numberOfStacks === 0 ||
+        this.operatorModeStateService.stackIsEmpty(stackIndex)
+      ) {
         this.operatorModeStateService.addItemToStack({
           format: 'isolated',
           stackIndex: 0,

--- a/packages/host/tests/acceptance/interact-submode-test.ts
+++ b/packages/host/tests/acceptance/interact-submode-test.ts
@@ -347,6 +347,49 @@ module('Acceptance | interact submode tests', function (hooks) {
         .doesNotExist();
       assert.dom('[data-test-search-input] input').hasValue('');
     });
+
+    test('Can open a recent card in empty stack', async function (assert) {
+      let operatorModeStateParam = stringify({ stacks: [] })!;
+
+      await visit(
+        `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+          operatorModeStateParam,
+        )}`,
+      );
+
+      await waitFor('[data-test-add-card-button]');
+      await click('[data-test-add-card-button]');
+
+      await waitFor('[data-test-url-field]');
+      await fillIn('[data-test-url-field] input', `${testRealmURL}index`);
+
+      await waitFor('[data-test-card-catalog-go-button][disabled]', {
+        count: 0,
+      });
+      await click('[data-test-card-catalog-go-button]');
+      await waitFor(`[data-test-stack-card="${testRealmURL}index"]`);
+
+      assert
+        .dom(`[data-test-stack-card="${testRealmURL}index"]`)
+        .containsText('Test Workspace B');
+
+      await click(
+        `[data-test-stack-card="${testRealmURL}index"] [data-test-close-button]`,
+      );
+      await waitFor(`[data-test-stack-card="${testRealmURL}index"]`, {
+        count: 0,
+      });
+      assert.dom('[data-test-add-card-button]').exists('stack is empty');
+
+      await click('[data-test-search-input] input');
+      assert.dom('[data-test-search-sheet]').hasClass('prompt');
+
+      await waitFor(`[data-test-search-result="${testRealmURL}index"]`);
+      await click(`[data-test-search-result="${testRealmURL}index"]`);
+
+      await waitFor(`[data-test-stack-card="${testRealmURL}index"]`);
+      assert.dom(`[data-test-stack-card="${testRealmURL}index"]`).exists();
+    });
   });
 
   module('1 stack', function () {


### PR DESCRIPTION
Investigating [CS-6174] further revealed that no card can be opened from the bottom Recent Cards menu in interact submode. Checking for empty stack resolved the issue. 