### PR TITLE
Clip embedded cards that overflow outside of their yielded area

### DIFF
--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -255,6 +255,7 @@ export function getBoxComponent(
         height: 100%;
         container-name: embedded-card;
         container-type: size;
+        overflow: hidden;
       }
 
       /* 


### PR DESCRIPTION
Prevent embedded cards from flowing outside the space that was allotted to them.

I left the percy diffs unapproved so that people can see how this changes things.