### PR TITLE
Fix: Editing containsMany field not triggering auto-save

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -2143,13 +2143,28 @@ function applySubscribersToInstanceValue(
   oldValue: BaseDef | BaseDef[],
   newValue: BaseDef | BaseDef[],
 ) {
+  // If value doesn't have its own subscribers,
+  // we can use instance's subscribers.
   let changeSubscribers = subscribers.get(instance);
+  if (isArrayOfCardOrField(oldValue) && subscribers.has(oldValue[0])) {
+    changeSubscribers = subscribers.get(oldValue[0]);
+  } else if (isCardOrField(oldValue) && subscribers.has(oldValue)) {
+    changeSubscribers = subscribers.get(oldValue);
+  }
+
   if (!changeSubscribers) {
     return;
   }
 
-  let toArray = (item: BaseDef | BaseDef[]) =>
-    isCardOrField(item) ? [item] : item ?? [];
+  let toArray = function (item: BaseDef | BaseDef[]) {
+    if (isCardOrField(item)) {
+      return [item];
+    } else if (isArrayOfCardOrField(item)) {
+      return [...item];
+    } else {
+      return [];
+    }
+  };
 
   let oldItems = toArray(oldValue);
   let newItems = toArray(newValue);

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -2106,7 +2106,9 @@ export function subscribeToChanges(
     includeComputeds: false,
   });
   Object.keys(fields).forEach((fieldName) => {
-    let field = getField(fieldOrCard, fieldName) as Field<typeof BaseDef>;
+    let field = getField(fieldOrCard.constructor, fieldName) as Field<
+      typeof BaseDef
+    >;
     if (
       field &&
       (field.fieldType === 'contains' || field.fieldType === 'containsMany')
@@ -2147,7 +2149,9 @@ export function unsubscribeFromChanges(
     includeComputeds: false,
   });
   Object.keys(fields).forEach((fieldName) => {
-    let field = getField(fieldOrCard, fieldName) as Field<typeof BaseDef>;
+    let field = getField(fieldOrCard.constructor, fieldName) as Field<
+      typeof BaseDef
+    >;
     if (
       field &&
       (field.fieldType === 'contains' || field.fieldType === 'containsMany')

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -2699,6 +2699,9 @@ async function _updateFromSerialized<T extends BaseDefConstructor>(
       instance[isSavedInstance] = false;
     }
     for (let [field, value] of values) {
+      if (!field) {
+        continue;
+      }
       if (field.name === 'id' && wasSaved && originalId !== value) {
         throw new Error(
           `cannot change the id for saved instance ${originalId}`,

--- a/packages/base/watched-array.ts
+++ b/packages/base/watched-array.ts
@@ -1,22 +1,30 @@
 class WatchedArray<T> {
-  constructor(subscriber: (arr: Array<T>) => void, arr: T[] = []) {
+  constructor(subscriber: (oldArr: Array<T>, arr: Array<T>) => void, arr: T[] = []) {
     this.#subscriber = subscriber;
     let clone = arr.slice();
     let self = this;
     return new Proxy(clone, {
       set(target, prop, value /*, _receiver */) {
+        let prevValues = [...target];
         (target as any)[prop] = value;
 
-        let done: () => void;
-        let notifyPromise = (self.#notifyPromise = new Promise<void>(
-          (res) => (done = res),
-        ));
-        (async () => {
-          await Promise.resolve();
-          if (self.#notifyPromise === notifyPromise) {
-            self.#subscriber([...target]);
-          }
-        })().then(done!);
+        // It seems the setter is called twice when adding or removing items from the array.
+        // The first call is to add the item, and the second call is to update the length value.
+        // When adding items, we need to notify the subscriber with the first call.
+        // When removing items, we need the second call.
+        if (prop !== 'length' || (prop === 'length' && value !== prevValues.length)) {
+          let done: () => void;
+          let notifyPromise = (self.#notifyPromise = new Promise<void>(
+            (res) => (done = res),
+          ));
+          (async () => {
+            await Promise.resolve();
+            if (self.#notifyPromise === notifyPromise) {
+              self.#subscriber(prevValues, [...target]);
+            }
+          })().then(done!);
+        }
+        
         return true;
       },
       getPrototypeOf() {
@@ -27,7 +35,7 @@ class WatchedArray<T> {
 
   #notifyPromise: Promise<void> | undefined;
 
-  #subscriber: (arr: Array<T>) => void;
+  #subscriber: (oldArr: Array<T>, arr: Array<T>) => void;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -845,6 +845,119 @@ module('Integration | card-basics', function (hooks) {
       );
     });
 
+    test('can subscribe and unsubscribe to changes of field instance within a composite containsMany field', async function (assert) {
+      let {
+        field,
+        contains,
+        containsMany,
+        FieldDef,
+        CardDef,
+        subscribeToChanges,
+        unsubscribeFromChanges,
+        flushLogs,
+      } = cardApi;
+      let { default: StringField } = string;
+      let { default: DateField } = date;
+
+      class WorkExperience extends FieldDef {
+        @field company = contains(StringField);
+        @field startDate = contains(DateField);
+        @field endDate = contains(DateField);
+      }
+
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field workExperiences = containsMany(WorkExperience);
+      }
+
+      let mango = new Person({
+        firstName: 'Mango',
+        workExperiences: [],
+      });
+
+      let changeEvent:
+        | { instance: BaseDef; fieldName: string; value: any }
+        | undefined;
+      let eventCount = 0;
+      let subscriber = (instance: BaseDef, fieldName: string, value: any) => {
+        eventCount++;
+        changeEvent = {
+          instance,
+          fieldName,
+          value,
+        };
+      };
+      subscribeToChanges(mango, subscriber);
+
+      try {
+        let firstWorkExperience = new WorkExperience();
+        mango.workExperiences.push(firstWorkExperience);
+        await flushLogs();
+        assert.strictEqual(
+          eventCount,
+          1,
+          'the change event was fired the correct amount of times',
+        );
+        assert.deepEqual(
+          changeEvent?.instance,
+          mango,
+          'the instance was correctly specified in change event',
+        );
+        assert.strictEqual(
+          changeEvent?.fieldName,
+          'workExperiences',
+          'the fieldName was correctly specified in change event',
+        );
+        assert.deepEqual(
+          changeEvent?.value[0],
+          firstWorkExperience,
+          'the field value was correctly specified in change event',
+        );
+
+        firstWorkExperience.company = 'First Company';
+        assert.strictEqual(
+          eventCount,
+          2,
+          'the change event was fired the correct amount of times',
+        );
+        assert.deepEqual(
+          changeEvent?.instance,
+          firstWorkExperience,
+          'the instance was correctly specified in change event',
+        );
+        assert.strictEqual(
+          changeEvent?.fieldName,
+          'company',
+          'the fieldName was correctly specified in change event',
+        );
+        assert.deepEqual(
+          changeEvent?.value,
+          'First Company',
+          'the field value was correctly specified in change event',
+        );
+
+        mango.workExperiences.pop();
+        await waitUntil(() => eventCount === 3);
+        assert.deepEqual(
+          changeEvent?.instance,
+          mango,
+          'the instance was correctly specified in change event',
+        );
+        assert.strictEqual(
+          changeEvent?.fieldName,
+          'workExperiences',
+          'the fieldName was correctly specified in change event',
+        );
+        assert.deepEqual(
+          changeEvent?.value.length,
+          0,
+          'the field value was correctly specified in change event',
+        );
+      } finally {
+        unsubscribeFromChanges(mango, subscriber);
+      }
+    });
+
     test('can subscribe and unsubscribe to card instance linksTo field changes', async function (assert) {
       let {
         field,

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -893,11 +893,7 @@ module('Integration | card-basics', function (hooks) {
         let firstWorkExperience = new WorkExperience();
         mango.workExperiences.push(firstWorkExperience);
         await flushLogs();
-        assert.strictEqual(
-          eventCount,
-          1,
-          'the change event was fired the correct amount of times',
-        );
+        await waitUntil(() => eventCount === 1);
         assert.deepEqual(
           changeEvent?.instance,
           mango,
@@ -915,11 +911,7 @@ module('Integration | card-basics', function (hooks) {
         );
 
         firstWorkExperience.company = 'First Company';
-        assert.strictEqual(
-          eventCount,
-          2,
-          'the change event was fired the correct amount of times',
-        );
+        await waitUntil(() => eventCount === 2);
         assert.deepEqual(
           changeEvent?.instance,
           firstWorkExperience,


### PR DESCRIPTION
Auto-save will be triggered if there are changes to an instance of `FieldDef` or `CardDef` that is subscribed. However, the value of the `containsMany` field could be instances of `FieldDef`. In the previous implementation, we didn't correctly traverse these values, which is why there were no subscribers for values of the `containsMany` field.

In this PR, I added additional steps to the `subscribeToChanges` and `unSubscribeToChanges` functions to handle the `containsMany` case. I also updated the `migrateSubscribers` function to `applySubscriberToInstanceValue`. This ensures that when items are added to or removed from an array in the `containsMany` field, we can also add or remove the subscribers accordingly.