### PR TITLE
Fix multiple overlapping card in a stack due to spam clicking

### DIFF
--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -5,7 +5,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
-import { restartableTask, task } from 'ember-concurrency';
+import { dropTask, task } from 'ember-concurrency';
 import { velcro } from 'ember-velcro';
 import { type TrackedArray, TrackedWeakMap } from 'tracked-built-ins';
 
@@ -308,7 +308,7 @@ export default class OperatorModeOverlays extends Component<Signature> {
     return !!this.realmSessionByCard.get(card)?.canWrite;
   }
 
-  private viewCard = restartableTask(
+  private viewCard = dropTask(
     async (
       card: CardDef,
       format: Format = 'isolated',

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -95,7 +95,6 @@ export default class OperatorModeStateService extends Service {
     if (!this.state.stacks[stackIndex]) {
       this.state.stacks[stackIndex] = new TrackedArray([]);
     }
-
     this.state.stacks[stackIndex].push(item);
     this.recentCardsService.add(item.card);
     this.schedulePersist();

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -95,8 +95,10 @@ export default class OperatorModeStateService extends Service {
     if (!this.state.stacks[stackIndex]) {
       this.state.stacks[stackIndex] = new TrackedArray([]);
     }
+
     let index = this.state.stacks[stackIndex].findIndex(
-      (existingItem: StackItem) => existingItem.card.id === item.card.id,
+      (existingItem: StackItem) =>
+        item.card.id && item.card.id === existingItem.card.id,
     );
     if (index > 0) {
       this.state.stacks[stackIndex].splice(index, 1);

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -96,13 +96,6 @@ export default class OperatorModeStateService extends Service {
       this.state.stacks[stackIndex] = new TrackedArray([]);
     }
 
-    let index = this.state.stacks[stackIndex].findIndex(
-      (existingItem: StackItem) =>
-        item.card.id && item.card.id === existingItem.card.id,
-    );
-    if (index > 0) {
-      this.state.stacks[stackIndex].splice(index, 1);
-    }
     this.state.stacks[stackIndex].push(item);
     this.recentCardsService.add(item.card);
     this.schedulePersist();

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -95,6 +95,12 @@ export default class OperatorModeStateService extends Service {
     if (!this.state.stacks[stackIndex]) {
       this.state.stacks[stackIndex] = new TrackedArray([]);
     }
+    let index = this.state.stacks[stackIndex].findIndex(
+      (existingItem: StackItem) => existingItem.card.id === item.card.id,
+    );
+    if (index > 0) {
+      this.state.stacks[stackIndex].splice(index, 1);
+    }
     this.state.stacks[stackIndex].push(item);
     this.recentCardsService.add(item.card);
     this.schedulePersist();

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -806,6 +806,37 @@ module('Acceptance | interact submode tests', function (hooks) {
       await deferred.promise;
     });
 
+    test<TestContextWithSave>('duplicate card in a stack is not allowed', async function (assert) {
+      await visitOperatorMode({
+        stacks: [
+          [
+            {
+              id: `${testRealmURL}index`,
+              format: 'isolated',
+            },
+          ],
+        ],
+      });
+
+      assert
+        .dom(
+          `[data-test-operator-mode-stack="0"] [data-test-cards-grid-item="${testRealmURL}Person/fadhlan"]`,
+        )
+        .exists();
+      await click(
+        `[data-test-operator-mode-stack="0"] [data-test-cards-grid-item="${testRealmURL}Person/fadhlan"]`,
+      );
+      assert
+        .dom(`[data-stack-card="${testRealmURL}Person/fadhlan"]`)
+        .exists({ count: 1 });
+      await click(
+        `[data-test-operator-mode-stack="0"] [data-test-cards-grid-item="${testRealmURL}Person/fadhlan"]`,
+      );
+      assert
+        .dom(`[data-stack-card="${testRealmURL}Person/fadhlan"]`)
+        .exists({ count: 1 });
+    });
+
     test('embedded card from writable realm shows pencil icon in edit mode', async (assert) => {
       await visitOperatorMode({
         stacks: [

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -818,20 +818,20 @@ module('Acceptance | interact submode tests', function (hooks) {
         ],
       });
 
-      assert
-        .dom(
+      await waitFor(
+        `[data-test-operator-mode-stack="0"] [data-test-cards-grid-item="${testRealmURL}Person/fadhlan"]`,
+      );
+      // Simulate simultaneous clicks for spam-clicking
+      await Promise.all([
+        click(
           `[data-test-operator-mode-stack="0"] [data-test-cards-grid-item="${testRealmURL}Person/fadhlan"]`,
-        )
-        .exists();
-      await click(
-        `[data-test-operator-mode-stack="0"] [data-test-cards-grid-item="${testRealmURL}Person/fadhlan"]`,
-      );
-      assert
-        .dom(`[data-stack-card="${testRealmURL}Person/fadhlan"]`)
-        .exists({ count: 1 });
-      await click(
-        `[data-test-operator-mode-stack="0"] [data-test-cards-grid-item="${testRealmURL}Person/fadhlan"]`,
-      );
+        ),
+        click(
+          `[data-test-operator-mode-stack="0"] [data-test-cards-grid-item="${testRealmURL}Person/fadhlan"]`,
+        ),
+      ]);
+
+      await waitFor(`[data-stack-card="${testRealmURL}Person/fadhlan"]`);
       assert
         .dom(`[data-stack-card="${testRealmURL}Person/fadhlan"]`)
         .exists({ count: 1 });


### PR DESCRIPTION
Ticket: CS-6590

~~This PR addresses an issue where multiple overlapping cards could appear in a stack if the user spam-clicked the card grid item. To prevent this, I've implemented a mechanism to disallow multiple cards with the same ID from being opened in a stack. Additionally, if there are duplicate cards in a stack, the latest one will be opened at the top of the stack. While it's unlikely that we'd need multiple cards with the same ID in a stack, I'm open to exploring alternative approaches to resolve this issue.~~

Based on @jurgenwerk 's feedback, I updated the approach to solve this issue by using `dropTask`.