### PR TITLE
Fix extra space under the header

### DIFF
--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -592,7 +592,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
     <style scoped>
       :global(:root) {
         --stack-card-footer-height: 6rem;
-        --stack-item-header-area-height: 3.5rem;
+        --stack-item-header-area-height: 3.375rem;
         --buried-operator-mode-header-height: 2.5rem;
       }
 


### PR DESCRIPTION
Since we shrunk the default spacing, the header height has changed. Open to other ideas.

Before:
<img width="1031" alt="header-bug" src="https://github.com/user-attachments/assets/1df57ed8-1161-4c20-bb35-957b5c4884ad">

After:
<img width="1108" alt="header" src="https://github.com/user-attachments/assets/c534aabf-6bec-4337-8287-ca0467dcc20f">
