### PR TITLE
Updating style containsMany field within FieldDef

### DIFF
--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -306,6 +306,7 @@ export function getPluralViewComponent(
         }
         .containsMany-field.atom-format {
           padding: var(--boxel-sp-sm);
+          background-color: var(--boxel-100);
           border: var(--boxel-border);
           border-radius: var(--boxel-border-radius);
         }

--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -307,7 +307,7 @@ export function getPluralViewComponent(
         .containsMany-field.atom-format {
           padding: var(--boxel-sp-sm);
           background-color: var(--boxel-100);
-          border: var(--boxel-border);
+          border: none !important;
           border-radius: var(--boxel-border-radius);
         }
       </style>


### PR DESCRIPTION
Ticket: CS-6215

In this PR, I simply make the background color of containsMany field within FieldDef to grey, so it will more clearly for user that this field cannot be edited.


<img width="522" alt="Screen Shot 2023-11-28 at 14 48 16" src="https://github.com/cardstack/boxel/assets/12637010/9272dd60-357b-45f1-875a-b27970605482">
