### PR TITLE
Add AI generated D&D character sheet

### DIFF
--- a/packages/drafts-realm/CharacterSheet/982ff843-2dfe-47fe-8be1-47221d5de933.json
+++ b/packages/drafts-realm/CharacterSheet/982ff843-2dfe-47fe-8be1-47221d5de933.json
@@ -1,0 +1,49 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "name": "Aric Stoneheart",
+      "level": 5,
+      "class": "Fighter",
+      "race": "Human",
+      "hitPoints": 45,
+      "strength": 18,
+      "dexterity": 14,
+      "constitution": 16,
+      "intelligence": 10,
+      "wisdom": 12,
+      "charisma": 10,
+      "title": "The Brave",
+      "description": "A seasoned warrior known for his valor in battle and strong sense of justice.",
+      "thumbnailURL": null
+    },
+    "relationships": {
+      "spells.0": {
+        "links": {
+          "self": "../Spell/c8ebdcf6-b548-474f-bf12-ee6396b9bfbc"
+        }
+      },
+      "spells.1": {
+        "links": {
+          "self": "../Spell/5ed539c4-ab38-494f-bcdb-b2fc8ecc141a"
+        }
+      },
+      "spells.2": {
+        "links": {
+          "self": "../Spell/d5858748-d81f-4e79-ba99-a4d62afa09c6"
+        }
+      },
+      "inventory.0": {
+        "links": {
+          "self": "../InventoryItem/c7bf0673-77dc-49d7-a791-58c84be0cd6f"
+        }
+      }
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../dnd",
+        "name": "CharacterSheet"
+      }
+    }
+  }
+}

--- a/packages/drafts-realm/DnDItem/8ec1b337-1a53-479e-9bb8-3047e714142c.json
+++ b/packages/drafts-realm/DnDItem/8ec1b337-1a53-479e-9bb8-3047e714142c.json
@@ -11,7 +11,7 @@
     "meta": {
       "adoptsFrom": {
         "module": "../dnd",
-        "name": "Item"
+        "name": "DnDItem"
       }
     }
   }

--- a/packages/drafts-realm/InventoryItem/c7bf0673-77dc-49d7-a791-58c84be0cd6f.json
+++ b/packages/drafts-realm/InventoryItem/c7bf0673-77dc-49d7-a791-58c84be0cd6f.json
@@ -1,0 +1,24 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "quantity": 2,
+      "title": "Potions",
+      "description": null,
+      "thumbnailURL": null
+    },
+    "relationships": {
+      "item": {
+        "links": {
+          "self": "../Item/8ec1b337-1a53-479e-9bb8-3047e714142c"
+        }
+      }
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../dnd",
+        "name": "InventoryItem"
+      }
+    }
+  }
+}

--- a/packages/drafts-realm/InventoryItem/c7bf0673-77dc-49d7-a791-58c84be0cd6f.json
+++ b/packages/drafts-realm/InventoryItem/c7bf0673-77dc-49d7-a791-58c84be0cd6f.json
@@ -10,7 +10,7 @@
     "relationships": {
       "item": {
         "links": {
-          "self": "../Item/8ec1b337-1a53-479e-9bb8-3047e714142c"
+          "self": "../DnDItem/8ec1b337-1a53-479e-9bb8-3047e714142c"
         }
       }
     },

--- a/packages/drafts-realm/Item/8ec1b337-1a53-479e-9bb8-3047e714142c.json
+++ b/packages/drafts-realm/Item/8ec1b337-1a53-479e-9bb8-3047e714142c.json
@@ -1,0 +1,18 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "name": "Potion of Healing",
+      "description": "A character who drinks the magical red fluid in this vial regains 2d4 + 2 hit points. Drinking or administering a potion takes an action.",
+      "value": 50,
+      "title": "Potion of Healing",
+      "thumbnailURL": null
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../dnd",
+        "name": "Item"
+      }
+    }
+  }
+}

--- a/packages/drafts-realm/Spell/5ed539c4-ab38-494f-bcdb-b2fc8ecc141a.json
+++ b/packages/drafts-realm/Spell/5ed539c4-ab38-494f-bcdb-b2fc8ecc141a.json
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "name": "Magic Missile",
+      "description": "You create three glowing darts of magical force. Each dart hits a creature of your choice that you can see within range. A dart deals 1d4 + 1 force damage to its target. The darts all strike simultaneously, and you can direct them to hit one creature or several.",
+      "level": 1,
+      "isPrepared": true,
+      "title": "Magic Missile",
+      "thumbnailURL": null
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../dnd",
+        "name": "Spell"
+      }
+    }
+  }
+}

--- a/packages/drafts-realm/Spell/5ed539c4-ab38-494f-bcdb-b2fc8ecc141a.json
+++ b/packages/drafts-realm/Spell/5ed539c4-ab38-494f-bcdb-b2fc8ecc141a.json
@@ -3,10 +3,14 @@
     "type": "card",
     "attributes": {
       "name": "Magic Missile",
-      "description": "You create three glowing darts of magical force. Each dart hits a creature of your choice that you can see within range. A dart deals 1d4 + 1 force damage to its target. The darts all strike simultaneously, and you can direct them to hit one creature or several.",
       "level": 1,
       "isPrepared": true,
+      "damageDice": [
+        "1d4"
+      ],
+      "spellDescription": "You create three glowing darts of magical force. Each dart hits a creature of your choice that you can see within range. A dart deals 1d4 + 1 force damage to its target. The darts all strike simultaneously, and you can direct them to hit one creature or several.",
       "title": "Magic Missile",
+      "description": "",
       "thumbnailURL": null
     },
     "meta": {

--- a/packages/drafts-realm/Spell/c8ebdcf6-b548-474f-bf12-ee6396b9bfbc.json
+++ b/packages/drafts-realm/Spell/c8ebdcf6-b548-474f-bf12-ee6396b9bfbc.json
@@ -1,0 +1,23 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "name": "Fireball",
+      "level": 3,
+      "isPrepared": true,
+      "damageDice": [
+        "8d6"
+      ],
+      "spellDescription": "A bright streak flashes from your pointing finger to a point you choose within range and then blossoms with a low roar into an explosion of flame. Each creature in a 20-foot-radius sphere centered on that point must make a Dexterity saving throw. A target takes 8d6 fire damage on a failed save, or half as much damage on a successful one.",
+      "title": "Fireball",
+      "description": "Fireball",
+      "thumbnailURL": null
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../dnd",
+        "name": "Spell"
+      }
+    }
+  }
+}

--- a/packages/drafts-realm/Spell/d5858748-d81f-4e79-ba99-a4d62afa09c6.json
+++ b/packages/drafts-realm/Spell/d5858748-d81f-4e79-ba99-a4d62afa09c6.json
@@ -1,0 +1,24 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "name": "Arcane Fury",
+      "level": 3,
+      "isPrepared": false,
+      "damageDice": [
+        "2d6",
+        "1d8"
+      ],
+      "spellDescription": "Arcane Fury is a level 3 spell that calls forth a devastating combination of fire and lightning, causing significant damage to all enemies in a 20-foot radius. When cast, the spell deals 2d6 fire damage and 1d8 lightning damage to each target within range\n\nUnleashing the raw force of untamed magic, the caster conjures a storm of fire and lightning towards their target.",
+      "title": "Arcane Fury",
+      "description": "",
+      "thumbnailURL": null
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../dnd",
+        "name": "Spell"
+      }
+    }
+  }
+}

--- a/packages/drafts-realm/dnd.gts
+++ b/packages/drafts-realm/dnd.gts
@@ -13,6 +13,8 @@ import BooleanField from 'https://cardstack.com/base/boolean';
 import MarkdownField from 'https://cardstack.com/base/markdown';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
 export class Spell extends CardDef {
   @field name = contains(StringField);
@@ -185,14 +187,14 @@ export class Spell extends CardDef {
 }
 
 // Define the Item card
-export class Item extends CardDef {
+export class DnDItem extends CardDef {
   @field name = contains(StringField);
   @field value = contains(NumberField);
 }
 
 // Define the InventoryItem card
 export class InventoryItem extends CardDef {
-  @field item = linksTo(Item);
+  @field item = linksTo(DnDItem);
   @field quantity = contains(NumberField);
 }
 

--- a/packages/drafts-realm/dnd.gts
+++ b/packages/drafts-realm/dnd.gts
@@ -11,8 +11,6 @@ import StringField from 'https://cardstack.com/base/string';
 import NumberField from 'https://cardstack.com/base/number';
 import BooleanField from 'https://cardstack.com/base/boolean';
 import MarkdownField from 'https://cardstack.com/base/markdown';
-import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 
@@ -30,15 +28,18 @@ export class Spell extends CardDef {
   };
 
   static isolated = class Isolated extends Component<typeof this> {
-    @tracked rolls = [];
+    // @ts-ignore TS1206: Decorators are not valid here.
+    @tracked rolls: { sides: number; roll: number; id: string }[] = [];
+    // @ts-ignore TS1206: Decorators are not valid here.
     @tracked totalDamage = 0;
+    // @ts-ignore TS1206: Decorators are not valid here.
     @tracked halfDamage = 0;
 
-    rollDie(sides) {
+    rollDie(sides: number) {
       return Math.floor(Math.random() * sides) + 1;
     }
 
-    parseDiceString(diceString) {
+    parseDiceString(diceString: string) {
       const [count, sides] = diceString.split('d').map(Number);
       if (isNaN(count) || isNaN(sides) || count <= 0 || sides <= 0) {
         throw new Error(`Invalid dice notation: ${diceString}`);
@@ -52,9 +53,10 @@ export class Spell extends CardDef {
       this.halfDamage = Math.floor(totalDamage / 2);
     }
 
+    // @ts-ignore TS1206: Decorators are not valid here.
     @action
     calculateDamage() {
-      let rolls = [];
+      let rolls: { sides: number; roll: number; id: string }[] = [];
       const diceStrings = this.args.model.damageDice || [];
 
       try {
@@ -73,8 +75,9 @@ export class Spell extends CardDef {
       }
     }
 
+    // @ts-ignore TS1206: Decorators are not valid here.
     @action
-    rerollDie(dieId) {
+    rerollDie(dieId: string) {
       let newRolls = this.rolls.map((roll) => {
         if (roll.id === dieId) {
           return { ...roll, roll: this.rollDie(roll.sides) };

--- a/packages/drafts-realm/dnd.gts
+++ b/packages/drafts-realm/dnd.gts
@@ -1,0 +1,380 @@
+import {
+  contains,
+  containsMany,
+  linksTo,
+  linksToMany,
+  field,
+  CardDef,
+  Component,
+} from 'https://cardstack.com/base/card-api';
+import StringField from 'https://cardstack.com/base/string';
+import NumberField from 'https://cardstack.com/base/number';
+import BooleanField from 'https://cardstack.com/base/boolean';
+import MarkdownField from 'https://cardstack.com/base/markdown';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
+
+export class Spell extends CardDef {
+  @field name = contains(StringField);
+  @field level = contains(NumberField);
+  @field isPrepared = contains(BooleanField);
+  @field damageDice = containsMany(StringField); // Field to store dice strings like "2d10", "1d8"
+  @field spellDescription = contains(MarkdownField);
+
+  static embedded = class Embedded extends Component<typeof this> {
+    <template>
+      <strong>{{@model.name}}</strong> (Level: {{@model.level}})
+    </template>
+  };
+
+  static isolated = class Isolated extends Component<typeof this> {
+    @tracked rolls = [];
+    @tracked totalDamage = 0;
+    @tracked halfDamage = 0;
+
+    rollDie(sides) {
+      return Math.floor(Math.random() * sides) + 1;
+    }
+
+    parseDiceString(diceString) {
+      const [count, sides] = diceString.split('d').map(Number);
+      if (isNaN(count) || isNaN(sides) || count <= 0 || sides <= 0) {
+        throw new Error(`Invalid dice notation: ${diceString}`);
+      }
+      return { count, sides };
+    }
+
+    calculateTotalDamage() {
+      let totalDamage = this.rolls.reduce((sum, roll) => sum + roll.roll, 0);
+      this.totalDamage = totalDamage;
+      this.halfDamage = Math.floor(totalDamage / 2);
+    }
+
+    @action
+    calculateDamage() {
+      let rolls = [];
+      const diceStrings = this.args.model.damageDice || [];
+
+      try {
+        diceStrings.forEach((diceString) => {
+          const { count, sides } = this.parseDiceString(diceString);
+          for (let i = 0; i < count; i++) {
+            const roll = this.rollDie(sides);
+            rolls.push({ sides, roll, id: `${diceString}-${i}` });
+          }
+        });
+
+        this.rolls = rolls;
+        this.calculateTotalDamage();
+      } catch (error) {
+        console.error(error);
+      }
+    }
+
+    @action
+    rerollDie(dieId) {
+      let newRolls = this.rolls.map((roll) => {
+        if (roll.id === dieId) {
+          return { ...roll, roll: this.rollDie(roll.sides) };
+        }
+        return roll;
+      });
+      this.rolls = newRolls;
+      this.calculateTotalDamage();
+    }
+
+    <template>
+      <div class='spell-card'>
+        <h1 class='spell-name'>{{@model.name}}</h1>
+        <p class='spell-level'>Level: {{@model.level}}</p>
+        <p class='spell-description'>{{@model.spellDescription}}</p>
+        <button class='roll-button' {{on 'click' this.calculateDamage}}>Roll
+          Damage</button>
+
+        {{#if this.rolls.length}}
+          <h2 class='damage-header'>Damage Rolls</h2>
+          <ul class='roll-list'>
+            {{#each this.rolls as |roll|}}
+              <li>{{roll.roll}}
+                (d{{roll.sides}})
+                <button
+                  class='reroll-button'
+                  {{on 'click' (fn this.rerollDie roll.id)}}
+                >Reroll</button>
+              </li>
+            {{/each}}
+          </ul>
+          <p class='total-damage'><strong>Total Damage:</strong>
+            {{this.totalDamage}}</p>
+          <p class='half-damage'><strong>Half Damage (on save):</strong>
+            {{this.halfDamage}}</p>
+        {{/if}}
+      </div>
+
+      <style>
+        .spell-card {
+          font-family: 'Papyrus', fantasy;
+          border: 2px solid #6b4226;
+          border-radius: 8px;
+          padding: 20px;
+          max-width: 600px;
+          margin: auto;
+          color: #4b2e14;
+        }
+
+        .spell-name {
+          font-size: 2em;
+          text-align: center;
+          margin-bottom: 10px;
+        }
+
+        .spell-level,
+        .spell-description,
+        .total-damage,
+        .half-damage {
+          font-size: 1.2em;
+          margin-bottom: 10px;
+        }
+
+        .roll-button,
+        .reroll-button {
+          font-family: 'Papyrus', fantasy;
+          background-color: #4b2e14;
+          color: white;
+          border: none;
+          border-radius: 4px;
+          padding: 10px 20px;
+          cursor: pointer;
+        }
+
+        .roll-button:hover,
+        .reroll-button:hover {
+          background-color: #6b4226;
+        }
+
+        .damage-header {
+          text-align: center;
+          margin-top: 20px;
+          font-size: 1.5em;
+        }
+
+        .roll-list {
+          list-style-type: none;
+          padding: 0;
+        }
+
+        .roll-list li {
+          display: flex;
+          margin: 5px 0;
+          justify-content: space-between;
+          align-items: center;
+        }
+
+        .roll-list li button {
+          padding: 5px 10px;
+          margin-left: 10px;
+        }
+      </style>
+    </template>
+  };
+}
+
+// Define the Item card
+export class Item extends CardDef {
+  @field name = contains(StringField);
+  @field value = contains(NumberField);
+}
+
+// Define the InventoryItem card
+export class InventoryItem extends CardDef {
+  @field item = linksTo(Item);
+  @field quantity = contains(NumberField);
+}
+
+// Define the CharacterSheet card with attributes
+export class CharacterSheet extends CardDef {
+  @field name = contains(StringField);
+  @field level = contains(NumberField);
+  @field class = contains(StringField);
+  @field race = contains(StringField);
+  @field hitPoints = contains(NumberField);
+  @field strength = contains(NumberField);
+  @field dexterity = contains(NumberField);
+  @field constitution = contains(NumberField);
+  @field intelligence = contains(NumberField);
+  @field wisdom = contains(NumberField);
+  @field charisma = contains(NumberField);
+  @field spells = linksToMany(Spell);
+  @field inventory = linksToMany(InventoryItem);
+  static isolated = class Isolated extends Component<typeof this> {
+    <template>
+      <!-- Character Header Section -->
+      <div class='character-header'>
+        <h1>{{@model.name}}</h1>
+        <h3>{{@model.title}}</h3>
+        <p>{{@model.description}}</p>
+      </div>
+
+      <!-- Character Basic Information Section -->
+      <div class='character-info'>
+        <div>
+          <strong>Level:</strong>
+          {{@model.level}}
+        </div>
+        <div>
+          <strong>Class:</strong>
+          {{@model.class}}
+        </div>
+        <div>
+          <strong>Race:</strong>
+          {{@model.race}}
+        </div>
+        <div>
+          <strong>Hit Points:</strong>
+          {{@model.hitPoints}}
+        </div>
+      </div>
+
+      <!-- Character Attributes Section -->
+      <div class='character-attributes'>
+        <h2>Attributes</h2>
+        <div class='attribute-grid'>
+          <div><strong>Strength:</strong> {{@model.strength}}</div>
+          <div><strong>Dexterity:</strong> {{@model.dexterity}}</div>
+          <div><strong>Constitution:</strong> {{@model.constitution}}</div>
+          <div><strong>Intelligence:</strong> {{@model.intelligence}}</div>
+          <div><strong>Wisdom:</strong> {{@model.wisdom}}</div>
+          <div><strong>Charisma:</strong> {{@model.charisma}}</div>
+        </div>
+      </div>
+
+      <!-- Character Spells Section -->
+      <div class='character-spells'>
+        <h2>Spells</h2>
+        <ul>
+          {{#each @fields.spells as |spell|}}
+            <li> <spell /> </li>
+          {{/each}}
+        </ul>
+      </div>
+
+      <!-- Character Inventory Section -->
+      <div class='character-inventory'>
+        <h2>Inventory</h2>
+        <ul>
+          {{#each @model.inventory as |inventoryItem|}}
+            <li>{{inventoryItem.item.name}}
+              (Quantity:
+              {{inventoryItem.quantity}})</li>
+          {{/each}}
+        </ul>
+      </div>
+
+      <!-- CSS Styling -->
+      <style>
+        body {
+          font-family: 'Cinzel', serif; /* Classic fantasy font */
+          background-color: #f5ecd3; /* Parchment background */
+          color: #333333; /* Dark text for readability */
+        }
+
+        .character-header {
+          text-align: center;
+          margin-bottom: 30px;
+          padding: 20px;
+          border: 3px solid #8a4f7d;
+          background-color: #fff8dc; /* Light parchment background */
+          border-radius: 10px;
+          box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+        }
+
+        .character-info,
+        .character-attributes,
+        .character-spells,
+        .character-inventory {
+          margin: 20px;
+          padding: 15px;
+          border: 2px solid #8a4f7d;
+          background-color: #fffaf0;
+          border-radius: 10px;
+          box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+        }
+
+        .character-info {
+          display: grid;
+          grid-template-columns: repeat(2, 1fr);
+          gap: 15px;
+          justify-items: center;
+        }
+
+        .character-attributes {
+          margin-top: 20px;
+        }
+
+        .attribute-grid {
+          display: grid;
+          grid-template-columns: repeat(3, 1fr);
+          gap: 20px;
+          text-align: center;
+        }
+
+        .character-info div,
+        .character-attributes div {
+          margin-bottom: 10px;
+        }
+
+        h1,
+        h2,
+        h3 {
+          font-family: 'Cinzel Decorative', serif; /* Decorative header font */
+        }
+
+        h2 {
+          border-bottom: 2px solid #8a4f7d;
+          padding-bottom: 5px;
+          margin-bottom: 15px;
+          text-transform: uppercase;
+        }
+
+        ul {
+          list-style: none;
+          padding: 0;
+        }
+
+        ul li {
+          background-color: #e6e2d3;
+          padding: 10px;
+          margin-bottom: 5px;
+          border-radius: 5px;
+          box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
+        }
+
+        ul li:nth-child(odd) {
+          background-color: #d2ccc4;
+        }
+
+        ul li:nth-child(even) {
+          background-color: #e6e2d3;
+        }
+
+        .character-header h1 {
+          font-size: 2.5em;
+          margin-bottom: 5px;
+          color: #8a4f7d;
+        }
+
+        .character-header h3 {
+          font-size: 1.5em;
+          margin-bottom: 15px;
+          color: #8a4f7d;
+        }
+
+        [hidden] {
+          display: none !important;
+        }
+      </style>
+    </template>
+  };
+}

--- a/packages/drafts-realm/dnd.gts
+++ b/packages/drafts-realm/dnd.gts
@@ -13,7 +13,15 @@ import BooleanField from 'https://cardstack.com/base/boolean';
 import MarkdownField from 'https://cardstack.com/base/markdown';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
+
+/**
+ * These imports *are* used, but a bug causes them to be flagged as unused
+ * It seems related to the other issue of saying decorators are not valid
+ */
+
+// @ts-ignore  TS6133: 'action' is declared but its value is never read.
 import { action } from '@ember/object';
+// @ts-ignore  TS6133: 'tracked' is declared but its value is never read.
 import { tracked } from '@glimmer/tracking';
 
 export class Spell extends CardDef {


### PR DESCRIPTION
The code and content here is almost entirely AI generated, and done within the assistant panel.

Not AI:

* Imports
* Delegate spell rendering to spell card
* Changed spell template from embedded to isolated
* Had to keep moving things from the "description" field as it's not *really* a description field.

Notes on dev:

Swapping back and forth to see the results was a pain. Particularly since you can't currently refresh operator mode or view cards on their own.

Very common to hit errors that didn't seem recoverable with missing loaders (error message just "this should not happen"), had to restart the realm server a lot locally.

Sometimes the page would say it was saving the card but it actually didn't, and the code on disk didn't match what I saw, so I was trying to debug the wrong code.

If there's a bug that stops it rendering, if you don't get a useful error the card seems like it stops existing in operator mode, difficult to tell where things are wrong if a nested card 

Rendering of linked cards adds a lot of framing that I'd like to remove.

Linked cards can't have interactive elements in them, as the whole div is clickable so you can't interact with them.

Notes on AI dev:

* It gets a bit confused with fields vs model, so I just told it about the model
* Patches would be better, mostly spat out the whole replacement file
* 4o is fast enough to make this dev generally quite fast
* worked well for debugging an issue with tracked objects and things not updating, I described the issue with rerolling and it explained the problem and then fixed it with a variable reassignment
* it's ok at templates, but not all fonts are available and it tries to set urls that it guesses at for textured backgrounds
* All code *ran* first time. The only fixes needed were to working code that just did the wrong thing, or the tracked rerendering issue.

[Screencast from 20-05-24 14:07:23.webm](https://github.com/cardstack/boxel/assets/53767/56822b6a-d9ad-4072-b2f6-6bdaf6790985)
