### PR TITLE
Fix bug where auto-attachment resource errors when new topmost card is saving

### DIFF
--- a/packages/host/app/resources/auto-attached-card.ts
+++ b/packages/host/app/resources/auto-attached-card.ts
@@ -1,5 +1,6 @@
 import { action } from '@ember/object';
 
+import { restartableTask } from 'ember-concurrency';
 import { Resource } from 'ember-resources';
 
 import { TrackedSet } from 'tracked-built-ins';
@@ -26,27 +27,37 @@ export class AutoAttachment extends Resource<Args> {
 
   modify(_positional: never[], named: Args['named']) {
     const { topMostStackItems, attachedCards } = named;
-    if (this.stackItemsChanged(topMostStackItems)) {
-      // we must be sure to clear the lastRemovedCards state so cards can be auto-attached again
-      // note: if two of the same cards are opened on separate stack, one will be auto-attached.
-      // If one is removed from one of the stacks, the card WILL be auto-attached.
-      this.lastRemovedCards.clear();
-    }
-    this.cards.clear();
-    topMostStackItems.forEach((item) => {
-      if (!this.hasRealmURL(item) || this.isIndexCard(item)) {
-        return;
-      }
-      if (
-        this.isAlreadyAttached(item.card, attachedCards) ||
-        this.wasPreviouslyRemoved(item.card)
-      ) {
-        return;
-      }
-      this.cards.add(item.card);
-    });
-    this.lastStackedItems = topMostStackItems;
+    this.updateAutoAttachedCardsTask.perform(topMostStackItems, attachedCards);
   }
+
+  private updateAutoAttachedCardsTask = restartableTask(
+    async (
+      topMostStackItems: StackItem[],
+      attachedCards: CardDef[] | undefined,
+    ) => {
+      await Promise.all(topMostStackItems.map((item) => item.ready()));
+      if (this.stackItemsChanged(topMostStackItems)) {
+        // we must be sure to clear the lastRemovedCards state so cards can be auto-attached again
+        // note: if two of the same cards are opened on separate stack, one will be auto-attached.
+        // If one is removed from one of the stacks, the card WILL be auto-attached.
+        this.lastRemovedCards.clear();
+      }
+      this.cards.clear();
+      topMostStackItems.forEach((item) => {
+        if (!this.hasRealmURL(item) || this.isIndexCard(item)) {
+          return;
+        }
+        if (
+          this.isAlreadyAttached(item.card, attachedCards) ||
+          this.wasPreviouslyRemoved(item.card)
+        ) {
+          return;
+        }
+        this.cards.add(item.card);
+      });
+      this.lastStackedItems = topMostStackItems;
+    },
+  );
 
   stackItemsChanged(topMostStackItems: StackItem[]) {
     if (topMostStackItems.length !== this.lastStackedItems.length) {

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -1,6 +1,7 @@
 import { registerDestructor } from '@ember/destroyable';
 
 import { service } from '@ember/service';
+import { waitForPromise } from '@ember/test-waiters';
 import { tracked } from '@glimmer/tracking';
 
 import { restartableTask } from 'ember-concurrency';
@@ -39,7 +40,9 @@ export class Search extends Resource<Args> {
   modify(_positional: never[], named: Args['named']) {
     let { query, realms, isLive, doWhileRefreshing } = named;
     this.realmsToSearch = realms ?? this.cardService.realmURLs;
+
     this.loaded = this.search.perform(query);
+    waitForPromise(this.loaded);
 
     if (isLive) {
       // TODO this triggers a new search against all realms if any single realm

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -913,6 +913,49 @@ module('Acceptance | interact submode tests', function (hooks) {
         )
         .exists('linked card now rendered as a stack item in edit format');
     });
+
+    test('New card is auto-attached once it is saved', async function (assert) {
+      let indexCardId = `${testRealm2URL}index`;
+      await visitOperatorMode({
+        stacks: [
+          [
+            {
+              id: indexCardId,
+              format: 'isolated',
+            },
+          ],
+        ],
+      });
+      assert.dom(`[data-test-stack-card="${indexCardId}"]`).exists();
+      await click('[data-test-open-ai-assistant]');
+      assert.dom('[data-test-attached-card]').doesNotExist();
+      // Press the + button to create a new card instance
+      await click('[data-test-create-new-card-button]');
+      // Select a card from catalog entries
+      await click(
+        `[data-test-select="https://cardstack.com/base/fields/skill-card"]`,
+      );
+      await waitUntil(
+        () =>
+          (
+            document.querySelector(`[data-test-card-catalog-go-button]`) as
+              | HTMLButtonElement
+              | undefined
+          )?.disabled === false,
+      );
+      await click(`[data-test-card-catalog-go-button]`);
+
+      // When edit view of new card opens, fill in a field and press the Pencil icon to finish editing
+      await waitFor('[data-test-field="instructions"] textarea');
+      await fillIn(
+        '[data-test-field="instructions"] textarea',
+        'Do this and that and this and that',
+      );
+      await click('[data-test-stack-card-index="1"] [data-test-edit-button]');
+      await waitFor(
+        '[data-test-card-format="isolated"] [data-test-field="instructions"] p',
+      );
+    });
   });
 
   module('1 stack, when the user lacks write permissions', function (hooks) {


### PR DESCRIPTION
When a new card is being saved, a card resource is in a state where it can't provide card. This caused our AutoAttachment resource code to crash as it assumed that every StackItem could provide a card via its CardResrouce. This PR makes the AutoAttachment resource wait for all stack items to be ready before performing its logic, using an ember-concurrency restartableTask