### PR TITLE
host: Change test message timestamp to be stable

### DIFF
--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -880,7 +880,7 @@ module('Integration | operator-mode', function (hooks) {
       room_id: 'testroom',
       state_key: 'state',
       type: 'm.room.message',
-      origin_server_ts: Date.now(),
+      origin_server_ts: new Date(1994, 0, 1, 12, 30).getTime(),
       content: {
         body: 'card with error',
         formatted_body: 'card with error',


### PR DESCRIPTION
This should prevent spurious Percy diffs like this:

![screencast 2024-02-01 13-31-45](https://github.com/cardstack/boxel/assets/43280/b783fd71-19c9-469f-8bc5-deee24dd681d)
