### PR TITLE
Fix: user credit amounts do not update in profile settings

### DIFF
--- a/packages/billing/stripe-webhook-handlers/index.ts
+++ b/packages/billing/stripe-webhook-handlers/index.ts
@@ -195,7 +195,7 @@ async function extractMatrixUserId(dbAdapter: DBAdapter, event: StripeEvent) {
     ? decodeWebSafeBase64(encodedMatrixUserId)
     : undefined;
 
-  if (event.data.object.customer) {
+  if (!matrixUserId && event.data.object.customer) {
     let user = await getUserByStripeId(dbAdapter, event.data.object.customer);
     matrixUserId = user?.matrixUserId;
   }

--- a/packages/billing/stripe-webhook-handlers/index.ts
+++ b/packages/billing/stripe-webhook-handlers/index.ts
@@ -186,9 +186,6 @@ async function sendBillingNotification({
   stripeEvent: StripeEvent;
 }) {
   let matrixUserId = await extractMatrixUserId(dbAdapter, stripeEvent);
-  if (!matrixUserId) {
-    throw new Error('Failed to extract matrix user id from stripe event');
-  }
   await sendMatrixEvent(matrixUserId, 'billing-notification');
 }
 
@@ -201,6 +198,10 @@ async function extractMatrixUserId(dbAdapter: DBAdapter, event: StripeEvent) {
   if (event.data.object.customer) {
     let user = await getUserByStripeId(dbAdapter, event.data.object.customer);
     matrixUserId = user?.matrixUserId;
+  }
+
+  if (!matrixUserId) {
+    throw new Error('Failed to extract matrix user id from stripe event');
   }
 
   return matrixUserId;

--- a/packages/billing/stripe-webhook-handlers/index.ts
+++ b/packages/billing/stripe-webhook-handlers/index.ts
@@ -189,6 +189,10 @@ async function sendBillingNotification({
   await sendMatrixEvent(matrixUserId, 'billing-notification');
 }
 
+// Stripe events will have a `customer` (stripe customer id) field in the "invoice.payment_succeeded" event
+// but not in the "checkout.session.completed" event. In the latter case, we need to look up the user by
+// the `client_reference_id` field, which is a url parameter with the value of an encoded matrix user id
+// (these are the payment links for subscribing to the free plan, and buying extra credits)
 async function extractMatrixUserId(dbAdapter: DBAdapter, event: StripeEvent) {
   let encodedMatrixUserId = event.data.object.client_reference_id;
   let matrixUserId = encodedMatrixUserId

--- a/packages/realm-server/handlers/handle-stripe-webhook.ts
+++ b/packages/realm-server/handlers/handle-stripe-webhook.ts
@@ -2,8 +2,6 @@ import Koa from 'koa';
 import { fetchRequestFromContext, setContextResponse } from '../middleware';
 import stripeWebhookHandler from '@cardstack/billing/stripe-webhook-handlers';
 import { CreateRoutesArgs } from '../routes';
-import { getUserByStripeId } from '@cardstack/billing/billing-queries';
-import { decodeWebSafeBase64 } from '@cardstack/runtime-common';
 
 export default function handleStripeWebhookRequest({
   dbAdapter,
@@ -12,29 +10,11 @@ export default function handleStripeWebhookRequest({
   return async function (ctxt: Koa.Context, _next: Koa.Next) {
     let request = await fetchRequestFromContext(ctxt);
 
-    let response = await stripeWebhookHandler(
+    let response = await stripeWebhookHandler({
       dbAdapter,
       request,
-      async ({
-        stripeCustomerId,
-        encodedMatrixUserId,
-      }: {
-        stripeCustomerId?: string;
-        encodedMatrixUserId?: string;
-      }) => {
-        let matrixUserId = encodedMatrixUserId
-          ? decodeWebSafeBase64(encodedMatrixUserId)
-          : undefined;
-        if (stripeCustomerId) {
-          let user = await getUserByStripeId(dbAdapter, stripeCustomerId);
-          matrixUserId = user?.matrixUserId;
-        }
-
-        if (matrixUserId) {
-          await sendEvent(matrixUserId, 'billing-notification');
-        }
-      },
-    );
+      sendMatrixEvent: sendEvent,
+    });
     await setContextResponse(ctxt, response);
   };
 }

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -4338,6 +4338,7 @@ module('Realm Server', function (hooks) {
             cancellation_details: {
               reason: 'payment_failure',
             },
+            customer: 'cus_123',
           },
         },
       };
@@ -4488,6 +4489,7 @@ module('Realm Server', function (hooks) {
             cancellation_details: {
               reason: 'payment_failure',
             },
+            customer: 'cus_123',
           },
         },
       };

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -4615,7 +4615,7 @@ module('Realm Server', function (hooks) {
             id: 'cs_test_1234567890',
             object: 'checkout.session',
             client_reference_id: encodeWebSafeBase64(userId),
-            customer: 'cus_123',
+            customer: undefined,
             metadata: {},
           },
         },


### PR DESCRIPTION
After investigating the issue, I discovered that the realm server did not send a `billing-notification` after handling the `checkout.session.completed` event. This occurred because we were expecting all events to include `event.data.object.customer`. However, for the `checkout.session.completed` event, the matrix user id is stored in `event.data.object.client_reference_id` instead.