### PR TITLE
Server name not hostname is used for matrix user ids

### DIFF
--- a/packages/host/app/components/ai-assistant/panel.gts
+++ b/packages/host/app/components/ai-assistant/panel.gts
@@ -48,8 +48,8 @@ import type {
 
 import { getRoom, RoomResource } from '../../resources/room';
 
-const { matrixURL } = ENV;
-export const aiBotUserId = `@${aiBotUsername}:${new URL(matrixURL).hostname}`;
+const { matrixServerName } = ENV;
+export const aiBotUserId = `@${aiBotUsername}:${matrixServerName}`;
 
 export type AiSessionRoom = { room: RoomField; member: RoomMemberField };
 


### PR DESCRIPTION
For localhost these are the same, but if matrix is on something like a.b.c.cardstack.com the server name may be just cardstack.com