### PR TITLE
Add Duplicate card instance action to inspector panel

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -41,8 +41,6 @@ import {
   type ModuleDeclaration,
 } from '@cardstack/host/resources/module-contents';
 import type CardService from '@cardstack/host/services/card-service';
-import type LoaderService from '@cardstack/host/services/loader-service';
-import type MessageService from '@cardstack/host/services/message-service';
 import type EnvironmentService from '@cardstack/host/services/environment-service';
 import type { FileView } from '@cardstack/host/services/operator-mode-state-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
@@ -107,12 +105,10 @@ const defaultPanelHeights: PanelHeights = {
 const waiter = buildWaiter('code-submode:waiter');
 
 export default class CodeSubmode extends Component<Signature> {
-  @service declare cardService: CardService;
-  @service declare messageService: MessageService;
-  @service declare operatorModeStateService: OperatorModeStateService;
-  @service declare recentFilesService: RecentFilesService;
-  @service declare loaderService: LoaderService;
-  @service declare environmentService: EnvironmentService;
+  @service private declare cardService: CardService;
+  @service private declare operatorModeStateService: OperatorModeStateService;
+  @service private declare recentFilesService: RecentFilesService;
+  @service private declare environmentService: EnvironmentService;
 
   @tracked private loadFileError: string | null = null;
   @tracked private cardError: Error | undefined;
@@ -497,6 +493,7 @@ export default class CodeSubmode extends Component<Signature> {
         displayName: string;
         ref: ResolvedCodeRef;
       },
+      sourceInstance?: CardDef,
     ) => {
       if (!this.createFileModal) {
         throw new Error(`bug: CreateFileModal not instantiated`);
@@ -506,6 +503,7 @@ export default class CodeSubmode extends Component<Signature> {
         fileType,
         this.realmURL,
         definitionClass,
+        sourceInstance,
       );
       this.isCreateModalOpen = false;
       if (url) {

--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -46,12 +46,15 @@ import RealmInfoProvider from './realm-info-provider';
 import RealmIcon from './realm-icon';
 import type LoaderService from '../../services/loader-service';
 import type CardService from '../../services/card-service';
+import type { CardDef } from 'https://cardstack.com/base/card-api';
 
 export type NewFileType =
+  | 'duplicate-instance'
   | 'card-instance'
   | 'card-definition'
   | 'field-definition';
 export const newFileTypes: NewFileType[] = [
+  'duplicate-instance',
   'card-instance',
   'card-definition',
   'field-definition',
@@ -74,7 +77,11 @@ export default class CreateFileModal extends Component<Signature> {
     <ModalContainer
       class='create-file-modal'
       @cardContainerClass='create-file'
-      @title='New {{this.maybeFileType.displayName}}'
+      @title='{{if
+        (eq this.maybeFileType.id "duplicate-instance")
+        "Duplicate"
+        "New"
+      }} {{this.maybeFileType.displayName}}'
       @size='medium'
       @isOpen={{this.isModalOpen}}
       @onClose={{this.onCancel}}
@@ -93,37 +100,39 @@ export default class CreateFileModal extends Component<Signature> {
                 @onSelect={{this.onSelectRealm}}
               />
             </FieldContainer>
-            <FieldContainer
-              @label={{if
-                (eq this.maybeFileType.id 'card-instance')
-                'Adopted From'
-                'Inherits From'
-              }}
-              class='field'
-              data-test-inherits-from-field
-            >
-              <div class='field-contents'>
-                {{#if this.definitionClass}}
-                  <Pill @inert={{true}}>
-                    {{this.definitionClass.displayName}}
-                  </Pill>
-                {{else}}
-                  {{#if this.selectedCatalogEntry}}
-                    <SelectedTypePill @entry={{this.selectedCatalogEntry}} />
+            {{#unless (eq this.fileType.id 'duplicate-instance')}}
+              <FieldContainer
+                @label={{if
+                  (eq this.maybeFileType.id 'card-instance')
+                  'Adopted From'
+                  'Inherits From'
+                }}
+                class='field'
+                data-test-inherits-from-field
+              >
+                <div class='field-contents'>
+                  {{#if this.definitionClass}}
+                    <Pill @inert={{true}}>
+                      {{this.definitionClass.displayName}}
+                    </Pill>
+                  {{else}}
+                    {{#if this.selectedCatalogEntry}}
+                      <SelectedTypePill @entry={{this.selectedCatalogEntry}} />
+                    {{/if}}
+                    <Button
+                      class={{if this.selectedCatalogEntry 'change-trigger'}}
+                      @kind='text-only'
+                      @size='small'
+                      @disabled={{this.isCreateRunning}}
+                      {{on 'click' (perform this.chooseType)}}
+                      data-test-select-card-type
+                    >
+                      {{if this.selectedCatalogEntry 'Change' 'Select'}}
+                    </Button>
                   {{/if}}
-                  <Button
-                    class={{if this.selectedCatalogEntry 'change-trigger'}}
-                    @kind='text-only'
-                    @size='small'
-                    @disabled={{this.isCreateRunning}}
-                    {{on 'click' (perform this.chooseType)}}
-                    data-test-select-card-type
-                  >
-                    {{if this.selectedCatalogEntry 'Change' 'Select'}}
-                  </Button>
-                {{/if}}
-              </div>
-            </FieldContainer>
+                </div>
+              </FieldContainer>
+            {{/unless}}
             {{#if
               (or
                 (eq this.fileType.id 'card-definition')
@@ -185,6 +194,17 @@ export default class CreateFileModal extends Component<Signature> {
                   data-test-create-card-instance
                 >
                   Create
+                </Button>
+              {{else if (eq this.fileType.id 'duplicate-instance')}}
+                <Button
+                  @kind='primary'
+                  @size='tall'
+                  @loading={{this.duplicateCardInstance.isRunning}}
+                  @disabled={{this.isDuplicateCardInstanceButtonDisabled}}
+                  {{on 'click' (perform this.duplicateCardInstance)}}
+                  data-test-duplicate-card-instance
+                >
+                  Duplicate
                 </Button>
               {{else if
                 (or
@@ -275,6 +295,7 @@ export default class CreateFileModal extends Component<Signature> {
           displayName: string;
           ref: ResolvedCodeRef;
         };
+        sourceInstance?: CardDef;
       }
     | undefined;
 
@@ -291,11 +312,13 @@ export default class CreateFileModal extends Component<Signature> {
       displayName: string;
       ref: ResolvedCodeRef;
     },
+    sourceInstance?: CardDef,
   ) {
     return await this.makeCreateFileRequst.perform(
       fileType,
       realmURL,
       definitionClass,
+      sourceInstance,
     );
   }
 
@@ -311,12 +334,14 @@ export default class CreateFileModal extends Component<Signature> {
         displayName: string;
         ref: ResolvedCodeRef;
       },
+      sourceInstance?: CardDef,
     ) => {
       this.currentRequest = {
         fileType,
         newFileDeferred: new Deferred(),
         realmURL,
         definitionClass,
+        sourceInstance,
       };
       await this.onSetup.perform();
       let url = await this.currentRequest.newFileDeferred.promise;
@@ -397,6 +422,10 @@ export default class CreateFileModal extends Component<Signature> {
       !this.selectedRealmURL ||
       this.createCardInstance.isRunning
     );
+  }
+
+  private get isDuplicateCardInstanceButtonDisabled() {
+    return !this.selectedRealmURL || this.duplicateCardInstance.isRunning;
   }
 
   private get isCreateDefinitionButtonDisabled() {
@@ -562,6 +591,33 @@ export class ${className} extends ${exportName} {
 
     await this.cardService.saveSource(url, src.join('\n').trim());
     this.currentRequest.newFileDeferred.fulfill(url);
+  });
+
+  private duplicateCardInstance = restartableTask(async () => {
+    if (!this.currentRequest) {
+      throw new Error(
+        `Cannot duplicateCardInstance when there is no this.currentRequest`,
+      );
+    }
+    if (!this.currentRequest.sourceInstance) {
+      throw new Error(
+        `Cannot duplicateCardInstance when there is no sourceInstance`,
+      );
+    }
+    if (!this.selectedRealmURL) {
+      throw new Error(
+        `Cannot duplicateCardInstance where where is no selected realm URL`,
+      );
+    }
+    let duplicate = await this.cardService.copyCard(
+      this.currentRequest.sourceInstance,
+      this.selectedRealmURL,
+    );
+    let saved = await this.cardService.saveModel(this, duplicate);
+    if (!saved) {
+      throw new Error(`unable to save duplicated card instance`);
+    }
+    this.currentRequest.newFileDeferred.fulfill(new URL(`${saved.id}.json`));
   });
 
   private createCardInstance = restartableTask(async () => {

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -19,7 +19,12 @@ import {
   LoadingIndicator,
 } from '@cardstack/boxel-ui/components';
 
-import { IconInherit, IconTrash, IconPlus } from '@cardstack/boxel-ui/icons';
+import {
+  IconInherit,
+  IconTrash,
+  IconPlus,
+  Copy,
+} from '@cardstack/boxel-ui/icons';
 
 import {
   hasExecutableExtension,
@@ -84,6 +89,7 @@ interface Signature {
         displayName: string;
         ref: ResolvedCodeRef;
       },
+      sourceInstance?: CardDef,
     ) => Promise<void>;
     delete: (
       card: CardDef | typeof CardDef | undefined,
@@ -185,6 +191,20 @@ export default class DetailPanel extends Component<Signature> {
         : []),
       { label: 'Delete', icon: IconTrash, handler: this.args.delete },
     ];
+  }
+
+  @action private duplicateInstance() {
+    if (!this.args.cardInstance) {
+      throw new Error('must have a selected card instance');
+    }
+    let id: NewFileType = 'duplicate-instance';
+    let cardDef = Reflect.getPrototypeOf(this.args.cardInstance)!
+      .constructor as typeof CardDef;
+    this.args.createFile(
+      { id, displayName: capitalize(cardDef.displayName || 'Instance') },
+      undefined,
+      this.args.cardInstance,
+    );
   }
 
   @action private createInstance() {
@@ -346,6 +366,9 @@ export default class DetailPanel extends Component<Signature> {
                 @fileExtension='.JSON'
                 @infoText={{this.lastModified.value}}
                 @actions={{array
+                  (hash
+                    label='Duplicate' handler=this.duplicateInstance icon=Copy
+                  )
                   (hash
                     label='Delete'
                     handler=(fn @delete @cardInstance)

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -24,6 +24,7 @@ import { Submodes } from '@cardstack/host/components/submode-switcher';
 
 import type LoaderService from '@cardstack/host/services/loader-service';
 import type MonacoService from '@cardstack/host/services/monaco-service';
+import type RealmInfoService from '@cardstack/host/services/realm-info-service';
 
 import {
   TestRealmAdapter,
@@ -40,6 +41,28 @@ import {
   type TestContextWithSave,
 } from '../../helpers';
 import { setupMatrixServiceMock } from '../../helpers/mock-matrix-service';
+
+const testRealmURL2 = 'http://test-realm/test2/';
+const realmAFiles: Record<string, any> = {
+  '.realm.json': {
+    name: 'Test Workspace A',
+    backgroundURL:
+      'https://i.postimg.cc/VNvHH93M/pawel-czerwinski-Ly-ZLa-A5jti-Y-unsplash.jpg',
+    iconURL: 'https://i.postimg.cc/L8yXRvws/icon.png',
+  },
+  'index.json': {
+    data: {
+      type: 'card',
+      attributes: {},
+      meta: {
+        adoptsFrom: {
+          module: 'https://cardstack.com/base/cards-grid',
+          name: 'CardsGrid',
+        },
+      },
+    },
+  },
+};
 
 const indexCardSource = `
   import { CardDef, Component } from "https://cardstack.com/base/card-api";
@@ -392,6 +415,11 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
 
     // this seeds the loader used during index which obtains url mappings
     // from the global loader
+    await setupAcceptanceTestRealm({
+      loader,
+      contents: realmAFiles,
+      realmURL: testRealmURL2,
+    });
     ({ realm, adapter } = await setupAcceptanceTestRealm({
       loader,
       contents: {
@@ -510,6 +538,13 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
       },
     }));
 
+    let realmService = this.owner.lookup(
+      'service:realm-info-service',
+    ) as RealmInfoService;
+
+    await realmService.fetchRealmInfo({
+      realmURL: new URL(testRealmURL2),
+    });
     monacoService = this.owner.lookup(
       'service:monaco-service',
     ) as MonacoService;
@@ -800,6 +835,120 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
         'expected exported class to have scrolled into view',
       );
     }
+  });
+
+  test<TestContextWithSave>('can duplicate an instance in same realm', async function (assert) {
+    assert.expect(10);
+    let operatorModeStateParam = stringify({
+      stacks: [[]],
+      submode: 'code',
+      codePath: `${testRealmURL}Pet/vangogh.json`,
+    })!;
+    await visit(
+      `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+        operatorModeStateParam,
+      )}`,
+    );
+    await waitForCodeEditor();
+    await waitFor(`[data-test-action-button="Duplicate"]`);
+    await click('[data-test-action-button="Duplicate"]');
+    await waitFor(
+      `[data-test-create-file-modal][data-test-ready] [data-test-realm-name="Test Workspace B"]`,
+    );
+    await percySnapshot(assert);
+
+    let deferred = new Deferred<void>();
+    let id: string | undefined;
+    this.onSave((url, json) => {
+      if (typeof json === 'string') {
+        throw new Error(`expected json save data`);
+      }
+      id = url.href;
+      assert.strictEqual(
+        json.data.attributes?.name,
+        'Van Gogh',
+        'the name field is correct',
+      );
+      assert.deepEqual(json.data.meta.adoptsFrom, {
+        module: '../pet',
+        name: 'Pet',
+      });
+      assert.strictEqual(json.data.meta.realmURL, testRealmURL);
+      deferred.fulfill();
+    });
+    await click('[data-test-duplicate-card-instance]');
+    await waitFor('[data-test-create-file-modal]', { count: 0 });
+    await deferred.promise;
+
+    await waitForCodeEditor();
+    await waitFor(`[data-test-code-mode-card-preview-header="${id}"]`);
+    assert.dom('[data-test-card-resource-loaded]').containsText('Pet');
+    assert
+      .dom(`[data-test-code-mode-card-preview-header="${id}"] .icon`)
+      .hasAttribute('alt', 'Icon for realm Test Workspace B');
+    assert.dom('[data-test-field="name"] input').hasValue('Van Gogh');
+    assert.dom('[data-test-card-url-bar-input]').hasValue(`${id}.json`);
+  });
+
+  test<TestContextWithSave>('can duplicate an instance in different realm', async function (assert) {
+    assert.expect(11);
+    let operatorModeStateParam = stringify({
+      stacks: [[]],
+      submode: 'code',
+      codePath: `${testRealmURL}Pet/vangogh.json`,
+    })!;
+    await visit(
+      `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
+        operatorModeStateParam,
+      )}`,
+    );
+    await waitForCodeEditor();
+    await waitFor(`[data-test-action-button="Duplicate"]`);
+    await click('[data-test-action-button="Duplicate"]');
+    await waitFor(
+      `[data-test-create-file-modal][data-test-ready] [data-test-realm-name="Test Workspace B"]`,
+    );
+
+    // realm selection
+    await click(`[data-test-realm-dropdown-trigger]`);
+    await waitFor(
+      '[data-test-boxel-dropdown-content] [data-test-boxel-menu-item-text="Base Workspace"]',
+    );
+    await click('[data-test-boxel-menu-item-text="Test Workspace A"]');
+    await waitFor(`[data-test-realm-name="Test Workspace A"]`);
+    assert.dom('[data-test-realm-name]').hasText('Test Workspace A');
+
+    let deferred = new Deferred<void>();
+    let id: string | undefined;
+    this.onSave((url, json) => {
+      if (typeof json === 'string') {
+        throw new Error(`expected json save data`);
+      }
+      id = url.href;
+      assert.strictEqual(
+        json.data.attributes?.name,
+        'Van Gogh',
+        'the name field is correct',
+      );
+      assert.deepEqual(json.data.meta.adoptsFrom, {
+        module: `${testRealmURL}pet`,
+        name: 'Pet',
+      });
+      assert.strictEqual(json.data.meta.realmURL, testRealmURL2);
+      deferred.fulfill();
+    });
+    await click('[data-test-duplicate-card-instance]');
+    await waitFor('[data-test-create-file-modal]', { count: 0 });
+    await deferred.promise;
+
+    await waitForCodeEditor();
+    await waitFor(`[data-test-code-mode-card-preview-header="${id}"]`);
+    assert.dom('[data-test-card-resource-loaded]').containsText('Pet');
+    assert
+      .dom(`[data-test-code-mode-card-preview-header="${id}"] .icon`)
+      .hasAttribute('alt', 'Icon for realm Test Workspace A');
+    assert.dom('[data-test-field="name"] input').hasValue('Van Gogh');
+    assert.dom('[data-test-card-url-bar-input]').hasValue(`${id}.json`);
   });
 
   test<TestContextWithSSE>('can delete a card instance from code submode with no recent files to fall back on', async function (assert) {


### PR DESCRIPTION
This PR adds a "Duplicate" action to the inspector panel for card instances that allows us to duplicate a card instance

![duplicate](https://github.com/cardstack/boxel/assets/61075/4139532a-1a9c-4ad3-8391-dab10115df12)
