### PR TITLE
ui: Fix direction of resize arrow when collapsed

### DIFF
--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
@@ -247,16 +247,19 @@ export default class Panel extends Component<Signature> {
 
     let toward: string | null = null;
 
+    let isFirstPanel = this.id === 1;
+    let isCollapsed = this.panelContext?.length === '0px';
+
+    let nextPanelIsLast = this.args.isLastPanel(this.id + 1);
+    let nextPanelIsCollapsed =
+      this.args.panelContext(this.id + 1)?.length === '0px';
+
     if (
-      (this.id === 1 && this.panelContext?.length !== '0px') ||
-      (this.args.isLastPanel(this.id + 1) &&
-        this.args.panelContext(this.id + 1)?.length === '0px')
+      (isFirstPanel && !isCollapsed) ||
+      (nextPanelIsLast && nextPanelIsCollapsed)
     ) {
       toward = reverse ? 'end' : 'beginning';
-    } else if (
-      this.args.isLastPanel(this.id + 1) ||
-      (this.id === 1 && this.panelContext?.length === '0px')
-    ) {
+    } else if (nextPanelIsLast || (isFirstPanel && isCollapsed)) {
       toward = reverse ? 'beginning' : 'end';
     }
 

--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
@@ -254,13 +254,18 @@ export default class Panel extends Component<Signature> {
     let nextPanelIsCollapsed =
       this.args.panelContext(this.id + 1)?.length === '0px';
 
-    if (
-      (isFirstPanel && !isCollapsed) ||
-      (nextPanelIsLast && nextPanelIsCollapsed)
-    ) {
-      toward = reverse ? 'end' : 'beginning';
+    if (isFirstPanel && !isCollapsed) {
+      if (nextPanelIsLast && nextPanelIsCollapsed) {
+        toward = reverse ? 'beginning' : 'end';
+      } else {
+        toward = reverse ? 'end' : 'beginning';
+      }
     } else if (nextPanelIsLast || (isFirstPanel && isCollapsed)) {
-      toward = reverse ? 'beginning' : 'end';
+      if (nextPanelIsCollapsed) {
+        toward = 'beginning';
+      } else {
+        toward = reverse ? 'beginning' : 'end';
+      }
     }
 
     if (toward) {

--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
@@ -249,13 +249,12 @@ export default class Panel extends Component<Signature> {
 
     if (
       (this.id === 1 && this.panelContext?.length !== '0px') ||
-      (this.id &&
-        this.args.isLastPanel(this.id + 1) &&
+      (this.args.isLastPanel(this.id + 1) &&
         this.args.panelContext(this.id + 1)?.length === '0px')
     ) {
       toward = reverse ? 'end' : 'beginning';
     } else if (
-      (this.id && this.args.isLastPanel(this.id + 1)) ||
+      this.args.isLastPanel(this.id + 1) ||
       (this.id === 1 && this.panelContext?.length === '0px')
     ) {
       toward = reverse ? 'beginning' : 'end';


### PR DESCRIPTION
This was a known bug in #727, the arrow was not pointing upward when the recent files panel was collapsed:

![screencast 2023-10-20 11-57-37](https://github.com/cardstack/boxel/assets/43280/7b120524-a2a6-4741-ab29-5bd5c38290f3)

This renames conditional components for clarity and fixes the bug:

![screencast 2023-10-27 15-43-19](https://github.com/cardstack/boxel/assets/43280/872c4ef3-11d1-42ef-9a1c-1bdbe573ccae)