### PR TITLE
host: Add version number

### DIFF
--- a/packages/host/app/components/submode-switcher.gts
+++ b/packages/host/app/components/submode-switcher.gts
@@ -6,6 +6,10 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 import get from 'lodash/get';
+
+import { BoxelDropdown, Button, Menu } from '@cardstack/boxel-ui/components';
+
+import { menuItemFunc, MenuItem } from '@cardstack/boxel-ui/helpers';
 import {
   DropdownArrowUp,
   DropdownArrowDown,
@@ -13,9 +17,7 @@ import {
   IconCode,
 } from '@cardstack/boxel-ui/icons';
 
-import { BoxelDropdown, Button, Menu } from '@cardstack/boxel-ui/components';
-
-import { menuItemFunc, MenuItem } from '@cardstack/boxel-ui/helpers';
+import config from '@cardstack/host/config/environment';
 
 export const Submodes = {
   Interact: 'interact',
@@ -40,6 +42,7 @@ export default class SubmodeSwitcher extends Component<Signature> {
           <Button
             class='submode-switcher-dropdown-trigger'
             aria-label='Options'
+            title={{this.appVersion}}
             {{on 'click' this.toggleDropdown}}
             {{bindings}}
           >
@@ -157,6 +160,11 @@ export default class SubmodeSwitcher extends Component<Signature> {
   @action onSubmodeSelect(submode: Submode) {
     this.isExpanded = false;
     this.args.onSubmodeSelect(submode);
+  }
+
+  get appVersion() {
+    // FIXME could use ember-cli-app-version but I can’t figure out the import!
+    return `Version ${config.APP.version}`;
   }
 
   get buildMenuItems(): MenuItem[] {

--- a/packages/host/app/components/submode-switcher.gts
+++ b/packages/host/app/components/submode-switcher.gts
@@ -163,7 +163,6 @@ export default class SubmodeSwitcher extends Component<Signature> {
   }
 
   get appVersion() {
-    // FIXME could use ember-cli-app-version but I can’t figure out the import!
     return `Version ${config.APP.version}`;
   }
 


### PR DESCRIPTION
The plan is for this be part of a dashboard button that doesn’t yet exist, so for now it’s a `title` on the submode trigger. `ember-cli-app-version` doesn’t have an accessible export for its `app-version` helper but it’s easy enough to use `config.APP.version`.

![Boxel 2023-11-27 16-24-24](https://github.com/cardstack/boxel/assets/43280/c11b4d3f-5876-440e-9fad-26299dddeab3)
