### PR TITLE
Prevent awkward StringField import during field rename

### DIFF
--- a/packages/host/app/components/operator-mode/edit-field-modal.gts
+++ b/packages/host/app/components/operator-mode/edit-field-modal.gts
@@ -112,8 +112,8 @@ export default class EditFieldModal extends Component<Signature> {
     // When adding a new field, we want to default to the base string card
     if (!field) {
       let ref = {
-        module: 'https://cardstack.com/base/string', // This seems fundamental enough to be hardcoded
-        name: 'default',
+        module: 'https://cardstack.com/base/card-api', // This seems fundamental enough to be hardcoded
+        name: 'StringField',
       };
       this.isFieldDef = true;
 


### PR DESCRIPTION
This prevents an awkward StringField import when editing an existing field.

Previously we would see this:
![image](https://github.com/cardstack/boxel/assets/61075/62a33f9a-b490-4018-9c2d-9b94fc36a60e)

Now we see this:
![image](https://github.com/cardstack/boxel/assets/61075/f9e718b1-9cfe-4437-9a9a-2bd47bc6d2ec)

The background:
This issue is a result of the fact that when we are dealing with reexports we use the code ref for the target of the reexport. We do this because when we want to show users the code mode for a card we prefer to show the module that has the actual code and not the reexport. This skews our code ref identities to use the inner most module of a reexport when possible. We see this when resolving the adoption chain for a card def, the process of identifying all the constituent fields and cards for a card def resolves the code refs to the inner most reexport. When pre-populating the edit field modal we use these discovered field code ref identities as the initial value. We mask this by setting the default StringField to use the same inner most code ref. This doesn't eliminate the problem but will greatly reduce it.