### PR TITLE
Run patchCard inside command service

### DIFF
--- a/packages/ai-bot/helpers.ts
+++ b/packages/ai-bot/helpers.ts
@@ -2,29 +2,13 @@ import {
   LooseCardResource,
   type LooseSingleCardDocument,
 } from '@cardstack/runtime-common';
+import { MODIFY_SYSTEM_MESSAGE } from '@cardstack/runtime-common/helpers/ai';
 import type {
   MatrixEvent as DiscreteMatrixEvent,
   CardFragmentContent,
   CommandEvent,
 } from 'https://cardstack.com/base/room';
 import { MatrixEvent, type IRoomEvent } from 'matrix-js-sdk';
-
-const MODIFY_SYSTEM_MESSAGE =
-  '\
-The user is using an application called Boxel, where they are working on editing "Cards" which are data models representable as JSON. \
-The user may be non-technical and should not need to understand the inner workings of Boxel. \
-The user may be asking questions about the contents of the cards rather than help editing them. Use your world knowledge to help them. \
-If the user wants the data they see edited, AND the patchCard function is available, you MUST use the "patchCard" function to make the change. \
-If the user wants the data they see edited, AND the patchCard function is NOT available, you MUST ask the user to open the card and share it with you \
-If you do not call patchCard, the user will not see the change. \
-You can ONLY modify cards shared with you, if there is no patchCard function or tool then the user hasn\'t given you access \
-NEVER tell the user to use patchCard, you should always do it for them. \
-If the user request is unclear, you may ask clarifying questions. \
-You may make multiple function calls, all calls are gated by the user so multiple options can be explored.\
-If a user asks you about things in the world, use your existing knowledge to help them. Only if necessary, add a *small* caveat at the end of your message to explain that you do not have live external data. \
-\
-If you need access to the cards the user can see, you can ask them to attach the cards. \
-If you encounter JSON structures, please enclose them within backticks to ensure they are displayed stylishly in Markdown.';
 
 type CommandMessage = {
   type: 'command';
@@ -303,7 +287,7 @@ export function isCommandEvent(
     event.content.msgtype === 'org.boxel.command' &&
     event.content.format === 'org.matrix.custom.html' &&
     typeof event.content.data === 'object' &&
-    typeof event.content.data.command === 'object'
+    typeof event.content.data.toolCall === 'object'
   );
 }
 
@@ -311,6 +295,6 @@ export function isPatchCommandEvent(
   event: DiscreteMatrixEvent,
 ): event is CommandEvent {
   return (
-    isCommandEvent(event) && event.content.data.command.type === 'patchCard'
+    isCommandEvent(event) && event.content.data.toolCall.name === 'patchCard'
   );
 }

--- a/packages/ai-bot/lib/matrix.ts
+++ b/packages/ai-bot/lib/matrix.ts
@@ -68,8 +68,8 @@ export async function sendMessage(
 }
 
 export interface FunctionToolCall {
-  name: 'searchCard' | 'patchCard';
-  arguments: any;
+  name: string;
+  arguments: { [key: string]: any };
 }
 
 // TODO we might want to think about how to handle patches that are larger than
@@ -81,7 +81,10 @@ export async function sendOption(
   functionCall: FunctionToolCall,
   eventToUpdate: string | undefined,
 ) {
-  let messageObject = toMatrixMessageContent(functionCall, eventToUpdate);
+  let messageObject = toMatrixMessageCommandContent(
+    functionCall,
+    eventToUpdate,
+  );
 
   if (messageObject !== undefined) {
     return await sendEvent(
@@ -122,52 +125,23 @@ export async function sendError(
   }
 }
 
-export const toMatrixMessageContent = (
+export const toMatrixMessageCommandContent = (
   functionCall: FunctionToolCall,
   eventToUpdate: string | undefined,
 ): IContent | undefined => {
   let { arguments: payload } = functionCall;
-  if (functionCall.name === 'patchCard') {
-    const id = payload['card_id'];
-    const body = payload['description'] || "Here's the change:";
-    let messageObject: IContent = {
-      body: body,
-      msgtype: 'org.boxel.command',
-      formatted_body: body,
-      format: 'org.matrix.custom.html',
-      data: {
-        command: {
-          type: functionCall.name,
-          id: id,
-          patch: {
-            attributes: payload['attributes'],
-            relationships: payload['relationships'],
-          },
-          eventId: eventToUpdate,
-          toolCall: functionCall,
-        },
-      },
-    };
-    return messageObject;
-  } else if (functionCall.name === 'searchCard') {
-    const body = payload['description'] || "Here's the query:";
-    let messageObject = {
-      body: body,
-      msgtype: 'org.boxel.command',
-      formatted_body: body,
-      format: 'org.matrix.custom.html',
-      data: {
-        command: {
-          type: functionCall.name,
-          search: { ...payload },
-          eventId: eventToUpdate,
-          toolCall: functionCall,
-        },
-      },
-    };
-    return messageObject;
-  }
-  return;
+  const body = payload['description'] || "Here's the change:";
+  let messageObject: IContent = {
+    body: body,
+    msgtype: 'org.boxel.command',
+    formatted_body: body,
+    format: 'org.matrix.custom.html',
+    data: {
+      eventId: eventToUpdate,
+      toolCall: functionCall,
+    },
+  };
+  return messageObject;
 };
 
 function getErrorMessage(error: any): string {

--- a/packages/ai-bot/lib/set-title.ts
+++ b/packages/ai-bot/lib/set-title.ts
@@ -99,8 +99,8 @@ export const getLatestPatchApplyMessage = (
       return [];
     }
     if (isPatchCommandEvent(commandEvent)) {
-      let patchMessage = JSON.stringify(commandEvent.content.data.command);
-      let content = `Applying patchCard with the payload ${patchMessage}. The patch being made is applied to the following ${attachedCardsToMessage(
+      let patchMessage = JSON.stringify(commandEvent.content.data.toolCall);
+      let content = `Applying patchCard with args${patchMessage}. The patch being made is applied to the following ${attachedCardsToMessage(
         history,
         aiBotUserId,
       )}`;

--- a/packages/ai-bot/tests/chat-titling-test.ts
+++ b/packages/ai-bot/tests/chat-titling-test.ts
@@ -375,10 +375,10 @@ module('shouldSetRoomTitle', () => {
           body: 'patching card',
           formatted_body: 'patching card',
           data: {
-            command: {
-              type: 'patchCard',
-              id: 'http://localhost:4201/drafts/Friend/1',
-              patch: {
+            toolCall: {
+              name: 'patchCard',
+              arguments: {
+                card_id: 'http://localhost:4201/drafts/Friend/1',
                 attributes: {
                   firstName: 'Dave',
                 },
@@ -440,10 +440,10 @@ module('shouldSetRoomTitle', () => {
           body: 'patching card',
           formatted_body: 'patching card',
           data: {
-            command: {
-              type: 'patchCard',
-              id: 'http://localhost:4201/drafts/Friend/1',
-              patch: {
+            toolCall: {
+              name: 'patchCard',
+              arguments: {
+                card_id: 'http://localhost:4201/drafts/Friend/1',
                 attributes: {
                   firstName: 'Dave',
                 },

--- a/packages/ai-bot/tests/responding-test.ts
+++ b/packages/ai-bot/tests/responding-test.ts
@@ -217,23 +217,14 @@ module('Responding', (hooks) => {
     assert.deepEqual(
       JSON.parse(sentEvents[1].content.data),
       {
-        command: {
-          type: 'patchCard',
-          id: 'card/1',
-          patch: {
+        eventId: '0',
+        toolCall: {
+          name: 'patchCard',
+          arguments: {
+            card_id: 'card/1',
+            description: 'A new thing',
             attributes: {
               some: 'thing',
-            },
-          },
-          eventId: '0',
-          toolCall: {
-            name: 'patchCard',
-            arguments: {
-              card_id: 'card/1',
-              description: 'A new thing',
-              attributes: {
-                some: 'thing',
-              },
             },
           },
         },
@@ -291,22 +282,13 @@ module('Responding', (hooks) => {
     assert.deepEqual(
       JSON.parse(sentEvents[2].content.data),
       {
-        command: {
-          type: 'patchCard',
-          id: 'card/1',
-          patch: {
+        toolCall: {
+          name: 'patchCard',
+          arguments: {
+            card_id: 'card/1',
+            description: 'A new thing',
             attributes: {
               some: 'thing',
-            },
-          },
-          toolCall: {
-            name: 'patchCard',
-            arguments: {
-              card_id: 'card/1',
-              description: 'A new thing',
-              attributes: {
-                some: 'thing',
-              },
             },
           },
         },

--- a/packages/base/room.gts
+++ b/packages/base/room.gts
@@ -579,7 +579,6 @@ export class RoomField extends FieldDef {
         } else if (event.content.msgtype === 'org.boxel.command') {
           // We only handle patches for now
           let command = event.content.data.command;
-          //TODO: This is here for backward compatibility reasons
           let annotation = this.events.find(
             (e) =>
               e.type === 'm.reaction' &&

--- a/packages/base/room.gts
+++ b/packages/base/room.gts
@@ -579,6 +579,7 @@ export class RoomField extends FieldDef {
         } else if (event.content.msgtype === 'org.boxel.command') {
           // We only handle patches for now
           let command = event.content.data.command;
+          //TODO: This is here for backward compatibility reasons
           let annotation = this.events.find(
             (e) =>
               e.type === 'm.reaction' &&

--- a/packages/host/app/components/ai-assistant/message/index.gts
+++ b/packages/host/app/components/ai-assistant/message/index.gts
@@ -219,7 +219,7 @@ export default class AiAssistantMessage extends Component<Signature> {
         overflow: auto;
       }
 
-      .content > :deep(.patch-message) {
+      .content > :deep(.command-message) {
         font-weight: 700;
         letter-spacing: var(--boxel-lsp-sm);
       }

--- a/packages/host/app/components/matrix/room-message.gts
+++ b/packages/host/app/components/matrix/room-message.gts
@@ -1,3 +1,4 @@
+import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
@@ -19,6 +20,7 @@ import { markdownToHtml } from '@cardstack/runtime-common';
 
 import monacoModifier from '@cardstack/host/modifiers/monaco';
 import type { MonacoEditorOptions } from '@cardstack/host/modifiers/monaco';
+import CommandService from '@cardstack/host/services/command-service';
 import type MatrixService from '@cardstack/host/services/matrix-service';
 import type MonacoService from '@cardstack/host/services/monaco-service';
 import { type MonacoSDK } from '@cardstack/host/services/monaco-service';
@@ -32,8 +34,6 @@ import { type ApplyButtonState } from '../ai-assistant/apply-button';
 import AiAssistantMessage from '../ai-assistant/message';
 import { aiBotUserId } from '../ai-assistant/panel';
 import ProfileAvatarIcon from '../operator-mode/profile-avatar-icon';
-import CommandService from '@cardstack/host/services/command-service';
-import { fn } from '@ember/helper';
 
 interface Signature {
   Element: HTMLDivElement;

--- a/packages/host/app/components/matrix/room-message.gts
+++ b/packages/host/app/components/matrix/room-message.gts
@@ -326,7 +326,7 @@ export default class RoomMessage extends Component<Signature> {
     );
   }
 
-  run = task(async (command: any, roomId: string) => {
+  run = task(async (command: Record<string, any>, roomId: string) => {
     return this.commandService.run.perform(command, roomId);
   });
 

--- a/packages/host/app/services/command-service.ts
+++ b/packages/host/app/services/command-service.ts
@@ -1,7 +1,9 @@
 import Service, { service } from '@ember/service';
-import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
+
 import { task } from 'ember-concurrency';
+
 import type MatrixService from '@cardstack/host/services/matrix-service';
+import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 export default class CommandService extends Service {
   @service declare operatorModeStateService: OperatorModeStateService;

--- a/packages/host/app/services/command-service.ts
+++ b/packages/host/app/services/command-service.ts
@@ -1,0 +1,31 @@
+import Service, { service } from '@ember/service';
+import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
+import { task } from 'ember-concurrency';
+import type MatrixService from '@cardstack/host/services/matrix-service';
+
+export default class CommandService extends Service {
+  @service declare operatorModeStateService: OperatorModeStateService;
+  @service private declare matrixService: MatrixService;
+
+  run = task(async (command: any, roomId: string) => {
+    let { payload, eventId } = command;
+    try {
+      this.matrixService.failedCommandState.delete(eventId);
+      if (command.commandType === 'patchCard') {
+        await this.operatorModeStateService.patchCard.perform(
+          payload.id,
+          payload.patch, //extracting patch here
+        );
+      }
+      await this.matrixService.sendReactionEvent(roomId, eventId, 'applied');
+    } catch (e) {
+      let error =
+        typeof e === 'string'
+          ? new Error(e)
+          : e instanceof Error
+          ? e
+          : new Error('Patch failed.');
+      this.matrixService.failedCommandState.set(eventId, error);
+    }
+  });
+}

--- a/packages/host/app/services/command-service.ts
+++ b/packages/host/app/services/command-service.ts
@@ -9,7 +9,7 @@ export default class CommandService extends Service {
   @service declare operatorModeStateService: OperatorModeStateService;
   @service private declare matrixService: MatrixService;
 
-  run = task(async (command: any, roomId: string) => {
+  run = task(async (command: Record<string, any>, roomId: string) => {
     let { payload, eventId } = command;
     try {
       this.matrixService.failedCommandState.delete(eventId);

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -31,6 +31,7 @@ import {
   generateCardPatchCallSpecification,
 } from '@cardstack/runtime-common/helpers/ai';
 
+import { getPatchTool } from '@cardstack/runtime-common/helpers/ai';
 import { RealmAuthClient } from '@cardstack/runtime-common/realm-auth-client';
 
 import { Submode } from '@cardstack/host/components/submode-switcher';
@@ -425,27 +426,7 @@ export default class MatrixService extends Service {
         });
         await realmSession.loaded;
         if (realmSession.canWrite) {
-          tools.push({
-            type: 'function',
-            function: {
-              name: 'patchCard',
-              description: `Propose a patch to an existing card to change its contents. Any attributes specified will be fully replaced, return the minimum required to make the change. If a relationship field value is removed, set the self property of the specific item to null. When editing a relationship array, display the full array in the patch code. Ensure the description explains what change you are making.`,
-              parameters: {
-                type: 'object',
-                properties: {
-                  card_id: {
-                    type: 'string',
-                    const: attachedOpenCard.id, // Force the valid card_id to be the id of the card being patched
-                  },
-                  description: {
-                    type: 'string',
-                  },
-                  ...patchSpec,
-                },
-                required: ['card_id', 'attributes', 'description'],
-              },
-            },
-          });
+          tools.push(getPatchTool(attachedOpenCard, patchSpec));
         }
       }
     }

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -898,14 +898,14 @@ module('Integration | operator-mode', function (hooks) {
           formatted_body: 'A patch',
           format: 'org.matrix.custom.html',
           data: JSON.stringify({
-            command: {
-              type: 'patchCard',
-              id: `${testRealmURL}Person/fadhlan`,
-              patch: {
+            toolCall: {
+              name: 'patchCard',
+              arguments: {
+                card_id: `${testRealmURL}Person/fadhlan`,
                 attributes: { firstName: 'Dave' },
               },
-              eventId: 'patch1',
             },
+            eventId: 'patch1',
           }),
           'm.relates_to': {
             rel_type: 'm.replace',
@@ -923,7 +923,7 @@ module('Integration | operator-mode', function (hooks) {
         assert.strictEqual(json.data.attributes?.firstName, 'Dave');
       });
       await click('[data-test-command-apply]');
-      await waitFor('[data-test-patch-card-idle]');
+      await waitFor('[data-test-command-card-idle]');
 
       assert.dom('[data-test-person]').hasText('Dave');
     });
@@ -953,12 +953,14 @@ module('Integration | operator-mode', function (hooks) {
           formatted_body: 'Changing first name to Evie',
           format: 'org.matrix.custom.html',
           data: JSON.stringify({
-            command: {
-              type: 'patchCard',
-              id: `${testRealmURL}Person/fadhlan`,
-              patch: { attributes: { firstName: 'Evie' } },
-              eventId: 'room1-event1',
+            toolCall: {
+              name: 'patchCard',
+              arguments: {
+                card_id: `${testRealmURL}Person/fadhlan`,
+                attributes: { firstName: 'Evie' },
+              },
             },
+            eventId: 'room1-event1',
           }),
           'm.relates_to': {
             rel_type: 'm.replace',
@@ -979,12 +981,14 @@ module('Integration | operator-mode', function (hooks) {
           formatted_body: 'Changing first name to Jackie',
           format: 'org.matrix.custom.html',
           data: JSON.stringify({
-            command: {
-              type: 'patchCard',
-              id: `${testRealmURL}Person/fadhlan`,
-              patch: { attributes: { firstName: 'Jackie' } },
-              eventId: 'room1-event2',
+            toolCall: {
+              name: 'patchCard',
+              arguments: {
+                card_id: `${testRealmURL}Person/fadhlan`,
+                attributes: { firstName: 'Jackie' },
+              },
             },
+            eventId: 'room1-event2',
           }),
           'm.relates_to': {
             rel_type: 'm.replace',
@@ -1005,12 +1009,14 @@ module('Integration | operator-mode', function (hooks) {
           formatted_body: 'Incorrect command',
           format: 'org.matrix.custom.html',
           data: JSON.stringify({
-            command: {
-              type: 'patchCard',
-              id: `${testRealmURL}Person/fadhlan`,
-              patch: { relationships: { pet: null } }, // this will error
-              eventId: 'room2-event1',
+            toolCall: {
+              name: 'patchCard',
+              arguments: {
+                card_id: `${testRealmURL}Person/fadhlan`,
+                relationships: { pet: null }, // this will error
+              },
             },
+            eventId: 'room2-event1',
           }),
           'm.relates_to': {
             rel_type: 'm.replace',
@@ -1024,7 +1030,7 @@ module('Integration | operator-mode', function (hooks) {
       await waitFor('[data-test-room-name="test room 1"]');
       await waitFor('[data-test-message-idx="1"] [data-test-command-apply]');
       await click('[data-test-message-idx="1"] [data-test-command-apply]');
-      await waitFor('[data-test-patch-card-idle]');
+      await waitFor('[data-test-command-card-idle]');
 
       assert
         .dom('[data-test-message-idx="1"] [data-test-apply-state="applied"]')
@@ -1038,7 +1044,7 @@ module('Integration | operator-mode', function (hooks) {
       await waitFor('[data-test-room-name="test room 2"]');
       await waitFor('[data-test-command-apply]');
       await click('[data-test-command-apply]');
-      await waitFor('[data-test-patch-card-idle]');
+      await waitFor('[data-test-command-card-idle]');
       assert
         .dom('[data-test-message-idx="0"] [data-test-apply-state="failed"]')
         .exists();
@@ -1097,14 +1103,14 @@ module('Integration | operator-mode', function (hooks) {
           formatted_body: 'A patch',
           format: 'org.matrix.custom.html',
           data: JSON.stringify({
-            command: {
-              type: 'patchCard',
-              id: otherCardID,
-              patch: {
+            toolCall: {
+              name: 'patchCard',
+              arguments: {
+                card_id: otherCardID,
                 attributes: { firstName: 'Dave' },
               },
-              eventId: 'event1',
             },
+            eventId: 'event1',
           }),
           'm.relates_to': {
             rel_type: 'm.replace',
@@ -1117,7 +1123,7 @@ module('Integration | operator-mode', function (hooks) {
       await waitFor('[data-test-command-apply="ready"]');
       await click('[data-test-command-apply]');
 
-      await waitFor('[data-test-patch-card-idle]');
+      await waitFor('[data-test-command-card-idle]');
       assert
         .dom('[data-test-card-error]')
         .containsText(
@@ -1138,7 +1144,7 @@ module('Integration | operator-mode', function (hooks) {
       await click('[data-test-ai-bot-retry-button]'); // retry the command with correct card
       assert.dom('[data-test-apply-state="applying"]').exists();
 
-      await waitFor('[data-test-patch-card-idle]');
+      await waitFor('[data-test-command-card-idle]');
       assert.dom('[data-test-apply-state="applied"]').exists();
       assert.dom('[data-test-person]').hasText('Dave');
       assert.dom('[data-test-command-apply]').doesNotExist();
@@ -1169,16 +1175,13 @@ module('Integration | operator-mode', function (hooks) {
 
       let roomId = await openAiAssistant();
       let payload = {
-        type: 'patchCard',
-        id: `${testRealmURL}Person/fadhlan`,
-        patch: {
-          attributes: {
-            firstName: 'Joy',
-            address: { shippingInfo: { preferredCarrier: 'UPS' } },
-          },
+        card_id: `${testRealmURL}Person/fadhlan`,
+        attributes: {
+          firstName: 'Joy',
+          address: { shippingInfo: { preferredCarrier: 'UPS' } },
         },
-        eventId: 'event1',
       };
+
       await addRoomEvent(matrixService, {
         event_id: 'event1',
         room_id: roomId,
@@ -1191,7 +1194,13 @@ module('Integration | operator-mode', function (hooks) {
           msgtype: 'org.boxel.command',
           formatted_body: 'A patch',
           format: 'org.matrix.custom.html',
-          data: JSON.stringify({ command: payload }),
+          data: JSON.stringify({
+            toolCall: {
+              name: 'patchCard',
+              arguments: payload,
+            },
+            eventId: 'event1',
+          }),
           'm.relates_to': {
             rel_type: 'm.replace',
             event_id: 'event1',
@@ -1207,7 +1216,7 @@ module('Integration | operator-mode', function (hooks) {
       assert.deepEqual(
         JSON.parse(getMonacoContent()),
         {
-          commandType: 'patchCard',
+          name: 'patchCard',
           payload,
         },
         'it can preview code when a change is proposed',
@@ -1218,7 +1227,7 @@ module('Integration | operator-mode', function (hooks) {
       assert.dom('[data-test-code-editor]').doesNotExist();
 
       await click('[data-test-command-apply="ready"]');
-      await waitFor('[data-test-patch-card-idle]');
+      await waitFor('[data-test-command-card-idle]');
       assert.dom('[data-test-apply-state="applied"]').exists();
       assert.dom('[data-test-person]').hasText('Joy');
       assert.dom(`[data-test-preferredcarrier]`).hasText('UPS');
@@ -1252,10 +1261,10 @@ module('Integration | operator-mode', function (hooks) {
           formatted_body: 'Removing pet and changing preferred carrier',
           format: 'org.matrix.custom.html',
           data: JSON.stringify({
-            command: {
-              type: 'patchCard',
-              id,
-              patch: {
+            toolCall: {
+              name: 'patchCard',
+              arguments: {
+                card_id: id,
                 attributes: {
                   address: { shippingInfo: { preferredCarrier: 'Fedex' } },
                 },
@@ -1263,8 +1272,8 @@ module('Integration | operator-mode', function (hooks) {
                   pet: { links: { self: null } },
                 },
               },
-              eventId: 'patch0',
             },
+            eventId: 'patch0',
           }),
           'm.relates_to': {
             rel_type: 'm.replace',
@@ -1281,7 +1290,7 @@ module('Integration | operator-mode', function (hooks) {
       assert.dom(`${stackCard} [data-test-pet="Mango"]`).exists();
 
       await click('[data-test-command-apply]');
-      await waitFor('[data-test-patch-card-idle]');
+      await waitFor('[data-test-command-card-idle]');
       assert.dom('[data-test-apply-state="applied"]').exists();
       assert.dom(`${stackCard} [data-test-preferredcarrier="Fedex"]`).exists();
       assert.dom(`${stackCard} [data-test-pet="Mango"]`).doesNotExist();
@@ -1298,10 +1307,10 @@ module('Integration | operator-mode', function (hooks) {
           formatted_body: 'Link to pet and change preferred carrier',
           format: 'org.matrix.custom.html',
           data: JSON.stringify({
-            command: {
-              type: 'patchCard',
-              id,
-              patch: {
+            toolCall: {
+              name: 'patchCard',
+              arguments: {
+                card_id: id,
                 attributes: {
                   address: { shippingInfo: { preferredCarrier: 'UPS' } },
                 },
@@ -1311,8 +1320,8 @@ module('Integration | operator-mode', function (hooks) {
                   },
                 },
               },
-              eventId: 'patch1',
             },
+            eventId: 'patch1',
           }),
           'm.relates_to': {
             rel_type: 'm.replace',
@@ -1326,7 +1335,9 @@ module('Integration | operator-mode', function (hooks) {
       assert.dom(`${stackCard} [data-test-pet]`).doesNotExist();
 
       await click('[data-test-command-apply]');
-      await waitFor('[data-test-message-idx="1"] [data-test-patch-card-idle]');
+      await waitFor(
+        '[data-test-message-idx="1"] [data-test-command-card-idle]',
+      );
       assert
         .dom('[data-test-message-idx="1"] [data-test-apply-state="applied"]')
         .exists();
@@ -1363,10 +1374,10 @@ module('Integration | operator-mode', function (hooks) {
           formatted_body: 'Change tripTitle to Trip to Japan',
           format: 'org.matrix.custom.html',
           data: JSON.stringify({
-            command: {
-              type: 'patchCard',
-              id,
-              patch: {
+            toolCall: {
+              name: 'patchCard',
+              arguments: {
+                card_id: id,
                 attributes: { trips: { tripTitle: 'Trip to Japan' } },
               },
               eventId: 'event1',
@@ -1382,7 +1393,7 @@ module('Integration | operator-mode', function (hooks) {
 
       await waitFor('[data-test-command-apply="ready"]');
       await click('[data-test-command-apply]');
-      await waitFor('[data-test-patch-card-idle]');
+      await waitFor('[data-test-command-card-idle]');
       assert.dom('[data-test-apply-state="applied"]').exists();
       assert.dom('[data-test-tripTitle]').hasText('Trip to Japan');
     });
@@ -1413,12 +1424,14 @@ module('Integration | operator-mode', function (hooks) {
           formatted_body: 'Change first name to Dave',
           format: 'org.matrix.custom.html',
           data: JSON.stringify({
-            command: {
-              type: 'patchCard',
-              id,
-              patch: { attributes: { firstName: 'Dave' } },
-              eventId: 'event1',
+            toolCall: {
+              name: 'patchCard',
+              arguments: {
+                card_id: id,
+                attributes: { firstName: 'Dave' },
+              },
             },
+            eventId: 'event1',
           }),
           'm.relates_to': {
             rel_type: 'm.replace',
@@ -1439,12 +1452,14 @@ module('Integration | operator-mode', function (hooks) {
           formatted_body: 'Incorrect patch command',
           format: 'org.matrix.custom.html',
           data: JSON.stringify({
-            command: {
-              type: 'patchCard',
-              id,
-              patch: { relationships: { pet: null } }, // this will error
-              eventId: 'event2',
+            toolCall: {
+              name: 'patchCard',
+              arguments: {
+                card_id: id,
+                relationships: { pet: null }, // this will error
+              },
             },
+            eventId: 'event2',
           }),
           'm.relates_to': {
             rel_type: 'm.replace',
@@ -1465,12 +1480,14 @@ module('Integration | operator-mode', function (hooks) {
           formatted_body: 'Change first name to Jackie',
           format: 'org.matrix.custom.html',
           data: JSON.stringify({
-            command: {
-              type: 'patchCard',
-              id,
-              patch: { attributes: { firstName: 'Jackie' } },
-              eventId: 'event3',
+            toolCall: {
+              name: 'patchCard',
+              arguments: {
+                card_id: id,
+                attributes: { firstName: 'Jackie' },
+              },
             },
+            eventId: 'event3',
           }),
           'm.relates_to': {
             rel_type: 'm.replace',
@@ -1488,7 +1505,9 @@ module('Integration | operator-mode', function (hooks) {
         .dom('[data-test-message-idx="2"] [data-test-apply-state="applying"]')
         .exists();
 
-      await waitFor('[data-test-message-idx="2"] [data-test-patch-card-idle]');
+      await waitFor(
+        '[data-test-message-idx="2"] [data-test-command-card-idle]',
+      );
       assert.dom('[data-test-apply-state="applied"]').exists({ count: 1 });
       assert
         .dom('[data-test-message-idx="2"] [data-test-apply-state="applied"]')
@@ -1497,7 +1516,9 @@ module('Integration | operator-mode', function (hooks) {
       assert.dom('[data-test-person]').hasText('Jackie');
 
       await click('[data-test-message-idx="1"] [data-test-command-apply]');
-      await waitFor('[data-test-message-idx="1"] [data-test-patch-card-idle]');
+      await waitFor(
+        '[data-test-message-idx="1"] [data-test-command-card-idle]',
+      );
       assert.dom('[data-test-apply-state="failed"]').exists({ count: 1 });
       assert
         .dom('[data-test-message-idx="1"] [data-test-apply-state="failed"]')
@@ -1534,12 +1555,14 @@ module('Integration | operator-mode', function (hooks) {
           formatted_body: 'Change first name to Dave',
           format: 'org.matrix.custom.html',
           data: JSON.stringify({
-            command: {
-              type: 'patchCard',
-              id,
-              patch: { attributes: { firstName: 'Dave' } },
-              eventId: undefined,
+            toolCall: {
+              name: 'patchCard',
+              arguments: {
+                card_id: id,
+                attributes: { firstName: 'Dave' },
+              },
             },
+            eventId: undefined,
           }),
           'm.relates_to': {
             rel_type: 'm.replace',
@@ -1557,7 +1580,9 @@ module('Integration | operator-mode', function (hooks) {
         .dom('[data-test-message-idx="0"] [data-test-apply-state="applying"]')
         .exists();
 
-      await waitFor('[data-test-message-idx="0"] [data-test-patch-card-idle]');
+      await waitFor(
+        '[data-test-message-idx="0"] [data-test-command-card-idle]',
+      );
       assert.dom('[data-test-apply-state="applied"]').exists({ count: 1 });
       assert
         .dom('[data-test-message-idx="0"] [data-test-apply-state="applied"]')
@@ -2175,14 +2200,14 @@ module('Integration | operator-mode', function (hooks) {
           formatted_body: 'A patch',
           format: 'org.matrix.custom.html',
           data: JSON.stringify({
-            command: {
-              type: 'patchCard',
-              id: `${testRealmURL}Person/fadhlan`,
-              patch: {
+            toolCall: {
+              name: 'patchCard',
+              arguments: {
+                card_id: `${testRealmURL}Person/fadhlan`,
                 attributes: { firstName: 'Dave' },
               },
-              eventId: 'patch1',
             },
+            eventId: 'patch1',
           }),
           'm.relates_to': {
             rel_type: 'm.replace',

--- a/packages/runtime-common/helpers/ai.ts
+++ b/packages/runtime-common/helpers/ai.ts
@@ -395,3 +395,20 @@ export function getSearchTool(attachedOpenCard: CardDef) {
     },
   };
 }
+
+export const MODIFY_SYSTEM_MESSAGE =
+  '\
+The user is using an application called Boxel, where they are working on editing "Cards" which are data models representable as JSON. \
+The user may be non-technical and should not need to understand the inner workings of Boxel. \
+The user may be asking questions about the contents of the cards rather than help editing them. Use your world knowledge to help them. \
+If the user wants the data they see edited, AND the patchCard function is available, you MUST use the "patchCard" function to make the change. \
+If the user wants the data they see edited, AND the patchCard function is NOT available, you MUST ask the user to open the card and share it with you \
+If you do not call patchCard, the user will not see the change. \
+You can ONLY modify cards shared with you, if there is no patchCard function or tool then the user hasn\'t given you access \
+NEVER tell the user to use patchCard, you should always do it for them. \
+If the user request is unclear, you may ask clarifying questions. \
+You may make multiple function calls, all calls are gated by the user so multiple options can be explored.\
+If a user asks you about things in the world, use your existing knowledge to help them. Only if necessary, add a *small* caveat at the end of your message to explain that you do not have live external data. \
+\
+If you need access to the cards the user can see, you can ask them to attach the cards. \
+If you encounter JSON structures, please enclose them within backticks to ensure they are displayed stylishly in Markdown.';


### PR DESCRIPTION
Merging into https://github.com/cardstack/boxel/pull/1341

I implement this as a first step to remove domain-specifc logic from the ai bot. Bcos when u make the ai-bot unopiniated about how the function tool call forms a matrix event, then a lot of the deciphering will need to go into the consumer (the host). This command service is the place I want to store everything domain-specific (eg patchCard or searchCard) for now.

command service 
- runs commands within cards
- execute matrix events (reaction / command result events)
- temporarily, a place to keep domain-specific code (like patchCard) as I refactor things out of the ui





