### PR TITLE
Add prefilled email on extra credit payment link

### DIFF
--- a/packages/host/app/components/operator-mode/profile/profile-subscription.gts
+++ b/packages/host/app/components/operator-mode/profile/profile-subscription.gts
@@ -24,9 +24,18 @@ export default class ProfileSubscription extends Component<Signature> {
   @service private declare matrixService: MatrixService;
 
   urlWithClientReferenceId = (url: string) => {
-    return `${url}?client_reference_id=${encodeWebSafeBase64(
+    const clientReferenceId = encodeWebSafeBase64(
       this.matrixService.userId as string,
-    )}`;
+    );
+    let newUrl = `${url}?client_reference_id=${clientReferenceId}`;
+
+    const stripeCustomerEmail =
+      this.billingService.subscriptionData?.stripeCustomerEmail;
+    if (stripeCustomerEmail) {
+      newUrl += `&prefilled_email=${encodeURIComponent(stripeCustomerEmail)}`;
+    }
+
+    return newUrl;
   };
 
   <template>


### PR DESCRIPTION
Refer to https://linear.app/cardstack/issue/CS-7592/save-users-stripe-email-to-users-table-so-that-we-can-prefill-the

What is changing
- add prefilled email on extra credit payment link

**Screenshot**
https://github.com/user-attachments/assets/27a14f50-d0a4-447a-98ed-d54f73bff3fa

