### PR TITLE
Remove next(). This caused the panels to be resized unnecessarily

### DIFF
--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
@@ -1,6 +1,5 @@
 import { registerDestructor } from '@ember/destroyable';
 import { action } from '@ember/object';
-import { next } from '@ember/runloop';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import type { WithBoundArgs } from '@glint/template';
@@ -531,7 +530,6 @@ export default class ResizablePanelGroup extends Component<Signature> {
     if (!this.panelGroupElement) {
       if (entry) {
         this.panelGroupElement = entry.target as HTMLDivElement;
-        next(this, this.onContainerResize, entry, _observer);
       }
       return;
     }


### PR DESCRIPTION
Im aware this breaks things. When opening ai assistant, if you resize the window and try to close the ai assistant, the ratios will be left out