### PR TITLE
Show icons next to filter list on left of cards grid

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -56,7 +56,12 @@ import FieldDefEditTemplate from './default-templates/field-edit';
 import CaptionsIcon from '@cardstack/boxel-icons/captions';
 import RectangleEllipsisIcon from '@cardstack/boxel-icons/rectangle-ellipsis';
 import LetterCaseIcon from '@cardstack/boxel-icons/letter-case';
-import type { Icon } from '@cardstack/boxel-icons/types';
+
+interface CardorFieldTypeIconSignature {
+  Element: Element;
+}
+
+type CardorFieldTypeIcon = ComponentLike<CardorFieldTypeIconSignature>;
 
 export { primitive, isField, type BoxComponent };
 export const serialize = Symbol.for('cardstack-serialize');
@@ -1648,7 +1653,7 @@ export class BaseDef {
   static baseDef: undefined;
   static data?: Record<string, any>; // TODO probably refactor this away all together
   static displayName = 'Base';
-  static icon: Icon;
+  static icon: CardorFieldTypeIcon;
 
   static getDisplayName(instance: BaseDef) {
     return instance.constructor.displayName;

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -56,6 +56,7 @@ import FieldDefEditTemplate from './default-templates/field-edit';
 import CaptionsIcon from '@cardstack/boxel-icons/captions';
 import RectangleEllipsisIcon from '@cardstack/boxel-icons/rectangle-ellipsis';
 import LetterCaseIcon from '@cardstack/boxel-icons/letter-case';
+import type { Icon } from '@cardstack/boxel-icons/types';
 
 export { primitive, isField, type BoxComponent };
 export const serialize = Symbol.for('cardstack-serialize');
@@ -1647,9 +1648,7 @@ export class BaseDef {
   static baseDef: undefined;
   static data?: Record<string, any>; // TODO probably refactor this away all together
   static displayName = 'Base';
-  static icon: ComponentLike<{
-    Element: Element;
-  }>;
+  static icon: Icon;
 
   static getDisplayName(instance: BaseDef) {
     return instance.constructor.displayName;

--- a/packages/base/cards-grid.gts
+++ b/packages/base/cards-grid.gts
@@ -41,7 +41,11 @@ import { type CatalogEntry } from './catalog-entry';
 import StringField from './string';
 import { TrackedArray } from 'tracked-built-ins';
 import { MenuItem } from '@cardstack/boxel-ui/helpers';
+import Captions from '@cardstack/boxel-icons/captions';
+import Stack2 from '@cardstack/boxel-icons/stack-2';
+import Star from '@cardstack/boxel-icons/star';
 
+type IconComponent = typeof Captions;
 interface SortOption {
   displayName: string;
   sort: Query['sort'];
@@ -318,31 +322,34 @@ class Isolated extends Component<typeof CardsGrid> {
     </style>
   </template>
 
-  filters: { displayName: string; query: any }[] = new TrackedArray([
-    {
-      displayName: 'Favorites',
-      query: {
-        filter: {
-          any:
-            this.args.model.favorites?.map((card) => {
-              return { eq: { id: card.id } } ?? {};
-            }) ?? [],
+  filters: { displayName: string; icon: IconComponent; query: any }[] =
+    new TrackedArray([
+      {
+        displayName: 'Favorites',
+        icon: Star,
+        query: {
+          filter: {
+            any:
+              this.args.model.favorites?.map((card) => {
+                return { eq: { id: card.id } } ?? {};
+              }) ?? [],
+          },
         },
       },
-    },
-    {
-      displayName: 'All Cards',
-      query: {
-        filter: {
-          not: {
-            eq: {
-              _cardType: 'Cards Grid',
+      {
+        displayName: 'All Cards',
+        icon: Stack2,
+        query: {
+          filter: {
+            not: {
+              eq: {
+                _cardType: 'Cards Grid',
+              },
             },
           },
         },
       },
-    },
-  ]);
+    ]);
 
   @tracked private selectedSortOption: SortOption = availableSortOptions[0];
   @tracked activeFilter = this.filters[0];
@@ -454,6 +461,7 @@ class Isolated extends Component<typeof CardsGrid> {
       const lastIndex = summary.id.lastIndexOf('/');
       this.filters.push({
         displayName: summary.attributes.displayName,
+        icon: Captions,
         query: {
           filter: {
             type: {

--- a/packages/boxel-ui/addon/src/components/filter-list/index.gts
+++ b/packages/boxel-ui/addon/src/components/filter-list/index.gts
@@ -2,11 +2,19 @@ import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
+import type { ComponentLike } from '@glint/template';
+
+export interface FilterListIconSignature {
+  Element: SVGElement;
+}
+
+export type FilterListIcon = ComponentLike<FilterListIconSignature>;
 
 import { cn, eq } from '../../helpers.ts';
 
 export type Filter = {
   displayName: string;
+  icon: FilterListIcon;
 };
 
 interface Signature {
@@ -31,7 +39,9 @@ export default class FilterList extends Component<Signature> {
           class={{cn 'filter-list__button' selected=(eq @activeFilter filter)}}
           {{on 'click' (fn this.onChanged filter)}}
           data-test-boxel-filter-list-button={{filter.displayName}}
-        >{{filter.displayName}}</button>
+        ><filter.icon
+            class='filter-list__icon'
+          />{{filter.displayName}}</button>
       {{/each}}
     </div>
     <style scoped>
@@ -57,6 +67,11 @@ export default class FilterList extends Component<Signature> {
       .filter-list__button:not(.selected):hover {
         background: var(--boxel-300);
         border-radius: 6px;
+      }
+      .filter-list__icon {
+        width: var(--boxel-icon-xs);
+        height: var(--boxel-icon-xs);
+        vertical-align: top;
       }
     </style>
   </template>

--- a/packages/boxel-ui/addon/src/components/filter-list/usage.gts
+++ b/packages/boxel-ui/addon/src/components/filter-list/usage.gts
@@ -1,9 +1,49 @@
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { fn } from '@ember/helper';
 import Component from '@glimmer/component';
 import { cached, tracked } from '@glimmer/tracking';
 import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
 
-import FilterList, { type Filter } from './index.gts';
+import FilterList, {
+  type Filter,
+  type FilterListIconSignature,
+} from './index.gts';
+
+const Captions: TemplateOnlyComponent<FilterListIconSignature> = <template>
+  <svg
+    xmlns='http://www.w3.org/2000/svg'
+    width='24'
+    height='24'
+    fill='none'
+    stroke='currentColor'
+    stroke-linecap='round'
+    stroke-linejoin='round'
+    stroke-width='2'
+    class='lucide lucide-captions'
+    viewBox='0 0 24 24'
+    ...attributes
+  ><rect width='18' height='14' x='3' y='5' rx='2' ry='2' /><path
+      d='M7 15h4m4 0h2M7 11h2m4 0h4'
+    /></svg>
+</template>;
+
+const Stack2: TemplateOnlyComponent<FilterListIconSignature> = <template>
+  <svg
+    xmlns='http://www.w3.org/2000/svg'
+    width='24'
+    height='24'
+    fill='none'
+    stroke='currentColor'
+    stroke-linecap='round'
+    stroke-linejoin='round'
+    stroke-width='2'
+    class='icon icon-tabler icons-tabler-outline icon-tabler-stack-2'
+    viewBox='0 0 24 24'
+    ...attributes
+  ><path stroke='none' d='M0 0h24v24H0z' /><path
+      d='M12 4 4 8l8 4 8-4-8-4M4 12l8 4 8-4M4 16l8 4 8-4'
+    /></svg>
+</template>;
 
 export default class FilterListUsage extends Component {
   private allItems = ['Author', 'BlogPost', 'Friend', 'Person', 'Pet'];
@@ -14,11 +54,13 @@ export default class FilterListUsage extends Component {
     let _filters = [
       {
         displayName: 'All Items',
+        icon: Stack2,
       },
     ];
     this.allItems.forEach((item) => {
       _filters.push({
         displayName: item,
+        icon: Captions,
       });
     });
 

--- a/packages/boxel-ui/addon/src/components/filter-list/usage.gts
+++ b/packages/boxel-ui/addon/src/components/filter-list/usage.gts
@@ -100,7 +100,7 @@ export default class FilterListUsage extends Component {
       <:api as |Args|>
         <Args.Object
           @name='filters'
-          @description='An array of Filters, where the Filter interface requires only a \`displayName\` property.'
+          @description='An array of Filters, where the Filter interface requires only displayName and icon properties.'
           @value={{this.filters}}
         />
         <Args.Object


### PR DESCRIPTION
- note that these do not yet reflect the icons referenced in the card definitions. we'll come back and do that after alpha release

![image](https://github.com/user-attachments/assets/b4c15dc0-e332-4b08-8c4d-b88c105d2c1a)

