### PR TITLE
Tool tip for less ambiguous name in schema editor

### DIFF
--- a/packages/boxel-ui/addon/src/components/tooltip/index.gts
+++ b/packages/boxel-ui/addon/src/components/tooltip/index.gts
@@ -46,7 +46,7 @@ export default class Tooltip extends Component<Signature> {
       </div>
       {{#if this.isHoverOnTrigger}}
         {{! @glint-ignore velcro.loop }}
-        <div class='tooltip' {{velcro.loop}}>
+        <div class='tooltip' {{velcro.loop}} data-test-tooltip-content>
           {{yield to='content'}}
         </div>
       {{/if}}

--- a/packages/host/app/components/operator-mode/card-adoption-chain.gts
+++ b/packages/host/app/components/operator-mode/card-adoption-chain.gts
@@ -21,7 +21,10 @@ interface Signature {
     file: Ready;
     cardInheritanceChain: CardInheritance[];
     moduleSyntax: ModuleSyntax;
-    openDefinition: (moduleHref: string, codeRef: ResolvedCodeRef) => void;
+    openDefinition: (
+      moduleHref: string,
+      codeRef: ResolvedCodeRef | undefined,
+    ) => void;
   };
 }
 

--- a/packages/host/app/components/operator-mode/card-schema-editor.gts
+++ b/packages/host/app/components/operator-mode/card-schema-editor.gts
@@ -55,7 +55,10 @@ interface Signature {
     allowAddingFields: boolean;
     childFields: string[];
     parentFields: string[];
-    openDefinition: (moduleHref: string, codeRef: ResolvedCodeRef) => void;
+    openDefinition: (
+      moduleHref: string,
+      codeRef: ResolvedCodeRef | undefined,
+    ) => void;
   };
 }
 
@@ -293,7 +296,9 @@ export default class CardSchemaEditor extends Component<Signature> {
             </:trigger>
             <:content>
               {{@cardType.module}}
-              ({{codeRef.name}})
+              {{#if codeRef.name}}
+                ({{codeRef.name}})
+              {{/if}}
             </:content>
           </Tooltip>
           <div class='total-fields' data-test-total-fields>
@@ -395,7 +400,9 @@ export default class CardSchemaEditor extends Component<Signature> {
                         </:trigger>
                         <:content>
                           {{moduleUrl}}
-                          ({{codeRef.name}})
+                          {{#if codeRef.name}}
+                            ({{codeRef.name}})
+                          {{/if}}
                         </:content>
                       </Tooltip>
                       <DropdownButton

--- a/packages/host/app/components/operator-mode/card-schema-editor.gts
+++ b/packages/host/app/components/operator-mode/card-schema-editor.gts
@@ -6,7 +6,7 @@ import Component from '@glimmer/component';
 
 import { tracked } from '@glimmer/tracking';
 
-import { DropdownButton } from '@cardstack/boxel-ui/components';
+import { DropdownButton, Tooltip } from '@cardstack/boxel-ui/components';
 import { gt, menuDivider, menuItem } from '@cardstack/boxel-ui/helpers';
 
 import {
@@ -270,24 +270,32 @@ export default class CardSchemaEditor extends Component<Signature> {
     >
       {{#let (getCodeRef @cardType) as |codeRef|}}
         <div class='header'>
-          <Pill
-            {{on 'click' (fn @openDefinition @cardType.module codeRef)}}
-            data-test-card-schema-navigational-button
-          >
-            <:icon>
-              <RealmInfoProvider @fileURL={{@cardType.module}}>
-                <:ready as |realmInfo|>
-                  <RealmIcon
-                    @realmIconURL={{realmInfo.iconURL}}
-                    @realmName={{realmInfo.name}}
-                  />
-                </:ready>
-              </RealmInfoProvider>
-            </:icon>
-            <:default>
-              {{@cardType.displayName}}
-            </:default>
-          </Pill>
+          <Tooltip @placement='top'>
+            <:trigger>
+              <Pill
+                {{on 'click' (fn @openDefinition @cardType.module codeRef)}}
+                data-test-card-schema-navigational-button
+              >
+                <:icon>
+                  <RealmInfoProvider @fileURL={{@cardType.module}}>
+                    <:ready as |realmInfo|>
+                      <RealmIcon
+                        @realmIconURL={{realmInfo.iconURL}}
+                        @realmName={{realmInfo.name}}
+                      />
+                    </:ready>
+                  </RealmInfoProvider>
+                </:icon>
+                <:default>
+                  {{@cardType.displayName}}
+                </:default>
+              </Pill>
+            </:trigger>
+            <:content>
+              {{@cardType.module}}
+              ({{codeRef.name}})
+            </:content>
+          </Tooltip>
           <div class='total-fields' data-test-total-fields>
             {{#if (gt this.totalOwnFields 0)}}
               <span class='total-fields-value'>+ {{this.totalOwnFields}}</span>
@@ -349,36 +357,47 @@ export default class CardSchemaEditor extends Component<Signature> {
                           /></span></button>
 
                     {{else}}
-                      <Pill
-                        {{on 'click' (fn @openDefinition moduleUrl codeRef)}}
-                        data-test-card-schema-field-navigational-button
-                      >
-                        <:icon>
-                          {{#if (this.isLinkedField field)}}
-                            <span class='linked-icon' data-test-linked-icon>
-                              <IconLink width='16px' height='16px' />
-                            </span>
-                          {{/if}}
-                          <RealmInfoProvider @fileURL={{moduleUrl}}>
-                            <:ready as |realmInfo|>
-                              <RealmIcon
-                                @realmIconURL={{realmInfo.iconURL}}
-                                @realmName={{realmInfo.name}}
-                              />
-                            </:ready>
-                          </RealmInfoProvider>
-                        </:icon>
-                        <:default>
-                          {{#let
-                            (this.fieldCardDisplayName field.card)
-                            as |cardDisplayName|
-                          }}
-                            <span
-                              data-test-card-display-name={{cardDisplayName}}
-                            >{{cardDisplayName}}</span>
-                          {{/let}}
-                        </:default>
-                      </Pill>
+                      <Tooltip @placement='top'>
+                        <:trigger>
+                          <Pill
+                            {{on
+                              'click'
+                              (fn @openDefinition moduleUrl codeRef)
+                            }}
+                            data-test-card-schema-field-navigational-button
+                          >
+                            <:icon>
+                              {{#if (this.isLinkedField field)}}
+                                <span class='linked-icon' data-test-linked-icon>
+                                  <IconLink width='16px' height='16px' />
+                                </span>
+                              {{/if}}
+                              <RealmInfoProvider @fileURL={{moduleUrl}}>
+                                <:ready as |realmInfo|>
+                                  <RealmIcon
+                                    @realmIconURL={{realmInfo.iconURL}}
+                                    @realmName={{realmInfo.name}}
+                                  />
+                                </:ready>
+                              </RealmInfoProvider>
+                            </:icon>
+                            <:default>
+                              {{#let
+                                (this.fieldCardDisplayName field.card)
+                                as |cardDisplayName|
+                              }}
+                                <span
+                                  data-test-card-display-name={{cardDisplayName}}
+                                >{{cardDisplayName}}</span>
+                              {{/let}}
+                            </:default>
+                          </Pill>
+                        </:trigger>
+                        <:content>
+                          {{moduleUrl}}
+                          ({{codeRef.name}})
+                        </:content>
+                      </Tooltip>
                       <DropdownButton
                         @icon={{ThreeDotsHorizontal}}
                         @label='field options'

--- a/packages/host/app/components/operator-mode/card-schema-editor.gts
+++ b/packages/host/app/components/operator-mode/card-schema-editor.gts
@@ -270,7 +270,7 @@ export default class CardSchemaEditor extends Component<Signature> {
     >
       {{#let (getCodeRef @cardType) as |codeRef|}}
         <div class='header'>
-          <Tooltip @placement='top'>
+          <Tooltip @placement='bottom'>
             <:trigger>
               <Pill
                 {{on 'click' (fn @openDefinition @cardType.module codeRef)}}
@@ -357,7 +357,7 @@ export default class CardSchemaEditor extends Component<Signature> {
                           /></span></button>
 
                     {{else}}
-                      <Tooltip @placement='top'>
+                      <Tooltip @placement='bottom'>
                         <:trigger>
                           <Pill
                             {{on

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -478,8 +478,10 @@ export default class CodeSubmode extends Component<Signature> {
   }
 
   @action
-  openDefinition(moduleHref: string, codeRef: ResolvedCodeRef) {
-    this.operatorModeStateService.updateCodeRefSelection(codeRef);
+  openDefinition(moduleHref: string, codeRef: ResolvedCodeRef | undefined) {
+    if (codeRef) {
+      this.operatorModeStateService.updateCodeRefSelection(codeRef);
+    }
     this.operatorModeStateService.updateCodePath(new URL(moduleHref));
   }
 

--- a/packages/host/app/components/operator-mode/definition-container/clickable.gts
+++ b/packages/host/app/components/operator-mode/definition-container/clickable.gts
@@ -4,7 +4,10 @@ import Component from '@glimmer/component';
 import { type ResolvedCodeRef } from '@cardstack/runtime-common/code-ref';
 
 export interface ClickableArgs {
-  openDefinition: (moduleHref: string, codeRef: ResolvedCodeRef) => void;
+  openDefinition: (
+    moduleHref: string,
+    codeRef: ResolvedCodeRef | undefined,
+  ) => void;
   moduleHref: string;
   codeRef?: ResolvedCodeRef;
 }

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -69,7 +69,10 @@ interface Signature {
     selectedDeclaration?: ModuleDeclaration;
     declarations: ModuleDeclaration[];
     selectDeclaration: (dec: ModuleDeclaration) => void;
-    openDefinition: (moduleHref: string, codeRef: ResolvedCodeRef) => void;
+    openDefinition: (
+      moduleHref: string,
+      codeRef: ResolvedCodeRef | undefined,
+    ) => void;
     delete: (
       card: CardDef | typeof CardDef | undefined,
     ) => void | Promise<void>;

--- a/packages/host/app/components/operator-mode/schema-editor-column.gts
+++ b/packages/host/app/components/operator-mode/schema-editor-column.gts
@@ -32,7 +32,10 @@ interface Signature {
     file: Ready;
     cardTypeResource?: CardType;
     card: typeof BaseDef;
-    openDefinition: (moduleHref: string, codeRef: ResolvedCodeRef) => void;
+    openDefinition: (
+      moduleHref: string,
+      codeRef: ResolvedCodeRef | undefined,
+    ) => void;
   };
 }
 

--- a/packages/host/app/resources/card-type.ts
+++ b/packages/host/app/resources/card-type.ts
@@ -221,16 +221,10 @@ export function getCodeRef(t: Type | FieldOfType): ResolvedCodeRef {
     codeRef = t.codeRef;
   }
   if (!isResolvedCodeRef(codeRef)) {
-    // handle base case
     if (codeRef.type === 'ancestorOf') {
-      if (
-        codeRef.card.module === 'https://cardstack.com/base/card-api' &&
-        codeRef.card.name === 'CardDef'
-      ) {
-        return {
-          module: codeRef.card.module,
-          name: 'BaseDef',
-        };
+      let parentCard = codeRef.card;
+      if (isResolvedCodeRef(parentCard)) {
+        return parentCard;
       }
     }
     throw new Error('codeRef is not resolved fully');

--- a/packages/host/app/resources/card-type.ts
+++ b/packages/host/app/resources/card-type.ts
@@ -213,7 +213,7 @@ export function isFieldOfType(obj: any): obj is FieldOfType {
   return obj && 'card' in obj;
 }
 
-export function getCodeRef(t: Type | FieldOfType): ResolvedCodeRef {
+export function getCodeRef(t: Type | FieldOfType): ResolvedCodeRef | undefined {
   let codeRef: CodeRef;
   if (isFieldOfType(t)) {
     codeRef = isCodeRefType(t.card) ? t.card : t.card.codeRef;
@@ -221,13 +221,7 @@ export function getCodeRef(t: Type | FieldOfType): ResolvedCodeRef {
     codeRef = t.codeRef;
   }
   if (!isResolvedCodeRef(codeRef)) {
-    if (codeRef.type === 'ancestorOf') {
-      let parentCard = codeRef.card;
-      if (isResolvedCodeRef(parentCard)) {
-        return parentCard;
-      }
-    }
-    throw new Error('codeRef is not resolved fully');
+    return undefined;
   }
   return codeRef;
 }

--- a/packages/host/app/resources/card-type.ts
+++ b/packages/host/app/resources/card-type.ts
@@ -221,6 +221,18 @@ export function getCodeRef(t: Type | FieldOfType): ResolvedCodeRef {
     codeRef = t.codeRef;
   }
   if (!isResolvedCodeRef(codeRef)) {
+    // handle base case
+    if (codeRef.type === 'ancestorOf') {
+      if (
+        codeRef.card.module === 'https://cardstack.com/base/card-api' &&
+        codeRef.card.name === 'CardDef'
+      ) {
+        return {
+          module: codeRef.card.module,
+          name: 'BaseDef',
+        };
+      }
+    }
     throw new Error('codeRef is not resolved fully');
   }
   return codeRef;

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -585,10 +585,10 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
       'ExportedClass class',
       'ExportedClassInheritLocalClass class',
       'exportedFunction function',
-      'LocalCard card', //TODO: CS-6009 will probably change this
+      'LocalCard card',
       'ExportedCard card',
       'ExportedCardInheritLocalCard card',
-      'LocalField field', //TODO: CS-6009 will probably change this
+      'LocalField field',
       'ExportedField field',
       'ExportedFieldInheritLocalField field',
       'default (DefaultClass) class',

--- a/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
@@ -547,9 +547,8 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
       '[data-test-card-schema="Employee"] [data-test-field-name="department"] [data-test-card-display-name="String"]',
     );
 
-    // TODO: CS-6110
-    // await waitFor('[data-test-current-module-name="string.ts"]');
-    // assert.dom('[data-test-current-module-name]').hasText('string.ts');
+    await waitFor('[data-test-current-module-name="card-api.gts"]');
+    assert.dom('[data-test-current-module-name]').hasText('card-api.gts');
   });
 
   test<TestContextWithSSE>('adding a field from schema editor - whole flow test', async function (assert) {

--- a/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
@@ -1,4 +1,10 @@
-import { visit, click, waitFor, fillIn } from '@ember/test-helpers';
+import {
+  visit,
+  click,
+  waitFor,
+  fillIn,
+  triggerEvent,
+} from '@ember/test-helpers';
 
 import { setupApplicationTest } from 'ember-qunit';
 import window from 'ember-window-mock';
@@ -180,6 +186,29 @@ const friendCardSource = `
   }
 `;
 
+const ambiguousDisplayNamesCardSource = `
+  import {
+    CardDef,
+    field,
+    linksTo,
+    Component,
+  } from 'https://cardstack.com/base/card-api';
+
+  export class Editor extends CardDef {
+    static displayName = 'Author Bio';
+  }
+
+  export class Author extends CardDef {
+    static displayName = 'Author Bio';
+  }
+
+  export class BlogPost extends CardDef {
+    static displayName = 'Blog Post';
+    @field authorBio = linksTo(Author);
+    @field editorBio = linksTo(Editor);
+  }
+`;
+
 module('Acceptance | code submode | schema editor tests', function (hooks) {
   let realm: Realm;
   let adapter: TestRealmAdapter;
@@ -220,6 +249,7 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
       'friend.gts': friendCardSource,
       'employee.gts': employeeCardSource,
       'in-this-file.gts': inThisFileSource,
+      'ambiguous-display-names.gts': ambiguousDisplayNamesCardSource,
       'person-entry.json': {
         data: {
           type: 'card',
@@ -797,5 +827,99 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
         `[data-test-card-schema="Person"] [data-test-field-name="firstName"]`,
       )
       .doesNotExist();
+  });
+
+  test('tooltip is displayed when hovering over a pill', async function (assert) {
+    let operatorModeStateParam = stringify({
+      stacks: [],
+      submode: 'code',
+      codePath: `${testRealmURL}ambiguous-display-names.gts`,
+    })!;
+
+    await visit(
+      `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+        operatorModeStateParam,
+      )}`,
+    );
+    await waitFor(`[data-test-boxel-selector-item-text="BlogPost"]`);
+    await click(`[data-test-boxel-selector-item-text="BlogPost"]`);
+
+    // hover over card type pill
+    await waitFor(
+      '[data-test-card-schema="Blog Post"] [data-test-card-schema-navigational-button]',
+    );
+    await triggerEvent(
+      '[data-test-card-schema="Blog Post"] [data-test-card-schema-navigational-button]',
+      'mouseenter',
+    );
+
+    await waitFor(
+      '[data-test-card-schema="Blog Post"] [data-test-tooltip-content]',
+    );
+    assert
+      .dom('[data-test-card-schema="Blog Post"] [data-test-tooltip-content]')
+      .hasText('http://test-realm/test/ambiguous-display-names (BlogPost)');
+    await triggerEvent(
+      '[data-test-card-schema="Blog Post"] [data-test-card-schema-navigational-button]',
+      'mouseleave',
+    );
+    // hover over card type pill (Base)
+    await waitFor(
+      '[data-test-card-schema="Base"] [data-test-card-schema-navigational-button]',
+    );
+    await triggerEvent(
+      '[data-test-card-schema="Base"] [data-test-card-schema-navigational-button]',
+      'mouseenter',
+    );
+    await waitFor('[data-test-card-schema="Base"] [data-test-tooltip-content]');
+    assert
+      .dom('[data-test-card-schema="Base"] [data-test-tooltip-content]')
+      .hasText('https://cardstack.com/base/card-api');
+
+    await triggerEvent(
+      '[data-test-card-schema="Base"] [data-test-card-schema-navigational-button]',
+      'mouseleave',
+    );
+
+    // hover over authorBio and editorBio -- tooltip should be different altho they have same display names
+    await waitFor(
+      '[data-test-card-schema="Blog Post"] [data-test-field-name="authorBio"] [data-test-card-display-name="Author Bio"]',
+    );
+    await triggerEvent(
+      '[data-test-card-schema="Blog Post"] [data-test-field-name="authorBio"] [data-test-card-display-name="Author Bio"]',
+      'mouseenter',
+    );
+    await waitFor(
+      '[data-test-card-schema="Blog Post"] [data-test-field-name="authorBio"] [data-test-tooltip-content]',
+    );
+    assert
+      .dom(
+        '[data-test-card-schema="Blog Post"] [data-test-field-name="authorBio"] [data-test-tooltip-content]',
+      )
+      .hasText('http://test-realm/test/ambiguous-display-names (Author)'); //shows Author
+    await triggerEvent(
+      '[data-test-card-schema="Blog Post"] [data-test-field-name="authorBio"] [data-test-card-display-name="Author Bio"]',
+      'mouseleave',
+    );
+
+    await waitFor(
+      '[data-test-card-schema="Blog Post"] [data-test-field-name="editorBio"] [data-test-card-display-name="Author Bio"]',
+    );
+    await triggerEvent(
+      '[data-test-card-schema="Blog Post"] [data-test-field-name="editorBio"] [data-test-card-display-name="Author Bio"]',
+      'mouseenter',
+    );
+    await waitFor(
+      '[data-test-card-schema="Blog Post"] [data-test-field-name="editorBio"] [data-test-tooltip-content]',
+    );
+    assert
+      .dom(
+        '[data-test-card-schema="Blog Post"] [data-test-field-name="editorBio"] [data-test-tooltip-content]',
+      )
+      .hasText('http://test-realm/test/ambiguous-display-names (Editor)'); //shows Editor
+    await triggerEvent(
+      '[data-test-card-schema="Blog Post"] [data-test-field-name="editorBio"] [data-test-card-display-name="Author Bio"]',
+      'mouseleave',
+    );
   });
 });


### PR DESCRIPTION
https://github.com/cardstack/boxel/assets/8165111/07d36d69-2b9d-4b84-a400-349a9d83c50d


I put the placement of tool tip at the bottom bcos it looks better

When codeRef is available 

![Screenshot 2023-10-31 at 9 01 10 PM](https://github.com/cardstack/boxel/assets/8165111/d76f55cc-bbcd-46b8-afb8-961b960058de)


When codeRef is unavailable 

![Screenshot 2023-10-31 at 9 00 04 PM](https://github.com/cardstack/boxel/assets/8165111/f583fad2-7292-492a-9e4c-0bd8ca06069d)


