### PR TITLE
Fix more flicker & loading issues

### DIFF
--- a/packages/host/app/components/operator-mode/card-adoption-chain.gts
+++ b/packages/host/app/components/operator-mode/card-adoption-chain.gts
@@ -1,5 +1,6 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
+import { LoadingIndicator } from '@cardstack/boxel-ui/components';
 
 import { IconInherit as InheritIcon } from '@cardstack/boxel-ui/icons';
 
@@ -11,6 +12,7 @@ import { CardInheritance } from '@cardstack/host/components/operator-mode/code-s
 
 import { Type } from '@cardstack/host/resources/card-type';
 import type { Ready } from '@cardstack/host/resources/file';
+import { ModuleContentsResource } from '@cardstack/host/resources/module-contents';
 
 import { isOwnField } from '@cardstack/host/utils/schema-editor';
 
@@ -18,6 +20,7 @@ interface Signature {
   Element: HTMLDivElement;
   Args: {
     file: Ready;
+    moduleContentsResource: ModuleContentsResource;
     cardInheritanceChain: CardInheritance[];
     moduleSyntax: ModuleSyntax;
     openDefinition: (
@@ -73,36 +76,47 @@ export default class CardAdoptionChain extends Component<Signature> {
         width: 100%;
         border: 1px solid var(--boxel-purple-200);
       }
+      .loading {
+        display: flex;
+        justify-content: center;
+        padding: var(--boxel-sp-sm);
+      }
     </style>
 
     <div class='card-adoption-chain' ...attributes>
-      {{#each @cardInheritanceChain as |data index|}}
-        <div class='chain'>
-          <CardSchemaEditor
-            @card={{data.card}}
-            @cardType={{data.cardType}}
-            @file={{@file}}
-            @moduleSyntax={{@moduleSyntax}}
-            @childFields={{this.getFields index 'successors'}}
-            @parentFields={{this.getFields index 'ancestors'}}
-            @allowFieldManipulation={{this.allowFieldManipulation
-              @file
-              data.cardType
-            }}
-            @openDefinition={{@openDefinition}}
-          />
-          <div class='content-with-line'>
-            <hr class='line' />
-            <div class='inherits-from'>
-              <span class='inherits-icon'><InheritIcon
-                  width='24px'
-                  height='24px'
-                /></span>
-              <span>Inherits From</span>
+      {{#if this.args.moduleContentsResource.isLoadingNewModule}}
+        <div class='loading'>
+          <LoadingIndicator />
+        </div>
+      {{else}}
+        {{#each @cardInheritanceChain as |data index|}}
+          <div class='chain'>
+            <CardSchemaEditor
+              @card={{data.card}}
+              @cardType={{data.cardType}}
+              @file={{@file}}
+              @moduleSyntax={{@moduleSyntax}}
+              @childFields={{this.getFields index 'successors'}}
+              @parentFields={{this.getFields index 'ancestors'}}
+              @allowFieldManipulation={{this.allowFieldManipulation
+                @file
+                data.cardType
+              }}
+              @openDefinition={{@openDefinition}}
+            />
+            <div class='content-with-line'>
+              <hr class='line' />
+              <div class='inherits-from'>
+                <span class='inherits-icon'><InheritIcon
+                    width='24px'
+                    height='24px'
+                  /></span>
+                <span>Inherits From</span>
+              </div>
             </div>
           </div>
-        </div>
-      {{/each}}
+        {{/each}}
+      {{/if}}
     </div>
   </template>
 

--- a/packages/host/app/components/operator-mode/card-adoption-chain.gts
+++ b/packages/host/app/components/operator-mode/card-adoption-chain.gts
@@ -1,6 +1,5 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
-import { LoadingIndicator } from '@cardstack/boxel-ui/components';
 
 import { IconInherit as InheritIcon } from '@cardstack/boxel-ui/icons';
 
@@ -12,7 +11,6 @@ import { CardInheritance } from '@cardstack/host/components/operator-mode/code-s
 
 import { Type } from '@cardstack/host/resources/card-type';
 import type { Ready } from '@cardstack/host/resources/file';
-import { ModuleContentsResource } from '@cardstack/host/resources/module-contents';
 
 import { isOwnField } from '@cardstack/host/utils/schema-editor';
 
@@ -20,7 +18,6 @@ interface Signature {
   Element: HTMLDivElement;
   Args: {
     file: Ready;
-    moduleContentsResource: ModuleContentsResource;
     cardInheritanceChain: CardInheritance[];
     moduleSyntax: ModuleSyntax;
     openDefinition: (
@@ -76,47 +73,36 @@ export default class CardAdoptionChain extends Component<Signature> {
         width: 100%;
         border: 1px solid var(--boxel-purple-200);
       }
-      .loading {
-        display: flex;
-        justify-content: center;
-        padding: var(--boxel-sp-sm);
-      }
     </style>
 
     <div class='card-adoption-chain' ...attributes>
-      {{#if this.args.moduleContentsResource.isLoadingNewModule}}
-        <div class='loading'>
-          <LoadingIndicator />
-        </div>
-      {{else}}
-        {{#each @cardInheritanceChain as |data index|}}
-          <div class='chain'>
-            <CardSchemaEditor
-              @card={{data.card}}
-              @cardType={{data.cardType}}
-              @file={{@file}}
-              @moduleSyntax={{@moduleSyntax}}
-              @childFields={{this.getFields index 'successors'}}
-              @parentFields={{this.getFields index 'ancestors'}}
-              @allowFieldManipulation={{this.allowFieldManipulation
-                @file
-                data.cardType
-              }}
-              @openDefinition={{@openDefinition}}
-            />
-            <div class='content-with-line'>
-              <hr class='line' />
-              <div class='inherits-from'>
-                <span class='inherits-icon'><InheritIcon
-                    width='24px'
-                    height='24px'
-                  /></span>
-                <span>Inherits From</span>
-              </div>
+      {{#each @cardInheritanceChain as |data index|}}
+        <div class='chain'>
+          <CardSchemaEditor
+            @card={{data.card}}
+            @cardType={{data.cardType}}
+            @file={{@file}}
+            @moduleSyntax={{@moduleSyntax}}
+            @childFields={{this.getFields index 'successors'}}
+            @parentFields={{this.getFields index 'ancestors'}}
+            @allowFieldManipulation={{this.allowFieldManipulation
+              @file
+              data.cardType
+            }}
+            @openDefinition={{@openDefinition}}
+          />
+          <div class='content-with-line'>
+            <hr class='line' />
+            <div class='inherits-from'>
+              <span class='inherits-icon'><InheritIcon
+                  width='24px'
+                  height='24px'
+                /></span>
+              <span>Inherits From</span>
             </div>
           </div>
-        {{/each}}
-      {{/if}}
+        </div>
+      {{/each}}
     </div>
   </template>
 

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -732,6 +732,7 @@ export default class CodeSubmode extends Component<Signature> {
                     <Accordion as |A|>
                       <SchemaEditor
                         @file={{this.readyFile}}
+                        @moduleContentsResource={{this.moduleContentsResource}}
                         @card={{this.selectedCardOrField.cardOrField}}
                         @cardTypeResource={{this.selectedCardOrField.cardType}}
                         @openDefinition={{this.openDefinition}}

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -328,7 +328,7 @@ export default class CodeSubmode extends Component<Signature> {
   }
 
   private get declarations() {
-    return this.moduleContentsResource?.declarations || [];
+    return this.moduleContentsResource?.declarations;
   }
 
   private get _selectedDeclaration() {
@@ -633,10 +633,10 @@ export default class CodeSubmode extends Component<Signature> {
                     <:inspector>
                       {{#if this.isReady}}
                         <DetailPanel
+                          @moduleContentsResource={{this.moduleContentsResource}}
                           @cardInstance={{this.card}}
                           @readyFile={{this.readyFile}}
                           @selectedDeclaration={{this.selectedDeclaration}}
-                          @declarations={{this.declarations}}
                           @selectDeclaration={{this.selectDeclaration}}
                           @delete={{perform this.delete}}
                           @openDefinition={{this.openDefinition}}

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -279,7 +279,8 @@ export default class CodeSubmode extends Component<Signature> {
       return `card preview error ${this.cardError.message}`;
     }
 
-    if (!this.isModule || !this.readyFile.name.endsWith('.json')) {
+    if (!this.isModule && !this.readyFile.name.endsWith('.json')) {
+      debugger;
       return 'No tools are available to inspect this file or its contents. Select a file with a .json, .gts or .ts extension.';
     }
 

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -264,6 +264,7 @@ export default class CodeSubmode extends Component<Signature> {
 
     // If rhs doesn't handle any case but we can't capture the error
     if (!this.card && !this.selectedCardOrField) {
+      // this will prevent displaying message during a page refresh
       if (isCardDocumentString(this.readyFile.content)) {
         return null;
       }
@@ -276,6 +277,10 @@ export default class CodeSubmode extends Component<Signature> {
     // - a json error will be caught by incompatibleFile
     if (this.cardError) {
       return `card preview error ${this.cardError.message}`;
+    }
+
+    if (!this.isModule || !this.readyFile.name.endsWith('.json')) {
+      return 'No tools are available to inspect this file or its contents. Select a file with a .json, .gts or .ts extension.';
     }
 
     return null;

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -280,7 +280,6 @@ export default class CodeSubmode extends Component<Signature> {
     }
 
     if (!this.isModule && !this.readyFile.name.endsWith('.json')) {
-      debugger;
       return 'No tools are available to inspect this file or its contents. Select a file with a .json, .gts or .ts extension.';
     }
 

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -279,7 +279,11 @@ export default class CodeSubmode extends Component<Signature> {
       return `card preview error ${this.cardError.message}`;
     }
 
-    if (!this.isModule && !this.readyFile.name.endsWith('.json')) {
+    if (
+      !this.isModule &&
+      !this.readyFile.name.endsWith('.json') &&
+      !this.card //for case of creating new card instance
+    ) {
       return 'No tools are available to inspect this file or its contents. Select a file with a .json, .gts or .ts extension.';
     }
 

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -244,10 +244,6 @@ export default class CodeSubmode extends Component<Signature> {
   }
 
   private get fileIncompatibilityMessage() {
-    //this will prevent displaying message during a page refresh
-    if (this.moduleContentsResource.isLoading) {
-      return null;
-    }
     // If file is incompatible
     if (this.isIncompatibleFile) {
       return `No tools are available to be used with this file type. Choose a file representing a card instance or module.`;
@@ -255,6 +251,10 @@ export default class CodeSubmode extends Component<Signature> {
 
     // If the module is incompatible
     if (this.isModule) {
+      //this will prevent displaying message during a page refresh
+      if (this.moduleContentsResource.isLoading) {
+        return null;
+      }
       if (!this.hasCardDefOrFieldDef) {
         return `No tools are available to be used with these file contents. Choose a module that has a card or field definition inside of it.`;
       } else if (this.isSelectedItemIncompatibleWithSchemaEditor) {
@@ -264,6 +264,9 @@ export default class CodeSubmode extends Component<Signature> {
 
     // If rhs doesn't handle any case but we can't capture the error
     if (!this.card && !this.selectedCardOrField) {
+      if (isCardDocumentString(this.readyFile.content)) {
+        return null;
+      }
       return 'No tools are available to inspect this file or its contents. Select a file with a .json, .gts or .ts extension.';
     }
 

--- a/packages/host/app/components/operator-mode/code-submode/schema-editor.gts
+++ b/packages/host/app/components/operator-mode/code-submode/schema-editor.gts
@@ -38,7 +38,11 @@ interface Signature {
       WithBoundArgs<typeof SchemaEditorTitle, 'totalFields'>,
       WithBoundArgs<
         typeof CardAdoptionChain,
-        'file' | 'moduleSyntax' | 'cardInheritanceChain' | 'openDefinition'
+        | 'file'
+        | 'moduleContentsResource'
+        | 'moduleSyntax'
+        | 'cardInheritanceChain'
+        | 'openDefinition'
       >,
     ];
   };

--- a/packages/host/app/components/operator-mode/code-submode/schema-editor.gts
+++ b/packages/host/app/components/operator-mode/code-submode/schema-editor.gts
@@ -1,5 +1,6 @@
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { LoadingIndicator } from '@cardstack/boxel-ui/components';
 
 //@ts-ignore cached not available yet in definitely typed
 import { cached } from '@glimmer/tracking';
@@ -38,11 +39,7 @@ interface Signature {
       WithBoundArgs<typeof SchemaEditorTitle, 'totalFields'>,
       WithBoundArgs<
         typeof CardAdoptionChain,
-        | 'file'
-        | 'moduleContentsResource'
-        | 'moduleSyntax'
-        | 'cardInheritanceChain'
-        | 'openDefinition'
+        'file' | 'moduleSyntax' | 'cardInheritanceChain' | 'openDefinition'
       >,
     ];
   };
@@ -117,16 +114,28 @@ export default class SchemaEditor extends Component<Signature> {
   }
 
   <template>
-    {{yield
-      (component SchemaEditorTitle totalFields=this.totalFields)
-      (component
-        CardAdoptionChain
-        file=@file
-        moduleContentsResource=@moduleContentsResource
-        moduleSyntax=this.moduleSyntax
-        cardInheritanceChain=this.cardInheritanceChain.value
-        openDefinition=@openDefinition
-      )
-    }}
+    <style>
+      .loading {
+        display: flex;
+        justify-content: center;
+        padding: var(--boxel-sp-xl);
+      }
+    </style>
+    {{#if @moduleContentsResource.isLoadingNewModule}}
+      <div class='loading'>
+        <LoadingIndicator />
+      </div>
+    {{else}}
+      {{yield
+        (component SchemaEditorTitle totalFields=this.totalFields)
+        (component
+          CardAdoptionChain
+          file=@file
+          moduleSyntax=this.moduleSyntax
+          cardInheritanceChain=this.cardInheritanceChain.value
+          openDefinition=@openDefinition
+        )
+      }}
+    {{/if}}
   </template>
 }

--- a/packages/host/app/components/operator-mode/code-submode/schema-editor.gts
+++ b/packages/host/app/components/operator-mode/code-submode/schema-editor.gts
@@ -12,6 +12,7 @@ import { ModuleSyntax } from '@cardstack/runtime-common/module-syntax';
 import CardAdoptionChain from '@cardstack/host/components/operator-mode/card-adoption-chain';
 import { CardType, Type } from '@cardstack/host/resources/card-type';
 import { Ready } from '@cardstack/host/resources/file';
+import { ModuleContentsResource } from '@cardstack/host/resources/module-contents';
 import { inheritanceChain } from '@cardstack/host/resources/inheritance-chain';
 import LoaderService from '@cardstack/host/services/loader-service';
 import { calculateTotalOwnFields } from '@cardstack/host/utils/schema-editor';
@@ -24,6 +25,7 @@ interface Signature {
   Element: HTMLElement;
   Args: {
     file: Ready;
+    moduleContentsResource: ModuleContentsResource;
     cardTypeResource?: CardType;
     card: typeof BaseDef;
     openDefinition: (
@@ -116,6 +118,7 @@ export default class SchemaEditor extends Component<Signature> {
       (component
         CardAdoptionChain
         file=@file
+        moduleContentsResource=@moduleContentsResource
         moduleSyntax=this.moduleSyntax
         cardInheritanceChain=this.cardInheritanceChain.value
         openDefinition=@openDefinition

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -50,6 +50,7 @@ import {
 } from 'https://cardstack.com/base/card-api';
 
 import { lastModifiedDate } from '../../resources/last-modified-date';
+import { ModuleContentsResource } from '../../resources/module-contents';
 
 import { type FileType, type NewFileType } from './create-file-modal';
 import {
@@ -68,10 +69,10 @@ import type OperatorModeStateService from '../../services/operator-mode-state-se
 interface Signature {
   Element: HTMLElement;
   Args: {
+    moduleContentsResource: ModuleContentsResource;
     readyFile: Ready;
     cardInstance: CardDef | undefined;
     selectedDeclaration?: ModuleDeclaration;
-    declarations: ModuleDeclaration[];
     selectDeclaration: (dec: ModuleDeclaration) => void;
     openDefinition: (
       codeRef: ResolvedCodeRef | undefined,
@@ -102,8 +103,12 @@ export default class DetailPanel extends Component<Signature> {
     return undefined;
   });
 
+  private get declarations() {
+    return this.args.moduleContentsResource.declarations;
+  }
+
   private get showInThisFilePanel() {
-    return this.isModule && this.args.declarations.length > 0;
+    return this.isModule && this.declarations.length > 0;
   }
 
   private get showInheritancePanel() {
@@ -133,7 +138,8 @@ export default class DetailPanel extends Component<Signature> {
 
   private get isLoading() {
     return (
-      this.args.declarations.some((dec) => {
+      this.args.moduleContentsResource.isLoadingNewModule ||
+      this.declarations.some((dec) => {
         if (isCardOrFieldDeclaration(dec)) {
           return dec.cardType?.isLoading;
         } else {
@@ -269,10 +275,10 @@ export default class DetailPanel extends Component<Signature> {
   }
 
   private get buildSelectorItems(): SelectorItem[] {
-    if (!this.args.declarations) {
+    if (!this.declarations) {
       return [];
     }
-    return this.args.declarations.map((dec) => {
+    return this.declarations.map((dec) => {
       const isSelected = this.args.selectedDeclaration === dec;
       return selectorItemFunc(
         [
@@ -287,7 +293,7 @@ export default class DetailPanel extends Component<Signature> {
   }
 
   private get numberOfItems() {
-    let numberOfElements = this.args.declarations.length || 0;
+    let numberOfElements = this.declarations.length || 0;
     return `${numberOfElements} ${getPlural('item', numberOfElements)}`;
   }
 

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -122,7 +122,7 @@ export default class DetailPanel extends Component<Signature> {
   }
 
   private get showDetailsPanel() {
-    return !this.isModule;
+    return !this.isModule && !isCardDocumentString(this.args.readyFile.content);
   }
 
   private get cardType() {

--- a/packages/host/app/resources/module-contents.ts
+++ b/packages/host/app/resources/module-contents.ts
@@ -73,7 +73,7 @@ interface Args {
 
 export class ModuleContentsResource extends Resource<Args> {
   @tracked private _declarations: ModuleDeclaration[] = [];
-  @tracked private _url: string | undefined;
+  private _url: string | undefined;
   private executableFile: Ready | undefined;
 
   get isLoading() {

--- a/packages/host/app/resources/module-contents.ts
+++ b/packages/host/app/resources/module-contents.ts
@@ -80,11 +80,9 @@ export class ModuleContentsResource extends Resource<Args> {
     return this.load.isRunning;
   }
 
-  // this resource is aware of loading new modules
-  // it has to know this to distinguish this with the act of editing of a file
-  // swtiching of files is typical, but when editing a file we don't want to introduce loading state
-  // that is why we have this loading getter consumers would typically want to use this instead of isLoading
-  // isLoading 'may' be useful when refreshing the page
+  // this resource is aware of loading new modules (ie it stores previous urls)
+  // it has to know this to distinguish the act of editing of a file and switching between definitions
+  // when editing a file we don't want to introduce loading state, whereas when switching between definitions we do
   get isLoadingNewModule() {
     return (
       this.load.isRunning && this._url && this._url !== this.executableFile?.url

--- a/packages/host/app/resources/module-contents.ts
+++ b/packages/host/app/resources/module-contents.ts
@@ -80,6 +80,11 @@ export class ModuleContentsResource extends Resource<Args> {
     return this.load.isRunning;
   }
 
+  // this resource is aware of loading new modules
+  // it has to know this to distinguish this with the act of editing of a file
+  // swtiching of files is typical, but when editing a file we don't want to introduce loading state
+  // that is why we have this loading getter consumers would typically want to use this instead of isLoading
+  // isLoading 'may' be useful when refreshing the page
   get isLoadingNewModule() {
     return (
       this.load.isRunning && this._url && this._url !== this.executableFile?.url
@@ -87,9 +92,7 @@ export class ModuleContentsResource extends Resource<Args> {
   }
 
   get declarations() {
-    //we need this check because we don't want to show data stale data from the old module.
-    //can be seen with a temporary flicker of the stale data
-    return this.isLoadingNewModule ? [] : this._declarations;
+    return this._declarations;
   }
 
   modify(_positional: never[], named: Args['named']) {


### PR DESCRIPTION
Remaining flickers & loading issues (so done with em!) A lot of the issue is because we our loader refresh occurs when a user edits, but when we edit we don't want to show a loading state rather present the stale value until the loading is complete then swap out the data. 


## going to .gitignore shows card schema from last file

https://github.com/cardstack/boxel/assets/8165111/86e04d3c-bdc6-43ec-b566-c6fc431592e8


## refreshing flickers json instance


https://github.com/cardstack/boxel/assets/8165111/7bf9a78a-25ab-4a74-87e4-66cac9b263a6




## navigating to card-api shows less items bcos it doesn't have enough time to load all declarations


https://github.com/cardstack/boxel/assets/8165111/aed9521e-f62d-4cdb-ba29-0ae4d92b27d2


