### PR TITLE
host: Fix appearance of username uniqueness checkmark

### DIFF
--- a/packages/boxel-ui/addon/src/components/input-group/index.gts
+++ b/packages/boxel-ui/addon/src/components/input-group/index.gts
@@ -34,6 +34,7 @@ export interface Signature {
     helperText?: string;
     id?: string;
     inputmode?: string;
+    invalidIcon?: Icon;
     onBlur?: (ev: Event) => void;
     onFocus?: (ev: Event) => void;
     onInput?: (val: string) => void;
@@ -41,6 +42,7 @@ export interface Signature {
     readonly?: boolean;
     required?: boolean;
     state?: InputValidationState;
+    validIcon?: Icon;
     value?: string;
   };
   Blocks: {
@@ -67,9 +69,9 @@ export default class InputGroup extends Component<Signature> {
     }
     switch (this.args.state) {
       case 'valid':
-        return SuccessBordered;
+        return this.args.validIcon ?? SuccessBordered;
       case 'invalid':
-        return FailureBordered;
+        return this.args.invalidIcon ?? FailureBordered;
       default:
         return undefined;
     }

--- a/packages/boxel-ui/addon/src/components/input-group/index.gts
+++ b/packages/boxel-ui/addon/src/components/input-group/index.gts
@@ -4,8 +4,8 @@ import Component from '@glimmer/component';
 
 import cn from '../../helpers/cn.ts';
 import { and, bool, eq, or } from '../../helpers/truth-helpers.ts';
-import SuccessBordered from '../../icons/check-mark.gts';
 import FailureBordered from '../../icons/failure-bordered.gts';
+import SuccessBordered from '../../icons/success-bordered.gts';
 import type { Icon } from '../../icons/types.ts';
 import { type InputValidationState } from '../input/index.gts';
 import LoadingIndicator from '../loading-indicator/index.gts';

--- a/packages/boxel-ui/addon/src/components/input-group/usage.gts
+++ b/packages/boxel-ui/addon/src/components/input-group/usage.gts
@@ -12,8 +12,13 @@ import {
 
 import cssVar from '../../helpers/css-var.ts';
 import BoxelField from '../field-container/index.gts';
-import { type InputValidationState } from '../input/index.gts';
+import {
+  type InputValidationState,
+  InputValidationStates,
+} from '../input/index.gts';
 import BoxelInputGroup from './index.gts';
+
+const validStates = Object.values(InputValidationStates);
 
 interface Token {
   icon: string;
@@ -123,10 +128,10 @@ export default class BoxelInputGroupUsage extends Component {
           @onInput={{fn (mut this.disabled)}}
           @value={{this.disabled}}
         />
-        <Args.Bool
+        <Args.String
           @name='state'
-          @description='The input state'
-          @defaultValue={{false}}
+          @description='The validation state of the input'
+          @options={{validStates}}
           @onInput={{fn (mut this.state)}}
           @value={{this.state}}
         />

--- a/packages/boxel-ui/addon/src/components/input-group/usage.gts
+++ b/packages/boxel-ui/addon/src/components/input-group/usage.gts
@@ -1,3 +1,4 @@
+import { CheckMark, IconX } from '@cardstack/boxel-ui/icons';
 import { A } from '@ember/array';
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
@@ -11,6 +12,7 @@ import {
 } from 'ember-freestyle/decorators/css-variable';
 
 import cssVar from '../../helpers/css-var.ts';
+import type { Icon } from '../../icons/types.ts';
 import BoxelField from '../field-container/index.gts';
 import {
   type InputValidationState,
@@ -19,6 +21,12 @@ import {
 import BoxelInputGroup from './index.gts';
 
 const validStates = Object.values(InputValidationStates);
+
+const validIconDescriptions = ['default', 'checkmark'];
+const validIconValues = [null, CheckMark];
+
+const invalidIconDescriptions = ['default', 'x'];
+const invalidIconValues = [null, IconX];
 
 interface Token {
   icon: string;
@@ -36,6 +44,12 @@ export default class BoxelInputGroupUsage extends Component {
   @tracked disabled = false;
   @tracked state: InputValidationState = 'initial';
   @tracked isShowingCopiedConfirmation = false;
+
+  @tracked validIcon: Icon | undefined;
+  @tracked validIconDescription = 'default';
+
+  @tracked invalidIcon: Icon | undefined;
+  @tracked invalidIconDescription = 'default';
 
   cssClassName = 'boxel-input-group';
   @cssVariable declare boxelInputGroupPaddingX: CSSVariableInfo;
@@ -57,6 +71,16 @@ export default class BoxelInputGroupUsage extends Component {
 
   @action log(s: string, _ev: Event): void {
     console.log(s);
+  }
+
+  @action onChooseValidIcon(s: keyof typeof validIconDescriptions) {
+    this.validIconDescription = s;
+    this.validIcon = validIconValues[validIconDescriptions.indexOf(s)];
+  }
+
+  @action onChooseInvalidIcon(s: keyof typeof invalidIconDescriptions) {
+    this.invalidIconDescription = s;
+    this.invalidIcon = invalidIconValues[invalidIconDescriptions.indexOf(s)];
   }
 
   @action onChooseToken(token: Token) {
@@ -99,6 +123,8 @@ export default class BoxelInputGroupUsage extends Component {
           @inputmode={{this.inputmode}}
           @onInput={{this.set}}
           @state={{this.state}}
+          @validIcon={{this.validIcon}}
+          @invalidIcon={{this.invalidIcon}}
           @errorMessage={{this.errorMessage}}
           @helperText={{this.helperText}}
           style={{cssVar
@@ -134,6 +160,20 @@ export default class BoxelInputGroupUsage extends Component {
           @options={{validStates}}
           @onInput={{fn (mut this.state)}}
           @value={{this.state}}
+        />
+        <Args.String
+          @name='validIcon'
+          @description='Override the default valid icon'
+          @options={{validIconDescriptions}}
+          @onInput={{fn this.onChooseValidIcon}}
+          @value={{this.validIconDescription}}
+        />
+        <Args.String
+          @name='inalidIcon'
+          @description='Override the default invalid icon'
+          @options={{invalidIconDescriptions}}
+          @onInput={{fn this.onChooseInvalidIcon}}
+          @value={{this.invalidIconDescription}}
         />
         <Args.String
           @name='helperText'

--- a/packages/boxel-ui/addon/src/components/input-group/usage.gts
+++ b/packages/boxel-ui/addon/src/components/input-group/usage.gts
@@ -22,11 +22,19 @@ import BoxelInputGroup from './index.gts';
 
 const validStates = Object.values(InputValidationStates);
 
-const validIconDescriptions = ['default', 'checkmark'];
-const validIconValues = [null, CheckMark];
+const ValidIcons = {
+  default: undefined,
+  checkmark: CheckMark,
+};
 
-const invalidIconDescriptions = ['default', 'x'];
-const invalidIconValues = [null, IconX];
+const validIconDescriptions = Object.keys(ValidIcons);
+
+const InvalidIcons = {
+  default: undefined,
+  x: IconX,
+};
+
+const invalidIconDescriptions = Object.keys(InvalidIcons);
 
 interface Token {
   icon: string;
@@ -46,10 +54,10 @@ export default class BoxelInputGroupUsage extends Component {
   @tracked isShowingCopiedConfirmation = false;
 
   @tracked validIcon: Icon | undefined;
-  @tracked validIconDescription = 'default';
+  @tracked validIconDescription: keyof typeof ValidIcons = 'default';
 
   @tracked invalidIcon: Icon | undefined;
-  @tracked invalidIconDescription = 'default';
+  @tracked invalidIconDescription: keyof typeof InvalidIcons = 'default';
 
   cssClassName = 'boxel-input-group';
   @cssVariable declare boxelInputGroupPaddingX: CSSVariableInfo;
@@ -73,14 +81,14 @@ export default class BoxelInputGroupUsage extends Component {
     console.log(s);
   }
 
-  @action onChooseValidIcon(s: keyof typeof validIconDescriptions) {
+  @action onChooseValidIcon(s: keyof typeof ValidIcons) {
     this.validIconDescription = s;
-    this.validIcon = validIconValues[validIconDescriptions.indexOf(s)];
+    this.validIcon = ValidIcons[s];
   }
 
-  @action onChooseInvalidIcon(s: keyof typeof invalidIconDescriptions) {
+  @action onChooseInvalidIcon(s: keyof typeof InvalidIcons) {
     this.invalidIconDescription = s;
-    this.invalidIcon = invalidIconValues[invalidIconDescriptions.indexOf(s)];
+    this.invalidIcon = InvalidIcons[s];
   }
 
   @action onChooseToken(token: Token) {

--- a/packages/boxel-ui/addon/src/components/input-group/usage.gts
+++ b/packages/boxel-ui/addon/src/components/input-group/usage.gts
@@ -177,7 +177,7 @@ export default class BoxelInputGroupUsage extends Component {
           @value={{this.validIconDescription}}
         />
         <Args.String
-          @name='inalidIcon'
+          @name='invalidIcon'
           @description='Override the default invalid icon'
           @options={{invalidIconDescriptions}}
           @onInput={{fn this.onChooseInvalidIcon}}

--- a/packages/boxel-ui/test-app/tests/integration/components/input-group-test.gts
+++ b/packages/boxel-ui/test-app/tests/integration/components/input-group-test.gts
@@ -5,7 +5,7 @@ import { BoxelInputGroup } from '@cardstack/boxel-ui/components';
 import { tracked } from '@glimmer/tracking';
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
-const OverrideIcon: TemplateOnlyComponent<Signature> = <template>
+const OverrideIcon: TemplateOnlyComponent = <template>
   <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'>
     <text data-test-override-icon>hey</text>
   </svg>
@@ -17,8 +17,8 @@ module('Integration | Component | InputGroup', function (hooks) {
   test('renders override icon arguments', async function (assert) {
     class StateObject {
       @tracked state = 'valid';
-      @tracked validIcon: string | undefined;
-      @tracked invalidIcon: string | undefined;
+      @tracked validIcon: TemplateOnlyComponent | undefined;
+      @tracked invalidIcon: TemplateOnlyComponent | undefined;
     }
 
     let stateObject = new StateObject();

--- a/packages/boxel-ui/test-app/tests/integration/components/input-group-test.gts
+++ b/packages/boxel-ui/test-app/tests/integration/components/input-group-test.gts
@@ -1,0 +1,54 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'test-app/tests/helpers';
+import { render, settled } from '@ember/test-helpers';
+import { BoxelInputGroup } from '@cardstack/boxel-ui/components';
+import { tracked } from '@glimmer/tracking';
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
+
+const OverrideIcon: TemplateOnlyComponent<Signature> = <template>
+  <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10'>
+    <text data-test-override-icon>hey</text>
+  </svg>
+</template>;
+
+module('Integration | Component | InputGroup', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('renders override icon arguments', async function (assert) {
+    class StateObject {
+      @tracked state = 'valid';
+      @tracked validIcon: string | undefined;
+      @tracked invalidIcon: string | undefined;
+    }
+
+    let stateObject = new StateObject();
+
+    await render(<template>
+      <BoxelInputGroup
+        @placeholder='InputGroup'
+        @value='hello'
+        @state={{stateObject.state}}
+        @validIcon={{stateObject.validIcon}}
+        @invalidIcon={{stateObject.invalidIcon}}
+      />
+    </template>);
+
+    assert.dom('[data-test-override-icon]').doesNotExist();
+
+    stateObject.validIcon = OverrideIcon;
+    await settled();
+
+    assert.dom('[data-test-override-icon]').exists();
+
+    stateObject.validIcon = undefined;
+    await settled();
+
+    assert.dom('[data-test-override-icon]').doesNotExist();
+
+    stateObject.invalidIcon = OverrideIcon;
+    stateObject.state = 'invalid';
+    await settled();
+
+    assert.dom('[data-test-override-icon]').exists();
+  });
+});

--- a/packages/host/app/components/matrix/register-user.gts
+++ b/packages/host/app/components/matrix/register-user.gts
@@ -23,6 +23,7 @@ import {
   FieldContainer,
 } from '@cardstack/boxel-ui/components';
 import { eq } from '@cardstack/boxel-ui/helpers';
+import { CheckMark } from '@cardstack/boxel-ui/icons';
 
 import ENV from '@cardstack/host/config/environment';
 import {
@@ -138,6 +139,7 @@ export default class RegisterUser extends Component<Signature> {
           @errorMessage={{this.usernameError}}
           @onInput={{this.setUsername}}
           @onBlur={{this.checkUsername}}
+          @validIcon={{CheckMark}}
         >
           <:before as |Accessories|>
             <Accessories.Text class='username-prefix'>@</Accessories.Text>
@@ -233,6 +235,9 @@ export default class RegisterUser extends Component<Signature> {
       }
       .registration-field :deep(.validation-icon-container.invalid) {
         display: none;
+      }
+      .registration-field :deep(.validation-icon-container.valid svg) {
+        height: var(--boxel-sp-xs);
       }
       .registration-field
         :deep(.boxel-input-group--invalid > :nth-last-child(2)) {


### PR DESCRIPTION
It was comically oversized:

<table>
<thead>
<tr>
<th>before</th>
<th>after</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="580" src="https://github.com/cardstack/boxel/assets/43280/c9b231d9-cb2b-4485-8205-c5834732e402">
</td>
<td>
<img width="580" alt="Boxel 2024-07-11 13-44-43" src="https://github.com/cardstack/boxel/assets/43280/1eb2551e-d86c-474c-b48f-3ccf7b9e48b7">
</td>
</tr>
</tbody>
</table>

Since the original Boxel UI design used the circled checkmark, this changes back to that as the default but adds a `@validIcon` override where the custom icon can be passed in. Though it’s not used here, I added `@invalidIcon` too, you can see it [in the preview](https://hostusername-uniqueness-checkmark-cs-6972.boxel-ui-preview.stack.cards/?s=Components&ss=%3CInputGroup%3E)

<img width="877" alt="Boxel Components 2024-07-11 15-50-54" src="https://github.com/cardstack/boxel/assets/43280/16934954-8814-4c2b-8ecb-911e40273258">
