### PR TITLE
Support for error index entries that have no `types` value

### DIFF
--- a/packages/host/app/lib/sqlite-adapter.ts
+++ b/packages/host/app/lib/sqlite-adapter.ts
@@ -220,6 +220,7 @@ export default class SQLiteAdapter implements DBAdapter {
         }
         return `ON CONFLICT (${pkColumns})`;
       })
+      .replace(/\(case jsonb_typeof(\([^)]*\)).+ end\)/, '$1')
       .replace(/ANY_VALUE\(([^)]*)\)/g, '$1')
       .replace(/CROSS JOIN LATERAL/g, 'CROSS JOIN')
       .replace(/ILIKE/g, 'LIKE') // sqlite LIKE is case insensitive

--- a/packages/host/app/lib/sqlite-adapter.ts
+++ b/packages/host/app/lib/sqlite-adapter.ts
@@ -220,7 +220,7 @@ export default class SQLiteAdapter implements DBAdapter {
         }
         return `ON CONFLICT (${pkColumns})`;
       })
-      .replace(/\(case jsonb_typeof(\([^)]*\)).+ end\)/, '$1')
+      .replace(/\(case jsonb_typeof(\([^)]*\)) when 'array' .+ end\)/, '$1')
       .replace(/ANY_VALUE\(([^)]*)\)/g, '$1')
       .replace(/CROSS JOIN LATERAL/g, 'CROSS JOIN')
       .replace(/ILIKE/g, 'LIKE') // sqlite LIKE is case insensitive

--- a/packages/runtime-common/expression.ts
+++ b/packages/runtime-common/expression.ts
@@ -359,7 +359,7 @@ export function expressionToSql(query: Expression) {
 
           tableValuedFunctions.set(key, {
             name,
-            fn: `jsonb_array_elements_text(${column}) as ${name}`,
+            fn: `jsonb_array_elements_text(case jsonb_typeof(${column}) when 'array' then ${column} else '[]' end) as ${name}`,
           });
         }
         return name;

--- a/packages/runtime-common/tests/index-query-engine-test.ts
+++ b/packages/runtime-common/tests/index-query-engine-test.ts
@@ -2921,6 +2921,33 @@ const tests = Object.freeze({
         search_doc: { name: 'Donald' },
       },
       {
+        url: `${testRealmURL}paper.json`,
+        file_alias: `${testRealmURL}paper`,
+        type: 'error',
+        realm_version: 1,
+        realm_url: testRealmURL,
+        deps: [],
+        types: null, // here we are asserting that we can handle a `null` types column
+        embedded_html: {
+          [`${testRealmURL}fancy-person/FancyPerson`]:
+            '<div>Paper (FancyPerson embedded template)</div>',
+          [`${testRealmURL}person/Person`]:
+            '<div>Paper (Person embedded template)</div>',
+          'https://cardstack.com/base/card-api/CardDef':
+            '<div>Paper (CardDef embedded template)</div>',
+        },
+        fitted_html: {
+          [`${testRealmURL}fancy-person/FancyPerson`]:
+            '<div>Paper (FancyPerson fitted template)</div>',
+          [`${testRealmURL}person/Person`]:
+            '<div>Paper (Person fitted template)</div>',
+          'https://cardstack.com/base/card-api/CardDef':
+            '<div>Paper (CardDef fitted template)</div>',
+        },
+        atom_html: 'Paper',
+        search_doc: { name: 'Paper' },
+      },
+      {
         url: `${testRealmURL}fancy-person.gts`,
         type: 'module',
         file_alias: `${testRealmURL}fancy-person`,


### PR DESCRIPTION
This PR fixes a bug where we are unable to use the card finder type filter in staging. Specifically we are encountering a SQL error when we execute the prerendered card search SQL in staging because the column, `types`, that is assumed to be a jsonb array value is actually `null`  for some error documents where the type of the instance is unable to be derived. This update makes our jsonb_array handling more resilient for postgres, in that it will convert `null` values to an empty array in this scenario. (SQLite is already flexible enough to handle this situation).