### PR TITLE
Remove Postgres infra as a dependency to migrations

### DIFF
--- a/docs/indexer-work-plan.mermaid
+++ b/docs/indexer-work-plan.mermaid
@@ -27,10 +27,8 @@ flowchart
     PostgresMigrations-->PostgresQueue
     JobQueueFacade-->SQLiteIndexerImplementation
     SQLiteIndexerImplementation-->PostgresIndexerImplementation
-    PostgresInfra-->PostgresIndexerImplementation
     TestHelperForIndexedCardTablePopulation-->SQLiteQueryEngineImplementation
     SQLiteQueryEngineImplementation-->PostgresQueryEngineImplementation
-    PostgresInfra-->PostgresQueryEngineImplementation
     SQLiteIndexerImplementation-->IndexInvalidation
     SQLiteIndexerImplementation-->UseSQLiteIndexerInHostTests
     PostgresIndexerImplementation-->UsePostgresIndexerInRealmServer

--- a/docs/indexer-work-plan.mermaid
+++ b/docs/indexer-work-plan.mermaid
@@ -29,8 +29,10 @@ flowchart
     SQLiteIndexerImplementation-->PostgresIndexerImplementation
     TestHelperForIndexedCardTablePopulation-->SQLiteQueryEngineImplementation
     SQLiteQueryEngineImplementation-->PostgresQueryEngineImplementation
+    PostgresMigrations-->PostgresQueryEngineImplementation
     SQLiteIndexerImplementation-->IndexInvalidation
     SQLiteIndexerImplementation-->UseSQLiteIndexerInHostTests
+    PostgresMigrations-->PostgresIndexerImplementation
     PostgresIndexerImplementation-->UsePostgresIndexerInRealmServer
     PostgresQueue-->UsePostgresIndexerInRealmServer
     JobQueueFacade-->PostgresQueue

--- a/docs/indexer-work-plan.mermaid
+++ b/docs/indexer-work-plan.mermaid
@@ -23,7 +23,7 @@ flowchart
     click UseSQLiteIndexerInHostTests "https://linear.app/cardstack/issue/CS-6638" "Open in Linear"
     UsePostgresIndexerInRealmServer[Use Postgres Indexer\nIn Realm Server\nCS-6639]
     click UsePostgresIndexerInRealmServer "https://linear.app/cardstack/issue/CS-6639" "Open in Linear"
-    PostgresInfra-->PostgresMigrations
+    PostgresInfra
     PostgresMigrations-->PostgresQueue
     JobQueueFacade-->SQLiteIndexerImplementation
     SQLiteIndexerImplementation-->PostgresIndexerImplementation


### PR DESCRIPTION
Migrations are actually run as part of realm server boot, and can automatically install into empty db on realm server startup. So really nothing is depending on infra.