### PR TITLE
Fix overlay when there are multiple modals shown

### DIFF
--- a/packages/boxel-ui/addon/src/components/modal/index.gts
+++ b/packages/boxel-ui/addon/src/components/modal/index.gts
@@ -95,7 +95,7 @@ export default class Modal extends Component<Signature> {
       }
 
       .overlay {
-        position: fixed;
+        position: absolute;
         top: 0;
         left: 0;
         bottom: 0;


### PR DESCRIPTION
This PR fixes a visual bug where a multi nested modal has an issue with the overlay.

Before: 
![Untitled 4](https://github.com/cardstack/boxel/assets/273660/32f07466-a4b9-414a-977c-57f0b3f7992d)

After:
![Untitled 4](https://github.com/cardstack/boxel/assets/273660/5ff416fb-6241-466c-a115-da9323812c58)

