### PR TITLE
Refactoring toward symbol portability

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -29,6 +29,7 @@ import {
   primitive,
   identifyCard,
   isCardDef,
+  isCardInstance as _isCardInstance,
   loadCard,
   humanReadable,
   maybeURL,
@@ -49,18 +50,18 @@ import {
 import type { ComponentLike } from '@glint/template';
 
 export { primitive, isField, type BoxComponent };
-export const serialize = Symbol('cardstack-serialize');
-export const deserialize = Symbol('cardstack-deserialize');
-export const useIndexBasedKey = Symbol('cardstack-use-index-based-key');
-export const fieldDecorator = Symbol('cardstack-field-decorator');
-export const fieldType = Symbol('cardstack-field-type');
-export const queryableValue = Symbol('cardstack-queryable-value');
-export const relativeTo = Symbol('cardstack-relative-to');
-export const realmInfo = Symbol('cardstack-realm-info');
-export const realmURL = Symbol('cardstack-realm-url');
+export const serialize = Symbol.for('cardstack-serialize');
+export const deserialize = Symbol.for('cardstack-deserialize');
+export const useIndexBasedKey = Symbol.for('cardstack-use-index-based-key');
+export const fieldDecorator = Symbol.for('cardstack-field-decorator');
+export const fieldType = Symbol.for('cardstack-field-type');
+export const queryableValue = Symbol.for('cardstack-queryable-value');
+export const relativeTo = Symbol.for('cardstack-relative-to');
+export const realmInfo = Symbol.for('cardstack-realm-info');
+export const realmURL = Symbol.for('cardstack-realm-url');
 // intentionally not exporting this so that the outside world
 // cannot mark a card as being saved
-const isSavedInstance = Symbol('cardstack-is-saved-instance');
+const isSavedInstance = Symbol.for('cardstack-is-saved-instance');
 
 export type BaseInstanceType<T extends BaseDefConstructor> = T extends {
   [primitive]: infer P;
@@ -178,7 +179,7 @@ const subscribers = new WeakMap<BaseDef, Set<CardChangeSubscriber>>();
 // involve rerunning async computed fields)
 const cardTracking = new TrackedWeakMap<object, any>();
 
-const isBaseInstance = Symbol('isBaseInstance');
+const isBaseInstance = Symbol.for('isBaseInstance');
 
 class Logger {
   private promises: Promise<any>[] = [];
@@ -2378,7 +2379,8 @@ export async function updateFromSerialized<T extends BaseDefConstructor>(
   if (!instance[relativeTo] && doc.data.id) {
     instance[relativeTo] = new URL(doc.data.id);
   }
-  if (instance instanceof CardDef) {
+
+  if (isCardInstance(instance)) {
     if (!instance[realmInfo] && doc.data.meta.realmInfo) {
       instance[realmInfo] = doc.data.meta.realmInfo;
     }
@@ -2387,6 +2389,11 @@ export async function updateFromSerialized<T extends BaseDefConstructor>(
     }
   }
   return await _updateFromSerialized(instance, doc.data, doc, identityContext);
+}
+
+// The typescript `is` type here refuses to work unless it's in this file.
+function isCardInstance(instance: any): instance is CardDef {
+  return _isCardInstance(instance);
 }
 
 async function _createFromSerialized<T extends BaseDefConstructor>(
@@ -2425,7 +2432,7 @@ async function _createFromSerialized<T extends BaseDefConstructor>(
   if (!instance) {
     instance = new card({ id: resource.id }) as BaseInstanceType<T>;
     instance[relativeTo] = _relativeTo;
-    if (instance instanceof CardDef) {
+    if (isCardInstance(instance)) {
       instance[realmInfo] = data?.meta?.realmInfo;
       instance[realmURL] = data?.meta?.realmURL
         ? new URL(data.meta.realmURL)
@@ -2507,7 +2514,7 @@ async function _updateFromSerialized<T extends BaseDefConstructor>(
   {
     let wasSaved = false;
     let originalId: string | undefined;
-    if (instance instanceof CardDef) {
+    if (isCardInstance(instance)) {
       wasSaved = instance[isSavedInstance];
       originalId = (instance as CardDef).id; // the instance is a composite card
       instance[isSavedInstance] = false;
@@ -2533,7 +2540,7 @@ async function _updateFromSerialized<T extends BaseDefConstructor>(
       deserialized.set(fieldName as string, value);
       logger.log(recompute(instance));
     }
-    if (instance instanceof CardDef && resource.id != null) {
+    if (isCardInstance(instance) && resource.id != null) {
       // importantly, we place this synchronously after the assignment of the model's
       // fields, such that subsequent assignment of the id field when the model is
       // saved will throw
@@ -2626,7 +2633,7 @@ function makeDescriptor<
     descriptor.set = function (this: BaseInstanceType<CardT>, value: any) {
       if (
         (field.card as typeof BaseDef) === IDField &&
-        this instanceof CardDef &&
+        isCardInstance(this) &&
         this[isSavedInstance]
       ) {
         throw new Error(

--- a/packages/base/cards-grid.gts
+++ b/packages/base/cards-grid.gts
@@ -17,6 +17,7 @@ import {
   getLiveCards,
   baseRealm,
   cardTypeDisplayName,
+  isCardInstance,
 } from '@cardstack/runtime-common';
 import { tracked } from '@glimmer/tracking';
 // @ts-ignore no types
@@ -271,8 +272,8 @@ export class CardsGrid extends CardDef {
   });
 
   static getDisplayName(instance: BaseDef) {
-    if (instance instanceof CardDef) {
-      return instance[realmInfo]?.name ?? this.displayName;
+    if (isCardInstance(instance)) {
+      return (instance as CardDef)[realmInfo]?.name ?? this.displayName;
     }
     return this.displayName;
   }

--- a/packages/runtime-common/code-ref.ts
+++ b/packages/runtime-common/code-ref.ts
@@ -73,11 +73,15 @@ export function isBaseDef(cardOrField: any): cardOrField is typeof BaseDef {
 }
 
 export function isCardDef(card: any): card is typeof CardDef {
-  return !('isFieldDef' in card) && 'isCardDef' in card && isBaseDef(card);
+  return isBaseDef(card) && 'isCardDef' in card;
+}
+
+export function isCardInstance(card: any): card is CardDef {
+  return isCardDef(card?.constructor);
 }
 
 export function isFieldDef(field: any): field is typeof FieldDef {
-  return 'isFieldDef' in field && isBaseDef(field);
+  return isBaseDef(field) && 'isFieldDef' in field;
 }
 
 export function codeRefWithAbsoluteURL(


### PR DESCRIPTION
This switches from `Symbol()` to `Symbol.for()` and replaces use of `instanceof` so that we can refactor toward not caring if different copies of the card api exist and inter-operate.