### PR TITLE
host: Add lint rule to forbid unwrapped setup helpers

### DIFF
--- a/packages/eslint-plugin-window-mock/index.js
+++ b/packages/eslint-plugin-window-mock/index.js
@@ -1,7 +1,9 @@
 const mockWindowOnly = require('./mock-window-only');
+const wrappedSetupHelpersOnly = require('./wrapped-setup-helpers-only');
 
 module.exports = {
   rules: {
     'mock-window-only': mockWindowOnly,
+    'wrapped-setup-helpers-only': wrappedSetupHelpersOnly,
   },
 };

--- a/packages/eslint-plugin-window-mock/wrapped-setup-helpers-only.js
+++ b/packages/eslint-plugin-window-mock/wrapped-setup-helpers-only.js
@@ -1,0 +1,32 @@
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Enforce use of wrapped setup helpers that use ember-window-mock',
+      category: 'Best Practices',
+      recommended: true,
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value === 'ember-qunit') {
+          node.specifiers.forEach((specifier) => {
+            if (
+              specifier.type === 'ImportSpecifier' &&
+              (specifier.imported.name === 'setupApplicationTest' ||
+                specifier.imported.name === 'setupRenderingTest')
+            ) {
+              context.report({
+                node: specifier,
+                message: `Importing ${specifier.imported.name} from ember-qunit is not allowed. Use host application’s wrapped setup helpers instead.`,
+              });
+            }
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/host/.eslintrc.js
+++ b/packages/host/.eslintrc.js
@@ -46,6 +46,7 @@ module.exports = {
         'no-undef': 'off',
         'ember/no-runloop': 'off',
         'window-mock/mock-window-only': 'error',
+        'window-mock/wrapped-setup-helpers-only': 'error',
       },
     },
     {
@@ -94,6 +95,7 @@ module.exports = {
         'node/no-deprecated-api': 'off',
         'deprecation/deprecation': 'off',
         'window-mock/mock-window-only': 'error',
+        'window-mock/wrapped-setup-helpers-only': 'error',
       },
     },
     // node files

--- a/packages/host/tests/acceptance/basic-test.gts
+++ b/packages/host/tests/acceptance/basic-test.gts
@@ -1,6 +1,5 @@
 import { find, visit, currentURL } from '@ember/test-helpers';
 
-import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
@@ -11,6 +10,7 @@ import {
   setupAcceptanceTestRealm,
   lookupLoaderService,
 } from '../helpers';
+import { setupApplicationTest } from '../helpers/setup';
 
 module('Acceptance | basic tests', function (hooks) {
   setupApplicationTest(hooks);

--- a/packages/host/tests/helpers/setup.ts
+++ b/packages/host/tests/helpers/setup.ts
@@ -1,3 +1,6 @@
+/* eslint-disable window-mock/wrapped-setup-helpers-only */
+// This is the one place we allow these to be used directly.
+
 import {
   setupApplicationTest as emberSetupApplicationTest,
   setupRenderingTest as emberSetupRenderingTest,


### PR DESCRIPTION
#1557 added wrappers for Ember test setup helpers to ensure `setupWindowMock` but [one was missed](https://github.com/cardstack/boxel/pull/1557/files#diff-b721f99526ea0c024f4c9e509117cc6a69fa258766e447392e2be5a58be1a08c0). This adds a lint rule to forbid the unwrapped helpers from being used.

I encountered this because I was rerunning the `basic-test` file repeatedly locally and kept seeing Matrix token errors.

You can see an example lint failure [in CI](https://github.com/cardstack/boxel/actions/runs/10837616365/job/30073938363?pr=1571#step:14:30) and [success after I fixed the import](https://github.com/cardstack/boxel/actions/runs/10837697595/job/30074224127?pr=1571):

```
[lint:js] /home/runner/work/boxel/boxel/packages/host/tests/acceptance/basic-test.gts
[lint:js]   3:10  error  Importing setupApplicationTest from ember-qunit is not allowed. Use host application’s wrapped setup helpers instead  window-mock/wrapped-setup-helpers-only
[lint:js] 
[lint:js] ✖ 1 problem (1 error, 0 warnings)
```

It doesn’t include an autofix because it would require determining relative paths which is possible but annoying and new test files are rarely created.