### PR TITLE
increase timeout for SSE test event assertions

### DIFF
--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -344,7 +344,7 @@ export function setupServerSentEvents(hooks: NestedHooks) {
               `expectEvent timed out, saw events ${JSON.stringify(events)}`,
             ),
           ),
-        opts?.timeout ?? 3000,
+        opts?.timeout ?? 10000,
       );
       let result = await callback();
       let decoder = new TextDecoder();

--- a/packages/host/tests/integration/components/card-copy-test.gts
+++ b/packages/host/tests/integration/components/card-copy-test.gts
@@ -5,7 +5,7 @@ import GlimmerComponent from '@glimmer/component';
 import { setupRenderingTest } from 'ember-qunit';
 import { setupWindowMock } from 'ember-window-mock/test-support';
 import flatMap from 'lodash/flatMap';
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { validate as uuidValidate } from 'uuid';
 
 import {
@@ -797,8 +797,7 @@ module('Integration | card-copy', function (hooks) {
     );
   });
 
-  // Skip flaky test: CS-6846
-  skip<TestContextForCopy>('can copy a card that has a relative link to card in source realm', async function (assert) {
+  test<TestContextForCopy>('can copy a card that has a relative link to card in source realm', async function (assert) {
     assert.expect(15);
     await setCardInOperatorModeState(
       [`${testRealmURL}index`],

--- a/packages/host/tests/integration/components/card-delete-test.gts
+++ b/packages/host/tests/integration/components/card-delete-test.gts
@@ -3,7 +3,7 @@ import GlimmerComponent from '@glimmer/component';
 
 import { setupRenderingTest } from 'ember-qunit';
 import { setupWindowMock } from 'ember-window-mock/test-support';
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
 import { Loader } from '@cardstack/runtime-common/loader';
@@ -607,8 +607,7 @@ module('Integration | card-delete', function (hooks) {
     assert.strictEqual(notFound, undefined, 'file ref does not exist');
   });
 
-  // Flaky test: CS-6843
-  skip<TestContextWithSSE>('can delete a card that is a recent item', async function (assert) {
+  test<TestContextWithSSE>('can delete a card that is a recent item', async function (assert) {
     assert.expect(6);
     let expectedEvents = [
       {
@@ -676,8 +675,7 @@ module('Integration | card-delete', function (hooks) {
       .doesNotExist('recent item removed');
   });
 
-  // Flaky test: CS-6843
-  skip<TestContextWithSSE>('can delete a card that is a selected item', async function (assert) {
+  test<TestContextWithSSE>('can delete a card that is a selected item', async function (assert) {
     assert.expect(6);
     let expectedEvents = [
       {


### PR DESCRIPTION
it's likely that the db based indexing effected the test timeouts for SSE events--specifically the scenarios where we are waiting for SQLite setup as part of running the test. I unskipped tests that failed specifically due to flaky SSE timeout in CI. I reran CI for this PR many times without any SSE timeout test failures