### PR TITLE
Follow redirections in virtual network

### DIFF
--- a/packages/realm-server/tests/virtual-network-test.ts
+++ b/packages/realm-server/tests/virtual-network-test.ts
@@ -5,7 +5,7 @@ import {
 import { module, test } from 'qunit';
 
 module('virtual-network', function () {
-  test('will respond wilth real (not virtual) url when handler makes a redirect', async function (assert) {
+  test('will respond with real (not virtual) url when handler makes a redirect', async function (assert) {
     let virtualNetwork = new VirtualNetwork();
     virtualNetwork.addURLMapping(
       new URL('https://cardstack.com/base/'),
@@ -30,5 +30,34 @@ module('virtual-network', function () {
       response.headers.get('Location'),
       'http://localhost:4201/base/__boxel/assets/',
     );
+  });
+
+  test('is able to follow redirects', async function (assert) {
+    let virtualNetwork = new VirtualNetwork();
+
+    virtualNetwork.mount(async (request: Request) => {
+      // Normally there would be some redirection logic here, but for this test we just want to make sure that the redirect is handled correctly
+      if (request.url == 'http://test-realm/test/person') {
+        return new Response(null, {
+          status: 302,
+          headers: {
+            Location: 'http://test-realm/test/person.gts',
+          },
+        }) as ResponseWithNodeStream;
+      }
+
+      return null;
+    });
+
+    virtualNetwork.mount(async (request: Request) => {
+      if (request.url == 'http://test-realm/test/person.gts') {
+        return new Response(null, { status: 200 });
+      }
+      return null;
+    });
+
+    let response = await virtualNetwork.fetch(`http://test-realm/test/person`);
+    assert.strictEqual(response.url, 'http://test-realm/test/person.gts');
+    assert.true(response.redirected);
   });
 });

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -431,42 +431,6 @@ export class Loader {
     }
   }
 
-  // For following redirects of responses returned by loader's urlHandlers
-  private async simulateFetch(
-    request: Request,
-    result: Response,
-  ): Promise<Response> {
-    const urlString = request.url;
-    let redirectedHeaderKey = 'simulated-fetch-redirected'; // Temporary header to track if the request was redirected in the redirection chain
-
-    if (result.status >= 300 && result.status < 400) {
-      const location = result.headers.get('location');
-      if (location) {
-        request.headers.set(redirectedHeaderKey, 'true');
-        return await this.fetch(new URL(location, urlString), request);
-      }
-    }
-
-    // We are using Object.defineProperty because `url` and `redirected`
-    // response properties are read-only. We are overriding these properties to
-    // conform to the Fetch API specification where the `url` property is set to
-    // the final URL and the `redirected` property is set to true if the request
-    // was redirected. Normally, when using a native fetch, these properties are
-    // set automatically by the client, but in this case, we are simulating the
-    // fetch and need to set these properties manually.
-
-    if (request.url && !result.url) {
-      Object.defineProperty(result, 'url', { value: urlString });
-
-      if (request.headers.get(redirectedHeaderKey) === 'true') {
-        Object.defineProperty(result, 'redirected', { value: true });
-        request.headers.delete(redirectedHeaderKey);
-      }
-    }
-
-    return result;
-  }
-
   async fetch(
     urlOrRequest: string | URL | Request,
     init?: RequestInit,

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -477,7 +477,11 @@ export class Loader {
 
         let result = await handler(request);
         if (result) {
-          return await this.simulateFetch(request, result);
+          return await followRedirections(
+            request,
+            result,
+            this.fetch.bind(this),
+          );
         }
       }
 
@@ -794,4 +798,40 @@ async function maybeHandleScopedCSSRequest(req: Request) {
   } else {
     return Promise.resolve(null);
   }
+}
+
+export async function followRedirections(
+  request: Request,
+  result: Response,
+  fetchImplementation: typeof fetch, // argument purposively not named `fetch` to avoid shadowing the global fetch
+): Promise<Response> {
+  const urlString = request.url;
+  let redirectedHeaderKey = 'simulated-fetch-redirected'; // Temporary header to track if the request was redirected in the redirection chain
+
+  if (result.status >= 300 && result.status < 400) {
+    const location = result.headers.get('location');
+    if (location) {
+      request.headers.set(redirectedHeaderKey, 'true');
+      return await fetchImplementation(new URL(location, urlString), request);
+    }
+  }
+
+  // We are using Object.defineProperty because `url` and `redirected`
+  // response properties are read-only. We are overriding these properties to
+  // conform to the Fetch API specification where the `url` property is set to
+  // the final URL and the `redirected` property is set to true if the request
+  // was redirected. Normally, when using a native fetch, these properties are
+  // set automatically by the client, but in this case, we are simulating the
+  // fetch and need to set these properties manually.
+
+  if (request.url && !result.url) {
+    Object.defineProperty(result, 'url', { value: urlString });
+
+    if (request.headers.get(redirectedHeaderKey) === 'true') {
+      Object.defineProperty(result, 'redirected', { value: true });
+      request.headers.delete(redirectedHeaderKey);
+    }
+  }
+
+  return result;
 }


### PR DESCRIPTION
When we were making the virtual network layer we acknowledged that we are going to need this but we didn't add it at that time.

Now that I've been trying to isolate loaders by making the realm create its own loader I realized this is now needed. For example, here is a failing test (from the isolated-loaders experimental branch) that made me realize that: 

<img width="1278" alt="image" src="https://github.com/cardstack/boxel/assets/273660/f5f4f557-ce7f-4c1f-aa28-fc87829e122e">

Adding redirection support in this PR solves this. So even if this change targets later work (isolated loaders (currently they are shared)) it's good we land this in main so that we have less changes to think about later when we will debug isolated loaders work. 
