### PR TITLE
Make chatbot adding triple backticks to json structures

### DIFF
--- a/packages/ai-bot/helpers.ts
+++ b/packages/ai-bot/helpers.ts
@@ -19,7 +19,8 @@ If the user request is unclear, you may ask clarifying questions. \
 You may make multiple function calls, all calls are gated by the user so multiple options can be explored.\
 If a user asks you about things in the world, use your existing knowledge to help them. Only if necessary, add a *small* caveat at the end of your message to explain that you do not have live external data. \
 \
-If you need access to the cards the user can see, you can ask them to attach the cards.';
+If you need access to the cards the user can see, you can ask them to attach the cards. \
+If you encounter JSON structures, please enclose them within backticks to ensure they are displayed stylishly in Markdown.';
 
 type CommandMessage = {
   type: 'command';
@@ -319,8 +320,6 @@ export function getModifyPrompt(
 
 export function cleanContent(content: string) {
   content = content.trim();
-  content = content.replace(/```json/g, '');
-  content = content.replace(/`/g, '');
   if (content.endsWith('json')) {
     content = content.slice(0, -4);
   }

--- a/packages/ai-bot/tests/response-parsing-test.ts
+++ b/packages/ai-bot/tests/response-parsing-test.ts
@@ -9,20 +9,6 @@ module('processStream', () => {
     assert.equal(result, expectedResult);
   });
 
-  test('should be able to remove markdown block quote delimiters', () => {
-    const input = 'Next there is some json in ```json { "a": "json" } ```';
-    const expectedResult = 'Next there is some json in  { "a": "json" }';
-    const result = cleanContent(input);
-    assert.equal(result, expectedResult);
-  });
-
-  test('should remove all backticks', () => {
-    const input = 'Next there is some json in ``';
-    const expectedResult = 'Next there is some json in';
-    const result = cleanContent(input);
-    assert.equal(result, expectedResult);
-  });
-
   test('should not have just json at the end', () => {
     const input = 'Here is the option: json';
     const expectedResult = 'Here is the option:';


### PR DESCRIPTION
Adding ` ```json {} ``` ` to JSON structures ensures they are displayed with a distinct style from the surrounding message text.

<img width="321" alt="Screenshot 2024-05-07 at 19 09 40" src="https://github.com/cardstack/boxel/assets/12637010/cec44187-3329-48cd-8734-f09ca8d37b55">
