### PR TITLE
Remove cached since SessionRoomData is not dependent on tracked properties

### DIFF
--- a/packages/host/app/components/ai-assistant/panel.gts
+++ b/packages/host/app/components/ai-assistant/panel.gts
@@ -455,7 +455,6 @@ export default class AiAssistantPanel extends Component<Signature> {
     this.isShowingPastSessions = false;
   }
 
-  @cached
   private get aiSessionRooms() {
     let sessions: SessionRoomData[] = [];
     for (let resource of this.roomResources.values()) {


### PR DESCRIPTION
Remove @cached decorator since cached only updates when a tracked property is used. Given SessionRoomData is just data as a function of resource, maybe we have been unreliably using tracked 

I can't seem to reliably reproduce this bug but one way is to ask ai bot for a long message and then logout while the message is streaming

Hold off on this. I think this changes the behaviour but it relies on a TrackedMap in the matrix service and im not sure how that gets updated. Perhaps worth pairing with ed first on this matrix room events tracked stuff first

