### PR TITLE
host: Add test fixes for Firefox

### DIFF
--- a/packages/host/tests/acceptance/code-submode/editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/editor-test.ts
@@ -28,7 +28,6 @@ import {
   setupAcceptanceTestRealm,
   visitOperatorMode,
   waitForCodeEditor,
-  waitForSyntaxHighlighting,
   type TestContextWithSSE,
   type TestContextWithSave,
 } from '../../helpers';
@@ -325,7 +324,7 @@ module('Acceptance | code submode | editor tests', function (hooks) {
     // TODO we often timeout waiting for syntax highlighting, so i'm commenting
     // out this assertion and creating a ticket to research this: CS-6770
 
-    await waitForSyntaxHighlighting('"Pet"', 'rgb(4, 81, 165)');
+    // await waitForSyntaxHighlighting('"Pet"', 'rgb(4, 81, 165)');
     // await percySnapshot(assert);
   });
 

--- a/packages/host/tests/acceptance/code-submode/editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/editor-test.ts
@@ -28,6 +28,7 @@ import {
   setupAcceptanceTestRealm,
   visitOperatorMode,
   waitForCodeEditor,
+  waitForSyntaxHighlighting,
   type TestContextWithSSE,
   type TestContextWithSave,
 } from '../../helpers';
@@ -324,7 +325,7 @@ module('Acceptance | code submode | editor tests', function (hooks) {
     // TODO we often timeout waiting for syntax highlighting, so i'm commenting
     // out this assertion and creating a ticket to research this: CS-6770
 
-    // await waitForSyntaxHighlighting('"Pet"', 'rgb(4, 81, 165)');
+    await waitForSyntaxHighlighting('"Pet"', 'rgb(4, 81, 165)');
     // await percySnapshot(assert);
   });
 
@@ -790,10 +791,9 @@ module('Acceptance | code submode | editor tests', function (hooks) {
 
       assert.dom('[data-test-realm-indicator-not-writable]').exists();
       assert.strictEqual(
-        find('.monaco-editor')
-          ?.computedStyleMap()
-          .get('background-color')!
-          .toString(),
+        window
+          .getComputedStyle(find('.monaco-editor')!)
+          .getPropertyValue('background-color')!,
         'rgb(235, 234, 237)', // equivalent to #ebeaed
         'monaco editor is greyed out when read-only',
       );

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -136,8 +136,9 @@ export async function waitForSyntaxHighlighting(
 
   await waitUntil(
     () =>
-      finalHighlightedToken?.computedStyleMap()?.get('color')?.toString() ===
-      color,
+      window
+        .getComputedStyle(finalHighlightedToken)
+        .getPropertyValue('color') === color,
     {
       timeout: 2000,
       timeoutMessage: 'timed out waiting for syntax highlighting',

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -137,7 +137,7 @@ export async function waitForSyntaxHighlighting(
   await waitUntil(
     () =>
       window
-        .getComputedStyle(finalHighlightedToken)
+        .getComputedStyle(finalHighlightedToken!)
         .getPropertyValue('color') === color,
     {
       timeout: 2000,

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -1848,7 +1848,7 @@ module('Integration | operator-mode', function (hooks) {
       },
     );
 
-    await waitFor('[data-test-person]');
+    await waitFor('[data-test-boxel-header-icon]');
     assert.dom('[data-test-boxel-header-title]').hasText('Person');
     assert
       .dom(`[data-test-boxel-header-icon="https://example-icon.test"]`)


### PR DESCRIPTION
It’s difficult to show partial success especially in the context of unreliability but here are the test failures on #1242 (left) vs #1423, which is #1242 plus this branch. There’s one failure that also disappeared but is surely flakiness as I didn’t change anything related to it.

<img width="1781" alt="boxel@7a8749c 2024-07-12 13-29-49" src="https://github.com/user-attachments/assets/3472698e-7dd5-49bc-b980-fd5e47dac3b2">

The other ones aren’t happening for me locally which make them harder to fix, but we can continue to chip away at these.