### PR TITLE
Update ember-template-imports to 4.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "ember-cli-htmlbars": "^6.3.0",
     "ember-resources": "^6.3.1",
     "ember-source": "~5.4.0",
-    "ember-template-imports": "^3.0.1",
+    "ember-template-imports": "^4.1.1",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.4.0",
     "eslint-plugin-import": "^2.26.0",

--- a/packages/boxel-motion/addon/package.json
+++ b/packages/boxel-motion/addon/package.json
@@ -71,7 +71,7 @@
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^8.0.1",
     "ember-source": "~5.4.0",
-    "ember-template-imports": "^3.1.2",
+    "ember-template-imports": "^4.1.1",
     "ember-template-lint": "^5.11.2",
     "ember-template-lint-plugin-prettier": "^5.0.0",
     "eslint": "^8.31.0",

--- a/packages/boxel-motion/test-app/package.json
+++ b/packages/boxel-motion/test-app/package.json
@@ -78,7 +78,7 @@
     "ember-resources": "^6.3.1",
     "ember-source": "^5.4.0",
     "ember-source-channel-url": "^3.0.0",
-    "ember-template-imports": "^3.0.1",
+    "ember-template-imports": "^4.1.1",
     "ember-template-lint": "^5.11.2",
     "ember-try": "^2.0.0",
     "eslint": "^8.52.0",

--- a/packages/boxel-ui/addon/package.json
+++ b/packages/boxel-ui/addon/package.json
@@ -76,7 +76,7 @@
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^8.0.1",
     "ember-concurrency": "^4.0.1",
-    "ember-template-imports": "^3.1.2",
+    "ember-template-imports": "^4.1.1",
     "ember-template-lint": "^5.11.2",
     "ember-template-lint-plugin-prettier": "^5.0.0",
     "eslint": "^8.31.0",

--- a/packages/boxel-ui/test-app/package.json
+++ b/packages/boxel-ui/test-app/package.json
@@ -78,7 +78,7 @@
     "ember-resources": "^6.3.1",
     "ember-source": "^5.4.0",
     "ember-source-channel-url": "^3.0.0",
-    "ember-template-imports": "^3.1.2",
+    "ember-template-imports": "^4.1.1",
     "ember-template-lint": "^5.11.2",
     "ember-try": "^2.0.0",
     "eslint": "^8.52.0",

--- a/packages/boxel-ui/test-app/tests/integration/components/resizable-panel-group-test.gts
+++ b/packages/boxel-ui/test-app/tests/integration/components/resizable-panel-group-test.gts
@@ -135,7 +135,7 @@ module('Integration | ResizablePanelGroup', function (hooks) {
     await sleep(100); // let didResizeModifier run
   }
 
-  test('it can lay out panels vertically (default)', async function (this: MyTestContext, assert) {
+  test<MyTestContext>('it can lay out panels vertically (default)', async function (assert) {
     this.renderController.containerStyle =
       'max-height: 100%; width: 100px; height: 318px;';
     await renderVerticalResizablePanelGroup(this.renderController);
@@ -143,7 +143,7 @@ module('Integration | ResizablePanelGroup', function (hooks) {
     assert.hasNumericStyle('.panel-1-content', 'height', 300 * 0.4, 1);
   });
 
-  test('it can lay out panels vertically (length specified)', async function (this: MyTestContext, assert) {
+  test<MyTestContext>('it can lay out panels vertically (length specified)', async function (assert) {
     this.renderController.containerStyle =
       'max-height: 100%; width: 200px; height: 518px; border: 1px solid green';
     this.renderController.panels[0].lengthPx = 355;
@@ -153,7 +153,7 @@ module('Integration | ResizablePanelGroup', function (hooks) {
     assert.hasNumericStyle('.panel-1-content', 'height', 143, 1);
   });
 
-  test('it respects vertical minLength (default)', async function (this: MyTestContext, assert) {
+  test<MyTestContext>('it respects vertical minLength (default)', async function (assert) {
     this.renderController.containerStyle =
       'max-height: 100%; width: 200px; height: 108px;';
     await renderVerticalResizablePanelGroup(this.renderController);
@@ -161,7 +161,7 @@ module('Integration | ResizablePanelGroup', function (hooks) {
     assert.hasNumericStyle('.panel-1-content', 'height', 50, 1);
   });
 
-  test('it respects vertical minLength (length specified)', async function (this: MyTestContext, assert) {
+  test<MyTestContext>('it respects vertical minLength (length specified)', async function (assert) {
     this.renderController.containerStyle =
       'max-height: 100%; width: 200px; height: 108px; border: 1px solid green';
     this.renderController.panels[0].lengthPx = 45;
@@ -171,7 +171,7 @@ module('Integration | ResizablePanelGroup', function (hooks) {
     assert.hasNumericStyle('.panel-1-content', 'height', 50, 2);
   });
 
-  test('it adjusts to its container growing (default)', async function (this: MyTestContext, assert) {
+  test<MyTestContext>('it adjusts to its container growing (default)', async function (assert) {
     this.renderController.containerStyle =
       'max-height: 100%; width: 200px; height: 218px;';
     await renderVerticalResizablePanelGroup(this.renderController);
@@ -182,7 +182,7 @@ module('Integration | ResizablePanelGroup', function (hooks) {
     assert.hasNumericStyle('.panel-1-content', 'height', 160, 1);
   });
 
-  test('it adjusts to its container growing (length specified)', async function (this: MyTestContext, assert) {
+  test<MyTestContext>('it adjusts to its container growing (length specified)', async function (assert) {
     this.renderController.containerStyle =
       'max-height: 100%; width: 200px; height: 218px; border: 1px solid green';
     this.renderController.panels[0].lengthPx = 100;
@@ -197,7 +197,7 @@ module('Integration | ResizablePanelGroup', function (hooks) {
     assert.hasNumericStyle('.panel-1-content', 'height', 200, 1.5);
   });
 
-  test('it adjusts to its container shrinking (default)', async function (this: MyTestContext, assert) {
+  test<MyTestContext>('it adjusts to its container shrinking (default)', async function (assert) {
     this.renderController.containerStyle =
       'max-height: 100%; width: 200px; height: 418px;';
     await renderVerticalResizablePanelGroup(this.renderController);
@@ -208,7 +208,7 @@ module('Integration | ResizablePanelGroup', function (hooks) {
     assert.hasNumericStyle('.panel-1-content', 'height', 80, 1);
   });
 
-  test('it adjusts to its container shrinking (length specified A)', async function (this: MyTestContext, assert) {
+  test<MyTestContext>('it adjusts to its container shrinking (length specified A)', async function (assert) {
     this.renderController.containerStyle =
       'max-height: 100%; width: 200px; height: 420px; border: 1px solid green';
     // Height ratio panel 1 and panel 2 is 3:2
@@ -225,7 +225,7 @@ module('Integration | ResizablePanelGroup', function (hooks) {
     assert.hasNumericStyle('.panel-1-content', 'height', 80, 1);
   });
 
-  test('it adjusts to its container shrinking (length specified B)', async function (this: MyTestContext, assert) {
+  test<MyTestContext>('it adjusts to its container shrinking (length specified B)', async function (assert) {
     this.renderController.containerStyle =
       'max-height: 100%; width: 200px; height: 620px; border: 1px solid green';
     // Height ratio panel 1 and panel 2 is 2:1
@@ -244,7 +244,7 @@ module('Integration | ResizablePanelGroup', function (hooks) {
     assert.hasNumericStyle('.panel-1-content', 'height', 67, 1);
   });
 
-  test('it adjusts to its container shrinking and growing', async function (this: MyTestContext, assert) {
+  test<MyTestContext>('it adjusts to its container shrinking and growing', async function (assert) {
     this.renderController.containerStyle =
       'max-height: 100%; width: 200px; height: 620px; border: 1px solid green';
     this.renderController.panels[0].lengthPx = 400;
@@ -276,7 +276,7 @@ module('Integration | ResizablePanelGroup', function (hooks) {
     assert.hasNumericStyle('.panel-1-content', 'height', 240, 1);
   });
 
-  test('it excludes hidden panels from participating in layout', async function (this: MyTestContext, assert) {
+  test<MyTestContext>('it excludes hidden panels from participating in layout', async function (assert) {
     this.renderController.containerStyle =
       'max-height: 100%; width: 200px; height: 218px;';
     this.renderController.panels = [

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -121,7 +121,7 @@
     "ember-resources": "^6.3.1",
     "ember-route-template": "^1.0.3",
     "ember-source": "~5.4.0",
-    "ember-template-imports": "^3.0.1",
+    "ember-template-imports": "^4.1.1",
     "ember-template-lint": "^5.11.2",
     "ember-test-selectors": "^6.0.0",
     "ember-velcro": "^2.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 overrides:
   '@types/eslint': 8.4.1
   '@embroider/util': 1.12.0
@@ -81,8 +85,8 @@ importers:
         specifier: ~5.4.0
         version: 5.4.1(patch_hash=oko46qetwhgpor6xgs7vahyney)(@babel/core@7.24.3)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.89.0)
       ember-template-imports:
-        specifier: ^3.0.1
-        version: 3.1.2(ember-cli-htmlbars@6.3.0)
+        specifier: ^4.1.1
+        version: 4.1.1
       eslint:
         specifier: ^7.32.0
         version: 7.32.0
@@ -320,8 +324,8 @@ importers:
         specifier: ~5.4.0
         version: 5.4.1(patch_hash=oko46qetwhgpor6xgs7vahyney)(@babel/core@7.24.3)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.89.0)
       ember-template-imports:
-        specifier: ^3.1.2
-        version: 3.4.2
+        specifier: ^4.1.1
+        version: 4.1.1
       ember-template-lint:
         specifier: ^5.11.2
         version: 5.11.2
@@ -530,8 +534,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       ember-template-imports:
-        specifier: ^3.0.1
-        version: 3.4.2
+        specifier: ^4.1.1
+        version: 4.1.1
       ember-template-lint:
         specifier: ^5.11.2
         version: 5.11.2
@@ -717,8 +721,8 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1(@babel/core@7.24.3)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1)
       ember-template-imports:
-        specifier: ^3.1.2
-        version: 3.1.2(ember-cli-htmlbars@6.3.0)
+        specifier: ^4.1.1
+        version: 4.1.1
       ember-template-lint:
         specifier: ^5.11.2
         version: 5.11.2
@@ -934,8 +938,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       ember-template-imports:
-        specifier: ^3.1.2
-        version: 3.1.2(ember-cli-htmlbars@6.3.0)
+        specifier: ^4.1.1
+        version: 4.1.1
       ember-template-lint:
         specifier: ^5.11.2
         version: 5.11.2
@@ -1279,8 +1283,8 @@ importers:
         specifier: ~5.4.0
         version: 5.4.1(patch_hash=oko46qetwhgpor6xgs7vahyney)(@babel/core@7.24.3)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.89.0)
       ember-template-imports:
-        specifier: ^3.0.1
-        version: 3.1.2(ember-cli-htmlbars@6.3.0)
+        specifier: ^4.1.1
+        version: 4.1.1
       ember-template-lint:
         specifier: ^5.11.2
         version: 5.11.2
@@ -4471,7 +4475,7 @@ packages:
       '@types/ember__object': ^4.0.4
       '@types/ember__routing': ^4.0.11
       ember-cli-htmlbars: ^6.0.1
-      ember-modifier: ^3.2.7 || ^4.0.0
+      ember-modifier: ^4.1.0
     peerDependenciesMeta:
       '@types/ember__array':
         optional: true
@@ -5112,7 +5116,7 @@ packages:
   /@prettier/sync@0.2.1(prettier@3.1.0-dev):
     resolution: {integrity: sha512-7ls1R6//+GPYD9vof1XaL5psViv83CwpdwlS8oUkWldYgbPhzZ3WgxIQMWqGyBmWPmoBfQg8C7jj7KI/ZuDHhQ==}
     peerDependencies:
-      prettier: ^3.0.0
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     dependencies:
       prettier: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
     dev: true
@@ -9962,6 +9966,10 @@ packages:
     resolution: {integrity: sha512-9guqKIx2H+78N17otBpl8yLZbQGL5q1vBO/jDb3gF2JjixtcVpC62jDUNxjVMNoaZ09oxRX84ZOD6VX02qkVvg==}
     dev: true
 
+  /content-tag@2.0.1:
+    resolution: {integrity: sha512-jxsETSDs5NbNwyiDuIp672fUMhUyu8Qxc5MOBOJOcgW/fQESI6o5K1LBDrnEE7Bh810a685lWEZHTF4jQYGEEw==}
+    dev: true
+
   /content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
@@ -12581,26 +12589,6 @@ packages:
       - '@babel/core'
       - supports-color
 
-  /ember-template-imports@3.1.2(ember-cli-htmlbars@6.3.0):
-    resolution: {integrity: sha512-8ocUuIxXeY7S5FQQf9hcLBCyGKNvSxXz9cV/dkUUMvGcnfh8NblrglqPggXmCbBcv4eDAoEzDmOfiGccD5kEJQ==}
-    engines: {node: 12.* || >= 14}
-    peerDependencies:
-      ember-cli-htmlbars: ^6.0.0
-    dependencies:
-      babel-import-util: 0.2.0
-      broccoli-stew: 3.0.0
-      ember-cli-babel-plugin-helpers: 1.1.1
-      ember-cli-htmlbars: 6.3.0
-      ember-cli-version-checker: 5.1.2
-      line-column: 1.0.2
-      magic-string: 0.25.9(patch_hash=sbmabuxrk2m44agmppz3qozwvq)
-      parse-static-imports: 1.1.0
-      string.prototype.matchall: 4.0.6
-      validate-peer-dependencies: 1.1.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /ember-template-imports@3.4.2:
     resolution: {integrity: sha512-OS8TUVG2kQYYwP3netunLVfeijPoOKIs1SvPQRTNOQX4Pu8xGGBEZmrv0U1YTnQn12Eg+p6w/0UdGbUnITjyzw==}
     engines: {node: 12.* || >= 14}
@@ -12618,12 +12606,23 @@ packages:
       - supports-color
     dev: true
 
+  /ember-template-imports@4.1.1:
+    resolution: {integrity: sha512-mnbL3hjo/Ctg7rkBtuYkBRJUn5bDYRQCEZQxmNozRnfoEp2RLSbT6SFJRAFDYXT2OrY+8i821S4kPL1i0QuGIw==}
+    engines: {node: 16.* || >= 18}
+    dependencies:
+      broccoli-stew: 3.0.0
+      content-tag: 2.0.1
+      ember-cli-version-checker: 5.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /ember-template-lint-plugin-prettier@5.0.0(ember-template-lint@5.11.2)(prettier@3.1.0-dev):
     resolution: {integrity: sha512-aXUYM4yuIdPZ80+AsAU8QBwGSJJ/aAkRsNcQ5vI5HmXiBjzHlDc/ZhmP6iVcYuCmoA/3iKcssMAYwIDbuby4pg==}
     engines: {node: ^16.0.0 || ^18.0.0 || >=20.0.0}
     peerDependencies:
       ember-template-lint: '>= 4.0.0'
-      prettier: '>= 3.0.0'
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     dependencies:
       '@prettier/sync': 0.2.1(prettier@3.1.0-dev)
       ember-template-lint: 5.11.2
@@ -12817,7 +12816,7 @@ packages:
     resolution: {integrity: sha512-4V6rT9b9XSeMaPmiYYA2hIhfMD088vru6AvfGWBY7L1w/st5hYv6iIfamy9+W1l9xKvIH3Hcl8+B0637/SRmzQ==}
     engines: {node: 14.* || >= 16}
     peerDependencies:
-      ember-modifier: ^3.2.7 || >= 4.0.0
+      ember-modifier: ^4.1.0
       ember-source: ^3.28.0 || ^4.0.0 || >= 5.0.0
     dependencies:
       '@embroider/addon-shim': 1.8.7
@@ -13502,7 +13501,7 @@ packages:
     peerDependencies:
       eslint: '>=5.0.0'
       eslint-config-prettier: '*'
-      prettier: '>=1.13.0'
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     peerDependenciesMeta:
       eslint-config-prettier:
         optional: true
@@ -13517,10 +13516,10 @@ packages:
     resolution: {integrity: sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      '@types/eslint': '>=8.0.0'
+      '@types/eslint': 8.4.1
       eslint: '>=8.0.0'
       eslint-config-prettier: '*'
-      prettier: '>=3.0.0'
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     peerDependenciesMeta:
       '@types/eslint':
         optional: true
@@ -13538,10 +13537,10 @@ packages:
     resolution: {integrity: sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      '@types/eslint': '>=8.0.0'
+      '@types/eslint': 8.4.1
       eslint: '>=8.0.0'
       eslint-config-prettier: '*'
-      prettier: '>=3.0.0'
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     peerDependenciesMeta:
       '@types/eslint':
         optional: true
@@ -13559,10 +13558,10 @@ packages:
     resolution: {integrity: sha512-C9GCVAs4Eq7ZC/XFQHITLiHJxQngdtraXaM+LoUFoFp/lHNl2Zn8f3WQbe9HvTBBQ9YnKFB0/2Ajdqwo5D1EAw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      '@types/eslint': '>=8.0.0'
+      '@types/eslint': 8.4.1
       eslint: '>=8.0.0'
       eslint-config-prettier: '*'
-      prettier: '>=3.0.0'
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     peerDependenciesMeta:
       '@types/eslint':
         optional: true
@@ -19552,7 +19551,7 @@ packages:
     resolution: {integrity: sha512-zJTC+NhEU0kHNnVh7OtcvMmkJmYTgFTist76FP9q07m9+WCvcaunR1sTFIOlGE9TH/5UGm6rlF86Umt9ouorAg==}
     engines: {node: 16.* || 18.* || >= 20}
     peerDependencies:
-      prettier: '>= 3.0.0'
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     dependencies:
       '@babel/core': 7.24.3(supports-color@8.1.1)
       '@glimmer/syntax': 0.84.3
@@ -23690,7 +23689,3 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
This includes a workaround for [this problem](https://github.com/ember-template-imports/ember-template-imports/issues/223) with the newly-included `content-tag`.