### PR TITLE
Create country field with dropdown edit mode

### DIFF
--- a/packages/boxel-ui/addon/src/components/select/index.gts
+++ b/packages/boxel-ui/addon/src/components/select/index.gts
@@ -33,6 +33,7 @@ const BoxelSelect: TemplateOnlyComponent<Signature> = <template>
     @renderInPlace={{@renderInPlace}}
     @verticalPosition={{@verticalPosition}}
     @dropdownClass={{cn 'boxel-select__dropdown' @dropdownClass}}
+    @loadingMessage={{@loadingMessage}}
     {{! We can avoid providing arguments to the triggerComponent as long as they are specified here https://github.com/cibernox/ember-power-select/blob/913c85ec82d5c6aeb80a7a3b9d9c21ca9613e900/ember-power-select/src/components/power-select.hbs#L79-L106 }}
     {{! Even the custom BoxelTriggerWrapper will receive these arguments }}
     @triggerComponent={{(if

--- a/packages/experiments-realm/CardWithCountryField/6f3855c6-26dd-48e1-b332-73444a1172d1.json
+++ b/packages/experiments-realm/CardWithCountryField/6f3855c6-26dd-48e1-b332-73444a1172d1.json
@@ -3,8 +3,8 @@
     "type": "card",
     "attributes": {
       "country": {
-        "name": "Cambodia",
-        "code": "KH"
+        "name": null,
+        "code": null
       },
       "title": null,
       "description": null,

--- a/packages/experiments-realm/CardWithCountryField/86fee625-f9f0-460a-99aa-917d25657ec1.json
+++ b/packages/experiments-realm/CardWithCountryField/86fee625-f9f0-460a-99aa-917d25657ec1.json
@@ -1,0 +1,20 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "country": {
+        "name": null,
+        "code": null
+      },
+      "title": null,
+      "description": null,
+      "thumbnailURL": null
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../country",
+        "name": "CardWithCountryField"
+      }
+    }
+  }
+}

--- a/packages/experiments-realm/country.gts
+++ b/packages/experiments-realm/country.gts
@@ -3,9 +3,16 @@ import {
   field,
   Component,
   CardDef,
+  FieldDef,
 } from 'https://cardstack.com/base/card-api';
 import StringField from 'https://cardstack.com/base/string';
 import World from '@cardstack/boxel-icons/world';
+import { BoxelSelect } from '@cardstack/boxel-ui/components';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { restartableTask } from 'ember-concurrency';
+import type Owner from '@ember/owner';
+import countryDataFind from 'https://esm.run/country-data-find@0.0.5';
 
 export class Country extends CardDef {
   static displayName = 'Country';
@@ -20,6 +27,77 @@ export class Country extends CardDef {
   static embedded = class Embedded extends Component<typeof this> {
     <template>
       <@fields.name />
+    </template>
+  };
+}
+
+function getCountryFlagEmoji(countryCode: string) {
+  const codePoints = countryCode
+    .toUpperCase()
+    .split('')
+    .map((char) => 127397 + char.charCodeAt(0));
+  return String.fromCodePoint(...codePoints);
+}
+
+interface CountryData {
+  code: string;
+  name: string;
+  emoji: string;
+}
+
+class CountryFieldEdit extends Component<typeof CountryField> {
+  @tracked countryDataFindLib: any;
+  @tracked country: CountryData | undefined;
+  @tracked countries: CountryData[] = [];
+
+  constructor(owner: Owner, args: any) {
+    super(owner, args);
+    this.loadCountries.perform();
+  }
+
+  private loadCountries = restartableTask(async () => {
+    this.countries = countryDataFind.Array().map((country: any) => {
+      return {
+        code: country.ISO2_CODE,
+        name: country.LIST_OF_NAME.ENG,
+        emoji: getCountryFlagEmoji(country.ISO2_CODE),
+      } as CountryData;
+    });
+  });
+
+  @action onSelectCountry(country: any) {
+    this.country = country;
+  }
+
+  <template>
+    <BoxelSelect
+      @options={{this.countries}}
+      @selected={{this.country}}
+      @onSelect={{@set}}
+      @loadingMessage='Loading countries...'
+      @onChange={{this.onSelectCountry}}
+      as |country|
+    >
+      {{country.emoji}}
+      {{country.name}}
+    </BoxelSelect>
+  </template>
+}
+
+export class CountryField extends FieldDef {
+  static displayName = 'Country';
+  @field name = contains(StringField);
+  @field code = contains(StringField);
+  static edit = CountryFieldEdit;
+}
+
+export class CardWithCountryField extends CardDef {
+  static displayName = 'Card With Country Field';
+  @field country = contains(CountryField);
+
+  static isolated = class Isolated extends Component<typeof this> {
+    <template>
+      <@fields.country />
     </template>
   };
 }

--- a/packages/experiments-realm/country.gts
+++ b/packages/experiments-realm/country.gts
@@ -107,6 +107,14 @@ export class CountryField extends FieldDef {
   @field name = contains(StringField);
   @field code = contains(StringField);
   static edit = CountryFieldEdit;
+
+  static atom = class Atom extends Component<typeof this> {
+    <template>
+      {{#if @model.name}}
+        {{@model.name}}
+      {{/if}}
+    </template>
+  };
 }
 
 export class CardWithCountryField extends CardDef {
@@ -115,7 +123,7 @@ export class CardWithCountryField extends CardDef {
 
   static isolated = class Isolated extends Component<typeof this> {
     <template>
-      <@fields.country />
+      <@fields.country @format='atom' />
     </template>
   };
 }

--- a/packages/experiments-realm/country.gts
+++ b/packages/experiments-realm/country.gts
@@ -74,7 +74,6 @@ class CountryFieldEdit extends Component<typeof CountryField> {
       @options={{this.countries}}
       @selected={{this.country}}
       @onSelect={{@set}}
-      @loadingMessage='Loading countries...'
       @onChange={{this.onSelectCountry}}
       as |country|
     >

--- a/packages/experiments-realm/country.gts
+++ b/packages/experiments-realm/country.gts
@@ -12,6 +12,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { restartableTask } from 'ember-concurrency';
 import type Owner from '@ember/owner';
+// @ts-ignore
 import countryDataFind from 'https://esm.run/country-data-find@0.0.5';
 
 export class Country extends CardDef {

--- a/packages/experiments-realm/country.gts
+++ b/packages/experiments-realm/country.gts
@@ -42,12 +42,17 @@ function getCountryFlagEmoji(countryCode: string) {
 interface CountryData {
   code: string;
   name: string;
-  emoji: string;
+  emoji?: string;
 }
 
 class CountryFieldEdit extends Component<typeof CountryField> {
-  @tracked countryDataFindLib: any;
-  @tracked country: CountryData | undefined;
+  @tracked country: CountryData | undefined =
+    this.args.model.name && this.args.model.code
+      ? {
+          name: this.args.model.name,
+          code: this.args.model.code,
+        }
+      : undefined;
   @tracked countries: CountryData[] = [];
 
   constructor(owner: Owner, args: any) {
@@ -59,27 +64,40 @@ class CountryFieldEdit extends Component<typeof CountryField> {
     this.countries = countryDataFind.Array().map((country: any) => {
       return {
         code: country.ISO2_CODE,
-        name: country.LIST_OF_NAME.ENG,
+        name: country.LIST_OF_NAME.ENG[0],
         emoji: getCountryFlagEmoji(country.ISO2_CODE),
       } as CountryData;
     });
   });
 
-  @action onSelectCountry(country: any) {
+  @action onSelectCountry(country: CountryData) {
     this.country = country;
+    this.args.model.name = country.name;
+    this.args.model.code = country.code;
+  }
+
+  @action countryEmoji(countryCode: string) {
+    return this.countries?.find((country) => country.code === countryCode)
+      ?.emoji;
   }
 
   <template>
-    <BoxelSelect
-      @options={{this.countries}}
-      @selected={{this.country}}
-      @onSelect={{@set}}
-      @onChange={{this.onSelectCountry}}
-      as |country|
-    >
-      {{country.emoji}}
-      {{country.name}}
-    </BoxelSelect>
+    {{#if this.loadCountries.isRunning}}
+      Loading countries...
+    {{else}}
+      <BoxelSelect
+        @placeholder={{'Choose a country'}}
+        @options={{this.countries}}
+        @selected={{this.country}}
+        @onChange={{this.onSelectCountry}}
+        as |country|
+      >
+        {{#let (this.countryEmoji country.code) as |emoji|}}
+          {{emoji}}
+        {{/let}}
+        {{country.name}}
+      </BoxelSelect>
+    {{/if}}
   </template>
 }
 


### PR DESCRIPTION
This creates a country field which is a field definition but it gets data of country codes from a [cdn](https://cdn.jsdelivr.net/npm/country-data-find/+esm). This is meant to support the form filling of an address field https://linear.app/cardstack/issue/CS-7410/refine-address-field

<img width="331" alt="Screenshot 2024-12-02 at 20 46 15" src="https://github.com/user-attachments/assets/a20c6b29-0787-44df-9f00-a6df05ffa668">
<img width="620" alt="Screenshot 2024-12-02 at 20 46 09" src="https://github.com/user-attachments/assets/52d95f6d-9cc8-4ffb-b8a8-a929fc5e759d">

Before we have feature of data realms, we would need this to enumerate fields inside of a dropdown

**Possible alternatives**

We can also hardcode the data inside of the country field itself
