### PR TITLE
Make activity card more pure presentational

### DIFF
--- a/packages/experiments-realm/components/activity-card.gts
+++ b/packages/experiments-realm/components/activity-card.gts
@@ -1,8 +1,8 @@
 import GlimmerComponent from '@glimmer/component';
-import { EntityDisplay } from './entity-display';
 
 interface ActivityCardArgs {
   Blocks: {
+    header: [];
     title: [];
     thumbnail: [];
     description?: [];
@@ -17,18 +17,9 @@ export default class ActivityCard extends GlimmerComponent<ActivityCardArgs> {
     <article class='activity-card' ...attributes>
       <header class='activity-card-header'>
         <div class='activity-card-title-desc-group'>
-          <EntityDisplay>
-            <:title>
-              <span class='activity-card-title'>
-                {{yield to='title'}}
-              </span>
-            </:title>
-            <:thumbnail>
-              <span class='activity-card-thumbnail'>
-                {{yield to='thumbnail'}}
-              </span>
-            </:thumbnail>
-          </EntityDisplay>
+          {{#if (has-block 'header')}}
+            {{yield to='header'}}
+          {{/if}}
 
           {{#if (has-block 'description')}}
             <p class='activity-card-description'>
@@ -81,24 +72,6 @@ export default class ActivityCard extends GlimmerComponent<ActivityCardArgs> {
         display: flex;
         align-items: center;
         gap: var(--activity-card-title-desc-group-gap, var(--boxel-sp-sm));
-      }
-      /* extend from entity-display */
-      .activity-card-thumbnail {
-        flex-shrink: 0;
-        width: var(--entity-display-thumbnail-size, var(--boxel-icon-sm));
-        height: var(--entity-display-thumbnail-size, var(--boxel-icon-sm));
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        color: var(--entity-display-thumbnail-color, var(--boxel-600));
-      }
-      .activity-card-title {
-        font-size: var(
-          --activity-card-title-font-size,
-          var(--boxel-font-size-sm)
-        );
-        font-weight: var(--activity-card-title-font-weight, 600);
-        margin: 0;
       }
       .activity-card-description {
         margin: 0;

--- a/packages/experiments-realm/crm/account.gts
+++ b/packages/experiments-realm/crm/account.gts
@@ -222,12 +222,18 @@ class IsolatedTemplate extends Component<typeof Account> {
           </:icon>
           <:content>
             <ActivityCard>
-              <:thumbnail>
-                <PhoneIcon />
-              </:thumbnail>
-              <:title>
-                Customer Call
-              </:title>
+              <:header>
+                <EntityDisplay>
+                  <:title>
+                    <span class='activity-card-title'>
+                      Customer Call
+                    </span>
+                  </:title>
+                  <:thumbnail>
+                    <PhoneIcon />
+                  </:thumbnail>
+                </EntityDisplay>
+              </:header>
               <:icon>
                 <Pill class='activity-pill'>
                   Left VoiceMail
@@ -252,6 +258,7 @@ class IsolatedTemplate extends Component<typeof Account> {
                   <EntityDisplay>
                     <:thumbnail>
                       <Avatar
+                        class='avatar'
                         @thumbnailURL='https://images.pexels.com/photos/1624229/pexels-photo-1624229.jpeg?auto=compress&cs=tinysrgb&w=300&h=300&dpr=2'
                       />
                     </:thumbnail>
@@ -291,6 +298,10 @@ class IsolatedTemplate extends Component<typeof Account> {
       .account-name {
         font: 600 var(--boxel-font-lg);
         margin: 0;
+      }
+      .avatar {
+        flex-shrink: 0;
+        --profile-avatar-icon-size: 25px;
       }
       /* Summary */
       .summary-title {
@@ -345,6 +356,14 @@ class IsolatedTemplate extends Component<typeof Account> {
         flex-wrap: wrap;
         align-items: center;
         gap: var(--boxel-sp);
+      }
+      .activity-card-title {
+        font-size: var(
+          --activity-card-title-font-size,
+          var(--boxel-font-size-sm)
+        );
+        font-weight: var(--activity-card-title-font-weight, 600);
+        margin: 0;
       }
       .activity-time {
         font-size: var(--boxel-font-xs);


### PR DESCRIPTION
### What is changing

We don't have an indicator to know whether the entity thumbnail is an image or an icon, the optimal way is to do the styling handling at the level we use the entity display component.

Hence, we make the activity card more presentational by displaying what it gives, and controlling the styling at the account card instead.

With this approach, we can control the image is not getting shrinked down:

![Screenshot 2024-12-19 at 12 15 58 PM](https://github.com/user-attachments/assets/c7dc2ab1-a868-49fd-b25f-8557b144bd23)


