### PR TITLE
Attempt to fix job queue hangs

### DIFF
--- a/packages/runtime-common/realm-index-updater.ts
+++ b/packages/runtime-common/realm-index-updater.ts
@@ -77,15 +77,12 @@ export class RealmIndexUpdater {
     return ignoreMap;
   }
 
+  async isNewIndex(): Promise<boolean> {
+    return await this.#indexWriter.isNewIndex(this.realmURL);
+  }
+
   async run() {
-    let isNewIndex = await this.#indexWriter.isNewIndex(this.realmURL);
-    if (isNewIndex) {
-      // we only await the full indexing at boot if this is a brand new index
-      await this.fullIndex();
-    } else {
-      // this promise is tracked in `this.indexing()` if consumers need it.
-      this.fullIndex();
-    }
+    await this.fullIndex();
   }
 
   indexing() {

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -574,7 +574,12 @@ export class Realm {
 
   async #startup() {
     await Promise.resolve();
-    await this.#realmIndexUpdater.run();
+    let isNewIndex = await this.#realmIndexUpdater.isNewIndex();
+    let promise = this.#realmIndexUpdater.run();
+    if (isNewIndex) {
+      // we only await the full indexing at boot if this is a brand new index
+      await promise;
+    }
     this.sendServerEvent({ type: 'index', data: { type: 'full' } });
     this.#perfLog.debug(
       `realm server startup in ${Date.now() - this.#startTime}ms`,

--- a/packages/runtime-common/worker.ts
+++ b/packages/runtime-common/worker.ts
@@ -232,6 +232,11 @@ export class Worker {
             `Error raised during indexing has likely stopped the indexer`,
             e,
           );
+          deferred.reject(
+            new Error(
+              'Rethrowing error from inside registerRunner: ' + e?.message,
+            ),
+          );
         }
       },
     });


### PR DESCRIPTION
Failed jobs must reject the pending promises, not leave them forever hanging.