### PR TITLE
Org boxel to app boxel migration

### DIFF
--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -426,9 +426,7 @@ export default class MatrixService extends Service {
               realms: accountDataContent.realms,
             });
             console.log('Removing your old realms data');
-            await this._client.setAccountData('com.cardstack.boxel.realms', {
-              realms: [],
-            });
+            await this._client.setAccountData('com.cardstack.boxel.realms', {});
           } else {
             console.log('No old realms found');
           }


### PR DESCRIPTION
Proposing adding a migration step, when logging in for the first time / using the app it will :+1: 
* Check for realms data under the new key
* If there is some carry on
* If not, check the old key
* * If in there, copy those to the new key
* * remove the old account data key (set to an empty object)
