### PR TITLE
Capture re-exported definitions & multi-level inherited local definitions 

### DIFF
--- a/packages/drafts-realm/in-this-file.gts
+++ b/packages/drafts-realm/in-this-file.gts
@@ -12,7 +12,8 @@ export const exportedVar = 'exported var';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const localVar = 'local var';
 
-class LocalClass {}
+class LocalClass
+ {}
 
 export class ExportedClass {}
 

--- a/packages/drafts-realm/local-inherit.gts
+++ b/packages/drafts-realm/local-inherit.gts
@@ -1,0 +1,29 @@
+import {
+  contains,
+  field,
+  CardDef,
+  FieldDef,
+} from 'https://cardstack.com/base/card-api';
+
+class GrandParent extends CardDef {
+  static displayName = 'local grandparent';
+}
+
+class Parent extends GrandParent {
+  static displayName = 'local parent';
+}
+
+class Activity extends FieldDef {
+  static displayName = 'my activity';
+}
+class Hobby extends Activity {
+  static displayName = 'my hobby';
+}
+class Sport extends Hobby {
+  static displayName = 'my sport';
+}
+
+export class Child extends Parent {
+  static displayName = 'exported child';
+  @field sport = contains(Sport);
+}

--- a/packages/drafts-realm/post.gts
+++ b/packages/drafts-realm/post.gts
@@ -13,6 +13,7 @@ import { Person } from './person';
 let imageURL = new URL('./logo.png', import.meta.url).href;
 
 class BasicCard extends FieldDef {
+  static displayName = 'Basic Card';
   @field title = contains(StringCard);
   static embedded = class Embedded extends Component<typeof this> {
     <template>

--- a/packages/drafts-realm/re-export.gts
+++ b/packages/drafts-realm/re-export.gts
@@ -18,3 +18,5 @@ export * from './in-this-file'; //Will not display inside "in-this-file"
 export default NumberCard;
 
 export { Person as Human } from './person';
+
+export { default as Date } from 'https://cardstack.com/base/date';

--- a/packages/drafts-realm/re-export.gts
+++ b/packages/drafts-realm/re-export.gts
@@ -1,0 +1,18 @@
+import {
+  CardDef,
+  FieldDef,
+  BaseDef as BDef,
+  contains,
+} from 'https://cardstack.com/base/card-api';
+import StringCard from 'https://cardstack.com/base/string';
+import NumberCard from 'https://cardstack.com/base/number';
+
+export const exportedVar = 'exported var';
+
+export { StringCard as StrCard };
+
+export { FieldDef as FDef, CardDef, contains, BDef };
+
+export * from './in-this-file';
+
+export default NumberCard;

--- a/packages/drafts-realm/re-export.gts
+++ b/packages/drafts-realm/re-export.gts
@@ -13,6 +13,8 @@ export { StringCard as StrCard };
 
 export { FieldDef as FDef, CardDef, contains, BDef };
 
-export * from './in-this-file';
+export * from './in-this-file'; //Will not display inside "in-this-file"
 
 export default NumberCard;
+
+export { Person as Human } from './person';

--- a/packages/host/app/components/operator-mode/card-adoption-chain.gts
+++ b/packages/host/app/components/operator-mode/card-adoption-chain.gts
@@ -21,8 +21,8 @@ interface Signature {
     cardInheritanceChain: CardInheritance[];
     moduleSyntax: ModuleSyntax;
     openDefinition: (
-      moduleHref: string,
       codeRef: ResolvedCodeRef | undefined,
+      localName: string | undefined,
     ) => void;
   };
 }

--- a/packages/host/app/components/operator-mode/card-schema-editor.gts
+++ b/packages/host/app/components/operator-mode/card-schema-editor.gts
@@ -51,8 +51,8 @@ interface Signature {
     childFields: string[];
     parentFields: string[];
     openDefinition: (
-      moduleHref: string,
       codeRef: ResolvedCodeRef | undefined,
+      localName: string | undefined,
     ) => void;
   };
 }
@@ -251,7 +251,7 @@ export default class CardSchemaEditor extends Component<Signature> {
           <Tooltip @placement='bottom'>
             <:trigger>
               <Pill
-                {{on 'click' (fn @openDefinition @cardType.module codeRef)}}
+                {{on 'click' (fn @openDefinition codeRef @cardType.localName)}}
                 data-test-card-schema-navigational-button
               >
                 <:icon>
@@ -337,7 +337,7 @@ export default class CardSchemaEditor extends Component<Signature> {
                           <Pill
                             {{on
                               'click'
-                              (fn @openDefinition moduleUrl codeRef)
+                              (fn @openDefinition codeRef field.card.localName)
                             }}
                             data-test-card-schema-field-navigational-button
                           >

--- a/packages/host/app/components/operator-mode/code-editor.gts
+++ b/packages/host/app/components/operator-mode/code-editor.gts
@@ -161,7 +161,7 @@ export default class CodeEditor extends Component<Signature> {
         //capturing position of named export declarations
         //this will always divert to the end of the specifier
         let specifier = declaration.path?.node.specifiers.find(
-          (specifier) => getName(specifier.exported) === declaration.exportedAs,
+          (specifier) => getName(specifier.exported) === declaration.exportName,
         );
         if (
           specifier &&

--- a/packages/host/app/components/operator-mode/code-editor.gts
+++ b/packages/host/app/components/operator-mode/code-editor.gts
@@ -14,6 +14,7 @@ import { Position } from 'monaco-editor';
 import { LoadingIndicator } from '@cardstack/boxel-ui/components';
 
 import { logger } from '@cardstack/runtime-common';
+import { getName } from '@cardstack/runtime-common/schema-analysis-plugin';
 
 import monacoModifier from '@cardstack/host/modifiers/monaco';
 import { isReady, type FileResource } from '@cardstack/host/resources/file';
@@ -148,6 +149,34 @@ export default class CodeEditor extends Component<Signature> {
       ) {
         this.monacoService.updateCursorPosition(
           new Position(start.line, start.column),
+        );
+      }
+    } else if (
+      declaration.path?.node &&
+      'loc' in declaration.path?.node &&
+      declaration.path.node.loc
+    ) {
+      //This is a fallback path if we cannot find declaration / code for element
+      if (declaration.path?.isExportNamedDeclaration()) {
+        //capturing position of named export declarations
+        //this will always divert to the end of the specifier
+        let specifier = declaration.path?.node.specifiers.find(
+          (specifier) => getName(specifier.exported) === declaration.exportedAs,
+        );
+        if (
+          specifier &&
+          specifier.exported.loc !== null &&
+          specifier.exported.loc !== undefined
+        ) {
+          let { start, end } = specifier.exported.loc;
+          this.monacoService.updateCursorPosition(
+            new Position(start.line, end.column + 1), //need to +1 for specifier positions
+          );
+        }
+      } else if (declaration.path.isExportDefaultDeclaration()) {
+        let { start, end } = declaration.path.node.loc;
+        this.monacoService.updateCursorPosition(
+          new Position(start.line, end.column),
         );
       }
     }

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -376,11 +376,19 @@ export default class CodeSubmode extends Component<Signature> {
   }
 
   @action
-  openDefinition(moduleHref: string, codeRef: ResolvedCodeRef | undefined) {
+  openDefinition(
+    codeRef: ResolvedCodeRef | undefined,
+    localName: string | undefined,
+  ) {
     if (codeRef) {
       this.operatorModeStateService.updateCodeRefSelection(codeRef);
+      this.operatorModeStateService.updateCodePath(new URL(codeRef.module));
+    } else if (localName) {
+      this.operatorModeStateService.updateLocalNameSelection(localName);
+      this.updateCursorByDeclaration?.(this.selectedDeclaration!);
+    } else {
+      console.log('No reference to codeRef or name found within module');
     }
-    this.operatorModeStateService.updateCodePath(new URL(moduleHref));
   }
 
   private onCardChange = () => {

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -343,7 +343,7 @@ export default class CodeSubmode extends Component<Signature> {
       let codeRef = this.operatorModeStateService.state.codeSelection?.codeRef;
       if (isCardOrFieldDeclaration(dec) && codeRef) {
         return (
-          dec.exportedAs === codeRef.name || dec.localName === codeRef.name
+          dec.exportName === codeRef.name || dec.localName === codeRef.name
         );
       }
       return false;

--- a/packages/host/app/components/operator-mode/definition-container/clickable.gts
+++ b/packages/host/app/components/operator-mode/definition-container/clickable.gts
@@ -5,11 +5,11 @@ import { type ResolvedCodeRef } from '@cardstack/runtime-common/code-ref';
 
 export interface ClickableArgs {
   openDefinition: (
-    moduleHref: string,
     codeRef: ResolvedCodeRef | undefined,
+    localName: string | undefined,
   ) => void;
-  moduleHref: string;
   codeRef?: ResolvedCodeRef;
+  localName?: string;
 }
 
 interface ClickableSignature {
@@ -23,9 +23,7 @@ interface ClickableSignature {
 export class Clickable extends Component<ClickableSignature> {
   @action
   handleClick() {
-    if (this.args.codeRef) {
-      this.args.openDefinition(this.args.moduleHref, this.args.codeRef);
-    }
+    this.args.openDefinition(this.args.codeRef, this.args.localName);
   }
   <template>
     <button

--- a/packages/host/app/components/operator-mode/definition-container/index.gts
+++ b/packages/host/app/components/operator-mode/definition-container/index.gts
@@ -91,9 +91,9 @@ export class ClickableModuleDefinitionContainer extends Component<ClickableModul
   <template>
     <Clickable
       @openDefinition={{@openDefinition}}
-      @moduleHref={{@moduleHref}}
       @codeRef={{@codeRef}}
-      data-test-definition-container={{@moduleHref}}
+      @localName={{@localName}}
+      data-test-clickable-definition-container
     >
       <BaseDefinitionContainer
         @title={{@title}}

--- a/packages/host/app/components/operator-mode/detail-panel-selector.gts
+++ b/packages/host/app/components/operator-mode/detail-panel-selector.gts
@@ -21,7 +21,9 @@ import scrollIntoViewModifier from '@cardstack/host/modifiers/scroll-into-view';
 import {
   type ModuleDeclaration,
   isCardOrFieldDeclaration,
+  isReexportCardOrField,
 } from '@cardstack/host/resources/module-contents';
+import { BaseDef } from 'https://cardstack.com/base/card-api';
 
 interface SelectorItemOptions {
   action: Function;
@@ -78,6 +80,19 @@ interface Signature {
   Blocks: EmptyObject;
 }
 
+function typeOfCardOrField(cardOrField: typeof BaseDef) {
+  if (isCardDef(cardOrField)) {
+    return 'card';
+  } else if (isFieldDef(cardOrField)) {
+    return 'field';
+  } else if (isBaseDef(cardOrField)) {
+    return 'base';
+  }
+  throw new Error(
+    `in-this-file panel: declaration should either be card, field, or base.`,
+  );
+}
+
 export default class Selector extends Component<Signature> {
   @action invokeSelectorItemAction(
     action: unknown,
@@ -93,21 +108,16 @@ export default class Selector extends Component<Signature> {
   }
 
   getType(declaration: ModuleDeclaration) {
-    let type = declaration.type as string;
     if (isCardOrFieldDeclaration(declaration)) {
-      if (isCardDef(declaration.cardOrField)) {
-        type = 'card';
-      } else if (isFieldDef(declaration.cardOrField)) {
-        type = 'field';
-      } else if (isBaseDef(declaration.cardOrField)) {
-        type = 'base';
-      } else {
-        throw new Error(
-          'card or field declaration does not have an appropriate type',
-        );
-      }
+      return typeOfCardOrField(declaration.cardOrField);
+    } else if (isReexportCardOrField(declaration)) {
+      return typeOfCardOrField(declaration.cardOrField);
+    } else if (declaration.type === 'class') {
+      return 'class';
+    } else if (declaration.type === 'function') {
+      return 'function';
     }
-    return type;
+    return '';
   }
 
   <template>

--- a/packages/host/app/components/operator-mode/detail-panel-selector.gts
+++ b/packages/host/app/components/operator-mode/detail-panel-selector.gts
@@ -155,16 +155,16 @@ export default class Selector extends Component<Signature> {
                   disabled={{selectorItem.disabled}}
                 >
                   <div class='selector-item'>
-                    {{#if selectorItem.declaration.exportedAs}}
+                    {{#if selectorItem.declaration.exportName}}
                       <span class='exported-arrow'>
                         <DiagonalArrowLeftUp width='20' height='20' />
                       </span>
                       <span
                         class='exported'
-                      >{{selectorItem.declaration.exportedAs}}</span>
+                      >{{selectorItem.declaration.exportName}}</span>
                       {{#unless
                         (eq
-                          selectorItem.declaration.exportedAs
+                          selectorItem.declaration.exportName
                           selectorItem.declaration.localName
                         )
                       }}<span

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -105,10 +105,6 @@ export default class DetailPanel extends Component<Signature> {
     );
   }
 
-  get showDetailsPanel() {
-    return this.isBinary || this.isNonCardJson;
-  }
-
   get cardType() {
     if (
       this.args.selectedDeclaration &&
@@ -149,17 +145,6 @@ export default class DetailPanel extends Component<Signature> {
 
   get isModule() {
     return hasExecutableExtension(this.args.readyFile.url);
-  }
-
-  get isBinary() {
-    return this.args.readyFile.isBinary;
-  }
-
-  private get isNonCardJson() {
-    return (
-      this.args.readyFile.url.endsWith('.json') &&
-      !isCardDocumentString(this.args.readyFile.content)
-    );
   }
 
   private get fileExtension() {
@@ -330,7 +315,7 @@ export default class DetailPanel extends Component<Signature> {
             {{/if}}
 
           </div>
-        {{else if this.showDetailsPanel}}
+        {{else}}
           <div class='details-panel'>
             <header class='panel-header' aria-label='Details Panel Header'>
               Details

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -16,8 +16,6 @@ import {
   LoadingIndicator,
 } from '@cardstack/boxel-ui/components';
 
-import { or, and } from '@cardstack/boxel-ui/helpers';
-
 import { IconInherit, IconTrash } from '@cardstack/boxel-ui/icons';
 
 import {
@@ -26,7 +24,11 @@ import {
   isCardDocumentString,
 } from '@cardstack/runtime-common';
 
-import { isCardDef, isFieldDef } from '@cardstack/runtime-common/code-ref';
+import {
+  isCardDef,
+  isFieldDef,
+  isBaseDef,
+} from '@cardstack/runtime-common/code-ref';
 
 import { type ResolvedCodeRef } from '@cardstack/runtime-common/code-ref';
 
@@ -36,6 +38,7 @@ import { type Ready } from '@cardstack/host/resources/file';
 import {
   type ModuleDeclaration,
   isCardOrFieldDeclaration,
+  isReexportCardOrField,
 } from '@cardstack/host/resources/module-contents';
 
 import {
@@ -67,8 +70,8 @@ interface Signature {
     declarations: ModuleDeclaration[];
     selectDeclaration: (dec: ModuleDeclaration) => void;
     openDefinition: (
-      moduleHref: string,
       codeRef: ResolvedCodeRef | undefined,
+      localName: string | undefined,
     ) => void;
     delete: (
       card: CardDef | typeof CardDef | undefined,
@@ -88,10 +91,29 @@ export default class DetailPanel extends Component<Signature> {
     return undefined;
   });
 
+  get showInThisFilePanel() {
+    return this.isModule && this.args.declarations.length > 0;
+  }
+
+  get showInheritancePanel() {
+    return (
+      (this.isModule &&
+        this.args.selectedDeclaration &&
+        (isCardOrFieldDeclaration(this.args.selectedDeclaration) ||
+          isReexportCardOrField(this.args.selectedDeclaration))) ||
+      this.isCardInstance
+    );
+  }
+
+  get showDetailsPanel() {
+    return this.isBinary || this.isNonCardJson;
+  }
+
   get cardType() {
     if (
       this.args.selectedDeclaration &&
-      isCardOrFieldDeclaration(this.args.selectedDeclaration)
+      (isCardOrFieldDeclaration(this.args.selectedDeclaration) ||
+        isReexportCardOrField(this.args.selectedDeclaration))
     ) {
       return this.args.selectedDeclaration.cardType;
     }
@@ -129,28 +151,15 @@ export default class DetailPanel extends Component<Signature> {
     return hasExecutableExtension(this.args.readyFile.url);
   }
 
-  get isField() {
-    if (
-      this.args.selectedDeclaration &&
-      isCardOrFieldDeclaration(this.args.selectedDeclaration)
-    ) {
-      return (
-        this.isModule && isFieldDef(this.args.selectedDeclaration?.cardOrField)
-      );
-    }
-    return false;
+  get isBinary() {
+    return this.args.readyFile.isBinary;
   }
 
-  get isCard() {
-    if (
-      this.args.selectedDeclaration &&
-      isCardOrFieldDeclaration(this.args.selectedDeclaration)
-    ) {
-      return (
-        this.isModule && isCardDef(this.args.selectedDeclaration?.cardOrField)
-      );
-    }
-    return false;
+  private get isNonCardJson() {
+    return (
+      this.args.readyFile.url.endsWith('.json') &&
+      !isCardDocumentString(this.args.readyFile.content)
+    );
   }
 
   private get fileExtension() {
@@ -179,11 +188,7 @@ export default class DetailPanel extends Component<Signature> {
     });
   }
 
-  get numberOfElementsGreaterThanZero() {
-    return this.args.declarations.length > 0;
-  }
-
-  get numberOfElementsInFileString() {
+  get numberOfItems() {
     let numberOfElements = this.args.declarations.length || 0;
     return `${numberOfElements} ${getPlural('item', numberOfElements)}`;
   }
@@ -195,13 +200,13 @@ export default class DetailPanel extends Component<Signature> {
           <LoadingIndicator />
         </div>
       {{else}}
-        {{#if (and this.isModule this.numberOfElementsGreaterThanZero)}}
+        {{#if this.showInThisFilePanel}}
           <div class='in-this-file-panel'>
             <div class='in-this-file-panel-banner'>
               <header class='panel-header' aria-label='In This File Header'>
                 In This File
               </header>
-              <span class='number-items'>{{this.numberOfElementsInFileString}}
+              <span class='number-items'>{{this.numberOfItems}}
               </span>
             </div>
             <CardContainer class='in-this-file-card-container'>
@@ -220,7 +225,7 @@ export default class DetailPanel extends Component<Signature> {
           </div>
         {{/if}}
 
-        {{#if (or this.isCardInstance this.isCard this.isField)}}
+        {{#if this.showInheritancePanel}}
           <div class='inheritance-panel'>
             <header
               class='panel-header'
@@ -261,87 +266,71 @@ export default class DetailPanel extends Component<Signature> {
                     @name={{this.cardInstanceType.type.displayName}}
                     @fileExtension={{this.cardInstanceType.type.moduleInfo.extension}}
                     @openDefinition={{@openDefinition}}
-                    @moduleHref={{this.cardInstanceType.type.module}}
                     @codeRef={{codeRef}}
                   />
                 {{/let}}
               {{/if}}
+            {{else if @selectedDeclaration}}
+              {{! Module case when selection exists}}
+              {{#let
+                (getDefinitionTitle @selectedDeclaration)
+                as |definitionTitle|
+              }}
+                {{#if (isCardOrFieldDeclaration @selectedDeclaration)}}
 
-            {{else if this.isField}}
-              {{#let 'Field Definition' as |definitionTitle|}}
-                <ModuleDefinitionContainer
-                  @title={{definitionTitle}}
-                  @fileURL={{this.cardType.type.module}}
-                  @name={{this.cardType.type.displayName}}
-                  @fileExtension={{this.cardType.type.moduleInfo.extension}}
-                  @infoText={{this.lastModified.value}}
-                  @isActive={{true}}
-                  @actions={{array
-                    (hash label='Delete' handler=@delete icon=IconTrash)
-                  }}
-                />
-                {{#if this.cardType.type.super}}
-                  {{#let (getCodeRef this.cardType.type.super) as |codeRef|}}
-                    <div class='chain'>
-                      <IconInherit
-                        class='chain-icon'
-                        width='24px'
-                        height='24px'
-                        role='presentation'
+                  <ModuleDefinitionContainer
+                    @title={{definitionTitle}}
+                    @fileURL={{this.cardType.type.module}}
+                    @name={{this.cardType.type.displayName}}
+                    @fileExtension={{this.cardType.type.moduleInfo.extension}}
+                    @infoText={{this.lastModified.value}}
+                    @isActive={{true}}
+                    @actions={{array
+                      (hash label='Delete' handler=@delete icon=IconTrash)
+                    }}
+                  />
+                  {{#if this.cardType.type.super}}
+                    {{#let (getCodeRef this.cardType.type.super) as |codeRef|}}
+                      <div class='chain'>
+                        <IconInherit
+                          class='chain-icon'
+                          width='24px'
+                          height='24px'
+                          role='presentation'
+                        />
+                        Inherits from
+                      </div>
+                      <ClickableModuleDefinitionContainer
+                        @title={{definitionTitle}}
+                        @fileURL={{this.cardType.type.super.module}}
+                        @name={{this.cardType.type.super.displayName}}
+                        @fileExtension={{this.cardType.type.super.moduleInfo.extension}}
+                        @openDefinition={{@openDefinition}}
+                        @codeRef={{codeRef}}
+                        @localName={{this.cardType.type.super.localName}}
                       />
-                      Inherits from
-                    </div>
-                    <ClickableModuleDefinitionContainer
-                      @title={{definitionTitle}}
-                      @fileURL={{this.cardType.type.super.module}}
-                      @name={{this.cardType.type.super.displayName}}
-                      @fileExtension={{this.cardType.type.super.moduleInfo.extension}}
-                      @openDefinition={{@openDefinition}}
-                      @moduleHref={{this.cardType.type.super.module}}
-                      @codeRef={{codeRef}}
-                    />
-                  {{/let}}
-                {{/if}}
-              {{/let}}
-            {{else if this.isCard}}
-              {{#let 'Card Definition' as |definitionTitle|}}
-                <ModuleDefinitionContainer
-                  @title={{definitionTitle}}
-                  @fileURL={{this.cardType.type.module}}
-                  @name={{this.cardType.type.displayName}}
-                  @fileExtension={{this.cardType.type.moduleInfo.extension}}
-                  @infoText={{this.lastModified.value}}
-                  @isActive={{true}}
-                  @actions={{array
-                    (hash label='Delete' handler=@delete icon=IconTrash)
-                  }}
-                />
-                {{#if this.cardType.type.super}}
-                  {{#let (getCodeRef this.cardType.type.super) as |codeRef|}}
-                    <div class='chain'>
-                      <IconInherit
-                        class='chain-icon'
-                        width='24px'
-                        height='24px'
-                        role='presentation'
+                    {{/let}}
+                  {{/if}}
+                {{else if (isReexportCardOrField @selectedDeclaration)}}
+                  {{#if this.cardType.type}}
+                    {{#let (getCodeRef this.cardType.type) as |codeRef|}}
+                      <ClickableModuleDefinitionContainer
+                        @title={{definitionTitle}}
+                        @fileURL={{this.cardType.type.module}}
+                        @name={{this.cardType.type.displayName}}
+                        @fileExtension={{this.cardType.type.moduleInfo.extension}}
+                        @openDefinition={{@openDefinition}}
+                        @codeRef={{codeRef}}
+                        @localName={{this.cardType.type.localName}}
                       />
-                      Inherits from
-                    </div>
-                    <ClickableModuleDefinitionContainer
-                      @title={{definitionTitle}}
-                      @fileURL={{this.cardType.type.super.module}}
-                      @name={{this.cardType.type.super.displayName}}
-                      @fileExtension={{this.cardType.type.super.moduleInfo.extension}}
-                      @openDefinition={{@openDefinition}}
-                      @moduleHref={{this.cardType.type.super.module}}
-                      @codeRef={{codeRef}}
-                    />
-                  {{/let}}
+                    {{/let}}
+                  {{/if}}
                 {{/if}}
               {{/let}}
             {{/if}}
+
           </div>
-        {{else}}
+        {{else if this.showDetailsPanel}}
           <div class='details-panel'>
             <header class='panel-header' aria-label='Details Panel Header'>
               Details
@@ -418,4 +407,26 @@ export default class DetailPanel extends Component<Signature> {
       }
     </style>
   </template>
+}
+
+function getDefinitionTitle(declaration: ModuleDeclaration) {
+  if (isCardOrFieldDeclaration(declaration)) {
+    if (isCardDef(declaration.cardOrField)) {
+      return 'Card Definition';
+    } else if (isFieldDef(declaration.cardOrField)) {
+      return 'Field Definition';
+    } else if (isBaseDef(declaration.cardOrField)) {
+      return 'Base Definition';
+    }
+  }
+  if (isReexportCardOrField(declaration)) {
+    if (isCardDef(declaration.cardOrField)) {
+      return 'Re-exported Card Definition';
+    } else if (isFieldDef(declaration.cardOrField)) {
+      return 'Re-exported Field Definition';
+    } else if (isBaseDef(declaration.cardOrField)) {
+      return 'Re-exported Base Definition';
+    }
+  }
+  return '';
 }

--- a/packages/host/app/components/operator-mode/schema-editor-column.gts
+++ b/packages/host/app/components/operator-mode/schema-editor-column.gts
@@ -31,8 +31,8 @@ interface Signature {
     cardTypeResource?: CardType;
     card: typeof BaseDef;
     openDefinition: (
-      moduleHref: string,
       codeRef: ResolvedCodeRef | undefined,
+      localName: string | undefined,
     ) => void;
   };
 }

--- a/packages/host/app/resources/card-type.ts
+++ b/packages/host/app/resources/card-type.ts
@@ -43,6 +43,7 @@ interface Args {
 
 export type CodeRefType = CodeRef & {
   displayName: string;
+  localName: string;
 };
 
 export interface FieldOfType {
@@ -60,6 +61,7 @@ export interface Type {
   fields: FieldOfType[];
   codeRef: CodeRef;
   moduleInfo: ModuleInfo;
+  localName: string;
 }
 
 interface ModuleInfo {
@@ -107,6 +109,7 @@ export class CardType extends Resource<Args> {
       return {
         ...ref,
         displayName: card.prototype.constructor.displayName,
+        localName: card.name,
       };
     }
     let id = internalKeyFor(ref, undefined);
@@ -159,6 +162,7 @@ export class CardType extends Resource<Args> {
       fields: fieldTypes,
       moduleInfo,
       codeRef: ref,
+      localName: card.name,
     };
     this.typeCache.set(id, type);
     return type;
@@ -212,7 +216,9 @@ export function getCardType(
 }
 
 function isCodeRefType(type: any): type is CodeRefType {
-  return type && isCodeRef(type) && 'displayName' in type;
+  return (
+    type && isCodeRef(type) && 'displayName' in type && 'localName' in type
+  );
 }
 
 export function isFieldOfType(obj: any): obj is FieldOfType {

--- a/packages/host/app/resources/import.ts
+++ b/packages/host/app/resources/import.ts
@@ -4,7 +4,7 @@ import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 import { Resource } from 'ember-resources';
 
-import { isBaseDef, logger } from '@cardstack/runtime-common';
+import { logger } from '@cardstack/runtime-common';
 import { Loader } from '@cardstack/runtime-common/loader';
 
 import type LoaderService from '../services/loader-service';
@@ -27,10 +27,6 @@ export class ImportResource extends Resource<Args> {
 
   get loaded() {
     return this.#loaded;
-  }
-
-  get cardsOrFieldsFromModule() {
-    return Object.values(this.module || {}).filter(isBaseDef);
   }
 
   private load = task(async (url: string, loader: Loader) => {

--- a/packages/host/app/resources/module-contents.ts
+++ b/packages/host/app/resources/module-contents.ts
@@ -183,7 +183,7 @@ function getExportedCardsOrFields(moduleProxy: object) {
 
 function collectLocalCardsOrFields(
   moduleSyntax: ModuleSyntax,
-  exportedCardsOrFields: any,
+  exportedCardsOrFields: Map<string, typeof BaseDef>,
 ): Map<PossibleCardOrFieldDeclaration, typeof BaseDef> {
   const localCardsOrFields: Map<
     PossibleCardOrFieldDeclaration,
@@ -192,21 +192,23 @@ function collectLocalCardsOrFields(
   let possibleCardsOrFields = moduleSyntax.possibleCardsOrFields;
 
   for (const value of moduleSyntax.declarations) {
-    const cardOrField = exportedCardsOrFields.get(value.localName);
+    if (value.localName !== undefined) {
+      const cardOrField = exportedCardsOrFields.get(value.localName);
 
-    if (cardOrField !== undefined) {
-      findLocalAncestor(
-        value,
-        cardOrField,
-        possibleCardsOrFields,
-        localCardsOrFields,
-      );
-      findLocalField(
-        value,
-        cardOrField,
-        possibleCardsOrFields,
-        localCardsOrFields,
-      );
+      if (cardOrField !== undefined) {
+        findLocalAncestor(
+          value,
+          cardOrField,
+          possibleCardsOrFields,
+          localCardsOrFields,
+        );
+        findLocalField(
+          value,
+          cardOrField,
+          possibleCardsOrFields,
+          localCardsOrFields,
+        );
+      }
     }
   }
 

--- a/packages/host/app/resources/module-contents.ts
+++ b/packages/host/app/resources/module-contents.ts
@@ -118,8 +118,8 @@ export class ModuleContentsResource extends Resource<Args> {
     this._declarations = [];
     moduleSyntax.declarations.forEach((value: Declaration) => {
       if (value.type === 'possibleCardOrField') {
-        let cardOrField = value.exportedAs
-          ? exportedCardsOrFields.get(value.exportedAs)
+        let cardOrField = value.exportName
+          ? exportedCardsOrFields.get(value.exportName)
           : localCardsOrFields.get(value);
         if (cardOrField !== undefined) {
           this._declarations.push({
@@ -130,18 +130,18 @@ export class ModuleContentsResource extends Resource<Args> {
           return;
         }
         // case where things statically look like cards or fields but are not
-        if (value.exportedAs !== undefined) {
+        if (value.exportName !== undefined) {
           this._declarations.push({
             localName: value.localName,
-            exportedAs: value.exportedAs,
+            exportName: value.exportName,
             path: value.path,
             type: 'class',
           } as ClassDeclaration);
         }
       } else if (value.type === 'reexport') {
         let cardOrField: typeof BaseDef | undefined;
-        if (value.exportedAs) {
-          let foundCardOrField = exportedCardsOrFields.get(value.exportedAs);
+        if (value.exportName) {
+          let foundCardOrField = exportedCardsOrFields.get(value.exportName);
           if (foundCardOrField) {
             cardOrField = foundCardOrField;
           }
@@ -154,7 +154,7 @@ export class ModuleContentsResource extends Resource<Args> {
           }
         }
       } else if (value.type === 'class' || value.type === 'function') {
-        if (value.exportedAs !== undefined) {
+        if (value.exportName !== undefined) {
           this.declarations.push(value as ModuleDeclaration);
         }
       }

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -934,7 +934,6 @@ module('Acceptance | code submode tests', function (hooks) {
         operatorModeStateParam,
       )}`,
     );
-    debugger;
 
     await waitFor('[data-test-file-incompatibility-message]');
     assert

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -1185,7 +1185,7 @@ module('Acceptance | code submode tests', function (hooks) {
       'cursor is at Employee declaration',
     );
 
-    await click(`[data-test-definition-container="${testRealmURL}person"]`);
+    await click(`[data-test-clickable-definition-container`);
     await waitFor(`[data-boxel-selector-item-text="Person"]`);
     await waitUntil(() => monacoService.hasFocus);
     lineCursorOn = monacoService.getLineCursorOn();

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -934,6 +934,7 @@ module('Acceptance | code submode tests', function (hooks) {
         operatorModeStateParam,
       )}`,
     );
+    debugger;
 
     await waitFor('[data-test-file-incompatibility-message]');
     assert

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -318,6 +318,7 @@ const reExportSource = `
   export * from './in-this-file'; //Will not display inside "in-this-file"
 
   export default NumberCard;
+  export { Person as Human } from './person';
 `;
 
 const localInheritSource = `
@@ -1273,6 +1274,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
       'CardDef card',
       'BDef base',
       'default (NumberCard) field',
+      'Human (Person) card',
     ];
     expectedElementNames.forEach(async (elementName, index) => {
       await waitFor(
@@ -1282,11 +1284,12 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
         .dom(`[data-test-boxel-selector-item]:nth-of-type(${index + 1})`)
         .hasText(elementName);
     });
-    assert.dom('[data-test-boxel-selector-item]').exists({ count: 5 });
+    assert.dom('[data-test-boxel-selector-item]').exists({ count: 6 });
 
     //clicking on a base card
     elementName = 'BDef';
     await click(`[data-test-boxel-selector-item-text="${elementName}"]`);
+    await waitFor('[data-test-boxel-selector-item-selected]');
     assert
       .dom('[data-test-boxel-selector-item-selected]')
       .hasText(`${elementName} base`);
@@ -1297,6 +1300,26 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
       .includesText('Re-exported Base Definition');
     assert.dom('[data-test-card-module-definition]').includesText('Base');
     assert.true(monacoService.getLineCursorOn()?.includes('BDef'));
+    assert
+      .dom('[data-test-file-incompatibility-message]')
+      .hasText(
+        'No tools are available to be used with these file contents. Choose a module that has a card or field definition inside of it.',
+      );
+
+    //clicking on re-export (which doesn't enter module scope)
+    elementName = 'Person';
+    await click(`[data-test-boxel-selector-item-text="${elementName}"]`);
+    await waitFor('[data-test-boxel-selector-item-selected]');
+    assert
+      .dom('[data-test-boxel-selector-item-selected]')
+      .hasText(`Human (${elementName}) card`);
+    assert.dom('[data-test-inheritance-panel-header]').exists();
+    assert.dom('[data-test-card-module-definition]').exists();
+    assert
+      .dom('[data-test-definition-header]')
+      .includesText('Re-exported Card Definition');
+    assert.dom('[data-test-card-module-definition]').includesText('Card');
+    assert.true(monacoService.getLineCursorOn()?.includes('Human'));
     assert
       .dom('[data-test-file-incompatibility-message]')
       .hasText(

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -319,6 +319,8 @@ const reExportSource = `
 
   export default NumberCard;
   export { Person as Human } from './person';
+
+  export { default as Date } from 'https://cardstack.com/base/date';
 `;
 
 const localInheritSource = `
@@ -1275,6 +1277,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
       'BDef base',
       'default (NumberCard) field',
       'Human (Person) card',
+      'Date (default) field',
     ];
     expectedElementNames.forEach(async (elementName, index) => {
       await waitFor(
@@ -1284,7 +1287,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
         .dom(`[data-test-boxel-selector-item]:nth-of-type(${index + 1})`)
         .hasText(elementName);
     });
-    assert.dom('[data-test-boxel-selector-item]').exists({ count: 6 });
+    assert.dom('[data-test-boxel-selector-item]').exists({ count: 7 });
 
     //clicking on a base card
     elementName = 'BDef';

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -299,6 +299,59 @@ const importsSource = `
   }
 `;
 
+const reExportSource = `
+  import {
+    CardDef,
+    FieldDef,
+    BaseDef as BDef,
+    contains,
+  } from 'https://cardstack.com/base/card-api';
+  import StringCard from 'https://cardstack.com/base/string';
+  import NumberCard from 'https://cardstack.com/base/number';
+
+  export const exportedVar = 'exported var';
+
+  export { StringCard as StrCard };
+
+  export { FieldDef as FDef, CardDef, contains, BDef };
+
+  export * from './in-this-file'; //Will not display inside "in-this-file"
+
+  export default NumberCard;
+`;
+
+const localInheritSource = `
+  import {
+    contains,
+    field,
+    CardDef,
+    FieldDef,
+  } from 'https://cardstack.com/base/card-api';
+
+  class GrandParent extends CardDef {
+    static displayName = 'local grandparent';
+  }
+
+  class Parent extends GrandParent {
+    static displayName = 'local parent';
+  }
+
+  class Activity extends FieldDef {
+    static displayName = 'my activity';
+  }
+  class Hobby extends Activity {
+    static displayName = 'my hobby';
+  }
+  class Sport extends Hobby {
+    static displayName = 'my sport';
+  }
+
+  export class Child extends Parent {
+    static displayName = 'exported child';
+    @field sport = contains(Sport);
+  }
+`;
+
 module('Acceptance | code submode | inspector tests', function (hooks) {
   let realm: Realm;
   let adapter: TestRealmAdapter;
@@ -334,6 +387,8 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
         'exports.gts': exportsSource,
         'special-exports.gts': specialExportsSource,
         'imports.gts': importsSource,
+        're-export.gts': reExportSource,
+        'local-inherit.gts': localInheritSource,
         'person-entry.json': {
           data: {
             type: 'card',
@@ -871,8 +926,8 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
       submode: Submodes.Code,
     });
     let selected = 'AncestorCard2 card';
-    await waitFor(`[data-test-definition-container]`);
-    await click(`[data-test-definition-container]`);
+    await waitFor(`[data-test-clickable-definition-container]`);
+    await click(`[data-test-clickable-definition-container]`);
     await waitFor('[data-test-boxel-selector-item-selected]');
     assert.dom('[data-test-boxel-selector-item-selected]').hasText(selected);
 
@@ -897,8 +952,8 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
       submode: Submodes.Code,
     });
     selected = 'default (DefaultAncestorCard) card';
-    await waitFor(`[data-test-definition-container]`);
-    await click(`[data-test-definition-container]`);
+    await waitFor(`[data-test-clickable-definition-container]`);
+    await click(`[data-test-clickable-definition-container]`);
     await waitFor('[data-test-boxel-selector-item-selected]');
     assert.dom('[data-test-boxel-selector-item-selected]').hasText(selected);
 
@@ -922,8 +977,8 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
       submode: Submodes.Code,
     });
     selected = 'RenamedAncestorCard (AncestorCard) card';
-    await waitFor(`[data-test-definition-container]`);
-    await click(`[data-test-definition-container]`);
+    await waitFor(`[data-test-clickable-definition-container]`);
+    await click(`[data-test-clickable-definition-container]`);
     await waitFor('[data-test-boxel-selector-item-selected]');
     assert.dom('[data-test-boxel-selector-item-selected]').hasText(selected);
 
@@ -947,7 +1002,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
       submode: Submodes.Code,
     });
     selected = 'AncestorCard3 card';
-    await click(`[data-test-definition-container]`);
+    await click(`[data-test-clickable-definition-container]`);
     await waitFor('[data-test-boxel-selector-item-selected]');
     assert.dom('[data-test-boxel-selector-item-selected]').hasText(selected);
 
@@ -973,8 +1028,8 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
       submode: Submodes.Code,
     });
     selected = 'ChildCard2 card';
-    await waitFor(`[data-test-definition-container]`);
-    await click(`[data-test-definition-container]`);
+    await waitFor(`[data-test-clickable-definition-container]`);
+    await click(`[data-test-clickable-definition-container]`);
     await waitFor('[data-test-boxel-selector-item-selected]');
 
     assert.dom('[data-test-boxel-selector-item-selected]').hasText(selected);
@@ -1000,7 +1055,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
       submode: Submodes.Code,
     });
     selected = 'AncestorField1 field';
-    await click(`[data-test-definition-container]`);
+    await click(`[data-test-clickable-definition-container]`);
     await waitFor('[data-test-boxel-selector-item-selected]');
     assert.dom('[data-test-boxel-selector-item-selected]').hasText(selected);
   });
@@ -1183,5 +1238,169 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     assert
       .dom('[data-test-boxel-selector-item-selected]')
       .hasText(`${elementName} card`);
+  });
+
+  test('in-this-file panel displays re-exports', async function (assert) {
+    let operatorModeStateParam = stringify({
+      stacks: [[]],
+      submode: 'code',
+      codePath: `${testRealmURL}re-export.gts`,
+    })!;
+
+    await visit(
+      `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+        operatorModeStateParam,
+      )}`,
+    );
+
+    await waitForCodeEditor();
+    await waitFor('[data-test-card-inspector-panel]');
+    await waitFor('[data-test-current-module-name]');
+    await waitFor('[data-test-in-this-file-selector]');
+    //default is the 1st index
+    let elementName = 'StrCard (StringCard) field';
+    assert
+      .dom('[data-test-boxel-selector-item]:nth-of-type(1)')
+      .hasText(elementName);
+    //TODO: intentionally not care about default line position for exports
+    //currently, only focus cursor if selecting declaration; not the reverse
+    //assert.true(monacoService.getLineCursorOn()?.includes('Str'));
+
+    // elements must be ordered by the way they appear in the source code
+    const expectedElementNames = [
+      'StrCard (StringCard) field',
+      'FDef (FieldDef) field',
+      'CardDef card',
+      'BDef base',
+      'default (NumberCard) field',
+    ];
+    expectedElementNames.forEach(async (elementName, index) => {
+      await waitFor(
+        `[data-test-boxel-selector-item]:nth-of-type(${index + 1})`,
+      );
+      assert
+        .dom(`[data-test-boxel-selector-item]:nth-of-type(${index + 1})`)
+        .hasText(elementName);
+    });
+    assert.dom('[data-test-boxel-selector-item]').exists({ count: 5 });
+
+    //clicking on a base card
+    elementName = 'BDef';
+    await click(`[data-test-boxel-selector-item-text="${elementName}"]`);
+    assert
+      .dom('[data-test-boxel-selector-item-selected]')
+      .hasText(`${elementName} base`);
+    assert.dom('[data-test-inheritance-panel-header]').exists();
+    assert.dom('[data-test-card-module-definition]').exists();
+    assert
+      .dom('[data-test-definition-header]')
+      .includesText('Re-exported Base Definition');
+    assert.dom('[data-test-card-module-definition]').includesText('Base');
+    assert.true(monacoService.getLineCursorOn()?.includes('BDef'));
+    assert
+      .dom('[data-test-file-incompatibility-message]')
+      .hasText(
+        'No tools are available to be used with these file contents. Choose a module that has a card or field definition inside of it.',
+      );
+  });
+
+  test('in-this-file displays local grandfather card. selection will move cursor and display card or field schema', async function (assert) {
+    let operatorModeStateParam = stringify({
+      stacks: [[]],
+      submode: 'code',
+      codePath: `${testRealmURL}local-inherit.gts`,
+    })!;
+
+    await visit(
+      `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+        operatorModeStateParam,
+      )}`,
+    );
+
+    await waitForCodeEditor();
+    await waitFor('[data-test-card-inspector-panel]');
+    await waitFor('[data-test-current-module-name]');
+    await waitFor('[data-test-in-this-file-selector]');
+    //default is the 1st index
+    let elementName = 'GrandParent card';
+    assert
+      .dom('[data-test-boxel-selector-item]:nth-of-type(1)')
+      .hasText(elementName);
+    assert.true(monacoService.getLineCursorOn()?.includes('GrandParent'));
+    assert.true(monacoService.getLineCursorOn()?.includes('CardDef'));
+    // elements must be ordered by the way they appear in the source code
+    const expectedElementNames = [
+      'GrandParent card',
+      'Parent card',
+      'Activity field',
+      'Hobby field',
+      'Sport field',
+      'Child card',
+    ];
+    expectedElementNames.forEach(async (elementName, index) => {
+      await waitFor(
+        `[data-test-boxel-selector-item]:nth-of-type(${index + 1})`,
+      );
+      assert
+        .dom(`[data-test-boxel-selector-item]:nth-of-type(${index + 1})`)
+        .hasText(elementName);
+    });
+
+    //select card defined locally
+    elementName = 'Parent';
+    await click(`[data-test-boxel-selector-item-text="${elementName}"]`);
+    assert
+      .dom('[data-test-boxel-selector-item-selected]')
+      .hasText(`${elementName} card`);
+    await waitFor('[data-test-card-module-definition]');
+    assert.dom('[data-test-inheritance-panel-header]').exists();
+    assert.dom('[data-test-card-module-definition]').exists();
+    assert.dom('[data-test-definition-header]').includesText('Card Definition');
+    assert
+      .dom('[data-test-card-module-definition]')
+      .includesText('local parent');
+    await waitFor('[data-test-card-schema="local parent"]');
+    assert
+      .dom('[data-test-card-schema="local grandparent"]')
+      .exists({ count: 1 });
+    assert.dom(`[data-test-card-schema="local parent"]`).exists();
+    assert.dom(`[data-test-card-schema="local grandparent"]`).exists();
+    assert.dom(`[data-test-total-fields]`).containsText('3 Fields');
+    assert.true(monacoService.getLineCursorOn()?.includes(elementName));
+    assert.true(monacoService.getLineCursorOn()?.includes('GrandParent'));
+
+    //select field defined locally
+    elementName = 'Sport';
+    await click(`[data-test-boxel-selector-item-text="${elementName}"]`);
+    assert
+      .dom('[data-test-boxel-selector-item-selected]')
+      .hasText(`${elementName} field`);
+    await waitFor('[data-test-card-module-definition]');
+    assert.dom('[data-test-inheritance-panel-header]').exists();
+    assert.dom('[data-test-card-module-definition]').exists();
+    assert
+      .dom('[data-test-definition-header]')
+      .includesText('Field Definition');
+    assert.dom('[data-test-card-module-definition]').includesText('my sport');
+    await waitFor('[data-test-card-schema="my sport"]');
+    assert.dom('[data-test-card-schema="my sport"]').exists({ count: 1 });
+    assert.dom(`[data-test-card-schema="my hobby"]`).exists({ count: 1 });
+    assert.dom(`[data-test-card-schema="my activity"]`).exists({ count: 1 });
+    assert.dom(`[data-test-total-fields]`).containsText('0 Fields');
+    assert.true(monacoService.getLineCursorOn()?.includes(elementName));
+
+    //clicking on inherited field defined locally
+    await waitFor(`[data-test-clickable-definition-container]`);
+    await click(`[data-test-clickable-definition-container]`); //clicking on Hobby
+    await waitFor('[data-test-boxel-selector-item-selected]');
+    assert
+      .dom('[data-test-boxel-selector-item-selected]')
+      .hasText('Hobby field');
+    await waitFor('[data-test-card-schema="my hobby"]');
+    assert.dom(`[data-test-card-schema="my hobby"]`).exists({ count: 1 });
+    assert.dom(`[data-test-card-schema="my activity"]`).exists({ count: 1 });
+    assert.dom(`[data-test-total-fields]`).containsText('0 Fields');
+    assert.true(monacoService.getLineCursorOn()?.includes('Hobby'));
+    assert.true(monacoService.getLineCursorOn()?.includes('Activity'));
   });
 });

--- a/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
@@ -490,12 +490,8 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
     assert
       .dom('[data-test-code-mode-card-preview-body]')
       .containsText('Hassan');
-    await waitFor(
-      `button[data-test-definition-container="${testRealmURL}person"]`,
-    );
-    await click(
-      `button[data-test-definition-container="${testRealmURL}person"]`,
-    );
+    await waitFor(`button[data-test-clickable-definition-container`);
+    await click(`button[data-test-clickable-definition-container`);
     await waitFor('[data-test-card-schema]');
     assert.dom('[data-test-card-schema]').exists({ count: 3 });
     assert.dom('[data-test-total-fields]').containsText('8 Fields');

--- a/packages/realm-server/tests/module-syntax-test.ts
+++ b/packages/realm-server/tests/module-syntax-test.ts
@@ -1,16 +1,16 @@
-import { module, test } from 'qunit';
-import { ModuleSyntax } from '@cardstack/runtime-common/module-syntax';
-import { dirSync } from 'tmp';
-import { Loader, baseRealm } from '@cardstack/runtime-common';
-import { testRealm, createRealm } from './helpers';
-import '@cardstack/runtime-common/helpers/code-equality-assertion';
-import { shimExternals } from '../lib/externals';
+import { module, test } from "qunit";
+import { ModuleSyntax } from "@cardstack/runtime-common/module-syntax";
+import { dirSync } from "tmp";
+import { Loader, baseRealm } from "@cardstack/runtime-common";
+import { testRealm, createRealm } from "./helpers";
+import "@cardstack/runtime-common/helpers/code-equality-assertion";
+import { shimExternals } from "../lib/externals";
 
-module('module-syntax', function () {
+module("module-syntax", function () {
   let loader = new Loader();
   loader.addURLMapping(
     new URL(baseRealm.url),
-    new URL('http://localhost:4201/base/'),
+    new URL("http://localhost:4201/base/"),
   );
   shimExternals(loader);
 
@@ -19,14 +19,14 @@ module('module-syntax', function () {
     mod.addField({
       cardBeingModified: {
         module: `${testRealm}dir/person.gts`,
-        name: 'Person',
+        name: "Person",
       },
-      fieldName: 'age',
+      fieldName: "age",
       fieldRef: {
-        module: 'https://cardstack.com/base/number',
-        name: 'default',
+        module: "https://cardstack.com/base/number",
+        name: "default",
       },
-      fieldType: 'contains',
+      fieldType: "contains",
       addFieldAtIndex,
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
@@ -35,7 +35,7 @@ module('module-syntax', function () {
     return mod;
   }
 
-  test('can get the code for a card', async function (assert) {
+  test("can get the code for a card", async function (assert) {
     let src = `
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -52,7 +52,7 @@ module('module-syntax', function () {
     assert.codeEqual(mod.code(), src);
   });
 
-  test('can add a field to a card', async function (assert) {
+  test("can add a field to a card", async function (assert) {
     let mod = addField(
       `
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
@@ -95,38 +95,38 @@ module('module-syntax', function () {
         }
       }
       `,
-      'original code formatting is preserved',
+      "original code formatting is preserved",
     );
 
-    let card = mod.possibleCardsOrFields.find((c) => c.exportedAs === 'Person');
-    let field = card!.possibleFields.get('age');
-    assert.ok(field, 'new field was added to syntax');
+    let card = mod.possibleCardsOrFields.find((c) => c.exportName === "Person");
+    let field = card!.possibleFields.get("age");
+    assert.ok(field, "new field was added to syntax");
     assert.deepEqual(
       field?.card,
       {
-        type: 'external',
-        module: 'https://cardstack.com/base/number',
-        name: 'default',
+        type: "external",
+        module: "https://cardstack.com/base/number",
+        name: "default",
       },
-      'the field card is correct',
+      "the field card is correct",
     );
     assert.deepEqual(
       field?.type,
       {
-        type: 'external',
-        module: 'https://cardstack.com/base/card-api',
-        name: 'contains',
+        type: "external",
+        module: "https://cardstack.com/base/card-api",
+        name: "contains",
       },
-      'the field type is correct',
+      "the field type is correct",
     );
     assert.deepEqual(
       field?.decorator,
       {
-        type: 'external',
-        module: 'https://cardstack.com/base/card-api',
-        name: 'field',
+        type: "external",
+        module: "https://cardstack.com/base/card-api",
+        name: "field",
       },
-      'the field decorator is correct',
+      "the field decorator is correct",
     );
 
     // add another field which will assert that the field path is correct since
@@ -134,14 +134,14 @@ module('module-syntax', function () {
     mod.addField({
       cardBeingModified: {
         module: `${testRealm}dir/person.gts`,
-        name: 'Person',
+        name: "Person",
       },
-      fieldName: 'lastName',
+      fieldName: "lastName",
       fieldRef: {
-        module: 'https://cardstack.com/base/string',
-        name: 'default',
+        module: "https://cardstack.com/base/string",
+        name: "default",
       },
-      fieldType: 'contains',
+      fieldType: "contains",
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
       outgoingRealmURL: undefined,
@@ -165,7 +165,7 @@ module('module-syntax', function () {
     );
   });
 
-  test('added field respects indentation of previous field', async function (assert) {
+  test("added field respects indentation of previous field", async function (assert) {
     // 4 space indent
     let mod = addField(
       `
@@ -193,11 +193,11 @@ module('module-syntax', function () {
             }
         }
       `,
-      'original code formatting is preserved',
+      "original code formatting is preserved",
     );
   });
 
-  test('added field respects indentation of previous class member', async function (assert) {
+  test("added field respects indentation of previous class member", async function (assert) {
     // 2 space indent
     let mod = addField(
       `
@@ -223,7 +223,7 @@ module('module-syntax', function () {
           }
         }
       `,
-      'original code formatting is preserved',
+      "original code formatting is preserved",
     );
   });
 
@@ -247,7 +247,7 @@ module('module-syntax', function () {
         @field age = contains(NumberCard);
       }
       `,
-      'original code formatting is preserved',
+      "original code formatting is preserved",
     );
     mod = addField(
       `
@@ -267,7 +267,7 @@ module('module-syntax', function () {
           @field age = contains(NumberCard);
         }
       `,
-      'original code formatting is preserved',
+      "original code formatting is preserved",
     );
 
     mod = addField(
@@ -288,7 +288,7 @@ module('module-syntax', function () {
           @field age = contains(NumberCard);
         }
       `,
-      'original code formatting is preserved',
+      "original code formatting is preserved",
     );
   });
 
@@ -321,11 +321,11 @@ module('module-syntax', function () {
             }
         }
       `,
-      'original code formatting is preserved',
+      "original code formatting is preserved",
     );
   });
 
-  test('can add a field to a card when the module url is relative', async function (assert) {
+  test("can add a field to a card when the module url is relative", async function (assert) {
     let src = `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -337,18 +337,18 @@ module('module-syntax', function () {
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/pet.gts`));
 
     mod.addField({
-      cardBeingModified: { module: `${testRealm}dir/pet`, name: 'Pet' }, // Card we want to add to
-      fieldName: 'bestFriend',
+      cardBeingModified: { module: `${testRealm}dir/pet`, name: "Pet" }, // Card we want to add to
+      fieldName: "bestFriend",
       fieldRef: {
-        module: '../person',
-        name: 'Person',
+        module: "../person",
+        name: "Person",
       },
-      fieldType: 'linksTo',
+      fieldType: "linksTo",
       incomingRelativeTo: new URL(
         `http://localhost:4202/node-test/catalog-entry/1`,
       ), // hypothethical catalog entry that lives at this id
-      outgoingRelativeTo: new URL('http://localhost:4202/node-test/pet'), // outgoing card
-      outgoingRealmURL: new URL('http://localhost:4202/node-test/'), // the realm that the catalog entry lives in
+      outgoingRelativeTo: new URL("http://localhost:4202/node-test/pet"), // outgoing card
+      outgoingRealmURL: new URL("http://localhost:4202/node-test/"), // the realm that the catalog entry lives in
     });
 
     assert.codeEqual(
@@ -365,7 +365,7 @@ module('module-syntax', function () {
     );
   });
 
-  test('can add a field to a card when the module url is from another realm', async function (assert) {
+  test("can add a field to a card when the module url is from another realm", async function (assert) {
     let src = `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -377,16 +377,16 @@ module('module-syntax', function () {
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/pet.gts`));
 
     mod.addField({
-      cardBeingModified: { module: `${testRealm}dir/pet`, name: 'Pet' }, // card we want to add to
-      fieldName: 'bestFriend',
+      cardBeingModified: { module: `${testRealm}dir/pet`, name: "Pet" }, // card we want to add to
+      fieldName: "bestFriend",
       fieldRef: {
-        module: '../person', // the other realm (will be from the /test realm not the /node-test)
-        name: 'Person',
+        module: "../person", // the other realm (will be from the /test realm not the /node-test)
+        name: "Person",
       },
-      fieldType: 'linksTo',
+      fieldType: "linksTo",
       incomingRelativeTo: new URL(`http://localhost:4202/test/catalog-entry/1`), // hypothethical catalog entry that lives at this id
-      outgoingRelativeTo: new URL('http://localhost:4202/node-test/pet'), // outgoing card
-      outgoingRealmURL: new URL('http://localhost:4202/node-test/'), // the realm that the catalog entry lives in
+      outgoingRelativeTo: new URL("http://localhost:4202/node-test/pet"), // outgoing card
+      outgoingRealmURL: new URL("http://localhost:4202/node-test/"), // the realm that the catalog entry lives in
     });
 
     assert.codeEqual(
@@ -412,13 +412,13 @@ module('module-syntax', function () {
 
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.addField({
-      cardBeingModified: { module: `${testRealm}dir/person`, name: 'Person' },
-      fieldName: 'firstName',
+      cardBeingModified: { module: `${testRealm}dir/person`, name: "Person" },
+      fieldName: "firstName",
       fieldRef: {
-        module: 'https://cardstack.com/base/string',
-        name: 'default',
+        module: "https://cardstack.com/base/string",
+        name: "default",
       },
-      fieldType: 'contains',
+      fieldType: "contains",
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
       outgoingRealmURL: undefined,
@@ -437,7 +437,7 @@ module('module-syntax', function () {
     );
   });
 
-  test('can add a field to an interior card that is the field of card that is exported', async function (assert) {
+  test("can add a field to an interior card that is the field of card that is exported", async function (assert) {
     let src = `
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -458,16 +458,16 @@ module('module-syntax', function () {
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.addField({
       cardBeingModified: {
-        type: 'fieldOf',
-        field: 'details',
-        card: { module: `${testRealm}dir/person`, name: 'Person' },
+        type: "fieldOf",
+        field: "details",
+        card: { module: `${testRealm}dir/person`, name: "Person" },
       },
-      fieldName: 'age',
+      fieldName: "age",
       fieldRef: {
-        module: 'https://cardstack.com/base/number',
-        name: 'default',
+        module: "https://cardstack.com/base/number",
+        name: "default",
       },
-      fieldType: 'contains',
+      fieldType: "contains",
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
       outgoingRealmURL: undefined,
@@ -496,7 +496,7 @@ module('module-syntax', function () {
     );
   });
 
-  test('can add a field to an interior card that is the ancestor of card that is exported', async function (assert) {
+  test("can add a field to an interior card that is the ancestor of card that is exported", async function (assert) {
     let src = `
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -516,15 +516,15 @@ module('module-syntax', function () {
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.addField({
       cardBeingModified: {
-        type: 'ancestorOf',
-        card: { module: `${testRealm}dir/person`, name: 'FancyPerson' },
+        type: "ancestorOf",
+        card: { module: `${testRealm}dir/person`, name: "FancyPerson" },
       },
-      fieldName: 'age',
+      fieldName: "age",
       fieldRef: {
-        module: 'https://cardstack.com/base/number',
-        name: 'default',
+        module: "https://cardstack.com/base/number",
+        name: "default",
       },
-      fieldType: 'contains',
+      fieldType: "contains",
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
       outgoingRealmURL: undefined,
@@ -552,7 +552,7 @@ module('module-syntax', function () {
     );
   });
 
-  test('can add a field to an interior card within a module that also has non card declarations', async function (assert) {
+  test("can add a field to an interior card within a module that also has non card declarations", async function (assert) {
     let src = `
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -575,16 +575,16 @@ module('module-syntax', function () {
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.addField({
       cardBeingModified: {
-        type: 'fieldOf',
-        field: 'details',
-        card: { module: `${testRealm}dir/person`, name: 'Person' },
+        type: "fieldOf",
+        field: "details",
+        card: { module: `${testRealm}dir/person`, name: "Person" },
       },
-      fieldName: 'age',
+      fieldName: "age",
       fieldRef: {
-        module: 'https://cardstack.com/base/number',
-        name: 'default',
+        module: "https://cardstack.com/base/number",
+        name: "default",
       },
-      fieldType: 'contains',
+      fieldType: "contains",
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
       outgoingRealmURL: undefined,
@@ -615,7 +615,7 @@ module('module-syntax', function () {
     );
   });
 
-  test('can add a containsMany field', async function (assert) {
+  test("can add a containsMany field", async function (assert) {
     let src = `
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -630,13 +630,13 @@ module('module-syntax', function () {
 
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.addField({
-      cardBeingModified: { module: `${testRealm}dir/person`, name: 'Person' },
-      fieldName: 'aliases',
+      cardBeingModified: { module: `${testRealm}dir/person`, name: "Person" },
+      fieldName: "aliases",
       fieldRef: {
-        module: 'https://cardstack.com/base/string',
-        name: 'default',
+        module: "https://cardstack.com/base/string",
+        name: "default",
       },
-      fieldType: 'containsMany',
+      fieldType: "containsMany",
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
       outgoingRealmURL: undefined,
@@ -657,23 +657,23 @@ module('module-syntax', function () {
         }
       `,
     );
-    let card = mod.possibleCardsOrFields.find((c) => c.exportedAs === 'Person');
-    let field = card!.possibleFields.get('aliases');
-    assert.ok(field, 'new field was added to syntax');
+    let card = mod.possibleCardsOrFields.find((c) => c.exportName === "Person");
+    let field = card!.possibleFields.get("aliases");
+    assert.ok(field, "new field was added to syntax");
     assert.deepEqual(
       field?.type,
       {
-        type: 'external',
-        module: 'https://cardstack.com/base/card-api',
-        name: 'containsMany',
+        type: "external",
+        module: "https://cardstack.com/base/card-api",
+        name: "containsMany",
       },
-      'the field type is correct',
+      "the field type is correct",
     );
   });
 
-  test('can add a linksTo field', async function (assert) {
+  test("can add a linksTo field", async function (assert) {
     let realm = await createRealm(loader, dirSync().name, {
-      'pet.gts': `
+      "pet.gts": `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
       export class Pet extends CardDef {
@@ -692,13 +692,13 @@ module('module-syntax', function () {
     `;
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.addField({
-      cardBeingModified: { module: `${testRealm}dir/person`, name: 'Person' },
-      fieldName: 'pet',
+      cardBeingModified: { module: `${testRealm}dir/person`, name: "Person" },
+      fieldName: "pet",
       fieldRef: {
         module: `${testRealm}dir/pet`,
-        name: 'Pet',
+        name: "Pet",
       },
-      fieldType: 'linksTo',
+      fieldType: "linksTo",
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
       outgoingRealmURL: undefined,
@@ -716,21 +716,21 @@ module('module-syntax', function () {
         }
       `,
     );
-    let card = mod.possibleCardsOrFields.find((c) => c.exportedAs === 'Person');
-    let field = card!.possibleFields.get('pet');
-    assert.ok(field, 'new field was added to syntax');
+    let card = mod.possibleCardsOrFields.find((c) => c.exportName === "Person");
+    let field = card!.possibleFields.get("pet");
+    assert.ok(field, "new field was added to syntax");
     assert.deepEqual(
       field?.type,
       {
-        type: 'external',
-        module: 'https://cardstack.com/base/card-api',
-        name: 'linksTo',
+        type: "external",
+        module: "https://cardstack.com/base/card-api",
+        name: "linksTo",
       },
-      'the field type is correct',
+      "the field type is correct",
     );
   });
 
-  test('can add a linksTo field with the same type as its enclosing card', async function (assert) {
+  test("can add a linksTo field with the same type as its enclosing card", async function (assert) {
     let src = `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -741,13 +741,13 @@ module('module-syntax', function () {
     `;
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.addField({
-      cardBeingModified: { module: `${testRealm}dir/person`, name: 'Person' },
-      fieldName: 'friend',
+      cardBeingModified: { module: `${testRealm}dir/person`, name: "Person" },
+      fieldName: "friend",
       fieldRef: {
         module: `${testRealm}dir/person`,
-        name: 'Person',
+        name: "Person",
       },
-      fieldType: 'linksTo',
+      fieldType: "linksTo",
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
       outgoingRealmURL: undefined,
@@ -765,21 +765,21 @@ module('module-syntax', function () {
         }
       `,
     );
-    let card = mod.possibleCardsOrFields.find((c) => c.exportedAs === 'Person');
-    let field = card!.possibleFields.get('friend');
-    assert.ok(field, 'new field was added to syntax');
+    let card = mod.possibleCardsOrFields.find((c) => c.exportName === "Person");
+    let field = card!.possibleFields.get("friend");
+    assert.ok(field, "new field was added to syntax");
     assert.deepEqual(
       field?.type,
       {
-        type: 'external',
-        module: 'https://cardstack.com/base/card-api',
-        name: 'linksTo',
+        type: "external",
+        module: "https://cardstack.com/base/card-api",
+        name: "linksTo",
       },
-      'the field type is correct',
+      "the field type is correct",
     );
   });
 
-  test('can handle field card declaration collisions when adding field', async function (assert) {
+  test("can handle field card declaration collisions when adding field", async function (assert) {
     let src = `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -793,13 +793,13 @@ module('module-syntax', function () {
 
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.addField({
-      cardBeingModified: { module: `${testRealm}dir/person`, name: 'Person' },
-      fieldName: 'age',
+      cardBeingModified: { module: `${testRealm}dir/person`, name: "Person" },
+      fieldName: "age",
       fieldRef: {
-        module: 'https://cardstack.com/base/number',
-        name: 'default',
+        module: "https://cardstack.com/base/number",
+        name: "default",
       },
-      fieldType: 'contains',
+      fieldType: "contains",
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
       outgoingRealmURL: undefined,
@@ -825,7 +825,7 @@ module('module-syntax', function () {
   // At this level, we can only see this specific module. we'll need the
   // upstream caller to perform a field existence check on the card
   // definition to ensure this field does not already exist in the adoption chain
-  test('throws when adding a field with a name the card already has', async function (assert) {
+  test("throws when adding a field with a name the card already has", async function (assert) {
     let src = `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -837,27 +837,27 @@ module('module-syntax', function () {
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     try {
       mod.addField({
-        cardBeingModified: { module: `${testRealm}dir/person`, name: 'Person' },
-        fieldName: 'firstName',
+        cardBeingModified: { module: `${testRealm}dir/person`, name: "Person" },
+        fieldName: "firstName",
         fieldRef: {
-          module: 'https://cardstack.com/base/string',
-          name: 'default',
+          module: "https://cardstack.com/base/string",
+          name: "default",
         },
-        fieldType: 'contains',
+        fieldType: "contains",
         incomingRelativeTo: undefined,
         outgoingRelativeTo: undefined,
         outgoingRealmURL: undefined,
       });
-      throw new Error('expected error was not thrown');
+      throw new Error("expected error was not thrown");
     } catch (err: any) {
       assert.ok(
         err.message.match(/field "firstName" already exists/),
-        'expected error was thrown',
+        "expected error was thrown",
       );
     }
   });
 
-  test('can remove a field from a card', async function (assert) {
+  test("can remove a field from a card", async function (assert) {
     let src = `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -869,8 +869,8 @@ module('module-syntax', function () {
     `;
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.removeField(
-      { module: `${testRealm}dir/person`, name: 'Person' },
-      'firstName',
+      { module: `${testRealm}dir/person`, name: "Person" },
+      "firstName",
     );
 
     assert.codeEqual(
@@ -894,15 +894,15 @@ module('module-syntax', function () {
         @field lastName = contains(StringCard);
       }
       `.trim(),
-      'original code formatting is preserved',
+      "original code formatting is preserved",
     );
 
-    let card = mod.possibleCardsOrFields.find((c) => c.exportedAs === 'Person');
-    let field = card!.possibleFields.get('firstName');
-    assert.strictEqual(field, undefined, 'field does not exist in syntax');
+    let card = mod.possibleCardsOrFields.find((c) => c.exportName === "Person");
+    let field = card!.possibleFields.get("firstName");
+    assert.strictEqual(field, undefined, "field does not exist in syntax");
   });
 
-  test('can use remove & add a field to achieve edit in place', async function (assert) {
+  test("can use remove & add a field to achieve edit in place", async function (assert) {
     let src = `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -917,18 +917,18 @@ module('module-syntax', function () {
 
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     let addFieldAtIndex = mod.removeField(
-      { module: `${testRealm}dir/person`, name: 'Person' },
-      'artistName',
+      { module: `${testRealm}dir/person`, name: "Person" },
+      "artistName",
     );
 
     mod.addField({
-      cardBeingModified: { module: `${testRealm}dir/person`, name: 'Person' },
-      fieldName: 'artistNames',
+      cardBeingModified: { module: `${testRealm}dir/person`, name: "Person" },
+      fieldName: "artistNames",
       fieldRef: {
-        module: 'https://cardstack.com/base/string',
-        name: 'default',
+        module: "https://cardstack.com/base/string",
+        name: "default",
       },
-      fieldType: 'containsMany',
+      fieldType: "containsMany",
       addFieldAtIndex,
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
@@ -951,7 +951,7 @@ module('module-syntax', function () {
     );
   });
 
-  test('can use remove & add a field to achieve edit in place - when field is at the beginning', async function (assert) {
+  test("can use remove & add a field to achieve edit in place - when field is at the beginning", async function (assert) {
     let src = `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -966,18 +966,18 @@ module('module-syntax', function () {
 
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     let addFieldAtIndex = mod.removeField(
-      { module: `${testRealm}dir/person`, name: 'Person' },
-      'firstName',
+      { module: `${testRealm}dir/person`, name: "Person" },
+      "firstName",
     );
 
     mod.addField({
-      cardBeingModified: { module: `${testRealm}dir/person`, name: 'Person' },
-      fieldName: 'firstNameAdjusted',
+      cardBeingModified: { module: `${testRealm}dir/person`, name: "Person" },
+      fieldName: "firstNameAdjusted",
       fieldRef: {
-        module: 'https://cardstack.com/base/string',
-        name: 'default',
+        module: "https://cardstack.com/base/string",
+        name: "default",
       },
-      fieldType: 'contains',
+      fieldType: "contains",
       addFieldAtIndex,
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
@@ -1000,7 +1000,7 @@ module('module-syntax', function () {
     );
   });
 
-  test('can use remove & add a field to achieve edit in place - when field is at the end', async function (assert) {
+  test("can use remove & add a field to achieve edit in place - when field is at the end", async function (assert) {
     let src = `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -1015,18 +1015,18 @@ module('module-syntax', function () {
 
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     let addFieldAtIndex = mod.removeField(
-      { module: `${testRealm}dir/person`, name: 'Person' },
-      'streetName',
+      { module: `${testRealm}dir/person`, name: "Person" },
+      "streetName",
     );
 
     mod.addField({
-      cardBeingModified: { module: `${testRealm}dir/person`, name: 'Person' },
-      fieldName: 'streetNameAdjusted',
+      cardBeingModified: { module: `${testRealm}dir/person`, name: "Person" },
+      fieldName: "streetNameAdjusted",
       fieldRef: {
-        module: 'https://cardstack.com/base/string',
-        name: 'default',
+        module: "https://cardstack.com/base/string",
+        name: "default",
       },
-      fieldType: 'contains',
+      fieldType: "contains",
       addFieldAtIndex,
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
@@ -1049,7 +1049,7 @@ module('module-syntax', function () {
     );
   });
 
-  test('can remove the last field from a card', async function (assert) {
+  test("can remove the last field from a card", async function (assert) {
     let src = `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -1061,8 +1061,8 @@ module('module-syntax', function () {
 
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.removeField(
-      { module: `${testRealm}dir/person`, name: 'Person' },
-      'firstName',
+      { module: `${testRealm}dir/person`, name: "Person" },
+      "firstName",
     );
 
     assert.codeEqual(
@@ -1074,7 +1074,7 @@ module('module-syntax', function () {
     );
   });
 
-  test('can remove a linksTo field with the same type as its enclosing card', async function (assert) {
+  test("can remove a linksTo field with the same type as its enclosing card", async function (assert) {
     let src = `
       import { contains, field, CardDef, linksTo } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -1086,8 +1086,8 @@ module('module-syntax', function () {
     `;
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.removeField(
-      { module: `${testRealm}dir/person`, name: 'Friend' },
-      'friend',
+      { module: `${testRealm}dir/person`, name: "Friend" },
+      "friend",
     );
 
     assert.codeEqual(
@@ -1102,12 +1102,12 @@ module('module-syntax', function () {
       `,
     );
 
-    let card = mod.possibleCardsOrFields.find((c) => c.exportedAs === 'Friend');
-    let field = card!.possibleFields.get('friend');
-    assert.strictEqual(field, undefined, 'field does not exist in syntax');
+    let card = mod.possibleCardsOrFields.find((c) => c.exportName === "Friend");
+    let field = card!.possibleFields.get("friend");
+    assert.strictEqual(field, undefined, "field does not exist in syntax");
   });
 
-  test('can remove the field of an interior card that is the ancestor of a card that is exported', async function (assert) {
+  test("can remove the field of an interior card that is the ancestor of a card that is exported", async function (assert) {
     let src = `
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -1124,10 +1124,10 @@ module('module-syntax', function () {
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.removeField(
       {
-        type: 'ancestorOf',
-        card: { module: `${testRealm}dir/person`, name: 'FancyPerson' },
+        type: "ancestorOf",
+        card: { module: `${testRealm}dir/person`, name: "FancyPerson" },
       },
-      'firstName',
+      "firstName",
     );
 
     assert.codeEqual(
@@ -1147,7 +1147,7 @@ module('module-syntax', function () {
     );
   });
 
-  test('can remove the field of an interior card that is the field of a card that is exported', async function (assert) {
+  test("can remove the field of an interior card that is the field of a card that is exported", async function (assert) {
     let src = `
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -1166,11 +1166,11 @@ module('module-syntax', function () {
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.removeField(
       {
-        type: 'fieldOf',
-        field: 'details',
-        card: { module: `${testRealm}dir/person`, name: 'Person' },
+        type: "fieldOf",
+        field: "details",
+        card: { module: `${testRealm}dir/person`, name: "Person" },
       },
-      'nickName',
+      "nickName",
     );
 
     assert.codeEqual(
@@ -1192,7 +1192,7 @@ module('module-syntax', function () {
     );
   });
 
-  test('throws when field to remove does not actually exist', async function (assert) {
+  test("throws when field to remove does not actually exist", async function (assert) {
     let src = `
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -1205,14 +1205,14 @@ module('module-syntax', function () {
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     try {
       mod.removeField(
-        { module: `${testRealm}dir/person`, name: 'Person' },
-        'foo',
+        { module: `${testRealm}dir/person`, name: "Person" },
+        "foo",
       );
-      throw new Error('expected error was not thrown');
+      throw new Error("expected error was not thrown");
     } catch (err: any) {
       assert.ok(
         err.message.match(/field "foo" does not exist/),
-        'expected error was thrown',
+        "expected error was thrown",
       );
     }
   });

--- a/packages/runtime-common/module-syntax.ts
+++ b/packages/runtime-common/module-syntax.ts
@@ -4,11 +4,13 @@ import { parse, print } from 'recast';
 import {
   schemaAnalysisPlugin,
   type Options,
-  type PossibleCardOrFieldClass,
+  type PossibleCardOrFieldDeclaration,
   type Declaration,
   type BaseDeclaration,
   type ClassReference,
-  isPossibleCardOrFieldClass,
+  type FunctionDeclaration,
+  type ClassDeclaration,
+  type Reexport,
   isInternalReference,
 } from './schema-analysis-plugin';
 import {
@@ -40,11 +42,18 @@ import type { types as t } from '@babel/core';
 import type { NodePath } from '@babel/traverse';
 import type { FieldType } from 'https://cardstack.com/base/card-api';
 
-export type { PossibleCardOrFieldClass, Declaration, BaseDeclaration };
-export { isPossibleCardOrFieldClass, isInternalReference };
+export type {
+  PossibleCardOrFieldDeclaration,
+  Declaration,
+  BaseDeclaration,
+  FunctionDeclaration,
+  ClassDeclaration,
+  Reexport,
+};
+export { isInternalReference };
 
 export class ModuleSyntax {
-  declare possibleCardsOrFields: PossibleCardOrFieldClass[];
+  declare possibleCardsOrFields: PossibleCardOrFieldDeclaration[];
   declare declarations: Declaration[];
   private declare ast: t.File;
   private url: URL;
@@ -260,8 +269,8 @@ export class ModuleSyntax {
   // This function performs the same job as
   // @cardstack/runtime-common/code-ref.ts#loadCard() but using syntax instead
   // of running code
-  private getCard(codeRef: CodeRef): PossibleCardOrFieldClass {
-    let cardOrFieldClass: PossibleCardOrFieldClass | undefined;
+  private getCard(codeRef: CodeRef): PossibleCardOrFieldDeclaration {
+    let cardOrFieldClass: PossibleCardOrFieldDeclaration | undefined;
     if (!('type' in codeRef)) {
       cardOrFieldClass = this.possibleCardsOrFields.find(
         (c) => c.exportedAs === codeRef.name,
@@ -300,7 +309,7 @@ export class ModuleSyntax {
 
   private getPossibleCardForClassReference(
     classRef: ClassReference,
-  ): PossibleCardOrFieldClass | undefined {
+  ): PossibleCardOrFieldDeclaration | undefined {
     if (classRef.type === 'external') {
       if (
         trimExecutableExtension(new URL(classRef.module, this.url)) === this.url

--- a/packages/runtime-common/module-syntax.ts
+++ b/packages/runtime-common/module-syntax.ts
@@ -273,7 +273,7 @@ export class ModuleSyntax {
     let cardOrFieldClass: PossibleCardOrFieldDeclaration | undefined;
     if (!('type' in codeRef)) {
       cardOrFieldClass = this.possibleCardsOrFields.find(
-        (c) => c.exportedAs === codeRef.name,
+        (c) => c.exportName === codeRef.name,
       );
     } else if (codeRef.type === 'ancestorOf') {
       let classRef = this.getCard(codeRef.card).super;
@@ -315,7 +315,7 @@ export class ModuleSyntax {
         trimExecutableExtension(new URL(classRef.module, this.url)) === this.url
       ) {
         return this.possibleCardsOrFields.find(
-          (c) => c.exportedAs === classRef.name,
+          (c) => c.exportName === classRef.name,
         );
       }
       throw new Error(

--- a/packages/runtime-common/remove-field-plugin.ts
+++ b/packages/runtime-common/remove-field-plugin.ts
@@ -1,5 +1,5 @@
 import type {
-  PossibleCardOrFieldClass,
+  PossibleCardOrFieldDeclaration,
   PossibleField,
 } from './schema-analysis-plugin';
 import { types as t } from '@babel/core';
@@ -11,7 +11,7 @@ interface State {
 }
 
 export interface Options {
-  card: PossibleCardOrFieldClass;
+  card: PossibleCardOrFieldDeclaration;
   field: PossibleField;
 }
 export function removeFieldPlugin() {

--- a/packages/runtime-common/schema-analysis-plugin.ts
+++ b/packages/runtime-common/schema-analysis-plugin.ts
@@ -17,7 +17,7 @@ export type ClassReference = ExternalReference | InternalReference;
 
 export interface BaseDeclaration {
   localName: string | undefined;
-  exportedAs: string | undefined; //generally, all our cases should have an exportedAs
+  exportName: string | undefined; //generally, all our cases should have an exportName
   path: NodePath;
 }
 
@@ -80,7 +80,7 @@ const coreVisitor = {
         insertOrReplace(
           {
             localName,
-            exportedAs: getExportName(path, localName),
+            exportName: getExportName(path, localName),
             path,
             type: 'function',
           },
@@ -100,7 +100,7 @@ const coreVisitor = {
             localName,
             path,
             possibleFields: new Map(),
-            exportedAs: getExportName(path, localName),
+            exportName: getExportName(path, localName),
             type: 'possibleCardOrField',
           };
           state.opts.possibleCardsOrFields.push(possibleCardOrField);
@@ -113,7 +113,7 @@ const coreVisitor = {
           insertOrReplace(
             {
               localName,
-              exportedAs: getExportName(path, localName),
+              exportName: getExportName(path, localName),
               path,
               type: 'class',
             },
@@ -131,7 +131,7 @@ const coreVisitor = {
           insertOrReplace(
             {
               localName,
-              exportedAs: getExportName(path, localName),
+              exportName: getExportName(path, localName),
               path,
               type: 'class',
             },
@@ -154,7 +154,7 @@ const coreVisitor = {
             localName,
             path,
             possibleFields: new Map(),
-            exportedAs: getExportName(path, localName),
+            exportName: getExportName(path, localName),
             type: 'possibleCardOrField',
           };
           state.opts.possibleCardsOrFields.push(possibleCardOrField);
@@ -165,7 +165,7 @@ const coreVisitor = {
             insertOrReplace(
               {
                 localName,
-                exportedAs: getExportName(path, localName),
+                exportName: getExportName(path, localName),
                 path,
                 type: 'class',
               },
@@ -282,7 +282,7 @@ const reExportVisitor = {
           insertOrReplace(
             {
               path,
-              exportedAs: getExportName(path, localName),
+              exportName: getExportName(path, localName),
               localName: localName,
               type: 'reexport',
             },
@@ -304,7 +304,7 @@ const reExportVisitor = {
       insertOrReplace(
         {
           path,
-          exportedAs: 'default',
+          exportName: 'default',
           localName,
           type: 'reexport',
         },

--- a/packages/runtime-common/schema-analysis-plugin.ts
+++ b/packages/runtime-common/schema-analysis-plugin.ts
@@ -530,9 +530,6 @@ function insertOrReplace(item: Declaration, arr: Declaration[]) {
     return i.localName === localName;
   });
   if (existingDeclaration) {
-    console.log(
-      `declaration of name ${localName} already exists. It is of type ${existingDeclaration.type}. Attempting to replace with type ${item.type}`,
-    );
     if (
       item.type === 'possibleCardOrField' &&
       existingDeclaration.type === 'reexport'

--- a/packages/runtime-common/schema-analysis-plugin.ts
+++ b/packages/runtime-common/schema-analysis-plugin.ts
@@ -386,7 +386,10 @@ function getExportName(
       localName,
     );
     if (maybeExportSpecifierLocal !== undefined) {
-      return getName(maybeExportSpecifierLocal.parentPath.node.exported);
+      return getName(
+        (maybeExportSpecifierLocal.parentPath as NodePath<t.ExportSpecifier>)
+          .node.exported,
+      );
     }
     // case that doesn't enter module scope
     // eg export { MyCard as SomeCard } from './some-module

--- a/packages/runtime-common/schema-analysis-plugin.ts
+++ b/packages/runtime-common/schema-analysis-plugin.ts
@@ -17,7 +17,7 @@ export type ClassReference = ExternalReference | InternalReference;
 
 export interface BaseDeclaration {
   localName: string | undefined;
-  exportedAs: string | undefined; //generally, all our cases should have an exportedAsName
+  exportedAs: string | undefined; //generally, all our cases should have an exportedAs
   path: NodePath;
 }
 
@@ -80,7 +80,7 @@ const coreVisitor = {
         insertOrReplace(
           {
             localName,
-            exportedAs: getExportedName(path, localName),
+            exportedAs: getExportName(path, localName),
             path,
             type: 'function',
           },
@@ -100,7 +100,7 @@ const coreVisitor = {
             localName,
             path,
             possibleFields: new Map(),
-            exportedAs: getExportedName(path, localName),
+            exportedAs: getExportName(path, localName),
             type: 'possibleCardOrField',
           };
           state.opts.possibleCardsOrFields.push(possibleCardOrField);
@@ -113,7 +113,7 @@ const coreVisitor = {
           insertOrReplace(
             {
               localName,
-              exportedAs: getExportedName(path, localName),
+              exportedAs: getExportName(path, localName),
               path,
               type: 'class',
             },
@@ -131,7 +131,7 @@ const coreVisitor = {
           insertOrReplace(
             {
               localName,
-              exportedAs: getExportedName(path, localName),
+              exportedAs: getExportName(path, localName),
               path,
               type: 'class',
             },
@@ -154,7 +154,7 @@ const coreVisitor = {
             localName,
             path,
             possibleFields: new Map(),
-            exportedAs: getExportedName(path, localName),
+            exportedAs: getExportName(path, localName),
             type: 'possibleCardOrField',
           };
           state.opts.possibleCardsOrFields.push(possibleCardOrField);
@@ -165,7 +165,7 @@ const coreVisitor = {
             insertOrReplace(
               {
                 localName,
-                exportedAs: getExportedName(path, localName),
+                exportedAs: getExportName(path, localName),
                 path,
                 type: 'class',
               },
@@ -282,7 +282,7 @@ const reExportVisitor = {
           insertOrReplace(
             {
               path,
-              exportedAs: getExportedName(path, localName),
+              exportedAs: getExportName(path, localName),
               localName: localName,
               type: 'reexport',
             },
@@ -365,7 +365,7 @@ function findExportSpecifierPathForNonBinding(
   return;
 }
 
-function getExportedName(
+function getExportName(
   path:
     | NodePath<t.ClassDeclaration>
     | NodePath<t.FunctionDeclaration>

--- a/packages/runtime-common/schema-analysis-plugin.ts
+++ b/packages/runtime-common/schema-analysis-plugin.ts
@@ -343,6 +343,7 @@ function findExportSpecifierPathForDeclaration(
       (b) => b.parentPath?.isExportSpecifier(),
     ) as NodePath<t.Identifier> | undefined;
   }
+  return undefined;
 }
 
 // find the specifier of a declaration that is referred in an export specifier as long as it enters the module scope
@@ -378,7 +379,7 @@ function getExportedName(
   } else if (parentPath.isExportDefaultDeclaration()) {
     // eg export default class MyClass {}
     return 'default';
-  } else if (path.isExportNamedDeclaration()) {
+  } else {
     // case that enters the module scope
     let maybeExportSpecifierLocal = findExportSpecifierPathForDeclaration(
       path,


### PR DESCRIPTION
https://linear.app/cardstack/issue/CS-6110/load-code-to-identify-carddeffielddef-capture-re-exported-definitions

https://github.com/cardstack/boxel/assets/8165111/a72e0ba6-0f78-4621-8bb9-4402f69e728a


https://linear.app/cardstack/issue/CS-6113/fix-post-card-need-to-consider-arbitrary-depth-inheritance

now, in-this-file panel should capture all cards/fields that are defined locally (as long its exported thru some relationship) and its inheritance should be displayed in card inheritance


https://github.com/cardstack/boxel/assets/8165111/591dd142-8357-4f80-9bb3-c0ef9c4f4d12




