### PR TITLE
ui: Add support for image imports

### DIFF
--- a/packages/boxel-ui/addon/rollup.config.mjs
+++ b/packages/boxel-ui/addon/rollup.config.mjs
@@ -53,7 +53,7 @@ export default {
 
     // addons are allowed to contain imports of .css files, which we want rollup
     // to leave alone and keep in the published output.
-    addon.keepAssets(['styles/*', '**/*.png', '**/*.webp']),
+    addon.keepAssets(['styles/*', '**/*.webp']),
 
     // Remove leftover build artifacts when starting a new build.
     addon.clean({ runOnce: true }),

--- a/packages/boxel-ui/addon/rollup.config.mjs
+++ b/packages/boxel-ui/addon/rollup.config.mjs
@@ -53,7 +53,7 @@ export default {
 
     // addons are allowed to contain imports of .css files, which we want rollup
     // to leave alone and keep in the published output.
-    addon.keepAssets(['styles/*']),
+    addon.keepAssets(['styles/*', '**/*.png', '**/*.webp']),
 
     // Remove leftover build artifacts when starting a new build.
     addon.clean({ runOnce: true }),

--- a/packages/boxel-ui/test-app/ember-cli-build.js
+++ b/packages/boxel-ui/test-app/ember-cli-build.js
@@ -44,6 +44,10 @@ module.exports = function (defaults) {
               test: /\.otf$/,
               type: 'asset',
             },
+            {
+              test: /\.webp$/,
+              type: 'asset',
+            },
           ],
         },
       },


### PR DESCRIPTION
This adds configuration that allows `boxel-ui` components to reference images. `.webp` in this case as that’s what led to the initial issue, but it’s easily extended if other formats seem necessary.

There are no images to import this way at the moment so I opened [this PR](https://github.com/cardstack/boxel/pull/1739) to show it in action, you can see at the [preview deployment](https://keep-images-example.boxel-ui-preview.stack.cards/?s=Components&ss=%3CButton%3E) that the button has a background image imported from the component’s directory.

Note that this does not allow cards to do the same, that will need to be addressed separately.