### PR TITLE
reassign the correct width to crm grid-view

### DIFF
--- a/packages/experiments-realm/crm-app.gts
+++ b/packages/experiments-realm/crm-app.gts
@@ -440,6 +440,13 @@ class CrmAppTemplate extends Component<typeof AppCard> {
       .view-menu {
         margin-left: auto;
       }
+      /* Cards grid crm */
+      .crm-app :where(.card-view-container) {
+        grid-template-columns: 1fr;
+      }
+      .crm-app :where(.grid-view) {
+        --grid-card-min-width: 300px;
+      }
     </style>
   </template>
 }


### PR DESCRIPTION
linear:https://linear.app/cardstack/issue/ECO-124/update-crm-app-grid-view-card-size-to-be-wider