### PR TITLE
Fix infinite loading spinner issue when updating chess card through ai bot apply button

### DIFF
--- a/packages/drafts-realm/chess-game.gts
+++ b/packages/drafts-realm/chess-game.gts
@@ -470,12 +470,6 @@ class Isolated extends BoxelComponent<typeof Chess> {
   </template>
 }
 
-class PgnFieldView extends BoxelComponent<typeof PgnField> {
-  <template>
-    {{@model}}
-  </template>
-}
-
 class PgnField extends FieldDef {
   static [primitive]: string;
   static displayName = 'PGN';
@@ -493,16 +487,11 @@ class PgnField extends FieldDef {
     return pgn as BaseInstanceType<T>;
   }
 
-  static embedded = PgnFieldView;
-  static atom = PgnFieldView;
-
   static edit = class Edit extends BoxelComponent<typeof this> {
     <template>
       <BoxelInput
-        type='date'
         @value={{@model}}
         @onInput={{@set}}
-        @max='9999-12-31'
         @disabled={{not @canEdit}}
       />
     </template>


### PR DESCRIPTION
Based on a pairing session with @ef4, it is expected that a card should have a proper way to validate the input value when deserializing it. To address this issue, I created a `PgnField` to check the PGN string value during deserialization.

https://github.com/cardstack/boxel/assets/12637010/026be87f-1d5f-4dba-ba6e-875457b1dc07


