### PR TITLE
Update realm to serve executable JS from index

### DIFF
--- a/packages/host/app/components/card-prerender.gts
+++ b/packages/host/app/components/card-prerender.gts
@@ -4,7 +4,7 @@ import Component from '@glimmer/component';
 
 import { didCancel, enqueueTask, restartableTask } from 'ember-concurrency';
 
-import { type Indexer } from '@cardstack/runtime-common';
+import { type Indexer, type TextFileRef } from '@cardstack/runtime-common';
 import type { LocalPath } from '@cardstack/runtime-common/paths';
 import { readFileAsText as _readFileAsText } from '@cardstack/runtime-common/stream';
 import {
@@ -152,9 +152,7 @@ export default class CardPrerender extends Component {
     function readFileAsText(
       path: LocalPath,
       opts?: { withFallbacks?: true },
-    ): Promise<
-      { content: string; lastModified: number; path: string } | undefined
-    > {
+    ): Promise<TextFileRef | undefined> {
       return _readFileAsText(
         path,
         self.localIndexer.adapter.openFile.bind(self.localIndexer.adapter),

--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -28,6 +28,7 @@ import {
   type IndexResults,
   type SingleCardDocument,
   type Relationship,
+  type TextFileRef,
 } from '@cardstack/runtime-common';
 import { Deferred } from '@cardstack/runtime-common/deferred';
 import {
@@ -272,7 +273,7 @@ export class CurrentRun {
     }
     let { content, lastModified } = fileRef;
     if (hasExecutableExtension(url.href)) {
-      await this.indexModule(url, content);
+      await this.indexModule(url, fileRef);
     } else {
       if (!identityContext) {
         let api = await this.#loader.import<typeof CardAPI>(
@@ -306,7 +307,7 @@ export class CurrentRun {
     log.debug(`completed visiting file ${url.href} in ${Date.now() - start}ms`);
   }
 
-  private async indexModule(url: URL, source: string): Promise<void> {
+  private async indexModule(url: URL, ref: TextFileRef): Promise<void> {
     let module: Record<string, unknown>;
     try {
       module = await this.loader.import(url.href);
@@ -332,15 +333,19 @@ export class CurrentRun {
 
     if (module) {
       for (let exportName of Object.keys(module)) {
-        module[exportName];
+        module[exportName]; // we do this so that we can allow code ref identifies to be wired up in the loader
       }
+    }
+    if (ref.isShimmed) {
+      log.debug(`skipping indexing of shimmed module ${url.href}`);
+      return;
     }
     let consumes = (await this.loader.getConsumedModules(url.href)).filter(
       (u) => u !== url.href,
     );
     await this.batch.updateEntry(new URL(url.href), {
       type: 'module',
-      source,
+      source: ref.content,
       deps: new Set(
         consumes.map((d) => trimExecutableExtension(new URL(d)).href),
       ),

--- a/packages/host/app/resources/import.ts
+++ b/packages/host/app/resources/import.ts
@@ -33,12 +33,15 @@ export class ImportResource extends Resource<Args> {
     try {
       let m = await loader.import<object>(url);
       this.module = m;
-    } catch (err) {
+    } catch (err: any) {
       let errResponse = await loader.fetch(url, {
         headers: { 'content-type': 'text/javascript' },
       });
       if (!errResponse.ok) {
-        this.error = { type: 'compile', message: await errResponse.text() };
+        this.error = {
+          type: 'compile',
+          message: err.responseText ?? (await errResponse.text()),
+        };
       } else {
         this.error = {
           type: 'runtime',

--- a/packages/host/tests/helpers/adapter.ts
+++ b/packages/host/tests/helpers/adapter.ts
@@ -5,6 +5,7 @@ import {
   RealmPaths,
   baseRealm,
   createResponse,
+  hasExecutableExtension,
 } from '@cardstack/runtime-common';
 
 import {
@@ -179,7 +180,7 @@ export class TestRealmAdapter implements RealmAdapter {
         fileRefContent =
           typeof value === 'string' ? value : JSON.stringify(value);
       }
-    } else if (path.endsWith('.gts')) {
+    } else if (hasExecutableExtension(path)) {
       if (typeof value === 'string') {
         fileRefContent = value;
       } else {

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -4556,8 +4556,14 @@ module('Integration | operator-mode', function (hooks) {
         overlayButtonElements.length - 1
       ].getBoundingClientRect();
 
-    assert.strictEqual(itemRect.top, overlayButtonRect.top);
-    assert.strictEqual(itemRect.left, overlayButtonRect.left);
+    assert.strictEqual(
+      Math.round(itemRect.top),
+      Math.round(overlayButtonRect.top),
+    );
+    assert.strictEqual(
+      Math.round(itemRect.left),
+      Math.round(overlayButtonRect.left),
+    );
 
     await click(
       `[data-test-stack-card="${testRealmURL}Person/burcu"] [data-test-edit-button]`,

--- a/packages/realm-server/tests/loader-test.ts
+++ b/packages/realm-server/tests/loader-test.ts
@@ -1,4 +1,4 @@
-import { module, test, only } from 'qunit';
+import { module, test } from 'qunit';
 import { Loader, VirtualNetwork, type Realm } from '@cardstack/runtime-common';
 import { dirSync, setGracefulCleanup, DirResult } from 'tmp';
 import {

--- a/packages/realm-server/tests/loader-test.ts
+++ b/packages/realm-server/tests/loader-test.ts
@@ -1,4 +1,4 @@
-import { module, test } from 'qunit';
+import { module, test, only } from 'qunit';
 import { Loader, VirtualNetwork, type Realm } from '@cardstack/runtime-common';
 import { dirSync, setGracefulCleanup, DirResult } from 'tmp';
 import {
@@ -83,22 +83,6 @@ module('loader', function (hooks) {
       `${testRealmHref}b`,
       `${testRealmHref}c`,
     ]);
-  });
-
-  test('can determine consumed modules when an error is encountered during loading', async function (assert) {
-    let loader = virtualNetwork.createLoader();
-    try {
-      await loader.import<{ d(): string }>(`${testRealmHref}d`);
-      throw new Error(`expected error was not thrown`);
-    } catch (e: any) {
-      assert.strictEqual(e.message, 'intentional error thrown');
-      assert.deepEqual(await loader.getConsumedModules(`${testRealmHref}d`), [
-        `${testRealmHref}a`,
-        `${testRealmHref}b`,
-        `${testRealmHref}c`,
-        `${testRealmHref}e`,
-      ]);
-    }
   });
 
   test('can get consumed modules within a cycle', async function (assert) {

--- a/packages/runtime-common/error.ts
+++ b/packages/runtime-common/error.ts
@@ -85,6 +85,8 @@ export class CardError extends Error implements SerializedError {
       } catch (err) {
         /* it's ok if we can't parse it*/
       }
+      // TODO probably we should refactor this--i don't think our errors follow
+      // this shape anymore
       if (
         maybeErrorJSON &&
         typeof maybeErrorJSON === 'object' &&

--- a/packages/runtime-common/error.ts
+++ b/packages/runtime-common/error.ts
@@ -85,14 +85,8 @@ export class CardError extends Error implements SerializedError {
       } catch (err) {
         /* it's ok if we can't parse it*/
       }
-      if (
-        maybeErrorJSON &&
-        typeof maybeErrorJSON === 'object' &&
-        'errors' in maybeErrorJSON &&
-        Array.isArray(maybeErrorJSON.errors) &&
-        maybeErrorJSON.errors.length > 0
-      ) {
-        return CardError.fromSerializableError(maybeErrorJSON.errors[0]);
+      if (maybeErrorJSON && typeof maybeErrorJSON === 'object') {
+        return CardError.fromSerializableError(maybeErrorJSON);
       }
       return new CardError(
         `unable to fetch ${url}${!maybeErrorJSON ? ': ' + text : ''}`,

--- a/packages/runtime-common/error.ts
+++ b/packages/runtime-common/error.ts
@@ -85,8 +85,14 @@ export class CardError extends Error implements SerializedError {
       } catch (err) {
         /* it's ok if we can't parse it*/
       }
-      if (maybeErrorJSON && typeof maybeErrorJSON === 'object') {
-        return CardError.fromSerializableError(maybeErrorJSON);
+      if (
+        maybeErrorJSON &&
+        typeof maybeErrorJSON === 'object' &&
+        'errors' in maybeErrorJSON &&
+        Array.isArray(maybeErrorJSON.errors) &&
+        maybeErrorJSON.errors.length > 0
+      ) {
+        return CardError.fromSerializableError(maybeErrorJSON.errors[0]);
       }
       return new CardError(
         `unable to fetch ${url}${!maybeErrorJSON ? ': ' + text : ''}`,

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -902,7 +902,7 @@ export class Realm {
       ) {
         if (fileRef[Symbol.for('shimmed-module')]) {
           // this response is ultimately thrown away and only the symbol value
-          // is preserved so what is inside this response is not important
+          // is preserved. so what is inside this response is not important
           let response = createResponse({ requestContext });
           (response as any)[Symbol.for('shimmed-module')] =
             fileRef[Symbol.for('shimmed-module')];

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -39,6 +39,7 @@ import {
   getFileWithFallbacks,
   writeToStream,
   waitForClose,
+  type TextFileRef,
 } from './stream';
 import { transpileJS } from './transpile';
 import {
@@ -1570,7 +1571,7 @@ export class Realm {
   private async readFileAsText(
     path: LocalPath,
     opts: { withFallbacks?: true } = {},
-  ): Promise<{ content: string; lastModified: number } | undefined> {
+  ): Promise<TextFileRef | undefined> {
     return readFileAsText(
       path,
       this.#adapter.openFile.bind(this.#adapter),

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -856,14 +856,14 @@ export class Realm {
     let localPath = this.paths.local(url);
 
     if (!localPath.startsWith(assetsDir)) {
-      try {
-        let useWorkInProgressIndex = Boolean(
-          request.headers.get('X-Boxel-Use-WIP-Index'),
-        );
-        let module = await this.#searchIndex.module(url, {
-          useWorkInProgressIndex,
-        });
-        if (module?.type === 'module') {
+      let useWorkInProgressIndex = Boolean(
+        request.headers.get('X-Boxel-Use-WIP-Index'),
+      );
+      let module = await this.#searchIndex.module(url, {
+        useWorkInProgressIndex,
+      });
+      if (module?.type === 'module') {
+        try {
           return createResponse({
             body: module.executableCode,
             init: {
@@ -872,8 +872,12 @@ export class Realm {
             },
             requestContext,
           });
+        } finally {
+          this.#logRequestPerformance(request, start, 'cache hit');
         }
-        if (module?.type === 'error') {
+      }
+      if (module?.type === 'error') {
+        try {
           // using "Not Acceptable" here because no text/javascript representation
           // can be made and we're sending text/html error page instead
           return createResponse({
@@ -884,9 +888,9 @@ export class Realm {
             },
             requestContext,
           });
+        } finally {
+          this.#logRequestPerformance(request, start, 'cache hit');
         }
-      } finally {
-        this.#logRequestPerformance(request, start, 'cache hit');
       }
     }
 

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -12,14 +12,12 @@ import {
 } from './error';
 import { v4 as uuidV4 } from 'uuid';
 import { formatRFC7231 } from 'date-fns';
-import { md5 } from 'super-fast-md5';
 import {
   isCardResource,
   executableExtensions,
   hasExecutableExtension,
   isNode,
   isSingleCardDocument,
-  baseRealm,
   assetsDir,
   logger,
   type CodeRef,
@@ -33,7 +31,6 @@ import {
   addAuthorizationHeader,
 } from './index';
 import merge from 'lodash/merge';
-import flatMap from 'lodash/flatMap';
 import mergeWith from 'lodash/mergeWith';
 import cloneDeep from 'lodash/cloneDeep';
 import {
@@ -217,8 +214,6 @@ export class Realm {
   #router: Router;
   #deferStartup: boolean;
   #useTestingDomain = false;
-  // TODO remove this after we serve transpiled js from index
-  #transpileCache = new Map<string, string>();
   #log = logger('realm');
   #perfLog = logger('perf');
   #startTime = Date.now();
@@ -538,40 +533,11 @@ export class Realm {
 
   async #startup() {
     await Promise.resolve();
-    // TODO remove this after we serve transpiled js from index
-    await this.#warmUpCache();
     await this.#searchIndex.run(this.#onIndexer);
     this.sendServerEvent({ type: 'index', data: { type: 'full' } });
     this.#perfLog.debug(
       `realm server startup in ${Date.now() - this.#startTime}ms`,
     );
-  }
-
-  // Take advantage of the fact that the base realm modules are static (for now)
-  // and cache the transpiled js for all the base realm modules so that all
-  // consuming realms can benefit from this work
-  // TODO remove this after we serve transpiled js from index
-  async #warmUpCache() {
-    if (this.url !== baseRealm.url) {
-      return;
-    }
-
-    let entries = await this.recursiveDirectoryEntries(new URL(this.url));
-    let modules = flatMap(entries, (e) =>
-      e.kind === 'file' && hasExecutableExtension(e.path) ? [e.path] : [],
-    );
-
-    for (let mod of modules) {
-      let handle = await this.#adapter.openFile(mod);
-      if (!handle) {
-        this.#log.error(
-          `cannot open file ${mod} when warming up transpilation cache`,
-        );
-        continue;
-      }
-
-      this.transpileJS(await fileContentToText(handle), handle.path);
-    }
   }
 
   get ready(): Promise<void> {
@@ -883,47 +849,75 @@ export class Realm {
     return undefined;
   }
 
-  // TODO we could really improve performance if this utilized the index instead
-  // of directly hitting the filesystem--especially the TS transpilation
-  // involved in making JS.
   async fallbackHandle(request: Request, requestContext: RequestContext) {
     let start = Date.now();
     let url = new URL(request.url);
     let localPath = this.paths.local(url);
 
     try {
+      if (!localPath.startsWith(assetsDir)) {
+        let useWorkInProgressIndex = Boolean(
+          request.headers.get('X-Boxel-Use-WIP-Index'),
+        );
+        let module = await this.#searchIndex.module(url, {
+          useWorkInProgressIndex,
+        });
+        if (module?.type === 'module') {
+          return createResponse({
+            body: module.executableCode,
+            init: {
+              status: 200,
+              headers: { 'content-type': 'text/javascript' },
+            },
+            requestContext,
+          });
+        }
+        if (module?.type === 'error') {
+          // using "Not Acceptable" here because no text/javascript representation
+          // can be made and we're sending text/html error page instead
+          return createResponse({
+            body: JSON.stringify(module.error, null, 2),
+            init: {
+              status: 406,
+              headers: { 'content-type': 'text/html' },
+            },
+            requestContext,
+          });
+        }
+      }
+
       let maybeFileRef = await this.getFileWithFallbacks(
         localPath,
         executableExtensions,
       );
-
       if (!maybeFileRef) {
         return notFound(request, requestContext, `${request.url} not found`);
       }
 
       let fileRef = maybeFileRef;
-
       if (
-        executableExtensions.some((extension) =>
-          fileRef.path.endsWith(extension),
-        ) &&
+        hasExecutableExtension(fileRef.path) &&
         !localPath.startsWith(assetsDir)
       ) {
-        let response = this.makeJS(
+        if (fileRef[Symbol.for('shimmed-module')]) {
+          // this response is ultimately thrown away and only the symbol value
+          // is preserved so what is inside this response is not important
+          let response = createResponse({ requestContext });
+          (response as any)[Symbol.for('shimmed-module')] =
+            fileRef[Symbol.for('shimmed-module')];
+          return response;
+        }
+        // fallback to the file system only after trying the index. during the
+        // initial index we need to use the API to run the indexer whose modules
+        // would otherwise live in index (this conundrum would go away if the
+        // API could be statically loaded and not come from the base realm.)
+        return this.makeJS(
           await fileContentToText(fileRef),
           fileRef.path,
           requestContext,
         );
-
-        if (fileRef[Symbol.for('shimmed-module')]) {
-          (response as any)[Symbol.for('shimmed-module')] =
-            fileRef[Symbol.for('shimmed-module')];
-        }
-
-        return response;
-      } else {
-        return await this.serveLocalFile(fileRef, requestContext);
       }
+      return await this.serveLocalFile(fileRef, requestContext);
     } finally {
       this.#logRequestPerformance(request, start);
     }
@@ -1190,40 +1184,16 @@ export class Realm {
     });
   }
 
-  private transpileJS(content: string, debugFilename: string): string {
-    let contentIsAllWhitespace = content.match(/^\s*$/);
-
-    if (contentIsAllWhitespace) {
-      throw new Error('File is empty');
-    }
-
-    let hash = md5(content);
-    let cached = this.#transpileCache.get(hash);
-    if (cached) {
-      return cached;
-    }
-    let src = transpileJS(content, debugFilename);
-    if (!src) {
-      throw new Error('bug: should never get here');
-    }
-
-    // This assumes the base realm is static. We take advantage of the static
-    // nature of the base realm such that we can cache the transpiled JS, which
-    // is the slowest part of module loading (and base realm modules are
-    // imported a lot by all realms)
-    if (this.url === baseRealm.url) {
-      this.#transpileCache.set(hash, src);
-    }
-    return src;
-  }
-
   private makeJS(
     content: string,
     debugFilename: string,
     requestContext: RequestContext,
   ): Response {
     try {
-      content = this.transpileJS(content, debugFilename);
+      if (content.match(/^\s*$/)) {
+        throw new Error('File is empty');
+      }
+      content = transpileJS(content, debugFilename);
     } catch (err: any) {
       // using "Not Acceptable" here because no text/javascript representation
       // can be made and we're sending text/html error page instead
@@ -1250,7 +1220,7 @@ export class Realm {
   // explicit file extensions in your source code
   private async getFileWithFallbacks(
     path: LocalPath,
-    fallbackExtensions: string[],
+    fallbackExtensions: string[] = [],
   ): Promise<FileRef | undefined> {
     return getFileWithFallbacks(
       path,
@@ -1543,24 +1513,6 @@ export class Realm {
       entries.push(entry);
     }
     return entries;
-  }
-
-  private async recursiveDirectoryEntries(
-    url: URL,
-  ): Promise<{ name: string; kind: Kind; path: LocalPath }[]> {
-    let entries = await this.directoryEntries(url);
-    if (!entries) {
-      return [];
-    }
-    let nestedEntries: { name: string; kind: Kind; path: LocalPath }[] = [];
-    for (let dirEntry of entries.filter((e) => e.kind === 'directory')) {
-      nestedEntries.push(
-        ...(await this.recursiveDirectoryEntries(
-          new URL(`${url.href}${dirEntry.name}`),
-        )),
-      );
-    }
-    return [...entries, ...nestedEntries];
   }
 
   private async getDirectoryListing(

--- a/packages/runtime-common/search-index.ts
+++ b/packages/runtime-common/search-index.ts
@@ -14,6 +14,7 @@ import {
   type FromScratchResult,
   type IncrementalArgs,
   type IncrementalResult,
+  type IndexedModuleOrError,
 } from '.';
 import { Realm } from './realm';
 import { RealmPaths } from './paths';
@@ -198,6 +199,10 @@ export class SearchIndex {
     return isIgnored(this.realmURL, this.ignoreMap, url);
   }
 
+  // TODO we should probably return the IndexedInstance type here so that we
+  // have access to both the serialized card instance and the source for the
+  // instance
+  // TODO rename to "instance" for consistency
   async card(url: URL, opts?: Options): Promise<SearchResult | undefined> {
     let doc: SingleCardDocument | undefined;
     let maybeCard = await this.#indexer.getCard(url, opts);
@@ -229,6 +234,13 @@ export class SearchIndex {
       }
     }
     return { type: 'doc', doc };
+  }
+
+  async module(
+    url: URL,
+    opts?: Options,
+  ): Promise<IndexedModuleOrError | undefined> {
+    return await this.#indexer.getModule(url, opts);
   }
 
   // this is meant for tests only

--- a/packages/runtime-common/stream.ts
+++ b/packages/runtime-common/stream.ts
@@ -51,13 +51,18 @@ export async function fileContentToText({ content }: FileRef): Promise<string> {
   }
 }
 
+export interface TextFileRef {
+  content: string;
+  lastModified: number;
+  path: string;
+  isShimmed?: true;
+}
+
 export async function readFileAsText(
   path: LocalPath,
   openFile: (path: string) => Promise<FileRef | undefined>,
   opts: { withFallbacks?: true } = {},
-): Promise<
-  { content: string; lastModified: number; path: string } | undefined
-> {
+): Promise<TextFileRef | undefined> {
   let ref: FileRef | undefined;
   if (opts.withFallbacks) {
     ref = await getFileWithFallbacks(path, openFile, executableExtensions);
@@ -71,6 +76,7 @@ export async function readFileAsText(
     content: await fileContentToText(ref),
     lastModified: ref.lastModified,
     path: ref.path,
+    ...(Symbol.for('shimmed-module') in ref ? { isShimmed: true } : {}),
   };
 }
 // we bother with this because typescript is picky about allowing you to use

--- a/packages/runtime-common/worker.ts
+++ b/packages/runtime-common/worker.ts
@@ -8,6 +8,7 @@ import {
   type Queue,
   type LocalPath,
   type RealmAdapter,
+  type TextFileRef,
 } from '.';
 import { Kind } from './realm';
 
@@ -27,9 +28,7 @@ export interface Reader {
   readFileAsText: (
     path: LocalPath,
     opts?: { withFallbacks?: true },
-  ) => Promise<
-    { content: string; lastModified: number; path: string } | undefined
-  >;
+  ) => Promise<TextFileRef | undefined>;
   readdir: (
     path: string,
   ) => AsyncGenerator<{ name: string; path: string; kind: Kind }, void>;
@@ -173,9 +172,7 @@ export class Worker {
   private async readFileAsText(
     path: LocalPath,
     opts: { withFallbacks?: true } = {},
-  ): Promise<
-    { content: string; lastModified: number; path: string } | undefined
-  > {
+  ): Promise<TextFileRef | undefined> {
     return readFileAsText(
       path,
       this.#realmAdapter.openFile.bind(this.#realmAdapter),


### PR DESCRIPTION
Sadly I'm not seeing much over all performance improvement in the host as a result of this. I'm definitely seeing server request times drop by about 90% for module code (from about 1.5 seconds to 120ms). but it looks like that is not the slowest part of card deserialization of the cards grid. Probably the browser's parallelization of code fetching is able to hide the poor server performance for fetching the transpiled code. That leads me to think that the slowest part of deserialization of the cards grid is the evaluation of all the different modules. 