### PR TITLE
Boxel UI/refactor icon button

### DIFF
--- a/packages/boxel-ui/addon/src/components/icon-button/index.gts
+++ b/packages/boxel-ui/addon/src/components/icon-button/index.gts
@@ -93,7 +93,7 @@ class IconButton extends Component<Signature> {
       }
 
       .svg-icon {
-        width: var(--inner-boxel-icon-button-widt);
+        width: var(--inner-boxel-icon-button-width);
         height: var(--inner-boxel-icon-button-width);
       }
     </style>

--- a/packages/boxel-ui/addon/src/components/icon-button/index.gts
+++ b/packages/boxel-ui/addon/src/components/icon-button/index.gts
@@ -2,7 +2,6 @@ import { concat } from '@ember/helper';
 import { on } from '@ember/modifier';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-
 import cn from '../../helpers/cn.ts';
 import type { Icon } from '../../icons/types.ts';
 
@@ -31,6 +30,10 @@ class IconButton extends Component<Signature> {
     this.isHoverOnButton = false;
   };
 
+  get hasCustomSizeAttributes() {
+    return this.args.width || this.args.height;
+  }
+
   <template>
     <button
       class={{cn (if @variant (concat @variant)) @class}}
@@ -44,7 +47,7 @@ class IconButton extends Component<Signature> {
         <@icon
           width={{if @width @width '16px'}}
           height={{if @height @height '16px'}}
-          style='margin: auto;'
+          class={{unless this.hasCustomSizeAttributes 'svg-icon'}}
         />
       {{/if}}
     </button>
@@ -52,13 +55,16 @@ class IconButton extends Component<Signature> {
       button {
         --inner-boxel-icon-button-width: var(--boxel-icon-button-width, 40px);
         --inner-boxel-icon-button-height: var(--boxel-icon-button-height, 40px);
-
         width: var(--inner-boxel-icon-button-width);
         height: var(--inner-boxel-icon-button-height);
+        display: flex;
+        align-items: center;
+        justify-content: center;
         padding: 0;
         background: var(--boxel-icon-button-background, none);
         border: 1px solid transparent;
         z-index: 0;
+        overflow: hidden;
       }
 
       button:hover {
@@ -76,7 +82,6 @@ class IconButton extends Component<Signature> {
 
       .secondary {
         --icon-color: var(--boxel-highlight);
-
         border: 1px solid rgb(255 255 255 / 35%);
         border-radius: 100px;
         background-color: #41404d;
@@ -84,6 +89,13 @@ class IconButton extends Component<Signature> {
 
       .secondary:hover {
         background-color: var(--boxel-purple-800);
+      }
+
+      .svg-icon {
+        --icon-width: var(--inner-boxel-icon-button-width);
+        --icon-height: var(--inner-boxel-icon-button-width);
+        width: var(--icon-width);
+        height: var(--icon-height);
       }
     </style>
   </template>

--- a/packages/boxel-ui/addon/src/components/icon-button/index.gts
+++ b/packages/boxel-ui/addon/src/components/icon-button/index.gts
@@ -31,10 +31,6 @@ class IconButton extends Component<Signature> {
     this.isHoverOnButton = false;
   };
 
-  get hasCustomSizeAttributes() {
-    return this.args.width || this.args.height;
-  }
-
   <template>
     <button
       class={{cn (if @variant (concat @variant)) @class}}
@@ -42,13 +38,11 @@ class IconButton extends Component<Signature> {
       {{on 'mouseleave' this.onMouseLeaveButton}}
       ...attributes
     >
-      {{! Using inline style attribute because targeting the svg using <style scoped> does not work - css scoping works incorrectly }}
-      {{! template-lint-disable no-inline-styles }}
       {{#if @icon}}
         <@icon
           width={{if @width @width '16px'}}
           height={{if @height @height '16px'}}
-          class={{unless this.hasCustomSizeAttributes 'svg-icon'}}
+          class='svg-icon'
         />
       {{/if}}
     </button>
@@ -58,7 +52,7 @@ class IconButton extends Component<Signature> {
         --inner-boxel-icon-button-height: var(--boxel-icon-button-height, 40px);
         width: var(--inner-boxel-icon-button-width);
         height: var(--inner-boxel-icon-button-height);
-        display: flex;
+        display: inline-flex;
         align-items: center;
         justify-content: center;
         padding: 0;
@@ -93,8 +87,8 @@ class IconButton extends Component<Signature> {
       }
 
       .svg-icon {
-        width: var(--inner-boxel-icon-button-width);
-        height: var(--inner-boxel-icon-button-width);
+        width: auto;
+        height: auto;
       }
     </style>
   </template>

--- a/packages/boxel-ui/addon/src/components/icon-button/index.gts
+++ b/packages/boxel-ui/addon/src/components/icon-button/index.gts
@@ -2,6 +2,7 @@ import { concat } from '@ember/helper';
 import { on } from '@ember/modifier';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+
 import cn from '../../helpers/cn.ts';
 import type { Icon } from '../../icons/types.ts';
 
@@ -84,7 +85,7 @@ class IconButton extends Component<Signature> {
         --icon-color: var(--boxel-highlight);
         border: 1px solid rgb(255 255 255 / 35%);
         border-radius: 100px;
-        background-color: #41404d;
+        background-color: var(--boxel-icon-button-background, #41404d);
       }
 
       .secondary:hover {
@@ -92,10 +93,8 @@ class IconButton extends Component<Signature> {
       }
 
       .svg-icon {
-        --icon-width: var(--inner-boxel-icon-button-width);
-        --icon-height: var(--inner-boxel-icon-button-width);
-        width: var(--icon-width);
-        height: var(--icon-height);
+        width: var(--inner-boxel-icon-button-widt);
+        height: var(--inner-boxel-icon-button-width);
       }
     </style>
   </template>

--- a/packages/boxel-ui/addon/src/components/icon-button/usage.gts
+++ b/packages/boxel-ui/addon/src/components/icon-button/usage.gts
@@ -18,8 +18,8 @@ import BoxelIconButton from './index.gts';
 export default class IconButtonUsage extends Component {
   @tracked icon: Icon = IconPlusCircle;
   @tracked variant?: string;
-  @tracked width = '40px';
-  @tracked height = '40px';
+  @tracked width = '16px';
+  @tracked height = '16px';
 
   @tracked showIconBorders = false;
   @tracked hideIconOverflow = false;
@@ -27,6 +27,7 @@ export default class IconButtonUsage extends Component {
   cssClassName = 'boxel-icon-button';
   @cssVariable declare boxelIconButtonWidth: CSSVariableInfo;
   @cssVariable declare boxelIconButtonHeight: CSSVariableInfo;
+  @cssVariable declare boxelIconButtonBackground: CSSVariableInfo;
 
   @action log(message: string): void {
     // eslint-disable-next-line no-console
@@ -54,6 +55,7 @@ export default class IconButtonUsage extends Component {
           style={{cssVar
             boxel-icon-button-width=this.boxelIconButtonWidth.value
             boxel-icon-button-height=this.boxelIconButtonHeight.value
+            boxel-icon-button-background=this.boxelIconButtonBackground.value
           }}
         />
       </:example>
@@ -106,6 +108,14 @@ export default class IconButtonUsage extends Component {
           @defaultValue={{this.boxelIconButtonHeight.defaults}}
           @value={{this.boxelIconButtonHeight.value}}
           @onInput={{this.boxelIconButtonHeight.update}}
+        />
+        <Css.Basic
+          @name='boxel-icon-button-background'
+          @type='color'
+          @description='Background color of the icon button'
+          @defaultValue={{this.boxelIconButtonBackground.defaults}}
+          @value={{this.boxelIconButtonBackground.value}}
+          @onInput={{this.boxelIconButtonBackground.update}}
         />
       </:cssVars>
     </FreestyleUsage>

--- a/packages/boxel-ui/addon/src/components/icon-button/usage.gts
+++ b/packages/boxel-ui/addon/src/components/icon-button/usage.gts
@@ -77,16 +77,16 @@ export default class IconButtonUsage extends Component {
           @onInput={{fn (mut this.variant)}}
           @defaultValue='<undefined>'
         />
-        <Args.Number
+        <Args.String
           @name='width'
-          @description='used to size the SVG rendering'
+          @description='used to size the SVG rendering (only accepts px values)'
           @defaultValue={{'16px'}}
           @value={{this.width}}
           @onInput={{fn (mut this.width)}}
         />
-        <Args.Number
+        <Args.String
           @name='height'
-          @description='used to size the SVG rendering'
+          @description='used to size the SVG rendering (only accepts px values)'
           @defaultValue={{'16px'}}
           @value={{this.height}}
           @onInput={{fn (mut this.height)}}


### PR DESCRIPTION
Linear: eco-79-improve-icon-button

1.  prevent icon overflow in icon-button component, use icon button wrapper width & height as max constraints,  allowing users to scale the icon smaller than the button wrapper while preventing any scaling that would cause the icon to overflow beyond the wrapper's boundaries
2. implement icon button bg color css var api


Before: 
![image](https://github.com/user-attachments/assets/71a4715f-84e2-43d4-a5b1-351774573aa5)

after:
![image](https://github.com/user-attachments/assets/5e7ee26f-8bb5-457e-bd72-c0aeb11b18ec)

