### PR TITLE
Fix stale credit info in account popup

### DIFF
--- a/packages/host/app/components/operator-mode/profile-info-popover.gts
+++ b/packages/host/app/components/operator-mode/profile-info-popover.gts
@@ -5,7 +5,7 @@ import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 
 import { Avatar, BoxelButton } from '@cardstack/boxel-ui/components';
-import { cn, or } from '@cardstack/boxel-ui/helpers';
+import { cn } from '@cardstack/boxel-ui/helpers';
 
 import WithSubscriptionData from '@cardstack/host/components/with-subscription-data';
 
@@ -144,10 +144,7 @@ export default class ProfileInfoPopover extends Component<ProfileInfoPopoverSign
               @as='anchor'
               @kind='secondary-light'
               @size='small'
-              @disabled={{or
-                subscriptionData.isLoading
-                this.billingService.fetchingStripePaymentLinks
-              }}
+              @disabled={{this.billingService.fetchingStripePaymentLinks}}
               @href={{this.billingService.customerPortalLink.url}}
               target='_blank'
               data-test-upgrade-plan-button
@@ -174,7 +171,7 @@ export default class ProfileInfoPopover extends Component<ProfileInfoPopoverSign
                   'secondary-light'
                 }}
                 @size={{if subscriptionData.isOutOfCredit 'base' 'small'}}
-                @disabled={{subscriptionData.isLoading}}
+                @disabled={{this.billingService.fetchingStripePaymentLinks}}
                 {{on 'click' @toggleProfileSettings}}
               >Buy more credits</BoxelButton>
             </div>

--- a/packages/host/app/services/billing-service.ts
+++ b/packages/host/app/services/billing-service.ts
@@ -130,9 +130,6 @@ export default class BillingService extends Service {
   }
 
   fetchSubscriptionData() {
-    if (this.subscriptionData) {
-      return;
-    }
     this.fetchSubscriptionDataTask.perform();
   }
 


### PR DESCRIPTION
Refer to https://linear.app/cardstack/issue/CS-7578/stale-credits-info-in-account-popup-problem

### What is changing

This is to fix stale credit info in the account popup after talking with the AI bot, credit is only updated until we refresh the page.

In this PR we fix it by fetching and showing up-to-date credit info in the account popup.

**Before**

https://github.com/user-attachments/assets/899d4b1e-490c-4b2f-875c-5e1d18307beb

**After**

https://github.com/user-attachments/assets/4a574873-996f-41fa-9d55-1b9553d6aba1



