### PR TITLE
Fix issue with deserializing card that has cycle in linksTo

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -40,7 +40,6 @@ import {
   maybeURL,
   maybeRelativeURL,
   moduleFrom,
-  getCard,
   trackCard,
   type Meta,
   type CardFields,
@@ -915,16 +914,9 @@ class LinksTo<CardT extends CardDefConstructor> implements Field<CardT> {
       return null;
     }
     let loader = Loader.getLoaderFor(this.card)!;
-    let cardResource = getCard(new URL(value.links.self, relativeTo), {
-      cachedOnly: true,
-      loader,
-    });
-    await cardResource.loaded;
-    let cachedInstance =
-      cardResource.card ??
-      identityContext.identities.get(
-        new URL(value.links.self, relativeTo).href,
-      );
+    let cachedInstance = identityContext.identities.get(
+      new URL(value.links.self, relativeTo).href,
+    );
     if (cachedInstance) {
       cachedInstance[isSavedInstance] = true;
       return cachedInstance as BaseInstanceType<CardT>;
@@ -1273,16 +1265,9 @@ class LinksToMany<FieldT extends CardDefConstructor>
           return null;
         }
         let loader = Loader.getLoaderFor(this.card)!;
-        let cardResource = getCard(new URL(value.links.self, relativeTo), {
-          cachedOnly: true,
-          loader,
-        });
-        await cardResource.loaded;
-        let cachedInstance =
-          cardResource.card ??
-          identityContext.identities.get(
-            new URL(value.links.self, relativeTo).href,
-          );
+        let cachedInstance = identityContext.identities.get(
+          new URL(value.links.self, relativeTo).href,
+        );
         if (cachedInstance) {
           cachedInstance[isSavedInstance] = true;
           return cachedInstance;
@@ -2452,11 +2437,8 @@ export async function updateFromSerialized<T extends BaseDefConstructor>(
   instance: BaseInstanceType<T>,
   doc: LooseSingleCardDocument,
 ): Promise<BaseInstanceType<T>> {
-  let identityContext = identityContexts.get(instance);
-  if (!identityContext) {
-    identityContext = new IdentityContext();
-    identityContexts.set(instance, identityContext);
-  }
+  let identityContext = new IdentityContext();
+  identityContexts.set(instance, identityContext);
   if (!instance[relativeTo] && doc.data.id) {
     instance[relativeTo] = new URL(doc.data.id);
   }

--- a/packages/host/app/lib/stack-item.ts
+++ b/packages/host/app/lib/stack-item.ts
@@ -1,9 +1,4 @@
-import {
-  type Deferred,
-  Loader,
-  apiFor,
-  loaderFor,
-} from '@cardstack/runtime-common';
+import { type Deferred, apiFor } from '@cardstack/runtime-common';
 
 import {
   type CardResource,
@@ -53,9 +48,7 @@ export class StackItem {
       this.cardResource = cardResource;
     } else if (card?.id) {
       // if the card is not actually new--load a resource instead
-      this.cardResource = getCard(owner, () => card!.id, {
-        loader: () => loaderFor(card!),
-      });
+      this.cardResource = getCard(owner, () => card!.id);
     } else if (card) {
       this.newCard = card;
       this.newCardApiPromise = apiFor(this.card).then(
@@ -104,16 +97,14 @@ export class StackItem {
     await Promise.all([this.cardResource?.loaded, this.newCardApiPromise]);
   }
 
-  async setCardURL(url: URL, loader?: Loader) {
+  async setCardURL(url: URL) {
     if (this.cardResource) {
       throw new Error(
         `Cannot set cardURL ${url.href} on this stack item when CardResource has already been set`,
       );
     }
 
-    this.cardResource = getCard(this.owner, () => url.href, {
-      ...(loader ? { loader: () => loader } : {}),
-    });
+    this.cardResource = getCard(this.owner, () => url.href);
     await this.cardResource.loaded;
     this.newCard = undefined;
   }

--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -18,6 +18,7 @@ import {
   type LooseSingleCardDocument,
   type RealmInfo,
   type Loader,
+  type PatchData,
 } from '@cardstack/runtime-common';
 import type { Query } from '@cardstack/runtime-common/query';
 
@@ -34,7 +35,7 @@ import type {
 } from 'https://cardstack.com/base/card-api';
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
 
-import { trackCard } from '../resources/card-resource';
+import { trackCard, getCard } from '../resources/card-resource';
 
 import type LoaderService from './loader-service';
 
@@ -56,8 +57,8 @@ export default class CardService extends Service {
 
   loaderToCardAPILoadingCache = new WeakMap<Loader, Promise<typeof CardAPI>>();
 
-  async getAPI(loader?: Loader): Promise<typeof CardAPI> {
-    loader = loader ?? this.loaderService.loader;
+  async getAPI(): Promise<typeof CardAPI> {
+    let loader = this.loaderService.loader;
     if (!this.loaderToCardAPILoadingCache.has(loader)) {
       let apiPromise = loader.import<typeof CardAPI>(
         'https://cardstack.com/base/card-api',
@@ -89,13 +90,11 @@ export default class CardService extends Service {
   async fetchJSON(
     url: string | URL,
     args?: RequestInit,
-    loader?: Loader,
   ): Promise<CardDocument | undefined> {
     let clientRequestId = uuidv4();
     this.clientRequestIds.add(clientRequestId);
 
-    loader = loader ?? this.loaderService.loader;
-    let response = await loader.fetch(url, {
+    let response = await this.loaderService.loader.fetch(url, {
       headers: {
         Accept: SupportedMimeType.CardJson,
         'X-Boxel-Client-Request-Id': clientRequestId,
@@ -124,15 +123,13 @@ export default class CardService extends Service {
     resource: LooseCardResource,
     doc: LooseSingleCardDocument | CardDocument,
     relativeTo?: URL | undefined,
-    loader?: Loader,
   ): Promise<CardDef> {
-    loader = loader ?? this.loaderService.loader;
-    let api = await this.getAPI(loader);
+    let api = await this.getAPI();
     let card = await api.createFromSerialized(
       resource,
       doc,
       relativeTo,
-      loader,
+      this.loaderService.loader,
     );
     // it's important that we absorb the field async here so that glimmer won't
     // encounter NotReady errors, since we don't have the luxury of the indexer
@@ -149,9 +146,8 @@ export default class CardService extends Service {
   async serializeCard(
     card: CardDef,
     opts?: SerializeOpts,
-    loader?: Loader,
   ): Promise<LooseSingleCardDocument> {
-    let api = await this.getAPI(loader);
+    let api = await this.getAPI();
     let serialized = api.serializeCard(card, opts);
     delete serialized.included;
     return serialized;
@@ -161,14 +157,12 @@ export default class CardService extends Service {
   async saveModel<T extends object>(
     owner: T,
     card: CardDef,
-    loader?: Loader,
   ): Promise<CardDef | undefined> {
     let cardChanged = false;
     function onCardChange() {
       cardChanged = true;
     }
-    loader = loader ?? this.loaderService.loader;
-    let api = await this.getAPI(loader);
+    let api = await this.getAPI();
     try {
       api.subscribeToChanges(card, onCardChange);
       let doc = await this.serializeCard(card, {
@@ -218,9 +212,8 @@ export default class CardService extends Service {
     }
   }
 
-  async saveSource(url: URL, content: string, loader?: Loader) {
-    loader = loader ?? this.loaderService.loader;
-    let response = await loader.fetch(url, {
+  async saveSource(url: URL, content: string) {
+    let response = await this.loaderService.loader.fetch(url, {
       method: 'POST',
       headers: {
         Accept: 'application/vnd.card+source',
@@ -239,9 +232,8 @@ export default class CardService extends Service {
     return response;
   }
 
-  async deleteSource(url: URL, loader?: Loader) {
-    loader = loader ?? this.loaderService.loader;
-    let response = await loader.fetch(url, {
+  async deleteSource(url: URL) {
+    let response = await this.loaderService.loader.fetch(url, {
       method: 'DELETE',
       headers: {
         Accept: 'application/vnd.card+source',
@@ -262,12 +254,19 @@ export default class CardService extends Service {
   async patchCard(
     card: CardDef,
     doc: LooseSingleCardDocument,
-    patchData: Record<string, any>,
-    loader?: Loader,
+    patchData: PatchData,
   ): Promise<CardDef | undefined> {
-    let api = await this.getAPI(loader);
+    let api = await this.getAPI();
     let initialDoc = await this.serializeCard(card);
     let updatedCard = await api.updateFromSerialized<typeof CardDef>(card, doc);
+    let linkedCards = await this.loadPatchedCards(patchData, new URL(card.id));
+    for (let [field, value] of Object.entries(linkedCards)) {
+      // TODO this triggers a save which is not ideal. perhaps instead we could
+      // introduce a new option to updateFromSerialized to accept a list of
+      // fields to pre-load? which in this case would be any relationships that
+      // were patched in
+      (updatedCard as any)[field] = value;
+    }
     let updatedCardDoc = await this.serializeCard(updatedCard);
 
     if (!this.isPatchApplied(updatedCardDoc.data, patchData, card.id)) {
@@ -280,6 +279,34 @@ export default class CardService extends Service {
     return await this.saveModel(this, updatedCard);
   }
 
+  private async loadPatchedCards(
+    patchData: PatchData,
+    relativeTo: URL,
+  ): Promise<{
+    [fieldName: string]: CardDef;
+  }> {
+    if (!patchData?.relationships) {
+      return {};
+    }
+    let result: { [fieldName: string]: CardDef } = {};
+    await Promise.all(
+      Object.entries(patchData.relationships).map(async ([fieldName, rel]) => {
+        if (!rel.links.self) {
+          return;
+        }
+
+        let id = rel.links.self;
+        let cardResource = getCard(this, () => new URL(id, relativeTo).href);
+        await cardResource.loaded;
+        if (cardResource.card) {
+          result[fieldName] = cardResource.card;
+        }
+      }),
+    );
+    return result;
+  }
+
+  // TODO let's use better types for cardData and patchData here
   private isPatchApplied(
     cardData: Record<string, any> | undefined,
     patchData: Record<string, any>,
@@ -347,13 +374,9 @@ export default class CardService extends Service {
     return json;
   }
 
-  async copyCard(
-    source: CardDef,
-    destinationRealm: URL,
-    loader?: Loader,
-  ): Promise<CardDef> {
-    loader = loader ?? this.loaderService.loader;
-    let api = await this.getAPI(loader);
+  async copyCard(source: CardDef, destinationRealm: URL): Promise<CardDef> {
+    let loader = this.loaderService.loader;
+    let api = await this.getAPI();
     let serialized = await this.serializeCard(source, {
       maybeRelativeURL: null, // forces URL's to be absolute.
     });
@@ -417,27 +440,23 @@ export default class CardService extends Service {
 
   async getFields(
     cardOrField: BaseDef,
-    loader?: Loader,
   ): Promise<{ [fieldName: string]: Field<typeof BaseDef> }> {
-    let api = await this.getAPI(loader);
+    let api = await this.getAPI();
     return api.getFields(cardOrField, { includeComputeds: true });
   }
 
-  async isPrimitive(card: typeof FieldDef, loader?: Loader): Promise<boolean> {
-    let api = await this.getAPI(loader);
+  async isPrimitive(card: typeof FieldDef): Promise<boolean> {
+    let api = await this.getAPI();
     return api.primitive in card;
   }
 
-  async getRealmInfo(
-    card: CardDef,
-    loader?: Loader,
-  ): Promise<RealmInfo | undefined> {
-    let api = await this.getAPI(loader);
+  async getRealmInfo(card: CardDef): Promise<RealmInfo | undefined> {
+    let api = await this.getAPI();
     return card[api.realmInfo];
   }
 
-  async getRealmURL(card: CardDef, loader?: Loader) {
-    let api = await this.getAPI(loader);
+  async getRealmURL(card: CardDef) {
+    let api = await this.getAPI();
     // in the case where we get no realm URL from the card, we are dealing with
     // a new card instance that does not have a realm URL yet. For now let's
     // assume that the new card instance will reside in the realm that is hosting the app...
@@ -445,8 +464,8 @@ export default class CardService extends Service {
     return card[api.realmURL] ?? new URL(ownRealmURL);
   }
 
-  async cardsSettled(loader?: Loader) {
-    let api = await this.getAPI(loader);
+  async cardsSettled() {
+    let api = await this.getAPI();
     await api.flushLogs();
   }
 
@@ -460,12 +479,8 @@ export default class CardService extends Service {
     return undefined;
   }
 
-  async getRealmInfoByRealmURL(
-    realmURL: URL,
-    loader?: Loader,
-  ): Promise<RealmInfo> {
-    loader = loader ?? this.loaderService.loader;
-    let response = await loader.fetch(`${realmURL}_info`, {
+  async getRealmInfoByRealmURL(realmURL: URL): Promise<RealmInfo> {
+    let response = await this.loaderService.loader.fetch(`${realmURL}_info`, {
       headers: { Accept: SupportedMimeType.RealmInfo },
       method: 'GET',
     });

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -518,7 +518,7 @@ module('Integration | operator-mode', function (hooks) {
           data: {
             type: 'card',
             attributes: {
-              firstName: 'Friend A',
+              name: 'Friend A',
             },
             relationships: {
               friend: {
@@ -539,7 +539,7 @@ module('Integration | operator-mode', function (hooks) {
           data: {
             type: 'card',
             attributes: {
-              firstName: 'Friend B',
+              name: 'Friend B',
             },
             relationships: {
               friend: {
@@ -2971,8 +2971,7 @@ module('Integration | operator-mode', function (hooks) {
       .containsText('Jackie Woody Mango');
   });
 
-  // CS-6837 - causes a loop and a crash
-  skip('can add a card to a linksTo field creating a loop', async function (assert) {
+  test('can add a card to a linksTo field creating a loop', async function (assert) {
     // Friend A already links to friend B.
     // This test links B back to A
     await setCardInOperatorModeState(`${testRealmURL}Friend/friend-b`);
@@ -3002,7 +3001,9 @@ module('Integration | operator-mode', function (hooks) {
     // Normally we'd only have an assert like this at the end that may work,
     // but the rest of the application may be broken.
 
-    assert.dom('[data-test-field="friend"]').containsText('Friend A');
+    assert
+      .dom('[data-test-stack-card] [data-test-field="friend"]')
+      .containsText('Friend A');
 
     // Instead try and go somewhere else in the application to see if it's broken
     await waitFor('[data-test-submode-switcher]');
@@ -3190,9 +3191,6 @@ module('Integration | operator-mode', function (hooks) {
       .doesNotContainText('Jackie');
     assert.dom(`[data-test-plural-view-item]`).doesNotExist();
   });
-
-  skip('can create a specialized a new card to populate a linksTo field');
-  skip('can create a specialized a new card to populate a linksToMany field');
 
   test('can close cards by clicking the header of a card deeper in the stack', async function (assert) {
     await setCardInOperatorModeState(`${testRealmURL}grid`);

--- a/packages/host/tests/unit/indexer-test.ts
+++ b/packages/host/tests/unit/indexer-test.ts
@@ -1,4 +1,4 @@
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 
 import { Indexer } from '@cardstack/runtime-common';
 import { runSharedTest } from '@cardstack/runtime-common/helpers';
@@ -70,4 +70,6 @@ module('Unit | indexer', function (hooks) {
   test('can perform invalidations for an instance with deps more than a thousand', async function (assert) {
     await runSharedTest(indexerTests, assert, { indexer, adapter });
   });
+
+  skip('TODO: cross realm invalidation');
 });

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -11,6 +11,11 @@ export interface LooseSingleCardDocument {
   included?: CardResource<Saved>[];
 }
 
+export type PatchData = {
+  attributes?: CardResource['attributes'];
+  relationships?: CardResource['relationships'];
+};
+
 export { Deferred } from './deferred';
 export { CardError } from './error';
 

--- a/packages/runtime-common/indexer.ts
+++ b/packages/runtime-common/indexer.ts
@@ -10,6 +10,7 @@ import {
   identifyCard,
   hasExecutableExtension,
   trimExecutableExtension,
+  RealmPaths,
 } from './index';
 import {
   type PgPrimitive,
@@ -51,7 +52,6 @@ import { type DBAdapter } from './db';
 
 import type { BaseDef, Field } from 'https://cardstack.com/base/card-api';
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
-import { RealmPaths } from './index';
 
 export interface BoxelIndexTable {
   url: string;
@@ -864,6 +864,11 @@ export class Batch {
           };
         },
   ): Promise<void> {
+    if (!new RealmPaths(this.realmURL).inRealm(url)) {
+      // TODO this is a workaround for CS-6886. after we have solved that issue we can
+      // drop this band-aid
+      return;
+    }
     let href = url.href;
     this.touched.add(href);
     let { nameExpressions, valueExpressions } = asExpressions(


### PR DESCRIPTION
This issue came down to not handling relative URL’s correctly in our identity context, as well as not detecting cycles in our unsubscribe logic. 

Also, pulling on this loose thread resulted in a bunch of related fixes and cleanup.