### PR TITLE
Display message command being called with args in View Code panel

### DIFF
--- a/packages/host/app/components/matrix/room-message.gts
+++ b/packages/host/app/components/matrix/room-message.gts
@@ -236,7 +236,8 @@ export default class Room extends Component<Signature> {
   }
 
   private get previewPatchCode() {
-    return JSON.stringify(this.args.message.command.payload.patch, null, 2);
+    let { commandType, payload } = this.args.message.command;
+    return JSON.stringify({ commandType, payload }, null, 2);
   }
 
   @action private viewCodeToggle() {

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -816,10 +816,14 @@ module('Integration | operator-mode', function (hooks) {
       assert.dom(`[data-test-preferredcarrier="DHL"]`).exists();
 
       let roomId = await openAiAssistant();
-      let patchData = {
-        attributes: {
-          firstName: 'Joy',
-          address: { shippingInfo: { preferredCarrier: 'UPS' } },
+      let payload = {
+        type: 'patch',
+        id: `${testRealmURL}Person/fadhlan`,
+        patch: {
+          attributes: {
+            firstName: 'Joy',
+            address: { shippingInfo: { preferredCarrier: 'UPS' } },
+          },
         },
       };
       addRoomEvent(matrixService, {
@@ -834,13 +838,7 @@ module('Integration | operator-mode', function (hooks) {
           msgtype: 'org.boxel.command',
           formatted_body: 'A patch',
           format: 'org.matrix.custom.html',
-          data: JSON.stringify({
-            command: {
-              type: 'patch',
-              id: `${testRealmURL}Person/fadhlan`,
-              patch: patchData,
-            },
-          }),
+          data: JSON.stringify({ command: payload }),
         },
       });
 
@@ -848,7 +846,10 @@ module('Integration | operator-mode', function (hooks) {
       await click('[data-test-view-code-button]');
 
       await waitForCodeEditor();
-      assert.deepEqual(JSON.parse(getMonacoContent()), patchData);
+      assert.deepEqual(JSON.parse(getMonacoContent()), {
+        commandType: 'patch',
+        payload,
+      });
       assert.dom('[data-test-copy-code]').isEnabled('copy button is available');
 
       await click('[data-test-view-code-button]');


### PR DESCRIPTION
Here is an option for what to display in View Code panel:

<img width="560" alt="view-code-panel" src="https://github.com/cardstack/boxel/assets/16160806/d6a17a9c-4861-4915-8755-325274c0a783">


Below are the fields of the command field:

<img width="488" alt="patch-field" src="https://github.com/cardstack/boxel/assets/16160806/92c55c96-bd22-4383-bbb0-adc27cb382a0">

