### PR TITLE
VSCode extension - Add diagnostics (error messages)

### DIFF
--- a/packages/vscode-boxel-tools/src/diagnostics.ts
+++ b/packages/vscode-boxel-tools/src/diagnostics.ts
@@ -1,0 +1,70 @@
+import * as vscode from 'vscode';
+import { RealmFS } from './file-system-provider';
+
+async function getErrorMessagesForFile(
+  fileUri: vscode.Uri,
+  realmFs: RealmFS,
+): Promise<string | undefined> {
+  const file = await realmFs.readRawTextFile(fileUri);
+  // We only care when there is an error code, ignore successful requests
+  if (file.success) {
+    return undefined;
+  }
+  return file.body;
+}
+
+function extractErrorsFromMessage(message: string): vscode.Diagnostic[] {
+  const diagnostics: vscode.Diagnostic[] = [];
+  //Check the first line looks like a file path, then a colon, and finishes with (number:number)
+  const lines = message.split('\n');
+  const firstLine = lines[0];
+  const filePathMatch = firstLine.match(/^(.+?):(.+?)\((\d+):(\d+)\)$/);
+  console.log('filePathMatch', filePathMatch);
+  console.log('firstLine', firstLine);
+  let range: vscode.Range;
+  if (filePathMatch) {
+    console.log('filePathMatch', filePathMatch);
+    const lineNumber = parseInt(filePathMatch[3]) - 1;
+    const columnNumber = parseInt(filePathMatch[4]) - 1;
+    range = new vscode.Range(
+      lineNumber,
+      columnNumber,
+      lineNumber,
+      columnNumber,
+    );
+  } else {
+    range = new vscode.Range(0, 0, 0, 0);
+  }
+
+  const diagnostic = new vscode.Diagnostic(
+    range,
+    message,
+    vscode.DiagnosticSeverity.Error, // Or Warning, Information, etc.
+  );
+
+  diagnostic.source = 'boxelrealm';
+
+  diagnostics.push(diagnostic);
+
+  return diagnostics;
+}
+
+export function updateDiagnostics(
+  document: vscode.TextDocument,
+  diagnosticCollection: vscode.DiagnosticCollection,
+  realmFs: RealmFS,
+): void {
+  getErrorMessagesForFile(document.uri, realmFs)
+    .then((apiErrors) => {
+      if (apiErrors) {
+        const diagnostics = extractErrorsFromMessage(apiErrors);
+        diagnosticCollection.set(document.uri, diagnostics);
+      } else {
+        diagnosticCollection.delete(document.uri);
+      }
+    })
+    .catch((error) => {
+      console.error('Failed to fetch errors:', error);
+      diagnosticCollection.delete(document.uri); // Clear diagnostics on error
+    });
+}

--- a/packages/vscode-boxel-tools/src/diagnostics.ts
+++ b/packages/vscode-boxel-tools/src/diagnostics.ts
@@ -15,26 +15,28 @@ async function getErrorMessagesForFile(
 
 function extractErrorsFromMessage(message: string): vscode.Diagnostic[] {
   const diagnostics: vscode.Diagnostic[] = [];
+  // Start with a default range
+  let lineNumber: number = 1;
+  let columnNumber: number = 1;
+
   //Check the first line looks like a file path, then a colon, and finishes with (number:number)
   const lines = message.split('\n');
   const firstLine = lines[0];
   const filePathMatch = firstLine.match(/^(.+?):(.+?)\((\d+):(\d+)\)$/);
-  console.log('filePathMatch', filePathMatch);
-  console.log('firstLine', firstLine);
-  let range: vscode.Range;
-  if (filePathMatch) {
-    console.log('filePathMatch', filePathMatch);
-    const lineNumber = parseInt(filePathMatch[3]) - 1;
-    const columnNumber = parseInt(filePathMatch[4]) - 1;
-    range = new vscode.Range(
-      lineNumber,
-      columnNumber,
-      lineNumber,
-      columnNumber,
-    );
-  } else {
-    range = new vscode.Range(0, 0, 0, 0);
+
+  if (filePathMatch && filePathMatch.length >= 5) {
+    // try and parse the line and column numbers, defaulting to 1 if they don't parse
+    // They should as the regex matches \d+:\d+
+    lineNumber = parseInt(filePathMatch[3]) || 1;
+    columnNumber = parseInt(filePathMatch[4]) || 1;
   }
+
+  const range = new vscode.Range(
+    lineNumber - 1,
+    columnNumber - 1,
+    lineNumber - 1,
+    columnNumber - 1,
+  );
 
   const diagnostic = new vscode.Diagnostic(
     range,

--- a/packages/vscode-boxel-tools/src/diagnostics.ts
+++ b/packages/vscode-boxel-tools/src/diagnostics.ts
@@ -16,8 +16,8 @@ async function getErrorMessagesForFile(
 function extractErrorsFromMessage(message: string): vscode.Diagnostic[] {
   const diagnostics: vscode.Diagnostic[] = [];
   // Start with a default range
-  let lineNumber: number = 1;
-  let columnNumber: number = 1;
+  let lineNumber = 1;
+  let columnNumber = 1;
 
   //Check the first line looks like a file path, then a colon, and finishes with (number:number)
   const lines = message.split('\n');

--- a/packages/vscode-boxel-tools/src/file-system-provider.ts
+++ b/packages/vscode-boxel-tools/src/file-system-provider.ts
@@ -186,6 +186,23 @@ export class RealmFS implements vscode.FileSystemProvider {
     throw vscode.FileSystemError.FileNotFound();
   }
 
+  async readRawTextFile(
+    uri: vscode.Uri,
+  ): Promise<{ success: boolean; body: string }> {
+    console.log('Fetching raw file:', uri);
+    let apiUrl = getUrl(uri);
+    console.log('API URL:', apiUrl);
+    const headers = {
+      Authorization: `${await this.getJWT(apiUrl)}`,
+    };
+
+    const response = await fetch(apiUrl, { headers });
+    return {
+      success: response.ok,
+      body: await response.text(),
+    };
+  }
+
   async writeFile(
     uri: vscode.Uri,
     content: Uint8Array,


### PR DESCRIPTION
Happens on save, but if we had a way of doing this live instead of saving and getting the response we could do it more frequently if we wanted.

![image](https://github.com/user-attachments/assets/f42a1426-4a93-48fa-b202-067f7695f9a7)
