### PR TITLE
Don't show duplicate instance menu item in New File menu

### DIFF
--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -55,9 +55,9 @@ export type NewFileType =
   | 'field-definition';
 export const newFileTypes: NewFileType[] = [
   'duplicate-instance',
-  'card-instance',
   'card-definition',
   'field-definition',
+  'card-instance',
 ];
 const waiter = buildWaiter('create-file-modal:on-setup-waiter');
 

--- a/packages/host/app/components/operator-mode/new-file-button.gts
+++ b/packages/host/app/components/operator-mode/new-file-button.gts
@@ -4,6 +4,7 @@ import startCase from 'lodash/startCase';
 import { BoxelDropdown, Button, Menu } from '@cardstack/boxel-ui/components';
 import { MenuItem } from '@cardstack/boxel-ui/helpers';
 import { IconPlus } from '@cardstack/boxel-ui/icons';
+import flatMap from 'lodash/flatMap';
 import { type FileType, newFileTypes } from './create-file-modal';
 
 interface Signature {
@@ -64,11 +65,16 @@ export default class NewFileButton extends Component<Signature> {
   </template>
 
   private get menuItems() {
-    return newFileTypes.map((id) => {
+    return flatMap(newFileTypes, (id) => {
+      if (id === 'duplicate-instance') {
+        return [];
+      }
       let displayName = capitalize(startCase(id));
-      return new MenuItem(displayName, 'action', {
-        action: () => this.args.onSelectNewFileType({ id, displayName }),
-      });
+      return [
+        new MenuItem(displayName, 'action', {
+          action: () => this.args.onSelectNewFileType({ id, displayName }),
+        }),
+      ];
     });
   }
 }

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -181,6 +181,33 @@ module('Acceptance | code submode | create-file tests', function (hooks) {
     });
   });
 
+  test('new file button has options to create card def, field def, and card instance files', async function (assert) {
+    await waitFor('[data-test-code-mode][data-test-save-idle]');
+    await waitFor('[data-test-new-file-button]');
+    await click('[data-test-new-file-button]');
+
+    assert
+      .dom(
+        '[data-test-new-file-dropdown-menu] [data-test-boxel-menu-item-text]',
+      )
+      .exists({ count: 3 });
+    assert
+      .dom(
+        '[data-test-new-file-dropdown-menu] [data-test-boxel-menu-item-text="Card Definition"]',
+      )
+      .exists();
+    assert
+      .dom(
+        '[data-test-new-file-dropdown-menu] [data-test-boxel-menu-item-text="Field Definition"]',
+      )
+      .exists();
+    assert
+      .dom(
+        '[data-test-new-file-dropdown-menu] [data-test-boxel-menu-item-text="Card Instance"]',
+      )
+      .exists();
+  });
+
   test<TestContextWithSave>('can create new card-instance file in local realm with card type from same realm', async function (assert) {
     const baseRealmIconURL = 'https://i.postimg.cc/d0B9qMvy/icon.png';
     assert.expect(13);


### PR DESCRIPTION
Remove the "Duplicate Instance" menu item from the New File menu.

Previously we were showing this:
![image](https://github.com/cardstack/boxel/assets/61075/f2177c0f-ad6e-4aef-9185-e79b0b541ae5)


Now we are showing this:
![image](https://github.com/cardstack/boxel/assets/61075/94218cc3-72c1-4e59-ba7d-546918675282)
