### PR TITLE
ci: Add host previews on changes to boxel-ui

### DIFF
--- a/.github/workflows/pr-boxel-host.yml
+++ b/.github/workflows/pr-boxel-host.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "packages/host/**"
+      - "packages/boxel-ui/**"
       - ".github/workflows/pr-boxel-host.yml"
       - "package.json"
       - "pnpm-lock.yaml"


### PR DESCRIPTION
I’d have appreciated a `host` preview deployment for #1428 for ease of review but it didn’t happen because there were no changes in `packages/host`.