### PR TITLE
Fix type import declarations in boxel-ui

### DIFF
--- a/packages/boxel-ui/addon/rollup.config.mjs
+++ b/packages/boxel-ui/addon/rollup.config.mjs
@@ -69,6 +69,16 @@ export default {
     }),
     scopedCSS('src'),
   ],
+
+  onLog(level, log, handler) {
+    if (log.code === 'UNUSED_EXTERNAL_IMPORT') {
+      // Turn unused external imports from warnings to errors. Warnings
+      // accumulate and just generate noise. And this is an easily-fixable issue
+      // usually caused by failing to declare a type import correctly.
+      level = 'error';
+    }
+    handler(level, log);
+  },
 };
 
 function scopedCSS(srcDir) {

--- a/packages/boxel-ui/addon/src/components/input-group/usage.gts
+++ b/packages/boxel-ui/addon/src/components/input-group/usage.gts
@@ -5,8 +5,8 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
 import {
+  type CSSVariableInfo,
   cssVariable,
-  CSSVariableInfo,
 } from 'ember-freestyle/decorators/css-variable';
 
 import cssVar from '../../helpers/css-var.ts';

--- a/packages/boxel-ui/addon/src/components/radio-input/usage.gts
+++ b/packages/boxel-ui/addon/src/components/radio-input/usage.gts
@@ -5,8 +5,8 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
 import {
+  type CSSVariableInfo,
   cssVariable,
-  CSSVariableInfo,
 } from 'ember-freestyle/decorators/css-variable';
 
 import cssVar from '../../helpers/css-var.ts';

--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/usage.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/usage.gts
@@ -3,8 +3,8 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
 import {
+  type CSSVariableInfo,
   cssVariable,
-  CSSVariableInfo,
 } from 'ember-freestyle/decorators/css-variable';
 
 import cssVar from '../../helpers/css-var.ts';

--- a/packages/boxel-ui/addon/src/components/tooltip/usage.gts
+++ b/packages/boxel-ui/addon/src/components/tooltip/usage.gts
@@ -1,7 +1,7 @@
 import { array, fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
-import { MiddlewareState } from '@floating-ui/dom';
+import type { MiddlewareState } from '@floating-ui/dom';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';

--- a/packages/boxel-ui/addon/src/modifiers/set-css-var.ts
+++ b/packages/boxel-ui/addon/src/modifiers/set-css-var.ts
@@ -1,4 +1,4 @@
-import Modifier, { NamedArgs, PositionalArgs } from 'ember-modifier';
+import Modifier, { type NamedArgs, type PositionalArgs } from 'ember-modifier';
 
 interface SetCssVarModifierSignature {
   Args: {


### PR DESCRIPTION
This adds missing `import type` declarations so that typescript will strip these imports correcty and stop generating extra noise in rollup.

It also changes the rollup config to prevent this problem from creeping back in by turning the rollup warning into a rollup error.