### PR TITLE
Support Matrix "Local Echo" when dealing with card fragments

### DIFF
--- a/packages/ai-bot/tests/history-construction-test.ts
+++ b/packages/ai-bot/tests/history-construction-test.ts
@@ -457,8 +457,9 @@ module('constructHistory', () => {
           data: JSON.stringify({
             context: {
               functions: [],
+              openCardIds: ['http://localhost:4201/drafts/Author/1'],
             },
-            attachedCardsTxnIds: ['1'],
+            attachedCardsTxnIds: ['1', '3'],
           }),
         },
         sender: '@user:localhost',
@@ -484,26 +485,9 @@ module('constructHistory', () => {
           data: {
             context: {
               functions: [],
-              openCards: [
-                {
-                  data: {
-                    type: 'card',
-                    id: 'http://localhost:4201/drafts/Author/1',
-                    attributes: {
-                      firstName: 'Mango',
-                      lastName: 'Abdel-Rahman',
-                    },
-                    meta: {
-                      adoptsFrom: {
-                        module: '../author',
-                        name: 'Author',
-                      },
-                    },
-                  },
-                },
-              ],
+              openCardIds: ['http://localhost:4201/drafts/Author/1'],
             },
-            attachedCardsTxnIds: ['1'],
+            attachedCardsTxnIds: ['1', '3'],
             attachedCards: [
               {
                 data: {
@@ -512,6 +496,22 @@ module('constructHistory', () => {
                   attributes: {
                     firstName: 'Terry',
                     lastName: 'Pratchett',
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: '../author',
+                      name: 'Author',
+                    },
+                  },
+                },
+              },
+              {
+                data: {
+                  type: 'card',
+                  id: 'http://localhost:4201/drafts/Author/1',
+                  attributes: {
+                    firstName: 'Mango',
+                    lastName: 'Abdel-Rahman',
                   },
                   meta: {
                     adoptsFrom: {

--- a/packages/ai-bot/tests/history-construction-test.ts
+++ b/packages/ai-bot/tests/history-construction-test.ts
@@ -457,9 +457,8 @@ module('constructHistory', () => {
           data: JSON.stringify({
             context: {
               functions: [],
-              openCardsEventIds: ['3'],
             },
-            attachedCardsEventIds: ['1'],
+            attachedCardsTxnIds: ['1'],
           }),
         },
         sender: '@user:localhost',
@@ -485,7 +484,6 @@ module('constructHistory', () => {
           data: {
             context: {
               functions: [],
-              openCardsEventIds: ['3'],
               openCards: [
                 {
                   data: {
@@ -505,7 +503,7 @@ module('constructHistory', () => {
                 },
               ],
             },
-            attachedCardsEventIds: ['1'],
+            attachedCardsTxnIds: ['1'],
             attachedCards: [
               {
                 data: {

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -204,8 +204,8 @@ test.describe('Room messages', () => {
     let boxelMessageData = JSON.parse(boxelMessage.content.data);
     // the card fragment events need to come before the boxel message event they
     // are used in, and the boxel message should point to the first fragment
-    expect(boxelMessageData.attachedCardsEventIds).toMatchObject([
-      cardFragments[0].event_id,
+    expect(boxelMessageData.attachedCardsTxnIds).toMatchObject([
+      cardFragments[0].unsigned.transaction_id,
     ]);
   });
 


### PR DESCRIPTION
The issue we were encountering in staging where we would get missing card fragment errors was due to a matrix feature called "local echo". This feature allows matrix clients to handle local messages before they have received a matrix server response. These locally echoed events are special in that their event ID's are actually not "real" event Id's rather the event ID is actually a transaction ID, and according to the matrix spec, the onus is on the client to correlate locally issued events with events received from the server (which have the real ID in them). so our client was dutifully gathering event Ids from card fragments and setting those in our boxel messages. However, the locally received events had transaction ID's masquerading as event ID's and the card fragments could not be constructed properly due to this ID mismatch. Oddly, when the matrix server is running locally, local echoes are not used (probably the matrix client is able to recognize this particular scenario and disable the feature).

The fix here is to use transaction ID's instead of event ID's for stitching together the card fragments since we can rely on those being consistent. Additionally, I added some logic to migrate the existing matrix events since this is a breaking change. We should remove this migration the next time we reset the state of the hosted matrix.