### PR TITLE
matrix: Add reroute to login when auth fails

### DIFF
--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -140,13 +140,17 @@ export default class MatrixService extends Service {
   }
 
   async logout() {
-    await this.flushMembership;
-    await this.flushTimeline;
-    clearAuth();
-    this.unbindEventListeners();
-    await this.client.stopClient();
-    await this.client.logout();
-    this.resetState();
+    try {
+      await this.flushMembership;
+      await this.flushTimeline;
+      clearAuth();
+      this.unbindEventListeners();
+      await this.client.logout(true);
+    } catch (e) {
+      console.log('Error logging out of Matrix', e);
+    } finally {
+      this.resetState();
+    }
   }
 
   async start(auth?: IAuthData) {
@@ -199,8 +203,13 @@ export default class MatrixService extends Service {
       saveAuth(auth);
       this.bindEventListeners();
 
-      await this._client.startClient();
-      await this.initializeRooms();
+      try {
+        await this._client.startClient();
+        await this.initializeRooms();
+      } catch (e) {
+        console.log('Error starting Matrix client', e);
+        await this.logout();
+      }
     }
   }
 

--- a/packages/matrix/tests/login.spec.ts
+++ b/packages/matrix/tests/login.spec.ts
@@ -96,4 +96,19 @@ test.describe('Login', () => {
     await openChat(page);
     await assertLoggedIn(page);
   });
+
+  test('it returns to login when auth is invalid', async ({ page }) => {
+    await page.addInitScript({
+      content: `
+        window.localStorage.setItem(
+          'auth',
+          '{"user_id":"@b:stack.cards","access_token":"INVALID_TOKEN","home_server":"stack.cards","device_id":"HELLO","well_known":{"m.homeserver":{"base_url":"http://example.com/"}}}'
+        )`,
+    });
+
+    await openRoot(page);
+    await toggleOperatorMode(page);
+
+    await assertLoggedOut(page);
+  });
 });


### PR DESCRIPTION
With invalid auth entering operator mode would just hang here:

<img width="302" alt="Boxel 2023-12-11 11-30-41" src="https://github.com/cardstack/boxel/assets/43280/e8a8cc62-a829-4032-89e6-ba8d3a2fad1f">

Now it detects the failure and returns to the login dialogue:

![screencast 2023-12-11 10-41-35](https://github.com/cardstack/boxel/assets/43280/80204798-b818-43d6-b449-257a8733b97d)
