### PR TITLE
Use dynamic context for "card context"

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -116,7 +116,6 @@ export interface CardContext {
       };
     };
   }>;
-  renderedIn?: Component<any>;
 }
 
 function isNotLoadedValue(val: any): val is NotLoadedValue {

--- a/packages/base/links-to-editor.gts
+++ b/packages/base/links-to-editor.gts
@@ -16,20 +16,23 @@ import {
   chooseCard,
   baseCardRef,
   identifyCard,
+  CardContextName,
 } from '@cardstack/runtime-common';
 import type { ComponentLike } from '@glint/template';
 import { AddButton, IconButton } from '@cardstack/boxel-ui/components';
 import { IconMinusCircle } from '@cardstack/boxel-ui/icons';
+import { consume } from 'ember-provide-consume-context';
 
 interface Signature {
   Args: {
     model: Box<CardDef | null>;
     field: Field<typeof CardDef>;
-    context?: CardContext;
   };
 }
 
 class LinksToEditor extends GlimmerComponent<Signature> {
+  @consume(CardContextName) declare cardContext: CardContext;
+
   <template>
     <div class='links-to-editor' data-test-links-to-editor={{@field.name}}>
       {{#if this.isEmpty}}
@@ -111,7 +114,6 @@ class LinksToEditor extends GlimmerComponent<Signature> {
       'embedded',
       this.args.model as Box<BaseDef>,
       this.args.field,
-      this.args.context,
     );
   }
 
@@ -121,7 +123,7 @@ class LinksToEditor extends GlimmerComponent<Signature> {
       { filter: { type } },
       {
         offerToCreate: { ref: type, relativeTo: undefined },
-        createNewCard: this.args.context?.actions?.createCard,
+        createNewCard: this.cardContext?.actions?.createCard,
       },
     );
     if (chosenCard) {
@@ -132,7 +134,7 @@ class LinksToEditor extends GlimmerComponent<Signature> {
   private createCard = restartableTask(async () => {
     let type = identifyCard(this.args.field.card) ?? baseCardRef;
     let newCard: CardDef | undefined =
-      await this.args.context?.actions?.createCard(type, undefined, {
+      await this.cardContext?.actions?.createCard(type, undefined, {
         isLinkedCard: true,
       });
     if (newCard) {
@@ -144,11 +146,10 @@ class LinksToEditor extends GlimmerComponent<Signature> {
 export function getLinksToEditor(
   model: Box<CardDef | null>,
   field: Field<typeof CardDef>,
-  context?: CardContext,
 ): ComponentLike<{ Args: {}; Blocks: {} }> {
   return class LinksToEditTemplate extends GlimmerComponent {
     <template>
-      <LinksToEditor @model={{model}} @field={{field}} @context={{context}} />
+      <LinksToEditor @model={{model}} @field={{field}} />
     </template>
   };
 }

--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -21,9 +21,11 @@ import {
   baseCardRef,
   identifyCard,
   getPlural,
+  CardContextName,
 } from '@cardstack/runtime-common';
 import { IconMinusCircle, IconX } from '@cardstack/boxel-ui/icons';
 import { eq } from '@cardstack/boxel-ui/helpers';
+import { consume } from 'ember-provide-consume-context';
 
 interface Signature {
   Args: {
@@ -35,11 +37,12 @@ interface Signature {
       field: Field<typeof BaseDef>,
       boxedElement: Box<BaseDef>,
     ): typeof BaseDef;
-    context?: CardContext;
   };
 }
 
 class LinksToManyEditor extends GlimmerComponent<Signature> {
+  @consume(CardContextName) declare cardContext: CardContext;
+
   <template>
     <div data-test-links-to-many={{@field.name}}>
       {{#if (eq @format 'edit')}}
@@ -53,7 +56,6 @@ class LinksToManyEditor extends GlimmerComponent<Signature> {
                     'embedded'
                     boxedElement
                     @field
-                    @context
                   )
                   as |Item|
                 }}
@@ -94,7 +96,6 @@ class LinksToManyEditor extends GlimmerComponent<Signature> {
                 'atom'
                 boxedElement
                 @field
-                @context
               )
               as |Item|
             }}
@@ -209,7 +210,7 @@ class LinksToManyEditor extends GlimmerComponent<Signature> {
       {
         offerToCreate: { ref: type, relativeTo: undefined },
         multiSelect: true,
-        createNewCard: this.args.context?.actions?.createCard,
+        createNewCard: this.cardContext?.actions?.createCard,
       },
     );
     if (chosenCard) {
@@ -231,7 +232,6 @@ export function getLinksToManyComponent({
   format,
   field,
   cardTypeFor,
-  context,
 }: {
   model: Box<CardDef>;
   arrayField: Box<CardDef[]>;
@@ -241,7 +241,6 @@ export function getLinksToManyComponent({
     field: Field<typeof BaseDef>,
     boxedElement: Box<BaseDef>,
   ): typeof BaseDef;
-  context?: CardContext;
 }): BoxComponent {
   if (format === 'edit' || format === 'atom') {
     return class LinksToManyEditorTemplate extends GlimmerComponent {
@@ -252,17 +251,10 @@ export function getLinksToManyComponent({
           @field={{field}}
           @format={{format}}
           @cardTypeFor={{cardTypeFor}}
-          @context={{context}}
         />
       </template>
     };
   } else {
-    return getPluralViewComponent(
-      arrayField,
-      field,
-      format,
-      cardTypeFor,
-      context,
-    );
+    return getPluralViewComponent(arrayField, field, format, cardTypeFor);
   }
 }

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -21,6 +21,7 @@
     "tracked-built-ins": "^2.0.1"
   },
   "peerDependencies": {
+    "ember-provide-consume-context": "^0.3.1",
     "ember-source": "~5.4.0"
   },
   "scripts": {}

--- a/packages/host/app/components/card-catalog/index.gts
+++ b/packages/host/app/components/card-catalog/index.gts
@@ -12,7 +12,7 @@ import { cn, eq, gt } from '@cardstack/boxel-ui/helpers';
 
 import { Eye as EyeIcon } from '@cardstack/boxel-ui/icons';
 
-import type { CardDef, CardContext } from 'https://cardstack.com/base/card-api';
+import type { CardDef } from 'https://cardstack.com/base/card-api';
 
 import CardCatalogItem from './item';
 import CardCatalogResultsHeader from './results-header';
@@ -26,7 +26,6 @@ interface Signature {
     results: RealmCards[];
     select: (card?: CardDef, ev?: KeyboardEvent | MouseEvent) => void;
     selectedCard: CardDef | undefined;
-    context?: CardContext;
   };
 }
 
@@ -60,7 +59,6 @@ export default class CardCatalog extends Component<Signature> {
                     @title={{card.title}}
                     @description={{card.description}}
                     @thumbnailURL={{card.thumbnailURL}}
-                    @context={{@context}}
                   />
                   <button
                     class='select'

--- a/packages/host/app/components/card-catalog/item.gts
+++ b/packages/host/app/components/card-catalog/item.gts
@@ -7,8 +7,6 @@ import { cn } from '@cardstack/boxel-ui/helpers';
 
 import { RealmPaths } from '@cardstack/runtime-common/paths';
 
-import type { CardContext } from 'https://cardstack.com/base/card-api';
-
 import type CardService from '../../services/card-service';
 import type LoaderService from '../../services/loader-service';
 
@@ -18,7 +16,6 @@ interface Signature {
     title: string | null;
     description: string | null;
     thumbnailURL: string | null;
-    context?: CardContext;
   };
 }
 

--- a/packages/host/app/components/card-catalog/modal.gts
+++ b/packages/host/app/components/card-catalog/modal.gts
@@ -30,7 +30,7 @@ import type { Query, Filter } from '@cardstack/runtime-common/query';
 
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
-import type { CardDef, CardContext } from 'https://cardstack.com/base/card-api';
+import type { CardDef } from 'https://cardstack.com/base/card-api';
 
 import { getCard } from '../../resources/card-resource';
 import { getSearchResults, Search } from '../../resources/search';
@@ -51,9 +51,7 @@ import type CardService from '../../services/card-service';
 import type LoaderService from '../../services/loader-service';
 
 interface Signature {
-  Args: {
-    context?: CardContext;
-  };
+  Args: {};
 }
 
 export interface RealmCards {
@@ -136,7 +134,6 @@ export default class CardCatalogModal extends Component<Signature> {
               }}
               @select={{this.selectCard}}
               @selectedCard={{this.state.selectedCard}}
-              @context={{@context}}
             />
           {{/if}}
         </:content>

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -18,6 +18,7 @@ import {
   waitForProperty,
 } from 'ember-concurrency';
 import Modifier from 'ember-modifier';
+import { provide } from 'ember-provide-consume-context';
 import { trackedFunction } from 'ember-resources/util/function';
 
 import { TrackedArray } from 'tracked-built-ins';
@@ -45,6 +46,7 @@ import {
 import {
   type Actions,
   cardTypeDisplayName,
+  CardContextName,
   Deferred,
 } from '@cardstack/runtime-common';
 
@@ -173,6 +175,8 @@ export default class OperatorModeStackItem extends Component<Signature> {
     return this.args.index + 1 < this.args.stackItems.length;
   }
 
+  @provide(CardContextName)
+  // @ts-expect-error noUnusedLocals
   private get context() {
     return {
       cardComponentModifier: this.cardTracker.trackElement,
@@ -527,11 +531,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
             {{ContentElement onSetup=this.setupContentEl}}
             data-test-stack-item-content
           >
-            <Preview
-              @card={{this.card}}
-              @format={{@item.format}}
-              @context={{this.context}}
-            />
+            <Preview @card={{this.card}} @format={{@item.format}} />
             <OperatorModeOverlays
               @renderedCardsForOverlayActions={{this.renderedCardsForOverlayActions}}
               @publicAPI={{@publicAPI}}

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -175,7 +175,6 @@ export default class OperatorModeStackItem extends Component<Signature> {
 
   private get context() {
     return {
-      renderedIn: this as Component<any>,
       cardComponentModifier: this.cardTracker.trackElement,
       actions: this.args.publicAPI,
     };

--- a/packages/host/app/components/preview.gts
+++ b/packages/host/app/components/preview.gts
@@ -2,7 +2,6 @@ import Component from '@glimmer/component';
 
 import type {
   BaseDef,
-  CardContext,
   Format,
   Field,
 } from 'https://cardstack.com/base/card-api';
@@ -12,7 +11,6 @@ interface Signature {
     card: BaseDef;
     format?: Format;
     field?: Field;
-    context?: CardContext;
   };
 }
 
@@ -26,7 +24,6 @@ export default class Preview extends Component<Signature> {
       this.args.card,
       this.args.format ?? 'isolated',
       this.args.field,
-      this.args.context,
     );
   }
 }

--- a/packages/host/app/lib/externals.ts
+++ b/packages/host/app/lib/externals.ts
@@ -16,6 +16,7 @@ import * as emberConcurrency from 'ember-concurrency';
 import * as emberConcurrencyAsyncArrowRuntime from 'ember-concurrency/-private/async-arrow-runtime';
 import * as cssUrl from 'ember-css-url';
 import * as emberModifier2 from 'ember-modifier';
+import * as emberProvideConsumeContext from 'ember-provide-consume-context';
 import * as emberResources from 'ember-resources';
 import * as ethers from 'ethers';
 import * as flat from 'flat';
@@ -59,6 +60,10 @@ export function shimExternals(virtualNetwork: VirtualNetwork) {
     emberConcurrencyAsyncArrowRuntime,
   );
   virtualNetwork.shimModule('ember-modifier', emberModifier2);
+  virtualNetwork.shimModule(
+    'ember-provide-consume-context',
+    emberProvideConsumeContext,
+  );
   virtualNetwork.shimModule('flat', flat);
   virtualNetwork.shimModule('lodash', lodash);
   virtualNetwork.shimModule('tracked-built-ins', tracked);

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -114,6 +114,7 @@
     "ember-modifier": "^4.1.0",
     "ember-moment": "^10.0.0",
     "ember-page-title": "^8.2.3",
+    "ember-provide-consume-context": "^0.3.1",
     "ember-qunit": "^8.0.1",
     "ember-resolver": "^11.0.1",
     "ember-resources": "^6.3.1",

--- a/packages/host/tests/helpers/render-component.ts
+++ b/packages/host/tests/helpers/render-component.ts
@@ -10,7 +10,6 @@ import type {
   BaseDef,
   Format,
   Field,
-  CardContext,
 } from 'https://cardstack.com/base/card-api';
 
 async function cardApi(
@@ -30,10 +29,9 @@ export async function renderCard(
   card: BaseDef,
   format: Format,
   field?: Field,
-  context?: CardContext,
 ) {
   let api = await cardApi(loader);
   await api.recompute(card, { recomputeAllFields: true });
-  await renderComponent(api.getComponent(card, format, field, context));
+  await renderComponent(api.getComponent(card, format, field));
   return (getContext() as { element: Element }).element;
 }

--- a/packages/host/tests/integration/search-index-test.gts
+++ b/packages/host/tests/integration/search-index-test.gts
@@ -2669,6 +2669,7 @@ module('Integration | search-index', function (hooks) {
         'https://packages/ember-concurrency',
         'https://packages/ember-concurrency/-private/async-arrow-runtime',
         'https://packages/ember-modifier',
+        'https://packages/ember-provide-consume-context',
         'https://packages/lodash',
         'https://packages/tracked-built-ins',
       ],

--- a/packages/host/types/global.d.ts
+++ b/packages/host/types/global.d.ts
@@ -4,6 +4,15 @@ import '@glint/environment-ember-loose/native-integration';
 import { ComponentLike } from '@glint/template';
 import 'ember-freestyle/glint';
 
+import type EmberContextTemplateRegistry from 'ember-provide-consume-context/template-registry';
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry
+    extends EmberContextTemplateRegistry /* other addon registries */ {
+    // local entries
+  }
+}
+
 // Types for compiled templates
 declare module '@cardstack/host/templates/*' {
   const tmpl: TemplateFactory;

--- a/packages/realm-server/lib/externals.ts
+++ b/packages/realm-server/lib/externals.ts
@@ -76,6 +76,14 @@ export function shimExternals(virtualNetwork: VirtualNetwork) {
     task() {},
     restartableTask() {},
   });
+  virtualNetwork.shimModule('ember-provide-consume-context', {
+    consume() {
+      return () => {};
+    },
+    provide() {
+      return () => {};
+    },
+  });
   // import * as emberConcurrencyAsyncArrowRuntime from 'ember-concurrency/-private/async-arrow-runtime';
   virtualNetwork.shimModule('ember-concurrency/-private/async-arrow-runtime', {
     default: () => {},

--- a/packages/runtime-common/constants.ts
+++ b/packages/runtime-common/constants.ts
@@ -20,3 +20,5 @@ export const isField = Symbol('cardstack-field');
 export const primitive = Symbol('cardstack-primitive');
 
 export const aiBotUsername = 'aibot';
+
+export const CardContextName = 'card-context';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
 
   packages/base:
     dependencies:
+      ember-provide-consume-context:
+        specifier: ^0.3.1
+        version: 0.3.1(@babel/core@7.24.3)(@ember/test-helpers@3.3.0)(ember-source@5.4.1)
       ember-source:
         specifier: ~5.4.0
         version: 5.4.1(@babel/core@7.24.3)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.89.0)
@@ -12101,7 +12104,6 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
-    dev: true
 
   /ember-qunit@5.1.2(@ember/test-helpers@2.9.3)(ember-source@3.27.0)(qunit@2.19.4):
     resolution: {integrity: sha512-mrnFaUhAJWkJWeRZKajLuuRmKsifRrhAla1sQAfIiuh7OCVY1eqFvSUFzLR7/WgdNwPrUzEOOx39MdVRZBd/7A==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1243,6 +1243,9 @@ importers:
       ember-page-title:
         specifier: ^8.2.3
         version: 8.2.3(ember-source@5.4.1)
+      ember-provide-consume-context:
+        specifier: ^0.3.1
+        version: 0.3.1(@babel/core@7.24.3)(@ember/test-helpers@3.3.0)(ember-source@5.4.1)
       ember-qunit:
         specifier: ^8.0.1
         version: 8.0.2(@ember/test-helpers@3.3.0)(@glint/template@1.3.0)(ember-source@5.4.1)(qunit@2.20.1)
@@ -12084,6 +12087,21 @@ packages:
       - '@glint/template'
       - supports-color
     dev: false
+
+  /ember-provide-consume-context@0.3.1(@babel/core@7.24.3)(@ember/test-helpers@3.3.0)(ember-source@5.4.1):
+    resolution: {integrity: sha512-bit/W23qNto4uO2H+O9NPK1klO1FwLhzwN9Goo/5cdKHKM4u0G6QFfY/vEHMaHIu97Exh1MMFtLBx5y9iZTPmw==}
+    peerDependencies:
+      '@ember/test-helpers': ^2.9.1 || ^3.0.0
+      ember-source: ^4.8.0 || ^5.0.0
+    dependencies:
+      '@ember/test-helpers': 3.3.0(@glint/template@1.3.0)(ember-source@5.4.1)(webpack@5.89.0)
+      '@embroider/addon-shim': 1.8.7
+      '@glimmer/component': 1.1.2(@babel/core@7.24.3)
+      ember-source: 5.4.1(@babel/core@7.24.3)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.89.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+    dev: true
 
   /ember-qunit@5.1.2(@ember/test-helpers@2.9.3)(ember-source@3.27.0)(qunit@2.19.4):
     resolution: {integrity: sha512-mrnFaUhAJWkJWeRZKajLuuRmKsifRrhAla1sQAfIiuh7OCVY1eqFvSUFzLR7/WgdNwPrUzEOOx39MdVRZBd/7A==}


### PR DESCRIPTION
This is a stepping stone toward our refactor from the @model/@fields template API. It introduces ember-provide-consume-context and uses it to convert the way that provide the cardComponentModifier and actions to cards from using prop drilling to using dynamic context.