### PR TITLE
Retrieve a new JWT in browser if receive 403 error from realm

### DIFF
--- a/packages/host/app/resources/realm-session.ts
+++ b/packages/host/app/resources/realm-session.ts
@@ -95,6 +95,14 @@ export class RealmSessionResource extends Resource<Args> {
     });
   }
 
+  async refreshToken() {
+    if (!this.token) {
+      throw new Error(`Cannot do session refresh without token`);
+    }
+    let { realm } = this.token;
+    return await this.getToken.perform(new URL(realm));
+  }
+
   get canRead() {
     return this.token?.permissions?.includes('read');
   }

--- a/packages/host/app/services/loader-service.ts
+++ b/packages/host/app/services/loader-service.ts
@@ -104,9 +104,9 @@ export default class LoaderService extends Service {
       body,
     });
 
-    // We will get a 403 from the server in two cases. The first one is when the request is not allowed, 
+    // We will get a 403 from the server in two cases. The first one is when the request is not allowed,
     // and the second one is when the JWT has expired or the permissions in the JWY payload differ
-    // from what is configured on the server (e.g. someone changed permissions for the user during the life 
+    // from what is configured on the server (e.g. someone changed permissions for the user during the life
     // of the JWT). The latter case is solved by trying to refresh the token.
     if (!response.ok && response.status === 403) {
       await realmSession.refreshToken();

--- a/packages/host/app/services/loader-service.ts
+++ b/packages/host/app/services/loader-service.ts
@@ -104,11 +104,11 @@ export default class LoaderService extends Service {
       body,
     });
 
-    // We will get a 403 from the server in two cases. The first one is when the request is not allowed,
+    // We will get a 401 from the server in two cases. The first one is when the request is not allowed,
     // and the second one is when the JWT has expired or the permissions in the JWY payload differ
     // from what is configured on the server (e.g. someone changed permissions for the user during the life
     // of the JWT). The latter case is solved by trying to refresh the token.
-    if (!response.ok && response.status === 403) {
+    if (!response.ok && response.status === 401) {
       await realmSession.refreshToken();
       if (!realmSession.rawRealmToken) {
         return null;

--- a/packages/host/app/services/loader-service.ts
+++ b/packages/host/app/services/loader-service.ts
@@ -110,7 +110,7 @@ export default class LoaderService extends Service {
     if (!response.ok && response.status === 403) {
       await realmSession.refreshToken();
       if (!realmSession.rawRealmToken) {
-        return;
+        return null;
       }
       request.headers.set('Authorization', realmSession.rawRealmToken);
       response = await this.loader.fetch(request.url, {

--- a/packages/host/app/services/loader-service.ts
+++ b/packages/host/app/services/loader-service.ts
@@ -104,9 +104,10 @@ export default class LoaderService extends Service {
       body,
     });
 
-    // Obtaining a new JWT
-    // if receiving `Authorization` error,
-    // which means user permissions is updated from the server.
+    // We will get a 403 from the server in two cases. The first one is when the request is not allowed, 
+    // and the second one is when the JWT has expired or the permissions in the JWY payload differ
+    // from what is configured on the server (e.g. someone changed permissions for the user during the life 
+    // of the JWT). The latter case is solved by trying to refresh the token.
     if (!response.ok && response.status === 403) {
       await realmSession.refreshToken();
       if (!realmSession.rawRealmToken) {

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -243,7 +243,7 @@ module('Acceptance | code submode | create-file tests', function (hooks) {
           throw new Error('A deliberate fetch error');
         }
 
-        return req;
+        return { req, res: null };
       },
     });
     ({ adapter } = await setupAcceptanceTestRealm({

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -30,11 +30,13 @@ import type OperatorModeStateService from '@cardstack/host/services/operator-mod
 import type RecentCardsService from '@cardstack/host/services/recent-cards-service';
 
 import {
+  createJWT,
   percySnapshot,
   setupLocalIndexing,
   setupServerSentEvents,
   setupOnSave,
   testRealmURL,
+  testRealmSecretSeed,
   type TestContextWithSSE,
   type TestContextWithSave,
   setupAcceptanceTestRealm,
@@ -47,21 +49,27 @@ let realmPermissions: { [realmURL: string]: ('read' | 'write')[] };
 
 module('Acceptance | interact submode tests', function (hooks) {
   let realm: Realm;
-  let onFetch: ((req: Request, body: string) => void) | undefined;
+  let onFetch: ((req: Request, body: string) => Response | null) | undefined;
   function wrappedOnFetch() {
     return async (req: Request) => {
       if (!onFetch) {
-        return Promise.resolve(req);
+        return Promise.resolve({
+          req,
+          res: null,
+        });
       }
       let { headers, method } = req;
       let body = await req.text();
-      onFetch(req, body);
+      let res = onFetch(req, body) ?? null;
       // need to return a new request since we just read the body
-      return new Request(req.url, {
-        method,
-        headers,
-        ...(body ? { body } : {}),
-      });
+      return {
+        req: new Request(req.url, {
+          method,
+          headers,
+          ...(body ? { body } : {}),
+        }),
+        res,
+      };
     };
   }
 
@@ -850,6 +858,76 @@ module('Acceptance | interact submode tests', function (hooks) {
           .doesNotExist('"..." menu does not exist');
       });
     });
+
+    module(
+      'when permission is updated after user has obtained the token',
+      function (hooks) {
+        hooks.beforeEach(async function () {
+          realmPermissions = { [testRealmURL]: ['read'] };
+        });
+
+        test('retrieve a new JWT if recevive 403 error', async function (assert) {
+          let token = createJWT(
+            {
+              user: '@testuser:staging',
+              realm: testRealmURL,
+              permissions: ['read', 'write'],
+            },
+            '7d',
+            testRealmSecretSeed,
+          );
+          let session = {
+            [`${testRealmURL}`]: token,
+          };
+          window.localStorage.setItem('boxel-session', JSON.stringify(session));
+
+          await visitOperatorMode({
+            stacks: [
+              [
+                {
+                  id: `${testRealmURL}Pet/mango`,
+                  format: 'isolated',
+                },
+              ],
+            ],
+          });
+
+          // Mock `Authorization` error response from the server.
+          onFetch = (req, _body) => {
+            if (
+              req.method !== 'GET' &&
+              req.method !== 'HEAD' &&
+              req.headers.get('Authorization') === token
+            ) {
+              return new Response(`Authorization error`, {
+                status: 403,
+              });
+            }
+
+            return null;
+          };
+          assert
+            .dom('[data-test-operator-mode-stack] [data-test-edit-button]')
+            .exists();
+          await click(
+            '[data-test-operator-mode-stack] [data-test-edit-button]',
+          );
+          await fillIn(
+            '[data-test-operator-mode-stack] [data-test-field="name"] [data-test-boxel-input]',
+            'Updated Ringo',
+          );
+          await click(
+            '[data-test-operator-mode-stack] [data-test-edit-button]',
+          );
+
+          let newToken = window.localStorage.getItem('boxel-session');
+          let claims = claimsFromRawToken(newToken!);
+          assert.notStrictEqual(newToken, token);
+          assert.strictEqual(claims.user, '@testuser:staging');
+          assert.deepEqual(claims.permissions, ['read']);
+        });
+      },
+    );
   });
 
   module('2 stacks with differing permissions', function (hooks) {
@@ -887,6 +965,7 @@ module('Acceptance | interact submode tests', function (hooks) {
           assert.strictEqual(claims.realm, 'http://test-realm/test2/');
           assert.deepEqual(claims.permissions, ['read', 'write']);
         }
+        return null;
       };
 
       assert

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -866,7 +866,7 @@ module('Acceptance | interact submode tests', function (hooks) {
           realmPermissions = { [testRealmURL]: ['read'] };
         });
 
-        test('retrieve a new JWT if recevive 403 error', async function (assert) {
+        test('retrieve a new JWT if recevive 401 error', async function (assert) {
           let token = createJWT(
             {
               user: '@testuser:staging',
@@ -900,7 +900,7 @@ module('Acceptance | interact submode tests', function (hooks) {
               req.headers.get('Authorization') === token
             ) {
               return new Response(`Authorization error`, {
-                status: 403,
+                status: 401,
               });
             }
 

--- a/packages/host/tests/integration/components/card-copy-test.gts
+++ b/packages/host/tests/integration/components/card-copy-test.gts
@@ -53,17 +53,20 @@ module('Integration | card-copy', function (hooks) {
   function wrappedOnFetch() {
     return async (req: Request) => {
       if (!onFetch) {
-        return Promise.resolve(req);
+        return Promise.resolve({ req, res: null });
       }
       let { headers, method } = req;
       let body = await req.text();
       onFetch(req, body);
       // need to return a new request since we just read the body
-      return new Request(req.url, {
-        method,
-        headers,
-        ...(body ? { body } : {}),
-      });
+      return {
+        req: new Request(req.url, {
+          method,
+          headers,
+          ...(body ? { body } : {}),
+        }),
+        res: null,
+      };
     };
   }
 

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -53,7 +53,7 @@ let createJWT = (
   realm: Realm,
   user: string,
   realmUrl: string,
-  permissions = [],
+  permissions: RealmPermissions['user'] = [],
 ) => {
   return realm.createJWT({ user, realm: realmUrl, permissions }, '7d');
 };
@@ -391,6 +391,19 @@ module('Realm Server', function (hooks) {
           .post('/')
           .send({})
           .set('Accept', 'application/vnd.card+json'); // no Authorization header
+
+        assert.strictEqual(response.status, 401, 'HTTP 401 status');
+      });
+
+      test('401 permissions have been updated', async function (assert) {
+        let response = await request
+          .post('/')
+          .send({})
+          .set('Accept', 'application/vnd.card+json')
+          .set(
+            'Authorization',
+            `Bearer ${createJWT(testRealm, 'john', testRealmHref, ['read'])}`,
+          );
 
         assert.strictEqual(response.status, 401, 'HTTP 401 status');
       });

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -252,7 +252,7 @@ module('Realm Server', function (hooks) {
           .set('Accept', 'application/vnd.card+json')
           .set(
             'Authorization',
-            `Bearer ${createJWT(testRealm, 'john', testRealmHref)}`,
+            `Bearer ${createJWT(testRealm, 'john', testRealmHref, ['read'])}`,
           );
 
         assert.strictEqual(response.status, 200, 'HTTP 200 status');
@@ -439,7 +439,10 @@ module('Realm Server', function (hooks) {
           .set('Accept', 'application/vnd.card+json')
           .set(
             'Authorization',
-            `Bearer ${createJWT(testRealm, 'john', testRealmHref)}`,
+            `Bearer ${createJWT(testRealm, 'john', testRealmHref, [
+              'read',
+              'write',
+            ])}`,
           );
 
         assert.strictEqual(response.status, 201, 'HTTP 201 status');
@@ -623,7 +626,10 @@ module('Realm Server', function (hooks) {
           .set('Accept', 'application/vnd.card+json')
           .set(
             'Authorization',
-            `Bearer ${createJWT(testRealm, 'john', testRealmHref)}`,
+            `Bearer ${createJWT(testRealm, 'john', testRealmHref, [
+              'read',
+              'write',
+            ])}`,
           );
 
         assert.strictEqual(response.status, 200, 'HTTP 200 status');
@@ -744,7 +750,10 @@ module('Realm Server', function (hooks) {
           .set('Accept', 'application/vnd.card+json')
           .set(
             'Authorization',
-            `Bearer ${createJWT(testRealm, 'john', testRealmHref)}`,
+            `Bearer ${createJWT(testRealm, 'john', testRealmHref, [
+              'read',
+              'write',
+            ])}`,
           );
 
         assert.strictEqual(response.status, 204, 'HTTP 204 status');
@@ -917,7 +926,7 @@ module('Realm Server', function (hooks) {
           .set('Accept', 'application/vnd.card+source')
           .set(
             'Authorization',
-            `Bearer ${createJWT(testRealm, 'john', testRealmHref)}`,
+            `Bearer ${createJWT(testRealm, 'john', testRealmHref, ['read'])}`,
           );
 
         assert.strictEqual(response.status, 200, 'HTTP 200 status');
@@ -1036,7 +1045,10 @@ module('Realm Server', function (hooks) {
           .set('Accept', 'application/vnd.card+source')
           .set(
             'Authorization',
-            `Bearer ${createJWT(testRealm, 'john', testRealmHref)}`,
+            `Bearer ${createJWT(testRealm, 'john', testRealmHref, [
+              'read',
+              'write',
+            ])}`,
           );
 
         assert.strictEqual(response.status, 204, 'HTTP 204 status');
@@ -1363,7 +1375,10 @@ module('Realm Server', function (hooks) {
           .send(`//TEST UPDATE\n${cardSrc}`)
           .set(
             'Authorization',
-            `Bearer ${createJWT(testRealm, 'john', testRealmHref)}`,
+            `Bearer ${createJWT(testRealm, 'john', testRealmHref, [
+              'read',
+              'write',
+            ])}`,
           );
 
         assert.strictEqual(response.status, 204, 'HTTP 204 status');
@@ -1481,7 +1496,7 @@ module('Realm Server', function (hooks) {
           .set('Accept', 'application/vnd.api+json')
           .set(
             'Authorization',
-            `Bearer ${createJWT(testRealm, 'john', testRealmHref)}`,
+            `Bearer ${createJWT(testRealm, 'john', testRealmHref, ['read'])}`,
           );
 
         assert.strictEqual(response.status, 200, 'HTTP 200 status');
@@ -1584,7 +1599,7 @@ module('Realm Server', function (hooks) {
           .set('Accept', 'application/vnd.card+json')
           .set(
             'Authorization',
-            `Bearer ${createJWT(testRealm, 'john', testRealmHref)}`,
+            `Bearer ${createJWT(testRealm, 'john', testRealmHref, ['read'])}`,
           );
 
         assert.strictEqual(response.status, 200, 'HTTP 200 status');
@@ -1680,7 +1695,7 @@ module('Realm Server', function (hooks) {
           .set('Accept', 'application/vnd.api+json')
           .set(
             'Authorization',
-            `Bearer ${createJWT(testRealm, 'john', testRealmHref)}`,
+            `Bearer ${createJWT(testRealm, 'john', testRealmHref, ['read'])}`,
           );
 
         assert.strictEqual(response.status, 200, 'HTTP 200 status');

--- a/packages/runtime-common/realm-permission-checker.ts
+++ b/packages/runtime-common/realm-permission-checker.ts
@@ -8,11 +8,13 @@ export default class RealmPermissionChecker {
   }
 
   can(username: string, action: 'read' | 'write') {
-    let userPermissions = [
+    return this.getUserPermissions(username).includes(action);
+  }
+
+  getUserPermissions(username: string) {
+    return [
       ...(this.realmPermissions['*'] || []),
       ...(this.realmPermissions[username] || []),
     ];
-
-    return userPermissions.includes(action);
   }
 }

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -990,6 +990,13 @@ export class Realm {
       let realmPermissionChecker = new RealmPermissionChecker(
         this.#permissions,
       );
+      
+      let permissions = realmPermissionChecker.getUserPermissions(token.user);
+      if (JSON.stringify(token.permissions.sort()) === JSON.stringify(permissions.sort())) {
+        throw new AuthorizationError(
+          'User permissions have been updated. Please refresh the token',
+        );
+      }
 
       if (!realmPermissionChecker.can(token.user, neededPermission)) {
         throw new AuthorizationError(

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -992,8 +992,8 @@ export class Realm {
       );
       
       let permissions = realmPermissionChecker.getUserPermissions(token.user);
-      if (JSON.stringify(token.permissions.sort()) === JSON.stringify(permissions.sort())) {
-        throw new AuthorizationError(
+      if (token.permissions.length > 0 && JSON.stringify(token.permissions.sort()) === JSON.stringify(permissions.sort())) {
+        throw new AuthenticationError(
           'User permissions have been updated. Please refresh the token',
         );
       }

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -992,7 +992,7 @@ export class Realm {
       );
       
       let permissions = realmPermissionChecker.getUserPermissions(token.user);
-      if (token.permissions.length > 0 && JSON.stringify(token.permissions.sort()) === JSON.stringify(permissions.sort())) {
+      if (JSON.stringify(token.permissions.sort()) !== JSON.stringify(permissions.sort())) {
         throw new AuthenticationError(
           'User permissions have been updated. Please refresh the token',
         );


### PR DESCRIPTION
From this [ticket](https://linear.app/cardstack/issue/CS-6445/include-and-verify-permission-level-in-jwt), there is a requirement to retrieve a new JWT and retry the request if client receive an error when fetching to API because the permission in current JWT is not valid anymore. So in this PR, I implemented that mechanism in `fetchWithAuth` handler.