### PR TITLE
Cleaning up usage of realm handler APIs

### DIFF
--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -345,8 +345,8 @@ export function setupServerSentEvents(hooks: NestedHooks) {
           },
         }),
       );
-      if (!response.ok) {
-        throw new Error(`failed to connect to realm: ${response.status}`);
+      if (!response?.ok) {
+        throw new Error(`failed to connect to realm: ${response?.status}`);
       }
       let reader = response.body!.getReader();
       let timeout = setTimeout(

--- a/packages/host/tests/integration/components/text-input-validator-test.gts
+++ b/packages/host/tests/integration/components/text-input-validator-test.gts
@@ -184,14 +184,6 @@ module('Integration | text-input-validator', function (hooks) {
 
   test('if json contains undeserializable values, the input box should show empty input box', async function (assert) {
     let card = await loadCard(`${testRealmURL}Sample/1`);
-    let response = await realm.handle(
-      new Request(`${testRealmURL}Sample/1`, {
-        headers: {
-          Accept: 'application/vnd.card+json',
-        },
-      }),
-    );
-    await response.json();
     await renderComponent(
       class TestDriver extends GlimmerComponent {
         <template>

--- a/packages/host/tests/integration/realm-test.ts
+++ b/packages/host/tests/integration/realm-test.ts
@@ -6,7 +6,7 @@ import { module, test } from 'qunit';
 
 import { validate as uuidValidate } from 'uuid';
 
-import { baseRealm, CodeRef } from '@cardstack/runtime-common';
+import { baseRealm, CodeRef, Realm } from '@cardstack/runtime-common';
 import { isSingleCardDocument } from '@cardstack/runtime-common/card-document';
 import {
   cardSrc,
@@ -48,6 +48,14 @@ module('Integration | realm', function (hooks) {
     async () => await loader.import(`${baseRealm.url}card-api`),
   );
 
+  async function handle(realm: Realm, ...args: Parameters<Realm['handle']>) {
+    let result = await realm.handle(...args);
+    if (!result) {
+      throw new Error(`realm didn't handle request`);
+    }
+    return result;
+  }
+
   test('realm can serve GET card requests', async function (assert) {
     let { realm, adapter } = await setupIntegrationTestRealm({
       loader,
@@ -65,7 +73,8 @@ module('Integration | realm', function (hooks) {
       },
     });
 
-    let response = await realm.handle(
+    let response = await handle(
+      realm,
       new Request(`${testRealmURL}dir/empty`, {
         headers: {
           Accept: 'application/vnd.card+json',
@@ -148,7 +157,8 @@ module('Integration | realm', function (hooks) {
       },
     });
 
-    let response = await realm.handle(
+    let response = await handle(
+      realm,
       new Request(`${testRealmURL}dir/mango`, {
         headers: {
           Accept: 'application/vnd.card+json',
@@ -254,7 +264,8 @@ module('Integration | realm', function (hooks) {
       },
     });
 
-    let response = await realm.handle(
+    let response = await handle(
+      realm,
       new Request(`${testRealmURL}dir/mango`, {
         headers: {
           Accept: 'application/vnd.card+json',
@@ -352,7 +363,8 @@ module('Integration | realm', function (hooks) {
       realmURL: `${testRealmURL}root/`,
     });
     {
-      let response = await realm.handle(
+      let response = await handle(
+        realm,
         new Request(`${testRealmURL}root/dir/empty`, {
           headers: {
             Accept: 'application/vnd.card+json',
@@ -368,7 +380,8 @@ module('Integration | realm', function (hooks) {
       );
     }
     {
-      let response = await realm.handle(
+      let response = await handle(
+        realm,
         new Request(`${testRealmURL}root/_search`, {
           headers: {
             Accept: 'application/vnd.card+json',
@@ -394,7 +407,8 @@ module('Integration | realm', function (hooks) {
       loader,
       contents: {},
     });
-    let response = await realm.handle(
+    let response = await handle(
+      realm,
       new Request(testRealmURL, {
         method: 'POST',
         headers: {
@@ -473,7 +487,8 @@ module('Integration | realm', function (hooks) {
         },
       },
     });
-    let response = await realm.handle(
+    let response = await handle(
+      realm,
       new Request(testRealmURL, {
         method: 'POST',
         headers: {
@@ -641,7 +656,8 @@ module('Integration | realm', function (hooks) {
       realm,
       expectedEvents,
       callback: async () => {
-        let response = realm.handle(
+        let response = handle(
+          realm,
           new Request(`${testRealmURL}dir/card`, {
             method: 'PATCH',
             headers: {
@@ -785,7 +801,8 @@ module('Integration | realm', function (hooks) {
         },
       },
     });
-    let response = await realm.handle(
+    let response = await handle(
+      realm,
       new Request(`${testRealmURL}ski-trip`, {
         method: 'PATCH',
         headers: {
@@ -957,7 +974,8 @@ module('Integration | realm', function (hooks) {
         },
       },
     });
-    let response = await realm.handle(
+    let response = await handle(
+      realm,
       new Request(`${testRealmURL}jackie`, {
         method: 'PATCH',
         headers: {
@@ -1163,7 +1181,8 @@ module('Integration | realm', function (hooks) {
       },
     });
 
-    let response = await realm.handle(
+    let response = await handle(
+      realm,
       new Request(`${testRealmURL}jackie`, {
         method: 'PATCH',
         headers: { Accept: 'application/vnd.card+json' },
@@ -1286,7 +1305,8 @@ module('Integration | realm', function (hooks) {
       },
     });
 
-    let response = await realm.handle(
+    let response = await handle(
+      realm,
       new Request(`${testRealmURL}jackie`, {
         method: 'PATCH',
         headers: { Accept: 'application/vnd.card+json' },
@@ -1400,7 +1420,8 @@ module('Integration | realm', function (hooks) {
       },
     });
 
-    let response = await realm.handle(
+    let response = await handle(
+      realm,
       new Request(`${testRealmURL}jackie`, {
         method: 'PATCH',
         headers: { Accept: 'application/vnd.card+json' },
@@ -1514,7 +1535,8 @@ module('Integration | realm', function (hooks) {
     });
 
     // changing linksTo field only
-    let response = await realm.handle(
+    let response = await handle(
+      realm,
       new Request(`${testRealmURL}jackie`, {
         method: 'PATCH',
         headers: { Accept: 'application/vnd.card+json' },
@@ -1653,7 +1675,8 @@ module('Integration | realm', function (hooks) {
       },
     });
 
-    let response = await realm.handle(
+    let response = await handle(
+      realm,
       new Request(`${testRealmURL}jackie`, {
         method: 'PATCH',
         headers: { Accept: 'application/vnd.card+json' },
@@ -1778,7 +1801,8 @@ module('Integration | realm', function (hooks) {
         },
       },
     });
-    let response = await realm.handle(
+    let response = await handle(
+      realm,
       new Request(`${testRealmURL}dir/mango`, {
         method: 'PATCH',
         headers: {
@@ -1969,7 +1993,8 @@ module('Integration | realm', function (hooks) {
       realm,
       expectedEvents,
       callback: async () => {
-        let response = realm.handle(
+        let response = handle(
+          realm,
           new Request(`${testRealmURL}cards/2`, {
             method: 'DELETE',
             headers: {
@@ -2009,7 +2034,8 @@ module('Integration | realm', function (hooks) {
         'dir/person.gts': cardSrc,
       },
     });
-    let response = await realm.handle(
+    let response = await handle(
+      realm,
       new Request(`${testRealmURL}dir/person.gts`, {
         headers: {
           Accept: 'application/vnd.card+source',
@@ -2032,7 +2058,8 @@ module('Integration | realm', function (hooks) {
         'dir/person.gts': cardSrc,
       },
     });
-    let response = await realm.handle(
+    let response = await handle(
+      realm,
       new Request(`${testRealmURL}dir/person`, {
         headers: {
           Accept: 'application/vnd.card+source',
@@ -2052,7 +2079,8 @@ module('Integration | realm', function (hooks) {
       loader,
       contents: {},
     });
-    let response = await realm.handle(
+    let response = await handle(
+      realm,
       new Request(`${testRealmURL}dir/person`, {
         headers: {
           Accept: 'application/vnd.card+source',
@@ -2083,7 +2111,8 @@ module('Integration | realm', function (hooks) {
         realm,
         expectedEvents,
         callback: async () => {
-          let response = realm.handle(
+          let response = handle(
+            realm,
             new Request(`${testRealmURL}dir/person.gts`, {
               method: 'POST',
               headers: {
@@ -2104,7 +2133,8 @@ module('Integration | realm', function (hooks) {
       );
     }
     {
-      let response = await realm.handle(
+      let response = await handle(
+        realm,
         new Request(`${testRealmURL}dir/person.gts`, {
           headers: {
             Accept: 'application/vnd.card+source',
@@ -2151,7 +2181,8 @@ module('Integration | realm', function (hooks) {
       realm,
       expectedEvents,
       callback: async () => {
-        let response = realm.handle(
+        let response = handle(
+          realm,
           new Request(`${testRealmURL}person`, {
             headers: {
               Accept: 'application/vnd.card+source',
@@ -2161,7 +2192,8 @@ module('Integration | realm', function (hooks) {
         await realm.flushUpdateEvents();
         assert.strictEqual((await response).status, 302, 'file exists');
 
-        response = realm.handle(
+        response = handle(
+          realm,
           new Request(`${testRealmURL}person`, {
             method: 'DELETE',
             headers: {
@@ -2175,7 +2207,8 @@ module('Integration | realm', function (hooks) {
     });
     assert.strictEqual(response.status, 204, 'file is deleted');
 
-    response = await realm.handle(
+    response = await handle(
+      realm,
       new Request(`${testRealmURL}person`, {
         headers: {
           Accept: 'application/vnd.card+source',
@@ -2192,7 +2225,10 @@ module('Integration | realm', function (hooks) {
         'dir/person.gts': cardSrc,
       },
     });
-    let response = await realm.handle(new Request(`${testRealmURL}dir/person`));
+    let response = await handle(
+      realm,
+      new Request(`${testRealmURL}dir/person`),
+    );
     assert.strictEqual(response.status, 200, 'HTTP 200 status code');
     let compiledJS = await response.text();
     assert.codeEqual(
@@ -2209,7 +2245,8 @@ module('Integration | realm', function (hooks) {
         'dir/person.gts': cardSrc,
       },
     });
-    let response = await realm.handle(
+    let response = await handle(
+      realm,
       new Request(`${testRealmURL}dir/person.gts`),
     );
     assert.strictEqual(response.status, 200, 'HTTP 200 status code');
@@ -2235,7 +2272,8 @@ module('Integration | realm', function (hooks) {
         'dir/index.html': html,
       },
     });
-    let response = await realm.handle(
+    let response = await handle(
+      realm,
       new Request(`${testRealmURL}dir/index.html`),
     );
     assert.strictEqual(response.status, 200, 'HTTP 200 status code');
@@ -2260,7 +2298,8 @@ module('Integration | realm', function (hooks) {
         },
       },
     });
-    let response = await realm.handle(
+    let response = await handle(
+      realm,
       new Request(`${testRealmURL}_search`, {
         headers: {
           Accept: 'application/vnd.card+json',
@@ -2346,7 +2385,8 @@ module('Integration | realm', function (hooks) {
       },
     });
 
-    let response = await realm.handle(
+    let response = await handle(
+      realm,
       new Request(
         `${testRealmURL}_search?${stringify({
           sort: [
@@ -2515,7 +2555,8 @@ module('Integration | realm', function (hooks) {
         'dir/subdir/file.txt': '',
       },
     });
-    let response = await realm.handle(
+    let response = await handle(
+      realm,
       new Request(`${testRealmURL}dir/`, {
         headers: {
           Accept: 'application/vnd.api+json',
@@ -2579,7 +2620,8 @@ posts/ignore-me.gts
     });
 
     {
-      let response = await realm.handle(
+      let response = await handle(
+        realm,
         new Request(
           `${testRealmURL}_typeOf?${stringify({
             type: 'exportedCard',
@@ -2597,7 +2639,8 @@ posts/ignore-me.gts
       assert.strictEqual(response.status, 404, 'HTTP 404 response');
     }
     {
-      let response = await realm.handle(
+      let response = await handle(
+        realm,
         new Request(`${testRealmURL}dir/`, {
           headers: {
             Accept: 'application/vnd.api+json',
@@ -2607,7 +2650,8 @@ posts/ignore-me.gts
       assert.strictEqual(response.status, 404, 'HTTP 404 response');
     }
     {
-      let response = await realm.handle(
+      let response = await handle(
+        realm,
         new Request(testRealmURL, {
           headers: {
             Accept: 'application/vnd.api+json',
@@ -2623,7 +2667,8 @@ posts/ignore-me.gts
       );
     }
     {
-      let response = await realm.handle(
+      let response = await handle(
+        realm,
         new Request(`${testRealmURL}posts/`, {
           headers: {
             Accept: 'application/vnd.api+json',
@@ -2651,7 +2696,8 @@ posts/ignore-me.gts
         }`,
       },
     });
-    let response = await realm.handle(
+    let response = await handle(
+      realm,
       new Request(`${testRealmURL}_info`, {
         headers: {
           Accept: 'application/vnd.api+json',
@@ -2681,7 +2727,8 @@ posts/ignore-me.gts
       loader,
       contents: {},
     });
-    let response = await realm.handle(
+    let response = await handle(
+      realm,
       new Request(`${testRealmURL}_info`, {
         headers: {
           Accept: 'application/vnd.api+json',
@@ -2709,7 +2756,8 @@ posts/ignore-me.gts
         '.realm.json': `Some example content that is not valid json`,
       },
     });
-    let response = await realm.handle(
+    let response = await handle(
+      realm,
       new Request(`${testRealmURL}_info`, {
         headers: {
           Accept: 'application/vnd.api+json',

--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -215,7 +215,7 @@ let dist: URL = new URL(distURL);
       },
     );
     realms.push(realm);
-    virtualNetwork.mount(realm.maybeExternalHandle);
+    virtualNetwork.mount(realm.handle);
   }
 
   let server = new RealmServer(realms, virtualNetwork);

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -214,7 +214,7 @@ export async function runBaseRealmServer(
     dbAdapter,
     permissions,
   });
-  virtualNetwork.mount(testBaseRealm.maybeExternalHandle);
+  virtualNetwork.mount(testBaseRealm.handle);
   await testBaseRealm.ready;
   let testBaseRealmServer = new RealmServer([testBaseRealm], virtualNetwork);
   return testBaseRealmServer.listen(parseInt(localBaseRealmURL.port));
@@ -249,7 +249,7 @@ export async function runTestRealmServer({
     queue,
     dbAdapter,
   });
-  virtualNetwork.mount(testRealm.maybeExternalHandle);
+  virtualNetwork.mount(testRealm.handle);
   await testRealm.ready;
   let testRealmServer = await new RealmServer(
     [testRealm],

--- a/packages/realm-server/tests/loader-test.ts
+++ b/packages/realm-server/tests/loader-test.ts
@@ -165,7 +165,7 @@ module('loader', function (hooks) {
           dbAdapter,
           queue,
         });
-        virtualNetwork.mount(realm.maybeHandle.bind(realm));
+        virtualNetwork.mount(realm.handle.bind(realm));
         await realm.ready;
       },
     });

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -2095,7 +2095,7 @@ module('Realm Server', function (hooks) {
     setupDB(hooks, {
       beforeEach: async (dbAdapter, queue) => {
         if (testRealm2) {
-          virtualNetwork.unmount(testRealm2.maybeExternalHandle);
+          virtualNetwork.unmount(testRealm2.handle);
         }
         ({ testRealm: testRealm2, testRealmServer: testRealmServer2 } =
           await runTestRealmServer({
@@ -2650,7 +2650,7 @@ module('Realm server serving multiple realms', function (hooks) {
         dbAdapter,
         deferStartUp: true,
       });
-      virtualNetwork.mount(base.maybeExternalHandle);
+      virtualNetwork.mount(base.handle);
 
       testRealm = await createRealm({
         dir: dir.name,
@@ -2660,7 +2660,7 @@ module('Realm server serving multiple realms', function (hooks) {
         dbAdapter,
         deferStartUp: true,
       });
-      virtualNetwork.mount(testRealm.maybeExternalHandle);
+      virtualNetwork.mount(testRealm.handle);
 
       testRealmServer = new RealmServer(
         [base, testRealm],


### PR DESCRIPTION
When we're done here the goal is that the only public handler API on `Realm` is `handle()`, which is allowed to return null when the request doesn't belong to this realm.

As of 71179e68e6b7e2cbc8ea582d28b793f2588f7ac4 there are two remaining uses of the older `maybeHandle` which is bad because it considers its requests "internal", bypassing auth. Nobody outside the realm's own loader's fetcher should be using that.