### PR TITLE
ui: Change rebuild:icons to only target *.svg

### DIFF
--- a/packages/boxel-ui/addon/bin/rebuild-icons.mjs
+++ b/packages/boxel-ui/addon/bin/rebuild-icons.mjs
@@ -21,13 +21,16 @@ const SUFFIX = `
 IconComponent.name = "__ICON_COMPONENT_NAME__";
 export default IconComponent;
 `;
-let componentsToGenerate = fs.readdirSync(srcDir).map((filename) => {
-  return {
-    name: toPascalCase(path.parse(filename).name),
-    sourceFile: filename,
-    outFile: filename.replace('.svg', '.gts'),
-  };
-});
+let componentsToGenerate = fs
+  .readdirSync(srcDir)
+  .filter((filename) => filename.endsWith('.svg'))
+  .map((filename) => {
+    return {
+      name: toPascalCase(path.parse(filename).name),
+      sourceFile: filename,
+      outFile: filename.replace('.svg', '.gts'),
+    };
+  });
 componentsToGenerate.sort((a, b) => a.name.localeCompare(b.name));
 
 for (const c of componentsToGenerate) {


### PR DESCRIPTION
I encountered this when rebuilding icons after adding one:

![addon 2024-02-12 10-57-36](https://github.com/cardstack/boxel/assets/43280/549e4848-2c16-487f-820d-f134c0b778ab)

This changes the script to ignore files that don’t end with `.svg`.