### PR TITLE
Reaction event refactor

### DIFF
--- a/packages/base/room.gts
+++ b/packages/base/room.gts
@@ -247,11 +247,18 @@ class CommandType extends FieldDef {
   static [primitive]: 'patch';
 }
 
+type CommandStatus = 'applied' | 'ready';
+
+class CommandStatusField extends FieldDef {
+  static [primitive]: CommandStatus;
+}
+
 // Subclass, add a validator that checks the fields required?
 class PatchField extends FieldDef {
   @field commandType = contains(CommandType);
   @field payload = contains(PatchObjectField);
   @field eventId = contains(StringField);
+  @field status = contains(CommandStatusField);
 }
 
 // A map from a hash of roomId + card document to the first card fragment event id.
@@ -577,6 +584,13 @@ export class RoomField extends FieldDef {
               `cannot handle commands in room with type ${command.type}`,
             );
           }
+          let annotation = this.events.find(
+            (e) =>
+              e.type === 'm.reaction' &&
+              e.content['m.relates_to']?.rel_type === 'm.annotation' &&
+              e.content['m.relates_to']?.event_id === command.eventId,
+          ) as ReactionEvent | undefined;
+
           messageField = new MessageField({
             ...cardArgs,
             formattedMessage: `<p class="patch-message">${event.content.formatted_body}</p>`,
@@ -584,6 +598,7 @@ export class RoomField extends FieldDef {
               eventId: event_id,
               commandType: command.type,
               payload: command,
+              status: annotation?.content['m.relates_to'].key ?? 'ready',
             }),
             isStreamingFinished: true,
           });

--- a/packages/host/app/components/matrix/room-message.gts
+++ b/packages/host/app/components/matrix/room-message.gts
@@ -318,7 +318,7 @@ export default class RoomMessage extends Component<Signature> {
     if (this.patchCard.isRunning) {
       return 'applying';
     }
-    if (this.patchCardError) {
+    if (this.errorMessage) {
       return 'failed';
     }
     return this.args.message.command.status;

--- a/packages/host/app/components/matrix/room-message.gts
+++ b/packages/host/app/components/matrix/room-message.gts
@@ -313,7 +313,7 @@ export default class RoomMessage extends Component<Signature> {
   @cached
   private get failedCommandState() {
     if (!this.args.message.command?.eventId) {
-      return;
+      return undefined;
     }
     return this.matrixService.failedCommandState.get(
       this.args.message.command.eventId,

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -49,7 +49,6 @@ import type {
   CardMessageContent,
   CardFragmentContent,
   ReactionEventContent,
-  ReactionEvent,
 } from 'https://cardstack.com/base/room';
 
 import { Timeline, Membership, addRoomEvent } from '../lib/matrix-handlers';
@@ -391,27 +390,6 @@ export default class MatrixService extends Service {
         }`,
       );
     }
-  }
-
-  async getReactionKeyForEvent(roomId: string, eventId: string) {
-    let room = await this.rooms.get(roomId);
-    if (!room) {
-      throw new Error(`Room ${roomId} not found`);
-    }
-
-    let event = room.events
-      .filter(
-        (e) =>
-          e.type === 'm.reaction' &&
-          e.content['m.relates_to'].rel_type === 'm.annotation' &&
-          e.content['m.relates_to'].event_id === eventId,
-      )
-      .sort((a, b) => b.origin_server_ts - a.origin_server_ts)[0];
-    if (!event) {
-      return;
-    }
-
-    return (event as ReactionEvent).content['m.relates_to'].key;
   }
 
   async sendMessage(

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -85,6 +85,7 @@ export default class MatrixService extends Service {
   rooms: TrackedMap<string, Promise<RoomField>> = new TrackedMap();
   messagesToSend: TrackedMap<string, string | undefined> = new TrackedMap();
   cardsToSend: TrackedMap<string, CardDef[] | undefined> = new TrackedMap();
+  failedCommandState: TrackedMap<string, Error> = new TrackedMap();
   flushTimeline: Promise<void> | undefined;
   flushMembership: Promise<void> | undefined;
   roomMembershipQueue: { event: MatrixEvent; member: RoomMember }[] = [];

--- a/packages/host/tests/helpers/mock-matrix-service.ts
+++ b/packages/host/tests/helpers/mock-matrix-service.ts
@@ -84,6 +84,7 @@ function generateMockMatrixService(
 
     messagesToSend: TrackedMap<string, string | undefined> = new TrackedMap();
     cardsToSend: TrackedMap<string, CardDef[] | undefined> = new TrackedMap();
+    failedCommandState: TrackedMap<string, Error> = new TrackedMap();
 
     async start(_auth?: any) {}
 

--- a/packages/host/tests/helpers/mock-matrix-service.ts
+++ b/packages/host/tests/helpers/mock-matrix-service.ts
@@ -16,7 +16,6 @@ import { OperatorModeContext } from '@cardstack/host/services/matrix-service';
 import { CardDef } from 'https://cardstack.com/base/card-api';
 import type {
   RoomField,
-  ReactionEvent,
   ReactionEventContent,
 } from 'https://cardstack.com/base/room';
 
@@ -152,34 +151,12 @@ function generateMockMatrixService(
       }
     }
 
-    async getReactionKeyForEvent(roomId: string, eventId: string) {
-      let room = await this.rooms.get(roomId);
-      if (!room) {
-        throw new Error(`Room ${roomId} not found`);
-      }
-
-      let event = room.events
-        .filter(
-          (e) =>
-            e.type === 'm.reaction' &&
-            e.content['m.relates_to'].rel_type === 'm.annotation' &&
-            e.content['m.relates_to'].event_id === eventId,
-        )
-        .sort((a, b) => b.origin_server_ts - a.origin_server_ts)[0];
-      if (!event) {
-        return;
-      }
-
-      return (event as ReactionEvent).content['m.relates_to'].key;
-    }
-
     async sendEvent(roomId: string, eventType: string, content: any) {
       await addRoomEvent(this, {
         event_id: uuid(),
         room_id: roomId,
         type: eventType,
-        sender: '@testuser:staging',
-        state_key: '@testuser:staging',
+        sender: this.userId,
         origin_server_ts: Date.now(),
         content,
         status: null,

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -768,8 +768,13 @@ module('Integration | operator-mode', function (hooks) {
               patch: {
                 attributes: { firstName: 'Dave' },
               },
+              eventId: 'patch1',
             },
           }),
+          'm.relates_to': {
+            rel_type: 'm.replace',
+            event_id: 'patch1',
+          },
         },
         status: null,
       });
@@ -922,8 +927,8 @@ module('Integration | operator-mode', function (hooks) {
       await click(`[data-test-enter-room="room2"]`);
       await waitFor('[data-test-room-name="test room 2"]');
       assert
-        .dom('[data-test-message-idx="0"] [data-test-apply-state="ready"]')
-        .exists('failed state is not saved');
+        .dom('[data-test-message-idx="0"] [data-test-apply-state="failed"]')
+        .exists();
     });
 
     test('it allows only applies changes from the chat if the stack contains a card with that ID', async function (assert) {
@@ -1085,7 +1090,7 @@ module('Integration | operator-mode', function (hooks) {
       await waitFor('[data-test-person="Fadhlan"]');
 
       let roomId = await openAiAssistant();
-      addRoomEvent(matrixService, {
+      await addRoomEvent(matrixService, {
         event_id: 'event1',
         room_id: roomId,
         state_key: 'state',
@@ -1101,8 +1106,13 @@ module('Integration | operator-mode', function (hooks) {
               type: 'patch',
               id,
               patch: { attributes: { pet: null } },
+              eventId: 'patch1',
             },
           }),
+          'm.relates_to': {
+            rel_type: 'm.replace',
+            event_id: 'patch1',
+          },
         },
         status: null,
       });
@@ -1116,7 +1126,7 @@ module('Integration | operator-mode', function (hooks) {
           `Failed to apply changes. The "pet" attribute does not exist on the card "${id}".`,
         );
 
-      addRoomEvent(matrixService, {
+      await addRoomEvent(matrixService, {
         event_id: 'event2',
         room_id: roomId,
         state_key: 'state',
@@ -1132,8 +1142,13 @@ module('Integration | operator-mode', function (hooks) {
               type: 'patch',
               id,
               patch: { attributes: {} },
+              eventId: 'patch2',
             },
           }),
+          'm.relates_to': {
+            rel_type: 'm.replace',
+            event_id: 'patch2',
+          },
         },
         status: null,
       });
@@ -1147,7 +1162,7 @@ module('Integration | operator-mode', function (hooks) {
         .dom(`[data-test-message-idx="1"] [data-test-card-error]`)
         .hasText(`Failed to apply changes. Patch failed.`);
 
-      addRoomEvent(matrixService, {
+      await addRoomEvent(matrixService, {
         event_id: 'event3',
         room_id: roomId,
         state_key: 'state',
@@ -1170,8 +1185,13 @@ module('Integration | operator-mode', function (hooks) {
                   },
                 },
               },
+              eventId: 'patch3',
             },
           }),
+          'm.relates_to': {
+            rel_type: 'm.replace',
+            event_id: 'patch3',
+          },
         },
         status: null,
       });
@@ -1920,8 +1940,13 @@ module('Integration | operator-mode', function (hooks) {
               patch: {
                 attributes: { firstName: 'Dave' },
               },
+              eventId: 'patch1',
             },
           }),
+          'm.relates_to': {
+            rel_type: 'm.replace',
+            event_id: 'patch1',
+          },
         },
         status: null,
       });

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -816,8 +816,13 @@ module('Integration | operator-mode', function (hooks) {
               type: 'patch',
               id: `${testRealmURL}Person/fadhlan`,
               patch: { attributes: { firstName: 'Evie' } },
+              eventId: 'room1-event1',
             },
           }),
+          'm.relates_to': {
+            rel_type: 'm.replace',
+            event_id: 'room1-event1',
+          },
         },
         status: null,
       });
@@ -837,8 +842,13 @@ module('Integration | operator-mode', function (hooks) {
               type: 'patch',
               id: `${testRealmURL}Person/fadhlan`,
               patch: { attributes: { firstName: 'Jackie' } },
+              eventId: 'room1-event2',
             },
           }),
+          'm.relates_to': {
+            rel_type: 'm.replace',
+            event_id: 'room1-event2',
+          },
         },
         status: null,
       });
@@ -858,8 +868,13 @@ module('Integration | operator-mode', function (hooks) {
               type: 'patch',
               id: `${testRealmURL}Person/fadhlan`,
               patch: { attributes: { pet: null } },
+              eventId: 'room2-event1',
             },
           }),
+          'm.relates_to': {
+            rel_type: 'm.replace',
+            event_id: 'room2-event1',
+          },
         },
         status: null,
       });
@@ -869,6 +884,7 @@ module('Integration | operator-mode', function (hooks) {
       await waitFor('[data-test-message-idx="1"] [data-test-command-apply]');
       await click('[data-test-message-idx="1"] [data-test-command-apply]');
       await waitFor('[data-test-patch-card-idle]');
+
       assert
         .dom('[data-test-message-idx="1"] [data-test-apply-state="applied"]')
         .exists();
@@ -906,8 +922,8 @@ module('Integration | operator-mode', function (hooks) {
       await click(`[data-test-enter-room="room2"]`);
       await waitFor('[data-test-room-name="test room 2"]');
       assert
-        .dom('[data-test-message-idx="0"] [data-test-apply-state="failed"]')
-        .exists();
+        .dom('[data-test-message-idx="0"] [data-test-apply-state="ready"]')
+        .exists('failed state is not saved');
     });
 
     test('it allows only applies changes from the chat if the stack contains a card with that ID', async function (assert) {
@@ -946,8 +962,13 @@ module('Integration | operator-mode', function (hooks) {
               patch: {
                 attributes: { firstName: 'Dave' },
               },
+              eventId: 'event1',
             },
           }),
+          'm.relates_to': {
+            rel_type: 'm.replace',
+            event_id: 'event1',
+          },
         },
         status: null,
       });
@@ -1003,8 +1024,9 @@ module('Integration | operator-mode', function (hooks) {
             address: { shippingInfo: { preferredCarrier: 'UPS' } },
           },
         },
+        eventId: 'event1',
       };
-      addRoomEvent(matrixService, {
+      await addRoomEvent(matrixService, {
         event_id: 'event1',
         room_id: roomId,
         state_key: 'state',
@@ -1017,6 +1039,10 @@ module('Integration | operator-mode', function (hooks) {
           formatted_body: 'A patch',
           format: 'org.matrix.custom.html',
           data: JSON.stringify({ command: payload }),
+          'm.relates_to': {
+            rel_type: 'm.replace',
+            event_id: 'event1',
+          },
         },
         status: null,
       });
@@ -1191,8 +1217,13 @@ module('Integration | operator-mode', function (hooks) {
               type: 'patch',
               id,
               patch: { attributes: { firstName: 'Dave' } },
+              eventId: 'event1',
             },
           }),
+          'm.relates_to': {
+            rel_type: 'm.replace',
+            event_id: 'event1',
+          },
         },
         status: null,
       });
@@ -1212,8 +1243,13 @@ module('Integration | operator-mode', function (hooks) {
               type: 'patch',
               id,
               patch: { attributes: { pet: 'Harry' } },
+              eventId: 'event2',
             },
           }),
+          'm.relates_to': {
+            rel_type: 'm.replace',
+            event_id: 'event2',
+          },
         },
         status: null,
       });
@@ -1233,8 +1269,13 @@ module('Integration | operator-mode', function (hooks) {
               type: 'patch',
               id,
               patch: { attributes: { firstName: 'Jackie' } },
+              eventId: 'event3',
             },
           }),
+          'm.relates_to': {
+            rel_type: 'm.replace',
+            event_id: 'event3',
+          },
         },
         status: null,
       });


### PR DESCRIPTION
Changes:
- only send reaction events for successful Apply commands
- save errors only temporarily in runtime
- update host tests to better mimic command events from ai-bot