### PR TITLE
ai: Add Sentry

### DIFF
--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -21,6 +21,14 @@ import {
 } from './helpers';
 import { OpenAIError } from 'openai/error';
 import type { MatrixEvent as DiscreteMatrixEvent } from 'https://cardstack.com/base/room';
+import * as Sentry from '@sentry/node';
+
+if (process.env.SENTRY_DSN) {
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    environment: process.env.SENTRY_ENVIRONMENT || 'development',
+  });
+}
 
 let log = logger('ai-bot');
 

--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -217,6 +217,8 @@ async function handleDebugCommands(
       room.roomId,
       eventBody.split('debug:title:set:')[1],
     );
+  } else if (eventBody.startsWith('debug:boom')) {
+    throw new Error('Boom');
   }
   // Use GPT to set the room title
   else if (eventBody.startsWith('debug:title:create')) {

--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -218,6 +218,7 @@ async function handleDebugCommands(
       eventBody.split('debug:title:set:')[1],
     );
   } else if (eventBody.startsWith('debug:boom')) {
+    await sendMessage(client, room, `Throwing an unhandled error`, undefined);
     throw new Error('Boom');
   }
   // Use GPT to set the room title

--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -161,6 +161,7 @@ async function sendError(
     // We've had a problem sending the error message back to the user
     // Log and continue
     log.error(`Error sending error message back to user: ${e}`);
+    Sentry.captureException(e);
   }
 }
 
@@ -200,6 +201,7 @@ async function setTitle(
     log.info('Setting room title to', title);
     return await client.setRoomName(room.roomId, title);
   } catch (error) {
+    Sentry.captureException(error);
     return await sendError(client, room, error, undefined);
   }
 }
@@ -241,6 +243,7 @@ async function handleDebugCommands(
         );
       }
     } catch (error) {
+      Sentry.captureException(error);
       return await sendMessage(
         client,
         room,
@@ -368,6 +371,7 @@ Common issues are:
           try {
             args = JSON.parse(functionCall.arguments);
           } catch (error) {
+            Sentry.captureException(error);
             return await sendError(
               client,
               room,
@@ -387,6 +391,7 @@ Common issues are:
           return;
         })
         .on('error', async (error: OpenAIError) => {
+          Sentry.captureException(error);
           return await sendError(client, room, error, initialMessage.event_id);
         });
 

--- a/packages/ai-bot/package.json
+++ b/packages/ai-bot/package.json
@@ -2,6 +2,7 @@
   "name": "@cardstack/ai-bot",
   "dependencies": {
     "@cardstack/runtime-common": "workspace:^",
+    "@sentry/node": "^7.105.0",
     "@types/node": "^18.18.5",
     "@types/stream-chain": "^2.0.1",
     "@types/stream-json": "^1.7.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 overrides:
   '@types/eslint': 8.4.1
   '@embroider/util': 1.12.0
@@ -106,6 +110,9 @@ importers:
       '@cardstack/runtime-common':
         specifier: workspace:^
         version: link:../runtime-common
+      '@sentry/node':
+        specifier: ^7.105.0
+        version: 7.105.0
       '@types/node':
         specifier: ^18.18.5
         version: 18.18.5
@@ -4559,7 +4566,7 @@ packages:
       '@types/ember__object': ^4.0.4
       '@types/ember__routing': ^4.0.11
       ember-cli-htmlbars: ^6.0.1
-      ember-modifier: ^3.2.7 || ^4.0.0
+      ember-modifier: ^4.1.0
     peerDependenciesMeta:
       '@types/ember__array':
         optional: true
@@ -5190,7 +5197,7 @@ packages:
   /@prettier/sync@0.2.1(prettier@3.1.0-dev):
     resolution: {integrity: sha512-7ls1R6//+GPYD9vof1XaL5psViv83CwpdwlS8oUkWldYgbPhzZ3WgxIQMWqGyBmWPmoBfQg8C7jj7KI/ZuDHhQ==}
     peerDependencies:
-      prettier: ^3.0.0
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     dependencies:
       prettier: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
     dev: true
@@ -5248,6 +5255,45 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /@sentry-internal/tracing@7.105.0:
+    resolution: {integrity: sha512-b+AFYB7Bc9vmyxl2jbmuT4esX5G0oPfpz35A0sxFzmJIhvMg1YMDNio2c81BtKN+VSPORCnKMLhfk3kyKKvWMQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry/core': 7.105.0
+      '@sentry/types': 7.105.0
+      '@sentry/utils': 7.105.0
+    dev: false
+
+  /@sentry/core@7.105.0:
+    resolution: {integrity: sha512-5xsaTG6jZincTeJUmZomlv20mVRZUEF1U/g89lmrSOybyk2+opEnB1JeBn4ODwnvmSik8r2QLr6/RiYlaxRJCg==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry/types': 7.105.0
+      '@sentry/utils': 7.105.0
+    dev: false
+
+  /@sentry/node@7.105.0:
+    resolution: {integrity: sha512-b0QwZ7vT4hcJi6LmNRh3dcaYpLtXnkYXkL0rfhMb8hN8sUx8zuOWFMI7j0cfAloVThUeJVwGyv9dERfzGS2r2w==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry-internal/tracing': 7.105.0
+      '@sentry/core': 7.105.0
+      '@sentry/types': 7.105.0
+      '@sentry/utils': 7.105.0
+    dev: false
+
+  /@sentry/types@7.105.0:
+    resolution: {integrity: sha512-80o0KMVM+X2Ym9hoQxvJetkJJwkpCg7o6tHHFXI+Rp7fawc2iCMTa0IRQMUiSkFvntQLYIdDoNNuKdzz2PbQGA==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /@sentry/utils@7.105.0:
+    resolution: {integrity: sha512-YVAV0c2KLM8+VZCicQ/E/P2+J9Vs0hGhrXwV7w6ZEAtvxrg4oF270toL1WRhvcaf8JO4J1v4V+LuU6Txs4uEeQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@sentry/types': 7.105.0
+    dev: false
 
   /@sideway/address@4.1.4:
     resolution: {integrity: sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==}
@@ -12721,7 +12767,7 @@ packages:
     engines: {node: ^16.0.0 || ^18.0.0 || >=20.0.0}
     peerDependencies:
       ember-template-lint: '>= 4.0.0'
-      prettier: '>= 3.0.0'
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     dependencies:
       '@prettier/sync': 0.2.1(prettier@3.1.0-dev)
       ember-template-lint: 5.11.2
@@ -13552,7 +13598,7 @@ packages:
     peerDependencies:
       eslint: '>=5.0.0'
       eslint-config-prettier: '*'
-      prettier: '>=1.13.0'
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     peerDependenciesMeta:
       eslint-config-prettier:
         optional: true
@@ -13567,10 +13613,10 @@ packages:
     resolution: {integrity: sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      '@types/eslint': '>=8.0.0'
+      '@types/eslint': 8.4.1
       eslint: '>=8.0.0'
       eslint-config-prettier: '*'
-      prettier: '>=3.0.0'
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     peerDependenciesMeta:
       '@types/eslint':
         optional: true
@@ -13588,10 +13634,10 @@ packages:
     resolution: {integrity: sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      '@types/eslint': '>=8.0.0'
+      '@types/eslint': 8.4.1
       eslint: '>=8.0.0'
       eslint-config-prettier: '*'
-      prettier: '>=3.0.0'
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     peerDependenciesMeta:
       '@types/eslint':
         optional: true
@@ -20134,7 +20180,7 @@ packages:
     resolution: {integrity: sha512-zJTC+NhEU0kHNnVh7OtcvMmkJmYTgFTist76FP9q07m9+WCvcaunR1sTFIOlGE9TH/5UGm6rlF86Umt9ouorAg==}
     engines: {node: 16.* || 18.* || >= 20}
     peerDependencies:
-      prettier: '>= 3.0.0'
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     dependencies:
       '@babel/core': 7.22.11(supports-color@8.1.1)
       '@glimmer/syntax': 0.84.3
@@ -24993,7 +25039,3 @@ packages:
     dependencies:
       eslint: 8.37.0
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
This initialises Sentry when `SENTRY_DSN` exists (there’s a corresponding infrastructure PR that connects that). Unhandled exceptions will be caught, and this also adds `Sentry.captureException` wherever an error is caught. It may be that this is overkill so I’m open to suggestion if it seems like some of those should be removed!

Check the `ai-bot` project in Sentry for example errors I’ve triggered. You can deliberately trigger an error by sending a special message starting with `debug:boom`. I’ve also successfully caused errors to be logged using a message like this: `debug:patch:what yes`.