### PR TITLE
Fix flake scroll-position test

### DIFF
--- a/packages/host/tests/acceptance/code-submode/file-tree-test.ts
+++ b/packages/host/tests/acceptance/code-submode/file-tree-test.ts
@@ -743,15 +743,23 @@ module('Acceptance | code submode | file-tree tests', function (hooks) {
       ],
       submode: 'code',
       fileView: 'browser',
-      codePath: `${testRealmURL}person-entry.json`,
+
+      // this was picked because it's way out in the middle of a long list of
+      // files. So it will get scrolled to the middle of the visible window,
+      // such that it's following entry (z80) is always on-screen.
+      //
+      // If instead we picked a file whose neighbor may hang off the bottom of
+      // the screen, choosing that neighbor would intentionally cause scroll and
+      // fail our test.
+      codePath: `${testRealmURL}z79.json`,
     });
 
-    await waitFor('[data-test-file="person.gts"]');
+    await waitFor('[data-test-file="z80.json"]');
 
     let scrollablePanel = find('[data-test-togglable-left-panel]');
     let currentScrollTop = scrollablePanel?.scrollTop;
 
-    await click('[data-test-file="person.gts"]');
+    await click('[data-test-file="z80.json"]');
 
     let newScrollTop = scrollablePanel?.scrollTop;
 


### PR DESCRIPTION
The test was failing because some of the content it was navigating to was offscreen, forcing scroll to happen at a time when the test assumed no scroll should happen.

Fixed by picking a different place in the same data to do the test.