### PR TITLE
Fix empty past session list

### DIFF
--- a/packages/host/app/components/ai-assistant/panel.gts
+++ b/packages/host/app/components/ai-assistant/panel.gts
@@ -310,7 +310,8 @@ export default class AiAssistantPanel extends Component<Signature> {
       }
       let { room } = resource;
       if (
-        room.invitedMembers.find((m) => aiBotUserId === m.userId) &&
+        (room.invitedMembers.find((m) => aiBotUserId === m.userId) ||
+          room.joinedMembers.find((m) => aiBotUserId === m.userId)) &&
         room.joinedMembers.find((m) => this.matrixService.userId === m.userId)
       ) {
         rooms.push(room);


### PR DESCRIPTION
Matrix state events replace old ones, and all can exist in the timeline.

IIUC the server is free to remove replaced events, particularly state events. This means that the invite event goes away and the joined one replaces it. So the check was failing before as it checked that the aibot was invited and the user joined, which failed when the event said the aibot had joined, with an event that replaced the invitation

Example event:

{
"type": "m.room.member",
"room_id": "!WoarPdNdmXjTbRiBkB:localhost",
"sender": "@aibot:localhost",
"content": {
    "membership": "join",
    "displayname": "aibot"
},
"state_key": "@aibot:localhost",
"origin_server_ts": 1705499375499,
"unsigned": {
    "replaces_state": "$asDvfrMGGkmWL9CO-LjsIsyhtb_8NxQQwxUgsPRJUyo",
    "prev_content": {
        "membership": "invite",
        "displayname": "aibot"
    },
    "prev_sender": "@ian:localhost",
    "age": 2947604562
},
"event_id": "$epC8gggcfRHaZEk9Ohjc79VwIJ6r03bZ9RMSoD4ZsFw", "user_id": "@aibot:localhost",
"age": 2947604562,
"replaces_state": "$asDvfrMGGkmWL9CO-LjsIsyhtb_8NxQQwxUgsPRJUyo", "prev_content": {
    "membership": "invite",
    "displayname": "aibot"
}
}

Unsure how to create a test for this.