### PR TITLE
Stop using async computed

### DIFF
--- a/docs/computed-fields.md
+++ b/docs/computed-fields.md
@@ -37,28 +37,6 @@ When any field consumed by the computed field changes, the value will [rerender]
 
 Computed fields are eagerly evaluated, they do not need to be consumed for `computeVia` to run.
 
-## Async computation
-
-The calculation can be async:
-
-```typescript
-@field slowName = contains(StringCard, {
-  computeVia: async function () {
-    await new Promise((resolve) => setTimeout(resolve, 10));
-    return this.firstName;
-  }
-});
-```
-
-The values of async computed fields are available synchronously in other `computedVia` functions. Since async field values are not guaranteed to be present, you can use card API [`getIfReady`](https://github.com/cardstack/boxel/blob/307d78676ebdb93cee75d61b8812914013a094a7/packages/base/card-api.gts#L2112) avoid errors about the field not being ready:
-
-```javascript
-await getIfReady(this, 'fullName');
-// 'Carl Stack'
-await getIfReady(this, 'fullName');
-// {type: 'not-ready', fieldName: 'fullName', instance: …}
-```
-
 ## Computed `linksTo` and `linksToMany`
 
 While `computeVia` can currently only be applied to `contains`/`containsMany` fields, there’s a plan to let it work for `linksTo` and `linksToMany` in the future.

--- a/packages/base/catalog-entry.gts
+++ b/packages/base/catalog-entry.gts
@@ -4,21 +4,13 @@ import {
   Component,
   CardDef,
   FieldDef,
-  BaseDef,
-  primitive,
   relativeTo,
   realmInfo,
 } from './card-api';
 import StringField from './string';
 import BooleanField from './boolean';
 import CodeRef from './code-ref';
-import {
-  baseCardRef,
-  isFieldDef,
-  loadCard,
-  Loader,
-} from '@cardstack/runtime-common';
-import { isEqual } from 'lodash';
+
 import { FieldContainer } from '@cardstack/boxel-ui/components';
 import GlimmerComponent from '@glimmer/component';
 
@@ -27,49 +19,10 @@ export class CatalogEntry extends CardDef {
   @field title = contains(StringField);
   @field description = contains(StringField);
   @field ref = contains(CodeRef);
-  @field isPrimitive = contains(BooleanField, {
-    computeVia: async function (this: CatalogEntry) {
-      let loader = Loader.getLoaderFor(Object.getPrototypeOf(this).constructor);
 
-      if (!loader) {
-        throw new Error(
-          'Could not find a loader for this instance’s class’s module',
-        );
-      }
-
-      let card: typeof BaseDef | undefined = await loadCard(this.ref, {
-        loader,
-        relativeTo: this[relativeTo],
-      });
-      if (!card) {
-        throw new Error(`Could not load card '${this.ref.name}'`);
-      }
-      // the base card is a special case where it is technically not a primitive, but because it has no fields
-      // it is not useful to treat as a composite card (for the purposes of creating new card instances).
-      return primitive in card || isEqual(baseCardRef, this.ref);
-    },
-  });
   // If it's not a field, then it's a card
-  @field isField = contains(BooleanField, {
-    computeVia: async function (this: CatalogEntry) {
-      let loader = Loader.getLoaderFor(Object.getPrototypeOf(this).constructor);
+  @field isField = contains(BooleanField);
 
-      if (!loader) {
-        throw new Error(
-          'Could not find a loader for this instance’s class’s module',
-        );
-      }
-
-      let card: typeof BaseDef | undefined = await loadCard(this.ref, {
-        loader,
-        relativeTo: this[relativeTo],
-      });
-      if (!card) {
-        throw new Error(`Could not load card '${this.ref.name}'`);
-      }
-      return isFieldDef(card);
-    },
-  });
   @field moduleHref = contains(StringField, {
     computeVia: function (this: CatalogEntry) {
       return new URL(this.ref.module, this[relativeTo]).href;
@@ -163,10 +116,6 @@ export class CatalogEntry extends CardDef {
         </div>
         {{#if @model.showDemo}}
           <div data-test-demo><@fields.demo /></div>
-        {{/if}}
-        {{! field needs to be used in order to be indexed }}
-        {{#if @model.isPrimitive}}
-          <div>Field is primitive</div>
         {{/if}}
       </CatalogEntryContainer>
       <style>

--- a/packages/base/fields/base64-image.json
+++ b/packages/base/fields/base64-image.json
@@ -4,6 +4,7 @@
     "attributes": {
       "title": "Base64 Image Field",
       "description": "A field capable of representing an image via base64 encoding.",
+      "isField": true,
       "ref": {
         "module": "https://cardstack.com/base/base64-image",
         "name": "Base64ImageField"

--- a/packages/base/fields/biginteger-field.json
+++ b/packages/base/fields/biginteger-field.json
@@ -4,6 +4,7 @@
     "attributes": {
       "title": "Bigint Field",
       "description": "A field that captures big int values",
+      "isField": true,
       "ref": {
         "module": "https://cardstack.com/base/big-integer",
         "name": "default"

--- a/packages/base/fields/boolean-field.json
+++ b/packages/base/fields/boolean-field.json
@@ -4,6 +4,7 @@
     "attributes": {
       "title": "Boolean Field",
       "description": "A field that captures boolean values (true/false)",
+      "isField": true,
       "ref": {
         "module": "https://cardstack.com/base/boolean",
         "name": "default"

--- a/packages/base/fields/code-ref-field.json
+++ b/packages/base/fields/code-ref-field.json
@@ -4,6 +4,7 @@
     "attributes": {
       "title": "Code Reference Field",
       "description": "A field that captures a reference to a card or field type",
+      "isField": true,
       "ref": {
         "module": "https://cardstack.com/base/code-ref",
         "name": "default"

--- a/packages/base/fields/date-field.json
+++ b/packages/base/fields/date-field.json
@@ -4,6 +4,7 @@
     "attributes": {
       "title": "Date Field",
       "description": "A field that captures date values",
+      "isField": true,
       "ref": {
         "module": "https://cardstack.com/base/date",
         "name": "default"

--- a/packages/base/fields/datetime-field.json
+++ b/packages/base/fields/datetime-field.json
@@ -4,6 +4,7 @@
     "attributes": {
       "title": "Date-time Field",
       "description": "A field that captures date-time values",
+      "isField": true,
       "ref": {
         "module": "https://cardstack.com/base/datetime",
         "name": "default"

--- a/packages/base/fields/ethereum-address-field.json
+++ b/packages/base/fields/ethereum-address-field.json
@@ -4,6 +4,7 @@
     "attributes": {
       "title": "Ethereum Address Field",
       "description": "A field that captures checksum ethereum addresses",
+      "isField": true,
       "ref": {
         "module": "https://cardstack.com/base/ethereum-address",
         "name": "default"

--- a/packages/base/fields/field.json
+++ b/packages/base/fields/field.json
@@ -4,6 +4,7 @@
     "attributes": {
       "title": "General Field",
       "description": "A general field that can contain any field type.",
+      "isField": true,
       "ref": {
         "module": "https://cardstack.com/base/card-api",
         "name": "FieldDef"

--- a/packages/base/fields/markdown-field.json
+++ b/packages/base/fields/markdown-field.json
@@ -4,6 +4,7 @@
     "attributes": {
       "title": "Markdown Field",
       "description": "A field that captures markdown values",
+      "isField": true,
       "ref": {
         "module": "https://cardstack.com/base/markdown",
         "name": "default"

--- a/packages/base/fields/number-field.json
+++ b/packages/base/fields/number-field.json
@@ -4,6 +4,7 @@
     "attributes": {
       "title": "Number Field",
       "description": "A field that captures number values",
+      "isField": true,
       "ref": {
         "module": "https://cardstack.com/base/number",
         "name": "default"

--- a/packages/base/fields/string-field.json
+++ b/packages/base/fields/string-field.json
@@ -4,6 +4,7 @@
     "attributes": {
       "title": "String Field",
       "description": "A field that captures string values",
+      "isField": true,
       "ref": {
         "module": "https://cardstack.com/base/string",
         "name": "default"

--- a/packages/base/fields/text-area-field.json
+++ b/packages/base/fields/text-area-field.json
@@ -4,6 +4,7 @@
     "attributes": {
       "title": "Text Area Field",
       "description": "A field that can capture string values in a multi-line input format. Useful for capturing a large body of text.",
+      "isField": true,
       "ref": {
         "module": "https://cardstack.com/base/text-area",
         "name": "default"

--- a/packages/base/types/card.json
+++ b/packages/base/types/card.json
@@ -4,7 +4,7 @@
     "attributes": {
       "title": "General Card",
       "description": "A general card that can contain any card type.",
-      "isField": true,
+      "isField": false,
       "ref": {
         "module": "https://cardstack.com/base/card-api",
         "name": "CardDef"

--- a/packages/base/types/card.json
+++ b/packages/base/types/card.json
@@ -4,6 +4,7 @@
     "attributes": {
       "title": "General Card",
       "description": "A general card that can contain any card type.",
+      "isField": true,
       "ref": {
         "module": "https://cardstack.com/base/card-api",
         "name": "CardDef"

--- a/packages/drafts-realm/CatalogEntry/1.json
+++ b/packages/drafts-realm/CatalogEntry/1.json
@@ -4,6 +4,7 @@
     "attributes": {
       "title": "Person",
       "description": "Catalog entry for Person card",
+      "isField": false,
       "ref": {
         "module": "../person",
         "name": "Person"

--- a/packages/drafts-realm/CatalogEntry/10.json
+++ b/packages/drafts-realm/CatalogEntry/10.json
@@ -4,6 +4,7 @@
     "attributes": {
       "title": "Friends from ../friends",
       "description": "Catalog entry for Friends from ../friends",
+      "isField": false,
       "ref": {
         "module": "../friends",
         "name": "Friends"

--- a/packages/drafts-realm/CatalogEntry/11.json
+++ b/packages/drafts-realm/CatalogEntry/11.json
@@ -4,6 +4,7 @@
     "attributes": {
       "title": "ContactCard",
       "description": "Catalog entry for ContactCard",
+      "isField": false,
       "ref": {
         "module": "../contact-card",
         "name": "ContactCard"

--- a/packages/drafts-realm/CatalogEntry/2.json
+++ b/packages/drafts-realm/CatalogEntry/2.json
@@ -3,6 +3,7 @@
     "attributes": {
       "title": "Pet",
       "description": "Catalog entry for Pet card",
+      "isField": false,
       "ref": {
         "module": "../pet",
         "name": "Pet"

--- a/packages/drafts-realm/CatalogEntry/3.json
+++ b/packages/drafts-realm/CatalogEntry/3.json
@@ -4,6 +4,7 @@
     "attributes": {
       "title": "Chain from /chain",
       "description": "Catalog entry for Chain from /chain",
+      "isField": false,
       "ref": {
         "module": "../chain",
         "name": "Chain"

--- a/packages/drafts-realm/CatalogEntry/4.json
+++ b/packages/drafts-realm/CatalogEntry/4.json
@@ -4,6 +4,7 @@
     "attributes": {
       "title": "Token from /asset",
       "description": "Catalog entry for Token from /asset",
+      "isField": false,
       "ref": {
         "module": "../asset",
         "name": "Token"

--- a/packages/drafts-realm/CatalogEntry/5.json
+++ b/packages/drafts-realm/CatalogEntry/5.json
@@ -4,6 +4,7 @@
     "attributes": {
       "title": "InvoicePacket from /invoice-packet",
       "description": "Catalog entry for InvoicePacket from /invoice-packet",
+      "isField": false,
       "ref": {
         "module": "../invoice-packet",
         "name": "InvoicePacket"

--- a/packages/drafts-realm/CatalogEntry/6.json
+++ b/packages/drafts-realm/CatalogEntry/6.json
@@ -4,6 +4,7 @@
     "attributes": {
       "title": "Friend from /friend",
       "description": "Catalog entry for Friend from /friend",
+      "isField": false,
       "ref": {
         "module": "../friend",
         "name": "Friend"

--- a/packages/drafts-realm/CatalogEntry/7.json
+++ b/packages/drafts-realm/CatalogEntry/7.json
@@ -4,6 +4,7 @@
     "attributes": {
       "title": "Booking Card",
       "description": "Catalog entry for Booking Card",
+      "isField": false,
       "ref": {
         "module": "../booking",
         "name": "Booking"

--- a/packages/drafts-realm/CatalogEntry/8.json
+++ b/packages/drafts-realm/CatalogEntry/8.json
@@ -4,6 +4,7 @@
     "attributes": {
       "title": "PublishingPacket from ../publishing-packet",
       "description": "Catalog entry for PublishingPacket from ../publishing-packet",
+      "isField": false,
       "ref": {
         "module": "../publishing-packet",
         "name": "PublishingPacket"

--- a/packages/drafts-realm/CatalogEntry/9.json
+++ b/packages/drafts-realm/CatalogEntry/9.json
@@ -4,6 +4,7 @@
     "attributes": {
       "title": "Claim from ../claim",
       "description": "Catalog entry for Claim from ../claim",
+      "isField": false,
       "ref": {
         "module": "../claim",
         "name": "Claim"

--- a/packages/drafts-realm/CatalogEntry/author.json
+++ b/packages/drafts-realm/CatalogEntry/author.json
@@ -5,19 +5,24 @@
       "title": "Author",
       "description": "Catalog entry for Author",
       "ref": {
-        "module": "../author",
-        "name": "Author"
+        "name": "Author",
+        "module": "../author"
       },
+      "isField": false,
       "demo": {
         "firstName": "Alice",
-        "lastName": "Enwunder"
+        "lastName": "Enwunder",
+        "photo": null,
+        "body": null,
+        "description": null,
+        "thumbnailURL": null
       }
     },
     "meta": {
       "fields": {
         "demo": {
           "adoptsFrom": {
-            "module": "../author",
+            "module": "http://localhost:4201/drafts/author",
             "name": "Author"
           }
         }

--- a/packages/drafts-realm/CatalogEntry/blog-post.json
+++ b/packages/drafts-realm/CatalogEntry/blog-post.json
@@ -4,6 +4,7 @@
     "attributes": {
       "title": "BlogPost",
       "description": "Catalog entry for BlogPost",
+      "isField": false,
       "ref": {
         "module": "../blog-post",
         "name": "BlogPost"

--- a/packages/drafts-realm/CatalogEntry/plant-info.json
+++ b/packages/drafts-realm/CatalogEntry/plant-info.json
@@ -4,6 +4,7 @@
     "attributes": {
       "title": "Plant Info",
       "description": "Catalog entry for Plant Info card",
+      "isField": false,
       "ref": {
         "module": "../plant-info",
         "name": "PlantInfo"

--- a/packages/drafts-realm/CatalogEntry/puppy.json
+++ b/packages/drafts-realm/CatalogEntry/puppy.json
@@ -4,6 +4,7 @@
     "attributes": {
       "title": "Puppy",
       "description": "Catalog entry for Puppy card",
+      "isField": false,
       "ref": {
         "module": "../puppy-card",
         "name": "PuppyCard"

--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -515,6 +515,7 @@ export default class CreateFileModal extends Component<Signature> {
     this.selectedCatalogEntry = await chooseCard({
       filter: {
         on: catalogEntryRef,
+        // REMEMBER ME
         eq: { isField },
       },
     });

--- a/packages/host/app/services/render-service.ts
+++ b/packages/host/app/services/render-service.ts
@@ -123,6 +123,7 @@ export default class RenderService extends Service {
     return parseCardHtml(html);
   }
 
+  // TODO delete me
   private async resolveField(
     params: Omit<RenderCardParams, 'format'> & { fieldName: string },
   ): Promise<void> {

--- a/packages/host/tests/acceptance/basic-test.gts
+++ b/packages/host/tests/acceptance/basic-test.gts
@@ -77,6 +77,7 @@ module('Acceptance | basic tests', function (hooks) {
         'person-entry.json': new CatalogEntry({
           title: 'Person',
           description: 'Catalog entry',
+          isField: false,
           ref: {
             module: `./person`,
             name: 'Person',

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -443,6 +443,7 @@ module('Acceptance | code submode tests', function (hooks) {
             attributes: {
               title: 'Person',
               description: 'Catalog entry',
+              isField: false,
               ref: {
                 module: `./person`,
                 name: 'Person',

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -91,6 +91,7 @@ const files: Record<string, any> = {
       attributes: {
         title: 'Error',
         description: 'Catalog entry for Error',
+        isField: false,
         ref: {
           module: '../error',
           name: 'default',
@@ -113,6 +114,7 @@ const files: Record<string, any> = {
       attributes: {
         title: 'Pet',
         description: 'Catalog entry for Pet',
+        isField: false,
         ref: { module: `../pet`, name: 'default' },
       },
       meta: {
@@ -129,6 +131,7 @@ const files: Record<string, any> = {
       attributes: {
         title: 'Person',
         description: 'Catalog entry for Person',
+        isField: false,
         ref: { module: `../person`, name: 'Person' },
       },
       meta: {

--- a/packages/host/tests/acceptance/code-submode/file-tree-test.ts
+++ b/packages/host/tests/acceptance/code-submode/file-tree-test.ts
@@ -220,6 +220,7 @@ module('Acceptance | code submode | file-tree tests', function (hooks) {
             attributes: {
               title: 'Person',
               description: 'Catalog entry',
+              isField: false,
               ref: {
                 module: `./person`,
                 name: 'Person',

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -437,6 +437,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
             attributes: {
               title: 'Person',
               description: 'Catalog entry',
+              isField: false,
               ref: {
                 module: `./person`,
                 name: 'Person',

--- a/packages/host/tests/acceptance/code-submode/recent-files-test.ts
+++ b/packages/host/tests/acceptance/code-submode/recent-files-test.ts
@@ -196,6 +196,7 @@ module('Acceptance | code submode | recent files tests', function (hooks) {
             attributes: {
               title: 'Person',
               description: 'Catalog entry',
+              isField: false,
               ref: {
                 module: `./person`,
                 name: 'Person',

--- a/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
@@ -249,6 +249,7 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
             attributes: {
               title: 'Person',
               description: 'Catalog entry',
+              isField: false,
               ref: {
                 module: `./person`,
                 name: 'Person',

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -258,6 +258,7 @@ module('Acceptance | interact submode tests', function (hooks) {
         'person-entry.json': new CatalogEntry({
           title: 'Person Card',
           description: 'Catalog entry for Person Card',
+          isField: false,
           ref: {
             module: `${testRealmURL}person`,
             name: 'Person',

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -266,6 +266,7 @@ module('Acceptance | operator mode tests', function (hooks) {
             attributes: {
               title: 'Person Card',
               description: 'Catalog entry for Person Card',
+              isField: false,
               ref: {
                 module: `${testRealmURL}person`,
                 name: 'Person',

--- a/packages/host/tests/acceptance/permissioned-realm-test.gts
+++ b/packages/host/tests/acceptance/permissioned-realm-test.gts
@@ -79,6 +79,7 @@ module('Acceptance | permissioned realm tests', function (hooks) {
         'person-entry.json': new CatalogEntry({
           title: 'Person',
           description: 'Catalog entry',
+          isField: false,
           ref: {
             module: `./person`,
             name: 'Person',

--- a/packages/host/tests/cards/person.gts
+++ b/packages/host/tests/cards/person.gts
@@ -14,8 +14,7 @@ export class Person extends CardDef {
   @field email = contains(StringCard);
   @field posts = contains(NumberCard);
   @field fullName = contains(StringCard, {
-    computeVia: async function (this: Person) {
-      await new Promise((resolve) => setTimeout(resolve, 10));
+    computeVia: function (this: Person) {
       return `${this.firstName ?? ''} ${this.lastName ?? ''}`;
     },
   });
@@ -46,8 +45,7 @@ export class PersonField extends FieldDef {
   @field email = contains(StringCard);
   @field posts = contains(NumberCard);
   @field fullName = contains(StringCard, {
-    computeVia: async function (this: Person) {
-      await new Promise((resolve) => setTimeout(resolve, 10));
+    computeVia: function (this: Person) {
       return `${this.firstName ?? ''} ${this.lastName ?? ''}`;
     },
   });

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -50,7 +50,6 @@ let date: typeof import('https://cardstack.com/base/date');
 let datetime: typeof import('https://cardstack.com/base/datetime');
 let boolean: typeof import('https://cardstack.com/base/boolean');
 let codeRef: typeof import('https://cardstack.com/base/code-ref');
-let catalogEntry: typeof import('https://cardstack.com/base/catalog-entry');
 let base64Image: typeof import('https://cardstack.com/base/base64-image');
 let ethereumAddress: typeof import('https://cardstack.com/base/ethereum-address');
 let markdown: typeof import('https://cardstack.com/base/markdown');
@@ -84,7 +83,6 @@ module('Integration | card-basics', function (hooks) {
     datetime = await loader.import(`${baseRealm.url}datetime`);
     boolean = await loader.import(`${baseRealm.url}boolean`);
     codeRef = await loader.import(`${baseRealm.url}code-ref`);
-    catalogEntry = await loader.import(`${baseRealm.url}catalog-entry`);
     base64Image = await loader.import(`${baseRealm.url}base64-image`);
     markdown = await loader.import(`${baseRealm.url}markdown`);
     ethereumAddress = await loader.import(`${baseRealm.url}ethereum-address`);
@@ -1152,56 +1150,6 @@ module('Integration | card-basics', function (hooks) {
       assert.dom('[data-test-person]').containsText('Hassan');
       assert.dom('[data-test-pet="Mango"]').containsText('Mango');
       assert.dom('[data-test-pet="Van Gogh"]').containsText('Van Gogh');
-    });
-
-    test('catalog entry isField indicates if the catalog entry is a field card', async function (assert) {
-      let { CatalogEntry } = catalogEntry;
-
-      let cardEntry = new CatalogEntry({
-        title: 'CatalogEntry Card',
-        ref: {
-          module: 'https://cardstack.com/base/catalog-entry',
-          name: 'CatalogEntry',
-        },
-      });
-      let fieldEntry = new CatalogEntry({
-        title: 'String Card',
-        ref: {
-          module: 'https://cardstack.com/base/string',
-          name: 'default',
-        },
-      });
-
-      await cardApi.recompute(cardEntry, { recomputeAllFields: true });
-      await cardApi.recompute(fieldEntry, { recomputeAllFields: true });
-
-      assert.strictEqual(cardEntry.isField, false, 'isField is correct');
-      assert.strictEqual(fieldEntry.isField, true, 'isField is correct');
-    });
-
-    test('catalog entry isField indicates if the catalog entry references a card descended from FieldDef', async function (assert) {
-      let { CatalogEntry } = catalogEntry;
-
-      let cardFromCardDef = new CatalogEntry({
-        title: 'CatalogEntry Card',
-        ref: {
-          module: 'https://cardstack.com/base/catalog-entry',
-          name: 'CatalogEntry',
-        },
-      });
-      let cardFromFieldDef = new CatalogEntry({
-        title: 'String Card',
-        ref: {
-          module: 'https://cardstack.com/base/string',
-          name: 'default',
-        },
-      });
-
-      await cardApi.recompute(cardFromCardDef, { recomputeAllFields: true });
-      await cardApi.recompute(cardFromFieldDef, { recomputeAllFields: true });
-
-      assert.strictEqual(cardFromCardDef.isField, false, 'isField is correct');
-      assert.strictEqual(cardFromFieldDef.isField, true, 'isField is correct');
     });
 
     test('render whole composite field', async function (assert) {

--- a/packages/host/tests/integration/components/card-catalog-test.gts
+++ b/packages/host/tests/integration/components/card-catalog-test.gts
@@ -95,6 +95,7 @@ module('Integration | card-catalog', function (hooks) {
         'CatalogEntry/publishing-packet.json': new CatalogEntry({
           title: 'Publishing Packet',
           description: 'Catalog entry for PublishingPacket',
+          isField: false,
           ref: {
             module: `../publishing-packet`,
             name: 'PublishingPacket',
@@ -103,6 +104,7 @@ module('Integration | card-catalog', function (hooks) {
         'CatalogEntry/author.json': new CatalogEntry({
           title: 'Author',
           description: 'Catalog entry for Author',
+          isField: false,
           ref: {
             module: `${testRealmURL}author`,
             name: 'Author',
@@ -111,6 +113,7 @@ module('Integration | card-catalog', function (hooks) {
         'CatalogEntry/blog-post.json': new CatalogEntry({
           title: 'BlogPost',
           description: 'Catalog entry for BlogPost',
+          isField: false,
           ref: {
             module: `${testRealmURL}blog-post`,
             name: 'BlogPost',
@@ -119,6 +122,7 @@ module('Integration | card-catalog', function (hooks) {
         'CatalogEntry/address.json': new CatalogEntry({
           title: 'Address',
           description: 'Catalog entry for Address field',
+          isField: true,
           ref: {
             module: `${testRealmURL}address`,
             name: 'Address',

--- a/packages/host/tests/integration/components/computed-test.gts
+++ b/packages/host/tests/integration/components/computed-test.gts
@@ -1,4 +1,4 @@
-import { waitUntil, fillIn, RenderingTestContext } from '@ember/test-helpers';
+import { RenderingTestContext } from '@ember/test-helpers';
 
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -154,202 +154,27 @@ module('Integration | computeds', function (hooks) {
     assert.dom('[data-test="firstName"]').hasText('Mango');
   });
 
-  test('can render an asynchronous computed field', async function (assert) {
-    let { field, contains, CardDef, Component } = cardApi;
-    let { default: StringField } = string;
-    class Person extends CardDef {
-      @field firstName = contains(StringField);
-      @field slowName = contains(StringField, {
-        computeVia: 'computeSlowName',
-      });
-      async computeSlowName() {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-        return this.firstName;
-      }
-      static isolated = class Isolated extends Component<typeof this> {
-        <template>
-          <@fields.slowName />
-        </template>
-      };
-    }
-
-    let mango = new Person({ firstName: 'Mango' });
-    let root = await renderCard(loader, mango, 'isolated');
-    assert.strictEqual(root.textContent!.trim(), 'Mango');
-  });
-
-  test('can render an asynchronous computed field (using an async function in `computeVia`)', async function (assert) {
-    let { field, contains, CardDef, Component } = cardApi;
-    let { default: StringField } = string;
-    class Person extends CardDef {
-      @field firstName = contains(StringField);
-      @field slowName = contains(StringField, {
-        computeVia: async function (this: Person) {
-          await new Promise((resolve) => setTimeout(resolve, 10));
-          return this.firstName;
-        },
-      });
-      static isolated = class Isolated extends Component<typeof this> {
-        <template>
-          <@fields.slowName />
-        </template>
-      };
-    }
-
-    let mango = new Person({ firstName: 'Mango' });
-    let root = await renderCard(loader, mango, 'isolated');
-    assert.strictEqual(root.textContent!.trim(), 'Mango');
-  });
-
-  test('can indirectly render an asynchronous computed field', async function (assert) {
-    let { field, contains, CardDef, Component } = cardApi;
-    let { default: StringField } = string;
-    class Person extends CardDef {
-      @field firstName = contains(StringField);
-      @field slowName = contains(StringField, {
-        computeVia: 'computeSlowName',
-      });
-      @field slowNameAlias = contains(StringField, {
-        computeVia: function (this: Person) {
-          return this.slowName;
-        },
-      });
-      async computeSlowName() {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-        return this.firstName;
-      }
-      static isolated = class Isolated extends Component<typeof this> {
-        <template>
-          <@fields.slowNameAlias />
-        </template>
-      };
-    }
-
-    let mango = new Person({ firstName: 'Mango' });
-    let root = await renderCard(loader, mango, 'isolated');
-    assert.strictEqual(root.textContent!.trim(), 'Mango');
-  });
-
-  test('can render a async computed that depends on an async computed: consumer field is first', async function (assert) {
-    let { field, contains, CardDef, Component } = cardApi;
-    let { default: StringField } = string;
-    class Person extends CardDef {
-      @field firstName = contains(StringField);
-      @field verySlowName = contains(StringField, {
-        computeVia: async function (this: Person) {
-          await new Promise((resolve) => setTimeout(resolve, 100));
-          return this.slowName;
-        },
-      });
-      @field slowName = contains(StringField, {
-        computeVia: async function (this: Person) {
-          await new Promise((resolve) => setTimeout(resolve, 100));
-          return this.firstName;
-        },
-      });
-      static isolated = class Isolated extends Component<typeof this> {
-        <template>
-          <@fields.verySlowName />
-        </template>
-      };
-    }
-    let mango = new Person({ firstName: 'Mango' });
-    let root = await renderCard(loader, mango, 'isolated');
-    assert.strictEqual(root.textContent!.trim(), 'Mango');
-  });
-
-  test('can render a nested asynchronous computed field', async function (assert) {
-    let { field, contains, CardDef, FieldDef, Component } = cardApi;
-    let { default: StringField } = string;
-    class Person extends FieldDef {
-      @field firstName = contains(StringField);
-      @field slowName = contains(StringField, {
-        computeVia: 'computeSlowName',
-      });
-      async computeSlowName() {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-        return this.firstName;
-      }
-    }
-
-    class Post extends CardDef {
-      @field title = contains(StringField);
-      @field author = contains(Person);
-      static isolated = class Isolated extends Component<typeof this> {
-        <template>
-          <@fields.title /> by {{@model.author.slowName}}
-        </template>
-      };
-    }
-    loader.shimModule(`${testRealmURL}test-cards`, { Post, Person });
-
-    let firstPost = new Post({
-      title: 'First Post',
-      author: new Person({ firstName: 'Mango' }),
-    });
-    let root = await renderCard(loader, firstPost, 'isolated');
-    assert.strictEqual(
-      cleanWhiteSpace(root.textContent!),
-      'First Post by Mango',
-    );
-  });
-
-  test('can render an asynchronous computed composite field', async function (assert) {
-    let { field, contains, CardDef, FieldDef, Component } = cardApi;
-    let { default: StringField } = string;
-    class Person extends FieldDef {
-      @field firstName = contains(StringField);
-      static embedded = class Embedded extends Component<typeof this> {
-        <template>
-          <span data-test='firstName'><@fields.firstName /></span>
-        </template>
-      };
-    }
-
-    class Post extends CardDef {
-      @field title = contains(StringField);
-      @field author = contains(Person, { computeVia: 'computeSlowAuthor' });
-      async computeSlowAuthor() {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-        let person = new Person();
-        person.firstName = 'Mango';
-        return person;
-      }
-      static isolated = class Isolated extends Component<typeof this> {
-        <template>
-          <div data-test='title'><@fields.title /></div> by <@fields.author />
-        </template>
-      };
-    }
-    let firstPost = new Post({ title: 'First Post' });
-    await renderCard(loader, firstPost, 'isolated');
-    assert.dom('[data-test="title"]').hasText('First Post');
-    assert.dom('[data-test="firstName"]').hasText('Mango');
-  });
-
   test('can render a containsMany computed primitive field', async function (assert) {
     let { field, contains, containsMany, CardDef, Component } = cardApi;
     let { default: StringField } = string;
     class Person extends CardDef {
       @field firstName = contains(StringField);
       @field languagesSpoken = containsMany(StringField);
-      @field slowLanguagesSpoken = containsMany(StringField, {
-        computeVia: 'computeSlowLanguagesSpoken',
+      @field reverseLanguagesSpoken = containsMany(StringField, {
+        computeVia: function (this: Person) {
+          return [...this.languagesSpoken].reverse();
+        },
       });
-      async computeSlowLanguagesSpoken() {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-        return this.languagesSpoken;
-      }
       static isolated = class Isolated extends Component<typeof this> {
         <template>
-          <@fields.firstName /> speaks <@fields.slowLanguagesSpoken />
+          <@fields.firstName /> speaks <@fields.reverseLanguagesSpoken />
         </template>
       };
     }
 
     let mango = new Person({
       firstName: 'Mango',
-      languagesSpoken: ['english', 'japanese'],
+      languagesSpoken: ['japanese', 'english'],
     });
 
     let root = await renderCard(loader, mango, 'isolated');
@@ -365,16 +190,14 @@ module('Integration | computeds', function (hooks) {
     class Person extends CardDef {
       @field firstName = contains(StringField);
       @field languagesSpoken = containsMany(StringField);
-      @field slowLanguagesSpoken = containsMany(StringField, {
-        computeVia: 'computeSlowLanguagesSpoken',
+      @field reverseLanguagesSpoken = containsMany(StringField, {
+        computeVia: function (this: Person) {
+          return [...this.languagesSpoken].reverse();
+        },
       });
-      async computeSlowLanguagesSpoken() {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-        return this.languagesSpoken;
-      }
       static isolated = class Isolated extends Component<typeof this> {
         <template>
-          <@fields.firstName /> speaks <@fields.slowLanguagesSpoken />
+          <@fields.firstName /> speaks <@fields.reverseLanguagesSpoken />
         </template>
       };
     }
@@ -382,7 +205,7 @@ module('Integration | computeds', function (hooks) {
     let mango = new Person({ firstName: 'Mango' });
     await renderCard(loader, mango, 'isolated'); // just using to absorb asynchronicity
     assert.deepEqual(
-      mango.slowLanguagesSpoken,
+      mango.reverseLanguagesSpoken,
       [],
       'empty containsMany field is initialized to an empty array',
     );
@@ -403,16 +226,14 @@ module('Integration | computeds', function (hooks) {
 
     class Family extends CardDef {
       @field people = containsMany(Person);
-      @field slowPeople = containsMany(Person, {
-        computeVia: 'computeSlowPeople',
+      @field reversePeople = containsMany(Person, {
+        computeVia: function (this: Family) {
+          return [...this.people].reverse();
+        },
       });
-      async computeSlowPeople() {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-        return this.people;
-      }
       static isolated = class Isolated extends Component<typeof this> {
         <template>
-          <@fields.slowPeople />
+          <@fields.reversePeople />
         </template>
       };
     }
@@ -434,7 +255,7 @@ module('Integration | computeds', function (hooks) {
       [...this.element.querySelectorAll('[data-test-firstName]')].map(
         (element) => element.textContent?.trim(),
       ),
-      ['Mango', 'Van Gogh', 'Hassan', 'Mariko', 'Yume', 'Sakura'],
+      ['Sakura', 'Yume', 'Mariko', 'Hassan', 'Van Gogh', 'Mango'],
     );
 
     await renderCard(loader, abdelRahmans, 'edit');
@@ -461,23 +282,21 @@ module('Integration | computeds', function (hooks) {
 
     class Family extends CardDef {
       @field people = containsMany(Person);
-      @field slowPeople = containsMany(Person, {
-        computeVia: 'computeSlowPeople',
+      @field reversePeople = containsMany(Person, {
+        computeVia: function (this: Family) {
+          return [...this.people].reverse();
+        },
       });
-      async computeSlowPeople() {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-        return this.people;
-      }
       static isolated = class Isolated extends Component<typeof this> {
         <template>
-          <@fields.slowPeople />
+          <@fields.reversePeople />
         </template>
       };
     }
     let abdelRahmans = new Family();
     await renderCard(loader, abdelRahmans, 'isolated'); // just using to absorb asynchronicity
     assert.deepEqual(
-      abdelRahmans.slowPeople,
+      abdelRahmans.reversePeople,
       [],
       'empty containsMany field is initialized to an empty array',
     );
@@ -497,15 +316,10 @@ module('Integration | computeds', function (hooks) {
     class Family extends CardDef {
       @field people = containsMany(Person);
       @field totalAge = contains(NumberField, {
-        computeVia: 'computeTotalAge',
+        computeVia: function (this: Family) {
+          return this.people.reduce((sum, person) => (sum += person.age), 0);
+        },
       });
-      async computeTotalAge() {
-        let totalAge = this.people.reduce(
-          (sum, person) => (sum += person.age),
-          0,
-        );
-        return totalAge;
-      }
     }
     loader.shimModule(`${testRealmURL}test-cards`, { Family, Person });
 
@@ -542,78 +356,6 @@ module('Integration | computeds', function (hooks) {
     assert
       .dom('[data-test-field=alias] input')
       .doesNotExist('input field not rendered for computed');
-  });
-
-  test('can maintain data consistency for async computed fields', async function (assert) {
-    let { field, contains, CardDef, FieldDef, Component } = cardApi;
-    let { default: StringField } = string;
-    class Location extends FieldDef {
-      @field city = contains(StringField);
-      static embedded = class Embedded extends Component<typeof this> {
-        <template>
-          <span data-test-location><@fields.city /></span>
-        </template>
-      };
-    }
-    class Person extends CardDef {
-      @field firstName = contains(StringField);
-      @field slowName = contains(StringField, {
-        computeVia: 'computeSlowName',
-      });
-      @field homeTown = contains(Location);
-      @field slowHomeTown = contains(Location, {
-        computeVia: 'computeSlowHomeTown',
-      });
-      async computeSlowName() {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-        return this.firstName;
-      }
-      async computeSlowHomeTown() {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-        return this.homeTown;
-      }
-      static edit = class Edit extends Component<typeof this> {
-        <template>
-          <div data-test-field='firstName'><@fields.firstName /></div>
-          <div data-test-field='homeTown'><@fields.homeTown.city /></div>
-          <div data-test-field='slowName'><@fields.slowName /></div>
-          <div data-test-field='slowHomeTown'><@fields.slowHomeTown /></div>
-          <div data-test-dep-field='firstName'>{{@model.firstName}}</div>
-          <div data-test-dep-field='homeTown'>{{@model.homeTown.city}}</div>
-        </template>
-      };
-    }
-    loader.shimModule(`${testRealmURL}test-cards`, { Location, Person });
-
-    let person = new Person({
-      firstName: 'Mango',
-      homeTown: new Location({ city: 'Bronxville' }),
-    });
-
-    await renderCard(loader, person, 'edit');
-    assert.dom('[data-test-field="slowName"]').containsText('Mango');
-    await fillIn('[data-test-field="firstName"] input', 'Van Gogh');
-    // We want to ensure data consistency, so that when the template rerenders,
-    // the template is always showing consistent field values
-    await waitUntil(() =>
-      document
-        .querySelector('[data-test-dep-field="firstName"]')
-        ?.textContent?.includes('Van Gogh'),
-    );
-    assert.dom('[data-test-field="slowName"]').containsText('Van Gogh');
-    assert
-      .dom('[data-test-field="slowHomeTown"] [data-test-location]')
-      .containsText('Bronxville');
-
-    await fillIn('[data-test-field="homeTown"] input', 'Scarsdale');
-    await waitUntil(() =>
-      document
-        .querySelector('[data-test-dep-field="homeTown"]')
-        ?.textContent?.includes('Scarsdale'),
-    );
-    assert
-      .dom('[data-test-field="slowHomeTown"] [data-test-location]')
-      .containsText('Scarsdale');
   });
 
   test('can render a computed linksTo relationship', async function (assert) {
@@ -669,53 +411,6 @@ module('Integration | computeds', function (hooks) {
     assert
       .dom('[data-test-field="friend"] [data-test-links-to-editor="friend"]')
       .doesNotExist();
-  });
-
-  test('can render an asynchronous computed linksTo field', async function (assert) {
-    let { field, contains, linksTo, CardDef, FieldDef, Component } = cardApi;
-    let { default: StringField } = string;
-    class Pet extends CardDef {
-      @field name = contains(StringField);
-      static embedded = class Embedded extends Component<typeof this> {
-        <template>
-          <span data-test='name'><@fields.name /></span>
-        </template>
-      };
-    }
-    class Person extends FieldDef {
-      @field firstName = contains(StringField);
-      @field bestFriend = linksTo(Pet);
-      static embedded = class Embedded extends Component<typeof this> {
-        <template>
-          <span data-test='firstName'><@fields.firstName /></span>
-          <span data-test='bestFriend'><@fields.bestFriend /></span>
-        </template>
-      };
-    }
-    class Post extends CardDef {
-      @field title = contains(StringField);
-      @field author = contains(Person);
-      @field friend = linksTo(Pet, {
-        computeVia: 'computeFriend',
-      });
-      async computeFriend(this: Post) {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-        return this.author.bestFriend;
-      }
-    }
-
-    let friend = new Pet({ name: 'Van Gogh' });
-    let author = new Person({ firstName: 'Mango', bestFriend: friend });
-    let firstPost = new Post({ title: 'First Post', author });
-
-    await renderCard(loader, firstPost, 'isolated');
-    assert.dom('[data-test-field="title"]').hasText('Title First Post');
-    assert
-      .dom('[data-test-field="author"] [data-test="firstName"]')
-      .hasText('Mango');
-    assert
-      .dom('[data-test-field="friend"] [data-test="name"]')
-      .hasText('Van Gogh');
   });
 
   test('can render a computed linksToMany relationship', async function (this: RenderingTestContext, assert) {
@@ -784,66 +479,5 @@ module('Integration | computeds', function (hooks) {
     assert
       .dom('[data-test-links-to-many="collaborators"] [data-test-remove-card]')
       .doesNotExist();
-  });
-
-  test('can render an asynchronous computed linksToMany field', async function (this: RenderingTestContext, assert) {
-    let { field, contains, linksTo, linksToMany, CardDef, Component } = cardApi;
-    let { default: StringField } = string;
-    class Pet extends CardDef {
-      @field name = contains(StringField);
-      static embedded = class Embedded extends Component<typeof this> {
-        <template>
-          <span data-test='name'><@fields.name /></span>
-        </template>
-      };
-    }
-    class Person extends CardDef {
-      @field firstName = contains(StringField);
-      @field pets = linksToMany(Pet);
-      static embedded = class Embedded extends Component<typeof this> {
-        <template>
-          <span data-test='firstName'><@fields.firstName /></span>
-        </template>
-      };
-    }
-    class Post extends CardDef {
-      @field title = contains(StringField);
-      @field author = linksTo(Person);
-      @field factCheckers = linksToMany(Pet);
-      @field collaborators = linksToMany(Pet, {
-        computeVia: 'findCollaborators',
-      });
-      async findCollaborators(this: Post) {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-        let mango = this.author.pets.find((p) => p.name === 'Mango');
-        return [mango, ...this.factCheckers];
-      }
-    }
-
-    let p1 = new Pet({ id: `${testRealmURL}mango`, name: 'Mango' });
-    let p2 = new Pet({ name: 'Tango' });
-    let f1 = new Pet({ name: 'A' });
-    let f2 = new Pet({ name: 'B' });
-    let f3 = new Pet({ name: 'C' });
-    let author = new Person({ firstName: 'Van Gogh', pets: [p1, p2] });
-    let firstPost = new Post({
-      title: 'First Post',
-      author,
-      factCheckers: [f1, f2, f3],
-    });
-
-    await renderCard(loader, firstPost, 'isolated');
-    assert.dom('[data-test-field="title"]').hasText('Title First Post');
-    assert
-      .dom('[data-test-field="author"] [data-test="firstName"]')
-      .hasText('Van Gogh');
-    assert.deepEqual(
-      [
-        ...this.element.querySelectorAll(
-          '[data-test-field="collaborators"] [data-test="name"]',
-        ),
-      ].map((element) => element.textContent?.trim()),
-      ['Mango', 'A', 'B', 'C'],
-    );
   });
 });

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -574,6 +574,7 @@ module('Integration | operator-mode', function (hooks) {
             attributes: {
               title: 'Publishing Packet',
               description: 'Catalog entry for PublishingPacket',
+              isField: false,
               ref: {
                 module: `${testRealmURL}publishing-packet`,
                 name: 'PublishingPacket',
@@ -611,6 +612,7 @@ module('Integration | operator-mode', function (hooks) {
             attributes: {
               title: 'General Pet Room',
               description: 'Catalog entry for Pet Room Card',
+              isField: false,
               ref: {
                 module: `${testRealmURL}pet-room`,
                 name: 'PetRoom',
@@ -642,6 +644,7 @@ module('Integration | operator-mode', function (hooks) {
                 module: `${testRealmURL}pet`,
                 name: 'Pet',
               },
+              isField: false,
               demo: {
                 name: 'Snoopy',
               },

--- a/packages/host/tests/integration/search-index-test.gts
+++ b/packages/host/tests/integration/search-index-test.gts
@@ -487,6 +487,7 @@ module(`Integration | search-index`, function (hooks) {
             attributes: {
               title: 'Person Card',
               description: 'Catalog entry for Person card',
+              isField: false,
               ref: {
                 module: './person',
                 name: 'Person',
@@ -530,7 +531,6 @@ module(`Integration | search-index`, function (hooks) {
           moduleHref: `${testRealmURL}person`,
           realmName: 'Unnamed Workspace',
           isField: false,
-          isPrimitive: false,
           ref: {
             module: `./person`,
             name: 'Person',
@@ -1366,6 +1366,7 @@ module(`Integration | search-index`, function (hooks) {
             attributes: {
               title: 'Booking',
               description: 'Catalog entry for Booking',
+              isField: false,
               ref: {
                 module: 'http://localhost:4202/test/booking',
                 name: 'Booking',
@@ -1412,7 +1413,6 @@ module(`Integration | search-index`, function (hooks) {
       },
       description: 'Catalog entry for Booking',
       isField: false,
-      isPrimitive: false,
       moduleHref: 'http://localhost:4202/test/booking',
       realmName: 'Unnamed Workspace',
       ref: 'http://localhost:4202/test/booking/Booking',
@@ -1699,6 +1699,7 @@ module(`Integration | search-index`, function (hooks) {
             attributes: {
               title: 'PetPerson',
               description: 'Catalog entry for PetPerson',
+              isField: false,
               ref: {
                 module: `${testModuleRealm}pet-person`,
                 name: 'PetPerson',
@@ -1763,7 +1764,6 @@ module(`Integration | search-index`, function (hooks) {
           },
           demo: { firstName: 'Hassan' },
           isField: false,
-          isPrimitive: false,
           moduleHref: `${testModuleRealm}pet-person`,
           realmName: 'Unnamed Workspace',
         },
@@ -1881,7 +1881,6 @@ module(`Integration | search-index`, function (hooks) {
           friend: null,
         },
         isField: false,
-        isPrimitive: false,
         moduleHref: `${testModuleRealm}pet-person`,
         realmName: 'Unnamed Workspace',
       });
@@ -3042,6 +3041,7 @@ posts/ignore-me.json
           attributes: {
             title: 'Post',
             description: 'A card that represents a blog post',
+            isField: false,
             ref: {
               module: `${testModuleRealm}post`,
               name: 'Post',
@@ -3061,6 +3061,7 @@ posts/ignore-me.json
           attributes: {
             title: 'Article',
             description: 'A card that represents an online article ',
+            isField: false,
             ref: {
               module: `${testModuleRealm}article`,
               name: 'Article',


### PR DESCRIPTION
This is preliminary work for removing the implementaiton of asyn computeds. This PR just stops relying on them.

 - Remove CatalogEntry's isPrimitive. It's unused, and one of only two async computeds that exist.
 - Convert CatalogEntry isField to simple boolean field
 - removing async computed from tests