### PR TITLE
Add command result event

### DIFF
--- a/packages/ai-bot/helpers.ts
+++ b/packages/ai-bot/helpers.ts
@@ -6,6 +6,7 @@ import { MODIFY_SYSTEM_MESSAGE } from '@cardstack/runtime-common/helpers/ai';
 import type {
   MatrixEvent as DiscreteMatrixEvent,
   CardFragmentContent,
+  CommandEvent,
 } from 'https://cardstack.com/base/room';
 import { MatrixEvent, type IRoomEvent } from 'matrix-js-sdk';
 
@@ -276,3 +277,16 @@ export const isCommandReactionEvent = (event?: MatrixEvent) => {
     content['m.relates_to']?.key === 'applied'
   );
 };
+
+export function isCommandEvent(
+  event: DiscreteMatrixEvent,
+): event is CommandEvent {
+  return (
+    event.type === 'm.room.message' &&
+    typeof event.content === 'object' &&
+    event.content.msgtype === 'org.boxel.command' &&
+    event.content.format === 'org.matrix.custom.html' &&
+    typeof event.content.data === 'object' &&
+    typeof event.content.data.toolCall === 'object'
+  );
+}

--- a/packages/ai-bot/helpers.ts
+++ b/packages/ai-bot/helpers.ts
@@ -6,7 +6,6 @@ import { MODIFY_SYSTEM_MESSAGE } from '@cardstack/runtime-common/helpers/ai';
 import type {
   MatrixEvent as DiscreteMatrixEvent,
   CardFragmentContent,
-  CommandEvent,
 } from 'https://cardstack.com/base/room';
 import { MatrixEvent, type IRoomEvent } from 'matrix-js-sdk';
 
@@ -277,24 +276,3 @@ export const isCommandReactionEvent = (event?: MatrixEvent) => {
     content['m.relates_to']?.key === 'applied'
   );
 };
-
-export function isCommandEvent(
-  event: DiscreteMatrixEvent,
-): event is CommandEvent {
-  return (
-    event.type === 'm.room.message' &&
-    typeof event.content === 'object' &&
-    event.content.msgtype === 'org.boxel.command' &&
-    event.content.format === 'org.matrix.custom.html' &&
-    typeof event.content.data === 'object' &&
-    typeof event.content.data.toolCall === 'object'
-  );
-}
-
-export function isPatchCommandEvent(
-  event: DiscreteMatrixEvent,
-): event is CommandEvent {
-  return (
-    isCommandEvent(event) && event.content.data.toolCall.name === 'patchCard'
-  );
-}

--- a/packages/ai-bot/lib/matrix.ts
+++ b/packages/ai-bot/lib/matrix.ts
@@ -130,7 +130,7 @@ export const toMatrixMessageCommandContent = (
   eventToUpdate: string | undefined,
 ): IContent | undefined => {
   let { arguments: payload } = functionCall;
-  const body = payload['description'] || "Here's the change:";
+  const body = payload['description'] || 'Issuing command';
   let messageObject: IContent = {
     body: body,
     msgtype: 'org.boxel.command',

--- a/packages/ai-bot/lib/set-title.ts
+++ b/packages/ai-bot/lib/set-title.ts
@@ -4,6 +4,7 @@ import {
   type OpenAIPromptMessage,
   isCommandReactionEvent,
   attachedCardsToMessage,
+  isCommandEvent,
 } from '../helpers';
 import { MatrixClient } from './matrix';
 import { MatrixEvent as DiscreteMatrixEvent } from 'https://cardstack.com/base/room';

--- a/packages/ai-bot/lib/set-title.ts
+++ b/packages/ai-bot/lib/set-title.ts
@@ -7,7 +7,6 @@ import {
 } from '../helpers';
 import { MatrixClient } from './matrix';
 import { MatrixEvent as DiscreteMatrixEvent } from 'https://cardstack.com/base/room';
-import { isCommandEvent } from 'https://cardstack.com/base/command';
 
 const SET_TITLE_SYSTEM_MESSAGE = `You are a chat titling system, you must read the conversation and return a suggested title of no more than six words.
 Do NOT say talk or discussion or discussing or chat or chatting, this is implied by the context. 

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -1051,13 +1051,16 @@ module('getModifyPrompt', () => {
       function: {
         name: 'searchCard',
         description:
-          'Propose a query to search for a card instance related to module it was from. \n        Always prioritise search based upon the card that was last shared. \n        Ensure that you find the correct "module" and "name" from the OUTERMOST "adoptsFrom" field from the card data that is shared',
+          'Propose a query to search for a card instance related to module it was from. Always prioritise search based upon the card that was last shared. Ensure that you find the correct "module" and "name" from the OUTERMOST "adoptsFrom" field from the card data that is shared',
         parameters: {
           type: 'object',
           properties: {
             card_id: {
               type: 'string',
               const: 'http://localhost:4201/drafts/Friend/1',
+            },
+            description: {
+              type: 'string',
             },
             filter: {
               type: 'object',
@@ -1079,7 +1082,7 @@ module('getModifyPrompt', () => {
               },
             },
           },
-          required: ['card_id', 'filter'],
+          required: ['card_id', 'filter', 'description'],
         },
       },
     });

--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -1,3 +1,8 @@
+import {
+  CommandEvent,
+  CommandResultEvent,
+  MatrixEvent as DiscreteMatrixEvent,
+} from './room';
 import { FieldDef, StringField, contains, field, primitive } from './card-api';
 
 type JSONValue = string | number | boolean | null | JSONObject | [JSONValue];
@@ -22,4 +27,27 @@ export class CommandField extends FieldDef {
   @field payload = contains(CommandObjectField);
   @field eventId = contains(StringField);
   @field status = contains(CommandStatusField);
+}
+
+export function isCommandEvent(
+  event: DiscreteMatrixEvent,
+): event is CommandEvent {
+  return (
+    event.type === 'm.room.message' &&
+    typeof event.content === 'object' &&
+    event.content.msgtype === 'org.boxel.command' &&
+    event.content.format === 'org.matrix.custom.html' &&
+    typeof event.content.data === 'object' &&
+    typeof event.content.data.toolCall === 'object'
+  );
+}
+
+export function isCommandResultEvent(
+  event: DiscreteMatrixEvent,
+): event is CommandResultEvent {
+  return (
+    event.type === 'm.room.message' &&
+    typeof event.content === 'object' &&
+    event.content.msgtype === 'org.boxel.commandResult'
+  );
 }

--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -28,26 +28,3 @@ export class CommandField extends FieldDef {
   @field eventId = contains(StringField);
   @field status = contains(CommandStatusField);
 }
-
-export function isCommandEvent(
-  event: DiscreteMatrixEvent,
-): event is CommandEvent {
-  return (
-    event.type === 'm.room.message' &&
-    typeof event.content === 'object' &&
-    event.content.msgtype === 'org.boxel.command' &&
-    event.content.format === 'org.matrix.custom.html' &&
-    typeof event.content.data === 'object' &&
-    typeof event.content.data.toolCall === 'object'
-  );
-}
-
-export function isCommandResultEvent(
-  event: DiscreteMatrixEvent,
-): event is CommandResultEvent {
-  return (
-    event.type === 'm.room.message' &&
-    typeof event.content === 'object' &&
-    event.content.msgtype === 'org.boxel.commandResult'
-  );
-}

--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -1,8 +1,3 @@
-import {
-  CommandEvent,
-  CommandResultEvent,
-  MatrixEvent as DiscreteMatrixEvent,
-} from './room';
 import { FieldDef, StringField, contains, field, primitive } from './card-api';
 
 type JSONValue = string | number | boolean | null | JSONObject | [JSONValue];

--- a/packages/base/room.gts
+++ b/packages/base/room.gts
@@ -929,34 +929,3 @@ export type MatrixEvent =
   | InviteEvent
   | JoinEvent
   | LeaveEvent;
-
-export function isCommandEvent(event: MatrixEvent): event is CommandEvent {
-  return (
-    event.type === 'm.room.message' &&
-    typeof event.content === 'object' &&
-    event.content.msgtype === 'org.boxel.command' &&
-    event.content.format === 'org.matrix.custom.html' &&
-    typeof event.content.data === 'object' &&
-    typeof event.content.data.toolCall === 'object'
-  );
-}
-
-export const isCommandReactionEvent = (
-  event: MatrixEvent,
-): event is ReactionEvent => {
-  return (
-    event.type === 'm.reaction' &&
-    event.content['m.relates_to']?.rel_type === 'm.annotation' &&
-    event.content['m.relates_to']?.key === 'applied'
-  );
-};
-
-export function isCommandResultEvent(
-  event: MatrixEvent,
-): event is CommandResultEvent {
-  return (
-    event.type === 'm.room.message' &&
-    typeof event.content === 'object' &&
-    event.content.msgtype === 'org.boxel.commandResult'
-  );
-}

--- a/packages/base/room.gts
+++ b/packages/base/room.gts
@@ -527,6 +527,8 @@ export class RoomField extends FieldDef {
           if (!fragments.has(event_id)) {
             fragments.set(event_id, event.content);
           }
+        } else if (event.content.msgtype === 'org.boxel.commandResult') {
+          //don't display command result in the room as a message
         } else if (event.content.msgtype === 'org.boxel.message') {
           // Safely skip over cases that don't have attached cards or a data type
           let cardDocs = event.content.data?.attachedCardsEventIds
@@ -809,6 +811,32 @@ interface CommandMessageContent {
   };
 }
 
+export interface CommandResultEvent {
+  type: 'm.room.message';
+  content: CommandResultContent;
+  unsigned: {
+    age: number;
+    transaction_id: string;
+    prev_content?: any;
+    prev_sender?: string;
+  };
+}
+
+export interface CommandResultContent {
+  'm.relates_to'?: {
+    rel_type: 'm.annotation';
+    key: string;
+    event_id: string;
+    'm.in_reply_to'?: {
+      event_id: string;
+    };
+  };
+  formatted_body: string;
+  body: string;
+  msgtype: 'org.boxel.commandResult';
+  result: any;
+}
+
 export interface ReactionEvent extends BaseMatrixEvent {
   type: 'm.reaction';
   content: ReactionEventContent;
@@ -893,6 +921,7 @@ export type MatrixEvent =
   | RoomPowerLevels
   | MessageEvent
   | CommandEvent
+  | CommandResultEvent
   | ReactionEvent
   | CardMessageEvent
   | RoomNameEvent

--- a/packages/base/room.gts
+++ b/packages/base/room.gts
@@ -929,3 +929,34 @@ export type MatrixEvent =
   | InviteEvent
   | JoinEvent
   | LeaveEvent;
+
+export function isCommandEvent(event: MatrixEvent): event is CommandEvent {
+  return (
+    event.type === 'm.room.message' &&
+    typeof event.content === 'object' &&
+    event.content.msgtype === 'org.boxel.command' &&
+    event.content.format === 'org.matrix.custom.html' &&
+    typeof event.content.data === 'object' &&
+    typeof event.content.data.toolCall === 'object'
+  );
+}
+
+export const isCommandReactionEvent = (
+  event: MatrixEvent,
+): event is ReactionEvent => {
+  return (
+    event.type === 'm.reaction' &&
+    event.content['m.relates_to']?.rel_type === 'm.annotation' &&
+    event.content['m.relates_to']?.key === 'applied'
+  );
+};
+
+export function isCommandResultEvent(
+  event: MatrixEvent,
+): event is CommandResultEvent {
+  return (
+    event.type === 'm.room.message' &&
+    typeof event.content === 'object' &&
+    event.content.msgtype === 'org.boxel.commandResult'
+  );
+}

--- a/packages/base/room.gts
+++ b/packages/base/room.gts
@@ -811,7 +811,7 @@ interface CommandMessageContent {
   };
 }
 
-export interface CommandResultEvent {
+export interface CommandResultEvent extends BaseMatrixEvent {
   type: 'm.room.message';
   content: CommandResultContent;
   unsigned: {

--- a/packages/host/app/lib/matrix-handlers/index.ts
+++ b/packages/host/app/lib/matrix-handlers/index.ts
@@ -11,6 +11,7 @@ import type * as CardAPI from 'https://cardstack.com/base/card-api';
 import type {
   RoomField,
   MatrixEvent as DiscreteMatrixEvent,
+  MessageField,
 } from 'https://cardstack.com/base/room';
 
 import type LoaderService from '../../services/loader-service';
@@ -143,4 +144,32 @@ export async function updateRoomEvent(
       event as unknown as DiscreteMatrixEvent;
     resolvedRoom.events = [...resolvedRoom.events];
   }
+}
+
+export async function getRoomEvents(
+  context: EventSendingContext,
+  roomId: string,
+): Promise<DiscreteMatrixEvent[]> {
+  if (!roomId) {
+    throw new Error(
+      `bug: roomId is undefined for event ${JSON.stringify(event, null, 2)}`,
+    );
+  }
+  let room = context.rooms.get(roomId);
+  let resolvedRoom = await room;
+  return resolvedRoom?.events ?? [];
+}
+
+export async function getRoomMessages(
+  context: EventSendingContext,
+  roomId: string,
+): Promise<MessageField[]> {
+  if (!roomId) {
+    throw new Error(
+      `bug: roomId is undefined for event ${JSON.stringify(event, null, 2)}`,
+    );
+  }
+  let room = context.rooms.get(roomId);
+  let resolvedRoom = await room;
+  return resolvedRoom?.messages ?? [];
 }

--- a/packages/host/app/lib/matrix-handlers/index.ts
+++ b/packages/host/app/lib/matrix-handlers/index.ts
@@ -13,10 +13,7 @@ import type {
   MatrixEvent as DiscreteMatrixEvent,
   CommandResultEvent,
   ReactionEvent,
-} from 'https://cardstack.com/base/room';
-import {
-  isCommandReactionEvent,
-  isCommandResultEvent,
+  CommandEvent,
 } from 'https://cardstack.com/base/room';
 
 import type LoaderService from '../../services/loader-service';
@@ -179,4 +176,37 @@ export async function getCommandReactionEvents(
 ): Promise<ReactionEvent[]> {
   let events = await getRoomEvents(context, roomId);
   return events.filter((e) => isCommandReactionEvent(e)) as ReactionEvent[];
+}
+
+export function isCommandEvent(
+  event: DiscreteMatrixEvent,
+): event is CommandEvent {
+  return (
+    event.type === 'm.room.message' &&
+    typeof event.content === 'object' &&
+    event.content.msgtype === 'org.boxel.command' &&
+    event.content.format === 'org.matrix.custom.html' &&
+    typeof event.content.data === 'object' &&
+    typeof event.content.data.toolCall === 'object'
+  );
+}
+
+export const isCommandReactionEvent = (
+  event: DiscreteMatrixEvent,
+): event is ReactionEvent => {
+  return (
+    event.type === 'm.reaction' &&
+    event.content['m.relates_to']?.rel_type === 'm.annotation' &&
+    event.content['m.relates_to']?.key === 'applied'
+  );
+};
+
+export function isCommandResultEvent(
+  event: DiscreteMatrixEvent,
+): event is CommandResultEvent {
+  return (
+    event.type === 'm.room.message' &&
+    typeof event.content === 'object' &&
+    event.content.msgtype === 'org.boxel.commandResult'
+  );
 }

--- a/packages/host/app/lib/matrix-handlers/index.ts
+++ b/packages/host/app/lib/matrix-handlers/index.ts
@@ -11,7 +11,12 @@ import type * as CardAPI from 'https://cardstack.com/base/card-api';
 import type {
   RoomField,
   MatrixEvent as DiscreteMatrixEvent,
-  MessageField,
+  CommandResultEvent,
+  ReactionEvent,
+} from 'https://cardstack.com/base/room';
+import {
+  isCommandReactionEvent,
+  isCommandResultEvent,
 } from 'https://cardstack.com/base/room';
 
 import type LoaderService from '../../services/loader-service';
@@ -160,16 +165,18 @@ export async function getRoomEvents(
   return resolvedRoom?.events ?? [];
 }
 
-export async function getRoomMessages(
+export async function getCommandResultEvents(
   context: EventSendingContext,
   roomId: string,
-): Promise<MessageField[]> {
-  if (!roomId) {
-    throw new Error(
-      `bug: roomId is undefined for event ${JSON.stringify(event, null, 2)}`,
-    );
-  }
-  let room = context.rooms.get(roomId);
-  let resolvedRoom = await room;
-  return resolvedRoom?.messages ?? [];
+): Promise<CommandResultEvent[]> {
+  let events = await getRoomEvents(context, roomId);
+  return events.filter((e) => isCommandResultEvent(e)) as CommandResultEvent[];
+}
+
+export async function getCommandReactionEvents(
+  context: EventSendingContext,
+  roomId: string,
+): Promise<ReactionEvent[]> {
+  let events = await getRoomEvents(context, roomId);
+  return events.filter((e) => isCommandReactionEvent(e)) as ReactionEvent[];
 }

--- a/packages/host/app/services/command-service.ts
+++ b/packages/host/app/services/command-service.ts
@@ -15,6 +15,7 @@ export default class CommandService extends Service {
 
   run = task(async (command: CommandField, roomId: string) => {
     let { payload, eventId } = command;
+    let res: any;
     try {
       this.matrixService.failedCommandState.delete(eventId);
       if (command.name === 'patchCard') {
@@ -23,12 +24,18 @@ export default class CommandService extends Service {
             "Patch command can't run because it doesn't have all the fields in payload",
           );
         }
-        await this.operatorModeStateService.patchCard.perform(payload.card_id, {
-          attributes: payload.attributes,
-          relationships: payload.relationships,
-        });
+        res = await this.operatorModeStateService.patchCard.perform(
+          payload.card_id,
+          {
+            attributes: payload.attributes,
+            relationships: payload.relationships,
+          },
+        );
       }
       await this.matrixService.sendReactionEvent(roomId, eventId, 'applied');
+      if (res) {
+        await this.matrixService.sendCommandResultMessage(roomId, eventId, res);
+      }
     } catch (e) {
       let error =
         typeof e === 'string'

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -29,6 +29,7 @@ import {
 import {
   basicMappings,
   generateCardPatchCallSpecification,
+  getSearchTool,
 } from '@cardstack/runtime-common/helpers/ai';
 
 import { getPatchTool } from '@cardstack/runtime-common/helpers/ai';
@@ -457,6 +458,7 @@ export default class MatrixService extends Service {
         await realmSession.loaded;
         if (realmSession.canWrite) {
           tools.push(getPatchTool(attachedOpenCard, patchSpec));
+          tools.push(getSearchTool(attachedOpenCard));
         }
       }
     }

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -50,6 +50,7 @@ import type {
   CardMessageContent,
   CardFragmentContent,
   ReactionEventContent,
+  CommandResultContent,
 } from 'https://cardstack.com/base/room';
 
 import { Timeline, Membership, addRoomEvent } from '../lib/matrix-handlers';
@@ -362,7 +363,11 @@ export default class MatrixService extends Service {
   private async sendEvent(
     roomId: string,
     eventType: string,
-    content: CardMessageContent | CardFragmentContent | ReactionEventContent,
+    content:
+      | CardMessageContent
+      | CardFragmentContent
+      | ReactionEventContent
+      | CommandResultContent,
   ) {
     if ('data' in content) {
       const encodedContent = {
@@ -385,6 +390,31 @@ export default class MatrixService extends Service {
     };
     try {
       return await this.sendEvent(roomId, 'm.reaction', content);
+    } catch (e) {
+      throw new Error(
+        `Error sending reaction event: ${
+          'message' in (e as Error) ? (e as Error).message : e
+        }`,
+      );
+    }
+  }
+
+  async sendCommandResultMessage(roomId: string, eventId: string, result: any) {
+    let body = `Command Results from command event ${eventId}`;
+    let html = markdownToHtml(body);
+    let content: CommandResultContent = {
+      'm.relates_to': {
+        event_id: eventId,
+        rel_type: 'm.annotation',
+        key: 'applied', //this is aggregated key. All annotations must have one. This identifies the reaction event.
+      },
+      body,
+      formatted_body: html,
+      msgtype: 'org.boxel.commandResult',
+      result,
+    };
+    try {
+      return await this.sendEvent(roomId, 'm.room.message', content);
     } catch (e) {
       throw new Error(
         `Error sending reaction event: ${

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -113,6 +113,7 @@ export default class OperatorModeStateService extends Service {
     ) {
       throw new Error(`Please open card '${id}' to make changes to it.`);
     }
+    let patchedCards: CardDef[] = [];
     for (let item of stackItems) {
       if ('card' in item && item.card.id == id) {
         let document = await this.cardService.serializeCard(item.card);
@@ -131,9 +132,17 @@ export default class OperatorModeStateService extends Service {
             document.data.relationships = mergedRel;
           }
         }
-        await this.cardService.patchCard(item.card, document, patch);
+        let newCard = await this.cardService.patchCard(
+          item.card,
+          document,
+          patch,
+        );
+        if (newCard) {
+          patchedCards.push(newCard);
+        }
       }
     }
+    return patchedCards;
   });
 
   async deleteCard(card: CardDef) {

--- a/packages/host/tests/helpers/mock-matrix-service.ts
+++ b/packages/host/tests/helpers/mock-matrix-service.ts
@@ -153,7 +153,11 @@ function generateMockMatrixService(
       }
     }
 
-    async sendCommandResultMessage(roomId: string, eventId: string, result: any) {
+    async sendCommandResultMessage(
+      roomId: string,
+      eventId: string,
+      result: any,
+    ) {
       let body = `Command Results from command event ${eventId}`;
       let html = body;
       let content: CommandResultContent = {

--- a/packages/host/tests/helpers/mock-matrix-service.ts
+++ b/packages/host/tests/helpers/mock-matrix-service.ts
@@ -17,6 +17,7 @@ import { CardDef } from 'https://cardstack.com/base/card-api';
 import type {
   RoomField,
   ReactionEventContent,
+  CommandResultContent,
 } from 'https://cardstack.com/base/room';
 
 let cardApi: typeof import('https://cardstack.com/base/card-api');
@@ -143,6 +144,31 @@ function generateMockMatrixService(
       };
       try {
         return await this.sendEvent(roomId, 'm.reaction', content);
+      } catch (e) {
+        throw new Error(
+          `Error sending reaction event: ${
+            'message' in (e as Error) ? (e as Error).message : e
+          }`,
+        );
+      }
+    }
+
+    async sendCommandResultMessage(roomId: string, eventId: string, result: any) {
+      let body = `Command Results from command event ${eventId}`;
+      let html = body;
+      let content: CommandResultContent = {
+        'm.relates_to': {
+          event_id: eventId,
+          rel_type: 'm.annotation',
+          key: 'applied', //this is aggregated key. All annotations must have one. This identifies the reaction event.
+        },
+        body,
+        formatted_body: html,
+        msgtype: 'org.boxel.commandResult',
+        result,
+      };
+      try {
+        return await this.sendEvent(roomId, 'm.room.message', content);
       } catch (e) {
         throw new Error(
           `Error sending reaction event: ${

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -29,7 +29,8 @@ import OperatorMode from '@cardstack/host/components/operator-mode/container';
 import {
   addRoomEvent,
   updateRoomEvent,
-  getRoomEvents,
+  getCommandResultEvents,
+  getCommandReactionEvents,
 } from '@cardstack/host/lib/matrix-handlers';
 
 import type LoaderService from '@cardstack/host/services/loader-service';
@@ -2508,9 +2509,12 @@ module('Integration | operator-mode', function (hooks) {
         },
         status: null,
       });
-      let events = await getRoomEvents(matrixService, 'room1');
+      let commandReactionEvents = await getCommandReactionEvents(
+        matrixService,
+        'room1',
+      );
       assert.equal(
-        events.filter((e) => e.room_id && e.type === 'm.reaction').length,
+        commandReactionEvents.length,
         0,
         'reaction event is not dispatched',
       );
@@ -2525,9 +2529,12 @@ module('Integration | operator-mode', function (hooks) {
         .dom('[data-test-message-idx="0"] [data-test-apply-state="applied"]')
         .exists();
 
-      events = await getRoomEvents(matrixService, 'room1');
+      commandReactionEvents = await getCommandReactionEvents(
+        matrixService,
+        'room1',
+      );
       assert.equal(
-        events.filter((e) => e.room_id && e.type === 'm.reaction').length,
+        commandReactionEvents.length,
         1,
         'reaction event is dispatched',
       );
@@ -2573,14 +2580,12 @@ module('Integration | operator-mode', function (hooks) {
         },
         status: null,
       });
-      let events = await getRoomEvents(matrixService, 'room1');
+      let commandResultEvents = await getCommandResultEvents(
+        matrixService,
+        'room1',
+      );
       assert.equal(
-        events.filter(
-          (e) =>
-            e.room_id &&
-            e.type === 'm.room.message' &&
-            e.content.msgtype === 'org.boxel.commandResult',
-        ).length,
+        commandResultEvents.length,
         0,
         'command result event is not dispatched',
       );
@@ -2594,17 +2599,17 @@ module('Integration | operator-mode', function (hooks) {
         .dom('[data-test-message-idx="0"] [data-test-apply-state="applied"]')
         .exists();
 
-      events = await getRoomEvents(matrixService, 'room1');
-      let commandResultEvent = events.filter(
-        (e) => e.room_id && e.content.msgtype === 'org.boxel.commandResult',
+      commandResultEvents = await getCommandResultEvents(
+        matrixService,
+        'room1',
       );
       assert.equal(
-        commandResultEvent.length,
+        commandResultEvents.length,
         1,
         'command result event is dispatched',
       );
       assert.equal(
-        commandResultEvent[0].content.result[0].firstName,
+        commandResultEvents[0].content.result[0].firstName,
         'Evie',
         'field has been changed',
       );

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -29,6 +29,7 @@ import OperatorMode from '@cardstack/host/components/operator-mode/container';
 import {
   addRoomEvent,
   updateRoomEvent,
+  getRoomEvents,
 } from '@cardstack/host/lib/matrix-handlers';
 
 import type LoaderService from '@cardstack/host/services/loader-service';
@@ -2465,6 +2466,148 @@ module('Integration | operator-mode', function (hooks) {
         .containsText(
           'Wednesday Jan 3, 2024, 12:31 PM This is the second message comes after the first message and before the replacement of the first message',
         );
+    });
+
+    test('after command is issued, a reaction event will be dispatched', async function (assert) {
+      await setCardInOperatorModeState(`${testRealmURL}Person/fadhlan`);
+      await renderComponent(
+        class TestDriver extends GlimmerComponent {
+          <template>
+            <OperatorMode @onClose={{noop}} />
+            <CardPrerender />
+          </template>
+        },
+      );
+      await waitFor('[data-test-person="Fadhlan"]');
+      await matrixService.createAndJoinRoom('room1', 'test room 1');
+      await addRoomEvent(matrixService, {
+        event_id: 'room1-event1',
+        room_id: 'room1',
+        state_key: 'state',
+        type: 'm.room.message',
+        origin_server_ts: new Date(2024, 0, 3, 12, 30).getTime(),
+        sender: '@aibot:localhost',
+        content: {
+          msgtype: 'org.boxel.command',
+          formatted_body: 'Changing first name to Evie',
+          format: 'org.matrix.custom.html',
+          data: JSON.stringify({
+            toolCall: {
+              name: 'patchCard',
+              arguments: {
+                card_id: `${testRealmURL}Person/fadhlan`,
+                attributes: { firstName: 'Evie' },
+              },
+            },
+            eventId: 'room1-event1',
+          }),
+          'm.relates_to': {
+            rel_type: 'm.replace',
+            event_id: 'room1-event1',
+          },
+        },
+        status: null,
+      });
+      let events = await getRoomEvents(matrixService, 'room1');
+      assert.equal(
+        events.filter((e) => e.room_id && e.type === 'm.reaction').length,
+        0,
+        'reaction event is not dispatched',
+      );
+
+      await click('[data-test-open-ai-assistant]');
+      await waitFor('[data-test-room-name="test room 1"]');
+      await waitFor('[data-test-message-idx="0"] [data-test-command-apply]');
+      await click('[data-test-message-idx="0"] [data-test-command-apply]');
+      await waitFor('[data-test-command-card-idle]');
+
+      assert
+        .dom('[data-test-message-idx="0"] [data-test-apply-state="applied"]')
+        .exists();
+
+      events = await getRoomEvents(matrixService, 'room1');
+      assert.equal(
+        events.filter((e) => e.room_id && e.type === 'm.reaction').length,
+        1,
+        'reaction event is dispatched',
+      );
+    });
+
+    test('after command is issued, a command result event is dispatched if a result is returned', async function (assert) {
+      await setCardInOperatorModeState(`${testRealmURL}Person/fadhlan`);
+      await renderComponent(
+        class TestDriver extends GlimmerComponent {
+          <template>
+            <OperatorMode @onClose={{noop}} />
+            <CardPrerender />
+          </template>
+        },
+      );
+      await waitFor('[data-test-person="Fadhlan"]');
+      await matrixService.createAndJoinRoom('room1', 'test room 1');
+      await addRoomEvent(matrixService, {
+        event_id: 'room1-event1',
+        room_id: 'room1',
+        state_key: 'state',
+        type: 'm.room.message',
+        origin_server_ts: new Date(2024, 0, 3, 12, 30).getTime(),
+        sender: '@aibot:localhost',
+        content: {
+          msgtype: 'org.boxel.command',
+          formatted_body: 'Changing first name to Evie',
+          format: 'org.matrix.custom.html',
+          data: JSON.stringify({
+            toolCall: {
+              name: 'patchCard',
+              arguments: {
+                card_id: `${testRealmURL}Person/fadhlan`,
+                attributes: { firstName: 'Evie' },
+              },
+            },
+            eventId: 'room1-event1',
+          }),
+          'm.relates_to': {
+            rel_type: 'm.replace',
+            event_id: 'room1-event1',
+          },
+        },
+        status: null,
+      });
+      let events = await getRoomEvents(matrixService, 'room1');
+      assert.equal(
+        events.filter(
+          (e) =>
+            e.room_id &&
+            e.type === 'm.room.message' &&
+            e.content.msgtype === 'org.boxel.commandResult',
+        ).length,
+        0,
+        'command result event is not dispatched',
+      );
+      await click('[data-test-open-ai-assistant]');
+      await waitFor('[data-test-room-name="test room 1"]');
+      await waitFor('[data-test-message-idx="0"] [data-test-command-apply]');
+      await click('[data-test-message-idx="0"] [data-test-command-apply]');
+      await waitFor('[data-test-command-card-idle]');
+
+      assert
+        .dom('[data-test-message-idx="0"] [data-test-apply-state="applied"]')
+        .exists();
+
+      events = await getRoomEvents(matrixService, 'room1');
+      let commandResultEvent = events.filter(
+        (e) => e.room_id && e.content.msgtype === 'org.boxel.commandResult',
+      );
+      assert.equal(
+        commandResultEvent.length,
+        1,
+        'command result event is dispatched',
+      );
+      assert.equal(
+        commandResultEvent[0].content.result[0].firstName,
+        'Evie',
+        'field has been changed',
+      );
     });
   });
 

--- a/packages/matrix/docker/synapse/index.ts
+++ b/packages/matrix/docker/synapse/index.ts
@@ -436,3 +436,25 @@ interface MessageEvent {
   event_id: string;
   room_id: string;
 }
+
+export async function putEvent(
+  accessToken: string,
+  roomId: string,
+  eventType: string,
+  txnId: string,
+  body: any,
+) {
+  let url = `http://localhost:${SYNAPSE_PORT}/_matrix/client/v3/rooms/${roomId}/send/${eventType}/${txnId}`;
+  let res = await await fetch(url, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify(body),
+  });
+  if (res.ok) {
+    let r = await res.json();
+    return r;
+  }
+  return;
+}

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { registerUser } from '../docker/synapse';
+import { Credentials, putEvent, registerUser } from '../docker/synapse';
 import {
   login,
   logout,
@@ -25,10 +25,11 @@ import {
 
 test.describe('Room messages', () => {
   let synapse: SynapseInstance;
+  let userCred: Credentials;
   test.beforeEach(async () => {
     synapse = await synapseStart();
     await registerRealmUsers(synapse);
-    await registerUser(synapse, 'user1', 'pass');
+    userCred = await registerUser(synapse, 'user1', 'pass');
   });
   test.afterEach(async () => {
     await synapseStop(synapse.synapseId);
@@ -1024,5 +1025,88 @@ test.describe('Room messages', () => {
     await expect(page.locator('[data-test-ai-bot-retry-button]')).toHaveCount(
       0,
     );
+  });
+
+  test(`applying a command dispatches a reaction event if command is succesful`, async ({
+    page,
+  }) => {
+    await login(page, 'user1', 'pass');
+    let room1 = await getRoomId(page);
+    let card_id = `${testHost}/hassan`;
+    let content = {
+      msgtype: 'org.boxel.command',
+      format: 'org.matrix.custom.html',
+      body: 'some command',
+      formatted_body: 'some command',
+      data: JSON.stringify({
+        toolCall: {
+          name: 'patchCard',
+          arguments: {
+            card_id,
+            attributes: {
+              firstName: 'Dave',
+            },
+          },
+        },
+      }),
+    };
+
+    await page
+      .locator(
+        `[data-test-stack-card="${testHost}/index"] [data-test-cards-grid-item="${card_id}"]`,
+      )
+      .click();
+    await putEvent(userCred.accessToken, room1, 'm.room.message', '1', content);
+    await page.locator('[data-test-command-apply]').click();
+    await page.locator('[data-test-command-idle]');
+
+    await expect(async () => {
+      let events = await getRoomEvents('user1', 'pass', room1);
+      let reactionEvent = (events as any).find(
+        (e: any) => e.type === 'm.reaction',
+      );
+      await expect(reactionEvent).toBeDefined();
+    }).toPass();
+  });
+
+  test(`applying a command dispatches a result event if command is succesful and result is returned`, async ({
+    page,
+  }) => {
+    await login(page, 'user1', 'pass');
+    let room1 = await getRoomId(page);
+    let card_id = `${testHost}/hassan`;
+    let content = {
+      msgtype: 'org.boxel.command',
+      format: 'org.matrix.custom.html',
+      body: 'some command',
+      formatted_body: 'some command',
+      data: JSON.stringify({
+        toolCall: {
+          name: 'patchCard',
+          arguments: {
+            card_id,
+            attributes: {
+              firstName: 'Dave',
+            },
+          },
+        },
+      }),
+    };
+
+    await page
+      .locator(
+        `[data-test-stack-card="${testHost}/index"] [data-test-cards-grid-item="${card_id}"]`,
+      )
+      .click();
+    await putEvent(userCred.accessToken, room1, 'm.room.message', '1', content);
+    await page.locator('[data-test-command-apply]').click();
+    await page.locator('[data-test-command-idle]');
+    await expect(async () => {
+      let events = await getRoomEvents('user1', 'pass', room1);
+      let commandResultEvent = (events as any).find(
+        (e: any) => e.content.msgtype === 'org.boxel.commandResult',
+      );
+      await expect(commandResultEvent).toBeDefined();
+    }).toPass();
   });
 });

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -291,7 +291,7 @@ test.describe('Room messages', () => {
     expect(serializeCard.data.attributes.picture).toBeUndefined();
   });
 
-  test(`it does include patch tool in message event when top-most card is writable and context is shared`, async ({
+  test(`it does include command tools (patch, search) in message event when top-most card is writable and context is shared`, async ({
     page,
   }) => {
     await login(page, 'user1', 'pass');
@@ -349,6 +349,46 @@ test.describe('Room messages', () => {
             required: ['card_id', 'attributes', 'description'],
           },
         },
+      },
+      {
+        function: {
+          description:
+            'Propose a query to search for a card instance related to module it was from. Always prioritise search based upon the card that was last shared. Ensure that you find the correct "module" and "name" from the OUTERMOST "adoptsFrom" field from the card data that is shared',
+          name: 'searchCard',
+          parameters: {
+            properties: {
+              card_id: {
+                const: `${testHost}/mango`,
+                type: 'string',
+              },
+              description: {
+                type: 'string',
+              },
+              filter: {
+                properties: {
+                  type: {
+                    properties: {
+                      module: {
+                        description: 'the absolute path of the module',
+                        type: 'string',
+                      },
+                      name: {
+                        description: 'the name of the module',
+                        type: 'string',
+                      },
+                    },
+                    required: ['module', 'name'],
+                    type: 'object',
+                  },
+                },
+                type: 'object',
+              },
+            },
+            required: ['card_id', 'filter', 'description'],
+            type: 'object',
+          },
+        },
+        type: 'function',
       },
     ]);
   });

--- a/packages/runtime-common/helpers/ai.ts
+++ b/packages/runtime-common/helpers/ai.ts
@@ -359,15 +359,16 @@ export function getSearchTool(attachedOpenCard: CardDef) {
     type: 'function',
     function: {
       name: 'searchCard',
-      description: `Propose a query to search for a card instance related to module it was from. 
-        Always prioritise search based upon the card that was last shared. 
-        Ensure that you find the correct "module" and "name" from the OUTERMOST "adoptsFrom" field from the card data that is shared`,
+      description: `Propose a query to search for a card instance related to module it was from. Always prioritise search based upon the card that was last shared. Ensure that you find the correct "module" and "name" from the OUTERMOST "adoptsFrom" field from the card data that is shared`,
       parameters: {
         type: 'object',
         properties: {
           card_id: {
             type: 'string',
             const: attachedOpenCard.id, // Force the valid card_id to be the id of the card being patched
+          },
+          description: {
+            type: 'string',
           },
           filter: {
             type: 'object',
@@ -390,7 +391,7 @@ export function getSearchTool(attachedOpenCard: CardDef) {
             },
           },
         },
-        required: ['card_id', 'filter'],
+        required: ['card_id', 'filter', 'description'],
       },
     },
   };

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -185,7 +185,7 @@ export interface CardSearch {
     realms?: string[],
   ): {
     instances: CardDef[];
-    ready: Promise<void>;
+    loaded: Promise<void>;
     isLoading: boolean;
   };
   getCard(


### PR DESCRIPTION
Pushing this into https://github.com/cardstack/boxel/pull/1341 until it gets merged

This adds the command result event. 

This event essentially puts a results into matrix when either a patch or search command is executed (not all commands need results). The source of this execution will be the command service (the user will trigger this from the host). After this I will add results card to which will render the data from this event which will make it more clear


