### PR TITLE
Prevent "In This File" type from wrapping

### DIFF
--- a/packages/host/app/components/operator-mode/detail-panel-selector.gts
+++ b/packages/host/app/components/operator-mode/detail-panel-selector.gts
@@ -278,6 +278,7 @@ export default class Selector extends Component<Signature> {
           margin-left: auto;
           text-transform: uppercase;
           color: var(--boxel-450);
+          white-space: nowrap;
         }
 
         .boxel-selector__item--selected .selector-item .type {


### PR DESCRIPTION
Before:
![image](https://github.com/cardstack/boxel/assets/353/825ac1d6-f03a-45d5-bd9e-9e091f148269)

After:
![image](https://github.com/cardstack/boxel/assets/353/da1de0e6-cec7-4daf-a4f5-489bf4adef95)
