### PR TITLE
fix for flaky realm info tests

### DIFF
--- a/packages/host/app/components/realm-dropdown.gts
+++ b/packages/host/app/components/realm-dropdown.gts
@@ -25,7 +25,10 @@ interface Signature {
 
 export default class RealmDropdown extends Component<Signature> {
   <template>
-    <BoxelDropdown @contentClass={{@contentClass}}>
+    <BoxelDropdown
+      @contentClass={{@contentClass}}
+      data-test-load-realms-loaded={{this.loaded}}
+    >
       <:trigger as |bindings|>
         <Button
           class='realm-dropdown-trigger'
@@ -92,6 +95,10 @@ export default class RealmDropdown extends Component<Signature> {
   constructor(owner: unknown, args: Signature['Args']) {
     super(owner, args);
     this.realmInfoService.fetchAllKnownRealmInfos.perform();
+  }
+
+  get loaded() {
+    return this.realmInfoService.fetchAllKnownRealmInfos.isIdle;
   }
 
   get realms(): RealmDropdownItem[] {

--- a/packages/host/app/services/realm-info-service.ts
+++ b/packages/host/app/services/realm-info-service.ts
@@ -1,6 +1,9 @@
 import Service, { service } from '@ember/service';
 
+import { buildWaiter } from '@ember/test-waiters';
+
 import { restartableTask } from 'ember-concurrency';
+import { TrackedMap } from 'tracked-built-ins';
 
 import {
   RealmInfo,
@@ -14,11 +17,12 @@ import ENV from '@cardstack/host/config/environment';
 import LoaderService from '@cardstack/host/services/loader-service';
 
 const { ownRealmURL, otherRealmURLs } = ENV;
+const waiter = buildWaiter('realm-info-service:waiter');
 
 export default class RealmInfoService extends Service {
   @service declare loaderService: LoaderService;
-  cachedRealmURLsForFileURL: Map<string, string> = new Map(); // Has the file url already been resolved to a realm url?
-  cachedRealmInfos: Map<string, RealmInfo> = new Map(); // Has the realm url already been resolved to a realm info?
+  cachedRealmURLsForFileURL: TrackedMap<string, string> = new TrackedMap(); // Has the file url already been resolved to a realm url?
+  cachedRealmInfos: TrackedMap<string, RealmInfo> = new TrackedMap(); // Has the realm url already been resolved to a realm info?
 
   async fetchRealmURL(fileURL: string): Promise<string> {
     if (this.cachedRealmURLsForFileURL.has(fileURL)) {
@@ -50,21 +54,26 @@ export default class RealmInfoService extends Service {
       throw new Error("Must provide either 'realmUrl' or 'fileUrl'");
     }
 
-    let realmURLString = realmURL
-      ? realmURL.href
-      : await this.fetchRealmURL(fileURL!);
+    let token = waiter.beginAsync();
+    try {
+      let realmURLString = realmURL
+        ? realmURL.href
+        : await this.fetchRealmURL(fileURL!);
 
-    if (this.cachedRealmInfos.has(realmURLString)) {
-      return this.cachedRealmInfos.get(realmURLString)!;
-    } else {
-      let realmInfoResponse = await this.loaderService.loader.fetch(
-        `${realmURLString}_info`,
-        { headers: { Accept: SupportedMimeType.RealmInfo } },
-      );
+      if (this.cachedRealmInfos.has(realmURLString)) {
+        return this.cachedRealmInfos.get(realmURLString)!;
+      } else {
+        let realmInfoResponse = await this.loaderService.loader.fetch(
+          `${realmURLString}_info`,
+          { headers: { Accept: SupportedMimeType.RealmInfo } },
+        );
 
-      let realmInfo = (await realmInfoResponse.json())?.data?.attributes;
-      this.cachedRealmInfos.set(realmURLString, realmInfo);
-      return realmInfo;
+        let realmInfo = (await realmInfoResponse.json())?.data?.attributes;
+        this.cachedRealmInfos.set(realmURLString, realmInfo);
+        return realmInfo;
+      }
+    } finally {
+      waiter.endAsync(token);
     }
   }
 
@@ -73,10 +82,16 @@ export default class RealmInfoService extends Service {
       ...new Set([ownRealmURL, baseRealm.url, ...otherRealmURLs]),
     ].map((path) => new RealmPaths(path).url);
 
-    await Promise.all(
-      paths.map(
-        async (path) => await this.fetchRealmInfo({ realmURL: new URL(path) }),
-      ),
-    );
+    let token = waiter.beginAsync();
+    try {
+      await Promise.all(
+        paths.map(
+          async (path) =>
+            await this.fetchRealmInfo({ realmURL: new URL(path) }),
+        ),
+      );
+    } finally {
+      waiter.endAsync(token);
+    }
   });
 }

--- a/packages/host/tests/acceptance/code-submode/editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/editor-test.ts
@@ -586,8 +586,6 @@ module('Acceptance | code submode | editor tests', function (hooks) {
     setMonacoContent('Hello Mars');
 
     await waitFor('[data-test-save-idle]');
-
-    await percySnapshot(assert);
   });
 
   test<TestContextWithSave>('unsaved changes made in monaco editor are saved when switching out of code submode', async function (assert) {
@@ -766,8 +764,6 @@ module('Acceptance | code submode | editor tests', function (hooks) {
         await waitFor('[data-test-save-idle]');
       },
     });
-
-    await percySnapshot(assert);
 
     let fileRef = await adapter.openFile('pet.gts');
     if (!fileRef) {


### PR DESCRIPTION
This PR adds tracking to the realm info data such that when it changes consuming templates will update, as well as to add test waiters around the loading of the realm info. Also adding a `loaded` test-selector to the realm dropdown in case it becomes necessary.

I'll re-run the CI tests a bunch of times to see if the flakiness disappears