### PR TITLE
Get all events from a room

### DIFF
--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -564,7 +564,7 @@ export default class MatrixService extends Service {
         await opts.onMessages(events);
       }
       messages.push(...events);
-    } while (!from);
+    } while (from);
     return messages;
   }
 

--- a/packages/matrix/docker/synapse/index.ts
+++ b/packages/matrix/docker/synapse/index.ts
@@ -408,7 +408,7 @@ export async function getAllRoomEvents(
     from = end;
     let events: MessageEvent[] = chunk;
     messages.push(...events);
-  } while (!from);
+  } while (from);
   return messages;
 }
 


### PR DESCRIPTION
The code before iterated over the events just once, so we were limited to 50 events. The "from" is a key for the next iteration, and it was stopping if it was present (which it always is in the first pass).