### PR TITLE
Fix issue where bad link during indexing triggers render cycle

### DIFF
--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -555,10 +555,7 @@ export class CurrentRun {
           deps: new Set(await this.loader.getConsumedModules(moduleURL)),
         },
       });
-      deferred.fulfill();
-    }
-
-    if (uncaughtError || typesMaybeError?.type === 'error') {
+    } else if (uncaughtError || typesMaybeError?.type === 'error') {
       let error: SearchEntryWithErrors;
       if (uncaughtError) {
         error = {
@@ -585,8 +582,8 @@ export class CurrentRun {
         `encountered error indexing card instance ${path}: ${error.error.detail}`,
       );
       await this.setInstance(instanceURL, error);
-      deferred.fulfill();
     }
+    deferred.fulfill();
   }
 
   private async setInstance(instanceURL: URL, entry: SearchEntryWithErrors) {

--- a/packages/host/app/services/render-service.ts
+++ b/packages/host/app/services/render-service.ts
@@ -140,7 +140,7 @@ export default class RenderService extends Service {
         let notLoaded = err.additionalErrors?.find((e: any) =>
           isNotLoadedError(e),
         ) as NotLoaded | undefined;
-        if (isCardError(err) && notLoaded) {
+        if (isCardError(err) && err.status !== 500 && notLoaded) {
           let linkURL = new URL(`${notLoaded.reference}.json`);
           if (realmPath.inRealm(linkURL)) {
             await visit(linkURL, identityContext);

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -185,6 +185,26 @@ module('indexing', function (hooks) {
               },
             },
           },
+          'bad-link.json': {
+            data: {
+              attributes: {
+                message: 'I have a bad link',
+              },
+              relationships: {
+                author: {
+                  links: {
+                    self: 'http://localhost:9000/this-is-a-link-to-nowhere',
+                  },
+                },
+              },
+              meta: {
+                adoptsFrom: {
+                  module: './post',
+                  name: 'Post',
+                },
+              },
+            },
+          },
           'boom.json': {
             data: {
               attributes: {
@@ -257,6 +277,22 @@ module('indexing', function (hooks) {
           `expected search entry to be a document but was: ${entry?.error.detail}`,
         );
       }
+    }
+  });
+
+  test('can make an error doc for a card that has a link to a URL that is not a card', async function (assert) {
+    let entry = await realm.searchIndex.card(new URL(`${testRealm}bad-link`));
+    if (entry?.type === 'error') {
+      assert.strictEqual(
+        entry.error.detail,
+        'unable to fetch http://localhost:9000/this-is-a-link-to-nowhere: fetch failed for http://localhost:9000/this-is-a-link-to-nowhere',
+      );
+      assert.deepEqual(entry.error.deps, [
+        `${testRealm}post`,
+        `http://localhost:9000/this-is-a-link-to-nowhere`,
+      ]);
+    } else {
+      assert.ok('false', 'expected search entry to be an error document');
     }
   });
 

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -366,7 +366,7 @@ module('indexing', function (hooks) {
       // assert.deepEqual returns false because despite having the same shape, the constructors are different
       isEqual(realm.searchIndex.stats, {
         instancesIndexed: 0,
-        instanceErrors: 3, // 1 post, 2 persons
+        instanceErrors: 4, // 1 post, 2 persons, 1 bad-link post
         moduleErrors: 3, // post, fancy person, person
       }),
       'indexed correct number of files',
@@ -396,7 +396,7 @@ module('indexing', function (hooks) {
       // assert.deepEqual returns false because despite having the same shape, the constructors are different
       isEqual(realm.searchIndex.stats, {
         instancesIndexed: 3, // 1 post and 2 persons
-        instanceErrors: 0,
+        instanceErrors: 1,
         moduleErrors: 0,
       }),
       'indexed correct number of files',
@@ -467,7 +467,7 @@ module('indexing', function (hooks) {
       // assert.deepEqual returns false because despite having the same shape, the constructors are different
       isEqual(realm.searchIndex.stats, {
         instancesIndexed: 1,
-        instanceErrors: 0,
+        instanceErrors: 1,
         moduleErrors: 0,
       }),
       'indexed correct number of files',
@@ -506,7 +506,7 @@ module('indexing', function (hooks) {
       // assert.deepEqual returns false because despite having the same shape, the constructors are different
       isEqual(realm.searchIndex.stats, {
         instancesIndexed: 3,
-        instanceErrors: 0,
+        instanceErrors: 1,
         moduleErrors: 0,
       }),
       'indexed correct number of files',
@@ -555,7 +555,7 @@ module('indexing', function (hooks) {
       // assert.deepEqual returns false because despite having the same shape, the constructors are different
       isEqual(realm.searchIndex.stats, {
         instancesIndexed: 0,
-        instanceErrors: 1,
+        instanceErrors: 2,
         moduleErrors: 0,
       }),
       'indexed correct number of files',
@@ -593,7 +593,7 @@ module('indexing', function (hooks) {
       // assert.deepEqual returns false because despite having the same shape, the constructors are different
       isEqual(realm.searchIndex.stats, {
         instancesIndexed: 1,
-        instanceErrors: 0,
+        instanceErrors: 1,
         moduleErrors: 0,
       }),
       'indexed correct number of files',


### PR DESCRIPTION
When we encounter an error loading a link, if the error has a 500 status code, don't try to resolve the field by visiting it (this is how we normally load links)