### PR TITLE
Remove pointer on resizable panel handle

### DIFF
--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/handle.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/handle.gts
@@ -90,11 +90,11 @@ export default class Handle extends Component<Signature> {
       }
 
       .resize-handle.horizontal {
-        cursor: col-resize;
+        cursor: unset;
       }
 
       .resize-handle.vertical {
-        cursor: row-resize;
+        cursor: unset;
       }
 
       .resize-handle.hidden {

--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/handle.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/handle.gts
@@ -90,11 +90,11 @@ export default class Handle extends Component<Signature> {
       }
 
       .resize-handle.horizontal {
-        cursor: unset;
+        cursor: col-resize;
       }
 
       .resize-handle.vertical {
-        cursor: unset;
+        cursor: row-resize;
       }
 
       .resize-handle.hidden {

--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/handle.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/handle.gts
@@ -42,7 +42,7 @@ export default class Handle extends Component<Signature> {
         {{on 'mousedown' @onMouseDown}}
         {{on 'dblclick' @onDoubleClick}}
         data-test-resize-handle
-      ><div class={{this.arrowResizeHandleClass}} /></button>
+      />
     </div>
     <style scoped>
       .separator-horizontal {
@@ -100,77 +100,6 @@ export default class Handle extends Component<Signature> {
       .resize-handle.hidden {
         visibility: hidden;
       }
-
-      .arrow {
-        content: '';
-        position: absolute;
-        width: 0;
-        height: 0;
-        pointer-events: none;
-      }
-
-      .arrow.right {
-        top: 50%;
-        right: calc(var(--boxel-panel-resize-handle-width) * -1);
-        transform: translateY(-50%);
-        border-top: 6px solid transparent;
-        border-bottom: 6px solid transparent;
-        border-left: 10px solid
-          var(--boxel-panel-resize-handle-background-color);
-      }
-
-      .resize-handle:hover .arrow.right {
-        border-left-color: var(
-          --boxel-panel-resize-handle-hover-background-color
-        );
-      }
-
-      .arrow.left {
-        top: 50%;
-        left: calc(var(--boxel-panel-resize-handle-width) * -1);
-        transform: translateY(-50%);
-        border-top: 6px solid transparent;
-        border-bottom: 6px solid transparent;
-        border-right: 10px solid
-          var(--boxel-panel-resize-handle-background-color);
-      }
-
-      .resize-handle:hover .arrow.left {
-        border-right-color: var(
-          --boxel-panel-resize-handle-hover-background-color
-        );
-      }
-
-      .arrow.top {
-        left: 50%;
-        top: calc(var(--boxel-panel-resize-handle-height) * -1);
-        transform: translateX(-50%);
-        border-left: 6px solid transparent;
-        border-right: 6px solid transparent;
-        border-bottom: 10px solid
-          var(--boxel-panel-resize-handle-background-color);
-      }
-
-      .resize-handle:hover .arrow.top {
-        border-bottom-color: var(
-          --boxel-panel-resize-handle-hover-background-color
-        );
-      }
-
-      .arrow.bottom {
-        left: 50%;
-        bottom: calc(var(--boxel-panel-resize-handle-height) * -1);
-        transform: translateX(-50%);
-        border-left: 6px solid transparent;
-        border-right: 6px solid transparent;
-        border-top: 10px solid var(--boxel-panel-resize-handle-background-color);
-      }
-
-      .resize-handle:hover .arrow.bottom {
-        border-top-color: var(
-          --boxel-panel-resize-handle-hover-background-color
-        );
-      }
     </style>
   </template>
 
@@ -184,51 +113,5 @@ export default class Handle extends Component<Signature> {
 
   @action registerHandle() {
     this.args.registerHandle(this);
-  }
-
-  get arrowResizeHandleClass() {
-    let horizontal = this.args.orientation === 'horizontal';
-    let reverse = this.args.reverseArrow;
-
-    let myIndex = this.args.panelGroupComponent.resizeHandles.indexOf(this);
-
-    if (myIndex == undefined) {
-      return '';
-    }
-
-    let toward: string | null = null;
-
-    let groupComponent = this.args.panelGroupComponent;
-
-    let isFirstPanel = myIndex === 0;
-    let isCollapsed = groupComponent.panels[myIndex]?.lengthPx === 0;
-
-    let nextPanelIsLast = groupComponent.resizeHandles.length - 1 === myIndex;
-    let nextPanelIsCollapsed =
-      groupComponent.panels[myIndex + 1]?.lengthPx === 0;
-
-    if (isFirstPanel && !isCollapsed) {
-      if (nextPanelIsLast && nextPanelIsCollapsed) {
-        toward = reverse ? 'beginning' : 'end';
-      } else {
-        toward = reverse ? 'end' : 'beginning';
-      }
-    } else if (nextPanelIsLast || (isFirstPanel && isCollapsed)) {
-      if (nextPanelIsCollapsed) {
-        toward = 'beginning';
-      } else {
-        toward = reverse ? 'beginning' : 'end';
-      }
-    }
-
-    if (toward) {
-      if (toward === 'beginning') {
-        return horizontal ? 'arrow left' : 'arrow top';
-      } else {
-        return horizontal ? 'arrow right' : 'arrow bottom';
-      }
-    } else {
-      return '';
-    }
   }
 }


### PR DESCRIPTION
Refer to https://linear.app/cardstack/issue/CS-7253/eliminate-pointer-on-resizable-panel-handle

### What is changing 
Remove the visual pointer element on the resize handle component.

----

#### Before

![image](https://github.com/user-attachments/assets/4ccdec19-4423-4464-b5b1-ea1966436e96)

#### After

![remove-visual-pointy-element](https://github.com/user-attachments/assets/07a7ab60-5389-4cd9-98c4-5e1e19079a68)


