### PR TITLE
Add commented out component template to new definitions

### DIFF
--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -503,9 +503,10 @@ export default class CreateFileModal extends Component<Signature> {
     if (className === exportName) {
       src = `
 import { ${exportName} as ${exportName}Parent } from '${moduleURL}';
+import { Component } from 'https://cardstack.com/base/card-api';
 export class ${className} extends ${exportName}Parent {
   static displayName = "${safeName}";
-}`;
+`;
     } else if (exportName === 'default') {
       let parent = camelize(
         module
@@ -517,16 +518,23 @@ export class ${className} extends ${exportName}Parent {
       parent = parent === className ? `${parent}Parent` : parent;
       src = `
 import ${parent} from '${moduleURL}';
+import { Component } from 'https://cardstack.com/base/card-api';
 export class ${className} extends ${parent} {
   static displayName = "${safeName}";
-}`;
+`;
     } else {
       src = `
 import { ${exportName} } from '${moduleURL}';
+import { Component } from 'https://cardstack.com/base/card-api';
 export class ${className} extends ${exportName} {
   static displayName = "${safeName}";
-}`;
+`;
     }
+
+    if (this.fileType.id === 'card-definition') {
+      src = `${src}${isolatedTemplateBoilerplate}`;
+    }
+    src = `${src}${embeddedEditAtomTemplateBoilerplate}\n}`;
     await this.cardService.saveSource(url, src.trim());
     this.currentRequest.newFileDeferred.fulfill(url);
   });
@@ -586,6 +594,22 @@ export class ${className} extends ${exportName} {
 function camelize(name: string) {
   return capitalize(camelCase(name));
 }
+
+const embeddedEditAtomTemplateBoilerplate = `
+  // static embedded = class Embedded extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static edit = class Edit extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static atom = class Atom extends Component<typeof this> {
+  //   <template></template>
+  // }`;
+
+const isolatedTemplateBoilerplate = `
+  // static isolated = class Isolated extends Component<typeof this> {
+  //   <template></template>
+  // }`;
 
 const SelectedTypePill: TemplateOnlyComponent<{
   entry: CatalogEntry;

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -440,18 +440,23 @@ import { Component } from 'https://cardstack.com/base/card-api';
 export class TestCard extends CardDef {
   static displayName = "Test Card";
 
-  // static isolated = class Isolated extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static embedded = class Embedded extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static edit = class Edit extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static atom = class Atom extends Component<typeof this> {
-  //   <template></template>
-  // }
+  /*
+  static isolated = class Isolated extends Component<typeof this> {
+    <template></template>
+  }
+  
+  static embedded = class Embedded extends Component<typeof this> {
+    <template></template>
+  }
+
+  static atom = class Atom extends Component<typeof this> {
+    <template></template>
+  }
+
+  static edit = class Edit extends Component<typeof this> {
+    <template></template>
+  }
+  */
 }`.trim();
     await openNewFileModal('Card Definition');
     assert
@@ -517,18 +522,23 @@ import { Component } from 'https://cardstack.com/base/card-api';
 export class TestCard extends Person {
   static displayName = "Test Card";
 
-  // static isolated = class Isolated extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static embedded = class Embedded extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static edit = class Edit extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static atom = class Atom extends Component<typeof this> {
-  //   <template></template>
-  // }
+  /*
+  static isolated = class Isolated extends Component<typeof this> {
+    <template></template>
+  }
+  
+  static embedded = class Embedded extends Component<typeof this> {
+    <template></template>
+  }
+
+  static atom = class Atom extends Component<typeof this> {
+    <template></template>
+  }
+
+  static edit = class Edit extends Component<typeof this> {
+    <template></template>
+  }
+  */
 }`.trim(),
         'the source is correct',
       );
@@ -574,15 +584,19 @@ import { Component } from 'https://cardstack.com/base/card-api';
 export class FieldThatExtendsFromBigInt extends BigInteger {
   static displayName = "Field that extends from big int";
 
-  // static embedded = class Embedded extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static edit = class Edit extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static atom = class Atom extends Component<typeof this> {
-  //   <template></template>
-  // }
+  /*
+  static embedded = class Embedded extends Component<typeof this> {
+    <template></template>
+  }
+
+  static atom = class Atom extends Component<typeof this> {
+    <template></template>
+  }
+
+  static edit = class Edit extends Component<typeof this> {
+    <template></template>
+  }
+  */
 }`.trim(),
         'the source is correct',
       );
@@ -621,18 +635,23 @@ import { Component } from 'https://cardstack.com/base/card-api';
 export class TestCard extends Pet {
   static displayName = "Test Card";
 
-  // static isolated = class Isolated extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static embedded = class Embedded extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static edit = class Edit extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static atom = class Atom extends Component<typeof this> {
-  //   <template></template>
-  // }
+  /*
+  static isolated = class Isolated extends Component<typeof this> {
+    <template></template>
+  }
+  
+  static embedded = class Embedded extends Component<typeof this> {
+    <template></template>
+  }
+
+  static atom = class Atom extends Component<typeof this> {
+    <template></template>
+  }
+
+  static edit = class Edit extends Component<typeof this> {
+    <template></template>
+  }
+  */
 }`.trim(),
         'the source is correct',
       );
@@ -672,18 +691,79 @@ import { Component } from 'https://cardstack.com/base/card-api';
 export class Pet extends PetParent {
   static displayName = "Pet";
 
-  // static isolated = class Isolated extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static embedded = class Embedded extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static edit = class Edit extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static atom = class Atom extends Component<typeof this> {
-  //   <template></template>
-  // }
+  /*
+  static isolated = class Isolated extends Component<typeof this> {
+    <template></template>
+  }
+  
+  static embedded = class Embedded extends Component<typeof this> {
+    <template></template>
+  }
+
+  static atom = class Atom extends Component<typeof this> {
+    <template></template>
+  }
+
+  static edit = class Edit extends Component<typeof this> {
+    <template></template>
+  }
+  */
+}`.trim(),
+        'the source is correct',
+      );
+      deferred.fulfill();
+    });
+
+    await percySnapshot(assert);
+    await click('[data-test-create-definition]');
+    await waitFor('[data-test-create-file-modal]', { count: 0 });
+    await deferred.promise;
+  });
+
+  test<TestContextWithSave>('can reconcile a classname collision with a javascript builtin object', async function (assert) {
+    assert.expect(1);
+    await openNewFileModal('Card Definition');
+
+    // select card type
+    await click('[data-test-select-card-type]');
+    await waitFor('[data-test-card-catalog-modal]');
+    await waitFor(`[data-test-select="${testRealmURL}Catalog-Entry/pet"]`);
+    await click(`[data-test-select="${testRealmURL}Catalog-Entry/pet"]`);
+    await click('[data-test-card-catalog-go-button]');
+    await waitFor(`[data-test-selected-type="Pet"]`);
+
+    await fillIn('[data-test-display-name-field]', 'Map');
+    await fillIn('[data-test-file-name-field]', 'test-card');
+    let deferred = new Deferred<void>();
+    this.onSave((content) => {
+      if (typeof content !== 'string') {
+        throw new Error(`expected string save data`);
+      }
+      assert.strictEqual(
+        content,
+        `
+import Pet from './pet';
+import { Component } from 'https://cardstack.com/base/card-api';
+export class Map0 extends Pet {
+  static displayName = "Map";
+
+  /*
+  static isolated = class Isolated extends Component<typeof this> {
+    <template></template>
+  }
+  
+  static embedded = class Embedded extends Component<typeof this> {
+    <template></template>
+  }
+
+  static atom = class Atom extends Component<typeof this> {
+    <template></template>
+  }
+
+  static edit = class Edit extends Component<typeof this> {
+    <template></template>
+  }
+  */
 }`.trim(),
         'the source is correct',
       );
@@ -715,18 +795,23 @@ import { Component } from 'https://cardstack.com/base/card-api';
 export class TestCard extends CardDef {
   static displayName = "Test Card";
 
-  // static isolated = class Isolated extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static embedded = class Embedded extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static edit = class Edit extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static atom = class Atom extends Component<typeof this> {
-  //   <template></template>
-  // }
+  /*
+  static isolated = class Isolated extends Component<typeof this> {
+    <template></template>
+  }
+  
+  static embedded = class Embedded extends Component<typeof this> {
+    <template></template>
+  }
+
+  static atom = class Atom extends Component<typeof this> {
+    <template></template>
+  }
+
+  static edit = class Edit extends Component<typeof this> {
+    <template></template>
+  }
+  */
 }`.trim(),
         'the source is correct',
       );
@@ -746,18 +831,23 @@ import { Component } from 'https://cardstack.com/base/card-api';
 export class TestCard extends CardDef {
   static displayName = "Test Card";
 
-  // static isolated = class Isolated extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static embedded = class Embedded extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static edit = class Edit extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static atom = class Atom extends Component<typeof this> {
-  //   <template></template>
-  // }
+  /*
+  static isolated = class Isolated extends Component<typeof this> {
+    <template></template>
+  }
+  
+  static embedded = class Embedded extends Component<typeof this> {
+    <template></template>
+  }
+
+  static atom = class Atom extends Component<typeof this> {
+    <template></template>
+  }
+
+  static edit = class Edit extends Component<typeof this> {
+    <template></template>
+  }
+  */
 }`.trim();
 
     await openNewFileModal('Card Definition');
@@ -793,18 +883,23 @@ import { Component } from 'https://cardstack.com/base/card-api';
 export class TestCard extends CardDef {
   static displayName = "Test Card";
 
-  // static isolated = class Isolated extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static embedded = class Embedded extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static edit = class Edit extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static atom = class Atom extends Component<typeof this> {
-  //   <template></template>
-  // }
+  /*
+  static isolated = class Isolated extends Component<typeof this> {
+    <template></template>
+  }
+  
+  static embedded = class Embedded extends Component<typeof this> {
+    <template></template>
+  }
+
+  static atom = class Atom extends Component<typeof this> {
+    <template></template>
+  }
+
+  static edit = class Edit extends Component<typeof this> {
+    <template></template>
+  }
+  */
 }`.trim();
 
     await openNewFileModal('Card Definition');
@@ -840,18 +935,23 @@ import { Component } from 'https://cardstack.com/base/card-api';
 export class TestCard extends CardDef {
   static displayName = "Test Card";
 
-  // static isolated = class Isolated extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static embedded = class Embedded extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static edit = class Edit extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static atom = class Atom extends Component<typeof this> {
-  //   <template></template>
-  // }
+  /*
+  static isolated = class Isolated extends Component<typeof this> {
+    <template></template>
+  }
+  
+  static embedded = class Embedded extends Component<typeof this> {
+    <template></template>
+  }
+
+  static atom = class Atom extends Component<typeof this> {
+    <template></template>
+  }
+
+  static edit = class Edit extends Component<typeof this> {
+    <template></template>
+  }
+  */
 }`.trim();
 
     await openNewFileModal('Card Definition');

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -436,8 +436,22 @@ module('Acceptance | code submode | create-file tests', function (hooks) {
     assert.expect(7);
     let expectedSrc = `
 import { CardDef } from 'https://cardstack.com/base/card-api';
+import { Component } from 'https://cardstack.com/base/card-api';
 export class TestCard extends CardDef {
   static displayName = "Test Card";
+
+  // static isolated = class Isolated extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static embedded = class Embedded extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static edit = class Edit extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static atom = class Atom extends Component<typeof this> {
+  //   <template></template>
+  // }
 }`.trim();
     await openNewFileModal('Card Definition');
     assert
@@ -499,8 +513,22 @@ export class TestCard extends CardDef {
         content,
         `
 import { Person } from './person';
+import { Component } from 'https://cardstack.com/base/card-api';
 export class TestCard extends Person {
   static displayName = "Test Card";
+
+  // static isolated = class Isolated extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static embedded = class Embedded extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static edit = class Edit extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static atom = class Atom extends Component<typeof this> {
+  //   <template></template>
+  // }
 }`.trim(),
         'the source is correct',
       );
@@ -542,8 +570,19 @@ export class TestCard extends Person {
         content,
         `
 import BigInteger from 'https://cardstack.com/base/big-integer';
+import { Component } from 'https://cardstack.com/base/card-api';
 export class FieldThatExtendsFromBigInt extends BigInteger {
   static displayName = "Field that extends from big int";
+
+  // static embedded = class Embedded extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static edit = class Edit extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static atom = class Atom extends Component<typeof this> {
+  //   <template></template>
+  // }
 }`.trim(),
         'the source is correct',
       );
@@ -578,8 +617,22 @@ export class FieldThatExtendsFromBigInt extends BigInteger {
         content,
         `
 import Pet from './pet';
+import { Component } from 'https://cardstack.com/base/card-api';
 export class TestCard extends Pet {
   static displayName = "Test Card";
+
+  // static isolated = class Isolated extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static embedded = class Embedded extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static edit = class Edit extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static atom = class Atom extends Component<typeof this> {
+  //   <template></template>
+  // }
 }`.trim(),
         'the source is correct',
       );
@@ -615,8 +668,22 @@ export class TestCard extends Pet {
         content,
         `
 import PetParent from './pet';
+import { Component } from 'https://cardstack.com/base/card-api';
 export class Pet extends PetParent {
   static displayName = "Pet";
+
+  // static isolated = class Isolated extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static embedded = class Embedded extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static edit = class Edit extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static atom = class Atom extends Component<typeof this> {
+  //   <template></template>
+  // }
 }`.trim(),
         'the source is correct',
       );
@@ -644,8 +711,22 @@ export class Pet extends PetParent {
         content,
         `
 import { CardDef } from 'https://cardstack.com/base/card-api';
+import { Component } from 'https://cardstack.com/base/card-api';
 export class TestCard extends CardDef {
   static displayName = "Test Card";
+
+  // static isolated = class Isolated extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static embedded = class Embedded extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static edit = class Edit extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static atom = class Atom extends Component<typeof this> {
+  //   <template></template>
+  // }
 }`.trim(),
         'the source is correct',
       );
@@ -661,8 +742,22 @@ export class TestCard extends CardDef {
     assert.expect(2);
     let expectedSrc = `
 import { CardDef } from 'https://cardstack.com/base/card-api';
+import { Component } from 'https://cardstack.com/base/card-api';
 export class TestCard extends CardDef {
   static displayName = "Test Card";
+
+  // static isolated = class Isolated extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static embedded = class Embedded extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static edit = class Edit extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static atom = class Atom extends Component<typeof this> {
+  //   <template></template>
+  // }
 }`.trim();
 
     await openNewFileModal('Card Definition');
@@ -694,8 +789,22 @@ export class TestCard extends CardDef {
     assert.expect(2);
     let expectedSrc = `
 import { CardDef } from 'https://cardstack.com/base/card-api';
+import { Component } from 'https://cardstack.com/base/card-api';
 export class TestCard extends CardDef {
   static displayName = "Test Card";
+
+  // static isolated = class Isolated extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static embedded = class Embedded extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static edit = class Edit extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static atom = class Atom extends Component<typeof this> {
+  //   <template></template>
+  // }
 }`.trim();
 
     await openNewFileModal('Card Definition');
@@ -727,8 +836,22 @@ export class TestCard extends CardDef {
     assert.expect(2);
     let expectedSrc = `
 import { CardDef } from 'https://cardstack.com/base/card-api';
+import { Component } from 'https://cardstack.com/base/card-api';
 export class TestCard extends CardDef {
   static displayName = "Test Card";
+
+  // static isolated = class Isolated extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static embedded = class Embedded extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static edit = class Edit extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static atom = class Atom extends Component<typeof this> {
+  //   <template></template>
+  // }
 }`.trim();
 
     await openNewFileModal('Card Definition');

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -1516,18 +1516,23 @@ import { Component } from 'https://cardstack.com/base/card-api';
 export class TestCard extends ExportedCard {
   static displayName = "Test Card";
 
-  // static isolated = class Isolated extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static embedded = class Embedded extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static edit = class Edit extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static atom = class Atom extends Component<typeof this> {
-  //   <template></template>
-  // }
+  /*
+  static isolated = class Isolated extends Component<typeof this> {
+    <template></template>
+  }
+  
+  static embedded = class Embedded extends Component<typeof this> {
+    <template></template>
+  }
+
+  static atom = class Atom extends Component<typeof this> {
+    <template></template>
+  }
+
+  static edit = class Edit extends Component<typeof this> {
+    <template></template>
+  }
+  */
 }`.trim();
     let operatorModeStateParam = stringify({
       stacks: [[]],
@@ -1650,15 +1655,19 @@ import { Component } from 'https://cardstack.com/base/card-api';
 export class TestField extends ExportedField {
   static displayName = "Test Field";
 
-  // static embedded = class Embedded extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static edit = class Edit extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static atom = class Atom extends Component<typeof this> {
-  //   <template></template>
-  // }
+  /*
+  static embedded = class Embedded extends Component<typeof this> {
+    <template></template>
+  }
+
+  static atom = class Atom extends Component<typeof this> {
+    <template></template>
+  }
+
+  static edit = class Edit extends Component<typeof this> {
+    <template></template>
+  }
+  */
 }`.trim(),
         'the source is correct',
       );
@@ -1725,18 +1734,23 @@ import { Component } from 'https://cardstack.com/base/card-api';
 export class ExportedCard extends ExportedCardParent {
   static displayName = "Exported Card";
 
-  // static isolated = class Isolated extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static embedded = class Embedded extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static edit = class Edit extends Component<typeof this> {
-  //   <template></template>
-  // }
-  // static atom = class Atom extends Component<typeof this> {
-  //   <template></template>
-  // }
+  /*
+  static isolated = class Isolated extends Component<typeof this> {
+    <template></template>
+  }
+  
+  static embedded = class Embedded extends Component<typeof this> {
+    <template></template>
+  }
+
+  static atom = class Atom extends Component<typeof this> {
+    <template></template>
+  }
+
+  static edit = class Edit extends Component<typeof this> {
+    <template></template>
+  }
+  */
 }`.trim();
     let operatorModeStateParam = stringify({
       stacks: [[]],

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -1512,8 +1512,22 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     assert.expect(11);
     let expectedSrc = `
 import { ExportedCard } from './in-this-file';
+import { Component } from 'https://cardstack.com/base/card-api';
 export class TestCard extends ExportedCard {
   static displayName = "Test Card";
+
+  // static isolated = class Isolated extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static embedded = class Embedded extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static edit = class Edit extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static atom = class Atom extends Component<typeof this> {
+  //   <template></template>
+  // }
 }`.trim();
     let operatorModeStateParam = stringify({
       stacks: [[]],
@@ -1632,8 +1646,19 @@ export class TestCard extends ExportedCard {
         content,
         `
 import { ExportedField } from './in-this-file';
+import { Component } from 'https://cardstack.com/base/card-api';
 export class TestField extends ExportedField {
   static displayName = "Test Field";
+
+  // static embedded = class Embedded extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static edit = class Edit extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static atom = class Atom extends Component<typeof this> {
+  //   <template></template>
+  // }
 }`.trim(),
         'the source is correct',
       );
@@ -1696,8 +1721,22 @@ export class TestField extends ExportedField {
     assert.expect(4);
     let expectedSrc = `
 import { ExportedCard as ExportedCardParent } from './in-this-file';
+import { Component } from 'https://cardstack.com/base/card-api';
 export class ExportedCard extends ExportedCardParent {
   static displayName = "Exported Card";
+
+  // static isolated = class Isolated extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static embedded = class Embedded extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static edit = class Edit extends Component<typeof this> {
+  //   <template></template>
+  // }
+  // static atom = class Atom extends Component<typeof this> {
+  //   <template></template>
+  // }
 }`.trim();
     let operatorModeStateParam = stringify({
       stacks: [[]],


### PR DESCRIPTION
This PR add commented out boilerplate for the component template formats available to the definition.

![boilerplate-templates](https://github.com/cardstack/boxel/assets/61075/f50ceb20-8dba-4c37-9892-f64e6944b53a)
