### PR TITLE
Fix card catalog reaching bottom viewport

### DIFF
--- a/packages/host/app/components/card-catalog/modal.gts
+++ b/packages/host/app/components/card-catalog/modal.gts
@@ -91,6 +91,7 @@ export default class CardCatalogModal extends Component<Signature> {
   <template>
     {{#if (and (gt this.stateStack.length 0) (not this.state.dismissModal))}}
       <ModalContainer
+        class='card-catalog-modal'
         @title={{this.state.chooseCardTitle}}
         @onClose={{fn this.pick undefined}}
         @zIndex={{this.zIndex}}
@@ -195,6 +196,12 @@ export default class CardCatalogModal extends Component<Signature> {
       </ModalContainer>
     {{/if}}
     <style>
+      .card-catalog-modal > :deep(.boxel-modal__inner) {
+        max-height: 80vh;
+      }
+      .card-catalog-modal.large {
+        --boxel-modal-offset-top: var(--boxel-sp-xxxl);
+      }
       .footer {
         display: flex;
         justify-content: space-between;


### PR DESCRIPTION
**Issue**

(1920x884)
![Screenshot 2024-04-15 at 14 59 17](https://github.com/cardstack/boxel/assets/8165111/fdef21a6-1711-4abc-adc0-41d35105071f)


**After Fix**

(1920x884)
![Screenshot 2024-04-15 at 11 48 13](https://github.com/cardstack/boxel/assets/8165111/617c3175-93c7-4c29-8607-e12275e9ef52)

(1440x1024)

<img width="718" alt="Screenshot 2024-04-15 at 11 50 33" src="https://github.com/cardstack/boxel/assets/8165111/b7ee42ba-c703-4652-b241-033cf11f8edc">




This is the design https://app.zeplin.io/project/64a592b657f3905149220785/screen/64a7157776ed5439ca7ce573. Shall I shift it the catalog modal to the right (1440x1024) 

