### PR TITLE
Prevent inputting years that exceed YYYY (4 digits)

### DIFF
--- a/packages/base/date.gts
+++ b/packages/base/date.gts
@@ -67,6 +67,7 @@ export default class DateField extends FieldDef {
         type='date'
         @value={{this.formatted}}
         @onInput={{fn this.parseInput @set}}
+        @max='9999-12-31'
       />
     </template>
 

--- a/packages/base/datetime.gts
+++ b/packages/base/datetime.gts
@@ -70,6 +70,7 @@ export default class DatetimeField extends FieldDef {
         type='datetime-local'
         @value={{this.formatted}}
         @onInput={{fn this.parseInput @set}}
+        @max='9999-12-31T23:59:59'
       />
     </template>
 

--- a/packages/boxel-ui/addon/src/components/input/index.gts
+++ b/packages/boxel-ui/addon/src/components/input/index.gts
@@ -60,6 +60,7 @@ export interface Signature {
     errorMessage?: string;
     helperText?: string;
     id?: string;
+    max?: string | number;
     onBlur?: (ev: Event) => void;
     onFocus?: (ev: Event) => void;
     onInput?: (val: string) => void;
@@ -155,6 +156,7 @@ export default class BoxelInput extends Component<Signature> {
           type={{this.type}}
           value={{@value}}
           placeholder={{@placeholder}}
+          max={{@max}}
           required={{@required}}
           disabled={{@disabled}}
           aria-describedby={{if

--- a/packages/boxel-ui/addon/src/components/input/usage.gts
+++ b/packages/boxel-ui/addon/src/components/input/usage.gts
@@ -31,6 +31,7 @@ export default class InputUsage extends Component {
   @tracked placeholder = '';
   @tracked errorMessage = '';
   @tracked helperText = '';
+  @tracked max = '';
   @tracked state: InputValidationState = 'initial';
   @tracked variant: 'large' | 'default' = 'default';
 
@@ -87,6 +88,7 @@ export default class InputUsage extends Component {
           @variant={{this.variant}}
           @errorMessage={{this.errorMessage}}
           @helperText={{this.helperText}}
+          @max={{this.max}}
           style={{cssVar boxel-input-height=this.boxelInputHeight.value}}
           @onBlur={{this.validate}}
           @onFocus={{this.logValue}}
@@ -144,6 +146,12 @@ export default class InputUsage extends Component {
           @name='helperText'
           @value={{this.helperText}}
           @onInput={{fn (mut this.helperText)}}
+        />
+        <Args.String
+          @name='max'
+          @value={{this.max}}
+          @onInput={{fn (mut this.max)}}
+          @description='Native <input> attribute, works with number, range, date, datetime-local, month, time and week types'
         />
         <Args.String
           @name='placeholder'


### PR DESCRIPTION
This PR fixes a bug where user was able to input a year number that exceeds 4 digits (this was reported as a bug by QA), causing our `parseISO` functions in date and datetime cards to throw an error. This was fixed by providing a max date/datetime limit which prevents the bug. 

Before (user was able to input year exceeding 4 digits)
<img width="803" alt="image" src="https://github.com/cardstack/boxel/assets/273660/416feb50-dcc2-4d1b-b5da-c85fb70f9bd2">

After (not being able to input more than 4 year digits):
<img width="357" alt="image" src="https://github.com/cardstack/boxel/assets/273660/126ec7e7-42af-4d7c-b6ef-a9506dbdd5a6">
