### PR TITLE
Fix "Clicking search panel (without left and right buttons activated) replace all cards in rightmost stack" test

### DIFF
--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -1488,8 +1488,9 @@ module('Acceptance | interact submode tests', function (hooks) {
 
       // Click on a recent search
       await click(`[data-test-search-result="${testRealmURL}Person/fadhlan"]`);
-      // There is some additional thing we are waiting on here, probably the
-      // card to load in the card resource, but I'm not too sure so using waitUntil instead
+
+      // We have to wait untill there is only one stack item in rightmost stack,
+      // because that's the expected behaviour when we open a card from card search.
       await waitUntil(
         () =>
           document.querySelectorAll(

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -11,7 +11,7 @@ import { setupApplicationTest } from 'ember-qunit';
 
 import window from 'ember-window-mock';
 import { setupWindowMock } from 'ember-window-mock/test-support';
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 import stringify from 'safe-stable-stringify';
 
 import { FieldContainer, GridContainer } from '@cardstack/boxel-ui/components';
@@ -1451,8 +1451,7 @@ module('Acceptance | interact submode tests', function (hooks) {
       assert.dom('[data-test-operator-mode-stack]').exists({ count: 2 });
     });
 
-    // skipping FLaky test: CS-6845
-    skip('Clicking search panel (without left and right buttons activated) replaces all cards in the rightmost stack', async function (assert) {
+    test('Clicking search panel (without left and right buttons activated) replaces all cards in the rightmost stack', async function (assert) {
       // creates a recent search
       window.localStorage.setItem(
         'recent-cards',
@@ -1491,12 +1490,11 @@ module('Acceptance | interact submode tests', function (hooks) {
       await click(`[data-test-search-result="${testRealmURL}Person/fadhlan"]`);
       // There is some additional thing we are waiting on here, probably the
       // card to load in the card resource, but I'm not too sure so using waitUntil instead
-      await waitUntil(() =>
-        document
-          .querySelector(
-            '[data-test-operator-mode-stack="1"] [data-test-stack-card-index="0"]',
-          )
-          ?.textContent?.includes('Fadhlan'),
+      await waitUntil(
+        () =>
+          document.querySelectorAll(
+            '[data-test-operator-mode-stack="1"] [data-test-stack-card-index]',
+          )?.length === 1,
       );
 
       assert.dom('[data-test-search-sheet]').doesNotHaveClass('prompt'); // Search closed


### PR DESCRIPTION
This PR is to fix flaky test with this error.

```
This test fails occasionally in CI but passes reliable in my local dev

not ok 145 Chrome 124.0 - [1813 ms] - Acceptance | interact submode tests > 2 stacks: Clicking search panel (without left and right buttons activated) replaces all cards in the rightmost stack
    ---
        actual: >
            Element [data-test-operator-mode-stack="1"] [data-test-stack-card-index="1"] exists once
        expected: >
            Element [data-test-operator-mode-stack="1"] [data-test-stack-card-index="1"] does not exist
        stack: >
                at DOMAssertions.exists (http://localhost:7357/assets/chunk.65a38cc37e071aac7e6e.js:34380:10)
                at DOMAssertions.doesNotExist (http://localhost:7357/assets/chunk.65a38cc37e071aac7e6e.js:34716:12)
                at Object.<anonymous> (http://localhost:7357/assets/chunk.65a38cc37e071aac7e6e.js:14879:90)
        message: >
            Element [data-test-operator-mode-stack="1"] [data-test-stack-card-index="1"] does not exist
        negative: >
            false
        browser log: |
            {"type":"info","text":"sending updates to 0 clients"}
            {"type":"info","text":"sending updates to 0 clients"}
            {"type":"warn","text":"Expected panelRatio and newContainerSize to be defined"}
            {"type":"error","text":"[object Object]"}
 ```
 
 I updated the condition in `waitUntil` function, instead of checking the text, I updated it to check the total of stack item in rightmost stack.