### PR TITLE
Better import declaration names for added fields

### DIFF
--- a/packages/host/app/components/operator-mode/edit-field-modal.gts
+++ b/packages/host/app/components/operator-mode/edit-field-modal.gts
@@ -229,6 +229,7 @@ export default class EditFieldModal extends Component<Signature> {
         fieldName,
         fieldRef: fieldRef as { module: string; name: string },
         fieldType,
+        fieldDefinitionType: this.isFieldDef ? 'field' : 'card',
         incomingRelativeTo,
         outgoingRelativeTo: this.loaderService.loader.reverseResolution(
           makeResolvedURL(this.operatorModeStateService.state.codePath!).href,

--- a/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
@@ -745,7 +745,7 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
       "code editor contains line 'luckyNumbers = containsMany(BigIntegerField)'",
     );
 
-    // Field is a card descending from CardDef (cardinality: one)
+    // Field is a definition descending from FieldDef (cardinality: one)
     await waitFor('[data-test-add-field-button]');
     await click('[data-test-add-field-button]');
     await click('[data-test-choose-card-button]');
@@ -771,7 +771,7 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
       "code editor contains line 'favPerson = linksTo(() => Person);'",
     );
 
-    // Field is a card descending from CardDef (cardinality: many)
+    // Field is a definition descending from FieldDef (cardinality: many)
     await waitFor('[data-test-add-field-button]');
     await click('[data-test-add-field-button]');
     await click('[data-test-choose-card-button]');

--- a/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
@@ -680,7 +680,7 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
       )
       .exists();
 
-    assert.ok(getMonacoContent().includes('birthdate = contains(DateCard)'));
+    assert.ok(getMonacoContent().includes('birthdate = contains(DateField)'));
   });
 
   test<TestContextWithSSE>('adding a field from schema editor - cardinality test', async function (assert) {
@@ -740,9 +740,9 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
 
     assert.ok(
       getMonacoContent().includes(
-        'luckyNumbers = containsMany(BigIntegerCard)',
+        'luckyNumbers = containsMany(BigIntegerField)',
       ),
-      "code editor contains line 'luckyNumbers = containsMany(BigIntegerCard)'",
+      "code editor contains line 'luckyNumbers = containsMany(BigIntegerField)'",
     );
 
     // Field is a card descending from CardDef (cardinality: one)
@@ -915,7 +915,7 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
       if (typeof content !== 'string') {
         throw new Error('expected string save data');
       }
-      assert.ok(content.includes('friendCount = contains(BigIntegerCard)'));
+      assert.ok(content.includes('friendCount = contains(BigIntegerField)'));
     });
     await click('[data-test-save-field-button]');
 

--- a/packages/realm-server/tests/module-syntax-test.ts
+++ b/packages/realm-server/tests/module-syntax-test.ts
@@ -38,10 +38,10 @@ module('module-syntax', function () {
   test('can get the code for a card', async function (assert) {
     let src = `
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
-      import StringCard from "https://cardstack.com/base/string";
+      import StringField from "https://cardstack.com/base/string";
 
       export class Person extends CardDef {
-        @field firstName = contains(StringCard);
+        @field firstName = contains(StringField);
         static embedded = class Embedded extends Component<typeof this> {
           <template><h1><@fields.firstName/></h1></template>
         }
@@ -56,9 +56,9 @@ module('module-syntax', function () {
     let mod = addField(
       `
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
-      import StringCard from "https://cardstack.com/base/string";
+      import StringField from "https://cardstack.com/base/string";
       export class Person extends CardDef {
-        @field firstName = contains(StringCard);
+        @field firstName = contains(StringField);
         static embedded = class Embedded extends Component<typeof this> {
           <template><h1><@fields.firstName/></h1></template>
         }
@@ -69,12 +69,12 @@ module('module-syntax', function () {
     assert.codeEqual(
       mod.code(),
       `
-      import NumberCard from "https://cardstack.com/base/number";
+      import NumberField from "https://cardstack.com/base/number";
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
-      import StringCard from "https://cardstack.com/base/string";
+      import StringField from "https://cardstack.com/base/string";
       export class Person extends CardDef {
-        @field firstName = contains(StringCard);
-        @field age = contains(NumberCard);
+        @field firstName = contains(StringField);
+        @field age = contains(NumberField);
         static embedded = class Embedded extends Component<typeof this> {
           <template><h1><@fields.firstName/></h1></template>
         }
@@ -84,12 +84,12 @@ module('module-syntax', function () {
     assert.strictEqual(
       mod.code(),
       `
-      import NumberCard from "https://cardstack.com/base/number";
+      import NumberField from "https://cardstack.com/base/number";
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
-      import StringCard from "https://cardstack.com/base/string";
+      import StringField from "https://cardstack.com/base/string";
       export class Person extends CardDef {
-        @field firstName = contains(StringCard);
-        @field age = contains(NumberCard);
+        @field firstName = contains(StringField);
+        @field age = contains(NumberField);
         static embedded = class Embedded extends Component<typeof this> {
           <template><h1><@fields.firstName/></h1></template>                
         }
@@ -149,14 +149,14 @@ module('module-syntax', function () {
     assert.codeEqual(
       mod.code(),
       `
-        import NumberCard from "https://cardstack.com/base/number";
+        import NumberField from "https://cardstack.com/base/number";
         import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
+        import StringField from "https://cardstack.com/base/string";
 
         export class Person extends CardDef {
-          @field firstName = contains(StringCard);
-          @field age = contains(NumberCard);
-          @field lastName = contains(StringCard);
+          @field firstName = contains(StringField);
+          @field age = contains(NumberField);
+          @field lastName = contains(StringField);
           static embedded = class Embedded extends Component<typeof this> {
             <template><h1><@fields.firstName/></h1></template>
           }
@@ -170,9 +170,9 @@ module('module-syntax', function () {
     let mod = addField(
       `
         import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
+        import StringField from "https://cardstack.com/base/string";
         export class Person extends CardDef {
-            @field firstName = contains(StringCard);
+            @field firstName = contains(StringField);
             static embedded = class Embedded extends Component<typeof this> {
                 <template><h1><@fields.firstName/></h1></template>
             }
@@ -182,12 +182,12 @@ module('module-syntax', function () {
     assert.strictEqual(
       mod.code(),
       `
-        import NumberCard from "https://cardstack.com/base/number";
+        import NumberField from "https://cardstack.com/base/number";
         import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
+        import StringField from "https://cardstack.com/base/string";
         export class Person extends CardDef {
-            @field firstName = contains(StringCard);
-            @field age = contains(NumberCard);
+            @field firstName = contains(StringField);
+            @field age = contains(NumberField);
             static embedded = class Embedded extends Component<typeof this> {
                 <template><h1><@fields.firstName/></h1></template>                
             }
@@ -202,7 +202,7 @@ module('module-syntax', function () {
     let mod = addField(
       `
         import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
+        import StringField from "https://cardstack.com/base/string";
         export class Person extends CardDef {
           static embedded = class Embedded extends Component<typeof this> {
             <template><h1><@fields.firstName/></h1></template>
@@ -213,11 +213,11 @@ module('module-syntax', function () {
     assert.strictEqual(
       mod.code(),
       `
-        import NumberCard from "https://cardstack.com/base/number";
+        import NumberField from "https://cardstack.com/base/number";
         import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
+        import StringField from "https://cardstack.com/base/string";
         export class Person extends CardDef {
-          @field age = contains(NumberCard);
+          @field age = contains(NumberField);
           static embedded = class Embedded extends Component<typeof this> {
             <template><h1><@fields.firstName/></h1></template>                
           }
@@ -231,7 +231,7 @@ module('module-syntax', function () {
     let mod = addField(
       `
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
-      import StringCard from "https://cardstack.com/base/string";
+      import StringField from "https://cardstack.com/base/string";
       export class Person extends CardDef {
       }
       `,
@@ -240,11 +240,11 @@ module('module-syntax', function () {
     assert.strictEqual(
       mod.code(),
       `
-      import NumberCard from "https://cardstack.com/base/number";
+      import NumberField from "https://cardstack.com/base/number";
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
-      import StringCard from "https://cardstack.com/base/string";
+      import StringField from "https://cardstack.com/base/string";
       export class Person extends CardDef {
-        @field age = contains(NumberCard);
+        @field age = contains(NumberField);
       }
       `,
       'original code formatting is preserved',
@@ -252,7 +252,7 @@ module('module-syntax', function () {
     mod = addField(
       `
         import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
+        import StringField from "https://cardstack.com/base/string";
         export class Person extends CardDef { }
       `,
     );
@@ -260,11 +260,11 @@ module('module-syntax', function () {
     assert.strictEqual(
       mod.code(),
       `
-        import NumberCard from "https://cardstack.com/base/number";
+        import NumberField from "https://cardstack.com/base/number";
         import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
+        import StringField from "https://cardstack.com/base/string";
         export class Person extends CardDef { 
-          @field age = contains(NumberCard);
+          @field age = contains(NumberField);
         }
       `,
       'original code formatting is preserved',
@@ -273,7 +273,7 @@ module('module-syntax', function () {
     mod = addField(
       `
         import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
+        import StringField from "https://cardstack.com/base/string";
         export class Person extends CardDef {}
       `,
     );
@@ -281,11 +281,11 @@ module('module-syntax', function () {
     assert.strictEqual(
       mod.code(),
       `
-        import NumberCard from "https://cardstack.com/base/number";
+        import NumberField from "https://cardstack.com/base/number";
         import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
+        import StringField from "https://cardstack.com/base/string";
         export class Person extends CardDef {
-          @field age = contains(NumberCard);
+          @field age = contains(NumberField);
         }
       `,
       'original code formatting is preserved',
@@ -297,9 +297,9 @@ module('module-syntax', function () {
     let mod = addField(
       `
         import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
+        import StringField from "https://cardstack.com/base/string";
         export class Person extends CardDef {
-            @field firstName = contains(StringCard);
+            @field firstName = contains(StringField);
             static embedded = class Embedded extends Component<typeof this> {
                 <template><h1><@fields.firstName/></h1></template>
             }
@@ -310,12 +310,12 @@ module('module-syntax', function () {
     assert.strictEqual(
       mod.code(),
       `
-        import NumberCard from "https://cardstack.com/base/number";
+        import NumberField from "https://cardstack.com/base/number";
         import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
+        import StringField from "https://cardstack.com/base/string";
         export class Person extends CardDef {
-            @field age = contains(NumberCard);
-            @field firstName = contains(StringCard);
+            @field age = contains(NumberField);
+            @field firstName = contains(StringField);
             static embedded = class Embedded extends Component<typeof this> {
                 <template><h1><@fields.firstName/></h1></template>                
             }
@@ -328,9 +328,9 @@ module('module-syntax', function () {
   test('can add a field to a card when the module url is relative', async function (assert) {
     let src = `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
-      import StringCard from "https://cardstack.com/base/string";
+      import StringField from "https://cardstack.com/base/string";
       export class Pet extends CardDef {
-        @field petName = contains(StringCard);
+        @field petName = contains(StringField);
       }
     `;
 
@@ -354,12 +354,12 @@ module('module-syntax', function () {
     assert.codeEqual(
       mod.code(),
       `
-        import { Person as PersonCard } from "./person";
+        import { Person } from "./person";
         import { contains, field, CardDef, linksTo } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
+        import StringField from "https://cardstack.com/base/string";
         export class Pet extends CardDef {
-          @field petName = contains(StringCard);
-          @field bestFriend = linksTo(PersonCard);
+          @field petName = contains(StringField);
+          @field bestFriend = linksTo(Person);
         }
       `,
     );
@@ -368,9 +368,9 @@ module('module-syntax', function () {
   test('can add a field to a card when the module url is from another realm', async function (assert) {
     let src = `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
-      import StringCard from "https://cardstack.com/base/string";
+      import StringField from "https://cardstack.com/base/string";
       export class Pet extends CardDef {
-        @field petName = contains(StringCard);
+        @field petName = contains(StringField);
       }
     `;
 
@@ -392,12 +392,12 @@ module('module-syntax', function () {
     assert.codeEqual(
       mod.code(),
       `
-        import { Person as PersonCard } from "http://localhost:4202/test/person";
+        import { Person } from "http://localhost:4202/test/person";
         import { contains, field, CardDef, linksTo } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
+        import StringField from "https://cardstack.com/base/string";
         export class Pet extends CardDef {
-          @field petName = contains(StringCard);
-          @field bestFriend = linksTo(PersonCard);
+          @field petName = contains(StringField);
+          @field bestFriend = linksTo(Person);
         }
       `,
     );
@@ -427,11 +427,11 @@ module('module-syntax', function () {
     assert.codeEqual(
       mod.code(),
       `
-          import StringCard from "https://cardstack.com/base/string";
+          import StringField from "https://cardstack.com/base/string";
           import { CardDef, field, contains } from "https://cardstack.com/base/card-api";
 
           export class Person extends CardDef {
-            @field firstName = contains(StringCard);
+            @field firstName = contains(StringField);
           }
         `,
     );
@@ -440,14 +440,14 @@ module('module-syntax', function () {
   test('can add a field to an interior card that is the field of card that is exported', async function (assert) {
     let src = `
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
-      import StringCard from "https://cardstack.com/base/string";
+      import StringField from "https://cardstack.com/base/string";
 
       class Details extends CardDef {
-        @field favoriteColor = contains(StringCard);
+        @field favoriteColor = contains(StringField);
       }
 
       export class Person extends CardDef {
-        @field firstName = contains(StringCard);
+        @field firstName = contains(StringField);
         @field details = contains(Details);
         static embedded = class Embedded extends Component<typeof this> {
           <template><h1><@fields.firstName/></h1></template>
@@ -476,17 +476,17 @@ module('module-syntax', function () {
     assert.codeEqual(
       mod.code(),
       `
-        import NumberCard from "https://cardstack.com/base/number";
+        import NumberField from "https://cardstack.com/base/number";
         import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
+        import StringField from "https://cardstack.com/base/string";
 
         class Details extends CardDef {
-          @field favoriteColor = contains(StringCard);
-          @field age = contains(NumberCard);
+          @field favoriteColor = contains(StringField);
+          @field age = contains(NumberField);
         }
 
         export class Person extends CardDef {
-          @field firstName = contains(StringCard);
+          @field firstName = contains(StringField);
           @field details = contains(Details);
           static embedded = class Embedded extends Component<typeof this> {
             <template><h1><@fields.firstName/></h1></template>
@@ -499,17 +499,17 @@ module('module-syntax', function () {
   test('can add a field to an interior card that is the ancestor of card that is exported', async function (assert) {
     let src = `
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
-      import StringCard from "https://cardstack.com/base/string";
+      import StringField from "https://cardstack.com/base/string";
 
       class Person extends CardDef {
-        @field firstName = contains(StringCard);
+        @field firstName = contains(StringField);
         static embedded = class Embedded extends Component<typeof this> {
           <template><h1><@fields.firstName/></h1></template>
         }
       }
 
       export class FancyPerson extends Person {
-        @field favoriteColor = contains(StringCard);
+        @field favoriteColor = contains(StringField);
       }
     `;
 
@@ -533,20 +533,20 @@ module('module-syntax', function () {
     assert.codeEqual(
       mod.code(),
       `
-        import NumberCard from "https://cardstack.com/base/number";
+        import NumberField from "https://cardstack.com/base/number";
         import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
+        import StringField from "https://cardstack.com/base/string";
 
         class Person extends CardDef {
-          @field firstName = contains(StringCard);
-          @field age = contains(NumberCard);
+          @field firstName = contains(StringField);
+          @field age = contains(NumberField);
           static embedded = class Embedded extends Component<typeof this> {
             <template><h1><@fields.firstName/></h1></template>
           }
         }
 
         export class FancyPerson extends Person {
-          @field favoriteColor = contains(StringCard);
+          @field favoriteColor = contains(StringField);
         }
       `,
     );
@@ -555,16 +555,16 @@ module('module-syntax', function () {
   test('can add a field to an interior card within a module that also has non card declarations', async function (assert) {
     let src = `
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
-      import StringCard from "https://cardstack.com/base/string";
+      import StringField from "https://cardstack.com/base/string";
 
       export class Foo {}
 
       class Details extends CardDef {
-        @field favoriteColor = contains(StringCard);
+        @field favoriteColor = contains(StringField);
       }
 
       export class Person extends CardDef {
-        @field firstName = contains(StringCard);
+        @field firstName = contains(StringField);
         @field details = contains(Details);
         static embedded = class Embedded extends Component<typeof this> {
           <template><h1><@fields.firstName/></h1></template>
@@ -593,19 +593,19 @@ module('module-syntax', function () {
     assert.codeEqual(
       mod.code(),
       `
-        import NumberCard from "https://cardstack.com/base/number";
+        import NumberField from "https://cardstack.com/base/number";
         import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
+        import StringField from "https://cardstack.com/base/string";
 
         export class Foo {}
 
         class Details extends CardDef {
-          @field favoriteColor = contains(StringCard);
-          @field age = contains(NumberCard);
+          @field favoriteColor = contains(StringField);
+          @field age = contains(NumberField);
         }
 
         export class Person extends CardDef {
-          @field firstName = contains(StringCard);
+          @field firstName = contains(StringField);
           @field details = contains(Details);
           static embedded = class Embedded extends Component<typeof this> {
             <template><h1><@fields.firstName/></h1></template>
@@ -618,10 +618,10 @@ module('module-syntax', function () {
   test('can add a containsMany field', async function (assert) {
     let src = `
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
-      import StringCard from "https://cardstack.com/base/string";
+      import StringField from "https://cardstack.com/base/string";
 
       export class Person extends CardDef {
-        @field firstName = contains(StringCard);
+        @field firstName = contains(StringField);
         static embedded = class Embedded extends Component<typeof this> {
           <template><h1><@fields.firstName/></h1></template>
         }
@@ -646,11 +646,11 @@ module('module-syntax', function () {
       mod.code(),
       `
         import { contains, field, Component, CardDef, containsMany } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
+        import StringField from "https://cardstack.com/base/string";
 
         export class Person extends CardDef {
-          @field firstName = contains(StringCard);
-          @field aliases = containsMany(StringCard);
+          @field firstName = contains(StringField);
+          @field aliases = containsMany(StringField);
           static embedded = class Embedded extends Component<typeof this> {
             <template><h1><@fields.firstName/></h1></template>
           }
@@ -675,9 +675,9 @@ module('module-syntax', function () {
     let realm = await createRealm(loader, dirSync().name, {
       'pet.gts': `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
-      import StringCard from "https://cardstack.com/base/string";
+      import StringField from "https://cardstack.com/base/string";
       export class Pet extends CardDef {
-        @field petName = contains(StringCard);
+        @field petName = contains(StringField);
       }
     `,
     });
@@ -685,9 +685,9 @@ module('module-syntax', function () {
 
     let src = `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
-      import StringCard from "https://cardstack.com/base/string";
+      import StringField from "https://cardstack.com/base/string";
       export class Person extends CardDef {
-        @field firstName = contains(StringCard);
+        @field firstName = contains(StringField);
       }
     `;
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
@@ -707,12 +707,12 @@ module('module-syntax', function () {
     assert.codeEqual(
       mod.code(),
       `
-        import { Pet as PetCard } from "${testRealm}dir/pet";
+        import { Pet } from "${testRealm}dir/pet";
         import { contains, field, CardDef, linksTo } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
+        import StringField from "https://cardstack.com/base/string";
         export class Person extends CardDef {
-          @field firstName = contains(StringCard);
-          @field pet = linksTo(PetCard);
+          @field firstName = contains(StringField);
+          @field pet = linksTo(Pet);
         }
       `,
     );
@@ -733,10 +733,10 @@ module('module-syntax', function () {
   test('can add a linksTo field with the same type as its enclosing card', async function (assert) {
     let src = `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
-      import StringCard from "https://cardstack.com/base/string";
+      import StringField from "https://cardstack.com/base/string";
 
       export class Person extends CardDef {
-        @field firstName = contains(StringCard);
+        @field firstName = contains(StringField);
       }
     `;
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
@@ -757,10 +757,10 @@ module('module-syntax', function () {
       mod.code(),
       `
         import { contains, field, CardDef, linksTo } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
+        import StringField from "https://cardstack.com/base/string";
 
         export class Person extends CardDef {
-          @field firstName = contains(StringCard);
+          @field firstName = contains(StringField);
           @field friend = linksTo(() => Person);
         }
       `,
@@ -782,12 +782,12 @@ module('module-syntax', function () {
   test('can handle field card declaration collisions when adding field', async function (assert) {
     let src = `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
-      import StringCard from "https://cardstack.com/base/string";
+      import StringField from "https://cardstack.com/base/string";
 
-      const NumberCard = "don't collide with me";
+      const NumberField = "don't collide with me";
 
       export class Person extends CardDef {
-        @field firstName = contains(StringCard);
+        @field firstName = contains(StringField);
       }
     `;
 
@@ -808,15 +808,54 @@ module('module-syntax', function () {
     assert.codeEqual(
       mod.code(),
       `
-        import NumberCard0 from "https://cardstack.com/base/number";
+        import NumberField0 from "https://cardstack.com/base/number";
         import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
+        import StringField from "https://cardstack.com/base/string";
 
-        const NumberCard = "don't collide with me";
+        const NumberField = "don't collide with me";
 
         export class Person extends CardDef {
-          @field firstName = contains(StringCard);
-          @field age = contains(NumberCard0);
+          @field firstName = contains(StringField);
+          @field age = contains(NumberField0);
+        }
+      `,
+    );
+  });
+
+  test('can handle builtin object collisions when adding a field', async function (assert) {
+    let src = `
+      import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
+      import StringField from "https://cardstack.com/base/string";
+
+      export class Person extends CardDef {
+        @field firstName = contains(StringField);
+      }
+    `;
+
+    let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
+    mod.addField({
+      cardBeingModified: { module: `${testRealm}dir/person`, name: 'Person' },
+      fieldName: 'map',
+      fieldRef: {
+        module: './map',
+        name: 'default',
+      },
+      fieldType: 'contains',
+      incomingRelativeTo: undefined,
+      outgoingRelativeTo: undefined,
+      outgoingRealmURL: undefined,
+    });
+
+    assert.codeEqual(
+      mod.code(),
+      `
+        import Map0 from "./map";
+        import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
+        import StringField from "https://cardstack.com/base/string";
+
+        export class Person extends CardDef {
+          @field firstName = contains(StringField);
+          @field map = contains(Map0);
         }
       `,
     );
@@ -828,10 +867,10 @@ module('module-syntax', function () {
   test('throws when adding a field with a name the card already has', async function (assert) {
     let src = `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
-      import StringCard from "https://cardstack.com/base/string";
+      import StringField from "https://cardstack.com/base/string";
 
       export class Person extends CardDef {
-        @field firstName = contains(StringCard);
+        @field firstName = contains(StringField);
       }
     `;
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
@@ -860,11 +899,11 @@ module('module-syntax', function () {
   test('can remove a field from a card', async function (assert) {
     let src = `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
-      import StringCard from "https://cardstack.com/base/string";
+      import StringField from "https://cardstack.com/base/string";
 
       export class Person extends CardDef {
-        @field firstName = contains(StringCard);
-        @field lastName = contains(StringCard);
+        @field firstName = contains(StringField);
+        @field lastName = contains(StringField);
       }
     `;
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
@@ -877,10 +916,10 @@ module('module-syntax', function () {
       mod.code(),
       `
         import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
+        import StringField from "https://cardstack.com/base/string";
 
         export class Person extends CardDef {
-          @field lastName = contains(StringCard);
+          @field lastName = contains(StringField);
         }
       `,
     );
@@ -888,10 +927,10 @@ module('module-syntax', function () {
       mod.code().trim(),
       `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
-      import StringCard from "https://cardstack.com/base/string";
+      import StringField from "https://cardstack.com/base/string";
 
       export class Person extends CardDef {
-        @field lastName = contains(StringCard);
+        @field lastName = contains(StringField);
       }
       `.trim(),
       'original code formatting is preserved',
@@ -905,13 +944,13 @@ module('module-syntax', function () {
   test('can use remove & add a field to achieve edit in place', async function (assert) {
     let src = `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
-      import StringCard from "https://cardstack.com/base/string";
+      import StringField from "https://cardstack.com/base/string";
 
       export class Person extends CardDef {
-        @field firstName = contains(StringCard);
-        @field lastName = contains(StringCard);
-        @field artistName = contains(StringCard);
-        @field streetName = contains(StringCard);
+        @field firstName = contains(StringField);
+        @field lastName = contains(StringField);
+        @field artistName = contains(StringField);
+        @field streetName = contains(StringField);
       }
     `;
 
@@ -939,13 +978,13 @@ module('module-syntax', function () {
       mod.code(),
       `
         import { contains, field, CardDef, containsMany } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
+        import StringField from "https://cardstack.com/base/string";
 
         export class Person extends CardDef {
-          @field firstName = contains(StringCard);
-          @field lastName = contains(StringCard);
-          @field artistNames = containsMany(StringCard);
-          @field streetName = contains(StringCard);
+          @field firstName = contains(StringField);
+          @field lastName = contains(StringField);
+          @field artistNames = containsMany(StringField);
+          @field streetName = contains(StringField);
         }
       `,
     );
@@ -954,13 +993,13 @@ module('module-syntax', function () {
   test('can use remove & add a field to achieve edit in place - when field is at the beginning', async function (assert) {
     let src = `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
-      import StringCard from "https://cardstack.com/base/string";
+      import StringField from "https://cardstack.com/base/string";
 
       export class Person extends CardDef {
-        @field firstName = contains(StringCard);
-        @field lastName = contains(StringCard);
-        @field artistName = contains(StringCard);
-        @field streetName = contains(StringCard);
+        @field firstName = contains(StringField);
+        @field lastName = contains(StringField);
+        @field artistName = contains(StringField);
+        @field streetName = contains(StringField);
       }
     `;
 
@@ -988,13 +1027,13 @@ module('module-syntax', function () {
       mod.code(),
       `
         import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
+        import StringField from "https://cardstack.com/base/string";
 
         export class Person extends CardDef {
-          @field firstNameAdjusted = contains(StringCard);
-          @field lastName = contains(StringCard);
-          @field artistName = contains(StringCard);
-          @field streetName = contains(StringCard);
+          @field firstNameAdjusted = contains(StringField);
+          @field lastName = contains(StringField);
+          @field artistName = contains(StringField);
+          @field streetName = contains(StringField);
         }
       `,
     );
@@ -1003,13 +1042,13 @@ module('module-syntax', function () {
   test('can use remove & add a field to achieve edit in place - when field is at the end', async function (assert) {
     let src = `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
-      import StringCard from "https://cardstack.com/base/string";
+      import StringField from "https://cardstack.com/base/string";
 
       export class Person extends CardDef {
-        @field firstName = contains(StringCard);
-        @field lastName = contains(StringCard);
-        @field artistName = contains(StringCard);
-        @field streetName = contains(StringCard);
+        @field firstName = contains(StringField);
+        @field lastName = contains(StringField);
+        @field artistName = contains(StringField);
+        @field streetName = contains(StringField);
       }
     `;
 
@@ -1037,13 +1076,13 @@ module('module-syntax', function () {
       mod.code(),
       `
         import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
+        import StringField from "https://cardstack.com/base/string";
 
         export class Person extends CardDef {
-          @field firstName = contains(StringCard);
-          @field lastName = contains(StringCard);
-          @field artistName = contains(StringCard);
-          @field streetNameAdjusted = contains(StringCard);
+          @field firstName = contains(StringField);
+          @field lastName = contains(StringField);
+          @field artistName = contains(StringField);
+          @field streetNameAdjusted = contains(StringField);
         }
       `,
     );
@@ -1052,10 +1091,10 @@ module('module-syntax', function () {
   test('can remove the last field from a card', async function (assert) {
     let src = `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
-      import StringCard from "https://cardstack.com/base/string";
+      import StringField from "https://cardstack.com/base/string";
 
       export class Person extends CardDef {
-        @field firstName = contains(StringCard);
+        @field firstName = contains(StringField);
       }
     `;
 
@@ -1077,10 +1116,10 @@ module('module-syntax', function () {
   test('can remove a linksTo field with the same type as its enclosing card', async function (assert) {
     let src = `
       import { contains, field, CardDef, linksTo } from "https://cardstack.com/base/card-api";
-      import StringCard from "https://cardstack.com/base/string";
+      import StringField from "https://cardstack.com/base/string";
 
       export class Friend extends CardDef {
-        @field firstName = contains(StringCard);
+        @field firstName = contains(StringField);
         @field friend = linksTo(() => Friend);
       }
     `;
@@ -1094,10 +1133,10 @@ module('module-syntax', function () {
       mod.code(),
       `
         import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
+        import StringField from "https://cardstack.com/base/string";
 
         export class Friend extends CardDef {
-          @field firstName = contains(StringCard);
+          @field firstName = contains(StringField);
         }
       `,
     );
@@ -1110,15 +1149,15 @@ module('module-syntax', function () {
   test('can remove the field of an interior card that is the ancestor of a card that is exported', async function (assert) {
     let src = `
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
-      import StringCard from "https://cardstack.com/base/string";
+      import StringField from "https://cardstack.com/base/string";
 
       class Person extends CardDef {
-        @field firstName = contains(StringCard);
-        @field lastName = contains(StringCard);
+        @field firstName = contains(StringField);
+        @field lastName = contains(StringField);
       }
 
       export class FancyPerson extends Person {
-        @field favoriteColor = contains(StringCard);
+        @field favoriteColor = contains(StringField);
       }
     `;
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
@@ -1134,14 +1173,14 @@ module('module-syntax', function () {
       mod.code(),
       `
         import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
+        import StringField from "https://cardstack.com/base/string";
 
         class Person extends CardDef {
-          @field lastName = contains(StringCard);
+          @field lastName = contains(StringField);
         }
 
         export class FancyPerson extends Person {
-          @field favoriteColor = contains(StringCard);
+          @field favoriteColor = contains(StringField);
         }
       `,
     );
@@ -1150,16 +1189,16 @@ module('module-syntax', function () {
   test('can remove the field of an interior card that is the field of a card that is exported', async function (assert) {
     let src = `
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
-      import StringCard from "https://cardstack.com/base/string";
+      import StringField from "https://cardstack.com/base/string";
 
       class Details extends CardDef {
-        @field nickName = contains(StringCard);
-        @field favoriteColor = contains(StringCard);
+        @field nickName = contains(StringField);
+        @field favoriteColor = contains(StringField);
       }
 
       export class Person extends CardDef {
-        @field firstName = contains(StringCard);
-        @field lastName = contains(StringCard);
+        @field firstName = contains(StringField);
+        @field lastName = contains(StringField);
         @field details = contains(Details);
       }
     `;
@@ -1177,15 +1216,15 @@ module('module-syntax', function () {
       mod.code(),
       `
         import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
-        import StringCard from "https://cardstack.com/base/string";
+        import StringField from "https://cardstack.com/base/string";
 
         class Details extends CardDef {
-          @field favoriteColor = contains(StringCard);
+          @field favoriteColor = contains(StringField);
         }
 
         export class Person extends CardDef {
-          @field firstName = contains(StringCard);
-          @field lastName = contains(StringCard);
+          @field firstName = contains(StringField);
+          @field lastName = contains(StringField);
           @field details = contains(Details);
         }
       `,
@@ -1195,10 +1234,10 @@ module('module-syntax', function () {
   test('throws when field to remove does not actually exist', async function (assert) {
     let src = `
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
-      import StringCard from "https://cardstack.com/base/string";
+      import StringField from "https://cardstack.com/base/string";
 
       export class Person extends CardDef {
-        @field firstName = contains(StringCard);
+        @field firstName = contains(StringField);
       }
     `;
 

--- a/packages/realm-server/tests/module-syntax-test.ts
+++ b/packages/realm-server/tests/module-syntax-test.ts
@@ -6,7 +6,7 @@ import { testRealm, createRealm } from './helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 import { shimExternals } from '../lib/externals';
 
-module('module-syntax', function () {
+module.only('module-syntax', function () {
   let loader = new Loader();
   loader.addURLMapping(
     new URL(baseRealm.url),
@@ -27,6 +27,7 @@ module('module-syntax', function () {
         name: 'default',
       },
       fieldType: 'contains',
+      fieldDefinitionType: 'field',
       addFieldAtIndex,
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
@@ -142,6 +143,7 @@ module('module-syntax', function () {
         name: 'default',
       },
       fieldType: 'contains',
+      fieldDefinitionType: 'field',
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
       outgoingRealmURL: undefined,
@@ -344,6 +346,7 @@ module('module-syntax', function () {
         name: 'Person',
       },
       fieldType: 'linksTo',
+      fieldDefinitionType: 'card',
       incomingRelativeTo: new URL(
         `http://localhost:4202/node-test/catalog-entry/1`,
       ), // hypothethical catalog entry that lives at this id
@@ -354,12 +357,12 @@ module('module-syntax', function () {
     assert.codeEqual(
       mod.code(),
       `
-        import { Person } from "./person";
+        import { Person as PersonCard } from "./person";
         import { contains, field, CardDef, linksTo } from "https://cardstack.com/base/card-api";
         import StringField from "https://cardstack.com/base/string";
         export class Pet extends CardDef {
           @field petName = contains(StringField);
-          @field bestFriend = linksTo(Person);
+          @field bestFriend = linksTo(PersonCard);
         }
       `,
     );
@@ -384,6 +387,7 @@ module('module-syntax', function () {
         name: 'Person',
       },
       fieldType: 'linksTo',
+      fieldDefinitionType: 'card',
       incomingRelativeTo: new URL(`http://localhost:4202/test/catalog-entry/1`), // hypothethical catalog entry that lives at this id
       outgoingRelativeTo: new URL('http://localhost:4202/node-test/pet'), // outgoing card
       outgoingRealmURL: new URL('http://localhost:4202/node-test/'), // the realm that the catalog entry lives in
@@ -392,12 +396,12 @@ module('module-syntax', function () {
     assert.codeEqual(
       mod.code(),
       `
-        import { Person } from "http://localhost:4202/test/person";
+        import { Person as PersonCard } from "http://localhost:4202/test/person";
         import { contains, field, CardDef, linksTo } from "https://cardstack.com/base/card-api";
         import StringField from "https://cardstack.com/base/string";
         export class Pet extends CardDef {
           @field petName = contains(StringField);
-          @field bestFriend = linksTo(Person);
+          @field bestFriend = linksTo(PersonCard);
         }
       `,
     );
@@ -419,6 +423,7 @@ module('module-syntax', function () {
         name: 'default',
       },
       fieldType: 'contains',
+      fieldDefinitionType: 'field',
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
       outgoingRealmURL: undefined,
@@ -463,6 +468,7 @@ module('module-syntax', function () {
         card: { module: `${testRealm}dir/person`, name: 'Person' },
       },
       fieldName: 'age',
+      fieldDefinitionType: 'field',
       fieldRef: {
         module: 'https://cardstack.com/base/number',
         name: 'default',
@@ -520,6 +526,7 @@ module('module-syntax', function () {
         card: { module: `${testRealm}dir/person`, name: 'FancyPerson' },
       },
       fieldName: 'age',
+      fieldDefinitionType: 'field',
       fieldRef: {
         module: 'https://cardstack.com/base/number',
         name: 'default',
@@ -580,6 +587,7 @@ module('module-syntax', function () {
         card: { module: `${testRealm}dir/person`, name: 'Person' },
       },
       fieldName: 'age',
+      fieldDefinitionType: 'field',
       fieldRef: {
         module: 'https://cardstack.com/base/number',
         name: 'default',
@@ -632,6 +640,7 @@ module('module-syntax', function () {
     mod.addField({
       cardBeingModified: { module: `${testRealm}dir/person`, name: 'Person' },
       fieldName: 'aliases',
+      fieldDefinitionType: 'field',
       fieldRef: {
         module: 'https://cardstack.com/base/string',
         name: 'default',
@@ -698,6 +707,7 @@ module('module-syntax', function () {
         module: `${testRealm}dir/pet`,
         name: 'Pet',
       },
+      fieldDefinitionType: 'card',
       fieldType: 'linksTo',
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
@@ -707,12 +717,12 @@ module('module-syntax', function () {
     assert.codeEqual(
       mod.code(),
       `
-        import { Pet } from "${testRealm}dir/pet";
+        import { Pet as PetCard } from "${testRealm}dir/pet";
         import { contains, field, CardDef, linksTo } from "https://cardstack.com/base/card-api";
         import StringField from "https://cardstack.com/base/string";
         export class Person extends CardDef {
           @field firstName = contains(StringField);
-          @field pet = linksTo(Pet);
+          @field pet = linksTo(PetCard);
         }
       `,
     );
@@ -748,6 +758,7 @@ module('module-syntax', function () {
         name: 'Person',
       },
       fieldType: 'linksTo',
+      fieldDefinitionType: 'card',
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
       outgoingRealmURL: undefined,
@@ -800,6 +811,7 @@ module('module-syntax', function () {
         name: 'default',
       },
       fieldType: 'contains',
+      fieldDefinitionType: 'field',
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
       outgoingRealmURL: undefined,
@@ -817,45 +829,6 @@ module('module-syntax', function () {
         export class Person extends CardDef {
           @field firstName = contains(StringField);
           @field age = contains(NumberField0);
-        }
-      `,
-    );
-  });
-
-  test('can handle builtin object collisions when adding a field', async function (assert) {
-    let src = `
-      import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
-      import StringField from "https://cardstack.com/base/string";
-
-      export class Person extends CardDef {
-        @field firstName = contains(StringField);
-      }
-    `;
-
-    let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
-    mod.addField({
-      cardBeingModified: { module: `${testRealm}dir/person`, name: 'Person' },
-      fieldName: 'map',
-      fieldRef: {
-        module: './map',
-        name: 'default',
-      },
-      fieldType: 'contains',
-      incomingRelativeTo: undefined,
-      outgoingRelativeTo: undefined,
-      outgoingRealmURL: undefined,
-    });
-
-    assert.codeEqual(
-      mod.code(),
-      `
-        import Map0 from "./map";
-        import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
-        import StringField from "https://cardstack.com/base/string";
-
-        export class Person extends CardDef {
-          @field firstName = contains(StringField);
-          @field map = contains(Map0);
         }
       `,
     );
@@ -883,6 +856,7 @@ module('module-syntax', function () {
           name: 'default',
         },
         fieldType: 'contains',
+        fieldDefinitionType: 'field',
         incomingRelativeTo: undefined,
         outgoingRelativeTo: undefined,
         outgoingRealmURL: undefined,
@@ -968,6 +942,7 @@ module('module-syntax', function () {
         name: 'default',
       },
       fieldType: 'containsMany',
+      fieldDefinitionType: 'field',
       addFieldAtIndex,
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
@@ -1017,6 +992,7 @@ module('module-syntax', function () {
         name: 'default',
       },
       fieldType: 'contains',
+      fieldDefinitionType: 'field',
       addFieldAtIndex,
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
@@ -1066,6 +1042,7 @@ module('module-syntax', function () {
         name: 'default',
       },
       fieldType: 'contains',
+      fieldDefinitionType: 'field',
       addFieldAtIndex,
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,

--- a/packages/realm-server/tests/module-syntax-test.ts
+++ b/packages/realm-server/tests/module-syntax-test.ts
@@ -1,16 +1,16 @@
-import { module, test } from "qunit";
-import { ModuleSyntax } from "@cardstack/runtime-common/module-syntax";
-import { dirSync } from "tmp";
-import { Loader, baseRealm } from "@cardstack/runtime-common";
-import { testRealm, createRealm } from "./helpers";
-import "@cardstack/runtime-common/helpers/code-equality-assertion";
-import { shimExternals } from "../lib/externals";
+import { module, test } from 'qunit';
+import { ModuleSyntax } from '@cardstack/runtime-common/module-syntax';
+import { dirSync } from 'tmp';
+import { Loader, baseRealm } from '@cardstack/runtime-common';
+import { testRealm, createRealm } from './helpers';
+import '@cardstack/runtime-common/helpers/code-equality-assertion';
+import { shimExternals } from '../lib/externals';
 
-module("module-syntax", function () {
+module('module-syntax', function () {
   let loader = new Loader();
   loader.addURLMapping(
     new URL(baseRealm.url),
-    new URL("http://localhost:4201/base/"),
+    new URL('http://localhost:4201/base/'),
   );
   shimExternals(loader);
 
@@ -19,14 +19,14 @@ module("module-syntax", function () {
     mod.addField({
       cardBeingModified: {
         module: `${testRealm}dir/person.gts`,
-        name: "Person",
+        name: 'Person',
       },
-      fieldName: "age",
+      fieldName: 'age',
       fieldRef: {
-        module: "https://cardstack.com/base/number",
-        name: "default",
+        module: 'https://cardstack.com/base/number',
+        name: 'default',
       },
-      fieldType: "contains",
+      fieldType: 'contains',
       addFieldAtIndex,
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
@@ -35,7 +35,7 @@ module("module-syntax", function () {
     return mod;
   }
 
-  test("can get the code for a card", async function (assert) {
+  test('can get the code for a card', async function (assert) {
     let src = `
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -52,7 +52,7 @@ module("module-syntax", function () {
     assert.codeEqual(mod.code(), src);
   });
 
-  test("can add a field to a card", async function (assert) {
+  test('can add a field to a card', async function (assert) {
     let mod = addField(
       `
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
@@ -95,38 +95,38 @@ module("module-syntax", function () {
         }
       }
       `,
-      "original code formatting is preserved",
+      'original code formatting is preserved',
     );
 
-    let card = mod.possibleCardsOrFields.find((c) => c.exportName === "Person");
-    let field = card!.possibleFields.get("age");
-    assert.ok(field, "new field was added to syntax");
+    let card = mod.possibleCardsOrFields.find((c) => c.exportName === 'Person');
+    let field = card!.possibleFields.get('age');
+    assert.ok(field, 'new field was added to syntax');
     assert.deepEqual(
       field?.card,
       {
-        type: "external",
-        module: "https://cardstack.com/base/number",
-        name: "default",
+        type: 'external',
+        module: 'https://cardstack.com/base/number',
+        name: 'default',
       },
-      "the field card is correct",
+      'the field card is correct',
     );
     assert.deepEqual(
       field?.type,
       {
-        type: "external",
-        module: "https://cardstack.com/base/card-api",
-        name: "contains",
+        type: 'external',
+        module: 'https://cardstack.com/base/card-api',
+        name: 'contains',
       },
-      "the field type is correct",
+      'the field type is correct',
     );
     assert.deepEqual(
       field?.decorator,
       {
-        type: "external",
-        module: "https://cardstack.com/base/card-api",
-        name: "field",
+        type: 'external',
+        module: 'https://cardstack.com/base/card-api',
+        name: 'field',
       },
-      "the field decorator is correct",
+      'the field decorator is correct',
     );
 
     // add another field which will assert that the field path is correct since
@@ -134,14 +134,14 @@ module("module-syntax", function () {
     mod.addField({
       cardBeingModified: {
         module: `${testRealm}dir/person.gts`,
-        name: "Person",
+        name: 'Person',
       },
-      fieldName: "lastName",
+      fieldName: 'lastName',
       fieldRef: {
-        module: "https://cardstack.com/base/string",
-        name: "default",
+        module: 'https://cardstack.com/base/string',
+        name: 'default',
       },
-      fieldType: "contains",
+      fieldType: 'contains',
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
       outgoingRealmURL: undefined,
@@ -165,7 +165,7 @@ module("module-syntax", function () {
     );
   });
 
-  test("added field respects indentation of previous field", async function (assert) {
+  test('added field respects indentation of previous field', async function (assert) {
     // 4 space indent
     let mod = addField(
       `
@@ -193,11 +193,11 @@ module("module-syntax", function () {
             }
         }
       `,
-      "original code formatting is preserved",
+      'original code formatting is preserved',
     );
   });
 
-  test("added field respects indentation of previous class member", async function (assert) {
+  test('added field respects indentation of previous class member', async function (assert) {
     // 2 space indent
     let mod = addField(
       `
@@ -223,7 +223,7 @@ module("module-syntax", function () {
           }
         }
       `,
-      "original code formatting is preserved",
+      'original code formatting is preserved',
     );
   });
 
@@ -247,7 +247,7 @@ module("module-syntax", function () {
         @field age = contains(NumberCard);
       }
       `,
-      "original code formatting is preserved",
+      'original code formatting is preserved',
     );
     mod = addField(
       `
@@ -267,7 +267,7 @@ module("module-syntax", function () {
           @field age = contains(NumberCard);
         }
       `,
-      "original code formatting is preserved",
+      'original code formatting is preserved',
     );
 
     mod = addField(
@@ -288,7 +288,7 @@ module("module-syntax", function () {
           @field age = contains(NumberCard);
         }
       `,
-      "original code formatting is preserved",
+      'original code formatting is preserved',
     );
   });
 
@@ -321,11 +321,11 @@ module("module-syntax", function () {
             }
         }
       `,
-      "original code formatting is preserved",
+      'original code formatting is preserved',
     );
   });
 
-  test("can add a field to a card when the module url is relative", async function (assert) {
+  test('can add a field to a card when the module url is relative', async function (assert) {
     let src = `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -337,18 +337,18 @@ module("module-syntax", function () {
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/pet.gts`));
 
     mod.addField({
-      cardBeingModified: { module: `${testRealm}dir/pet`, name: "Pet" }, // Card we want to add to
-      fieldName: "bestFriend",
+      cardBeingModified: { module: `${testRealm}dir/pet`, name: 'Pet' }, // Card we want to add to
+      fieldName: 'bestFriend',
       fieldRef: {
-        module: "../person",
-        name: "Person",
+        module: '../person',
+        name: 'Person',
       },
-      fieldType: "linksTo",
+      fieldType: 'linksTo',
       incomingRelativeTo: new URL(
         `http://localhost:4202/node-test/catalog-entry/1`,
       ), // hypothethical catalog entry that lives at this id
-      outgoingRelativeTo: new URL("http://localhost:4202/node-test/pet"), // outgoing card
-      outgoingRealmURL: new URL("http://localhost:4202/node-test/"), // the realm that the catalog entry lives in
+      outgoingRelativeTo: new URL('http://localhost:4202/node-test/pet'), // outgoing card
+      outgoingRealmURL: new URL('http://localhost:4202/node-test/'), // the realm that the catalog entry lives in
     });
 
     assert.codeEqual(
@@ -365,7 +365,7 @@ module("module-syntax", function () {
     );
   });
 
-  test("can add a field to a card when the module url is from another realm", async function (assert) {
+  test('can add a field to a card when the module url is from another realm', async function (assert) {
     let src = `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -377,16 +377,16 @@ module("module-syntax", function () {
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/pet.gts`));
 
     mod.addField({
-      cardBeingModified: { module: `${testRealm}dir/pet`, name: "Pet" }, // card we want to add to
-      fieldName: "bestFriend",
+      cardBeingModified: { module: `${testRealm}dir/pet`, name: 'Pet' }, // card we want to add to
+      fieldName: 'bestFriend',
       fieldRef: {
-        module: "../person", // the other realm (will be from the /test realm not the /node-test)
-        name: "Person",
+        module: '../person', // the other realm (will be from the /test realm not the /node-test)
+        name: 'Person',
       },
-      fieldType: "linksTo",
+      fieldType: 'linksTo',
       incomingRelativeTo: new URL(`http://localhost:4202/test/catalog-entry/1`), // hypothethical catalog entry that lives at this id
-      outgoingRelativeTo: new URL("http://localhost:4202/node-test/pet"), // outgoing card
-      outgoingRealmURL: new URL("http://localhost:4202/node-test/"), // the realm that the catalog entry lives in
+      outgoingRelativeTo: new URL('http://localhost:4202/node-test/pet'), // outgoing card
+      outgoingRealmURL: new URL('http://localhost:4202/node-test/'), // the realm that the catalog entry lives in
     });
 
     assert.codeEqual(
@@ -412,13 +412,13 @@ module("module-syntax", function () {
 
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.addField({
-      cardBeingModified: { module: `${testRealm}dir/person`, name: "Person" },
-      fieldName: "firstName",
+      cardBeingModified: { module: `${testRealm}dir/person`, name: 'Person' },
+      fieldName: 'firstName',
       fieldRef: {
-        module: "https://cardstack.com/base/string",
-        name: "default",
+        module: 'https://cardstack.com/base/string',
+        name: 'default',
       },
-      fieldType: "contains",
+      fieldType: 'contains',
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
       outgoingRealmURL: undefined,
@@ -437,7 +437,7 @@ module("module-syntax", function () {
     );
   });
 
-  test("can add a field to an interior card that is the field of card that is exported", async function (assert) {
+  test('can add a field to an interior card that is the field of card that is exported', async function (assert) {
     let src = `
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -458,16 +458,16 @@ module("module-syntax", function () {
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.addField({
       cardBeingModified: {
-        type: "fieldOf",
-        field: "details",
-        card: { module: `${testRealm}dir/person`, name: "Person" },
+        type: 'fieldOf',
+        field: 'details',
+        card: { module: `${testRealm}dir/person`, name: 'Person' },
       },
-      fieldName: "age",
+      fieldName: 'age',
       fieldRef: {
-        module: "https://cardstack.com/base/number",
-        name: "default",
+        module: 'https://cardstack.com/base/number',
+        name: 'default',
       },
-      fieldType: "contains",
+      fieldType: 'contains',
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
       outgoingRealmURL: undefined,
@@ -496,7 +496,7 @@ module("module-syntax", function () {
     );
   });
 
-  test("can add a field to an interior card that is the ancestor of card that is exported", async function (assert) {
+  test('can add a field to an interior card that is the ancestor of card that is exported', async function (assert) {
     let src = `
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -516,15 +516,15 @@ module("module-syntax", function () {
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.addField({
       cardBeingModified: {
-        type: "ancestorOf",
-        card: { module: `${testRealm}dir/person`, name: "FancyPerson" },
+        type: 'ancestorOf',
+        card: { module: `${testRealm}dir/person`, name: 'FancyPerson' },
       },
-      fieldName: "age",
+      fieldName: 'age',
       fieldRef: {
-        module: "https://cardstack.com/base/number",
-        name: "default",
+        module: 'https://cardstack.com/base/number',
+        name: 'default',
       },
-      fieldType: "contains",
+      fieldType: 'contains',
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
       outgoingRealmURL: undefined,
@@ -552,7 +552,7 @@ module("module-syntax", function () {
     );
   });
 
-  test("can add a field to an interior card within a module that also has non card declarations", async function (assert) {
+  test('can add a field to an interior card within a module that also has non card declarations', async function (assert) {
     let src = `
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -575,16 +575,16 @@ module("module-syntax", function () {
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.addField({
       cardBeingModified: {
-        type: "fieldOf",
-        field: "details",
-        card: { module: `${testRealm}dir/person`, name: "Person" },
+        type: 'fieldOf',
+        field: 'details',
+        card: { module: `${testRealm}dir/person`, name: 'Person' },
       },
-      fieldName: "age",
+      fieldName: 'age',
       fieldRef: {
-        module: "https://cardstack.com/base/number",
-        name: "default",
+        module: 'https://cardstack.com/base/number',
+        name: 'default',
       },
-      fieldType: "contains",
+      fieldType: 'contains',
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
       outgoingRealmURL: undefined,
@@ -615,7 +615,7 @@ module("module-syntax", function () {
     );
   });
 
-  test("can add a containsMany field", async function (assert) {
+  test('can add a containsMany field', async function (assert) {
     let src = `
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -630,13 +630,13 @@ module("module-syntax", function () {
 
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.addField({
-      cardBeingModified: { module: `${testRealm}dir/person`, name: "Person" },
-      fieldName: "aliases",
+      cardBeingModified: { module: `${testRealm}dir/person`, name: 'Person' },
+      fieldName: 'aliases',
       fieldRef: {
-        module: "https://cardstack.com/base/string",
-        name: "default",
+        module: 'https://cardstack.com/base/string',
+        name: 'default',
       },
-      fieldType: "containsMany",
+      fieldType: 'containsMany',
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
       outgoingRealmURL: undefined,
@@ -657,23 +657,23 @@ module("module-syntax", function () {
         }
       `,
     );
-    let card = mod.possibleCardsOrFields.find((c) => c.exportName === "Person");
-    let field = card!.possibleFields.get("aliases");
-    assert.ok(field, "new field was added to syntax");
+    let card = mod.possibleCardsOrFields.find((c) => c.exportName === 'Person');
+    let field = card!.possibleFields.get('aliases');
+    assert.ok(field, 'new field was added to syntax');
     assert.deepEqual(
       field?.type,
       {
-        type: "external",
-        module: "https://cardstack.com/base/card-api",
-        name: "containsMany",
+        type: 'external',
+        module: 'https://cardstack.com/base/card-api',
+        name: 'containsMany',
       },
-      "the field type is correct",
+      'the field type is correct',
     );
   });
 
-  test("can add a linksTo field", async function (assert) {
+  test('can add a linksTo field', async function (assert) {
     let realm = await createRealm(loader, dirSync().name, {
-      "pet.gts": `
+      'pet.gts': `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
       export class Pet extends CardDef {
@@ -692,13 +692,13 @@ module("module-syntax", function () {
     `;
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.addField({
-      cardBeingModified: { module: `${testRealm}dir/person`, name: "Person" },
-      fieldName: "pet",
+      cardBeingModified: { module: `${testRealm}dir/person`, name: 'Person' },
+      fieldName: 'pet',
       fieldRef: {
         module: `${testRealm}dir/pet`,
-        name: "Pet",
+        name: 'Pet',
       },
-      fieldType: "linksTo",
+      fieldType: 'linksTo',
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
       outgoingRealmURL: undefined,
@@ -716,21 +716,21 @@ module("module-syntax", function () {
         }
       `,
     );
-    let card = mod.possibleCardsOrFields.find((c) => c.exportName === "Person");
-    let field = card!.possibleFields.get("pet");
-    assert.ok(field, "new field was added to syntax");
+    let card = mod.possibleCardsOrFields.find((c) => c.exportName === 'Person');
+    let field = card!.possibleFields.get('pet');
+    assert.ok(field, 'new field was added to syntax');
     assert.deepEqual(
       field?.type,
       {
-        type: "external",
-        module: "https://cardstack.com/base/card-api",
-        name: "linksTo",
+        type: 'external',
+        module: 'https://cardstack.com/base/card-api',
+        name: 'linksTo',
       },
-      "the field type is correct",
+      'the field type is correct',
     );
   });
 
-  test("can add a linksTo field with the same type as its enclosing card", async function (assert) {
+  test('can add a linksTo field with the same type as its enclosing card', async function (assert) {
     let src = `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -741,13 +741,13 @@ module("module-syntax", function () {
     `;
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.addField({
-      cardBeingModified: { module: `${testRealm}dir/person`, name: "Person" },
-      fieldName: "friend",
+      cardBeingModified: { module: `${testRealm}dir/person`, name: 'Person' },
+      fieldName: 'friend',
       fieldRef: {
         module: `${testRealm}dir/person`,
-        name: "Person",
+        name: 'Person',
       },
-      fieldType: "linksTo",
+      fieldType: 'linksTo',
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
       outgoingRealmURL: undefined,
@@ -765,21 +765,21 @@ module("module-syntax", function () {
         }
       `,
     );
-    let card = mod.possibleCardsOrFields.find((c) => c.exportName === "Person");
-    let field = card!.possibleFields.get("friend");
-    assert.ok(field, "new field was added to syntax");
+    let card = mod.possibleCardsOrFields.find((c) => c.exportName === 'Person');
+    let field = card!.possibleFields.get('friend');
+    assert.ok(field, 'new field was added to syntax');
     assert.deepEqual(
       field?.type,
       {
-        type: "external",
-        module: "https://cardstack.com/base/card-api",
-        name: "linksTo",
+        type: 'external',
+        module: 'https://cardstack.com/base/card-api',
+        name: 'linksTo',
       },
-      "the field type is correct",
+      'the field type is correct',
     );
   });
 
-  test("can handle field card declaration collisions when adding field", async function (assert) {
+  test('can handle field card declaration collisions when adding field', async function (assert) {
     let src = `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -793,13 +793,13 @@ module("module-syntax", function () {
 
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.addField({
-      cardBeingModified: { module: `${testRealm}dir/person`, name: "Person" },
-      fieldName: "age",
+      cardBeingModified: { module: `${testRealm}dir/person`, name: 'Person' },
+      fieldName: 'age',
       fieldRef: {
-        module: "https://cardstack.com/base/number",
-        name: "default",
+        module: 'https://cardstack.com/base/number',
+        name: 'default',
       },
-      fieldType: "contains",
+      fieldType: 'contains',
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
       outgoingRealmURL: undefined,
@@ -825,7 +825,7 @@ module("module-syntax", function () {
   // At this level, we can only see this specific module. we'll need the
   // upstream caller to perform a field existence check on the card
   // definition to ensure this field does not already exist in the adoption chain
-  test("throws when adding a field with a name the card already has", async function (assert) {
+  test('throws when adding a field with a name the card already has', async function (assert) {
     let src = `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -837,27 +837,27 @@ module("module-syntax", function () {
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     try {
       mod.addField({
-        cardBeingModified: { module: `${testRealm}dir/person`, name: "Person" },
-        fieldName: "firstName",
+        cardBeingModified: { module: `${testRealm}dir/person`, name: 'Person' },
+        fieldName: 'firstName',
         fieldRef: {
-          module: "https://cardstack.com/base/string",
-          name: "default",
+          module: 'https://cardstack.com/base/string',
+          name: 'default',
         },
-        fieldType: "contains",
+        fieldType: 'contains',
         incomingRelativeTo: undefined,
         outgoingRelativeTo: undefined,
         outgoingRealmURL: undefined,
       });
-      throw new Error("expected error was not thrown");
+      throw new Error('expected error was not thrown');
     } catch (err: any) {
       assert.ok(
         err.message.match(/field "firstName" already exists/),
-        "expected error was thrown",
+        'expected error was thrown',
       );
     }
   });
 
-  test("can remove a field from a card", async function (assert) {
+  test('can remove a field from a card', async function (assert) {
     let src = `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -869,8 +869,8 @@ module("module-syntax", function () {
     `;
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.removeField(
-      { module: `${testRealm}dir/person`, name: "Person" },
-      "firstName",
+      { module: `${testRealm}dir/person`, name: 'Person' },
+      'firstName',
     );
 
     assert.codeEqual(
@@ -894,15 +894,15 @@ module("module-syntax", function () {
         @field lastName = contains(StringCard);
       }
       `.trim(),
-      "original code formatting is preserved",
+      'original code formatting is preserved',
     );
 
-    let card = mod.possibleCardsOrFields.find((c) => c.exportName === "Person");
-    let field = card!.possibleFields.get("firstName");
-    assert.strictEqual(field, undefined, "field does not exist in syntax");
+    let card = mod.possibleCardsOrFields.find((c) => c.exportName === 'Person');
+    let field = card!.possibleFields.get('firstName');
+    assert.strictEqual(field, undefined, 'field does not exist in syntax');
   });
 
-  test("can use remove & add a field to achieve edit in place", async function (assert) {
+  test('can use remove & add a field to achieve edit in place', async function (assert) {
     let src = `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -917,18 +917,18 @@ module("module-syntax", function () {
 
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     let addFieldAtIndex = mod.removeField(
-      { module: `${testRealm}dir/person`, name: "Person" },
-      "artistName",
+      { module: `${testRealm}dir/person`, name: 'Person' },
+      'artistName',
     );
 
     mod.addField({
-      cardBeingModified: { module: `${testRealm}dir/person`, name: "Person" },
-      fieldName: "artistNames",
+      cardBeingModified: { module: `${testRealm}dir/person`, name: 'Person' },
+      fieldName: 'artistNames',
       fieldRef: {
-        module: "https://cardstack.com/base/string",
-        name: "default",
+        module: 'https://cardstack.com/base/string',
+        name: 'default',
       },
-      fieldType: "containsMany",
+      fieldType: 'containsMany',
       addFieldAtIndex,
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
@@ -951,7 +951,7 @@ module("module-syntax", function () {
     );
   });
 
-  test("can use remove & add a field to achieve edit in place - when field is at the beginning", async function (assert) {
+  test('can use remove & add a field to achieve edit in place - when field is at the beginning', async function (assert) {
     let src = `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -966,18 +966,18 @@ module("module-syntax", function () {
 
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     let addFieldAtIndex = mod.removeField(
-      { module: `${testRealm}dir/person`, name: "Person" },
-      "firstName",
+      { module: `${testRealm}dir/person`, name: 'Person' },
+      'firstName',
     );
 
     mod.addField({
-      cardBeingModified: { module: `${testRealm}dir/person`, name: "Person" },
-      fieldName: "firstNameAdjusted",
+      cardBeingModified: { module: `${testRealm}dir/person`, name: 'Person' },
+      fieldName: 'firstNameAdjusted',
       fieldRef: {
-        module: "https://cardstack.com/base/string",
-        name: "default",
+        module: 'https://cardstack.com/base/string',
+        name: 'default',
       },
-      fieldType: "contains",
+      fieldType: 'contains',
       addFieldAtIndex,
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
@@ -1000,7 +1000,7 @@ module("module-syntax", function () {
     );
   });
 
-  test("can use remove & add a field to achieve edit in place - when field is at the end", async function (assert) {
+  test('can use remove & add a field to achieve edit in place - when field is at the end', async function (assert) {
     let src = `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -1015,18 +1015,18 @@ module("module-syntax", function () {
 
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     let addFieldAtIndex = mod.removeField(
-      { module: `${testRealm}dir/person`, name: "Person" },
-      "streetName",
+      { module: `${testRealm}dir/person`, name: 'Person' },
+      'streetName',
     );
 
     mod.addField({
-      cardBeingModified: { module: `${testRealm}dir/person`, name: "Person" },
-      fieldName: "streetNameAdjusted",
+      cardBeingModified: { module: `${testRealm}dir/person`, name: 'Person' },
+      fieldName: 'streetNameAdjusted',
       fieldRef: {
-        module: "https://cardstack.com/base/string",
-        name: "default",
+        module: 'https://cardstack.com/base/string',
+        name: 'default',
       },
-      fieldType: "contains",
+      fieldType: 'contains',
       addFieldAtIndex,
       incomingRelativeTo: undefined,
       outgoingRelativeTo: undefined,
@@ -1049,7 +1049,7 @@ module("module-syntax", function () {
     );
   });
 
-  test("can remove the last field from a card", async function (assert) {
+  test('can remove the last field from a card', async function (assert) {
     let src = `
       import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -1061,8 +1061,8 @@ module("module-syntax", function () {
 
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.removeField(
-      { module: `${testRealm}dir/person`, name: "Person" },
-      "firstName",
+      { module: `${testRealm}dir/person`, name: 'Person' },
+      'firstName',
     );
 
     assert.codeEqual(
@@ -1074,7 +1074,7 @@ module("module-syntax", function () {
     );
   });
 
-  test("can remove a linksTo field with the same type as its enclosing card", async function (assert) {
+  test('can remove a linksTo field with the same type as its enclosing card', async function (assert) {
     let src = `
       import { contains, field, CardDef, linksTo } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -1086,8 +1086,8 @@ module("module-syntax", function () {
     `;
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.removeField(
-      { module: `${testRealm}dir/person`, name: "Friend" },
-      "friend",
+      { module: `${testRealm}dir/person`, name: 'Friend' },
+      'friend',
     );
 
     assert.codeEqual(
@@ -1102,12 +1102,12 @@ module("module-syntax", function () {
       `,
     );
 
-    let card = mod.possibleCardsOrFields.find((c) => c.exportName === "Friend");
-    let field = card!.possibleFields.get("friend");
-    assert.strictEqual(field, undefined, "field does not exist in syntax");
+    let card = mod.possibleCardsOrFields.find((c) => c.exportName === 'Friend');
+    let field = card!.possibleFields.get('friend');
+    assert.strictEqual(field, undefined, 'field does not exist in syntax');
   });
 
-  test("can remove the field of an interior card that is the ancestor of a card that is exported", async function (assert) {
+  test('can remove the field of an interior card that is the ancestor of a card that is exported', async function (assert) {
     let src = `
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -1124,10 +1124,10 @@ module("module-syntax", function () {
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.removeField(
       {
-        type: "ancestorOf",
-        card: { module: `${testRealm}dir/person`, name: "FancyPerson" },
+        type: 'ancestorOf',
+        card: { module: `${testRealm}dir/person`, name: 'FancyPerson' },
       },
-      "firstName",
+      'firstName',
     );
 
     assert.codeEqual(
@@ -1147,7 +1147,7 @@ module("module-syntax", function () {
     );
   });
 
-  test("can remove the field of an interior card that is the field of a card that is exported", async function (assert) {
+  test('can remove the field of an interior card that is the field of a card that is exported', async function (assert) {
     let src = `
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -1166,11 +1166,11 @@ module("module-syntax", function () {
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     mod.removeField(
       {
-        type: "fieldOf",
-        field: "details",
-        card: { module: `${testRealm}dir/person`, name: "Person" },
+        type: 'fieldOf',
+        field: 'details',
+        card: { module: `${testRealm}dir/person`, name: 'Person' },
       },
-      "nickName",
+      'nickName',
     );
 
     assert.codeEqual(
@@ -1192,7 +1192,7 @@ module("module-syntax", function () {
     );
   });
 
-  test("throws when field to remove does not actually exist", async function (assert) {
+  test('throws when field to remove does not actually exist', async function (assert) {
     let src = `
       import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
       import StringCard from "https://cardstack.com/base/string";
@@ -1205,14 +1205,14 @@ module("module-syntax", function () {
     let mod = new ModuleSyntax(src, new URL(`${testRealm}dir/person`));
     try {
       mod.removeField(
-        { module: `${testRealm}dir/person`, name: "Person" },
-        "foo",
+        { module: `${testRealm}dir/person`, name: 'Person' },
+        'foo',
       );
-      throw new Error("expected error was not thrown");
+      throw new Error('expected error was not thrown');
     } catch (err: any) {
       assert.ok(
         err.message.match(/field "foo" does not exist/),
-        "expected error was thrown",
+        'expected error was thrown',
       );
     }
   });

--- a/packages/runtime-common/constants.ts
+++ b/packages/runtime-common/constants.ts
@@ -1,15 +1,19 @@
 import { RealmPaths } from './paths';
-import type { CodeRef } from './code-ref';
+import type { ResolvedCodeRef } from './code-ref';
 
 export const baseRealm = new RealmPaths('https://cardstack.com/base/');
 
-export const catalogEntryRef: CodeRef = {
+export const catalogEntryRef: ResolvedCodeRef = {
   module: `${baseRealm.url}catalog-entry`,
   name: 'CatalogEntry',
 };
-export const baseCardRef: CodeRef = {
+export const baseCardRef: ResolvedCodeRef = {
   module: `${baseRealm.url}card-api`,
   name: 'CardDef',
+};
+export const baseFieldRef: ResolvedCodeRef = {
+  module: `${baseRealm.url}card-api`,
+  name: 'FieldDef',
 };
 
 export const isField = Symbol('cardstack-field');

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -36,14 +36,7 @@ export interface DirectoryEntryRelationship {
 import { RealmPaths, type LocalPath } from './paths';
 import { Query } from './query';
 import { Loader } from './loader';
-export {
-  aiBotUsername,
-  baseRealm,
-  catalogEntryRef,
-  baseCardRef,
-  isField,
-  primitive,
-} from './constants';
+export * from './constants';
 export { makeLogDefinitions, logger } from './log';
 export { RealmPaths, Loader, type LocalPath, type Query };
 export { NotLoaded, isNotLoadedError } from './not-loaded';

--- a/packages/runtime-common/module-syntax.ts
+++ b/packages/runtime-common/module-syntax.ts
@@ -27,6 +27,8 @@ import {
   maybeRelativeURL,
   trimExecutableExtension,
   codeRefWithAbsoluteURL,
+  baseCardRef,
+  baseFieldRef,
   type CodeRef,
 } from './index';
 //@ts-ignore unsure where these types live
@@ -459,9 +461,14 @@ function suggestedCardName(
   ref: { name: string; module: string },
   type: 'card' | 'field',
 ): string {
-  if (ref.name.toLowerCase().endsWith(type)) {
+  if (
+    ref.name.toLowerCase().endsWith(type) ||
+    isEqual(ref, baseCardRef) ||
+    isEqual(ref, baseFieldRef)
+  ) {
     return ref.name;
   }
+
   let name = ref.name;
   if (name === 'default') {
     name = ref.module.split('/').pop()!;

--- a/packages/runtime-common/module-syntax.ts
+++ b/packages/runtime-common/module-syntax.ts
@@ -451,14 +451,25 @@ function getProgramPath(path: NodePath<any>): NodePath<t.Program> {
 }
 
 function suggestedCardName(ref: { name: string; module: string }): string {
-  if (ref.name.toLowerCase().endsWith('card')) {
-    return ref.name;
-  }
   let name = ref.name;
   if (name === 'default') {
     name = ref.module.split('/').pop()!;
   }
-  return upperFirst(camelCase(`${name} card`));
+  if (
+    ref.module.startsWith('https://') &&
+    baseRealm.inRealm(new URL(ref.module))
+  ) {
+    // we suffix these specifically because we know they are fields and don't collide
+    // JS keywords like `String`, `Number`, and `Date`
+    name = `${name} field`;
+  }
+
+  // otherwise we do a more general check for javascript built-ins
+  let suggestedName = upperFirst(camelCase(`${name}`));
+  if (typeof (globalThis as any)[suggestedName] !== 'undefined') {
+    suggestedName = `${suggestedName}0`;
+  }
+  return suggestedName;
 }
 
 function insertFieldBeforePath(


### PR DESCRIPTION
This PR adds better import declaration names for added fields. We'll use the `Field` suffix  when we see the field originates from the base realm (where all our catalog entries are for fields). Otherwise we won't try to guess card or field (which can't be done from a purely syntax perspective), but we will make sure that the declaration doesn't collide with a JS built-in, like `Map`, or `Array`.  

(also prettier wasn't run on one of the test modules so i had to do that as well)

![field-import-declaration](https://github.com/cardstack/boxel/assets/61075/5244c7fe-d1df-457d-8d71-e2bd743dd33d)
