### PR TITLE
Ensure that field components do not get recreated when state changes

### DIFF
--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -284,9 +284,10 @@ export function getPluralViewComponent(
   ) => typeof BaseDef,
   context?: CardContext,
 ): BoxComponent {
-  let components = model.children.map((child) =>
-    getBoxComponent(cardTypeFor(field, child), format, child, field, context),
-  );
+  let components = () =>
+    model.children.map((child) =>
+      getBoxComponent(cardTypeFor(field, child), format, child, field, context),
+    ); // Wrap the the components in a function so that the template is reactive to changes in the model (this is essentially a helper)
   let pluralViewComponent: TemplateOnlyComponent<BoxComponentSignature> =
     <template>
       {{#let (if @format @format format) as |format|}}
@@ -298,7 +299,7 @@ export function getPluralViewComponent(
           data-test-plural-view={{field.fieldType}}
           data-test-plural-view-format={{format}}
         >
-          {{#each components as |Item i|}}
+          {{#each (components) as |Item i|}}
             <div data-test-plural-view-item={{i}}>
               <Item @format={{format}} />
             </div>

--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -331,9 +331,7 @@ export function getPluralViewComponent(
       let components = getComponents();
 
       if (property === Symbol.iterator) {
-        if (property === Symbol.iterator) {
-          return components[Symbol.iterator];
-        }
+        return components[Symbol.iterator];
       }
       if (property === 'length') {
         return components.length;

--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -284,7 +284,7 @@ export function getPluralViewComponent(
   ) => typeof BaseDef,
   context?: CardContext,
 ): BoxComponent {
-  let components = () =>
+  let getComponents = () =>
     model.children.map((child) =>
       getBoxComponent(cardTypeFor(field, child), format, child, field, context),
     ); // Wrap the the components in a function so that the template is reactive to changes in the model (this is essentially a helper)
@@ -299,7 +299,7 @@ export function getPluralViewComponent(
           data-test-plural-view={{field.fieldType}}
           data-test-plural-view-format={{format}}
         >
-          {{#each (components) as |Item i|}}
+          {{#each (getComponents) as |Item i|}}
             <div data-test-plural-view-item={{i}}>
               <Item @format={{format}} />
             </div>
@@ -328,8 +328,12 @@ export function getPluralViewComponent(
     get(target, property, received) {
       // proxying the bare minimum of an Array in order to render within a
       // template. add more getters as necessary...
+      let components = getComponents();
+
       if (property === Symbol.iterator) {
-        return components[Symbol.iterator];
+        if (property === Symbol.iterator) {
+          return components[Symbol.iterator];
+        }
       }
       if (property === 'length') {
         return components.length;

--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -196,11 +196,7 @@ function fieldsComponentsFor<T extends BaseDef>(
 ): FieldsTypeFor<T> {
   // This is a cache of the fields we've already created components for
   // so that they do not get recreated
-  let stableComponentsForPrimitives = new Map<string, BoxComponent>();
-  let stableComponentsForCompoundFields = new WeakMap<
-    object,
-    Map<string, BoxComponent>
-  >();
+  let stableComponents = new Map<string, BoxComponent>();
 
   return new Proxy(target, {
     get(target, property, received) {
@@ -213,32 +209,7 @@ function fieldsComponentsFor<T extends BaseDef>(
         return Reflect.get(target, property, received);
       }
 
-      let stable: BoxComponent | undefined;
-
-      // debugger;
-      let propertyValue = isCard(model.value)
-        ? model.value[property as keyof BaseDef]
-        : undefined;
-      if (
-        isCard(model.value) &&
-        typeof propertyValue === 'object' &&
-        propertyValue !== null
-      ) {
-        let stableComponents =
-          stableComponentsForCompoundFields.get(propertyValue);
-
-        if (!stableComponents && propertyValue !== undefined) {
-          stableComponents = new Map();
-          stableComponentsForCompoundFields.set(
-            propertyValue,
-            stableComponents,
-          );
-        }
-        stable = stableComponents?.get(property);
-      } else {
-        stable = stableComponentsForPrimitives.get(property);
-      }
-
+      let stable = stableComponents.get(property);
       if (stable) {
         return stable;
       }
@@ -259,15 +230,7 @@ function fieldsComponentsFor<T extends BaseDef>(
         defaultFormat,
         context,
       );
-
-      if (typeof propertyValue === 'object') {
-        stableComponentsForCompoundFields
-          .get(propertyValue)
-          ?.set(property, result);
-      } else {
-        stableComponentsForPrimitives.set(property, result);
-      }
-
+      stableComponents.set(property, result);
       return result;
     },
     getPrototypeOf() {

--- a/packages/base/watched-array.ts
+++ b/packages/base/watched-array.ts
@@ -37,5 +37,3 @@ export { WatchedArray };
 
 // Ensure instanceof works correctly
 Object.setPrototypeOf(WatchedArray.prototype, Array.prototype);
-
-// Maybe it needs to be a tracked array?

--- a/packages/base/watched-array.ts
+++ b/packages/base/watched-array.ts
@@ -37,3 +37,5 @@ export { WatchedArray };
 
 // Ensure instanceof works correctly
 Object.setPrototypeOf(WatchedArray.prototype, Array.prototype);
+
+// Maybe it needs to be a tracked array?


### PR DESCRIPTION
This is a result of pairing with @ef4 yesterday -

The issue we were solving is a bug where the "contains many" editor component will lose focus after inputting a single character, making it impossible to write a word in one go:

<img width="542" alt="image" src="https://github.com/cardstack/boxel/assets/273660/fc0c4db8-fd96-4f5c-bcc5-8ed7a3522712">

It turns out the whole editor component got replaced (i.e. we could see that  the id in `<div id="ember102"...` got replaced) in DOM after state changes. The fix is that we now cache the components by field name, using the same technique we already use in `getBoxComponent`. 

We were thinking about the possibilities about adding a test for this, but we don't actually know enough about the source of this problem. The described bug reproduction is one way to see the bug, but we assume that this is only one case among many, and that the glimmer engine is **usually** smart enough to not recreate components (but not in this case)...