### PR TITLE
Flush the loader on code write so that the preview or schema editor gets refreshed

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -531,7 +531,8 @@ export default class CodeSubmode extends Component<Signature> {
       throw new Error('File is not ready to be written to');
     }
 
-    return file.write(content);
+    // flush the loader so that the preview (when card instance data is shown), or schema editor (when module code is shown) gets refreshed on save
+    return file.write(content, true);
   }
 
   private safeJSONParse(content: string) {


### PR DESCRIPTION

<img width="1211" alt="image" src="https://github.com/cardstack/boxel/assets/273660/305b79f8-31b0-4d60-8ba5-c69a214b615d">

