### PR TITLE
Use the correct realm when creating cards in blog post app

### DIFF
--- a/packages/experiments-realm/blog-app.gts
+++ b/packages/experiments-realm/blog-app.gts
@@ -399,7 +399,6 @@ class BlogAppTemplate extends Component<typeof BlogApp> {
         },
         meta: {
           adoptsFrom: ref,
-          realmURL: currentRealm.href,
         },
       },
     };

--- a/packages/experiments-realm/blog-app.gts
+++ b/packages/experiments-realm/blog-app.gts
@@ -399,6 +399,7 @@ class BlogAppTemplate extends Component<typeof BlogApp> {
         },
         meta: {
           adoptsFrom: ref,
+          realmURL: currentRealm.href,
         },
       },
     };

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -192,6 +192,11 @@ export default class InteractSubmode extends Component<Signature> {
             },
           },
         };
+
+        if (opts?.realmURL && !doc.data.meta.realmURL) {
+          doc.data.meta.realmURL = opts.realmURL.href;
+        }
+
         let newCard = await here.cardService.createFromSerialized(
           doc.data,
           doc,


### PR DESCRIPTION
<img width="1182" alt="image" src="https://github.com/user-attachments/assets/35881378-0d45-47d7-9713-c233fd795c43" />

Fixes a bug where creating a post, author, or category put the newly created card into the default realm instead of the realm where the blog post app lives (currently in "experiments")