### PR TITLE
ci: Remove unused change-check output

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -268,7 +268,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       boxel: ${{ steps.filter.outputs.boxel }}
-      ai-bot: ${{ steps.filter.outputs.ai-bot }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3


### PR DESCRIPTION
I noticed this orphaned output while working on #1630, it should have been part of #1380.