### PR TITLE
Add support for tracking errors in indexing identity map

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -268,6 +268,7 @@ export async function flushLogs() {
 
 export class IdentityContext {
   readonly identities = new Map<string, CardDef>();
+  readonly errors = new Set<string>();
 }
 
 type JSONAPIResource =

--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -231,7 +231,6 @@ export class CurrentRun {
     mtimes: LastModifiedTimes,
   ): Promise<void> {
     log.debug(`discovering invalidations in dir ${url.href}`);
-    console.log(`discovering invalidations in dir ${url.href}`);
     let ignorePatterns = await this.#reader.readFile(
       new URL('.gitignore', url),
     );
@@ -282,7 +281,6 @@ export class CurrentRun {
     }
     let start = Date.now();
     log.debug(`begin visiting file ${url.href}`);
-    console.log(`begin visiting file ${url.href}`);
     let localPath: string;
     try {
       localPath = this.#realmPaths.local(url);
@@ -346,9 +344,6 @@ export class CurrentRun {
       }
     }
     log.debug(`completed visiting file ${url.href} in ${Date.now() - start}ms`);
-    console.log(
-      `completed visiting file ${url.href} in ${Date.now() - start}ms`,
-    );
   }
 
   private async indexModule(url: URL, ref: TextFileRef): Promise<void> {
@@ -567,6 +562,7 @@ export class CurrentRun {
       });
     } else if (uncaughtError || typesMaybeError?.type === 'error') {
       let error: ErrorEntry;
+      identityContext.errors.add(instanceURL.href);
       if (uncaughtError) {
         error = {
           type: 'error',

--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -231,6 +231,7 @@ export class CurrentRun {
     mtimes: LastModifiedTimes,
   ): Promise<void> {
     log.debug(`discovering invalidations in dir ${url.href}`);
+    console.log(`discovering invalidations in dir ${url.href}`);
     let ignorePatterns = await this.#reader.readFile(
       new URL('.gitignore', url),
     );
@@ -281,6 +282,7 @@ export class CurrentRun {
     }
     let start = Date.now();
     log.debug(`begin visiting file ${url.href}`);
+    console.log(`begin visiting file ${url.href}`);
     let localPath: string;
     try {
       localPath = this.#realmPaths.local(url);
@@ -344,6 +346,9 @@ export class CurrentRun {
       }
     }
     log.debug(`completed visiting file ${url.href} in ${Date.now() - start}ms`);
+    console.log(
+      `completed visiting file ${url.href} in ${Date.now() - start}ms`,
+    );
   }
 
   private async indexModule(url: URL, ref: TextFileRef): Promise<void> {

--- a/packages/host/app/services/render-service.ts
+++ b/packages/host/app/services/render-service.ts
@@ -137,7 +137,7 @@ export default class RenderService extends Service {
         if (isCardError(err) && err.status !== 500 && notLoaded) {
           let links =
             typeof notLoaded.reference === 'string'
-              ? notLoaded.reference
+              ? [notLoaded.reference]
               : notLoaded.reference;
           for (let link of links) {
             if (identityContext.errors.has(link)) {

--- a/packages/host/app/services/render-service.ts
+++ b/packages/host/app/services/render-service.ts
@@ -135,13 +135,22 @@ export default class RenderService extends Service {
           isNotLoadedError(e),
         ) as NotLoaded | undefined;
         if (isCardError(err) && err.status !== 500 && notLoaded) {
-          let linkURL = new URL(`${notLoaded.reference}.json`);
-          if (realmPath.inRealm(linkURL)) {
-            await visit(linkURL, identityContext);
-          } else {
-            // in this case the instance we are linked to is a missing instance
-            // in an external realm.
-            throw err;
+          let links =
+            typeof notLoaded.reference === 'string'
+              ? notLoaded.reference
+              : notLoaded.reference;
+          for (let link of links) {
+            if (identityContext.errors.has(link)) {
+              throw err; // the linked card was already found to be in an error state
+            }
+            let linkURL = new URL(`${link}.json`);
+            if (realmPath.inRealm(linkURL)) {
+              await visit(linkURL, identityContext);
+            } else {
+              // in this case the instance we are linked to is a missing instance
+              // in an external realm.
+              throw err;
+            }
           }
         } else {
           throw err;

--- a/packages/realm-server/tests/cards/FamilyPhotoCard/265bb8ca-4289-43e2-8a3d-dd1a73c1b024.json
+++ b/packages/realm-server/tests/cards/FamilyPhotoCard/265bb8ca-4289-43e2-8a3d-dd1a73c1b024.json
@@ -1,14 +1,6 @@
 {
   "data": {
     "type": "card",
-    "attributes": {
-      "photoUrl": "http://lukemelia.com/photo-wall/IMG_6618.PNG",
-      "widthInches": 10,
-      "heightInches": 13,
-      "title": "Baby Chiara",
-      "description": "Chiara as a baby model",
-      "thumbnailURL": null
-    },
     "relationships": {
       "taggedPeople.0": {
         "links": {

--- a/packages/realm-server/tests/cards/FamilyPhotoCard/265bb8ca-4289-43e2-8a3d-dd1a73c1b024.json
+++ b/packages/realm-server/tests/cards/FamilyPhotoCard/265bb8ca-4289-43e2-8a3d-dd1a73c1b024.json
@@ -1,0 +1,26 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "photoUrl": "http://lukemelia.com/photo-wall/IMG_6618.PNG",
+      "widthInches": 10,
+      "heightInches": 13,
+      "title": "Baby Chiara",
+      "description": "Chiara as a baby model",
+      "thumbnailURL": null
+    },
+    "relationships": {
+      "taggedPeople.0": {
+        "links": {
+          "self": "../PersonCard/bae37f39-8ee5-4072-a82a-85ef8ec15d6b"
+        }
+      }
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../family_photo_card",
+        "name": "FamilyPhotoCard"
+      }
+    }
+  }
+}

--- a/packages/realm-server/tests/cards/FamilyPhotoCard/9be794c4-fb87-4d44-973b-482c4ef0c1c5.json
+++ b/packages/realm-server/tests/cards/FamilyPhotoCard/9be794c4-fb87-4d44-973b-482c4ef0c1c5.json
@@ -1,14 +1,6 @@
 {
   "data": {
     "type": "card",
-    "attributes": {
-      "photoUrl": "https://lukemelia.com/IMG_6615.jpg",
-      "widthInches": 10,
-      "heightInches": 8,
-      "title": "Baby Sophie and parents",
-      "description": "Black & white pick of infant sophie in between her parents",
-      "thumbnailURL": null
-    },
     "relationships": {
       "taggedPeople.0": {
         "links": {

--- a/packages/realm-server/tests/cards/FamilyPhotoCard/9be794c4-fb87-4d44-973b-482c4ef0c1c5.json
+++ b/packages/realm-server/tests/cards/FamilyPhotoCard/9be794c4-fb87-4d44-973b-482c4ef0c1c5.json
@@ -1,0 +1,36 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "photoUrl": "https://lukemelia.com/IMG_6615.jpg",
+      "widthInches": 10,
+      "heightInches": 8,
+      "title": "Baby Sophie and parents",
+      "description": "Black & white pick of infant sophie in between her parents",
+      "thumbnailURL": null
+    },
+    "relationships": {
+      "taggedPeople.0": {
+        "links": {
+          "self": "../PersonCard/936d9784-5e80-4fb5-88e2-8d29a07d07db"
+        }
+      },
+      "taggedPeople.1": {
+        "links": {
+          "self": "../PersonCard/19c90c40-1df9-42e2-8f85-795229a4bc7c"
+        }
+      },
+      "taggedPeople.2": {
+        "links": {
+          "self": "../PersonCard/50812f7d-fa48-46ed-a45d-548cb254cf48"
+        }
+      }
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../family_photo_card",
+        "name": "FamilyPhotoCard"
+      }
+    }
+  }
+}

--- a/packages/realm-server/tests/cards/PersonCard/19c90c40-1df9-42e2-8f85-795229a4bc7c.json
+++ b/packages/realm-server/tests/cards/PersonCard/19c90c40-1df9-42e2-8f85-795229a4bc7c.json
@@ -2,7 +2,7 @@
   "data": {
     "type": "card",
     "attributes": {
-      "name": "Wonki Kim",
+      "name": "Mango",
       "description": null,
       "thumbnailURL": null
     },

--- a/packages/realm-server/tests/cards/PersonCard/19c90c40-1df9-42e2-8f85-795229a4bc7c.json
+++ b/packages/realm-server/tests/cards/PersonCard/19c90c40-1df9-42e2-8f85-795229a4bc7c.json
@@ -1,0 +1,16 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "name": "Wonki Kim",
+      "description": null,
+      "thumbnailURL": null
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../person-with-error",
+        "name": "PersonCard"
+      }
+    }
+  }
+}

--- a/packages/realm-server/tests/cards/PersonCard/50812f7d-fa48-46ed-a45d-548cb254cf48.json
+++ b/packages/realm-server/tests/cards/PersonCard/50812f7d-fa48-46ed-a45d-548cb254cf48.json
@@ -1,0 +1,16 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "name": "Eunice Kim",
+      "description": null,
+      "thumbnailURL": null
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../person-with-error",
+        "name": "PersonCard"
+      }
+    }
+  }
+}

--- a/packages/realm-server/tests/cards/PersonCard/50812f7d-fa48-46ed-a45d-548cb254cf48.json
+++ b/packages/realm-server/tests/cards/PersonCard/50812f7d-fa48-46ed-a45d-548cb254cf48.json
@@ -2,7 +2,7 @@
   "data": {
     "type": "card",
     "attributes": {
-      "name": "Eunice Kim",
+      "name": "Paper",
       "description": null,
       "thumbnailURL": null
     },

--- a/packages/realm-server/tests/cards/PersonCard/936d9784-5e80-4fb5-88e2-8d29a07d07db.json
+++ b/packages/realm-server/tests/cards/PersonCard/936d9784-5e80-4fb5-88e2-8d29a07d07db.json
@@ -1,0 +1,16 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "name": "Sophie Kim",
+      "description": null,
+      "thumbnailURL": null
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../person-with-error",
+        "name": "PersonCard"
+      }
+    }
+  }
+}

--- a/packages/realm-server/tests/cards/PersonCard/936d9784-5e80-4fb5-88e2-8d29a07d07db.json
+++ b/packages/realm-server/tests/cards/PersonCard/936d9784-5e80-4fb5-88e2-8d29a07d07db.json
@@ -2,7 +2,7 @@
   "data": {
     "type": "card",
     "attributes": {
-      "name": "Sophie Kim",
+      "name": "Van Gogh",
       "description": null,
       "thumbnailURL": null
     },

--- a/packages/realm-server/tests/cards/PersonCard/bae37f39-8ee5-4072-a82a-85ef8ec15d6b.json
+++ b/packages/realm-server/tests/cards/PersonCard/bae37f39-8ee5-4072-a82a-85ef8ec15d6b.json
@@ -1,0 +1,16 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "name": "Chiara Kimelia",
+      "description": null,
+      "thumbnailURL": null
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../person-with-error",
+        "name": "PersonCard"
+      }
+    }
+  }
+}

--- a/packages/realm-server/tests/cards/PersonCard/bae37f39-8ee5-4072-a82a-85ef8ec15d6b.json
+++ b/packages/realm-server/tests/cards/PersonCard/bae37f39-8ee5-4072-a82a-85ef8ec15d6b.json
@@ -2,7 +2,7 @@
   "data": {
     "type": "card",
     "attributes": {
-      "name": "Chiara Kimelia",
+      "name": "Jade",
       "description": null,
       "thumbnailURL": null
     },

--- a/packages/realm-server/tests/cards/family_photo_card.gts
+++ b/packages/realm-server/tests/cards/family_photo_card.gts
@@ -1,0 +1,57 @@
+import {
+  contains,
+  linksToMany,
+  field,
+  CardDef,
+  Component,
+} from 'https://cardstack.com/base/card-api';
+import StringField from 'https://cardstack.com/base/string';
+import NumberField from 'https://cardstack.com/base/number';
+import { PersonCard } from './person-with-error';
+
+export class FamilyPhotoCard extends CardDef {
+  static displayName = 'Family Photo Card';
+
+  // URL of the photo
+  @field photoUrl = contains(StringField, {
+    description: 'URL of the photo',
+  });
+  @field thumbnailUrl = contains(StringField, {
+    computeVia: function (this: FamilyPhotoCard) {
+      return this.photoUrl;
+    },
+  });
+
+  // Tags: People linked to this photo
+  @field taggedPeople = linksToMany(PersonCard);
+  @field widthInches = contains(NumberField);
+  @field heightInches = contains(NumberField);
+
+  static isolated = class Isolated extends Component<typeof this> {
+    <template>
+      <style>
+        .photo {
+          max-width: 100%;
+          border: 2px solid #ccc;
+          border-radius: 5px;
+          display: block;
+        }
+      </style>
+      <div>
+        <div>
+          Dimensions:
+          {{@model.widthInches}}" by
+          {{@model.heightInches}}"</div>
+        <div>Tagged People:</div>
+        <ul>
+          {{#each @model.taggedPeople as |person|}}
+            <li>{{person.name}}</li>
+          {{/each}}
+        </ul>
+      </div>
+      <img src={{@model.photoUrl}} alt='Photo' class='photo' />
+    </template>
+  };
+
+  static embedded = this.isolated;
+}

--- a/packages/realm-server/tests/cards/person-with-error.gts
+++ b/packages/realm-server/tests/cards/person-with-error.gts
@@ -24,14 +24,6 @@ export class PersonCard extends CardDef {
     },
   });
 
-  // Total photos they appear in (computed)
-  //  @field totalPhotos = contains(NumberField, {
-  //    computeVia: function (this: PersonCard) {
-  //     // Links to photos are dynamically counted
-  //      return this.linksToMany(PhotoCard).length;
-  //    },
-  //  });
-
   static isolated = class Isolated extends Component<typeof this> {
     get query() {
       return {
@@ -40,7 +32,6 @@ export class PersonCard extends CardDef {
             // @ts-expect-error "import.meta" is actually fine to here since
             //  were actually transpile this module in our realm server
             module: new URL('./family_photo_card.gts', import.meta.url).href,
-            // module: //'http://localhost:4201/user/personal/family_photo_card.gts',
             name: 'FamilyPhotoCard',
           },
         },

--- a/packages/realm-server/tests/cards/person-with-error.gts
+++ b/packages/realm-server/tests/cards/person-with-error.gts
@@ -1,0 +1,101 @@
+import {
+  CardDef,
+  Component,
+  field,
+  contains,
+  realmURL,
+  StringField,
+} from 'https://cardstack.com/base/card-api';
+
+function removeFileExtension(cardUrl: string) {
+  return cardUrl.replace(/\.[^/.]+$/, '');
+}
+
+export class PersonCard extends CardDef {
+  static displayName = 'Person';
+
+  // Name of the person
+  @field name = contains(StringField, {
+    description: 'Name of the person',
+  });
+  @field title = contains(StringField, {
+    computeVia: function (this: PersonCard) {
+      return this.name;
+    },
+  });
+
+  // Total photos they appear in (computed)
+  //  @field totalPhotos = contains(NumberField, {
+  //    computeVia: function (this: PersonCard) {
+  //     // Links to photos are dynamically counted
+  //      return this.linksToMany(PhotoCard).length;
+  //    },
+  //  });
+
+  static isolated = class Isolated extends Component<typeof this> {
+    get query() {
+      return {
+        filter: {
+          type: {
+            // @ts-expect-error "import.meta" is actually fine to here since
+            //  were actually transpile this module in our realm server
+            module: new URL('./family_photo_card.gts', import.meta.url).href,
+            // module: //'http://localhost:4201/user/personal/family_photo_card.gts',
+            name: 'FamilyPhotoCard',
+          },
+        },
+      };
+    }
+    get realms() {
+      return [this.args.model[realmURL]];
+    }
+    <template>
+      <style>
+        .person {
+          font-weight: bold;
+        }
+      </style>
+      <div>
+        <span class='person'>{{@model.name}}</span>
+      </div>
+      {{#let
+        (component @context.prerenderedCardSearchComponent)
+        as |PrerenderedCardSearch|
+      }}
+        <PrerenderedCardSearch
+          @query={{this.query}}
+          @format='fitted'
+          @realms={{this.realms}}
+        >
+
+          <:loading>
+            Loading...
+          </:loading>
+          <:response as |cards|>
+            {{#each cards as |card|}}
+              <li
+                class='card'
+                {{@context.cardComponentModifier
+                  cardId=card.url
+                  format='data'
+                  fieldType=undefined
+                  fieldName=undefined
+                }}
+                {{! In order to support scrolling cards into view we use a selector that is not pruned out in production builds }}
+                data-cards-grid-item={{removeFileExtension card.url}}
+              >
+                {{! @glint-ignore the error in this module is that 'CardContainer' is not imported !}}
+                <CardContainer @displayBoundaries='true'>
+                  {{card.component}}
+                  {{! @glint-ignore the error is this module is that 'CardContainer' is not imported !}}
+                </CardContainer>
+              </li>
+            {{/each}}
+          </:response>
+        </PrerenderedCardSearch>
+      {{/let}}
+    </template>
+  };
+
+  static embedded = this.isolated;
+}

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -4682,6 +4682,22 @@ module('Realm server with realm mounted at the origin', function (hooks) {
                 kind: 'file',
               },
             },
+            'family_photo_card.gts': {
+              links: {
+                related: `${testRealmHref}family_photo_card.gts`,
+              },
+              meta: {
+                kind: 'file',
+              },
+            },
+            'FamilyPhotoCard/': {
+              links: {
+                related: `${testRealmHref}FamilyPhotoCard/`,
+              },
+              meta: {
+                kind: 'directory',
+              },
+            },
             'friend.gts': {
               links: {
                 related: `${testRealmHref}friend.gts`,
@@ -4746,6 +4762,14 @@ module('Realm server with realm mounted at the origin', function (hooks) {
                 kind: 'file',
               },
             },
+            'person-with-error.gts': {
+              links: {
+                related: `${testRealmHref}person-with-error.gts`,
+              },
+              meta: {
+                kind: 'file',
+              },
+            },
             'person.gts': {
               links: {
                 related: `${testRealmHref}person.gts`,
@@ -4760,6 +4784,14 @@ module('Realm server with realm mounted at the origin', function (hooks) {
               },
               meta: {
                 kind: 'file',
+              },
+            },
+            'PersonCard/': {
+              links: {
+                related: `${testRealmHref}PersonCard/`,
+              },
+              meta: {
+                kind: 'directory',
               },
             },
             'query-test-cards.gts': {


### PR DESCRIPTION
This PR addresses a cycle that was discovered in staging. The issue is that the identity map that we use during indexing is blind to error documents--it only recognizes running cards. Because of this, it is possible to introduce a cycle in our indexer using a strategically placed error document. In this PR we provide visibility into the instances that are in an error state as part of our identity map so that we can skip over trying to visit them when we know the instance is in an error state.

I had difficulty isolating the specific logic that triggered the cycle in our test realms that spin up within the each test--but i could absolutely see it in our actual realm. so i just used the actual files that caused the cycle in staging in our node-test realm. When the fix is not working, the realm server will hang from the cycle. the fact that the realm server starts up proves that the issue is fixed.