### PR TITLE
host: Restore header workspace icons

### DIFF
--- a/packages/boxel-ui/addon/src/components/realm-icon/index.gts
+++ b/packages/boxel-ui/addon/src/components/realm-icon/index.gts
@@ -51,7 +51,6 @@ export default class RealmIcon extends Component<Signature> {
         background-size: contain;
         background-position: center;
         background-repeat: no-repeat;
-        height: 100%;
       }
       .indexing {
         animation: pulse-border 2.5s linear infinite;


### PR DESCRIPTION
They’re currently vertically collapsed:

![Boxel 2024-10-29 14-05-37](https://github.com/user-attachments/assets/5cdc0b17-b798-4b61-bb18-0c5c47cbde36)

CS-7450