### PR TITLE
Fix vertical alignment of folders and files in FileTree - also tighten up spacing between entries by 2px

### DIFF
--- a/packages/host/app/components/editor/directory.gts
+++ b/packages/host/app/components/editor/directory.gts
@@ -77,7 +77,6 @@ export default class Directory extends Component<Args> {
         --icon-margin: 4px;
 
         padding-left: 0em;
-        margin-bottom: 2px;
       }
 
       .level .level {
@@ -112,7 +111,6 @@ export default class Directory extends Component<Args> {
       .directory :deep(.icon) {
         width: var(--icon-length);
         height: var(--icon-length);
-        margin-right: var(--icon-margin);
         margin-bottom: -4px;
       }
 


### PR DESCRIPTION
Before:
![image](https://github.com/cardstack/boxel/assets/353/48760f7a-db60-49d3-b8c1-0669b6c88aa9)

After:
<img width="357" alt="vertical-alignment" src="https://github.com/cardstack/boxel/assets/353/45de6b94-93c8-4353-8ca8-c305159b8f58">
