### PR TITLE
Fix admin data

### DIFF
--- a/packages/experiments-realm/blog-app.gts
+++ b/packages/experiments-realm/blog-app.gts
@@ -236,11 +236,11 @@ class BlogAppTemplate extends Component<typeof BlogApp> {
               @query={{this.query}}
               @realms={{this.realms}}
             >
-              <:adminData as |card|>
+              <:meta as |card|>
                 {{#if this.showAdminData}}
                   <BlogAdminData @cardId={{card.url}} />
                 {{/if}}
-              </:adminData>
+              </:meta>
             </CardsGrid>
           </div>
         {{/if}}

--- a/packages/experiments-realm/components/grid.gts
+++ b/packages/experiments-realm/components/grid.gts
@@ -60,8 +60,10 @@ export class CardsGrid extends GlimmerComponent<CardsGridSignature> {
                     <card.component />
                   </CardContainer>
                 </div>
-                {{#if (has-block 'meta')}}
-                  {{yield card to='meta'}}
+                {{#if (eq @selectedView 'card')}}
+                  {{#if (has-block 'meta')}}
+                    {{yield card to='meta'}}
+                  {{/if}}
                 {{/if}}
               </li>
             {{/each}}

--- a/packages/experiments-realm/components/grid.gts
+++ b/packages/experiments-realm/components/grid.gts
@@ -45,21 +45,18 @@ export class CardsGrid extends GlimmerComponent<CardsGridSignature> {
           <:response as |cards|>
             {{#each cards key='url' as |card|}}
               <li class='{{@selectedView}}-view-container'>
-                <div
+                <CardContainer
                   {{@context.cardComponentModifier
                     cardId=card.url
                     format='data'
                     fieldType=undefined
                     fieldName=undefined
                   }}
+                  class='card'
+                  @displayBoundaries={{not (eq @selectedView 'card')}}
                 >
-                  <CardContainer
-                    class='card'
-                    @displayBoundaries={{not (eq @selectedView 'card')}}
-                  >
-                    <card.component />
-                  </CardContainer>
-                </div>
+                  <card.component />
+                </CardContainer>
                 {{#if (eq @selectedView 'card')}}
                   {{#if (has-block 'meta')}}
                     {{yield card to='meta'}}

--- a/packages/experiments-realm/components/grid.gts
+++ b/packages/experiments-realm/components/grid.gts
@@ -44,22 +44,25 @@ export class CardsGrid extends GlimmerComponent<CardsGridSignature> {
           </:loading>
           <:response as |cards|>
             {{#each cards key='url' as |card|}}
-              <li
-                class='{{@selectedView}}-view-container'
-                {{@context.cardComponentModifier
-                  cardId=card.url
-                  format='data'
-                  fieldType=undefined
-                  fieldName=undefined
-                }}
-              >
-                <CardContainer
-                  class='card'
-                  @displayBoundaries={{not (eq @selectedView 'card')}}
+              <li class='{{@selectedView}}-view-container'>
+                <div
+                  {{@context.cardComponentModifier
+                    cardId=card.url
+                    format='data'
+                    fieldType=undefined
+                    fieldName=undefined
+                  }}
                 >
-                  <card.component />
-                </CardContainer>
-                {{yield card to='adminData'}}
+                  <CardContainer
+                    class='card'
+                    @displayBoundaries={{not (eq @selectedView 'card')}}
+                  >
+                    <card.component />
+                  </CardContainer>
+                </div>
+                {{#if (has-block 'adminData')}}
+                  {{yield card to='adminData'}}
+                {{/if}}
               </li>
             {{/each}}
           </:response>

--- a/packages/experiments-realm/components/grid.gts
+++ b/packages/experiments-realm/components/grid.gts
@@ -23,7 +23,7 @@ interface CardsGridSignature {
     format: Format;
   };
   Blocks: {
-    adminData: [card: PrerenderedCard];
+    meta: [card: PrerenderedCard];
   };
   Element: HTMLElement;
 }
@@ -60,8 +60,8 @@ export class CardsGrid extends GlimmerComponent<CardsGridSignature> {
                     <card.component />
                   </CardContainer>
                 </div>
-                {{#if (has-block 'adminData')}}
-                  {{yield card to='adminData'}}
+                {{#if (has-block 'meta')}}
+                  {{yield card to='meta'}}
                 {{/if}}
               </li>
             {{/each}}


### PR DESCRIPTION
**Problem**

When not having admin data ie embedded in crm, the overlay will span the empty space provided for admin data. 

**Solution**

Make admin data as an allocated slot of the grid that places meta/adminData next to the card. there shudn be overlay over the card, otherwise, that wud just reside inside of the embedded template itself



