### PR TITLE
Improve keyboard handling of CodeMode New file modals

### DIFF
--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -1,4 +1,5 @@
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
+import { hash } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import type Owner from '@ember/owner';
@@ -10,6 +11,7 @@ import { tracked } from '@glimmer/tracking';
 
 import { restartableTask, enqueueTask } from 'ember-concurrency';
 import perform from 'ember-concurrency/helpers/perform';
+import focusTrap from 'ember-focus-trap/modifiers/focus-trap';
 import onKeyMod from 'ember-keyboard/modifiers/on-key';
 import camelCase from 'lodash/camelCase';
 
@@ -88,6 +90,10 @@ export default class CreateFileModal extends Component<Signature> {
       @size='medium'
       @isOpen={{this.isModalOpen}}
       @onClose={{this.onCancel}}
+      {{focusTrap
+        isActive=this.onSetup.isIdle
+        focusTrapOptions=(hash initialFocus=this.initialFocusSelector)
+      }}
       data-test-ready={{this.onSetup.isIdle}}
       data-test-create-file-modal
     >
@@ -182,6 +188,7 @@ export default class CreateFileModal extends Component<Signature> {
             <div class='footer-buttons'>
               <Button
                 {{on 'click' this.onCancel}}
+                {{onKeyMod 'Escape'}}
                 @size='tall'
                 data-test-cancel-create-file
               >
@@ -389,6 +396,18 @@ export default class CreateFileModal extends Component<Signature> {
   @action private setFileName(name: string) {
     this.fileNameError = undefined;
     this.fileName = name;
+  }
+
+  private get initialFocusSelector() {
+    switch (this.maybeFileType?.id) {
+      case 'card-instance':
+      case 'card-definition':
+      case 'field-definition':
+      case 'duplicate-instance':
+        return '.create-file-modal .realm-dropdown-trigger';
+      default:
+        return false;
+    }
   }
 
   private get maybeFileType() {

--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -10,6 +10,7 @@ import { tracked } from '@glimmer/tracking';
 
 import { restartableTask, enqueueTask } from 'ember-concurrency';
 import perform from 'ember-concurrency/helpers/perform';
+import onKeyMod from 'ember-keyboard/modifiers/on-key';
 import camelCase from 'lodash/camelCase';
 
 import {
@@ -193,6 +194,7 @@ export default class CreateFileModal extends Component<Signature> {
                   @loading={{this.createCardInstance.isRunning}}
                   @disabled={{this.isCreateCardInstanceButtonDisabled}}
                   {{on 'click' (perform this.createCardInstance)}}
+                  {{onKeyMod 'Enter'}}
                   data-test-create-card-instance
                 >
                   Create
@@ -204,6 +206,7 @@ export default class CreateFileModal extends Component<Signature> {
                   @loading={{this.duplicateCardInstance.isRunning}}
                   @disabled={{this.isDuplicateCardInstanceButtonDisabled}}
                   {{on 'click' (perform this.duplicateCardInstance)}}
+                  {{onKeyMod 'Enter'}}
                   data-test-duplicate-card-instance
                 >
                   Duplicate
@@ -220,6 +223,7 @@ export default class CreateFileModal extends Component<Signature> {
                   @loading={{this.createDefinition.isRunning}}
                   @disabled={{this.isCreateDefinitionButtonDisabled}}
                   {{on 'click' (perform this.createDefinition)}}
+                  {{onKeyMod 'Enter'}}
                   data-test-create-definition
                 >
                   Create

--- a/packages/host/app/components/operator-mode/edit-field-modal.gts
+++ b/packages/host/app/components/operator-mode/edit-field-modal.gts
@@ -8,6 +8,8 @@ import { tracked } from '@glimmer/tracking';
 
 import { restartableTask } from 'ember-concurrency';
 
+import onKeyMod from 'ember-keyboard/modifiers/on-key';
+
 import {
   BoxelButton,
   BoxelInput,
@@ -434,6 +436,7 @@ export default class EditFieldModal extends Component<Signature> {
             <BoxelButton
               @kind='primary'
               {{on 'click' this.saveField}}
+              {{onKeyMod 'Enter'}}
               @disabled={{this.submitDisabled}}
               data-test-save-field-button
             >

--- a/packages/host/app/components/operator-mode/edit-field-modal.gts
+++ b/packages/host/app/components/operator-mode/edit-field-modal.gts
@@ -1,4 +1,5 @@
 import { fn } from '@ember/helper';
+import { hash } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
@@ -8,6 +9,7 @@ import { tracked } from '@glimmer/tracking';
 
 import { restartableTask } from 'ember-concurrency';
 
+import focusTrap from 'ember-focus-trap/modifiers/focus-trap';
 import onKeyMod from 'ember-keyboard/modifiers/on-key';
 
 import {
@@ -349,6 +351,9 @@ export default class EditFieldModal extends Component<Signature> {
       @onClose={{@onClose}}
       @size='medium'
       @centered={{true}}
+      {{focusTrap
+        focusTrapOptions=(hash initialFocus='.add-field-modal input')
+      }}
       class='add-field-modal'
       data-test-add-field-modal
       style={{cssVar boxel-modal-offset-top='40vh'}}
@@ -428,6 +433,7 @@ export default class EditFieldModal extends Component<Signature> {
             <BoxelButton
               @kind='secondary-light'
               {{on 'click' @onClose}}
+              {{onKeyMod 'Escape'}}
               data-test-cancel-adding-field-button
             >
               Cancel


### PR DESCRIPTION
* Make Enter key activate primary button of Create Card/Field/Instance modal in Code Submode
* Enter key also submits form for Add/Edit Field modal in Code submode
* Add focusTrap and make Escape equivalent to pressing Cancel button