### PR TITLE
Inspector Delete support for non-card instances

### DIFF
--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -1,5 +1,6 @@
 import { hash, array } from '@ember/helper';
 import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 
@@ -17,8 +18,9 @@ import {
   CardContainer,
   Header,
   LoadingIndicator,
+  IconButton,
 } from '@cardstack/boxel-ui/components';
-
+import { cssVar } from '@cardstack/boxel-ui/helpers';
 import { IconInherit, IconTrash, IconPlus } from '@cardstack/boxel-ui/icons';
 
 import {
@@ -85,9 +87,7 @@ interface Signature {
         ref: ResolvedCodeRef;
       },
     ) => Promise<void>;
-    delete: (
-      card: CardDef | typeof CardDef | undefined,
-    ) => void | Promise<void>;
+    delete: (item: CardDef | URL | null | undefined) => void | Promise<void>;
   };
 }
 
@@ -109,6 +109,10 @@ export default class DetailPanel extends Component<Signature> {
 
   private get showInThisFilePanel() {
     return this.isModule && this.declarations.length > 0;
+  }
+
+  private get codePath() {
+    return this.operatorModeStateService.state.codePath;
   }
 
   private get showInheritancePanel() {
@@ -183,7 +187,6 @@ export default class DetailPanel extends Component<Signature> {
             },
           ]
         : []),
-      { label: 'Delete', icon: IconTrash, handler: this.args.delete },
     ];
   }
 
@@ -319,7 +322,21 @@ export default class DetailPanel extends Component<Signature> {
                 @hasBackground={{true}}
                 class='header'
                 data-test-current-module-name={{@readyFile.name}}
-              />
+              >
+                <:actions>
+                  <IconButton
+                    data-test-delete-module-button
+                    @icon={{IconTrash}}
+                    aria-label='Delete'
+                    {{on 'click' (fn @delete this.codePath)}}
+                    style={{cssVar
+                      boxel-icon-button-width='24px'
+                      boxel-icon-button-height='24px'
+                      icon-color='var(--boxel-highlight)'
+                    }}
+                  />
+                </:actions>
+              </Header>
               <Selector
                 @class='in-this-file-menu'
                 @items={{this.buildSelectorItems}}
@@ -442,7 +459,11 @@ export default class DetailPanel extends Component<Signature> {
               @fileExtension={{this.fileExtension}}
               @infoText={{this.lastModified.value}}
               @actions={{array
-                (hash label='Delete' handler=@delete icon=IconTrash)
+                (hash
+                  label='Delete'
+                  handler=(fn @delete this.codePath)
+                  icon=IconTrash
+                )
               }}
             />
           </div>

--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -229,6 +229,25 @@ export default class CardService extends Service {
     return response;
   }
 
+  async deleteSource(url: URL, loader?: Loader) {
+    loader = loader ?? this.loaderService.loader;
+    let response = await loader.fetch(url, {
+      method: 'DELETE',
+      headers: {
+        Accept: 'application/vnd.card+source',
+      },
+    });
+
+    if (!response.ok) {
+      let errorMessage = `Could not delete file ${url}, status ${
+        response.status
+      }: ${response.statusText} - ${await response.text()}`;
+      console.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+    return response;
+  }
+
   // we return undefined if the card changed locally while the save was in-flight
   async patchCard(
     card: CardDef,

--- a/packages/host/app/services/recent-files-service.ts
+++ b/packages/host/app/services/recent-files-service.ts
@@ -19,6 +19,8 @@ export interface RecentFile {
 }
 
 export default class RecentFilesService extends Service {
+  // we shouldn't be making assumptions about what realm the files are coming
+  // from, the caller should just tell us
   @service declare operatorModeStateService: OperatorModeStateService;
 
   @tracked recentFiles = new TrackedArray<RecentFile>([]);
@@ -47,6 +49,8 @@ export default class RecentFilesService extends Service {
     if (!url) {
       return;
     }
+    // TODO this wont work when visiting files that come from multiple realms in
+    // code mode...
     let realmURL = this.operatorModeStateService.resolvedRealmURL;
 
     if (realmURL) {
@@ -58,6 +62,8 @@ export default class RecentFilesService extends Service {
   }
 
   addRecentFile(file: LocalPath) {
+    // TODO this wont work when visiting files that come from multiple realms in
+    // code mode...
     let currentRealmUrl = this.operatorModeStateService.realmURL;
 
     if (!currentRealmUrl) {
@@ -95,6 +101,8 @@ export default class RecentFilesService extends Service {
   }
 
   private findRecentFileIndex(path: LocalPath) {
+    // TODO this wont work when visiting files that come from multiple realms in
+    // code mode...
     let currentRealmUrl = this.operatorModeStateService.realmURL;
 
     return this.recentFiles.findIndex(

--- a/packages/runtime-common/card-document.ts
+++ b/packages/runtime-common/card-document.ts
@@ -196,7 +196,6 @@ export function isCardDocumentString(maybeJsonString: string) {
     let doc = JSON.parse(maybeJsonString);
     return isSingleCardDocument(doc) || isCardCollectionDocument(doc);
   } catch (err) {
-    console.log(`string ${maybeJsonString} is not a valid card doc`);
     return false;
   }
 }


### PR DESCRIPTION
This PR provides delete support for non-card instances. In the screenshot we delete a definition, and then we delete the next recent file an image

![delete](https://github.com/cardstack/boxel/assets/61075/0f1b55a7-88f4-4913-9f2d-fff63b9a2d98)

