### PR TITLE
ci: Update Playwright to fix Matrix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@glint/core": "1.3.0",
     "@glint/environment-ember-loose": "1.3.0",
     "@glint/environment-ember-template-imports": "1.3.0",
-    "@playwright/test": "^1.43.1",
+    "@playwright/test": "^1.48.0",
     "@typescript-eslint/eslint-plugin": "^5.17.0",
     "@typescript-eslint/parser": "^5.17.0",
     "ember-cli-htmlbars": "^6.3.0",

--- a/packages/matrix/package.json
+++ b/packages/matrix/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "devDependencies": {
     "@aws-crypto/sha256-js": "^5.2.0",
-    "@playwright/test": "^1.43.1",
+    "@playwright/test": "^1.48.0",
     "@types/fs-extra": "^9.0.13",
     "@types/jsonwebtoken": "^9.0.5",
     "@types/node": "^18.18.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: 1.3.0
         version: 1.3.0(@glint/environment-ember-loose@1.3.0)(@glint/template@1.3.0)
       '@playwright/test':
-        specifier: ^1.43.1
-        version: 1.43.1
+        specifier: ^1.48.0
+        version: 1.48.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.17.0
         version: 5.48.1(@typescript-eslint/parser@5.48.1)(eslint@8.57.0)(typescript@5.1.6)
@@ -1493,8 +1493,8 @@ importers:
         specifier: ^5.2.0
         version: 5.2.0
       '@playwright/test':
-        specifier: ^1.43.1
-        version: 1.43.1
+        specifier: ^1.48.0
+        version: 1.48.0
       '@types/fs-extra':
         specifier: ^9.0.13
         version: 9.0.13
@@ -6271,12 +6271,12 @@ packages:
       tslib: 2.6.2
     dev: true
 
-  /@playwright/test@1.43.1:
-    resolution: {integrity: sha512-HgtQzFgNEEo4TE22K/X7sYTYNqEMMTZmFS8kTq6m8hXj+m1D8TgwgIbumHddJa9h4yl4GkKb8/bgAl2+g7eDgA==}
-    engines: {node: '>=16'}
+  /@playwright/test@1.48.0:
+    resolution: {integrity: sha512-W5lhqPUVPqhtc/ySvZI5Q8X2ztBOUgZ8LbAFy0JQgrXZs2xaILrUcNO3rQjwbLPfGK13+rZsDa1FpG+tqYkT5w==}
+    engines: {node: '>=18'}
     hasBin: true
     dependencies:
-      playwright: 1.43.1
+      playwright: 1.48.0
     dev: true
 
   /@pnpm/constants@7.1.1:
@@ -21126,18 +21126,18 @@ packages:
       find-up: 3.0.0
     dev: true
 
-  /playwright-core@1.43.1:
-    resolution: {integrity: sha512-EI36Mto2Vrx6VF7rm708qSnesVQKbxEWvPrfA1IPY6HgczBplDx7ENtx+K2n4kJ41sLLkuGfmb0ZLSSXlDhqPg==}
-    engines: {node: '>=16'}
+  /playwright-core@1.48.0:
+    resolution: {integrity: sha512-RBvzjM9rdpP7UUFrQzRwR8L/xR4HyC1QXMzGYTbf1vjw25/ya9NRAVnXi/0fvFopjebvyPzsmoK58xxeEOaVvA==}
+    engines: {node: '>=18'}
     hasBin: true
     dev: true
 
-  /playwright@1.43.1:
-    resolution: {integrity: sha512-V7SoH0ai2kNt1Md9E3Gwas5B9m8KR2GVvwZnAI6Pg0m3sh7UvgiYhRrhsziCmqMJNouPckiOhk8T+9bSAK0VIA==}
-    engines: {node: '>=16'}
+  /playwright@1.48.0:
+    resolution: {integrity: sha512-qPqFaMEHuY/ug8o0uteYJSRfMGFikhUysk8ZvAtfKmUK3kc/6oNl/y3EczF8OFGYIi/Ex2HspMfzYArk6+XQSA==}
+    engines: {node: '>=18'}
     hasBin: true
     dependencies:
-      playwright-core: 1.43.1
+      playwright-core: 1.48.0
     optionalDependencies:
       fsevents: 2.3.2
     dev: true


### PR DESCRIPTION
The Matrix tests were [failing](https://github.com/cardstack/boxel/actions/runs/11275816324/job/31359375579) on Ubuntu 24 runners in the “Install Playwright Browsers” step:

```
Package libicu70 is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

Package libasound2 is a virtual package provided by:
  liboss4-salsa-asound2 4.2-build2020-1ubuntu3
  libasound2t64 1.2.11-1build2 (= 1.2.11-1build2)

E: Package 'libasound2' has no installation candidate
E: Package 'libicu70' has no installation candidate
E: Unable to locate package libffi7
E: Unable to locate package libx264-163
Failed to install browsers
Error: Installation process exited with code: 100
```

The Playwright [changelog](https://playwright.dev/docs/release-notes) mentions these relevant items since the previous version 1.43.1:

* 1.47: The `mcr.microsoft.com/playwright:v1.47.0` now serves a Playwright image based on Ubuntu 24.04 Noble.
* 1.45: Playwright now supports Chromium, Firefox and WebKit on Ubuntu 24.04.