### PR TITLE
Activity and recency indicators in the AI sessions list

### DIFF
--- a/packages/base/room.gts
+++ b/packages/base/room.gts
@@ -153,6 +153,7 @@ type MessageFieldArgs = {
   isStreamingFinished?: boolean;
   clientGeneratedId?: string | null;
   status: EventStatus | null;
+  eventId: string;
 };
 
 type AttachedCardResource = {
@@ -277,6 +278,7 @@ export function getEventIdForCard(
 }
 
 export class MessageField extends FieldDef {
+  @field eventId = contains(StringField);
   @field author = contains(RoomMemberField);
   @field message = contains(MarkdownField);
   @field formattedMessage = contains(MarkdownField);
@@ -288,6 +290,7 @@ export class MessageField extends FieldDef {
   @field command = contains(PatchField);
   @field isStreamingFinished = contains(BooleanField);
   @field errorMessage = contains(StringField);
+
   // ID from the client and can be used by client
   // to verify whether the message is already sent or not.
   @field clientGeneratedId = contains(StringField);
@@ -464,7 +467,7 @@ export class RoomField extends FieldDef {
         roomMemberCache.set(this, roomMembers);
       }
 
-      for (let event of this.newEvents) {
+      for (let event of this.events) {
         if (event.type !== 'm.room.member') {
           continue;
         }
@@ -530,6 +533,7 @@ export class RoomField extends FieldDef {
           attachedCard: null,
           command: null,
           status: event.status,
+          eventId: event.event_id,
         };
 
         if (event.status === 'cancelled' || event.status === 'not_sent') {
@@ -778,7 +782,6 @@ interface LeaveEvent extends RoomStateEvent {
   };
 }
 
-//Here are some message events
 interface MessageEvent extends BaseMatrixEvent {
   type: 'm.room.message';
   content: {

--- a/packages/host/app/components/ai-assistant/panel.gts
+++ b/packages/host/app/components/ai-assistant/panel.gts
@@ -61,6 +61,19 @@ let currentRoomIdPersistenceKey = 'aiPanelCurrentRoomId';
 let newSessionIdPersistenceKey = 'aiPanelNewSessionId';
 
 export default class AiAssistantPanel extends Component<Signature> {
+  get hasOtherActiveSessions() {
+    let oneMinuteAgo = new Date(Date.now() - 60 * 1000).getTime();
+
+    return this.aiSessionRooms.some((session) => {
+      let isActive =
+        this.matrixService.getLastActiveTimestamp(session) > oneMinuteAgo;
+      if (this.currentRoom) {
+        return this.currentRoom.roomId !== session.roomId && isActive;
+      }
+      return isActive;
+    });
+  }
+
   <template>
     <Velcro @placement='bottom' @offsetOptions={{-50}} as |popoverVelcro|>
       <div
@@ -109,15 +122,20 @@ export default class AiAssistantPanel extends Component<Signature> {
               <LoadingIndicator @color='var(--boxel-light)' />
             {{else}}
               <Button
-                class='past-sessions-button'
+                class='past-sessions-button
+                  {{if
+                    this.hasOtherActiveSessions
+                    "past-sessions-button-active"
+                  }}'
                 @kind='secondary-dark'
                 @size='small'
                 @disabled={{this.displayRoomError}}
                 {{on 'click' this.displayPastSessions}}
                 data-test-past-sessions-button
               >
-                Past Sessions
+                All Sessions
                 <DropdownArrowFilled width='10' height='10' />
+
               </Button>
             {{/if}}
           </div>
@@ -257,8 +275,61 @@ export default class AiAssistantPanel extends Component<Signature> {
         --icon-color: var(--boxel-light);
         margin-left: var(--boxel-sp-xs);
       }
+
+      .past-sessions-button-active::before {
+        content: '';
+        position: absolute;
+        top: -105px;
+        left: -55px;
+        width: 250px;
+        height: 250px;
+        background: conic-gradient(
+          #ffcc8f 0deg,
+          #ff3966 45deg,
+          #ff309e 90deg,
+          #aa1dc9 135deg,
+          #d7fad6 180deg,
+          #5fdfea 225deg,
+          #3d83f2 270deg,
+          #5145e8 315deg,
+          #ffcc8f 360deg
+        );
+        z-index: -1;
+        animation: spin 4s infinite linear;
+      }
+
+      .past-sessions-button-active::after {
+        content: '';
+        position: absolute;
+        top: 1px;
+        left: 1px;
+        right: 1px;
+        bottom: 1px;
+        background: #272330;
+        border-radius: inherit;
+        z-index: -1;
+      }
+
+      .past-sessions-button-active {
+        position: relative;
+        display: inline-block;
+        border-radius: 3rem;
+        color: white;
+        background: #272330;
+        border: none;
+        cursor: pointer;
+        z-index: 1;
+        overflow: hidden;
+      }
+
       .loading-new-session {
         padding: var(--boxel-sp);
+      }
+
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
       }
     </style>
   </template>

--- a/packages/host/app/components/ai-assistant/panel.gts
+++ b/packages/host/app/components/ai-assistant/panel.gts
@@ -315,7 +315,7 @@ export default class AiAssistantPanel extends Component<Signature> {
         left: 1px;
         right: 1px;
         bottom: 1px;
-        background: #272330;
+        background: var(--boxel-700);
         border-radius: inherit;
         z-index: -1;
       }
@@ -325,7 +325,7 @@ export default class AiAssistantPanel extends Component<Signature> {
         display: inline-block;
         border-radius: 3rem;
         color: white;
-        background: #272330;
+        background: var(--boxel-700);
         border: none;
         cursor: pointer;
         z-index: 1;

--- a/packages/host/app/components/ai-assistant/past-session-item.gts
+++ b/packages/host/app/components/ai-assistant/past-session-item.gts
@@ -17,6 +17,7 @@ import {
   IconPencil,
   IconTrash,
   ThreeDotsHorizontal,
+  IconCircle,
 } from '@cardstack/boxel-ui/icons';
 
 import type MatrixService from '@cardstack/host/services/matrix-service';
@@ -32,6 +33,7 @@ export type RoomActions = {
 interface Signature {
   Args: {
     room: RoomField;
+    currentRoomId?: string;
     actions: RoomActions;
   };
 }
@@ -45,8 +47,32 @@ export default class PastSessionItem extends Component<Signature> {
         data-test-enter-room={{@room.roomId}}
       >
         <div class='name'>{{@room.name}}</div>
-        <div class='date' data-test-last-active={{this.lastActive}}>
-          {{this.formattedDate}}
+        <div
+          class='date
+            {{if this.isStreaming "is-streaming"}}
+            {{if this.hasUnseenMessage "has-unseen-message"}}'
+          data-test-last-active={{this.lastActive}}
+          data-test-is-streaming={{this.isStreaming}}
+          data-test-is-unseen-message={{this.hasUnseenMessage}}
+        >
+          {{#if this.isStreaming}}
+            <IconCircle
+              width='12px'
+              height='12px'
+              class='icon-recency-indicator icon-streaming pulsing'
+            />
+            Thinking…
+          {{else if this.hasUnseenMessage}}
+            <IconCircle
+              width='10px'
+              height='10px'
+              class='icon-recency-indicator icon-new-messages'
+            />
+            Updated
+            {{this.formattedDate}}
+          {{else}}
+            {{this.formattedDate}}
+          {{/if}}
         </div>
       </button>
       <BoxelDropdown>
@@ -85,6 +111,11 @@ export default class PastSessionItem extends Component<Signature> {
     </li>
 
     <style>
+      :global(:root) {
+        --color-streaming: #01c6bf;
+        --color-new-messages: #00ad4a;
+      }
+
       .session {
         display: flex;
         align-items: center;
@@ -126,6 +157,40 @@ export default class PastSessionItem extends Component<Signature> {
       .menu :deep(.boxel-menu__item:nth-child(2) svg) {
         --icon-stroke-width: 0.5px;
       }
+      .icon-recency-indicator {
+        display: inline-block;
+        margin-right: 4px;
+      }
+      .icon-streaming {
+        --icon-color: var(--color-streaming);
+      }
+      .icon-new-messages {
+        --icon-color: var(--color-new-messages);
+        --icon-fill-color: var(--color-new-messages);
+      }
+      .has-unseen-message {
+        color: var(--color-new-messages);
+      }
+      .is-streaming {
+        color: var(--color-streaming);
+      }
+      .pulsing {
+        animation: pulse 2s infinite;
+      }
+      @keyframes pulse {
+        0% {
+          transform: scale(1);
+          opacity: 1;
+        }
+        50% {
+          transform: scale(0.2);
+          opacity: 0.7;
+        }
+        100% {
+          transform: scale(1);
+          opacity: 1;
+        }
+      }
     </style>
   </template>
 
@@ -138,6 +203,26 @@ export default class PastSessionItem extends Component<Signature> {
       return new Date();
     }
     return this.args.room.created;
+  }
+
+  get lastSessionMessage() {
+    return this.args.room.messages[this.args.room.messages.length - 1];
+  }
+
+  get isStreaming() {
+    if (!this.lastSessionMessage) {
+      return false;
+    }
+    return !this.lastSessionMessage.isStreamingFinished;
+  }
+
+  get hasUnseenMessage() {
+    if (!this.lastSessionMessage) {
+      return false;
+    }
+    return !this.matrixService.currentUserEventReadReceipts.has(
+      this.lastSessionMessage.eventId,
+    );
   }
 
   private get lastActive() {

--- a/packages/host/app/components/ai-assistant/past-sessions.gts
+++ b/packages/host/app/components/ai-assistant/past-sessions.gts
@@ -13,6 +13,7 @@ interface Signature {
   Args: {
     sessions: RoomField[];
     roomActions: RoomActions;
+    currentRoomId?: string;
     onClose: () => void;
   };
   Element: HTMLElement;
@@ -39,7 +40,11 @@ const AiAssistantPastSessionsList: TemplateOnlyComponent<Signature> = <template>
       {{#if @sessions}}
         <ul class='past-sessions'>
           {{#each @sessions as |session|}}
-            <PastSessionItem @room={{session}} @actions={{@roomActions}} />
+            <PastSessionItem
+              @room={{session}}
+              @actions={{@roomActions}}
+              @currentRoomId={{@currentRoomId}}
+            />
           {{/each}}
         </ul>
       {{else}}

--- a/packages/host/app/components/ai-assistant/past-sessions.gts
+++ b/packages/host/app/components/ai-assistant/past-sessions.gts
@@ -25,7 +25,7 @@ const AiAssistantPastSessionsList: TemplateOnlyComponent<Signature> = <template>
     ...attributes
   >
     <:header>
-      Past Sessions
+      All Sessions
       <IconButton
         @icon={{DropdownArrowFilled}}
         @width='12px'

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -48,6 +48,7 @@ export default class Room extends Component<Signature> {
         <AiAssistantConversation>
           {{#each this.room.messages as |message i|}}
             <RoomMessage
+              @room={{this.room}}
               @roomId={{@roomId}}
               @message={{message}}
               @index={{i}}

--- a/packages/host/app/lib/matrix-handlers/index.ts
+++ b/packages/host/app/lib/matrix-handlers/index.ts
@@ -56,6 +56,7 @@ export interface Context extends EventSendingContext {
     event: Event,
     roomId: string,
   ) => Promise<void>;
+  addEventReadReceipt(eventId: string, receipt: { readAt: Date }): void;
 }
 
 export async function addRoomEvent(context: EventSendingContext, event: Event) {

--- a/packages/host/app/lib/matrix-handlers/timeline.ts
+++ b/packages/host/app/lib/matrix-handlers/timeline.ts
@@ -16,6 +16,19 @@ import {
   updateRoomEvent,
 } from './index';
 
+export function onReceipt(context: Context) {
+  return async (e: MatrixEvent) => {
+    let userId = context.client.credentials.userId!;
+    let eventIds = Object.keys(e.getContent());
+    for (let eventId of eventIds) {
+      let receipt = e.getContent()[eventId]['m.read'][userId];
+      if (receipt) {
+        context.addEventReadReceipt(eventId, { readAt: receipt.ts });
+      }
+    }
+  };
+}
+
 export function onTimeline(context: Context) {
   return (e: MatrixEvent) => {
     context.timelineQueue.push({ event: e });

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -93,10 +93,16 @@ export default class MatrixService extends Service {
   #ready: Promise<void>;
   #matrixSDK: typeof MatrixSDK | undefined;
   #eventBindings: [EmittedEvents, (...arg: any[]) => void][] | undefined;
+  currentUserEventReadReceipts: TrackedMap<string, { readAt: Date }> =
+    new TrackedMap();
 
   constructor(owner: Owner) {
     super(owner);
     this.#ready = this.loadSDK.perform();
+  }
+
+  addEventReadReceipt(eventId: string, receipt: { readAt: Date }) {
+    this.currentUserEventReadReceipts.set(eventId, receipt);
   }
 
   get ready() {
@@ -135,6 +141,7 @@ export default class MatrixService extends Service {
         this.matrixSDK.RoomEvent.LocalEchoUpdated,
         Timeline.onUpdateEventStatus(this),
       ],
+      [this.matrixSDK.RoomEvent.Receipt, Timeline.onReceipt(this)],
     ];
   });
 

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -2109,6 +2109,12 @@ module('Integration | operator-mode', function (hooks) {
           'Answer to my current question is in progress',
         );
 
+      await click('[data-test-past-sessions-button]');
+      assert
+        .dom("[data-test-enter-room='New AI Assistant Chat']")
+        .includesText('Thinking');
+      assert.dom('[data-test-is-streaming]').exists();
+
       await addRoomEvent(matrixService, {
         event_id: 'event4',
         room_id: roomId,
@@ -2148,6 +2154,11 @@ module('Integration | operator-mode', function (hooks) {
           'ai-avatar-animated',
           'Answer to my last question is not in progress',
         );
+
+      assert
+        .dom("[data-test-enter-room='New AI Assistant Chat']")
+        .doesNotContainText('Thinking');
+      assert.dom('[data-test-is-streaming]').doesNotExist();
     });
 
     test('it does not display the streaming indicator when ai bot sends an option', async function (assert) {
@@ -2199,6 +2210,153 @@ module('Integration | operator-mode', function (hooks) {
           'ai-avatar-animated',
           'ai bot patch message does not have a spinner',
         );
+    });
+
+    test('it animates the sessions dropdown button when there are other sessions that have activity which was not seen by the user yet', async function (assert) {
+      await setCardInOperatorModeState();
+      await renderComponent(
+        class TestDriver extends GlimmerComponent {
+          <template>
+            <OperatorMode @onClose={{noop}} />
+            <CardPrerender />
+          </template>
+        },
+      );
+      let roomId = await openAiAssistant();
+
+      await addRoomEvent(matrixService, {
+        event_id: 'event0',
+        room_id: roomId,
+        state_key: 'state',
+        type: 'm.room.message',
+        sender: '@matic:boxel',
+        content: {
+          body: 'Say one word.',
+          msgtype: 'org.boxel.message',
+          formatted_body: 'Say one word.',
+          format: 'org.matrix.custom.html',
+        },
+        origin_server_ts: Date.now() - 100,
+        unsigned: {
+          age: 105,
+          transaction_id: '1',
+        },
+        status: null,
+      });
+
+      await addRoomEvent(matrixService, {
+        event_id: 'event1',
+        room_id: roomId,
+        state_key: 'state',
+        type: 'm.room.message',
+        sender: '@aibot:localhost',
+        content: {
+          body: 'Word.',
+          msgtype: 'm.text',
+          formatted_body: 'Word.',
+          format: 'org.matrix.custom.html',
+          isStreamingFinished: true,
+        },
+        origin_server_ts: Date.now() - 99,
+        unsigned: {
+          age: 105,
+          transaction_id: '1',
+        },
+        status: null,
+      });
+
+      assert
+        .dom('[data-test-past-sessions-button] [data-test-has-active-sessions]')
+        .doesNotExist();
+      assert
+        .dom(
+          "[data-test-enter-room='New AI Assistant Chat'] [data-test-is-streaming]",
+        )
+        .doesNotExist();
+
+      // Create a new room with some activity (this could happen when we will have a feature that interacts with AI outside of the AI pannel, i.e. "commands")
+
+      let anotherRoomId = await matrixService.createAndJoinRoom('Another Room');
+
+      await addRoomEvent(matrixService, {
+        event_id: 'event2',
+        room_id: anotherRoomId,
+        state_key: 'state',
+        type: 'm.room.message',
+        sender: '@aibot:localhost',
+        content: {
+          body: 'I sent a message from the background.',
+          msgtype: 'm.text',
+          formatted_body: 'Word.',
+          format: 'org.matrix.custom.html',
+          isStreamingFinished: true,
+        },
+        origin_server_ts: Date.now() - 98,
+        unsigned: {
+          age: 105,
+          transaction_id: '1',
+        },
+        status: null,
+      });
+
+      await waitFor('[data-test-has-active-sessions]');
+
+      assert
+        .dom('[data-test-past-sessions-button][data-test-has-active-sessions]')
+        .exists("'All Sessions button' is animated");
+
+      await click('[data-test-past-sessions-button]');
+
+      assert
+        .dom(
+          "[data-test-joined-room='Another Room'] [data-test-is-unseen-message]",
+        )
+        .exists('Newly created room has an unseen message');
+
+      assert
+        .dom(
+          "[data-test-joined-room='Another Room'] [data-test-is-unseen-message]",
+        )
+        .containsText('Updated');
+
+      assert
+        .dom(
+          "[data-test-joined-room='New AI Assistant Chat'][data-test-is-unseen-message]",
+        )
+        .doesNotExist("Old room doesn't have an unseen message");
+
+      assert
+        .dom("[data-test-joined-room='New AI Assistant Chat']")
+        .doesNotContainText('Updated');
+
+      await click("[data-test-enter-room='Another Room']");
+      assert
+        .dom(
+          "[data-test-joined-room='Another Room'] [data-test-is-unseen-message]",
+        )
+        .doesNotExist(
+          "Newly created room doesn't have an unseen message because we just opened it and saw the message",
+        );
+      assert
+        .dom(
+          "[data-test-joined-room='New AI Assistant'] [data-test-is-unseen-message]",
+        )
+        .doesNotExist("Old room doesn't have an unseen message");
+
+      assert
+        .dom('[data-test-past-sessions-button][data-test-has-active-sessions]')
+        .doesNotExist(
+          "'All Sessions button' is not animated anymore because the other active session was seen",
+        );
+
+      await click('[data-test-past-sessions-button]');
+
+      assert
+        .dom("[data-test-joined-room='New AI Assistant Chat']")
+        .doesNotContainText('Updated');
+      assert
+        .dom("[data-test-joined-room='Another Room']")
+        .doesNotContainText('Updated');
     });
 
     test('it can retry a message when receiving an error from the AI bot', async function (assert) {

--- a/packages/host/tests/integration/components/room-message-test.gts
+++ b/packages/host/tests/integration/components/room-message-test.gts
@@ -29,6 +29,7 @@ module('Integration | Component | RoomMessage', function (hooks) {
     let testScenario = {
       message,
       isStreaming,
+      room: { messages: [message] },
       monacoSDK: {},
       currentEditor: {},
       setCurrentMonacoContainer: null,
@@ -48,6 +49,7 @@ module('Integration | Component | RoomMessage', function (hooks) {
         @currentEditor={{testScenario.currentEditor}}
         @setCurrentEditor={{testScenario.setCurrentMonacoContainer}}
         @retryAction={{testScenario.maybeRetryAction}}
+        @room={{testScenario.room}}
         data-test-message-idx='1'
       />
     </template>);


### PR DESCRIPTION
1. "Past Sessions" button in the AI panel is now "All Sessions"


2. The button gets an animated indicator when there are other active sessions (active means they had a new AI bot message in the last minute) whose content wasn't seen yet by the user. This is a preparatory feature for when we'll have "commands" where AI activity could be spawned from places other than the AI panel. This indicator is useful for users to see they have new active sessions with bot activity when AI activity will be triggered from cards, for example (when we'll have the commands feature)

Button treatment (animated glow when there are other active and unseen sessions):


![animated-button](https://github.com/cardstack/boxel/assets/273660/ae912aed-b928-4ea7-9d16-eeef478767ac)

3. Recency indicators in the sessions list 

- "Thinking" when bot is streaming in another room
- "Updated" when there is unseen content in another room


![recency-indicators](https://github.com/cardstack/boxel/assets/273660/303198b8-abdf-4935-bb7b-005f5c092075)


