### PR TITLE
Fix card saving related bugs in Firefox

### DIFF
--- a/packages/host/app/services/loader-service.ts
+++ b/packages/host/app/services/loader-service.ts
@@ -92,18 +92,8 @@ export default class LoaderService extends Service {
     }
 
     request.headers.set('Authorization', realmSession.rawRealmToken);
-    let body;
-    if (request.body && !request.bodyUsed) {
-      body =
-        request.headers.get('content-type') === 'application/json'
-          ? JSON.stringify(await request.json())
-          : await request.text();
-    }
-    let response = await this.loader.fetch(request.url, {
-      method: request.method,
-      headers: new Headers(request.headers),
-      body,
-    });
+
+    let response = await this.loader.fetch(request);
 
     // We will get a 401 from the server in three cases. When the token is invalid,
     // the JWT is expired, and the permissions in the JWT payload differ
@@ -115,11 +105,7 @@ export default class LoaderService extends Service {
         return null;
       }
       request.headers.set('Authorization', realmSession.rawRealmToken);
-      response = await this.loader.fetch(request.url, {
-        method: request.method,
-        headers: new Headers(request.headers),
-        body,
-      });
+      response = await this.loader.fetch(request);
     }
 
     return response;

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -58,16 +58,12 @@ module('Acceptance | interact submode tests', function (hooks) {
           res: null,
         });
       }
-      let { headers, method } = req;
-      let body = await req.text();
+
+      let body = await req.clone().text();
       let res = onFetch(req, body) ?? null;
-      // need to return a new request since we just read the body
+
       return {
-        req: new Request(req.url, {
-          method,
-          headers,
-          ...(body ? { body } : {}),
-        }),
+        req,
         res,
       };
     };
@@ -974,7 +970,7 @@ module('Acceptance | interact submode tests', function (hooks) {
           realmPermissions = { [testRealmURL]: ['read'] };
         });
 
-        test('retrieve a new JWT if recevive 401 error', async function (assert) {
+        test('retrieve a new JWT on  401 error', async function (assert) {
           let token = createJWT(
             {
               user: '@testuser:staging',

--- a/packages/host/tests/integration/components/card-copy-test.gts
+++ b/packages/host/tests/integration/components/card-copy-test.gts
@@ -55,16 +55,11 @@ module('Integration | card-copy', function (hooks) {
       if (!onFetch) {
         return Promise.resolve({ req, res: null });
       }
-      let { headers, method } = req;
-      let body = await req.text();
+
+      let body = await req.clone().text();
       onFetch(req, body);
-      // need to return a new request since we just read the body
       return {
-        req: new Request(req.url, {
-          method,
-          headers,
-          ...(body ? { body } : {}),
-        }),
+        req,
         res: null,
       };
     };

--- a/packages/runtime-common/virtual-network.ts
+++ b/packages/runtime-common/virtual-network.ts
@@ -207,31 +207,6 @@ function isUrlLike(moduleIdentifier: string): boolean {
   );
 }
 
-async function getContentOfReadableStream(
-  requestBody: ReadableStream<Uint8Array> | null,
-): Promise<Uint8Array | null> {
-  if (requestBody) {
-    let isPending = true;
-    let arrayLength = 0;
-    let unit8Arrays = [];
-    let reader = requestBody.getReader();
-    do {
-      let readableResults = await reader.read();
-
-      if (readableResults.value) {
-        arrayLength += readableResults.value.length;
-        unit8Arrays.push(readableResults.value);
-      }
-
-      isPending = !readableResults.done;
-    } while (isPending);
-    let mergedArray = new Uint8Array(arrayLength);
-    unit8Arrays.forEach((array) => mergedArray.set(array));
-    return mergedArray;
-  }
-  return null;
-}
-
 async function buildRequest(url: string, originalRequest: Request) {
   if (url === originalRequest.url) {
     return originalRequest;

--- a/packages/runtime-common/virtual-network.ts
+++ b/packages/runtime-common/virtual-network.ts
@@ -240,7 +240,7 @@ async function buildRequest(url: string, originalRequest: Request) {
   // To reach the goal of creating a new Request but with a different url it is
   // usually enough to create a new Request object with the new url and the same
   // properties as the original request, but there are issues when the body is
-  // a ReadableStream - browser reports the following error:
+  // a ReadableStream - Chrome browseer, for example, reports the following error:
   // "TypeError: Failed to construct 'Request': The `duplex` member must be
   // specified for a request with a streaming body." Even adding the `duplex`
   // property will not fix the issue - the browser request being made to
@@ -250,9 +250,11 @@ async function buildRequest(url: string, originalRequest: Request) {
   // the new url and the body as a Uint8Array.
 
   let body = null;
-  if (originalRequest.body) {
-    body = await getContentOfReadableStream(originalRequest.clone().body);
+
+  if (['POST', 'PUT', 'PATCH'].includes(originalRequest.method)) {
+    body = await originalRequest.clone().text();
   }
+
   return new Request(url, {
     method: originalRequest.method,
     headers: originalRequest.headers,

--- a/packages/runtime-common/virtual-network.ts
+++ b/packages/runtime-common/virtual-network.ts
@@ -215,7 +215,7 @@ async function buildRequest(url: string, originalRequest: Request) {
   // To reach the goal of creating a new Request but with a different url it is
   // usually enough to create a new Request object with the new url and the same
   // properties as the original request, but there are issues when the body is
-  // a ReadableStream - Chrome browseer, for example, reports the following error:
+  // a ReadableStream - Chrome browser, for example, reports the following error:
   // "TypeError: Failed to construct 'Request': The `duplex` member must be
   // specified for a request with a streaming body." Even adding the `duplex`
   // property will not fix the issue - the browser request being made to


### PR DESCRIPTION
I was researching why our recent percy builds started to fail with ["Some snapshots in this build took too long to render even after multiple retries."](https://percy.io/Cardstack-1/-cardstack-host/builds/33961724/failed-snapshots/1858965283) errors...failures say these failed tests failed to render (timed out) in Firefox, so I took a look at how things look in that browser. 

I discovered creating and saving files in Firefox didn't work (due to https://github.com/cardstack/boxel/pull/1208#discussion_r1584384242):

![image](https://github.com/cardstack/boxel/assets/273660/74e59582-cfbe-4cdd-9f83-77c724281e39)

This unfortunately didn't actually fix percy failures I was trying to fix, but it's still a critical bug fix. 