### PR TITLE
Make MarkdownFields subclasses of StringFields

### DIFF
--- a/packages/base/markdown.gts
+++ b/packages/base/markdown.gts
@@ -1,4 +1,4 @@
-import { primitive, Component, useIndexBasedKey } from './card-api';
+import { Component } from './card-api';
 import StringField from './string';
 import { BoxelInput } from '@cardstack/boxel-ui/components';
 import { markdownToHtml } from '@cardstack/runtime-common';

--- a/packages/base/markdown.gts
+++ b/packages/base/markdown.gts
@@ -1,4 +1,4 @@
-import { primitive, Component, useIndexBasedKey, FieldDef } from './card-api';
+import { primitive, Component, useIndexBasedKey } from './card-api';
 import StringField from './string';
 import { BoxelInput } from '@cardstack/boxel-ui/components';
 import { markdownToHtml } from '@cardstack/runtime-common';

--- a/packages/base/markdown.gts
+++ b/packages/base/markdown.gts
@@ -1,4 +1,5 @@
 import { primitive, Component, useIndexBasedKey, FieldDef } from './card-api';
+import StringField from './string';
 import { BoxelInput } from '@cardstack/boxel-ui/components';
 import { markdownToHtml } from '@cardstack/runtime-common';
 
@@ -10,10 +11,8 @@ class View extends Component<typeof MarkdownField> {
   </template>
 }
 
-export default class MarkdownField extends FieldDef {
+export default class MarkdownField extends StringField {
   static displayName = 'Markdown';
-  static [primitive]: string;
-  static [useIndexBasedKey]: never;
 
   static embedded = View;
   static atom = View;


### PR DESCRIPTION
The initial intent is to then let the patching be able to update markdown fields as they'll be marked as strings in the json schema, but more broadly I think it's reasonable that markdown is a valid string, if that causes other problems we can solve this differently.