### PR TITLE
Fix duelling loaders on the server

### DIFF
--- a/packages/host/app/services/loader-service.ts
+++ b/packages/host/app/services/loader-service.ts
@@ -12,8 +12,12 @@ export default class LoaderService extends Service {
   @tracked loader = this.makeInstance();
 
   reset() {
-    this.loader = Loader.cloneLoader(this.loader);
-    shimExternals(this.loader);
+    if (this.loader) {
+      this.loader = Loader.cloneLoader(this.loader);
+      shimExternals(this.loader);
+    } else {
+      this.loader = this.makeInstance();
+    }
   }
 
   private makeInstance() {

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -22,6 +22,7 @@ import {
   baseRealm,
   loadCard,
   Deferred,
+  RealmPaths,
   type LooseSingleCardDocument,
 } from '@cardstack/runtime-common';
 import { stringify } from 'qs';
@@ -627,7 +628,7 @@ module('Realm Server', function (hooks) {
     }
 
     // make an instance of the card def
-    let id: string | undefined;
+    let maybeId: string | undefined;
     {
       let response = await expectEvent({
         assert,
@@ -654,12 +655,13 @@ module('Realm Server', function (hooks) {
         },
       });
       assert.strictEqual(response.status, 201, 'HTTP 201 status');
-      id = response.body.data.id;
+      maybeId = response.body.data.id;
     }
-    if (!id) {
+    if (!maybeId) {
       assert.ok(false, 'new card identifier was undefined');
       return;
     }
+    let id = maybeId;
 
     // modify field
     {
@@ -702,6 +704,104 @@ module('Realm Server', function (hooks) {
       assert.deepEqual(json.data.attributes, {
         field1: 'a',
         field2a: null,
+        title: null,
+        description: null,
+        thumbnailURL: null,
+      });
+    }
+
+    // set value on renamed field
+    {
+      let expected = [
+        {
+          type: 'incremental',
+          invalidations: [id],
+          clientRequestId: null,
+        },
+      ];
+      let response = await expectEvent({
+        assert,
+        expected,
+        callback: async () => {
+          return await request
+            .patch(new URL(id).pathname)
+            .send({
+              data: {
+                type: 'card',
+                attributes: {
+                  field2a: 'c',
+                },
+                meta: {
+                  adoptsFrom: {
+                    module: `${testRealmURL}test-card`,
+                    name: 'TestCard',
+                  },
+                },
+              },
+            })
+            .set('Accept', 'application/vnd.card+json');
+        },
+      });
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      assert.strictEqual(
+        response.get('X-boxel-realm-url'),
+        testRealmURL.href,
+        'realm url header is correct',
+      );
+
+      let json = response.body;
+      assert.deepEqual(json.data.attributes, {
+        field1: 'a',
+        field2a: 'c',
+        title: null,
+        description: null,
+        thumbnailURL: null,
+      });
+    }
+
+    // verify file serialization is correct
+    {
+      let localPath = new RealmPaths(testRealmURL).local(id);
+      let jsonFile = `${join(dir.name, localPath)}.json`;
+      let doc = JSON.parse(
+        readFileSync(jsonFile, { encoding: 'utf8' }),
+      ) as LooseSingleCardDocument;
+      assert.deepEqual(
+        doc,
+        {
+          data: {
+            type: 'card',
+            attributes: {
+              field1: 'a',
+              field2a: 'c',
+              title: null,
+              description: null,
+              thumbnailURL: null,
+            },
+            meta: {
+              adoptsFrom: {
+                module: '/test-card',
+                name: 'TestCard',
+              },
+            },
+          },
+        },
+        'instance serialized to filesystem correctly',
+      );
+    }
+
+    // verify instance GET is correct
+    {
+      let response = await request
+        .get(new URL(id).pathname)
+        .set('Accept', 'application/vnd.card+json');
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      let json = response.body;
+      assert.deepEqual(json.data.attributes, {
+        field1: 'a',
+        field2a: 'c',
         title: null,
         description: null,
         thumbnailURL: null,

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -114,7 +114,9 @@ type EvaluatableDep =
 
 export type RequestHandler = (req: Request) => Promise<Response | null>;
 
+let nonce = 0;
 export class Loader {
+  nonce = nonce++; // the nonce is a useful debugging tool that let's us compare loaders
   private log = logger('loader');
   private modules = new Map<string, Module>();
   private urlHandlers: RequestHandler[] = [maybeHandleScopedCSSRequest];

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -202,7 +202,9 @@ export class Realm {
   #startedUp = new Deferred<void>();
   #searchIndex: SearchIndex;
   #adapter: RealmAdapter;
-  #loader: Loader;
+  // This loader is not meant to be used operationally, rather it serves as a
+  // template that we clone for each indexing operation
+  loaderTemplate: Loader;
   #router: Router;
   #deferStartup: boolean;
   #useTestingDomain = false;
@@ -240,8 +242,8 @@ export class Realm {
     this.paths = new RealmPaths(url);
     this.#getIndexHTML = getIndexHTML;
     this.#useTestingDomain = Boolean(opts?.useTestingDomain);
-    this.#loader = loader;
-    this.#loader.registerURLHandler(this.maybeHandle.bind(this));
+    this.loaderTemplate = loader;
+    this.loaderTemplate.registerURLHandler(this.maybeHandle.bind(this));
     this.#adapter = adapter;
     this.#searchIndex = new SearchIndex(
       this,
@@ -462,7 +464,9 @@ export class Realm {
   }
 
   get loader() {
-    return this.#loader;
+    // the current loader used by the search index will contain the latest
+    // module updates as we obtain a new loader for each indexing run
+    return this.searchIndex.loader;
   }
 
   get searchIndex() {

--- a/packages/runtime-common/search-index.ts
+++ b/packages/runtime-common/search-index.ts
@@ -179,7 +179,7 @@ export class SearchIndex {
     this.#runner = runner;
     this.#index = {
       realmURL: new URL(realm.url),
-      loader: Loader.cloneLoader(realm.loader),
+      loader: Loader.cloneLoader(realm.loaderTemplate),
       ignoreMap: new URLMap(),
       ignoreMapContents: new URLMap(),
       instances: new URLMap(),
@@ -216,7 +216,7 @@ export class SearchIndex {
         ignoreMap: current.ignoreMap,
         realmURL: current.realmURL,
         stats: current.stats,
-        loader: Loader.cloneLoader(this.#realm.loader),
+        loader: Loader.cloneLoader(this.#realm.loaderTemplate),
       };
     });
   }
@@ -245,7 +245,7 @@ export class SearchIndex {
         ignoreMapContents: current.ignoreMapContents,
         realmURL: current.realmURL,
         stats: current.stats,
-        loader: Loader.cloneLoader(this.#realm.loader),
+        loader: Loader.cloneLoader(this.#realm.loaderTemplate),
       };
     });
   }


### PR DESCRIPTION
The issue is that on the server we have 2 competing loaders right now. The loader in the `Realm` and the loader in the `SearchIndex`. The loader in the `Realm` is actually never intended to be used operationally. Rather it serves as a "template" that the `SearchIndex` clones each time there is an indexing operation. The latest and greatest loader lives in the `SearchIndex`, however, the `Realm` does actually use it's own loader (which never gets updated from module writes) for serialization activities. 

In this PR we rename the `Realm.#loader` so it's more clear that we don't operationally ever use it, and rather only use it as a means to clone `SearchIndex` loaders. As well as, the `Realm.loader` should be an alias to the `SearchIndex.loader` so that the file serialization logic uses the latest loader.

In terms of reproducing the bug CS-6354 locally, where there was a discrepancy between the browser's version of the card def and the server's version of the card def, it was a bit hit or miss for me. Initially I was able to reproduce this bug locally, however, occasionally I am not able to reproduce the bug locally. So I'm not 100% sure about that the `Realm.loader` is the true culprit here, there may be some async as well at play (?)--but as it is written it is definitely incorrect.

I'd like to get this into staging and then see where we stand in terms of reproducing CS-6354 (which i was able to reproduce pretty easily in staging)