### PR TITLE
Mock matrix at the client level

### DIFF
--- a/packages/host/app/components/ai-assistant/panel.gts
+++ b/packages/host/app/components/ai-assistant/panel.gts
@@ -427,6 +427,7 @@ export default class AiAssistantPanel extends Component<Signature> {
         window.localStorage.setItem(newSessionIdPersistenceKey, newRoomId);
         this.enterRoom(newRoomId);
       } catch (e) {
+        console.log(e);
         this.displayRoomError = true;
         this.currentRoomId = undefined;
       }

--- a/packages/host/app/lib/matrix-handlers/membership.ts
+++ b/packages/host/app/lib/matrix-handlers/membership.ts
@@ -1,4 +1,4 @@
-import debounce from 'lodash/debounce';
+import { debounce } from '@ember/runloop';
 
 import type { MatrixEvent as DiscreteMatrixEvent } from 'https://cardstack.com/base/matrix-event';
 
@@ -18,9 +18,9 @@ export function onMembership(MatrixService: MatrixService) {
 
 const STATE_EVENTS_OF_INTEREST = ['m.room.create', 'm.room.name'];
 
-const debouncedMembershipDrain = debounce((MatrixService: MatrixService) => {
-  drainMembership(MatrixService);
-}, eventDebounceMs);
+function debouncedMembershipDrain(MatrixService: MatrixService) {
+  debounce(null, drainMembership, MatrixService, eventDebounceMs);
+}
 
 async function drainMembership(MatrixService: MatrixService) {
   await MatrixService.flushMembership;

--- a/packages/host/app/lib/matrix-handlers/timeline.ts
+++ b/packages/host/app/lib/matrix-handlers/timeline.ts
@@ -1,4 +1,5 @@
-import debounce from 'lodash/debounce';
+import { debounce } from '@ember/runloop';
+
 import { Room, type MatrixEvent } from 'matrix-js-sdk';
 
 import type MatrixService from '@cardstack/host/services/matrix-service';
@@ -45,9 +46,9 @@ export function onUpdateEventStatus(MatrixService: MatrixService) {
   };
 }
 
-const debouncedTimelineDrain = debounce((MatrixService: MatrixService) => {
-  drainTimeline(MatrixService);
-}, eventDebounceMs);
+function debouncedTimelineDrain(MatrixService: MatrixService) {
+  debounce(null, drainTimeline, MatrixService, eventDebounceMs);
+}
 
 async function drainTimeline(MatrixService: MatrixService) {
   await MatrixService.flushTimeline;

--- a/packages/host/app/services/matrix-sdk-loader.ts
+++ b/packages/host/app/services/matrix-sdk-loader.ts
@@ -50,7 +50,41 @@ export class ExtendedMatrixSDK {
   }
 }
 
-export type ExtendedClient = MatrixSDK.MatrixClient & {
+export type ExtendedClient = Pick<
+  MatrixSDK.MatrixClient,
+  | 'addThreePidOnly'
+  | 'createRoom'
+  | 'credentials'
+  | 'decryptEventIfNeeded'
+  | 'deleteThreePid'
+  | 'fetchRoomEvent'
+  | 'forget'
+  | 'getJoinedRooms'
+  | 'getProfileInfo'
+  | 'getRoom'
+  | 'getThreePids'
+  | 'getUserId'
+  | 'invite'
+  | 'isLoggedIn'
+  | 'isUsernameAvailable'
+  | 'joinRoom'
+  | 'leave'
+  | 'loginWithPassword'
+  | 'logout'
+  | 'off'
+  | 'on'
+  | 'registerRequest'
+  | 'requestPasswordEmailToken'
+  | 'roomState'
+  | 'scrollback'
+  | 'sendEvent'
+  | 'sendReadReceipt'
+  | 'setDisplayName'
+  | 'setPassword'
+  | 'setPowerLevel'
+  | 'setRoomName'
+  | 'startClient'
+> & {
   allRoomMessages(
     roomId: string,
     opts?: MessageOptions,
@@ -183,7 +217,7 @@ function extendedClient(client: MatrixSDK.MatrixClient): ExtendedClient {
   }) as unknown as ExtendedClient;
 }
 
-interface MessageOptions {
+export interface MessageOptions {
   direction?: 'forward' | 'backward';
   onMessages?: (messages: DiscreteMatrixEvent[]) => Promise<void>;
   pageSize: number;

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -175,15 +175,7 @@ export default class MatrixService extends Service {
         async (e) => {
           if (e.event.type == 'com.cardstack.boxel.realms') {
             this.cardService.setRealms(e.event.content.realms);
-            // It would be better to not have this special exception for tests,
-            // but we don't have the ability to mock the Realm server's matrix
-            // client yet, so this would fail under test.
-            //
-            // Previously this entire service was unused in tests, so we're at
-            // least using *more* of it, even if we're skipping this part.
-            if (!isTesting()) {
-              await this.loginToRealms();
-            }
+            await this.loginToRealms();
             this.accountDataProcessed.fulfill();
           }
         },

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -151,7 +151,7 @@ export default class MatrixService extends Service {
     await this.cardAPIModule.loaded;
     // The matrix SDK is VERY big so we only load it when we need it
     this.#matrixSDK = await this.matrixSdkLoader.load();
-    this._client = await this.matrixSDK.createClient({
+    this._client = this.matrixSDK.createClient({
       baseUrl: matrixURL,
     });
 
@@ -301,6 +301,7 @@ export default class MatrixService extends Service {
       try {
         await this._client.startClient();
         await this.accountDataProcessed.promise;
+        debugger;
         await this.loginToRealms();
         await this.initializeRooms();
       } catch (e) {

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -1,7 +1,6 @@
 import type Owner from '@ember/owner';
 import type RouterService from '@ember/routing/router-service';
 import Service, { service } from '@ember/service';
-import { isTesting } from '@embroider/macros';
 import { cached, tracked } from '@glimmer/tracking';
 
 import format from 'date-fns/format';

--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -89,10 +89,7 @@ module.exports = function (environment) {
     ENV.minSaveTaskDurationMs = 0;
     ENV.sqlSchema = sqlSchema;
 
-    ENV.testRealmURLs = [
-      'http://test-realm/test/',
-      'https://cardstack.com/base/',
-    ];
+    ENV.testRealmURLs = ['http://test-realm/test/'];
   }
 
   if (environment === 'production') {

--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -89,7 +89,10 @@ module.exports = function (environment) {
     ENV.minSaveTaskDurationMs = 0;
     ENV.sqlSchema = sqlSchema;
 
-    ENV.testRealmURLs = ['http://test-realm/test/'];
+    ENV.testRealmURLs = [
+      'http://test-realm/test/',
+      'https://cardstack.com/base/',
+    ];
   }
 
   if (environment === 'production') {

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -97,7 +97,6 @@ async function assertMessages(
 
 module('Acceptance | AI Assistant tests', function (hooks) {
   setupApplicationTest(hooks);
-  setupBaseRealm(hooks);
   setupLocalIndexing(hooks);
   setupServerSentEvents(hooks);
   setupOnSave(hooks);
@@ -106,6 +105,7 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     loggedInAs: '@testuser:staging',
     activeRealms: [testRealmURL],
   });
+  setupBaseRealm(hooks);
 
   hooks.beforeEach(async function () {
     class Pet extends CardDef {

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -1,4 +1,4 @@
-import { click, fillIn, waitFor } from '@ember/test-helpers';
+import { click, fillIn } from '@ember/test-helpers';
 
 import { setupApplicationTest } from 'ember-qunit';
 
@@ -32,7 +32,6 @@ import { setupMockMatrix } from '../helpers/mock-matrix';
 
 async function selectCardFromCatalog(cardId: string) {
   await click('[data-test-choose-card-btn]');
-  await waitFor(`[data-test-select="${cardId}"]`);
   await click(`[data-test-select="${cardId}"]`);
   await click('[data-test-card-catalog-go-button]');
 }
@@ -61,7 +60,7 @@ async function assertMessages(
       assert
         .dom(`[data-test-message-idx="${index}"] [data-test-message-cards]`)
         .exists({ count: 1 });
-      await assert
+      assert
         .dom(`[data-test-message-idx="${index}"] [data-test-attached-card]`)
         .exists({ count: cards.length });
       cards.map(async (card) => {
@@ -80,7 +79,7 @@ async function assertMessages(
         }
 
         if (card.realmIconUrl) {
-          await assert
+          assert
             .dom(
               `[data-test-message-idx="${index}"] [data-test-attached-card="${card.id}"] [data-test-realm-icon-url="${card.realmIconUrl}"]`,
             )
@@ -88,7 +87,7 @@ async function assertMessages(
         }
       });
     } else {
-      await assert
+      assert
         .dom(`[data-test-message-idx="${index}"] [data-test-message-cards]`)
         .doesNotExist();
     }
@@ -228,7 +227,6 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     const testCard = `${testRealmURL}Person/hassan`;
 
     for (let i = 1; i <= 3; i++) {
-      await waitFor('[data-test-message-field]');
       await fillIn('[data-test-message-field]', `Message - ${i}`);
       await selectCardFromCatalog(testCard);
       await click('[data-test-send-message-btn]');
@@ -255,9 +253,6 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     //Test the scenario where there is an update to the card
     await click(
       `[data-test-stack-card="${testRealmURL}index"] [data-test-cards-grid-item="${testCard}"]`,
-    );
-    await waitFor(
-      `[data-test-stack-card="${testCard}"] [data-test-edit-button]`,
     );
 
     await click(`[data-test-stack-card="${testCard}"] [data-test-edit-button]`);

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -28,7 +28,7 @@ import {
   StringField,
 } from '../helpers/base-realm';
 
-import { setupMatrixServiceMock } from '../helpers/mock-matrix-service';
+import { setupMockMatrix } from '../helpers/mock-matrix';
 
 async function selectCardFromCatalog(cardId: string) {
   await click('[data-test-choose-card-btn]');
@@ -102,7 +102,7 @@ module('Acceptance | AI Assistant tests', function (hooks) {
   setupServerSentEvents(hooks);
   setupOnSave(hooks);
   setupWindowMock(hooks);
-  setupMatrixServiceMock(hooks);
+  setupMockMatrix(hooks, { loggedInAs: '@testuser:staging' });
 
   hooks.beforeEach(async function () {
     class Pet extends CardDef {

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -102,7 +102,10 @@ module('Acceptance | AI Assistant tests', function (hooks) {
   setupServerSentEvents(hooks);
   setupOnSave(hooks);
   setupWindowMock(hooks);
-  setupMockMatrix(hooks, { loggedInAs: '@testuser:staging' });
+  setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:staging',
+    activeRealms: [testRealmURL],
+  });
 
   hooks.beforeEach(async function () {
     class Pet extends CardDef {

--- a/packages/host/tests/acceptance/permissioned-realm-test.gts
+++ b/packages/host/tests/acceptance/permissioned-realm-test.gts
@@ -15,14 +15,17 @@ import {
   testRealmURL,
   lookupLoaderService,
 } from '../helpers';
-import { setupMatrixServiceMock } from '../helpers/mock-matrix-service';
+import { setupMockMatrix } from '../helpers/mock-matrix';
 
 module('Acceptance | permissioned realm tests', function (hooks) {
   setupApplicationTest(hooks);
   setupLocalIndexing(hooks);
   setupServerSentEvents(hooks);
   setupWindowMock(hooks);
-  setupMatrixServiceMock(hooks);
+  setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:staging',
+    activeRealms: [testRealmURL],
+  });
 
   hooks.beforeEach(async function () {
     let loader = lookupLoaderService().loader;

--- a/packages/host/tests/helpers/mock-matrix.ts
+++ b/packages/host/tests/helpers/mock-matrix.ts
@@ -1,6 +1,12 @@
 import window from 'ember-window-mock';
 
-import { ExtendedMatrixSDK } from '@cardstack/host/services/matrix-sdk-loader';
+import type {
+  ExtendedClient,
+  ExtendedMatrixSDK,
+  MessageOptions,
+} from '@cardstack/host/services/matrix-sdk-loader';
+
+import { MatrixEvent } from 'https://cardstack.com/base/matrix-event';
 
 import { createJWT } from './index';
 
@@ -81,18 +87,17 @@ class ServerState {
   }
 }
 
-class MockSDK implements ExtendedMatrixSDK {
+// without this, using a class as an interface forces you to have the same
+// private and protected methods too
+type PublicAPI<T> = { [K in keyof T]: T[K] };
+
+class MockSDK implements PublicAPI<ExtendedMatrixSDK> {
   private serverState = new ServerState();
 
   constructor(private sdkOpts: Options) {}
 
   createClient(clientOpts: MatrixSDK.ICreateClientOpts) {
-    return new MockClient(
-      this,
-      this.serverState,
-      clientOpts,
-      this.sdkOpts,
-    ) as unknown as MatrixSDK.MatrixClient;
+    return new MockClient(this, this.serverState, clientOpts, this.sdkOpts);
   }
 
   RoomEvent = {
@@ -116,25 +121,7 @@ class MockSDK implements ExtendedMatrixSDK {
   } as ExtendedMatrixSDK['ClientEvent'];
 }
 
-class MockClient
-  implements
-    Pick<
-      MatrixSDK.MatrixClient,
-      | 'isLoggedIn'
-      | 'getUserId'
-      | 'getProfileInfo'
-      | 'getThreePids'
-      | 'createRoom'
-      | 'setPowerLevel'
-      | 'on'
-      | 'off'
-      | 'startClient'
-      | 'getJoinedRooms'
-      | 'decryptEventIfNeeded'
-      | 'getRoom'
-      | 'sendEvent'
-    >
-{
+class MockClient implements ExtendedClient {
   private listeners = new Map();
 
   constructor(
@@ -144,11 +131,168 @@ class MockClient
     private sdkOpts: Options,
   ) {}
 
-  async sendEvent(
+  addThreePidOnly(_data: MatrixSDK.IAddThreePidOnlyBody): Promise<{}> {
+    throw new Error('Method not implemented.');
+  }
+
+  get credentials(): { userId: string | null } {
+    throw new Error('Method not implemented.');
+  }
+
+  deleteThreePid(
+    _medium: string,
+    _address: string,
+  ): Promise<{ id_server_unbind_result: MatrixSDK.IdServerUnbindResult }> {
+    throw new Error('Method not implemented.');
+  }
+
+  fetchRoomEvent(
+    _roomId: string,
+    _eventId: string,
+  ): Promise<Partial<MatrixSDK.IEvent>> {
+    throw new Error('Method not implemented.');
+  }
+
+  forget(_roomId: string, _deleteRoom?: boolean | undefined): Promise<{}> {
+    throw new Error('Method not implemented.');
+  }
+
+  isUsernameAvailable(_username: string): Promise<boolean> {
+    throw new Error('Method not implemented.');
+  }
+
+  leave(_roomId: string): Promise<{}> {
+    throw new Error('Method not implemented.');
+  }
+
+  registerRequest(
+    _data: MatrixSDK.RegisterRequest,
+    _kind?: string | undefined,
+  ): Promise<MatrixSDK.RegisterResponse> {
+    throw new Error('Method not implemented.');
+  }
+
+  requestPasswordEmailToken(
+    _email: string,
+    _clientSecret: string,
+    _sendAttempt: number,
+    _nextLink?: string | undefined,
+  ): Promise<MatrixSDK.IRequestTokenResponse> {
+    throw new Error('Method not implemented.');
+  }
+
+  scrollback(
+    _room: MatrixSDK.Room,
+    _limit?: number | undefined,
+  ): Promise<MatrixSDK.Room> {
+    throw new Error('Method not implemented.');
+  }
+
+  sendReadReceipt(
+    _event: MatrixSDK.MatrixEvent | null,
+    _receiptType?: MatrixSDK.ReceiptType | undefined,
+    _unthreaded?: boolean | undefined,
+  ): Promise<{} | undefined> {
+    throw new Error('Method not implemented.');
+  }
+
+  setPassword(
+    _authDict: MatrixSDK.AuthDict,
+    _newPassword: string,
+    _logoutDevices?: boolean | undefined,
+  ): Promise<{}> {
+    throw new Error('Method not implemented.');
+  }
+
+  setRoomName(
+    _roomId: string,
+    _name: string,
+  ): Promise<MatrixSDK.ISendEventResponse> {
+    throw new Error('Method not implemented.');
+  }
+
+  invite(
+    _roomId: string,
+    _userId: string,
+    _reason?: string | undefined,
+  ): Promise<{}> {
+    throw new Error('Method not implemented.');
+  }
+
+  joinRoom(
+    _roomIdOrAlias: string,
+    _opts?: MatrixSDK.IJoinRoomOpts | undefined,
+  ): Promise<MatrixSDK.Room> {
+    throw new Error('Method not implemented.');
+  }
+
+  loginWithPassword(
+    _user: string,
+    _password: string,
+  ): Promise<MatrixSDK.LoginResponse> {
+    throw new Error('Method not implemented.');
+  }
+
+  logout(_stopClient?: boolean | undefined): Promise<{}> {
+    throw new Error('Method not implemented.');
+  }
+
+  roomState(_roomId: string): Promise<MatrixSDK.IStateEventWithRoomId[]> {
+    throw new Error('Method not implemented.');
+  }
+
+  setDisplayName(_name: string): Promise<{}> {
+    throw new Error('Method not implemented.');
+  }
+
+  allRoomMessages(
+    _roomId: string,
+    _opts?: MessageOptions | undefined,
+  ): Promise<MatrixEvent[]> {
+    throw new Error('Method not implemented.');
+  }
+
+  requestEmailToken(
+    _type: 'registration' | 'threepid',
+    _email: string,
+    _clientSecret: string,
+    _sendAttempt: number,
+  ): Promise<MatrixSDK.IRequestTokenResponse> {
+    throw new Error('Method not implemented.');
+  }
+
+  loginWithEmail(
+    _email: string,
+    _password: string,
+  ): Promise<MatrixSDK.LoginResponse> {
+    throw new Error('Method not implemented.');
+  }
+
+  sendEvent(
     roomId: string,
     eventType: string,
     content: MatrixSDK.IContent,
-  ): Promise<MatrixSDK.ISendEventResponse> {
+    txnId?: string,
+  ): Promise<MatrixSDK.ISendEventResponse>;
+  sendEvent(
+    roomId: string,
+    threadId: string | null,
+    eventType: string,
+    content: MatrixSDK.IContent,
+    txnId?: string,
+  ): Promise<MatrixSDK.ISendEventResponse>;
+  async sendEvent(...args: any[]): Promise<MatrixSDK.ISendEventResponse> {
+    let roomId: string;
+
+    let eventType: string;
+    let content: MatrixSDK.IContent;
+
+    if (typeof args[2] === 'object') {
+      [roomId, eventType, content] = args;
+    } else {
+      [roomId, , eventType, content] = args;
+    }
+
     let roomEvent = {
       event_id: this.serverState.eventId(),
       room_id: roomId,
@@ -252,8 +396,8 @@ class MockClient
   }
 
   off<T extends MatrixSDK.EmittedEvents | MatrixSDK.EventEmitterEvents>(
-    event: T,
-    listener: MatrixSDK.Listener<
+    _event: T,
+    _listener: MatrixSDK.Listener<
       MatrixSDK.EmittedEvents,
       MatrixSDK.ClientEventHandlerMap,
       T
@@ -263,11 +407,13 @@ class MockClient
   }
 
   async setPowerLevel(
-    roomId: string,
-    userId: string | string[],
-    powerLevel: number | undefined,
-    event?: MatrixSDK.MatrixEvent | null | undefined,
-  ): Promise<MatrixSDK.ISendEventResponse> {}
+    _roomId: string,
+    _userId: string | string[],
+    _powerLevel: number | undefined,
+    _event?: MatrixSDK.MatrixEvent | null | undefined,
+  ): Promise<MatrixSDK.ISendEventResponse> {
+    return { event_id: this.serverState.eventId() };
+  }
 
   async createRoom(
     _options: MatrixSDK.ICreateRoomOpts,

--- a/packages/host/tests/helpers/mock-matrix.ts
+++ b/packages/host/tests/helpers/mock-matrix.ts
@@ -1,0 +1,195 @@
+import window from 'ember-window-mock';
+
+import { ExtendedMatrixSDK } from '@cardstack/host/services/matrix-sdk-loader';
+
+import type * as MatrixSDK from 'matrix-js-sdk';
+
+export interface Options {
+  loggedInAs?: string;
+  displayName?: string;
+}
+
+export function setupMockMatrix(hooks: NestedHooks, opts: Options = {}) {
+  hooks.beforeEach(function () {
+    let sdk = new MockSDK(opts);
+    if (opts.loggedInAs) {
+      window.localStorage.setItem(
+        'auth',
+        JSON.stringify({
+          access_token: 'mock-access-token',
+          device_id: 'mock-device-id',
+          user_id: opts.loggedInAs,
+        }),
+      );
+    }
+    this.owner.register(
+      'service:matrixSdkLoader',
+      {
+        async load() {
+          return sdk;
+        },
+      },
+      {
+        instantiate: false,
+      },
+    );
+  });
+}
+
+class MockSDK implements ExtendedMatrixSDK {
+  constructor(private sdkOpts: Options) {}
+
+  createClient(clientOpts: MatrixSDK.ICreateClientOpts) {
+    return new MockClient(
+      this,
+      clientOpts,
+      this.sdkOpts,
+    ) as unknown as MatrixSDK.MatrixClient;
+  }
+
+  RoomEvent = {
+    Timeline: 'Room.timeline',
+    LocalEchoUpdated: 'Room.localEchoUpdated',
+    Receipt: 'Room.receipt',
+  };
+
+  RoomMemberEvent = {
+    Membership: 'RoomMember.membership',
+  };
+
+  Preset = {
+    PrivateChat: 'private_chat',
+    TrustedPrivateChat: 'trusted_private_chat',
+    PublicChat: 'public_chat',
+  };
+
+  ClientEvent = {
+    AccountData: 'accountData',
+  } as ExtendedMatrixSDK['ClientEvent'];
+}
+
+class MockClient
+  implements
+    Pick<
+      MatrixSDK.MatrixClient,
+      | 'isLoggedIn'
+      | 'getUserId'
+      | 'getProfileInfo'
+      | 'getThreePids'
+      | 'createRoom'
+      | 'setPowerLevel'
+      | 'on'
+      | 'off'
+      | 'startClient'
+    >
+{
+  private listeners = new Map();
+
+  constructor(
+    private sdk: MockSDK,
+    _clientOpts: MatrixSDK.ICreateClientOpts,
+    private sdkOpts: Options,
+  ) {}
+
+  async startClient(
+    _opts?: MatrixSDK.IStartClientOpts | undefined,
+  ): Promise<void> {
+    await this.emitEvent(this.sdk.ClientEvent.AccountData, {
+      type: 'com.cardstack.boxel.realms',
+      content: {
+        realms: [],
+      },
+    });
+  }
+
+  private async emitEvent(
+    eventType: MatrixSDK.EmittedEvents | MatrixSDK.EventEmitterEvents,
+    event: { type: string; content: any },
+  ) {
+    let handlers = this.listeners.get(eventType);
+    if (handlers) {
+      for (let handler of handlers) {
+        await handler({ event });
+      }
+    }
+  }
+
+  on<T extends MatrixSDK.EmittedEvents | MatrixSDK.EventEmitterEvents>(
+    event: T,
+    listener: MatrixSDK.Listener<
+      MatrixSDK.EmittedEvents,
+      MatrixSDK.ClientEventHandlerMap,
+      T
+    >,
+  ): MatrixSDK.MatrixClient {
+    if (!event) {
+      throw new Error(`missing event type in matrix mock`);
+    }
+    let list = this.listeners.get(event);
+    if (!list) {
+      list = [];
+      this.listeners.set(event, list);
+    }
+    list.push(listener);
+    return this as unknown as MatrixSDK.MatrixClient;
+  }
+
+  off<T extends MatrixSDK.EmittedEvents | MatrixSDK.EventEmitterEvents>(
+    event: T,
+    listener: MatrixSDK.Listener<
+      MatrixSDK.EmittedEvents,
+      MatrixSDK.ClientEventHandlerMap,
+      T
+    >,
+  ): MatrixSDK.MatrixClient {
+    return this as unknown as MatrixSDK.MatrixClient;
+  }
+
+  async setPowerLevel(
+    roomId: string,
+    userId: string | string[],
+    powerLevel: number | undefined,
+    event?: MatrixSDK.MatrixEvent | null | undefined,
+  ): Promise<MatrixSDK.ISendEventResponse> {
+    throw new Error('Method not implemented.');
+  }
+
+  async createRoom(
+    _options: MatrixSDK.ICreateRoomOpts,
+  ): Promise<{ room_id: string }> {
+    throw new Error('Method not implemented.');
+  }
+
+  async getThreePids(): Promise<{ threepids: MatrixSDK.IThreepid[] }> {
+    return {
+      threepids: [
+        {
+          added_at: 0,
+          validated_at: 0,
+          address: 'testuser@example.com',
+          medium: 'email' as MatrixSDK.ThreepidMedium.Email,
+        },
+      ],
+    };
+  }
+
+  async getProfileInfo(
+    _userId: string,
+    _info?: string | undefined,
+  ): Promise<{
+    avatar_url?: string | undefined;
+    displayname?: string | undefined;
+  }> {
+    return {
+      displayname: this.sdkOpts.displayName ?? 'Mock User',
+    };
+  }
+
+  isLoggedIn() {
+    return Boolean(this.sdkOpts.loggedInAs);
+  }
+
+  getUserId(): string | null {
+    return this.sdkOpts.loggedInAs ?? null;
+  }
+}

--- a/packages/host/tests/helpers/mock-matrix.ts
+++ b/packages/host/tests/helpers/mock-matrix.ts
@@ -7,6 +7,7 @@ import type * as MatrixSDK from 'matrix-js-sdk';
 export interface Options {
   loggedInAs?: string;
   displayName?: string;
+  activeRealms?: string[];
 }
 
 export function setupMockMatrix(hooks: NestedHooks, opts: Options = {}) {
@@ -36,12 +37,35 @@ export function setupMockMatrix(hooks: NestedHooks, opts: Options = {}) {
   });
 }
 
+class ServerState {
+  #roomCounter = 0;
+  #eventCounter = 0;
+  #rooms: { id: string }[] = [];
+
+  get rooms(): { id: string }[] {
+    return this.#rooms;
+  }
+
+  createRoom(): string {
+    let id = `mock_room_${this.#roomCounter++}`;
+    this.#rooms.push({ id });
+    return id;
+  }
+
+  eventId(): string {
+    return `mock_event_${this.#eventCounter++}`;
+  }
+}
+
 class MockSDK implements ExtendedMatrixSDK {
+  private serverState = new ServerState();
+
   constructor(private sdkOpts: Options) {}
 
   createClient(clientOpts: MatrixSDK.ICreateClientOpts) {
     return new MockClient(
       this,
+      this.serverState,
       clientOpts,
       this.sdkOpts,
     ) as unknown as MatrixSDK.MatrixClient;
@@ -51,17 +75,17 @@ class MockSDK implements ExtendedMatrixSDK {
     Timeline: 'Room.timeline',
     LocalEchoUpdated: 'Room.localEchoUpdated',
     Receipt: 'Room.receipt',
-  };
+  } as ExtendedMatrixSDK['RoomEvent'];
 
   RoomMemberEvent = {
     Membership: 'RoomMember.membership',
-  };
+  } as ExtendedMatrixSDK['RoomMemberEvent'];
 
   Preset = {
     PrivateChat: 'private_chat',
     TrustedPrivateChat: 'trusted_private_chat',
     PublicChat: 'public_chat',
-  };
+  } as ExtendedMatrixSDK['Preset'];
 
   ClientEvent = {
     AccountData: 'accountData',
@@ -81,35 +105,104 @@ class MockClient
       | 'on'
       | 'off'
       | 'startClient'
+      | 'getJoinedRooms'
+      | 'decryptEventIfNeeded'
+      | 'getRoom'
+      | 'sendEvent'
     >
 {
   private listeners = new Map();
 
   constructor(
     private sdk: MockSDK,
+    private serverState: ServerState,
     _clientOpts: MatrixSDK.ICreateClientOpts,
     private sdkOpts: Options,
   ) {}
 
+  async sendEvent(
+    roomId: string,
+    eventType: string,
+    content: MatrixSDK.IContent,
+  ): Promise<MatrixSDK.ISendEventResponse> {
+    let roomEvent = {
+      event_id: this.serverState.eventId(),
+      room_id: roomId,
+      state_key: 'state',
+      type: eventType,
+      sender: this.sdkOpts.loggedInAs || 'unknown_user',
+      origin_server_ts: Date.now(),
+      content,
+      status: null,
+      unsigned: {
+        age: 105,
+        transaction_id: '1',
+      },
+    };
+    await this.emitEvent(roomEvent);
+    return roomEvent;
+  }
+
+  getRoom(roomId: string | undefined): MatrixSDK.Room | null {
+    let hit = this.serverState.rooms.find((r) => r.id === roomId);
+    if (hit) {
+      return {
+        getMember(_userId: string) {
+          return {
+            membership: 'join',
+          };
+        },
+        oldState: {},
+      } as MatrixSDK.Room;
+    }
+    return null;
+  }
+
+  async decryptEventIfNeeded(
+    _event: MatrixSDK.MatrixEvent,
+    _options?: MatrixSDK.IDecryptOptions | undefined,
+  ): Promise<void> {}
+
+  async getJoinedRooms(): Promise<{
+    joined_rooms: string[];
+  }> {
+    return {
+      joined_rooms: this.serverState.rooms.map((r) => r.id),
+    };
+  }
+
   async startClient(
     _opts?: MatrixSDK.IStartClientOpts | undefined,
   ): Promise<void> {
-    await this.emitEvent(this.sdk.ClientEvent.AccountData, {
+    await this.emitEvent({
       type: 'com.cardstack.boxel.realms',
       content: {
-        realms: [],
+        realms: this.sdkOpts.activeRealms ?? [],
       },
     });
   }
 
-  private async emitEvent(
-    eventType: MatrixSDK.EmittedEvents | MatrixSDK.EventEmitterEvents,
-    event: { type: string; content: any },
-  ) {
-    let handlers = this.listeners.get(eventType);
+  private eventHandlerType(type: string) {
+    switch (type) {
+      case 'com.cardstack.boxel.realms':
+        return this.sdk.ClientEvent.AccountData;
+      case 'm.room.create':
+      case 'm.room.message':
+        return this.sdk.RoomEvent.Timeline;
+      default:
+        throw new Error(`unknown type ${type} in mock`);
+    }
+  }
+
+  private async emitEvent(event: { type: string } & Record<string, unknown>) {
+    let handlers = this.listeners.get(this.eventHandlerType(event.type));
     if (handlers) {
       for (let handler of handlers) {
-        await handler({ event });
+        let result: any = { event };
+        result.getContent = function () {
+          return this.event.content;
+        };
+        await handler(result);
       }
     }
   }
@@ -150,14 +243,23 @@ class MockClient
     userId: string | string[],
     powerLevel: number | undefined,
     event?: MatrixSDK.MatrixEvent | null | undefined,
-  ): Promise<MatrixSDK.ISendEventResponse> {
-    throw new Error('Method not implemented.');
-  }
+  ): Promise<MatrixSDK.ISendEventResponse> {}
 
   async createRoom(
     _options: MatrixSDK.ICreateRoomOpts,
   ): Promise<{ room_id: string }> {
-    throw new Error('Method not implemented.');
+    let room_id = this.serverState.createRoom();
+
+    this.emitEvent({
+      event_id: this.serverState.eventId(),
+      origin_server_ts: new Date().getTime(),
+      room_id,
+      sender: this.sdkOpts.loggedInAs ?? 'unknown_user',
+      state_key: '',
+      type: 'm.room.create',
+    });
+
+    return { room_id };
   }
 
   async getThreePids(): Promise<{ threepids: MatrixSDK.IThreepid[] }> {

--- a/packages/host/tests/integration/components/ai-assistant-panel-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel-test.gts
@@ -11,7 +11,6 @@ import { format, subMinutes } from 'date-fns';
 import { setupRenderingTest } from 'ember-qunit';
 import window from 'ember-window-mock';
 import { setupWindowMock } from 'ember-window-mock/test-support';
-import { EventStatus } from 'matrix-js-sdk';
 import { module, test } from 'qunit';
 
 import { Deferred, baseRealm } from '@cardstack/runtime-common';
@@ -1265,7 +1264,7 @@ module('Integration | ai-assistant-panel', function (hooks) {
           age: 105,
           transaction_id: '1',
         },
-        status: EventStatus.SENDING,
+        status: 'sending',
       };
       await addRoomEvent(this, event);
     };
@@ -1286,7 +1285,7 @@ module('Integration | ai-assistant-panel', function (hooks) {
     let newEvent = {
       ...event,
       event_id: 'updated-event-id',
-      status: EventStatus.SENT,
+      status: 'sent',
     };
     await updateRoomEvent(matrixService, newEvent, event.event_id);
     await waitUntil(
@@ -1343,7 +1342,7 @@ module('Integration | ai-assistant-panel', function (hooks) {
           age: 105,
           transaction_id: '1',
         },
-        status: EventStatus.SENDING,
+        status: 'sending',
       };
       await addRoomEvent(this, event);
     };
@@ -1363,7 +1362,7 @@ module('Integration | ai-assistant-panel', function (hooks) {
     let newEvent = {
       ...event,
       event_id: 'updated-event-id',
-      status: EventStatus.NOT_SENT,
+      status: 'not_sent',
     };
     await updateRoomEvent(matrixService, newEvent, event.event_id);
     await waitUntil(


### PR DESCRIPTION
We are working on changing how matrix gets mocked in tests. Right now the whole matrix service gets mocked, which means we're unable to exercise a large part of our actual logic. This also forces the implementation of the matrix service to be splatted over several files.

Instead, we want to mock the actual Matrix client that underlies the matrix service and let the matrix service function in tests.