### PR TITLE
Fix for issue that causes realm to stop indexing when it encounters a consumer in different realm

### DIFF
--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -379,7 +379,18 @@ export class CurrentRun {
     resource: LooseCardResource;
     identityContext: IdentityContextType;
   }): Promise<void> {
-    let fileURL = this.#realmPaths.fileURL(path).href;
+    let fileURL: string | undefined;
+    try {
+      fileURL = this.#realmPaths.fileURL(path).href;
+    } catch (e) {
+      // until we have cross realm invalidation, if our invalidation
+      // graph cross a realm just skip over the file. it will be out
+      // of date, but such is life...
+      log.error(
+        `Invalidation of ${path} cannot be performed as it is in a different realm than the realm whose contents are being invalidated (${this.realmURL.href})`,
+      );
+      return;
+    }
     let indexingInstance = this.#indexingInstances.get(fileURL);
     if (indexingInstance) {
       return await indexingInstance;


### PR DESCRIPTION
This PR contains a workaround for an issue that @tintinthong ran into when editing a module in the base realm that was consumed by an instance in a different realm. Ultimately we need a realm to realm invalidation protocol to address this situation. This is simply a band-aid to prevent indexing from breaking.