### PR TITLE
Improve vertical stack layout buried cards offset

### DIFF
--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -663,7 +663,7 @@ export default class InteractSubmode extends Component<Signature> {
                   'operator-mode-stack'
                   (if backgroundImageURLSpecificToThisStack 'with-bg-image')
                   (if
-                    (gt stack.length 1 and lt stack.length 3)
+                    (and (gt stack.length 1) (lt stack.length 3))
                     'medium-padding-top'
                   )
                   (if (gt stack.length 2) 'small-padding-top')

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -663,10 +663,10 @@ export default class InteractSubmode extends Component<Signature> {
                   'operator-mode-stack'
                   (if backgroundImageURLSpecificToThisStack 'with-bg-image')
                   (if
-                    (gt stack.length 1 and lt stack.length 4)
+                    (gt stack.length 1 and lt stack.length 3)
                     'medium-padding-top'
                   )
-                  (if (gt stack.length 3) 'small-padding-top')
+                  (if (gt stack.length 2) 'small-padding-top')
                 }}
                 style={{if
                   backgroundImageURLSpecificToThisStack

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -17,7 +17,7 @@ import get from 'lodash/get';
 import { TrackedWeakMap, TrackedSet } from 'tracked-built-ins';
 
 import { Tooltip } from '@cardstack/boxel-ui/components';
-import { cn, eq } from '@cardstack/boxel-ui/helpers';
+import { cn, eq, lt, gt, and } from '@cardstack/boxel-ui/helpers';
 import { Download } from '@cardstack/boxel-ui/icons';
 
 import {
@@ -662,6 +662,11 @@ export default class InteractSubmode extends Component<Signature> {
                 class={{cn
                   'operator-mode-stack'
                   (if backgroundImageURLSpecificToThisStack 'with-bg-image')
+                  (if
+                    (gt stack.length 1 and lt stack.length 4)
+                    'medium-padding-top'
+                  )
+                  (if (gt stack.length 3) 'small-padding-top')
                 }}
                 style={{if
                   backgroundImageURLSpecificToThisStack

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -181,13 +181,19 @@ export default class OperatorModeStackItem extends Component<Signature> {
   private get styleForStackedCard(): SafeString {
     const stackItemMaxWidth = '50rem';
     const widthReductionPercent = 5; // Every new card on the stack is 5% wider than the previous one
-    const isLastItem = this.args.index === this.args.stackItems.length - 1;
-    let offsetPx = 15; // Every new card on the stack is 15px lower than the previous one in default
+    const isFirstCard = this.args.index === 0;
+    const isLastCard = this.args.index === this.args.stackItems.length - 1;
 
-    if (this.args.stackItems.length === 2) {
-      offsetPx = 30; // If there are only two items on the stack, the first item is 30px lower than the second one
-    } else if (isLastItem) {
-      offsetPx = 18; // If it's the last item on the stack, it's 18px lower than the second to last item
+    let offsetPx = 15; // Every new card on the stack is 15px lower than the previous one in default
+    let marginTopPx = offsetPx * this.args.index;
+
+    if (isFirstCard) {
+      marginTopPx = 0;
+    } else if (isLastCard) {
+      if (this.args.stackItems.length === 2) {
+        marginTopPx = 30;
+      }
+      marginTopPx = 15 * this.args.index + 25;
     }
 
     let invertedIndex = this.args.stackItems.length - this.args.index - 1;
@@ -197,11 +203,11 @@ export default class OperatorModeStackItem extends Component<Signature> {
       : `calc(${stackItemMaxWidth} * ${maxWidthPercent} / 100)`;
 
     let styles = `
-      height: calc(100% - ${offsetPx}px * ${this.args.index});
+      height: calc(100% - ${marginTopPx}px);
       width: ${width};
       max-width: ${maxWidthPercent}%;
       z-index: calc(${this.args.index} + 1);
-      margin-top: calc(${offsetPx}px * ${this.args.index});
+      margin-top: ${marginTopPx}px;
     `; // using margin-top instead of padding-top to hide scrolled content from view
 
     if (this.args.item.isWideFormat) {

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -181,22 +181,25 @@ export default class OperatorModeStackItem extends Component<Signature> {
   private get styleForStackedCard(): SafeString {
     const stackItemMaxWidth = '50rem';
     const widthReductionPercent = 5; // Every new card on the stack is 5% wider than the previous one
-    const isFirstCard = this.args.index === 0;
-    const isLastCard = this.args.index === this.args.stackItems.length - 1;
+    const numberOfCards = this.args.stackItems.length;
+    const invertedIndex = numberOfCards - this.args.index - 1;
+    const isLastCard = this.args.index === numberOfCards - 1;
+    const isSecondLastCard = this.args.index === numberOfCards - 2;
 
-    let offsetPx = 15; // Every new card on the stack is 15px lower than the previous one in default
-    let marginTopPx = offsetPx * this.args.index;
+    let marginTopPx = 0;
 
-    if (isFirstCard) {
-      marginTopPx = 0;
-    } else if (isLastCard) {
-      if (this.args.stackItems.length === 2) {
-        marginTopPx = 30;
-      }
-      marginTopPx = 15 * this.args.index + 25;
+    if (invertedIndex > 2) {
+      marginTopPx = -5; // If there are more than 3 cards, those cards are buried behind the header
     }
 
-    let invertedIndex = this.args.stackItems.length - this.args.index - 1;
+    if (numberOfCards > 1) {
+      if (isLastCard) {
+        marginTopPx = numberOfCards === 2 ? 30 : 55;
+      } else if (isSecondLastCard && numberOfCards > 2) {
+        marginTopPx = 25;
+      }
+    }
+
     let maxWidthPercent = 100 - invertedIndex * widthReductionPercent;
     let width = this.isItemFullWidth
       ? '100%'

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -181,7 +181,14 @@ export default class OperatorModeStackItem extends Component<Signature> {
   private get styleForStackedCard(): SafeString {
     const stackItemMaxWidth = '50rem';
     const widthReductionPercent = 5; // Every new card on the stack is 5% wider than the previous one
-    const offsetPx = 30; // Every new card on the stack is 30px lower than the previous one
+    const isLastItem = this.args.index === this.args.stackItems.length - 1;
+    let offsetPx = 15; // Every new card on the stack is 15px lower than the previous one in default
+
+    if (this.args.stackItems.length === 2) {
+      offsetPx = 30; // If there are only two items on the stack, the first item is 30px lower than the second one
+    } else if (isLastItem) {
+      offsetPx = 18; // If it's the last item on the stack, it's 18px lower than the second to last item
+    }
 
     let invertedIndex = this.args.stackItems.length - this.args.index - 1;
     let maxWidthPercent = 100 - invertedIndex * widthReductionPercent;

--- a/packages/host/app/components/operator-mode/stack.gts
+++ b/packages/host/app/components/operator-mode/stack.gts
@@ -91,6 +91,13 @@ export default class OperatorModeStack extends Component<Signature> {
         display: none;
       }
 
+      .operator-mode-stack.medium-padding-top {
+        padding-top: var(--submode-switcher-trigger-height);
+      }
+      .operator-mode-stack.small-padding-top {
+        padding-top: var(--boxel-sp);
+      }
+
       .operator-mode-stack
         :deep(.field-component-card.fitted-format .missing-embedded-template) {
         margin-top: calc(-1 * var(--boxel-sp-lg));


### PR DESCRIPTION
Refer to https://linear.app/cardstack/issue/CS-7231/improve-vertical-layout-so-that-topmost-card-has-more-height-and

### What is changing
Improve vertical stack layout when cards get stacked (more than 1), by:
- tweaking the margin-top calculation on each card index
- appropriate top padding adjustment when the number of cards buried/stacked

**Before**

https://github.com/user-attachments/assets/c64f4e23-62cb-4a01-856b-f4260f6ecd95

**After**

https://github.com/user-attachments/assets/35d276f3-cf8c-4086-b9f5-fe229966edae







