### PR TITLE
More indexer api cleanup

### DIFF
--- a/packages/host/app/lib/sqlite-adapter.ts
+++ b/packages/host/app/lib/sqlite-adapter.ts
@@ -70,11 +70,11 @@ export default class SQLiteAdapter implements DBAdapter {
       }
 
       this.tables = (
-        (await this.execute(
+        (await this.internalExecute(
           `SELECT name FROM pragma_table_list WHERE schema = 'main' AND name != 'sqlite_schema'`,
         )) as { name: string }[]
       ).map((r) => r.name);
-      let pks = (await this.execute(
+      let pks = (await this.internalExecute(
         `
         SELECT m.name AS table_name,
         GROUP_CONCAT(p.name, ', ') AS primary_keys
@@ -93,6 +93,10 @@ export default class SQLiteAdapter implements DBAdapter {
   async execute(sql: string, opts?: ExecuteOptions) {
     this.assertNotClosed();
     await this.started;
+    return await this.internalExecute(sql, opts);
+  }
+
+  private async internalExecute(sql: string, opts?: ExecuteOptions) {
     sql = this.adjustSQL(sql);
     return await this.query(sql, opts);
   }

--- a/packages/host/app/lib/sqlite-adapter.ts
+++ b/packages/host/app/lib/sqlite-adapter.ts
@@ -15,9 +15,8 @@ export default class SQLiteAdapter implements DBAdapter {
   private _dbId: string | undefined;
   private primaryKeys = new Map<string, string>();
   private tables: string[] = [];
-  private started = this.#startClient();
-
   #isClosed = false;
+  private started = this.#startClient();
 
   // TODO: one difference that I'm seeing is that it looks like "json_each" is
   // actually similar to "json_each_text" in postgres. i think we might need to

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -108,7 +108,6 @@ export async function getDbAdapter() {
     | undefined;
   if (!dbAdapter) {
     dbAdapter = new SQLiteAdapter(sqlSchema);
-    await dbAdapter.startClient();
     (globalThis as any).__sqliteAdapter = dbAdapter;
   }
   return dbAdapter;

--- a/packages/host/tests/unit/index-query-engine-test.ts
+++ b/packages/host/tests/unit/index-query-engine-test.ts
@@ -5,7 +5,6 @@ import {
   VirtualNetwork,
   baseRealm,
   IndexQueryEngine,
-  IndexUpdater,
   fetcher,
   maybeHandleScopedCSSRequest,
 } from '@cardstack/runtime-common';
@@ -31,14 +30,13 @@ let codeRef: typeof import('https://cardstack.com/base/code-ref');
 let { resolvedBaseRealmURL } = ENV;
 
 module('Unit | query', function (hooks) {
-  let adapter: SQLiteAdapter;
+  let dbAdapter: SQLiteAdapter;
   let indexQueryEngine: IndexQueryEngine;
-  let indexUpdater: IndexUpdater;
   let loader: Loader;
   let testCards: { [name: string]: CardDef } = {};
 
   hooks.before(async function () {
-    adapter = await getDbAdapter();
+    dbAdapter = await getDbAdapter();
   });
 
   hooks.beforeEach(async function () {
@@ -182,17 +180,14 @@ module('Unit | query', function (hooks) {
       setCardAsSavedForTest(card);
     }
 
-    await adapter.reset();
-    indexQueryEngine = new IndexQueryEngine(adapter);
-    indexUpdater = new IndexUpdater(adapter);
-    await indexUpdater.ready();
-    await indexQueryEngine.ready();
+    await dbAdapter.reset();
+    indexQueryEngine = new IndexQueryEngine(dbAdapter);
   });
 
   test('can get all cards with empty filter', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -201,7 +196,7 @@ module('Unit | query', function (hooks) {
   test('deleted cards are not included in results', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -210,7 +205,7 @@ module('Unit | query', function (hooks) {
   test('error docs are not included in results', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -219,7 +214,7 @@ module('Unit | query', function (hooks) {
   test('can filter by type', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -228,7 +223,7 @@ module('Unit | query', function (hooks) {
   test(`can filter using 'eq'`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -237,7 +232,7 @@ module('Unit | query', function (hooks) {
   test(`can filter using 'eq' thru nested fields`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -246,7 +241,7 @@ module('Unit | query', function (hooks) {
   test(`can use 'eq' to match multiple fields`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -255,7 +250,7 @@ module('Unit | query', function (hooks) {
   test(`can use 'eq' to find 'null' values`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -264,7 +259,7 @@ module('Unit | query', function (hooks) {
   test(`can use 'eq' to match against number type`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -273,7 +268,7 @@ module('Unit | query', function (hooks) {
   test(`can use 'eq' to match against boolean type`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -282,7 +277,7 @@ module('Unit | query', function (hooks) {
   test('can filter eq from a code ref query value', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -291,7 +286,7 @@ module('Unit | query', function (hooks) {
   test('can filter eq from a date query value', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -300,7 +295,7 @@ module('Unit | query', function (hooks) {
   test(`can search with a 'not' filter`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -309,7 +304,7 @@ module('Unit | query', function (hooks) {
   test('can handle a filter with double negatives', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -318,7 +313,7 @@ module('Unit | query', function (hooks) {
   test(`can use a 'contains' filter`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -327,7 +322,7 @@ module('Unit | query', function (hooks) {
   test(`contains filter is case insensitive`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -336,7 +331,7 @@ module('Unit | query', function (hooks) {
   test(`can use 'contains' to match multiple fields`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -345,7 +340,7 @@ module('Unit | query', function (hooks) {
   test(`can use a 'contains' filter to match 'null'`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -354,7 +349,7 @@ module('Unit | query', function (hooks) {
   test(`can use 'every' to combine multiple filters`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -363,7 +358,7 @@ module('Unit | query', function (hooks) {
   test(`can use 'any' to combine multiple filters`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -372,7 +367,7 @@ module('Unit | query', function (hooks) {
   test(`gives a good error when query refers to missing card`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -381,7 +376,7 @@ module('Unit | query', function (hooks) {
   test(`gives a good error when query refers to missing field`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -390,7 +385,7 @@ module('Unit | query', function (hooks) {
   test(`it can filter on a plural primitive field using 'eq'`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -399,7 +394,7 @@ module('Unit | query', function (hooks) {
   test(`it can filter on a nested field within a plural composite field using 'eq'`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -408,7 +403,7 @@ module('Unit | query', function (hooks) {
   test('it can match a null in a plural field', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -417,7 +412,7 @@ module('Unit | query', function (hooks) {
   test('it can match a leaf plural field nested in a plural composite field', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -426,7 +421,7 @@ module('Unit | query', function (hooks) {
   test('it can match thru a plural nested composite field that is field of a singular composite field', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -435,7 +430,7 @@ module('Unit | query', function (hooks) {
   test(`can return a single result for a card when there are multiple matches within a result's search doc`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -444,7 +439,7 @@ module('Unit | query', function (hooks) {
   test('can perform query against WIP version of the index', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -453,7 +448,7 @@ module('Unit | query', function (hooks) {
   test('can perform query against "production" version of the index', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -462,7 +457,7 @@ module('Unit | query', function (hooks) {
   test('can sort search results', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -471,7 +466,7 @@ module('Unit | query', function (hooks) {
   test('can sort descending', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -480,7 +475,7 @@ module('Unit | query', function (hooks) {
   test('nulls are sorted to the end of search results', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -489,7 +484,7 @@ module('Unit | query', function (hooks) {
   test('can get paginated results that are stable during index mutations', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -498,7 +493,7 @@ module('Unit | query', function (hooks) {
   test(`can filter using 'gt'`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -507,7 +502,7 @@ module('Unit | query', function (hooks) {
   test(`can filter using 'gte'`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -516,7 +511,7 @@ module('Unit | query', function (hooks) {
   test(`can filter using 'gt' thru nested fields`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -525,7 +520,7 @@ module('Unit | query', function (hooks) {
   test(`can filter using 'gt' thru a plural primitive field`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -534,7 +529,7 @@ module('Unit | query', function (hooks) {
   test(`can filter using 'gt' thru a plural composite field`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -543,7 +538,7 @@ module('Unit | query', function (hooks) {
   test(`can filter using 'lt'`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -552,7 +547,7 @@ module('Unit | query', function (hooks) {
   test(`can filter using 'lte'`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -561,7 +556,7 @@ module('Unit | query', function (hooks) {
   test(`can combine 'range' filter`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -570,7 +565,7 @@ module('Unit | query', function (hooks) {
   test(`cannot filter 'null' value using 'range'`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });
@@ -579,7 +574,7 @@ module('Unit | query', function (hooks) {
   test('can get prerendered cards (html + css) from the indexer', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards,
     });

--- a/packages/host/tests/unit/index-updater-test.ts
+++ b/packages/host/tests/unit/index-updater-test.ts
@@ -22,8 +22,6 @@ module('Unit | index-updater', function (hooks) {
     await adapter.reset();
     indexUpdater = new IndexUpdater(adapter);
     indexQueryEngine = new IndexQueryEngine(adapter);
-    await indexUpdater.ready();
-    await indexQueryEngine.ready();
   });
 
   test('can perform invalidations for a instance entry', async function (assert) {

--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -146,7 +146,6 @@ let dist: URL = new URL(distURL);
   let realms: Realm[] = [];
   let dbAdapter = new PgAdapter();
   let queue = new PgQueue(dbAdapter);
-  await dbAdapter.startClient();
 
   for (let [i, path] of paths.entries()) {
     let url = hrefs[i][0];

--- a/packages/realm-server/pg-adapter.ts
+++ b/packages/realm-server/pg-adapter.ts
@@ -21,10 +21,9 @@ function config() {
 }
 
 export default class PgAdapter implements DBAdapter {
+  #isClosed = false;
   private pool: Pool;
   private started = this.#startClient();
-
-  #isClosed = false;
 
   constructor() {
     let { user, host, database, password, port } = config();

--- a/packages/realm-server/pg-queue.ts
+++ b/packages/realm-server/pg-queue.ts
@@ -254,7 +254,6 @@ export default class PgQueue implements Queue {
   async start() {
     if (!this.jobRunner && !this.#isDestroyed) {
       this.#hasStarted = true;
-      await this.pgClient.startClient();
       this.jobRunner = new WorkLoop('jobRunner', this.pollInterval);
       this.jobRunner.run(async (loop) => {
         await this.pgClient.listen('jobs', loop.wake.bind(loop), async () => {

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -38,7 +38,7 @@ let fastbootState:
   | { getRunner: IndexRunner; getIndexHTML: () => Promise<string> }
   | undefined;
 
-export async function prepareTestDB() {
+export function prepareTestDB(): void {
   process.env.PGDATABASE = `test_db_${Math.floor(10000000 * Math.random())}`;
 }
 

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -63,7 +63,6 @@ export function setupDB(
     prepareTestDB();
     dbAdapter = new PgAdapter();
     queue = new PgQueue(dbAdapter);
-    await dbAdapter.startClient();
   };
 
   const runAfterHook = async () => {

--- a/packages/realm-server/tests/index-query-engine-test.ts
+++ b/packages/realm-server/tests/index-query-engine-test.ts
@@ -3,7 +3,6 @@ import { prepareTestDB } from './helpers';
 import {
   Loader,
   IndexQueryEngine,
-  IndexUpdater,
   VirtualNetwork,
   baseRealm,
   fetcher,
@@ -101,9 +100,8 @@ async function makeTestCards(loader: Loader) {
 }
 
 module('query', function (hooks) {
-  let adapter: PgAdapter;
+  let dbAdapter: PgAdapter;
   let indexQueryEngine: IndexQueryEngine;
-  let indexUpdater: IndexUpdater;
   let loader: Loader;
 
   hooks.beforeEach(async function () {
@@ -121,21 +119,18 @@ module('query', function (hooks) {
     ]);
     loader = new Loader(fetch, virtualNetwork.resolveImport);
 
-    adapter = new PgAdapter();
-    indexQueryEngine = new IndexQueryEngine(adapter);
-    indexUpdater = new IndexUpdater(adapter);
-    await indexUpdater.ready();
-    await indexQueryEngine.ready();
+    dbAdapter = new PgAdapter();
+    indexQueryEngine = new IndexQueryEngine(dbAdapter);
   });
 
   hooks.afterEach(async function () {
-    await indexQueryEngine.teardown();
+    await dbAdapter.close();
   });
 
   test('can get all cards with empty filter', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -144,7 +139,7 @@ module('query', function (hooks) {
   test('deleted cards are not included in results', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -153,7 +148,7 @@ module('query', function (hooks) {
   test('error docs are not included in results', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -162,7 +157,7 @@ module('query', function (hooks) {
   test('can filter by type', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -171,7 +166,7 @@ module('query', function (hooks) {
   test(`can filter using 'eq'`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -180,7 +175,7 @@ module('query', function (hooks) {
   test(`can filter using 'eq' thru nested fields`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -189,7 +184,7 @@ module('query', function (hooks) {
   test(`can use 'eq' to match multiple fields`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -198,7 +193,7 @@ module('query', function (hooks) {
   test(`can use 'eq' to find 'null' values`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -207,7 +202,7 @@ module('query', function (hooks) {
   test(`can use 'eq' to match against number type`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -216,7 +211,7 @@ module('query', function (hooks) {
   test(`can use 'eq' to match against boolean type`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -225,7 +220,7 @@ module('query', function (hooks) {
   test('can filter eq from a code ref query value', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -234,7 +229,7 @@ module('query', function (hooks) {
   test('can filter eq from a date query value', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -243,7 +238,7 @@ module('query', function (hooks) {
   test(`can search with a 'not' filter`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -252,7 +247,7 @@ module('query', function (hooks) {
   test('can handle a filter with double negatives', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -261,7 +256,7 @@ module('query', function (hooks) {
   test(`can use a 'contains' filter`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -270,7 +265,7 @@ module('query', function (hooks) {
   test(`contains filter is case insensitive`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -279,7 +274,7 @@ module('query', function (hooks) {
   test(`can use 'contains' to match multiple fields`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -288,7 +283,7 @@ module('query', function (hooks) {
   test(`can use a 'contains' filter to match 'null'`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -297,7 +292,7 @@ module('query', function (hooks) {
   test(`can use 'every' to combine multiple filters`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -306,7 +301,7 @@ module('query', function (hooks) {
   test(`can use 'any' to combine multiple filters`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -315,7 +310,7 @@ module('query', function (hooks) {
   test(`gives a good error when query refers to missing card`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -324,7 +319,7 @@ module('query', function (hooks) {
   test(`gives a good error when query refers to missing field`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -333,7 +328,7 @@ module('query', function (hooks) {
   test(`it can filter on a plural primitive field using 'eq'`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -342,7 +337,7 @@ module('query', function (hooks) {
   test(`it can filter on a nested field within a plural composite field using 'eq'`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -351,7 +346,7 @@ module('query', function (hooks) {
   test('it can match a null in a plural field', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -360,7 +355,7 @@ module('query', function (hooks) {
   test('it can match a leaf plural field nested in a plural composite field', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -369,7 +364,7 @@ module('query', function (hooks) {
   test('it can match thru a plural nested composite field that is field of a singular composite field', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -378,7 +373,7 @@ module('query', function (hooks) {
   test(`can return a single result for a card when there are multiple matches within a result's search doc`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -387,7 +382,7 @@ module('query', function (hooks) {
   test('can perform query against WIP version of the index', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -396,7 +391,7 @@ module('query', function (hooks) {
   test('can perform query against "production" version of the index', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -405,7 +400,7 @@ module('query', function (hooks) {
   test('can sort search results', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -414,7 +409,7 @@ module('query', function (hooks) {
   test('can sort descending', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -423,7 +418,7 @@ module('query', function (hooks) {
   test('nulls are sorted to the end of search results', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -432,7 +427,7 @@ module('query', function (hooks) {
   test('can get paginated results that are stable during index mutations', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -441,7 +436,7 @@ module('query', function (hooks) {
   test(`can filter using 'gt'`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -450,7 +445,7 @@ module('query', function (hooks) {
   test(`can filter using 'gte'`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -459,7 +454,7 @@ module('query', function (hooks) {
   test(`can filter using 'gt' thru nested fields`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -468,7 +463,7 @@ module('query', function (hooks) {
   test(`can filter using 'gt' thru a plural primitive field`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -477,7 +472,7 @@ module('query', function (hooks) {
   test(`can filter using 'gt' thru a plural composite field`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -486,7 +481,7 @@ module('query', function (hooks) {
   test(`can filter using 'lt'`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -495,7 +490,7 @@ module('query', function (hooks) {
   test(`can filter using 'lte'`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -504,7 +499,7 @@ module('query', function (hooks) {
   test(`can combine 'range' filter`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -513,7 +508,7 @@ module('query', function (hooks) {
   test(`cannot filter 'null' value using 'range'`, async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });
@@ -522,7 +517,7 @@ module('query', function (hooks) {
   test('can get prerendered cards (html + css) from the indexer', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
-      indexUpdater,
+      dbAdapter,
       loader,
       testCards: await makeTestCards(loader),
     });

--- a/packages/realm-server/tests/index-updater-test.ts
+++ b/packages/realm-server/tests/index-updater-test.ts
@@ -15,12 +15,10 @@ module('index-updater', function (hooks) {
     adapter = new PgAdapter();
     indexUpdater = new IndexUpdater(adapter);
     indexQueryEngine = new IndexQueryEngine(adapter);
-    await indexUpdater.ready();
-    await indexQueryEngine.ready();
   });
 
   hooks.afterEach(async function () {
-    await indexUpdater.teardown();
+    await adapter.close();
   });
 
   test('can perform invalidations for a instance entry', async function (assert) {

--- a/packages/realm-server/tests/queue-test.ts
+++ b/packages/realm-server/tests/queue-test.ts
@@ -10,10 +10,12 @@ import queueTests from '@cardstack/runtime-common/tests/queue-test';
 
 module('queue', function (hooks) {
   let queue: Queue;
+  let adapter: PgAdapter;
 
   hooks.beforeEach(async function () {
     prepareTestDB();
-    queue = new PgQueue(new PgAdapter());
+    adapter = new PgAdapter();
+    queue = new PgQueue(adapter);
     await queue.start();
   });
 
@@ -38,8 +40,15 @@ module('queue', function (hooks) {
   module('multiple queue clients', function (nestedHooks) {
     let queue2: Queue;
     nestedHooks.beforeEach(async function () {
-      queue2 = new PgQueue(new PgAdapter());
+      let adapter2 = new PgAdapter();
+      queue2 = new PgQueue(adapter2);
       await queue2.start();
+
+      // Because we need tight timing control for this test, we don't want any
+      // concurrent migrations and their retries altering the timing. This
+      // ensures both adapters have gotten fully past that and are quiescent.
+      await adapter.execute('select 1');
+      await adapter2.execute('select 1');
     });
 
     nestedHooks.afterEach(async function () {

--- a/packages/runtime-common/db.ts
+++ b/packages/runtime-common/db.ts
@@ -13,10 +13,6 @@ export interface ExecuteOptions {
 
 export interface DBAdapter {
   isClosed: boolean;
-  // DB implementations perform DB connection and migration in this method.
-  // DBAdapter implementations can take in DB specific config in their
-  // constructors (username, password, etc)
-  startClient: () => Promise<void>;
   execute: (
     sql: string,
     opts?: ExecuteOptions,

--- a/packages/runtime-common/search-index.ts
+++ b/packages/runtime-common/search-index.ts
@@ -106,7 +106,6 @@ export class SearchIndex {
     onIndexUpdaterReady?: (indexUpdater: IndexUpdater) => Promise<void>,
   ) {
     await this.#queue.start();
-    await this.#indexUpdater.ready();
     if (onIndexUpdaterReady) {
       await onIndexUpdaterReady(this.#indexUpdater);
     }

--- a/packages/runtime-common/tests/index-updater-test.ts
+++ b/packages/runtime-common/tests/index-updater-test.ts
@@ -760,7 +760,7 @@ const tests = Object.freeze({
   },
 
   'can get an error doc': async (assert, { indexQueryEngine, adapter }) => {
-    setupIndex(adapter, [
+    await setupIndex(adapter, [
       {
         url: `${testRealmURL}1.json`,
         realm_version: 1,
@@ -1178,7 +1178,7 @@ const tests = Object.freeze({
     assert,
     { indexQueryEngine, adapter },
   ) => {
-    setupIndex(adapter, [
+    await setupIndex(adapter, [
       {
         url: `${testRealmURL}person.gts`,
         realm_version: 1,
@@ -1212,7 +1212,7 @@ const tests = Object.freeze({
     assert,
     { indexQueryEngine, adapter },
   ) => {
-    setupIndex(adapter, [
+    await setupIndex(adapter, [
       {
         url: `${testRealmURL}person.gts`,
         type: 'module',
@@ -1324,7 +1324,7 @@ const tests = Object.freeze({
     assert,
     { indexQueryEngine, adapter },
   ) => {
-    setupIndex(adapter, [
+    await setupIndex(adapter, [
       {
         url: `${testRealmURL}person.gts`,
         realm_version: 1,
@@ -1358,7 +1358,7 @@ const tests = Object.freeze({
     assert,
     { indexQueryEngine, adapter },
   ) => {
-    setupIndex(adapter, [
+    await setupIndex(adapter, [
       {
         url: `${testRealmURL}person.gts`,
         type: 'css',

--- a/packages/runtime-common/tests/index-updater-test.ts
+++ b/packages/runtime-common/tests/index-updater-test.ts
@@ -24,7 +24,7 @@ const tests = Object.freeze({
     { indexUpdater, adapter },
   ) => {
     await setupIndex(
-      indexUpdater,
+      adapter,
       [
         { realm_url: testRealmURL, current_version: 1 },
         { realm_url: testRealmURL2, current_version: 5 },
@@ -144,10 +144,10 @@ const tests = Object.freeze({
 
   'can perform invalidations for a module entry': async (
     assert,
-    { indexUpdater },
+    { indexUpdater, adapter },
   ) => {
     await setupIndex(
-      indexUpdater,
+      adapter,
       [
         { realm_url: testRealmURL, current_version: 1 },
         { realm_url: testRealmURL2, current_version: 5 },
@@ -214,7 +214,7 @@ const tests = Object.freeze({
     { indexUpdater, adapter },
   ) => {
     await setupIndex(
-      indexUpdater,
+      adapter,
       [{ realm_url: testRealmURL, current_version: 2 }],
       [
         {
@@ -282,10 +282,10 @@ const tests = Object.freeze({
 
   'can prevent concurrent batch invalidations from colliding': async (
     assert,
-    { indexUpdater },
+    { indexUpdater, adapter },
   ) => {
     await setupIndex(
-      indexUpdater,
+      adapter,
       [{ realm_url: testRealmURL, current_version: 1 }],
       [
         {
@@ -330,7 +330,7 @@ const tests = Object.freeze({
   'can prevent concurrent batch invalidations from colliding when making new generation':
     async (assert, { indexUpdater, adapter }) => {
       await setupIndex(
-        indexUpdater,
+        adapter,
         [{ realm_url: testRealmURL, current_version: 1 }],
         [
           {
@@ -431,7 +431,7 @@ const tests = Object.freeze({
 
   'can update an index entry': async (assert, { indexUpdater, adapter }) => {
     await setupIndex(
-      indexUpdater,
+      adapter,
       [{ realm_url: testRealmURL, current_version: 1 }],
       [
         {
@@ -616,7 +616,7 @@ const tests = Object.freeze({
     { indexUpdater, adapter },
   ) => {
     await setupIndex(
-      indexUpdater,
+      adapter,
       [{ realm_url: testRealmURL, current_version: 1 }],
       [
         {
@@ -759,11 +759,8 @@ const tests = Object.freeze({
     );
   },
 
-  'can get an error doc': async (
-    assert,
-    { indexUpdater, indexQueryEngine },
-  ) => {
-    await setupIndex(indexUpdater, [
+  'can get an error doc': async (assert, { indexQueryEngine, adapter }) => {
+    setupIndex(adapter, [
       {
         url: `${testRealmURL}1.json`,
         realm_version: 1,
@@ -793,7 +790,7 @@ const tests = Object.freeze({
 
   'can get "production" index entry': async (
     assert,
-    { indexUpdater, indexQueryEngine },
+    { indexUpdater, indexQueryEngine, adapter },
   ) => {
     let originalModified = Date.now();
     let originalResource: LooseCardResource = {
@@ -811,7 +808,7 @@ const tests = Object.freeze({
     };
     let originalSource = JSON.stringify(originalResource);
     await setupIndex(
-      indexUpdater,
+      adapter,
       [{ realm_url: testRealmURL, current_version: 1 }],
       [
         {
@@ -888,10 +885,10 @@ const tests = Object.freeze({
 
   'can get work in progress card': async (
     assert,
-    { indexUpdater, indexQueryEngine },
+    { indexUpdater, indexQueryEngine, adapter },
   ) => {
     await setupIndex(
-      indexUpdater,
+      adapter,
       [{ realm_url: testRealmURL, current_version: 1 }],
       [
         {
@@ -984,10 +981,10 @@ const tests = Object.freeze({
 
   'returns undefined when getting a deleted card': async (
     assert,
-    { indexUpdater, indexQueryEngine },
+    { adapter, indexQueryEngine },
   ) => {
     await setupIndex(
-      indexUpdater,
+      adapter,
       [{ realm_url: testRealmURL, current_version: 1 }],
       [
         {
@@ -1017,7 +1014,7 @@ const tests = Object.freeze({
       }
       indexRows.sort((a, b) => a.url.localeCompare(b.url));
       await setupIndex(
-        indexUpdater,
+        adapter,
         [{ realm_url: testRealmURL, current_version: 1 }],
         indexRows,
       );
@@ -1075,8 +1072,8 @@ const tests = Object.freeze({
     },
 
   'can get compiled module and source when requested with file extension':
-    async (assert, { indexUpdater, indexQueryEngine }) => {
-      await setupIndex(indexUpdater);
+    async (assert, { indexUpdater, indexQueryEngine, adapter }) => {
+      await setupIndex(adapter);
       let batch = await indexUpdater.createBatch(new URL(testRealmURL));
       let now = Date.now();
       await batch.updateEntry(new URL(`${testRealmURL}person.gts`), {
@@ -1105,8 +1102,8 @@ const tests = Object.freeze({
     },
 
   'can get compiled module and source when requested without file extension':
-    async (assert, { indexUpdater, indexQueryEngine }) => {
-      await setupIndex(indexUpdater);
+    async (assert, { indexUpdater, indexQueryEngine, adapter }) => {
+      await setupIndex(adapter);
       let batch = await indexUpdater.createBatch(new URL(testRealmURL));
       let now = Date.now();
       await batch.updateEntry(new URL(`${testRealmURL}person.gts`), {
@@ -1136,9 +1133,9 @@ const tests = Object.freeze({
 
   'can get compiled module and source from WIP index': async (
     assert,
-    { indexUpdater, indexQueryEngine },
+    { indexUpdater, indexQueryEngine, adapter },
   ) => {
-    await setupIndex(indexUpdater);
+    await setupIndex(adapter);
     let batch = await indexUpdater.createBatch(new URL(testRealmURL));
     let now = Date.now();
     await batch.updateEntry(new URL(`${testRealmURL}person.gts`), {
@@ -1179,9 +1176,9 @@ const tests = Object.freeze({
 
   'can get error doc for module': async (
     assert,
-    { indexUpdater, indexQueryEngine },
+    { indexQueryEngine, adapter },
   ) => {
-    await setupIndex(indexUpdater, [
+    setupIndex(adapter, [
       {
         url: `${testRealmURL}person.gts`,
         realm_version: 1,
@@ -1213,9 +1210,9 @@ const tests = Object.freeze({
 
   'returns undefined when getting a deleted module': async (
     assert,
-    { indexUpdater, indexQueryEngine },
+    { indexQueryEngine, adapter },
   ) => {
-    await setupIndex(indexUpdater, [
+    setupIndex(adapter, [
       {
         url: `${testRealmURL}person.gts`,
         type: 'module',
@@ -1233,9 +1230,9 @@ const tests = Object.freeze({
 
   'can get css when requested with file extension': async (
     assert,
-    { indexUpdater, indexQueryEngine },
+    { indexUpdater, indexQueryEngine, adapter },
   ) => {
-    await setupIndex(indexUpdater);
+    await setupIndex(adapter);
     let batch = await indexUpdater.createBatch(new URL(testRealmURL));
     let now = Date.now();
     await batch.updateEntry(new URL(`${testRealmURL}person.gts`), {
@@ -1260,9 +1257,9 @@ const tests = Object.freeze({
 
   'can get css when requested without file extension': async (
     assert,
-    { indexUpdater, indexQueryEngine },
+    { indexUpdater, indexQueryEngine, adapter },
   ) => {
-    await setupIndex(indexUpdater);
+    await setupIndex(adapter);
     let batch = await indexUpdater.createBatch(new URL(testRealmURL));
     let now = Date.now();
     await batch.updateEntry(new URL(`${testRealmURL}person.gts`), {
@@ -1287,9 +1284,9 @@ const tests = Object.freeze({
 
   'can get css from WIP index': async (
     assert,
-    { indexUpdater, indexQueryEngine },
+    { indexUpdater, indexQueryEngine, adapter },
   ) => {
-    await setupIndex(indexUpdater);
+    await setupIndex(adapter);
     let batch = await indexUpdater.createBatch(new URL(testRealmURL));
     let now = Date.now();
     await batch.updateEntry(new URL(`${testRealmURL}person.gts`), {
@@ -1325,9 +1322,9 @@ const tests = Object.freeze({
 
   'can get error doc for css': async (
     assert,
-    { indexUpdater, indexQueryEngine },
+    { indexQueryEngine, adapter },
   ) => {
-    await setupIndex(indexUpdater, [
+    setupIndex(adapter, [
       {
         url: `${testRealmURL}person.gts`,
         realm_version: 1,
@@ -1359,9 +1356,9 @@ const tests = Object.freeze({
 
   'returns undefined when getting deleted css': async (
     assert,
-    { indexUpdater, indexQueryEngine },
+    { indexQueryEngine, adapter },
   ) => {
-    await setupIndex(indexUpdater, [
+    setupIndex(adapter, [
       {
         url: `${testRealmURL}person.gts`,
         type: 'css',

--- a/packages/runtime-common/worker.ts
+++ b/packages/runtime-common/worker.ts
@@ -164,13 +164,12 @@ export class Worker {
 
   async run() {
     await this.#queue.start();
-    await this.#indexUpdater.ready();
 
-    await this.#queue.register(
+    this.#queue.register(
       `from-scratch-index:${this.#realmURL}`,
       this.fromScratch,
     );
-    await this.#queue.register(
+    this.#queue.register(
       `incremental-index:${this.#realmURL}`,
       this.incremental,
     );


### PR DESCRIPTION
This is a followup to #1406 that eliminates more API surface from IndexUpdater and IndexQueryEngine.