### PR TITLE
Remove auto-generated ember ID's from prerendered HTML

### DIFF
--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -412,20 +412,24 @@ export class CurrentRun {
           identityContext,
         },
       );
-      isolatedHtml = await this.#renderCard({
-        card,
-        format: 'isolated',
-        visit: this.visitFile.bind(this),
-        identityContext,
-        realmPath: this.#realmPaths,
-      });
-      atomHtml = await this.#renderCard({
-        card,
-        format: 'atom',
-        visit: this.visitFile.bind(this),
-        identityContext,
-        realmPath: this.#realmPaths,
-      });
+      isolatedHtml = sanitizeHTML(
+        await this.#renderCard({
+          card,
+          format: 'isolated',
+          visit: this.visitFile.bind(this),
+          identityContext,
+          realmPath: this.#realmPaths,
+        }),
+      );
+      atomHtml = sanitizeHTML(
+        await this.#renderCard({
+          card,
+          format: 'atom',
+          visit: this.visitFile.bind(this),
+          identityContext,
+          realmPath: this.#realmPaths,
+        }),
+      );
       cardType = Reflect.getPrototypeOf(card)?.constructor as typeof CardDef;
       let data = api.serializeCard(card, { includeComputeds: true });
       // prepare the document for index serialization
@@ -548,13 +552,15 @@ export class CurrentRun {
           identityContext: modifiedContext,
         },
       );
-      let embeddedHtml = await this.#renderCard({
-        card,
-        format: 'embedded',
-        visit: this.visitFile.bind(this),
-        identityContext: modifiedContext,
-        realmPath: this.#realmPaths,
-      });
+      let embeddedHtml = sanitizeHTML(
+        await this.#renderCard({
+          card,
+          format: 'embedded',
+          visit: this.visitFile.bind(this),
+          identityContext: modifiedContext,
+          realmPath: this.#realmPaths,
+        }),
+      );
       let ref = refURL === types[0].refURL ? 'default' : refURL;
       result[ref] = embeddedHtml;
     }
@@ -622,6 +628,11 @@ export class CurrentRun {
     deferred.fulfill(result);
     return result;
   }
+}
+
+function sanitizeHTML(html: string): string {
+  // currently this only involves removing auto-generated ember ID's
+  return html.replace(/\s+id="ember[0-9]+"/g, '');
 }
 
 function assertURLEndsWithJSON(url: URL): URL {

--- a/packages/host/tests/integration/search-index-test.gts
+++ b/packages/host/tests/integration/search-index-test.gts
@@ -1002,8 +1002,18 @@ module(`Integration | search-index`, function (hooks) {
         cleanWhiteSpace(`<h1> Van Gogh </h1>`),
       );
       assert.strictEqual(
+        false,
+        isolatedHtml!.includes('id="ember'),
+        `isolated HTML does not include ember ID's`,
+      );
+      assert.strictEqual(
         trimCardContainer(stripScopedCSSAttributes(embeddedHtml!)),
         cleanWhiteSpace(`<h1> Person Embedded Card: Van Gogh </h1>`),
+      );
+      assert.strictEqual(
+        false,
+        embeddedHtml!.includes('id="ember'),
+        `embeddedHtml HTML does not include ember ID's`,
       );
     } else {
       assert.ok(
@@ -1061,6 +1071,11 @@ module(`Integration | search-index`, function (hooks) {
       trimCardContainer(stripScopedCSSAttributes(atomHtml!)),
       cleanWhiteSpace(`<div class="atom">Van Gogh</div>`),
       'atom html is correct',
+    );
+    assert.strictEqual(
+      false,
+      atomHtml!.includes('id="ember'),
+      `atom HTML does not include ember ID's`,
     );
   });
 
@@ -1179,6 +1194,11 @@ module(`Integration | search-index`, function (hooks) {
     let { embeddedHtml, _embeddedHtmlByClassHierarchy } =
       (await getInstance(realm, new URL(`${testRealmURL}germaine`))) ?? {};
     assert.strictEqual(
+      false,
+      embeddedHtml!.includes('id="ember'),
+      `HTML does not include ember ID's`,
+    );
+    assert.strictEqual(
       trimCardContainer(stripScopedCSSAttributes(embeddedHtml!)),
       cleanWhiteSpace(
         `<h1> Fancy Person Embedded Card: Germaine - hot pink </h1>`,
@@ -1200,11 +1220,21 @@ module(`Integration | search-index`, function (hooks) {
       'default embedded HTML is correct',
     );
     assert.strictEqual(
+      false,
+      embeddedHtmls['default'].includes('id="ember'),
+      `default embedded HTML does not include ember ID's`,
+    );
+    assert.strictEqual(
       trimCardContainer(
         stripScopedCSSAttributes(embeddedHtmls[`${testRealmURL}person/Person`]),
       ),
       cleanWhiteSpace(`<h1> Person Embedded Card: Germaine </h1>`),
       `${testRealmURL}person/Person embedded HTML is correct`,
+    );
+    assert.strictEqual(
+      false,
+      embeddedHtmls[`${testRealmURL}person/Person`].includes('id="ember'),
+      `${testRealmURL}person/Person embedded HTML does not include ember ID's`,
     );
     assert.strictEqual(
       trimCardContainer(stripScopedCSSAttributes(embeddedHtmls[cardDefRefURL])),
@@ -1226,6 +1256,11 @@ module(`Integration | search-index`, function (hooks) {
         </div>
       `),
       `${cardDefRefURL} embedded HTML is correct`,
+    );
+    assert.strictEqual(
+      false,
+      embeddedHtmls[cardDefRefURL].includes('id="ember'),
+      `${cardDefRefURL} embedded HTML does not include ember ID's`,
     );
   });
 


### PR DESCRIPTION
This PR strips out auto-generated ember ID's from the HTML of the prerendered cards.