### PR TITLE
script to migrate existing realms to use boxel hosted images

### DIFF
--- a/packages/realm-server/Dockerfile
+++ b/packages/realm-server/Dockerfile
@@ -6,7 +6,7 @@ ENV realm_server_script=$realm_server_script
 
 WORKDIR /realm-server
 
-RUN apt-get update && apt-get install -y ca-certificates curl unzip postgresql
+RUN apt-get update && apt-get install -y ca-certificates curl unzip postgresql jq
 RUN npm install -g pnpm@8.10.5
 
 COPY pnpm-lock.yaml ./

--- a/packages/realm-server/scripts/migrate-realm-images.sh
+++ b/packages/realm-server/scripts/migrate-realm-images.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <directory>"
+  exit 1
+fi
+
+search_dir="$1"
+
+background_base_url="https://boxel-images.boxel.ai/background-images/"
+icon_base_url="https://boxel-images.boxel.ai/icons/"
+
+find "$search_dir" -type f -name "*.realm.json" | while read json_file; do
+  echo "Processing $json_file..."
+
+  jq --arg background_base_url "$background_base_url" \
+    --arg icon_base_url "$icon_base_url" \
+    '
+       # For the backgroundURL, preserve the last part of the URL and add the new base URL
+       .backgroundURL |= ($background_base_url + (. | capture(".*/(?<file>[^/]+)$").file)) |
+       
+       # For the iconURL, preserve the last part of the URL and add the new base URL
+       .iconURL |= ($icon_base_url + (. | capture(".*/(?<file>[^/]+)$").file))
+       ' \
+    "$json_file" >tmp.$$.json && mv tmp.$$.json "$json_file"
+
+  echo "$json_file updated."
+done


### PR DESCRIPTION
This is a result from actually running this script on my local `packages/realm-server/realms` folder. This script will update `.realm.json` files from this :
```json
{
  "name": "Hassan 1's Workspace",
  "iconURL": "https://i.postimg.cc/GhPDx7kn/Letter-h.png",
  "backgroundURL": "https://i.postimg.cc/52dV1ZFL/4k-curvilinear-stairs.jpg"
}
```

to this
```json
{
  "name": "Hassan 1's Workspace",
  "iconURL": "https://boxel-images.boxel.ai/icons/Letter-h.png",
  "backgroundURL": "https://boxel-images.boxel.ai/background-images/4k-curvilinear-stairs.jpg"
}

```