### PR TITLE
boxel-motion improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,19 @@ jobs:
         if: always()
         run: pnpm run lint
         working-directory: packages/boxel-ui/test-app
+      - name: Lint Boxel Motion
+        if: always()
+        run: pnpm run lint
+        working-directory: packages/boxel-motion/addon
+      - name: Build Boxel Motion
+        # To faciliate linting of projects that depend on Boxel Motion
+        if: always()
+        run: pnpm run build
+        working-directory: packages/boxel-motion/addon
+      - name: Lint Boxel Motion Test App
+        if: always()
+        run: pnpm run lint
+        working-directory: packages/boxel-motion/test-app
       - name: Lint Host
         if: always()
         run: pnpm run lint
@@ -159,6 +172,9 @@ jobs:
       - name: Build boxel-ui
         run: pnpm build
         working-directory: packages/boxel-ui/addon
+      - name: Build boxel-motion
+        run: pnpm build
+        working-directory: packages/boxel-motion/addon
       - name: Build host dist/ for fastboot
         run: pnpm build
         env:
@@ -192,6 +208,9 @@ jobs:
       - name: Build boxel-ui
         run: pnpm build
         working-directory: packages/boxel-ui/addon
+      - name: Build boxel-motion
+        run: pnpm build
+        working-directory: packages/boxel-motion/addon
       - name: Build host dist/ for fastboot
         run: pnpm build
         env:

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -21,11 +21,13 @@ To build the entire repository and run the application, follow these steps:
    pnpm install
    ```
 
-4. Build the boxel-ui:
+4. Build the boxel-ui and boxl-motion addons:
 
    ```zsh
    cd ./packages/boxel-ui/addon
    pnpm rebuild:icons
+   pnpm build
+   cd ../../boxel-motion/addon
    pnpm build
    ```
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ Make sure that you have created a matrix user for the base realm, drafts realm, 
 In order to run the ember-cli hosted app:
 
 1. `pnpm build` in the boxel-ui/addon workspace to build the boxel-ui addon.
-2. `pnpm start` in the host/ workspace to serve the ember app. Note that this script includes the environment variable `OWN_REALM_URL=http://localhost:4201/draft/` which configures the host to point to the draft realm's cards realm by default.
-3. `pnpm start:all` in the realm-server/ to serve the base realm, draft realm and published realm -- this will also allow you to switch between the app and the tests without having to restart servers)
+2. `pnpm build` in the boxel-motion/addon workspace to build the boxel-motion addon.
+3. `pnpm start` in the host/ workspace to serve the ember app. Note that this script includes the environment variable `OWN_REALM_URL=http://localhost:4201/draft/` which configures the host to point to the draft realm's cards realm by default.
+4. `pnpm start:all` in the realm-server/ to serve the base realm, draft realm and published realm -- this will also allow you to switch between the app and the tests without having to restart servers)
 
 The app is available at http://localhost:4200. It will serve the draft realm (configurable with OWN_REALM_URL, as mentioned above). You can open the base and draft cards workspace directly by entering http://localhost:4201/base or http://localhost:4201/draft in the browser (and additionally the published realm by entering http://localhost:4201/published).
 

--- a/packages/boxel-motion/addon/package.json
+++ b/packages/boxel-motion/addon/package.json
@@ -117,6 +117,7 @@
       "types": "./declarations/*.d.ts",
       "default": "./dist/*.js"
     },
+    "./styles/*.css": "./dist/styles/*.css",
     "./addon-main.js": "./addon-main.cjs"
   },
   "files": [

--- a/packages/boxel-motion/addon/rollup.config.mjs
+++ b/packages/boxel-motion/addon/rollup.config.mjs
@@ -51,6 +51,10 @@ export default {
     // Ensure that .gjs files are properly integrated as Javascript
     addon.gjs(),
 
+    // addons are allowed to contain imports of .css files, which we want rollup
+    // to leave alone and keep in the published output.
+    addon.keepAssets(['styles/*']),
+
     // Remove leftover build artifacts when starting a new build.
     addon.clean({ runOnce: true }),
 

--- a/packages/boxel-motion/addon/src/behaviors/base.ts
+++ b/packages/boxel-motion/addon/src/behaviors/base.ts
@@ -36,6 +36,8 @@ export type Frame = {
 export type FrameGenerator = Generator<Frame | void, void, never>;
 
 export default interface Behavior {
+  fill: boolean;
+
   /**
    * Calculates the frames for the given parameters.
    *

--- a/packages/boxel-motion/addon/src/behaviors/spring.ts
+++ b/packages/boxel-motion/addon/src/behaviors/spring.ts
@@ -36,6 +36,7 @@ type SpringValues = {
 };
 
 export default class SpringBehavior implements Behavior {
+  fill = true;
   private options: SpringOptions;
 
   constructor(options?: SpringOptionsArgument) {

--- a/packages/boxel-motion/addon/src/behaviors/static.ts
+++ b/packages/boxel-motion/addon/src/behaviors/static.ts
@@ -1,16 +1,23 @@
-import type Behavior from './base.ts';
+import type Behavior from './base';
 import {
   type Frame,
   type StaticToFramesArgument,
   timeToFrame,
 } from './base.ts';
 
+export interface StaticBehaviorOptions {
+  fill?: boolean;
+}
 export default class StaticBehavior implements Behavior {
+  fill: boolean;
+  constructor(options?: StaticBehaviorOptions) {
+    this.fill = options?.fill ?? false;
+  }
+
   *getFrames(options: StaticToFramesArgument) {
     let frameCount = timeToFrame(options.duration) + 1;
 
     for (let i = 0; i < frameCount; i++) {
-      // TODO: this can explicitly be non-numeric, fix TS
       yield { value: options.value, velocity: 0 } as Frame;
     }
   }

--- a/packages/boxel-motion/addon/src/behaviors/tween.ts
+++ b/packages/boxel-motion/addon/src/behaviors/tween.ts
@@ -15,6 +15,7 @@ export interface TweenBehaviorOptions {
 }
 
 export default class TweenBehavior implements Behavior {
+  fill = true;
   easing: Easing;
 
   constructor(options?: TweenBehaviorOptions) {

--- a/packages/boxel-motion/addon/src/behaviors/wait.ts
+++ b/packages/boxel-motion/addon/src/behaviors/wait.ts
@@ -2,6 +2,7 @@ import type Behavior from './base.ts';
 import { type WaitToFramesArgument, timeToFrame } from './base.ts';
 
 export default class WaitBehavior implements Behavior {
+  fill = false;
   *getFrames(options: WaitToFramesArgument) {
     let frameCount = timeToFrame(options.duration) + 1;
 

--- a/packages/boxel-motion/addon/src/index.ts
+++ b/packages/boxel-motion/addon/src/index.ts
@@ -4,13 +4,14 @@ import StaticBehavior from './behaviors/static.ts';
 import TweenBehavior from './behaviors/tween.ts';
 import WaitBehavior from './behaviors/wait.ts';
 import AnimationContext from './components/animation-context.gts';
-import { type Changeset } from './models/animator.ts';
+import { type Changeset, type IContext } from './models/animator.ts';
 import {
   type AnimationDefinition,
   type AnimationTimeline,
   OrchestrationMatrix,
 } from './models/orchestration.ts';
 import Sprite, { type ISpriteModifier, SpriteType } from './models/sprite.ts';
+import sprite from './modifiers/sprite.ts';
 import AnimationsService from './services/animations.ts';
 
 export {
@@ -20,10 +21,12 @@ export {
   AnimationTimeline,
   Changeset,
   FPS,
+  IContext,
   ISpriteModifier,
   OrchestrationMatrix,
   SpringBehavior,
-  Sprite,
+  Sprite, // model
+  sprite, // modifier
   SpriteType,
   StaticBehavior,
   TweenBehavior,

--- a/packages/boxel-motion/addon/src/models/sprite.ts
+++ b/packages/boxel-motion/addon/src/models/sprite.ts
@@ -163,9 +163,14 @@ export default class Sprite {
 
   get initial(): { [k in string]: Value } {
     let initialBounds = {};
+    let boundsRect: DOMRect;
     if (this.initialBounds) {
-      let { x, y, width, height, top, right, bottom, left } =
-        this.initialBounds.relativeToParent;
+      if (this.type == SpriteType.Removed) {
+        // because removed sprites are moved to the orphans container under the AnimationContext
+        boundsRect = this.initialBounds.relativeToContext;
+      } else {
+        boundsRect = this.initialBounds.relativeToParent;
+      }
 
       initialBounds = {
         // TODO: maybe also for top/left?
@@ -173,14 +178,14 @@ export default class Sprite {
         'translate-x': `${-(this.boundsDelta?.x ?? 0)}px`,
         'translate-y': `${-(this.boundsDelta?.y ?? 0)}px`,
 
-        x: `${x}px`,
-        y: `${y}px`,
-        width: `${width}px`,
-        height: `${height}px`,
-        top: `${top}px`,
-        right: `${right}px`,
-        bottom: `${bottom}px`,
-        left: `${left}px`,
+        x: `${boundsRect.x}px`,
+        y: `${boundsRect.y}px`,
+        width: `${boundsRect.width}px`,
+        height: `${boundsRect.height}px`,
+        top: `${boundsRect.top}px`,
+        right: `${boundsRect.right}px`,
+        bottom: `${boundsRect.bottom}px`,
+        left: `${boundsRect.left}px`,
       };
     }
 

--- a/packages/boxel-motion/addon/src/styles/addon.css
+++ b/packages/boxel-motion/addon/src/styles/addon.css
@@ -1,0 +1,9 @@
+.animation-context {
+  position: relative;
+}
+.animation-context.debugging {
+  border: 1px dashed blue;
+}
+.animation-context.debugging .sprite {
+  border: 1px dotted green;
+}

--- a/packages/boxel-motion/addon/src/utils/generate-frames.ts
+++ b/packages/boxel-motion/addon/src/utils/generate-frames.ts
@@ -75,7 +75,6 @@ export default function generateFrames(
 
     return resolveFrameGenerator(normalizedProperty, generator);
   }
-
   if (typeof options !== 'object') {
     if (!(timing.behavior instanceof StaticBehavior)) {
       throw new Error(
@@ -84,7 +83,7 @@ export default function generateFrames(
     }
 
     if (!timing.duration) {
-      throw new Error('Static behavior requires a duration');
+      timing.duration = 1;
     }
 
     // todo maybe throw error if options is not numeric or string

--- a/packages/boxel-motion/test-app/app/app.js
+++ b/packages/boxel-motion/test-app/app/app.js
@@ -2,6 +2,7 @@ import Application from '@ember/application';
 import config from 'boxel-motion-test-app/config/environment';
 import loadInitializers from 'ember-load-initializers';
 import Resolver from 'ember-resolver';
+import '@cardstack/boxel-motion/styles/addon.css';
 import './deprecation-workflow';
 
 export default class App extends Application {

--- a/packages/boxel-motion/test-app/app/controllers/split-view.ts
+++ b/packages/boxel-motion/test-app/app/controllers/split-view.ts
@@ -1,0 +1,88 @@
+import {
+  type Changeset,
+  StaticBehavior,
+  SpringBehavior,
+  AnimationDefinition,
+} from '@cardstack/boxel-motion';
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class SplitView extends Controller {
+  @tracked isViewSplit = false;
+
+  @action
+  toggle() {
+    this.isViewSplit = !this.isViewSplit;
+  }
+
+  transition(changeset: Changeset): AnimationDefinition {
+    let animationDefinition: AnimationDefinition = {
+      timeline: {
+        type: 'parallel',
+        animations: [],
+      },
+    };
+    addPanelAnimation.call(this, changeset, animationDefinition);
+    return animationDefinition;
+  }
+}
+
+function addPanelAnimation(
+  changeset: Changeset,
+  animationDefinition: AnimationDefinition,
+) {
+  let containerSprite = changeset.spriteFor({
+    id: 'sidebar-container',
+  });
+  if (!containerSprite) {
+    return;
+  }
+  let behavior = new SpringBehavior({ overshootClamping: true });
+  animationDefinition.timeline.animations.push({
+    sprites: new Set([containerSprite]),
+    properties: {
+      width: {},
+    },
+    timing: {
+      behavior,
+    },
+  });
+  let contentSprite = changeset.spriteFor({
+    id: 'sidebar-content',
+  });
+  if (contentSprite) {
+    animationDefinition.timeline.animations.push({
+      sprites: new Set([contentSprite]),
+      properties: {
+        left: {
+          from: contentSprite.initial?.left || containerSprite.initial.width,
+          to: contentSprite.final?.left || containerSprite.initial.right,
+        },
+      },
+      timing: {
+        behavior,
+      },
+    });
+    let fixedContentWidth = Math.max(
+      contentSprite.initialBounds?.element?.width || 0,
+      contentSprite.finalBounds?.element?.width || 0,
+    );
+    animationDefinition.timeline.animations.push({
+      sprites: new Set([contentSprite]),
+      properties: {
+        width: `${fixedContentWidth}px`,
+      },
+      timing: {
+        behavior: new StaticBehavior({ fill: true }),
+      },
+    });
+  }
+}
+
+// DO NOT DELETE: this is how TypeScript knows how to look up your controllers.
+declare module '@ember/controller' {
+  interface Registry {
+    'split-view': SplitView;
+  }
+}

--- a/packages/boxel-motion/test-app/app/router.js
+++ b/packages/boxel-motion/test-app/app/router.js
@@ -22,4 +22,5 @@ Router.map(function () {
   this.route('simple-orchestration');
   this.route('list');
   this.route('in-out');
+  this.route('split-view');
 });

--- a/packages/boxel-motion/test-app/app/styles/app.css
+++ b/packages/boxel-motion/test-app/app/styles/app.css
@@ -5,6 +5,5 @@
 @import 'nested-contexts.css';
 @import 'nested-sprites.css';
 @import 'prune-and-graft.css';
-@import 'removed-sprite-interruption.css';
 @import 'motion-study/details.css';
 @import 'motion-study/index.css';

--- a/packages/boxel-motion/test-app/app/templates/application.hbs
+++ b/packages/boxel-motion/test-app/app/templates/application.hbs
@@ -39,7 +39,7 @@
   <li>
     <LinkTo @route="removed-sprite-interruption">
       Removed Sprite Interruption
-    </LinkTo>
+    </LinkTo>     
   </li>
   <li>
     <LinkTo @route="list">
@@ -59,6 +59,11 @@
   <li>
     <LinkTo @route="prune-and-graft">
       Prune And Graft
+    </LinkTo>
+  </li>
+  <li>
+    <LinkTo @route="split-view">
+      Split View
     </LinkTo>
   </li>
 </ul>

--- a/packages/boxel-motion/test-app/app/templates/removed-sprite-interruption.hbs
+++ b/packages/boxel-motion/test-app/app/templates/removed-sprite-interruption.hbs
@@ -25,3 +25,50 @@
     </button>
   </div>
 </div>
+<style>
+  .container {
+    padding: 12px;
+  }
+
+  .double-render > div:first-child > * {
+    outline: 4px solid red !important;
+  }
+
+  .double-render {
+    width: 200px;
+    height: 220px;
+    border-radius: 8px;
+    border: 1px solid black;
+    position: relative;
+  }
+
+  .count {
+    position: absolute;
+    left: 50%;
+    bottom: 0;
+    transform: translateX(-50%);
+  }
+
+  .sprite {
+    background: #faa;
+    width: 180px;
+    height: 180px;
+    border-radius: 8px;
+    margin: 4px auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+  }
+
+  .buttons {
+    padding: 12px 0px;
+    display: flex;
+    gap: 4px;
+  }
+
+  .button {
+    border: 1px solid black;
+    background: #eee;
+  }
+</style>

--- a/packages/boxel-motion/test-app/app/templates/split-view.hbs
+++ b/packages/boxel-motion/test-app/app/templates/split-view.hbs
@@ -1,0 +1,32 @@
+<style>
+  .split-view-toggle-button {
+      position: absolute;
+      bottom: 1.25rem;
+      right: 1.25rem;
+      margin-right: 0;
+    }
+</style>
+<AnimationContext
+  @use={{this.transition}} class="w-2/3 h-64 mx-auto flex flex-row overflow-hidden"
+>
+  <div class="flex-grow bg-yellow-lightest relative">
+    <div class="border border-blue bg-white my-12 mx-16 h-32 rounded">
+      <h2 class="mx-auto mt-12 w-12 text-center font-bold">Hello</h2>
+    </div>
+    <button
+      class="split-view-toggle-button w-12 h-12 text-white rounded shadow sprite {{if this.isViewSplit 'bg-green-light' 'bg-green-dark'}}"
+      type="button" {{on "click" this.toggle}}
+    >Toggle</button>
+  </div>
+  <div class="{{if this.isViewSplit 'w-64' 'w-0'}} bg-green-light flex-none sprite" {{sprite id="sidebar-container"}}>
+    {{#if this.isViewSplit}}
+      <div class="p-6 bg-green-dark relative sprite" {{sprite id="sidebar-content"}}>
+        <h2>Sidebar</h2>
+        <button class="split-view-close-button w-6 h-6 border border-green rounded absolute pin-t pin-r" type="button" {{on "click" this.toggle}}>X</button>
+        <div>
+          This is my sidebar content. There is a lot of important information here.
+        </div>
+      </div>
+    {{/if}}
+  </div>
+</AnimationContext>

--- a/packages/boxel-motion/test-app/vendor/app.css
+++ b/packages/boxel-motion/test-app/vendor/app.css
@@ -172,13 +172,6 @@ video {
 
 /* ======================== */
 
-.animation-context {
-  /* border: 1px dashed blue; */
-  position: relative;
-}
-.sprite {
-  /* border: 1px dotted green; */
-}
 .some-container.with-padded-animation-context .animation-context {
   padding: 20px;
 }


### PR DESCRIPTION
- Add Split View example to boxel-motion test app as a study for the AI Assistant Panel animation
- Incorporate boxel-motion builds into CI
- Generalize fill behavior of behaviors rather than special casing StaticBehavior treatment
- Default StaticBehavior to a duration of 1, since you can now opt into forward fill
    - when using StaticBehavior with SpringBehavior, you don't know how long the animation will be, and you may want a static animation to persist for the duration of the animation
- Use context-relative bounds for removed sprites

_extracted from #1097_
