### PR TITLE
Allow searching when there are no cards open

### DIFF
--- a/packages/ai-bot/helpers.ts
+++ b/packages/ai-bot/helpers.ts
@@ -248,9 +248,11 @@ const searchTool: Tool = {
     description:
       'Propose a query to search for a card instance filtered by type. \
   If a card was shared with you, always prioritise search based upon the card that was last shared. \
-  In addition, you also have access to the following card types without any card being open in the stack: \
-  {"module": "http://localhost:4201/experiments/author", "name": "Author"}, \
-  {"module": "http://localhost:4201/experiments/pet", "name": "Pet"}',
+  If you do not have information on card module and name, do the search using the `_cardType` attribute. \
+  For example, if a user asks you to search or find Pet cards, you can use this filter: \
+  { filter: { eq: { _cardType: "Pet" } } }\
+   Another example, if you need to find Person cards, and you do not know the module and name, you can use this filter:\
+  { filter: { eq: { _cardType: "Person" } } }',
     parameters: {
       type: 'object',
       properties: {
@@ -273,6 +275,16 @@ const searchTool: Tool = {
                 },
               },
               required: ['module', 'name'],
+            },
+            eq: {
+              type: 'object',
+              properties: {
+                _cardType: {
+                  type: 'string',
+                  description: 'name of the card type',
+                },
+              },
+              required: ['_cardType'],
             },
           },
         },

--- a/packages/ai-bot/helpers.ts
+++ b/packages/ai-bot/helpers.ts
@@ -3,6 +3,7 @@ import {
   type LooseSingleCardDocument,
   type CardResource,
 } from '@cardstack/runtime-common';
+import { getSearchTool } from '@cardstack/runtime-common/helpers/ai';
 import type {
   MatrixEvent as DiscreteMatrixEvent,
   CardFragmentContent,
@@ -241,60 +242,11 @@ export function getRelevantCards(
   };
 }
 
-const searchTool: Tool = {
-  type: 'function',
-  function: {
-    name: 'searchCard',
-    description:
-      'Propose a query to search for a card instance filtered by type. \
-  If a card was shared with you, always prioritise search based upon the card that was last shared. \
-  If you do not have information on card module and name, do the search using the `_cardType` attribute. \
-  For example, if a user asks you to search or find Pet cards, you can use this filter: \
-  { filter: { eq: { _cardType: "Pet" } } }\
-   Another example, if you need to find Person cards, and you do not know the module and name, you can use this filter:\
-  { filter: { eq: { _cardType: "Person" } } }',
-    parameters: {
-      type: 'object',
-      properties: {
-        description: {
-          type: 'string',
-        },
-        filter: {
-          type: 'object',
-          properties: {
-            type: {
-              type: 'object',
-              properties: {
-                module: {
-                  type: 'string',
-                  description: 'the absolute path of the module',
-                },
-                name: {
-                  type: 'string',
-                  description: 'the name of the module',
-                },
-              },
-              required: ['module', 'name'],
-            },
-            eq: {
-              type: 'object',
-              properties: {
-                _cardType: {
-                  type: 'string',
-                  description: 'name of the card type',
-                },
-              },
-              required: ['_cardType'],
-            },
-          },
-        },
-      },
-      required: ['filter', 'description'],
-    },
-  },
-};
-
-export function getTools(history: DiscreteMatrixEvent[], aiBotUserId: string) {
+export function getTools(
+  history: DiscreteMatrixEvent[],
+  aiBotUserId: string,
+): Tool[] {
+  let searchTool = getSearchTool();
   let tools = [searchTool];
   // Just get the users messages
   const userMessages = history.filter((event) => event.sender !== aiBotUserId);

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -715,7 +715,9 @@ module('getModifyPrompt', () => {
     );
     assert.equal(
       mostRecentlyAttachedCard,
-      history[0].content.data.attachedCards[0]['data'],
+      (history[0].content as CardMessageContent).data.attachedCards?.[0][
+        'data'
+      ],
     );
   });
 
@@ -765,12 +767,9 @@ module('getModifyPrompt', () => {
             context: {
               openCardIds: ['http://localhost:4201/experiments/Friend/1'],
               tools: [
-                getPatchTool(
-                  { id: 'http://localhost:4201/experiments/Friend/1' },
-                  {
-                    firstName: { type: 'string' },
-                  },
-                ),
+                getPatchTool('http://localhost:4201/experiments/Friend/1', {
+                  firstName: { type: 'string' },
+                }),
               ],
               submode: 'interact',
             },
@@ -926,12 +925,9 @@ module('getModifyPrompt', () => {
             context: {
               openCardIds: ['http://localhost:4201/experiments/Friend/1'],
               tools: [
-                getPatchTool(
-                  { id: 'http://localhost:4201/experiments/Friend/1' } as any,
-                  {
-                    firstName: { type: 'string' },
-                  },
-                ),
+                getPatchTool('http://localhost:4201/experiments/Friend/1', {
+                  firstName: { type: 'string' },
+                }),
               ],
               submode: 'interact',
             },
@@ -990,12 +986,9 @@ module('getModifyPrompt', () => {
             context: {
               openCardIds: ['http://localhost:4201/experiments/Friend/1'],
               tools: [
-                getPatchTool(
-                  { id: 'http://localhost:4201/experiments/Friend/1' } as any,
-                  {
-                    firstName: { type: 'string' },
-                  },
-                ),
+                getPatchTool('http://localhost:4201/experiments/Friend/1', {
+                  firstName: { type: 'string' },
+                }),
               ],
               submode: 'interact',
             },
@@ -1022,12 +1015,9 @@ module('getModifyPrompt', () => {
             context: {
               openCardIds: ['http://localhost:4201/experiments/Meeting/2'],
               tools: [
-                getPatchTool(
-                  { id: 'http://localhost:4201/experiments/Meeting/2' },
-                  {
-                    location: { type: 'string' },
-                  },
-                ),
+                getPatchTool('http://localhost:4201/experiments/Meeting/2', {
+                  location: { type: 'string' },
+                }),
               ],
               submode: 'interact',
             },

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -721,7 +721,7 @@ module('getModifyPrompt', () => {
     );
   });
 
-  test('If there are no functions in the last message from the user, store none', () => {
+  test('If there are no functions in the last message from the user, store only searchTool', () => {
     const history: DiscreteMatrixEvent[] = [
       {
         type: 'm.room.message',
@@ -750,10 +750,11 @@ module('getModifyPrompt', () => {
       },
     ];
     const functions = getTools(history, '@aibot:localhost');
-    assert.equal(functions.length, 0);
+    assert.equal(functions.length, 1);
+    assert.deepEqual(functions[0], getSearchTool());
   });
 
-  test('If a user stops sharing their context then ignore function calls', () => {
+  test('If a user stops sharing their context then ignore function calls with exception of searchTool', () => {
     const history: DiscreteMatrixEvent[] = [
       {
         type: 'm.room.message',
@@ -811,7 +812,8 @@ module('getModifyPrompt', () => {
       },
     ];
     const functions = getTools(history, '@aibot:localhost');
-    assert.equal(functions.length, 0);
+    assert.equal(functions.length, 1);
+    assert.deepEqual(functions[0], getSearchTool());
   });
 
   test("Don't break when there is an older format type with open cards", () => {
@@ -1578,42 +1580,7 @@ module('getModifyPrompt', () => {
 
     const functions = getTools(history, '@aibot:localhost');
     assert.equal(functions.length, 1);
-    assert.deepEqual(functions[0], {
-      type: 'function',
-      function: {
-        name: 'searchCard',
-        description:
-          'Propose a query to search for a card instance filtered by type. Always prioritise search based upon the card that was last shared.',
-        parameters: {
-          type: 'object',
-          properties: {
-            description: {
-              type: 'string',
-            },
-            filter: {
-              type: 'object',
-              properties: {
-                type: {
-                  type: 'object',
-                  properties: {
-                    module: {
-                      type: 'string',
-                      description: 'the absolute path of the module',
-                    },
-                    name: {
-                      type: 'string',
-                      description: 'the name of the module',
-                    },
-                  },
-                  required: ['module', 'name'],
-                },
-              },
-            },
-          },
-          required: ['filter', 'description'],
-        },
-      },
-    });
+    assert.deepEqual(functions[0], getSearchTool());
   });
 
   test('Return host result of tool call back to open ai', () => {
@@ -1678,43 +1645,7 @@ module('getModifyPrompt', () => {
                     },
                   },
                 },
-                {
-                  type: 'function',
-                  function: {
-                    name: 'searchCard',
-                    description:
-                      'Propose a query to search for a card instance filtered by type. Always prioritise search based upon the card that was last shared.',
-                    parameters: {
-                      type: 'object',
-                      properties: {
-                        description: {
-                          type: 'string',
-                        },
-                        filter: {
-                          type: 'object',
-                          properties: {
-                            type: {
-                              type: 'object',
-                              properties: {
-                                module: {
-                                  type: 'string',
-                                  description:
-                                    'the absolute path of the module',
-                                },
-                                name: {
-                                  type: 'string',
-                                  description: 'the name of the module',
-                                },
-                              },
-                              required: ['module', 'name'],
-                            },
-                          },
-                        },
-                      },
-                      required: ['filter', 'description'],
-                    },
-                  },
-                },
+                getSearchTool(),
               ],
               submode: 'interact',
             },
@@ -1863,43 +1794,7 @@ module('getModifyPrompt', () => {
                     },
                   },
                 },
-                {
-                  type: 'function',
-                  function: {
-                    name: 'searchCard',
-                    description:
-                      'Propose a query to search for a card instance filtered by type. Always prioritise search based upon the card that was last shared.',
-                    parameters: {
-                      type: 'object',
-                      properties: {
-                        description: {
-                          type: 'string',
-                        },
-                        filter: {
-                          type: 'object',
-                          properties: {
-                            type: {
-                              type: 'object',
-                              properties: {
-                                module: {
-                                  type: 'string',
-                                  description:
-                                    'the absolute path of the module',
-                                },
-                                name: {
-                                  type: 'string',
-                                  description: 'the name of the module',
-                                },
-                              },
-                              required: ['module', 'name'],
-                            },
-                          },
-                        },
-                      },
-                      required: ['filter', 'description'],
-                    },
-                  },
-                },
+                getSearchTool(),
               ],
               submode: 'interact',
             },

--- a/packages/host/app/services/command-service.ts
+++ b/packages/host/app/services/command-service.ts
@@ -9,7 +9,11 @@ import {
   baseRealm,
   LooseSingleCardDocument,
 } from '@cardstack/runtime-common';
-import { CardTypeFilter, assertQuery } from '@cardstack/runtime-common/query';
+import {
+  type CardTypeFilter,
+  type EqFilter,
+  assertQuery,
+} from '@cardstack/runtime-common/query';
 
 import type MatrixService from '@cardstack/host/services/matrix-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
@@ -162,7 +166,7 @@ export default class CommandService extends Service {
 }
 
 type PatchPayload = { card_id: string } & PatchData;
-type SearchPayload = { card_id: string; filter: CardTypeFilter };
+type SearchPayload = { card_id: string; filter: CardTypeFilter | EqFilter };
 
 function hasPatchData(payload: any): payload is PatchPayload {
   return (

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -516,7 +516,7 @@ export default class MatrixService extends Service {
           mappings,
         );
         if (this.realm.canWrite(attachedOpenCard.id)) {
-          tools.push(getPatchTool(attachedOpenCard, patchSpec));
+          tools.push(getPatchTool(attachedOpenCard.id, patchSpec));
           tools.push(getSearchTool());
           tools.push(getGenerateAppModuleTool(attachedOpenCard.id));
         }

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -296,7 +296,9 @@ test.describe('Room messages', () => {
   }) => {
     await login(page, 'user1', 'pass');
     let room1 = await getRoomId(page);
-    await page.locator(`[data-test-boxel-filter-list-button="All Cards"]`).click();
+    await page
+      .locator(`[data-test-boxel-filter-list-button="All Cards"]`)
+      .click();
     await page
       .locator(
         `[data-test-stack-card="${testHost}/index"] [data-test-cards-grid-item="${testHost}/mango"]`,
@@ -352,39 +354,50 @@ test.describe('Room messages', () => {
         },
       },
       {
+        type: 'function',
         function: {
-          description: `Propose a query to search for a card instance filtered by type. Always prioritise search based upon the card that was last shared.`,
           name: 'searchCard',
+          description:
+            'Propose a query to search for a card instance filtered by type.   If a card was shared with you, always prioritise search based upon the card that was last shared.   If you do not have information on card module and name, do the search using the `_cardType` attribute.',
           parameters: {
+            type: 'object',
             properties: {
               description: {
                 type: 'string',
               },
               filter: {
+                type: 'object',
                 properties: {
                   type: {
+                    type: 'object',
                     properties: {
                       module: {
-                        description: 'the absolute path of the module',
                         type: 'string',
+                        description: 'the absolute path of the module',
                       },
                       name: {
-                        description: 'the name of the module',
                         type: 'string',
+                        description: 'the name of the module',
                       },
                     },
                     required: ['module', 'name'],
+                  },
+                  eq: {
                     type: 'object',
+                    properties: {
+                      _cardType: {
+                        type: 'string',
+                        description: 'name of the card type',
+                      },
+                    },
+                    required: ['_cardType'],
                   },
                 },
-                type: 'object',
               },
             },
             required: ['filter', 'description'],
-            type: 'object',
           },
         },
-        type: 'function',
       },
       {
         type: 'function',
@@ -425,7 +438,9 @@ test.describe('Room messages', () => {
   }) => {
     await login(page, 'user1', 'pass');
     let room1 = await getRoomId(page);
-    await page.locator(`[data-test-boxel-filter-list-button="All Cards"]`).click();
+    await page
+      .locator(`[data-test-boxel-filter-list-button="All Cards"]`)
+      .click();
     await page
       .locator(
         `[data-test-stack-card="${testHost}/index"] [data-test-cards-grid-item="${testHost}/mango"]`,
@@ -452,7 +467,9 @@ test.describe('Room messages', () => {
     // the base realm is a read-only realm
     await login(page, 'user1', 'pass', { url: `http://localhost:4201/base` });
     let room1 = await getRoomId(page);
-    await page.locator(`[data-test-boxel-filter-list-button="All Cards"]`).click();
+    await page
+      .locator(`[data-test-boxel-filter-list-button="All Cards"]`)
+      .click();
     await page
       .locator(
         '[data-test-stack-card="https://cardstack.com/base/index"] [data-test-cards-grid-item="https://cardstack.com/base/fields/boolean-field"]',
@@ -680,7 +697,9 @@ test.describe('Room messages', () => {
     test.beforeEach(async ({ page }) => {
       await login(page, 'user1', 'pass');
       await getRoomId(page);
-      await page.locator(`[data-test-boxel-filter-list-button="All Cards"]`).click();
+      await page
+        .locator(`[data-test-boxel-filter-list-button="All Cards"]`)
+        .click();
     });
 
     test('displays auto-attached card (1 stack)', async ({ page }) => {
@@ -755,7 +774,9 @@ test.describe('Room messages', () => {
     }) => {
       const testCard1 = `${testHost}/jersey`;
       const embeddedCard = `${testHost}/justin`;
-      await page.locator(`[data-test-boxel-filter-list-button="All Cards"]`).click();
+      await page
+        .locator(`[data-test-boxel-filter-list-button="All Cards"]`)
+        .click();
       await page
         .locator(
           `[data-test-stack-item-content] [data-test-cards-grid-item='${testCard1}']`,
@@ -972,7 +993,9 @@ test.describe('Room messages', () => {
 
     await login(page, 'user1', 'pass');
     await page.locator(`[data-test-room-settled]`).waitFor();
-    await page.locator(`[data-test-boxel-filter-list-button="All Cards"]`).click();
+    await page
+      .locator(`[data-test-boxel-filter-list-button="All Cards"]`)
+      .click();
 
     for (let i = 1; i <= 3; i++) {
       await page.locator('[data-test-message-field]').fill(`Message - ${i}`);
@@ -1057,7 +1080,9 @@ test.describe('Room messages', () => {
       }),
     };
 
-    await page.locator(`[data-test-boxel-filter-list-button="All Cards"]`).click();
+    await page
+      .locator(`[data-test-boxel-filter-list-button="All Cards"]`)
+      .click();
     await page
       .locator(
         `[data-test-stack-card="${testHost}/index"] [data-test-cards-grid-item="${card_id}"]`,
@@ -1104,7 +1129,9 @@ test.describe('Room messages', () => {
       }),
     };
 
-    await page.locator(`[data-test-boxel-filter-list-button="All Cards"]`).click();
+    await page
+      .locator(`[data-test-boxel-filter-list-button="All Cards"]`)
+      .click();
     await page
       .locator(
         `[data-test-stack-card="${testHost}/index"] [data-test-cards-grid-item="${card_id}"]`,

--- a/packages/runtime-common/helpers/ai.ts
+++ b/packages/runtime-common/helpers/ai.ts
@@ -398,12 +398,15 @@ export function getPatchTool(
   };
 }
 
-export function getSearchTool() {
+export function getSearchTool(): Tool {
   return {
     type: 'function',
     function: {
       name: 'searchCard',
-      description: `Propose a query to search for a card instance filtered by type. Always prioritise search based upon the card that was last shared.`,
+      description:
+        'Propose a query to search for a card instance filtered by type. \
+  If a card was shared with you, always prioritise search based upon the card that was last shared. \
+  If you do not have information on card module and name, do the search using the `_cardType` attribute.',
       parameters: {
         type: 'object',
         properties: {
@@ -418,7 +421,7 @@ export function getSearchTool() {
                 properties: {
                   module: {
                     type: 'string',
-                    description: `the absolute path of the module`,
+                    description: 'the absolute path of the module',
                   },
                   name: {
                     type: 'string',

--- a/packages/runtime-common/helpers/ai.ts
+++ b/packages/runtime-common/helpers/ai.ts
@@ -423,6 +423,16 @@ export function getSearchTool() {
                 },
                 required: ['module', 'name'],
               },
+              eq: {
+                type: 'object',
+                properties: {
+                  _cardType: {
+                    type: 'string',
+                    description: 'name of the card type',
+                  },
+                },
+                required: ['_cardType'],
+              },
             },
           },
         },

--- a/packages/runtime-common/helpers/ai.ts
+++ b/packages/runtime-common/helpers/ai.ts
@@ -2,6 +2,7 @@ import type * as CardAPI from 'https://cardstack.com/base/card-api';
 import { primitive } from '../constants';
 import { Loader } from '../loader';
 import { CardDef } from 'https://cardstack.com/base/card-api';
+import type { Tool } from 'https://cardstack.com/base/matrix-event';
 
 type ArraySchema = {
   type: 'array';
@@ -370,7 +371,10 @@ export function generateCardPatchCallSpecification(
   }
 }
 
-export function getPatchTool(attachedOpenCard: CardDef, patchSpec: any) {
+export function getPatchTool(
+  attachedOpenCardId: CardDef['id'],
+  patchSpec: any,
+): Tool {
   return {
     type: 'function',
     function: {
@@ -381,7 +385,7 @@ export function getPatchTool(attachedOpenCard: CardDef, patchSpec: any) {
         properties: {
           card_id: {
             type: 'string',
-            const: attachedOpenCard.id, // Force the valid card_id to be the id of the card being patched
+            const: attachedOpenCardId, // Force the valid card_id to be the id of the card being patched
           },
           description: {
             type: 'string',


### PR DESCRIPTION
- My approach to this was asking the bot to compose an equality search using the `_cardType` property. It seems to be working. Please let me know of any comments about this approach. Is it sufficient?
- Made changes in ai-bot package so that the `searchTool` is always available, even when there are no cards attached to the chat. Updated the tests accordingly, please review. (Also some type error fixes.)

<img width="1478" alt="no-open-card-country-search" src="https://github.com/user-attachments/assets/1bfaba32-f347-4f92-ab3d-faa96ecee1ce">
<img width="1152" alt="no-open-card-map-search" src="https://github.com/user-attachments/assets/d42011a4-f053-4694-a43d-9425791edd20">

When a card is open, the module search is as before:
<img width="1149" alt="open-card-item-search" src="https://github.com/user-attachments/assets/6cdeb803-344c-462b-b44c-f6671aa77681">
When a card is open, can still do search for unrelated cards:
<img width="1152" alt="open-card-unrelated-search" src="https://github.com/user-attachments/assets/3316d113-4bbf-4948-9d84-805573eaca0d">