### PR TITLE
Fix issue around card def module errors stopping indexing

### DIFF
--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -421,6 +421,8 @@ export class CurrentRun {
     let isolatedHtml: string | undefined;
     let atomHtml: string | undefined;
     let card: CardDef | undefined;
+    let embeddedHtml: Record<string, string> | undefined;
+    let fittedHtml: Record<string, string> | undefined;
     try {
       let api = await this.loaderService.loader.import<typeof CardAPI>(
         `${baseRealm.url}card-api`,
@@ -507,31 +509,27 @@ export class CurrentRun {
       // "_" prefix to make a decent attempt to not pollute the userland
       // namespace for cards
       searchData._cardType = getDisplayName(cardType);
+      typesMaybeError = await this.getTypes(cardType);
+      if (card && typesMaybeError?.type === 'types') {
+        embeddedHtml = await this.buildCardHtml(
+          card,
+          typesMaybeError.types,
+          'embedded',
+          identityContext,
+        );
+      }
+      if (card && typesMaybeError?.type === 'types') {
+        fittedHtml = await this.buildCardHtml(
+          card,
+          typesMaybeError.types,
+          'fitted',
+          identityContext,
+        );
+      }
     } catch (err: any) {
       uncaughtError = err;
     }
-    // if we already encountered an uncaught error then no need to deal with this
-    if (!uncaughtError && cardType) {
-      typesMaybeError = await this.getTypes(cardType);
-    }
-    let embeddedHtml: Record<string, string> | undefined;
-    if (card && typesMaybeError?.type === 'types') {
-      embeddedHtml = await this.buildCardHtml(
-        card,
-        typesMaybeError.types,
-        'embedded',
-        identityContext,
-      );
-    }
-    let fittedHtml: Record<string, string> | undefined;
-    if (card && typesMaybeError?.type === 'types') {
-      fittedHtml = await this.buildCardHtml(
-        card,
-        typesMaybeError.types,
-        'fitted',
-        identityContext,
-      );
-    }
+
     if (searchData && doc && typesMaybeError?.type === 'types') {
       await this.updateEntry(instanceURL, {
         type: 'instance',

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -738,7 +738,7 @@ module('indexing', function (hooks) {
         instanceErrors: 1,
         moduleErrors: 0,
         modulesIndexed: 1,
-        totalIndexEntries: 10,
+        totalIndexEntries: 11,
       },
       'indexed correct number of files',
     );

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -445,7 +445,7 @@ module('indexing', function (hooks) {
         instanceErrors: 0,
         moduleErrors: 0,
         modulesIndexed: 0,
-        totalIndexEntries: 10,
+        totalIndexEntries: 11,
       },
       'indexed correct number of files',
     );
@@ -473,7 +473,7 @@ module('indexing', function (hooks) {
         instanceErrors: 1,
         moduleErrors: 1,
         modulesIndexed: 0,
-        totalIndexEntries: 8,
+        totalIndexEntries: 9,
       },
       'indexed correct number of files',
     );
@@ -492,7 +492,7 @@ module('indexing', function (hooks) {
         instanceErrors: 4, // 1 post, 2 persons, 1 bad-link post
         moduleErrors: 3, // post, fancy person, person
         modulesIndexed: 0,
-        totalIndexEntries: 2,
+        totalIndexEntries: 3,
       },
       'indexed correct number of files',
     );
@@ -525,7 +525,7 @@ module('indexing', function (hooks) {
         instanceErrors: 1,
         moduleErrors: 0,
         modulesIndexed: 3,
-        totalIndexEntries: 8,
+        totalIndexEntries: 9,
       },
       'indexed correct number of files',
     );
@@ -561,7 +561,7 @@ module('indexing', function (hooks) {
         instanceErrors: 0,
         moduleErrors: 0,
         modulesIndexed: 0,
-        totalIndexEntries: 9,
+        totalIndexEntries: 10,
       },
       'index did not touch any files',
     );
@@ -602,7 +602,7 @@ module('indexing', function (hooks) {
         instanceErrors: 1,
         moduleErrors: 0,
         modulesIndexed: 1,
-        totalIndexEntries: 10,
+        totalIndexEntries: 11,
       },
       'indexed correct number of files',
     );
@@ -644,7 +644,7 @@ module('indexing', function (hooks) {
         instanceErrors: 1,
         moduleErrors: 0,
         modulesIndexed: 3,
-        totalIndexEntries: 10,
+        totalIndexEntries: 11,
       },
       'indexed correct number of files',
     );
@@ -697,7 +697,7 @@ module('indexing', function (hooks) {
         instanceErrors: 2,
         moduleErrors: 0,
         modulesIndexed: 0,
-        totalIndexEntries: 8,
+        totalIndexEntries: 9,
       },
       'indexed correct number of files',
     );

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -153,6 +153,21 @@ module('indexing', function (hooks) {
               }
             }
           `,
+          'boom2.gts': `
+            import { contains, field, CardDef, Component } from "https://cardstack.com/base/card-api";
+            import StringCard from "https://cardstack.com/base/string";
+
+            export class Boom extends CardDef {
+              @field firstName = contains(StringCard);
+              boom = () => {};
+              static isolated = class Isolated extends Component<typeof this> {
+                <template>
+                  {{! From CS-7216 we are using a modifier in a strict mode template that is not imported }}
+                  <h1 {{did-insert this.boom}}><@fields.firstName/></h1>
+                </template>
+              }
+            }
+          `,
           'mango.json': {
             data: {
               attributes: {
@@ -245,6 +260,19 @@ module('indexing', function (hooks) {
               },
             },
           },
+          'boom2.json': {
+            data: {
+              attributes: {
+                firstName: 'Boom!',
+              },
+              meta: {
+                adoptsFrom: {
+                  module: './boom2',
+                  name: 'Boom',
+                },
+              },
+            },
+          },
           'empty.json': {
             data: {
               attributes: {},
@@ -306,6 +334,20 @@ module('indexing', function (hooks) {
           'Encountered error rendering HTML for card: intentional error',
         );
         assert.deepEqual(entry.error.deps, [`${testRealm}boom`]);
+      } else {
+        assert.ok('false', 'expected search entry to be an error document');
+      }
+    }
+    {
+      let entry = await realm.realmIndexQueryEngine.cardDocument(
+        new URL(`${testRealm}boom2`),
+      );
+      if (entry?.type === 'error') {
+        assert.strictEqual(
+          entry.error.detail,
+          'Encountered error rendering HTML for card: Attempted to resolve a modifier in a strict mode template, but it was not in scope: did-insert',
+        );
+        assert.deepEqual(entry.error.deps, [`${testRealm}boom2`]);
       } else {
         assert.ok('false', 'expected search entry to be an error document');
       }


### PR DESCRIPTION
This fixes the issue that we saw in production where were were encountering: "Invalid value used as weak map key" error. Ultimately this was the error: "Attempted to resolve a modifier in a strict mode template, but it was not in scope: did-insert", however the production build of ember strips out these useful rendering error messages. This was truly a userland error. the template needs to import `did-insert` if it wants to use it as a modifier and it wasn't. 

Our indexing process's try/catch that is used to capture errors during indexing was not enclosing the HTML pre-generation work, so any exceptions raised during HTML generation were uncaught and stopping the worker. The fix was to include the HTML pre-generation within the scope of the indexer's try/catch.