### PR TITLE
host: Fix read receipt errors

### DIFF
--- a/packages/host/app/components/matrix/room-message.gts
+++ b/packages/host/app/components/matrix/room-message.gts
@@ -90,6 +90,10 @@ class SendReadReceipt extends Modifier<SendReadReceiptModifierSignature> {
       getTs: () => message.created.getTime(),
     };
 
+    if (message.eventId.startsWith('~')) {
+      debugger;
+    }
+
     // Without scheduling this after render, this produces the "attempted to update value, but it had already been used previously in the same computation" error
     schedule('afterRender', () => {
       matrixService.client.sendReadReceipt(matrixEvent as MatrixEvent);

--- a/packages/host/app/components/matrix/room-message.gts
+++ b/packages/host/app/components/matrix/room-message.gts
@@ -79,6 +79,12 @@ class SendReadReceipt extends Modifier<SendReadReceiptModifierSignature> {
       return;
     }
 
+    let messageIsFromBot = message.author.userId === aiBotUserId;
+
+    if (!messageIsFromBot) {
+      return;
+    }
+
     if (matrixService.currentUserEventReadReceipts.has(message.eventId)) {
       return;
     }

--- a/packages/host/app/components/matrix/room-message.gts
+++ b/packages/host/app/components/matrix/room-message.gts
@@ -96,12 +96,12 @@ class SendReadReceipt extends Modifier<SendReadReceiptModifierSignature> {
       }, room ${roomId}, ts ${message.created.getTime()}`,
     );
 
-    if (message.eventId.startsWith('~')) {
-      debugger;
-    }
-
     // Without scheduling this after render, this produces the "attempted to update value, but it had already been used previously in the same computation" error
     schedule('afterRender', () => {
+      if (message.eventId.startsWith('~')) {
+        debugger;
+      }
+
       matrixService.client.sendReadReceipt(matrixEvent as MatrixEvent);
     });
   }

--- a/packages/host/app/components/matrix/room-message.gts
+++ b/packages/host/app/components/matrix/room-message.gts
@@ -90,6 +90,12 @@ class SendReadReceipt extends Modifier<SendReadReceiptModifierSignature> {
       getTs: () => message.created.getTime(),
     };
 
+    console.log(
+      `artificial matrix event: id ${
+        message.eventId
+      }, room ${roomId}, ts ${message.created.getTime()}`,
+    );
+
     if (message.eventId.startsWith('~')) {
       debugger;
     }

--- a/packages/host/app/components/matrix/room-message.gts
+++ b/packages/host/app/components/matrix/room-message.gts
@@ -90,18 +90,8 @@ class SendReadReceipt extends Modifier<SendReadReceiptModifierSignature> {
       getTs: () => message.created.getTime(),
     };
 
-    console.log(
-      `artificial matrix event: id ${
-        message.eventId
-      }, room ${roomId}, ts ${message.created.getTime()}`,
-    );
-
     // Without scheduling this after render, this produces the "attempted to update value, but it had already been used previously in the same computation" error
     schedule('afterRender', () => {
-      if (message.eventId.startsWith('~')) {
-        debugger;
-      }
-
       matrixService.client.sendReadReceipt(matrixEvent as MatrixEvent);
     });
   }

--- a/packages/host/app/resources/room.ts
+++ b/packages/host/app/resources/room.ts
@@ -196,6 +196,7 @@ export class RoomResource extends Resource<Args> {
         roomId,
         userId: event.sender,
       });
+      console.log('new message', event.content.body, event.event_id);
       let messageArgs = new Message({
         author,
         created: new Date(event.origin_server_ts),

--- a/packages/host/app/resources/room.ts
+++ b/packages/host/app/resources/room.ts
@@ -196,7 +196,6 @@ export class RoomResource extends Resource<Args> {
         roomId,
         userId: event.sender,
       });
-      console.log('new message', event.content.body, event.event_id);
       let messageArgs = new Message({
         author,
         created: new Date(event.origin_server_ts),


### PR DESCRIPTION
There are periodic errors like this in the console when using the chat sidebar:

<img width="826" alt="Personal — Boxel 2024-07-19 13-41-30" src="https://github.com/user-attachments/assets/f22d242d-4394-45d4-8b52-a3980d93f223">

Looking closely at the URL shows us what’s happening. Here’s a comparison between the components of a `POST https://matrix-staging.stack.cards/_matrix/client/v3/rooms/…` request that works and one that doesn’t:

<table>
<thead>
<tr>
<th rowspan=2>works</th>
<th colspan=2>request subpath</th>
</tr>
<tr>
<th>room id</th>
<th>event (message) id</th>
</thead>
<tbody>
<tr>
<td rowspan=2>
no
</td>
<td colspan=2>
<code>…!oOtrxkiWIrCdGkPkQQ%3Astack.cards/receipt/m.read/~!oOtrxkiWIrCdGkPkQQ%3Astack.cards%3Am1721414442124.3</code>
</td>
</tr>
<tr>
<td>!oOtrxkiWIrCdGkPkQQ:stack.cards</td>
<td>~!oOtrxkiWIrCdGkPkQQ:stack.cards:m1721414</td>
<tr>
<td rowspan=2>
yes
</td>
<td colspan=2>
<code>…!oOtrxkiWIrCdGkPkQQ%3Astack.cards/receipt/m.read/%24DUv4ECe9TaOtbNGavLPGeoytY0Od3O-dTl_NiuJms3U</code>
</td>
</tr>
<tr>
<td>!oOtrxkiWIrCdGkPkQQ:stack.cards</td>
<td>$DUv4ECe9TaOtbNGavLPGeoytY0Od3O-dTl_NiuJms3U</td>
</tr>
</tbody>
</table>

It’s seemingly undocumented but the Matrix SDK [uses `~` as a prefix for “local” events](https://github.com/matrix-org/matrix-js-sdk/blob/6f63ff1711664154359bb1b998a80f4274569468/spec/unit/event-timeline-set.spec.ts#L411), in this case a message that hasn’t yet been sent to the server. Specifically it’s [`~[room id]:[transaction id]`](https://github.com/matrix-org/matrix-js-sdk/blob/6f63ff1711664154359bb1b998a80f4274569468/spec/unit/matrix-client.spec.ts#L1469). When the server accepts the message the local id gets replaced with a global one.

The server is rejecting the creation of a read receipt for an event that it doesn’t yet know about. To avoid this, I changed the read receipt modifier to only try to create them for bot-generated events, which will never have local event ids.

You can see the test failing [here](https://github.com/cardstack/boxel/runs/27678437638) before I added the fix. I’ve since been unable to reproduce the Matrix error on [the preview deployment](https://hostread-receipt-flakiness-cs-7012.boxel-host-preview.stack.cards/).