### PR TITLE
Preserve scroll position when switching between different formats in card preview

### DIFF
--- a/packages/host/app/modifiers/scroll-into-view.ts
+++ b/packages/host/app/modifiers/scroll-into-view.ts
@@ -1,4 +1,4 @@
-import Modifier, { type PositionalArgs } from 'ember-modifier';
+import Modifier, { PositionalArgs } from 'ember-modifier';
 
 interface ScrollIntoViewModifierArgs {
   Positional: [boolean];
@@ -10,17 +10,20 @@ interface ScrollIntoViewModifierSignature {
 }
 
 export default class ScrollIntoViewModifier extends Modifier<ScrollIntoViewModifierSignature> {
+  element!: Element;
   #didSetup = false;
 
   modify(
     element: Element,
     [shouldScrollIntoView]: PositionalArgs<ScrollIntoViewModifierSignature>,
   ): void {
+    this.element = element;
+
     if (!this.#didSetup) {
       this.#didSetup = true;
 
       if (shouldScrollIntoView) {
-        element.scrollIntoView({ block: 'center' });
+        this.element.scrollIntoView({ block: 'center' });
       }
     }
   }

--- a/packages/host/app/modifiers/scroll-into-view.ts
+++ b/packages/host/app/modifiers/scroll-into-view.ts
@@ -1,4 +1,4 @@
-import Modifier, { PositionalArgs } from 'ember-modifier';
+import Modifier, { type PositionalArgs } from 'ember-modifier';
 
 interface ScrollIntoViewModifierArgs {
   Positional: [boolean];
@@ -10,20 +10,17 @@ interface ScrollIntoViewModifierSignature {
 }
 
 export default class ScrollIntoViewModifier extends Modifier<ScrollIntoViewModifierSignature> {
-  element!: Element;
   #didSetup = false;
 
   modify(
     element: Element,
     [shouldScrollIntoView]: PositionalArgs<ScrollIntoViewModifierSignature>,
   ): void {
-    this.element = element;
-
     if (!this.#didSetup) {
       this.#didSetup = true;
 
       if (shouldScrollIntoView) {
-        this.element.scrollIntoView({ block: 'center' });
+        element.scrollIntoView({ block: 'center' });
       }
     }
   }

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -111,6 +111,7 @@ const petCardSource = `
     }
     static isolated = class Isolated extends Component<typeof this> {
       <template>
+        <h1>{{@model.title}}</h1>
         <h2 data-test-pet={{@model.name}}>
           <@fields.name/>
         </h2>

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -5,6 +5,7 @@ import {
   fillIn,
   triggerKeyEvent,
   waitUntil,
+  scrollTo,
 } from '@ember/test-helpers';
 
 import percySnapshot from '@percy/ember';
@@ -106,6 +107,19 @@ const petCardSource = `
         <h3 data-test-pet={{@model.name}}>
           <@fields.name/>
         </h3>
+      </template>
+    }
+    static isolated = class Isolated extends Component<typeof this> {
+      <template>
+        <h2 data-test-pet={{@model.name}}>
+          <@fields.name/>
+        </h2>
+        <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/>
+        <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/>
+        <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/>
+        <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/>
+        <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/>
+        <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/>
       </template>
     }
   }
@@ -1049,5 +1063,33 @@ module('Acceptance | code submode tests', function (hooks) {
       `${testRealmURL}person.gts-test`,
     );
     assert.false(monacoService.hasFocus);
+  });
+
+  test('scroll position persists when changing card preview format', async function (assert) {
+    let operatorModeStateParam = stringify({
+      stacks: [[]],
+      submode: 'code',
+      codePath: `${testRealmURL}Pet/mango.json`,
+    })!;
+
+    await visit(
+      `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+        operatorModeStateParam,
+      )}`,
+    );
+    await waitForCodeEditor();
+    await waitFor('[data-test-code-mode-card-preview-body]');
+
+    await scrollTo('[data-test-code-mode-card-preview-body]', 0, 100);
+    await click('[data-test-preview-card-footer-button-edit]');
+    await click('[data-test-preview-card-footer-button-isolated]');
+    let element = document.querySelector(
+      '[data-test-code-mode-card-preview-body]',
+    )!;
+    assert.strictEqual(
+      element.scrollTop,
+      100,
+      'the scroll position is correct',
+    );
   });
 });

--- a/packages/host/tests/acceptance/code-submode/recent-files-test.ts
+++ b/packages/host/tests/acceptance/code-submode/recent-files-test.ts
@@ -338,11 +338,17 @@ module('Acceptance | code submode | recent files tests', function (hooks) {
 
     assert.dom('[data-test-recent-file]').exists({ count: 2 });
 
+    await waitFor(
+      '[data-test-recent-file]:nth-child(1) [data-test-realm-icon-url]',
+    );
     assert
       .dom('[data-test-recent-file]:nth-child(1) [data-test-realm-icon-url]')
       .hasAttribute('src', 'https://i.postimg.cc/L8yXRvws/icon.png')
       .hasAttribute('alt', 'Icon for realm Test Workspace B');
 
+    await waitFor(
+      '[data-test-recent-file]:nth-child(2) [data-test-realm-icon-url]',
+    );
     assert
       .dom('[data-test-recent-file]:nth-child(2) [data-test-realm-icon-url]')
       .hasAttribute('src', 'https://i.postimg.cc/d0B9qMvy/icon.png');


### PR DESCRIPTION
This preserves the scroll position when switching between different formats in the card preview (previously you were always scrolled to the top when ever changing the format of the card preview).

![scroll-position](https://github.com/cardstack/boxel/assets/61075/01c3a593-86ff-4666-b5b4-ca5bf82940d2)
