### PR TITLE
regression fix: choosing a card when creating a new file puts card chooser behind it

### DIFF
--- a/packages/host/app/components/card-catalog/modal.gts
+++ b/packages/host/app/components/card-catalog/modal.gts
@@ -93,6 +93,7 @@ export default class CardCatalogModal extends Component<Signature> {
         class='card-catalog-modal'
         @title={{this.state.chooseCardTitle}}
         @onClose={{fn this.pick undefined}}
+        @layer='urgent'
         {{focusTrap
           isActive=(not this.state.dismissModal)
           focusTrapOptions=(hash

--- a/packages/host/app/components/modal-container.gts
+++ b/packages/host/app/components/modal-container.gts
@@ -19,6 +19,7 @@ interface Signature {
     centered?: boolean;
     cardContainerClass?: string;
     isOpen?: boolean;
+    layer?: 'urgent';
   };
   Blocks: {
     content: [];
@@ -42,6 +43,7 @@ export default class ModalContainer extends Component<Signature> {
       @isOpen={{this.isOpen}}
       @onClose={{@onClose}}
       @centered={{@centered}}
+      @layer={{@layer}}
       ...attributes
     >
       <CardContainer


### PR DESCRIPTION
I found a scenario where z-index [change](https://github.com/cardstack/boxel/pull/1166) breaks. But this has nothing to do with incrementing the z-index, rather just because I changed the default value of the z-index in my previous pr

https://github.com/cardstack/boxel/assets/8165111/0578e332-c7de-4b22-9687-b721061687ab

[preview](https://fix-new-file-in-front-of-card-chooser.boxel-host-preview.stack.cards/)

