### PR TITLE
Fix cursor position on monaco auto save

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -32,11 +32,10 @@ import type { PanelContext } from '@cardstack/boxel-ui/components';
 import { cn, and, not } from '@cardstack/boxel-ui/helpers';
 import { CheckMark, File } from '@cardstack/boxel-ui/icons';
 
-import { Deferred } from '@cardstack/runtime-common';
-
 import {
   type SingleCardDocument,
   RealmPaths,
+  Deferred,
   logger,
   isCardDocumentString,
   isSingleCardDocument,
@@ -466,7 +465,8 @@ export default class CodeSubmode extends Component<Signature> {
 
   private contentChangedTask = restartableTask(async (content: string) => {
     this.hasUnsavedSourceChanges = true;
-    await timeout(autoSaveDelayMs);
+    // note that there is already a debounce in the monaco modifier so there
+    // is no need to delay further for auto save initiation
     if (
       !isReady(this.currentOpenFile) ||
       content === this.currentOpenFile?.content

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -883,7 +883,7 @@ export default class CodeSubmode extends Component<Signature> {
                         </span>
                       </span>
                     {{else}}
-                      <span class='saved-msg'>
+                      <span data-test-saved class='saved-msg'>
                         Saved
                       </span>
                       <CheckMark width='27' height='27' />

--- a/packages/host/app/config/environment.d.ts
+++ b/packages/host/app/config/environment.d.ts
@@ -21,4 +21,6 @@ declare const config: {
   logLevels: string;
   resolvedOwnRealmURL: string;
   autoSaveDelayMs: number;
+  monacoDebounceMs: number;
+  serverEchoDebounceMs: number;
 };

--- a/packages/host/app/modifiers/monaco.ts
+++ b/packages/host/app/modifiers/monaco.ts
@@ -100,11 +100,7 @@ export default class Monaco extends Modifier<Signature> {
       });
     }
     this.lastLanguage = language;
-    if (
-      this.editor &&
-      !this.editor.hasTextFocus()
-      // Date.now() >= this.lastModified + serverEchoDebounceMs
-    ) {
+    if (this.editor && !this.editor.hasTextFocus()) {
       initializeCursorPosition?.();
     }
   }

--- a/packages/host/app/services/monaco-service.ts
+++ b/packages/host/app/services/monaco-service.ts
@@ -7,6 +7,7 @@ import merge from 'lodash/merge';
 
 import { type SingleCardDocument } from '@cardstack/runtime-common';
 
+import config from '@cardstack/host/config/environment';
 import CardService from '@cardstack/host/services/card-service';
 import {
   type MonacoLanguageConfig,
@@ -20,10 +21,14 @@ import type * as _MonacoSDK from 'monaco-editor';
 export type MonacoSDK = typeof _MonacoSDK;
 export type IStandaloneCodeEditor = _MonacoSDK.editor.IStandaloneCodeEditor;
 
+const { serverEchoDebounceMs } = config;
+
 export default class MonacoService extends Service {
   #ready: Promise<MonacoSDK>;
   @tracked editor: _MonacoSDK.editor.ICodeEditor | null = null;
   @service declare cardService: CardService;
+  // this is in the service so that we can manipulate it in our tests
+  serverEchoDebounceMs = serverEchoDebounceMs;
 
   constructor(properties: object) {
     super(properties);

--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -27,7 +27,7 @@ module.exports = function (environment) {
     matrixURL: process.env.MATRIX_URL || 'http://localhost:8008',
     autoSaveDelayMs: 500,
     monacoDebounceMs: 500,
-    serverEchoDebounceMs: 2000,
+    serverEchoDebounceMs: 5000,
 
     // the fields below may be rewritten by the realm server
     ownRealmURL:

--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -26,6 +26,8 @@ module.exports = function (environment) {
     logLevels: process.env.LOG_LEVELS || '*=info,current-run=error',
     matrixURL: process.env.MATRIX_URL || 'http://localhost:8008',
     autoSaveDelayMs: 500,
+    monacoDebounceMs: 500,
+    serverEchoDebounceMs: 2000,
 
     // the fields below may be rewritten by the realm server
     ownRealmURL:
@@ -67,6 +69,8 @@ module.exports = function (environment) {
     ENV.APP.autoboot = false;
     ENV.APP.experimentalAIEnabled = true;
     ENV.autoSaveDelayMs = 0;
+    ENV.monacoDebounceMs = 0;
+    ENV.serverEchoDebounceMs = 0;
   }
 
   if (environment === 'production') {

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -905,7 +905,7 @@ module('Acceptance | code submode tests', function (hooks) {
   test<TestContextWithSSE>('the monaco cursor position is maintained during an auto-save', async function (assert) {
     assert.expect(3);
     // we only want to change this for this particular test so we emulate what the non-test env sees
-    monacoService.serverEchoDebounceMs = 2000;
+    monacoService.serverEchoDebounceMs = 5000;
     let expectedEvents = [
       {
         type: 'index',

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -26,11 +26,13 @@ import {
   TestRealm,
   TestRealmAdapter,
   getMonacoContent,
+  setMonacoContent,
   setupLocalIndexing,
   testRealmURL,
   sourceFetchRedirectHandle,
   sourceFetchReturnUrlHandle,
   setupServerSentEvents,
+  type TestContextWithSSE,
 } from '../helpers';
 
 const indexCardSource = `
@@ -898,5 +900,64 @@ module('Acceptance | code submode tests', function (hooks) {
     assert
       .dom('[data-test-boxel-selector-item-selected]')
       .hasText(`${elementName} card`);
+  });
+
+  test<TestContextWithSSE>('the monaco cursor position is maintained during an auto-save', async function (assert) {
+    assert.expect(3);
+    // we only want to change this for this particular test so we emulate what the non-test env sees
+    monacoService.serverEchoDebounceMs = 2000;
+    let expectedEvents = [
+      {
+        type: 'index',
+        data: {
+          type: 'incremental',
+          invalidations: [`${testRealmURL}in-this-file.gts`],
+        },
+      },
+    ];
+
+    try {
+      let operatorModeStateParam = stringify({
+        stacks: [[]],
+        submode: 'code',
+        codePath: `${testRealmURL}in-this-file.gts`,
+      })!;
+
+      await visit(
+        `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+          operatorModeStateParam,
+        )}`,
+      );
+      await waitFor('[data-test-editor]');
+
+      let originalPosition: MonacoSDK.Position | undefined | null;
+      await this.expectEvents(
+        assert,
+        realm,
+        adapter,
+        expectedEvents,
+        async () => {
+          setMonacoContent(`// This is a change \n${inThisFileSource}`);
+          monacoService.updateCursorPosition(new MonacoSDK.Position(45, 0));
+          originalPosition = monacoService.getCursorPosition();
+        },
+      );
+      await waitFor('[data-test-saved]');
+      await waitFor('[data-test-save-idle]');
+      let currentPosition = monacoService.getCursorPosition();
+      assert.strictEqual(
+        originalPosition!.lineNumber,
+        currentPosition?.lineNumber,
+        'cursor position line number has not changed',
+      );
+      assert.strictEqual(
+        originalPosition!.column,
+        currentPosition?.column,
+        'cursor position column has not changed',
+      );
+    } finally {
+      // set this back correctly regardless of test outcome
+      monacoService.serverEchoDebounceMs = 0;
+    }
   });
 });

--- a/packages/host/tests/acceptance/code-submode/file-tree-test.ts
+++ b/packages/host/tests/acceptance/code-submode/file-tree-test.ts
@@ -27,7 +27,6 @@ import {
   testRealmURL,
   sourceFetchRedirectHandle,
   sourceFetchReturnUrlHandle,
-  setupServerSentEvents,
 } from '../../helpers';
 
 const indexCardSource = `
@@ -198,7 +197,6 @@ module('Acceptance | code submode tests', function (hooks) {
 
   setupApplicationTest(hooks);
   setupLocalIndexing(hooks);
-  setupServerSentEvents(hooks);
   setupWindowMock(hooks);
 
   hooks.afterEach(async function () {

--- a/packages/host/tests/acceptance/code-submode/recent-files-test.ts
+++ b/packages/host/tests/acceptance/code-submode/recent-files-test.ts
@@ -27,7 +27,6 @@ import {
   testRealmURL,
   sourceFetchRedirectHandle,
   sourceFetchReturnUrlHandle,
-  setupServerSentEvents,
 } from '../../helpers';
 
 const indexCardSource = `
@@ -191,7 +190,6 @@ module('Acceptance | code submode | recent files tests', function (hooks) {
 
   setupApplicationTest(hooks);
   setupLocalIndexing(hooks);
-  setupServerSentEvents(hooks);
   setupWindowMock(hooks);
 
   hooks.afterEach(async function () {


### PR DESCRIPTION
This was really tricky because the module contents resource runs on every module file save and as a result the getters in code mode compute a new cursor position on each save. this comes down to realizing that changes the monaco modifier receives that coincide with modifications within the monaco editor are ultimately just SSE server echoes of auto-saved monaco content. I added an SSE echo debounce to the monaco modifier and that solves this problem.

![monaco-cursor](https://github.com/cardstack/boxel/assets/61075/394f8048-1521-44ee-894e-5ddabef8fe63)
