### PR TITLE
Allow overwriting card instance data by the code editor

### DIFF
--- a/packages/host/app/components/operator-mode/code-editor.gts
+++ b/packages/host/app/components/operator-mode/code-editor.gts
@@ -13,7 +13,7 @@ import { Position } from 'monaco-editor';
 
 import { LoadingIndicator } from '@cardstack/boxel-ui/components';
 
-import { logger, RealmPaths } from '@cardstack/runtime-common';
+import { logger } from '@cardstack/runtime-common';
 
 import monacoModifier from '@cardstack/host/modifiers/monaco';
 import { isReady, type FileResource } from '@cardstack/host/resources/file';
@@ -193,6 +193,16 @@ export default class CodeEditor extends Component<Signature> {
   private writeSourceCodeToFile(file: FileResource, content: string) {
     if (file.state !== 'ready') {
       throw new Error('File is not ready to be written to');
+    }
+
+    let isJSON = file.name.endsWith('.json');
+    let validJSON = isJSON && this.safeJSONParse(content);
+
+    if (isJSON && !validJSON) {
+      log.warn(
+        `content for ${this.codePath} is not valid JSON, skipping write`,
+      );
+      return;
     }
 
     // flush the loader so that the preview (when card instance data is shown), or schema editor (when module code is shown) gets refreshed on save

--- a/packages/host/app/components/operator-mode/code-editor.gts
+++ b/packages/host/app/components/operator-mode/code-editor.gts
@@ -176,21 +176,9 @@ export default class CodeEditor extends Component<Signature> {
     if (!isReady(this.args.file) || content === this.args.file?.content) {
       return;
     }
-    let isJSON = this.args.file.name.endsWith('.json');
-    let validJSON = isJSON && this.safeJSONParse(content);
 
-    if (validJSON && isSingleCardDocument(validJSON)) {
-      // Does not perform the save using the card api service because that
-      // will perform a patch request, which will would not work in case the
-      // card instance has an indexing error. Instead, we save the validated card instance data
-      // directly to the file, similar to how we save the card source code
-      await this.saveCardJson.perform(content);
-    } else if (!isJSON || validJSON) {
-      // writes source code and non-card instance valid JSON,
-      // then updates the state of the file resource
-      this.writeSourceCodeToFile(this.args.file, content);
-      this.waitForSourceCodeWrite.perform();
-    }
+    this.writeSourceCodeToFile(this.args.file, content);
+    this.waitForSourceCodeWrite.perform();
     this.hasUnsavedSourceChanges = false;
   });
 

--- a/packages/host/app/components/operator-mode/code-editor.gts
+++ b/packages/host/app/components/operator-mode/code-editor.gts
@@ -13,11 +13,7 @@ import { Position } from 'monaco-editor';
 
 import { LoadingIndicator } from '@cardstack/boxel-ui/components';
 
-import {
-  logger,
-  isSingleCardDocument,
-  RealmPaths,
-} from '@cardstack/runtime-common';
+import { logger, RealmPaths } from '@cardstack/runtime-common';
 
 import monacoModifier from '@cardstack/host/modifiers/monaco';
 import { isReady, type FileResource } from '@cardstack/host/resources/file';
@@ -213,48 +209,6 @@ export default class CodeEditor extends Component<Signature> {
       return;
     }
   }
-
-  private saveCardJson = task(async (content: string) => {
-    if (!this.codePath) {
-      return;
-    }
-    let json = this.safeJSONParse(content);
-    let realmPath = new RealmPaths(this.cardService.defaultURL);
-    let url = realmPath.fileURL(this.codePath.href.replace(/\.json$/, ''));
-    let realmURL = this.readyFile.realmURL;
-    if (!realmURL) {
-      throw new Error(`cannot determine realm for ${this.codePath}`);
-    }
-
-    let doc = this.monacoService.reverseFileSerialization(
-      json,
-      url.href,
-      realmURL,
-    );
-
-    try {
-      // Check if the card instance data conforms to the card definition
-      await this.cardService.createFromSerialized(doc.data, doc, url);
-    } catch (e) {
-      // TODO probably we should show a message in the UI that the card
-      // instance JSON is not actually a valid card
-      console.error(
-        'JSON is not a valid card--TODO this should be an error message in the code editor',
-      );
-      return;
-    }
-
-    try {
-      // these saves can happen so fast that we'll make sure to wait at
-      // least 500ms for human consumption
-      this.args.onFileSave('started');
-      let writePromise = this.writeSourceCodeToFile(this.readyFile, content);
-      await all([writePromise, timeout(500)]);
-      this.args.onFileSave('finished');
-    } catch (e) {
-      console.error('Failed to save single card document', e);
-    }
-  });
 
   private get language(): string | undefined {
     if (this.codePath) {

--- a/packages/host/app/components/operator-mode/code-editor.gts
+++ b/packages/host/app/components/operator-mode/code-editor.gts
@@ -5,26 +5,33 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 //@ts-expect-error cached type not available yet
 import { cached, tracked } from '@glimmer/tracking';
+
 import { task, restartableTask, timeout, all } from 'ember-concurrency';
+
 import perform from 'ember-concurrency/helpers/perform';
 import { Position } from 'monaco-editor';
+
 import { LoadingIndicator } from '@cardstack/boxel-ui/components';
+
 import {
   logger,
   isSingleCardDocument,
   RealmPaths,
-  type SingleCardDocument,
 } from '@cardstack/runtime-common';
+
 import monacoModifier from '@cardstack/host/modifiers/monaco';
 import { isReady, type FileResource } from '@cardstack/host/resources/file';
 import { type ModuleDeclaration } from '@cardstack/host/resources/module-contents';
+
+import { type ModuleContentsResource } from '@cardstack/host/resources/module-contents';
 import type CardService from '@cardstack/host/services/card-service';
+
 import type MonacoService from '@cardstack/host/services/monaco-service';
 import type { MonacoSDK } from '@cardstack/host/services/monaco-service';
+
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
+
 import BinaryFileInfo from './binary-file-info';
-import { type ModuleContentsResource } from '@cardstack/host/resources/module-contents';
-import { type CardDef } from 'https://cardstack.com/base/card-api';
 
 interface Signature {
   Args: {

--- a/packages/host/tests/acceptance/code-submode/editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/editor-test.ts
@@ -387,16 +387,16 @@ module('Acceptance | code submode | editor tests', function (hooks) {
       },
     ];
 
-    await this.expectEvents(
+    await this.expectEvents({
       assert,
       realm,
       adapter,
       expectedEvents,
-      async () => {
+      callback: async () => {
         setMonacoContent(JSON.stringify(editedCard));
         await waitFor('[data-test-save-idle]');
       },
-    );
+    });
 
     let fileRef = await adapter.openFile('Person/john-with-bad-pet-link.json');
     if (!fileRef) {

--- a/packages/host/tests/acceptance/code-submode/editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/editor-test.ts
@@ -459,11 +459,11 @@ module('Acceptance | code submode | editor tests', function (hooks) {
       .dom('[data-test-code-mode-card-preview-body] [data-test-field="name"]')
       .containsText('Mango');
 
-    this.onSave((json) => {
-      if (typeof json === 'string') {
-        throw new Error('expected JSON save data');
+    this.onSave((content) => {
+      if (typeof content !== 'string') {
+        throw new Error('expected string save data');
       }
-      assert.strictEqual(json.data.attributes?.name, 'MangoXXX');
+      assert.strictEqual(JSON.parse(content).data.attributes?.name, 'MangoXXX');
     });
 
     await this.expectEvents(
@@ -731,6 +731,7 @@ module('Acceptance | code submode | editor tests', function (hooks) {
             `${testRealmURL}Pet/mango`,
             `${testRealmURL}Pet/vangogh`,
             `${testRealmURL}Person/fadhlan`,
+            `${testRealmURL}Person/john-with-bad-pet-link`,
             `${testRealmURL}person`,
           ],
         },

--- a/packages/host/tests/acceptance/code-submode/editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/editor-test.ts
@@ -351,13 +351,6 @@ module('Acceptance | code submode | editor tests', function (hooks) {
       )}`,
     );
     await waitFor('[data-test-editor]');
-    await waitFor('[data-test-file-incompatibility-message]');
-
-    assert
-      .dom('[data-test-file-incompatibility-message]')
-      .containsText(
-        'No tools are available to inspect this file or its contents.',
-      );
 
     let editedCard: LooseSingleCardDocument = {
       data: {

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -216,6 +216,14 @@ export class Realm {
     return this.paths.url;
   }
 
+  get writableFileExtensions(): string[] {
+    // We include .json (card instance data) because we want to allow the
+    // card instance data to be overwritten directly (by the code editor) and not go
+    // through the card API which tries to fetch the instance data from the index and patch it.
+    // The card instance in the index could be broken so we want to have a way to overwrite it directly.
+    return [...executableExtensions, '.json'];
+  }
+
   constructor(
     url: string,
     adapter: RealmAdapter,
@@ -259,7 +267,7 @@ export class Realm {
         this.removeCard.bind(this),
       )
       .post(
-        `/.+(${executableExtensions.map((e) => '\\' + e).join('|')})`,
+        `/.+(${this.writableFileExtensions.map((e) => '\\' + e).join('|')})`,
         SupportedMimeType.CardSource,
         this.upsertCardSource.bind(this),
       )


### PR DESCRIPTION
This PR changes the way the code editor is saving the card instance data - now it does it by writing the validated JSON directly to the file and not through the `saveModel` anymore. This is because the latter will try to patch the data by fetching the instance from the index and merging the new data. But this is problematic in the case where the card instance data is broken and cannot be loaded - in this case it's better to write directly to the file, without patching.

Here is one example, a card with broken links (notice the `trips` relationship urls):

<img width="904" alt="image" src="https://github.com/cardstack/boxel/assets/273660/af181a06-9ba3-474b-a8f2-70680df084b4">

We can now adjust the links and get the card instance in a good state again (after auto save):

<img width="898" alt="image" src="https://github.com/cardstack/boxel/assets/273660/85930207-9831-47bb-9456-a1539141a778">

Previously it was impossible to fix the broken card instance data using the code editor because patching a broken instance resulted in errors. 
 