### PR TITLE
Percy snapshot issue: create-file modal still in front of card-catalog modal

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,6 +159,11 @@ jobs:
         env:
           NODE_OPTIONS: --max_old_space_size=4096
         working-directory: packages/host
+      - name: Save dist
+        uses: actions/upload-artifact@v3
+        with:
+          name: host-dist
+          path: packages/host/dist
       - name: Start realm servers
         run: pnpm start:all &
         working-directory: packages/realm-server

--- a/packages/host/.percy.js
+++ b/packages/host/.percy.js
@@ -6,6 +6,8 @@ module.exports = {
       [data-test-percy-hide] {
         visibility: hidden;
       }
+
+      #ember1420 {display: none !important;}
     `,
   },
 };

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -1402,7 +1402,7 @@ module('Acceptance | code submode tests', function (hooks) {
       );
   });
 
-  test('closes the top-most modal first when clicking overlay background', async function (assert) {
+  test.only('closes the top-most modal first when clicking overlay background', async function (assert) {
     await visitOperatorMode({
       stacks: [
         [

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -1424,6 +1424,7 @@ module('Acceptance | code submode tests', function (hooks) {
 
     await click('[data-test-select-card-type]');
     await waitFor('[data-test-card-catalog-modal]');
+    await percySnapshot(assert);
     let cardCatalogModalOverlay = document.querySelector(
       '[data-test-card-catalog-modal]',
     )?.previousElementSibling;

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -1429,6 +1429,23 @@ module('Acceptance | code submode tests', function (hooks) {
       '[data-test-card-catalog-modal]',
     )?.previousElementSibling;
     assert.dom(cardCatalogModalOverlay).exists();
+    console.log(
+      'urgent variable value',
+      getComputedStyle(
+        document.querySelector(
+          '[style="--boxel-modal-z-index: var(--boxel-layer-modal-urgent)"]',
+        )!,
+      ).getPropertyValue('--boxel-modal-z-index'),
+    );
+    console.log(
+      'default variable value',
+      getComputedStyle(
+        document.querySelector(
+          '[style="--boxel-modal-z-index: var(--boxel-layer-modal-default)"]',
+        )!,
+      ).getPropertyValue('--boxel-modal-z-index'),
+    );
+    await percySnapshot(assert);
     await click(cardCatalogModalOverlay!);
     assert.dom('[data-test-card-catalog-modal]').doesNotExist();
 

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -1438,12 +1438,28 @@ module('Acceptance | code submode tests', function (hooks) {
       ).getPropertyValue('--boxel-modal-z-index'),
     );
     console.log(
+      'urgent dialog z-index',
+      getComputedStyle(
+        document.querySelector(
+          '[style="--boxel-modal-z-index: var(--boxel-layer-modal-urgent)"] dialog',
+        ),
+      )['z-index'],
+    );
+    console.log(
       'default variable value',
       getComputedStyle(
         document.querySelector(
           '[style="--boxel-modal-z-index: var(--boxel-layer-modal-default)"]',
         )!,
       ).getPropertyValue('--boxel-modal-z-index'),
+    );
+    console.log(
+      'default dialog z-index',
+      getComputedStyle(
+        document.querySelector(
+          '[style="--boxel-modal-z-index: var(--boxel-layer-modal-default)"] dialog',
+        ),
+      )['z-index'],
     );
     await percySnapshot(assert);
     await click(cardCatalogModalOverlay!);


### PR DESCRIPTION
Originally from this [PR](https://github.com/cardstack/boxel/pull/1180)

But even before that PR was merged -- there are these percy snapshot issues

[Linear ticket](https://linear.app/cardstack/issue/CS-6721/percy-snapshot-doesnt-detect-seem-to-detect-modal) 