### PR TITLE
host: Move assistant image CSS to global styles

### DIFF
--- a/packages/host/app/components/ai-assistant/button.gts
+++ b/packages/host/app/components/ai-assistant/button.gts
@@ -31,14 +31,5 @@ export default class AiAssistantButton extends Component<Signature> {
         cursor: pointer;
       }
     </style>
-    <style unscoped>
-      .ai-assistant-button {
-        background-image: image-set(
-          url(/images/ai-assist-icon.webp) 1x,
-          url(/images/ai-assist-icon@2x.webp) 2x,
-          url(/images/ai-assist-icon@3x.webp) 3x
-        );
-      }
-    </style>
   </template>
 }

--- a/packages/host/app/components/ai-assistant/button.gts
+++ b/packages/host/app/components/ai-assistant/button.gts
@@ -10,7 +10,6 @@ export default class AiAssistantButton extends Component<Signature> {
     <button
       class='ai-assistant-button'
       data-test-open-ai-assistant
-      style="background-image: image-set(url('/images/ai-assist-icon.webp') 1x, url('/images/ai-assist-icon@2x.webp') 2x, url('/images/ai-assist-icon@3x.webp') 3x)"
       ...attributes
     />
     <style>
@@ -30,6 +29,15 @@ export default class AiAssistantButton extends Component<Signature> {
       }
       .ai-assistant-button:hover {
         cursor: pointer;
+      }
+    </style>
+    <style unscoped>
+      .ai-assistant-button {
+        background-image: image-set(
+          url(/images/ai-assist-icon.webp) 1x,
+          url(/images/ai-assist-icon@2x.webp) 2x,
+          url(/images/ai-assist-icon@3x.webp) 3x
+        );
       }
     </style>
   </template>

--- a/packages/host/app/styles/app.css
+++ b/packages/host/app/styles/app.css
@@ -12,3 +12,11 @@
 .link:hover {
   color: var(--boxel-highlight-hover);
 }
+
+.ai-assistant-button {
+  background-image: image-set(
+    url(/images/ai-assist-icon.webp) 1x,
+    url(/images/ai-assist-icon@2x.webp) 2x,
+    url(/images/ai-assist-icon@3x.webp) 3x
+  );
+}

--- a/packages/host/ember-cli-build.js
+++ b/packages/host/ember-cli-build.js
@@ -32,6 +32,10 @@ module.exports = function (defaults) {
 
     packagerOptions: {
       ...{
+        publicAssetURL:
+          EmberApp.env() === 'production'
+            ? 'https://boxel-host-staging.stack.cards/'
+            : '/',
         webpackConfig: {
           devtool: 'source-map',
           module: {


### PR DESCRIPTION
This is a workaround for a [problem with `glimmer-scoped-css`](https://github.com/cardstack/glimmer-scoped-css/pull/23) processing relative URLs in CSS. Until we can fix that, this references the image in unscoped CSS that’s unlikely to conflict due to its specific class name.