### PR TITLE
ci: Add Matrix trace uploads

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,6 +112,15 @@ jobs:
           path: packages/matrix/blob-report
           retention-days: 1
 
+      - name: Upload Playwright traces
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces-${{ matrix.shardIndex }}
+          path: packages/matrix/test-results/**/trace.zip
+          retention-days: 30
+          if-no-files-found: ignore
+
   matrix-client-merge-reports-and-publish:
     name: Merge Matrix reports and publish
     if: always()


### PR DESCRIPTION
This is extracted from #1400, I needed it there to understand why tests were failing. It’s my understanding that these should be included in the blob reports that are merged into the HTML report as the documentation [says](https://playwright.dev/docs/test-sharding#merging-reports-from-multiple-shards):

> Blob report contains information about all the tests that were run and their results as well as all test attachments such as traces and screenshot diffs.

That’s not working, so this uploads them as artefacts to the workflow, they can be downloaded via the Actions UI and viewed [with this tool](https://trace.playwright.dev/).

<img width="650" alt="boxel@53b51ff 2024-07-08 15-27-58" src="https://github.com/cardstack/boxel/assets/43280/8be6ace7-276b-4705-ae7d-3eb415e1efab">
