### PR TITLE
modify-atom-view-for-task

### DIFF
--- a/packages/experiments-realm/productivity/task.gts
+++ b/packages/experiments-realm/productivity/task.gts
@@ -772,17 +772,35 @@ export class Task extends CardDef {
 
   static atom = class Atom extends Component<typeof this> {
     <template>
-      <span class='short-id'>{{@model.shortId}}</span>
-      {{@model.taskName}}
-      <Avatar
-        @userId={{@model.assignee.id}}
-        @displayName={{@model.assignee.name}}
-        @isReady={{true}}
-      />
+      <div class='task-atom'>
+        {{#if @model.assignee}}
+          <div class='avatar-wrapper'>
+            <Avatar
+              @userId={{@model.assignee.id}}
+              @displayName={{@model.assignee.name}}
+              @isReady={{true}}
+              class='avatar'
+            />
+          </div>
+        {{/if}}
+        <div class='task-title'>{{@model.taskName}}</div>
+      </div>
       <style scoped>
-        .short-id {
-          color: var(--boxel-purple);
-          font-size: var(--boxel-font-size-sm);
+        .task-atom {
+          display: flex;
+          align-items: center;
+          gap: var(--boxel-sp-xxxs);
+        }
+        .avatar-wrapper {
+          display: inline-block;
+        }
+        .avatar {
+          --profile-avatar-icon-size: 20px;
+        }
+        .task-title {
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
         }
       </style>
     </template>


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/ECO-31/fix-pill-inside-ai-chat-atom-task-appears-so-weird


Before:
![image](https://github.com/user-attachments/assets/76a08ef7-ed91-4ea9-a8e9-08d6fea9c10b)


After:
<img width="370" alt="Screenshot 2024-10-30 at 14 56 40" src="https://github.com/user-attachments/assets/94cec12d-1bc9-44a8-9908-a7de3a94c525">
