### PR TITLE
Add HEAD request handler

### DIFF
--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -1927,6 +1927,22 @@ module('Realm Server', function (hooks) {
         assert.strictEqual(response.status, 404, 'HTTP 404 status');
       }
     });
+
+    test('can make HEAD request to get realmURL and isPublicReadable status', async function (assert) {
+      let response = await request
+        .head('/person-1')
+        .set('Accept', 'application/vnd.card+json');
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      assert.strictEqual(
+        response.headers['x-boxel-realm-url'],
+        testRealmURL.href,
+      );
+      assert.strictEqual(
+        response.headers['x-boxel-realm-public-readable'],
+        'true',
+      );
+    });
   });
 
   module('BOXEL_HTTP_BASIC_PW env var', function (hooks) {

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -388,6 +388,13 @@ export class Realm {
         SupportedMimeType.RealmInfo,
         this.readinessCheck.bind(this),
       );
+    Object.values(SupportedMimeType).forEach((mimeType) => {
+      this.#router.head('/.*', mimeType as SupportedMimeType, async () =>
+        createResponse(this, null, {
+          status: 200,
+        }),
+      );
+    });
 
     this.#deferStartup = opts?.deferStartUp ?? false;
     if (!opts?.deferStartUp) {

--- a/packages/runtime-common/router.ts
+++ b/packages/runtime-common/router.ts
@@ -11,7 +11,7 @@ export enum AuthenticationErrorMessages {
 }
 
 type Handler = (request: Request) => Promise<Response>;
-export type Method = 'GET' | 'POST' | 'PATCH' | 'DELETE';
+export type Method = 'GET' | 'POST' | 'PATCH' | 'DELETE' | 'HEAD';
 export enum SupportedMimeType {
   CardJson = 'application/vnd.card+json',
   CardSource = 'application/vnd.card+source',
@@ -21,13 +21,14 @@ export enum SupportedMimeType {
   EventStream = 'text/event-stream',
   HTML = 'text/html',
   JSONAPI = 'application/vnd.api+json',
+  All = '*/*',
 }
 
 function isHTTPMethod(method: unknown): method is Method {
   if (typeof method !== 'string') {
     return false;
   }
-  return ['GET', 'POST', 'PATCH', 'DELETE'].includes(method);
+  return ['GET', 'POST', 'PATCH', 'DELETE', 'HEAD'].includes(method);
 }
 
 export function extractSupportedMimeType(
@@ -112,6 +113,10 @@ export class Router {
   }
   delete(path: string, mimeType: SupportedMimeType, handler: Handler): Router {
     this.setRoute(mimeType, 'DELETE', path, handler);
+    return this;
+  }
+  head(path: string, mimeType: SupportedMimeType, handler: Handler): Router {
+    this.setRoute(mimeType, 'HEAD', path, handler);
     return this;
   }
 


### PR DESCRIPTION
As mentioned in the [ticket](https://linear.app/cardstack/issue/CS-6856/make-sure-realm-can-handle-head-requests-from-the-client), the goal of this PR is to remove `404` errors when host retrieves `realmURL` and `publicReadable` status with `HEAD` request.