### PR TITLE
Fix AI panel trigger covering card catalog

### DIFF
--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -256,7 +256,6 @@ export default class SubmodeLayout extends Component<Signature> {
         margin-right: 0;
         background-color: var(--boxel-ai-purple);
         box-shadow: var(--boxel-deep-box-shadow);
-        z-index: 100;
       }
 
       .ai-assistant-panel {

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -256,6 +256,7 @@ export default class SubmodeLayout extends Component<Signature> {
         margin-right: 0;
         background-color: var(--boxel-ai-purple);
         box-shadow: var(--boxel-deep-box-shadow);
+        z-index: calc(var(--boxel-modal-z-index) - 1);
       }
 
       .ai-assistant-panel {


### PR DESCRIPTION
<img width="854" alt="Screenshot 2024-04-13 at 13 13 51" src="https://github.com/cardstack/boxel/assets/8165111/a54216f3-e84e-4bdc-9661-cf401d35e9b5">

Previously, you could also click on ai button when choosing a card. You can see the percy change. After this change, the button is overlayed (greyed out) and trying to click on it will close the modal


