### PR TITLE
Sort cards in cards grid by type, then by title

### DIFF
--- a/packages/base/cards-grid.gts
+++ b/packages/base/cards-grid.gts
@@ -196,7 +196,7 @@ class Isolated extends Component<typeof CardsGrid> {
               module: `${baseRealm.url}card-api`,
               name: 'CardDef',
             },
-            by: 'cardTypeName',
+            by: 'cardType',
           },
           {
             on: {

--- a/packages/base/cards-grid.gts
+++ b/packages/base/cards-grid.gts
@@ -196,6 +196,13 @@ class Isolated extends Component<typeof CardsGrid> {
               module: `${baseRealm.url}card-api`,
               name: 'CardDef',
             },
+            by: 'cardTypeName',
+          },
+          {
+            on: {
+              module: `${baseRealm.url}card-api`,
+              name: 'CardDef',
+            },
             by: 'title',
           },
         ],

--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -424,6 +424,11 @@ export class CurrentRun {
           `bug: could not derive search doc for instance ${instanceURL.href}`,
         );
       }
+      if (cardType.displayName === 'Card') {
+        searchData.cardTypeName = cardType.name;
+      } else {
+        searchData.cardTypeName = cardType.displayName;
+      }
     } catch (err: any) {
       uncaughtError = err;
     }

--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -419,15 +419,17 @@ export class CurrentRun {
         },
       }) as SingleCardDocument;
       searchData = await api.searchDoc(card);
+
       if (!searchData) {
         throw new Error(
           `bug: could not derive search doc for instance ${instanceURL.href}`,
         );
       }
+
       if (cardType.displayName === 'Card') {
-        searchData.cardTypeName = cardType.name;
+        searchData.cardType = cardType.name;
       } else {
-        searchData.cardTypeName = cardType.displayName;
+        searchData.cardType = cardType.displayName;
       }
     } catch (err: any) {
       uncaughtError = err;

--- a/packages/host/tests/integration/search-index-test.gts
+++ b/packages/host/tests/integration/search-index-test.gts
@@ -3647,7 +3647,7 @@ posts/ignore-me.json
       });
 
       assert.deepEqual(
-        matching.slice(0, 7).map((m) => m.id), // first 7 should be enough to test sorting by card type (name)
+        matching.map((m) => m.id),
         [
           `${paths.url}card-1`, // article
           `${paths.url}cards/2`, // article
@@ -3656,6 +3656,17 @@ posts/ignore-me.json
           `${paths.url}books/2`, // book
           `${paths.url}books/3`, // book
           `${paths.url}booking1`, // booking
+          `${paths.url}booking2`, // booking
+          `${paths.url}catalog-entry-1`, // catalog entry
+          `${paths.url}catalog-entry-2`, // catalog entry
+          `${paths.url}mango`, // dog
+          `${paths.url}ringo`, // dog
+          `${paths.url}vangogh`, // dog
+          `${paths.url}friend2`, // friend
+          `${paths.url}friend1`, // friend
+          `${paths.url}person-card1`, // person
+          `${paths.url}person-card2`, // person
+          `${paths.url}cards/1`, // person
         ],
       );
     });

--- a/packages/host/tests/integration/search-index-test.gts
+++ b/packages/host/tests/integration/search-index-test.gts
@@ -1235,6 +1235,7 @@ module('Integration | search-index', function (hooks) {
         posts: 100,
         title: 'Hassan Abdel-Rahman',
         thumbnailURL: undefined,
+        cardType: 'Person',
       },
       `search doc does not include fullName field`,
     );
@@ -1285,6 +1286,7 @@ module('Integration | search-index', function (hooks) {
       new URL(`${testRealmURL}CatalogEntry/booking`),
     );
     assert.deepEqual(entry?.searchData, {
+      cardType: 'Catalog Entry',
       id: `${testRealmURL}CatalogEntry/booking`,
       demo: {
         endTime: undefined,
@@ -1452,6 +1454,7 @@ module('Integration | search-index', function (hooks) {
     );
     if (hassanEntry) {
       assert.deepEqual(hassanEntry.searchData, {
+        cardType: 'Pet Person',
         id: `${testRealmURL}PetPerson/hassan`,
         firstName: 'Hassan',
         pets: [
@@ -1546,6 +1549,7 @@ module('Integration | search-index', function (hooks) {
     );
     if (entry) {
       assert.deepEqual(entry.searchData, {
+        cardType: 'Pet Person',
         id: `${testRealmURL}PetPerson/burcu`,
         firstName: 'Burcu',
         pets: [],
@@ -1736,6 +1740,7 @@ module('Integration | search-index', function (hooks) {
     );
     if (entry) {
       assert.deepEqual(entry.searchData, {
+        cardType: 'Catalog Entry',
         id: `${testRealmURL}pet-person-catalog-entry`,
         title: 'PetPerson',
         description: 'Catalog entry for PetPerson',
@@ -1892,6 +1897,7 @@ module('Integration | search-index', function (hooks) {
     );
     if (hassanEntry) {
       assert.deepEqual(hassanEntry.searchData, {
+        cardType: 'Friend',
         id: `${testRealmURL}Friend/hassan`,
         firstName: 'Hassan',
         title: 'Hassan',
@@ -2055,6 +2061,7 @@ module('Integration | search-index', function (hooks) {
     );
     if (hassanEntry) {
       assert.deepEqual(hassanEntry.searchData, {
+        cardType: 'Friend',
         id: `${testRealmURL}Friend/hassan`,
         firstName: 'Hassan',
         description: 'Dog owner',
@@ -2161,6 +2168,7 @@ module('Integration | search-index', function (hooks) {
     );
     if (mangoEntry) {
       assert.deepEqual(mangoEntry.searchData, {
+        cardType: 'Friend',
         id: `${testRealmURL}Friend/mango`,
         firstName: 'Mango',
         title: 'Mango',
@@ -2324,6 +2332,7 @@ module('Integration | search-index', function (hooks) {
       assert.deepEqual(
         hassanEntry.searchData,
         {
+          cardType: 'Friends',
           id: hassanID,
           firstName: 'Hassan',
           title: 'Hassan',
@@ -2447,6 +2456,7 @@ module('Integration | search-index', function (hooks) {
       assert.deepEqual(
         mangoEntry.searchData,
         {
+          cardType: 'Friends',
           id: mangoID,
           firstName: 'Mango',
           title: 'Mango',
@@ -2571,6 +2581,7 @@ module('Integration | search-index', function (hooks) {
       assert.deepEqual(
         vanGoghEntry.searchData,
         {
+          cardType: 'Friends',
           id: vanGoghID,
           firstName: 'Van Gogh',
           title: 'Van Gogh',
@@ -3630,7 +3641,7 @@ posts/ignore-me.json
         sort: [
           {
             on: baseCardRef,
-            by: 'cardTypeName',
+            by: 'cardType',
           },
         ],
       });

--- a/packages/host/tests/integration/search-index-test.gts
+++ b/packages/host/tests/integration/search-index-test.gts
@@ -3625,6 +3625,30 @@ posts/ignore-me.json
       );
     });
 
+    test('can sort by card display name (card type shown in the interface)', async function (assert) {
+      let { data: matching } = await indexer.search({
+        sort: [
+          {
+            on: baseCardRef,
+            by: 'cardTypeName',
+          },
+        ],
+      });
+
+      assert.deepEqual(
+        matching.slice(0, 7).map((m) => m.id), // first 7 should be enough to test sorting by card type (name)
+        [
+          `${paths.url}card-1`, // article
+          `${paths.url}cards/2`, // article
+          `${paths.url}card-2`, // book
+          `${paths.url}books/1`, // book
+          `${paths.url}books/2`, // book
+          `${paths.url}books/3`, // book
+          `${paths.url}booking1`, // booking
+        ],
+      );
+    });
+
     test('can sort by multiple string field conditions in given directions', async function (assert) {
       let { data: matching } = await indexer.search({
         sort: [


### PR DESCRIPTION
This PR adjusts the sorting of the cards in card grid. It first sorts by card type, then by title. Previously the sorting order was unpredictable and cards changed positions after editing, which was confusing. 

Here you can see the cards being sorted by card type and then by the title:
<img width="844" alt="image" src="https://github.com/cardstack/boxel/assets/273660/10197513-746d-426b-ac4c-e20456491b46">
