### PR TITLE
tools: Fix iteration in development

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,9 @@
       "runtimeExecutable": "${execPath}",
       "args": [
         "--extensionDevelopmentPath=${workspaceRoot}/packages/vscode-boxel-tools"
-      ]
+      ],
+      "outFiles": ["${workspaceFolder}/packages/vscode-boxel-tools/dist/**"],
+      "preLaunchTask": "Compile Boxel tools (development)"
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "extensionHost",
+      "request": "launch",
+      "name": "Launch Boxel Tools",
+      "runtimeExecutable": "${execPath}",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceRoot}/packages/vscode-boxel-tools"
+      ]
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Compile Boxel tools (development)",
+      "type": "shell",
+      "options": {
+        "cwd": "${workspaceFolder}/packages/vscode-boxel-tools"
+      },
+      "command": "pnpm",
+      "args": ["compile:development"],
+      "problemMatcher": []
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,8 +8,9 @@
         "cwd": "${workspaceFolder}/packages/vscode-boxel-tools"
       },
       "command": "pnpm",
-      "args": ["compile:development"],
-      "problemMatcher": []
+      "args": ["watch"],
+      "isBackground": true,
+      "problemMatcher": ["$tsc"]
     }
   ]
 }

--- a/packages/vscode-boxel-tools/package.json
+++ b/packages/vscode-boxel-tools/package.json
@@ -66,6 +66,7 @@
     "vscode:publish": "pnpm vsce publish --no-dependencies",
     "vscode:publish:prerelease": "pnpm vsce publish --no-dependencies --pre-release",
     "compile": "node esbuild.mjs --production",
+    "compile:development": "node esbuild.mjs",
     "lint": "concurrently \"pnpm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"pnpm:lint:*:fix\" --names \"fix:\"",
     "lint:js": "eslint . --cache",


### PR DESCRIPTION
The [documentation](https://github.com/cardstack/boxel/blob/e1bc7894ceff6b6fc99e6f375071ce252aaf0ae7/packages/vscode-boxel-tools/README.md?plain=1#L54) says you can press F5 to run the extension in the development host but that hasn’t been true since it was imported into the monorepo.