### PR TITLE
remove live search from SearchResource

### DIFF
--- a/packages/experiments-realm/garden-design.gts
+++ b/packages/experiments-realm/garden-design.gts
@@ -16,7 +16,7 @@ import type Owner from '@ember/owner';
 import { htmlSafe } from '@ember/template';
 import { tracked } from '@glimmer/tracking';
 import { TrackedMap } from 'tracked-built-ins';
-import { baseRealm, getLiveCards } from '@cardstack/runtime-common';
+import { baseRealm, getCards } from '@cardstack/runtime-common';
 
 class Isolated extends Component<typeof GardenDesign> {
   <template>
@@ -211,7 +211,8 @@ class Isolated extends Component<typeof GardenDesign> {
       }),
     );
     this.updateGridModel();
-    this.liveQuery = getLiveCards(
+    // TODO refactor to use <PrerenderedCardSearch> component from the @context if you want live search
+    this.liveQuery = getCards(
       {
         filter: {
           eq: {
@@ -229,16 +230,6 @@ class Isolated extends Component<typeof GardenDesign> {
         ],
       },
       this.args.model[realmURL] ? [this.args.model[realmURL].href] : undefined,
-      async (ready: Promise<void> | undefined) => {
-        if (this.args.context?.actions) {
-          this.args.context.actions.doWithStableScroll(
-            this.args.model as CardDef,
-            async () => {
-              await ready;
-            },
-          );
-        }
-      },
     );
   }
 

--- a/packages/experiments-realm/monetary-amount.gts
+++ b/packages/experiments-realm/monetary-amount.gts
@@ -9,7 +9,7 @@ import { Component } from 'https://cardstack.com/base/card-api';
 import { Currency } from './asset';
 import { action } from '@ember/object';
 import { BoxelInputGroup } from '@cardstack/boxel-ui/components';
-import { getLiveCards } from '@cardstack/runtime-common';
+import { getCards } from '@cardstack/runtime-common';
 import { guidFor } from '@ember/object/internals';
 import GlimmerComponent from '@glimmer/component';
 
@@ -39,7 +39,8 @@ class Edit extends Component<typeof MonetaryAmount> {
     return guidFor(this);
   }
 
-  liveCurrencyQuery = getLiveCards(
+  // TODO refactor to use <PrerenderedCardSearch> component from the @context if you want live search
+  liveCurrencyQuery = getCards(
     {
       filter: {
         type: {

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -21,7 +21,6 @@ import RealmIndexingIndicator from '@cardstack/host/components/operator-mode/rea
 import { getCard, trackCard } from '@cardstack/host/resources/card-resource';
 
 import {
-  getLiveSearchResults,
   getSearchResults,
   type Search,
 } from '@cardstack/host/resources/search';
@@ -82,21 +81,6 @@ export default class OperatorModeContainer extends Component<Signature> {
   @action
   trackCard<T extends object>(owner: T, card: CardDef, realmURL: URL) {
     return trackCard(owner, card, realmURL);
-  }
-
-  // public API
-  @action
-  getLiveCards(
-    query: Query,
-    realms?: string[],
-    doWhileRefreshing?: (ready: Promise<void> | undefined) => Promise<void>,
-  ): Search {
-    return getLiveSearchResults(
-      this,
-      query,
-      realms,
-      doWhileRefreshing ? () => doWhileRefreshing : undefined,
-    );
   }
 
   private saveSource = task(async (url: URL, content: string) => {

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -1,5 +1,3 @@
-import { registerDestructor } from '@ember/destroyable';
-
 import { service } from '@ember/service';
 import { waitForPromise } from '@ember/test-waiters';
 import { tracked } from '@glimmer/tracking';
@@ -8,7 +6,7 @@ import { restartableTask } from 'ember-concurrency';
 import { Resource } from 'ember-resources';
 import flatMap from 'lodash/flatMap';
 
-import { type RealmCards, subscribeToRealm } from '@cardstack/runtime-common';
+import { type RealmCards } from '@cardstack/runtime-common';
 
 import type { Query } from '@cardstack/runtime-common/query';
 
@@ -21,7 +19,6 @@ interface Args {
   named: {
     query: Query;
     realms?: string[];
-    isLive?: true;
     doWhileRefreshing?: (ready: Promise<void> | undefined) => Promise<void>;
   };
 }
@@ -35,45 +32,13 @@ export class Search extends Resource<Args> {
   @tracked private staleInstancesByRealm: RealmCards[] = [];
   @tracked private realmsToSearch: string[] = [];
   loaded: Promise<void> | undefined;
-  private subscriptions: { url: string; unsubscribe: () => void }[] = [];
 
   modify(_positional: never[], named: Args['named']) {
-    let { query, realms, isLive, doWhileRefreshing } = named;
+    let { query, realms } = named;
     this.realmsToSearch = realms ?? this.realmServer.availableRealmURLs;
 
     this.loaded = this.search.perform(query);
     waitForPromise(this.loaded);
-
-    if (isLive) {
-      // TODO this triggers a new search against all realms if any single realm
-      // updates. Make this more precise where we only search the updated realm
-      // instead of all realms.
-      this.subscriptions = this.realmsToSearch.map((realm) => ({
-        url: `${realm}_message`,
-        unsubscribe: subscribeToRealm(`${realm}_message`, ({ type }) => {
-          // we are only interested in index events
-          if (type !== 'index') {
-            return;
-          }
-          // we show stale instances during a live refresh while we are
-          // waiting for the new instances to arrive--this eliminates the flash
-          // while we wait
-          this.staleInstances = [...(this.instances ?? [])];
-          this.staleInstancesByRealm = [...(this._instancesByRealm ?? [])];
-
-          this.search.perform(query);
-          if (doWhileRefreshing) {
-            this.doWhileRefreshing.perform(doWhileRefreshing);
-          }
-        }),
-      }));
-
-      registerDestructor(this, () => {
-        for (let subscription of this.subscriptions) {
-          subscription.unsubscribe();
-        }
-      });
-    }
   }
 
   get instances() {
@@ -83,14 +48,6 @@ export class Search extends Resource<Args> {
   get instancesByRealm() {
     return this.isLoading ? this.staleInstancesByRealm : this._instancesByRealm;
   }
-
-  private doWhileRefreshing = restartableTask(
-    async (
-      doWhileRefreshing: (ready: Promise<void> | undefined) => Promise<void>,
-    ) => {
-      await doWhileRefreshing(this.loaded);
-    },
-  );
 
   private search = restartableTask(async (query: Query) => {
     this._instances = flatMap(
@@ -133,26 +90,6 @@ export function getSearchResults(
     named: {
       query,
       realms: realms ?? undefined,
-    },
-  })) as Search;
-}
-
-// A new search is triggered whenever the index updates. Consumers of this
-// function that render their cards using {{#each}} should make sure to use the
-// "key" field: {{#each #this.results.instances key="id" as |instance|}} in
-// order to keep the results stable between refreshes.
-export function getLiveSearchResults(
-  parent: object,
-  query: Query,
-  realms?: string[],
-  doWhileRefreshing?: () => (ready: Promise<void> | undefined) => Promise<void>,
-) {
-  return Search.from(parent, () => ({
-    named: {
-      isLive: true,
-      query,
-      realms: realms ?? undefined,
-      doWhileRefreshing: doWhileRefreshing ? doWhileRefreshing() : undefined,
     },
   })) as Search;
 }

--- a/packages/host/tests/cards/app-card.gts
+++ b/packages/host/tests/cards/app-card.gts
@@ -14,7 +14,7 @@ import {
 import { cn } from '@cardstack/boxel-ui/helpers';
 
 import {
-  getLiveCards,
+  getCards,
   codeRefWithAbsoluteURL,
   type Query,
   type Loader,
@@ -353,19 +353,10 @@ class AppCardIsolated extends Component<typeof AppCard> {
         },
       };
     }
-    this.liveQuery = getLiveCards(
+    // TODO refactor to use <PrerenderedCardSearch> component from the @context if you want live search
+    this.liveQuery = getCards(
       query,
       [this.currentRealm.href], // we're only searching in the current realm
-      async (ready: Promise<void> | undefined) => {
-        if (this.args.context?.actions) {
-          this.args.context.actions.doWithStableScroll(
-            this.args.model as CardDef,
-            async () => {
-              await ready;
-            },
-          );
-        }
-      },
     );
   }
 

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -222,14 +222,6 @@ export interface CardSearch {
     cardError?: undefined | { id: string; error: Error };
   };
   trackCard<T extends object>(owner: T, card: CardDef, realmURL: URL): CardDef;
-  getLiveCards(
-    query: Query,
-    realms?: string[],
-    doWhileRefreshing?: (ready: Promise<void> | undefined) => Promise<void>,
-  ): {
-    instances: CardDef[];
-    isLoading: boolean;
-  };
 }
 
 export interface CardCatalogQuery extends Query {
@@ -267,16 +259,6 @@ export function trackCard<T extends object>(
   }
   let finder: CardSearch = here._CARDSTACK_CARD_SEARCH;
   return finder?.trackCard(owner, card, realmURL);
-}
-
-export function getLiveCards(
-  query: Query,
-  realms?: string[],
-  doWhileRefreshing?: (ready: Promise<void> | undefined) => Promise<void>,
-) {
-  let here = globalThis as any;
-  let finder: CardSearch = here._CARDSTACK_CARD_SEARCH;
-  return finder?.getLiveCards(query, realms, doWhileRefreshing);
 }
 
 export interface CardCreator {


### PR DESCRIPTION
This PR removes the live search mechanism from the `SearchResource`. This mechanism has been obsoleted. If you want to have a live search use the `<PrerenderedCardSearch>` component from the `@context`.