### PR TITLE
Add context when send message under interact submode

### DIFF
--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -386,11 +386,20 @@ export default class InteractSubmode extends Component<Signature> {
       let newRoomId = await this.matrixService.createRoom(`New AI chat`, [
         aiBotUsername,
       ]);
+      const context = {
+        submode: this.operatorModeStateService.state.submode,
+        openCardIds: this.operatorModeStateService
+          .topMostStackItems()
+          .map((item) => item.card.id),
+      };
+
       await this.matrixService.sendMessage(
         newRoomId,
         message,
         [card],
         [commandCard],
+        undefined,
+        context,
       );
     },
   );


### PR DESCRIPTION
Refer to https://linear.app/cardstack/issue/CS-7142/set-patchcard-as-an-available-tool-on-the-prd

### What is changing
When sending a message from a card in interact submode, we should also send context parameters (e.g., submode, openCardIds) to ensure patch tools are generated.