### PR TITLE
host: Update operator mode assertion for subsets

### DIFF
--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -1261,12 +1261,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await waitFor(`[data-test-boxel-selector-item-text="${elementName}"]`);
     await click(`[data-test-boxel-selector-item-text="${elementName}"]`);
     assert.operatorModeParametersMatch(currentURL(), {
-      codePath: `${testRealmURL}imports.gts`,
       codeSelection: elementName,
-      fileView: 'inspector',
-      openDirs: {},
-      stacks: [[]],
-      submode: Submodes.Code,
     });
     let selected = 'AncestorCard2 card';
     await waitFor(`[data-test-clickable-definition-container]`);
@@ -1281,12 +1276,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await waitFor(`[data-test-boxel-selector-item-text="${elementName}"]`);
     await click(`[data-test-boxel-selector-item-text="${elementName}"]`);
     assert.operatorModeParametersMatch(currentURL(), {
-      codePath: `${testRealmURL}imports.gts`,
       codeSelection: elementName,
-      fileView: 'inspector',
-      openDirs: {},
-      stacks: [[]],
-      submode: Submodes.Code,
     });
     selected = 'default (DefaultAncestorCard) card';
     await waitFor(`[data-test-clickable-definition-container]`);
@@ -1301,12 +1291,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await waitFor(`[data-test-boxel-selector-item-text="${elementName}"]`);
     await click(`[data-test-boxel-selector-item-text="${elementName}"]`);
     assert.operatorModeParametersMatch(currentURL(), {
-      codePath: `${testRealmURL}imports.gts`,
       codeSelection: elementName,
-      fileView: 'inspector',
-      openDirs: {},
-      stacks: [[]],
-      submode: Submodes.Code,
     });
     selected = 'RenamedAncestorCard (AncestorCard) card';
     await waitFor(`[data-test-clickable-definition-container]`);
@@ -1321,12 +1306,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await waitFor(`[data-test-boxel-selector-item-text="${elementName}"]`);
     await click(`[data-test-boxel-selector-item-text="${elementName}"]`);
     assert.operatorModeParametersMatch(currentURL(), {
-      codePath: `${testRealmURL}imports.gts`,
       codeSelection: elementName,
-      fileView: 'inspector',
-      openDirs: {},
-      stacks: [[]],
-      submode: Submodes.Code,
     });
     selected = 'AncestorCard3 card';
     await click(`[data-test-clickable-definition-container]`);
@@ -1341,12 +1321,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await waitFor(`[data-test-boxel-selector-item-text="${elementName}"]`);
     await click(`[data-test-boxel-selector-item-text="${elementName}"]`);
     assert.operatorModeParametersMatch(currentURL(), {
-      codePath: `${testRealmURL}imports.gts`,
       codeSelection: elementName,
-      fileView: 'inspector',
-      openDirs: {},
-      stacks: [[]],
-      submode: Submodes.Code,
     });
     selected = 'ChildCard2 card';
     await waitFor(`[data-test-clickable-definition-container]`);
@@ -1362,12 +1337,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await waitFor(`[data-test-boxel-selector-item-text="${elementName}"]`);
     await click(`[data-test-boxel-selector-item-text="${elementName}"]`);
     assert.operatorModeParametersMatch(currentURL(), {
-      codePath: `${testRealmURL}imports.gts`,
       codeSelection: elementName,
-      fileView: 'inspector',
-      openDirs: {},
-      stacks: [[]],
-      submode: Submodes.Code,
     });
     selected = 'AncestorField1 field';
     await click(`[data-test-clickable-definition-container]`);
@@ -1396,12 +1366,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
       `[data-test-card-schema="${elementName}"] [data-test-card-schema-navigational-button]`,
     );
     assert.operatorModeParametersMatch(currentURL(), {
-      codePath: `${testRealmURL}exports.gts`,
       codeSelection: elementName,
-      fileView: 'inspector',
-      openDirs: {},
-      stacks: [],
-      submode: Submodes.Code,
     });
 
     await waitFor('[data-test-boxel-selector-item-selected]');
@@ -1420,12 +1385,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
       `[data-test-card-schema="ChildCard1"] [data-test-field-name="field1"] [data-test-card-display-name="${elementName}"]`,
     );
     assert.operatorModeParametersMatch(currentURL(), {
-      codePath: `${testRealmURL}exports.gts`,
       codeSelection: elementName,
-      fileView: 'inspector',
-      openDirs: {},
-      stacks: [],
-      submode: Submodes.Code,
     });
     await waitFor('[data-test-boxel-selector-item-selected]');
     assert
@@ -1445,12 +1405,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     );
 
     assert.operatorModeParametersMatch(currentURL(), {
-      codePath: `${testRealmURL}exports.gts`,
       codeSelection: elementName,
-      fileView: 'inspector',
-      openDirs: {},
-      stacks: [],
-      submode: Submodes.Code,
     });
     await waitFor('[data-test-boxel-selector-item-selected]');
     assert
@@ -1468,12 +1423,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
       `[data-test-card-schema="ChildCard1"] [data-test-field-name="field3"] [data-test-card-display-name="${elementName}"]`,
     );
     assert.operatorModeParametersMatch(currentURL(), {
-      codePath: `${testRealmURL}imports.gts`,
       codeSelection: elementName,
-      fileView: 'inspector',
-      openDirs: {},
-      stacks: [],
-      submode: Submodes.Code,
     });
     await waitFor('[data-test-boxel-selector-item-selected]');
     assert
@@ -1493,12 +1443,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     );
 
     assert.operatorModeParametersMatch(currentURL(), {
-      codePath: `${testRealmURL}exports.gts`,
       codeSelection: elementName,
-      fileView: 'inspector',
-      openDirs: {},
-      stacks: [],
-      submode: Submodes.Code,
     });
     await waitFor('[data-test-boxel-selector-item-selected]');
     assert

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -25,7 +25,6 @@ import { Realm } from '@cardstack/runtime-common/realm';
 
 import { AuthenticationErrorMessages } from '@cardstack/runtime-common/router';
 
-import { Submodes } from '@cardstack/host/components/submode-switcher';
 import { claimsFromRawToken } from '@cardstack/host/resources/realm-session';
 import type LoaderService from '@cardstack/host/services/loader-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
@@ -565,7 +564,6 @@ module('Acceptance | interact submode tests', function (hooks) {
       // Remove mango (the dog) from the stack
       await click('[data-test-stack-card-index="1"] [data-test-close-button]');
 
-      // The stack should be updated in the URL
       assert.operatorModeParametersMatch(currentURL(), {
         stacks: [
           [
@@ -575,9 +573,6 @@ module('Acceptance | interact submode tests', function (hooks) {
             },
           ],
         ],
-        submode: Submodes.Interact,
-        fileView: 'inspector',
-        openDirs: {},
       });
 
       await waitFor('[data-test-operator-mode-stack] [data-test-pet="Mango"]');
@@ -1405,7 +1400,6 @@ module('Acceptance | interact submode tests', function (hooks) {
       assert.dom('[data-test-operator-mode-stack="1"]').doesNotExist();
       assert.dom('[data-test-operator-mode-stack="0"]').includesText('Fadhlan');
 
-      // The stack should be updated in the URL
       assert.operatorModeParametersMatch(currentURL(), {
         stacks: [
           [
@@ -1415,9 +1409,6 @@ module('Acceptance | interact submode tests', function (hooks) {
             },
           ],
         ],
-        submode: Submodes.Interact,
-        fileView: 'inspector',
-        openDirs: {},
       });
 
       // Close the last card in the last stack that is left - should get the empty state

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -571,18 +571,7 @@ module('Acceptance | operator mode tests', function (hooks) {
       '[data-test-address-with-no-embedded] [data-test-open-code-submode]',
     );
     assert.operatorModeParametersMatch(currentURL(), {
-      stacks: [
-        [
-          {
-            id: `${testRealmURL}Person/fadhlan`,
-            format: 'isolated',
-          },
-        ],
-      ],
-      submode: Submodes.Code,
       codePath: `${testRealmURL}address-with-no-embedded-template.gts`,
-      fileView: 'inspector',
-      openDirs: {},
     });
 
     // Toggle back to interactive mode
@@ -597,18 +586,8 @@ module('Acceptance | operator mode tests', function (hooks) {
       '[data-test-country-with-no-embedded] [data-test-open-code-submode]',
     );
     assert.operatorModeParametersMatch(currentURL(), {
-      stacks: [
-        [
-          {
-            id: `${testRealmURL}Person/fadhlan`,
-            format: 'isolated',
-          },
-        ],
-      ],
       submode: Submodes.Code,
       codePath: `${testRealmURL}country-with-no-embedded-template.gts`,
-      fileView: 'inspector',
-      openDirs: {},
     });
   });
 
@@ -642,20 +621,6 @@ module('Acceptance | operator mode tests', function (hooks) {
 
       // Submode is reflected in the URL
       assert.operatorModeParametersMatch(currentURL(), {
-        stacks: [
-          [
-            {
-              id: `${testRealmURL}Person/fadhlan`,
-              format: 'isolated',
-            },
-          ],
-          [
-            {
-              id: `${testRealmURL}Pet/mango`,
-              format: 'isolated',
-            },
-          ],
-        ],
         submode: Submodes.Code,
         codePath: `${testRealmURL}Pet/mango.json`,
         fileView: 'inspector',
@@ -673,23 +638,7 @@ module('Acceptance | operator mode tests', function (hooks) {
 
       // Submode is reflected in the URL
       assert.operatorModeParametersMatch(currentURL(), {
-        stacks: [
-          [
-            {
-              id: `${testRealmURL}Person/fadhlan`,
-              format: 'isolated',
-            },
-          ],
-          [
-            {
-              id: `${testRealmURL}Pet/mango`,
-              format: 'isolated',
-            },
-          ],
-        ],
         submode: Submodes.Interact,
-        fileView: 'inspector',
-        openDirs: { [testRealmURL]: ['Pet/'] },
       });
     });
   });


### PR DESCRIPTION
This lets `assert.operatorModeParametersMatch` only compare the relevant subset of operator mode query parameters, which makes for clearer assertions after the irrelevant parameters have been removed.

This is something I originally wanted in #713. I was going to include it in #1339 but that’s no longer going to store sidebar state in a query parameter so it doesn’t fit.