### PR TITLE
links-to component respects realm permissions of linked card

### DIFF
--- a/packages/host/app/components/operator-mode/overlay-item-header.gts
+++ b/packages/host/app/components/operator-mode/overlay-item-header.gts
@@ -12,7 +12,7 @@ import {
   Menu,
   Tooltip,
 } from '@cardstack/boxel-ui/components';
-import { eq, menuItem } from '@cardstack/boxel-ui/helpers';
+import { eq, menuItem, and } from '@cardstack/boxel-ui/helpers';
 
 import {
   IconPencil,
@@ -34,6 +34,7 @@ import { type RenderedCardForOverlayActions } from './stack-item';
 
 interface Signature {
   item: RenderedCardForOverlayActions;
+  canWrite: boolean;
   openOrSelectCard: (
     card: CardDef,
     format?: Format,
@@ -68,8 +69,9 @@ export default class OperatorModeOverlayItemHeader extends Component<Signature> 
       </div>
 
       <div class='header-actions'>
-        {{! Offer to edit embedded card only when the stack item is in edit mode  }}
-        {{#if (eq @item.stackItem.format 'edit')}}
+        {{! Offer to edit embedded card only when the stack item is in edit 
+            mode and you can write to the card in question }}
+        {{#if (and @canWrite (eq @item.stackItem.format 'edit'))}}
           <IconButton
             @icon={{IconPencil}}
             @width='24px'

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -79,7 +79,10 @@ module('Acceptance | interact submode tests', function (hooks) {
   });
 
   hooks.beforeEach(async function () {
-    realmPermissions = { [testRealmURL]: ['read', 'write'] };
+    realmPermissions = {
+      [testRealmURL]: ['read', 'write'],
+      [testRealm2URL]: ['read', 'write'],
+    };
     window.localStorage.removeItem('recent-cards');
     window.localStorage.removeItem('recent-files');
     window.localStorage.removeItem('boxel-session');
@@ -824,7 +827,10 @@ module('Acceptance | interact submode tests', function (hooks) {
 
     module('when the user lacks write permissions', function (hooks) {
       hooks.beforeEach(async function () {
-        realmPermissions = { [testRealmURL]: ['read'] };
+        realmPermissions = {
+          [testRealmURL]: ['read'],
+          [testRealm2URL]: ['read', 'write'],
+        };
       });
 
       test('the edit button is hidden when the user lacks permissions', async function (assert) {

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -268,6 +268,10 @@ module('Acceptance | interact submode tests', function (hooks) {
           iconURL: 'https://i.postimg.cc/d0B9qMvy/icon.png',
         },
         'Pet/ringo.json': new Pet({ name: 'Ringo' }),
+        'Person/hassan.json': new Person({
+          firstName: 'Hassan',
+          pet: mangoPet,
+        }),
       },
     });
   });
@@ -791,6 +795,33 @@ module('Acceptance | interact submode tests', function (hooks) {
       await deferred.promise;
     });
 
+    test('embedded card from writable realm shows pencil icon in edit mode', async (assert) => {
+      await visitOperatorMode({
+        stacks: [
+          [
+            {
+              id: `${testRealm2URL}Person/hassan`,
+              format: 'edit',
+            },
+          ],
+        ],
+      });
+      assert
+        .dom(
+          `[data-test-overlay-card="${testRealmURL}Pet/mango"] [data-test-embedded-card-edit-button]`,
+        )
+        .exists();
+      await click(
+        `[data-test-overlay-card="${testRealmURL}Pet/mango"] [data-test-embedded-card-edit-button]`,
+      );
+      await waitFor(`[data-test-stack-card="${testRealmURL}Pet/mango"]`);
+      assert
+        .dom(
+          `[data-test-stack-card="${testRealmURL}Pet/mango"] [data-test-card-format="edit"]`,
+        )
+        .exists('linked card now rendered as a stack item in edit format');
+    });
+
     module('when the user lacks write permissions', function (hooks) {
       hooks.beforeEach(async function () {
         realmPermissions = { [testRealmURL]: ['read'] };
@@ -848,6 +879,38 @@ module('Acceptance | interact submode tests', function (hooks) {
             `[data-test-overlay-card="${testRealmURL}Pet/mango"] button.more-actions`,
           )
           .doesNotExist('"..." menu does not exist');
+      });
+
+      test('embedded card from read-only realm does not show pencil icon in edit mode', async (assert) => {
+        await visitOperatorMode({
+          stacks: [
+            [
+              {
+                id: `${testRealm2URL}Person/hassan`,
+                format: 'edit',
+              },
+            ],
+          ],
+        });
+        assert
+          .dom(`[data-test-overlay-card="${testRealmURL}Pet/mango"]`)
+          .exists();
+        assert
+          .dom(
+            `[data-test-overlay-card="${testRealmURL}Pet/mango"] [data-test-embedded-card-edit-button]`,
+          )
+          .doesNotExist('edit icon not displayed for linked card');
+        await click(
+          `[data-test-links-to-editor="pet"] [data-test-field-component-card]`,
+        );
+        await waitFor(`[data-test-stack-card="${testRealmURL}Pet/mango"]`);
+        assert
+          .dom(
+            `[data-test-stack-card="${testRealmURL}Pet/mango"] [data-test-card-format="isolated"]`,
+          )
+          .exists(
+            'linked card now rendered as a stack item in isolated (non-edit) format',
+          );
       });
     });
   });


### PR DESCRIPTION
This PR adds logic to hide the pencil ("edit") icon for links to component when the linked card is in a realm that the session cannot write to. Additionally, when you click on such a link, the linked card is added to the stack in isolated mode instead of inheriting the edit mode format of its "parent" card.