### PR TITLE
Paging support for search

### DIFF
--- a/packages/host/tests/helpers/indexer.ts
+++ b/packages/host/tests/helpers/indexer.ts
@@ -73,7 +73,7 @@ export async function serializeCard(card: CardDef): Promise<CardResource> {
   return api.serializeCard(card).data as CardResource;
 }
 
-type TestIndexRow =
+export type TestIndexRow =
   | (Pick<IndexedCardsTable, 'card_url'> &
       Partial<Omit<IndexedCardsTable, 'card_url'>>)
   | CardDef

--- a/packages/host/tests/unit/indexer-test.ts
+++ b/packages/host/tests/unit/indexer-test.ts
@@ -461,11 +461,11 @@ module('Unit | indexer', function (hooks) {
     );
     assert.strictEqual(
       versions.length,
-      1,
+      2,
       'correct number of versions exist for the entry after finishing the batch',
     );
 
-    let [finalVersion] = versions;
+    let [_, finalVersion] = versions;
     assert.deepEqual(
       finalVersion,
       {
@@ -558,11 +558,11 @@ module('Unit | indexer', function (hooks) {
     );
     assert.strictEqual(
       versions.length,
-      1,
+      2,
       'correct number of versions exist for the entry after finishing the batch',
     );
 
-    let [finalVersion] = versions;
+    let [_, finalVersion] = versions;
     assert.deepEqual(
       finalVersion,
       { realm_version: 2, is_deleted: true },

--- a/packages/host/tests/unit/query-test.ts
+++ b/packages/host/tests/unit/query-test.ts
@@ -173,7 +173,11 @@ module('Unit | query', function (hooks) {
     let { mango, vangogh, paper } = testCards;
     await setupIndex(client, [mango, vangogh, paper]);
 
-    let { cards, meta } = await client.search({}, loader);
+    let { cards, meta } = await client.search(
+      new URL(testRealmURL),
+      {},
+      loader,
+    );
     assert.strictEqual(meta.page.total, 3, 'the total results meta is correct');
     assert.deepEqual(
       cards,
@@ -194,7 +198,7 @@ module('Unit | query', function (hooks) {
       { card: paper, data: { is_deleted: true } },
     ]);
 
-    let { meta } = await client.search({}, loader);
+    let { meta } = await client.search(new URL(testRealmURL), {}, loader);
     assert.strictEqual(meta.page.total, 2, 'the total results meta is correct');
   });
 
@@ -203,6 +207,7 @@ module('Unit | query', function (hooks) {
     await setupIndex(client, [mango, vangogh, paper]);
 
     let { cards, meta } = await client.search(
+      new URL(testRealmURL),
       {
         filter: {
           type: { module: `${testRealmURL}person`, name: 'Person' },
@@ -230,6 +235,7 @@ module('Unit | query', function (hooks) {
     ]);
 
     let { cards, meta } = await client.search(
+      new URL(testRealmURL),
       {
         filter: {
           eq: { name: 'Mango' },
@@ -285,6 +291,7 @@ module('Unit | query', function (hooks) {
     ]);
 
     let { cards, meta } = await client.search(
+      new URL(testRealmURL),
       {
         filter: {
           on: { module: `${testRealmURL}person`, name: 'Person' },
@@ -326,6 +333,7 @@ module('Unit | query', function (hooks) {
     ]);
 
     let { cards, meta } = await client.search(
+      new URL(testRealmURL),
       {
         filter: {
           on: { module: `${testRealmURL}person`, name: 'Person' },
@@ -369,6 +377,7 @@ module('Unit | query', function (hooks) {
     ]);
 
     let { cards, meta } = await client.search(
+      new URL(testRealmURL),
       {
         filter: {
           on: { module: `${testRealmURL}person`, name: 'Person' },
@@ -406,6 +415,7 @@ module('Unit | query', function (hooks) {
     ]);
 
     let { cards, meta } = await client.search(
+      new URL(testRealmURL),
       {
         filter: {
           on: {
@@ -457,6 +467,7 @@ module('Unit | query', function (hooks) {
     ]);
 
     let { cards, meta } = await client.search(
+      new URL(testRealmURL),
       {
         filter: {
           on: {
@@ -505,6 +516,7 @@ module('Unit | query', function (hooks) {
     ]);
 
     let { cards, meta } = await client.search(
+      new URL(testRealmURL),
       {
         filter: {
           on: { module: `${testRealmURL}person`, name: 'Person' },
@@ -552,6 +564,7 @@ module('Unit | query', function (hooks) {
     ]);
 
     let { cards, meta } = await client.search(
+      new URL(testRealmURL),
       {
         filter: {
           on: { module: `${testRealmURL}person`, name: 'Person' },
@@ -599,6 +612,7 @@ module('Unit | query', function (hooks) {
     ]);
 
     let { cards, meta } = await client.search(
+      new URL(testRealmURL),
       {
         filter: {
           on: { module: `${testRealmURL}person`, name: 'Person' },
@@ -640,6 +654,7 @@ module('Unit | query', function (hooks) {
     ]);
 
     let { cards, meta } = await client.search(
+      new URL(testRealmURL),
       {
         filter: {
           on: { module: `${testRealmURL}person`, name: 'Person' },
@@ -675,6 +690,7 @@ module('Unit | query', function (hooks) {
     ]);
 
     let { cards, meta } = await client.search(
+      new URL(testRealmURL),
       {
         filter: {
           on: { module: `${testRealmURL}person`, name: 'Person' },
@@ -730,6 +746,7 @@ module('Unit | query', function (hooks) {
     ]);
 
     let { cards, meta } = await client.search(
+      new URL(testRealmURL),
       {
         filter: {
           on: { module: `${testRealmURL}person`, name: 'Person' },
@@ -780,6 +797,7 @@ module('Unit | query', function (hooks) {
     ]);
 
     let { cards, meta } = await client.search(
+      new URL(testRealmURL),
       {
         filter: {
           on: { module: `${testRealmURL}person`, name: 'Person' },
@@ -809,6 +827,7 @@ module('Unit | query', function (hooks) {
 
     try {
       await client.search(
+        new URL(testRealmURL),
         {
           filter: {
             on: {
@@ -837,6 +856,7 @@ module('Unit | query', function (hooks) {
     };
     try {
       await client.search(
+        new URL(testRealmURL),
         {
           filter: {
             on: cardRef,
@@ -863,6 +883,7 @@ module('Unit | query', function (hooks) {
 
     try {
       await client.search(
+        new URL(testRealmURL),
         {
           filter: {
             on: { module: `${testRealmURL}person`, name: 'Person' },
@@ -907,6 +928,7 @@ module('Unit | query', function (hooks) {
     ]);
 
     let { cards, meta } = await client.search(
+      new URL(testRealmURL),
       {
         filter: {
           on: { module: `${testRealmURL}person`, name: 'Person' },
@@ -950,6 +972,7 @@ module('Unit | query', function (hooks) {
 
     {
       let { cards, meta } = await client.search(
+        new URL(testRealmURL),
         {
           filter: {
             on: { module: `${testRealmURL}person`, name: 'Person' },
@@ -968,6 +991,7 @@ module('Unit | query', function (hooks) {
     }
     {
       let { cards, meta } = await client.search(
+        new URL(testRealmURL),
         {
           filter: {
             on: { module: `${testRealmURL}person`, name: 'Person' },
@@ -1014,6 +1038,7 @@ module('Unit | query', function (hooks) {
     ]);
 
     let { cards, meta } = await client.search(
+      new URL(testRealmURL),
       {
         filter: {
           on: { module: `${testRealmURL}person`, name: 'Person' },
@@ -1057,6 +1082,7 @@ module('Unit | query', function (hooks) {
     ]);
 
     let { cards, meta } = await client.search(
+      new URL(testRealmURL),
       {
         filter: {
           on: { module: `${testRealmURL}person`, name: 'Person' },
@@ -1097,6 +1123,7 @@ module('Unit | query', function (hooks) {
     ]);
 
     let { cards, meta } = await client.search(
+      new URL(testRealmURL),
       {
         filter: {
           on: { module: `${testRealmURL}person`, name: 'Person' },
@@ -1128,6 +1155,7 @@ module('Unit | query', function (hooks) {
     ]);
 
     let { cards, meta } = await client.search(
+      new URL(testRealmURL),
       {
         filter: {
           on: { module: `${testRealmURL}person`, name: 'Person' },
@@ -1171,6 +1199,7 @@ module('Unit | query', function (hooks) {
     );
 
     let { cards, meta } = await client.search(
+      new URL(testRealmURL),
       {
         filter: {
           eq: { name: 'Mango' },
@@ -1182,6 +1211,11 @@ module('Unit | query', function (hooks) {
     );
 
     assert.strictEqual(meta.page.total, 2, 'the total results meta is correct');
+    assert.strictEqual(
+      meta.page.realmVersion,
+      2,
+      'the realm version queried is correct',
+    );
     assert.deepEqual(
       getIds(cards),
       [mango.id, vangogh.id],
@@ -1215,6 +1249,7 @@ module('Unit | query', function (hooks) {
     );
 
     let { cards, meta } = await client.search(
+      new URL(testRealmURL),
       {
         filter: {
           eq: { name: 'Mango' },
@@ -1225,6 +1260,11 @@ module('Unit | query', function (hooks) {
     );
 
     assert.strictEqual(meta.page.total, 1, 'the total results meta is correct');
+    assert.strictEqual(
+      meta.page.realmVersion,
+      1,
+      'the realm version queried is correct',
+    );
     assert.deepEqual(getIds(cards), [mango.id], 'results are correct');
   });
 
@@ -1258,6 +1298,7 @@ module('Unit | query', function (hooks) {
     ]);
 
     let { cards, meta } = await client.search(
+      new URL(testRealmURL),
       {
         sort: [
           {
@@ -1307,6 +1348,7 @@ module('Unit | query', function (hooks) {
     ]);
 
     let { cards, meta } = await client.search(
+      new URL(testRealmURL),
       {
         sort: [
           {

--- a/packages/runtime-common/indexer/client.ts
+++ b/packages/runtime-common/indexer/client.ts
@@ -83,9 +83,7 @@ interface QueryResultsMeta {
   // consistent paginated results...
   page: {
     total: number;
-    realmVersion?: number;
-    startIndex?: number;
-    pageSize?: number;
+    realmVersion: number;
   };
 }
 
@@ -166,11 +164,12 @@ export class IndexerDBClient {
   }
 
   async cardsThatReference(cardId: string): Promise<string[]> {
-    // TODO we really need a cursor based solution to iterate through
-    // this--pervious implementations ran into a bug that necessitated a cursor
-    // for large invalidations. But beware, cursor support for SQLite in worker
-    // mode is very limited. This will likely require some custom work...
-
+    // TODO we really need a solution to iterate through large invalidation
+    // result sets for this--pervious implementations ran into a bug that
+    // necessitated a cursor for large invalidations. But beware, there is no
+    // cursor support for SQLite in worker mode. Instead, implement paging for
+    // this query. we can probably do something similar to how we are paging the
+    // search() method using realm_version for stability between pages.
     let rows = (await this.query([
       `SELECT card_url
        FROM
@@ -199,24 +198,25 @@ export class IndexerDBClient {
     // TODO this should be returning a CardCollectionDocument--handle that in
     // subsequent PR where we start storing card documents in "pristine_doc"
   ): Promise<{ cards: LooseCardResource[]; meta: QueryResultsMeta }> {
-    let [{ current_version }] = (await this.query([
-      'SELECT current_version FROM realm_versions WHERE realm_url =',
-      param(realmURL.href),
-    ])) as Pick<RealmVersionsTable, 'current_version'>[];
-    if (current_version == null) {
-      throw new Error(`No current version found for realm ${realmURL.href}`);
+    let version: number;
+    if (page?.realmVersion) {
+      version = page.realmVersion;
+    } else {
+      let [{ current_version }] = (await this.query([
+        'SELECT current_version FROM realm_versions WHERE realm_url =',
+        param(realmURL.href),
+      ])) as Pick<RealmVersionsTable, 'current_version'>[];
+      if (current_version == null) {
+        throw new Error(`No current version found for realm ${realmURL.href}`);
+      }
+      version = opts?.useWorkInProgressIndex
+        ? current_version + 1
+        : current_version;
     }
-    let version = opts?.useWorkInProgressIndex
-      ? current_version + 1
-      : current_version;
     let conditions: CardExpression[] = [
-      [
-        ...every([
-          ['i.realm_url = ', param(realmURL.href)],
-          ['is_deleted = FALSE OR is_deleted IS NULL'],
-          realmVersionExpression({ withMaxVersion: version }),
-        ]),
-      ],
+      ['i.realm_url = ', param(realmURL.href)],
+      ['is_deleted = FALSE OR is_deleted IS NULL'],
+      realmVersionExpression({ withMaxVersion: version }),
     ];
     if (filter) {
       conditions.push(this.filterCondition(filter, baseCardRef));
@@ -225,16 +225,17 @@ export class IndexerDBClient {
     let everyCondition = every(conditions);
     let query = [
       'SELECT card_url, pristine_doc',
-      `FROM indexed_cards as i ${placeholder}`,
+      `FROM indexed_cards AS i ${placeholder}`,
       `INNER JOIN realm_versions r ON i.realm_url = r.realm_url`,
       'WHERE',
       ...everyCondition,
       'GROUP BY card_url',
       ...this.orderExpression(sort),
+      ...(page ? [`LIMIT ${page.size} OFFSET ${page.number * page.size}`] : []),
     ];
     let queryCount = [
-      'SELECT count(DISTINCT card_url) as total',
-      `FROM indexed_cards as i ${placeholder}`,
+      'SELECT count(DISTINCT card_url) AS total',
+      `FROM indexed_cards AS i ${placeholder}`,
       `INNER JOIN realm_versions r ON i.realm_url = r.realm_url`,
       'WHERE',
       ...everyCondition,
@@ -823,23 +824,13 @@ export class Batch {
       ...addExplicitParens(separatedByCommas(valueExpressions)),
     ] as Expression);
 
-    // prune obsolete index entries
+    // prune obsolete generation index entries
     if (this.isNewGeneration) {
       await this.client.query([
         `DELETE FROM indexed_cards`,
         'WHERE realm_version <',
         param(this.realmVersion),
       ]);
-    } else {
-      await this.client.query([
-        `DELETE FROM indexed_cards`,
-        `WHERE card_url IN`,
-        ...addExplicitParens(
-          separatedByCommas([...this.touched].map((i) => [param(i)])),
-        ),
-        'AND realm_version <',
-        param(this.realmVersion),
-      ] as Expression);
     }
   }
 

--- a/packages/runtime-common/query.ts
+++ b/packages/runtime-common/query.ts
@@ -7,7 +7,11 @@ import { type CodeRef, isCodeRef } from './index';
 export interface Query {
   filter?: Filter;
   sort?: Sort;
-  page?: { size?: number | string; realmVersion?: number };
+  page?: {
+    number: number; // page.number is 0-based
+    size: number;
+    realmVersion?: number;
+  };
 }
 
 export type CardURL = string;

--- a/packages/runtime-common/query.ts
+++ b/packages/runtime-common/query.ts
@@ -7,7 +7,7 @@ import { type CodeRef, isCodeRef } from './index';
 export interface Query {
   filter?: Filter;
   sort?: Sort;
-  page?: { size?: number | string; cursor?: string }; // Support for this is not yet implmented
+  page?: { size?: number | string; realmVersion?: number };
 }
 
 export type CardURL = string;


### PR DESCRIPTION
This PR provides paging support for our searches. SQLite running in worker thread does not support cursors as there is not a way to serialize cursors over the postMessage boundary. So instead each search result returns the realm version that the search query ran against. For subsequent pages we can provide the realm version of the first page of results to hold the result set stable while we page through it. There was a minor adjustment to only cleanup old realm versions on generation changes instead of each update to the index so that older versions can remain available for pagination. It's not possible to paginate thru a generation change, but that should be fine since generation changes only happen when the realm does a full index which is during realm startup.