### PR TITLE
Refactor card chooser to allow user to specify realm to create new card

### DIFF
--- a/packages/boxel-ui/addon/src/styles/variables.css
+++ b/packages/boxel-ui/addon/src/styles/variables.css
@@ -124,6 +124,7 @@
   --boxel-light: #fff;
   --boxel-dark: #000;
   --boxel-dark-hover: rgba(0, 0, 0, 0.1);
+  --boxel-darker-hover: rgba(0, 0, 0, 0.5);
 
   --boxel-highlight: var(--boxel-teal);
   --boxel-highlight-hover: var(--boxel-dark-teal);

--- a/packages/host/app/components/card-catalog/index.gts
+++ b/packages/host/app/components/card-catalog/index.gts
@@ -1,3 +1,4 @@
+import { TemplateOnlyComponent } from '@ember/component/template-only';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
@@ -54,104 +55,102 @@ interface ButtonSignature {
     cardRefName: string | undefined;
   };
 }
-class ItemButton extends Component<ButtonSignature> {
-  <template>
-    {{#if @card}}
-      <button
-        class='catalog-item {{if @isSelected "selected"}}'
-        {{on 'click' (fn @select @card.url)}}
-        {{on 'dblclick' (fn @select @card.url)}}
-        {{on 'keydown' (fn @handleEnterKey @card.url)}}
-        data-test-select={{removeFileExtension @card.url}}
-        aria-label='Select'
-        data-test-card-catalog-item={{removeFileExtension @card.url}}
-        data-test-card-catalog-item-selected={{@isSelected}}
-        {{scrollIntoViewModifier
-          @isSelected
-          container='card-catalog'
-          key=@card.url
-        }}
-      >
-        {{@card.component}}
-      </button>
-    {{else if @newCard}}
-      <button
-        class='create-card catalog-item {{if @isSelected "selected"}}'
-        {{on 'click' (fn @select @newCard)}}
-        {{on 'dblclick' (fn @select @newCard)}}
-        {{on 'keydown' (fn @handleEnterKey @newCard)}}
-        data-test-select={{@newCardKey @newCard.realmURL}}
-        aria-label='Select'
-        data-test-card-catalog-item={{@newCardKey @newCard.realmURL}}
-        data-test-card-catalog-item-selected={{@isSelected}}
-        {{scrollIntoViewModifier
-          @isSelected
-          container='card-catalog'
-          key=(@newCardKey @newCard.realmURL)
-        }}
-      >
-        <div class='add-icon'>
-          <IconPlus width='20' height='20' role='presentation' />
-        </div>
-        <div class='create-new-text'>
-          Create New
-          {{@cardRefName}}
-        </div>
-      </button>
-    {{/if}}
-    <style scoped>
-      .catalog-item {
-        border: 1px solid var(--boxel-200);
-        border-radius: var(--boxel-border-radius-xl);
-        background-color: var(--boxel-light);
-        width: 100%;
-        height: 63px;
-        overflow: hidden;
-        cursor: pointer;
-        container-name: fitted-card;
-        container-type: size;
-        display: flex;
-        text-align: left;
-        margin: auto;
-      }
+let ItemButton: TemplateOnlyComponent<ButtonSignature> = <template>
+  {{#if @card}}
+    <button
+      class='catalog-item {{if @isSelected "selected"}}'
+      {{on 'click' (fn @select @card.url)}}
+      {{on 'dblclick' (fn @select @card.url)}}
+      {{on 'keydown' (fn @handleEnterKey @card.url)}}
+      data-test-select={{removeFileExtension @card.url}}
+      aria-label='Select'
+      data-test-card-catalog-item={{removeFileExtension @card.url}}
+      data-test-card-catalog-item-selected={{@isSelected}}
+      {{scrollIntoViewModifier
+        @isSelected
+        container='card-catalog'
+        key=@card.url
+      }}
+    >
+      {{@card.component}}
+    </button>
+  {{else if @newCard}}
+    <button
+      class='create-card catalog-item {{if @isSelected "selected"}}'
+      {{on 'click' (fn @select @newCard)}}
+      {{on 'dblclick' (fn @select @newCard)}}
+      {{on 'keydown' (fn @handleEnterKey @newCard)}}
+      data-test-select={{@newCardKey @newCard.realmURL}}
+      aria-label='Select'
+      data-test-card-catalog-item={{@newCardKey @newCard.realmURL}}
+      data-test-card-catalog-item-selected={{@isSelected}}
+      {{scrollIntoViewModifier
+        @isSelected
+        container='card-catalog'
+        key=(@newCardKey @newCard.realmURL)
+      }}
+    >
+      <div class='add-icon'>
+        <IconPlus width='20' height='20' role='presentation' />
+      </div>
+      <div class='create-new-text'>
+        Create New
+        {{@cardRefName}}
+      </div>
+    </button>
+  {{/if}}
+  <style scoped>
+    .catalog-item {
+      border: 1px solid var(--boxel-200);
+      border-radius: var(--boxel-border-radius-xl);
+      background-color: var(--boxel-light);
+      width: 100%;
+      height: 63px;
+      overflow: hidden;
+      cursor: pointer;
+      container-name: fitted-card;
+      container-type: size;
+      display: flex;
+      text-align: left;
+      margin: auto;
+    }
 
-      .catalog-item.selected {
-        border-color: var(--boxel-highlight);
-        box-shadow: 0 0 0 1px var(--boxel-highlight);
-      }
+    .catalog-item.selected {
+      border-color: var(--boxel-highlight);
+      box-shadow: 0 0 0 1px var(--boxel-highlight);
+    }
 
-      .catalog-item:hover {
-        border-color: var(--boxel-darker-hover);
-      }
+    .catalog-item:hover {
+      border-color: var(--boxel-darker-hover);
+    }
 
-      .catalog-item.selected:hover {
-        border-color: var(--boxel-highlight);
-      }
+    .catalog-item.selected:hover {
+      border-color: var(--boxel-highlight);
+    }
 
-      .create-card.catalog-item {
-        display: flex;
-        height: 40px;
-        border-radius: var(--boxel-border-radius-lg);
-        justify-content: center;
-        padding: var(--boxel-sp-xs) var(--boxel-sp-sm);
-        column-gap: var(--boxel-sp-xs);
-        flex-wrap: nowrap;
-      }
-      .create-card .add-icon {
-        flex: 1;
-        display: flex;
-        justify-content: center;
-        max-width: 41px;
-      }
-      .create-card .create-new-text {
-        flex: 4;
-        font: 600 var(--boxel-font-sm);
-        letter-spacing: var(--boxel-lsp);
-        line-height: 1.5;
-      }
-    </style>
-  </template>
-}
+    .create-card.catalog-item {
+      display: flex;
+      height: 40px;
+      border-radius: var(--boxel-border-radius-lg);
+      justify-content: center;
+      padding: var(--boxel-sp-xs) var(--boxel-sp-sm);
+      column-gap: var(--boxel-sp-xs);
+      flex-wrap: nowrap;
+    }
+    .create-card .add-icon {
+      flex: 1;
+      display: flex;
+      justify-content: center;
+      max-width: 41px;
+    }
+    .create-card .create-new-text {
+      flex: 4;
+      font: 600 var(--boxel-font-sm);
+      letter-spacing: var(--boxel-lsp);
+      line-height: 1.5;
+    }
+  </style>
+</template>;
 
 interface Signature {
   Args: {

--- a/packages/host/app/components/card-catalog/index.gts
+++ b/packages/host/app/components/card-catalog/index.gts
@@ -55,7 +55,8 @@ interface ButtonSignature {
     cardRefName: string | undefined;
   };
 }
-let ItemButton: TemplateOnlyComponent<ButtonSignature> = <template>
+
+const ItemButton: TemplateOnlyComponent<ButtonSignature> = <template>
   {{#if @card}}
     <button
       class='catalog-item {{if @isSelected "selected"}}'

--- a/packages/host/app/components/card-catalog/index.gts
+++ b/packages/host/app/components/card-catalog/index.gts
@@ -134,7 +134,7 @@ const ItemButton: TemplateOnlyComponent<ButtonSignature> = <template>
       height: 40px;
       border-radius: var(--boxel-border-radius-lg);
       justify-content: center;
-      padding: var(--boxel-sp-xs) var(--boxel-sp-sm);
+      padding: var(--boxel-sp-xs) var(--boxel-sp);
       column-gap: var(--boxel-sp-xs);
       flex-wrap: nowrap;
     }

--- a/packages/host/app/components/card-catalog/index.gts
+++ b/packages/host/app/components/card-catalog/index.gts
@@ -83,7 +83,7 @@ const ItemButton: TemplateOnlyComponent<ButtonSignature> = <template>
       {{on 'keydown' (fn @handleEnterKey @newCard)}}
       data-test-select={{@newCardKey @newCard.realmURL}}
       aria-label='Select'
-      data-test-card-catalog-item={{@newCardKey @newCard.realmURL}}
+      data-test-card-catalog-create-new-button={{@newCard.realmURL}}
       data-test-card-catalog-item-selected={{@isSelected}}
       {{scrollIntoViewModifier
         @isSelected

--- a/packages/host/app/components/card-catalog/index.gts
+++ b/packages/host/app/components/card-catalog/index.gts
@@ -1,25 +1,37 @@
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 
 import Component from '@glimmer/component';
+import { cached } from '@glimmer/tracking';
+
+import isEqual from 'lodash/isEqual';
 
 import pluralize from 'pluralize';
 
 import { Button } from '@cardstack/boxel-ui/components';
 
 import { add, cn, eq, gt, lt, subtract } from '@cardstack/boxel-ui/helpers';
+import { IconPlus } from '@cardstack/boxel-ui/icons';
 
-import type { RealmInfo } from '@cardstack/runtime-common';
+import type { RealmInfo, CodeRef } from '@cardstack/runtime-common';
 
 import { HTMLComponent } from '@cardstack/host/lib/html-component';
 
 import RestoreScrollPosition from '@cardstack/host/modifiers/restore-scroll-position';
 import scrollIntoViewModifier from '@cardstack/host/modifiers/scroll-into-view';
+import type RealmService from '@cardstack/host/services/realm';
 
 import { removeFileExtension } from '../search-sheet/utils';
 
 import CardCatalogResultsHeader from './results-header';
+
+export interface NewCardArgs {
+  ref: CodeRef;
+  relativeTo: string | undefined;
+  realmURL: string;
+}
 
 interface PrerenderedCard {
   component: HTMLComponent;
@@ -28,12 +40,132 @@ interface PrerenderedCard {
   realmInfo?: RealmInfo;
 }
 
+interface ButtonSignature {
+  Args: {
+    card?: PrerenderedCard;
+    newCard?: NewCardArgs;
+    isSelected: boolean;
+    select: (
+      card?: string | NewCardArgs,
+      ev?: KeyboardEvent | MouseEvent,
+    ) => void;
+    handleEnterKey: (card: string | NewCardArgs, event: KeyboardEvent) => void;
+    newCardKey: (realmURL: string) => string;
+    cardRefName: string | undefined;
+  };
+}
+class ItemButton extends Component<ButtonSignature> {
+  <template>
+    {{#if @card}}
+      <button
+        class='catalog-item {{if @isSelected "selected"}}'
+        {{on 'click' (fn @select @card.url)}}
+        {{on 'dblclick' (fn @select @card.url)}}
+        {{on 'keydown' (fn @handleEnterKey @card.url)}}
+        data-test-select={{removeFileExtension @card.url}}
+        aria-label='Select'
+        data-test-card-catalog-item={{removeFileExtension @card.url}}
+        data-test-card-catalog-item-selected={{@isSelected}}
+        {{scrollIntoViewModifier
+          @isSelected
+          container='card-catalog'
+          key=@card.url
+        }}
+      >
+        {{@card.component}}
+      </button>
+    {{else if @newCard}}
+      <button
+        class='create-card catalog-item {{if @isSelected "selected"}}'
+        {{on 'click' (fn @select @newCard)}}
+        {{on 'dblclick' (fn @select @newCard)}}
+        {{on 'keydown' (fn @handleEnterKey @newCard)}}
+        data-test-select={{@newCardKey @newCard.realmURL}}
+        aria-label='Select'
+        data-test-card-catalog-item={{@newCardKey @newCard.realmURL}}
+        data-test-card-catalog-item-selected={{@isSelected}}
+        {{scrollIntoViewModifier
+          @isSelected
+          container='card-catalog'
+          key=(@newCardKey @newCard.realmURL)
+        }}
+      >
+        <div class='add-icon'>
+          <IconPlus width='20' height='20' role='presentation' />
+        </div>
+        <div class='create-new-text'>
+          Create New
+          {{@cardRefName}}
+        </div>
+      </button>
+    {{/if}}
+    <style scoped>
+      .catalog-item {
+        border: 1px solid var(--boxel-200);
+        border-radius: var(--boxel-border-radius-xl);
+        background-color: var(--boxel-light);
+        width: 100%;
+        height: 63px;
+        overflow: hidden;
+        cursor: pointer;
+        container-name: fitted-card;
+        container-type: size;
+        display: flex;
+        text-align: left;
+        margin: auto;
+      }
+
+      .catalog-item.selected {
+        border-color: var(--boxel-highlight);
+        box-shadow: 0 0 0 1px var(--boxel-highlight);
+      }
+
+      .catalog-item:hover {
+        border-color: var(--boxel-darker-hover);
+      }
+
+      .catalog-item.selected:hover {
+        border-color: var(--boxel-highlight);
+      }
+
+      .create-card.catalog-item {
+        display: flex;
+        height: 40px;
+        border-radius: var(--boxel-border-radius-lg);
+        justify-content: center;
+        padding: var(--boxel-sp-xs) var(--boxel-sp-sm);
+        column-gap: var(--boxel-sp-xs);
+        flex-wrap: nowrap;
+      }
+      .create-card .add-icon {
+        flex: 1;
+        display: flex;
+        justify-content: center;
+        max-width: 41px;
+      }
+      .create-card .create-new-text {
+        flex: 4;
+        font: 600 var(--boxel-font-sm);
+        letter-spacing: var(--boxel-lsp);
+        line-height: 1.5;
+      }
+    </style>
+  </template>
+}
+
 interface Signature {
   Args: {
     cards: PrerenderedCard[];
-    select: (cardUrl?: string, ev?: KeyboardEvent | MouseEvent) => void;
-    selectedCardUrl?: string;
+    select: (
+      card?: string | NewCardArgs,
+      ev?: KeyboardEvent | MouseEvent,
+    ) => void;
+    selectedCard?: string | NewCardArgs;
     hasPreselectedCard?: boolean;
+    offerToCreate?: {
+      ref: CodeRef;
+      relativeTo: URL | undefined;
+    };
     realmInfos: Record<string, RealmInfo>;
   };
 }
@@ -41,7 +173,7 @@ interface Signature {
 export default class CardCatalog extends Component<Signature> {
   <template>
     <div class='card-catalog' data-test-card-catalog>
-      {{#each-in this.groupedCardsByRealm as |_realmUrl realmData|}}
+      {{#each-in this.groupedCardsByRealm as |realmUrl realmData|}}
         <section
           class='card-catalog__realm'
           data-test-realm={{realmData.realmInfo.name}}
@@ -50,37 +182,41 @@ export default class CardCatalog extends Component<Signature> {
             @realm={{realmData.realmInfo}}
             @resultsCount={{realmData.cardsTotal}}
           />
-
           <ul
             class='card-catalog__group'
             {{RestoreScrollPosition
-              key=@selectedCardUrl
+              key=this.selectedCardScrollKey
               container='card-catalog'
             }}
           >
+            {{#if @offerToCreate}}
+              {{#let
+                (deepEq @selectedCard (this.newCardArgs realmUrl))
+                as |isSelected|
+              }}
+                <ItemButton
+                  @newCard={{(this.newCardArgs realmUrl)}}
+                  @isSelected={{isSelected}}
+                  @select={{@select}}
+                  @handleEnterKey={{this.handleEnterKey}}
+                  @newCardKey={{this.newCardKey}}
+                  @cardRefName={{this.cardRefName}}
+                />
+              {{/let}}
+            {{/if}}
+
             {{#each realmData.cards as |card index|}}
               {{#if (lt index realmData.displayedCardsCount)}}
-                {{#let (eq @selectedCardUrl card.url) as |isSelected|}}
+                {{#let (eq @selectedCard card.url) as |isSelected|}}
                   <li class={{cn 'item' selected=isSelected}}>
-                    <button
-                      class='catalog-item {{if isSelected "selected"}}'
-                      {{on 'click' (fn @select card.url)}}
-                      {{on 'dblclick' (fn @select card.url)}}
-                      {{on 'keydown' (fn this.handleEnterKey card.url)}}
-                      data-test-select={{removeFileExtension card.url}}
-                      aria-label='Select'
-                      data-test-card-catalog-item={{removeFileExtension
-                        card.url
-                      }}
-                      data-test-card-catalog-item-selected={{isSelected}}
-                      {{scrollIntoViewModifier
-                        isSelected
-                        container='card-catalog'
-                        key=card.url
-                      }}
-                    >
-                      {{card.component}}
-                    </button>
+                    <ItemButton
+                      @card={{card}}
+                      @isSelected={{isSelected}}
+                      @select={{@select}}
+                      @handleEnterKey={{this.handleEnterKey}}
+                      @newCardKey={{this.newCardKey}}
+                      @cardRefName={{this.cardRefName}}
+                    />
                   </li>
                 {{/let}}
               {{/if}}
@@ -120,13 +256,43 @@ export default class CardCatalog extends Component<Signature> {
       {{else}}
         <p>No cards available</p>
       {{/each-in}}
+      {{#if @offerToCreate}}
+        {{#each-in this.writableRealmsWithoutResults as |realmUrl realmInfo|}}
+          <section
+            class='card-catalog__realm'
+            data-test-realm={{realmInfo.name}}
+          >
+            <CardCatalogResultsHeader
+              @realm={{realmInfo}}
+              @resultsCount={{0}}
+            />
+            <ul
+              class='card-catalog__group'
+              {{RestoreScrollPosition
+                key=this.selectedCardScrollKey
+                container='card-catalog'
+              }}
+            >
+              {{#let
+                (deepEq @selectedCard (this.newCardArgs realmUrl))
+                as |isSelected|
+              }}
+                <ItemButton
+                  @newCard={{(this.newCardArgs realmUrl)}}
+                  @isSelected={{isSelected}}
+                  @select={{@select}}
+                  @handleEnterKey={{this.handleEnterKey}}
+                  @newCardKey={{this.newCardKey}}
+                  @cardRefName={{this.cardRefName}}
+                />
+              {{/let}}
+            </ul>
+          </section>
+        {{/each-in}}
+      {{/if}}
     </div>
 
     <style scoped>
-      .catalog-item.selected {
-        border-color: var(--boxel-highlight);
-        box-shadow: 0 0 0 1px var(--boxel-highlight);
-      }
       .card-catalog {
         display: grid;
         gap: var(--boxel-sp-xl);
@@ -169,24 +335,21 @@ export default class CardCatalog extends Component<Signature> {
         justify-content: center;
         align-items: center;
       }
-
-      .catalog-item {
-        border: 1px solid var(--boxel-200);
-        border-radius: var(--boxel-border-radius);
-        background-color: var(--boxel-light);
-        width: 100%;
-        height: 63px;
-        overflow: hidden;
-        cursor: pointer;
-        container-name: fitted-card;
-        container-type: size;
-        display: flex;
-        text-align: left;
-        margin: auto;
-      }
     </style>
   </template>
 
+  @service private declare realm: RealmService;
+
+  @cached
+  private get selectedCardScrollKey() {
+    return typeof this.args.selectedCard === 'string'
+      ? this.args.selectedCard
+      : typeof this.args.selectedCard === 'object'
+      ? `new card for ${this.args.selectedCard.realmURL}`
+      : undefined;
+  }
+
+  @cached
   private get groupedCardsByRealm(): Record<
     string,
     {
@@ -237,17 +400,68 @@ export default class CardCatalog extends Component<Signature> {
     return groupedCards;
   }
 
+  @cached
+  private get writableRealmsWithoutResults(): Record<string, RealmInfo> {
+    let realms: Record<string, RealmInfo> = {};
+    for (let realmURL of Object.keys(this.args.realmInfos)) {
+      if (
+        this.realm.canWrite(realmURL) &&
+        !this.groupedCardsByRealm[realmURL]
+      ) {
+        realms[realmURL] = this.args.realmInfos[realmURL];
+      }
+    }
+    return realms;
+  }
+
+  private get cardRefName() {
+    if (!this.args.offerToCreate) {
+      return undefined;
+    }
+    return (
+      (
+        this.args.offerToCreate?.ref as {
+          module: string;
+          name: string;
+        }
+      ).name ?? 'Card'
+    );
+  }
+
   // do not paginate if there's pre-selected card (because we scroll to it)
   private pageSize = this.args.hasPreselectedCard ? this.args.cards.length : 5;
 
   @action
-  private handleEnterKey(cardUrl: string, event: KeyboardEvent) {
+  private handleEnterKey(card: string | NewCardArgs, event: KeyboardEvent) {
     if (event.key === 'Enter') {
-      this.args.select(cardUrl, event);
+      this.args.select(card, event);
     }
+  }
+
+  @action
+  private newCardArgs(realmURL: string) {
+    if (!this.args.offerToCreate) {
+      throw new Error(
+        `cannot create newCardArgs when there is not this.args.offerToCreate argument`,
+      );
+    }
+    let { ref, relativeTo } = this.args.offerToCreate;
+    return {
+      ref,
+      relativeTo: relativeTo ? relativeTo.href : undefined,
+      realmURL,
+    };
+  }
+
+  private newCardKey(realmURL: string) {
+    return `new card for ${realmURL}`;
   }
 }
 
 function min(a: number, b: number) {
   return Math.min(a, b);
+}
+
+function deepEq(a: unknown, b: unknown) {
+  return isEqual(a, b);
 }

--- a/packages/host/app/components/card-catalog/modal.gts
+++ b/packages/host/app/components/card-catalog/modal.gts
@@ -15,7 +15,6 @@ import { TrackedArray, TrackedObject } from 'tracked-built-ins';
 
 import { Button, BoxelInput } from '@cardstack/boxel-ui/components';
 import { eq, not } from '@cardstack/boxel-ui/helpers';
-import { IconPlus } from '@cardstack/boxel-ui/icons';
 
 import {
   createNewCard,
@@ -26,6 +25,7 @@ import {
   Loader,
   RealmInfo,
   CardCatalogQuery,
+  isCardInstance,
 } from '@cardstack/runtime-common';
 
 import type {
@@ -39,11 +39,6 @@ import {
   isCardTypeFilter,
   isEveryFilter,
 } from '@cardstack/runtime-common/query';
-
-import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
-
-import RealmService from '@cardstack/host/services/realm';
-import RealmServerService from '@cardstack/host/services/realm-server';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 
@@ -62,10 +57,13 @@ import { Submodes } from '../submode-switcher';
 
 import CardCatalogFilters from './filters';
 
-import CardCatalog from './index';
+import CardCatalog, { type NewCardArgs } from './index';
 
 import type CardService from '../../services/card-service';
 import type LoaderService from '../../services/loader-service';
+import type OperatorModeStateService from '../../services/operator-mode-state-service';
+import type RealmService from '../../services/realm';
+import type RealmServerService from '../../services/realm-server';
 
 interface Signature {
   Args: {};
@@ -78,7 +76,6 @@ type Request = {
     offerToCreate?: {
       ref: CodeRef;
       relativeTo: URL | undefined;
-      realmURL: URL | undefined;
     };
     createNewCard?: CreateNewCard;
   };
@@ -87,7 +84,7 @@ type Request = {
 type State = {
   id: number;
   request: Request;
-  selectedCardUrl?: string;
+  selectedCard?: string | NewCardArgs;
   searchKey: string;
   cardUrlFromSearchKey: string;
   chooseCardTitle: string;
@@ -155,8 +152,15 @@ export default class CardCatalogModal extends Component<Signature> {
                     @cards={{cards}}
                     @realmInfos={{this.availableRealms}}
                     @select={{this.selectCard}}
-                    @selectedCardUrl={{this.state.selectedCardUrl}}
+                    @selectedCard={{this.state.selectedCard}}
                     @hasPreselectedCard={{this.state.hasPreselectedCard}}
+                    @offerToCreate={{unless
+                      (eq
+                        this.operatorModeStateService.state.submode
+                        Submodes.Code
+                      )
+                      this.state.request.opts.offerToCreate
+                    }}
                   />
                 {{/if}}
               </:response>
@@ -164,35 +168,6 @@ export default class CardCatalogModal extends Component<Signature> {
           </:content>
           <:footer>
             <div class='footer'>
-              <div class='footer__actions-left'>
-                {{#if this.state.request.opts.offerToCreate}}
-                  {{#unless
-                    (eq
-                      this.operatorModeStateService.state.submode Submodes.Code
-                    )
-                  }}
-                    <Button
-                      @kind='secondary-light'
-                      @size='tall'
-                      class='create-new-button'
-                      {{on
-                        'click'
-                        (fn
-                          this.createNew
-                          this.state.request.opts.offerToCreate.ref
-                          this.state.request.opts.offerToCreate.relativeTo
-                          this.state.request.opts.offerToCreate.realmURL
-                        )
-                      }}
-                      data-test-card-catalog-create-new-button
-                    >
-                      <IconPlus width='20' height='20' role='presentation' />
-                      Create New
-                      {{this.cardRefName}}
-                    </Button>
-                  {{/unless}}
-                {{/if}}
-              </div>
               <div>
                 <Button
                   @kind='secondary-light'
@@ -206,11 +181,11 @@ export default class CardCatalogModal extends Component<Signature> {
                 <Button
                   @kind='primary'
                   @size='tall'
-                  @disabled={{eq this.state.selectedCardUrl undefined}}
+                  @disabled={{eq this.state.selectedCard undefined}}
                   class='footer-button'
                   {{on
                     'click'
-                    (fn this.pick this.state.selectedCardUrl undefined)
+                    (fn this.pick this.state.selectedCard undefined)
                   }}
                   data-test-card-catalog-go-button
                 >
@@ -243,23 +218,16 @@ export default class CardCatalogModal extends Component<Signature> {
       .footer-button + .footer-button {
         margin-left: var(--boxel-sp-xs);
       }
-      .create-new-button {
-        --icon-color: var(--boxel-highlight);
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        gap: var(--boxel-sp-xxs);
-      }
     </style>
   </template>
 
   stateStack: State[] = new TrackedArray<State>();
   stateId = 0;
-  @service declare cardService: CardService;
-  @service declare loaderService: LoaderService;
-  @service declare operatorModeStateService: OperatorModeStateService;
-  @service declare realmServer: RealmServerService;
-  @service declare realm: RealmService;
+  @service private declare cardService: CardService;
+  @service private declare loaderService: LoaderService;
+  @service private declare operatorModeStateService: OperatorModeStateService;
+  @service private declare realmServer: RealmServerService;
+  @service private declare realm: RealmService;
 
   constructor(owner: Owner, args: {}) {
     super(owner, args);
@@ -269,7 +237,7 @@ export default class CardCatalogModal extends Component<Signature> {
     });
   }
 
-  get cardUrls() {
+  private get cardUrls() {
     if (!this.state) {
       return [];
     }
@@ -280,7 +248,7 @@ export default class CardCatalogModal extends Component<Signature> {
     return [];
   }
 
-  get availableRealms(): Record<string, RealmInfo> | undefined {
+  private get availableRealms(): Record<string, RealmInfo> | undefined {
     let items: Record<string, RealmInfo> = {};
     for (let [url, realmMeta] of Object.entries(this.realm.allRealmsInfo)) {
       if (this.state == null || !this.state.availableRealmUrls.includes(url)) {
@@ -291,32 +259,18 @@ export default class CardCatalogModal extends Component<Signature> {
     return items;
   }
 
-  get cardRefName() {
-    if (!this.state) {
-      return undefined;
-    }
-    return (
-      (
-        this.state.request.opts?.offerToCreate?.ref as {
-          module: string;
-          name: string;
-        }
-      ).name ?? 'Card'
-    );
-  }
-
-  get state(): State | undefined {
+  private get state(): State | undefined {
     return this.stateStack[this.stateStack.length - 1];
   }
 
-  @action onSelectRealm(realmUrl: string) {
+  @action private onSelectRealm(realmUrl: string) {
     if (!this.state) {
       return;
     }
     this.state.selectedRealmUrls = [...this.state.selectedRealmUrls, realmUrl];
   }
 
-  @action onDeselectRealm(realmUrl: string) {
+  @action private onDeselectRealm(realmUrl: string) {
     if (!this.state) {
       return;
     }
@@ -332,7 +286,7 @@ export default class CardCatalogModal extends Component<Signature> {
     }
     this.state.searchKey = '';
     this.state.cardUrlFromSearchKey = '';
-    this.state.selectedCardUrl = undefined;
+    this.state.selectedCard = undefined;
     this.state.dismissModal = false;
     this.state.query = this.state.originalQuery;
     this.state.hasPreselectedCard = false;
@@ -425,7 +379,7 @@ export default class CardCatalogModal extends Component<Signature> {
         originalQuery: query,
         availableRealmUrls: this.realmServer.availableRealmURLs,
         selectedRealmUrls: this.realmServer.availableRealmURLs,
-        selectedCardUrl: preselectedCardUrl,
+        selectedCard: preselectedCardUrl,
         hasPreselectedCard: Boolean(preselectedCardUrl),
       });
       this.stateStack.push(cardCatalogState);
@@ -440,7 +394,7 @@ export default class CardCatalogModal extends Component<Signature> {
   );
 
   @action
-  setSearchKey(searchKey: string) {
+  private setSearchKey(searchKey: string) {
     if (!this.state) {
       return;
     }
@@ -452,7 +406,7 @@ export default class CardCatalogModal extends Component<Signature> {
     }
   }
 
-  get searchKeyIsURL() {
+  private get searchKeyIsURL() {
     if (!this.state) {
       return false;
     }
@@ -464,20 +418,20 @@ export default class CardCatalogModal extends Component<Signature> {
     }
   }
 
-  debouncedSearchFieldUpdate = restartableTask(async () => {
+  private debouncedSearchFieldUpdate = restartableTask(async () => {
     await timeout(500);
     this.onSearchFieldUpdated();
   });
 
   @action
-  onSearchFieldKeypress(e: KeyboardEvent) {
+  private onSearchFieldKeypress(e: KeyboardEvent) {
     if (e.key === 'Enter') {
       this.onSearchFieldUpdated();
     }
   }
 
   @action
-  onSearchFieldUpdated() {
+  private onSearchFieldUpdated() {
     if (!this.state) {
       return;
     }
@@ -543,38 +497,43 @@ export default class CardCatalogModal extends Component<Signature> {
     }
   }
 
-  @action selectCard(
-    cardUrl?: string,
+  @action private selectCard(
+    card?: string | NewCardArgs,
     event?: MouseEvent | KeyboardEvent,
   ): void {
-    if (!this.state || !cardUrl) {
+    if (!this.state || !card) {
       return;
     }
 
-    this.state.selectedCardUrl = cardUrl;
+    this.state.selectedCard = card;
     this.state.hasPreselectedCard = false;
 
     if (
       (event instanceof KeyboardEvent && event?.key === 'Enter') ||
       (event instanceof MouseEvent && event?.type === 'dblclick')
     ) {
-      this.pickCard.perform(cardUrl);
+      this.pickCard.perform(card);
     }
   }
 
   pickCard = restartableTask(
-    async (cardUrlOrCardDef?: string | CardDef, state?: State) => {
+    async (item?: string | CardDef | NewCardArgs, state?: State) => {
       if (!this.state) {
         return;
       }
       let card: CardDef | undefined;
 
-      if (cardUrlOrCardDef) {
-        let isCardDef = typeof cardUrlOrCardDef !== 'string';
-        if (isCardDef) {
-          card = cardUrlOrCardDef as CardDef;
+      if (item) {
+        if (isCardInstance(item)) {
+          card = item;
+        } else if (typeof item === 'string') {
+          card = await this.cardService.getCard(item);
         } else {
-          card = await this.cardService.getCard(cardUrlOrCardDef as string);
+          card = await this.createNewTask.perform(
+            item.ref,
+            item.relativeTo ? new URL(item.relativeTo) : undefined,
+            new URL(item.realmURL),
+          );
         }
       }
 
@@ -595,25 +554,17 @@ export default class CardCatalogModal extends Component<Signature> {
     },
   );
 
-  @action handleKeydown(event: KeyboardEvent) {
+  @action private handleKeydown(event: KeyboardEvent) {
     if (event.key === 'Escape') {
       this.pick(undefined);
     }
   }
 
-  @action pick(cardUrlOrCardDef?: string | CardDef, state?: State) {
-    this.pickCard.perform(cardUrlOrCardDef, state);
+  @action private pick(item?: string | CardDef | NewCardArgs, state?: State) {
+    this.pickCard.perform(item, state);
   }
 
-  @action createNew(
-    ref: CodeRef,
-    relativeTo: URL | undefined,
-    realmURL: URL | undefined,
-  ) {
-    this.createNewTask.perform(ref, relativeTo, realmURL);
-  }
-
-  createNewTask = task(
+  private createNewTask = task(
     async (
       ref: CodeRef,
       relativeTo: URL | undefined /* this should be the catalog entry ID */,
@@ -624,11 +575,6 @@ export default class CardCatalogModal extends Component<Signature> {
       }
       let newCard;
       this.state.dismissModal = true;
-
-      // We need to store the current state in a variable
-      // because there is a possibility that in createNewCard,
-      // users will open the card catalog modal and insert a new state into the stack.
-      let currentState = this.state;
       if (this.state.request.opts?.createNewCard) {
         newCard = await this.state.request.opts?.createNewCard(
           ref,
@@ -641,7 +587,7 @@ export default class CardCatalogModal extends Component<Signature> {
       } else {
         newCard = await createNewCard(ref, relativeTo, { realmURL });
       }
-      this.pick(newCard, currentState);
+      return newCard;
     },
   );
 }

--- a/packages/host/app/components/card-catalog/results-header.gts
+++ b/packages/host/app/components/card-catalog/results-header.gts
@@ -28,6 +28,8 @@ const CardCatalogResultsHeader: TemplateOnlyComponent<Signature> = <template>
         results
       {{else if (eq @resultsCount 1)}}
         1 result
+      {{else if (eq @resultsCount 0)}}
+        No results
       {{/if}}
     </span>
   </header>

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -1005,6 +1005,7 @@ module('Acceptance | interact submode tests', function (hooks) {
       });
       await click('[data-test-add-new]');
       await click('[data-test-card-catalog-create-new-button]');
+      await click(`[data-test-card-catalog-go-button]`);
     });
   });
 

--- a/packages/host/tests/integration/components/card-editor-test.gts
+++ b/packages/host/tests/integration/components/card-editor-test.gts
@@ -481,6 +481,7 @@ module('Integration | card-editor', function (hooks) {
     await click('[data-test-add-new]');
     await waitFor('[data-test-card-catalog-create-new-button]');
     await click('[data-test-card-catalog-create-new-button]');
+    await click(`[data-test-card-catalog-go-button]`);
     await waitFor('[data-test-create-new-card="Pet"]');
 
     assert.dom('[data-test-field="name"] input').exists();

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -757,6 +757,7 @@ module('Integration | operator-mode', function (hooks) {
     await click('[data-test-add-new]');
     await waitFor(`[data-test-card-catalog-modal]`);
     await click(`[data-test-card-catalog-create-new-button]`);
+    await click(`[data-test-card-catalog-go-button]`);
 
     await waitFor(`[data-test-stack-card-index="2"]`);
     assert.dom('[data-test-stack-card-index]').exists({ count: 3 });
@@ -776,6 +777,7 @@ module('Integration | operator-mode', function (hooks) {
     );
     await waitFor(`[data-test-card-catalog-modal]`);
     await click(`[data-test-card-catalog-create-new-button]`);
+    await click(`[data-test-card-catalog-go-button]`);
 
     await waitFor(`[data-test-stack-card-index="3"]`);
 
@@ -925,6 +927,7 @@ module('Integration | operator-mode', function (hooks) {
     await click('[data-test-add-new]');
     await waitFor(`[data-test-card-catalog-modal]`);
     await click(`[data-test-card-catalog-create-new-button]`);
+    await click(`[data-test-card-catalog-go-button]`);
     await waitFor('[data-test-stack-card-index="1"]');
 
     assert
@@ -1131,6 +1134,7 @@ module('Integration | operator-mode', function (hooks) {
       .dom('[data-test-card-catalog-create-new-button]')
       .hasText('Create New Pet');
     await click('[data-test-card-catalog-create-new-button]');
+    await click(`[data-test-card-catalog-go-button]`);
 
     await waitFor(`[data-test-stack-card-index="1"]`);
     await fillIn(
@@ -1172,6 +1176,7 @@ module('Integration | operator-mode', function (hooks) {
       .dom('[data-test-card-catalog-create-new-button]')
       .hasText('Create New Pet');
     await click('[data-test-card-catalog-create-new-button]');
+    await click(`[data-test-card-catalog-go-button]`);
 
     await waitFor(`[data-test-stack-card-index="1"]`);
     await fillIn(
@@ -2420,6 +2425,7 @@ module('Integration | operator-mode', function (hooks) {
     await waitFor(`[data-test-card-catalog-modal]`);
     await waitFor(`[data-test-card-catalog-create-new-button]`);
     await click(`[data-test-card-catalog-create-new-button]`);
+    await click(`[data-test-card-catalog-go-button]`);
     await waitFor('[data-test-stack-card-index="1"]');
     assert.dom(`[data-test-stack-card-index="1"]`).exists();
     let ids = Array.from(savedCards);
@@ -2469,6 +2475,7 @@ module('Integration | operator-mode', function (hooks) {
     await click('[data-test-add-new]');
     await waitFor(`[data-test-card-catalog-modal]`);
     await click(`[data-test-card-catalog-create-new-button]`);
+    await click(`[data-test-card-catalog-go-button]`);
     await waitFor('[data-test-stack-card-index="1"]');
 
     await click('[data-test-stack-card-index="1"] [data-test-edit-button]');


### PR DESCRIPTION
This PR refactors the card chooser so that you can choose the realm of a newly created card. 

Note that for now please don't choose to create a new linked card in a realm that is different than the realm of the consuming card. This will result in an error doc in the index for the consuming card. A solution for this scenario is forthcoming.

![new-card](https://github.com/user-attachments/assets/3a1eb759-84c0-4b5c-9be7-6623472bdbce)

