### PR TITLE
Add realm token refresh support

### DIFF
--- a/packages/host/app/resources/realm-session.ts
+++ b/packages/host/app/resources/realm-session.ts
@@ -143,8 +143,9 @@ export function getRealmSession(
 
 export function clearAllRealmSessions() {
   window.localStorage.removeItem(sessionLocalStorageKey);
-  for (let timeout of sessionExpirations.values()) {
+  for (let [realm, timeout] of sessionExpirations.entries()) {
     clearTimeout(timeout);
+    sessionExpirations.delete(realm);
   }
 }
 

--- a/packages/host/app/resources/realm-session.ts
+++ b/packages/host/app/resources/realm-session.ts
@@ -1,7 +1,7 @@
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
-import { restartableTask, timeout } from 'ember-concurrency';
+import { restartableTask, dropTask, timeout } from 'ember-concurrency';
 import { Resource } from 'ember-resources';
 import window from 'ember-window-mock';
 
@@ -63,7 +63,7 @@ export class RealmSessionResource extends Resource<Args> {
     return this.rawToken;
   }
 
-  private scheduleSessionRefresh = restartableTask(async () => {
+  private scheduleSessionRefresh = dropTask(async () => {
     if (!this.token) {
       throw new Error(`Cannot schedule session refresh without token`);
     }

--- a/packages/host/app/resources/realm-session.ts
+++ b/packages/host/app/resources/realm-session.ts
@@ -1,8 +1,7 @@
-import { isDestroyed, isDestroying } from '@ember/destroyable';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
-import { restartableTask } from 'ember-concurrency';
+import { restartableTask, timeout } from 'ember-concurrency';
 import { Resource } from 'ember-resources';
 import window from 'ember-window-mock';
 
@@ -22,8 +21,6 @@ interface Args {
 
 export const sessionLocalStorageKey = 'boxel-session';
 export const tokenRefreshPeriodSec = 5 * 60; // 5 minutes
-// This is module scope so that all realm resources can share the realm refresh timers
-const sessionExpirations: Map<string, number> = new Map();
 
 export class RealmSessionResource extends Resource<Args> {
   @tracked private token: JWTPayload | undefined;
@@ -66,39 +63,25 @@ export class RealmSessionResource extends Resource<Args> {
     return this.rawToken;
   }
 
-  private scheduleSessionRefresh() {
+  private scheduleSessionRefresh = restartableTask(async () => {
     if (!this.token) {
       throw new Error(`Cannot schedule session refresh without token`);
     }
     let { realm, exp } = this.token;
-    if (sessionExpirations.has(realm)) {
-      return;
-    }
-
     let expirationMs = exp * 1000; // token expiration is unix time (seconds)
     let refreshMs = Math.max(
       expirationMs - Date.now() - tokenRefreshPeriodSec * 1000,
       0,
     );
-    sessionExpirations.set(
-      realm,
-      setTimeout(() => {
-        sessionExpirations.delete(realm);
-        // There is no guarantee that this resource wont be destroyed by the
-        // time session expires, so we should guard for that. if the session is
-        // unable to be refreshed, the next realm session resource created will
-        // obtain a new session. We could use EC to manage the session refresh,
-        // but then logging out would be very awkward in that you'd need a
-        // mechanism with a different lifetime than this resource to hold
-        // pointers to all the sessions resources' timer task cancellations when
-        // logging out.
-        if (isDestroyed(this) || isDestroying(this)) {
-          return;
-        }
-        this.getToken.perform(new URL(realm));
-      }, refreshMs) as unknown as number,
-    ); // don't use NodeJS Timeout type
-  }
+    // use EC timeout so we can gracefully handle clearing timeouts when this
+    // resource is destroyed
+    await timeout(refreshMs);
+    // make sure the token still exists in local storage, otherwise we have been
+    // logged out while we were waiting for the session to expire
+    if (processTokenFromStorage(new URL(realm))) {
+      await this.getToken.perform(new URL(realm));
+    }
+  });
 
   private getTokenForRealmOfCard = restartableTask(async (card: CardDef) => {
     let realmURL = await this.cardService.getRealmURL(card);
@@ -125,12 +108,13 @@ export class RealmSessionResource extends Resource<Args> {
     this.rawToken = rawToken;
     this.token = claimsFromRawToken(rawToken);
     persistRealmSession(rawToken);
-    this.scheduleSessionRefresh();
+    this.scheduleSessionRefresh.perform();
   }
 
   private clearToken(realmURL: URL) {
     this.token = undefined;
     this.rawToken = undefined;
+    this.scheduleSessionRefresh.cancelAll();
     clearRealmSession(realmURL);
   }
 }
@@ -155,10 +139,6 @@ export function getRealmSession(
 
 export function clearAllRealmSessions() {
   window.localStorage.removeItem(sessionLocalStorageKey);
-  for (let [realm, timeout] of sessionExpirations.entries()) {
-    clearTimeout(timeout);
-    sessionExpirations.delete(realm);
-  }
 }
 
 function persistRealmSession(rawToken: string) {
@@ -182,7 +162,6 @@ function clearRealmSession(realmURL: URL) {
   let session = JSON.parse(sessionStr);
   delete session[realmURL.href];
   window.localStorage.setItem(sessionLocalStorageKey, JSON.stringify(session));
-  clearTimeout(sessionExpirations.get(realmURL.href));
 }
 
 export function claimsFromRawToken(rawToken: string): JWTPayload {

--- a/packages/host/app/resources/realm-session.ts
+++ b/packages/host/app/resources/realm-session.ts
@@ -1,7 +1,7 @@
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
-import { restartableTask, dropTask, timeout } from 'ember-concurrency';
+import { restartableTask, timeout } from 'ember-concurrency';
 import { Resource } from 'ember-resources';
 import window from 'ember-window-mock';
 
@@ -63,7 +63,7 @@ export class RealmSessionResource extends Resource<Args> {
     return this.rawToken;
   }
 
-  private scheduleSessionRefresh = dropTask(async () => {
+  private scheduleSessionRefresh = restartableTask(async () => {
     if (!this.token) {
       throw new Error(`Cannot schedule session refresh without token`);
     }

--- a/packages/host/app/resources/realm-session.ts
+++ b/packages/host/app/resources/realm-session.ts
@@ -1,4 +1,8 @@
-import { registerDestructor } from '@ember/destroyable';
+import {
+  registerDestructor,
+  isDestroyed,
+  isDestroying,
+} from '@ember/destroyable';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
@@ -128,6 +132,9 @@ export class RealmSessionResource extends Resource<Args> {
       realm,
       setTimeout(() => {
         sessionExpirations.delete(realm);
+        if (isDestroyed(this) || isDestroying(this)) {
+          return;
+        }
         this.getToken.perform(new URL(realm));
       }, refreshMs) as unknown as number,
     ); // don't use NodeJS Timeout type

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -177,14 +177,14 @@ const filesB: Record<string, any> = {
   },
 };
 
-let realmPermissions: { [realmURL: string]: ('read' | 'write')[] } = {};
+let realmPermissions: { [realmURL: string]: ('read' | 'write')[] };
 
 module('Acceptance | code submode | create-file tests', function (hooks) {
   async function openNewFileModal(
     menuSelection: string,
     expectedRealmName = 'Test Workspace A',
   ) {
-    await waitFor('[data-test-code-mode][data-test-save-idle]');
+    await waitForCodeEditor();
     await waitFor('[data-test-new-file-button]');
     await click('[data-test-new-file-button]');
     await click(`[data-test-boxel-menu-item-text="${menuSelection}"]`);
@@ -218,7 +218,7 @@ module('Acceptance | code submode | create-file tests', function (hooks) {
   setupServerSentEvents(hooks);
   setupOnSave(hooks);
   setupWindowMock(hooks);
-  setupMatrixServiceMock(hooks, () => realmPermissions);
+  setupMatrixServiceMock(hooks, { realmPermissions: () => realmPermissions });
 
   hooks.afterEach(async function () {
     window.localStorage.removeItem('recent-files');

--- a/packages/host/tests/acceptance/code-submode/editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/editor-test.ts
@@ -36,9 +36,7 @@ import {
 } from '../../helpers';
 import { setupMatrixServiceMock } from '../../helpers/mock-matrix-service';
 
-let realmPermissions: { [realmURL: string]: ('read' | 'write')[] } = {
-  [testRealmURL]: ['read', 'write'],
-};
+let realmPermissions: { [realmURL: string]: ('read' | 'write')[] };
 
 module('Acceptance | code submode | editor tests', function (hooks) {
   let realm: Realm;
@@ -50,7 +48,7 @@ module('Acceptance | code submode | editor tests', function (hooks) {
   setupServerSentEvents(hooks);
   setupOnSave(hooks);
   setupWindowMock(hooks);
-  setupMatrixServiceMock(hooks, () => realmPermissions);
+  setupMatrixServiceMock(hooks, { realmPermissions: () => realmPermissions });
 
   hooks.afterEach(async function () {
     window.localStorage.removeItem('recent-cards');

--- a/packages/host/tests/acceptance/code-submode/file-tree-test.ts
+++ b/packages/host/tests/acceptance/code-submode/file-tree-test.ts
@@ -26,9 +26,7 @@ import {
 } from '../../helpers';
 import { setupMatrixServiceMock } from '../../helpers/mock-matrix-service';
 
-let realmPermissions: { [realmURL: string]: ('read' | 'write')[] } = {
-  [testRealmURL]: ['read', 'write'],
-};
+let realmPermissions: { [realmURL: string]: ('read' | 'write')[] };
 
 const indexCardSource = `
   import { CardDef, Component } from "https://cardstack.com/base/card-api";
@@ -196,7 +194,7 @@ module('Acceptance | code submode | file-tree tests', function (hooks) {
   setupApplicationTest(hooks);
   setupLocalIndexing(hooks);
   setupWindowMock(hooks);
-  setupMatrixServiceMock(hooks, () => realmPermissions);
+  setupMatrixServiceMock(hooks, { realmPermissions: () => realmPermissions });
 
   hooks.afterEach(async function () {
     window.localStorage.removeItem('recent-files');

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -395,7 +395,7 @@ const localInheritSource = `
   }
 `;
 
-let realmPermissions: { [realmURL: string]: ('read' | 'write')[] } = {};
+let realmPermissions: { [realmURL: string]: ('read' | 'write')[] };
 
 module('Acceptance | code submode | inspector tests', function (hooks) {
   let realm: Realm;
@@ -407,7 +407,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
   setupServerSentEvents(hooks);
   setupOnSave(hooks);
   setupWindowMock(hooks);
-  setupMatrixServiceMock(hooks, () => realmPermissions);
+  setupMatrixServiceMock(hooks, { realmPermissions: () => realmPermissions });
 
   hooks.afterEach(async function () {
     window.localStorage.removeItem('recent-files');

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -43,7 +43,7 @@ import {
 import { setupMatrixServiceMock } from '../helpers/mock-matrix-service';
 
 const testRealm2URL = `http://test-realm/test2/`;
-let realmPermissions: { [realmURL: string]: ('read' | 'write')[] } = {};
+let realmPermissions: { [realmURL: string]: ('read' | 'write')[] };
 
 module('Acceptance | interact submode tests', function (hooks) {
   let realm: Realm;
@@ -70,7 +70,7 @@ module('Acceptance | interact submode tests', function (hooks) {
   setupServerSentEvents(hooks);
   setupOnSave(hooks);
   setupWindowMock(hooks);
-  setupMatrixServiceMock(hooks, () => realmPermissions);
+  setupMatrixServiceMock(hooks, { realmPermissions: () => realmPermissions });
 
   hooks.afterEach(async function () {
     window.localStorage.removeItem('recent-cards');

--- a/packages/host/tests/acceptance/operator-mode-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-test.gts
@@ -19,6 +19,10 @@ import { FieldContainer } from '@cardstack/boxel-ui/components';
 import { baseRealm, primitive } from '@cardstack/runtime-common';
 
 import { Submodes } from '@cardstack/host/components/submode-switcher';
+import {
+  tokenRefreshPeriodSec,
+  sessionLocalStorageKey,
+} from '@cardstack/host/resources/realm-session';
 import type LoaderService from '@cardstack/host/services/loader-service';
 
 import {
@@ -35,13 +39,15 @@ import {
   setupMatrixServiceMock,
 } from '../helpers/mock-matrix-service';
 
+let sessionExpirationSec: number;
+
 module('Acceptance | operator mode tests', function (hooks) {
   setupApplicationTest(hooks);
   setupLocalIndexing(hooks);
   setupServerSentEvents(hooks);
   setupOnSave(hooks);
   setupWindowMock(hooks);
-  setupMatrixServiceMock(hooks);
+  setupMatrixServiceMock(hooks, { expiresInSec: () => sessionExpirationSec });
 
   hooks.afterEach(async function () {
     window.localStorage.removeItem('recent-cards');
@@ -51,6 +57,7 @@ module('Acceptance | operator mode tests', function (hooks) {
   hooks.beforeEach(async function () {
     window.localStorage.removeItem('recent-cards');
     window.localStorage.removeItem('recent-files');
+    sessionExpirationSec = 60 * 60;
 
     let loader = (this.owner.lookup('service:loader-service') as LoaderService)
       .loader;
@@ -681,6 +688,45 @@ module('Acceptance | operator mode tests', function (hooks) {
         fileView: 'inspector',
         openDirs: { [testRealmURL]: ['Pet/'] },
       });
+    });
+  });
+
+  module('realm session expiration', function () {
+    let refreshInSec = 1;
+
+    hooks.beforeEach(async function () {
+      sessionExpirationSec = tokenRefreshPeriodSec + refreshInSec;
+    });
+
+    test('realm session refreshes within 5 minute window of expiration', async function (assert) {
+      await visit('/');
+
+      // Enter operator mode
+      await triggerEvent(document.body, 'keydown', {
+        code: 'Key.',
+        key: '.',
+        ctrlKey: true,
+      });
+
+      await waitFor('[data-test-operator-mode-stack]');
+      let originalToken = window.localStorage.getItem(sessionLocalStorageKey);
+      await waitUntil(
+        () => {
+          return (
+            window.localStorage.getItem(sessionLocalStorageKey) !==
+            originalToken
+          );
+        },
+        { timeout: refreshInSec * 3 * 1000 },
+      );
+
+      let newToken = window.localStorage.getItem(sessionLocalStorageKey);
+      assert.ok(newToken, 'new session token obtained');
+      assert.notEqual(
+        originalToken,
+        newToken,
+        'new session token is different than original session token',
+      );
     });
   });
 });

--- a/packages/host/tests/acceptance/operator-mode-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-test.gts
@@ -692,7 +692,7 @@ module('Acceptance | operator mode tests', function (hooks) {
   });
 
   module('realm session expiration', function () {
-    let refreshInSec = 1;
+    let refreshInSec = 2;
 
     hooks.beforeEach(async function () {
       sessionExpirationSec = tokenRefreshPeriodSec + refreshInSec;
@@ -711,12 +711,8 @@ module('Acceptance | operator mode tests', function (hooks) {
       await waitFor('[data-test-operator-mode-stack]');
       let originalToken = window.localStorage.getItem(sessionLocalStorageKey);
       await waitUntil(
-        () => {
-          return (
-            window.localStorage.getItem(sessionLocalStorageKey) !==
-            originalToken
-          );
-        },
+        () =>
+          window.localStorage.getItem(sessionLocalStorageKey) !== originalToken,
         { timeout: refreshInSec * 3 * 1000 },
       );
 

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -58,7 +58,7 @@ let createJWT = (
   return realm.createJWT({ user, realm: realmUrl, permissions }, '7d');
 };
 
-module.only('Realm Server', function (hooks) {
+module('Realm Server', function (hooks) {
   async function expectEvent<T>({
     assert,
     expected,


### PR DESCRIPTION
This PR will obtain a new realm session token within 5 minutes of the expiration of the current realm session token for all active realm session tokens