### PR TITLE
AI bot: Add a development start command that includes the local DB env vars

### DIFF
--- a/packages/ai-bot/package.json
+++ b/packages/ai-bot/package.json
@@ -23,7 +23,8 @@
   },
   "scripts": {
     "lint": "eslint . --cache --ext ts",
-    "start": "NODE_NO_WARNINGS=1 PGDATABASE=boxel PGPORT=5435 ts-node --transpileOnly main",
+    "start": "NODE_NO_WARNINGS=1 ts-node --transpileOnly main",
+    "start:development": "NODE_NO_WARNINGS=1 PGDATABASE=boxel PGPORT=5435 ts-node --transpileOnly main",
     "test": "NODE_NO_WARNINGS=1 qunit --require ts-node/register/transpile-only tests/index.ts",
     "get-chat": "NODE_NO_WARNINGS=1 ts-node --transpileOnly scripts/get_chat.ts"
   },


### PR DESCRIPTION
This fixes a bug in the AI bot where it wasn't able to write consumption cost to the DB, with an `ETIMEDOUT` error while trying to connect to the database.  

Hardcoding PG env vars in the `start` script was a mistake. This lead to a bug where the AI bot in staging/production wanted to make requests to RDS using `PGPORT` with the value of 5435 while the real port it should be using is the one configured in the parameter store (which is differs from `5435`). I fixed that and added a convenience script for starting the bot in development which uses the 5435 port.