### PR TITLE
Fix outline issue when focusing on buttons

### DIFF
--- a/packages/host/app/components/modal-container.gts
+++ b/packages/host/app/components/modal-container.gts
@@ -100,11 +100,12 @@ export default class ModalContainer extends Component<Signature> {
         background: none;
         font: var(--boxel-font-lg);
         position: absolute;
-        top: 0;
-        right: 0;
+        top: 1px;
+        right: 1px;
         width: 50px;
         height: 50px;
-        padding: 0;
+        padding: var(--boxel-sp-xs);
+        border-top-right-radius: calc(var(--boxel-border-radius) - 1px);
       }
 
       .dialog-box__close:hover {

--- a/packages/host/app/components/modal-container.gts
+++ b/packages/host/app/components/modal-container.gts
@@ -85,7 +85,7 @@ export default class ModalContainer extends Component<Signature> {
       }
 
       .dialog-box__content {
-        padding: 0 var(--boxel-sp-xl) var(--boxel-sp-xl);
+        padding: var(--boxel-sp-5xs) var(--boxel-sp-xl) var(--boxel-sp-xl);
         height: 100%;
         overflow: auto;
       }

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -193,6 +193,12 @@ export default class OperatorModeContainer extends Component<Signature> {
         --operator-mode-min-width: 20.5rem;
         --operator-mode-left-column: 14rem;
       }
+      :global(button:focus:not(:disabled)) {
+        outline-color: var(--boxel-highlight);
+      }
+      :global(dialog:focus) {
+        outline: none;
+      }
       :global(.operator-mode .boxel-modal__inner) {
         display: block;
       }


### PR DESCRIPTION
This PR addresses the issue related to the outline color when focusing on buttons. I have updated the outline color to boxel-teal. Additionally, I made adjustments to the button positions to enhance the overall appearance of the outline.

Before:


https://github.com/cardstack/boxel/assets/12637010/59907dd6-68d0-4bd3-8ada-4f48797f7288

After:


https://github.com/cardstack/boxel/assets/12637010/4edfb9dc-c8e9-4014-953f-c3b9a7c210c6

