### PR TITLE
fix realm_user_permissions primary key

### DIFF
--- a/packages/host/config/schema/1720544504545_schema.sql
+++ b/packages/host/config/schema/1720544504545_schema.sql
@@ -28,7 +28,7 @@
    username TEXT NOT NULL,
    read BOOLEAN NOT NULL,
    write BOOLEAN NOT NULL,
-   PRIMARY KEY ( realm_url, username, read, write ) 
+   PRIMARY KEY ( realm_url, username ) 
 );
 
  CREATE TABLE IF NOT EXISTS realm_versions (

--- a/packages/realm-server/migrations/1720544504545_fix-user-permissions-pk.js
+++ b/packages/realm-server/migrations/1720544504545_fix-user-permissions-pk.js
@@ -1,0 +1,18 @@
+let table = 'realm_user_permissions';
+
+exports.up = (pgm) => {
+  // since we are loosening the PK remove all records as we may have records
+  // that currently have PK collisions
+  pgm.sql(`DELETE FROM ${table}`);
+  pgm.dropConstraint(table, 'unique_realm_user_permissions');
+  pgm.addConstraint(table, `${table}_pkey`, {
+    primaryKey: ['realm_url', 'username'],
+  });
+};
+
+exports.down = (pgm) => {
+  pgm.dropConstraint(table, `${table}_pkey`);
+  pgm.addConstraint(table, 'unique_realm_user_permissions', {
+    primaryKey: ['realm_url', 'username', 'read', 'write'],
+  });
+};


### PR DESCRIPTION
Fix the `realm_user_permissions` table primary key. This primary key should only include the `realm` and `user` columns.