### PR TITLE
Trigger unhandled exception in fastboot during indexing

### DIFF
--- a/packages/host/app/components/card-prerender.gts
+++ b/packages/host/app/components/card-prerender.gts
@@ -49,9 +49,9 @@ export default class CardPrerender extends Component {
     }
   }
 
-  private async fromScratch(realmURL: URL): Promise<IndexResults> {
+  private async fromScratch(realmURL: URL, boom?: true): Promise<IndexResults> {
     try {
-      let results = await this.doFromScratch.perform(realmURL);
+      let results = await this.doFromScratch.perform(realmURL, boom);
       return results;
     } catch (e: any) {
       if (!didCancel(e)) {
@@ -96,7 +96,7 @@ export default class CardPrerender extends Component {
     await register(this.fromScratch.bind(this), this.incremental.bind(this));
   });
 
-  private doFromScratch = enqueueTask(async (realmURL: URL) => {
+  private doFromScratch = enqueueTask(async (realmURL: URL, boom?: true) => {
     let { reader, indexer } = this.getRunnerParams();
     await this.resetLoaderInFastboot.perform();
     let current = await CurrentRun.fromScratch(
@@ -107,6 +107,7 @@ export default class CardPrerender extends Component {
         indexer,
         renderCard: this.renderService.renderCard.bind(this.renderService),
       }),
+      boom,
     );
     this.renderService.indexRunDeferred?.fulfill();
     return current;

--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -120,12 +120,20 @@ export class CurrentRun {
     ]);
   }
 
-  static async fromScratch(current: CurrentRun): Promise<IndexResults> {
+  static async fromScratch(
+    current: CurrentRun,
+    boom?: true,
+  ): Promise<IndexResults> {
     await current.whileIndexing(async () => {
       let start = Date.now();
       log.debug(`starting from scratch indexing`);
       current.#batch = await current.#indexer.createBatch(current.realmURL);
       await current.batch.makeNewGeneration();
+      if (boom) {
+        throw new Error(
+          `Boom! this is a manually generated unhanded exception during indexing used for testing`,
+        );
+      }
       await current.visitDirectory(current.realmURL);
       await current.batch.done();
       log.debug(`completed from scratch indexing in ${Date.now() - start}ms`);

--- a/packages/runtime-common/worker.ts
+++ b/packages/runtime-common/worker.ts
@@ -110,7 +110,9 @@ export class Worker {
   #indexer: Indexer;
   #queue: Queue;
   #loader: Loader;
-  #fromScratch: ((realmURL: URL) => Promise<IndexResults>) | undefined;
+  #fromScratch:
+    | ((realmURL: URL, boom?: true) => Promise<IndexResults>)
+    | undefined;
   #realmAdapter: RealmAdapter;
   #incremental:
     | ((
@@ -195,13 +197,14 @@ export class Worker {
     return result;
   }
 
-  private fromScratch = async (args: FromScratchArgs) => {
+  private fromScratch = async (args: FromScratchArgs & { boom?: true }) => {
     return await this.prepareAndRunJob<FromScratchResult>(async () => {
       if (!this.#fromScratch) {
         throw new Error(`Index runner has not been registered`);
       }
       let { ignoreData, stats } = await this.#fromScratch(
         new URL(args.realmURL),
+        args.boom,
       );
       return {
         ignoreData: { ...ignoreData },


### PR DESCRIPTION
In order to test sentry logging of indexing errors, this adds a manually invoked unhandled exception job option `boom` that allows us to throw an excpeption within fastboot to trigger an unhandled exception during indexing. 

This is triggered by manually adding a from-scratch indexing job with the `boom: true` argument . (this is also a useful way to leave failed indexing artifacts in the DB to test the indexer's ability to recover from such scenarios)