### PR TITLE
CardsGrid state management bug

### DIFF
--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -275,13 +275,6 @@ export async function enterWorkspace(
 }
 
 export async function showAllCards(page: Page) {
-  // TODO: there seems to be something off with show all cards for cards grid.
-  // sometimes after clicking on it in our matrix tests, the cards grid goes
-  // back to displaying favorite cards--like some async thing is triggering a
-  // rerender of the cards grid with its initial state. There is some mystery
-  // async that we need to await before we can actually click on the all cards
-  // button
-  await new Promise((r) => setTimeout(r, 1000)); // TODO figure out what we need to wait on here
   await expect(
     page.locator(`[data-test-boxel-filter-list-button="All Cards"]`),
   ).toHaveCount(1);

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -765,8 +765,7 @@ test.describe('Room messages', () => {
       await expect(page.locator(`[data-test-attached-card]`)).toHaveCount(0);
     });
 
-    // Flaky matrix test: CS-7275
-    test.skip('replaces auto-attached card when drilling down (1 stack)', async ({
+    test('replaces auto-attached card when drilling down (1 stack)', async ({
       page,
     }) => {
       const testCard1 = `${testHost}/jersey`;


### PR DESCRIPTION
The refactors that we have done around the guest mode look like they have solved the cardsgrid state issues when the filter would reset after opening a card from the cards grid and closing it. This PR removes the matrix worksarounds that we had in place to deal with this bug.