### PR TITLE
matrix: Fix documentation on running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ pnpm start:without-matrix
 Then to run the tests from the CLI execute the following from `packages/matrix`:
 
 ```
-pnpm start:test
+pnpm test
 ```
 
 Alternatively you can also run these tests from VS Code using the VS Code Playwright plugin (which is very strongly recommended). From the "test tube" icon, you can click on the play button to run a single test or all the tests.


### PR DESCRIPTION
You can see the referenced command [here](https://github.com/cardstack/boxel/blob/ecf2926b6c6fa3885ac5b6dc4bf58ee191f13555/packages/matrix/package.json#L28).