### PR TITLE
Fix and some test coverage for ResizablePanelGroup

### DIFF
--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
@@ -1,5 +1,6 @@
 import { on } from '@ember/modifier';
 import { scheduleOnce } from '@ember/runloop';
+import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
@@ -7,23 +8,26 @@ import cssVars from '../../helpers/css-var.ts';
 import { eq } from '../../helpers/truth-helpers.ts';
 
 export type PanelContext = {
-  defaultLength: string;
-  length: string;
-  minLength?: string;
+  defaultLengthFraction?: number;
+  lengthPx: number;
+  minLengthPx?: number;
 };
 
 interface Signature {
   Args: {
-    defaultLength: string;
+    defaultLengthFraction: number;
     hideHandle: boolean;
     isLastPanel: (panelId: number) => boolean;
-    length?: string;
-    minLength?: string;
+    lengthPx?: number;
+    minLengthPx?: number;
     onResizeHandlerDblClick: (event: MouseEvent) => void;
     onResizeHandlerMouseDown: (event: MouseEvent) => void;
     orientation: 'horizontal' | 'vertical';
     panelContext: (panelId: number) => PanelContext | undefined;
-    registerPanel: (context: PanelContext) => number;
+    registerPanel: (context: {
+      defaultLengthFraction: number | undefined;
+      lengthPx: number | undefined;
+    }) => number;
     reverseHandlerArrow: boolean;
   };
   Blocks: {
@@ -40,16 +44,12 @@ export default class Panel extends Component<Signature> {
       style={{if
         (eq @orientation 'horizontal')
         (cssVars
-          boxel-panel-width=this.panelContext.length
-          boxel-panel-min-width=(if
-            this.panelContext.minLength this.panelContext.minLength @minLength
-          )
+          boxel-panel-width=this.lengthCssValue
+          boxel-panel-min-width=this.minLengthCssValue
         )
         (cssVars
-          boxel-panel-height=this.panelContext.length
-          boxel-panel-min-height=(if
-            this.panelContext.minLength this.panelContext.minLength @minLength
-          )
+          boxel-panel-height=this.lengthCssValue
+          boxel-panel-min-height=this.minLengthCssValue
         )
       }}
     >
@@ -61,6 +61,7 @@ export default class Panel extends Component<Signature> {
           id={{this.resizeHandlerId}}
           class='resize-handler {{@orientation}} {{if @hideHandle "hidden"}}'
           aria-label={{this.resizeHandlerId}}
+          data-test-resize-handler={{this.resizeHandlerId}}
           {{on 'mousedown' @onResizeHandlerMouseDown}}
           {{on 'dblclick' @onResizeHandlerDblClick}}
         ><div class={{this.arrowResizeHandlerClass}} /></button>
@@ -227,24 +228,46 @@ export default class Panel extends Component<Signature> {
 
   private registerPanel() {
     this.id = this.args.registerPanel({
-      length: this.args.length ?? this.args.defaultLength,
-      defaultLength: this.args.defaultLength,
+      lengthPx: this.args.lengthPx,
+      defaultLengthFraction: this.args.defaultLengthFraction,
     });
   }
 
   get panelContext() {
     if (!this.id) {
       return {
-        length: this.args.defaultLength,
-        defaultLength: this.args.defaultLength,
-        minLength: undefined,
+        lengthPx: undefined,
+        defaultLengthFraction: this.args.defaultLengthFraction,
+        minLengthPx: undefined,
       };
     }
     return this.args.panelContext(this.id);
   }
 
+  get minLengthCssValue() {
+    if (this.panelContext?.minLengthPx !== undefined) {
+      return htmlSafe(`${this.panelContext.minLengthPx}px`);
+    } else if (this.args.minLengthPx !== undefined) {
+      return htmlSafe(`${this.args.minLengthPx}px`);
+    }
+    return undefined;
+  }
+
+  get lengthCssValue() {
+    let lengthPx = this.panelContext?.lengthPx;
+    let defaultLengthFraction = this.panelContext?.defaultLengthFraction;
+    if (lengthPx === -1 && defaultLengthFraction) {
+      return htmlSafe(`${defaultLengthFraction * 100}%`);
+    } else if (lengthPx !== -1 && lengthPx !== undefined) {
+      return htmlSafe(`${lengthPx}px`);
+    }
+    return undefined;
+  }
+
   get resizeHandlerId() {
-    return `resize-handler-${this.args.orientation}-${this.id}`;
+    let { id } = this;
+    let { orientation } = this.args;
+    return `resize-handler-${orientation}-${id}`;
   }
 
   get isLastPanel() {
@@ -262,11 +285,11 @@ export default class Panel extends Component<Signature> {
     let toward: string | null = null;
 
     let isFirstPanel = this.id === 1;
-    let isCollapsed = this.panelContext?.length === '0px';
+    let isCollapsed = this.panelContext?.lengthPx === 0;
 
     let nextPanelIsLast = this.args.isLastPanel(this.id + 1);
     let nextPanelIsCollapsed =
-      this.args.panelContext(this.id + 1)?.length === '0px';
+      this.args.panelContext(this.id + 1)?.lengthPx === 0;
 
     if (isFirstPanel && !isCollapsed) {
       if (nextPanelIsLast && nextPanelIsCollapsed) {

--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/usage.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/usage.gts
@@ -11,22 +11,22 @@ import cssVar from '../../helpers/css-var.ts';
 import ResizablePanelGroup from './index.gts';
 
 export default class ResizablePanelUsage extends Component {
-  @tracked horizontalPanel1DefaultWidth = '25%';
-  @tracked horizontalPanel1MinWidth = 'none';
+  @tracked horizontalPanel1DefaultWidthFraction = 0.25;
+  @tracked horizontalPanel1MinWidthPx = undefined;
 
-  @tracked horizontalPanel2DefaultWidth = '50%';
-  @tracked horizontalPanel2MinWidth = 'none';
+  @tracked horizontalPanel2DefaultWidthFraction = 0.5;
+  @tracked horizontalPanel2MinWidthPx = undefined;
 
-  @tracked horizontalPanel3DefaultWidth = '25%';
-  @tracked horizontalPanel3MinWidth = 'none';
+  @tracked horizontalPanel3DefaultWidthFraction = 0.25;
+  @tracked horizontalPanel3MinWidthPx = undefined;
 
   @tracked verticalReverseCollapse = true;
 
-  @tracked verticalPanel1DefaultHeight = '33%';
-  @tracked verticalPanel1MinHeight = 'none';
+  @tracked verticalPanel1DefaultHeightFraction = 0.33;
+  @tracked verticalPanel1MinHeightPx = undefined;
 
-  @tracked verticalPanel2DefaultHeight = '67%';
-  @tracked verticalPanel2MinHeight = 'none';
+  @tracked verticalPanel2DefaultHeightFraction = 0.67;
+  @tracked verticalPanel2MinHeightPx = undefined;
 
   cssClassName = 'boxel-panel';
   @cssVariable declare boxelPanelResizeHandlerHeight: CSSVariableInfo;
@@ -40,8 +40,8 @@ export default class ResizablePanelUsage extends Component {
       <:example>
         <ResizablePanelGroup @orientation='horizontal' as |ResizablePanel|>
           <ResizablePanel
-            @defaultLength={{this.horizontalPanel1DefaultWidth}}
-            @minLength={{this.horizontalPanel1MinWidth}}
+            @defaultLengthFraction={{this.horizontalPanel1DefaultWidthFraction}}
+            @minLengthPx={{this.horizontalPanel1MinWidthPx}}
             style={{cssVar
               boxel-panel-resize-handler-height=this.boxelPanelResizeHandlerHeight.value
               boxel-panel-resize-handler-background-color=this.boxelPanelResizeHandlerBackgroundColor.value
@@ -51,8 +51,8 @@ export default class ResizablePanelUsage extends Component {
             Panel 1
           </ResizablePanel>
           <ResizablePanel
-            @defaultLength={{this.horizontalPanel2DefaultWidth}}
-            @minLength={{this.horizontalPanel2MinWidth}}
+            @defaultLengthFraction={{this.horizontalPanel2DefaultWidthFraction}}
+            @minLengthPx={{this.horizontalPanel2MinWidthPx}}
             style={{cssVar
               boxel-panel-resize-handler-height=this.boxelPanelResizeHandlerHeight.value
               boxel-panel-resize-handler-background-color=this.boxelPanelResizeHandlerBackgroundColor.value
@@ -62,8 +62,8 @@ export default class ResizablePanelUsage extends Component {
             Panel 2
           </ResizablePanel>
           <ResizablePanel
-            @defaultLength={{this.horizontalPanel3DefaultWidth}}
-            @minLength={{this.horizontalPanel3MinWidth}}
+            @defaultLengthFraction={{this.horizontalPanel3DefaultWidthFraction}}
+            @minLengthPx={{this.horizontalPanel3MinWidthPx}}
             style={{cssVar
               boxel-panel-resize-handler-height=this.boxelPanelResizeHandlerHeight.value
               boxel-panel-resize-handler-background-color=this.boxelPanelResizeHandlerBackgroundColor.value
@@ -75,46 +75,46 @@ export default class ResizablePanelUsage extends Component {
         </ResizablePanelGroup>
       </:example>
       <:api as |Args|>
-        <Args.String
-          @name='defaultWidth - Panel 1'
+        <Args.Number
+          @name='defaultWidthFraction - Panel 1'
           @description="The default width of the panel is determined by this argument, which operates similarly to the 'width' property in CSS."
-          @value={{this.horizontalPanel1DefaultWidth}}
-          @onInput={{fn (mut this.horizontalPanel1DefaultWidth)}}
+          @value={{this.horizontalPanel1DefaultWidthFraction}}
+          @onInput={{fn (mut this.horizontalPanel1DefaultWidthFraction)}}
           @required={{true}}
         />
         <Args.String
-          @name='minWidth - Panel 1'
+          @name='minWidthPx - Panel 1'
           @description="The minimum width of the panel is determined by this argument, which operates similarly to the 'min-width' property in CSS. In double-click event, this argumen will be ingored."
-          @value={{this.horizontalPanel1MinWidth}}
-          @onInput={{fn (mut this.horizontalPanel1MinWidth)}}
+          @value={{this.horizontalPanel1MinWidthPx}}
+          @onInput={{fn (mut this.horizontalPanel1MinWidthPx)}}
           @required={{false}}
         />
         <Args.String
-          @name='defaultWidth - Panel 2'
+          @name='defaultWidthFraction - Panel 2'
           @description="The default width of the panel is determined by this argument, which operates similarly to the 'width' property in CSS."
-          @value={{this.horizontalPanel2DefaultWidth}}
-          @onInput={{fn (mut this.horizontalPanel2DefaultWidth)}}
+          @value={{this.horizontalPanel2DefaultWidthFraction}}
+          @onInput={{fn (mut this.horizontalPanel2DefaultWidthFraction)}}
           @required={{true}}
         />
         <Args.String
-          @name='minWidth - Panel 2'
+          @name='minWidthPx - Panel 2'
           @description="The minimum width of the panel is determined by this argument, which operates similarly to the 'min-width' property in CSS. In double-click event, this argumen will be ingored."
-          @value={{this.horizontalPanel2MinWidth}}
-          @onInput={{fn (mut this.horizontalPanel2MinWidth)}}
+          @value={{this.horizontalPanel2MinWidthPx}}
+          @onInput={{fn (mut this.horizontalPanel2MinWidthPx)}}
           @required={{false}}
         />
         <Args.String
-          @name='defaultWidth - Panel 3'
+          @name='defaultWidthFraction - Panel 3'
           @description="The default width of the panel is determined by this argument, which operates similarly to the 'width' property in CSS."
-          @value={{this.horizontalPanel3DefaultWidth}}
-          @onInput={{fn (mut this.horizontalPanel3DefaultWidth)}}
+          @value={{this.horizontalPanel3DefaultWidthFraction}}
+          @onInput={{fn (mut this.horizontalPanel3DefaultWidthFraction)}}
           @required={{true}}
         />
         <Args.String
-          @name='minWidth - Panel 3'
+          @name='minWidthPx - Panel 3'
           @description="The minimum width of the panel is determined by this argument, which operates similarly to the 'min-width' property in CSS. In double-click event, this argumen will be ingored."
-          @value={{this.horizontalPanel3MinWidth}}
-          @onInput={{fn (mut this.horizontalPanel3MinWidth)}}
+          @value={{this.horizontalPanel3MinWidthPx}}
+          @onInput={{fn (mut this.horizontalPanel3MinWidthPx)}}
           @required={{false}}
         />
       </:api>
@@ -156,8 +156,8 @@ export default class ResizablePanelUsage extends Component {
             as |ResizablePanel|
           >
             <ResizablePanel
-              @defaultLength={{this.verticalPanel1DefaultHeight}}
-              @minLength={{this.verticalPanel1MinHeight}}
+              @defaultLengthFraction={{this.verticalPanel1DefaultHeightFraction}}
+              @minLengthPx={{this.verticalPanel1MinHeightPx}}
               style={{cssVar
                 boxel-panel-resize-handler-width=this.boxelPanelResizeHandlerWidth.value
                 boxel-panel-resize-handler-background-color=this.boxelPanelResizeHandlerBackgroundColor.value
@@ -167,8 +167,8 @@ export default class ResizablePanelUsage extends Component {
               Panel 1
             </ResizablePanel>
             <ResizablePanel
-              @defaultLength={{this.verticalPanel2DefaultHeight}}
-              @minLength={{this.verticalPanel2MinHeight}}
+              @defaultLengthFraction={{this.verticalPanel2DefaultHeightFraction}}
+              @minLengthPx={{this.verticalPanel2MinHeightPx}}
               style={{cssVar
                 boxel-panel-resize-handler-width=this.boxelPanelResizeHandlerWidth.value
                 boxel-panel-resize-handler-background-color=this.boxelPanelResizeHandlerBackgroundColor.value
@@ -188,32 +188,32 @@ export default class ResizablePanelUsage extends Component {
           @value={{this.verticalReverseCollapse}}
           @onInput={{fn (mut this.verticalReverseCollapse)}}
         />
-        <Args.String
-          @name='defaultHeight - Panel 1'
+        <Args.Number
+          @name='defaultHeightFraction - Panel 1'
           @description="The default height of the panel is determined by this argument, which operates similarly to the 'height' property in CSS."
-          @value={{this.verticalPanel1DefaultHeight}}
-          @onInput={{fn (mut this.verticalPanel1DefaultHeight)}}
+          @value={{this.verticalPanel1DefaultHeightFraction}}
+          @onInput={{fn (mut this.verticalPanel1DefaultHeightFraction)}}
           @required={{true}}
         />
-        <Args.String
-          @name='minHeight - Panel 1'
+        <Args.Number
+          @name='minHeightPx - Panel 1'
           @description="The minimum height of the panel is determined by this argument, which operates similarly to the 'min-height' property in CSS. In double-click event, this argumen will be ingored."
-          @value={{this.verticalPanel1MinHeight}}
-          @onInput={{fn (mut this.verticalPanel1MinHeight)}}
+          @value={{this.verticalPanel1MinHeightPx}}
+          @onInput={{fn (mut this.verticalPanel1MinHeightPx)}}
           @required={{false}}
         />
-        <Args.String
-          @name='defaultHeight - Panel 2'
+        <Args.Number
+          @name='defaultHeightFraction - Panel 2'
           @description="The default height of the panel is determined by this argument, which operates similarly to the 'height' property in CSS."
-          @value={{this.verticalPanel2DefaultHeight}}
-          @onInput={{fn (mut this.verticalPanel2DefaultHeight)}}
+          @value={{this.verticalPanel2DefaultHeightFraction}}
+          @onInput={{fn (mut this.verticalPanel2DefaultHeightFraction)}}
           @required={{true}}
         />
-        <Args.String
-          @name='minHeight - Panel 2'
+        <Args.Number
+          @name='minHeightPx - Panel 2'
           @description="The minimum height of the panel is determined by this argument, which operates similarly to the 'min-height' property in CSS. In double-click event, this argumen will be ingored."
-          @value={{this.verticalPanel2MinHeight}}
-          @onInput={{fn (mut this.verticalPanel2MinHeight)}}
+          @value={{this.verticalPanel2MinHeightPx}}
+          @onInput={{fn (mut this.verticalPanel2MinHeightPx)}}
           @required={{false}}
         />
       </:api>

--- a/packages/boxel-ui/test-app/package.json
+++ b/packages/boxel-ui/test-app/package.json
@@ -72,6 +72,7 @@
     "ember-resources": "^6.3.1",
     "ember-source": "^4.12.0",
     "ember-source-channel-url": "^3.0.0",
+    "ember-template-imports": "^3.1.2",
     "ember-template-lint": "^5.7.2",
     "ember-try": "^2.0.0",
     "eslint": "^8.37.0",

--- a/packages/boxel-ui/test-app/tests/helpers/height-assertion.ts
+++ b/packages/boxel-ui/test-app/tests/helpers/height-assertion.ts
@@ -1,0 +1,62 @@
+export default function (assert: Assert) {
+  assert.hasNumericStyle = function (
+    target: string | Element | null,
+    propertyName: string,
+    expectedValue: number,
+    allowedDifference = 0,
+  ) {
+    let message =
+      `expected ${target} to have ${propertyName} ` +
+      (allowedDifference
+        ? `within ${allowedDifference} of ${expectedValue}`
+        : `of ${expectedValue}`);
+    let el: Element | null = null;
+    if (typeof target === 'string') {
+      el =
+        document.querySelector('#ember-testing')?.querySelector(target) || null;
+    } else {
+      el = target;
+    }
+    if (!el) {
+      throw new Error(`No element specified/found. Target was ${target}`);
+    }
+    let cStyle = getComputedStyle(el);
+    let actualValue = cStyle[propertyName as any];
+    let actualNumericValue: number;
+    if (typeof actualValue === 'number') {
+      actualNumericValue = actualValue;
+    } else {
+      actualNumericValue = Number(actualValue.replace(/[^0-9.]/g, ''));
+    }
+    if (Math.abs(actualNumericValue - expectedValue) <= allowedDifference) {
+      this.pushResult({
+        result: true,
+        actual: actualValue,
+        expected: allowedDifference
+          ? `within ${allowedDifference} of ${expectedValue}`
+          : expectedValue,
+        message,
+      });
+    } else {
+      this.pushResult({
+        result: false,
+        actual: actualValue,
+        expected: allowedDifference
+          ? `within ${allowedDifference} of ${expectedValue}`
+          : expectedValue,
+        message,
+      });
+    }
+  };
+}
+
+declare global {
+  interface Assert {
+    hasNumericStyle(
+      target: string | Element | null,
+      propertyName: string,
+      expectedValue: number,
+      allowedDifferencePx?: number,
+    ): void;
+  }
+}

--- a/packages/boxel-ui/test-app/tests/integration/components/resizable-panel-group-test.gts
+++ b/packages/boxel-ui/test-app/tests/integration/components/resizable-panel-group-test.gts
@@ -1,0 +1,198 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { doubleClick, render, RenderingTestContext } from '@ember/test-helpers';
+import { ResizablePanelGroup } from '@cardstack/boxel-ui/components';
+import { tracked } from '@glimmer/tracking';
+
+function sleep(ms: number) {
+  return new Promise(function (resolve) {
+    setTimeout(resolve, ms);
+  });
+}
+
+class RenderController {
+  @tracked containerStyle = '';
+  @tracked panel1LengthPx: number | undefined;
+  @tracked panel2LengthPx: number | undefined;
+  panel1InnerContentStyle: string | undefined;
+}
+
+interface MyTestContext extends RenderingTestContext {
+  renderController: RenderController;
+}
+
+module('Integration | ResizablePanelGroup', function (hooks) {
+  setupRenderingTest(hooks);
+  hooks.beforeEach(function (this: MyTestContext) {
+    this.renderController = new RenderController();
+  });
+
+  async function renderVerticalResizablePanelGroup(
+    renderController: RenderController,
+  ) {
+    await render(<template>
+      {{! template-lint-disable no-inline-styles }}
+      <div id='test-container' style={{renderController.containerStyle}}>
+        <ResizablePanelGroup
+          @orientation='vertical'
+          @reverseCollapse={{true}}
+          as |ResizablePanel|
+        >
+          <ResizablePanel
+            @defaultLengthFraction={{0.6}}
+            @lengthPx={{renderController.panel1LengthPx}}
+          >
+            <div
+              class='panel-1-content'
+              style='border: 1px solid red; height: 100%; overflow-y:auto'
+            >
+              <div style={{renderController.panel1InnerContentStyle}}>
+                Panel 1
+              </div>
+            </div>
+          </ResizablePanel>
+          <ResizablePanel
+            @defaultLengthFraction={{0.4}}
+            @minLengthPx={{50}}
+            @lengthPx={{renderController.panel2LengthPx}}
+          >
+            <div
+              class='panel-2-content'
+              style='border: 1px solid red; height: 100%;'
+            >
+              Panel 2
+            </div>
+          </ResizablePanel>
+        </ResizablePanelGroup>
+      </div>
+    </template>);
+    await sleep(100); // let didResizeModifier run
+  }
+
+  test('it can lay out panels vertically (default)', async function (this: MyTestContext, assert) {
+    this.renderController.containerStyle =
+      'max-height: 100%; width: 100px; height: 318px;';
+    await renderVerticalResizablePanelGroup(this.renderController);
+    assert.hasNumericStyle('.panel-1-content', 'height', (318 - 18) * 0.6, 1);
+    assert.hasNumericStyle('.panel-2-content', 'height', (318 - 18) * 0.4, 1);
+  });
+
+  test('it can lay out panels vertically (length specified)', async function (this: MyTestContext, assert) {
+    this.renderController.containerStyle =
+      'max-height: 100%; width: 200px; height: 518px; border: 1px solid green';
+    this.renderController.panel1LengthPx = 355;
+    this.renderController.panel2LengthPx = 143;
+    await renderVerticalResizablePanelGroup(this.renderController);
+    assert.hasNumericStyle('.panel-1-content', 'height', 355, 1);
+    assert.hasNumericStyle('.panel-2-content', 'height', 143, 1);
+  });
+
+  test('it respects vertical minLength (default)', async function (this: MyTestContext, assert) {
+    this.renderController.containerStyle =
+      'max-height: 100%; width: 200px; height: 108px;';
+    await renderVerticalResizablePanelGroup(this.renderController);
+    assert.hasNumericStyle('.panel-1-content', 'height', 40, 1);
+    assert.hasNumericStyle('.panel-2-content', 'height', 50, 1);
+  });
+
+  test('it respects vertical minLength (length specified)', async function (this: MyTestContext, assert) {
+    this.renderController.containerStyle =
+      'max-height: 100%; width: 200px; height: 108px; border: 1px solid green';
+    this.renderController.panel1LengthPx = 45;
+    this.renderController.panel2LengthPx = 45;
+    await renderVerticalResizablePanelGroup(this.renderController);
+    assert.hasNumericStyle('.panel-1-content', 'height', 40, 2);
+    assert.hasNumericStyle('.panel-2-content', 'height', 50, 2);
+  });
+
+  test('it adjusts to its container growing (default)', async function (this: MyTestContext, assert) {
+    this.renderController.containerStyle =
+      'max-height: 100%; width: 200px; height: 218px;';
+    await renderVerticalResizablePanelGroup(this.renderController);
+    this.renderController.containerStyle =
+      'max-height: 100%; width: 200px; height: 418px;';
+    await sleep(100); // let didResizeModifier run
+    assert.hasNumericStyle('.panel-1-content', 'height', 240, 1);
+    assert.hasNumericStyle('.panel-2-content', 'height', 160, 1);
+  });
+
+  test('it adjusts to its container growing (length specified)', async function (this: MyTestContext, assert) {
+    this.renderController.containerStyle =
+      'max-height: 100%; width: 200px; height: 218px; border: 1px solid green';
+    this.renderController.panel1LengthPx = 100;
+    this.renderController.panel2LengthPx = 100;
+    await renderVerticalResizablePanelGroup(this.renderController);
+    assert.hasNumericStyle('.panel-1-content', 'height', 100, 1.5);
+    assert.hasNumericStyle('.panel-2-content', 'height', 100, 1.5);
+    this.renderController.containerStyle =
+      'max-height: 100%; width: 200px; height: 418px; border: 1px solid green';
+    await sleep(100); // let didResizeModifier run
+    assert.hasNumericStyle('.panel-1-content', 'height', 200, 1.5);
+    assert.hasNumericStyle('.panel-2-content', 'height', 200, 1.5);
+  });
+
+  test('it adjusts to its container shrinking (default)', async function (this: MyTestContext, assert) {
+    this.renderController.containerStyle =
+      'max-height: 100%; width: 200px; height: 418px;';
+    await renderVerticalResizablePanelGroup(this.renderController);
+    this.renderController.containerStyle =
+      'max-height: 100%; width: 200px; height: 218px;';
+    await sleep(100); // let didResizeModifier run
+    assert.hasNumericStyle('.panel-1-content', 'height', 120, 1);
+    assert.hasNumericStyle('.panel-2-content', 'height', 80, 1);
+  });
+
+  test('it adjusts to its container shrinking (length specified A)', async function (this: MyTestContext, assert) {
+    this.renderController.containerStyle =
+      'max-height: 100%; width: 200px; height: 418px; border: 1px solid green';
+    this.renderController.panel1LengthPx = 240;
+    this.renderController.panel2LengthPx = 160;
+    await renderVerticalResizablePanelGroup(this.renderController);
+    this.renderController.containerStyle =
+      'max-height: 100%; width: 200px; height: 218px; border: 1px solid green';
+    await sleep(100); // let didResizeModifier run
+    assert.hasNumericStyle('.panel-1-content', 'height', 120, 1);
+    assert.hasNumericStyle('.panel-2-content', 'height', 80, 1);
+  });
+
+  test('it adjusts to its container shrinking (length specified B)', async function (this: MyTestContext, assert) {
+    this.renderController.containerStyle =
+      'max-height: 100%; width: 200px; height: 618px; border: 1px solid green';
+    this.renderController.panel1LengthPx = 400;
+    this.renderController.panel2LengthPx = 200;
+    this.renderController.panel1InnerContentStyle =
+      'height: 180px; background: blue';
+    await renderVerticalResizablePanelGroup(this.renderController);
+    this.renderController.containerStyle =
+      'max-height: 100%; width: 200px; height: 218px; border: 1px solid green';
+    await sleep(100); // let didResizeModifier run
+    assert.hasNumericStyle('.panel-1-content', 'height', 150, 1);
+    assert.hasNumericStyle('.panel-2-content', 'height', 50, 1);
+  });
+
+  test('it adjusts to its container shrinking and growing', async function (this: MyTestContext, assert) {
+    this.renderController.containerStyle =
+      'max-height: 100%; width: 200px; height: 618px; border: 1px solid green';
+    this.renderController.panel1LengthPx = 400;
+    this.renderController.panel2LengthPx = 200;
+    this.renderController.panel1InnerContentStyle =
+      'height: 180px; background: blue';
+    await renderVerticalResizablePanelGroup(this.renderController);
+    this.renderController.panel1LengthPx = 50;
+    this.renderController.panel2LengthPx = 550;
+    await doubleClick('[data-test-resize-handler]'); // Double-click to hide recent
+    await sleep(100); // let didResizeModifier run
+    assert.hasNumericStyle('.panel-1-content', 'height', 598, 1);
+    assert.hasNumericStyle('.panel-2-content', 'height', 2, 1);
+    this.renderController.containerStyle =
+      'max-height: 100%; width: 200px; height: 318px; border: 1px solid green'; // shrink container by ~50%
+    await sleep(100); // let didResizeModifier run
+    await doubleClick('[data-test-resize-handler]'); // Double-click to unhide recent
+    this.renderController.containerStyle =
+      'max-height: 100%; width: 200px; height: 618px; border: 1px solid green'; // increase window/container height to original height
+    await sleep(100); // let didResizeModifier run
+    // expected behavior: panel height percentages would remain consistent
+    assert.hasNumericStyle('.panel-1-content', 'height', 345, 1);
+    assert.hasNumericStyle('.panel-2-content', 'height', 253, 1);
+  });
+});

--- a/packages/boxel-ui/test-app/tests/test-helper.js
+++ b/packages/boxel-ui/test-app/tests/test-helper.js
@@ -8,10 +8,12 @@ import {
   setRunOptions,
   setupConsoleLogger,
 } from 'ember-a11y-testing/test-support';
+import setupHeightAssertion from 'test-app/tests/helpers/height-assertion';
 
 setApplication(Application.create(config.APP));
 
 setup(QUnit.assert);
+setupHeightAssertion(QUnit.assert);
 
 // https://github.com/dequelabs/axe-core/issues/3082
 // turn off the rule for aria-allowed-role for now until ember-a11y-testing is updated with bugfix from axe-core

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -98,29 +98,32 @@ const log = logger('component:code-submode');
 const { autoSaveDelayMs } = config;
 
 type PanelWidths = {
-  rightPanel: string;
-  codeEditorPanel: string;
-  leftPanel: string;
-  emptyCodeModePanel: string;
+  rightPanel: number;
+  codeEditorPanel: number;
+  leftPanel: number;
+  emptyCodeModePanel: number;
 };
 
 type PanelHeights = {
-  filePanel: string;
-  recentPanel: string;
+  filePanel: number;
+  recentPanel: number;
 };
 
 const CodeModePanelWidths = 'code-mode-panel-widths';
 const defaultPanelWidths: PanelWidths = {
-  leftPanel: 'var(--operator-mode-left-column)',
-  codeEditorPanel: '48%',
-  rightPanel: '32%',
-  emptyCodeModePanel: '80%',
+  // 14rem as a fraction of the layout width
+  leftPanel:
+    (14.0 * parseFloat(getComputedStyle(document.documentElement).fontSize)) /
+    (document.documentElement.clientWidth - 40 - 36),
+  codeEditorPanel: 0.48,
+  rightPanel: 0.32,
+  emptyCodeModePanel: 0.8,
 };
 
 const CodeModePanelHeights = 'code-mode-panel-heights';
 const defaultPanelHeights: PanelHeights = {
-  filePanel: '60%',
-  recentPanel: '40%',
+  filePanel: 0.6,
+  recentPanel: 0.4,
 };
 
 const cardEditorSaveTimes = new Map<string, number>();
@@ -169,12 +172,12 @@ export default class CodeSubmode extends Component<Signature> {
     this.panelWidths = localStorage.getItem(CodeModePanelWidths)
       ? // @ts-ignore Type 'null' is not assignable to type 'string'
         JSON.parse(localStorage.getItem(CodeModePanelWidths))
-      : defaultPanelWidths;
+      : {};
 
     this.panelHeights = localStorage.getItem(CodeModePanelHeights)
       ? // @ts-ignore Type 'null' is not assignable to type 'string'
         JSON.parse(localStorage.getItem(CodeModePanelHeights))
-      : defaultPanelHeights;
+      : {};
 
     registerDestructor(this, () => {
       // destructor functons are called synchronously. in order to save,
@@ -625,17 +628,17 @@ export default class CodeSubmode extends Component<Signature> {
 
   @action
   private onListPanelContextChange(listPanelContext: PanelContext[]) {
-    this.panelWidths.leftPanel = listPanelContext[0]?.length;
-    this.panelWidths.codeEditorPanel = listPanelContext[1]?.length;
-    this.panelWidths.rightPanel = listPanelContext[2]?.length;
+    this.panelWidths.leftPanel = listPanelContext[0]?.lengthPx;
+    this.panelWidths.codeEditorPanel = listPanelContext[1]?.lengthPx;
+    this.panelWidths.rightPanel = listPanelContext[2]?.lengthPx;
 
     localStorage.setItem(CodeModePanelWidths, JSON.stringify(this.panelWidths));
   }
 
   @action
   private onFilePanelContextChange(filePanelContext: PanelContext[]) {
-    this.panelHeights.filePanel = filePanelContext[0]?.length;
-    this.panelHeights.recentPanel = filePanelContext[1]?.length;
+    this.panelHeights.filePanel = filePanelContext[0]?.lengthPx;
+    this.panelHeights.recentPanel = filePanelContext[1]?.lengthPx;
 
     localStorage.setItem(
       CodeModePanelHeights,
@@ -754,8 +757,8 @@ export default class CodeSubmode extends Component<Signature> {
           as |ResizablePanel|
         >
           <ResizablePanel
-            @defaultLength={{defaultPanelWidths.leftPanel}}
-            @length='var(--operator-mode-left-column)'
+            @defaultLengthFraction={{defaultPanelWidths.leftPanel}}
+            @lengthPx={{this.panelWidths.leftPanel}}
           >
             <div class='column'>
               <ResizablePanelGroup
@@ -765,8 +768,8 @@ export default class CodeSubmode extends Component<Signature> {
                 as |VerticallyResizablePanel|
               >
                 <VerticallyResizablePanel
-                  @defaultLength={{defaultPanelHeights.filePanel}}
-                  @length={{this.panelHeights.filePanel}}
+                  @defaultLengthFraction={{defaultPanelHeights.filePanel}}
+                  @lengthPx={{this.panelHeights.filePanel}}
                 >
 
                   {{! Move each container and styles to separate component }}
@@ -832,9 +835,9 @@ export default class CodeSubmode extends Component<Signature> {
                   </div>
                 </VerticallyResizablePanel>
                 <VerticallyResizablePanel
-                  @defaultLength={{defaultPanelHeights.recentPanel}}
-                  @length={{this.panelHeights.recentPanel}}
-                  @minLength='100px'
+                  @defaultLengthFraction={{defaultPanelHeights.recentPanel}}
+                  @lengthPx={{this.panelHeights.recentPanel}}
+                  @minLengthPx={{100}}
                 >
                   <aside class='inner-container recent-files'>
                     <header
@@ -853,9 +856,9 @@ export default class CodeSubmode extends Component<Signature> {
           </ResizablePanel>
           {{#if this.codePath}}
             <ResizablePanel
-              @defaultLength={{defaultPanelWidths.codeEditorPanel}}
-              @length={{this.panelWidths.codeEditorPanel}}
-              @minLength='300px'
+              @defaultLengthFraction={{defaultPanelWidths.codeEditorPanel}}
+              @lengthPx={{this.panelWidths.codeEditorPanel}}
+              @minLengthPx={{300}}
             >
               <div class='inner-container'>
                 {{#if this.isReady}}
@@ -900,8 +903,8 @@ export default class CodeSubmode extends Component<Signature> {
               </div>
             </ResizablePanel>
             <ResizablePanel
-              @defaultLength={{defaultPanelWidths.rightPanel}}
-              @length={{this.panelWidths.rightPanel}}
+              @defaultLengthFraction={{defaultPanelWidths.rightPanel}}
+              @lengthPx={{this.panelWidths.rightPanel}}
             >
               <div class='inner-container'>
                 {{#if this.isLoading}}
@@ -935,8 +938,8 @@ export default class CodeSubmode extends Component<Signature> {
             </ResizablePanel>
           {{else}}
             <ResizablePanel
-              @defaultLength={{defaultPanelWidths.emptyCodeModePanel}}
-              @length={{this.panelWidths.emptyCodeModePanel}}
+              @defaultLengthFraction={{defaultPanelWidths.emptyCodeModePanel}}
+              @lengthPx={{this.panelWidths.emptyCodeModePanel}}
             >
               <div
                 class='inner-container inner-container--empty'

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -121,9 +121,11 @@ const defaultPanelWidths: PanelWidths = {
 };
 
 const CodeModePanelHeights = 'code-mode-panel-heights';
+const ApproximateRecentPanelDefaultFraction =
+  (50 + 43 * 3.5) / (document.documentElement.clientHeight - 430); // room for about 3.5 recent files
 const defaultPanelHeights: PanelHeights = {
-  filePanel: 0.6,
-  recentPanel: 0.4,
+  filePanel: 1 - ApproximateRecentPanelDefaultFraction,
+  recentPanel: ApproximateRecentPanelDefaultFraction,
 };
 
 const cardEditorSaveTimes = new Map<string, number>();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -885,7 +885,7 @@ importers:
         version: 1.2.1(typescript@5.1.6)
       '@glint/environment-ember-template-imports':
         specifier: ^1.2.1
-        version: 1.2.1(@glint/environment-ember-loose@1.2.1)(@glint/template@1.2.1)(ember-template-imports@3.4.2)
+        version: 1.2.1(@glint/environment-ember-loose@1.2.1)(@glint/template@1.2.1)(ember-template-imports@3.1.2)
       '@glint/template':
         specifier: ^1.2.1
         version: 1.2.1
@@ -979,6 +979,9 @@ importers:
       ember-source-channel-url:
         specifier: ^3.0.0
         version: 3.0.0
+      ember-template-imports:
+        specifier: ^3.1.2
+        version: 3.1.2(ember-cli-htmlbars@6.3.0)
       ember-template-lint:
         specifier: ^5.7.2
         version: 5.11.2
@@ -10153,9 +10156,9 @@ packages:
     dependencies:
       '@types/parse-json': 4.0.1
       import-fresh: 3.3.0
-      parse-json: 5.1.0
+      parse-json: 5.2.0
       path-type: 4.0.0
-      yaml: 1.10.0
+      yaml: 1.10.2
     dev: true
 
   /cosmiconfig@8.2.0:


### PR DESCRIPTION
- Fixes issue where panels were not resized smaller than their content, even if the total space available cannot accommodate it. We want it to be reduced so the layout is not broken and the developer can style an element with `overflow-y: auto` to scroll in that case.

Before:

https://github.com/cardstack/boxel/assets/353/b2ebca4a-944b-4aff-8049-312a4a204ea8

After:

https://github.com/cardstack/boxel/assets/353/4dae429c-ce76-4cf5-bf50-0e17a29dc34b

