### PR TITLE
host: Remove secret logout button

### DIFF
--- a/packages/host/tests/acceptance/operator-mode-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-test.gts
@@ -395,15 +395,15 @@ module('Acceptance | operator mode tests', function (hooks) {
       .dom('[data-test-profile-icon]')
       .hasAttribute('style', 'background: #5ead6b');
 
-    assert.dom('[data-test-profile-popover]').doesNotHaveClass('opened');
+    assert.dom('[data-test-profile-popover]').doesNotExist();
 
     await click('[data-test-profile-icon-button]');
 
-    assert.dom('[data-test-profile-popover]').hasClass('opened');
+    assert.dom('[data-test-profile-popover]').exists();
 
     await click('[data-test-profile-icon-button]');
 
-    assert.dom('[data-test-profile-popover]').doesNotHaveClass('opened'); // Clicking again closes the popover
+    assert.dom('[data-test-profile-popover]').doesNotExist(); // Clicking again closes the popover
 
     await click('[data-test-profile-icon-button]');
 


### PR DESCRIPTION
This is extracted from #909 for independent review.

You can see here that having the profile popover rendered with 0 opacity means I can log out with an invisible button:

![screencast 2023-12-14 14-34-59](https://github.com/cardstack/boxel/assets/43280/70a26491-1e6d-4053-8a6c-95353212eacc)

Since the purpose of using 0 opacity was to animate the appearance of the popover, this uses a modifier to preserve that. It doesn’t have an equivalent animation when closing the popover, though. 25% animation speed:

![screencast 2023-12-15 11-01-07](https://github.com/cardstack/boxel/assets/43280/aaa26928-349c-4439-bd7d-c1d49574183d)

I tried using `boxel-motion` but I couldn’t get it working locally! I think we should move toward using that so we have a consistent framework for animations rather than this kind of baroque implementation.