### PR TITLE
Do not show bot streaming message indicator when it sends an error or an apply option

### DIFF
--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -104,6 +104,7 @@ async function sendOption(
     msgtype: 'org.boxel.command',
     formatted_body: body,
     format: 'org.matrix.custom.html',
+    isStreamingFinished: true,
     data: {
       command: {
         type: 'patch',
@@ -159,6 +160,9 @@ async function sendError(
       room,
       'There was an error processing your request, please try again later',
       eventToUpdate,
+      {
+        isStreamingFinished: true,
+      },
     );
   } catch (e) {
     // We've had a problem sending the error message back to the user

--- a/packages/base/room.gts
+++ b/packages/base/room.gts
@@ -520,6 +520,7 @@ export class RoomField extends FieldDef {
               commandType: command.type,
               payload: command,
             }),
+            isStreamingFinished: true,
           });
         } else {
           // Text from the AI bot


### PR DESCRIPTION
Forgot to address this case in https://github.com/cardstack/boxel/pull/1104. 

Fixes a bug where the ai avatar kept spinning when the message sent was either an error or a prompt to apply the patch:

<img width="780" alt="image" src="https://github.com/cardstack/boxel/assets/273660/d95fabb7-ba81-43f0-9b21-f4ab20aea78a">