### PR TITLE
Move test synapse server to new port

### DIFF
--- a/packages/matrix/docker/index.ts
+++ b/packages/matrix/docker/index.ts
@@ -4,7 +4,7 @@ import * as fse from 'fs-extra';
 
 export function dockerRun(args: {
   image: string;
-  containerName: string;
+  containerName?: string;
   dockerParams?: string[];
   applicationParams?: string[];
   runAsUser?: true;
@@ -19,6 +19,9 @@ export function dockerRun(args: {
   }
 
   return new Promise<string>((resolve, reject) => {
+    if (!args.containerName) {
+      args.containerName = `boxel-test-${Date.now()}`;
+    }
     childProcess.execFile(
       'docker',
       [

--- a/packages/matrix/package.json
+++ b/packages/matrix/package.json
@@ -21,6 +21,7 @@
     "stop:smtp": "ts-node --transpileOnly ./scripts/smtp.ts stop",
     "assert-smtp-running": "if [ \"`docker ps -f name='boxel-smtp' --format '{{.Names}}'`\" = 'boxel-smtp' ]; then echo 'SMTP is already running'; else pnpm run start:smtp; fi",
     "start:admin": "docker start synapse-admin",
+    "start:realm": "cd ../realm-server && pnpm start:matrix-test-realms",
     "start:host-pre-built": "cd ../host && pnpm start --path ./dist",
     "stop:admin": "docker stop synapse-admin",
     "register-bot-user": "USERNAME=aibot PASSWORD=pass ts-node --transpileOnly ./scripts/register-test-user.ts",

--- a/packages/matrix/scripts/synapse.ts
+++ b/packages/matrix/scripts/synapse.ts
@@ -12,6 +12,7 @@ let dataDir = process.env.SYNAPSE_DATA_DIR
       template: 'dev',
       dataDir,
       containerName: 'boxel-synapse',
+      port: 8008,
     });
   } else if (command === 'stop') {
     await dockerStop({ containerId: 'boxel-synapse' });

--- a/packages/matrix/tests/forgot-password.spec.ts
+++ b/packages/matrix/tests/forgot-password.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 import {
   synapseStop,
   updateUser,
@@ -14,6 +14,7 @@ import {
   login,
   registerRealmUsers,
   startTestingSynapse,
+  test,
 } from '../helpers';
 import { registerUser, createRegistrationToken } from '../docker/synapse';
 

--- a/packages/matrix/tests/forgot-password.spec.ts
+++ b/packages/matrix/tests/forgot-password.spec.ts
@@ -1,6 +1,5 @@
 import { expect, test } from '@playwright/test';
 import {
-  synapseStart,
   synapseStop,
   updateUser,
   type SynapseInstance,
@@ -14,6 +13,7 @@ import {
   validateEmailForResetPassword,
   login,
   registerRealmUsers,
+  startTestingSynapse,
 } from '../helpers';
 import { registerUser, createRegistrationToken } from '../docker/synapse';
 
@@ -27,18 +27,22 @@ test.describe('Forgot password', () => {
   let synapse: SynapseInstance;
 
   test.beforeEach(async ({ page }) => {
-    synapse = await synapseStart({
+    synapse = await startTestingSynapse({
       template: 'test',
     });
     await smtpStart();
 
     let admin = await registerUser(synapse, 'admin', 'adminpass', true);
-    await createRegistrationToken(admin.accessToken, REGISTRATION_TOKEN);
+    await createRegistrationToken(
+      synapse,
+      admin.accessToken,
+      REGISTRATION_TOKEN,
+    );
     await registerRealmUsers(synapse);
     await clearLocalStorage(page);
     await gotoRegistration(page);
     await registerUser(synapse, username, password);
-    await updateUser(admin.accessToken, '@user1:localhost', {
+    await updateUser(synapse, admin.accessToken, '@user1:localhost', {
       emailAddresses: [email],
       displayname: name,
     });

--- a/packages/matrix/tests/login-using-email.spec.ts
+++ b/packages/matrix/tests/login-using-email.spec.ts
@@ -1,6 +1,5 @@
 import { expect, test } from '@playwright/test';
 import {
-  synapseStart,
   synapseStop,
   updateUser,
   type SynapseInstance,
@@ -13,6 +12,7 @@ import {
   gotoRegistration,
   assertLoggedIn,
   registerRealmUsers,
+  startTestingSynapse,
 } from '../helpers';
 import { registerUser, createRegistrationToken } from '../docker/synapse';
 
@@ -22,18 +22,22 @@ test.describe('Login using email', () => {
   let synapse: SynapseInstance;
 
   test.beforeEach(async ({ page }) => {
-    synapse = await synapseStart({
+    synapse = await startTestingSynapse({
       template: 'test',
     });
     await smtpStart();
 
     let admin = await registerUser(synapse, 'admin', 'adminpass', true);
-    await createRegistrationToken(admin.accessToken, REGISTRATION_TOKEN);
+    await createRegistrationToken(
+      synapse,
+      admin.accessToken,
+      REGISTRATION_TOKEN,
+    );
     await registerRealmUsers(synapse);
     await clearLocalStorage(page);
     await gotoRegistration(page);
     await registerUser(synapse, 'user1', 'mypassword1!');
-    await updateUser(admin.accessToken, '@user1:localhost', {
+    await updateUser(synapse, admin.accessToken, '@user1:localhost', {
       emailAddresses: ['user1@example.com'],
       displayname: 'Test User',
     });

--- a/packages/matrix/tests/login-using-email.spec.ts
+++ b/packages/matrix/tests/login-using-email.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 import {
   synapseStop,
   updateUser,
@@ -13,6 +13,7 @@ import {
   assertLoggedIn,
   registerRealmUsers,
   startTestingSynapse,
+  test,
 } from '../helpers';
 import { registerUser, createRegistrationToken } from '../docker/synapse';
 

--- a/packages/matrix/tests/login.spec.ts
+++ b/packages/matrix/tests/login.spec.ts
@@ -1,10 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { registerUser } from '../docker/synapse';
-import {
-  synapseStart,
-  synapseStop,
-  type SynapseInstance,
-} from '../docker/synapse';
+import { synapseStop, type SynapseInstance } from '../docker/synapse';
 import {
   clearLocalStorage,
   assertLoggedIn,
@@ -14,6 +10,7 @@ import {
   openRoot,
   toggleOperatorMode,
   registerRealmUsers,
+  startTestingSynapse,
   testHost,
 } from '../helpers';
 import jwt from 'jsonwebtoken';
@@ -23,7 +20,7 @@ const REALM_SECRET_SEED = "shhh! it's a secret";
 test.describe('Login', () => {
   let synapse: SynapseInstance;
   test.beforeEach(async ({ page }) => {
-    synapse = await synapseStart();
+    synapse = await startTestingSynapse();
     await registerRealmUsers(synapse);
     await registerUser(synapse, 'user1', 'pass');
     await clearLocalStorage(page);

--- a/packages/matrix/tests/login.spec.ts
+++ b/packages/matrix/tests/login.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 import { registerUser } from '../docker/synapse';
 import { synapseStop, type SynapseInstance } from '../docker/synapse';
 import {
@@ -12,6 +12,7 @@ import {
   registerRealmUsers,
   startTestingSynapse,
   testHost,
+  test,
 } from '../helpers';
 import jwt from 'jsonwebtoken';
 

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 import { registerUser } from '../docker/synapse';
 import {
   login,
@@ -13,17 +13,15 @@ import {
   reloadAndOpenAiAssistant,
   isInRoom,
   registerRealmUsers,
+  startTestingSynapse,
+  test,
 } from '../helpers';
-import {
-  synapseStart,
-  synapseStop,
-  type SynapseInstance,
-} from '../docker/synapse';
+import { synapseStop, type SynapseInstance } from '../docker/synapse';
 
 test.describe('Room messages', () => {
   let synapse: SynapseInstance;
   test.beforeEach(async () => {
-    synapse = await synapseStart();
+    synapse = await startTestingSynapse();
     await registerRealmUsers(synapse);
     await registerUser(synapse, 'user1', 'pass');
     await registerUser(synapse, 'user2', 'pass');

--- a/packages/matrix/tests/objectives.spec.ts
+++ b/packages/matrix/tests/objectives.spec.ts
@@ -1,10 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { registerUser } from '../docker/synapse';
-import {
-  synapseStart,
-  synapseStop,
-  type SynapseInstance,
-} from '../docker/synapse';
+import { synapseStop, type SynapseInstance } from '../docker/synapse';
 import {
   login,
   logout,
@@ -15,12 +11,13 @@ import {
   sendMessage,
   joinRoom,
   registerRealmUsers,
+  startTestingSynapse,
 } from '../helpers';
 
 test.describe('Room objectives', () => {
   let synapse: SynapseInstance;
   test.beforeEach(async () => {
-    synapse = await synapseStart();
+    synapse = await startTestingSynapse();
     await registerRealmUsers(synapse);
     await registerUser(synapse, 'user1', 'pass');
     await registerUser(synapse, 'user2', 'pass');

--- a/packages/matrix/tests/objectives.spec.ts
+++ b/packages/matrix/tests/objectives.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 import { registerUser } from '../docker/synapse';
 import { synapseStop, type SynapseInstance } from '../docker/synapse';
 import {
@@ -12,6 +12,7 @@ import {
   joinRoom,
   registerRealmUsers,
   startTestingSynapse,
+  test,
 } from '../helpers';
 
 test.describe('Room objectives', () => {

--- a/packages/matrix/tests/profile.spec.ts
+++ b/packages/matrix/tests/profile.spec.ts
@@ -1,4 +1,4 @@
-import { expect, type Page, test } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 import {
   synapseStop,
   type SynapseInstance,
@@ -13,6 +13,7 @@ import {
   assertLoggedIn,
   registerRealmUsers,
   startTestingSynapse,
+  test,
 } from '../helpers';
 
 test.describe('Profile', () => {

--- a/packages/matrix/tests/profile.spec.ts
+++ b/packages/matrix/tests/profile.spec.ts
@@ -1,6 +1,5 @@
 import { expect, type Page, test } from '@playwright/test';
 import {
-  synapseStart,
   synapseStop,
   type SynapseInstance,
   registerUser,
@@ -13,24 +12,23 @@ import {
   assertLoggedOut,
   assertLoggedIn,
   registerRealmUsers,
+  startTestingSynapse,
 } from '../helpers';
 
 test.describe('Profile', () => {
   let synapse: SynapseInstance;
   test.beforeEach(async () => {
-    synapse = await synapseStart({
-      template: 'test',
-    });
+    synapse = await startTestingSynapse();
     await smtpStart();
 
     let admin = await registerUser(synapse, 'admin', 'adminpass', true);
     await registerRealmUsers(synapse);
     await registerUser(synapse, 'user1', 'pass');
     await registerUser(synapse, 'user0', 'pass');
-    await updateUser(admin.accessToken, '@user1:localhost', {
+    await updateUser(synapse, admin.accessToken, '@user1:localhost', {
       emailAddresses: ['user1@localhost'],
     });
-    await updateUser(admin.accessToken, '@user0:localhost', {
+    await updateUser(synapse, admin.accessToken, '@user0:localhost', {
       emailAddresses: ['user0@localhost'],
     });
   });

--- a/packages/matrix/tests/registration-with-token.spec.ts
+++ b/packages/matrix/tests/registration-with-token.spec.ts
@@ -1,9 +1,5 @@
 import { expect, test } from '@playwright/test';
-import {
-  synapseStart,
-  synapseStop,
-  type SynapseInstance,
-} from '../docker/synapse';
+import { synapseStop, type SynapseInstance } from '../docker/synapse';
 import { smtpStart, smtpStop } from '../docker/smtp4dev';
 import {
   clearLocalStorage,
@@ -13,6 +9,7 @@ import {
   assertLoggedOut,
   logout,
   registerRealmUsers,
+  startTestingSynapse,
 } from '../helpers';
 import { registerUser, createRegistrationToken } from '../docker/synapse';
 
@@ -22,9 +19,7 @@ test.describe('User Registration w/ Token', () => {
   let synapse: SynapseInstance;
 
   test.beforeEach(async () => {
-    synapse = await synapseStart({
-      template: 'test',
-    });
+    synapse = await startTestingSynapse();
     await smtpStart();
   });
 
@@ -36,7 +31,11 @@ test.describe('User Registration w/ Token', () => {
   test('it can register a user with a registration token', async ({ page }) => {
     let admin = await registerUser(synapse, 'admin', 'adminpass', true);
     await registerRealmUsers(synapse);
-    await createRegistrationToken(admin.accessToken, REGISTRATION_TOKEN);
+    await createRegistrationToken(
+      synapse,
+      admin.accessToken,
+      REGISTRATION_TOKEN,
+    );
     await clearLocalStorage(page);
     await gotoRegistration(page);
 

--- a/packages/matrix/tests/registration-with-token.spec.ts
+++ b/packages/matrix/tests/registration-with-token.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 import { synapseStop, type SynapseInstance } from '../docker/synapse';
 import { smtpStart, smtpStop } from '../docker/smtp4dev';
 import {
@@ -10,6 +10,7 @@ import {
   logout,
   registerRealmUsers,
   startTestingSynapse,
+  test,
 } from '../helpers';
 import { registerUser, createRegistrationToken } from '../docker/synapse';
 

--- a/packages/matrix/tests/registration-with-token.spec.ts
+++ b/packages/matrix/tests/registration-with-token.spec.ts
@@ -101,7 +101,11 @@ test.describe('User Registration w/ Token', () => {
   }) => {
     let admin = await registerUser(synapse, 'admin', 'adminpass', true);
     await registerRealmUsers(synapse);
-    await createRegistrationToken(admin.accessToken, REGISTRATION_TOKEN);
+    await createRegistrationToken(
+      synapse,
+      admin.accessToken,
+      REGISTRATION_TOKEN,
+    );
     await registerUser(synapse, 'user1', 'pass');
     await clearLocalStorage(page);
 
@@ -155,7 +159,11 @@ test.describe('User Registration w/ Token', () => {
   }) => {
     let admin = await registerUser(synapse, 'admin', 'adminpass', true);
     await registerRealmUsers(synapse);
-    await createRegistrationToken(admin.accessToken, REGISTRATION_TOKEN);
+    await createRegistrationToken(
+      synapse,
+      admin.accessToken,
+      REGISTRATION_TOKEN,
+    );
     await clearLocalStorage(page);
 
     await gotoRegistration(page);
@@ -315,7 +323,7 @@ test.describe('User Registration w/ Token', () => {
     await registerRealmUsers(synapse);
     await clearLocalStorage(page);
     await createRegistrationToken(
-      // synapse,
+      synapse,
       admin.accessToken,
       REGISTRATION_TOKEN,
     );

--- a/packages/matrix/tests/registration-without-token.spec.ts
+++ b/packages/matrix/tests/registration-without-token.spec.ts
@@ -1,9 +1,5 @@
 import { test, expect } from '@playwright/test';
-import {
-  synapseStart,
-  synapseStop,
-  type SynapseInstance,
-} from '../docker/synapse';
+import { synapseStop, type SynapseInstance } from '../docker/synapse';
 import { smtpStart, smtpStop } from '../docker/smtp4dev';
 import {
   clearLocalStorage,
@@ -11,13 +7,14 @@ import {
   gotoRegistration,
   assertLoggedIn,
   registerRealmUsers,
+  startTestingSynapse,
 } from '../helpers';
 
 test.describe('User Registration w/o Token', () => {
   let synapse: SynapseInstance;
 
   test.beforeEach(async () => {
-    synapse = await synapseStart({
+    synapse = await startTestingSynapse({
       template: 'test-without-registration-token',
     });
     await smtpStart();

--- a/packages/matrix/tests/registration-without-token.spec.ts
+++ b/packages/matrix/tests/registration-without-token.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { expect } from '@playwright/test';
 import { synapseStop, type SynapseInstance } from '../docker/synapse';
 import { smtpStart, smtpStop } from '../docker/smtp4dev';
 import {
@@ -8,6 +8,7 @@ import {
   assertLoggedIn,
   registerRealmUsers,
   startTestingSynapse,
+  test,
 } from '../helpers';
 
 test.describe('User Registration w/o Token', () => {

--- a/packages/matrix/tests/room-creation.spec.ts
+++ b/packages/matrix/tests/room-creation.spec.ts
@@ -1,10 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { registerUser } from '../docker/synapse';
-import {
-  synapseStart,
-  synapseStop,
-  type SynapseInstance,
-} from '../docker/synapse';
+import { synapseStop, type SynapseInstance } from '../docker/synapse';
 import {
   login,
   logout,
@@ -12,12 +8,13 @@ import {
   createRoom,
   reloadAndOpenAiAssistant,
   registerRealmUsers,
+  startTestingSynapse,
 } from '../helpers';
 
 test.describe('Room creation', () => {
   let synapse: SynapseInstance;
   test.beforeEach(async () => {
-    synapse = await synapseStart();
+    synapse = await startTestingSynapse();
     await registerRealmUsers(synapse);
     await registerUser(synapse, 'user1', 'pass');
     await registerUser(synapse, 'user2', 'pass');

--- a/packages/matrix/tests/room-creation.spec.ts
+++ b/packages/matrix/tests/room-creation.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 import { registerUser } from '../docker/synapse';
 import { synapseStop, type SynapseInstance } from '../docker/synapse';
 import {
@@ -9,6 +9,7 @@ import {
   reloadAndOpenAiAssistant,
   registerRealmUsers,
   startTestingSynapse,
+  test,
 } from '../helpers';
 
 test.describe('Room creation', () => {

--- a/packages/matrix/tests/room-membership.spec.ts
+++ b/packages/matrix/tests/room-membership.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 import { registerUser } from '../docker/synapse';
 import { synapseStop, type SynapseInstance } from '../docker/synapse';
 import {
@@ -13,6 +13,7 @@ import {
   reloadAndOpenAiAssistant,
   registerRealmUsers,
   startTestingSynapse,
+  test,
 } from '../helpers';
 
 test.describe('Room membership', () => {

--- a/packages/matrix/tests/room-membership.spec.ts
+++ b/packages/matrix/tests/room-membership.spec.ts
@@ -1,10 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { registerUser } from '../docker/synapse';
-import {
-  synapseStart,
-  synapseStop,
-  type SynapseInstance,
-} from '../docker/synapse';
+import { synapseStop, type SynapseInstance } from '../docker/synapse';
 import {
   login,
   logout,
@@ -16,12 +12,13 @@ import {
   inviteToRoom,
   reloadAndOpenAiAssistant,
   registerRealmUsers,
+  startTestingSynapse,
 } from '../helpers';
 
 test.describe('Room membership', () => {
   let synapse: SynapseInstance;
   test.beforeEach(async () => {
-    synapse = await synapseStart();
+    synapse = await startTestingSynapse();
     await registerRealmUsers(synapse);
     await registerUser(synapse, 'user1', 'pass');
     await registerUser(synapse, 'user2', 'pass');


### PR DESCRIPTION
This goes part way, getting tests working with matrix using a new port

Adds:

* New test realm for matrix tests
* New port for synapse running for the matrix tests


Missing:

* Scripts for starting new test realm
* Handling that we now need two different IP addresses
* Password resets failing, possibly due to these changes?

I had to make changes in more places than I was expecting, and the synapse port needs to be known before the realm server can start. Ideally we'd be able to lean more on docker, let it handle the naming of services & connections and just return the ports for the app to use. 