### PR TITLE
Improve realm-icon visibility on dark colored stack-item header

### DIFF
--- a/packages/boxel-ui/addon/src/helpers/contrast-color.ts
+++ b/packages/boxel-ui/addon/src/helpers/contrast-color.ts
@@ -5,7 +5,11 @@
   Inspired by https://stackoverflow.com/a/35970186
   More info: https://www.w3.org/TR/WCAG20-TECHS/G18.html
 */
-export function getContrastColor(value: string | undefined) {
+export function getContrastColor(
+  value: string | undefined,
+  darkColor = 'var(--boxel-dark, #000000)',
+  lightColor = 'var(--boxel-light, #ffffff)',
+) {
   if (!value) {
     return;
   }
@@ -43,7 +47,5 @@ export function getContrastColor(value: string | undefined) {
   let ratio = (lum + 0.05) / 0.05; // luminocity of black is 0
 
   // contrast ratio should be at least 4.5 for regular sized text based on WCAG guidelines
-  return ratio >= 4.5
-    ? 'var(--boxel-dark, #000000)'
-    : 'var(--boxel-light, #ffffff)';
+  return ratio >= 4.5 ? darkColor : lightColor;
 }

--- a/packages/boxel-ui/test-app/tests/unit/constrast-color-test.ts
+++ b/packages/boxel-ui/test-app/tests/unit/constrast-color-test.ts
@@ -55,4 +55,14 @@ module('Unit | contrast-color test', function () {
     let color = getContrastColor('#6638ff');
     assert.strictEqual(color, lightText);
   });
+
+  test('can use different lightColor value', function (assert) {
+    let color = getContrastColor('#000', undefined, '#ddd');
+    assert.strictEqual(color, '#ddd');
+  });
+
+  test('can use different darkColor value', function (assert) {
+    let color = getContrastColor('#fff', '#333');
+    assert.strictEqual(color, '#333');
+  });
 });

--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -45,6 +45,7 @@ interface Signature {
     toggleSelect?: (card: CardDef) => void;
     selectedCards?: TrackedArray<CardDef>;
   };
+  Element: HTMLElement;
 }
 
 let boundRenderedCardElement = new WeakSet<HTMLElement>();
@@ -69,6 +70,7 @@ export default class OperatorModeOverlays extends Component<Signature> {
           data-test-overlay-card={{card.id}}
           data-test-overlay-card-display-name={{cardTypeDisplayName card}}
           style={{this.zIndexStyle renderedCard.element}}
+          ...attributes
         >
           {{#if (this.isIncludeHeader renderedCard)}}
             <OperatorModeOverlayItemHeader
@@ -322,6 +324,6 @@ export default class OperatorModeOverlays extends Component<Signature> {
       zIndexParentElement === 'auto'
         ? zIndexParentElement
         : String(Number(zIndexParentElement) + 1);
-    return htmlSafe(`z-index: ${zIndex}`);
+    return htmlSafe(`z-index: ${zIndex};`);
   }
 }

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -183,13 +183,19 @@ export default class OperatorModeStackItem extends Component<Signature> {
       ? '100%'
       : `calc(${stackItemMaxWidth} * ${maxWidthPercent} / 100)`;
 
-    return htmlSafe(`
+    let styles = `
       height: calc(100% - ${offsetPx}px * ${this.args.index});
       width: ${width};
       max-width: ${maxWidthPercent}%;
       z-index: calc(${this.args.index} + 1);
       margin-top: calc(${offsetPx}px * ${this.args.index});
-    `); // using margin-top instead of padding-top to hide scrolled content from view
+    `; // using margin-top instead of padding-top to hide scrolled content from view
+
+    if (this.args.item.isWideFormat) {
+      styles += 'transition: width var(--boxel-transition)';
+    }
+
+    return htmlSafe(styles);
   }
 
   private get isBuried() {
@@ -431,6 +437,11 @@ export default class OperatorModeStackItem extends Component<Signature> {
                   <RealmIcon
                     @realmInfo={{realmInfo}}
                     class='header-icon'
+                    style={{cssVar
+                      realm-icon-background=(getContrastColor
+                        @item.headerColor 'transparent'
+                      )
+                    }}
                     data-test-boxel-header-icon={{realmInfo.iconURL}}
                     {{on 'mouseenter' this.hoverOnRealmIcon}}
                     {{on 'mouseleave' this.hoverOnRealmIcon}}
@@ -544,6 +555,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
               @publicAPI={{@publicAPI}}
               @toggleSelect={{this.toggleSelect}}
               @selectedCards={{this.selectedCards}}
+              class={{if @item.isWideFormat 'delay'}}
             />
           </div>
         {{/if}}
@@ -571,6 +583,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
       }
 
       .header-icon {
+        background-color: var(--realm-icon-background);
         border: 1px solid rgba(0, 0, 0, 0.15);
         border-radius: 7px;
       }
@@ -716,6 +729,9 @@ export default class OperatorModeStackItem extends Component<Signature> {
         display: flex;
         justify: center;
         align-items: center;
+      }
+      .delay {
+        transition: all var(--boxel-transition);
       }
     </style>
   </template>


### PR DESCRIPTION
- Change 1: Added white background-color to realm icon when stack item header is dark colored. The card author has the option to ignore this by using a realm icon with a background, if they don't want this treatment.

Below: No change for light-colored header, white background for dark colored header:
<img width="977" alt="realm-icon-bg" src="https://github.com/user-attachments/assets/2d83e6ae-88e8-42cb-88eb-0c914c950f82">

- Change 2: Added css transition for full-width stack item.