### PR TITLE
Allow realm to boot without blocking on initial index

### DIFF
--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -25,7 +25,7 @@
     "start:build": "NODE_OPTIONS='--max-old-space-size=8192' FASTBOOT_DISABLED=true ember build --watch",
     "test": "concurrently \"pnpm:lint\" \"pnpm:test:*\" --names \"lint,test:\"",
     "test-with-percy": "percy exec --parallel -- pnpm test:wait-for-servers",
-    "test:wait-for-servers": "NODE_NO_WARNINGS=1 start-server-and-test 'pnpm run wait' 'http-get://localhost:4201/base/fields/boolean-field?acceptHeader=application%2Fvnd.card%2Bjson|http-get://localhost:4202/test/hassan?acceptHeader=application%2Fvnd.card%2Bjson|http://localhost:8008|http://localhost:5001' 'ember-test-pre-built'",
+    "test:wait-for-servers": "./scripts/test-wait-for-servers.sh",
     "ember-test-pre-built": "ember exam --path ./dist --split $HOST_TEST_PARTITION_COUNT --partition $HOST_TEST_PARTITION --preserve-test-name",
     "wait": "sleep 10000000"
   },

--- a/packages/host/scripts/test-wait-for-servers.sh
+++ b/packages/host/scripts/test-wait-for-servers.sh
@@ -1,0 +1,6 @@
+#! /bin/sh
+
+NODE_NO_WARNINGS=1 start-server-and-test \
+  'pnpm run wait' \
+  'http-get://localhost:4201/base/_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson|http-get://localhost:4202/test/_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson|http://localhost:8008|http://localhost:5001' \
+  'ember-test-pre-built'

--- a/packages/matrix/scripts/test.sh
+++ b/packages/matrix/scripts/test.sh
@@ -3,7 +3,7 @@ shard_flag=${1:+--shard}
 echo "running tests: ${1}"
 start-server-and-test \
   'pnpm run wait' \
-  'http-get://localhost:4201/base/fields/boolean-field?acceptHeader=application%2Fvnd.card%2Bjson|http-get://localhost:4202/test/hassan?acceptHeader=application%2Fvnd.card%2Bjson' \
+  'http-get://localhost:4201/base/_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson|http-get://localhost:4202/test/_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson' \
   'pnpm run start:host-pre-built' \
   'http://127.0.0.1:4200' \
   "pnpm playwright test ${shard_flag} ${1}"

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -907,6 +907,29 @@ test.describe('Room messages', () => {
     );
   });
 
+  /*
+    TODO: This matrix test appears to be leaking state. any tests that are 
+    run after it encounter this failure:
+
+    Error: page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:4202/test
+    Call log:
+      - navigating to "http://localhost:4202/test", waiting until "load"
+
+
+      at ../helpers/index.ts:63
+
+      61 |
+      62 | export async function openRoot(page: Page, url = testHost) {
+    > 63 |   await page.goto(url);
+        |              ^
+      64 |   await expect(page.locator('.cards-grid')).toHaveCount(1);
+      65 |   let isOperatorMode = !!(await page.evaluate(() =>
+      66 |     document.querySelector('dialog.operator-mode'),
+
+        at openRoot (/home/runner/work/boxel/boxel/packages/matrix/helpers/index.ts:63:14)
+        at login (/home/runner/work/boxel/boxel/packages/matrix/helpers/index.ts:232:11)
+        at /home/runner/work/boxel/boxel/packages/matrix/tests/messages.spec.ts:1013:16
+  */
   test('attaches a card in a conversation multiple times', async ({ page }) => {
     const testCard = `${testHost}/hassan`;
 

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -1009,8 +1009,29 @@ test.describe('Room messages', () => {
       .click();
   });
 
-  test('displays error message if message is too large', async ({ page }) => {
-    await new Promise((res) => setTimeout(res, 2000));
+  /*
+      TODO need to revisit this test. it fails with the following error.
+      It is very unclear what is so special about this particular test that
+      we consistently get this failure.
+
+      Error: page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:4202/test
+      Call log:
+        - navigating to "http://localhost:4202/test", waiting until "load"
+
+
+        at ../helpers/index.ts:63
+
+        61 |
+        62 | export async function openRoot(page: Page, url = testHost) {
+      > 63 |   await page.goto(url);
+          |              ^
+        64 |   await expect(page.locator('.cards-grid')).toHaveCount(1);
+        65 |   let isOperatorMode = !!(await page.evaluate(() =>
+        66 |     document.querySelector('dialog.operator-mode'),
+  */
+  test.skip('displays error message if message is too large', async ({
+    page,
+  }) => {
     await login(page, 'user1', 'pass');
 
     await page.locator('[data-test-message-field]').fill('a'.repeat(65000));

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -1010,6 +1010,7 @@ test.describe('Room messages', () => {
   });
 
   test('displays error message if message is too large', async ({ page }) => {
+    await new Promise((res) => setTimeout(res, 2000));
     await login(page, 'user1', 'pass');
 
     await page.locator('[data-test-message-field]').fill('a'.repeat(65000));

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -890,7 +890,24 @@ test.describe('Room messages', () => {
     ]);
   });
 
-  test('attaches a card in a coversation multiple times', async ({ page }) => {
+  test('displays error message if message is too large', async ({ page }) => {
+    await login(page, 'user1', 'pass');
+
+    await page.locator('[data-test-message-field]').fill('a'.repeat(65000));
+    await page.locator('[data-test-send-message-btn]').click();
+
+    await expect(page.locator('[data-test-ai-assistant-message]')).toHaveCount(
+      1,
+    );
+    await expect(page.locator('[data-test-card-error]')).toContainText(
+      'Message is too large',
+    );
+    await expect(page.locator('[data-test-ai-bot-retry-button]')).toHaveCount(
+      0,
+    );
+  });
+
+  test('attaches a card in a conversation multiple times', async ({ page }) => {
     const testCard = `${testHost}/hassan`;
 
     await login(page, 'user1', 'pass');
@@ -1007,44 +1024,5 @@ test.describe('Room messages', () => {
     await page
       .locator(`[data-test-stack-card="${testCard}"] [data-test-edit-button]`)
       .click();
-  });
-
-  /*
-      TODO need to revisit this test. it fails with the following error.
-      It is very unclear what is so special about this particular test that
-      we consistently get this failure.
-
-      Error: page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:4202/test
-      Call log:
-        - navigating to "http://localhost:4202/test", waiting until "load"
-
-
-        at ../helpers/index.ts:63
-
-        61 |
-        62 | export async function openRoot(page: Page, url = testHost) {
-      > 63 |   await page.goto(url);
-          |              ^
-        64 |   await expect(page.locator('.cards-grid')).toHaveCount(1);
-        65 |   let isOperatorMode = !!(await page.evaluate(() =>
-        66 |     document.querySelector('dialog.operator-mode'),
-  */
-  test.skip('displays error message if message is too large', async ({
-    page,
-  }) => {
-    await login(page, 'user1', 'pass');
-
-    await page.locator('[data-test-message-field]').fill('a'.repeat(65000));
-    await page.locator('[data-test-send-message-btn]').click();
-
-    await expect(page.locator('[data-test-ai-assistant-message]')).toHaveCount(
-      1,
-    );
-    await expect(page.locator('[data-test-card-error]')).toContainText(
-      'Message is too large',
-    );
-    await expect(page.locator('[data-test-ai-bot-retry-button]')).toHaveCount(
-      0,
-    );
   });
 });

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -890,46 +890,7 @@ test.describe('Room messages', () => {
     ]);
   });
 
-  test('displays error message if message is too large', async ({ page }) => {
-    await login(page, 'user1', 'pass');
-
-    await page.locator('[data-test-message-field]').fill('a'.repeat(65000));
-    await page.locator('[data-test-send-message-btn]').click();
-
-    await expect(page.locator('[data-test-ai-assistant-message]')).toHaveCount(
-      1,
-    );
-    await expect(page.locator('[data-test-card-error]')).toContainText(
-      'Message is too large',
-    );
-    await expect(page.locator('[data-test-ai-bot-retry-button]')).toHaveCount(
-      0,
-    );
-  });
-
-  /*
-    TODO: This matrix test appears to be leaking state. any tests that are 
-    run after it encounter this failure:
-
-    Error: page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:4202/test
-    Call log:
-      - navigating to "http://localhost:4202/test", waiting until "load"
-
-
-      at ../helpers/index.ts:63
-
-      61 |
-      62 | export async function openRoot(page: Page, url = testHost) {
-    > 63 |   await page.goto(url);
-        |              ^
-      64 |   await expect(page.locator('.cards-grid')).toHaveCount(1);
-      65 |   let isOperatorMode = !!(await page.evaluate(() =>
-      66 |     document.querySelector('dialog.operator-mode'),
-
-        at openRoot (/home/runner/work/boxel/boxel/packages/matrix/helpers/index.ts:63:14)
-        at login (/home/runner/work/boxel/boxel/packages/matrix/helpers/index.ts:232:11)
-        at /home/runner/work/boxel/boxel/packages/matrix/tests/messages.spec.ts:1013:16
-  */
+  // TODO: This matrix test mutates state in the index. please move that part into host tests
   test('attaches a card in a conversation multiple times', async ({ page }) => {
     const testCard = `${testHost}/hassan`;
 
@@ -977,6 +938,7 @@ test.describe('Room messages', () => {
     expect(messageEvents.length).toEqual(3);
     expect(cardFragmentEvents.length).toEqual(2);
 
+    // TODO: this assertion needs to move into host tests!!
     //Test the scenario where there is an update to the card
     await page
       .locator(
@@ -1037,6 +999,9 @@ test.describe('Room messages', () => {
     expect(messageEvents.length).toEqual(4);
     expect(cardFragmentEvents.length).toEqual(3);
 
+    // TODO: the fact that we are reverting state in the index is a tell that
+    // this test should not be here
+
     // Revert updates
     await page
       .locator(`[data-test-stack-card="${testCard}"] [data-test-edit-button]`)
@@ -1047,5 +1012,22 @@ test.describe('Room messages', () => {
     await page
       .locator(`[data-test-stack-card="${testCard}"] [data-test-edit-button]`)
       .click();
+  });
+
+  test('displays error message if message is too large', async ({ page }) => {
+    await login(page, 'user1', 'pass');
+
+    await page.locator('[data-test-message-field]').fill('a'.repeat(65000));
+    await page.locator('[data-test-send-message-btn]').click();
+
+    await expect(page.locator('[data-test-ai-assistant-message]')).toHaveCount(
+      1,
+    );
+    await expect(page.locator('[data-test-card-error]')).toContainText(
+      'Message is too large',
+    );
+    await expect(page.locator('[data-test-ai-bot-retry-button]')).toHaveCount(
+      0,
+    );
   });
 });

--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -229,6 +229,13 @@ let dist: URL = new URL(distURL);
   let server = new RealmServer(realms, virtualNetwork);
 
   server.listen(port);
+
+  await Promise.all(workers.map((worker) => worker.run()));
+
+  for (let realm of realms) {
+    await realm.start();
+  }
+
   log.info(`Realm server listening on port ${port} is serving realms:`);
   let additionalMappings = hrefs.slice(paths.length);
   for (let [index, { url }] of realms.entries()) {
@@ -241,14 +248,6 @@ let dist: URL = new URL(distURL);
     }
   }
   log.info(`Using host url: '${dist}' for card pre-rendering`);
-
-  await Promise.all(workers.map((worker) => worker.run()));
-
-  for (let realm of realms) {
-    log.info(`Starting realm ${realm.url}...`);
-    await realm.start();
-    log.info(`Realm ${realm.url} has started`);
-  }
 })().catch((e: any) => {
   Sentry.captureException(e);
   console.error(

--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -153,6 +153,7 @@ let dist: URL = new URL(distURL);
   let dbAdapter = new PgAdapter();
   let queue = new PgQueue(dbAdapter);
 
+  let start = Date.now();
   for (let [i, path] of paths.entries()) {
     let url = hrefs[i][0];
 
@@ -225,11 +226,12 @@ let dist: URL = new URL(distURL);
     realms.push(realm);
     virtualNetwork.mount(realm.handle);
   }
+  log.info(`workers for port ${port} started in ${Date.now() - start}ms`);
 
   let server = new RealmServer(realms, virtualNetwork);
 
   server.listen(port);
-  log.info(`Realm server listening on port ${port}:`);
+  log.info(`Realm server listening on port ${port} is serving realms:`);
   let additionalMappings = hrefs.slice(paths.length);
   for (let [index, { url }] of realms.entries()) {
     log.info(`    ${url} => ${hrefs[index][1]}, serving path ${paths[index]}`);
@@ -245,13 +247,7 @@ let dist: URL = new URL(distURL);
   for (let realm of realms) {
     log.info(`Starting realm ${realm.url}...`);
     await realm.start();
-    log.info(
-      `Realm ${realm.url} has started (${JSON.stringify(
-        realm.searchIndex.stats,
-        null,
-        2,
-      )})`,
-    );
+    log.info(`Realm ${realm.url} has started`);
   }
 })().catch((e: any) => {
   Sentry.captureException(e);

--- a/packages/realm-server/pg-queue.ts
+++ b/packages/realm-server/pg-queue.ts
@@ -218,14 +218,6 @@ export default class PgQueue implements Queue {
           category,
           status: 'idle',
         } as QueueTable);
-        // await this.query([
-        //   'INSERT INTO queues',
-        //   ...addExplicitParens(separatedByCommas(nameExpressions)),
-        //   'VALUES',
-        //   ...addExplicitParens(separatedByCommas(valueExpressions)),
-        //   // we just need to seed this when it doesn't exist
-        //   // 'ON CONFLICT (working_queues_pkey) DO NOTHING',
-        // ] as Expression);
         await this.query(
           upsert(
             'queues',

--- a/packages/realm-server/pg-queue.ts
+++ b/packages/realm-server/pg-queue.ts
@@ -222,6 +222,8 @@ export default class PgQueue implements Queue {
           ...addExplicitParens(separatedByCommas(nameExpressions)),
           'VALUES',
           ...addExplicitParens(separatedByCommas(valueExpressions)),
+          // we just need to seed this when it doesn't exist
+          'ON CONFLICT (working_queues_pkey) DO NOTHING',
         ] as Expression);
       }
     }

--- a/packages/realm-server/pg-queue.ts
+++ b/packages/realm-server/pg-queue.ts
@@ -12,6 +12,7 @@ import {
   logger,
   asExpressions,
   Deferred,
+  upsert,
   Job,
   setErrorReporter,
 } from '@cardstack/runtime-common';
@@ -217,14 +218,22 @@ export default class PgQueue implements Queue {
           category,
           status: 'idle',
         } as QueueTable);
-        await this.query([
-          'INSERT INTO queues',
-          ...addExplicitParens(separatedByCommas(nameExpressions)),
-          'VALUES',
-          ...addExplicitParens(separatedByCommas(valueExpressions)),
-          // we just need to seed this when it doesn't exist
-          // 'ON CONFLICT (working_queues_pkey) DO NOTHING',
-        ] as Expression);
+        // await this.query([
+        //   'INSERT INTO queues',
+        //   ...addExplicitParens(separatedByCommas(nameExpressions)),
+        //   'VALUES',
+        //   ...addExplicitParens(separatedByCommas(valueExpressions)),
+        //   // we just need to seed this when it doesn't exist
+        //   // 'ON CONFLICT (working_queues_pkey) DO NOTHING',
+        // ] as Expression);
+        await this.query(
+          upsert(
+            'queues',
+            'working_queues_pkey',
+            nameExpressions,
+            valueExpressions,
+          ),
+        );
       }
     }
     {

--- a/packages/realm-server/pg-queue.ts
+++ b/packages/realm-server/pg-queue.ts
@@ -223,7 +223,7 @@ export default class PgQueue implements Queue {
           'VALUES',
           ...addExplicitParens(separatedByCommas(valueExpressions)),
           // we just need to seed this when it doesn't exist
-          'ON CONFLICT (working_queues_pkey) DO NOTHING',
+          // 'ON CONFLICT (working_queues_pkey) DO NOTHING',
         ] as Expression);
       }
     }

--- a/packages/realm-server/scripts/start-all.sh
+++ b/packages/realm-server/scripts/start-all.sh
@@ -2,7 +2,7 @@
 
 NODE_NO_WARNINGS=1 start-server-and-test \
   'run-p start:pg start:matrix start:smtp start:development start:base:root' \
-  'http-get://localhost:4201/base/fields/boolean-field?acceptHeader=application%2Fvnd.card%2Bjson|http-get://localhost:4203/fields/boolean-field?acceptHeader=application%2Fvnd.card%2Bjson|http-get://localhost:4201/drafts/_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson|http://localhost:8008|http://localhost:5001' \
+  'http-get://localhost:4201/base/_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson|http-get://localhost:4203/_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson|http-get://localhost:4201/drafts/_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson|http://localhost:8008|http://localhost:5001' \
   'run-p start:test-realms start:test-container' \
-  'http-get://localhost:4202/node-test/person-1?acceptHeader=application%2Fvnd.card%2Bjson|http-get://127.0.0.1:4205' \
+  'http-get://localhost:4202/node-test/_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson|http-get://127.0.0.1:4205' \
   'wait'

--- a/packages/realm-server/scripts/start-without-matrix.sh
+++ b/packages/realm-server/scripts/start-without-matrix.sh
@@ -1,7 +1,7 @@
 #! /bin/sh
 NODE_NO_WARNINGS=1 start-server-and-test \
   'run-p start:pg start:development start:base:root' \
-  'http-get://localhost:4201/base/fields/boolean-field?acceptHeader=application%2Fvnd.card%2Bjson|http-get://localhost:4203/fields/boolean-field?acceptHeader=application%2Fvnd.card%2Bjson|http-get://localhost:4201/drafts/index?acceptHeader=application%2Fvnd.card%2Bjson' \
+  'http-get://localhost:4201/base/_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson|http-get://localhost:4203/_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson|http-get://localhost:4201/drafts/_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson' \
   'run-p start:test-realms start:test-container' \
-  'http-get://localhost:4202/node-test/person-1?acceptHeader=application%2Fvnd.card%2Bjson|http-get://127.0.0.1:4205' \
+  'http-get://localhost:4202/node-test/_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson|http-get://127.0.0.1:4205' \
   'wait'

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -118,7 +118,6 @@ export async function createRealm({
   queue,
   dbAdapter,
   matrixConfig = testMatrix,
-  deferStartUp,
 }: {
   dir: string;
   fileSystem?: Record<string, string | LooseSingleCardDocument>;
@@ -148,32 +147,33 @@ export async function createRealm({
   }
 
   let adapter = new NodeAdapter(dir);
-  let realm = new Realm(
-    {
-      url: realmURL,
-      adapter,
-      getIndexHTML: fastbootState.getIndexHTML,
-      matrix: matrixConfig,
-      realmSecretSeed: "shhh! it's a secret",
-      virtualNetwork,
-      dbAdapter,
-      queue,
-      onIndexWriterReady: async (indexWriter) => {
-        let worker = new Worker({
-          realmURL: new URL(realmURL!),
-          indexWriter,
-          queue,
-          realmAdapter: adapter,
-          runnerOptsManager: manager,
-          loader: realm.loaderTemplate,
-          indexRunner,
-        });
-        await worker.run();
-      },
-      assetsURL: new URL(`http://example.com/notional-assets-host/`),
+  let worker: Worker | undefined;
+  let realm = new Realm({
+    url: realmURL,
+    adapter,
+    getIndexHTML: fastbootState.getIndexHTML,
+    matrix: matrixConfig,
+    realmSecretSeed: "shhh! it's a secret",
+    virtualNetwork,
+    dbAdapter,
+    queue,
+    withIndexWriter: (indexWriter, loader) => {
+      worker = new Worker({
+        realmURL: new URL(realmURL!),
+        indexWriter,
+        queue,
+        realmAdapter: adapter,
+        runnerOptsManager: manager,
+        loader,
+        indexRunner,
+      });
     },
-    { deferStartUp },
-  );
+    assetsURL: new URL(`http://example.com/notional-assets-host/`),
+  });
+  if (!worker) {
+    throw new Error(`worker for realm ${realmURL} was not created`);
+  }
+  await worker.run();
   return realm;
 }
 
@@ -214,7 +214,7 @@ export async function runBaseRealmServer(
     permissions,
   });
   virtualNetwork.mount(testBaseRealm.handle);
-  await testBaseRealm.ready;
+  await testBaseRealm.start();
   let testBaseRealmServer = new RealmServer([testBaseRealm], virtualNetwork);
   return testBaseRealmServer.listen(parseInt(localBaseRealmURL.port));
 }
@@ -249,7 +249,7 @@ export async function runTestRealmServer({
     dbAdapter,
   });
   virtualNetwork.mount(testRealm.handle);
-  await testRealm.ready;
+  await testRealm.start();
   let testRealmServer = await new RealmServer(
     [testRealm],
     virtualNetwork,

--- a/packages/realm-server/tests/loader-test.ts
+++ b/packages/realm-server/tests/loader-test.ts
@@ -166,7 +166,7 @@ module('loader', function (hooks) {
           queue,
         });
         virtualNetwork.mount(realm.handle.bind(realm));
-        await realm.ready;
+        await realm.start();
       },
     });
 

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -138,14 +138,6 @@ export class IndexQueryEngine {
     return this.query(await this.makeExpression(query, loader));
   }
 
-  async isNewIndex(realm: URL): Promise<boolean> {
-    let [row] = (await this.query([
-      'SELECT current_version FROM realm_versions WHERE realm_url =',
-      param(realm.href),
-    ])) as Pick<RealmVersionsTable, 'current_version'>[];
-    return !row;
-  }
-
   async getModule(
     url: URL,
     opts?: GetEntryOptions,

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -137,6 +137,14 @@ export class IndexQueryEngine {
     return this.query(await this.makeExpression(query, loader));
   }
 
+  async isNewIndex(realm: URL): Promise<boolean> {
+    let [row] = (await this.query([
+      'SELECT current_version FROM realm_versions WHERE realm_url =',
+      param(realm.href),
+    ])) as Pick<RealmVersionsTable, 'current_version'>[];
+    return !row;
+  }
+
   async getModule(
     url: URL,
     opts?: GetEntryOptions,

--- a/packages/runtime-common/realm-index-updater.ts
+++ b/packages/runtime-common/realm-index-updater.ts
@@ -34,10 +34,12 @@ export class RealmIndexUpdater {
     realm,
     dbAdapter,
     queue,
+    withIndexWriter,
   }: {
     realm: Realm;
     dbAdapter: DBAdapter;
     queue: Queue;
+    withIndexWriter?: (indexWriter: IndexWriter, loader: Loader) => void;
   }) {
     if (!dbAdapter) {
       throw new Error(
@@ -48,6 +50,9 @@ export class RealmIndexUpdater {
     this.#queue = queue;
     this.#realm = realm;
     this.#loader = Loader.cloneLoader(this.#realm.loaderTemplate);
+    if (withIndexWriter) {
+      withIndexWriter(this.#indexWriter, this.#realm.loaderTemplate);
+    }
   }
 
   get stats() {
@@ -72,11 +77,8 @@ export class RealmIndexUpdater {
     return ignoreMap;
   }
 
-  async run(onIndexWriterReady?: (indexWriter: IndexWriter) => Promise<void>) {
+  async run() {
     await this.#queue.start();
-    if (onIndexWriterReady) {
-      await onIndexWriterReady(this.#indexWriter);
-    }
 
     let isNewIndex = await this.#indexWriter.isNewIndex(this.realmURL);
     if (isNewIndex) {

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -408,7 +408,7 @@ export class Realm {
     _request: Request,
     requestContext: RequestContext,
   ) {
-    await this.ready;
+    await this.#startedUp.promise;
 
     return createResponse({
       body: null,
@@ -422,7 +422,7 @@ export class Realm {
 
   async start() {
     this.#startedUp.fulfill((() => this.#startup())());
-    await this.ready;
+    await this.#startedUp.promise;
   }
 
   async fullIndex() {
@@ -560,10 +560,6 @@ export class Realm {
     this.#perfLog.debug(
       `realm server startup in ${Date.now() - this.#startTime}ms`,
     );
-  }
-
-  private get ready(): Promise<void> {
-    return this.#startedUp.promise;
   }
 
   // TODO get rid of this
@@ -796,7 +792,7 @@ export class Realm {
       // local requests are allowed to query the realm as the index is being built up
       if (!isLocal) {
         let timeout = await Promise.race<void | Error>([
-          this.ready,
+          this.#startedUp.promise,
           new Promise((resolve) =>
             setTimeout(() => {
               resolve(

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -145,7 +145,6 @@ export interface RealmAdapter {
 }
 
 interface Options {
-  deferStartUp?: true;
   useTestingDomain?: true;
   disableModuleCaching?: true;
 }
@@ -222,7 +221,6 @@ export class Realm {
   #realmIndexQueryEngine: RealmIndexQueryEngine;
   #adapter: RealmAdapter;
   #router: Router;
-  #deferStartup: boolean;
   #useTestingDomain = false;
   #log = logger('realm');
   #perfLog = logger('perf');
@@ -234,9 +232,6 @@ export class Realm {
   #realmSecretSeed: string;
   #disableModuleCaching = false;
 
-  #onIndexWriterReady:
-    | ((indexWriter: IndexWriter) => Promise<void>)
-    | undefined;
   #publicEndpoints: RouteTable<true> = new Map([
     [
       SupportedMimeType.Session,
@@ -277,7 +272,7 @@ export class Realm {
       dbAdapter,
       queue,
       virtualNetwork,
-      onIndexWriterReady,
+      withIndexWriter,
       assetsURL,
     }: {
       url: string;
@@ -288,7 +283,7 @@ export class Realm {
       dbAdapter: DBAdapter;
       queue: Queue;
       virtualNetwork: VirtualNetwork;
-      onIndexWriterReady?: (indexWriter: IndexWriter) => Promise<void>;
+      withIndexWriter?: (indexWriter: IndexWriter, loader: Loader) => void;
       assetsURL: URL;
     },
     opts?: Options,
@@ -327,11 +322,11 @@ export class Realm {
     this.loaderTemplate = loader;
 
     this.#adapter = adapter;
-    this.#onIndexWriterReady = onIndexWriterReady;
     this.#realmIndexUpdater = new RealmIndexUpdater({
       realm: this,
       dbAdapter,
       queue,
+      withIndexWriter,
     });
     this.#realmIndexQueryEngine = new RealmIndexQueryEngine({
       realm: this,
@@ -407,11 +402,6 @@ export class Realm {
         return createResponse({ init: { status: 200 }, requestContext });
       });
     });
-
-    this.#deferStartup = opts?.deferStartUp ?? false;
-    if (!opts?.deferStartUp) {
-      this.#startedUp.fulfill((() => this.#startup())());
-    }
   }
 
   private async readinessCheck(
@@ -430,11 +420,8 @@ export class Realm {
     });
   }
 
-  // it's only necessary to call this when the realm is using a deferred startup
   async start() {
-    if (this.#deferStartup) {
-      this.#startedUp.fulfill((() => this.#startup())());
-    }
+    this.#startedUp.fulfill((() => this.#startup())());
     await this.ready;
   }
 
@@ -568,14 +555,14 @@ export class Realm {
 
   async #startup() {
     await Promise.resolve();
-    await this.#realmIndexUpdater.run(this.#onIndexWriterReady);
+    await this.#realmIndexUpdater.run();
     this.sendServerEvent({ type: 'index', data: { type: 'full' } });
     this.#perfLog.debug(
       `realm server startup in ${Date.now() - this.#startTime}ms`,
     );
   }
 
-  get ready(): Promise<void> {
+  private get ready(): Promise<void> {
     return this.#startedUp.promise;
   }
 

--- a/packages/runtime-common/worker.ts
+++ b/packages/runtime-common/worker.ts
@@ -165,14 +165,16 @@ export class Worker {
   async run() {
     await this.#queue.start();
 
-    this.#queue.register(
-      `from-scratch-index:${this.#realmURL}`,
-      this.fromScratch,
-    );
-    this.#queue.register(
-      `incremental-index:${this.#realmURL}`,
-      this.incremental,
-    );
+    await Promise.all([
+      this.#queue.register(
+        `from-scratch-index:${this.#realmURL}`,
+        this.fromScratch,
+      ),
+      this.#queue.register(
+        `incremental-index:${this.#realmURL}`,
+        this.incremental,
+      ),
+    ]);
   }
 
   private async prepareAndRunJob<T>(run: () => Promise<T>): Promise<T> {


### PR DESCRIPTION
This PR updates the realm such that it can boot without blocking on the initial index. As part of this PR, I've also moved the worker startup outside of the realm constructor and enforced that all realms need to be started with `Realm.start()`. Before you could use the deferStartup option, such that the realm could be started as soon as its instantiated--this addresses a long standing request to assert that all realms should use deferred startup that Ed mentioned awhile back.

If you use the console to know when the realm is ready to serve files, as soon as you see the server mapping summary, the realm is ready to serve files. We still show the stats after the full index has completed, but there is no need to wait until that time.
![image](https://github.com/user-attachments/assets/08fb668c-c492-4d5f-b608-cf1b728fc100)


