### PR TITLE
Fix typo causing search results card to be overridden

### DIFF
--- a/packages/host/app/resources/room.ts
+++ b/packages/host/app/resources/room.ts
@@ -196,9 +196,10 @@ export class RoomResource extends Resource<Args> {
         // otherwise, the message field (may) still but it occurs only accidentally because of a ..thinking event
         // TOOD: Refactor having many if conditions to some variant of a strategy pattern
         update = true;
-      } else if (event.content['m.relates_to']?.rel_type === 'm.replace')
+      } else if (event.content['m.relates_to']?.rel_type === 'm.replace') {
         event_id = event.content['m.relates_to'].event_id;
-      update = true;
+        update = true;
+      }
       if (this._messageCache.has(event_id) && !update) {
         continue;
       }

--- a/packages/host/tests/integration/components/ai-assistant-panel-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel-test.gts
@@ -1706,6 +1706,10 @@ module('Integration | ai-assistant-panel', function (hooks) {
         },
         eventId: '__EVENT_ID__',
       }),
+      'm.relates_to': {
+        rel_type: 'm.replace',
+        event_id: '__EVENT_ID__',
+      },
     });
     let commandReactionEvents = getRoomEvents(roomId).filter(
       (event) =>
@@ -1776,6 +1780,10 @@ module('Integration | ai-assistant-panel', function (hooks) {
         },
         eventId: '__EVENT_ID__',
       }),
+      'm.relates_to': {
+        rel_type: 'm.replace',
+        event_id: '__EVENT_ID__',
+      },
     });
     let commandResultEvents = getRoomEvents(roomId).filter(
       (event) =>
@@ -1836,6 +1844,10 @@ module('Integration | ai-assistant-panel', function (hooks) {
         },
         eventId: '__EVENT_ID__',
       }),
+      'm.relates_to': {
+        rel_type: 'm.replace',
+        event_id: '__EVENT_ID__',
+      },
     });
     await waitFor('[data-test-command-apply]');
     await click('[data-test-message-idx="0"] [data-test-command-apply]');
@@ -1947,6 +1959,10 @@ module('Integration | ai-assistant-panel', function (hooks) {
         },
         eventId: '__EVENT_ID__',
       }),
+      'm.relates_to': {
+        rel_type: 'm.replace',
+        event_id: '__EVENT_ID__',
+      },
     });
     await waitFor('[data-test-command-apply]');
     await click('[data-test-message-idx="0"] [data-test-command-apply]');


### PR DESCRIPTION
Curly parentheses were missing at the conditional where we determine which messages should be replaced. This meant that the `update: true` was applying to messages that it should not apply to. This caused the message with the search results content to be overridden on refresh and the message would appear empty.

I was not able to replicate this in tests, however, some tests were passing because of the error above. I updated the messages in those tests to mimic real-life message structure and now they are passing.

Before: (on refresh)
<img width="370" alt="before" src="https://github.com/user-attachments/assets/4fbf7b05-4d73-436a-9539-f8941f54a6e6">

After:
<img width="372" alt="after" src="https://github.com/user-attachments/assets/fd545c9d-db07-4067-b1c1-aa9ddfc72c23">