### PR TITLE
Fix checkout.session.completed handler to properly handle buying extra credits 

### DIFF
--- a/packages/billing/stripe-webhook-handlers/index.ts
+++ b/packages/billing/stripe-webhook-handlers/index.ts
@@ -79,7 +79,7 @@ export type StripeCheckoutSessionCompletedWebhookEvent = StripeEvent & {
       id: string;
       object: 'checkout.session';
       client_reference_id: string;
-      customer: string;
+      customer: string | null; // string when payment link is for subcribing to the free plan, null when buying extra credits
       metadata:
         | {
             credit_reload_amount: string;

--- a/packages/billing/stripe-webhook-handlers/index.ts
+++ b/packages/billing/stripe-webhook-handlers/index.ts
@@ -79,7 +79,7 @@ export type StripeCheckoutSessionCompletedWebhookEvent = StripeEvent & {
       id: string;
       object: 'checkout.session';
       client_reference_id: string;
-      customer: string | null; // string when payment link is for subcribing to the free plan, null when buying extra credits
+      customer: string | null; // string when payment link is for subscribing to the free plan, null when buying extra credits
       metadata:
         | {
             credit_reload_amount: string;

--- a/packages/host/app/components/operator-mode/profile/profile-subscription.gts
+++ b/packages/host/app/components/operator-mode/profile/profile-subscription.gts
@@ -1,3 +1,4 @@
+import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
@@ -20,6 +21,16 @@ interface Signature {
 }
 
 export default class ProfileSubscription extends Component<Signature> {
+  @service private declare billingService: BillingService;
+  @service private declare matrixService: MatrixService;
+
+  @action
+  urlWithClientReferenceId(url: string) {
+    return `${url}?client_reference_id=${encodeWebSafeBase64(
+      this.matrixService.userId as string,
+    )}`;
+  }
+
   <template>
     <WithSubscriptionData as |subscriptionData|>
       <FieldContainer
@@ -161,13 +172,4 @@ export default class ProfileSubscription extends Component<Signature> {
       }
     </style>
   </template>
-
-  @service private declare billingService: BillingService;
-  @service private declare matrixService: MatrixService;
-
-  urlWithClientReferenceId(url: string) {
-    return `${url}?client_reference_id=${encodeWebSafeBase64(
-      this.matrixService.userId as string,
-    )}`;
-  }
 }

--- a/packages/host/app/components/operator-mode/profile/profile-subscription.gts
+++ b/packages/host/app/components/operator-mode/profile/profile-subscription.gts
@@ -1,4 +1,3 @@
-import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 

--- a/packages/host/app/components/operator-mode/profile/profile-subscription.gts
+++ b/packages/host/app/components/operator-mode/profile/profile-subscription.gts
@@ -8,8 +8,11 @@ import {
 } from '@cardstack/boxel-ui/components';
 import { IconHexagon } from '@cardstack/boxel-ui/icons';
 
+import { encodeWebSafeBase64 } from '@cardstack/runtime-common';
+
 import WithSubscriptionData from '@cardstack/host/components/with-subscription-data';
 import BillingService from '@cardstack/host/services/billing-service';
+import MatrixService from '@cardstack/host/services/matrix-service';
 
 interface Signature {
   Args: {};
@@ -71,7 +74,7 @@ export default class ProfileSubscription extends Component<Signature> {
                       @as='anchor'
                       @kind='secondary-light'
                       @size='extra-small'
-                      @href={{paymentLink.url}}
+                      @href={{this.urlWithClientReferenceId paymentLink.url}}
                       target='_blank'
                       data-test-pay-button={{index}}
                     >Pay</BoxelButton>
@@ -83,6 +86,7 @@ export default class ProfileSubscription extends Component<Signature> {
         </div>
       </FieldContainer>
     </WithSubscriptionData>
+
     <style scoped>
       .profile-field :deep(.invalid) {
         box-shadow: none;
@@ -159,4 +163,11 @@ export default class ProfileSubscription extends Component<Signature> {
   </template>
 
   @service private declare billingService: BillingService;
+  @service private declare matrixService: MatrixService;
+
+  urlWithClientReferenceId(url: string) {
+    return `${url}?client_reference_id=${encodeWebSafeBase64(
+      this.matrixService.userId as string,
+    )}`;
+  }
 }

--- a/packages/host/app/components/operator-mode/profile/profile-subscription.gts
+++ b/packages/host/app/components/operator-mode/profile/profile-subscription.gts
@@ -24,12 +24,11 @@ export default class ProfileSubscription extends Component<Signature> {
   @service private declare billingService: BillingService;
   @service private declare matrixService: MatrixService;
 
-  @action
-  urlWithClientReferenceId(url: string) {
+  urlWithClientReferenceId = (url: string) => {
     return `${url}?client_reference_id=${encodeWebSafeBase64(
       this.matrixService.userId as string,
     )}`;
-  }
+  };
 
   <template>
     <WithSubscriptionData as |subscriptionData|>

--- a/packages/host/app/components/operator-mode/profile/profile-subscription.gts
+++ b/packages/host/app/components/operator-mode/profile/profile-subscription.gts
@@ -12,8 +12,8 @@ import { IconHexagon } from '@cardstack/boxel-ui/icons';
 import { encodeWebSafeBase64 } from '@cardstack/runtime-common';
 
 import WithSubscriptionData from '@cardstack/host/components/with-subscription-data';
-import BillingService from '@cardstack/host/services/billing-service';
-import MatrixService from '@cardstack/host/services/matrix-service';
+import type BillingService from '@cardstack/host/services/billing-service';
+import type MatrixService from '@cardstack/host/services/matrix-service';
 
 interface Signature {
   Args: {};

--- a/packages/host/app/services/billing-service.ts
+++ b/packages/host/app/services/billing-service.ts
@@ -9,7 +9,7 @@ import { trackedFunction } from 'ember-resources/util/function';
 
 import {
   SupportedMimeType,
-  encodeToAlphanumeric,
+  encodeWebSafeBase64,
 } from '@cardstack/runtime-common';
 
 import NetworkService from './network';
@@ -93,11 +93,13 @@ export default class BillingService extends Service {
         };
       }[];
     };
+
     let links = json.data.map((data) => ({
       type: data.type,
       url: data.attributes.url,
       creditReloadAmount: data.attributes.metadata?.creditReloadAmount,
     })) as StripeLink[];
+
     return {
       customerPortalLink: links.find(
         (link) => link.type === 'customer-portal-link',
@@ -116,7 +118,7 @@ export default class BillingService extends Service {
     // so we can identify the user payment in our system when we get the webhook
     // the client reference id must be alphanumeric, so we encode the matrix user id
     // https://docs.stripe.com/payment-links/url-parameters#streamline-reconciliation-with-a-url-parameter
-    const clientReferenceId = encodeToAlphanumeric(matrixUserId);
+    const clientReferenceId = encodeWebSafeBase64(matrixUserId);
     return `${this.freePlanPaymentLink?.url}?client_reference_id=${clientReferenceId}`;
   }
 

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -13,7 +13,11 @@ import { module, test } from 'qunit';
 
 import { FieldContainer } from '@cardstack/boxel-ui/components';
 
-import { baseRealm, primitive } from '@cardstack/runtime-common';
+import {
+  baseRealm,
+  encodeWebSafeBase64,
+  primitive,
+} from '@cardstack/runtime-common';
 
 import { Submodes } from '@cardstack/host/components/submode-switcher';
 import {
@@ -937,15 +941,30 @@ module('Acceptance | operator mode tests', function (hooks) {
       assert.dom('[data-test-payment-link]').exists({ count: 3 });
       assert
         .dom('[data-test-pay-button="0"]')
-        .hasAttribute('href', 'https://extra-credits-payment-link-1250');
+        .hasAttribute(
+          'href',
+          `https://extra-credits-payment-link-1250?client_reference_id=${encodeWebSafeBase64(
+            '@testuser:staging',
+          )}`,
+        );
       assert.dom('[data-test-pay-button="0"]').hasAttribute('target', '_blank');
       assert
         .dom('[data-test-pay-button="1"]')
-        .hasAttribute('href', 'https://extra-credits-payment-link-15000');
+        .hasAttribute(
+          'href',
+          `https://extra-credits-payment-link-15000?client_reference_id=${encodeWebSafeBase64(
+            '@testuser:staging',
+          )}`,
+        );
       assert.dom('[data-test-pay-button="1"]').hasAttribute('target', '_blank');
       assert
         .dom('[data-test-pay-button="2"]')
-        .hasAttribute('href', 'https://extra-credits-payment-link-80000');
+        .hasAttribute(
+          'href',
+          `https://extra-credits-payment-link-80000?client_reference_id=${encodeWebSafeBase64(
+            '@testuser:staging',
+          )}`,
+        );
       assert.dom('[data-test-pay-button="2"]').hasAttribute('target', '_blank');
 
       // out of credit

--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -620,11 +620,11 @@ export async function setupPayment(
   // mock trigger stripe webhook 'invoice.payment_succeeded'
   await realmServer.executeSQL(
     `INSERT INTO subscriptions (
-      user_id, 
-      plan_id, 
-      started_at, 
+      user_id,
+      plan_id,
+      started_at,
       ended_at,
-      status, 
+      status,
       stripe_subscription_id
     ) VALUES (
       '${userId}',
@@ -643,8 +643,8 @@ export async function setupPayment(
 
   await realmServer.executeSQL(
     `INSERT INTO subscription_cycles (
-      subscription_id, 
-      period_start, 
+      subscription_id,
+      period_start,
       period_end
     ) VALUES (
       '${subscriptionUUID}',
@@ -681,7 +681,7 @@ export async function setupUserSubscribed(
   username: string,
   realmServer: IsolatedRealmServer,
 ) {
-  const matrixUserId = encodeToAlphanumeric(username);
+  const matrixUserId = encodeWebSafeBase64(username);
   await setupUser(username, realmServer);
   await setupPayment(matrixUserId, realmServer);
 }
@@ -753,7 +753,7 @@ export async function waitUntil<T>(
   throw new Error('Timeout waiting for condition');
 }
 
-export function encodeToAlphanumeric(string: string) {
+export function encodeWebSafeBase64(string: string) {
   return Buffer.from(string)
     .toString('base64')
     .replace(/\+/g, '-')

--- a/packages/matrix/tests/registration-with-token.spec.ts
+++ b/packages/matrix/tests/registration-with-token.spec.ts
@@ -25,7 +25,7 @@ import {
   enterWorkspace,
   showAllCards,
   setupUser,
-  encodeToAlphanumeric,
+  encodeWebSafeBase64,
 } from '../helpers';
 import { registerUser, createRegistrationToken } from '../docker/synapse';
 
@@ -115,7 +115,7 @@ test.describe('User Registration w/ Token - isolated realm server', () => {
     );
 
     // base 64 encode the matrix user id
-    const matrixUserId = encodeToAlphanumeric('@user1:localhost');
+    const matrixUserId = encodeWebSafeBase64('@user1:localhost');
     await setupPayment(matrixUserId, realmServer, page);
     await assertLoggedIn(page, {
       email: 'user1@example.com',
@@ -205,7 +205,7 @@ test.describe('User Registration w/ Token - isolated realm server', () => {
       page.locator('[data-test-setup-payment-message]'),
     ).toContainText('Setup your payment method now to enjoy Boxel');
 
-    const user2MatrixUserId = encodeToAlphanumeric('@user2:localhost');
+    const user2MatrixUserId = encodeWebSafeBase64('@user2:localhost');
 
     await setupPayment(user2MatrixUserId, realmServer, page);
 

--- a/packages/matrix/tests/registration-without-token.spec.ts
+++ b/packages/matrix/tests/registration-without-token.spec.ts
@@ -17,7 +17,7 @@ import {
   assertLoggedIn,
   setupPayment,
   registerRealmUsers,
-  encodeToAlphanumeric,
+  encodeWebSafeBase64,
 } from '../helpers';
 
 test.describe('User Registration w/o Token', () => {
@@ -69,7 +69,7 @@ test.describe('User Registration w/o Token', () => {
     );
 
     // base 64 encode the matrix user id
-    const matrixUserId = encodeToAlphanumeric('@user1:localhost');
+    const matrixUserId = encodeWebSafeBase64('@user1:localhost');
 
     await setupPayment(matrixUserId, realmServer, page);
     await assertLoggedIn(page);

--- a/packages/realm-server/tests/billing-test.ts
+++ b/packages/realm-server/tests/billing-test.ts
@@ -1,4 +1,9 @@
-import { encodeWebSafeBase64, param, query } from '@cardstack/runtime-common';
+import {
+  decodeWebSafeBase64,
+  encodeWebSafeBase64,
+  param,
+  query,
+} from '@cardstack/runtime-common';
 import { module, test } from 'qunit';
 import {
   fetchSubscriptionsByUserId,
@@ -80,6 +85,19 @@ async function fetchCreditsLedgerByUser(
       }) as LedgerEntry,
   );
 }
+
+module('billing utils', function () {
+  test('encoding client_reference_id to be web safe in payment links', function (assert) {
+    assert.strictEqual(
+      decodeWebSafeBase64(encodeWebSafeBase64('@mike_1:cardstack.com')),
+      '@mike_1:cardstack.com',
+    );
+    assert.strictEqual(
+      decodeWebSafeBase64(encodeWebSafeBase64('@hans.müller:matrix.de')),
+      '@hans.müller:matrix.de',
+    );
+  });
+});
 
 module('billing', function (hooks) {
   let dbAdapter: PgAdapter;

--- a/packages/realm-server/tests/billing-test.ts
+++ b/packages/realm-server/tests/billing-test.ts
@@ -1,4 +1,4 @@
-import { encodeToAlphanumeric, param, query } from '@cardstack/runtime-common';
+import { encodeWebSafeBase64, param, query } from '@cardstack/runtime-common';
 import { module, test } from 'qunit';
 import {
   fetchSubscriptionsByUserId,
@@ -741,7 +741,7 @@ module('billing', function (hooks) {
               object: {
                 id: 'cs_test_1234567890',
                 object: 'checkout.session',
-                client_reference_id: encodeToAlphanumeric(matrixUserId),
+                client_reference_id: encodeWebSafeBase64(matrixUserId),
                 customer: 'cus_123',
                 metadata: {},
               },
@@ -787,7 +787,7 @@ module('billing', function (hooks) {
               object: {
                 id: 'cs_test_1234567890',
                 object: 'checkout.session',
-                client_reference_id: encodeToAlphanumeric(matrixUserId),
+                client_reference_id: encodeWebSafeBase64(matrixUserId),
                 customer: 'cus_123',
                 metadata: {},
               },
@@ -843,7 +843,8 @@ module('billing', function (hooks) {
               object: {
                 id: 'cs_test_1234567890',
                 object: 'checkout.session',
-                customer: 'cus_123',
+                customer: null,
+                client_reference_id: encodeWebSafeBase64(matrixUserId),
                 metadata: {
                   credit_reload_amount: '25000',
                 },

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -31,7 +31,7 @@ import {
   type SingleCardDocument,
   type QueuePublisher,
   type QueueRunner,
-  encodeToAlphanumeric,
+  encodeWebSafeBase64,
 } from '@cardstack/runtime-common';
 import { stringify } from 'qs';
 import { v4 as uuidv4 } from 'uuid';
@@ -4507,7 +4507,7 @@ module('Realm Server', function (hooks) {
           object: {
             id: 'cs_test_1234567890',
             object: 'checkout.session',
-            client_reference_id: encodeToAlphanumeric(userId),
+            client_reference_id: encodeWebSafeBase64(userId),
             customer: 'cus_123',
             metadata: {},
           },

--- a/packages/runtime-common/utils.ts
+++ b/packages/runtime-common/utils.ts
@@ -20,10 +20,21 @@ export async function retry<T>(
   return null;
 }
 
-export function encodeToAlphanumeric(matrixUserId: string) {
-  return Buffer.from(matrixUserId)
-    .toString('base64')
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=+$/, '');
+export function encodeWebSafeBase64(decoded: string) {
+  return (
+    Buffer.from(decoded)
+      .toString('base64')
+      // Replace + with - and / with _ to make base64 URL-safe (this is a requirement for client_reference_id query param in Stripe payment link)
+      // Then remove any trailing = padding characters that are added by base64 encoding
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '')
+  );
+}
+
+export function decodeWebSafeBase64(encoded: string) {
+  return Buffer.from(
+    encoded.replace(/-/g, '+').replace(/_/g, '/'),
+    'base64',
+  ).toString('utf8');
 }


### PR DESCRIPTION
We had a flaw in our "credit buy" links where we forgot to include the client_reference_id, which tells us which user bought the credits. I added that query param in the links and adjusted the webhook handler. Also did a small refactor for encoding/decoding logic so that it's clearer what it does. 

Tested on staging and I was able to buy myself extra credits without problems. 