### PR TITLE
host: Restore recent files background

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -975,7 +975,7 @@ export default class CodeSubmode extends Component<Signature> {
         height: 100%;
       }
 
-      .recent-files {
+      .inner-container.recent-files {
         background-color: var(--boxel-200);
       }
 


### PR DESCRIPTION
Before and after:

<img width="267" alt="Boxel 2024-06-05 15-33-25" src="https://github.com/cardstack/boxel/assets/43280/1e646943-9707-43ac-b472-fe9ed2e75fc1">

<img width="267" alt="Boxel 2024-06-05 15-32-50" src="https://github.com/cardstack/boxel/assets/43280/9bf63a09-8382-402b-b095-1e060da2c556">

This should have been caught by Percy but I think we’re seeing too many false positives and just approving 😞