### PR TITLE
Use correct migrations table when using CLI for migrations

### DIFF
--- a/packages/realm-server/package.json
+++ b/packages/realm-server/package.json
@@ -96,7 +96,7 @@
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
     "lint:glint": "glint",
-    "migrate": "PGDATABASE=boxel ./scripts/ensure-db-exists.sh && PGPORT=5435 PGDATABASE=boxel PGUSER=postgres node-pg-migrate",
+    "migrate": "PGDATABASE=boxel ./scripts/ensure-db-exists.sh && PGPORT=5435 PGDATABASE=boxel PGUSER=postgres node-pg-migrate --migrations-table migrations",
     "make-schema": "./scripts/schema-dump.sh",
     "drop-db": "docker exec boxel-pg dropdb -U postgres -w",
     "drop-all-dbs": "./scripts/drop-all-dbs.sh"


### PR DESCRIPTION
I ran into a problem where if I:

1. Drop all dbs ` pnom drop-all-dbs`
2. Migrate manually `pnpm migrate up`
3. Run realms `pnpm start:all`

...the realm will crash with `Unexpected error encountered starting realm, stopping server error: relation "boxel_index" already exists` error

This happens because the server on boot will try to run migrations but migrations were already run. It doesn't know the migrations were already run because there is a discrepancy in where migration run data is stored. When pnpm command is used, the migrations are stored in table `pgmigrations` (because this is [the default](https://github.com/salsita/node-pg-migrate/blob/3060a72ac1d1d88ead6e60f2155eda6ea8c7ae48/bin/node-pg-migrate.ts#L442-L443) for node-pg-migrate). When migrations are run from within the server on boot, it will store it in `migrations`(because we specify it here: https://github.com/cardstack/boxel/blob/aed81176a3ca3fcd17aeb3985879d8e9be5ee8cc/packages/realm-server/pg-adapter.ts#L168) 

The alternative to the proposed solution would be to change `migrationsTable` config in the code above to `pgmigrations`. But we'd have to do some cleanup in our deployed environments to delete `migrations` table (because we'd be using `pgmigrations` from there on). I think it's easier if we just supply the table argument in the pnpm command and leave the rest