### PR TITLE
Move search icon placement to always be on the LEFT

### DIFF
--- a/packages/boxel-ui/addon/src/components/input/index.gts
+++ b/packages/boxel-ui/addon/src/components/input/index.gts
@@ -13,6 +13,7 @@ import IconSearch from '../../icons/icon-search.gts';
 import LoadingIndicator from '../../icons/loading-indicator.gts';
 import SuccessBordered from '../../icons/success-bordered.gts';
 import type { Icon } from '../../icons/types.ts';
+import cssVar from '../../helpers/css-var.ts';
 
 type Values<T> = T[keyof T];
 
@@ -185,6 +186,9 @@ export default class BoxelInput extends Component<Signature> {
               'search-icon-container'
               has-validation=this.hasValidation
             }}
+            style={{cssVar
+              search-input-icon-color='var(--boxel-input-search-icon-color)'
+            }}
           >
             <IconSearch class='search-icon' width='20' height='20' />
           </div>
@@ -301,10 +305,11 @@ export default class BoxelInput extends Component<Signature> {
         --boxel-form-control-border-radius: var(--boxel-border-radius-xl)
           var(--boxel-border-radius-xl) 0 0;
       }
+      .search-icon {
+        --icon-color: var(--search-input-icon-color, var(--boxel-highlight));
+      }
 
       .search-icon-container {
-        --icon-color: var(--boxel-highlight);
-
         grid-area: pre-icon;
 
         display: flex;

--- a/packages/boxel-ui/addon/src/components/input/index.gts
+++ b/packages/boxel-ui/addon/src/components/input/index.gts
@@ -13,6 +13,7 @@ import IconSearch from '../../icons/icon-search.gts';
 import LoadingIndicator from '../../icons/loading-indicator.gts';
 import SuccessBordered from '../../icons/success-bordered.gts';
 import type { Icon } from '../../icons/types.ts';
+import cssVar from '../../helpers/css-var.ts';
 
 type Values<T> = T[keyof T];
 
@@ -185,6 +186,9 @@ export default class BoxelInput extends Component<Signature> {
               'search-icon-container'
               has-validation=this.hasValidation
             }}
+            style={{cssVar
+              search-input-icon-color='var(--boxel-input-search-icon-color)'
+            }}
           >
             <IconSearch class='search-icon' width='20' height='20' />
           </div>
@@ -302,7 +306,11 @@ export default class BoxelInput extends Component<Signature> {
           var(--boxel-border-radius-xl) 0 0;
       }
 
-      .search-icon-container {
+      <<<<<<< Updated upstream ======= .search-icon {
+        --icon-color: var(--search-input-icon-color);
+      }
+
+      >>>>>>>Stashed changes .search-icon-container {
         --icon-color: var(--boxel-highlight);
 
         grid-area: pre-icon;

--- a/packages/boxel-ui/addon/src/components/input/index.gts
+++ b/packages/boxel-ui/addon/src/components/input/index.gts
@@ -4,7 +4,6 @@ import { guidFor } from '@ember/object/internals';
 import Component from '@glimmer/component';
 
 import cn from '../../helpers/cn.ts';
-import cssVar from '../../helpers/css-var.ts';
 import element from '../../helpers/element.ts';
 import optional from '../../helpers/optional.ts';
 import pick from '../../helpers/pick.ts';
@@ -186,9 +185,6 @@ export default class BoxelInput extends Component<Signature> {
               'search-icon-container'
               has-validation=this.hasValidation
             }}
-            style={{cssVar
-              search-input-icon-color='var(--boxel-input-search-icon-color)'
-            }}
           >
             <IconSearch class='search-icon' width='20' height='20' />
           </div>
@@ -306,11 +302,7 @@ export default class BoxelInput extends Component<Signature> {
           var(--boxel-border-radius-xl) 0 0;
       }
 
-      <<<<<<< Updated upstream ======= .search-icon {
-        --icon-color: var(--search-input-icon-color);
-      }
-
-      >>>>>>>Stashed changes .search-icon-container {
+      .search-icon-container {
         --icon-color: var(--boxel-highlight);
 
         grid-area: pre-icon;

--- a/packages/boxel-ui/addon/src/components/input/index.gts
+++ b/packages/boxel-ui/addon/src/components/input/index.gts
@@ -4,6 +4,7 @@ import { guidFor } from '@ember/object/internals';
 import Component from '@glimmer/component';
 
 import cn from '../../helpers/cn.ts';
+import cssVar from '../../helpers/css-var.ts';
 import element from '../../helpers/element.ts';
 import optional from '../../helpers/optional.ts';
 import pick from '../../helpers/pick.ts';
@@ -13,7 +14,6 @@ import IconSearch from '../../icons/icon-search.gts';
 import LoadingIndicator from '../../icons/loading-indicator.gts';
 import SuccessBordered from '../../icons/success-bordered.gts';
 import type { Icon } from '../../icons/types.ts';
-import cssVar from '../../helpers/css-var.ts';
 
 type Values<T> = T[keyof T];
 

--- a/packages/boxel-ui/addon/src/components/input/index.gts
+++ b/packages/boxel-ui/addon/src/components/input/index.gts
@@ -292,9 +292,7 @@ export default class BoxelInput extends Component<Signature> {
         padding-top: var(--boxel-sp-xxxs);
         padding-right: var(--boxel-sp-xl);
         padding-bottom: var(--boxel-sp-xxxs);
-      }
-
-      .search.has-validation {
+        /* to account for the icon being on the left */
         padding-right: unset;
         padding-left: var(--boxel-sp-xxl); /* leave room for icon */
       }
@@ -307,16 +305,12 @@ export default class BoxelInput extends Component<Signature> {
       .search-icon-container {
         --icon-color: var(--boxel-highlight);
 
-        grid-area: post-icon;
+        grid-area: pre-icon;
 
         display: flex;
         height: 100%;
         align-items: center;
         justify-content: center;
-      }
-
-      .search-icon-container.has-validation {
-        grid-area: pre-icon;
       }
 
       .validation-icon-container {


### PR DESCRIPTION
**Current search icon placement**


<img width="324" alt="Screenshot 2024-11-28 at 10 03 26" src="https://github.com/user-attachments/assets/a0b5426d-c31d-4595-8009-5ecb057d6343">
<img width="1091" alt="Screenshot 2024-11-28 at 10 03 12" src="https://github.com/user-attachments/assets/190bc431-d8c2-4707-8c83-ef73cefd99ca">

With validation (moves to the left)

<img width="1463" alt="Screenshot 2024-11-28 at 10 04 52" src="https://github.com/user-attachments/assets/f9867749-88ab-4225-a971-f52d520ab8c4">
<img width="1435" alt="Screenshot 2024-11-28 at 10 03 36" src="https://github.com/user-attachments/assets/726c2808-282b-4d2e-8b0f-d9cc63b3d070">

**New search icon placement**

ALWAYS ON THE LEFT