### PR TITLE
remove worker exception testing

### DIFF
--- a/packages/host/app/components/card-prerender.gts
+++ b/packages/host/app/components/card-prerender.gts
@@ -49,9 +49,9 @@ export default class CardPrerender extends Component {
     }
   }
 
-  private async fromScratch(realmURL: URL, boom?: true): Promise<IndexResults> {
+  private async fromScratch(realmURL: URL): Promise<IndexResults> {
     try {
-      let results = await this.doFromScratch.perform(realmURL, boom);
+      let results = await this.doFromScratch.perform(realmURL);
       return results;
     } catch (e: any) {
       if (!didCancel(e)) {

--- a/packages/host/app/components/card-prerender.gts
+++ b/packages/host/app/components/card-prerender.gts
@@ -96,7 +96,7 @@ export default class CardPrerender extends Component {
     await register(this.fromScratch.bind(this), this.incremental.bind(this));
   });
 
-  private doFromScratch = enqueueTask(async (realmURL: URL, boom?: true) => {
+  private doFromScratch = enqueueTask(async (realmURL: URL) => {
     let { reader, indexer } = this.getRunnerParams();
     await this.resetLoaderInFastboot.perform();
     let current = await CurrentRun.fromScratch(
@@ -107,7 +107,6 @@ export default class CardPrerender extends Component {
         indexer,
         renderCard: this.renderService.renderCard.bind(this.renderService),
       }),
-      boom,
     );
     this.renderService.indexRunDeferred?.fulfill();
     return current;

--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -120,20 +120,12 @@ export class CurrentRun {
     ]);
   }
 
-  static async fromScratch(
-    current: CurrentRun,
-    boom?: true,
-  ): Promise<IndexResults> {
+  static async fromScratch(current: CurrentRun): Promise<IndexResults> {
     await current.whileIndexing(async () => {
       let start = Date.now();
       log.debug(`starting from scratch indexing`);
       current.#batch = await current.#indexer.createBatch(current.realmURL);
       await current.batch.makeNewGeneration();
-      if (boom) {
-        throw new Error(
-          `Boom! this is a manually generated unhandled exception during indexing used for testing`,
-        );
-      }
       await current.visitDirectory(current.realmURL);
       await current.batch.done();
       log.debug(`completed from scratch indexing in ${Date.now() - start}ms`);

--- a/packages/runtime-common/worker.ts
+++ b/packages/runtime-common/worker.ts
@@ -213,14 +213,13 @@ export class Worker {
     return result;
   }
 
-  private fromScratch = async (args: FromScratchArgs & { boom?: true }) => {
+  private fromScratch = async (args: FromScratchArgs) => {
     return await this.prepareAndRunJob<FromScratchResult>(async () => {
       if (!this.#fromScratch) {
         throw new Error(`Index runner has not been registered`);
       }
       let { ignoreData, stats } = await this.#fromScratch(
         new URL(args.realmURL),
-        args.boom,
       );
       return {
         ignoreData: { ...ignoreData },


### PR DESCRIPTION
This removes the "boom" option for throwing an error inside of the indexer