### PR TITLE
Realm dropdown shows only readable realms

### DIFF
--- a/packages/host/app/components/realm-dropdown.gts
+++ b/packages/host/app/components/realm-dropdown.gts
@@ -6,6 +6,7 @@ import { MenuItem, cssVar } from '@cardstack/boxel-ui/helpers';
 import { DropdownArrowDown } from '@cardstack/boxel-ui/icons';
 
 import { type RealmInfo, RealmPaths } from '@cardstack/runtime-common';
+
 import ENV from '@cardstack/host/config/environment';
 
 import RealmIcon from './operator-mode/realm-icon';

--- a/packages/host/app/components/realm-dropdown.gts
+++ b/packages/host/app/components/realm-dropdown.gts
@@ -58,7 +58,7 @@ export default class RealmDropdown extends Component<Signature> {
               @realmIconURL={{this.selectedRealm.iconURL}}
               @realmName={{this.selectedRealm.name}}
             />
-            <div class='selected-item'>
+            <div class='selected-item' data-test-selected-realm>
               {{this.selectedRealm.name}}
             </div>
           {{else}}

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -93,7 +93,7 @@ export class Search extends Resource<Args> {
     this._instances = flatMap(
       await Promise.all(
         // use a Set since the default URL may actually be the base realm
-        this.realmsToSearch.map(
+        [...new Set(this.realmsToSearch)].map(
           async (realm) => await this.cardService.search(query, new URL(realm)),
         ),
       ),

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -92,8 +92,7 @@ export class Search extends Resource<Args> {
   private search = restartableTask(async (query: Query) => {
     this._instances = flatMap(
       await Promise.all(
-        // use a Set since the default URL may actually be the base realm
-        [...new Set(this.realmsToSearch)].map(
+        this.realmsToSearch.map(
           async (realm) => await this.cardService.search(query, new URL(realm)),
         ),
       ),

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -246,7 +246,11 @@ export default class MatrixService extends Service {
       return inflightAuth;
     }
 
-    let realmAuthClient = new RealmAuthClient(realmURL, this.client);
+    let realmAuthClient = new RealmAuthClient(
+      realmURL,
+      this.client,
+      this.loaderService.loader,
+    );
 
     let jwtPromise = realmAuthClient.getJWT();
 

--- a/packages/host/app/services/realm-info-service.ts
+++ b/packages/host/app/services/realm-info-service.ts
@@ -107,14 +107,16 @@ export default class RealmInfoService extends Service {
 
         let realmInfo = (await realmInfoResponse.json())?.data
           ?.attributes as RealmInfo;
-        let realmSession = getRealmSession(this, {
-          realmURL: () => new URL(realmURLString!),
-        });
-        await realmSession.loaded;
+        // let realmSession = getRealmSession(this, {
+        //   realmURL: () => new URL(realmURLString!),
+        // });
+        // await realmSession.loaded;
         this.cachedRealmInfos.set(realmURLString, {
           ...realmInfo,
-          canRead: !!realmSession.canRead,
-          canWrite: !!realmSession.canWrite,
+          // canRead: !!realmSession.canRead,
+          // canWrite: !!realmSession.canWrite,
+          canRead: true,
+          canWrite: true,
         });
         return realmInfo;
       }

--- a/packages/host/app/services/realm-info-service.ts
+++ b/packages/host/app/services/realm-info-service.ts
@@ -107,16 +107,14 @@ export default class RealmInfoService extends Service {
 
         let realmInfo = (await realmInfoResponse.json())?.data
           ?.attributes as RealmInfo;
-        // let realmSession = getRealmSession(this, {
-        //   realmURL: () => new URL(realmURLString!),
-        // });
-        // await realmSession.loaded;
+        let realmSession = getRealmSession(this, {
+          realmURL: () => new URL(realmURLString!),
+        });
+        await realmSession.loaded;
         this.cachedRealmInfos.set(realmURLString, {
           ...realmInfo,
-          // canRead: !!realmSession.canRead,
-          // canWrite: !!realmSession.canWrite,
-          canRead: true,
-          canWrite: true,
+          canRead: !!realmSession.canRead,
+          canWrite: !!realmSession.canWrite,
         });
         return realmInfo;
       }

--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -1,6 +1,10 @@
 'use strict';
 
 module.exports = function (environment) {
+  const ownRealmURL =
+    environment === 'test'
+      ? 'http://test-realm/test/'
+      : process.env.OWN_REALM_URL || 'http://localhost:4200/'; // this should be provided as an *unresolved* URL
   const ENV = {
     modulePrefix: '@cardstack/host',
     environment,
@@ -34,10 +38,7 @@ module.exports = function (environment) {
     minSaveTaskDurationMs: 1000,
 
     // the fields below may be rewritten by the realm server
-    ownRealmURL:
-      environment === 'test'
-        ? 'http://test-realm/test/'
-        : process.env.OWN_REALM_URL || 'http://localhost:4200/', // this should be provided as an *unresolved* URL
+    ownRealmURL,
     // This is temporary until we have a better way to discover realms besides
     // our own
     otherRealmURLs: process.env.OTHER_REALM_URLS

--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -1,10 +1,6 @@
 'use strict';
 
 module.exports = function (environment) {
-  const ownRealmURL =
-    environment === 'test'
-      ? 'http://test-realm/test/'
-      : process.env.OWN_REALM_URL || 'http://localhost:4200/'; // this should be provided as an *unresolved* URL
   const ENV = {
     modulePrefix: '@cardstack/host',
     environment,
@@ -38,15 +34,15 @@ module.exports = function (environment) {
     minSaveTaskDurationMs: 1000,
 
     // the fields below may be rewritten by the realm server
-    ownRealmURL,
+    ownRealmURL:
+      environment === 'test'
+        ? 'http://test-realm/test/'
+        : process.env.OWN_REALM_URL || 'http://localhost:4200/', // this should be provided as an *unresolved* URL
     // This is temporary until we have a better way to discover realms besides
     // our own
-    otherRealmURLs: [
-      ownRealmURL,
-      ...(process.env.OTHER_REALM_URLS
-        ? process.env.OTHER_REALM_URLS.split(',').map((u) => u.trim())
-        : []),
-    ],
+    otherRealmURLs: process.env.OTHER_REALM_URLS
+      ? process.env.OTHER_REALM_URLS.split(',').map((u) => u.trim())
+      : [],
     hostsOwnAssets: true,
     resolvedBaseRealmURL:
       process.env.RESOLVED_BASE_REALM_URL || 'http://localhost:4201/base/',

--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -41,9 +41,12 @@ module.exports = function (environment) {
     ownRealmURL,
     // This is temporary until we have a better way to discover realms besides
     // our own
-    otherRealmURLs: process.env.OTHER_REALM_URLS
-      ? process.env.OTHER_REALM_URLS.split(',').map((u) => u.trim())
-      : [],
+    otherRealmURLs: [
+      ownRealmURL,
+      ...(process.env.OTHER_REALM_URLS
+        ? process.env.OTHER_REALM_URLS.split(',').map((u) => u.trim())
+        : []),
+    ],
     hostsOwnAssets: true,
     resolvedBaseRealmURL:
       process.env.RESOLVED_BASE_REALM_URL || 'http://localhost:4201/base/',

--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -43,7 +43,7 @@ module.exports = function (environment) {
     // our own
     otherRealmURLs: [
       ownRealmURL,
-      ...(environment !== 'test' && process.env.OTHER_REALM_URLS
+      ...(process.env.OTHER_REALM_URLS
         ? process.env.OTHER_REALM_URLS.split(',').map((u) => u.trim())
         : []),
     ],

--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -42,7 +42,7 @@ module.exports = function (environment) {
     // This is temporary until we have a better way to discover realms besides
     // our own
     otherRealmURLs: [
-      // ownRealmURL,
+      ownRealmURL,
       ...(process.env.OTHER_REALM_URLS
         ? process.env.OTHER_REALM_URLS.split(',').map((u) => u.trim())
         : []),

--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -43,7 +43,7 @@ module.exports = function (environment) {
     // our own
     otherRealmURLs: [
       ownRealmURL,
-      ...(process.env.OTHER_REALM_URLS
+      ...(environment !== 'test' && process.env.OTHER_REALM_URLS
         ? process.env.OTHER_REALM_URLS.split(',').map((u) => u.trim())
         : []),
     ],

--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -1,10 +1,6 @@
 'use strict';
 
 module.exports = function (environment) {
-  const ownRealmURL =
-    environment === 'test'
-      ? 'http://test-realm/test/'
-      : process.env.OWN_REALM_URL || 'http://localhost:4200/'; // this should be provided as an *unresolved* URL
   const ENV = {
     modulePrefix: '@cardstack/host',
     environment,
@@ -38,15 +34,16 @@ module.exports = function (environment) {
     minSaveTaskDurationMs: 1000,
 
     // the fields below may be rewritten by the realm server
-    ownRealmURL,
+    ownRealmURL:
+      environment === 'test'
+        ? 'http://test-realm/test/'
+        : process.env.OWN_REALM_URL || 'http://localhost:4200/', // this should be provided as an *unresolved* URL
     // This is temporary until we have a better way to discover realms besides
     // our own
-    otherRealmURLs: [
-      ownRealmURL,
-      ...(process.env.OTHER_REALM_URLS
+    otherRealmURLs:
+      environment !== 'test' && process.env.OTHER_REALM_URLS
         ? process.env.OTHER_REALM_URLS.split(',').map((u) => u.trim())
-        : []),
-    ],
+        : [],
     hostsOwnAssets: true,
     resolvedBaseRealmURL:
       process.env.RESOLVED_BASE_REALM_URL || 'http://localhost:4201/base/',

--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -42,7 +42,7 @@ module.exports = function (environment) {
     // This is temporary until we have a better way to discover realms besides
     // our own
     otherRealmURLs: [
-      ownRealmURL,
+      // ownRealmURL,
       ...(process.env.OTHER_REALM_URLS
         ? process.env.OTHER_REALM_URLS.split(',').map((u) => u.trim())
         : []),

--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -1,6 +1,10 @@
 'use strict';
 
 module.exports = function (environment) {
+  const ownRealmURL =
+    environment === 'test'
+      ? 'http://test-realm/test/'
+      : process.env.OWN_REALM_URL || 'http://localhost:4200/'; // this should be provided as an *unresolved* URL
   const ENV = {
     modulePrefix: '@cardstack/host',
     environment,
@@ -34,15 +38,15 @@ module.exports = function (environment) {
     minSaveTaskDurationMs: 1000,
 
     // the fields below may be rewritten by the realm server
-    ownRealmURL:
-      environment === 'test'
-        ? 'http://test-realm/test/'
-        : process.env.OWN_REALM_URL || 'http://localhost:4200/', // this should be provided as an *unresolved* URL
+    ownRealmURL,
     // This is temporary until we have a better way to discover realms besides
     // our own
-    otherRealmURLs: process.env.OTHER_REALM_URLS
-      ? process.env.OTHER_REALM_URLS.split(',').map((u) => u.trim())
-      : [],
+    otherRealmURLs: [
+      ownRealmURL,
+      ...(process.env.OTHER_REALM_URLS
+        ? process.env.OTHER_REALM_URLS.split(',').map((u) => u.trim())
+        : []),
+    ],
     hostsOwnAssets: true,
     resolvedBaseRealmURL:
       process.env.RESOLVED_BASE_REALM_URL || 'http://localhost:4201/base/',

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -1,3 +1,4 @@
+import type Owner from '@ember/owner';
 import { click, fillIn, waitFor } from '@ember/test-helpers';
 
 import { setupApplicationTest } from 'ember-qunit';
@@ -9,7 +10,6 @@ import { baseRealm, Deferred } from '@cardstack/runtime-common';
 
 import type LoaderService from '@cardstack/host/services/loader-service';
 import type RealmInfoService from '@cardstack/host/services/realm-info-service';
-import type Owner from '@ember/owner';
 
 import {
   percySnapshot,

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -1186,7 +1186,7 @@ export class TestCard extends CardDef {
           .split('\n');
         assert.deepEqual(
           menuItems,
-          ['Published Workspace', 'Test Workspace A'], // TODO remove "Published Workspace" after default realm persmissions are no longer wide open
+          ['Test Workspace A'],
           'the realm dropdown list is correct',
         );
       }
@@ -1249,7 +1249,7 @@ export class TestCard extends CardDef {
         );
         assert
           .dom('[data-test-selected-realm]')
-          .containsText('Published Workspace'); // TODO change this to "Test Workspace B" after default realm permissions are no longer wide open
+          .containsText('Test Workspace B');
         let menuItems = document
           .querySelector('[data-test-realm-dropdown-menu]')!
           .textContent!.replace(/^\s*/gm, '')
@@ -1257,7 +1257,7 @@ export class TestCard extends CardDef {
           .split('\n');
         assert.deepEqual(
           menuItems,
-          ['Published Workspace', 'Test Workspace B'], // TODO remove "Published Workspace" after default realm persmissions are no longer wide open
+          ['Test Workspace B'],
           'the realm dropdown list is correct',
         );
       }
@@ -1272,14 +1272,14 @@ export class TestCard extends CardDef {
 
       test('read only realm is not present in realm drop down when creating card definition', async function (assert) {
         await visitOperatorMode(this.owner);
-        await openNewFileModal('Card Definition', 'Published Workspace'); // TODO change this to "Test Workspace B" after default realm permissions are no longer wide open
+        await openNewFileModal('Card Definition', 'Test Workspace B');
         await waitFor(`[data-test-selected-type="General Card"]`);
         await assertRealmDropDownIsCorrect(assert);
       });
 
       test('read only realm is not present in realm drop down when creating card instance', async function (assert) {
         await visitOperatorMode(this.owner);
-        await openNewFileModal('Card Instance', 'Published Workspace'); // TODO change this to "Test Workspace B" after default realm permissions are no longer wide open
+        await openNewFileModal('Card Instance', 'Test Workspace B');
         await waitFor(`[data-test-selected-type="General Card"]`);
         await assertRealmDropDownIsCorrect(assert);
       });

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -64,7 +64,7 @@ const files: Record<string, any> = {
     import { contains, linksTo, field, CardDef, Component } from "https://cardstack.com/base/card-api";
     import StringField from "https://cardstack.com/base/string";
 
-    export class Pet extends CardDef {
+    export default class Pet extends CardDef {
       static displayName = 'Pet';
       @field name = contains(StringField);
 
@@ -78,7 +78,7 @@ const files: Record<string, any> = {
   'person.gts': `
     import { contains, linksTo, field, CardDef } from "https://cardstack.com/base/card-api";
     import StringField from "https://cardstack.com/base/string";
-    import { Pet } from "./pet";
+    import Pet from "./pet";
 
     export class Person extends CardDef {
       static displayName = 'Person';
@@ -149,7 +149,7 @@ const files: Record<string, any> = {
       meta: {
         adoptsFrom: {
           module: `../pet`,
-          name: 'Pet',
+          name: 'default',
         },
       },
     },

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -78,7 +78,7 @@ const files: Record<string, any> = {
   'person.gts': `
     import { contains, linksTo, field, CardDef } from "https://cardstack.com/base/card-api";
     import StringField from "https://cardstack.com/base/string";
-    import Pet from "./pet";
+    import { Pet } from "./pet";
 
     export class Person extends CardDef {
       static displayName = 'Person';

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -395,9 +395,7 @@ const localInheritSource = `
   }
 `;
 
-let realmPermissions: { [realmURL: string]: ('read' | 'write')[] } = {
-  [testRealmURL]: ['read', 'write'],
-};
+let realmPermissions: { [realmURL: string]: ('read' | 'write')[] } = {};
 
 module('Acceptance | code submode | inspector tests', function (hooks) {
   let realm: Realm;

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -43,9 +43,7 @@ import {
 import { setupMatrixServiceMock } from '../helpers/mock-matrix-service';
 
 const testRealm2URL = `http://test-realm/test2/`;
-let realmPermissions: { [realmURL: string]: ('read' | 'write')[] } = {
-  [testRealmURL]: ['read', 'write'],
-};
+let realmPermissions: { [realmURL: string]: ('read' | 'write')[] } = {};
 
 module('Acceptance | interact submode tests', function (hooks) {
   let realm: Realm;

--- a/packages/matrix/playwright.config.ts
+++ b/packages/matrix/playwright.config.ts
@@ -51,6 +51,6 @@ export default defineConfig({
 
   // For expect calls
   expect: {
-    timeout: 30000,
+    timeout: 60000,
   },
 });

--- a/packages/matrix/playwright.config.ts
+++ b/packages/matrix/playwright.config.ts
@@ -47,7 +47,7 @@ export default defineConfig({
     },
   ],
   // General timeout per test
-  timeout: 30000,
+  timeout: 120000,
 
   // For expect calls
   expect: {

--- a/packages/matrix/playwright.config.ts
+++ b/packages/matrix/playwright.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   testDir: './tests',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 1 : 0,
   workers: 1,
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
@@ -45,10 +45,10 @@ export default defineConfig({
     },
   ],
   // General timeout per test
-  timeout: 120000,
+  timeout: 30000,
 
   // For expect calls
   expect: {
-    timeout: 60000,
+    timeout: 30000,
   },
 });

--- a/packages/matrix/playwright.config.ts
+++ b/packages/matrix/playwright.config.ts
@@ -12,7 +12,9 @@ let group2 = tests.slice(middle);
 export default defineConfig({
   testDir: './tests',
   fullyParallel: true,
-  forbidOnly: !!process.env.CI,
+  // forbidOnly: !!process.env.CI,
+  // TODO remove this!
+  forbidOnly: false,
   retries: process.env.CI ? 1 : 0,
   workers: 1,
   reporter: 'html',

--- a/packages/matrix/playwright.config.ts
+++ b/packages/matrix/playwright.config.ts
@@ -51,6 +51,6 @@ export default defineConfig({
 
   // For expect calls
   expect: {
-    timeout: 60000,
+    timeout: 30000,
   },
 });

--- a/packages/matrix/playwright.config.ts
+++ b/packages/matrix/playwright.config.ts
@@ -12,10 +12,8 @@ let group2 = tests.slice(middle);
 export default defineConfig({
   testDir: './tests',
   fullyParallel: true,
-  // forbidOnly: !!process.env.CI,
-  // TODO remove this!
-  forbidOnly: false,
-  retries: process.env.CI ? 1 : 0,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
   workers: 1,
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
@@ -51,6 +49,6 @@ export default defineConfig({
 
   // For expect calls
   expect: {
-    timeout: 30000,
+    timeout: 60000,
   },
 });

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -133,6 +133,7 @@ test.describe('Room messages', () => {
     await createRoom(page);
 
     await page.locator('[data-test-choose-card-btn]').click();
+    await expect(page.locator(`[data-test-card-catalog]`)).toHaveCount(1); // this triggers a wait for this element
     await expect(page.locator(`[data-test-select="${testCard}"]`)).toHaveCount(
       1,
     ); // this triggers a wait for this element

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -133,7 +133,11 @@ test.describe('Room messages', () => {
     await createRoom(page);
 
     await page.locator('[data-test-choose-card-btn]').click();
-    await expect(page.locator(`[data-test-card-catalog]`)).toHaveCount(1); // this triggers a wait for this element
+    await expect(
+      page.locator(
+        `[data-test-card-catalog] [data-test-realm="Test Workspace A"]`,
+      ),
+    ).toHaveCount(1); // this triggers a wait for this element
     await expect(page.locator(`[data-test-select="${testCard}"]`)).toHaveCount(
       1,
     ); // this triggers a wait for this element

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -128,13 +128,6 @@ test.describe('Room messages', () => {
 
   // TODO remove this!!
   test.only('can add a card to a markdown message', async ({ page }) => {
-    // from https://github.com/microsoft/playwright/issues/13090 if you are
-    // encountering "target closed" errors on .click() in GH actions but not
-    // locally, using `test.slow()` can work around the issue. which appears to
-    // be that the test takes longer than the global timeout. All the tests that
-    // are selecting a card from the catalog seems to be encountering this.
-    // test.slow();
-
     const testCard = `${testHost}/hassan`;
     await login(page, 'user1', 'pass');
     await createRoom(page);

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -128,6 +128,7 @@ test.describe('Room messages', () => {
 
   // TODO remove this!!
   test.only('can add a card to a markdown message', async ({ page }) => {
+    test.slow();
     const testCard = `${testHost}/hassan`;
     await login(page, 'user1', 'pass');
     await createRoom(page);

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -126,8 +126,7 @@ test.describe('Room messages', () => {
     ).toHaveValue('room 2 message');
   });
 
-  // TODO remove this!!
-  test.only('can add a card to a markdown message', async ({ page }) => {
+  test('can add a card to a markdown message', async ({ page }) => {
     const testCard = `${testHost}/hassan`;
     await login(page, 'user1', 'pass');
     await createRoom(page);

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -133,14 +133,6 @@ test.describe('Room messages', () => {
     await createRoom(page);
 
     await page.locator('[data-test-choose-card-btn]').click();
-    await expect(
-      page.locator(
-        `[data-test-card-catalog] [data-test-realm="Test Workspace A"]`,
-      ),
-    ).toHaveCount(1); // this triggers a wait for this element
-    await expect(page.locator(`[data-test-select="${testCard}"]`)).toHaveCount(
-      1,
-    ); // this triggers a wait for this element
     await page.locator(`[data-test-select="${testCard}"]`).click();
     await page.locator('[data-test-card-catalog-go-button]').click();
     await expect(

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -126,7 +126,8 @@ test.describe('Room messages', () => {
     ).toHaveValue('room 2 message');
   });
 
-  test('can add a card to a markdown message', async ({ page }) => {
+  // TODO remove this!!
+  test.only('can add a card to a markdown message', async ({ page }) => {
     const testCard = `${testHost}/hassan`;
     await login(page, 'user1', 'pass');
     await createRoom(page);
@@ -326,7 +327,9 @@ test.describe('Room messages', () => {
     ]);
   });
 
-  test('displays view all pill if attached card more than 4', async ({ page }) => {
+  test('displays view all pill if attached card more than 4', async ({
+    page,
+  }) => {
     const testCard1 = `${testHost}/hassan`;
     const testCard2 = `${testHost}/mango`;
     const testCard3 = `${testHost}/type-examples`;

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -128,12 +128,21 @@ test.describe('Room messages', () => {
 
   // TODO remove this!!
   test.only('can add a card to a markdown message', async ({ page }) => {
-    test.slow();
+    // from https://github.com/microsoft/playwright/issues/13090 if you are
+    // encountering "target closed" errors on .click() in GH actions but not
+    // locally, using `test.slow()` can work around the issue. which appears to
+    // be that the test takes longer than the global timeout. All the tests that
+    // are selecting a card from the catalog seems to be encountering this.
+    // test.slow();
+
     const testCard = `${testHost}/hassan`;
     await login(page, 'user1', 'pass');
     await createRoom(page);
 
     await page.locator('[data-test-choose-card-btn]').click();
+    await expect(page.locator(`[data-test-select="${testCard}"]`)).toHaveCount(
+      1,
+    ); // this triggers a wait for this element
     await page.locator(`[data-test-select="${testCard}"]`).click();
     await page.locator('[data-test-card-catalog-go-button]').click();
     await expect(

--- a/packages/realm-server/.realms.json.development
+++ b/packages/realm-server/.realms.json.development
@@ -16,7 +16,7 @@
   },
   "https://cardstack.com/base/": {
     "users": {
-      "*": ["read", "write"]
+      "*": ["read"]
     }
   }
 }

--- a/packages/realm-server/.realms.json.test
+++ b/packages/realm-server/.realms.json.test
@@ -1,7 +1,7 @@
 {
   "https://cardstack.com/base/": {
     "users": {
-      "*": ["read", "write"]
+      "*": ["read"]
     }
   },
   "http://localhost:4202/node-test/": {

--- a/packages/realm-server/tests/auth-client-test.ts
+++ b/packages/realm-server/tests/auth-client-test.ts
@@ -3,8 +3,9 @@ import { module, test } from 'qunit';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 import {
   RealmAuthClient,
-  RealmAuthMatrixClientInterface,
+  type RealmAuthMatrixClientInterface,
 } from '@cardstack/runtime-common/realm-auth-client';
+import { Loader } from '@cardstack/runtime-common';
 import jwt from 'jsonwebtoken';
 
 function createJWT(expiresIn: string | number) {
@@ -32,10 +33,12 @@ module('realm-auth-client', function (assert) {
         return Promise.resolve();
       },
     } as RealmAuthMatrixClientInterface;
+    let loader = new Loader();
 
     client = new RealmAuthClient(
       new URL('http://testrealm.com/'),
       mockMatrixClient,
+      loader,
     ) as any;
 
     // [] notation is a hack to make TS happy so we can set private properties with mocks

--- a/packages/runtime-common/realm-auth-client.ts
+++ b/packages/runtime-common/realm-auth-client.ts
@@ -1,4 +1,5 @@
 import { TokenClaims } from './realm';
+import { type Loader } from './loader';
 
 // iat - issued at (seconds since epoch)
 // exp - expires at (seconds since epoch)
@@ -15,14 +16,13 @@ export interface RealmAuthMatrixClientInterface {
 }
 
 export class RealmAuthClient {
-  private realmURL: URL;
   private jwt: string | undefined;
-  private matrixClient: RealmAuthMatrixClientInterface;
 
-  constructor(realmURL: URL, matrixClient: RealmAuthMatrixClientInterface) {
-    this.matrixClient = matrixClient;
-    this.realmURL = realmURL;
-  }
+  constructor(
+    private realmURL: URL,
+    private matrixClient: RealmAuthMatrixClientInterface,
+    private loader: Loader,
+  ) {}
 
   async getJWT() {
     let tokenRefreshLeadTimeSeconds = 60;
@@ -94,7 +94,7 @@ export class RealmAuthClient {
   }
 
   private async initiateSessionRequest() {
-    return fetch(`${this.realmURL.href}_session`, {
+    return this.loader.fetch(`${this.realmURL.href}_session`, {
       method: 'POST',
       headers: {
         Accept: 'application/json',
@@ -106,7 +106,7 @@ export class RealmAuthClient {
   }
 
   private async challengeRequest(challenge: string) {
-    return fetch(`${this.realmURL.href}_session`, {
+    return this.loader.fetch(`${this.realmURL.href}_session`, {
       method: 'POST',
       headers: {
         Accept: 'application/json',


### PR DESCRIPTION
In this PR we make the base realm a read-only realm. The realm drop down is updated to only show writable realms. We also provide a default realm menu item fallbacks for the case when the current realm is a read-only realm.

TODO:
- [x] tests
- [x] update staging to make base realm read-only
- [x] update production to make base realm read-only