### PR TITLE
To avoid losing data during card editing, do not reload card on SSE from auto save

### DIFF
--- a/packages/host/app/resources/card-resource.ts
+++ b/packages/host/app/resources/card-resource.ts
@@ -227,7 +227,12 @@ export class CardResource extends Resource<Args> {
           }
 
           if (invalidations.includes(card.id)) {
-            this.reload.perform(card);
+            // Do not reload if the event is a result of a request that we made. Otherwise we risk overwriting
+            // the inputs with past values. This can happen if the user makes edits in the time between the auto
+            // save request and the arrival SSE event.
+            if (!this.cardService.clientRequestIds.has(data.clientRequestId)) {
+              this.reload.perform(card);
+            }
           }
         },
       ),

--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -4,6 +4,8 @@ import { task } from 'ember-concurrency';
 
 import { stringify } from 'qs';
 
+import { v4 as uuidv4 } from 'uuid';
+
 import {
   SupportedMimeType,
   type LooseCardResource,
@@ -29,7 +31,6 @@ import type {
   Field,
   SerializeOpts,
 } from 'https://cardstack.com/base/card-api';
-
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
 
 import { trackCard } from '../resources/card-resource';
@@ -43,7 +44,11 @@ const { ownRealmURL, otherRealmURLs } = ENV;
 export default class CardService extends Service {
   @service private declare loaderService: LoaderService;
   @service private declare messageService: MessageService;
+
   private subscriber: CardSaveSubscriber | undefined;
+  // For tracking requests during the duration of this service. Used for being able to tell when to ignore an incremental indexing SSE event.
+  // We want to ignore it when it is a result of our own request so that we don't reload the card and overwrite any unsaved changes made during auto save request and SSE event.
+  clientRequestIds = new Set<string>();
 
   private getAPI = task(async (loader?: Loader) => {
     loader = loader ?? this.loaderService.loader;
@@ -72,9 +77,15 @@ export default class CardService extends Service {
     args?: RequestInit,
     loader?: Loader,
   ): Promise<CardDocument | undefined> {
+    let clientRequestId = uuidv4();
+    this.clientRequestIds.add(clientRequestId);
+
     loader = loader ?? this.loaderService.loader;
     let response = await loader.fetch(url, {
-      headers: { Accept: SupportedMimeType.CardJson },
+      headers: {
+        Accept: SupportedMimeType.CardJson,
+        'X-Boxel-Client-Request-Id': clientRequestId,
+      },
       ...args,
     });
     if (!response.ok) {

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -397,7 +397,15 @@ export function setupServerSentEvents(hooks: NestedHooks) {
         }
       }
       if (expectedEvents) {
-        assert.deepEqual(events, expectedEvents, 'sse response is correct');
+        let eventsWithoutClientRequestId = events.map((e) => {
+          delete e.data.clientRequestId;
+          return e;
+        });
+        assert.deepEqual(
+          eventsWithoutClientRequestId,
+          expectedEvents,
+          'sse response is correct',
+        );
       }
       if (onEvents) {
         onEvents(events);

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -68,7 +68,7 @@ export class RealmServer {
         cors({
           origin: '*',
           allowHeaders:
-            'Authorization, Content-Type, If-Match, X-Requested-With',
+            'Authorization, Content-Type, If-Match, X-Requested-With, X-Boxel-Client-Request-Id',
         }),
       )
       .use(async (ctx, next) => {

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -288,6 +288,7 @@ module('Realm Server', function (hooks) {
       {
         type: 'incremental',
         invalidations: [`${testRealmURL}person-1`],
+        clientRequestId: null,
       },
     ];
     let response = await expectEvent({

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -564,6 +564,7 @@ module('Realm Server', function (hooks) {
       {
         type: 'incremental',
         invalidations: [`${testRealmURL}unused-card.gts`],
+        clientRequestId: null,
       },
     ];
     let response = await expectEvent({

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -161,10 +161,12 @@ interface IndexEvent {
   type: 'index';
   data: IncrementalIndexEventData | FullIndexEventData;
   id?: string;
+  clientRequestId?: string | null;
 }
 interface IncrementalIndexEventData {
   type: 'incremental';
   invalidations: string[];
+  clientRequestId?: string | null;
 }
 interface FullIndexEventData {
   type: 'full';
@@ -186,6 +188,7 @@ interface WriteOperation {
   type: 'write';
   path: LocalPath;
   contents: string;
+  clientRequestId?: string | null; // Used for client to be able to see if the SSE event is a result of the client's own write
   deferred: Deferred<WriteResult>;
 }
 
@@ -330,7 +333,11 @@ export class Realm {
     this.#operationQueue = [];
     for (let operation of operations) {
       if (operation.type === 'write') {
-        let result = await this.#write(operation.path, operation.contents);
+        let result = await this.#write(
+          operation.path,
+          operation.contents,
+          operation.clientRequestId,
+        );
         operation.deferred.fulfill(result);
       } else {
         await this.#delete(operation.path);
@@ -341,19 +348,28 @@ export class Realm {
     operationsDrained!();
   }
 
-  async write(path: LocalPath, contents: string): Promise<WriteResult> {
+  async write(
+    path: LocalPath,
+    contents: string,
+    clientRequestId?: string | null,
+  ): Promise<WriteResult> {
     let deferred = new Deferred<WriteResult>();
     this.#operationQueue.push({
       type: 'write',
       path,
       contents,
+      clientRequestId,
       deferred,
     });
     this.drainOperations();
     return deferred.promise;
   }
 
-  async #write(path: LocalPath, contents: string): Promise<WriteResult> {
+  async #write(
+    path: LocalPath,
+    contents: string,
+    clientRequestId?: string | null,
+  ): Promise<WriteResult> {
     await this.trackOwnWrite(path);
     let results = await this.#adapter.write(path, contents);
     await this.#searchIndex.update(this.paths.fileURL(path), {
@@ -363,6 +379,7 @@ export class Realm {
           data: {
             type: 'incremental',
             invalidations: invalidatedURLs.map((u) => u.href),
+            clientRequestId: clientRequestId ?? null, // use null instead of undefined for valid JSON serialization
           },
         });
       },
@@ -861,6 +878,7 @@ export class Realm {
         null,
         2,
       ),
+      request.headers.get('X-Boxel-Client-Request-Id'),
     );
     let instanceURL = url.href.replace(/\.json$/, '');
     let entry = await this.#searchIndex.card(new URL(instanceURL), {


### PR DESCRIPTION
This PR adds a change that prevents the card model to be reloaded during auto saving. The issue is that the realm sends an SSE after incremental indexing is done, and the card resource will reload the card when receiving that event. That is useful for having fresh data when other entities are updating it, but when the user is typing, everything that was edited between the auto save request and the SSE event will be lost. The solution is to not reload card data when the SSE event is a result of the editor's own action. 

Previously, editing of input fields was quite buggy, notice how it's jumping and overwriting input with past data as I type:

https://github.com/cardstack/boxel/assets/273660/77dfa698-5693-44aa-b287-423d6c8a273a


After the fix (typing works ok, no data loss):

https://github.com/cardstack/boxel/assets/273660/89584191-07eb-42d3-a30c-c1984101cd3f

