### PR TITLE
host: Fix editor permissions icon to right-aligned

### DIFF
--- a/packages/host/app/components/editor/file-tree.gts
+++ b/packages/host/app/components/editor/file-tree.gts
@@ -30,20 +30,18 @@ export default class FileTree extends Component<Signature> {
     <div class='realm-info'>
       <RealmInfoProvider @realmURL={{@realmURL}}>
         <:ready as |realmInfo|>
-          <section class='icon-and-title'>
-            <RealmIcon
-              @realmIconURL={{realmInfo.iconURL}}
-              @realmName={{realmInfo.name}}
-              class='icon'
-            />
-            {{#let (concat 'In ' realmInfo.name) as |realmTitle|}}
-              <span
-                class='realm-title'
-                data-test-realm-name={{realmInfo.name}}
-                title={{realmTitle}}
-              >{{realmTitle}}</span>
-            {{/let}}
-          </section>
+          <RealmIcon
+            @realmIconURL={{realmInfo.iconURL}}
+            @realmName={{realmInfo.name}}
+            class='icon'
+          />
+          {{#let (concat 'In ' realmInfo.name) as |realmTitle|}}
+            <span
+              class='realm-title'
+              data-test-realm-name={{realmInfo.name}}
+              title={{realmTitle}}
+            >{{realmTitle}}</span>
+          {{/let}}
           {{#if this.canWrite}}
             <Tooltip @placement='top' class='editability-icon'>
               <:trigger>
@@ -107,17 +105,12 @@ export default class FileTree extends Component<Signature> {
         box-shadow: var(--boxel-box-shadow);
         z-index: 1;
 
-        display: flex;
+        display: grid;
+        grid-template-columns: auto 1fr auto;
+        justify-content: center;
         align-items: center;
-        justify-content: space-between;
         gap: var(--boxel-sp-xxxs);
         font: 700 var(--boxel-font-sm);
-      }
-
-      .icon-and-title {
-        display: flex;
-        align-items: center;
-        gap: var(--boxel-sp-xxxs);
       }
 
       .realm-info img {

--- a/packages/host/app/components/editor/file-tree.gts
+++ b/packages/host/app/components/editor/file-tree.gts
@@ -107,7 +107,6 @@ export default class FileTree extends Component<Signature> {
 
         display: grid;
         grid-template-columns: auto 1fr auto;
-        justify-content: center;
         align-items: center;
         gap: var(--boxel-sp-xxxs);
         font: 700 var(--boxel-font-sm);

--- a/packages/host/app/components/editor/file-tree.gts
+++ b/packages/host/app/components/editor/file-tree.gts
@@ -30,18 +30,20 @@ export default class FileTree extends Component<Signature> {
     <div class='realm-info'>
       <RealmInfoProvider @realmURL={{@realmURL}}>
         <:ready as |realmInfo|>
-          <RealmIcon
-            @realmIconURL={{realmInfo.iconURL}}
-            @realmName={{realmInfo.name}}
-            class='icon'
-          />
-          {{#let (concat 'In ' realmInfo.name) as |realmTitle|}}
-            <span
-              class='realm-title'
-              data-test-realm-name={{realmInfo.name}}
-              title={{realmTitle}}
-            >{{realmTitle}}</span>
-          {{/let}}
+          <section class='icon-and-title'>
+            <RealmIcon
+              @realmIconURL={{realmInfo.iconURL}}
+              @realmName={{realmInfo.name}}
+              class='icon'
+            />
+            {{#let (concat 'In ' realmInfo.name) as |realmTitle|}}
+              <span
+                class='realm-title'
+                data-test-realm-name={{realmInfo.name}}
+                title={{realmTitle}}
+              >{{realmTitle}}</span>
+            {{/let}}
+          </section>
           {{#if this.canWrite}}
             <Tooltip @placement='top' class='editability-icon'>
               <:trigger>
@@ -107,8 +109,15 @@ export default class FileTree extends Component<Signature> {
 
         display: flex;
         align-items: center;
+        justify-content: space-between;
         gap: var(--boxel-sp-xxxs);
         font: 700 var(--boxel-font-sm);
+      }
+
+      .icon-and-title {
+        display: flex;
+        align-items: center;
+        gap: var(--boxel-sp-xxxs);
       }
 
       .realm-info img {


### PR DESCRIPTION
The pencil icon was formerly aligned alongside the title, now it moves to the other edge:

<img width="285" alt="Boxel 2024-03-05 11-51-50" src="https://github.com/cardstack/boxel/assets/43280/eebe398f-20ab-49a4-812d-2d81a6346512">

I switched to grid layout to preserve the ellipsis truncation of the title in a narrower column.