### PR TITLE
tools: Fix version commit determination

### DIFF
--- a/.github/workflows/manual-vscode-boxel-tools.yml
+++ b/.github/workflows/manual-vscode-boxel-tools.yml
@@ -49,7 +49,14 @@ jobs:
             echo ""
           fi
 
-          LAST_VERSION_CHANGE=$(git log -1 --pretty=format:%H --grep="version" -- $PACKAGE_JSON)
+          # Find the most recent commit that changed the version in package.json
+          LAST_VERSION_CHANGE=$(git rev-list -n 1 HEAD -- $PACKAGE_JSON | while read commit; do
+            if git show $commit:$PACKAGE_JSON | grep -q "\"version\": \"$CURRENT_VERSION\""; then
+              echo $commit
+              break
+            fi
+          done)
+
           echo "Last version change commit: $LAST_VERSION_CHANGE"
 
           if [ -z "$LAST_VERSION_CHANGE" ]; then


### PR DESCRIPTION
This is a followup to #1634, as when I tried to deploy after merging it [failed](https://github.com/cardstack/boxel/actions/runs/11218433258/job/31182188988#step:5:52) to find the commit when the version was changed. This is a different approach, when I ran it locally with `main` checked out it succeeded 🤞🏻