### PR TITLE
Refactor module syntax to use CodeRef to identify card being modified 

### DIFF
--- a/packages/host/app/components/operator-mode/edit-field-modal.gts
+++ b/packages/host/app/components/operator-mode/edit-field-modal.gts
@@ -211,27 +211,20 @@ export default class EditFieldModal extends Component<Signature> {
       );
     }
 
-    let identifiedCard = identifyCard(this.args.card) as {
-      module: string;
-      name: string;
-    };
-
+    let identifiedCard = identifyCard(this.args.card)!;
     let addFieldAtIndex = undefined;
 
     if (!this.isNewField) {
       // We are editing a field, so we need to first remove the old one, and then add the new one
       addFieldAtIndex = this.args.moduleSyntax.removeField(
-        { type: 'exportedName', name: identifiedCard.name },
+        identifiedCard,
         this.args.field!.name,
       );
     }
 
     try {
       this.args.moduleSyntax.addField(
-        {
-          type: 'exportedName',
-          name: identifiedCard.name,
-        },
+        identifiedCard,
         this.fieldName,
         this.fieldRef as { module: string; name: string },
         this.fieldType,

--- a/packages/host/app/components/operator-mode/remove-field-modal.gts
+++ b/packages/host/app/components/operator-mode/remove-field-modal.gts
@@ -31,15 +31,9 @@ interface Signature {
 export default class RemoveFieldModal extends Component<Signature> {
   private removeFieldTask = restartableTask(async () => {
     let { field, card, file, moduleSyntax } = this.args;
-    let identifiedCard = identifyCard(card) as {
-      module: string;
-      name: string;
-    };
+    let identifiedCard = identifyCard(card)!;
 
-    this.args.moduleSyntax.removeField(
-      { type: 'exportedName', name: identifiedCard.name },
-      field.name,
-    );
+    this.args.moduleSyntax.removeField(identifiedCard, field.name);
 
     await file.write(moduleSyntax.code(), true);
     this.args.onClose();

--- a/packages/host/app/components/operator-mode/schema-editor-column.gts
+++ b/packages/host/app/components/operator-mode/schema-editor-column.gts
@@ -128,7 +128,10 @@ export default class SchemaEditorColumn extends Component<Signature> {
 
   @cached
   get moduleSyntax() {
-    return new ModuleSyntax(this.args.file.content);
+    return new ModuleSyntax(
+      this.args.file.content,
+      new URL(this.args.file.url),
+    );
   }
 
   <template>

--- a/packages/host/app/resources/module-contents.ts
+++ b/packages/host/app/resources/module-contents.ts
@@ -83,7 +83,10 @@ export class ModuleContentsResource extends Resource<Args> {
     // - includes card/field, either
     //   - an exported card/field
     //   - a card/field that was local but related to another card/field which was exported, e.g. inherited OR a field of the exported card/field
-    let moduleSyntax = new ModuleSyntax(executableFile.content);
+    let moduleSyntax = new ModuleSyntax(
+      executableFile.content,
+      new URL(executableFile.url),
+    );
     let localCardsOrFields = collectLocalCardsOrFields(
       moduleSyntax,
       exportedCardsOrFields,

--- a/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
@@ -758,9 +758,7 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
     await waitFor('[data-test-add-field-button]');
     await click('[data-test-add-field-button]');
     await click('[data-test-choose-card-button]');
-    +(await waitFor(
-      '[data-test-select="http://test-realm/test/person-entry"]',
-    ));
+    await waitFor('[data-test-select="http://test-realm/test/person-entry"]');
     await click('[data-test-select="http://test-realm/test/person-entry"]');
     await click('[data-test-card-catalog-go-button]');
     await fillIn('[data-test-field-name-input]', 'favPerson');

--- a/packages/realm-server/tests/module-syntax-test.ts
+++ b/packages/realm-server/tests/module-syntax-test.ts
@@ -27,7 +27,7 @@ module('module-syntax', function () {
       }
     `;
 
-    let mod = new ModuleSyntax(src);
+    let mod = new ModuleSyntax(src, new URL(testRealm));
     assert.codeEqual(mod.code(), src);
   });
 
@@ -44,9 +44,9 @@ module('module-syntax', function () {
       }
     `;
 
-    let mod = new ModuleSyntax(src);
+    let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person.gts`));
     mod.addField(
-      { type: 'exportedName', name: 'Person' },
+      { module: `${testRealm}dir/person.gts`, name: 'Person' },
       'age',
       {
         module: 'https://cardstack.com/base/number',
@@ -109,7 +109,7 @@ module('module-syntax', function () {
     // add another field which will assert that the field path is correct since
     // the new field must go after this field
     mod.addField(
-      { type: 'exportedName', name: 'Person' },
+      { module: `${testRealm}dir/person.gts`, name: 'Person' },
       'lastName',
       {
         module: 'https://cardstack.com/base/string',
@@ -148,10 +148,10 @@ module('module-syntax', function () {
       }
     `;
 
-    let mod = new ModuleSyntax(src);
+    let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/pet.gts`));
 
     mod.addField(
-      { type: 'exportedName', name: 'Pet' }, // Card we want to add to
+      { module: `${testRealm}dir/pet`, name: 'Pet' }, // Card we want to add to
       'bestFriend',
       {
         module: '../person',
@@ -186,10 +186,10 @@ module('module-syntax', function () {
       }
     `;
 
-    let mod = new ModuleSyntax(src);
+    let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/pet.gts`));
 
     mod.addField(
-      { type: 'exportedName', name: 'Pet' }, // card we want to add to
+      { module: `${testRealm}dir/pet`, name: 'Pet' }, // card we want to add to
       'bestFriend',
       {
         module: '../person', // the other realm (will be from the /test realm not the /node-test)
@@ -222,9 +222,9 @@ module('module-syntax', function () {
         export class Person extends CardDef { }
       `;
 
-    let mod = new ModuleSyntax(src);
+    let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.addField(
-      { type: 'exportedName', name: 'Person' },
+      { module: `${testRealm}dir/person`, name: 'Person' },
       'firstName',
       {
         module: 'https://cardstack.com/base/string',
@@ -249,7 +249,66 @@ module('module-syntax', function () {
     );
   });
 
-  test('can add a field to a card that is not exported', async function (assert) {
+  test('can add a field to an interior card that is the field of card that is exported', async function (assert) {
+    let src = `
+      import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
+      import StringCard from "https://cardstack.com/base/string";
+
+      class Details extends CardDef {
+        @field favoriteColor = contains(StringCard);
+      }
+
+      export class Person extends CardDef {
+        @field firstName = contains(StringCard);
+        @field details = contains(Details);
+        static embedded = class Embedded extends Component<typeof this> {
+          <template><h1><@fields.firstName/></h1></template>
+        }
+      }
+    `;
+
+    let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
+    mod.addField(
+      {
+        type: 'fieldOf',
+        field: 'details',
+        card: { module: `${testRealm}dir/person`, name: 'Person' },
+      },
+      'age',
+      {
+        module: 'https://cardstack.com/base/number',
+        name: 'default',
+      },
+      'contains',
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    assert.codeEqual(
+      mod.code(),
+      `
+        import NumberCard from "https://cardstack.com/base/number";
+        import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
+        import StringCard from "https://cardstack.com/base/string";
+
+        class Details extends CardDef {
+          @field favoriteColor = contains(StringCard);
+          @field age = contains(NumberCard);
+        }
+
+        export class Person extends CardDef {
+          @field firstName = contains(StringCard);
+          @field details = contains(Details);
+          static embedded = class Embedded extends Component<typeof this> {
+            <template><h1><@fields.firstName/></h1></template>
+          }
+        }
+      `,
+    );
+  });
+
+  test('can add a field to an interior card that is the ancestor of card that is exported', async function (assert) {
     let src = `
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -266,9 +325,12 @@ module('module-syntax', function () {
       }
     `;
 
-    let mod = new ModuleSyntax(src);
+    let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.addField(
-      { type: 'localName', name: 'Person' },
+      {
+        type: 'ancestorOf',
+        card: { module: `${testRealm}dir/person`, name: 'FancyPerson' },
+      },
       'age',
       {
         module: 'https://cardstack.com/base/number',
@@ -315,9 +377,9 @@ module('module-syntax', function () {
       }
     `;
 
-    let mod = new ModuleSyntax(src);
+    let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.addField(
-      { type: 'exportedName', name: 'Person' },
+      { module: `${testRealm}dir/person`, name: 'Person' },
       'aliases',
       {
         module: 'https://cardstack.com/base/string',
@@ -377,9 +439,9 @@ module('module-syntax', function () {
         @field firstName = contains(StringCard);
       }
     `;
-    let mod = new ModuleSyntax(src);
+    let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.addField(
-      { type: 'exportedName', name: 'Person' },
+      { module: `${testRealm}dir/person`, name: 'Person' },
       'pet',
       {
         module: `${testRealm}dir/pet`,
@@ -426,9 +488,9 @@ module('module-syntax', function () {
         @field firstName = contains(StringCard);
       }
     `;
-    let mod = new ModuleSyntax(src);
+    let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.addField(
-      { type: 'exportedName', name: 'Person' },
+      { module: `${testRealm}dir/person`, name: 'Person' },
       'friend',
       {
         module: `${testRealm}dir/person`,
@@ -478,9 +540,9 @@ module('module-syntax', function () {
       }
     `;
 
-    let mod = new ModuleSyntax(src);
+    let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.addField(
-      { type: 'exportedName', name: 'Person' },
+      { module: `${testRealm}dir/person`, name: 'Person' },
       'age',
       {
         module: 'https://cardstack.com/base/number',
@@ -521,10 +583,10 @@ module('module-syntax', function () {
         @field firstName = contains(StringCard);
       }
     `;
-    let mod = new ModuleSyntax(src);
+    let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     try {
       mod.addField(
-        { type: 'exportedName', name: 'Person' },
+        { module: `${testRealm}dir/person`, name: 'Person' },
         'firstName',
         {
           module: 'https://cardstack.com/base/string',
@@ -554,8 +616,11 @@ module('module-syntax', function () {
         @field lastName = contains(StringCard);
       }
     `;
-    let mod = new ModuleSyntax(src);
-    mod.removeField({ type: 'exportedName', name: 'Person' }, 'firstName');
+    let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
+    mod.removeField(
+      { module: `${testRealm}dir/person`, name: 'Person' },
+      'firstName',
+    );
 
     assert.codeEqual(
       mod.code(),
@@ -587,14 +652,14 @@ module('module-syntax', function () {
       }
     `;
 
-    let mod = new ModuleSyntax(src);
+    let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     let fieldIndex = mod.removeField(
-      { type: 'exportedName', name: 'Person' },
+      { module: `${testRealm}dir/person`, name: 'Person' },
       'artistName',
     );
 
     mod.addField(
-      { type: 'exportedName', name: 'Person' },
+      { module: `${testRealm}dir/person`, name: 'Person' },
       'artistNames',
       {
         module: 'https://cardstack.com/base/string',
@@ -636,14 +701,14 @@ module('module-syntax', function () {
       }
     `;
 
-    let mod = new ModuleSyntax(src);
+    let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     let fieldIndex = mod.removeField(
-      { type: 'exportedName', name: 'Person' },
+      { module: `${testRealm}dir/person`, name: 'Person' },
       'firstName',
     );
 
     mod.addField(
-      { type: 'exportedName', name: 'Person' },
+      { module: `${testRealm}dir/person`, name: 'Person' },
       'firstNameAdjusted',
       {
         module: 'https://cardstack.com/base/string',
@@ -685,14 +750,14 @@ module('module-syntax', function () {
       }
     `;
 
-    let mod = new ModuleSyntax(src);
+    let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     let fieldIndex = mod.removeField(
-      { type: 'exportedName', name: 'Person' },
+      { module: `${testRealm}dir/person`, name: 'Person' },
       'streetName',
     );
 
     mod.addField(
-      { type: 'exportedName', name: 'Person' },
+      { module: `${testRealm}dir/person`, name: 'Person' },
       'streetNameAdjusted',
       {
         module: 'https://cardstack.com/base/string',
@@ -731,8 +796,11 @@ module('module-syntax', function () {
       }
     `;
 
-    let mod = new ModuleSyntax(src);
-    mod.removeField({ type: 'exportedName', name: 'Person' }, 'firstName');
+    let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
+    mod.removeField(
+      { module: `${testRealm}dir/person`, name: 'Person' },
+      'firstName',
+    );
 
     assert.codeEqual(
       mod.code(),
@@ -753,8 +821,11 @@ module('module-syntax', function () {
         @field friend = linksTo(() => Friend);
       }
     `;
-    let mod = new ModuleSyntax(src);
-    mod.removeField({ type: 'exportedName', name: 'Friend' }, 'friend');
+    let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
+    mod.removeField(
+      { module: `${testRealm}dir/person`, name: 'Friend' },
+      'friend',
+    );
 
     assert.codeEqual(
       mod.code(),
@@ -773,7 +844,7 @@ module('module-syntax', function () {
     assert.strictEqual(field, undefined, 'field does not exist in syntax');
   });
 
-  test('can remove the field from a card that is not exported', async function (assert) {
+  test('can remove the field of an interior card that is the ancestor of a card that is exported', async function (assert) {
     let src = `
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -787,8 +858,14 @@ module('module-syntax', function () {
         @field favoriteColor = contains(StringCard);
       }
     `;
-    let mod = new ModuleSyntax(src);
-    mod.removeField({ type: 'localName', name: 'Person' }, 'firstName');
+    let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
+    mod.removeField(
+      {
+        type: 'ancestorOf',
+        card: { module: `${testRealm}dir/person`, name: 'FancyPerson' },
+      },
+      'firstName',
+    );
 
     assert.codeEqual(
       mod.code(),
@@ -807,6 +884,51 @@ module('module-syntax', function () {
     );
   });
 
+  test('can remove the field of an interior card that is the field of a card that is exported', async function (assert) {
+    let src = `
+      import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
+      import StringCard from "https://cardstack.com/base/string";
+
+      class Details extends CardDef {
+        @field nickName = contains(StringCard);
+        @field favoriteColor = contains(StringCard);
+      }
+
+      export class Person extends CardDef {
+        @field firstName = contains(StringCard);
+        @field lastName = contains(StringCard);
+        @field details = contains(Details);
+      }
+    `;
+    let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
+    mod.removeField(
+      {
+        type: 'fieldOf',
+        field: 'details',
+        card: { module: `${testRealm}dir/person`, name: 'Person' },
+      },
+      'nickName',
+    );
+
+    assert.codeEqual(
+      mod.code(),
+      `
+        import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
+        import StringCard from "https://cardstack.com/base/string";
+
+        class Details extends CardDef {
+          @field favoriteColor = contains(StringCard);
+        }
+
+        export class Person extends CardDef {
+          @field firstName = contains(StringCard);
+          @field lastName = contains(StringCard);
+          @field details = contains(Details);
+        }
+      `,
+    );
+  });
+
   test('throws when field to remove does not actually exist', async function (assert) {
     let src = `
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
@@ -817,9 +939,12 @@ module('module-syntax', function () {
       }
     `;
 
-    let mod = new ModuleSyntax(src);
+    let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     try {
-      mod.removeField({ type: 'exportedName', name: 'Person' }, 'foo');
+      mod.removeField(
+        { module: `${testRealm}dir/person`, name: 'Person' },
+        'foo',
+      );
       throw new Error('expected error was not thrown');
     } catch (err: any) {
       assert.ok(

--- a/packages/runtime-common/code-ref.ts
+++ b/packages/runtime-common/code-ref.ts
@@ -8,6 +8,7 @@ import {
 import { Loader } from './loader';
 import { isField } from './constants';
 import { CardError } from './error';
+import { trimExecutableExtension } from './index';
 
 export type ResolvedCodeRef = {
   module: string;
@@ -82,9 +83,14 @@ export function isFieldDef(field: any): field is typeof FieldDef {
 export function codeRefWithAbsoluteURL(
   ref: CodeRef,
   relativeTo?: URL | undefined,
+  opts?: { trimExecutableExtension?: true },
 ): CodeRef {
   if (!('type' in ref)) {
-    return { ...ref, module: new URL(ref.module, relativeTo).href };
+    let moduleURL = new URL(ref.module, relativeTo);
+    if (opts?.trimExecutableExtension) {
+      moduleURL = trimExecutableExtension(moduleURL);
+    }
+    return { ...ref, module: moduleURL.href };
   }
   return { ...ref, card: codeRefWithAbsoluteURL(ref.card, relativeTo) };
 }

--- a/packages/runtime-common/module-syntax.ts
+++ b/packages/runtime-common/module-syntax.ts
@@ -331,8 +331,12 @@ function makeNewField({
   if (
     (fieldType === 'linksTo' || fieldType === 'linksToMany') &&
     isEqual(
-      codeRefWithAbsoluteURL(fieldRef, moduleURL),
-      codeRefWithAbsoluteURL(cardBeingModified, moduleURL),
+      codeRefWithAbsoluteURL(fieldRef, moduleURL, {
+        trimExecutableExtension: true,
+      }),
+      codeRefWithAbsoluteURL(cardBeingModified, moduleURL, {
+        trimExecutableExtension: true,
+      }),
     )
   ) {
     // syntax for when a card has a linksTo or linksToMany field to a card with the same type as itself

--- a/packages/runtime-common/module-syntax.ts
+++ b/packages/runtime-common/module-syntax.ts
@@ -261,10 +261,7 @@ export class ModuleSyntax {
           `Cannot resolve class reference with undefined 'classIndex' when looking up interior card/field in module ${this.url.href}`,
         );
       }
-      let declaration = this.declarations[classRef.classIndex];
-      return this.possibleCardsOrFields.find(
-        (c) => c.path === declaration.path,
-      );
+      return this.possibleCardsOrFields[classRef.classIndex];
     }
   }
 }


### PR DESCRIPTION
The issue here is that the ModuleSyntax did not operate on CodeRefs, rather it used a very simple mechanism to identify a declaration in the module that is a card that is being modified--either the exported name of the card (which lines up nicely for CodeRef's of exported cards), or the module scoped declaration of a card for non-exported cards. it didn't know how to resolve a CodeRef because you needed to have a running card in order to resolve a CodeRef.

The fix was to build a mechanism that works like `@cardstack/runtime-common/code-ref.ts#loadCard()` to identify a card, but to use syntax instead of a running card to actually operate.

![adding-fields-bug](https://github.com/cardstack/boxel/assets/61075/dc911720-808e-4446-aaf7-21f67f2629ce)
