### PR TITLE
Fix nested field remove button alignment

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -1928,16 +1928,6 @@ class FieldDefEditTemplate extends GlimmerComponent<{
         content: 'None';
         color: var(--boxel-450);
       }
-      /* this aligns edit fields with containsMany, linksTo, and linksToMany fields */
-      .field-def-edit-template
-        > .boxel-field
-        > :deep(
-          *:nth-child(2):not(.links-to-many-editor):not(
-              .contains-many-editor
-            ):not(.links-to-editor)
-        ) {
-        padding-right: var(--boxel-icon-lg);
-      }
     </style>
   </template>
 }

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -1787,10 +1787,15 @@ class DefaultCardDefTemplate extends GlimmerComponent<{
         gap: var(--boxel-sp-lg);
         padding: var(--boxel-sp-xl);
       }
-      .default-card-template.edit {
-        padding-right: var(
-          --boxel-sp-xxl
-        ); /* allow room for trash/delete icons that appear on hover */
+      /* this aligns edit fields with containsMany, linksTo, and linksToMany fields */
+      .default-card-template.edit
+        > .boxel-field
+        > :deep(
+          *:nth-child(2):not(.links-to-many-editor):not(
+              .contains-many-editor
+            ):not(.links-to-editor)
+        ) {
+        padding-right: var(--boxel-icon-lg);
       }
     </style>
   </template>
@@ -1922,6 +1927,16 @@ class FieldDefEditTemplate extends GlimmerComponent<{
         display: block;
         content: 'None';
         color: var(--boxel-450);
+      }
+      /* this aligns edit fields with containsMany, linksTo, and linksToMany fields */
+      .field-def-edit-template
+        > .boxel-field
+        > :deep(
+          *:nth-child(2):not(.links-to-many-editor):not(
+              .contains-many-editor
+            ):not(.links-to-editor)
+        ) {
+        padding-right: var(--boxel-icon-lg);
       }
     </style>
   </template>

--- a/packages/base/contains-many-component.gts
+++ b/packages/base/contains-many-component.gts
@@ -34,30 +34,31 @@ interface ContainsManyEditorSignature {
 
 class ContainsManyEditor extends GlimmerComponent<ContainsManyEditorSignature> {
   <template>
-    <div data-test-contains-many={{@field.name}}>
+    <div class='contains-many-editor' data-test-contains-many={{@field.name}}>
       {{#if @arrayField.children.length}}
         <ul class='list'>
           {{#each @arrayField.children as |boxedElement i|}}
             <li class='editor' data-test-item={{i}}>
-              {{#let
-                (getBoxComponent
-                  (@cardTypeFor @field boxedElement) boxedElement @field
-                )
-                as |Item|
-              }}
-                <Item />
-              {{/let}}
-              <div class='remove-button-container'>
-                <IconButton
-                  @icon={{IconTrash}}
-                  @width='18px'
-                  @height='18px'
-                  class='remove'
-                  {{on 'click' (fn this.remove i)}}
-                  data-test-remove={{i}}
-                  aria-label='Remove'
-                />
+              <IconButton
+                @icon={{IconTrash}}
+                @width='18px'
+                @height='18px'
+                class='remove'
+                {{on 'click' (fn this.remove i)}}
+                data-test-remove={{i}}
+                aria-label='Remove'
+              />
+              <div class='item-container'>
+                {{#let
+                  (getBoxComponent
+                    (@cardTypeFor @field boxedElement) boxedElement @field
+                  )
+                  as |Item|
+                }}
+                  <Item />
+                {{/let}}
               </div>
+
             </li>
           {{/each}}
         </ul>
@@ -73,6 +74,9 @@ class ContainsManyEditor extends GlimmerComponent<ContainsManyEditorSignature> {
       </AddButton>
     </div>
     <style>
+      .contains-many-editor {
+        --remove-icon-size: var(--boxel-icon-lg);
+      }
       .list {
         list-style: none;
         padding: 0;
@@ -80,13 +84,8 @@ class ContainsManyEditor extends GlimmerComponent<ContainsManyEditorSignature> {
       }
       .editor {
         position: relative;
-        cursor: pointer;
-        padding: var(--boxel-sp);
-        background-color: var(--boxel-100);
-        border-radius: var(--boxel-form-control-border-radius);
-      }
-      .editor:hover {
-        background-color: var(--boxel-200);
+        display: grid;
+        grid-template-columns: 1fr var(--remove-icon-size);
       }
       .editor :deep(.boxel-input:hover) {
         border-color: var(--boxel-form-control-border-color);
@@ -94,18 +93,28 @@ class ContainsManyEditor extends GlimmerComponent<ContainsManyEditorSignature> {
       .editor + .editor {
         margin-top: var(--boxel-sp-xs);
       }
-      .remove-button-container {
-        position: absolute;
-        top: 0;
-        left: 100%;
-        height: 100%;
+      .item-container {
+        padding: var(--boxel-sp);
+        background-color: var(--boxel-100);
+        border-radius: var(--boxel-form-control-border-radius);
+        order: -1;
+        transition: background-color var(--boxel-transition);
       }
       .remove {
         --icon-color: var(--boxel-dark);
+        --icon-stroke-width: 1.5px;
       }
-      .editor:hover .remove,
+      .remove:focus,
       .remove:hover {
         --icon-color: var(--boxel-red);
+        outline: 0;
+      }
+      .remove:focus + .item-container,
+      .remove:hover + .item-container {
+        background-color: var(--boxel-200);
+      }
+      .add-new {
+        width: calc(100% - var(--remove-icon-size));
       }
     </style>
   </template>

--- a/packages/base/links-to-editor.gts
+++ b/packages/base/links-to-editor.gts
@@ -46,42 +46,47 @@ export class LinksToEditor extends GlimmerComponent<Signature> {
           {{@field.card.displayName}}
         </AddButton>
       {{else}}
+        <IconButton
+          @variant='primary'
+          @icon={{IconMinusCircle}}
+          @width='20px'
+          @height='20px'
+          class='remove'
+          {{on 'click' this.remove}}
+          disabled={{this.isEmpty}}
+          aria-label='Remove'
+          data-test-remove-card
+        />
         <DefaultFormatProvider @value='embedded'>
           <this.linkedCard />
         </DefaultFormatProvider>
-        <div class='remove-button-container'>
-          <IconButton
-            @variant='primary'
-            @icon={{IconMinusCircle}}
-            @width='20px'
-            @height='20px'
-            class='remove'
-            {{on 'click' this.remove}}
-            disabled={{this.isEmpty}}
-            aria-label='Remove'
-            data-test-remove-card
-          />
-        </div>
       {{/if}}
     </div>
     <style>
       .links-to-editor {
+        --remove-icon-size: var(--boxel-icon-lg);
         position: relative;
+        display: grid;
+        grid-template-columns: 1fr var(--remove-icon-size);
       }
-      .remove-button-container {
-        position: absolute;
-        top: 0;
-        left: 100%;
-        height: 100%;
-        display: flex;
-        align-items: center;
+      .links-to-editor > :deep(.boxel-card-container.embedded-format) {
+        order: -1;
       }
       .remove {
         --icon-color: var(--boxel-light);
+        align-self: center;
+        outline: 0;
       }
+      .remove:focus,
       .remove:hover {
         --icon-bg: var(--boxel-dark);
         --icon-border: var(--boxel-dark);
+      }
+      .remove:focus + :deep(.boxel-card-container.embedded-format),
+      .remove:hover + :deep(.boxel-card-container.embedded-format) {
+        box-shadow:
+          0 0 0 1px var(--boxel-light-500),
+          var(--boxel-box-shadow-hover);
       }
     </style>
   </template>

--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -49,7 +49,7 @@ class LinksToManyEditor extends GlimmerComponent<Signature> {
   @consume(CardContextName) declare cardContext: CardContext;
 
   <template>
-    <div data-test-links-to-many={{@field.name}}>
+    <div class='links-to-many-editor' data-test-links-to-many={{@field.name}}>
       {{#if (eq @childFormat 'atom')}}
         <LinksToManyCompactEditor
           @model={{@model}}
@@ -122,50 +122,43 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
   @consume(CardContextName) declare cardContext: CardContext;
 
   <template>
-    <div class='links-to-many-editor' data-test-contains-many={{@field.name}}>
-      {{#if @arrayField.children.length}}
-        <ul class='list'>
-          {{#each @arrayField.children as |boxedElement i|}}
-            <li class='editor' data-test-item={{i}}>
-              <IconButton
-                @variant='primary'
-                @icon={{IconMinusCircle}}
-                @width='20px'
-                @height='20px'
-                class='remove'
-                {{on 'click' (fn @remove i)}}
-                aria-label='Remove'
-                data-test-remove-card
-                data-test-remove={{i}}
-              />
-              {{#let
-                (getBoxComponent
-                  (this.args.cardTypeFor @field boxedElement)
-                  boxedElement
-                  @field
-                )
-                as |Item|
-              }}
-                <Item @format='embedded' />
-              {{/let}}
-            </li>
-          {{/each}}
-        </ul>
-      {{/if}}
-      <AddButton
-        class='add-new'
-        @variant='full-width'
-        {{on 'click' @add}}
-        data-test-add-new
-      >
-        Add
-        {{getPlural @field.card.displayName}}
-      </AddButton>
-    </div>
+    {{#if @arrayField.children.length}}
+      <ul class='list'>
+        {{#each @arrayField.children as |boxedElement i|}}
+          <li class='editor' data-test-item={{i}}>
+            <IconButton
+              @variant='primary'
+              @icon={{IconMinusCircle}}
+              @width='20px'
+              @height='20px'
+              class='remove'
+              {{on 'click' (fn @remove i)}}
+              aria-label='Remove'
+              data-test-remove-card
+              data-test-remove={{i}}
+            />
+            {{#let
+              (getBoxComponent
+                (this.args.cardTypeFor @field boxedElement) boxedElement @field
+              )
+              as |Item|
+            }}
+              <Item @format='embedded' />
+            {{/let}}
+          </li>
+        {{/each}}
+      </ul>
+    {{/if}}
+    <AddButton
+      class='add-new'
+      @variant='full-width'
+      {{on 'click' @add}}
+      data-test-add-new
+    >
+      Add
+      {{getPlural @field.card.displayName}}
+    </AddButton>
     <style>
-      .links-to-many-editor {
-        --remove-icon-size: var(--boxel-icon-lg);
-      }
       .list {
         list-style: none;
         padding: 0;
@@ -177,7 +170,7 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
       .editor {
         position: relative;
         display: grid;
-        grid-template-columns: 1fr var(--remove-icon-size);
+        grid-template-columns: 1fr var(--boxel-icon-lg);
       }
       .editor > :deep(.boxel-card-container.embedded-format) {
         order: -1;
@@ -199,7 +192,7 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
           var(--boxel-box-shadow-hover);
       }
       .add-new {
-        width: calc(100% - var(--remove-icon-size));
+        width: calc(100% - var(--boxel-icon-lg));
       }
     </style>
   </template>

--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -122,19 +122,11 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
   @consume(CardContextName) declare cardContext: CardContext;
 
   <template>
-    {{#if @arrayField.children.length}}
-      <ul class='list'>
-        {{#each @arrayField.children as |boxedElement i|}}
-          <li class='editor' data-test-item={{i}}>
-            {{#let
-              (getBoxComponent
-                (this.args.cardTypeFor @field boxedElement) boxedElement @field
-              )
-              as |Item|
-            }}
-              <Item @format='embedded' />
-            {{/let}}
-            <div class='remove-button-container'>
+    <div class='links-to-many-editor' data-test-contains-many={{@field.name}}>
+      {{#if @arrayField.children.length}}
+        <ul class='list'>
+          {{#each @arrayField.children as |boxedElement i|}}
+            <li class='editor' data-test-item={{i}}>
               <IconButton
                 @variant='primary'
                 @icon={{IconMinusCircle}}
@@ -146,21 +138,34 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
                 data-test-remove-card
                 data-test-remove={{i}}
               />
-            </div>
-          </li>
-        {{/each}}
-      </ul>
-    {{/if}}
-    <AddButton
-      class='add-new'
-      @variant='full-width'
-      {{on 'click' @add}}
-      data-test-add-new
-    >
-      Add
-      {{getPlural @field.card.displayName}}
-    </AddButton>
+              {{#let
+                (getBoxComponent
+                  (this.args.cardTypeFor @field boxedElement)
+                  boxedElement
+                  @field
+                )
+                as |Item|
+              }}
+                <Item @format='embedded' />
+              {{/let}}
+            </li>
+          {{/each}}
+        </ul>
+      {{/if}}
+      <AddButton
+        class='add-new'
+        @variant='full-width'
+        {{on 'click' @add}}
+        data-test-add-new
+      >
+        Add
+        {{getPlural @field.card.displayName}}
+      </AddButton>
+    </div>
     <style>
+      .links-to-many-editor {
+        --remove-icon-size: var(--boxel-icon-lg);
+      }
       .list {
         list-style: none;
         padding: 0;
@@ -171,21 +176,30 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
       }
       .editor {
         position: relative;
+        display: grid;
+        grid-template-columns: 1fr var(--remove-icon-size);
       }
-      .remove-button-container {
-        position: absolute;
-        top: 0;
-        left: 100%;
-        height: 100%;
-        display: flex;
-        align-items: center;
+      .editor > :deep(.boxel-card-container.embedded-format) {
+        order: -1;
       }
       .remove {
         --icon-color: var(--boxel-light);
+        align-self: center;
+        outline: 0;
       }
+      .remove:focus,
       .remove:hover {
         --icon-bg: var(--boxel-dark);
         --icon-border: var(--boxel-dark);
+      }
+      .remove:focus + :deep(.boxel-card-container.embedded-format),
+      .remove:hover + :deep(.boxel-card-container.embedded-format) {
+        box-shadow:
+          0 0 0 1px var(--boxel-light-500),
+          var(--boxel-box-shadow-hover);
+      }
+      .add-new {
+        width: calc(100% - var(--remove-icon-size));
       }
     </style>
   </template>

--- a/packages/boxel-ui/addon/raw-icons/icon-trash.svg
+++ b/packages/boxel-ui/addon/raw-icons/icon-trash.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0.5 0.5 12.7 14">
-    <g fill="none" stroke="var(--icon-color, #000)" stroke-linecap="round" stroke-linejoin="round" stroke-width="var(--icon-stroke-width, 1px)">
-        <path d="m3 6h11.7" transform="translate(-2 -2.4)"/>
-        <path d="m14.1 4.6v9.1a1.3 1.3 0 0 1 -1.3 1.3h-6.5a1.3 1.3 0 0 1 -1.3-1.3v-9.1m1.95 0v-1.3a1.3 1.3 0 0 1 1.3-1.3h2.6a1.3 1.3 0 0 1 1.3 1.3v1.3" transform="translate(-2.7 -1)"/>
-        <path d="m10 11v3.9" stroke-width="1" transform="translate(-4.45 -4.15)"/>
-        <path d="m14 11v3.9" stroke-width="1" transform="translate(-5.85 -4.15)"/>
-    </g>
+  <g fill="none" stroke="var(--icon-color, #000)" stroke-linecap="round" stroke-linejoin="round" stroke-width="var(--icon-stroke-width, 1px)">
+    <path d="m3 6h11.7" transform="translate(-2 -2.4)"/>
+    <path d="m14.1 4.6v9.1a1.3 1.3 0 0 1 -1.3 1.3h-6.5a1.3 1.3 0 0 1 -1.3-1.3v-9.1m1.95 0v-1.3a1.3 1.3 0 0 1 1.3-1.3h2.6a1.3 1.3 0 0 1 1.3 1.3v1.3" transform="translate(-2.7 -1)"/>
+    <path d="m10 11v3.9" stroke-width="var(--icon-stroke-width, 1px)" transform="translate(-4.45 -4.15)"/>
+    <path d="m14 11v3.9" stroke-width="var(--icon-stroke-width, 1px)" transform="translate(-5.85 -4.15)"/>
+  </g>
 </svg>

--- a/packages/boxel-ui/addon/src/components/field-container/index.gts
+++ b/packages/boxel-ui/addon/src/components/field-container/index.gts
@@ -81,7 +81,6 @@ const FieldContainer: TemplateOnlyComponent<Signature> = <template>
     .horizontal {
       grid-template-columns: var(--boxel-field-label-size, minmax(4rem, 25%)) 1fr;
       gap: 0 var(--boxel-sp-lg);
-      padding-right: var(--boxel-sp-xl);
     }
 
     .small-label {

--- a/packages/boxel-ui/addon/src/icons/icon-trash.gts
+++ b/packages/boxel-ui/addon/src/icons/icon-trash.gts
@@ -15,8 +15,8 @@ const IconComponent: TemplateOnlyComponent<Signature> = <template>
       stroke-linejoin='round'
       stroke-width='var(--icon-stroke-width, 1px)'
     ><path
-        d='M1 3.6h11.7M11.4 3.6v9.1a1.3 1.3 0 0 1-1.3 1.3H3.6a1.3 1.3 0 0 1-1.3-1.3V3.6m1.95 0V2.3A1.3 1.3 0 0 1 5.55 1h2.6a1.3 1.3 0 0 1 1.3 1.3v1.3'
-      /><path stroke-width='1' d='M5.55 6.85v3.9M8.15 6.85v3.9' /></g></svg>
+        d='M1 3.6h11.7M11.4 3.6v9.1a1.3 1.3 0 0 1-1.3 1.3H3.6a1.3 1.3 0 0 1-1.3-1.3V3.6m1.95 0V2.3A1.3 1.3 0 0 1 5.55 1h2.6a1.3 1.3 0 0 1 1.3 1.3v1.3M5.55 6.85v3.9M8.15 6.85v3.9'
+      /></g></svg>
 </template>;
 
 // @ts-expect-error this is the only way to set a name on a Template Only Component currently


### PR DESCRIPTION
### Before:
![image](https://github.com/cardstack/boxel/assets/16160806/f39b8194-02fb-41a2-b545-051bcba0f3cc)

### After:
No hover:
<img width="775" alt="default-edit" src="https://github.com/cardstack/boxel/assets/16160806/1b38e66c-4991-4944-b39e-7d24a0648283">

Outer remove icon (trash can button) is hovered:
<img width="771" alt="item-hovered" src="https://github.com/cardstack/boxel/assets/16160806/4b9a3fe7-0cbc-4e8b-9ec3-25addf1b3980">

Inner remove icon (minus button) is hovered:
<img width="768" alt="innermost-card-hovered" src="https://github.com/cardstack/boxel/assets/16160806/a6248181-2648-41a0-9399-d2f1b67a0b12">

~~###Note:~~
~~Previously we were using absolute positioning for remove icons, which caused the alignment issue. The changes I made in this PR mean that the fields without remove icon will be aligned differently:~~
<img width="798" alt="field-alignment" src="https://github.com/cardstack/boxel/assets/16160806/18d8b550-d74e-4fea-a2a6-9f54feed46e4">

### Update: Alignment issue is fixed
<img width="708" alt="aligned" src="https://github.com/cardstack/boxel/assets/16160806/25c498b6-8179-4a78-bcb6-abc4a9201ffd">