### PR TITLE
Using atom format for team-member in task app

### DIFF
--- a/packages/experiments-realm/productivity/task.gts
+++ b/packages/experiments-realm/productivity/task.gts
@@ -232,17 +232,19 @@ export class TeamMember extends User {
 
   static atom = class Atom extends Component<typeof this> {
     <template>
-      <div class='assignee-display'>
-        <Avatar
-          class='avatar'
-          @userId={{@model.id}}
-          @displayName={{@model.name}}
-          @isReady={{true}}
-        />
-        <span class='assignee-name'>
-          {{@model.name}}
-        </span>
-      </div>
+      {{#if @model}}
+        <div class='assignee-display'>
+          <Avatar
+            class='avatar'
+            @userId={{@model.id}}
+            @displayName={{@model.name}}
+            @isReady={{true}}
+          />
+          <span class='assignee-name'>
+            {{@model.name}}
+          </span>
+        </div>
+      {{/if}}
       <style scoped>
         .assignee-display {
           display: flex;
@@ -339,13 +341,11 @@ class Fitted extends Component<typeof Task> {
       </div>
 
       <div class='card-info'>
-        {{#if @model.assignee}}
-          <@fields.assignee
-            class='card-assignee'
-            @format='atom'
-            @displayContainer={{false}}
-          />
-        {{/if}}
+        <@fields.assignee
+          class='card-assignee'
+          @format='atom'
+          @displayContainer={{false}}
+        />
 
         {{#if @model.tags.length}}
           <div class='card-tags'>
@@ -630,13 +630,11 @@ class TaskIsolated extends Component<typeof Task> {
       </div>
       <div class='task-meta'>
         <div class='row-1'>
-          {{#if @model.assignee}}
-            <@fields.assignee
-              class='task-assignee'
-              @format='atom'
-              @displayContainer={{false}}
-            />
-          {{/if}}
+          <@fields.assignee
+            class='task-assignee'
+            @format='atom'
+            @displayContainer={{false}}
+          />
           {{#if this.hasDateRange}}
             <div class='task-dates'>
               <Calendar width='14px' height='14px' class='calendar-icon' />
@@ -925,13 +923,11 @@ export class Task extends CardDef {
   static atom = class Atom extends Component<typeof this> {
     <template>
       <div class='task-atom'>
-        {{#if @model.assignee}}
-          <@fields.assignee
-            @format='atom'
-            @displayContainer={{false}}
-            class='task-assignee'
-          />
-        {{/if}}
+        <@fields.assignee
+          @format='atom'
+          @displayContainer={{false}}
+          class='task-assignee'
+        />
         <div class='task-title'>{{@model.taskName}}</div>
       </div>
       <style scoped>

--- a/packages/experiments-realm/productivity/task.gts
+++ b/packages/experiments-realm/productivity/task.gts
@@ -243,11 +243,7 @@ export class TeamMember extends User {
           {{@model.name}}
         </span>
       </div>
-
-      {{! can be changed to scoped if needed }}
-      {{! template-lint-disable require-scoped-style }}
-
-      <style>
+      <style scoped>
         .assignee-display {
           display: flex;
           align-items: center;
@@ -258,14 +254,14 @@ export class TeamMember extends User {
           width: fit-content;
         }
         .avatar {
-          --profile-avatar-icon-size: 26px;
+          --profile-avatar-icon-size: 20px;
           --profile-avatar-icon-border: 0px;
           flex-shrink: 0;
         }
         .assignee-name {
-          font-size: 12px;
-          font-weight: 500;
           padding: 0 var(--boxel-sp-xs) 0 var(--boxel-sp-xxxs);
+          font: 600 var(--boxel-font-xs);
+          letter-spacing: var(--boxel-lsp-sm);
           white-space: nowrap;
           overflow: hidden;
           text-overflow: ellipsis;
@@ -344,7 +340,11 @@ class Fitted extends Component<typeof Task> {
 
       <div class='card-info'>
         {{#if @model.assignee}}
-          <@fields.assignee @format='atom' />
+          <@fields.assignee
+            class='card-assignee'
+            @format='atom'
+            @displayContainer={{false}}
+          />
         {{/if}}
 
         {{#if @model.tags.length}}
@@ -376,8 +376,7 @@ class Fitted extends Component<typeof Task> {
       </div>
     </div>
 
-    {{! template-lint-disable require-scoped-style }}
-    <style>
+    <style scoped>
       .card-info {
         position: relative;
         display: flex;
@@ -386,23 +385,11 @@ class Fitted extends Component<typeof Task> {
         gap: var(--boxel-sp-xxs);
         overflow-x: hidden;
       }
-      .card-info .boundaries {
-        box-shadow: none;
-      }
-      .card-info .field-component-card.atom-format.display-container-true {
-        padding: 0;
-        background-color: transparent;
+      .card-assignee {
         width: auto;
         height: auto;
         overflow: unset;
       }
-      .card-assignee {
-        display: inline-flex;
-        align-items: center;
-        overflow: hidden;
-      }
-    </style>
-    <style scoped>
       .task-card {
         width: 100%;
         height: 100%;
@@ -644,17 +631,11 @@ class TaskIsolated extends Component<typeof Task> {
       <div class='task-meta'>
         <div class='row-1'>
           {{#if @model.assignee}}
-            <div class='task-assignee'>
-              <Avatar
-                class='avatar'
-                @userId={{@model.assignee.id}}
-                @displayName={{@model.assignee.name}}
-                @isReady={{true}}
-              />
-              <span class='assignee-name'>
-                {{@model.assignee.name}}
-              </span>
-            </div>
+            <@fields.assignee
+              class='task-assignee'
+              @format='atom'
+              @displayContainer={{false}}
+            />
           {{/if}}
           {{#if this.hasDateRange}}
             <div class='task-dates'>
@@ -741,11 +722,9 @@ class TaskIsolated extends Component<typeof Task> {
         gap: var(--boxel-sp-xs);
       }
       .task-assignee {
-        display: inline-flex;
-        align-items: center;
-        background-color: var(--boxel-200);
-        border-radius: 100px;
-        overflow: hidden;
+        width: auto;
+        height: auto;
+        overflow: unset;
       }
       .row-1 {
         display: flex;
@@ -947,14 +926,11 @@ export class Task extends CardDef {
     <template>
       <div class='task-atom'>
         {{#if @model.assignee}}
-          <div class='avatar-wrapper'>
-            <Avatar
-              @userId={{@model.assignee.id}}
-              @displayName={{@model.assignee.name}}
-              @isReady={{true}}
-              class='avatar'
-            />
-          </div>
+          <@fields.assignee
+            @format='atom'
+            @displayContainer={{false}}
+            class='task-assignee'
+          />
         {{/if}}
         <div class='task-title'>{{@model.taskName}}</div>
       </div>
@@ -964,11 +940,10 @@ export class Task extends CardDef {
           align-items: center;
           gap: var(--boxel-sp-xxxs);
         }
-        .avatar-wrapper {
-          display: inline-block;
-        }
-        .avatar {
-          --profile-avatar-icon-size: 20px;
+        .task-assignee {
+          width: auto;
+          height: auto;
+          overflow: unset;
         }
         .task-title {
           white-space: nowrap;


### PR DESCRIPTION
@lucaslyl @tintinthong Here is how you can use the atom format without sacrificing on the `scoped` attribute. You can set `@displayContainer` to false to hide the borders and add a classname on the field component to style it from where you consume it.

I noticed that the overlay design doesn't work so well on these. I think any improvements needed for the overlays should be handled by core team so that it works for all apps they're used in.