### PR TITLE
host: Remove realm URLs from config

### DIFF
--- a/packages/host/app/components/pill-menu/usage.gts
+++ b/packages/host/app/components/pill-menu/usage.gts
@@ -11,8 +11,7 @@ import { TrackedObject } from 'tracked-built-ins';
 import { IconX } from '@cardstack/boxel-ui/icons';
 
 import { getPlural } from '@cardstack/runtime-common';
-
-import ENV from '@cardstack/host/config/environment';
+import { baseRealm } from '@cardstack/runtime-common/constants';
 
 import { getCard } from '@cardstack/host/resources/card-resource';
 
@@ -24,13 +23,15 @@ import PillMenu from './index';
 
 import type { PillMenuItem } from './index';
 
-const { ownRealmURL } = ENV;
-const sampleCardURLs = [`${ownRealmURL}Author/1`, `${ownRealmURL}BlogPost/1`];
+const sampleCardURLs = [
+  baseRealm.fileURL('Author/1'),
+  baseRealm.fileURL('BlogPost/1'),
+];
 
 export default class PillMenuUsage extends Component {
   headerIconURL = headerIcon;
   resources = sampleCardURLs.map((url) =>
-    getCard(this, () => url, {
+    getCard(this, () => url.toString(), {
       isLive: () => false,
     }),
   );

--- a/packages/host/app/config/environment.d.ts
+++ b/packages/host/app/config/environment.d.ts
@@ -11,17 +11,12 @@ declare const config: {
   locationType: 'history' | 'hash' | 'none' | 'auto';
   rootURL: string;
   APP: Record<string, unknown>;
-  ownRealmURL: string;
-  otherRealmURLs: string[];
-  initialRealmURLs: string[];
   matrixURL: string;
   matrixServerName: string;
   experimentalAIEnabled: boolean;
-  resolvedBaseRealmURL: string;
   hostsOwnAssets: boolean;
   realmsServed?: string[];
   logLevels: string;
-  resolvedOwnRealmURL: string;
   autoSaveDelayMs: number;
   monacoDebounceMs: number;
   monacoCursorDebounceMs: number;

--- a/packages/host/app/router.ts
+++ b/packages/host/app/router.ts
@@ -1,20 +1,11 @@
 import EmberRouter from '@ember/routing/router';
 import config from '@cardstack/host/config/environment';
-const { ownRealmURL, resolvedOwnRealmURL, hostsOwnAssets } = config;
+const { hostsOwnAssets } = config;
 
 export default class Router extends EmberRouter {
   location = config.locationType;
   rootURL = config.rootURL;
 }
-
-// When resolvedOwnRealmURL is available, that is actually the path in the browser.
-// It will not be available when running in fastboot.
-// When paths of resolvedOwnRealmURL and ownRealmURL are not symmetrical,
-// that means that means the resolvedOwnRealmURL should be used instead of ownRealmURL.
-let path = new URL(resolvedOwnRealmURL ?? ownRealmURL).pathname.replace(
-  /\/$/,
-  '',
-);
 
 Router.map(function () {
   this.route('host-freestyle', { path: '/_freestyle' });
@@ -25,7 +16,8 @@ Router.map(function () {
   // component exists to support the indexer
   this.route('acceptance-test-setup');
 
-  if (!path || hostsOwnAssets) {
+  // FIXME Removed reference to ownRealmURL, does it make sense?
+  if (hostsOwnAssets) {
     this.route('index-card', { path: '/' });
   }
 });

--- a/packages/host/app/routes/card.gts
+++ b/packages/host/app/routes/card.gts
@@ -20,7 +20,7 @@ import { CardDef } from 'https://cardstack.com/base/card-api';
 
 import type CardService from '../services/card-service';
 
-const { ownRealmURL, loginMessageTimeoutMs } = ENV;
+const { loginMessageTimeoutMs } = ENV;
 
 export type Model = CardDef | null;
 
@@ -59,13 +59,13 @@ export default class RenderCard extends Route<Model | null> {
     let { path, operatorModeState, operatorModeEnabled } = params;
     path = path || '';
     let url = path
-      ? new URL(`/${path}`, ownRealmURL)
-      : new URL('./', ownRealmURL);
+      ? new URL(`/${path}`, this.cardService.defaultURL)
+      : new URL('./', this.cardService.defaultURL);
 
     try {
       await this.loadMatrix.perform();
       let isPublicReadableRealm = await this.realmInfoService.isPublicReadable(
-        new URL(ownRealmURL),
+        new URL(this.cardService.defaultURL),
       );
       let model = null;
       if (!isPublicReadableRealm && !this.matrixService.isLoggedIn) {
@@ -99,7 +99,7 @@ export default class RenderCard extends Route<Model | null> {
       console.error(e);
       (e as any).loadType = params.operatorModeEnabled
         ? 'stack'
-        : url.href === ownRealmURL
+        : url.href === this.cardService.defaultURL.href
         ? 'index'
         : 'card';
       (e as any).operatorModeState = params.operatorModeState;
@@ -112,7 +112,7 @@ export default class RenderCard extends Route<Model | null> {
     // so users will be redirected to operator mode.
     // We can update the codes below after we have a clear idea on how to implement authentication in guest mode.
     let isPublicReadableRealm = await this.realmInfoService.isPublicReadable(
-      new URL(ownRealmURL),
+      new URL(this.cardService.defaultURL),
     );
     if (
       !isPublicReadableRealm &&
@@ -120,8 +120,8 @@ export default class RenderCard extends Route<Model | null> {
     ) {
       let path = transition.to?.params?.path ?? '';
       let url = path
-        ? new URL(`/${path}`, ownRealmURL)
-        : new URL('./', ownRealmURL);
+        ? new URL(`/${path}`, this.cardService.defaultURL)
+        : new URL('./', this.cardService.defaultURL);
       await this.router.replaceWith(`card`, {
         queryParams: {
           operatorModeEnabled: 'true',

--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -72,7 +72,7 @@ export default class CardService extends Service {
   // Note that this should be the unresolved URL and that we need to rely on our
   // fetch to do any URL resolution.
   get defaultURL(): URL {
-    return new URL(ownRealmURL);
+    return new URL(this.realmURLs[0]);
   }
 
   onSave(subscriber: CardSaveSubscriber) {

--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -42,7 +42,7 @@ export type CardSaveSubscriber = (
   content: SingleCardDocument | string,
 ) => void;
 
-const { ownRealmURL, environment, initialRealmURLs } = ENV;
+const { environment } = ENV;
 
 export default class CardService extends Service {
   @service private declare loaderService: LoaderService;
@@ -67,7 +67,7 @@ export default class CardService extends Service {
     return this.loaderToCardAPILoadingCache.get(loader)!;
   }
 
-  realmURLs = new TrackedArray(initialRealmURLs);
+  realmURLs = new TrackedArray<string>();
 
   // Note that this should be the unresolved URL and that we need to rely on our
   // fetch to do any URL resolution.
@@ -461,7 +461,7 @@ export default class CardService extends Service {
     // a new card instance that does not have a realm URL yet. For now let's
     // assume that the new card instance will reside in the realm that is hosting the app...
     // TODO change this after implementing CS-6381
-    return card[api.realmURL] ?? new URL(ownRealmURL);
+    return card[api.realmURL] ?? this.defaultURL;
   }
 
   async cardsSettled() {

--- a/packages/host/app/services/loader-service.ts
+++ b/packages/host/app/services/loader-service.ts
@@ -13,8 +13,7 @@ import {
 } from '@cardstack/runtime-common';
 import { Loader } from '@cardstack/runtime-common/loader';
 
-import config from '@cardstack/host/config/environment';
-
+import CardService from '@cardstack/host/services/card-service';
 import RealmInfoService from '@cardstack/host/services/realm-info-service';
 
 import { shimExternals } from '../lib/externals';
@@ -39,6 +38,7 @@ function getNativeFetch(): typeof fetch {
 }
 
 export default class LoaderService extends Service {
+  @service declare cardService: CardService;
   @service declare fastboot: { isFastBoot: boolean };
   @service declare realmInfoService: RealmInfoService;
   @service declare realm: RealmService;
@@ -66,7 +66,7 @@ export default class LoaderService extends Service {
     if (!this.fastboot.isFastBoot) {
       virtualNetwork.addURLMapping(
         new URL(baseRealm.url),
-        new URL(config.resolvedBaseRealmURL),
+        new this.cardService.defaultURL(),
       );
     }
     shimExternals(virtualNetwork);

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -21,12 +21,9 @@ import {
   SupportedMimeType,
 } from '@cardstack/runtime-common';
 
-import ENV from '@cardstack/host/config/environment';
-
+import type CardService from './card-service';
 import type LoaderService from './loader-service';
 import type MatrixService from './matrix-service';
-
-const { ownRealmURL } = ENV;
 
 interface Meta {
   info: RealmInfo;
@@ -38,6 +35,7 @@ type AuthStatus =
   | { type: 'anonymous' };
 
 class RealmResource {
+  @service declare cardService: CardService;
   @service private declare matrixService: MatrixService;
   @service declare loaderService: LoaderService;
 
@@ -286,7 +284,9 @@ export default class RealmService extends Service {
       .filter(([, i]) => i.canWrite)
       .sort(([, i], [, j]) => i.info.name.localeCompare(j.info.name));
 
-    let ownRealm = writeableRealms.find(([url]) => url === ownRealmURL);
+    let ownRealm = writeableRealms.find(
+      ([url]) => url === this.cardService.defaultURL,
+    );
     if (ownRealm) {
       return { path: ownRealm[0], info: ownRealm[1].info };
     } else {

--- a/packages/host/app/templates/card.gts
+++ b/packages/host/app/templates/card.gts
@@ -56,7 +56,7 @@ interface CardRouteSignature {
     model: CardModel | null;
   };
 }
-const { ownRealmURL } = ENV;
+
 @keyResponder
 class CardRouteComponent extends Component<CardRouteSignature> {
   isolatedCardComponent: ComponentLike | undefined;
@@ -121,7 +121,7 @@ class CardRouteComponent extends Component<CardRouteSignature> {
     // Users are not allowed to open guest mode
     // if realm is not publicly readable
     let isPublicReadableRealm = await this.realmInfoService.isPublicReadable(
-      new URL(ownRealmURL),
+      new URL(this.cardService.defaultURL),
     );
     if (!isPublicReadableRealm && this.args.controller.operatorModeEnabled) {
       return;
@@ -162,7 +162,9 @@ class CardRouteComponent extends Component<CardRouteSignature> {
   private fetchIsPublicReadableStatus = trackedFunction(
     this,
     async () =>
-      await this.realmInfoService.isPublicReadable(new URL(ownRealmURL)),
+      await this.realmInfoService.isPublicReadable(
+        new URL(this.cardService.defaultURL),
+      ),
   );
 
   <template>

--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -41,26 +41,7 @@ module.exports = function (environment) {
     loginMessageTimeoutMs: 1000,
     minSaveTaskDurationMs: 1000,
 
-    // the fields below may be rewritten by the realm server
-    // FIXME remove outdated realm URL properiets
-    initialRealmURLs: [process.env.OWN_REALM_URL || 'http://localhost:4200/'],
-    ownRealmURL:
-      environment === 'test'
-        ? 'http://test-realm/test/'
-        : process.env.OWN_REALM_URL || 'http://localhost:4200/', // this should be provided as an *unresolved* URL
-    // This is temporary until we have a better way to discover realms besides
-    // our own
-    otherRealmURLs:
-      environment !== 'test' && process.env.OTHER_REALM_URLS
-        ? process.env.OTHER_REALM_URLS.split(',').map((u) => u.trim())
-        : [],
     hostsOwnAssets: true,
-    resolvedBaseRealmURL:
-      process.env.RESOLVED_BASE_REALM_URL || 'http://localhost:4201/base/',
-    resolvedOwnRealmURL:
-      environment === 'test'
-        ? 'http://test-realm/test/'
-        : process.env.OWN_REALM_URL || 'http://localhost:4200/',
     featureFlags: {},
   };
 

--- a/packages/host/tests/unit/index-query-engine-test.ts
+++ b/packages/host/tests/unit/index-query-engine-test.ts
@@ -27,7 +27,6 @@ let date: typeof import('https://cardstack.com/base/date');
 let number: typeof import('https://cardstack.com/base/number');
 let boolean: typeof import('https://cardstack.com/base/boolean');
 let codeRef: typeof import('https://cardstack.com/base/code-ref');
-let { resolvedBaseRealmURL } = ENV;
 
 module('Unit | query', function (hooks) {
   let dbAdapter: SQLiteAdapter;
@@ -43,7 +42,7 @@ module('Unit | query', function (hooks) {
     let virtualNetwork = new VirtualNetwork();
     virtualNetwork.addURLMapping(
       new URL(baseRealm.url),
-      new URL(resolvedBaseRealmURL),
+      new URL('http://example.com/FIXME what should go here?'),
     );
     shimExternals(virtualNetwork);
     let fetch = fetcher(virtualNetwork.fetch, [

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -807,8 +807,6 @@ export class Realm {
       (_match, g1, g2, g3) => {
         let config = JSON.parse(decodeURIComponent(g2));
         config = merge({}, config, {
-          ownRealmURL: this.url, // unresolved url
-          resolvedOwnRealmURL: this.url,
           hostsOwnAssets: !isNode,
           realmsServed: opts?.realmsServed,
           assetsURL: this.#assetsURL.href,


### PR DESCRIPTION
This is broken off from #1490, which was almost fully working but didn’t actually remove these hard-coded URLs. `defaultURL` and other getters are widely used within the application but the behaviour in the absence of realm URLs on startup needs more thought.