### PR TITLE
Host and realm use the same logic for authenticating against a realm

### DIFF
--- a/packages/host/app/resources/realm.ts
+++ b/packages/host/app/resources/realm.ts
@@ -69,7 +69,9 @@ export class RealmResource extends Resource<Args> {
   });
 
   private getToken = restartableTask(async (realmURL: URL) => {
+    await this.matrixService.ready;
     let rawToken = await this.matrixService.createRealmSession(realmURL);
+
     if (rawToken) {
       this.token = claimsFromRawToken(rawToken);
       setRealmSession(realmURL, rawToken);

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -26,6 +26,7 @@ import {
 } from '@cardstack/runtime-common/helpers/ai';
 
 import { RealmAuthClient } from '@cardstack/runtime-common/realm-auth-client';
+
 import { Submode } from '@cardstack/host/components/submode-switcher';
 import ENV from '@cardstack/host/config/environment';
 

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -25,6 +25,7 @@ import {
   generatePatchCallSpecification,
 } from '@cardstack/runtime-common/helpers/ai';
 
+import { RealmAuthClient } from '@cardstack/runtime-common/realm-auth-client';
 import { Submode } from '@cardstack/host/components/submode-switcher';
 import ENV from '@cardstack/host/config/environment';
 
@@ -46,10 +47,6 @@ import type CardService from './card-service';
 import type LoaderService from './loader-service';
 
 import type * as MatrixSDK from 'matrix-js-sdk';
-import {
-  RealmAuthClient,
-  RealmAuthMatrixClientInterface,
-} from '@cardstack/runtime-common/realm-auth-client';
 
 const { matrixURL, ownRealmURL } = ENV;
 const AI_BOT_POWER_LEVEL = 50; // this is required to set the room name

--- a/packages/realm-server/tests/auth-client-test.ts
+++ b/packages/realm-server/tests/auth-client-test.ts
@@ -1,9 +1,11 @@
 import { module, test } from 'qunit';
 
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
-import { RealmAuthClient } from '@cardstack/runtime-common/realm-auth-client';
+import {
+  RealmAuthClient,
+  RealmAuthMatrixClientInterface,
+} from '@cardstack/runtime-common/realm-auth-client';
 import jwt from 'jsonwebtoken';
-import { MatrixClient } from '@cardstack/runtime-common/matrix-client';
 
 function createJWT(expiresIn: string | number) {
   return jwt.sign({}, 'secret', { expiresIn });
@@ -13,29 +15,30 @@ module('realm-auth-client', function (assert) {
   let client: RealmAuthClient;
 
   assert.beforeEach(function () {
-    client = new RealmAuthClient(
-      'user',
-      'password',
-      new URL('http://testmatrix.com/'),
-      new URL('http://testrealm.com/'),
-    ) as any;
     let mockMatrixClient = {
-      async login() {
-        return Promise.resolve();
+      isLoggedIn() {
+        return true;
       },
-      async getRooms() {
+      getUserId() {
+        return 'userId';
+      },
+      async getJoinedRooms() {
         return Promise.resolve({ joined_rooms: [] });
       },
       async joinRoom() {
         return Promise.resolve();
       },
-      async sendRoomEvent() {
+      async sendEvent() {
         return Promise.resolve();
       },
-    };
+    } as RealmAuthMatrixClientInterface;
+
+    client = new RealmAuthClient(
+      new URL('http://testrealm.com/'),
+      mockMatrixClient,
+    ) as any;
 
     // [] notation is a hack to make TS happy so we can set private properties with mocks
-    client['matrixClient'] = mockMatrixClient as unknown as MatrixClient;
     client['initiateSessionRequest'] = async function (): Promise<Response> {
       return {
         status: 401,
@@ -80,7 +83,7 @@ module('realm-auth-client', function (assert) {
   });
 
   test('it refreshes the jwt if it expired in the client', async function (assert) {
-    let jwtFromClient = createJWT(Date.now() / 1000 - 1); // Expired 1 second ago
+    let jwtFromClient = createJWT(-1); // Expired 1 second ago
     client['jwt'] = jwtFromClient;
     assert.notEqual(jwtFromClient, await client.getJWT(), 'jwt got refreshed');
   });

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -4,3 +4,4 @@ import './loader-test';
 import './indexing-test';
 import './module-syntax-test';
 import './permissions/permission-checker-test';
+import './auth-client-test';

--- a/packages/runtime-common/matrix-client.ts
+++ b/packages/runtime-common/matrix-client.ts
@@ -13,8 +13,12 @@ export class MatrixClient {
     private password: string,
   ) {}
 
-  get userId() {
+  getUserId() {
     return this.access?.userId;
+  }
+
+  isLoggedIn() {
+    return this.access !== undefined;
   }
 
   private async request(
@@ -72,7 +76,7 @@ export class MatrixClient {
     this.access = { accessToken, deviceId, userId };
   }
 
-  async getRooms() {
+  async getJoinedRooms() {
     let response = await this.request('_matrix/client/v3/joined_rooms');
 
     return (await response.json()) as { joined_rooms: string[] };
@@ -144,7 +148,7 @@ export class MatrixClient {
     return json as T;
   }
 
-  async sendRoomEvent<T>(roomId: string, type: string, content: T) {
+  async sendEvent<T>(roomId: string, type: string, content: T) {
     if (!this.access) {
       throw new Error(`Missing matrix access token`);
     }
@@ -211,6 +215,13 @@ export class MatrixClient {
     } else {
       return json.user_id;
     }
+  }
+
+  async sendMessage(roomId: string, message: string) {
+    return this.sendEvent(roomId, 'm.room.message', {
+      body: message,
+      msgtype: 'm.text',
+    });
   }
 }
 

--- a/packages/runtime-common/realm-auth-client.ts
+++ b/packages/runtime-common/realm-auth-client.ts
@@ -1,27 +1,27 @@
 import { TokenClaims } from './realm';
-import { MatrixClient } from './matrix-client';
 
 // iat - issued at (seconds since epoch)
 // exp - expires at (seconds since epoch)
 export type JWTPayload = TokenClaims & { iat: number; exp: number };
 
+// This auth client is intended to be used in both the host app and the realm node environment, where we use different matrix client implementations (in host we have the official matrix sdk
+// and in realm we have a custom implementation). This interface is used to enforce compatibility between the two implementations for the mechanisms used for getting a JWT token from the realm server.
+export interface RealmAuthMatrixClientInterface {
+  isLoggedIn(): boolean;
+  getUserId(): string | null | undefined;
+  getJoinedRooms(): Promise<{ joined_rooms: string[] }>;
+  joinRoom(room: string): Promise<any>;
+  sendEvent(room: string, type: string, content: any): Promise<any>;
+}
+
 export class RealmAuthClient {
   private realmURL: URL;
   private jwt: string | undefined;
-  private matrixClient: MatrixClient;
+  private matrixClient: RealmAuthMatrixClientInterface;
 
-  constructor(
-    matrixUsername: string,
-    matrixPassword: string,
-    matrixURL: URL,
-    realmURL: URL,
-  ) {
+  constructor(realmURL: URL, matrixClient: RealmAuthMatrixClientInterface) {
+    this.matrixClient = matrixClient;
     this.realmURL = realmURL;
-    this.matrixClient = new MatrixClient(
-      matrixURL,
-      matrixUsername,
-      matrixPassword,
-    );
   }
 
   async getJWT() {
@@ -46,7 +46,11 @@ export class RealmAuthClient {
   }
 
   private async createRealmSession() {
-    await this.matrixClient.login();
+    if (!this.matrixClient.isLoggedIn) {
+      throw new Error(
+        `must be logged in to matrix before a realm session can be created`,
+      );
+    }
 
     let initialResponse = await this.initiateSessionRequest();
 
@@ -65,13 +69,13 @@ export class RealmAuthClient {
 
     let { room, challenge } = initialJSON;
 
-    let rooms = (await this.matrixClient.getRooms()).joined_rooms;
+    let { joined_rooms: rooms } = await this.matrixClient.getJoinedRooms();
 
     if (!rooms.includes(room)) {
       await this.matrixClient.joinRoom(room);
     }
 
-    await this.matrixClient.sendRoomEvent(room, 'm.room.message', {
+    await this.matrixClient.sendEvent(room, 'm.room.message', {
       body: `auth-response: ${challenge}`,
       msgtype: 'm.text',
     });
@@ -96,7 +100,7 @@ export class RealmAuthClient {
         Accept: 'application/json',
       },
       body: JSON.stringify({
-        user: this.matrixClient.userId,
+        user: this.matrixClient.getUserId(),
       }),
     });
   }
@@ -108,7 +112,7 @@ export class RealmAuthClient {
         Accept: 'application/json',
       },
       body: JSON.stringify({
-        user: this.matrixClient.userId,
+        user: this.matrixClient.getUserId(),
         challenge,
       }),
     });

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -635,7 +635,7 @@ export class Realm {
     hash.update(challenge);
     hash.update(this.#realmSecretSeed);
     let hashedChallenge = uint8ArrayToHex(await hash.digest());
-    await this.#matrixClient.sendRoomEvent(roomId, 'm.room.message', {
+    await this.#matrixClient.sendEvent(roomId, 'm.room.message', {
       body: `auth-challenge: ${hashedChallenge}`,
       msgtype: 'm.text',
     });
@@ -687,7 +687,7 @@ export class Realm {
       (m) => {
         return (
           m.type === 'm.room.message' &&
-          m.sender === this.#matrixClient.userId &&
+          m.sender === this.#matrixClient.getUserId() &&
           m.content.body.startsWith('auth-challenge:') &&
           m.origin_server_ts > oneMinuteAgo
         );


### PR DESCRIPTION
This PR consolidates the logic where we use matrix rooms to perform authentication between the 2 parties which results in a JWT.

Before this PR, the logic was performed in two different places but with different code which was essentially doing the same thing. 