### PR TITLE
guard against set title twice in room

### DIFF
--- a/packages/ai-bot/lib/set-title.ts
+++ b/packages/ai-bot/lib/set-title.ts
@@ -119,7 +119,7 @@ export const getLatestPatchApplyMessage = (
   return [];
 };
 
-const roomTitleAlreadySet = (rawEventLog: DiscreteMatrixEvent[]) => {
+export const roomTitleAlreadySet = (rawEventLog: DiscreteMatrixEvent[]) => {
   return (
     rawEventLog.filter((event) => event.type === 'm.room.name').length > 1 ??
     false


### PR DESCRIPTION
This broke the previous behaviour bcause now everytime we apply a patch the title of the room is set. Now (or as previously) we just dont set it once its already set. Funnily, this is actually an expensive check but its not already different from what we are doing. We will solve the inital room sync optimisation separately