### PR TITLE
host: Remove linting from test command in CI

### DIFF
--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -24,7 +24,7 @@
     "start": "FASTBOOT_DISABLED=true OWN_REALM_URL=http://localhost:4201/drafts/ OTHER_REALM_URLS=http://localhost:4201/published/ ember serve",
     "start:build": "FASTBOOT_DISABLED=true ember build --watch",
     "test": "concurrently \"npm:lint\" \"npm:test:*\" --names \"lint,test:\"",
-    "test-with-percy": "concurrently \"npm:lint\" \"percy exec -- pnpm test:wait-for-servers\" --names \"lint,test:\"",
+    "test-with-percy": "percy exec -- pnpm test:wait-for-servers",
     "test:wait-for-servers": "NODE_NO_WARNINGS=1 start-server-and-test 'pnpm run wait' 'http-get://localhost:4201/base/fields/boolean-field?acceptHeader=application%2Fvnd.card%2Bjson|http-get://localhost:4202/test/hassan?acceptHeader=application%2Fvnd.card%2Bjson' 'ember-test-pre-built'",
     "ember-test-pre-built": "ember test --path ./dist",
     "wait": "sleep 10000000"


### PR DESCRIPTION
This reduces redundancy like seen in [this run](https://github.com/cardstack/boxel/actions/runs/6973618109) where the host job fails with a linting error also covered by the failing lint job.