### PR TITLE
tools: Remove workspace folders with logout

### DIFF
--- a/packages/vscode-boxel-tools/src/extension.ts
+++ b/packages/vscode-boxel-tools/src/extension.ts
@@ -23,6 +23,10 @@ export async function activate(context: vscode.ExtensionContext) {
 
   vscode.commands.registerCommand('boxelrealm.logout', async (_) => {
     await authProvider.clearAllSessions();
+    vscode.workspace.updateWorkspaceFolders(
+      0,
+      vscode.workspace.workspaceFolders?.length ?? 0,
+    );
     vscode.window.showInformationMessage('Logged out of synapse');
   });
 


### PR DESCRIPTION
Previously the realm folder would remain after logout, attempts to view and edit files would fail because of the lack of authentication.

![screencast 2024-10-21 12-23-25](https://github.com/user-attachments/assets/10f5848d-f75a-4e4a-8e42-85a06d729be3)
