### PR TITLE
host: Fix label for single search result

### DIFF
--- a/packages/host/app/components/search-sheet/index.gts
+++ b/packages/host/app/components/search-sheet/index.gts
@@ -276,7 +276,8 @@ export default class SearchSheet extends Component<Signature> {
               <Label
                 data-test-search-result-label
               >{{this.searchCardResults.length}}
-                Results for "{{this.searchKey}}"</Label>
+                Result{{unless (eq this.searchCardResults.length 1) 's'}}
+                for "{{this.searchKey}}"</Label>
             {{/if}}
             <div class='search-result-section__body'>
               <div class='search-result-section__cards'>

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -1778,6 +1778,15 @@ module('Integration | operator-mode', function (hooks) {
       .dom(`[data-test-search-result="${testRealmURL}Author/mark"]`)
       .exists();
 
+    await click(`[data-test-search-sheet-cancel-button]`);
+
+    await focus(`[data-test-search-field]`);
+    await typeIn(`[data-test-search-field]`, 'Mar');
+    await waitFor(`[data-test-search-sheet-search-result]`);
+    assert
+      .dom(`[data-test-search-result-label]`)
+      .containsText('1 Result for "Mar"');
+
     //Ensures that there is no cards when reopen the search sheet
     await click(`[data-test-search-sheet-cancel-button]`);
     await focus(`[data-test-search-field]`);


### PR DESCRIPTION
This addresses this edge case, before and after:

<table>
<tbody>
<tr>
<td>
<img width="313" alt="Boxel 2023-11-13 13-50-28" src="https://github.com/cardstack/boxel/assets/43280/e9ecc94b-50f8-4241-812e-17524552297a">
</td>
<td>
<img width="469" alt="Boxel 2023-11-13 15-22-10" src="https://github.com/cardstack/boxel/assets/43280/e4598875-997c-4917-87b1-5d470077242f">
</td>
</tr>
</table>

Maybe we should have a helper as we already have `pluralize` in `runtime-common` but for now this is custom in the template.