### PR TITLE
host: Change message editor to not capture scroll

### DIFF
--- a/packages/host/app/components/matrix/room-message.gts
+++ b/packages/host/app/components/matrix/room-message.gts
@@ -233,6 +233,9 @@ export default class RoomMessage extends Component<Signature> {
     wordWrap: 'on',
     wrappingIndent: 'indent',
     fontWeight: 'bold',
+    scrollbar: {
+      alwaysConsumeMouseWheel: false,
+    },
   };
 
   @service private declare operatorModeStateService: OperatorModeStateService;


### PR DESCRIPTION
This allows the parent container to scroll to see the entire code block where previously it was just truncated and scrolling was swallowed by the editor.

Before, you can only see the entire patch when the parent container is positioned correctly:

![editor-scroll-screencast 2024-05-30 11-43-57](https://github.com/cardstack/boxel/assets/43280/deb98e01-66d9-492c-a5ad-659da698808d)

After, scroll chaining allows the parent container to scroll when needed:

![scroll-success-screencast 2024-05-30 11-45-47](https://github.com/cardstack/boxel/assets/43280/989c47a0-e326-475a-a5f1-cb45e42310ba)
