### PR TITLE
Do not use flex-grow on dropdown trigger

### DIFF
--- a/packages/boxel-ui/addon/src/components/field-container/index.gts
+++ b/packages/boxel-ui/addon/src/components/field-container/index.gts
@@ -101,12 +101,8 @@ const FieldContainer: TemplateOnlyComponent<Signature> = <template>
       display: flex;
       align-items: center;
     }
-
-    .horizontal > .content > :empty {
-      flex: 0;
-    }
-
-    .horizontal > .content > :not(:empty) {
+    /* TODO: refactor field-container so it doesn't impose flex on field contents */
+    .horizontal > .content > :deep(*):not(.ember-basic-dropdown-trigger) {
       flex: 1;
     }
 

--- a/packages/boxel-ui/addon/src/components/multi-select/index.gts
+++ b/packages/boxel-ui/addon/src/components/multi-select/index.gts
@@ -133,15 +133,19 @@ export class BoxelMultiSelectBasic<ItemT> extends Component<Signature<ItemT>> {
         position: relative;
         display: flex;
         align-items: stretch;
-        flex-grow: 1;
         overflow: hidden;
         border: 1px solid var(--boxel-border-color);
         border-radius: var(--boxel-border-radius-sm);
+        max-width: 100%;
+        width: 100%;
       }
       .ember-power-select-multiple-options {
         list-style: none;
         gap: var(--boxel-sp-xxxs);
         width: auto;
+      }
+      .ember-power-select-trigger {
+        padding: 0;
       }
     </style>
   </template>
@@ -168,7 +172,7 @@ export default class BoxelMultiSelect<ItemT> extends Component<
       @registerAPI={{@registerAPI}}
       @initiallyOpened={{@initiallyOpened}}
       @extra={{@extra}}
-      {{! Do not remove eventType argument 
+      {{! Do not remove eventType argument
     This is to ensure that the click event from selected item does not bubble up to the trigger
      and cause the dropdown to close
        do not remove eventType argument }}

--- a/packages/boxel-ui/addon/src/components/multi-select/usage.gts
+++ b/packages/boxel-ui/addon/src/components/multi-select/usage.gts
@@ -14,6 +14,7 @@ import pluralize from 'pluralize';
 import cn from '../../helpers/cn.ts';
 import cssVar from '../../helpers/css-var.ts';
 import CheckMark from '../../icons/check-mark.gts';
+import BoxelField from '../field-container/index.gts';
 import BoxelMultiSelect, { BoxelMultiSelectBasic } from './index.gts';
 import BoxelSelectedItem from './selected-item.gts';
 
@@ -391,6 +392,28 @@ export default class BoxelMultiSelectUsage extends Component {
             you should use this.
           </p>
         </:description>
+      </FreestyleUsage>
+      <FreestyleUsage @name='Usage with FieldContainer'>
+        <:example>
+          <BoxelField @label='Country'>
+            <BoxelMultiSelect
+              @options={{this.items}}
+              @selected={{this.selectedItems}}
+              @onChange={{this.onSelectItems}}
+              @placeholder={{this.placeholder}}
+              @disabled={{this.disabled}}
+              @renderInPlace={{this.renderInPlace}}
+              @matchTriggerWidth={{this.matchTriggerWidth}}
+              @searchField='name'
+              @searchEnabled={{true}}
+              @closeOnSelect={{false}}
+              @ariaLabel='Select countries'
+              as |option|
+            >
+              {{option.name}}
+            </BoxelMultiSelect>
+          </BoxelField>
+        </:example>
       </FreestyleUsage>
     </div>
   </template>

--- a/packages/boxel-ui/addon/src/components/select/index.gts
+++ b/packages/boxel-ui/addon/src/components/select/index.gts
@@ -54,10 +54,14 @@ const BoxelSelect: TemplateOnlyComponent<Signature> = <template>
       position: relative;
       display: flex;
       align-items: stretch;
-      flex-grow: 1;
       overflow: hidden;
       border: 1px solid var(--boxel-border-color);
       border-radius: var(--boxel-border-radius-sm);
+      max-width: 100%;
+      width: 100%;
+    }
+    .ember-power-select-trigger {
+      padding: 0;
     }
   </style>
   {{! template-lint-disable require-scoped-style }}

--- a/packages/boxel-ui/addon/src/components/select/usage.gts
+++ b/packages/boxel-ui/addon/src/components/select/usage.gts
@@ -8,6 +8,7 @@ import {
   cssVariable,
 } from 'ember-freestyle/decorators/css-variable';
 
+import BoxelField from '../field-container/index.gts';
 import BoxelSelect from './index.gts';
 
 interface Country {
@@ -47,7 +48,6 @@ export default class BoxelSelectUsage extends Component {
   <template>
     <FreestyleUsage @name='Select'>
       <:example>
-
         <BoxelSelect
           @placeholder={{this.placeholder}}
           @searchEnabled={{this.searchEnabled}}
@@ -137,6 +137,29 @@ export default class BoxelSelectUsage extends Component {
           @description='Tells the component what property of the options should be used to filter'
         />
       </:api>
+    </FreestyleUsage>
+    <FreestyleUsage @name='Usage with FieldContainer'>
+      <:example>
+        <BoxelField @label='Country'>
+          <BoxelSelect
+            @placeholder={{this.placeholder}}
+            @searchEnabled={{this.searchEnabled}}
+            @searchField={{this.searchField}}
+            @selected={{this.selectedItem}}
+            @onChange={{this.onSelectItem}}
+            @options={{this.items}}
+            @verticalPosition={{this.verticalPosition}}
+            @renderInPlace={{this.renderInPlace}}
+            @disabled={{this.disabled}}
+            @dropdownClass='boxel-select-usage'
+            @matchTriggerWidth={{this.matchTriggerWidth}}
+            aria-label={{this.placeholder}}
+            as |item|
+          >
+            <div>{{item.name}}</div>
+          </BoxelSelect>
+        </BoxelField>
+      </:example>
     </FreestyleUsage>
   </template>
 }


### PR DESCRIPTION
@lucaslyl The issue with calling display none on wormhole container is that it hides the dropdown menu contents when `@renderInPlace` is set to `true`. That is why we can't use that solution.

- added usage with field-container in usage docs so we can see the problem
- removed `flex-grow: 1` from select and multi-select components, used 100% width instead. This can be changed by the consumer of the component to a different value if desired.
- updated field-container component to not apply flex:1 to dropdown with a note to do further refactor.

Let me know if this solves the problem you were experiencing. It's up to you if you want to keep the :empty vs not :empty change you made. 