### PR TITLE
fix bug where background style causes an /undefined fetch

### DIFF
--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -254,6 +254,9 @@ export default class InteractSubmode extends Component<Signature> {
     // only return a background image when both stacks originate from the same realm
     // otherwise we delegate to each stack to handle this
     let { hasDifferingBackgroundURLs } = this.stackBackgroundsState;
+    if (this.stackBackgroundsState.backgroundImageURLs.length === 0) {
+      return false;
+    }
     if (!hasDifferingBackgroundURLs) {
       return htmlSafe(
         `background-image: url(${this.stackBackgroundsState.backgroundImageURLs[0]});`,


### PR DESCRIPTION
@jurgenwerk did most of the work debugging here. It should be resolved with an early return

<img width="1495" alt="image" src="https://github.com/cardstack/boxel/assets/8165111/4db58b3a-79ee-4e26-9a05-ed6a33b83829">
