### PR TITLE
Add ability to filter prerendered cards by url

### DIFF
--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -1962,6 +1962,46 @@ module('Realm Server', function (hooks) {
         assert.strictEqual(json.data[0].id, 'http://127.0.0.1:4444/jimmy.json');
       });
 
+      test('can use cardUrls to filter prerendered instances', async function (assert) {
+        let query: Query & {
+          prerenderedHtmlFormat: string;
+          cardUrls: string[];
+        } = {
+          prerenderedHtmlFormat: 'embedded',
+          cardUrls: [`${testRealmHref}jimmy.json`],
+        };
+        let response = await request
+          .get(`/_search-prerendered?${stringify(query)}`)
+          .set('Accept', 'application/vnd.card+json');
+
+        let json = response.body;
+
+        assert.strictEqual(
+          json.data.length,
+          1,
+          'one prerendered card instance is returned in the filtered search results',
+        );
+        assert.strictEqual(json.data[0].id, 'http://127.0.0.1:4444/jimmy.json');
+
+        query = {
+          prerenderedHtmlFormat: 'embedded',
+          cardUrls: [`${testRealmHref}jimmy.json`, `${testRealmHref}jane.json`],
+        };
+        response = await request
+          .get(`/_search-prerendered?${stringify(query)}`)
+          .set('Accept', 'application/vnd.card+json');
+
+        json = response.body;
+
+        assert.strictEqual(
+          json.data.length,
+          2,
+          '2 prerendered card instances are returned in the filtered search results',
+        );
+        assert.strictEqual(json.data[0].id, 'http://127.0.0.1:4444/jane.json');
+        assert.strictEqual(json.data[1].id, 'http://127.0.0.1:4444/jimmy.json');
+      });
+
       test('can sort prerendered instances', async function (assert) {
         let query: Query & { prerenderedHtmlFormat: string } = {
           sort: [

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -93,6 +93,7 @@ export type QueryOptions = WIPOptions & PrerenderedCardOptions;
 
 interface PrerenderedCardOptions {
   htmlFormat?: 'embedded' | 'fitted' | 'atom';
+  cardUrls?: string[];
 }
 
 interface WIPOptions {
@@ -297,6 +298,16 @@ export class IndexQueryEngine {
       ['is_deleted = FALSE OR is_deleted IS NULL'],
       realmVersionExpression({ withMaxVersion: version }),
     ];
+
+    if (opts.cardUrls && opts.cardUrls.length > 0) {
+      conditions.push([
+        'i.url IN',
+        ...addExplicitParens(
+          separatedByCommas(opts.cardUrls.map((url) => [param(url)])),
+        ),
+      ]);
+    }
+
     if (filter) {
       conditions.push(this.filterCondition(filter, baseCardRef));
     }

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -1618,6 +1618,8 @@ export class Realm {
 
     let parsedQueryString = qs.parse(new URL(request.url).search.slice(1));
     let htmlFormat = parsedQueryString.prerenderedHtmlFormat as string;
+    let cardUrls = parsedQueryString.cardUrls as string[];
+
     if (!isValidPrerenderedHtmlFormat(htmlFormat)) {
       return badRequest(
         JSON.stringify({
@@ -1628,8 +1630,9 @@ export class Realm {
         requestContext,
       );
     }
-    // prerenederedHtmlFormat is a special parameter only for this endpoint so don't include it in our Query for card search
+    // prerenderedHtmlFormat and cardUrls are special parameters only for this endpoint so don't include it in our Query for standard card search
     delete parsedQueryString.prerenderedHtmlFormat;
+    delete parsedQueryString.cardUrls;
 
     let cardsQuery = parsedQueryString;
     assertQuery(parsedQueryString);
@@ -1639,6 +1642,7 @@ export class Realm {
       {
         useWorkInProgressIndex,
         htmlFormat,
+        cardUrls,
       },
     );
 


### PR DESCRIPTION
This is a bite sized PR extracted from https://github.com/cardstack/boxel/pull/1521 (work in progress PR for showing prerendered cards in cards chooser).

It's intended for cases where users search for a card using its URL in places where we show a list of cards. Without this PR, we could still search for a card by url using `getCard` from card service, but then we would mix two approaches of loading cards in the card catalog (one using `getCard`, one using prerendered endpoint), which seems complicated/cluttered. I would rather see that any card we show in the card catalog (be it a list filtered by filters, or a single card searched by url) is a prerendered card.

Later we can also use this approach to render "recent cards", which are now individually loaded using `getCard`. 

<img width="974" alt="image" src="https://github.com/user-attachments/assets/d658a4f8-12db-4403-a557-9cb0057984dd">


