### PR TITLE
Add error-handling to full reset script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "deploy:boxel-motion:preview-staging": "cd packages/boxel-motion/addon && pnpm build && cd ../test-app && pnpm exec ember deploy s3-preview-staging --verbose",
     "deploy:boxel-ui": "pnpm run build-common-deps && cd packages/boxel-ui/test-app && pnpm exec ember deploy",
     "deploy:boxel-ui:preview-staging": "pnpm run build-common-deps && cd packages/boxel-ui/test-app && pnpm exec ember deploy s3-preview-staging --verbose",
+    "full-reset": "./scripts/full-reset.sh",
     "lint": "pnpm run --filter './packages/**' --if-present -r lint",
     "lint:fix": "pnpm run --filter './packages/**' --if-present -r lint:fix"
   },

--- a/packages/realm-server/package.json
+++ b/packages/realm-server/package.json
@@ -91,7 +91,7 @@
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
     "lint:glint": "glint",
-    "full-reset": "./scripts/full-reset.sh"
+    "full-reset": "echo 'This script has moved to the root package.json'"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/realm-server/scripts/full-reset.sh
+++ b/packages/realm-server/scripts/full-reset.sh
@@ -2,29 +2,47 @@
 CURRENT_DIR="$(pwd)"
 SCRIPTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-cd ${SCRIPTS_DIR}/../../postgres
-pnpm run drop-db boxel
-pnpm run drop-db boxel_test
-pnpm run drop-db boxel_base
+errors=()
 
-# clearing the DB means that we also lose all the info we have on the realm
-# owners of the dynamic realms, which means that we should eliminate these as
-# well.
-rm -rf "${SCRIPTS_DIR}/../realms"
+run_command() {
+    "$@"
+    if [ $? -ne 0 ]; then
+        errors+=("Failed: $*")
+    fi
+}
 
-# also now you will have users that have realm associations to realms that don't
-# exist anymore, so we should clear the matrix state so it can be in sync with
-# the DB state
-cd "${SCRIPTS_DIR}/../../matrix"
-pnpm stop:synapse
-rm -rf ./synapse-data
-pnpm start:synapse
-pnpm register-all
+cd ${SCRIPTS_DIR}/../../postgres || errors+=("Failed: changing to postgres directory")
+run_command pnpm run drop-db boxel
+run_command pnpm run drop-db boxel_test
+run_command pnpm run drop-db boxel_base
 
-cd "${CURRENT_DIR}"
+if ! rm -rf "${SCRIPTS_DIR}/../realms"; then
+    errors+=("Failed: removing realms directory")
+fi
+
+cd "${SCRIPTS_DIR}/../../matrix" || errors+=("Failed: changing to matrix directory")
+
+run_command pnpm stop:synapse
+
+if ! rm -rf ./synapse-data; then
+    errors+=("Failed: removing synapse-data")
+fi
+
+run_command pnpm start:synapse
+run_command pnpm register-all
+
+cd "${CURRENT_DIR}" || errors+=("Failed: returning to original directory")
 
 echo "
 WARNING: Any matrix server authorization tokens cached in the browser's localstorage are now invalid. Make sure to clear browser localstorage. Also make sure to execute the following in the browser after logging in as 'user' to add the experiments realm:
 
 window['@cardstack/host'].lookup('service:matrix-service')._client.setAccountData('com.cardstack.boxel.realms', {realms: ['http://localhost:4201/experiments/']})
 "
+
+if [ ${#errors[@]} -ne 0 ]; then
+    echo "\nThe following errors occurred during execution:"
+    printf '%s\n' "${errors[@]}"
+    exit 1
+else
+    echo "\nAll operations completed successfully."
+fi

--- a/scripts/full-reset.sh
+++ b/scripts/full-reset.sh
@@ -38,8 +38,8 @@ window['@cardstack/host'].lookup('service:matrix-service')._client.setAccountDat
 "
 
 if [ ${#errors[@]} -ne 0 ]; then
-    echo "\nThe following errors occurred during execution:"
-    printf '%s\n' "${errors[@]}"
+    echo "\n\033[1;31mThe following errors occurred during execution:\033[0m"
+    printf '\033[1;31m%s\033[0m\n' "${errors[@]}"
     exit 1
 else
     echo "\nAll operations completed successfully."

--- a/scripts/full-reset.sh
+++ b/scripts/full-reset.sh
@@ -11,7 +11,7 @@ run_command() {
     fi
 }
 
-cd ${SCRIPTS_DIR}/../../postgres || errors+=("Failed: changing to postgres directory")
+cd ${SCRIPTS_DIR}/../packages/postgres || errors+=("Failed: changing to postgres directory")
 run_command pnpm run drop-db boxel
 run_command pnpm run drop-db boxel_test
 run_command pnpm run drop-db boxel_base
@@ -20,7 +20,7 @@ if ! rm -rf "${SCRIPTS_DIR}/../realms"; then
     errors+=("Failed: removing realms directory")
 fi
 
-cd "${SCRIPTS_DIR}/../../matrix" || errors+=("Failed: changing to matrix directory")
+cd "${SCRIPTS_DIR}/../packages/matrix" || errors+=("Failed: changing to matrix directory")
 
 run_command pnpm stop:synapse
 

--- a/scripts/full-reset.sh
+++ b/scripts/full-reset.sh
@@ -31,8 +31,6 @@ fi
 run_command pnpm start:synapse
 run_command pnpm register-all
 
-cd "${CURRENT_DIR}" || errors+=("Failed: returning to original directory")
-
 echo "
 WARNING: Any matrix server authorization tokens cached in the browser's localstorage are now invalid. Make sure to clear browser localstorage. Also make sure to execute the following in the browser after logging in as 'user' to add the experiments realm:
 

--- a/scripts/full-reset.sh
+++ b/scripts/full-reset.sh
@@ -16,7 +16,7 @@ run_command pnpm run drop-db boxel
 run_command pnpm run drop-db boxel_test
 run_command pnpm run drop-db boxel_base
 
-if ! rm -rf "${SCRIPTS_DIR}/../realms"; then
+if ! rm -rf "${SCRIPTS_DIR}/../packages/realm-server/realms"; then
     errors+=("Failed: removing realms directory")
 fi
 


### PR DESCRIPTION
This is currently based on #1778 which adjusts the script name and database commands root.

If there are errors in any of the steps they’re now highlighted so we can scroll back to examine them:

<img width="401" alt="boxel-motion 2024-11-08 14-25-31" src="https://github.com/user-attachments/assets/b5fe8047-6bf7-4895-91fb-a04e37f73157">

I opened a database client to the `boxel` database to reproduce the situation that led me to want this improvement.

I also chose to move the script to the root because it spans packages outside `packages/realm-server`.