### PR TITLE
link to project from isolated mode to continue

### DIFF
--- a/packages/experiments-realm/work-tracker.gts
+++ b/packages/experiments-realm/work-tracker.gts
@@ -10,7 +10,11 @@ import { tracked } from '@glimmer/tracking';
 import { on } from '@ember/modifier';
 import { TrackedMap } from 'tracked-built-ins';
 import GlimmerComponent from '@glimmer/component';
-import { DndItem, LoadingIndicator } from '@cardstack/boxel-ui/components';
+import {
+  BoxelButton,
+  DndItem,
+  LoadingIndicator,
+} from '@cardstack/boxel-ui/components';
 import {
   DndKanbanBoard,
   DndColumn,
@@ -344,11 +348,19 @@ class WorkTrackerIsolated extends Component<typeof AppCard> {
     }
   }
 
+  @action viewCard() {
+    this.args.context?.actions?.viewCard?.(new URL(this.args.model.id), 'edit');
+  }
+
   <template>
     <div class='task-app'>
       {{#if (not this.currentProject.id)}}
         <div class='disabled'>
-          Link a project to continue
+          {{#if @context.actions.viewCard}}
+            <BoxelButton @kind='primary' {{on 'click' this.viewCard}}>
+              Link a project to continue
+            </BoxelButton>
+          {{/if}}
         </div>
       {{/if}}
       <div class='filter-section'>


### PR DESCRIPTION
Display if no project is linked

<img width="1420" alt="Screenshot 2024-12-22 at 23 29 07" src="https://github.com/user-attachments/assets/3bb7f115-96ea-446c-bfd8-f1d68dfcf2e9" />

Only goes to edit mode. If we want to use the links-to-many-editor it wud be too many changes 

<img width="1430" alt="Screenshot 2024-12-22 at 23 29 12" src="https://github.com/user-attachments/assets/1c030b3f-c381-4f15-a03b-cd0806686987" />

