### PR TITLE
Hide sort options and admin data for author and category filters

### DIFF
--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -76,9 +76,10 @@ export * from './fetcher';
 export * from './scoped-css';
 export * from './utils';
 export * from './authorization-middleware';
+export * from './query';
 export { mergeRelationships } from './merge-relationships';
 export { makeLogDefinitions, logger } from './log';
-export { RealmPaths, Loader, type LocalPath, type Query };
+export { RealmPaths, Loader, type LocalPath };
 export { NotLoaded, isNotLoadedError } from './not-loaded';
 export {
   cardTypeDisplayName,


### PR DESCRIPTION
Since we have decided that Author and Category types won't have PublishDate and Status fields, hiding the Sort Menu and admin data for these types on Blog App. They will be displayed in alphabetical order of card title.

Author type:
<img width="1087" alt="author" src="https://github.com/user-attachments/assets/b1cc2607-47e2-4606-8c77-114c3db0c657">

Blog Post type (sort and info not hidden):
<img width="1097" alt="blog-post" src="https://github.com/user-attachments/assets/06b6b55b-b458-47d4-916b-7e8cc237a13c">