### PR TITLE
Prevent losing input focus when editing card fields in code mode

### DIFF
--- a/packages/host/app/modifiers/monaco.ts
+++ b/packages/host/app/modifiers/monaco.ts
@@ -107,7 +107,10 @@ export default class Monaco extends Modifier<Signature> {
       });
     }
     this.lastLanguage = language;
-    this.initializeCursorPosition.perform(initialCursorPosition);
+
+    if (initialCursorPosition != null) {
+      this.initializeCursorPosition.perform(initialCursorPosition);
+    }
   }
 
   private onContentChanged = restartableTask(


### PR DESCRIPTION
Observe this bug where after some typing auto save triggers, the input focus is lost (while editing card field in code mode):

https://github.com/cardstack/boxel/assets/273660/88fcf654-a8a0-47b1-893e-1bb567e3ddcc

This bug was quite annoying when typing into card fields. 

I fell into the rabbit hole of checking where and how rerendering happens in the card rendering mechanism but I wasn't able to detect any field rerendering (that could attribute to losing focus) on SSE.

It turns out it's the *code editor* that is stealing focus on file reload! The fix was very simple after finding that out - do not try to set cursor position when there is no selected declaration (keep in mind a JSON file is opened in the code editor at that time, which does not have any declarations). 