### PR TITLE
Stream ai messages at a more consistent rate refactor

### DIFF
--- a/packages/ai-bot/lib/matrix.ts
+++ b/packages/ai-bot/lib/matrix.ts
@@ -1,9 +1,19 @@
-import { IContent, Room, MatrixClient } from 'matrix-js-sdk';
+import { IContent } from 'matrix-js-sdk';
 import { logger } from '@cardstack/runtime-common';
 import { OpenAIError } from 'openai/error';
 import * as Sentry from '@sentry/node';
 
 let log = logger('ai-bot');
+
+export interface MatrixClient {
+  sendEvent(
+    roomId: string,
+    eventType: string,
+    content: IContent,
+  ): Promise<{ event_id: string }>;
+
+  setRoomName(roomId: string, title: string): Promise<{ event_id: string }>;
+}
 
 export async function sendEvent(
   client: MatrixClient,

--- a/packages/ai-bot/lib/matrix.ts
+++ b/packages/ai-bot/lib/matrix.ts
@@ -7,7 +7,7 @@ let log = logger('ai-bot');
 
 export async function sendEvent(
   client: MatrixClient,
-  room: Room,
+  roomId: string,
   eventType: string,
   content: IContent,
   eventToUpdate: string | undefined,
@@ -22,12 +22,12 @@ export async function sendEvent(
     };
   }
   log.debug('sending event', content);
-  return await client.sendEvent(room.roomId, eventType, content);
+  return await client.sendEvent(roomId, eventType, content);
 }
 
 export async function sendMessage(
   client: MatrixClient,
-  room: Room,
+  roomId: string,
   content: string,
   eventToUpdate: string | undefined,
   data: any = {},
@@ -50,7 +50,7 @@ export async function sendMessage(
   };
   return await sendEvent(
     client,
-    room,
+    roomId,
     'm.room.message',
     messageObject,
     eventToUpdate,
@@ -62,7 +62,7 @@ export async function sendMessage(
 // like we split cards into fragments
 export async function sendOption(
   client: MatrixClient,
-  room: Room,
+  roomId: string,
   patch: any,
   eventToUpdate: string | undefined,
 ) {
@@ -88,7 +88,7 @@ export async function sendOption(
   };
   return await sendEvent(
     client,
-    room,
+    roomId,
     'm.room.message',
     messageObject,
     eventToUpdate,
@@ -97,7 +97,7 @@ export async function sendOption(
 
 export async function sendError(
   client: MatrixClient,
-  room: Room,
+  roomId: string,
   error: any,
   eventToUpdate: string | undefined,
 ) {
@@ -106,7 +106,7 @@ export async function sendError(
     log.error(errorMessage);
     await sendMessage(
       client,
-      room,
+      roomId,
       'There was an error processing your request, please try again later',
       eventToUpdate,
       {

--- a/packages/ai-bot/lib/send-response.ts
+++ b/packages/ai-bot/lib/send-response.ts
@@ -77,6 +77,7 @@ export class Responder {
             error,
             this.initialMessageReplaced ? undefined : this.initialMessageId,
           );
+          this.initialMessageReplaced = true;
         }
         if (functionCall.name === 'patchCard') {
           await sendOption(

--- a/packages/ai-bot/lib/send-response.ts
+++ b/packages/ai-bot/lib/send-response.ts
@@ -59,7 +59,6 @@ export class Responder {
     this.initialMessageId = initialMessage.event_id;
   }
 
-  // Can have
   async onChunk(chunk: {
     usage?: { prompt_tokens: number; completion_tokens: number };
   }) {

--- a/packages/ai-bot/lib/send-response.ts
+++ b/packages/ai-bot/lib/send-response.ts
@@ -1,0 +1,118 @@
+import { cleanContent } from '../helpers';
+import { logger } from '@cardstack/runtime-common';
+import { MatrixClient, sendError, sendMessage, sendOption } from './matrix';
+
+import * as Sentry from '@sentry/node';
+import { OpenAIError } from 'openai/error';
+
+let log = logger('ai-bot');
+
+export class Responder {
+  // internally has a debounced function that will send the text messages
+
+  initialMessageId: string | undefined;
+  initialMessageReplaced = false;
+  unsent = 0;
+  client: MatrixClient;
+  roomId: string;
+
+  constructor(client: MatrixClient, roomId: string) {
+    this.roomId = roomId;
+    this.client = client;
+  }
+
+  async initialize() {
+    let initialMessage = await sendMessage(
+      this.client,
+      this.roomId,
+      'Thinking...',
+      undefined,
+    );
+    this.initialMessageId = initialMessage.event_id;
+  }
+
+  // Can have
+  async onChunk(chunk: {
+    usage?: { prompt_tokens: number; completion_tokens: number };
+  }) {
+    // This usage value is set *once* and *only once* at the end of the conversation
+    // It will be null at all other times.
+    if (chunk.usage) {
+      log.info(
+        `Request used ${chunk.usage.prompt_tokens} prompt tokens and ${chunk.usage.completion_tokens}`,
+      );
+    }
+  }
+
+  async onContent(snapshot: string) {
+    this.unsent += 1;
+    if (this.unsent > 40) {
+      this.unsent = 0;
+      await sendMessage(
+        this.client,
+        this.roomId,
+        cleanContent(snapshot),
+        this.initialMessageId,
+      );
+    }
+    this.initialMessageReplaced = true;
+  }
+
+  async onMessage(msg: {
+    role: string;
+    tool_calls?: { function: { name: string; arguments: string } }[];
+  }) {
+    if (msg.role === 'assistant') {
+      for (const toolCall of msg.tool_calls || []) {
+        const functionCall = toolCall.function;
+        log.debug('[Room Timeline] Function call', toolCall);
+        let args;
+        try {
+          args = JSON.parse(functionCall.arguments);
+        } catch (error) {
+          Sentry.captureException(error);
+          return await sendError(
+            this.client,
+            this.roomId,
+            error,
+            this.initialMessageReplaced ? undefined : this.initialMessageId,
+          );
+        }
+        if (functionCall.name === 'patchCard') {
+          await sendOption(
+            this.client,
+            this.roomId,
+            args,
+            this.initialMessageReplaced ? undefined : this.initialMessageId,
+          );
+          this.initialMessageReplaced = true;
+        }
+      }
+    }
+  }
+
+  async onError(error: OpenAIError) {
+    Sentry.captureException(error);
+    return await sendError(
+      this.client,
+      this.roomId,
+      error,
+      this.initialMessageId,
+    );
+  }
+
+  async finalize(finalContent: string | void | null | undefined) {
+    if (finalContent) {
+      finalContent = cleanContent(finalContent);
+      await sendMessage(
+        this.client,
+        this.roomId,
+        finalContent,
+        this.initialMessageId,
+        {
+          isStreamingFinished: true,
+        },
+      );
+    }
+  }
+}

--- a/packages/ai-bot/lib/set-title.ts
+++ b/packages/ai-bot/lib/set-title.ts
@@ -1,9 +1,4 @@
-import {
-  Room,
-  MatrixClient,
-  type MatrixEvent,
-  type IEventRelation,
-} from 'matrix-js-sdk';
+import { type MatrixEvent, type IEventRelation } from 'matrix-js-sdk';
 import OpenAI from 'openai';
 import {
   type OpenAIPromptMessage,
@@ -11,6 +6,7 @@ import {
   isPatchCommandEvent,
   attachedCardsToMessage,
 } from '../helpers';
+import { MatrixClient } from './matrix';
 import type { MatrixEvent as DiscreteMatrixEvent } from 'https://cardstack.com/base/room';
 
 const SET_TITLE_SYSTEM_MESSAGE = `You are a chat titling system, you must read the conversation and return a suggested title of no more than six words.
@@ -21,7 +17,7 @@ Explain the general actions and user intent. If 'patchCard' was used, express th
 export async function setTitle(
   openai: OpenAI,
   client: MatrixClient,
-  room: Room,
+  roomId: string,
   history: DiscreteMatrixEvent[],
   userId: string,
   event?: MatrixEvent,
@@ -52,7 +48,7 @@ export async function setTitle(
   let title = result.choices[0].message.content || 'no title';
   // strip leading and trailing quotes
   title = title.replace(/^"(.*)"$/, '$1');
-  return await client.setRoomName(room.roomId, title);
+  return await client.setRoomName(roomId, title);
 }
 
 export function getStartOfConversation(

--- a/packages/ai-bot/package.json
+++ b/packages/ai-bot/package.json
@@ -15,6 +15,8 @@
     "typescript": "~5.1.6"
   },
   "devDependencies": {
+    "@sinonjs/fake-timers": "^11.2.2",
+    "@types/sinonjs__fake-timers": "^8.1.5",
     "qunit": "^2.18.0"
   },
   "scripts": {

--- a/packages/ai-bot/tests/index.ts
+++ b/packages/ai-bot/tests/index.ts
@@ -3,3 +3,4 @@ import './response-parsing-test';
 import './history-construction-test';
 import './prompt-construction-test';
 import './chat-titling-test';
+import './responding-test';

--- a/packages/ai-bot/tests/responding-test.ts
+++ b/packages/ai-bot/tests/responding-test.ts
@@ -2,7 +2,6 @@ import { module, test, assert } from 'qunit';
 import { Responder } from '../lib/send-response';
 import { IContent } from 'matrix-js-sdk';
 import { MatrixClient } from '../lib/matrix';
-import { setName } from '@ember/-internals/utils/lib/name';
 
 class FakeMatrixClient implements MatrixClient {
   private eventId = 0;

--- a/packages/ai-bot/tests/responding-test.ts
+++ b/packages/ai-bot/tests/responding-test.ts
@@ -1,0 +1,251 @@
+import { module, test, assert } from 'qunit';
+import { Responder } from '../lib/send-response';
+import { IContent } from 'matrix-js-sdk';
+import { MatrixClient } from '../lib/matrix';
+import { setName } from '@ember/-internals/utils/lib/name';
+
+class FakeMatrixClient implements MatrixClient {
+  private eventId = 0;
+  private sentEvents: {
+    eventId: string;
+    roomId: string;
+    eventType: string;
+    content: IContent;
+  }[] = [];
+
+  async sendEvent(
+    roomId: string,
+    eventType: string,
+    content: IContent,
+  ): Promise<{ event_id: string }> {
+    const messageEventId = this.eventId.toString();
+    this.sentEvents.push({
+      eventId: messageEventId,
+      roomId,
+      eventType,
+      content,
+    });
+    this.eventId++;
+    return { event_id: messageEventId.toString() };
+  }
+
+  async setRoomName(
+    _roomId: string,
+    _title: string,
+  ): Promise<{ event_id: string }> {
+    this.eventId++;
+    return { event_id: this.eventId.toString() };
+  }
+
+  getSentEvents() {
+    return this.sentEvents;
+  }
+
+  resetSentEvents() {
+    this.sentEvents = [];
+    this.eventId = 0;
+  }
+}
+
+module('Responding', (hooks) => {
+  let fakeMatrixClient: FakeMatrixClient;
+  let responder: Responder;
+
+  hooks.beforeEach(() => {
+    fakeMatrixClient = new FakeMatrixClient();
+    responder = new Responder(fakeMatrixClient, 'room-id');
+  });
+
+  hooks.afterEach(() => {
+    fakeMatrixClient.resetSentEvents();
+  });
+
+  test('Sends thinking message', async () => {
+    await responder.initialize();
+
+    const sentEvents = fakeMatrixClient.getSentEvents();
+    assert.equal(sentEvents.length, 1, 'One event should be sent');
+    assert.equal(
+      sentEvents[0].eventType,
+      'm.room.message',
+      'Event type should be m.room.message',
+    );
+    assert.equal(
+      sentEvents[0].content.msgtype,
+      'm.text',
+      'Message type should be m.text',
+    );
+    assert.equal(
+      sentEvents[0].content.body,
+      'Thinking...',
+      'Message body should match',
+    );
+  });
+
+  test('Sends message content events after 40 unsent, and replace the thinking message', async () => {
+    await responder.initialize();
+
+    for (let i = 0; i < 40; i++) {
+      await responder.onContent('content ' + i);
+    }
+
+    let sentEvents = fakeMatrixClient.getSentEvents();
+    assert.equal(sentEvents.length, 1, 'Only initial message should be sent');
+    assert.equal(
+      sentEvents[0].content.body,
+      'Thinking...',
+      'Just the thinking message sent',
+    );
+
+    await responder.onContent('content final');
+
+    sentEvents = fakeMatrixClient.getSentEvents();
+    assert.equal(sentEvents.length, 2, 'Only initial message should be sent');
+    assert.equal(
+      sentEvents[0].content.body,
+      'Thinking...',
+      'Just the thinking message sent',
+    );
+    assert.equal(
+      sentEvents[1].content.body,
+      'content final',
+      'The final content should be sent',
+    );
+    assert.deepEqual(
+      sentEvents[1].content['m.relates_to'],
+      {
+        rel_type: 'm.replace',
+        event_id: '0',
+      },
+      'The final content should replace the original thinking message',
+    );
+  });
+
+  test('Sends tool call event and replaces thinking message when tool call happens with no content', async () => {
+    const patchArgs = {
+      card_id: 'card/1',
+      description: 'A new thing',
+      attributes: { some: 'thing' },
+    };
+
+    await responder.initialize();
+
+    await responder.onMessage({
+      role: 'assistant',
+      tool_calls: [
+        {
+          function: {
+            name: 'patchCard',
+            arguments: JSON.stringify(patchArgs),
+          },
+        },
+      ],
+    });
+
+    let sentEvents = fakeMatrixClient.getSentEvents();
+    assert.equal(
+      sentEvents.length,
+      2,
+      'Thinking message and tool call event should be sent',
+    );
+    assert.equal(
+      sentEvents[0].content.body,
+      'Thinking...',
+      'Thinking message should be sent first',
+    );
+    assert.deepEqual(
+      JSON.parse(sentEvents[1].content.data),
+      {
+        command: {
+          type: 'patchCard',
+          id: patchArgs.card_id,
+          patch: { attributes: patchArgs.attributes },
+          eventId: '0',
+        },
+      },
+      'Tool call event should be sent with correct content',
+    );
+    assert.deepEqual(
+      sentEvents[1].content.body,
+      patchArgs.description,
+      'Body text should be the description',
+    );
+    assert.deepEqual(
+      sentEvents[1].content['m.relates_to'],
+      {
+        rel_type: 'm.replace',
+        event_id: '0',
+      },
+      'The tool call event should replace the thinking message',
+    );
+  });
+
+  test('Sends tool call event separately when content is sent before tool call, under the chunk threshold', async () => {
+    const patchArgs = {
+      card_id: 'card/1',
+      description: 'A new thing',
+      attributes: { some: 'thing' },
+    };
+    await responder.initialize();
+
+    await responder.onContent('some content');
+
+    await responder.onMessage({
+      role: 'assistant',
+      tool_calls: [
+        {
+          function: {
+            name: 'patchCard',
+            arguments: JSON.stringify(patchArgs),
+          },
+        },
+      ],
+    });
+
+    let sentEvents = fakeMatrixClient.getSentEvents();
+    assert.equal(
+      sentEvents.length,
+      2,
+      'Thinking message, and tool call event should be sent',
+    );
+    assert.equal(
+      sentEvents[0].content.body,
+      'Thinking...',
+      'Thinking message should be sent first',
+    );
+    assert.deepEqual(
+      JSON.parse(sentEvents[1].content.data),
+      {
+        command: {
+          type: 'patchCard',
+          id: patchArgs.card_id,
+          patch: { attributes: patchArgs.attributes },
+        },
+      },
+      'Tool call event should be sent with correct content',
+    );
+    assert.notOk(
+      sentEvents[1].content['m.relates_to'],
+      'The tool call event should not replace any message',
+    );
+
+    // Send enough chunks to
+    for (let i = 0; i < 40; i++) {
+      await responder.onContent('content ' + i);
+    }
+
+    assert.equal(
+      sentEvents[2].content.body,
+      'content 39',
+      'Content event should be sent next',
+    );
+    assert.deepEqual(
+      sentEvents[2].content['m.relates_to'],
+      {
+        rel_type: 'm.replace',
+        event_id: '0',
+      },
+      'The content event should replace the thinking message',
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,13 @@ importers:
       typescript:
         specifier: ~5.1.6
         version: 5.1.6
+    devDependencies:
+      '@sinonjs/fake-timers':
+        specifier: ^11.2.2
+        version: 11.2.2
+      '@types/sinonjs__fake-timers':
+        specifier: ^8.1.5
+        version: 8.1.5
 
   packages/base:
     dependencies:
@@ -1645,6 +1652,36 @@ importers:
       yargs:
         specifier: ^17.5.1
         version: 17.5.1
+
+  packages/realm1:
+    devDependencies:
+      '@cardstack/boxel-ui':
+        specifier: workspace:*
+        version: link:../boxel-ui/addon
+      '@cardstack/runtime-common':
+        specifier: workspace:*
+        version: link:../runtime-common
+      '@types/lodash':
+        specifier: ^4.14.182
+        version: 4.14.182
+      ember-modifier:
+        specifier: ^4.1.0
+        version: 4.1.0(ember-source@5.4.1)
+
+  packages/realm2:
+    devDependencies:
+      '@cardstack/boxel-ui':
+        specifier: workspace:*
+        version: link:../boxel-ui/addon
+      '@cardstack/runtime-common':
+        specifier: workspace:*
+        version: link:../runtime-common
+      '@types/lodash':
+        specifier: ^4.14.182
+        version: 4.14.182
+      ember-modifier:
+        specifier: ^4.1.0
+        version: 4.1.0(ember-source@5.4.1)
 
   packages/runtime-common:
     dependencies:
@@ -5224,6 +5261,18 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /@sinonjs/commons@3.0.1:
+    resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
+    dependencies:
+      type-detect: 4.0.8
+    dev: true
+
+  /@sinonjs/fake-timers@11.2.2:
+    resolution: {integrity: sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==}
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+    dev: true
+
   /@smithy/is-array-buffer@2.0.0:
     resolution: {integrity: sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==}
     engines: {node: '>=14.0.0'}
@@ -5712,6 +5761,10 @@ packages:
       '@types/http-errors': 2.0.3
       '@types/mime': 3.0.3
       '@types/node': 18.18.5
+    dev: true
+
+  /@types/sinonjs__fake-timers@8.1.5:
+    resolution: {integrity: sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==}
     dev: true
 
   /@types/stream-chain@2.0.1:
@@ -22047,6 +22100,11 @@ packages:
     engines: {node: '>= 0.8.0'}
     dependencies:
       prelude-ls: 1.2.1
+    dev: true
+
+  /type-detect@4.0.8:
+    resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
+    engines: {node: '>=4'}
     dev: true
 
   /type-fest@0.11.0:


### PR DESCRIPTION
Pulls out the logic of how and when to send messages with streaming into its own class, and adds tests.

Then this PR adds lodash debouncing to more smoothly send the messages.


This is the refactor before lodash:
https://github.com/cardstack/boxel/compare/e63b192750f802767c6ebb756df84bb199ee8695...98fcab90f3ce966bc394abd66d4a840bfe00ba58

And the addition of lodash

https://github.com/cardstack/boxel/compare/98fcab90f3ce966bc394abd66d4a840bfe00ba58...78e96f6868680d79978c8cfe9f6fddc718438609