### PR TITLE
Fix grid card display in app cards

### DIFF
--- a/packages/experiments-realm/ai-app-generator.gts
+++ b/packages/experiments-realm/ai-app-generator.gts
@@ -1,4 +1,4 @@
-import type { CardDef, CardContext } from 'https://cardstack.com/base/card-api';
+import type { CardContext } from 'https://cardstack.com/base/card-api';
 import {
   CardContainer,
   FieldContainer,
@@ -18,6 +18,7 @@ import {
   baseRealm,
   type CodeRef,
   type LooseSingleCardDocument,
+  type Query,
 } from '@cardstack/runtime-common';
 import { AppCard, Tab, CardsGrid } from './app-card';
 
@@ -104,7 +105,8 @@ class HowToSidebar extends GlimmerComponent {
 
 class CardListSidebar extends GlimmerComponent<{
   title: string;
-  instances: CardDef[];
+  query: Query;
+  realms: string[];
   context?: CardContext;
 }> {
   <template>
@@ -113,9 +115,10 @@ class CardListSidebar extends GlimmerComponent<{
         <h3 class='sidebar-title'>{{@title}}</h3>
       </header>
       <CardsGrid
-        @isListFormat={{true}}
-        @instances={{@instances}}
+        @query={{@query}}
+        @realms={{@realms}}
         @context={{@context}}
+        @isListFormat={{true}}
       />
     </aside>
     <style scoped>
@@ -280,11 +283,14 @@ class Isolated extends AppCard.isolated {
                 <p class='error'>{{this.errorMessage}}</p>
               {{/if}}
             </section>
-            <CardListSidebar
-              @title='Browse Sample Apps'
-              @instances={{this.instances}}
-              @context={{@context}}
-            />
+            {{#if this.query}}
+              <CardListSidebar
+                @title='Browse Sample Apps'
+                @query={{this.query}}
+                @realms={{this.realms}}
+                @context={{@context}}
+              />
+            {{/if}}
           </div>
         {{else}}
           {{#if
@@ -308,11 +314,14 @@ class Isolated extends AppCard.isolated {
               Create new requirement
             </Button>
           {{/if}}
-          <CardsGrid
-            class='grid-cards'
-            @instances={{this.instances}}
-            @context={{@context}}
-          />
+          {{#if this.query}}
+            <CardsGrid
+              class='grid-cards'
+              @query={{this.query}}
+              @realms={{this.realms}}
+              @context={{@context}}
+            />
+          {{/if}}
         {{/if}}
       </div>
     </section>


### PR DESCRIPTION
Fixes the card display in app cards mentioned in cs-7164. Something that I thought wouldn't be necessary is after specifying `@format="fitted"` in `PrerenderedCardSearch` component, the cards weren't displaying the fitted styles. I had to add `container-name: fitted-card;  container-type: size;` in my own container for the styles to show up.

Here's the after:
<img width="1258" alt="sidebar-grid" src="https://github.com/user-attachments/assets/20f6154d-7e03-499b-a642-79b11e1e9014">
<img width="1257" alt="grid-1" src="https://github.com/user-attachments/assets/f139442e-1dc6-41e7-91bd-768eade3e1bc">
<img width="1260" alt="grid-2" src="https://github.com/user-attachments/assets/f6601b9a-896b-4de5-a68f-fd9de0b01ea5">
<img width="1259" alt="grid-3" src="https://github.com/user-attachments/assets/3f6ea0d5-b5bc-4a43-a903-7abd8adb6a72">