### PR TITLE
host: Add display of card preview errors

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -800,18 +800,35 @@ export default class CodeSubmode extends Component<Signature> {
             >
               <InnerContainer>
                 {{#if this.isReady}}
-                  {{#if this.fileIncompatibilityMessage}}
+                  {{#if this.cardResource.cardError}}
+                    <div
+                      class='preview-error-container'
+                      data-test-file-incompatibility-message
+                    >
+                      <div class='preview-error-box'>
+                        <div class='preview-error-text'>
+                          Card Preview Error
+                        </div>
+                        <p>
+                          {{this.fileIncompatibilityMessage}}
+                        </p>
+
+                        <hr class='preview-error' />
+
+                        {{#each this.fileIncompatibilityErrors as |error|}}
+                          <pre
+                            class='preview-error'
+                            data-test-card-preview-error
+                          >{{error}}</pre>
+                        {{/each}}
+                      </div>
+                    </div>
+                  {{else if this.fileIncompatibilityMessage}}
                     <div
                       class='file-incompatible-message'
                       data-test-file-incompatibility-message
                     >
                       {{this.fileIncompatibilityMessage}}
-                      {{#each this.fileIncompatibilityErrors as |error|}}
-                        <pre
-                          class='error'
-                          data-test-card-preview-error
-                        >{{error}}</pre>
-                      {{/each}}
                     </div>
                   {{else if this.selectedCardOrField.cardOrField}}
                     <Accordion as |A|>
@@ -1046,7 +1063,31 @@ export default class CodeSubmode extends Component<Signature> {
         padding: var(--boxel-sp-sm);
       }
 
-      pre.error {
+      .preview-error-container {
+        background: var(--boxel-100);
+        padding: var(--boxel-sp);
+        border-radius: var(--boxel-radius);
+        height: 100%;
+      }
+
+      .preview-error-box {
+        border-radius: var(--boxel-border-radius);
+        padding: var(--boxel-sp);
+        background: var(--boxel-200);
+      }
+
+      .preview-error-text {
+        color: red;
+        font-weight: 600;
+      }
+
+      hr.preview-error {
+        width: calc(100% + var(--boxel-sp) * 2);
+        margin-left: calc(var(--boxel-sp) * -1);
+        margin-top: calc(var(--boxel-sp-sm) + 1px);
+      }
+
+      pre.preview-error {
         white-space: pre-wrap;
         text-align: left;
       }

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -338,6 +338,7 @@ export default class CodeSubmode extends Component<Signature> {
             return detailsWithoutDuplicateSuffixes;
           }
         } catch (e) {
+          console.log('Error extracting card preview errors', e);
           return [];
         }
       }

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -1047,6 +1047,7 @@ export default class CodeSubmode extends Component<Signature> {
 
       pre.error {
         white-space: pre-wrap;
+        text-align: left;
       }
     </style>
   </template>

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -257,7 +257,7 @@ export default class CodeSubmode extends Component<Signature> {
   private get fileIncompatibilityMessage() {
     if (this.isCard) {
       if (this.cardResource.cardError) {
-        return `Card preview failed. Make sure both the card instance data and card definition files have no syntax errors and that their data schema matches. `;
+        return `Card preview failed. Make sure both the card instance data and card definition files have no errors and that their data schema matches. `;
       }
     }
 

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -319,7 +319,23 @@ export default class CodeSubmode extends Component<Signature> {
               )
               .map((e: SerializedError) => e.detail);
 
-            return allDetails;
+            // There’s often a pair of errors where one has an unhelpful prefix like this:
+            // cannot return card from index: Not Found - http://test-realm/test/non-card not found
+            // http://test-realm/test/non-card not found
+
+            let detailsWithoutDuplicateSuffixes = allDetails.reduce(
+              (details: string[], currentDetail: string) => {
+                return [
+                  ...details.filter(
+                    (existingDetail) => !existingDetail.endsWith(currentDetail),
+                  ),
+                  currentDetail,
+                ];
+              },
+              [],
+            );
+
+            return detailsWithoutDuplicateSuffixes;
           }
         } catch (e) {
           return [];

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -254,6 +254,10 @@ export default class CodeSubmode extends Component<Signature> {
     return !!(this.codePath && this.currentOpenFile?.state !== 'not-found');
   }
 
+  private get isCardPreviewError() {
+    return this.isCard && this.cardResource.cardError;
+  }
+
   private get fileIncompatibilityMessage() {
     if (this.isCard) {
       if (this.cardResource.cardError) {
@@ -800,7 +804,7 @@ export default class CodeSubmode extends Component<Signature> {
             >
               <InnerContainer>
                 {{#if this.isReady}}
-                  {{#if this.cardResource.cardError}}
+                  {{#if this.isCardPreviewError}}
                     <div
                       class='preview-error-container'
                       data-test-file-incompatibility-message

--- a/packages/host/app/resources/card-resource.ts
+++ b/packages/host/app/resources/card-resource.ts
@@ -20,6 +20,8 @@ import {
   type SingleCardDocument,
 } from '@cardstack/runtime-common';
 
+import { ErrorDetails } from '@cardstack/runtime-common/error';
+
 import type MessageService from '@cardstack/host/services/message-service';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
@@ -31,7 +33,7 @@ import type LoaderService from '../services/loader-service';
 
 interface CardError {
   id: string;
-  error: Error;
+  error: ErrorDetails;
 }
 
 interface Args {

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -718,6 +718,7 @@ module('Acceptance | code submode tests', function (hooks) {
 
     assert
       .dom('[data-test-card-preview-error]')
+      .exists({ count: 1 })
       .includesText(`${testRealmURL}non-card not found`);
 
     await visitOperatorMode({


### PR DESCRIPTION
This attempts to extract realm server errors to show when card preview fails:

<img width="990" alt="Boxel 2024-01-26 12-57-30" src="https://github.com/cardstack/boxel/assets/43280/844a31ad-6ba4-4936-b3e7-2832e3c423c9">

They’re extracted from `errors[].detail` and `errors[].additionalErrors[].detail` and processed to remove an unhelpful error prefix.