### PR TITLE
ci: Update dorny/paths-filter to fix deprecation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -330,7 +330,7 @@ jobs:
       ai-bot: ${{ steps.filter.outputs.ai-bot }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |


### PR DESCRIPTION
As seen [here](https://github.com/cardstack/boxel/actions/runs/9095697124), it only runs on `main` so I missed it in #1214.