### PR TITLE
host: Add ESLint rule for using mock window

### DIFF
--- a/packages/eslint-plugin-window-mock/index.js
+++ b/packages/eslint-plugin-window-mock/index.js
@@ -1,7 +1,7 @@
-const noDirectLocalStorage = require('./mock-window-only');
+const mockWindowOnly = require('./mock-window-only');
 
 module.exports = {
   rules: {
-    'mock-window-only': noDirectLocalStorage,
+    'mock-window-only': mockWindowOnly,
   },
 };

--- a/packages/eslint-plugin-window-mock/index.js
+++ b/packages/eslint-plugin-window-mock/index.js
@@ -1,0 +1,7 @@
+const noDirectLocalStorage = require('./mock-window-only');
+
+module.exports = {
+  rules: {
+    'mock-window-only': noDirectLocalStorage,
+  },
+};

--- a/packages/eslint-plugin-window-mock/mock-window-only.js
+++ b/packages/eslint-plugin-window-mock/mock-window-only.js
@@ -2,7 +2,7 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {
-      description: 'Disallow direct use of localStorage',
+      description: 'Enforce use of window mock localStorage',
       category: 'Best Practices',
       recommended: true,
     },
@@ -35,7 +35,7 @@ module.exports = {
           context.report({
             node,
             message:
-              'Use window.localStorage instead of directly accessing localStorage',
+              'Use ember-window-mock window.localStorage instead of directly accessing localStorage',
             fix(fixer) {
               const fixes = [fixer.insertTextBefore(node, 'window.')];
 

--- a/packages/eslint-plugin-window-mock/mock-window-only.js
+++ b/packages/eslint-plugin-window-mock/mock-window-only.js
@@ -1,0 +1,59 @@
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow direct use of localStorage',
+      category: 'Best Practices',
+      recommended: true,
+    },
+    fixable: 'code',
+    schema: [],
+  },
+  create(context) {
+    let importAdded = false;
+
+    return {
+      Program(node) {
+        importAdded = node.body.some(
+          (n) =>
+            n.type === 'ImportDeclaration' &&
+            n.source.value === 'ember-window-mock',
+        );
+      },
+      MemberExpression(node) {
+        if (
+          node.object.type === 'Identifier' &&
+          node.object.name === 'localStorage' &&
+          !context
+            .getAncestors()
+            .some(
+              (ancestor) =>
+                ancestor.type === 'MemberExpression' &&
+                ancestor.object.name === 'window',
+            )
+        ) {
+          context.report({
+            node,
+            message:
+              'Use window.localStorage instead of directly accessing localStorage',
+            fix(fixer) {
+              const fixes = [fixer.insertTextBefore(node, 'window.')];
+
+              if (!importAdded) {
+                fixes.unshift(
+                  fixer.insertTextBefore(
+                    context.getSourceCode().ast.body[0],
+                    "import window from 'ember-window-mock';\n",
+                  ),
+                );
+                importAdded = true;
+              }
+
+              return fixes;
+            },
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-window-mock/package.json
+++ b/packages/eslint-plugin-window-mock/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "eslint-plugin-window-mock",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/packages/host/.eslintrc.js
+++ b/packages/host/.eslintrc.js
@@ -22,7 +22,7 @@ module.exports = {
           ],
         },
       },
-      plugins: ['ember', '@typescript-eslint'],
+      plugins: ['ember', '@typescript-eslint', 'window-mock'],
       extends: [
         'eslint:recommended',
         'plugin:ember/recommended',
@@ -45,6 +45,7 @@ module.exports = {
         '@typescript-eslint/no-non-null-assertion': 'off',
         'no-undef': 'off',
         'ember/no-runloop': 'off',
+        'window-mock/mock-window-only': 'error',
       },
     },
     {
@@ -64,7 +65,7 @@ module.exports = {
         },
         warnOnUnsupportedTypeScriptVersion: false,
       },
-      plugins: ['ember'],
+      plugins: ['ember', 'window-mock'],
       extends: [
         'eslint:recommended',
         'plugin:@typescript-eslint/recommended',
@@ -92,6 +93,7 @@ module.exports = {
         'ember/no-runloop': 'off',
         'node/no-deprecated-api': 'off',
         'deprecation/deprecation': 'off',
+        'window-mock/mock-window-only': 'error',
       },
     },
     // node files

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -16,6 +16,7 @@ import perform from 'ember-concurrency/helpers/perform';
 import FromElseWhere from 'ember-elsewhere/components/from-elsewhere';
 
 import { provide } from 'ember-provide-consume-context';
+import window from 'ember-window-mock';
 
 import { Accordion } from '@cardstack/boxel-ui/components';
 
@@ -160,14 +161,14 @@ export default class CodeSubmode extends Component<Signature> {
   constructor(owner: Owner, args: Signature['Args']) {
     super(owner, args);
     this.operatorModeStateService.subscribeToOpenFileStateChanges(this);
-    this.panelWidths = localStorage.getItem(CodeModePanelWidths)
+    this.panelWidths = window.localStorage.getItem(CodeModePanelWidths)
       ? // @ts-ignore Type 'null' is not assignable to type 'string'
-        JSON.parse(localStorage.getItem(CodeModePanelWidths))
+        JSON.parse(window.localStorage.getItem(CodeModePanelWidths))
       : {};
 
-    this.panelHeights = localStorage.getItem(CodeModePanelHeights)
+    this.panelHeights = window.localStorage.getItem(CodeModePanelHeights)
       ? // @ts-ignore Type 'null' is not assignable to type 'string'
-        JSON.parse(localStorage.getItem(CodeModePanelHeights))
+        JSON.parse(window.localStorage.getItem(CodeModePanelHeights))
       : {};
 
     registerDestructor(this, () => {
@@ -504,7 +505,10 @@ export default class CodeSubmode extends Component<Signature> {
     this.panelWidths.codeEditorPanel = panels[1]?.lengthPx;
     this.panelWidths.rightPanel = panels[2]?.lengthPx;
 
-    localStorage.setItem(CodeModePanelWidths, JSON.stringify(this.panelWidths));
+    window.localStorage.setItem(
+      CodeModePanelWidths,
+      JSON.stringify(this.panelWidths),
+    );
   }
 
   @action
@@ -512,7 +516,7 @@ export default class CodeSubmode extends Component<Signature> {
     this.panelHeights.filePanel = panels[0]?.lengthPx;
     this.panelHeights.recentPanel = panels[1]?.lengthPx;
 
-    localStorage.setItem(
+    window.localStorage.setItem(
       CodeModePanelHeights,
       JSON.stringify(this.panelHeights),
     );

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -6,6 +6,7 @@ import { cached, tracked } from '@glimmer/tracking';
 import format from 'date-fns/format';
 
 import { task } from 'ember-concurrency';
+import window from 'ember-window-mock';
 import {
   type LoginResponse,
   type MatrixEvent,
@@ -890,16 +891,16 @@ export default class MatrixService
 }
 
 function saveAuth(auth: LoginResponse) {
-  localStorage.setItem('auth', JSON.stringify(auth));
+  window.localStorage.setItem('auth', JSON.stringify(auth));
 }
 
 function clearAuth() {
-  localStorage.removeItem('auth');
-  localStorage.removeItem(currentRoomIdPersistenceKey);
+  window.localStorage.removeItem('auth');
+  window.localStorage.removeItem(currentRoomIdPersistenceKey);
 }
 
 function getAuth(): LoginResponse | undefined {
-  let auth = localStorage.getItem('auth');
+  let auth = window.localStorage.getItem('auth');
   if (!auth) {
     return;
   }

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -136,6 +136,7 @@
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-qunit": "^8.0.1",
     "eslint-plugin-qunit-dom": "mainmatter/eslint-plugin-qunit-dom#d66c841",
+    "eslint-plugin-window-mock": "workspace:*",
     "ethers": "^6.6.2",
     "fast-json-stable-stringify": "^2.1.0",
     "filesize": "^10.0.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,7 +50,7 @@ importers:
         version: 4.0.0
       '@babel/core':
         specifier: ^7.24.3
-        version: 7.24.3
+        version: 7.24.3(supports-color@8.1.1)
       '@glimmer/component':
         specifier: ^1.1.2
         version: 1.1.2(@babel/core@7.24.3)
@@ -172,7 +172,7 @@ importers:
     devDependencies:
       '@babel/core':
         specifier: ^7.24.3
-        version: 7.24.3
+        version: 7.24.3(supports-color@8.1.1)
       '@cardstack/boxel-ui':
         specifier: workspace:*
         version: link:../boxel-ui/addon
@@ -272,7 +272,7 @@ importers:
     devDependencies:
       '@babel/core':
         specifier: ^7.24.3
-        version: 7.24.3
+        version: 7.24.3(supports-color@8.1.1)
       '@babel/plugin-proposal-decorators':
         specifier: ^7.22.10
         version: 7.22.10(@babel/core@7.24.3)
@@ -380,7 +380,7 @@ importers:
     devDependencies:
       '@babel/core':
         specifier: ^7.24.3
-        version: 7.24.3
+        version: 7.24.3(supports-color@8.1.1)
       '@babel/eslint-parser':
         specifier: ^7.23.10
         version: 7.23.10(@babel/core@7.24.3)(eslint@8.57.0)
@@ -684,7 +684,7 @@ importers:
     devDependencies:
       '@babel/core':
         specifier: ^7.24.3
-        version: 7.24.3
+        version: 7.24.3(supports-color@8.1.1)
       '@babel/plugin-proposal-decorators':
         specifier: ^7.22.10
         version: 7.22.10(@babel/core@7.24.3)
@@ -787,7 +787,7 @@ importers:
     devDependencies:
       '@babel/core':
         specifier: ^7.24.3
-        version: 7.24.3
+        version: 7.24.3(supports-color@8.1.1)
       '@babel/eslint-parser':
         specifier: ^7.22.15
         version: 7.23.10(@babel/core@7.24.3)(eslint@8.57.0)
@@ -999,6 +999,8 @@ importers:
         specifier: ^5.89.0
         version: 5.89.0
 
+  packages/eslint-plugin-window-mock: {}
+
   packages/experiments-realm:
     devDependencies:
       '@cardstack/boxel-ui':
@@ -1027,7 +1029,7 @@ importers:
     devDependencies:
       '@babel/core':
         specifier: ^7.24.3
-        version: 7.24.3
+        version: 7.24.3(supports-color@8.1.1)
       '@babel/plugin-proposal-decorators':
         specifier: ^7.23.2
         version: 7.24.1(@babel/core@7.24.3)
@@ -1343,6 +1345,9 @@ importers:
       eslint-plugin-qunit-dom:
         specifier: mainmatter/eslint-plugin-qunit-dom#d66c841
         version: github.com/mainmatter/eslint-plugin-qunit-dom/d66c841(eslint@8.57.0)
+      eslint-plugin-window-mock:
+        specifier: workspace:*
+        version: link:../eslint-plugin-window-mock
       ethers:
         specifier: ^6.6.2
         version: 6.6.2
@@ -1693,7 +1698,7 @@ importers:
         version: 7.17.12(@babel/core@7.24.3)
       '@babel/plugin-transform-class-properties':
         specifier: ^7.24.7
-        version: 7.24.7(@babel/core@7.24.3)
+        version: 7.24.7(@babel/core@7.24.3)(supports-color@8.1.1)
       '@babel/plugin-transform-modules-amd':
         specifier: ^7.13.0
         version: 7.13.0(@babel/core@7.24.3)
@@ -1823,7 +1828,7 @@ importers:
     devDependencies:
       '@babel/core':
         specifier: ^7.24.3
-        version: 7.24.3
+        version: 7.24.3(supports-color@8.1.1)
       '@glint/environment-ember-loose':
         specifier: 1.3.0
         version: 1.3.0(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0)
@@ -1893,7 +1898,7 @@ importers:
     devDependencies:
       '@babel/core':
         specifier: ^7.24.3
-        version: 7.24.3
+        version: 7.24.3(supports-color@8.1.1)
       '@ember/optional-features':
         specifier: ^2.0.0
         version: 2.0.0
@@ -2038,7 +2043,7 @@ importers:
     devDependencies:
       '@babel/core':
         specifier: ^7.24.3
-        version: 7.24.3
+        version: 7.24.3(supports-color@8.1.1)
       '@types/babel__core':
         specifier: ^7.1.19
         version: 7.1.19
@@ -2155,28 +2160,6 @@ packages:
     resolution: {integrity: sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==}
     engines: {node: '>=6.9.0'}
 
-  /@babel/core@7.24.3:
-    resolution: {integrity: sha512-5FcvN1JHw2sHJChotgx8Ek0lyuh4kCKelgMTTqhYJJtloNvUfpAFMeNQUtdlIaktwrSV9LtCdqwk48wL2wBacQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@ampproject/remapping': 2.2.1
-      '@babel/code-frame': 7.24.7
-      '@babel/generator': 7.24.10
-      '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.24.3)
-      '@babel/helpers': 7.24.1
-      '@babel/parser': 7.24.8
-      '@babel/template': 7.24.7
-      '@babel/traverse': 7.24.8(supports-color@8.1.1)
-      '@babel/types': 7.24.9
-      convert-source-map: 2.0.0
-      debug: 4.3.4(supports-color@8.1.1)
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
   /@babel/core@7.24.3(supports-color@8.1.1):
     resolution: {integrity: sha512-5FcvN1JHw2sHJChotgx8Ek0lyuh4kCKelgMTTqhYJJtloNvUfpAFMeNQUtdlIaktwrSV9LtCdqwk48wL2wBacQ==}
     engines: {node: '>=6.9.0'}
@@ -2206,7 +2189,7 @@ packages:
       '@babel/core': ^7.11.0
       eslint: ^7.5.0 || ^8.0.0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
       eslint: 8.57.0
       eslint-visitor-keys: 2.1.0
@@ -2282,7 +2265,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
@@ -2299,7 +2282,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
@@ -2309,25 +2292,6 @@ packages:
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       semver: 6.3.1
-
-  /@babel/helper-create-class-features-plugin@7.24.8(@babel/core@7.24.3):
-    resolution: {integrity: sha512-4f6Oqnmyp2PP3olgUMmOwC3akxSm5aBYraQ6YDdKy7NcAMkDECHWG0DEnV6M2UAkERgIBhYt8S27rURPg7SxWA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.24.3
-      '@babel/helper-annotate-as-pure': 7.24.7
-      '@babel/helper-environment-visitor': 7.24.7
-      '@babel/helper-function-name': 7.24.7
-      '@babel/helper-member-expression-to-functions': 7.24.8(supports-color@8.1.1)
-      '@babel/helper-optimise-call-expression': 7.24.7
-      '@babel/helper-replace-supers': 7.24.7(@babel/core@7.24.3)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7(supports-color@8.1.1)
-      '@babel/helper-split-export-declaration': 7.24.7
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
 
   /@babel/helper-create-class-features-plugin@7.24.8(@babel/core@7.24.3)(supports-color@8.1.1):
     resolution: {integrity: sha512-4f6Oqnmyp2PP3olgUMmOwC3akxSm5aBYraQ6YDdKy7NcAMkDECHWG0DEnV6M2UAkERgIBhYt8S27rURPg7SxWA==}
@@ -2347,7 +2311,6 @@ packages:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/helper-create-regexp-features-plugin@7.22.15(@babel/core@7.24.3):
     resolution: {integrity: sha512-29FkPLFjn4TPEa3RE7GpW+qbE8tlsu3jntNYNfcGsc49LphF1PQIiD+vMZ1z1xVOKt+93khA9tc2JBs3kBjA7w==}
@@ -2359,20 +2322,6 @@ packages:
       '@babel/helper-annotate-as-pure': 7.22.5
       regexpu-core: 5.3.2
       semver: 6.3.1
-
-  /@babel/helper-define-polyfill-provider@0.4.3(@babel/core@7.24.3):
-    resolution: {integrity: sha512-WBrLmuPP47n7PNwsZ57pqam6G/RGo1vw/87b0Blc53tZNGZ4x7YvZ6HgQe2vo1W/FR20OgjeZuGXzudPiXHFug==}
-    peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
-    dependencies:
-      '@babel/core': 7.24.3
-      '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-plugin-utils': 7.24.8
-      debug: 4.3.4(supports-color@8.1.1)
-      lodash.debounce: 4.0.8
-      resolve: 1.22.8
-    transitivePeerDependencies:
-      - supports-color
 
   /@babel/helper-define-polyfill-provider@0.4.3(@babel/core@7.24.3)(supports-color@8.1.1):
     resolution: {integrity: sha512-WBrLmuPP47n7PNwsZ57pqam6G/RGo1vw/87b0Blc53tZNGZ4x7YvZ6HgQe2vo1W/FR20OgjeZuGXzudPiXHFug==}
@@ -2387,7 +2336,6 @@ packages:
       resolve: 1.22.8
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/helper-environment-visitor@7.22.20:
     resolution: {integrity: sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==}
@@ -2473,7 +2421,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-simple-access': 7.22.5
@@ -2524,7 +2472,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-member-expression-to-functions': 7.23.0
       '@babel/helper-optimise-call-expression': 7.22.5
@@ -2535,23 +2483,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-member-expression-to-functions': 7.23.0
       '@babel/helper-optimise-call-expression': 7.22.5
-
-  /@babel/helper-replace-supers@7.24.7(@babel/core@7.24.3):
-    resolution: {integrity: sha512-qTAxxBM81VEyoAY0TtLrx1oAEJc09ZK67Q9ljQToqCnA+55eNwCORaxlKyu+rNfX86o8OXRUSNUnrtsAZXM9sg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.24.3
-      '@babel/helper-environment-visitor': 7.24.7
-      '@babel/helper-member-expression-to-functions': 7.24.8(supports-color@8.1.1)
-      '@babel/helper-optimise-call-expression': 7.24.7
-    transitivePeerDependencies:
-      - supports-color
 
   /@babel/helper-replace-supers@7.24.7(@babel/core@7.24.3)(supports-color@8.1.1):
     resolution: {integrity: sha512-qTAxxBM81VEyoAY0TtLrx1oAEJc09ZK67Q9ljQToqCnA+55eNwCORaxlKyu+rNfX86o8OXRUSNUnrtsAZXM9sg==}
@@ -2565,7 +2500,6 @@ packages:
       '@babel/helper-optimise-call-expression': 7.24.7
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/helper-simple-access@7.22.5:
     resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
@@ -2632,23 +2566,13 @@ packages:
       '@babel/template': 7.24.0
       '@babel/types': 7.24.9
 
-  /@babel/helpers@7.24.1:
-    resolution: {integrity: sha512-BpU09QqEe6ZCHuIHFphEFgvNSrubve1FtyMton26ekZ85gRGi6LrTF7zArARp2YvyFxloeiRmtSCq5sjh1WqIg==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/template': 7.24.0
-      '@babel/traverse': 7.24.1(supports-color@8.1.1)
-      '@babel/types': 7.24.0
-    transitivePeerDependencies:
-      - supports-color
-
   /@babel/helpers@7.24.1(supports-color@8.1.1):
     resolution: {integrity: sha512-BpU09QqEe6ZCHuIHFphEFgvNSrubve1FtyMton26ekZ85gRGi6LrTF7zArARp2YvyFxloeiRmtSCq5sjh1WqIg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.24.0
       '@babel/traverse': 7.24.1(supports-color@8.1.1)
-      '@babel/types': 7.24.9
+      '@babel/types': 7.24.0
     transitivePeerDependencies:
       - supports-color
 
@@ -2725,7 +2649,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.24.3)
       '@babel/helper-plugin-utils': 7.22.5
 
@@ -2735,7 +2659,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.24.3)
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/helper-replace-supers': 7.22.20(@babel/core@7.24.3)
@@ -2748,7 +2672,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-create-class-features-plugin': 7.24.1(@babel/core@7.24.3)
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/plugin-syntax-decorators': 7.24.1(@babel/core@7.24.3)
@@ -2760,7 +2684,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-create-class-features-plugin': 7.24.1(@babel/core@7.24.3)
       '@babel/helper-plugin-utils': 7.24.0
 
@@ -2779,9 +2703,9 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.24.7
-      '@babel/helper-create-class-features-plugin': 7.24.8(@babel/core@7.24.3)
+      '@babel/helper-create-class-features-plugin': 7.24.8(@babel/core@7.24.3)(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.3)
     transitivePeerDependencies:
@@ -2800,7 +2724,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.12.13
 
   /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.24.3):
@@ -2818,7 +2742,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-decorators@7.22.10(@babel/core@7.24.3):
@@ -2827,7 +2751,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-decorators@7.24.1(@babel/core@7.24.3):
@@ -2836,7 +2760,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.0
 
   /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.24.3):
@@ -2844,7 +2768,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.24.3):
@@ -2934,7 +2858,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.24.3):
@@ -2961,7 +2885,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-typescript@7.22.5(@babel/core@7.24.3):
@@ -2970,7 +2894,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.24.3):
@@ -3030,7 +2954,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-transform-class-properties@7.22.5(@babel/core@7.24.3):
@@ -3039,22 +2963,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.24.3)
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
-
-  /@babel/plugin-transform-class-properties@7.24.7(@babel/core@7.24.3):
-    resolution: {integrity: sha512-vKbfawVYayKcSeSR5YYzzyXvsDFWU2mD8U5TFeXtbCPLFUqe7GyCgvO6XDHzje862ODrOwy6WCPmKeWHbCFJ4w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.24.3
-      '@babel/helper-create-class-features-plugin': 7.24.8(@babel/core@7.24.3)
-      '@babel/helper-plugin-utils': 7.24.8
-    transitivePeerDependencies:
-      - supports-color
 
   /@babel/plugin-transform-class-properties@7.24.7(@babel/core@7.24.3)(supports-color@8.1.1):
     resolution: {integrity: sha512-vKbfawVYayKcSeSR5YYzzyXvsDFWU2mD8U5TFeXtbCPLFUqe7GyCgvO6XDHzje862ODrOwy6WCPmKeWHbCFJ4w==}
@@ -3067,7 +2979,6 @@ packages:
       '@babel/helper-plugin-utils': 7.24.8
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/plugin-transform-class-static-block@7.22.11(@babel/core@7.24.3):
     resolution: {integrity: sha512-GMM8gGmqI7guS/llMFk1bJDkKfn3v3C4KHK9Yg1ey5qcHcOlKb0QvcMrgzvxo+T03/4szNh5lghY+fEC98Kq9g==}
@@ -3075,7 +2986,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.12.0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-create-class-features-plugin': 7.24.1(@babel/core@7.24.3)
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.3)
@@ -3228,7 +3139,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-module-transforms': 7.18.9
       '@babel/helper-plugin-utils': 7.22.5
       babel-plugin-dynamic-import-node: 2.3.3
@@ -3241,7 +3152,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.24.3)
       '@babel/helper-plugin-utils': 7.24.0
 
@@ -3323,7 +3234,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
     dev: true
 
@@ -3366,7 +3277,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.3)
@@ -3377,7 +3288,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
 
   /@babel/plugin-transform-private-methods@7.22.5(@babel/core@7.24.3):
@@ -3436,12 +3347,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.24.8
-      babel-plugin-polyfill-corejs2: 0.4.6(@babel/core@7.24.3)
-      babel-plugin-polyfill-corejs3: 0.8.5(@babel/core@7.24.3)
-      babel-plugin-polyfill-regenerator: 0.5.3(@babel/core@7.24.3)
+      babel-plugin-polyfill-corejs2: 0.4.6(@babel/core@7.24.3)(supports-color@8.1.1)
+      babel-plugin-polyfill-corejs3: 0.8.5(@babel/core@7.24.3)(supports-color@8.1.1)
+      babel-plugin-polyfill-regenerator: 0.5.3(@babel/core@7.24.3)(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -3498,7 +3409,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-create-class-features-plugin': 7.24.1(@babel/core@7.24.3)
       '@babel/helper-plugin-utils': 7.24.8
@@ -3509,7 +3420,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.24.3)
 
@@ -3518,7 +3429,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-create-class-features-plugin': 7.24.1(@babel/core@7.24.3)
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.24.3)
@@ -3568,96 +3479,6 @@ packages:
     dependencies:
       core-js: 2.6.12
       regenerator-runtime: 0.13.11
-
-  /@babel/preset-env@7.23.2(@babel/core@7.24.3):
-    resolution: {integrity: sha512-BW3gsuDD+rvHL2VO2SjAUNTBe5YrjsTiDyqamPDWY723na3/yPQ65X5oQkFVJZ0o50/2d+svm1rkPoJeR1KxVQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/compat-data': 7.23.5
-      '@babel/core': 7.24.3
-      '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/helper-validator-option': 7.23.5
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.22.15(@babel/core@7.24.3)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.22.15(@babel/core@7.24.3)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.24.3)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.3)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.24.3)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.3)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.3)
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.24.3)
-      '@babel/plugin-syntax-import-assertions': 7.22.5(@babel/core@7.24.3)
-      '@babel/plugin-syntax-import-attributes': 7.22.5(@babel/core@7.24.3)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.24.3)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.3)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.3)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.3)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.3)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.3)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.3)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.3)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.3)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.24.3)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.24.3)
-      '@babel/plugin-transform-arrow-functions': 7.22.5(@babel/core@7.24.3)
-      '@babel/plugin-transform-async-generator-functions': 7.23.2(@babel/core@7.24.3)
-      '@babel/plugin-transform-async-to-generator': 7.22.5(@babel/core@7.24.3)
-      '@babel/plugin-transform-block-scoped-functions': 7.22.5(@babel/core@7.24.3)
-      '@babel/plugin-transform-block-scoping': 7.23.0(@babel/core@7.24.3)
-      '@babel/plugin-transform-class-properties': 7.24.7(@babel/core@7.24.3)
-      '@babel/plugin-transform-class-static-block': 7.22.11(@babel/core@7.24.3)
-      '@babel/plugin-transform-classes': 7.22.15(@babel/core@7.24.3)
-      '@babel/plugin-transform-computed-properties': 7.22.5(@babel/core@7.24.3)
-      '@babel/plugin-transform-destructuring': 7.23.0(@babel/core@7.24.3)
-      '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.24.3)
-      '@babel/plugin-transform-duplicate-keys': 7.22.5(@babel/core@7.24.3)
-      '@babel/plugin-transform-dynamic-import': 7.22.11(@babel/core@7.24.3)
-      '@babel/plugin-transform-exponentiation-operator': 7.22.5(@babel/core@7.24.3)
-      '@babel/plugin-transform-export-namespace-from': 7.22.11(@babel/core@7.24.3)
-      '@babel/plugin-transform-for-of': 7.22.15(@babel/core@7.24.3)
-      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.24.3)
-      '@babel/plugin-transform-json-strings': 7.22.11(@babel/core@7.24.3)
-      '@babel/plugin-transform-literals': 7.22.5(@babel/core@7.24.3)
-      '@babel/plugin-transform-logical-assignment-operators': 7.22.11(@babel/core@7.24.3)
-      '@babel/plugin-transform-member-expression-literals': 7.22.5(@babel/core@7.24.3)
-      '@babel/plugin-transform-modules-amd': 7.23.0(@babel/core@7.24.3)
-      '@babel/plugin-transform-modules-commonjs': 7.23.0(@babel/core@7.24.3)
-      '@babel/plugin-transform-modules-systemjs': 7.23.0(@babel/core@7.24.3)
-      '@babel/plugin-transform-modules-umd': 7.22.5(@babel/core@7.24.3)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.24.3)
-      '@babel/plugin-transform-new-target': 7.22.5(@babel/core@7.24.3)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.22.11(@babel/core@7.24.3)
-      '@babel/plugin-transform-numeric-separator': 7.22.11(@babel/core@7.24.3)
-      '@babel/plugin-transform-object-rest-spread': 7.22.15(@babel/core@7.24.3)
-      '@babel/plugin-transform-object-super': 7.22.5(@babel/core@7.24.3)
-      '@babel/plugin-transform-optional-catch-binding': 7.22.11(@babel/core@7.24.3)
-      '@babel/plugin-transform-optional-chaining': 7.23.0(@babel/core@7.24.3)
-      '@babel/plugin-transform-parameters': 7.22.15(@babel/core@7.24.3)
-      '@babel/plugin-transform-private-methods': 7.22.5(@babel/core@7.24.3)
-      '@babel/plugin-transform-private-property-in-object': 7.22.11(@babel/core@7.24.3)
-      '@babel/plugin-transform-property-literals': 7.22.5(@babel/core@7.24.3)
-      '@babel/plugin-transform-regenerator': 7.22.10(@babel/core@7.24.3)
-      '@babel/plugin-transform-reserved-words': 7.22.5(@babel/core@7.24.3)
-      '@babel/plugin-transform-shorthand-properties': 7.22.5(@babel/core@7.24.3)
-      '@babel/plugin-transform-spread': 7.22.5(@babel/core@7.24.3)
-      '@babel/plugin-transform-sticky-regex': 7.22.5(@babel/core@7.24.3)
-      '@babel/plugin-transform-template-literals': 7.22.5(@babel/core@7.24.3)
-      '@babel/plugin-transform-typeof-symbol': 7.22.5(@babel/core@7.24.3)
-      '@babel/plugin-transform-unicode-escapes': 7.22.10(@babel/core@7.24.3)
-      '@babel/plugin-transform-unicode-property-regex': 7.22.5(@babel/core@7.24.3)
-      '@babel/plugin-transform-unicode-regex': 7.22.5(@babel/core@7.24.3)
-      '@babel/plugin-transform-unicode-sets-regex': 7.22.5(@babel/core@7.24.3)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.24.3)
-      '@babel/types': 7.24.0
-      babel-plugin-polyfill-corejs2: 0.4.6(@babel/core@7.24.3)
-      babel-plugin-polyfill-corejs3: 0.8.5(@babel/core@7.24.3)
-      babel-plugin-polyfill-regenerator: 0.5.3(@babel/core@7.24.3)
-      core-js-compat: 3.33.0
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
 
   /@babel/preset-env@7.23.2(@babel/core@7.24.3)(supports-color@8.1.1):
     resolution: {integrity: sha512-BW3gsuDD+rvHL2VO2SjAUNTBe5YrjsTiDyqamPDWY723na3/yPQ65X5oQkFVJZ0o50/2d+svm1rkPoJeR1KxVQ==}
@@ -3748,7 +3569,6 @@ packages:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.24.3):
     resolution: {integrity: sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==}
@@ -4140,10 +3960,10 @@ packages:
       '@embroider/core': ^3.4.14
     dependencies:
       '@babel/code-frame': 7.24.2
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.3)
       '@babel/plugin-transform-runtime': 7.23.2(@babel/core@7.24.3)
-      '@babel/preset-env': 7.23.2(@babel/core@7.24.3)
+      '@babel/preset-env': 7.23.2(@babel/core@7.24.3)(supports-color@8.1.1)
       '@babel/runtime': 7.22.11
       '@babel/traverse': 7.24.1(supports-color@8.1.1)
       '@embroider/core': 3.4.14(@glint/template@1.3.0)
@@ -4193,7 +4013,7 @@ packages:
     resolution: {integrity: sha512-WVVKup9j1LzciQDL3jfvADJIyLTPe3+cWKzZwqwSnDkYIx2Nsq5a/drKcjJZPJtwU1ddbMpDnUVgGtOurN1VcA==}
     engines: {node: 12.* || 14.* || >= 16}
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/parser': 7.24.1
       '@babel/traverse': 7.24.1(supports-color@8.1.1)
       '@embroider/macros': 1.16.5(@glint/template@1.3.0)
@@ -5480,7 +5300,7 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-module-imports': 7.22.15
       '@rollup/pluginutils': 5.0.5(rollup@4.18.1)
       rollup: 4.18.1
@@ -7978,7 +7798,7 @@ packages:
       '@babel/core': ^7.0.0
       webpack: '>=2'
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       find-cache-dir: 3.3.2
       loader-utils: 2.0.4
       make-dir: 3.1.0
@@ -8031,7 +7851,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-beta.42
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       semver: 5.7.2
 
   /babel-plugin-debug-macros@0.3.4(@babel/core@7.24.3):
@@ -8040,7 +7860,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       semver: 5.7.2
 
   /babel-plugin-dynamic-import-node@2.3.3:
@@ -8123,18 +7943,6 @@ packages:
       resolve: 1.22.8
     dev: true
 
-  /babel-plugin-polyfill-corejs2@0.4.6(@babel/core@7.24.3):
-    resolution: {integrity: sha512-jhHiWVZIlnPbEUKSSNb9YoWcQGdlTLq7z1GHL4AjFxaoOUMuuEVJ+Y4pAaQUGOGk93YsVCKPbqbfw3m0SM6H8Q==}
-    peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
-    dependencies:
-      '@babel/compat-data': 7.23.5
-      '@babel/core': 7.24.3
-      '@babel/helper-define-polyfill-provider': 0.4.3(@babel/core@7.24.3)
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
   /babel-plugin-polyfill-corejs2@0.4.6(@babel/core@7.24.3)(supports-color@8.1.1):
     resolution: {integrity: sha512-jhHiWVZIlnPbEUKSSNb9YoWcQGdlTLq7z1GHL4AjFxaoOUMuuEVJ+Y4pAaQUGOGk93YsVCKPbqbfw3m0SM6H8Q==}
     peerDependencies:
@@ -8144,18 +7952,6 @@ packages:
       '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-define-polyfill-provider': 0.4.3(@babel/core@7.24.3)(supports-color@8.1.1)
       semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /babel-plugin-polyfill-corejs3@0.8.5(@babel/core@7.24.3):
-    resolution: {integrity: sha512-Q6CdATeAvbScWPNLB8lzSO7fgUVBkQt6zLgNlfyeCr/EQaEQR+bWiBYYPYAFyE528BMjRhL+1QBMOI4jc/c5TA==}
-    peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
-    dependencies:
-      '@babel/core': 7.24.3
-      '@babel/helper-define-polyfill-provider': 0.4.3(@babel/core@7.24.3)
-      core-js-compat: 3.33.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8169,17 +7965,6 @@ packages:
       core-js-compat: 3.33.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /babel-plugin-polyfill-regenerator@0.5.3(@babel/core@7.24.3):
-    resolution: {integrity: sha512-8sHeDOmXC8csczMrYEOf0UTNa4yE2SxV5JGeT/LP1n0OYVDUUFPxG9vdk2AlDlIit4t+Kf0xCtpgXPBwnn/9pw==}
-    peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
-    dependencies:
-      '@babel/core': 7.24.3
-      '@babel/helper-define-polyfill-provider': 0.4.3(@babel/core@7.24.3)
-    transitivePeerDependencies:
-      - supports-color
 
   /babel-plugin-polyfill-regenerator@0.5.3(@babel/core@7.24.3)(supports-color@8.1.1):
     resolution: {integrity: sha512-8sHeDOmXC8csczMrYEOf0UTNa4yE2SxV5JGeT/LP1n0OYVDUUFPxG9vdk2AlDlIit4t+Kf0xCtpgXPBwnn/9pw==}
@@ -8190,7 +7975,6 @@ packages:
       '@babel/helper-define-polyfill-provider': 0.4.3(@babel/core@7.24.3)(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /babel-plugin-syntax-async-functions@6.13.0:
     resolution: {integrity: sha512-4Zp4unmHgw30A1eWI5EpACji2qMocisdXhAftfhXoSV9j0Tvj6nRFE3tOmRY912E0FMRm/L5xWE7MGVT2FoLnw==}
@@ -8849,7 +8633,7 @@ packages:
     resolution: {integrity: sha512-6IXBgfRt7HZ61g67ssBc6lBb3Smw3DPZ9dEYirgtvXWpRZ2A9M22nxy6opEwJDgDJzlu/bB7ToppW33OFkA1gA==}
     engines: {node: '>= 6'}
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/polyfill': 7.12.1
       broccoli-funnel: 2.0.2
       broccoli-merge-trees: 3.0.2
@@ -8870,7 +8654,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.17.9
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       broccoli-persistent-filter: 3.1.3
       clone: 2.1.2
       hash-for-dep: 1.5.1
@@ -11449,8 +11233,8 @@ packages:
     resolution: {integrity: sha512-gLqML2k77AuUiXxWNon1FSzuG1DV7PEPpCLCU5aJvf6fdL6rmFfElsZRh+8ELEB/qP9dT+LHjNEunVzd2dYc8A==}
     engines: {node: '>= 10.*'}
     dependencies:
-      '@babel/core': 7.24.3
-      '@babel/preset-env': 7.23.2(@babel/core@7.24.3)
+      '@babel/core': 7.24.3(supports-color@8.1.1)
+      '@babel/preset-env': 7.23.2(@babel/core@7.24.3)(supports-color@8.1.1)
       '@babel/traverse': 7.24.0
       '@babel/types': 7.24.9
       '@embroider/shared-internals': 1.8.3
@@ -11488,12 +11272,12 @@ packages:
     resolution: {integrity: sha512-pkWIljmJClYL17YBk8FjO7NrZPQoY9v0b+FooJvaHf/xlDQIBYVP7OaDHbNuNbpj7+wAwSDAnnwxjCoLsmm4cw==}
     engines: {node: 12.* || 14.* || >= 16}
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/plugin-proposal-class-properties': 7.16.7(@babel/core@7.24.3)
       '@babel/plugin-proposal-decorators': 7.22.10(@babel/core@7.24.3)
       '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.24.3)
       '@babel/plugin-transform-class-static-block': 7.22.11(@babel/core@7.24.3)
-      '@babel/preset-env': 7.23.2(@babel/core@7.24.3)
+      '@babel/preset-env': 7.23.2(@babel/core@7.24.3)(supports-color@8.1.1)
       '@embroider/macros': 1.16.5(@glint/template@1.3.0)
       '@embroider/shared-internals': 2.5.2
       babel-loader: 8.3.0(@babel/core@7.24.3)(webpack@5.89.0)
@@ -11535,7 +11319,7 @@ packages:
       '@glimmer/tracking': ^1.1.2
       ember-source: ^3.28.0 || ^4.0.0 || >=5.0.0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@ember/test-helpers': 3.3.0(@glint/template@1.3.0)(ember-source@5.4.1)(webpack@5.89.0)
       '@embroider/addon-shim': 1.8.9
       '@embroider/macros': 1.16.5(@glint/template@1.3.0)
@@ -11598,7 +11382,7 @@ packages:
     resolution: {integrity: sha512-JJYeYjiz/JTn34q7F5DSOjkkZqy8qwFOOxXfE6pe9yEJqWGu4qErKxlz8I22JoVEQ/aBUO+OcKTpmctvykM9YA==}
     engines: {node: 6.* || 8.* || >= 10.*}
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/plugin-proposal-class-properties': 7.16.7(@babel/core@7.24.3)
       '@babel/plugin-proposal-decorators': 7.24.1(@babel/core@7.24.3)
@@ -11608,7 +11392,7 @@ packages:
       '@babel/plugin-transform-runtime': 7.23.2(@babel/core@7.24.3)
       '@babel/plugin-transform-typescript': 7.22.15(@babel/core@7.24.3)
       '@babel/polyfill': 7.12.1
-      '@babel/preset-env': 7.23.2(@babel/core@7.24.3)
+      '@babel/preset-env': 7.23.2(@babel/core@7.24.3)(supports-color@8.1.1)
       '@babel/runtime': 7.12.18
       amd-name-resolver: 1.3.1
       babel-plugin-debug-macros: 0.3.4(@babel/core@7.24.3)
@@ -11637,7 +11421,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.12.0
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/plugin-proposal-class-properties': 7.16.7(@babel/core@7.24.3)
       '@babel/plugin-proposal-decorators': 7.24.1(@babel/core@7.24.3)
@@ -11647,7 +11431,7 @@ packages:
       '@babel/plugin-transform-modules-amd': 7.23.0(@babel/core@7.24.3)
       '@babel/plugin-transform-runtime': 7.23.2(@babel/core@7.24.3)
       '@babel/plugin-transform-typescript': 7.22.15(@babel/core@7.24.3)
-      '@babel/preset-env': 7.23.2(@babel/core@7.24.3)
+      '@babel/preset-env': 7.23.2(@babel/core@7.24.3)(supports-color@8.1.1)
       '@babel/runtime': 7.12.18
       amd-name-resolver: 1.3.1
       babel-plugin-debug-macros: 0.3.4(@babel/core@7.24.3)
@@ -12129,7 +11913,7 @@ packages:
     engines: {node: 10.* || >= 12}
     hasBin: true
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/plugin-transform-modules-amd': 7.13.0(@babel/core@7.24.3)
       amd-name-resolver: 1.3.1
       babel-plugin-module-resolver: 4.1.0
@@ -12455,7 +12239,7 @@ packages:
     resolution: {integrity: sha512-gyUrjiSju4QwNrsCLbBpP0FL6VDFZaELNW7Kbcp60xXhjvNjncYgzm4zzYXhT+i1lLA6WEgRZ3lOGgyBORYD0w==}
     engines: {node: 12.* || 14.* || >= 16}
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       broccoli-funnel: 2.0.1
       ember-cli-babel: 7.26.11
       resolve: 1.22.8
@@ -12606,7 +12390,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/eslint-parser': 7.23.10(@babel/core@7.24.3)(eslint@8.57.0)
       '@glimmer/syntax': 0.92.0
       '@typescript-eslint/parser': 7.9.0(eslint@8.57.0)(typescript@5.1.6)
@@ -12625,7 +12409,7 @@ packages:
       ember-source: '>= 4.0.0'
       qunit: '*'
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       chalk: 5.3.0
       cli-table3: 0.6.3
       debug: 4.3.4(supports-color@8.1.1)
@@ -20008,7 +19792,7 @@ packages:
     peerDependencies:
       prettier: github:cardstack/prettier#glimmer-style-tag-in-template-support || 3.1.0-dev
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@glimmer/syntax': 0.84.3
       ember-cli-htmlbars: 6.3.0
       ember-template-imports: 3.4.2
@@ -20709,7 +20493,7 @@ packages:
   /remove-types@1.0.0:
     resolution: {integrity: sha512-G7Hk1Q+UJ5DvlNAoJZObxANkBZGiGdp589rVcTW/tYqJWJ5rwfraSnKSQaETN8Epaytw8J40nS/zC7bcHGv36w==}
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@babel/plugin-syntax-decorators': 7.24.1(@babel/core@7.24.3)
       '@babel/plugin-transform-typescript': 7.22.15(@babel/core@7.24.3)
       prettier: github.com/cardstack/prettier/60eccfdc598d682a931d3c569ffb0c4f92ef5db6
@@ -23710,7 +23494,7 @@ packages:
   /workerpool@3.1.2:
     resolution: {integrity: sha512-WJFA0dGqIK7qj7xPTqciWBH5DlJQzoPjsANvc3Y4hNB0SScT+Emjvt0jPPkDBUjBNngX1q9hHgt1Gfwytu6pug==}
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       object-assign: 4.1.1
       rsvp: 4.8.5
     transitivePeerDependencies:
@@ -24119,7 +23903,7 @@ packages:
     peerDependencies:
       ember-source: '>= 4.0.0'
     dependencies:
-      '@babel/core': 7.24.3
+      '@babel/core': 7.24.3(supports-color@8.1.1)
       '@ember/string': 3.1.1
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 4.2.0


### PR DESCRIPTION
This rule detects when `localStorage` is used in `host` without going through `ember-window-mock`, which should help prevent state leakage between tests. When used with `--fix` it adds the `window.` prefix and the necessary import; the code changes in `host` are the result of that.