### PR TITLE
Add loading state on add button

### DIFF
--- a/packages/boxel-ui/addon/src/components/add-button/index.gts
+++ b/packages/boxel-ui/addon/src/components/add-button/index.gts
@@ -42,9 +42,9 @@ const AddButton: TemplateOnlyComponent<Signature> = <template>
     </button>
   {{else}}
     {{#if (bool @loading)}}
-      <button class='add-button loading' disabled ...attributes>
+      <div class='add-button loading'>
         <LoadingIndicator />
-      </button>
+      </div>
     {{else}}
       <IconButton
         @icon={{PlusCircleIcon}}

--- a/packages/boxel-ui/addon/src/components/add-button/index.gts
+++ b/packages/boxel-ui/addon/src/components/add-button/index.gts
@@ -4,6 +4,7 @@ import { bool, eq } from '../../helpers/truth-helpers.ts';
 import IconPlus from '../../icons/icon-plus.gts';
 import PlusCircleIcon from '../../icons/icon-plus-circle.gts';
 import IconButton from '../icon-button/index.gts';
+import LoadingIndicator from '../loading-indicator/index.gts';
 
 interface Signature {
   Args: {
@@ -11,6 +12,7 @@ interface Signature {
     iconHeight?: string;
     iconWidth?: string;
     variant?: AddButtonVariant;
+    loading?: boolean;
   };
   Blocks: {
     default: [];
@@ -37,6 +39,10 @@ const AddButton: TemplateOnlyComponent<Signature> = <template>
         />
       {{/unless}}
       {{yield}}
+    </button>
+  {{else if (bool @loading)}}
+    <button class='add-button loading' disabled ...attributes>
+      <LoadingIndicator />
     </button>
   {{else}}
     <IconButton
@@ -113,6 +119,14 @@ const AddButton: TemplateOnlyComponent<Signature> = <template>
       background-color: var(--boxel-highlight-hover);
       box-shadow: var(--boxel-box-shadow);
       cursor: pointer;
+    }
+
+    .loading {
+      width: 40px;
+      height: 40px;
+      display: flex;
+      justify-content: center;
+      align-items: center;
     }
   </style>
 </template>;

--- a/packages/boxel-ui/addon/src/components/add-button/index.gts
+++ b/packages/boxel-ui/addon/src/components/add-button/index.gts
@@ -40,20 +40,22 @@ const AddButton: TemplateOnlyComponent<Signature> = <template>
       {{/unless}}
       {{yield}}
     </button>
-  {{else if (bool @loading)}}
-    <button class='add-button loading' disabled ...attributes>
-      <LoadingIndicator />
-    </button>
   {{else}}
-    <IconButton
-      @icon={{PlusCircleIcon}}
-      @width='40px'
-      @height='40px'
-      class='add-button'
-      aria-label='Add'
-      data-test-create-new-card-button
-      ...attributes
-    />
+    {{#if (bool @loading)}}
+      <button class='add-button loading' disabled ...attributes>
+        <LoadingIndicator />
+      </button>
+    {{else}}
+      <IconButton
+        @icon={{PlusCircleIcon}}
+        @width='40px'
+        @height='40px'
+        class='add-button'
+        aria-label='Add'
+        data-test-create-new-card-button
+        ...attributes
+      />
+    {{/if}}
   {{/if}}
 
   <style scoped>

--- a/packages/boxel-ui/addon/src/components/add-button/index.gts
+++ b/packages/boxel-ui/addon/src/components/add-button/index.gts
@@ -11,8 +11,8 @@ interface Signature {
     hideIcon?: boolean;
     iconHeight?: string;
     iconWidth?: string;
-    variant?: AddButtonVariant;
     loading?: boolean;
+    variant?: AddButtonVariant;
   };
   Blocks: {
     default: [];

--- a/packages/experiments-realm/app-card.gts
+++ b/packages/experiments-realm/app-card.gts
@@ -197,7 +197,12 @@ class DefaultTabTemplate extends GlimmerComponent<DefaultTabSignature> {
         <div class='add-card-button'>
           <Tooltip @placement='left' @offset={{6}}>
             <:trigger>
-              <AddButton {{on 'click' this.createNew}} />
+              <div class='add-card-button-container'>
+                <AddButton
+                  {{on 'click' this.createNew}}
+                  @loading={{this.isCreateCardRunning}}
+                />
+              </div>
             </:trigger>
             <:content>
               Add a new card to this collection
@@ -219,6 +224,11 @@ class DefaultTabTemplate extends GlimmerComponent<DefaultTabSignature> {
         left: 100%;
         bottom: 20px;
         z-index: 1;
+      }
+      .add-card-button-container {
+        display: flex;
+        justify-content: center;
+        align-items: center;
       }
       .error {
         color: var(--boxel-error-100);


### PR DESCRIPTION
Refer to https://linear.app/cardstack/issue/CS-7212/creating-new-card-instances-does-not-produce-feedback-to-user-while-it

### What is changing

There is a scenario where adding a card without choosing the card type, which immediately skips the card selection screen and displays a new card instance. Eg: Staging Realm -> Online Piano App ( Interact Mode )

**Actual result:**
- there is no indicator to show that the card is creating in progress, as it wasn't responded with immediate feedback
- the extra card will created if user clicks more than one time on plus button


https://github.com/user-attachments/assets/b768127e-c78f-4e2f-bba2-dccfa6644766


**Expected result (fixed in this PR):**
- show loading indicator while adding a new card instance
- disabled state while card is making in progress

https://github.com/user-attachments/assets/86ba9eb4-7057-4df3-b19a-84219c2ffa2d


