### PR TITLE
Fix safari icon bug

### DIFF
--- a/packages/boxel-ui/addon/src/components/icon-button/index.gts
+++ b/packages/boxel-ui/addon/src/components/icon-button/index.gts
@@ -85,11 +85,6 @@ class IconButton extends Component<Signature> {
       .secondary:hover {
         background-color: var(--boxel-purple-800);
       }
-
-      .svg-icon {
-        width: auto;
-        height: auto;
-      }
     </style>
   </template>
 }


### PR DESCRIPTION
A relatively recent change in IconButton component was setting svg width and height to `auto`, which translated to 0 for some browsers, such as Safari.

Before:
<img width="882" alt="icon-bug" src="https://github.com/user-attachments/assets/c364f71a-2bf9-4d72-8041-3d789ee9537f" />

After:
<img width="788" alt="icon-fixed" src="https://github.com/user-attachments/assets/c696ba5f-cf7f-4054-bf71-047891d2cee5" />
