### PR TITLE
Bugfix: Adding index cards to empty stack by url

### DIFF
--- a/packages/host/app/components/card-catalog/modal.gts
+++ b/packages/host/app/components/card-catalog/modal.gts
@@ -385,8 +385,11 @@ export default class CardCatalogModal extends Component<Signature> {
     this.state.searchResults = [];
   }
 
-  private getCard = task(async (cardID: string) => {
-    const cardResource = getCard(this, () => cardID);
+  private getCard = task(async (cardURL: string) => {
+    let maybeIndexCardURL = this.cardService.realmURLs.find(
+      (u) => u === cardURL + '/',
+    );
+    const cardResource = getCard(this, () => maybeIndexCardURL ?? cardURL);
     await cardResource.loaded;
     let { card } = cardResource;
     if (!card) {
@@ -395,7 +398,7 @@ export default class CardCatalogModal extends Component<Signature> {
     }
     let realmInfo = await this.cardService.getRealmInfo(card);
     if (!realmInfo) {
-      this.setErrorState(`Encountered error getting realm info for ${cardID}`);
+      this.setErrorState(`Encountered error getting realm info for ${cardURL}`);
       return;
     }
     this.state.searchResults = [

--- a/packages/host/app/components/card-catalog/modal.gts
+++ b/packages/host/app/components/card-catalog/modal.gts
@@ -300,7 +300,7 @@ export default class CardCatalogModal extends Component<Signature> {
     )) as T | undefined;
   }
 
-  private _chooseCard = restartableTask(
+  private _chooseCard = task(
     async <T extends CardDef>(
       query: Query,
       opts: {
@@ -385,7 +385,7 @@ export default class CardCatalogModal extends Component<Signature> {
     this.state.searchResults = [];
   }
 
-  private getCard = task(async (cardURL: string) => {
+  private getCard = restartableTask(async (cardURL: string) => {
     let maybeIndexCardURL = this.cardService.realmURLs.find(
       (u) => u === cardURL + '/',
     );

--- a/packages/host/app/components/card-catalog/modal.gts
+++ b/packages/host/app/components/card-catalog/modal.gts
@@ -389,7 +389,9 @@ export default class CardCatalogModal extends Component<Signature> {
     let maybeIndexCardURL = this.cardService.realmURLs.find(
       (u) => u === cardURL + '/',
     );
-    const cardResource = getCard(this, () => maybeIndexCardURL ?? cardURL);
+    const cardResource = getCard(this, () => maybeIndexCardURL ?? cardURL, {
+      isLive: () => false,
+    });
     await cardResource.loaded;
     let { card } = cardResource;
     if (!card) {

--- a/packages/host/app/components/search-sheet/index.gts
+++ b/packages/host/app/components/search-sheet/index.gts
@@ -29,6 +29,7 @@ import {
   isSingleCardDocument,
   baseRealm,
   catalogEntryRef,
+  type CardDocument,
 } from '@cardstack/runtime-common';
 
 import ENV from '@cardstack/host/config/environment';
@@ -157,7 +158,14 @@ export default class SearchSheet extends Component<Signature> {
   getCard = restartableTask(async (cardURL: string) => {
     this.clearSearchCardResults();
 
-    let maybeCardDoc = await this.cardService.fetchJSON(cardURL);
+    let maybeCardDoc: CardDocument | undefined;
+    try {
+      maybeCardDoc = await this.cardService.fetchJSON(cardURL);
+    } catch (e) {
+      // Not found message is displayed in getter for searchLabel
+      console.error(`Unable to fetch card at ${cardURL}`);
+    }
+
     if (isSingleCardDocument(maybeCardDoc)) {
       let card = await this.cardService.createFromSerialized(
         maybeCardDoc.data,

--- a/packages/host/app/components/search-sheet/index.gts
+++ b/packages/host/app/components/search-sheet/index.gts
@@ -157,23 +157,16 @@ export default class SearchSheet extends Component<Signature> {
   getCard = restartableTask(async (cardURL: string) => {
     this.clearSearchCardResults();
 
-    let response = await this.loaderService.loader.fetch(cardURL, {
-      headers: {
-        Accept: 'application/vnd.card+json',
-      },
-    });
-    if (response.ok) {
-      let maybeCardDoc = await response.json();
-      if (isSingleCardDocument(maybeCardDoc)) {
-        let card = await this.cardService.createFromSerialized(
-          maybeCardDoc.data,
-          maybeCardDoc,
-          new URL(maybeCardDoc.data.id),
-        );
+    let maybeCardDoc = await this.cardService.fetchJSON(cardURL);
+    if (isSingleCardDocument(maybeCardDoc)) {
+      let card = await this.cardService.createFromSerialized(
+        maybeCardDoc.data,
+        maybeCardDoc,
+        new URL(maybeCardDoc.data.id),
+      );
 
-        this.clearSearchCardResults();
-        this.searchCardResults.push(card);
-      }
+      this.clearSearchCardResults();
+      this.searchCardResults.push(card);
     }
   });
 

--- a/packages/host/app/components/search-sheet/index.gts
+++ b/packages/host/app/components/search-sheet/index.gts
@@ -155,7 +155,9 @@ export default class SearchSheet extends Component<Signature> {
     let maybeIndexCardURL = this.cardService.realmURLs.find(
       (u) => u === cardURL + '/',
     );
-    const cardResource = getCard(this, () => maybeIndexCardURL ?? cardURL);
+    const cardResource = getCard(this, () => maybeIndexCardURL ?? cardURL, {
+      isLive: () => false,
+    });
     await cardResource.loaded;
     let { card } = cardResource;
     if (!card) {

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -7,11 +7,9 @@ import { restartableTask } from 'ember-concurrency';
 import { Resource } from 'ember-resources';
 import flatMap from 'lodash/flatMap';
 
-import { baseRealm, subscribeToRealm } from '@cardstack/runtime-common';
+import { subscribeToRealm } from '@cardstack/runtime-common';
 
 import type { Query } from '@cardstack/runtime-common/query';
-
-import ENV from '@cardstack/host/config/environment';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 
@@ -28,10 +26,6 @@ interface Args {
   };
 }
 
-// This is temporary until we have a better way of discovering the realms that
-// are available for a user to search from
-const { otherRealmURLs } = ENV;
-
 export class Search extends Resource<Args> {
   @service private declare cardService: CardService;
   @tracked private _instances: CardDef[] = [];
@@ -44,15 +38,7 @@ export class Search extends Resource<Args> {
 
   modify(_positional: never[], named: Args['named']) {
     let { query, realms, isLive, doWhileRefreshing } = named;
-    this.realmsToSearch = realms ?? [
-      ...new Set(
-        realms ?? [
-          this.cardService.defaultURL.href,
-          baseRealm.url,
-          ...otherRealmURLs,
-        ],
-      ),
-    ];
+    this.realmsToSearch = realms ?? this.cardService.realmURLs;
     this.ready = this.search.perform(query);
 
     if (isLive) {

--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -7,6 +7,7 @@ import { stringify } from 'qs';
 import { v4 as uuidv4 } from 'uuid';
 
 import {
+  baseRealm,
   SupportedMimeType,
   type LooseCardResource,
   isSingleCardDocument,
@@ -58,6 +59,10 @@ export default class CardService extends Service {
     return api;
   });
 
+  // This is temporary until we have a better way of discovering the realms that
+  // are available for a user // unresolved URLs
+  realmURLs = [...new Set([ownRealmURL, baseRealm.url, ...otherRealmURLs])];
+
   // Note that this should be the unresolved URL and that we need to rely on our
   // fetch to do any URL resolution.
   get defaultURL(): URL {
@@ -91,7 +96,7 @@ export default class CardService extends Service {
     if (!response.ok) {
       let err = new Error(
         `status: ${response.status} -
-        ${response.statusText}. ${await response.text()}`,
+          ${response.statusText}. ${await response.text()}`,
       );
       (err as any).status = response.status;
       throw err;
@@ -355,8 +360,7 @@ export default class CardService extends Service {
   }
 
   getRealmURLFor(url: URL) {
-    let realmURLS = new Set([ownRealmURL, ...otherRealmURLs]);
-    for (let realmURL of realmURLS) {
+    for (let realmURL of this.realmURLs) {
       let path = new RealmPaths(realmURL);
       if (path.inRealm(url)) {
         return new URL(realmURL);

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -62,8 +62,12 @@ module('Acceptance | interact submode tests', function (hooks) {
       .loader;
     let cardApi: typeof import('https://cardstack.com/base/card-api');
     let string: typeof import('https://cardstack.com/base/string');
+    let catalogEntry: typeof import('https://cardstack.com/base/catalog-entry');
+    let cardsGrid: typeof import('https://cardstack.com/base/cards-grid');
     cardApi = await loader.import(`${baseRealm.url}card-api`);
     string = await loader.import(`${baseRealm.url}string`);
+    catalogEntry = await loader.import(`${baseRealm.url}catalog-entry`);
+    cardsGrid = await loader.import(`${baseRealm.url}cards-grid`);
 
     let {
       field,
@@ -75,6 +79,8 @@ module('Acceptance | interact submode tests', function (hooks) {
       FieldDef,
     } = cardApi;
     let { default: StringField } = string;
+    let { CatalogEntry } = catalogEntry;
+    let { CardsGrid } = cardsGrid;
 
     class Pet extends CardDef {
       static displayName = 'Pet';
@@ -181,6 +187,8 @@ module('Acceptance | interact submode tests', function (hooks) {
       };
     }
 
+    let mangoPet = new Pet({ name: 'Mango' });
+
     ({ realm } = await setupAcceptanceTestRealm({
       loader,
       contents: {
@@ -189,104 +197,30 @@ module('Acceptance | interact submode tests', function (hooks) {
         'pet.gts': { Pet },
         'shipping-info.gts': { ShippingInfo },
         'README.txt': `Hello World`,
-        'person-entry.json': {
-          data: {
-            type: 'card',
-            attributes: {
-              title: 'Person Card',
-              description: 'Catalog entry for Person Card',
-              ref: {
-                module: `${testRealmURL}person`,
-                name: 'Person',
-              },
-            },
-            meta: {
-              adoptsFrom: {
-                module: 'https://cardstack.com/base/catalog-entry',
-                name: 'CatalogEntry',
-              },
-            },
+        'person-entry.json': new CatalogEntry({
+          title: 'Person Card',
+          description: 'Catalog entry for Person Card',
+          ref: {
+            module: `${testRealmURL}person`,
+            name: 'Person',
           },
-        },
-        'Pet/mango.json': {
-          data: {
-            attributes: {
-              name: 'Mango',
-            },
-            meta: {
-              adoptsFrom: {
-                module: `${testRealmURL}pet`,
-                name: 'Pet',
-              },
-            },
-          },
-        },
-        'Pet/vangogh.json': {
-          data: {
-            attributes: {
-              name: 'Van Gogh',
-            },
-            meta: {
-              adoptsFrom: {
-                module: `${testRealmURL}pet`,
-                name: 'Pet',
-              },
-            },
-          },
-        },
-
-        'Person/fadhlan.json': {
-          data: {
-            attributes: {
-              firstName: 'Fadhlan',
-              address: {
-                city: 'Bandung',
-                country: 'Indonesia',
-                shippingInfo: {
-                  preferredCarrier: 'DHL',
-                  remarks: `Don't let bob deliver the package--he's always bringing it to the wrong address`,
-                },
-              },
-            },
-            relationships: {
-              pet: {
-                links: {
-                  self: `${testRealmURL}Pet/mango`,
-                },
-              },
-            },
-            meta: {
-              adoptsFrom: {
-                module: `${testRealmURL}person`,
-                name: 'Person',
-              },
-            },
-          },
-        },
-        'grid.json': {
-          data: {
-            type: 'card',
-            attributes: {},
-            meta: {
-              adoptsFrom: {
-                module: 'https://cardstack.com/base/cards-grid',
-                name: 'CardsGrid',
-              },
-            },
-          },
-        },
-        'index.json': {
-          data: {
-            type: 'card',
-            attributes: {},
-            meta: {
-              adoptsFrom: {
-                module: 'https://cardstack.com/base/cards-grid',
-                name: 'CardsGrid',
-              },
-            },
-          },
-        },
+        }),
+        'Pet/mango.json': mangoPet,
+        'Pet/vangogh.json': new Pet({ name: 'Van Gogh' }),
+        'Person/fadhlan.json': new Person({
+          firstName: 'Fadhlan',
+          address: new Address({
+            city: 'Bandung',
+            country: 'Indonesia',
+            shippingInfo: new ShippingInfo({
+              preferredCarrier: 'DHL',
+              remarks: `Don't let bob deliver the package--he's always bringing it to the wrong address`,
+            }),
+          }),
+          pet: mangoPet,
+        }),
+        'grid.json': new CardsGrid(),
+        'index.json': new CardsGrid(),
         '.realm.json': {
           name: 'Test Workspace B',
           backgroundURL:

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -375,6 +375,7 @@ module('Acceptance | interact submode tests', function (hooks) {
     });
 
     test('Can add an index card by URL (without "index" in path) using the add button', async function (assert) {
+      const wrongURL = 'https://cardstack.com/bas';
       await visit(
         `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
           stringify({ stacks: [] })!,
@@ -387,13 +388,35 @@ module('Acceptance | interact submode tests', function (hooks) {
       await waitFor('[data-test-card-catalog]');
       await fillIn(
         '[data-test-card-catalog-modal] [data-test-search-field]',
+        wrongURL,
+      );
+      await waitFor('[data-test-boxel-input-error-message]');
+      assert
+        .dom('[data-test-boxel-input-error-message]')
+        .hasText(`Could not find card at ${wrongURL}`);
+      assert.dom('[data-test-boxel-input-validation-state="invalid"]').exists();
+
+      await fillIn(
+        '[data-test-card-catalog-modal] [data-test-search-field]',
+        baseRealm.url.slice(0, -1),
+      );
+      await waitFor(`[data-test-card-catalog-item="${baseRealm.url}index"]`, {
+        timeout: 2000,
+      });
+      assert.dom('[data-test-card-catalog-item]').hasText('Base Workspace');
+
+      await fillIn(
+        '[data-test-card-catalog-modal] [data-test-search-field]',
         testRealmURL,
       );
-
       await waitFor(`[data-test-card-catalog-item="${testRealmURL}index"]`, {
         timeout: 2000,
       });
       assert.dom('[data-test-card-catalog-item]').hasText('Test Workspace B');
+      assert.dom('[data-test-boxel-input-error-message]').doesNotExist();
+      assert
+        .dom('[data-test-boxel-input-validation-state="invalid"]')
+        .doesNotExist();
 
       await click(`[data-test-select="${testRealmURL}index"]`);
       await click('[data-test-card-catalog-go-button]');

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -345,6 +345,64 @@ module('Acceptance | interact submode tests', function (hooks) {
       assert.dom('[data-test-search-field]').hasValue('');
     });
 
+    test('Can add a card by URL using the add button', async function (assert) {
+      await visit(
+        `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+          stringify({ stacks: [] })!,
+        )}`,
+      );
+
+      assert.dom('[data-test-operator-mode-stack]').doesNotExist();
+
+      await click('[data-test-add-card-button]');
+      await waitFor('[data-test-card-catalog]');
+      await fillIn(
+        '[data-test-card-catalog-modal] [data-test-search-field]',
+        `${testRealmURL}index`,
+      );
+
+      await waitFor(`[data-test-card-catalog-item="${testRealmURL}index"]`, {
+        timeout: 2000,
+      });
+      assert.dom('[data-test-card-catalog-item]').hasText('Test Workspace B');
+
+      await click(`[data-test-select="${testRealmURL}index"]`);
+      await click('[data-test-card-catalog-go-button]');
+      await waitFor('[data-test-card-catalog]', { count: 0 });
+      assert.dom('[data-test-operator-mode-stack]').exists({ count: 1 });
+      assert.dom('[data-test-stack-card-index]').exists({ count: 1 });
+      assert.dom('[data-test-stack-card-header]').hasText('Test Workspace B');
+    });
+
+    test('Can add an index card by URL (without "index" in path) using the add button', async function (assert) {
+      await visit(
+        `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+          stringify({ stacks: [] })!,
+        )}`,
+      );
+
+      assert.dom('[data-test-operator-mode-stack]').doesNotExist();
+
+      await click('[data-test-add-card-button]');
+      await waitFor('[data-test-card-catalog]');
+      await fillIn(
+        '[data-test-card-catalog-modal] [data-test-search-field]',
+        testRealmURL,
+      );
+
+      await waitFor(`[data-test-card-catalog-item="${testRealmURL}index"]`, {
+        timeout: 2000,
+      });
+      assert.dom('[data-test-card-catalog-item]').hasText('Test Workspace B');
+
+      await click(`[data-test-select="${testRealmURL}index"]`);
+      await click('[data-test-card-catalog-go-button]');
+      await waitFor('[data-test-card-catalog]', { count: 0 });
+      assert.dom('[data-test-operator-mode-stack]').exists({ count: 1 });
+      assert.dom('[data-test-stack-card-index]').exists({ count: 1 });
+      assert.dom('[data-test-stack-card-header]').hasText('Test Workspace B');
+    });
+
     test('Can open a recent card in empty stack', async function (assert) {
       let operatorModeStateParam = stringify({ stacks: [] })!;
 


### PR DESCRIPTION
[CS-6322]

Clicking on + button during empty stack in interact mode: Now the following examples work without 'index' in the path name:
- `https://cardstack.com/base`
- `https://cardstack.com/base/`
- `http://localhost:4201/drafts`
- `http://localhost:4201/drafts/`

Added error display when a url is not found. (Previously only error was thrown in console with no UI changes)