### PR TITLE
ci: Fix main attachment of Playwright status link

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,8 @@ name: CI
 
 on:
   push:
-    branches: [ci/playwright-report-status-on-main] # FIXME restore
+    branches: [main]
+  pull_request:
 
 permissions:
   checks: write

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,8 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
-  pull_request:
+    branches: [ci/playwright-report-status-on-main] # FIXME restore
 
 permissions:
   checks: write

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -281,7 +281,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           curl \
             -X POST \


### PR DESCRIPTION
This corrects an error in #1169; you can see when you view the statuses attached to [the commit where I merged it](https://github.com/cardstack/boxel/commit/0fe906c8aca1878522884f640c8e783316c15a1a) that a [report is generated](https://boxel-matrix-playwright-reports.stack.cards/main/20240422_174103Z/index.html) but the [status is not attached](https://github.com/cardstack/boxel/actions/runs/8788353636/job/24116041235#step:12:30) because the API URL is for pull requests only, not pushes to a branch. This adds a fallback for the SHA when the CI job is running outside of a PR.

In [`c056b17`](https://github.com/cardstack/boxel/pull/1192/commits/c056b177bfbcd3a28876329856e35c30deebb4c4) I hacked the workflow to run on `push` to this branch and the status was correctly attached:

<img width="598" alt="boxel 2024-04-22 13-24-05" src="https://github.com/cardstack/boxel/assets/43280/eba0f535-9569-40f6-9d2e-3d9d3e80424c">