### PR TITLE
CS 7612 Payment setup copy adjustment

### DIFF
--- a/.github/workflows/build-host.yml
+++ b/.github/workflows/build-host.yml
@@ -30,14 +30,12 @@ jobs:
             echo "MATRIX_URL=https://matrix.boxel.ai" >> $GITHUB_ENV
             echo "MATRIX_SERVER_NAME=boxel.ai" >> $GITHUB_ENV
             echo "EXPERIMENTAL_AI_ENABLED=true" >> $GITHUB_ENV
-            echo "STRIPE_PAYMENT_LINK=https://buy.stripe.com/00g29k8zLgI35xK000" >> $GITHUB_ENV
           elif [ "$INPUT_ENVIRONMENT" = "staging" ]; then
             echo "OWN_REALM_URL=https://realms-staging.stack.cards/experiments/" >> $GITHUB_ENV
             echo "RESOLVED_BASE_REALM_URL=https://realms-staging.stack.cards/base/" >> $GITHUB_ENV
             echo "MATRIX_URL=https://matrix-staging.stack.cards" >> $GITHUB_ENV
             echo "MATRIX_SERVER_NAME=stack.cards" >> $GITHUB_ENV
             echo "EXPERIMENTAL_AI_ENABLED=true" >> $GITHUB_ENV
-            echo "STRIPE_PAYMENT_LINK=https://buy.stripe.com/test_9AQdUjgaDePb8lWcMN" >> $GITHUB_ENV
           else
             echo "unrecognized environment"
             exit 1;

--- a/.github/workflows/pr-boxel-host.yml
+++ b/.github/workflows/pr-boxel-host.yml
@@ -61,7 +61,6 @@ jobs:
           MATRIX_URL: https://matrix-staging.stack.cards
           MATRIX_SERVER_NAME: stack.cards
           EXPERIMENTAL_AI_ENABLED: true
-          STRIPE_PAYMENT_LINK: https://buy.stripe.com/test_9AQdUjgaDePb8lWcMN
           S3_PREVIEW_BUCKET_NAME: boxel-host-preview.stack.cards
           AWS_S3_BUCKET: boxel-host-preview.stack.cards
           AWS_REGION: us-east-1
@@ -93,7 +92,6 @@ jobs:
           MATRIX_URL: https://matrix.boxel.ai
           MATRIX_SERVER_NAME: boxel.ai
           EXPERIMENTAL_AI_ENABLED: true
-          STRIPE_PAYMENT_LINK: https://buy.stripe.com/00g29k8zLgI35xK000
           S3_PREVIEW_BUCKET_NAME: boxel-host-preview.boxel.ai
           AWS_S3_BUCKET: boxel-host-preview.boxel.ai
           AWS_REGION: us-east-1

--- a/packages/host/app/components/matrix/payment-setup.gts
+++ b/packages/host/app/components/matrix/payment-setup.gts
@@ -85,7 +85,7 @@ export default class PaymentSetup extends Component<Signature> {
           {{else}}
             <div class='success-banner' data-test-setup-payment-message>
               <InfoCircleIcon class='info-icon' />
-              Setup your payment method now to enjoy Boxel
+              Set up your payment method now to enjoy Boxel
             </div>
           {{/if}}
 

--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -38,9 +38,6 @@ module.exports = function (environment) {
     loginMessageTimeoutMs: 1000,
     minSaveTaskDurationMs: 1000,
     iconsURL: process.env.ICONS_URL || 'https://boxel-icons.boxel.ai',
-    stripePaymentLink:
-      process.env.STRIPE_PAYMENT_LINK ||
-      'https://buy.stripe.com/test_4gw01WfWb2c1dBm7sv',
 
     // the fields below may be rewritten by the realm server
     hostsOwnAssets: true,

--- a/packages/matrix/tests/registration-with-token.spec.ts
+++ b/packages/matrix/tests/registration-with-token.spec.ts
@@ -209,7 +209,7 @@ test.describe('User Registration w/ Token - isolated realm server', () => {
 
     await expect(
       page.locator('[data-test-setup-payment-message]'),
-    ).toContainText('Setup your payment method now to enjoy Boxel');
+    ).toContainText('Set up your payment method now to enjoy Boxel');
 
     const user2MatrixUserId = encodeWebSafeBase64('@user2:localhost');
 


### PR DESCRIPTION
Refer to https://linear.app/cardstack/issue/CS-7612/setup-should-be-set-up-on-pre-stripe-reg-screen

### What is changing
- change "Setup" to "Set up"
- clean up unused Stripe environment variables

**Before**
![image](https://github.com/user-attachments/assets/aa932fce-b27a-412d-af1f-eafe20fc2a01)

**After**
![Screenshot 2024-12-09 at 3 01 33 PM](https://github.com/user-attachments/assets/63126737-fc54-4857-a856-277b98b80553)
