### PR TITLE
ci: Remove redundant production deployment

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -52,6 +52,7 @@ jobs:
 
   deploy-motion:
     name: Deploy boxel-motion
+    if: inputs.environment == 'staging'
     uses: ./.github/workflows/deploy-motion.yml
     secrets: inherit
     with:
@@ -59,6 +60,7 @@ jobs:
 
   deploy-ui:
     name: Deploy boxel-ui
+    if: inputs.environment == 'staging'
     uses: ./.github/workflows/deploy-ui.yml
     secrets: inherit
     with:


### PR DESCRIPTION
I had mild confusion seeing these being deployed when I was testing #1471 in production. There‘s no need to deploy them on production deploys since they always only deploy to staging, which will already have been covered by the deployment on merges to `main`.