### PR TITLE
Refactor code selection

### DIFF
--- a/packages/host/app/components/operator-mode/card-schema-editor.gts
+++ b/packages/host/app/components/operator-mode/card-schema-editor.gts
@@ -273,6 +273,8 @@ export default class CardSchemaEditor extends Component<Signature> {
               {{@cardType.module}}
               {{#if codeRef.name}}
                 ({{codeRef.name}})
+              {{else}}
+                ({{@cardType.localName}})
               {{/if}}
             </:content>
           </Tooltip>

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -356,7 +356,7 @@ export default class CodeSubmode extends Component<Signature> {
 
       // when opening new definition,
       // checks codeRef from serialized url
-      let codeRef = this.operatorModeStateService.state.codeSelection?.codeRef;
+      let codeRef = this.operatorModeStateService.state.codeSelection.codeRef;
       if (isCardOrFieldDeclaration(dec) && codeRef) {
         return (
           dec.exportName === codeRef.name || dec.localName === codeRef.name

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -345,6 +345,7 @@ export default class CodeSubmode extends Component<Signature> {
 
   private get _selectedDeclaration() {
     let codeSelection = this.operatorModeStateService.state.codeSelection;
+    debugger;
     return this.moduleContentsResource?.declarations.find((dec) => {
       return codeSelection
         ? dec.exportName === codeSelection || dec.localName === codeSelection

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -344,25 +344,11 @@ export default class CodeSubmode extends Component<Signature> {
   }
 
   private get _selectedDeclaration() {
+    let codeSelection = this.operatorModeStateService.state.codeSelection;
     return this.moduleContentsResource?.declarations.find((dec) => {
-      // when refreshing module,
-      // checks localName from serialized url
-      if (
-        this.operatorModeStateService.state.codeSelection.localName ===
-        dec.localName
-      ) {
-        return true;
-      }
-
-      // when opening new definition,
-      // checks codeRef from serialized url
-      let codeRef = this.operatorModeStateService.state.codeSelection.codeRef;
-      if (isCardOrFieldDeclaration(dec) && codeRef) {
-        return (
-          dec.exportName === codeRef.name || dec.localName === codeRef.name
-        );
-      }
-      return false;
+      return codeSelection
+        ? dec.exportName === codeSelection || dec.localName === codeSelection
+        : false;
     });
   }
 
@@ -387,8 +373,7 @@ export default class CodeSubmode extends Component<Signature> {
 
   @action
   private selectDeclaration(dec: ModuleDeclaration) {
-    this.operatorModeStateService.updateLocalNameSelection(dec.localName);
-    this.updateCursorByDeclaration?.(dec);
+    this.openDefinition(undefined, dec.localName);
   }
 
   @action
@@ -396,15 +381,11 @@ export default class CodeSubmode extends Component<Signature> {
     codeRef: ResolvedCodeRef | undefined,
     localName: string | undefined,
   ) {
-    if (codeRef) {
-      this.operatorModeStateService.updateCodeRefSelection(codeRef);
-      this.operatorModeStateService.updateCodePath(new URL(codeRef.module));
-    } else if (localName) {
-      this.operatorModeStateService.updateLocalNameSelection(localName);
-      this.updateCursorByDeclaration?.(this.selectedDeclaration!);
-    } else {
-      console.log('No reference to codeRef or name found within module');
-    }
+    this.operatorModeStateService.updateCodePathWithCodeSelection(
+      codeRef,
+      localName,
+      () => this.updateCursorByDeclaration?.(this.selectedDeclaration!),
+    );
   }
 
   private onCardChange = () => {

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -345,7 +345,6 @@ export default class CodeSubmode extends Component<Signature> {
 
   private get _selectedDeclaration() {
     let codeSelection = this.operatorModeStateService.state.codeSelection;
-    debugger;
     return this.moduleContentsResource?.declarations.find((dec) => {
       return codeSelection
         ? dec.exportName === codeSelection || dec.localName === codeSelection

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -255,6 +255,7 @@ export default class OperatorModeStateService extends Service {
       //in the same module
       this.state.codeSelection = localName;
       onLocalSelection();
+      this.schedulePersist();
     }
   }
 

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -365,6 +365,7 @@ export default class OperatorModeStateService extends Service {
       codePath: this.state.codePath?.toString(),
       fileView: this.state.fileView?.toString() as FileView,
       openDirs: Object.fromEntries(this.state.openDirs.entries()),
+      codeSelection: this.state.codeSelection,
     };
 
     for (let stack of this.state.stacks) {

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -409,6 +409,7 @@ export default class OperatorModeStateService extends Service {
       codePath: rawState.codePath ? new URL(rawState.codePath) : null,
       fileView: rawState.fileView ?? 'inspector',
       openDirs,
+      codeSelection: rawState.codeSelection,
     });
 
     let stackIndex = 0;

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -365,7 +365,6 @@ export default class OperatorModeStateService extends Service {
       codePath: this.state.codePath?.toString(),
       fileView: this.state.fileView?.toString() as FileView,
       openDirs: Object.fromEntries(this.state.openDirs.entries()),
-      codeSelection: this.state.codeSelection,
     };
 
     for (let stack of this.state.stacks) {

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -248,7 +248,7 @@ export default class OperatorModeStateService extends Service {
   ) {
     //moving from one definition to another
     if (codeRef) {
-      //in a different module
+      //(possibly) in a different module
       this.state.codeSelection = codeRef.name;
       this.updateCodePath(new URL(codeRef.module));
     } else if (localName) {

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -996,6 +996,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     let elementName = 'ChildCard1';
     await waitFor(`[data-test-boxel-selector-item-text="${elementName}"]`);
     await click(`[data-test-boxel-selector-item-text="${elementName}"]`);
+    debugger;
     assert.operatorModeParametersMatch(currentURL(), {
       codePath: `${testRealmURL}imports.gts`,
       codeSelection: elementName,
@@ -1008,6 +1009,8 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await waitFor(`[data-test-clickable-definition-container]`);
     await click(`[data-test-clickable-definition-container]`);
     await waitFor('[data-test-boxel-selector-item-selected]');
+    let url = currentURL();
+    console.log(url);
     assert.dom('[data-test-boxel-selector-item-selected]').hasText(selected);
 
     //clicking on default card

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -998,9 +998,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await click(`[data-test-boxel-selector-item-text="${elementName}"]`);
     assert.operatorModeParametersMatch(currentURL(), {
       codePath: `${testRealmURL}imports.gts`,
-      codeSelection: {
-        localName: elementName,
-      },
+      codeSelection: elementName,
       fileView: 'inspector',
       openDirs: {},
       stacks: [[]],
@@ -1024,9 +1022,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await click(`[data-test-boxel-selector-item-text="${elementName}"]`);
     assert.operatorModeParametersMatch(currentURL(), {
       codePath: `${testRealmURL}imports.gts`,
-      codeSelection: {
-        localName: elementName,
-      },
+      codeSelection: elementName,
       fileView: 'inspector',
       openDirs: {},
       stacks: [[]],
@@ -1049,9 +1045,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await click(`[data-test-boxel-selector-item-text="${elementName}"]`);
     assert.operatorModeParametersMatch(currentURL(), {
       codePath: `${testRealmURL}imports.gts`,
-      codeSelection: {
-        localName: elementName,
-      },
+      codeSelection: elementName,
       fileView: 'inspector',
       openDirs: {},
       stacks: [[]],
@@ -1074,9 +1068,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await click(`[data-test-boxel-selector-item-text="${elementName}"]`);
     assert.operatorModeParametersMatch(currentURL(), {
       codePath: `${testRealmURL}imports.gts`,
-      codeSelection: {
-        localName: elementName,
-      },
+      codeSelection: elementName,
       fileView: 'inspector',
       openDirs: {},
       stacks: [[]],
@@ -1100,9 +1092,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await click(`[data-test-boxel-selector-item-text="${elementName}"]`);
     assert.operatorModeParametersMatch(currentURL(), {
       codePath: `${testRealmURL}imports.gts`,
-      codeSelection: {
-        localName: elementName,
-      },
+      codeSelection: elementName,
       fileView: 'inspector',
       openDirs: {},
       stacks: [[]],
@@ -1127,9 +1117,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await click(`[data-test-boxel-selector-item-text="${elementName}"]`);
     assert.operatorModeParametersMatch(currentURL(), {
       codePath: `${testRealmURL}imports.gts`,
-      codeSelection: {
-        localName: elementName,
-      },
+      codeSelection: elementName,
       fileView: 'inspector',
       openDirs: {},
       stacks: [[]],
@@ -1171,12 +1159,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     );
     assert.operatorModeParametersMatch(currentURL(), {
       codePath: `${testRealmURL}exports.gts`,
-      codeSelection: {
-        codeRef: {
-          module: `${testRealmURL}exports`,
-          name: elementName,
-        },
-      },
+      codeSelection: elementName,
       fileView: 'inspector',
       openDirs: {},
       stacks: [],
@@ -1204,12 +1187,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     );
     assert.operatorModeParametersMatch(currentURL(), {
       codePath: `${testRealmURL}exports.gts`,
-      codeSelection: {
-        codeRef: {
-          module: `${testRealmURL}exports`,
-          name: elementName,
-        },
-      },
+      codeSelection: elementName,
       fileView: 'inspector',
       openDirs: {},
       stacks: [],
@@ -1238,12 +1216,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
 
     assert.operatorModeParametersMatch(currentURL(), {
       codePath: `${testRealmURL}exports.gts`,
-      codeSelection: {
-        codeRef: {
-          module: `${testRealmURL}exports`,
-          name: elementName,
-        },
-      },
+      codeSelection: elementName,
       fileView: 'inspector',
       openDirs: {},
       stacks: [],
@@ -1270,12 +1243,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     );
     assert.operatorModeParametersMatch(currentURL(), {
       codePath: `${testRealmURL}imports.gts`,
-      codeSelection: {
-        codeRef: {
-          module: `${testRealmURL}imports`,
-          name: elementName,
-        },
-      },
+      codeSelection: elementName,
       fileView: 'inspector',
       openDirs: {},
       stacks: [],
@@ -1304,12 +1272,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
 
     assert.operatorModeParametersMatch(currentURL(), {
       codePath: `${testRealmURL}exports.gts`,
-      codeSelection: {
-        codeRef: {
-          module: `${testRealmURL}exports`,
-          name: elementName,
-        },
-      },
+      codeSelection: elementName,
       fileView: 'inspector',
       openDirs: {},
       stacks: [],

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -996,7 +996,6 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     let elementName = 'ChildCard1';
     await waitFor(`[data-test-boxel-selector-item-text="${elementName}"]`);
     await click(`[data-test-boxel-selector-item-text="${elementName}"]`);
-    debugger;
     assert.operatorModeParametersMatch(currentURL(), {
       codePath: `${testRealmURL}imports.gts`,
       codeSelection: elementName,
@@ -1009,8 +1008,6 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await waitFor(`[data-test-clickable-definition-container]`);
     await click(`[data-test-clickable-definition-container]`);
     await waitFor('[data-test-boxel-selector-item-selected]');
-    let url = currentURL();
-    console.log(url);
     assert.dom('[data-test-boxel-selector-item-selected]').hasText(selected);
 
     //clicking on default card

--- a/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
@@ -970,7 +970,7 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
     await waitFor('[data-test-card-schema="Base"] [data-test-tooltip-content]');
     assert
       .dom('[data-test-card-schema="Base"] [data-test-tooltip-content]')
-      .hasText('https://cardstack.com/base/card-api');
+      .hasText('https://cardstack.com/base/card-api (BaseDef)');
 
     await triggerEvent(
       '[data-test-card-schema="Base"] [data-test-card-schema-navigational-button]',

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -498,7 +498,6 @@ module('Acceptance | interact submode tests', function (hooks) {
         submode: Submodes.Interact,
         fileView: 'inspector',
         openDirs: {},
-        codeSelection: {},
       });
 
       await waitFor('[data-test-pet="Mango"]');
@@ -524,7 +523,6 @@ module('Acceptance | interact submode tests', function (hooks) {
             submode: 'interact',
             fileView: 'inspector',
             openDirs: {},
-            codeSelection: {},
           })!,
         )}`,
       );
@@ -552,7 +550,6 @@ module('Acceptance | interact submode tests', function (hooks) {
             submode: 'interact',
             fileView: 'inspector',
             openDirs: {},
-            codeSelection: {},
           })!,
         )}`,
       );
@@ -870,7 +867,6 @@ module('Acceptance | interact submode tests', function (hooks) {
         submode: Submodes.Interact,
         fileView: 'inspector',
         openDirs: {},
-        codeSelection: {},
       });
 
       // Close the last card in the last stack that is left - should get the empty state

--- a/packages/host/tests/acceptance/operator-mode-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-test.gts
@@ -471,7 +471,6 @@ module('Acceptance | operator mode tests', function (hooks) {
       codePath: `${testRealmURL}address-with-no-embedded-template.gts`,
       fileView: 'inspector',
       openDirs: {},
-      codeSelection: {},
     });
 
     // Toggle back to interactive mode
@@ -494,7 +493,6 @@ module('Acceptance | operator mode tests', function (hooks) {
       codePath: `${testRealmURL}country-with-no-embedded-template.gts`,
       fileView: 'inspector',
       openDirs: {},
-      codeSelection: {},
     });
   });
 
@@ -550,7 +548,6 @@ module('Acceptance | operator mode tests', function (hooks) {
         codePath: `${testRealmURL}Pet/mango.json`,
         fileView: 'inspector',
         openDirs: { [testRealmURL]: ['Pet/'] },
-        codeSelection: {},
       });
 
       // Toggle back to interactive mode
@@ -579,7 +576,6 @@ module('Acceptance | operator mode tests', function (hooks) {
         submode: Submodes.Interact,
         fileView: 'inspector',
         openDirs: { [testRealmURL]: ['Pet/'] },
-        codeSelection: {},
       });
     });
   });


### PR DESCRIPTION
Part of code-submode refactor 

- [x] Investigate whether operatorModeStateService.state.codeSelection might be undefined and type accordingly
- [x] Simplify selectedDeclaration
  - [x] Consider whether openDefinition can be simplified to only require one call to operatorModeStateService
  - [x] module is part of CodeRef type **// this argument was removed in another pr.** 


**Before**

```
codeSelection = {} // this used to be a thing in the serialized url
```

```
codeSelection = {codeRef: {module: xxx, name: xxx}} //or
codeSelection = {localName: xxx}
codeSelection = {codeRef: {module: xxx, name: xxx}, localName: xxx} //but this was a possibility too
```

**After**

now codeSelection is either in the url or not. 

```
codeSelection = xxx
```
