### PR TITLE
Refactor file and directory resources to use index based event for triggering live updates

### DIFF
--- a/packages/host/app/resources/directory.ts
+++ b/packages/host/app/resources/directory.ts
@@ -65,9 +65,20 @@ export class DirectoryResource extends Resource<Args> {
         url: realmURL.href,
         unsubscribe: this.messageService.subscribe(
           realmURL.href,
-          ({ type }) => {
-            // we are only interested in the filesystem based events
-            if (type === 'update') {
+          ({ type, data: dataStr }) => {
+            if (!this.directoryURL) {
+              return;
+            }
+            let eventData = JSON.parse(dataStr);
+            if (type !== 'index' || !eventData.updatedFile) {
+              return;
+            }
+
+            let { updatedFile } = eventData as { updatedFile: string };
+            let segments = updatedFile.split('/');
+            segments.pop();
+            let updatedDir = segments.join('/').replace(/([^/])$/, '$1/'); // directories always end in '/'
+            if (updatedDir === this.directoryURL.href) {
               this.readdir.perform();
             }
           },

--- a/packages/host/app/routes/index.ts
+++ b/packages/host/app/routes/index.ts
@@ -46,9 +46,9 @@ export default class Index extends Route<void> {
     cardPath?: string;
     path: string;
     operatorModeState: string;
-    operatorModeEnabled: boolean;
+    workspaceChooserOpened?: boolean;
   }): Promise<void> {
-    let { operatorModeState, cardPath } = params;
+    let { operatorModeState, cardPath, workspaceChooserOpened } = params;
 
     if (!this.didMatrixServiceStart) {
       await this.matrixService.ready;
@@ -104,7 +104,15 @@ export default class Index extends Route<void> {
         ],
       ];
     }
-    if (!operatorModeState) {
+    let operatorModeStateObject = operatorModeState
+      ? JSON.parse(operatorModeState)
+      : undefined;
+    if (
+      !operatorModeStateObject ||
+      (operatorModeStateObject.submode === Submodes.Interact &&
+        operatorModeStateObject.stacks.length === 0 &&
+        workspaceChooserOpened !== true)
+    ) {
       this.router.transitionTo('index', {
         queryParams: {
           cardPath: undefined,
@@ -117,8 +125,6 @@ export default class Index extends Route<void> {
       });
       return;
     } else {
-      let operatorModeStateObject = JSON.parse(operatorModeState);
-
       if (this.operatorModeStateService.serialize() === operatorModeState) {
         // If the operator mode state in the query param is the same as the one we have in memory,
         // we don't want to restore it again, because it will lead to rerendering of the stack items, which can

--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -287,6 +287,11 @@ export async function enterWorkspace(
     page.locator(`[data-test-workspace="${workspace}"]`),
   ).toHaveCount(1);
   await page.locator(`[data-test-workspace="${workspace}"]`).click();
+  await expect(
+    page.locator(
+      `[data-test-stack-card-index="0"] [data-test-boxel-header-title]`,
+    ),
+  ).toContainText(workspace);
 }
 
 export async function showAllCards(page: Page) {

--- a/packages/matrix/tests/live-cards.spec.ts
+++ b/packages/matrix/tests/live-cards.spec.ts
@@ -191,6 +191,5 @@ test.describe('Live Cards', () => {
     );
     writeFileSync(instance2Path, 'hi');
     await expect(page.locator('[data-test-file="hello.txt"]')).toHaveCount(1);
-    // assert that code mode file tree is live bound
   });
 });

--- a/packages/matrix/tests/live-cards.spec.ts
+++ b/packages/matrix/tests/live-cards.spec.ts
@@ -168,5 +168,29 @@ test.describe('Live Cards', () => {
     await expect(
       page.locator(`[data-test-stack-card="${realmURL}test"]`),
     ).toContainText('Hello Mango !!!!');
+
+    // assert that code mode file tree is live bound
+    await page.goto(
+      `${realmURL}?operatorModeState=${encodeURIComponent(
+        JSON.stringify({
+          stacks: [],
+          codePath: `${realmURL}index.json`,
+          fileView: 'browser',
+          submode: 'code',
+        }),
+      )}`,
+    );
+    await expect(page.locator('[data-test-file="index.json"]')).toHaveCount(1);
+    await expect(page.locator('[data-test-file="hello.txt"]')).toHaveCount(0);
+    let instance2Path = join(
+      realmServer.realmPath,
+      '..',
+      'user1',
+      realmName,
+      'hello.txt',
+    );
+    writeFileSync(instance2Path, 'hi');
+    await expect(page.locator('[data-test-file="hello.txt"]')).toHaveCount(1);
+    // assert that code mode file tree is live bound
   });
 });

--- a/packages/matrix/tests/registration-with-token.spec.ts
+++ b/packages/matrix/tests/registration-with-token.spec.ts
@@ -150,6 +150,14 @@ test.describe('User Registration w/ Token - isolated realm server', () => {
     let newRealmURL = new URL('user1/personal/', serverIndexUrl).href;
     await enterWorkspace(page, "Test User's Workspace");
 
+    // assert back button brings you back to workspace chooser
+    await page.goBack();
+    await expect(
+      page.locator(`[data-test-workspace="Test User's Workspace"]`),
+    ).toHaveCount(1);
+    await enterWorkspace(page, "Test User's Workspace");
+
+    // assert workspace chooser toggle states
     await expect(
       page.locator(`[data-test-stack-card="${newRealmURL}index"]`),
     ).toHaveCount(1);


### PR DESCRIPTION
Currently the directory resource expects an event type of `"update"` in order to trigger a live update. The `"update"` type events are only triggered via a direct manipulation of the underlying file system as noticed by the file watcher. Updates that are the result of interacting the the HTTP API do not trigger these types of events. Rather the HTTP API file updates trigger `"index"` event types. The boxel vs code extension will be using the HTTP API to update files, so we should standardize our file and directory resources on those events. Moreover, now that we have an event for index initiation, we can make our system more responsive by triggering the file and directory live update on the index initiation event instead of the index completion event. The file and directory resources are not dependent on indexing artifacts--rather these reflect the underlying state of the file system, so it would be better to rely on the index initiation events for these resource to fetch live updates.

Also, during this work I found a bug where when you click on the back button after selecting a workspace you were brought to an empty stack with no workspace chooser and a disabled workspace toggle button. I fixed the bug by making it impossible to view empty stacks in interact mode without the workspace chooser displayed.