### PR TITLE
Fix interruptive cursor focus when editing URL bar

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -45,12 +45,13 @@ import {
 import { type ResolvedCodeRef } from '@cardstack/runtime-common/code-ref';
 
 import RecentFiles from '@cardstack/host/components/editor/recent-files';
-import SchemaEditorColumn from '@cardstack/host/components/operator-mode/schema-editor-column';
 import RealmInfoProvider from '@cardstack/host/components/operator-mode/realm-info-provider';
+import SchemaEditorColumn from '@cardstack/host/components/operator-mode/schema-editor-column';
 import config from '@cardstack/host/config/environment';
 
 import monacoModifier from '@cardstack/host/modifiers/monaco';
 
+import { getCard } from '@cardstack/host/resources/card-resource';
 import {
   isReady,
   type Ready,
@@ -83,10 +84,8 @@ import CardPreviewPanel from './card-preview-panel';
 import CardURLBar from './card-url-bar';
 import DeleteModal from './delete-modal';
 import DetailPanel from './detail-panel';
-import SubmodeLayout from './submode-layout';
 import NewFileButton from './new-file-button';
-
-import { getCard } from '@cardstack/host/resources/card-resource';
+import SubmodeLayout from './submode-layout';
 
 interface Signature {
   Args: {
@@ -382,14 +381,12 @@ export default class CodeSubmode extends Component<Signature> {
     return this.card;
   }
 
-  @action
-  private initializeMonacoCursorPosition() {
+  private get initialMonacoCursorPosition() {
     if (this.selectedDeclaration?.path?.node.loc) {
       let { start } = this.selectedDeclaration.path.node.loc;
-      this.monacoService.updateCursorPosition(
-        new Position(start.line, start.column),
-      );
+      return new Position(start.line, start.column);
     }
+    return undefined;
   }
 
   @action
@@ -875,7 +872,7 @@ export default class CodeSubmode extends Component<Signature> {
                         contentChanged=(perform this.contentChangedTask)
                         monacoSDK=this.monacoSDK
                         language=this.language
-                        initializeCursorPosition=this.initializeMonacoCursorPosition
+                        initialCursorPosition=this.initialMonacoCursorPosition
                         onCursorPositionChange=this.selectDeclarationByMonacoCursorPosition
                       }}
                     ></div>

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -381,6 +381,7 @@ export default class CodeSubmode extends Component<Signature> {
     return this.card;
   }
 
+  @cached
   private get initialMonacoCursorPosition() {
     if (this.selectedDeclaration?.path?.node.loc) {
       let { start } = this.selectedDeclaration.path.node.loc;

--- a/packages/host/app/config/environment.d.ts
+++ b/packages/host/app/config/environment.d.ts
@@ -22,5 +22,6 @@ declare const config: {
   resolvedOwnRealmURL: string;
   autoSaveDelayMs: number;
   monacoDebounceMs: number;
+  monacoCursorDebounceMs: number;
   serverEchoDebounceMs: number;
 };

--- a/packages/host/app/services/monaco-service.ts
+++ b/packages/host/app/services/monaco-service.ts
@@ -26,7 +26,7 @@ const { serverEchoDebounceMs } = config;
 export default class MonacoService extends Service {
   #ready: Promise<MonacoSDK>;
   @tracked editor: _MonacoSDK.editor.ICodeEditor | null = null;
-  @tracked isFocus = false;
+  @tracked hasFocus = false;
   @service declare cardService: CardService;
   // this is in the service so that we can manipulate it in our tests
   serverEchoDebounceMs = serverEchoDebounceMs;
@@ -47,10 +47,10 @@ export default class MonacoService extends Service {
     monaco.editor.onDidCreateEditor((editor: _MonacoSDK.editor.ICodeEditor) => {
       this.editor = editor;
       this.editor.onDidFocusEditorText(() => {
-        this.isFocus = true;
+        this.hasFocus = true;
       });
       this.editor.onDidBlurEditorText(() => {
-        this.isFocus = false;
+        this.hasFocus = false;
       });
     });
     await Promise.all(promises);

--- a/packages/host/app/services/monaco-service.ts
+++ b/packages/host/app/services/monaco-service.ts
@@ -26,6 +26,7 @@ const { serverEchoDebounceMs } = config;
 export default class MonacoService extends Service {
   #ready: Promise<MonacoSDK>;
   @tracked editor: _MonacoSDK.editor.ICodeEditor | null = null;
+  @tracked isFocus = false;
   @service declare cardService: CardService;
   // this is in the service so that we can manipulate it in our tests
   serverEchoDebounceMs = serverEchoDebounceMs;
@@ -45,6 +46,12 @@ export default class MonacoService extends Service {
     );
     monaco.editor.onDidCreateEditor((editor: _MonacoSDK.editor.ICodeEditor) => {
       this.editor = editor;
+      this.editor.onDidFocusEditorText(() => {
+        this.isFocus = true;
+      });
+      this.editor.onDidBlurEditorText(() => {
+        this.isFocus = false;
+      });
     });
     await Promise.all(promises);
     return monaco;

--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -27,6 +27,7 @@ module.exports = function (environment) {
     matrixURL: process.env.MATRIX_URL || 'http://localhost:8008',
     autoSaveDelayMs: 500,
     monacoDebounceMs: 500,
+    monacoCursorDebounceMs: 200,
     serverEchoDebounceMs: 5000,
 
     // the fields below may be rewritten by the realm server
@@ -70,6 +71,7 @@ module.exports = function (environment) {
     ENV.APP.experimentalAIEnabled = true;
     ENV.autoSaveDelayMs = 0;
     ENV.monacoDebounceMs = 0;
+    ENV.monacoCursorDebounceMs = 0;
     ENV.serverEchoDebounceMs = 0;
   }
 

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -4,6 +4,7 @@ import {
   waitFor,
   fillIn,
   triggerKeyEvent,
+  waitUntil,
 } from '@ember/test-helpers';
 
 import percySnapshot from '@percy/ember';
@@ -984,6 +985,7 @@ module('Acceptance | code submode tests', function (hooks) {
     await click(`[data-test-definition-container="${testRealmURL}person"]`);
     await waitFor(`[data-boxel-selector-item-text="Person"]`);
     lineCursorOn = monacoService.getLineCursorOn();
+    await waitUntil(() => monacoService.hasFocus);
     assert.true(lineCursorOn?.includes('Person'));
   });
 
@@ -1004,22 +1006,22 @@ module('Acceptance | code submode tests', function (hooks) {
 
     await waitFor(`[data-boxel-selector-item-text="Employee"]`);
     await click(`[data-boxel-selector-item-text="Employee"]`);
-    assert.true(monacoService.isFocus);
+    assert.true(monacoService.hasFocus);
 
     await fillIn('[data-test-card-url-bar] input', `${testRealmURL}person.gts`);
-    assert.false(monacoService.isFocus);
+    assert.false(monacoService.hasFocus);
     await triggerKeyEvent(
       '[data-test-card-url-bar-input]',
       'keypress',
       'Enter',
     );
     await waitFor(`[data-boxel-selector-item-text="Person"]`);
-    assert.true(monacoService.isFocus);
+    assert.true(monacoService.hasFocus);
 
     await fillIn(
       '[data-test-card-url-bar] input',
       `${testRealmURL}person.gts-test`,
     );
-    assert.false(monacoService.isFocus);
+    assert.false(monacoService.hasFocus);
   });
 });


### PR DESCRIPTION
**Ticket: CS-6224**

**Problem**
Before this PR, Monaco cursor position would initialize every time focus wasn't in the Monaco editor. This caused the cursor focus in the URL bar to move to Monaco editor. Additionally, initializing cursor position could lead to an infinite Glimmer invalidation error. When moving focus from the URL bar to the code editor, the `onBlur` function in the URL bar could be triggered, updating the `value` for the second time in the same computation.

**Solution**
Instead of using `hasTextFocus` to determine the initialization of the Monaco cursor position, I now record the last cursor position. If the last cursor position is not `null`, then the cursor position in Monaco doesn't need to be initialized. I also made the cursor position initialization process asynchronous, creating a new process to avoid potential infinite Glimmer invalidation errors.

Before:

https://github.com/cardstack/boxel/assets/12637010/f4c901ce-1e31-43eb-a0e8-c32e0d5d0c72

After:


https://github.com/cardstack/boxel/assets/12637010/dccad6e0-99f3-4aa8-ae0d-016663b742f4

