### PR TITLE
Fix flaky test due to mock room creation timestamps

### DIFF
--- a/packages/host/tests/helpers/mock-matrix-service.ts
+++ b/packages/host/tests/helpers/mock-matrix-service.ts
@@ -49,7 +49,11 @@ let nonce = 0;
 export type MockMatrixService = MatrixService & {
   sendReactionDeferred: Deferred<void>; // used to assert applying state in apply button
   cardAPI: typeof cardApi;
-  createAndJoinRoom(roomId: string, roomName?: string): Promise<string>;
+  createAndJoinRoom(
+    roomId: string,
+    roomName: string,
+    timestamp?: number,
+  ): Promise<string>;
 };
 
 class MockClient {
@@ -199,7 +203,7 @@ function generateMockMatrixService(
       if (document.querySelector('[data-test-throw-room-error]')) {
         throw new Error('Intentional error thrown');
       }
-      return await this.createAndJoinRoom(name);
+      return await this.createAndJoinRoom(name, name);
     }
 
     async sendReactionEvent(roomId: string, eventId: string, status: string) {
@@ -391,7 +395,11 @@ function generateMockMatrixService(
       await this.profile.load.perform();
     }
 
-    async createAndJoinRoom(roomId: string, name?: string) {
+    async createAndJoinRoom(
+      roomId: string,
+      name: string,
+      timestamp = Date.now(),
+    ) {
       await addRoomEvent(this, {
         event_id: 'eventname',
         room_id: roomId,
@@ -404,7 +412,7 @@ function generateMockMatrixService(
         event_id: 'eventcreate',
         room_id: roomId,
         type: 'm.room.create',
-        origin_server_ts: Date.now(),
+        origin_server_ts: timestamp,
         content: {
           creator: '@testuser:staging',
           room_version: '0',
@@ -418,11 +426,11 @@ function generateMockMatrixService(
         type: 'm.room.member',
         sender: '@testuser:staging',
         state_key: '@testuser:staging',
-        origin_server_ts: Date.now(),
+        origin_server_ts: timestamp,
         content: {
           displayname: 'testuser',
           membership: 'join',
-          membershipTs: Date.now(),
+          membershipTs: timestamp,
           membershipInitiator: '@testuser:staging',
         },
         status: null,

--- a/packages/host/tests/integration/components/ai-assistant-panel-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel-test.gts
@@ -1093,14 +1093,18 @@ module('Integration | ai-assistant-panel', function (hooks) {
         },
       );
 
-      await matrixService.createAndJoinRoom('test1', 'test room 1');
+      let now = Date.now();
+
+      await matrixService.createAndJoinRoom('test1', 'test room 1', now - 2);
       const room2Id = await matrixService.createAndJoinRoom(
         'test2',
         'test room 2',
+        now - 1,
       );
       const room3Id = await matrixService.createAndJoinRoom(
         'test3',
         'test room 3',
+        now,
       );
 
       await openAiAssistant();


### PR DESCRIPTION
The mock rooms were all being created potentially on the same timestamp, resulting in the "newest" not being what was expeted by the test.