### PR TITLE
Cs 6642 resizable panel id undefined

### DIFF
--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
@@ -204,6 +204,7 @@ export default class ResizablePanelGroup extends Component<Signature> {
     defaultLengthFraction: number | undefined;
     lengthPx: number | undefined;
     minLengthPx: number | undefined;
+    isHidden: boolean | undefined;
   }) {
     let id = Number(this.listPanelContext.size);
 
@@ -213,6 +214,8 @@ export default class ResizablePanelGroup extends Component<Signature> {
         context.defaultLengthFraction === undefined
       ) {
         context.lengthPx = -1;
+      } else if (context.isHidden) {
+        context.lengthPx = 0;
       } else {
         context.lengthPx =
           context.defaultLengthFraction * this.panelGroupLengthPx;
@@ -226,6 +229,7 @@ export default class ResizablePanelGroup extends Component<Signature> {
       minLengthPx: context.minLengthPx,
       collapsible:
         context.collapsible == undefined ? true : context.collapsible,
+      isHidden: context.isHidden,
     });
 
     this.calculatePanelRatio();

--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
@@ -202,9 +202,9 @@ export default class ResizablePanelGroup extends Component<Signature> {
   registerPanel(context: {
     collapsible: boolean | undefined;
     defaultLengthFraction: number | undefined;
+    isHidden: boolean | undefined;
     lengthPx: number | undefined;
     minLengthPx: number | undefined;
-    isHidden: boolean | undefined;
   }) {
     let id = Number(this.listPanelContext.size);
 

--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
@@ -104,10 +104,6 @@ export default class Panel extends Component<Signature> {
     registerDestructor(this, this.unregisterPanel);
   }
 
-  get panelElId() {
-    return this.args.resizablePanelElId(this.id);
-  }
-
   @action
   registerPanel() {
     if (this.id == undefined) {

--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
@@ -105,7 +105,6 @@ export default class Panel extends Component<Signature> {
   }
 
   get panelElId() {
-    debugger;
     return this.args.resizablePanelElId(this.id);
   }
 

--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
@@ -18,6 +18,7 @@ export type PanelContext = {
   initialMinLengthPx?: number;
   lengthPx: number;
   minLengthPx?: number;
+  isHidden?: boolean;
 };
 
 interface Signature {
@@ -36,6 +37,7 @@ interface Signature {
       defaultLengthFraction: number | undefined;
       lengthPx: number | undefined;
       minLengthPx: number | undefined;
+      isHidden: boolean | undefined;
     }) => number;
     resizablePanelElId: (id: number | undefined) => string;
     unregisterPanel: (id: number) => void;
@@ -46,15 +48,9 @@ interface Signature {
   Element: HTMLDivElement;
 }
 
-let managePanelRegistration = modifier(
-  (_element, [panel, isHidden]: [Panel, boolean | undefined]) => {
-    if (isHidden) {
-      scheduleOnce('afterRender', panel, panel.unregisterPanel);
-    } else {
-      scheduleOnce('afterRender', panel, panel.registerPanel);
-    }
-  },
-);
+let managePanelRegistration = modifier((_element, [panel]: [Panel]) => {
+  scheduleOnce('afterRender', panel, panel.registerPanel);
+});
 
 export default class Panel extends Component<Signature> {
   <template>
@@ -73,7 +69,7 @@ export default class Panel extends Component<Signature> {
         )
       }}
       {{createRef (@resizablePanelElId this.id) bucket=@panelGroupComponent}}
-      {{managePanelRegistration this @isHidden}}
+      {{managePanelRegistration this}}
       ...attributes
     >
       {{yield}}
@@ -108,6 +104,11 @@ export default class Panel extends Component<Signature> {
     registerDestructor(this, this.unregisterPanel);
   }
 
+  get panelElId() {
+    debugger;
+    return this.args.resizablePanelElId(this.id);
+  }
+
   @action
   registerPanel() {
     if (this.id == undefined) {
@@ -116,6 +117,7 @@ export default class Panel extends Component<Signature> {
         defaultLengthFraction: this.args.defaultLengthFraction,
         minLengthPx: this.args.minLengthPx,
         collapsible: this.args.collapsible,
+        isHidden: this.args.isHidden,
       });
     }
   }

--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
@@ -16,9 +16,9 @@ export type PanelContext = {
   defaultLengthFraction?: number;
   id: number;
   initialMinLengthPx?: number;
+  isHidden?: boolean;
   lengthPx: number;
   minLengthPx?: number;
-  isHidden?: boolean;
 };
 
 interface Signature {
@@ -35,9 +35,9 @@ interface Signature {
     registerPanel: (context: {
       collapsible: boolean | undefined;
       defaultLengthFraction: number | undefined;
+      isHidden: boolean | undefined;
       lengthPx: number | undefined;
       minLengthPx: number | undefined;
-      isHidden: boolean | undefined;
     }) => number;
     resizablePanelElId: (id: number | undefined) => string;
     unregisterPanel: (id: number) => void;

--- a/packages/boxel-ui/test-app/tests/integration/components/resizable-panel-group-test.gts
+++ b/packages/boxel-ui/test-app/tests/integration/components/resizable-panel-group-test.gts
@@ -300,8 +300,8 @@ module('Integration | ResizablePanelGroup', function (hooks) {
     assert.hasNumericStyle('.panel-1-content', 'height', 0, 0);
     this.renderController.panels[1].isHidden = false;
     await sleep(100); // let didResizeModifier run
-    assert.hasNumericStyle('.panel-0-content', 'height', 156, 1);
-    assert.hasNumericStyle('.panel-1-content', 'height', 62, 1);
+    assert.hasNumericStyle('.panel-0-content', 'height', 168, 1);
+    assert.hasNumericStyle('.panel-1-content', 'height', 50, 1);
     this.renderController.panels[1].isHidden = true;
     await sleep(100); // let didResizeModifier run
     assert.hasNumericStyle('.panel-0-content', 'height', 218, 1);


### PR DESCRIPTION
https://linear.app/cardstack/issue/CS-6642/resizable-panel-id-undefined

We get a situation when a panel isHidden, the html div id is undefined. 

Currently, registration of a panel works like this (its bcos we use a modifier)
- the panel puts a div with an undefined id
- the panel group then mutates the div with the defined id during registration 
- its the same the other way, when we toggle a panel to be hidden, the placeholder element will have its id removed. This is bcos registration of a panel is toggled with isHidden arg.

I propose we just stop unregistering via a modifier that is toggled by @isHIdden arg



