### PR TITLE
Clicking account icon shows account panel with sign out button

### DIFF
--- a/packages/boxel-ui/addon/src/styles/variables.css
+++ b/packages/boxel-ui/addon/src/styles/variables.css
@@ -15,6 +15,7 @@
     var(--boxel-font-family);
 
   /* font-sizes */
+  --boxel-font-size-xxl: 2.5rem; /* 40px */
   --boxel-font-size-xl: 2rem; /* 32px */
   --boxel-font-size-lg: 1.375rem; /* 22px */
   --boxel-font-size-med: 1.25rem; /* 20px */

--- a/packages/host/app/components/matrix/login.gts
+++ b/packages/host/app/components/matrix/login.gts
@@ -28,7 +28,11 @@ interface Signature {
 
 export default class Login extends Component<Signature> {
   <template>
-    <form class='login-form' {{on 'submit' this.handleSubmit}}>
+    <form
+      class='login-form'
+      {{on 'submit' this.handleSubmit}}
+      data-test-login-form
+    >
       <BoxelHeader @title='Boxel' @hasBackground={{false}} class='header'>
         <:icon>
           <BoxelIcon />

--- a/packages/host/app/components/operator-mode/profile-avatar-icon.gts
+++ b/packages/host/app/components/operator-mode/profile-avatar-icon.gts
@@ -1,0 +1,59 @@
+import { htmlSafe } from '@ember/template';
+import Component from '@glimmer/component';
+
+import { cn } from '@cardstack/boxel-ui/helpers';
+
+import { stringToColor } from '@cardstack/host/lib/utils';
+
+interface Signature {
+  Args: {
+    userId: string | null;
+  };
+  Element: HTMLElement;
+}
+
+export default class ProfileAvatarIcon extends Component<Signature> {
+  get userInitials() {
+    // Transform @user:localhost into U, for example
+    return this.args.userId?.split(':')[0].slice(1, 2).toUpperCase();
+  }
+
+  <template>
+    <style>
+      .profile-icon {
+        width: 40px;
+        height: 40px;
+        border-radius: 50px;
+        border: 2px solid white;
+        display: flex;
+      }
+
+      .profile-icon--big {
+        width: 80px;
+        height: 80px;
+      }
+
+      .profile-icon > span {
+        color: white;
+        margin: auto;
+
+        font-size: var(--boxel-font-size-lg);
+      }
+
+      .profile-icon--big > span {
+        font-size: var(--boxel-font-size-xxl);
+      }
+    </style>
+
+    <div
+      class='profile-icon'
+      style={{htmlSafe (cn 'background:' (stringToColor @userId))}}
+      data-test-profile-icon
+      ...attributes
+    >
+      <span>
+        {{this.userInitials}}
+      </span>
+    </div>
+  </template>
+}

--- a/packages/host/app/components/operator-mode/profile-info-popover.gts
+++ b/packages/host/app/components/operator-mode/profile-info-popover.gts
@@ -55,7 +55,7 @@ export default class ProfileInfoPopover extends Component<Signature> {
       }
 
       .profile-popover-header {
-        font-color: var(--boxel-dark);
+        color: var(--boxel-dark);
         text-transform: uppercase;
       }
 

--- a/packages/host/app/components/operator-mode/profile-info-popover.gts
+++ b/packages/host/app/components/operator-mode/profile-info-popover.gts
@@ -1,0 +1,142 @@
+import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import onClickOutside from 'ember-click-outside/modifiers/on-click-outside';
+
+import { BoxelButton } from '@cardstack/boxel-ui/components';
+
+import { not } from '@cardstack/boxel-ui/helpers';
+
+import ProfileAvatarIcon from '@cardstack/host/components/operator-mode/profile-avatar-icon';
+import MatrixService from '@cardstack/host/services/matrix-service';
+
+interface Signature {
+  Args: {};
+  Element: HTMLElement;
+}
+
+export default class ProfileInfoPopover extends Component<Signature> {
+  @service declare matrixService: MatrixService;
+  @tracked private isOpened = false;
+
+  @action setPopoverProfileOpen(open: boolean) {
+    this.isOpened = open;
+  }
+
+  @action logout() {
+    this.matrixService.logout();
+  }
+
+  <template>
+    <style>
+      .profile-popover {
+        width: 280px;
+        height: 280px;
+        position: absolute;
+        bottom: 68px;
+        left: 20px;
+        z-index: 1;
+        background: white;
+        padding: var(--boxel-sp);
+        flex-direction: column;
+        border-radius: var(--boxel-border-radius);
+        box-shadow: var(--boxel-deep-box-shadow);
+        transition: all 0.1s ease-out;
+        opacity: 0;
+        display: flex;
+      }
+
+      .profile-popover.opened {
+        opacity: 1;
+      }
+
+      .profile-popover-header {
+        font-color: var(--boxel-dark);
+        text-transform: uppercase;
+      }
+
+      .profile-popover-body {
+        margin: auto;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .profile-popover-body > * {
+        margin: auto;
+      }
+
+      .profile-popover-body > .profile-icon {
+        width: 70px;
+        height: 70px;
+        font-size: var(--boxel-font-size-xxl);
+      }
+
+      .profile-handle {
+        margin-top: var(--boxel-sp-xs);
+        color: var(--boxel-500);
+      }
+
+      .profile-icon-container {
+        bottom: 0;
+        position: absolute;
+        width: var(--search-sheet-closed-height);
+        height: var(--search-sheet-closed-height);
+        border-radius: 50px;
+        margin-left: var(--boxel-sp);
+        z-index: 1;
+      }
+
+      .profile-icon-button {
+        border: 0;
+        padding: 0;
+        background: transparent;
+      }
+    </style>
+
+    <div class='profile-icon-container'>
+      <button
+        class='profile-icon-button'
+        {{on 'click' (fn this.setPopoverProfileOpen (not this.isOpened))}}
+        data-test-profile-icon-button
+      >
+        <ProfileAvatarIcon @userId={{this.matrixService.userId}} />
+      </button>
+    </div>
+
+    <div
+      class='profile-popover {{if this.isOpened "opened"}}'
+      {{onClickOutside
+        (fn this.setPopoverProfileOpen false)
+        exceptSelector='.profile-icon-button'
+      }}
+      data-test-profile-popover
+    >
+      <div class='profile-popover-header'>
+        Signed in as
+      </div>
+
+      <div class='profile-popover-body' data-test-profile-icon-container>
+        <ProfileAvatarIcon
+          @userId={{this.matrixService.userId}}
+          class='profile-icon--big'
+        />
+
+        <div class='profile-handle' data-test-profile-icon-handle>
+          {{this.matrixService.userId}}
+        </div>
+      </div>
+
+      <BoxelButton
+        {{on 'click' this.logout}}
+        @kind='primary-dark'
+        data-test-signout-button
+      >
+        Sign out
+      </BoxelButton>
+    </div>
+  </template>
+}

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -5,7 +5,7 @@ import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
-import { IconButton } from '@cardstack/boxel-ui/components';
+import { BoxelButton, IconButton } from '@cardstack/boxel-ui/components';
 import { cn } from '@cardstack/boxel-ui/helpers';
 import { Sparkle as SparkleIcon } from '@cardstack/boxel-ui/icons';
 
@@ -23,6 +23,8 @@ import SubmodeSwitcher, { Submode, Submodes } from '../submode-switcher';
 
 import type MatrixService from '../../services/matrix-service';
 import type OperatorModeStateService from '../../services/operator-mode-state-service';
+
+import ProfileInfoPopover from '@cardstack/host/components/operator-mode/profile-info-popover';
 
 const { APP } = ENV;
 
@@ -106,35 +108,6 @@ export default class SubmodeLayout extends Component<Signature> {
     this.closeSearchSheet();
   }
 
-  // Used to generate a color for the profile avatar
-  // Copied from https://github.com/mui/material-ui/issues/12700
-  stringToColor(string: string | null) {
-    if (!string) {
-      return 'transparent';
-    }
-
-    let hash = 0;
-    let i;
-
-    for (i = 0; i < string.length; i += 1) {
-      hash = string.charCodeAt(i) + ((hash << 5) - hash);
-    }
-
-    let color = '#';
-
-    for (i = 0; i < 3; i += 1) {
-      const value = (hash >> (i * 8)) & 0xff;
-      color += `00${value.toString(16)}`.substr(-2);
-    }
-
-    return color;
-  }
-
-  get userInitals() {
-    // transform @user:localhost into U, for example
-    return this.matrixService.userId?.split(':')[0].slice(1, 2).toUpperCase();
-  }
-
   <template>
     <div class='operator-mode__with-chat {{this.chatVisibilityClass}}'>
       <SubmodeSwitcher
@@ -162,19 +135,7 @@ export default class SubmodeLayout extends Component<Signature> {
       {{/if}}
     </div>
 
-    <div class='profile-icon-container' data-test-profile-icon-container>
-      <button
-        class='profile-icon'
-        style={{htmlSafe
-          (cn 'background:' (this.stringToColor this.matrixService.userId))
-        }}
-        data-test-profile-icon
-      >
-        <span>
-          {{this.userInitals}}
-        </span>
-      </button>
-    </div>
+    <ProfileInfoPopover />
 
     <SearchSheet
       @mode={{this.searchSheetMode}}
@@ -184,7 +145,55 @@ export default class SubmodeLayout extends Component<Signature> {
       @onSearch={{this.expandSearchToShowResults}}
       @onCardSelect={{this.handleCardSelectFromSearch}}
     />
+
     <style>
+      .profile-popover {
+        width: 280px;
+        height: 280px;
+        position: absolute;
+        bottom: 68px;
+        left: 20px;
+        z-index: 1;
+        background: white;
+        padding: var(--boxel-sp);
+        flex-direction: column;
+        border-radius: var(--boxel-border-radius);
+        box-shadow: var(--boxel-deep-box-shadow);
+        transition: all 0.1s ease-out;
+        opacity: 0;
+        display: flex;
+      }
+
+      .profile-popover.opened {
+        opacity: 1;
+      }
+
+      .profile-popover-header {
+        font-color: var(--boxel-dark);
+        text-transform: uppercase;
+      }
+
+      .profile-popover-body {
+        margin: auto;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .profile-popover-body > * {
+        margin: auto;
+      }
+
+      .profile-popover-body > .profile-icon {
+        width: 70px;
+        height: 70px;
+        font-size: var(--boxel-font-size-xxl);
+      }
+
+      .profile-handle {
+        margin-top: var(--boxel-sp-xs);
+        color: var(--boxel-500);
+      }
+
       .operator-mode__with-chat {
         display: grid;
         grid-template-rows: 1fr;
@@ -245,6 +254,7 @@ export default class SubmodeLayout extends Component<Signature> {
         height: var(--search-sheet-closed-height);
         border-radius: 50px;
         margin-left: var(--boxel-sp);
+        z-index: 1;
       }
 
       .profile-icon {

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -1,14 +1,15 @@
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import { htmlSafe } from '@ember/template';
+
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
-import { BoxelButton, IconButton } from '@cardstack/boxel-ui/components';
-import { cn } from '@cardstack/boxel-ui/helpers';
+import { IconButton } from '@cardstack/boxel-ui/components';
+
 import { Sparkle as SparkleIcon } from '@cardstack/boxel-ui/icons';
 
+import ProfileInfoPopover from '@cardstack/host/components/operator-mode/profile-info-popover';
 import ENV from '@cardstack/host/config/environment';
 import { assertNever } from '@cardstack/host/utils/assert-never';
 
@@ -23,8 +24,6 @@ import SubmodeSwitcher, { Submode, Submodes } from '../submode-switcher';
 
 import type MatrixService from '../../services/matrix-service';
 import type OperatorModeStateService from '../../services/operator-mode-state-service';
-
-import ProfileInfoPopover from '@cardstack/host/components/operator-mode/profile-info-popover';
 
 const { APP } = ENV;
 

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -244,32 +244,6 @@ export default class SubmodeLayout extends Component<Signature> {
         grid-column: 2;
         z-index: 1;
       }
-
-      .profile-icon-container {
-        bottom: 0;
-        display: flex;
-        position: absolute;
-        width: var(--search-sheet-closed-height);
-        height: var(--search-sheet-closed-height);
-        border-radius: 50px;
-        margin-left: var(--boxel-sp);
-        z-index: 1;
-      }
-
-      .profile-icon {
-        width: 40px;
-        height: 40px;
-        border-radius: 50px;
-        border: 2px solid white;
-        display: flex;
-      }
-
-      .profile-icon > span {
-        color: white;
-        margin: auto;
-
-        font-size: var(--boxel-font-size-lg);
-      }
     </style>
   </template>
 }

--- a/packages/host/app/lib/utils.ts
+++ b/packages/host/app/lib/utils.ts
@@ -48,3 +48,27 @@ export async function getModulesInRealm(
 export function stripFileExtension(path: string): string {
   return path.replace(/\.[^/.]+$/, '');
 }
+
+// Used to generate a color for the profile avatar
+// Copied from https://github.com/mui/material-ui/issues/12700
+export function stringToColor(string: string | null) {
+  if (!string) {
+    return 'transparent';
+  }
+
+  let hash = 0;
+  let i;
+
+  for (i = 0; i < string.length; i += 1) {
+    hash = string.charCodeAt(i) + ((hash << 5) - hash);
+  }
+
+  let color = '#';
+
+  for (i = 0; i < 3; i += 1) {
+    const value = (hash >> (i * 8)) & 0xff;
+    color += `00${value.toString(16)}`.substr(-2);
+  }
+
+  return color;
+}

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -999,43 +999,6 @@ module('Acceptance | code submode tests', function (hooks) {
     });
   });
 
-  test('has a profile icon in the bottom left corner that opens profile info popover', async function (assert) {
-    let operatorModeStateParam = stringify({
-      stacks: [],
-      submode: 'code',
-      codePath: `${testRealmURL}employee.gts`,
-    })!;
-
-    await visit(
-      `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
-        operatorModeStateParam,
-      )}`,
-    );
-
-    assert.dom('[data-test-profile-icon]').hasText('T');
-    assert
-      .dom('[data-test-profile-icon]')
-      .hasAttribute('style', 'background: #5ead6b');
-
-    assert.dom('[data-test-profile-popover]').doesNotHaveClass('opened');
-
-    await click('[data-test-profile-icon-button]');
-
-    assert.dom('[data-test-profile-popover]').hasClass('opened');
-
-    await click('[data-test-profile-icon-button]');
-
-    assert.dom('[data-test-profile-popover]').doesNotHaveClass('opened'); // Clicking again closes the popover
-
-    await click('[data-test-profile-icon-button]');
-
-    assert.dom('[data-test-profile-icon-handle]').hasText('@testuser:staging');
-
-    await click('[data-test-signout-button]');
-
-    assert.dom('[data-test-login-form]').exists();
-  });
-
   test('changes cursor position when selected module declaration is changed', async function (assert) {
     let operatorModeStateParam = stringify({
       stacks: [[]],

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -999,7 +999,7 @@ module('Acceptance | code submode tests', function (hooks) {
     });
   });
 
-  test('has a profile icon in the bottom left corner', async function (assert) {
+  test('has a profile icon in the bottom left corner that opens profile info popover', async function (assert) {
     let operatorModeStateParam = stringify({
       stacks: [],
       submode: 'code',
@@ -1011,10 +1011,29 @@ module('Acceptance | code submode tests', function (hooks) {
         operatorModeStateParam,
       )}`,
     );
-    assert.dom('[data-test-profile-icon-container]').hasText('T');
+
+    assert.dom('[data-test-profile-icon]').hasText('T');
     assert
       .dom('[data-test-profile-icon]')
       .hasAttribute('style', 'background: #5ead6b');
+
+    assert.dom('[data-test-profile-popover]').doesNotHaveClass('opened');
+
+    await click('[data-test-profile-icon-button]');
+
+    assert.dom('[data-test-profile-popover]').hasClass('opened');
+
+    await click('[data-test-profile-icon-button]');
+
+    assert.dom('[data-test-profile-popover]').doesNotHaveClass('opened'); // Clicking again closes the popover
+
+    await click('[data-test-profile-icon-button]');
+
+    assert.dom('[data-test-profile-icon-handle]').hasText('@testuser:staging');
+
+    await click('[data-test-signout-button]');
+
+    assert.dom('[data-test-login-form]').exists();
   });
 
   test('changes cursor position when selected module declaration is changed', async function (assert) {

--- a/packages/host/tests/acceptance/operator-mode-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-test.gts
@@ -377,6 +377,43 @@ module('Acceptance | operator mode tests', function (hooks) {
     });
   });
 
+  test('has a profile icon in the bottom left corner that opens profile info popover', async function (assert) {
+    let operatorModeStateParam = stringify({
+      stacks: [],
+      submode: 'code',
+      codePath: `${testRealmURL}employee.gts`,
+    })!;
+
+    await visit(
+      `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+        operatorModeStateParam,
+      )}`,
+    );
+
+    assert.dom('[data-test-profile-icon]').hasText('T');
+    assert
+      .dom('[data-test-profile-icon]')
+      .hasAttribute('style', 'background: #5ead6b');
+
+    assert.dom('[data-test-profile-popover]').doesNotHaveClass('opened');
+
+    await click('[data-test-profile-icon-button]');
+
+    assert.dom('[data-test-profile-popover]').hasClass('opened');
+
+    await click('[data-test-profile-icon-button]');
+
+    assert.dom('[data-test-profile-popover]').doesNotHaveClass('opened'); // Clicking again closes the popover
+
+    await click('[data-test-profile-icon-button]');
+
+    assert.dom('[data-test-profile-icon-handle]').hasText('@testuser:staging');
+
+    await click('[data-test-signout-button]');
+
+    assert.dom('[data-test-login-form]').exists();
+  });
+
   test('visiting index card and entering operator mode', async function (assert) {
     await visit('/');
 

--- a/packages/host/tests/helpers/mock-matrix-service.ts
+++ b/packages/host/tests/helpers/mock-matrix-service.ts
@@ -1,4 +1,5 @@
 import Service, { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 import { TrackedMap } from 'tracked-built-ins';
 
@@ -17,7 +18,13 @@ let cardApi: typeof import('https://cardstack.com/base/card-api');
 
 class MockClient {
   lastSentEvent: any;
-  public getProfileInfo(userId: string) {
+  userId: string | undefined;
+
+  constructor(userId: string | undefined) {
+    this.userId = userId;
+  }
+
+  public getProfileInfo(userId: string | null) {
     return Promise.resolve({
       displayname: userId,
     });
@@ -33,13 +40,16 @@ class MockClient {
       ],
     });
   }
+  public getUserId() {
+    return this.userId;
+  }
 }
 
 export class MockMatrixService extends Service {
   @service declare loaderService: LoaderService;
   lastMessageSent: any;
   // @ts-ignore
-  client: MockClient = new MockClient();
+  @tracked client: MockClient = new MockClient('@testuser:staging');
   // @ts-ignore
   cardAPI!: typeof cardApi;
   // These will be empty in the tests, but we need to define them to satisfy the interface
@@ -50,10 +60,10 @@ export class MockMatrixService extends Service {
   async start(_auth?: any) {}
 
   get isLoggedIn() {
-    return true;
+    return this.userId !== undefined;
   }
   get userId() {
-    return '@testuser:staging';
+    return this.client.getUserId();
   }
 
   async allowedToSetObjective(_roomId: string): Promise<boolean> {
@@ -75,6 +85,10 @@ export class MockMatrixService extends Service {
     context?: OperatorModeContext,
   ) {
     this.lastMessageSent = { roomId, body, card, context };
+  }
+
+  async logout() {
+    this.client = new MockClient(undefined);
   }
 
   public createAndJoinRoom(roomId: string) {

--- a/packages/matrix/tests/login.spec.ts
+++ b/packages/matrix/tests/login.spec.ts
@@ -57,6 +57,22 @@ test.describe('Login', () => {
     await assertLoggedOut(page);
   });
 
+  test('it can logout using the profile menu', async ({ page }) => {
+    await login(page, 'user1', 'pass');
+
+    await expect(
+      page.locator(
+        '[data-test-profile-icon-button] > [data-test-profile-icon]',
+      ),
+    ).toHaveText('U');
+    await page.locator('[data-test-profile-icon-button]').click();
+    await expect(page.locator('[data-test-profile-icon-handle]')).toHaveText(
+      '@user1:localhost',
+    );
+    await page.locator('[data-test-signout-button]').click();
+    await expect(page.locator('[data-test-login-form]')).toBeVisible();
+  });
+
   test('it shows an error when invalid credentials are provided', async ({
     page,
   }) => {


### PR DESCRIPTION
This adds a popover displaying basic user info and offers a sign out action.

In the video below I exercise:
1. Clicking on the user avatar will open a popover
2. Clicking on the avatar again will close it
3. Clicking outside the popover will close it
4. Clicking on "sign out" will perform a logout in the matrix service and bring the user to the login screen

https://github.com/cardstack/boxel/assets/273660/91f861f4-3b4a-4a9b-b030-fd31bc9d6659

