### PR TITLE
Prevent deletion of index.json for a workspace

### DIFF
--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -34,7 +34,7 @@ import {
   type LooseSingleCardDocument,
 } from '@cardstack/runtime-common';
 
-import { StackItem } from '@cardstack/host/lib/stack-item';
+import { StackItem, isIndexCard } from '@cardstack/host/lib/stack-item';
 
 import { stackBackgroundsResource } from '@cardstack/host/resources/stack-backgrounds';
 
@@ -254,8 +254,11 @@ export default class InteractSubmode extends Component<Signature> {
           loadedCard = card as CardDef;
         }
 
+        const stackItem = this.allStackItems.find(
+          (item) => item.card === loadedCard,
+        );
         // if is workspace index card, do not allow deletion
-        if (here.realm.isIndexCard(loadedCard.id)) {
+        if (stackItem && isIndexCard(stackItem)) {
           throw new Error('Cannot delete workspace index card');
         }
 

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -254,7 +254,7 @@ export default class InteractSubmode extends Component<Signature> {
           loadedCard = card as CardDef;
         }
 
-        const stackItem = this.allStackItems.find(
+        const stackItem = here.allStackItems.find(
           (item) => item.card === loadedCard,
         );
         // if is workspace index card, do not allow deletion

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -254,6 +254,11 @@ export default class InteractSubmode extends Component<Signature> {
           loadedCard = card as CardDef;
         }
 
+        // if is workspace index card, do not allow deletion
+        if (here.realm.isIndexCard(loadedCard.id)) {
+          throw new Error('Cannot delete workspace index card');
+        }
+
         if (!here.itemToDelete) {
           here.itemToDelete = loadedCard;
           return;

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -62,7 +62,7 @@ import RealmIcon from '@cardstack/host/components/operator-mode/realm-icon';
 
 import config from '@cardstack/host/config/environment';
 
-import { type StackItem } from '@cardstack/host/lib/stack-item';
+import { type StackItem, isIndexCard } from '@cardstack/host/lib/stack-item';
 
 import type {
   CardDef,
@@ -292,7 +292,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
       }),
     ];
     if (
-      !this.realm.isIndexCard(this.card.id) && // workspace index card cannot be deleted
+      !isIndexCard(this.args.item) && // workspace index card cannot be deleted
       this.realm.canWrite(this.card.id)
     ) {
       menuItems.push(

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -291,7 +291,10 @@ export default class OperatorModeStackItem extends Component<Signature> {
         disabled: !this.card.id,
       }),
     ];
-    if (this.realm.canWrite(this.card.id)) {
+    if (
+      !this.realm.isIndexCard(this.card.id) && // workspace index card cannot be deleted
+      this.realm.canWrite(this.card.id)
+    ) {
       menuItems.push(
         new MenuItem('Delete', 'action', {
           action: () => this.args.publicAPI.delete(this.card),

--- a/packages/host/app/lib/stack-item.ts
+++ b/packages/host/app/lib/stack-item.ts
@@ -149,3 +149,8 @@ export class StackItem {
     });
   }
 }
+
+export function isIndexCard(stackItem: StackItem) {
+  let realmURL = stackItem.card[stackItem.api.realmURL];
+  return stackItem.card.id === `${realmURL!.href}index`;
+}

--- a/packages/host/app/lib/stack-item.ts
+++ b/packages/host/app/lib/stack-item.ts
@@ -152,5 +152,8 @@ export class StackItem {
 
 export function isIndexCard(stackItem: StackItem) {
   let realmURL = stackItem.card[stackItem.api.realmURL];
-  return stackItem.card.id === `${realmURL!.href}index`;
+  if (!realmURL) {
+    return false;
+  }
+  return stackItem.card.id === `${realmURL.href}index`;
 }

--- a/packages/host/app/resources/auto-attached-card.ts
+++ b/packages/host/app/resources/auto-attached-card.ts
@@ -6,6 +6,7 @@ import { Resource } from 'ember-resources';
 import { TrackedSet } from 'tracked-built-ins';
 
 import type { StackItem } from '@cardstack/host/lib/stack-item';
+import { isIndexCard } from '@cardstack/host/lib/stack-item';
 
 import { type CardDef } from 'https://cardstack.com/base/card-api';
 
@@ -44,7 +45,7 @@ export class AutoAttachment extends Resource<Args> {
       }
       this.cards.clear();
       topMostStackItems.forEach((item) => {
-        if (!this.hasRealmURL(item) || this.isIndexCard(item)) {
+        if (!this.hasRealmURL(item) || isIndexCard(item)) {
           return;
         }
         if (
@@ -74,11 +75,6 @@ export class AutoAttachment extends Resource<Args> {
   private hasRealmURL(stackItem: StackItem) {
     let realmURL = stackItem.card[stackItem.api.realmURL];
     return Boolean(realmURL);
-  }
-
-  private isIndexCard(stackItem: StackItem) {
-    let realmURL = stackItem.card[stackItem.api.realmURL];
-    return stackItem.card.id === `${realmURL!.href}index`;
   }
 
   private isAlreadyAttached(

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -277,10 +277,6 @@ export default class RealmService extends Service {
     return this.knownRealm(url)?.isPublic ?? false;
   };
 
-  isIndexCard = (url: string): boolean => {
-    return url.endsWith('/index');
-  };
-
   canRead = (url: string): boolean => {
     return this.knownRealm(url)?.canRead ?? false;
   };

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -277,6 +277,10 @@ export default class RealmService extends Service {
     return this.knownRealm(url)?.isPublic ?? false;
   };
 
+  isIndexCard = (url: string): boolean => {
+    return url.endsWith('/index');
+  };
+
   canRead = (url: string): boolean => {
     return this.knownRealm(url)?.canRead ?? false;
   };

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -1388,7 +1388,6 @@ module('Acceptance | interact submode tests', function (hooks) {
       });
       await click('[data-test-more-options-button]');
       assert.dom('[data-test-boxel-menu-item-text="Delete"]').doesNotExist();
-      await click('[data-test-close-button]');
     });
   });
 });

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -1373,4 +1373,22 @@ module('Acceptance | interact submode tests', function (hooks) {
         .hasText('FadhlanXXX');
     });
   });
+
+  module('workspace index card', function () {
+    test('cannot be deleted', async function (assert) {
+      await visitOperatorMode({
+        stacks: [
+          [
+            {
+              id: `${testRealmURL}index`,
+              format: 'isolated',
+            },
+          ],
+        ],
+      });
+      await click('[data-test-more-options-button]');
+      assert.dom('[data-test-boxel-menu-item-text="Delete"]').doesNotExist();
+      await click('[data-test-close-button]');
+    });
+  });
 });


### PR DESCRIPTION
Refer to https://linear.app/cardstack/issue/CS-7339/deleting-the-index-card-while-in-a-personal-workspace-will-cause-that

### What is changing
Preventing a user delete index.json file in a workspace at UI and API level 

---

### UI
- hide delete option on operator/interact mode

**Before**

<img width="1440" alt="Screenshot 2024-10-14 at 1 55 53 PM" src="https://github.com/user-attachments/assets/f4c7d719-10a0-4511-b259-36008fe47185">

**After**

<img width="1440" alt="Screenshot 2024-10-14 at 1 56 05 PM" src="https://github.com/user-attachments/assets/0c86b678-c1bf-47f3-955a-8450ada83e2d">

---

### Public API
- throw error when tends to delete index.json card for a workspace