### PR TITLE
Ensure tests are settled to avoid getting torn down before local indexer finishes

### DIFF
--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -1,5 +1,10 @@
 import Service from '@ember/service';
-import { type TestContext, getContext, visit } from '@ember/test-helpers';
+import {
+  type TestContext,
+  getContext,
+  visit,
+  settled,
+} from '@ember/test-helpers';
 import { findAll, waitUntil, waitFor, click } from '@ember/test-helpers';
 import { buildWaiter } from '@ember/test-waiters';
 import GlimmerComponent from '@glimmer/component';
@@ -52,7 +57,6 @@ import { TestRealmAdapter } from './adapter';
 import percySnapshot from './percy-snapshot';
 import { renderComponent } from './render-component';
 import visitOperatorMode from './visit-operator-mode';
-import { settled } from '@ember/test-helpers';
 
 export { visitOperatorMode, testRealmURL, testRealmInfo, percySnapshot };
 export * from '@cardstack/runtime-common/helpers';


### PR DESCRIPTION
This is a result of pairing with @habdelra where we explored test flakiness where there are several tests that start failing when (even a very small) a delay is introduced in realm's `internalHandle` (for example fetching user permissions from the database), or sometimes even without that. 

Our hypothesis was that there is some indexing still in progress when a test is already done, causing the `CardPrerender` component to throw an error, which propagates to the `model` hook of the card index route, and then it tries to render the error template but things fall apart because the owner was already destroyed (test was finished): `global failure: Error: Cannot call `.factoryFor('template:index-card_error')` after the owner has been destroyed`

So after introducing the change, problems went away, at least in my PR (https://github.com/cardstack/boxel/pull/1306) where the problem was happening consistently. Per @habdelra this is also flaky elsewhere so this is a separate PR. 