### PR TITLE
AI panel: auto open last chat room

### DIFF
--- a/packages/host/app/components/ai-assistant/button.gts
+++ b/packages/host/app/components/ai-assistant/button.gts
@@ -6,7 +6,11 @@ interface Signature {
 
 export default class AiAssistantButton extends Component<Signature> {
   <template>
-    <button class='ai-assistant-button' data-test-open-ai-panel ...attributes />
+    <button
+      class='ai-assistant-button'
+      data-test-open-ai-assistant
+      ...attributes
+    />
     <style>
       .ai-assistant-button {
         width: var(--container-button-size);

--- a/packages/host/app/components/ai-assistant/button.gts
+++ b/packages/host/app/components/ai-assistant/button.gts
@@ -6,11 +6,7 @@ interface Signature {
 
 export default class AiAssistantButton extends Component<Signature> {
   <template>
-    <button
-      class='ai-assistant-button'
-      data-test-open-ai-assistant
-      ...attributes
-    />
+    <button class='ai-assistant-button' data-test-open-ai-panel ...attributes />
     <style>
       .ai-assistant-button {
         width: var(--container-button-size);

--- a/packages/host/app/components/ai-assistant/panel.gts
+++ b/packages/host/app/components/ai-assistant/panel.gts
@@ -79,7 +79,7 @@ export default class AiAssistantPanel extends Component<Signature> {
             class='close-ai-panel'
             {{on 'click' @onClose}}
             aria-label='Remove'
-            data-test-close-ai-panel
+            data-test-close-ai-assistant
           />
         </header>
         <div class='menu'>

--- a/packages/host/tests/helpers/mock-matrix-service.ts
+++ b/packages/host/tests/helpers/mock-matrix-service.ts
@@ -17,7 +17,7 @@ let cardApi: typeof import('https://cardstack.com/base/card-api');
 
 export type MockMatrixService = MatrixService & {
   cardAPI: typeof cardApi;
-  createAndJoinRoom(roomId: string): Promise<void>;
+  createAndJoinRoom(roomId: string, roomName?: string): Promise<void>;
   lastMessageSent: any;
 };
 
@@ -132,33 +132,34 @@ function generateMockMatrixService(
       await this.profile.load.perform();
     }
 
-    public createAndJoinRoom(roomId: string) {
-      addRoomEvent(this, {
+    async createAndJoinRoom(roomId: string, name?: string) {
+      await addRoomEvent(this, {
         event_id: 'eventname',
         room_id: roomId,
         type: 'm.room.name',
         content: {
-          name: 'test_a',
+          name: name || 'test_a',
         },
       });
 
-      addRoomEvent(this, {
+      await addRoomEvent(this, {
         event_id: 'eventcreate',
         room_id: roomId,
         type: 'm.room.create',
-        origin_server_ts: 0,
+        origin_server_ts: Date.now(),
         content: {
           creator: '@testuser:staging',
           room_version: '0',
         },
       });
 
-      addRoomEvent(this, {
+      await addRoomEvent(this, {
         event_id: 'eventjoin',
         room_id: roomId,
         type: 'm.room.member',
         sender: '@testuser:staging',
         state_key: '@testuser:staging',
+        origin_server_ts: Date.now(),
         content: {
           displayname: 'testuser',
           membership: 'join',

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -976,7 +976,7 @@ module('Integration | operator-mode', function (hooks) {
     await click('[data-test-past-sessions-button]');
     await click('[data-test-enter-room="test room 2"]');
 
-    await click('[data-test-close-ai-panel]');
+    await click('[data-test-close-ai-assistant]');
     await click('[data-test-open-ai-assistant]');
     await waitFor(`[data-room-settled]`);
     assert
@@ -985,7 +985,7 @@ module('Integration | operator-mode', function (hooks) {
         "test room 2 is the most recently selected room and it's opened initially",
       );
 
-    await click('[data-test-close-ai-panel]');
+    await click('[data-test-close-ai-assistant]');
     localStorage.setItem(
       'aiPanelCurrentRoomId',
       "room-id-that-doesn't-exist-and-should-not-break-the-implementation",

--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -35,6 +35,13 @@ export async function openAiAssistant(page: Page) {
   await page.waitForFunction(() =>
     document.querySelector('[data-test-close-ai-assistant]'),
   );
+
+  await page.waitForFunction(
+    () =>
+      document
+        .querySelector('[data-test-room]')
+        ?.getAttribute('data-test-room'),
+  ); // Opening the AI assistant either opens last room or creates one - wait for it to settle
 }
 
 export async function openRoot(page: Page) {
@@ -239,9 +246,13 @@ export async function isInRoom(page: Page, roomName: string) {
 
 export async function deleteRoom(page: Page, roomName: string) {
   await page.locator(`[data-test-past-sessions-button]`).click();
+
+  // Here, past sessions could be rerendered because in one case we're creating a new room when opening an AI panel, so we need to wait for the past sessions to settle
+  await page.waitForTimeout(500);
   await page
     .locator(`[data-test-past-session-options-button="${roomName}"]`)
     .click();
+
   await page.locator(`[data-test-boxel-menu-item-text="Delete"]`).click();
   await page
     .locator(
@@ -367,6 +378,7 @@ export async function assertMessages(
 
 export async function assertRooms(page: Page, rooms: string[]) {
   await page.locator(`[data-test-past-sessions-button]`).click(); // toggle past sessions on
+
   if (rooms && rooms.length > 0) {
     await page.waitForFunction(
       (rooms) =>

--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -31,9 +31,9 @@ export async function toggleOperatorMode(page: Page) {
 }
 
 export async function openAiAssistant(page: Page) {
-  await page.locator('[data-test-open-ai-panel]').click();
+  await page.locator('[data-test-open-ai-assistant]').click();
   await page.waitForFunction(() =>
-    document.querySelector('[data-test-close-ai-panel]'),
+    document.querySelector('[data-test-close-ai-assistant]'),
   );
 }
 

--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -31,7 +31,7 @@ export async function toggleOperatorMode(page: Page) {
 }
 
 export async function openAiAssistant(page: Page) {
-  await page.locator('[data-test-open-ai-assistant]').click();
+  await page.locator('[data-test-open-ai-panel]').click();
   await page.waitForFunction(() =>
     document.querySelector('[data-test-close-ai-panel]'),
   );

--- a/packages/matrix/tests/room-creation.spec.ts
+++ b/packages/matrix/tests/room-creation.spec.ts
@@ -14,15 +14,18 @@ import {
   openRenameMenu,
   reloadAndOpenAiAssistant,
   registerRealmUsers,
+  clearLocalStorage,
 } from '../helpers';
 
 test.describe('Room creation', () => {
   let synapse: SynapseInstance;
-  test.beforeEach(async () => {
+
+  test.beforeEach(async ({ page }) => {
     synapse = await synapseStart();
     await registerRealmUsers(synapse);
     await registerUser(synapse, 'user1', 'pass');
     await registerUser(synapse, 'user2', 'pass');
+    await clearLocalStorage(page);
   });
   test.afterEach(async () => {
     await synapseStop(synapse.synapseId);
@@ -30,31 +33,46 @@ test.describe('Room creation', () => {
 
   test('it can create a room', async ({ page }) => {
     await login(page, 'user1', 'pass');
-    await assertRooms(page, []);
 
-    let name = await createRoom(page);
-    await assertRooms(page, [name]);
+    let room1 = (await page
+      .locator(`[data-test-room]`)
+      .getAttribute('data-test-room')) as string;
+
+    await assertRooms(page, [room1]);
+
+    let room2 = await createRoom(page);
+    await assertRooms(page, [room1, room2]);
 
     await reloadAndOpenAiAssistant(page);
-    await assertRooms(page, [name]);
+    await assertRooms(page, [room1, room2]);
 
     await logout(page);
     await login(page, 'user1', 'pass');
-    await assertRooms(page, [name]);
+    await assertRooms(page, [room1, room2]);
 
     // user2 should not be able to see user1's room
     await logout(page);
     await login(page, 'user2', 'pass');
-    await assertRooms(page, []);
+
+    let room1New = (await page
+      .locator(`[data-test-room]`)
+      .getAttribute('data-test-room')) as string; // Automatically created room
+
+    await assertRooms(page, [room1New]);
   });
 
   test('it can rename a room', async ({ page }) => {
     await login(page, 'user1', 'pass');
-    await assertRooms(page, []);
 
-    let room1 = await createRoom(page);
+    let room1 = (await page
+      .locator(`[data-test-room]`)
+      .getAttribute('data-test-room')) as string;
+
+    await assertRooms(page, [room1]);
+
     let room2 = await createRoom(page);
-    await assertRooms(page, [room1, room2]);
+    let room3 = await createRoom(page);
+    await assertRooms(page, [room1, room2, room3]);
 
     await openRenameMenu(page, room1);
     await expect(page.locator('[data-test-rename-session]')).toHaveCount(1);
@@ -73,26 +91,31 @@ test.describe('Room creation', () => {
 
     await expect(page.locator('[data-test-rename-session]')).toHaveCount(0);
     await expect(page.locator('[data-test-past-sessions]')).toHaveCount(0);
-    await assertRooms(page, [newRoom1, room2]);
+    await assertRooms(page, [newRoom1, room2, room3]);
 
     await openRoom(page, newRoom1);
     await expect(page.locator(`[data-test-room-name]`)).toHaveText(newRoom1);
 
     await reloadAndOpenAiAssistant(page);
-    await assertRooms(page, [newRoom1, room2]);
+    await assertRooms(page, [newRoom1, room2, room3]);
 
     await logout(page);
     await login(page, 'user1', 'pass');
-    await assertRooms(page, [newRoom1, room2]);
+    await assertRooms(page, [newRoom1, room2, room3]);
   });
 
   test('it can cancel renaming a room', async ({ page }) => {
     await login(page, 'user1', 'pass');
-    await assertRooms(page, []);
 
-    let room1 = await createRoom(page);
+    let room1 = (await page
+      .locator(`[data-test-room]`)
+      .getAttribute('data-test-room')) as string;
+
+    await assertRooms(page, [room1]);
+
     let room2 = await createRoom(page);
-    await assertRooms(page, [room1, room2]);
+    let room3 = await createRoom(page);
+    await assertRooms(page, [room1, room2, room3]);
 
     await openRenameMenu(page, room1);
     const newName = 'Room 1';
@@ -103,31 +126,14 @@ test.describe('Room creation', () => {
     await page.locator('[data-test-cancel-name-button]').click();
     await expect(page.locator(`[data-test-past-sessions]`)).toHaveCount(0);
     await expect(page.locator(`[data-test-rename-session]`)).toHaveCount(0);
-    await assertRooms(page, [room1, room2]);
+    await assertRooms(page, [room1, room2, room3]);
 
     await openRenameMenu(page, room1);
     let name = await page.locator('[data-test-name-field]').inputValue();
     expect(name).not.toEqual(newName);
     expect(name).toEqual(room1);
     await expect(page.locator('[data-test-save-name-button]')).toBeDisabled();
-  });
-
-  test('rooms are sorted by join date', async ({ page }) => {
-    await login(page, 'user1', 'pass');
-    let room1 = await createRoom(page);
-    let room2 = await createRoom(page);
-    await assertRooms(page, [room1, room2]);
-
-    await openRenameMenu(page, room1);
-    await page.locator(`[data-test-name-field]`).fill('Room Z');
-    await page.locator('[data-test-save-name-button]').click();
-    await expect(page.locator(`[data-test-past-sessions]`)).toHaveCount(0);
-    await expect(page.locator(`[data-test-rename-session]`)).toHaveCount(0);
-
-    await openRenameMenu(page, room2);
-    await page.locator(`[data-test-name-field]`).fill('Room A');
-    await page.locator('[data-test-save-name-button]').click();
-
-    await assertRooms(page, ['Room Z', 'Room A']);
+    await page.locator('[data-test-cancel-name-button]').click();
+    expect(await page.locator(`[data-test-rename-session]`)).toHaveCount(0);
   });
 });


### PR DESCRIPTION
Memorizes last opened chat room using local storage, and opens it when opening the AI panel. If there is no chat room id found in local storage, then it opens the most recently joined room. 