### PR TITLE
Add live card support for showing and dismissing errors

### DIFF
--- a/packages/host/app/components/operator-mode/card-error-detail.gts
+++ b/packages/host/app/components/operator-mode/card-error-detail.gts
@@ -19,7 +19,7 @@ import type CommandService from '../../services/command-service';
 
 interface Signature {
   Args: {
-    error: CardError['errors'][0];
+    error: CardError;
     viewInCodeMode?: true;
     title?: string;
   };

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -30,8 +30,6 @@ import type IndexController from '@cardstack/host/controllers';
 
 import { assertNever } from '@cardstack/host/utils/assert-never';
 
-import type { CardDef } from 'https://cardstack.com/base/card-api';
-
 import SearchSheet, {
   SearchSheetMode,
   SearchSheetModes,
@@ -99,12 +97,16 @@ export default class SubmodeLayout extends Component<Signature> {
     return this.operatorModeStateService.state?.stacks.flat() ?? [];
   }
 
-  private get lastCardInRightMostStack(): CardDef | null {
+  private get lastCardIdInRightMostStack() {
     if (this.allStackItems.length <= 0) {
       return null;
     }
 
-    return this.allStackItems[this.allStackItems.length - 1].card;
+    let stackItem = this.allStackItems[this.allStackItems.length - 1];
+    if (stackItem.cardError) {
+      return stackItem.cardError.id;
+    }
+    return stackItem.card.id;
   }
 
   private get isToggleWorkspaceChooserDisabled() {
@@ -118,8 +120,8 @@ export default class SubmodeLayout extends Component<Signature> {
         break;
       case Submodes.Code:
         this.operatorModeStateService.updateCodePath(
-          this.lastCardInRightMostStack
-            ? new URL(this.lastCardInRightMostStack.id + '.json')
+          this.lastCardIdInRightMostStack
+            ? new URL(this.lastCardIdInRightMostStack + '.json')
             : null,
         );
         break;

--- a/packages/host/app/resources/card-resource.ts
+++ b/packages/host/app/resources/card-resource.ts
@@ -35,7 +35,7 @@ import type RealmService from '../services/realm';
 
 interface CardErrors {
   errors: {
-    id: string;
+    id?: string; // 404 errors won't necessarily have an id
     status: number;
     title: string;
     message: string;
@@ -340,7 +340,9 @@ export class CardResource extends Resource<Args> {
     if (this.onCardInstanceChange) {
       this.onCardInstanceChange(this._card, instance);
     }
-    this.subscribeToRealm(maybeCard.id);
+    if (maybeCard.id) {
+      this.subscribeToRealm(maybeCard.id);
+    }
     this.setCardOrError(maybeCard);
   }
 

--- a/packages/host/app/resources/card-resource.ts
+++ b/packages/host/app/resources/card-resource.ts
@@ -102,13 +102,14 @@ class LiveCardIdentityContext implements IdentityContext {
 }
 
 let liveCardIdentityContext = new LiveCardIdentityContext();
-const realmSubscriptions: Map<
+let realmSubscriptions: Map<
   string,
   WeakMap<CardResource, { unsubscribe: () => void }>
 > = new Map();
 
-export function testOnlyResetLiveCardIdentityContext() {
+export function testOnlyResetCardResourceModuleState() {
   liveCardIdentityContext = new LiveCardIdentityContext();
+  realmSubscriptions = new Map();
 }
 
 export class CardResource extends Resource<Args> {

--- a/packages/host/app/resources/card-resource.ts
+++ b/packages/host/app/resources/card-resource.ts
@@ -209,7 +209,10 @@ export class CardResource extends Resource<Args> {
       realmURL = card[this.api.realmURL];
     }
     if (!realmURL) {
-      throw new Error(`could not determine realm for card ${id}`);
+      console.warn(
+        `could not determine realm for card ${id} when trying to subscribe to realm`,
+      );
+      return;
     }
     let realmSubscribers = realmSubscriptions.get(realmURL.href);
     if (!realmSubscribers) {

--- a/packages/host/app/resources/card-resource.ts
+++ b/packages/host/app/resources/card-resource.ts
@@ -4,6 +4,7 @@
 
 import { registerDestructor } from '@ember/destroyable';
 import { getOwner } from '@ember/owner';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 import { restartableTask } from 'ember-concurrency';
@@ -13,11 +14,10 @@ import { Resource } from 'ember-resources';
 import status from 'statuses';
 
 import {
-  Loader,
   isSingleCardDocument,
   apiFor,
-  loaderFor,
   hasExecutableExtension,
+  isCardInstance,
 } from '@cardstack/runtime-common';
 
 import type MessageService from '@cardstack/host/services/message-service';
@@ -31,8 +31,9 @@ import type * as CardAPI from 'https://cardstack.com/base/card-api';
 
 import type CardService from '../services/card-service';
 import type LoaderService from '../services/loader-service';
+import type RealmService from '../services/realm';
 
-export interface CardError {
+interface CardErrors {
   errors: {
     id: string;
     status: number;
@@ -47,12 +48,13 @@ export interface CardError {
   }[];
 }
 
+export type CardError = CardErrors['errors'][0];
+
 interface Args {
   named: {
     // using string type here so that URL's that have the same href but are
     // different instances don't result in re-running the resource
     url: string | undefined;
-    loader: Loader;
     isLive: boolean;
     // this is not always constructed within a container so we pass in our services
     cardService: CardService;
@@ -69,7 +71,7 @@ class LiveCardIdentityContext implements IdentityContext {
   #cards = new Map<
     string,
     {
-      card: CardDef;
+      card: CardDef | undefined; // undefined means that the card is in an error state
       subscribers: Set<object>;
     }
   >();
@@ -83,13 +85,23 @@ class LiveCardIdentityContext implements IdentityContext {
   delete(url: string): void {
     this.#cards.delete(url);
   }
-
+  update(url: string, instance: CardDef | undefined) {
+    let entry = this.#cards.get(url);
+    if (!entry) {
+      this.#cards.set(url, { card: instance, subscribers: new Set() });
+    } else {
+      entry.card = instance;
+    }
+  }
+  hasError(url: string) {
+    return this.#cards.has(url) && !this.#cards.get(url)?.card;
+  }
   subscribers(url: string): Set<object> | undefined {
     return this.#cards.get(url)?.subscribers;
   }
 }
 
-const liveCards: WeakMap<Loader, LiveCardIdentityContext> = new WeakMap();
+const liveCardIdentityContext = new LiveCardIdentityContext();
 const realmSubscriptions: Map<
   string,
   WeakMap<CardResource, { unsubscribe: () => void }>
@@ -98,7 +110,8 @@ const realmSubscriptions: Map<
 export class CardResource extends Resource<Args> {
   url: string | undefined;
   @tracked loaded: Promise<void> | undefined;
-  @tracked cardError: CardError['errors'][0] | undefined;
+  @tracked cardError: CardError | undefined;
+  @service private declare realm: RealmService;
   @tracked private _card: CardDef | undefined;
   @tracked private _api: typeof CardAPI | undefined;
   @tracked private staleCard: CardDef | undefined;
@@ -106,7 +119,6 @@ export class CardResource extends Resource<Args> {
   private declare messageService: MessageService;
   private declare loaderService: LoaderService;
   private declare resetLoader: () => void;
-  private _loader: Loader | undefined;
   private onCardInstanceChange?: (
     oldCard: CardDef | undefined,
     newCard: CardDef | undefined,
@@ -120,7 +132,6 @@ export class CardResource extends Resource<Args> {
 
     let {
       url,
-      loader,
       isLive,
       onCardInstanceChange,
       messageService,
@@ -129,8 +140,7 @@ export class CardResource extends Resource<Args> {
     } = named;
     this.messageService = messageService;
     this.cardService = cardService;
-    this.url = url;
-    this._loader = loader;
+    this.url = url?.replace(/\.json$/, '');
     this.onCardInstanceChange = onCardInstanceChange;
     this.cardError = undefined;
     this.resetLoader = resetLoader;
@@ -141,8 +151,8 @@ export class CardResource extends Resource<Args> {
     }
 
     registerDestructor(this, () => {
-      if (this.card) {
-        this.removeLiveCardEntry(this.card);
+      if (this.url) {
+        this.removeLiveCardEntry(this.url);
       }
       this.unsubscribeFromRealm();
     });
@@ -164,43 +174,37 @@ export class CardResource extends Resource<Args> {
     return this._api;
   }
 
-  private get loader() {
-    if (!this._loader) {
-      throw new Error(
-        `bug: should never get here, loader is obtained via owner`,
-      );
-    }
-    return this._loader;
-  }
-
   private loadStaticModel = restartableTask(async (url: URL) => {
-    let card = await this.getCard(url);
-    await this.updateCardInstance(card);
+    let cardOrError = await this.getCard(url);
+    await this.updateCardInstance(cardOrError);
   });
 
   private loadLiveModel = restartableTask(async (url: URL) => {
-    let identityContext = liveCards.get(this.loader);
-    if (!identityContext) {
-      identityContext = new LiveCardIdentityContext();
-      liveCards.set(this.loader, identityContext);
+    let cardOrError = await this.getCard(url, liveCardIdentityContext);
+    if (isCardInstance(cardOrError)) {
+      let subscribers = liveCardIdentityContext.subscribers(cardOrError.id)!;
+      subscribers.add(this);
+    } else {
+      console.warn(`cannot load card ${cardOrError.id}`, cardOrError);
+      this.subscribeToRealm(url.href);
     }
-    let card = await this.getCard(url, identityContext);
-    if (!card) {
-      if (this.cardError) {
-        console.warn(`cannot load card ${this.cardError.id}`, this.cardError);
-      }
-      this.clearCardInstance();
-      return;
-    }
-    let subscribers = identityContext.subscribers(card.id)!;
-    subscribers.add(this);
-    await this.updateCardInstance(card);
+    await this.updateCardInstance(cardOrError);
   });
 
-  private subscribeToRealm(card: CardDef) {
-    let realmURL = card[this.api.realmURL];
+  private subscribeToRealm(cardOrId: CardDef | string) {
+    let card: CardDef | undefined;
+    let id: string;
+    let realmURL: URL | undefined;
+    if (typeof cardOrId === 'string') {
+      id = cardOrId;
+      realmURL = this.realm.realmOfURL(new URL(id));
+    } else {
+      card = cardOrId;
+      id = card.id;
+      realmURL = card[this.api.realmURL];
+    }
     if (!realmURL) {
-      throw new Error(`could not determine realm for card ${card.id}`);
+      throw new Error(`could not determine realm for card ${id}`);
     }
     let realmSubscribers = realmSubscriptions.get(realmURL.href);
     if (!realmSubscribers) {
@@ -211,7 +215,6 @@ export class CardResource extends Resource<Args> {
       return;
     }
     realmSubscribers.set(this, {
-      // TODO figure out how to go in an out of errors via SSE
       unsubscribe: this.messageService.subscribe(
         realmURL.href,
         ({ type, data: dataStr }) => {
@@ -224,13 +227,21 @@ export class CardResource extends Resource<Args> {
           }
           let invalidations = data.invalidations as string[];
           let card = this.url
-            ? liveCards.get(this.loader)?.get(this.url)
+            ? liveCardIdentityContext.get(this.url)
             : undefined;
 
           if (!card) {
-            // the initial card static load has not actually completed yet
-            // (perhaps the loader just changed). in this case we ignore this
-            // message.
+            if (this.url && liveCardIdentityContext.hasError(this.url)) {
+              if (invalidations.find((i) => hasExecutableExtension(i))) {
+                // the invalidation included code changes too. in this case we
+                // need to flush the loader so that we can pick up any updated
+                // code before re-running the card
+                this.resetLoader();
+              }
+              // we've already established a subscription--we're in it, just
+              // load the updated instance
+              this.loadStaticModel.perform(new URL(this.url));
+            }
             return;
           }
 
@@ -253,10 +264,7 @@ export class CardResource extends Resource<Args> {
     });
   }
 
-  private async getCard(
-    url: URL,
-    identityContext?: IdentityContext,
-  ): Promise<CardDef | undefined> {
+  private async getCard(url: URL, identityContext?: LiveCardIdentityContext) {
     if (typeof url === 'string') {
       url = new URL(url);
     }
@@ -266,7 +274,6 @@ export class CardResource extends Resource<Args> {
     if (existingCard) {
       return existingCard;
     }
-    this.cardError = undefined;
     try {
       let json = await this.cardService.fetchJSON(url);
       if (!isSingleCardDocument(json)) {
@@ -283,65 +290,28 @@ export class CardResource extends Resource<Args> {
           identityContext,
         },
       );
+      if (identityContext && identityContext.hasError(url.href)) {
+        liveCardIdentityContext.update(url.href, card);
+      }
       return card;
     } catch (error: any) {
-      let errorResponse: CardError;
-      try {
-        errorResponse = JSON.parse(error.responseText) as CardError;
-      } catch (parseError) {
-        switch (error.status) {
-          // tailor HTTP responses as necessary for better user feedback
-          case 404:
-            errorResponse = {
-              errors: [
-                {
-                  id: url.href,
-                  status: 404,
-                  title: 'Card Not Found',
-                  message: `The card ${url.href} does not exist`,
-                  realm: error.responseHeaders?.get('X-Boxel-Realm-Url'),
-                  meta: {
-                    lastKnownGoodHtml: null,
-                    scopedCssUrls: [],
-                    stack: null,
-                  },
-                },
-              ],
-            };
-            break;
-          default:
-            errorResponse = {
-              errors: [
-                {
-                  id: url.href,
-                  status: error.status,
-                  title: status.message[error.status] ?? `HTTP ${error.status}`,
-                  message: `Received HTTP ${error.status} from server ${
-                    error.responseText ?? ''
-                  }`.trim(),
-                  realm: error.responseHeaders?.get('X-Boxel-Realm-Url'),
-                  meta: {
-                    lastKnownGoodHtml: null,
-                    scopedCssUrls: [],
-                    stack: null,
-                  },
-                },
-              ],
-            };
-        }
+      if (identityContext) {
+        liveCardIdentityContext.update(url.href, undefined);
       }
-      this.cardError = errorResponse.errors[0];
-      return;
+      let errorResponse = processCardError(url, error);
+      return errorResponse.errors[0];
     }
   }
 
-  // TODO deal with live update of card that goes into and out of an error state
   private reload = task(async (card: CardDef) => {
     try {
       await this.cardService.reloadCard(card);
     } catch (err: any) {
       if (err.status !== 404) {
-        throw err;
+        liveCardIdentityContext.update(card.id, undefined);
+        let errorResponse = processCardError(new URL(card.id), err);
+        this.setCardOrError(errorResponse.errors[0]);
+        return;
       }
       // in this case the document was invalidated in the index because the
       // file was deleted
@@ -361,39 +331,38 @@ export class CardResource extends Resource<Args> {
     }
   };
 
-  private async updateCardInstance(maybeCard: CardDef | undefined) {
-    if (maybeCard) {
+  private async updateCardInstance(maybeCard: CardDef | CardError) {
+    let instance: CardDef | undefined;
+    if (isCardInstance(maybeCard)) {
+      instance = maybeCard;
       this._api = await apiFor(maybeCard);
-    } else {
-      this._api = undefined;
     }
     if (this.onCardInstanceChange) {
-      this.onCardInstanceChange(this._card, maybeCard);
+      this.onCardInstanceChange(this._card, instance);
     }
-    if (maybeCard) {
-      this.subscribeToRealm(maybeCard);
-    }
-
-    // clean up the live card entry if the new card is undefined or if it's
-    // using a different loader
-    if (
-      this._card &&
-      (!maybeCard || loaderFor(maybeCard) !== loaderFor(this._card))
-    ) {
-      this.removeLiveCardEntry(this._card);
-    }
-    this._card = maybeCard;
-    this.staleCard = maybeCard;
+    this.subscribeToRealm(maybeCard.id);
+    this.setCardOrError(maybeCard);
   }
 
-  private removeLiveCardEntry(card: CardDef) {
-    let loader = loaderFor(card);
-    let subscribers = liveCards.get(loader)?.subscribers(card.id);
+  private setCardOrError(cardOrError: CardDef | CardError) {
+    if (isCardInstance(cardOrError)) {
+      this._card = cardOrError;
+      this.staleCard = cardOrError;
+      this.cardError = undefined;
+    } else {
+      this.cardError = cardOrError;
+      this._card = undefined;
+      this.staleCard = undefined;
+    }
+  }
+
+  private removeLiveCardEntry(id: string) {
+    let subscribers = liveCardIdentityContext.subscribers(id);
     if (subscribers && subscribers.has(this)) {
       subscribers.delete(this);
     }
     if (subscribers && subscribers.size === 0) {
-      liveCards.get(loader)!.delete(card.id);
+      liveCardIdentityContext.delete(id);
     }
   }
 
@@ -428,7 +397,6 @@ export function getCard(
       onCardInstanceChange: opts?.onCardInstanceChange
         ? opts.onCardInstanceChange()
         : undefined,
-      loader: loaderService.loader,
       resetLoader: loaderService.reset.bind(loaderService),
       messageService: (getOwner(parent) as any).lookup(
         'service:message-service',
@@ -438,4 +406,51 @@ export function getCard(
       ) as CardService,
     },
   }));
+}
+
+function processCardError(url: URL, error: any): CardErrors {
+  try {
+    let errorResponse = JSON.parse(error.responseText) as CardErrors;
+    return errorResponse;
+  } catch (parseError) {
+    switch (error.status) {
+      // tailor HTTP responses as necessary for better user feedback
+      case 404:
+        return {
+          errors: [
+            {
+              id: url.href,
+              status: 404,
+              title: 'Card Not Found',
+              message: `The card ${url.href} does not exist`,
+              realm: error.responseHeaders?.get('X-Boxel-Realm-Url'),
+              meta: {
+                lastKnownGoodHtml: null,
+                scopedCssUrls: [],
+                stack: null,
+              },
+            },
+          ],
+        };
+      default:
+        return {
+          errors: [
+            {
+              id: url.href,
+              status: error.status,
+              title: status.message[error.status] ?? `HTTP ${error.status}`,
+              message: `Received HTTP ${error.status} from server ${
+                error.responseText ?? ''
+              }`.trim(),
+              realm: error.responseHeaders?.get('X-Boxel-Realm-Url'),
+              meta: {
+                lastKnownGoodHtml: null,
+                scopedCssUrls: [],
+                stack: null,
+              },
+            },
+          ],
+        };
+    }
+  }
 }

--- a/packages/host/app/resources/card-resource.ts
+++ b/packages/host/app/resources/card-resource.ts
@@ -107,7 +107,7 @@ let realmSubscriptions: Map<
   WeakMap<CardResource, { unsubscribe: () => void }>
 > = new Map();
 
-export function testOnlyResetCardResourceModuleState() {
+export function testOnlyResetLiveCardState() {
   liveCardIdentityContext = new LiveCardIdentityContext();
   realmSubscriptions = new Map();
 }

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -27,6 +27,7 @@ import {
   type RealmInfo,
   type IndexEventData,
   RealmPermissions,
+  RealmPaths,
 } from '@cardstack/runtime-common';
 
 import ENV from '@cardstack/host/config/environment';
@@ -480,6 +481,16 @@ export default class RealmService extends Service {
       realmsMeta[url] = this.meta(url);
     }
     return realmsMeta;
+  }
+
+  realmOfURL(url: URL) {
+    for (const realm of this.realms.keys()) {
+      let realmURL = new URL(realm);
+      if (new RealmPaths(realmURL).inRealm(url)) {
+        return new URL(realmURL);
+      }
+    }
+    return undefined;
   }
 
   @cached

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -40,7 +40,7 @@ import CardPrerender from '@cardstack/host/components/card-prerender';
 import ENV from '@cardstack/host/config/environment';
 import SQLiteAdapter from '@cardstack/host/lib/sqlite-adapter';
 
-import { testOnlyResetLiveCardIdentityContext } from '@cardstack/host/resources/card-resource';
+import { testOnlyResetCardResourceModuleState } from '@cardstack/host/resources/card-resource';
 
 import type CardService from '@cardstack/host/services/card-service';
 import type { CardSaveSubscriber } from '@cardstack/host/services/card-service';
@@ -295,7 +295,7 @@ export function setupServerSentEvents(hooks: NestedHooks) {
   hooks.beforeEach<TestContextWithSSE>(function () {
     this.subscribers = [];
     let self = this;
-    testOnlyResetLiveCardIdentityContext();
+    testOnlyResetCardResourceModuleState();
 
     class MockMessageService extends Service {
       register() {

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -40,7 +40,7 @@ import CardPrerender from '@cardstack/host/components/card-prerender';
 import ENV from '@cardstack/host/config/environment';
 import SQLiteAdapter from '@cardstack/host/lib/sqlite-adapter';
 
-import { testOnlyResetCardResourceModuleState } from '@cardstack/host/resources/card-resource';
+import { testOnlyResetLiveCardState } from '@cardstack/host/resources/card-resource';
 
 import type CardService from '@cardstack/host/services/card-service';
 import type { CardSaveSubscriber } from '@cardstack/host/services/card-service';
@@ -295,7 +295,7 @@ export function setupServerSentEvents(hooks: NestedHooks) {
   hooks.beforeEach<TestContextWithSSE>(function () {
     this.subscribers = [];
     let self = this;
-    testOnlyResetCardResourceModuleState();
+    testOnlyResetLiveCardState();
 
     class MockMessageService extends Service {
       register() {

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -40,6 +40,8 @@ import CardPrerender from '@cardstack/host/components/card-prerender';
 import ENV from '@cardstack/host/config/environment';
 import SQLiteAdapter from '@cardstack/host/lib/sqlite-adapter';
 
+import { testOnlyResetLiveCardIdentityContext } from '@cardstack/host/resources/card-resource';
+
 import type CardService from '@cardstack/host/services/card-service';
 import type { CardSaveSubscriber } from '@cardstack/host/services/card-service';
 
@@ -293,6 +295,7 @@ export function setupServerSentEvents(hooks: NestedHooks) {
   hooks.beforeEach<TestContextWithSSE>(function () {
     this.subscribers = [];
     let self = this;
+    testOnlyResetLiveCardIdentityContext();
 
     class MockMessageService extends Service {
       register() {

--- a/packages/host/tests/integration/components/ai-assistant-panel-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel-test.gts
@@ -2172,8 +2172,8 @@ module('Integration | ai-assistant-panel', function (hooks) {
   });
 
   test('it can copy search results card to workspace', async function (assert) {
-    const id = `${testRealmURL}Person/fadhlan.json`;
-    const roomId = await renderAiAssistantPanel(id);
+    const id = `${testRealmURL}Person/fadhlan`;
+    const roomId = await renderAiAssistantPanel(`${id}.json`);
     const toolArgs = {
       description: 'Search for Person cards',
       attributes: {
@@ -2247,8 +2247,8 @@ module('Integration | ai-assistant-panel', function (hooks) {
   });
 
   test('it can copy search results card to workspace (no cards in stack)', async function (assert) {
-    const id = `${testRealmURL}Person/fadhlan.json`;
-    const roomId = await renderAiAssistantPanel(id);
+    const id = `${testRealmURL}Person/fadhlan`;
+    const roomId = await renderAiAssistantPanel(`${id}.json`);
     const toolArgs = {
       description: 'Search for Person cards',
       attributes: {


### PR DESCRIPTION
This PR adds support for showing and dismissing errors in a live fashion in both stack items and in code mode.

![sse-errors](https://github.com/user-attachments/assets/421a25d3-cb5d-472c-890c-dbff2de17f5c)

(note from the screenshot that there is already an existing bug in main where the monaco editor is not live updating based on file system changes--that is unrelated to this PR)