### PR TITLE
Fixes bug: GTS module updates are reflected in rendered instances that consume GTS module

### DIFF
--- a/packages/host/app/components/operator-mode/realm-indexing-indicator.gts
+++ b/packages/host/app/components/operator-mode/realm-indexing-indicator.gts
@@ -64,23 +64,18 @@ export default class RealmIndexingIndicator extends Component {
   }
 
   @cached
-  get indexingRealmNames() {
+  private get indexingRealmNames() {
     return [...this.indexingRealms.values()].map((v) => v.name).join(', ');
   }
 
-  get isIndexing() {
+  private get isIndexing() {
     return this.indexingRealms.size > 0;
-  }
-
-  get isPlural() {
-    return this.indexingRealms.size > 1;
   }
 
   <template>
     {{#if this.isIndexing}}
       <div class='realm-indexing-indicator' data-test-realm-indexing-indicator>
         Indexing
-        {{#if this.isPlural}}realms{{else}}realm{{/if}}
         {{this.indexingRealmNames}}
       </div>
     {{/if}}

--- a/packages/host/app/resources/card-resource.ts
+++ b/packages/host/app/resources/card-resource.ts
@@ -17,6 +17,7 @@ import {
   isSingleCardDocument,
   apiFor,
   loaderFor,
+  hasExecutableExtension,
   type SingleCardDocument,
 } from '@cardstack/runtime-common';
 
@@ -46,6 +47,7 @@ interface Args {
     // this is not always constructed within a container so we pass in our services
     cardService: CardService;
     messageService: MessageService;
+    resetLoader: () => void;
     onCardInstanceChange?: (
       oldCard: CardDef | undefined,
       newCard: CardDef | undefined,
@@ -80,6 +82,7 @@ export class CardResource extends Resource<Args> {
   private declare cardService: CardService;
   private declare messageService: MessageService;
   private declare loaderService: LoaderService;
+  private declare resetLoader: () => void;
   private _loader: Loader | undefined;
   private onCardInstanceChange?: (
     oldCard: CardDef | undefined,
@@ -99,6 +102,7 @@ export class CardResource extends Resource<Args> {
       onCardInstanceChange,
       messageService,
       cardService,
+      resetLoader,
     } = named;
     this.messageService = messageService;
     this.cardService = cardService;
@@ -106,6 +110,7 @@ export class CardResource extends Resource<Args> {
     this._loader = loader;
     this.onCardInstanceChange = onCardInstanceChange;
     this.cardError = undefined;
+    this.resetLoader = resetLoader;
     if (isLive && this.url) {
       this.loaded = this.loadLiveModel.perform(new URL(this.url));
     } else if (this.url) {
@@ -227,6 +232,12 @@ export class CardResource extends Resource<Args> {
             // the inputs with past values. This can happen if the user makes edits in the time between the auto
             // save request and the arrival SSE event.
             if (!this.cardService.clientRequestIds.has(data.clientRequestId)) {
+              if (invalidations.find((i) => hasExecutableExtension(i))) {
+                // the invalidation included code changes too. in this case we
+                // need to flush the loader so that we can pick up any updated
+                // code before re-running the card
+                this.resetLoader();
+              }
               this.reload.perform(card);
             }
           }
@@ -376,6 +387,9 @@ export function getCard(
     ) => void;
   },
 ) {
+  let loaderService = (getOwner(parent) as any).lookup(
+    'service:loader-service',
+  ) as LoaderService;
   return CardResource.from(parent, () => ({
     named: {
       url: url(),
@@ -383,11 +397,8 @@ export function getCard(
       onCardInstanceChange: opts?.onCardInstanceChange
         ? opts.onCardInstanceChange()
         : undefined,
-      loader: (
-        (getOwner(parent) as any).lookup(
-          'service:loader-service',
-        ) as LoaderService
-      ).loader,
+      loader: loaderService.loader,
+      resetLoader: loaderService.reset.bind(loaderService),
       messageService: (getOwner(parent) as any).lookup(
         'service:message-service',
       ) as MessageService,

--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -83,6 +83,21 @@ export async function openAiAssistant(page: Page) {
   ); // Opening the AI assistant either opens last room or creates one - wait for it to settle
 }
 
+export async function createRealm(
+  page: Page,
+  endpoint: string,
+  name = endpoint,
+) {
+  await page.locator('[data-test-add-workspace]').click();
+  await page.locator('[data-test-display-name-field]').fill(name);
+  await page.locator('[data-test-endpoint-field]').fill(endpoint);
+  await page.locator('[data-test-create-workspace-submit]').click();
+  await expect(page.locator(`[data-test-workspace="${name}"]`)).toBeVisible();
+  await expect(page.locator('[data-test-create-workspace-modal]')).toHaveCount(
+    0,
+  );
+}
+
 export async function openRoot(page: Page, url = testHost) {
   await page.goto(url);
 }

--- a/packages/matrix/tests/create-realm.spec.ts
+++ b/packages/matrix/tests/create-realm.spec.ts
@@ -10,7 +10,12 @@ import {
   type IsolatedRealmServer,
   appURL,
 } from '../helpers/isolated-realm-server';
-import { clearLocalStorage, login, registerRealmUsers } from '../helpers';
+import {
+  clearLocalStorage,
+  createRealm,
+  login,
+  registerRealmUsers,
+} from '../helpers';
 
 test.describe('Create Realm via Dashboard', () => {
   let synapse: SynapseInstance;
@@ -42,16 +47,7 @@ test.describe('Create Realm via Dashboard', () => {
       url: serverIndexUrl,
       skipOpeningAssistant: true,
     });
-    await page.locator('[data-test-add-workspace]').click();
-    await page.locator('[data-test-display-name-field]').fill('New Workspace');
-    await page.locator('[data-test-endpoint-field]').fill('new-workspace');
-    await page.locator('[data-test-create-workspace-submit]').click();
-    await expect(
-      page.locator('[data-test-workspace="New Workspace"]'),
-    ).toBeVisible();
-    await expect(
-      page.locator('[data-test-create-workspace-modal]'),
-    ).toHaveCount(0);
+    await createRealm(page, 'new-workspace', 'New Workspace');
     await page.locator('[data-test-workspace="New Workspace"]').click();
     let newRealmURL = new URL('user1/new-workspace/', serverIndexUrl).href;
     await expect(

--- a/packages/matrix/tests/live-cards.spec.ts
+++ b/packages/matrix/tests/live-cards.spec.ts
@@ -86,7 +86,7 @@ test.describe('Live Cards', () => {
     });
     await expect(
       page.locator('[data-test-realm-indexing-indicator]'),
-    ).toContainText(`Indexing realm Test User's Workspace`);
+    ).toContainText(`Indexing ${realmName}`);
     await expect(
       page.locator(`[data-test-card="${realmURL}hello-world"]`),
     ).toContainText('Hello Mars');

--- a/packages/matrix/tests/live-cards.spec.ts
+++ b/packages/matrix/tests/live-cards.spec.ts
@@ -1,0 +1,163 @@
+import { test, expect } from '@playwright/test';
+import { writeJSONSync, writeFileSync } from 'fs-extra';
+import { join } from 'path';
+import {
+  synapseStart,
+  synapseStop,
+  type SynapseInstance,
+  registerUser,
+} from '../docker/synapse';
+import {
+  startServer as startRealmServer,
+  type IsolatedRealmServer,
+  appURL,
+} from '../helpers/isolated-realm-server';
+import {
+  clearLocalStorage,
+  createRealm,
+  login,
+  registerRealmUsers,
+  showAllCards,
+} from '../helpers';
+
+test.describe('Live Cards', () => {
+  let synapse: SynapseInstance;
+  let realmServer: IsolatedRealmServer;
+  const serverIndexUrl = new URL(appURL).origin;
+  const realmName = 'realm1';
+  const realmURL = new URL(`user1/${realmName}/`, serverIndexUrl).href;
+
+  test.beforeEach(async () => {
+    // synapse defaults to 30s for beforeEach to finish, we need a bit more time
+    // to safely start the realm
+    test.setTimeout(120_000);
+    synapse = await synapseStart({
+      template: 'test',
+    });
+    await registerRealmUsers(synapse);
+    realmServer = await startRealmServer();
+    await registerUser(synapse, 'user1', 'pass');
+  });
+
+  test.afterEach(async () => {
+    await realmServer?.stop();
+    await synapseStop(synapse.synapseId);
+  });
+
+  test('it can subscribe to SSE events of a private realm', async ({
+    page,
+  }) => {
+    await clearLocalStorage(page, serverIndexUrl);
+    await login(page, 'user1', 'pass', {
+      url: serverIndexUrl,
+      skipOpeningAssistant: true,
+    });
+    await createRealm(page, realmName);
+    await page.goto(`${realmURL}hello-world`);
+    await expect(
+      page.locator(`[data-test-card="${realmURL}hello-world"]`),
+    ).toContainText('Hello World');
+
+    // assert that instance updates are live bound
+    let helloWorldPath = join(
+      realmServer.realmPath,
+      '..',
+      'user1',
+      realmName,
+      'hello-world.json',
+    );
+    writeJSONSync(helloWorldPath, {
+      data: {
+        type: 'card',
+        attributes: {
+          title: 'Hello Mars',
+          description: 'This is a test card instance.',
+        },
+        meta: {
+          adoptsFrom: {
+            module: 'https://cardstack.com/base/card-api',
+            name: 'CardDef',
+          },
+        },
+      },
+    });
+    await expect(
+      page.locator(`[data-test-card="${realmURL}hello-world"]`),
+    ).toContainText('Hello Mars');
+
+    // assert that index card is live bound
+    await page.goto(realmURL);
+    await showAllCards(page);
+
+    let cardDefPath = join(
+      realmServer.realmPath,
+      '..',
+      'user1',
+      realmName,
+      'sample-card.gts',
+    );
+    writeFileSync(
+      cardDefPath,
+      `
+      import { CardDef, field, contains, StringField } from 'https://cardstack.com/base/card-api';
+      import { Component } from 'https://cardstack.com/base/card-api';
+      export class SampleCard extends CardDef {
+        @field name = contains(StringField);
+        static isolated = class Isolated extends Component<typeof this> {
+          <template>
+            Hello <@fields.name />
+          </template>
+        };
+      }`,
+    );
+    let instancePath = join(
+      realmServer.realmPath,
+      '..',
+      'user1',
+      realmName,
+      'test.json',
+    );
+    writeJSONSync(instancePath, {
+      data: {
+        type: 'card',
+        attributes: {
+          title: 'Mango',
+          name: 'Mango',
+        },
+        meta: {
+          adoptsFrom: {
+            module: './sample-card',
+            name: 'SampleCard',
+          },
+        },
+      },
+    });
+
+    await expect(
+      page.locator(`[data-test-cards-grid-item="${realmURL}test"]`),
+    ).toHaveCount(1);
+    await page.locator(`[data-test-cards-grid-item="${realmURL}test"]`).click();
+    await expect(
+      page.locator(`[data-test-stack-card="${realmURL}test"]`),
+    ).toContainText('Hello Mango');
+
+    // assert that instances that consume updated modules are live bound
+    writeFileSync(
+      cardDefPath,
+      `
+      import { CardDef, field, contains, StringField } from 'https://cardstack.com/base/card-api';
+      import { Component } from 'https://cardstack.com/base/card-api';
+      export class SampleCard extends CardDef {
+        @field name = contains(StringField);
+        static isolated = class Isolated extends Component<typeof this> {
+          <template>
+            Hello <@fields.name /> !!!!
+          </template>
+        };
+      }`,
+    );
+    await expect(
+      page.locator(`[data-test-stack-card="${realmURL}test"]`),
+    ).toContainText('Hello Mango !!!!');
+  });
+});

--- a/packages/matrix/tests/registration-with-token.spec.ts
+++ b/packages/matrix/tests/registration-with-token.spec.ts
@@ -1,6 +1,4 @@
 import { expect, test } from '@playwright/test';
-import { writeJSONSync } from 'fs-extra';
-import { join } from 'path';
 import {
   synapseStart,
   synapseStop,
@@ -215,33 +213,6 @@ test.describe('User Registration w/ Token - isolated realm server', () => {
     await expect(
       page.locator(`[data-test-card="${newRealmURL}hello-world"]`),
     ).toContainText('Hello World');
-
-    // assert that host app can subscribe to SSE events of a private realm
-    let path = join(
-      realmServer.realmPath,
-      '..',
-      'user1',
-      'personal',
-      'hello-world.json',
-    );
-    writeJSONSync(path, {
-      data: {
-        type: 'card',
-        attributes: {
-          title: 'Hello Mars',
-          description: 'This is a test card instance.',
-        },
-        meta: {
-          adoptsFrom: {
-            module: 'https://cardstack.com/base/card-api',
-            name: 'CardDef',
-          },
-        },
-      },
-    });
-    await expect(
-      page.locator(`[data-test-card="${newRealmURL}hello-world"]`),
-    ).toContainText('Hello Mars');
 
     // assert that non-logged in user is prompted to login before navigating
     // directly to card in private repo


### PR DESCRIPTION
This PR fixes a bug where GTS file updates were not being reflected live in card instances that consume the GTS file. All the SSE plumbing was working just fine, the issue was that the browser was still trying to render with the old module that was cached in the loader after the GTS file was updated. The solution was to treat this in the same way that we treat module updates in the monaco code editor, where updates to executable code trigger the loader service to refresh the loader so that the cached modules are cleared. 

![live-update](https://github.com/user-attachments/assets/ff40b724-a318-440c-8435-cd9c8d8b8b33)
