### PR TITLE
[ai-bot] Remove glint config

### DIFF
--- a/packages/ai-bot/package.json
+++ b/packages/ai-bot/package.json
@@ -15,6 +15,7 @@
     "typescript": "~5.1.6"
   },
   "devDependencies": {
+    "@types/qunit": "^2.19.10",
     "qunit": "^2.18.0"
   },
   "scripts": {

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -556,7 +556,7 @@ module('getModifyPrompt', () => {
   });
 
   test('If there are no functions in the last message from the user, store none', () => {
-    const history: IRoomEvent[] = [
+    const history: DiscreteMatrixEvent[] = [
       {
         type: 'm.room.message',
         sender: '@ian:localhost',
@@ -738,7 +738,7 @@ module('getModifyPrompt', () => {
   });
 
   test('Create patch function calls when there is a cardSpec', () => {
-    const history: IRoomEvent[] = [
+    const history: DiscreteMatrixEvent[] = [
       {
         type: 'm.room.message',
         sender: '@ian:localhost',

--- a/packages/ai-bot/tsconfig.json
+++ b/packages/ai-bot/tsconfig.json
@@ -32,7 +32,7 @@
     "typeRoots": ["../boxel-ui/types"]
   },
   "glint": {
-    "environment": ["ember-loose", "ember-template-imports"],
+    "environment": ["ember-loose"],
     "transform": {
       "include": ["../base/**", "./**", "../boxel-ui/addon/**"]
     }

--- a/packages/ai-bot/tsconfig.json
+++ b/packages/ai-bot/tsconfig.json
@@ -31,12 +31,6 @@
     },
     "typeRoots": ["../boxel-ui/types"]
   },
-  "glint": {
-    "environment": ["ember-loose"],
-    "transform": {
-      "include": ["../base/**", "./**", "../boxel-ui/addon/**"]
-    }
-  },
   "include": ["../base/**/*", "./**/*"],
   "exclude": ["../base/__boxel/**/*"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,10 @@ importers:
       typescript:
         specifier: ~5.1.6
         version: 5.1.6
+    devDependencies:
+      '@types/qunit':
+        specifier: ^2.19.10
+        version: 2.19.10
 
   packages/base:
     dependencies:


### PR DESCRIPTION
**EDIT: should we just remove glint config from the ai-bot**. 
Even if you have glint running, it should not do anything. I know the suggestion in glint is to stop with typescript builtin but, if you want to see type errors, ud need that builtin plugin. 

Another option is really to fix the types in the test to be more explicit. I have most of these changes actually. Im open to suggestions. 

I think I am confused as to what glint transforms are doing. If there are no ember templates, why am I relying on it to tell me about my typescript and making typescript work different. I mean there is nothing in CI that checks for types in ai-bot (just eslint). Even so, I have found that after I remove glint that tsc still complains about this `import type { MatrixEvent as DiscreteMatrixEvent } from 'https://cardstack.com/base/room';` which I thought the `paths` key in tsconfig would handled but apparently its only when glint is involved that it works as expected.

**Old Description**

~~Need some guidance on this. It looks like our default local use in the monorepo is to activate glint. But here, we activate the ember-template-import plugin when no templates are found -- in the ai-bot. Showing errors. I just removed this.~~

~~These errors are essentially not inferring a (nested) union type correctly (at least with glint). Typescript doesn't seem to complain about it.~~

~~Are we still expecting the ai-bot to use glint the way the rest of subpackages use it? Or, do we run glint in CI for the ai-bot?~~

<img width="1329" alt="Screenshot 2024-05-15 at 14 02 06" src="https://github.com/cardstack/boxel/assets/8165111/1926848c-673a-47c9-8ec9-38f92f4bb328">
