### PR TITLE
matrix: Add link to registration success template

### DIFF
--- a/.github/workflows/sync-synapse-templates.yml
+++ b/.github/workflows/sync-synapse-templates.yml
@@ -34,11 +34,13 @@ jobs:
             echo "AWS_S3_BUCKET=cardstack-matrix-synapse-production" >> $GITHUB_ENV
             echo "AWS_ECS_CLUSTER=production" >> $GITHUB_ENV
             echo "AWS_ECS_SERVICE=synapse-production" >> $GITHUB_ENV
+            echo "HOST_DOMAIN=app.boxel.ai" >> $GITHUB_ENV
           elif [ "$INPUT_ENVIRONMENT" = "staging" ]; then
             echo "AWS_ROLE_ARN=arn:aws:iam::680542703984:role/github-synapse" >> $GITHUB_ENV
             echo "AWS_S3_BUCKET=cardstack-matrix-synapse-staging" >> $GITHUB_ENV
             echo "AWS_ECS_CLUSTER=staging" >> $GITHUB_ENV
             echo "AWS_ECS_SERVICE=synapse-staging" >> $GITHUB_ENV
+            echo "HOST_DOMAIN=realms-staging.stack.cards"
           else
             echo "unrecognized environment"
             exit 1;
@@ -49,6 +51,10 @@ jobs:
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: us-east-1
+
+      - name: Replace URL in registration success template
+        run: |
+          sed -i "s/http:\/\/localhost:4200/https:\/\/${{ env.HOST_DOMAIN }}/" packages/matrix/docker/synapse/templates/registration_success.html
 
       - name: S3 Sync
         run: |

--- a/.github/workflows/sync-synapse-templates.yml
+++ b/.github/workflows/sync-synapse-templates.yml
@@ -40,7 +40,7 @@ jobs:
             echo "AWS_S3_BUCKET=cardstack-matrix-synapse-staging" >> $GITHUB_ENV
             echo "AWS_ECS_CLUSTER=staging" >> $GITHUB_ENV
             echo "AWS_ECS_SERVICE=synapse-staging" >> $GITHUB_ENV
-            echo "HOST_DOMAIN=realms-staging.stack.cards"
+            echo "HOST_DOMAIN=realms-staging.stack.cards" >> $GITHUB_ENV
           else
             echo "unrecognized environment"
             exit 1;

--- a/packages/matrix/docker/synapse/templates/registration_success.html
+++ b/packages/matrix/docker/synapse/templates/registration_success.html
@@ -1,5 +1,5 @@
 {% extends "_base.html" %}
 {% block title %}Your email has now been validated{% endblock %}
 {% block body %}
-<p style="margin: 0;">Your email has now been validated, please return to Boxel registration screen. You may now close this window.</p>
+<p style="margin: 0;">Your email has now been validated, please return to the <a href="http://localhost:4200">Boxel registration screen</a>. You may now close this window.</p>
 {% endblock %}


### PR DESCRIPTION
The workflow to sync the templates now replaces the development environment URL with one appropriate to the environment.

![Boxel Email Verification 2024-10-23 12-27-02](https://github.com/user-attachments/assets/0f79f4e1-9c11-4f64-a6e2-d688176cb2af)

![Boxel Email Verification 2024-10-23 12-49-06](https://github.com/user-attachments/assets/ffabfbaf-ed4e-40de-a2f8-742362706b7d)

(Why does the cursor appear too high in the screenshot? 🤔)

This introduces some duplication where the domains for staging and production Boxel would need to be updated here if they ever change. If this is a concern, one way to address it would be to make Terraform [`github_actions_secret`](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_secret) resources for use in this workflow.