### PR TITLE
TestRealmAdapter handles shimmed modules

### DIFF
--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -21,9 +21,9 @@ import {
   waitForCodeEditor,
   getMonacoContent,
   visitOperatorMode as _visitOperatorMode,
-  TestRealmAdapter,
   type TestContextWithSave,
 } from '../../helpers';
+import { TestRealmAdapter } from '../../helpers/adapter';
 import { setupMatrixServiceMock } from '../../helpers/mock-matrix-service';
 
 const testRealmURL2 = 'http://test-realm/test2/';

--- a/packages/host/tests/acceptance/code-submode/editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/editor-test.ts
@@ -19,7 +19,6 @@ import type LoaderService from '@cardstack/host/services/loader-service';
 import type MonacoService from '@cardstack/host/services/monaco-service';
 
 import {
-  TestRealmAdapter,
   percySnapshot,
   setupLocalIndexing,
   setupServerSentEvents,
@@ -34,6 +33,7 @@ import {
   type TestContextWithSSE,
   type TestContextWithSave,
 } from '../../helpers';
+import { TestRealmAdapter } from '../../helpers/adapter';
 import { setupMatrixServiceMock } from '../../helpers/mock-matrix-service';
 
 let realmPermissions: { [realmURL: string]: ('read' | 'write')[] };

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -29,7 +29,6 @@ import { SerializedState } from '@cardstack/host/services/operator-mode-state-se
 import type RealmInfoService from '@cardstack/host/services/realm-info-service';
 
 import {
-  TestRealmAdapter,
   elementIsVisible,
   getMonacoContent,
   percySnapshot,
@@ -44,6 +43,7 @@ import {
   type TestContextWithSave,
   setMonacoContent,
 } from '../../helpers';
+import { TestRealmAdapter } from '../../helpers/adapter';
 import { setupMatrixServiceMock } from '../../helpers/mock-matrix-service';
 
 const testRealmURL2 = 'http://test-realm/test2/';

--- a/packages/host/tests/helpers/adapter.ts
+++ b/packages/host/tests/helpers/adapter.ts
@@ -172,10 +172,6 @@ export class TestRealmAdapter implements RealmAdapter {
     }
   }
 
-  get c() {
-    return this.#contents;
-  }
-
   async openFile(path: LocalPath): Promise<FileRef | undefined> {
     let content;
     try {

--- a/packages/host/tests/helpers/adapter.ts
+++ b/packages/host/tests/helpers/adapter.ts
@@ -15,11 +15,9 @@ import {
   UpdateEventData,
 } from '@cardstack/runtime-common/realm';
 
-import { testRealmURL } from './const';
-
 import { WebMessageStream, messageCloseHandler } from './stream';
 
-import { Dir, createJWT } from '.';
+import { Dir, createJWT, testRealmURL } from '.';
 
 type CardAPI = typeof import('https://cardstack.com/base/card-api');
 

--- a/packages/host/tests/helpers/adapter.ts
+++ b/packages/host/tests/helpers/adapter.ts
@@ -1,0 +1,251 @@
+import {
+  LocalPath,
+  LooseSingleCardDocument,
+  RealmAdapter,
+  RealmPaths,
+  createResponse,
+} from '@cardstack/runtime-common';
+
+import {
+  FileRef,
+  Kind,
+  Realm,
+  RealmInfo,
+  TokenClaims,
+  UpdateEventData,
+} from '@cardstack/runtime-common/realm';
+
+import { testRealmURL } from './const';
+
+import { WebMessageStream, messageCloseHandler } from './stream';
+
+import { CardDocFiles, Dir, createJWT } from '.';
+
+type FilesForTestAdapter = Record<
+  string,
+  string | LooseSingleCardDocument | CardDocFiles | RealmInfo
+>;
+class TokenExpiredError extends Error {}
+class JsonWebTokenError extends Error {}
+
+export class TestRealmAdapter implements RealmAdapter {
+  #files: Dir = {};
+  #lastModified: Map<string, number> = new Map();
+  #paths: RealmPaths;
+  #subscriber: ((message: UpdateEventData) => void) | undefined;
+
+  constructor(
+    flatFiles: FilesForTestAdapter,
+    realmURL = new URL(testRealmURL),
+  ) {
+    this.#paths = new RealmPaths(realmURL);
+    let now = Date.now();
+    for (let [path, content] of Object.entries(flatFiles)) {
+      let segments = path.split('/');
+      let last = segments.pop()!;
+      let dir = this.#traverse(segments, 'directory');
+      if (typeof dir === 'string') {
+        throw new Error(`tried to use file as directory`);
+      }
+      this.#lastModified.set(this.#paths.fileURL(path).href, now);
+      if (typeof content === 'string') {
+        dir[last] = content;
+      } else {
+        dir[last] = JSON.stringify(content);
+      }
+    }
+  }
+
+  createJWT(claims: TokenClaims, expiration: string, secret: string) {
+    return createJWT(claims, expiration, secret);
+  }
+
+  verifyJWT(
+    token: string,
+    secret: string,
+  ): TokenClaims & { iat: number; exp: number } {
+    let [_header, payload, signature] = token.split('.');
+    if (signature === secret) {
+      let claims = JSON.parse(atob(payload)) as {
+        iat: number;
+        exp: number;
+      } & TokenClaims;
+      let expiration = claims.exp;
+      if (expiration > Date.now() / 1000) {
+        throw new TokenExpiredError(`JWT token expired at ${expiration}`);
+      }
+      return claims;
+    }
+    throw new JsonWebTokenError(`unable to verify JWT: ${token}`);
+  }
+
+  get lastModified() {
+    return this.#lastModified;
+  }
+
+  // this is to aid debugging since privates are actually not visible in the debugger
+  get files() {
+    return this.#files;
+  }
+
+  async *readdir(
+    path: string,
+  ): AsyncGenerator<{ name: string; path: string; kind: Kind }, void> {
+    let dir =
+      path === '' ? this.#files : this.#traverse(path.split('/'), 'directory');
+    for (let [name, content] of Object.entries(dir)) {
+      yield {
+        name,
+        path: path === '' ? name : `${path}/${name}`,
+        kind: typeof content === 'string' ? 'file' : 'directory',
+      };
+    }
+  }
+
+  async exists(path: string): Promise<boolean> {
+    let maybeFilename = path.split('/').pop()!;
+    try {
+      // a quirk of our test file system's traverse is that it creates
+      // directories as it goes--so do our best to determine if we are checking for
+      // a file that exists (because of this behavior directories always exist)
+      await this.#traverse(
+        path.split('/'),
+        maybeFilename.includes('.') ? 'file' : 'directory',
+      );
+      return true;
+    } catch (err: any) {
+      if (err.name === 'NotFoundError') {
+        return false;
+      }
+      if (err.name === 'TypeMismatchError') {
+        try {
+          await this.#traverse(path.split('/'), 'file');
+          return true;
+        } catch (err: any) {
+          if (err.name === 'NotFoundError') {
+            return false;
+          }
+          throw err;
+        }
+      }
+      throw err;
+    }
+  }
+
+  async openFile(path: LocalPath): Promise<FileRef | undefined> {
+    let content;
+    try {
+      content = this.#traverse(path.split('/'), 'file');
+    } catch (err: any) {
+      if (['TypeMismatchError', 'NotFoundError'].includes(err.name)) {
+        return undefined;
+      }
+      throw err;
+    }
+    if (typeof content !== 'string') {
+      return undefined;
+    }
+    return {
+      path,
+      content,
+      lastModified: this.#lastModified.get(this.#paths.fileURL(path).href)!,
+    };
+  }
+
+  async write(
+    path: LocalPath,
+    contents: string | object,
+  ): Promise<{ lastModified: number }> {
+    let segments = path.split('/');
+    let name = segments.pop()!;
+    let dir = this.#traverse(segments, 'directory');
+    if (typeof dir === 'string') {
+      throw new Error(`treated file as a directory`);
+    }
+    if (typeof dir[name] === 'object') {
+      throw new Error(
+        `cannot write file over an existing directory at ${path}`,
+      );
+    }
+
+    let type = dir[name] ? 'updated' : 'added';
+    dir[name] =
+      typeof contents === 'string'
+        ? contents
+        : JSON.stringify(contents, null, 2);
+    let lastModified = Date.now();
+    this.#lastModified.set(this.#paths.fileURL(path).href, lastModified);
+
+    this.postUpdateEvent({ [type]: path } as
+      | { added: string }
+      | { updated: string });
+
+    return { lastModified };
+  }
+
+  postUpdateEvent(data: UpdateEventData) {
+    this.#subscriber?.(data);
+  }
+
+  async remove(path: LocalPath) {
+    let segments = path.split('/');
+    let name = segments.pop()!;
+    let dir = this.#traverse(segments, 'directory');
+    if (typeof dir === 'string') {
+      throw new Error(`tried to use file as directory`);
+    }
+    delete dir[name];
+    this.postUpdateEvent({ removed: path });
+  }
+
+  #traverse(
+    segments: string[],
+    targetKind: Kind,
+    originalPath = segments.join('/'),
+  ): string | Dir {
+    let dir: Dir | string = this.#files;
+    while (segments.length > 0) {
+      if (typeof dir === 'string') {
+        throw new Error(`tried to use file as directory`);
+      }
+      let name = segments.shift()!;
+      if (name === '') {
+        return dir;
+      }
+      if (dir[name] === undefined) {
+        if (
+          segments.length > 0 ||
+          (segments.length === 0 && targetKind === 'directory')
+        ) {
+          dir[name] = {};
+        } else if (segments.length === 0 && targetKind === 'file') {
+          let err = new Error(`${originalPath} not found`);
+          err.name = 'NotFoundError'; // duck type to the same as what the FileSystem API looks like
+          throw err;
+        }
+      }
+      dir = dir[name];
+    }
+    return dir;
+  }
+
+  createStreamingResponse(
+    realm: Realm,
+    _request: Request,
+    responseInit: ResponseInit,
+    cleanup: () => void,
+  ) {
+    let s = new WebMessageStream();
+    let response = createResponse(realm, s.readable, responseInit);
+    messageCloseHandler(s.readable, cleanup);
+    return { response, writable: s.writable };
+  }
+
+  async subscribe(cb: (message: UpdateEventData) => void): Promise<void> {
+    this.#subscriber = cb;
+  }
+
+  unsubscribe(): void {
+    this.#subscriber = undefined;
+  }
+}

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -9,12 +9,9 @@ import { parse } from 'date-fns';
 import ms from 'ms';
 
 import {
-  Kind,
   RealmAdapter,
-  FileRef,
   LooseSingleCardDocument,
   baseRealm,
-  createResponse,
   RealmPermissions,
   Deferred,
   type RealmInfo,
@@ -22,10 +19,9 @@ import {
 } from '@cardstack/runtime-common';
 
 import { Loader } from '@cardstack/runtime-common/loader';
-import { LocalPath, RealmPaths } from '@cardstack/runtime-common/paths';
+
 import { Realm } from '@cardstack/runtime-common/realm';
 
-import type { UpdateEventData } from '@cardstack/runtime-common/realm';
 import {
   RunnerOptionsManager,
   type RunState,
@@ -47,11 +43,12 @@ import {
   type FieldDef,
 } from 'https://cardstack.com/base/card-api';
 
+import { TestRealmAdapter } from './adapter';
 import { testRealmInfo, testRealmURL } from './const';
 import percySnapshot from './percy-snapshot';
 
 import { renderComponent } from './render-component';
-import { WebMessageStream, messageCloseHandler } from './stream';
+
 import visitOperatorMode from './visit-operator-mode';
 
 export { visitOperatorMode, testRealmURL, testRealmInfo, percySnapshot };
@@ -573,10 +570,6 @@ export function setupCardLogs(
     await api.flushLogs();
   });
 }
-type FilesForTestAdapter = Record<
-  string,
-  string | LooseSingleCardDocument | CardDocFiles | RealmInfo
->;
 
 export function createJWT(
   claims: TokenClaims,
@@ -599,231 +592,6 @@ export function createJWT(
   // this is our silly JWT--we don't sign with crypto since we are running in the
   // browser so the secret is the signature
   return `${headerAndPayload}.${secret}`;
-}
-
-class TokenExpiredError extends Error {}
-class JsonWebTokenError extends Error {}
-
-export class TestRealmAdapter implements RealmAdapter {
-  #files: Dir = {};
-  #lastModified: Map<string, number> = new Map();
-  #paths: RealmPaths;
-  #subscriber: ((message: UpdateEventData) => void) | undefined;
-
-  constructor(
-    flatFiles: FilesForTestAdapter,
-    realmURL = new URL(testRealmURL),
-  ) {
-    this.#paths = new RealmPaths(realmURL);
-    let now = Date.now();
-    for (let [path, content] of Object.entries(flatFiles)) {
-      let segments = path.split('/');
-      let last = segments.pop()!;
-      let dir = this.#traverse(segments, 'directory');
-      if (typeof dir === 'string') {
-        throw new Error(`tried to use file as directory`);
-      }
-      this.#lastModified.set(this.#paths.fileURL(path).href, now);
-      if (typeof content === 'string') {
-        dir[last] = content;
-      } else {
-        dir[last] = JSON.stringify(content);
-      }
-    }
-  }
-
-  createJWT(claims: TokenClaims, expiration: string, secret: string) {
-    return createJWT(claims, expiration, secret);
-  }
-
-  verifyJWT(
-    token: string,
-    secret: string,
-  ): TokenClaims & { iat: number; exp: number } {
-    let [_header, payload, signature] = token.split('.');
-    if (signature === secret) {
-      let claims = JSON.parse(atob(payload)) as {
-        iat: number;
-        exp: number;
-      } & TokenClaims;
-      let expiration = claims.exp;
-      if (expiration > Date.now() / 1000) {
-        throw new TokenExpiredError(`JWT token expired at ${expiration}`);
-      }
-      return claims;
-    }
-    throw new JsonWebTokenError(`unable to verify JWT: ${token}`);
-  }
-
-  get lastModified() {
-    return this.#lastModified;
-  }
-
-  // this is to aid debugging since privates are actually not visible in the debugger
-  get files() {
-    return this.#files;
-  }
-
-  async *readdir(
-    path: string,
-  ): AsyncGenerator<{ name: string; path: string; kind: Kind }, void> {
-    let dir =
-      path === '' ? this.#files : this.#traverse(path.split('/'), 'directory');
-    for (let [name, content] of Object.entries(dir)) {
-      yield {
-        name,
-        path: path === '' ? name : `${path}/${name}`,
-        kind: typeof content === 'string' ? 'file' : 'directory',
-      };
-    }
-  }
-
-  async exists(path: string): Promise<boolean> {
-    let maybeFilename = path.split('/').pop()!;
-    try {
-      // a quirk of our test file system's traverse is that it creates
-      // directories as it goes--so do our best to determine if we are checking for
-      // a file that exists (because of this behavior directories always exist)
-      await this.#traverse(
-        path.split('/'),
-        maybeFilename.includes('.') ? 'file' : 'directory',
-      );
-      return true;
-    } catch (err: any) {
-      if (err.name === 'NotFoundError') {
-        return false;
-      }
-      if (err.name === 'TypeMismatchError') {
-        try {
-          await this.#traverse(path.split('/'), 'file');
-          return true;
-        } catch (err: any) {
-          if (err.name === 'NotFoundError') {
-            return false;
-          }
-          throw err;
-        }
-      }
-      throw err;
-    }
-  }
-
-  async openFile(path: LocalPath): Promise<FileRef | undefined> {
-    let content;
-    try {
-      content = this.#traverse(path.split('/'), 'file');
-    } catch (err: any) {
-      if (['TypeMismatchError', 'NotFoundError'].includes(err.name)) {
-        return undefined;
-      }
-      throw err;
-    }
-    if (typeof content !== 'string') {
-      return undefined;
-    }
-    return {
-      path,
-      content,
-      lastModified: this.#lastModified.get(this.#paths.fileURL(path).href)!,
-    };
-  }
-
-  async write(
-    path: LocalPath,
-    contents: string | object,
-  ): Promise<{ lastModified: number }> {
-    let segments = path.split('/');
-    let name = segments.pop()!;
-    let dir = this.#traverse(segments, 'directory');
-    if (typeof dir === 'string') {
-      throw new Error(`treated file as a directory`);
-    }
-    if (typeof dir[name] === 'object') {
-      throw new Error(
-        `cannot write file over an existing directory at ${path}`,
-      );
-    }
-
-    let type = dir[name] ? 'updated' : 'added';
-    dir[name] =
-      typeof contents === 'string'
-        ? contents
-        : JSON.stringify(contents, null, 2);
-    let lastModified = Date.now();
-    this.#lastModified.set(this.#paths.fileURL(path).href, lastModified);
-
-    this.postUpdateEvent({ [type]: path } as
-      | { added: string }
-      | { updated: string });
-
-    return { lastModified };
-  }
-
-  postUpdateEvent(data: UpdateEventData) {
-    this.#subscriber?.(data);
-  }
-
-  async remove(path: LocalPath) {
-    let segments = path.split('/');
-    let name = segments.pop()!;
-    let dir = this.#traverse(segments, 'directory');
-    if (typeof dir === 'string') {
-      throw new Error(`tried to use file as directory`);
-    }
-    delete dir[name];
-    this.postUpdateEvent({ removed: path });
-  }
-
-  #traverse(
-    segments: string[],
-    targetKind: Kind,
-    originalPath = segments.join('/'),
-  ): string | Dir {
-    let dir: Dir | string = this.#files;
-    while (segments.length > 0) {
-      if (typeof dir === 'string') {
-        throw new Error(`tried to use file as directory`);
-      }
-      let name = segments.shift()!;
-      if (name === '') {
-        return dir;
-      }
-      if (dir[name] === undefined) {
-        if (
-          segments.length > 0 ||
-          (segments.length === 0 && targetKind === 'directory')
-        ) {
-          dir[name] = {};
-        } else if (segments.length === 0 && targetKind === 'file') {
-          let err = new Error(`${originalPath} not found`);
-          err.name = 'NotFoundError'; // duck type to the same as what the FileSystem API looks like
-          throw err;
-        }
-      }
-      dir = dir[name];
-    }
-    return dir;
-  }
-
-  createStreamingResponse(
-    realm: Realm,
-    _request: Request,
-    responseInit: ResponseInit,
-    cleanup: () => void,
-  ) {
-    let s = new WebMessageStream();
-    let response = createResponse(realm, s.readable, responseInit);
-    messageCloseHandler(s.readable, cleanup);
-    return { response, writable: s.writable };
-  }
-
-  async subscribe(cb: (message: UpdateEventData) => void): Promise<void> {
-    this.#subscriber = cb;
-  }
-
-  unsubscribe(): void {
-    this.#subscriber = undefined;
-  }
 }
 
 export function delay(delayAmountMs: number): Promise<void> {

--- a/packages/host/tests/integration/components/card-delete-test.gts
+++ b/packages/host/tests/integration/components/card-delete-test.gts
@@ -25,10 +25,10 @@ import {
   setupLocalIndexing,
   setupOnSave,
   setupServerSentEvents,
-  TestRealmAdapter,
   type TestContextWithSSE,
   setupIntegrationTestRealm,
 } from '../../helpers';
+import { TestRealmAdapter } from '../../helpers/adapter';
 import { setupMatrixServiceMock } from '../../helpers/mock-matrix-service';
 import { renderComponent } from '../../helpers/render-component';
 

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -41,10 +41,10 @@ import {
   setupOnSave,
   showSearchResult,
   type TestContextWithSave,
-  TestRealmAdapter,
   getMonacoContent,
   waitForCodeEditor,
 } from '../../helpers';
+import { TestRealmAdapter } from '../../helpers/adapter';
 import {
   setupMatrixServiceMock,
   MockMatrixService,

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -872,7 +872,7 @@ export class Realm {
       return notFound(this, request, `${request.url} not found`);
     }
 
-    let fileRef = maybeFileRef; // todo rename to fileHandle (or ref)
+    let fileRef = maybeFileRef;
 
     if (
       executableExtensions.some((extension) =>
@@ -880,8 +880,6 @@ export class Realm {
       ) &&
       !localPath.startsWith(assetsDir)
     ) {
-      // propagate the shimmed symbol to the response - the loader should deal with it
-      // value should not be the proxied module but the module
       let response = this.makeJS(
         await fileContentToText(fileRef),
         fileRef.path,


### PR DESCRIPTION
This change solves a bunch of failing tests when I try to isolate the loaders (i.e. making the realm create one for itself).

2 examples of failing tests:

<img width="947" alt="image" src="https://github.com/cardstack/boxel/assets/273660/ecc377ba-5ba2-4f04-a3a2-6a75f7034200">

<img width="1259" alt="image" src="https://github.com/cardstack/boxel/assets/273660/7506899d-60da-4217-a7e1-3b77c7253fe7">


Currently the loaders are still shared in main branch so this change has no effect here, but when we will isolate the loaders  as described above, this fixes the problem of missing shims in different loaders. The solution is to [propagate the shim from the test realm adapter](https://github.com/cardstack/boxel/pull/1172/files#diff-2c5c1a121648aee54962f7d0e222bcfc5bba373c045b0a1a2e921cf5000bc4e5R200) all the way up to the loader where it gets evaluated as a shim.  