### PR TITLE
ci: Add linting for catalog realm

### DIFF
--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -94,6 +94,10 @@ jobs:
         if: always()
         run: pnpm run lint
         working-directory: packages/base
+      - name: Lint Catalog Realm
+        if: always()
+        run: pnpm run lint
+        working-directory: packages/catalog-realm
       - name: Lint Experiments Realm
         if: always()
         run: pnpm run lint

--- a/packages/catalog-realm/package.json
+++ b/packages/catalog-realm/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "lint": "concurrently \"pnpm:lint:*(!fix)\" --names \"lint:\"",
-    "lint:hbs": "ember-template-lint .",
+    "lint:hbs": "ember-template-lint . --no-error-on-unmatched-pattern",
     "lint:hbs:fix": "ember-template-lint . --fix"
   },
   "volta": {


### PR DESCRIPTION
The template lint flag stops it from failing when no `.gts` files exist.