### PR TITLE
ui: Fix widths of icons in Freestyle

### DIFF
--- a/packages/boxel-ui/addon/src/components/icon-button/usage.gts
+++ b/packages/boxel-ui/addon/src/components/icon-button/usage.gts
@@ -181,6 +181,8 @@ export default class IconButtonUsage extends Component {
 
       .show-borders .icon {
         border: 1px solid var(--boxel-500);
+        width: calc(var(--boxel-icon-button-width) + 2px);
+        height: calc(var(--boxel-icon-button-height) + 2px);
       }
     </style>
   </template>


### PR DESCRIPTION
The border needs to be included in the container width.

This fixes a problem in #1159 which made us believe the icons were exceeding their viewboxes. See the preview [here](https://uiicons-border-calc-cs-6700.boxel-ui-preview.stack.cards/?f=All%20Icons&s=Components&ss=%3CIconButton%3E).

Before:

![screencast 2024-04-11 11-04-34](https://github.com/cardstack/boxel/assets/43280/f8a3ed41-193b-4708-87c1-db88d7eb0d32)

After:

<img width="979" alt="Boxel Components 2024-04-11 14-24-11" src="https://github.com/cardstack/boxel/assets/43280/e7d4e178-ff5a-4a75-9607-0be858246e6a">