### PR TITLE
Add a component that displays prerendered content (static html + css)

### DIFF
--- a/packages/boxel-ui/addon/src/components.ts
+++ b/packages/boxel-ui/addon/src/components.ts
@@ -30,6 +30,7 @@ import ResizablePanelGroup, {
 } from './components/resizable-panel-group/index.gts';
 import BoxelSelect from './components/select/index.gts';
 import Tooltip from './components/tooltip/index.gts';
+import Prerendered from './components/prerendered/index.gts';
 
 export {
   Accordion,
@@ -58,6 +59,7 @@ export {
   Message,
   Modal,
   RadioInput,
+  Prerendered,
   ResizablePanel,
   ResizablePanelGroup,
   ResizeHandle,

--- a/packages/boxel-ui/addon/src/components/prerendered/index.gts
+++ b/packages/boxel-ui/addon/src/components/prerendered/index.gts
@@ -1,0 +1,23 @@
+interface Signature {
+  Args: {
+    html?: string;
+    css?: string;
+  };
+  Blocks: {
+    default: [];
+  };
+}
+
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
+
+const Prerendered: TemplateOnlyComponent<Signature> = <template>
+  <style unscoped>
+    {{@css}}
+  </style>
+
+  {{{@html}}}
+
+  {{yield}}
+</template>;
+
+export default Prerendered;

--- a/packages/boxel-ui/addon/src/components/prerendered/usage.gts
+++ b/packages/boxel-ui/addon/src/components/prerendered/usage.gts
@@ -1,0 +1,35 @@
+import { fn } from '@ember/helper';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
+import Prerendered from './index.gts';
+
+export default class PrerenderedUsage extends Component {
+  @tracked css = '.red { color: red; }';
+  @tracked html = '<h1 class="red">This is static prerendered HTML</h1>';
+
+  <template>
+    <FreestyleUsage
+      @name='Prerendered Component'
+      @description='Component that renders static HTML and CSS. Used for rendering pre-rendered content.'
+    >
+      <:example>
+        <Prerendered @css={{this.css}} @html={{this.html}} />
+      </:example>
+      <:api as |Args|>
+        <Args.String
+          @name='html'
+          @description='Prerendered html'
+          @value={{this.html}}
+          @onInput={{fn (mut this.html)}}
+        />
+        <Args.String
+          @name='css'
+          @description='CSS'
+          @value={{this.css}}
+          @onInput={{fn (mut this.css)}}
+        />
+      </:api>
+    </FreestyleUsage>
+  </template>
+}

--- a/packages/boxel-ui/addon/src/usage.ts
+++ b/packages/boxel-ui/addon/src/usage.ts
@@ -18,6 +18,7 @@ import LoadingIndicatorUsage from './components/loading-indicator/usage.gts';
 import MenuUsage from './components/menu/usage.gts';
 import MessageUsage from './components/message/usage.gts';
 import ModalUsage from './components/modal/usage.gts';
+import Prerendered from './components/prerendered/usage.gts';
 import RadioInputUsage from './components/radio-input/usage.gts';
 import ResizablePanelGroupUsage from './components/resizable-panel-group/usage.gts';
 import SelectUsage from './components/select/usage.gts';
@@ -45,4 +46,5 @@ export const ALL_USAGE_COMPONENTS = [
   ['ResizablePanelGroup', ResizablePanelGroupUsage],
   ['Select', SelectUsage],
   ['Tooltip', TooltipUsage],
+  ['Prerendered', Prerendered],
 ];


### PR DESCRIPTION
This is a component that I think will be needed for the task of displaying prerendered cards in cards-grid for the purposes of performance improvements. This is how it looks like in the Boxel UI components explorer:

<img width="1059" alt="image" src="https://github.com/user-attachments/assets/62b0b32a-1169-48f3-86de-9c2fa1f05dc9">

Looks pretty straighforward but there is a bug that I am struggling with. After introducing this change, I am not able to run host app, because it fails with:

```
Build Error (PackagerRunner) in ../../../../boxel-ui/addon/dist/index-629a5edd.js

Module not found: Error: @cardstack/boxel-ui is trying to import from style-loader!css-loader!glimmer-scoped-css but that is not one of its explicit dependencies
```

If I remove the `unscoped` from `<style unscoped>` the host can be started ok... 