### PR TITLE
host: Fix module hooks nesting

### DIFF
--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -684,7 +684,7 @@ module('Acceptance | operator mode tests', function (hooks) {
     });
   });
 
-  module('realm session expiration', function () {
+  module('realm session expiration', function (hooks) {
     let refreshInSec = 2;
 
     hooks.beforeEach(async function () {


### PR DESCRIPTION
This fixes the warning seen [here](https://github.com/cardstack/boxel/actions/runs/9067743924/job/24913534947?pr=1242#step:9:41):

> The `beforeEach` hook was called inside the wrong module (`Acceptance | operator mode tests > realm session expiration`). Instead, use hooks provided by the callback to the containing module (`Acceptance | operator mode tests`). This will become an error in QUnit 3.0.

You can see it’s missing from [the same place](https://github.com/cardstack/boxel/actions/runs/9068031403/job/24914406081?pr=1252#step:9:40) in logs from this PR.