### PR TITLE
host: Remove incorrect “Cancel” in close tooltip

### DIFF
--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -474,7 +474,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
                   />
                 </:trigger>
                 <:content>
-                  {{if (eq @item.format 'isolated') 'Close' 'Cancel & Close'}}
+                  Close
                 </:content>
               </Tooltip>
             </:actions>


### PR DESCRIPTION
This addresses this false promise, there‘s no cancellation of edits since they autosave:

![Boxel 2023-11-22 15-15-46](https://github.com/cardstack/boxel/assets/43280/f9201cc8-6d0f-44f4-bd66-1efe1fab9109)
