### PR TITLE
Relax indexing timeouts

### DIFF
--- a/packages/runtime-common/realm-index-updater.ts
+++ b/packages/runtime-common/realm-index-updater.ts
@@ -102,7 +102,7 @@ export class RealmIndexUpdater {
       let job = await this.#queue.publish<FromScratchResult>(
         `from-scratch-index`,
         'indexing',
-        120,
+        4 * 60,
         args,
       );
       let { ignoreData, stats } = await job.done;
@@ -140,7 +140,7 @@ export class RealmIndexUpdater {
       let job = await this.#queue.publish<IncrementalResult>(
         `incremental-index`,
         'indexing',
-        120,
+        4 * 60,
         args,
       );
       let { invalidations, ignoreData, stats } = await job.done;


### PR DESCRIPTION
I'm seeing in staging that a full index of the experiments realm is just a couple seconds shy of 2 minutes--meaning that we barely passed our indexing timeout. I'm relaxing this timeout so we have a bit more headroom for indexing.