### PR TITLE
Allow stack items to render full-width and have header background-color

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -2223,6 +2223,8 @@ export class CardDef extends BaseDef {
   static isolated: BaseDefComponent = DefaultCardDefTemplate;
   static edit: BaseDefComponent = DefaultCardDefTemplate;
   static atom: BaseDefComponent = DefaultAtomViewTemplate;
+
+  static prefersWideFormat = false; // whether the card is full-width in the stack
 }
 
 export type BaseDefConstructor = typeof BaseDef;

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -2225,6 +2225,7 @@ export class CardDef extends BaseDef {
   static atom: BaseDefComponent = DefaultAtomViewTemplate;
 
   static prefersWideFormat = false; // whether the card is full-width in the stack
+  static headerColor: string | null = null; // set string color value if the stack-item header has a background color
 }
 
 export type BaseDefConstructor = typeof BaseDef;

--- a/packages/drafts-realm/leaflet-gtfs.gts
+++ b/packages/drafts-realm/leaflet-gtfs.gts
@@ -26,6 +26,7 @@ type Route = {
 export class LeafletGtfs extends CardDef {
   static displayName = 'Leaflet GTFS';
   static prefersWideFormat = true;
+  static headerColor = 'seagreen';
 
   @field lat = contains(NumberField);
   @field lon = contains(NumberField);

--- a/packages/drafts-realm/leaflet-gtfs.gts
+++ b/packages/drafts-realm/leaflet-gtfs.gts
@@ -25,6 +25,7 @@ type Route = {
 
 export class LeafletGtfs extends CardDef {
   static displayName = 'Leaflet GTFS';
+  static prefersWideFormat = true;
 
   @field lat = contains(NumberField);
   @field lon = contains(NumberField);

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -177,6 +177,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
     return htmlSafe(`
       height: calc(100% - ${offsetPx}px * ${this.args.index});
       width: ${width};
+      max-width: ${100 - invertedIndex * widthReductionPercent}%;
       z-index: ${itemsOnStackCount - invertedIndex};
       margin-top: calc(${offsetPx}px * ${this.args.index});
     `); // using margin-top instead of padding-top to hide scrolled content from view

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -163,14 +163,20 @@ export default class OperatorModeStackItem extends Component<Signature> {
   }
 
   private get styleForStackedCard(): SafeString {
+    const stackItemMaxWidth = '50rem';
     let itemsOnStackCount = this.args.stackItems.length;
     let invertedIndex = itemsOnStackCount - this.args.index - 1;
     let widthReductionPercent = 5; // Every new card on the stack is 5% wider than the previous one
     let offsetPx = 30; // Every new card on the stack is 30px lower than the previous one
+    let width = this.args.item.isWideFormat
+      ? '100%'
+      : `calc(${stackItemMaxWidth} * ${
+          100 - invertedIndex * widthReductionPercent
+        } / 100)`;
 
     return htmlSafe(`
       height: calc(100% - ${offsetPx}px * ${this.args.index});
-      width: ${100 - invertedIndex * widthReductionPercent}%;
+      width: ${width};
       z-index: ${itemsOnStackCount - invertedIndex};
       margin-top: calc(${offsetPx}px * ${this.args.index});
     `); // using margin-top instead of padding-top to hide scrolled content from view

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -33,7 +33,7 @@ import {
   LoadingIndicator,
 } from '@cardstack/boxel-ui/components';
 import { MenuItem } from '@cardstack/boxel-ui/helpers';
-import { cn, eq, optional } from '@cardstack/boxel-ui/helpers';
+import { cn, cssVar, eq, optional } from '@cardstack/boxel-ui/helpers';
 
 import {
   IconPencil,
@@ -401,7 +401,9 @@ export default class OperatorModeStackItem extends Component<Signature> {
           <Header
             @size='large'
             @title={{this.headerTitle}}
+            @hasBackground={{true}}
             class={{cn 'header' header--icon-hovered=this.isHoverOnRealmIcon}}
+            style={{cssVar boxel-header-background-color=@item.headerColor}}
             {{on
               'click'
               (optional
@@ -547,8 +549,8 @@ export default class OperatorModeStackItem extends Component<Signature> {
         --boxel-header-padding: var(--boxel-sp-sm);
         --boxel-header-text-font: var(--boxel-font-med);
         --boxel-header-border-radius: var(--boxel-border-radius-xl);
+        --boxel-header-background-color: var(--boxel-light);
         z-index: 1;
-        background-color: var(--boxel-light);
         max-width: max-content;
         height: fit-content;
         min-width: 100%;

--- a/packages/host/app/components/operator-mode/stack.gts
+++ b/packages/host/app/components/operator-mode/stack.gts
@@ -112,7 +112,6 @@ export default class OperatorModeStack extends Component<Signature> {
         position: relative;
         display: flex;
         justify-content: center;
-        max-width: 50rem;
         margin: 0 auto;
         border-bottom-left-radius: var(--boxel-border-radius);
         border-bottom-right-radius: var(--boxel-border-radius);

--- a/packages/host/app/lib/stack-item.ts
+++ b/packages/host/app/lib/stack-item.ts
@@ -91,6 +91,17 @@ export class StackItem {
     );
   }
 
+  get headerColor() {
+    if (
+      this.card?.constructor &&
+      'headerColor' in this.card.constructor &&
+      this.card.constructor.headerColor != null
+    ) {
+      return this.card.constructor.headerColor;
+    }
+    return;
+  }
+
   get api() {
     let api = this.cardResource?.api ?? this.newCardApi;
     if (!api) {

--- a/packages/host/app/lib/stack-item.ts
+++ b/packages/host/app/lib/stack-item.ts
@@ -84,22 +84,29 @@ export class StackItem {
   }
 
   get isWideFormat() {
-    return (
-      this.card?.constructor &&
-      'prefersWideFormat' in this.card.constructor &&
-      this.card.constructor.prefersWideFormat
+    if (!this.cardResource || !this.cardResource.card) {
+      return false;
+    }
+    let { constructor } = this.cardResource.card;
+    return Boolean(
+      constructor &&
+        'prefersWideFormat' in constructor &&
+        constructor.prefersWideFormat,
     );
   }
 
   get headerColor() {
-    if (
-      this.card?.constructor &&
-      'headerColor' in this.card.constructor &&
-      this.card.constructor.headerColor != null
-    ) {
-      return this.card.constructor.headerColor;
+    if (!this.cardResource || !this.cardResource.card) {
+      return;
     }
-    return;
+    let cardDef = this.cardResource.card.constructor;
+    if (!cardDef || !('headerColor' in cardDef)) {
+      return;
+    }
+    if (cardDef.headerColor == null) {
+      return;
+    }
+    return cardDef.headerColor as string;
   }
 
   get api() {

--- a/packages/host/app/lib/stack-item.ts
+++ b/packages/host/app/lib/stack-item.ts
@@ -83,6 +83,14 @@ export class StackItem {
     throw new Error(`This StackItem has no card set`);
   }
 
+  get isWideFormat() {
+    return (
+      this.card?.constructor &&
+      'prefersWideFormat' in this.card.constructor &&
+      this.card.constructor.prefersWideFormat
+    );
+  }
+
   get api() {
     let api = this.cardResource?.api ?? this.newCardApi;
     if (!api) {


### PR DESCRIPTION
CS-6988

This came out of the AI app generation spike work, however it does affect the host app because of the visual treatment we want to be able to have for cards. These changes allow any card to be able to render in full-width and have header background-color in interact mode by defining static properties in their card def. Here's an example:

<img width="1629" alt="leaflet-code-mode" src="https://github.com/user-attachments/assets/8d356709-18b5-4109-bf2d-3e9b8de4a035">

<img width="1080" alt="stack-item" src="https://github.com/user-attachments/assets/f28a012a-0b20-48be-b58a-e7a1012cf29f">


