### PR TITLE
host: Fix improper wrapping in file tree

### DIFF
--- a/packages/host/app/components/editor/directory.gts
+++ b/packages/host/app/components/editor/directory.gts
@@ -32,6 +32,7 @@ export default class Directory extends Component<Args> {
           {{#if (eq entry.kind 'file')}}
             <button
               data-test-file={{entryPath}}
+              title={{entry.name}}
               {{on 'click' (fn this.openFile entryPath)}}
               {{scrollIntoViewModifier
                 (fileIsSelected entryPath this.operatorModeStateService)
@@ -49,6 +50,7 @@ export default class Directory extends Component<Args> {
           {{else}}
             <button
               data-test-directory={{entryPath}}
+              title={{entry.name}}
               {{on 'click' (fn this.toggleDirectory entryPath)}}
               class='directory'
             >
@@ -93,6 +95,9 @@ export default class Directory extends Component<Args> {
         padding: var(--boxel-sp-xxxs);
         width: 100%;
         text-align: start;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
 
       .directory:hover,

--- a/packages/host/tests/acceptance/code-submode/file-tree-test.ts
+++ b/packages/host/tests/acceptance/code-submode/file-tree-test.ts
@@ -298,12 +298,14 @@ module('Acceptance | code submode | file-tree tests', function (hooks) {
     await waitFor('[data-test-file]');
     assert
       .dom('[data-test-directory="Person/"]')
-      .exists('Person/ directory entry is rendered');
+      .exists('Person/ directory entry is rendered')
+      .hasAttribute('title', 'Person/');
     assert.dom('[data-test-directory="Person/"] .icon').hasClass('closed');
 
     assert
       .dom('[data-test-file="person.gts"]')
-      .exists('person.gts file entry is rendered');
+      .exists('person.gts file entry is rendered')
+      .hasAttribute('title', 'person.gts');
 
     await click('[data-test-directory="Person/"]');
     assert.dom('[data-test-directory="Person/"] .icon').hasClass('open');


### PR DESCRIPTION
Long entries could wrap in a weird fashion:

![image](https://github.com/cardstack/boxel/assets/43280/8f80ba5f-19b1-4f2f-aabd-76dc5b471950)

Now they don’t wrap and become truncated with an ellipsis, I added a `title` as is the convention so you can still see the full name by hovering.

![screencast 2024-02-07 15-58-45](https://github.com/cardstack/boxel/assets/43280/81a0c0fb-b084-4ca9-99f5-6462ea9538a1)
