### PR TITLE
improve header component

### DIFF
--- a/packages/boxel-ui/addon/src/components/card-container/index.gts
+++ b/packages/boxel-ui/addon/src/components/card-container/index.gts
@@ -32,7 +32,7 @@ const CardContainer: TemplateOnlyComponent<Signature> = <template>
       ...attributes
     >
       {{#if (or (has-block 'header') (bool @label) (bool @title))}}
-        <Header @label={{@label}} @title={{@title}}>
+        <Header @size='large' @subtitle={{@label}} @title={{@title}}>
           {{yield to='header'}}
         </Header>
       {{/if}}

--- a/packages/boxel-ui/addon/src/components/card-container/usage.gts
+++ b/packages/boxel-ui/addon/src/components/card-container/usage.gts
@@ -22,7 +22,11 @@ export default class CardContainerUsage extends Component {
           @isHighlighted={{this.isHighlighted}}
         >
           {{! Usage with BoxelHeader component }}
-          <BoxelHeader @title='Card' @isHighlighted={{this.isHighlighted}} />
+          <BoxelHeader
+            @size='large'
+            @title='Card'
+            @isHighlighted={{this.isHighlighted}}
+          />
           <div>Card Here</div>
         </BoxelCardContainer>
       </:example>

--- a/packages/boxel-ui/addon/src/components/header/index.gts
+++ b/packages/boxel-ui/addon/src/components/header/index.gts
@@ -1,15 +1,16 @@
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
 import cn from '../../helpers/cn.ts';
-import { bool, eq, or } from '../../helpers/truth-helpers.ts';
+import { eq, or } from '../../helpers/truth-helpers.ts';
 import Label from '../label/index.gts';
 
 interface Signature {
   Args: {
     hasBackground?: boolean;
+    hasBottomBorder?: boolean;
     isHighlighted?: boolean;
-    label?: string;
     size?: 'large';
+    subtitle?: string;
     title?: string;
   };
   Blocks: {
@@ -26,7 +27,8 @@ const Header: TemplateOnlyComponent<Signature> = <template>
     class={{cn
       has-background=@hasBackground
       highlighted=@isHighlighted
-      large=(or (bool @title) (eq @size 'large'))
+      large=(eq @size 'large')
+      hasBottomBorder=@hasBottomBorder
     }}
     data-test-boxel-header
     ...attributes
@@ -35,17 +37,18 @@ const Header: TemplateOnlyComponent<Signature> = <template>
       {{yield to='icon'}}
     {{/if}}
 
-    {{#if (or @label @title)}}
+    {{#if (or @subtitle @title)}}
       <div
         class='title {{if (has-block "detail") "with-detail"}}'
         data-test-boxel-header-title
       >
-        {{#if @label}}
+        {{#if @title}}{{@title}}{{/if}}
+        {{#if @subtitle}}
           <Label data-test-boxel-header-label>
-            {{@label}}
+            {{@subtitle}}
+
           </Label>
         {{/if}}
-        {{#if @title}}{{@title}}{{/if}}
       </div>
     {{/if}}
 
@@ -66,10 +69,10 @@ const Header: TemplateOnlyComponent<Signature> = <template>
   <style>
     @layer {
       header {
+        --default-header-padding: 0 var(--boxel-sp-xxxs) 0 var(--boxel-sp-sm);
         position: relative;
         display: flex;
         align-items: center;
-        padding: 0 var(--boxel-sp-xxxs) 0 var(--boxel-sp-sm);
         min-height: var(--boxel-header-min-height, 1.875rem); /* 30px */
         color: var(--boxel-header-text-color, var(--boxel-dark));
         border-top-right-radius: calc(
@@ -78,24 +81,26 @@ const Header: TemplateOnlyComponent<Signature> = <template>
         border-top-left-radius: calc(
           var(--boxel-header-border-radius, var(--boxel-border-radius)) - 1px
         );
-        font: 600 var(--boxel-header-text-size, var(--boxel-font-xs));
-        letter-spacing: var(--boxel-lsp-xl);
-        text-transform: uppercase;
+        font: var(--boxel-header-font-weight, 700)
+          var(--boxel-header-text-font, var(--boxel-font-sm));
+        letter-spacing: var(--boxel-header-letter-spacing, normal);
+        text-transform: var(--boxel-header-text-transform);
         transition:
           background-color var(--boxel-transition),
           color var(--boxel-transition);
         gap: var(--boxel-sp-xs);
+        padding: var(--boxel-header-padding, var(--default-header-padding));
       }
       header .title {
         max-width: var(
           --boxel-header-max-width,
-          calc(100% - 10rem)
+          100%
         ); /* this includes the space to show the header buttons */
-        text-overflow: ellipsis;
+        text-overflow: var(--boxel-header-text-overflow, ellipsis);
         overflow: hidden;
         text-wrap: nowrap;
       }
-      .header .title.with-detail {
+      header .title.with-detail {
         max-width: var(
           --boxel-header-detail-max-width,
           calc(100% - 23rem)
@@ -103,9 +108,12 @@ const Header: TemplateOnlyComponent<Signature> = <template>
       }
       .large {
         padding: var(--boxel-header-padding, var(--boxel-sp-xl));
-        font: 700 var(--boxel-header-text-size, var(--boxel-font-lg));
-        letter-spacing: var(--boxel-header-letter-spacing, normal);
-        text-transform: var(--boxel-header-text-transform, none);
+        font: var(--boxel-header-font-weight, 700)
+          var(--boxel-header-text-font, var(--boxel-font-lg));
+      }
+      .hasBottomBorder {
+        border-bottom: 1px solid
+          var(--boxel--header-border-color, var(--boxel-200));
       }
       .has-background {
         background-color: var(
@@ -123,7 +131,7 @@ const Header: TemplateOnlyComponent<Signature> = <template>
         gap: var(--boxel-sp-xxs);
       }
       .detail {
-        margin-left: var(--boxel-header-detail-margin-left, 0);
+        margin-left: var(--boxel-header-detail-margin-left, auto);
       }
     }
   </style>

--- a/packages/boxel-ui/addon/src/components/header/usage.gts
+++ b/packages/boxel-ui/addon/src/components/header/usage.gts
@@ -1,62 +1,206 @@
+import { cssVar } from '@cardstack/boxel-ui/helpers';
+import { ThreeDotsHorizontal } from '@cardstack/boxel-ui/icons';
 import { fn } from '@ember/helper';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
+import {
+  type CSSVariableInfo,
+  cssVariable,
+} from 'ember-freestyle/decorators/css-variable';
 
 import BoxelButton from '../button/index.gts';
+import CardContainer from '../card-container/index.gts';
+import BoxelDropdown from '../dropdown/index.gts';
+import IconButton from '../icon-button/index.gts';
 import BoxelHeader from './index.gts';
 
 export default class HeaderUsage extends Component {
-  @tracked title = 'Header';
+  @tracked title = 'Title';
+  @tracked subtitle = undefined;
+  @tracked size: 'large' | undefined = 'large';
   @tracked hasBackground = true;
   @tracked isHighlighted = false;
+  @tracked hasBottomBorder = false;
+
+  @cssVariable({ cssClassName: 'header-freestyle-container' })
+  declare boxelHeaderTextFont: CSSVariableInfo;
+  @cssVariable({ cssClassName: 'header-freestyle-container' })
+  declare boxelHeaderTextTransform: CSSVariableInfo;
+
+  get sizes() {
+    return ['large', '<anyting other than large>'];
+  }
 
   <template>
-    <FreestyleUsage @name='Header'>
-      <:description>
-        Usually shown at the top of card containers
-      </:description>
-      <:example>
-        <BoxelHeader
-          @title={{this.title}}
-          @hasBackground={{this.hasBackground}}
-          @isHighlighted={{this.isHighlighted}}
-        >
-          <:icon>
-            🌏
-          </:icon>
-          <:actions>
-            <BoxelButton>Edit</BoxelButton>
-          </:actions>
-        </BoxelHeader>
-      </:example>
-      <:api as |Args|>
-        <Args.String
-          @name='title'
-          @description='Header label text'
-          @value={{this.title}}
-          @onInput={{fn (mut this.title)}}
-        />
-        <Args.Bool
-          @name='hasBackground'
-          @description='(styling) Adds background color'
-          @defaultValue={{false}}
-          @value={{this.hasBackground}}
-          @onInput={{fn (mut this.hasBackground)}}
-        />
-        <Args.Bool
-          @name='isHighlighted'
-          @description='(styling) Highlights header'
-          @defaultValue={{false}}
-          @value={{this.isHighlighted}}
-          @onInput={{fn (mut this.isHighlighted)}}
-        />
-        <Args.Yield
-          @name='icon'
-          @description='Content for the icon of the header'
-        />
-        <Args.Yield @description='Content' />
-      </:api>
-    </FreestyleUsage>
+    <div
+      class='header-freestyle-container'
+      style={{cssVar
+        boxel-header-text-font=this.boxelHeaderTextFont.value
+        boxel-header-text-transform=this.boxelHeaderTextTransform.value
+      }}
+    >
+      <FreestyleUsage @name='Header'>
+        <:description>
+          Usually shown at the top of card containers
+        </:description>
+        <:example>
+          <BoxelHeader
+            @title={{this.title}}
+            @subtitle={{this.subtitle}}
+            @size={{this.size}}
+            @hasBackground={{this.hasBackground}}
+            @isHighlighted={{this.isHighlighted}}
+            @hasBottomBorder={{this.hasBottomBorder}}
+          >
+            <:icon>
+              🌏
+            </:icon>
+            <:actions>
+              <BoxelButton>Edit</BoxelButton>
+            </:actions>
+          </BoxelHeader>
+        </:example>
+        <:api as |Args|>
+          <Args.String
+            @name='title'
+            @description='Title'
+            @value={{this.title}}
+            @onInput={{fn (mut this.title)}}
+          />
+          <Args.String
+            @name='subtitle'
+            @description='Subtitle'
+            @value={{this.subtitle}}
+            @onInput={{fn (mut this.subtitle)}}
+          />
+          <Args.String
+            @name='size'
+            @description='large | <anyting other than large>'
+            @options={{this.sizes}}
+            @value={{this.size}}
+            @onInput={{fn (mut this.size)}}
+          />
+          <Args.Bool
+            @name='hasBackground'
+            @description='(styling) Adds background color'
+            @defaultValue={{false}}
+            @value={{this.hasBackground}}
+            @onInput={{fn (mut this.hasBackground)}}
+          />
+          <Args.Bool
+            @name='isHighlighted'
+            @description='(styling) Highlights header'
+            @defaultValue={{false}}
+            @value={{this.isHighlighted}}
+            @onInput={{fn (mut this.isHighlighted)}}
+          />
+          <Args.Bool
+            @name='hasBottomBorder'
+            @description='bottom border'
+            @defaultValue={{false}}
+            @value={{this.hasBottomBorder}}
+            @onInput={{fn (mut this.hasBottomBorder)}}
+          />
+          <Args.Yield
+            @name='icon'
+            @description='Content for the icon of the header'
+          />
+          <Args.Yield @description='Content' />
+        </:api>
+        <:cssVars as |Css|>
+          <Css.Basic
+            @name='boxel-header-text-font'
+            @type='font'
+            @description='some font'
+            @defaultValue={{this.boxelHeaderTextFont.defaults}}
+            @value={{this.boxelHeaderTextFont.value}}
+            @onInput={{this.boxelHeaderTextFont.update}}
+          />
+          <Css.Basic
+            @name='boxel-header-text-transform'
+            @type='text-transform'
+            @description='e.g. uppercase, lowercase'
+            @defaultValue={{this.boxelHeaderTextTransform.defaults}}
+            @value={{this.boxelHeaderTextTransform.value}}
+            @onInput={{this.boxelHeaderTextTransform.update}}
+          />
+        </:cssVars>
+      </FreestyleUsage>
+
+      <FreestyleUsage @name='Card Container Usage'>
+        <:example>
+          <CardContainer>
+            <BoxelHeader
+              @size='large'
+              @title='Card'
+              @isHighlighted={{this.isHighlighted}}
+            />
+            <div>Card Here</div>
+          </CardContainer>
+        </:example>
+      </FreestyleUsage>
+      <FreestyleUsage @name='Definition Usage'>
+        <:example>
+          <BoxelHeader
+            @title='Definition'
+            @hasBackground={{true}}
+            class='definition-container'
+          >
+            <:detail>
+              <div>
+                .gts
+              </div>
+            </:detail>
+          </BoxelHeader>
+        </:example>
+      </FreestyleUsage>
+      <FreestyleUsage @name='AI Command Results'>
+        <:example>
+          <BoxelHeader
+            @title=' Results'
+            @subtitle='25 results'
+            @hasBackground={{this.hasBackground}}
+            @isHighlighted={{this.isHighlighted}}
+            class='command-results'
+          >
+            <:icon>
+              🌏
+            </:icon>
+            <:actions>
+              <BoxelDropdown>
+                <:trigger as |bindings|>
+                  <IconButton
+                    @icon={{ThreeDotsHorizontal}}
+                    @width='20px'
+                    @height='20px'
+                    class='icon-button'
+                    aria-label='Options'
+                    data-test-more-options-button
+                    {{bindings}}
+                  />
+                </:trigger>
+              </BoxelDropdown>
+            </:actions>
+          </BoxelHeader>
+        </:example>
+      </FreestyleUsage>
+    </div>
+    <style>
+      .definition-container {
+        --boxel-header-text-transform: uppercase;
+        --boxel-header-text-color: var(--boxel-450);
+      }
+      .command-results {
+        --boxel-label-color: var(--boxel-400);
+        --boxel-label-font-weight: 500;
+        --boxel-label-font: 500 var(--boxel-font-xs);
+      }
+    </style>
+    <style>
+      :global(.header-freestyle-container) {
+        --boxel-header-text-transform: none;
+      }
+    </style>
   </template>
 }

--- a/packages/boxel-ui/addon/src/components/label/index.gts
+++ b/packages/boxel-ui/addon/src/components/label/index.gts
@@ -20,12 +20,9 @@ const Label: TemplateOnlyComponent<Signature> = <template>
   {{/let}}
   <style>
     .boxel-label {
-      --boxel-label-font: 700 var(--boxel-font-sm);
-      --boxel-label-letter-spacing: var(--boxel-lsp-sm);
-
       color: var(--boxel-label-color);
-      font: var(--boxel-label-font);
-      letter-spacing: var(--boxel-label-letter-spacing);
+      font: var(--boxel-label-font, 700 var(--boxel-font-sm));
+      letter-spacing: var(--boxel-label-letter-spacing, var(--boxel-lsp-sm) ;);
     }
   </style>
 </template>;

--- a/packages/boxel-ui/addon/src/components/label/index.gts
+++ b/packages/boxel-ui/addon/src/components/label/index.gts
@@ -22,7 +22,7 @@ const Label: TemplateOnlyComponent<Signature> = <template>
     .boxel-label {
       color: var(--boxel-label-color);
       font: var(--boxel-label-font, 700 var(--boxel-font-sm));
-      letter-spacing: var(--boxel-label-letter-spacing, var(--boxel-lsp-sm) ;);
+      letter-spacing: var(--boxel-label-letter-spacing, var(--boxel-lsp-sm));
     }
   </style>
 </template>;

--- a/packages/host/app/components/matrix/auth-container.gts
+++ b/packages/host/app/components/matrix/auth-container.gts
@@ -54,8 +54,6 @@ const AuthContainer: TemplateOnlyComponent<Signature> = <template>
       position: relative;
     }
     .header {
-      --boxel-header-icon-width: var(--boxel-icon-med);
-      --boxel-header-icon-height: var(--boxel-icon-med);
       --boxel-header-padding: var(--boxel-sp);
       --boxel-header-text-font: var(--boxel-font);
 

--- a/packages/host/app/components/matrix/auth-container.gts
+++ b/packages/host/app/components/matrix/auth-container.gts
@@ -57,7 +57,7 @@ const AuthContainer: TemplateOnlyComponent<Signature> = <template>
       --boxel-header-icon-width: var(--boxel-icon-med);
       --boxel-header-icon-height: var(--boxel-icon-med);
       --boxel-header-padding: var(--boxel-sp);
-      --boxel-header-text-size: var(--boxel-font);
+      --boxel-header-text-font: var(--boxel-font);
 
       background-color: var(--boxel-light);
       text-transform: uppercase;

--- a/packages/host/app/components/modal-container.gts
+++ b/packages/host/app/components/modal-container.gts
@@ -58,7 +58,7 @@ export default class ModalContainer extends Component<Signature> {
             {{yield to='sidebar'}}
           </aside>
         {{/if}}
-        <Header @title={{@title}} class='dialog-box__header'>
+        <Header @size='large' @title={{@title}} class='dialog-box__header'>
           <IconButton
             @icon={{IconX}}
             @width='12'

--- a/packages/host/app/components/operator-mode/definition-container/base.gts
+++ b/packages/host/app/components/operator-mode/definition-container/base.gts
@@ -79,15 +79,15 @@ const BaseDefinitionContainer: TemplateOnlyComponent<BaseSignature> = <template>
       overflow-wrap: anywhere;
     }
     .header {
-      --boxel-header-text-size: var(--boxel-font-size-sm);
+      --boxel-header-text-font: var(--boxel-font-size-sm);
       --boxel-header-padding: var(--boxel-sp-xs);
-      --boxel-header-text-size: var(--boxel-font-size-sm);
+      --boxel-header-text-font: var(--boxel-font-size-sm);
       --boxel-header-text-transform: uppercase;
       --boxel-header-letter-spacing: var(--boxel-lsp-xxl);
-      --boxel-header-detail-margin-left: auto;
       --boxel-header-detail-max-width: none;
       --boxel-header-background-color: var(--boxel-100);
       --boxel-header-text-color: var(--boxel-450);
+      --boxel-header-max-width: calc(100% - 10rem);
     }
 
     .header.active {

--- a/packages/host/app/components/operator-mode/definition-container/base.gts
+++ b/packages/host/app/components/operator-mode/definition-container/base.gts
@@ -81,7 +81,6 @@ const BaseDefinitionContainer: TemplateOnlyComponent<BaseSignature> = <template>
     .header {
       --boxel-header-text-font: var(--boxel-font-size-sm);
       --boxel-header-padding: var(--boxel-sp-xs);
-      --boxel-header-text-font: var(--boxel-font-size-sm);
       --boxel-header-text-transform: uppercase;
       --boxel-header-letter-spacing: var(--boxel-lsp-xxl);
       --boxel-header-detail-max-width: none;

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -540,7 +540,7 @@ export default class DetailPanel extends Component<Signature> {
     <style>
       .header {
         --boxel-header-padding: var(--boxel-sp-xs);
-        --boxel-header-text-size: var(--boxel-font-size-xs);
+        --boxel-header-text-font: var(--boxel-font-size-xs);
         --boxel-header-text-transform: uppercase;
         --boxel-header-letter-spacing: var(--boxel-lsp-xxl);
         --boxel-header-background-color: var(--boxel-100);

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -412,6 +412,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
           </div>
         {{else}}
           <Header
+            @size='large'
             @title={{this.headerTitle}}
             class={{cn 'header' header--icon-hovered=this.isHoverOnRealmIcon}}
             {{on
@@ -556,7 +557,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
         --boxel-header-icon-width: var(--boxel-icon-med);
         --boxel-header-icon-height: var(--boxel-icon-med);
         --boxel-header-padding: var(--boxel-sp-sm);
-        --boxel-header-text-size: var(--boxel-font-med);
+        --boxel-header-text-font: var(--boxel-font-med);
         --boxel-header-border-radius: var(--boxel-border-radius-xl);
         z-index: 1;
         background-color: var(--boxel-light);
@@ -578,7 +579,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
 
       .header--icon-hovered {
         --boxel-header-text-color: var(--boxel-highlight);
-        --boxel-header-text-size: var(--boxel-font);
+        --boxel-header-text-font: var(--boxel-font);
       }
 
       .save-indicator {
@@ -638,7 +639,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
         font: 700 var(--boxel-font);
         gap: var(--boxel-sp-xxxs);
         --boxel-header-padding: var(--boxel-sp-xs);
-        --boxel-header-text-size: var(--boxel-font-size);
+        --boxel-header-text-font: var(--boxel-font-size);
         --boxel-header-icon-width: var(--boxel-icon-sm);
         --boxel-header-icon-height: var(--boxel-icon-sm);
         --boxel-header-border-radius: var(--boxel-border-radius-lg);


### PR DESCRIPTION
This PR adapted the header component to be used for the search-result message https://app.zeplin.io/project/6583222060c21c47521d7385/screen/666c4c25703ae7a7d23ec146

- I changed `@large` to be a explicit set by `@size`
- I changed `@label` to `@subtitle`. And I also flipped them around so `@title` is above `@subtitle`. Our old workflow used to use this.
- I fixed usage to work 'some' CSS toggles and added examples for some use-cases we use

https://improve-header-component.boxel-ui-preview.stack.cards/


