### PR TITLE
Fix URL Bar too short

### DIFF
--- a/packages/boxel-ui/addon/src/components/input/index.gts
+++ b/packages/boxel-ui/addon/src/components/input/index.gts
@@ -222,6 +222,7 @@ export default class BoxelInput extends Component<Signature> {
           'pre-icon input post-icon'
           'error error error'
           'helper helper helper';
+        width: 100%;
       }
 
       .boxel-input {


### PR DESCRIPTION
Before:
<img width="686" alt="Screen Shot 2023-11-14 at 11 24 50" src="https://github.com/cardstack/boxel/assets/12637010/594b2f24-a65a-409e-8a75-5b9ad65406f1">

After:
<img width="676" alt="Screen Shot 2023-11-14 at 11 29 29" src="https://github.com/cardstack/boxel/assets/12637010/e6536ba8-dabc-404b-b064-6f96111fdd6d">
