### PR TITLE
Add account icon bottom left

### DIFF
--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -1,10 +1,12 @@
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 import { IconButton } from '@cardstack/boxel-ui/components';
+import { cn } from '@cardstack/boxel-ui/helpers';
 import { Sparkle as SparkleIcon } from '@cardstack/boxel-ui/icons';
 
 import ENV from '@cardstack/host/config/environment';
@@ -163,7 +165,9 @@ export default class SubmodeLayout extends Component<Signature> {
     <div class='profile-icon-container' data-test-profile-icon-container>
       <button
         class='profile-icon'
-        style='background: {{this.stringToColor this.matrixService.userId}}'
+        style={{htmlSafe
+          (cn 'background:' (this.stringToColor this.matrixService.userId))
+        }}
         data-test-profile-icon
       >
         <span>

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -250,7 +250,6 @@ export default class SubmodeLayout extends Component<Signature> {
       .profile-icon {
         width: 40px;
         height: 40px;
-        background: blue;
         border-radius: 50px;
         border: 2px solid white;
         display: flex;

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -19,6 +19,7 @@ import SearchSheet, {
 } from '../search-sheet';
 import SubmodeSwitcher, { Submode, Submodes } from '../submode-switcher';
 
+import type MatrixService from '../../services/matrix-service';
 import type OperatorModeStateService from '../../services/operator-mode-state-service';
 
 const { APP } = ENV;
@@ -40,6 +41,7 @@ export default class SubmodeLayout extends Component<Signature> {
   @tracked private searchSheetMode: SearchSheetMode = SearchSheetModes.Closed;
 
   @service private declare operatorModeStateService: OperatorModeStateService;
+  @service declare matrixService: MatrixService;
 
   private get chatVisibilityClass() {
     return this.isChatVisible ? 'chat-open' : 'chat-closed';
@@ -102,6 +104,35 @@ export default class SubmodeLayout extends Component<Signature> {
     this.closeSearchSheet();
   }
 
+  // Used to generate a color for the profile avatar
+  // Copied from https://github.com/mui/material-ui/issues/12700
+  stringToColor(string: string | null) {
+    if (!string) {
+      return 'transparent';
+    }
+
+    let hash = 0;
+    let i;
+
+    for (i = 0; i < string.length; i += 1) {
+      hash = string.charCodeAt(i) + ((hash << 5) - hash);
+    }
+
+    let color = '#';
+
+    for (i = 0; i < 3; i += 1) {
+      const value = (hash >> (i * 8)) & 0xff;
+      color += `00${value.toString(16)}`.substr(-2);
+    }
+
+    return color;
+  }
+
+  get userInitals() {
+    // transform @user:localhost into U, for example
+    return this.matrixService.userId?.split(':')[0].slice(1, 2).toUpperCase();
+  }
+
   <template>
     <div class='operator-mode__with-chat {{this.chatVisibilityClass}}'>
       <SubmodeSwitcher
@@ -128,6 +159,19 @@ export default class SubmodeLayout extends Component<Signature> {
         {{/if}}
       {{/if}}
     </div>
+
+    <div class='profile-icon-container' data-test-profile-icon-container>
+      <button
+        class='profile-icon'
+        style='background: {{this.stringToColor this.matrixService.userId}}'
+        data-test-profile-icon
+      >
+        <span>
+          {{this.userInitals}}
+        </span>
+      </button>
+    </div>
+
     <SearchSheet
       @mode={{this.searchSheetMode}}
       @onBlur={{this.closeSearchSheet}}
@@ -187,6 +231,32 @@ export default class SubmodeLayout extends Component<Signature> {
         height: 100vh;
         grid-column: 2;
         z-index: 1;
+      }
+
+      .profile-icon-container {
+        bottom: 0;
+        display: flex;
+        position: absolute;
+        width: var(--search-sheet-closed-height);
+        height: var(--search-sheet-closed-height);
+        border-radius: 50px;
+        margin-left: var(--boxel-sp);
+      }
+
+      .profile-icon {
+        width: 40px;
+        height: 40px;
+        background: blue;
+        border-radius: 50px;
+        border: 2px solid white;
+        display: flex;
+      }
+
+      .profile-icon > span {
+        color: white;
+        margin: auto;
+
+        font-size: var(--boxel-font-size-lg);
       }
     </style>
   </template>

--- a/packages/host/app/components/search-sheet/index.gts
+++ b/packages/host/app/components/search-sheet/index.gts
@@ -363,8 +363,8 @@ export default class SearchSheet extends Component<Signature> {
         display: flex;
         flex-direction: column;
         justify-content: stretch;
-        left: var(--boxel-sp);
-        width: calc(100% - (2 * var(--boxel-sp)));
+        left: 70px;
+        width: calc(100% - (7 * var(--boxel-sp)));
         position: absolute;
         z-index: 1;
         transition:

--- a/packages/host/app/components/search-sheet/index.gts
+++ b/packages/host/app/components/search-sheet/index.gts
@@ -363,7 +363,7 @@ export default class SearchSheet extends Component<Signature> {
         display: flex;
         flex-direction: column;
         justify-content: stretch;
-        left: 70px;
+        left: calc(6 * var(--boxel-sp-xs));
         width: calc(100% - (7 * var(--boxel-sp)));
         position: absolute;
         z-index: 1;

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -162,6 +162,7 @@ export default class MatrixService extends Service {
       user_id: userId,
       device_id: deviceId,
     } = auth;
+
     if (!accessToken) {
       throw new Error(
         `Cannot create matrix client from auth that has no access token: ${JSON.stringify(

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -999,6 +999,24 @@ module('Acceptance | code submode tests', function (hooks) {
     });
   });
 
+  test('has a profile icon in the bottom left corner', async function (assert) {
+    let operatorModeStateParam = stringify({
+      stacks: [],
+      submode: 'code',
+      codePath: `${testRealmURL}employee.gts`,
+    })!;
+
+    await visit(
+      `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+        operatorModeStateParam,
+      )}`,
+    );
+    assert.dom('[data-test-profile-icon-container]').hasText('T');
+    assert
+      .dom('[data-test-profile-icon]')
+      .hasAttribute('style', 'background: #5ead6b');
+  });
+
   test('changes cursor position when selected module declaration is changed', async function (assert) {
     let operatorModeStateParam = stringify({
       stacks: [[]],


### PR DESCRIPTION
This is preparatory work for adding a profile popup with profile info + signout option, which will be my next task, and it will look like this:

<img width="563" alt="image" src="https://github.com/cardstack/boxel/assets/273660/0b54d599-e6f9-411a-89d9-81a2fd5e1f01">

Currently, clicking on the avatar icon does nothing. 

The avatar icon looks like this:

<img width="581" alt="image" src="https://github.com/cardstack/boxel/assets/273660/62c08be9-26e9-4d33-8ade-0ca9e5f37d17">

Its color changes depending on the username. Here are a couple of random examples:

@john@acme.org
<img width="279" alt="image" src="https://github.com/cardstack/boxel/assets/273660/8b2ec422-c5a9-44de-8365-da51dd08cbb2">

@melinda@matrix.org
<img width="334" alt="image" src="https://github.com/cardstack/boxel/assets/273660/b3502672-6fa2-4684-9f4b-cc5414887e4e">

@keanu@matrix-reloaded.org
<img width="319" alt="image" src="https://github.com/cardstack/boxel/assets/273660/ea7d4589-7bab-4d21-8cf1-5f946cc2b2a4">

@costanza@import-export.net: 
<img width="345" alt="image" src="https://github.com/cardstack/boxel/assets/273660/e133c6aa-057f-446a-a0f4-c78005201e02">

With search opened:

<img width="1991" alt="image" src="https://github.com/cardstack/boxel/assets/273660/04a2913c-2f00-41cb-9319-47684f1f400a">
