### PR TITLE
host: Remove now-unnecessary Webpack workaround

### DIFF
--- a/packages/host/ember-cli-build.js
+++ b/packages/host/ember-cli-build.js
@@ -49,10 +49,6 @@ module.exports = function (defaults) {
               process: 'process',
             }),
             new webpack.IgnorePlugin({
-              // workaround for https://github.com/embroider-build/ember-auto-import/issues/578
-              resourceRegExp: /moment-timezone/,
-            }),
-            new webpack.IgnorePlugin({
               resourceRegExp: /^https:\/\/cardstack\.com\/base/,
             }),
             new MomentLocalesPlugin({


### PR DESCRIPTION
I noticed this while looking at Webpack config in #883, it has [been fixed](https://github.com/embroider-build/ember-auto-import/issues/578#issuecomment-1680845297).
