### PR TITLE
add retry for failed fetch of base realm artifacts in test env

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   host-test:
     name: Host Tests
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/packages/runtime-common/virtual-network.ts
+++ b/packages/runtime-common/virtual-network.ts
@@ -122,7 +122,7 @@ export class VirtualNetwork {
       return next(await this.mapRequest(request, 'virtual-to-real'));
     });
 
-    return fetchWithRetries(new URL(request.url), () =>
+    return withRetries(new URL(request.url), () =>
       fetcher(this.nativeFetch, handlers)(request, init),
     );
   }
@@ -206,7 +206,7 @@ function isUrlLike(moduleIdentifier: string): boolean {
 // Fetch failed" exceptions.
 const maxAttempts = 5;
 const backOffMs = 100;
-async function fetchWithRetries(
+async function withRetries(
   url: URL,
   fetchFn: () => ReturnType<typeof globalThis.fetch>,
 ) {

--- a/packages/runtime-common/virtual-network.ts
+++ b/packages/runtime-common/virtual-network.ts
@@ -122,7 +122,9 @@ export class VirtualNetwork {
       return next(await this.mapRequest(request, 'virtual-to-real'));
     });
 
-    // Retry if fetch fails in CI for base realm artifacts
+    // This is to handle a very mysterious situation in our CI environment where
+    // fetches for base realm artifacts seem to vanish and we see "TypeError:
+    // Fetch failed" exceptions.
     const maxAttempts = 5;
     const backOffMs = 100;
     let attempt = 0;


### PR DESCRIPTION
This PR is a workaround for the mysterious fetch failed errors that we see in our CI environment for base realm artifacts