### PR TITLE
CS-6878: Use user default realm when launching new file modal

### DIFF
--- a/packages/host/app/components/card-prerender.gts
+++ b/packages/host/app/components/card-prerender.gts
@@ -49,9 +49,9 @@ export default class CardPrerender extends Component {
     }
   }
 
-  private async fromScratch(realmURL: URL, boom?: true): Promise<IndexResults> {
+  private async fromScratch(realmURL: URL): Promise<IndexResults> {
     try {
-      let results = await this.doFromScratch.perform(realmURL, boom);
+      let results = await this.doFromScratch.perform(realmURL);
       return results;
     } catch (e: any) {
       if (!didCancel(e)) {

--- a/packages/host/app/components/card-prerender.gts
+++ b/packages/host/app/components/card-prerender.gts
@@ -96,7 +96,7 @@ export default class CardPrerender extends Component {
     await register(this.fromScratch.bind(this), this.incremental.bind(this));
   });
 
-  private doFromScratch = enqueueTask(async (realmURL: URL, boom?: true) => {
+  private doFromScratch = enqueueTask(async (realmURL: URL) => {
     let { reader, indexer } = this.getRunnerParams();
     await this.resetLoaderInFastboot.perform();
     let current = await CurrentRun.fromScratch(
@@ -107,7 +107,6 @@ export default class CardPrerender extends Component {
         indexer,
         renderCard: this.renderService.renderCard.bind(this.renderService),
       }),
-      boom,
     );
     this.renderService.indexRunDeferred?.fulfill();
     return current;

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -52,7 +52,8 @@ import type CardService from '@cardstack/host/services/card-service';
 import type EnvironmentService from '@cardstack/host/services/environment-service';
 import type { FileView } from '@cardstack/host/services/operator-mode-state-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
-import RecentFilesService from '@cardstack/host/services/recent-files-service';
+import type RealmInfoService from '@cardstack/host/services/realm-info-service';
+import type RecentFilesService from '@cardstack/host/services/recent-files-service';
 
 import type { CardDef, Format } from 'https://cardstack.com/base/card-api';
 
@@ -118,6 +119,7 @@ export default class CodeSubmode extends Component<Signature> {
   @service private declare operatorModeStateService: OperatorModeStateService;
   @service private declare recentFilesService: RecentFilesService;
   @service private declare environmentService: EnvironmentService;
+  @service private declare realmInfoService: RealmInfoService;
 
   @tracked private loadFileError: string | null = null;
   @tracked private userHasDismissedURLError = false;
@@ -602,9 +604,10 @@ export default class CodeSubmode extends Component<Signature> {
         throw new Error(`bug: CreateFileModal not instantiated`);
       }
       this.isCreateModalOpen = true;
+      await this.realmInfoService.fetchAllKnownRealmInfos.perform();
       let url = await this.createFileModal.createNewFile(
         fileType,
-        this.realmURL,
+        new URL(this.realmInfoService.userDefaultRealm.path),
         definitionClass,
         sourceInstance,
       );

--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -569,7 +569,6 @@ export default class CreateFileModal extends Component<Signature> {
       ref: { name: exportName, module },
     } = (this.definitionClass ?? this.selectedCatalogEntry)!; // we just checked above to make sure one of these exists
     let className = convertToClassName(this.displayName);
-
     let absoluteModule = new URL(module, this.selectedCatalogEntry?.id);
     let moduleURL = maybeRelativeURL(
       absoluteModule,

--- a/packages/host/app/components/realm-dropdown.gts
+++ b/packages/host/app/components/realm-dropdown.gts
@@ -8,8 +8,6 @@ import { DropdownArrowDown } from '@cardstack/boxel-ui/icons';
 
 import { type RealmInfo, RealmPaths } from '@cardstack/runtime-common';
 
-import ENV from '@cardstack/host/config/environment';
-
 import RealmIcon from './operator-mode/realm-icon';
 
 import type RealmInfoService from '../services/realm-info-service';
@@ -17,7 +15,6 @@ import type RealmInfoService from '../services/realm-info-service';
 export interface RealmDropdownItem extends RealmInfo {
   path: string;
 }
-const { ownRealmURL } = ENV;
 
 interface Signature {
   Args: {
@@ -165,15 +162,8 @@ export default class RealmDropdown extends Component<Signature> {
       return selectedRealm;
     }
 
-    // if there is no selected realm then default to the user's personal
-    // realm. Currently the personal realm has not yet been implemented,
-    // until then default to the realm serving the host app if it is writable,
-    // otherwise default to the first writable realm lexically
-    let ownRealm = this.realms.find((r) => r.path === ownRealmURL);
-    if (ownRealm) {
-      return ownRealm;
-    } else {
-      return this.realms[0];
-    }
+    return this.realms.find(
+      (realm) => realm.path === this.realmInfoService.userDefaultRealm.path,
+    );
   }
 }

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -679,7 +679,7 @@ export class TestCard extends Person {
   });
 
   test<TestContextWithSave>('can create new card definition in different realm than realm of current file opened in code mode', async function (assert) {
-    assert.expect(1);
+    let done = assert.async();
     await visitOperatorMode(this.owner, `${baseRealm.url}card-api.gts`);
     await openNewFileModal('Card Definition');
 
@@ -693,18 +693,16 @@ export class TestCard extends Person {
     await fillIn('[data-test-display-name-field]', 'Test Card');
     await fillIn('[data-test-file-name-field]', 'test-card');
 
-    let deferred = new Deferred<void>();
     this.onSave((url, content) => {
       if (typeof content !== 'string') {
         throw new Error(`expected string save data`);
       }
       assert.strictEqual(url.href, `${testRealmURL}test-card.gts`);
-      deferred.fulfill();
+      done();
     });
 
     await click('[data-test-create-definition]');
     await waitFor('[data-test-create-file-modal]', { count: 0 });
-    await deferred.promise;
   });
 
   test('an error when creating a new card definition is shown', async function (assert) {

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -678,7 +678,36 @@ export class TestCard extends Person {
     await deferred.promise;
   });
 
-  test<TestContextWithSave>('an error when creating a new card definition is shown', async function (assert) {
+  test<TestContextWithSave>('can create new card definition in different realm than realm of current file opened in code mode', async function (assert) {
+    assert.expect(1);
+    await visitOperatorMode(this.owner, `${baseRealm.url}card-api.gts`);
+    await openNewFileModal('Card Definition');
+
+    await click('[data-test-select-card-type]');
+    await waitFor('[data-test-card-catalog-modal]');
+    await waitFor(`[data-test-select="${testRealmURL}Catalog-Entry/person"]`);
+    await click(`[data-test-select="${testRealmURL}Catalog-Entry/person"]`);
+    await click('[data-test-card-catalog-go-button]');
+    await waitFor(`[data-test-selected-type="Person"]`);
+
+    await fillIn('[data-test-display-name-field]', 'Test Card');
+    await fillIn('[data-test-file-name-field]', 'test-card');
+
+    let deferred = new Deferred<void>();
+    this.onSave((url, content) => {
+      if (typeof content !== 'string') {
+        throw new Error(`expected string save data`);
+      }
+      assert.strictEqual(url.href, `${testRealmURL}test-card.gts`);
+      deferred.fulfill();
+    });
+
+    await click('[data-test-create-definition]');
+    await waitFor('[data-test-create-file-modal]', { count: 0 });
+    await deferred.promise;
+  });
+
+  test('an error when creating a new card definition is shown', async function (assert) {
     await visitOperatorMode(this.owner);
     await openNewFileModal('Card Definition');
 
@@ -765,7 +794,7 @@ export class FieldThatExtendsFromBigInt extends BigInteger {
     await deferred.promise;
   });
 
-  test<TestContextWithSave>('an error when creating a new field definition is shown', async function (assert) {
+  test('an error when creating a new field definition is shown', async function (assert) {
     await visitOperatorMode(this.owner);
     await openNewFileModal('Field Definition');
     await click('[data-test-select-card-type]');


### PR DESCRIPTION
We were not supplying the correct initial realm URL to the new file modal. This PR centralizes that logic and we use that from the code submode to call the new file modal