### PR TITLE
Remove linebreak in new card/field defs

### DIFF
--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -521,7 +521,7 @@ export class ${className} extends ${exportName} {
   static displayName = "${safeName}";
 }`;
     }
-    await this.cardService.saveSource(url, src);
+    await this.cardService.saveSource(url, src.trim());
     this.currentRequest.newFileDeferred.fulfill(url);
   });
 

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -432,7 +432,7 @@ module('Acceptance | code submode | create-file tests', function (hooks) {
 import { CardDef } from 'https://cardstack.com/base/card-api';
 export class TestCard extends CardDef {
   static displayName = "Test Card";
-}`;
+}`.trim();
     await openNewFileModal('Card Definition');
     assert
       .dom('[data-test-create-definition]')
@@ -500,7 +500,7 @@ export class TestCard extends CardDef {
 import BigInteger from 'https://cardstack.com/base/big-integer';
 export class FieldThatExtendsFromBigInt extends BigInteger {
   static displayName = "Field that extends from big int";
-}`,
+}`.trim(),
         'the source is correct',
       );
       deferred.fulfill();
@@ -536,7 +536,7 @@ export class FieldThatExtendsFromBigInt extends BigInteger {
 import Pet from '${testRealmURL}pet';
 export class TestCard extends Pet {
   static displayName = "Test Card";
-}`,
+}`.trim(),
         'the source is correct',
       );
       deferred.fulfill();
@@ -573,7 +573,7 @@ export class TestCard extends Pet {
 import PetParent from '${testRealmURL}pet';
 export class Pet extends PetParent {
   static displayName = "Pet";
-}`,
+}`.trim(),
         'the source is correct',
       );
       deferred.fulfill();
@@ -602,7 +602,7 @@ export class Pet extends PetParent {
 import { CardDef } from 'https://cardstack.com/base/card-api';
 export class TestCard extends CardDef {
   static displayName = "Test Card";
-}`,
+}`.trim(),
         'the source is correct',
       );
       deferred.fulfill();
@@ -619,7 +619,7 @@ export class TestCard extends CardDef {
 import { CardDef } from 'https://cardstack.com/base/card-api';
 export class TestCard extends CardDef {
   static displayName = "Test Card";
-}`;
+}`.trim();
 
     await openNewFileModal('Card Definition');
 
@@ -652,7 +652,7 @@ export class TestCard extends CardDef {
 import { CardDef } from 'https://cardstack.com/base/card-api';
 export class TestCard extends CardDef {
   static displayName = "Test Card";
-}`;
+}`.trim();
 
     await openNewFileModal('Card Definition');
 
@@ -685,7 +685,7 @@ export class TestCard extends CardDef {
 import { CardDef } from 'https://cardstack.com/base/card-api';
 export class TestCard extends CardDef {
   static displayName = "Test Card";
-}`;
+}`.trim();
 
     await openNewFileModal('Card Definition');
 

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -1439,7 +1439,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
 import { ExportedCard } from '${testRealmURL}in-this-file';
 export class TestCard extends ExportedCard {
   static displayName = "Test Card";
-}`;
+}`.trim();
     let operatorModeStateParam = stringify({
       stacks: [[]],
       submode: 'code',
@@ -1559,7 +1559,7 @@ export class TestCard extends ExportedCard {
 import { ExportedField } from '${testRealmURL}in-this-file';
 export class TestField extends ExportedField {
   static displayName = "Test Field";
-}`,
+}`.trim(),
         'the source is correct',
       );
       deferred.fulfill();
@@ -1623,7 +1623,7 @@ export class TestField extends ExportedField {
 import { ExportedCard as ExportedCardParent } from '${testRealmURL}in-this-file';
 export class ExportedCard extends ExportedCardParent {
   static displayName = "Exported Card";
-}`;
+}`.trim();
     let operatorModeStateParam = stringify({
       stacks: [[]],
       submode: 'code',


### PR DESCRIPTION
Remove the initial line break in the new card/field def code

![line-break](https://github.com/cardstack/boxel/assets/61075/372e5e9e-5136-4ea0-834c-9d8e070caecc)
