### PR TITLE
Consolidate imports from runtime/common

### DIFF
--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -11,8 +11,7 @@ import perform from 'ember-concurrency/helpers/perform';
 import { Modal, LoadingIndicator } from '@cardstack/boxel-ui/components';
 import { and, not } from '@cardstack/boxel-ui/helpers';
 
-import { type Loader } from '@cardstack/runtime-common';
-import type { Query } from '@cardstack/runtime-common/query';
+import type { Loader, Query } from '@cardstack/runtime-common';
 
 import Auth from '@cardstack/host/components/matrix/auth';
 import CodeSubmode from '@cardstack/host/components/operator-mode/code-submode';

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -45,7 +45,7 @@ export {
   primitive,
 } from './constants';
 export { makeLogDefinitions, logger } from './log';
-export { RealmPaths, Loader, LocalPath };
+export { RealmPaths, Loader, type LocalPath, type Query };
 export { NotLoaded, isNotLoadedError } from './not-loaded';
 export { NotReady, isNotReadyError } from './not-ready';
 export { cardTypeDisplayName } from './helpers/card-type-display-name';
@@ -310,9 +310,7 @@ export interface Actions {
     card: CardDef,
     changeSizeCallback: () => Promise<void>,
   ) => Promise<void>;
-  openCodeSubmode: (
-    url: URL,
-  ) => void;
+  openCodeSubmode: (url: URL) => void;
   // more CRUD ops to come...
 }
 


### PR DESCRIPTION
All items (`*`) in `code-ref` are already re-exported from runtime-common/index as mentioned during sprint planning.

Consolidated remaining import from runtime/common in OperatorModeContainer component. We can continue this type of consolidation as we come across them, since doing it all at once may cause merge conflicts.