### PR TITLE
Patch the matrix js SDK with a throttled sync in its `doSync()` loop

### DIFF
--- a/patches/matrix-js-sdk@31.0.0.patch
+++ b/patches/matrix-js-sdk@31.0.0.patch
@@ -37,20 +37,104 @@ index 9115598fd769bad15ed23293a68d617d5dbf21a5..95c28e59d8414dbc0837f5c85c98dd96
  }
  function anySignal(signals) {
 diff --git a/lib/sync.js b/lib/sync.js
-index f59265e1089ce832c0be8a23aa19813c2d4738cc..e9b70f2b75a89bb561fc420f03b5106a55f34e09 100644
+index f59265e1089ce832c0be8a23aa19813c2d4738cc..630f58767cbb887620883d075e1b947b9f83b944 100644
 --- a/lib/sync.js
 +++ b/lib/sync.js
-@@ -747,6 +747,13 @@ class SyncApi {
+@@ -719,7 +719,7 @@ class SyncApi {
+    * Invoke me to do /sync calls
+    */
+   async doSync(syncOptions) {
+-    while (this.running) {
++    async function _sync() {
+       const syncToken = this.client.store.getSyncToken();
+       let data;
+       try {
+@@ -729,8 +729,8 @@ class SyncApi {
+         data = await this.currentSyncRequest;
+       } catch (e) {
+         const abort = await this.onSyncError(e);
+-        if (abort) return;
+-        continue;
++        if (abort) return true;
++        return;
+       } finally {
+         this.currentSyncRequest = undefined;
+       }
+@@ -747,6 +747,7 @@ class SyncApi {
          nextSyncToken: data.next_batch,
          catchingUp: this.catchingUp
        };
 +
-+      if (syncToken === data.next_batch) {
-+        // there are no updates and we are just idle--wait before 
-+        // continuing so that idle syncs don't DDoS the server
-+        await new Promise(r => setTimeout(r, 1000));
-+      }
-+
        if (this.syncOpts.crypto) {
          // tell the crypto module we're about to process a sync
          // response
+@@ -798,6 +799,14 @@ class SyncApi {
+         await this.client.store.save();
+       }
+     }
++
++    const throttledSync = throttle(_sync.bind(this), 1000);
++
++    while (this.running) {
++      let abort = await throttledSync();
++      if (abort) { return; }
++    }
++
+     if (!this.running) {
+       debuglog("Sync no longer running: exiting.");
+       if (this.connectionReturnedDefer) {
+@@ -1624,6 +1633,54 @@ class SyncApi {
+   }
+ }
+ 
++// https://chatgpt.com/share/6734ecfd-cab0-8009-bbb9-b0126ed13d6a
++function throttle(func, wait) {
++  let lastCall = 0;
++  let timeoutId = null;
++  let lastArgs = null;
++  let lastContext = null;
++  let pendingPromise = null;
++
++  const invokeFunc = async (time) => {
++    lastCall = time;
++    const result = func.apply(lastContext, lastArgs);
++    lastArgs = lastContext = null;
++    pendingPromise = result instanceof Promise ? result : Promise.resolve(result);
++    await pendingPromise;
++  };
++
++  const throttled = function(...args) {
++    const now = Date.now();
++    lastArgs = args;
++    lastContext = this;
++
++    const isLeadingCall = lastCall === 0;
++
++    if (isLeadingCall) {
++      invokeFunc(now);
++    }
++
++    const remainingTime = wait - (now - lastCall);
++
++    if (remainingTime <= 0 || remainingTime > wait) {
++      if (timeoutId) {
++        clearTimeout(timeoutId);
++        timeoutId = null;
++      }
++      invokeFunc(now);
++    } else if (!timeoutId) {
++      timeoutId = setTimeout(() => {
++        timeoutId = null;
++        invokeFunc(Date.now());
++      }, remainingTime);
++    }
++
++    return pendingPromise;
++  };
++
++  return throttled;
++}
++
+ // /!\ This function is not intended for public use! It's only exported from
+ // here in order to share some common logic with sliding-sync-sdk.ts.
+ exports.SyncApi = SyncApi;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ patchedDependencies:
     hash: sbmabuxrk2m44agmppz3qozwvq
     path: patches/magic-string@0.25.9.patch
   matrix-js-sdk@31.0.0:
-    hash: igcckcqmkyc37qn7cofjntczfm
+    hash: 5fxoq6o42simiavsj5daibqlfy
     path: patches/matrix-js-sdk@31.0.0.patch
   style-loader@2.0.0:
     hash: xqjji5denmqrswdovljl2t3yv4
@@ -134,7 +134,7 @@ importers:
         version: 1.7.3
       matrix-js-sdk:
         specifier: ^31.0.0
-        version: 31.0.0(patch_hash=igcckcqmkyc37qn7cofjntczfm)
+        version: 31.0.0(patch_hash=5fxoq6o42simiavsj5daibqlfy)
       openai:
         specifier: 4.47.1
         version: 4.47.1
@@ -220,7 +220,7 @@ importers:
         version: 6.6.2
       matrix-js-sdk:
         specifier: ^31.0.0
-        version: 31.0.0(patch_hash=igcckcqmkyc37qn7cofjntczfm)
+        version: 31.0.0(patch_hash=5fxoq6o42simiavsj5daibqlfy)
       super-fast-md5:
         specifier: ^1.0.1
         version: 1.0.1
@@ -1583,7 +1583,7 @@ importers:
         version: 1.8.1
       matrix-js-sdk:
         specifier: ^31.0.0
-        version: 31.0.0(patch_hash=igcckcqmkyc37qn7cofjntczfm)
+        version: 31.0.0(patch_hash=5fxoq6o42simiavsj5daibqlfy)
       moment:
         specifier: ^2.29.4
         version: 2.29.4
@@ -2131,7 +2131,7 @@ importers:
     dependencies:
       matrix-js-sdk:
         specifier: ^31.0.0
-        version: 31.0.0(patch_hash=igcckcqmkyc37qn7cofjntczfm)
+        version: 31.0.0(patch_hash=5fxoq6o42simiavsj5daibqlfy)
     devDependencies:
       '@babel/preset-typescript':
         specifier: ^7.24.7
@@ -19719,7 +19719,7 @@ packages:
   /matrix-events-sdk@0.0.1:
     resolution: {integrity: sha512-1QEOsXO+bhyCroIe2/A5OwaxHvBm7EsSQ46DEDn8RBIfQwN5HWBpFvyWWR4QY0KHPPnnJdI99wgRiAl7Ad5qaA==}
 
-  /matrix-js-sdk@31.0.0(patch_hash=igcckcqmkyc37qn7cofjntczfm):
+  /matrix-js-sdk@31.0.0(patch_hash=5fxoq6o42simiavsj5daibqlfy):
     resolution: {integrity: sha512-2TqDwEK34NFS0uiOti02CBCupwJcAIxWarOSD0yIrgMpIwSVNB795jEnXxNXz+bgPKsepDmiqeg2DrlinIoW1w==}
     engines: {node: '>=18.0.0'}
     dependencies:


### PR DESCRIPTION
This PR adds a workaround for the scenario when the synapse server starts "tight looping" the sync https://github.com/element-hq/synapse/issues/15824. There is a known bug with the synapse server where the sync will start to "tight loop", such that instead of waiting the normal 30 seconds in between a sync, a new sync request is immediately issued. this can result in thousands of sync requests per minute. We implemented a workaround for this issue, which i think covers the most common form of this bug (presence notification events), but this bug seems to occasionally manifest itself for other types of events too. (I've seen this locally a bunch of times).

The matrix js SDK relies on long polling, so that the server controls the response timing. but when this bug manifests itself the server no longer waits the normal 30 seconds before responding to the client when the sync state has not changed. in scenarios such as these, the sync state has not actually changed--we get the same sync token on each request (meaning that the matrix state for this user is unchanged) over and over again, thousands of times per minute.

This PR limits the sync loop to never making a sync call more than once per second. Note that sync is called directly for other reasons as well, but specifically in the cases where the chat is idle, we should never be making more than one call per second.

Note that I worked with ChatGPT to use a throttle that is based on lodash's implementation which is specifically sensitive to the needs of async functions. Details here: https://chatgpt.com/share/6734ecfd-cab0-8009-bbb9-b0126ed13d6a