### PR TITLE
Prevent background color from overflowing card container corners.

### DIFF
--- a/packages/boxel-ui/addon/src/components/card-container/index.gts
+++ b/packages/boxel-ui/addon/src/components/card-container/index.gts
@@ -34,6 +34,7 @@ const CardContainer: TemplateOnlyComponent<Signature> = <template>
         box-shadow var(--boxel-transition);
       height: 100%;
       width: 100%;
+      overflow: hidden;
     }
     .boundaries {
       box-shadow: 0 0 0 1px var(--boxel-light-500);


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/5701a4ce-22aa-4f4b-8261-bf9e2209a001)

After:

![image](https://github.com/user-attachments/assets/ab520ce5-80d4-4b9a-b1fd-36fe4ad9d07f)
