### PR TITLE
host: Change test to use extracted storage key

### DIFF
--- a/packages/host/tests/integration/components/ai-assistant-panel-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel-test.gts
@@ -11,6 +11,7 @@ import { module, test } from 'qunit';
 import { Deferred, baseRealm } from '@cardstack/runtime-common';
 import { Loader } from '@cardstack/runtime-common/loader';
 
+import { currentRoomIdPersistenceKey } from '@cardstack/host/components/ai-assistant/panel';
 import CardPrerender from '@cardstack/host/components/card-prerender';
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
 
@@ -1084,7 +1085,7 @@ module('Integration | ai-assistant-panel', function (hooks) {
 
     await click('[data-test-close-ai-assistant]');
     window.localStorage.setItem(
-      'aiPanelCurrentRoomId',
+      currentRoomIdPersistenceKey,
       "room-id-that-doesn't-exist-and-should-not-break-the-implementation",
     );
     await click('[data-test-open-ai-assistant]');
@@ -1095,7 +1096,7 @@ module('Integration | ai-assistant-panel', function (hooks) {
         "test room 3 is the most recently created room and it's opened initially",
       );
 
-    window.localStorage.removeItem('aiPanelCurrentRoomId'); // Cleanup
+    window.localStorage.removeItem(currentRoomIdPersistenceKey); // Cleanup
   });
 
   test('can close past-sessions list on outside click', async function (assert) {


### PR DESCRIPTION
I found this while looking into a possible Matrix room persistence bug.