### PR TITLE
Add 35% white outline around submode elements that may need contrast from dark workspace background

### DIFF
--- a/packages/boxel-ui/addon/src/styles/variables.css
+++ b/packages/boxel-ui/addon/src/styles/variables.css
@@ -62,6 +62,7 @@
   --boxel-border-color: #d3d3d3;
   --boxel-border: 1px solid var(--boxel-border-color);
   --boxel-border-dark: 1px solid var(--boxel-dark);
+  --boxel-border-flexible: 1px solid rgba(255, 255, 255, 0.35);
   --boxel-border-card: 1px solid rgba(0,0,0, 0.1 );
   --boxel-border-radius-xs: 1.5px;
   --boxel-border-radius-sm: 6px;

--- a/packages/host/app/components/ai-assistant/button.gts
+++ b/packages/host/app/components/ai-assistant/button.gts
@@ -25,7 +25,7 @@ const AiAssistantButton: TemplateOnlyComponent<Signature> = <template>
       right: var(--boxel-sp);
       border-radius: var(--boxel-border-radius);
       background-color: var(--boxel-dark);
-      border: 1px solid rgba(255, 255, 255, 0.35);
+      border: var(--boxel-border-flexible);
 
       background-image: image-set(
         url('./ai-assist-icon.webp') 1x,

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -414,7 +414,9 @@ export default class SubmodeLayout extends Component<Signature> {
 
       .workspace-button {
         border: none;
+        outline: var(--boxel-border-flexible);
         margin-right: var(--boxel-sp-xs);
+        border-radius: var(--boxel-border-radius);
       }
       .dark-icon {
         --icon-bg-opacity: 1;

--- a/packages/host/app/components/search-sheet/index.gts
+++ b/packages/host/app/components/search-sheet/index.gts
@@ -300,6 +300,10 @@ export default class SearchSheet extends Component<Signature> {
         width: var(--search-sheet-closed-width);
       }
 
+      .closed .search-sheet__search-input-group {
+        outline: var(--boxel-border-flexible);
+      }
+
       .search-sheet.closed .search-sheet-content {
         display: none;
       }

--- a/packages/host/app/components/submode-switcher.gts
+++ b/packages/host/app/components/submode-switcher.gts
@@ -91,6 +91,7 @@ export default class SubmodeSwitcher extends Component<Signature> {
 
         height: var(--submode-switcher-trigger-height);
         border: none;
+        outline: var(--boxel-border-flexible);
         padding: var(--boxel-sp-xxs) var(--boxel-sp-xs);
         border-radius: var(--boxel-border-radius);
         background: var(--boxel-dark);


### PR DESCRIPTION
<img width="868" alt="image" src="https://github.com/user-attachments/assets/9c3ec619-e7a7-46a3-bbbc-702509982c04">
