### PR TITLE
Can patch nested linked fields via AI Assistant Panel

### DIFF
--- a/packages/drafts-realm/TripInfo/2d7badfc-484c-40c3-a65b-45f4513a77d6.json
+++ b/packages/drafts-realm/TripInfo/2d7badfc-484c-40c3-a65b-45f4513a77d6.json
@@ -29,7 +29,17 @@
       },
       "traveler.nextTravelGoal.country": {
         "links": {
+          "self": "http://localhost:4201/drafts/Country/argentina"
+        }
+      },
+      "traveler.nextTravelGoal.alternateTrips.0": {
+        "links": {
           "self": "http://localhost:4201/drafts/Country/brazil"
+        }
+      },
+      "traveler.nextTravelGoal.alternateTrips.1": {
+        "links": {
+          "self": "http://localhost:4201/drafts/Country/2"
         }
       },
       "startLocation": {

--- a/packages/drafts-realm/TripInfo/2d7badfc-484c-40c3-a65b-45f4513a77d6.json
+++ b/packages/drafts-realm/TripInfo/2d7badfc-484c-40c3-a65b-45f4513a77d6.json
@@ -3,7 +3,10 @@
     "type": "card",
     "attributes": {
       "traveler": {
-        "name": "Marcelius Wilde"
+        "name": "Marcelius Wilde",
+        "nextTravelGoal": {
+          "goalTitle": "Summer '25"
+        }
       },
       "description": null,
       "thumbnailURL": null
@@ -22,6 +25,11 @@
       "traveler.countriesVisited.0": {
         "links": {
           "self": "http://localhost:4201/drafts/Country/4"
+        }
+      },
+      "traveler.nextTravelGoal.country": {
+        "links": {
+          "self": "http://localhost:4201/drafts/Country/brazil"
         }
       },
       "startLocation": {

--- a/packages/drafts-realm/TripInfo/a32d7aae-dd43-4dd5-b399-e62ab2e7d412.json
+++ b/packages/drafts-realm/TripInfo/a32d7aae-dd43-4dd5-b399-e62ab2e7d412.json
@@ -3,7 +3,10 @@
     "type": "card",
     "attributes": {
       "traveler": {
-        "name": "Mickey"
+        "name": "Mickey",
+        "nextTravelGoal": {
+          "goalTitle": null
+        }
       },
       "description": null,
       "thumbnailURL": null
@@ -22,6 +25,21 @@
       "traveler.countriesVisited": {
         "links": {
           "self": null
+        }
+      },
+      "traveler.nextTravelGoal.country": {
+        "links": {
+          "self": "http://localhost:4201/drafts/Country/2"
+        }
+      },
+      "traveler.nextTravelGoal.alternateTrips.0": {
+        "links": {
+          "self": "http://localhost:4201/drafts/Country/argentina"
+        }
+      },
+      "traveler.nextTravelGoal.alternateTrips.1": {
+        "links": {
+          "self": "http://localhost:4201/drafts/Country/brazil"
         }
       },
       "startLocation": {

--- a/packages/drafts-realm/trip-info.gts
+++ b/packages/drafts-realm/trip-info.gts
@@ -15,14 +15,18 @@ class TravelGoal extends FieldDef {
   static displayName = 'Travel Goal';
   @field goalTitle = contains(StringField);
   @field country = linksTo(Country);
+  @field alternateTrips = linksToMany(Country);
   static embedded = class Embedded extends Component<typeof this> {
     <template>
-      <CardContainer class="container">
+      <CardContainer class='container'>
         <FieldContainer @label='Goal Title'>
           <@fields.goalTitle />
         </FieldContainer>
         <FieldContainer @label='Country'>
           <@fields.country />
+        </FieldContainer>
+        <FieldContainer @label='Alternate Trips'>
+          <@fields.alternateTrips />
         </FieldContainer>
       </CardContainer>
       <style>
@@ -35,7 +39,7 @@ class TravelGoal extends FieldDef {
         }
       </style>
     </template>
-  }
+  };
 }
 
 class Traveler extends FieldDef {
@@ -92,7 +96,6 @@ export class TripInfo extends CardDef {
   });
   @field startLocation = linksTo(Country);
   @field endLocation = linksTo(Country);
-
   /*
   static isolated = class Isolated extends Component<typeof this> {
     <template></template>

--- a/packages/drafts-realm/trip-info.gts
+++ b/packages/drafts-realm/trip-info.gts
@@ -8,14 +8,42 @@ import {
   linksToMany,
 } from 'https://cardstack.com/base/card-api';
 import { Component } from 'https://cardstack.com/base/card-api';
-import { FieldContainer } from '@cardstack/boxel-ui/components';
+import { CardContainer, FieldContainer } from '@cardstack/boxel-ui/components';
 import { Country } from './country';
+
+class TravelGoal extends FieldDef {
+  static displayName = 'Travel Goal';
+  @field goalTitle = contains(StringField);
+  @field country = linksTo(Country);
+  static embedded = class Embedded extends Component<typeof this> {
+    <template>
+      <CardContainer class="container">
+        <FieldContainer @label='Goal Title'>
+          <@fields.goalTitle />
+        </FieldContainer>
+        <FieldContainer @label='Country'>
+          <@fields.country />
+        </FieldContainer>
+      </CardContainer>
+      <style>
+        .container {
+          padding: 20px;
+          background-color: whitesmoke;
+        }
+        .container > * + * {
+          margin-top: 20px;
+        }
+      </style>
+    </template>
+  }
+}
 
 class Traveler extends FieldDef {
   static displayName = 'Traveler';
   @field name = contains(StringField);
   @field countryOfOrigin = linksTo(Country);
   @field countriesVisited = linksToMany(Country);
+  @field nextTravelGoal = contains(TravelGoal);
 
   static embedded = class Embedded extends Component<typeof this> {
     <template>
@@ -36,6 +64,9 @@ class Traveler extends FieldDef {
           {{else}}
             Unknown
           {{/if}}
+        </FieldContainer>
+        <FieldContainer @label='Next Travel Goal' @vertical={{true}}>
+          <@fields.nextTravelGoal />
         </FieldContainer>
       </div>
       <style>

--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -260,14 +260,15 @@ export default class CardService extends Service {
     for (let [field, value] of Object.entries(linkedCards)) {
       if (field.includes('.')) {
         let parts = field.split('.');
-        let maybeIndex = Number(parts.pop());
-        if (isNaN(maybeIndex) || parts.length > 1) {
-          // TODO nested linksTo or nested linksToMany [cs-6799]
-          throw new Error('Not implemented.');
-        } else {
-          let fieldName = parts.join('.');
-          (card as any)[fieldName][maybeIndex] = value;
+        let leaf = parts.pop();
+        if (!leaf) {
+          throw new Error(`bug: error in field name "${field}"`);
         }
+        let inner = card;
+        for (let part of parts) {
+          inner = (inner as any)[part];
+        }
+        (inner as any)[leaf.match(/^\d+$/) ? Number(leaf) : leaf] = value;
       } else {
         // TODO this could trigger a save. perhaps instead we could
         // introduce a new option to updateFromSerialized to accept a list of

--- a/packages/host/tests/unit/ai-function-generation-test.ts
+++ b/packages/host/tests/unit/ai-function-generation-test.ts
@@ -8,6 +8,7 @@ import { baseRealm } from '@cardstack/runtime-common';
 import {
   generateCardPatchCallSpecification,
   basicMappings,
+  type LinksToSchema,
   type RelationshipSchema,
   type RelationshipsSchema,
   type ObjectSchema,
@@ -104,11 +105,16 @@ module('Unit | ai-function-generation-test', function (hooks) {
   });
 
   test(`generates a simple compliant schema for nested types`, async function (assert) {
-    let { field, contains, CardDef, FieldDef } = cardApi;
+    let { field, contains, linksTo, linksToMany, CardDef, FieldDef } = cardApi;
     let { default: StringField } = string;
 
+    class InnerCard extends CardDef {
+      @field name = contains(StringField);
+    }
     class InternalField extends FieldDef {
       @field innerStringField = contains(StringField);
+      @field linkedCard = linksTo(InnerCard);
+      @field linkedCards = linksToMany(InnerCard);
     }
     class BasicCard extends CardDef {
       @field containerField = contains(InternalField);
@@ -119,6 +125,13 @@ module('Unit | ai-function-generation-test', function (hooks) {
       cardApi,
       mappings,
     );
+    const links: LinksToSchema['properties']['links'] = {
+      type: 'object',
+      properties: {
+        self: { type: 'string' },
+      },
+      required: ['self'],
+    };
     assert.deepEqual(schema, {
       attributes: {
         type: 'object',
@@ -133,6 +146,25 @@ module('Unit | ai-function-generation-test', function (hooks) {
             },
           },
         },
+      },
+      relationships: {
+        type: 'object',
+        properties: {
+          'containerField.linkedCard': {
+            type: 'object',
+            properties: { links },
+            required: ['links'],
+          },
+          'containerField.linkedCards': {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: { links },
+              required: ['links'],
+            },
+          },
+        },
+        required: ['containerField.linkedCard', 'containerField.linkedCards'],
       },
     });
   });
@@ -275,6 +307,79 @@ module('Unit | ai-function-generation-test', function (hooks) {
       required: ['linkedCards'],
     };
     assert.deepEqual(schema, { attributes, relationships });
+  });
+
+  test(`supports deeply nested fields`, async function (assert) {
+    let { field, contains, linksTo, CardDef, FieldDef } = cardApi;
+    let { default: StringField } = string;
+
+    class PetCard extends CardDef {
+      @field name = contains(StringField);
+    }
+    class FriendField extends FieldDef {
+      @field name = contains(StringField);
+      @field pet = linksTo(PetCard);
+    }
+    class ChildField extends FieldDef {
+      @field name = contains(StringField);
+      @field friend = contains(FriendField);
+    }
+    class ParentCard extends CardDef {
+      @field name = contains(StringField);
+      @field child = contains(ChildField);
+    }
+
+    let schema = generateCardPatchCallSpecification(
+      ParentCard,
+      cardApi,
+      mappings,
+    );
+
+    let attributes: ObjectSchema = {
+      type: 'object',
+      properties: {
+        title: { type: 'string' },
+        description: { type: 'string' },
+        thumbnailURL: { type: 'string' },
+        name: { type: 'string' },
+        child: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            friend: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+              },
+            },
+          },
+        },
+      },
+    };
+    let linkedRelationship: RelationshipSchema = {
+      type: 'object',
+      properties: {
+        links: {
+          type: 'object',
+          properties: {
+            self: { type: 'string' },
+          },
+          required: ['self'],
+        },
+      },
+      required: ['links'],
+    };
+    let relationships: RelationshipsSchema = {
+      type: 'object',
+      properties: {
+        'child.friend.pet': linkedRelationship,
+      },
+      required: ['child.friend.pet'],
+    };
+    assert.deepEqual(schema, {
+      attributes,
+      relationships,
+    });
   });
 
   test(`skips over fields that can't be recognised`, async function (assert) {
@@ -420,13 +525,23 @@ module('Unit | ai-function-generation-test', function (hooks) {
   });
 
   test(`supports descriptions on nested fields`, async function (assert) {
-    let { field, contains, CardDef, FieldDef } = cardApi;
+    let { field, contains, linksTo, linksToMany, CardDef, FieldDef } = cardApi;
     let { default: StringField } = string;
-
+    class InnerCard extends CardDef {
+      @field name = contains(StringField);
+    }
     class InternalField extends FieldDef {
       @field innerStringField = contains(StringField, {
         description: 'Desc #2',
       });
+      @field linkedCard = linksTo(InnerCard, {
+        description: 'Desc #3',
+      });
+      @field linkedCard2 = linksTo(InnerCard);
+      @field linkedCards = linksToMany(InnerCard, {
+        description: 'Desc #4',
+      });
+      @field linkedCards2 = linksToMany(InnerCard);
     }
     class BasicCard extends CardDef {
       @field containerField = contains(InternalField, {
@@ -439,6 +554,13 @@ module('Unit | ai-function-generation-test', function (hooks) {
       cardApi,
       mappings,
     );
+    const links: LinksToSchema['properties']['links'] = {
+      type: 'object',
+      properties: {
+        self: { type: 'string' },
+      },
+      required: ['self'],
+    };
     assert.deepEqual(schema, {
       attributes: {
         type: 'object',
@@ -454,6 +576,45 @@ module('Unit | ai-function-generation-test', function (hooks) {
             },
           },
         },
+      },
+      relationships: {
+        type: 'object',
+        properties: {
+          'containerField.linkedCard': {
+            type: 'object',
+            description: 'Desc #3',
+            properties: { links },
+            required: ['links'],
+          },
+          'containerField.linkedCard2': {
+            type: 'object',
+            properties: { links },
+            required: ['links'],
+          },
+          'containerField.linkedCards': {
+            type: 'array',
+            description: 'Desc #4',
+            items: {
+              type: 'object',
+              properties: { links },
+              required: ['links'],
+            },
+          },
+          'containerField.linkedCards2': {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: { links },
+              required: ['links'],
+            },
+          },
+        },
+        required: [
+          'containerField.linkedCard',
+          'containerField.linkedCard2',
+          'containerField.linkedCards',
+          'containerField.linkedCards2',
+        ],
       },
     });
   });

--- a/packages/host/tests/unit/ai-function-generation-test.ts
+++ b/packages/host/tests/unit/ai-function-generation-test.ts
@@ -169,90 +169,6 @@ module('Unit | ai-function-generation-test', function (hooks) {
     });
   });
 
-  test(`generates correct schema for complex nested card`, async function (assert) {
-    let { field, contains, linksTo, linksToMany, CardDef, FieldDef } = cardApi;
-    let { default: StringField } = string;
-    class Country extends CardDef {
-      @field name = contains(StringField);
-    }
-    class TravelGoal extends FieldDef {
-      @field goalTitle = contains(StringField);
-      @field country = linksTo(Country);
-    }
-    class Traveler extends FieldDef {
-      @field name = contains(StringField);
-      @field countryOfOrigin = linksTo(Country);
-      @field countriesVisited = linksToMany(Country);
-      @field nextTravelGoal = contains(TravelGoal);
-    }
-    class TripInfo extends CardDef {
-      @field traveler = contains(Traveler);
-    }
-
-    let schema = generateCardPatchCallSpecification(
-      TripInfo,
-      cardApi,
-      mappings,
-    );
-    const links: LinksToSchema['properties']['links'] = {
-      type: 'object',
-      properties: {
-        self: { type: 'string' },
-      },
-      required: ['self'],
-    };
-    assert.deepEqual(schema, {
-      attributes: {
-        type: 'object',
-        properties: {
-          thumbnailURL: { type: 'string' },
-          title: { type: 'string' },
-          description: { type: 'string' },
-          traveler: {
-            type: 'object',
-            properties: {
-              name: { type: 'string' },
-              nextTravelGoal: {
-                type: 'object',
-                properties: {
-                  goalTitle: { type: 'string' },
-                },
-              },
-            },
-          },
-        },
-      },
-      relationships: {
-        type: 'object',
-        properties: {
-          'traveler.countryOfOrigin': {
-            type: 'object',
-            properties: { links },
-            required: ['links'],
-          },
-          'traveler.countriesVisited': {
-            type: 'array',
-            items: {
-              type: 'object',
-              properties: { links },
-              required: ['links'],
-            },
-          },
-          'traveler.nextTravelGoal.country': {
-            type: 'object',
-            properties: { links },
-            required: ['links'],
-          },
-        },
-        required: [
-          'traveler.countryOfOrigin',
-          'traveler.countriesVisited',
-          'traveler.nextTravelGoal.country',
-        ],
-      },
-    });
-  });
-
   test(`should support contains many`, async function (assert) {
     let { field, contains, containsMany, CardDef, FieldDef } = cardApi;
     let { default: StringField } = string;
@@ -463,6 +379,90 @@ module('Unit | ai-function-generation-test', function (hooks) {
     assert.deepEqual(schema, {
       attributes,
       relationships,
+    });
+  });
+
+  test(`generates correct schema for nested linksTo and linksToMany fields`, async function (assert) {
+    let { field, contains, linksTo, linksToMany, CardDef, FieldDef } = cardApi;
+    let { default: StringField } = string;
+    class Country extends CardDef {
+      @field name = contains(StringField);
+    }
+    class TravelGoal extends FieldDef {
+      @field goalTitle = contains(StringField);
+      @field country = linksTo(Country);
+    }
+    class Traveler extends FieldDef {
+      @field name = contains(StringField);
+      @field countryOfOrigin = linksTo(Country);
+      @field countriesVisited = linksToMany(Country);
+      @field nextTravelGoal = contains(TravelGoal);
+    }
+    class TripInfo extends CardDef {
+      @field traveler = contains(Traveler);
+    }
+
+    let schema = generateCardPatchCallSpecification(
+      TripInfo,
+      cardApi,
+      mappings,
+    );
+    const links: LinksToSchema['properties']['links'] = {
+      type: 'object',
+      properties: {
+        self: { type: 'string' },
+      },
+      required: ['self'],
+    };
+    assert.deepEqual(schema, {
+      attributes: {
+        type: 'object',
+        properties: {
+          thumbnailURL: { type: 'string' },
+          title: { type: 'string' },
+          description: { type: 'string' },
+          traveler: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              nextTravelGoal: {
+                type: 'object',
+                properties: {
+                  goalTitle: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+      },
+      relationships: {
+        type: 'object',
+        properties: {
+          'traveler.countryOfOrigin': {
+            type: 'object',
+            properties: { links },
+            required: ['links'],
+          },
+          'traveler.countriesVisited': {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: { links },
+              required: ['links'],
+            },
+          },
+          'traveler.nextTravelGoal.country': {
+            type: 'object',
+            properties: { links },
+            required: ['links'],
+          },
+        },
+        required: [
+          'traveler.countryOfOrigin',
+          'traveler.countriesVisited',
+          'traveler.nextTravelGoal.country',
+        ],
+      },
     });
   });
 

--- a/packages/host/tests/unit/ai-function-generation-test.ts
+++ b/packages/host/tests/unit/ai-function-generation-test.ts
@@ -169,6 +169,90 @@ module('Unit | ai-function-generation-test', function (hooks) {
     });
   });
 
+  test(`generates correct schema for complex nested card`, async function (assert) {
+    let { field, contains, linksTo, linksToMany, CardDef, FieldDef } = cardApi;
+    let { default: StringField } = string;
+    class Country extends CardDef {
+      @field name = contains(StringField);
+    }
+    class TravelGoal extends FieldDef {
+      @field goalTitle = contains(StringField);
+      @field country = linksTo(Country);
+    }
+    class Traveler extends FieldDef {
+      @field name = contains(StringField);
+      @field countryOfOrigin = linksTo(Country);
+      @field countriesVisited = linksToMany(Country);
+      @field nextTravelGoal = contains(TravelGoal);
+    }
+    class TripInfo extends CardDef {
+      @field traveler = contains(Traveler);
+    }
+
+    let schema = generateCardPatchCallSpecification(
+      TripInfo,
+      cardApi,
+      mappings,
+    );
+    const links: LinksToSchema['properties']['links'] = {
+      type: 'object',
+      properties: {
+        self: { type: 'string' },
+      },
+      required: ['self'],
+    };
+    assert.deepEqual(schema, {
+      attributes: {
+        type: 'object',
+        properties: {
+          thumbnailURL: { type: 'string' },
+          title: { type: 'string' },
+          description: { type: 'string' },
+          traveler: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              nextTravelGoal: {
+                type: 'object',
+                properties: {
+                  goalTitle: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+      },
+      relationships: {
+        type: 'object',
+        properties: {
+          'traveler.countryOfOrigin': {
+            type: 'object',
+            properties: { links },
+            required: ['links'],
+          },
+          'traveler.countriesVisited': {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: { links },
+              required: ['links'],
+            },
+          },
+          'traveler.nextTravelGoal.country': {
+            type: 'object',
+            properties: { links },
+            required: ['links'],
+          },
+        },
+        required: [
+          'traveler.countryOfOrigin',
+          'traveler.countriesVisited',
+          'traveler.nextTravelGoal.country',
+        ],
+      },
+    });
+  });
+
   test(`should support contains many`, async function (assert) {
     let { field, contains, containsMany, CardDef, FieldDef } = cardApi;
     let { default: StringField } = string;

--- a/packages/runtime-common/helpers/ai.ts
+++ b/packages/runtime-common/helpers/ai.ts
@@ -295,7 +295,7 @@ function generateRelationshipFieldsInfo(
     usedFieldsOnly: false,
   });
   for (let [fName, fValue] of Object.entries(fields)) {
-    let flatFieldName = fieldName ? `${fieldName}\.${fName}` : fName;
+    let flatFieldName = fieldName ? `${fieldName}.${fName}` : fName;
     if (fValue.computeVia) {
       continue;
     } else if (


### PR DESCRIPTION
Can link/unlink existing cards to deeply nested linksTo and linksToMany fields via the ai-bot. Screenshots below are using the `TripInfo` card.

<img width="445" alt="1" src="https://github.com/cardstack/boxel/assets/16160806/e10b888b-d0b0-458f-a980-33c1d4b2a233">
<img width="438" alt="2" src="https://github.com/cardstack/boxel/assets/16160806/b402878e-3a82-4676-a776-d86016c272a9">
<img width="426" alt="3" src="https://github.com/cardstack/boxel/assets/16160806/9d086b4d-dfdf-4854-a80f-224e6b15e07d">
<img width="415" alt="4" src="https://github.com/cardstack/boxel/assets/16160806/78f63040-e9df-40f9-94b7-d470cdb44082">
<img width="538" alt="5" src="https://github.com/cardstack/boxel/assets/16160806/43054342-ec7a-4da3-9e2a-b1eb69bdd4c9">
<img width="540" alt="6" src="https://github.com/cardstack/boxel/assets/16160806/cde8f55c-e17f-437b-a720-579eb02457bc">
