### PR TITLE
host: Remove whitespace from inserted templates

### DIFF
--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -537,7 +537,7 @@ export class ${className} extends ${exportName} {
         `  static isolated = class Isolated extends Component<typeof this> {
     <template></template>
   }
-  `,
+`,
       );
     }
     src.push(

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -444,7 +444,7 @@ export class TestCard extends CardDef {
   static isolated = class Isolated extends Component<typeof this> {
     <template></template>
   }
-  
+
   static embedded = class Embedded extends Component<typeof this> {
     <template></template>
   }
@@ -526,7 +526,7 @@ export class TestCard extends Person {
   static isolated = class Isolated extends Component<typeof this> {
     <template></template>
   }
-  
+
   static embedded = class Embedded extends Component<typeof this> {
     <template></template>
   }
@@ -639,7 +639,7 @@ export class TestCard extends Pet {
   static isolated = class Isolated extends Component<typeof this> {
     <template></template>
   }
-  
+
   static embedded = class Embedded extends Component<typeof this> {
     <template></template>
   }
@@ -695,7 +695,7 @@ export class Pet extends PetParent {
   static isolated = class Isolated extends Component<typeof this> {
     <template></template>
   }
-  
+
   static embedded = class Embedded extends Component<typeof this> {
     <template></template>
   }
@@ -751,7 +751,7 @@ export class Map0 extends Pet {
   static isolated = class Isolated extends Component<typeof this> {
     <template></template>
   }
-  
+
   static embedded = class Embedded extends Component<typeof this> {
     <template></template>
   }
@@ -799,7 +799,7 @@ export class TestCard extends CardDef {
   static isolated = class Isolated extends Component<typeof this> {
     <template></template>
   }
-  
+
   static embedded = class Embedded extends Component<typeof this> {
     <template></template>
   }
@@ -835,7 +835,7 @@ export class TestCard extends CardDef {
   static isolated = class Isolated extends Component<typeof this> {
     <template></template>
   }
-  
+
   static embedded = class Embedded extends Component<typeof this> {
     <template></template>
   }
@@ -887,7 +887,7 @@ export class TestCard extends CardDef {
   static isolated = class Isolated extends Component<typeof this> {
     <template></template>
   }
-  
+
   static embedded = class Embedded extends Component<typeof this> {
     <template></template>
   }
@@ -939,7 +939,7 @@ export class TestCard extends CardDef {
   static isolated = class Isolated extends Component<typeof this> {
     <template></template>
   }
-  
+
   static embedded = class Embedded extends Component<typeof this> {
     <template></template>
   }

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -1483,7 +1483,7 @@ export class TestCard extends ExportedCard {
   static isolated = class Isolated extends Component<typeof this> {
     <template></template>
   }
-  
+
   static embedded = class Embedded extends Component<typeof this> {
     <template></template>
   }
@@ -1701,7 +1701,7 @@ export class ExportedCard extends ExportedCardParent {
   static isolated = class Isolated extends Component<typeof this> {
     <template></template>
   }
-  
+
   static embedded = class Embedded extends Component<typeof this> {
     <template></template>
   }


### PR DESCRIPTION
In [this commit](https://github.com/cardstack/boxel/pull/883/commits/35711aa7dc63bfe4fc8b7fcb555109b06cd59431) I accepted the editor’s autosave that removed whitespace from blank lines. That produced [these test failures](https://github.com/cardstack/boxel/pull/883/checks?check_run_id=19456557986) since the tests were expecting those spaces. I think we can just remove them from the inserted comments so this doesn’t happen to anyone else, as editors will continue to make this autofix.