### PR TITLE
Remove button title (2 tooltips)

### DIFF
--- a/packages/boxel-ui/addon/src/components/add-button/index.gts
+++ b/packages/boxel-ui/addon/src/components/add-button/index.gts
@@ -44,7 +44,6 @@ const AddButton: TemplateOnlyComponent<Signature> = <template>
       @width='40px'
       @height='40px'
       class='add-button'
-      title='Add'
       data-test-create-new-card-button
       ...attributes
     />


### PR DESCRIPTION
<img width="448" alt="Screenshot 2024-09-13 at 16 05 15" src="https://github.com/user-attachments/assets/4ef50d34-24bd-46c2-bb9e-58d208b7867d">

I dont think fallback is needed here. And title is not an accesibility feature (Apparently in ember it is)