### PR TITLE
ci: Fix Matrix URL for production previews

### DIFF
--- a/.github/workflows/pr-boxel-host.yml
+++ b/.github/workflows/pr-boxel-host.yml
@@ -83,6 +83,7 @@ jobs:
           OWN_REALM_URL: https://realms.cardstack.com/drafts/
           OTHER_REALM_URLS: https://realms.cardstack.com/published/
           RESOLVED_BASE_REALM_URL: https://realms.cardstack.com/base/
+          MATRIX_URL: https://matrix.cardstack.com
           S3_PREVIEW_BUCKET_NAME: boxel-host-preview.cardstack.com
           AWS_S3_BUCKET: boxel-host-preview.cardstack.com
           AWS_REGION: us-east-1


### PR DESCRIPTION
One can’t currently enter operator mode on production preview deployments because the Matrix URL is missing so it defaults to localhost.