### PR TITLE
Update select component to work with :global and get freestyle to work

### DIFF
--- a/packages/boxel-ui/addon/src/components/input-group/accessories/index.gts
+++ b/packages/boxel-ui/addon/src/components/input-group/accessories/index.gts
@@ -173,9 +173,7 @@ export const Select: TemplateOnlyComponent<SelectAccessorySignature> =
         z-index: 2;
       }
 
-      .boxel-input-group__select-accessory :deep(.boxel-select),
-      .boxel-input-group__select-accessory
-        :deep(.boxel-select--selected .boxel-select__item) {
+      .boxel-input-group__select-accessory :deep(.boxel-select) {
         font: var(--boxel-button-font, var(--boxel-font-sm));
         font-weight: 600;
         padding: var(
@@ -189,11 +187,6 @@ export const Select: TemplateOnlyComponent<SelectAccessorySignature> =
         :deep(.boxel-select .ember-power-select-placeholder) {
         font: var(--boxel-button-font, var(--boxel-font-sm));
         font-weight: 600;
-      }
-
-      .boxel-input-group__select-accessory
-        :deep(.boxel-select--selected .boxel-select__item) {
-        padding: 0;
       }
 
       .boxel-input-group__select-accessory

--- a/packages/boxel-ui/addon/src/components/input-group/accessories/index.gts
+++ b/packages/boxel-ui/addon/src/components/input-group/accessories/index.gts
@@ -140,7 +140,10 @@ export const Select: TemplateOnlyComponent<SelectAccessorySignature> =
     >
       <BoxelSelect
         @disabled={{@disabled}}
-        @dropdownClass={{cn 'boxel-select__dropdown-accesories' @dropdownClass}}
+        @dropdownClass={{cn
+          'boxel-input-group__select-accessory__dropdown'
+          @dropdownClass
+        }}
         @placeholder={{@placeholder}}
         @options={{@options}}
         @searchField={{@searchField}}
@@ -198,7 +201,7 @@ export const Select: TemplateOnlyComponent<SelectAccessorySignature> =
       }
     </style>
     <style>
-      :global(.boxel-select__dropdown-accesories ul) {
+      :global(.boxel-input-group__select-accessory__dropdown ul) {
         font: var(--boxel-button-font, var(--boxel-font-sm));
         font-weight: 600;
         padding: var(--boxel-sp-xs) var(--boxel-sp-xs) var(--boxel-sp-xs)

--- a/packages/boxel-ui/addon/src/components/input-group/accessories/index.gts
+++ b/packages/boxel-ui/addon/src/components/input-group/accessories/index.gts
@@ -156,7 +156,11 @@ export const Select: TemplateOnlyComponent<SelectAccessorySignature> =
         ...attributes
         as |item|
       >
-        <div>{{item}}</div>
+        {{#if (has-block)}}
+          {{yield item}}
+        {{else}}
+          <div>{{item}}</div>
+        {{/if}}
       </BoxelSelect>
     </div>
     <style>

--- a/packages/boxel-ui/addon/src/components/input-group/accessories/index.gts
+++ b/packages/boxel-ui/addon/src/components/input-group/accessories/index.gts
@@ -151,7 +151,6 @@ export const Select: TemplateOnlyComponent<SelectAccessorySignature> =
         @selected={{@selected}}
         @onChange={{@onChange}}
         @onBlur={{@onBlur}}
-        @renderInPlace={{true}}
         data-test-boxel-input-group-select-accessory-trigger
         ...attributes
         as |item|
@@ -204,6 +203,11 @@ export const Select: TemplateOnlyComponent<SelectAccessorySignature> =
         border-color: var(--boxel-error-100);
       }
 
+      .boxel-input-group__select-accessory
+        :deep(.ember-power-select-status-icon) {
+        position: relative;
+      }
+
       :global(.boxel-input-group__select-accessory__dropdown ul) {
         font: var(--boxel-button-font, var(--boxel-font-sm));
         font-weight: 600;
@@ -211,9 +215,12 @@ export const Select: TemplateOnlyComponent<SelectAccessorySignature> =
           var(--boxel-sp-xs);
       }
 
-      .boxel-input-group__select-accessory
-        :deep(.ember-power-select-status-icon) {
-        position: relative;
+      :global(
+          .boxel-input-group__select-accessory__dropdown
+            .ember-power-select-option
+        ) {
+        padding: var(--boxel-sp-xs) var(--boxel-sp-xs) var(--boxel-sp-xs)
+          var(--boxel-sp-xs);
       }
     </style>
   </template>;

--- a/packages/boxel-ui/addon/src/components/input-group/accessories/index.gts
+++ b/packages/boxel-ui/addon/src/components/input-group/accessories/index.gts
@@ -210,7 +210,6 @@ export const Select: TemplateOnlyComponent<SelectAccessorySignature> =
 
       :global(.boxel-input-group__select-accessory__dropdown ul) {
         font: var(--boxel-button-font, var(--boxel-font-sm));
-        font-weight: 600;
         padding: var(--boxel-sp-xs) var(--boxel-sp-xs) var(--boxel-sp-xs)
           var(--boxel-sp-xs);
       }

--- a/packages/boxel-ui/addon/src/components/input-group/accessories/index.gts
+++ b/packages/boxel-ui/addon/src/components/input-group/accessories/index.gts
@@ -153,13 +153,7 @@ export const Select: TemplateOnlyComponent<SelectAccessorySignature> =
         ...attributes
         as |item|
       >
-        {{#if (has-block)}}
-          hi
-          {{yield item}}
-        {{else}}
-          what
-          <div>{{item}}</div>
-        {{/if}}
+        <div>{{item}}</div>
       </BoxelSelect>
     </div>
     <style>
@@ -188,7 +182,6 @@ export const Select: TemplateOnlyComponent<SelectAccessorySignature> =
         font: var(--boxel-button-font, var(--boxel-font-sm));
         font-weight: 600;
       }
-
       .boxel-input-group__select-accessory
         :deep([aria-expanded='true'] .ember-power-select-status-icon) {
         transform: rotate(180deg);

--- a/packages/boxel-ui/addon/src/components/input-group/accessories/index.gts
+++ b/packages/boxel-ui/addon/src/components/input-group/accessories/index.gts
@@ -140,7 +140,7 @@ export const Select: TemplateOnlyComponent<SelectAccessorySignature> =
     >
       <BoxelSelect
         @disabled={{@disabled}}
-        @dropdownClass={{@dropdownClass}}
+        @dropdownClass={{cn 'boxel-select__dropdown-accesories' @dropdownClass}}
         @placeholder={{@placeholder}}
         @options={{@options}}
         @searchField={{@searchField}}
@@ -148,13 +148,16 @@ export const Select: TemplateOnlyComponent<SelectAccessorySignature> =
         @selected={{@selected}}
         @onChange={{@onChange}}
         @onBlur={{@onBlur}}
+        @renderInPlace={{true}}
         data-test-boxel-input-group-select-accessory-trigger
         ...attributes
         as |item|
       >
         {{#if (has-block)}}
+          hi
           {{yield item}}
         {{else}}
+          what
           <div>{{item}}</div>
         {{/if}}
       </BoxelSelect>
@@ -176,11 +179,8 @@ export const Select: TemplateOnlyComponent<SelectAccessorySignature> =
       .boxel-input-group__select-accessory :deep(.boxel-select) {
         font: var(--boxel-button-font, var(--boxel-font-sm));
         font-weight: 600;
-        padding: var(
-          --boxel-button-padding,
-          var(--boxel-sp-xs) var(--boxel-sp-xs) var(--boxel-sp-xs)
-            var(--boxel-sp-xs)
-        );
+        padding: var(--boxel-sp-xs) var(--boxel-sp-xs) var(--boxel-sp-xs)
+          var(--boxel-sp-xs);
       }
 
       .boxel-input-group__select-accessory
@@ -202,6 +202,14 @@ export const Select: TemplateOnlyComponent<SelectAccessorySignature> =
 
       .boxel-input-group--invalid .boxel-input-group__select-accessory {
         border-color: var(--boxel-error-100);
+      }
+    </style>
+    <style>
+      :global(.boxel-select__dropdown-accesories ul) {
+        font: var(--boxel-button-font, var(--boxel-font-sm));
+        font-weight: 600;
+        padding: var(--boxel-sp-xs) var(--boxel-sp-xs) var(--boxel-sp-xs)
+          var(--boxel-sp-xs);
       }
     </style>
   </template>;

--- a/packages/boxel-ui/addon/src/components/input-group/accessories/index.gts
+++ b/packages/boxel-ui/addon/src/components/input-group/accessories/index.gts
@@ -210,6 +210,11 @@ export const Select: TemplateOnlyComponent<SelectAccessorySignature> =
         padding: var(--boxel-sp-xs) var(--boxel-sp-xs) var(--boxel-sp-xs)
           var(--boxel-sp-xs);
       }
+
+      .boxel-input-group__select-accessory
+        :deep(.ember-power-select-status-icon) {
+        position: relative;
+      }
     </style>
   </template>;
 

--- a/packages/boxel-ui/addon/src/components/input-group/accessories/index.gts
+++ b/packages/boxel-ui/addon/src/components/input-group/accessories/index.gts
@@ -203,8 +203,7 @@ export const Select: TemplateOnlyComponent<SelectAccessorySignature> =
       .boxel-input-group--invalid .boxel-input-group__select-accessory {
         border-color: var(--boxel-error-100);
       }
-    </style>
-    <style>
+
       :global(.boxel-input-group__select-accessory__dropdown ul) {
         font: var(--boxel-button-font, var(--boxel-font-sm));
         font-weight: 600;

--- a/packages/boxel-ui/addon/src/components/input-group/accessories/index.gts
+++ b/packages/boxel-ui/addon/src/components/input-group/accessories/index.gts
@@ -121,7 +121,7 @@ export const Text: TemplateOnlyComponent<TextSignature> = <template>
 interface SelectAccessorySignature<ItemT = any> {
   Args: BoxelSelectArgs<ItemT>;
   Blocks: {
-    default: [ItemT, string];
+    default: [ItemT];
   };
   Element: HTMLElement;
 }
@@ -150,12 +150,12 @@ export const Select: TemplateOnlyComponent<SelectAccessorySignature> =
         @onBlur={{@onBlur}}
         data-test-boxel-input-group-select-accessory-trigger
         ...attributes
-        as |item itemCssClass|
+        as |item|
       >
         {{#if (has-block)}}
-          {{yield item itemCssClass}}
+          {{yield item}}
         {{else}}
-          <div class={{itemCssClass}}>{{item}}</div>
+          <div>{{item}}</div>
         {{/if}}
       </BoxelSelect>
     </div>

--- a/packages/boxel-ui/addon/src/components/input-group/accessories/index.gts
+++ b/packages/boxel-ui/addon/src/components/input-group/accessories/index.gts
@@ -208,16 +208,11 @@ export const Select: TemplateOnlyComponent<SelectAccessorySignature> =
         position: relative;
       }
 
-      :global(.boxel-input-group__select-accessory__dropdown ul) {
-        font: var(--boxel-button-font, var(--boxel-font-sm));
-        padding: var(--boxel-sp-xs) var(--boxel-sp-xs) var(--boxel-sp-xs)
-          var(--boxel-sp-xs);
-      }
-
       :global(
           .boxel-input-group__select-accessory__dropdown
             .ember-power-select-option
         ) {
+        font: var(--boxel-button-font, var(--boxel-font-sm));
         padding: var(--boxel-sp-xs) var(--boxel-sp-xs) var(--boxel-sp-xs)
           var(--boxel-sp-xs);
       }

--- a/packages/boxel-ui/addon/src/components/input-group/accessories/index.gts
+++ b/packages/boxel-ui/addon/src/components/input-group/accessories/index.gts
@@ -151,6 +151,7 @@ export const Select: TemplateOnlyComponent<SelectAccessorySignature> =
         @selected={{@selected}}
         @onChange={{@onChange}}
         @onBlur={{@onBlur}}
+        @matchTriggerWidth={{@matchTriggerWidth}}
         data-test-boxel-input-group-select-accessory-trigger
         ...attributes
         as |item|

--- a/packages/boxel-ui/addon/src/components/input-group/usage.gts
+++ b/packages/boxel-ui/addon/src/components/input-group/usage.gts
@@ -331,9 +331,9 @@ export default class BoxelInputGroupUsage extends Component {
               @options={{this.selectExampleItems}}
               @dropdownClass='boxel-select-usage-dropdown'
               aria-label='Select an item'
-              as |item itemCssClass|
+              as |item|
             >
-              <div class={{itemCssClass}}>{{item}}</div>
+              <div>{{item}}</div>
             </Accessories.Select>
           </:after>
         </BoxelInputGroup>

--- a/packages/boxel-ui/addon/src/components/select/index.gts
+++ b/packages/boxel-ui/addon/src/components/select/index.gts
@@ -20,7 +20,7 @@ interface Signature<ItemT = any> {
 
 const BoxelSelect: TemplateOnlyComponent<Signature> = <template>
   <PowerSelect
-    class={{'boxel-select'}}
+    class='boxel-select'
     @options={{@options}}
     @searchField={{@searchField}}
     @selected={{@selected}}

--- a/packages/boxel-ui/addon/src/components/select/index.gts
+++ b/packages/boxel-ui/addon/src/components/select/index.gts
@@ -53,9 +53,6 @@ const BoxelSelect: TemplateOnlyComponent<Signature> = <template>
       padding-right: var(--boxel-sp);
     }
 
-    .boxel-select :deep(.ember-power-select-status-icon) {
-      position: relative;
-    }
     .boxel-select:after {
       display: none;
     }

--- a/packages/boxel-ui/addon/src/components/select/index.gts
+++ b/packages/boxel-ui/addon/src/components/select/index.gts
@@ -20,7 +20,7 @@ interface Signature<ItemT = any> {
 
 const BoxelSelect: TemplateOnlyComponent<Signature> = <template>
   <PowerSelect
-    class={{cn 'boxel-select' boxel-select--selected=@selected}}
+    class={{'boxel-select'}}
     @options={{@options}}
     @searchField={{@searchField}}
     @selected={{@selected}}

--- a/packages/boxel-ui/addon/src/components/select/index.gts
+++ b/packages/boxel-ui/addon/src/components/select/index.gts
@@ -50,7 +50,6 @@ const BoxelSelect: TemplateOnlyComponent<Signature> = <template>
       background: none;
       display: flex;
       gap: var(--boxel-sp-sm);
-      padding-right: var(--boxel-sp);
     }
 
     .boxel-select:after {

--- a/packages/boxel-ui/addon/src/components/select/index.gts
+++ b/packages/boxel-ui/addon/src/components/select/index.gts
@@ -13,7 +13,7 @@ export interface BoxelSelectArgs<ItemT> extends PowerSelectArgs {
 interface Signature<ItemT = any> {
   Args: BoxelSelectArgs<ItemT>;
   Blocks: {
-    default: [ItemT, string];
+    default: [ItemT];
   };
   Element: HTMLElement;
 }
@@ -40,7 +40,7 @@ const BoxelSelect: TemplateOnlyComponent<Signature> = <template>
     ...attributes
     as |item|
   >
-    {{yield item 'boxel-select__item'}}
+    {{yield item}}
   </PowerSelect>
   <style>
     .boxel-select {

--- a/packages/boxel-ui/addon/src/components/select/index.gts
+++ b/packages/boxel-ui/addon/src/components/select/index.gts
@@ -51,97 +51,6 @@ const BoxelSelect: TemplateOnlyComponent<Signature> = <template>
       gap: var(--boxel-sp-sm);
       padding-right: var(--boxel-sp);
     }
-    .boxel-select__dropdown {
-      --boxel-select-current-color: var(--boxel-light-100);
-      --boxel-select-selected-color: var(--boxel-highlight);
-      --boxel-select-below-transitioning-in-animation: drop-fade-below
-        var(--boxel-transition);
-      --boxel-select-below-transitioning-out-animation: var(
-          --boxel-select-below-transitioning-in-animation
-        )
-        reverse;
-      --boxel-select-above-transitioning-in-animation: drop-fade-above
-        var(--boxel-transition);
-      --boxel-select-above-transitioning-out-animation: var(
-          --boxel-select-above-transitioning-in-animation
-        )
-        reverse;
-
-      box-shadow: var(--boxel-box-shadow);
-      border-radius: var(--boxel-form-control-border-radius);
-    }
-
-    .boxel-select__dropdown :deep(ul) {
-      list-style: none;
-      padding: 0;
-      overflow: auto;
-    }
-
-    .boxel-select__dropdown
-      :deep(.ember-power-select-option[aria-selected='true']) {
-      background-color: var(--boxel-select-selected-color);
-    }
-
-    .boxel-select__dropdown
-      :deep(.ember-power-select-option[aria-current='true']) {
-      background-color: var(--boxel-select-current-color);
-    }
-
-    /* stylelint-disable-next-line max-line-length */
-    .boxel-select__dropdown
-      :deep(
-        .ember-power-select-option:hover:not([aria-disabled='true']):not(
-            .ember-power-select-option--no-matches-message
-          )
-      ) {
-      cursor: pointer;
-    }
-
-    .boxel-select__dropdown :deep(.ember-power-select-search) {
-      padding: 4px;
-    }
-
-    .boxel-select__dropdown :deep(.ember-power-select-search-input) {
-      border: 1px solid #aaa;
-      border-radius: 0;
-      width: 100%;
-      font-size: inherit;
-      line-height: inherit;
-      padding: 0 5px;
-    }
-
-    .boxel-select__dropdown :deep(.ember-power-select-search-input:focus) {
-      border: 1px solid var(--boxel-outline-color);
-      box-shadow: var(--boxel-box-shadow-hover);
-      outline: var(--boxel-outline);
-    }
-
-    .boxel-select__dropdown
-      :deep(.ember-power-select-option--no-matches-message) {
-      padding: var(--boxel-sp-xxs) var(--boxel-sp-sm);
-    }
-
-    .boxel-select__item {
-      font-weight: 600;
-      font-size: var(--boxel-font-size-sm);
-      padding: var(--boxel-sp-xxs) var(--boxel-sp-sm);
-    }
-
-    .boxel-select__dropdown.ember-basic-dropdown-content--below.ember-basic-dropdown--transitioning-in {
-      animation: var(--boxel-select-below-transitioning-in-animation);
-    }
-
-    .boxel-select__dropdown.ember-basic-dropdown-content--below.ember-basic-dropdown--transitioning-out {
-      animation: var(--boxel-select-below-transitioning-out-animation);
-    }
-
-    .boxel-select__dropdown.ember-basic-dropdown-content--above.ember-basic-dropdown--transitioning-in {
-      animation: var(--boxel-select-above-transitioning-in-animation);
-    }
-
-    .boxel-select__dropdown.ember-basic-dropdown-content--above.ember-basic-dropdown--transitioning-out {
-      animation: var(--boxel-select-above-transitioning-out-animation);
-    }
 
     .boxel-select :deep(.ember-power-select-status-icon) {
       position: relative;
@@ -172,6 +81,56 @@ const BoxelSelect: TemplateOnlyComponent<Signature> = <template>
         opacity: 1;
         transform: translateY(0);
       }
+    }
+  </style>
+  <style>
+    :global(.boxel-select__dropdown) {
+      --boxel-select-current-color: var(--boxel-light-100);
+      --boxel-select-selected-color: var(--boxel-highlight);
+      --boxel-select-below-transitioning-in-animation: drop-fade-below
+        var(--boxel-transition);
+      --boxel-select-below-transitioning-out-animation: var(
+          --boxel-select-below-transitioning-in-animation
+        )
+        reverse;
+      --boxel-select-above-transitioning-in-animation: drop-fade-above
+        var(--boxel-transition);
+      --boxel-select-above-transitioning-out-animation: var(
+          --boxel-select-above-transitioning-in-animation
+        )
+        reverse;
+
+      box-shadow: var(--boxel-box-shadow);
+      border-radius: var(--boxel-form-control-border-radius);
+    }
+    :global(.boxel-select__dropdown ul) {
+      list-style: none;
+      padding: 0;
+      overflow: auto;
+    }
+    :global(
+        .boxel-select__dropdown .ember-power-select-option[aria-selected='true']
+      ) {
+      background-color: var(--boxel-select-selected-color);
+    }
+
+    :global(
+        .boxel-select__dropdown .ember-power-select-option[aria-current='true']
+      ) {
+      background-color: var(--boxel-select-current-color);
+      color: black;
+    }
+
+    :global(.boxel-select__dropdown .ember-power-select-search-input:focus) {
+      border: 1px solid var(--boxel-outline-color);
+      box-shadow: var(--boxel-box-shadow-hover);
+      outline: var(--boxel-outline);
+    }
+
+    :global(
+        .boxel-select__dropdown .ember-power-select-option--no-matches-message
+      ) {
+      padding: var(--boxel-sp-xxs) var(--boxel-sp-sm);
     }
   </style>
 </template>;

--- a/packages/boxel-ui/addon/src/components/select/index.gts
+++ b/packages/boxel-ui/addon/src/components/select/index.gts
@@ -42,6 +42,7 @@ const BoxelSelect: TemplateOnlyComponent<Signature> = <template>
   >
     {{yield item}}
   </PowerSelect>
+
   <style>
     .boxel-select {
       border: 1px solid var(--boxel-form-control-border-color);
@@ -59,6 +60,12 @@ const BoxelSelect: TemplateOnlyComponent<Signature> = <template>
       display: none;
     }
   </style>
+  {{! Note: When editing dropdown of the PowerSelect component we target 
+  the styles using :global -- this is not a mistake. The reason we do this is because 
+  content is teleported to an element #ember-basic-dropdown-wormhole at the top of the dom 
+  Therefore, our out-of-the-box scoped css solution do not work and we must use an escape hatch (ie :global) to 
+  ensure styles are being applied correctly.
+   }}
   <style>
     :global(.boxel-select__dropdown) {
       --boxel-select-current-color: var(--boxel-light-100);

--- a/packages/boxel-ui/addon/src/components/select/index.gts
+++ b/packages/boxel-ui/addon/src/components/select/index.gts
@@ -58,30 +58,6 @@ const BoxelSelect: TemplateOnlyComponent<Signature> = <template>
     .boxel-select:after {
       display: none;
     }
-
-    @keyframes drop-fade-below {
-      0% {
-        opacity: 0;
-        transform: translateY(-20px);
-      }
-
-      100% {
-        opacity: 1;
-        transform: translateY(0);
-      }
-    }
-
-    @keyframes drop-fade-above {
-      0% {
-        opacity: 0;
-        transform: translateY(20px);
-      }
-
-      100% {
-        opacity: 1;
-        transform: translateY(0);
-      }
-    }
   </style>
   <style>
     :global(.boxel-select__dropdown) {

--- a/packages/boxel-ui/addon/src/components/select/index.gts
+++ b/packages/boxel-ui/addon/src/components/select/index.gts
@@ -68,8 +68,8 @@ const BoxelSelect: TemplateOnlyComponent<Signature> = <template>
    }}
   <style>
     :global(.boxel-select__dropdown) {
-      --boxel-select-current-color: var(--boxel-light-100);
-      --boxel-select-selected-color: var(--boxel-highlight);
+      --boxel-select-current-color: var(--boxel-highlight);
+      --boxel-select-selected-color: var(--boxel-light-100);
       --boxel-select-below-transitioning-in-animation: drop-fade-below
         var(--boxel-transition);
       --boxel-select-below-transitioning-out-animation: var(

--- a/packages/boxel-ui/addon/src/components/select/index.gts
+++ b/packages/boxel-ui/addon/src/components/select/index.gts
@@ -66,19 +66,6 @@ const BoxelSelect: TemplateOnlyComponent<Signature> = <template>
     :global(.boxel-select__dropdown) {
       --boxel-select-current-color: var(--boxel-highlight);
       --boxel-select-selected-color: var(--boxel-light-100);
-      --boxel-select-below-transitioning-in-animation: drop-fade-below
-        var(--boxel-transition);
-      --boxel-select-below-transitioning-out-animation: var(
-          --boxel-select-below-transitioning-in-animation
-        )
-        reverse;
-      --boxel-select-above-transitioning-in-animation: drop-fade-above
-        var(--boxel-transition);
-      --boxel-select-above-transitioning-out-animation: var(
-          --boxel-select-above-transitioning-in-animation
-        )
-        reverse;
-
       box-shadow: var(--boxel-box-shadow);
       border-radius: var(--boxel-form-control-border-radius);
     }

--- a/packages/boxel-ui/addon/src/components/select/index.gts
+++ b/packages/boxel-ui/addon/src/components/select/index.gts
@@ -33,7 +33,7 @@ const BoxelSelect: TemplateOnlyComponent<Signature> = <template>
     @dropdownClass={{cn 'boxel-select__dropdown' @dropdownClass}}
     @triggerComponent={{@triggerComponent}}
     @disabled={{@disabled}}
-    @matchTriggerWidth={{false}}
+    @matchTriggerWidth={{@matchTriggerWidth}}
     @eventType='click'
     @searchEnabled={{@searchEnabled}}
     @beforeOptionsComponent={{component BeforeOptions autofocus=false}}

--- a/packages/boxel-ui/addon/src/components/select/usage.gts
+++ b/packages/boxel-ui/addon/src/components/select/usage.gts
@@ -29,7 +29,7 @@ export default class BoxelSelectUsage extends Component {
   @tracked placeholder = 'Select Item';
   @tracked verticalPosition = 'auto' as const;
 
-  @tracked renderInPlace = true;
+  @tracked renderInPlace = false;
   @tracked disabled = false;
   @tracked searchField = '';
   @tracked searchEnabled = false;
@@ -116,7 +116,7 @@ export default class BoxelSelectUsage extends Component {
         />
         <Args.Bool
           @name='renderInPlace'
-          @defaultValue={{true}}
+          @defaultValue={{false}}
           @value={{this.renderInPlace}}
           @onInput={{fn (mut this.renderInPlace)}}
           @description='When passed true, the content will render next to the trigger instead of being placed in the root of the body'

--- a/packages/boxel-ui/addon/src/components/select/usage.gts
+++ b/packages/boxel-ui/addon/src/components/select/usage.gts
@@ -1,4 +1,3 @@
-import { A } from '@ember/array';
 import { array, fn } from '@ember/helper';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
@@ -11,16 +10,26 @@ import {
 
 import BoxelSelect from './index.gts';
 
-export default class BoxelSelectUsage extends Component {
-  @tracked items = A(
-    [...new Array(10)].map((_, idx) => `Item - ${idx}`),
-  ) as Array<any>;
+interface Country {
+  name: string;
+}
 
-  @tracked selectedItem: string | null = null;
+export default class BoxelSelectUsage extends Component {
+  @tracked items = [
+    { name: 'United States' },
+    { name: 'Spain' },
+    { name: 'Portugal' },
+    { name: 'Russia' },
+    { name: 'Latvia' },
+    { name: 'Brazil' },
+    { name: 'United Kingdom' },
+  ] as Array<Country>;
+
+  @tracked selectedItem: Country | null = null;
   @tracked placeholder = 'Select Item';
   @tracked verticalPosition = 'auto' as const;
 
-  @tracked renderInPlace = false;
+  @tracked renderInPlace = true;
   @tracked disabled = false;
   @tracked searchField = '';
   @tracked searchEnabled = false;
@@ -34,23 +43,23 @@ export default class BoxelSelectUsage extends Component {
   @cssVariable({ cssClassName: 'boxel-select__dropdown' })
   declare boxelSelectAboveTransitioningInAnimation: CSSVariableInfo;
 
-  @action onSelectItem(item: string | null): void {
+  @action onSelectItem(item: Country | null): void {
     this.selectedItem = item;
   }
 
   <template>
-    <FreestyleUsage @name='Select'>
-      <:example>
-        <style
-          unscoped
-        >
-          .boxel-select-usage-dropdown {
+    <style
+    >
+          :global(.boxel-select-usage) {
             --boxel-select-current-color: {{this.boxelSelectCurrentColor.value}};
             --boxel-select-selected-color: {{this.boxelSelectSelectedColor.value}};
             --boxel-select-below-transitioning-in-animation: {{this.boxelSelectBelowTransitioningInAnimation.value}};
             --boxel-select-above-transitioning-in-animation: {{this.boxelSelectAboveTransitioningInAnimation.value}};
           }
         </style>
+    <FreestyleUsage @name='Select'>
+      <:example>
+
         <BoxelSelect
           @placeholder={{this.placeholder}}
           @searchEnabled={{this.searchEnabled}}
@@ -61,11 +70,11 @@ export default class BoxelSelectUsage extends Component {
           @verticalPosition={{this.verticalPosition}}
           @renderInPlace={{this.renderInPlace}}
           @disabled={{this.disabled}}
-          @dropdownClass='boxel-select-usage-dropdown'
-          aria-label='Select an item'
-          as |item itemCssClass|
+          @dropdownClass='boxel-select-usage'
+          aria-label={{this.placeholder}}
+          as |item|
         >
-          <div class={{itemCssClass}}>{{item}}</div>
+          <div>{{item.name}}</div>
         </BoxelSelect>
       </:example>
       <:api as |Args|>
@@ -74,7 +83,7 @@ export default class BoxelSelectUsage extends Component {
           @description='An array of items, to be listed on dropdown'
           @required={{true}}
           @items={{this.items}}
-          @onChange={{fn (mut this.items)}}
+          @onChange={{this.onSelectItem}}
         />
         <Args.Action
           @name='onChange'
@@ -90,15 +99,34 @@ export default class BoxelSelectUsage extends Component {
           @name='item'
           @description='Item to be presented on dropdown'
         />
-        <Args.Yield
-          @name='itemCssClass'
-          @description='Class to be set on item wrapper to add default styles'
-        />
         <Args.String
           @name='placeholder'
           @description='Placeholder for trigger component'
           @value={{this.placeholder}}
           @onInput={{fn (mut this.placeholder)}}
+        />
+
+        <Args.String
+          @name='verticalPosition'
+          @defaultValue='auto'
+          @value={{this.verticalPosition}}
+          @options={{array 'auto' 'above' 'below'}}
+          @onInput={{fn (mut this.verticalPosition)}}
+          @description='The vertical positioning strategy of the content'
+        />
+        <Args.Bool
+          @name='renderInPlace'
+          @defaultValue={{true}}
+          @value={{this.renderInPlace}}
+          @onInput={{fn (mut this.renderInPlace)}}
+          @description='When passed true, the content will render next to the trigger instead of being placed in the root of the body'
+        />
+        <Args.Bool
+          @name='disabled'
+          @defaultValue={{false}}
+          @value={{this.disabled}}
+          @onInput={{fn (mut this.disabled)}}
+          @description='When truthy the component cannot be interacted'
         />
         <Args.Bool
           @name='searchEnabled'
@@ -107,41 +135,9 @@ export default class BoxelSelectUsage extends Component {
           @onInput={{fn (mut this.searchEnabled)}}
         />
         <Args.String
-          @name='verticalPosition'
-          @defaults='auto'
-          @options={{array 'auto' 'above' 'below'}}
-          @onInput={{fn (mut this.verticalPosition)}}
-          @description='The vertical positioning strategy of the content'
-        />
-        <Args.Bool
-          @name='renderInPlace'
-          @defaults={{false}}
-          @onInput={{fn (mut this.renderInPlace)}}
-          @description='When passed true, the content will render next to the trigger instead of being placed in the root of the body'
-        />
-        <Args.Bool
-          @name='disabled'
-          @defaults={{false}}
-          @onInput={{fn (mut this.disabled)}}
-          @description='When truthy the component cannot be interacted'
-        />
-        <Args.String
           @name='searchField'
           @onInput={{fn (mut this.searchField)}}
-          @description='Tells the component what property of the options should be used to filter
-'
-        />
-        <Args.String
-          @name='dropdownClass'
-          @description='Class to be applied to the dropdown only'
-        />
-        <Args.Object
-          @name='triggerComponent'
-          @description='The component to rended as content instead of the default trigger component'
-        />
-        <Args.Object
-          @name='selectedItemComponent'
-          @description='The component to render to customize just the selected item of the trigger'
+          @description='Tells the component what property of the options should be used to filter'
         />
       </:api>
       <:cssVars as |Css|>

--- a/packages/boxel-ui/addon/src/components/select/usage.gts
+++ b/packages/boxel-ui/addon/src/components/select/usage.gts
@@ -54,8 +54,6 @@ export default class BoxelSelectUsage extends Component {
           .boxel-select-usage {
             --boxel-select-current-color: {{this.boxelSelectCurrentColor.value}};
             --boxel-select-selected-color: {{this.boxelSelectSelectedColor.value}};
-            --boxel-select-below-transitioning-in-animation: {{this.boxelSelectBelowTransitioningInAnimation.value}};
-            --boxel-select-above-transitioning-in-animation: {{this.boxelSelectAboveTransitioningInAnimation.value}};
           }
         </style>
     <FreestyleUsage @name='Select'>

--- a/packages/boxel-ui/addon/src/components/select/usage.gts
+++ b/packages/boxel-ui/addon/src/components/select/usage.gts
@@ -125,6 +125,7 @@ export default class BoxelSelectUsage extends Component {
         />
         <Args.Bool
           @name='searchEnabled'
+          @defaultValue={{false}}
           @description='True to show a search box at the top of the list of items'
           @value={{this.searchEnabled}}
           @onInput={{fn (mut this.searchEnabled)}}

--- a/packages/boxel-ui/addon/src/components/select/usage.gts
+++ b/packages/boxel-ui/addon/src/components/select/usage.gts
@@ -49,8 +49,9 @@ export default class BoxelSelectUsage extends Component {
 
   <template>
     <style
+      unscoped
     >
-          :global(.boxel-select-usage) {
+          .boxel-select-usage {
             --boxel-select-current-color: {{this.boxelSelectCurrentColor.value}};
             --boxel-select-selected-color: {{this.boxelSelectSelectedColor.value}};
             --boxel-select-below-transitioning-in-animation: {{this.boxelSelectBelowTransitioningInAnimation.value}};

--- a/packages/boxel-ui/addon/src/components/select/usage.gts
+++ b/packages/boxel-ui/addon/src/components/select/usage.gts
@@ -38,10 +38,6 @@ export default class BoxelSelectUsage extends Component {
   declare boxelSelectCurrentColor: CSSVariableInfo;
   @cssVariable({ cssClassName: 'boxel-select__dropdown' })
   declare boxelSelectSelectedColor: CSSVariableInfo;
-  @cssVariable({ cssClassName: 'boxel-select__dropdown' })
-  declare boxelSelectBelowTransitioningInAnimation: CSSVariableInfo;
-  @cssVariable({ cssClassName: 'boxel-select__dropdown' })
-  declare boxelSelectAboveTransitioningInAnimation: CSSVariableInfo;
 
   @action onSelectItem(item: Country | null): void {
     this.selectedItem = item;
@@ -153,22 +149,6 @@ export default class BoxelSelectUsage extends Component {
           @defaultValue={{this.boxelSelectSelectedColor.defaults}}
           @value={{this.boxelSelectSelectedColor.value}}
           @onInput={{this.boxelSelectSelectedColor.update}}
-        />
-        <Css.Basic
-          @name='boxel-select-below-transitioning-in-animation'
-          @type='transition'
-          @description='Animation for dropdown appearing below. On close animation is reversed'
-          @defaultValue={{this.boxelSelectBelowTransitioningInAnimation.defaults}}
-          @value={{this.boxelSelectBelowTransitioningInAnimation.value}}
-          @onInput={{this.boxelSelectBelowTransitioningInAnimation.update}}
-        />
-        <Css.Basic
-          @name='boxel-select-above-transitioning-in-animation'
-          @type='transition'
-          @description='Animation for dropdown appearing above. On close animation is reversed'
-          @defaultValue={{this.boxelSelectAboveTransitioningInAnimation.defaults}}
-          @value={{this.boxelSelectAboveTransitioningInAnimation.value}}
-          @onInput={{this.boxelSelectAboveTransitioningInAnimation.update}}
         />
       </:cssVars>
     </FreestyleUsage>

--- a/packages/boxel-ui/addon/src/components/select/usage.gts
+++ b/packages/boxel-ui/addon/src/components/select/usage.gts
@@ -33,6 +33,7 @@ export default class BoxelSelectUsage extends Component {
   @tracked disabled = false;
   @tracked searchField = '';
   @tracked searchEnabled = false;
+  @tracked matchTriggerWidth = true;
 
   @cssVariable({ cssClassName: 'boxel-select__dropdown' })
   declare boxelSelectCurrentColor: CSSVariableInfo;
@@ -66,6 +67,7 @@ export default class BoxelSelectUsage extends Component {
           @renderInPlace={{this.renderInPlace}}
           @disabled={{this.disabled}}
           @dropdownClass='boxel-select-usage'
+          @matchTriggerWidth={{this.matchTriggerWidth}}
           aria-label={{this.placeholder}}
           as |item|
         >
@@ -115,6 +117,13 @@ export default class BoxelSelectUsage extends Component {
           @value={{this.renderInPlace}}
           @onInput={{fn (mut this.renderInPlace)}}
           @description='When passed true, the content will render next to the trigger instead of being placed in the root of the body'
+        />
+        <Args.Bool
+          @name='matchTriggerWidth'
+          @defaultValue={{true}}
+          @value={{this.matchTriggerWidth}}
+          @onInput={{fn (mut this.matchTriggerWidth)}}
+          @description='Allow dropdown width to match trigger width'
         />
         <Args.Bool
           @name='disabled'

--- a/packages/drafts-realm/monetary-amount.gts
+++ b/packages/drafts-realm/monetary-amount.gts
@@ -104,10 +104,7 @@ class Edit extends Component<typeof MonetaryAmount> {
         >
           <div
             data-test-currency={{item.symbol}}
-            class={{cn
-              'input-selectable-currency-amount__dropdown-item'
-              itemCssClass
-            }}
+            class='input-selectable-currency-amount__dropdown-item'
             title={{item.name}}
           >
             {{#if item.logoURL}}

--- a/packages/drafts-realm/monetary-amount.gts
+++ b/packages/drafts-realm/monetary-amount.gts
@@ -10,7 +10,6 @@ import { Currency } from './asset';
 import { action } from '@ember/object';
 import { BoxelInputGroup } from '@cardstack/boxel-ui/components';
 import { getLiveCards } from '@cardstack/runtime-common';
-import { cn } from '@cardstack/boxel-ui/helpers';
 import { guidFor } from '@ember/object/internals';
 import GlimmerComponent from '@glimmer/component';
 

--- a/packages/drafts-realm/monetary-amount.gts
+++ b/packages/drafts-realm/monetary-amount.gts
@@ -100,7 +100,7 @@ class Edit extends Component<typeof MonetaryAmount> {
           @onChange={{this.setCurrency}}
           @dropdownClass='input-selectable-currency-amount__dropdown'
           @verticalPosition='below'
-          as |item itemCssClass|
+          as |item|
         >
           <div
             data-test-currency={{item.symbol}}


### PR DESCRIPTION
This PR is intended to get everything minimally working. A lot of the things were not working as I expected. Here are a few UI changes that you'll find. Note: wormhole is buggy when using animations and I will check that out separately.

In this PR, we also use :global to solve the issues where the styles cannot be applied to dropdown element which is teleported in the wormhole


![Screenshot 2024-04-22 at 17 34 47](https://github.com/cardstack/boxel/assets/8165111/8b7ba7bc-1f89-4773-84f7-7169ef3cd2e2)


![Screenshot 2024-04-22 at 17 36 56](https://github.com/cardstack/boxel/assets/8165111/1df14fe2-c056-49de-b9e8-fe32df6ca2d1)

![Screenshot 2024-04-22 at 17 50 28](https://github.com/cardstack/boxel/assets/8165111/2934aa19-cdef-4e5c-aee4-1a674f6c737e)


![Screenshot 2024-04-22 at 17 37 14](https://github.com/cardstack/boxel/assets/8165111/f9e769f5-32ea-463c-ab7f-a3468529e0e7)



**Before**

![Screenshot 2024-04-22 at 15 57 04](https://github.com/cardstack/boxel/assets/8165111/8696a8a5-3faf-4575-a9a9-04d253ceb682)

**After**

![Screenshot 2024-04-22 at 17 44 49](https://github.com/cardstack/boxel/assets/8165111/3cf75706-b851-46b3-8bf2-1dc55fb82855)


