### PR TITLE
Reduce the time that old code is pointing to new DB migration

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -87,7 +87,10 @@ jobs:
       dockerfile: "packages/postgres/Dockerfile"
 
   migrate-db:
-    needs: [build-pg-migration]
+    # use "deploy-host" and "build-realm-server" as deps so we can run
+    # migrations at last possible moment in order to reduce the amount of time
+    # that old code is pointing to new schema
+    needs: [build-pg-migration, build-realm-server, deploy-host]
     name: Deploy and run DB migrations
     uses: cardstack/gh-actions/.github/workflows/ecs-deploy.yml@main
     secrets: inherit

--- a/packages/matrix/tests/room-creation.spec.ts
+++ b/packages/matrix/tests/room-creation.spec.ts
@@ -118,7 +118,9 @@ test.describe('Room creation', () => {
     expect(user2Room).not.toEqual(newRoom);
   });
 
-  test('it can rename a room', async ({ page }) => {
+  // skipping flaky test:
+  // https://linear.app/cardstack/issue/CS-7637/flaky-test-room-creationspects1217-%E2%80%BA-room-creation-%E2%80%BA-it-can-rename-a
+  test.skip('it can rename a room', async ({ page }) => {
     await login(page, 'user1', 'pass', { url: appURL });
 
     let room1 = await getRoomId(page);


### PR DESCRIPTION
In this PR we wait until the last possible moment before running the DB migrations so that we reduce the amount of time that old code is pointing to newly migrated DB.