### PR TITLE
Fix displays recently accessed card test

### DIFF
--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -3257,8 +3257,7 @@ module('Integration | operator-mode', function (hooks) {
     assert.dom(`[data-test-create-new-card-button]`).isNotVisible();
   });
 
-  // Flaky test: CS-6842
-  skip(`displays recently accessed card`, async function (assert) {
+  test(`displays recently accessed card`, async function (assert) {
     await setCardInOperatorModeState(`${testRealmURL}grid`);
     await renderComponent(
       class TestDriver extends GlimmerComponent {
@@ -3293,7 +3292,7 @@ module('Integration | operator-mode', function (hooks) {
 
     await waitFor(`[data-test-cards-grid-item]`);
     await click(`[data-test-cards-grid-item="${testRealmURL}Person/burcu"]`);
-    assert.dom(`[data-test-stack-card-index="1"]`).exists();
+    await waitFor(`[data-test-stack-card-index="1"]`);
 
     await focus(`[data-test-search-field]`);
     assert.dom(`[data-test-search-sheet-recent-card]`).exists({ count: 2 });

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -16,7 +16,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import window from 'ember-window-mock';
 import { setupWindowMock } from 'ember-window-mock/test-support';
 import { EventStatus } from 'matrix-js-sdk';
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 
 import { FieldContainer } from '@cardstack/boxel-ui/components';
 


### PR DESCRIPTION
This PR is to fix flaky test which is the "displays recently accessed card" test. I'm unable to reproduce the error locally but from the error message in CI, I think we can fix it using `waitFor`.

```
Integration | operator-mode: displays recently accessed card
    ---
        actual: >
            Element [data-test-stack-card-index="1"] does not exist
        expected: >
            Element [data-test-stack-card-index="1"] exists
        stack: >
                at DOMAssertions.exists (http://localhost:7357/assets/chunk.bfccc53674c3d8abe6b8.js:34362:10)
                at DOMAssertions.exists (http://localhost:7357/assets/chunk.bfccc53674c3d8abe6b8.js:34697:12)
                at Object.<anonymous> (http://localhost:7357/assets/chunk.bfccc53674c3d8abe6b8.js:25098:2265)
        message: >
            Element [data-test-stack-card-index="1"] exists
        negative: >
            false
        browser log: |
            {"type":"info","text":"sending updates to 0 clients"}
            {"type":"warn","text":"Expected panelRatio and newContainerSize to be defined"}
 ```