### PR TITLE
Remove the extra tooltip from AddButton component

### DIFF
--- a/packages/boxel-ui/addon/src/components/add-button/index.gts
+++ b/packages/boxel-ui/addon/src/components/add-button/index.gts
@@ -44,7 +44,6 @@ const AddButton: TemplateOnlyComponent<Signature> = <template>
       @width='40px'
       @height='40px'
       class='add-button'
-      title='Add'
       data-test-create-new-card-button
       ...attributes
     />

--- a/packages/boxel-ui/addon/src/components/add-button/index.gts
+++ b/packages/boxel-ui/addon/src/components/add-button/index.gts
@@ -44,6 +44,7 @@ const AddButton: TemplateOnlyComponent<Signature> = <template>
       @width='40px'
       @height='40px'
       class='add-button'
+      aria-label='Add'
       data-test-create-new-card-button
       ...attributes
     />


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/b0143329-4d22-41ed-8e5c-2cb473b5b6ff)

After:
<img width="327" alt="button" src="https://github.com/user-attachments/assets/fc5dd5e5-d1f3-420d-9063-19ed1ed0ff68">
