### PR TITLE
Make sure to register queue handlers before starting queue

### DIFF
--- a/packages/host/app/lib/browser-queue.ts
+++ b/packages/host/app/lib/browser-queue.ts
@@ -42,9 +42,6 @@ export class BrowserQueue implements Queue {
   }
 
   register<A, T>(category: string, handler: (arg: A) => Promise<T>) {
-    if (!this.#hasStarted) {
-      throw new Error(`Cannot register category on unstarted Queue`);
-    }
     if (this.isDestroyed) {
       throw new Error(`Cannot register category on a destroyed Queue`);
     }
@@ -53,9 +50,6 @@ export class BrowserQueue implements Queue {
   }
 
   async publish<T>(category: string, arg: PgPrimitive): Promise<Job<T>> {
-    if (!this.#hasStarted) {
-      throw new Error(`Cannot publish job on unstarted Queue`);
-    }
     if (this.isDestroyed) {
       throw new Error(`Cannot publish job on a destroyed Queue`);
     }

--- a/packages/runtime-common/worker.ts
+++ b/packages/runtime-common/worker.ts
@@ -161,11 +161,11 @@ export class Worker {
   }
 
   async run() {
-    await this.#queue.start();
     await Promise.all([
       this.#queue.register(`from-scratch-index`, this.fromScratch),
       this.#queue.register(`incremental-index`, this.incremental),
     ]);
+    await this.#queue.start();
   }
 
   private async prepareAndRunJob<T>(


### PR DESCRIPTION
Fixes issue in staging where we start the queue before we have registered handlers, based on the error that we see in ECS:

![image](https://github.com/user-attachments/assets/8f9b6b06-27c2-477a-9f45-2489ff9a2437)

As part of this I removed assertions in our browser-queue used for testing that aren't actually observed by the real pg-queue.