### PR TITLE
Fix task cancellation error when fetching subscription data

### DIFF
--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -328,9 +328,6 @@ export default class OperatorModeStackItem extends Component<Signature> {
 
   @cached
   get cardError() {
-    if (this.args.item.cardError) {
-      debugger;
-    }
     return this.args.item.cardError;
   }
 

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -328,6 +328,9 @@ export default class OperatorModeStackItem extends Component<Signature> {
 
   @cached
   get cardError() {
+    if (this.args.item.cardError) {
+      debugger;
+    }
     return this.args.item.cardError;
   }
 

--- a/packages/host/app/components/with-subscription-data.gts
+++ b/packages/host/app/components/with-subscription-data.gts
@@ -3,6 +3,8 @@ import { hash } from '@ember/helper';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
+import { task } from 'ember-concurrency';
+
 import { LoadingIndicator } from '@cardstack/boxel-ui/components';
 import { cn } from '@cardstack/boxel-ui/helpers';
 import { IconHexagon } from '@cardstack/boxel-ui/icons';
@@ -73,7 +75,7 @@ export default class WithSubscriptionData extends Component<WithSubscriptionData
 
   constructor(...args: [any, any]) {
     super(...args);
-    this.billingService.fetchSubscriptionData();
+    this.fetchSubscriptionData.perform();
   }
 
   private get isLoading() {
@@ -119,6 +121,10 @@ export default class WithSubscriptionData extends Component<WithSubscriptionData
       this.creditsAvailableInPlanAllowance <= 0
     );
   }
+
+  private fetchSubscriptionData = task(async () => {
+    await this.billingService.fetchSubscriptionData();
+  });
 
   <template>
     {{yield

--- a/packages/host/app/services/billing-service.ts
+++ b/packages/host/app/services/billing-service.ts
@@ -3,8 +3,6 @@ import Service from '@ember/service';
 import { service } from '@ember/service';
 import { tracked, cached } from '@glimmer/tracking';
 
-import { dropTask } from 'ember-concurrency';
-
 import { trackedFunction } from 'ember-resources/util/function';
 
 import {
@@ -33,6 +31,7 @@ interface StripeLink {
 
 export default class BillingService extends Service {
   @tracked private _subscriptionData: SubscriptionData | null = null;
+  @tracked private _fetchingSubscriptionData = false;
 
   @service private declare realmServer: RealmServerService;
   @service private declare network: NetworkService;
@@ -42,7 +41,7 @@ export default class BillingService extends Service {
     super(owner);
     this.realmServer.subscribeEvent(
       'billing-notification',
-      this.subscriptionDataRefresher.bind(this),
+      this.fetchSubscriptionData.bind(this),
     );
     this.reset.register(this);
   }
@@ -144,53 +143,50 @@ export default class BillingService extends Service {
   }
 
   get fetchingSubscriptionData() {
-    return this.fetchSubscriptionDataTask.isRunning;
+    return this._fetchingSubscriptionData;
   }
 
-  fetchSubscriptionData() {
-    this.fetchSubscriptionDataTask.perform();
-  }
-
-  private async subscriptionDataRefresher() {
-    await this.fetchSubscriptionDataTask.perform();
-  }
-
-  private fetchSubscriptionDataTask = dropTask(async () => {
-    let response = await this.network.fetch(`${this.url.origin}/_user`, {
-      headers: {
-        Accept: SupportedMimeType.JSONAPI,
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${await this.getToken()}`,
-      },
-    });
-    if (!response.ok) {
-      console.error(
-        `Failed to fetch user for realm server ${this.url.origin}: ${response.status}`,
-      );
-      return;
+  async fetchSubscriptionData() {
+    this._fetchingSubscriptionData = true;
+    try {
+      let response = await this.network.fetch(`${this.url.origin}/_user`, {
+        headers: {
+          Accept: SupportedMimeType.JSONAPI,
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${await this.getToken()}`,
+        },
+      });
+      if (!response.ok) {
+        console.error(
+          `Failed to fetch user for realm server ${this.url.origin}: ${response.status}`,
+        );
+        return;
+      }
+      let json = await response.json();
+      let plan =
+        json.included?.find((i: { type: string }) => i.type === 'plan')
+          ?.attributes?.name ?? null;
+      let creditsAvailableInPlanAllowance =
+        json.data?.attributes?.creditsAvailableInPlanAllowance ?? null;
+      let creditsIncludedInPlanAllowance =
+        json.data?.attributes?.creditsIncludedInPlanAllowance ?? null;
+      let extraCreditsAvailableInBalance =
+        json.data?.attributes?.extraCreditsAvailableInBalance ?? null;
+      let stripeCustomerId = json.data?.attributes?.stripeCustomerId ?? null;
+      let stripeCustomerEmail =
+        json.data?.attributes?.stripeCustomerEmail ?? null;
+      this._subscriptionData = {
+        plan,
+        creditsAvailableInPlanAllowance,
+        creditsIncludedInPlanAllowance,
+        extraCreditsAvailableInBalance,
+        stripeCustomerId,
+        stripeCustomerEmail,
+      };
+    } finally {
+      this._fetchingSubscriptionData = false;
     }
-    let json = await response.json();
-    let plan =
-      json.included?.find((i: { type: string }) => i.type === 'plan')
-        ?.attributes?.name ?? null;
-    let creditsAvailableInPlanAllowance =
-      json.data?.attributes?.creditsAvailableInPlanAllowance ?? null;
-    let creditsIncludedInPlanAllowance =
-      json.data?.attributes?.creditsIncludedInPlanAllowance ?? null;
-    let extraCreditsAvailableInBalance =
-      json.data?.attributes?.extraCreditsAvailableInBalance ?? null;
-    let stripeCustomerId = json.data?.attributes?.stripeCustomerId ?? null;
-    let stripeCustomerEmail =
-      json.data?.attributes?.stripeCustomerEmail ?? null;
-    this._subscriptionData = {
-      plan,
-      creditsAvailableInPlanAllowance,
-      creditsIncludedInPlanAllowance,
-      extraCreditsAvailableInBalance,
-      stripeCustomerId,
-      stripeCustomerEmail,
-    };
-  });
+  }
 
   private async getToken() {
     if (!this.realmServer.token) {


### PR DESCRIPTION
This issue was driving me crazy, I had to fix it....

This fixes the task cancellation error when fetching subscription data. Please make sure that tasks are only used in places where the lifetime of the owner is not infinte. Using a task in a service is a code smell. Anytime a Task.perform is `awaited` on the outside the task become non-cancellable. In this case the task lived in a service, which lives forever,. There is no need for cancellable promises that Tasks provide because the service never goes away.

![image](https://github.com/user-attachments/assets/77c3162b-690b-4c32-a389-87184927ad10)

This PR removes the task from the service, and adds it to the component that consumes this service's async, which is where it should always have been.
