### PR TITLE
Sending an ai assistant prompt submits the attached cards

### DIFF
--- a/packages/host/app/components/ai-assistant/chat-input/index.gts
+++ b/packages/host/app/components/ai-assistant/chat-input/index.gts
@@ -15,7 +15,7 @@ interface Signature {
   Args: {
     value: string;
     onInput: (val: string) => void;
-    onSend: (val: string) => void;
+    onSend: () => void;
     canSend: boolean;
   };
 }
@@ -105,7 +105,7 @@ export default class AiAssistantChatInput extends Component<Signature> {
     if (!this.args.canSend) {
       return;
     }
-    this.args.onSend(this.args.value);
+    this.args.onSend();
   }
 
   @action

--- a/packages/host/app/components/ai-assistant/chat-input/usage.gts
+++ b/packages/host/app/components/ai-assistant/chat-input/usage.gts
@@ -13,8 +13,8 @@ export default class AiAssistantChatInputUsage extends Component {
   @tracked value = '';
   @tracked canSend = true;
 
-  @action onSend(message: string) {
-    console.log(`message sent: ${message}`);
+  @action onSend() {
+    console.log(`message sent: ${this.value}`);
     this.mockSend.perform();
   }
 

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -956,6 +956,7 @@ test.describe('Room messages', () => {
     const prompt = {
       from: 'user1',
       message: 'Make this more polite.', // a prompt on new-session template
+      cards: [],
     };
     await login(page, 'user1', 'pass');
     await page.locator(`[data-test-room-settled]`).waitFor();
@@ -966,6 +967,75 @@ test.describe('Room messages', () => {
     await page.locator(`[data-test-prompt="1"]`).click();
     await expect(page.locator(`[data-test-new-session]`)).toHaveCount(0);
     await assertMessages(page, [prompt]);
+  });
+
+  test('sending a prompt submits attached cards', async ({ page }) => {
+    const testCard1 = `${testHost}/mango`;
+    const testCard2 = `${testHost}/hassan`;
+
+    await login(page, 'user1', 'pass');
+    await getRoomId(page);
+    await showAllCards(page);
+    await page
+      .locator(
+        `[data-test-stack-item-content] [data-test-cards-grid-item='${testCard1}']`,
+      )
+      .click();
+
+    await page
+      .locator('[data-test-message-field]')
+      .fill(`Change title to Mango`);
+    await selectCardFromCatalog(page, testCard2);
+    await expect(page.locator(`[data-test-message-field]`)).toHaveValue(
+      'Change title to Mango',
+    );
+    await expect(
+      page.locator(`[data-test-chat-input-area] [data-test-attached-card]`),
+    ).toHaveCount(2);
+
+    await page.locator(`[data-test-prompt="0"]`).click();
+
+    const message1 = {
+      from: 'user1',
+      message: 'Fill in the title and description.', // prompt is submitted
+      cards: [
+        { id: testCard1, title: 'Mango' }, // auto-attached card is submitted
+        { id: testCard2, title: 'Hassan' }, // attached card is submitted
+      ],
+    };
+    await assertMessages(page, [message1]);
+
+    await expect(
+      page.locator(`[data-test-chat-input-area] [data-test-attached-card]`),
+    ).toHaveCount(2); // attached cards remain
+    await expect(page.locator(`[data-test-message-field]`)).toHaveValue(
+      'Change title to Mango',
+    ); // previously typed message remains
+
+    await page.locator('[data-test-send-message-btn]').click();
+
+    const message2 = {
+      from: 'user1',
+      message: 'Change title to Mango',
+      cards: [
+        { id: testCard1, title: 'Mango' },
+        { id: testCard2, title: 'Hassan' },
+      ],
+    };
+    await assertMessages(page, [message1, message2]);
+
+    await expect(
+      page.locator(`[data-test-chat-input-area] [data-test-attached-card]`),
+    ).toHaveCount(1); // only auto-attached card remains
+    await expect(page.locator(`[data-test-message-field]`)).toBeEmpty(); // message field is empty
+
+    await page.locator('[data-test-send-message-btn]').click();
+
+    const message3 = {
+      from: 'user1',
+      cards: [{ id: testCard1, title: 'Mango' }],
+    };
+    await assertMessages(page, [message1, message2, message3]);
   });
 
   test('ai panel stays open when last card is closed and workspace chooser is opened', async ({


### PR DESCRIPTION
- When submitting a prompt on the new session template, auto-attached or user-attached cards are also submitted.
- I also made the change that if the user has a message that was typed in the text box but not sent, it won't be replaced with empty textbox upon clicking on a prompt