### PR TITLE
unskip previously flaky test

### DIFF
--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -12,7 +12,7 @@ import { setupApplicationTest } from 'ember-qunit';
 
 import window from 'ember-window-mock';
 import { setupWindowMock } from 'ember-window-mock/test-support';
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 
 import { FieldContainer } from '@cardstack/boxel-ui/components';
 
@@ -536,8 +536,7 @@ module('Acceptance | operator mode tests', function (hooks) {
     assert.dom('[data-test-profile-icon]').hasText('J'); // From display name "John"
   });
 
-  // Flaky test: CS-6841
-  skip('can open code submode when card or field has no embedded template', async function (assert) {
+  test('can open code submode when card or field has no embedded template', async function (assert) {
     await visitOperatorMode({
       stacks: [
         [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1656,36 +1656,6 @@ importers:
         specifier: ^17.5.1
         version: 17.5.1
 
-  packages/realm1:
-    devDependencies:
-      '@cardstack/boxel-ui':
-        specifier: workspace:*
-        version: link:../boxel-ui/addon
-      '@cardstack/runtime-common':
-        specifier: workspace:*
-        version: link:../runtime-common
-      '@types/lodash':
-        specifier: ^4.14.182
-        version: 4.14.182
-      ember-modifier:
-        specifier: ^4.1.0
-        version: 4.1.0(ember-source@5.4.1)
-
-  packages/realm2:
-    devDependencies:
-      '@cardstack/boxel-ui':
-        specifier: workspace:*
-        version: link:../boxel-ui/addon
-      '@cardstack/runtime-common':
-        specifier: workspace:*
-        version: link:../runtime-common
-      '@types/lodash':
-        specifier: ^4.14.182
-        version: 4.14.182
-      ember-modifier:
-        specifier: ^4.1.0
-        version: 4.1.0(ember-source@5.4.1)
-
   packages/runtime-common:
     dependencies:
       '@aws-crypto/sha256-js':


### PR DESCRIPTION
The fix for this test's flakiness was addressed in https://github.com/cardstack/boxel/pull/1313. Additionally, running pnpm introduced a lockfile updated which is part of this PR as well.