### PR TITLE
Improve "buy credits" payment links display

### DIFF
--- a/packages/host/app/components/operator-mode/profile/profile-subscription.gts
+++ b/packages/host/app/components/operator-mode/profile/profile-subscription.gts
@@ -87,7 +87,7 @@ export default class ProfileSubscription extends Component<Signature> {
                 }}
                   <div class='payment-link' data-test-payment-link={{index}}>
                     <span><IconHexagon width='16px' height='16px' />
-                      {{paymentLink.creditReloadAmount}}</span>
+                      {{paymentLink.amountFormatted}}</span>
                     <BoxelButton
                       @as='anchor'
                       @kind='secondary-light'
@@ -95,7 +95,7 @@ export default class ProfileSubscription extends Component<Signature> {
                       @href={{this.urlWithClientReferenceId paymentLink.url}}
                       target='_blank'
                       data-test-pay-button={{index}}
-                    >Pay</BoxelButton>
+                    >Buy</BoxelButton>
                   </div>
                 {{/each}}
               {{/if}}

--- a/packages/host/app/components/with-subscription-data.gts
+++ b/packages/host/app/components/with-subscription-data.gts
@@ -12,6 +12,7 @@ import { IconHexagon } from '@cardstack/boxel-ui/icons';
 import BillingService from '../services/billing-service';
 
 import type { ComponentLike } from '@glint/template';
+import { formatNumber } from '../helpers/format-number';
 
 interface ValueSignature {
   Args: {
@@ -102,7 +103,9 @@ export default class WithSubscriptionData extends Component<WithSubscriptionData
   private get monthlyCreditText() {
     return this.creditsAvailableInPlanAllowance != null &&
       this.creditsIncludedInPlanAllowance != null
-      ? `${this.creditsAvailableInPlanAllowance} of ${this.creditsIncludedInPlanAllowance} left`
+      ? `${formatNumber(
+          this.creditsAvailableInPlanAllowance,
+        )} of ${formatNumber(this.creditsIncludedInPlanAllowance)} left`
       : null;
   }
 
@@ -149,7 +152,7 @@ export default class WithSubscriptionData extends Component<WithSubscriptionData
         additionalCredit=(component
           Value
           tag='additional-credit'
-          value=this.extraCreditsAvailableInBalance
+          value=(formatNumber this.extraCreditsAvailableInBalance)
           isLoading=this.isLoading
           isOutOfCredit=this.isOutOfCredit
           displayCreditIcon=true

--- a/packages/host/app/components/with-subscription-data.gts
+++ b/packages/host/app/components/with-subscription-data.gts
@@ -9,10 +9,10 @@ import { LoadingIndicator } from '@cardstack/boxel-ui/components';
 import { cn } from '@cardstack/boxel-ui/helpers';
 import { IconHexagon } from '@cardstack/boxel-ui/icons';
 
+import { formatNumber } from '../helpers/format-number';
 import BillingService from '../services/billing-service';
 
 import type { ComponentLike } from '@glint/template';
-import { formatNumber } from '../helpers/format-number';
 
 interface ValueSignature {
   Args: {

--- a/packages/host/app/helpers/format-number.ts
+++ b/packages/host/app/helpers/format-number.ts
@@ -1,0 +1,20 @@
+import { helper } from '@ember/component/helper';
+
+type PositionalArgs = number;
+
+interface Signature {
+  Args: {
+    Positional: PositionalArgs;
+  };
+  Return: string;
+}
+
+export function formatNumber(number?: number | null): string {
+  if (number == undefined || number == null) {
+    return '';
+  }
+
+  return number.toLocaleString();
+}
+
+export default helper<Signature>(formatNumber);

--- a/packages/host/app/services/billing-service.ts
+++ b/packages/host/app/services/billing-service.ts
@@ -10,6 +10,8 @@ import {
   encodeWebSafeBase64,
 } from '@cardstack/runtime-common';
 
+import { formatNumber } from '../helpers/format-number';
+
 import NetworkService from './network';
 import RealmServerService from './realm-server';
 import ResetService from './reset';
@@ -89,9 +91,9 @@ export default class BillingService extends Service {
       .sort((a, b) => a.creditReloadAmount - b.creditReloadAmount)
       .map((link) => ({
         ...link,
-        amountFormatted: `${link.creditReloadAmount.toLocaleString(
-          'en-US',
-        )} credits for $${link.price.toLocaleString('en-US')}`,
+        amountFormatted: `${formatNumber(
+          link.creditReloadAmount,
+        )} credits for $${formatNumber(link.price)}`,
       }));
   }
 

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -1082,7 +1082,7 @@ module('Acceptance | operator mode tests', function (hooks) {
       assert.dom('[data-test-subscription-data="plan"]').hasText('Free');
       assert
         .dom('[data-test-subscription-data="monthly-credit"]')
-        .hasText('0 of 1000 left');
+        .hasText('0 of 1,000 left');
       assert
         .dom('[data-test-subscription-data="monthly-credit"]')
         .hasClass('out-of-credit');
@@ -1105,7 +1105,7 @@ module('Acceptance | operator mode tests', function (hooks) {
       assert.dom('[data-test-subscription-data="plan"]').hasText('Free');
       assert
         .dom('[data-test-subscription-data="monthly-credit"]')
-        .hasText('0 of 1000 left');
+        .hasText('0 of 1,000 left');
       assert
         .dom('[data-test-subscription-data="monthly-credit"]')
         .hasClass('out-of-credit');

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -994,7 +994,7 @@ module('Acceptance | operator mode tests', function (hooks) {
       assert.dom('[data-test-subscription-data="plan"]').hasText('Free');
       assert
         .dom('[data-test-subscription-data="monthly-credit"]')
-        .hasText('1000 of 1000 left');
+        .hasText('1,000 of 1,000 left');
       assert
         .dom('[data-test-subscription-data="monthly-credit"]')
         .hasNoClass('out-of-credit');
@@ -1023,7 +1023,7 @@ module('Acceptance | operator mode tests', function (hooks) {
       assert.dom('[data-test-subscription-data="plan"]').hasText('Free');
       assert
         .dom('[data-test-subscription-data="monthly-credit"]')
-        .hasText('1000 of 1000 left');
+        .hasText('1,000 of 1,000 left');
       assert
         .dom('[data-test-subscription-data="monthly-credit"]')
         .hasNoClass('out-of-credit');

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -1128,7 +1128,7 @@ module('Acceptance | operator mode tests', function (hooks) {
       assert.dom('[data-test-subscription-data="plan"]').hasText('Free');
       assert
         .dom('[data-test-subscription-data="monthly-credit"]')
-        .hasText('1000 of 1000 left');
+        .hasText('1,000 of 1,000 left');
       assert
         .dom('[data-test-subscription-data="monthly-credit"]')
         .hasNoClass('out-of-credit');

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -824,6 +824,7 @@ export function setupRealmServerEndpoints(
                   url: 'https://extra-credits-payment-link-1250',
                   metadata: {
                     creditReloadAmount: 1250,
+                    price: 5,
                   },
                 },
               },
@@ -834,6 +835,7 @@ export function setupRealmServerEndpoints(
                   url: 'https://extra-credits-payment-link-15000',
                   metadata: {
                     creditReloadAmount: 15000,
+                    price: 30,
                   },
                 },
               },
@@ -844,6 +846,7 @@ export function setupRealmServerEndpoints(
                   url: 'https://extra-credits-payment-link-80000',
                   metadata: {
                     creditReloadAmount: 80000,
+                    price: 100,
                   },
                 },
               },

--- a/packages/realm-server/handlers/handle-stripe-links.ts
+++ b/packages/realm-server/handlers/handle-stripe-links.ts
@@ -108,6 +108,7 @@ export default function handleStripeLinksRequest(): (
             url: link.url,
             metadata: {
               creditReloadAmount: parseInt(link.metadata.credit_reload_amount),
+              price: parseFloat(link.metadata.price),
             },
           },
         })),


### PR DESCRIPTION
Adjusts order of links to be ascending, and fixes large numbers formatting. 

Before:
<img width="915" alt="image" src="https://github.com/user-attachments/assets/1f09bd83-bedc-4a75-8709-e084499540b9">

After:
<img width="970" alt="image" src="https://github.com/user-attachments/assets/3f3e64da-dcb7-46d0-a323-8de4ec6783b3">
