### PR TITLE
Add round corners of cards in CardsGrid

### DIFF
--- a/packages/base/cards-grid.gts
+++ b/packages/base/cards-grid.gts
@@ -170,7 +170,7 @@ class Isolated extends Component<typeof CardsGrid> {
                       {{! In order to support scrolling cards into view we use a selector that is not pruned out in production builds }}
                       data-cards-grid-item={{removeFileExtension card.url}}
                     >
-                      <CardContainer>
+                      <CardContainer @displayBoundaries='true'>
                         {{card.component}}
                       </CardContainer>
                     </li>
@@ -303,6 +303,7 @@ class Isolated extends Component<typeof CardsGrid> {
         cursor: pointer;
         container-name: fitted-card;
         container-type: size;
+        padding: 1px;
       }
       .add-button {
         display: inline-block;


### PR DESCRIPTION
In this PR, I set the `CardContainer`'s `boundaries` property to `true`, which adds a border with rounded corners to each fitted card in the `CardsGrid`. This change ensures consistency with the fitted cards displayed in the fitted gallery of the code mode preview panel.

Before:
<img width="583" alt="Screenshot 2024-10-04 at 16 50 31" src="https://github.com/user-attachments/assets/8aec61cd-d73f-45a8-995d-c6632e1dc076">


After:
<img width="592" alt="Screenshot 2024-10-04 at 16 48 22" src="https://github.com/user-attachments/assets/6e01983a-41a2-4174-ba0f-0a0d4376899d">

