### PR TITLE
Added atom preview tab

### DIFF
--- a/packages/host/app/components/operator-mode/card-preview-panel.gts
+++ b/packages/host/app/components/operator-mode/card-preview-panel.gts
@@ -132,6 +132,12 @@ export default class CardPreviewPanel extends Component<Signature> {
           data-test-preview-card-footer-button-isolated
         >Isolated</button>
         <button
+          class='footer-button {{if (eq this.previewFormat "atom") "active"}}'
+          {{on 'click' (fn this.setPreviewFormat 'atom')}}
+          data-test-preview-card-footer-button-atom
+        >
+          Atom</button>
+        <button
           class='footer-button
             {{if (eq this.previewFormat "embedded") "active"}}'
           {{on 'click' (fn this.setPreviewFormat 'embedded')}}

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -84,8 +84,8 @@ const defaultPanelWidths: PanelWidths = {
   leftPanel:
     (14.0 * parseFloat(getComputedStyle(document.documentElement).fontSize)) /
     (document.documentElement.clientWidth - 40 - 36),
-  codeEditorPanel: 0.48,
-  rightPanel: 0.32,
+  codeEditorPanel: 0.4,
+  rightPanel: 0.4,
   emptyCodeModePanel: 0.8,
 };
 

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -702,6 +702,15 @@ module('Acceptance | code submode tests', function (hooks) {
       .dom('[data-test-preview-card-footer-button-isolated]')
       .hasClass('active');
 
+    await click('[data-test-preview-card-footer-button-atom]');
+    assert
+      .dom('[data-test-preview-card-footer-button-atom]')
+      .hasClass('active');
+    assert.dom('[data-test-code-mode-card-preview-body ] .atom-card').exists();
+    assert
+      .dom('[data-test-code-mode-card-preview-body] .atom-card')
+      .includesText('Fadhlan');
+
     await click('[data-test-preview-card-footer-button-embedded]');
     assert
       .dom('[data-test-preview-card-footer-button-embedded]')


### PR DESCRIPTION
This PR adds the atom format preview tab. I also widened the default width of the preview panel to accommodate the new button (the code editor and card preview default to the same width now)

![atom-preview](https://github.com/cardstack/boxel/assets/61075/abcb33b5-7ffa-4e9f-b158-6d48dc8d307e)
