### PR TITLE
Reduce jank in overlay display

### DIFF
--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -218,36 +218,39 @@ export function getBoxComponent(
               as |c displayContainer|
             }}
               {{#if (isCard model.value)}}
-                <DefaultFormatsProvider
-                  @value={{defaultFieldFormats effectiveFormats.cardDef}}
-                >
-                  <CardContainer
-                    @displayBoundaries={{displayContainer}}
-                    class='field-component-card
-                      {{effectiveFormats.cardDef}}-format display-container-{{displayContainer}}'
-                    {{context.cardComponentModifier
-                      card=model.value
-                      format=effectiveFormats.cardDef
-                      fieldType=field.fieldType
-                      fieldName=field.name
-                    }}
-                    data-test-card-format={{effectiveFormats.cardDef}}
-                    data-test-field-component-card
-                    {{! @glint-ignore  Argument of type 'unknown' is not assignable to parameter of type 'Element'}}
-                    ...attributes
+                {{#let model.value as |card|}}
+                  <DefaultFormatsProvider
+                    @value={{defaultFieldFormats effectiveFormats.cardDef}}
                   >
-                    <c.CardOrFieldFormatComponent
-                      @cardOrField={{cardOrField}}
-                      @model={{model.value}}
-                      @fields={{c.fields}}
-                      @format={{effectiveFormats.cardDef}}
-                      @set={{model.set}}
-                      @fieldName={{model.name}}
-                      @context={{context}}
-                      @canEdit={{permissions.canWrite}}
-                    />
-                  </CardContainer>
-                </DefaultFormatsProvider>
+                    <CardContainer
+                      @displayBoundaries={{displayContainer}}
+                      class='field-component-card
+                        {{effectiveFormats.cardDef}}-format display-container-{{displayContainer}}'
+                      {{context.cardComponentModifier
+                        card=card
+                        format=effectiveFormats.cardDef
+                        fieldType=field.fieldType
+                        fieldName=field.name
+                      }}
+                      data-test-card={{card.id}}
+                      data-test-card-format={{effectiveFormats.cardDef}}
+                      data-test-field-component-card
+                      {{! @glint-ignore  Argument of type 'unknown' is not assignable to parameter of type 'Element'}}
+                      ...attributes
+                    >
+                      <c.CardOrFieldFormatComponent
+                        @cardOrField={{cardOrField}}
+                        @model={{card}}
+                        @fields={{c.fields}}
+                        @format={{effectiveFormats.cardDef}}
+                        @set={{model.set}}
+                        @fieldName={{model.name}}
+                        @context={{context}}
+                        @canEdit={{permissions.canWrite}}
+                      />
+                    </CardContainer>
+                  </DefaultFormatsProvider>
+                {{/let}}
               {{else if (isCompoundField model.value)}}
                 <DefaultFormatsProvider
                   @value={{defaultFieldFormats effectiveFormats.fieldDef}}

--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -63,141 +63,122 @@ export default class OperatorModeOverlays extends Component<Signature> {
         (this.isSelected renderedCard.cardDefOrId)
         as |cardDefOrId cardId isSelected|
       }}
-        <div
-          class={{cn
-            'actions-overlay'
-            selected=isSelected
-            hovered=(this.isHovered renderedCard)
-          }}
-          {{velcro renderedCard.element middleware=(Array this.offset)}}
-          data-test-overlay-selected={{if
-            isSelected
-            (removeFileExtension cardId)
-          }}
-          data-test-overlay-card={{removeFileExtension cardId}}
-          style={{this.zIndexStyle renderedCard.element}}
-          {{on 'mouseenter' (fn this.setCurrentlyHoveredCard renderedCard)}}
-          {{on 'mouseleave' (fn this.setCurrentlyHoveredCard null)}}
-          ...attributes
-        >
-          <div class={{cn 'actions' field=(this.isField renderedCard)}}>
-            {{#if (this.isButtonDisplayed 'select' renderedCard)}}
-              <div class='actions-item select'>
-                <IconButton
-                  class='actions-item__button'
-                  {{! @glint-ignore (glint thinks toggleSelect is not in this scope but it actually is - we check for it in the condition above) }}
-                  {{on 'click' (fn @toggleSelect cardDefOrId)}}
-                  @width='100%'
-                  @height='100%'
-                  @icon={{if isSelected IconCircleSelected IconCircle}}
-                  aria-label='select card'
-                  data-test-overlay-select={{(removeFileExtension cardId)}}
-                />
-              </div>
-            {{/if}}
-            {{#if
-              (or
-                (this.isButtonDisplayed 'edit' renderedCard)
-                (this.isButtonDisplayed 'more-options' renderedCard)
-              )
+        {{#if (or isSelected (this.isHovered renderedCard))}}
+          <div
+            class={{cn
+              'actions-overlay'
+              selected=isSelected
+              hovered=(this.isHovered renderedCard)
             }}
-              <div class='actions-item'>
-                {{#if (this.isButtonDisplayed 'edit' renderedCard)}}
+            {{velcro renderedCard.element middleware=(Array this.offset)}}
+            data-test-overlay-selected={{if
+              isSelected
+              (removeFileExtension cardId)
+            }}
+            data-test-overlay-card={{removeFileExtension cardId}}
+            style={{renderedCard.overlayZIndexStyle}}
+            ...attributes
+          >
+            <div class={{cn 'actions' field=(this.isField renderedCard)}}>
+              {{#if (this.isButtonDisplayed 'select' renderedCard)}}
+                <div class='actions-item select'>
                   <IconButton
-                    @icon={{IconPencil}}
+                    class='actions-item__button'
+                    {{! @glint-ignore (glint thinks toggleSelect is not in this scope but it actually is - we check for it in the condition above) }}
+                    {{on 'click' (fn @toggleSelect cardDefOrId)}}
                     @width='100%'
                     @height='100%'
-                    class='actions-item__button'
-                    aria-label='Edit'
-                    data-test-overlay-edit
-                    {{on
-                      'click'
-                      (fn
-                        this.openOrSelectCard
-                        cardDefOrId
-                        'edit'
-                        renderedCard.fieldType
-                        renderedCard.fieldName
-                      )
-                    }}
+                    @icon={{if isSelected IconCircleSelected IconCircle}}
+                    aria-label='select card'
+                    data-test-overlay-select={{(removeFileExtension cardId)}}
                   />
-                {{/if}}
-                {{#if (this.isButtonDisplayed 'more-options' renderedCard)}}
-                  <div>
-                    <BoxelDropdown
-                      @registerAPI={{(this.registerDropdownAPI renderedCard)}}
+                </div>
+              {{/if}}
+              {{#if
+                (or
+                  (this.isButtonDisplayed 'edit' renderedCard)
+                  (this.isButtonDisplayed 'more-options' renderedCard)
+                )
+              }}
+                <div class='actions-item'>
+                  {{#if (this.isButtonDisplayed 'edit' renderedCard)}}
+                    <IconButton
+                      @icon={{IconPencil}}
+                      @width='100%'
+                      @height='100%'
+                      class='actions-item__button'
+                      aria-label='Edit'
+                      data-test-overlay-edit
                       {{on
-                        'mouseenter'
-                        (fn this.setCurrentlyHoveredCard renderedCard)
+                        'click'
+                        (fn
+                          this.openOrSelectCard
+                          cardDefOrId
+                          'edit'
+                          renderedCard.fieldType
+                          renderedCard.fieldName
+                        )
                       }}
-                      {{on 'mouseleave' (fn this.setCurrentlyHoveredCard null)}}
-                    >
-                      <:trigger as |bindings|>
-                        <Tooltip @placement='top'>
-                          <:trigger>
-                            <IconButton
-                              @icon={{ThreeDotsHorizontal}}
-                              @width='100%'
-                              @height='100%'
-                              class='actions-item__button'
-                              aria-label='Options'
-                              data-test-overlay-more-options
-                              {{bindings}}
+                    />
+                  {{/if}}
+                  {{#if (this.isButtonDisplayed 'more-options' renderedCard)}}
+                    <div>
+                      <BoxelDropdown
+                        @registerAPI={{(this.registerDropdownAPI renderedCard)}}
+                      >
+                        <:trigger as |bindings|>
+                          <Tooltip @placement='top'>
+                            <:trigger>
+                              <IconButton
+                                @icon={{ThreeDotsHorizontal}}
+                                @width='100%'
+                                @height='100%'
+                                class='actions-item__button'
+                                aria-label='Options'
+                                data-test-overlay-more-options
+                                {{bindings}}
+                              />
+                            </:trigger>
+                            <:content>
+                              More Options
+                            </:content>
+                          </Tooltip>
+                        </:trigger>
+                        <:content as |dd|>
+                          {{#if (this.isMenuDisplayed 'view' renderedCard)}}
+                            <Menu
+                              @closeMenu={{dd.close}}
+                              @items={{array
+                                (menuItem
+                                  'View card'
+                                  (fn this.openOrSelectCard cardDefOrId)
+                                )
+                              }}
                             />
-                          </:trigger>
-                          <:content>
-                            More Options
-                          </:content>
-                        </Tooltip>
-                      </:trigger>
-                      <:content as |dd|>
-                        {{#if (this.isMenuDisplayed 'view' renderedCard)}}
-                          <Menu
-                            @closeMenu={{dd.close}}
-                            @items={{array
-                              (menuItem
-                                'View card'
-                                (fn this.openOrSelectCard cardDefOrId)
-                              )
-                            }}
-                            {{on
-                              'mouseenter'
-                              (fn this.setCurrentlyHoveredCard renderedCard)
-                            }}
-                            {{on
-                              'mouseleave'
-                              (fn this.setCurrentlyHoveredCard null)
-                            }}
-                          />
-                        {{else if (this.isMenuDisplayed 'delete' renderedCard)}}
-                          <Menu
-                            @closeMenu={{dd.close}}
-                            @items={{array
-                              (menuItem
-                                'Delete'
-                                (fn @publicAPI.delete cardDefOrId)
-                                icon=IconTrash
-                                dangerous=true
-                              )
-                            }}
-                            {{on
-                              'mouseenter'
-                              (fn this.setCurrentlyHoveredCard renderedCard)
-                            }}
-                            {{on
-                              'mouseleave'
-                              (fn this.setCurrentlyHoveredCard null)
-                            }}
-                          />
-                        {{/if}}
-                      </:content>
-                    </BoxelDropdown>
-                  </div>
-                {{/if}}
-              </div>
-            {{/if}}
+                          {{else if
+                            (this.isMenuDisplayed 'delete' renderedCard)
+                          }}
+                            <Menu
+                              @closeMenu={{dd.close}}
+                              @items={{array
+                                (menuItem
+                                  'Delete'
+                                  (fn @publicAPI.delete cardDefOrId)
+                                  icon=IconTrash
+                                  dangerous=true
+                                )
+                              }}
+                            />
+                          {{/if}}
+                        </:content>
+                      </BoxelDropdown>
+                    </div>
+                  {{/if}}
+                </div>
+              {{/if}}
+            </div>
           </div>
-        </div>
+        {{/if}}
       {{/let}}
     {{/each}}
     <style>
@@ -401,12 +382,23 @@ export default class OperatorModeOverlays extends Component<Signature> {
       renderedCard.element.addEventListener(
         'mouseenter',
         // eslint-disable-next-line ember/no-side-effects
-        (_e: MouseEvent) => this.setCurrentlyHoveredCard(renderedCard),
+        (_ev: MouseEvent) => {
+          if (this.currentlyHoveredCard === renderedCard) {
+            return;
+          }
+          this.setCurrentlyHoveredCard(renderedCard);
+        },
       );
       renderedCard.element.addEventListener(
         'mouseleave',
         // eslint-disable-next-line ember/no-side-effects
-        (_e: MouseEvent) => this.setCurrentlyHoveredCard(null),
+        (ev: MouseEvent) => {
+          let relatedTarget = ev.relatedTarget as HTMLElement;
+          if (relatedTarget?.closest?.('.actions-overlay')) {
+            return;
+          }
+          this.setCurrentlyHoveredCard(null);
+        },
       );
       renderedCard.element.addEventListener('click', (e: MouseEvent) => {
         // prevent outer nested contains fields from triggering when inner most
@@ -420,6 +412,7 @@ export default class OperatorModeOverlays extends Component<Signature> {
         );
       });
       renderedCard.element.style.cursor = 'pointer';
+      renderedCard.overlayZIndexStyle = this.zIndexStyle(renderedCard.element);
     }
 
     return renderedCards;

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -110,6 +110,7 @@ export interface RenderedCardForOverlayActions {
   fieldName: string | undefined;
   format: Format | 'data';
   stackItem: StackItem;
+  overlayZIndexStyle?: SafeString;
 }
 
 export default class OperatorModeStackItem extends Component<Signature> {
@@ -560,7 +561,6 @@ export default class OperatorModeStackItem extends Component<Signature> {
               @publicAPI={{@publicAPI}}
               @toggleSelect={{this.toggleSelect}}
               @selectedCards={{this.selectedCards}}
-              class={{if @item.isWideFormat 'delay'}}
             />
           </div>
         {{/if}}
@@ -734,9 +734,6 @@ export default class OperatorModeStackItem extends Component<Signature> {
         display: flex;
         justify: center;
         align-items: center;
-      }
-      .delay {
-        transition: all var(--boxel-transition);
       }
     </style>
   </template>

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -818,6 +818,10 @@ module('Acceptance | interact submode tests', function (hooks) {
           ],
         ],
       });
+      await triggerEvent(
+        `[data-test-stack-card="${testRealm2URL}Person/hassan"] [data-test-links-to-editor="pet"] [data-test-field-component-card]`,
+        'mouseenter',
+      );
       assert
         .dom(
           `[data-test-overlay-card="${testRealmURL}Pet/mango"] [data-test-overlay-edit]`,
@@ -1054,6 +1058,10 @@ module('Acceptance | interact submode tests', function (hooks) {
           ],
         ],
       });
+      await triggerEvent(
+        `[data-test-stack-card="${testRealm2URL}Person/hassan"] [data-test-links-to-editor="pet"] [data-test-field-component-card]`,
+        'mouseenter',
+      );
       assert
         .dom(`[data-test-overlay-card="${testRealmURL}Pet/mango"]`)
         .exists();

--- a/packages/host/tests/integration/components/ai-assistant-panel-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel-test.gts
@@ -556,6 +556,10 @@ module('Integration | ai-assistant-panel', function (hooks) {
     assert.dom('[data-test-command-apply]').doesNotExist();
     assert.dom('[data-test-person]').hasText('Fadhlan');
 
+    await triggerEvent(
+      `[data-test-stack-card="${testRealmURL}Person/fadhlan"] [data-test-field-component-card][data-test-card-format="fitted"]`,
+      'mouseenter',
+    );
     await waitFor('[data-test-overlay-card] [data-test-overlay-more-options]');
     await percySnapshot(
       'Integration | ai-assistant-panel | it only applies changes from the chat if the stack contains a card with that ID | error',
@@ -574,12 +578,13 @@ module('Integration | ai-assistant-panel', function (hooks) {
     assert.dom('[data-test-command-apply]').doesNotExist();
     assert.dom('[data-test-ai-bot-retry-button]').doesNotExist();
 
-    await waitUntil(
-      () =>
-        document.querySelectorAll(
-          '[data-test-overlay-card] [data-test-overlay-more-options]',
-        ).length === 2,
+    await triggerEvent(
+      `[data-test-stack-card="${testRealmURL}Person/burcu"] [data-test-plural-view="linksToMany"] [data-test-plural-view-item="0"]`,
+      'mouseenter',
     );
+    assert
+      .dom('[data-test-overlay-card] [data-test-overlay-more-options]')
+      .exists();
     await percySnapshot(
       'Integration | ai-assistant-panel | it only applies changes from the chat if the stack contains a card with that ID | error fixed',
     );

--- a/packages/host/tests/integration/components/card-copy-test.gts
+++ b/packages/host/tests/integration/components/card-copy-test.gts
@@ -1,4 +1,4 @@
-import { waitUntil, waitFor, click } from '@ember/test-helpers';
+import { waitUntil, waitFor, click, triggerEvent } from '@ember/test-helpers';
 
 import { buildWaiter } from '@ember/test-waiters';
 import GlimmerComponent from '@glimmer/component';
@@ -307,6 +307,10 @@ module('Integration | card-copy', function (hooks) {
       '[data-test-operator-mode-stack="0"] [data-test-cards-grid-item]',
     );
 
+    await triggerEvent(
+      `[data-test-cards-grid-item="${testRealmURL}Person/hassan"]`,
+      'mouseenter',
+    );
     await click(
       `[data-test-overlay-card="${testRealmURL}Person/hassan"] button.actions-item__button`,
     );
@@ -352,14 +356,16 @@ module('Integration | card-copy', function (hooks) {
         </template>
       },
     );
-    await waitFor(
-      '[data-test-operator-mode-stack="0"] [data-test-cards-grid-item]',
-    );
-    await waitFor(
-      '[data-test-operator-mode-stack="1"] [data-test-cards-grid-item]',
+    await triggerEvent(
+      `[data-test-cards-grid-item="${testRealmURL}Person/hassan"]`,
+      'mouseenter',
     );
     await click(
       `[data-test-overlay-card="${testRealmURL}Person/hassan"] button.actions-item__button`,
+    );
+    await triggerEvent(
+      `[data-test-cards-grid-item="${testRealm2URL}Pet/paper"]`,
+      'mouseenter',
     );
     await click(
       `[data-test-overlay-card="${testRealm2URL}Pet/paper"] button.actions-item__button`,
@@ -382,11 +388,9 @@ module('Integration | card-copy', function (hooks) {
         </template>
       },
     );
-    await waitFor(
-      '[data-test-operator-mode-stack="0"] [data-test-cards-grid-item]',
-    );
-    await waitFor(
-      '[data-test-operator-mode-stack="1"] [data-test-cards-grid-item]',
+    await triggerEvent(
+      `[data-test-cards-grid-item="${testRealmURL}Person/hassan"]`,
+      'mouseenter',
     );
     await click(
       `[data-test-operator-mode-stack="0"] [data-test-overlay-card="${testRealmURL}Person/hassan"] button.actions-item__button`,
@@ -429,11 +433,9 @@ module('Integration | card-copy', function (hooks) {
         </template>
       },
     );
-    await waitFor(
-      '[data-test-operator-mode-stack="0"] [data-test-cards-grid-item]',
-    );
-    await waitFor(
-      '[data-test-operator-mode-stack="1"] [data-test-cards-grid-item]',
+    await triggerEvent(
+      `[data-test-cards-grid-item="${testRealmURL}Person/hassan"]`,
+      'mouseenter',
     );
     await click(
       `[data-test-operator-mode-stack="0"] [data-test-overlay-card="${testRealmURL}Person/hassan"] button.actions-item__button`,
@@ -456,11 +458,9 @@ module('Integration | card-copy', function (hooks) {
         </template>
       },
     );
-    await waitFor(
-      '[data-test-operator-mode-stack="0"] [data-test-cards-grid-item]',
-    );
-    await waitFor(
-      '[data-test-operator-mode-stack="1"] [data-test-cards-grid-item]',
+    await triggerEvent(
+      `[data-test-cards-grid-item="${testRealmURL}Person/hassan"]`,
+      'mouseenter',
     );
     await click(
       `[data-test-overlay-card="${testRealmURL}Person/hassan"] button.actions-item__button`,
@@ -486,11 +486,9 @@ module('Integration | card-copy', function (hooks) {
         </template>
       },
     );
-    await waitFor(
-      '[data-test-operator-mode-stack="0"] [data-test-cards-grid-item]',
-    );
-    await waitFor(
-      '[data-test-operator-mode-stack="1"] [data-test-cards-grid-item]',
+    await triggerEvent(
+      `[data-test-cards-grid-item="${testRealm2URL}Pet/paper"]`,
+      'mouseenter',
     );
     await click(
       ` [data-test-overlay-card="${testRealm2URL}Pet/paper"] button.actions-item__button`,
@@ -516,17 +514,23 @@ module('Integration | card-copy', function (hooks) {
         </template>
       },
     );
-    await waitFor(
-      '[data-test-operator-mode-stack="0"] [data-test-cards-grid-item]',
-    );
-    await waitFor(
-      '[data-test-operator-mode-stack="1"] [data-test-cards-grid-item]',
+    await triggerEvent(
+      `[data-test-cards-grid-item="${testRealmURL}Person/hassan"]`,
+      'mouseenter',
     );
     await click(
       `[data-test-overlay-card="${testRealmURL}Person/hassan"] button.actions-item__button`,
     );
+    await triggerEvent(
+      `[data-test-cards-grid-item="${testRealmURL}Pet/mango"]`,
+      'mouseenter',
+    );
     await click(
       `[data-test-overlay-card="${testRealmURL}Pet/mango"] button.actions-item__button`,
+    );
+    await triggerEvent(
+      `[data-test-cards-grid-item="${testRealmURL}Pet/vangogh"]`,
+      'mouseenter',
     );
     await click(
       `[data-test-overlay-card="${testRealmURL}Pet/vangogh"] button.actions-item__button`,
@@ -638,11 +642,9 @@ module('Integration | card-copy', function (hooks) {
         }
       },
       callback: async () => {
-        await waitFor(
-          '[data-test-operator-mode-stack="0"] [data-test-cards-grid-item]',
-        );
-        await waitFor(
-          '[data-test-operator-mode-stack="1"] [data-test-cards-grid-item]',
+        await triggerEvent(
+          `[data-test-cards-grid-item="${testRealmURL}Pet/mango"]`,
+          'mouseenter',
         );
         await click(
           `[data-test-overlay-card="${testRealmURL}Pet/mango"] button.actions-item__button`,
@@ -688,6 +690,10 @@ module('Integration | card-copy', function (hooks) {
       .dom(`.selected[data-test-overlay-card="${testRealmURL}Pet/mango"]`)
       .doesNotExist('souce card is not selected');
 
+    await triggerEvent(
+      `[data-test-cards-grid-item="${testRealm2URL}Pet/paper"]`,
+      'mouseenter',
+    );
     await click(
       `[data-test-overlay-card="${testRealm2URL}Pet/paper"] button.actions-item__button`,
     );
@@ -734,14 +740,16 @@ module('Integration | card-copy', function (hooks) {
         );
       },
       callback: async () => {
-        await waitFor(
-          '[data-test-operator-mode-stack="0"] [data-test-cards-grid-item]',
-        );
-        await waitFor(
-          '[data-test-operator-mode-stack="1"] [data-test-cards-grid-item]',
+        await triggerEvent(
+          `[data-test-cards-grid-item="${testRealmURL}Pet/mango"]`,
+          'mouseenter',
         );
         await click(
           `[data-test-overlay-card="${testRealmURL}Pet/mango"] button.actions-item__button`,
+        );
+        await triggerEvent(
+          `[data-test-cards-grid-item="${testRealmURL}Pet/vangogh"]`,
+          'mouseenter',
         );
         await click(
           `[data-test-overlay-card="${testRealmURL}Pet/vangogh"] button.actions-item__button`,
@@ -867,11 +875,9 @@ module('Integration | card-copy', function (hooks) {
         }
       },
       callback: async () => {
-        await waitFor(
-          '[data-test-operator-mode-stack="0"] [data-test-cards-grid-item]',
-        );
-        await waitFor(
-          '[data-test-operator-mode-stack="1"] [data-test-cards-grid-item]',
+        await triggerEvent(
+          `[data-test-cards-grid-item="${testRealmURL}Person/hassan"]`,
+          'mouseenter',
         );
         await click(
           `[data-test-overlay-card="${testRealmURL}Person/hassan"] button.actions-item__button`,
@@ -995,11 +1001,9 @@ module('Integration | card-copy', function (hooks) {
         }
       },
       callback: async () => {
-        await waitFor(
-          '[data-test-operator-mode-stack="0"] [data-test-cards-grid-item]',
-        );
-        await waitFor(
-          '[data-test-operator-mode-stack="1"] [data-test-cards-grid-item]',
+        await triggerEvent(
+          `[data-test-cards-grid-item="${testRealmURL}Person/sakura"]`,
+          'mouseenter',
         );
         await click(
           `[data-test-overlay-card="${testRealmURL}Person/sakura"] button.actions-item__button`,

--- a/packages/host/tests/integration/components/card-def-field-def-relationships-test.gts
+++ b/packages/host/tests/integration/components/card-def-field-def-relationships-test.gts
@@ -487,10 +487,7 @@ module('Integration | CardDef-FieldDef relationships test', function (hooks) {
         'linked card content is correct',
       );
 
-    await triggerEvent(
-      `[data-test-overlay-card="${testRealmURL}usd"]`,
-      'mouseenter',
-    );
+    await triggerEvent(`[data-test-card="${testRealmURL}usd"]`, 'mouseenter');
     assert
       .dom(
         `[data-test-overlay-card="${testRealmURL}usd"] [data-test-overlay-edit]`,

--- a/packages/host/tests/integration/components/card-delete-test.gts
+++ b/packages/host/tests/integration/components/card-delete-test.gts
@@ -1,4 +1,10 @@
-import { waitUntil, waitFor, click, focus } from '@ember/test-helpers';
+import {
+  waitUntil,
+  waitFor,
+  click,
+  focus,
+  triggerEvent,
+} from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 
 import { setupRenderingTest } from 'ember-qunit';
@@ -201,11 +207,11 @@ module('Integration | card-delete', function (hooks) {
     );
     let fileRef = await adapter.openFile('Pet/mango.json');
     assert.ok(fileRef, 'card instance exists in file system');
-    await waitFor(
-      `[data-test-operator-mode-stack="0"] [data-test-cards-grid-item="${testRealmURL}Pet/mango"]`,
-    );
     assert.dom('[data-test-delete-modal-container]').doesNotExist();
-
+    await triggerEvent(
+      `[data-test-cards-grid-item="${testRealmURL}Pet/mango"]`,
+      'mouseenter',
+    );
     await click(
       `[data-test-overlay-card="${testRealmURL}Pet/mango"] [data-test-overlay-more-options]`,
     );
@@ -247,8 +253,9 @@ module('Integration | card-delete', function (hooks) {
     );
     let fileRef = await adapter.openFile('Pet/mango.json');
     assert.ok(fileRef, 'card instance exists in file system');
-    await waitFor(
-      `[data-test-operator-mode-stack="0"] [data-test-cards-grid-item="${testRealmURL}Pet/mango"]`,
+    await triggerEvent(
+      `[data-test-cards-grid-item="${testRealmURL}Pet/mango"]`,
+      'mouseenter',
     );
     await click(
       `[data-test-overlay-card="${testRealmURL}Pet/mango"] [data-test-overlay-more-options]`,
@@ -500,11 +507,9 @@ module('Integration | card-delete', function (hooks) {
       realm,
       expectedEvents,
       callback: async () => {
-        await waitFor(
+        await triggerEvent(
           `[data-test-operator-mode-stack="0"] [data-test-cards-grid-item="${testRealmURL}Pet/mango"]`,
-        );
-        await waitFor(
-          `[data-test-operator-mode-stack="1"] [data-test-cards-grid-item="${testRealmURL}Pet/mango"]`,
+          'mouseenter',
         );
         await click(
           `[data-test-operator-mode-stack="0"] [data-test-overlay-card="${testRealmURL}Pet/mango"] [data-test-overlay-more-options]`,
@@ -572,6 +577,10 @@ module('Integration | card-delete', function (hooks) {
             `[data-test-operator-mode-stack="1"] [data-test-stack-card="${testRealmURL}Pet/mango"]`,
           )
           .exists();
+        await triggerEvent(
+          `[data-test-operator-mode-stack="0"] [data-test-cards-grid-item="${testRealmURL}Pet/mango"]`,
+          'mouseenter',
+        );
         await click(
           `[data-test-operator-mode-stack="0"] [data-test-overlay-card="${testRealmURL}Pet/mango"] [data-test-overlay-more-options]`,
         );
@@ -647,6 +656,10 @@ module('Integration | card-delete', function (hooks) {
           .dom(`[data-test-search-result="${testRealmURL}Pet/mango"]`)
           .exists();
         await click('[data-test-search-sheet-cancel-button]');
+        await triggerEvent(
+          `[data-test-cards-grid-item="${testRealmURL}Pet/mango"]`,
+          'mouseenter',
+        );
         await click(
           `[data-test-overlay-card="${testRealmURL}Pet/mango"] [data-test-overlay-more-options]`,
         );
@@ -702,14 +715,16 @@ module('Integration | card-delete', function (hooks) {
       realm,
       expectedEvents,
       callback: async () => {
-        await waitFor(
-          `[data-test-operator-mode-stack="0"] [data-test-cards-grid-item]`,
-        );
-        await waitFor(
-          `[data-test-operator-mode-stack="1"] [data-test-cards-grid-item]`,
+        await triggerEvent(
+          `[data-test-cards-grid-item="${testRealmURL}Pet/mango"]`,
+          'mouseenter',
         );
         await click(
           `[data-test-overlay-card="${testRealmURL}Pet/mango"] [data-test-overlay-select]`,
+        );
+        await triggerEvent(
+          `[data-test-cards-grid-item="${testRealmURL}Pet/vangogh"]`,
+          'mouseenter',
         );
         await click(
           `[data-test-overlay-card="${testRealmURL}Pet/vangogh"] [data-test-overlay-select]`,

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -1830,12 +1830,20 @@ module('Integration | operator-mode', function (hooks) {
     );
     assert.dom('[data-test-overlay-selected]').doesNotExist();
 
+    await triggerEvent(
+      `[data-test-cards-grid-item="${testRealmURL}Person/fadhlan"]`,
+      'mouseenter',
+    );
     await click(`[data-test-overlay-select="${testRealmURL}Person/fadhlan"]`);
     assert
       .dom(`[data-test-overlay-selected="${testRealmURL}Person/fadhlan"]`)
       .exists();
     assert.dom('[data-test-overlay-selected]').exists({ count: 1 });
 
+    await triggerEvent(
+      `[data-test-cards-grid-item="${testRealmURL}Pet/jackie"]`,
+      'mouseenter',
+    );
     await click(`[data-test-overlay-select="${testRealmURL}Pet/jackie"]`);
     await click(`[data-test-cards-grid-item="${testRealmURL}Author/1"]`);
     await click(`[data-test-cards-grid-item="${testRealmURL}BlogPost/2"]`);
@@ -1903,8 +1911,6 @@ module('Integration | operator-mode', function (hooks) {
         </template>
       },
     );
-
-    await waitFor(`[data-test-overlay-card="${testRealmURL}Author/1"]`);
 
     await click('[data-test-author]');
     await waitFor('[data-test-stack-card-index="1"]');
@@ -2520,9 +2526,10 @@ module('Integration | operator-mode', function (hooks) {
     assert.dom(`[data-test-item="1"]`).hasText('Buzz');
     assert.dom(`[data-test-item="2"]`).hasText('Jackie');
 
+    await triggerEvent(`[data-test-item="0"]`, 'mouseenter');
     let itemElement = document.querySelector('[data-test-item="0"]');
     let overlayButtonElements = document.querySelectorAll(
-      `[data-test-overlay-card="${testRealmURL}Pet/woody"]`,
+      `[data-test-card="${testRealmURL}Pet/woody"]`,
     );
     if (
       !itemElement ||


### PR DESCRIPTION
1) Only render the overlay DOM for currently selected or hovered cards
2) Calculate the z-index once per card
3) Remove animated transition from overlay
4) Eliminate some event handlers