### PR TITLE
Fix: when moving from 2 panel to 3 panel the left panel gets larger than expected

### DIFF
--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
@@ -237,7 +237,6 @@ export default class ResizablePanelGroup extends Component<Signature> {
   unregisterPanel(id: number) {
     this.listPanelContext.delete(id);
     this.calculatePanelRatio();
-    this.onContainerResize();
   }
 
   calculatePanelRatio() {

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -89,14 +89,15 @@ type PanelHeights = {
 type SelectedAccordionItem = 'schema-editor' | null;
 
 const CodeModePanelWidths = 'code-mode-panel-widths';
+const defaultLeftPanelWidth =
+  (14.0 * parseFloat(getComputedStyle(document.documentElement).fontSize)) /
+  (document.documentElement.clientWidth - 40 - 36);
 const defaultPanelWidths: PanelWidths = {
   // 14rem as a fraction of the layout width
-  leftPanel:
-    (14.0 * parseFloat(getComputedStyle(document.documentElement).fontSize)) /
-    (document.documentElement.clientWidth - 40 - 36),
-  codeEditorPanel: 0.4,
-  rightPanel: 0.4,
-  emptyCodeModePanel: 0.8,
+  leftPanel: defaultLeftPanelWidth,
+  codeEditorPanel: (1 - defaultLeftPanelWidth) / 2,
+  rightPanel: (1 - defaultLeftPanelWidth) / 2,
+  emptyCodeModePanel: 1 - defaultLeftPanelWidth,
 };
 
 const CodeModePanelHeights = 'code-mode-panel-heights';


### PR DESCRIPTION
This was the original [linear](https://linear.app/cardstack/issue/CS-6238/resizable-panel-snaps-out-when-going-into-code-mode-from-empty-stack) ticket but the task changed slightly based on this [comment](https://linear.app/cardstack/issue/CS-6238/resizable-panel-snaps-out-when-going-into-code-mode-from-empty-stack#comment-567ce34b) 
