### PR TITLE
host: Remove stack trace from Percy snapshots

### DIFF
--- a/packages/host/app/components/operator-mode/card-error-detail.gts
+++ b/packages/host/app/components/operator-mode/card-error-detail.gts
@@ -78,6 +78,7 @@ export default class CardErrorDetail extends Component<Signature> {
                 <div class='detail-title'>Stack trace:</div>
                 <pre
                   data-test-error-stack
+                  data-test-percy-hide
                 >
 {{@error.meta.stack}}
                 </pre>


### PR DESCRIPTION
This should prevent diff noise as seen here:

<img width="1122" alt="Build #8966 - Cardstack - Percy | Visual testing as a service 2024-12-06 15-24-31" src="https://github.com/user-attachments/assets/b9b3eeae-ec74-4084-be0c-0592b7e3ca87">
