### PR TITLE
Lock the synapse version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 For a quickstart, see [here](./QUICKSTART.md)
 
+
 ## Setup
 
 - you will want the [Glint](https://marketplace.visualstudio.com/items?itemName=typed-ember.glint-vscode) vscode extension

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 For a quickstart, see [here](./QUICKSTART.md)
 
-
 ## Setup
 
 - you will want the [Glint](https://marketplace.visualstudio.com/items?itemName=typed-ember.glint-vscode) vscode extension

--- a/packages/matrix/docker/synapse/index.ts
+++ b/packages/matrix/docker/synapse/index.ts
@@ -126,7 +126,7 @@ export async function synapseStart(
   );
   await dockerCreateNetwork({ networkName: 'boxel' });
   const synapseId = await dockerRun({
-    image: 'matrixdotorg/synapse:v1.109.0',
+    image: 'matrixdotorg/synapse:v1.118.0',
     containerName: 'boxel-synapse',
     dockerParams: [
       '--rm',

--- a/packages/matrix/docker/synapse/index.ts
+++ b/packages/matrix/docker/synapse/index.ts
@@ -126,7 +126,7 @@ export async function synapseStart(
   );
   await dockerCreateNetwork({ networkName: 'boxel' });
   const synapseId = await dockerRun({
-    image: 'matrixdotorg/synapse:v1.110.0',
+    image: 'matrixdotorg/synapse:v1.99.0rc1',
     containerName: 'boxel-synapse',
     dockerParams: [
       '--rm',

--- a/packages/matrix/docker/synapse/index.ts
+++ b/packages/matrix/docker/synapse/index.ts
@@ -126,7 +126,7 @@ export async function synapseStart(
   );
   await dockerCreateNetwork({ networkName: 'boxel' });
   const synapseId = await dockerRun({
-    image: 'matrixdotorg/synapse:v1.118.0',
+    image: 'matrixdotorg/synapse:v1.110.0',
     containerName: 'boxel-synapse',
     dockerParams: [
       '--rm',

--- a/packages/matrix/docker/synapse/index.ts
+++ b/packages/matrix/docker/synapse/index.ts
@@ -126,7 +126,7 @@ export async function synapseStart(
   );
   await dockerCreateNetwork({ networkName: 'boxel' });
   const synapseId = await dockerRun({
-    image: 'matrixdotorg/synapse:develop',
+    image: 'matrixdotorg/synapse:v1.109.0',
     containerName: 'boxel-synapse',
     dockerParams: [
       '--rm',


### PR DESCRIPTION
This PR locks our synapse version to the same version that is used in production (1.99.0.rc1)