### PR TITLE
add pointer for whole filter-trigger btn

### DIFF
--- a/packages/experiments-realm/productivity/filter-trigger.gts
+++ b/packages/experiments-realm/productivity/filter-trigger.gts
@@ -10,7 +10,7 @@ export class FilterTrigger extends GlimmerComponent<TriggerSignature> {
   <template>
     <div class='filter-trigger'>
       <IconButton @icon={{ListFilter}} width='13px' height='13px' />
-      Filter
+      <span class='filter-trigger-text'>Filter</span>
     </div>
 
     <style scoped>
@@ -18,6 +18,15 @@ export class FilterTrigger extends GlimmerComponent<TriggerSignature> {
         display: flex;
         align-items: center;
         font: 600 var(--boxel-font-sm);
+        transition: background-color 0.5s ease-in-out;
+        overflow: hidden;
+      }
+      .filter-trigger-text {
+        padding-right: var(--boxel-sp-sm);
+      }
+      .filter-trigger:hover {
+        cursor: pointer;
+        background-color: var(--boxel-100);
       }
     </style>
     {{! template-lint-disable require-scoped-style }}


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/ECO-114/pointer-is-not-showing-when-hovering-over-filter

![image](https://github.com/user-attachments/assets/741500c6-03f8-4b16-a3f7-c2fe0cc93587)
