### PR TITLE
Search for instances by card type

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -684,6 +684,7 @@ export default class CodeSubmode extends Component<Signature> {
     <SubmodeLayout
       @onCardSelectFromSearch={{this.openSearchResultInEditor}}
       @hideAiAssistant={{true}}
+      as |search|
     >
       <div
         class='code-mode'
@@ -744,6 +745,7 @@ export default class CodeSubmode extends Component<Signature> {
                           @delete={{this.setItemToDelete}}
                           @goToDefinition={{this.goToDefinition}}
                           @createFile={{perform this.createFile}}
+                          @openSearch={{search.openSearchToResults}}
                           data-test-card-inspector-panel
                         />
                       {{/if}}

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -191,7 +191,7 @@ export default class DetailPanel extends Component<Signature> {
       (this.args.selectedDeclaration?.cardOrField as typeof CardDef).isCardDef
         ? [
             {
-              label: 'Search for Instances',
+              label: 'Find instances',
               icon: IconSearch,
               handler: this.searchForInstances,
             },

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -20,6 +20,7 @@ import {
   IconInherit,
   IconTrash,
   IconPlus,
+  IconSearch,
   Copy,
 } from '@cardstack/boxel-ui/icons';
 
@@ -30,6 +31,7 @@ import {
   isCardDef,
   isFieldDef,
   isBaseDef,
+  internalKeyFor,
   type ResolvedCodeRef,
 } from '@cardstack/runtime-common';
 
@@ -72,6 +74,7 @@ interface Signature {
     cardInstance: CardDef | undefined;
     selectedDeclaration?: ModuleDeclaration;
     selectDeclaration: (dec: ModuleDeclaration) => void;
+    openSearch: (term: string) => void;
     goToDefinition: (
       codeRef: ResolvedCodeRef | undefined,
       localName: string | undefined,
@@ -184,6 +187,15 @@ export default class DetailPanel extends Component<Signature> {
             },
           ]
         : []),
+      ...(this.args.selectedDeclaration?.exportName
+        ? [
+            {
+              label: 'Search for Instances',
+              icon: IconSearch,
+              handler: this.searchForInstances,
+            },
+          ]
+        : []),
     ];
   }
 
@@ -239,7 +251,7 @@ export default class DetailPanel extends Component<Signature> {
 
   @action private createInstance() {
     if (!this.args.selectedDeclaration) {
-      throw new Error('must have a selected delcaration');
+      throw new Error('must have a selected declaration');
     }
     if (
       this.args.selectedDeclaration &&
@@ -262,7 +274,7 @@ export default class DetailPanel extends Component<Signature> {
 
   @action private inherit() {
     if (!this.args.selectedDeclaration) {
-      throw new Error('must have a selected delcaration');
+      throw new Error('must have a selected declaration');
     }
     if (
       this.args.selectedDeclaration &&
@@ -289,6 +301,25 @@ export default class DetailPanel extends Component<Signature> {
         displayName,
       },
     );
+  }
+
+  @action private searchForInstances() {
+    if (!this.args.selectedDeclaration) {
+      throw new Error('must have a selected declaration');
+    }
+    if (
+      this.args.selectedDeclaration &&
+      (!isCardOrFieldDeclaration(this.args.selectedDeclaration) ||
+        !isCardDef(this.args.selectedDeclaration.cardOrField))
+    ) {
+      throw new Error(`bug: the selected declaration is not a card definition`);
+    }
+    let ref = this.getSelectedDeclarationAsCodeRef();
+    let refURL = internalKeyFor(
+      ref,
+      this.operatorModeStateService.state.codePath!,
+    );
+    this.args.openSearch(`carddef:${refURL}`);
   }
 
   private getSelectedDeclarationAsCodeRef(): ResolvedCodeRef {

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -187,7 +187,8 @@ export default class DetailPanel extends Component<Signature> {
             },
           ]
         : []),
-      ...(this.args.selectedDeclaration?.exportName
+      ...(this.args.selectedDeclaration?.exportName &&
+      (this.args.selectedDeclaration?.cardOrField as typeof CardDef).isCardDef
         ? [
             {
               label: 'Search for Instances',

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -531,7 +531,7 @@ export default class InteractSubmode extends Component<Signature> {
     <SubmodeLayout
       @onSearchSheetClosed={{this.clearSearchSheetTrigger}}
       @onCardSelectFromSearch={{perform this.openSelectedSearchResultInStack}}
-      as |openSearch|
+      as |search|
     >
       <div class='operator-mode__main' style={{this.backgroundImageStyle}}>
         {{#if (eq this.allStackItems.length 0)}}
@@ -595,13 +595,19 @@ export default class InteractSubmode extends Component<Signature> {
             data-test-add-card-left-stack
             @triggerSide={{SearchSheetTriggers.DropCardToLeftNeighborStackButton}}
             @activeTrigger={{this.searchSheetTrigger}}
-            @onTrigger={{fn this.showSearchWithTrigger openSearch}}
+            @onTrigger={{fn
+              this.showSearchWithTrigger
+              search.openSearchToPrompt
+            }}
           />
           <NeighborStackTriggerButton
             data-test-add-card-right-stack
             @triggerSide={{SearchSheetTriggers.DropCardToRightNeighborStackButton}}
             @activeTrigger={{this.searchSheetTrigger}}
-            @onTrigger={{fn this.showSearchWithTrigger openSearch}}
+            @onTrigger={{fn
+              this.showSearchWithTrigger
+              search.openSearchToPrompt
+            }}
           />
         {{/if}}
         {{#if this.itemToDelete}}

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -1,3 +1,4 @@
+import { hash } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
@@ -6,6 +7,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 import onClickOutside from 'ember-click-outside/modifiers/on-click-outside';
+import { restartableTask, timeout } from 'ember-concurrency';
 
 import { ResizablePanelGroup } from '@cardstack/boxel-ui/components';
 import type { PanelContext } from '@cardstack/boxel-ui/components';
@@ -46,7 +48,12 @@ interface Signature {
     onCardSelectFromSearch: (card: CardDef) => void;
   };
   Blocks: {
-    default: [openSearch: () => void];
+    default: [
+      {
+        openSearchToPrompt: () => void;
+        openSearchToResults: (term: string) => void;
+      },
+    ];
   };
 }
 
@@ -60,9 +67,11 @@ export default class SubmodeLayout extends Component<Signature> {
     aiAssistantPanel: 200,
   };
   @service private declare operatorModeStateService: OperatorModeStateService;
-  @service declare matrixService: MatrixService;
+  @service private declare matrixService: MatrixService;
 
   private searchElement: HTMLElement | null = null;
+  private suppressSearchClose = false;
+  private declare doSearch: (term: string) => void;
 
   private get aiAssistantVisibilityClass() {
     return this.isAiAssistantVisible
@@ -107,6 +116,9 @@ export default class SubmodeLayout extends Component<Signature> {
   }
 
   @action private closeSearchSheet() {
+    if (this.suppressSearchClose) {
+      return;
+    }
     this.searchSheetMode = SearchSheetModes.Closed;
     this.args.onSearchSheetClosed?.();
   }
@@ -116,7 +128,7 @@ export default class SubmodeLayout extends Component<Signature> {
   }
 
   @action private openSearchSheetToPrompt() {
-    if (this.searchSheetMode == SearchSheetModes.Closed) {
+    if (this.searchSheetMode === SearchSheetModes.Closed) {
       this.searchSheetMode = SearchSheetModes.SearchPrompt;
     }
 
@@ -129,13 +141,13 @@ export default class SubmodeLayout extends Component<Signature> {
     this.closeSearchSheet();
   }
 
-  @action toggleProfileSettings() {
+  @action private toggleProfileSettings() {
     this.profileSettingsOpened = !this.profileSettingsOpened;
 
     this.profileSummaryOpened = false;
   }
 
-  @action toggleProfileSummary() {
+  @action private toggleProfileSummary() {
     this.profileSummaryOpened = !this.profileSummaryOpened;
   }
 
@@ -149,6 +161,33 @@ export default class SubmodeLayout extends Component<Signature> {
   private storeSearchElement(element: HTMLElement) {
     this.searchElement = element;
   }
+  @action
+  private openSearchAndShowResults(term: string) {
+    this.doOpenSearchAndShowResults.perform(term);
+  }
+
+  @action
+  private setupSearch(doSearch: (term: string) => void) {
+    this.doSearch = doSearch;
+  }
+
+  private doOpenSearchAndShowResults = restartableTask(async (term: string) => {
+    this.suppressSearchClose = true;
+
+    let wasClosed = this.searchSheetMode === SearchSheetModes.Closed;
+    this.searchSheetMode = SearchSheetModes.SearchResults;
+    this.searchElement?.focus();
+    if (wasClosed) {
+      this.args.onSearchSheetOpened?.();
+    }
+    this.doSearch(term);
+
+    // we need to prevent the onblur of the search sheet from triggering a
+    // search sheet close from the click that actually triggered the search
+    // sheet to show in the first place
+    await timeout(250);
+    this.suppressSearchClose = false;
+  });
 
   <template>
     <div class='submode-layout {{this.aiAssistantVisibilityClass}}'>
@@ -169,7 +208,12 @@ export default class SubmodeLayout extends Component<Signature> {
             @onSubmodeSelect={{this.updateSubmode}}
             class='submode-switcher'
           />
-          {{yield this.openSearchSheetToPrompt}}
+          {{yield
+            (hash
+              openSearchToPrompt=this.openSearchSheetToPrompt
+              openSearchToResults=this.openSearchAndShowResults
+            )
+          }}
           <div class='profile-icon-container'>
             <button
               class='profile-icon-button'
@@ -181,6 +225,7 @@ export default class SubmodeLayout extends Component<Signature> {
           </div>
           <SearchSheet
             @mode={{this.searchSheetMode}}
+            @onSetup={{this.setupSearch}}
             @onBlur={{this.closeSearchSheet}}
             @onCancel={{this.closeSearchSheet}}
             @onFocus={{this.openSearchSheetToPrompt}}

--- a/packages/host/app/components/search-sheet/usage.gts
+++ b/packages/host/app/components/search-sheet/usage.gts
@@ -36,6 +36,10 @@ export default class SearchSheetUsage extends Component {
     // noop
   }
 
+  @action onSearchSetup() {
+    // noop
+  }
+
   <template>
     <FreestyleUsage @name='SearchSheet'>
       <:description>
@@ -45,6 +49,7 @@ export default class SearchSheetUsage extends Component {
         <div class='example-container'>
           <SearchSheet
             @mode={{this.mode}}
+            @onSetup={{this.onSearchSetup}}
             @onCancel={{this.onCancel}}
             @onFocus={{this.onFocus}}
             @onBlur={{this.onBlur}}

--- a/packages/host/app/lib/sqlite-adapter.ts
+++ b/packages/host/app/lib/sqlite-adapter.ts
@@ -214,6 +214,7 @@ export default class SQLiteAdapter implements DBAdapter {
       })
       .replace(/ANY_VALUE\(([^)]*)\)/g, '$1')
       .replace(/CROSS JOIN LATERAL/g, 'CROSS JOIN')
+      .replace(/ILIKE/g, 'LIKE') // sqlite LIKE is case insensitive
       .replace(/jsonb_array_elements_text\(/g, 'json_each(')
       .replace(/jsonb_tree\(/g, 'json_tree(')
       .replace(/([^\s]+\s[^\s]+)_array_element/g, (match, group) => {

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -13,7 +13,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import window from 'ember-window-mock';
 import { setupWindowMock } from 'ember-window-mock/test-support';
 import * as MonacoSDK from 'monaco-editor';
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 
 import stringify from 'safe-stable-stringify';
 
@@ -2182,16 +2182,69 @@ export class ExportedCard extends ExportedCardParent {
       .doesNotExist('field defs do not display a create instance button');
   });
 
-  skip('can search for instances of an exported card definition', async function (_assert) {
-    // TODO
+  test('can search for instances of an exported card definition', async function (assert) {
+    await visitOperatorMode({
+      stacks: [[]],
+      submode: 'code',
+      codePath: `${testRealmURL}pet`,
+    });
+
+    await waitForCodeEditor();
+    await waitFor('[data-boxel-selector-item-text="Pet"]');
+
+    await click('[data-boxel-selector-item-text="Pet"]');
+    await waitFor('[data-test-card-module-definition]');
+
+    await click('[data-test-action-button="Search for Instances"]');
+    await waitFor('[data-test-search-sheet-search-result]');
+    assert
+      .dom('[data-test-search-field]')
+      .hasValue(`carddef:${testRealmURL}pet/Pet`);
+    assert
+      .dom('[data-test-search-label]')
+      .hasText(`2 Results for “carddef:${testRealmURL}pet/Pet”`);
+    assert.dom(`[data-test-search-result="${testRealmURL}Pet/mango"]`).exists();
+    assert
+      .dom(`[data-test-search-result="${testRealmURL}Pet/vangogh"]`)
+      .exists();
   });
 
-  skip('search for instances action is not displayed for non-exported Card definition', async function (_assert) {
-    // TODO
+  test('search for instances action is not displayed for non-exported Card definition', async function (assert) {
+    await visitOperatorMode({
+      stacks: [[]],
+      submode: 'code',
+      codePath: `${testRealmURL}in-this-file.gts`,
+    });
+
+    await waitForCodeEditor();
+    await waitFor('[data-boxel-selector-item-text="LocalCard"]');
+
+    await click('[data-boxel-selector-item-text="LocalCard"]');
+    await waitFor('[data-test-card-module-definition]');
+
+    assert
+      .dom('[data-test-action-button="Search for Instances"]')
+      .doesNotExist(
+        'non-exported card defs do not display a search for instances button',
+      );
   });
 
-  skip('search for instances action is not displayed for field definition', async function (_assert) {
-    // TODO
+  test('search for instances action is not displayed for field definition', async function (assert) {
+    await visitOperatorMode({
+      stacks: [[]],
+      submode: 'code',
+      codePath: `${testRealmURL}in-this-file.gts`,
+    });
+
+    await waitForCodeEditor();
+    await waitFor('[data-boxel-selector-item-text="ExportedField"]');
+
+    await click('[data-boxel-selector-item-text="ExportedField"]');
+    await waitFor('[data-test-card-module-definition]');
+
+    assert
+      .dom('[data-test-action-button="Search for Instances"]')
+      .doesNotExist('field defs do not display a search for instances button');
   });
 
   module('when the user lacks write permissions', function (hooks) {

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -13,7 +13,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import window from 'ember-window-mock';
 import { setupWindowMock } from 'ember-window-mock/test-support';
 import * as MonacoSDK from 'monaco-editor';
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 
 import stringify from 'safe-stable-stringify';
 
@@ -2180,6 +2180,18 @@ export class ExportedCard extends ExportedCardParent {
     assert
       .dom('[data-test-action-button="Create Instance"]')
       .doesNotExist('field defs do not display a create instance button');
+  });
+
+  skip('can search for instances of an exported card definition', async function (_assert) {
+    // TODO
+  });
+
+  skip('search for instances action is not displayed for non-exported Card definition', async function (_assert) {
+    // TODO
+  });
+
+  skip('search for instances action is not displayed for field definition', async function (_assert) {
+    // TODO
   });
 
   module('when the user lacks write permissions', function (hooks) {

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -2182,7 +2182,7 @@ export class ExportedCard extends ExportedCardParent {
       .doesNotExist('field defs do not display a create instance button');
   });
 
-  test('can search for instances of an exported card definition', async function (assert) {
+  test('can find instances of an exported card definition', async function (assert) {
     await visitOperatorMode({
       stacks: [[]],
       submode: 'code',
@@ -2195,7 +2195,7 @@ export class ExportedCard extends ExportedCardParent {
     await click('[data-boxel-selector-item-text="Pet"]');
     await waitFor('[data-test-card-module-definition]');
 
-    await click('[data-test-action-button="Search for Instances"]');
+    await click('[data-test-action-button="Find instances"]');
     await waitFor('[data-test-search-sheet-search-result]');
     assert
       .dom('[data-test-search-field]')
@@ -2209,7 +2209,7 @@ export class ExportedCard extends ExportedCardParent {
       .exists();
   });
 
-  test('search for instances action is not displayed for non-exported Card definition', async function (assert) {
+  test('find instances action is not displayed for non-exported Card definition', async function (assert) {
     await visitOperatorMode({
       stacks: [[]],
       submode: 'code',
@@ -2223,13 +2223,13 @@ export class ExportedCard extends ExportedCardParent {
     await waitFor('[data-test-card-module-definition]');
 
     assert
-      .dom('[data-test-action-button="Search for Instances"]')
+      .dom('[data-test-action-button="Find instances"]')
       .doesNotExist(
-        'non-exported card defs do not display a search for instances button',
+        'non-exported card defs do not display a Find instances button',
       );
   });
 
-  test('search for instances action is not displayed for field definition', async function (assert) {
+  test('find instances action is not displayed for field definition', async function (assert) {
     await visitOperatorMode({
       stacks: [[]],
       submode: 'code',
@@ -2243,8 +2243,8 @@ export class ExportedCard extends ExportedCardParent {
     await waitFor('[data-test-card-module-definition]');
 
     assert
-      .dom('[data-test-action-button="Search for Instances"]')
-      .doesNotExist('field defs do not display a search for instances button');
+      .dom('[data-test-action-button="Find instances"]')
+      .doesNotExist('field defs do not display a Find instances button');
   });
 
   module('when the user lacks write permissions', function (hooks) {

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -3355,12 +3355,12 @@ module('Integration | operator-mode', function (hooks) {
     await waitFor(`[data-test-cards-grid-item]`);
 
     await focus(`[data-test-search-field]`);
-    await typeIn(`[data-test-search-field]`, 'Ma');
-    assert.dom(`[data-test-search-label]`).containsText('Searching for “Ma”');
+    await typeIn(`[data-test-search-field]`, 'ma');
+    assert.dom(`[data-test-search-label]`).containsText('Searching for “ma”');
 
     await waitFor(`[data-test-search-sheet-search-result]`);
-    assert.dom(`[data-test-search-label]`).containsText('3 Results for “Ma”');
-    assert.dom(`[data-test-search-sheet-search-result]`).exists({ count: 3 });
+    assert.dom(`[data-test-search-label]`).containsText('4 Results for “ma”');
+    assert.dom(`[data-test-search-sheet-search-result]`).exists({ count: 4 });
     assert.dom(`[data-test-search-result="${testRealmURL}Pet/mango"]`).exists();
     assert
       .dom(`[data-test-search-result="${testRealmURL}Author/mark"]`)

--- a/packages/host/tests/unit/query-test.ts
+++ b/packages/host/tests/unit/query-test.ts
@@ -298,6 +298,14 @@ module('Unit | query', function (hooks) {
     });
   });
 
+  test(`contains filter is case insensitive`, async function (assert) {
+    await runSharedTest(queryTests, assert, {
+      indexer,
+      loader,
+      testCards,
+    });
+  });
+
   test(`can use 'contains' to match multiple fields`, async function (assert) {
     await runSharedTest(queryTests, assert, {
       indexer,

--- a/packages/realm-server/tests/query-test.ts
+++ b/packages/realm-server/tests/query-test.ts
@@ -241,6 +241,14 @@ module('query', function (hooks) {
     });
   });
 
+  test(`contains filter is case insensitive`, async function (assert) {
+    await runSharedTest(queryTests, assert, {
+      indexer,
+      loader,
+      testCards: await makeTestCards(loader),
+    });
+  });
+
   test(`can use 'contains' to match multiple fields`, async function (assert) {
     await runSharedTest(queryTests, assert, {
       indexer,

--- a/packages/runtime-common/indexer.ts
+++ b/packages/runtime-common/indexer.ts
@@ -570,7 +570,7 @@ export class Indexer {
       fieldArity({
         type: onRef,
         path: key,
-        value: [query, 'LIKE', v],
+        value: [query, 'ILIKE', v],
         errorHint: 'filter',
       }),
     ];

--- a/packages/runtime-common/tests/query-test.ts
+++ b/packages/runtime-common/tests/query-test.ts
@@ -704,6 +704,54 @@ const tests = Object.freeze({
     );
   },
 
+  'contains filter is case insensitive': async (
+    assert,
+    { indexer, loader, testCards },
+  ) => {
+    let { mango, vangogh, ringo } = testCards;
+    await setupIndex(indexer, [
+      {
+        card: mango,
+        data: {
+          search_doc: {
+            name: 'Mango',
+          },
+        },
+      },
+      {
+        card: vangogh,
+        data: {
+          search_doc: {
+            name: 'Van Gogh',
+          },
+        },
+      },
+      {
+        card: ringo,
+        data: {
+          search_doc: {
+            name: 'Ringo',
+          },
+        },
+      },
+    ]);
+
+    let type = await personCardType(testCards);
+    let { cards: results, meta } = await indexer.search(
+      new URL(testRealmURL),
+      {
+        filter: {
+          on: type,
+          contains: { name: 'mang' },
+        },
+      },
+      loader,
+    );
+
+    assert.strictEqual(meta.page.total, 1, 'the total results meta is correct');
+    assert.deepEqual(getIds(results), [mango.id], 'results are correct');
+  },
+
   "can use 'contains' to match multiple fields": async (
     assert,
     { indexer, loader, testCards },


### PR DESCRIPTION
This PR adds a "search for instances" action to the inspector panel.

Also this restores case insensitivity to the contains filter, which used to be the case before the postgres index.

![search-for-instances](https://github.com/cardstack/boxel/assets/61075/7bae847b-c46a-4096-a658-17c6903648ac)

