### PR TITLE
Add option to disable module caching in realm server for development

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -42,7 +42,7 @@ To build the entire repository and run the application, follow these steps:
 
    ```zsh
    cd ./packages/realm-server
-   pnpm start:all
+   DISABLE_MODULE_CACHING=true pnpm start:all
    ```
 
    Note: Ensure that the realm-server is completely started by looking out for tor the test-realm indexing output.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ In order to run the realm server hosted app:
 
 You can visit the URL of each realm server to view that realm's app. So for instance, the base realm's app is available at `http://localhost:4201/base` and the draft realm's app is at `http://localhost:4201/draft`.
 
-Live reloads are not available in this mode, but you can just refresh the page to grab the latest code changes if you are running rebuilds (step #1 and #2 above).
+Live reloads are not available in this mode, however, if you use start the server with the environment variable `DISABLE_MODULE_CACHING=true` you can just refresh the page to grab the latest code changes if you are running rebuilds (step #1 and #2 above).
 
 #### Using `start:all`
 

--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -43,6 +43,12 @@ if (!REALM_SECRET_SEED) {
   process.exit(-1);
 }
 
+if (process.env.DISABLE_MODULE_CACHING === 'true') {
+  console.warn(
+    `module caching has been disabled, module executables will be served directly from the filesystem`,
+  );
+}
+
 let {
   port,
   distURL = 'http://localhost:4200',
@@ -207,6 +213,9 @@ let dist: URL = new URL(distURL);
       },
       {
         deferStartUp: true,
+        ...(process.env.DISABLE_MODULE_CACHING === 'true'
+          ? { disableModuleCaching: true }
+          : {}),
         ...(useTestingDomain
           ? {
               useTestingDomain,

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -144,6 +144,7 @@ export interface RealmAdapter {
 interface Options {
   deferStartUp?: true;
   useTestingDomain?: true;
+  disableModuleCaching?: true;
 }
 
 interface IndexHTMLOptions {
@@ -227,6 +228,7 @@ export class Realm {
   #flushUpdateEvents: Promise<void> | undefined;
   #recentWrites: Map<string, number> = new Map();
   #realmSecretSeed: string;
+  #disableModuleCaching = false;
 
   #onIndexer: ((indexer: Indexer) => Promise<void>) | undefined;
   #publicEndpoints: RouteTable<true> = new Map([
@@ -292,6 +294,7 @@ export class Realm {
     this.#getIndexHTML = getIndexHTML;
     this.#useTestingDomain = Boolean(opts?.useTestingDomain);
     this.#assetsURL = assetsURL;
+    this.#disableModuleCaching = Boolean(opts?.disableModuleCaching);
 
     let fetch = fetcher(virtualNetwork.fetch, [
       async (req, next) => {
@@ -871,40 +874,42 @@ export class Realm {
     let url = new URL(request.url);
     let localPath = this.paths.local(url);
 
-    let useWorkInProgressIndex = Boolean(
-      request.headers.get('X-Boxel-Use-WIP-Index'),
-    );
-    let module = await this.#searchIndex.module(url, {
-      useWorkInProgressIndex,
-    });
-    if (module?.type === 'module') {
-      try {
-        return createResponse({
-          body: module.executableCode,
-          init: {
-            status: 200,
-            headers: { 'content-type': 'text/javascript' },
-          },
-          requestContext,
-        });
-      } finally {
-        this.#logRequestPerformance(request, start, 'cache hit');
+    if (!this.#disableModuleCaching) {
+      let useWorkInProgressIndex = Boolean(
+        request.headers.get('X-Boxel-Use-WIP-Index'),
+      );
+      let module = await this.#searchIndex.module(url, {
+        useWorkInProgressIndex,
+      });
+      if (module?.type === 'module') {
+        try {
+          return createResponse({
+            body: module.executableCode,
+            init: {
+              status: 200,
+              headers: { 'content-type': 'text/javascript' },
+            },
+            requestContext,
+          });
+        } finally {
+          this.#logRequestPerformance(request, start, 'cache hit');
+        }
       }
-    }
-    if (module?.type === 'error') {
-      try {
-        // using "Not Acceptable" here because no text/javascript representation
-        // can be made and we're sending text/html error page instead
-        return createResponse({
-          body: JSON.stringify(module.error, null, 2),
-          init: {
-            status: 406,
-            headers: { 'content-type': 'text/html' },
-          },
-          requestContext,
-        });
-      } finally {
-        this.#logRequestPerformance(request, start, 'cache hit');
+      if (module?.type === 'error') {
+        try {
+          // using "Not Acceptable" here because no text/javascript representation
+          // can be made and we're sending text/html error page instead
+          return createResponse({
+            body: JSON.stringify(module.error, null, 2),
+            init: {
+              status: 406,
+              headers: { 'content-type': 'text/html' },
+            },
+            requestContext,
+          });
+        } finally {
+          this.#logRequestPerformance(request, start, 'cache hit');
+        }
       }
     }
 


### PR DESCRIPTION
This PR introduces a new environment variable for the realm server that can be triggered like this:
```
DISABLE_MODULE_CACHING=true pnpm start:all
```

This facilitates rapid feedback for card module development, such that card modules will be served directly from the filesystem, so any changes to card modules (CSS or js) will be immediately available without a server restart.