### PR TITLE
Add a route to serve card css (Card CSS API) 

### DIFF
--- a/packages/realm-server/tests/cards/fancy-person.gts
+++ b/packages/realm-server/tests/cards/fancy-person.gts
@@ -1,0 +1,27 @@
+import {
+  contains,
+  field,
+  Component,
+} from 'https://cardstack.com/base/card-api';
+import StringCard from 'https://cardstack.com/base/string';
+import { Person } from './person';
+
+export class FancyPerson extends Person {
+  static displayName = 'Person';
+  @field firstName = contains(StringCard);
+  @field title = contains(StringCard, {
+    computeVia: function (this: FancyPerson) {
+      return this.firstName;
+    },
+  });
+  static isolated = class Isolated extends Component<typeof this> {
+    <template>
+      <style>
+        .fancy-border {
+          border: 1px solid pink;
+        }
+      </style>
+      <h1 data-test-card class='.fancy-border'><@fields.firstName /></h1>
+    </template>
+  };
+}

--- a/packages/realm-server/tests/cards/fancy-person.gts
+++ b/packages/realm-server/tests/cards/fancy-person.gts
@@ -21,7 +21,7 @@ export class FancyPerson extends Person {
           border: 1px solid pink;
         }
       </style>
-      <h1 data-test-card class='.fancy-border'><@fields.firstName /></h1>
+      <h1 data-test-card class='fancy-border'><@fields.firstName /></h1>
     </template>
   };
 }

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -149,8 +149,6 @@ export class RealmIndexQueryEngine {
     return { type: 'doc', doc };
   }
 
-  // this is for tests--it's unlikely we'd actually want to access CSS directly
-  // this way
   async css(url: URL, opts?: Options): Promise<IndexedCSSOrError | undefined> {
     return await this.#indexQueryEngine.getCSS(url, opts);
   }

--- a/packages/runtime-common/router.ts
+++ b/packages/runtime-common/router.ts
@@ -19,6 +19,7 @@ export type Method = 'GET' | 'POST' | 'PATCH' | 'DELETE' | 'HEAD';
 export enum SupportedMimeType {
   CardJson = 'application/vnd.card+json',
   CardSource = 'application/vnd.card+source',
+  CardCss = 'application/vnd.card+css',
   DirectoryListing = 'application/vnd.api+json',
   RealmInfo = 'application/vnd.api+json',
   Session = 'application/json',


### PR DESCRIPTION
This adds a realm route so that we are able to query the css of a module. 

This is a part of the larger task for showing prerendered cards in cards grid/card catalog/search results where `/search-prerendered` endpoint will respond  with css module ids (in addition to card prerendered html), which identify the css files needed for prerendered cards. These ids will be used to fetch the css using the route in this PR. 