### PR TITLE
Add explicit css relationships to the prerendered card payload

### DIFF
--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -1855,14 +1855,15 @@ module('Realm Server', function (hooks) {
           'embedded html looks correct (CardDef template)',
         );
 
-        // TODO: why is card-api module + css not present in the boxel index table?
-        assert.deepEqual(
-          json.data[0].relationships['prerendered-card-css'].data[0],
-          {
-            type: 'prerendered-card-css',
-            id: 'https://cardstack.com/base/card-api',
-          },
-        );
+        // TODO: uncomment when we have a way to include cross realm css in the response
+        // This will be the same time when the test that follows this one should be unskipped
+        // assert.deepEqual(
+        //   json.data[0].relationships['prerendered-card-css'].data[0],
+        //   {
+        //     type: 'prerendered-card-css',
+        //     id: 'https://cardstack.com/base/card-api',
+        //   },
+        // );
 
         // 2nd card: Person Craig
         assert.strictEqual(json.data[1].type, 'prerendered-card');
@@ -1892,6 +1893,103 @@ module('Realm Server', function (hooks) {
         );
 
         assert.strictEqual(json.meta.page.total, 4, 'total count is correct');
+      });
+
+      // Skipped until we have a way to include cross realm css in the response
+      test.skip('returns correct css in relationships, even the one indexed in another realm (CardDef)', async function (assert) {
+        let query: Query & { prerenderedHtmlFormat: string } = {
+          filter: {
+            on: {
+              module: `${testRealmHref}fancy-person`,
+              name: 'FancyPerson',
+            },
+            not: {
+              eq: {
+                firstName: 'Peter',
+              },
+            },
+          },
+          prerenderedHtmlFormat: 'embedded',
+        };
+
+        let response = await request
+          .get(`/_search-prerendered?${stringify(query)}`)
+          .set('Accept', 'application/vnd.card+json');
+
+        let json = response.body;
+
+        assert.strictEqual(
+          json.data.length,
+          2,
+          'returned results count is correct',
+        );
+
+        // 1st card: FancyPerson Jane
+        assert.true(
+          json.data[0].attributes.html
+            .replace(/\s+/g, ' ')
+            .includes('Embedded Card FancyPerson: Jane'),
+          'embedded html for Jane looks correct (FancyPerson template)',
+        );
+        assert.deepEqual(
+          json.data[0].relationships['prerendered-card-css'].data,
+          [
+            {
+              type: 'prerendered-card-css',
+              id: `${testRealmHref}fancy-person`,
+            },
+            {
+              type: 'prerendered-card-css',
+              id: `${testRealmHref}person`,
+            },
+            {
+              type: 'prerendered-card-css',
+              id: 'https://cardstack.com/base/card-api',
+            },
+          ],
+        );
+
+        //  2nd card: FancyPerson Jimmy
+
+        assert.true(
+          json.data[1].attributes.html
+            .replace(/\s+/g, ' ')
+            .includes('Embedded Card FancyPerson: Jimmy'),
+          'embedded html for Jimmy looks correct (FancyPerson template)',
+        );
+
+        assert.deepEqual(
+          json.data[1].relationships['prerendered-card-css'].data,
+          [
+            {
+              type: 'prerendered-card-css',
+              id: `${testRealmHref}fancy-person`,
+            },
+            {
+              type: `prerendered-card-css`,
+              id: `${testRealmHref}person`,
+            },
+            {
+              type: `prerendered-card-css`,
+              id: `https://cardstack.com/base/card-api`,
+            },
+          ],
+        );
+
+        // Included css modules
+        assert.strictEqual(
+          json.included.length,
+          3,
+          '3 css modules are included',
+        );
+        assert.deepEqual(
+          json.included.map((i: any) => i.id),
+          [
+            `${testRealmHref}fancy-person`,
+            `${testRealmHref}person`,
+            'https://cardstack.com/base/card-api',
+          ],
+        );
       });
 
       test('can filter prerendered instances', async function (assert) {

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -1855,6 +1855,15 @@ module('Realm Server', function (hooks) {
           'embedded html looks correct (CardDef template)',
         );
 
+        // TODO: why is card-api module + css not present in the boxel index table?
+        assert.deepEqual(
+          json.data[0].relationships['prerendered-card-css'].data[0],
+          {
+            type: 'prerendered-card-css',
+            id: 'https://cardstack.com/base/card-api',
+          },
+        );
+
         // 2nd card: Person Craig
         assert.strictEqual(json.data[1].type, 'prerendered-card');
         assert.true(

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -1896,6 +1896,7 @@ module('Realm Server', function (hooks) {
       });
 
       // Skipped until we have a way to include cross realm css in the response
+      // @ts-ignore
       test.skip('returns correct css in relationships, even the one indexed in another realm (CardDef)', async function (assert) {
         let query: Query & { prerenderedHtmlFormat: string } = {
           filter: {

--- a/packages/runtime-common/card-document.ts
+++ b/packages/runtime-common/card-document.ts
@@ -278,6 +278,16 @@ export function transformResultsToPrerenderedCardsDoc(results: {
     attributes: {
       html: card.html,
     },
+    relationships: {
+      'prerendered-card-css': {
+        data: card.cssModuleIds.map((cssModuleId) => {
+          return {
+            type: 'prerendered-card-css',
+            id: cssModuleId,
+          };
+        }),
+      },
+    },
   }));
 
   let included = prerenderedCardCssItems.map((css) => ({

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -509,9 +509,9 @@ export class IndexQueryEngine {
       return {
         url: card.url!,
         html: card.html,
-        cssModuleIds: groupedCssInstanceData.map(
-          (cssRecord) => cssRecord.css_module_id,
-        ),
+        cssModuleIds: groupedCssInstanceData
+          .map((cssRecord) => cssRecord.css_module_id)
+          .sort((a, b) => a.localeCompare(b)), // Sort by css module id for determinism (especially in tests). We do it in JS because SQLite and Postgres have different sorting behavior for urls
       };
     });
 
@@ -522,7 +522,7 @@ export class IndexQueryEngine {
           source: cssRecord.css_source,
         };
       })
-      .sort((a, b) => a.cssModuleId.localeCompare(b.cssModuleId)); // Sort by css module id for determinism (especially in tests). We do it in JS because SQLite and Postgres have different sorting behavior for urls
+      .sort((a, b) => a.cssModuleId.localeCompare(b.cssModuleId)); // Same comment for sorting as above
 
     return { prerenderedCards, prerenderedCardCssItems, meta };
   }

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -112,6 +112,7 @@ export interface PrerenderedCardCssItem {
 export interface PrerenderedCard {
   url: string;
   html: string;
+  cssModuleIds: string[];
 }
 
 export interface QueryResultsMeta {
@@ -508,6 +509,9 @@ export class IndexQueryEngine {
       return {
         url: card.url!,
         html: card.html,
+        cssModuleIds: groupedCssInstanceData.map(
+          (cssRecord) => cssRecord.css_module_id,
+        ),
       };
     });
 

--- a/packages/runtime-common/tests/index-query-engine-test.ts
+++ b/packages/runtime-common/tests/index-query-engine-test.ts
@@ -2699,6 +2699,11 @@ const tests = Object.freeze({
       prerenderedCards[0].html,
       '<div>Donald (FancyPerson embedded template)</div>',
     );
+    assert.deepEqual(prerenderedCards[0].cssModuleIds, [
+      `${testRealmURL}fancy-person`,
+      `${testRealmURL}person`,
+      'https://cardstack.com/base/card-api',
+    ]);
 
     assert.strictEqual(
       prerenderedCardCssItems.length,


### PR DESCRIPTION
Adds a `relationships` to the prerendered card payload so that it conforms to JSON:API rules and makes the relationships explicit. 

```
{
  "data": [
    {
      "type": "prerendered-card",
      "id": "http://127.0.0.1:4444/jimmy",
      "attributes": {
        "html": "embedded template"
      },
      "relationships": {
        "prerendered-card-css": {
          "data": [
            {
              "type": "prerendered-card-css",
              "id": "http://127.0.0.1:4444/fancy-person"
            },
            {
              "type": "prerendered-card-css",
              "id": "http://127.0.0.1:4444/person"
            },
            {
              "type": "prerendered-card-css",
              "id": "https://cardstack.com/base/card-api"
            }
          ]
        }
      }
    }
  ],
  "included": [
    {
      "type": "prerendered-card-css",
      "id": "http://127.0.0.1:4444/fancy-person",
      "attributes": {
        "content": ".fancy-border[data-scopedcss-b9c3801d7f-4c0a5cc85e] {\n border: 1px solid pink;\n }"
      }
    },
    {
      "type": "prerendered-card-css",
      "id": "http://127.0.0.1:4444/person",
      "attributes": {
        "content": ".border[data-scopedcss-2a598dec83-c0485838e3] {\n border: 1px solid red;\n }"
      }
    },
    {
      "type": "prerendered-card-css",
      "id": "https://cardstack.com/base/card-api",
      "attributes": {
        "content": ".default-card-template { ... }"
      }
    }
  ],
  "meta": {
    "page": {
      "total": 1,
      "realmVersion": 1
    }
  }
}
```

This includes a refactor of realm tests–previously, base and test realm server were running on different servers, which is problematic if we want to request prerendered cards from the test realm which should include css from modules indexed in the base realm. Since realms currently can't index content from other realms that live in other servers, it wasn't possible to see css content indexed, for example from `CardDef` which lives in the base realm. Now, both base and test realm are run on the same server which solves the issue. More details about this: https://github.com/cardstack/boxel/pull/1455#discussion_r1689919327