### PR TITLE
Use relative URL's for import specifiers when possible for new card/field defs

### DIFF
--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -3,7 +3,6 @@ import { action } from '@ember/object';
 import type Owner from '@ember/owner';
 import { service } from '@ember/service';
 import { buildWaiter } from '@ember/test-waiters';
-import { isTesting } from '@embroider/macros';
 import Component from '@glimmer/component';
 
 import { all, task, timeout } from 'ember-concurrency';
@@ -20,6 +19,7 @@ import CodeSubmode from '@cardstack/host/components/operator-mode/code-submode';
 import InteractSubmode from '@cardstack/host/components/operator-mode/interact-submode';
 import config from '@cardstack/host/config/environment';
 import { getCard, trackCard } from '@cardstack/host/resources/card-resource';
+import { isTesting } from '@embroider/macros';
 
 import {
   getLiveSearchResults,
@@ -38,6 +38,8 @@ import type OperatorModeStateService from '../../services/operator-mode-state-se
 
 const waiter = buildWaiter('operator-mode-container:write-waiter');
 
+const { loginMessageTimeoutMs } = config;
+
 interface Signature {
   Args: {
     onClose: () => void;
@@ -53,7 +55,7 @@ export default class OperatorModeContainer extends Component<Signature> {
     super(owner, args);
 
     this.loadMatrix.perform();
-    if (config.environment === 'test') {
+    if (isTesting()) {
       (globalThis as any)._CARDSTACK_CARD_SEARCH = this;
       registerDestructor(this, () => {
         delete (globalThis as any)._CARDSTACK_CARD_SEARCH;
@@ -151,7 +153,7 @@ export default class OperatorModeContainer extends Component<Signature> {
         await this.matrixService.start();
         resolve();
       }),
-      timeout(1000),
+      timeout(loginMessageTimeoutMs),
     ]);
   });
 

--- a/packages/host/app/config/environment.d.ts
+++ b/packages/host/app/config/environment.d.ts
@@ -24,4 +24,5 @@ declare const config: {
   monacoDebounceMs: number;
   monacoCursorDebounceMs: number;
   serverEchoDebounceMs: number;
+  loginMessageTimeoutMs: number;
 };

--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -29,6 +29,7 @@ module.exports = function (environment) {
     monacoDebounceMs: 500,
     monacoCursorDebounceMs: 200,
     serverEchoDebounceMs: 5000,
+    loginMessageTimeoutMs: 1000,
 
     // the fields below may be rewritten by the realm server
     ownRealmURL:
@@ -73,6 +74,7 @@ module.exports = function (environment) {
     ENV.monacoDebounceMs = 0;
     ENV.monacoCursorDebounceMs = 0;
     ENV.serverEchoDebounceMs = 0;
+    ENV.loginMessageTimeoutMs = 0;
   }
 
   if (environment === 'production') {

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -802,7 +802,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     }
   });
 
-  test<TestContextWithSSE>('Can delete a card instance from code submode with no recent files to fall back on', async function (assert) {
+  test<TestContextWithSSE>('can delete a card instance from code submode with no recent files to fall back on', async function (assert) {
     let expectedEvents = [
       {
         type: 'index',
@@ -864,7 +864,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     });
     await waitFor('[data-test-empty-code-mode]');
     await percySnapshot(
-      'Acceptance | operator mode tests | Can delete a card instance from code submode with no recent files - empty code submode',
+      'Acceptance | operator mode tests | can delete a card instance from code submode with no recent files - empty code submode',
     );
     await click('[data-test-submode-switcher] button');
     await click('[data-test-boxel-menu-item-text="Interact"]');
@@ -1508,10 +1508,10 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     assert.true(monacoService.getLineCursorOn()?.includes('Activity'));
   });
 
-  test<TestContextWithSave>('Can inherit from an exported card def declaration', async function (assert) {
+  test<TestContextWithSave>('can inherit from an exported card def declaration', async function (assert) {
     assert.expect(11);
     let expectedSrc = `
-import { ExportedCard } from '${testRealmURL}in-this-file';
+import { ExportedCard } from './in-this-file';
 export class TestCard extends ExportedCard {
   static displayName = "Test Card";
 }`.trim();
@@ -1592,7 +1592,7 @@ export class TestCard extends ExportedCard {
       .hasNoValue('filename field is empty');
   });
 
-  test<TestContextWithSave>('Can inherit from an exported field def declaration', async function (assert) {
+  test<TestContextWithSave>('can inherit from an exported field def declaration', async function (assert) {
     assert.expect(2);
     let operatorModeStateParam = stringify({
       stacks: [[]],
@@ -1631,7 +1631,7 @@ export class TestCard extends ExportedCard {
       assert.strictEqual(
         content,
         `
-import { ExportedField } from '${testRealmURL}in-this-file';
+import { ExportedField } from './in-this-file';
 export class TestField extends ExportedField {
   static displayName = "Test Field";
 }`.trim(),
@@ -1695,7 +1695,7 @@ export class TestField extends ExportedField {
   test<TestContextWithSave>(`can handle the situation where there is a class name collision with the inherited cards class name`, async function (assert) {
     assert.expect(4);
     let expectedSrc = `
-import { ExportedCard as ExportedCardParent } from '${testRealmURL}in-this-file';
+import { ExportedCard as ExportedCardParent } from './in-this-file';
 export class ExportedCard extends ExportedCardParent {
   static displayName = "Exported Card";
 }`.trim();
@@ -1819,7 +1819,7 @@ export class ExportedCard extends ExportedCardParent {
       .doesNotExist('non-exported cards do not display an inherit button');
   });
 
-  test<TestContextWithSave>('Can create an instance from an exported card definition', async function (assert) {
+  test<TestContextWithSave>('can create an instance from an exported card definition', async function (assert) {
     assert.expect(8);
     let operatorModeStateParam = stringify({
       stacks: [[]],


### PR DESCRIPTION
This PR uses relative URL's for import specifiers when possible for new card/field defs. also speed up tests by using 0ms wait time for login message

![relative-import-specifiers](https://github.com/cardstack/boxel/assets/61075/2b5c81dc-6a7d-4c17-aff2-c82589c68293)
