### PR TITLE
Add types for chess.js

### DIFF
--- a/packages/drafts-realm/Chess/c09f9bb3-df3f-4337-a6bd-cc4c96a5caa3.json
+++ b/packages/drafts-realm/Chess/c09f9bb3-df3f-4337-a6bd-cc4c96a5caa3.json
@@ -9,7 +9,7 @@
     },
     "meta": {
       "adoptsFrom": {
-        "module": "../chess",
+        "module": "../chess-game",
         "name": "Chess"
       }
     }

--- a/packages/drafts-realm/chess-game.gts
+++ b/packages/drafts-realm/chess-game.gts
@@ -21,8 +21,13 @@ import {
 
 //@ts-ignore
 import { action } from '@ember/object';
+
 //@ts-ignore
-import { Chess as ChessJS } from 'https://cdn.jsdelivr.net/npm/chess.js/+esm';
+import { Chess as _ChessJS } from 'https://cdn.jsdelivr.net/npm/chess.js/+esm';
+import type { Chess as _ChessJSType } from 'chess.js';
+type ChessJS = _ChessJSType;
+const ChessJS: typeof _ChessJSType = _ChessJS;
+
 //@ts-ignore
 import {
   MARKER_TYPE,
@@ -124,6 +129,7 @@ class ChessboardModifier extends Modifier<ChessboardModifierSignature> {
         }
         return result;
       }
+      return undefined;
     }
     if (this.chessboard === undefined) {
       this.chessboard = new Chessboard(element, {
@@ -157,9 +163,9 @@ interface ChessJSResourceArgs {
 }
 
 class ChessJSResource extends Resource<ChessJSResourceArgs> {
-  game: ChessJS;
-  snapshot: ChessJS;
-  private future: any[] = [];
+  game!: ChessJS;
+  snapshot!: ChessJS;
+  private future: string[] = [];
   @tracked snapshotPgn: string | undefined;
 
   modify(_positional: never[], named: ChessJSResourceArgs['named']) {
@@ -171,7 +177,7 @@ class ChessJSResource extends Resource<ChessJSResourceArgs> {
 
     if (this.snapshotPgn) {
       this.snapshot.loadPgn(this.snapshotPgn);
-    } else {
+    } else if (named.pgn) {
       this.snapshot.loadPgn(named.pgn);
     }
   }
@@ -343,10 +349,7 @@ class ChessGameComponent extends Component<ChessGameComponentSignature> {
   }
 
   get notAtMostCurrentMove() {
-    return (
-      !this.args.analysis &&
-      !(this.pgnDisplay === this.game.pgn({ strict: true }))
-    );
+    return !this.args.analysis && !(this.pgnDisplay === this.game.pgn());
   }
 
   //Game state
@@ -354,7 +357,7 @@ class ChessGameComponent extends Component<ChessGameComponentSignature> {
     return this.chessJSResource.game;
   }
   get pgnDisplay() {
-    return this.snapshot.pgn({ strict: true });
+    return this.snapshot.pgn();
   }
 
   get isGameOver() {
@@ -362,7 +365,7 @@ class ChessGameComponent extends Component<ChessGameComponentSignature> {
   }
 
   get moves() {
-    return this.game.history({ verbose: true }).map((move: any) => move.san);
+    return this.game.history({ verbose: true }).map((move) => move.san);
   }
 
   @action
@@ -379,7 +382,7 @@ class ChessGameComponent extends Component<ChessGameComponentSignature> {
     return this.snapshot.history({ verbose: true });
   }
   get snapshotMoves() {
-    return this.snapshotHistory.map((move: any) => move.san);
+    return this.snapshotHistory.map((move) => move.san);
   }
 
   get fen() {

--- a/packages/drafts-realm/package.json
+++ b/packages/drafts-realm/package.json
@@ -7,6 +7,7 @@
     "@cardstack/boxel-ui": "workspace:*",
     "@cardstack/runtime-common": "workspace:*",
     "@types/lodash": "^4.14.182",
+    "chess.js": "1.0.0-beta.8",
     "ember-modifier": "^4.1.0",
     "tracked-built-ins": "^3.3.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 overrides:
   '@types/eslint': 8.4.1
   '@embroider/util': 1.12.0
@@ -1006,6 +1010,9 @@ importers:
       '@types/lodash':
         specifier: ^4.14.182
         version: 4.14.182
+      chess.js:
+        specifier: 1.0.0-beta.8
+        version: 1.0.0-beta.8
       ember-modifier:
         specifier: ^4.1.0
         version: 4.1.0(ember-source@5.4.1)
@@ -4484,7 +4491,7 @@ packages:
       '@types/ember__object': ^4.0.4
       '@types/ember__routing': ^4.0.11
       ember-cli-htmlbars: ^6.0.1
-      ember-modifier: ^3.2.7 || ^4.0.0
+      ember-modifier: ^4.1.0
     peerDependenciesMeta:
       '@types/ember__array':
         optional: true
@@ -5144,7 +5151,7 @@ packages:
   /@prettier/sync@0.2.1(prettier@3.1.0-dev):
     resolution: {integrity: sha512-7ls1R6//+GPYD9vof1XaL5psViv83CwpdwlS8oUkWldYgbPhzZ3WgxIQMWqGyBmWPmoBfQg8C7jj7KI/ZuDHhQ==}
     peerDependencies:
-      prettier: ^3.0.0
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     dependencies:
       prettier: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
     dev: true
@@ -9359,6 +9366,10 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
+  /chess.js@1.0.0-beta.8:
+    resolution: {integrity: sha512-UngzUMXmexcQaQA/UEJuJj5vatEy34awYMD5YMOp/FW3HM7lqspp7ymYs5JAmquDq0WROtURRfSffoa/vrCCyw==}
+    dev: true
+
   /chokidar@2.1.8:
     resolution: {integrity: sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==}
     deprecated: Chokidar 2 does not receive security updates since 2019. Upgrade to chokidar 3 with 15x fewer dependencies
@@ -12552,7 +12563,7 @@ packages:
     peerDependencies:
       '@ember/test-helpers': ^2.6.0 || >= 3.0.0
       '@ember/test-waiters': '>= 3.0.1'
-      ember-modifier: ^3.2.0 || >= 4.0.0
+      ember-modifier: ^4.1.0
       ember-source: ^3.28.0 || >= 4.0.0
     dependencies:
       '@ember/test-helpers': 3.3.0(@glint/template@1.3.0)(ember-source@5.4.1)(webpack@5.89.0)
@@ -12726,7 +12737,7 @@ packages:
     engines: {node: ^16.0.0 || ^18.0.0 || >=20.0.0}
     peerDependencies:
       ember-template-lint: '>= 4.0.0'
-      prettier: '>= 3.0.0'
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     dependencies:
       '@prettier/sync': 0.2.1(prettier@3.1.0-dev)
       ember-template-lint: 5.11.2
@@ -12920,7 +12931,7 @@ packages:
     resolution: {integrity: sha512-4V6rT9b9XSeMaPmiYYA2hIhfMD088vru6AvfGWBY7L1w/st5hYv6iIfamy9+W1l9xKvIH3Hcl8+B0637/SRmzQ==}
     engines: {node: 14.* || >= 16}
     peerDependencies:
-      ember-modifier: ^3.2.7 || >= 4.0.0
+      ember-modifier: ^4.1.0
       ember-source: ^3.28.0 || ^4.0.0 || >= 5.0.0
     dependencies:
       '@embroider/addon-shim': 1.8.7
@@ -13609,7 +13620,7 @@ packages:
     peerDependencies:
       eslint: '>=5.0.0'
       eslint-config-prettier: '*'
-      prettier: '>=1.13.0'
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     peerDependenciesMeta:
       eslint-config-prettier:
         optional: true
@@ -13624,10 +13635,10 @@ packages:
     resolution: {integrity: sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      '@types/eslint': '>=8.0.0'
+      '@types/eslint': 8.4.1
       eslint: '>=8.0.0'
       eslint-config-prettier: '*'
-      prettier: '>=3.0.0'
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     peerDependenciesMeta:
       '@types/eslint':
         optional: true
@@ -13645,10 +13656,10 @@ packages:
     resolution: {integrity: sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      '@types/eslint': '>=8.0.0'
+      '@types/eslint': 8.4.1
       eslint: '>=8.0.0'
       eslint-config-prettier: '*'
-      prettier: '>=3.0.0'
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     peerDependenciesMeta:
       '@types/eslint':
         optional: true
@@ -13666,10 +13677,10 @@ packages:
     resolution: {integrity: sha512-C9GCVAs4Eq7ZC/XFQHITLiHJxQngdtraXaM+LoUFoFp/lHNl2Zn8f3WQbe9HvTBBQ9YnKFB0/2Ajdqwo5D1EAw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      '@types/eslint': '>=8.0.0'
+      '@types/eslint': 8.4.1
       eslint: '>=8.0.0'
       eslint-config-prettier: '*'
-      prettier: '>=3.0.0'
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     peerDependenciesMeta:
       '@types/eslint':
         optional: true
@@ -19768,7 +19779,7 @@ packages:
     resolution: {integrity: sha512-zJTC+NhEU0kHNnVh7OtcvMmkJmYTgFTist76FP9q07m9+WCvcaunR1sTFIOlGE9TH/5UGm6rlF86Umt9ouorAg==}
     engines: {node: 16.* || 18.* || >= 20}
     peerDependencies:
-      prettier: '>= 3.0.0'
+      prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support
     dependencies:
       '@babel/core': 7.24.3(supports-color@8.1.1)
       '@glimmer/syntax': 0.84.3
@@ -23944,7 +23955,3 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
While starting to refactor the chess example we noticed that chess.js is written in typescript and has good upstream types, so it would be nice to use them. 

- needed to rename chess.gts to chess-game.gts because of https://github.com/typed-ember/glint/issues/724