### PR TITLE
Fix stripe script forward tcp error

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ There is some pre-setup needed to enable free plan on development account:
 1. Go to `packages/realm-server` and run stripe script to listen for the webhooks that Stripe sends to the realm server
 
 ```
-pnpm stripe listen --forward-to localhost:4201/_stripe-webhook --api-key sk_test_api_key_from_the_sandbox_account
+pnpm stripe listen --forward-to host.docker.internal:4201/_stripe-webhook --api-key sk_test_api_key_from_the_sandbox_account
 ```
 
 2. You will get webhook signing secret from stripe cli after Step 1 is done

--- a/packages/realm-server/package.json
+++ b/packages/realm-server/package.json
@@ -97,7 +97,7 @@
     "lint:glint": "glint",
     "full-reset": "./scripts/full-reset.sh",
     "sync-stripe-products": "NODE_NO_WARNINGS=1 PGDATABASE=boxel PGPORT=5435 ts-node --transpileOnly scripts/sync-stripe-products.ts",
-    "stripe": "docker run --rm -it stripe/stripe-cli:latest"
+    "stripe": "docker run --rm --add-host=host.docker.internal:host-gateway -it stripe/stripe-cli:latest"
   },
   "volta": {
     "extends": "../../package.json"


### PR DESCRIPTION
### What is fixing
- To fix stripe CLI within docker cannot communicate and forward localhost webhook calls.

**Current**

```
[ERROR] Failed to POST: Post "http://localhost:4201/_stripe-webhook": dial tcp 127.0.0.1:4201: connect: connection refuse
```

**Fix**

![Screenshot 2024-12-02 at 11 13 03 AM](https://github.com/user-attachments/assets/783a12f8-24ce-4680-a203-25dd474f8df4)
