### PR TITLE
Do not render index card twice

### DIFF
--- a/packages/host/app/templates/card.gts
+++ b/packages/host/app/templates/card.gts
@@ -181,17 +181,17 @@ class CardRouteComponent extends Component<CardRouteSignature> {
   );
 
   <template>
-    <div class='card-isolated-component'>
-      {{#if (and (bool @model) this.isPublicReadableRealm)}}
-        {{! @glint-ignore model should not be null}}
-        <Preview @card={{@model}} @format='isolated' />
-      {{else}}
-        <div>ERROR: cannot load card</div>
-      {{/if}}
-    </div>
-
     {{#if @controller.operatorModeEnabled}}
       <OperatorModeContainer @onClose={{this.closeOperatorMode}} />
+    {{else}}
+      <div class='card-isolated-component'>
+        {{#if (and (bool @model) this.isPublicReadableRealm)}}
+          {{! @glint-ignore model should not be null}}
+          <Preview @card={{@model}} @format='isolated' />
+        {{else}}
+          <div>ERROR: cannot load card</div>
+        {{/if}}
+      </div>
     {{/if}}
 
     {{outlet}}


### PR DESCRIPTION
1- The change in this PR should prevent the index card from rendering unnecessarily in the background

2- Looked into why the search query seems to be running multiple times as mentioned in ticket CS-6802. It is because we are running the query for each realm to display results from all available realms. This is why the result returned for each query is different. https://github.com/cardstack/boxel/blob/04a2db4b8264cf640bec27e210706de373d21304/packages/host/app/resources/search.ts#L94-L97

https://github.com/cardstack/boxel/blob/04a2db4b8264cf640bec27e210706de373d21304/packages/host/app/services/card-service.ts#L382-L383

Is there a better way to do this now that we have postgres?