### PR TITLE
Make button text color to be black in matrix email

### DIFF
--- a/packages/matrix/docker/synapse/templates/password_reset.html
+++ b/packages/matrix/docker/synapse/templates/password_reset.html
@@ -4,6 +4,6 @@
 <p style="margin: 0; margin-bottom: 15px;">If you've lost your password or wish to reset it, use the button below to get started.</p>
 <p style="margin: 0;">If you did not request a password reset, you can safely ignore this email. Only a person with access to your email can reset your account password.</p>
 <div style="margin-top: 35px; width: 100%;">
-  <a style="padding: 12px 0; font-weight: 600; font-size: 13px; letter-spacing: 0.025em; color: white; background-color: #03c4bf; border: 1px solid #03c4bf; border-radius: 100px; cursor: pointer; text-decoration: none; width:100%; display:block; text-align: center;" href="{{ link }}">Reset Password</a>
+  <a style="padding: 12px 0; font-weight: 600; font-size: 13px; letter-spacing: 0.025em; color: black; background-color: #00ffba; border: 1px solid #00ffba; border-radius: 100px; cursor: pointer; text-decoration: none; width:100%; display:block; text-align: center;" href="{{ link }}">Reset Password</a>
 </div>
 {% endblock %}

--- a/packages/matrix/docker/synapse/templates/password_reset_confirmation.html
+++ b/packages/matrix/docker/synapse/templates/password_reset_confirmation.html
@@ -10,7 +10,7 @@
   
       <p style="margin: 0;">You have requested to <strong>reset your Boxel account password</strong>. Click the link below to confirm this action. <br /><br />
           If you did not mean to do this, please close this page and your password will not be changed.</p>
-      <p><button type="submit" style="padding: 12px 0; font-family: 'Poppins', 'Open Sans', helvetica, 'Arial', sans-serif; font-weight: 600; font-size: 13px; letter-spacing: 0.025em; color: white; background-color: #00ffba; border: 1px solid #00ffba; border-radius: 100px; cursor: pointer; width:100%;">Confirm changing my password</button></p>
+      <p><button type="submit" style="padding: 12px 0; font-family: 'Poppins', 'Open Sans', helvetica, 'Arial', sans-serif; font-weight: 600; font-size: 13px; letter-spacing: 0.025em; color: black; background-color: #00ffba; border: 1px solid #00ffba; border-radius: 100px; cursor: pointer; width:100%;">Confirm changing my password</button></p>
     </form>
   </td>
 </tr>

--- a/packages/matrix/docker/synapse/templates/registration.html
+++ b/packages/matrix/docker/synapse/templates/registration.html
@@ -3,6 +3,6 @@
 {% block body %}
 <p style="margin: 0;">Please confirm that this is your e-mail address by clicking on the button below or use <a href="{{ link }}">this link</a>.</p>
 <div style="margin-top: 35px; width: 100%;">
-  <a style="padding: 12px 0; font-weight: 600; font-size: 13px; letter-spacing: 0.025em; color: white; background-color: #00ffba; border: 1px solid #00ffba; border-radius: 100px; cursor: pointer; text-decoration: none; width:100%; display:block; text-align: center;" href="{{ link }}">Verify Email</a>
+  <a style="padding: 12px 0; font-weight: 600; font-size: 13px; letter-spacing: 0.025em; color: black; background-color: #00ffba; border: 1px solid #00ffba; border-radius: 100px; cursor: pointer; text-decoration: none; width:100%; display:block; text-align: center;" href="{{ link }}">Verify Email</a>
 </div>
 {% endblock %}


### PR DESCRIPTION
TODO:

- [x] Push the updated email templates to staging and production.
- [x] Restart matrix server in staging and production.

<img width="588" alt="Screenshot 2024-11-26 at 17 45 04" src="https://github.com/user-attachments/assets/1b93bbb1-8a86-407d-9a72-b383f10a2bfa">
<img width="608" alt="Screenshot 2024-11-26 at 17 44 27" src="https://github.com/user-attachments/assets/b906628b-3381-4004-a3e5-955fda480ac5">
<img width="727" alt="Screenshot 2024-11-26 at 17 43 50" src="https://github.com/user-attachments/assets/0e5e92d5-6beb-4e1d-9ebd-a80d9589ba63">

