### PR TITLE
host: Remove inspector incompatibility message

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -278,17 +278,6 @@ export default class CodeSubmode extends Component<Signature> {
     return null;
   }
 
-  private get inspectorFileIncompatibilityMessage() {
-    //this will prevent displaying message during a page refresh
-    if (this.moduleContentsResource.isLoading) {
-      return null;
-    }
-    if (!this.card && !this.isModule && this.isIncompatibleFile) {
-      return 'Inspector cannot be used with this file type. Select a file with a .json, .gts or .ts extension.';
-    }
-    return null;
-  }
-
   private get readyFile() {
     if (isReady(this.currentOpenFile)) {
       return this.currentOpenFile;
@@ -633,25 +622,16 @@ export default class CodeSubmode extends Component<Signature> {
                         <FileTree @realmURL={{this.realmURL}} />
                       {{else}}
                         {{#if this.isReady}}
-                          {{#if this.inspectorFileIncompatibilityMessage}}
-                            <div
-                              class='file-incompatible-message'
-                              data-test-detail-panel-file-incompatibility-message
-                            >
-                              {{this.inspectorFileIncompatibilityMessage}}
-                            </div>
-                          {{else}}
-                            <DetailPanel
-                              @cardInstance={{this.card}}
-                              @readyFile={{this.readyFile}}
-                              @selectedDeclaration={{this.selectedDeclaration}}
-                              @declarations={{this.declarations}}
-                              @selectDeclaration={{this.selectDeclaration}}
-                              @delete={{perform this.delete}}
-                              @openDefinition={{this.openDefinition}}
-                              data-test-card-inspector-panel
-                            />
-                          {{/if}}
+                          <DetailPanel
+                            @cardInstance={{this.card}}
+                            @readyFile={{this.readyFile}}
+                            @selectedDeclaration={{this.selectedDeclaration}}
+                            @declarations={{this.declarations}}
+                            @selectDeclaration={{this.selectDeclaration}}
+                            @delete={{perform this.delete}}
+                            @openDefinition={{this.openDefinition}}
+                            data-test-card-inspector-panel
+                          />
                         {{/if}}
                       {{/if}}
                     </section>

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -276,7 +276,7 @@ export default class CodeSubmode extends Component<Signature> {
     if (this.moduleContentsResource.isLoading) {
       return null;
     }
-    if (!this.card && !this.isModule && !this.isIncompatibleFile) {
+    if (!this.card && !this.isModule && this.isIncompatibleFile) {
       return 'Inspector cannot be used with this file type. Select a file with a .json, .gts or .ts extension.';
     }
     return null;

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -10,8 +10,10 @@ import { isTesting } from '@embroider/macros';
 import Component from '@glimmer/component';
 //@ts-expect-error cached type not available yet
 import { cached, tracked } from '@glimmer/tracking';
+
 import { dropTask, restartableTask, timeout, all } from 'ember-concurrency';
 import perform from 'ember-concurrency/helpers/perform';
+
 import {
   Button,
   LoadingIndicator,
@@ -20,12 +22,14 @@ import {
 import type { PanelContext } from '@cardstack/boxel-ui/components';
 import { cn, and, not } from '@cardstack/boxel-ui/helpers';
 import { CheckMark, File } from '@cardstack/boxel-ui/icons';
+
 import {
   Deferred,
   isCardDocumentString,
   hasExecutableExtension,
 } from '@cardstack/runtime-common';
 import { type ResolvedCodeRef } from '@cardstack/runtime-common/code-ref';
+
 import RecentFiles from '@cardstack/host/components/editor/recent-files';
 import RealmInfoProvider from '@cardstack/host/components/operator-mode/realm-info-provider';
 import SchemaEditorColumn from '@cardstack/host/components/operator-mode/schema-editor-column';
@@ -43,8 +47,11 @@ import type MessageService from '@cardstack/host/services/message-service';
 import type { FileView } from '@cardstack/host/services/operator-mode-state-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 import RecentFilesService from '@cardstack/host/services/recent-files-service';
+
 import type { CardDef, Format } from 'https://cardstack.com/base/card-api';
+
 import FileTree from '../editor/file-tree';
+
 import CardPreviewPanel from './card-preview-panel';
 import CardURLBar from './card-url-bar';
 import CodeEditor from './code-editor';

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -129,17 +129,6 @@ export default class DetailPanel extends Component<Signature> {
     return hasExecutableExtension(this.args.readyFile.url);
   }
 
-  get isBinary() {
-    return this.args.readyFile.isBinary;
-  }
-
-  private get isNonCardJson() {
-    return (
-      this.args.readyFile.url.endsWith('.json') &&
-      !isCardDocumentString(this.args.readyFile.content)
-    );
-  }
-
   get isField() {
     if (
       this.args.selectedDeclaration &&
@@ -353,21 +342,19 @@ export default class DetailPanel extends Component<Signature> {
             {{/if}}
           </div>
         {{else}}
-          {{#if (or this.isBinary this.isNonCardJson)}}
-            <div class='details-panel'>
-              <header class='panel-header' aria-label='Details Panel Header'>
-                Details
-              </header>
-              <FileDefinitionContainer
-                @fileURL={{@readyFile.url}}
-                @fileExtension={{this.fileExtension}}
-                @infoText={{this.lastModified.value}}
-                @actions={{array
-                  (hash label='Delete' handler=@delete icon=IconTrash)
-                }}
-              />
-            </div>
-          {{/if}}
+          <div class='details-panel'>
+            <header class='panel-header' aria-label='Details Panel Header'>
+              Details
+            </header>
+            <FileDefinitionContainer
+              @fileURL={{@readyFile.url}}
+              @fileExtension={{this.fileExtension}}
+              @infoText={{this.lastModified.value}}
+              @actions={{array
+                (hash label='Delete' handler=@delete icon=IconTrash)
+              }}
+            />
+          </div>
         {{/if}}
       {{/if}}
     </div>

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -1,4 +1,5 @@
 import { hash, array } from '@ember/helper';
+import { fn } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 
@@ -6,6 +7,8 @@ import Component from '@glimmer/component';
 
 // @ts-expect-error cached doesn't have type yet
 import { tracked, cached } from '@glimmer/tracking';
+
+import { use, resource } from 'ember-resources';
 
 import {
   CardContainer,
@@ -15,6 +18,8 @@ import {
 
 import { or, and } from '@cardstack/boxel-ui/helpers';
 
+import { IconInherit, IconTrash } from '@cardstack/boxel-ui/icons';
+
 import {
   hasExecutableExtension,
   getPlural,
@@ -23,8 +28,10 @@ import {
 
 import { isCardDef, isFieldDef } from '@cardstack/runtime-common/code-ref';
 
+import { type ResolvedCodeRef } from '@cardstack/runtime-common/code-ref';
+
+import { getCodeRef, getCardType } from '@cardstack/host/resources/card-type';
 import { type Ready } from '@cardstack/host/resources/file';
-import { IconInherit, IconTrash } from '@cardstack/boxel-ui/icons';
 
 import {
   type ModuleDeclaration,
@@ -50,13 +57,6 @@ import Selector from './detail-panel-selector';
 import { SelectorItem, selectorItemFunc } from './detail-panel-selector';
 
 import type OperatorModeStateService from '../../services/operator-mode-state-service';
-import { fn } from '@ember/helper';
-
-import { getCodeRef, getCardType } from '@cardstack/host/resources/card-type';
-
-import { use, resource } from 'ember-resources';
-
-import { type ResolvedCodeRef } from '@cardstack/runtime-common/code-ref';
 
 interface Signature {
   Element: HTMLElement;

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -738,14 +738,24 @@ module('Acceptance | code submode tests', function (hooks) {
 
     await waitFor('[data-test-binary-info]');
 
+    assert.dom('[data-test-definition-file-extension]').hasText('.png');
+    await waitFor('[data-test-definition-realm-name]');
+    assert
+      .dom('[data-test-definition-realm-name]')
+      .hasText('in Test Workspace A');
+    assert.dom('[data-test-definition-info-text]').containsText('Last saved');
+    assert
+      .dom('[data-test-binary-info] [data-test-file-name]')
+      .hasText('mango.png');
+    assert.dom('[data-test-binary-info] [data-test-size]').hasText('114.71 kB');
+    assert
+      .dom('[data-test-binary-info] [data-test-last-modified]')
+      .containsText('Last modified');
     assert
       .dom('[data-test-file-incompatibility-message]')
       .hasText(
         'No tools are available to be used with this file type. Choose a file representing a card instance or module.',
       );
-    assert
-      .dom('[data-test-detail-panel-file-incompatibility-message]')
-      .exists();
 
     await percySnapshot(assert);
   });
@@ -913,7 +923,7 @@ module('Acceptance | code submode tests', function (hooks) {
     assert.dom('[data-test-file-incompatibility-message]').exists();
   });
 
-  test('displays clear message on inspector-panel and schema-editor when file is completely unsupported', async function (assert) {
+  test('displays clear message on schema-editor when file is completely unsupported', async function (assert) {
     let operatorModeStateParam = stringify({
       stacks: [],
       submode: 'code',
@@ -933,12 +943,8 @@ module('Acceptance | code submode tests', function (hooks) {
         'No tools are available to inspect this file or its contents. Select a file with a .json, .gts or .ts extension.',
       );
 
-    await waitFor('[data-test-detail-panel-file-incompatibility-message]');
-    assert
-      .dom('[data-test-detail-panel-file-incompatibility-message]')
-      .hasText(
-        'Inspector cannot be used with this file type. Select a file with a .json, .gts or .ts extension.',
-      );
+    await waitFor('[data-test-definition-file-extension]');
+    assert.dom('[data-test-definition-file-extension]').hasText('.txt');
   });
 
   test('Clicking card in search panel opens card JSON in editor', async function (assert) {

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -738,24 +738,15 @@ module('Acceptance | code submode tests', function (hooks) {
 
     await waitFor('[data-test-binary-info]');
 
-    assert.dom('[data-test-definition-file-extension]').hasText('.png');
-    await waitFor('[data-test-definition-realm-name]');
-    assert
-      .dom('[data-test-definition-realm-name]')
-      .hasText('in Test Workspace A');
-    assert.dom('[data-test-definition-info-text]').containsText('Last saved');
-    assert
-      .dom('[data-test-binary-info] [data-test-file-name]')
-      .hasText('mango.png');
-    assert.dom('[data-test-binary-info] [data-test-size]').hasText('114.71 kB');
-    assert
-      .dom('[data-test-binary-info] [data-test-last-modified]')
-      .containsText('Last modified');
     assert
       .dom('[data-test-file-incompatibility-message]')
       .hasText(
         'No tools are available to be used with this file type. Choose a file representing a card instance or module.',
       );
+    assert
+      .dom('[data-test-detail-panel-file-incompatibility-message]')
+      .exists();
+
     await percySnapshot(assert);
   });
 

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -756,7 +756,6 @@ module('Acceptance | code submode tests', function (hooks) {
       .hasText(
         'No tools are available to be used with this file type. Choose a file representing a card instance or module.',
       );
-
     await percySnapshot(assert);
   });
 

--- a/packages/host/tests/acceptance/operator-mode-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-test.gts
@@ -14,11 +14,12 @@ import { setupWindowMock } from 'ember-window-mock/test-support';
 import { module, test } from 'qunit';
 import stringify from 'safe-stable-stringify';
 
+import { FieldContainer } from '@cardstack/boxel-ui/components';
+
 import { baseRealm, primitive } from '@cardstack/runtime-common';
 
 import { Submodes } from '@cardstack/host/components/submode-switcher';
 import type LoaderService from '@cardstack/host/services/loader-service';
-import { FieldContainer } from '@cardstack/boxel-ui/components';
 
 import {
   setupLocalIndexing,


### PR DESCRIPTION
This removes the incompatibility message of the inspector view, which would render for some kinds of file:

<img width="867" alt="Boxel 2023-11-29 11-38-29" src="https://github.com/cardstack/boxel/assets/43280/3c7d6f6c-ba20-4386-8db5-18d2024a356c">

but not others:

<img width="1209" alt="Boxel 2023-11-29 11-37-38" src="https://github.com/cardstack/boxel/assets/43280/98ce7d2c-d19d-4a52-b704-e4b80bda00b8">

Now any kind of file can be inspected:

<img width="869" alt="Boxel 2023-11-29 13-23-47" src="https://github.com/cardstack/boxel/assets/43280/11f4beee-61c8-4eca-a247-39867375b879">
