### PR TITLE
Do not reload files which are not a subject of invalidation

### DIFF
--- a/packages/host/app/components/operator-mode/card-adoption-chain.gts
+++ b/packages/host/app/components/operator-mode/card-adoption-chain.gts
@@ -13,6 +13,7 @@ import { Type } from '@cardstack/host/resources/card-type';
 import type { Ready } from '@cardstack/host/resources/file';
 
 import { isOwnField } from '@cardstack/host/utils/schema-editor';
+import { stripFileExtension } from '@cardstack/host/lib/utils';
 
 interface Signature {
   Element: HTMLDivElement;
@@ -126,7 +127,6 @@ export default class CardAdoptionChain extends Component<Signature> {
   @action allowFieldManipulation(file: Ready, cardType: Type): boolean {
     // Only allow add/edit/remove for fields from the currently opened module
 
-    // Strip the file extension from the file url
-    return file.url.replace(/\.[^/.]+$/, '') === cardType.module;
+    return stripFileExtension(file.url) === cardType.module;
   }
 }

--- a/packages/host/app/components/operator-mode/card-adoption-chain.gts
+++ b/packages/host/app/components/operator-mode/card-adoption-chain.gts
@@ -9,11 +9,11 @@ import { ModuleSyntax } from '@cardstack/runtime-common/module-syntax';
 import CardSchemaEditor from '@cardstack/host/components/operator-mode/card-schema-editor';
 import { CardInheritance } from '@cardstack/host/components/operator-mode/code-submode/schema-editor';
 
+import { stripFileExtension } from '@cardstack/host/lib/utils';
 import { Type } from '@cardstack/host/resources/card-type';
 import type { Ready } from '@cardstack/host/resources/file';
 
 import { isOwnField } from '@cardstack/host/utils/schema-editor';
-import { stripFileExtension } from '@cardstack/host/lib/utils';
 
 interface Signature {
   Element: HTMLDivElement;
@@ -126,7 +126,6 @@ export default class CardAdoptionChain extends Component<Signature> {
 
   @action allowFieldManipulation(file: Ready, cardType: Type): boolean {
     // Only allow add/edit/remove for fields from the currently opened module
-
     return stripFileExtension(file.url) === cardType.module;
   }
 }

--- a/packages/host/app/lib/utils.ts
+++ b/packages/host/app/lib/utils.ts
@@ -44,3 +44,7 @@ export async function getModulesInRealm(
   }
   return [...modules, ...nestedResults];
 }
+
+export function stripFileExtension(path: string): string {
+  return path.replace(/\.[^/.]+$/, '');
+}

--- a/packages/host/app/resources/file.ts
+++ b/packages/host/app/resources/file.ts
@@ -9,6 +9,7 @@ import { Resource } from 'ember-resources';
 
 import { SupportedMimeType, logger } from '@cardstack/runtime-common';
 
+import { stripFileExtension } from '@cardstack/host/lib/utils';
 import type CardService from '@cardstack/host/services/card-service';
 
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
@@ -17,7 +18,6 @@ import type RecentFilesService from '@cardstack/host/services/recent-files-servi
 import type LoaderService from '../services/loader-service';
 
 import type MessageService from '../services/message-service';
-import { stripFileExtension } from '@cardstack/host/lib/utils';
 
 const log = logger('resource:file');
 const utf8 = new TextDecoder();
@@ -201,6 +201,7 @@ class _FileResource extends Resource<Args> {
           invalidationUrl === stripFileExtension(this.url),
       );
 
+      // Do not reload this file if someone other client else made changes to some other file
       if (isInvalidated) {
         this.read.perform();
       }

--- a/packages/host/app/resources/file.ts
+++ b/packages/host/app/resources/file.ts
@@ -201,7 +201,7 @@ class _FileResource extends Resource<Args> {
           invalidationUrl === stripFileExtension(this.url),
       );
 
-      // Do not reload this file if someone other client else made changes to some other file
+      // Do not reload this file if some other client else made changes to some other file
       if (isInvalidated) {
         this.read.perform();
       }

--- a/packages/host/app/resources/file.ts
+++ b/packages/host/app/resources/file.ts
@@ -197,8 +197,20 @@ class _FileResource extends Resource<Args> {
       }
 
       let isInvalidated = eventData.invalidations.some(
-        (invalidationUrl: string) =>
-          invalidationUrl === stripFileExtension(this.url),
+        (invalidationUrl: string) => {
+          let invalidationUrlHasExtension = invalidationUrl
+            .split('/')
+            .pop()
+            .includes('.');
+
+          // This conditional is here because changes to card instance json files, for example `drafts/Authors/1.json`,
+          // will be in invalidations in the following form: `drafts/Authors/1` (without the .json extension)
+          if (invalidationUrlHasExtension) {
+            return this.url === invalidationUrl;
+          } else {
+            return stripFileExtension(this.url) === invalidationUrl;
+          }
+        },
       );
 
       // Do not reload this file if some other client else made changes to some other file

--- a/packages/host/app/resources/file.ts
+++ b/packages/host/app/resources/file.ts
@@ -200,7 +200,7 @@ class _FileResource extends Resource<Args> {
         (invalidationUrl: string) => {
           let invalidationUrlHasExtension = invalidationUrl
             .split('/')
-            .pop()
+            .pop()!
             .includes('.');
 
           // This conditional is here because changes to card instance json files, for example `drafts/Authors/1.json`,


### PR DESCRIPTION
The problem is that the currently opened file will be reloaded even when some other client makes changes to any other file in the realm. Checking whether file belongs to the invalidations list fixes that. 