### PR TITLE
implement css var --summary-card-min-height for summary-card and default min-height for tile

### DIFF
--- a/packages/experiments-realm/components/summary-card.gts
+++ b/packages/experiments-realm/components/summary-card.gts
@@ -40,6 +40,7 @@ export default class SummaryCard extends GlimmerComponent<SummaryCardArgs> {
         gap: var(--boxel-sp-sm);
         overflow: hidden;
         min-width: 0;
+        min-height: var(--summary-card-min-height, 120px);
       }
       .summary-card-header {
         position: relative;


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/ECO-129/tiles-inside-isolated-view-shud-have-min-height

![image](https://github.com/user-attachments/assets/9f248985-463e-4d1c-a070-4dd8b1c99747)
