### PR TITLE
Fix a bug in getConsumedModules

### DIFF
--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -86,6 +86,10 @@ module('indexing', function (hooks) {
               static embedded = class Isolated extends Component<typeof this> {
                 <template>
                   <h1> Embedded Card Person: <@fields.firstName/></h1>
+
+                  <style>
+                    h1 { color: red }
+                  </style>
                 </template>
               }
             }
@@ -99,12 +103,22 @@ module('indexing', function (hooks) {
             }
           `,
           'fancy-person.gts': `
-            import { contains, field } from "https://cardstack.com/base/card-api";
+            import { contains, field, Component } from "https://cardstack.com/base/card-api";
             import StringCard from "https://cardstack.com/base/string";
             import { Person } from "./person";
 
             export class FancyPerson extends Person {
               @field favoriteColor = contains(StringCard);
+
+              static embedded = class Embedded extends Component<typeof this> {
+                <template>
+                  <h1> Embedded Card Fancy Person: <@fields.firstName/></h1>
+
+                  <style>
+                    h1 { color: pink }
+                  </style>
+                </template>
+              }
             }
           `,
           'post.gts': `
@@ -641,6 +655,62 @@ module('indexing', function (hooks) {
       }),
       'indexed correct number of files',
     );
+  });
+
+  test('sets urls containing encoded CSS for deps for a module', async function (assert) {
+    let entry = (await realm.realmIndexQueryEngine.module(
+      new URL('http://test-realm/fancy-person.gts'),
+    )) as { deps: string[] };
+
+    let assertCssDependency = (
+      deps: string[],
+      pattern: RegExp,
+      fileName: string,
+    ) => {
+      assert.true(
+        !!deps.find((dep) => pattern.test(dep)),
+        `css for ${fileName} is in the deps`,
+      );
+    };
+
+    let dependencies = [
+      {
+        pattern: /fancy-person\.gts.*\.glimmer-scoped\.css$/,
+        fileName: 'fancy-person.gts',
+      },
+      {
+        pattern: /test-realm\/person\.gts.*\.glimmer-scoped\.css$/,
+        fileName: 'person.gts',
+      },
+      {
+        pattern: /cardstack.com\/base\/card-api\.gts.*\.glimmer-scoped\.css$/,
+        fileName: 'card-api.gts',
+      },
+      {
+        pattern:
+          /cardstack.com\/base\/links-to-many-component.gts.*\.glimmer-scoped\.css$/,
+        fileName: 'links-to-many-component.gts',
+      },
+      {
+        pattern:
+          /cardstack.com\/base\/links-to-editor.gts.*\.glimmer-scoped\.css$/,
+        fileName: 'links-to-editor.gts',
+      },
+      {
+        pattern:
+          /cardstack.com\/base\/contains-many-component.gts.*\.glimmer-scoped\.css$/,
+        fileName: 'contains-many-component.gts',
+      },
+      {
+        pattern:
+          /cardstack.com\/base\/field-component.gts.*\.glimmer-scoped\.css$/,
+        fileName: 'field-component.gts',
+      },
+    ];
+
+    dependencies.forEach(({ pattern, fileName }) => {
+      assertCssDependency(entry.deps, pattern, fileName);
+    });
   });
 });
 

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -59,6 +59,7 @@ interface IndexedModule {
   source: string;
   canonicalURL: string;
   lastModified: number;
+  deps: string[] | null;
 }
 
 interface IndexedCSS {
@@ -169,6 +170,7 @@ export class IndexQueryEngine {
       executableCode,
       source,
       lastModified: parseInt(lastModified),
+      deps: moduleEntry.deps,
     };
   }
 

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -146,15 +146,15 @@ export class Loader {
 
   async getConsumedModules(
     moduleIdentifier: string,
-    consumed = new Set<string>(),
+    consumed: string[] = [],
     initialIdentifier = moduleIdentifier,
   ): Promise<string[]> {
-    if (consumed.has(moduleIdentifier)) {
+    if (consumed.includes(moduleIdentifier)) {
       return [];
     }
     // you can't consume yourself
     if (moduleIdentifier !== initialIdentifier) {
-      consumed.add(moduleIdentifier);
+      consumed.push(moduleIdentifier);
     }
 
     let resolvedModuleIdentifier = new URL(moduleIdentifier);
@@ -178,7 +178,8 @@ export class Loader {
     if (module?.state === 'evaluated' || module?.state === 'broken') {
       let cached = this.consumptionCache.get(module);
       if (cached) {
-        return cached;
+        consumed.push(...cached);
+        return [...new Set(consumed)];
       }
       for (let consumedModule of module?.consumedModules ?? []) {
         await this.getConsumedModules(
@@ -187,9 +188,10 @@ export class Loader {
           initialIdentifier,
         );
       }
-      cached = [...consumed];
+      cached = consumed;
       this.consumptionCache.set(module, cached);
-      return cached;
+
+      return [...new Set(cached)]; // Get rid of duplicates
     }
     return [];
   }


### PR DESCRIPTION
`deps` field for module entries  in `boxel_index` table was missing glimmer scope CSS urls for modules that the indexed module extends from. The issue was a bug in caching during recursive calls of consumed modules discovery. 

This bug was preventing us from gathering all the needed css (from all the modules in the dependency chain) for prerendered cards.  We paired on this with @habdelra yesterday. 