### PR TITLE
Fix user ID suffix in username field

### DIFF
--- a/.github/workflows/build-host.yml
+++ b/.github/workflows/build-host.yml
@@ -29,12 +29,14 @@ jobs:
             echo "OTHER_REALM_URLS=https://realms.cardstack.com/published/" >> $GITHUB_ENV
             echo "RESOLVED_BASE_REALM_URL=https://realms.cardstack.com/base/" >> $GITHUB_ENV
             echo "MATRIX_URL=https://matrix.cardstack.com" >> $GITHUB_ENV
+            echo "MATRIX_SERVER_NAME=matrix.cardstack.com" >> $GITHUB_ENV
             echo "EXPERIMENTAL_AI_ENABLED=true" >> $GITHUB_ENV
           elif [ "$INPUT_ENVIRONMENT" = "staging" ]; then
             echo "OWN_REALM_URL=https://realms-staging.stack.cards/drafts/" >> $GITHUB_ENV
             echo "OTHER_REALM_URLS=https://realms-staging.stack.cards/published/" >> $GITHUB_ENV
             echo "RESOLVED_BASE_REALM_URL=https://realms-staging.stack.cards/base/" >> $GITHUB_ENV
             echo "MATRIX_URL=https://matrix-staging.stack.cards" >> $GITHUB_ENV
+            echo "MATRIX_SERVER_NAME=stack.cards" >> $GITHUB_ENV
             echo "EXPERIMENTAL_AI_ENABLED=true" >> $GITHUB_ENV
           else
             echo "unrecognized environment"

--- a/packages/host/app/components/matrix/register-user.gts
+++ b/packages/host/app/components/matrix/register-user.gts
@@ -40,7 +40,7 @@ const MATRIX_REGISTRATION_TYPES = {
   register: undefined,
 };
 
-const { matrixURL } = ENV;
+const { matrixServerName } = ENV;
 interface Signature {
   Args: {
     setMode: (mode: AuthMode) => void;
@@ -139,7 +139,7 @@ export default class RegisterUser extends Component<Signature> {
             <Accessories.Text class='username-prefix'>@</Accessories.Text>
           </:before>
           <:after as |Accessories|>
-            <Accessories.Text>{{this.usernameSuffix}}</Accessories.Text>
+            <Accessories.Text>{{matrixServerName}}</Accessories.Text>
           </:after>
         </BoxelInputGroup>
       </FieldContainer>
@@ -420,10 +420,6 @@ export default class RegisterUser extends Component<Signature> {
 
   private get emailInputState() {
     return this.emailError ? 'invalid' : 'initial';
-  }
-
-  private get usernameSuffix() {
-    return ':' + new URL(matrixURL).hostname;
   }
 
   @action

--- a/packages/host/app/config/environment.d.ts
+++ b/packages/host/app/config/environment.d.ts
@@ -14,6 +14,7 @@ declare const config: {
   ownRealmURL: string;
   otherRealmURLs: string[];
   matrixURL: string;
+  matrixServerName: string;
   experimentalAIEnabled: boolean;
   resolvedBaseRealmURL: string;
   hostsOwnAssets: boolean;

--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -25,6 +25,7 @@ module.exports = function (environment) {
     },
     logLevels: process.env.LOG_LEVELS || '*=info,current-run=error',
     matrixURL: process.env.MATRIX_URL || 'http://localhost:8008',
+    matrixServerName: process.env.MATRIX_SERVER_NAME || 'localhost',
     autoSaveDelayMs: 500,
     monacoDebounceMs: 500,
     monacoCursorDebounceMs: 200,


### PR DESCRIPTION
Previously, the user ID suffix was extracted from the matrixURL environment variable. However, the user ID suffix, which is the matrix server name, is not always a part of the matrix URL. I also couldn't find any matrix API that provides server name data before a user logs in. To address this, I've introduced the matrixServerName in the environment variable. This provides a more precise way to determine the user ID suffix.