### PR TITLE
tools: Fix login failure messages

### DIFF
--- a/packages/vscode-boxel-tools/src/synapse-auth-provider.ts
+++ b/packages/vscode-boxel-tools/src/synapse-auth-provider.ts
@@ -39,7 +39,8 @@ async function loginWithEmail(
 }
 
 async function login(username: string, password: string, matrixUrl: string) {
-  let usernameIsEmailAddress = username.includes('@');
+  let usernameIsMatrixId = username.startsWith('@');
+  let usernameIsEmailAddress = username.includes('@') && !usernameIsMatrixId;
 
   let login;
 

--- a/packages/vscode-boxel-tools/src/synapse-auth-provider.ts
+++ b/packages/vscode-boxel-tools/src/synapse-auth-provider.ts
@@ -39,17 +39,20 @@ async function loginWithEmail(
 }
 
 async function login(username: string, password: string, matrixUrl: string) {
-  try {
+  let usernameIsEmailAddress = username.includes('@');
+
+  let login;
+
+  if (usernameIsEmailAddress) {
+    login = await loginWithEmail(username, password, matrixUrl);
+  } else {
     let client = createClient({
       baseUrl: matrixUrl,
     });
-    let login = await client.loginWithPassword(username, password);
-    return login;
-  } catch (error) {
-    console.log('Login with password failed, trying login with email', error);
-    let login = await loginWithEmail(username, password, matrixUrl);
-    return login;
+
+    login = await client.loginWithPassword(username, password);
   }
+  return login;
 }
 
 export class SynapseAuthProvider implements vscode.AuthenticationProvider {


### PR DESCRIPTION
Previously entering incorrect credentials would produce an error referencing “email address” even if you didn’t use one:

![image](https://github.com/user-attachments/assets/6ac10f66-d638-4978-8aa1-ec286da38d37)

This was because it first tried username/password and then fell back to email address/password, so Synapse would reject the credential if it wasn’t an email address. Now it decides whether to try email login by seeing if the credential looks like an email address: it has `@` but not at the beginning, as a Matrix username does.

You can see the success paths here, with plain username, email address, and Matrix username:

![screencast 2024-12-03 10-30-00](https://github.com/user-attachments/assets/15121397-7636-42c6-a05b-2a20815f3314)

And the failures here:

![screencast 2024-12-03 10-31-40](https://github.com/user-attachments/assets/3e1f9a4d-4a47-44cd-9549-3807b6678832)
