### PR TITLE
ci: Add more paths for Yaml lint workflow

### DIFF
--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -93,8 +93,3 @@ jobs:
         if: always()
         run: pnpm run lint
         working-directory: packages/vscode-boxel-tools
-      # uncomment this after there are actual gts files to lint in seed realm
-      # - name: Lint Seed Realm
-      #   if: always()
-      #   run: pnpm run lint
-      #   working-directory: packages/seed-realm

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "**.yml"
+      - "**.yaml"
 
 jobs:
   lint:


### PR DESCRIPTION
This workflow was triggered only on changes to `.yml` files, but we also have `.yaml` files, prominently the [main CI workflow](https://github.com/cardstack/boxel/blob/main/.github/workflows/ci.yaml). Another approach would be to standardise on and enforce a single extension.

But something should change because it’s confusing to get lint errors on unchanged files like I did [here](https://github.com/cardstack/boxel/actions/runs/11151163428/job/30993952188?pr=1634).

To remove the lint error I just removed the placeholder lint step, it’s easily restored from history when needed, or copied from another realm lint step.

```
[warning] comment not indented like content (comments-indentation)
```