### PR TITLE
Remove rate limits locally

### DIFF
--- a/packages/matrix/docker/synapse/index.ts
+++ b/packages/matrix/docker/synapse/index.ts
@@ -298,6 +298,35 @@ export async function createRegistrationToken(
   }
 }
 
+export async function removeRateLimit(
+  adminUsername: string,
+  adminPassword: string,
+  username: string,
+): Promise<void> {
+  console.log(
+    `Logging in as admin user to remove rate limit for user ${username}`,
+  );
+  let { accessToken } = await loginUser(adminUsername, adminPassword);
+  let response = await fetch(
+    `http://localhost:8008/_synapse/admin/v1/users/@${username}:localhost/override_ratelimit`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({ messages_per_second: 0, burst_count: 0 }),
+    },
+  );
+
+  console.log(
+    `Received: ${response.status}, ${response.statusText}, ${JSON.stringify(
+      await response.json(),
+    )}`,
+  );
+
+  return;
+}
+
 export async function updateUser(
   adminAccessToken: string,
   userId: string,

--- a/packages/matrix/scripts/register-test-user.ts
+++ b/packages/matrix/scripts/register-test-user.ts
@@ -1,6 +1,6 @@
 import * as childProcess from 'child_process';
 
-import { loginUser } from '../docker/synapse';
+import { loginUser, removeRateLimit } from '../docker/synapse';
 
 export const adminUsername = 'admin';
 export const adminPassword = 'password';
@@ -22,6 +22,7 @@ let password = process.env.PASSWORD || adminPassword;
               );
               return;
             } else {
+              await removeRateLimit(adminUsername, adminPassword, username);
               console.log(
                 `User ${username} already exists and the password matches`,
               );
@@ -31,6 +32,7 @@ let password = process.env.PASSWORD || adminPassword;
           }
           reject(err);
         }
+        await removeRateLimit(adminUsername, adminPassword, username);
         console.log(stdout.trim());
         resolve(stdout.trim());
       },


### PR DESCRIPTION
Removes rate limits from newly created and existing users created locally. Safe to run repeatedly.

Run `pnpm register-bot-user` to remove the rate limits for your existing aibot user.