### PR TITLE
Mask scroll restore in filetree

### DIFF
--- a/packages/host/app/components/editor/file-tree.gts
+++ b/packages/host/app/components/editor/file-tree.gts
@@ -1,19 +1,22 @@
 import type RouterService from '@ember/routing/router-service';
+import type Owner from '@ember/owner';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 
 import RealmIcon from '@cardstack/host/components/operator-mode/realm-icon';
 import RealmInfoProvider from '@cardstack/host/components/operator-mode/realm-info-provider';
+import { restartableTask, timeout } from 'ember-concurrency';
 
 import Directory from './directory';
 
-interface Args {
+interface Signature {
   Args: {
     realmURL: URL;
   };
 }
 
-export default class FileTree extends Component<Args> {
+export default class FileTree extends Component<Signature> {
   <template>
     <div class='realm-info'>
       <RealmInfoProvider @realmURL={{@realmURL}}>
@@ -30,9 +33,23 @@ export default class FileTree extends Component<Args> {
     </div>
     <nav>
       <Directory @relativePath='' @realmURL={{@realmURL}} />
+      {{#if this.showMask}}
+        <div class='mask' data-test-file-tree-mask></div>
+      {{/if}}
     </nav>
 
     <style>
+      .mask {
+        position: absolute;
+        top: 0;
+        left: 0;
+        background-color: white;
+        height: 100%;
+        width: 100%;
+      }
+      nav {
+        position: relative;
+      }
       .realm-info {
         position: sticky;
         top: calc(var(--boxel-sp-xxs) * -1);
@@ -56,5 +73,16 @@ export default class FileTree extends Component<Args> {
     </style>
   </template>
 
-  @service declare router: RouterService;
+  @service private declare router: RouterService;
+  @tracked private showMask = true;
+  constructor(owner: Owner, args: Signature['Args']) {
+    super(owner, args);
+    this.hideMask.perform();
+  }
+
+  private hideMask = restartableTask(async () => {
+    // fine tuned to coincide with debounce in RestoreScrollPosition modifier
+    await timeout(200);
+    this.showMask = false;
+  });
 }

--- a/packages/host/app/components/editor/file-tree.gts
+++ b/packages/host/app/components/editor/file-tree.gts
@@ -82,7 +82,7 @@ export default class FileTree extends Component<Signature> {
 
   private hideMask = restartableTask(async () => {
     // fine tuned to coincide with debounce in RestoreScrollPosition modifier
-    await timeout(200);
+    await timeout(300);
     this.showMask = false;
   });
 }

--- a/packages/host/app/components/operator-mode/code-submode/inner-container.gts
+++ b/packages/host/app/components/operator-mode/code-submode/inner-container.gts
@@ -52,7 +52,7 @@ class InnerContainerContent extends Component<ContentSignature> {
     super(owner, args);
     if (this.args.withMask) {
       this.setVisible();
-      this.args.whenVisible(this.setVisible);
+      this.args.whenVisible?.(this.setVisible);
     }
   }
 

--- a/packages/host/app/components/operator-mode/code-submode/inner-container.gts
+++ b/packages/host/app/components/operator-mode/code-submode/inner-container.gts
@@ -11,8 +11,8 @@ interface ContentSignature {
     default: [];
   };
   Args: {
-    withMask: boolean;
-    whenVisible: (setVisible: () => void) => void;
+    withMask?: boolean;
+    whenVisible?: (setVisible: () => void) => void;
   };
 }
 

--- a/packages/host/app/components/operator-mode/code-submode/left-panel-toggle.gts
+++ b/packages/host/app/components/operator-mode/code-submode/left-panel-toggle.gts
@@ -69,6 +69,7 @@ interface Signature {
 
 export default class CodeSubmodeLeftPanelToggle extends Component<Signature> {
   @service declare operatorModeStateService: OperatorModeStateService;
+  private notifyFileBrowserIsVisible: (() => void) | undefined;
 
   private get isFileTreeShowing() {
     return this.args.fileView === 'browser' || !this.args.isFileOpen;
@@ -94,6 +95,17 @@ export default class CodeSubmodeLeftPanelToggle extends Component<Signature> {
     }
   }
 
+  private setFileView = (view: FileView) => {
+    this.args.setFileView(view);
+    if (view === 'browser') {
+      this.notifyFileBrowserIsVisible?.();
+    }
+  };
+
+  private whenFileBrowserVisible = (setVisible: () => void) => {
+    this.notifyFileBrowserIsVisible = setVisible;
+  };
+
   <template>
     <InnerContainer
       class={{cn 'left-panel' file-browser=this.isFileTreeShowing}}
@@ -108,14 +120,14 @@ export default class CodeSubmodeLeftPanelToggle extends Component<Signature> {
         <ToggleButton
           @disabled={{not @isFileOpen}}
           @isActive={{not this.isFileTreeShowing}}
-          {{on 'click' (fn @setFileView 'inspector')}}
+          {{on 'click' (fn this.setFileView 'inspector')}}
           data-test-inspector-toggle
         >
           Inspector
         </ToggleButton>
         <ToggleButton
           @isActive={{this.isFileTreeShowing}}
-          {{on 'click' (fn @setFileView 'browser')}}
+          {{on 'click' (fn this.setFileView 'browser')}}
           data-test-file-browser-toggle
         >
           File Tree
@@ -124,6 +136,8 @@ export default class CodeSubmodeLeftPanelToggle extends Component<Signature> {
       <InnerContainerContent
         class='content'
         data-test-togglable-left-panel
+        @withMask={{this.isFileTreeShowing}}
+        @whenVisible={{this.whenFileBrowserVisible}}
         {{RestoreScrollPosition
           container=this.scrollPositionContainer
           key=this.scrollPositionKey

--- a/packages/host/tests/acceptance/code-submode/file-tree-test.ts
+++ b/packages/host/tests/acceptance/code-submode/file-tree-test.ts
@@ -442,6 +442,7 @@ module('Acceptance | code submode | file-tree tests', function (hooks) {
     assert.dom('[data-test-realm-name]').hasText(`In ${realmInfo.name}`);
 
     await waitFor('[data-test-file]');
+    await waitFor('[data-test-file-tree-mask]', { count: 0 });
     let fileElement = find(`[data-test-file="${openFilename}"]`)!;
     assert.ok(
       await elementIsVisible(fileElement),
@@ -484,6 +485,7 @@ module('Acceptance | code submode | file-tree tests', function (hooks) {
     assert.dom('[data-test-realm-name]').hasText(`In ${realmInfo.name}`);
 
     await waitFor(`[data-test-file="${openFilename}"]`);
+    await waitFor('[data-test-file-tree-mask]', { count: 0 });
     let fileElement = find(`[data-test-file="${openFilename}"]`)!;
 
     if (!fileElement) {
@@ -524,6 +526,7 @@ module('Acceptance | code submode | file-tree tests', function (hooks) {
     assert.dom('[data-test-realm-name]').hasText(`In ${realmInfo.name}`);
 
     await waitFor('[data-test-file]');
+    await waitFor('[data-test-file-tree-mask]', { count: 0 });
     let openFileSelector = `[data-test-file="${openFilename}"]`;
     let openFileElement = find(openFileSelector)!;
     assert.ok(
@@ -551,6 +554,7 @@ module('Acceptance | code submode | file-tree tests', function (hooks) {
 
     await click(fileToOpenElement);
     await waitFor(openFileSelector);
+    await waitFor('[data-test-file-tree-mask]', { count: 0 });
 
     openFileElement = find(openFileSelector)!;
     fileToOpenElement = find(fileToOpenSelector)!;
@@ -584,6 +588,7 @@ module('Acceptance | code submode | file-tree tests', function (hooks) {
     let endDirectorySelector = `[data-test-directory="zzz/"]`;
 
     await waitFor(endDirectorySelector);
+    await waitFor('[data-test-file-tree-mask]', { count: 0 });
     let endDirectoryElement = find(endDirectorySelector);
 
     if (!endDirectoryElement) {
@@ -607,6 +612,7 @@ module('Acceptance | code submode | file-tree tests', function (hooks) {
 
     await click('[data-test-file-browser-toggle]');
     await waitFor(endDirectorySelector);
+    await waitFor('[data-test-file-tree-mask]', { count: 0 });
 
     endDirectoryElement = find(endDirectorySelector);
 
@@ -642,6 +648,7 @@ module('Acceptance | code submode | file-tree tests', function (hooks) {
 
     await click('[data-test-file-browser-toggle]');
     await waitFor(endDirectorySelector);
+    await waitFor('[data-test-file-tree-mask]', { count: 0 });
 
     endDirectoryElement = find(endDirectorySelector);
 
@@ -685,6 +692,7 @@ module('Acceptance | code submode | file-tree tests', function (hooks) {
       'Enter',
     );
     await waitFor('[data-test-realm-name="Test Workspace B"]');
+    await waitFor('[data-test-file-tree-mask]', { count: 0 });
 
     endDirectoryElement = find(endDirectorySelector);
 


### PR DESCRIPTION
This Pr does a best attempt top hide the scroll position restore in the file tree. We cannot really hide the scroll bar jumping, but we can hide the directory contents flashing.

Before:
![scroll-mask-before](https://github.com/cardstack/boxel/assets/61075/b25a467a-1935-4ed5-a76b-220a6d767383)

After:
![scroll-mask-after](https://github.com/cardstack/boxel/assets/61075/1e3537e1-c81e-4d9f-8295-87050da9da80)
