### PR TITLE
Fix unable to scroll messages in chat panel

### DIFF
--- a/packages/host/app/components/ai-assistant/message/index.gts
+++ b/packages/host/app/components/ai-assistant/message/index.gts
@@ -233,7 +233,6 @@ export class AiAssistantConversation extends Component<AiAssistantConversationSi
       .ai-assistant-conversation {
         display: flex;
         flex-direction: column;
-        justify-content: flex-end;
         padding: var(--boxel-sp);
         overflow-y: auto;
       }

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -8,6 +8,7 @@ import { enqueueTask, restartableTask, timeout, all } from 'ember-concurrency';
 
 import { TrackedMap } from 'tracked-built-ins';
 
+import scrollIntoViewModifier from '@cardstack/host/modifiers/scroll-into-view';
 import { getRoom } from '@cardstack/host/resources/room';
 
 import type CardService from '@cardstack/host/services/card-service';
@@ -41,7 +42,11 @@ export default class Room extends Component<Signature> {
       {{#if this.room.messages}}
         <AiAssistantConversation>
           {{#each this.room.messages as |message i|}}
-            <RoomMessage @message={{message}} data-test-message-idx={{i}} />
+            <RoomMessage
+              @message={{message}}
+              data-test-message-idx={{i}}
+              {{scrollIntoViewModifier (this.isLastMessage i)}}
+            />
           {{/each}}
         </AiAssistantConversation>
       {{else}}
@@ -250,6 +255,12 @@ export default class Room extends Component<Signature> {
           this.cardsToAttach?.length ||
           this.autoAttachedCard,
       )
+    );
+  }
+
+  private isLastMessage(messageIndex: number) {
+    return (
+      (this.room && messageIndex === this.room.messages.length - 1) ?? false
     );
   }
 }

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -258,6 +258,7 @@ export default class Room extends Component<Signature> {
     );
   }
 
+  @action
   private isLastMessage(messageIndex: number) {
     return (
       (this.room && messageIndex === this.room.messages.length - 1) ?? false


### PR DESCRIPTION
Ticket: CS-6620

We attempted to set the scroll position to the last message in a room using `justify-content: flex-end;`. However, this prevented us from scrolling through messages. To resolve this issue, I removed `justify-content: flex-end;` and implemented `scrollIntoViewModifier` in the room messages.



https://github.com/cardstack/boxel/assets/12637010/0940fa23-93b9-4854-934e-258b004b6c0f



