### PR TITLE
Update IDField to ReadOnlyField

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -7,7 +7,7 @@ import { flatMap, merge, isEqual } from 'lodash';
 import { TrackedWeakMap } from 'tracked-built-ins';
 import { WatchedArray } from './watched-array';
 import { BoxelInput, FieldContainer } from '@cardstack/boxel-ui/components';
-import { cn, eq, not, pick } from '@cardstack/boxel-ui/helpers';
+import { cn, eq, not } from '@cardstack/boxel-ui/helpers';
 import { on } from '@ember/modifier';
 import { startCase } from 'lodash';
 import {
@@ -2284,7 +2284,7 @@ export class FieldDef extends BaseDef {
   static atom: BaseDefComponent = DefaultAtomViewTemplate;
 }
 
-class IDField extends FieldDef {
+export class ReadOnlyField extends FieldDef {
   static [primitive]: string;
   static [useIndexBasedKey]: never;
   static embedded = class Embedded extends Component<typeof this> {
@@ -2294,12 +2294,7 @@ class IDField extends FieldDef {
   };
   static edit = class Edit extends Component<typeof this> {
     <template>
-      {{! template-lint-disable require-input-label }}
-      <input
-        type='text'
-        value={{@model}}
-        {{on 'input' (pick 'target.value' @set)}}
-      />
+      {{@model}}
     </template>
   };
 }
@@ -2350,7 +2345,7 @@ export class CardDef extends BaseDef {
   [isSavedInstance] = false;
   [realmInfo]: RealmInfo | undefined = undefined;
   [realmURL]: URL | undefined = undefined;
-  @field id = contains(IDField);
+  @field id = contains(ReadOnlyField);
   @field title = contains(StringField);
   @field description = contains(StringField);
   // TODO: this will probably be an image or image url field card when we have it
@@ -3159,7 +3154,7 @@ function makeDescriptor<
   } else {
     descriptor.set = function (this: BaseInstanceType<CardT>, value: any) {
       if (
-        (field.card as typeof BaseDef) === IDField &&
+        (field.card as typeof BaseDef) === ReadOnlyField &&
         isCardInstance(this) &&
         this[isSavedInstance]
       ) {
@@ -3168,7 +3163,7 @@ function makeDescriptor<
             field.name
           }' on the saved card '${
             (this as any)[field.name]
-          }' because it is the card's identifier`,
+          }' because it is a read-only field`,
         );
       }
       value = field.validate(this, value);

--- a/packages/host/tests/helpers/base-realm.ts
+++ b/packages/host/tests/helpers/base-realm.ts
@@ -71,6 +71,7 @@ let unsubscribeFromChanges: (typeof CardAPIModule)['unsubscribeFromChanges'];
 let flushLogs: (typeof CardAPIModule)['flushLogs'];
 let queryableValue: (typeof CardAPIModule)['queryableValue'];
 let getFieldDescription: (typeof CardAPIModule)['getFieldDescription'];
+let ReadOnlyField: (typeof CardAPIModule)['ReadOnlyField'];
 
 async function initialize() {
   let owner = (getContext() as TestContext).owner;
@@ -150,6 +151,7 @@ async function initialize() {
     queryableValue,
     MaybeBase64Field,
     getFieldDescription,
+    ReadOnlyField,
   } = cardAPI);
 }
 
@@ -190,4 +192,5 @@ export {
   flushLogs,
   queryableValue,
   getFieldDescription,
+  ReadOnlyField,
 };

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -69,6 +69,7 @@ import {
   subscribeToChanges,
   TextAreaField,
   unsubscribeFromChanges,
+  ReadOnlyField,
 } from '../../helpers/base-realm';
 import { mango } from '../../helpers/image-fixture';
 import { setupMatrixServiceMock } from '../../helpers/mock-matrix-service';
@@ -2473,6 +2474,27 @@ module('Integration | card-basics', function (hooks) {
         'The place where the person was born',
         getFieldDescription(Person, 'hometown'),
       );
+    });
+
+    test('ReadOnlyField wont display input field', async function (assert) {
+      class Person extends CardDef {
+        @field readOnlyField = contains(ReadOnlyField);
+        @field name = contains(StringField);
+
+        static isolated = class Isolated extends Component<typeof this> {
+          <template>
+            {{@model.readOnlyField}}
+            {{@model.name}}
+          </template>
+        };
+      }
+
+      let person = new Person({ readOnlyField: 'Test', name: 'Mango' });
+      await renderCard(loader, person, 'edit');
+      assert.dom('[data-test-field="name"] input').exists({ count: 1 });
+      assert
+        .dom('[data-test-field="readOnlyField"] input')
+        .exists({ count: 0 });
     });
   });
 });


### PR DESCRIPTION
As mentioned in the [ticket](https://linear.app/cardstack/issue/CS-7018/carddef-id-fields-have-mutable-ids-in-edit-format), the ID should not be editable by the user. Therefore, in this PR, I updated the edit format for `IDField` and renamed it to `ReadOnlyField`.

<img width="596" alt="Screenshot 2024-08-05 at 14 03 14" src="https://github.com/user-attachments/assets/266ae826-839f-4ce3-b023-61a13931da7e">


