### PR TITLE
Fix flickering because details-panel was too eagerly showing

### DIFF
--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -105,6 +105,10 @@ export default class DetailPanel extends Component<Signature> {
     );
   }
 
+  get showDetailsPanel() {
+    return !this.isModule;
+  }
+
   get cardType() {
     if (
       this.args.selectedDeclaration &&
@@ -315,7 +319,7 @@ export default class DetailPanel extends Component<Signature> {
             {{/if}}
 
           </div>
-        {{else}}
+        {{else if this.showDetailsPanel}}
           <div class='details-panel'>
             <header class='panel-header' aria-label='Details Panel Header'>
               Details


### PR DESCRIPTION
Main issue was binary file (#else) case was appearing. Solution check if it is not a module