### PR TITLE
Code mode preview container overflow and border gap fix

### DIFF
--- a/packages/experiments-realm/ai-app-generator.gts
+++ b/packages/experiments-realm/ai-app-generator.gts
@@ -327,6 +327,7 @@ class DashboardTab extends GlimmerComponent<{
         gap: var(--boxel-sp-xxl);
         padding: var(--boxel-sp);
         background-color: #f7f7f7;
+        overflow-x: auto;
       }
       .section-header {
         display: flex;

--- a/packages/host/app/components/operator-mode/card-preview-panel/index.gts
+++ b/packages/host/app/components/operator-mode/card-preview-panel/index.gts
@@ -230,6 +230,10 @@ export default class CardPreviewPanel extends Component<Signature> {
         margin: var(--boxel-sp-sm);
       }
 
+      .preview-content > :deep(.boxel-card-container.boundaries) {
+        overflow: hidden;
+      }
+
       .header-actions {
         margin-left: auto;
       }

--- a/packages/host/app/components/operator-mode/profile/profile-email.gts
+++ b/packages/host/app/components/operator-mode/profile/profile-email.gts
@@ -339,6 +339,7 @@ export default class ProfileEmail extends Component<Signature> {
         margin-top: var(--boxel-sp-xl);
         border-radius: var(--boxel-border-radius);
         border: 2px solid var(--boxel-warning-100);
+        overflow: hidden;
       }
       .warning-title {
         display: flex;
@@ -347,8 +348,6 @@ export default class ProfileEmail extends Component<Signature> {
         font-weight: 600;
         padding: var(--boxel-sp-xxs);
         background-color: var(--boxel-warning-100);
-        border-top-left-radius: var(--boxel-border-radius);
-        border-top-right-radius: var(--boxel-border-radius);
       }
       .warning-title span {
         margin-left: var(--boxel-sp-xs);


### PR DESCRIPTION
- Fixes code mode preview container background overflow

Before:
<img width="77" alt="overflow-2" src="https://github.com/user-attachments/assets/e5fd71be-ce73-4efe-9186-98e4fa8f8868">
<img width="1484" alt="overflow-1" src="https://github.com/user-attachments/assets/b4e21f34-e42a-4ac1-9cef-9848c207c090">

After:
<img width="456" alt="overflow-after" src="https://github.com/user-attachments/assets/33301868-93b5-4b44-bff4-41210b5bd3d0">

- Fixes gap in Profile settings warning box

Before:
<img width="916" alt="border-gap-before" src="https://github.com/user-attachments/assets/f2ae91b9-2f2a-4174-b2a2-3808e285c241">
After:
<img width="712" alt="settings-fix" src="https://github.com/user-attachments/assets/93b91d43-a3c0-4a1d-b9e1-4542d09ce945">

