### PR TITLE
Prevent realm info icons from flickering on loader flushes

### DIFF
--- a/packages/host/app/components/operator-mode/realm-info-provider.gts
+++ b/packages/host/app/components/operator-mode/realm-info-provider.gts
@@ -32,6 +32,7 @@ export interface Signature {
 
 export default class RealmInfoProvider extends Component<Signature> {
   @service declare realmInfoService: RealmInfoService;
+  cachedRealmInfo: RealmInfo | null = null;
 
   @use private realmInfoResource = resource(() => {
     if (!('fileURL' in this.args) && !('realmURL' in this.args)) {
@@ -50,7 +51,7 @@ export default class RealmInfoProvider extends Component<Signature> {
       load: () => Promise<void>;
     } = new TrackedObject({
       isLoading: true,
-      value: null,
+      value: this.cachedRealmInfo,
       error: undefined,
       load: async () => {
         state.isLoading = true;
@@ -59,6 +60,7 @@ export default class RealmInfoProvider extends Component<Signature> {
           let realmInfo = await this.realmInfoService.fetchRealmInfo(this.args);
 
           state.value = realmInfo;
+          this.cachedRealmInfo = realmInfo;
         } catch (error: any) {
           state.error = error;
         } finally {


### PR DESCRIPTION
This was very annoying when adding, removing, editing files... on each edit the resource would kick in, get the cached data from the service, but it would have `null` value in between, causing a quick flicker on icons all over the place. No more!

@tintinthong suggested to use the other form of resources (not this "inline" `@use` form) which would likely solve the issue too but I opted into this solution because it's easier.