### PR TITLE
WIP make computeds run all the time

### DIFF
--- a/packages/host/app/components/ai-assistant/panel.gts
+++ b/packages/host/app/components/ai-assistant/panel.gts
@@ -375,7 +375,9 @@ export default class AiAssistantPanel extends Component<Signature> {
   @cached
   private get aiSessionRooms() {
     let rooms: RoomField[] = [];
-    for (let resource of this.roomResources.values()) {
+    let roomResources = this.roomResources.values();
+    console.log('roomResources', roomResources);
+    for (let resource of roomResources) {
       if (!resource.room) {
         continue;
       }
@@ -385,12 +387,18 @@ export default class AiAssistantPanel extends Component<Signature> {
         // rooms don't immediately have a created date
         room.created = new Date();
       }
+      console.log('this.matrixService.userId', this.matrixService.userId);
+      console.log('room.invitedMembers', room.invitedMembers);
+      console.log('room.joinedMembers', room.joinedMembers);
       if (
         (room.invitedMembers.find((m) => aiBotUserId === m.userId) ||
           room.joinedMembers.find((m) => aiBotUserId === m.userId)) &&
         room.joinedMembers.find((m) => this.matrixService.userId === m.userId)
       ) {
+        console.log('pushing room to result set', room);
         rooms.push(room);
+      } else {
+        console.log('excluding room from result set', room);
       }
     }
     // sort in reverse chronological order of last activity

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -1697,7 +1697,6 @@ module('Integration | operator-mode', function (hooks) {
       await waitFor(`[data-test-open-ai-assistant]`);
       await click('[data-test-open-ai-assistant]');
       await waitFor(`[data-room-settled]`);
-
       assert
         .dom(`[data-test-room="${room3Id}"]`)
         .exists(

--- a/packages/host/tests/integration/realm-test.ts
+++ b/packages/host/tests/integration/realm-test.ts
@@ -206,6 +206,8 @@ module('Integration | realm', function (hooks) {
             firstName: 'Hassan',
             lastName: 'Abdel-Rahman',
             title: 'Hassan Abdel-Rahman',
+            fullName: 'Hassan Abdel-Rahman',
+            description: 'Person',
           },
           meta: {
             adoptsFrom: {
@@ -314,6 +316,8 @@ module('Integration | realm', function (hooks) {
             firstName: 'Hassan',
             lastName: 'Abdel-Rahman',
             title: 'Hassan Abdel-Rahman',
+            fullName: 'Hassan Abdel-Rahman',
+            description: 'Person',
           },
           meta: {
             adoptsFrom: {
@@ -558,6 +562,8 @@ module('Integration | realm', function (hooks) {
             firstName: 'Hassan',
             lastName: 'Abdel-Rahman',
             title: 'Hassan Abdel-Rahman',
+            fullName: 'Hassan Abdel-Rahman',
+            description: 'Person',
           },
           meta: {
             adoptsFrom: {
@@ -836,10 +842,12 @@ module('Integration | realm', function (hooks) {
           hosts: [
             {
               firstName: 'Hassan',
+              fullName: 'Hassan ',
               lastName: null,
               title: 'Hassan ',
               email: null,
               posts: null,
+              description: 'Person',
             },
           ],
           sponsors: ['Burton'],
@@ -1038,6 +1046,8 @@ module('Integration | realm', function (hooks) {
             firstName: 'Hassan',
             lastName: 'Abdel-Rahman',
             title: 'Hassan Abdel-Rahman',
+            fullName: 'Hassan Abdel-Rahman',
+            description: 'Person',
           },
           meta: {
             adoptsFrom: {
@@ -1857,7 +1867,9 @@ module('Integration | realm', function (hooks) {
             firstName: 'Mariko',
             lastName: 'Abdel-Rahman',
             title: 'Mariko Abdel-Rahman',
+            fullName: 'Mariko Abdel-Rahman',
             email: null,
+            description: 'Person',
             posts: null,
             thumbnailURL: null,
           },
@@ -2409,6 +2421,8 @@ module('Integration | realm', function (hooks) {
             firstName: 'Mariko',
             lastName: 'Abdel-Rahman',
             title: 'Mariko Abdel-Rahman',
+            fullName: 'Mariko Abdel-Rahman',
+            description: 'Person',
             email: null,
             posts: null,
             thumbnailURL: null,
@@ -2475,6 +2489,8 @@ module('Integration | realm', function (hooks) {
             firstName: 'Hassan',
             lastName: 'Abdel-Rahman',
             title: 'Hassan Abdel-Rahman',
+            description: 'Person',
+            fullName: 'Hassan Abdel-Rahman',
           },
           meta: {
             adoptsFrom: {

--- a/packages/host/tests/integration/search-index-test.gts
+++ b/packages/host/tests/integration/search-index-test.gts
@@ -529,6 +529,7 @@ module(`Integration | search-index`, function (hooks) {
         attributes: {
           title: 'Person Card',
           description: 'Catalog entry for Person card',
+          thumbnailURL: null,
           moduleHref: `${testRealmURL}person`,
           realmName: 'Unnamed Workspace',
           isField: false,
@@ -1348,8 +1349,10 @@ module(`Integration | search-index`, function (hooks) {
       entry?.searchDoc,
       {
         id: `${testRealmURL}Person/hassan`,
+        description: 'Person',
         firstName: 'Hassan',
         lastName: 'Abdel-Rahman',
+        fullName: 'Hassan Abdel-Rahman',
         email: 'hassan@cardstack.com',
         posts: 100,
         title: 'Hassan Abdel-Rahman',
@@ -1412,6 +1415,8 @@ module(`Integration | search-index`, function (hooks) {
         sponsors: null,
         title: null,
         venue: null,
+        description: null,
+        thumbnailURL: null,
       },
       description: 'Catalog entry for Booking',
       isField: false,
@@ -1419,6 +1424,7 @@ module(`Integration | search-index`, function (hooks) {
       realmName: 'Unnamed Workspace',
       ref: 'http://localhost:4202/test/booking/Booking',
       title: 'Booking',
+      thumbnailURL: null,
     });
     // we should be able to perform a structured clone of the search doc (this
     // emulates the limitations of the postMessage used to communicate between
@@ -1760,6 +1766,8 @@ module(`Integration | search-index`, function (hooks) {
         attributes: {
           title: 'PetPerson',
           description: 'Catalog entry for PetPerson',
+          thumbnailURL: null,
+
           ref: {
             module: `${testModuleRealm}pet-person`,
             name: 'PetPerson',
@@ -1859,9 +1867,13 @@ module(`Integration | search-index`, function (hooks) {
         id: `${testRealmURL}pet-person-catalog-entry`,
         title: 'PetPerson',
         description: 'Catalog entry for PetPerson',
+        thumbnailURL: null,
         ref: `${testModuleRealm}pet-person/PetPerson`,
         demo: {
           firstName: 'Hassan',
+          description: 'A person with pets',
+          thumbnailURL: null,
+          title: 'Hassan Pet Person',
           pets: [
             {
               id: `${testRealmURL}Pet/mango`,
@@ -2289,6 +2301,7 @@ module(`Integration | search-index`, function (hooks) {
             id: `${testRealmURL}Friend/mango`,
           },
           description: 'Dog owner',
+          title: 'Hassan',
         },
       });
     } else {
@@ -2458,6 +2471,7 @@ module(`Integration | search-index`, function (hooks) {
             {
               id: vanGoghID,
               firstName: 'Van Gogh',
+              title: 'Van Gogh',
               friends: [{ id: hassanID }],
             },
           ],
@@ -2570,11 +2584,13 @@ module(`Integration | search-index`, function (hooks) {
             {
               id: hassanID,
               firstName: 'Hassan',
+              title: 'Hassan',
               friends: [
                 { id: mangoID },
                 {
                   id: vanGoghID,
                   firstName: 'Van Gogh',
+                  title: 'Van Gogh',
                   friends: [{ id: hassanID }],
                 },
               ],


### PR DESCRIPTION
- [ ] make computeds run all the time by updating getter
- [ ] make relationshipMeta always return a descriptive value, and make field accessor never throw NotLoaded

Note from LM: The issue I have run into is that if the field accessor doesn't throw, there is no way for the indexer to wait for the card to be fully loaded (currently we are catching NotLoaded errors when attempting to render a card for indexing)

ef4: makes sense. we can make the relationship loading process register itself somehow. It's not unlike test waiters or fastboot deferred.