### PR TITLE
Add seed realm

### DIFF
--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -89,7 +89,9 @@ jobs:
         if: always()
         run: pnpm run lint
         working-directory: packages/experiments-realm
-      - name: Lint Seed Realm
-        if: always()
-        run: pnpm run lint
-        working-directory: packages/seed-realm
+      # uncomment this after there are linting scripts in seed realm
+      # (which require actual gts files to lint)
+      # - name: Lint Seed Realm
+      #   if: always()
+      #   run: pnpm run lint
+      #   working-directory: packages/seed-realm

--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -89,3 +89,7 @@ jobs:
         if: always()
         run: pnpm run lint
         working-directory: packages/experiments-realm
+      - name: Lint Seed Realm
+        if: always()
+        run: pnpm run lint
+        working-directory: packages/seed-realm

--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -89,8 +89,7 @@ jobs:
         if: always()
         run: pnpm run lint
         working-directory: packages/experiments-realm
-      # uncomment this after there are linting scripts in seed realm
-      # (which require actual gts files to lint)
+      # uncomment this after there are actual gts files to lint in seed realm
       # - name: Lint Seed Realm
       #   if: always()
       #   run: pnpm run lint

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Instead of running `pnpm start:base`, you can alternatively use `pnpm start:all`
 | ----- | --------------------------------------------------------- | ------------------- | -------------------- |
 | :4201 | `/base` base realm                                        | ✅                  | ✅                   |
 | :4201 | `/experiments` experiments realm                          | ✅                  | 🚫                   |
-| :4201 | `/seed` seed realm (requires realm permissions)           | ✅                  | 🚫                   |
+| :4201 | `/seed` seed realm                                        | ✅                  | 🚫                   |
 | :4202 | `/test` host test realm, `/node-test` node test realm     | ✅                  | 🚫                   |
 | :4203 | `root (/)` base realm                                     | ✅                  | 🚫                   |
 | :4204 | `root (/)` experiments realm                              | ✅                  | 🚫                   |

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Instead of running `pnpm start:base`, you can alternatively use `pnpm start:all`
 | ----- | --------------------------------------------------------- | ------------------- | -------------------- |
 | :4201 | `/base` base realm                                        | ✅                  | ✅                   |
 | :4201 | `/experiments` experiments realm                          | ✅                  | 🚫                   |
+| :4201 | `/seed` seed realm (requires realm permissions)           | ✅                  | 🚫                   |
 | :4202 | `/test` host test realm, `/node-test` node test realm     | ✅                  | 🚫                   |
 | :4203 | `root (/)` base realm                                     | ✅                  | 🚫                   |
 | :4204 | `root (/)` experiments realm                              | ✅                  | 🚫                   |

--- a/packages/host/tsconfig.json
+++ b/packages/host/tsconfig.json
@@ -34,6 +34,7 @@
     "transform": {
       "include": [
         "../experiments-realm/**",
+        "../seed-realm/**",
         "../base/**",
         "app/**",
         "tests/**",
@@ -44,6 +45,7 @@
   "include": [
     "../base/**/*",
     "../experiments-realm/**/*",
+    "../seed-realm/**/*",
     "app/**/*",
     "tests/**/*",
     "types/**/*"

--- a/packages/matrix/docker/synapse/index.ts
+++ b/packages/matrix/docker/synapse/index.ts
@@ -252,6 +252,7 @@ export async function registerUser(
         'http://localhost:4202/test/',
         'http://localhost:4201/experiments/',
         'https://cardstack.com/base/',
+        // intentionally not including seed realm here
       ],
     }),
   );

--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -40,6 +40,11 @@ export async function registerRealmUsers(synapse: SynapseInstance) {
   );
   await registerUser(
     synapse,
+    'seed_realm',
+    await realmPassword('seed_realm', realmSecretSeed),
+  );
+  await registerUser(
+    synapse,
     'test_realm',
     await realmPassword('test_realm', realmSecretSeed),
   );

--- a/packages/matrix/scripts/register-realm-users.sh
+++ b/packages/matrix/scripts/register-realm-users.sh
@@ -21,5 +21,6 @@ ts-node --transpileOnly ./scripts/register-realm-user.ts realm-server
 ts-node --transpileOnly ./scripts/register-realm-user.ts node-test_realm-server
 ts-node --transpileOnly ./scripts/register-realm-user.ts base_realm
 ts-node --transpileOnly ./scripts/register-realm-user.ts experiments_realm
+ts-node --transpileOnly ./scripts/register-realm-user.ts seed_realm
 ts-node --transpileOnly ./scripts/register-realm-user.ts node-test_realm
 ts-node --transpileOnly ./scripts/register-realm-user.ts test_realm

--- a/packages/realm-server/package.json
+++ b/packages/realm-server/package.json
@@ -77,6 +77,7 @@
     "test:wait-for-servers": "NODE_NO_WARNINGS=1 start-server-and-test 'pnpm run wait' 'http-get://localhost:4201/base/fields/boolean-field?acceptHeader=application%2Fvnd.card%2Bjson' 'pnpm run wait' 'http-get://localhost:4202/node-test/person-1?acceptHeader=application%2Fvnd.card%2Bjson|http://localhost:8008|http://localhost:5001' 'test'",
     "setup:base-in-deployment": "mkdir -p /persistent/base && cp --verbose --update --recursive ../base/. /persistent/base/",
     "setup:experiments-in-deployment": "mkdir -p /persistent/experiments && cp --verbose --update --recursive ../experiments-realm/. /persistent/experiments/",
+    "setup:seed-in-deployment": "mkdir -p /persistent/seed && cp --verbose --update --recursive ../seed-realm/. /persistent/seed/",
     "start": "PGPORT=5435 NODE_NO_WARNINGS=1 ts-node --transpileOnly main",
     "start:base": "./scripts/start-base.sh",
     "start:test-realms": "./scripts/start-test-realms.sh",

--- a/packages/realm-server/scripts/start-development.sh
+++ b/packages/realm-server/scripts/start-development.sh
@@ -31,4 +31,9 @@ NODE_ENV=development \
   --path='../experiments-realm' \
   --username='experiments_realm' \
   --fromUrl='http://localhost:4201/experiments/' \
-  --toUrl='http://localhost:4201/experiments/'
+  --toUrl='http://localhost:4201/experiments/' \
+  \
+  --path='../seed-realm' \
+  --username='seed_realm' \
+  --fromUrl='http://localhost:4201/seed/' \
+  --toUrl='http://localhost:4201/seed/'

--- a/packages/realm-server/scripts/start-production.sh
+++ b/packages/realm-server/scripts/start-production.sh
@@ -26,5 +26,5 @@ NODE_NO_WARNINGS=1 \
   \
   --path='../seed-realm' \
   --username='seed_realm' \
-  --fromUrl='http://localhost:4201/seed/' \
-  --toUrl='http://localhost:4201/seed/'
+  --fromUrl='https://app.boxel.ai/seed/' \
+  --toUrl='https://app.boxel.ai/seed/'

--- a/packages/realm-server/scripts/start-production.sh
+++ b/packages/realm-server/scripts/start-production.sh
@@ -1,6 +1,7 @@
 #! /bin/sh
 pnpm setup:base-in-deployment
 pnpm setup:experiments-in-deployment
+pnpm setup:seed-in-deployment
 NODE_NO_WARNINGS=1 \
   LOG_LEVELS='*=info' \
   MATRIX_URL=https://matrix.boxel.ai \
@@ -21,4 +22,9 @@ NODE_NO_WARNINGS=1 \
   --path='/persistent/experiments' \
   --username='experiments_realm' \
   --fromUrl='https://app.boxel.ai/experiments/' \
-  --toUrl='https://app.boxel.ai/experiments/'
+  --toUrl='https://app.boxel.ai/experiments/' \
+  \
+  --path='../seed-realm' \
+  --username='seed_realm' \
+  --fromUrl='http://localhost:4201/seed/' \
+  --toUrl='http://localhost:4201/seed/'

--- a/packages/realm-server/scripts/start-staging.sh
+++ b/packages/realm-server/scripts/start-staging.sh
@@ -26,5 +26,5 @@ NODE_NO_WARNINGS=1 \
   \
   --path='../seed-realm' \
   --username='seed_realm' \
-  --fromUrl='http://localhost:4201/seed/' \
-  --toUrl='http://localhost:4201/seed/'
+  --fromUrl='https://realms-staging.stack.cards/seed/' \
+  --toUrl='https://realms-staging.stack.cards/seed/'

--- a/packages/realm-server/scripts/start-staging.sh
+++ b/packages/realm-server/scripts/start-staging.sh
@@ -1,6 +1,7 @@
 #! /bin/sh
 pnpm setup:base-in-deployment
 pnpm setup:experiments-in-deployment
+pnpm setup:seed-in-deployment
 NODE_NO_WARNINGS=1 \
   LOG_LEVELS='perf=debug' \
   MATRIX_URL=https://matrix-staging.stack.cards \
@@ -21,4 +22,9 @@ NODE_NO_WARNINGS=1 \
   --path='/persistent/experiments' \
   --username='experiments_realm' \
   --fromUrl='https://realms-staging.stack.cards/experiments/' \
-  --toUrl='https://realms-staging.stack.cards/experiments/'
+  --toUrl='https://realms-staging.stack.cards/experiments/' \
+  \
+  --path='../seed-realm' \
+  --username='seed_realm' \
+  --fromUrl='http://localhost:4201/seed/' \
+  --toUrl='http://localhost:4201/seed/'

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -925,7 +925,7 @@ module('permissioned realm', function (hooks) {
           instancesIndexed: 0,
           moduleErrors: 1,
           modulesIndexed: 0,
-          totalIndexEntries: 2,
+          totalIndexEntries: 0,
         },
         'has a module error',
       );

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -37,6 +37,7 @@ setGracefulCleanup();
 // loading of cards necessary for indexing and the ability to manipulate the
 // underlying filesystem in a manner that doesn't leak into other tests (as well
 // as to test through loader caching)
+
 module('indexing', function (hooks) {
   let { virtualNetwork: baseRealmServerVirtualNetwork, loader } =
     createVirtualNetworkAndLoader();
@@ -402,7 +403,7 @@ module('indexing', function (hooks) {
         instanceErrors: 0,
         moduleErrors: 0,
         modulesIndexed: 0,
-        totalIndexEntries: 12,
+        totalIndexEntries: 10,
       },
       'indexed correct number of files',
     );
@@ -430,7 +431,7 @@ module('indexing', function (hooks) {
         instanceErrors: 1,
         moduleErrors: 1,
         modulesIndexed: 0,
-        totalIndexEntries: 12,
+        totalIndexEntries: 8,
       },
       'indexed correct number of files',
     );
@@ -449,7 +450,7 @@ module('indexing', function (hooks) {
         instanceErrors: 4, // 1 post, 2 persons, 1 bad-link post
         moduleErrors: 3, // post, fancy person, person
         modulesIndexed: 0,
-        totalIndexEntries: 12,
+        totalIndexEntries: 2,
       },
       'indexed correct number of files',
     );
@@ -482,7 +483,7 @@ module('indexing', function (hooks) {
         instanceErrors: 1,
         moduleErrors: 0,
         modulesIndexed: 3,
-        totalIndexEntries: 12,
+        totalIndexEntries: 8,
       },
       'indexed correct number of files',
     );
@@ -518,7 +519,7 @@ module('indexing', function (hooks) {
         instanceErrors: 0,
         moduleErrors: 0,
         modulesIndexed: 0,
-        totalIndexEntries: 12,
+        totalIndexEntries: 9,
       },
       'index did not touch any files',
     );
@@ -559,7 +560,7 @@ module('indexing', function (hooks) {
         instanceErrors: 1,
         moduleErrors: 0,
         modulesIndexed: 1,
-        totalIndexEntries: 12,
+        totalIndexEntries: 10,
       },
       'indexed correct number of files',
     );
@@ -601,7 +602,7 @@ module('indexing', function (hooks) {
         instanceErrors: 1,
         moduleErrors: 0,
         modulesIndexed: 3,
-        totalIndexEntries: 12,
+        totalIndexEntries: 10,
       },
       'indexed correct number of files',
     );
@@ -654,7 +655,7 @@ module('indexing', function (hooks) {
         instanceErrors: 2,
         moduleErrors: 0,
         modulesIndexed: 0,
-        totalIndexEntries: 12,
+        totalIndexEntries: 8,
       },
       'indexed correct number of files',
     );
@@ -695,7 +696,7 @@ module('indexing', function (hooks) {
         instanceErrors: 1,
         moduleErrors: 0,
         modulesIndexed: 1,
-        totalIndexEntries: 12,
+        totalIndexEntries: 10,
       },
       'indexed correct number of files',
     );

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -227,6 +227,7 @@ export class Batch {
       ...every([
         ['i.realm_url =', param(this.realmURL.href)],
         ['i.type != ', param('error')],
+        ['i.is_deleted != true'],
         realmVersionExpression({ useWorkInProgressIndex: true }),
       ]),
     ] as Expression)) as { total: string }[];

--- a/packages/seed-realm/.gitignore
+++ b/packages/seed-realm/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/packages/seed-realm/.realm.json
+++ b/packages/seed-realm/.realm.json
@@ -1,0 +1,3 @@
+{
+  "name": "Seed Workspace"
+}

--- a/packages/seed-realm/.realm.json
+++ b/packages/seed-realm/.realm.json
@@ -1,3 +1,5 @@
 {
-  "name": "Seed Workspace"
+  "name": "Seed Workspace",
+  "backgroundURL": "https://i.postimg.cc/3NWxSJ3N/daniela-paola-alchapar-Cki-Dm2-TEy-Cs-unsplash.jpg",
+  "iconURL": "https://i.postimg.cc/BZ1WgK0D/S.webp"
 }

--- a/packages/seed-realm/.template-lintrc.js
+++ b/packages/seed-realm/.template-lintrc.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = {
+  extends: ['recommended', '@cardstack/template-lint:recommended'],
+  plugins: ['../template-lint/plugin'],
+};

--- a/packages/seed-realm/TODO.md
+++ b/packages/seed-realm/TODO.md
@@ -1,0 +1,1 @@
+Make sure to lint for hbs when we add template files to this realm like we do in the experiments realm. Currently linting for hbs fails because there are no hbs files in this realm.

--- a/packages/seed-realm/TODO.md
+++ b/packages/seed-realm/TODO.md
@@ -1,1 +1,1 @@
-Make sure to lint for hbs when we add template files to this realm like we do in the experiments realm. Currently linting for hbs fails because there are no hbs files in this realm.
+Make sure to lint for hbs when we add gts files to this realm like we do in the experiments realm. Currently linting for templates fails because there are no gts files in this realm.

--- a/packages/seed-realm/hello-world.json
+++ b/packages/seed-realm/hello-world.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "title": "Hello World",
+      "description": "This is a test card instance."
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "https://cardstack.com/base/card-api",
+        "name": "CardDef"
+      }
+    }
+  }
+}

--- a/packages/seed-realm/index.json
+++ b/packages/seed-realm/index.json
@@ -1,0 +1,13 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {},
+    "relationships": {},
+    "meta": {
+      "adoptsFrom": {
+        "module": "https://cardstack.com/base/cards-grid",
+        "name": "CardsGrid"
+      }
+    }
+  }
+}

--- a/packages/seed-realm/package.json
+++ b/packages/seed-realm/package.json
@@ -15,9 +15,7 @@
     "tracked-built-ins": "^3.3.0"
   },
   "scripts": {
-    "lint": "concurrently \"pnpm:lint:*(!fix)\" --names \"lint:\"",
-    "lint:hbs": "ember-template-lint .",
-    "lint:hbs:fix": "ember-template-lint . --fix"
+    "lint": "concurrently \"pnpm:lint:*(!fix)\" --names \"lint:\""
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/seed-realm/package.json
+++ b/packages/seed-realm/package.json
@@ -14,7 +14,11 @@
     "ember-template-lint": "^5.11.2",
     "tracked-built-ins": "^3.3.0"
   },
-  "scripts": {},
+  "scripts": {
+    "lint": "concurrently \"pnpm:lint:*(!fix)\" --names \"lint:\"",
+    "lint:hbs": "ember-template-lint .",
+    "lint:hbs:fix": "ember-template-lint . --fix"
+  },
   "volta": {
     "extends": "../../package.json"
   }

--- a/packages/seed-realm/package.json
+++ b/packages/seed-realm/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@cardstack/seed-realm",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "devDependencies": {
+    "@cardstack/boxel-ui": "workspace:*",
+    "@cardstack/runtime-common": "workspace:*",
+    "@types/lodash": "^4.14.182",
+    "chess.js": "1.0.0-beta.8",
+    "concurrently": "^8.0.1",
+    "ember-concurrency": "^4.0.2",
+    "ember-modifier": "^4.1.0",
+    "ember-template-lint": "^5.11.2",
+    "tracked-built-ins": "^3.3.0"
+  },
+  "scripts": {
+    "lint": "concurrently \"pnpm:lint:*(!fix)\" --names \"lint:\"",
+    "lint:hbs": "ember-template-lint .",
+    "lint:hbs:fix": "ember-template-lint . --fix"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/packages/seed-realm/package.json
+++ b/packages/seed-realm/package.json
@@ -14,9 +14,7 @@
     "ember-template-lint": "^5.11.2",
     "tracked-built-ins": "^3.3.0"
   },
-  "scripts": {
-    "lint": "concurrently \"pnpm:lint:*(!fix)\" --names \"lint:\""
-  },
+  "scripts": {},
   "volta": {
     "extends": "../../package.json"
   }

--- a/packages/seed-realm/tsconfig.json
+++ b/packages/seed-realm/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2020",
     "allowJs": true,
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "allowSyntheticDefaultImports": true,
     "noImplicitAny": true,
     "noImplicitThis": true,
@@ -21,23 +21,11 @@
     "module": "es2022",
     "strict": true,
     "experimentalDecorators": true,
-    "skipLibCheck": true,
     "paths": {
-      "https://cardstack.com/base/*": ["../base/*"],
-      "@cardstack/boxel-ui": ["../boxel-ui/addon"],
-      "@cardstack/boxel-ui/*": ["../boxel-ui/addon/*"],
-      "*": ["types/*"]
+      "https://cardstack.com/base/*": ["../base/*"]
     }
   },
   "glint": {
-    "environment": ["ember-loose", "ember-template-imports"],
-    "transform": {
-      "include": [
-        "../experiments-realm/**",
-        "../base/**",
-        "../seed-realm/**",
-        "../boxel-ui/addon/**"
-      ]
-    }
+    "environment": ["ember-loose", "ember-template-imports"]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1872,6 +1872,36 @@ importers:
         specifier: ^6.3.0
         version: 6.3.0
 
+  packages/seed-realm:
+    devDependencies:
+      '@cardstack/boxel-ui':
+        specifier: workspace:*
+        version: link:../boxel-ui/addon
+      '@cardstack/runtime-common':
+        specifier: workspace:*
+        version: link:../runtime-common
+      '@types/lodash':
+        specifier: ^4.14.182
+        version: 4.14.182
+      chess.js:
+        specifier: 1.0.0-beta.8
+        version: 1.0.0-beta.8
+      concurrently:
+        specifier: ^8.0.1
+        version: 8.2.2
+      ember-concurrency:
+        specifier: ^4.0.2
+        version: 4.0.2(@babel/core@7.24.3)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1)
+      ember-modifier:
+        specifier: ^4.1.0
+        version: 4.1.0(ember-source@5.4.1)
+      ember-template-lint:
+        specifier: ^5.11.2
+        version: 5.11.2
+      tracked-built-ins:
+        specifier: ^3.3.0
+        version: 3.3.0
+
   packages/template-lint:
     devDependencies:
       ember-template-lint:


### PR DESCRIPTION
This PR adds a seed realm. This realm will be used to seed dynamically created realms in a future PR (as well as, as future PR will set the permissions correctly for this realm). For now though, this PR is just focused on the boilerplate for adding a new realm. this PR also fixes a minor bug where the total index entries in the stats were counting deleted files.

***Note for developers*** make sure to re-run the following script from the matrix workspace in order to create the seed realm user:
```
pnpm register-realm-users 
```

TODO:
- [x] Create `seed_realm` user in staging
- [x] Create `seed_realm` user in production