### PR TITLE
removing shimExternals from test that already use a loader with shimExternals init

### DIFF
--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -8,7 +8,6 @@ import {
   type LooseSingleCardDocument,
 } from '@cardstack/runtime-common';
 import { type Loader } from '@cardstack/runtime-common/loader';
-import { shimExternals } from '@cardstack/host/lib/externals';
 import type LoaderService from '@cardstack/host/services/loader-service';
 import type { OperatorModeState } from '@cardstack/host/services/operator-mode-state-service';
 import type { Submode } from '@cardstack/host/components/submode-switcher';
@@ -70,8 +69,6 @@ module('Acceptance | code submode | create-file tests', function (hooks) {
   hooks.beforeEach(async function () {
     loader = (this.owner.lookup('service:loader-service') as LoaderService)
       .loader;
-    shimExternals(loader);
-
     catalogEntry = await loader.import(`${baseRealm.url}catalog-entry`);
 
     createTestRealm = async (files) => {

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -19,7 +19,6 @@ import { baseRealm } from '@cardstack/runtime-common';
 import { cardTypeDisplayName, type CodeRef } from '@cardstack/runtime-common';
 import { Loader } from '@cardstack/runtime-common/loader';
 
-import { shimExternals } from '@cardstack/host/lib/externals';
 import type LoaderService from '@cardstack/host/services/loader-service';
 
 import {
@@ -65,7 +64,6 @@ module('Integration | card-basics', function (hooks) {
   );
 
   hooks.beforeEach(async function () {
-    shimExternals(loader);
     cardApi = await loader.import(`${baseRealm.url}card-api`);
     primitive = cardApi.primitive;
     queryableValue = cardApi.queryableValue;

--- a/packages/host/tests/integration/components/card-def-field-def-relationships-test.gts
+++ b/packages/host/tests/integration/components/card-def-field-def-relationships-test.gts
@@ -11,7 +11,6 @@ import CardPrerender from '@cardstack/host/components/card-prerender';
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
 import type LoaderService from '@cardstack/host/services/loader-service';
 import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
-import { shimExternals } from '@cardstack/host/lib/externals';
 import {
   saveCard,
   setupCardLogs,
@@ -54,7 +53,6 @@ module('Integration | CardDef-FieldDef relationships test', function (hooks) {
   hooks.beforeEach(async function () {
     loader = (this.owner.lookup('service:loader-service') as LoaderService)
       .loader;
-    shimExternals(loader);
     cardApi = await loader.import(`${baseRealm.url}card-api`);
     string = await loader.import(`${baseRealm.url}string`);
     number = await loader.import(`${baseRealm.url}number`);

--- a/packages/host/tests/integration/components/preview-test.gts
+++ b/packages/host/tests/integration/components/preview-test.gts
@@ -10,7 +10,6 @@ import { Loader } from '@cardstack/runtime-common/loader';
 
 import Preview from '@cardstack/host/components/preview';
 
-import { shimExternals } from '@cardstack/host/lib/externals';
 import type LoaderService from '@cardstack/host/services/loader-service';
 
 import { testRealmURL, shimModule } from '../../helpers';
@@ -30,7 +29,6 @@ module('Integration | preview', function (hooks) {
   hooks.beforeEach(async function () {
     loader = (this.owner.lookup('service:loader-service') as LoaderService)
       .loader;
-    shimExternals(loader);
     cardApi = await loader.import(`${baseRealm.url}card-api`);
     string = await loader.import(`${baseRealm.url}string`);
     this.owner.register('service:local-indexer', MockLocalIndexer);

--- a/packages/host/tests/integration/components/serialization-test.gts
+++ b/packages/host/tests/integration/components/serialization-test.gts
@@ -12,7 +12,6 @@ import {
 } from '@cardstack/runtime-common';
 import { Loader } from '@cardstack/runtime-common/loader';
 
-import { shimExternals } from '@cardstack/host/lib/externals';
 import type LoaderService from '@cardstack/host/services/loader-service';
 
 import { type CardDef as CardDefType } from 'https://cardstack.com/base/card-api';
@@ -44,7 +43,6 @@ module('Integration | serialization', function (hooks) {
   hooks.beforeEach(async function () {
     loader = (this.owner.lookup('service:loader-service') as LoaderService)
       .loader;
-    shimExternals(loader);
   });
 
   setupCardLogs(

--- a/packages/host/tests/integration/components/text-input-filter-test.gts
+++ b/packages/host/tests/integration/components/text-input-filter-test.gts
@@ -21,7 +21,6 @@ import CardEditor from '@cardstack/host/components/card-editor';
 
 import CardPrerender from '@cardstack/host/components/card-prerender';
 import CreateCardModal from '@cardstack/host/components/create-card-modal';
-import { shimExternals } from '@cardstack/host/lib/externals';
 import type LoaderService from '@cardstack/host/services/loader-service';
 
 import { CardDef } from 'https://cardstack.com/base/card-api';
@@ -74,7 +73,6 @@ module('Integration | text-input-filter', function (hooks) {
       new URL(baseRealm.url),
       new URL('http://localhost:4201/base/'),
     );
-    shimExternals(loader);
     cardApi = await loader.import(`${baseRealm.url}card-api`);
 
     adapter = new TestRealmAdapter({

--- a/packages/host/tests/integration/realm-test.ts
+++ b/packages/host/tests/integration/realm-test.ts
@@ -16,8 +16,6 @@ import {
 import stripScopedCSSGlimmerAttributes from '@cardstack/runtime-common/helpers/strip-scoped-css-glimmer-attributes';
 import { Loader } from '@cardstack/runtime-common/loader';
 
-import { shimExternals } from '@cardstack/host/lib/externals';
-
 import type LoaderService from '@cardstack/host/services/loader-service';
 
 import {
@@ -48,10 +46,6 @@ module('Integration | realm', function (hooks) {
     hooks,
     async () => await loader.import(`${baseRealm.url}card-api`),
   );
-
-  hooks.beforeEach(function () {
-    shimExternals(loader);
-  });
 
   test('realm can serve GET card requests', async function (assert) {
     let adapter = new TestRealmAdapter({

--- a/packages/host/tests/unit/ai-function-generation-test.ts
+++ b/packages/host/tests/unit/ai-function-generation-test.ts
@@ -11,7 +11,6 @@ import {
 } from '@cardstack/runtime-common/helpers/ai';
 import { Loader } from '@cardstack/runtime-common/loader';
 
-import { shimExternals } from '@cardstack/host/lib/externals';
 import type LoaderService from '@cardstack/host/services/loader-service';
 
 import { primitive as primitiveType } from 'https://cardstack.com/base/card-api';
@@ -42,7 +41,6 @@ module('Unit | ai-function-generation-test', function (hooks) {
       .loader;
   });
   hooks.beforeEach(async function () {
-    shimExternals(loader);
     cardApi = await loader.import(`${baseRealm.url}card-api`);
     primitive = cardApi.primitive;
     string = await loader.import(`${baseRealm.url}string`);


### PR DESCRIPTION
i dono why we ever used this. shimExternals is already called in the loader service. if there is a reason, wud appreciate feedback.

