### PR TITLE
Disable "presence" feature to stop run away /sync

### DIFF
--- a/packages/matrix/docker/synapse/dev/homeserver.yaml
+++ b/packages/matrix/docker/synapse/dev/homeserver.yaml
@@ -19,6 +19,9 @@ database:
 
 log_config: "/data/log.config"
 
+presence:
+  enabled: false
+
 rc_messages_per_second: 10000
 rc_message_burst_count: 10000
 rc_registration:

--- a/packages/matrix/docker/synapse/test/homeserver.yaml
+++ b/packages/matrix/docker/synapse/test/homeserver.yaml
@@ -19,6 +19,9 @@ database:
 
 log_config: "/data/log.config"
 
+presence:
+  enabled: false
+
 rc_messages_per_second: 10000
 rc_message_burst_count: 10000
 rc_registration:


### PR DESCRIPTION
This is a workaround for a synapse bug that is triggering a run away sync https://github.com/element-hq/synapse/issues/15824

Many people have indicated that disabling the "presence" feature will prevent is a workaround for this bug. Presence tracking allows users to see the state (e.g online/offline) of other local and remote users. my local testing seems to indicate this workaround does actually work.

TODO
- [x] create infra PR to fix this in hosted environments. https://github.com/cardstack/infra/pull/541