### PR TITLE
Introduce search feature 

### DIFF
--- a/packages/ai-bot/helpers.ts
+++ b/packages/ai-bot/helpers.ts
@@ -1,4 +1,7 @@
-import { type LooseSingleCardDocument } from '@cardstack/runtime-common';
+import {
+  LooseCardResource,
+  type LooseSingleCardDocument,
+} from '@cardstack/runtime-common';
 import type {
   MatrixEvent as DiscreteMatrixEvent,
   CardFragmentContent,
@@ -145,8 +148,9 @@ export interface OpenAIPromptMessage {
 export function getRelevantCards(
   history: DiscreteMatrixEvent[],
   aiBotUserId: string,
-) {
+): [LooseCardResource | undefined, LooseCardResource[]] {
   let relevantCards: Map<string, any> = new Map();
+  let mostRecentlySharedCard;
   for (let event of history) {
     if (event.type !== 'm.room.message') {
       continue;
@@ -157,6 +161,7 @@ export function getRelevantCards(
         const attachedCards = content.data?.attachedCards || [];
         for (let card of attachedCards) {
           if (card.data.id) {
+            mostRecentlySharedCard = card.data;
             relevantCards.set(card.data.id, card.data);
           } else {
             throw new Error(`bug: don't know how to handle card without ID`);
@@ -170,7 +175,7 @@ export function getRelevantCards(
   let sortedCards = Array.from(relevantCards.values()).sort((a, b) => {
     return a.id.localeCompare(b.id);
   });
-  return sortedCards;
+  return [mostRecentlySharedCard, sortedCards];
 }
 
 export function getTools(history: DiscreteMatrixEvent[], aiBotUserId: string) {
@@ -230,8 +235,7 @@ export function getModifyPrompt(
   let systemMessage =
     MODIFY_SYSTEM_MESSAGE +
     `
-  The user currently has given you the following data to work with:
-  Cards:\n`;
+  The user currently has given you the following data to work with. \n`;
   systemMessage += attachedCardsToMessage(history, aiBotUserId);
   if (tools.length == 0) {
     systemMessage +=
@@ -253,9 +257,21 @@ export const attachedCardsToMessage = (
   history: DiscreteMatrixEvent[],
   aiBotUserId: string,
 ) => {
-  return `Full card data: ${JSON.stringify(
-    getRelevantCards(history, aiBotUserId),
-  )}`;
+  let [mostRecentlySharedCard, allSharedCards] = getRelevantCards(
+    history,
+    aiBotUserId,
+  );
+  let a =
+    mostRecentlySharedCard !== undefined
+      ? `Most recently shared card: ${JSON.stringify(
+          mostRecentlySharedCard,
+        )}.\n`
+      : ``;
+  let b =
+    allSharedCards.length > 0
+      ? `All previously shared cards: ${JSON.stringify(allSharedCards)}.\n`
+      : ``;
+  return a + b;
 };
 
 export function cleanContent(content: string) {
@@ -266,8 +282,7 @@ export function cleanContent(content: string) {
   return content.trim();
 }
 
-//matrix-js-sdk extensions
-export const isPatchReactionEvent = (event?: MatrixEvent) => {
+export const isCommandReactionEvent = (event?: MatrixEvent) => {
   if (event === undefined) {
     return false;
   }

--- a/packages/ai-bot/lib/matrix.ts
+++ b/packages/ai-bot/lib/matrix.ts
@@ -144,6 +144,7 @@ export const toMatrixMessageContent = (
             relationships: payload['relationships'],
           },
           eventId: eventToUpdate,
+          toolCall: functionCall,
         },
       },
     };
@@ -160,6 +161,7 @@ export const toMatrixMessageContent = (
           type: functionCall.name,
           search: { ...payload },
           eventId: eventToUpdate,
+          toolCall: functionCall,
         },
       },
     };

--- a/packages/ai-bot/lib/matrix.ts
+++ b/packages/ai-bot/lib/matrix.ts
@@ -139,7 +139,6 @@ export const toMatrixMessageContent = (
         command: {
           type: functionCall.name,
           id: id,
-          //TODO: maybe this should just return the payload but it might interfere with burcus work
           patch: {
             attributes: payload['attributes'],
             relationships: payload['relationships'],

--- a/packages/ai-bot/lib/matrix.ts
+++ b/packages/ai-bot/lib/matrix.ts
@@ -67,42 +67,32 @@ export async function sendMessage(
   );
 }
 
+export interface FunctionToolCall {
+  name: 'searchCard' | 'patchCard';
+  arguments: any;
+}
+
 // TODO we might want to think about how to handle patches that are larger than
 // 65KB (the maximum matrix event size), such that we split them into fragments
 // like we split cards into fragments
 export async function sendOption(
   client: MatrixClient,
   roomId: string,
-  patch: any,
+  functionCall: FunctionToolCall,
   eventToUpdate: string | undefined,
 ) {
-  log.debug('sending option', patch);
-  const id = patch['card_id'];
-  const body = patch['description'] || "Here's the change:";
-  let messageObject = {
-    body: body,
-    msgtype: 'org.boxel.command',
-    formatted_body: body,
-    format: 'org.matrix.custom.html',
-    data: {
-      command: {
-        type: 'patchCard',
-        id: id,
-        patch: {
-          attributes: patch['attributes'],
-          relationships: patch['relationships'],
-        },
-        eventId: eventToUpdate,
-      },
-    },
-  };
-  return await sendEvent(
-    client,
-    roomId,
-    'm.room.message',
-    messageObject,
-    eventToUpdate,
-  );
+  let messageObject = toMatrixMessageContent(functionCall, eventToUpdate);
+
+  if (messageObject !== undefined) {
+    return await sendEvent(
+      client,
+      roomId,
+      'm.room.message',
+      messageObject,
+      eventToUpdate,
+    );
+  }
+  return;
 }
 
 export async function sendError(
@@ -131,6 +121,53 @@ export async function sendError(
     Sentry.captureException(e);
   }
 }
+
+export const toMatrixMessageContent = (
+  functionCall: FunctionToolCall,
+  eventToUpdate: string | undefined,
+): IContent | undefined => {
+  let { arguments: payload } = functionCall;
+  if (functionCall.name === 'patchCard') {
+    const id = payload['card_id'];
+    const body = payload['description'] || "Here's the change:";
+    let messageObject: IContent = {
+      body: body,
+      msgtype: 'org.boxel.command',
+      formatted_body: body,
+      format: 'org.matrix.custom.html',
+      data: {
+        command: {
+          type: functionCall.name,
+          id: id,
+          //TODO: maybe this should just return the payload but it might interfere with burcus work
+          patch: {
+            attributes: payload['attributes'],
+            relationships: payload['relationships'],
+          },
+          eventId: eventToUpdate,
+        },
+      },
+    };
+    return messageObject;
+  } else if (functionCall.name === 'searchCard') {
+    const body = payload['description'] || "Here's the query:";
+    let messageObject = {
+      body: body,
+      msgtype: 'org.boxel.command',
+      formatted_body: body,
+      format: 'org.matrix.custom.html',
+      data: {
+        command: {
+          type: functionCall.name,
+          search: { ...payload },
+          eventId: eventToUpdate,
+        },
+      },
+    };
+    return messageObject;
+  }
+  return;
+};
 
 function getErrorMessage(error: any): string {
   if (error instanceof OpenAIError) {

--- a/packages/ai-bot/lib/set-title.ts
+++ b/packages/ai-bot/lib/set-title.ts
@@ -2,7 +2,7 @@ import { type MatrixEvent, type IEventRelation } from 'matrix-js-sdk';
 import OpenAI from 'openai';
 import {
   type OpenAIPromptMessage,
-  isPatchReactionEvent,
+  isCommandReactionEvent,
   isPatchCommandEvent,
   attachedCardsToMessage,
 } from '../helpers';
@@ -140,7 +140,7 @@ export function shouldSetRoomTitle(
   event?: MatrixEvent,
 ) {
   return (
-    (isPatchReactionEvent(event) ||
+    (isCommandReactionEvent(event) ||
       userAlreadyHasSentNMessages(rawEventLog, aiBotUserId)) &&
     !roomTitleAlreadySet(rawEventLog)
   );

--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -11,7 +11,7 @@ import {
   constructHistory,
   getModifyPrompt,
   getTools,
-  isPatchReactionEvent,
+  isCommandReactionEvent,
 } from './helpers';
 import {
   shouldSetRoomTitle,
@@ -152,6 +152,10 @@ Common issues are:
         if (event.getContent().msgtype === 'org.boxel.cardFragment') {
           return; // don't respond to card fragments, we just gather these in our history
         }
+
+        if (event.getContent().msgtype === 'org.boxel.commandResult') {
+          return; //don't responsd to command results
+        }
         if (event.getSender() === aiBotUserId) {
           return;
         }
@@ -203,12 +207,12 @@ Common issues are:
     },
   );
 
-  //handle reaction events
+  //handle set title by commands
   client.on(RoomEvent.Timeline, async function (event, room) {
     if (!room) {
       return;
     }
-    if (!isPatchReactionEvent(event)) {
+    if (!isCommandReactionEvent(event)) {
       return;
     }
     log.info(

--- a/packages/ai-bot/tests/responding-test.ts
+++ b/packages/ai-bot/tests/responding-test.ts
@@ -219,9 +219,23 @@ module('Responding', (hooks) => {
       {
         command: {
           type: 'patchCard',
-          id: patchArgs.card_id,
-          patch: { attributes: patchArgs.attributes },
+          id: 'card/1',
+          patch: {
+            attributes: {
+              some: 'thing',
+            },
+          },
           eventId: '0',
+          toolCall: {
+            name: 'patchCard',
+            arguments: {
+              card_id: 'card/1',
+              description: 'A new thing',
+              attributes: {
+                some: 'thing',
+              },
+            },
+          },
         },
       },
       'Tool call event should be sent with correct content',
@@ -279,8 +293,22 @@ module('Responding', (hooks) => {
       {
         command: {
           type: 'patchCard',
-          id: patchArgs.card_id,
-          patch: { attributes: patchArgs.attributes },
+          id: 'card/1',
+          patch: {
+            attributes: {
+              some: 'thing',
+            },
+          },
+          toolCall: {
+            name: 'patchCard',
+            arguments: {
+              card_id: 'card/1',
+              description: 'A new thing',
+              attributes: {
+                some: 'thing',
+              },
+            },
+          },
         },
       },
       'Tool call event should be sent with correct content',

--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -1,0 +1,60 @@
+import { contains, field, primitive, FieldDef, Component } from './card-api';
+
+import StringField from './string';
+
+class CommandObjectField extends FieldDef {
+  //this is probably wrong
+  static [primitive]: Object;
+}
+
+type CommandTypeValue = string;
+
+class CommandType extends FieldDef {
+  static [primitive]: CommandTypeValue;
+}
+
+type CommandStatus = 'applied' | 'ready';
+
+class CommandStatusField extends FieldDef {
+  static [primitive]: CommandStatus;
+}
+
+class CommandResultObjectField extends FieldDef {
+  static [primitive]: Object; //TODO: keeping types opened
+
+  static embedded = class Embedded extends Component<typeof this> {
+    get arrs() {
+      return this.args.model as any[];
+    }
+    <template>
+      {{#each this.arrs as |id i|}}
+        <div>
+          {{i}}.
+          {{id}}
+        </div>
+      {{/each}}
+    </template>
+  };
+}
+
+export class CommandField extends FieldDef {
+  @field eventId = contains(StringField);
+  @field commandType = contains(CommandType);
+  @field payload = contains(CommandObjectField); //args returned by open ai
+  @field status = contains(CommandStatusField);
+  @field result = contains(CommandResultObjectField);
+}
+
+export interface CommandMessageContent {
+  'm.relates_to'?: {
+    rel_type: string;
+    event_id: string;
+  };
+  msgtype: 'org.boxel.command';
+  format: 'org.matrix.custom.html';
+  body: string;
+  formatted_body: string;
+  data: {
+    command: any; //type CommandPayload: PatchCardPayload | SearchCardPayload;
+  };
+}

--- a/packages/base/patch-command.gts
+++ b/packages/base/patch-command.gts
@@ -1,5 +1,4 @@
 import { CommandField } from './command';
-import { action } from '@ember/object';
 
 type JSONValue = string | number | boolean | null | JSONObject | [JSONValue];
 
@@ -12,14 +11,4 @@ export interface PatchCardPayload {
   eventId: string;
 }
 
-export class PatchCommandField extends CommandField {
-  //Runs functions available to host
-  get hostCommandArgs() {
-    return this.payload;
-  }
-
-  @action
-  run() {
-    this.hostCommand();
-  }
-}
+export class PatchCommandField extends CommandField {}

--- a/packages/base/patch-command.gts
+++ b/packages/base/patch-command.gts
@@ -1,0 +1,25 @@
+import { CommandField } from './command';
+import { action } from '@ember/object';
+
+type JSONValue = string | number | boolean | null | JSONObject | [JSONValue];
+
+type JSONObject = { [x: string]: JSONValue };
+
+export type PatchObject = { patch: { attributes: JSONObject }; id: string };
+export interface PatchCardPayload {
+  type: 'patchCard';
+  payload: PatchObject;
+  eventId: string;
+}
+
+export class PatchCommandField extends CommandField {
+  //Runs functions available to host
+  get hostCommandArgs() {
+    return this.payload;
+  }
+
+  @action
+  run() {
+    this.hostCommand();
+  }
+}

--- a/packages/base/room.gts
+++ b/packages/base/room.gts
@@ -817,6 +817,7 @@ export interface CommandResultContent {
   body: string;
   msgtype: 'org.boxel.commandResult';
   result: any;
+  toolCall: any;
 }
 
 // difference Command result and reaction event is that reaction event requires
@@ -941,6 +942,7 @@ const toCommandField = (
         commandType,
         payload,
         status,
+        result,
       });
     }
   }

--- a/packages/base/search-command.gts
+++ b/packages/base/search-command.gts
@@ -1,0 +1,83 @@
+import {
+  ResolvedCodeRef,
+  codeRefWithAbsoluteURL,
+  getCards,
+  isResolvedCodeRef,
+} from '@cardstack/runtime-common';
+import { CardTypeFilter, Query } from '@cardstack/runtime-common/query';
+import { CommandField } from './command';
+import { Component } from './card-api';
+import { on } from '@ember/modifier';
+import { Button } from '@cardstack/boxel-ui/components';
+import { task } from 'ember-concurrency';
+import { not } from '@cardstack/boxel-ui/helpers';
+
+export type SearchObject = {
+  search: {
+    card_id: string; //we search relative to the card that is shared
+    filter: CardTypeFilter; //TODO: can be enhanced by other filter types
+  };
+};
+
+export interface SearchCardPayload {
+  type: 'searchCard';
+  payload: SearchObject;
+  eventId: string;
+}
+
+class EmbeddedView extends Component<typeof CommandField> {
+  get queryArgs() {
+    let query = (this.args.model.payload as SearchObject).search;
+    let codeRef = query.filter.type;
+    if (!isResolvedCodeRef(codeRef)) {
+      return {};
+    }
+    let adoptsFrom: ResolvedCodeRef = {
+      name: codeRef.name,
+      module: codeRef.module,
+    };
+    //If ai returns a relative module path, we make it absolute
+    let maybeCodeRef = codeRefWithAbsoluteURL(
+      adoptsFrom,
+      new URL(query.card_id), //relative to the attached card id shared
+    );
+    if ('name' in maybeCodeRef && 'module' in maybeCodeRef) {
+      query.filter.type = maybeCodeRef;
+    }
+    return {
+      filter: { type: query.filter.type },
+    } as Query;
+  }
+  cardSearchResource = getCards(this.queryArgs);
+
+  apply = task(async () => {
+    await this.cardSearchResource.loaded;
+    this.args.model.result = this.cardSearchResource.instances.map(
+      (card) => card.id,
+    );
+  });
+
+  <template>
+    <div class='embedded-command'>
+      <h3>{{this.args.model.commandType}} command</h3>
+      {{#if this.apply.isRunning}}
+        ...Loading
+      {{else}}
+        <@fields.result @format='embedded' />
+      {{/if}}
+      {{#if (not this.args.model.result)}}
+        <Button {{on 'click' this.apply.perform}}>Apply</Button>
+      {{/if}}
+    </div>
+    <style>
+      .embedded-command {
+        border: 2px solid white;
+        border-radius: 10px; /* Adjust the radius as needed */
+      }
+    </style>
+  </template>
+}
+
+export class SearchCommandField extends CommandField {
+  static embedded = EmbeddedView;
+}

--- a/packages/drafts-realm/Product/12df8671-2b17-4922-9a48-0ee8d795dd88.json
+++ b/packages/drafts-realm/Product/12df8671-2b17-4922-9a48-0ee8d795dd88.json
@@ -31,12 +31,12 @@
       },
       "unitPrice.currency": {
         "links": {
-          "self": "http://localhost:4201/drafts/Currency/3"
+          "self": "../Currency/3"
         }
       },
       "shippingCost.currency": {
         "links": {
-          "self": "http://localhost:4201/drafts/Currency/2"
+          "self": "../Currency/2"
         }
       }
     },

--- a/packages/drafts-realm/Product/12df8671-2b17-4922-9a48-0ee8d795dd88.json
+++ b/packages/drafts-realm/Product/12df8671-2b17-4922-9a48-0ee8d795dd88.json
@@ -31,12 +31,12 @@
       },
       "unitPrice.currency": {
         "links": {
-          "self": "../Currency/2"
+          "self": "http://localhost:4201/drafts/Currency/3"
         }
       },
       "shippingCost.currency": {
         "links": {
-          "self": "../Currency/2"
+          "self": "http://localhost:4201/drafts/Currency/2"
         }
       }
     },

--- a/packages/host/app/components/ai-assistant/message/index.gts
+++ b/packages/host/app/components/ai-assistant/message/index.gts
@@ -219,7 +219,7 @@ export default class AiAssistantMessage extends Component<Signature> {
         overflow: auto;
       }
 
-      .content > :deep(.patch-message) {
+      .content > :deep(.command-message) {
         font-weight: 700;
         letter-spacing: var(--boxel-lsp-sm);
       }

--- a/packages/host/app/components/matrix/room-message.gts
+++ b/packages/host/app/components/matrix/room-message.gts
@@ -334,7 +334,7 @@ export default class RoomMessage extends Component<Signature> {
   }
 
   private handleCommand = task(async () => {
-    let { eventId } = this.args.message.command;
+    let { eventId, payload } = this.args.message.command;
     try {
       let res: any;
       this.matrixService.failedCommandState.delete(eventId);
@@ -357,6 +357,7 @@ export default class RoomMessage extends Component<Signature> {
           this.args.roomId,
           eventId,
           res,
+          (payload as any).toolCall,
         );
       }
     } catch (e) {

--- a/packages/host/app/components/matrix/room-message.gts
+++ b/packages/host/app/components/matrix/room-message.gts
@@ -12,7 +12,7 @@ import { modifier } from 'ember-modifier';
 import { trackedFunction } from 'ember-resources/util/function';
 
 import { Button } from '@cardstack/boxel-ui/components';
-import { bool } from '@cardstack/boxel-ui/helpers';
+import { and, bool } from '@cardstack/boxel-ui/helpers';
 import { Copy as CopyIcon } from '@cardstack/boxel-ui/icons';
 
 import { markdownToHtml } from '@cardstack/runtime-common';
@@ -25,8 +25,8 @@ import { type MonacoSDK } from '@cardstack/host/services/monaco-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 import { BaseDef, type CardDef } from 'https://cardstack.com/base/card-api';
-import { type MessageField } from 'https://cardstack.com/base/room';
 import { PatchObject } from 'https://cardstack.com/base/patch-command';
+import { type MessageField } from 'https://cardstack.com/base/room';
 
 import ApplyButton from '../ai-assistant/apply-button';
 import { type ApplyButtonState } from '../ai-assistant/apply-button';
@@ -120,7 +120,10 @@ export default class RoomMessage extends Component<Signature> {
         {{#if (bool this.isCommand)}}
           <div
             class='command-button-bar'
-            data-test-command-card-idle={{this.operatorModeStateService.patchCard.isIdle}}
+            data-test-command-card-idle={{(and
+              this.operatorModeStateService.patchCard.isIdle
+              this.handleCommand.isIdle
+            )}}
           >
             <Button
               class='view-code-button'
@@ -139,7 +142,7 @@ export default class RoomMessage extends Component<Signature> {
             />
 
             <div>
-              {{#let (getComponent this.args.message) as |Component|}}
+              {{#let (getComponent @message) as |Component|}}
                 <Component @format='embedded' />
               {{/let}}
             </div>
@@ -330,10 +333,6 @@ export default class RoomMessage extends Component<Signature> {
     );
   }
 
-  get commandIsRunning() {
-    return this.handleCommand.isRunning;
-  }
-
   private handleCommand = task(async () => {
     let { eventId } = this.args.message.command;
     try {
@@ -401,7 +400,7 @@ export default class RoomMessage extends Component<Signature> {
 
   @cached
   private get applyButtonState(): ApplyButtonState {
-    if (this.commandIsRunning) {
+    if (this.handleCommand.isRunning) {
       return 'applying';
     }
     if (this.failedCommandState) {

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -31,6 +31,10 @@ import {
   generateCardPatchCallSpecification,
 } from '@cardstack/runtime-common/helpers/ai';
 
+import {
+  getPatchTool,
+  getSearchTool,
+} from '@cardstack/runtime-common/helpers/ai';
 import { RealmAuthClient } from '@cardstack/runtime-common/realm-auth-client';
 
 import { Submode } from '@cardstack/host/components/submode-switcher';
@@ -362,7 +366,11 @@ export default class MatrixService extends Service {
   private async sendEvent(
     roomId: string,
     eventType: string,
-    content: CardMessageContent | CardFragmentContent | ReactionEventContent,
+    content:
+      | CardMessageContent
+      | CardFragmentContent
+      | ReactionEventContent
+      | CommandResultContent,
   ) {
     if ('data' in content) {
       const encodedContent = {
@@ -420,69 +428,10 @@ export default class MatrixService extends Service {
   }
 
   private addTools = (attachedOpenCard: CardDef, patchSpec: any) => {
-    let tools = [];
-    tools.push({
-      type: 'function',
-      function: {
-        name: 'patchCard',
-        description: `Propose a patch to an existing card to change its contents. Any attributes specified will be fully replaced, return the minimum required to make the change. If a relationship field value is removed, set the self property of the specific item to null. When editing a relationship array, display the full array in the patch code. Ensure the description explains what change you are making.`,
-        parameters: {
-          type: 'object',
-          properties: {
-            card_id: {
-              type: 'string',
-              const: attachedOpenCard.id, // Force the valid card_id to be the id of the card being patched
-            },
-            description: {
-              type: 'string',
-            },
-            ...patchSpec,
-          },
-          required: ['card_id', 'attributes', 'description'],
-        },
-      },
-    });
-    //need to make sure filter object is returned
-    tools.push({
-      type: 'function',
-      function: {
-        name: 'searchCard',
-        description: `Propose a query to search for a card instance related to module it was from. 
-        Always prioritise search based upon the card that was last shared. 
-        Ensure that you find the correct "module" and "name" from the OUTERMOST "adoptsFrom" field from the card data that is shared`,
-        parameters: {
-          type: 'object',
-          properties: {
-            card_id: {
-              type: 'string',
-              const: attachedOpenCard.id, // Force the valid card_id to be the id of the card being patched
-            },
-            filter: {
-              type: 'object',
-              properties: {
-                type: {
-                  //resolved code ref essentially
-                  type: 'object',
-                  properties: {
-                    module: {
-                      type: 'string',
-                      description: `the absolute path of the module`,
-                    },
-                    name: {
-                      type: 'string',
-                      description: 'the name of the module',
-                    },
-                  },
-                  required: ['module', 'name'],
-                },
-              },
-            },
-          },
-          required: ['card_id', 'filter'],
-        },
-      },
-    });
-    return tools;
+    return [
+      getPatchTool(attachedOpenCard, patchSpec),
+      getSearchTool(attachedOpenCard),
+    ];
   };
 
   async sendMessage(

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -402,7 +402,12 @@ export default class MatrixService extends Service {
     }
   }
 
-  async sendCommandResultMessage(roomId: string, eventId: string, result: any) {
+  async sendCommandResultMessage(
+    roomId: string,
+    eventId: string,
+    result: any,
+    toolCall: any,
+  ) {
     let body = `Command Results from command event ${eventId}`;
     let html = markdownToHtml(body);
     let content: CommandResultContent = {
@@ -415,6 +420,7 @@ export default class MatrixService extends Service {
       formatted_body: html,
       msgtype: 'org.boxel.commandResult',
       result,
+      toolCall,
     };
     try {
       return await this.sendEvent(roomId, 'm.room.message', content);

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -1524,7 +1524,7 @@ module('Integration | operator-mode', function (hooks) {
               type: 'patchCard',
               id,
               patch: { attributes: { firstName: 'Dave' } },
-              eventId: undefined,
+              eventId: 'event1',
             },
           }),
           'm.relates_to': {
@@ -1536,7 +1536,6 @@ module('Integration | operator-mode', function (hooks) {
       });
 
       await waitFor('[data-test-command-apply="ready"]', { count: 1 });
-
       await click('[data-test-message-idx="0"] [data-test-command-apply]');
       assert.dom('[data-test-apply-state="applying"]').exists({ count: 1 });
       assert

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -903,7 +903,7 @@ module('Integration | operator-mode', function (hooks) {
         assert.strictEqual(json.data.attributes?.firstName, 'Dave');
       });
       await click('[data-test-command-apply]');
-      await waitFor('[data-test-patch-card-idle]');
+      await waitFor('[data-test-command-card-idle]');
 
       assert.dom('[data-test-person]').hasText('Dave');
     });
@@ -1004,7 +1004,7 @@ module('Integration | operator-mode', function (hooks) {
       await waitFor('[data-test-room-name="test room 1"]');
       await waitFor('[data-test-message-idx="1"] [data-test-command-apply]');
       await click('[data-test-message-idx="1"] [data-test-command-apply]');
-      await waitFor('[data-test-patch-card-idle]');
+      await waitFor('[data-test-command-card-idle]');
 
       assert
         .dom('[data-test-message-idx="1"] [data-test-apply-state="applied"]')
@@ -1018,7 +1018,7 @@ module('Integration | operator-mode', function (hooks) {
       await waitFor('[data-test-room-name="test room 2"]');
       await waitFor('[data-test-command-apply]');
       await click('[data-test-command-apply]');
-      await waitFor('[data-test-patch-card-idle]');
+      await waitFor('[data-test-command-card-idle]');
       assert
         .dom('[data-test-message-idx="0"] [data-test-apply-state="failed"]')
         .exists();
@@ -1097,7 +1097,7 @@ module('Integration | operator-mode', function (hooks) {
       await waitFor('[data-test-command-apply="ready"]');
       await click('[data-test-command-apply]');
 
-      await waitFor('[data-test-patch-card-idle]');
+      await waitFor('[data-test-command-card-idle]');
       assert
         .dom('[data-test-card-error]')
         .containsText(
@@ -1118,7 +1118,7 @@ module('Integration | operator-mode', function (hooks) {
       await click('[data-test-ai-bot-retry-button]'); // retry the command with correct card
       assert.dom('[data-test-apply-state="applying"]').exists();
 
-      await waitFor('[data-test-patch-card-idle]');
+      await waitFor('[data-test-command-card-idle]');
       assert.dom('[data-test-apply-state="applied"]').exists();
       assert.dom('[data-test-person]').hasText('Dave');
       assert.dom('[data-test-command-apply]').doesNotExist();
@@ -1198,7 +1198,7 @@ module('Integration | operator-mode', function (hooks) {
       assert.dom('[data-test-code-editor]').doesNotExist();
 
       await click('[data-test-command-apply="ready"]');
-      await waitFor('[data-test-patch-card-idle]');
+      await waitFor('[data-test-command-card-idle]');
       assert.dom('[data-test-apply-state="applied"]').exists();
       assert.dom('[data-test-person]').hasText('Joy');
       assert.dom(`[data-test-preferredcarrier]`).hasText('UPS');
@@ -1261,7 +1261,7 @@ module('Integration | operator-mode', function (hooks) {
       assert.dom(`${stackCard} [data-test-pet="Mango"]`).exists();
 
       await click('[data-test-command-apply]');
-      await waitFor('[data-test-patch-card-idle]');
+      await waitFor('[data-test-command-card-idle]');
       assert.dom('[data-test-apply-state="applied"]').exists();
       assert.dom(`${stackCard} [data-test-preferredcarrier="Fedex"]`).exists();
       assert.dom(`${stackCard} [data-test-pet="Mango"]`).doesNotExist();
@@ -1306,7 +1306,9 @@ module('Integration | operator-mode', function (hooks) {
       assert.dom(`${stackCard} [data-test-pet]`).doesNotExist();
 
       await click('[data-test-command-apply]');
-      await waitFor('[data-test-message-idx="1"] [data-test-patch-card-idle]');
+      await waitFor(
+        '[data-test-message-idx="1"] [data-test-command-card-idle]',
+      );
       assert
         .dom('[data-test-message-idx="1"] [data-test-apply-state="applied"]')
         .exists();
@@ -1362,7 +1364,7 @@ module('Integration | operator-mode', function (hooks) {
 
       await waitFor('[data-test-command-apply="ready"]');
       await click('[data-test-command-apply]');
-      await waitFor('[data-test-patch-card-idle]');
+      await waitFor('[data-test-command-card-idle]');
       assert.dom('[data-test-apply-state="applied"]').exists();
       assert.dom('[data-test-tripTitle]').hasText('Trip to Japan');
     });
@@ -1468,7 +1470,9 @@ module('Integration | operator-mode', function (hooks) {
         .dom('[data-test-message-idx="2"] [data-test-apply-state="applying"]')
         .exists();
 
-      await waitFor('[data-test-message-idx="2"] [data-test-patch-card-idle]');
+      await waitFor(
+        '[data-test-message-idx="2"] [data-test-command-card-idle]',
+      );
       assert.dom('[data-test-apply-state="applied"]').exists({ count: 1 });
       assert
         .dom('[data-test-message-idx="2"] [data-test-apply-state="applied"]')
@@ -1477,7 +1481,9 @@ module('Integration | operator-mode', function (hooks) {
       assert.dom('[data-test-person]').hasText('Jackie');
 
       await click('[data-test-message-idx="1"] [data-test-command-apply]');
-      await waitFor('[data-test-message-idx="1"] [data-test-patch-card-idle]');
+      await waitFor(
+        '[data-test-message-idx="1"] [data-test-command-card-idle]',
+      );
       assert.dom('[data-test-apply-state="failed"]').exists({ count: 1 });
       assert
         .dom('[data-test-message-idx="1"] [data-test-apply-state="failed"]')
@@ -1537,7 +1543,9 @@ module('Integration | operator-mode', function (hooks) {
         .dom('[data-test-message-idx="0"] [data-test-apply-state="applying"]')
         .exists();
 
-      await waitFor('[data-test-message-idx="0"] [data-test-patch-card-idle]');
+      await waitFor(
+        '[data-test-message-idx="0"] [data-test-command-card-idle]',
+      );
       assert.dom('[data-test-apply-state="applied"]').exists({ count: 1 });
       assert
         .dom('[data-test-message-idx="0"] [data-test-apply-state="applied"]')

--- a/packages/host/tests/integration/components/room-message-test.gts
+++ b/packages/host/tests/integration/components/room-message-test.gts
@@ -33,6 +33,7 @@ module('Integration | Component | RoomMessage', function (hooks) {
       currentEditor: {},
       setCurrentMonacoContainer: null,
       maybeRetryAction: null,
+      runCommand: () => {},
     };
 
     return testScenario;
@@ -48,6 +49,7 @@ module('Integration | Component | RoomMessage', function (hooks) {
         @currentEditor={{testScenario.currentEditor}}
         @setCurrentEditor={{testScenario.setCurrentMonacoContainer}}
         @retryAction={{testScenario.maybeRetryAction}}
+        @runCommand={{testScenario.runCommand}}
         data-test-message-idx='1'
       />
     </template>);

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -285,49 +285,47 @@ test.describe('Room messages', () => {
     let message = (await getRoomEvents()).pop()!;
     expect(message.content.msgtype).toStrictEqual('org.boxel.message');
     let boxelMessageData = JSON.parse(message.content.data);
-    expect(boxelMessageData.context.tools).toMatchObject([
-      {
-        type: 'function',
-        function: {
-          name: 'patchCard',
-          description:
-            'Propose a patch to an existing card to change its contents. Any attributes specified will be fully replaced, return the minimum required to make the change. If a relationship field value is removed, set the self property of the specific item to null. When editing a relationship array, display the full array in the patch code. Ensure the description explains what change you are making.',
-          parameters: {
-            type: 'object',
-            properties: {
-              description: {
-                type: 'string',
-              },
-              card_id: {
-                type: 'string',
-                const: `${testHost}/mango`,
-              },
-              attributes: {
-                type: 'object',
-                properties: {
-                  firstName: {
-                    type: 'string',
-                  },
-                  lastName: {
-                    type: 'string',
-                  },
-                  email: {
-                    type: 'string',
-                  },
-                  posts: {
-                    type: 'number',
-                  },
-                  thumbnailURL: {
-                    type: 'string',
-                  },
+    expect(boxelMessageData.context.tools[0]).toMatchObject({
+      type: 'function',
+      function: {
+        name: 'patchCard',
+        description:
+          'Propose a patch to an existing card to change its contents. Any attributes specified will be fully replaced, return the minimum required to make the change. If a relationship field value is removed, set the self property of the specific item to null. When editing a relationship array, display the full array in the patch code. Ensure the description explains what change you are making.',
+        parameters: {
+          type: 'object',
+          properties: {
+            description: {
+              type: 'string',
+            },
+            card_id: {
+              type: 'string',
+              const: `${testHost}/mango`,
+            },
+            attributes: {
+              type: 'object',
+              properties: {
+                firstName: {
+                  type: 'string',
+                },
+                lastName: {
+                  type: 'string',
+                },
+                email: {
+                  type: 'string',
+                },
+                posts: {
+                  type: 'number',
+                },
+                thumbnailURL: {
+                  type: 'string',
                 },
               },
             },
-            required: ['card_id', 'attributes', 'description'],
           },
+          required: ['card_id', 'attributes', 'description'],
         },
       },
-    ]);
+    });
   });
 
   test(`it does not include patch tool in message event for an open card that is not attached`, async ({
@@ -352,7 +350,7 @@ test.describe('Room messages', () => {
     let message = (await getRoomEvents()).pop()!;
     expect(message.content.msgtype).toStrictEqual('org.boxel.message');
     let boxelMessageData = JSON.parse(message.content.data);
-    expect(boxelMessageData.context.tools).toMatchObject([]);
+    expect(boxelMessageData.context.tools.length).toEqual(0);
   });
 
   test(`it does not include patch tool in message event when top-most card is read-only`, async ({
@@ -375,7 +373,7 @@ test.describe('Room messages', () => {
     let message = (await getRoomEvents()).pop()!;
     expect(message.content.msgtype).toStrictEqual('org.boxel.message');
     let boxelMessageData = JSON.parse(message.content.data);
-    expect(boxelMessageData.context.tools).toMatchObject([]);
+    expect(boxelMessageData.context.tools.length).toEqual(0);
   });
 
   test('can send only a card as a message', async ({ page }) => {

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -188,6 +188,7 @@ export interface CardSearch {
     instances: CardDef[];
     ready: Promise<void>;
     isLoading: boolean;
+    loaded?: Promise<void>;
   };
   getCard(
     url: URL,


### PR DESCRIPTION
**EDIT: I have converted this PR to draft because it is difficult to review** 


I consider this preliminary PR to introduce search

<img width="1486" alt="Screenshot 2024-06-10 at 18 04 23" src="https://github.com/cardstack/boxel/assets/8165111/5ba0513a-edef-4e22-ba23-fc71bccb5ae5">

<img width="1504" alt="Screenshot 2024-06-10 at 18 17 07" src="https://github.com/cardstack/boxel/assets/8165111/b6c6cdcb-781d-4055-8e12-0bcb89874b7b">

**Whats in this PR**
- search by card type shared inside the matrix message
- rendering of the command field as tho it was a standalone field. usage of runtime common api bcos command field just can't know about host without globals
- connect matrix message to create a CommandField with a result field associated with it
- trying to isolate things into a command but much work is needed here. Its just not doable. 


**Whats not in this PR**
- A refined UI for search
- search is still a field and its not a card
- The original `apply` button doesn't behave like a command. Bcos its attached to the room-message component

**Feedback for command API**
- `patchCard` relies on operatorModeStateService / cardService
- commands relies on sending matrix event via the matrix service. If I click a button say in the embedded component of a card, I would like a way to trigger a matrix event -- the integration point with matrix is essentially what we need. 


