### PR TITLE
Pin to v3.1 of smtp4dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ node_modules
 .tmp
 .dist
 /junit
+/playwright-report
 .eslintcache
 schema_tmp.sql

--- a/packages/matrix/docker/smtp4dev.ts
+++ b/packages/matrix/docker/smtp4dev.ts
@@ -16,7 +16,7 @@ export async function smtpStart(opts?: Options) {
   let portMapping = `${mailClientPort}:80`;
   await dockerCreateNetwork({ networkName: 'boxel' });
   const containerId = await dockerRun({
-    image: 'rnwood/smtp4dev',
+    image: 'rnwood/smtp4dev:v3.1',
     containerName: 'boxel-smtp',
     dockerParams: ['-p', portMapping, '--network=boxel'],
   });


### PR DESCRIPTION
the docker hub image of the smtp dev server that we use for testing has been updated (we were not pinned to a particular version for this image). this PR pins us back to the version we were using.