### PR TITLE
host: Move image references into style tags

### DIFF
--- a/packages/host/app/components/ai-assistant/button.gts
+++ b/packages/host/app/components/ai-assistant/button.gts
@@ -1,20 +1,14 @@
 import Component from '@glimmer/component';
 
-import assistantIcon1x from './ai-assist-icon.webp';
-import assistantIcon2x from './ai-assist-icon@2x.webp';
-import assistantIcon3x from './ai-assist-icon@3x.webp';
-
 interface Signature {
   Element: HTMLButtonElement;
 }
 
 export default class AiAssistantButton extends Component<Signature> {
   <template>
-    {{! template-lint-disable no-inline-styles style-concatenation }}
     <button
       class='ai-assistant-button'
       data-test-open-ai-assistant
-      style='background-image: image-set(url({{assistantIcon1x}}) 1x, url({{assistantIcon2x}}) 2x, url({{assistantIcon3x}}) 3x)'
       ...attributes
     />
     <style>
@@ -28,6 +22,12 @@ export default class AiAssistantButton extends Component<Signature> {
         border-radius: var(--boxel-border-radius);
         background-color: var(--boxel-ai-purple);
         border: none;
+
+        background-image: image-set(
+          url('./ai-assist-icon.webp') 1x,
+          url('./ai-assist-icon@2x.webp') 2x,
+          url('./ai-assist-icon@3x.webp')
+        );
         background-size: 26px 26px;
         background-position: center;
         background-repeat: no-repeat;

--- a/packages/host/app/components/ai-assistant/message/index.gts
+++ b/packages/host/app/components/ai-assistant/message/index.gts
@@ -11,10 +11,6 @@ import { FailureBordered } from '@cardstack/boxel-ui/icons';
 
 import { type CardDef } from 'https://cardstack.com/base/card-api';
 
-import assistantIcon1x from '../ai-assist-icon.webp';
-import assistantIcon2x from '../ai-assist-icon@2x.webp';
-import assistantIcon3x from '../ai-assist-icon@3x.webp';
-
 import type { ComponentLike } from '@glint/template';
 
 interface Signature {
@@ -47,11 +43,7 @@ export default class AiAssistantMessage extends Component<Signature> {
     >
       <div class='meta'>
         {{#if @isFromAssistant}}
-          {{! template-lint-disable no-inline-styles style-concatenation }}
-          <div
-            class='ai-avatar'
-            style='background-image: image-set(url({{assistantIcon1x}}) 1x, url({{assistantIcon2x}}) 2x, url({{assistantIcon3x}}) 3x)'
-          ></div>
+          <div class='ai-avatar'></div>
         {{else if @profileAvatar}}
           <@profileAvatar />
         {{/if}}
@@ -116,6 +108,12 @@ export default class AiAssistantMessage extends Component<Signature> {
       .ai-avatar {
         width: var(--ai-assistant-message-avatar-size);
         height: var(--ai-assistant-message-avatar-size);
+
+        background-image: image-set(
+          url('../ai-assist-icon.webp') 1x,
+          url('../ai-assist-icon@2x.webp') 2x,
+          url('../ai-assist-icon@3x.webp')
+        );
         background-repeat: no-repeat;
         background-size: var(--ai-assistant-message-avatar-size);
       }

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -135,7 +135,7 @@
     "fast-json-stable-stringify": "^2.1.0",
     "filesize": "^10.0.12",
     "flat": "^5.0.2",
-    "glimmer-scoped-css": "^0.4.0",
+    "glimmer-scoped-css": "^0.4.1",
     "ignore": "^5.2.0",
     "indefinite": "^2.4.3",
     "loader.js": "^4.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1368,8 +1368,8 @@ importers:
         specifier: ^5.0.2
         version: 5.0.2
       glimmer-scoped-css:
-        specifier: ^0.4.0
-        version: 0.4.0
+        specifier: ^0.4.1
+        version: 0.4.1
       ignore:
         specifier: ^5.2.0
         version: 5.2.0
@@ -15360,6 +15360,18 @@ packages:
       super-fast-md5: 1.0.1
     transitivePeerDependencies:
       - supports-color
+
+  /glimmer-scoped-css@0.4.1:
+    resolution: {integrity: sha512-BWZyBEpmZu0RLnuOaSBJkCjSMoGuxO3glq7JCM1QH0r9Ki8OVdYj+nUIgfg03T5duqbeQqR1Oad8MvDF/O4bCQ==}
+    dependencies:
+      '@embroider/addon-shim': 1.8.6
+      js-string-escape: 1.0.1
+      postcss: 8.4.31
+      postcss-selector-parser: 6.0.13
+      super-fast-md5: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /glob-parent@3.1.0:
     resolution: {integrity: sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==}


### PR DESCRIPTION
This benefits from the `0.4.1` bug fix in `glimmer-scoped-css` that lets us use `url(…` in CSS.

Here it is working in staging:

![Boxel 2024-02-01 16-10-21](https://github.com/cardstack/boxel/assets/43280/1cb432cd-7da4-4351-9437-68b7c95f3c61)
