### PR TITLE
Support for handling malformed URIs

### DIFF
--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -2910,6 +2910,11 @@ module('Realm Server', function (hooks) {
       }
     });
 
+    test('returns 404 for request that has malformed URI', async function (assert) {
+      let response = await request2.get('/%c0').set('Accept', '*/*');
+      assert.strictEqual(response.status, 404, 'HTTP 404 status');
+    });
+
     test('can dynamically load a card definition from own realm', async function (assert) {
       let ref = {
         module: `${testRealmHref}person`,
@@ -3251,7 +3256,7 @@ module('Realm Server', function (hooks) {
   });
 });
 
-module('Realm Server serving from root', function (hooks) {
+module('Realm server with realm mounted at the origin', function (hooks) {
   let testRealmServer: Server;
 
   let request: SuperTest<Test>;
@@ -3295,7 +3300,7 @@ module('Realm Server serving from root', function (hooks) {
     },
   });
 
-  test('serves a root directory GET request', async function (assert) {
+  test('serves an origin realm directory GET request', async function (assert) {
     let response = await request
       .get('/')
       .set('Accept', 'application/vnd.api+json');

--- a/packages/runtime-common/paths.ts
+++ b/packages/runtime-common/paths.ts
@@ -44,7 +44,15 @@ export class RealmPaths {
   }
 
   inRealm(url: URL): boolean {
-    let decodedHref = decodeURI(url.href);
+    let decodedHref: string;
+    try {
+      decodedHref = decodeURI(url.href);
+    } catch (e) {
+      console.warn(
+        `encountered malformed URI ${url} when checking if in realm ${this.url}, treating as not in this realm`,
+      );
+      return false;
+    }
     return (
       decodedHref.startsWith(this.url) ||
       decodedHref.split('?')[0] == this.url.replace(/\/$/, '') // check if url without querystring same as realm url without trailing slash (for detecting root realm urls with missing trailing slash)


### PR DESCRIPTION
Our sentry logs reveal that we are being probed with malformed URI's. our server currently throws an uncaught error when it receives such a request. This PR handles that scenario and returns a 404 for such requests