### PR TITLE
Don't show field manipulation buttons in schema editor for read-only card defs

### DIFF
--- a/packages/host/app/components/operator-mode/card-adoption-chain.gts
+++ b/packages/host/app/components/operator-mode/card-adoption-chain.gts
@@ -21,6 +21,7 @@ interface Signature {
     file: Ready;
     cardInheritanceChain: CardInheritance[];
     moduleSyntax: ModuleSyntax;
+    isReadOnly: boolean;
     goToDefinition: (
       codeRef: ResolvedCodeRef | undefined,
       localName: string | undefined,
@@ -125,6 +126,9 @@ export default class CardAdoptionChain extends Component<Signature> {
   }
 
   @action allowFieldManipulation(file: Ready, cardType: Type): boolean {
+    if (this.args.isReadOnly) {
+      return false;
+    }
     // Only allow add/edit/remove for fields from the currently opened module
     return stripFileExtension(file.url) === cardType.module;
   }

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -872,6 +872,7 @@ export default class CodeSubmode extends Component<Signature> {
                         @card={{this.selectedCardOrField.cardOrField}}
                         @cardTypeResource={{this.selectedCardOrField.cardType}}
                         @goToDefinition={{this.goToDefinition}}
+                        @isReadOnly={{this.isReadOnly}}
                         as |SchemaEditorTitle SchemaEditorPanel|
                       >
                         <A.Item

--- a/packages/host/app/components/operator-mode/code-submode/schema-editor.gts
+++ b/packages/host/app/components/operator-mode/code-submode/schema-editor.gts
@@ -30,6 +30,7 @@ interface Signature {
     moduleContentsResource: ModuleContentsResource;
     cardTypeResource?: CardType;
     card: typeof BaseDef;
+    isReadOnly: boolean;
     goToDefinition: (
       codeRef: ResolvedCodeRef | undefined,
       localName: string | undefined,
@@ -40,7 +41,11 @@ interface Signature {
       WithBoundArgs<typeof SchemaEditorTitle, 'totalFields' | 'hasModuleError'>,
       WithBoundArgs<
         typeof CardAdoptionChain,
-        'file' | 'moduleSyntax' | 'cardInheritanceChain' | 'goToDefinition'
+        | 'file'
+        | 'moduleSyntax'
+        | 'cardInheritanceChain'
+        | 'goToDefinition'
+        | 'isReadOnly'
       >,
     ];
   };
@@ -156,6 +161,7 @@ export default class SchemaEditor extends Component<Signature> {
         (component
           CardAdoptionChain
           file=@file
+          isReadOnly=@isReadOnly
           moduleSyntax=this.moduleSyntax
           cardInheritanceChain=this.cardInheritanceChain.value
           goToDefinition=@goToDefinition

--- a/packages/host/tests/acceptance/code-submode/editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/editor-test.ts
@@ -769,16 +769,8 @@ module('Acceptance | code submode | editor tests', function (hooks) {
 
     test('the editor is read-only', async function (assert) {
       await visitOperatorMode({
-        stacks: [
-          [
-            {
-              id: `${testRealmURL}Pet/mango`,
-              format: 'isolated',
-            },
-          ],
-        ],
         submode: 'code',
-        codePath: `${testRealmURL}Pet/mango.json`,
+        codePath: `${testRealmURL}pet.gts`,
       });
 
       await waitForCodeEditor();
@@ -798,6 +790,13 @@ module('Acceptance | code submode | editor tests', function (hooks) {
         'rgb(235, 234, 237)', // equivalent to #ebeaed
         'monaco editor is greyed out when read-only',
       );
+
+      assert
+        .dom('[data-test-add-field-button]')
+        .doesNotExist('add field button does not exist');
+      assert
+        .dom('[data-test-schema-editor-field-contextual-button]')
+        .doesNotExist('field context menu button does not exist');
     });
   });
 });


### PR DESCRIPTION
The PR removes the add field button and field context menu button when the card displayed in the schema editor comes from a read-only realm

before:

![image](https://github.com/user-attachments/assets/40501af4-ab5e-493e-abf0-03e527410ffc)


after:

![image](https://github.com/user-attachments/assets/87856040-7f48-4998-8d58-2c768d8adbce)
