### PR TITLE
Fix fitted task in anticipation for using in CRM

### DIFF
--- a/packages/experiments-realm/Tag/ad921cba-ffc7-4fdb-af34-ab8b93eae228.json
+++ b/packages/experiments-realm/Tag/ad921cba-ffc7-4fdb-af34-ab8b93eae228.json
@@ -2,7 +2,7 @@
   "data": {
     "type": "card",
     "attributes": {
-      "name": "Application",
+      "name": "App",
       "color": "",
       "description": null,
       "thumbnailURL": null

--- a/packages/experiments-realm/Task/10402eaa-3826-4602-994b-60b7506fb98d.json
+++ b/packages/experiments-realm/Task/10402eaa-3826-4602-994b-60b7506fb98d.json
@@ -2,29 +2,25 @@
   "data": {
     "type": "card",
     "attributes": {
-      "taskName": "Pill Picker Example",
-      "taskDetail": "Use multi-select but for pills",
-      "status": {
-        "index": 1,
-        "label": "Next Sprint"
-      },
       "priority": {
         "index": 1,
         "label": "Medium"
       },
-      "dateRange": {
-        "start": "2024-11-14",
-        "end": "2024-12-15"
+      "status": {
+        "completed": false,
+        "index": 1,
+        "label": "Next Sprint"
       },
+      "taskName": "Pill Picker Example",
+      "dateRange": {
+        "start": "2024-12-08",
+        "end": "2024-12-10"
+      },
+      "taskDetail": "Use multi-select but for pills",
       "description": null,
       "thumbnailURL": null
     },
     "relationships": {
-      "assignee": {
-        "links": {
-          "self": null
-        }
-      },
       "project": {
         "links": {
           "self": "../Project/51ca069b-1c55-4648-8654-bd82bf162f9d"
@@ -36,6 +32,11 @@
         }
       },
       "children": {
+        "links": {
+          "self": null
+        }
+      },
+      "assignee": {
         "links": {
           "self": null
         }

--- a/packages/experiments-realm/Task/d21d407b-9c1c-4204-a3bb-7b91f9260017.json
+++ b/packages/experiments-realm/Task/d21d407b-9c1c-4204-a3bb-7b91f9260017.json
@@ -2,29 +2,25 @@
   "data": {
     "type": "card",
     "attributes": {
-      "taskName": "Create RHS Sheet",
-      "taskDetail": null,
-      "status": {
-        "index": 0,
-        "label": "Backlog"
-      },
       "priority": {
         "index": null,
         "label": null
       },
-      "dateRange": {
-        "start": "2024-11-13",
-        "end": "2024-11-14"
+      "status": {
+        "completed": false,
+        "index": 0,
+        "label": "Backlog"
       },
+      "taskName": "Create RHS Sheet",
+      "dateRange": {
+        "start": "2024-12-01",
+        "end": "2024-12-08"
+      },
+      "taskDetail": null,
       "description": null,
       "thumbnailURL": null
     },
     "relationships": {
-      "assignee": {
-        "links": {
-          "self": "../TeamMember/4c9614cd-ecda-42cf-bc18-37903019a7be"
-        }
-      },
       "project": {
         "links": {
           "self": null
@@ -38,6 +34,11 @@
       "children": {
         "links": {
           "self": null
+        }
+      },
+      "assignee": {
+        "links": {
+          "self": "../TeamMember/4c9614cd-ecda-42cf-bc18-37903019a7be"
         }
       },
       "tags": {

--- a/packages/experiments-realm/productivity/task.gts
+++ b/packages/experiments-realm/productivity/task.gts
@@ -18,9 +18,13 @@ import CheckboxIcon from '@cardstack/boxel-icons/checkbox';
 import UsersIcon from '@cardstack/boxel-icons/users';
 import UserIcon from '@cardstack/boxel-icons/user';
 import Calendar from '@cardstack/boxel-icons/calendar';
-import { isToday, isThisWeek, addWeeks } from 'date-fns';
 import { User } from '../user';
-import { TaskBase, BaseTaskStatusField, BaseTaskPriority } from '../task';
+import {
+  TaskBase,
+  BaseTaskStatusField,
+  BaseTaskPriority,
+  getDueDateStatus,
+} from '../task';
 
 export class Team extends CardDef {
   static displayName = 'Team';
@@ -139,33 +143,6 @@ function shortenId(id: string): string {
   const shortUuid = id.slice(0, 8);
   const decimal = parseInt(shortUuid, 16);
   return decimal.toString(36).padStart(6, '0');
-}
-
-function getDueDateStatus(dueDateString: string | null) {
-  if (!dueDateString) return null;
-
-  const dueDate = new Date(dueDateString);
-  const today = new Date();
-  const nextWeek = addWeeks(today, 1);
-
-  if (isToday(dueDate)) {
-    return {
-      label: 'Due Today',
-      color: '#01de67',
-    };
-  } else if (isThisWeek(dueDate)) {
-    return {
-      label: 'This Week',
-      color: '#ffbc00',
-    };
-  } else if (dueDate > today && dueDate < nextWeek) {
-    return {
-      label: 'Next Week',
-      color: '#4fc8fd',
-    };
-  }
-
-  return null;
 }
 
 class TaskIsolated extends Component<typeof Task> {

--- a/packages/experiments-realm/task.gts
+++ b/packages/experiments-realm/task.gts
@@ -147,9 +147,7 @@ export class FittedTask extends Component<typeof TaskBase> {
           {{/if}}
         </div>
         <div class='priority-and-id-container'>
-          <div class='priority'>
-            <@fields.priority @format='atom' />
-          </div>
+          <@fields.priority class='priority' @format='atom' />
           <span class='short-id'>{{@model.shortId}}</span>
         </div>
       </header>
@@ -367,10 +365,14 @@ export class FittedTask extends Component<typeof TaskBase> {
         header {
           flex-wrap: nowrap;
         }
+        .card-assignee {
+          display: none;
+        }
       }
 
       /*Aspect Ratio 3.9, 226px × 58px*/
-      @container (aspect-ratio > 2.0) and (151px <= width < 227px) and (29px <= height < 59px) {
+      /*Aspect Ratio 2.6, 300px × 115px*/
+      @container (aspect-ratio > 2.0) and (151px <= width < 301px) and (29px <= height < 116px) {
         .task-title {
           font-size: var(--boxel-font-size-sm);
           -webkit-line-clamp: 1;
@@ -386,6 +388,12 @@ export class FittedTask extends Component<typeof TaskBase> {
         }
         header {
           flex-wrap: nowrap;
+        }
+        .date-info-container .date-status-pill {
+          display: none;
+        }
+        .card-assignee {
+          display: none;
         }
       }
 
@@ -557,7 +565,7 @@ function shortenId(id: string): string {
   return decimal.toString(36).padStart(6, '0');
 }
 
-function getDueDateStatus(dueDateString: string | null) {
+export function getDueDateStatus(dueDateString: string | null) {
   if (!dueDateString) return null;
 
   const dueDate = new Date(dueDateString);

--- a/packages/experiments-realm/task.gts
+++ b/packages/experiments-realm/task.gts
@@ -229,6 +229,7 @@ export class FittedTask extends Component<typeof TaskBase> {
         align-items: center;
         gap: var(--boxel-sp-xxxs);
         overflow: hidden;
+        line-height: 1;
       }
       .card-tag {
         width: auto;

--- a/packages/experiments-realm/task.gts
+++ b/packages/experiments-realm/task.gts
@@ -332,7 +332,7 @@ export class FittedTask extends Component<typeof TaskBase> {
         margin-left: auto;
       }
       /*catch all for dismissing tags*/
-      @container fitted-card  (width <= 226px) {
+      @container fitted-card (width <= 226px) {
         .card-tags {
           display: none;
         }

--- a/packages/experiments-realm/task.gts
+++ b/packages/experiments-realm/task.gts
@@ -129,7 +129,7 @@ export class FittedTask extends Component<typeof TaskBase> {
   <template>
     <div class='task-card'>
       <header>
-        <div>
+        <div class='task-status-and-tags-container'>
           <TaskCompletionStatus
             class='task-completion-status'
             @completed={{this.isCompleted}}
@@ -194,6 +194,10 @@ export class FittedTask extends Component<typeof TaskBase> {
         --boxel-circle-size: 14px;
         --boxel-border-radius: var(--boxel-border-radius-lg);
       }
+
+      .task-status-and-tags-container {
+      }
+
       .task-card {
         --task-font-weight-500: 500;
         --task-font-weight-600: 600;
@@ -524,7 +528,18 @@ export class BaseTaskPriority extends LooseGooseyField {
       return this.selectedPriority?.icon;
     }
     <template>
-      <this.selectedIcon width='14px' height='14px' />
+      <div class='icon-container'>
+        <this.selectedIcon width='14px' height='14px' />
+      </div>
+      <style scoped>
+        .icon-container {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          width: 100%;
+          height: 100%;
+        }
+      </style>
     </template>
   };
 }

--- a/packages/experiments-realm/task.gts
+++ b/packages/experiments-realm/task.gts
@@ -146,8 +146,10 @@ export class FittedTask extends Component<typeof TaskBase> {
             </div>
           {{/if}}
         </div>
-        <div class='short-id-container'>
-          <@fields.priority @format='atom' />
+        <div class='priority-and-id-container'>
+          <div class='priority'>
+            <@fields.priority @format='atom' />
+          </div>
           <span class='short-id'>{{@model.shortId}}</span>
         </div>
       </header>
@@ -239,7 +241,7 @@ export class FittedTask extends Component<typeof TaskBase> {
         overflow: hidden;
         text-overflow: ellipsis;
       }
-      .short-id-container {
+      .priority-and-id-container {
         display: flex;
         align-items: center;
         gap: var(--boxel-sp-xxxs);
@@ -329,101 +331,71 @@ export class FittedTask extends Component<typeof TaskBase> {
         overflow: unset;
         margin-left: auto;
       }
-
-      /* Square/Portrait Container (aspect-ratio <= 1.0) */
-      @container (aspect-ratio <= 1.0) {
-        .task-card {
-          padding: var(--boxel-sp-xs);
-        }
-
-        .date-status-pill {
-          display: none;
-        }
-
-        footer {
-          margin-top: auto;
-        }
-      }
-
-      /* Compact Portrait (height <= 230px) */
-      @container (aspect-ratio <= 1.0) and (height <=230px) {
-        .task-card {
-          gap: var(--boxel-sp-5xs);
-        }
-
-        .task-title {
-          -webkit-line-clamp: 1;
-        }
-
+      /*catch all for dismissing tags*/
+      @container fitted-card  (width <= 226px) {
         .card-tags {
           display: none;
         }
       }
 
-      /* Landscape Container (1.0 < aspect-ratio <= 2.0) */
-      @container (1.0 < aspect-ratio <= 2.0) {
-        .task-card {
-          padding: var(--boxel-sp-sm);
-        }
-      }
-
-      /* Extra styles for very narrow height but medium*/
-      @container (aspect-ratio < 2.0) and (height <= 78px) {
-        .task-title {
-          -webkit-line-clamp: 1;
-        }
-
-        .card-tags,
+      /*Aspect Ratio 0.95, 140px × 148px*/
+      /*Aspect Ratio 0.94, 120px × 128px*/
+      @container fitted-card (aspect-ratio <1.0) and (118px <= height < 129px) {
+        .priority,
         .date-info-container {
           display: none;
         }
+        header {
+          flex-wrap: nowrap;
+        }
       }
 
-      /* Extra styles for width <= 150px and height <= 100px */
-      @container (width <= 150px) and (height <= 100px) {
-        .card-tags,
-        .card-info,
-        footer {
+      /*Aspect Ratio 3.4, 100px × 29px*/
+      /*Aspect Ratio 2.6, 150px × 58px*/
+      @container (aspect-ratio > 2.0) and (100px <= width <151px) and (29px <= height < 59px) {
+        .task-card {
+          padding: var(--boxel-sp-xxxs);
+          flex-direction: row;
+          align-items: center;
+          gap: var(--boxel-sp-sm);
+        }
+        .task-title,
+        .priority,
+        .date-info-container {
           display: none;
         }
-      }
-
-      /* Extra styles for width > 280px and height 78px */
-      @container (width > 280px) and (height <= 78px) {
-        .task-completion-status {
-          display: inline-flex;
+        header {
+          flex-wrap: nowrap;
         }
       }
 
-      @container (aspect-ratio > 2.0) and (height <= 78px) {
+      /*Aspect Ratio 3.9, 226px × 58px*/
+      @container (aspect-ratio > 2.0) and (151px <= width < 227px) and (29px <= height < 59px) {
+        .task-title {
+          font-size: var(--boxel-font-size-sm);
+          -webkit-line-clamp: 1;
+        }
+        .task-card {
+          padding: var(--boxel-sp-xxxs);
+          flex-direction: row;
+          align-items: center;
+          gap: var(--boxel-sp-sm);
+        }
+        .priority {
+          display: none;
+        }
+        header {
+          flex-wrap: nowrap;
+        }
+      }
+
+      /*Aspect Ratio 8.6, 500px × 58px*/
+      @container fitted-card (aspect-ratio > 6.0) {
         .task-card {
           padding: var(--boxel-sp-xs);
           flex-direction: row;
           align-items: center;
           gap: var(--boxel-sp-sm);
-        }
-
-        .card-tags,
-        .date-info-container {
-          display: none;
-        }
-        .task-title {
-          font-size: var(--boxel-font-size-sm);
-          -webkit-line-clamp: 1;
-        }
-      }
-
-      /* Extra styles for small size */
-      @container (width <= 400px) and (height <= 58px) {
-        footer {
-          display: none;
-        }
-      }
-
-      /* Extra styles for super narrow height */
-      @container (aspect-ratio > 6.0) and (height <= 78px) {
-        .task-card {
-          padding: var(--boxel-sp-xs);
         }
 
         .card-tags,
@@ -439,16 +411,9 @@ export class FittedTask extends Component<typeof TaskBase> {
           margin-top: 0;
           margin-left: auto;
         }
-      }
-
-      /* Wide Container (aspect-ratio > 2.0) */
-      @container (aspect-ratio > 2.0) {
-        .task-card {
-          gap: var(--boxel-sp-xxxs);
-        }
-
-        .task-title {
-          -webkit-line-clamp: 1;
+        .task-completion-status {
+          --boxel-circle-size: 18px;
+          --boxel-border-radius: var(--boxel-border-radius-xs);
         }
       }
     </style>

--- a/packages/experiments-realm/task.gts
+++ b/packages/experiments-realm/task.gts
@@ -190,6 +190,12 @@ export class FittedTask extends Component<typeof TaskBase> {
     </div>
 
     <style scoped>
+      .task-status-and-tags-container {
+        display: flex;
+        align-items: center;
+        gap: var(--boxel-sp-xxxs);
+        flex-shrink: 0;
+      }
       .task-completion-status {
         --boxel-circle-size: 14px;
         --boxel-border-radius: var(--boxel-border-radius-lg);

--- a/packages/experiments-realm/task.gts
+++ b/packages/experiments-realm/task.gts
@@ -196,12 +196,10 @@ export class FittedTask extends Component<typeof TaskBase> {
         gap: var(--boxel-sp-xxxs);
         flex-shrink: 0;
       }
+
       .task-completion-status {
         --boxel-circle-size: 14px;
         --boxel-border-radius: var(--boxel-border-radius-lg);
-      }
-
-      .task-status-and-tags-container {
       }
 
       .task-card {


### PR DESCRIPTION
I wanted to incorporate the round circle on the top-left as part of design into the fitted but I noticed it was very difficult to mangle with the container queries that dont conform in some way to the fitted driver in code made the container queries  more dumb. 

This shud unblock the crm stuff 

**Before**

<img width="1087" alt="Screenshot 2024-12-05 at 00 29 39" src="https://github.com/user-attachments/assets/5c55c833-c7b6-4363-9952-1bce31d7f844">
<img width="1097" alt="Screenshot 2024-12-05 at 00 29 32" src="https://github.com/user-attachments/assets/1c83f80b-d109-4753-8709-cf235d266230">
<img width="1090" alt="Screenshot 2024-12-05 at 00 29 24" src="https://github.com/user-attachments/assets/b78f2c8d-3c58-4b6a-8a1f-a27b0a24e3b9">
<img width="1083" alt="Screenshot 2024-12-05 at 00 29 11" src="https://github.com/user-attachments/assets/ad76e75d-7d96-4b5b-a99f-85f9ff6e4308">


**After**

<img width="554" alt="Screenshot 2024-12-04 at 19 38 16" src="https://github.com/user-attachments/assets/3642a1f2-61d0-40c9-bcc1-90f34a66c82e">
<img width="551" alt="Screenshot 2024-12-04 at 19 38 08" src="https://github.com/user-attachments/assets/83fec49f-2b2e-4c38-b108-cc6931cfb273">
<img width="555" alt="Screenshot 2024-12-04 at 19 37 59" src="https://github.com/user-attachments/assets/051573c9-759c-48b5-89ec-20fa0ae1a218">
<img width="550" alt="Screenshot 2024-12-04 at 19 37 30" src="https://github.com/user-attachments/assets/f92567ae-2b6f-48be-81c8-128fb9b379ea">

A more explicit way of dealing with fitted task

Perhaps, we can fix the overflow: hidden separately