### PR TITLE
Cs 7659 currency & amount with currency field

### DIFF
--- a/packages/experiments-realm/ExperimentsFieldsPreview/d1c2764b-44b9-45a3-8752-fe891eeb2873.json
+++ b/packages/experiments-realm/ExperimentsFieldsPreview/d1c2764b-44b9-45a3-8752-fe891eeb2873.json
@@ -1,0 +1,70 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "url": null,
+      "urls": [],
+      "address": {
+        "addressLine1": null,
+        "addressLine2": null,
+        "city": null,
+        "state": null,
+        "postalCode": null,
+        "country": {
+          "name": null,
+          "code": null
+        },
+        "poBoxNumber": null
+      },
+      "website": null,
+      "email": null,
+      "emails": [],
+      "phone": {
+        "type": null,
+        "country": null,
+        "area": null,
+        "number": null
+      },
+      "percentage": null,
+      "currency": {
+        "code": null
+      },
+      "amountWithCurrency": {
+        "amount": null,
+        "currency": {
+          "code": null
+        }
+      },
+      "contactLink": {
+        "label": null,
+        "value": null
+      },
+      "contactLinks": [],
+      "statusTag": {
+        "lightColor": null,
+        "darkColor": null,
+        "index": null,
+        "label": null
+      },
+      "featuredImage": {
+        "imageUrl": null,
+        "credit": null,
+        "caption": null,
+        "altText": null,
+        "size": "actual",
+        "height": null,
+        "width": null
+      },
+      "images": [],
+      "title": null,
+      "description": null,
+      "thumbnailURL": null
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../experiments_fields_preview",
+        "name": "ExperimentsFieldsPreview"
+      }
+    }
+  }
+}

--- a/packages/experiments-realm/ExperimentsFieldsPreview/de720f57-964b-4a09-8d52-80cd8bb4b739.json
+++ b/packages/experiments-realm/ExperimentsFieldsPreview/de720f57-964b-4a09-8d52-80cd8bb4b739.json
@@ -8,14 +8,14 @@
         "https://boxel/dan"
       ],
       "address": {
-        "addressLine1": null,
+        "addressLine1": "285 Fulton Street ",
         "addressLine2": null,
-        "city": null,
-        "state": null,
-        "postalCode": null,
+        "city": "New York City",
+        "state": "NY",
+        "postalCode": "10007",
         "country": {
-          "name": null,
-          "code": null
+          "name": "United States of America",
+          "code": "US"
         },
         "poBoxNumber": null
       },

--- a/packages/experiments-realm/ExperimentsFieldsPreview/de720f57-964b-4a09-8d52-80cd8bb4b739.json
+++ b/packages/experiments-realm/ExperimentsFieldsPreview/de720f57-964b-4a09-8d52-80cd8bb4b739.json
@@ -73,6 +73,9 @@
           "width": null
         }
       ],
+      "currency": {
+        "code": "CDF"
+      },
       "title": "Custom Field Preview",
       "description": null,
       "thumbnailURL": null

--- a/packages/experiments-realm/ExperimentsFieldsPreview/de720f57-964b-4a09-8d52-80cd8bb4b739.json
+++ b/packages/experiments-realm/ExperimentsFieldsPreview/de720f57-964b-4a09-8d52-80cd8bb4b739.json
@@ -7,15 +7,15 @@
         "https://boxel/alice",
         "https://boxel/dan"
       ],
-      "location": {
-        "addressLine1": "285 Fulton Street ",
+      "address": {
+        "addressLine1": null,
         "addressLine2": null,
-        "city": "New York City",
-        "state": "NY",
-        "postalCode": "10007",
+        "city": null,
+        "state": null,
+        "postalCode": null,
         "country": {
-          "name": "United States of America",
-          "code": "US"
+          "name": null,
+          "code": null
         },
         "poBoxNumber": null
       },
@@ -25,7 +25,22 @@
         "alice@email.com",
         "dan@email.com"
       ],
+      "phone": {
+        "type": null,
+        "country": null,
+        "area": null,
+        "number": null
+      },
       "percentage": 100.159393,
+      "currency": {
+        "code": "EUR"
+      },
+      "amountWithCurrency": {
+        "amount": 20000000,
+        "currency": {
+          "code": "JPY"
+        }
+      },
       "contactLink": {
         "label": "Email",
         "value": "alice@email.com"
@@ -73,9 +88,6 @@
           "width": null
         }
       ],
-      "currency": {
-        "code": "CDF"
-      },
       "title": "Custom Field Preview",
       "description": null,
       "thumbnailURL": null

--- a/packages/experiments-realm/experiments_fields_preview.gts
+++ b/packages/experiments-realm/experiments_fields_preview.gts
@@ -6,6 +6,7 @@ import { UrlField } from './url';
 import { WebsiteField } from './website';
 import { Address as AddressField } from './address';
 import { PercentageField } from './percentage';
+import { CurrencyField } from './fields/currency';
 import {
   CardDef,
   field,
@@ -33,6 +34,7 @@ export class ExperimentsFieldsPreview extends CardDef {
   @field contactLinks = containsMany(ContactLinkField);
   @field featuredImage = contains(FeaturedImageField);
   @field images = containsMany(FeaturedImageField);
+  @field currency = contains(CurrencyField);
   static displayName = 'Custom Fields ';
   static isolated = class Isolated extends Component<typeof this> {
     <template>

--- a/packages/experiments-realm/experiments_fields_preview.gts
+++ b/packages/experiments-realm/experiments_fields_preview.gts
@@ -7,6 +7,7 @@ import { WebsiteField } from './website';
 import { Address as AddressField } from './address';
 import { PercentageField } from './percentage';
 import { CurrencyField } from './fields/currency';
+import { AmountWithCurrency as AmountWithCurrencyField } from './fields/amount-with-currency';
 import {
   CardDef,
   field,
@@ -30,11 +31,13 @@ export class ExperimentsFieldsPreview extends CardDef {
   @field emails = containsMany(EmailField);
   @field phone = contains(PhoneField);
   @field percentage = contains(PercentageField);
+  @field currency = contains(CurrencyField);
+  @field amountWithCurrency = contains(AmountWithCurrencyField);
   @field contactLink = contains(ContactLinkField);
   @field contactLinks = containsMany(ContactLinkField);
   @field featuredImage = contains(FeaturedImageField);
   @field images = containsMany(FeaturedImageField);
-  @field currency = contains(CurrencyField);
+
   static displayName = 'Custom Fields ';
   static isolated = class Isolated extends Component<typeof this> {
     <template>

--- a/packages/experiments-realm/fields/amount-with-currency.gts
+++ b/packages/experiments-realm/fields/amount-with-currency.gts
@@ -6,17 +6,13 @@ import { action } from '@ember/object';
 import { BoxelInputGroup } from '@cardstack/boxel-ui/components';
 import { guidFor } from '@ember/object/internals';
 
-// @ts-ignore
-import { getSymbolFromCode } from 'https://esm.run/currency-code-symbol-map';
-
 class View extends Component<typeof AmountWithCurrency> {
   get formatNumberWithSeparator() {
-    const num = this.args.model.amount;
-    const currencyCode = this.args.model.currency?.code;
-    const currencySymbol = getSymbolFromCode(currencyCode) || '';
+    let num = this.args.model.amount;
+    const currencySymbol = this.args.model.currency?.symbol;
 
     if (num === null || num === undefined) {
-      return '';
+      num = 0;
     }
 
     return `${currencySymbol} ${num.toLocaleString('en-US')}`;
@@ -36,7 +32,7 @@ class Edit extends Component<typeof AmountWithCurrency> {
   setAmount(val: number) {
     let newModel = new AmountWithCurrency();
     newModel.amount = val;
-    newModel.currency = this.args.model.currency as CurrencyField;
+    newModel.currency.code = newModel.currency.code || 'USD';
     this.args.set(newModel);
   }
 
@@ -108,7 +104,7 @@ class Edit extends Component<typeof AmountWithCurrency> {
 }
 
 export class AmountWithCurrency extends FieldDef {
-  static displayName = 'AmountWithCurrency';
+  static displayName = 'Amount With Currency';
 
   @field amount = contains(NumberField);
   @field currency = contains(CurrencyField);

--- a/packages/experiments-realm/fields/amount-with-currency.gts
+++ b/packages/experiments-realm/fields/amount-with-currency.gts
@@ -1,0 +1,114 @@
+import NumberField from 'https://cardstack.com/base/number';
+import { FieldDef, field, contains } from 'https://cardstack.com/base/card-api';
+import { Component } from 'https://cardstack.com/base/card-api';
+import { CurrencyField } from './currency';
+import { action } from '@ember/object';
+import { BoxelInputGroup } from '@cardstack/boxel-ui/components';
+import { guidFor } from '@ember/object/internals';
+
+// @ts-ignore
+import { getSymbolFromCode } from 'https://esm.run/currency-code-symbol-map';
+
+class View extends Component<typeof AmountWithCurrency> {
+  get formatNumberWithSeparator() {
+    const num = this.args.model.amount;
+    const currencyCode = this.args.model.currency?.code;
+    const currencySymbol = getSymbolFromCode(currencyCode) || '';
+
+    if (num === null || num === undefined) {
+      return '';
+    }
+
+    return `${currencySymbol} ${num.toLocaleString('en-US')}`;
+  }
+
+  <template>
+    {{this.formatNumberWithSeparator}}
+  </template>
+}
+
+class Edit extends Component<typeof AmountWithCurrency> {
+  get id() {
+    return guidFor(this);
+  }
+
+  @action
+  setAmount(val: number) {
+    let newModel = new AmountWithCurrency();
+    newModel.amount = val;
+    newModel.currency = this.args.model.currency as CurrencyField;
+    this.args.set(newModel);
+  }
+
+  @action
+  setCurrency(val: CurrencyField) {
+    let newModel = new AmountWithCurrency();
+    newModel.amount = this.args.model.amount as number;
+    newModel.currency = val;
+    this.args.set(newModel);
+  }
+
+  <template>
+    <BoxelInputGroup
+      @id={{this.id}}
+      @placeholder='0.00'
+      @value={{@model.amount}}
+      @invalid={{false}}
+      @onInput={{this.setAmount}}
+      @autocomplete='off'
+      @inputmode='decimal'
+      class='input-selectable-currency-amount'
+    >
+      <:before as |Accessories|>
+        <Accessories.Text>{{@model.currency.symbol}}</Accessories.Text>
+      </:before>
+      <:after>
+        <div class='input-selectable-currency'>
+          <@fields.currency style='height: 100%;' />
+        </div>
+      </:after>
+    </BoxelInputGroup>
+    <style scoped>
+      .input-selectable-currency-amount {
+        position: relative;
+        width: 100%;
+      }
+
+      .input-selectable-currency-amount__select[aria-disabled='true'] {
+        opacity: 0.5;
+      }
+
+      .input-selectable-currency-amount__dropdown-item {
+        white-space: nowrap;
+      }
+
+      .input-selectable-currency-amount__dropdown
+        :deep(.ember-power-select-options[role='listbox']) {
+        max-height: 18em;
+      }
+
+      :deep(.currency-field-edit) {
+        min-width: 100px;
+        font-size: var(--boxel-font-size-sm);
+      }
+
+      .boxel-selectable-currency-icon__icon {
+        margin-right: var(--boxel-sp-xxxs);
+        vertical-align: bottom;
+        width: var(--boxel-icon-sm);
+        height: var(--boxel-icon-sm);
+      }
+    </style>
+  </template>
+}
+
+export class AmountWithCurrency extends FieldDef {
+  static displayName = 'AmountWithCurrency';
+
+  @field amount = contains(NumberField);
+  @field currency = contains(CurrencyField);
+
+  static edit = Edit;
+  static atom = View;
+  static embedded = View;
+}

--- a/packages/experiments-realm/fields/amount-with-currency.gts
+++ b/packages/experiments-realm/fields/amount-with-currency.gts
@@ -64,7 +64,7 @@ class Edit extends Component<typeof AmountWithCurrency> {
       </:before>
       <:after>
         <div class='input-selectable-currency'>
-          <@fields.currency style='height: 100%;' />
+          <@fields.currency />
         </div>
       </:after>
     </BoxelInputGroup>
@@ -87,8 +87,13 @@ class Edit extends Component<typeof AmountWithCurrency> {
         max-height: 18em;
       }
 
+      .input-selectable-currency > div {
+        height: 100%;
+      }
+
       :deep(.currency-field-edit) {
         min-width: 100px;
+        height: 100%;
         font-size: var(--boxel-font-size-sm);
       }
 

--- a/packages/experiments-realm/fields/currency.gts
+++ b/packages/experiments-realm/fields/currency.gts
@@ -1,0 +1,110 @@
+import {
+  contains,
+  field,
+  Component,
+  CardDef,
+  FieldDef,
+} from 'https://cardstack.com/base/card-api';
+import StringField from 'https://cardstack.com/base/string';
+import CurrencyDollarIcon from '@cardstack/boxel-icons/currency-dollar';
+import { BoxelSelect } from '@cardstack/boxel-ui/components';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { restartableTask } from 'ember-concurrency';
+import type Owner from '@ember/owner';
+// @ts-ignore
+import { currencyCodeSymbolMapping } from 'https://esm.run/currency-code-symbol-map';
+
+export class Currency extends CardDef {
+  static displayName = 'Currency';
+  static icon = CurrencyDollarIcon;
+  @field code = contains(StringField);
+
+  static embedded = class Embedded extends Component<typeof this> {
+    <template>
+      <@fields.code />
+    </template>
+  };
+}
+
+interface CurrencyData {
+  code: string;
+}
+
+class CurrencyFieldEdit extends Component<typeof CurrencyField> {
+  @tracked currency: CurrencyData | undefined = this.args.model.code
+    ? {
+        code: this.args.model.code,
+      }
+    : undefined;
+  @tracked currencies: CurrencyData[] = [];
+
+  constructor(owner: Owner, args: any) {
+    super(owner, args);
+    this.loadCurrencies.perform();
+  }
+
+  private loadCurrencies = restartableTask(async () => {
+    this.currencies = Object.entries(currencyCodeSymbolMapping).map(
+      ([code, symbol]) => {
+        return {
+          code,
+          symbol,
+        } as CurrencyData;
+      },
+    );
+  });
+
+  @action onSelectCurrency(currency: CurrencyData) {
+    this.currency = { code: currency.code };
+    this.args.model.code = currency.code;
+  }
+
+  <template>
+    {{#if this.loadCurrencies.isRunning}}
+      Loading currencies...
+    {{else}}
+      <BoxelSelect
+        @placeholder={{'Choose a currency'}}
+        @options={{this.currencies}}
+        @selected={{this.currency}}
+        @onChange={{this.onSelectCurrency}}
+        @searchEnabled={{true}}
+        @searchField='code'
+        as |currency|
+      >
+        {{currency.code}}
+      </BoxelSelect>
+    {{/if}}
+  </template>
+}
+
+export class CurrencyField extends FieldDef {
+  static displayName = 'Currency';
+  @field code = contains(StringField);
+  static edit = CurrencyFieldEdit;
+
+  static atom = class Atom extends Component<typeof this> {
+    get symbol() {
+      return currencyCodeSymbolMapping[this.args.model.code];
+    }
+
+    <template>
+      {{this.symbol}}
+    </template>
+  };
+
+  static embedded = class Embedded extends Component<typeof this> {
+    get symbol() {
+      return currencyCodeSymbolMapping[this.args.model.code];
+    }
+
+    <template>
+      {{#if @model.code}}
+        {{this.symbol}}
+      {{else}}
+        Please select a currency
+      {{/if}}
+    </template>
+  };
+}

--- a/packages/experiments-realm/fields/currency.gts
+++ b/packages/experiments-realm/fields/currency.gts
@@ -71,6 +71,7 @@ class CurrencyFieldEdit extends Component<typeof CurrencyField> {
         @onChange={{this.onSelectCurrency}}
         @searchEnabled={{true}}
         @searchField='code'
+        class='currency-field-edit'
         as |currency|
       >
         {{currency.code}}
@@ -84,24 +85,20 @@ export class CurrencyField extends FieldDef {
   @field code = contains(StringField);
   static edit = CurrencyFieldEdit;
 
-  static atom = class Atom extends Component<typeof this> {
-    get symbol() {
-      return currencyCodeSymbolMapping[this.args.model.code];
-    }
+  get symbol() {
+    return currencyCodeSymbolMapping[this.code];
+  }
 
+  static atom = class Atom extends Component<typeof this> {
     <template>
-      {{this.symbol}}
+      {{@model.symbol}}
     </template>
   };
 
   static embedded = class Embedded extends Component<typeof this> {
-    get symbol() {
-      return currencyCodeSymbolMapping[this.args.model.code];
-    }
-
     <template>
       {{#if @model.code}}
-        {{this.symbol}}
+        {{@model.symbol}}
       {{else}}
         Please select a currency
       {{/if}}

--- a/packages/experiments-realm/fields/currency.gts
+++ b/packages/experiments-realm/fields/currency.gts
@@ -32,11 +32,12 @@ interface CurrencyData {
 }
 
 class CurrencyFieldEdit extends Component<typeof CurrencyField> {
+  // TODO: this is a temporary fix to show the default symbol until the field allows for a default value
   @tracked currency: CurrencyData | undefined = this.args.model.code
     ? {
         code: this.args.model.code,
       }
-    : undefined;
+    : { code: 'USD' };
   @tracked currencies: CurrencyData[] = [];
 
   constructor(owner: Owner, args: any) {
@@ -86,7 +87,8 @@ export class CurrencyField extends FieldDef {
   static edit = CurrencyFieldEdit;
 
   get symbol() {
-    return currencyCodeSymbolMapping[this.code];
+    // TODO: this is a temporary fix to show the default symbol until the field allows for a default value
+    return currencyCodeSymbolMapping[this.code || 'USD'];
   }
 
   static atom = class Atom extends Component<typeof this> {
@@ -97,7 +99,8 @@ export class CurrencyField extends FieldDef {
 
   static embedded = class Embedded extends Component<typeof this> {
     <template>
-      {{#if @model.code}}
+      {{! TODO: this is a temporary fix to show the default symbol until the field allows for a default value }}
+      {{#if @model.symbol}}
         {{@model.symbol}}
       {{else}}
         Please select a currency


### PR DESCRIPTION
Refer to https://linear.app/cardstack/issue/CS-7659/create-currency-amt-field

### What is changing
- add currency field based on the list ready in the `currency-code-symbol-map` package (via CDN)
- add the amount with the currency field 

**Screenshots**
![Screenshot 2024-12-16 at 4 06 26 PM](https://github.com/user-attachments/assets/74bf36e0-ff52-40b7-889b-afb47b046ea8)
![Screenshot 2024-12-16 at 4 06 33 PM](https://github.com/user-attachments/assets/7b577d64-733a-453f-91d7-6752c1559663)
