### PR TITLE
Draft: Refactor resizable panel

### DIFF
--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
@@ -572,7 +572,7 @@ export default class ResizablePanelGroup extends Component<Signature> {
 
     // console.log(`newContainerSize ${newContainerSize}`);
 
-    // this.listPanelContext.recomputeLengthsOnResize(newContainerSize);
+    this.listPanelContext.recomputeLengthsOnResize(newContainerSize);
   }
 
   private findPanelsByResizeHandle(ResizeHandleId: string) {
@@ -749,68 +749,74 @@ class PanelContextMap {
     }
   }
 
-  //   recomputeLengthsOnResize(newSize: number) {
-  //     //keep ratios stale
-  //     let remainingContainerSize = newSize;
-  //     let totalNewPanelRatio = Array.from(this.values())
-  //       .filter((c) => !c.initialMinLengthPx && c.ratio)
-  //       .map((c) => c.ratio!)
-  //       .reduce((accum, currentValue) => {
-  //         if (currentValue) {
-  //           return accum + currentValue;
-  //         } else {
-  //           return accum;
-  //         }
-  //       }, 0);
-  //     if (totalNewPanelRatio === 0) {
-  //       if (this.size === 3) {
-  //         debugger;
-  //       }
-  //       throw new Error('new ratio 0');
-  //     }
-  //     // for (const [k, v] of this.entries()) {
-  //     //   if (v.initialMinLengthPx) {
-  //     //     let proportionalSize = v.ratio * newSize;
-  //     //     let actualSize = proportionalSize; //v.initialMinLengthPx;
-  //     //     // Math.round(Math.max(proportionalSize, v.initialMinLengthPx)); //tricky
-  //     //     this.set(k, { ...v, lengthPx: actualSize }, false);
-  //     //   }
-  //     // }
-  //     // remainingContainerSize =
-  //     //   remainingContainerSize - this.totalLengthInitialhMinLengthPx;
-  //     // let totalNewPanelRatio = Array.from(this.values())
-  //     //   .filter((c) => !c.initialMinLengthPx && c.ratio)
-  //     //   .map((c) => c.ratio!)
-  //     //   .reduce((accum, currentValue) => {
-  //     //     if (currentValue) {
-  //     //       return accum + currentValue;
-  //     //     } else {
-  //     //       return accum;
-  //     //    4
-  //     //   }, 0);
-  //     // if (totalNewPanelRatio === 0) {
-  //     //   return;
-  //     // }
-  //     for (const [k, v] of this.entries()) {
-  //       if (!v.initialMinLengthPx) {
-  //         if (v.ratio === undefined) {
-  //           debugger;
-  //           throw new Error('ratio undefined');
-  //         }
-  //         let newPanelRatio = v.ratio / totalNewPanelRatio;
-  //         let proportionalSize = newPanelRatio * remainingContainerSize;
-  //         let actualSize = Math.round(proportionalSize);
-  //         this.set(
-  //           k,
-  //           {
-  //             ...v,
-  //             ratio: newPanelRatio, //newPanelRatio ?? v.defaultLengthFraction,
-  //             lengthPx: actualSize,
-  //           },
-  //           false,
-  //         );
-  //       }
-  //     }
-  //   }
-  // }
+  recomputeLengthsOnResize(newSize: number) {
+    //keep ratios stale
+    let remainingContainerSize = newSize;
+    if (this.isRatioStale) {
+      throw new Error('ratio is stale');
+    }
+    let totalNewPanelRatio = sumArray(this.ratios);
+
+    // let totalNewPanelRatio = Array.from(this.values())
+    //   .filter((c) => !c.initialMinLengthPx && c.ratio)
+    //   .map((c) => c.ratio!)
+    //   .reduce((accum, currentValue) => {
+    //     if (currentValue) {
+    //       return accum + currentValue;
+    //     } else {
+    //       return accum;
+    //     }
+    //   }, 0);
+    if (totalNewPanelRatio === 0) {
+      if (this.size === 3) {
+        debugger;
+      }
+      throw new Error('new ratio 0');
+    }
+    // for (const [k, v] of this.entries()) {
+    //   if (v.initialMinLengthPx) {
+    //     let proportionalSize = v.ratio * newSize;
+    //     let actualSize = proportionalSize; //v.initialMinLengthPx;
+    //     // Math.round(Math.max(proportionalSize, v.initialMinLengthPx)); //tricky
+    //     this.set(k, { ...v, lengthPx: actualSize }, false);
+    //   }
+    // }
+    // remainingContainerSize =
+    //   remainingContainerSize - this.totalLengthInitialhMinLengthPx;
+    // let totalNewPanelRatio = Array.from(this.values())
+    //   .filter((c) => !c.initialMinLengthPx && c.ratio)
+    //   .map((c) => c.ratio!)
+    //   .reduce((accum, currentValue) => {
+    //     if (currentValue) {
+    //       return accum + currentValue;
+    //     } else {
+    //       return accum;
+    //    4
+    //   }, 0);
+    // if (totalNewPanelRatio === 0) {
+    //   return;
+    // }
+    for (const [k, v] of this.#panelContextMap.entries()) {
+      if (!v.initialMinLengthPx) {
+        let ratio = this.#ratios.get(k);
+        if (ratio === undefined) {
+          debugger;
+          throw new Error('ratio undefined');
+        }
+        let newPanelRatio = ratio / totalNewPanelRatio;
+        this.#ratios.set(k, newPanelRatio);
+
+        let proportionalSize = newPanelRatio * remainingContainerSize;
+        let actualSize = Math.round(proportionalSize);
+        this.set(
+          k,
+          {
+            ...v,
+            lengthPx: actualSize,
+          },
+          false,
+        );
+      }
+    }
+  }
 }

--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
@@ -159,6 +159,7 @@ export default class ResizablePanelGroup extends Component<Signature> {
       ? resizeHandleContainer[this.offsetLengthProperty]
       : 0;
     let panelGroupElement = this.panelGroupElement;
+    debugger;
     if (panelGroupElement === undefined) {
       console.warn('Expected panelGroupElement to be defined');
       return undefined;
@@ -189,7 +190,7 @@ export default class ResizablePanelGroup extends Component<Signature> {
   minimumLengthToShowHandles = 30;
 
   resizablePanelIdCache = new WeakMap<ResizablePanel, number>();
-  listPanelContext = new TrackedMap<number, PanelContext>();
+  listPanelContext = new PanelContextMap();
   currentResizeHandle: {
     id: string;
     initialPosition: number;
@@ -201,73 +202,115 @@ export default class ResizablePanelGroup extends Component<Signature> {
   @action
   registerPanel(context: {
     collapsible: boolean | undefined;
-    defaultLengthFraction: number | undefined;
-    lengthPx: number | undefined;
+    defaultLengthFraction: number;
     minLengthPx: number | undefined;
   }) {
     let id = Number(this.listPanelContext.size);
 
-    if (context.lengthPx === undefined) {
-      if (
-        this.panelGroupLengthPx === undefined ||
-        context.defaultLengthFraction === undefined
-      ) {
-        context.lengthPx = -1;
-      } else {
-        context.lengthPx =
-          context.defaultLengthFraction * this.panelGroupLengthPx;
-      }
+    // if (context.lengthPx === undefined) {
+    //   if (
+    //     this.panelGroupLengthPx === undefined ||
+    //     context.defaultLengthFraction === undefined
+    //   ) {
+    //     context.lengthPx = -1;
+    //   } else {
+    //     context.lengthPx =
+    //       context.defaultLengthFraction * this.panelGroupLengthPx;
+    //   }
+    // }
+    // context.lengthPx = context.defaultLengthFraction * this.panelGroupLengthPx;
+    if (this.args.orientation === 'horizontal') {
+      // console.log('===========');
+      // console.log('==compare sum====');
+      // console.log(this.listPanelContext.lengths);
+      // console.log(`sum ${this.listPanelContext.sum}`);
+      // console.log(`panel group length: ${this.panelGroupLengthPx}`);
+      // console.log(`is ratio stale? ${this.listPanelContext.isRatioStale}`);
     }
     //Update previous lengthPx
-    let previousId = id - 1;
-    let previousContextEl = this.listPanelContext.get(previousId);
-    if (
-      previousContextEl !== undefined &&
-      previousContextEl.defaultLengthFraction &&
-      this.panelGroupLengthPx
-    ) {
-      previousContextEl.lengthPx =
-        previousContextEl.defaultLengthFraction * this.panelGroupLengthPx;
+    // let previousId = id - 1;
+    // let previousContextEl = this.listPanelContext.get(previousId);
+    // if (
+    //   previousContextEl !== undefined &&
+    //   previousContextEl.defaultLengthFraction &&
+    //   this.panelGroupLengthPx
+    // ) {
+    //   debugger;
+    //   previousContextEl.lengthPx =
+    //     previousContextEl.defaultLengthFraction * this.panelGroupLengthPx;
+    // }
+    if (this.args.orientation === 'horizontal') {
+      // console.log('==compare sum====');
+      // console.log(this.listPanelContext.lengths);
+      // console.log(`sum ${this.listPanelContext.sum}`);
+      // console.log(`panel group length: ${this.panelGroupLengthPx}`);
+      // console.log(`is ratio stale? ${this.listPanelContext.isRatioStale}`);
     }
-    this.listPanelContext.set(id, {
+    this.listPanelContext.set(
       id,
-      defaultLengthFraction: context.defaultLengthFraction,
-      lengthPx: context.lengthPx,
-      initialMinLengthPx: context.minLengthPx,
-      minLengthPx: context.minLengthPx,
-      collapsible:
-        context.collapsible == undefined ? true : context.collapsible,
-    });
-    this.calculatePanelRatio();
-    this.onContainerResize();
+      {
+        id,
+        defaultLengthFraction: context.defaultLengthFraction,
+        lengthPx: context.defaultLengthFraction * this.panelGroupLengthPx!,
+        initialMinLengthPx: context.minLengthPx,
+        minLengthPx: context.minLengthPx,
+        collapsible:
+          context.collapsible == undefined ? true : context.collapsible,
+        ratio: context.defaultLengthFraction ?? 0,
+      },
+      true,
+    );
+    // if (this.args.orientation === 'horizontal') {
+    //   console.log(`is ratio stale ${this.listPanelContext.isRatioStale}`);
+    // }
+    // this.onContainerResize();
+    if (this.args.orientation === 'horizontal') {
+      console.log(
+        this.listPanelContext.isLengthsStale(this.panelGroupLengthPx!),
+      );
+    }
     return id;
   }
 
   @action
   unregisterPanel(id: number) {
     this.listPanelContext.delete(id);
-    this.calculatePanelRatio();
-    this.onContainerResize();
-  }
-
-  calculatePanelRatio() {
-    let panelLengths = Array.from(this.listPanelContext.values()).map(
-      (panelContext) => panelContext.lengthPx,
-    );
-
-    this.panelRatios = [];
-    for (let index = 0; index < panelLengths.length; index++) {
-      let panelLength = panelLengths[index];
-      if (panelLength == undefined) {
-        break;
-      }
-      let panelLengthSum = sumArray(panelLengths);
-      if (panelLengthSum === 0) {
-        break;
-      }
-      this.panelRatios[index] = panelLength / panelLengthSum;
+    if (this.args.orientation === 'horizontal') {
+      console.log(`is ratio stale ${this.listPanelContext.isRatioStale}`);
     }
+    // this.onContainerResize();
   }
+
+  // calculateRatio(panelLength: number) {
+  //   let panelLengths = Array.from(this.listPanelContext.values()).map(
+  //     (panelContext) => panelContext.lengthPx,
+  //   );
+  //   let panelLengthSum = sumArray(panelLengths);
+  //   if (panelLengthSum === 0) {
+  //     return 0;
+  //   }
+
+  //   return panelLength / panelLengthSum;
+  // }
+
+  // calculatePanelRatio() {
+  //   let panelLengths = Array.from(this.listPanelContext.values()).map(
+  //     (panelContext) => panelContext.lengthPx,
+  //   );
+
+  //   this.panelRatios = [];
+  //   for (let index = 0; index < panelLengths.length; index++) {
+  //     let panelLength = panelLengths[index];
+  //     if (panelLength == undefined) {
+  //       break;
+  //     }
+  //     let panelLengthSum = sumArray(panelLengths);
+  //     if (panelLengthSum === 0) {
+  //       break;
+  //     }
+  //     this.panelRatios[index] = panelLength / panelLengthSum;
+  //   }
+  // }
 
   @action
   panelContext(panelId: number) {
@@ -408,7 +451,7 @@ export default class ResizablePanelGroup extends Component<Signature> {
     this.currentResizeHandle.initialPosition =
       event[this.clientPositionProperty];
 
-    this.calculatePanelRatio();
+    // this.calculatePanelRatio();
   }
 
   // This event only applies to the first and last resize handler.
@@ -505,8 +548,6 @@ export default class ResizablePanelGroup extends Component<Signature> {
         nextPanelElContext.initialMinLengthPx,
       );
     }
-
-    this.calculatePanelRatio();
   }
 
   @action
@@ -520,20 +561,28 @@ export default class ResizablePanelGroup extends Component<Signature> {
   ) {
     let leftPanelContext = this.listPanelContext.get(prevPanelElId);
     if (leftPanelContext) {
-      this.listPanelContext.set(prevPanelElId, {
-        ...leftPanelContext,
-        lengthPx: newPrevPanelElLength,
-        minLengthPx: newPrevPanelElMinLength,
-      });
+      this.listPanelContext.set(
+        prevPanelElId,
+        {
+          ...leftPanelContext,
+          lengthPx: newPrevPanelElLength,
+          minLengthPx: newPrevPanelElMinLength,
+        },
+        true,
+      );
     }
 
     let rightPanelContext = this.listPanelContext.get(nextPanelElId);
     if (rightPanelContext) {
-      this.listPanelContext.set(nextPanelElId, {
-        ...rightPanelContext,
-        lengthPx: newNextPanelElLength,
-        minLengthPx: newNextPanelElMinLength,
-      });
+      this.listPanelContext.set(
+        nextPanelElId,
+        {
+          ...rightPanelContext,
+          lengthPx: newNextPanelElLength,
+          minLengthPx: newNextPanelElMinLength,
+        },
+        true,
+      );
     }
 
     this.args.onListPanelContextChange?.(
@@ -555,11 +604,11 @@ export default class ResizablePanelGroup extends Component<Signature> {
       this.panelGroupElement[this.perpendicularLengthProperty] <
       this.minimumLengthToShowHandles;
 
-    let panelLengths: number[] = Array.from(this.listPanelContext.values()).map(
-      (panelContext) => panelContext.lengthPx,
-    );
-
     let newContainerSize = this.panelGroupLengthWithoutResizeHandlePx;
+    if (this.args.orientation === 'horizontal') {
+      // console.log('container resizing');
+      // console.log(newContainerSize);
+    }
     if (newContainerSize == undefined) {
       console.warn('Expected newContainerSize to be defined');
       return;
@@ -567,69 +616,76 @@ export default class ResizablePanelGroup extends Component<Signature> {
 
     let remainingContainerSize = newContainerSize;
     let calculateLengthsOfPanelWithMinLegth = () => {
-      let panelContexts = Array.from(this.listPanelContext)
-        .map((panelContextTuple) => panelContextTuple[1])
-        .filter((panelContext) => panelContext.initialMinLengthPx);
-
-      panelContexts.forEach((panelContext) => {
-        let panelRatio = this.panelRatios[panelContext.id];
-        if (!panelRatio || !newContainerSize) {
-          console.warn(
-            'Expected panelRatio and newContainerSize to be defined',
+      for (const [k, v] of this.listPanelContext.entries()) {
+        if (v.initialMinLengthPx) {
+          if (v.lengthPx === undefined) {
+            throw new Error('h');
+          }
+          let panelRatio = v.ratio;
+          // if (panelRatio === 0) {
+          //   debugger;
+          // }
+          // if (newContainerSize === 0) {
+          //   debugger;
+          // }
+          if (panelRatio === undefined || newContainerSize === undefined) {
+            console.warn(
+              'Expected panelRatio and newContainerSize to be defined',
+            );
+            return;
+          }
+          let proportionalSize = panelRatio * newContainerSize;
+          let actualSize = Math.round(
+            v?.initialMinLengthPx
+              ? Math.max(proportionalSize, v.initialMinLengthPx)
+              : proportionalSize,
           );
-          return;
+          this.listPanelContext.set(k, {
+            ...v,
+            lengthPx: actualSize,
+          });
+          remainingContainerSize = remainingContainerSize - actualSize;
         }
-        let proportionalSize = panelRatio * newContainerSize;
-        let actualSize = Math.round(
-          panelContext?.initialMinLengthPx
-            ? Math.max(proportionalSize, panelContext.initialMinLengthPx)
-            : proportionalSize,
-        );
-        panelLengths[panelContext.id] = actualSize;
-        remainingContainerSize = remainingContainerSize - actualSize;
-      });
+      }
     };
     calculateLengthsOfPanelWithMinLegth();
 
     let calculateLengthsOfPanelWithoutMinLength = () => {
-      let panelContexts = Array.from(this.listPanelContext)
-        .map((panelContextTuple) => panelContextTuple[1])
-        .filter((panelContext) => !panelContext.initialMinLengthPx);
-      let panelContextIds = panelContexts.map(
-        (panelContext) => panelContext.id,
-      );
-      let newPanelRatios = this.panelRatios.filter((_panelRatio, index) =>
-        panelContextIds.includes(index),
-      );
-      let totalNewPanelRatio = newPanelRatios.reduce(
-        (prevValue, currentValue) => prevValue + currentValue,
-        0,
-      );
-      newPanelRatios = newPanelRatios.map(
-        (panelRatio) => panelRatio / totalNewPanelRatio,
-      );
+      let totalNewPanelRatio = Array.from(this.listPanelContext.values())
+        .filter((c) => !c.initialMinLengthPx && c.ratio)
+        .map((c) => c.ratio!)
+        .reduce((accum, currentValue) => {
+          if (currentValue) {
+            return accum + currentValue;
+          } else {
+            return accum;
+          }
+        }, 0);
 
-      panelContexts.forEach((panelContext, index) => {
-        let panelRatio = newPanelRatios[index];
-        if (!panelRatio) {
-          console.warn('Expected panelRatio to be defined');
-          return;
+      for (const [k, v] of this.listPanelContext.entries()) {
+        if (!v.initialMinLengthPx && v.ratio) {
+          if (totalNewPanelRatio) {
+            let newPanelRatio = v.ratio / totalNewPanelRatio;
+            let proportionalSize = newPanelRatio * remainingContainerSize;
+            let actualSize = Math.round(proportionalSize);
+            this.listPanelContext.set(k, {
+              ...v,
+              ratio: newPanelRatio ?? v.defaultLengthFraction,
+              lengthPx: actualSize,
+            });
+          }
         }
-        let proportionalSize = panelRatio * remainingContainerSize;
-        let actualSize = Math.round(proportionalSize);
-        panelLengths[panelContext.id] = actualSize;
-      });
+      }
     };
     calculateLengthsOfPanelWithoutMinLength();
-
-    for (let index = 0; index <= this.listPanelContext.size; index++) {
-      let panelContext = this.listPanelContext.get(index);
-      if (panelContext) {
-        this.listPanelContext.set(index, {
-          ...panelContext,
-          lengthPx: panelLengths[index] || 0,
-        });
-      }
+    if (this.args.orientation === 'horizontal') {
+      console.log('on container resize executed finish');
+      debugger;
+      console.log(this.listPanelContext.lengths);
+      console.log(`sum ${this.listPanelContext.sum}`);
+      console.log(`panel group length: ${this.panelGroupLengthPx}`);
+      console.log(`ratios ${this.listPanelContext.ratios}`);
+      console.log(`is ratio stale? ${this.listPanelContext.isRatioStale}`);
     }
   }
 
@@ -669,5 +725,73 @@ export default class ResizablePanelGroup extends Component<Signature> {
   @action
   private ResizeHandleElId(id: number | undefined): string {
     return `${ResizeHandleElIdPrefix}-${this.args.orientation}-${id}`;
+  }
+}
+
+class PanelContextMap extends TrackedMap<number, PanelContext> {
+  set(key: number, value: PanelContext, recompute = false) {
+    super.set(key, value);
+    if (recompute === true) {
+      this.recalculateRatios();
+    }
+    return this;
+  }
+
+  delete(key: number) {
+    let o = super.delete(key);
+    this.recalculateRatios();
+    return o;
+  }
+
+  get lengths() {
+    let panelLengths: number[] = Array.from(this.values()).map(
+      (panelContext) => panelContext.lengthPx,
+    );
+    return panelLengths;
+  }
+
+  get sum() {
+    return sumArray(this.lengths);
+  }
+
+  get ratios() {
+    return Array.from(this.values()).map((o) => o.ratio);
+  }
+
+  get isRatioStale() {
+    let tolerance = 0.05;
+    let ratioSum = sumArray(this.ratios);
+    // console.log(`current ratio sum ${ratioSum}`);
+    // console.log(this.ratios);
+    return Math.abs(ratioSum - 1) > tolerance;
+  }
+
+  isLengthsStale(fullWidth: number) {
+    console.log('is lengths stale');
+    console.log(this.sum);
+    console.log(fullWidth);
+    return fullWidth !== this.sum;
+  }
+
+  recalculateRatios() {
+    if (this.sum === 0) {
+      console.warn('sum = 0 ');
+      return;
+    }
+    for (const [k, v] of this.entries()) {
+      if (v.lengthPx === undefined) {
+        throw new Error('h');
+      }
+      let ratio = v.lengthPx / this.sum;
+      this.set(
+        k,
+        {
+          ...v,
+          ratio,
+        },
+        false,
+      );
+    }
+    console.log('Ratios recalculated');
   }
 }

--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
@@ -159,7 +159,6 @@ export default class ResizablePanelGroup extends Component<Signature> {
       ? resizeHandleContainer[this.offsetLengthProperty]
       : 0;
     let panelGroupElement = this.panelGroupElement;
-    debugger;
     if (panelGroupElement === undefined) {
       console.warn('Expected panelGroupElement to be defined');
       return undefined;
@@ -202,56 +201,18 @@ export default class ResizablePanelGroup extends Component<Signature> {
   @action
   registerPanel(context: {
     collapsible: boolean | undefined;
-    defaultLengthFraction: number;
+    defaultLengthFraction: number | undefined;
+    lengthPx: number | undefined;
     minLengthPx: number | undefined;
   }) {
     let id = Number(this.listPanelContext.size);
 
-    // if (context.lengthPx === undefined) {
-    //   if (
-    //     this.panelGroupLengthPx === undefined ||
-    //     context.defaultLengthFraction === undefined
-    //   ) {
-    //     context.lengthPx = -1;
-    //   } else {
-    //     context.lengthPx =
-    //       context.defaultLengthFraction * this.panelGroupLengthPx;
-    //   }
-    // }
-    // context.lengthPx = context.defaultLengthFraction * this.panelGroupLengthPx;
-    if (this.args.orientation === 'horizontal') {
-      // console.log('===========');
-      // console.log('==compare sum====');
-      // console.log(this.listPanelContext.lengths);
-      // console.log(`sum ${this.listPanelContext.sum}`);
-      // console.log(`panel group length: ${this.panelGroupLengthPx}`);
-      // console.log(`is ratio stale? ${this.listPanelContext.isRatioStale}`);
-    }
-    //Update previous lengthPx
-    // let previousId = id - 1;
-    // let previousContextEl = this.listPanelContext.get(previousId);
-    // if (
-    //   previousContextEl !== undefined &&
-    //   previousContextEl.defaultLengthFraction &&
-    //   this.panelGroupLengthPx
-    // ) {
-    //   debugger;
-    //   previousContextEl.lengthPx =
-    //     previousContextEl.defaultLengthFraction * this.panelGroupLengthPx;
-    // }
-    if (this.args.orientation === 'horizontal') {
-      // console.log('==compare sum====');
-      // console.log(this.listPanelContext.lengths);
-      // console.log(`sum ${this.listPanelContext.sum}`);
-      // console.log(`panel group length: ${this.panelGroupLengthPx}`);
-      // console.log(`is ratio stale? ${this.listPanelContext.isRatioStale}`);
-    }
     this.listPanelContext.set(
       id,
       {
         id,
         defaultLengthFraction: context.defaultLengthFraction,
-        lengthPx: context.defaultLengthFraction * this.panelGroupLengthPx!,
+        lengthPx: context.lengthPx,
         initialMinLengthPx: context.minLengthPx,
         minLengthPx: context.minLengthPx,
         collapsible:
@@ -260,57 +221,14 @@ export default class ResizablePanelGroup extends Component<Signature> {
       },
       true,
     );
-    // if (this.args.orientation === 'horizontal') {
-    //   console.log(`is ratio stale ${this.listPanelContext.isRatioStale}`);
-    // }
-    // this.onContainerResize();
-    if (this.args.orientation === 'horizontal') {
-      console.log(
-        this.listPanelContext.isLengthsStale(this.panelGroupLengthPx!),
-      );
-    }
+
     return id;
   }
 
   @action
   unregisterPanel(id: number) {
     this.listPanelContext.delete(id);
-    if (this.args.orientation === 'horizontal') {
-      console.log(`is ratio stale ${this.listPanelContext.isRatioStale}`);
-    }
-    // this.onContainerResize();
   }
-
-  // calculateRatio(panelLength: number) {
-  //   let panelLengths = Array.from(this.listPanelContext.values()).map(
-  //     (panelContext) => panelContext.lengthPx,
-  //   );
-  //   let panelLengthSum = sumArray(panelLengths);
-  //   if (panelLengthSum === 0) {
-  //     return 0;
-  //   }
-
-  //   return panelLength / panelLengthSum;
-  // }
-
-  // calculatePanelRatio() {
-  //   let panelLengths = Array.from(this.listPanelContext.values()).map(
-  //     (panelContext) => panelContext.lengthPx,
-  //   );
-
-  //   this.panelRatios = [];
-  //   for (let index = 0; index < panelLengths.length; index++) {
-  //     let panelLength = panelLengths[index];
-  //     if (panelLength == undefined) {
-  //       break;
-  //     }
-  //     let panelLengthSum = sumArray(panelLengths);
-  //     if (panelLengthSum === 0) {
-  //       break;
-  //     }
-  //     this.panelRatios[index] = panelLength / panelLengthSum;
-  //   }
-  // }
 
   @action
   panelContext(panelId: number) {
@@ -450,8 +368,6 @@ export default class ResizablePanelGroup extends Component<Signature> {
 
     this.currentResizeHandle.initialPosition =
       event[this.clientPositionProperty];
-
-    // this.calculatePanelRatio();
   }
 
   // This event only applies to the first and last resize handler.
@@ -605,10 +521,6 @@ export default class ResizablePanelGroup extends Component<Signature> {
       this.minimumLengthToShowHandles;
 
     let newContainerSize = this.panelGroupLengthWithoutResizeHandlePx;
-    if (this.args.orientation === 'horizontal') {
-      // console.log('container resizing');
-      // console.log(newContainerSize);
-    }
     if (newContainerSize == undefined) {
       console.warn('Expected newContainerSize to be defined');
       return;
@@ -678,15 +590,6 @@ export default class ResizablePanelGroup extends Component<Signature> {
       }
     };
     calculateLengthsOfPanelWithoutMinLength();
-    if (this.args.orientation === 'horizontal') {
-      console.log('on container resize executed finish');
-      debugger;
-      console.log(this.listPanelContext.lengths);
-      console.log(`sum ${this.listPanelContext.sum}`);
-      console.log(`panel group length: ${this.panelGroupLengthPx}`);
-      console.log(`ratios ${this.listPanelContext.ratios}`);
-      console.log(`is ratio stale? ${this.listPanelContext.isRatioStale}`);
-    }
   }
 
   private findPanelsByResizeHandle(ResizeHandleId: string) {

--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
@@ -207,6 +207,18 @@ export default class ResizablePanelGroup extends Component<Signature> {
   }) {
     let id = Number(this.listPanelContext.size);
 
+    if (context.lengthPx === undefined) {
+      if (
+        this.panelGroupLengthPx === undefined ||
+        context.defaultLengthFraction === undefined
+      ) {
+        context.lengthPx = -1;
+      } else {
+        context.lengthPx =
+          context.defaultLengthFraction * this.panelGroupLengthPx;
+      }
+    }
+
     this.listPanelContext.set(
       id,
       {

--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
@@ -18,6 +18,7 @@ export type PanelContext = {
   initialMinLengthPx?: number;
   lengthPx: number;
   minLengthPx?: number;
+  ratio: number;
 };
 
 interface Signature {

--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
@@ -18,7 +18,6 @@ export type PanelContext = {
   initialMinLengthPx?: number;
   lengthPx: number;
   minLengthPx?: number;
-  ratio: number;
 };
 
 interface Signature {

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -100,7 +100,7 @@ const defaultPanelWidths: PanelWidths = {
     (document.documentElement.clientWidth - 40 - 36),
   codeEditorPanel: 0.4,
   rightPanel: 0.4,
-  emptyCodeModePanel: 0.2,
+  emptyCodeModePanel: 0.8,
 };
 
 const CodeModePanelHeights = 'code-mode-panel-heights';
@@ -771,7 +771,7 @@ export default class CodeSubmode extends Component<Signature> {
             <ResizablePanel
               @defaultLengthFraction={{defaultPanelWidths.codeEditorPanel}}
               @lengthPx={{this.panelWidths.codeEditorPanel}}
-              {{!-- @minLengthPx={{300}} --}}
+              @minLengthPx={{300}}
             >
               <InnerContainer>
                 {{#if this.isReady}}

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -98,8 +98,6 @@ const defaultPanelWidths: PanelWidths = {
   rightPanel: 0.4,
   emptyCodeModePanel: 0.8,
 };
-console.log('default panel widths');
-console.log(defaultPanelWidths);
 
 const CodeModePanelHeights = 'code-mode-panel-heights';
 const ApproximateRecentPanelDefaultFraction =
@@ -497,14 +495,10 @@ export default class CodeSubmode extends Component<Signature> {
 
   @action
   private onListPanelContextChange(listPanelContext: PanelContext[]) {
-    // this.panelWidths.leftPanel = listPanelContext[0]?.lengthPx;
-    // this.panelWidths.codeEditorPanel = listPanelContext[1]?.lengthPx;
-    // this.panelWidths.rightPanel = listPanelContext[2]?.lengthPx;
-    this.panelWidths.leftPanel = listPanelContext[0]?.ratio;
-    this.panelWidths.codeEditorPanel = listPanelContext[1]?.ratio;
-    this.panelWidths.rightPanel = listPanelContext[2]?.ratio;
+    this.panelWidths.leftPanel = listPanelContext[0]?.lengthPx;
+    this.panelWidths.codeEditorPanel = listPanelContext[1]?.lengthPx;
+    this.panelWidths.rightPanel = listPanelContext[2]?.lengthPx;
 
-    localStorage.setItem(CodeModePanelWidths, JSON.stringify(this.panelWidths));
     localStorage.setItem(CodeModePanelWidths, JSON.stringify(this.panelWidths));
   }
 
@@ -750,7 +744,7 @@ export default class CodeSubmode extends Component<Signature> {
                 <VerticallyResizeHandle />
                 <VerticallyResizablePanel
                   @defaultLengthFraction={{defaultPanelHeights.recentPanel}}
-                  {{!-- @lengthPx={{this.panelHeights.recentPanel}} --}}
+                  @lengthPx={{this.panelHeights.recentPanel}}
                   @minLengthPx={{100}}
                 >
                   <InnerContainer
@@ -772,7 +766,7 @@ export default class CodeSubmode extends Component<Signature> {
           {{#if this.codePath}}
             <ResizablePanel
               @defaultLengthFraction={{defaultPanelWidths.codeEditorPanel}}
-              {{!-- @lengthPx={{this.panelWidths.codeEditorPanel}} --}}
+              @lengthPx={{this.panelWidths.codeEditorPanel}}
               @minLengthPx={{300}}
             >
               <InnerContainer>
@@ -798,7 +792,7 @@ export default class CodeSubmode extends Component<Signature> {
             <ResizeHandle />
             <ResizablePanel
               @defaultLengthFraction={{defaultPanelWidths.rightPanel}}
-              {{!-- @lengthPx={{this.panelWidths.rightPanel}} --}}
+              @lengthPx={{this.panelWidths.rightPanel}}
             >
               <InnerContainer>
                 {{#if this.isReady}}

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -98,6 +98,8 @@ const defaultPanelWidths: PanelWidths = {
   rightPanel: 0.4,
   emptyCodeModePanel: 0.8,
 };
+console.log('default panel widths');
+console.log(defaultPanelWidths);
 
 const CodeModePanelHeights = 'code-mode-panel-heights';
 const ApproximateRecentPanelDefaultFraction =
@@ -495,10 +497,14 @@ export default class CodeSubmode extends Component<Signature> {
 
   @action
   private onListPanelContextChange(listPanelContext: PanelContext[]) {
-    this.panelWidths.leftPanel = listPanelContext[0]?.lengthPx;
-    this.panelWidths.codeEditorPanel = listPanelContext[1]?.lengthPx;
-    this.panelWidths.rightPanel = listPanelContext[2]?.lengthPx;
+    // this.panelWidths.leftPanel = listPanelContext[0]?.lengthPx;
+    // this.panelWidths.codeEditorPanel = listPanelContext[1]?.lengthPx;
+    // this.panelWidths.rightPanel = listPanelContext[2]?.lengthPx;
+    this.panelWidths.leftPanel = listPanelContext[0]?.ratio;
+    this.panelWidths.codeEditorPanel = listPanelContext[1]?.ratio;
+    this.panelWidths.rightPanel = listPanelContext[2]?.ratio;
 
+    localStorage.setItem(CodeModePanelWidths, JSON.stringify(this.panelWidths));
     localStorage.setItem(CodeModePanelWidths, JSON.stringify(this.panelWidths));
   }
 
@@ -744,7 +750,7 @@ export default class CodeSubmode extends Component<Signature> {
                 <VerticallyResizeHandle />
                 <VerticallyResizablePanel
                   @defaultLengthFraction={{defaultPanelHeights.recentPanel}}
-                  @lengthPx={{this.panelHeights.recentPanel}}
+                  {{!-- @lengthPx={{this.panelHeights.recentPanel}} --}}
                   @minLengthPx={{100}}
                 >
                   <InnerContainer
@@ -766,7 +772,7 @@ export default class CodeSubmode extends Component<Signature> {
           {{#if this.codePath}}
             <ResizablePanel
               @defaultLengthFraction={{defaultPanelWidths.codeEditorPanel}}
-              @lengthPx={{this.panelWidths.codeEditorPanel}}
+              {{!-- @lengthPx={{this.panelWidths.codeEditorPanel}} --}}
               @minLengthPx={{300}}
             >
               <InnerContainer>
@@ -792,7 +798,7 @@ export default class CodeSubmode extends Component<Signature> {
             <ResizeHandle />
             <ResizablePanel
               @defaultLengthFraction={{defaultPanelWidths.rightPanel}}
-              @lengthPx={{this.panelWidths.rightPanel}}
+              {{!-- @lengthPx={{this.panelWidths.rightPanel}} --}}
             >
               <InnerContainer>
                 {{#if this.isReady}}

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -89,6 +89,10 @@ type PanelHeights = {
 type SelectedAccordionItem = 'schema-editor' | null;
 
 const CodeModePanelWidths = 'code-mode-panel-widths';
+// These are defaults that it takes up in the screen
+// This will let defaults sum to 1
+// This will make the lengths accurate when you provide it.
+// If the lengths are not accurate, it is safe to say that
 const defaultPanelWidths: PanelWidths = {
   // 14rem as a fraction of the layout width
   leftPanel:
@@ -96,7 +100,7 @@ const defaultPanelWidths: PanelWidths = {
     (document.documentElement.clientWidth - 40 - 36),
   codeEditorPanel: 0.4,
   rightPanel: 0.4,
-  emptyCodeModePanel: 0.8,
+  emptyCodeModePanel: 0.2,
 };
 
 const CodeModePanelHeights = 'code-mode-panel-heights';
@@ -767,7 +771,7 @@ export default class CodeSubmode extends Component<Signature> {
             <ResizablePanel
               @defaultLengthFraction={{defaultPanelWidths.codeEditorPanel}}
               @lengthPx={{this.panelWidths.codeEditorPanel}}
-              @minLengthPx={{300}}
+              {{!-- @minLengthPx={{300}} --}}
             >
               <InnerContainer>
                 {{#if this.isReady}}


### PR DESCRIPTION
Bleurgh this is just a draft to possibly make things better -- im not too optimistic. I find dealing with hard coded pixels and ratios so counter intiutive and maintaining the state between the two. 


**Currently**
- There is stale ratios variable that gets written when registering and unregistering panels. onContainerResize, these ratios will remain. So when, we resize the browser, as long as we havent registered anything, we should return to its original size

**Attempted**
- I was thinking why not just use ratio as a key in the PanelContext. And overwrite .set so when we register or unregister a new panel, we will update the ratios also automatically. 
- I also want to change the calculateRatios and onContainerResize calls when registering or unregistering. The setter should handle all of it. 
- Trying to get rid of the 2 functions in onContainerResize that are accounting for min widths


**TODO**
- [ ] Why isn registerPanel doing any resizing. Shudn it register independently and resize to screen. Test are just registering panels regardless of the size of the screen.
- [ ] Why is onContainerResize getting called so eagerly. Can we separate registerPanel
- [ ] Are we clear why registerPanel is triggering containerResize? 
- [ ] Can registerPanel and containerResize call same function (idempotently)? Perhaps not becos registerPanel adds. 
- [ ] Can we just NEVER update or set ratios from the component? Lets create an api for this
- [ ] When is defaultLengthFraction chosen over lengthPx and vice versa 
- [ ] Why is there a grey screen when shrinking container
- [ ] Why is minLengthPx that is so big breaking reactivity
- [ ] Revisit the idea of having ratios always balanced at one place and move the unbalancedness outside

