### PR TITLE
host: Add handling for Unicode in file/class names

### DIFF
--- a/packages/host/app/components/card-catalog/item.gts
+++ b/packages/host/app/components/card-catalog/item.gts
@@ -93,7 +93,7 @@ export default class CardCatalogItem extends Component<Signature> {
     if (!path) {
       return undefined;
     }
-    let realmPath = new RealmPaths(this.cardService.defaultURL.href);
+    let realmPath = new RealmPaths(this.cardService.defaultURL);
 
     if (/^(\.\.\/)+/.test(path)) {
       let localPath = new URL(path, realmPath.url).pathname.replace(/^\//, '');

--- a/packages/host/app/components/editor/recent-files.gts
+++ b/packages/host/app/components/editor/recent-files.gts
@@ -1,4 +1,3 @@
-import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
@@ -59,11 +58,15 @@ class File extends Component<FileArgs> {
   }
 
   get fullUrl() {
-    return `${this.args.recentFile.realmURL}${this.args.recentFile.filePath}`;
+    return new URL(
+      `${this.args.recentFile.realmURL}${this.args.recentFile.filePath}`,
+    );
   }
 
   get isSelected() {
-    return this.operatorModeStateService.state.codePath?.href === this.fullUrl;
+    return (
+      this.operatorModeStateService.state.codePath?.href === this.fullUrl.href
+    );
   }
 
   <template>
@@ -72,9 +75,9 @@ class File extends Component<FileArgs> {
       {{! template-lint-disable require-presentational-children }}
       <li
         class='recent-file'
-        data-test-recent-file={{this.fullUrl}}
+        data-test-recent-file={{this.fullUrl.href}}
         role='button'
-        {{on 'click' (fn this.openFile this.fullUrl)}}
+        {{on 'click' this.openFile}}
       >
         <RealmInfoProvider @realmURL={{@recentFile.realmURL}}>
           <:ready as |realmInfo|>

--- a/packages/host/app/components/operator-mode/card-url-bar.gts
+++ b/packages/host/app/components/operator-mode/card-url-bar.gts
@@ -206,7 +206,7 @@ export default class CardURLBar extends Component<Signature> {
   @service private declare cardService: CardService;
 
   private urlBar: URLBarResource = urlBarResource(this, () => ({
-    getValue: () => this.codePath,
+    getValue: () => decodeURI(this.codePath),
     setValue: (url: string) => {
       this.operatorModeStateService.updateCodePath(new URL(url));
     },

--- a/packages/host/app/components/operator-mode/card-url-bar.gts
+++ b/packages/host/app/components/operator-mode/card-url-bar.gts
@@ -206,7 +206,7 @@ export default class CardURLBar extends Component<Signature> {
   @service private declare cardService: CardService;
 
   private urlBar: URLBarResource = urlBarResource(this, () => ({
-    getValue: () => decodeURI(this.codePath),
+    getValue: () => (this.codePath ? decodeURI(this.codePath) : ''),
     setValue: (url: string) => {
       this.operatorModeStateService.updateCodePath(new URL(url));
     },

--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -591,6 +591,7 @@ export class ${className} extends ${exportName}Parent {
           .split('/')
           .pop()!
           .replace(/\.[^.]+$/, ''),
+        { pascalCase: true },
       );
       // check for parent/className declaration collision
       parent = parent === className ? `${parent}Parent` : parent;

--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -725,12 +725,20 @@ export class ${className} extends ${exportName} {
   });
 }
 
-function convertToClassName(input: string) {
+export function convertToClassName(input: string) {
   // \p{L}: a letter
   let invalidLeadingCharactersRemoved = camelCase(
     input.replace(/^[^\p{L}_$]+/u, ''),
     { pascalCase: true },
   );
+
+  if (!invalidLeadingCharactersRemoved) {
+    let prefixedInput = `Class${input}`;
+    invalidLeadingCharactersRemoved = camelCase(
+      prefixedInput.replace(/^[^\p{L}_$]+/u, ''),
+      { pascalCase: true },
+    );
+  }
 
   let className = invalidLeadingCharactersRemoved.replace(
     // \p{N}: a number

--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -586,7 +586,7 @@ import { Component } from 'https://cardstack.com/base/card-api';
 export class ${className} extends ${exportName}Parent {
   static displayName = "${this.displayName}";`);
     } else if (exportName === 'default') {
-      let parent = camelize(
+      let parent = camelCase(
         module
           .split('/')
           .pop()!

--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -724,7 +724,7 @@ export class ${className} extends ${exportName} {
   });
 }
 
-function convertToClassName(input) {
+function convertToClassName(input: string) {
   // \p{L}: a letter
   let invalidLeadingCharactersRemoved = camelCase(
     input.replace(/^[^\p{L}_$]+/u, ''),

--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -725,7 +725,10 @@ export class ${className} extends ${exportName} {
 }
 
 function convertToClassName(input) {
+  // \p{L}: a letter
   let invalidLeadingCharactersRemoved = input.replace(/^[^\p{L}_$]+/u, '');
+
+  // \p{N}: a number
   let invalidCharactersRemoved = invalidLeadingCharactersRemoved.replace(
     /[^\p{L}\p{N}_$]+/gu,
     '',

--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -726,15 +726,16 @@ export class ${className} extends ${exportName} {
 
 function convertToClassName(input) {
   // \p{L}: a letter
-  let invalidLeadingCharactersRemoved = input.replace(/^[^\p{L}_$]+/u, '');
+  let invalidLeadingCharactersRemoved = camelCase(
+    input.replace(/^[^\p{L}_$]+/u, ''),
+    { pascalCase: true },
+  );
 
-  // \p{N}: a number
-  let invalidCharactersRemoved = invalidLeadingCharactersRemoved.replace(
+  let className = invalidLeadingCharactersRemoved.replace(
+    // \p{N}: a number
     /[^\p{L}\p{N}_$]+/gu,
     '',
   );
-
-  let className = camelCase(invalidCharactersRemoved, { pascalCase: true });
 
   // make sure we don't collide with a javascript built-in object
   if (typeof (globalThis as any)[className] !== 'undefined') {

--- a/packages/host/app/components/operator-mode/delete-modal.gts
+++ b/packages/host/app/components/operator-mode/delete-modal.gts
@@ -135,7 +135,7 @@ export default class DeleteModal extends Component<Signature> {
     if (this.item instanceof URL) {
       return {
         type: 'file',
-        name: this.item.href.split('/').pop()!,
+        name: decodeURI(this.item.href).split('/').pop()!,
         id: this.item.href,
       };
     }

--- a/packages/host/app/components/realm-dropdown.gts
+++ b/packages/host/app/components/realm-dropdown.gts
@@ -158,7 +158,7 @@ export default class RealmDropdown extends Component<Signature> {
     if (this.args.selectedRealmURL) {
       selectedRealm = this.realms.find(
         (realm) =>
-          realm.path === new RealmPaths(this.args.selectedRealmURL as URL).url,
+          realm.path === new RealmPaths(this.args.selectedRealmURL!).url,
       );
     }
     if (selectedRealm) {

--- a/packages/host/app/resources/file.ts
+++ b/packages/host/app/resources/file.ts
@@ -182,6 +182,7 @@ class _FileResource extends Resource<Args> {
     await realmSession.loaded;
 
     let self = this;
+    let rawName = response.url.split('/').pop();
 
     this.updateState({
       state: 'ready',
@@ -189,7 +190,7 @@ class _FileResource extends Resource<Args> {
       realmURL,
       content,
       realmSession,
-      name: response.url.split('/').pop()!,
+      name: rawName ? decodeURIComponent(rawName) : rawName!,
       size,
       url: response.url,
       write(content: string, flushLoader?: true) {

--- a/packages/host/app/resources/file.ts
+++ b/packages/host/app/resources/file.ts
@@ -182,7 +182,6 @@ class _FileResource extends Resource<Args> {
     await realmSession.loaded;
 
     let self = this;
-    let rawName = response.url.split('/').pop();
 
     this.updateState({
       state: 'ready',
@@ -190,7 +189,7 @@ class _FileResource extends Resource<Args> {
       realmURL,
       content,
       realmSession,
-      name: rawName ? decodeURIComponent(rawName) : rawName!,
+      name: response.url.split('/').pop()!,
       size,
       url: response.url,
       write(content: string, flushLoader?: true) {

--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -439,7 +439,7 @@ export default class CardService extends Service {
 
   getRealmURLFor(url: URL) {
     for (let realmURL of this.realmURLs) {
-      let path = new RealmPaths(realmURL);
+      let path = new RealmPaths(new URL(realmURL));
       if (path.inRealm(url)) {
         return new URL(realmURL);
       }

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -145,7 +145,7 @@ export default class OperatorModeStateService extends Service {
 
     let cardRealmUrl = await this.cardService.getRealmURL(card);
     let realmPaths = new RealmPaths(cardRealmUrl);
-    let cardPath = realmPaths.local(`${card.id}.json`);
+    let cardPath = realmPaths.local(new URL(`${card.id}.json`));
     this.recentFilesService.removeRecentFile(cardPath);
     await this.cardService.deleteCard(card);
   }

--- a/packages/host/app/services/realm-info-service.ts
+++ b/packages/host/app/services/realm-info-service.ts
@@ -124,7 +124,7 @@ export default class RealmInfoService extends Service {
 
   fetchAllKnownRealmInfos = restartableTask(async () => {
     let paths = this.cardService.realmURLs.map(
-      (path) => new RealmPaths(path).url,
+      (path) => new RealmPaths(new URL(path)).url,
     );
     let token = waiter.beginAsync();
     try {

--- a/packages/host/app/services/recent-files-service.ts
+++ b/packages/host/app/services/recent-files-service.ts
@@ -46,8 +46,8 @@ export default class RecentFilesService extends Service {
     this.persistRecentFiles();
   }
 
-  addRecentFileUrl(url: string) {
-    if (!url) {
+  addRecentFileUrl(urlString: string) {
+    if (!urlString) {
       return;
     }
     // TODO this wont work when visiting files that come from multiple realms in
@@ -56,7 +56,9 @@ export default class RecentFilesService extends Service {
 
     if (realmURL) {
       let realmPaths = new RealmPaths(new URL(realmURL));
-      if (realmPaths.inRealm(new URL(url))) {
+      let url = new URL(urlString);
+
+      if (realmPaths.inRealm(url)) {
         this.addRecentFile(realmPaths.local(url));
       }
     }

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -77,6 +77,7 @@
     "broccoli-plugin": "^4.0.7",
     "broccoli-source": "^3.0.1",
     "buffer": "^6.0.3",
+    "camelcase": "^8.0.0",
     "concurrently": "^8.2.2",
     "crypto-browserify": "^3.12.0",
     "date-fns": "^2.28.0",

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -77,7 +77,7 @@
     "broccoli-plugin": "^4.0.7",
     "broccoli-source": "^3.0.1",
     "buffer": "^6.0.3",
-    "camelcase": "^8.0.0",
+    "camelcase": "^6.3.0",
     "concurrently": "^8.2.2",
     "crypto-browserify": "^3.12.0",
     "date-fns": "^2.28.0",

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -560,8 +560,8 @@ module('Acceptance | code submode | create-file tests', function (hooks) {
     let expectedSrc = `
 import { CardDef } from 'https://cardstack.com/base/card-api';
 import { Component } from 'https://cardstack.com/base/card-api';
-export class TestCard extends CardDef {
-  static displayName = "Test Card";
+export class TrèsTestCard extends CardDef {
+  static displayName = "Très Test Card";
 
   /*
   static isolated = class Isolated extends Component<typeof this> {
@@ -587,7 +587,7 @@ export class TestCard extends CardDef {
     assert
       .dom('[data-test-create-definition]')
       .isDisabled('create button is disabled');
-    await fillIn('[data-test-display-name-field]', 'Test Card');
+    await fillIn('[data-test-display-name-field]', 'Très Test Card');
     assert
       .dom(`[data-test-inherits-from-field] [data-test-boxel-field-label]`)
       .hasText('Inherits From');
@@ -614,7 +614,7 @@ export class TestCard extends CardDef {
       'monaco displays the new definition',
     );
 
-    await waitFor('[data-test-card-schema="Test Card"]');
+    await waitFor('[data-test-card-schema="Très Test Card"]');
     assert.dom('[data-test-current-module-name]').hasText('très-test-card.gts');
     assert
       .dom('[data-test-card-url-bar-input]')

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -556,7 +556,7 @@ module('Acceptance | code submode | create-file tests', function (hooks) {
   });
 
   test<TestContextWithSave>('can create a new card definition in different realm than inherited definition', async function (assert) {
-    assert.expect(10);
+    assert.expect(11);
     let expectedSrc = `
 import { CardDef } from 'https://cardstack.com/base/card-api';
 import { Component } from 'https://cardstack.com/base/card-api';
@@ -616,6 +616,9 @@ export class TestCard extends CardDef {
 
     await waitFor('[data-test-card-schema="Test Card"]');
     assert.dom('[data-test-current-module-name]').hasText('très-test-card.gts');
+    assert
+      .dom('[data-test-card-url-bar-input]')
+      .hasValue(`${testRealmURL}très-test-card.gts`);
     assert
       .dom('[data-test-card-schema]')
       .exists({ count: 3 }, 'the card hierarchy is displayed in schema editor');

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -961,54 +961,6 @@ export class Map0 extends Pet {
     await deferred.promise;
   });
 
-  test<TestContextWithSave>('can sanitize display name when creating a new definition', async function (assert) {
-    assert.expect(1);
-    await visitOperatorMode(this.owner);
-    await openNewFileModal('Card Definition');
-
-    await fillIn('[data-test-display-name-field]', 'Test Card; { }');
-    await fillIn('[data-test-file-name-field]', 'test-card');
-    let deferred = new Deferred<void>();
-    this.onSave((_, content) => {
-      if (typeof content !== 'string') {
-        throw new Error(`expected string save data`);
-      }
-      assert.strictEqual(
-        content,
-        `
-import { CardDef } from 'https://cardstack.com/base/card-api';
-import { Component } from 'https://cardstack.com/base/card-api';
-export class TestCard extends CardDef {
-  static displayName = "Test Card";
-
-  /*
-  static isolated = class Isolated extends Component<typeof this> {
-    <template></template>
-  }
-
-  static embedded = class Embedded extends Component<typeof this> {
-    <template></template>
-  }
-
-  static atom = class Atom extends Component<typeof this> {
-    <template></template>
-  }
-
-  static edit = class Edit extends Component<typeof this> {
-    <template></template>
-  }
-  */
-}`.trim(),
-        'the source is correct',
-      );
-      deferred.fulfill();
-    });
-
-    await click('[data-test-create-definition]');
-    await waitFor('[data-test-create-file-modal]', { count: 0 });
-    await deferred.promise;
-  });
-
   test<TestContextWithSave>('can specify new directory as part of filename when creating a new definition', async function (assert) {
     assert.expect(2);
     let expectedSrc = `

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -561,7 +561,7 @@ module('Acceptance | code submode | create-file tests', function (hooks) {
 import { CardDef } from 'https://cardstack.com/base/card-api';
 import { Component } from 'https://cardstack.com/base/card-api';
 export class TrèsTestCard extends CardDef {
-  static displayName = "Très Test Card";
+  static displayName = "Très Test Card 😀";
 
   /*
   static isolated = class Isolated extends Component<typeof this> {
@@ -587,7 +587,7 @@ export class TrèsTestCard extends CardDef {
     assert
       .dom('[data-test-create-definition]')
       .isDisabled('create button is disabled');
-    await fillIn('[data-test-display-name-field]', 'Très Test Card');
+    await fillIn('[data-test-display-name-field]', 'Très Test Card 😀');
     assert
       .dom(`[data-test-inherits-from-field] [data-test-boxel-field-label]`)
       .hasText('Inherits From');
@@ -614,7 +614,7 @@ export class TrèsTestCard extends CardDef {
       'monaco displays the new definition',
     );
 
-    await waitFor('[data-test-card-schema="Très Test Card"]');
+    await waitFor('[data-test-card-schema="Très Test Card 😀"]');
     assert.dom('[data-test-current-module-name]').hasText('très-test-card.gts');
     assert
       .dom('[data-test-card-url-bar-input]')

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -561,7 +561,7 @@ module('Acceptance | code submode | create-file tests', function (hooks) {
 import { CardDef } from 'https://cardstack.com/base/card-api';
 import { Component } from 'https://cardstack.com/base/card-api';
 export class TrèsTestCard extends CardDef {
-  static displayName = "Très Test Card 😀";
+  static displayName = "Très test card 😀";
 
   /*
   static isolated = class Isolated extends Component<typeof this> {
@@ -587,7 +587,7 @@ export class TrèsTestCard extends CardDef {
     assert
       .dom('[data-test-create-definition]')
       .isDisabled('create button is disabled');
-    await fillIn('[data-test-display-name-field]', 'Très Test Card 😀');
+    await fillIn('[data-test-display-name-field]', 'Très test card 😀');
     assert
       .dom(`[data-test-inherits-from-field] [data-test-boxel-field-label]`)
       .hasText('Inherits From');
@@ -614,7 +614,7 @@ export class TrèsTestCard extends CardDef {
       'monaco displays the new definition',
     );
 
-    await waitFor('[data-test-card-schema="Très Test Card 😀"]');
+    await waitFor('[data-test-card-schema="Très test card 😀"]');
     assert.dom('[data-test-current-module-name]').hasText('très-test-card.gts');
     assert
       .dom('[data-test-card-url-bar-input]')

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -556,7 +556,7 @@ module('Acceptance | code submode | create-file tests', function (hooks) {
   });
 
   test<TestContextWithSave>('can create a new card definition in different realm than inherited definition', async function (assert) {
-    assert.expect(9);
+    assert.expect(10);
     let expectedSrc = `
 import { CardDef } from 'https://cardstack.com/base/card-api';
 import { Component } from 'https://cardstack.com/base/card-api';
@@ -594,7 +594,7 @@ export class TestCard extends CardDef {
     assert
       .dom('[data-test-create-definition]')
       .isDisabled('create button is disabled');
-    await fillIn('[data-test-file-name-field]', 'test-card');
+    await fillIn('[data-test-file-name-field]', 'très-test-card');
     assert
       .dom('[data-test-create-definition]')
       .isEnabled('create button is enabled');
@@ -615,6 +615,7 @@ export class TestCard extends CardDef {
     );
 
     await waitFor('[data-test-card-schema="Test Card"]');
+    assert.dom('[data-test-current-module-name]').hasText('très-test-card.gts');
     assert
       .dom('[data-test-card-schema]')
       .exists({ count: 3 }, 'the card hierarchy is displayed in schema editor');

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -467,6 +467,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
             },
           },
         },
+        'léame.md': 'hola mundo',
         'readme.md': 'hello world',
         'not-json.json': 'I am not JSON.',
         'Person/1.json': {
@@ -1226,21 +1227,21 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await visitOperatorMode({
       stacks: [[]],
       submode: 'code',
-      codePath: `${testRealmURL}readme.md`,
+      codePath: `${testRealmURL}léame.md`,
     });
     await waitForCodeEditor();
     assert.dom('[data-test-delete-modal-container]').doesNotExist();
 
     await waitFor(`[data-test-action-button="Delete"]`);
     await click('[data-test-action-button="Delete"]');
-    await waitFor(`[data-test-delete-modal="${testRealmURL}readme.md"]`);
+    await waitFor(`[data-test-delete-modal="${testRealmURL}l%C3%A9ame.md"]`);
     assert
       .dom('[data-test-delete-msg]')
-      .includesText('Delete the file readme.md?');
+      .includesText('Delete the file léame.md?');
     await click('[data-test-confirm-delete-button]');
     await waitFor('[data-test-empty-code-mode]');
 
-    let notFound = await adapter.openFile('readme.md');
+    let notFound = await adapter.openFile('léame.md');
     assert.strictEqual(notFound, undefined, 'file ref does not exist');
     assert.dom('[data-test-delete-modal-container]').doesNotExist();
   });

--- a/packages/host/tests/acceptance/code-submode/recent-files-test.ts
+++ b/packages/host/tests/acceptance/code-submode/recent-files-test.ts
@@ -192,6 +192,7 @@ module('Acceptance | code submode | recent files tests', function (hooks) {
         'index.gts': indexCardSource,
         'pet-person.gts': personCardSource,
         'person.gts': personCardSource,
+        'français.json': '{}',
         'friend.gts': friendCardSource,
         'employee.gts': employeeCardSource,
         'in-this-file.gts': inThisFileSource,
@@ -278,7 +279,7 @@ module('Acceptance | code submode | recent files tests', function (hooks) {
       'recent-files',
       JSON.stringify([
         [testRealmURL, 'index.json'],
-        ['http://localhost:4202/test/', 'person.gts'],
+        ['http://localhost:4202/test/', 'français.json'],
         'a-non-url-to-ignore',
       ]),
     );
@@ -331,8 +332,8 @@ module('Acceptance | code submode | recent files tests', function (hooks) {
       .dom('[data-test-recent-file]:nth-child(1)')
       .containsText('index.json');
 
-    await waitFor('[data-test-file="person.gts"]');
-    await click('[data-test-file="person.gts"]');
+    await waitFor('[data-test-file="français.json"]');
+    await click('[data-test-file="français.json"]');
 
     assert
       .dom('[data-test-recent-file]:first-child')
@@ -347,7 +348,7 @@ module('Acceptance | code submode | recent files tests', function (hooks) {
 
     assert
       .dom('[data-test-recent-file]:first-child')
-      .containsText('person.gts');
+      .containsText('français.json');
     assert
       .dom('[data-test-recent-file]:nth-child(2)')
       .containsText('Person/1.json');
@@ -356,9 +357,9 @@ module('Acceptance | code submode | recent files tests', function (hooks) {
       JSON.parse(window.localStorage.getItem('recent-files') || '[]'),
       [
         [testRealmURL, 'index.json'],
-        [testRealmURL, 'person.gts'],
+        [testRealmURL, 'français.json'],
         [testRealmURL, 'Person/1.json'],
-        ['http://localhost:4202/test/', 'person.gts'],
+        ['http://localhost:4202/test/', 'français.json'],
       ],
     );
   });

--- a/packages/host/tests/integration/search-index-test.gts
+++ b/packages/host/tests/integration/search-index-test.gts
@@ -28,7 +28,7 @@ import {
   setupIntegrationTestRealm,
 } from '../helpers';
 
-const paths = new RealmPaths(testRealmURL);
+const paths = new RealmPaths(new URL(testRealmURL));
 const testModuleRealm = 'http://localhost:4202/test/';
 
 let loader: Loader;

--- a/packages/host/tests/unit/convert-to-class-name-test.ts
+++ b/packages/host/tests/unit/convert-to-class-name-test.ts
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+
+import { convertToClassName } from '@cardstack/host/components/operator-mode/create-file-modal';
+
+module('Unit | convertToClassName', function () {
+  test('it removes invalid characters and provides a fallback', function (assert) {
+    assert.strictEqual(convertToClassName('hey'), 'Hey');
+    assert.strictEqual(convertToClassName('hey there'), 'HeyThere');
+
+    assert.strictEqual(convertToClassName('hey!'), 'Hey');
+    assert.strictEqual(convertToClassName('hé'), 'Hé');
+    assert.strictEqual(convertToClassName('hey 😀'), 'Hey');
+
+    assert.strictEqual(convertToClassName('123hey'), 'Hey');
+    assert.strictEqual(convertToClassName('123'), 'Class123');
+  });
+});

--- a/packages/host/tests/unit/realm-paths-test.ts
+++ b/packages/host/tests/unit/realm-paths-test.ts
@@ -4,73 +4,71 @@ import { RealmPaths } from '@cardstack/runtime-common';
 
 module('Unit | RealmPaths', function (hooks) {
   let realmPaths: RealmPaths;
-  module('RealmPaths from a URL', function (hooks) {
-    hooks.beforeEach(function () {
-      realmPaths = new RealmPaths(new URL('https://cardstack.com/hümans'));
-    });
+  hooks.beforeEach(function () {
+    realmPaths = new RealmPaths(new URL('https://cardstack.com/hümans'));
+  });
 
-    test('#local', function (assert) {
-      assert.strictEqual(
-        realmPaths.local(new URL('https://cardstack.com/hümans/example')),
-        'example',
-      );
-      assert.strictEqual(
-        realmPaths.local(new URL('https://cardstack.com/hümans/éxample')),
-        'éxample',
-      );
-      assert.strictEqual(
-        realmPaths.local(
-          new URL('https://cardstack.com/hümans/éxample?stripped=true'),
-        ),
-        'éxample',
-      );
-      assert.strictEqual(
-        realmPaths.local(
-          new URL('https://cardstack.com/hümans/éxample?stripped=ü'),
-          {
-            preserveQuerystring: true,
-          },
-        ),
-        'éxample?stripped=ü',
-      );
-    });
+  test('#local', function (assert) {
+    assert.strictEqual(
+      realmPaths.local(new URL('https://cardstack.com/hümans/example')),
+      'example',
+    );
+    assert.strictEqual(
+      realmPaths.local(new URL('https://cardstack.com/hümans/éxample')),
+      'éxample',
+    );
+    assert.strictEqual(
+      realmPaths.local(
+        new URL('https://cardstack.com/hümans/éxample?stripped=true'),
+      ),
+      'éxample',
+    );
+    assert.strictEqual(
+      realmPaths.local(
+        new URL('https://cardstack.com/hümans/éxample?stripped=ü'),
+        {
+          preserveQuerystring: true,
+        },
+      ),
+      'éxample?stripped=ü',
+    );
+  });
 
-    test('#fileURL', function (assert) {
-      assert.strictEqual(
-        realmPaths.fileURL('example').href,
-        'https://cardstack.com/h%C3%BCmans/example',
-      );
-      assert.strictEqual(
-        realmPaths.fileURL('éxample').href,
-        'https://cardstack.com/h%C3%BCmans/%C3%A9xample',
-      );
-    });
+  test('#fileURL', function (assert) {
+    assert.strictEqual(
+      realmPaths.fileURL('example').href,
+      'https://cardstack.com/h%C3%BCmans/example',
+    );
+    assert.strictEqual(
+      realmPaths.fileURL('éxample').href,
+      'https://cardstack.com/h%C3%BCmans/%C3%A9xample',
+    );
+  });
 
-    test('#directoryURL', function (assert) {
-      assert.strictEqual(
-        realmPaths.directoryURL('').href,
-        'https://cardstack.com/h%C3%BCmans/',
-      );
-      assert.strictEqual(
-        realmPaths.directoryURL('example').href,
-        'https://cardstack.com/h%C3%BCmans/example/',
-      );
-      assert.strictEqual(
-        realmPaths.directoryURL('éxample').href,
-        'https://cardstack.com/h%C3%BCmans/%C3%A9xample/',
-      );
-    });
+  test('#directoryURL', function (assert) {
+    assert.strictEqual(
+      realmPaths.directoryURL('').href,
+      'https://cardstack.com/h%C3%BCmans/',
+    );
+    assert.strictEqual(
+      realmPaths.directoryURL('example').href,
+      'https://cardstack.com/h%C3%BCmans/example/',
+    );
+    assert.strictEqual(
+      realmPaths.directoryURL('éxample').href,
+      'https://cardstack.com/h%C3%BCmans/%C3%A9xample/',
+    );
+  });
 
-    test('#inRealm', function (assert) {
-      assert.true(
-        realmPaths.inRealm(new URL('https://cardstack.com/hümans/example')),
-      );
-      assert.true(
-        realmPaths.inRealm(new URL('https://cardstack.com/hümans/éxample')),
-      );
-      assert.false(
-        realmPaths.inRealm(new URL('https://cardstack.com/humans/éxample')),
-      );
-    });
+  test('#inRealm', function (assert) {
+    assert.true(
+      realmPaths.inRealm(new URL('https://cardstack.com/hümans/example')),
+    );
+    assert.true(
+      realmPaths.inRealm(new URL('https://cardstack.com/hümans/éxample')),
+    );
+    assert.false(
+      realmPaths.inRealm(new URL('https://cardstack.com/humans/éxample')),
+    );
   });
 });

--- a/packages/host/tests/unit/realm-paths-test.ts
+++ b/packages/host/tests/unit/realm-paths-test.ts
@@ -1,0 +1,76 @@
+import { module, test } from 'qunit';
+
+import { RealmPaths } from '@cardstack/runtime-common';
+
+module('Unit | RealmPaths', function (hooks) {
+  let realmPaths: RealmPaths;
+  module('RealmPaths from a URL', function (hooks) {
+    hooks.beforeEach(function () {
+      realmPaths = new RealmPaths(new URL('https://cardstack.com/hümans'));
+    });
+
+    test('#local', function (assert) {
+      assert.strictEqual(
+        realmPaths.local(new URL('https://cardstack.com/hümans/example')),
+        'example',
+      );
+      assert.strictEqual(
+        realmPaths.local(new URL('https://cardstack.com/hümans/éxample')),
+        'éxample',
+      );
+      assert.strictEqual(
+        realmPaths.local(
+          new URL('https://cardstack.com/hümans/éxample?stripped=true'),
+        ),
+        'éxample',
+      );
+      assert.strictEqual(
+        realmPaths.local(
+          new URL('https://cardstack.com/hümans/éxample?stripped=ü'),
+          {
+            preserveQuerystring: true,
+          },
+        ),
+        'éxample?stripped=ü',
+      );
+    });
+
+    test('#fileURL', function (assert) {
+      assert.strictEqual(
+        realmPaths.fileURL('example').href,
+        'https://cardstack.com/h%C3%BCmans/example',
+      );
+      assert.strictEqual(
+        realmPaths.fileURL('éxample').href,
+        'https://cardstack.com/h%C3%BCmans/%C3%A9xample',
+      );
+    });
+
+    test('#directoryURL', function (assert) {
+      assert.strictEqual(
+        realmPaths.directoryURL('').href,
+        'https://cardstack.com/h%C3%BCmans/',
+      );
+      assert.strictEqual(
+        realmPaths.directoryURL('example').href,
+        'https://cardstack.com/h%C3%BCmans/example/',
+      );
+      assert.strictEqual(
+        realmPaths.directoryURL('éxample').href,
+        'https://cardstack.com/h%C3%BCmans/%C3%A9xample/',
+      );
+    });
+
+    test('#inRealm', function (assert) {
+      assert.true(
+        realmPaths.inRealm(new URL('https://cardstack.com/hümans/example')),
+      );
+      assert.true(
+        realmPaths.inRealm(new URL('https://cardstack.com/hümans/éxample')),
+      );
+      assert.false(
+        realmPaths.inRealm(new URL('https://cardstack.com/humans/éxample')),
+      );
+    });
+  });
+});

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -3,7 +3,7 @@ import './realm-server-test';
 import './loader-test';
 import './indexing-test';
 import './indexer-test';
-import './module-syntax-test';
+// import './module-syntax-test';
 import './permissions/permission-checker-test';
 import './auth-client-test';
 import './virtual-network-test';

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -3,7 +3,7 @@ import './realm-server-test';
 import './loader-test';
 import './indexing-test';
 import './indexer-test';
-// import './module-syntax-test';
+import './module-syntax-test';
 import './permissions/permission-checker-test';
 import './auth-client-test';
 import './virtual-network-test';

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -1280,7 +1280,7 @@ module('Realm Server', function (hooks) {
 
         // verify file serialization is correct
         {
-          let localPath = new RealmPaths(testRealmURL).local(id);
+          let localPath = new RealmPaths(testRealmURL).local(new URL(id));
           let jsonFile = `${join(dir.name, localPath)}.json`;
           let doc = JSON.parse(
             readFileSync(jsonFile, { encoding: 'utf8' }),

--- a/packages/runtime-common/constants.ts
+++ b/packages/runtime-common/constants.ts
@@ -1,7 +1,7 @@
 import { RealmPaths } from './paths';
 import type { ResolvedCodeRef } from './code-ref';
 
-export const baseRealm = new RealmPaths('https://cardstack.com/base/');
+export const baseRealm = new RealmPaths(new URL('https://cardstack.com/base/'));
 
 export const catalogEntryRef: ResolvedCodeRef = {
   module: `${baseRealm.url}catalog-entry`,

--- a/packages/runtime-common/module-syntax.ts
+++ b/packages/runtime-common/module-syntax.ts
@@ -19,7 +19,6 @@ import {
 } from './remove-field-plugin';
 import { ImportUtil } from 'babel-import-util';
 import camelCase from 'camelcase';
-import upperFirst from 'lodash/upperFirst';
 import isEqual from 'lodash/isEqual';
 import { parseTemplates } from '@cardstack/ember-template-imports/lib/parse-templates';
 import {
@@ -473,7 +472,7 @@ function suggestedCardName(
   if (name === 'default') {
     name = ref.module.split('/').pop()!;
   }
-  return upperFirst(camelCase(`${name} ${type}`));
+  return camelCase(`${name} ${type}`, { pascalCase: true });
 }
 
 function insertFieldBeforePath(

--- a/packages/runtime-common/module-syntax.ts
+++ b/packages/runtime-common/module-syntax.ts
@@ -18,7 +18,7 @@ import {
   Options as RemoveOptions,
 } from './remove-field-plugin';
 import { ImportUtil } from 'babel-import-util';
-import camelCase from 'lodash/camelCase';
+import camelCase from 'camelcase';
 import upperFirst from 'lodash/upperFirst';
 import isEqual from 'lodash/isEqual';
 import { parseTemplates } from '@cardstack/ember-template-imports/lib/parse-templates';

--- a/packages/runtime-common/package.json
+++ b/packages/runtime-common/package.json
@@ -58,6 +58,7 @@
     "@types/dompurify": "^3.0.2",
     "@types/js-string-escape": "^1.0.1",
     "@types/qunit": "^2.11.3",
+    "concurrently": "^8.2.2",
     "dompurify": "^3.0.3",
     "ember-cli-htmlbars": "^6.3.0"
   },
@@ -66,7 +67,9 @@
     "ember-cli-htmlbars": "^6.3.0"
   },
   "scripts": {
-    "lint": "eslint . --cache --ext ts",
-    "lint:js:fix": "eslint . --fix"
+    "lint": "concurrently \"pnpm:lint:*(!fix)\" --names \"lint:\"",
+    "lint:js": "eslint . ",
+    "lint:js:fix": "eslint . --fix",
+    "lint:types": "glint"
   }
 }

--- a/packages/runtime-common/package.json
+++ b/packages/runtime-common/package.json
@@ -29,6 +29,7 @@
     "@types/uuid": "^9.0.8",
     "babel-import-util": "^1.2.2",
     "babel-plugin-ember-template-compilation": "^2.2.1",
+    "camelcase": "^8.0.0",
     "date-fns": "^2.28.0",
     "diff": "^5.1.0",
     "ember-concurrency-async-plugin": "workspace:*",

--- a/packages/runtime-common/package.json
+++ b/packages/runtime-common/package.json
@@ -29,7 +29,7 @@
     "@types/uuid": "^9.0.8",
     "babel-import-util": "^1.2.2",
     "babel-plugin-ember-template-compilation": "^2.2.1",
-    "camelcase": "^8.0.0",
+    "camelcase": "^6.3.0",
     "date-fns": "^2.28.0",
     "diff": "^5.1.0",
     "ember-concurrency-async-plugin": "workspace:*",

--- a/packages/runtime-common/package.json
+++ b/packages/runtime-common/package.json
@@ -58,7 +58,6 @@
     "@types/dompurify": "^3.0.2",
     "@types/js-string-escape": "^1.0.1",
     "@types/qunit": "^2.11.3",
-    "concurrently": "^8.2.2",
     "dompurify": "^3.0.3",
     "ember-cli-htmlbars": "^6.3.0"
   },
@@ -67,9 +66,7 @@
     "ember-cli-htmlbars": "^6.3.0"
   },
   "scripts": {
-    "lint": "concurrently \"pnpm:lint:*(!fix)\" --names \"lint:\"",
-    "lint:js": "eslint . ",
-    "lint:js:fix": "eslint . --fix",
-    "lint:types": "glint"
+    "lint": "eslint . --cache --ext ts",
+    "lint:js:fix": "eslint . --fix"
   }
 }

--- a/packages/runtime-common/paths.ts
+++ b/packages/runtime-common/paths.ts
@@ -10,9 +10,6 @@ export class RealmPaths {
 
   local(url: URL, opts: LocalOptions = {}): LocalPath {
     if (!this.inRealm(url)) {
-      if (!url || !url.href || url.href.includes('undefined')) {
-        debugger;
-      }
       let error = new Error(`realm ${this.url} does not contain ${url.href}`);
       (error as any).status = 404;
       throw error;

--- a/packages/runtime-common/paths.ts
+++ b/packages/runtime-common/paths.ts
@@ -36,7 +36,7 @@ export class RealmPaths {
     local = local.replace(/\/+$/, '');
 
     // the LocalPath has no leading nor trailing slashes
-    return local;
+    return decodeURI(local);
   }
 
   fileURL(local: LocalPath): URL {

--- a/packages/runtime-common/paths.ts
+++ b/packages/runtime-common/paths.ts
@@ -4,20 +4,15 @@ interface LocalOptions {
 export class RealmPaths {
   readonly url: string;
 
-  constructor(realmURL: string | URL) {
-    this.url =
-      (typeof realmURL === 'string' ? realmURL : realmURL.href).replace(
-        /\/$/,
-        '',
-      ) + '/';
+  constructor(realmURL: URL) {
+    this.url = ensureTrailingSlash(decodeURI(realmURL.href));
   }
 
-  local(url: URL | string, opts: LocalOptions = {}): LocalPath {
-    if (typeof url === 'string') {
-      url = new URL(url);
-    }
-
+  local(url: URL, opts: LocalOptions = {}): LocalPath {
     if (!this.inRealm(url)) {
+      if (!url || !url.href || url.href.includes('undefined')) {
+        debugger;
+      }
       let error = new Error(`realm ${this.url} does not contain ${url.href}`);
       (error as any).status = 404;
       throw error;
@@ -25,18 +20,18 @@ export class RealmPaths {
 
     if (opts.preserveQuerystring !== true) {
       // strip query params
-      url = new URL(url.pathname, url);
+      url = new URL(decodeURI(url.pathname), url);
     }
 
     // this will always remove a leading slash because our constructor ensures
     // this.#realm has a trailing slash.
-    let local = url.href.slice(this.url.length);
+    let local = decodeURI(url.href).slice(this.url.length);
 
     // this will remove any trailing slashes
     local = local.replace(/\/+$/, '');
 
     // the LocalPath has no leading nor trailing slashes
-    return decodeURI(local);
+    return local;
   }
 
   fileURL(local: LocalPath): URL {
@@ -52,9 +47,10 @@ export class RealmPaths {
   }
 
   inRealm(url: URL): boolean {
+    let decodedHref = decodeURI(url.href);
     return (
-      url.href.startsWith(this.url) ||
-      url.href.split('?')[0] == this.url.replace(/\/$/, '') // check if url without querystring same as realm url without trailing slash (for detecting root realm urls with missing trailing slash)
+      decodedHref.startsWith(this.url) ||
+      decodedHref.split('?')[0] == this.url.replace(/\/$/, '') // check if url without querystring same as realm url without trailing slash (for detecting root realm urls with missing trailing slash)
     );
   }
 }
@@ -64,6 +60,10 @@ export function join(...pathParts: string[]): LocalPath {
     .map((p) => p.replace(/^\//, '').replace(/\/$/, ''))
     .filter(Boolean)
     .join('/');
+}
+
+function ensureTrailingSlash(realmUrlString: string) {
+  return realmUrlString.replace(/\/$/, '') + '/';
 }
 
 // Documenting that this represents a local path within realm, with no leading

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -287,7 +287,7 @@ export class Realm {
     },
     opts?: Options,
   ) {
-    this.paths = new RealmPaths(url);
+    this.paths = new RealmPaths(new URL(url));
     let { username, password, url: matrixURL } = matrix;
     this.#matrixClient = new MatrixClient(matrixURL, username, password);
     this.#permissions = permissions;
@@ -1093,7 +1093,7 @@ export class Realm {
 
   private async upsertCardSource(request: Request): Promise<Response> {
     let { lastModified } = await this.write(
-      this.paths.local(request.url),
+      this.paths.local(new URL(request.url)),
       await request.text(),
     );
     return createResponse(this, null, {
@@ -1105,7 +1105,7 @@ export class Realm {
   private async getCardSourceOrRedirect(
     request: Request,
   ): Promise<ResponseWithNodeStream> {
-    let localName = this.paths.local(request.url);
+    let localName = this.paths.local(new URL(request.url));
     let handle = await this.getFileWithFallbacks(localName, [
       ...executableExtensions,
       '.json',
@@ -1124,7 +1124,7 @@ export class Realm {
   }
 
   private async removeCardSource(request: Request): Promise<Response> {
-    let localName = this.paths.local(request.url);
+    let localName = this.paths.local(new URL(request.url));
     let handle = await this.getFileWithFallbacks(localName, [
       ...executableExtensions,
       '.json',
@@ -1281,7 +1281,7 @@ export class Realm {
   }
 
   private async patchCard(request: Request): Promise<Response> {
-    let localPath = this.paths.local(request.url);
+    let localPath = this.paths.local(new URL(request.url));
     if (localPath.startsWith('_')) {
       return methodNotAllowed(this, request);
     }
@@ -1372,7 +1372,7 @@ export class Realm {
   }
 
   private async getCard(request: Request): Promise<Response> {
-    let localPath = this.paths.local(request.url);
+    let localPath = this.paths.local(new URL(request.url));
     if (localPath === '') {
       localPath = 'index';
     }
@@ -1468,7 +1468,7 @@ export class Realm {
 
   private async getDirectoryListing(request: Request): Promise<Response> {
     // a LocalPath has no leading nor trailing slash
-    let localPath: LocalPath = this.paths.local(request.url);
+    let localPath: LocalPath = this.paths.local(new URL(request.url));
     let url = this.paths.directoryURL(localPath);
     let entries = await this.directoryEntries(url);
     if (!entries) {

--- a/packages/runtime-common/router.ts
+++ b/packages/runtime-common/router.ts
@@ -63,7 +63,7 @@ export function lookupRouteTable<T>(
   }
 
   // we construct a new URL within RealmPath.local() param that strips off the query string
-  let requestPath = `/${paths.local(request.url)}`;
+  let requestPath = `/${paths.local(new URL(request.url))}`;
   // add a leading and trailing slashes back so we can match on routing rules for directories.
   requestPath =
     request.url.endsWith('/') && requestPath !== '/'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1142,8 +1142,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       camelcase:
-        specifier: ^8.0.0
-        version: 8.0.0
+        specifier: ^6.3.0
+        version: 6.3.0
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
@@ -1721,8 +1721,8 @@ importers:
         specifier: ^2.2.1
         version: 2.2.1
       camelcase:
-        specifier: ^8.0.0
-        version: 8.0.0
+        specifier: ^6.3.0
+        version: 6.3.0
       date-fns:
         specifier: ^2.28.0
         version: 2.28.0
@@ -9020,13 +9020,13 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
+
   /camelcase@7.0.1:
     resolution: {integrity: sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==}
     engines: {node: '>=14.16'}
-
-  /camelcase@8.0.0:
-    resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
-    engines: {node: '>=16'}
 
   /can-symlink@1.0.0:
     resolution: {integrity: sha512-RbsNrFyhwkx+6psk/0fK/Q9orOUr9VMxohGd8vTa4djf4TGLfblBgUfqZChrZuW0Q+mz2eBPFLusw9Jfukzmhg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1802,6 +1802,9 @@ importers:
       '@types/qunit':
         specifier: ^2.11.3
         version: 2.11.3
+      concurrently:
+        specifier: ^8.2.2
+        version: 8.2.2
       dompurify:
         specifier: ^3.0.3
         version: 3.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 overrides:
   '@types/eslint': 8.4.1
   '@embroider/util': 1.12.0
@@ -1137,6 +1141,9 @@ importers:
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
+      camelcase:
+        specifier: ^8.0.0
+        version: 8.0.0
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
@@ -1713,6 +1720,9 @@ importers:
       babel-plugin-ember-template-compilation:
         specifier: ^2.2.1
         version: 2.2.1
+      camelcase:
+        specifier: ^8.0.0
+        version: 8.0.0
       date-fns:
         specifier: ^2.28.0
         version: 2.28.0
@@ -4427,7 +4437,7 @@ packages:
       '@types/ember__object': ^4.0.4
       '@types/ember__routing': ^4.0.11
       ember-cli-htmlbars: ^6.0.1
-      ember-modifier: ^3.2.7 || ^4.0.0
+      ember-modifier: ^4.1.0
     peerDependenciesMeta:
       '@types/ember__array':
         optional: true
@@ -5068,7 +5078,7 @@ packages:
   /@prettier/sync@0.2.1(prettier@3.1.0-dev):
     resolution: {integrity: sha512-7ls1R6//+GPYD9vof1XaL5psViv83CwpdwlS8oUkWldYgbPhzZ3WgxIQMWqGyBmWPmoBfQg8C7jj7KI/ZuDHhQ==}
     peerDependencies:
-      prettier: ^3.0.0
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     dependencies:
       prettier: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
     dev: true
@@ -9014,6 +9024,10 @@ packages:
     resolution: {integrity: sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==}
     engines: {node: '>=14.16'}
 
+  /camelcase@8.0.0:
+    resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
+    engines: {node: '>=16'}
+
   /can-symlink@1.0.0:
     resolution: {integrity: sha512-RbsNrFyhwkx+6psk/0fK/Q9orOUr9VMxohGd8vTa4djf4TGLfblBgUfqZChrZuW0Q+mz2eBPFLusw9Jfukzmhg==}
     hasBin: true
@@ -12441,7 +12455,7 @@ packages:
     engines: {node: ^16.0.0 || ^18.0.0 || >=20.0.0}
     peerDependencies:
       ember-template-lint: '>= 4.0.0'
-      prettier: '>= 3.0.0'
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     dependencies:
       '@prettier/sync': 0.2.1(prettier@3.1.0-dev)
       ember-template-lint: 5.11.2
@@ -12635,7 +12649,7 @@ packages:
     resolution: {integrity: sha512-4V6rT9b9XSeMaPmiYYA2hIhfMD088vru6AvfGWBY7L1w/st5hYv6iIfamy9+W1l9xKvIH3Hcl8+B0637/SRmzQ==}
     engines: {node: 14.* || >= 16}
     peerDependencies:
-      ember-modifier: ^3.2.7 || >= 4.0.0
+      ember-modifier: ^4.1.0
       ember-source: ^3.28.0 || ^4.0.0 || >= 5.0.0
     dependencies:
       '@embroider/addon-shim': 1.8.7
@@ -13294,7 +13308,7 @@ packages:
     peerDependencies:
       eslint: '>=5.0.0'
       eslint-config-prettier: '*'
-      prettier: '>=1.13.0'
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     peerDependenciesMeta:
       eslint-config-prettier:
         optional: true
@@ -13309,10 +13323,10 @@ packages:
     resolution: {integrity: sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      '@types/eslint': '>=8.0.0'
+      '@types/eslint': 8.4.1
       eslint: '>=8.0.0'
       eslint-config-prettier: '*'
-      prettier: '>=3.0.0'
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     peerDependenciesMeta:
       '@types/eslint':
         optional: true
@@ -13330,10 +13344,10 @@ packages:
     resolution: {integrity: sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      '@types/eslint': '>=8.0.0'
+      '@types/eslint': 8.4.1
       eslint: '>=8.0.0'
       eslint-config-prettier: '*'
-      prettier: '>=3.0.0'
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     peerDependenciesMeta:
       '@types/eslint':
         optional: true
@@ -13351,10 +13365,10 @@ packages:
     resolution: {integrity: sha512-C9GCVAs4Eq7ZC/XFQHITLiHJxQngdtraXaM+LoUFoFp/lHNl2Zn8f3WQbe9HvTBBQ9YnKFB0/2Ajdqwo5D1EAw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      '@types/eslint': '>=8.0.0'
+      '@types/eslint': 8.4.1
       eslint: '>=8.0.0'
       eslint-config-prettier: '*'
-      prettier: '>=3.0.0'
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     peerDependenciesMeta:
       '@types/eslint':
         optional: true
@@ -19336,7 +19350,7 @@ packages:
     resolution: {integrity: sha512-zJTC+NhEU0kHNnVh7OtcvMmkJmYTgFTist76FP9q07m9+WCvcaunR1sTFIOlGE9TH/5UGm6rlF86Umt9ouorAg==}
     engines: {node: 16.* || 18.* || >= 20}
     peerDependencies:
-      prettier: '>= 3.0.0'
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     dependencies:
       '@babel/core': 7.24.3(supports-color@8.1.1)
       '@glimmer/syntax': 0.84.3
@@ -23460,7 +23474,3 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1802,9 +1802,6 @@ importers:
       '@types/qunit':
         specifier: ^2.11.3
         version: 2.11.3
-      concurrently:
-        specifier: ^8.2.2
-        version: 8.2.2
       dompurify:
         specifier: ^3.0.3
         version: 3.0.3


### PR DESCRIPTION
This fixes file creation to support characters that are valid as part of file and identifier names that were previously being stripped. It also leaves the display name alone.

![screencast 2024-04-30 10-26-23](https://github.com/cardstack/boxel/assets/43280/4f3e7365-323e-4f69-a909-897a125c4b11)

Since URL handling and display is scattered across the application, this introduces a convention for consistency:
* if the object is a URL it’s encoded, so `…/hé` becomes `…/h%C3%A9`
* if it’s a string (or its alias `LocalPath`) it’s the result of `decodeURI`
 
This does mean that conversions from URL to string need to include that, if we find that it’s not being used properly, we can look into how to enforce it more consistently, maybe with a type. But `RealmPaths` now only accepts URLs which should help facilitate this.