### PR TITLE
Fix background clicking stacked modals issue

### DIFF
--- a/packages/boxel-ui/addon/src/components/modal/index.gts
+++ b/packages/boxel-ui/addon/src/components/modal/index.gts
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 import setBodyClass from 'ember-set-body-class/helpers/set-body-class';
 
 import cssVar from '../../helpers/css-var.ts';
-import { eq } from '../../helpers/truth-helpers.ts';
+import { bool, eq } from '../../helpers/truth-helpers.ts';
 
 interface Signature {
   Args: {
@@ -16,6 +16,7 @@ interface Signature {
     layer?: 'urgent';
     onClose: () => void;
     size?: 'x-small' | 'small' | 'medium' | 'large' | 'full-screen';
+    zIndex?: number;
   };
   Blocks: {
     default: [];
@@ -36,9 +37,13 @@ export default class Modal extends Component<Signature> {
       <div
         style={{cssVar
           boxel-modal-z-index=(if
-            (eq @layer 'urgent')
-            'var(--boxel-layer-modal-urgent)'
-            'var(--boxel-layer-modal-default)'
+            (bool @zIndex)
+            @zIndex
+            (if
+              (eq @layer 'urgent')
+              'var(--boxel-layer-modal-urgent)'
+              'var(--boxel-layer-modal-default)'
+            )
           )
         }}
       >

--- a/packages/host/app/components/modal-container.gts
+++ b/packages/host/app/components/modal-container.gts
@@ -44,6 +44,7 @@ export default class ModalContainer extends Component<Signature> {
       @isOpen={{this.isOpen}}
       @onClose={{@onClose}}
       @centered={{@centered}}
+      @zIndex={{@zIndex}}
       style={{this.styleString}}
       ...attributes
     >

--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -92,7 +92,9 @@ export default class CreateFileModal extends Component<Signature> {
       @onClose={{this.onCancel}}
       {{focusTrap
         isActive=this.onSetup.isIdle
-        focusTrapOptions=(hash initialFocus=this.initialFocusSelector)
+        focusTrapOptions=(hash
+          initialFocus=this.initialFocusSelector allowOutsideClick=true
+        )
       }}
       data-test-ready={{this.onSetup.isIdle}}
       data-test-create-file-modal

--- a/packages/host/app/components/operator-mode/edit-field-modal.gts
+++ b/packages/host/app/components/operator-mode/edit-field-modal.gts
@@ -358,7 +358,9 @@ export default class EditFieldModal extends Component<Signature> {
       @size='medium'
       @centered={{true}}
       {{focusTrap
-        focusTrapOptions=(hash initialFocus='.edit-field-modal input')
+        focusTrapOptions=(hash
+          initialFocus='.edit-field-modal input' allowOutsideClick=true
+        )
       }}
       @cardContainerClass='edit-field'
       class='edit-field-modal'

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -1406,4 +1406,41 @@ module('Acceptance | code submode tests', function (hooks) {
         'can not create new card for linksToMany field in code mode',
       );
   });
+
+  test('closes the top-most modal first when clicking overlay background', async function (assert) {
+    await visitOperatorMode({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}Person/1`,
+            format: 'isolated',
+          },
+        ],
+      ],
+      submode: 'code',
+      codePath: `${testRealmURL}Person/1.json`,
+    });
+
+    await waitFor('[data-test-code-mode][data-test-save-idle]');
+    await waitFor('[data-test-new-file-button]');
+    await click('[data-test-new-file-button]');
+    await click(`[data-test-boxel-menu-item-text="Card Instance"]`);
+    await waitFor(`[data-test-create-file-modal][data-test-ready]`);
+
+    await click('[data-test-select-card-type]');
+    await waitFor('[data-test-card-catalog-modal]');
+    let cardCatalogModalOverlay = document.querySelector(
+      '[data-test-card-catalog-modal]',
+    )?.previousElementSibling;
+    assert.dom(cardCatalogModalOverlay).exists();
+    await click(cardCatalogModalOverlay!);
+    assert.dom('[data-test-card-catalog-modal]').doesNotExist();
+
+    let createFileModalOverlay = document.querySelector(
+      '[data-test-create-file-modal]',
+    )?.previousElementSibling;
+    assert.dom(createFileModalOverlay).exists();
+    await click(createFileModalOverlay!);
+    assert.dom('[data-test-create-file-modal]').doesNotExist();
+  });
 });


### PR DESCRIPTION
Ticket: CS-6541

Previously, when multiple modals were stacked, clicking on the modal background would close the bottom-most modal, contrary to the expected behavior. Here is the screenshot of the fix.



https://github.com/cardstack/boxel/assets/12637010/1e2c5891-1126-4077-825c-eb1f41f018e8



