### PR TITLE
Remove isPatchApplied method; and resolve card-not-loaded bug during patch

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -731,7 +731,7 @@ class Contains<CardT extends FieldDefConstructor> implements Field<CardT, any> {
     doc: CardDocument,
     relationships: JSONAPIResource['relationships'] | undefined,
     fieldMeta: CardFields[string] | undefined,
-    identityContext: undefined,
+    identityContext: IdentityContext,
     _instancePromise: Promise<BaseDef>,
     _loadedValue: any,
     relativeTo: URL | undefined,

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -737,7 +737,7 @@ class Contains<CardT extends FieldDefConstructor> implements Field<CardT, any> {
     relativeTo: URL | undefined,
   ): Promise<BaseInstanceType<CardT>> {
     if (primitive in this.card) {
-      return this.card[deserialize](value, relativeTo, doc);
+      return this.card[deserialize](value, relativeTo, doc, identityContext);
     }
     if (fieldMeta && Array.isArray(fieldMeta)) {
       throw new Error(

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -531,7 +531,7 @@ class ContainsMany<FieldT extends FieldDefConstructor>
     doc: CardDocument,
     relationships: JSONAPIResource['relationships'] | undefined,
     fieldMeta: CardFields[string] | undefined,
-    _identityContext: undefined,
+    identityContext: undefined,
     instancePromise: Promise<BaseDef>,
     _loadedValue: any,
     relativeTo: URL | undefined,
@@ -569,7 +569,7 @@ class ContainsMany<FieldT extends FieldDefConstructor>
               entry,
               relativeTo,
               doc,
-              _identityContext,
+              identityContext,
             );
           } else {
             let meta = metas[index];
@@ -596,7 +596,7 @@ class ContainsMany<FieldT extends FieldDefConstructor>
             }
             return (
               await cardClassFromResource(resource, this.card, relativeTo)
-            )[deserialize](resource, relativeTo, doc, _identityContext);
+            )[deserialize](resource, relativeTo, doc, identityContext);
           }
         }),
       ),
@@ -731,7 +731,7 @@ class Contains<CardT extends FieldDefConstructor> implements Field<CardT, any> {
     doc: CardDocument,
     relationships: JSONAPIResource['relationships'] | undefined,
     fieldMeta: CardFields[string] | undefined,
-    _identityContext: undefined,
+    identityContext: undefined,
     _instancePromise: Promise<BaseDef>,
     _loadedValue: any,
     relativeTo: URL | undefined,
@@ -765,7 +765,7 @@ class Contains<CardT extends FieldDefConstructor> implements Field<CardT, any> {
     }
     return (await cardClassFromResource(resource, this.card, relativeTo))[
       deserialize
-    ](resource, relativeTo, doc, _identityContext);
+    ](resource, relativeTo, doc, identityContext);
   }
 
   emptyValue(_instance: BaseDef) {

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -565,7 +565,12 @@ class ContainsMany<FieldT extends FieldDefConstructor>
       await Promise.all(
         value.map(async (entry, index) => {
           if (primitive in this.card) {
-            return this.card[deserialize](entry, relativeTo, doc);
+            return this.card[deserialize](
+              entry,
+              relativeTo,
+              doc,
+              _identityContext,
+            );
           } else {
             let meta = metas[index];
             let resource: LooseCardResource = {
@@ -591,7 +596,7 @@ class ContainsMany<FieldT extends FieldDefConstructor>
             }
             return (
               await cardClassFromResource(resource, this.card, relativeTo)
-            )[deserialize](resource, relativeTo, doc);
+            )[deserialize](resource, relativeTo, doc, _identityContext);
           }
         }),
       ),
@@ -760,7 +765,7 @@ class Contains<CardT extends FieldDefConstructor> implements Field<CardT, any> {
     }
     return (await cardClassFromResource(resource, this.card, relativeTo))[
       deserialize
-    ](resource, relativeTo, doc);
+    ](resource, relativeTo, doc, _identityContext);
   }
 
   emptyValue(_instance: BaseDef) {
@@ -2549,11 +2554,51 @@ export async function createFromSerialized<T extends BaseDefConstructor>(
   );
 }
 
+// Crawls all fields for cards and populates the identityContext
+function buildIdentityContext(
+  instance: CardDef | FieldDef,
+  identityContext: IdentityContext = new IdentityContext(),
+  visited: WeakSet<CardDef | FieldDef> = new WeakSet(),
+) {
+  if (instance == null || visited.has(instance)) {
+    return identityContext;
+  }
+  visited.add(instance);
+  let fields = getFields(instance);
+  for (let fieldName of Object.keys(fields)) {
+    let value = peekAtField(instance, fieldName);
+    if (value == null) {
+      continue;
+    }
+    if (Array.isArray(value)) {
+      for (let item of value) {
+        if (value == null) {
+          continue;
+        }
+        if (isCard(item)) {
+          identityContext.identities.set(item.id, item);
+        }
+        if (isCardOrField(item)) {
+          buildIdentityContext(item, identityContext, visited);
+        }
+      }
+    } else {
+      if (isCard(value) && value.id) {
+        identityContext.identities.set(value.id, value);
+      }
+      if (isCardOrField(value)) {
+        buildIdentityContext(value, identityContext, visited);
+      }
+    }
+  }
+  return identityContext;
+}
+
 export async function updateFromSerialized<T extends BaseDefConstructor>(
   instance: BaseInstanceType<T>,
   doc: LooseSingleCardDocument,
 ): Promise<BaseInstanceType<T>> {
-  let identityContext = new IdentityContext();
+  let identityContext = buildIdentityContext(instance);
   identityContexts.set(instance, identityContext);
   if (!instance[relativeTo] && doc.data.id) {
     instance[relativeTo] = new URL(doc.data.id);

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -531,7 +531,7 @@ class ContainsMany<FieldT extends FieldDefConstructor>
     doc: CardDocument,
     relationships: JSONAPIResource['relationships'] | undefined,
     fieldMeta: CardFields[string] | undefined,
-    identityContext: undefined,
+    identityContext: IdentityContext,
     instancePromise: Promise<BaseDef>,
     _loadedValue: any,
     relativeTo: URL | undefined,

--- a/packages/drafts-realm/TripInfo/a32d7aae-dd43-4dd5-b399-e62ab2e7d412.json
+++ b/packages/drafts-realm/TripInfo/a32d7aae-dd43-4dd5-b399-e62ab2e7d412.json
@@ -1,0 +1,35 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "traveler": {
+        "name": "Mickey"
+      },
+      "description": null,
+      "thumbnailURL": null
+    },
+    "relationships": {
+      "destinations": {
+        "links": {
+          "self": null
+        }
+      },
+      "traveler.countryOfOrigin": {
+        "links": {
+          "self": "http://localhost:4201/drafts/Country/1"
+        }
+      },
+      "traveler.countriesVisited": {
+        "links": {
+          "self": null
+        }
+      }
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../trip-info",
+        "name": "TripInfo"
+      }
+    }
+  }
+}

--- a/packages/drafts-realm/TripInfo/a32d7aae-dd43-4dd5-b399-e62ab2e7d412.json
+++ b/packages/drafts-realm/TripInfo/a32d7aae-dd43-4dd5-b399-e62ab2e7d412.json
@@ -23,6 +23,16 @@
         "links": {
           "self": null
         }
+      },
+      "startLocation": {
+        "links": {
+          "self": null
+        }
+      },
+      "endLocation": {
+        "links": {
+          "self": "../Country/2"
+        }
       }
     },
     "meta": {

--- a/packages/drafts-realm/country.gts
+++ b/packages/drafts-realm/country.gts
@@ -17,9 +17,7 @@ export class Country extends CardDef {
 
   static embedded = class Embedded extends Component<typeof this> {
     <template>
-      <address>
-        <@fields.name />
-      </address>
+      <@fields.name />
     </template>
   };
 }

--- a/packages/drafts-realm/trip-info.gts
+++ b/packages/drafts-realm/trip-info.gts
@@ -1,6 +1,14 @@
 import StringField from 'https://cardstack.com/base/string';
-import { CardDef, FieldDef, contains, field, linksTo, linksToMany } from 'https://cardstack.com/base/card-api';
+import {
+  CardDef,
+  FieldDef,
+  contains,
+  field,
+  linksTo,
+  linksToMany,
+} from 'https://cardstack.com/base/card-api';
 import { Component } from 'https://cardstack.com/base/card-api';
+import { FieldContainer } from '@cardstack/boxel-ui/components';
 import { Country } from './country';
 
 class Traveler extends FieldDef {
@@ -12,9 +20,23 @@ class Traveler extends FieldDef {
   static embedded = class Embedded extends Component<typeof this> {
     <template>
       <div class='traveler'>
-        <div><strong>Name:</strong> <@fields.name /></div>
-        <div><strong>Country of Origin:</strong> <@fields.countryOfOrigin /></div>
-        <div><strong>Countries Visited:</strong> <@fields.countriesVisited /></div>
+        <FieldContainer @label='Name' @vertical={{true}}>
+          <@fields.name />
+        </FieldContainer>
+        <FieldContainer @label='Country of Origin' @vertical={{true}}>
+          {{#if @model.countryOfOrigin}}
+            <@fields.countryOfOrigin />
+          {{else}}
+            Unknown
+          {{/if}}
+        </FieldContainer>
+        <FieldContainer @label='Countries Visited' @vertical={{true}}>
+          {{#if @model.countriesVisited.length}}
+            <@fields.countriesVisited />
+          {{else}}
+            Unknown
+          {{/if}}
+        </FieldContainer>
       </div>
       <style>
         .traveler {
@@ -27,14 +49,18 @@ class Traveler extends FieldDef {
 }
 
 export class TripInfo extends CardDef {
-  static displayName = "Trip Info";
+  static displayName = 'Trip Info';
   @field destinations = linksToMany(Country);
   @field traveler = contains(Traveler);
   @field title = contains(StringField, {
     computeVia: function (this: TripInfo) {
-      return this.traveler?.name ? `Trip Info for ${this.traveler.name}` : 'Trip Info';
+      return this.traveler?.name
+        ? `Trip Info for ${this.traveler.name}`
+        : 'Trip Info';
     },
   });
+  @field startLocation = linksTo(Country);
+  @field endLocation = linksTo(Country);
 
   /*
   static isolated = class Isolated extends Component<typeof this> {

--- a/packages/drafts-realm/trip-info.gts
+++ b/packages/drafts-realm/trip-info.gts
@@ -1,0 +1,53 @@
+import StringField from 'https://cardstack.com/base/string';
+import { CardDef, FieldDef, contains, field, linksTo, linksToMany } from 'https://cardstack.com/base/card-api';
+import { Component } from 'https://cardstack.com/base/card-api';
+import { Country } from './country';
+
+class Traveler extends FieldDef {
+  static displayName = 'Traveler';
+  @field name = contains(StringField);
+  @field countryOfOrigin = linksTo(Country);
+  @field countriesVisited = linksToMany(Country);
+
+  static embedded = class Embedded extends Component<typeof this> {
+    <template>
+      <div class='traveler'>
+        <div><strong>Name:</strong> <@fields.name /></div>
+        <div><strong>Country of Origin:</strong> <@fields.countryOfOrigin /></div>
+        <div><strong>Countries Visited:</strong> <@fields.countriesVisited /></div>
+      </div>
+      <style>
+        .traveler {
+          display: grid;
+          gap: 20px;
+        }
+      </style>
+    </template>
+  };
+}
+
+export class TripInfo extends CardDef {
+  static displayName = "Trip Info";
+  @field destinations = linksToMany(Country);
+  @field traveler = contains(Traveler);
+  @field title = contains(StringField, {
+    computeVia: function (this: TripInfo) {
+      return this.traveler?.name ? `Trip Info for ${this.traveler.name}` : 'Trip Info';
+    },
+  });
+
+  /*
+  static isolated = class Isolated extends Component<typeof this> {
+    <template></template>
+  }
+  static embedded = class Embedded extends Component<typeof this> {
+    <template></template>
+  }
+  static atom = class Atom extends Component<typeof this> {
+    <template></template>
+  }
+  static edit = class Edit extends Component<typeof this> {
+    <template></template>
+  }
+  */
+}

--- a/packages/host/app/components/matrix/room-message.gts
+++ b/packages/host/app/components/matrix/room-message.gts
@@ -331,7 +331,7 @@ export default class RoomMessage extends Component<Signature> {
           ? new Error(e)
           : e instanceof Error
           ? e
-          : new Error('Unknown error.');
+          : new Error('Patch failed.');
       this.matrixService.failedCommandState.set(eventId, error);
     }
   });

--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -256,14 +256,18 @@ export default class CardService extends Service {
   ): Promise<CardDef | undefined> {
     let api = await this.getAPI();
     let linkedCards = await this.loadPatchedCards(patchData, new URL(card.id));
-    let updatedCard = await api.updateFromSerialized<typeof CardDef>(card, doc);
     for (let [field, value] of Object.entries(linkedCards)) {
-      // TODO this triggers a save which is not ideal. perhaps instead we could
+      if (field.includes('.') || Array.isArray(value)) {
+        // TODO [wip] linksToMany and nested linksTo
+        throw new Error('Not implemented.');
+      }
+      // TODO perhaps instead we could
       // introduce a new option to updateFromSerialized to accept a list of
       // fields to pre-load? which in this case would be any relationships that
       // were patched in
-      (updatedCard as any)[field] = value;
+      (card as any)[field] = value;
     }
+    let updatedCard = await api.updateFromSerialized<typeof CardDef>(card, doc);
     // TODO setting `this` as an owner until we can have a better solution here...
     // (currently only used by the AI bot to patch cards from chat)
     return await this.saveModel(this, updatedCard);

--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -1,7 +1,5 @@
 import Service, { service } from '@ember/service';
 
-import isEqual from 'lodash/isEqual';
-
 import { stringify } from 'qs';
 
 import { v4 as uuidv4 } from 'uuid';

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -429,7 +429,7 @@ export default class MatrixService extends Service {
             type: 'function',
             function: {
               name: 'patchCard',
-              description: `Propose a patch to an existing card to change its contents. Any attributes specified will be fully replaced, return the minimum required to make the change. Ensure the description explains what change you are making`,
+              description: `Propose a patch to an existing card to change its contents. Any attributes specified will be fully replaced, return the minimum required to make the change. If a relationship field value is removed, set the self property to null. Ensure the description explains what change you are making`,
               parameters: {
                 type: 'object',
                 properties: {

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -6,12 +6,16 @@ import Service, { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 import { task } from 'ember-concurrency';
-import { merge } from 'lodash';
+import { mergeWith } from 'lodash';
 import stringify from 'safe-stable-stringify';
 import { TrackedArray, TrackedMap, TrackedObject } from 'tracked-built-ins';
 
-import { type ResolvedCodeRef } from '@cardstack/runtime-common/code-ref';
-import { RealmPaths } from '@cardstack/runtime-common/paths';
+import {
+  mergeRelationships,
+  type PatchData,
+  RealmPaths,
+  type ResolvedCodeRef,
+} from '@cardstack/runtime-common';
 
 import { Submode, Submodes } from '@cardstack/host/components/submode-switcher';
 import { StackItem } from '@cardstack/host/lib/stack-item';
@@ -101,7 +105,7 @@ export default class OperatorModeStateService extends Service {
     this.schedulePersist();
   }
 
-  patchCard = task({ enqueue: true }, async (id: string, patch: any) => {
+  patchCard = task({ enqueue: true }, async (id: string, patch: PatchData) => {
     let stackItems = this.state?.stacks.flat() ?? [];
     if (
       !stackItems.length ||
@@ -112,7 +116,21 @@ export default class OperatorModeStateService extends Service {
     for (let item of stackItems) {
       if ('card' in item && item.card.id == id) {
         let document = await this.cardService.serializeCard(item.card);
-        document.data = merge(document.data, patch);
+        if (patch.attributes) {
+          document.data.attributes = mergeWith(
+            document.data.attributes,
+            patch.attributes,
+          );
+        }
+        if (patch.relationships) {
+          let mergedRel = mergeRelationships(
+            document.data.relationships,
+            patch.relationships,
+          );
+          if (mergedRel && Object.keys(mergedRel).length !== 0) {
+            document.data.relationships = mergedRel;
+          }
+        }
         await this.cardService.patchCard(item.card, document, patch);
       }
     }

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -924,7 +924,7 @@ module('Integration | operator-mode', function (hooks) {
             command: {
               type: 'patchCard',
               id: `${testRealmURL}Person/fadhlan`,
-              patch: { attributes: { pet: null } },
+              patch: { relationships: { pet: null } }, // this will error
               eventId: 'room2-event1',
             },
           }),
@@ -1244,143 +1244,6 @@ module('Integration | operator-mode', function (hooks) {
       assert.dom(`${stackCard} [data-test-country="Indonesia"]`).exists();
     });
 
-    test('it will throw error when patch code refers to nonexistent or incorrect field', async function (assert) {
-      let id = `${testRealmURL}Person/fadhlan`;
-      await setCardInOperatorModeState(id);
-      await renderComponent(
-        class TestDriver extends GlimmerComponent {
-          <template>
-            <OperatorMode @onClose={{noop}} />
-            <CardPrerender />
-          </template>
-        },
-      );
-      await waitFor('[data-test-person="Fadhlan"]');
-
-      let roomId = await openAiAssistant();
-      await addRoomEvent(matrixService, {
-        event_id: 'event1',
-        room_id: roomId,
-        state_key: 'state',
-        type: 'm.room.message',
-        origin_server_ts: new Date(2024, 0, 3, 12, 30).getTime(),
-        sender: '@aibot:localhost',
-        content: {
-          msgtype: 'org.boxel.command',
-          formatted_body: 'Removing pet from person card',
-          format: 'org.matrix.custom.html',
-          data: JSON.stringify({
-            command: {
-              type: 'patchCard',
-              id,
-              patch: { attributes: { pet: null } },
-              eventId: 'patch1',
-            },
-          }),
-          'm.relates_to': {
-            rel_type: 'm.replace',
-            event_id: 'patch1',
-          },
-        },
-        status: null,
-      });
-      await waitFor('[data-test-command-apply="ready"]');
-      await click('[data-test-command-apply]');
-      await waitFor('[data-test-patch-card-idle]');
-      assert.dom('[data-test-apply-state="failed"]').exists();
-      assert
-        .dom(`[data-test-card-error]`)
-        .hasText(`Failed to apply changes. Patch failed.`);
-
-      await addRoomEvent(matrixService, {
-        event_id: 'event3',
-        room_id: roomId,
-        state_key: 'state',
-        type: 'm.room.message',
-        origin_server_ts: new Date(2024, 0, 3, 12, 30).getTime(),
-        sender: '@aibot:localhost',
-        content: {
-          msgtype: 'org.boxel.command',
-          formatted_body:
-            "Adding 'Indonesia' to the list of countries visited in the trips attribute.",
-          format: 'org.matrix.custom.html',
-          data: JSON.stringify({
-            command: {
-              type: 'patchCard',
-              id,
-              patch: {
-                attributes: {
-                  trips: {
-                    countriesVisited: ['Indonesia'],
-                  },
-                },
-              },
-              eventId: 'patch3',
-            },
-          }),
-          'm.relates_to': {
-            rel_type: 'm.replace',
-            event_id: 'patch3',
-          },
-        },
-        status: null,
-      });
-      await waitFor('[data-test-command-apply="ready"]');
-      await click('[data-test-command-apply]');
-      await waitFor('[data-test-message-idx="1"] [data-test-patch-card-idle]');
-      assert
-        .dom('[data-test-message-idx="1"] [data-test-apply-state="failed"]')
-        .exists();
-      assert
-        .dom(`[data-test-message-idx="1"] [data-test-card-error]`)
-        .hasText(`Failed to apply changes. Patch failed.`);
-      assert.dom('[data-test-trips]').hasText('');
-
-      await addRoomEvent(matrixService, {
-        event_id: 'event4',
-        room_id: roomId,
-        state_key: 'state',
-        type: 'm.room.message',
-        origin_server_ts: new Date(2024, 0, 3, 12, 30).getTime(),
-        sender: '@aibot:localhost',
-        content: {
-          msgtype: 'org.boxel.command',
-          formatted_body: 'Change preferred carrier',
-          format: 'org.matrix.custom.html',
-          data: JSON.stringify({
-            command: {
-              type: 'patchCard',
-              id,
-              patch: {
-                attributes: {
-                  address: { shippingInfo: { carrier: 'UPS' } },
-                },
-              },
-              eventId: 'patch4',
-            },
-          }),
-          'm.relates_to': {
-            rel_type: 'm.replace',
-            event_id: 'patch4',
-          },
-        },
-        status: null,
-      });
-
-      await waitFor('[data-test-command-apply="ready"]');
-      assert.dom('[data-test-preferredcarrier="DHL"]').exists();
-
-      await click('[data-test-command-apply]');
-      await waitFor('[data-test-message-idx="1"] [data-test-patch-card-idle]');
-      assert
-        .dom('[data-test-message-idx="1"] [data-test-apply-state="failed"]')
-        .exists();
-      assert
-        .dom(`[data-test-message-idx="1"] [data-test-card-error]`)
-        .hasText(`Failed to apply changes. Patch failed.`);
-      assert.dom('[data-test-preferredcarrier="DHL"]').exists();
-    });
-
     test('button states only apply to a single button in a chat room', async function (assert) {
       let id = `${testRealmURL}Person/fadhlan`;
       await setCardInOperatorModeState(id);
@@ -1430,13 +1293,13 @@ module('Integration | operator-mode', function (hooks) {
         sender: '@aibot:localhost',
         content: {
           msgtype: 'org.boxel.command',
-          formatted_body: 'Change first name to Dave',
+          formatted_body: 'Incorrect patch command',
           format: 'org.matrix.custom.html',
           data: JSON.stringify({
             command: {
               type: 'patchCard',
               id,
-              patch: { attributes: { pet: 'Harry' } },
+              patch: { relationships: { pet: null } }, // this will error
               eventId: 'event2',
             },
           }),
@@ -1456,7 +1319,7 @@ module('Integration | operator-mode', function (hooks) {
         sender: '@aibot:localhost',
         content: {
           msgtype: 'org.boxel.command',
-          formatted_body: 'Change first name to Dave',
+          formatted_body: 'Change first name to Jackie',
           format: 'org.matrix.custom.html',
           data: JSON.stringify({
             command: {

--- a/packages/host/tests/unit/ai-function-generation-test.ts
+++ b/packages/host/tests/unit/ai-function-generation-test.ts
@@ -206,7 +206,7 @@ module('Unit | ai-function-generation-test', function (hooks) {
         links: {
           type: 'object',
           properties: {
-            self: { type: 'null' },
+            self: { type: 'string' },
           },
           required: ['self'],
         },
@@ -443,7 +443,7 @@ module('Unit | ai-function-generation-test', function (hooks) {
             links: {
               type: 'object',
               properties: {
-                self: { type: 'null' },
+                self: { type: 'string' },
               },
               required: ['self'],
             },
@@ -457,7 +457,7 @@ module('Unit | ai-function-generation-test', function (hooks) {
             links: {
               type: 'object',
               properties: {
-                self: { type: 'null' },
+                self: { type: 'string' },
               },
               required: ['self'],
             },

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -291,7 +291,7 @@ test.describe('Room messages', () => {
         function: {
           name: 'patchCard',
           description:
-            'Propose a patch to an existing card to change its contents. Any attributes specified will be fully replaced, return the minimum required to make the change. Ensure the description explains what change you are making',
+            'Propose a patch to an existing card to change its contents. Any attributes specified will be fully replaced, return the minimum required to make the change. If a relationship field value is removed, set the self property to null. Ensure the description explains what change you are making',
           parameters: {
             type: 'object',
             properties: {

--- a/packages/runtime-common/helpers/ai.ts
+++ b/packages/runtime-common/helpers/ai.ts
@@ -26,7 +26,7 @@ export type RelationshipSchema = {
     links: {
       type: 'object';
       properties: {
-        self: { type: 'null' | 'string' };
+        self: { type: 'string' | 'null' };
       };
       required: ['self'];
     };
@@ -215,7 +215,7 @@ function generatePatchCallSpecification(
             links: {
               type: 'object',
               properties: {
-                self: { type: 'null' || 'string' },
+                self: { type: 'string' },
               },
               required: ['self'],
             },

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -49,6 +49,7 @@ export * from './db';
 export * from './worker';
 export * from './stream';
 export * from './realm';
+export { mergeRelationships } from './merge-relationships';
 export { makeLogDefinitions, logger } from './log';
 export { RealmPaths, Loader, type LocalPath, type Query };
 export { NotLoaded, isNotLoadedError } from './not-loaded';


### PR DESCRIPTION
- Removed the `isPatchApplied` method (also see related test removed in operator-mode-tests)
- I was able to reproduce the 'card not loaded' error on main branch, as well as in tests, which resulted in infinite rerenders and crashed the app. The changes in `card-api` resolve this bug.
- Fixed error in linksTo patching, where links were primarily set to be null