### PR TITLE
Fix: apply button is not replaced with check mark icon

### DIFF
--- a/packages/base/room.gts
+++ b/packages/base/room.gts
@@ -588,7 +588,10 @@ export class RoomField extends FieldDef {
             (e) =>
               e.type === 'm.reaction' &&
               e.content['m.relates_to']?.rel_type === 'm.annotation' &&
-              e.content['m.relates_to']?.event_id === command.eventId,
+              e.content['m.relates_to']?.event_id ===
+                // If the message is a replacement message, eventId in command payload will be undefined.
+                // Because it will not refer to any other events, so we can use event_id of the message itself.
+                (command.eventId ?? event_id),
           ) as ReactionEvent | undefined;
 
           messageField = new MessageField({

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -1499,7 +1499,7 @@ module('Integration | operator-mode', function (hooks) {
         .exists();
     });
 
-    test('essures applied state displayed as a check mark even eventId in command payload is undefined', async function (assert) {
+    test('assures applied state displayed as a check mark even eventId in command payload is undefined', async function (assert) {
       let id = `${testRealmURL}Person/fadhlan`;
       await setCardInOperatorModeState(id);
       await renderComponent(

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -1526,7 +1526,7 @@ module('Integration | operator-mode', function (hooks) {
           format: 'org.matrix.custom.html',
           data: JSON.stringify({
             command: {
-              type: 'patch',
+              type: 'patchCard',
               id,
               patch: { attributes: { firstName: 'Dave' } },
               eventId: undefined,


### PR DESCRIPTION
**Problem**
I encountered a bug where there are multiple responses from ai bot and the patch command message is not the first response. The apply button of that message would not be replaced with check mark icon even after the patch was applied. 

**Solution**
We looked up the reaction event (the event that indicates the command is already applied) using `eventId` from the command payload while `eventId` in command payload can be `undefined`.  If `eventId` in command payload is undefined, then that message is not a replacement message for "Thinking" message, in that case we can use `eventId` of the message it self.