### PR TITLE
experiments: Add guard against missing tab

### DIFF
--- a/packages/experiments-realm/app-card.gts
+++ b/packages/experiments-realm/app-card.gts
@@ -269,7 +269,10 @@ class DefaultTabTemplate extends GlimmerComponent<DefaultTabSignature> {
     }
 
     this.args.model.tabs = tabs;
-    this.args.setActiveTab(tabs[0].tabId);
+
+    if (tabs[0]) {
+      this.args.setActiveTab(tabs[0].tabId);
+    }
   }
 
   setTabs(tabs: Tab[]) {


### PR DESCRIPTION
This should prevent this error seen in Sentry:

<img width="570" alt="TypeError: Cannot read properties of undefined (reading 'tabId') — cardstack — realm-server 2024-09-20 13-47-10" src="https://github.com/user-attachments/assets/d12ce52f-85dd-404d-bd11-28e9926a833f">
