### PR TITLE
Show module syntax errors in schema editor

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -364,6 +364,9 @@ export default class CodeSubmode extends Component<Signature> {
   }
 
   private get selectedDeclaration() {
+    if (!this.isModule || this.moduleContentsResource.moduleError) {
+      return undefined;
+    }
     if (this._selectedDeclaration) {
       return this._selectedDeclaration;
     } else {

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -725,7 +725,7 @@ export default class CodeSubmode extends Component<Signature> {
                     </div>
                   {{else if
                     (or
-                      (bool this.selectedCardOrField)
+                      (bool this.selectedCardOrField.cardOrField)
                       (bool this.moduleContentsResource.moduleError)
                     )
                   }}

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -781,7 +781,10 @@ export default class CodeSubmode extends Component<Signature> {
                         class='accordion-item'
                         @contentClass='accordion-item-content'
                         @onClick={{fn this.selectAccordionItem 'schema-editor'}}
-                        @isOpen={{true}}
+                        @isOpen={{eq
+                          this.selectedAccordionItem
+                          'schema-editor'
+                        }}
                       >
                         <:title>
                           <SchemaEditorTitle @hasModuleError={{true}} />

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -57,7 +57,7 @@ import CardURLBar from './card-url-bar';
 import CodeEditor from './code-editor';
 import InnerContainer from './code-submode/inner-container';
 import CodeSubmodeLeftPanelToggle from './code-submode/left-panel-toggle';
-import SchemaEditor from './code-submode/schema-editor';
+import SchemaEditor, { SchemaEditorTitle } from './code-submode/schema-editor';
 import CreateFileModal, { type FileType } from './create-file-modal';
 import DeleteModal from './delete-modal';
 import DetailPanel from './detail-panel';
@@ -253,6 +253,7 @@ export default class CodeSubmode extends Component<Signature> {
   }
 
   private get fileIncompatibilityMessage() {
+    debugger;
     if (this.isCard) {
       if (this.cardResource.cardError) {
         return `Card preview failed. Make sure both the card instance data and card definition files have no syntax errors and that their data schema matches. `;
@@ -723,12 +724,7 @@ export default class CodeSubmode extends Component<Signature> {
                     >
                       {{this.fileIncompatibilityMessage}}
                     </div>
-                  {{else if
-                    (or
-                      (bool this.selectedCardOrField.cardOrField)
-                      (bool this.moduleContentsResource.moduleError)
-                    )
-                  }}
+                  {{else if this.selectedCardOrField.cardOrField}}
                     <Accordion as |A|>
                       <SchemaEditor
                         @file={{this.readyFile}}
@@ -754,16 +750,28 @@ export default class CodeSubmode extends Component<Signature> {
                             <SchemaEditorTitle />
                           </:title>
                           <:content>
-                            {{#if this.moduleContentsResource.moduleError}}
-                              <SyntaxErrorDisplay
-                                @syntaxErrors={{this.moduleContentsResource.moduleError.message}}
-                              />
-                            {{else}}
-                              <SchemaEditorPanel class='accordion-content' />
-                            {{/if}}
+                            <SchemaEditorPanel class='accordion-content' />
                           </:content>
                         </A.Item>
                       </SchemaEditor>
+                    </Accordion>
+                  {{else if this.moduleContentsResource.moduleError}}
+                    <Accordion as |A|>
+                      <A.Item
+                        class='accordion-item'
+                        @contentClass='accordion-item-content'
+                        @onClick={{fn this.selectAccordionItem 'schema-editor'}}
+                        @isOpen={{true}}
+                      >
+                        <:title>
+                          <SchemaEditorTitle @hasModuleError={{true}} />
+                        </:title>
+                        <:content>
+                          <SyntaxErrorDisplay
+                            @syntaxErrors={{this.moduleContentsResource.moduleError.message}}
+                          />
+                        </:content>
+                      </A.Item>
                     </Accordion>
                   {{else if this.card}}
                     <CardPreviewPanel

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -21,7 +21,7 @@ import {
   ResizablePanelGroup,
 } from '@cardstack/boxel-ui/components';
 import type { PanelContext } from '@cardstack/boxel-ui/components';
-import { and, not, bool, eq, or } from '@cardstack/boxel-ui/helpers';
+import { and, not, bool, eq } from '@cardstack/boxel-ui/helpers';
 import { CheckMark, File } from '@cardstack/boxel-ui/icons';
 
 import {

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -114,9 +114,7 @@ export default class CodeSubmode extends Component<Signature> {
   @service declare recentFilesService: RecentFilesService;
   @service declare loaderService: LoaderService;
   @service declare environmentService: EnvironmentService;
-
   @tracked private loadFileError: string | null = null;
-
   @tracked private userHasDismissedURLError = false;
   @tracked private sourceFileIsSaving = false;
   @tracked private previewFormat: Format = 'isolated';
@@ -253,7 +251,6 @@ export default class CodeSubmode extends Component<Signature> {
   }
 
   private get fileIncompatibilityMessage() {
-    debugger;
     if (this.isCard) {
       if (this.cardResource.cardError) {
         return `Card preview failed. Make sure both the card instance data and card definition files have no syntax errors and that their data schema matches. `;

--- a/packages/host/app/components/operator-mode/code-submode/schema-editor.gts
+++ b/packages/host/app/components/operator-mode/code-submode/schema-editor.gts
@@ -28,7 +28,7 @@ interface Signature {
     file: Ready;
     moduleContentsResource: ModuleContentsResource;
     cardTypeResource?: CardType;
-    card: typeof BaseDef;
+    card?: typeof BaseDef;
     openDefinition: (
       codeRef: ResolvedCodeRef | undefined,
       localName: string | undefined,

--- a/packages/host/app/components/operator-mode/code-submode/schema-editor.gts
+++ b/packages/host/app/components/operator-mode/code-submode/schema-editor.gts
@@ -36,7 +36,7 @@ interface Signature {
   };
   Blocks: {
     default: [
-      WithBoundArgs<typeof SchemaEditorTitle, 'totalFields'>,
+      WithBoundArgs<typeof SchemaEditorTitle, 'totalFields' | 'hasModuleError'>,
       WithBoundArgs<
         typeof CardAdoptionChain,
         'file' | 'moduleSyntax' | 'cardInheritanceChain' | 'openDefinition'
@@ -53,17 +53,35 @@ export type CardInheritance = {
 interface TitleSignature {
   Args: {
     totalFields: number;
+    hasModuleError: boolean;
   };
 }
 
 class SchemaEditorTitle extends Component<TitleSignature> {
   <template>
     Schema Editor
-    <div class='total-fields' data-test-total-fields>
-      <span class='total-fields-value'>{{@totalFields}}</span>
-      <span class='total-fields-label'>{{getPlural 'Field' @totalFields}}</span>
-    </div>
+
+    {{#if @hasModuleError}}
+      <span class='syntax-error'>Fail to parse</span>
+    {{else}}
+      <div class='total-fields' data-test-total-fields>
+        <span class='total-fields-value'>{{@totalFields}}</span>
+        <span class='total-fields-label'>{{getPlural
+            'Field'
+            @totalFields
+          }}</span>
+      </div>
+    {{/if}}
+
     <style>
+      .syntax-error {
+        margin-left: auto;
+        color: var(--boxel-400);
+        font-size: var(--boxel-font-size-sm);
+        font-weight: 500;
+        margin-right: var(--boxel-sp-sm);
+        margin-top: 3px;
+      }
       .total-fields {
         display: flex;
         align-items: baseline;
@@ -113,6 +131,10 @@ export default class SchemaEditor extends Component<Signature> {
     );
   }
 
+  get hasModuleError() {
+    return !!this.args?.moduleContentsResource?.moduleError?.message;
+  }
+
   <template>
     <style>
       .loading {
@@ -126,8 +148,13 @@ export default class SchemaEditor extends Component<Signature> {
         <LoadingIndicator />
       </div>
     {{else}}
+
       {{yield
-        (component SchemaEditorTitle totalFields=this.totalFields)
+        (component
+          SchemaEditorTitle
+          totalFields=this.totalFields
+          hasModuleError=this.hasModuleError
+        )
         (component
           CardAdoptionChain
           file=@file

--- a/packages/host/app/components/operator-mode/code-submode/schema-editor.gts
+++ b/packages/host/app/components/operator-mode/code-submode/schema-editor.gts
@@ -28,7 +28,7 @@ interface Signature {
     file: Ready;
     moduleContentsResource: ModuleContentsResource;
     cardTypeResource?: CardType;
-    card?: typeof BaseDef;
+    card: typeof BaseDef;
     openDefinition: (
       codeRef: ResolvedCodeRef | undefined,
       localName: string | undefined,
@@ -52,12 +52,12 @@ export type CardInheritance = {
 
 interface TitleSignature {
   Args: {
-    totalFields: number;
-    hasModuleError: boolean;
+    totalFields?: number;
+    hasModuleError?: boolean;
   };
 }
 
-class SchemaEditorTitle extends Component<TitleSignature> {
+export class SchemaEditorTitle extends Component<TitleSignature> {
   <template>
     Schema Editor
 

--- a/packages/host/app/components/operator-mode/syntax-error-display.gts
+++ b/packages/host/app/components/operator-mode/syntax-error-display.gts
@@ -36,6 +36,10 @@ export default class SyntaxErrorDisplay extends Component<Signature> {
         margin-left: calc(var(--boxel-sp) * -1);
         margin-top: calc(var(--boxel-sp-sm) + 1px);
       }
+
+      pre {
+        overflow: auto;
+      }
     </style>
 
     <div class='syntax-error-container' data-test-syntax-error>

--- a/packages/host/app/components/operator-mode/syntax-error-display.gts
+++ b/packages/host/app/components/operator-mode/syntax-error-display.gts
@@ -35,7 +35,7 @@ export default class SyntaxErrorDisplay extends Component<Signature> {
       }
     </style>
 
-    <div class='syntax-error-container'>
+    <div class='syntax-error-container' data-test-syntax-error>
       <div class='syntax-error-box'>
         <div class='syntax-error-text'>
           Syntax Error

--- a/packages/host/app/components/operator-mode/syntax-error-display.gts
+++ b/packages/host/app/components/operator-mode/syntax-error-display.gts
@@ -1,0 +1,49 @@
+import Component from '@glimmer/component';
+
+interface Signature {
+  Element: HTMLElement;
+  Args: {
+    syntaxErrors: string;
+  };
+}
+
+export default class SyntaxErrorDisplay extends Component<Signature> {
+  <template>
+    <style>
+      .syntax-error-container {
+        background: var(--boxel-100);
+        padding: var(--boxel-sp);
+        border-radius: var(--boxel-radius);
+        height: 100%;
+      }
+
+      .syntax-error-box {
+        border-radius: var(--boxel-border-radius);
+        padding: var(--boxel-sp);
+        background: var(--boxel-200);
+      }
+
+      .syntax-error-text {
+        color: red;
+        font-weight: 600;
+      }
+
+      hr {
+        width: calc(100% + var(--boxel-sp) * 2);
+        margin-left: calc(var(--boxel-sp) * -1);
+        margin-top: calc(var(--boxel-sp-sm) + 1px);
+      }
+    </style>
+
+    <div class='syntax-error-container'>
+      <div class='syntax-error-box'>
+        <div class='syntax-error-text'>
+          Syntax Error
+        </div>
+
+        <hr />
+        <pre>{{this.args.syntaxErrors}}</pre>
+      </div>
+    </div>
+  </template>
+}

--- a/packages/host/app/components/operator-mode/syntax-error-display.gts
+++ b/packages/host/app/components/operator-mode/syntax-error-display.gts
@@ -45,7 +45,7 @@ export default class SyntaxErrorDisplay extends Component<Signature> {
         </div>
 
         <hr />
-        <pre>{{this.removeSourceMappingURL this.args.syntaxErrors}}</pre>
+        <pre>{{this.removeSourceMappingURL @syntaxErrors}}</pre>
       </div>
     </div>
   </template>

--- a/packages/host/app/components/operator-mode/syntax-error-display.gts
+++ b/packages/host/app/components/operator-mode/syntax-error-display.gts
@@ -8,6 +8,9 @@ interface Signature {
 }
 
 export default class SyntaxErrorDisplay extends Component<Signature> {
+  removeSourceMappingURL(syntaxErrors: string): string {
+    return syntaxErrors.replace(/\/\/# sourceMappingURL=.*/g, '');
+  }
   <template>
     <style>
       .syntax-error-container {
@@ -42,7 +45,7 @@ export default class SyntaxErrorDisplay extends Component<Signature> {
         </div>
 
         <hr />
-        <pre>{{this.args.syntaxErrors}}</pre>
+        <pre>{{this.removeSourceMappingURL this.args.syntaxErrors}}</pre>
       </div>
     </div>
   </template>

--- a/packages/host/app/resources/card-resource.ts
+++ b/packages/host/app/resources/card-resource.ts
@@ -106,7 +106,7 @@ export class CardResource extends Resource<Args> {
     this.cachedOnly = cachedOnly;
     this._loader = loader;
     this.onCardInstanceChange = onCardInstanceChange;
-
+    this.cardError = undefined;
     if (isLive && this.url) {
       this.loaded = this.loadLiveModel.perform(new URL(this.url));
     } else if (this.url) {

--- a/packages/host/app/resources/module-contents.ts
+++ b/packages/host/app/resources/module-contents.ts
@@ -72,6 +72,9 @@ interface Args {
 }
 
 export class ModuleContentsResource extends Resource<Args> {
+  @tracked moduleError:
+    | { type: 'runtime' | 'compile'; message: string }
+    | undefined = undefined;
   @tracked private _declarations: ModuleDeclaration[] = [];
   private _url: string | undefined;
   private executableFile: Ready | undefined;
@@ -105,6 +108,8 @@ export class ModuleContentsResource extends Resource<Args> {
     //==loading module
     let moduleResource = importResource(this, () => executableFile.url);
     await moduleResource.loaded; // we need to await this otherwise, it will go into an infinite loop
+
+    this.moduleError = moduleResource.error;
     if (moduleResource.module === undefined) {
       return;
     }

--- a/packages/host/app/resources/module-contents.ts
+++ b/packages/host/app/resources/module-contents.ts
@@ -99,6 +99,7 @@ export class ModuleContentsResource extends Resource<Args> {
   modify(_positional: never[], named: Args['named']) {
     let { executableFile } = named;
     this.executableFile = executableFile;
+    this.moduleError = undefined;
     if (this.executableFile) {
       this.load.perform(this.executableFile);
     }

--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -97,11 +97,15 @@ export default class CardService extends Service {
       ...args,
     });
     if (!response.ok) {
+      let responseText = await response.text();
       let err = new Error(
         `status: ${response.status} -
-          ${response.statusText}. ${await response.text()}`,
-      );
-      (err as any).status = response.status;
+          ${response.statusText}. ${responseText}`,
+      ) as any;
+
+      err.status = response.status;
+      err.responseText = responseText;
+
       throw err;
     }
     if (response.status !== 204) {

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -363,6 +363,8 @@ const txtSource = `
   Hello, world!
 `;
 
+const brokenSource = 'some text to make the code broken' + friendCardSource;
+
 module('Acceptance | code submode tests', function (hooks) {
   let realm: Realm;
   let monacoService: MonacoService;
@@ -402,6 +404,7 @@ module('Acceptance | code submode tests', function (hooks) {
         'address.gts': addressFieldSource,
         'country.gts': countryCardSource,
         'trips.gts': tripsFieldSource,
+        'broken.gts': brokenSource,
         'person-entry.json': {
           data: {
             type: 'card',
@@ -657,6 +660,26 @@ module('Acceptance | code submode tests', function (hooks) {
       .hasText(
         'No tools are available to be used with this file type. Choose a file representing a card instance or module.',
       );
+  });
+
+  test('showing module with a syntax error will display the error', async function (assert) {
+    let operatorModeStateParam = stringify({
+      stacks: [],
+      submode: 'code',
+      codePath: `${testRealmURL}broken.gts`,
+    })!;
+
+    await visit(
+      `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+        operatorModeStateParam,
+      )}`,
+    );
+
+    await waitFor('[data-test-syntax-error]');
+
+    assert
+      .dom('[data-test-syntax-error]')
+      .includesText('/broken.gts: Missing semicolon. (1:4)');
   });
 
   test('empty state displays default realm info', async function (assert) {

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -501,6 +501,7 @@ module('indexing', function (hooks) {
             status: 404,
             title: 'Not Found',
             deps: ['http://test-realm/post'],
+            responseText: undefined,
           },
         }),
         'card instance is an error document',

--- a/packages/runtime-common/error.ts
+++ b/packages/runtime-common/error.ts
@@ -3,6 +3,7 @@ import { createResponse } from './create-response';
 export interface ErrorDetails {
   status?: number;
   title?: string;
+  responseText?: string;
   source?: {
     pointer?: string;
     header?: string;
@@ -26,15 +27,20 @@ export class CardError extends Error implements SerializedError {
   status: number;
   title?: string;
   source?: ErrorDetails['source'];
+  responseText?: string;
   isCardError: true = true;
   additionalErrors: (CardError | Error)[] | null = null;
   deps?: string[];
 
-  constructor(detail: string, { status, title, source }: ErrorDetails = {}) {
+  constructor(
+    detail: string,
+    { status, title, source, responseText }: ErrorDetails = {},
+  ) {
     super(detail);
     this.detail = detail;
     this.status = status || 500;
     this.title = title || getReasonPhrase(this.status);
+    this.responseText = responseText;
     this.source = source;
   }
   toJSON() {

--- a/packages/runtime-common/error.ts
+++ b/packages/runtime-common/error.ts
@@ -91,6 +91,7 @@ export class CardError extends Error implements SerializedError {
         {
           title: response.statusText,
           status: response.status,
+          responseText: text,
         },
       );
     }

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -754,6 +754,7 @@ export class Realm {
         [makeEmberTemplatePlugin, templateOptions],
         loaderPlugin,
       ],
+      highlightCode: false, // Do not output ANSI color codes in error messages so that the client can display them plainly
     })?.code;
     if (!src) {
       throw new Error('bug: should never get here');
@@ -966,6 +967,7 @@ export class Realm {
     }
     if (maybeError.type === 'error') {
       return systemError(
+        this.url,
         `cannot return card from index: ${maybeError.error.title} - ${maybeError.error.detail}`,
         CardError.fromSerializableError(maybeError.error),
       );


### PR DESCRIPTION
Display module syntax errors in the right side panel:

<img width="1251" alt="image" src="https://github.com/cardstack/boxel/assets/273660/f5c9efd5-5a86-44ba-adc9-6469cbddfc89">

Video:

https://github.com/cardstack/boxel/assets/273660/b5396e32-7017-4d19-a891-c4f7669c263c


