### PR TITLE
ai: Add attachment for JSON parse failure

### DIFF
--- a/packages/ai-bot/helpers.ts
+++ b/packages/ai-bot/helpers.ts
@@ -119,7 +119,14 @@ export function constructHistory(
       try {
         rawEvent.content.data = JSON.parse(rawEvent.content.data);
       } catch (e) {
-        Sentry.captureException(e);
+        Sentry.captureException(e, {
+          attachments: [
+            {
+              data: rawEvent.content.data,
+              filename: 'rawEventContentData.txt',
+            },
+          ],
+        });
         log.error('Error parsing JSON', e);
         throw new HistoryConstructionError((e as Error).message);
       }


### PR DESCRIPTION
It’s helpful when seeing an error like this to have the data attached that failed to parse:

<img width="718" alt="AI-BOT-P - SyntaxError: Unexpected token o in JSON at position 1 - buck doyle@cardstack com - Cardstack Mail 2024-12-11 12-16-06" src="https://github.com/user-attachments/assets/5cde9cd1-69e8-4f5f-8b46-480902e85599" />

I’d prefer this to be applied through the whole codebase but it’s not clear to me how to easily accomplish that, something to think about if we keep getting errors like this elsewhere.