### PR TITLE
Remove unecessary loader state reset before each index run

### DIFF
--- a/packages/host/app/components/card-prerender.gts
+++ b/packages/host/app/components/card-prerender.gts
@@ -3,7 +3,7 @@ import { getOwner, setOwner } from '@ember/owner';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
-import { didCancel, enqueueTask, restartableTask } from 'ember-concurrency';
+import { didCancel, enqueueTask } from 'ember-concurrency';
 
 import { type IndexWriter } from '@cardstack/runtime-common';
 import { readFileAsText as _readFileAsText } from '@cardstack/runtime-common/stream';
@@ -101,7 +101,6 @@ export default class CardPrerender extends Component {
 
   private doFromScratch = enqueueTask(async (realmURL: URL) => {
     let { reader, indexWriter } = this.getRunnerParams(realmURL);
-    await this.resetLoaderInFastboot.perform();
     let currentRun = new CurrentRun({
       realmURL,
       reader,
@@ -123,7 +122,6 @@ export default class CardPrerender extends Component {
       ignoreData: Record<string, string>,
     ) => {
       let { reader, indexWriter } = this.getRunnerParams(realmURL);
-      await this.resetLoaderInFastboot.perform();
       let currentRun = new CurrentRun({
         realmURL,
         reader,
@@ -140,14 +138,6 @@ export default class CardPrerender extends Component {
       return current;
     },
   );
-
-  // perform this in EC task to prevent rerender cycles
-  private resetLoaderInFastboot = restartableTask(async () => {
-    if (this.fastboot.isFastBoot) {
-      await Promise.resolve();
-      this.loaderService.reset();
-    }
-  });
 
   private getRunnerParams(realmURL: URL): {
     reader: Reader;


### PR DESCRIPTION
Since each index run is a separate visit to the ember app running in fastboot, there is no need to reset the loader between index runs as the app state should not be leaking between different visits of the fastboot app.