### PR TITLE
Use relative links because linked cards are from the same realm

### DIFF
--- a/packages/drafts-realm/Person/1.json
+++ b/packages/drafts-realm/Person/1.json
@@ -26,12 +26,12 @@
       },
       "trips.countriesVisited.0": {
         "links": {
-          "self": "http://localhost:4201/drafts/Country/1"
+          "self": "../Country/1"
         }
       },
       "trips.countriesVisited.1": {
         "links": {
-          "self": "http://localhost:4201/drafts/Country/2"
+          "self": "../Country/2"
         }
       }
     },


### PR DESCRIPTION
These URLs were invalid in deployed realm environments (staging, production). 

I am not sure how these URL were checked in because when I was testing, saving instance data doesn't even trigger when editing the collection of trips/countries in the preview (we have a separate bug opened for that). Maybe they were added manually into the instance or are a result of some previous faulty code. 

Anyway, it's good that running the realm on this data uncovered a cascade of other problems (which will be handled in separate PRs). For now, let's fix our deployed environments by correcting the seed data. 