### PR TITLE
Make sure legacy users have a users table entry (fixes stripe subscribe failure)

### DIFF
--- a/packages/billing/stripe-webhook-handlers/checkout-session-completed.ts
+++ b/packages/billing/stripe-webhook-handlers/checkout-session-completed.ts
@@ -34,14 +34,15 @@ export async function handleCheckoutSessionCompleted(
     if (matrixUserName) {
       // The matrix user id was encoded to be alphanumeric by replacing + with - and / with _
       // Now we need to reverse that encoding to get back the original base64 string
-      const base64UserId = matrixUserName.replace(/-/g, '+').replace(/_/g, '/');
-      const decodedMatrixUserName = Buffer.from(
-        base64UserId,
-        'base64',
-      ).toString('utf8');
+      const base64MatrixUserId = matrixUserName
+        .replace(/-/g, '+')
+        .replace(/_/g, '/');
+      const matrixUserId = Buffer.from(base64MatrixUserId, 'base64').toString(
+        'utf8',
+      );
       await updateUserStripeCustomerId(
         dbAdapter,
-        decodedMatrixUserName,
+        matrixUserId,
         stripeCustomerId,
       );
     }

--- a/packages/host/app/services/billing-service.ts
+++ b/packages/host/app/services/billing-service.ts
@@ -87,29 +87,31 @@ export default class BillingService extends Service {
         Authorization: `Bearer ${await this.getToken()}`,
       },
     });
-    if (response.status !== 200) {
-      throw new Error(
+
+    if (response.ok) {
+      let json = await response.json();
+      let plan =
+        json.included?.find((i: { type: string }) => i.type === 'plan')
+          ?.attributes?.name ?? null;
+      let creditsAvailableInPlanAllowance =
+        json.data?.attributes?.creditsAvailableInPlanAllowance ?? null;
+      let creditsIncludedInPlanAllowance =
+        json.data?.attributes?.creditsIncludedInPlanAllowance ?? null;
+      let extraCreditsAvailableInBalance =
+        json.data?.attributes?.extraCreditsAvailableInBalance ?? null;
+      let stripeCustomerId = json.data?.attributes?.stripeCustomerId ?? null;
+      this._subscriptionData = {
+        plan,
+        creditsAvailableInPlanAllowance,
+        creditsIncludedInPlanAllowance,
+        extraCreditsAvailableInBalance,
+        stripeCustomerId,
+      };
+    } else {
+      console.error(
         `Failed to fetch user for realm server ${this.url.origin}: ${response.status}`,
       );
     }
-    let json = await response.json();
-    let plan =
-      json.included?.find((i: { type: string }) => i.type === 'plan')
-        ?.attributes?.name ?? null;
-    let creditsAvailableInPlanAllowance =
-      json.data?.attributes?.creditsAvailableInPlanAllowance ?? null;
-    let creditsIncludedInPlanAllowance =
-      json.data?.attributes?.creditsIncludedInPlanAllowance ?? null;
-    let extraCreditsAvailableInBalance =
-      json.data?.attributes?.extraCreditsAvailableInBalance ?? null;
-    let stripeCustomerId = json.data?.attributes?.stripeCustomerId ?? null;
-    this._subscriptionData = {
-      plan,
-      creditsAvailableInPlanAllowance,
-      creditsIncludedInPlanAllowance,
-      extraCreditsAvailableInBalance,
-      stripeCustomerId,
-    };
   });
 
   private async getToken() {

--- a/packages/host/app/services/billing-service.ts
+++ b/packages/host/app/services/billing-service.ts
@@ -5,7 +5,10 @@ import { tracked } from '@glimmer/tracking';
 
 import { dropTask } from 'ember-concurrency';
 
-import { SupportedMimeType } from '@cardstack/runtime-common';
+import {
+  SupportedMimeType,
+  encodeToAlphanumeric,
+} from '@cardstack/runtime-common';
 
 import ENV from '@cardstack/host/config/environment';
 
@@ -43,20 +46,12 @@ export default class BillingService extends Service {
     this._subscriptionData = null;
   }
 
-  encodeToAlphanumeric(matrixUserId: string) {
-    return Buffer.from(matrixUserId)
-      .toString('base64')
-      .replace(/\+/g, '-')
-      .replace(/\//g, '_')
-      .replace(/=+$/, '');
-  }
-
   getStripePaymentLink(matrixUserId: string): string {
     // We use the matrix user id (@username:example.com) as the client reference id for stripe
     // so we can identify the user payment in our system when we get the webhook
     // the client reference id must be alphanumeric, so we encode the matrix user id
     // https://docs.stripe.com/payment-links/url-parameters#streamline-reconciliation-with-a-url-parameter
-    const clientReferenceId = this.encodeToAlphanumeric(matrixUserId);
+    const clientReferenceId = encodeToAlphanumeric(matrixUserId);
     return `${stripePaymentLink}?client_reference_id=${clientReferenceId}`;
   }
 

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -3976,7 +3976,7 @@ module('Realm Server', function (hooks) {
     });
   });
 
-  module.only('stripe webhook handler', function (hooks) {
+  module('stripe webhook handler', function (hooks) {
     let createSubscriptionStub: sinon.SinonStub;
     let fetchPriceListStub: sinon.SinonStub;
     let matrixClient: MatrixClient;

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -31,6 +31,7 @@ import {
   type SingleCardDocument,
   type QueuePublisher,
   type QueueRunner,
+  encodeToAlphanumeric,
 } from '@cardstack/runtime-common';
 import { stringify } from 'qs';
 import { v4 as uuidv4 } from 'uuid';
@@ -3975,7 +3976,7 @@ module('Realm Server', function (hooks) {
     });
   });
 
-  module('stripe webhook handler', function (hooks) {
+  module.only('stripe webhook handler', function (hooks) {
     let createSubscriptionStub: sinon.SinonStub;
     let fetchPriceListStub: sinon.SinonStub;
     let matrixClient: MatrixClient;
@@ -4506,7 +4507,7 @@ module('Realm Server', function (hooks) {
           object: {
             id: 'cs_test_1234567890',
             object: 'checkout.session',
-            client_reference_id: userId,
+            client_reference_id: encodeToAlphanumeric(userId),
             customer: 'cus_123',
             metadata: {},
           },

--- a/packages/runtime-common/utils.ts
+++ b/packages/runtime-common/utils.ts
@@ -19,3 +19,11 @@ export async function retry<T>(
 
   return null;
 }
+
+export function encodeToAlphanumeric(matrixUserId: string) {
+  return Buffer.from(matrixUserId)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}


### PR DESCRIPTION
Stripe webhooks expect that there is a user entry in our database which has the matrix user id field saved.

For old users, created prior to when we introduced the users table, Stripe webhooks failed to work, resulting in a malfunctioning Stripe free plan subscription flow.

This PR adds an adjustment where the `checkout.session.completed` webhook will insert a user in case it doesn't exist yet. This fixes the issue described above. 