### PR TITLE
Fix cards grid custom fitted displays

### DIFF
--- a/packages/base/cards-grid.gts
+++ b/packages/base/cards-grid.gts
@@ -150,23 +150,21 @@ class Isolated extends Component<typeof CardsGrid> {
                 <:response as |cards|>
                   {{measureLoadTime}}
                   {{#each cards as |card|}}
-                    <CardContainer class='card'>
-                      <li
-                        {{@context.cardComponentModifier
-                          cardId=card.url
-                          format='data'
-                          fieldType=undefined
-                          fieldName=undefined
-                        }}
-                        data-test-cards-grid-item={{removeFileExtension
-                          card.url
-                        }}
-                        {{! In order to support scrolling cards into view we use a selector that is not pruned out in production builds }}
-                        data-cards-grid-item={{removeFileExtension card.url}}
-                      >
+                    <li
+                      {{@context.cardComponentModifier
+                        cardId=card.url
+                        format='data'
+                        fieldType=undefined
+                        fieldName=undefined
+                      }}
+                      data-test-cards-grid-item={{removeFileExtension card.url}}
+                      {{! In order to support scrolling cards into view we use a selector that is not pruned out in production builds }}
+                      data-cards-grid-item={{removeFileExtension card.url}}
+                    >
+                      <CardContainer class='card'>
                         {{card.component}}
-                      </li>
-                    </CardContainer>
+                      </CardContainer>
+                    </li>
                   {{/each}}
                 </:response>
               </PrerenderedCardSearch>

--- a/packages/base/cards-grid.gts
+++ b/packages/base/cards-grid.gts
@@ -151,6 +151,7 @@ class Isolated extends Component<typeof CardsGrid> {
                   {{measureLoadTime}}
                   {{#each cards as |card|}}
                     <li
+                      class='card'
                       {{@context.cardComponentModifier
                         cardId=card.url
                         format='data'
@@ -161,7 +162,7 @@ class Isolated extends Component<typeof CardsGrid> {
                       {{! In order to support scrolling cards into view we use a selector that is not pruned out in production builds }}
                       data-cards-grid-item={{removeFileExtension card.url}}
                     >
-                      <CardContainer class='card'>
+                      <CardContainer>
                         {{card.component}}
                       </CardContainer>
                     </li>

--- a/packages/boxel-ui/addon/src/components/card-container/index.gts
+++ b/packages/boxel-ui/addon/src/components/card-container/index.gts
@@ -48,6 +48,8 @@ const CardContainer: TemplateOnlyComponent<Signature> = <template>
       transition:
         max-width var(--boxel-transition),
         box-shadow var(--boxel-transition);
+      height: 100%;
+      width: 100%;
     }
     .boundaries {
       box-shadow: 0 0 0 1px var(--boxel-light-500);


### PR DESCRIPTION
Should the container query exist on the Card Container? This PR places the container query on li instead

**Before**

<img width="1681" alt="Screenshot 2024-09-12 at 13 52 28" src="https://github.com/user-attachments/assets/ee04e38e-772d-44e7-830b-79aeceed1b12">
<img width="1828" alt="Screenshot 2024-09-12 at 13 52 20" src="https://github.com/user-attachments/assets/fbc31eca-3c51-4b3b-9cd1-75e40a5b4c16">

**After**

<img width="1483" alt="Screenshot 2024-09-12 at 15 03 37" src="https://github.com/user-attachments/assets/f70a0bda-1d2a-4cb2-86ff-08912472111e">
<img width="1616" alt="Screenshot 2024-09-12 at 15 03 23" src="https://github.com/user-attachments/assets/bdf37460-d3c8-4e40-895e-f246e31b8b53">


**Resizing shud work**
<img width="1814" alt="Screenshot 2024-09-12 at 15 05 33" src="https://github.com/user-attachments/assets/ac5cf71b-06ba-4416-8863-dfe392e0467d">
<img width="498" alt="Screenshot 2024-09-12 at 15 05 06" src="https://github.com/user-attachments/assets/8d21a634-cbb9-4972-a571-14d7e7dfa1b7">

