### PR TITLE
interact-submode publicAPI refactor

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -1732,7 +1732,7 @@ class MissingEmbeddedTemplate extends GlimmerComponent<{
         for
         {{if (isCardDef @cardOrField) 'CardDef' 'FieldDef'}}:
         {{@cardOrField.displayName}}</span>
-      {{#if @context.actions.openCodeSubmode}}
+      {{#if @context.actions.changeSubmode}}
         <span
           class='open-code-submode'
           {{on 'click' this.openCodeSubmode}}
@@ -1785,7 +1785,7 @@ class MissingEmbeddedTemplate extends GlimmerComponent<{
       return;
     }
     let moduleId = moduleFrom(ref);
-    this.args.context?.actions?.openCodeSubmode(new URL(moduleId));
+    this.args.context?.actions?.changeSubmode(new URL(moduleId), 'code');
   }
 }
 

--- a/packages/drafts-realm/claim.gts
+++ b/packages/drafts-realm/claim.gts
@@ -114,7 +114,7 @@ class Isolated extends Component<typeof Claim> {
             Claiming...
           {{else if this.hasBeenClaimed}}
             Claim has been used
-          {{else if @context.actions.createCardDirectly}}
+          {{else if @context.actions.createCard}}
             Claim
           {{else if this.inEnvThatCanCreateNewCard}}
             Claim
@@ -166,7 +166,7 @@ class Isolated extends Component<typeof Claim> {
   get cannotClickClaimButton() {
     return (
       this.hasBeenClaimed ||
-      (!!!this.args.context?.actions?.createCardDirectly &&
+      (!!!this.args.context?.actions?.createCard &&
         !this.inEnvThatCanCreateNewCard)
     );
   }
@@ -252,19 +252,17 @@ class Isolated extends Component<typeof Claim> {
               },
             },
           },
-          meta: {
-            adoptsFrom: {
-              module: `${realmUrl.href}transaction`,
-              name: 'Transaction',
-            },
-          },
         },
       };
-      if (this.args.context?.actions?.createCardDirectly) {
+
+      if (this.args.context?.actions?.createCard) {
         // create using operator mode action
-        await this.args.context.actions.createCardDirectly(
-          transactionDoc,
+        await this.args.context.actions.createCard(
+          transactionCardRef,
           undefined,
+          {
+            doc: transactionDoc,
+          },
         );
       } else {
         // create using create card modal

--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -34,7 +34,6 @@ interface Signature {
   Args: {
     renderedCardsForOverlayActions: RenderedCardForOverlayActions[];
     publicAPI: Actions;
-    delete: (card: CardDef) => void;
     toggleSelect?: (card: CardDef) => void;
     selectedCards?: TrackedArray<CardDef>;
   };
@@ -126,7 +125,10 @@ export default class OperatorModeOverlays extends Component<Signature> {
                   @closeMenu={{dd.close}}
                   @items={{array
                     (menuItem
-                      'Delete' (fn @delete card) icon=IconTrash dangerous=true
+                      'Delete'
+                      (fn @publicAPI.deleteCard card)
+                      icon=IconTrash
+                      dangerous=true
                     )
                   }}
                   {{on

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -76,9 +76,6 @@ interface Signature {
     publicAPI: Actions;
     close: (item: StackItem) => void;
     dismissStackedCardsAbove: (stackIndex: number) => void;
-    edit: (item: StackItem) => void;
-    save: (item: StackItem, dismiss: boolean) => void;
-    delete: (card: CardDef) => void;
     onSelectedCards: (selectedCards: CardDef[], stackItem: StackItem) => void;
     setupStackItem: (
       stackItem: StackItem,
@@ -278,7 +275,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
   private initiateAutoSaveTask = restartableTask(async () => {
     await timeout(this.environmentService.autoSaveDelayMs);
     this.isSaving = true;
-    this.args.save(this.args.item, false);
+    this.args.publicAPI.saveCard(this.card, false);
     this.isSaving = false;
     this.lastSaved = Date.now();
     this.calculateLastSavedMsg();
@@ -393,7 +390,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
                       @height='24px'
                       class='icon-button'
                       aria-label='Edit'
-                      {{on 'click' (fn @edit @item)}}
+                      {{on 'click' (fn @publicAPI.editCard this.card)}}
                       data-test-edit-button
                     />
                   </:trigger>
@@ -410,7 +407,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
                       @height='24px'
                       class='icon-save'
                       aria-label='Finish Editing'
-                      {{on 'click' (fn @save @item true)}}
+                      {{on 'click' (fn @publicAPI.saveCard this.card true)}}
                       data-test-edit-button
                     />
                   </:trigger>
@@ -451,7 +448,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
                         )
                         (menuItem
                           'Delete'
-                          (fn @delete this.card)
+                          (fn @publicAPI.deleteCard this.card)
                           icon=IconTrash
                           dangerous=true
                           disabled=(not this.card.id)
@@ -501,7 +498,6 @@ export default class OperatorModeStackItem extends Component<Signature> {
             <OperatorModeOverlays
               @renderedCardsForOverlayActions={{this.renderedCardsForOverlayActions}}
               @publicAPI={{@publicAPI}}
-              @delete={{@delete}}
               @toggleSelect={{this.toggleSelect}}
               @selectedCards={{this.selectedCards}}
             />

--- a/packages/host/app/components/operator-mode/stack.gts
+++ b/packages/host/app/components/operator-mode/stack.gts
@@ -19,9 +19,6 @@ interface Signature {
     stackIndex: number;
     publicAPI: Actions;
     close: (stackItem: StackItem) => void;
-    edit: (stackItem: StackItem) => void;
-    save: (stackItem: StackItem, dismiss: boolean) => void;
-    delete: (card: CardDef) => void;
     onSelectedCards: (selectedCards: CardDef[], stackItem: StackItem) => void;
     setupStackItem: (
       stackItem: StackItem,
@@ -53,9 +50,6 @@ export default class OperatorModeStack extends Component<Signature> {
             @publicAPI={{@publicAPI}}
             @dismissStackedCardsAbove={{perform this.dismissStackedCardsAbove}}
             @close={{@close}}
-            @edit={{@edit}}
-            @save={{@save}}
-            @delete={{@delete}}
             @onSelectedCards={{@onSelectedCards}}
             @setupStackItem={{@setupStackItem}}
           />

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -295,16 +295,14 @@ export interface Actions {
     fieldType?: 'linksTo' | 'contains' | 'containsMany' | 'linksToMany',
     fieldName?: string,
   ) => Promise<void>;
-  createCardDirectly: (
-    doc: LooseSingleCardDocument,
-    relativeTo: URL | undefined,
-  ) => Promise<void>;
+  editCard: (card: CardDef) => void;
+  saveCard(card: CardDef, dismissItem: boolean): void;
+  deleteCard: (card: CardDef, opts?: { afterDelete: () => void }) => void;
   doWithStableScroll: (
     card: CardDef,
     changeSizeCallback: () => Promise<void>,
   ) => Promise<void>;
-  openCodeSubmode: (url: URL) => void;
-  // more CRUD ops to come...
+  changeSubmode: (url: URL, submode: 'code' | 'interact') => void;
 }
 
 export function hasExecutableExtension(path: string): boolean {


### PR DESCRIPTION
- refactor to add `edit`, `delete`, `save` to interact-submode's publicAPI
- the methods now accept `CardDef` instead of `StackItem` as argument -- this way the API is not specific to interact mode and can be used in more places