### PR TITLE
Fixing CI host test failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 For a quickstart, see [here](./QUICKSTART.md)
 
+
 ## Setup
 
 - you will want the [Glint](https://marketplace.visualstudio.com/items?itemName=typed-ember.glint-vscode) vscode extension

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 For a quickstart, see [here](./QUICKSTART.md)
 
-
 ## Setup
 
 - you will want the [Glint](https://marketplace.visualstudio.com/items?itemName=typed-ember.glint-vscode) vscode extension

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -6,6 +6,9 @@ import type Owner from '@ember/owner';
 import { schedule } from '@ember/runloop';
 import { service } from '@ember/service';
 import { htmlSafe, SafeString } from '@ember/template';
+
+import { isTesting } from '@embroider/macros';
+
 import Component from '@glimmer/component';
 
 import { tracked, cached } from '@glimmer/tracking';
@@ -440,7 +443,9 @@ export default class OperatorModeStackItem extends Component<Signature> {
   private closeItem = async () => {
     this.isClosing = true;
     // wait for the animation to complete
-    await timeout(100);
+    if (!isTesting()) {
+      await timeout(100);
+    }
     this.args.close(this.args.item);
   };
 

--- a/packages/host/app/components/operator-mode/stack.gts
+++ b/packages/host/app/components/operator-mode/stack.gts
@@ -3,7 +3,6 @@ import { isTesting } from '@embroider/macros';
 import Component from '@glimmer/component';
 
 import { task, timeout } from 'ember-concurrency';
-
 import perform from 'ember-concurrency/helpers/perform';
 
 import type { Actions } from '@cardstack/runtime-common';

--- a/packages/host/app/components/operator-mode/stack.gts
+++ b/packages/host/app/components/operator-mode/stack.gts
@@ -1,8 +1,8 @@
+import { isTesting } from '@embroider/macros';
+
 import Component from '@glimmer/component';
 
 import { task, timeout } from 'ember-concurrency';
-
-import { isTesting } from '@embroider/macros';
 
 import perform from 'ember-concurrency/helpers/perform';
 

--- a/packages/host/app/components/operator-mode/stack.gts
+++ b/packages/host/app/components/operator-mode/stack.gts
@@ -1,6 +1,9 @@
 import Component from '@glimmer/component';
 
 import { task, timeout } from 'ember-concurrency';
+
+import { isTesting } from '@embroider/macros';
+
 import perform from 'ember-concurrency/helpers/perform';
 
 import type { Actions } from '@cardstack/runtime-common';
@@ -46,7 +49,9 @@ export default class OperatorModeStack extends Component<Signature> {
     if (lastItemEl) {
       lastItemEl.classList.add('closing-animation');
     }
-    await timeout(100);
+    if (!isTesting()) {
+      await timeout(100);
+    }
 
     await Promise.all(itemsToDismiss.map((i) => this.args.close(i)));
   });

--- a/packages/host/app/components/operator-mode/stack.gts
+++ b/packages/host/app/components/operator-mode/stack.gts
@@ -41,14 +41,14 @@ export default class OperatorModeStack extends Component<Signature> {
     }
 
     // add closing animation on last item
-    const lastItemIndex = this.args.stackItems.length - 1;
-    const lastItemEl = document.querySelector(
-      `[data-stack-card-index="${lastItemIndex}"]`,
-    ) as HTMLElement;
-    if (lastItemEl) {
-      lastItemEl.classList.add('closing-animation');
-    }
     if (!isTesting()) {
+      const lastItemIndex = this.args.stackItems.length - 1;
+      const lastItemEl = document.querySelector(
+        `[data-stack-card-index="${lastItemIndex}"]`,
+      ) as HTMLElement;
+      if (lastItemEl) {
+        lastItemEl.classList.add('closing-animation');
+      }
       await timeout(100);
     }
 


### PR DESCRIPTION
This PR fixes test instability that the animation of cardsstacking PR recently introduced. All the animations no longer run in tests, as well as I replaced a raw async function in the `StackItem` component with an EC task.