### PR TITLE
Use `{{#each}}` key to provide component stability for `AiAssistantPastSessionsList`

### DIFF
--- a/packages/host/app/components/ai-assistant/past-sessions.gts
+++ b/packages/host/app/components/ai-assistant/past-sessions.gts
@@ -37,7 +37,7 @@ const AiAssistantPastSessionsList: TemplateOnlyComponent<Signature> = <template>
     <:body>
       {{#if @sessions}}
         <ul class='past-sessions'>
-          {{#each @sessions as |session|}}
+          {{#each @sessions key='roomId' as |session|}}
             <PastSessionItem @session={{session}} @actions={{@roomActions}} />
           {{/each}}
         </ul>


### PR DESCRIPTION
The issue here is that in the `host/app/components/ai-assistant/panel.gts` module, the `AiAssistantPanel.aiSessionsRooms` getter. Specifically this getter returns a different array instance each time it's recomputed so that there is no component stability for the `AIPastSessionsList` component that consumes this as an argument. each time there is a matrix event that is received (which happens via the /sync calls),  a wholly new array is created, and hence the AIPastSessionsList component's {{#each}} is re-rendered for all the items in the array. The solution is to use the `key` property of the {{#each}} helper to guide ember on how to stabilize the rerenders, so that it knows what is new and what is the same in the array.

Before:
![screencast 2024-10-30 09-22-56](https://github.com/user-attachments/assets/73f3782a-f8c6-4338-8a7e-759e40b623b5)


After:
![thinking](https://github.com/user-attachments/assets/65688e83-c33a-4d0f-81b5-09cd0816bd49)
