### PR TITLE
common: Change SSE logging to debug level

### DIFF
--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -1679,7 +1679,7 @@ export class Realm {
   }
 
   private async sendServerEvent(event: ServerEvents): Promise<void> {
-    this.#log.info(
+    this.#log.debug(
       `sending updates to ${this.listeningClients.length} clients`,
     );
     let { type, data, id } = event;


### PR DESCRIPTION
This will reduce verbosity in output as seen [here](https://github.com/cardstack/boxel/actions/runs/9197685411/job/25298710657?pr=1242#step:10:5021).

<img width="717" alt="boxel@260895d 2024-05-23 11-25-52" src="https://github.com/cardstack/boxel/assets/43280/7495c7d1-7a3c-48aa-8f02-abb1425ace21">

If you search for `sending` [in logs from this PR](https://github.com/cardstack/boxel/actions/runs/9211627446/job/25341434483?pr=1287), it’s not present.