### PR TITLE
realm: Remove error reporting on indexing

### DIFF
--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -36,7 +36,6 @@ import {
   type SerializedError,
 } from '@cardstack/runtime-common/error';
 import { RealmPaths, LocalPath } from '@cardstack/runtime-common/paths';
-import { reportError } from '@cardstack/runtime-common/realm';
 import {
   isIgnored,
   type Reader,
@@ -476,9 +475,9 @@ export class CurrentRun {
         deferred.reject(err);
         throw err;
       }
-      let warning = `encountered error indexing card instance ${path}: ${error.error.detail}`;
-      log.warn(warning);
-      reportError(new Error(warning));
+      log.warn(
+        `encountered error indexing card instance ${path}: ${error.error.detail}`,
+      );
       this.setInstance(instanceURL, error);
       deferred.fulfill();
     }


### PR DESCRIPTION
This part of #1084 turned out to be unnecessary as we expect indexing errors from userland data.