### PR TITLE
Use open router for ai bot

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -100,7 +100,7 @@ To build the entire repository and run the application, follow these steps:
 
     ```zsh
     cd ./packages/ai-bot
-    OPENAI_API_KEY=*** pnpm start
+    OPENROUTER_API_KEY=*** pnpm start
     ```
 
 ## Cleanup command

--- a/packages/ai-bot/README.md
+++ b/packages/ai-bot/README.md
@@ -20,10 +20,10 @@ If you are working on boxel development, you do not need to connect this up to O
 
 ### Access to GPT4
 
-You can get an OpenAI api key one from the staging parameter store or ask within the team.
-Set this as the `OPENAI_API_KEY` environment variable. Note that if you set this broadly (such as in your bashrc) this will be used by default for many other openai based tools.
+You can get an OpenRouter api key one from the staging parameter store or ask within the team.
+Set this as the `OPENROUTER_API_KEY` environment variable.
 
-    OPENAI_API_KEY="sk-..."
+    OPENROUTER_API_KEY="sk-..."
 
 ## Running
 

--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -46,12 +46,12 @@ class Assistant {
     let messages = getModifyPrompt(history, this.id, tools);
     if (tools.length === 0) {
       return this.openai.beta.chat.completions.stream({
-        model: 'gpt-4o',
+        model: 'openai/gpt-4o',
         messages: messages,
       });
     } else {
       return this.openai.beta.chat.completions.stream({
-        model: 'gpt-4o',
+        model: 'openai/gpt-4o',
         messages: messages,
         tools: tools,
         tool_choice: 'auto',

--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -33,7 +33,10 @@ class Assistant {
   id: string;
 
   constructor(client: MatrixClient, id: string) {
-    this.openai = new OpenAI();
+    this.openai = new OpenAI({
+      baseURL: 'https://openrouter.ai/api/v1', // We use openrouter so that we can track usage cost in $
+      apiKey: process.env.OPENROUTER_API_KEY,
+    });
     this.id = id;
     this.client = client;
   }


### PR DESCRIPTION
We are replacing the AI "backend" from OpenAI to OpenRouter so that we can track $ cost for our AI generations (needed for tracking user credit spending), and be more flexible about which AI model to use in case we'll want to change it later.

This depends on https://github.com/cardstack/infra/pull/561 - need to deploy that one first. 