### PR TITLE
Free plan credits should not carry over when upgrading to a paid plan

### DIFF
--- a/packages/billing/billing-queries.ts
+++ b/packages/billing/billing-queries.ts
@@ -101,7 +101,7 @@ export async function getPlanByStripeId(
   return {
     id: results[0].id,
     name: results[0].name,
-    monthlyPrice: results[0].monthly_price,
+    monthlyPrice: parseFloat(results[0].monthly_price as string),
     creditsIncluded: results[0].credits_included,
     stripePlanId: results[0].stripe_plan_id,
   } as Plan;
@@ -456,7 +456,7 @@ export async function getPlanById(
   return {
     id: results[0].id,
     name: results[0].name,
-    monthlyPrice: results[0].monthly_price,
+    monthlyPrice: parseFloat(results[0].monthly_price as string),
     creditsIncluded: results[0].credits_included,
     stripePlanId: results[0].stripe_plan_id,
   } as Plan;
@@ -478,7 +478,7 @@ export async function getPlanByMonthlyPrice(
   return {
     id: results[0].id,
     name: results[0].name,
-    monthlyPrice: results[0].monthly_price,
+    monthlyPrice: parseFloat(results[0].monthly_price as string),
     creditsIncluded: results[0].credits_included,
     stripePlanId: results[0].stripe_plan_id,
   } as Plan;

--- a/packages/billing/billing-queries.ts
+++ b/packages/billing/billing-queries.ts
@@ -1,6 +1,7 @@
 import {
   DBAdapter,
   Expression,
+  PgPrimitive,
   addExplicitParens,
   asExpressions,
   every,
@@ -57,6 +58,16 @@ export interface LedgerEntry {
   subscriptionCycleId: string | null;
 }
 
+function planRowToPlan(row: Record<string, PgPrimitive>): Plan {
+  return {
+    id: row.id,
+    name: row.name,
+    monthlyPrice: parseFloat(row.monthly_price as string),
+    creditsIncluded: row.credits_included,
+    stripePlanId: row.stripe_plan_id,
+  } as Plan;
+}
+
 export async function insertStripeEvent(
   dbAdapter: DBAdapter,
   event: StripeEvent,
@@ -98,13 +109,7 @@ export async function getPlanByStripeId(
     return null;
   }
 
-  return {
-    id: results[0].id,
-    name: results[0].name,
-    monthlyPrice: parseFloat(results[0].monthly_price as string),
-    creditsIncluded: results[0].credits_included,
-    stripePlanId: results[0].stripe_plan_id,
-  } as Plan;
+  return planRowToPlan(results[0]);
 }
 
 export async function updateUserStripeCustomerId(
@@ -453,13 +458,7 @@ export async function getPlanById(
     return null;
   }
 
-  return {
-    id: results[0].id,
-    name: results[0].name,
-    monthlyPrice: parseFloat(results[0].monthly_price as string),
-    creditsIncluded: results[0].credits_included,
-    stripePlanId: results[0].stripe_plan_id,
-  } as Plan;
+  return planRowToPlan(results[0]);
 }
 
 export async function getPlanByMonthlyPrice(
@@ -475,13 +474,7 @@ export async function getPlanByMonthlyPrice(
     return null;
   }
 
-  return {
-    id: results[0].id,
-    name: results[0].name,
-    monthlyPrice: parseFloat(results[0].monthly_price as string),
-    creditsIncluded: results[0].credits_included,
-    stripePlanId: results[0].stripe_plan_id,
-  } as Plan;
+  return planRowToPlan(results[0]);
 }
 
 export async function expireRemainingPlanAllowanceInSubscriptionCycle(

--- a/packages/billing/stripe-webhook-handlers/payment-succeeded.ts
+++ b/packages/billing/stripe-webhook-handlers/payment-succeeded.ts
@@ -22,10 +22,6 @@ import { StripeInvoicePaymentSucceededWebhookEvent } from '.';
 import { PgAdapter, TransactionManager } from '@cardstack/postgres';
 import { ProrationCalculator } from '../proration-calculator';
 
-// TODOs that will be handled in a separated PRs:
-// - signal to frontend that subscription has been created and credits have been added
-// - put this in a background job
-
 export async function handlePaymentSucceeded(
   dbAdapter: DBAdapter,
   event: StripeInvoicePaymentSucceededWebhookEvent,

--- a/packages/realm-server/tests/billing-test.ts
+++ b/packages/realm-server/tests/billing-test.ts
@@ -350,8 +350,8 @@ module('billing', function (hooks) {
 
         subscriptionCycle = subscriptionCycles[0];
 
-        // User received 5000 credits from the creator plan, plus 500 from the plan allowance they had left from the free plan
-        assert.strictEqual(creditsBalance, 5500);
+        // User received 5000 credits from the creator plan, but the 500 credits from the plan allowance they had left from the free plan were expired
+        assert.strictEqual(creditsBalance, 5000);
 
         // User spent 2000 credits from the plan allowance
         await addToCreditsLedger(dbAdapter, {
@@ -361,11 +361,11 @@ module('billing', function (hooks) {
           subscriptionCycleId: subscriptionCycle.id,
         });
 
-        // Assert that the user now has 3500 credits left
+        // Assert that the user now has 3000 credits left
         creditsBalance = await sumUpCreditsLedger(dbAdapter, {
           userId: user.id,
         });
-        assert.strictEqual(creditsBalance, 3500);
+        assert.strictEqual(creditsBalance, 3000);
 
         // Now, user upgrades to power user plan ($49 monthly) in the middle of the month:
 

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -461,7 +461,7 @@ export async function insertPlan(
   return {
     id: result[0].id,
     name: result[0].name,
-    monthlyPrice: result[0].monthly_price,
+    monthlyPrice: parseFloat(result[0].monthly_price as string),
     creditsIncluded: result[0].credits_included,
     stripePlanId: result[0].stripe_plan_id,
   } as Plan;

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -2761,7 +2761,7 @@ module('Realm Server', function (hooks) {
       john: ['read', 'write'],
     });
 
-    test('user is not found', async function (assert) {
+    test('responds with 404 if user is not found', async function (assert) {
       let response = await request
         .get(`/_user`)
         .set('Accept', 'application/vnd.api+json')
@@ -2772,7 +2772,7 @@ module('Realm Server', function (hooks) {
       assert.strictEqual(response.status, 404, 'HTTP 404 status');
     });
 
-    test('subscription is not found', async function (assert) {
+    test('responds with 200 and null subscription values if user is not subscribed', async function (assert) {
       let user = await insertUser(
         dbAdapter,
         'user@test',
@@ -2812,7 +2812,7 @@ module('Realm Server', function (hooks) {
       );
     });
 
-    test('user subscibes to a plan and has extra credit', async function (assert) {
+    test('response has correct values for subscribed user who has some extra credits', async function (assert) {
       let user = await insertUser(
         dbAdapter,
         'user@test',


### PR DESCRIPTION
Previously, if you had 1000 credits from the free plan, and upgraded to a paid plan (e.g. "creator" plan for 5000 credits), you'd get 6000 credits. This change adjusts the plan upgrading logic to not add unused free plan credits when a paid subscription is made. 