### PR TITLE
host: Add radius transition for submode animation

### DIFF
--- a/packages/host/app/components/submode-switcher.gts
+++ b/packages/host/app/components/submode-switcher.gts
@@ -99,10 +99,21 @@ export default class SubmodeSwitcher extends Component<Signature> {
         width: var(--submode-switcher-width);
         height: var(--submode-switcher-height);
         gap: var(--boxel-sp-sm);
+
+        transition:
+          border-bottom-right-radius var(--boxel-transition),
+          border-bottom-left-radius var(--boxel-transition);
       }
+
       .submode-switcher-dropdown-trigger[aria-expanded='true'] {
         border-bottom-right-radius: 0;
         border-bottom-left-radius: 0;
+
+        transition:
+          border-bottom-right-radius var(--boxel-transition)
+            var(--boxel-transition),
+          border-bottom-left-radius var(--boxel-transition)
+            var(--boxel-transition);
       }
       .arrow-icon {
         margin-left: auto;


### PR DESCRIPTION
This improves the appearance of the bottom corners of the dropdown trigger as the dropdown opens and closes. Here’s how it looked before, you can see when focusing on the lower right of the trigger that it becomes rounded as soon as the closure begins, which looks weird:

![screencast 2023-10-31 15-40-13](https://github.com/cardstack/boxel/assets/43280/0bb5937d-0c6f-4680-95b7-e951ab0ee0ee)

This smooths it out a bit:

![screencast 2023-10-31 15-37-58](https://github.com/cardstack/boxel/assets/43280/cace2bcb-401b-4932-af24-22b6064d91b3)
