### PR TITLE
[ai-bot refactor] Move handleDebug command out + misc

### DIFF
--- a/packages/ai-bot/lib/debug.ts
+++ b/packages/ai-bot/lib/debug.ts
@@ -1,7 +1,6 @@
 import { Room, MatrixClient } from 'matrix-js-sdk';
 import { setTitle } from './set-title';
 import { sendError, sendOption, sendMessage } from './matrix';
-import type { MatrixEvent as DiscreteMatrixEvent } from 'https://cardstack.com/base/room';
 import OpenAI from 'openai';
 
 import * as Sentry from '@sentry/node';
@@ -11,7 +10,6 @@ export async function handleDebugCommands(
   eventBody: string,
   client: MatrixClient,
   room: Room,
-  history: DiscreteMatrixEvent[],
   userId: string,
 ) {
   // Explicitly set the room name
@@ -31,7 +29,7 @@ export async function handleDebugCommands(
   }
   // Use GPT to set the room title
   else if (eventBody.startsWith('debug:title:create')) {
-    return await setTitle(openai, client, room, history, userId);
+    return await setTitle(openai, client, room, [], userId);
   } else if (eventBody.startsWith('debug:patch:')) {
     let patchMessage = eventBody.split('debug:patch:')[1];
     // If there's a card attached, we need to split it off to parse the json

--- a/packages/ai-bot/lib/debug.ts
+++ b/packages/ai-bot/lib/debug.ts
@@ -1,6 +1,6 @@
 import { Room, MatrixClient } from 'matrix-js-sdk';
 import { setTitle } from './set-title';
-import { sendError, sendOption, sendMessage } from '../main';
+import { sendError, sendOption, sendMessage } from './matrix';
 import type { MatrixEvent as DiscreteMatrixEvent } from 'https://cardstack.com/base/room';
 import OpenAI from 'openai';
 

--- a/packages/ai-bot/lib/debug.ts
+++ b/packages/ai-bot/lib/debug.ts
@@ -1,0 +1,63 @@
+import { Room, MatrixClient } from 'matrix-js-sdk';
+import { setTitle } from './set-title';
+import { sendError, sendOption, sendMessage } from '../main';
+import type { MatrixEvent as DiscreteMatrixEvent } from 'https://cardstack.com/base/room';
+import OpenAI from 'openai';
+
+import * as Sentry from '@sentry/node';
+
+export async function handleDebugCommands(
+  openai: OpenAI,
+  eventBody: string,
+  client: MatrixClient,
+  room: Room,
+  history: DiscreteMatrixEvent[],
+  userId: string,
+) {
+  // Explicitly set the room name
+  if (eventBody.startsWith('debug:title:set:')) {
+    return await client.setRoomName(
+      room.roomId,
+      eventBody.split('debug:title:set:')[1],
+    );
+  } else if (eventBody.startsWith('debug:boom')) {
+    await sendError(
+      client,
+      room,
+      `Boom! Throwing an unhandled error`,
+      undefined,
+    );
+    throw new Error('Boom!');
+  }
+  // Use GPT to set the room title
+  else if (eventBody.startsWith('debug:title:create')) {
+    return await setTitle(openai, client, room, history, userId);
+  } else if (eventBody.startsWith('debug:patch:')) {
+    let patchMessage = eventBody.split('debug:patch:')[1];
+    // If there's a card attached, we need to split it off to parse the json
+    patchMessage = patchMessage.split('(Card')[0];
+    let command: {
+      card_id?: string;
+      description?: string;
+      attributes?: any;
+    } = {};
+    try {
+      command = JSON.parse(patchMessage);
+      if (!command.card_id || !command.description || !command.attributes) {
+        throw new Error(
+          'Invalid debug patch: card_id, description, or attributes is missing.',
+        );
+      }
+    } catch (error) {
+      Sentry.captureException(error);
+      return await sendMessage(
+        client,
+        room,
+        `Error parsing your debug patch, ${error} ${patchMessage}`,
+        undefined,
+      );
+    }
+    return await sendOption(client, room, command, undefined);
+  }
+  return;
+}

--- a/packages/ai-bot/lib/matrix.ts
+++ b/packages/ai-bot/lib/matrix.ts
@@ -1,0 +1,134 @@
+import { IContent, Room, MatrixClient } from 'matrix-js-sdk';
+import { logger } from '@cardstack/runtime-common';
+import { OpenAIError } from 'openai/error';
+import * as Sentry from '@sentry/node';
+
+let log = logger('ai-bot');
+
+export async function sendEvent(
+  client: MatrixClient,
+  room: Room,
+  eventType: string,
+  content: IContent,
+  eventToUpdate: string | undefined,
+) {
+  if (content.data) {
+    content.data = JSON.stringify(content.data);
+  }
+  if (eventToUpdate) {
+    content['m.relates_to'] = {
+      rel_type: 'm.replace',
+      event_id: eventToUpdate,
+    };
+  }
+  log.info('Sending', content);
+  return await client.sendEvent(room.roomId, eventType, content);
+}
+
+export async function sendMessage(
+  client: MatrixClient,
+  room: Room,
+  content: string,
+  eventToUpdate: string | undefined,
+  data: any = {},
+) {
+  log.info('Sending', content);
+  let messageObject: IContent = {
+    ...{
+      body: content,
+      msgtype: 'm.text',
+      formatted_body: content,
+      format: 'org.matrix.custom.html',
+      'm.new_content': {
+        body: content,
+        msgtype: 'm.text',
+        formatted_body: content,
+        format: 'org.matrix.custom.html',
+      },
+    },
+    ...data,
+  };
+  return await sendEvent(
+    client,
+    room,
+    'm.room.message',
+    messageObject,
+    eventToUpdate,
+  );
+}
+
+// TODO we might want to think about how to handle patches that are larger than
+// 65KB (the maximum matrix event size), such that we split them into fragments
+// like we split cards into fragments
+export async function sendOption(
+  client: MatrixClient,
+  room: Room,
+  patch: any,
+  eventToUpdate: string | undefined,
+) {
+  log.info('sending option', patch);
+  const id = patch['card_id'];
+  const body = patch['description'] || "Here's the change:";
+  let messageObject = {
+    body: body,
+    msgtype: 'org.boxel.command',
+    formatted_body: body,
+    format: 'org.matrix.custom.html',
+    data: {
+      command: {
+        type: 'patch',
+        id: id,
+        patch: {
+          attributes: patch['attributes'],
+          relationships: patch['relationships'],
+        },
+        eventId: eventToUpdate,
+      },
+    },
+  };
+  log.info(JSON.stringify(messageObject, null, 2));
+  return await sendEvent(
+    client,
+    room,
+    'm.room.message',
+    messageObject,
+    eventToUpdate,
+  );
+}
+
+export async function sendError(
+  client: MatrixClient,
+  room: Room,
+  error: any,
+  eventToUpdate: string | undefined,
+) {
+  try {
+    let errorMessage = getErrorMessage(error);
+    log.error(errorMessage);
+    await sendMessage(
+      client,
+      room,
+      'There was an error processing your request, please try again later',
+      eventToUpdate,
+      {
+        isStreamingFinished: true,
+        errorMessage,
+      },
+    );
+  } catch (e) {
+    // We've had a problem sending the error message back to the user
+    // Log and continue
+    log.error(`Error sending error message back to user: ${e}`);
+    Sentry.captureException(e);
+  }
+}
+
+function getErrorMessage(error: any): string {
+  if (error instanceof OpenAIError) {
+    return `OpenAI error: ${error.name} - ${error.message}`;
+  }
+  if (typeof error === 'string') {
+    return `Unknown error: ${error}`;
+  }
+  return `Unknown error`;
+}

--- a/packages/ai-bot/lib/matrix.ts
+++ b/packages/ai-bot/lib/matrix.ts
@@ -21,7 +21,7 @@ export async function sendEvent(
       event_id: eventToUpdate,
     };
   }
-  log.info('Sending', content);
+  log.debug('sending event', content);
   return await client.sendEvent(room.roomId, eventType, content);
 }
 
@@ -32,7 +32,7 @@ export async function sendMessage(
   eventToUpdate: string | undefined,
   data: any = {},
 ) {
-  log.info('Sending', content);
+  log.debug('sending message', content);
   let messageObject: IContent = {
     ...{
       body: content,
@@ -66,7 +66,7 @@ export async function sendOption(
   patch: any,
   eventToUpdate: string | undefined,
 ) {
-  log.info('sending option', patch);
+  log.debug('sending option', patch);
   const id = patch['card_id'];
   const body = patch['description'] || "Here's the change:";
   let messageObject = {
@@ -86,7 +86,6 @@ export async function sendOption(
       },
     },
   };
-  log.info(JSON.stringify(messageObject, null, 2));
   return await sendEvent(
     client,
     room,

--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -61,17 +61,12 @@ class Assistant {
     }
   }
 
-  async handleDebugCommands(
-    eventBody: string,
-    room: Room,
-    history: DiscreteMatrixEvent[],
-  ) {
+  async handleDebugCommands(eventBody: string, room: Room) {
     return handleDebugCommands(
       this.openai,
       eventBody,
       this.client,
       room,
-      history,
       this.id,
     );
   }
@@ -293,17 +288,14 @@ Common issues are:
   //handle debug events
   client.on(RoomEvent.Timeline, async function (event, room) {
     let eventBody = event.getContent().body;
-    if (!eventBody.startsWith('debug:')) {
+    let isDebugEvent = eventBody.startsWith('debug:');
+    if (!isDebugEvent) {
       return;
     }
     if (!room) {
       return;
     }
-    //very inefficient to load initial
-    let initial = await client.roomInitialSync(room!.roomId, 1000);
-    let eventList = (initial!.messages?.chunk || []) as DiscreteMatrixEvent[];
-    let history: DiscreteMatrixEvent[] = constructHistory(eventList);
-    return await assistant.handleDebugCommands(eventBody, room, history);
+    return await assistant.handleDebugCommands(eventBody, room);
   });
 
   await client.startClient();

--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -287,6 +287,12 @@ Common issues are:
 
   //handle debug events
   client.on(RoomEvent.Timeline, async function (event, room) {
+    if (event.event.origin_server_ts! < startTime) {
+      return;
+    }
+    if (event.getType() !== 'm.room.message') {
+      return;
+    }
     let eventBody = event.getContent().body;
     let isDebugEvent = eventBody.startsWith('debug:');
     if (!isDebugEvent) {

--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -118,7 +118,7 @@ Common issues are:
       client
         .joinRoom(member.roomId)
         .then(function () {
-          log.info('Auto-joined %s', member.roomId);
+          log.info('%s auto-joined %s', member.name, member.roomId);
         })
         .catch(function (err) {
           log.info(
@@ -138,7 +138,14 @@ Common issues are:
         if (!room) {
           return;
         }
-        log.info('(%s) %s :: %s', room?.name, event.getSender(), eventBody);
+        log.info(
+          '(%s) (Room: "%s" %s) (Message: %s %s)',
+          event.getType(),
+          room?.name,
+          room?.roomId,
+          event.getSender(),
+          eventBody,
+        );
 
         if (event.event.origin_server_ts! < startTime) {
           return;
@@ -159,8 +166,6 @@ Common issues are:
         let initial = await client.roomInitialSync(room!.roomId, 1000);
         let eventList = (initial!.messages?.chunk ||
           []) as DiscreteMatrixEvent[];
-        log.info(eventList);
-
         log.info('Total event list', eventList.length);
         let history: DiscreteMatrixEvent[] = constructHistory(eventList);
         log.info("Compressed into just the history that's ", history.length);
@@ -195,7 +200,7 @@ Common issues are:
             if (msg.role === 'assistant') {
               for (const toolCall of msg.tool_calls || []) {
                 const functionCall = toolCall.function;
-                console.log('Function call', toolCall);
+                log.debug('[Room Timeline] Function call', toolCall);
                 let args;
                 try {
                   args = JSON.parse(functionCall.arguments);

--- a/packages/ai-bot/setup-logger.ts
+++ b/packages/ai-bot/setup-logger.ts
@@ -1,10 +1,7 @@
 import { makeLogDefinitions } from '@cardstack/runtime-common';
 import { logger as matrixJsLogger } from 'matrix-js-sdk/lib/logger';
 
-if (
-  process.env.DISABLE_MATRIX_JS_LOGGING &&
-  process.env.DISABLE_MATRIX_JS_LOGGING === 'TRUE'
-) {
+if (process.env.DISABLE_MATRIX_JS_LOGGING === 'TRUE') {
   matrixJsLogger.disableAll();
 }
 (globalThis as any)._logDefinitions = makeLogDefinitions(

--- a/packages/ai-bot/setup-logger.ts
+++ b/packages/ai-bot/setup-logger.ts
@@ -1,4 +1,12 @@
 import { makeLogDefinitions } from '@cardstack/runtime-common';
+import { logger as matrixJsLogger } from 'matrix-js-sdk/lib/logger';
+
+if (
+  process.env.DISABLE_MATRIX_JS_LOGGING &&
+  process.env.DISABLE_MATRIX_JS_LOGGING === 'TRUE'
+) {
+  matrixJsLogger.disableAll();
+}
 (globalThis as any)._logDefinitions = makeLogDefinitions(
   process.env.LOG_LEVELS || '*=info',
 );


### PR DESCRIPTION
This introduces
- optional environment variable to remove matrix js sdk logs
- set the level of some verbose logs to DEBUG so its not issued by default 
- introduce a class called assistant
- puts debug into its own listener of Room.Timeline
- puts all the matrix send messages into its own module

I sure there are ways to clean up better, but, I think this has better isolation of concerns. I tried to figure out whether there is a listener so I can trigger roomInitialSync sparingly, but I think im limited to this for now. We can cache but I dono what the repurcussions of that is.