### PR TITLE
Update glimmer-scoped-css to 0.4.1 in all packages

### DIFF
--- a/packages/boxel-motion/test-app/package.json
+++ b/packages/boxel-motion/test-app/package.json
@@ -87,7 +87,7 @@
     "eslint-plugin-n": "^16.2.0",
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-qunit": "^8.0.1",
-    "glimmer-scoped-css": "^0.4.0",
+    "glimmer-scoped-css": "^0.4.1",
     "loader.js": "^4.7.0",
     "normalize.css": "8.0.1",
     "prettier": "^3.0.3",

--- a/packages/boxel-ui/addon/package.json
+++ b/packages/boxel-ui/addon/package.json
@@ -86,7 +86,7 @@
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-simple-import-sort": "^8.0.0",
     "eslint-plugin-typescript-sort-keys": "^2.1.0",
-    "glimmer-scoped-css": "^0.4.0",
+    "glimmer-scoped-css": "^0.4.1",
     "prettier": "^2.8.7",
     "prettier-plugin-ember-template-tag": "^1.1.0",
     "rollup": "^3.28.1",

--- a/packages/boxel-ui/addon/rollup.config.mjs
+++ b/packages/boxel-ui/addon/rollup.config.mjs
@@ -94,10 +94,15 @@ function scopedCSS(srcDir) {
       hash.update(source);
       let cssFileName = hash.digest('hex').slice(0, 10) + '.css';
       let dir = path.dirname(localPath);
-      let css = decodeScopedCSSRequest(source);
+      let cssAndFile = decodeScopedCSSRequest(source);
       return {
         id: path.resolve(path.dirname(importer), cssFileName),
-        meta: { 'scoped-css': { css, fileName: path.join(dir, cssFileName) } },
+        meta: {
+          'scoped-css': {
+            css: cssAndFile.css,
+            fileName: path.join(dir, cssFileName),
+          },
+        },
         external: 'relative',
       };
     },

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -879,7 +879,7 @@ async function maybeHandleScopedCSSRequest(req: Request) {
     if (typeof (globalThis as any).document == 'undefined') {
       return Promise.resolve(new Response('', { status: 200 }));
     } else {
-      let decodedCSS = decodeScopedCSSRequest(req.url);
+      let decodedCSS = decodeScopedCSSRequest(req.url).css;
       return Promise.resolve(
         new Response(`
           let styleNode = document.createElement('style');

--- a/packages/runtime-common/package.json
+++ b/packages/runtime-common/package.json
@@ -34,7 +34,7 @@
     "ember-concurrency-async-plugin": "workspace:*",
     "ember-source": "~5.4.0",
     "flat": "^5.0.2",
-    "glimmer-scoped-css": "^0.4.0",
+    "glimmer-scoped-css": "^0.4.1",
     "http-status-codes": "^2.2.0",
     "ignore": "^5.2.0",
     "js-string-escape": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 overrides:
   '@types/eslint': 8.4.1
   '@embroider/util': 1.12.0
@@ -545,7 +549,7 @@ importers:
         specifier: ^8.0.1
         version: 8.1.1(eslint@8.57.0)
       glimmer-scoped-css:
-        specifier: ^0.4.0
+        specifier: ^0.4.1
         version: 0.4.1
       loader.js:
         specifier: ^4.7.0
@@ -735,8 +739,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0(@typescript-eslint/parser@5.48.1)(eslint@8.37.0)(typescript@5.1.6)
       glimmer-scoped-css:
-        specifier: ^0.4.0
-        version: 0.4.0
+        specifier: ^0.4.1
+        version: 0.4.1
       prettier:
         specifier: github:cardstack/prettier#glimmer-style-tag-in-template-support
         version: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
@@ -1702,8 +1706,8 @@ importers:
         specifier: ^5.0.2
         version: 5.0.2
       glimmer-scoped-css:
-        specifier: ^0.4.0
-        version: 0.4.0
+        specifier: ^0.4.1
+        version: 0.4.1
       http-status-codes:
         specifier: ^2.2.0
         version: 2.2.0
@@ -4400,7 +4404,7 @@ packages:
       '@types/ember__object': ^4.0.4
       '@types/ember__routing': ^4.0.11
       ember-cli-htmlbars: ^6.0.1
-      ember-modifier: ^3.2.7 || ^4.0.0
+      ember-modifier: ^4.1.0
     peerDependenciesMeta:
       '@types/ember__array':
         optional: true
@@ -5044,7 +5048,7 @@ packages:
   /@prettier/sync@0.2.1(prettier@3.1.0-dev):
     resolution: {integrity: sha512-7ls1R6//+GPYD9vof1XaL5psViv83CwpdwlS8oUkWldYgbPhzZ3WgxIQMWqGyBmWPmoBfQg8C7jj7KI/ZuDHhQ==}
     peerDependencies:
-      prettier: ^3.0.0
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     dependencies:
       prettier: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
     dev: true
@@ -12385,7 +12389,7 @@ packages:
     engines: {node: ^16.0.0 || ^18.0.0 || >=20.0.0}
     peerDependencies:
       ember-template-lint: '>= 4.0.0'
-      prettier: '>= 3.0.0'
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     dependencies:
       '@prettier/sync': 0.2.1(prettier@3.1.0-dev)
       ember-template-lint: 5.11.2
@@ -12579,7 +12583,7 @@ packages:
     resolution: {integrity: sha512-4V6rT9b9XSeMaPmiYYA2hIhfMD088vru6AvfGWBY7L1w/st5hYv6iIfamy9+W1l9xKvIH3Hcl8+B0637/SRmzQ==}
     engines: {node: 14.* || >= 16}
     peerDependencies:
-      ember-modifier: ^3.2.7 || >= 4.0.0
+      ember-modifier: ^4.1.0
       ember-source: ^3.28.0 || ^4.0.0 || >= 5.0.0
     dependencies:
       '@embroider/addon-shim': 1.8.7
@@ -13238,7 +13242,7 @@ packages:
     peerDependencies:
       eslint: '>=5.0.0'
       eslint-config-prettier: '*'
-      prettier: '>=1.13.0'
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     peerDependenciesMeta:
       eslint-config-prettier:
         optional: true
@@ -13253,10 +13257,10 @@ packages:
     resolution: {integrity: sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      '@types/eslint': '>=8.0.0'
+      '@types/eslint': 8.4.1
       eslint: '>=8.0.0'
       eslint-config-prettier: '*'
-      prettier: '>=3.0.0'
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     peerDependenciesMeta:
       '@types/eslint':
         optional: true
@@ -13274,10 +13278,10 @@ packages:
     resolution: {integrity: sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      '@types/eslint': '>=8.0.0'
+      '@types/eslint': 8.4.1
       eslint: '>=8.0.0'
       eslint-config-prettier: '*'
-      prettier: '>=3.0.0'
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     peerDependenciesMeta:
       '@types/eslint':
         optional: true
@@ -14875,28 +14879,16 @@ packages:
       through: 2.2.7
     dev: true
 
-  /glimmer-scoped-css@0.4.0:
-    resolution: {integrity: sha512-ZiUZzseqXQ0vHxwM8OSKwclPL16UnYOFo/W6QrIAi6PF1el/RtkQNvCgWwAQFv2QsJHXcBXxb9BFzPFNtgAexw==}
-    dependencies:
-      '@embroider/addon-shim': 1.8.6
-      js-string-escape: 1.0.1
-      postcss: 8.4.31
-      postcss-selector-parser: 6.0.13
-      super-fast-md5: 1.0.1
-    transitivePeerDependencies:
-      - supports-color
-
   /glimmer-scoped-css@0.4.1:
     resolution: {integrity: sha512-BWZyBEpmZu0RLnuOaSBJkCjSMoGuxO3glq7JCM1QH0r9Ki8OVdYj+nUIgfg03T5duqbeQqR1Oad8MvDF/O4bCQ==}
     dependencies:
-      '@embroider/addon-shim': 1.8.6
+      '@embroider/addon-shim': 1.8.7
       js-string-escape: 1.0.1
       postcss: 8.4.31
       postcss-selector-parser: 6.0.13
       super-fast-md5: 1.0.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /glob-parent@3.1.0:
     resolution: {integrity: sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==}
@@ -19136,7 +19128,7 @@ packages:
     resolution: {integrity: sha512-zJTC+NhEU0kHNnVh7OtcvMmkJmYTgFTist76FP9q07m9+WCvcaunR1sTFIOlGE9TH/5UGm6rlF86Umt9ouorAg==}
     engines: {node: 16.* || 18.* || >= 20}
     peerDependencies:
-      prettier: '>= 3.0.0'
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     dependencies:
       '@babel/core': 7.24.3(supports-color@8.1.1)
       '@glimmer/syntax': 0.84.3
@@ -23238,7 +23230,3 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
This updates the `boxel-ui` Rollup configuration to use the new interface of `decodeScopedCSSRequest`, otherwise you see errors [like this](https://github.com/cardstack/boxel/actions/runs/8640570829/job/23688692675?pr=1158#step:4:22):

```
[!] (plugin scoped-css) RollupError: Could not set source for asset "components/accordion/8042e6ceab.css", asset source needs to be a string, Uint8Array or Buffer.
    at error (/home/runner/work/boxel/boxel/node_modules/.pnpm/rollup@3.28.1/node_modules/rollup/dist/shared/rollup.js:353:30)
    at getValidSource (/home/runner/work/boxel/boxel/node_modules/.pnpm/rollup@3.28.1/node_modules/rollup/dist/shared/rollup.js:1133:16)
    at FileEmitter.emitAsset (/home/runner/work/boxel/boxel/node_modules/.pnpm/rollup@3.28.1/node_modules/rollup/dist/shared/rollup.js:1293:15)
    at FileEmitter.emitFile (/home/runner/work/boxel/boxel/node_modules/.pnpm/rollup@3.28.1/node_modules/rollup/dist/shared/rollup.js:1173:25)
    at Object.generateBundle (file:///home/runner/work/boxel/boxel/packages/boxel-ui/addon/rollup.config.mjs:108:16)
    at /home/runner/work/boxel/boxel/node_modules/.pnpm/rollup@3.28.1/node_modules/rollup/dist/shared/rollup.js:1913:40
```

Is it worth using [`@rollup/plugin-typescript`](https://www.npmjs.com/package/@rollup/plugin-typescript) to allow us to use a Typescript config file? That would have made the fix more obvious.

A similar change is needed in `…/runtime-common/loader.ts`.