### PR TITLE
Avoid getLoaderFor in base/card-api

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -3408,5 +3408,10 @@ declare module 'ember-provide-consume-context/context-registry' {
 function myLoader(): Loader {
   // we know this code is always loaded by an instance of our Loader, which sets
   // import.meta.loader.
+
+  // When type-checking realm-server, tsc sees this file and thinks
+  // it will be transpiled to CommonJS and so it complains about this line. But
+  // this file is always loaded through our loader and always has access to import.meta.
+  // @ts-ignore
   return (import.meta as any).loader;
 }

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -1033,7 +1033,6 @@ class LinksTo<CardT extends CardDefConstructor> implements Field<CardT> {
       json.data,
       json,
       new URL(json.data.id),
-      myLoader(),
       {
         identityContext,
       },
@@ -1448,7 +1447,6 @@ class LinksToMany<FieldT extends CardDefConstructor>
           json.data,
           json,
           new URL(json.data.id),
-          myLoader(),
           {
             identityContext,
           },
@@ -2650,7 +2648,6 @@ export async function createFromSerialized<T extends BaseDefConstructor>(
   resource: LooseCardResource,
   doc: LooseSingleCardDocument | CardDocument,
   relativeTo: URL | undefined,
-  loader: Loader,
   opts?: { identityContext?: IdentityContext },
 ): Promise<BaseInstanceType<T>> {
   let identityContext = opts?.identityContext ?? new IdentityContext();
@@ -2658,7 +2655,7 @@ export async function createFromSerialized<T extends BaseDefConstructor>(
     meta: { adoptsFrom },
   } = resource;
   let card: typeof BaseDef | undefined = await loadCard(adoptsFrom, {
-    loader,
+    loader: myLoader(),
     relativeTo,
   });
   if (!card) {

--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -406,7 +406,6 @@ export class CurrentRun {
         adjustedResource,
         { data: adjustedResource },
         new URL(fileURL),
-        this.loaderService.loader,
         {
           identityContext,
         },
@@ -546,7 +545,6 @@ export class CurrentRun {
         resourceForType,
         { data: resourceForType },
         new URL(resource.id),
-        this.loaderService.loader,
         {
           identityContext: modifiedContext,
         },

--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -46,7 +46,6 @@ import { type Reader, type Stats } from '@cardstack/runtime-common/worker';
 import {
   CardDef,
   type IdentityContext as IdentityContextType,
-  LoaderType,
 } from 'https://cardstack.com/base/card-api';
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
 
@@ -407,7 +406,7 @@ export class CurrentRun {
         adjustedResource,
         { data: adjustedResource },
         new URL(fileURL),
-        this.loaderService.loader as unknown as LoaderType,
+        this.loaderService.loader,
         {
           identityContext,
         },
@@ -547,7 +546,7 @@ export class CurrentRun {
         resourceForType,
         { data: resourceForType },
         new URL(resource.id),
-        this.loaderService.loader as unknown as LoaderType,
+        this.loaderService.loader,
         {
           identityContext: modifiedContext,
         },

--- a/packages/host/app/lib/matrix-handlers/index.ts
+++ b/packages/host/app/lib/matrix-handlers/index.ts
@@ -11,7 +11,6 @@ import type * as CardAPI from 'https://cardstack.com/base/card-api';
 import type { MatrixEvent as DiscreteMatrixEvent } from 'https://cardstack.com/base/matrix-event';
 import type { RoomField } from 'https://cardstack.com/base/room';
 
-import type LoaderService from '../../services/loader-service';
 import type * as MatrixSDK from 'matrix-js-sdk';
 
 export * as Membership from './membership';
@@ -40,7 +39,6 @@ export interface EventSendingContext {
   setRoom: (roomId: string, roomPromise: Promise<RoomField>) => void;
   getRoom: (roomId: string) => Promise<RoomField> | undefined;
   cardAPI: typeof CardAPI;
-  loaderService: LoaderService;
 }
 
 export interface Context extends EventSendingContext {
@@ -93,7 +91,6 @@ export async function addRoomEvent(context: EventSendingContext, event: Event) {
       data,
       { data },
       undefined,
-      context.loaderService.loader,
     );
     context.setRoom(roomId, room!);
   }

--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -123,12 +123,7 @@ export default class CardService extends Service {
     relativeTo?: URL | undefined,
   ): Promise<CardDef> {
     let api = await this.getAPI();
-    let card = await api.createFromSerialized(
-      resource,
-      doc,
-      relativeTo,
-      this.loaderService.loader,
-    );
+    let card = await api.createFromSerialized(resource, doc, relativeTo);
     // it's important that we absorb the field async here so that glimmer won't
     // encounter NotLoaded errors, since we don't have the luxury of the indexer
     // being able to inform us of which fields are used or not at this point.
@@ -351,7 +346,6 @@ export default class CardService extends Service {
   }
 
   async copyCard(source: CardDef, destinationRealm: URL): Promise<CardDef> {
-    let loader = this.loaderService.loader;
     let api = await this.getAPI();
     let serialized = await this.serializeCard(source, {
       maybeRelativeURL: null, // forces URL's to be absolute.
@@ -362,7 +356,6 @@ export default class CardService extends Service {
       json.data,
       json,
       new URL(json.data.id),
-      loader,
     )) as CardDef;
     if (this.subscriber) {
       this.subscriber(new URL(json.data.id), json);

--- a/packages/host/tests/integration/components/card-delete-test.gts
+++ b/packages/host/tests/integration/components/card-delete-test.gts
@@ -57,7 +57,6 @@ module('Integration | card-delete', function (hooks) {
       result.doc.data,
       result.doc,
       new URL(url),
-      loader,
     );
     await recompute(card, { loadFields: true });
     return card;

--- a/packages/host/tests/integration/components/card-editor-test.gts
+++ b/packages/host/tests/integration/components/card-editor-test.gts
@@ -78,7 +78,6 @@ module('Integration | card-editor', function (hooks) {
       result.doc.data,
       result.doc,
       new URL(result.doc.data.id),
-      loader,
     );
     await recompute(card, { loadFields: true });
     return card;

--- a/packages/host/tests/integration/components/serialization-test.gts
+++ b/packages/host/tests/integration/components/serialization-test.gts
@@ -118,7 +118,6 @@ module('Integration | serialization', function (hooks) {
       resource,
       { data: resource },
       undefined,
-      loader,
     );
     let root = await renderCard(loader, firstPost, 'isolated');
 
@@ -163,7 +162,6 @@ module('Integration | serialization', function (hooks) {
       resource,
       { data: resource },
       undefined,
-      loader,
     ); // Deserializing should be fault tolerant and not throw an error if the instance data does not match the card definition
 
     let root = await renderCard(loader, post, 'isolated');
@@ -200,7 +198,6 @@ module('Integration | serialization', function (hooks) {
       resource,
       { data: resource },
       undefined,
-      loader,
     )) as CardDefType;
 
     assert.strictEqual(
@@ -378,7 +375,6 @@ module('Integration | serialization', function (hooks) {
       resource,
       { data: resource },
       undefined,
-      loader,
     );
 
     try {
@@ -438,7 +434,6 @@ module('Integration | serialization', function (hooks) {
       resource,
       { data: resource },
       undefined,
-      loader,
     );
     assert.ok(
       driver.ref !== ref,
@@ -551,7 +546,6 @@ module('Integration | serialization', function (hooks) {
       resource,
       { data: resource },
       undefined,
-      loader,
     );
     let root = await renderCard(loader, firstPost, 'isolated');
     assert.strictEqual(
@@ -772,7 +766,6 @@ module('Integration | serialization', function (hooks) {
       doc.data,
       doc,
       undefined,
-      loader,
     );
 
     assert.ok(card instanceof Person, 'card is an instance of person');
@@ -879,7 +872,6 @@ module('Integration | serialization', function (hooks) {
       doc.data,
       doc,
       undefined,
-      loader,
     );
 
     try {
@@ -1053,7 +1045,6 @@ module('Integration | serialization', function (hooks) {
       doc.data,
       doc,
       undefined,
-      loader,
     );
     assert.ok(card instanceof Person, 'card is a Person');
     assert.strictEqual(card.firstName, 'Hassan');
@@ -1122,12 +1113,7 @@ module('Integration | serialization', function (hooks) {
         },
       ],
     };
-    let card = await createFromSerialized<typeof Pet>(
-      doc.data,
-      doc,
-      undefined,
-      loader,
-    );
+    let card = await createFromSerialized<typeof Pet>(doc.data, doc, undefined);
 
     assert.ok(card instanceof Pet, 'card is an instance of pet');
     assert.strictEqual(card.firstName, 'Jackie');
@@ -1319,7 +1305,6 @@ module('Integration | serialization', function (hooks) {
       doc.data,
       doc,
       undefined,
-      loader,
     );
     assert.ok(card instanceof Person, 'card is a Person');
     assert.strictEqual(card.firstName, 'Hassan');
@@ -1467,7 +1452,6 @@ module('Integration | serialization', function (hooks) {
       serialized.data,
       serialized,
       undefined,
-      loader,
     );
     if (card instanceof Person) {
       assert.strictEqual(card.firstName, 'Hassan');
@@ -1588,7 +1572,6 @@ module('Integration | serialization', function (hooks) {
       serialized.data,
       serialized,
       undefined,
-      loader,
     );
     if (card instanceof Person) {
       assert.strictEqual(card.firstName, 'Hassan');
@@ -1720,7 +1703,6 @@ module('Integration | serialization', function (hooks) {
       serialized.data,
       serialized,
       undefined,
-      loader,
     );
     if (card instanceof Person) {
       assert.strictEqual(card.firstName, 'Hassan');
@@ -1809,7 +1791,6 @@ module('Integration | serialization', function (hooks) {
       doc.data,
       doc,
       undefined,
-      loader,
     );
     if (mango instanceof Person) {
       let { parent, favorite } = mango;
@@ -1899,7 +1880,6 @@ module('Integration | serialization', function (hooks) {
       doc.data,
       doc,
       undefined,
-      loader,
     );
     let root = await renderCard(loader, firstPost, 'isolated');
     assert.strictEqual(
@@ -1962,7 +1942,6 @@ module('Integration | serialization', function (hooks) {
       doc.data,
       doc,
       undefined,
-      loader,
     );
     await renderCard(loader, firstPost, 'isolated');
     assert
@@ -2366,7 +2345,6 @@ module('Integration | serialization', function (hooks) {
         doc.data,
         doc,
         undefined,
-        loader,
       );
 
       assert.ok(card instanceof Person, 'card is an instance of person');
@@ -2484,7 +2462,6 @@ module('Integration | serialization', function (hooks) {
         doc.data,
         doc,
         undefined,
-        loader,
       );
       assert.ok(card instanceof Person, 'card is a Person');
       assert.strictEqual(card.firstName, 'Burcu');
@@ -2532,7 +2509,6 @@ module('Integration | serialization', function (hooks) {
         doc.data,
         doc,
         undefined,
-        loader,
       );
 
       try {
@@ -2593,7 +2569,6 @@ module('Integration | serialization', function (hooks) {
       doc.data,
       doc,
       undefined,
-      loader,
     );
     let root = await renderCard(loader, classSchedule, 'isolated');
     assert.strictEqual(
@@ -2652,7 +2627,6 @@ module('Integration | serialization', function (hooks) {
       doc.data,
       doc,
       undefined,
-      loader,
     );
     await renderCard(loader, classSchedule, 'isolated');
     assert.deepEqual(
@@ -2922,7 +2896,6 @@ module('Integration | serialization', function (hooks) {
       payload.data,
       payload,
       new URL(testRealmURL),
-      loader,
     ); // success is not blowing up
     assert.strictEqual(post2.author.firstName, 'Mango');
     let { author } = post2;
@@ -3031,7 +3004,6 @@ module('Integration | serialization', function (hooks) {
       payload.data,
       payload,
       new URL(testRealmURL),
-      loader,
     ); // success is not blowing up
     assert.strictEqual(post2.author.firstName, 'Mango');
     assert.strictEqual(post2.author.loves.firstName, 'Van Gogh');
@@ -3149,7 +3121,6 @@ module('Integration | serialization', function (hooks) {
       payload.data,
       payload,
       new URL(testRealmURL),
-      loader,
     );
     let { people } = group2;
     assert.ok(Array.isArray(people), 'people is an array');
@@ -3285,7 +3256,6 @@ module('Integration | serialization', function (hooks) {
       payload.data,
       payload,
       new URL(testRealmURL),
-      loader,
     );
     let { people } = group2;
     assert.ok(Array.isArray(people), 'people is an array');
@@ -3384,7 +3354,6 @@ module('Integration | serialization', function (hooks) {
       doc.data,
       doc,
       undefined,
-      loader,
     );
 
     assert.ok(card instanceof Person, 'card is an instance of person');
@@ -3442,7 +3411,6 @@ module('Integration | serialization', function (hooks) {
       doc.data,
       doc,
       new URL(testRealmURL),
-      loader,
     );
     assert.strictEqual(person.firstName, 'Mango');
     assert.deepEqual(
@@ -3514,7 +3482,6 @@ module('Integration | serialization', function (hooks) {
       doc.data,
       doc,
       new URL(testRealmURL),
-      loader,
     );
     assert.strictEqual(post.title, 'Things I Want to Chew');
     assert.strictEqual(post.author.firstName, 'Mango');
@@ -3610,7 +3577,6 @@ module('Integration | serialization', function (hooks) {
       doc.data,
       doc,
       new URL(testRealmURL),
-      loader,
     );
     let posts = blog.posts;
     assert.strictEqual(posts.length, 2, 'number of posts is correct');
@@ -3794,7 +3760,6 @@ module('Integration | serialization', function (hooks) {
       doc.data,
       doc,
       new URL(testRealmURL),
-      loader,
     );
     let posts = blog.posts;
     assert.strictEqual(
@@ -4205,7 +4170,6 @@ module('Integration | serialization', function (hooks) {
         doc.data,
         doc,
         undefined,
-        loader,
       );
 
       assert.ok(card instanceof Person, 'card is an instance of person');
@@ -4380,7 +4344,6 @@ module('Integration | serialization', function (hooks) {
         serialized.data,
         serialized,
         undefined,
-        loader,
       );
       if (card instanceof Person) {
         assert.strictEqual(card.firstName, 'Hassan');
@@ -4524,7 +4487,6 @@ module('Integration | serialization', function (hooks) {
         doc.data,
         doc,
         undefined,
-        loader,
       );
       assert.ok(card instanceof Person, 'card is a Person');
       assert.strictEqual(card.firstName, 'Hassan');
@@ -4599,7 +4561,6 @@ module('Integration | serialization', function (hooks) {
         doc.data,
         doc,
         undefined,
-        loader,
       );
 
       try {
@@ -4853,7 +4814,6 @@ module('Integration | serialization', function (hooks) {
         doc.data,
         doc,
         new URL(`${testRealmURL}Person/hassan`),
-        loader,
       );
       assert.ok(card instanceof Person, 'card is a Person');
       assert.strictEqual(card.firstName, 'Hassan');
@@ -5078,7 +5038,6 @@ module('Integration | serialization', function (hooks) {
         doc.data,
         doc,
         undefined,
-        loader,
       );
       assert.ok(card instanceof Person, 'card is an instance of person');
       assert.strictEqual(card.firstName, 'Burcu');
@@ -5194,7 +5153,6 @@ module('Integration | serialization', function (hooks) {
         doc.data,
         doc,
         undefined,
-        loader,
       );
 
       assert.ok(card instanceof Person, 'card is a Person');
@@ -5253,7 +5211,6 @@ module('Integration | serialization', function (hooks) {
         doc.data,
         doc,
         undefined,
-        loader,
       );
 
       try {
@@ -5374,7 +5331,6 @@ module('Integration | serialization', function (hooks) {
           resource,
           { data: resource },
           undefined,
-          loader,
         );
 
         assert.strictEqual(sample.someNumber, 42);
@@ -5472,7 +5428,6 @@ module('Integration | serialization', function (hooks) {
           resource,
           { data: resource },
           undefined,
-          loader,
         );
 
         assert.strictEqual(isBigInt(sample.someBigInt), true);
@@ -5626,7 +5581,6 @@ module('Integration | serialization', function (hooks) {
           resource,
           { data: resource },
           undefined,
-          loader,
         );
 
         assert.strictEqual(isEthAddress(sample.someAddress), true);

--- a/packages/host/tests/integration/components/text-input-validator-test.gts
+++ b/packages/host/tests/integration/components/text-input-validator-test.gts
@@ -64,7 +64,6 @@ module('Integration | text-input-validator', function (hooks) {
       result.doc.data,
       result.doc,
       new URL(result.doc.data.id),
-      loader,
     );
     await recompute(card, { loadFields: true });
     return card;

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -2130,7 +2130,6 @@ module('Realm Server', function (hooks) {
         doc.data,
         doc,
         undefined,
-        loader,
       );
       assert.strictEqual(person.firstName, 'Mango', 'card data is correct');
     });
@@ -2154,7 +2153,6 @@ module('Realm Server', function (hooks) {
         doc.data,
         doc,
         undefined,
-        loader,
       );
       assert.strictEqual(person.firstName, 'Mango', 'card data is correct');
     });
@@ -2179,7 +2177,6 @@ module('Realm Server', function (hooks) {
         doc.data,
         doc,
         undefined,
-        loader,
       );
       assert.deepEqual(testCard.ref, ref, 'card data is correct');
     });

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -1771,7 +1771,6 @@ export class Realm {
       doc.data,
       doc,
       relativeTo,
-      this.loader,
     )) as CardDef;
     await api.flushLogs();
     let data: LooseSingleCardDocument = api.serializeCard(card); // this strips out computeds

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -61,7 +61,6 @@ import { type CardDef } from 'https://cardstack.com/base/card-api';
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
 import { createResponse } from './create-response';
 import { mergeRelationships } from './merge-relationships';
-import type { LoaderType } from 'https://cardstack.com/base/card-api';
 import { MatrixClient, waitForMatrixMessage } from './matrix-client';
 import { Sha256 } from '@aws-crypto/sha256-js';
 
@@ -1772,7 +1771,7 @@ export class Realm {
       doc.data,
       doc,
       relativeTo,
-      this.loader as unknown as LoaderType,
+      this.loader,
     )) as CardDef;
     await api.flushLogs();
     let data: LooseSingleCardDocument = api.serializeCard(card); // this strips out computeds


### PR DESCRIPTION
It's not necessary to use getLoaderFor anywhere in `base` because all of `base` is always loaded by an instance of our Loader, and that is the relevant instance to use for everything.

This fixes a crash when loading a linksTo a Card that can have more than one CodeRef depending on the specific timing of how it has already been accessed.