### PR TITLE
When indexing a card and card loading fails, do not let realm server go into an unresponsive error state

### DIFF
--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -540,11 +540,17 @@ export class CurrentRun {
     let types: string[] = [];
     let fullRef: CodeRef = ref;
     while (fullRef) {
-      let loadedCard = await loadCard(fullRef, { loader: this.loader });
-      let loadedCardRef = identifyCard(loadedCard);
-      if (!loadedCardRef) {
-        throw new Error(`could not identify card ${loadedCard.name}`);
+      let loadedCard, loadedCardRef;
+      try {
+        loadedCard = await loadCard(fullRef, { loader: this.loader });
+        loadedCardRef = identifyCard(loadedCard);
+        if (!loadedCardRef) {
+          throw new Error(`could not identify card ${loadedCard.name}`);
+        }
+      } catch (error) {
+        return { type: 'error', error: serializableError(error) };
       }
+
       types.push(internalKeyFor(loadedCardRef, undefined));
       if (!isEqual(loadedCardRef, baseCardRef)) {
         fullRef = {

--- a/packages/host/tests/integration/realm-test.ts
+++ b/packages/host/tests/integration/realm-test.ts
@@ -2808,4 +2808,30 @@ posts/ignore-me.gts
       '/_info response is correct',
     );
   });
+
+  test('realm does not crash when indexing a broken instance', async function (assert) {
+    let realm = await TestRealm.create(
+      loader,
+      {
+        'FieldDef/1.json': {
+          data: {
+            type: 'card',
+            meta: {
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/card-api',
+                name: 'FieldDef',
+              },
+            },
+          },
+        },
+      },
+      this.owner,
+    ); // this is an example of a card that where loadCard will throw an error
+
+    await realm.ready;
+    assert.ok(
+      true,
+      'realm did not crash when trying to index a broken instance',
+    );
+  });
 });

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -556,4 +556,26 @@ module('indexing', function (hooks) {
       'indexed correct number of files',
     );
   });
+
+  test('does not crash when indexing a broken instance', async function (assert) {
+    await realm.write(
+      'broken.json',
+      JSON.stringify({
+        data: {
+          type: 'card',
+          meta: {
+            adoptsFrom: {
+              module: 'https://cardstack.com/base/card-api',
+              name: 'FieldDef',
+            },
+          },
+        },
+      } as LooseSingleCardDocument),
+    ); // this is an example of a card that where loadCard will throw an error
+
+    assert.ok(
+      true,
+      'the realm server does not crash during indexing when the instance is broken',
+    );
+  });
 });

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -556,26 +556,4 @@ module('indexing', function (hooks) {
       'indexed correct number of files',
     );
   });
-
-  test('does not crash when indexing a broken instance', async function (assert) {
-    await realm.write(
-      'broken.json',
-      JSON.stringify({
-        data: {
-          type: 'card',
-          meta: {
-            adoptsFrom: {
-              module: 'https://cardstack.com/base/card-api',
-              name: 'FieldDef',
-            },
-          },
-        },
-      } as LooseSingleCardDocument),
-    ); // this is an example of a card that where loadCard will throw an error
-
-    assert.ok(
-      true,
-      'the realm server does not crash during indexing when the instance is broken',
-    );
-  });
 });


### PR DESCRIPTION
The story goes like this - there was a card instance on staging like this: 

```
data: {
  type: 'card',
  meta: {
    adoptsFrom: {
      module: 'https://cardstack.com/base/card-api',
      name: 'FieldDef',
    },
  },
}
```

This instance crippled the realm server to the point it became unresponsive during indexing (staging was impossible to open and the request to fetch any card timed out). The error in the logs was `loadCard Ancestor of Ancestor of FieldDef from https://cardstack.com/base/card-api`, coming from `loadCard` (which is called from `getTypes`, which is called from `indexCard`). 

After removing this card instance things started to work again but I have no idea how this instance was created - maybe with the AI bot? I can not think of a way to reproduce this... 

This PR makes the indexing process more robust in a way that doesn't break the realm server during indexing a broken or unknown instance. 