### PR TITLE
Styling loading spinner in stack item

### DIFF
--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -392,7 +392,10 @@ export default class OperatorModeStackItem extends Component<Signature> {
         {{ContentElement onSetup=this.setupContainerEl}}
       >
         {{#if this.loadCard.isRunning}}
-          <LoadingIndicator />
+          <div class='loading' data-test-stack-item-loading-card>
+            <LoadingIndicator @color='var(--boxel-dark)' />
+            <span class='loading__message'>Loading card...</span>
+          </div>
         {{else}}
           <Header
             @title={{this.headerTitle}}
@@ -533,6 +536,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
     <style>
       :global(:root) {
         --stack-card-footer-height: 6rem;
+        --stack-item-header-area-height: 3.5rem;
         --buried-operator-mode-header-height: 2.5rem;
       }
 
@@ -586,7 +590,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
         position: relative;
         height: 100%;
         display: grid;
-        grid-template-rows: 3.5rem auto;
+        grid-template-rows: var(--stack-item-header-area-height) auto;
         box-shadow: var(--boxel-deep-box-shadow);
         pointer-events: auto;
       }
@@ -676,6 +680,26 @@ export default class OperatorModeStackItem extends Component<Signature> {
       .header-icon {
         width: var(--boxel-header-icon-width);
         height: var(--boxel-header-icon-height);
+      }
+
+      .loading {
+        grid-area: 2;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: calc(100% - var(--stack-item-header-area-height));
+        padding: var(--boxel-sp);
+        color: var(--boxel-dark);
+
+        --icon-color: var(--boxel-dark);
+      }
+      .loading__message {
+        margin-left: var(--boxel-sp-5xs);
+      }
+      .loading :deep(.boxel-loading-indicator) {
+        display: flex;
+        justify: center;
+        align-items: center;
       }
     </style>
   </template>


### PR DESCRIPTION
Before:
<img width="983" alt="Screenshot 2024-03-08 at 14 14 08" src="https://github.com/cardstack/boxel/assets/12637010/22d01004-3759-4e4c-93c6-f1e6773cdc82">



After:
<img width="1073" alt="Screenshot 2024-03-08 at 14 09 04" src="https://github.com/cardstack/boxel/assets/12637010/5b910519-b01c-47e6-b7a2-ce43516e44c7">
