### PR TITLE
Display default cursor on modal

### DIFF
--- a/packages/boxel-ui/addon/src/components/modal/index.gts
+++ b/packages/boxel-ui/addon/src/components/modal/index.gts
@@ -150,6 +150,7 @@ export default class Modal extends Component<Signature> {
       :global(.boxel-modal__inner > *) {
         width: 100%;
         pointer-events: auto;
+        cursor: default;
       }
     </style>
   </template>


### PR DESCRIPTION
This was for the text cursor that appears when hovering over realm name in the url bar in code submode. I noticed that it happens in a couple of other places as well. This change fixes it. Special cursors (pointers etc) still work where needed.