### PR TITLE
Preserve original card type name in prerendered HTML

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -1820,10 +1820,11 @@ class DefaultEmbeddedTemplate extends GlimmerComponent<{
         </div>
         <div class='info-section'>
           <h3 class='card-title' data-test-card-title>{{@model.title}}</h3>
-          <h4
-            class='card-display-name'
-            data-test-card-display-name
-          >{{cardTypeDisplayName @model}}</h4>
+          <h4 class='card-display-name' data-test-card-display-name>
+            <!-- __org.boxel.cardType START -->
+            {{cardTypeDisplayName @model}}
+            <!-- __org.boxel.cardType END -->
+          </h4>
         </div>
         <div
           class='card-description'

--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -475,6 +475,7 @@ export class CurrentRun {
     if (adjustedResource && typesMaybeError?.type === 'types') {
       embeddedHtml = await this.buildEmbeddedHtml(
         adjustedResource,
+        searchData?._cardType ?? 'Card',
         typesMaybeError.types,
         identityContext,
       );
@@ -528,6 +529,7 @@ export class CurrentRun {
 
   private async buildEmbeddedHtml(
     resource: CardResource,
+    typeName: string,
     types: CardType[],
     identityContext: IdentityContextType,
   ): Promise<{ [refURL: string]: string }> {
@@ -559,6 +561,10 @@ export class CurrentRun {
           identityContext: modifiedContext,
           realmPath: this.#realmPaths,
         }),
+      );
+      embeddedHtml = embeddedHtml.replace(
+        /<!-- __org\.boxel\.cardType START -->\s*.*?\s*<!-- __org\.boxel\.cardType END -->/gm,
+        typeName,
       );
 
       result[refURL] = embeddedHtml;

--- a/packages/host/tests/integration/card-prerender-test.gts
+++ b/packages/host/tests/integration/card-prerender-test.gts
@@ -286,11 +286,11 @@ module('Integration | card-prerender', function (hooks) {
     // Since there is no "on" filter, the prerendered html must be from a CardDef template
 
     [
-      'test card: pet mango',
-      'test card: pet vangogh',
-      'test card: person jane',
-      'test card: person jimmy',
-    ].forEach((title, index) => {
+      ['test card: pet mango', 'Pet'],
+      ['test card: pet vangogh', 'Pet'],
+      ['test card: person jane', 'FancyPerson'],
+      ['test card: person jimmy', 'FancyPerson'],
+    ].forEach(([title, type], index) => {
       assert.strictEqual(
         trimCardContainer(
           stripScopedCSSAttributes(results.prerenderedCards[index].html),
@@ -304,7 +304,7 @@ module('Integration | card-prerender', function (hooks) {
           </div>
           <div class="info-section">
             <h3 class="card-title" data-test-card-title>${title}</h3>
-            <h4 class="card-display-name" data-test-card-display-name>Card</h4>
+            <h4 class="card-display-name" data-test-card-display-name> ${type} </h4>
           </div>
           <div class="card-description" data-test-card-description></div>
         </div>

--- a/packages/host/tests/integration/search-index-test.gts
+++ b/packages/host/tests/integration/search-index-test.gts
@@ -1061,6 +1061,7 @@ module(`Integration | search-index`, function (hooks) {
 
   test(`can generate embedded HTML for instance's card class hierarchy`, async function (assert) {
     class Person extends CardDef {
+      static displayName = 'Person';
       @field firstName = contains(StringField);
       static embedded = class Isolated extends Component<typeof this> {
         <template>
@@ -1070,6 +1071,7 @@ module(`Integration | search-index`, function (hooks) {
     }
 
     class FancyPerson extends Person {
+      static displayName = 'Fancy Person';
       @field favoriteColor = contains(StringField);
       static embedded = class Isolated extends Component<typeof this> {
         <template>
@@ -1163,7 +1165,9 @@ module(`Integration | search-index`, function (hooks) {
             </div>
             <div class="info-section">
               <h3 class="card-title" data-test-card-title></h3>
-              <h4 class="card-display-name" data-test-card-display-name>Card</h4>
+              <h4 class="card-display-name" data-test-card-display-name>
+                Fancy Person
+              </h4>
             </div>
             <div class="card-description" data-test-card-description>Fancy Germaine</div>
           </div>


### PR DESCRIPTION
The various embedded HTML renderings for an instance along the class hierarchy do not preserve the original card type name--rather they use the card type name associated to the card def class being used to render the card. This PR fixes the embedded HTML generated so that we preserve the original card type name in all the renderings for a card