### PR TITLE
Fix relative URL calculation when URL is the same as the `relativeTo`

### DIFF
--- a/packages/runtime-common/url.ts
+++ b/packages/runtime-common/url.ts
@@ -40,19 +40,22 @@ export function relativeURL(
     return url.pathname;
   }
 
+  let lastPart: string | undefined;
   while (
     ourParts[0] === theirParts[0] &&
     ourParts.length > 0 &&
     theirParts.length > 0
   ) {
-    ourParts.shift();
+    lastPart = ourParts.shift();
     theirParts.shift();
   }
   if (theirParts.length > 1) {
     theirParts.shift();
-    return [...theirParts.map(() => '..'), ...ourParts].join('/');
+    let relative = [...theirParts.map(() => '..'), ...ourParts].join('/');
+    return relative === '.' && lastPart ? `./${lastPart}` : relative;
   } else {
-    return ['.', ...ourParts].join('/');
+    let relative = ['.', ...ourParts].join('/');
+    return relative === '.' && lastPart ? `./${lastPart}` : relative;
   }
 }
 


### PR DESCRIPTION
When creating a linkTo relationship to one's self, the relative URL calculation for the linked card was returning `"."`. Our indexer didn't know how to handle that. This PR updates the relative URL calculation for a URL that is the same as the `relativeTo` URL to be `"./filename"`, where we include the last segment of the URL.

screen cast of a successful relationship to one's self after this fix is made:

![link](https://github.com/user-attachments/assets/5461e2f8-5d79-4449-aa6f-aa002e8ae94b)
