### PR TITLE
tools: Fix task launch in development

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,7 +10,37 @@
       "command": "pnpm",
       "args": ["watch"],
       "isBackground": true,
-      "problemMatcher": ["$tsc-watch"]
+      "problemMatcher": [
+        // Adapted from https://github.com/connor4312/esbuild-problem-matchers/blob/51e17a9f4464dd008bfc07871482b94dc87901ce/package.json#L68
+        {
+          "severity": "error",
+          "applyTo": "closedDocuments",
+          "source": "esbuild",
+          "fileLocation": "relative",
+          "pattern": [
+            {
+              "regexp": "^[✘▲] \\[([A-Z]+)\\] (.+)",
+              "severity": 1,
+              "message": 2
+            },
+            {
+              "regexp": "^(?:\\t| {4})(?!\\s)([^:]+)(?::([0-9]+))?(?::([0-9]+))?:$",
+              "file": 1,
+              "line": 2,
+              "column": 3
+            }
+          ],
+          "background": {
+            "activeOnStart": true,
+            "beginsPattern": {
+              "regexp": "\\[watch\\] build started"
+            },
+            "endsPattern": {
+              "regexp": "\\[watch\\] build finished"
+            }
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Recently when I want to iterate on the extension I get the warning seen in the screenshot and have to “Debug Anyway”. The `$tsc-watch` problem matcher was inappropriate because the build is run through `esbuild` so it was looking for patterns that never matched.

This PR adapts problem matchers from [this extension](https://github.com/connor4312/esbuild-problem-matchers/blob/51e17a9f4464dd008bfc07871482b94dc87901ce/package.json#L68) that work for `esbuild`, now pressing F5 opens the extension development host with no manual intervention. We could instead require developers to install the extension and then use `$esbuild-watch` but that seems annoying.

![boxel-motion 2024-11-07 15-17-29](https://github.com/user-attachments/assets/292d4e85-619c-4c60-a5a7-1b6bc284fd66)
