### PR TITLE
Add live option to `getCards()`

### DIFF
--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -70,8 +70,15 @@ export default class OperatorModeContainer extends Component<Signature> {
 
   // public API
   @action
-  getCards(query: Query, realms?: string[]): Search {
-    return getSearchResults(this, query, realms);
+  getCards(
+    query: Query,
+    realms?: string[],
+    opts?: {
+      isLive?: true;
+      doWhileRefreshing?: (ready: Promise<void> | undefined) => Promise<void>;
+    },
+  ): Search {
+    return getSearchResults(this, query, realms, opts);
   }
 
   // public API

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -53,9 +53,6 @@ export class Search extends Resource<Args> {
     waitForPromise(this.loaded);
 
     if (isLive) {
-      // TODO this triggers a new search against all realms if any single realm
-      // updates. Make this more precise where we only search the updated realm
-      // instead of all realms.
       this.subscriptions = this.realmsToSearch.map((realm) => ({
         url: `${realm}_message`,
         unsubscribe: subscribeToRealm(

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -56,7 +56,7 @@ export class Search extends Resource<Args> {
       this.subscriptions = this.realmsToSearch.map((realm) => ({
         url: `${realm}_message`,
         unsubscribe: subscribeToRealm(
-          `${realm}_message`,
+          realm,
           ({ type, data }: { type: string; data: string }) => {
             let eventData = JSON.parse(data);
             // we are only interested in incremental index events

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -196,10 +196,6 @@ export function getSearchResults(
   query: Query,
   realms?: string[],
   opts?: {
-    // A new search is triggered whenever the index updates. Consumers of this
-    // function that render their cards using {{#each}} should make sure to use the
-    // "key" field: {{#each #this.results.instances key="id" as |instance|}} in
-    // order to keep the results stable between refreshes.
     isLive?: true;
     // it is probably desirable that dynamic context action `doWithStableScroll()`
     // is used here. For example:

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -1,16 +1,27 @@
+import { registerDestructor } from '@ember/destroyable';
+
 import { service } from '@ember/service';
 import { waitForPromise } from '@ember/test-waiters';
-import { tracked } from '@glimmer/tracking';
+import { tracked, cached } from '@glimmer/tracking';
 
 import { restartableTask } from 'ember-concurrency';
 import { Resource } from 'ember-resources';
 import flatMap from 'lodash/flatMap';
 
-import { type RealmCards } from '@cardstack/runtime-common';
+import { stringify } from 'qs';
+import { TrackedMap } from 'tracked-built-ins';
+
+import {
+  subscribeToRealm,
+  isCardCollectionDocument,
+  SingleCardDocument,
+} from '@cardstack/runtime-common';
 
 import type { Query } from '@cardstack/runtime-common/query';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
+
+import { type CardResource, getCard, asURL } from './card-resource';
 
 import type CardService from '../services/card-service';
 import type RealmServerService from '../services/realm-server';
@@ -19,6 +30,7 @@ interface Args {
   named: {
     query: Query;
     realms?: string[];
+    isLive?: true;
     doWhileRefreshing?: (ready: Promise<void> | undefined) => Promise<void>;
   };
 }
@@ -26,54 +38,155 @@ interface Args {
 export class Search extends Resource<Args> {
   @service private declare cardService: CardService;
   @service private declare realmServer: RealmServerService;
-  @tracked private _instances: CardDef[] = [];
-  @tracked private _instancesByRealm: RealmCards[] = [];
-  @tracked private staleInstances: CardDef[] = [];
-  @tracked private staleInstancesByRealm: RealmCards[] = [];
   @tracked private realmsToSearch: string[] = [];
   loaded: Promise<void> | undefined;
+  private subscriptions: { url: string; unsubscribe: () => void }[] = [];
+  private cardResources = new Map<string, CardResource>();
+  private seenCardResource = new TrackedMap<string, CardResource>();
+  private currentResults = new TrackedMap<string, CardResource>();
 
   modify(_positional: never[], named: Args['named']) {
-    let { query, realms } = named;
+    let { query, realms, isLive, doWhileRefreshing } = named;
     this.realmsToSearch = realms ?? this.realmServer.availableRealmURLs;
 
     this.loaded = this.search.perform(query);
     waitForPromise(this.loaded);
+
+    if (isLive) {
+      // TODO this triggers a new search against all realms if any single realm
+      // updates. Make this more precise where we only search the updated realm
+      // instead of all realms.
+      this.subscriptions = this.realmsToSearch.map((realm) => ({
+        url: `${realm}_message`,
+        unsubscribe: subscribeToRealm(
+          `${realm}_message`,
+          ({ type, data }: { type: string; data: string }) => {
+            let eventData = JSON.parse(data);
+            // we are only interested in incremental index events
+            if (type !== 'index' || eventData.type !== 'incremental') {
+              return;
+            }
+            this.search.perform(query);
+            if (doWhileRefreshing) {
+              this.doWhileRefreshing.perform(doWhileRefreshing);
+            }
+          },
+        ),
+      }));
+
+      registerDestructor(this, () => {
+        for (let subscription of this.subscriptions) {
+          subscription.unsubscribe();
+        }
+      });
+    }
   }
 
+  @cached
   get instances() {
-    return this.isLoading ? this.staleInstances : this._instances;
+    return [...this.currentResults.values()].map((r) => r.card) as CardDef[]; // empty results are filtered out already
   }
 
+  @cached
   get instancesByRealm() {
-    return this.isLoading ? this.staleInstancesByRealm : this._instancesByRealm;
+    return this.realmsToSearch
+      .map((realm) => {
+        let cards = this.instances.filter((card) => card.id.startsWith(realm));
+        return { realm, cards };
+      })
+      .filter((r) => r.cards.length > 0);
+  }
+
+  private doWhileRefreshing = restartableTask(
+    async (
+      doWhileRefreshing: (ready: Promise<void> | undefined) => Promise<void>,
+    ) => {
+      await doWhileRefreshing(this.loaded);
+    },
+  );
+
+  // By default, this does a tracked read from seenCards so that your
+  // answer can be invalidated if a new card is discovered. Internally, we also
+  // use it untracked to implement the read-through cache.
+  private seenCard(url: string, tracked = true): CardResource | undefined {
+    let resource = this.cardResources.get(url);
+    if (resource) {
+      return resource;
+    }
+    if (tracked) {
+      this.seenCardResource.has(url);
+    }
+    return undefined;
+  }
+
+  private getOrCreateCardResource(
+    urlOrDoc: string | SingleCardDocument,
+  ): CardResource {
+    let url = asURL(urlOrDoc);
+    // this should be the only place we do the untracked read. It needs to be
+    // untracked so our `this.cardResources.set` below will not be an assertion.
+    let resource = this.seenCard(url, false);
+    if (!resource) {
+      resource = getCard(this, () => urlOrDoc, {
+        isLive: () => true,
+      });
+      this.cardResources.set(url, resource);
+      // only after the set has happened can we safely do the tracked read to
+      // establish our dependency.
+      this.seenCardResource.set(url, resource);
+    }
+    return resource;
   }
 
   private search = restartableTask(async (query: Query) => {
-    this._instances = flatMap(
+    let results = flatMap(
       await Promise.all(
-        this.realmsToSearch.map(
-          async (realm) => await this.cardService.search(query, new URL(realm)),
-        ),
+        this.realmsToSearch.map(async (realm) => {
+          let json = await this.cardService.fetchJSON(
+            `${realm}_search?${stringify(query)}`,
+          );
+          if (!isCardCollectionDocument(json)) {
+            throw new Error(
+              `The realm search response was not a card collection document:
+        ${JSON.stringify(json, null, 2)}`,
+            );
+          }
+          let collectionDoc = json;
+          return (
+            // use Promise.allSettled so that if one particular realm is
+            // misbehaving it doesn't effect results from other realms
+            (
+              (
+                await Promise.allSettled(
+                  collectionDoc.data.map(async (doc) =>
+                    this.getOrCreateCardResource({ data: doc }),
+                  ),
+                )
+              ).filter(
+                (p) => p.status === 'fulfilled',
+              ) as PromiseFulfilledResult<CardResource>[]
+            ).map((p) => p.value)
+          );
+        }),
       ),
     );
 
-    let realmsWithCards = this.realmsToSearch
-      .map((url) => {
-        let cards = this._instances.filter((card) => card.id.startsWith(url));
-        return { url, cards };
-      })
-      .filter((r) => r.cards.length > 0);
-
-    this._instancesByRealm = await Promise.all(
-      realmsWithCards.map(async ({ url, cards }) => {
-        let realmInfo = await this.cardService.getRealmInfo(cards[0]);
-        if (!realmInfo) {
-          throw new Error(`Could not find realm info for card ${cards[0].id}`);
-        }
-        return { url, realmInfo, cards };
-      }),
-    );
+    await Promise.all(results.map((r) => r.loaded));
+    let resultsWithoutErrors = results.filter((r) => r.card && r.url);
+    let resultMap = new Map<string, CardResource>();
+    for (let resource of resultsWithoutErrors) {
+      resultMap.set(resource.url!, resource);
+    }
+    for (let url of this.currentResults.keys()) {
+      if (!resultMap.has(url)) {
+        this.currentResults.delete(url);
+      }
+    }
+    for (let [url, resource] of resultMap) {
+      if (!this.currentResults.has(url)) {
+        this.currentResults.set(url, resource);
+      }
+    }
   });
 
   get isLoading() {
@@ -85,11 +198,32 @@ export function getSearchResults(
   parent: object,
   query: Query,
   realms?: string[],
+  opts?: {
+    // A new search is triggered whenever the index updates. Consumers of this
+    // function that render their cards using {{#each}} should make sure to use the
+    // "key" field: {{#each #this.results.instances key="id" as |instance|}} in
+    // order to keep the results stable between refreshes.
+    isLive?: true;
+    // it is probably desirable that dynamic context action `doWithStableScroll()`
+    // is used here. For example:
+    //
+    //   async (ready: Promise<void> | undefined) => {
+    //     if (this.args.context?.actions) {
+    //       this.args.context.actions.doWithStableScroll(
+    //         this.args.model as CardDef,
+    //         async () => { await ready; }
+    //       );
+    //     }
+    //   }
+    doWhileRefreshing?: (ready: Promise<void> | undefined) => Promise<void>;
+  },
 ) {
   return Search.from(parent, () => ({
     named: {
       query,
       realms: realms ?? undefined,
+      isLive: opts?.isLive,
+      doWhileRefreshing: opts?.doWhileRefreshing,
     },
   })) as Search;
 }

--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -449,40 +449,30 @@ export default class CardService extends Service {
     try {
       console.time('search deserialization');
       return (
-        // use Promise.allSettled so that if one particular realm is
-        // misbehaving it doesn't effect results from other realms
-        (
-          (
-            await Promise.allSettled(
-              collectionDoc.data.map(async (doc) => {
-                try {
-                  return await this.createFromSerialized(
-                    doc,
-                    collectionDoc,
-                    new URL(doc.id),
-                  );
-                } catch (e) {
-                  console.warn(
-                    `Skipping ${
-                      doc.id
-                    }. Encountered error deserializing from search result for query ${JSON.stringify(
-                      query,
-                      null,
-                      2,
-                    )} against realm ${realmURL}`,
-                    e,
-                  );
-                  return undefined;
-                }
-              }),
-            )
-          ).filter(
-            (p) => p.status === 'fulfilled',
-          ) as PromiseFulfilledResult<CardDef>[]
+        await Promise.all(
+          collectionDoc.data.map(async (doc) => {
+            try {
+              return await this.createFromSerialized(
+                doc,
+                collectionDoc,
+                new URL(doc.id),
+              );
+            } catch (e) {
+              console.warn(
+                `Skipping ${
+                  doc.id
+                }. Encountered error deserializing from search result for query ${JSON.stringify(
+                  query,
+                  null,
+                  2,
+                )} against realm ${realmURL}`,
+                e,
+              );
+              return undefined;
+            }
+          }),
         )
-          .map((p) => p.value)
-          .filter(Boolean) as CardDef[]
-      );
+      ).filter(Boolean) as CardDef[];
     } finally {
       if (environment !== 'test') {
         console.timeEnd('search deserialization');

--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -437,6 +437,11 @@ export default class CardService extends Service {
     await this.fetchJSON(card.id, { method: 'DELETE' });
   }
 
+  // TODO consider retiring this.  i don't think it really does what we want
+  // since it is not live, and the cards that it returns are not live and does
+  // not leverage the identity map from CardResource, so it may create
+  // duplicative instances of cards when it deserializes the results. instead of
+  // using this please use the SearchResource.
   async search(query: Query, realmURL: URL): Promise<CardDef[]> {
     let json = await this.fetchJSON(`${realmURL}_search?${stringify(query)}`);
     if (!isCardCollectionDocument(json)) {

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -223,6 +223,10 @@ export interface CardSearch {
   getCards(
     query: Query,
     realms?: string[],
+    opts?: {
+      isLive?: true;
+      doWhileRefreshing?: (ready: Promise<void> | undefined) => Promise<void>;
+    },
   ): {
     instances: CardDef[];
     loaded: Promise<void>;
@@ -242,10 +246,17 @@ export interface CardCatalogQuery extends Query {
   filter?: CardTypeFilter | EveryFilter;
 }
 
-export function getCards(query: Query, realms?: string[]) {
+export function getCards(
+  query: Query,
+  realms?: string[],
+  opts?: {
+    isLive?: true;
+    doWhileRefreshing?: (ready: Promise<void> | undefined) => Promise<void>;
+  },
+) {
   let here = globalThis as any;
   let finder: CardSearch = here._CARDSTACK_CARD_SEARCH;
-  return finder?.getCards(query, realms);
+  return finder?.getCards(query, realms, opts);
 }
 
 export function getCard<T extends CardDef>(


### PR DESCRIPTION
This PR adds new options to the `getCards()` API that allows the search to be live as well as to return live cards. The cards from the search are actually provided via `CardResource`.

In this approach I follow a similar pattern to how we get or create realm resources from the realm service, only instead of realm resources I'm operating with card resources, which takes advantage of an identity map for all the cards it deals with.

Probably a future refactor is to retire the `CardService.search()`. i don't think it really does what we want since it is not live, and the cards that it returns are not live and does not leverage the identity map from `CardResource`, so it may create duplicative instances of cards when it deserializes the results.