### PR TITLE
create AvatarGroup reusable components

### DIFF
--- a/packages/boxel-ui/addon/src/components/avatar/index.gts
+++ b/packages/boxel-ui/addon/src/components/avatar/index.gts
@@ -28,17 +28,14 @@ export default class Avatar extends Component<Signature> {
   }
 
   <template>
-    {{#let
-      (if @userId (deterministicColorFromString @userId) this.defaultBgColor)
-      as |bgColor|
-    }}
+    {{#let (deterministicColorFromString @userId) as |bgColor|}}
       <div
         class='profile-icon'
         style={{if
           @thumbnailURL
           (setBackgroundImage @thumbnailURL)
           (cssVar
-            profile-avatar-icon-background=bgColor
+            profile-avatar-icon-background={{if bgColor bgColor '#EEEEEE'}}
             profile-avatar-text-color=(getContrastColor bgColor)
           )
         }}
@@ -71,6 +68,9 @@ export default class Avatar extends Component<Signature> {
         line-height: 1;
       }
     </style>
+
+
+
   </template>
 
   get profileInitials() {

--- a/packages/boxel-ui/addon/src/components/avatar/index.gts
+++ b/packages/boxel-ui/addon/src/components/avatar/index.gts
@@ -1,15 +1,15 @@
+import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
 
 import { getContrastColor } from '../../helpers/contrast-color.ts';
 import cssVar from '../../helpers/css-var.ts';
 import { deterministicColorFromString } from '../../helpers/deterministic-color-from-string.ts';
-import { htmlSafe } from '@ember/template';
 
 interface Signature {
   Args: {
-    thumbnailURL?: string;
     displayName?: string;
     isReady: boolean;
+    thumbnailURL?: string;
     userId: string;
   };
   Element: HTMLDivElement;

--- a/packages/boxel-ui/addon/src/components/avatar/index.gts
+++ b/packages/boxel-ui/addon/src/components/avatar/index.gts
@@ -37,6 +37,7 @@ export default class Avatar extends Component<Signature> {
         }}
         data-test-profile-icon={{@isReady}}
         data-test-profile-icon-userId={{@userId}}
+        role='img'
         aria-label={{if @displayName @displayName @userId}}
         ...attributes
       >

--- a/packages/boxel-ui/addon/src/components/avatar/index.gts
+++ b/packages/boxel-ui/addon/src/components/avatar/index.gts
@@ -23,10 +23,6 @@ const setBackgroundImage = (backgroundURL: string | null | undefined) => {
 };
 
 export default class Avatar extends Component<Signature> {
-  get defaultBgColor() {
-    return '#00FFFF';
-  }
-
   <template>
     {{#let (deterministicColorFromString @userId) as |bgColor|}}
       <div
@@ -35,7 +31,7 @@ export default class Avatar extends Component<Signature> {
           @thumbnailURL
           (setBackgroundImage @thumbnailURL)
           (cssVar
-            profile-avatar-icon-background={{if bgColor bgColor '#EEEEEE'}}
+            profile-avatar-icon-background=bgColor
             profile-avatar-text-color=(getContrastColor bgColor)
           )
         }}
@@ -68,9 +64,6 @@ export default class Avatar extends Component<Signature> {
         line-height: 1;
       }
     </style>
-
-
-
   </template>
 
   get profileInitials() {

--- a/packages/boxel-ui/addon/src/components/avatar/index.gts
+++ b/packages/boxel-ui/addon/src/components/avatar/index.gts
@@ -24,7 +24,7 @@ const setBackgroundImage = (backgroundURL: string | null | undefined) => {
 
 export default class Avatar extends Component<Signature> {
   get defaultBgColor() {
-    return '#eeeeee';
+    return '#00FFFF';
   }
 
   <template>

--- a/packages/boxel-ui/addon/src/components/avatar/index.gts
+++ b/packages/boxel-ui/addon/src/components/avatar/index.gts
@@ -37,7 +37,7 @@ export default class Avatar extends Component<Signature> {
         }}
         data-test-profile-icon={{@isReady}}
         data-test-profile-icon-userId={{@userId}}
-        role='img'
+        role={{if @thumbnailURL 'img' 'presentation'}}
         aria-label={{if @displayName @displayName @userId}}
         ...attributes
       >

--- a/packages/boxel-ui/addon/src/components/avatar/usage.gts
+++ b/packages/boxel-ui/addon/src/components/avatar/usage.gts
@@ -62,7 +62,6 @@ export default class AvatarUsage extends Component {
           />
           <Args.String
             @name='thumbnailURL'
-            @name='thumbnailURL'
             @description='URL of the user thumbnail'
             @value={{this.thumbnailURL}}
             @onInput={{fn (mut this.thumbnailURL)}}

--- a/packages/boxel-ui/addon/src/components/avatar/usage.gts
+++ b/packages/boxel-ui/addon/src/components/avatar/usage.gts
@@ -13,6 +13,8 @@ import Avatar from './index.gts';
 export default class AvatarUsage extends Component {
   @tracked userId = 'user123';
   @tracked displayName = 'John Doe';
+  @tracked thumbnailURL =
+    'https://images.pexels.com/photos/4571943/pexels-photo-4571943.jpeg?auto=compress&cs=tinysrgb&w=300&h=300&dpr=1';
   @tracked isReady = true;
 
   @cssVariable({ cssClassName: 'avatar-freestyle-container' })
@@ -39,6 +41,7 @@ export default class AvatarUsage extends Component {
           <Avatar
             @userId={{this.userId}}
             @displayName={{this.displayName}}
+            @thumbnailURL={{this.thumbnailURL}}
             @isReady={{this.isReady}}
           />
         </:example>
@@ -56,6 +59,13 @@ export default class AvatarUsage extends Component {
             @defaultValue='userId'
             @value={{this.displayName}}
             @onInput={{fn (mut this.displayName)}}
+          />
+          <Args.String
+            @name='thumbnailURL'
+            @name='thumbnailURL'
+            @description='URL of the user thumbnail'
+            @value={{this.thumbnailURL}}
+            @onInput={{fn (mut this.thumbnailURL)}}
           />
           <Args.Bool
             @name='isReady'

--- a/packages/boxel-ui/addon/src/helpers/deterministic-color-from-string.ts
+++ b/packages/boxel-ui/addon/src/helpers/deterministic-color-from-string.ts
@@ -9,7 +9,7 @@ import {
 // Selects a random color from a set of colors based on the input string
 export function deterministicColorFromString(str: string): string {
   if (!str) {
-    return 'transparent';
+    return '#EEEEEE';
   }
 
   // Generate hash value between 0-1

--- a/packages/experiments-realm/components/avatar-group.gts
+++ b/packages/experiments-realm/components/avatar-group.gts
@@ -5,7 +5,7 @@ import { Avatar } from '@cardstack/boxel-ui/components';
 interface AvatarGroupSignature {
   Args: {
     thumbnailURL?: string;
-    name: string;
+    name?: string;
     userID: string;
   };
   Blocks: { content: [] };

--- a/packages/experiments-realm/components/avatar-group.gts
+++ b/packages/experiments-realm/components/avatar-group.gts
@@ -24,6 +24,7 @@ export default class AvatarGroup extends GlimmerComponent<AvatarGroupSignature> 
         @displayName={{@name}}
         @thumbnailURL={{@thumbnailURL}}
         @isReady={{true}}
+        class='avatar-thumbnail'
       />
 
       <div class='avatar-info'>
@@ -43,21 +44,8 @@ export default class AvatarGroup extends GlimmerComponent<AvatarGroupSignature> 
         min-width: 0;
       }
       .avatar-thumbnail {
-        background-color: var(--boxel-200);
-        width: 60px;
-        height: 60px;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
         flex-shrink: 0;
-        background-size: cover;
-        background-position: center;
-        border-radius: 50%;
-      }
-      .avatar-thumbnail .user-icon {
-        color: var(--boxel-500);
-        width: auto;
-        height: auto;
+        --profile-avatar-icon-size: 60px;
       }
       .avatar-info {
         min-width: 0;

--- a/packages/experiments-realm/components/avatar-group.gts
+++ b/packages/experiments-realm/components/avatar-group.gts
@@ -1,0 +1,86 @@
+import GlimmerComponent from '@glimmer/component';
+import { htmlSafe } from '@ember/template';
+import UserCircleIcon from '@cardstack/boxel-icons/user-circle';
+
+interface AvatarGroupSignature {
+  Args: {
+    thumbnailURL?: string;
+    name?: string;
+  };
+  Blocks: { company: [] };
+  Element: HTMLElement;
+}
+
+export default class AvatarGroup extends GlimmerComponent<AvatarGroupSignature> {
+  get backgroundImageStyle() {
+    return htmlSafe(`background-image: url(${this.args.thumbnailURL});`);
+  }
+  x;
+
+  <template>
+    <div class='avatar-container'>
+      <div
+        class='avatar-thumbnail'
+        {{! template-lint-disable no-inline-styles }}
+        style={{this.backgroundImageStyle}}
+      >
+        {{#unless this.args.thumbnailURL}}
+          <UserCircleIcon width='20' height='20' class='user-icon' />
+        {{/unless}}
+      </div>
+      <div class='avatar-info'>
+        <h3 class='name'>
+          {{if this.args.name this.args.name 'No Name Assigned'}}
+        </h3>
+        {{yield to='company'}}
+      </div>
+    </div>
+
+    <style scoped>
+      .avatar-container {
+        display: flex;
+        align-items: center;
+        gap: var(--boxel-sp);
+        min-width: 0;
+      }
+      .avatar-thumbnail {
+        background-color: var(--boxel-200);
+        width: 60px;
+        height: 60px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+        background-size: cover;
+        background-position: center;
+        border-radius: 50%;
+      }
+      .avatar-thumbnail .user-icon {
+        color: var(--boxel-500);
+        width: auto;
+        height: auto;
+      }
+      .avatar-info {
+        min-width: 0;
+        width: 100%;
+        overflow: hidden;
+      }
+      .name {
+        -webkit-line-clamp: 1;
+        text-wrap: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        margin: 0;
+        font-size: var(--boxel-font-size-med);
+        font-weight: 600;
+        letter-spacing: var(--boxel-lsp-sm);
+      }
+      .company-container {
+        background: transparent;
+        width: auto;
+        height: auto;
+        overflow: unset;
+      }
+    </style>
+  </template>
+}

--- a/packages/experiments-realm/components/avatar-group.gts
+++ b/packages/experiments-realm/components/avatar-group.gts
@@ -15,7 +15,6 @@ export default class AvatarGroup extends GlimmerComponent<AvatarGroupSignature> 
   get backgroundImageStyle() {
     return htmlSafe(`background-image: url(${this.args.thumbnailURL});`);
   }
-  x;
 
   <template>
     <div class='avatar-container'>
@@ -24,13 +23,13 @@ export default class AvatarGroup extends GlimmerComponent<AvatarGroupSignature> 
         {{! template-lint-disable no-inline-styles }}
         style={{this.backgroundImageStyle}}
       >
-        {{#unless this.args.thumbnailURL}}
+        {{#unless @thumbnailURL}}
           <UserCircleIcon width='20' height='20' class='user-icon' />
         {{/unless}}
       </div>
       <div class='avatar-info'>
         <h3 class='name'>
-          {{if this.args.name this.args.name 'No Name Assigned'}}
+          {{if @name @name 'No Name Assigned'}}
         </h3>
         {{yield to='company'}}
       </div>

--- a/packages/experiments-realm/components/avatar-group.gts
+++ b/packages/experiments-realm/components/avatar-group.gts
@@ -74,12 +74,6 @@ export default class AvatarGroup extends GlimmerComponent<AvatarGroupSignature> 
         font-weight: 600;
         letter-spacing: var(--boxel-lsp-sm);
       }
-      .company-container {
-        background: transparent;
-        width: auto;
-        height: auto;
-        overflow: unset;
-      }
     </style>
   </template>
 }

--- a/packages/experiments-realm/components/avatar-group.gts
+++ b/packages/experiments-realm/components/avatar-group.gts
@@ -1,13 +1,14 @@
 import GlimmerComponent from '@glimmer/component';
 import { htmlSafe } from '@ember/template';
-import UserCircleIcon from '@cardstack/boxel-icons/user-circle';
+import { Avatar } from '@cardstack/boxel-ui/components';
 
 interface AvatarGroupSignature {
   Args: {
     thumbnailURL?: string;
-    name?: string;
+    name: string;
+    userID: string;
   };
-  Blocks: { company: [] };
+  Blocks: { content: [] };
   Element: HTMLElement;
 }
 
@@ -17,26 +18,25 @@ export default class AvatarGroup extends GlimmerComponent<AvatarGroupSignature> 
   }
 
   <template>
-    <div class='avatar-container'>
-      <div
-        class='avatar-thumbnail'
-        {{! template-lint-disable no-inline-styles }}
-        style={{this.backgroundImageStyle}}
-      >
-        {{#unless @thumbnailURL}}
-          <UserCircleIcon width='20' height='20' class='user-icon' />
-        {{/unless}}
-      </div>
+    <div class='avatar-group'>
+      <Avatar
+        @userID={{@userID}}
+        @displayName={{@name}}
+        @thumbnailURL={{@thumbnailURL}}
+        @isReady={{true}}
+      />
+
       <div class='avatar-info'>
         <h3 class='name'>
           {{if @name @name 'No Name Assigned'}}
         </h3>
-        {{yield to='company'}}
+
+        {{yield to='content'}}
       </div>
     </div>
 
     <style scoped>
-      .avatar-container {
+      .avatar-group {
         display: flex;
         align-items: center;
         gap: var(--boxel-sp);


### PR DESCRIPTION
1) Done extend the avatar with new thumbnail args,
2) Intergrate Avatar boxel-ui  components to avatar group

Avatar UI component:
![image](https://github.com/user-attachments/assets/66adf5c1-09fc-42c8-9ee5-390045923ab4)

[RESULT] Avatar Group with thumbnail:
<img width="294" alt="Screenshot 2024-12-04 at 07 21 25" src="https://github.com/user-attachments/assets/1ac8199e-8988-4b5b-bf0e-dbf8306d3438">

[RESULT] Avatar Group without thumbnail:
<img width="287" alt="Screenshot 2024-12-04 at 07 22 07" src="https://github.com/user-attachments/assets/38b4b389-e72b-4b5b-ab26-90c243299795">

