### PR TITLE
Report queue errors with sentry

### DIFF
--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -131,7 +131,7 @@ export class CurrentRun {
       await current.batch.makeNewGeneration();
       if (boom) {
         throw new Error(
-          `Boom! this is a manually generated unhanded exception during indexing used for testing`,
+          `Boom! this is a manually generated unhandled exception during indexing used for testing`,
         );
       }
       await current.visitDirectory(current.realmURL);

--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -275,6 +275,7 @@ if (distURL) {
     );
   }
 })().catch((e: any) => {
+  Sentry.captureException(e);
   console.error(
     `Unexpected error encountered starting realm, stopping server`,
     e,

--- a/packages/realm-server/pg-queue.ts
+++ b/packages/realm-server/pg-queue.ts
@@ -44,6 +44,13 @@ const defaultQueueOpts: Required<QueueOpts> = Object.freeze({
   queueName: 'default',
 });
 
+if (process.env.SENTRY_DSN) {
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    environment: process.env.SENTRY_ENVIRONMENT || 'development',
+  });
+}
+
 // Tracks a job that should loop with a timeout and an interruptible sleep.
 class WorkLoop {
   private internalWaker: Deferred<void> | undefined;

--- a/packages/realm-server/pg-queue.ts
+++ b/packages/realm-server/pg-queue.ts
@@ -13,9 +13,9 @@ import {
   asExpressions,
   Deferred,
   Job,
-  reportError,
 } from '@cardstack/runtime-common';
 import PgAdapter from './pg-adapter';
+import * as Sentry from '@sentry/node';
 
 const log = logger('queue');
 
@@ -340,6 +340,7 @@ export default class PgQueue implements Queue {
           result = await this.runJob(firstJob.category, firstJob.args);
           newStatus = 'resolved';
         } catch (err: any) {
+          Sentry.captureException(err);
           console.error(
             `Error running job ${firstJob.id}: category=${
               firstJob.category
@@ -348,7 +349,6 @@ export default class PgQueue implements Queue {
           );
           result = serializableError(err);
           newStatus = 'rejected';
-          reportError(err);
         }
         log.debug(`finished %s as %s`, coalescedIds, newStatus);
         await query([

--- a/packages/realm-server/pg-queue.ts
+++ b/packages/realm-server/pg-queue.ts
@@ -13,9 +13,9 @@ import {
   asExpressions,
   Deferred,
   Job,
+  reportError,
 } from '@cardstack/runtime-common';
 import PgAdapter from './pg-adapter';
-import * as Sentry from '@sentry/node';
 
 const log = logger('queue');
 
@@ -43,13 +43,6 @@ export interface QueueOpts {
 const defaultQueueOpts: Required<QueueOpts> = Object.freeze({
   queueName: 'default',
 });
-
-if (process.env.SENTRY_DSN) {
-  Sentry.init({
-    dsn: process.env.SENTRY_DSN,
-    environment: process.env.SENTRY_ENVIRONMENT || 'development',
-  });
-}
 
 // Tracks a job that should loop with a timeout and an interruptible sleep.
 class WorkLoop {
@@ -347,7 +340,6 @@ export default class PgQueue implements Queue {
           result = await this.runJob(firstJob.category, firstJob.args);
           newStatus = 'resolved';
         } catch (err: any) {
-          Sentry.captureException(err);
           console.error(
             `Error running job ${firstJob.id}: category=${
               firstJob.category
@@ -356,6 +348,7 @@ export default class PgQueue implements Queue {
           );
           result = serializableError(err);
           newStatus = 'rejected';
+          reportError(err);
         }
         log.debug(`finished %s as %s`, coalescedIds, newStatus);
         await query([

--- a/packages/runtime-common/worker.ts
+++ b/packages/runtime-common/worker.ts
@@ -187,8 +187,12 @@ export class Worker {
       registerRunner: async (fromScratch, incremental) => {
         this.#fromScratch = fromScratch;
         this.#incremental = incremental;
-        let result = await run();
-        deferred.fulfill(result);
+        try {
+          let result = await run();
+          deferred.fulfill(result);
+        } catch (e) {
+          deferred.reject(e);
+        }
       },
     });
     await this.#runner(optsId);

--- a/packages/runtime-common/worker.ts
+++ b/packages/runtime-common/worker.ts
@@ -4,6 +4,7 @@ import {
   Loader,
   readFileAsText,
   Deferred,
+  reportError,
   type Queue,
   type LocalPath,
   type RealmAdapter,
@@ -190,8 +191,19 @@ export class Worker {
         try {
           let result = await run();
           deferred.fulfill(result);
-        } catch (e) {
-          deferred.reject(e);
+        } catch (e: any) {
+          // this exception is _very_ difficult to thread thru fastboot (a
+          // `deferred.reject(e)` doesn't do the thing you'd expect). Presumably
+          // the only kind of exceptions that get raised at this level would be
+          // indexer DB issues. Let's just log in sentry here and let developers
+          // followup on the issue from the sentry logs. Likely if an exception
+          // was raised to this level the fastboot instance is probably no
+          // longer usable.0
+          reportError(e);
+          console.error(
+            `Error raised during indexing has likely stopped the indexer`,
+            e,
+          );
         }
       },
     });

--- a/packages/runtime-common/worker.ts
+++ b/packages/runtime-common/worker.ts
@@ -198,7 +198,7 @@ export class Worker {
           // indexer DB issues. Let's just log in sentry here and let developers
           // followup on the issue from the sentry logs. Likely if an exception
           // was raised to this level the fastboot instance is probably no
-          // longer usable.0
+          // longer usable.
           reportError(e);
           console.error(
             `Error raised during indexing has likely stopped the indexer`,


### PR DESCRIPTION
using our new "boom" queue job revealed that sentry is not reporting errors encountered during indexing. this addresses that