### PR TITLE
ui: Update raw crossed-out-pencil to match output

### DIFF
--- a/packages/boxel-ui/addon/raw-icons/icon-pencil-crossed-out.svg
+++ b/packages/boxel-ui/addon/raw-icons/icon-pencil-crossed-out.svg
@@ -3,7 +3,8 @@
   <path fill="var(--icon-color, #000)" stroke="var(--icon-color, #000)"
     d="m.75 17.5a.751.751 0 0 1 -.75-.75v-4.181a.755.755 0 0 1 .22-.53l11.241-11.239a2.72 2.72 0 0 1 3.848 0l1.391 1.391a2.72 2.72 0 0 1 0 3.848l-11.238 11.241a.747.747 0 0 1 -.531.22zm.75-4.621v3.121h3.12l7.91-7.91-3.12-3.12zm12.091-5.849 2.051-2.051a1.223 1.223 0 0 0 0-1.727l-1.393-1.394a1.222 1.222 0 0 0 -1.727 0l-2.052 2.052z"
     stroke-width="var(--icon-stroke-width, 0.7)" transform="translate(3.25 3.25)" />
-  <line fill="none" stroke="white" stroke-width="4" stroke-linecap="round"
+  <line fill="none" stroke='var(--icon-background-color, #fff)' stroke-width="4"
+    stroke-linecap="round"
     x1="3.25" x2="20.75" y1="3.25" y2="20.75" />
   <line fill="none" stroke="var(--icon-color, #000)" stroke-width="2" stroke-linecap="round"
     x1="3.25" x2="20.75" y1="3.25" y2="20.75" />


### PR DESCRIPTION
I noticed while working on #1134 that `icon-pencil-crossed-out.gts` was changing when I ran `pnpm rebuild:icons` because the generated component had been updated but the raw SVG had not.

Is there a way we can protect against this, maybe a lint-esque CI task that checks whether running `pnpm rebuild:icons` results in any changes? 🤔