### PR TITLE
Create card instance action item

### DIFF
--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -388,7 +388,7 @@ export default class CreateFileModal extends Component<Signature> {
 
   private get isCreateCardInstanceButtonDisabled() {
     return (
-      !this.selectedCatalogEntry ||
+      (!this.selectedCatalogEntry && !this.definitionClass) ||
       !this.selectedRealmURL ||
       this.createCardInstance.isRunning
     );
@@ -531,15 +531,22 @@ export class ${className} extends ${exportName} {
         `Cannot createCardInstance when there is no this.currentRequest`,
       );
     }
-    if (!this.selectedCatalogEntry?.ref || !this.selectedRealmURL) {
-      return;
+    if (
+      (!this.selectedCatalogEntry?.ref && !this.definitionClass) ||
+      !this.selectedRealmURL
+    ) {
+      throw new Error(
+        `bug: cannot create card instance with out adoptsFrom ref and selected realm URL`,
+      );
     }
 
-    let { ref } = this.definitionClass
-      ? this.definitionClass
-      : this.selectedCatalogEntry;
+    let { ref } = (
+      this.definitionClass ? this.definitionClass : this.selectedCatalogEntry
+    )!; // we just checked above to make sure one of these exist
 
-    let relativeTo = new URL(this.selectedCatalogEntry.id);
+    let relativeTo = this.selectedCatalogEntry
+      ? new URL(this.selectedCatalogEntry.id)
+      : undefined;
     // we make the code ref use an absolute URL for safety in
     // the case it's being created in a different realm than where the card
     // definition comes from

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -1743,4 +1743,126 @@ export class ExportedCard extends ExportedCardParent {
       .dom('[data-test-action-button="Inherit"]')
       .doesNotExist('non-exported cards do not display an inherit button');
   });
+
+  test<TestContextWithSave>('Can create an instance from an exported card definition', async function (assert) {
+    assert.expect(8);
+    let operatorModeStateParam = stringify({
+      stacks: [[]],
+      submode: 'code',
+      codePath: `${testRealmURL}in-this-file.gts`,
+    })!;
+
+    await visit(
+      `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+        operatorModeStateParam,
+      )}`,
+    );
+    await waitForCodeEditor();
+    await waitFor('[data-boxel-selector-item-text="ExportedCard"]');
+
+    await click('[data-boxel-selector-item-text="ExportedCard"]');
+    await waitFor('[data-test-card-module-definition]');
+
+    await click('[data-test-action-button="Create Instance"]');
+    await waitFor(
+      `[data-test-create-file-modal][data-test-ready] [data-test-realm-name="Test Workspace B"]`,
+    );
+
+    assert
+      .dom('[data-test-inherits-from-field] .pill.inert')
+      .includesText('exported card', 'the inherits from is correct');
+    assert.dom('[data-test-create-card-instance]').isEnabled();
+
+    let deferred = new Deferred<void>();
+    let id: string | undefined;
+    this.onSave((json) => {
+      if (typeof json === 'string') {
+        throw new Error(`expected JSON save data`);
+      }
+      id = json.data.id;
+      assert.strictEqual(
+        json.data.attributes?.someString,
+        null,
+        'someString field is empty',
+      );
+      assert.strictEqual(
+        json.data.meta.realmURL,
+        testRealmURL,
+        'realm url is correct',
+      );
+      assert.deepEqual(
+        json.data.meta.adoptsFrom,
+        {
+          module: '../in-this-file',
+          name: 'ExportedCard',
+        },
+        'adoptsFrom is correct',
+      );
+      deferred.fulfill();
+    });
+
+    await percySnapshot(assert);
+    await click('[data-test-create-card-instance]');
+    await waitFor('[data-test-create-file-modal]', { count: 0 });
+    await deferred.promise;
+
+    if (!id) {
+      assert.ok(false, 'card instance ID does not exist');
+    }
+    await waitFor('[data-test-create-file-modal]', { count: 0 });
+    await waitFor(`[data-test-code-mode-card-preview-header="${id}"]`);
+    assert
+      .dom('[data-test-card-resource-loaded]')
+      .containsText('exported card');
+    assert.dom('[data-test-field="someString"] input').hasValue('');
+    assert.dom('[data-test-card-url-bar-input]').hasValue(`${id}.json`);
+  });
+
+  test('Create instance action is not displayed for non-exported Card definition', async function (assert) {
+    let operatorModeStateParam = stringify({
+      stacks: [[]],
+      submode: 'code',
+      codePath: `${testRealmURL}in-this-file.gts`,
+    })!;
+
+    await visit(
+      `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+        operatorModeStateParam,
+      )}`,
+    );
+    await waitForCodeEditor();
+    await waitFor('[data-boxel-selector-item-text="LocalCard"]');
+
+    await click('[data-boxel-selector-item-text="LocalCard"]');
+    await waitFor('[data-test-card-module-definition]');
+
+    assert
+      .dom('[data-test-action-button="Create Instance"]')
+      .doesNotExist(
+        'non-exported card defs do not display a create instance button',
+      );
+  });
+
+  test('Create instance action is not displayed for field definition', async function (assert) {
+    let operatorModeStateParam = stringify({
+      stacks: [[]],
+      submode: 'code',
+      codePath: `${testRealmURL}in-this-file.gts`,
+    })!;
+
+    await visit(
+      `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+        operatorModeStateParam,
+      )}`,
+    );
+    await waitForCodeEditor();
+    await waitFor('[data-boxel-selector-item-text="ExportedField"]');
+
+    await click('[data-boxel-selector-item-text="ExportedField"]');
+    await waitFor('[data-test-card-module-definition]');
+
+    assert
+      .dom('[data-test-action-button="Create Instance"]')
+      .doesNotExist('field defs do not display a create instance button');
+  });
 });


### PR DESCRIPTION
This PR adds a "create card instance" action item in the left hand panel.

![create-instance](https://github.com/cardstack/boxel/assets/61075/1131eed8-e7c9-4483-b17c-512da61d02cd)
