### PR TITLE
Use encodeURIComponent to fetch user profile

### DIFF
--- a/packages/runtime-common/matrix-client.ts
+++ b/packages/runtime-common/matrix-client.ts
@@ -193,7 +193,7 @@ export class MatrixClient {
     userId: string,
   ): Promise<{ displayname: string } | undefined> {
     let response = await this.request(
-      `_matrix/client/v3/profile/${userId}`,
+      `_matrix/client/v3/profile/${encodeURIComponent(userId)}`,
       'GET',
       undefined,
       false,


### PR DESCRIPTION
Ticket: CS-7319

This PR fixes a bug where a permission error occurs when copying a card from the experiments realm to the personal realm. After investigating, it was found that when validating user permissions for realm users (e.g., `@realm/user_personal-workspace:localhost`), the user profile was always unknown. To resolve this issue, we need to use `encodeURIComponent` when fetching the matrix profile.