### PR TITLE
Remove https when displaying website fields

### DIFF
--- a/packages/experiments-realm/website.gts
+++ b/packages/experiments-realm/website.gts
@@ -3,17 +3,32 @@ import { UrlField } from './url';
 import { Component } from 'https://cardstack.com/base/card-api';
 import { EntityDisplay } from './components/entity-display';
 
+const domainWithPath = (urlString: string | null) => {
+  if (!urlString) {
+    return '';
+  }
+
+  const url = new URL(urlString);
+  return `${url.hostname}${url.pathname === '/' ? '' : url.pathname}`;
+};
+
 export class WebsiteField extends UrlField {
   static icon = WorldWwwIcon;
   static displayName = 'Website';
 
-  static atom = class Atom extends Component<typeof this> {
+  static atom = class Atom extends Component<typeof WebsiteField> {
     <template>
-      <EntityDisplay @name={{@model}}>
+      <EntityDisplay @name={{domainWithPath @model}}>
         <:thumbnail>
           <WorldWwwIcon class='icon' />
         </:thumbnail>
       </EntityDisplay>
+    </template>
+  };
+
+  static embedded = class Embedded extends Component<typeof WebsiteField> {
+    <template>
+      {{domainWithPath @model}}
     </template>
   };
 }


### PR DESCRIPTION
Refer to https://linear.app/cardstack/issue/CS-7671/remove-https-from-website-fields

### What is changing
- exclude URL's protocol and query when displaying website field value
- display hostname and pathname only

**Before**
![Screenshot 2024-12-13 at 4 24 58 PM](https://github.com/user-attachments/assets/4af3e30d-141b-4638-ab0a-9390b16c4c75)


**Now**
![Screenshot 2024-12-13 at 4 23 23 PM](https://github.com/user-attachments/assets/552d8cb7-2c3b-4a8d-ab16-a895e8505ed5)
