### PR TITLE
Loader should be able to identify shimmed modules

### DIFF
--- a/packages/host/tests/helpers/adapter.ts
+++ b/packages/host/tests/helpers/adapter.ts
@@ -183,10 +183,6 @@ export class TestRealmAdapter implements RealmAdapter {
       if (typeof value === 'string') {
         fileRefContent = value;
       } else {
-        let moduleURLString = `${this.#paths.url}${path.replace(/\.gts$/, '')}`;
-
-        this.#loader.shimModule(moduleURLString, value as object);
-
         fileRefContent = shimmedModuleIndicator;
       }
     } else {

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -550,9 +550,14 @@ export class Loader {
     }
 
     if (loaded.type === 'shimmed') {
+      let proxiedModule = this.createModuleProxy(
+        loaded.module,
+        moduleIdentifier,
+      );
+
       this.setModule(moduleIdentifier, {
         state: 'evaluated',
-        moduleInstance: loaded.module,
+        moduleInstance: proxiedModule,
         consumedModules: new Set(),
       });
       module.deferred.fulfill();


### PR DESCRIPTION
Removes the need for test adapter to call loader.shimModule.