### PR TITLE
CardPill bug fix and updates

### DIFF
--- a/packages/host/app/components/ai-assistant/card-picker/index.gts
+++ b/packages/host/app/components/ai-assistant/card-picker/index.gts
@@ -65,7 +65,11 @@ export default class AiAssistantCardPicker extends Component<Signature> {
           (not this.isViewAllAttachedCards)
         )
       }}
-        <Pill {{on 'click' this.toggleViewAllAttachedCards}} data-test-view-all>
+        <Pill
+          @kind='button'
+          {{on 'click' this.toggleViewAllAttachedCards}}
+          data-test-view-all
+        >
           View All ({{this.cardsToDisplay.length}})
         </Pill>
       {{/if}}
@@ -85,8 +89,6 @@ export default class AiAssistantCardPicker extends Component<Signature> {
     </div>
     <style>
       .card-picker {
-        --pill-height: 1.875rem;
-        --pill-content-max-width: 10rem;
         background-color: var(--boxel-light);
         color: var(--boxel-dark);
         display: flex;

--- a/packages/host/app/components/card-pill.gts
+++ b/packages/host/app/components/card-pill.gts
@@ -13,7 +13,7 @@ import Pill from '@cardstack/host/components/pill';
 import { type CardDef } from 'https://cardstack.com/base/card-api';
 
 interface CardPillSignature {
-  Element: HTMLDivElement;
+  Element: HTMLDivElement | HTMLButtonElement;
   Args: {
     card: CardDef;
     isAutoAttachedCard?: boolean;
@@ -28,10 +28,10 @@ export default class CardPill extends Component<CardPillSignature> {
 
   <template>
     <Pill
-      @inert={{true}}
       class={{cn 'card-pill' is-autoattached=@isAutoAttachedCard}}
       data-test-attached-card={{@card.id}}
       data-test-autoattached-card={{@isAutoAttachedCard}}
+      ...attributes
     >
       <:icon>
         <RealmInfoProvider @fileURL={{@card.id}}>
@@ -60,6 +60,28 @@ export default class CardPill extends Component<CardPillSignature> {
       </:default>
     </Pill>
     <style>
+      .card-pill {
+        --pill-icon-size: 18px;
+        border: 1px solid var(--boxel-400);
+        height: var(--pill-height, 1.875rem);
+      }
+      .is-autoattached {
+        border-style: dashed;
+      }
+      .card-content {
+        display: flex;
+        max-width: 100px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .card-content > :deep(.atom-format) {
+        background: none;
+        border-radius: 0;
+        white-space: inherit;
+        overflow: inherit;
+        text-overflow: inherit;
+      }
       .remove-button {
         --boxel-icon-button-width: 12px;
         --boxel-icon-button-height: 25px;
@@ -72,31 +94,6 @@ export default class CardPill extends Component<CardPillSignature> {
       .remove-button:focus:not(:disabled),
       .remove-button:hover:not(:disabled) {
         --icon-color: var(--boxel-highlight);
-      }
-      .card-pill {
-        --pill-icon-size: 18px;
-        padding: var(--boxel-sp-5xs);
-        background-color: var(--boxel-light);
-        border: 1px solid var(--boxel-400);
-        height: var(--pill-height);
-      }
-      .card-title {
-        max-width: 10rem;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
-      .is-autoattached {
-        border-style: dashed;
-      }
-      .card-content {
-        display: flex;
-        max-width: 100px;
-      }
-      :deep(.atom-format) {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
       }
     </style>
   </template>

--- a/packages/host/app/components/operator-mode/card-schema-editor.gts
+++ b/packages/host/app/components/operator-mode/card-schema-editor.gts
@@ -160,11 +160,6 @@ export default class CardSchemaEditor extends Component<Signature> {
         letter-spacing: var(--boxel-lsp-xs);
       }
 
-      .realm-icon > img {
-        height: 20px;
-        width: 20px;
-      }
-
       .header {
         display: flex;
         justify-content: space-between;
@@ -254,6 +249,7 @@ export default class CardSchemaEditor extends Component<Signature> {
           <Tooltip @placement='bottom'>
             <:trigger>
               <Pill
+                @kind='button'
                 {{on 'click' (fn @goToDefinition codeRef @cardType.localName)}}
                 data-test-card-schema-navigational-button
               >
@@ -340,6 +336,7 @@ export default class CardSchemaEditor extends Component<Signature> {
                       <Tooltip @placement='bottom'>
                         <:trigger>
                           <Pill
+                            @kind='button'
                             {{on
                               'click'
                               (fn @goToDefinition codeRef field.card.localName)

--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -1,4 +1,3 @@
-import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { hash } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
@@ -41,13 +40,11 @@ import { getCard } from '@cardstack/host/resources/card-resource';
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 import type { CatalogEntry } from 'https://cardstack.com/base/catalog-entry';
 
+import CardPill from '../card-pill';
 import ModalContainer from '../modal-container';
 
 import Pill from '../pill';
 import RealmDropdown, { type RealmDropdownItem } from '../realm-dropdown';
-
-import RealmIcon from './realm-icon';
-import RealmInfoProvider from './realm-info-provider';
 
 import type CardService from '../../services/card-service';
 import type LoaderService from '../../services/loader-service';
@@ -122,12 +119,15 @@ export default class CreateFileModal extends Component<Signature> {
               >
                 <div class='field-contents'>
                   {{#if this.definitionClass}}
-                    <Pill @inert={{true}}>
+                    <Pill class='definition-pill'>
                       {{this.definitionClass.displayName}}
                     </Pill>
                   {{else}}
                     {{#if this.selectedCatalogEntry}}
-                      <SelectedTypePill @entry={{this.selectedCatalogEntry}} />
+                      <CardPill
+                        @card={{this.selectedCatalogEntry}}
+                        data-test-selected-type={{this.selectedCatalogEntry.title}}
+                      />
                     {{/if}}
                     <Button
                       class={{if this.selectedCatalogEntry 'change-trigger'}}
@@ -298,6 +298,9 @@ export default class CreateFileModal extends Component<Signature> {
       .error-message {
         color: var(--boxel-error-100);
         margin-top: var(--boxel-sp-lg);
+      }
+      .definition-pill {
+        padding-left: var(--boxel-sp-xxxs);
       }
     </style>
   </template>
@@ -753,36 +756,3 @@ export function convertToClassName(input: string) {
 
   return className;
 }
-
-const SelectedTypePill: TemplateOnlyComponent<{
-  entry: CatalogEntry;
-}> = <template>
-  <Pill
-    @inert={{true}}
-    class='selected-type'
-    data-test-selected-type={{@entry.title}}
-  >
-    <:icon>
-      <RealmInfoProvider @fileURL={{@entry.id}}>
-        <:ready as |realmInfo|>
-          <RealmIcon
-            @realmIconURL={{realmInfo.iconURL}}
-            @realmName={{realmInfo.name}}
-          />
-        </:ready>
-      </RealmInfoProvider>
-    </:icon>
-    <:default>
-      {{@entry.title}}
-    </:default>
-  </Pill>
-  <style>
-    .selected-type {
-      padding: var(--boxel-sp-xxxs);
-      gap: var(--boxel-sp-xxxs);
-    }
-    .selected-type :deep(.icon) {
-      margin-right: 0;
-    }
-  </style>
-</template>;

--- a/packages/host/app/components/operator-mode/edit-field-modal.gts
+++ b/packages/host/app/components/operator-mode/edit-field-modal.gts
@@ -313,32 +313,6 @@ export default class EditFieldModal extends Component<Signature> {
         margin-left: auto;
       }
 
-      .pill {
-        border: 1px solid var(--boxel-400);
-        padding: var(--boxel-sp-xxxs) var(--boxel-sp-xs);
-        border-radius: 8px;
-        background-color: white;
-        font-weight: 600;
-        display: inline-flex;
-      }
-
-      .pill > div {
-        display: flex;
-      }
-
-      .pill > div > span {
-        margin: auto;
-      }
-
-      .realm-icon {
-        margin-right: var(--boxel-sp-xxxs);
-      }
-
-      .realm-icon > img {
-        height: 20px;
-        width: 20px;
-      }
-
       .card-chooser-area {
         display: flex;
       }
@@ -371,7 +345,7 @@ export default class EditFieldModal extends Component<Signature> {
         <FieldContainer @label='Field Type'>
           <div class='card-chooser-area'>
             {{#if this.fieldCard}}
-              <Pill @inert={{true}} data-test-selected-field-realm-icon>
+              <Pill data-test-selected-field-realm-icon>
                 <:icon>
                   {{#if this.fieldModuleURL.href}}
                     <RealmInfoProvider @fileURL={{this.fieldModuleURL.href}}>

--- a/packages/host/app/components/pill.gts
+++ b/packages/host/app/components/pill.gts
@@ -1,10 +1,10 @@
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
-import { element, cn } from '@cardstack/boxel-ui/helpers';
+import { element, cn, eq } from '@cardstack/boxel-ui/helpers';
 
 export interface PillSignature {
   Args: {
-    inert?: boolean;
+    kind?: 'button' | 'default';
   };
   Blocks: {
     default: [];
@@ -14,47 +14,49 @@ export interface PillSignature {
 }
 
 const Pill: TemplateOnlyComponent<PillSignature> = <template>
-  {{#let (element (if @inert 'div' 'button')) as |Tag|}}
-    <Tag class={{cn 'pill' inert=@inert}} ...attributes>
-      <figure class='icon'>
-        {{yield to='icon'}}
-      </figure>
+  {{#let (element (if (eq @kind 'button') 'button' 'div')) as |Tag|}}
+    <Tag class={{cn 'pill' button-pill=(eq @kind 'button')}} ...attributes>
+      {{#if (has-block 'icon')}}
+        <figure class='icon'>
+          {{yield to='icon'}}
+        </figure>
+      {{/if}}
       {{yield}}
     </Tag>
   {{/let}}
 
   <style>
-    .pill {
-      display: inline-flex;
-      align-items: center;
-      gap: var(--boxel-sp-5xs);
-      padding: var(--boxel-sp-5xs) var(--boxel-sp-xxxs) var(--boxel-sp-5xs)
-        var(--boxel-sp-5xs);
-      background-color: var(--boxel-light);
-      border: 1px solid var(--boxel-400);
-      border-radius: var(--boxel-border-radius-sm);
-      font: 700 var(--boxel-font-sm);
-      letter-spacing: var(--boxel-lsp-xs);
-    }
+    @layer {
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--pill-gap, var(--boxel-sp-5xs));
+        padding: var(
+          --pill-padding,
+          var(--boxel-sp-5xs) var(--boxel-sp-xxxs) var(--boxel-sp-5xs)
+            var(--boxel-sp-5xs)
+        );
+        background-color: var(--boxel-light);
+        color: var(--boxel-dark);
+        border: 1px solid var(--boxel-400);
+        border-radius: var(--boxel-border-radius-sm);
+        font: 700 var(--boxel-font-sm);
+        letter-spacing: var(--boxel-lsp-xs);
+      }
 
-    .inert {
-      border: 0;
-      background-color: var(--boxel-100);
-      color: inherit;
-    }
+      .button-pill:not(:disabled):hover {
+        background-color: var(--boxel-100);
+      }
 
-    .pill:not(.inert):hover {
-      background-color: var(--boxel-100);
-    }
+      .icon {
+        display: flex;
+        margin-block: 0;
+        margin-inline: 0;
+      }
 
-    .icon {
-      display: flex;
-      margin-block: 0;
-      margin-inline: 0;
-    }
-
-    .icon > :deep(*) {
-      height: var(--pill-icon-size, 1.25rem);
+      .icon > :deep(*) {
+        height: var(--pill-icon-size, 1.25rem);
+      }
     }
   </style>
 </template>;

--- a/packages/host/app/components/realm-dropdown.gts
+++ b/packages/host/app/components/realm-dropdown.gts
@@ -51,8 +51,8 @@ export default class RealmDropdown extends Component<Signature> {
           {{#if this.selectedRealm}}
             <RealmIcon
               class='icon'
-              width='20'
-              height='20'
+              width='18'
+              height='18'
               @realmIconURL={{this.selectedRealm.iconURL}}
               @realmName={{this.selectedRealm.name}}
             />
@@ -62,7 +62,7 @@ export default class RealmDropdown extends Component<Signature> {
           {{else}}
             Select a workspace
           {{/if}}
-          <DropdownArrowDown class='arrow-icon' width='18px' height='18px' />
+          <DropdownArrowDown class='arrow-icon' width='13px' height='13px' />
         </Button>
       </:trigger>
       <:content as |dd|>
@@ -83,14 +83,14 @@ export default class RealmDropdown extends Component<Signature> {
         width: var(--realm-dropdown-width, auto);
         display: flex;
         justify-content: flex-start;
-        gap: var(--boxel-sp-xxxs);
-        padding: var(--boxel-sp-xxxs);
+        gap: var(--boxel-sp-5xs);
+        padding: var(--boxel-sp-5xs) var(--boxel-sp-xxs) var(--boxel-sp-5xs)
+          var(--boxel-sp-5xs);
         border-radius: var(--boxel-border-radius);
       }
       .arrow-icon {
         --icon-color: var(--boxel-highlight);
         margin-left: auto;
-        padding-right: var(--boxel-sp-xxxs);
       }
       .realm-dropdown-trigger[aria-expanded='true'] .arrow-icon {
         transform: scaleY(-1);
@@ -101,7 +101,9 @@ export default class RealmDropdown extends Component<Signature> {
         white-space: nowrap;
       }
       .realm-dropdown-menu {
-        --boxel-menu-item-content-padding: var(--boxel-sp-xs);
+        --boxel-menu-item-content-padding: var(--boxel-sp-xxs)
+          var(--boxel-sp-xxs) var(--boxel-sp-xxs) var(--boxel-sp-xxxs);
+        --boxel-menu-item-gap: var(--boxel-sp-4xs);
         width: var(--realm-dropdown-width, auto);
       }
     </style>

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -1787,7 +1787,7 @@ export class TestCard extends ExportedCard {
     );
 
     assert
-      .dom('[data-test-inherits-from-field] .pill.inert')
+      .dom('[data-test-inherits-from-field] .pill')
       .includesText('exported card', 'the inherits from is correct');
     assert.dom('[data-test-create-definition]').isDisabled();
 
@@ -1831,7 +1831,7 @@ export class TestCard extends ExportedCard {
       `[data-test-create-file-modal][data-test-ready] [data-test-realm-name="Test Workspace B"]`,
     );
     assert
-      .dom('[data-test-inherits-from-field] .pill.inert')
+      .dom('[data-test-inherits-from-field] .pill')
       .includesText('Test Card', 'the inherits from is correct');
     assert
       .dom('[data-test-display-name-field]')
@@ -1861,7 +1861,7 @@ export class TestCard extends ExportedCard {
     );
 
     assert
-      .dom('[data-test-inherits-from-field] .pill.inert')
+      .dom('[data-test-inherits-from-field] .pill')
       .includesText('exported field', 'the inherits from is correct');
 
     await fillIn('[data-test-display-name-field]', 'Test Field');
@@ -1936,7 +1936,7 @@ export class TestField extends ExportedField {
       `[data-test-create-file-modal][data-test-ready] [data-test-realm-name="Test Workspace B"]`,
     );
     assert
-      .dom('[data-test-inherits-from-field] .pill.inert')
+      .dom('[data-test-inherits-from-field] .pill')
       .includesText('exported card', 'the inherits from is correct');
     assert
       .dom('[data-test-display-name-field]')
@@ -2095,7 +2095,7 @@ export class ExportedCard extends ExportedCardParent {
     );
 
     assert
-      .dom('[data-test-inherits-from-field] .pill.inert')
+      .dom('[data-test-inherits-from-field] .pill')
       .includesText('exported card', 'the inherits from is correct');
     assert.dom('[data-test-create-card-instance]').isEnabled();
 


### PR DESCRIPTION
Fixed the bug below. Also changed the component argument. Instead of `inert`, an optional new argument is `kind` and values are `button` or `default`. The inert styling was outdated, so removed it. We seem to be rarely using the button option so it made sense to make the default not be a button. Instead we place other interactive elements inside the pill, such as a remove icon. Adjusted the realm dropdown menu to match the pill styling.

Before:
<img width="500" alt="cardpill-before" src="https://github.com/cardstack/boxel/assets/16160806/8054295b-9e95-42db-817a-3380a6d41920">

After:
<img width="500" alt="cardpill-after" src="https://github.com/cardstack/boxel/assets/16160806/64fec58d-57ff-40f6-b0a9-919fbe0ac9bc">
