### PR TITLE
Responsive card preview footer buttons

### DIFF
--- a/packages/host/app/components/operator-mode/card-preview-panel.gts
+++ b/packages/host/app/components/operator-mode/card-preview-panel.gts
@@ -5,6 +5,7 @@ import { action } from '@ember/object';
 import Component from '@glimmer/component';
 
 import { tracked } from '@glimmer/tracking';
+
 import { task } from 'ember-concurrency';
 
 import perform from 'ember-concurrency/helpers/perform';

--- a/packages/host/app/components/operator-mode/card-preview-panel.gts
+++ b/packages/host/app/components/operator-mode/card-preview-panel.gts
@@ -337,9 +337,9 @@ class ResizeModifier extends Modifier<ResizeSignature> {
     { setFooterWidthPx }: ResizeSignature['Args']['Named'],
   ) {
     let resizeObserver = new ResizeObserver(() => {
-      requestAnimationFrame(() => {
+      setTimeout(() => {
         setFooterWidthPx(element.clientWidth);
-      });
+      }, 1);
     });
 
     resizeObserver.observe(element);

--- a/packages/host/app/components/operator-mode/card-preview-panel.gts
+++ b/packages/host/app/components/operator-mode/card-preview-panel.gts
@@ -337,6 +337,7 @@ class ResizeModifier extends Modifier<ResizeSignature> {
     { setFooterWidthPx }: ResizeSignature['Args']['Named'],
   ) {
     let resizeObserver = new ResizeObserver(() => {
+      // setTimeout prevents the "ResizeObserver loop completed with undelivered notifications" error that happens in tests
       setTimeout(() => {
         setFooterWidthPx(element.clientWidth);
       }, 1);

--- a/packages/host/app/components/operator-mode/card-preview-panel.gts
+++ b/packages/host/app/components/operator-mode/card-preview-panel.gts
@@ -337,7 +337,9 @@ class ResizeModifier extends Modifier<ResizeSignature> {
     { setFooterWidthPx }: ResizeSignature['Args']['Named'],
   ) {
     let resizeObserver = new ResizeObserver(() => {
-      setFooterWidthPx(element.clientWidth);
+      requestAnimationFrame(() => {
+        setFooterWidthPx(element.clientWidth);
+      });
     });
 
     resizeObserver.observe(element);


### PR DESCRIPTION
1. Buttons expand together with the whole width of the panel
2. When they get too squished, they get separated and jump in new row if neeeded
3. Small refactor to get rid of the fixed heights in the header and footer - use flex grow instead

https://github.com/cardstack/boxel/assets/273660/fac216f9-1837-4d0b-a8d8-b2d26b0a5dbf

