### PR TITLE
host: Fix SVG width typo

### DIFF
--- a/packages/host/app/components/matrix/payment-setup.gts
+++ b/packages/host/app/components/matrix/payment-setup.gts
@@ -130,10 +130,7 @@ export default class PaymentSetup extends Component<Signature> {
               target={{if (eq environment 'development') '_blank' '_self'}}
             >
               Set up Secure Payment Method
-              <span class='lock-icon'><Lock
-                  width='16cpx'
-                  height='16px'
-                /></span>
+              <span class='lock-icon'><Lock width='16px' height='16px' /></span>
             </BoxelButton>
 
             <p class='payment-note'>


### PR DESCRIPTION
I noticed this in the console in production:

<img width="408" alt="Boxel 2024-11-27 14-57-27" src="https://github.com/user-attachments/assets/8037a69c-8b21-4ce0-9f36-3479022b12e4">
