### PR TITLE
Fix CardError doc shape to be consistent with the HTTP card error response

### DIFF
--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -347,7 +347,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
     }
     return this.cardError.status === 404 &&
       // a missing link error looks a lot like a missing card error
-      this.cardError.message.includes('missing')
+      this.cardError.message?.includes('missing')
       ? `Link Not Found`
       : this.cardError.title;
   }

--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -362,7 +362,7 @@ export class CurrentRun {
         type: 'error',
         error: {
           status: 500,
-          detail: `encountered error loading module "${url.href}": ${err.message}`,
+          message: `encountered error loading module "${url.href}": ${err.message}`,
           additionalErrors: null,
           deps,
         },
@@ -569,7 +569,7 @@ export class CurrentRun {
           error:
             uncaughtError instanceof CardError
               ? serializableError(uncaughtError)
-              : { detail: `${uncaughtError.message}` },
+              : { message: `${uncaughtError.message}` },
         };
         error.error.deps = [
           moduleURL,
@@ -585,7 +585,7 @@ export class CurrentRun {
         throw err;
       }
       log.warn(
-        `encountered error indexing card instance ${path}: ${error.error.detail}`,
+        `encountered error indexing card instance ${path}: ${error.error.message}`,
       );
       await this.updateEntry(instanceURL, error);
     }

--- a/packages/host/tests/integration/components/card-delete-test.gts
+++ b/packages/host/tests/integration/components/card-delete-test.gts
@@ -54,7 +54,7 @@ module('Integration | card-delete', function (hooks) {
     if (!result || result.type === 'error') {
       throw new Error(
         `cannot get instance ${url} from the index: ${
-          result ? result.error.errorDetail.detail : 'not found'
+          result ? result.error.errorDetail.message : 'not found'
         }`,
       );
     }

--- a/packages/host/tests/integration/components/card-editor-test.gts
+++ b/packages/host/tests/integration/components/card-editor-test.gts
@@ -74,7 +74,7 @@ module('Integration | card-editor', function (hooks) {
     if (!result || result.type === 'error') {
       throw new Error(
         `cannot get instance ${url} from the index: ${
-          result ? result.error.errorDetail.detail : 'not found'
+          result ? result.error.errorDetail.message : 'not found'
         }`,
       );
     }

--- a/packages/host/tests/integration/components/text-input-validator-test.gts
+++ b/packages/host/tests/integration/components/text-input-validator-test.gts
@@ -54,7 +54,7 @@ module('Integration | text-input-validator', function (hooks) {
     if (!result || result.type === 'error') {
       throw new Error(
         `cannot get instance ${url} from the index: ${
-          result ? result.error.errorDetail.detail : 'not found'
+          result ? result.error.errorDetail.message : 'not found'
         }`,
       );
     }

--- a/packages/host/tests/integration/realm-indexing-and-querying-test.gts
+++ b/packages/host/tests/integration/realm-indexing-and-querying-test.gts
@@ -227,7 +227,7 @@ module(`Integration | realm indexing and querying`, function (hooks) {
       );
       if (mango?.type === 'error') {
         assert.deepEqual(
-          mango.error.errorDetail.detail,
+          mango.error.errorDetail.message,
           `missing file ${testRealmURL}Person/owner.json`,
         );
         assert.deepEqual(mango.error.errorDetail.deps, [
@@ -297,7 +297,7 @@ module(`Integration | realm indexing and querying`, function (hooks) {
       } else {
         assert.ok(
           false,
-          `search entry was an error: ${mango?.error.errorDetail.detail}`,
+          `search entry was an error: ${mango?.error.errorDetail.message}`,
         );
       }
     }
@@ -379,7 +379,7 @@ module(`Integration | realm indexing and querying`, function (hooks) {
     } else {
       assert.ok(
         false,
-        `search entry was an error: ${entry?.error.errorDetail.detail}`,
+        `search entry was an error: ${entry?.error.errorDetail.message}`,
       );
     }
     {
@@ -423,7 +423,7 @@ module(`Integration | realm indexing and querying`, function (hooks) {
       } else {
         assert.ok(
           false,
-          `search entry was an error: ${entry?.error.errorDetail.detail}`,
+          `search entry was an error: ${entry?.error.errorDetail.message}`,
         );
       }
     }
@@ -512,7 +512,7 @@ module(`Integration | realm indexing and querying`, function (hooks) {
     } else {
       assert.ok(
         false,
-        `search entry was an error: ${mango?.error.errorDetail.detail}`,
+        `search entry was an error: ${mango?.error.errorDetail.message}`,
       );
     }
   });
@@ -598,7 +598,7 @@ module(`Integration | realm indexing and querying`, function (hooks) {
     } else {
       assert.ok(
         false,
-        `search entry was an error: ${mango?.error.errorDetail.detail}`,
+        `search entry was an error: ${mango?.error.errorDetail.message}`,
       );
     }
   });
@@ -674,7 +674,7 @@ module(`Integration | realm indexing and querying`, function (hooks) {
     } else {
       assert.ok(
         false,
-        `search entry was an error: ${entry?.error.errorDetail.detail}`,
+        `search entry was an error: ${entry?.error.errorDetail.message}`,
       );
     }
   });
@@ -753,7 +753,7 @@ module(`Integration | realm indexing and querying`, function (hooks) {
         );
         if (entry?.type === 'error') {
           assert.strictEqual(
-            entry.error.errorDetail.detail,
+            entry.error.errorDetail.message,
             'Encountered error rendering HTML for card: intentional error',
           );
           assert.deepEqual(entry.error.errorDetail.deps, [
@@ -794,7 +794,7 @@ module(`Integration | realm indexing and querying`, function (hooks) {
         } else {
           assert.ok(
             false,
-            `expected search entry to be a document but was: ${entry?.error.errorDetail.detail}`,
+            `expected search entry to be a document but was: ${entry?.error.errorDetail.message}`,
           );
         }
       }
@@ -831,7 +831,7 @@ module(`Integration | realm indexing and querying`, function (hooks) {
         } else {
           assert.ok(
             false,
-            `expected search entry to be a document but was: ${entry?.error.errorDetail.detail}`,
+            `expected search entry to be a document but was: ${entry?.error.errorDetail.message}`,
           );
         }
       }
@@ -922,7 +922,7 @@ module(`Integration | realm indexing and querying`, function (hooks) {
     let entry = await indexer.cardDocument(new URL(`${testRealmURL}vangogh`));
     if (entry?.type === 'error') {
       assert.strictEqual(
-        entry.error.errorDetail.detail,
+        entry.error.errorDetail.message,
         'Encountered error rendering HTML for card: intentional error',
       );
     } else {
@@ -963,7 +963,7 @@ module(`Integration | realm indexing and querying`, function (hooks) {
     } else {
       assert.ok(
         false,
-        `expected search entry to be a document but was: ${entry?.error.errorDetail.detail}`,
+        `expected search entry to be a document but was: ${entry?.error.errorDetail.message}`,
       );
     }
   });
@@ -1058,7 +1058,7 @@ module(`Integration | realm indexing and querying`, function (hooks) {
     let entry = await indexer.cardDocument(new URL(`${testRealmURL}vangogh`));
     if (entry?.type === 'error') {
       assert.strictEqual(
-        entry.error.errorDetail.detail,
+        entry.error.errorDetail.message,
         'Encountered error rendering HTML for card: intentional error',
       );
     } else {
@@ -1112,7 +1112,7 @@ module(`Integration | realm indexing and querying`, function (hooks) {
     } else {
       assert.ok(
         false,
-        `expected search entry to be a document but was: ${entry?.error.errorDetail.detail}`,
+        `expected search entry to be a document but was: ${entry?.error.errorDetail.message}`,
       );
     }
   });
@@ -1488,7 +1488,7 @@ module(`Integration | realm indexing and querying`, function (hooks) {
     } else {
       assert.ok(
         false,
-        `search entry was an error: ${card?.error.errorDetail.detail}`,
+        `search entry was an error: ${card?.error.errorDetail.message}`,
       );
     }
   });
@@ -1700,7 +1700,7 @@ module(`Integration | realm indexing and querying`, function (hooks) {
     } else {
       assert.ok(
         false,
-        `search entry was an error: ${vendor?.error.errorDetail.detail}`,
+        `search entry was an error: ${vendor?.error.errorDetail.message}`,
       );
     }
   });
@@ -1743,7 +1743,7 @@ module(`Integration | realm indexing and querying`, function (hooks) {
       );
       if (card?.type === 'error') {
         assert.ok(
-          card.error.errorDetail.detail.includes('intentional error thrown'),
+          card.error.errorDetail.message.includes('intentional error thrown'),
           'error doc includes raised error message',
         );
       } else {
@@ -1760,7 +1760,7 @@ module(`Integration | realm indexing and querying`, function (hooks) {
       } else {
         assert.ok(
           false,
-          `search entry was an error: ${card?.error.errorDetail.detail}`,
+          `search entry was an error: ${card?.error.errorDetail.message}`,
         );
       }
     }
@@ -2081,7 +2081,7 @@ module(`Integration | realm indexing and querying`, function (hooks) {
     } else {
       assert.ok(
         false,
-        `search entry was an error: ${hassan?.error.errorDetail.detail}`,
+        `search entry was an error: ${hassan?.error.errorDetail.message}`,
       );
     }
 
@@ -2186,7 +2186,7 @@ module(`Integration | realm indexing and querying`, function (hooks) {
     } else {
       assert.ok(
         false,
-        `search entry was an error: ${card?.error.errorDetail.detail}`,
+        `search entry was an error: ${card?.error.errorDetail.message}`,
       );
     }
 
@@ -2387,7 +2387,7 @@ module(`Integration | realm indexing and querying`, function (hooks) {
     } else {
       assert.ok(
         false,
-        `search entry was an error: ${catalogEntry?.error.errorDetail.detail}`,
+        `search entry was an error: ${catalogEntry?.error.errorDetail.message}`,
       );
     }
 
@@ -2551,7 +2551,7 @@ module(`Integration | realm indexing and querying`, function (hooks) {
     } else {
       assert.ok(
         false,
-        `search entry was an error: ${hassan?.error.errorDetail.detail}`,
+        `search entry was an error: ${hassan?.error.errorDetail.message}`,
       );
     }
 
@@ -2726,7 +2726,7 @@ module(`Integration | realm indexing and querying`, function (hooks) {
     } else {
       assert.ok(
         false,
-        `search entry was an error: ${hassan?.error.errorDetail.detail}`,
+        `search entry was an error: ${hassan?.error.errorDetail.message}`,
       );
     }
 
@@ -2844,7 +2844,7 @@ module(`Integration | realm indexing and querying`, function (hooks) {
     } else {
       assert.ok(
         false,
-        `search entry was an error: ${mango?.error.errorDetail.detail}`,
+        `search entry was an error: ${mango?.error.errorDetail.message}`,
       );
     }
 
@@ -2954,7 +2954,7 @@ module(`Integration | realm indexing and querying`, function (hooks) {
     } else {
       assert.ok(
         false,
-        `search entry was an error: ${hassan?.error.errorDetail.detail}`,
+        `search entry was an error: ${hassan?.error.errorDetail.message}`,
       );
     }
 
@@ -3132,7 +3132,7 @@ module(`Integration | realm indexing and querying`, function (hooks) {
     } else {
       assert.ok(
         false,
-        `search entry was an error: ${hassan?.error.errorDetail.detail}`,
+        `search entry was an error: ${hassan?.error.errorDetail.message}`,
       );
     }
 
@@ -3265,7 +3265,7 @@ module(`Integration | realm indexing and querying`, function (hooks) {
     } else {
       assert.ok(
         false,
-        `search entry was an error: ${mango?.error.errorDetail.detail}`,
+        `search entry was an error: ${mango?.error.errorDetail.message}`,
       );
     }
 
@@ -3397,7 +3397,7 @@ module(`Integration | realm indexing and querying`, function (hooks) {
     } else {
       assert.ok(
         false,
-        `search entry was an error: ${vanGogh?.error.errorDetail.detail}`,
+        `search entry was an error: ${vanGogh?.error.errorDetail.message}`,
       );
     }
 

--- a/packages/host/tests/integration/realm-test.ts
+++ b/packages/host/tests/integration/realm-test.ts
@@ -480,7 +480,7 @@ module('Integration | realm', function (hooks) {
     let result = await queryEngine.cardDocument(new URL(json.data.links.self));
     if (result?.type === 'error') {
       throw new Error(
-        `unexpected error when getting card from index: ${result.error.errorDetail.detail}`,
+        `unexpected error when getting card from index: ${result.error.errorDetail.message}`,
       );
     }
     assert.strictEqual(
@@ -845,7 +845,7 @@ module('Integration | realm', function (hooks) {
     let result = await queryEngine.cardDocument(new URL(json.data.links.self));
     if (result?.type === 'error') {
       throw new Error(
-        `unexpected error when getting card from index: ${result.error.errorDetail.detail}`,
+        `unexpected error when getting card from index: ${result.error.errorDetail.message}`,
       );
     }
     assert.strictEqual(
@@ -2474,7 +2474,7 @@ module('Integration | realm', function (hooks) {
     );
     if (result?.type === 'error') {
       throw new Error(
-        `unexpected error when getting card from index: ${result.error.errorDetail.detail}`,
+        `unexpected error when getting card from index: ${result.error.errorDetail.message}`,
       );
     }
     assert.strictEqual(
@@ -2526,7 +2526,7 @@ module('Integration | realm', function (hooks) {
     result = await queryEngine.cardDocument(new URL(`${testRealmURL}cards/1`));
     if (result?.type === 'error') {
       throw new Error(
-        `unexpected error when getting card from index: ${result.error.errorDetail.detail}`,
+        `unexpected error when getting card from index: ${result.error.errorDetail.message}`,
       );
     }
     assert.strictEqual(

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -337,7 +337,7 @@ module('indexing', function (hooks) {
       );
       if (entry?.type === 'error') {
         assert.strictEqual(
-          entry.error.errorDetail.detail,
+          entry.error.errorDetail.message,
           'Encountered error rendering HTML for card: intentional error',
         );
         assert.deepEqual(entry.error.errorDetail.deps, [`${testRealm}boom`]);
@@ -351,7 +351,7 @@ module('indexing', function (hooks) {
       );
       if (entry?.type === 'error') {
         assert.strictEqual(
-          entry.error.errorDetail.detail,
+          entry.error.errorDetail.message,
           'Encountered error rendering HTML for card: Attempted to resolve a modifier in a strict mode template, but it was not in scope: did-insert',
         );
         assert.deepEqual(entry.error.errorDetail.deps, [`${testRealm}boom2`]);
@@ -395,7 +395,7 @@ module('indexing', function (hooks) {
       } else {
         assert.ok(
           false,
-          `expected search entry to be a document but was: ${entry?.error.errorDetail.detail}`,
+          `expected search entry to be a document but was: ${entry?.error.errorDetail.message}`,
         );
       }
     }
@@ -407,7 +407,7 @@ module('indexing', function (hooks) {
     );
     if (entry?.type === 'error') {
       assert.strictEqual(
-        entry.error.errorDetail.detail,
+        entry.error.errorDetail.message,
         'unable to fetch http://localhost:9000/this-is-a-link-to-nowhere: fetch failed for http://localhost:9000/this-is-a-link-to-nowhere',
       );
       assert.deepEqual(entry.error.errorDetail.deps, [
@@ -683,7 +683,7 @@ module('indexing', function (hooks) {
         {
           isCardError: true,
           additionalErrors: null,
-          detail: 'http://test-realm/post not found',
+          message: 'http://test-realm/post not found',
           status: 404,
           title: 'Not Found',
           deps: ['http://test-realm/post'],

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -2197,7 +2197,7 @@ module('Realm Server', function (hooks) {
           assert.strictEqual(response.status, 400, 'HTTP 200 status');
 
           assert.ok(
-            response.body.errors[0].detail.includes(
+            response.body.errors[0].message.includes(
               "Must include a 'prerenderedHtmlFormat' parameter with a value of 'embedded' or 'atom' to use this endpoint",
             ),
           );

--- a/packages/runtime-common/error.ts
+++ b/packages/runtime-common/error.ts
@@ -136,7 +136,10 @@ export function serializableError(err: any): any {
     return err;
   }
 
-  let result = Object.assign({}, err, { stack: err.stack });
+  let result = Object.assign({}, err, {
+    stack: err.stack,
+    message: err.message,
+  });
   result.additionalErrors =
     result.additionalErrors?.map((inner) => serializableError(inner)) ?? null;
   return result;

--- a/packages/runtime-common/error.ts
+++ b/packages/runtime-common/error.ts
@@ -14,7 +14,7 @@ export interface ErrorDetails {
 }
 
 export interface SerializedError {
-  detail: string;
+  message: string;
   status: number;
   title?: string;
   source?: ErrorDetails['source'];
@@ -25,7 +25,7 @@ export interface SerializedError {
 }
 
 export class CardError extends Error implements SerializedError {
-  detail: string;
+  message: string;
   status: number;
   title?: string;
   source?: ErrorDetails['source'];
@@ -35,11 +35,11 @@ export class CardError extends Error implements SerializedError {
   deps?: string[];
 
   constructor(
-    detail: string,
+    message: string,
     { status, title, source, responseText }: ErrorDetails = {},
   ) {
-    super(detail);
-    this.detail = detail;
+    super(message);
+    this.message = message;
     this.status = status || 500;
     this.title = title || getReasonPhrase(this.status);
     this.responseText = responseText;
@@ -48,7 +48,7 @@ export class CardError extends Error implements SerializedError {
   toJSON() {
     return {
       title: this.title,
-      detail: this.detail,
+      message: this.message,
       code: this.status,
       source: this.source,
       stack: this.stack,
@@ -59,7 +59,7 @@ export class CardError extends Error implements SerializedError {
     if (!err || typeof err !== 'object' || !isCardError(err)) {
       return err;
     }
-    let result = new CardError(err.detail, {
+    let result = new CardError(err.message, {
       status: err.status,
       title: err.title,
       source: err.source,

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -1397,14 +1397,14 @@ export class Realm {
       if (maybeError.type === 'error') {
         return systemError({
           requestContext,
-          message: `cannot return card from index: ${maybeError.error.errorDetail.title} - ${maybeError.error.errorDetail.detail}`,
+          message: `cannot return card from index: ${maybeError.error.errorDetail.title} - ${maybeError.error.errorDetail.message}`,
           additionalError: CardError.fromSerializableError(maybeError.error),
           // This is based on https://jsonapi.org/format/#errors
           body: {
             id: url.href,
             status: maybeError.error.errorDetail.status,
             title: maybeError.error.errorDetail.title,
-            message: maybeError.error.errorDetail.detail,
+            message: maybeError.error.errorDetail.message,
             // note that this is actually available as part of the response
             // header too--it's just easier for clients when it is here
             realm: this.url,

--- a/packages/runtime-common/tests/index-query-engine-test.ts
+++ b/packages/runtime-common/tests/index-query-engine-test.ts
@@ -80,7 +80,7 @@ const tests = Object.freeze({
         pristine_doc: undefined,
         types: [],
         error_doc: {
-          detail: 'test error',
+          message: 'test error',
           status: 500,
           additionalErrors: [],
         },

--- a/packages/runtime-common/tests/index-writer-test.ts
+++ b/packages/runtime-common/tests/index-writer-test.ts
@@ -563,7 +563,7 @@ const tests = Object.freeze({
     await batch.updateEntry(new URL(`${testRealmURL}1.json`), {
       type: 'error',
       error: {
-        detail: 'test error',
+        message: 'test error',
         status: 500,
         additionalErrors: [],
       },
@@ -585,7 +585,7 @@ const tests = Object.freeze({
         pristine_doc: resource,
         source,
         error_doc: {
-          detail: 'test error',
+          message: 'test error',
           status: 500,
           additionalErrors: [],
         },
@@ -627,7 +627,7 @@ const tests = Object.freeze({
       await batch.updateEntry(new URL(`${testRealmURL}1.json`), {
         type: 'error',
         error: {
-          detail: 'test error',
+          message: 'test error',
           status: 500,
           additionalErrors: [],
         },
@@ -649,7 +649,7 @@ const tests = Object.freeze({
           pristine_doc: null,
           source: null,
           error_doc: {
-            detail: 'test error',
+            message: 'test error',
             status: 500,
             additionalErrors: [],
           },
@@ -678,7 +678,7 @@ const tests = Object.freeze({
         realm_url: testRealmURL,
         type: 'error',
         error_doc: {
-          detail: 'test error',
+          message: 'test error',
           status: 500,
           additionalErrors: [],
         },
@@ -691,7 +691,7 @@ const tests = Object.freeze({
       assert.deepEqual(entry, {
         type: 'error',
         error: {
-          detail: 'test error',
+          message: 'test error',
           status: 500,
           additionalErrors: [],
         },
@@ -1123,7 +1123,7 @@ const tests = Object.freeze({
         realm_url: testRealmURL,
         type: 'error',
         error_doc: {
-          detail: 'test error',
+          message: 'test error',
           status: 500,
           additionalErrors: [],
         },
@@ -1136,7 +1136,7 @@ const tests = Object.freeze({
       assert.deepEqual(result, {
         type: 'error',
         error: {
-          detail: 'test error',
+          message: 'test error',
           status: 500,
           additionalErrors: [],
         },


### PR DESCRIPTION
We have a bug where there is an incongruity between the `CardError` shape and the HTTP error body response for card errors that resulted in a bug in rendering card errors during the sprint demo. This PR brings these shapes into alignment.

This PR will require that we clear the index as the old `CardError` shape is currently resident in the index for existing card errors.