### PR TITLE
CS-7168 : Fix gray line divider appeared in the text body

### DIFF
--- a/packages/host/app/components/operator-mode/card-preview-panel/index.gts
+++ b/packages/host/app/components/operator-mode/card-preview-panel/index.gts
@@ -227,6 +227,7 @@ export default class CardPreviewPanel extends Component<Signature> {
 
       .preview-content {
         height: auto;
+        margin: var(--boxel-sp-sm);
       }
 
       .header-actions {

--- a/packages/host/app/components/operator-mode/card-preview-panel/index.gts
+++ b/packages/host/app/components/operator-mode/card-preview-panel/index.gts
@@ -150,19 +150,26 @@ export default class CardPreviewPanel extends Component<Signature> {
         onScroll=this.onScroll
       }}
     >
+
       {{#if (eq this.format 'fitted')}}
-        <FittedFormatGallery @card={{@card}} />
+        <div class='fitted-wrapper'>
+          <FittedFormatGallery @card={{@card}} />
+        </div>
       {{else if (eq this.format 'embedded')}}
-        <EmbeddedPreview @card={{@card}} />
+        <div class='embedded-wrapper'>
+          <EmbeddedPreview @card={{@card}} />
+        </div>
       {{else if (eq this.format 'atom')}}
         <div class='atom-wrapper'>
           <Preview @card={{@card}} @format={{this.format}} />
         </div>
       {{else}}
-        <Preview @card={{@card}} @format={{this.format}} />
+        <div class='wrapper'>
+          <Preview @card={{@card}} @format={{this.format}} />
+        </div>
       {{/if}}
-    </div>
 
+    </div>
     <div
       class='preview-footer'
       {{ResizeModifier setFooterWidthPx=this.setFooterWidthPx}}
@@ -221,6 +228,9 @@ export default class CardPreviewPanel extends Component<Signature> {
 
       .preview-body {
         flex-grow: 1;
+        overflow-y: auto;
+      }
+      .preview-body > * {
         overflow-y: auto;
       }
 

--- a/packages/host/app/components/operator-mode/card-preview-panel/index.gts
+++ b/packages/host/app/components/operator-mode/card-preview-panel/index.gts
@@ -150,25 +150,19 @@ export default class CardPreviewPanel extends Component<Signature> {
         onScroll=this.onScroll
       }}
     >
-
-      {{#if (eq this.format 'fitted')}}
-        <div class='fitted-wrapper'>
+      <div class='preview-content'>
+        {{#if (eq this.format 'fitted')}}
           <FittedFormatGallery @card={{@card}} />
-        </div>
-      {{else if (eq this.format 'embedded')}}
-        <div class='embedded-wrapper'>
+        {{else if (eq this.format 'embedded')}}
           <EmbeddedPreview @card={{@card}} />
-        </div>
-      {{else if (eq this.format 'atom')}}
-        <div class='atom-wrapper'>
+        {{else if (eq this.format 'atom')}}
+          <div class='atom-wrapper'>
+            <Preview @card={{@card}} @format={{this.format}} />
+          </div>
+        {{else}}
           <Preview @card={{@card}} @format={{this.format}} />
-        </div>
-      {{else}}
-        <div class='wrapper'>
-          <Preview @card={{@card}} @format={{this.format}} />
-        </div>
-      {{/if}}
-
+        {{/if}}
+      </div>
     </div>
     <div
       class='preview-footer'
@@ -230,8 +224,9 @@ export default class CardPreviewPanel extends Component<Signature> {
         flex-grow: 1;
         overflow-y: auto;
       }
-      .preview-body > * {
-        overflow-y: auto;
+
+      .preview-content {
+        height: auto;
       }
 
       .header-actions {


### PR DESCRIPTION
https://linear.app/cardstack/issue/CS-7168/[bug]-[code-mode]-gray-line-divider-appeared-in-the-text-body

**The Problem:**
The <Preview/> component likely has a fixed height or a height that doesn't account for its full content, the preview body didn't calculate the total scrollable height that causing the gray line (from the cardContainer box-shadow) you observed. 

**My Solution**
By wrapping the **Preview (FittedFormatGallery, EmbeddedPreview, Preview)** component in a  **'preview-content'** div with _**height: auto**_, you allow this wrapper to expand to the full height of its content. _**height: auto**_ lets the div grow as tall as necessary to contain all of its child elements, including the full content of **Preview**. When the preview-body (the scroll container) has a child with _**height: auto**_, it can correctly calculate the **total scrollable height**, not only the visible area.


**Before:**
![image](https://github.com/user-attachments/assets/49a5fce8-a173-4475-8b2e-017e26d944c9)


**After:** 
![image](https://github.com/user-attachments/assets/282ab6b4-3cb4-4e8d-ab5b-61f80b1d61cb)


But we can still see the boundaries because that is cardContainer (box-shadow) behaviour, the stack-item have the same behaviour but the stack-item component hide the shadow - 
![image](https://github.com/user-attachments/assets/db0888a8-6e19-4155-9720-7e787eb6cb6b)

