### PR TITLE
Use UUID's for server assigned card identifiers

### DIFF
--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -954,17 +954,17 @@ module('Acceptance | code submode tests', function (hooks) {
       await waitForCodeEditor();
 
       let originalPosition: MonacoSDK.Position | undefined | null;
-      await this.expectEvents(
+      await this.expectEvents({
         assert,
         realm,
         adapter,
         expectedEvents,
-        async () => {
+        callback: async () => {
           setMonacoContent(`// This is a change \n${inThisFileSource}`);
           monacoService.updateCursorPosition(new MonacoSDK.Position(45, 0));
           originalPosition = monacoService.getCursorPosition();
         },
-      );
+      });
       await waitFor('[data-test-saved]');
       await waitFor('[data-test-save-idle]');
       let currentPosition = monacoService.getCursorPosition();

--- a/packages/host/tests/acceptance/code-submode/editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/editor-test.ts
@@ -363,15 +363,15 @@ module('Acceptance | code submode | editor tests', function (hooks) {
       assert.strictEqual(json.data.attributes?.name, 'MangoXXX');
     });
 
-    await this.expectEvents(
+    await this.expectEvents({
       assert,
       realm,
       adapter,
       expectedEvents,
-      async () => {
+      callback: async () => {
         setMonacoContent(JSON.stringify(expected));
       },
-    );
+    });
 
     await waitFor('[data-test-save-idle]');
 
@@ -447,15 +447,15 @@ module('Acceptance | code submode | editor tests', function (hooks) {
     });
 
     await click('[data-test-preview-card-footer-button-edit]');
-    await this.expectEvents(
+    await this.expectEvents({
       assert,
       realm,
       adapter,
       expectedEvents,
-      async () => {
+      callback: async () => {
         await fillIn('[data-test-field="name"] input', 'MangoXXX');
       },
-    );
+    });
     await waitFor('[data-test-save-idle]');
   });
 
@@ -652,16 +652,16 @@ module('Acceptance | code submode | editor tests', function (hooks) {
     );
     await waitForCodeEditor();
 
-    await this.expectEvents(
+    await this.expectEvents({
       assert,
       realm,
       adapter,
       expectedEvents,
-      async () => {
+      callback: async () => {
         setMonacoContent(expected);
         await waitFor('[data-test-save-idle]');
       },
-    );
+    });
 
     await percySnapshot(assert);
 

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -729,15 +729,15 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await click('[data-test-action-button="Delete"]');
     await waitFor(`[data-test-delete-modal="${testRealmURL}Pet/vangogh"]`);
     await percySnapshot(assert);
-    await this.expectEvents(
+    await this.expectEvents({
       assert,
       realm,
       adapter,
       expectedEvents,
-      async () => {
+      callback: async () => {
         await click('[data-test-confirm-delete-button]');
       },
-    );
+    });
     await waitFor('[data-test-empty-code-mode]');
     await percySnapshot(
       'Acceptance | operator mode tests | Can delete a card instance from code submode with no recent files - empty code submode',
@@ -816,15 +816,15 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await waitFor(`[data-test-action-button="Delete"]`);
     await click('[data-test-action-button="Delete"]');
     await waitFor(`[data-test-delete-modal="${testRealmURL}Pet/vangogh"]`);
-    await this.expectEvents(
+    await this.expectEvents({
       assert,
       realm,
       adapter,
       expectedEvents,
-      async () => {
+      callback: async () => {
         await click('[data-test-confirm-delete-button]');
       },
-    );
+    });
     await waitForCodeEditor();
     assert
       .dom('[data-test-card-url-bar-input]')

--- a/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
@@ -221,15 +221,15 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
     assert: Assert,
     expectedEvents: { type: string; data: Record<string, any> }[],
   ) {
-    await context.expectEvents(
+    await context.expectEvents({
       assert,
       realm,
       adapter,
       expectedEvents,
-      async () => {
+      callback: async () => {
         await click('[data-test-save-field-button]');
       },
-    );
+    });
   }
   setupApplicationTest(hooks);
   setupLocalIndexing(hooks);

--- a/packages/host/tests/acceptance/interact-submode-test.ts
+++ b/packages/host/tests/acceptance/interact-submode-test.ts
@@ -947,12 +947,12 @@ module('Acceptance | interact submode tests', function (hooks) {
     assert
       .dom('[data-test-operator-mode-stack="0"] [data-test-person]')
       .hasText('Fadhlan');
-    await this.expectEvents(
+    await this.expectEvents({
       assert,
       realm,
       adapter,
       expectedEvents,
-      async () => {
+      callback: async () => {
         await realm.write(
           'Person/fadhlan.json',
           JSON.stringify({
@@ -971,7 +971,7 @@ module('Acceptance | interact submode tests', function (hooks) {
           } as LooseSingleCardDocument),
         );
       },
-    );
+    });
     await waitUntil(
       () =>
         document
@@ -1013,12 +1013,12 @@ module('Acceptance | interact submode tests', function (hooks) {
       )}`,
     );
     await waitFor('[data-test-card-resource-loaded]');
-    await this.expectEvents(
+    await this.expectEvents({
       assert,
       realm,
       adapter,
       expectedEvents,
-      async () => {
+      callback: async () => {
         await realm.write(
           'Person/fadhlan.json',
           JSON.stringify({
@@ -1037,7 +1037,7 @@ module('Acceptance | interact submode tests', function (hooks) {
           } as LooseSingleCardDocument),
         );
       },
-    );
+    });
     await waitUntil(
       () =>
         document

--- a/packages/host/tests/integration/components/card-copy-test.gts
+++ b/packages/host/tests/integration/components/card-copy-test.gts
@@ -1,4 +1,5 @@
 import { waitUntil, waitFor, click } from '@ember/test-helpers';
+import { validate as uuidValidate } from 'uuid';
 import GlimmerComponent from '@glimmer/component';
 
 import percySnapshot from '@percy/ember';
@@ -12,6 +13,8 @@ import {
 } from '@cardstack/runtime-common';
 import { Loader } from '@cardstack/runtime-common/loader';
 import { Realm } from '@cardstack/runtime-common/realm';
+
+import flatMap from 'lodash/flatMap';
 
 import CardPrerender from '@cardstack/host/components/card-prerender';
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
@@ -614,19 +617,8 @@ module('Integration | card-copy', function (hooks) {
       .containsText('Copy 1 Card', 'button text is correct');
   });
 
-  // HASSAN START HERE ON TUES
-
   test<TestContextForCopy>('can copy a card', async function (assert) {
-    assert.expect(11);
-    let expectedEvents = [
-      {
-        type: 'index',
-        data: {
-          type: 'incremental',
-          invalidations: [`${testRealm2URL}Pet/1`],
-        },
-      },
-    ];
+    assert.expect(12);
     await setCardInOperatorModeState(
       [`${testRealmURL}index`],
       [`${testRealm2URL}index`],
@@ -639,11 +631,14 @@ module('Integration | card-copy', function (hooks) {
         </template>
       },
     );
+    let id: string | undefined;
     this.onSave((json) => {
       if (typeof json === 'string') {
         throw new Error('expected JSON save data');
       }
-      assert.strictEqual(json.data.id, `${testRealm2URL}Pet/1`);
+      id = json.data.id.split('/').pop()!;
+      assert.true(uuidValidate(id), 'card identifier is UUID');
+      assert.strictEqual(json.data.id, `${testRealm2URL}Pet/${id}`);
       assert.strictEqual(json.data.attributes?.firstName, 'Mango');
       assert.deepEqual(json.data.meta.adoptsFrom, {
         module: `${testRealmURL}pet`,
@@ -655,7 +650,19 @@ module('Integration | card-copy', function (hooks) {
       assert,
       realm: realm2,
       adapter: adapter2,
-      expectedEvents,
+      expectedNumberOfEvents: 1,
+      onEvents: ([event]) => {
+        if (event.type === 'index') {
+          assert.deepEqual(event.data.invalidations, [
+            `${testRealm2URL}Pet/${id}`,
+          ]);
+        } else {
+          assert.ok(
+            false,
+            `expected 'index' event, but received ${JSON.stringify(event)}`,
+          );
+        }
+      },
       callback: async () => {
         await waitFor(
           '[data-test-operator-mode-stack="0"] [data-test-cards-grid-item]',
@@ -669,11 +676,13 @@ module('Integration | card-copy', function (hooks) {
         assert
           .dom(`.selected[data-test-overlay-card="${testRealmURL}Pet/mango"]`)
           .exists('souce card is selected');
-        assert
-          .dom(
-            `[data-test-operator-mode-stack="1"] [data-test-cards-grid-item="${testRealm2URL}Pet/1"]`,
-          )
-          .doesNotExist('card does not initially exist in destiation realm');
+        assert.strictEqual(
+          document.querySelectorAll(
+            '[data-test-operator-mode-stack="1"] [data-test-cards-grid-item]',
+          ).length,
+          1,
+          '1 card exists in destination realm',
+        );
         await click('[data-test-copy-button]');
       },
     });
@@ -683,14 +692,17 @@ module('Integration | card-copy', function (hooks) {
           `[data-test-operator-mode-stack="1"] [data-test-cards-grid-item]`,
         ).length === 2,
     );
+    if (!id) {
+      assert.ok(false, 'new card identifier was undefined');
+    }
     assert
       .dom(
-        `[data-test-operator-mode-stack="1"] [data-test-cards-grid-item="${testRealm2URL}Pet/1"]`,
+        `[data-test-operator-mode-stack="1"] [data-test-cards-grid-item="${testRealm2URL}Pet/${id}"]`,
       )
       .exists('copied card appears in destination realm');
     assert
       .dom(
-        `[data-test-operator-mode-stack="1"] [data-test-cards-grid-item="${testRealm2URL}Pet/1"]`,
+        `[data-test-operator-mode-stack="1"] [data-test-cards-grid-item="${testRealm2URL}Pet/${id}"]`,
       )
       .containsText('Mango');
 
@@ -711,23 +723,7 @@ module('Integration | card-copy', function (hooks) {
   });
 
   test<TestContextForCopy>('can copy mulitple cards', async function (assert) {
-    assert.expect(8);
-    let expectedEvents = [
-      {
-        type: 'index',
-        data: {
-          type: 'incremental',
-          invalidations: [`${testRealm2URL}Pet/1`],
-        },
-      },
-      {
-        type: 'index',
-        data: {
-          type: 'incremental',
-          invalidations: [`${testRealm2URL}Pet/2`],
-        },
-      },
-    ];
+    assert.expect(7);
     await setCardInOperatorModeState(
       [`${testRealmURL}index`],
       [`${testRealm2URL}index`],
@@ -751,7 +747,19 @@ module('Integration | card-copy', function (hooks) {
       assert,
       realm: realm2,
       adapter: adapter2,
-      expectedEvents,
+      expectedNumberOfEvents: 2,
+      onEvents: (events) => {
+        assert.deepEqual(
+          events.map((e) => e.type),
+          ['index', 'index'],
+          'event types are correct',
+        );
+        assert.deepEqual(
+          flatMap(events, (e) => e.data.invalidations),
+          [savedCards[0].data.id, savedCards[1].data.id],
+          'event invalidations are correct',
+        );
+      },
       callback: async () => {
         await waitFor(
           '[data-test-operator-mode-stack="0"] [data-test-cards-grid-item]',
@@ -766,16 +774,13 @@ module('Integration | card-copy', function (hooks) {
           `[data-test-overlay-card="${testRealmURL}Pet/vangogh"] button.select`,
         );
 
-        assert
-          .dom(
-            `[data-test-operator-mode-stack="1"] [data-test-cards-grid-item="${testRealm2URL}Pet/1"]`,
-          )
-          .doesNotExist('card does not initially exist in destiation realm');
-        assert
-          .dom(
-            `[data-test-operator-mode-stack="1"] [data-test-cards-grid-item="${testRealm2URL}Pet/2"]`,
-          )
-          .doesNotExist('card does not initially exist in destiation realm');
+        assert.strictEqual(
+          document.querySelectorAll(
+            '[data-test-operator-mode-stack="1"] [data-test-cards-grid-item]',
+          ).length,
+          1,
+          '1 card exists in destination realm',
+        );
         await click('[data-test-copy-button]');
       },
     });
@@ -785,21 +790,18 @@ module('Integration | card-copy', function (hooks) {
           `[data-test-operator-mode-stack="1"] [data-test-cards-grid-item]`,
         ).length === 3,
     );
-    assert
-      .dom(
-        `[data-test-operator-mode-stack="1"] [data-test-cards-grid-item="${testRealm2URL}Pet/1"]`,
-      )
-      .exists('copied card appears in destination realm');
-    assert
-      .dom(
-        `[data-test-operator-mode-stack="1"] [data-test-cards-grid-item="${testRealm2URL}Pet/2"]`,
-      )
-      .exists('copied card appears in destination realm');
     assert.strictEqual(savedCards.length, 2, 'correct number of cards saved');
-    assert.deepEqual(savedCards.map((c) => c.data.id).sort(), [
-      `${testRealm2URL}Pet/1`,
-      `${testRealm2URL}Pet/2`,
-    ]);
+    let cardIds = savedCards.map((c) => c.data.id.split('/').pop()!);
+    assert
+      .dom(
+        `[data-test-operator-mode-stack="1"] [data-test-cards-grid-item="${testRealm2URL}Pet/${cardIds[0]}"]`,
+      )
+      .exists('copied card appears in destination realm');
+    assert
+      .dom(
+        `[data-test-operator-mode-stack="1"] [data-test-cards-grid-item="${testRealm2URL}Pet/${cardIds[1]}"]`,
+      )
+      .exists('copied card appears in destination realm');
     assert.deepEqual(
       savedCards.map((c) => c.data.attributes?.firstName).sort(),
       ['Mango', 'Van Gogh'],
@@ -808,15 +810,6 @@ module('Integration | card-copy', function (hooks) {
 
   test<TestContextForCopy>('can copy a card that has a relative link to card in source realm', async function (assert) {
     assert.expect(15);
-    let expectedEvents = [
-      {
-        type: 'index',
-        data: {
-          type: 'incremental',
-          invalidations: [`${testRealm2URL}Person/1`],
-        },
-      },
-    ];
     await setCardInOperatorModeState(
       [`${testRealmURL}index`],
       [`${testRealm2URL}index`],
@@ -841,11 +834,13 @@ module('Integration | card-copy', function (hooks) {
       }
     };
 
+    let id: string | undefined;
     this.onSave((json) => {
       if (typeof json === 'string') {
         throw new Error('expected JSON save data');
       }
-      assert.strictEqual(json.data.id, `${testRealm2URL}Person/1`);
+      id = json.data.id.split('/').pop()!;
+      assert.strictEqual(json.data.id, `${testRealm2URL}Person/${id}`);
       assert.strictEqual(json.data.attributes?.firstName, 'Hassan');
       assert.deepEqual(json.data.meta.adoptsFrom, {
         module: `${testRealmURL}person`,
@@ -876,7 +871,19 @@ module('Integration | card-copy', function (hooks) {
       assert,
       realm: realm2,
       adapter: adapter2,
-      expectedEvents,
+      expectedNumberOfEvents: 1,
+      onEvents: ([event]) => {
+        if (event.type === 'index') {
+          assert.deepEqual(event.data.invalidations, [
+            `${testRealm2URL}Person/${id}`,
+          ]);
+        } else {
+          assert.ok(
+            false,
+            `expected 'index' event, but received ${JSON.stringify(event)}`,
+          );
+        }
+      },
       callback: async () => {
         await waitFor(
           '[data-test-operator-mode-stack="0"] [data-test-cards-grid-item]',
@@ -888,11 +895,13 @@ module('Integration | card-copy', function (hooks) {
           `[data-test-overlay-card="${testRealmURL}Person/hassan"] button.select`,
         );
 
-        assert
-          .dom(
-            `[data-test-operator-mode-stack="1"] [data-test-cards-grid-item="${testRealm2URL}Person/1"]`,
-          )
-          .doesNotExist('card does not initially exist in destiation realm');
+        assert.strictEqual(
+          document.querySelectorAll(
+            '[data-test-operator-mode-stack="1"] [data-test-cards-grid-item]',
+          ).length,
+          1,
+          '1 card exists in destination realm',
+        );
         await click('[data-test-copy-button]');
       },
     });
@@ -902,30 +911,24 @@ module('Integration | card-copy', function (hooks) {
           `[data-test-operator-mode-stack="1"] [data-test-cards-grid-item]`,
         ).length === 2,
     );
+    if (!id) {
+      assert.ok(false, 'new card identifier was undefined');
+    }
     assert
       .dom(
-        `[data-test-operator-mode-stack="1"] [data-test-cards-grid-item="${testRealm2URL}Person/1"]`,
+        `[data-test-operator-mode-stack="1"] [data-test-cards-grid-item="${testRealm2URL}Person/${id}"]`,
       )
       .exists('copied card appears in destination realm');
 
     assert
       .dom(
-        `[data-test-operator-mode-stack="1"] [data-test-cards-grid-item="${testRealm2URL}Person/1"]`,
+        `[data-test-operator-mode-stack="1"] [data-test-cards-grid-item="${testRealm2URL}Person/${id}"]`,
       )
       .containsText('Hassan');
   });
 
   test<TestContextForCopy>('can copy a card that has a link to card in destination realm', async function (assert) {
     assert.expect(15);
-    let expectedEvents = [
-      {
-        type: 'index',
-        data: {
-          type: 'incremental',
-          invalidations: [`${testRealm2URL}Person/1`],
-        },
-      },
-    ];
     await setCardInOperatorModeState(
       [`${testRealmURL}index`],
       [`${testRealm2URL}index`],
@@ -949,11 +952,13 @@ module('Integration | card-copy', function (hooks) {
         );
       }
     };
+    let id: string | undefined;
     this.onSave((json) => {
       if (typeof json === 'string') {
         throw new Error('expected JSON save data');
       }
-      assert.strictEqual(json.data.id, `${testRealm2URL}Person/1`);
+      id = json.data.id.split('/').pop()!;
+      assert.strictEqual(json.data.id, `${testRealm2URL}Person/${id}`);
       assert.strictEqual(json.data.attributes?.firstName, 'Sakura');
       assert.deepEqual(json.data.meta.adoptsFrom, {
         module: `${testRealmURL}person`,
@@ -984,7 +989,19 @@ module('Integration | card-copy', function (hooks) {
       assert,
       realm: realm2,
       adapter: adapter2,
-      expectedEvents,
+      expectedNumberOfEvents: 1,
+      onEvents: ([event]) => {
+        if (event.type === 'index') {
+          assert.deepEqual(event.data.invalidations, [
+            `${testRealm2URL}Person/${id}`,
+          ]);
+        } else {
+          assert.ok(
+            false,
+            `expected 'index' event, but received ${JSON.stringify(event)}`,
+          );
+        }
+      },
       callback: async () => {
         await waitFor(
           '[data-test-operator-mode-stack="0"] [data-test-cards-grid-item]',
@@ -996,11 +1013,13 @@ module('Integration | card-copy', function (hooks) {
           `[data-test-overlay-card="${testRealmURL}Person/sakura"] button.select`,
         );
 
-        assert
-          .dom(
-            `[data-test-operator-mode-stack="1"] [data-test-cards-grid-item="${testRealm2URL}Person/1"]`,
-          )
-          .doesNotExist('card does not initially exist in destiation realm');
+        assert.strictEqual(
+          document.querySelectorAll(
+            '[data-test-operator-mode-stack="1"] [data-test-cards-grid-item]',
+          ).length,
+          1,
+          '1 card exists in destination realm',
+        );
         await click('[data-test-copy-button]');
       },
     });
@@ -1010,15 +1029,18 @@ module('Integration | card-copy', function (hooks) {
           `[data-test-operator-mode-stack="1"] [data-test-cards-grid-item]`,
         ).length === 2,
     );
+    if (!id) {
+      assert.ok(false, 'new card identifier was undefined');
+    }
     assert
       .dom(
-        `[data-test-operator-mode-stack="1"] [data-test-cards-grid-item="${testRealm2URL}Person/1"]`,
+        `[data-test-operator-mode-stack="1"] [data-test-cards-grid-item="${testRealm2URL}Person/${id}"]`,
       )
       .exists('copied card appears in destination realm');
 
     assert
       .dom(
-        `[data-test-operator-mode-stack="1"] [data-test-cards-grid-item="${testRealm2URL}Person/1"]`,
+        `[data-test-operator-mode-stack="1"] [data-test-cards-grid-item="${testRealm2URL}Person/${id}"]`,
       )
       .containsText('Sakura');
   });

--- a/packages/host/tests/integration/components/card-copy-test.gts
+++ b/packages/host/tests/integration/components/card-copy-test.gts
@@ -614,6 +614,8 @@ module('Integration | card-copy', function (hooks) {
       .containsText('Copy 1 Card', 'button text is correct');
   });
 
+  // HASSAN START HERE ON TUES
+
   test<TestContextForCopy>('can copy a card', async function (assert) {
     assert.expect(11);
     let expectedEvents = [
@@ -649,12 +651,12 @@ module('Integration | card-copy', function (hooks) {
       });
       assert.strictEqual(json.data.meta.realmURL, testRealm2URL);
     });
-    await this.expectEvents(
+    await this.expectEvents({
       assert,
-      realm2,
-      adapter2,
+      realm: realm2,
+      adapter: adapter2,
       expectedEvents,
-      async () => {
+      callback: async () => {
         await waitFor(
           '[data-test-operator-mode-stack="0"] [data-test-cards-grid-item]',
         );
@@ -674,7 +676,7 @@ module('Integration | card-copy', function (hooks) {
           .doesNotExist('card does not initially exist in destiation realm');
         await click('[data-test-copy-button]');
       },
-    );
+    });
     await waitUntil(
       () =>
         document.querySelectorAll(
@@ -745,12 +747,12 @@ module('Integration | card-copy', function (hooks) {
       }
       savedCards.push(json);
     });
-    await this.expectEvents(
+    await this.expectEvents({
       assert,
-      realm2,
-      adapter2,
+      realm: realm2,
+      adapter: adapter2,
       expectedEvents,
-      async () => {
+      callback: async () => {
         await waitFor(
           '[data-test-operator-mode-stack="0"] [data-test-cards-grid-item]',
         );
@@ -776,7 +778,7 @@ module('Integration | card-copy', function (hooks) {
           .doesNotExist('card does not initially exist in destiation realm');
         await click('[data-test-copy-button]');
       },
-    );
+    });
     await waitUntil(
       () =>
         document.querySelectorAll(
@@ -870,12 +872,12 @@ module('Integration | card-copy', function (hooks) {
       });
       assert.deepEqual(included.meta.realmURL, testRealmURL);
     });
-    await this.expectEvents(
+    await this.expectEvents({
       assert,
-      realm2,
-      adapter2,
+      realm: realm2,
+      adapter: adapter2,
       expectedEvents,
-      async () => {
+      callback: async () => {
         await waitFor(
           '[data-test-operator-mode-stack="0"] [data-test-cards-grid-item]',
         );
@@ -893,7 +895,7 @@ module('Integration | card-copy', function (hooks) {
           .doesNotExist('card does not initially exist in destiation realm');
         await click('[data-test-copy-button]');
       },
-    );
+    });
     await waitUntil(
       () =>
         document.querySelectorAll(
@@ -978,12 +980,12 @@ module('Integration | card-copy', function (hooks) {
       });
       assert.deepEqual(included.meta.realmURL, testRealm2URL);
     });
-    await this.expectEvents(
+    await this.expectEvents({
       assert,
-      realm2,
-      adapter2,
+      realm: realm2,
+      adapter: adapter2,
       expectedEvents,
-      async () => {
+      callback: async () => {
         await waitFor(
           '[data-test-operator-mode-stack="0"] [data-test-cards-grid-item]',
         );
@@ -1001,7 +1003,7 @@ module('Integration | card-copy', function (hooks) {
           .doesNotExist('card does not initially exist in destiation realm');
         await click('[data-test-copy-button]');
       },
-    );
+    });
     await waitUntil(
       () =>
         document.querySelectorAll(

--- a/packages/host/tests/integration/components/card-delete-test.gts
+++ b/packages/host/tests/integration/components/card-delete-test.gts
@@ -219,15 +219,15 @@ module('Integration | card-delete', function (hooks) {
       'Integration | card-delete | can delete a card from the index card stack item, modal',
     );
 
-    await this.expectEvents(
+    await this.expectEvents({
       assert,
       realm,
       adapter,
       expectedEvents,
-      async () => {
+      callback: async () => {
         await click('[data-test-confirm-delete-button]');
       },
-    );
+    });
     await waitUntil(
       () =>
         document.querySelectorAll(
@@ -297,12 +297,12 @@ module('Integration | card-delete', function (hooks) {
     );
     let fileRef = await adapter.openFile('Pet/mango.json');
     assert.ok(fileRef, 'card instance exists in file system');
-    await this.expectEvents(
+    await this.expectEvents({
       assert,
       realm,
       adapter,
       expectedEvents,
-      async () => {
+      callback: async () => {
         await waitFor(`[data-test-operator-mode-stack="0"] [data-test-pet]`);
         assert
           .dom(
@@ -319,7 +319,7 @@ module('Integration | card-delete', function (hooks) {
           .containsText('Delete the card Mango?');
         await click('[data-test-confirm-delete-button]');
       },
-    );
+    });
     await waitUntil(
       () =>
         !document.querySelector(
@@ -360,12 +360,12 @@ module('Integration | card-delete', function (hooks) {
     );
     let fileRef = await adapter.openFile('Pet/mango.json');
     assert.ok(fileRef, 'card instance exists in file system');
-    await this.expectEvents(
+    await this.expectEvents({
       assert,
       realm,
       adapter,
       expectedEvents,
-      async () => {
+      callback: async () => {
         await waitFor(`[data-test-operator-mode-stack="0"] [data-test-pet]`);
         assert
           .dom(
@@ -385,7 +385,7 @@ module('Integration | card-delete', function (hooks) {
           .containsText('Delete the card Mango?');
         await click('[data-test-confirm-delete-button]');
       },
-    );
+    });
     await waitUntil(
       () =>
         !document.querySelector(
@@ -426,12 +426,12 @@ module('Integration | card-delete', function (hooks) {
     );
     let fileRef = await adapter.openFile('Pet/mango.json');
     assert.ok(fileRef, 'card instance exists in file system');
-    await this.expectEvents(
+    await this.expectEvents({
       assert,
       realm,
       adapter,
       expectedEvents,
-      async () => {
+      callback: async () => {
         await waitFor(`[data-test-operator-mode-stack="0"] [data-test-pet]`);
         await waitFor(`[data-test-operator-mode-stack="1"] [data-test-pet]`);
         assert
@@ -454,7 +454,7 @@ module('Integration | card-delete', function (hooks) {
           .containsText('Delete the card Mango?');
         await click('[data-test-confirm-delete-button]');
       },
-    );
+    });
     await waitUntil(
       () =>
         !document.querySelector(
@@ -500,12 +500,12 @@ module('Integration | card-delete', function (hooks) {
     );
     let fileRef = await adapter.openFile('Pet/mango.json');
     assert.ok(fileRef, 'card instance exists in file system');
-    await this.expectEvents(
+    await this.expectEvents({
       assert,
       realm,
       adapter,
       expectedEvents,
-      async () => {
+      callback: async () => {
         await waitFor(
           `[data-test-operator-mode-stack="0"] [data-test-cards-grid-item="${testRealmURL}Pet/mango"]`,
         );
@@ -522,7 +522,7 @@ module('Integration | card-delete', function (hooks) {
           .containsText('Delete the card Mango?');
         await click('[data-test-confirm-delete-button]');
       },
-    );
+    });
     await waitUntil(
       () =>
         document.querySelectorAll(
@@ -564,12 +564,12 @@ module('Integration | card-delete', function (hooks) {
     );
     let fileRef = await adapter.openFile('Pet/mango.json');
     assert.ok(fileRef, 'card instance exists in file system');
-    await this.expectEvents(
+    await this.expectEvents({
       assert,
       realm,
       adapter,
       expectedEvents,
-      async () => {
+      callback: async () => {
         await waitFor(
           `[data-test-operator-mode-stack="0"] [data-test-cards-grid-item="${testRealmURL}Pet/mango"]`,
         );
@@ -589,7 +589,7 @@ module('Integration | card-delete', function (hooks) {
           .containsText('Delete the card Mango?');
         await click('[data-test-confirm-delete-button]');
       },
-    );
+    });
     await waitUntil(
       () =>
         !document.querySelector(
@@ -641,12 +641,12 @@ module('Integration | card-delete', function (hooks) {
     );
     let fileRef = await adapter.openFile('Pet/mango.json');
     assert.ok(fileRef, 'card instance exists in file system');
-    await this.expectEvents(
+    await this.expectEvents({
       assert,
       realm,
       adapter,
       expectedEvents,
-      async () => {
+      callback: async () => {
         await waitFor(
           `[data-test-operator-mode-stack="0"] [data-test-cards-grid-item="${testRealmURL}Pet/mango"]`,
         );
@@ -665,7 +665,7 @@ module('Integration | card-delete', function (hooks) {
           .containsText('Delete the card Mango?');
         await click('[data-test-confirm-delete-button]');
       },
-    );
+    });
     await waitUntil(
       () =>
         document.querySelectorAll(
@@ -705,12 +705,12 @@ module('Integration | card-delete', function (hooks) {
     );
     let fileRef = await adapter.openFile('Pet/mango.json');
     assert.ok(fileRef, 'card instance exists in file system');
-    await this.expectEvents(
+    await this.expectEvents({
       assert,
       realm,
       adapter,
       expectedEvents,
-      async () => {
+      callback: async () => {
         await waitFor(
           `[data-test-operator-mode-stack="0"] [data-test-cards-grid-item]`,
         );
@@ -736,7 +736,7 @@ module('Integration | card-delete', function (hooks) {
           .containsText('Delete the card Mango?');
         await click('[data-test-confirm-delete-button]');
       },
-    );
+    });
     await waitUntil(
       () =>
         document.querySelectorAll(

--- a/packages/host/tests/integration/realm-test.ts
+++ b/packages/host/tests/integration/realm-test.ts
@@ -4,6 +4,8 @@ import { setupRenderingTest } from 'ember-qunit';
 import { stringify } from 'qs';
 import { module, test } from 'qunit';
 
+import { validate as uuidValidate } from 'uuid';
+
 import { baseRealm, CodeRef } from '@cardstack/runtime-common';
 import { isSingleCardDocument } from '@cardstack/runtime-common/card-document';
 import {
@@ -393,154 +395,52 @@ module('Integration | realm', function (hooks) {
     }
   });
 
-  test<TestContextWithSSE>('realm can serve create card requests', async function (assert) {
+  test('realm can serve create card requests', async function (assert) {
     let adapter = new TestRealmAdapter({});
     let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
     await realm.ready;
-    let expected = [
-      {
-        type: 'index',
-        data: {
-          type: 'incremental',
-          invalidations: [`${testRealmURL}CardDef/1`],
+    let response = await realm.handle(
+      new Request(testRealmURL, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/vnd.card+json',
         },
-      },
-    ];
-    let response = await this.expectEvents(
-      assert,
-      realm,
-      adapter,
-      expected,
-      async () => {
-        let response = realm.handle(
-          new Request(testRealmURL, {
-            method: 'POST',
-            headers: {
-              Accept: 'application/vnd.card+json',
-            },
-            body: JSON.stringify(
-              {
-                data: {
-                  type: 'card',
-                  meta: {
-                    adoptsFrom: {
-                      module: 'https://cardstack.com/base/card-api',
-                      name: 'CardDef',
-                    },
-                  },
+        body: JSON.stringify(
+          {
+            data: {
+              type: 'card',
+              meta: {
+                adoptsFrom: {
+                  module: 'https://cardstack.com/base/card-api',
+                  name: 'CardDef',
                 },
               },
-              null,
-              2,
-            ),
-          }),
-        );
-        await Promise.all([realm.flushOperations(), realm.flushUpdateEvents()]);
-        return await response;
-      },
-    );
-    assert.strictEqual((await response).status, 201, 'successful http status');
-    let json = await response.json();
-    if (isSingleCardDocument(json)) {
-      assert.strictEqual(
-        json.data.id,
-        `${testRealmURL}CardDef/1`,
-        'the id is correct',
-      );
-      assert.ok(
-        (await adapter.openFile('CardDef/1.json'))?.content,
-        'file contents exist',
-      );
-    } else {
-      assert.ok(false, 'response body is not a card document');
-    }
-
-    let searchIndex = realm.searchIndex;
-    let result = await searchIndex.card(new URL(json.data.links.self));
-    if (result?.type === 'error') {
-      throw new Error(
-        `unexpected error when getting card from index: ${result.error.detail}`,
-      );
-    }
-    assert.strictEqual(
-      result?.doc.data.id,
-      `${testRealmURL}CardDef/1`,
-      'found card in index',
-    );
-  });
-
-  test<TestContextWithSSE>('new cards are assigned sequential IDs', async function (assert) {
-    let adapter = new TestRealmAdapter({
-      'CardDef/1.json': {
-        data: {
-          type: 'card',
-          meta: {
-            adoptsFrom: {
-              module: 'https://cardstack.com/base/card-api',
-              name: 'CardDef',
             },
           },
-        },
-      },
-    });
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
-    let expected = [
-      {
-        type: 'index',
-        data: {
-          type: 'incremental',
-          invalidations: [`${testRealmURL}CardDef/2`],
-        },
-      },
-    ];
-    let response = await this.expectEvents(
-      assert,
-      realm,
-      adapter,
-      expected,
-      async () => {
-        let response = realm.handle(
-          new Request(testRealmURL, {
-            method: 'POST',
-            headers: {
-              Accept: 'application/vnd.card+json',
-            },
-            body: JSON.stringify(
-              {
-                data: {
-                  type: 'card',
-                  meta: {
-                    adoptsFrom: {
-                      module: 'https://cardstack.com/base/card-api',
-                      name: 'CardDef',
-                    },
-                  },
-                },
-              },
-              null,
-              2,
-            ),
-          }),
-        );
-        await Promise.all([realm.flushOperations(), realm.flushUpdateEvents()]);
-        return await response;
-      },
+          null,
+          2,
+        ),
+      }),
     );
-    assert.strictEqual((await response).status, 201, 'successful http status');
     let json = await response.json();
+    let id: string | undefined;
     if (isSingleCardDocument(json)) {
+      id = json.data.id.split('/').pop()!;
+      assert.true(uuidValidate(id), 'card ID is a UUID');
       assert.strictEqual(
         json.data.id,
-        `${testRealmURL}CardDef/2`,
-        'the id is correct',
+        `${testRealmURL}CardDef/${id}`,
+        'the card URL is correct',
       );
       assert.ok(
-        (await adapter.openFile('CardDef/2.json'))?.content,
+        (await adapter.openFile(`CardDef/${id}.json`))?.content,
         'file contents exist',
       );
     } else {
       assert.ok(false, 'response body is not a card document');
+    }
+    if (!id) {
+      assert.ok(false, 'card document is missing an ID');
     }
 
     let searchIndex = realm.searchIndex;
@@ -552,7 +452,7 @@ module('Integration | realm', function (hooks) {
     }
     assert.strictEqual(
       result?.doc.data.id,
-      `${testRealmURL}CardDef/2`,
+      `${testRealmURL}CardDef/${id}`,
       'found card in index',
     );
   });
@@ -611,10 +511,12 @@ module('Integration | realm', function (hooks) {
     );
     assert.strictEqual(response.status, 201, 'successful http status');
     let json = await response.json();
+    let id = json.data.id.split('/').pop()!;
+    assert.ok(uuidValidate(id), 'card ID is a UUID');
     assert.deepEqual(json, {
       data: {
         type: 'card',
-        id: `${testRealmURL}Pet/1`,
+        id: `${testRealmURL}Pet/${id}`,
         attributes: {
           firstName: 'Mango',
           title: 'Mango',
@@ -637,12 +539,14 @@ module('Integration | realm', function (hooks) {
             module: 'http://localhost:4202/test/pet',
             name: 'Pet',
           },
-          lastModified: adapter.lastModified.get(`${testRealmURL}Pet/1.json`),
+          lastModified: adapter.lastModified.get(
+            `${testRealmURL}Pet/${id}.json`,
+          ),
           realmInfo: testRealmInfo,
           realmURL: testRealmURL,
         },
         links: {
-          self: `${testRealmURL}Pet/1`,
+          self: `${testRealmURL}Pet/${id}`,
         },
       },
       included: [
@@ -674,7 +578,7 @@ module('Integration | realm', function (hooks) {
         },
       ],
     });
-    let fileRef = await adapter.openFile('Pet/1.json');
+    let fileRef = await adapter.openFile(`Pet/${id}.json`);
     if (!fileRef) {
       throw new Error('file not found');
     }
@@ -726,7 +630,7 @@ module('Integration | realm', function (hooks) {
     });
     let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
     await realm.ready;
-    let expected = [
+    let expectedEvents = [
       {
         type: 'index',
         data: {
@@ -735,12 +639,12 @@ module('Integration | realm', function (hooks) {
         },
       },
     ];
-    let response = await this.expectEvents(
+    let response = await this.expectEvents({
       assert,
       realm,
       adapter,
-      expected,
-      async () => {
+      expectedEvents,
+      callback: async () => {
         let response = realm.handle(
           new Request(`${testRealmURL}dir/card`, {
             method: 'PATCH',
@@ -770,7 +674,7 @@ module('Integration | realm', function (hooks) {
         await Promise.all([realm.flushOperations(), realm.flushUpdateEvents()]);
         return await response;
       },
-    );
+    });
     assert.strictEqual(response.status, 200, 'successful http status');
     let json = await response.json();
     if (isSingleCardDocument(json)) {
@@ -2019,7 +1923,7 @@ module('Integration | realm', function (hooks) {
       'found card in index',
     );
 
-    let expected = [
+    let expectedEvents = [
       {
         type: 'index',
         data: {
@@ -2028,12 +1932,12 @@ module('Integration | realm', function (hooks) {
         },
       },
     ];
-    let response = await this.expectEvents(
+    let response = await this.expectEvents({
       assert,
       realm,
       adapter,
-      expected,
-      async () => {
+      expectedEvents,
+      callback: async () => {
         let response = realm.handle(
           new Request(`${testRealmURL}cards/2`, {
             method: 'DELETE',
@@ -2045,7 +1949,7 @@ module('Integration | realm', function (hooks) {
         await Promise.all([realm.flushOperations(), realm.flushUpdateEvents()]);
         return await response;
       },
-    );
+    });
     assert.strictEqual(response.status, 204, 'status was 204');
 
     result = await searchIndex.card(new URL(`${testRealmURL}cards/2`));
@@ -2135,7 +2039,7 @@ module('Integration | realm', function (hooks) {
     await realm.ready;
 
     {
-      let expected = [
+      let expectedEvents = [
         {
           type: 'index',
           data: {
@@ -2144,12 +2048,12 @@ module('Integration | realm', function (hooks) {
           },
         },
       ];
-      let response = await this.expectEvents(
+      let response = await this.expectEvents({
         assert,
         realm,
         adapter,
-        expected,
-        async () => {
+        expectedEvents,
+        callback: async () => {
           let response = realm.handle(
             new Request(`${testRealmURL}dir/person.gts`, {
               method: 'POST',
@@ -2165,7 +2069,7 @@ module('Integration | realm', function (hooks) {
           ]);
           return await response;
         },
-      );
+      });
 
       assert.strictEqual(response.status, 204, 'HTTP status is 204');
       assert.ok(
@@ -2202,7 +2106,7 @@ module('Integration | realm', function (hooks) {
     let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
     await realm.ready;
 
-    let expected = [
+    let expectedEvents = [
       {
         type: 'index',
         data: {
@@ -2211,12 +2115,12 @@ module('Integration | realm', function (hooks) {
         },
       },
     ];
-    let response = await this.expectEvents(
+    let response = await this.expectEvents({
       assert,
       realm,
       adapter,
-      expected,
-      async () => {
+      expectedEvents,
+      callback: async () => {
         let response = realm.handle(
           new Request(`${testRealmURL}person`, {
             headers: {
@@ -2238,7 +2142,7 @@ module('Integration | realm', function (hooks) {
         await Promise.all([realm.flushOperations(), realm.flushUpdateEvents()]);
         return await response;
       },
-    );
+    });
     assert.strictEqual(response.status, 204, 'file is deleted');
 
     response = await realm.handle(

--- a/packages/realm-server/package.json
+++ b/packages/realm-server/package.json
@@ -24,6 +24,7 @@
     "@types/sane": "^2.0.1",
     "@types/supertest": "^2.0.12",
     "@types/tmp": "^0.2.3",
+    "@types/uuid": "^9.0.4",
     "@types/yargs": "^17.0.10",
     "basic-auth": "^2.0.1",
     "date-fns": "^2.28.0",
@@ -53,6 +54,7 @@
     "ts-node": "^10.9.1",
     "typescript": "^5.1.6",
     "typescript-memoize": "^1.1.1",
+    "uuid": "^9.0.1",
     "yargs": "^17.5.1"
   },
   "scripts": {

--- a/packages/runtime-common/package.json
+++ b/packages/runtime-common/package.json
@@ -23,6 +23,7 @@
     "@types/lodash": "^4.14.182",
     "@types/pluralize": "^0.0.30",
     "@types/qs": "^6.9.7",
+    "@types/uuid": "^9.0.4",
     "babel-import-util": "^1.2.2",
     "babel-plugin-ember-template-compilation": "^2.2.0",
     "date-fns": "^2.28.0",
@@ -41,7 +42,8 @@
     "qs": "^6.10.5",
     "qunit": "^2.18.0",
     "super-fast-md5": "^1.0.1",
-    "transform-modules-amd-plugin": "workspace:*"
+    "transform-modules-amd-plugin": "workspace:*",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.22.11",

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -747,17 +747,10 @@ export class Realm {
       name = 'cards';
     }
 
-    let localPath: LocalPath | undefined;
-    let fileURL: URL | undefined;
-    while (!fileURL || !localPath || (await this.#adapter.exists(localPath))) {
-      let pathname = `/${join(
-        new URL(this.url).pathname,
-        name,
-        uuidV4() + '.json',
-      )}`;
-      fileURL = this.paths.fileURL(pathname);
-      localPath = this.paths.local(fileURL);
-    }
+    let fileURL = this.paths.fileURL(
+      `/${join(new URL(this.url).pathname, name, uuidV4() + '.json')}`,
+    );
+    let localPath = this.paths.local(fileURL);
     let { lastModified } = await this.write(
       localPath,
       JSON.stringify(

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -14,6 +14,7 @@ import {
   badRequest,
   CardError,
 } from './error';
+import { v4 as uuidV4 } from 'uuid';
 import { formatRFC7231 } from 'date-fns';
 import { md5 } from 'super-fast-md5';
 import {
@@ -746,24 +747,17 @@ export class Realm {
       name = 'cards';
     }
 
-    let dirName = `/${join(new URL(this.url).pathname, name)}/`;
-    let entries = await this.directoryEntries(new URL(dirName, this.url));
-    let index = 0;
-    if (entries) {
-      for (let { name, kind } of entries) {
-        if (kind === 'directory') {
-          continue;
-        }
-        if (!/^[\d]+\.json$/.test(name)) {
-          continue;
-        }
-        let num = parseInt(name.replace('.json', ''));
-        index = Math.max(index, num);
-      }
+    let localPath: LocalPath | undefined;
+    let fileURL: URL | undefined;
+    while (!fileURL || !localPath || (await this.#adapter.exists(localPath))) {
+      let pathname = `/${join(
+        new URL(this.url).pathname,
+        name,
+        uuidV4() + '.json',
+      )}`;
+      fileURL = this.paths.fileURL(pathname);
+      localPath = this.paths.local(fileURL);
     }
-    let pathname = `${dirName}${++index}.json`;
-    let fileURL = this.paths.fileURL(pathname);
-    let localPath: LocalPath = this.paths.local(fileURL);
     let { lastModified } = await this.write(
       localPath,
       JSON.stringify(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1689,6 +1689,9 @@ importers:
       '@types/qs':
         specifier: ^6.9.7
         version: 6.9.7
+      '@types/uuid':
+        specifier: ^9.0.4
+        version: 9.0.4
       babel-import-util:
         specifier: ^1.2.2
         version: 1.2.2
@@ -1746,6 +1749,9 @@ importers:
       transform-modules-amd-plugin:
         specifier: workspace:*
         version: link:../../vendor/transform-modules-amd-plugin
+      uuid:
+        specifier: ^9.0.1
+        version: 9.0.1
     devDependencies:
       '@babel/core':
         specifier: ^7.22.11
@@ -5939,7 +5945,6 @@ packages:
 
   /@types/uuid@9.0.4:
     resolution: {integrity: sha512-zAuJWQflfx6dYJM62vna+Sn5aeSWhh3OB+wfUEACNcqUSc0AGc5JKl+ycL1vrH7frGTXhJchYjE1Hak8L819dA==}
-    dev: true
 
   /@types/yargs-parser@21.0.2:
     resolution: {integrity: sha512-5qcvofLPbfjmBfKaLfj/+f+Sbd6pN4zl7w7VSVI5uz7m9QZTuB2aZAa2uo1wHFBNN2x6g/SoTkXmd8mQnQF2Cw==}
@@ -8097,6 +8102,7 @@ packages:
 
   /bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+    requiresBuild: true
     dependencies:
       file-uri-to-path: 1.0.0
     dev: true
@@ -14565,6 +14571,7 @@ packages:
 
   /file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -18743,6 +18750,7 @@ packages:
 
   /nan@2.18.0:
     resolution: {integrity: sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -23429,7 +23437,6 @@ packages:
   /uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
-    dev: true
 
   /v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
@@ -24879,6 +24886,7 @@ packages:
       '@types/lodash': 4.14.182
       '@types/pluralize': 0.0.30
       '@types/qs': 6.9.7
+      '@types/uuid': 9.0.4
       babel-import-util: 1.2.2
       babel-plugin-ember-template-compilation: 2.2.0
       date-fns: 2.30.0
@@ -24899,6 +24907,7 @@ packages:
       qunit: 2.19.4
       super-fast-md5: 1.0.1
       transform-modules-amd-plugin: link:vendor/transform-modules-amd-plugin
+      uuid: 9.0.1
     transitivePeerDependencies:
       - '@angular/core'
       - '@glimmer/component'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1536,6 +1536,9 @@ importers:
       '@types/tmp':
         specifier: ^0.2.3
         version: 0.2.3
+      '@types/uuid':
+        specifier: ^9.0.4
+        version: 9.0.4
       '@types/yargs':
         specifier: ^17.0.10
         version: 17.0.10
@@ -1623,6 +1626,9 @@ importers:
       typescript-memoize:
         specifier: ^1.1.1
         version: 1.1.1
+      uuid:
+        specifier: ^9.0.1
+        version: 9.0.1
       yargs:
         specifier: ^17.5.1
         version: 17.5.1
@@ -11187,7 +11193,7 @@ packages:
       '@babel/plugin-proposal-decorators': 7.22.10(@babel/core@7.22.11)
       '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.22.11)
       '@babel/plugin-proposal-private-property-in-object': 7.21.11(@babel/core@7.22.11)
-      '@babel/plugin-transform-modules-amd': 7.13.0(@babel/core@7.22.11)
+      '@babel/plugin-transform-modules-amd': 7.23.0(@babel/core@7.22.11)
       '@babel/plugin-transform-runtime': 7.23.2(@babel/core@7.22.11)
       '@babel/plugin-transform-typescript': 7.22.15(@babel/core@7.22.11)
       '@babel/polyfill': 7.12.1


### PR DESCRIPTION
This PR updates the realm to use UUID's as card identifiers instead of sequence numbers. Also, this PR updates the `expectEvents()` that is used to drive SSE in tests so that it is more flexible, as we won't know the new card IDs in advance.