### PR TITLE
Update secondary-dark button disabled state

### DIFF
--- a/packages/boxel-ui/addon/src/components/button/index.gts
+++ b/packages/boxel-ui/addon/src/components/button/index.gts
@@ -199,13 +199,21 @@ export default class ButtonComponent extends Component<Signature> {
         .kind-secondary-dark:not(:disabled) {
           /* transparent on dark background */
           --boxel-button-color: transparent;
-          --boxel-button-border: 1px solid var(--boxel-purple-400);
+          --boxel-button-border: 1px solid var(--boxel-400);
           --boxel-button-text-color: var(--boxel-light);
         }
 
         .kind-secondary-dark:not(:disabled):hover,
         .kind-secondary-dark:not(:disabled):active {
           --boxel-button-border: 1px solid var(--boxel-light);
+        }
+
+        .kind-secondary-dark:disabled,
+        a.kind-secondary-dark:not([href]),
+        a.kind-secondary-dark[href=''],
+        a.kind-secondary-dark.disabled-link {
+          --boxel-button-color: transparent;
+          opacity: 0.35;
         }
 
         .kind-secondary-light:not(:disabled) {


### PR DESCRIPTION
This change requires running `pnpm build` on boxel-ui package and/or host app to observe.

<img width="1194" alt="disabled-btn" src="https://github.com/cardstack/boxel/assets/16160806/f2930190-32fa-4398-a830-fb401b7dab26">
<img width="372" alt="ai-asst" src="https://github.com/cardstack/boxel/assets/16160806/e2d5a260-817b-417f-83f4-83f2c4dd955f">
