### PR TITLE
realm: Add pre-handler logging

### DIFF
--- a/packages/realm-server/middleware/index.ts
+++ b/packages/realm-server/middleware/index.ts
@@ -51,9 +51,16 @@ export function healthCheck(ctxt: Koa.Context, next: Koa.Next) {
 
 export function httpLogging(ctxt: Koa.Context, next: Koa.Next) {
   let logger = getLogger('realm:requests');
+
+  logger.info(
+    `<-- ${ctxt.method} ${ctxt.req.headers.accept} ${
+      fullRequestURL(ctxt).href
+    }`,
+  );
+
   ctxt.res.on('finish', () => {
     logger.info(
-      `${ctxt.method} ${ctxt.req.headers.accept} ${
+      `--> ${ctxt.method} ${ctxt.req.headers.accept} ${
         fullRequestURL(ctxt).href
       }: ${ctxt.status}`,
     );

--- a/packages/runtime-common/router.ts
+++ b/packages/runtime-common/router.ts
@@ -152,8 +152,6 @@ export class Router {
     request: Request,
     requestContext: RequestContext,
   ): Promise<Response> {
-    this.log.info(`Request for ${request.method} ${request.url}`);
-
     let handler = this.lookupHandler(request);
     if (!handler) {
       return notFound(request, requestContext);

--- a/packages/runtime-common/router.ts
+++ b/packages/runtime-common/router.ts
@@ -152,6 +152,8 @@ export class Router {
     request: Request,
     requestContext: RequestContext,
   ): Promise<Response> {
+    this.log.info(`Request for ${request.method} ${request.url}`);
+
     let handler = this.lookupHandler(request);
     if (!handler) {
       return notFound(request, requestContext);


### PR DESCRIPTION
One small obstacle to debugging the production write problems was that we thought the `PATCH` wasn’t reaching the server, leading to some red herring research about WAF blockages, etc. It’s common to have logging both before and after a request handler for this reason.

I borrowed the `<--`/`-->` from [`koa-logger`](https://github.com/koajs/logger), which also includes timing and size logging, should we also have those?

An example of one request:

```
<-- PATCH application/vnd.card+json https://realms-staging.stack.cards/experiments/Friend/1
--> PATCH application/vnd.card+json https://realms-staging.stack.cards/experiments/Friend/1: 200
```