### PR TITLE
Prerendered cards: allow requesting for specific embedded variant

### DIFF
--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -560,8 +560,8 @@ export class CurrentRun {
           realmPath: this.#realmPaths,
         }),
       );
-      let ref = refURL === types[0].refURL ? 'default' : refURL;
-      result[ref] = embeddedHtml;
+
+      result[refURL] = embeddedHtml;
     }
     return result;
   }

--- a/packages/host/tests/integration/card-prerender-test.gts
+++ b/packages/host/tests/integration/card-prerender-test.gts
@@ -62,6 +62,7 @@ module('Integration | card-prerender', function (hooks) {
             type: 'card',
             id: `${testRealmURL}Pet/mango`,
             attributes: {
+              title: 'test card: pet mango',
               firstName: 'Mango',
             },
             meta: {
@@ -77,6 +78,7 @@ module('Integration | card-prerender', function (hooks) {
             type: 'card',
             id: `${testRealmURL}Pet/vangogh`,
             attributes: {
+              title: 'test card: pet vangogh',
               firstName: 'Van Gogh',
             },
             meta: {
@@ -134,7 +136,9 @@ module('Integration | card-prerender', function (hooks) {
         `,
         'jane.json': {
           data: {
+            type: 'card',
             attributes: {
+              title: 'test card: person jane',
               firstName: 'Jane',
               favoriteColor: 'blue',
             },
@@ -148,7 +152,9 @@ module('Integration | card-prerender', function (hooks) {
         },
         'jimmy.json': {
           data: {
+            type: 'card',
             attributes: {
+              title: 'test card: person jimmy',
               firstName: 'Jimmy',
               favoriteColor: 'black',
             },
@@ -195,7 +201,7 @@ module('Integration | card-prerender', function (hooks) {
     }
   });
 
-  test('can get prerendered cards with their html + css', async function (assert) {
+  test('indexer returns correct prerendered cards with their html + css when there is "on" filter specified', async function (assert) {
     let results = await realm.searchIndex.searchPrerendered(
       {
         filter: {
@@ -261,5 +267,52 @@ module('Integration | card-prerender', function (hooks) {
       results.prerenderedCards[0].html.includes('Embedded Card FancyPerson'),
       'the embedded card html looks correct',
     );
+  });
+
+  test('indexer returns correct prerendered cards with their html + css when there is no "on" filter specified', async function (assert) {
+    let results = await realm.searchIndex.searchPrerendered(
+      {},
+      {
+        htmlFormat: 'embedded',
+      },
+    );
+
+    assert.strictEqual(
+      results.meta.page.total,
+      4,
+      'the search results contain the correct number of items',
+    );
+
+    // Since there is no "on" filter, the prerendered html must be from a CardDef template
+
+    [
+      'test card: pet mango',
+      'test card: pet vangogh',
+      'test card: person jane',
+      'test card: person jimmy',
+    ].forEach((title, index) => {
+      assert.strictEqual(
+        trimCardContainer(
+          stripScopedCSSAttributes(results.prerenderedCards[index].html),
+        ),
+        cleanWhiteSpace(`
+        <div class="embedded-template">
+          <div class="thumbnail-section">
+            <div class="card-thumbnail">
+              <div class="card-thumbnail-text" data-test-card-thumbnail-text>Card</div>
+            </div>
+            <div class="thumbnail-subsection">
+              <div class="thumbnail-subsection">
+                <h3 class="card-title" data-test-card-title>${title}</h3>
+              </div>
+              <div class="thumbnail-subsection">
+                <h4 class="card-display-name" data-test-card-display-name>Card</h4>
+              </div>
+            </div>
+          </div>
+        </div>
+      `),
+      );
+    });
   });
 });

--- a/packages/host/tests/integration/search-index-test.gts
+++ b/packages/host/tests/integration/search-index-test.gts
@@ -654,7 +654,11 @@ module(`Integration | search-index`, function (hooks) {
             cleanWhiteSpace(`<h1> Van Gogh </h1>`),
           );
           assert.strictEqual(
-            trimCardContainer(stripScopedCSSAttributes(embeddedHtml!)),
+            trimCardContainer(
+              stripScopedCSSAttributes(
+                embeddedHtml![`${testRealmURL}person/Person`],
+              ),
+            ),
             cleanWhiteSpace(`<h1> Person Embedded Card: Van Gogh </h1>`),
           );
         } else {
@@ -679,7 +683,11 @@ module(`Integration | search-index`, function (hooks) {
             cleanWhiteSpace(`<h1> Van Gogh </h1>`),
           );
           assert.strictEqual(
-            trimCardContainer(stripScopedCSSAttributes(embeddedHtml!)),
+            trimCardContainer(
+              stripScopedCSSAttributes(
+                embeddedHtml![`${testRealmURL}person/Person`],
+              ),
+            ),
             cleanWhiteSpace(`<h1> Person Embedded Card: Van Gogh </h1>`),
           );
         } else {
@@ -796,7 +804,11 @@ module(`Integration | search-index`, function (hooks) {
         cleanWhiteSpace(`<h1> Van Gogh </h1>`),
       );
       assert.strictEqual(
-        trimCardContainer(stripScopedCSSAttributes(embeddedHtml!)),
+        trimCardContainer(
+          stripScopedCSSAttributes(
+            embeddedHtml![`${testRealmURL}person/Person`],
+          ),
+        ),
         cleanWhiteSpace(`<h1> Person Embedded Card: Van Gogh </h1>`),
       );
     } else {
@@ -920,12 +932,16 @@ module(`Integration | search-index`, function (hooks) {
         `isolated HTML does not include ember ID's`,
       );
       assert.strictEqual(
-        trimCardContainer(stripScopedCSSAttributes(embeddedHtml!)),
+        trimCardContainer(
+          stripScopedCSSAttributes(
+            embeddedHtml![`${testRealmURL}person/Person`],
+          ),
+        ),
         cleanWhiteSpace(`<h1> Person Embedded Card: Van Gogh </h1>`),
       );
       assert.strictEqual(
         false,
-        embeddedHtml!.includes('id="ember'),
+        Object.values(embeddedHtml!).join('').includes('id="ember'),
         `embeddedHtml HTML does not include ember ID's`,
       );
     } else {
@@ -1088,59 +1104,56 @@ module(`Integration | search-index`, function (hooks) {
       },
     });
 
-    let { embeddedHtml, _embeddedHtmlByClassHierarchy } =
+    let { embeddedHtml } =
       (await getInstance(realm, new URL(`${testRealmURL}germaine`))) ?? {};
     assert.strictEqual(
       false,
-      embeddedHtml!.includes('id="ember'),
+      Object.values(embeddedHtml!).join('').includes('id="ember'),
       `HTML does not include ember ID's`,
     );
     assert.strictEqual(
-      trimCardContainer(stripScopedCSSAttributes(embeddedHtml!)),
+      trimCardContainer(
+        stripScopedCSSAttributes(
+          embeddedHtml![`${testRealmURL}fancy-person/FancyPerson`],
+        ),
+      ),
       cleanWhiteSpace(
         `<h1> Fancy Person Embedded Card: Germaine - hot pink </h1>`,
       ),
       'default embedded HTML is correct',
     );
-    let embeddedHtmls = _embeddedHtmlByClassHierarchy!;
+
     let cardDefRefURL = internalKeyFor(baseCardRef, undefined);
     assert.deepEqual(
-      Object.keys(embeddedHtmls),
-      ['default', `${testRealmURL}person/Person`, cardDefRefURL],
+      Object.keys(embeddedHtml!),
+      [
+        `${testRealmURL}fancy-person/FancyPerson`,
+        `${testRealmURL}person/Person`,
+        cardDefRefURL,
+      ],
       'embedded class hierarchy is correct',
     );
-    assert.strictEqual(
-      trimCardContainer(stripScopedCSSAttributes(embeddedHtmls['default'])),
-      cleanWhiteSpace(
-        `<h1> Fancy Person Embedded Card: Germaine - hot pink </h1>`,
-      ),
-      'default embedded HTML is correct',
-    );
-    assert.strictEqual(
-      false,
-      embeddedHtmls['default'].includes('id="ember'),
-      `default embedded HTML does not include ember ID's`,
-    );
+
     assert.strictEqual(
       trimCardContainer(
-        stripScopedCSSAttributes(embeddedHtmls[`${testRealmURL}person/Person`]),
+        stripScopedCSSAttributes(embeddedHtml![`${testRealmURL}person/Person`]),
       ),
       cleanWhiteSpace(`<h1> Person Embedded Card: Germaine </h1>`),
       `${testRealmURL}person/Person embedded HTML is correct`,
     );
     assert.strictEqual(
       false,
-      embeddedHtmls[`${testRealmURL}person/Person`].includes('id="ember'),
+      embeddedHtml![`${testRealmURL}person/Person`].includes('id="ember'),
       `${testRealmURL}person/Person embedded HTML does not include ember ID's`,
     );
     assert.strictEqual(
-      trimCardContainer(stripScopedCSSAttributes(embeddedHtmls[cardDefRefURL])),
+      trimCardContainer(stripScopedCSSAttributes(embeddedHtml![cardDefRefURL])),
       cleanWhiteSpace(`
         <div class="embedded-template">
           <div class="thumbnail-section">
             <div class="card-thumbnail">
               <div class="card-thumbnail-text" data-test-card-thumbnail-text>Card</div>
-            </div> 
+            </div>
             <div class="thumbnail-subsection">
               <div class="thumbnail-subsection">
                 <h3 class="card-title" data-test-card-title></h3>
@@ -1154,9 +1167,10 @@ module(`Integration | search-index`, function (hooks) {
       `),
       `${cardDefRefURL} embedded HTML is correct`,
     );
+
     assert.strictEqual(
       false,
-      embeddedHtmls[cardDefRefURL].includes('id="ember'),
+      embeddedHtml![cardDefRefURL].includes('id="ember'),
       `${cardDefRefURL} embedded HTML does not include ember ID's`,
     );
   });

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -257,7 +257,11 @@ module('indexing', function (hooks) {
         'pre-rendered isolated format html is correct',
       );
       assert.strictEqual(
-        trimCardContainer(stripScopedCSSAttributes(entry!.embeddedHtml!)),
+        trimCardContainer(
+          stripScopedCSSAttributes(
+            entry!.embeddedHtml![`${testRealm}person/Person`],
+          ),
+        ),
         cleanWhiteSpace(`<h1> Embedded Card Person: Mango </h1>`),
         'pre-rendered embedded format html is correct',
       );
@@ -296,7 +300,11 @@ module('indexing', function (hooks) {
             cleanWhiteSpace(`<h1> Van Gogh </h1>`),
           );
           assert.strictEqual(
-            trimCardContainer(stripScopedCSSAttributes(item.embeddedHtml!)),
+            trimCardContainer(
+              stripScopedCSSAttributes(
+                item.embeddedHtml![`${testRealm}person/Person`]!,
+              ),
+            ),
             cleanWhiteSpace(`<h1> Embedded Card Person: Van Gogh </h1>`),
           );
         } else {

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -1654,8 +1654,20 @@ module('Realm Server', function (hooks) {
         });
 
         test('returns prerendered instances', async function (assert) {
+          let query: Query & { prerenderedHtmlFormat: string } = {
+            filter: {
+              on: {
+                module: `${testRealmHref}person`,
+                name: 'Person',
+              },
+              eq: {
+                firstName: 'John',
+              },
+            },
+            prerenderedHtmlFormat: 'embedded',
+          };
           let response = await request
-            .get(`/_search-prerendered?prerenderedHtmlFormat=embedded`)
+            .get(`/_search-prerendered?${stringify(query)}`)
             .set('Accept', 'application/vnd.card+json');
 
           assert.strictEqual(response.status, 200, 'HTTP 200 status');
@@ -1753,6 +1765,7 @@ module('Realm Server', function (hooks) {
             data: {
               attributes: {
                 firstName: 'Aaron',
+                title: 'Person Aaron',
               },
               meta: {
                 adoptsFrom: {
@@ -1766,6 +1779,7 @@ module('Realm Server', function (hooks) {
             data: {
               attributes: {
                 firstName: 'Craig',
+                title: 'Person Craig',
               },
               meta: {
                 adoptsFrom: {
@@ -1780,6 +1794,7 @@ module('Realm Server', function (hooks) {
               attributes: {
                 firstName: 'Jane',
                 favoriteColor: 'blue',
+                title: 'FancyPerson Jane',
               },
               meta: {
                 adoptsFrom: {
@@ -1794,6 +1809,7 @@ module('Realm Server', function (hooks) {
               attributes: {
                 firstName: 'Jimmy',
                 favoriteColor: 'black',
+                title: 'FancyPerson Jimmy',
               },
               meta: {
                 adoptsFrom: {
@@ -1806,7 +1822,7 @@ module('Realm Server', function (hooks) {
         },
       );
 
-      test('returns instances with prerendered embedded html + css', async function (assert) {
+      test('returns instances with CardDef prerendered embedded html + css when there is no "on" filter', async function (assert) {
         let response = await request
           .get(`/_search-prerendered?prerenderedHtmlFormat=embedded`)
           .set('Accept', 'application/vnd.card+json');
@@ -1835,7 +1851,7 @@ module('Realm Server', function (hooks) {
         assert.true(
           json.data[0].attributes.html
             .replace(/\s+/g, ' ')
-            .includes('Embedded Card Person: Aaron'),
+            .includes('Person Aaron'),
           'embedded html looks correct',
         );
         assert.strictEqual(
@@ -1854,7 +1870,7 @@ module('Realm Server', function (hooks) {
         assert.true(
           json.data[1].attributes.html
             .replace(/\s+/g, ' ')
-            .includes('Embedded Card Person: Craig'),
+            .includes('Person Craig'),
           'embedded html for Craig looks correct',
         );
         assert.strictEqual(
@@ -1873,7 +1889,7 @@ module('Realm Server', function (hooks) {
         assert.true(
           json.data[2].attributes.html
             .replace(/\s+/g, ' ')
-            .includes('Embedded Card FancyPerson: Jane'),
+            .includes('FancyPerson Jane'),
           'embedded html for Jane looks correct',
         );
         assert.strictEqual(
@@ -1901,7 +1917,7 @@ module('Realm Server', function (hooks) {
         assert.true(
           json.data[3].attributes.html
             .replace(/\s+/g, ' ')
-            .includes('Embedded Card FancyPerson: Jimmy'),
+            .includes('FancyPerson Jimmy'),
           'embedded html for Jimmy looks correct',
         );
         assert.strictEqual(

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -74,7 +74,7 @@ export interface IndexedInstance {
   canonicalURL: string;
   lastModified: number;
   isolatedHtml: string | null;
-  embeddedHtml: string | null;
+  embeddedHtml: { [refURL: string]: string } | null;
   atomHtml: string | null;
   searchDoc: Record<string, any> | null;
   types: string[] | null;
@@ -82,10 +82,6 @@ export interface IndexedInstance {
   realmVersion: number;
   realmURL: string;
   indexedAt: number | null;
-  // TODO this is used for testing, lets remove this after we have a way to ask
-  // for which card class to use for embedded HTML. This will mean we'll need to
-  // alter the way we test this so that it's a bit more indirect.
-  _embeddedHtmlByClassHierarchy: { [refURL: string]: string } | null;
 }
 interface IndexedError {
   type: 'error';
@@ -237,10 +233,8 @@ export class IndexQueryEngine {
     opts?: GetEntryOptions,
   ): Promise<IndexedInstanceOrError | undefined> {
     let result = (await this.query([
-      `SELECT i.*, embedded_html ->> `,
-      param('default'),
-      ` as default_embedded_html
-       FROM boxel_index as i
+      `SELECT i.*, embedded_html`,
+      `FROM boxel_index as i
        INNER JOIN realm_versions r ON i.realm_url = r.realm_url
        WHERE`,
       ...every([
@@ -257,9 +251,7 @@ export class IndexQueryEngine {
     ] as Expression)) as unknown as (BoxelIndexTable & {
       default_embedded_html: string | null;
     })[];
-    let maybeResult:
-      | (BoxelIndexTable & { default_embedded_html: string | null })
-      | undefined = result[0];
+    let maybeResult: BoxelIndexTable | undefined = result[0];
     if (!maybeResult) {
       return undefined;
     }
@@ -276,8 +268,7 @@ export class IndexQueryEngine {
       pristine_doc: instance,
       isolated_html: isolatedHtml,
       atom_html: atomHtml,
-      default_embedded_html: embeddedHtml,
-      embedded_html: _embeddedHtmlByClassHierarchy,
+      embedded_html: embeddedHtml,
       search_doc: searchDoc,
       realm_version: realmVersion,
       realm_url: realmURL,
@@ -309,9 +300,6 @@ export class IndexQueryEngine {
       deps,
       lastModified: parseInt(lastModified),
       realmVersion,
-      // TODO this is used for testing, lets remove this after we have a way to ask
-      // for which card class to use for embedded HTML
-      _embeddedHtmlByClassHierarchy,
     };
   }
 

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -443,9 +443,18 @@ export class IndexQueryEngine {
     ) {
       throw new Error(`htmlFormat must be either 'embedded' or 'atom'`);
     }
+
+    let ref: CodeRef;
+    let filterOnValue = filter && 'type' in filter ? filter.type : filter?.on;
+    if (filterOnValue) {
+      ref = filterOnValue;
+    } else {
+      ref = baseCardRef;
+    }
+
     let htmlColumnExpression =
       opts.htmlFormat == 'embedded'
-        ? ['embedded_html ->> ', param('default')] // TODO: this param should be the value of card type specified in the ON filter - if that is not present, or the query has different card type values in ON filters, we should default to CardDef embedded template in the embedded_html JSON
+        ? ['embedded_html ->> ', param(internalKeyFor(ref, undefined))]
         : ['atom_html'];
 
     let { results, meta } = (await this._search(

--- a/packages/runtime-common/tests/index-query-engine-test.ts
+++ b/packages/runtime-common/tests/index-query-engine-test.ts
@@ -2479,14 +2479,17 @@ const tests = Object.freeze({
     await setupIndex(dbAdapter, [
       {
         url: `${testRealmURL}vangogh.json`,
-        file_alias: `${testRealmURL}vangogh.json`,
+        file_alias: `${testRealmURL}vangogh`,
         type: 'instance',
         realm_version: 1,
         realm_url: testRealmURL,
         deps: [`${testRealmURL}person`],
         types: [],
         embedded_html: {
-          default: '<div>Van Gogh</div>',
+          [`${testRealmURL}person/Person`]:
+            '<div>Van Gogh (Person embedded template)</div>',
+          'https://cardstack.com/base/card-api/CardDef':
+            '<div>Van Gogh (CardDef embedded template)</div>',
         },
         atom_html: 'Van Gogh',
       },
@@ -2516,7 +2519,7 @@ const tests = Object.freeze({
     let { prerenderedCards, prerenderedCardCssItems, meta } =
       await indexQueryEngine.searchPrerendered(
         new URL(testRealmURL),
-        {},
+        {}, // When there is no ON filter, embedded template for CardDef is used
         loader,
         {
           htmlFormat: 'embedded',
@@ -2538,7 +2541,10 @@ const tests = Object.freeze({
       prerenderedCards[0].url,
       'http://test-realm/test/vangogh.json',
     );
-    assert.strictEqual(prerenderedCards[0].html, '<div>Van Gogh</div>');
+    assert.strictEqual(
+      prerenderedCards[0].html,
+      '<div>Van Gogh (CardDef embedded template)</div>',
+    );
 
     assert.strictEqual(prerenderedCardCssItems.length, 1);
     assert.strictEqual(

--- a/packages/runtime-common/tests/index-updater-test.ts
+++ b/packages/runtime-common/tests/index-updater-test.ts
@@ -876,7 +876,6 @@ const tests = Object.freeze({
         isolatedHtml: null,
         atomHtml: null,
         embeddedHtml: null,
-        _embeddedHtmlByClassHierarchy: null,
       });
     } else {
       assert.ok(false, `expected index entry to not be an error document`);
@@ -972,7 +971,6 @@ const tests = Object.freeze({
         isolatedHtml: null,
         embeddedHtml: null,
         atomHtml: null,
-        _embeddedHtmlByClassHierarchy: null,
       });
     } else {
       assert.ok(false, `expected index entry to not be an error document`);


### PR DESCRIPTION
Changes:

1. Removes `default` entry from `embedded_html` JSON field and replaces it with the card type name. This is so that we can refer to the specific name when requesting prerendered cards  (see point (2) below):

An example boxel index entry for an instance of a Country:

`embedded_html` previously: 
```
{"default": "<div>...</div>", "https://cardstack.com/base/card-api/CardDef": "<div>...</div>"}
```

Now: 
```
{"http://localhost:4201/drafts/country/Country": "<div>...</div>", "https://cardstack.com/base/card-api/CardDef": "<div>...</div>" } 
```

2. When requesting prerendered cards using `_/search-prerendered` endpoint, check the value of the "on" filter  and use it to get the appropriate embedded template variant, otherwise fall back to `CardDef` template. 

So for example if the provided search filter is 

```
filter: {
  on: {
    module: `https://realm-url.com/Person`,
    name: 'FancyPerson',
  },
  eq: {
    firstName: 'Jimmy'
  },
}
```

Then the prerendered cards query will return embedded html that by looking up the `https://realm-url.com/Person/fancy-person` property in `embedded_html` JSON. And if there is no `on` filter, then it will return the `CardDef` embedded template. 

Also a note–the change where the prerendered CSS is narrowed down to only the specified module is coming in the next PR.