### PR TITLE
Do not close past-sessions list when renaming or deleting a room

### DIFF
--- a/packages/host/app/components/ai-assistant/panel.gts
+++ b/packages/host/app/components/ai-assistant/panel.gts
@@ -367,9 +367,9 @@ export default class AiAssistantPanel extends Component<Signature> {
   }
 
   @action
-  private enterRoom(roomId: string, hidePastSessions = true) {
+  private enterRoom(roomId: string, hidePastSessionsList = true) {
     this.currentRoomId = roomId;
-    if (hidePastSessions) {
+    if (hidePastSessionsList) {
       this.hidePastSessions();
     }
     window.localStorage.setItem(currentRoomIdPersistenceKey, roomId);

--- a/packages/host/app/components/ai-assistant/panel.gts
+++ b/packages/host/app/components/ai-assistant/panel.gts
@@ -367,7 +367,7 @@ export default class AiAssistantPanel extends Component<Signature> {
   }
 
   @action
-  private enterRoom(roomId: string, hidePastSessions: boolean = true) {
+  private enterRoom(roomId: string, hidePastSessions = true) {
     this.currentRoomId = roomId;
     if (hidePastSessions) {
       this.hidePastSessions();

--- a/packages/host/app/components/ai-assistant/panel.gts
+++ b/packages/host/app/components/ai-assistant/panel.gts
@@ -131,7 +131,7 @@ export default class AiAssistantPanel extends Component<Signature> {
         {{else if this.roomToRename}}
           <RenameSession
             @room={{this.roomToRename}}
-            @onClose={{fn this.setRoomToRename undefined}}
+            @onClose={{this.onCloseRename}}
             {{popoverVelcro.loop}}
           />
         {{/if}}
@@ -367,15 +367,22 @@ export default class AiAssistantPanel extends Component<Signature> {
   }
 
   @action
-  private enterRoom(roomId: string) {
+  private enterRoom(roomId: string, hidePastSessions: boolean = true) {
     this.currentRoomId = roomId;
-    this.hidePastSessions();
+    if (hidePastSessions) {
+      this.hidePastSessions();
+    }
     window.localStorage.setItem(currentRoomIdPersistenceKey, roomId);
   }
 
   @action private setRoomToRename(room: RoomField | undefined) {
     this.roomToRename = room;
     this.hidePastSessions();
+  }
+
+  @action private onCloseRename() {
+    this.roomToRename = undefined;
+    this.displayPastSessions();
   }
 
   @action private setRoomToDelete(room: RoomField | undefined) {
@@ -410,13 +417,12 @@ export default class AiAssistantPanel extends Component<Signature> {
         window.localStorage.removeItem(currentRoomIdPersistenceKey);
         let latestRoom = this.aiSessionRooms[0];
         if (latestRoom) {
-          this.enterRoom(latestRoom.roomId);
+          this.enterRoom(latestRoom.roomId, false);
         } else {
           this.createNewSession();
         }
       }
       this.roomToDelete = undefined;
-      this.hidePastSessions();
     } catch (e) {
       console.error(e);
       this.roomDeleteError = 'Error deleting room';


### PR DESCRIPTION
A nuance: If the deleted room is the last remaining room, then the past-sessions list will be closed and the new room that is created will be entered.