### PR TITLE
Only show finder filter scrollbar when hovered

### DIFF
--- a/packages/base/cards-grid.gts
+++ b/packages/base/cards-grid.gts
@@ -259,6 +259,9 @@ class Isolated extends Component<typeof CardsGrid> {
         top: var(--cards-grid-padding-top);
         padding-right: var(--boxel-sp-sm);
         height: 100%;
+        overflow-y: hidden;
+      }
+      :deep(.filter-list:hover) {
         overflow-y: auto;
       }
       :deep(.filter-list__button:first-child) {


### PR DESCRIPTION
This PR updates the cards grid such that the filter list scroll bar is only shown when hovered over. 

Note that this update is hostile to touch devices like the iPad...

![scroll](https://github.com/user-attachments/assets/3d3631cb-7e24-4137-b6ad-9ef9ad472759)
