### PR TITLE
Test waiter improvements

### DIFF
--- a/packages/host/app/components/card-catalog/modal.gts
+++ b/packages/host/app/components/card-catalog/modal.gts
@@ -6,9 +6,8 @@ import type Owner from '@ember/owner';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
-import { restartableTask, task } from 'ember-concurrency';
+import { restartableTask, task, timeout } from 'ember-concurrency';
 import focusTrap from 'ember-focus-trap/modifiers/focus-trap';
-import debounce from 'lodash/debounce';
 
 import { TrackedArray, TrackedObject } from 'tracked-built-ins';
 
@@ -389,7 +388,7 @@ export default class CardCatalogModal extends Component<Signature> {
     if (!this.state.searchKey) {
       this.resetState();
     } else {
-      this.debouncedSearchFieldUpdate();
+      this.debouncedSearchFieldUpdate.perform();
     }
   }
 
@@ -405,7 +404,10 @@ export default class CardCatalogModal extends Component<Signature> {
     }
   }
 
-  debouncedSearchFieldUpdate = debounce(() => this.onSearchFieldUpdated(), 500);
+  debouncedSearchFieldUpdate = restartableTask(async () => {
+    await timeout(500);
+    this.onSearchFieldUpdated();
+  });
 
   @action setCardURL(cardURL: string) {
     if (!this.state) {

--- a/packages/host/app/services/loader-service.ts
+++ b/packages/host/app/services/loader-service.ts
@@ -1,5 +1,5 @@
 import Service, { service } from '@ember/service';
-import { buildWaiter } from '@ember/test-waiters';
+
 import { tracked } from '@glimmer/tracking';
 
 import {
@@ -23,8 +23,6 @@ import type RealmService from './realm';
 
 const isFastBoot = typeof (globalThis as any).FastBoot !== 'undefined';
 
-let virtualNetworkFetchWaiter = buildWaiter('virtual-network-fetch');
-
 function getNativeFetch(): typeof fetch {
   if (isFastBoot) {
     let optsId = (globalThis as any).runnerOptsId;
@@ -36,15 +34,7 @@ function getNativeFetch(): typeof fetch {
     ) => RunnerOpts;
     return getRunnerOpts(optsId)._fetch;
   } else {
-    let fetchWithWaiter: typeof globalThis.fetch = async (...args) => {
-      let token = virtualNetworkFetchWaiter.beginAsync();
-      try {
-        return await fetch(...args);
-      } finally {
-        virtualNetworkFetchWaiter.endAsync(token);
-      }
-    };
-    return fetchWithWaiter;
+    return fetch;
   }
 }
 

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -3,7 +3,6 @@ import {
   click,
   fillIn,
   triggerKeyEvent,
-  waitUntil,
 } from '@ember/test-helpers';
 
 import { triggerEvent } from '@ember/test-helpers';
@@ -1399,13 +1398,6 @@ module('Acceptance | interact submode tests', function (hooks) {
         },
       });
 
-      await waitUntil(() =>
-        document
-          .querySelector(
-            '[data-test-operator-mode-stack="0"] [data-test-person]',
-          )
-          ?.textContent?.includes('FadhlanXXX'),
-      );
       assert
         .dom('[data-test-operator-mode-stack="0"] [data-test-person]')
         .hasText('FadhlanXXX');

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -3,7 +3,6 @@ import {
   click,
   fillIn,
   triggerKeyEvent,
-  waitFor,
   waitUntil,
 } from '@ember/test-helpers';
 
@@ -314,7 +313,6 @@ module('Acceptance | interact submode tests', function (hooks) {
     test('Clicking card in search panel opens card on a new stack', async function (assert) {
       await visitOperatorMode({});
 
-      await waitFor('[data-test-search-sheet="closed"]');
       assert.dom('[data-test-operator-mode-stack]').doesNotExist();
       assert.dom('[data-test-search-sheet]').doesNotHaveClass('prompt'); // Search closed
 
@@ -327,24 +325,12 @@ module('Acceptance | interact submode tests', function (hooks) {
 
       assert.dom('[data-test-search-sheet]').hasClass('results'); // Search open
 
-      await waitFor(`[data-test-search-result="${testRealmURL}Pet/mango"]`, {
-        timeout: 2000,
-      });
-
       // Click on search result
       await click(`[data-test-search-result="${testRealmURL}Pet/mango"]`);
 
-      await waitUntil(
-        () =>
-          !document
-            .querySelector('[data-test-search-sheet]')!
-            .classList.contains('results'),
-      ); // Search closed
+      // Search closed
 
       // The card appears on a new stack
-      await waitFor('[data-test-operator-mode-stack]');
-
-      await waitFor('[data-test-operator-mode-stack="0"]');
       assert.dom('[data-test-operator-mode-stack]').exists({ count: 1 });
       assert
         .dom(
@@ -364,24 +350,18 @@ module('Acceptance | interact submode tests', function (hooks) {
 
       assert.dom('[data-test-operator-mode-stack]').doesNotExist();
 
-      await waitFor('[data-test-add-card-button]');
       await click('[data-test-add-card-button]');
-      await waitFor('[data-test-card-catalog]');
       await fillIn(
         '[data-test-card-catalog-modal] [data-test-search-field]',
         `${testRealmURL}index`,
       );
 
-      await waitFor(`[data-test-card-catalog-item="${testRealmURL}index"]`, {
-        timeout: 2000,
-      });
       assert
         .dom(`[data-test-card-catalog-item="${testRealmURL}index"]`)
         .hasText('Test Workspace B');
 
       await click(`[data-test-select="${testRealmURL}index"]`);
       await click('[data-test-card-catalog-go-button]');
-      await waitFor('[data-test-card-catalog]', { count: 0 });
       assert.dom('[data-test-operator-mode-stack]').exists({ count: 1 });
       assert.dom('[data-test-stack-card-index]').exists({ count: 1 });
       assert.dom('[data-test-stack-card-header]').hasText('Test Workspace B');
@@ -393,17 +373,12 @@ module('Acceptance | interact submode tests', function (hooks) {
 
       assert.dom('[data-test-operator-mode-stack]').doesNotExist();
 
-      await waitFor('[data-test-add-card-button]');
       await click('[data-test-add-card-button]');
-      await waitFor('[data-test-card-catalog]');
       await fillIn(
         '[data-test-card-catalog-modal] [data-test-search-field]',
         wrongURL,
       );
 
-      await waitFor('[data-test-boxel-input-error-message]', {
-        timeout: 2000,
-      });
       assert
         .dom('[data-test-boxel-input-error-message]')
         .hasText(`Could not find card at ${wrongURL}`);
@@ -413,18 +388,12 @@ module('Acceptance | interact submode tests', function (hooks) {
         '[data-test-card-catalog-modal] [data-test-search-field]',
         baseRealm.url.slice(0, -1),
       );
-      await waitFor(`[data-test-card-catalog-item="${baseRealm.url}index"]`, {
-        timeout: 2000,
-      });
       assert.dom('[data-test-card-catalog-item]').hasText('Base Workspace');
 
       await fillIn(
         '[data-test-card-catalog-modal] [data-test-search-field]',
         testRealmURL,
       );
-      await waitFor(`[data-test-card-catalog-item="${testRealmURL}index"]`, {
-        timeout: 2000,
-      });
       assert.dom('[data-test-card-catalog-item]').hasText('Test Workspace B');
       assert.dom('[data-test-boxel-input-error-message]').doesNotExist();
       assert
@@ -433,7 +402,7 @@ module('Acceptance | interact submode tests', function (hooks) {
 
       await click(`[data-test-select="${testRealmURL}index"]`);
       await click('[data-test-card-catalog-go-button]');
-      await waitFor('[data-test-card-catalog]', { count: 0 });
+
       assert.dom('[data-test-operator-mode-stack]').exists({ count: 1 });
       assert.dom('[data-test-stack-card-index]').exists({ count: 1 });
       assert.dom('[data-test-stack-card-header]').hasText('Test Workspace B');
@@ -442,19 +411,10 @@ module('Acceptance | interact submode tests', function (hooks) {
     test('Can open a recent card in empty stack', async function (assert) {
       await visitOperatorMode({});
 
-      await waitFor('[data-test-add-card-button]');
       await click('[data-test-add-card-button]');
 
-      await waitFor('[data-test-search-field]');
       await click('[data-test-search-field]');
       await fillIn('[data-test-search-field]', `${testRealmURL}person-entry`);
-
-      await waitFor(
-        `[data-test-card-catalog-item="${testRealmURL}person-entry"]`,
-      );
-      await waitFor('[data-test-card-catalog-item]', {
-        count: 1,
-      });
 
       assert.dom('[data-test-realm-filter-button]').isDisabled();
 
@@ -465,11 +425,7 @@ module('Acceptance | interact submode tests', function (hooks) {
       assert.dom('[data-test-card-catalog-item]').exists({ count: 1 });
       await click('[data-test-select]');
 
-      await waitFor('[data-test-card-catalog-go-button][disabled]', {
-        count: 0,
-      });
       await click('[data-test-card-catalog-go-button]');
-      await waitFor(`[data-test-stack-card="${testRealmURL}person-entry"]`);
 
       assert
         .dom(`[data-test-stack-card="${testRealmURL}person-entry"]`)
@@ -479,18 +435,14 @@ module('Acceptance | interact submode tests', function (hooks) {
       await click(
         `[data-test-stack-card="${testRealmURL}person-entry"] [data-test-close-button]`,
       );
-      await waitFor(`[data-test-stack-card="${testRealmURL}person-entry"]`, {
-        count: 0,
-      });
+
       assert.dom('[data-test-add-card-button]').exists('stack is empty');
 
       await click('[data-test-search-field]');
       assert.dom('[data-test-search-sheet]').hasClass('prompt');
 
-      await waitFor(`[data-test-search-result="${testRealmURL}person-entry"]`);
       await click(`[data-test-search-result="${testRealmURL}person-entry"]`);
 
-      await waitFor(`[data-test-stack-card="${testRealmURL}person-entry"]`);
       assert
         .dom(`[data-test-stack-card="${testRealmURL}person-entry"]`)
         .exists();
@@ -499,17 +451,13 @@ module('Acceptance | interact submode tests', function (hooks) {
     test('Handles a URL with no results', async function (assert) {
       await visitOperatorMode({});
 
-      await waitFor('[data-test-add-card-button]');
       await click('[data-test-add-card-button]');
 
-      await waitFor('[data-test-search-field]');
       await fillIn(
         '[data-test-search-field]',
         `${testRealmURL}xyz-does-not-exist`,
       );
 
-      await waitFor('[data-test-card-catalog]');
-      await waitFor('[data-test-card-catalog-item]', { count: 0 });
       assert.dom(`[data-test-card-catalog]`).hasText('No cards available');
     });
   });
@@ -555,7 +503,6 @@ module('Acceptance | interact submode tests', function (hooks) {
         ],
       });
 
-      await waitFor('[data-test-operator-mode-stack] [data-test-pet="Mango"]');
       await click('[data-test-operator-mode-stack] [data-test-pet="Mango"]');
       let expectedURL = `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
         stringify({
@@ -576,9 +523,6 @@ module('Acceptance | interact submode tests', function (hooks) {
           openDirs: {},
         })!,
       )}`;
-      // There is some additional thing we are waiting on here, probably the
-      // card to load in the card resource, but I'm not too sure so using waitUntil instead
-      await waitUntil(() => currentURL() === expectedURL);
       assert.strictEqual(currentURL(), expectedURL);
 
       // Click Edit on the top card
@@ -679,12 +623,6 @@ module('Acceptance | interact submode tests', function (hooks) {
         '[data-test-operator-mode-stack="0"] [data-test-close-button]',
       );
 
-      // There is now only 1 stack and the buttons to add a neighbor stack are back
-      await waitUntil(
-        () =>
-          document.querySelectorAll('[data-test-operator-mode-stack]')
-            .length === 1,
-      );
       assert
         .dom('[data-test-operator-mode-stack]')
         .exists({ count: 1 }, 'after close, expect 1 stack');
@@ -706,17 +644,7 @@ module('Acceptance | interact submode tests', function (hooks) {
 
       // There are now 2 stacks
       assert.dom('[data-test-operator-mode-stack]').exists({ count: 2 });
-      await waitUntil(() =>
-        document
-          .querySelector('[data-test-operator-mode-stack="0"]')
-          ?.textContent?.includes('Fadhlan'),
-      );
       assert.dom('[data-test-operator-mode-stack="0"]').includesText('Fadhlan');
-      await waitUntil(() =>
-        document
-          .querySelector('[data-test-operator-mode-stack="1"]')
-          ?.textContent?.includes('Mango'),
-      );
       assert.dom('[data-test-operator-mode-stack="1"]').includesText('Mango'); // Mango gets moved onto the right stack
 
       // Buttons to add a neighbor stack are gone
@@ -726,13 +654,6 @@ module('Acceptance | interact submode tests', function (hooks) {
       // Close the only card in the 1st stack
       await click(
         '[data-test-operator-mode-stack="0"] [data-test-close-button]',
-      );
-      // There is some additional thing we are waiting on here, probably the
-      // card to load in the card resource, but I'm not too sure so using waitUntil instead
-      await waitUntil(
-        () =>
-          document.querySelectorAll('[data-test-operator-mode-stack]')
-            .length === 1,
       );
 
       // There is now only 1 stack and the buttons to add a neighbor stack are back
@@ -793,14 +714,6 @@ module('Acceptance | interact submode tests', function (hooks) {
 
       // Click on a recent search
       await click(`[data-test-search-result="${testRealmURL}Pet/mango"]`);
-      // There is some additional thing we are waiting on here, probably the
-      // card to load in the card resource, but I'm not too sure so using waitUntil instead
-      await waitUntil(
-        () =>
-          document.querySelectorAll(
-            '[data-test-operator-mode-stack="0"] [data-test-stack-card-index="1"]',
-          ).length === 0,
-      );
 
       assert.dom('[data-test-search-sheet]').doesNotHaveClass('prompt'); // Search closed
 
@@ -820,7 +733,6 @@ module('Acceptance | interact submode tests', function (hooks) {
 
     test('search can be dismissed with escape', async function (assert) {
       await visitOperatorMode({});
-      await waitFor('[data-test-search-sheet="closed"]');
       await click('[data-test-search-field]');
 
       assert.dom('[data-test-search-sheet]').hasClass('prompt');
@@ -860,13 +772,9 @@ module('Acceptance | interact submode tests', function (hooks) {
         deferred.fulfill();
       });
       await click('[data-test-create-new-card-button]');
-      await waitFor(
-        `[data-test-card-catalog-item="${testRealmURL}person-entry"]`,
-      );
       await click(`[data-test-select="${testRealmURL}person-entry"]`);
       await click('[data-test-card-catalog-go-button]');
 
-      await waitFor('[data-test-stack-card-index="1"]');
       await fillIn(`[data-test-field="firstName"] input`, 'Hassan');
       await click('[data-test-stack-card-index="1"] [data-test-close-button]');
 
@@ -885,9 +793,6 @@ module('Acceptance | interact submode tests', function (hooks) {
         ],
       });
 
-      await waitFor(
-        `[data-test-operator-mode-stack="0"] [data-test-cards-grid-item="${testRealmURL}Person/fadhlan"]`,
-      );
       // Simulate simultaneous clicks for spam-clicking
       await Promise.all([
         click(
@@ -898,7 +803,6 @@ module('Acceptance | interact submode tests', function (hooks) {
         ),
       ]);
 
-      await waitFor(`[data-stack-card="${testRealmURL}Person/fadhlan"]`);
       assert
         .dom(`[data-stack-card="${testRealmURL}Person/fadhlan"]`)
         .exists({ count: 1 });
@@ -923,7 +827,6 @@ module('Acceptance | interact submode tests', function (hooks) {
       await click(
         `[data-test-overlay-card="${testRealmURL}Pet/mango"] [data-test-overlay-edit]`,
       );
-      await waitFor(`[data-test-stack-card="${testRealmURL}Pet/mango"]`);
       assert
         .dom(
           `[data-test-stack-card="${testRealmURL}Pet/mango"] [data-test-card-format="edit"]`,
@@ -952,26 +855,15 @@ module('Acceptance | interact submode tests', function (hooks) {
       await click(
         `[data-test-select="https://cardstack.com/base/fields/skill-card"]`,
       );
-      await waitUntil(
-        () =>
-          (
-            document.querySelector(`[data-test-card-catalog-go-button]`) as
-              | HTMLButtonElement
-              | undefined
-          )?.disabled === false,
-      );
+
       await click(`[data-test-card-catalog-go-button]`);
 
       // When edit view of new card opens, fill in a field and press the Pencil icon to finish editing
-      await waitFor('[data-test-field="instructions"] textarea');
       await fillIn(
         '[data-test-field="instructions"] textarea',
         'Do this and that and this and that',
       );
       await click('[data-test-stack-card-index="1"] [data-test-edit-button]');
-      await waitFor(
-        '[data-test-card-format="isolated"] [data-test-field="instructions"] p',
-      );
     });
   });
 
@@ -1128,7 +1020,6 @@ module('Acceptance | interact submode tests', function (hooks) {
           ],
         ],
       });
-      await waitFor('[data-test-more-options-button]');
       await click('[data-test-more-options-button]');
       assert
         .dom('[data-test-boxel-menu-item-text="Delete"]')
@@ -1146,9 +1037,6 @@ module('Acceptance | interact submode tests', function (hooks) {
           ],
         ],
       });
-      await waitFor(
-        `[data-test-operator-mode-stack="0"] [data-test-cards-grid-item="${testRealmURL}Pet/mango"]`,
-      );
       assert
         .dom(
           `[data-test-overlay-card="${testRealmURL}Pet/mango"] [data-test-overlay-more-options]`,
@@ -1178,7 +1066,6 @@ module('Acceptance | interact submode tests', function (hooks) {
       await click(
         `[data-test-links-to-editor="pet"] [data-test-field-component-card]`,
       );
-      await waitFor(`[data-test-stack-card="${testRealmURL}Pet/mango"]`);
       assert
         .dom(
           `[data-test-stack-card="${testRealmURL}Pet/mango"] [data-test-card-format="isolated"]`,
@@ -1267,9 +1154,6 @@ module('Acceptance | interact submode tests', function (hooks) {
           ],
         ],
       });
-      await waitFor(
-        '[data-test-operator-mode-stack="0"] [data-test-more-options-button]',
-      );
       await click(
         '[data-test-operator-mode-stack="0"] [data-test-more-options-button]',
       );
@@ -1277,9 +1161,6 @@ module('Acceptance | interact submode tests', function (hooks) {
         .dom('[data-test-boxel-menu-item-text="Delete"]')
         .doesNotExist('delete menu item is not rendered');
 
-      await waitFor(
-        '[data-test-operator-mode-stack="1"] [data-test-more-options-button]',
-      );
       await click(
         '[data-test-operator-mode-stack="1"] [data-test-more-options-button]',
       );
@@ -1305,18 +1186,12 @@ module('Acceptance | interact submode tests', function (hooks) {
           ],
         ],
       });
-      await waitFor(
-        `[data-test-operator-mode-stack="0"] [data-test-cards-grid-item="${testRealmURL}Pet/mango"]`,
-      );
       assert
         .dom(
           `[data-test-operator-mode-stack="0"] [data-test-overlay-card="${testRealmURL}Pet/mango"] [data-test-overlay-more-options]`,
         )
         .doesNotExist('"..." menu does not exist');
 
-      await waitFor(
-        `[data-test-operator-mode-stack="1"] [data-test-cards-grid-item="${testRealm2URL}Pet/ringo"]`,
-      );
       await triggerEvent(
         `[data-test-operator-mode-stack="1"] [data-test-cards-grid-item="${testRealm2URL}Pet/ringo"]`,
         'mouseenter',
@@ -1447,15 +1322,6 @@ module('Acceptance | interact submode tests', function (hooks) {
 
       // Click on a recent search
       await click(`[data-test-search-result="${testRealmURL}Person/fadhlan"]`);
-
-      // We have to wait untill there is only one stack item in rightmost stack,
-      // because that's the expected behaviour when we open a card from card search.
-      await waitUntil(
-        () =>
-          document.querySelectorAll(
-            '[data-test-operator-mode-stack="1"] [data-test-stack-card-index]',
-          )?.length === 1,
-      );
 
       assert.dom('[data-test-search-sheet]').doesNotHaveClass('prompt'); // Search closed
 

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -395,6 +395,7 @@ export function setupServerSentEvents(hooks: NestedHooks) {
       }
       clearTimeout(timeout);
       realm.unsubscribe();
+      await settled();
       return result;
     };
   });

--- a/packages/host/tests/helpers/visit-operator-mode.ts
+++ b/packages/host/tests/helpers/visit-operator-mode.ts
@@ -1,4 +1,4 @@
-import { visit, waitFor } from '@ember/test-helpers';
+import { visit } from '@ember/test-helpers';
 
 import stringify from 'safe-stable-stringify';
 
@@ -26,7 +26,4 @@ export default async function visitOperatorMode({
       operatorModeStateParam,
     )}`,
   );
-  if (stacks && stacks.length > 0 && (!submode || submode === 'interact')) {
-    await waitFor('[data-test-operator-mode-stack]');
-  }
 }

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -812,9 +812,6 @@ module('Integration | operator-mode', function (hooks) {
     assert.dom('[data-test-add-new]').exists();
     await click('[data-test-add-new]');
     await waitFor(`[data-test-card-catalog-modal]`);
-    await click(`[data-test-card-catalog-create-new-button]`);
-
-    await click('[data-test-add-new]');
     await waitFor(`[data-test-card-catalog-item="${testRealmURL}Author/2"]`);
     await click(`[data-test-select="${testRealmURL}Author/2"]`);
     assert

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -9,6 +9,7 @@ import {
   triggerEvent,
   triggerKeyEvent,
   typeIn,
+  settled,
 } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 
@@ -1333,10 +1334,8 @@ module('Integration | operator-mode', function (hooks) {
         </template>
       },
     );
-    await waitFor(`[data-test-stack-card="${testRealmURL}grid"]`);
-    assert.dom(`[data-test-stack-card-header]`).containsText(realmName);
 
-    await waitFor(`[data-test-cards-grid-item]`);
+    assert.dom(`[data-test-stack-card-header]`).containsText(realmName);
 
     await focus(`[data-test-search-field]`);
     typeIn(`[data-test-search-field]`, 'ma');
@@ -1346,13 +1345,8 @@ module('Integration | operator-mode', function (hooks) {
       )?.innerText.includes('Searching for “ma”'),
     );
     assert.dom(`[data-test-search-label]`).containsText('Searching for “ma”');
+    await settled();
 
-    await waitFor(`[data-test-search-sheet-search-result]`);
-    await waitUntil(() =>
-      (
-        document.querySelector('[data-test-search-label]') as HTMLElement
-      )?.innerText.includes('4'),
-    );
     assert.dom(`[data-test-search-label]`).containsText('4 Results for “ma”');
     assert.dom(`[data-test-search-sheet-search-result]`).exists({ count: 4 });
     assert.dom(`[data-test-realm-name]`).exists({ count: 4 });
@@ -1368,12 +1362,7 @@ module('Integration | operator-mode', function (hooks) {
 
     await focus(`[data-test-search-field]`);
     await typeIn(`[data-test-search-field]`, 'Mark J');
-    await waitFor(`[data-test-search-sheet-search-result]`);
-    await waitUntil(() =>
-      (
-        document.querySelector('[data-test-search-label]') as HTMLElement
-      )?.innerText.includes('1'),
-    );
+
     assert
       .dom(`[data-test-search-label]`)
       .containsText('1 Result for “Mark J”');
@@ -1396,15 +1385,8 @@ module('Integration | operator-mode', function (hooks) {
       .dom(`[data-test-search-label]`)
       .containsText('Searching for “No Cards”');
 
-    await waitUntil(
-      () =>
-        (
-          document.querySelector('[data-test-search-label]') as HTMLElement
-        )?.innerText.includes('0'),
-      {
-        timeoutMessage: 'timed out waiting for search label to show 0 results',
-      },
-    );
+    await settled();
+
     assert
       .dom(`[data-test-search-label]`)
       .containsText('0 Results for “No Cards”');

--- a/packages/host/tests/test-helper.js
+++ b/packages/host/tests/test-helper.js
@@ -5,7 +5,10 @@ import { setApplication } from '@ember/test-helpers';
 import { setup } from 'qunit-dom';
 import setupOperatorModeParametersMatchAssertion from '@cardstack/host/tests/helpers/operator-mode-parameters-match';
 import start from 'ember-exam/test-support/start';
+import { useTestWaiters } from '@cardstack/runtime-common';
+import * as TestWaiters from '@ember/test-waiters';
 
+useTestWaiters(TestWaiters);
 setApplication(Application.create(config.APP));
 
 setup(QUnit.assert);

--- a/packages/runtime-common/virtual-network.ts
+++ b/packages/runtime-common/virtual-network.ts
@@ -4,12 +4,12 @@ import {
   PACKAGES_FAKE_ORIGIN,
 } from './package-shim-handler';
 import type { Readable } from 'stream';
-import { simulateNetworkBehaviors } from './fetcher';
+import { fetcher, type FetcherMiddlewareHandler } from './fetcher';
 export interface ResponseWithNodeStream extends Response {
   nodeStream?: Readable;
 }
 
-export type Handler = (req: Request) => Promise<ResponseWithNodeStream | null>;
+export type Handler = (req: Request) => Promise<Response | null>;
 
 export class VirtualNetwork {
   private handlers: Handler[] = [];
@@ -106,6 +106,24 @@ export class VirtualNetwork {
     return response;
   };
 
+  private async runFetch(request: Request, init?: RequestInit) {
+    let handlers: FetcherMiddlewareHandler[] = this.handlers.map((h) => {
+      return async (request, next) => {
+        let response = await h(request);
+        if (response) {
+          return response;
+        }
+        return next(request);
+      };
+    });
+
+    handlers.push(async (request, next) => {
+      return next(await this.mapRequest(request, 'virtual-to-real'));
+    });
+
+    return await fetcher(this.nativeFetch, handlers)(request, init);
+  }
+
   // This method is used to handle the boundary between the real and virtual network,
   // when a request is made to the realm from the realm server - it maps requests
   // by changing their URL from real to virtual, as defined in the url mapping config
@@ -163,18 +181,6 @@ export class VirtualNetwork {
       }
       response.headers.set('Location', finalRedirectionURL);
     }
-  }
-
-  private async runFetch(request: Request, init?: RequestInit) {
-    for (let handler of this.handlers) {
-      let response = await handler(request);
-      if (response) {
-        return await simulateNetworkBehaviors(request, response, this.fetch);
-      }
-    }
-
-    let internalRequest = await this.mapRequest(request, 'virtual-to-real');
-    return await this.nativeFetch(internalRequest, init);
   }
 
   createEventSource(url: string) {


### PR DESCRIPTION
For cs-7120, added test waiters to:

 - all response-body reading in the virtual network, including for non-native Responses
 - sqlite WASM communication
 - debounced input field in card catalog modal
 - make the `expectEvents` test helper wait for `settled`, just like all the ember-provided test helpers

This allowed us to remove a large number of `waitFor` / `waitUntil` in the interact submode tests and there are probably other tests that could be similarly cleaned up.
