### PR TITLE
Update registration token error message 

### DIFF
--- a/packages/host/app/components/matrix/register-user.gts
+++ b/packages/host/app/components/matrix/register-user.gts
@@ -585,9 +585,10 @@ export default class RegisterUser extends Component<Signature> {
         console.log('Error verifying token', e);
 
         let extractedError = extractTokenErrorMessage(e);
-        let errorText = extractedError || e.message;
-
-        this.tokenError = `There was an error verifying token: ${errorText}`;
+        let errorText =
+          extractedError ||
+          'This registration token does not exist or has exceeded its usage limit.';
+        this.tokenError = errorText;
 
         if (!extractedError) {
           throw e;

--- a/packages/matrix/tests/registration-with-token.spec.ts
+++ b/packages/matrix/tests/registration-with-token.spec.ts
@@ -322,17 +322,6 @@ test.describe('User Registration w/ Token', () => {
       ),
       'no error message is displayed',
     ).toHaveCount(0);
-    await page.locator('[data-test-register-btn]').click();
-
-    await page.locator('[data-test-token-field]').fill('abc123');
-    await page.locator('[data-test-next-btn]').click();
-
-    await validateEmail(page, 'user2@example.com');
-
-    await assertLoggedIn(page, {
-      userId: '@user2:localhost',
-      displayName: 'Test User',
-    });
   });
 
   test('it shows an error when the username start with an underscore', async ({
@@ -375,17 +364,6 @@ test.describe('User Registration w/ Token', () => {
       ),
       'no error message is displayed',
     ).toHaveCount(0);
-    await page.locator('[data-test-register-btn]').click();
-
-    await page.locator('[data-test-token-field]').fill('abc123');
-    await page.locator('[data-test-next-btn]').click();
-
-    await validateEmail(page, 'user1@example.com');
-
-    await assertLoggedIn(page, {
-      userId: '@user1:localhost',
-      displayName: 'Test User',
-    });
   });
 
   test('it shows an error when the username start with "realm/"', async ({
@@ -428,17 +406,6 @@ test.describe('User Registration w/ Token', () => {
       ),
       'no error message is displayed',
     ).toHaveCount(0);
-    await page.locator('[data-test-register-btn]').click();
-
-    await page.locator('[data-test-token-field]').fill('abc123');
-    await page.locator('[data-test-next-btn]').click();
-
-    await validateEmail(page, 'user1@example.com');
-
-    await assertLoggedIn(page, {
-      userId: '@user1:localhost',
-      displayName: 'Test User',
-    });
   });
 
   test(`it show an error when a invalid registration token is used`, async ({
@@ -487,7 +454,9 @@ test.describe('User Registration w/ Token', () => {
       page.locator(
         '[data-test-token-field] ~ [data-test-boxel-input-error-message]',
       ),
-    ).toContainText('Invalid registration token');
+    ).toContainText(
+      'This registration token does not exist or has exceeded its usage limit.',
+    );
 
     await page.locator('[data-test-token-field]').fill('abc123');
     await expect(
@@ -502,13 +471,6 @@ test.describe('User Registration w/ Token', () => {
       ),
       'no error message is displayed',
     ).toHaveCount(0);
-    await page.locator('[data-test-next-btn]').click();
-    await validateEmail(page, 'user1@example.com');
-
-    await assertLoggedIn(page, {
-      userId: '@user1:localhost',
-      displayName: 'Test User',
-    });
   });
 
   test(`it shows an error when passwords do not match`, async ({ page }) => {

--- a/packages/matrix/tests/registration-with-token.spec.ts
+++ b/packages/matrix/tests/registration-with-token.spec.ts
@@ -621,8 +621,6 @@ test.describe('User Registration w/ Token', () => {
       page.locator(
         '[data-test-token-field] ~ [data-test-boxel-input-error-message]',
       ),
-    ).toContainText(
-      'There was an error verifying token: Could not connect to server',
-    );
+    ).toContainText('Could not connect to server');
   });
 });


### PR DESCRIPTION
In this PR we updated the token error message that appears when the token is invalid.

Also, I've removed redundant test assertions in the register user matrix tests (we already have a test for a successful user registration--no need to keep performing that assertion in all the tests)