### PR TITLE
tools: Add file explorer autoopen

### DIFF
--- a/packages/vscode-boxel-tools/src/extension.ts
+++ b/packages/vscode-boxel-tools/src/extension.ts
@@ -41,5 +41,6 @@ export async function activate(context: vscode.ExtensionContext) {
     }));
     console.log('Realm list', realmList);
     vscode.workspace.updateWorkspaceFolders(0, 0, ...realmList);
+    await vscode.commands.executeCommand('workbench.view.explorer');
   });
 }


### PR DESCRIPTION
This opens the file explorer as part of the “Create Workspace” command.

![screencast 2024-10-04 13-48-53](https://github.com/user-attachments/assets/3b778e3a-9141-4b5f-b025-d6dde166c419)
