### PR TITLE
Add isolated realm server for matrix tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,17 +72,18 @@ Live reloads are not available in this mode, however, if you use start the serve
 
 Instead of running `pnpm start:base`, you can alternatively use `pnpm start:all` which also serves a few other realms on other ports--this is convenient if you wish to switch between the app and the tests without having to restart servers. Here's what is spun up with `start:all`:
 
-| Port  | Description                                               | Running `start:all` | Running `start:base` |
-| ----- | --------------------------------------------------------- | ------------------- | -------------------- |
-| :4201 | `/base` base realm                                        | ✅                  | ✅                   |
-| :4201 | `/experiments` experiments realm                          | ✅                  | 🚫                   |
-| :4201 | `/seed` seed realm                                        | ✅                  | 🚫                   |
-| :4202 | `/test` host test realm, `/node-test` node test realm     | ✅                  | 🚫                   |
-| :4203 | `root (/)` base realm                                     | ✅                  | 🚫                   |
-| :4204 | `root (/)` experiments realm                              | ✅                  | 🚫                   |
-| :5001 | Mail user interface for viewing emails sent to local SMTP | ✅                  | 🚫                   |
-| :5435 | Postgres DB                                               | ✅                  | 🚫                   |
-| :8008 | Matrix synapse server                                     | ✅                  | 🚫                   |
+| Port  | Description                                                   | Running `start:all` | Running `start:base` |
+| ----- | ------------------------------------------------------------- | ------------------- | -------------------- |
+| :4201 | `/base` base realm                                            | ✅                  | ✅                   |
+| :4201 | `/experiments` experiments realm                              | ✅                  | 🚫                   |
+| :4201 | `/seed` seed realm                                            | ✅                  | 🚫                   |
+| :4202 | `/test` host test realm, `/node-test` node test realm         | ✅                  | 🚫                   |
+| :4203 | `root (/)` base realm                                         | ✅                  | 🚫                   |
+| :4204 | `root (/)` experiments realm                                  | ✅                  | 🚫                   |
+| :4205 | `/test` realm for matrix client tests (playwright controlled) | 🚫                  | 🚫                   |
+| :5001 | Mail user interface for viewing emails sent to local SMTP     | ✅                  | 🚫                   |
+| :5435 | Postgres DB                                                   | ✅                  | 🚫                   |
+| :8008 | Matrix synapse server                                         | ✅                  | 🚫                   |
 
 #### Using `start:development`
 

--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -94,8 +94,8 @@ export async function openRoot(page: Page, url = testHost) {
   }
 }
 
-export async function clearLocalStorage(page: Page) {
-  await openRoot(page);
+export async function clearLocalStorage(page: Page, appURL = testHost) {
+  await openRoot(page, appURL);
   await page.evaluate(() => window.localStorage.clear());
 }
 
@@ -230,15 +230,15 @@ export async function validateEmailForResetPassword(
   return resetPasswordPage;
 }
 
-export async function gotoRegistration(page: Page) {
-  await openRoot(page);
+export async function gotoRegistration(page: Page, appURL = testHost) {
+  await openRoot(page, appURL);
   await toggleOperatorMode(page);
   await page.locator('[data-test-register-user]').click();
   await expect(page.locator('[data-test-register-btn]')).toHaveCount(1);
 }
 
-export async function gotoForgotPassword(page: Page) {
-  await openRoot(page);
+export async function gotoForgotPassword(page: Page, appURL = testHost) {
+  await openRoot(page, appURL);
   await toggleOperatorMode(page);
   await page.locator('[data-test-forgot-password]').click();
   await expect(page.locator('[data-test-reset-your-password-btn]')).toHaveCount(

--- a/packages/matrix/helpers/isolated-realm-server.ts
+++ b/packages/matrix/helpers/isolated-realm-server.ts
@@ -1,0 +1,103 @@
+import { spawn } from 'child_process';
+import { resolve, join } from 'path';
+// @ts-expect-error no types
+import { dirSync, setGracefulCleanup } from 'tmp';
+import { ensureDirSync, copySync } from 'fs-extra';
+
+setGracefulCleanup();
+
+const testRealmCards = resolve(
+  join(__dirname, '..', '..', 'host', 'tests', 'cards'),
+);
+const realmServerDir = resolve(join(__dirname, '..', '..', 'realm-server'));
+const matrixDir = resolve(join(__dirname, '..'));
+export const appURL = 'http://localhost:4205/test';
+
+// The isolated realm is fairly expensive to test with. Please use your best
+// judgement to decide if your test really merits an isolated realm for testing
+// or if a mock would be more suitable.
+
+export async function startServer() {
+  let dir = dirSync();
+  let testRealmDir = join(dir.name, 'test');
+  ensureDirSync(testRealmDir);
+  copySync(testRealmCards, testRealmDir);
+
+  process.env.PGPORT = '5435';
+  process.env.PGDATABASE = `test_db_${Math.floor(10000000 * Math.random())}`;
+  process.env.NODE_NO_WARNINGS = '1';
+  process.env.REALM_SECRET_SEED = "shhh! it's a secret";
+  process.env.MATRIX_URL = 'http://localhost:8008';
+  process.env.REALM_SERVER_MATRIX_USERNAME = 'realm_server';
+
+  let realmServer = spawn(
+    'ts-node',
+    [
+      `--transpileOnly`,
+      'main',
+      `--port=4205`,
+      `--matrixURL='http://localhost:8008'`,
+      `--realmsRootPath='${dir.name}'`,
+      `--matrixRegistrationSecretFile='${join(
+        matrixDir,
+        'registration_secret.txt',
+      )}`,
+      `--path='${testRealmDir}'`,
+      `--username='test_realm'`,
+      `--fromUrl='/test/'`,
+      `--toUrl='/test/'`,
+      `--fromUrl='https://cardstack.com/base/'`,
+      `--toUrl='http://localhost:4201/base/'`,
+    ],
+    {
+      cwd: realmServerDir,
+      stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
+    },
+  );
+  if (realmServer.stdout) {
+    realmServer.stdout.on('data', (data: Buffer) =>
+      console.log(`realm server: ${data.toString()}`),
+    );
+  }
+  if (realmServer.stderr) {
+    realmServer.stderr.on('data', (data: Buffer) =>
+      console.error(`realm server: ${data.toString()}`),
+    );
+  }
+
+  let timeout = await Promise.race([
+    new Promise<void>((r) => {
+      realmServer.on('message', (message) => {
+        if (message === 'ready') {
+          r();
+        }
+      });
+    }),
+    new Promise<true>((r) => setTimeout(() => r(true), 30_000)),
+  ]);
+  if (timeout) {
+    console.error(
+      `timed-out waiting for realm server to start. Stopping server`,
+    );
+    process.exit(-2);
+  }
+
+  return new IsolatedRealmServer(realmServer);
+}
+
+export class IsolatedRealmServer {
+  constructor(private realmServerProcess: ReturnType<typeof spawn>) {}
+
+  async stop() {
+    let stopped: () => void;
+    let stop = new Promise<void>((r) => (stopped = r));
+    this.realmServerProcess.on('message', (message) => {
+      if (message === 'stopped') {
+        stopped();
+      }
+    });
+    this.realmServerProcess.send('stop');
+    await stop;
+    this.realmServerProcess.kill();
+  }
+}

--- a/packages/matrix/helpers/isolated-realm-server.ts
+++ b/packages/matrix/helpers/isolated-realm-server.ts
@@ -76,10 +76,9 @@ export async function startServer() {
     new Promise<true>((r) => setTimeout(() => r(true), 30_000)),
   ]);
   if (timeout) {
-    console.error(
+    throw new Error(
       `timed-out waiting for realm server to start. Stopping server`,
     );
-    process.exit(-2);
   }
 
   return new IsolatedRealmServer(realmServer);

--- a/packages/matrix/package.json
+++ b/packages/matrix/package.json
@@ -11,6 +11,7 @@
     "fs-extra": "^10.1.0",
     "jsonwebtoken": "^9.0.2",
     "start-server-and-test": "^1.14.0",
+    "tmp": "^0.2.1",
     "ts-node": "^10.9.1",
     "typescript": "~5.1.6"
   },

--- a/packages/matrix/tests/registration-with-token.spec.ts
+++ b/packages/matrix/tests/registration-with-token.spec.ts
@@ -5,9 +5,9 @@ import {
   type SynapseInstance,
 } from '../docker/synapse';
 import {
-  startServer as startRealmServer,
-  IsolatedRealmServer,
   appURL,
+  startServer as startRealmServer,
+  type IsolatedRealmServer,
 } from '../helpers/isolated-realm-server';
 import { smtpStart, smtpStop } from '../docker/smtp4dev';
 import {
@@ -33,11 +33,10 @@ test.describe('User Registration w/ Token - isolated realm server', () => {
     });
     await smtpStart();
     realmServer = await startRealmServer();
-    console.log('=================');
   });
 
   test.afterEach(async () => {
-    realmServer.stop();
+    await realmServer.stop();
     await synapseStop(synapse.synapseId);
     await smtpStop();
   });

--- a/packages/matrix/tests/registration-without-token.spec.ts
+++ b/packages/matrix/tests/registration-without-token.spec.ts
@@ -6,6 +6,11 @@ import {
 } from '../docker/synapse';
 import { smtpStart, smtpStop } from '../docker/smtp4dev';
 import {
+  appURL,
+  startServer as startRealmServer,
+  type IsolatedRealmServer,
+} from '../helpers/isolated-realm-server';
+import {
   clearLocalStorage,
   validateEmail,
   gotoRegistration,
@@ -15,6 +20,7 @@ import {
 
 test.describe('User Registration w/o Token', () => {
   let synapse: SynapseInstance;
+  let realmServer: IsolatedRealmServer;
 
   test.beforeEach(async () => {
     synapse = await synapseStart({
@@ -22,9 +28,11 @@ test.describe('User Registration w/o Token', () => {
     });
     await smtpStart();
     await registerRealmUsers(synapse);
+    realmServer = await startRealmServer();
   });
 
   test.afterEach(async () => {
+    await realmServer.stop();
     await synapseStop(synapse.synapseId);
     await smtpStop();
   });
@@ -32,8 +40,8 @@ test.describe('User Registration w/o Token', () => {
   test('it can register a user without a registration token', async ({
     page,
   }) => {
-    await clearLocalStorage(page);
-    await gotoRegistration(page);
+    await clearLocalStorage(page, appURL);
+    await gotoRegistration(page, appURL);
 
     await expect(
       page.locator('[data-test-token-field]'),

--- a/packages/realm-server/scripts/start-base-root.sh
+++ b/packages/realm-server/scripts/start-base-root.sh
@@ -14,7 +14,6 @@ NODE_ENV=development \
   REALM_SECRET_SEED="shhh! it's a secret" \
   MATRIX_URL=http://localhost:8008 \
   REALM_SERVER_MATRIX_USERNAME=realm_server \
-  REALM_SERVER_MATRIX_PASSWORD=password \
   ts-node \
   --transpileOnly main \
   --port=4203 \

--- a/packages/realm-server/scripts/start-base.sh
+++ b/packages/realm-server/scripts/start-base.sh
@@ -14,7 +14,6 @@ NODE_ENV=development \
   REALM_SECRET_SEED="shhh! it's a secret" \
   MATRIX_URL=http://localhost:8008 \
   REALM_SERVER_MATRIX_USERNAME=realm_server \
-  REALM_SERVER_MATRIX_PASSWORD=password \
   ts-node \
   --transpileOnly main \
   --port=4201 \

--- a/packages/realm-server/scripts/start-development.sh
+++ b/packages/realm-server/scripts/start-development.sh
@@ -15,7 +15,6 @@ NODE_ENV=development \
   REALM_SECRET_SEED="shhh! it's a secret" \
   MATRIX_URL=http://localhost:8008 \
   REALM_SERVER_MATRIX_USERNAME=realm_server \
-  REALM_SERVER_MATRIX_PASSWORD=password \
   ts-node \
   --transpileOnly main \
   --port=4201 \

--- a/packages/realm-server/scripts/start-experiments-root.sh
+++ b/packages/realm-server/scripts/start-experiments-root.sh
@@ -13,7 +13,6 @@ NODE_NO_WARNINGS=1 \
   REALM_SECRET_SEED="shhh! it's a secret" \
   MATRIX_URL=http://localhost:8008 \
   REALM_SERVER_MATRIX_USERNAME=realm_server \
-  REALM_SERVER_MATRIX_PASSWORD=password \
   ts-node \
   --transpileOnly main \
   --port=4204 \

--- a/packages/realm-server/scripts/start-test-realms.sh
+++ b/packages/realm-server/scripts/start-test-realms.sh
@@ -14,8 +14,6 @@ NODE_ENV=test \
   REALM_SECRET_SEED="shhh! it's a secret" \
   MATRIX_URL=http://localhost:8008 \
   REALM_SERVER_MATRIX_USERNAME=realm_server \
-  REALM_SERVER_MATRIX_PASSWORD=password \
-  PGPORT="5435" \
   ts-node \
   --transpileOnly main \
   --port=4202 \

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import supertest, { Test, SuperTest } from 'supertest';
 import { join, resolve } from 'path';
 import { Server } from 'http';
-import { dirSync, setGracefulCleanup, DirResult } from 'tmp';
+import { dirSync, setGracefulCleanup, type DirResult } from 'tmp';
 import { validate as uuidValidate } from 'uuid';
 import {
   copySync,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1489,6 +1489,9 @@ importers:
       start-server-and-test:
         specifier: ^1.14.0
         version: 1.14.0
+      tmp:
+        specifier: ^0.2.1
+        version: 0.2.1
       ts-node:
         specifier: ^10.9.1
         version: 10.9.1(@types/node@18.18.5)(typescript@5.1.6)


### PR DESCRIPTION
This PR adds an isolated realm server that can be used for matrix tests that need to manipulate the realm server's state. Due to the expensive nature of the isolated realm server, this PR also uses the isolated realm server _only_ for the register user happy path tests (there are only 3) which will start manipulating realm server state in a subsequent PR.