### PR TITLE
Handle uri encoded filenames during indexing

### DIFF
--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -247,9 +247,8 @@ export class CurrentRun {
 
     let fileRef = await this.#reader.readFileAsText(localPath);
     if (!fileRef) {
-      let error = new CardError(`missing file ${url.href}`, { status: 404 });
-      error.deps = [url.href];
-      throw error;
+      log.error(`could not read file '${url.href}', skipping...`);
+      return;
     }
     let { content, lastModified } = fileRef;
     if (hasExecutableExtension(url.href)) {

--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -245,7 +245,10 @@ export class CurrentRun {
     log.debug(`begin visiting file ${url.href}`);
     let localPath = this.#realmPaths.local(url);
 
-    let fileRef = await this.#reader.readFileAsText(encodeURI(localPath));
+    let fileRef = await this.#reader.readFileAsText(localPath);
+    if (!fileRef) {
+      fileRef = await this.#reader.readFileAsText(encodeURI(localPath));
+    }
     if (!fileRef) {
       let error = new CardError(`missing file ${url.href}`, { status: 404 });
       error.deps = [url.href];

--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -245,10 +245,11 @@ export class CurrentRun {
     log.debug(`begin visiting file ${url.href}`);
     let localPath = this.#realmPaths.local(url);
 
-    let fileRef = await this.#reader.readFileAsText(localPath);
+    let fileRef = await this.#reader.readFileAsText(encodeURI(localPath));
     if (!fileRef) {
-      log.error(`could not read file '${url.href}', skipping...`);
-      return;
+      let error = new CardError(`missing file ${url.href}`, { status: 404 });
+      error.deps = [url.href];
+      throw error;
     }
     let { content, lastModified } = fileRef;
     if (hasExecutableExtension(url.href)) {

--- a/packages/realm-server/tests/cards/%F0%9F%98%80.gts
+++ b/packages/realm-server/tests/cards/%F0%9F%98%80.gts
@@ -1,0 +1,7 @@
+// This is a file that contains url encoded file name to assert
+// that the realm server can safely skip over this type of file
+
+import { CardDef } from 'https://cardstack.com/base/card-api';
+export class Test extends CardDef {
+  static displayName = 'test';
+}

--- a/packages/realm-server/tests/cards/%F0%9F%98%80.gts
+++ b/packages/realm-server/tests/cards/%F0%9F%98%80.gts
@@ -1,5 +1,5 @@
 // This is a file that contains url encoded file name to assert
-// that the realm server can safely skip over this type of file
+// that the realm server can handle this type of file
 
 import { CardDef } from 'https://cardstack.com/base/card-api';
 export class Test extends CardDef {

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -2414,6 +2414,14 @@ module('Realm Server serving from root', function (hooks) {
           id: testRealmHref,
           type: 'directory',
           relationships: {
+            '%F0%9F%98%80.gts': {
+              links: {
+                related: 'http://127.0.0.1:4444/%F0%9F%98%80.gts',
+              },
+              meta: {
+                kind: 'file',
+              },
+            },
             'a.js': {
               links: {
                 related: `${testRealmHref}a.js`,


### PR DESCRIPTION
This PR prevents the realm server from crashing when it encounteres a URI encoded file. The exception that we throw when a file cannot be found is critical for the proper functioning of indexing, skipping over a missing file without notifying the system via a 404 error prevents the indexer from crawling links properly. In order to address this scenario we provide a URI encoded fallback such that if the file cannot be loaded due to the fact that we have a character in the filename that has a code point outside of the 256 ASCII range (like an emoji in this particular case), then we will try uri encoding the filename to see if that results in a hit on the filesystem.