### PR TITLE
Remove error icon, so file extensions won't be covered 

### DIFF
--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -205,6 +205,9 @@ export default class OperatorModeContainer extends Component<Signature> {
       :global(.operator-mode .boxel-modal__inner) {
         display: block;
       }
+      :global(.input-container .invalid + .validation-icon-container) {
+        display: none;
+      }
       .operator-mode {
         min-width: var(--operator-mode-min-width);
       }


### PR DESCRIPTION
Based on this error states design https://app.zeplin.io/project/652ea0fee5ade422add72a63/screen/656a47310f3cc3690168fcbb, so I removed the error icon.

<img width="669" alt="Screenshot 2024-02-19 at 10 50 18" src="https://github.com/cardstack/boxel/assets/12637010/0b0da4f6-9a4a-4b49-af40-4d3d89f086cc">
