### PR TITLE
Add better error messages to the AI bot

### DIFF
--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -182,7 +182,8 @@ Common issues are:
    - Check it is reachable at ${matrixUrl}/_matrix/client/versions
    - If running in development, check the docker container is running (see the boxel README)
 - The bot is not registered on the matrix server
-   - The bot uses the username ${aiBotUsername}
+  - The bot uses the username ${aiBotUsername}
+- The bot is registered but the password is incorrect
    - The bot password ${
      process.env.BOXEL_AIBOT_PASSWORD
        ? 'is set in the env var, check it is correct'

--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -165,13 +165,32 @@ async function getResponse(history: IRoomEvent[], aiBotUsername: string) {
 }
 
 (async () => {
+  const matrixUrl = process.env.MATRIX_URL || 'http://localhost:8008';
   let client = createClient({
-    baseUrl: process.env.MATRIX_URL || 'http://localhost:8008',
+    baseUrl: matrixUrl,
   });
-  let auth = await client.loginWithPassword(
-    aiBotUsername,
-    process.env.BOXEL_AIBOT_PASSWORD || 'pass',
-  );
+  let auth = await client
+    .loginWithPassword(
+      aiBotUsername,
+      process.env.BOXEL_AIBOT_PASSWORD || 'pass',
+    )
+    .catch((e) => {
+      log.error(e);
+      log.info(`The matrix bot could not login to the server.
+Common issues are:
+- The server is not running (configured to use ${matrixUrl})
+   - Check it is reachable at ${matrixUrl}/_matrix/client/versions
+   - If running in development, check the docker container is running (see the boxel README)
+- The bot is not registered on the matrix server
+   - The bot uses the username ${aiBotUsername}
+   - The bot password ${
+     process.env.BOXEL_AIBOT_PASSWORD
+       ? 'is set in the env var, check it is correct'
+       : 'is not set in the env var so defaults to "pass"'
+   }
+      `);
+      process.exit(1);
+    });
   let { user_id: userId } = auth;
   client.on(RoomMemberEvent.Membership, function (_event, member) {
     if (member.membership === 'invite' && member.userId === userId) {


### PR DESCRIPTION
Output when the uername/pass doesn't match (the error message tells you if you're overriding it or not)

```
$ BOXEL_AIBOT_PASSWORD=hey pnpm start

> @cardstack/ai-bot@ start /home/ian/projects/boxel/packages/ai-bot
> NODE_NO_WARNINGS=1 ts-node --transpileOnly main

M_FORBIDDEN: MatrixError: [403] Invalid username or password (http://localhost:8008/_matrix/client/r0/login)
    at parseErrorResponse (/home/ian/projects/boxel/node_modules/.pnpm/matrix-js-sdk@25.0.0_patch_hash=vlqn3jrrd7zoh7xnqjj35ihq2i/node_modules/matrix-js-sdk/src/http-api/utils.ts:90:16)
    at MatrixHttpApi.requestOtherUrl (/home/ian/projects/boxel/node_modules/.pnpm/matrix-js-sdk@25.0.0_patch_hash=vlqn3jrrd7zoh7xnqjj35ihq2i/node_modules/matrix-js-sdk/src/http-api/fetch.ts:287:37)
    at processTicksAndRejections (node:internal/process/task_queues:95:5) {
  httpStatus: 403,
  url: 'http://localhost:8008/_matrix/client/r0/login',
  event: undefined,
  errcode: 'M_FORBIDDEN',
  data: { errcode: 'M_FORBIDDEN', error: 'Invalid username or password' }
}
The matrix bot could not login to the server.
Common issues are:
- The server is not running (configured to use http://localhost:8008)
   - Check it is reachable at http://localhost:8008/_matrix/client/versions
   - If running in development, check the docker container is running (see the boxel README)
- The bot is not registered on the matrix server
  - The bot uses the username aibot
- The bot is registered but the password is incorrect
   - The bot password is set in the env var, check it is correct

 ELIFECYCLE  Command failed with exit code 1.
```

And an example when there's no matrix server running at the url
```
$ MATRIX_URL=http://localhost:12345 pnpm start

> @cardstack/ai-bot@ start /home/ian/projects/boxel/packages/ai-bot
> NODE_NO_WARNINGS=1 ts-node --transpileOnly main

ConnectionError: fetch failed: fetch failed
    at MatrixHttpApi.requestOtherUrl (/home/ian/projects/boxel/node_modules/.pnpm/matrix-js-sdk@25.0.0_patch_hash=vlqn3jrrd7zoh7xnqjj35ihq2i/node_modules/matrix-js-sdk/src/http-api/fetch.ts:281:19)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
The matrix bot could not login to the server.
Common issues are:
- The server is not running (configured to use http://localhost:12345)
   - Check it is reachable at http://localhost:12345/_matrix/client/versions
   - If running in development, check the docker container is running (see the boxel README)
- The bot is not registered on the matrix server
  - The bot uses the username aibot
- The bot is registered but the password is incorrect
   - The bot password is not set in the env var so defaults to "pass"

 ELIFECYCLE  Command failed with exit code 1.
```