### PR TITLE
Add Prerendered component

### DIFF
--- a/packages/boxel-ui/addon/src/components.ts
+++ b/packages/boxel-ui/addon/src/components.ts
@@ -23,6 +23,7 @@ import Menu from './components/menu/index.gts';
 import BoxelMessage from './components/message/index.gts';
 import Message from './components/message/index.gts';
 import Modal from './components/modal/index.gts';
+import Prerendered from './components/prerendered/index.gts';
 import RadioInput from './components/radio-input/index.gts';
 import ResizablePanelGroup, {
   ResizablePanel,
@@ -30,7 +31,6 @@ import ResizablePanelGroup, {
 } from './components/resizable-panel-group/index.gts';
 import BoxelSelect from './components/select/index.gts';
 import Tooltip from './components/tooltip/index.gts';
-import Prerendered from './components/prerendered/index.gts';
 
 export {
   Accordion,
@@ -58,10 +58,10 @@ export {
   Menu,
   Message,
   Modal,
+  Prerendered,
   RadioInput,
   ResizablePanel,
   ResizablePanelGroup,
   ResizeHandle,
   Tooltip,
-  Prerendered,
 };

--- a/packages/boxel-ui/addon/src/components.ts
+++ b/packages/boxel-ui/addon/src/components.ts
@@ -30,6 +30,7 @@ import ResizablePanelGroup, {
 } from './components/resizable-panel-group/index.gts';
 import BoxelSelect from './components/select/index.gts';
 import Tooltip from './components/tooltip/index.gts';
+import Prerendered from './components/prerendered/index.gts';
 
 export {
   Accordion,
@@ -62,4 +63,5 @@ export {
   ResizablePanelGroup,
   ResizeHandle,
   Tooltip,
+  Prerendered,
 };

--- a/packages/boxel-ui/addon/src/components/prerendered/index.gts
+++ b/packages/boxel-ui/addon/src/components/prerendered/index.gts
@@ -1,0 +1,44 @@
+import Component from '@glimmer/component';
+
+interface Signature {
+  Args: {
+    css?: string;
+    html?: string;
+  };
+  Blocks: {
+    default: [];
+  };
+}
+
+export default class Prerendered extends Component<Signature> {
+  constructor(owner: unknown, args: Signature['Args']) {
+    super(owner, args);
+
+    if (this.args.css) {
+      let styleElement = document.createElement('style');
+      document.head.appendChild(styleElement);
+      styleElement.textContent = this.args.css;
+      let randomId = Math.random().toString(36).substring(7);
+      styleElement.setAttribute('data-prerendered-card-css', randomId);
+    }
+  }
+
+  <template>
+    {{! Ideally, rendering passed in css would look like this: }}
+
+    {{!--  <style unscoped>
+              {{@css}}
+            </style>
+    --}}
+
+    {{! but using \`unscoped\` attribute produces the following build error in host:
+          (Build Error (PackagerRunner) in ../../../../boxel-ui/addon/dist/index-629a5edd.js
+          Module not found: Error: @cardstack/boxel-ui is trying to import from style-loader!css-loader!glimmer-scoped-css but that is not one of its explicit dependencies) }}
+
+    {{! We are using a workaround with the constructor until we fix the above - tracking this issue in CS-6989  }}
+
+    {{{@html}}}
+
+    {{yield}}
+  </template>
+}

--- a/packages/boxel-ui/addon/src/components/prerendered/index.gts
+++ b/packages/boxel-ui/addon/src/components/prerendered/index.gts
@@ -1,3 +1,4 @@
+import { registerDestructor } from '@ember/destroyable';
 import Component from '@glimmer/component';
 
 interface Signature {
@@ -14,13 +15,22 @@ export default class Prerendered extends Component<Signature> {
   constructor(owner: unknown, args: Signature['Args']) {
     super(owner, args);
 
+    let randomId = Math.random().toString(36).substring(7);
     if (this.args.css) {
       let styleElement = document.createElement('style');
       document.head.appendChild(styleElement);
       styleElement.textContent = this.args.css;
-      let randomId = Math.random().toString(36).substring(7);
       styleElement.setAttribute('data-prerendered-card-css', randomId);
     }
+
+    registerDestructor(this, () => {
+      let styleElement = document.querySelector(
+        `[data-prerendered-card-css="${randomId}"]`,
+      );
+      if (styleElement) {
+        styleElement.remove();
+      }
+    });
   }
 
   <template>

--- a/packages/boxel-ui/addon/src/components/prerendered/usage.gts
+++ b/packages/boxel-ui/addon/src/components/prerendered/usage.gts
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
+
 import Prerendered from './index.gts';
 
 export default class PrerenderedUsage extends Component {

--- a/packages/boxel-ui/addon/src/components/prerendered/usage.gts
+++ b/packages/boxel-ui/addon/src/components/prerendered/usage.gts
@@ -1,0 +1,33 @@
+import Component from '@glimmer/component';
+import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
+import Prerendered from './index.gts';
+
+export default class PrerenderedUsage extends Component {
+  css = '.red { color: red; }';
+  html = '<h1 class="red">This is static prerendered HTML</h1>';
+
+  <template>
+    <FreestyleUsage
+      @name='Prerendered Component'
+      @description='Component that renders static HTML and CSS. Used for rendering pre-rendered content.'
+    >
+      <:example>
+        <Prerendered @css={{this.css}} @html={{this.html}} />
+      </:example>
+      <:api as |Args|>
+        <Args.String
+          @name='html'
+          @description='Prerendered html'
+          @value={{this.html}}
+          @readOnly={{true}}
+        />
+        <Args.String
+          @name='css'
+          @description='CSS'
+          @value={{this.css}}
+          @readOnly={{true}}
+        />
+      </:api>
+    </FreestyleUsage>
+  </template>
+}

--- a/packages/boxel-ui/addon/src/usage.ts
+++ b/packages/boxel-ui/addon/src/usage.ts
@@ -18,6 +18,7 @@ import LoadingIndicatorUsage from './components/loading-indicator/usage.gts';
 import MenuUsage from './components/menu/usage.gts';
 import MessageUsage from './components/message/usage.gts';
 import ModalUsage from './components/modal/usage.gts';
+import Prerendered from './components/prerendered/usage.gts';
 import RadioInputUsage from './components/radio-input/usage.gts';
 import ResizablePanelGroupUsage from './components/resizable-panel-group/usage.gts';
 import SelectUsage from './components/select/usage.gts';
@@ -41,6 +42,7 @@ export const ALL_USAGE_COMPONENTS = [
   ['Menu', MenuUsage],
   ['Message', MessageUsage],
   ['Modal', ModalUsage],
+  ['Prerendered', Prerendered],
   ['RadioInput', RadioInputUsage],
   ['ResizablePanelGroup', ResizablePanelGroupUsage],
   ['Select', SelectUsage],


### PR DESCRIPTION
This is a component that we'll use to render static prerendered content, more specifically for the future purposes of showing prerendered cards in the cards grid. 

This is implemented in the boxel UI addon so that the cards (i.e. cards grid) can import it. If we added it to the host app, cards would not be able to import it. However there's a pending issue mentioned in the code comment where we use a workaround until it's fixed. 

Screenshot from the boxel UI component explorer:
<img width="1528" alt="image" src="https://github.com/user-attachments/assets/ce39bfb3-147a-4657-82cf-913f13b1ea43">
