### PR TITLE
setting matrix URLs for staging and production

### DIFF
--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -139,8 +139,20 @@ let realmPermissions = new RealmPermissions();
     let url = hrefs[i][0];
     let manager = new RunnerOptionsManager();
     let matrixURL = String(matrixURLs[i]);
+    if (matrixURL.length === 0) {
+      console.error(`missing matrix URL for realm ${url}`);
+      process.exit(-1);
+    }
     let username = String(usernames[i]);
+    if (username.length === 0) {
+      console.error(`missing username for realm ${url}`);
+      process.exit(-1);
+    }
     let password = String(passwords[i]);
+    if (password.length === 0) {
+      console.error(`missing password for realm ${url}`);
+      process.exit(-1);
+    }
     let { getRunner, distPath } = await makeFastBootIndexRunner(
       dist,
       manager.getOptions.bind(manager),

--- a/packages/realm-server/scripts/start-production.sh
+++ b/packages/realm-server/scripts/start-production.sh
@@ -7,7 +7,7 @@ NODE_NO_WARNINGS=1 LOG_LEVELS='*=info' REALM_USER_PERMISSIONS="{}" ts-node \
   --port=3000 \
   \
   --path='/persistent/base' \
-  --matrixURL=${MATRIX_URL} \
+  --matrixURL='https://matrix.cardstack.com' \
   --username='base_realm' \
   --password=${BASE_REALM_PASSWORD} \
   --distURL='https://boxel-host.cardstack.com' \
@@ -15,14 +15,14 @@ NODE_NO_WARNINGS=1 LOG_LEVELS='*=info' REALM_USER_PERMISSIONS="{}" ts-node \
   --toUrl='https://realms.cardstack.com/base/' \
   \
   --path='/persistent/drafts' \
-  --matrixURL=${MATRIX_URL} \
+  --matrixURL='https://matrix.cardstack.com' \
   --username='drafts_realm' \
   --password=${DRAFTS_REALM_PASSWORD} \
   --fromUrl='https://realms.cardstack.com/drafts/' \
   --toUrl='https://realms.cardstack.com/drafts/' \
   \
   --path='/persistent/published' \
-  --matrixURL=${MATRIX_URL} \
+  --matrixURL='https://matrix.cardstack.com' \
   --username='published_realm' \
   --password=${PUBLISHED_REALM_PASSWORD} \
   --fromUrl='https://realms.cardstack.com/published/' \

--- a/packages/realm-server/scripts/start-staging.sh
+++ b/packages/realm-server/scripts/start-staging.sh
@@ -7,7 +7,7 @@ NODE_NO_WARNINGS=1 LOG_LEVELS='*=info' REALM_USER_PERMISSIONS="{}" ts-node \
   --port=3000 \
   \
   --path='/persistent/base' \
-  --matrixURL=${MATRIX_URL} \
+  --matrixURL='https://matrix-staging.stack.cards' \
   --username='base_realm' \
   --password=${BASE_REALM_PASSWORD} \
   --distURL='https://boxel-host-staging.stack.cards' \
@@ -15,14 +15,14 @@ NODE_NO_WARNINGS=1 LOG_LEVELS='*=info' REALM_USER_PERMISSIONS="{}" ts-node \
   --toUrl='https://realms-staging.stack.cards/base/' \
   \
   --path='/persistent/drafts' \
-  --matrixURL=${MATRIX_URL} \
+  --matrixURL='https://matrix-staging.stack.cards' \
   --username='drafts_realm' \
   --password=${DRAFTS_REALM_PASSWORD} \
   --fromUrl='https://realms-staging.stack.cards/drafts/' \
   --toUrl='https://realms-staging.stack.cards/drafts/' \
   \
   --path='/persistent/published' \
-  --matrixURL=${MATRIX_URL} \
+  --matrixURL='https://matrix-staging.stack.cards' \
   --username='published_realm' \
   --password=${PUBLISHED_REALM_PASSWORD} \
   --fromUrl='https://realms-staging.stack.cards/published/' \


### PR DESCRIPTION
Setting the URLs statically in the staging/production start scripts. (this follows the same strategy as in .github/workflows/build-host.yml). Also adding error checking for missing URLs, usernames, and passwords in realm script