### PR TITLE
Capture pre-rendered embedded format html/css

### DIFF
--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -351,6 +351,7 @@ export class CurrentRun {
     let searchData: Record<string, any> | undefined;
     let cardType: typeof CardDef | undefined;
     let isolatedHtml: string | undefined;
+    let embeddedHtml: string | undefined;
     try {
       let api = await this.loaderService.loader.import<typeof CardAPI>(
         `${baseRealm.url}card-api`,
@@ -385,6 +386,13 @@ export class CurrentRun {
       isolatedHtml = await this.#renderCard({
         card,
         format: 'isolated',
+        visit: this.visitFile.bind(this),
+        identityContext,
+        realmPath: this.#realmPaths,
+      });
+      embeddedHtml = await this.#renderCard({
+        card,
+        format: 'embedded',
         visit: this.visitFile.bind(this),
         identityContext,
         realmPath: this.#realmPaths,
@@ -437,6 +445,7 @@ export class CurrentRun {
         resource: doc.data,
         searchData,
         isolatedHtml,
+        embeddedHtml,
         lastModified,
         types: typesMaybeError.types,
         deps: new Set([

--- a/packages/host/tests/integration/components/card-editor-test.gts
+++ b/packages/host/tests/integration/components/card-editor-test.gts
@@ -32,6 +32,7 @@ import {
 } from '../../helpers';
 import { setupMatrixServiceMock } from '../../helpers/mock-matrix-service';
 import { renderComponent } from '../../helpers/render-component';
+import { waitUntil } from '@ember/test-helpers';
 
 let cardApi: typeof import('https://cardstack.com/base/card-api');
 let string: typeof import('https://cardstack.com/base/string');
@@ -479,6 +480,9 @@ module('Integration | card-editor', function (hooks) {
 
     await click('[data-test-create-new-card="Pet"] [data-test-save-card]');
     await waitFor('[data-test-pet="Simba"]');
+    await waitUntil(
+      () => !document.querySelector('[data-test-create-new-card="Pet"]'),
+    );
     assert.dom('[data-test-create-new-card="Pet"]').doesNotExist();
     assert.dom('[data-test-remove-card]').exists();
 

--- a/packages/host/tests/integration/components/card-editor-test.gts
+++ b/packages/host/tests/integration/components/card-editor-test.gts
@@ -4,6 +4,7 @@ import {
   click,
   RenderingTestContext,
 } from '@ember/test-helpers';
+import { waitUntil } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 
 import { setupRenderingTest } from 'ember-qunit';
@@ -32,7 +33,6 @@ import {
 } from '../../helpers';
 import { setupMatrixServiceMock } from '../../helpers/mock-matrix-service';
 import { renderComponent } from '../../helpers/render-component';
-import { waitUntil } from '@ember/test-helpers';
 
 let cardApi: typeof import('https://cardstack.com/base/card-api');
 let string: typeof import('https://cardstack.com/base/string');

--- a/packages/host/tests/integration/search-index-test.gts
+++ b/packages/host/tests/integration/search-index-test.gts
@@ -602,6 +602,11 @@ module(`Integration | search-index`, function (hooks) {
             <h1><@fields.firstName /></h1>
           </template>
         };
+        static embedded = class Isolated extends Component<typeof this> {
+          <template>
+            <h1> Person Embedded Card: <@fields.firstName /></h1>
+          </template>
+        };
       }
 
       class Boom extends CardDef {
@@ -668,11 +673,15 @@ module(`Integration | search-index`, function (hooks) {
         );
         if (entry?.type === 'doc') {
           assert.deepEqual(entry.doc.data.attributes?.firstName, 'Van Gogh');
-          let { isolatedHtml } =
+          let { isolatedHtml, embeddedHtml } =
             (await getInstance(realm, new URL(`${testRealmURL}vangogh`))) ?? {};
           assert.strictEqual(
             trimCardContainer(stripScopedCSSAttributes(isolatedHtml!)),
             cleanWhiteSpace(`<h1> Van Gogh </h1>`),
+          );
+          assert.strictEqual(
+            trimCardContainer(stripScopedCSSAttributes(embeddedHtml!)),
+            cleanWhiteSpace(`<h1> Person Embedded Card: Van Gogh </h1>`),
           );
         } else {
           assert.ok(
@@ -699,6 +708,11 @@ module(`Integration | search-index`, function (hooks) {
         static isolated = class Isolated extends Component<typeof this> {
           <template>
             <h1><@fields.firstName /></h1>
+          </template>
+        };
+        static embedded = class Isolated extends Component<typeof this> {
+          <template>
+            <h1> Person Embedded Card: <@fields.firstName /></h1>
           </template>
         };
       }
@@ -728,11 +742,15 @@ module(`Integration | search-index`, function (hooks) {
         );
         if (entry?.type === 'doc') {
           assert.deepEqual(entry.doc.data.attributes?.firstName, 'Van Gogh');
-          let { isolatedHtml } =
+          let { isolatedHtml, embeddedHtml } =
             (await getInstance(realm, new URL(`${testRealmURL}vangogh`))) ?? {};
           assert.strictEqual(
             trimCardContainer(stripScopedCSSAttributes(isolatedHtml!)),
             cleanWhiteSpace(`<h1> Van Gogh </h1>`),
+          );
+          assert.strictEqual(
+            trimCardContainer(stripScopedCSSAttributes(embeddedHtml!)),
+            cleanWhiteSpace(`<h1> Person Embedded Card: Van Gogh </h1>`),
           );
         } else {
           assert.ok(
@@ -781,6 +799,11 @@ module(`Integration | search-index`, function (hooks) {
       static isolated = class Isolated extends Component<typeof this> {
         <template>
           <h1><@fields.firstName /></h1>
+        </template>
+      };
+      static embedded = class Isolated extends Component<typeof this> {
+        <template>
+          <h1> Person Embedded Card: <@fields.firstName /></h1>
         </template>
       };
     }
@@ -841,7 +864,7 @@ module(`Integration | search-index`, function (hooks) {
     );
     if (entry?.type === 'doc') {
       assert.deepEqual(entry.doc.data.attributes?.firstName, 'Van Gogh');
-      let { isolatedHtml } =
+      let { isolatedHtml, embeddedHtml } =
         (await getInstance(
           realm,
           new URL(`${testRealmURL}working-van-gogh`),
@@ -849,6 +872,10 @@ module(`Integration | search-index`, function (hooks) {
       assert.strictEqual(
         trimCardContainer(stripScopedCSSAttributes(isolatedHtml!)),
         cleanWhiteSpace(`<h1> Van Gogh </h1>`),
+      );
+      assert.strictEqual(
+        trimCardContainer(stripScopedCSSAttributes(embeddedHtml!)),
+        cleanWhiteSpace(`<h1> Person Embedded Card: Van Gogh </h1>`),
       );
     } else {
       assert.ok(
@@ -899,6 +926,11 @@ module(`Integration | search-index`, function (hooks) {
       static isolated = class Isolated extends Component<typeof this> {
         <template>
           <h1><@fields.firstName /></h1>
+        </template>
+      };
+      static embedded = class Isolated extends Component<typeof this> {
+        <template>
+          <h1> Person Embedded Card: <@fields.firstName /></h1>
         </template>
       };
     }
@@ -961,12 +993,16 @@ module(`Integration | search-index`, function (hooks) {
     );
     if (entry?.type === 'doc') {
       assert.deepEqual(entry.doc.data.attributes?.firstName, 'Van Gogh');
-      let { isolatedHtml } =
+      let { isolatedHtml, embeddedHtml } =
         (await getInstance(realm, new URL(`${testRealmURL}working-vangogh`))) ??
         {};
       assert.strictEqual(
         trimCardContainer(stripScopedCSSAttributes(isolatedHtml!)),
         cleanWhiteSpace(`<h1> Van Gogh </h1>`),
+      );
+      assert.strictEqual(
+        trimCardContainer(stripScopedCSSAttributes(embeddedHtml!)),
+        cleanWhiteSpace(`<h1> Person Embedded Card: Van Gogh </h1>`),
       );
     } else {
       assert.ok(

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -250,7 +250,6 @@ module('indexing', function (hooks) {
 
   test('can store card pre-rendered html in the index', async function (assert) {
     let entry = await realm.searchIndex.instance(new URL(`${testRealm}mango`));
-    console.log(entry);
     if (entry?.type === 'instance') {
       assert.strictEqual(
         trimCardContainer(stripScopedCSSAttributes(entry!.isolatedHtml!)),

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -83,6 +83,11 @@ module('indexing', function (hooks) {
                   <h1><@fields.firstName/></h1>
                 </template>
               }
+              static embedded = class Isolated extends Component<typeof this> {
+                <template>
+                  <h1> Embedded Card Person: <@fields.firstName/></h1>
+                </template>
+              }
             }
           `,
           'pet.gts': `
@@ -245,11 +250,17 @@ module('indexing', function (hooks) {
 
   test('can store card pre-rendered html in the index', async function (assert) {
     let entry = await realm.searchIndex.instance(new URL(`${testRealm}mango`));
+    console.log(entry);
     if (entry?.type === 'instance') {
       assert.strictEqual(
         trimCardContainer(stripScopedCSSAttributes(entry!.isolatedHtml!)),
         cleanWhiteSpace(`<h1> Mango </h1>`),
-        'pre-rendered html is correct',
+        'pre-rendered isolated format html is correct',
+      );
+      assert.strictEqual(
+        trimCardContainer(stripScopedCSSAttributes(entry!.embeddedHtml!)),
+        cleanWhiteSpace(`<h1> Embedded Card Person: Mango </h1>`),
+        'pre-rendered embedded format html is correct',
       );
     } else {
       assert.ok(false, 'expected index entry not to be an error');
@@ -284,6 +295,10 @@ module('indexing', function (hooks) {
           assert.strictEqual(
             trimCardContainer(stripScopedCSSAttributes(item.isolatedHtml!)),
             cleanWhiteSpace(`<h1> Van Gogh </h1>`),
+          );
+          assert.strictEqual(
+            trimCardContainer(stripScopedCSSAttributes(item.embeddedHtml!)),
+            cleanWhiteSpace(`<h1> Embedded Card Person: Van Gogh </h1>`),
           );
         } else {
           assert.ok(false, 'expected index entry not to be an error');

--- a/packages/runtime-common/indexer.ts
+++ b/packages/runtime-common/indexer.ts
@@ -99,6 +99,7 @@ export interface IndexedInstance {
   canonicalURL: string;
   lastModified: number;
   isolatedHtml: string | null;
+  embeddedHtml: string | null;
   searchDoc: Record<string, any> | null;
   types: string[] | null;
   deps: string[] | null;
@@ -257,6 +258,7 @@ export class Indexer {
       url: canonicalURL,
       pristine_doc: instance,
       isolated_html: isolatedHtml,
+      embedded_html: embeddedHtml,
       search_doc: searchDoc,
       realm_version: realmVersion,
       realm_url: realmURL,
@@ -279,6 +281,7 @@ export class Indexer {
       realmURL,
       instance,
       isolatedHtml,
+      embeddedHtml,
       searchDoc,
       types,
       indexedAt: indexedAt != null ? parseInt(indexedAt) : null,
@@ -920,6 +923,7 @@ export interface InstanceEntry {
   resource: CardResource;
   searchData: Record<string, any>;
   isolatedHtml?: string;
+  embeddedHtml?: string;
   types: string[];
   deps: Set<string>;
 }
@@ -973,6 +977,7 @@ export class Batch {
               pristine_doc: entry.resource,
               search_doc: entry.searchData,
               isolated_html: entry.isolatedHtml,
+              embedded_html: entry.embeddedHtml,
               deps: [...entry.deps],
               types: entry.types,
               source: entry.source,

--- a/packages/runtime-common/tests/indexer-test.ts
+++ b/packages/runtime-common/tests/indexer-test.ts
@@ -870,6 +870,7 @@ const tests = Object.freeze({
         types: null,
         indexedAt: null,
         isolatedHtml: null,
+        embeddedHtml: null,
       });
     } else {
       assert.ok(false, `expected index entry to not be an error document`);
@@ -957,6 +958,7 @@ const tests = Object.freeze({
         deps: [],
         types: [],
         isolatedHtml: null,
+        embeddedHtml: null,
       });
     } else {
       assert.ok(false, `expected index entry to not be an error document`);


### PR DESCRIPTION
There is already `embedded_html` field in the db, in this PR I just ensure that we render the card for `embedded` format and include it during indexing.