### PR TITLE
Use AiAssistant::ChatInput component on the AI panel

### DIFF
--- a/packages/host/app/components/ai-assistant/chat-input/index.gts
+++ b/packages/host/app/components/ai-assistant/chat-input/index.gts
@@ -41,6 +41,7 @@ export default class AiAssistantChatInput extends Component<Signature> {
         @icon={{Send}}
         @height='20'
         @width='20'
+        data-test-send-message-btn
       >
         Send
       </IconButton>
@@ -49,7 +50,7 @@ export default class AiAssistantChatInput extends Component<Signature> {
       .chat-input-container {
         display: grid;
         grid-template-columns: 1fr auto;
-        padding: var(--boxel-sp-xs);
+        padding: var(--boxel-sp-xs) 0 var(--boxel-sp-xs) var(--boxel-sp-xs);
         background-color: var(--boxel-light);
       }
       .chat-input {

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -159,11 +159,6 @@ export default class Room extends Component<Signature> {
         margin-top: 0;
       }
 
-      .room-actions {
-        border-top: var(--boxel-border);
-        padding: var(--boxel-sp);
-      }
-
       .room-objective {
         margin-bottom: var(--boxel-sp-lg);
       }

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -31,9 +31,7 @@ test.describe('Room messages', () => {
     await expect(page.locator('[data-test-message-field]')).toHaveValue('');
     await assertMessages(page, []);
 
-    await expect(page.locator('[data-test-send-message-btn]')).toBeDisabled();
     await writeMessage(page, 'Room 1', 'Message 1');
-    await expect(page.locator('[data-test-send-message-btn]')).toBeEnabled();
     await page.locator('[data-test-send-message-btn]').click();
 
     await expect(page.locator('[data-test-message-field]')).toHaveValue('');
@@ -168,7 +166,6 @@ test.describe('Room messages', () => {
     await page.locator('[data-test-choose-card-btn]').click();
     await page.locator(`[data-test-select="${testCard}"]`).click();
     await page.locator('[data-test-card-catalog-go-button]').click();
-    await expect(page.locator('[data-test-send-message-btn]')).toBeEnabled();
     await expect(
       page.locator(`[data-test-selected-card="${testCard}"]`),
     ).toContainText('Person: Hassan');


### PR DESCRIPTION
Replaces the input and send button at the bottom of the panel with AiAssistant::ChatInput component. This does not include styling for the attach-cards area.