### PR TITLE
Add read only indicator and change background in editor when read only

### DIFF
--- a/packages/boxel-ui/addon/src/icons/icon-pencil-crossed-out.gts
+++ b/packages/boxel-ui/addon/src/icons/icon-pencil-crossed-out.gts
@@ -17,7 +17,7 @@ const IconComponent: TemplateOnlyComponent<Signature> = <template>
       d='M4 20.75a.751.751 0 0 1-.75-.75v-4.181a.755.755 0 0 1 .22-.53L14.711 4.05a2.72 2.72 0 0 1 3.848 0l1.391 1.391a2.72 2.72 0 0 1 0 3.848L8.712 20.53a.747.747 0 0 1-.531.22zm.75-4.621v3.121h3.12l7.91-7.91-3.12-3.12zm12.091-5.849 2.051-2.051a1.223 1.223 0 0 0 0-1.727l-1.393-1.394a1.222 1.222 0 0 0-1.727 0L13.72 7.16z'
     /><path
       fill='none'
-      stroke='#fff'
+      stroke='var(--icon-background-color, #fff)'
       stroke-linecap='round'
       stroke-width='4'
       d='m3.25 3.25 17.5 17.5'

--- a/packages/host/app/components/operator-mode/code-editor.gts
+++ b/packages/host/app/components/operator-mode/code-editor.gts
@@ -39,6 +39,7 @@ interface Signature {
     file: FileResource | undefined;
     moduleContentsResource: ModuleContentsResource | undefined;
     selectedDeclaration: ModuleDeclaration | undefined;
+    isReadOnly: boolean;
     saveSourceOnClose: (url: URL, content: string) => void;
     selectDeclaration: (declaration: ModuleDeclaration) => void;
     onFileSave: (status: 'started' | 'finished') => void;
@@ -287,17 +288,13 @@ export default class CodeEditor extends Component<Signature> {
     return undefined;
   }
 
-  private get readOnly() {
-    return !this.readyFile.realmSession.canWrite;
-  }
-
   <template>
     {{#if this.isReady}}
       {{#if this.readyFile.isBinary}}
         <BinaryFileInfo @readyFile={{this.readyFile}} />
       {{else}}
         <div
-          class='monaco-container'
+          class='monaco-container {{if @isReadOnly "readonly"}}'
           data-test-editor
           data-test-percy-hide
           {{monacoModifier
@@ -307,7 +304,7 @@ export default class CodeEditor extends Component<Signature> {
             language=this.language
             initialCursorPosition=this.initialMonacoCursorPosition
             onCursorPositionChange=this.selectDeclarationByMonacoCursorPosition
-            readOnly=this.readOnly
+            readOnly=@isReadOnly
           }}
         ></div>
       {{/if}}
@@ -324,6 +321,10 @@ export default class CodeEditor extends Component<Signature> {
         width: 100%;
         min-width: 100%;
         padding: var(--boxel-sp) 0;
+      }
+
+      .monaco-container.readonly {
+        background-color: #ebeaed;
       }
 
       .loading {

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -17,13 +17,10 @@ import FromElseWhere from 'ember-elsewhere/components/from-elsewhere';
 
 import { Accordion } from '@cardstack/boxel-ui/components';
 
-import {
-  LoadingIndicator,
-  ResizablePanelGroup,
-} from '@cardstack/boxel-ui/components';
+import { ResizablePanelGroup } from '@cardstack/boxel-ui/components';
 import type { PanelContext } from '@cardstack/boxel-ui/components';
 import { and, not, bool, eq } from '@cardstack/boxel-ui/helpers';
-import { CheckMark, File } from '@cardstack/boxel-ui/icons';
+import { File } from '@cardstack/boxel-ui/icons';
 
 import {
   isCardDocumentString,
@@ -35,8 +32,10 @@ import { SerializedError } from '@cardstack/runtime-common/error';
 import { isEquivalentBodyPosition } from '@cardstack/runtime-common/schema-analysis-plugin';
 
 import RecentFiles from '@cardstack/host/components/editor/recent-files';
+import CodeSubmodeEditorIndicator from '@cardstack/host/components/operator-mode/code-submode/editor-indicator';
 import RealmInfoProvider from '@cardstack/host/components/operator-mode/realm-info-provider';
 import SyntaxErrorDisplay from '@cardstack/host/components/operator-mode/syntax-error-display';
+
 import { getCard } from '@cardstack/host/resources/card-resource';
 import { isReady, type FileResource } from '@cardstack/host/resources/file';
 import {
@@ -657,6 +656,10 @@ export default class CodeSubmode extends Component<Signature> {
     this.selectedAccordionItem = item;
   }
 
+  get isReadOnly() {
+    return !this.readyFile.realmSession.canWrite;
+  }
+
   <template>
     <RealmInfoProvider @realmURL={{this.realmURL}}>
       <:ready as |realmInfo|>
@@ -776,25 +779,14 @@ export default class CodeSubmode extends Component<Signature> {
                     @selectDeclaration={{this.selectDeclaration}}
                     @onFileSave={{this.onSourceFileSave}}
                     @onSetup={{this.setupCodeEditor}}
+                    @isReadOnly={{this.isReadOnly}}
+                  />
+
+                  <CodeSubmodeEditorIndicator
+                    @isSaving={{this.isSaving}}
+                    @isReadOnly={{this.isReadOnly}}
                   />
                 {{/if}}
-                <div class='save-indicator {{if this.isSaving "visible"}}'>
-                  {{#if this.isSaving}}
-                    <span class='saving-msg'>
-                      Now Saving
-                    </span>
-                    <span class='save-spinner'>
-                      <span class='save-spinner-inner'>
-                        <LoadingIndicator />
-                      </span>
-                    </span>
-                  {{else}}
-                    <span data-test-saved class='saved-msg'>
-                      Saved
-                    </span>
-                    <CheckMark width='27' height='27' />
-                  {{/if}}
-                </div>
               </InnerContainer>
             </ResizablePanel>
             <ResizeHandle />
@@ -999,43 +991,6 @@ export default class CodeSubmode extends Component<Signature> {
         margin: 40vh auto;
       }
 
-      .save-indicator {
-        --icon-color: var(--boxel-highlight);
-        position: absolute;
-        display: flex;
-        align-items: center;
-        height: 2.5rem;
-        width: 140px;
-        bottom: 0;
-        right: 0;
-        background-color: var(--boxel-200);
-        padding: 0 var(--boxel-sp-xxs) 0 var(--boxel-sp-sm);
-        border-top-left-radius: var(--boxel-border-radius);
-        font: var(--boxel-font-sm);
-        font-weight: 500;
-        transform: translateX(140px);
-        transition: all var(--boxel-transition);
-        transition-delay: 5s;
-      }
-      .save-indicator.visible {
-        transform: translateX(0px);
-        transition-delay: 0s;
-      }
-      .save-spinner {
-        display: inline-block;
-        position: relative;
-      }
-      .save-spinner-inner {
-        display: inline-block;
-        position: absolute;
-        top: -7px;
-      }
-      .saving-msg {
-        margin-right: var(--boxel-sp-sm);
-      }
-      .saved-msg {
-        margin-right: var(--boxel-sp-xxs);
-      }
       .file-incompatible-message {
         display: flex;
         flex-wrap: wrap;

--- a/packages/host/app/components/operator-mode/code-submode/editor-indicator.gts
+++ b/packages/host/app/components/operator-mode/code-submode/editor-indicator.gts
@@ -1,0 +1,110 @@
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
+
+import { LoadingIndicator } from '@cardstack/boxel-ui/components';
+
+import { CheckMark, IconPencilCrossedOut } from '@cardstack/boxel-ui/icons';
+
+interface Signature {
+  Element: HTMLElement;
+  Blocks: {
+    default: [];
+  };
+  Args: {
+    isReadOnly: boolean;
+    isSaving: boolean;
+  };
+}
+
+const CodeSubmodeEditorIndicator: TemplateOnlyComponent<Signature> = <template>
+  <style>
+    .indicator {
+      position: absolute;
+      display: flex;
+      align-items: center;
+      height: 2.5rem;
+      bottom: 0;
+      right: 0;
+      padding: 0 var(--boxel-sp-xxs) 0 var(--boxel-sp-sm);
+      border-top-left-radius: var(--boxel-border-radius);
+      font: var(--boxel-font-sm);
+      font-weight: 500;
+      transform: translateX(140px);
+      transition: all var(--boxel-transition);
+      transition-delay: 5s;
+      min-width: 140px;
+    }
+
+    .indicator-icon {
+      margin-right: var(--boxel-sp-xxs);
+    }
+
+    .indicator-saving {
+      --icon-color: var(--boxel-highlight);
+      background-color: var(--boxel-200);
+    }
+
+    .indicator-read-only {
+      --icon-color: var(--boxel-800);
+      --icon-background-color: #ffd73c;
+      background-color: #ffd73c;
+    }
+
+    .indicator.visible {
+      transform: translateX(0px);
+      transition-delay: 0s;
+    }
+    .save-spinner {
+      display: inline-block;
+      position: relative;
+    }
+    .save-spinner-inner {
+      display: inline-block;
+      position: absolute;
+      top: -7px;
+    }
+    .indicator-msg {
+      margin-right: var(--boxel-sp-sm);
+    }
+    .saved-msg {
+      margin-right: var(--boxel-sp-xxs);
+    }
+  </style>
+
+  {{#if @isReadOnly}}
+    <div
+      class='indicator indicator-read-only visible'
+      data-test-realm-indicator-not-writable
+    >
+      <span class='indicator-icon'>
+        <IconPencilCrossedOut
+          width='18px'
+          height='18px'
+          aria-label='Cannot edit in read-only space'
+        />
+      </span>
+      <span class='indicator-msg'>
+        Cannot edit in read-only space
+      </span>
+    </div>
+  {{else}}
+    <div class='indicator indicator-saving {{if @isSaving "visible"}}'>
+      {{#if @isSaving}}
+        <span class='indicator-msg'>
+          Now Saving
+        </span>
+        <span class='save-spinner'>
+          <span class='save-spinner-inner'>
+            <LoadingIndicator />
+          </span>
+        </span>
+      {{else}}
+        <span data-test-saved class='indicator-msg'>
+          Saved
+        </span>
+        <CheckMark width='27' height='27' />
+      {{/if}}
+    </div>
+  {{/if}}
+</template>;
+
+export default CodeSubmodeEditorIndicator;

--- a/packages/host/app/modifiers/monaco.ts
+++ b/packages/host/app/modifiers/monaco.ts
@@ -66,6 +66,15 @@ export default class Monaco extends Modifier<Signature> {
         this.model.setValue(content);
       }
     } else {
+      monacoSDK.editor.defineTheme('boxel-theme', {
+        base: 'vs',
+        inherit: true,
+        rules: [],
+        colors: {
+          'editor.background': readOnly ? '#EBEAED' : '#FFFFFF',
+        },
+      });
+
       let editorOptions: MonacoSDK.editor.IStandaloneEditorConstructionOptions =
         {
           readOnly,
@@ -76,6 +85,7 @@ export default class Monaco extends Modifier<Signature> {
           minimap: {
             enabled: false,
           },
+          theme: 'boxel-theme',
         };
 
       // Code rendering is inconsistently wrapped without this, producing spurious visual diffs

--- a/packages/host/tests/acceptance/code-submode/editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/editor-test.ts
@@ -1,4 +1,4 @@
-import { click, waitFor, fillIn } from '@ember/test-helpers';
+import { click, waitFor, fillIn, find } from '@ember/test-helpers';
 
 import { setupApplicationTest } from 'ember-qunit';
 
@@ -798,6 +798,16 @@ module('Acceptance | code submode | editor tests', function (hooks) {
           MonacoSDK.editor.EditorOption.readOnly,
         ),
         'editor should be read-only',
+      );
+
+      assert.dom('[data-test-realm-indicator-not-writable]').exists();
+      assert.strictEqual(
+        find('.monaco-editor')
+          ?.computedStyleMap()
+          .get('background-color')!
+          .toString(),
+        'rgb(235, 234, 237)', // equivalent to #ebeaed
+        'monaco editor is greyed out when read-only',
       );
     });
   });


### PR DESCRIPTION
This PR dims the background a bit and puts the readonly indicator in the code editor when the user doesn't have permission to edit: 

<img width="608" alt="image" src="https://github.com/cardstack/boxel/assets/273660/60963073-05a9-435c-a86c-f4fda16fac20">
