### PR TITLE
Fix messages order

### DIFF
--- a/packages/base/room.gts
+++ b/packages/base/room.gts
@@ -611,6 +611,11 @@ export class RoomField extends FieldDef {
         }
 
         if (messageField) {
+          // if the message is a replacement for other messages,
+          // use `created` from the oldest one.
+          if (newMessages.has(event_id)) {
+            messageField.created = newMessages.get(event_id)!.created;
+          }
           newMessages.set(
             (event.content as CardMessageContent).clientGeneratedId ?? event_id,
             messageField,

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -2363,7 +2363,6 @@ module('Integration | operator-mode', function (hooks) {
       await addRoomEvent(matrixService, firstMessageReplacement);
 
       await waitFor('[data-test-message-idx="0"]');
-      await this.pauseTest();
 
       assert
         .dom('[data-test-message-idx="0"]')


### PR DESCRIPTION
Originally, the issue was identified because the patch messages could render in reverse order. However, upon investigation, I found that the problem occurred because we were defining the `created` field of `MessageField` using `origin_server_ts` from the event, even if it was a replacement event for another event. For a replacement event, we should use the `origin_server_ts` or `created` timestamp from the oldest message event.