### PR TITLE
Fix resizable panel ratio issue when resizing

### DIFF
--- a/packages/boxel-ui/addon/package.json
+++ b/packages/boxel-ui/addon/package.json
@@ -47,13 +47,15 @@
     "ember-link": "^2.1.0",
     "ember-load-initializers": "^2.1.2",
     "ember-modifier": "^4.1.0",
+    "ember-ref-bucket": "5.0.5",
     "ember-resize-modifier": "^0.6.0",
     "ember-set-body-class": "^1.0.2",
     "ember-velcro": "^2.1.0",
     "file-loader": "^6.2.0",
     "focus-trap": "^7.4.3",
     "lodash": "^4.17.21",
-    "tracked-built-ins": "^3.2.0"
+    "tracked-built-ins": "^3.2.0",
+    "typescript": "^5.1.6"
   },
   "devDependencies": {
     "@babel/core": "^7.22.11",

--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
@@ -511,7 +511,7 @@ export default class ResizablePanelGroup extends Component<Signature> {
         panelLengths[panelContext.id] = actualSize;
       });
     };
-    calculateLengtsOfPanelWithoutMinLegth();
+    calculateLengthsOfPanelWithoutMinLength();
 
     for (let index = 0; index <= this.listPanelContext.size; index++) {
       let panelContext = this.listPanelContext.get(index);

--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
@@ -4,6 +4,8 @@ import { next } from '@ember/runloop';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import type { WithBoundArgs } from '@glint/template';
+import { nodeFor } from 'ember-ref-bucket';
+import { resolveGlobalRef } from 'ember-ref-bucket/utils/ref';
 import didResizeModifier from 'ember-resize-modifier/modifiers/did-resize';
 import { TrackedMap } from 'tracked-built-ins';
 
@@ -117,10 +119,8 @@ export default class ResizablePanelGroup extends Component<Signature> {
   }
 
   private get panelGroupLengthWithoutResizeHandlerPx() {
-    let resizeHandlerSelector = `#resize-handler-${this.args.orientation}-0`;
-    let resizeHandlerEl = this.panelGroupElement?.querySelector(
-      resizeHandlerSelector,
-    ) as HTMLElement;
+    let resizeHandlerSelector = `resize-handler-${this.args.orientation}-0`;
+    let resizeHandlerEl = this.getHtmlElement(resizeHandlerSelector);
     if (!resizeHandlerEl) {
       console.error(
         `Could not find selector: ${resizeHandlerSelector} when handling window resize for resizeable panel group`,
@@ -214,7 +214,7 @@ export default class ResizablePanelGroup extends Component<Signature> {
       return;
     }
 
-    let parentElement = document.querySelector(`#${buttonId}`)?.parentElement;
+    let parentElement = this.getHtmlElement(buttonId).parentElement;
     this.currentResizeHandler = {
       id: buttonId,
       initialPosition: event[this.clientPositionProperty],
@@ -335,7 +335,7 @@ export default class ResizablePanelGroup extends Component<Signature> {
       return undefined;
     }
 
-    let parentElement = document.querySelector(`#${buttonId}`)?.parentElement;
+    let parentElement = this.getHtmlElement(buttonId).parentElement;
     let prevEl = parentElement?.previousElementSibling as HTMLElement;
     let nextEl = parentElement?.nextElementSibling as HTMLElement;
 
@@ -516,5 +516,9 @@ export default class ResizablePanelGroup extends Component<Signature> {
         });
       }
     }
+  }
+
+  private getHtmlElement(id: string): HTMLElement {
+    return nodeFor(resolveGlobalRef(), id);
   }
 }

--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
@@ -183,7 +183,6 @@ export default class ResizablePanelGroup extends Component<Signature> {
     return id;
   }
 
-  @action
   calculatePanelRatio() {
     let panelLengths = Array.from(this.listPanelContext.values()).map(
       (panelContext) => panelContext.lengthPx,

--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
@@ -254,9 +254,7 @@ export default class ResizablePanelGroup extends Component<Signature> {
     let firstElContext = this.listPanelContext.get(Number(firstElId));
     let secondElContext = this.listPanelContext.get(Number(secondElId));
     if (!firstElContext || !secondElContext) {
-      console.warn(
-        'Expected firstElContext && nextElCosecondElContextntext to be defined',
-      );
+      console.warn('Expected firstElContext && secondElContext to be defined');
       return;
     }
 

--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
@@ -325,6 +325,10 @@ export default class ResizablePanelGroup extends Component<Signature> {
   @action
   onResizeHandlerDblClick(event: MouseEvent) {
     let buttonId = (event.target as HTMLElement).id;
+    let isFirstButton = buttonId.includes('0');
+    let isLastButton = buttonId.includes(
+      String(this.listPanelContext.size - 2),
+    );
     let panelGroupLengthPx = this.panelGroupLengthWithoutResizeHandlerPx;
     if (panelGroupLengthPx === undefined) {
       console.warn('Expected panelGroupLengthPx to be defined');
@@ -343,11 +347,7 @@ export default class ResizablePanelGroup extends Component<Signature> {
     }
     let prevElLength = prevElContext.lengthPx;
     let nextElLength = nextElContext.lengthPx;
-    if (
-      buttonId.includes('0') &&
-      prevElLength > 0 &&
-      !this.args.reverseCollapse
-    ) {
+    if (isFirstButton && prevElLength > 0 && !this.args.reverseCollapse) {
       this.setSiblingPanelContexts(
         Number(prevEl.id),
         Number(nextEl.id),
@@ -356,7 +356,7 @@ export default class ResizablePanelGroup extends Component<Signature> {
         0,
         nextElContext.initialMinLengthPx,
       );
-    } else if (buttonId.includes('0') && prevElLength <= 0) {
+    } else if (isFirstButton && prevElLength <= 0) {
       this.setSiblingPanelContexts(
         Number(prevEl.id),
         Number(nextEl.id),
@@ -370,10 +370,7 @@ export default class ResizablePanelGroup extends Component<Signature> {
         prevElContext.initialMinLengthPx,
         nextElContext.initialMinLengthPx,
       );
-    } else if (
-      buttonId.includes(String(this.listPanelContext.size - 2)) &&
-      nextElLength > 0
-    ) {
+    } else if (isLastButton && nextElLength > 0) {
       this.setSiblingPanelContexts(
         Number(prevEl.id),
         Number(nextEl.id),
@@ -382,10 +379,7 @@ export default class ResizablePanelGroup extends Component<Signature> {
         prevElContext.initialMinLengthPx,
         0,
       );
-    } else if (
-      buttonId.includes(String(this.listPanelContext.size - 2)) &&
-      nextElLength <= 0
-    ) {
+    } else if (isLastButton && nextElLength <= 0) {
       this.setSiblingPanelContexts(
         Number(prevEl.id),
         Number(nextEl.id),
@@ -458,7 +452,7 @@ export default class ResizablePanelGroup extends Component<Signature> {
     }
 
     let remainingContainerSize = newContainerSize;
-    let calculateLengtsOfPanelWithMinLegth = () => {
+    let calculateLengthsOfPanelWithMinLegth = () => {
       let panelContexts = Array.from(this.listPanelContext)
         .map((panelContextTuple) => panelContextTuple[1])
         .filter((panelContext) => panelContext.initialMinLengthPx);
@@ -481,9 +475,9 @@ export default class ResizablePanelGroup extends Component<Signature> {
         remainingContainerSize = remainingContainerSize - actualSize;
       });
     };
-    calculateLengtsOfPanelWithMinLegth();
+    calculateLengthsOfPanelWithMinLegth();
 
-    let calculateLengtsOfPanelWithoutMinLegth = () => {
+    let calculateLengthsOfPanelWithoutMinLength = () => {
       let panelContexts = Array.from(this.listPanelContext)
         .map((panelContextTuple) => panelContextTuple[1])
         .filter((panelContext) => !panelContext.initialMinLengthPx);

--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
@@ -27,6 +27,7 @@ interface Signature {
     registerPanel: (context: {
       defaultLengthFraction: number | undefined;
       lengthPx: number | undefined;
+      minLengthPx: number | undefined;
     }) => number;
     reverseHandlerArrow: boolean;
   };
@@ -230,6 +231,7 @@ export default class Panel extends Component<Signature> {
     this.id = this.args.registerPanel({
       lengthPx: this.args.lengthPx,
       defaultLengthFraction: this.args.defaultLengthFraction,
+      minLengthPx: this.args.minLengthPx,
     });
   }
 

--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
@@ -8,10 +8,10 @@ import cssVars from '../../helpers/css-var.ts';
 import { eq } from '../../helpers/truth-helpers.ts';
 
 export type PanelContext = {
-  id: number;
   defaultLengthFraction?: number;
-  lengthPx: number;
+  id: number;
   initialMinLengthPx?: number;
+  lengthPx: number;
   minLengthPx?: number;
 };
 

--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
@@ -8,8 +8,10 @@ import cssVars from '../../helpers/css-var.ts';
 import { eq } from '../../helpers/truth-helpers.ts';
 
 export type PanelContext = {
+  id: number;
   defaultLengthFraction?: number;
   lengthPx: number;
+  initialMinLengthPx?: number;
   minLengthPx?: number;
 };
 
@@ -236,7 +238,7 @@ export default class Panel extends Component<Signature> {
   }
 
   get panelContext() {
-    if (!this.id) {
+    if (this.id == undefined) {
       return {
         lengthPx: undefined,
         defaultLengthFraction: this.args.defaultLengthFraction,
@@ -280,13 +282,13 @@ export default class Panel extends Component<Signature> {
     let horizontal = this.args.orientation === 'horizontal';
     let reverse = this.args.reverseHandlerArrow;
 
-    if (!this.id) {
+    if (this.id == undefined) {
       return '';
     }
 
     let toward: string | null = null;
 
-    let isFirstPanel = this.id === 1;
+    let isFirstPanel = this.id === 0;
     let isCollapsed = this.panelContext?.lengthPx === 0;
 
     let nextPanelIsLast = this.args.isLastPanel(this.id + 1);

--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
@@ -3,6 +3,8 @@ import { scheduleOnce } from '@ember/runloop';
 import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { ref } from 'ember-ref-bucket';
+import createRef from 'ember-ref-bucket/modifiers/create-ref';
 
 import cssVars from '../../helpers/css-var.ts';
 import { eq } from '../../helpers/truth-helpers.ts';
@@ -67,6 +69,7 @@ export default class Panel extends Component<Signature> {
           data-test-resize-handler={{this.resizeHandlerId}}
           {{on 'mousedown' @onResizeHandlerMouseDown}}
           {{on 'dblclick' @onResizeHandlerDblClick}}
+          {{createRef this.resizeHandlerId bucket=undefined}}
         ><div class={{this.arrowResizeHandlerClass}} /></button>
       </div>
     {{/unless}}
@@ -223,6 +226,7 @@ export default class Panel extends Component<Signature> {
   </template>
 
   @tracked id: number | undefined;
+  @ref('test') newButton: any | null = null;
 
   constructor(owner: any, args: any) {
     super(owner, args);

--- a/packages/boxel-ui/addon/src/types/ember-ref-bucket/index.d.ts
+++ b/packages/boxel-ui/addon/src/types/ember-ref-bucket/index.d.ts
@@ -1,0 +1,27 @@
+declare module 'ember-ref-bucket/modifiers/create-ref' {
+  import { ClassBasedModifier } from 'ember-modifier';
+
+  const createRef: ClassBasedModifier<{
+    Args: {
+      Named: {
+        attributes?: any;
+        character?: any;
+        children?: any;
+        resize?: any;
+        subtree?: any;
+        tracked?: any;
+      };
+    };
+  }>;
+
+  export default createRef;
+}
+
+declare module 'ember-ref-bucket' {
+  export declare let ref = (_name, _fn?): PropertyDecorator => {};
+  export function nodeFor(_context, _name): HTMLElement {}
+}
+
+declare module 'ember-ref-bucket/utils/ref' {
+  export function resolveGlobalRef() {}
+}

--- a/packages/boxel-ui/test-app/tests/integration/components/resizable-panel-group-test.gts
+++ b/packages/boxel-ui/test-app/tests/integration/components/resizable-panel-group-test.gts
@@ -144,35 +144,43 @@ module('Integration | ResizablePanelGroup', function (hooks) {
 
   test('it adjusts to its container shrinking (length specified A)', async function (this: MyTestContext, assert) {
     this.renderController.containerStyle =
-      'max-height: 100%; width: 200px; height: 418px; border: 1px solid green';
+      'max-height: 100%; width: 200px; height: 420px; border: 1px solid green';
+    // Height ratio panel 1 and panel 2 is 3:2
     this.renderController.panel1LengthPx = 240;
     this.renderController.panel2LengthPx = 160;
     await renderVerticalResizablePanelGroup(this.renderController);
+    assert.hasNumericStyle('.panel-1-content', 'height', 240, 1);
+    assert.hasNumericStyle('.panel-2-content', 'height', 160, 1);
     this.renderController.containerStyle =
-      'max-height: 100%; width: 200px; height: 218px; border: 1px solid green';
+      'max-height: 100%; width: 200px; height: 220px; border: 1px solid green';
     await sleep(100); // let didResizeModifier run
+    // Maintain the ratio 3:2 when resizing
     assert.hasNumericStyle('.panel-1-content', 'height', 120, 1);
     assert.hasNumericStyle('.panel-2-content', 'height', 80, 1);
   });
 
   test('it adjusts to its container shrinking (length specified B)', async function (this: MyTestContext, assert) {
     this.renderController.containerStyle =
-      'max-height: 100%; width: 200px; height: 618px; border: 1px solid green';
+      'max-height: 100%; width: 200px; height: 620px; border: 1px solid green';
+    // Height ratio panel 1 and panel 2 is 2:1
     this.renderController.panel1LengthPx = 400;
     this.renderController.panel2LengthPx = 200;
     this.renderController.panel1InnerContentStyle =
       'height: 180px; background: blue';
     await renderVerticalResizablePanelGroup(this.renderController);
+    assert.hasNumericStyle('.panel-1-content', 'height', 400, 1);
+    assert.hasNumericStyle('.panel-2-content', 'height', 200, 1);
     this.renderController.containerStyle =
-      'max-height: 100%; width: 200px; height: 218px; border: 1px solid green';
+      'max-height: 100%; width: 200px; height: 220px; border: 1px solid green';
     await sleep(100); // let didResizeModifier run
-    assert.hasNumericStyle('.panel-1-content', 'height', 150, 1);
-    assert.hasNumericStyle('.panel-2-content', 'height', 50, 1);
+    // Maintain the ratio 2:1 when resizing
+    assert.hasNumericStyle('.panel-1-content', 'height', 133, 1);
+    assert.hasNumericStyle('.panel-2-content', 'height', 67, 1);
   });
 
   test('it adjusts to its container shrinking and growing', async function (this: MyTestContext, assert) {
     this.renderController.containerStyle =
-      'max-height: 100%; width: 200px; height: 618px; border: 1px solid green';
+      'max-height: 100%; width: 200px; height: 620px; border: 1px solid green';
     this.renderController.panel1LengthPx = 400;
     this.renderController.panel2LengthPx = 200;
     this.renderController.panel1InnerContentStyle =
@@ -180,19 +188,25 @@ module('Integration | ResizablePanelGroup', function (hooks) {
     await renderVerticalResizablePanelGroup(this.renderController);
     this.renderController.panel1LengthPx = 50;
     this.renderController.panel2LengthPx = 550;
+    await sleep(100); // let didResizeModifier run
     await doubleClick('[data-test-resize-handler]'); // Double-click to hide recent
-    await sleep(100); // let didResizeModifier run
-    assert.hasNumericStyle('.panel-1-content', 'height', 598, 1);
-    assert.hasNumericStyle('.panel-2-content', 'height', 2, 1);
+    await sleep(100); // let onResizeHandlerDblClick run
+    assert.hasNumericStyle('.panel-1-content', 'height', 600, 1);
+    assert.hasNumericStyle('.panel-2-content', 'height', 0, 2);
     this.renderController.containerStyle =
-      'max-height: 100%; width: 200px; height: 318px; border: 1px solid green'; // shrink container by ~50%
+      'max-height: 100%; width: 200px; height: 320px; border: 1px solid green'; // shrink container by ~50%
     await sleep(100); // let didResizeModifier run
+    assert.hasNumericStyle('.panel-1-content', 'height', 300, 1);
+    assert.hasNumericStyle('.panel-2-content', 'height', 0, 2);
     await doubleClick('[data-test-resize-handler]'); // Double-click to unhide recent
+    await sleep(100); // let onResizeHandlerDblClick run
+    assert.hasNumericStyle('.panel-1-content', 'height', 180, 1);
+    assert.hasNumericStyle('.panel-2-content', 'height', 120, 1);
     this.renderController.containerStyle =
-      'max-height: 100%; width: 200px; height: 618px; border: 1px solid green'; // increase window/container height to original height
+      'max-height: 100%; width: 200px; height: 620px; border: 1px solid green'; // increase window/container height to original height
     await sleep(100); // let didResizeModifier run
     // expected behavior: panel height percentages would remain consistent
-    assert.hasNumericStyle('.panel-1-content', 'height', 345, 1);
-    assert.hasNumericStyle('.panel-2-content', 'height', 253, 1);
+    assert.hasNumericStyle('.panel-1-content', 'height', 360, 1);
+    assert.hasNumericStyle('.panel-2-content', 'height', 240, 1);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -710,6 +710,9 @@ importers:
       ember-modifier:
         specifier: ^4.1.0
         version: 4.1.0(ember-source@4.12.0)
+      ember-ref-bucket:
+        specifier: 5.0.5
+        version: 5.0.5(@glint/template@1.2.1)(ember-source@4.12.0)(webpack@5.89.0)
       ember-resize-modifier:
         specifier: ^0.6.0
         version: 0.6.0(@glint/template@1.2.1)(ember-source@4.12.0)(webpack@5.89.0)
@@ -12299,6 +12302,21 @@ packages:
       - supports-color
       - webpack
     dev: true
+
+  /ember-ref-bucket@5.0.5(@glint/template@1.2.1)(ember-source@4.12.0)(webpack@5.89.0):
+    resolution: {integrity: sha512-kHTAy+cH4mv3TnbQyTFnMGW/mpRmDd4s5RCAMliX2KKPANQjzBlYsebHtYlLUXhHvkJnnECCD8O3jTsQQS0wAQ==}
+    engines: {node: 14.* || 16.* || >= 18}
+    dependencies:
+      ember-auto-import: 2.6.3(@glint/template@1.2.1)(webpack@5.89.0)
+      ember-cli-babel: 7.26.11
+      ember-cli-htmlbars: 6.3.0
+      ember-modifier: 4.1.0(ember-source@4.12.0)
+    transitivePeerDependencies:
+      - '@glint/template'
+      - ember-source
+      - supports-color
+      - webpack
+    dev: false
 
   /ember-resize-modifier@0.6.0(@glint/template@1.2.1)(ember-source@4.12.0)(webpack@5.89.0):
     resolution: {integrity: sha512-7KGLYC3MyNNaNKJJsHZsOoyAIA98+1yK9Xyb1dEXUeXboCd2dBcbapDuSmJWV51J03AZ90LGvOH5DDL0y6KXMQ==}


### PR DESCRIPTION
Ticket: CS-6168

Previously, we encountered difficulty maintaining the ratio of resizable panels during resizing. This was due to the absence of a recorded ratio to guide the adjustment of panel sizes when `didResize` is triggered. In this PR, I've introduced a new `panelRatio` field. With this addition, we can now leverage the `panelRatio` field to determine panel sizes accurately during resizing operations.

Before:

https://github.com/cardstack/boxel/assets/12637010/968fd842-6fd5-432e-97c2-b2860eb5b246


After:

https://github.com/cardstack/boxel/assets/12637010/b494e518-1e6e-401c-9f77-9fe02b8d12ec

