### PR TITLE
Enhance syntax of VirtualNetwork to add shimAsyncModule

### DIFF
--- a/packages/host/app/lib/externals.ts
+++ b/packages/host/app/lib/externals.ts
@@ -22,7 +22,6 @@ import * as emberProvideConsumeContextContextProvider from 'ember-provide-consum
 import * as emberResources from 'ember-resources';
 import * as ethers from 'ethers';
 import * as flat from 'flat';
-import * as lodash from 'lodash';
 import * as matrixJsSDK from 'matrix-js-sdk';
 import * as superFastMD5 from 'super-fast-md5';
 import * as tracked from 'tracked-built-ins';
@@ -78,7 +77,10 @@ export function shimExternals(virtualNetwork: VirtualNetwork) {
     emberProvideConsumeContextContextProvider,
   );
   virtualNetwork.shimModule('flat', flat);
-  virtualNetwork.shimModule('lodash', lodash);
+  virtualNetwork.shimAsyncModule({
+    id: 'lodash',
+    resolve: () => import(`lodash`),
+  });
   virtualNetwork.shimModule('tracked-built-ins', tracked);
   virtualNetwork.shimModule('date-fns', dateFns);
   virtualNetwork.shimModule('@ember/destroyable', emberDestroyable);

--- a/packages/realm-server/lib/externals.ts
+++ b/packages/realm-server/lib/externals.ts
@@ -118,7 +118,10 @@ export function shimExternals(virtualNetwork: VirtualNetwork) {
     // implementations
     TrackedWeakMap: WeakMap,
   });
-  virtualNetwork.shimModule('lodash', lodash);
+  virtualNetwork.shimAsyncModule({
+    id: 'lodash',
+    resolve: async () => lodash,
+  });
   virtualNetwork.shimModule('date-fns', dateFns);
   virtualNetwork.shimModule('ember-resources', { Resource: class {} });
   virtualNetwork.shimModule('@ember/destroyable', {});

--- a/packages/runtime-common/package-shim-handler.ts
+++ b/packages/runtime-common/package-shim-handler.ts
@@ -1,5 +1,10 @@
 import { logger, trimExecutableExtension } from './index';
 
+export type ModuleLike = Record<string, any>;
+export type ModuleDescriptor =
+  | { prefix: `${string}/`; resolve: (rest: string) => Promise<ModuleLike> }
+  | { id: string; resolve: () => Promise<ModuleLike> };
+
 function trimModuleIdentifier(moduleIdentifier: string): string {
   return trimExecutableExtension(new URL(moduleIdentifier)).href;
 }
@@ -8,7 +13,11 @@ export const PACKAGES_FAKE_ORIGIN = 'https://packages/';
 
 export class PackageShimHandler {
   private resolveImport: (moduleIdentifier: string) => string;
-  private modules = new Map<string, Record<string, any>>();
+  private moduleIds = new Map<string, () => Promise<ModuleLike>>();
+  private modulePrefixes = new Map<
+    string,
+    (rest: string) => Promise<ModuleLike>
+  >();
   private log = logger('shim-handler');
 
   constructor(resolveImport: (moduleIdentifier: string) => string) {
@@ -18,13 +27,14 @@ export class PackageShimHandler {
   handle = async (request: Request): Promise<Response | null> => {
     if (request.url.startsWith(PACKAGES_FAKE_ORIGIN)) {
       try {
-        let shimmedModule = this.getModule(request.url);
+        let shimmedModule =
+          (await this.getModule(request.url)) ||
+          (await this.getModuleByPrefix(request.url));
         if (shimmedModule) {
           let response = new Response();
           (response as any)[Symbol.for('shimmed-module')] = shimmedModule;
           return response;
         }
-
         return null;
       } catch (err: any) {
         this.log.error(
@@ -37,16 +47,46 @@ export class PackageShimHandler {
     return null;
   };
 
-  shimModule(moduleIdentifier: string, module: Record<string, any>) {
+  shimModule(moduleIdentifier: string, module: ModuleLike) {
     moduleIdentifier = this.resolveImport(moduleIdentifier);
-    this.setModule(moduleIdentifier, module);
+    this.moduleIds.set(
+      trimModuleIdentifier(moduleIdentifier),
+      async () => module,
+    );
   }
 
-  private setModule(moduleIdentifier: string, module: Record<string, any>) {
-    this.modules.set(trimModuleIdentifier(moduleIdentifier), module);
+  shimAsyncModule(descriptor: ModuleDescriptor) {
+    if ('prefix' in descriptor) {
+      this.modulePrefixes.set(
+        this.resolveImport(descriptor.prefix),
+        descriptor.resolve,
+      );
+    } else {
+      this.moduleIds.set(
+        trimModuleIdentifier(descriptor.id),
+        descriptor.resolve,
+      );
+    }
   }
 
-  private getModule(moduleIdentifier: string): Record<string, any> | undefined {
-    return this.modules.get(trimModuleIdentifier(moduleIdentifier));
+  private async getModule(url: string): Promise<ModuleLike | undefined> {
+    let resolver = this.moduleIds.get(trimModuleIdentifier(url));
+    if (resolver) {
+      return await resolver();
+    }
+    return undefined;
+  }
+
+  private async getModuleByPrefix(
+    url: string,
+  ): Promise<ModuleLike | undefined> {
+    for (const [modulePrefix, resolveModule] of this.modulePrefixes) {
+      if (url.startsWith(modulePrefix)) {
+        let rest = url.slice(modulePrefix.length);
+        return await resolveModule(rest);
+        break;
+      }
+    }
+    return undefined;
   }
 }

--- a/packages/runtime-common/virtual-network.ts
+++ b/packages/runtime-common/virtual-network.ts
@@ -3,6 +3,8 @@ import { baseRealm } from './index';
 import {
   PackageShimHandler,
   PACKAGES_FAKE_ORIGIN,
+  type ModuleLike,
+  ModuleDescriptor,
 } from './package-shim-handler';
 import type { Readable } from 'stream';
 import { fetcher, type FetcherMiddlewareHandler } from './fetcher';
@@ -30,8 +32,12 @@ export class VirtualNetwork {
 
   private packageShimHandler = new PackageShimHandler(this.resolveImport);
 
-  shimModule(moduleIdentifier: string, module: Record<string, any>) {
+  shimModule(moduleIdentifier: string, module: ModuleLike) {
     this.packageShimHandler.shimModule(moduleIdentifier, module);
+  }
+
+  shimAsyncModule(descriptor: ModuleDescriptor) {
+    this.packageShimHandler.shimAsyncModule(descriptor);
   }
 
   addURLMapping(from: URL, to: URL) {


### PR DESCRIPTION
- this allows async resolution of modules to be implemented using dynamic import
- gives build tools like webpack an opportunity code split these modules
- also supports prefix-based module shimming, so that we can load patterns like @cardstack/boxel-icons/my-icon without having to consume the entirety of @cardstack/boxel-icons