### PR TITLE
host: Update to ember-window-mock v1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
       "ember-css-url@1.0.0": "patches/ember-css-url@1.0.0.patch",
       "matrix-js-sdk@31.0.0": "patches/matrix-js-sdk@31.0.0.patch",
       "ember-basic-dropdown@8.0.4": "patches/ember-basic-dropdown@8.0.4.patch",
-      "ember-source@5.4.1": "patches/ember-source@5.4.1.patch"
+      "ember-source@5.4.1": "patches/ember-source@5.4.1.patch",
+      "ember-window-mock@1.0.0": "patches/ember-window-mock@1.0.0.patch"
     }
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
       "ember-css-url@1.0.0": "patches/ember-css-url@1.0.0.patch",
       "matrix-js-sdk@31.0.0": "patches/matrix-js-sdk@31.0.0.patch",
       "ember-basic-dropdown@8.0.4": "patches/ember-basic-dropdown@8.0.4.patch",
-      "ember-source@5.4.1": "patches/ember-source@5.4.1.patch",
-      "ember-window-mock@1.0.0": "patches/ember-window-mock@1.0.0.patch"
+      "ember-source@5.4.1": "patches/ember-source@5.4.1.patch"
     }
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
       "allowedVersions": {
         "mustache": "3",
         "prettier@github:cardstack/prettier#glimmer-style-tag-in-template-support": "3.1.0-dev",
-        "ember-qunit@5.1.2>ember-source": "*",
-        "ember-window-mock@0.9.0>ember-source": "*"
+        "ember-qunit@5.1.2>ember-source": "*"
       }
     },
     "patchedDependencies": {

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -127,7 +127,7 @@
     "ember-template-lint": "^5.11.2",
     "ember-test-selectors": "^6.0.0",
     "ember-velcro": "^2.1.3",
-    "ember-window-mock": "^1.0.0",
+    "ember-window-mock": "^1.0.1",
     "eslint": "^8.52.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-ember": "^12.1.1",

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -127,7 +127,7 @@
     "ember-template-lint": "^5.11.2",
     "ember-test-selectors": "^6.0.0",
     "ember-velcro": "^2.1.3",
-    "ember-window-mock": "^0.9.0",
+    "ember-window-mock": "^1.0.0",
     "eslint": "^8.52.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-ember": "^12.1.1",

--- a/patches/ember-window-mock@1.0.0.patch
+++ b/patches/ember-window-mock@1.0.0.patch
@@ -1,0 +1,21 @@
+diff --git a/package.json b/package.json
+index 903370d1a4d5e9b453181894853ca2ffabb270fe..89b04e671fad004c4eeaf52274f3fd5c2518fe96 100644
+--- a/package.json
++++ b/package.json
+@@ -10,12 +10,12 @@
+   "author": "Simon Ihmig <simon.ihmig@gmail.com>",
+   "exports": {
+     ".": {
+-      "default": "./src/index.js",
+-      "types": "./index.d.ts"
++      "types": "./index.d.ts",
++      "default": "./src/index.js"
+     },
+     "./test-support": {
+-      "default": "./src/test-support/index.js",
+-      "types": "./index.d.ts"
++      "types": "./index.d.ts",
++      "default": "./src/test-support/index.js"
+     },
+     "./addon-main.js": "./addon-main.cjs"
+   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,9 @@ patchedDependencies:
   ember-source@5.4.1:
     hash: oko46qetwhgpor6xgs7vahyney
     path: patches/ember-source@5.4.1.patch
+  ember-window-mock@1.0.0:
+    hash: vxcb2xxweyc64j67v24dzpz2jq
+    path: patches/ember-window-mock@1.0.0.patch
   fastboot@4.1.0:
     hash: kizxbxhfcldguz4jcwonfduu2y
     path: patches/fastboot@4.1.0.patch
@@ -1315,7 +1318,7 @@ importers:
         version: 2.1.3(ember-modifier@4.1.0)(ember-source@5.4.1)
       ember-window-mock:
         specifier: ^1.0.0
-        version: 1.0.0(@glint/template@1.3.0)
+        version: 1.0.0(patch_hash=vxcb2xxweyc64j67v24dzpz2jq)(@glint/template@1.3.0)
       eslint:
         specifier: ^8.52.0
         version: 8.57.0
@@ -13198,7 +13201,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /ember-window-mock@1.0.0(@glint/template@1.3.0):
+  /ember-window-mock@1.0.0(patch_hash=vxcb2xxweyc64j67v24dzpz2jq)(@glint/template@1.3.0):
     resolution: {integrity: sha512-zaTxOj72fGUXcOC6ib/+JC9SfXQepRPATN1qlyxPEaMN8qnCb3A0MmnBVuXazR6TS2HSxe7pCwoee5dByEVx3A==}
     dependencies:
       '@embroider/addon-shim': 1.8.9
@@ -13207,6 +13210,7 @@ packages:
       - '@glint/template'
       - supports-color
     dev: true
+    patched: true
 
   /emit-function@0.0.2:
     resolution: {integrity: sha512-WRHUvrW3lcV45D+IQ9F3Wro5jFjnJcX82IQHo0r47gkajeMEKpJPUeQ4BgbyUb1T1dT17XFkgPwwrg4owU0fRw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1314,8 +1314,8 @@ importers:
         specifier: ^2.1.3
         version: 2.1.3(ember-modifier@4.1.0)(ember-source@5.4.1)
       ember-window-mock:
-        specifier: ^0.9.0
-        version: 0.9.0(ember-source@5.4.1)
+        specifier: ^1.0.0
+        version: 1.0.0(@glint/template@1.3.0)
       eslint:
         specifier: ^8.52.0
         version: 8.57.0
@@ -13198,16 +13198,13 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /ember-window-mock@0.9.0(ember-source@5.4.1):
-    resolution: {integrity: sha512-jFWq8zNFhiKNA0QnJFnhsYW+Y+2FwpvFuAf4s393Il5f1fJJfZoiwjL5l8FMpxV1alf2o8jZ2XqNQWh8rM9YBA==}
-    engines: {node: 16.* || >= 18}
-    peerDependencies:
-      ember-source: '*'
+  /ember-window-mock@1.0.0(@glint/template@1.3.0):
+    resolution: {integrity: sha512-zaTxOj72fGUXcOC6ib/+JC9SfXQepRPATN1qlyxPEaMN8qnCb3A0MmnBVuXazR6TS2HSxe7pCwoee5dByEVx3A==}
     dependencies:
-      ember-cli-babel: 7.26.11
-      ember-cli-htmlbars: 6.3.0
-      ember-source: 5.4.1(patch_hash=oko46qetwhgpor6xgs7vahyney)(@babel/core@7.24.3)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.89.0)
+      '@embroider/addon-shim': 1.8.9
+      '@embroider/macros': 1.16.5(@glint/template@1.3.0)
     transitivePeerDependencies:
+      - '@glint/template'
       - supports-color
     dev: true
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,9 +25,6 @@ patchedDependencies:
   ember-source@5.4.1:
     hash: oko46qetwhgpor6xgs7vahyney
     path: patches/ember-source@5.4.1.patch
-  ember-window-mock@1.0.0:
-    hash: vxcb2xxweyc64j67v24dzpz2jq
-    path: patches/ember-window-mock@1.0.0.patch
   fastboot@4.1.0:
     hash: kizxbxhfcldguz4jcwonfduu2y
     path: patches/fastboot@4.1.0.patch
@@ -1317,8 +1314,8 @@ importers:
         specifier: ^2.1.3
         version: 2.1.3(ember-modifier@4.1.0)(ember-source@5.4.1)
       ember-window-mock:
-        specifier: ^1.0.0
-        version: 1.0.0(patch_hash=vxcb2xxweyc64j67v24dzpz2jq)(@glint/template@1.3.0)
+        specifier: ^1.0.1
+        version: 1.0.1(@glint/template@1.3.0)
       eslint:
         specifier: ^8.52.0
         version: 8.57.0
@@ -13201,8 +13198,8 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /ember-window-mock@1.0.0(patch_hash=vxcb2xxweyc64j67v24dzpz2jq)(@glint/template@1.3.0):
-    resolution: {integrity: sha512-zaTxOj72fGUXcOC6ib/+JC9SfXQepRPATN1qlyxPEaMN8qnCb3A0MmnBVuXazR6TS2HSxe7pCwoee5dByEVx3A==}
+  /ember-window-mock@1.0.1(@glint/template@1.3.0):
+    resolution: {integrity: sha512-K7o0o+t1DEWLsaw+TtS/D2t31pPUTYdabG6AKKKxJxZdgKNLwyMtlK7+X2UV0kRnr0CgiOeOMenvck0+8XbDmA==}
     dependencies:
       '@embroider/addon-shim': 1.8.9
       '@embroider/macros': 1.16.5(@glint/template@1.3.0)
@@ -13210,7 +13207,6 @@ packages:
       - '@glint/template'
       - supports-color
     dev: true
-    patched: true
 
   /emit-function@0.0.2:
     resolution: {integrity: sha512-WRHUvrW3lcV45D+IQ9F3Wro5jFjnJcX82IQHo0r47gkajeMEKpJPUeQ4BgbyUb1T1dT17XFkgPwwrg4owU0fRw==}


### PR DESCRIPTION
This permits the removal of a [pnpm peer dependency override](https://github.com/cardstack/boxel/pull/1431/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R37) from #1431.