### PR TITLE
Add endpoint for returning stripe links

### DIFF
--- a/packages/realm-server/handlers/handle-stripe-links.ts
+++ b/packages/realm-server/handlers/handle-stripe-links.ts
@@ -1,0 +1,124 @@
+import Koa from 'koa';
+import { setContextResponse } from '../middleware';
+
+import Stripe from 'stripe';
+import { SupportedMimeType } from '@cardstack/runtime-common';
+
+type CustomerPortalLink = {
+  type: 'customer-portal-link';
+  id: 'customer-portal-link';
+  attributes: {
+    url: string;
+  };
+};
+
+type FreePlanPaymentLink = {
+  type: 'free-plan-payment-link';
+  id: 'free-plan-payment-link';
+  attributes: {
+    url: string;
+  };
+};
+
+type ExtraCreditsPaymentLink = {
+  type: 'extra-credits-payment-link';
+  id: `extra-credits-payment-link-${number}`;
+  attributes: {
+    url: string;
+    metadata: {
+      creditReloadAmount: number;
+    };
+  };
+};
+
+type PaymentLink =
+  | CustomerPortalLink
+  | FreePlanPaymentLink
+  | ExtraCreditsPaymentLink;
+
+interface APIResponse {
+  data: PaymentLink[];
+}
+
+export default function handleStripeLinksRequest(): (
+  ctxt: Koa.Context,
+  next: Koa.Next,
+) => Promise<void> {
+  return async function (ctxt: Koa.Context, _next: Koa.Next) {
+    let stripe = new Stripe(process.env.STRIPE_API_KEY!);
+
+    let configurations = await stripe.billingPortal.configurations.list();
+    if (configurations.data.length !== 1) {
+      throw new Error('Expected exactly one billing portal configuration');
+    }
+
+    let configuration = configurations.data[0];
+    let customerPortalLink = configuration.login_page.url;
+
+    if (!customerPortalLink) {
+      throw new Error(
+        'Expected customer portal link in the billing portal configuration',
+      );
+    }
+
+    let paymentLinks = await stripe.paymentLinks.list({
+      active: true,
+    });
+
+    let freePlanPaymentLink = paymentLinks.data.find(
+      (link) => link.metadata?.free_plan === 'true',
+    );
+
+    if (!freePlanPaymentLink) {
+      throw new Error(
+        'Expected free plan payment link with metadata.free_plan=true but none found',
+      );
+    }
+
+    let creditTopUpPaymentLinks = paymentLinks.data.filter(
+      (link) => !!link.metadata?.credit_reload_amount,
+    );
+
+    if (creditTopUpPaymentLinks.length !== 3) {
+      throw new Error(
+        'Expected exactly three credit top up payment links with metadata.credit_reload_amount defined but none found',
+      );
+    }
+
+    let response = {
+      data: [
+        {
+          type: 'customer-portal-link',
+          id: 'customer-portal-link',
+          attributes: {
+            url: customerPortalLink,
+          },
+        },
+        {
+          type: 'free-plan-payment-link',
+          id: 'free-plan-payment-link',
+          attributes: {
+            url: freePlanPaymentLink.url,
+          },
+        },
+        ...creditTopUpPaymentLinks.map((link, index) => ({
+          type: 'extra-credits-payment-link',
+          id: `extra-credits-payment-link-${index}`,
+          attributes: {
+            url: link.url,
+            metadata: {
+              creditReloadAmount: parseInt(link.metadata.credit_reload_amount),
+            },
+          },
+        })),
+      ],
+    } as APIResponse;
+
+    return setContextResponse(
+      ctxt,
+      new Response(JSON.stringify(response), {
+        headers: { 'content-type': SupportedMimeType.JSONAPI },
+      }),
+    );
+  };
+}

--- a/packages/realm-server/handlers/handle-stripe-links.ts
+++ b/packages/realm-server/handlers/handle-stripe-links.ts
@@ -81,7 +81,7 @@ export default function handleStripeLinksRequest(): (
 
     if (creditTopUpPaymentLinks.length !== 3) {
       throw new Error(
-        'Expected exactly three credit top up payment links with metadata.credit_reload_amount defined but none found',
+        `Expected exactly three credit top up payment links with metadata.credit_reload_amount defined but ${creditTopUpPaymentLinks.length} found`,
       );
     }
 

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -51,7 +51,7 @@ export function createRoutes(args: CreateRoutesArgs) {
     jwtMiddleware(args.secretSeed),
     handleFetchUserRequest(args),
   );
-  router.get('/_stripe-links', handleStripeLinksRequest(args));
+  router.get('/_stripe-links', handleStripeLinksRequest());
 
   return router.routes();
 }

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -8,6 +8,7 @@ import handleFetchUserRequest from './handlers/handle-fetch-user';
 import handleStripeWebhookRequest from './handlers/handle-stripe-webhook';
 import { healthCheck, jwtMiddleware, livenessCheck } from './middleware';
 import Koa from 'koa';
+import handleStripeLinksRequest from './handlers/handle-stripe-links';
 
 export type CreateRoutesArgs = {
   dbAdapter: DBAdapter;
@@ -50,6 +51,7 @@ export function createRoutes(args: CreateRoutesArgs) {
     jwtMiddleware(args.secretSeed),
     handleFetchUserRequest(args),
   );
+  router.get('/_stripe-links', handleStripeLinksRequest(args));
 
   return router.routes();
 }


### PR DESCRIPTION
The host app will need the following links that lead to Stripe selling pages:

1. Stripe customer portal link (here users will be able to login into Stripe and manage their Boxel subscription)
2. Free plan payment link (this is used for the initial user signup flow where users enter their payment method and subscribe to a free plan, and are redirected back to Boxel)
3. Credit top up links (users will use this to buy additional credits)

I considered adding a JWT requirement for this but since these are public links I decided to keep this endpoint public too. 

Here is an example of the output:

```json
{
  "data": [
    {
      "type": "customer-portal-link",
      "id": "customer-portal-link",
      "attributes": {
        "url": "https://billing.stripe.com/p/login/test_cN216h3BlbML3FS144"
      }
    },
    {
      "type": "free-plan-payment-link",
      "id": "free-plan-payment-link",
      "attributes": {
        "url": "https://buy.stripe.com/test_8wM5mgdO36sheFq3cd"
      }
    },
    {
      "type": "extra-credits-payment-link",
      "id": "extra-credits-payment-link-0",
      "attributes": {
        "url": "https://buy.stripe.com/test_bIY01W11heYNeFqbIO",
        "metadata": {
          "creditReloadAmount": 15000
        }
      }
    },
    {
      "type": "extra-credits-payment-link",
      "id": "extra-credits-payment-link-1",
      "attributes": {
        "url": "https://buy.stripe.com/test_bIY5mg6lBdUJ68U4gl",
        "metadata": {
          "creditReloadAmount": 80000
        }
      }
    },
    {
      "type": "extra-credits-payment-link",
      "id": "extra-credits-payment-link-2",
      "attributes": {
        "url": "https://buy.stripe.com/test_fZebKE4dt03TcxieUY",
        "metadata": {
          "creditReloadAmount": 1250
        }
      }
    }
  ]
}
```