### PR TITLE
host: Add focus on search on add card button click

### DIFF
--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -62,7 +62,7 @@ export default class SubmodeLayout extends Component<Signature> {
   @service private declare operatorModeStateService: OperatorModeStateService;
   @service declare matrixService: MatrixService;
 
-  private searchElement: Element | null = null;
+  private searchElement: HTMLElement | null = null;
 
   private get aiAssistantVisibilityClass() {
     return this.isAiAssistantVisible
@@ -146,7 +146,7 @@ export default class SubmodeLayout extends Component<Signature> {
   }
 
   @action
-  private storeSearchElement(element: Element) {
+  private storeSearchElement(element: HTMLElement) {
     this.searchElement = element;
   }
 

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -62,6 +62,8 @@ export default class SubmodeLayout extends Component<Signature> {
   @service private declare operatorModeStateService: OperatorModeStateService;
   @service declare matrixService: MatrixService;
 
+  private searchElement: Element | null = null;
+
   private get aiAssistantVisibilityClass() {
     return this.isAiAssistantVisible
       ? 'ai-assistant-open'
@@ -118,6 +120,7 @@ export default class SubmodeLayout extends Component<Signature> {
       this.searchSheetMode = SearchSheetModes.SearchPrompt;
     }
 
+    this.searchElement?.focus();
     this.args.onSearchSheetOpened?.();
   }
 
@@ -140,6 +143,11 @@ export default class SubmodeLayout extends Component<Signature> {
   private onListPanelContextChange(listPanelContext: PanelContext[]) {
     this.panelWidths.submodePanel = listPanelContext[0]?.lengthPx;
     this.panelWidths.aiAssistantPanel = listPanelContext[1]?.lengthPx;
+  }
+
+  @action
+  private storeSearchElement(element: Element) {
+    this.searchElement = element;
   }
 
   <template>
@@ -221,6 +229,7 @@ export default class SubmodeLayout extends Component<Signature> {
       @onFocus={{this.openSearchSheetToPrompt}}
       @onSearch={{this.expandSearchToShowResults}}
       @onCardSelect={{this.handleCardSelectFromSearch}}
+      @onInputInsertion={{this.storeSearchElement}}
     />
 
     <style>

--- a/packages/host/app/components/search-sheet/index.gts
+++ b/packages/host/app/components/search-sheet/index.gts
@@ -60,15 +60,15 @@ interface Signature {
     onBlur: () => void;
     onSearch: (term: string) => void;
     onCardSelect: (card: CardDef) => void;
-    onInputInsertion?: (element: Element) => void;
+    onInputInsertion?: (element: HTMLElement) => void;
   };
   Blocks: {};
 }
 
 let elementCallback = modifier(
-  (element, [callback]: [((element: Element) => void) | undefined]) => {
+  (element, [callback]: [((element: HTMLElement) => void) | undefined]) => {
     if (callback) {
-      callback(element);
+      callback(element as HTMLElement);
     }
   },
 );

--- a/packages/host/app/components/search-sheet/index.gts
+++ b/packages/host/app/components/search-sheet/index.gts
@@ -9,6 +9,7 @@ import { cached, tracked } from '@glimmer/tracking';
 
 import onClickOutside from 'ember-click-outside/modifiers/on-click-outside';
 import { restartableTask } from 'ember-concurrency';
+import { modifier } from 'ember-modifier';
 
 import debounce from 'lodash/debounce';
 
@@ -59,9 +60,18 @@ interface Signature {
     onBlur: () => void;
     onSearch: (term: string) => void;
     onCardSelect: (card: CardDef) => void;
+    onInputInsertion?: (element: Element) => void;
   };
   Blocks: {};
 }
+
+let elementCallback = modifier(
+  (element, [callback]: [((element: Element) => void) | undefined]) => {
+    if (callback) {
+      callback(element);
+    }
+  },
+);
 
 export default class SearchSheet extends Component<Signature> {
   @tracked searchKey = '';
@@ -299,6 +309,7 @@ export default class SearchSheet extends Component<Signature> {
         @placeholder={{this.placeholderText}}
         @onFocus={{@onFocus}}
         @onInput={{this.setSearchKey}}
+        {{elementCallback @onInputInsertion}}
         {{on 'keydown' this.onSearchInputKeyDown}}
         class='search-sheet__search-input-group'
         data-test-search-field

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -619,6 +619,7 @@ module('Acceptance | interact submode tests', function (hooks) {
       // Add a card to the left stack
       await click('[data-test-add-card-left-stack]');
 
+      assert.dom('[data-test-search-field]').isFocused();
       assert.dom('[data-test-search-sheet]').hasClass('prompt'); // Search opened
 
       await click(`[data-test-search-result="${testRealmURL}Pet/mango"]`);


### PR DESCRIPTION
Previously clicking the add card buttons in interact mode would open the search but not focus it.

![screencast 2024-02-16 17-26-36](https://github.com/cardstack/boxel/assets/43280/b38c2b0f-a656-4996-8bad-b34e657c146e)

I don’t love this implementation, I’m open to suggestions for improvement! `autofocus` doesn’t work when the element is already in the DOM.