### PR TITLE
Flaky test fixes

### DIFF
--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -1732,10 +1732,20 @@ module('Integration | operator-mode', function (hooks) {
     await waitFor(`[data-test-cards-grid-item]`);
     for (let i = 1; i <= 11; i++) {
       await click(`[data-test-cards-grid-item="${testRealmURL}Person/${i}"]`);
-      await click(`[data-test-stack-card-index="1"] [data-test-close-button]`);
+      await waitFor(
+        `[data-test-stack-card-index="1"][data-test-stack-card="${testRealmURL}Person/${i}"]`,
+      );
+      await click(
+        `[data-test-stack-card-index="1"][data-test-stack-card="${testRealmURL}Person/${i}"] [data-test-close-button]`,
+      );
+      await waitFor(
+        `[data-test-stack-card-index="1"][data-test-stack-card="${testRealmURL}Person/${i}"]`,
+        { count: 0 },
+      );
     }
 
     await focus(`[data-test-search-input] input`);
+    await waitFor(`[data-test-search-result]`);
     assert.dom(`[data-test-search-result]`).exists({ count: 10 });
   });
 

--- a/packages/host/tests/integration/realm-test.ts
+++ b/packages/host/tests/integration/realm-test.ts
@@ -438,7 +438,7 @@ module('Integration | realm', function (hooks) {
             ),
           }),
         );
-        await realm.flushOperations();
+        await Promise.all([realm.flushOperations(), realm.flushUpdateEvents()]);
 
         assert.strictEqual(
           (await response).status,
@@ -520,7 +520,7 @@ module('Integration | realm', function (hooks) {
             ),
           }),
         );
-        await realm.flushOperations();
+        await Promise.all([realm.flushOperations(), realm.flushUpdateEvents()]);
         assert.strictEqual(
           (await response).status,
           201,
@@ -767,7 +767,7 @@ module('Integration | realm', function (hooks) {
             ),
           }),
         );
-        await realm.flushOperations();
+        await Promise.all([realm.flushOperations(), realm.flushUpdateEvents()]);
         return await response;
       },
     );
@@ -2042,7 +2042,7 @@ module('Integration | realm', function (hooks) {
             },
           }),
         );
-        await realm.flushOperations();
+        await Promise.all([realm.flushOperations(), realm.flushUpdateEvents()]);
         return await response;
       },
     );
@@ -2159,7 +2159,10 @@ module('Integration | realm', function (hooks) {
               body: cardSrc,
             }),
           );
-          await realm.flushOperations();
+          await Promise.all([
+            realm.flushOperations(),
+            realm.flushUpdateEvents(),
+          ]);
           return await response;
         },
       );
@@ -2221,7 +2224,7 @@ module('Integration | realm', function (hooks) {
             },
           }),
         );
-        await realm.flushOperations();
+        await Promise.all([realm.flushOperations(), realm.flushUpdateEvents()]);
         assert.strictEqual((await response).status, 302, 'file exists');
 
         response = realm.handle(
@@ -2232,7 +2235,7 @@ module('Integration | realm', function (hooks) {
             },
           }),
         );
-        await realm.flushOperations();
+        await Promise.all([realm.flushOperations(), realm.flushUpdateEvents()]);
         return await response;
       },
     );

--- a/packages/host/tests/integration/realm-test.ts
+++ b/packages/host/tests/integration/realm-test.ts
@@ -394,191 +394,91 @@ module('Integration | realm', function (hooks) {
   });
 
   test<TestContextWithSSE>('realm can serve create card requests', async function (assert) {
-    let adapter = new TestRealmAdapter({});
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
-    {
-      let expected = [
-        {
-          type: 'index',
-          data: {
-            type: 'incremental',
-            invalidations: [`${testRealmURL}CardDef/1`],
-          },
-        },
-      ];
-      let response = await this.expectEvents(
-        assert,
-        realm,
-        adapter,
-        expected,
-        async () => {
-          let response = realm.handle(
-            new Request(testRealmURL, {
-              method: 'POST',
-              headers: {
-                Accept: 'application/vnd.card+json',
-              },
-              body: JSON.stringify(
-                {
-                  data: {
-                    type: 'card',
-                    meta: {
-                      adoptsFrom: {
-                        module: 'https://cardstack.com/base/card-api',
-                        name: 'CardDef',
-                      },
-                    },
-                  },
-                },
-                null,
-                2,
-              ),
-            }),
-          );
-          await Promise.all([
-            realm.flushOperations(),
-            realm.flushUpdateEvents(),
-          ]);
-          return await response;
-        },
-      );
-
-      assert.strictEqual(
-        (await response).status,
-        201,
-        'successful http status',
-      );
-      let json = await response.json();
-      if (isSingleCardDocument(json)) {
-        assert.strictEqual(
-          json.data.id,
-          `${testRealmURL}CardDef/1`,
-          'the id is correct',
-        );
-        assert.ok(json.data.meta.lastModified, 'lastModified is populated');
-        let fileRef = await adapter.openFile('CardDef/1.json');
-        if (!fileRef) {
-          throw new Error('file not found');
-        }
-        assert.deepEqual(
-          JSON.parse(fileRef.content as string),
-          {
-            data: {
-              attributes: {
-                description: null,
-                thumbnailURL: null,
-                title: null,
-              },
-              type: 'card',
-              meta: {
-                adoptsFrom: {
-                  module: 'https://cardstack.com/base/card-api',
-                  name: 'CardDef',
-                },
-              },
+    let adapter = new TestRealmAdapter({
+      'CardDef/1.json': {
+        data: {
+          type: 'card',
+          meta: {
+            adoptsFrom: {
+              module: 'https://cardstack.com/base/card-api',
+              name: 'CardDef',
             },
           },
-          'file contents are correct',
-        );
-      } else {
-        assert.ok(false, 'response body is not a card document');
-      }
-
-      let searchIndex = realm.searchIndex;
-      let result = await searchIndex.card(new URL(json.data.links.self));
-      if (result?.type === 'error') {
-        throw new Error(
-          `unexpected error when getting card from index: ${result.error.detail}`,
-        );
-      }
-      assert.strictEqual(
-        result?.doc.data.id,
-        `${testRealmURL}CardDef/1`,
-        'found card in index',
-      );
-    }
-
-    // create second file
-    {
-      let expected = [
-        {
-          type: 'index',
-          data: {
-            type: 'incremental',
-            invalidations: [`${testRealmURL}CardDef/2`],
-          },
         },
-      ];
-      let response = await this.expectEvents(
-        assert,
-        realm,
-        adapter,
-        expected,
-        async () => {
-          let response = realm.handle(
-            new Request(testRealmURL, {
-              method: 'POST',
-              headers: {
-                Accept: 'application/vnd.card+json',
-              },
-              body: JSON.stringify(
-                {
-                  data: {
-                    type: 'card',
-                    meta: {
-                      adoptsFrom: {
-                        module: 'https://cardstack.com/base/card-api',
-                        name: 'CardDef',
-                      },
+      },
+    });
+    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
+    await realm.ready;
+    let expected = [
+      {
+        type: 'index',
+        data: {
+          type: 'incremental',
+          invalidations: [`${testRealmURL}CardDef/2`],
+        },
+      },
+    ];
+    let response = await this.expectEvents(
+      assert,
+      realm,
+      adapter,
+      expected,
+      async () => {
+        let response = realm.handle(
+          new Request(testRealmURL, {
+            method: 'POST',
+            headers: {
+              Accept: 'application/vnd.card+json',
+            },
+            body: JSON.stringify(
+              {
+                data: {
+                  type: 'card',
+                  meta: {
+                    adoptsFrom: {
+                      module: 'https://cardstack.com/base/card-api',
+                      name: 'CardDef',
                     },
                   },
                 },
-                null,
-                2,
-              ),
-            }),
-          );
-          await Promise.all([
-            realm.flushOperations(),
-            realm.flushUpdateEvents(),
-          ]);
-          return await response;
-        },
-      );
+              },
+              null,
+              2,
+            ),
+          }),
+        );
+        await Promise.all([realm.flushOperations(), realm.flushUpdateEvents()]);
+        return await response;
+      },
+    );
+    assert.strictEqual((await response).status, 201, 'successful http status');
+    let json = await response.json();
+    if (isSingleCardDocument(json)) {
       assert.strictEqual(
-        (await response).status,
-        201,
-        'successful http status',
-      );
-      let json = await response.json();
-      if (isSingleCardDocument(json)) {
-        assert.strictEqual(
-          json.data.id,
-          `${testRealmURL}CardDef/2`,
-          'the id is correct',
-        );
-        assert.ok(
-          (await adapter.openFile('CardDef/2.json'))?.content,
-          'file contents exist',
-        );
-      } else {
-        assert.ok(false, 'response body is not a card document');
-      }
-
-      let searchIndex = realm.searchIndex;
-      let result = await searchIndex.card(new URL(json.data.links.self));
-      if (result?.type === 'error') {
-        throw new Error(
-          `unexpected error when getting card from index: ${result.error.detail}`,
-        );
-      }
-      assert.strictEqual(
-        result?.doc.data.id,
+        json.data.id,
         `${testRealmURL}CardDef/2`,
-        'found card in index',
+        'the id is correct',
+      );
+      assert.ok(
+        (await adapter.openFile('CardDef/2.json'))?.content,
+        'file contents exist',
+      );
+    } else {
+      assert.ok(false, 'response body is not a card document');
+    }
+
+    let searchIndex = realm.searchIndex;
+    let result = await searchIndex.card(new URL(json.data.links.self));
+    if (result?.type === 'error') {
+      throw new Error(
+        `unexpected error when getting card from index: ${result.error.detail}`,
       );
     }
+    assert.strictEqual(
+      result?.doc.data.id,
+      `${testRealmURL}CardDef/2`,
+      'found card in index',
+    );
   });
 
   test('realm can serve POST requests that include linksTo fields', async function (assert) {


### PR DESCRIPTION
This PR attempts to fix 2 flaky tests:
- Global error: ResizeObserver loop completed with undelivered notifications
- realm can serve card source post request

I tried running a bunch of times locally and things look ok. I'll also try running this a bunch of times in CI to see if things look ok there too