### PR TITLE
host: Add wrapping in assistant responses

### DIFF
--- a/packages/host/app/components/ai-assistant/message/index.gts
+++ b/packages/host/app/components/ai-assistant/message/index.gts
@@ -207,6 +207,10 @@ export default class AiAssistantMessage extends Component<Signature> {
         white-space: pre-wrap;
       }
 
+      .is-from-assistant .content :deep(pre code) {
+        overflow-wrap: break-word;
+      }
+
       .is-pending .content,
       .is-pending .content .cards > :deep(.card-pill),
       .is-pending .content .cards > :deep(.card-pill .boxel-card-container) {

--- a/packages/host/app/components/ai-assistant/message/index.gts
+++ b/packages/host/app/components/ai-assistant/message/index.gts
@@ -203,6 +203,10 @@ export default class AiAssistantMessage extends Component<Signature> {
         -moz-osx-font-smoothing: grayscale;
       }
 
+      .is-from-assistant .content :deep(pre) {
+        white-space: pre-wrap;
+      }
+
       .is-pending .content,
       .is-pending .content .cards > :deep(.card-pill),
       .is-pending .content .cards > :deep(.card-pill .boxel-card-container) {

--- a/packages/host/tests/integration/components/ai-assistant-panel-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel-test.gts
@@ -506,7 +506,8 @@ module('Integration | ai-assistant-panel', function (hooks) {
       content: {
         body: 'i am the body',
         msgtype: 'org.boxel.command',
-        formatted_body: 'A patch',
+        formatted_body:
+          'A patch<pre><code>https://www.example.com/path/to/resource?query=param1value&anotherQueryParam=anotherValue&additionalParam=additionalValue&longparameter1=someLongValue1</code></pre>',
         format: 'org.matrix.custom.html',
         data: JSON.stringify({
           command: {


### PR DESCRIPTION
<table>
<thead>
<tr>
<th>before</th><th>after</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="364" alt="Boxel 2024-07-04 14-49-43" src="https://github.com/cardstack/boxel/assets/43280/2e31e241-69ff-452b-84e4-66c6286b1ad9">
</td>
<td>
<img width="365" alt="Boxel 2024-07-04 14-47-30" src="https://github.com/cardstack/boxel/assets/43280/1a9053fa-dd43-45a9-93a5-c4a330d98d29">
</td>
</tr>
<tr>
<td>
<img width="367" alt="Boxel 2024-07-04 14-51-38" src="https://github.com/cardstack/boxel/assets/43280/fa93e915-2ab2-4b39-a290-c7dc231908bb">
</td>
<td>
<img width="368" alt="Boxel 2024-07-04 14-48-02" src="https://github.com/cardstack/boxel/assets/43280/2ed2f60c-25b6-48c4-841f-8375cd2f9df9">
</td>
</tr>
</tbody>
</table>

The `pre` property is needed to allow wrapping at all. The `code` one is additionally needed as otherwise it will only partially wrap:

<img width="366" alt="Boxel 2024-07-04 14-53-08" src="https://github.com/cardstack/boxel/assets/43280/1d14dce0-844d-4337-acba-5d6e3fe92409">
