### PR TITLE
tools: Fix problem matcher for watching

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,7 +10,7 @@
       "command": "pnpm",
       "args": ["watch"],
       "isBackground": true,
-      "problemMatcher": ["$tsc"]
+      "problemMatcher": ["$tsc-watch"]
     }
   ]
 }


### PR DESCRIPTION
This fixes this warning that shows when doing local development:

![Monosnap 2024-10-21 09-54-23](https://github.com/user-attachments/assets/27e582eb-9461-4abf-8ebf-fa919dc32e73)

A similar error also shows in the “Output” tab:

> Task Compile Boxel tools (development) is a background task but uses a problem matcher without a background pattern