### PR TITLE
[WIP] Card header improvements

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -2385,7 +2385,6 @@ export class CardDef extends BaseDef {
   static atom: BaseDefComponent = DefaultAtomViewTemplate;
 
   static prefersWideFormat = false; // whether the card is full-width in the stack
-  static headerColor: string | null = null; // set string color value if the stack-item header has a background color
 }
 
 export type BaseDefConstructor = typeof BaseDef;

--- a/packages/drafts-realm/app-card.gts
+++ b/packages/drafts-realm/app-card.gts
@@ -6,7 +6,7 @@ import {
   FieldDef,
 } from 'https://cardstack.com/base/card-api';
 import { Component } from 'https://cardstack.com/base/card-api';
-import { eq } from '@cardstack/boxel-ui/helpers';
+import { cssVar, eq } from '@cardstack/boxel-ui/helpers';
 
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
@@ -21,6 +21,7 @@ import { getLiveCards, cardTypeDisplayName } from '@cardstack/runtime-common';
 // @ts-ignore no types
 import cssUrl from 'ember-css-url';
 import BooleanField from 'https://cardstack.com/base/boolean';
+import { ColorPicker } from './color-picker';
 
 class Tab extends FieldDef {
   @field ref = contains(CodeRefField);
@@ -208,12 +209,6 @@ class Isolated extends Component<typeof AppCard> {
     this.moduleName = (event.target as HTMLInputElement).value;
   }
 
-  get headerColor() {
-    let hc = Object.getPrototypeOf(this.args.model).constructor.headerColor;
-    console.log('hello', hc);
-    return hc;
-  }
-
   <template>
     {{#if this.noTabs}}
       <div
@@ -242,7 +237,7 @@ class Isolated extends Component<typeof AppCard> {
       <section class='dashboard'>
         <header
           class='dashboard-header'
-          style='background-color: {{this.headerColor}}'
+          style={{cssVar db-header-bg-color=this.args.model.headerColor.value}}
         >
           <h1 class='dashboard-title'><@fields.title /></h1>
           <nav class='dashboard-nav'>
@@ -558,11 +553,8 @@ class Isolated extends Component<typeof AppCard> {
 
 export class AppCard extends CardDef {
   static displayName = 'AppCard';
-
   static prefersWideFormat = true;
-  static headerColor = '#009879';
-
+  @field headerColor = contains(ColorPicker);
   @field tabs = containsMany(Tab);
-
   static isolated = Isolated;
 }

--- a/packages/drafts-realm/app-card.gts
+++ b/packages/drafts-realm/app-card.gts
@@ -237,7 +237,7 @@ class Isolated extends Component<typeof AppCard> {
       <section class='dashboard'>
         <header
           class='dashboard-header'
-          style={{cssVar db-header-bg-color=this.args.model.headerColor.value}}
+          style={{cssVar db-header-bg-color=this.args.model.headerColor}}
         >
           <h1 class='dashboard-title'><@fields.title /></h1>
           <nav class='dashboard-nav'>

--- a/packages/drafts-realm/color-picker.gts
+++ b/packages/drafts-realm/color-picker.gts
@@ -1,0 +1,57 @@
+import {
+  field,
+  contains,
+  FieldDef,
+  Component,
+} from 'https://cardstack.com/base/card-api';
+import StringField from 'https://cardstack.com/base/string';
+import { action } from '@ember/object';
+import { BoxelInput } from '@cardstack/boxel-ui/components';
+
+class ColorPickerTemplate extends Component<typeof ColorPicker> {
+  @action
+  setColor(color: string) {
+    this.args.model.value = color;
+  }
+  <template>
+    <div class='color-picker'>
+      <label>
+        <span class='boxel-sr-only'>Hex Code</span>
+        <BoxelInput
+          @value={{this.args.model.value}}
+          @onInput={{this.setColor}}
+        />
+      </label>
+      <label>
+        <span class='boxel-sr-only'>Color</span>
+        <BoxelInput
+          class='color-input'
+          @type='color'
+          @value={{this.args.model.value}}
+          @onInput={{this.setColor}}
+        />
+      </label>
+    </div>
+    <style>
+      .color-picker {
+        display: flex;
+        gap: 10px;
+      }
+      .color-input {
+        grid-column: 1 / -1;
+        padding: 5px;
+      }
+      .color-input:hover:not(:disabled) {
+        cursor: pointer;
+      }
+    </style>
+  </template>
+}
+
+export class ColorPicker extends FieldDef {
+  static displayName = 'Color Picker';
+  @field value = contains(StringField);
+  static isolated = ColorPickerTemplate;
+  static embedded = ColorPickerTemplate;
+  static edit = ColorPickerTemplate;
+}

--- a/packages/drafts-realm/color-picker.gts
+++ b/packages/drafts-realm/color-picker.gts
@@ -1,11 +1,5 @@
-import {
-  field,
-  contains,
-  FieldDef,
-  Component,
-} from 'https://cardstack.com/base/card-api';
+import { Component } from 'https://cardstack.com/base/card-api';
 import StringField from 'https://cardstack.com/base/string';
-import { action } from '@ember/object';
 import { BoxelInput } from '@cardstack/boxel-ui/components';
 
 class ColorPickerTemplate extends Component<typeof ColorPicker> {
@@ -13,7 +7,7 @@ class ColorPickerTemplate extends Component<typeof ColorPicker> {
     <div class='color-picker'>
       <label>
         <span class='boxel-sr-only'>Hex Code</span>
-        <BoxelInput @value={{this.currentColor}} @onInput={{this.setColor}} />
+        <BoxelInput @value={{this.currentColor}} @onInput={{@set}} />
       </label>
       <label>
         <span class='boxel-sr-only'>Color</span>
@@ -21,7 +15,7 @@ class ColorPickerTemplate extends Component<typeof ColorPicker> {
           class='color-input'
           @type='color'
           @value={{this.currentColor}}
-          @onInput={{this.setColor}}
+          @onInput={{@set}}
         />
       </label>
     </div>
@@ -41,16 +35,12 @@ class ColorPickerTemplate extends Component<typeof ColorPicker> {
   </template>
 
   get currentColor() {
-    return this.args.model.value ?? '#ffffff';
-  }
-  @action setColor(color: string) {
-    this.args.model.value = color;
+    return this.args.model?.trim().length ? this.args.model : '#ffffff';
   }
 }
 
-export class ColorPicker extends FieldDef {
+export class ColorPicker extends StringField {
   static displayName = 'Color Picker';
-  @field value = contains(StringField);
   static isolated = ColorPickerTemplate;
   static embedded = ColorPickerTemplate;
   static edit = ColorPickerTemplate;

--- a/packages/drafts-realm/color-picker.gts
+++ b/packages/drafts-realm/color-picker.gts
@@ -9,25 +9,18 @@ import { action } from '@ember/object';
 import { BoxelInput } from '@cardstack/boxel-ui/components';
 
 class ColorPickerTemplate extends Component<typeof ColorPicker> {
-  @action
-  setColor(color: string) {
-    this.args.model.value = color;
-  }
   <template>
     <div class='color-picker'>
       <label>
         <span class='boxel-sr-only'>Hex Code</span>
-        <BoxelInput
-          @value={{this.args.model.value}}
-          @onInput={{this.setColor}}
-        />
+        <BoxelInput @value={{this.currentColor}} @onInput={{this.setColor}} />
       </label>
       <label>
         <span class='boxel-sr-only'>Color</span>
         <BoxelInput
           class='color-input'
           @type='color'
-          @value={{this.args.model.value}}
+          @value={{this.currentColor}}
           @onInput={{this.setColor}}
         />
       </label>
@@ -46,6 +39,13 @@ class ColorPickerTemplate extends Component<typeof ColorPicker> {
       }
     </style>
   </template>
+
+  get currentColor() {
+    return this.args.model.value ?? '#ffffff';
+  }
+  @action setColor(color: string) {
+    this.args.model.value = color;
+  }
 }
 
 export class ColorPicker extends FieldDef {

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -168,11 +168,12 @@ export default class OperatorModeStackItem extends Component<Signature> {
     let invertedIndex = itemsOnStackCount - this.args.index - 1;
     let widthReductionPercent = 5; // Every new card on the stack is 5% wider than the previous one
     let offsetPx = 30; // Every new card on the stack is 30px lower than the previous one
-    let width = this.args.item.isWideFormat
-      ? '100%'
-      : `calc(${stackItemMaxWidth} * ${
-          100 - invertedIndex * widthReductionPercent
-        } / 100)`;
+    let width =
+      !this.isBuried && this.args.item.isWideFormat
+        ? '100%'
+        : `calc(${stackItemMaxWidth} * ${
+            100 - invertedIndex * widthReductionPercent
+          } / 100)`;
 
     return htmlSafe(`
       height: calc(100% - ${offsetPx}px * ${this.args.index});

--- a/packages/host/app/lib/stack-item.ts
+++ b/packages/host/app/lib/stack-item.ts
@@ -99,14 +99,15 @@ export class StackItem {
     if (!this.cardResource || !this.cardResource.card) {
       return;
     }
-    let cardDef = this.cardResource.card.constructor;
+    let cardDef = this.cardResource.card;
     if (!cardDef || !('headerColor' in cardDef)) {
       return;
     }
-    if (cardDef.headerColor == null) {
+    let color = cardDef.headerColor as { value: string } | null;
+    if (color == null || !color.value) {
       return;
     }
-    return cardDef.headerColor as string;
+    return color.value;
   }
 
   get api() {

--- a/packages/host/app/lib/stack-item.ts
+++ b/packages/host/app/lib/stack-item.ts
@@ -103,11 +103,13 @@ export class StackItem {
     if (!cardDef || !('headerColor' in cardDef)) {
       return;
     }
-    let color = cardDef.headerColor as { value: string } | null;
-    if (color == null || !color.value) {
+    if (
+      cardDef.headerColor == null ||
+      typeof cardDef.headerColor !== 'string'
+    ) {
       return;
     }
-    return color.value;
+    return cardDef.headerColor;
   }
 
   get api() {


### PR DESCRIPTION
Note: Making changes to this PR after the discussion mentioned below, do not review yet.

~- do not make headerColor a static property (if a card has `headerColor` property, each instance can set a different header color)~ --> after discussing this with Chris, Luke, Ian, we decided to keep this static property. Instead, each newly generated app will be a subclass and will be able to specify their own static headerColor. 
- if card is buried in the stack, do not keep it full-width