### PR TITLE
Cs-7109/show-view-code-panel-above-result

### DIFF
--- a/packages/host/app/components/matrix/room-message.gts
+++ b/packages/host/app/components/matrix/room-message.gts
@@ -200,10 +200,6 @@ export default class RoomMessage extends Component<Signature> {
               data-test-command-apply={{this.applyButtonState}}
             />
           </div>
-
-          {{#let this.getComponent as |Component|}}
-            <Component @format='embedded' />
-          {{/let}}
           {{#if this.isDisplayingCode}}
             <div class='preview-code'>
               <Button
@@ -238,6 +234,9 @@ export default class RoomMessage extends Component<Signature> {
               />
             </div>
           {{/if}}
+          {{#let this.getComponent as |Component|}}
+            <Component @format='embedded' />
+          {{/let}}
         {{/if}}
       </AiAssistantMessage>
     {{/if}}
@@ -273,7 +272,7 @@ export default class RoomMessage extends Component<Signature> {
         --fill-container-spacing: calc(
           -1 * var(--ai-assistant-message-padding)
         );
-        margin: var(--boxel-sp) var(--fill-container-spacing)
+        margin: var(--boxel-sp) var(--fill-container-spacing) 0
           var(--fill-container-spacing);
         padding: var(--spacing) 0;
         background-color: var(--boxel-dark);


### PR DESCRIPTION
**Before**
<img width="349" alt="Screenshot 2024-09-10 at 14 12 26" src="https://github.com/user-attachments/assets/148deba9-b939-4a0c-852c-6ad2bf5a4fe4">

**After**

<img width="350" alt="Screenshot 2024-09-10 at 14 10 48" src="https://github.com/user-attachments/assets/12fc4bda-f15e-42f8-9789-26ca51204e1e">
