### PR TITLE
host: Fix deployed read-only code mode tooltips

### DIFF
--- a/packages/host/app/styles/app.css
+++ b/packages/host/app/styles/app.css
@@ -25,15 +25,15 @@
   position: absolute;
   font: var(--boxel-tooltip-font, var(--boxel-font-xs));
   z-index: 5;
+}
 
-  .message {
-    padding: 0;
-    color: inherit;
-    background-color: transparent;
-    border: 0;
-  }
+.ember-application .monaco-editor .monaco-editor-overlaymessage .message {
+  padding: 0;
+  color: inherit;
+  background-color: transparent;
+  border: 0;
+}
 
-  .anchor.top, .anchor.below {
-      display: none;
-  }
+.ember-application .monaco-editor .monaco-editor-overlaymessage .anchor.top, .ember-application .monaco-editor .monaco-editor-overlaymessage .anchor.below {
+  display: none;
 }


### PR DESCRIPTION
I accomplished #1039 using CSS nesting which I thought was [safe to use](https://caniuse.com/css-nesting) but something in the build pipeline was stripping it out, resulting in an unfortunate mix of styles:

![StatusIndicator 2024-02-20 15-47-11](https://github.com/cardstack/boxel/assets/43280/72053803-46a3-45c7-8ff0-9e66e1a762f4)

This flattens out the nesting at the expense of lengthy selectors, but it works!

![Boxel 2024-02-20 17-29-34](https://github.com/cardstack/boxel/assets/43280/e72b563f-5dc2-4dad-883e-28c33976b47c)
