### PR TITLE
ui: Move tooltips to overlay

### DIFF
--- a/packages/boxel-ui/addon/src/components/tooltip/index.gts
+++ b/packages/boxel-ui/addon/src/components/tooltip/index.gts
@@ -1,5 +1,6 @@
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import { getOwner } from '@ember/owner';
 import type { MiddlewareState } from '@floating-ui/dom';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
@@ -20,12 +21,14 @@ export default class Tooltip extends Component<Signature> {
   @tracked isHoverOnTrigger = false;
 
   get tooltipOverlay() {
+    // @ts-expect-error rootElement is present but not in the type
+    let applicationElement = getOwner(this)?.rootElement ?? document.body;
     let container = document.querySelector('#tooltip-overlay') as HTMLElement;
 
     if (!container) {
       container = document.createElement('div');
       container.id = 'tooltip-overlay';
-      document.body.appendChild(container);
+      document.querySelector(applicationElement).appendChild(container);
     }
 
     return container;

--- a/packages/boxel-ui/addon/src/components/tooltip/index.gts
+++ b/packages/boxel-ui/addon/src/components/tooltip/index.gts
@@ -19,6 +19,18 @@ interface Signature {
 export default class Tooltip extends Component<Signature> {
   @tracked isHoverOnTrigger = false;
 
+  get tooltipOverlay() {
+    let container = document.querySelector('#tooltip-overlay') as HTMLElement;
+
+    if (!container) {
+      container = document.createElement('div');
+      container.id = 'tooltip-overlay';
+      document.body.appendChild(container);
+    }
+
+    return container;
+  }
+
   @action
   onMouseEnter() {
     this.isHoverOnTrigger = true;
@@ -45,10 +57,12 @@ export default class Tooltip extends Component<Signature> {
         {{yield to='trigger'}}
       </div>
       {{#if this.isHoverOnTrigger}}
-        {{! @glint-ignore velcro.loop }}
-        <div class='tooltip' {{velcro.loop}} data-test-tooltip-content>
-          {{yield to='content'}}
-        </div>
+        {{#in-element this.tooltipOverlay}}
+          {{! @glint-ignore velcro.loop }}
+          <div class='tooltip' {{velcro.loop}} data-test-tooltip-content>
+            {{yield to='content'}}
+          </div>
+        {{/in-element}}
       {{/if}}
     </Velcro>
 
@@ -68,6 +82,16 @@ export default class Tooltip extends Component<Signature> {
         position: absolute;
         font: var(--boxel-tooltip-font, var(--boxel-font-xs));
         z-index: 5;
+      }
+
+      :global(#tooltip-overlay) {
+        position: absolute;
+        z-index: 10000;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        pointer-events: none;
       }
     </style>
   </template>

--- a/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
@@ -1010,11 +1010,9 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
       'mouseenter',
     );
 
-    await waitFor(
-      '[data-test-card-schema="Blog Post"] [data-test-tooltip-content]',
-    );
+    await waitFor('[data-test-tooltip-content]');
     assert
-      .dom('[data-test-card-schema="Blog Post"] [data-test-tooltip-content]')
+      .dom('[data-test-tooltip-content]')
       .hasText('http://test-realm/test/ambiguous-display-names (BlogPost)');
     await triggerEvent(
       '[data-test-card-schema="Blog Post"] [data-test-card-schema-navigational-button]',
@@ -1028,9 +1026,9 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
       '[data-test-card-schema="Base"] [data-test-card-schema-navigational-button]',
       'mouseenter',
     );
-    await waitFor('[data-test-card-schema="Base"] [data-test-tooltip-content]');
+    await waitFor('[data-test-tooltip-content]');
     assert
-      .dom('[data-test-card-schema="Base"] [data-test-tooltip-content]')
+      .dom('[data-test-tooltip-content]')
       .hasText('https://cardstack.com/base/card-api (BaseDef)');
 
     await triggerEvent(
@@ -1046,13 +1044,9 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
       '[data-test-card-schema="Blog Post"] [data-test-field-name="authorBio"] [data-test-card-display-name="Author Bio"]',
       'mouseenter',
     );
-    await waitFor(
-      '[data-test-card-schema="Blog Post"] [data-test-field-name="authorBio"] [data-test-tooltip-content]',
-    );
+    await waitFor('[data-test-tooltip-content]');
     assert
-      .dom(
-        '[data-test-card-schema="Blog Post"] [data-test-field-name="authorBio"] [data-test-tooltip-content]',
-      )
+      .dom('[data-test-tooltip-content]')
       .hasText('http://test-realm/test/ambiguous-display-names (Author)'); //shows Author
     await triggerEvent(
       '[data-test-card-schema="Blog Post"] [data-test-field-name="authorBio"] [data-test-card-display-name="Author Bio"]',
@@ -1066,13 +1060,9 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
       '[data-test-card-schema="Blog Post"] [data-test-field-name="editorBio"] [data-test-card-display-name="Author Bio"]',
       'mouseenter',
     );
-    await waitFor(
-      '[data-test-card-schema="Blog Post"] [data-test-field-name="editorBio"] [data-test-tooltip-content]',
-    );
+    await waitFor('[data-test-tooltip-content]');
     assert
-      .dom(
-        '[data-test-card-schema="Blog Post"] [data-test-field-name="editorBio"] [data-test-tooltip-content]',
-      )
+      .dom('[data-test-tooltip-content]')
       .hasText('http://test-realm/test/ambiguous-display-names (Editor)'); //shows Editor
     await triggerEvent(
       '[data-test-card-schema="Blog Post"] [data-test-field-name="editorBio"] [data-test-card-display-name="Author Bio"]',


### PR DESCRIPTION
This fixes the truncation in Safari seen in the top window here:

![screencast 2024-01-22 13-49-59](https://github.com/cardstack/boxel/assets/43280/96ceb740-489a-4094-8ae1-8d9849109ea7)

The `Tooltip` component in `boxel-ui` finds or inserts an overlay element for tooltips to be inserted into. To make tests that make assertions about tooltips the overlay is inserted on `owner.rootElement` despite that being [undocumented API](https://api.emberjs.com/ember/4.12/classes/Owner).