### PR TITLE
Fix adding a new card to get started

### DIFF
--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -146,7 +146,6 @@ export default class OperatorModeContainer extends Component<Signature> {
   }
 
   <template>
-    <CardCatalogModal />
     <Modal
       class='operator-mode'
       @size='full-screen'
@@ -155,6 +154,7 @@ export default class OperatorModeContainer extends Component<Signature> {
       @isOverlayDismissalDisabled={{true}}
       @boxelModalOverlayColor='var(--operator-mode-bg-color)'
     >
+      <CardCatalogModal />
       {{#if this.isCodeMode}}
         <CodeSubmode
           @saveSourceOnClose={{perform this.saveSource}}

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -27,6 +27,7 @@ import {
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 
 import { Submodes } from '../submode-switcher';
+import CardCatalogModal from '../card-catalog/modal';
 
 import type CardService from '../../services/card-service';
 import type OperatorModeStateService from '../../services/operator-mode-state-service';
@@ -145,6 +146,7 @@ export default class OperatorModeContainer extends Component<Signature> {
   }
 
   <template>
+    <CardCatalogModal />
     <Modal
       class='operator-mode'
       @size='full-screen'

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -44,7 +44,6 @@ import CopyButton from './copy-button';
 import DeleteModal from './delete-modal';
 import OperatorModeStack from './stack';
 import SubmodeLayout from './submode-layout';
-import CardCatalogModal from '../card-catalog/modal';
 
 const waiter = buildWaiter('operator-mode:interact-submode-waiter');
 
@@ -599,7 +598,6 @@ export default class InteractSubmode extends Component<Signature> {
   }
 
   <template>
-    <CardCatalogModal />
     <SubmodeLayout
       @onSearchSheetClosed={{this.clearSearchSheetTrigger}}
       @onCardSelectFromSearch={{perform this.openSelectedSearchResultInStack}}

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -44,6 +44,7 @@ import CopyButton from './copy-button';
 import DeleteModal from './delete-modal';
 import OperatorModeStack from './stack';
 import SubmodeLayout from './submode-layout';
+import CardCatalogModal from '../card-catalog/modal';
 
 const waiter = buildWaiter('operator-mode:interact-submode-waiter');
 
@@ -598,6 +599,7 @@ export default class InteractSubmode extends Component<Signature> {
   }
 
   <template>
+    <CardCatalogModal />
     <SubmodeLayout
       @onSearchSheetClosed={{this.clearSearchSheetTrigger}}
       @onCardSelectFromSearch={{perform this.openSelectedSearchResultInStack}}

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -16,7 +16,6 @@ import { assertNever } from '@cardstack/host/utils/assert-never';
 
 import SubmodeSwitcher, { Submode, Submodes } from '../submode-switcher';
 import ChatSidebar from '../matrix/chat-sidebar';
-import CardCatalogModal from '../card-catalog/modal';
 import SearchSheet, {
   SearchSheetMode,
   SearchSheetModes,
@@ -114,8 +113,6 @@ export default class SubmodeLayout extends Component<Signature> {
   }
 
   <template>
-    <CardCatalogModal />
-
     <div class='operator-mode__with-chat {{this.chatVisibilityClass}}'>
       <SubmodeSwitcher
         @submode={{this.operatorModeStateService.state.submode}}


### PR DESCRIPTION
https://linear.app/cardstack/issue/CS-6217/add-a-card-to-get-started-button-not-working

bleurgh race condition with the globals
- interact-submode & code-submode both write to the same global `_CARDSTACK_CARD_CHOOSER`
- the destructor of the previous component runs after the setter of the new component
- the places affected adding a new card when stack is empty (interact) & adding new card when adding new field (code)

 I lifted the component that sets the global higher up 