### PR TITLE
Add a dropdown to cards-grid card to order by title or updated at 

### DIFF
--- a/packages/base/cards-grid.gts
+++ b/packages/base/cards-grid.gts
@@ -17,6 +17,9 @@ import {
   FilterList,
   Tooltip,
   type Filter,
+  BoxelDropdown,
+  Menu as BoxelMenu,
+  BoxelButton,
 } from '@cardstack/boxel-ui/components';
 import {
   chooseCard,
@@ -24,14 +27,46 @@ import {
   baseRealm,
   isCardInstance,
   SupportedMimeType,
+  Query,
 } from '@cardstack/runtime-common';
 import { tracked } from '@glimmer/tracking';
-
+import { DropdownArrowDown } from '@cardstack/boxel-ui/icons';
 // @ts-ignore no types
 import cssUrl from 'ember-css-url';
 import { type CatalogEntry } from './catalog-entry';
 import StringField from './string';
 import { TrackedArray } from 'tracked-built-ins';
+import { MenuItem } from '@cardstack/boxel-ui/helpers';
+
+interface SortOption {
+  displayName: string;
+  sort: Query['sort'];
+}
+
+let availableSortOptions: SortOption[] = [
+  {
+    displayName: 'A-Z',
+    sort: [
+      {
+        on: {
+          module: `${baseRealm.url}card-api`,
+          name: 'CardDef',
+        },
+        by: 'title',
+        direction: 'asc',
+      },
+    ],
+  },
+  {
+    displayName: 'Updated at',
+    sort: [
+      {
+        by: 'lastModified',
+        direction: 'desc',
+      },
+    ],
+  },
+];
 
 class Isolated extends Component<typeof CardsGrid> {
   <template>
@@ -44,7 +79,32 @@ class Isolated extends Component<typeof CardsGrid> {
         />
       </div>
       <div class='content'>
-        <span class='headline'>{{this.activeFilter.displayName}}</span>
+        <div class='top-bar'>
+          <div class='title'>
+            {{this.activeFilter.displayName}}
+          </div>
+          <div class='sorting'>
+            <span>
+              Sort by
+            </span>
+
+            <BoxelDropdown>
+              <:trigger as |bindings|>
+                <BoxelButton class='sort-button' {{bindings}}>
+                  {{this.selectedSortOption.displayName}}
+                  <DropdownArrowDown width='12px' height='12px' />
+                </BoxelButton>
+              </:trigger>
+              <:content as |dd|>
+                <BoxelMenu
+                  @closeMenu={{dd.close}}
+                  @items={{this.sortMenuOptions}}
+                />
+              </:content>
+            </BoxelDropdown>
+          </div>
+        </div>
+
         <ul class='cards' data-test-cards-grid-cards>
           {{#if this.isShowingCards}}
             {{#let
@@ -52,7 +112,7 @@ class Isolated extends Component<typeof CardsGrid> {
               as |PrerenderedCardSearch|
             }}
               <PrerenderedCardSearch
-                @query={{this.activeFilter.query}}
+                @query={{this.query}}
                 @format='fitted'
                 @realms={{this.realms}}
               >
@@ -105,6 +165,32 @@ class Isolated extends Component<typeof CardsGrid> {
     <style scoped>
       :global(:root) {
         --cards-grid-padding-top: var(--boxel-sp-lg);
+      }
+      .top-bar {
+        display: flex;
+        padding-right: var(--boxel-sp);
+      }
+      .sort-button {
+        border-radius: var(--boxel-border-radius);
+        min-width: 200px;
+        justify-content: flex-start;
+        padding-left: var(--boxel-sp-sm);
+        padding-right: var(--boxel-sp-sm);
+      }
+
+      .sort-button > svg {
+        margin-left: auto;
+      }
+      .sorting {
+        margin-left: auto;
+      }
+      .sorting > span {
+        margin-right: var(--boxel-sp-xs);
+      }
+      .title {
+        font: bold var(--boxel-font-lg);
+        line-height: 1.58;
+        letter-spacing: 0.21px;
       }
       .cards-grid {
         --grid-card-width: 11.125rem;
@@ -177,11 +263,6 @@ class Isolated extends Component<typeof CardsGrid> {
     </style>
   </template>
 
-  constructor(owner: any, args: any) {
-    super(owner, args);
-    this.loadFilterList.perform();
-  }
-
   filters: { displayName: string; query: any }[] = new TrackedArray([
     {
       displayName: 'Favorites',
@@ -192,22 +273,6 @@ class Isolated extends Component<typeof CardsGrid> {
               return { eq: { id: card.id } } ?? {};
             }) ?? [],
         },
-        sort: [
-          {
-            on: {
-              module: `${baseRealm.url}card-api`,
-              name: 'CardDef',
-            },
-            by: '_cardType',
-          },
-          {
-            on: {
-              module: `${baseRealm.url}card-api`,
-              name: 'CardDef',
-            },
-            by: 'title',
-          },
-        ],
       },
     },
     {
@@ -220,41 +285,55 @@ class Isolated extends Component<typeof CardsGrid> {
             },
           },
         },
-        // sorting by title so that we can maintain stability in
-        // the ordering of the search results (server sorts results
-        // by order indexed by default)
-        sort: [
-          {
-            on: {
-              module: `${baseRealm.url}card-api`,
-              name: 'CardDef',
-            },
-            by: '_cardType',
-          },
-          {
-            on: {
-              module: `${baseRealm.url}card-api`,
-              name: 'CardDef',
-            },
-            by: 'title',
-          },
-        ],
       },
     },
   ]);
+
+  @tracked private selectedSortOption: SortOption = availableSortOptions[0];
   @tracked activeFilter = this.filters[0];
+
+  @action setSelectedSortOption(option: SortOption) {
+    this.selectedSortOption = option;
+    this.activeFilter = this.activeFilter;
+  }
 
   @action onFilterChanged(filter: Filter) {
     this.activeFilter = filter;
   }
 
-  get realms(): string[] {
-    return this.args.model[realmURL] ? [this.args.model[realmURL].href] : [];
-  }
-
   @action
   createNew() {
     this.createCard.perform();
+  }
+
+  constructor(owner: any, args: any) {
+    super(owner, args);
+    this.loadFilterList.perform();
+  }
+
+  private get sortMenuOptions() {
+    return availableSortOptions.map((option) => {
+      return new MenuItem(option.displayName, 'action', {
+        action: () => {
+          this.setSelectedSortOption(option);
+        },
+      });
+    });
+  }
+
+  private get realms(): string[] {
+    return this.args.model[realmURL] ? [this.args.model[realmURL].href] : [];
+  }
+
+  private get query() {
+    return { ...this.activeFilter.query, sort: this.selectedSortOption.sort };
+  }
+
+  private get isShowingCards() {
+    return (
+      this.activeFilter.displayName !== 'Favorites' ||
+      (this.args.model.favorites && this.args.model.favorites.length > 0)
+    );
   }
 
   private createCard = restartableTask(async () => {
@@ -309,33 +388,10 @@ class Isolated extends Component<typeof CardsGrid> {
               name: summary.id.substring(lastIndex + 1),
             },
           },
-          sort: [
-            {
-              on: {
-                module: `${baseRealm.url}card-api`,
-                name: 'CardDef',
-              },
-              by: '_cardType',
-            },
-            {
-              on: {
-                module: `${baseRealm.url}card-api`,
-                name: 'CardDef',
-              },
-              by: 'title',
-            },
-          ],
         },
       });
     });
   });
-
-  private get isShowingCards() {
-    return (
-      this.activeFilter.displayName !== 'Favorites' ||
-      (this.args.model.favorites && this.args.model.favorites.length > 0)
-    );
-  }
 }
 
 export class CardsGrid extends CardDef {

--- a/packages/host/tests/unit/index-query-engine-test.ts
+++ b/packages/host/tests/unit/index-query-engine-test.ts
@@ -579,4 +579,13 @@ module('Unit | query', function (hooks) {
       testCards,
     });
   });
+
+  test('can sort using a general field that is not an attribute of a card', async function (assert) {
+    await runSharedTest(indexQueryEngineTests, assert, {
+      indexQueryEngine,
+      dbAdapter,
+      loader,
+      testCards,
+    });
+  });
 });

--- a/packages/realm-server/tests/index-query-engine-test.ts
+++ b/packages/realm-server/tests/index-query-engine-test.ts
@@ -522,4 +522,13 @@ module('query', function (hooks) {
       testCards: await makeTestCards(loader),
     });
   });
+
+  test('can sort using a general field that is not an attribute of a card', async function (assert) {
+    await runSharedTest(indexQueryEngineTests, assert, {
+      indexQueryEngine,
+      dbAdapter,
+      loader,
+      testCards: await makeTestCards(loader),
+    });
+  });
 });

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -119,6 +119,11 @@ export interface QueryResultsMeta {
   };
 }
 
+// A mapper for fields that can be sorted on but are not an attribute of a card
+export const generalSortFields: Record<string, string> = {
+  lastModified: 'last_modified',
+};
+
 export function isValidPrerenderedHtmlFormat(
   format: string | undefined,
 ): format is PrerenderedCardOptions['htmlFormat'] {
@@ -371,6 +376,15 @@ export class IndexQueryEngine {
     return { cards, meta };
   }
 
+  private generalFieldSortColumn(field: string) {
+    let mappedField = generalSortFields[field];
+    if (mappedField) {
+      return mappedField;
+    } else {
+      throw new Error(`Unknown sort field: ${field}`);
+    }
+  }
+
   private orderExpression(sort: Sort | undefined): CardExpression {
     if (!sort) {
       return ['ORDER BY url COLLATE "POSIX"'];
@@ -382,7 +396,9 @@ export class IndexQueryEngine {
           // intentionally not using field arity here--not sure what it means to
           // sort via a plural field
           'ANY_VALUE(',
-          fieldQuery(s.by, s.on, false, 'sort'),
+          'on' in s
+            ? fieldQuery(s.by, s.on, false, 'sort')
+            : this.generalFieldSortColumn(s.by),
           ')',
           s.direction ?? 'asc',
           'NULLS LAST',
@@ -479,7 +495,7 @@ export class IndexQueryEngine {
     let results = (await this.query([
       `SELECT value
        FROM realm_meta rm
-       INNER JOIN realm_versions rv 
+       INNER JOIN realm_versions rv
        ON rm.realm_url = rv.realm_url AND rm.realm_version = rv.current_version
        WHERE`,
       ...every([['rm.realm_url =', param(realmURL.href)]]),

--- a/packages/runtime-common/query.ts
+++ b/packages/runtime-common/query.ts
@@ -3,7 +3,7 @@ import isEqual from 'lodash/isEqual';
 import { assertJSONValue, assertJSONPrimitive } from './json-validation';
 import qs from 'qs';
 
-import { type CodeRef, isCodeRef } from './index';
+import { type CodeRef, isCodeRef, generalSortFields } from './index';
 
 export interface Query {
   filter?: Filter;
@@ -29,11 +29,20 @@ export interface TypedFilter {
   on?: CodeRef;
 }
 
-interface SortExpression {
+type GeneralSortField = keyof typeof generalSortFields;
+
+type SortExpressionWithoutCodeRef = {
+  by: GeneralSortField;
+  direction?: 'asc' | 'desc';
+};
+
+type SortExpressionWithCodeRef = {
   by: string;
   on: CodeRef;
   direction?: 'asc' | 'desc';
-}
+};
+
+type SortExpression = SortExpressionWithoutCodeRef | SortExpressionWithCodeRef;
 
 export type Sort = SortExpression[];
 
@@ -164,6 +173,9 @@ function assertSortExpression(
     );
   }
   if (!('on' in sort)) {
+    if (Object.keys(generalSortFields).includes(sort.by)) {
+      return;
+    }
     throw new Error(
       `${pointer.concat('on').join('/') || '/'}: missing on object`,
     );

--- a/packages/runtime-common/tests/index-query-engine-test.ts
+++ b/packages/runtime-common/tests/index-query-engine-test.ts
@@ -2472,6 +2472,94 @@ const tests = Object.freeze({
       `'null' is not a permitted value in a 'range' filter`,
     );
   },
+  'can sort using a general field that is not an attribute of a card': async (
+    assert,
+    { indexQueryEngine, dbAdapter, loader },
+  ) => {
+    await setupIndex(dbAdapter, [
+      {
+        url: `${testRealmURL}vangogh.json`,
+        file_alias: `${testRealmURL}vangogh`,
+        type: 'instance',
+        realm_version: 1,
+        realm_url: testRealmURL,
+        deps: [],
+        last_modified: '1',
+      },
+      {
+        url: `${testRealmURL}jimmy.json`,
+        file_alias: `${testRealmURL}jimmy`,
+        type: 'instance',
+        realm_version: 1,
+        realm_url: testRealmURL,
+        deps: [],
+        last_modified: '3',
+      },
+      {
+        url: `${testRealmURL}donald.json`,
+        file_alias: `${testRealmURL}donald`,
+        type: 'instance',
+        realm_version: 1,
+        realm_url: testRealmURL,
+        deps: [],
+        last_modified: '2',
+      },
+    ]);
+
+    let { prerenderedCards: results } =
+      await indexQueryEngine.searchPrerendered(
+        new URL(testRealmURL),
+        {
+          sort: [
+            {
+              by: 'lastModified',
+              direction: 'desc',
+            },
+          ],
+        },
+        loader,
+        {
+          htmlFormat: 'embedded',
+        },
+      );
+
+    assert.deepEqual(
+      results.map((r: { url: string }) => r.url),
+      [
+        `${testRealmURL}jimmy.json`,
+        `${testRealmURL}donald.json`,
+        `${testRealmURL}vangogh.json`,
+      ],
+      'results are correct',
+    );
+
+    let { prerenderedCards: results2 } =
+      await indexQueryEngine.searchPrerendered(
+        new URL(testRealmURL),
+        {
+          sort: [
+            {
+              by: 'lastModified',
+              direction: 'asc',
+            },
+          ],
+        },
+        loader,
+        {
+          htmlFormat: 'embedded',
+        },
+      );
+
+    assert.deepEqual(
+      results2.map((r: { url: string }) => r.url),
+      [
+        `${testRealmURL}vangogh.json`,
+        `${testRealmURL}donald.json`,
+        `${testRealmURL}jimmy.json`,
+      ],
+      'results are correct',
+    );
+  },
   'can get prerendered cards from the indexer': async (
     assert,
     { indexQueryEngine, dbAdapter, loader },


### PR DESCRIPTION
- Allow ordering by a non-card attribute field (`lastModified` in this case)
- Use it to sort by lastModified in index card (in addition to sorting by `title`)

<img width="1181" alt="image" src="https://github.com/user-attachments/assets/edfae408-8e7e-42eb-b329-46bf61c83b77">

https://github.com/user-attachments/assets/d8430b2d-1b55-44e9-aced-2d34c2c7e97d


