### PR TITLE
Refactor some string test code to use shimModule

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -2452,6 +2452,10 @@ async function _updateFromSerialized<T extends BaseDefConstructor>(
   return instance;
 }
 
+export function setCardAsSavedForTest(instance: CardDef): void {
+  instance[isSavedInstance] = true;
+}
+
 export async function searchDoc<CardT extends BaseDefConstructor>(
   instance: InstanceType<CardT>,
 ): Promise<Record<string, any>> {

--- a/packages/host/app/router.ts
+++ b/packages/host/app/router.ts
@@ -19,8 +19,11 @@ let path = new URL(resolvedOwnRealmURL ?? ownRealmURL).pathname.replace(
 Router.map(function () {
   this.route('host-freestyle', { path: '/_freestyle' });
   this.route('indexer', { path: '/indexer/:id' });
-  this.route('acceptance-test-setup');
   this.route('card', { path: '/*path' });
+
+  // this route is empty but lets the application.hbs render, so that the CardPrerender
+  // component exists to support the indexer
+  this.route('acceptance-test-setup');
 
   if (!path || hostsOwnAssets) {
     this.route('index-card', { path: '/' });

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -11,13 +11,10 @@ import type RealmInfoService from '@cardstack/host/services/realm-info-service';
 import type { OperatorModeState } from '@cardstack/host/services/operator-mode-state-service';
 import type { Submode } from '@cardstack/host/components/submode-switcher';
 import {
-  TestRealm,
-  TestRealmAdapter,
   setupLocalIndexing,
   testRealmURL,
-  sourceFetchRedirectHandle,
-  sourceFetchReturnUrlHandle,
   setupOnSave,
+  setupAcceptanceTestRealm,
   setupServerSentEvents,
   type TestContextWithSave,
 } from '../../helpers';
@@ -140,44 +137,15 @@ module('Acceptance | code submode | create-file tests', function (hooks) {
     window.localStorage.removeItem('recent-files');
     let loader = (this.owner.lookup('service:loader-service') as LoaderService)
       .loader;
-    let realm = await TestRealm.create(loader, files, this.owner, {
-      realmURL: testRealmURL,
-      isAcceptanceTest: true,
-      overridingHandlers: [
-        async (req: Request) => {
-          return sourceFetchRedirectHandle(
-            req,
-            new TestRealmAdapter(files),
-            testRealmURL,
-          );
-        },
-        async (req: Request) => {
-          return sourceFetchReturnUrlHandle(req, realm.maybeHandle.bind(realm));
-        },
-      ],
+    await setupAcceptanceTestRealm({
+      loader,
+      contents: files,
     });
-    await realm.ready;
-
-    let realm2 = await TestRealm.create(loader, filesB, this.owner, {
+    await setupAcceptanceTestRealm({
+      loader,
+      contents: filesB,
       realmURL: testRealmURL2,
-      isAcceptanceTest: true,
-      overridingHandlers: [
-        async (req: Request) => {
-          return sourceFetchRedirectHandle(
-            req,
-            new TestRealmAdapter(files),
-            testRealmURL,
-          );
-        },
-        async (req: Request) => {
-          return sourceFetchReturnUrlHandle(
-            req,
-            realm2.maybeHandle.bind(realm2),
-          );
-        },
-      ],
     });
-    await realm2.ready;
 
     let realmService = this.owner.lookup(
       'service:realm-info-service',

--- a/packages/host/tests/acceptance/code-submode/editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/editor-test.ts
@@ -15,7 +15,6 @@ import config from '@cardstack/host/config/environment';
 import type LoaderService from '@cardstack/host/services/loader-service';
 
 import {
-  TestRealm,
   TestRealmAdapter,
   setupLocalIndexing,
   setupServerSentEvents,
@@ -23,12 +22,11 @@ import {
   testRealmURL,
   getMonacoContent,
   setMonacoContent,
+  setupAcceptanceTestRealm,
   waitForSyntaxHighlighting,
   waitForCodeEditor,
   type TestContextWithSSE,
   type TestContextWithSave,
-  sourceFetchRedirectHandle,
-  sourceFetchReturnUrlHandle,
 } from '../../helpers';
 
 module('Acceptance | code submode | editor tests', function (hooks) {
@@ -50,8 +48,13 @@ module('Acceptance | code submode | editor tests', function (hooks) {
     window.localStorage.removeItem('recent-cards');
     window.localStorage.removeItem('recent-files');
 
-    adapter = new TestRealmAdapter({
-      'pet.gts': `
+    let loader = (this.owner.lookup('service:loader-service') as LoaderService)
+      .loader;
+
+    ({ realm, adapter } = await setupAcceptanceTestRealm({
+      loader,
+      contents: {
+        'pet.gts': `
         import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
         import StringCard from "https://cardstack.com/base/string";
 
@@ -72,7 +75,7 @@ module('Acceptance | code submode | editor tests', function (hooks) {
           }
         }
       `,
-      'shipping-info.gts': `
+        'shipping-info.gts': `
         import { contains, field, Component, FieldDef } from "https://cardstack.com/base/card-api";
         import StringCard from "https://cardstack.com/base/string";
         export class ShippingInfo extends FieldDef {
@@ -92,7 +95,7 @@ module('Acceptance | code submode | editor tests', function (hooks) {
           }
         }
       `,
-      'address.gts': `
+        'address.gts': `
         import { contains, field, Component, FieldDef } from "https://cardstack.com/base/card-api";
         import StringCard from "https://cardstack.com/base/string";
         import { ShippingInfo } from "./shipping-info";
@@ -128,7 +131,7 @@ module('Acceptance | code submode | editor tests', function (hooks) {
           };
         }
       `,
-      'person.gts': `
+        'person.gts': `
         import { contains, linksTo, field, Component, CardDef, linksToMany } from "https://cardstack.com/base/card-api";
         import StringCard from "https://cardstack.com/base/string";
         import { Pet } from "./pet";
@@ -165,133 +168,118 @@ module('Acceptance | code submode | editor tests', function (hooks) {
           }
         }
       `,
-      'README.txt': `Hello World`,
-      'Pet/mango.json': {
-        data: {
-          attributes: {
-            name: 'Mango',
-          },
-          meta: {
-            adoptsFrom: {
-              module: `${testRealmURL}pet`,
-              name: 'Pet',
+        'README.txt': `Hello World`,
+        'Pet/mango.json': {
+          data: {
+            attributes: {
+              name: 'Mango',
             },
-          },
-        },
-      },
-      'Pet/vangogh.json': {
-        data: {
-          attributes: {
-            name: 'Van Gogh',
-          },
-          meta: {
-            adoptsFrom: {
-              module: `${testRealmURL}pet`,
-              name: 'Pet',
-            },
-          },
-        },
-      },
-
-      'Person/fadhlan.json': {
-        data: {
-          attributes: {
-            firstName: 'Fadhlan',
-            address: {
-              city: 'Bandung',
-              country: 'Indonesia',
-              shippingInfo: {
-                preferredCarrier: 'DHL',
-                remarks: `Don't let bob deliver the package--he's always bringing it to the wrong address`,
+            meta: {
+              adoptsFrom: {
+                module: `${testRealmURL}pet`,
+                name: 'Pet',
               },
             },
           },
-          relationships: {
-            pet: {
-              links: {
-                self: `${testRealmURL}Pet/mango`,
+        },
+        'Pet/vangogh.json': {
+          data: {
+            attributes: {
+              name: 'Van Gogh',
+            },
+            meta: {
+              adoptsFrom: {
+                module: `${testRealmURL}pet`,
+                name: 'Pet',
               },
             },
           },
-          meta: {
-            adoptsFrom: {
-              module: `${testRealmURL}person`,
-              name: 'Person',
-            },
-          },
         },
-      },
-      'grid.json': {
-        data: {
-          type: 'card',
-          attributes: {},
-          meta: {
-            adoptsFrom: {
-              module: 'https://cardstack.com/base/cards-grid',
-              name: 'CardsGrid',
+
+        'Person/fadhlan.json': {
+          data: {
+            attributes: {
+              firstName: 'Fadhlan',
+              address: {
+                city: 'Bandung',
+                country: 'Indonesia',
+                shippingInfo: {
+                  preferredCarrier: 'DHL',
+                  remarks: `Don't let bob deliver the package--he's always bringing it to the wrong address`,
+                },
+              },
             },
-          },
-        },
-      },
-      'index.json': {
-        data: {
-          type: 'card',
-          attributes: {},
-          meta: {
-            adoptsFrom: {
-              module: 'https://cardstack.com/base/cards-grid',
-              name: 'CardsGrid',
+            relationships: {
+              pet: {
+                links: {
+                  self: `${testRealmURL}Pet/mango`,
+                },
+              },
             },
-          },
-        },
-      },
-      '.realm.json': {
-        name: 'Test Workspace B',
-        backgroundURL:
-          'https://i.postimg.cc/VNvHH93M/pawel-czerwinski-Ly-ZLa-A5jti-Y-unsplash.jpg',
-        iconURL: 'https://i.postimg.cc/L8yXRvws/icon.png',
-      },
-      'Person/john-with-bad-pet-link.json': {
-        data: {
-          attributes: {
-            firstName: 'John',
-            address: {
-              city: 'Ljubljana',
-              country: 'Slovenia',
-            },
-          },
-          relationships: {
-            pet: {
-              links: {
-                self: `http://badlink.com/nonexisting-pet`,
+            meta: {
+              adoptsFrom: {
+                module: `${testRealmURL}person`,
+                name: 'Person',
               },
             },
           },
-          meta: {
-            adoptsFrom: {
-              module: `${testRealmURL}person`,
-              name: 'Person',
+        },
+        'grid.json': {
+          data: {
+            type: 'card',
+            attributes: {},
+            meta: {
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/cards-grid',
+                name: 'CardsGrid',
+              },
+            },
+          },
+        },
+        'index.json': {
+          data: {
+            type: 'card',
+            attributes: {},
+            meta: {
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/cards-grid',
+                name: 'CardsGrid',
+              },
+            },
+          },
+        },
+        '.realm.json': {
+          name: 'Test Workspace B',
+          backgroundURL:
+            'https://i.postimg.cc/VNvHH93M/pawel-czerwinski-Ly-ZLa-A5jti-Y-unsplash.jpg',
+          iconURL: 'https://i.postimg.cc/L8yXRvws/icon.png',
+        },
+        'Person/john-with-bad-pet-link.json': {
+          data: {
+            attributes: {
+              firstName: 'John',
+              address: {
+                city: 'Ljubljana',
+                country: 'Slovenia',
+              },
+            },
+            relationships: {
+              pet: {
+                links: {
+                  self: `http://badlink.com/nonexisting-pet`,
+                },
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: `${testRealmURL}person`,
+                name: 'Person',
+              },
             },
           },
         },
       },
-    });
-
-    let loader = (this.owner.lookup('service:loader-service') as LoaderService)
-      .loader;
-
-    realm = await TestRealm.createWithAdapter(adapter, loader, this.owner, {
-      isAcceptanceTest: true,
-      overridingHandlers: [
-        async (req: Request) => {
-          return sourceFetchRedirectHandle(req, adapter, testRealmURL);
-        },
-        async (req: Request) => {
-          return sourceFetchReturnUrlHandle(req, realm.maybeHandle.bind(realm));
-        },
-      ],
-    });
-    await realm.ready;
+    }));
   });
 
   test('card instance JSON displayed in monaco editor', async function (assert) {
@@ -390,7 +378,6 @@ module('Acceptance | code submode | editor tests', function (hooks) {
     await this.expectEvents({
       assert,
       realm,
-      adapter,
       expectedEvents,
       callback: async () => {
         setMonacoContent(JSON.stringify(editedCard));
@@ -469,7 +456,6 @@ module('Acceptance | code submode | editor tests', function (hooks) {
     await this.expectEvents({
       assert,
       realm,
-      adapter,
       expectedEvents,
       callback: async () => {
         setMonacoContent(JSON.stringify(expected));
@@ -553,7 +539,6 @@ module('Acceptance | code submode | editor tests', function (hooks) {
     await this.expectEvents({
       assert,
       realm,
-      adapter,
       expectedEvents,
       callback: async () => {
         await fillIn('[data-test-field="name"] input', 'MangoXXX');
@@ -757,7 +742,6 @@ module('Acceptance | code submode | editor tests', function (hooks) {
     await this.expectEvents({
       assert,
       realm,
-      adapter,
       expectedEvents,
       callback: async () => {
         setMonacoContent(expected);

--- a/packages/host/tests/acceptance/code-submode/file-tree-test.ts
+++ b/packages/host/tests/acceptance/code-submode/file-tree-test.ts
@@ -16,17 +16,12 @@ import stringify from 'safe-stable-stringify';
 
 import { baseRealm } from '@cardstack/runtime-common';
 
-import { Realm } from '@cardstack/runtime-common/realm';
-
 import type LoaderService from '@cardstack/host/services/loader-service';
 
 import {
-  TestRealm,
-  TestRealmAdapter,
   setupLocalIndexing,
   testRealmURL,
-  sourceFetchRedirectHandle,
-  sourceFetchReturnUrlHandle,
+  setupAcceptanceTestRealm,
   waitForCodeEditor,
 } from '../../helpers';
 
@@ -193,9 +188,6 @@ const realmInfo = {
 };
 
 module('Acceptance | code submode | file-tree tests', function (hooks) {
-  let realm: Realm;
-  let adapter: TestRealmAdapter;
-
   setupApplicationTest(hooks);
   setupLocalIndexing(hooks);
   setupWindowMock(hooks);
@@ -207,102 +199,93 @@ module('Acceptance | code submode | file-tree tests', function (hooks) {
   hooks.beforeEach(async function () {
     window.localStorage.removeItem('recent-files');
 
-    // this seeds the loader used during index which obtains url mappings
-    // from the global loader
-    adapter = new TestRealmAdapter({
-      'index.gts': indexCardSource,
-      'pet-person.gts': personCardSource,
-      'person.gts': personCardSource,
-      'friend.gts': friendCardSource,
-      'employee.gts': employeeCardSource,
-      'in-this-file.gts': inThisFileSource,
-      'person-entry.json': {
-        data: {
-          type: 'card',
-          attributes: {
-            title: 'Person',
-            description: 'Catalog entry',
-            ref: {
-              module: `./person`,
-              name: 'Person',
-            },
-          },
-          meta: {
-            adoptsFrom: {
-              module: `${baseRealm.url}catalog-entry`,
-              name: 'CatalogEntry',
-            },
-          },
-        },
-      },
-      'index.json': {
-        data: {
-          type: 'card',
-          attributes: {},
-          meta: {
-            adoptsFrom: {
-              module: './index',
-              name: 'Index',
-            },
-          },
-        },
-      },
-      'not-json.json': 'I am not JSON.',
-      'Person/1.json': {
-        data: {
-          type: 'card',
-          attributes: {
-            firstName: 'Hassan',
-            lastName: 'Abdel-Rahman',
-          },
-          meta: {
-            adoptsFrom: {
-              module: '../person',
-              name: 'Person',
-            },
-          },
-        },
-      },
-      'z00.json': '{}',
-      'z01.json': '{}',
-      'z02.json': '{}',
-      'z03.json': '{}',
-      'z04.json': '{}',
-      'z05.json': '{}',
-      'z06.json': '{}',
-      'z07.json': '{}',
-      'z08.json': '{}',
-      'z09.json': '{}',
-      'z10.json': '{}',
-      'z11.json': '{}',
-      'z12.json': '{}',
-      'z13.json': '{}',
-      'z14.json': '{}',
-      'z15.json': '{}',
-      'z16.json': '{}',
-      'z17.json': '{}',
-      'z18.json': '{}',
-      'z19.json': '{}',
-      'zzz/zzz/file.json': '{}',
-      '.realm.json': realmInfo,
-    });
-
     let loader = (this.owner.lookup('service:loader-service') as LoaderService)
       .loader;
 
-    realm = await TestRealm.createWithAdapter(adapter, loader, this.owner, {
-      isAcceptanceTest: true,
-      overridingHandlers: [
-        async (req: Request) => {
-          return sourceFetchRedirectHandle(req, adapter, testRealmURL);
+    // this seeds the loader used during index which obtains url mappings
+    // from the global loader
+    await setupAcceptanceTestRealm({
+      loader,
+      contents: {
+        'index.gts': indexCardSource,
+        'pet-person.gts': personCardSource,
+        'person.gts': personCardSource,
+        'friend.gts': friendCardSource,
+        'employee.gts': employeeCardSource,
+        'in-this-file.gts': inThisFileSource,
+        'person-entry.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              title: 'Person',
+              description: 'Catalog entry',
+              ref: {
+                module: `./person`,
+                name: 'Person',
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: `${baseRealm.url}catalog-entry`,
+                name: 'CatalogEntry',
+              },
+            },
+          },
         },
-        async (req: Request) => {
-          return sourceFetchReturnUrlHandle(req, realm.maybeHandle.bind(realm));
+        'index.json': {
+          data: {
+            type: 'card',
+            attributes: {},
+            meta: {
+              adoptsFrom: {
+                module: './index',
+                name: 'Index',
+              },
+            },
+          },
         },
-      ],
+        'not-json.json': 'I am not JSON.',
+        'Person/1.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              firstName: 'Hassan',
+              lastName: 'Abdel-Rahman',
+            },
+            meta: {
+              adoptsFrom: {
+                module: '../person',
+                name: 'Person',
+              },
+            },
+          },
+        },
+        'z00.json': '{}',
+        'z01.json': '{}',
+        'z02.json': '{}',
+        'z03.json': '{}',
+        'z04.json': '{}',
+        'z05.json': '{}',
+        'z06.json': '{}',
+        'z07.json': '{}',
+        'z08.json': '{}',
+        'z09.json': '{}',
+        'z10.json': '{}',
+        'z11.json': '{}',
+        'z12.json': '{}',
+        'z13.json': '{}',
+        'z14.json': '{}',
+        'z15.json': '{}',
+        'z16.json': '{}',
+        'z17.json': '{}',
+        'z18.json': '{}',
+        'z19.json': '{}',
+        'zzz/zzz/file.json': '{}',
+        '.realm.json': realmInfo,
+      },
     });
-    await realm.ready;
   });
+
   test('can navigate file tree, file view mode is persisted in query parameter', async function (assert) {
     let codeModeStateParam = stringify({
       stacks: [

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -18,13 +18,11 @@ import type LoaderService from '@cardstack/host/services/loader-service';
 import type MonacoService from '@cardstack/host/services/monaco-service';
 
 import {
-  TestRealm,
   TestRealmAdapter,
   getMonacoContent,
   setupLocalIndexing,
   testRealmURL,
-  sourceFetchRedirectHandle,
-  sourceFetchReturnUrlHandle,
+  setupAcceptanceTestRealm,
   setupServerSentEvents,
   waitForCodeEditor,
   type TestContextWithSSE,
@@ -318,139 +316,130 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
   hooks.beforeEach(async function () {
     window.localStorage.removeItem('recent-files');
 
-    // this seeds the loader used during index which obtains url mappings
-    // from the global loader
-    adapter = new TestRealmAdapter({
-      'index.gts': indexCardSource,
-      'pet-person.gts': personCardSource,
-      'person.gts': personCardSource,
-      'pet.gts': petCardSource,
-      'friend.gts': friendCardSource,
-      'employee.gts': employeeCardSource,
-      'in-this-file.gts': inThisFileSource,
-      'exports.gts': exportsSource,
-      'special-exports.gts': specialExportsSource,
-      'imports.gts': importsSource,
-      'person-entry.json': {
-        data: {
-          type: 'card',
-          attributes: {
-            title: 'Person',
-            description: 'Catalog entry',
-            ref: {
-              module: `./person`,
-              name: 'Person',
-            },
-          },
-          meta: {
-            adoptsFrom: {
-              module: `${baseRealm.url}catalog-entry`,
-              name: 'CatalogEntry',
-            },
-          },
-        },
-      },
-      'index.json': {
-        data: {
-          type: 'card',
-          attributes: {},
-          meta: {
-            adoptsFrom: {
-              module: './index',
-              name: 'Index',
-            },
-          },
-        },
-      },
-      'not-json.json': 'I am not JSON.',
-      'Person/1.json': {
-        data: {
-          type: 'card',
-          attributes: {
-            firstName: 'Hassan',
-            lastName: 'Abdel-Rahman',
-          },
-          meta: {
-            adoptsFrom: {
-              module: '../person',
-              name: 'Person',
-            },
-          },
-        },
-      },
-      'Pet/mango.json': {
-        data: {
-          attributes: {
-            name: 'Mango',
-          },
-          meta: {
-            adoptsFrom: {
-              module: `${testRealmURL}pet`,
-              name: 'Pet',
-            },
-          },
-        },
-      },
-      'Pet/vangogh.json': {
-        data: {
-          attributes: {
-            name: 'Van Gogh',
-          },
-          meta: {
-            adoptsFrom: {
-              module: `${testRealmURL}pet`,
-              name: 'Pet',
-            },
-          },
-        },
-      },
-      'z00.json': '{}',
-      'z01.json': '{}',
-      'z02.json': '{}',
-      'z03.json': '{}',
-      'z04.json': '{}',
-      'z05.json': '{}',
-      'z06.json': '{}',
-      'z07.json': '{}',
-      'z08.json': '{}',
-      'z09.json': '{}',
-      'z10.json': '{}',
-      'z11.json': '{}',
-      'z12.json': '{}',
-      'z13.json': '{}',
-      'z14.json': '{}',
-      'z15.json': '{}',
-      'z16.json': '{}',
-      'z17.json': '{}',
-      'z18.json': '{}',
-      'z19.json': '{}',
-      'zzz/zzz/file.json': '{}',
-      '.realm.json': {
-        name: 'Test Workspace B',
-        backgroundURL:
-          'https://i.postimg.cc/VNvHH93M/pawel-czerwinski-Ly-ZLa-A5jti-Y-unsplash.jpg',
-        iconURL: 'https://i.postimg.cc/L8yXRvws/icon.png',
-      },
-    });
-
     let loader = (this.owner.lookup('service:loader-service') as LoaderService)
       .loader;
+
+    // this seeds the loader used during index which obtains url mappings
+    // from the global loader
+    ({ realm, adapter } = await setupAcceptanceTestRealm({
+      loader,
+      contents: {
+        'index.gts': indexCardSource,
+        'pet-person.gts': personCardSource,
+        'person.gts': personCardSource,
+        'pet.gts': petCardSource,
+        'friend.gts': friendCardSource,
+        'employee.gts': employeeCardSource,
+        'in-this-file.gts': inThisFileSource,
+        'exports.gts': exportsSource,
+        'special-exports.gts': specialExportsSource,
+        'imports.gts': importsSource,
+        'person-entry.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              title: 'Person',
+              description: 'Catalog entry',
+              ref: {
+                module: `./person`,
+                name: 'Person',
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: `${baseRealm.url}catalog-entry`,
+                name: 'CatalogEntry',
+              },
+            },
+          },
+        },
+        'index.json': {
+          data: {
+            type: 'card',
+            attributes: {},
+            meta: {
+              adoptsFrom: {
+                module: './index',
+                name: 'Index',
+              },
+            },
+          },
+        },
+        'not-json.json': 'I am not JSON.',
+        'Person/1.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              firstName: 'Hassan',
+              lastName: 'Abdel-Rahman',
+            },
+            meta: {
+              adoptsFrom: {
+                module: '../person',
+                name: 'Person',
+              },
+            },
+          },
+        },
+        'Pet/mango.json': {
+          data: {
+            attributes: {
+              name: 'Mango',
+            },
+            meta: {
+              adoptsFrom: {
+                module: `${testRealmURL}pet`,
+                name: 'Pet',
+              },
+            },
+          },
+        },
+        'Pet/vangogh.json': {
+          data: {
+            attributes: {
+              name: 'Van Gogh',
+            },
+            meta: {
+              adoptsFrom: {
+                module: `${testRealmURL}pet`,
+                name: 'Pet',
+              },
+            },
+          },
+        },
+        'z00.json': '{}',
+        'z01.json': '{}',
+        'z02.json': '{}',
+        'z03.json': '{}',
+        'z04.json': '{}',
+        'z05.json': '{}',
+        'z06.json': '{}',
+        'z07.json': '{}',
+        'z08.json': '{}',
+        'z09.json': '{}',
+        'z10.json': '{}',
+        'z11.json': '{}',
+        'z12.json': '{}',
+        'z13.json': '{}',
+        'z14.json': '{}',
+        'z15.json': '{}',
+        'z16.json': '{}',
+        'z17.json': '{}',
+        'z18.json': '{}',
+        'z19.json': '{}',
+        'zzz/zzz/file.json': '{}',
+        '.realm.json': {
+          name: 'Test Workspace B',
+          backgroundURL:
+            'https://i.postimg.cc/VNvHH93M/pawel-czerwinski-Ly-ZLa-A5jti-Y-unsplash.jpg',
+          iconURL: 'https://i.postimg.cc/L8yXRvws/icon.png',
+        },
+      },
+    }));
+
     monacoService = this.owner.lookup(
       'service:monaco-service',
     ) as MonacoService;
-
-    realm = await TestRealm.createWithAdapter(adapter, loader, this.owner, {
-      isAcceptanceTest: true,
-      overridingHandlers: [
-        async (req: Request) => {
-          return sourceFetchRedirectHandle(req, adapter, testRealmURL);
-        },
-        async (req: Request) => {
-          return sourceFetchReturnUrlHandle(req, realm.maybeHandle.bind(realm));
-        },
-      ],
-    });
-    await realm.ready;
   });
 
   test('inspector will show json instance definition and module definition in card inheritance panel', async function (assert) {
@@ -732,7 +721,6 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await this.expectEvents({
       assert,
       realm,
-      adapter,
       expectedEvents,
       callback: async () => {
         await click('[data-test-confirm-delete-button]');
@@ -819,7 +807,6 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await this.expectEvents({
       assert,
       realm,
-      adapter,
       expectedEvents,
       callback: async () => {
         await click('[data-test-confirm-delete-button]');

--- a/packages/host/tests/acceptance/code-submode/recent-files-test.ts
+++ b/packages/host/tests/acceptance/code-submode/recent-files-test.ts
@@ -16,17 +16,12 @@ import stringify from 'safe-stable-stringify';
 
 import { baseRealm } from '@cardstack/runtime-common';
 
-import { Realm } from '@cardstack/runtime-common/realm';
-
 import type LoaderService from '@cardstack/host/services/loader-service';
 
 import {
-  TestRealm,
-  TestRealmAdapter,
   setupLocalIndexing,
   testRealmURL,
-  sourceFetchRedirectHandle,
-  sourceFetchReturnUrlHandle,
+  setupAcceptanceTestRealm,
   waitForCodeEditor,
 } from '../../helpers';
 
@@ -186,9 +181,6 @@ const friendCardSource = `
 `;
 
 module('Acceptance | code submode | recent files tests', function (hooks) {
-  let realm: Realm;
-  let adapter: TestRealmAdapter;
-
   setupApplicationTest(hooks);
   setupLocalIndexing(hooks);
   setupWindowMock(hooks);
@@ -200,106 +192,96 @@ module('Acceptance | code submode | recent files tests', function (hooks) {
   hooks.beforeEach(async function () {
     window.localStorage.removeItem('recent-files');
 
-    // this seeds the loader used during index which obtains url mappings
-    // from the global loader
-    adapter = new TestRealmAdapter({
-      'index.gts': indexCardSource,
-      'pet-person.gts': personCardSource,
-      'person.gts': personCardSource,
-      'friend.gts': friendCardSource,
-      'employee.gts': employeeCardSource,
-      'in-this-file.gts': inThisFileSource,
-      'person-entry.json': {
-        data: {
-          type: 'card',
-          attributes: {
-            title: 'Person',
-            description: 'Catalog entry',
-            ref: {
-              module: `./person`,
-              name: 'Person',
-            },
-          },
-          meta: {
-            adoptsFrom: {
-              module: `${baseRealm.url}catalog-entry`,
-              name: 'CatalogEntry',
-            },
-          },
-        },
-      },
-      'index.json': {
-        data: {
-          type: 'card',
-          attributes: {},
-          meta: {
-            adoptsFrom: {
-              module: './index',
-              name: 'Index',
-            },
-          },
-        },
-      },
-      'not-json.json': 'I am not JSON.',
-      'Person/1.json': {
-        data: {
-          type: 'card',
-          attributes: {
-            firstName: 'Hassan',
-            lastName: 'Abdel-Rahman',
-          },
-          meta: {
-            adoptsFrom: {
-              module: '../person',
-              name: 'Person',
-            },
-          },
-        },
-      },
-      'z00.json': '{}',
-      'z01.json': '{}',
-      'z02.json': '{}',
-      'z03.json': '{}',
-      'z04.json': '{}',
-      'z05.json': '{}',
-      'z06.json': '{}',
-      'z07.json': '{}',
-      'z08.json': '{}',
-      'z09.json': '{}',
-      'z10.json': '{}',
-      'z11.json': '{}',
-      'z12.json': '{}',
-      'z13.json': '{}',
-      'z14.json': '{}',
-      'z15.json': '{}',
-      'z16.json': '{}',
-      'z17.json': '{}',
-      'z18.json': '{}',
-      'z19.json': '{}',
-      'zzz/zzz/file.json': '{}',
-      '.realm.json': {
-        name: 'Test Workspace B',
-        backgroundURL:
-          'https://i.postimg.cc/VNvHH93M/pawel-czerwinski-Ly-ZLa-A5jti-Y-unsplash.jpg',
-        iconURL: 'https://i.postimg.cc/L8yXRvws/icon.png',
-      },
-    });
-
     let loader = (this.owner.lookup('service:loader-service') as LoaderService)
       .loader;
 
-    realm = await TestRealm.createWithAdapter(adapter, loader, this.owner, {
-      isAcceptanceTest: true,
-      overridingHandlers: [
-        async (req: Request) => {
-          return sourceFetchRedirectHandle(req, adapter, testRealmURL);
+    // this seeds the loader used during index which obtains url mappings
+    // from the global loader
+    await setupAcceptanceTestRealm({
+      loader,
+      contents: {
+        'index.gts': indexCardSource,
+        'pet-person.gts': personCardSource,
+        'person.gts': personCardSource,
+        'friend.gts': friendCardSource,
+        'employee.gts': employeeCardSource,
+        'in-this-file.gts': inThisFileSource,
+        'person-entry.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              title: 'Person',
+              description: 'Catalog entry',
+              ref: {
+                module: `./person`,
+                name: 'Person',
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: `${baseRealm.url}catalog-entry`,
+                name: 'CatalogEntry',
+              },
+            },
+          },
         },
-        async (req: Request) => {
-          return sourceFetchReturnUrlHandle(req, realm.maybeHandle.bind(realm));
+        'index.json': {
+          data: {
+            type: 'card',
+            attributes: {},
+            meta: {
+              adoptsFrom: {
+                module: './index',
+                name: 'Index',
+              },
+            },
+          },
         },
-      ],
+        'not-json.json': 'I am not JSON.',
+        'Person/1.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              firstName: 'Hassan',
+              lastName: 'Abdel-Rahman',
+            },
+            meta: {
+              adoptsFrom: {
+                module: '../person',
+                name: 'Person',
+              },
+            },
+          },
+        },
+        'z00.json': '{}',
+        'z01.json': '{}',
+        'z02.json': '{}',
+        'z03.json': '{}',
+        'z04.json': '{}',
+        'z05.json': '{}',
+        'z06.json': '{}',
+        'z07.json': '{}',
+        'z08.json': '{}',
+        'z09.json': '{}',
+        'z10.json': '{}',
+        'z11.json': '{}',
+        'z12.json': '{}',
+        'z13.json': '{}',
+        'z14.json': '{}',
+        'z15.json': '{}',
+        'z16.json': '{}',
+        'z17.json': '{}',
+        'z18.json': '{}',
+        'z19.json': '{}',
+        'zzz/zzz/file.json': '{}',
+        '.realm.json': {
+          name: 'Test Workspace B',
+          backgroundURL:
+            'https://i.postimg.cc/VNvHH93M/pawel-czerwinski-Ly-ZLa-A5jti-Y-unsplash.jpg',
+          iconURL: 'https://i.postimg.cc/L8yXRvws/icon.png',
+        },
+      },
     });
-    await realm.ready;
   });
 
   test('recent file links are shown', async function (assert) {

--- a/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
@@ -21,12 +21,9 @@ import { Realm } from '@cardstack/runtime-common/realm';
 import type LoaderService from '@cardstack/host/services/loader-service';
 
 import {
-  TestRealm,
-  TestRealmAdapter,
   setupLocalIndexing,
   testRealmURL,
-  sourceFetchRedirectHandle,
-  sourceFetchReturnUrlHandle,
+  setupAcceptanceTestRealm,
   setupServerSentEvents,
   setupOnSave,
   getMonacoContent,
@@ -215,7 +212,6 @@ const ambiguousDisplayNamesCardSource = `
 
 module('Acceptance | code submode | schema editor tests', function (hooks) {
   let realm: Realm;
-  let adapter: TestRealmAdapter;
 
   async function saveField(
     context: TestContextWithSSE,
@@ -225,7 +221,6 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
     await context.expectEvents({
       assert,
       realm,
-      adapter,
       expectedEvents,
       callback: async () => {
         await click('[data-test-save-field-button]');
@@ -245,107 +240,97 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
   hooks.beforeEach(async function () {
     window.localStorage.removeItem('recent-files');
 
-    // this seeds the loader used during index which obtains url mappings
-    // from the global loader
-    adapter = new TestRealmAdapter({
-      'index.gts': indexCardSource,
-      'pet-person.gts': personCardSource,
-      'person.gts': personCardSource,
-      'friend.gts': friendCardSource,
-      'employee.gts': employeeCardSource,
-      'in-this-file.gts': inThisFileSource,
-      'ambiguous-display-names.gts': ambiguousDisplayNamesCardSource,
-      'person-entry.json': {
-        data: {
-          type: 'card',
-          attributes: {
-            title: 'Person',
-            description: 'Catalog entry',
-            ref: {
-              module: `./person`,
-              name: 'Person',
-            },
-          },
-          meta: {
-            adoptsFrom: {
-              module: `${baseRealm.url}catalog-entry`,
-              name: 'CatalogEntry',
-            },
-          },
-        },
-      },
-      'index.json': {
-        data: {
-          type: 'card',
-          attributes: {},
-          meta: {
-            adoptsFrom: {
-              module: './index',
-              name: 'Index',
-            },
-          },
-        },
-      },
-      'not-json.json': 'I am not JSON.',
-      'Person/1.json': {
-        data: {
-          type: 'card',
-          attributes: {
-            firstName: 'Hassan',
-            lastName: 'Abdel-Rahman',
-          },
-          meta: {
-            adoptsFrom: {
-              module: '../person',
-              name: 'Person',
-            },
-          },
-        },
-      },
-      'z00.json': '{}',
-      'z01.json': '{}',
-      'z02.json': '{}',
-      'z03.json': '{}',
-      'z04.json': '{}',
-      'z05.json': '{}',
-      'z06.json': '{}',
-      'z07.json': '{}',
-      'z08.json': '{}',
-      'z09.json': '{}',
-      'z10.json': '{}',
-      'z11.json': '{}',
-      'z12.json': '{}',
-      'z13.json': '{}',
-      'z14.json': '{}',
-      'z15.json': '{}',
-      'z16.json': '{}',
-      'z17.json': '{}',
-      'z18.json': '{}',
-      'z19.json': '{}',
-      'zzz/zzz/file.json': '{}',
-      '.realm.json': {
-        name: 'Test Workspace B',
-        backgroundURL:
-          'https://i.postimg.cc/VNvHH93M/pawel-czerwinski-Ly-ZLa-A5jti-Y-unsplash.jpg',
-        iconURL: 'https://i.postimg.cc/L8yXRvws/icon.png',
-      },
-    });
-
     let loader = (this.owner.lookup('service:loader-service') as LoaderService)
       .loader;
 
-    realm = await TestRealm.createWithAdapter(adapter, loader, this.owner, {
-      isAcceptanceTest: true,
-      overridingHandlers: [
-        async (req: Request) => {
-          return sourceFetchRedirectHandle(req, adapter, testRealmURL);
+    // this seeds the loader used during index which obtains url mappings
+    // from the global loader
+    ({ realm } = await setupAcceptanceTestRealm({
+      loader,
+      contents: {
+        'index.gts': indexCardSource,
+        'pet-person.gts': personCardSource,
+        'person.gts': personCardSource,
+        'friend.gts': friendCardSource,
+        'employee.gts': employeeCardSource,
+        'in-this-file.gts': inThisFileSource,
+        'ambiguous-display-names.gts': ambiguousDisplayNamesCardSource,
+        'person-entry.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              title: 'Person',
+              description: 'Catalog entry',
+              ref: {
+                module: `./person`,
+                name: 'Person',
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: `${baseRealm.url}catalog-entry`,
+                name: 'CatalogEntry',
+              },
+            },
+          },
         },
-        async (req: Request) => {
-          return sourceFetchReturnUrlHandle(req, realm.maybeHandle.bind(realm));
+        'index.json': {
+          data: {
+            type: 'card',
+            attributes: {},
+            meta: {
+              adoptsFrom: {
+                module: './index',
+                name: 'Index',
+              },
+            },
+          },
         },
-      ],
-    });
-    await realm.ready;
+        'not-json.json': 'I am not JSON.',
+        'Person/1.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              firstName: 'Hassan',
+              lastName: 'Abdel-Rahman',
+            },
+            meta: {
+              adoptsFrom: {
+                module: '../person',
+                name: 'Person',
+              },
+            },
+          },
+        },
+        'z00.json': '{}',
+        'z01.json': '{}',
+        'z02.json': '{}',
+        'z03.json': '{}',
+        'z04.json': '{}',
+        'z05.json': '{}',
+        'z06.json': '{}',
+        'z07.json': '{}',
+        'z08.json': '{}',
+        'z09.json': '{}',
+        'z10.json': '{}',
+        'z11.json': '{}',
+        'z12.json': '{}',
+        'z13.json': '{}',
+        'z14.json': '{}',
+        'z15.json': '{}',
+        'z16.json': '{}',
+        'z17.json': '{}',
+        'z18.json': '{}',
+        'z19.json': '{}',
+        'zzz/zzz/file.json': '{}',
+        '.realm.json': {
+          name: 'Test Workspace B',
+          backgroundURL:
+            'https://i.postimg.cc/VNvHH93M/pawel-czerwinski-Ly-ZLa-A5jti-Y-unsplash.jpg',
+          iconURL: 'https://i.postimg.cc/L8yXRvws/icon.png',
+        },
+      },
+    }));
   });
 
   test('schema editor lists the inheritance chain', async function (assert) {

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -17,6 +17,7 @@ import { module, test } from 'qunit';
 import stringify from 'safe-stable-stringify';
 
 import {
+  baseRealm,
   type LooseSingleCardDocument,
   Deferred,
 } from '@cardstack/runtime-common';
@@ -40,6 +41,8 @@ import {
   sourceFetchReturnUrlHandle,
 } from '../helpers';
 
+import { FieldContainer } from '@cardstack/boxel-ui/components';
+
 module('Acceptance | interact submode tests', function (hooks) {
   let realm: Realm;
   let adapter: TestRealmAdapter;
@@ -59,124 +62,130 @@ module('Acceptance | interact submode tests', function (hooks) {
     window.localStorage.removeItem('recent-cards');
     window.localStorage.removeItem('recent-files');
 
+    let loader = (this.owner.lookup('service:loader-service') as LoaderService)
+      .loader;
+    let cardApi: typeof import('https://cardstack.com/base/card-api');
+    let string: typeof import('https://cardstack.com/base/string');
+    cardApi = await loader.import(`${baseRealm.url}card-api`);
+    string = await loader.import(`${baseRealm.url}string`);
+
+    let {
+      field,
+      contains,
+      linksTo,
+      linksToMany,
+      CardDef,
+      Component,
+      FieldDef,
+    } = cardApi;
+    let { default: StringField } = string;
+
+    class Pet extends CardDef {
+      static displayName = 'Pet';
+      @field name = contains(StringField);
+      @field title = contains(StringField, {
+        computeVia: function (this: Pet) {
+          return this.name;
+        },
+      });
+      static embedded = class Embedded extends Component<typeof this> {
+        <template>
+          <h3 data-test-pet={{@model.name}}>
+            <@fields.name />
+          </h3>
+        </template>
+      };
+    }
+
+    class ShippingInfo extends FieldDef {
+      static displayName = 'Shipping Info';
+      @field preferredCarrier = contains(StringField);
+      @field remarks = contains(StringField);
+      @field title = contains(StringField, {
+        computeVia: function (this: ShippingInfo) {
+          return this.preferredCarrier;
+        },
+      });
+      static embedded = class Embedded extends Component<typeof this> {
+        <template>
+          <span data-test-preferredCarrier={{@model.preferredCarrier}}></span>
+          <@fields.preferredCarrier />
+        </template>
+      };
+    }
+
+    class Address extends FieldDef {
+      static displayName = 'Address';
+      @field city = contains(StringField);
+      @field country = contains(StringField);
+      @field shippingInfo = contains(ShippingInfo);
+      static embedded = class Embedded extends Component<typeof this> {
+        <template>
+          <h3 data-test-city={{@model.city}}>
+            <@fields.city />
+          </h3>
+          <h3 data-test-country={{@model.country}}>
+            <@fields.country />
+          </h3>
+          <div data-test-shippingInfo-field><@fields.shippingInfo /></div>
+        </template>
+      };
+
+      static edit = class Edit extends Component<typeof this> {
+        <template>
+          <FieldContainer @label='city' @tag='label' data-test-boxel-input-city>
+            <@fields.city />
+          </FieldContainer>
+          <FieldContainer
+            @label='country'
+            @tag='label'
+            data-test-boxel-input-country
+          >
+            <@fields.country />
+          </FieldContainer>
+          <div data-test-shippingInfo-field><@fields.shippingInfo /></div>
+        </template>
+      };
+    }
+
+    class Person extends CardDef {
+      static displayName = 'Person';
+      @field firstName = contains(StringField);
+      @field pet = linksTo(Pet);
+      @field friends = linksToMany(Pet);
+      @field firstLetterOfTheName = contains(StringField, {
+        computeVia: function (this: Person) {
+          if (!this.firstName) {
+            return;
+          }
+          return this.firstName[0];
+        },
+      });
+      @field title = contains(StringField, {
+        computeVia: function (this: Person) {
+          return this.firstName;
+        },
+      });
+      @field address = contains(Address);
+      static isolated = class Isolated extends Component<typeof this> {
+        <template>
+          <h2 data-test-person={{@model.firstName}}>
+            <@fields.firstName />
+          </h2>
+          <p data-test-first-letter-of-the-name={{@model.firstLetterOfTheName}}>
+            <@fields.firstLetterOfTheName />
+          </p>
+          Pet:
+          <@fields.pet />
+          Friends:
+          <@fields.friends />
+          Address:
+          <@fields.address />
+        </template>
+      };
+    }
+
     adapter = new TestRealmAdapter({
-      'pet.gts': `
-        import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
-
-        export class Pet extends CardDef {
-          static displayName = 'Pet';
-          @field name = contains(StringCard);
-          @field title = contains(StringCard, {
-            computeVia: function (this: Pet) {
-              return this.name;
-            },
-          });
-          static embedded = class Embedded extends Component<typeof this> {
-            <template>
-              <h3 data-test-pet={{@model.name}}>
-                <@fields.name/>
-              </h3>
-            </template>
-          }
-        }
-      `,
-      'shipping-info.gts': `
-        import { contains, field, Component, FieldDef } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
-        export class ShippingInfo extends FieldDef {
-          static displayName = 'Shipping Info';
-          @field preferredCarrier = contains(StringCard);
-          @field remarks = contains(StringCard);
-          @field title = contains(StringCard, {
-            computeVia: function (this: ShippingInfo) {
-              return this.preferredCarrier;
-            },
-          });
-          static embedded = class Embedded extends Component<typeof this> {
-            <template>
-              <span data-test-preferredCarrier={{@model.preferredCarrier}}></span>
-              <@fields.preferredCarrier/>
-            </template>
-          }
-        }
-      `,
-      'address.gts': `
-        import { contains, field, Component, FieldDef } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
-        import { ShippingInfo } from "./shipping-info";
-        import { FieldContainer } from '@cardstack/boxel-ui/components';
-
-        export class Address extends FieldDef {
-          static displayName = 'Address';
-          @field city = contains(StringCard);
-          @field country = contains(StringCard);
-          @field shippingInfo = contains(ShippingInfo);
-          static embedded = class Embedded extends Component<typeof this> {
-            <template>
-              <h3 data-test-city={{@model.city}}>
-                <@fields.city/>
-              </h3>
-              <h3 data-test-country={{@model.country}}>
-                <@fields.country/>
-              </h3>
-              <div data-test-shippingInfo-field><@fields.shippingInfo/></div>
-            </template>
-          }
-
-          static edit = class Edit extends Component<typeof this> {
-            <template>
-              <FieldContainer @label='city' @tag='label' data-test-boxel-input-city>
-                <@fields.city />
-              </FieldContainer>
-              <FieldContainer @label='country' @tag='label' data-test-boxel-input-country>
-                <@fields.country />
-              </FieldContainer>
-              <div data-test-shippingInfo-field><@fields.shippingInfo/></div>
-            </template>
-          };
-        }
-      `,
-      'person.gts': `
-        import { contains, linksTo, field, Component, CardDef, linksToMany } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
-        import { Pet } from "./pet";
-        import { Address } from "./address";
-
-        export class Person extends CardDef {
-          static displayName = 'Person';
-          @field firstName = contains(StringCard);
-          @field pet = linksTo(Pet);
-          @field friends = linksToMany(Pet);
-          @field firstLetterOfTheName = contains(StringCard, {
-            computeVia: function (this: Chain) {
-              if (!this.firstName) {
-                return;
-              }
-              return this.firstName[0];
-            },
-          });
-          @field title = contains(StringCard, {
-            computeVia: function (this: Person) {
-              return this.firstName;
-            },
-          });
-          @field address = contains(Address);
-          static isolated = class Isolated extends Component<typeof this> {
-            <template>
-              <h2 data-test-person={{@model.firstName}}>
-                <@fields.firstName/>
-              </h2>
-              <p data-test-first-letter-of-the-name={{@model.firstLetterOfTheName}}>
-                <@fields.firstLetterOfTheName/>
-              </p>
-              Pet: <@fields.pet/>
-              Friends: <@fields.friends/>
-              Address: <@fields.address/>
-            </template>
-          }
-        }
-      `,
       'README.txt': `Hello World`,
       'person-entry.json': {
         data: {
@@ -284,9 +293,6 @@ module('Acceptance | interact submode tests', function (hooks) {
       },
     });
 
-    let loader = (this.owner.lookup('service:loader-service') as LoaderService)
-      .loader;
-
     realm = await TestRealm.createWithAdapter(adapter, loader, this.owner, {
       isAcceptanceTest: true,
       overridingHandlers: [
@@ -297,6 +303,12 @@ module('Acceptance | interact submode tests', function (hooks) {
           return sourceFetchReturnUrlHandle(req, realm.maybeHandle.bind(realm));
         },
       ],
+      shimModules: {
+        'address.gts': { Address },
+        'person.gts': { Person },
+        'pet.gts': { Pet },
+        'shipping-info.gts': { ShippingInfo },
+      },
     });
     await realm.ready;
   });
@@ -1020,80 +1032,13 @@ module('Acceptance | interact submode tests', function (hooks) {
         );
       },
     });
-    await waitUntil(
-      () =>
-        document
-          .querySelector(
-            '[data-test-operator-mode-stack="0"] [data-test-person]',
-          )
-          ?.textContent?.includes('FadhlanXXX'),
+    await waitUntil(() =>
+      document
+        .querySelector('[data-test-operator-mode-stack="0"] [data-test-person]')
+        ?.textContent?.includes('FadhlanXXX'),
     );
     assert
       .dom('[data-test-operator-mode-stack="0"] [data-test-person]')
       .hasText('FadhlanXXX');
-  });
-
-  test<TestContextWithSSE>('card preview live updates when index changes', async function (assert) {
-    let expectedEvents = [
-      {
-        type: 'index',
-        data: {
-          type: 'incremental',
-          invalidations: [`${testRealmURL}Person/fadhlan`],
-        },
-      },
-    ];
-    let operatorModeStateParam = stringify({
-      stacks: [
-        [
-          {
-            id: `${testRealmURL}Person/fadhlan`,
-            format: 'isolated',
-          },
-        ],
-      ],
-      submode: 'code',
-      codePath: `${testRealmURL}Person/fadhlan.json`,
-    })!;
-    await visit(
-      `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
-        operatorModeStateParam,
-      )}`,
-    );
-    await waitFor('[data-test-card-resource-loaded]');
-    await this.expectEvents({
-      assert,
-      realm,
-      adapter,
-      expectedEvents,
-      callback: async () => {
-        await realm.write(
-          'Person/fadhlan.json',
-          JSON.stringify({
-            data: {
-              type: 'card',
-              attributes: {
-                firstName: 'FadhlanXXX',
-              },
-              meta: {
-                adoptsFrom: {
-                  module: '../person',
-                  name: 'Person',
-                },
-              },
-            },
-          } as LooseSingleCardDocument),
-        );
-      },
-    });
-    await waitUntil(
-      () =>
-        document
-          .querySelector('[data-test-code-mode-card-preview-body]')
-          ?.textContent?.includes('FadhlanXXX'),
-    );
-    assert
-      .dom('[data-test-code-mode-card-preview-body]')
-      .includesText('FadhlanXXX');
   });
 });

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -29,23 +29,19 @@ import type OperatorModeStateService from '@cardstack/host/services/operator-mod
 import type RecentCardsService from '@cardstack/host/services/recent-cards-service';
 
 import {
-  TestRealm,
-  TestRealmAdapter,
   setupLocalIndexing,
   setupServerSentEvents,
   setupOnSave,
   testRealmURL,
   type TestContextWithSSE,
   type TestContextWithSave,
-  sourceFetchRedirectHandle,
-  sourceFetchReturnUrlHandle,
+  setupAcceptanceTestRealm,
 } from '../helpers';
 
 import { FieldContainer } from '@cardstack/boxel-ui/components';
 
 module('Acceptance | interact submode tests', function (hooks) {
   let realm: Realm;
-  let adapter: TestRealmAdapter;
 
   setupApplicationTest(hooks);
   setupLocalIndexing(hooks);
@@ -185,132 +181,120 @@ module('Acceptance | interact submode tests', function (hooks) {
       };
     }
 
-    adapter = new TestRealmAdapter({
-      'README.txt': `Hello World`,
-      'person-entry.json': {
-        data: {
-          type: 'card',
-          attributes: {
-            title: 'Person Card',
-            description: 'Catalog entry for Person Card',
-            ref: {
-              module: `${testRealmURL}person`,
-              name: 'Person',
-            },
-          },
-          meta: {
-            adoptsFrom: {
-              module: 'https://cardstack.com/base/catalog-entry',
-              name: 'CatalogEntry',
-            },
-          },
-        },
-      },
-      'Pet/mango.json': {
-        data: {
-          attributes: {
-            name: 'Mango',
-          },
-          meta: {
-            adoptsFrom: {
-              module: `${testRealmURL}pet`,
-              name: 'Pet',
-            },
-          },
-        },
-      },
-      'Pet/vangogh.json': {
-        data: {
-          attributes: {
-            name: 'Van Gogh',
-          },
-          meta: {
-            adoptsFrom: {
-              module: `${testRealmURL}pet`,
-              name: 'Pet',
-            },
-          },
-        },
-      },
-
-      'Person/fadhlan.json': {
-        data: {
-          attributes: {
-            firstName: 'Fadhlan',
-            address: {
-              city: 'Bandung',
-              country: 'Indonesia',
-              shippingInfo: {
-                preferredCarrier: 'DHL',
-                remarks: `Don't let bob deliver the package--he's always bringing it to the wrong address`,
-              },
-            },
-          },
-          relationships: {
-            pet: {
-              links: {
-                self: `${testRealmURL}Pet/mango`,
-              },
-            },
-          },
-          meta: {
-            adoptsFrom: {
-              module: `${testRealmURL}person`,
-              name: 'Person',
-            },
-          },
-        },
-      },
-      'grid.json': {
-        data: {
-          type: 'card',
-          attributes: {},
-          meta: {
-            adoptsFrom: {
-              module: 'https://cardstack.com/base/cards-grid',
-              name: 'CardsGrid',
-            },
-          },
-        },
-      },
-      'index.json': {
-        data: {
-          type: 'card',
-          attributes: {},
-          meta: {
-            adoptsFrom: {
-              module: 'https://cardstack.com/base/cards-grid',
-              name: 'CardsGrid',
-            },
-          },
-        },
-      },
-      '.realm.json': {
-        name: 'Test Workspace B',
-        backgroundURL:
-          'https://i.postimg.cc/VNvHH93M/pawel-czerwinski-Ly-ZLa-A5jti-Y-unsplash.jpg',
-        iconURL: 'https://i.postimg.cc/L8yXRvws/icon.png',
-      },
-    });
-
-    realm = await TestRealm.createWithAdapter(adapter, loader, this.owner, {
-      isAcceptanceTest: true,
-      overridingHandlers: [
-        async (req: Request) => {
-          return sourceFetchRedirectHandle(req, adapter, testRealmURL);
-        },
-        async (req: Request) => {
-          return sourceFetchReturnUrlHandle(req, realm.maybeHandle.bind(realm));
-        },
-      ],
-      shimModules: {
+    ({ realm } = await setupAcceptanceTestRealm({
+      loader,
+      contents: {
         'address.gts': { Address },
         'person.gts': { Person },
         'pet.gts': { Pet },
         'shipping-info.gts': { ShippingInfo },
+        'README.txt': `Hello World`,
+        'person-entry.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              title: 'Person Card',
+              description: 'Catalog entry for Person Card',
+              ref: {
+                module: `${testRealmURL}person`,
+                name: 'Person',
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/catalog-entry',
+                name: 'CatalogEntry',
+              },
+            },
+          },
+        },
+        'Pet/mango.json': {
+          data: {
+            attributes: {
+              name: 'Mango',
+            },
+            meta: {
+              adoptsFrom: {
+                module: `${testRealmURL}pet`,
+                name: 'Pet',
+              },
+            },
+          },
+        },
+        'Pet/vangogh.json': {
+          data: {
+            attributes: {
+              name: 'Van Gogh',
+            },
+            meta: {
+              adoptsFrom: {
+                module: `${testRealmURL}pet`,
+                name: 'Pet',
+              },
+            },
+          },
+        },
+
+        'Person/fadhlan.json': {
+          data: {
+            attributes: {
+              firstName: 'Fadhlan',
+              address: {
+                city: 'Bandung',
+                country: 'Indonesia',
+                shippingInfo: {
+                  preferredCarrier: 'DHL',
+                  remarks: `Don't let bob deliver the package--he's always bringing it to the wrong address`,
+                },
+              },
+            },
+            relationships: {
+              pet: {
+                links: {
+                  self: `${testRealmURL}Pet/mango`,
+                },
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: `${testRealmURL}person`,
+                name: 'Person',
+              },
+            },
+          },
+        },
+        'grid.json': {
+          data: {
+            type: 'card',
+            attributes: {},
+            meta: {
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/cards-grid',
+                name: 'CardsGrid',
+              },
+            },
+          },
+        },
+        'index.json': {
+          data: {
+            type: 'card',
+            attributes: {},
+            meta: {
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/cards-grid',
+                name: 'CardsGrid',
+              },
+            },
+          },
+        },
+        '.realm.json': {
+          name: 'Test Workspace B',
+          backgroundURL:
+            'https://i.postimg.cc/VNvHH93M/pawel-czerwinski-Ly-ZLa-A5jti-Y-unsplash.jpg',
+          iconURL: 'https://i.postimg.cc/L8yXRvws/icon.png',
+        },
       },
-    });
-    await realm.ready;
+    }));
   });
 
   module('0 stacks', function () {
@@ -1010,7 +994,6 @@ module('Acceptance | interact submode tests', function (hooks) {
     await this.expectEvents({
       assert,
       realm,
-      adapter,
       expectedEvents,
       callback: async () => {
         await realm.write(

--- a/packages/host/tests/acceptance/operator-mode-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-test.gts
@@ -15,27 +15,20 @@ import { module, test } from 'qunit';
 import stringify from 'safe-stable-stringify';
 
 import { baseRealm, primitive } from '@cardstack/runtime-common';
-import { Realm } from '@cardstack/runtime-common/realm';
 
 import { Submodes } from '@cardstack/host/components/submode-switcher';
 import type LoaderService from '@cardstack/host/services/loader-service';
 import { FieldContainer } from '@cardstack/boxel-ui/components';
 
 import {
-  TestRealm,
-  TestRealmAdapter,
   setupLocalIndexing,
   setupServerSentEvents,
   setupOnSave,
   testRealmURL,
-  sourceFetchRedirectHandle,
-  sourceFetchReturnUrlHandle,
+  setupAcceptanceTestRealm,
 } from '../helpers';
 
 module('Acceptance | operator mode tests', function (hooks) {
-  let realm: Realm;
-  let adapter: TestRealmAdapter;
-
   setupApplicationTest(hooks);
   setupLocalIndexing(hooks);
   setupServerSentEvents(hooks);
@@ -205,147 +198,136 @@ module('Acceptance | operator mode tests', function (hooks) {
         },
       });
     }
-    adapter = new TestRealmAdapter({
-      'README.txt': `Hello World`,
-      'person-entry.json': {
-        data: {
-          type: 'card',
-          attributes: {
-            title: 'Person Card',
-            description: 'Catalog entry for Person Card',
-            ref: {
-              module: `${testRealmURL}person`,
-              name: 'Person',
-            },
-          },
-          meta: {
-            adoptsFrom: {
-              module: 'https://cardstack.com/base/catalog-entry',
-              name: 'CatalogEntry',
-            },
-          },
-        },
-      },
-      'Pet/mango.json': {
-        data: {
-          attributes: {
-            name: 'Mango',
-          },
-          meta: {
-            adoptsFrom: {
-              module: `${testRealmURL}pet`,
-              name: 'Pet',
-            },
-          },
-        },
-      },
-      'Pet/vangogh.json': {
-        data: {
-          attributes: {
-            name: 'Van Gogh',
-          },
-          meta: {
-            adoptsFrom: {
-              module: `${testRealmURL}pet`,
-              name: 'Pet',
-            },
-          },
-        },
-      },
 
-      'Person/fadhlan.json': {
-        data: {
-          attributes: {
-            firstName: 'Fadhlan',
-            address: {
-              city: 'Bandung',
-              country: 'Indonesia',
-              shippingInfo: {
-                preferredCarrier: 'DHL',
-                remarks: `Don't let bob deliver the package--he's always bringing it to the wrong address`,
-              },
-            },
-          },
-          relationships: {
-            pet: {
-              links: {
-                self: `${testRealmURL}Pet/mango`,
-              },
-            },
-          },
-          meta: {
-            adoptsFrom: {
-              module: `${testRealmURL}person`,
-              name: 'Person',
-            },
-          },
-        },
-      },
-      'boom.json': {
-        data: {
-          attributes: {
-            firstName: 'Boom!',
-          },
-          meta: {
-            adoptsFrom: {
-              module: './boom-person',
-              name: 'BoomPerson',
-            },
-          },
-        },
-      },
-      'grid.json': {
-        data: {
-          type: 'card',
-          attributes: {},
-          meta: {
-            adoptsFrom: {
-              module: 'https://cardstack.com/base/cards-grid',
-              name: 'CardsGrid',
-            },
-          },
-        },
-      },
-      'index.json': {
-        data: {
-          type: 'card',
-          attributes: {},
-          meta: {
-            adoptsFrom: {
-              module: 'https://cardstack.com/base/cards-grid',
-              name: 'CardsGrid',
-            },
-          },
-        },
-      },
-      '.realm.json': {
-        name: 'Test Workspace B',
-        backgroundURL:
-          'https://i.postimg.cc/VNvHH93M/pawel-czerwinski-Ly-ZLa-A5jti-Y-unsplash.jpg',
-        iconURL: 'https://i.postimg.cc/L8yXRvws/icon.png',
-      },
-    });
-
-    realm = await TestRealm.createWithAdapter(adapter, loader, this.owner, {
-      isAcceptanceTest: true,
-      overridingHandlers: [
-        async (req: Request) => {
-          return sourceFetchRedirectHandle(req, adapter, testRealmURL);
-        },
-        async (req: Request) => {
-          return sourceFetchReturnUrlHandle(req, realm.maybeHandle.bind(realm));
-        },
-      ],
-      shimModules: {
+    await setupAcceptanceTestRealm({
+      loader,
+      contents: {
         'address.gts': { Address },
         'boom-field.gts': { BoomField },
         'boom-person.gts': { BoomPerson },
         'person.gts': { Person },
         'pet.gts': { Pet },
         'shipping-info.gts': { ShippingInfo },
+        'README.txt': `Hello World`,
+        'person-entry.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              title: 'Person Card',
+              description: 'Catalog entry for Person Card',
+              ref: {
+                module: `${testRealmURL}person`,
+                name: 'Person',
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/catalog-entry',
+                name: 'CatalogEntry',
+              },
+            },
+          },
+        },
+        'Pet/mango.json': {
+          data: {
+            attributes: {
+              name: 'Mango',
+            },
+            meta: {
+              adoptsFrom: {
+                module: `${testRealmURL}pet`,
+                name: 'Pet',
+              },
+            },
+          },
+        },
+        'Pet/vangogh.json': {
+          data: {
+            attributes: {
+              name: 'Van Gogh',
+            },
+            meta: {
+              adoptsFrom: {
+                module: `${testRealmURL}pet`,
+                name: 'Pet',
+              },
+            },
+          },
+        },
+
+        'Person/fadhlan.json': {
+          data: {
+            attributes: {
+              firstName: 'Fadhlan',
+              address: {
+                city: 'Bandung',
+                country: 'Indonesia',
+                shippingInfo: {
+                  preferredCarrier: 'DHL',
+                  remarks: `Don't let bob deliver the package--he's always bringing it to the wrong address`,
+                },
+              },
+            },
+            relationships: {
+              pet: {
+                links: {
+                  self: `${testRealmURL}Pet/mango`,
+                },
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: `${testRealmURL}person`,
+                name: 'Person',
+              },
+            },
+          },
+        },
+        'boom.json': {
+          data: {
+            attributes: {
+              firstName: 'Boom!',
+            },
+            meta: {
+              adoptsFrom: {
+                module: './boom-person',
+                name: 'BoomPerson',
+              },
+            },
+          },
+        },
+        'grid.json': {
+          data: {
+            type: 'card',
+            attributes: {},
+            meta: {
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/cards-grid',
+                name: 'CardsGrid',
+              },
+            },
+          },
+        },
+        'index.json': {
+          data: {
+            type: 'card',
+            attributes: {},
+            meta: {
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/cards-grid',
+                name: 'CardsGrid',
+              },
+            },
+          },
+        },
+        '.realm.json': {
+          name: 'Test Workspace B',
+          backgroundURL:
+            'https://i.postimg.cc/VNvHH93M/pawel-czerwinski-Ly-ZLa-A5jti-Y-unsplash.jpg',
+          iconURL: 'https://i.postimg.cc/L8yXRvws/icon.png',
+        },
       },
     });
-    await realm.ready;
   });
 
   test('visiting index card and entering operator mode', async function (assert) {

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -1,6 +1,5 @@
-import Owner from '@ember/owner';
 import Service from '@ember/service';
-import { type TestContext, visit } from '@ember/test-helpers';
+import { type TestContext, getContext, visit } from '@ember/test-helpers';
 import { findAll, waitUntil, waitFor, click } from '@ember/test-helpers';
 import { buildWaiter } from '@ember/test-waiters';
 import GlimmerComponent from '@glimmer/component';
@@ -19,7 +18,6 @@ import {
   executableExtensions,
   SupportedMimeType,
 } from '@cardstack/runtime-common';
-import { type RequestHandler } from '@cardstack/runtime-common/loader';
 
 import { Loader } from '@cardstack/runtime-common/loader';
 import { LocalPath, RealmPaths } from '@cardstack/runtime-common/paths';
@@ -146,7 +144,6 @@ export interface TestContextWithSSE extends TestContext {
   expectEvents: (args: {
     assert: Assert;
     realm: Realm;
-    adapter: TestRealmAdapter;
     expectedEvents?: { type: string; data: Record<string, any> }[];
     expectedNumberOfEvents?: number;
     onEvents?: (events: { type: string; data: Record<string, any> }[]) => void;
@@ -155,63 +152,6 @@ export interface TestContextWithSSE extends TestContext {
   }) => Promise<any>;
   subscribers: ((e: { type: string; data: string }) => void)[];
 }
-
-interface Options {
-  realmURL?: string;
-  isAcceptanceTest?: true;
-  onFetch?: (req: Request) => Promise<Request>;
-  overridingHandlers?: RequestHandler[];
-  shimModules?: Record<string, Record<string, any>>;
-}
-
-// We use a rendered component to facilitate our indexing (this emulates
-// the work that the Fastboot renderer is doing), which means that the
-// `setupRenderingTest(hooks)` from ember-qunit must be used in your tests.
-export const TestRealm = {
-  async create(
-    loader: Loader,
-    flatFiles: Record<string, string | LooseSingleCardDocument | CardDocFiles>,
-    owner: Owner,
-    opts?: Options,
-  ): Promise<Realm> {
-    if (opts?.isAcceptanceTest) {
-      await visit('/acceptance-test-setup');
-    } else {
-      await makeRenderer();
-    }
-    return await makeRealm(
-      new TestRealmAdapter(flatFiles),
-      loader,
-      owner,
-      opts?.realmURL,
-      opts?.onFetch,
-      opts?.overridingHandlers,
-      opts?.shimModules,
-    );
-  },
-
-  async createWithAdapter(
-    adapter: RealmAdapter,
-    loader: Loader,
-    owner: Owner,
-    opts?: Options,
-  ): Promise<Realm> {
-    if (opts?.isAcceptanceTest) {
-      await visit('/acceptance-test-setup');
-    } else {
-      await makeRenderer();
-    }
-    return await makeRealm(
-      adapter,
-      loader,
-      owner,
-      opts?.realmURL,
-      opts?.onFetch,
-      opts?.overridingHandlers,
-      opts?.shimModules,
-    );
-  },
-};
 
 async function makeRenderer() {
   // This emulates the application.hbs
@@ -329,7 +269,6 @@ export function setupServerSentEvents(hooks: NestedHooks) {
     this.expectEvents = async <T,>({
       assert,
       realm,
-      adapter,
       expectedEvents,
       expectedNumberOfEvents,
       onEvents,
@@ -338,7 +277,6 @@ export function setupServerSentEvents(hooks: NestedHooks) {
     }: {
       assert: Assert;
       realm: Realm;
-      adapter: TestRealmAdapter;
       expectedEvents?: { type: string; data: Record<string, any> }[];
       expectedNumberOfEvents?: number;
       onEvents?: (
@@ -417,7 +355,7 @@ export function setupServerSentEvents(hooks: NestedHooks) {
         onEvents(events);
       }
       clearTimeout(timeout);
-      adapter.unsubscribe();
+      realm.unsubscribe();
       return result;
     };
   });
@@ -436,15 +374,113 @@ function getEventData(message: string) {
 }
 
 let runnerOptsMgr = new RunnerOptionsManager();
-async function makeRealm(
-  adapter: RealmAdapter,
-  loader: Loader,
-  owner: Owner,
-  realmURL = testRealmURL,
-  onFetch?: (req: Request) => Promise<Request>,
-  overridingHandlers?: RequestHandler[],
-  shimModules?: Record<string, Record<string, any>>,
-) {
+
+interface RealmContents {
+  [key: string]:
+    | CardDef
+    | LooseSingleCardDocument
+    | RealmInfo
+    | Record<string, unknown>
+    | string;
+}
+export async function setupAcceptanceTestRealm({
+  loader,
+  contents,
+  realmURL,
+  onFetch,
+}: {
+  loader: Loader;
+  contents: RealmContents;
+  realmURL?: string;
+  onFetch?: (req: Request) => Promise<Request>;
+}) {
+  return await setupTestRealm({
+    loader,
+    contents,
+    realmURL,
+    onFetch,
+    isAcceptanceTest: true,
+  });
+}
+
+export async function setupIntegrationTestRealm({
+  loader,
+  contents,
+  realmURL,
+  onFetch,
+}: {
+  loader: Loader;
+  contents: RealmContents;
+  realmURL?: string;
+  onFetch?: (req: Request) => Promise<Request>;
+}) {
+  return await setupTestRealm({
+    loader,
+    contents,
+    realmURL,
+    onFetch,
+    isAcceptanceTest: false,
+  });
+}
+
+async function setupTestRealm({
+  loader,
+  contents,
+  realmURL,
+  onFetch,
+  isAcceptanceTest,
+}: {
+  loader: Loader;
+  contents: RealmContents;
+  realmURL?: string;
+  onFetch?: (req: Request) => Promise<Request>;
+  isAcceptanceTest?: boolean;
+}) {
+  realmURL = realmURL ?? testRealmURL;
+  for (const [path, mod] of Object.entries(contents)) {
+    if (path.endsWith('.gts') && typeof mod !== 'string') {
+      await shimModule(
+        `${realmURL}${path.replace(/\.gts$/, '')}`,
+        mod as object,
+        loader,
+      );
+    }
+  }
+  let api = await loader.import<CardAPI>(`${baseRealm.url}card-api`);
+  for (const [path, value] of Object.entries(contents)) {
+    if (path.endsWith('.json') && api.isCard(value)) {
+      value.id = `${realmURL}${path.replace(/\.json$/, '')}`;
+      api.setCardAsSavedForTest(value);
+    }
+  }
+  for (const [path, value] of Object.entries(contents)) {
+    if (path.endsWith('.json') && api.isCard(value)) {
+      let doc = api.serializeCard(value);
+      contents[path] = doc;
+    }
+  }
+
+  let flatFiles: Record<string, string> = {};
+  for (const [path, value] of Object.entries(contents)) {
+    if (path.endsWith('.gts') && typeof value !== 'string') {
+      flatFiles[path] = '// this file is shimmed';
+    } else if (typeof value === 'string') {
+      flatFiles[path] = value;
+    } else {
+      flatFiles[path] = JSON.stringify(value);
+    }
+  }
+  let adapter = new TestRealmAdapter(flatFiles, new URL(realmURL));
+  let owner = (getContext() as TestContext).owner;
+  if (isAcceptanceTest) {
+    await visit('/acceptance-test-setup');
+  } else {
+    // We use a rendered component to facilitate our indexing (this emulates
+    // the work that the Fastboot renderer is doing), which means that the
+    // `setupRenderingTest(hooks)` from ember-qunit must be used in your tests.
+    await makeRenderer();
+  }
+
   let localIndexer = owner.lookup(
     'service:local-indexer',
   ) as unknown as MockLocalIndexer;
@@ -462,17 +498,6 @@ async function makeRealm(
       return realm.maybeHandle(req);
     });
   }
-  if (overridingHandlers && overridingHandlers.length > 0) {
-    loader.prependURLHandlers(overridingHandlers);
-  }
-
-  if (shimModules) {
-    for (const path of Object.keys(shimModules)) {
-      let module = shimModules[path];
-      let moduleURL = `${realmURL}${path}`;
-      await shimModule(moduleURL, module, loader);
-    }
-  }
 
   realm = new Realm(
     realmURL,
@@ -486,8 +511,13 @@ async function makeRealm(
     async () =>
       `<html><body>Intentionally empty index.html (these tests will not exercise this capability)</body></html>`,
   );
+  loader.prependURLHandlers([
+    (req) => sourceFetchRedirectHandle(req, adapter, realmURL!),
+    (req) => sourceFetchReturnUrlHandle(req, realm.maybeHandle.bind(realm)),
+  ]);
 
-  return realm;
+  await realm.ready;
+  return { realm, adapter };
 }
 
 export async function saveCard(instance: CardDef, id: string, loader: Loader) {
@@ -523,6 +553,10 @@ export function setupCardLogs(
     await api.flushLogs();
   });
 }
+type FilesForTestAdapter = Record<
+  string,
+  string | LooseSingleCardDocument | CardDocFiles | RealmInfo
+>;
 
 export class TestRealmAdapter implements RealmAdapter {
   #files: Dir = {};
@@ -531,10 +565,7 @@ export class TestRealmAdapter implements RealmAdapter {
   #subscriber: ((message: UpdateEventData) => void) | undefined;
 
   constructor(
-    flatFiles: Record<
-      string,
-      string | LooseSingleCardDocument | CardDocFiles | RealmInfo
-    >,
+    flatFiles: FilesForTestAdapter,
     realmURL = new URL(testRealmURL),
   ) {
     this.#paths = new RealmPaths(realmURL);

--- a/packages/host/tests/integration/card-prerender-test.gts
+++ b/packages/host/tests/integration/card-prerender-test.gts
@@ -13,17 +13,15 @@ import type LoaderService from '@cardstack/host/services/loader-service';
 import {
   testRealmURL,
   setupCardLogs,
-  TestRealmAdapter,
-  TestRealm,
   cleanWhiteSpace,
   trimCardContainer,
   setupLocalIndexing,
+  setupIntegrationTestRealm,
 } from '../helpers';
 
 let loader: Loader;
 
 module('Integration | card-prerender', function (hooks) {
-  let adapter: TestRealmAdapter;
   let realm: Realm;
 
   setupRenderingTest(hooks);
@@ -56,45 +54,43 @@ module('Integration | card-prerender', function (hooks) {
         </template>
       };
     }
-    adapter = new TestRealmAdapter({
-      'Pet/mango.json': {
-        data: {
-          type: 'card',
-          id: `${testRealmURL}Pet/mango`,
-          attributes: {
-            firstName: 'Mango',
-          },
-          meta: {
-            adoptsFrom: {
-              module: `${testRealmURL}pet`,
-              name: 'Pet',
-            },
-          },
-        },
-      },
-      'Pet/vangogh.json': {
-        data: {
-          type: 'card',
-          id: `${testRealmURL}Pet/vangogh`,
-          attributes: {
-            firstName: 'Van Gogh',
-          },
-          meta: {
-            adoptsFrom: {
-              module: `${testRealmURL}pet`,
-              name: 'Pet',
-            },
-          },
-        },
-      },
-    });
 
-    realm = await TestRealm.createWithAdapter(adapter, loader, this.owner, {
-      shimModules: {
+    ({ realm } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
         'pet.gts': { Pet },
+        'Pet/mango.json': {
+          data: {
+            type: 'card',
+            id: `${testRealmURL}Pet/mango`,
+            attributes: {
+              firstName: 'Mango',
+            },
+            meta: {
+              adoptsFrom: {
+                module: `${testRealmURL}pet`,
+                name: 'Pet',
+              },
+            },
+          },
+        },
+        'Pet/vangogh.json': {
+          data: {
+            type: 'card',
+            id: `${testRealmURL}Pet/vangogh`,
+            attributes: {
+              firstName: 'Van Gogh',
+            },
+            meta: {
+              adoptsFrom: {
+                module: `${testRealmURL}pet`,
+                name: 'Pet',
+              },
+            },
+          },
+        },
       },
-    });
-    await realm.ready;
+    }));
   });
 
   test("can generate the card's pre-rendered HTML", async function (assert) {

--- a/packages/host/tests/integration/components/card-catalog-filters-test.gts
+++ b/packages/host/tests/integration/components/card-catalog-filters-test.gts
@@ -15,8 +15,7 @@ import OperatorModeStateService from '@cardstack/host/services/operator-mode-sta
 import {
   testRealmURL,
   setupLocalIndexing,
-  TestRealmAdapter,
-  TestRealm,
+  setupIntegrationTestRealm,
 } from '../../helpers';
 import { renderComponent } from '../../helpers/render-component';
 
@@ -64,106 +63,104 @@ module('Integration | card-catalog filters', function (hooks) {
       @field blogPost = linksTo(BlogPost);
     }
 
-    let adapter = new TestRealmAdapter({
-      '.realm.json': `{ "name": "${realmName}", "iconURL": "https://example-icon.test" }`,
-      'index.json': {
-        data: {
-          type: 'card',
-          attributes: {},
-          meta: {
-            adoptsFrom: {
-              module: 'https://cardstack.com/base/cards-grid',
-              name: 'CardsGrid',
-            },
-          },
-        },
-      },
-      'CatalogEntry/publishing-packet.json': {
-        data: {
-          type: 'card',
-          attributes: {
-            title: 'Publishing Packet',
-            description: 'Catalog entry for PublishingPacket',
-            ref: {
-              module: `../publishing-packet`,
-              name: 'PublishingPacket',
-            },
-          },
-          meta: {
-            adoptsFrom: {
-              module: 'https://cardstack.com/base/catalog-entry',
-              name: 'CatalogEntry',
-            },
-          },
-        },
-      },
-      'CatalogEntry/author.json': {
-        data: {
-          type: 'card',
-          attributes: {
-            title: 'Author',
-            description: 'Catalog entry for Author',
-            ref: {
-              module: `${testRealmURL}author`,
-              name: 'Author',
-            },
-          },
-          meta: {
-            adoptsFrom: {
-              module: 'https://cardstack.com/base/catalog-entry',
-              name: 'CatalogEntry',
-            },
-          },
-        },
-      },
-      'CatalogEntry/blog-post.json': {
-        data: {
-          type: 'card',
-          attributes: {
-            title: 'BlogPost',
-            description: 'Catalog entry for BlogPost',
-            ref: {
-              module: `${testRealmURL}blog-post`,
-              name: 'BlogPost',
-            },
-          },
-          meta: {
-            adoptsFrom: {
-              module: 'https://cardstack.com/base/catalog-entry',
-              name: 'CatalogEntry',
-            },
-          },
-        },
-      },
-      'CatalogEntry/address.json': {
-        data: {
-          type: 'card',
-          attributes: {
-            title: 'Address',
-            description: 'Catalog entry for Address field',
-            ref: {
-              module: `${testRealmURL}address`,
-              name: 'Address',
-            },
-          },
-          meta: {
-            adoptsFrom: {
-              module: 'https://cardstack.com/base/catalog-entry',
-              name: 'CatalogEntry',
-            },
-          },
-        },
-      },
-    });
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner, {
-      shimModules: {
+    await setupIntegrationTestRealm({
+      loader,
+      contents: {
         'blog-post.gts': { BlogPost },
         'address.gts': { Address },
         'author.gts': { Author },
         'publishing-packet.gts': { PublishingPacket },
+        '.realm.json': `{ "name": "${realmName}", "iconURL": "https://example-icon.test" }`,
+        'index.json': {
+          data: {
+            type: 'card',
+            attributes: {},
+            meta: {
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/cards-grid',
+                name: 'CardsGrid',
+              },
+            },
+          },
+        },
+        'CatalogEntry/publishing-packet.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              title: 'Publishing Packet',
+              description: 'Catalog entry for PublishingPacket',
+              ref: {
+                module: `../publishing-packet`,
+                name: 'PublishingPacket',
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/catalog-entry',
+                name: 'CatalogEntry',
+              },
+            },
+          },
+        },
+        'CatalogEntry/author.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              title: 'Author',
+              description: 'Catalog entry for Author',
+              ref: {
+                module: `${testRealmURL}author`,
+                name: 'Author',
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/catalog-entry',
+                name: 'CatalogEntry',
+              },
+            },
+          },
+        },
+        'CatalogEntry/blog-post.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              title: 'BlogPost',
+              description: 'Catalog entry for BlogPost',
+              ref: {
+                module: `${testRealmURL}blog-post`,
+                name: 'BlogPost',
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/catalog-entry',
+                name: 'CatalogEntry',
+              },
+            },
+          },
+        },
+        'CatalogEntry/address.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              title: 'Address',
+              description: 'Catalog entry for Address field',
+              ref: {
+                module: `${testRealmURL}address`,
+                name: 'Address',
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/catalog-entry',
+                name: 'CatalogEntry',
+              },
+            },
+          },
+        },
       },
     });
-    await realm.ready;
 
     let operatorModeStateService = this.owner.lookup(
       'service:operator-mode-state-service',

--- a/packages/host/tests/integration/components/card-catalog-filters-test.gts
+++ b/packages/host/tests/integration/components/card-catalog-filters-test.gts
@@ -4,6 +4,8 @@ import GlimmerComponent from '@glimmer/component';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
+import { baseRealm } from '@cardstack/runtime-common';
+
 import CardPrerender from '@cardstack/host/components/card-prerender';
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
 
@@ -24,140 +26,143 @@ module('Integration | card-catalog filters', function (hooks) {
   setupRenderingTest(hooks);
   setupLocalIndexing(hooks);
 
-  let adapter = new TestRealmAdapter({
-    '.realm.json': `{ "name": "${realmName}", "iconURL": "https://example-icon.test" }`,
-    'index.json': {
-      data: {
-        type: 'card',
-        attributes: {},
-        meta: {
-          adoptsFrom: {
-            module: 'https://cardstack.com/base/cards-grid',
-            name: 'CardsGrid',
-          },
-        },
-      },
-    },
-    'blog-post.gts': `
-      import StringCard from 'https://cardstack.com/base/string';
-      import TextAreaCard from 'https://cardstack.com/base/text-area';
-      import { CardDef, field, contains, linksTo } from 'https://cardstack.com/base/card-api';
-      import { Author } from './author';
-      export class BlogPost extends CardDef {
-        @field title = contains(StringCard);
-        @field body = contains(TextAreaCard);
-        @field authorBio = linksTo(Author);
-      }
-    `,
-    'address.gts': `
-      import StringCard from 'https://cardstack.com/base/string';
-      import { FieldDef, field, contains } from 'https://cardstack.com/base/card-api';
-      export class Address extends FieldDef {
-        @field street = contains(StringCard);
-        @field city = contains(StringCard);
-        @field state = contains(StringCard);
-        @field zip = contains(StringCard);
-      }
-    `,
-    'author.gts': `
-      import StringCard from 'https://cardstack.com/base/string';
-      import { CardDef, field, contains } from 'https://cardstack.com/base/card-api';
-      export class Author extends CardDef {
-        @field firstName = contains(StringCard);
-        @field lastName = contains(StringCard);
-      }
-    `,
-    'publishing-packet.gts': `
-      import { CardDef, field, linksTo } from 'https://cardstack.com/base/card-api';
-      import { BlogPost } from './blog-post';
-      export class PublishingPacket extends CardDef {
-        @field blogPost = linksTo(BlogPost);
-      }
-    `,
-    'CatalogEntry/publishing-packet.json': {
-      data: {
-        type: 'card',
-        attributes: {
-          title: 'Publishing Packet',
-          description: 'Catalog entry for PublishingPacket',
-          ref: {
-            module: `../publishing-packet`,
-            name: 'PublishingPacket',
-          },
-        },
-        meta: {
-          adoptsFrom: {
-            module: 'https://cardstack.com/base/catalog-entry',
-            name: 'CatalogEntry',
-          },
-        },
-      },
-    },
-    'CatalogEntry/author.json': {
-      data: {
-        type: 'card',
-        attributes: {
-          title: 'Author',
-          description: 'Catalog entry for Author',
-          ref: {
-            module: `${testRealmURL}author`,
-            name: 'Author',
-          },
-        },
-        meta: {
-          adoptsFrom: {
-            module: 'https://cardstack.com/base/catalog-entry',
-            name: 'CatalogEntry',
-          },
-        },
-      },
-    },
-    'CatalogEntry/blog-post.json': {
-      data: {
-        type: 'card',
-        attributes: {
-          title: 'BlogPost',
-          description: 'Catalog entry for BlogPost',
-          ref: {
-            module: `${testRealmURL}blog-post`,
-            name: 'BlogPost',
-          },
-        },
-        meta: {
-          adoptsFrom: {
-            module: 'https://cardstack.com/base/catalog-entry',
-            name: 'CatalogEntry',
-          },
-        },
-      },
-    },
-    'CatalogEntry/address.json': {
-      data: {
-        type: 'card',
-        attributes: {
-          title: 'Address',
-          description: 'Catalog entry for Address field',
-          ref: {
-            module: `${testRealmURL}address`,
-            name: 'Address',
-          },
-        },
-        meta: {
-          adoptsFrom: {
-            module: 'https://cardstack.com/base/catalog-entry',
-            name: 'CatalogEntry',
-          },
-        },
-      },
-    },
-  });
-
   let noop = () => {};
 
   hooks.beforeEach(async function () {
     let loader = (this.owner.lookup('service:loader-service') as LoaderService)
       .loader;
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
+    let cardApi: typeof import('https://cardstack.com/base/card-api');
+    let string: typeof import('https://cardstack.com/base/string');
+    let textArea: typeof import('https://cardstack.com/base/text-area');
+    cardApi = await loader.import(`${baseRealm.url}card-api`);
+    string = await loader.import(`${baseRealm.url}string`);
+    textArea = await loader.import(`${baseRealm.url}text-area`);
+
+    let { field, contains, linksTo, CardDef, FieldDef } = cardApi;
+    let { default: StringField } = string;
+    let { default: TextAreaField } = textArea;
+
+    class Author extends CardDef {
+      @field firstName = contains(StringField);
+      @field lastName = contains(StringField);
+    }
+
+    class BlogPost extends CardDef {
+      @field title = contains(StringField);
+      @field body = contains(TextAreaField);
+      @field authorBio = linksTo(Author);
+    }
+
+    class Address extends FieldDef {
+      @field street = contains(StringField);
+      @field city = contains(StringField);
+      @field state = contains(StringField);
+      @field zip = contains(StringField);
+    }
+
+    class PublishingPacket extends CardDef {
+      @field blogPost = linksTo(BlogPost);
+    }
+
+    let adapter = new TestRealmAdapter({
+      '.realm.json': `{ "name": "${realmName}", "iconURL": "https://example-icon.test" }`,
+      'index.json': {
+        data: {
+          type: 'card',
+          attributes: {},
+          meta: {
+            adoptsFrom: {
+              module: 'https://cardstack.com/base/cards-grid',
+              name: 'CardsGrid',
+            },
+          },
+        },
+      },
+      'CatalogEntry/publishing-packet.json': {
+        data: {
+          type: 'card',
+          attributes: {
+            title: 'Publishing Packet',
+            description: 'Catalog entry for PublishingPacket',
+            ref: {
+              module: `../publishing-packet`,
+              name: 'PublishingPacket',
+            },
+          },
+          meta: {
+            adoptsFrom: {
+              module: 'https://cardstack.com/base/catalog-entry',
+              name: 'CatalogEntry',
+            },
+          },
+        },
+      },
+      'CatalogEntry/author.json': {
+        data: {
+          type: 'card',
+          attributes: {
+            title: 'Author',
+            description: 'Catalog entry for Author',
+            ref: {
+              module: `${testRealmURL}author`,
+              name: 'Author',
+            },
+          },
+          meta: {
+            adoptsFrom: {
+              module: 'https://cardstack.com/base/catalog-entry',
+              name: 'CatalogEntry',
+            },
+          },
+        },
+      },
+      'CatalogEntry/blog-post.json': {
+        data: {
+          type: 'card',
+          attributes: {
+            title: 'BlogPost',
+            description: 'Catalog entry for BlogPost',
+            ref: {
+              module: `${testRealmURL}blog-post`,
+              name: 'BlogPost',
+            },
+          },
+          meta: {
+            adoptsFrom: {
+              module: 'https://cardstack.com/base/catalog-entry',
+              name: 'CatalogEntry',
+            },
+          },
+        },
+      },
+      'CatalogEntry/address.json': {
+        data: {
+          type: 'card',
+          attributes: {
+            title: 'Address',
+            description: 'Catalog entry for Address field',
+            ref: {
+              module: `${testRealmURL}address`,
+              name: 'Address',
+            },
+          },
+          meta: {
+            adoptsFrom: {
+              module: 'https://cardstack.com/base/catalog-entry',
+              name: 'CatalogEntry',
+            },
+          },
+        },
+      },
+    });
+    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner, {
+      shimModules: {
+        'blog-post.gts': { BlogPost },
+        'address.gts': { Address },
+        'author.gts': { Author },
+        'publishing-packet.gts': { PublishingPacket },
+      },
+    });
     await realm.ready;
 
     let operatorModeStateService = this.owner.lookup(

--- a/packages/host/tests/integration/components/card-copy-test.gts
+++ b/packages/host/tests/integration/components/card-copy-test.gts
@@ -29,10 +29,9 @@ import {
   setupLocalIndexing,
   setupOnSave,
   setupServerSentEvents,
-  TestRealmAdapter,
-  TestRealm,
   type TestContextWithSave,
   type TestContextWithSSE,
+  setupIntegrationTestRealm,
 } from '../../helpers';
 import { renderComponent } from '../../helpers/render-component';
 
@@ -47,8 +46,6 @@ type TestContextForCopy = TestContextWithSave & TestContextWithSSE;
 
 module('Integration | card-copy', function (hooks) {
   let onFetch: ((req: Request, body: string) => void) | undefined;
-  let adapter1: TestRealmAdapter;
-  let adapter2: TestRealmAdapter;
   let realm1: Realm;
   let realm2: Realm;
   let noop = () => {};
@@ -155,123 +152,118 @@ module('Integration | card-copy', function (hooks) {
       };
     }
 
-    adapter1 = new TestRealmAdapter({
-      'index.json': {
-        data: {
-          type: 'card',
-          meta: {
-            adoptsFrom: {
-              module: 'https://cardstack.com/base/cards-grid',
-              name: 'CardsGrid',
-            },
-          },
-        },
-      },
-      'Person/hassan.json': {
-        data: {
-          type: 'card',
-          attributes: {
-            firstName: 'Hassan',
-          },
-          relationships: {
-            pet: {
-              links: {
-                self: '../Pet/mango',
+    ({ realm: realm1 } = await setupIntegrationTestRealm({
+      loader,
+      onFetch: wrappedOnFetch(),
+      contents: {
+        'person.gts': { Person },
+        'pet.gts': { Pet },
+        'index.json': {
+          data: {
+            type: 'card',
+            meta: {
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/cards-grid',
+                name: 'CardsGrid',
               },
             },
           },
-          meta: {
-            adoptsFrom: {
-              module: `../person`,
-              name: 'Person',
+        },
+        'Person/hassan.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              firstName: 'Hassan',
+            },
+            relationships: {
+              pet: {
+                links: {
+                  self: '../Pet/mango',
+                },
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: `../person`,
+                name: 'Person',
+              },
             },
           },
         },
-      },
-      'Pet/mango.json': {
-        data: {
-          type: 'card',
-          attributes: {
-            firstName: 'Mango',
-          },
-          meta: {
-            adoptsFrom: {
-              module: '../pet',
-              name: 'Pet',
+        'Pet/mango.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              firstName: 'Mango',
+            },
+            meta: {
+              adoptsFrom: {
+                module: '../pet',
+                name: 'Pet',
+              },
             },
           },
         },
-      },
-      'Pet/vangogh.json': {
-        data: {
-          type: 'card',
-          attributes: {
-            firstName: 'Van Gogh',
-          },
-          meta: {
-            adoptsFrom: {
-              module: '../pet',
-              name: 'Pet',
+        'Pet/vangogh.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              firstName: 'Van Gogh',
+            },
+            meta: {
+              adoptsFrom: {
+                module: '../pet',
+                name: 'Pet',
+              },
             },
           },
         },
+        '.realm.json': {
+          name: 'Test Workspace 1',
+          backgroundURL:
+            'https://i.postimg.cc/VNvHH93M/pawel-czerwinski-Ly-ZLa-A5jti-Y-unsplash.jpg',
+          iconURL: 'https://i.postimg.cc/L8yXRvws/icon.png',
+        },
       },
-      '.realm.json': {
-        name: 'Test Workspace 1',
-        backgroundURL:
-          'https://i.postimg.cc/VNvHH93M/pawel-czerwinski-Ly-ZLa-A5jti-Y-unsplash.jpg',
-        iconURL: 'https://i.postimg.cc/L8yXRvws/icon.png',
-      },
-    });
+    }));
 
-    adapter2 = new TestRealmAdapter({
-      'index.json': {
-        data: {
-          type: 'card',
-          meta: {
-            adoptsFrom: {
-              module: 'https://cardstack.com/base/cards-grid',
-              name: 'CardsGrid',
-            },
-          },
-        },
-      },
-      'Pet/paper.json': {
-        data: {
-          type: 'card',
-          attributes: {
-            firstName: 'Paper',
-          },
-          meta: {
-            adoptsFrom: {
-              module: `${testRealmURL}pet`,
-              name: 'Pet',
-            },
-          },
-        },
-      },
-      '.realm.json': {
-        name: 'Test Workspace 2',
-        backgroundURL:
-          'https://i.postimg.cc/tgRHRV8C/pawel-czerwinski-h-Nrd99q5pe-I-unsplash.jpg',
-        iconURL: 'https://i.postimg.cc/d0B9qMvy/icon.png',
-      },
-    });
-
-    realm1 = await TestRealm.createWithAdapter(adapter1, loader, this.owner, {
-      realmURL: testRealmURL,
-      onFetch: wrappedOnFetch(),
-      shimModules: {
-        'person.gts': { Person },
-        'pet.gts': { Pet },
-      },
-    });
-    await realm1.ready;
-
-    realm2 = await TestRealm.createWithAdapter(adapter2, loader, this.owner, {
+    ({ realm: realm2 } = await setupIntegrationTestRealm({
+      loader,
       realmURL: testRealm2URL,
-    });
-    await realm2.ready;
+      contents: {
+        'index.json': {
+          data: {
+            type: 'card',
+            meta: {
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/cards-grid',
+                name: 'CardsGrid',
+              },
+            },
+          },
+        },
+        'Pet/paper.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              firstName: 'Paper',
+            },
+            meta: {
+              adoptsFrom: {
+                module: `${testRealmURL}pet`,
+                name: 'Pet',
+              },
+            },
+          },
+        },
+        '.realm.json': {
+          name: 'Test Workspace 2',
+          backgroundURL:
+            'https://i.postimg.cc/tgRHRV8C/pawel-czerwinski-h-Nrd99q5pe-I-unsplash.jpg',
+          iconURL: 'https://i.postimg.cc/d0B9qMvy/icon.png',
+        },
+      },
+    }));
 
     // write in the new record last because it's link didn't exist until realm2 was created
     await realm1.write(
@@ -653,7 +645,6 @@ module('Integration | card-copy', function (hooks) {
     await this.expectEvents({
       assert,
       realm: realm2,
-      adapter: adapter2,
       expectedNumberOfEvents: 1,
       onEvents: ([event]) => {
         if (event.type === 'index') {
@@ -750,7 +741,6 @@ module('Integration | card-copy', function (hooks) {
     await this.expectEvents({
       assert,
       realm: realm2,
-      adapter: adapter2,
       expectedNumberOfEvents: 2,
       onEvents: (events) => {
         assert.deepEqual(
@@ -874,7 +864,6 @@ module('Integration | card-copy', function (hooks) {
     await this.expectEvents({
       assert,
       realm: realm2,
-      adapter: adapter2,
       expectedNumberOfEvents: 1,
       onEvents: ([event]) => {
         if (event.type === 'index') {
@@ -992,7 +981,6 @@ module('Integration | card-copy', function (hooks) {
     await this.expectEvents({
       assert,
       realm: realm2,
-      adapter: adapter2,
       expectedNumberOfEvents: 1,
       onEvents: ([event]) => {
         if (event.type === 'index') {

--- a/packages/host/tests/integration/components/card-delete-test.gts
+++ b/packages/host/tests/integration/components/card-delete-test.gts
@@ -26,8 +26,8 @@ import {
   setupOnSave,
   setupServerSentEvents,
   TestRealmAdapter,
-  TestRealm,
   type TestContextWithSSE,
+  setupIntegrationTestRealm,
 } from '../../helpers';
 import { renderComponent } from '../../helpers/render-component';
 
@@ -130,61 +130,57 @@ module('Integration | card-delete', function (hooks) {
         </template>
       };
     }
-    adapter = new TestRealmAdapter({
-      'index.json': {
-        data: {
-          type: 'card',
-          meta: {
-            adoptsFrom: {
-              module: 'https://cardstack.com/base/cards-grid',
-              name: 'CardsGrid',
-            },
-          },
-        },
-      },
-      'Pet/mango.json': {
-        data: {
-          type: 'card',
-          attributes: {
-            firstName: 'Mango',
-          },
-          meta: {
-            adoptsFrom: {
-              module: '../pet',
-              name: 'Pet',
-            },
-          },
-        },
-      },
-      'Pet/vangogh.json': {
-        data: {
-          type: 'card',
-          attributes: {
-            firstName: 'Van Gogh',
-          },
-          meta: {
-            adoptsFrom: {
-              module: '../pet',
-              name: 'Pet',
-            },
-          },
-        },
-      },
-      '.realm.json': {
-        name: 'Test Workspace 1',
-        backgroundURL:
-          'https://i.postimg.cc/VNvHH93M/pawel-czerwinski-Ly-ZLa-A5jti-Y-unsplash.jpg',
-        iconURL: 'https://i.postimg.cc/L8yXRvws/icon.png',
-      },
-    });
-
-    realm = await TestRealm.createWithAdapter(adapter, loader, this.owner, {
-      realmURL: testRealmURL,
-      shimModules: {
+    ({ realm, adapter } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
         'pet.gts': { Pet },
+        'index.json': {
+          data: {
+            type: 'card',
+            meta: {
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/cards-grid',
+                name: 'CardsGrid',
+              },
+            },
+          },
+        },
+        'Pet/mango.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              firstName: 'Mango',
+            },
+            meta: {
+              adoptsFrom: {
+                module: '../pet',
+                name: 'Pet',
+              },
+            },
+          },
+        },
+        'Pet/vangogh.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              firstName: 'Van Gogh',
+            },
+            meta: {
+              adoptsFrom: {
+                module: '../pet',
+                name: 'Pet',
+              },
+            },
+          },
+        },
+        '.realm.json': {
+          name: 'Test Workspace 1',
+          backgroundURL:
+            'https://i.postimg.cc/VNvHH93M/pawel-czerwinski-Ly-ZLa-A5jti-Y-unsplash.jpg',
+          iconURL: 'https://i.postimg.cc/L8yXRvws/icon.png',
+        },
       },
-    });
-    await realm.ready;
+    }));
   });
 
   test<TestContextWithSSE>('can delete a card from the index card stack item', async function (assert) {
@@ -228,7 +224,6 @@ module('Integration | card-delete', function (hooks) {
     await this.expectEvents({
       assert,
       realm,
-      adapter,
       expectedEvents,
       callback: async () => {
         await click('[data-test-confirm-delete-button]');
@@ -306,7 +301,6 @@ module('Integration | card-delete', function (hooks) {
     await this.expectEvents({
       assert,
       realm,
-      adapter,
       expectedEvents,
       callback: async () => {
         await waitFor(`[data-test-operator-mode-stack="0"] [data-test-pet]`);
@@ -369,7 +363,6 @@ module('Integration | card-delete', function (hooks) {
     await this.expectEvents({
       assert,
       realm,
-      adapter,
       expectedEvents,
       callback: async () => {
         await waitFor(`[data-test-operator-mode-stack="0"] [data-test-pet]`);
@@ -435,7 +428,6 @@ module('Integration | card-delete', function (hooks) {
     await this.expectEvents({
       assert,
       realm,
-      adapter,
       expectedEvents,
       callback: async () => {
         await waitFor(`[data-test-operator-mode-stack="0"] [data-test-pet]`);
@@ -509,7 +501,6 @@ module('Integration | card-delete', function (hooks) {
     await this.expectEvents({
       assert,
       realm,
-      adapter,
       expectedEvents,
       callback: async () => {
         await waitFor(
@@ -573,7 +564,6 @@ module('Integration | card-delete', function (hooks) {
     await this.expectEvents({
       assert,
       realm,
-      adapter,
       expectedEvents,
       callback: async () => {
         await waitFor(
@@ -650,7 +640,6 @@ module('Integration | card-delete', function (hooks) {
     await this.expectEvents({
       assert,
       realm,
-      adapter,
       expectedEvents,
       callback: async () => {
         await waitFor(
@@ -714,7 +703,6 @@ module('Integration | card-delete', function (hooks) {
     await this.expectEvents({
       assert,
       realm,
-      adapter,
       expectedEvents,
       callback: async () => {
         await waitFor(

--- a/packages/host/tests/integration/components/card-editor-test.gts
+++ b/packages/host/tests/integration/components/card-editor-test.gts
@@ -27,9 +27,8 @@ import {
   shimModule,
   setupCardLogs,
   setupLocalIndexing,
-  TestRealmAdapter,
-  TestRealm,
   saveCard,
+  setupIntegrationTestRealm,
 } from '../../helpers';
 import { renderComponent } from '../../helpers/render-component';
 
@@ -39,7 +38,6 @@ let string: typeof import('https://cardstack.com/base/string');
 let loader: Loader;
 
 module('Integration | card-editor', function (hooks) {
-  let adapter: TestRealmAdapter;
   let realm: Realm;
   setupRenderingTest(hooks);
 
@@ -118,106 +116,105 @@ module('Integration | card-editor', function (hooks) {
         </template>
       };
     }
-    adapter = new TestRealmAdapter({
-      'Pet/mango.json': {
-        data: {
-          type: 'card',
-          id: `${testRealmURL}Pet/mango`,
-          attributes: {
-            name: 'Mango',
-          },
-          meta: {
-            adoptsFrom: {
-              module: `${testRealmURL}pet`,
-              name: 'Pet',
-            },
-          },
-        },
-      },
-      'Pet/vangogh.json': {
-        data: {
-          type: 'card',
-          id: `${testRealmURL}Pet/vangogh`,
-          attributes: {
-            name: 'Van Gogh',
-          },
-          meta: {
-            adoptsFrom: {
-              module: `${testRealmURL}pet`,
-              name: 'Pet',
-            },
-          },
-        },
-      },
-      'Pet/ringo.json': {
-        data: {
-          type: 'card',
-          id: `${testRealmURL}Pet/ringo`,
-          attributes: {
-            name: 'Ringo',
-            favoriteToy: 'sneaky snake',
-          },
-          meta: {
-            adoptsFrom: {
-              module: `${testRealmURL}fancy-pet`,
-              name: 'FancyPet',
-            },
-          },
-        },
-      },
-      'Person/hassan.json': {
-        data: {
-          type: 'card',
-          id: `${testRealmURL}Person/hassan`,
-          attributes: {
-            firstName: 'Hassan',
-          },
-          relationships: {
-            pet: {
-              links: {
-                self: `${testRealmURL}Pet/mango`,
-              },
-            },
-          },
-          meta: {
-            adoptsFrom: {
-              module: `${testRealmURL}person`,
-              name: 'Person',
-            },
-          },
-        },
-      },
-      'Person/mariko.json': {
-        data: {
-          type: 'card',
-          id: `${testRealmURL}Person/mariko`,
-          attributes: {
-            firstName: 'Mariko',
-          },
-          relationships: {
-            pet: {
-              links: {
-                self: null,
-              },
-            },
-          },
-          meta: {
-            adoptsFrom: {
-              module: `${testRealmURL}person`,
-              name: 'Person',
-            },
-          },
-        },
-      },
-    });
-    realm = await TestRealm.createWithAdapter(adapter, loader, this.owner, {
-      shimModules: {
+
+    ({ realm } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
         'pet.gts': { Pet },
         'fancy-pet.gts': { FancyPet },
         'person.gts': { Person },
+        'Pet/mango.json': {
+          data: {
+            type: 'card',
+            id: `${testRealmURL}Pet/mango`,
+            attributes: {
+              name: 'Mango',
+            },
+            meta: {
+              adoptsFrom: {
+                module: `${testRealmURL}pet`,
+                name: 'Pet',
+              },
+            },
+          },
+        },
+        'Pet/vangogh.json': {
+          data: {
+            type: 'card',
+            id: `${testRealmURL}Pet/vangogh`,
+            attributes: {
+              name: 'Van Gogh',
+            },
+            meta: {
+              adoptsFrom: {
+                module: `${testRealmURL}pet`,
+                name: 'Pet',
+              },
+            },
+          },
+        },
+        'Pet/ringo.json': {
+          data: {
+            type: 'card',
+            id: `${testRealmURL}Pet/ringo`,
+            attributes: {
+              name: 'Ringo',
+              favoriteToy: 'sneaky snake',
+            },
+            meta: {
+              adoptsFrom: {
+                module: `${testRealmURL}fancy-pet`,
+                name: 'FancyPet',
+              },
+            },
+          },
+        },
+        'Person/hassan.json': {
+          data: {
+            type: 'card',
+            id: `${testRealmURL}Person/hassan`,
+            attributes: {
+              firstName: 'Hassan',
+            },
+            relationships: {
+              pet: {
+                links: {
+                  self: `${testRealmURL}Pet/mango`,
+                },
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: `${testRealmURL}person`,
+                name: 'Person',
+              },
+            },
+          },
+        },
+        'Person/mariko.json': {
+          data: {
+            type: 'card',
+            id: `${testRealmURL}Person/mariko`,
+            attributes: {
+              firstName: 'Mariko',
+            },
+            relationships: {
+              pet: {
+                links: {
+                  self: null,
+                },
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: `${testRealmURL}person`,
+                name: 'Person',
+              },
+            },
+          },
+        },
       },
-    });
-    await realm.ready;
+    }));
   });
 
   test('renders card in edit (default) format', async function (assert) {

--- a/packages/host/tests/integration/components/text-input-filter-test.gts
+++ b/packages/host/tests/integration/components/text-input-filter-test.gts
@@ -29,9 +29,8 @@ import {
   testRealmURL,
   setupCardLogs,
   setupLocalIndexing,
-  TestRealmAdapter,
-  TestRealm,
   saveCard,
+  setupIntegrationTestRealm,
 } from '../../helpers';
 import { renderComponent } from '../../helpers/render-component';
 
@@ -40,7 +39,6 @@ let cardApi: typeof import('https://cardstack.com/base/card-api');
 let loader: Loader;
 
 module('Integration | text-input-filter', function (hooks) {
-  let adapter: TestRealmAdapter;
   let realm: Realm;
   setupRenderingTest(hooks);
   setupLocalIndexing(hooks);
@@ -86,31 +84,28 @@ module('Integration | text-input-filter', function (hooks) {
       @field someBigInt = contains(BigIntegerField);
       @field anotherBigInt = contains(BigIntegerField);
     }
-
-    adapter = new TestRealmAdapter({
-      'Sample/1.json': {
-        data: {
-          type: 'card',
-          id: `${testRealmURL}Sample/1`,
-          attributes: {
-            someBigInt: null,
-            anotherBigInt: '123',
-          },
-          meta: {
-            adoptsFrom: {
-              module: `${testRealmURL}sample`,
-              name: 'Sample',
+    ({ realm } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'sample.gts': { Sample },
+        'Sample/1.json': {
+          data: {
+            type: 'card',
+            id: `${testRealmURL}Sample/1`,
+            attributes: {
+              someBigInt: null,
+              anotherBigInt: '123',
+            },
+            meta: {
+              adoptsFrom: {
+                module: `${testRealmURL}sample`,
+                name: 'Sample',
+              },
             },
           },
         },
       },
-    });
-    realm = await TestRealm.createWithAdapter(adapter, loader, this.owner, {
-      shimModules: {
-        'sample.gts': { Sample },
-      },
-    });
-    await realm.ready;
+    }));
   });
 
   setupCardLogs(

--- a/packages/host/tests/integration/components/text-input-filter-test.gts
+++ b/packages/host/tests/integration/components/text-input-filter-test.gts
@@ -74,18 +74,20 @@ module('Integration | text-input-filter', function (hooks) {
       new URL('http://localhost:4201/base/'),
     );
     cardApi = await loader.import(`${baseRealm.url}card-api`);
+    let bigInteger: typeof import('https://cardstack.com/base/big-integer');
+    cardApi = await loader.import(`${baseRealm.url}card-api`);
+    bigInteger = await loader.import(`${baseRealm.url}big-integer`);
+
+    let { field, contains, CardDef } = cardApi;
+    let { default: BigIntegerField } = bigInteger;
+
+    class Sample extends CardDef {
+      static displayName = 'Sample';
+      @field someBigInt = contains(BigIntegerField);
+      @field anotherBigInt = contains(BigIntegerField);
+    }
 
     adapter = new TestRealmAdapter({
-      'sample.gts': `
-        import { contains, field, CardDef } from 'https://cardstack.com/base/card-api';
-        import BigIntegerCard from 'https://cardstack.com/base/big-integer';
-
-        export class Sample extends CardDef {
-        static displayName = 'Sample';
-        @field someBigInt = contains(BigIntegerCard);
-        @field anotherBigInt = contains(BigIntegerCard);
-        }
-      `,
       'Sample/1.json': {
         data: {
           type: 'card',
@@ -103,7 +105,11 @@ module('Integration | text-input-filter', function (hooks) {
         },
       },
     });
-    realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
+    realm = await TestRealm.createWithAdapter(adapter, loader, this.owner, {
+      shimModules: {
+        'sample.gts': { Sample },
+      },
+    });
     await realm.ready;
   });
 

--- a/packages/host/tests/integration/realm-test.ts
+++ b/packages/host/tests/integration/realm-test.ts
@@ -18,15 +18,17 @@ import { Loader } from '@cardstack/runtime-common/loader';
 
 import type LoaderService from '@cardstack/host/services/loader-service';
 
+import type * as CardAPI from 'https://cardstack.com/base/card-api';
+import type * as StringFieldMod from 'https://cardstack.com/base/string';
+
 import {
-  TestRealm,
-  TestRealmAdapter,
   testRealmURL,
   testRealmInfo,
   setupCardLogs,
   setupLocalIndexing,
   setupServerSentEvents,
   type TestContextWithSSE,
+  setupIntegrationTestRealm,
 } from '../helpers';
 
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
@@ -48,20 +50,21 @@ module('Integration | realm', function (hooks) {
   );
 
   test('realm can serve GET card requests', async function (assert) {
-    let adapter = new TestRealmAdapter({
-      'dir/empty.json': {
-        data: {
-          meta: {
-            adoptsFrom: {
-              module: 'https://cardstack.com/base/card-api',
-              name: 'CardDef',
+    let { realm, adapter } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'dir/empty.json': {
+          data: {
+            meta: {
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/card-api',
+                name: 'CardDef',
+              },
             },
           },
         },
       },
     });
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
 
     let response = await realm.handle(
       new Request(`${testRealmURL}dir/empty`, {
@@ -102,48 +105,49 @@ module('Integration | realm', function (hooks) {
   });
 
   test('realm can serve GET card requests with linksTo relationships', async function (assert) {
-    let adapter = new TestRealmAdapter({
-      'dir/owner.json': {
-        data: {
-          id: `${testRealmURL}dir/owner`,
-          attributes: {
-            firstName: 'Hassan',
-            lastName: 'Abdel-Rahman',
-          },
-          meta: {
-            adoptsFrom: {
-              module: 'http://localhost:4202/test/person',
-              name: 'Person',
+    let { realm, adapter } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'dir/owner.json': {
+          data: {
+            id: `${testRealmURL}dir/owner`,
+            attributes: {
+              firstName: 'Hassan',
+              lastName: 'Abdel-Rahman',
             },
-          },
-        },
-      },
-      'dir/mango.json': {
-        data: {
-          id: `${testRealmURL}dir/mango`,
-          attributes: {
-            description: null,
-            thumbnailURL: null,
-            firstName: 'Mango',
-          },
-          relationships: {
-            owner: {
-              links: {
-                self: `${testRealmURL}dir/owner`,
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/person',
+                name: 'Person',
               },
             },
           },
-          meta: {
-            adoptsFrom: {
-              module: 'http://localhost:4202/test/pet',
-              name: 'Pet',
+        },
+        'dir/mango.json': {
+          data: {
+            id: `${testRealmURL}dir/mango`,
+            attributes: {
+              description: null,
+              thumbnailURL: null,
+              firstName: 'Mango',
+            },
+            relationships: {
+              owner: {
+                links: {
+                  self: `${testRealmURL}dir/owner`,
+                },
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/pet',
+                name: 'Pet',
+              },
             },
           },
         },
       },
     });
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
 
     let response = await realm.handle(
       new Request(`${testRealmURL}dir/mango`, {
@@ -222,33 +226,34 @@ module('Integration | realm', function (hooks) {
   });
 
   test('realm can serve GET card requests with linksTo relationships to other realms', async function (assert) {
-    let adapter = new TestRealmAdapter({
-      'dir/mango.json': {
-        data: {
-          id: `${testRealmURL}dir/mango`,
-          attributes: {
-            description: null,
-            thumbnailURL: null,
-            firstName: 'Mango',
-          },
-          relationships: {
-            owner: {
-              links: {
-                self: `http://localhost:4202/test/hassan`,
+    let { realm, adapter } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'dir/mango.json': {
+          data: {
+            id: `${testRealmURL}dir/mango`,
+            attributes: {
+              description: null,
+              thumbnailURL: null,
+              firstName: 'Mango',
+            },
+            relationships: {
+              owner: {
+                links: {
+                  self: `http://localhost:4202/test/hassan`,
+                },
               },
             },
-          },
-          meta: {
-            adoptsFrom: {
-              module: 'http://localhost:4202/test/pet',
-              name: 'Pet',
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/pet',
+                name: 'Pet',
+              },
             },
           },
         },
       },
     });
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
 
     let response = await realm.handle(
       new Request(`${testRealmURL}dir/mango`, {
@@ -331,9 +336,9 @@ module('Integration | realm', function (hooks) {
   });
 
   test("realm can route requests correctly when mounted in the origin's subdir", async function (assert) {
-    let realm = await TestRealm.create(
+    let { realm } = await setupIntegrationTestRealm({
       loader,
-      {
+      contents: {
         'dir/empty.json': {
           data: {
             meta: {
@@ -345,12 +350,8 @@ module('Integration | realm', function (hooks) {
           },
         },
       },
-      this.owner,
-      {
-        realmURL: `${testRealmURL}root/`,
-      },
-    );
-    await realm.ready;
+      realmURL: `${testRealmURL}root/`,
+    });
     {
       let response = await realm.handle(
         new Request(`${testRealmURL}root/dir/empty`, {
@@ -390,9 +391,10 @@ module('Integration | realm', function (hooks) {
   });
 
   test('realm can serve create card requests', async function (assert) {
-    let adapter = new TestRealmAdapter({});
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
+    let { realm, adapter } = await setupIntegrationTestRealm({
+      loader,
+      contents: {},
+    });
     let response = await realm.handle(
       new Request(testRealmURL, {
         method: 'POST',
@@ -452,25 +454,26 @@ module('Integration | realm', function (hooks) {
   });
 
   test('realm can serve POST requests that include linksTo fields', async function (assert) {
-    let adapter = new TestRealmAdapter({
-      'dir/owner.json': {
-        data: {
-          id: `${testRealmURL}dir/owner`,
-          attributes: {
-            firstName: 'Hassan',
-            lastName: 'Abdel-Rahman',
-          },
-          meta: {
-            adoptsFrom: {
-              module: 'http://localhost:4202/test/person',
-              name: 'Person',
+    let { realm, adapter } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'dir/owner.json': {
+          data: {
+            id: `${testRealmURL}dir/owner`,
+            attributes: {
+              firstName: 'Hassan',
+              lastName: 'Abdel-Rahman',
+            },
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/person',
+                name: 'Person',
+              },
             },
           },
         },
       },
     });
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
     let response = await realm.handle(
       new Request(testRealmURL, {
         method: 'POST',
@@ -606,24 +609,25 @@ module('Integration | realm', function (hooks) {
   });
 
   test<TestContextWithSSE>('realm can serve patch card requests', async function (assert) {
-    let adapter = new TestRealmAdapter({
-      'dir/card.json': {
-        data: {
-          attributes: {
-            firstName: 'Mango',
-            lastName: 'Abdel-Rahman',
-          },
-          meta: {
-            adoptsFrom: {
-              module: 'http://localhost:4202/test/person',
-              name: 'Person',
+    let { realm, adapter } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'dir/card.json': {
+          data: {
+            attributes: {
+              firstName: 'Mango',
+              lastName: 'Abdel-Rahman',
+            },
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/person',
+                name: 'Person',
+              },
             },
           },
         },
       },
     });
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
     let expectedEvents = [
       {
         type: 'index',
@@ -636,7 +640,6 @@ module('Integration | realm', function (hooks) {
     let response = await this.expectEvents({
       assert,
       realm,
-      adapter,
       expectedEvents,
       callback: async () => {
         let response = realm.handle(
@@ -756,29 +759,30 @@ module('Integration | realm', function (hooks) {
   });
 
   test('realm can remove item from containsMany field via PATCH request', async function (assert) {
-    let adapter = new TestRealmAdapter({
-      'ski-trip.json': {
-        data: {
-          attributes: {
-            title: 'Gore Mountain Ski Trip',
-            venue: 'Gore Mountain',
-            startTime: '2023-02-18T10:00:00.000Z',
-            endTime: '2023-02-19T02:00:00.000Z',
-            hosts: [{ firstName: 'Hassan' }, { firstName: 'Mango' }],
-            sponsors: ['Burton', 'Spy Optics'],
-            posts: [],
-          },
-          meta: {
-            adoptsFrom: {
-              module: 'http://localhost:4202/test/booking',
-              name: 'Booking',
+    let { realm, adapter } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'ski-trip.json': {
+          data: {
+            attributes: {
+              title: 'Gore Mountain Ski Trip',
+              venue: 'Gore Mountain',
+              startTime: '2023-02-18T10:00:00.000Z',
+              endTime: '2023-02-19T02:00:00.000Z',
+              hosts: [{ firstName: 'Hassan' }, { firstName: 'Mango' }],
+              sponsors: ['Burton', 'Spy Optics'],
+              posts: [],
+            },
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/booking',
+                name: 'Booking',
+              },
             },
           },
         },
       },
     });
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
     let response = await realm.handle(
       new Request(`${testRealmURL}ski-trip`, {
         method: 'PATCH',
@@ -890,64 +894,65 @@ module('Integration | realm', function (hooks) {
   });
 
   test('realm can remove item from linksToMany field via PATCH request', async function (assert) {
-    let adapter = new TestRealmAdapter({
-      'dir/van-gogh.json': {
-        data: {
-          id: `${testRealmURL}dir/van-gogh`,
-          attributes: { firstName: 'Van Gogh' },
-          relationships: { owner: { links: { self: null } } },
-          meta: {
-            adoptsFrom: {
-              module: `http://localhost:4202/test/pet`,
-              name: 'Pet',
+    let { realm, adapter } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'dir/van-gogh.json': {
+          data: {
+            id: `${testRealmURL}dir/van-gogh`,
+            attributes: { firstName: 'Van Gogh' },
+            relationships: { owner: { links: { self: null } } },
+            meta: {
+              adoptsFrom: {
+                module: `http://localhost:4202/test/pet`,
+                name: 'Pet',
+              },
             },
           },
         },
-      },
-      'dir/mango.json': {
-        data: {
-          id: `${testRealmURL}dir/mango`,
-          attributes: { firstName: 'Mango' },
-          relationships: { owner: { links: { self: null } } },
-          meta: {
-            adoptsFrom: {
-              module: `http://localhost:4202/test/pet`,
-              name: 'Pet',
+        'dir/mango.json': {
+          data: {
+            id: `${testRealmURL}dir/mango`,
+            attributes: { firstName: 'Mango' },
+            relationships: { owner: { links: { self: null } } },
+            meta: {
+              adoptsFrom: {
+                module: `http://localhost:4202/test/pet`,
+                name: 'Pet',
+              },
             },
           },
         },
-      },
-      'dir/friend.json': {
-        data: {
-          id: `${testRealmURL}dir/friend`,
-          attributes: { firstName: 'Hassan', lastName: 'Abdel-Rahman' },
-          meta: {
-            adoptsFrom: {
-              module: 'http://localhost:4202/test/person',
-              name: 'Person',
+        'dir/friend.json': {
+          data: {
+            id: `${testRealmURL}dir/friend`,
+            attributes: { firstName: 'Hassan', lastName: 'Abdel-Rahman' },
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/person',
+                name: 'Person',
+              },
             },
           },
         },
-      },
-      'jackie.json': {
-        data: {
-          id: `${testRealmURL}jackie`,
-          attributes: { firstName: 'Jackie' },
-          relationships: {
-            'pets.0': { links: { self: `${testRealmURL}dir/van-gogh` } },
-            friend: { links: { self: `${testRealmURL}dir/friend` } },
-          },
-          meta: {
-            adoptsFrom: {
-              module: `http://localhost:4202/test/pet-person`,
-              name: 'PetPerson',
+        'jackie.json': {
+          data: {
+            id: `${testRealmURL}jackie`,
+            attributes: { firstName: 'Jackie' },
+            relationships: {
+              'pets.0': { links: { self: `${testRealmURL}dir/van-gogh` } },
+              friend: { links: { self: `${testRealmURL}dir/friend` } },
+            },
+            meta: {
+              adoptsFrom: {
+                module: `http://localhost:4202/test/pet-person`,
+                name: 'PetPerson',
+              },
             },
           },
         },
       },
     });
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
     let response = await realm.handle(
       new Request(`${testRealmURL}jackie`, {
         method: 'PATCH',
@@ -1090,64 +1095,65 @@ module('Integration | realm', function (hooks) {
   });
 
   test('realm can add an item to linksToMany relationships via PATCH request', async function (assert) {
-    let adapter = new TestRealmAdapter({
-      'dir/van-gogh.json': {
-        data: {
-          id: `${testRealmURL}dir/van-gogh`,
-          attributes: { firstName: 'Van Gogh' },
-          relationships: { owner: { links: { self: null } } },
-          meta: {
-            adoptsFrom: {
-              module: `http://localhost:4202/test/pet`,
-              name: 'Pet',
+    let { realm, adapter } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'dir/van-gogh.json': {
+          data: {
+            id: `${testRealmURL}dir/van-gogh`,
+            attributes: { firstName: 'Van Gogh' },
+            relationships: { owner: { links: { self: null } } },
+            meta: {
+              adoptsFrom: {
+                module: `http://localhost:4202/test/pet`,
+                name: 'Pet',
+              },
             },
           },
         },
-      },
-      'dir/mango.json': {
-        data: {
-          id: `${testRealmURL}dir/mango`,
-          attributes: { firstName: 'Mango' },
-          relationships: { owner: { links: { self: null } } },
-          meta: {
-            adoptsFrom: {
-              module: `http://localhost:4202/test/pet`,
-              name: 'Pet',
+        'dir/mango.json': {
+          data: {
+            id: `${testRealmURL}dir/mango`,
+            attributes: { firstName: 'Mango' },
+            relationships: { owner: { links: { self: null } } },
+            meta: {
+              adoptsFrom: {
+                module: `http://localhost:4202/test/pet`,
+                name: 'Pet',
+              },
             },
           },
         },
-      },
-      'dir/friend.json': {
-        data: {
-          id: `${testRealmURL}dir/friend`,
-          attributes: { firstName: 'Hassan', lastName: 'Abdel-Rahman' },
-          meta: {
-            adoptsFrom: {
-              module: 'http://localhost:4202/test/person',
-              name: 'Person',
+        'dir/friend.json': {
+          data: {
+            id: `${testRealmURL}dir/friend`,
+            attributes: { firstName: 'Hassan', lastName: 'Abdel-Rahman' },
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/person',
+                name: 'Person',
+              },
             },
           },
         },
-      },
-      'jackie.json': {
-        data: {
-          id: `${testRealmURL}jackie`,
-          attributes: { firstName: 'Jackie' },
-          relationships: {
-            'pets.0': { links: { self: `${testRealmURL}dir/van-gogh` } },
-            friend: { links: { self: `${testRealmURL}dir/friend` } },
-          },
-          meta: {
-            adoptsFrom: {
-              module: `http://localhost:4202/test/pet-person`,
-              name: 'PetPerson',
+        'jackie.json': {
+          data: {
+            id: `${testRealmURL}jackie`,
+            attributes: { firstName: 'Jackie' },
+            relationships: {
+              'pets.0': { links: { self: `${testRealmURL}dir/van-gogh` } },
+              friend: { links: { self: `${testRealmURL}dir/friend` } },
+            },
+            meta: {
+              adoptsFrom: {
+                module: `http://localhost:4202/test/pet-person`,
+                name: 'PetPerson',
+              },
             },
           },
         },
       },
     });
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
 
     let response = await realm.handle(
       new Request(`${testRealmURL}jackie`, {
@@ -1223,51 +1229,52 @@ module('Integration | realm', function (hooks) {
   });
 
   test('realm can add items to null linksToMany relationship via PATCH request', async function (assert) {
-    let adapter = new TestRealmAdapter({
-      'dir/van-gogh.json': {
-        data: {
-          id: `${testRealmURL}dir/van-gogh`,
-          attributes: { firstName: 'Van Gogh' },
-          relationships: { owner: { links: { self: null } } },
-          meta: {
-            adoptsFrom: {
-              module: `http://localhost:4202/test/pet`,
-              name: 'Pet',
+    let { realm, adapter } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'dir/van-gogh.json': {
+          data: {
+            id: `${testRealmURL}dir/van-gogh`,
+            attributes: { firstName: 'Van Gogh' },
+            relationships: { owner: { links: { self: null } } },
+            meta: {
+              adoptsFrom: {
+                module: `http://localhost:4202/test/pet`,
+                name: 'Pet',
+              },
             },
           },
         },
-      },
-      'dir/mango.json': {
-        data: {
-          id: `${testRealmURL}dir/mango`,
-          attributes: { firstName: 'Mango' },
-          relationships: { owner: { links: { self: null } } },
-          meta: {
-            adoptsFrom: {
-              module: `http://localhost:4202/test/pet`,
-              name: 'Pet',
+        'dir/mango.json': {
+          data: {
+            id: `${testRealmURL}dir/mango`,
+            attributes: { firstName: 'Mango' },
+            relationships: { owner: { links: { self: null } } },
+            meta: {
+              adoptsFrom: {
+                module: `http://localhost:4202/test/pet`,
+                name: 'Pet',
+              },
             },
           },
         },
-      },
-      'jackie.json': {
-        data: {
-          id: `${testRealmURL}jackie`,
-          attributes: { firstName: 'Jackie' },
-          relationships: {
-            pets: { links: { self: null } },
-          },
-          meta: {
-            adoptsFrom: {
-              module: `http://localhost:4202/test/pet-person`,
-              name: 'PetPerson',
+        'jackie.json': {
+          data: {
+            id: `${testRealmURL}jackie`,
+            attributes: { firstName: 'Jackie' },
+            relationships: {
+              pets: { links: { self: null } },
+            },
+            meta: {
+              adoptsFrom: {
+                module: `http://localhost:4202/test/pet-person`,
+                name: 'PetPerson',
+              },
             },
           },
         },
       },
     });
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
 
     let response = await realm.handle(
       new Request(`${testRealmURL}jackie`, {
@@ -1331,52 +1338,53 @@ module('Integration | realm', function (hooks) {
   });
 
   test('realm can remove all items to in a linksToMany relationship via PATCH request', async function (assert) {
-    let adapter = new TestRealmAdapter({
-      'dir/van-gogh.json': {
-        data: {
-          id: `${testRealmURL}dir/van-gogh`,
-          attributes: { firstName: 'Van Gogh' },
-          relationships: { owner: { links: { self: null } } },
-          meta: {
-            adoptsFrom: {
-              module: `http://localhost:4202/test/pet`,
-              name: 'Pet',
+    let { realm, adapter } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'dir/van-gogh.json': {
+          data: {
+            id: `${testRealmURL}dir/van-gogh`,
+            attributes: { firstName: 'Van Gogh' },
+            relationships: { owner: { links: { self: null } } },
+            meta: {
+              adoptsFrom: {
+                module: `http://localhost:4202/test/pet`,
+                name: 'Pet',
+              },
             },
           },
         },
-      },
-      'dir/mango.json': {
-        data: {
-          id: `${testRealmURL}dir/mango`,
-          attributes: { firstName: 'Mango' },
-          relationships: { owner: { links: { self: null } } },
-          meta: {
-            adoptsFrom: {
-              module: `http://localhost:4202/test/pet`,
-              name: 'Pet',
+        'dir/mango.json': {
+          data: {
+            id: `${testRealmURL}dir/mango`,
+            attributes: { firstName: 'Mango' },
+            relationships: { owner: { links: { self: null } } },
+            meta: {
+              adoptsFrom: {
+                module: `http://localhost:4202/test/pet`,
+                name: 'Pet',
+              },
             },
           },
         },
-      },
-      'jackie.json': {
-        data: {
-          id: `${testRealmURL}jackie`,
-          attributes: { firstName: 'Jackie' },
-          relationships: {
-            'pets.0': { links: { self: `${testRealmURL}dir/mango` } },
-            'pets.1': { links: { self: `${testRealmURL}dir/van-gogh` } },
-          },
-          meta: {
-            adoptsFrom: {
-              module: `http://localhost:4202/test/pet-person`,
-              name: 'PetPerson',
+        'jackie.json': {
+          data: {
+            id: `${testRealmURL}jackie`,
+            attributes: { firstName: 'Jackie' },
+            relationships: {
+              'pets.0': { links: { self: `${testRealmURL}dir/mango` } },
+              'pets.1': { links: { self: `${testRealmURL}dir/van-gogh` } },
+            },
+            meta: {
+              adoptsFrom: {
+                module: `http://localhost:4202/test/pet-person`,
+                name: 'PetPerson',
+              },
             },
           },
         },
       },
     });
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
 
     let response = await realm.handle(
       new Request(`${testRealmURL}jackie`, {
@@ -1430,63 +1438,64 @@ module('Integration | realm', function (hooks) {
   });
 
   test('realm can serve PATCH requests to linksTo field in a card that also has a linksToMany field', async function (assert) {
-    let adapter = new TestRealmAdapter({
-      'dir/van-gogh.json': {
-        data: {
-          id: `${testRealmURL}dir/van-gogh`,
-          attributes: { firstName: 'Van Gogh' },
-          relationships: { owner: { links: { self: null } } },
-          meta: {
-            adoptsFrom: {
-              module: `http://localhost:4202/test/pet`,
-              name: 'Pet',
+    let { realm, adapter } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'dir/van-gogh.json': {
+          data: {
+            id: `${testRealmURL}dir/van-gogh`,
+            attributes: { firstName: 'Van Gogh' },
+            relationships: { owner: { links: { self: null } } },
+            meta: {
+              adoptsFrom: {
+                module: `http://localhost:4202/test/pet`,
+                name: 'Pet',
+              },
             },
           },
         },
-      },
-      'dir/friend.json': {
-        data: {
-          id: `${testRealmURL}dir/friend`,
-          attributes: { firstName: 'Hassan', lastName: 'Abdel-Rahman' },
-          meta: {
-            adoptsFrom: {
-              module: 'http://localhost:4202/test/person',
-              name: 'Person',
+        'dir/friend.json': {
+          data: {
+            id: `${testRealmURL}dir/friend`,
+            attributes: { firstName: 'Hassan', lastName: 'Abdel-Rahman' },
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/person',
+                name: 'Person',
+              },
             },
           },
         },
-      },
-      'dir/different-friend.json': {
-        data: {
-          id: `${testRealmURL}dir/friend`,
-          attributes: { firstName: 'Burcu' },
-          meta: {
-            adoptsFrom: {
-              module: 'http://localhost:4202/test/person',
-              name: 'Person',
+        'dir/different-friend.json': {
+          data: {
+            id: `${testRealmURL}dir/friend`,
+            attributes: { firstName: 'Burcu' },
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/person',
+                name: 'Person',
+              },
             },
           },
         },
-      },
-      'jackie.json': {
-        data: {
-          id: `${testRealmURL}jackie`,
-          attributes: { firstName: 'Jackie' },
-          relationships: {
-            'pets.0': { links: { self: `${testRealmURL}dir/van-gogh` } },
-            friend: { links: { self: `${testRealmURL}dir/friend` } },
-          },
-          meta: {
-            adoptsFrom: {
-              module: `http://localhost:4202/test/pet-person`,
-              name: 'PetPerson',
+        'jackie.json': {
+          data: {
+            id: `${testRealmURL}jackie`,
+            attributes: { firstName: 'Jackie' },
+            relationships: {
+              'pets.0': { links: { self: `${testRealmURL}dir/van-gogh` } },
+              friend: { links: { self: `${testRealmURL}dir/friend` } },
+            },
+            meta: {
+              adoptsFrom: {
+                module: `http://localhost:4202/test/pet-person`,
+                name: 'PetPerson',
+              },
             },
           },
         },
       },
     });
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
 
     // changing linksTo field only
     let response = await realm.handle(
@@ -1551,76 +1560,77 @@ module('Integration | realm', function (hooks) {
   });
 
   test('realm can serve PATCH requests to both linksTo and linksToMany fields', async function (assert) {
-    let adapter = new TestRealmAdapter({
-      'dir/van-gogh.json': {
-        data: {
-          id: `${testRealmURL}dir/van-gogh`,
-          attributes: { firstName: 'Van Gogh' },
-          relationships: { owner: { links: { self: null } } },
-          meta: {
-            adoptsFrom: {
-              module: `http://localhost:4202/test/pet`,
-              name: 'Pet',
+    let { realm, adapter } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'dir/van-gogh.json': {
+          data: {
+            id: `${testRealmURL}dir/van-gogh`,
+            attributes: { firstName: 'Van Gogh' },
+            relationships: { owner: { links: { self: null } } },
+            meta: {
+              adoptsFrom: {
+                module: `http://localhost:4202/test/pet`,
+                name: 'Pet',
+              },
             },
           },
         },
-      },
-      'dir/mango.json': {
-        data: {
-          id: `${testRealmURL}dir/mango`,
-          attributes: { firstName: 'Mango' },
-          relationships: { owner: { links: { self: null } } },
-          meta: {
-            adoptsFrom: {
-              module: `http://localhost:4202/test/pet`,
-              name: 'Pet',
+        'dir/mango.json': {
+          data: {
+            id: `${testRealmURL}dir/mango`,
+            attributes: { firstName: 'Mango' },
+            relationships: { owner: { links: { self: null } } },
+            meta: {
+              adoptsFrom: {
+                module: `http://localhost:4202/test/pet`,
+                name: 'Pet',
+              },
             },
           },
         },
-      },
-      'dir/friend.json': {
-        data: {
-          id: `${testRealmURL}dir/friend`,
-          attributes: { firstName: 'Hassan', lastName: 'Abdel-Rahman' },
-          meta: {
-            adoptsFrom: {
-              module: 'http://localhost:4202/test/person',
-              name: 'Person',
+        'dir/friend.json': {
+          data: {
+            id: `${testRealmURL}dir/friend`,
+            attributes: { firstName: 'Hassan', lastName: 'Abdel-Rahman' },
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/person',
+                name: 'Person',
+              },
             },
           },
         },
-      },
-      'dir/different-friend.json': {
-        data: {
-          id: `${testRealmURL}dir/friend`,
-          attributes: { firstName: 'Burcu' },
-          meta: {
-            adoptsFrom: {
-              module: 'http://localhost:4202/test/person',
-              name: 'Person',
+        'dir/different-friend.json': {
+          data: {
+            id: `${testRealmURL}dir/friend`,
+            attributes: { firstName: 'Burcu' },
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/person',
+                name: 'Person',
+              },
             },
           },
         },
-      },
-      'jackie.json': {
-        data: {
-          id: `${testRealmURL}jackie`,
-          attributes: { firstName: 'Jackie' },
-          relationships: {
-            'pets.0': { links: { self: `${testRealmURL}dir/van-gogh` } },
-            friend: { links: { self: `${testRealmURL}dir/friend` } },
-          },
-          meta: {
-            adoptsFrom: {
-              module: `http://localhost:4202/test/pet-person`,
-              name: 'PetPerson',
+        'jackie.json': {
+          data: {
+            id: `${testRealmURL}jackie`,
+            attributes: { firstName: 'Jackie' },
+            relationships: {
+              'pets.0': { links: { self: `${testRealmURL}dir/van-gogh` } },
+              friend: { links: { self: `${testRealmURL}dir/friend` } },
+            },
+            meta: {
+              adoptsFrom: {
+                module: `http://localhost:4202/test/pet-person`,
+                name: 'PetPerson',
+              },
             },
           },
         },
       },
     });
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
 
     let response = await realm.handle(
       new Request(`${testRealmURL}jackie`, {
@@ -1686,63 +1696,64 @@ module('Integration | realm', function (hooks) {
   });
 
   test('realm can serve PATCH requests that include linksTo fields', async function (assert) {
-    let adapter = new TestRealmAdapter({
-      'dir/hassan.json': {
-        data: {
-          id: `${testRealmURL}dir/hassan`,
-          attributes: {
-            firstName: 'Hassan',
-            lastName: 'Abdel-Rahman',
-          },
-          meta: {
-            adoptsFrom: {
-              module: 'http://localhost:4202/test/person',
-              name: 'Person',
+    let { realm, adapter } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'dir/hassan.json': {
+          data: {
+            id: `${testRealmURL}dir/hassan`,
+            attributes: {
+              firstName: 'Hassan',
+              lastName: 'Abdel-Rahman',
             },
-          },
-        },
-      },
-      'dir/mariko.json': {
-        data: {
-          id: `${testRealmURL}dir/mariko`,
-          attributes: {
-            firstName: 'Mariko',
-            lastName: 'Abdel-Rahman',
-          },
-          meta: {
-            adoptsFrom: {
-              module: 'http://localhost:4202/test/person',
-              name: 'Person',
-            },
-          },
-        },
-      },
-      'dir/mango.json': {
-        data: {
-          id: `${testRealmURL}dir/mango`,
-          attributes: {
-            description: null,
-            thumbnailURL: null,
-            firstName: 'Mango',
-          },
-          relationships: {
-            owner: {
-              links: {
-                self: `${testRealmURL}dir/hassan`,
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/person',
+                name: 'Person',
               },
             },
           },
-          meta: {
-            adoptsFrom: {
-              module: 'http://localhost:4202/test/pet',
-              name: 'Pet',
+        },
+        'dir/mariko.json': {
+          data: {
+            id: `${testRealmURL}dir/mariko`,
+            attributes: {
+              firstName: 'Mariko',
+              lastName: 'Abdel-Rahman',
+            },
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/person',
+                name: 'Person',
+              },
+            },
+          },
+        },
+        'dir/mango.json': {
+          data: {
+            id: `${testRealmURL}dir/mango`,
+            attributes: {
+              description: null,
+              thumbnailURL: null,
+              firstName: 'Mango',
+            },
+            relationships: {
+              owner: {
+                links: {
+                  self: `${testRealmURL}dir/hassan`,
+                },
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/pet',
+                name: 'Pet',
+              },
             },
           },
         },
       },
     });
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
     let response = await realm.handle(
       new Request(`${testRealmURL}dir/mango`, {
         method: 'PATCH',
@@ -1875,30 +1886,31 @@ module('Integration | realm', function (hooks) {
   });
 
   test<TestContextWithSSE>('realm can serve delete card requests', async function (assert) {
-    let adapter = new TestRealmAdapter({
-      'cards/1.json': {
-        data: {
-          meta: {
-            adoptsFrom: {
-              module: 'https://cardstack.com/base/card-api',
-              name: 'CardDef',
+    let { realm } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'cards/1.json': {
+          data: {
+            meta: {
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/card-api',
+                name: 'CardDef',
+              },
             },
           },
         },
-      },
-      'cards/2.json': {
-        data: {
-          meta: {
-            adoptsFrom: {
-              module: 'https://cardstack.com/base/card-api',
-              name: 'CardDef',
+        'cards/2.json': {
+          data: {
+            meta: {
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/card-api',
+                name: 'CardDef',
+              },
             },
           },
         },
       },
     });
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
 
     let searchIndex = realm.searchIndex;
 
@@ -1929,7 +1941,6 @@ module('Integration | realm', function (hooks) {
     let response = await this.expectEvents({
       assert,
       realm,
-      adapter,
       expectedEvents,
       callback: async () => {
         let response = realm.handle(
@@ -1966,14 +1977,12 @@ module('Integration | realm', function (hooks) {
   });
 
   test('realm can serve card source file', async function (assert) {
-    let realm = await TestRealm.create(
+    let { realm } = await setupIntegrationTestRealm({
       loader,
-      {
+      contents: {
         'dir/person.gts': cardSrc,
       },
-      this.owner,
-    );
-    await realm.ready;
+    });
     let response = await realm.handle(
       new Request(`${testRealmURL}dir/person.gts`, {
         headers: {
@@ -1991,14 +2000,12 @@ module('Integration | realm', function (hooks) {
   });
 
   test('realm provide redirect for card source', async function (assert) {
-    let realm = await TestRealm.create(
+    let { realm } = await setupIntegrationTestRealm({
       loader,
-      {
+      contents: {
         'dir/person.gts': cardSrc,
       },
-      this.owner,
-    );
-    await realm.ready;
+    });
     let response = await realm.handle(
       new Request(`${testRealmURL}dir/person`, {
         headers: {
@@ -2015,8 +2022,10 @@ module('Integration | realm', function (hooks) {
   });
 
   test('realm returns 404 when no card source can be found', async function (assert) {
-    let realm = await TestRealm.create(loader, {}, this.owner);
-    await realm.ready;
+    let { realm } = await setupIntegrationTestRealm({
+      loader,
+      contents: {},
+    });
     let response = await realm.handle(
       new Request(`${testRealmURL}dir/person`, {
         headers: {
@@ -2028,9 +2037,10 @@ module('Integration | realm', function (hooks) {
   });
 
   test<TestContextWithSSE>('realm can serve card source post request', async function (assert) {
-    let adapter = new TestRealmAdapter({});
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
+    let { realm } = await setupIntegrationTestRealm({
+      loader,
+      contents: {},
+    });
 
     {
       let expectedEvents = [
@@ -2045,7 +2055,6 @@ module('Integration | realm', function (hooks) {
       let response = await this.expectEvents({
         assert,
         realm,
-        adapter,
         expectedEvents,
         callback: async () => {
           let response = realm.handle(
@@ -2086,19 +2095,24 @@ module('Integration | realm', function (hooks) {
   });
 
   test<TestContextWithSSE>('realm can serve card source delete request', async function (assert) {
-    let adapter = new TestRealmAdapter({
-      'person.gts': `
-      import { contains, field, CardDef } from 'https://cardstack.com/base/card-api';
-      import StringCard from 'https://cardstack.com/base/string';
+    let { field, contains, CardDef } = await loader.import<typeof CardAPI>(
+      'https://cardstack.com/base/card-api',
+    );
+    let { default: StringField } = await loader.import<typeof StringFieldMod>(
+      'https://cardstack.com/base/string',
+    );
 
-      export class Person extends CardDef {
-        @field firstName = contains(StringCard);
-        @field lastName = contains(StringCard);
-      }
-    `,
+    class Person extends CardDef {
+      @field firstName = contains(StringField);
+      @field lastName = contains(StringField);
+    }
+
+    let { realm } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'person.gts': { Person },
+      },
     });
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
 
     let expectedEvents = [
       {
@@ -2112,7 +2126,6 @@ module('Integration | realm', function (hooks) {
     let response = await this.expectEvents({
       assert,
       realm,
-      adapter,
       expectedEvents,
       callback: async () => {
         let response = realm.handle(
@@ -2150,14 +2163,12 @@ module('Integration | realm', function (hooks) {
   });
 
   test('realm can serve compiled js file when requested without file extension ', async function (assert) {
-    let realm = await TestRealm.create(
+    let { realm } = await setupIntegrationTestRealm({
       loader,
-      {
+      contents: {
         'dir/person.gts': cardSrc,
       },
-      this.owner,
-    );
-    await realm.ready;
+    });
     let response = await realm.handle(new Request(`${testRealmURL}dir/person`));
     assert.strictEqual(response.status, 200, 'HTTP 200 status code');
     let compiledJS = await response.text();
@@ -2169,14 +2180,12 @@ module('Integration | realm', function (hooks) {
   });
 
   test('realm can serve compiled js file when requested with file extension ', async function (assert) {
-    let realm = await TestRealm.create(
+    let { realm } = await setupIntegrationTestRealm({
       loader,
-      {
+      contents: {
         'dir/person.gts': cardSrc,
       },
-      this.owner,
-    );
-    await realm.ready;
+    });
     let response = await realm.handle(
       new Request(`${testRealmURL}dir/person.gts`),
     );
@@ -2197,14 +2206,12 @@ module('Integration | realm', function (hooks) {
         </body>
       </html>
     `.trim();
-    let realm = await TestRealm.create(
+    let { realm } = await setupIntegrationTestRealm({
       loader,
-      {
+      contents: {
         'dir/index.html': html,
       },
-      this.owner,
-    );
-    await realm.ready;
+    });
     let response = await realm.handle(
       new Request(`${testRealmURL}dir/index.html`),
     );
@@ -2214,9 +2221,9 @@ module('Integration | realm', function (hooks) {
   });
 
   test('realm can serve search requests', async function (assert) {
-    let realm = await TestRealm.create(
+    let { realm } = await setupIntegrationTestRealm({
       loader,
-      {
+      contents: {
         'dir/empty.json': {
           data: {
             attributes: {},
@@ -2229,9 +2236,7 @@ module('Integration | realm', function (hooks) {
           },
         },
       },
-      this.owner,
-    );
-    await realm.ready;
+    });
     let response = await realm.handle(
       new Request(`${testRealmURL}_search`, {
         headers: {
@@ -2253,69 +2258,70 @@ module('Integration | realm', function (hooks) {
   });
 
   test('realm can serve search requests whose results have linksTo fields', async function (assert) {
-    let adapter = new TestRealmAdapter({
-      'dir/mariko.json': {
-        data: {
-          id: `${testRealmURL}dir/mariko`,
-          attributes: {
-            firstName: 'Mariko',
-            lastName: 'Abdel-Rahman',
-          },
-          meta: {
-            adoptsFrom: {
-              module: 'http://localhost:4202/test/person',
-              name: 'Person',
+    let { realm, adapter } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'dir/mariko.json': {
+          data: {
+            id: `${testRealmURL}dir/mariko`,
+            attributes: {
+              firstName: 'Mariko',
+              lastName: 'Abdel-Rahman',
             },
-          },
-        },
-      },
-      'dir/mango.json': {
-        data: {
-          id: `${testRealmURL}dir/mango`,
-          attributes: {
-            description: null,
-            thumbnailURL: null,
-            firstName: 'Mango',
-          },
-          relationships: {
-            owner: {
-              links: {
-                self: `${testRealmURL}dir/mariko`,
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/person',
+                name: 'Person',
               },
             },
           },
-          meta: {
-            adoptsFrom: {
-              module: 'http://localhost:4202/test/pet',
-              name: 'Pet',
-            },
-          },
         },
-      },
-      'dir/vanGogh.json': {
-        data: {
-          id: `${testRealmURL}dir/vanGogh`,
-          attributes: {
-            firstName: 'Van Gogh',
-          },
-          relationships: {
-            owner: {
-              links: {
-                self: `http://localhost:4202/test/hassan`,
+        'dir/mango.json': {
+          data: {
+            id: `${testRealmURL}dir/mango`,
+            attributes: {
+              description: null,
+              thumbnailURL: null,
+              firstName: 'Mango',
+            },
+            relationships: {
+              owner: {
+                links: {
+                  self: `${testRealmURL}dir/mariko`,
+                },
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/pet',
+                name: 'Pet',
               },
             },
           },
-          meta: {
-            adoptsFrom: {
-              module: 'http://localhost:4202/test/pet',
-              name: 'Pet',
+        },
+        'dir/vanGogh.json': {
+          data: {
+            id: `${testRealmURL}dir/vanGogh`,
+            attributes: {
+              firstName: 'Van Gogh',
+            },
+            relationships: {
+              owner: {
+                links: {
+                  self: `http://localhost:4202/test/hassan`,
+                },
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/pet',
+                name: 'Pet',
+              },
             },
           },
         },
       },
     });
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
 
     let response = await realm.handle(
       new Request(
@@ -2469,9 +2475,9 @@ module('Integration | realm', function (hooks) {
   });
 
   test('realm can serve directory requests', async function (assert) {
-    let realm = await TestRealm.create(
+    let { realm } = await setupIntegrationTestRealm({
       loader,
-      {
+      contents: {
         'dir/empty.json': {
           data: {
             attributes: {},
@@ -2485,9 +2491,7 @@ module('Integration | realm', function (hooks) {
         },
         'dir/subdir/file.txt': '',
       },
-      this.owner,
-    );
-    await realm.ready;
+    });
     let response = await realm.handle(
       new Request(`${testRealmURL}dir/`, {
         headers: {
@@ -2533,9 +2537,9 @@ module('Integration | realm', function (hooks) {
       export class Post extends CardDef {}
     `;
 
-    let realm = await TestRealm.create(
+    let { realm } = await setupIntegrationTestRealm({
       loader,
-      {
+      contents: {
         'sample-post.json': '',
         'posts/1.json': '',
         'posts/nested.gts': cardSource,
@@ -2549,9 +2553,7 @@ module('Integration | realm', function (hooks) {
 posts/ignore-me.gts
 `,
       },
-      this.owner,
-    );
-    await realm.ready;
+    });
 
     {
       let response = await realm.handle(
@@ -2616,18 +2618,16 @@ posts/ignore-me.gts
   });
 
   test('realm can serve info requests by reading .realm.json', async function (assert) {
-    let realm = await TestRealm.create(
+    let { realm } = await setupIntegrationTestRealm({
       loader,
-      {
+      contents: {
         '.realm.json': `{
           "name": "Example Workspace",
           "backgroundURL": "https://example-background-url.com",
           "iconURL": "https://example-icon-url.com"
         }`,
       },
-      this.owner,
-    );
-    await realm.ready;
+    });
     let response = await realm.handle(
       new Request(`${testRealmURL}_info`, {
         headers: {
@@ -2654,8 +2654,10 @@ posts/ignore-me.gts
   });
 
   test('realm can serve info requests if .realm.json is missing', async function (assert) {
-    let realm = await TestRealm.create(loader, {}, this.owner);
-    await realm.ready;
+    let { realm } = await setupIntegrationTestRealm({
+      loader,
+      contents: {},
+    });
     let response = await realm.handle(
       new Request(`${testRealmURL}_info`, {
         headers: {
@@ -2678,14 +2680,12 @@ posts/ignore-me.gts
   });
 
   test('realm can serve info requests if .realm.json is malformed', async function (assert) {
-    let realm = await TestRealm.create(
+    let { realm } = await setupIntegrationTestRealm({
       loader,
-      {
+      contents: {
         '.realm.json': `Some example content that is not valid json`,
       },
-      this.owner,
-    );
-    await realm.ready;
+    });
     let response = await realm.handle(
       new Request(`${testRealmURL}_info`, {
         headers: {
@@ -2708,9 +2708,9 @@ posts/ignore-me.gts
   });
 
   test('realm does not crash when indexing a broken instance', async function (assert) {
-    let realm = await TestRealm.create(
+    await setupIntegrationTestRealm({
       loader,
-      {
+      contents: {
         'FieldDef/1.json': {
           data: {
             type: 'card',
@@ -2723,10 +2723,8 @@ posts/ignore-me.gts
           },
         },
       },
-      this.owner,
-    ); // this is an example of a card that where loadCard will throw an error
+    }); // this is an example of a card that where loadCard will throw an error
 
-    await realm.ready;
     assert.ok(
       true,
       'realm did not crash when trying to index a broken instance',

--- a/packages/host/tests/integration/search-index-test.gts
+++ b/packages/host/tests/integration/search-index-test.gts
@@ -18,8 +18,6 @@ import { SearchIndex } from '@cardstack/runtime-common/search-index';
 import type LoaderService from '@cardstack/host/services/loader-service';
 
 import {
-  TestRealm,
-  TestRealmAdapter,
   testRealmURL,
   testRealmInfo,
   cleanWhiteSpace,
@@ -27,6 +25,7 @@ import {
   setupCardLogs,
   setupLocalIndexing,
   type CardDocFiles,
+  setupIntegrationTestRealm,
 } from '../helpers';
 
 const paths = new RealmPaths(testRealmURL);
@@ -49,20 +48,21 @@ module('Integration | search-index', function (hooks) {
   );
 
   test('full indexing discovers card instances', async function (assert) {
-    let adapter = new TestRealmAdapter({
-      'empty.json': {
-        data: {
-          meta: {
-            adoptsFrom: {
-              module: 'https://cardstack.com/base/card-api',
-              name: 'CardDef',
+    let { realm, adapter } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'empty.json': {
+          data: {
+            meta: {
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/card-api',
+                name: 'CardDef',
+              },
             },
           },
         },
       },
     });
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
     let indexer = realm.searchIndex;
     let { data: cards } = await indexer.search({});
     assert.deepEqual(cards, [
@@ -91,31 +91,32 @@ module('Integration | search-index', function (hooks) {
   });
 
   test('can recover from indexing a card with a broken link', async function (assert) {
-    let adapter = new TestRealmAdapter({
-      'Pet/mango.json': {
-        data: {
-          id: `${testRealmURL}Pet/mango`,
-          attributes: {
-            firstName: 'Mango',
-          },
-          relationships: {
-            owner: {
-              links: {
-                self: `${testRealmURL}Person/owner`,
+    let { realm, adapter } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'Pet/mango.json': {
+          data: {
+            id: `${testRealmURL}Pet/mango`,
+            attributes: {
+              firstName: 'Mango',
+            },
+            relationships: {
+              owner: {
+                links: {
+                  self: `${testRealmURL}Person/owner`,
+                },
               },
             },
-          },
-          meta: {
-            adoptsFrom: {
-              module: 'http://localhost:4202/test/pet',
-              name: 'Pet',
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/pet',
+                name: 'Pet',
+              },
             },
           },
         },
       },
     });
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
     let indexer = realm.searchIndex;
     {
       let mango = await indexer.card(new URL(`${testRealmURL}Pet/mango`));
@@ -190,45 +191,46 @@ module('Integration | search-index', function (hooks) {
   });
 
   test('can index card with linkTo field', async function (assert) {
-    let adapter = new TestRealmAdapter({
-      'Person/owner.json': {
-        data: {
-          id: `${testRealmURL}Person/owner`,
-          attributes: {
-            firstName: 'Hassan',
-          },
-          meta: {
-            adoptsFrom: {
-              module: 'http://localhost:4202/test/person',
-              name: 'Person',
+    let { realm, adapter } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'Person/owner.json': {
+          data: {
+            id: `${testRealmURL}Person/owner`,
+            attributes: {
+              firstName: 'Hassan',
             },
-          },
-        },
-      },
-      'Pet/mango.json': {
-        data: {
-          id: `${testRealmURL}Pet/mango`,
-          attributes: {
-            firstName: 'Mango',
-          },
-          relationships: {
-            owner: {
-              links: {
-                self: `${testRealmURL}Person/owner`,
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/person',
+                name: 'Person',
               },
             },
           },
-          meta: {
-            adoptsFrom: {
-              module: 'http://localhost:4202/test/pet',
-              name: 'Pet',
+        },
+        'Pet/mango.json': {
+          data: {
+            id: `${testRealmURL}Pet/mango`,
+            attributes: {
+              firstName: 'Mango',
+            },
+            relationships: {
+              owner: {
+                links: {
+                  self: `${testRealmURL}Person/owner`,
+                },
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/pet',
+                name: 'Pet',
+              },
             },
           },
         },
       },
     });
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
     let indexer = realm.searchIndex;
     let mango = await indexer.card(new URL(`${testRealmURL}Pet/mango`));
     if (mango?.type === 'doc') {
@@ -269,45 +271,46 @@ module('Integration | search-index', function (hooks) {
   });
 
   test('can index card with a relative linkTo field', async function (assert) {
-    let adapter = new TestRealmAdapter({
-      'Person/owner.json': {
-        data: {
-          id: `${testRealmURL}Person/owner`,
-          attributes: {
-            firstName: 'Hassan',
-          },
-          meta: {
-            adoptsFrom: {
-              module: 'http://localhost:4202/test/person',
-              name: 'Person',
+    let { realm, adapter } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'Person/owner.json': {
+          data: {
+            id: `${testRealmURL}Person/owner`,
+            attributes: {
+              firstName: 'Hassan',
             },
-          },
-        },
-      },
-      'Pet/mango.json': {
-        data: {
-          id: `${testRealmURL}Pet/mango`,
-          attributes: {
-            firstName: 'Mango',
-          },
-          relationships: {
-            owner: {
-              links: {
-                self: `../Person/owner`,
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/person',
+                name: 'Person',
               },
             },
           },
-          meta: {
-            adoptsFrom: {
-              module: 'http://localhost:4202/test/pet',
-              name: 'Pet',
+        },
+        'Pet/mango.json': {
+          data: {
+            id: `${testRealmURL}Pet/mango`,
+            attributes: {
+              firstName: 'Mango',
+            },
+            relationships: {
+              owner: {
+                links: {
+                  self: `../Person/owner`,
+                },
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/pet',
+                name: 'Pet',
+              },
             },
           },
         },
       },
     });
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
     let indexer = realm.searchIndex;
     let mango = await indexer.card(new URL(`${testRealmURL}Pet/mango`));
     if (mango?.type === 'doc') {
@@ -348,47 +351,53 @@ module('Integration | search-index', function (hooks) {
   });
 
   test('can index a card with relative code-ref fields', async function (assert) {
-    let adapter = new TestRealmAdapter({
-      'person.gts': `
-        import { contains, field, CardDef, Component } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
+    let cardApi: typeof import('https://cardstack.com/base/card-api');
+    let string: typeof import('https://cardstack.com/base/string');
+    cardApi = await loader.import(`${baseRealm.url}card-api`);
+    string = await loader.import(`${baseRealm.url}string`);
 
-        export class Person extends CardDef {
-          @field firstName = contains(StringCard);
-        }
-      `,
-      'person-catalog-entry.json': {
-        data: {
-          attributes: {
-            title: 'Person Card',
-            description: 'Catalog entry for Person card',
-            ref: {
-              module: './person',
-              name: 'Person',
-            },
-            demo: {
-              firstName: 'Mango',
-            },
-          },
-          meta: {
-            fields: {
+    let { field, contains, CardDef } = cardApi;
+    let { default: StringField } = string;
+
+    class Person extends CardDef {
+      @field firstName = contains(StringField);
+    }
+
+    let { realm, adapter } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'person.gts': { Person },
+        'person-catalog-entry.json': {
+          data: {
+            attributes: {
+              title: 'Person Card',
+              description: 'Catalog entry for Person card',
+              ref: {
+                module: './person',
+                name: 'Person',
+              },
               demo: {
-                adoptsFrom: {
-                  module: './person',
-                  name: 'Person',
-                },
+                firstName: 'Mango',
               },
             },
-            adoptsFrom: {
-              module: 'https://cardstack.com/base/catalog-entry',
-              name: 'CatalogEntry',
+            meta: {
+              fields: {
+                demo: {
+                  adoptsFrom: {
+                    module: './person',
+                    name: 'Person',
+                  },
+                },
+              },
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/catalog-entry',
+                name: 'CatalogEntry',
+              },
             },
           },
         },
       },
     });
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
     let indexer = realm.searchIndex;
     let entry = await indexer.card(
       new URL(`${testRealmURL}person-catalog-entry`),
@@ -473,46 +482,40 @@ module('Integration | search-index', function (hooks) {
           }
         };
       }
-      let adapter = new TestRealmAdapter({
-        'vangogh.json': {
-          data: {
-            attributes: {
-              firstName: 'Van Gogh',
-            },
-            meta: {
-              adoptsFrom: {
-                module: './person',
-                name: 'Person',
+
+      let { realm } = await setupIntegrationTestRealm({
+        loader,
+        contents: {
+          'person.gts': { Person },
+          'boom.gts': { Boom },
+          'vangogh.json': {
+            data: {
+              attributes: {
+                firstName: 'Van Gogh',
+              },
+              meta: {
+                adoptsFrom: {
+                  module: './person',
+                  name: 'Person',
+                },
               },
             },
           },
-        },
-        'boom.json': {
-          data: {
-            attributes: {
-              firstName: 'Boom!',
-            },
-            meta: {
-              adoptsFrom: {
-                module: './boom',
-                name: 'Boom',
+          'boom.json': {
+            data: {
+              attributes: {
+                firstName: 'Boom!',
+              },
+              meta: {
+                adoptsFrom: {
+                  module: './boom',
+                  name: 'Boom',
+                },
               },
             },
           },
         },
       });
-      let realm = await TestRealm.createWithAdapter(
-        adapter,
-        loader,
-        this.owner,
-        {
-          shimModules: {
-            'person.gts': { Person },
-            'boom.gts': { Boom },
-          },
-        },
-      );
-      await realm.ready;
       let indexer = realm.searchIndex;
       {
         let entry = await indexer.card(new URL(`${testRealmURL}boom`));
@@ -564,32 +567,25 @@ module('Integration | search-index', function (hooks) {
           </template>
         };
       }
-      let adapter = new TestRealmAdapter({
-        'vangogh.json': {
-          data: {
-            attributes: {
-              firstName: 'Van Gogh',
-            },
-            meta: {
-              adoptsFrom: {
-                module: './person',
-                name: 'Person',
+      let { realm } = await setupIntegrationTestRealm({
+        loader,
+        contents: {
+          'person.gts': { Person },
+          'vangogh.json': {
+            data: {
+              attributes: {
+                firstName: 'Van Gogh',
+              },
+              meta: {
+                adoptsFrom: {
+                  module: './person',
+                  name: 'Person',
+                },
               },
             },
           },
         },
       });
-      let realm = await TestRealm.createWithAdapter(
-        adapter,
-        loader,
-        this.owner,
-        {
-          shimModules: {
-            'person.gts': { Person },
-          },
-        },
-      );
-      await realm.ready;
       let indexer = realm.searchIndex;
       {
         let entry = await indexer.card(new URL(`${testRealmURL}vangogh`));
@@ -652,45 +648,43 @@ module('Integration | search-index', function (hooks) {
         </template>
       };
     }
-    let adapter = new TestRealmAdapter({
-      'vangogh.json': {
-        data: {
-          attributes: {
-            firstName: 'Van Gogh',
-            boom: {
-              firstName: 'Mango',
-            },
-          },
-          meta: {
-            adoptsFrom: {
-              module: './boom-person',
-              name: 'BoomPerson',
-            },
-          },
-        },
-      },
-      'working-van-gogh.json': {
-        data: {
-          attributes: {
-            firstName: 'Van Gogh',
-          },
-          meta: {
-            adoptsFrom: {
-              module: './person',
-              name: 'Person',
-            },
-          },
-        },
-      },
-    });
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner, {
-      shimModules: {
+    let { realm } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
         'boom-person.gts': { BoomPerson },
         'boom.gts': { Boom },
         'person.gts': { Person },
+        'vangogh.json': {
+          data: {
+            attributes: {
+              firstName: 'Van Gogh',
+              boom: {
+                firstName: 'Mango',
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: './boom-person',
+                name: 'BoomPerson',
+              },
+            },
+          },
+        },
+        'working-van-gogh.json': {
+          data: {
+            attributes: {
+              firstName: 'Van Gogh',
+            },
+            meta: {
+              adoptsFrom: {
+                module: './person',
+                name: 'Person',
+              },
+            },
+          },
+        },
       },
     });
-    await realm.ready;
     let indexer = realm.searchIndex;
 
     let entry = await indexer.card(new URL(`${testRealmURL}vangogh`));
@@ -769,46 +763,45 @@ module('Integration | search-index', function (hooks) {
         </template>
       };
     }
-    let adapter = new TestRealmAdapter({
-      'vangogh.json': {
-        data: {
-          attributes: {
-            firstName: 'Van Gogh',
-            boom: {
-              firstName: 'Mango',
-            },
-          },
-          meta: {
-            adoptsFrom: {
-              module: './boom-person2',
-              name: 'BoomPerson2',
-            },
-          },
-        },
-      },
-      'working-vangogh.json': {
-        data: {
-          attributes: {
-            firstName: 'Van Gogh',
-          },
-          meta: {
-            adoptsFrom: {
-              module: './person',
-              name: 'Person',
-            },
-          },
-        },
-      },
-    });
 
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner, {
-      shimModules: {
+    let { realm } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
         'boom-person2.gts': { BoomPerson2 },
         'custom-boom.gts': { CustomBoom },
         'person.gts': { Person },
+
+        'vangogh.json': {
+          data: {
+            attributes: {
+              firstName: 'Van Gogh',
+              boom: {
+                firstName: 'Mango',
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: './boom-person2',
+                name: 'BoomPerson2',
+              },
+            },
+          },
+        },
+        'working-vangogh.json': {
+          data: {
+            attributes: {
+              firstName: 'Van Gogh',
+            },
+            meta: {
+              adoptsFrom: {
+                module: './person',
+                name: 'Person',
+              },
+            },
+          },
+        },
       },
     });
-    await realm.ready;
 
     let indexer = realm.searchIndex;
     let entry = await indexer.card(new URL(`${testRealmURL}vangogh`));
@@ -852,7 +845,7 @@ module('Integration | search-index', function (hooks) {
     let { field, contains, linksTo, CardDef, FieldDef } = cardApi;
     let { default: StringField } = string;
 
-    class Person extends CardDef {
+    class Person extends FieldDef {
       @field firstName = contains(StringField);
       @field pet = linksTo(() => PetCard);
       @field title = contains(StringField, {
@@ -863,7 +856,7 @@ module('Integration | search-index', function (hooks) {
     }
     class Appointment extends FieldDef {
       @field title = contains(StringField);
-      @field contact = linksTo(() => Person);
+      @field contact = contains(Person);
     }
 
     class PetCard extends CardDef {
@@ -871,89 +864,66 @@ module('Integration | search-index', function (hooks) {
       @field appointment = contains(Appointment);
       @field title = contains(StringField, {
         computeVia: function (this: PetCard) {
-          return { title: this.firstName };
+          return this.firstName;
         },
       });
     }
-    let adapter = new TestRealmAdapter({
-      'jackie.json': {
-        data: {
-          attributes: {
-            firstName: 'Jackie',
-            appointment: {
-              title: 'Vet visit',
-              contact: { firstName: 'Burcu' },
+
+    let { realm } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'person-card.gts': { Person },
+        'appointment.gts': { Appointment },
+        'pet-card.gts': { PetCard },
+        'jackie.json': {
+          data: {
+            attributes: {
+              firstName: 'Jackie',
+              appointment: {
+                title: 'Vet visit',
+                contact: { firstName: 'Burcu' },
+              },
+              description: 'Dog',
+              thumbnailURL: './jackie.jpg',
             },
-            description: 'Dog',
-            thumbnailURL: './jackie.jpg',
-          },
-          meta: { adoptsFrom: { module: `./pet-card`, name: 'PetCard' } },
-          relationships: {
-            'appointment.contact.pet': {
-              links: { self: `${testRealmURL}mango` },
+            meta: { adoptsFrom: { module: `./pet-card`, name: 'PetCard' } },
+            relationships: {
+              'appointment.contact.pet': {
+                links: { self: `${testRealmURL}mango` },
+              },
             },
           },
         },
-      },
-      'mango.json': {
-        data: {
-          attributes: { firstName: 'Mango' },
-          meta: {
-            adoptsFrom: { module: `./pet-card`, name: 'PetCard' },
+        'mango.json': {
+          data: {
+            attributes: { firstName: 'Mango' },
+            meta: {
+              adoptsFrom: { module: `./pet-card`, name: 'PetCard' },
+            },
           },
         },
       },
     });
 
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner, {
-      shimModules: {
-        'person-card.gts': { Person },
-        'appointment.gts': { Appointment },
-        'pet-card.gts': { PetCard },
-      },
-    });
-    await realm.ready;
     let indexer = realm.searchIndex;
     let card = await indexer.card(new URL(`${testRealmURL}jackie`));
 
     if (card?.type === 'doc') {
-      assert.deepEqual(card.doc, {
-        data: {
-          id: `${testRealmURL}jackie`,
-          type: 'card',
-          links: { self: `${testRealmURL}jackie` },
-          attributes: {
-            firstName: 'Jackie',
-            title: 'Jackie',
-            appointment: {
-              title: 'Vet visit',
-              description: null,
-              thumbnailURL: null,
-              contact: {
-                firstName: 'Burcu',
-                description: null,
-                thumbnailURL: null,
-              },
-            },
-            description: 'Dog',
-            thumbnailURL: `./jackie.jpg`,
+      assert.deepEqual(card.doc.data.attributes, {
+        firstName: 'Jackie',
+        title: 'Jackie',
+        appointment: {
+          title: 'Vet visit',
+          contact: {
+            firstName: 'Burcu',
           },
-          meta: {
-            adoptsFrom: {
-              module: `./pet-card`,
-              name: 'PetCard',
-            },
-            lastModified: adapter.lastModified.get(
-              `${testRealmURL}jackie.json`,
-            ),
-            realmInfo: testRealmInfo,
-            realmURL: 'http://test-realm/test/',
-          },
-          relationships: {
-            'appointment.contact.pet': {
-              links: { self: `${testRealmURL}mango` },
-            },
-          },
+        },
+        description: 'Dog',
+        thumbnailURL: `./jackie.jpg`,
+      });
+      assert.deepEqual(card.doc.data.relationships, {
+        'appointment.contact.pet': {
+          links: { self: `${testRealmURL}mango` },
         },
       });
     } else {
@@ -962,78 +932,79 @@ module('Integration | search-index', function (hooks) {
   });
 
   test('can index a card with a containsMany composite containing a linkTo field', async function (assert) {
-    let adapter = new TestRealmAdapter({
-      'Vendor/vendor1.json': {
-        data: {
-          id: `${testRealmURL}Vendor/vendor1`,
-          attributes: {
-            name: 'Acme Industries',
-            paymentMethods: [
-              {
-                type: 'crypto',
-                payment: {
-                  address: '0x1111',
+    let { realm, adapter } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'Vendor/vendor1.json': {
+          data: {
+            id: `${testRealmURL}Vendor/vendor1`,
+            attributes: {
+              name: 'Acme Industries',
+              paymentMethods: [
+                {
+                  type: 'crypto',
+                  payment: {
+                    address: '0x1111',
+                  },
+                },
+                {
+                  type: 'crypto',
+                  payment: {
+                    address: '0x2222',
+                  },
+                },
+              ],
+            },
+            relationships: {
+              'paymentMethods.0.payment.chain': {
+                links: {
+                  self: `${testRealmURL}Chain/1`,
                 },
               },
-              {
-                type: 'crypto',
-                payment: {
-                  address: '0x2222',
+              'paymentMethods.1.payment.chain': {
+                links: {
+                  self: `${testRealmURL}Chain/2`,
                 },
               },
-            ],
-          },
-          relationships: {
-            'paymentMethods.0.payment.chain': {
-              links: {
-                self: `${testRealmURL}Chain/1`,
-              },
             },
-            'paymentMethods.1.payment.chain': {
-              links: {
-                self: `${testRealmURL}Chain/2`,
+            meta: {
+              adoptsFrom: {
+                module: `http://localhost:4202/test/vendor`,
+                name: 'Vendor',
               },
-            },
-          },
-          meta: {
-            adoptsFrom: {
-              module: `http://localhost:4202/test/vendor`,
-              name: 'Vendor',
             },
           },
         },
-      },
-      'Chain/1.json': {
-        data: {
-          id: `${testRealmURL}Chain/1`,
-          attributes: {
-            name: 'Ethereum Mainnet',
-          },
-          meta: {
-            adoptsFrom: {
-              module: `http://localhost:4202/test/chain`,
-              name: 'Chain',
+        'Chain/1.json': {
+          data: {
+            id: `${testRealmURL}Chain/1`,
+            attributes: {
+              name: 'Ethereum Mainnet',
+            },
+            meta: {
+              adoptsFrom: {
+                module: `http://localhost:4202/test/chain`,
+                name: 'Chain',
+              },
             },
           },
         },
-      },
-      'Chain/2.json': {
-        data: {
-          id: `${testRealmURL}Chain/2`,
-          attributes: {
-            name: 'Polygon',
-          },
-          meta: {
-            adoptsFrom: {
-              module: `http://localhost:4202/test/chain`,
-              name: 'Chain',
+        'Chain/2.json': {
+          data: {
+            id: `${testRealmURL}Chain/2`,
+            attributes: {
+              name: 'Polygon',
+            },
+            meta: {
+              adoptsFrom: {
+                module: `http://localhost:4202/test/chain`,
+                name: 'Chain',
+              },
             },
           },
         },
       },
     });
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
     let indexer = realm.searchIndex;
     let vendor = await indexer.card(new URL(`${testRealmURL}Vendor/vendor1`), {
       loadLinks: true,
@@ -1158,35 +1129,36 @@ module('Integration | search-index', function (hooks) {
   });
 
   test('can tolerate a card whose computed throws an exception', async function (assert) {
-    let adapter = new TestRealmAdapter({
-      'Boom/boom.json': {
-        data: {
-          id: `${testRealmURL}Boom/boom`,
-          meta: {
-            adoptsFrom: {
-              module: 'http://localhost:4202/test/card-with-error',
-              name: 'Boom',
+    let { realm } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'Boom/boom.json': {
+          data: {
+            id: `${testRealmURL}Boom/boom`,
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/card-with-error',
+                name: 'Boom',
+              },
             },
           },
         },
-      },
-      'Person/owner.json': {
-        data: {
-          id: `${testRealmURL}Person/owner`,
-          attributes: {
-            firstName: 'Hassan',
-          },
-          meta: {
-            adoptsFrom: {
-              module: 'http://localhost:4202/test/person',
-              name: 'Person',
+        'Person/owner.json': {
+          data: {
+            id: `${testRealmURL}Person/owner`,
+            attributes: {
+              firstName: 'Hassan',
+            },
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/person',
+                name: 'Person',
+              },
             },
           },
         },
       },
     });
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
     let indexer = realm.searchIndex;
     {
       let card = await indexer.card(new URL(`${testRealmURL}Boom/boom`));
@@ -1211,43 +1183,44 @@ module('Integration | search-index', function (hooks) {
   });
 
   test(`search doc includes 'contains' and used 'linksTo' fields`, async function (assert) {
-    let adapter = new TestRealmAdapter({
-      'Pet/mango.json': {
-        data: {
-          attributes: { firstName: 'Mango' },
-          relationships: {
-            owner: {
-              links: { self: `${testRealmURL}Person/hassan` },
+    let { realm } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'Pet/mango.json': {
+          data: {
+            attributes: { firstName: 'Mango' },
+            relationships: {
+              owner: {
+                links: { self: `${testRealmURL}Person/hassan` },
+              },
             },
-          },
-          meta: {
-            adoptsFrom: {
-              module: `${testModuleRealm}pet`,
-              name: 'Pet',
+            meta: {
+              adoptsFrom: {
+                module: `${testModuleRealm}pet`,
+                name: 'Pet',
+              },
             },
           },
         },
-      },
-      'Person/hassan.json': {
-        data: {
-          id: `${testRealmURL}Person/hassan`,
-          attributes: {
-            firstName: 'Hassan',
-            lastName: 'Abdel-Rahman',
-            email: 'hassan@cardstack.com',
-            posts: 100,
-          },
-          meta: {
-            adoptsFrom: {
-              module: 'http://localhost:4202/test/person',
-              name: 'Person',
+        'Person/hassan.json': {
+          data: {
+            id: `${testRealmURL}Person/hassan`,
+            attributes: {
+              firstName: 'Hassan',
+              lastName: 'Abdel-Rahman',
+              email: 'hassan@cardstack.com',
+              posts: 100,
+            },
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/person',
+                name: 'Person',
+              },
             },
           },
         },
       },
     });
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
     let indexer = realm.searchIndex;
     let entry = await indexer.searchEntry(
       new URL(`${testRealmURL}Person/hassan`),
@@ -1268,44 +1241,45 @@ module('Integration | search-index', function (hooks) {
   });
 
   test('search doc normalizes containsMany composite fields', async function (assert) {
-    let adapter = new TestRealmAdapter({
-      'CatalogEntry/booking.json': {
-        data: {
-          attributes: {
-            title: 'Booking',
-            description: 'Catalog entry for Booking',
-            ref: {
-              module: 'http://localhost:4202/test/booking',
-              name: 'Booking',
-            },
-            demo: {
-              title: null,
-              venue: null,
-              startTime: null,
-              endTime: null,
-              hosts: [],
-              sponsors: [],
-            },
-          },
-          meta: {
-            fields: {
+    let { realm } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'CatalogEntry/booking.json': {
+          data: {
+            attributes: {
+              title: 'Booking',
+              description: 'Catalog entry for Booking',
+              ref: {
+                module: 'http://localhost:4202/test/booking',
+                name: 'Booking',
+              },
               demo: {
-                adoptsFrom: {
-                  module: 'http://localhost:4202/test/booking',
-                  name: 'Booking',
-                },
+                title: null,
+                venue: null,
+                startTime: null,
+                endTime: null,
+                hosts: [],
+                sponsors: [],
               },
             },
-            adoptsFrom: {
-              module: 'https://cardstack.com/base/catalog-entry',
-              name: 'CatalogEntry',
+            meta: {
+              fields: {
+                demo: {
+                  adoptsFrom: {
+                    module: 'http://localhost:4202/test/booking',
+                    name: 'Booking',
+                  },
+                },
+              },
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/catalog-entry',
+                name: 'CatalogEntry',
+              },
             },
           },
         },
       },
     });
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
     let indexer = realm.searchIndex;
     let entry = await indexer.searchEntry(
       new URL(`${testRealmURL}CatalogEntry/booking`),
@@ -1336,52 +1310,53 @@ module('Integration | search-index', function (hooks) {
   });
 
   test('can index a card with linksToMany field', async function (assert) {
-    let adapter = new TestRealmAdapter({
-      'Pet/vanGogh.json': {
-        data: {
-          attributes: { firstName: 'Van Gogh' },
-          meta: {
-            adoptsFrom: {
-              module: `${testModuleRealm}pet`,
-              name: 'Pet',
+    let { realm, adapter } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'Pet/vanGogh.json': {
+          data: {
+            attributes: { firstName: 'Van Gogh' },
+            meta: {
+              adoptsFrom: {
+                module: `${testModuleRealm}pet`,
+                name: 'Pet',
+              },
             },
           },
         },
-      },
-      'PetPerson/hassan.json': {
-        data: {
-          attributes: { firstName: 'Hassan' },
-          relationships: {
-            'pets.0': {
-              links: { self: `${testRealmURL}Pet/mango` },
+        'PetPerson/hassan.json': {
+          data: {
+            attributes: { firstName: 'Hassan' },
+            relationships: {
+              'pets.0': {
+                links: { self: `${testRealmURL}Pet/mango` },
+              },
+              'pets.1': {
+                links: { self: `${testRealmURL}Pet/vanGogh` },
+              },
             },
-            'pets.1': {
-              links: { self: `${testRealmURL}Pet/vanGogh` },
-            },
-          },
-          meta: {
-            adoptsFrom: {
-              module: `${testModuleRealm}pet-person`,
-              name: 'PetPerson',
+            meta: {
+              adoptsFrom: {
+                module: `${testModuleRealm}pet-person`,
+                name: 'PetPerson',
+              },
             },
           },
         },
-      },
-      'Pet/mango.json': {
-        data: {
-          attributes: { firstName: 'Mango' },
-          meta: {
-            adoptsFrom: {
-              module: `${testModuleRealm}pet`,
-              name: 'Pet',
+        'Pet/mango.json': {
+          data: {
+            attributes: { firstName: 'Mango' },
+            meta: {
+              adoptsFrom: {
+                module: `${testModuleRealm}pet`,
+                name: 'Pet',
+              },
             },
           },
         },
       },
     });
 
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
     let indexer = realm.searchIndex;
     let hassan = await indexer.card(
       new URL(`${testRealmURL}PetPerson/hassan`),
@@ -1511,23 +1486,23 @@ module('Integration | search-index', function (hooks) {
   });
 
   test('can index a card with empty linksToMany field value', async function (assert) {
-    let adapter = new TestRealmAdapter({
-      'PetPerson/burcu.json': {
-        data: {
-          attributes: { firstName: 'Burcu' },
-          relationships: { pets: { links: { self: null } } },
-          meta: {
-            adoptsFrom: {
-              module: `${testModuleRealm}pet-person`,
-              name: 'PetPerson',
+    let { realm, adapter } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'PetPerson/burcu.json': {
+          data: {
+            attributes: { firstName: 'Burcu' },
+            relationships: { pets: { links: { self: null } } },
+            meta: {
+              adoptsFrom: {
+                module: `${testModuleRealm}pet-person`,
+                name: 'PetPerson',
+              },
             },
           },
         },
       },
     });
-
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
     let indexer = realm.searchIndex;
     let card = await indexer.card(new URL(`${testRealmURL}PetPerson/burcu`), {
       loadLinks: true,
@@ -1588,68 +1563,69 @@ module('Integration | search-index', function (hooks) {
   });
 
   test('can index a card that contains a card with a linksToMany field', async function (assert) {
-    let adapter = new TestRealmAdapter({
-      'Pet/vanGogh.json': {
-        data: {
-          attributes: { firstName: 'Van Gogh' },
-          meta: {
-            adoptsFrom: {
-              module: `${testModuleRealm}pet`,
-              name: 'Pet',
-            },
-          },
-        },
-      },
-      'pet-person-catalog-entry.json': {
-        data: {
-          attributes: {
-            title: 'PetPerson',
-            description: 'Catalog entry for PetPerson',
-            ref: {
-              module: `${testModuleRealm}pet-person`,
-              name: 'PetPerson',
-            },
-            demo: { firstName: 'Hassan' },
-          },
-          relationships: {
-            'demo.pets.0': {
-              links: { self: `${testRealmURL}Pet/mango` },
-            },
-            'demo.pets.1': {
-              links: { self: `${testRealmURL}Pet/vanGogh` },
-            },
-          },
-          meta: {
-            fields: {
-              demo: {
-                adoptsFrom: {
-                  module: `${testModuleRealm}pet-person`,
-                  name: 'PetPerson',
-                },
+    let { realm, adapter } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'Pet/vanGogh.json': {
+          data: {
+            attributes: { firstName: 'Van Gogh' },
+            meta: {
+              adoptsFrom: {
+                module: `${testModuleRealm}pet`,
+                name: 'Pet',
               },
             },
-            adoptsFrom: {
-              module: 'https://cardstack.com/base/catalog-entry',
-              name: 'CatalogEntry',
+          },
+        },
+        'pet-person-catalog-entry.json': {
+          data: {
+            attributes: {
+              title: 'PetPerson',
+              description: 'Catalog entry for PetPerson',
+              ref: {
+                module: `${testModuleRealm}pet-person`,
+                name: 'PetPerson',
+              },
+              demo: { firstName: 'Hassan' },
+            },
+            relationships: {
+              'demo.pets.0': {
+                links: { self: `${testRealmURL}Pet/mango` },
+              },
+              'demo.pets.1': {
+                links: { self: `${testRealmURL}Pet/vanGogh` },
+              },
+            },
+            meta: {
+              fields: {
+                demo: {
+                  adoptsFrom: {
+                    module: `${testModuleRealm}pet-person`,
+                    name: 'PetPerson',
+                  },
+                },
+              },
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/catalog-entry',
+                name: 'CatalogEntry',
+              },
             },
           },
         },
-      },
-      'Pet/mango.json': {
-        data: {
-          attributes: { firstName: 'Mango' },
-          meta: {
-            adoptsFrom: {
-              module: `${testModuleRealm}pet`,
-              name: 'Pet',
+        'Pet/mango.json': {
+          data: {
+            attributes: { firstName: 'Mango' },
+            meta: {
+              adoptsFrom: {
+                module: `${testModuleRealm}pet`,
+                name: 'Pet',
+              },
             },
           },
         },
       },
     });
 
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
     let indexer = realm.searchIndex;
     let catalogEntry = await indexer.card(
       new URL(`${testRealmURL}pet-person-catalog-entry`),
@@ -1801,77 +1777,78 @@ module('Integration | search-index', function (hooks) {
   });
 
   test('can index a card that has nested linksTo fields', async function (assert) {
-    let adapter = new TestRealmAdapter({
-      'Friend/hassan.json': {
-        data: {
-          id: `${testRealmURL}Friend/hassan`,
-          attributes: {
-            firstName: 'Hassan',
-            description: 'Friend of dogs',
-          },
-          relationships: {
-            friend: {
-              links: {
-                self: `${testRealmURL}Friend/mango`,
+    let { realm, adapter } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'Friend/hassan.json': {
+          data: {
+            id: `${testRealmURL}Friend/hassan`,
+            attributes: {
+              firstName: 'Hassan',
+              description: 'Friend of dogs',
+            },
+            relationships: {
+              friend: {
+                links: {
+                  self: `${testRealmURL}Friend/mango`,
+                },
               },
             },
-          },
-          meta: {
-            adoptsFrom: {
-              module: 'http://localhost:4202/test/friend',
-              name: 'Friend',
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/friend',
+                name: 'Friend',
+              },
             },
           },
         },
-      },
-      'Friend/mango.json': {
-        data: {
-          id: `${testRealmURL}Friend/mango`,
-          attributes: {
-            firstName: 'Mango',
-            description: 'Dog friend',
-          },
-          relationships: {
-            friend: {
-              links: {
-                self: `${testRealmURL}Friend/vanGogh`,
+        'Friend/mango.json': {
+          data: {
+            id: `${testRealmURL}Friend/mango`,
+            attributes: {
+              firstName: 'Mango',
+              description: 'Dog friend',
+            },
+            relationships: {
+              friend: {
+                links: {
+                  self: `${testRealmURL}Friend/vanGogh`,
+                },
               },
             },
-          },
-          meta: {
-            adoptsFrom: {
-              module: 'http://localhost:4202/test/friend',
-              name: 'Friend',
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/friend',
+                name: 'Friend',
+              },
             },
           },
         },
-      },
-      'Friend/vanGogh.json': {
-        data: {
-          id: `${testRealmURL}Friend/vanGogh`,
-          attributes: {
-            firstName: 'Van Gogh',
-            description: 'Dog friend',
-            thumbnailURL: 'van-gogh.jpg',
-          },
-          relationships: {
-            friend: {
-              links: {
-                self: null,
+        'Friend/vanGogh.json': {
+          data: {
+            id: `${testRealmURL}Friend/vanGogh`,
+            attributes: {
+              firstName: 'Van Gogh',
+              description: 'Dog friend',
+              thumbnailURL: 'van-gogh.jpg',
+            },
+            relationships: {
+              friend: {
+                links: {
+                  self: null,
+                },
               },
             },
-          },
-          meta: {
-            adoptsFrom: {
-              module: 'http://localhost:4202/test/friend',
-              name: 'Friend',
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/friend',
+                name: 'Friend',
+              },
             },
           },
         },
       },
     });
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
     let indexer = realm.searchIndex;
     let hassan = await indexer.card(new URL(`${testRealmURL}Friend/hassan`));
     if (hassan?.type === 'doc') {
@@ -1945,54 +1922,55 @@ module('Integration | search-index', function (hooks) {
   });
 
   test('can index a field with a cycle in the linksTo field', async function (assert) {
-    let adapter = new TestRealmAdapter({
-      'Friend/hassan.json': {
-        data: {
-          id: `${testRealmURL}Friend/hassan`,
-          attributes: {
-            firstName: 'Hassan',
-            description: 'Dog owner',
-          },
-          relationships: {
-            friend: {
-              links: {
-                self: `${testRealmURL}Friend/mango`,
+    let { realm, adapter } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'Friend/hassan.json': {
+          data: {
+            id: `${testRealmURL}Friend/hassan`,
+            attributes: {
+              firstName: 'Hassan',
+              description: 'Dog owner',
+            },
+            relationships: {
+              friend: {
+                links: {
+                  self: `${testRealmURL}Friend/mango`,
+                },
               },
             },
-          },
-          meta: {
-            adoptsFrom: {
-              module: 'http://localhost:4202/test/friend',
-              name: 'Friend',
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/friend',
+                name: 'Friend',
+              },
             },
           },
         },
-      },
-      'Friend/mango.json': {
-        data: {
-          id: `${testRealmURL}Friend/mango`,
-          attributes: {
-            firstName: 'Mango',
-            description: 'Dog friend',
-          },
-          relationships: {
-            friend: {
-              links: {
-                self: `${testRealmURL}Friend/hassan`,
+        'Friend/mango.json': {
+          data: {
+            id: `${testRealmURL}Friend/mango`,
+            attributes: {
+              firstName: 'Mango',
+              description: 'Dog friend',
+            },
+            relationships: {
+              friend: {
+                links: {
+                  self: `${testRealmURL}Friend/hassan`,
+                },
               },
             },
-          },
-          meta: {
-            adoptsFrom: {
-              module: 'http://localhost:4202/test/friend',
-              name: 'Friend',
+            meta: {
+              adoptsFrom: {
+                module: 'http://localhost:4202/test/friend',
+                name: 'Friend',
+              },
             },
           },
         },
       },
     });
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
     let indexer = realm.searchIndex;
     let hassan = await indexer.card(new URL(`${testRealmURL}Friend/hassan`), {
       loadLinks: true,
@@ -2211,34 +2189,35 @@ module('Integration | search-index', function (hooks) {
     let mangoID = `${testRealmURL}Friends/mango`;
     let vanGoghID = `${testRealmURL}Friends/vanGogh`;
     let friendsRef = { module: `${testModuleRealm}friends`, name: 'Friends' };
-    let adapter = new TestRealmAdapter({
-      'Friends/vanGogh.json': {
-        data: {
-          attributes: { firstName: 'Van Gogh' },
-          relationships: { 'friends.0': { links: { self: hassanID } } },
-          meta: { adoptsFrom: friendsRef },
-        },
-      },
-      'Friends/hassan.json': {
-        data: {
-          attributes: { firstName: 'Hassan' },
-          relationships: {
-            'friends.0': { links: { self: mangoID } },
-            'friends.1': { links: { self: vanGoghID } },
+    let { realm, adapter } = await setupIntegrationTestRealm({
+      loader,
+      contents: {
+        'Friends/vanGogh.json': {
+          data: {
+            attributes: { firstName: 'Van Gogh' },
+            relationships: { 'friends.0': { links: { self: hassanID } } },
+            meta: { adoptsFrom: friendsRef },
           },
-          meta: { adoptsFrom: friendsRef },
         },
-      },
-      'Friends/mango.json': {
-        data: {
-          attributes: { firstName: 'Mango' },
-          relationships: { 'friends.0': { links: { self: hassanID } } },
-          meta: { adoptsFrom: friendsRef },
+        'Friends/hassan.json': {
+          data: {
+            attributes: { firstName: 'Hassan' },
+            relationships: {
+              'friends.0': { links: { self: mangoID } },
+              'friends.1': { links: { self: vanGoghID } },
+            },
+            meta: { adoptsFrom: friendsRef },
+          },
+        },
+        'Friends/mango.json': {
+          data: {
+            attributes: { firstName: 'Mango' },
+            relationships: { 'friends.0': { links: { self: hassanID } } },
+            meta: { adoptsFrom: friendsRef },
+          },
         },
       },
     });
-    let realm = await TestRealm.createWithAdapter(adapter, loader, this.owner);
-    await realm.ready;
     let indexer = realm.searchIndex;
     assert.deepEqual(
       indexer.stats,
@@ -2626,9 +2605,9 @@ module('Integration | search-index', function (hooks) {
   });
 
   test("indexing identifies an instance's card references", async function (assert) {
-    let realm = await TestRealm.create(
+    let { realm } = await setupIntegrationTestRealm({
       loader,
-      {
+      contents: {
         'person-1.json': {
           data: {
             attributes: {
@@ -2643,9 +2622,7 @@ module('Integration | search-index', function (hooks) {
           },
         },
       },
-      this.owner,
-    );
-    await realm.ready;
+    });
     let indexer = realm.searchIndex;
     let refs = (await indexer.searchEntry(new URL(`${testRealmURL}person-1`)))
       ?.deps;
@@ -2687,9 +2664,9 @@ module('Integration | search-index', function (hooks) {
   });
 
   test('search index does not contain entries that match patterns in ignore files', async function (assert) {
-    let realm = await TestRealm.create(
+    let { realm } = await setupIntegrationTestRealm({
       loader,
-      {
+      contents: {
         'ignore-me-1.json': { data: { meta: { adoptsFrom: baseCardRef } } },
         'posts/nested.json': { data: { meta: { adoptsFrom: baseCardRef } } },
         'posts/please-ignore-me.json': {
@@ -2706,10 +2683,8 @@ dir/
 posts/please-ignore-me.json
       `,
       },
-      this.owner,
-    );
+    });
 
-    await realm.ready;
     let indexer = realm.searchIndex;
 
     {
@@ -2759,16 +2734,14 @@ posts/please-ignore-me.json
   });
 
   test('search index ignores .realm.json file', async function (assert) {
-    let realm = await TestRealm.create(
+    let { realm } = await setupIntegrationTestRealm({
       loader,
-      {
+      contents: {
         '.realm.json': `{ name: 'Example Workspace' }`,
         'post.json': { data: { meta: { adoptsFrom: baseCardRef } } },
       },
-      this.owner,
-    );
+    });
 
-    await realm.ready;
     let indexer = realm.searchIndex;
     let card = await indexer.card(new URL(`${testRealmURL}post`));
     assert.ok(card, 'instance exists');
@@ -2781,18 +2754,16 @@ posts/please-ignore-me.json
   });
 
   test("incremental indexing doesn't process ignored files", async function (assert) {
-    let realm = await TestRealm.create(
+    let { realm } = await setupIntegrationTestRealm({
       loader,
-      {
+      contents: {
         'posts/ignore-me.json': { data: { meta: { adoptsFrom: baseCardRef } } },
         '.gitignore': `
 posts/ignore-me.json
       `,
       },
-      this.owner,
-    );
+    });
 
-    await realm.ready;
     let indexer = realm.searchIndex;
     await indexer.update(new URL(`${testRealmURL}posts/ignore-me.json`));
 
@@ -3174,8 +3145,10 @@ posts/ignore-me.json
     let indexer: SearchIndex;
 
     hooks.beforeEach(async function () {
-      let realm = await TestRealm.create(loader, sampleCards, this.owner);
-      await realm.ready;
+      let { realm } = await setupIntegrationTestRealm({
+        loader,
+        contents: sampleCards,
+      });
       indexer = realm.searchIndex;
     });
 

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -1140,14 +1140,14 @@ export class Realm {
     doc: LooseSingleCardDocument,
     relativeTo: URL,
   ): Promise<LooseSingleCardDocument> {
-    let api = await this.searchIndex.loader.import<typeof CardAPI>(
+    let api = await this.loader.import<typeof CardAPI>(
       'https://cardstack.com/base/card-api',
     );
     let card = (await api.createFromSerialized(
       doc.data,
       doc,
       relativeTo,
-      this.searchIndex.loader as unknown as LoaderType,
+      this.loader as unknown as LoaderType,
     )) as CardDef;
     let data: LooseSingleCardDocument = api.serializeCard(card); // this strips out computeds
     delete data.data.id; // the ID is derived from the filename, so we don't serialize it on disk
@@ -1218,6 +1218,10 @@ export class Realm {
     waitForClose(writable);
 
     return response;
+  }
+
+  unsubscribe() {
+    this.#adapter.unsubscribe();
   }
 
   private async drainUpdates() {


### PR DESCRIPTION
This PR introduces `setupIntegrationTestRealm` and `setupAcceptanceTestRealm`, which replace `TestRealm.create` and `TestRealm.createWithAdapter` and provide a more succinct and powerful API. The new power is that the `contents` param, a list of the resources in the realm structured as map of path/value entries, can provide card JSON or definition code strings as values, like the previous version, but can also provide card instances or definition modules as values. We should prefer the latter going forward, except in cases where the specific string representation of a file is part of the test. This will give us better typechecking and make refactoring much easier.