### PR TITLE
realm: Add fix for tasks in card definitions

### DIFF
--- a/packages/realm-server/lib/externals.ts
+++ b/packages/realm-server/lib/externals.ts
@@ -80,6 +80,7 @@ export function shimExternals(loader: Loader) {
   // import * as emberConcurrencyAsyncArrowRuntime from 'ember-concurrency/-private/async-arrow-runtime';
   loader.shimModule('ember-concurrency/-private/async-arrow-runtime', {
     default: () => {},
+    buildTask: () => {},
   });
   // import * as emberModifier from 'ember-modifier';
   loader.shimModule('ember-modifier', {


### PR DESCRIPTION
Card definitions that included standard Ember Concurrency exports could not be instantiated, there was an error on the realm server:

![Boxel 2024-02-08 12-59-05](https://github.com/cardstack/boxel/assets/43280/9bd0903c-bcfe-4dc0-8125-5994a66874bd)

The lack of failure indication in the modal is separately addressed in #1016.

The problem was that the card instantiation in the realm server was calling a public Ember Concurrency export that wasn’t properly shimmed. There’s room for DX improvement here to make it clearer when an expected property on an import isn’t found, this is recorded as 6563.

<details>
<summary>Reproduction details</summary>
Make a card definition like this <code>task.gts</code>:

```js
import { CardDef } from 'https://cardstack.com/base/card-api';
import { restartableTask } from 'ember-concurrency';

export class Task extends CardDef {
  static displayName = 'task';

  private task = restartableTask({}, async () => {
    return;
  });
}
```

Add a catalog entry <code>CatalogyEntry/task.json</code>:

```js
{
  "data": {
    "type": "card",
    "attributes": {
      "title": "Task",
      "description": "Catalog entry for Task",
      "ref": {
        "module": "../task",
        "name": "Task"
      },
      "demo": {
        "title": "Jortle"
      }
    },
    "meta": {
      "fields": {
        "demo": {
          "adoptsFrom": {
            "module": "../task",
            "name": "Task"
          }
        }
      },
      "adoptsFrom": {
        "module": "https://cardstack.com/base/catalog-entry",
        "name": "CatalogEntry"
      }
    }
  }
}
```

Then try creating a card instance that adopts from `Task`.
</details>