### PR TITLE
Up matrix test timeout

### DIFF
--- a/packages/matrix/tests/forgot-password.spec.ts
+++ b/packages/matrix/tests/forgot-password.spec.ts
@@ -26,7 +26,10 @@ const password = 'mypassword1!';
 test.describe('Forgot password', () => {
   let synapse: SynapseInstance;
 
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    // These tests specifically are pretty slow as there's lots of reloading
+    // Add 30s to the overall test timeout
+    testInfo.setTimeout(testInfo.timeout + 30000);
     synapse = await synapseStart({
       template: 'test',
     });

--- a/packages/matrix/tests/login.spec.ts
+++ b/packages/matrix/tests/login.spec.ts
@@ -22,7 +22,10 @@ const REALM_SECRET_SEED = "shhh! it's a secret";
 
 test.describe('Login', () => {
   let synapse: SynapseInstance;
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    // These tests specifically are pretty slow as there's lots of reloading
+    // Add 30s to the overall test timeout
+    testInfo.setTimeout(testInfo.timeout + 30000);
     synapse = await synapseStart();
     await registerRealmUsers(synapse);
     await registerUser(synapse, 'user1', 'pass');


### PR DESCRIPTION
There is some flakiness in some tests, but one of the key things that seems to be happening is a test timeout of 30s gets hit. This is not a timeout for waiting for some specific selector, it's just a total time for the test, a bunch were being stopped as a failure while actively correctly navigating.

You can add test.slow() to individual tests, this change only increases the timeout for the test suites that do a lot of navigation, as they're the ones that are the slowest.

This may be less relevant with performance improvements, or more relevant if CI is slow.