### PR TITLE
Fix top-bar overlap with chat-drawer and simplify ordering

### DIFF
--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
@@ -132,7 +132,6 @@ export default class Panel extends Component<Signature> {
         background-color: var(--boxel-panel-resize-handler-background-color);
 
         position: relative;
-        z-index: 2;
       }
 
       .resize-handler:hover {

--- a/packages/host/app/components/matrix/chat-sidebar.gts
+++ b/packages/host/app/components/matrix/chat-sidebar.gts
@@ -54,7 +54,6 @@ export default class ChatSidebar extends Component<Args> {
         position: absolute;
         top: 0;
         right: 0;
-        z-index: 1;
       }
     </style>
   </template>

--- a/packages/host/app/components/operator-mode/card-url-bar.gts
+++ b/packages/host/app/components/operator-mode/card-url-bar.gts
@@ -175,6 +175,7 @@ export default class CardURLBar extends Component<Signature> {
         box-shadow: var(--boxel-deep-box-shadow);
         font: var(--boxel-font-sm);
         font-weight: 500;
+        z-index: 1;
       }
       .warning {
         display: flex;

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -809,7 +809,6 @@ export default class CodeSubmode extends Component<Signature> {
         max-height: 100vh;
         left: 0;
         right: 0;
-        z-index: 1;
         padding: var(--code-mode-padding-top) var(--boxel-sp)
           var(--code-mode-padding-bottom);
         overflow: auto;
@@ -862,7 +861,6 @@ export default class CodeSubmode extends Component<Signature> {
         padding: var(--boxel-sp) var(--boxel-sp) 0
           var(--code-mode-top-bar-padding-left);
         display: flex;
-        z-index: 2;
       }
 
       .loading {

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -108,7 +108,7 @@ export default class SubmodeLayout extends Component<Signature> {
   }
 
   <template>
-    <div class='operator-mode__with-chat {{this.chatVisibilityClass}}'>
+    <div class='operator-mode-with-chat {{this.chatVisibilityClass}}'>
       <SubmodeSwitcher
         @submode={{this.operatorModeStateService.state.submode}}
         @onSubmodeSelect={{this.updateSubmode}}
@@ -146,12 +146,16 @@ export default class SubmodeLayout extends Component<Signature> {
     />
 
     <style>
-      .operator-mode__with-chat {
+      .operator-mode-with-chat {
         display: grid;
         grid-template-rows: 1fr;
         grid-template-columns: 1.5fr 0.5fr;
         gap: 0px;
         height: 100%;
+      }
+
+      .operator-mode-with-chat > * {
+        z-index: 1;
       }
 
       .chat-open {
@@ -177,7 +181,6 @@ export default class SubmodeLayout extends Component<Signature> {
         border: none;
         box-shadow: var(--boxel-deep-box-shadow);
         transition: background-color var(--boxel-transition);
-        z-index: 1;
       }
       .chat-btn:hover {
         --icon-color: var(--boxel-dark);
@@ -188,14 +191,12 @@ export default class SubmodeLayout extends Component<Signature> {
         position: absolute;
         top: 0;
         left: 0;
-        z-index: 2;
         padding: var(--boxel-sp);
       }
 
       .container__chat-sidebar {
         height: 100vh;
         grid-column: 2;
-        z-index: 1;
       }
     </style>
   </template>

--- a/packages/host/app/components/search-sheet/index.gts
+++ b/packages/host/app/components/search-sheet/index.gts
@@ -389,10 +389,12 @@ export default class SearchSheet extends Component<Signature> {
 
       .prompt {
         height: var(--search-sheet-prompt-height);
+        box-shadow: var(--boxel-deep-box-shadow);
       }
 
       .results {
         height: calc(100% - var(--stack-padding-top));
+        box-shadow: var(--boxel-deep-box-shadow);
       }
 
       .footer {


### PR DESCRIPTION
Before:
<img width="1247" alt="before" src="https://github.com/cardstack/boxel/assets/16160806/795335e0-b47d-44e7-bca2-160f17439ba5">

After:
<img width="1503" alt="after" src="https://github.com/cardstack/boxel/assets/16160806/176fa403-3de1-453a-8950-efdb29e05b22">
