### PR TITLE
Realm chooser drop down should default to currently displayed realm if it is writable

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -611,16 +611,16 @@ export default class CodeSubmode extends Component<Signature> {
 
       if (sourceInstance && this.realm.canWrite(sourceInstance.id)) {
         destinationRealm = this.realm.url(sourceInstance.id);
-      }
-
-      if (
+      } else if (
         definitionClass?.ref &&
         this.realm.canWrite(definitionClass.ref.module)
       ) {
         destinationRealm = this.realm.url(definitionClass.ref.module);
-      }
-
-      if (!destinationRealm && this.realm.defaultWritableRealm) {
+      } else if (
+        this.realm.canWrite(this.operatorModeStateService.realmURL.href)
+      ) {
+        destinationRealm = this.operatorModeStateService.realmURL.href;
+      } else if (this.realm.defaultWritableRealm) {
         destinationRealm = this.realm.defaultWritableRealm.path;
       }
 


### PR DESCRIPTION
This PR defaults the realm chooser drop down to the currently displayed realm in code mode if that realm is writable, Previously it would default to the default writable realm--which is the user's personal realm).