### PR TITLE
Embedded Google Maps card

### DIFF
--- a/packages/drafts-realm/Map/20ad25ba-de18-40dc-979e-4603f62b5a2b.json
+++ b/packages/drafts-realm/Map/20ad25ba-de18-40dc-979e-4603f62b5a2b.json
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "address": "Livarska Ulica 10, Ljubljana, Slovenia",
+      "mapWidth": 600,
+      "mapHeight": 400,
+      "title": null,
+      "description": null,
+      "thumbnailURL": null
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../map",
+        "name": "Map"
+      }
+    }
+  }
+}

--- a/packages/drafts-realm/map.gts
+++ b/packages/drafts-realm/map.gts
@@ -1,0 +1,52 @@
+import NumberField from 'https://cardstack.com/base/number';
+import {
+  CardDef,
+  field,
+  contains,
+  StringField,
+} from 'https://cardstack.com/base/card-api';
+import { Component } from 'https://cardstack.com/base/card-api';
+
+function or(value: number | undefined, defaultValue: number) {
+  return value || defaultValue;
+}
+
+export class Map extends CardDef {
+  static displayName = 'Map';
+
+  @field address = contains(StringField);
+
+  @field mapUrl = contains(StringField, {
+    computeVia: function (this: Map) {
+      return `https://maps.google.com/maps?q=${this.address}&t=&z=13&ie=UTF8&iwloc=&output=embed`;
+    },
+  });
+  @field mapWidth = contains(NumberField);
+  @field mapHeight = contains(NumberField);
+
+  static isolated = class Isolated extends Component<typeof this> {
+    <template>
+      <div class='gmap_canvas'><iframe
+          id='gmap_canvas'
+          width={{or @model.mapWidth 600}}
+          height={{or @model.mapHeight 400}}
+          src={{@model.mapUrl}}
+          frameborder='0'
+          scrolling='no'
+          marginheight='0'
+          marginwidth='0'
+        ></iframe></div>
+    </template>
+  };
+
+  static atom = class Atom extends Component<typeof this> {
+    <template>
+      <a
+        href='https://www.google.com/maps/place/{{@model.address}}'
+        target='_blank'
+      >📍 {{@model.address}}</a>
+    </template>
+  };
+
+  static embedded = this.isolated;
+}


### PR DESCRIPTION
This PR adds a useful card - embedded google maps card, it shows a map that renders the provided address in an iframe. 

Isolated and embedded:
<img width="1540" alt="image" src="https://github.com/cardstack/boxel/assets/273660/732c67c5-3d38-4653-9aa0-22824d4033b7">

Atom (it's a external link to open the map):
<img width="329" alt="image" src="https://github.com/cardstack/boxel/assets/273660/246cb081-854f-4dc4-a23a-cab8113dea52">
