### PR TITLE
ui: Remove warning about missing panel values

### DIFF
--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
@@ -563,9 +563,6 @@ export default class ResizablePanelGroup extends Component<Signature> {
       panelContexts.forEach((panelContext) => {
         let panelRatio = this.panelRatios[panelContext.id];
         if (!panelRatio || !newContainerSize) {
-          console.warn(
-            'Expected panelRatio and newContainerSize to be defined',
-          );
           return;
         }
         let proportionalSize = panelRatio * newContainerSize;


### PR DESCRIPTION
This removes some log noise in tests:

<img width="987" alt="boxel@d88a532 2024-05-28 11-47-17" src="https://github.com/cardstack/boxel/assets/43280/2e549fef-6aef-4521-9bad-9f682e6b7b12">
