### PR TITLE
host: Add handling for instance creation failure

### DIFF
--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -210,6 +210,7 @@ export default class CardService extends Service {
       // save has failed. Until that ticket is implemented, the only indication
       // of a failed auto-save will be from the console.
       console.error(`Failed to save ${card.id}: `, err);
+      throw err;
       return;
     } finally {
       api.unsubscribeFromChanges(card, onCardChange);


### PR DESCRIPTION
I expect this to cause failures elsewhere 🧐

The original issue relates to a failure when creating an instance where the card uses `restartableTask` but maybe addressing that should be in a separate PR.