### PR TITLE
host: Fix Freestyle navigation

### DIFF
--- a/packages/host/app/controllers/host-freestyle.ts
+++ b/packages/host/app/controllers/host-freestyle.ts
@@ -1,0 +1,3 @@
+import FreestyleController from 'ember-freestyle/controllers/freestyle';
+
+export default FreestyleController;


### PR DESCRIPTION
This reexport brings in the query parameters needed to make navigation between components work vs this:

![screencast 2024-01-09 12-54-55](https://github.com/cardstack/boxel/assets/43280/d151846f-2bc8-41ed-aaf0-0770ee2f6379)
