### PR TITLE
CS-7168 : Fix gray line divider appeared in the text body

### DIFF
--- a/packages/host/app/components/operator-mode/card-preview-panel/index.gts
+++ b/packages/host/app/components/operator-mode/card-preview-panel/index.gts
@@ -151,18 +151,23 @@ export default class CardPreviewPanel extends Component<Signature> {
       }}
     >
       {{#if (eq this.format 'fitted')}}
-        <FittedFormatGallery @card={{@card}} />
+        <div class='fitted-wrapper'>
+          <FittedFormatGallery @card={{@card}} />
+        </div>
       {{else if (eq this.format 'embedded')}}
-        <EmbeddedPreview @card={{@card}} />
+        <div class='embedded-wrapper'>
+          <EmbeddedPreview @card={{@card}} />
+        </div>
       {{else if (eq this.format 'atom')}}
         <div class='atom-wrapper'>
           <Preview @card={{@card}} @format={{this.format}} />
         </div>
       {{else}}
-        <Preview @card={{@card}} @format={{this.format}} />
+        <div class='wrapper'>
+          <Preview @card={{@card}} @format={{this.format}} />
+        </div>
       {{/if}}
     </div>
-
     <div
       class='preview-footer'
       {{ResizeModifier setFooterWidthPx=this.setFooterWidthPx}}


### PR DESCRIPTION
https://linear.app/cardstack/issue/CS-7168/[bug]-[code-mode]-gray-line-divider-appeared-in-the-text-body

Before:
![image](https://github.com/user-attachments/assets/49a5fce8-a173-4475-8b2e-017e26d944c9)


After: 
![image](https://github.com/user-attachments/assets/282ab6b4-3cb4-4e8d-ab5b-61f80b1d61cb)
