### PR TITLE
Remove container div from HTML when capturing pre-rendered embedded HTML

### DIFF
--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -412,23 +412,27 @@ export class CurrentRun {
           identityContext,
         },
       );
-      isolatedHtml = sanitizeHTML(
-        await this.#renderCard({
-          card,
-          format: 'isolated',
-          visit: this.visitFile.bind(this),
-          identityContext,
-          realmPath: this.#realmPaths,
-        }),
+      isolatedHtml = unwrap(
+        sanitizeHTML(
+          await this.#renderCard({
+            card,
+            format: 'isolated',
+            visit: this.visitFile.bind(this),
+            identityContext,
+            realmPath: this.#realmPaths,
+          }),
+        ),
       );
-      atomHtml = sanitizeHTML(
-        await this.#renderCard({
-          card,
-          format: 'atom',
-          visit: this.visitFile.bind(this),
-          identityContext,
-          realmPath: this.#realmPaths,
-        }),
+      atomHtml = unwrap(
+        sanitizeHTML(
+          await this.#renderCard({
+            card,
+            format: 'atom',
+            visit: this.visitFile.bind(this),
+            identityContext,
+            realmPath: this.#realmPaths,
+          }),
+        ),
       );
       cardType = Reflect.getPrototypeOf(card)?.constructor as typeof CardDef;
       let data = api.serializeCard(card, { includeComputeds: true });
@@ -553,23 +557,18 @@ export class CurrentRun {
           identityContext: modifiedContext,
         },
       );
-      let embeddedHtml = sanitizeHTML(
-        await this.#renderCard({
-          card,
-          format: 'embedded',
-          visit: this.visitFile.bind(this),
-          identityContext: modifiedContext,
-          realmPath: this.#realmPaths,
-        }),
+      let embeddedHtml = unwrap(
+        sanitizeHTML(
+          await this.#renderCard({
+            card,
+            format: 'embedded',
+            visit: this.visitFile.bind(this),
+            identityContext: modifiedContext,
+            realmPath: this.#realmPaths,
+          }),
+        ),
       );
       embeddedHtml = embeddedHtml
-        .trim()
-        // we unwrap the outer div (and cleanup empty html comments) as the
-        // outer div is actually the container that the embedded HTML is
-        // rendering into
-        .replace(/^<div ([^<]*\n)/, '')
-        .replace(/^<!---->/, '')
-        .replace(/<\/div>$/, '')
         .replace(
           /<!-- __org\.boxel\.cardType START -->\s*.*?\s*<!-- __org\.boxel\.cardType END -->/gm,
           typeName,
@@ -656,4 +655,16 @@ function assertURLEndsWithJSON(url: URL): URL {
     return new URL(`${url}.json`);
   }
   return url;
+}
+
+// we unwrap the outer div (and cleanup empty html comments) as the
+// outer div is actually the container that the card HTML is
+// rendering into
+function unwrap(html: string): string {
+  return html
+    .trim()
+    .replace(/^<div ([^<]*\n)/, '')
+    .replace(/^<!---->/, '')
+    .replace(/<\/div>$/, '')
+    .trim();
 }

--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -562,10 +562,19 @@ export class CurrentRun {
           realmPath: this.#realmPaths,
         }),
       );
-      embeddedHtml = embeddedHtml.replace(
-        /<!-- __org\.boxel\.cardType START -->\s*.*?\s*<!-- __org\.boxel\.cardType END -->/gm,
-        typeName,
-      );
+      embeddedHtml = embeddedHtml
+        .trim()
+        // we unwrap the outer div (and cleanup empty html comments) as the
+        // outer div is actually the container that the embedded HTML is
+        // rendering into
+        .replace(/^<div ([^<]*\n)/, '')
+        .replace(/^<!---->/, '')
+        .replace(/<\/div>$/, '')
+        .replace(
+          /<!-- __org\.boxel\.cardType START -->\s*.*?\s*<!-- __org\.boxel\.cardType END -->/gm,
+          typeName,
+        )
+        .trim();
 
       result[refURL] = embeddedHtml;
     }

--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -568,12 +568,10 @@ export class CurrentRun {
           }),
         ),
       );
-      embeddedHtml = embeddedHtml
-        .replace(
-          /<!-- __org\.boxel\.cardType START -->\s*.*?\s*<!-- __org\.boxel\.cardType END -->/gm,
-          typeName,
-        )
-        .trim();
+      embeddedHtml = embeddedHtml.replace(
+        /<!-- __org\.boxel\.cardType START -->\s*.*?\s*<!-- __org\.boxel\.cardType END -->/gm,
+        typeName,
+      );
 
       result[refURL] = embeddedHtml;
     }

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -82,13 +82,6 @@ export function cleanWhiteSpace(text: string) {
   return text.replace(/[\s ]+/g, ' ').trim();
 }
 
-export function trimCardContainer(text: string) {
-  return cleanWhiteSpace(text).replace(
-    /<div .*? data-test-field-component-card>\s?[<!---->]*? (.*?) <\/div>$/g,
-    '$1',
-  );
-}
-
 export function getMonacoContent(): string {
   return (window as any).monaco.editor.getModels()[0].getValue();
 }

--- a/packages/host/tests/integration/card-prerender-test.gts
+++ b/packages/host/tests/integration/card-prerender-test.gts
@@ -12,7 +12,6 @@ import {
   testRealmURL,
   setupCardLogs,
   cleanWhiteSpace,
-  trimCardContainer,
   setupLocalIndexing,
   setupIntegrationTestRealm,
   lookupLoaderService,
@@ -177,7 +176,7 @@ module('Integration | card-prerender', function (hooks) {
       );
       if (entry?.type === 'instance') {
         assert.strictEqual(
-          trimCardContainer(stripScopedCSSAttributes(entry!.isolatedHtml!)),
+          cleanWhiteSpace(stripScopedCSSAttributes(entry!.isolatedHtml!)),
           cleanWhiteSpace(`<h3> Mango </h3>`),
           'the pre-rendered HTML is correct',
         );
@@ -191,7 +190,7 @@ module('Integration | card-prerender', function (hooks) {
       );
       if (entry?.type === 'instance') {
         assert.strictEqual(
-          trimCardContainer(stripScopedCSSAttributes(entry!.isolatedHtml!)),
+          cleanWhiteSpace(stripScopedCSSAttributes(entry!.isolatedHtml!)),
           cleanWhiteSpace(`<h3> Van Gogh </h3>`),
           'the pre-rendered HTML is correct',
         );

--- a/packages/host/tests/integration/card-prerender-test.gts
+++ b/packages/host/tests/integration/card-prerender-test.gts
@@ -291,7 +291,7 @@ module('Integration | card-prerender', function (hooks) {
       ['test card: person jimmy', 'FancyPerson'],
     ].forEach(([title, type], index) => {
       assert.strictEqual(
-        trimCardContainer(
+        cleanWhiteSpace(
           stripScopedCSSAttributes(results.prerenderedCards[index].html),
         ),
         cleanWhiteSpace(`

--- a/packages/host/tests/integration/search-index-test.gts
+++ b/packages/host/tests/integration/search-index-test.gts
@@ -1152,25 +1152,19 @@ module(`Integration | search-index`, function (hooks) {
     assert.strictEqual(
       cleanWhiteSpace(stripScopedCSSAttributes(embeddedHtml![cardDefRefURL])),
       cleanWhiteSpace(`
-        <div class="ember-view boxel-card-container boundaries field-component-card embedded-format display-container-true"
-              data-test-boxel-card-container 
-              data-test-card-format="embedded"
-              data-test-field-component-card>
-          <!---->
-          <div class="embedded-template">
-            <div class="thumbnail-section">
-              <div class="card-thumbnail">
-                <div class="card-thumbnail-text" data-test-card-thumbnail-text>Card</div>
-              </div>
+        <div class="embedded-template">
+          <div class="thumbnail-section">
+            <div class="card-thumbnail">
+              <div class="card-thumbnail-text" data-test-card-thumbnail-text>Card</div>
             </div>
-            <div class="info-section">
-              <h3 class="card-title" data-test-card-title></h3>
-              <h4 class="card-display-name" data-test-card-display-name>
-                Fancy Person
-              </h4>
-            </div>
-            <div class="card-description" data-test-card-description>Fancy Germaine</div>
           </div>
+          <div class="info-section">
+            <h3 class="card-title" data-test-card-title></h3>
+            <h4 class="card-display-name" data-test-card-display-name>
+              Fancy Person
+            </h4>
+          </div>
+          <div class="card-description" data-test-card-description>Fancy Germaine</div>
         </div>
       `),
       `${cardDefRefURL} embedded HTML is correct`,

--- a/packages/host/tests/integration/search-index-test.gts
+++ b/packages/host/tests/integration/search-index-test.gts
@@ -22,7 +22,6 @@ import {
   testRealmURL,
   testRealmInfo,
   cleanWhiteSpace,
-  trimCardContainer,
   setupCardLogs,
   setupLocalIndexing,
   type CardDocFiles,
@@ -650,11 +649,11 @@ module(`Integration | search-index`, function (hooks) {
           let { isolatedHtml, embeddedHtml } =
             (await getInstance(realm, new URL(`${testRealmURL}vangogh`))) ?? {};
           assert.strictEqual(
-            trimCardContainer(stripScopedCSSAttributes(isolatedHtml!)),
+            cleanWhiteSpace(stripScopedCSSAttributes(isolatedHtml!)),
             cleanWhiteSpace(`<h1> Van Gogh </h1>`),
           );
           assert.strictEqual(
-            trimCardContainer(
+            cleanWhiteSpace(
               stripScopedCSSAttributes(
                 embeddedHtml![`${testRealmURL}person/Person`],
               ),
@@ -679,11 +678,11 @@ module(`Integration | search-index`, function (hooks) {
           let { isolatedHtml, embeddedHtml } =
             (await getInstance(realm, new URL(`${testRealmURL}vangogh`))) ?? {};
           assert.strictEqual(
-            trimCardContainer(stripScopedCSSAttributes(isolatedHtml!)),
+            cleanWhiteSpace(stripScopedCSSAttributes(isolatedHtml!)),
             cleanWhiteSpace(`<h1> Van Gogh </h1>`),
           );
           assert.strictEqual(
-            trimCardContainer(
+            cleanWhiteSpace(
               stripScopedCSSAttributes(
                 embeddedHtml![`${testRealmURL}person/Person`],
               ),
@@ -800,11 +799,11 @@ module(`Integration | search-index`, function (hooks) {
           new URL(`${testRealmURL}working-van-gogh`),
         )) ?? {};
       assert.strictEqual(
-        trimCardContainer(stripScopedCSSAttributes(isolatedHtml!)),
+        cleanWhiteSpace(stripScopedCSSAttributes(isolatedHtml!)),
         cleanWhiteSpace(`<h1> Van Gogh </h1>`),
       );
       assert.strictEqual(
-        trimCardContainer(
+        cleanWhiteSpace(
           stripScopedCSSAttributes(
             embeddedHtml![`${testRealmURL}person/Person`],
           ),
@@ -923,7 +922,7 @@ module(`Integration | search-index`, function (hooks) {
         (await getInstance(realm, new URL(`${testRealmURL}working-vangogh`))) ??
         {};
       assert.strictEqual(
-        trimCardContainer(stripScopedCSSAttributes(isolatedHtml!)),
+        cleanWhiteSpace(stripScopedCSSAttributes(isolatedHtml!)),
         cleanWhiteSpace(`<h1> Van Gogh </h1>`),
       );
       assert.strictEqual(
@@ -932,7 +931,7 @@ module(`Integration | search-index`, function (hooks) {
         `isolated HTML does not include ember ID's`,
       );
       assert.strictEqual(
-        trimCardContainer(
+        cleanWhiteSpace(
           stripScopedCSSAttributes(
             embeddedHtml![`${testRealmURL}person/Person`],
           ),
@@ -989,7 +988,7 @@ module(`Integration | search-index`, function (hooks) {
       (await getInstance(realm, new URL(`${testRealmURL}vangogh`))) ?? {};
 
     assert.strictEqual(
-      trimCardContainer(stripScopedCSSAttributes(atomHtml!)),
+      cleanWhiteSpace(stripScopedCSSAttributes(atomHtml!)),
       cleanWhiteSpace(`<div class="atom">Van Gogh</div>`),
       'atom html is correct',
     );
@@ -1115,7 +1114,7 @@ module(`Integration | search-index`, function (hooks) {
       `HTML does not include ember ID's`,
     );
     assert.strictEqual(
-      trimCardContainer(
+      cleanWhiteSpace(
         stripScopedCSSAttributes(
           embeddedHtml![`${testRealmURL}fancy-person/FancyPerson`],
         ),
@@ -1138,7 +1137,7 @@ module(`Integration | search-index`, function (hooks) {
     );
 
     assert.strictEqual(
-      trimCardContainer(
+      cleanWhiteSpace(
         stripScopedCSSAttributes(embeddedHtml![`${testRealmURL}person/Person`]),
       ),
       cleanWhiteSpace(`<h1> Person Embedded Card: Germaine </h1>`),


### PR DESCRIPTION
The PR removes the outer div from the prerendered HTML that we capture for the embedded format. The outer div is actually the container that the embedded view is rendering into. We don't want anything outside the card boundary in our captured HTML