### PR TITLE
Add fallback for cases with missing skillcard titles

### DIFF
--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -447,7 +447,11 @@ export default class Room extends Component<Signature> {
 
   private get sortedSkills(): Skill[] {
     return [...this.skills].sort((a, b) => {
-      return a.card.title.localeCompare(b.card.title);
+      // Not all of the skills have a title, so we use the skillEventId as a fallback
+      // which should be consistent.
+      let aTitle = a.card.title || a.skillEventId;
+      let bTitle = b.card.title || b.skillEventId;
+      return aTitle.localeCompare(bTitle);
     });
   }
 


### PR DESCRIPTION
If titles are missing, currently the app breaks. This happens for cards that are created on the fly or skillcards that exist normally. Here there's just a fallback to an id that's stable and guaranteed to exist, the result is untitled skillcards will be at the top of the list, but always be in the same order.