### PR TITLE
Show workspace chooser instead of "add new card" after closing the last remaining card on the stack

### DIFF
--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -18,13 +18,11 @@ import { TrackedWeakMap, TrackedSet } from 'tracked-built-ins';
 
 import { Tooltip } from '@cardstack/boxel-ui/components';
 import { cn, eq } from '@cardstack/boxel-ui/helpers';
-import { IconPlus, Download } from '@cardstack/boxel-ui/icons';
+import { Download } from '@cardstack/boxel-ui/icons';
 
 import {
   aiBotUsername,
   Deferred,
-  baseCardRef,
-  chooseCard,
   codeRefWithAbsoluteURL,
   getCard,
   moduleFrom,
@@ -301,18 +299,6 @@ export default class InteractSubmode extends Component<Signature> {
     }
     return item;
   }
-
-  private addCard = restartableTask(async () => {
-    let type = baseCardRef;
-    let chosenCard: CardDef | undefined = await chooseCard({
-      filter: { type },
-    });
-
-    if (chosenCard) {
-      // This is called when there are no cards in the stack left, so we can assume the stackIndex is 0
-      this.publicAPI(this, 0).viewCard(chosenCard, 'isolated');
-    }
-  });
 
   private close = task(async (item: StackItem) => {
     let { card, request } = item;

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -639,61 +639,45 @@ export default class InteractSubmode extends Component<Signature> {
           </Tooltip>
         {{/if}}
         <div class='stacks'>
-          {{#if (eq this.allStackItems.length 0)}}
-            <div class='no-cards' data-test-empty-stack>
-              <p class='add-card-title'>
-                Add a card to get started
-              </p>
-
-              <button
-                class='add-card-button'
-                {{on 'click' (fn (perform this.addCard))}}
-                data-test-add-card-button
-              >
-                <IconPlus width='36px' height='36px' />
-              </button>
-            </div>
-          {{else}}
-            {{#each this.stacks as |stack stackIndex|}}
-              {{#let
-                (get
-                  this.stackBackgroundsState.differingBackgroundImageURLs
-                  stackIndex
-                )
-                as |backgroundImageURLSpecificToThisStack|
-              }}
-                <OperatorModeStack
-                  data-test-operator-mode-stack={{stackIndex}}
-                  class={{cn
-                    'operator-mode-stack'
-                    (if backgroundImageURLSpecificToThisStack 'with-bg-image')
-                  }}
-                  style={{if
-                    backgroundImageURLSpecificToThisStack
-                    (htmlSafe
-                      (concat
-                        'background-image: url('
-                        backgroundImageURLSpecificToThisStack
-                        ')'
-                      )
+          {{#each this.stacks as |stack stackIndex|}}
+            {{#let
+              (get
+                this.stackBackgroundsState.differingBackgroundImageURLs
+                stackIndex
+              )
+              as |backgroundImageURLSpecificToThisStack|
+            }}
+              <OperatorModeStack
+                data-test-operator-mode-stack={{stackIndex}}
+                class={{cn
+                  'operator-mode-stack'
+                  (if backgroundImageURLSpecificToThisStack 'with-bg-image')
+                }}
+                style={{if
+                  backgroundImageURLSpecificToThisStack
+                  (htmlSafe
+                    (concat
+                      'background-image: url('
+                      backgroundImageURLSpecificToThisStack
+                      ')'
                     )
-                  }}
-                  @stackItems={{stack}}
-                  @stackIndex={{stackIndex}}
-                  @publicAPI={{this.publicAPI this stackIndex}}
-                  @close={{perform this.close}}
-                  @onSelectedCards={{this.onSelectedCards}}
-                  @setupStackItem={{this.setupStackItem}}
-                />
-              {{/let}}
-            {{/each}}
+                  )
+                }}
+                @stackItems={{stack}}
+                @stackIndex={{stackIndex}}
+                @publicAPI={{this.publicAPI this stackIndex}}
+                @close={{perform this.close}}
+                @onSelectedCards={{this.onSelectedCards}}
+                @setupStackItem={{this.setupStackItem}}
+              />
+            {{/let}}
+          {{/each}}
 
-            <CopyButton
-              @selectedCards={{this.selectedCards}}
-              @copy={{fn (perform this.copy)}}
-              @isCopying={{this.copy.isRunning}}
-            />
-          {{/if}}
+          <CopyButton
+            @selectedCards={{this.selectedCards}}
+            @copy={{fn (perform this.copy)}}
+            @isCopying={{this.copy.isRunning}}
+          />
         </div>
         {{#if this.canCreateNeighborStack}}
           <Tooltip @placement='left'>
@@ -744,29 +728,6 @@ export default class InteractSubmode extends Component<Signature> {
       .operator-mode__main .add-card-to-neighbor-stack {
         flex: 0;
         flex-basis: var(--container-button-size);
-      }
-      .no-cards {
-        max-width: 50rem;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
-      }
-      .add-card-title {
-        color: var(--boxel-light);
-        font: var(--boxel-font-lg);
-      }
-      .add-card-button {
-        --icon-color: var(--boxel-light);
-        height: 350px;
-        width: 200px;
-        vertical-align: middle;
-        background-color: var(--boxel-highlight);
-        border: none;
-        border-radius: var(--boxel-border-radius);
-      }
-      .add-card-button:hover {
-        background-color: var(--boxel-highlight-hover);
       }
       .add-card-to-neighbor-stack {
         --icon-color: var(--boxel-highlight-hover);

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -199,6 +199,10 @@ export default class OperatorModeStateService extends Service {
         });
     }
 
+    if (this.state.stacks.length === 0) {
+      this.operatorModeController.workspaceChooserOpened = true;
+    }
+
     this.schedulePersist();
   }
 

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -362,21 +362,10 @@ module('Acceptance | interact submode tests', function (hooks) {
     test('Can open a recent card in empty stack', async function (assert) {
       await visitOperatorMode({});
 
-      await click('[data-test-add-card-button]');
-
       await click('[data-test-search-field]');
       await fillIn('[data-test-search-field]', `${testRealmURL}person-entry`);
 
-      assert.dom('[data-test-realm-filter-button]').isDisabled();
-
-      assert
-        .dom(`[data-test-realm="Test Workspace B"] [data-test-results-count]`)
-        .hasText('1 result');
-
-      assert.dom('[data-test-card-catalog-item]').exists({ count: 1 });
-      await click('[data-test-select]');
-
-      await click('[data-test-card-catalog-go-button]');
+      await click('[data-test-card="http://test-realm/test/person-entry"]');
 
       assert
         .dom(`[data-test-stack-card="${testRealmURL}person-entry"]`)
@@ -1201,12 +1190,12 @@ module('Acceptance | interact submode tests', function (hooks) {
         ],
       });
 
-      // Close the last card in the last stack that is left - should get the empty state
+      // Close the last card in the last stack that is left
       await click(
         '[data-test-operator-mode-stack="0"] [data-test-close-button]',
       );
 
-      assert.dom('.no-cards').includesText('Add a card to get started');
+      assert.dom('[data-test-workspace-chooser]').exists();
     });
 
     test('visiting 2 stacks from differing realms', async function (assert) {

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -344,66 +344,19 @@ module('Acceptance | interact submode tests', function (hooks) {
       assert.dom('[data-test-search-field]').hasValue('');
     });
 
-    test('Can add a card by URL using the add button', async function (assert) {
+    test('Can search for an index card by URL (without "index" in path)', async function (assert) {
       await visitOperatorMode({});
 
-      assert.dom('[data-test-operator-mode-stack]').doesNotExist();
+      await click('[data-test-search-field]');
 
-      await click('[data-test-add-card-button]');
-      await fillIn(
-        '[data-test-card-catalog-modal] [data-test-search-field]',
-        `${testRealmURL}index`,
-      );
+      await fillIn('[data-test-search-field]', testRealmURL);
 
       assert
-        .dom(`[data-test-card-catalog-item="${testRealmURL}index"] .card-title`)
-        .hasText('Test Workspace B');
-      await click(`[data-test-select="${testRealmURL}index"]`);
-      await click('[data-test-card-catalog-go-button]');
-      assert.dom('[data-test-operator-mode-stack]').exists({ count: 1 });
-      assert.dom('[data-test-stack-card-index]').exists({ count: 1 });
-      assert.dom('[data-test-stack-card-header]').hasText('Test Workspace B');
-    });
-
-    test('Can add an index card by URL (without "index" in path) using the add button', async function (assert) {
-      const wrongURL = 'https://example.test/this/is/a/wrong/url';
-      await visitOperatorMode({});
-
-      assert.dom('[data-test-operator-mode-stack]').doesNotExist();
-
-      await click('[data-test-add-card-button]');
-      await fillIn(
-        '[data-test-card-catalog-modal] [data-test-search-field]',
-        wrongURL,
-      );
-
-      await fillIn(
-        '[data-test-card-catalog-modal] [data-test-search-field]',
-        baseRealm.url.slice(0, -1),
-      );
-
+        .dom('[data-test-search-label]')
+        .includesText('Card found at http://test-realm/test/');
       assert
-        .dom('[data-test-card-catalog-item] .card-title')
-        .hasText('Base Workspace');
-
-      await fillIn(
-        '[data-test-card-catalog-modal] [data-test-search-field]',
-        testRealmURL,
-      );
-      assert
-        .dom('[data-test-card-catalog-item] .card-title')
-        .hasText('Test Workspace B');
-      assert.dom('[data-test-boxel-input-error-message]').doesNotExist();
-      assert
-        .dom('[data-test-boxel-input-validation-state="invalid"]')
-        .doesNotExist();
-
-      await click(`[data-test-select="${testRealmURL}index"]`);
-      await click('[data-test-card-catalog-go-button]');
-
-      assert.dom('[data-test-operator-mode-stack]').exists({ count: 1 });
-      assert.dom('[data-test-stack-card-index]').exists({ count: 1 });
-      assert.dom('[data-test-stack-card-header]').hasText('Test Workspace B');
+        .dom('[data-test-card="http://test-realm/test/index"]')
+        .exists({ count: 1 });
     });
 
     test('Can open a recent card in empty stack', async function (assert) {

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -387,8 +387,6 @@ module('Acceptance | interact submode tests', function (hooks) {
         `[data-test-stack-card="${testRealmURL}person-entry"] [data-test-close-button]`,
       );
 
-      assert.dom('[data-test-add-card-button]').exists('stack is empty');
-
       await click('[data-test-search-field]');
       assert.dom('[data-test-search-sheet]').hasClass('prompt');
 
@@ -397,19 +395,6 @@ module('Acceptance | interact submode tests', function (hooks) {
       assert
         .dom(`[data-test-stack-card="${testRealmURL}person-entry"]`)
         .exists();
-    });
-
-    test('Handles a URL with no results', async function (assert) {
-      await visitOperatorMode({});
-
-      await click('[data-test-add-card-button]');
-
-      await fillIn(
-        '[data-test-search-field]',
-        `${testRealmURL}xyz-does-not-exist`,
-      );
-
-      assert.dom(`[data-test-card-catalog]`).hasText('No cards available');
     });
   });
 

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -520,7 +520,7 @@ module('Integration | operator-mode', function (hooks) {
     assert.dom('[data-test-pet]').includesText('Paper Bad cat!');
   });
 
-  test('displays add card button if user closes the only card in the stack and opens a card from card chooser', async function (assert) {
+  test('opens workspace chooser after closing the only remainingcard on the stack', async function (assert) {
     await setCardInOperatorModeState(`${testRealmURL}Person/fadhlan`);
 
     await renderComponent(
@@ -537,23 +537,8 @@ module('Integration | operator-mode', function (hooks) {
     await click('[data-test-close-button]');
     await waitUntil(() => !document.querySelector('[data-test-stack-card]'));
     assert.dom('[data-test-person]').isNotVisible();
-    assert.dom('[data-test-add-card-button]').isVisible();
-
-    await click('[data-test-add-card-button]');
-    assert.dom('[data-test-card-catalog-modal]').isVisible();
-
-    await waitFor(`[data-test-select]`);
-    await showSearchResult(
-      'Operator Mode Workspace',
-      `${testRealmURL}Person/fadhlan`,
-    );
-
+    assert.dom('[data-test-workspace-chooser]').isVisible();
     await percySnapshot(assert);
-
-    await click(`[data-test-select="${testRealmURL}Person/fadhlan"]`);
-    await click('[data-test-card-catalog-go-button]');
-
-    await waitFor(`[data-test-stack-card="${testRealmURL}Person/fadhlan"]`);
   });
 
   test('displays cards on cards-grid and includes `catalog-entry` instances', async function (assert) {

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -33,7 +33,6 @@ import {
   setupLocalIndexing,
   setupServerSentEvents,
   setupOnSave,
-  showSearchResult,
   type TestContextWithSave,
   lookupLoaderService,
 } from '../../helpers';

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -969,25 +969,6 @@ test.describe('Room messages', () => {
     await assertMessages(page, [prompt]);
   });
 
-  test('sends message when no card open in the stack', async ({ page }) => {
-    await login(page, 'user1', 'pass');
-    await page
-      .locator('[data-test-stack-card] [data-test-close-button]')
-      .click();
-    await page
-      .locator('[data-test-message-field]')
-      .fill('Sending message with no card open');
-    await page.locator('[data-test-send-message-btn]').click();
-
-    await assertMessages(page, [
-      {
-        from: 'user1',
-        message: 'Sending message with no card open',
-        cards: [],
-      },
-    ]);
-  });
-
   test('attaches a card in a conversation multiple times', async ({ page }) => {
     const testCard = `${testHost}/hassan`;
 


### PR DESCRIPTION
Removes this and replaces it with workspace chooser:

<img width="302" alt="image" src="https://github.com/user-attachments/assets/9ebd7564-9a74-47ec-86c8-db421c68062f">

