### PR TITLE
Better Card displayName approach: use card class prototype when rendering card component

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -3,13 +3,12 @@ import { action } from '@ember/object';
 import GlimmerComponent from '@glimmer/component';
 // @ts-ignore no types
 import cssUrl from 'ember-css-url';
-import { flatMap, merge, isEqual } from 'lodash';
+import { flatMap, merge, isEqual, startCase } from 'lodash';
 import { TrackedWeakMap } from 'tracked-built-ins';
 import { WatchedArray } from './watched-array';
 import { BoxelInput, FieldContainer } from '@cardstack/boxel-ui/components';
 import { cn, eq, not, pick } from '@cardstack/boxel-ui/helpers';
 import { on } from '@ember/modifier';
-import { startCase } from 'lodash';
 import {
   getBoxComponent,
   type BoxComponent,
@@ -51,6 +50,7 @@ import {
   type CardResource,
   type Actions,
   type RealmInfo,
+  CodeRef,
 } from '@cardstack/runtime-common';
 import type { ComponentLike } from '@glint/template';
 import { initSharedState } from './shared-state';
@@ -1702,8 +1702,12 @@ export class BaseDef {
     return _createFromSerialized(this, data, doc, relativeTo, identityContext);
   }
 
-  static getComponent(card: BaseDef, field?: Field) {
-    return getComponent(card, field);
+  static getComponent(
+    card: BaseDef,
+    field?: Field,
+    opts?: { componentCodeRef?: CodeRef },
+  ) {
+    return getComponent(card, field, opts);
   }
 
   static assignInitialFieldValue(
@@ -1821,9 +1825,7 @@ class DefaultEmbeddedTemplate extends GlimmerComponent<{
         <div class='info-section'>
           <h3 class='card-title' data-test-card-title>{{@model.title}}</h3>
           <h4 class='card-display-name' data-test-card-display-name>
-            <!-- __org.boxel.cardType START -->
             {{cardTypeDisplayName @model}}
-            <!-- __org.boxel.cardType END -->
           </h4>
         </div>
         <div
@@ -3232,12 +3234,17 @@ export type SignatureFor<CardT extends BaseDefConstructor> = {
   };
 };
 
-export function getComponent(model: BaseDef, field?: Field): BoxComponent {
+export function getComponent(
+  model: BaseDef,
+  field?: Field,
+  opts?: { componentCodeRef?: CodeRef },
+): BoxComponent {
   let box = Box.create(model);
   let boxComponent = getBoxComponent(
     model.constructor as BaseDefConstructor,
     box,
     field,
+    opts,
   );
   return boxComponent;
 }

--- a/packages/host/app/services/render-service.ts
+++ b/packages/host/app/services/render-service.ts
@@ -6,7 +6,7 @@ import Serializer from '@simple-dom/serializer';
 
 import voidMap from '@simple-dom/void-map';
 
-import { baseRealm, RealmPaths } from '@cardstack/runtime-common';
+import { baseRealm, RealmPaths, type CodeRef } from '@cardstack/runtime-common';
 import { Deferred } from '@cardstack/runtime-common/deferred';
 import { isCardError, CardError } from '@cardstack/runtime-common/error';
 import {
@@ -42,6 +42,7 @@ interface RenderCardParams {
   format?: Format;
   identityContext: IdentityContextType;
   realmPath: RealmPaths;
+  componentCodeRef?: CodeRef;
 }
 export type RenderCard = (params: RenderCardParams) => Promise<string>;
 
@@ -62,8 +63,11 @@ export default class RenderService extends Service {
       format = 'embedded',
       identityContext,
       realmPath,
+      componentCodeRef,
     } = params;
-    let component = card.constructor.getComponent(card);
+    let component = card.constructor.getComponent(card, undefined, {
+      componentCodeRef,
+    });
 
     let element = getIsolatedRenderElement(this.document);
     let notLoaded: NotLoaded | undefined;

--- a/packages/host/tests/integration/card-prerender-test.gts
+++ b/packages/host/tests/integration/card-prerender-test.gts
@@ -44,6 +44,7 @@ module('Integration | card-prerender', function (hooks) {
     let { default: StringField } = string;
 
     class Pet extends CardDef {
+      static displayName = 'Pet';
       @field firstName = contains(StringField);
       static isolated = class Isolated extends Component<typeof this> {
         <template>
@@ -93,6 +94,7 @@ module('Integration | card-prerender', function (hooks) {
           import StringCard from "https://cardstack.com/base/string";
 
           export class Person extends CardDef {
+            static displayName = 'Person';
             @field firstName = contains(StringCard);
             static isolated = class Isolated extends Component<typeof this> {
               <template>
@@ -118,6 +120,7 @@ module('Integration | card-prerender', function (hooks) {
           import StringCard from "https://cardstack.com/base/string";
 
           export class FancyPerson extends Person {
+            static displayName = 'Fancy Person';
             @field favoriteColor = contains(StringCard);
 
             static embedded = class Embedded extends Component<typeof this> {
@@ -286,8 +289,8 @@ module('Integration | card-prerender', function (hooks) {
     [
       ['test card: pet mango', 'Pet'],
       ['test card: pet vangogh', 'Pet'],
-      ['test card: person jane', 'FancyPerson'],
-      ['test card: person jimmy', 'FancyPerson'],
+      ['test card: person jane', 'Fancy Person'],
+      ['test card: person jimmy', 'Fancy Person'],
     ].forEach(([title, type], index) => {
       assert.strictEqual(
         cleanWhiteSpace(
@@ -297,7 +300,7 @@ module('Integration | card-prerender', function (hooks) {
         <div class="embedded-template">
           <div class="thumbnail-section">
             <div class="card-thumbnail">
-              <div class="card-thumbnail-text" data-test-card-thumbnail-text>Card</div>
+              <div class="card-thumbnail-text" data-test-card-thumbnail-text>${type}</div>
             </div>
           </div>
           <div class="info-section">

--- a/packages/host/tests/integration/realm-indexing-and-querying-test.gts
+++ b/packages/host/tests/integration/realm-indexing-and-querying-test.gts
@@ -1160,7 +1160,7 @@ module(`Integration | realm indexing and querying`, function (hooks) {
           <div class="embedded-template">
             <div class="thumbnail-section">
               <div class="card-thumbnail">
-                <div class="card-thumbnail-text" data-test-card-thumbnail-text>Card</div>
+                <div class="card-thumbnail-text" data-test-card-thumbnail-text>Fancy Person</div>
               </div>
             </div>
             <div class="info-section">


### PR DESCRIPTION
This PR uses a better approach for rendering card display names when we are generating the prerendered HTML for a card's adoption chain. instead of trying to render an instance using a different card class we render a card using it's original card class and only use a card class's prototype's component when rendering higher in the adoption chain. The way we can still access the display name of the native card class when rendering higher up in the adoption chain. (this also caught a couple bugs in our previous implementation)