### PR TITLE
Return index card in the search results

### DIFF
--- a/packages/runtime-common/indexer.ts
+++ b/packages/runtime-common/indexer.ts
@@ -367,8 +367,6 @@ export class Indexer {
       ['i.realm_url = ', param(realmURL.href)],
       ['i.type =', param('instance')],
       ['is_deleted = FALSE OR is_deleted IS NULL'],
-      // our tests assert that the index card should not come back in the search results, so:
-      ['url !=', param(new RealmPaths(realmURL).fileURL('index.json').href)],
       realmVersionExpression({ withMaxVersion: version }),
     ];
     if (filter) {


### PR DESCRIPTION
This is to fix the situation in interact mode where if you close the index card in the stack, there is no way of adding that card back onto the stack. 

Before:

<img width="729" alt="image" src="https://github.com/cardstack/boxel/assets/273660/1273ecb4-ee63-4f42-8f14-22aa9b8bb86a">


After:

<img width="617" alt="image" src="https://github.com/cardstack/boxel/assets/273660/cf4c6a04-354a-46dc-922d-4b8731e175fc">
