### PR TITLE
Fix overlay issue where zIndex is not computed for already bound card elements 

### DIFF
--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -541,7 +541,6 @@ export default class OperatorModeOverlays extends Component<Signature> {
           'http://localhost:4201/experiments/Task/20058a9d-3c2d-4b42-8430-a95b6183245c.json')
     ) {
       if (this.currentlyHoveredCard !== renderedCard) {
-        debugger;
       }
     }
     return this.currentlyHoveredCard?.element === renderedCard.element;

--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -2,7 +2,7 @@ import { fn, array } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import { htmlSafe } from '@ember/template';
+import { SafeString, htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
@@ -53,7 +53,7 @@ interface Signature {
 }
 
 let boundRenderedCardElement = new WeakSet<HTMLElement>();
-let computedZIndex = new WeakMap<HTMLElement, string>();
+let computedZIndex = new WeakMap<HTMLElement, SafeString>();
 
 export default class OperatorModeOverlays extends Component<Signature> {
   <template>

--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -512,37 +512,12 @@ export default class OperatorModeOverlays extends Component<Signature> {
   }
 
   @action private isSelected(cardDefOrId: CardDefOrId) {
-    console.log(
-      'isSelected',
-      this.args.selectedCards?.some(
-        (card: CardDefOrId) => card === cardDefOrId,
-      ),
-      cardDefOrId,
-    );
     return this.args.selectedCards?.some(
       (card: CardDefOrId) => card === cardDefOrId,
     );
   }
 
   @action private isHovered(renderedCard: RenderedCardForOverlayActions) {
-    console.log(
-      'isHovered',
-      this.currentlyHoveredCard === renderedCard,
-      renderedCard.cardDefOrId,
-    );
-    if (
-      (renderedCard.cardDefOrId ===
-        'http://localhost:4201/experiments/Task/346cc7ac-eb65-41fd-a1d7-0400668da097.json' &&
-        this.currentlyHoveredCard?.cardDefOrId ===
-          'http://localhost:4201/experiments/Task/346cc7ac-eb65-41fd-a1d7-0400668da097.json') ||
-      (renderedCard.cardDefOrId ===
-        'http://localhost:4201/experiments/Task/20058a9d-3c2d-4b42-8430-a95b6183245c.json' &&
-        this.currentlyHoveredCard?.cardDefOrId ===
-          'http://localhost:4201/experiments/Task/20058a9d-3c2d-4b42-8430-a95b6183245c.json')
-    ) {
-      if (this.currentlyHoveredCard !== renderedCard) {
-      }
-    }
     return this.currentlyHoveredCard?.element === renderedCard.element;
   }
 

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -110,7 +110,6 @@ export interface RenderedCardForOverlayActions {
   fieldName: string | undefined;
   format: Format | 'data';
   stackItem: StackItem;
-  overlayZIndexStyle?: SafeString;
 }
 
 export default class OperatorModeStackItem extends Component<Signature> {


### PR DESCRIPTION
The issue here is the functioning of overlays when there is more than one pre-rendered search on a stack (Currently, I guess we always only ever have one query on the stack). When that occurs, the card elements in the 1st search gets bounded to a weak set `boundRenderedCardElement`. When the 2nd search completes, we loop thru elements of the 1st search but skip them bcos they are assumed to already be bounded in the set. The issue is when we skip these, we miss out on the mutation of `renderedCard.overlayZIndexStyle` hence, some cards do not have the z-style property. 


Note: 
I attempted not to regress on the PR https://github.com/cardstack/boxel/pull/1517. I think this PR wants to only compute the ZIndex once. So I have introduced a weakmap of ZIndex for every element encountered