### PR TITLE
Update default atom template styles

### DIFF
--- a/packages/base/contains-many-component.gts
+++ b/packages/base/contains-many-component.gts
@@ -70,6 +70,8 @@ class ContainsManyEditor extends GlimmerComponent<ContainsManyEditorSignature> {
           <AddButton
             class='add-new'
             @variant='full-width'
+            @iconWidth='12px'
+            @iconHeight='12px'
             {{on 'click' this.add}}
             data-test-add-new
           >
@@ -82,6 +84,10 @@ class ContainsManyEditor extends GlimmerComponent<ContainsManyEditorSignature> {
     <style scoped>
       .contains-many-editor {
         --remove-icon-size: var(--boxel-icon-lg);
+      }
+      .contains-many-editor
+        :deep(.compound-field.edit-format .add-button--full-width) {
+        border: var(--boxel-border);
       }
       .list {
         list-style: none;
@@ -211,14 +217,11 @@ export function getContainsManyComponent({
               ...attributes
             >
               {{#each (getComponents) as |Item i|}}
-                <span
-                  class='containsMany-item'
-                  data-test-plural-view-item={{i}}
-                >
+                <div class='containsMany-item' data-test-plural-view-item={{i}}>
                   <Item
                     @format={{getPluralChildFormat effectiveFormat model}}
                   />
-                </span>
+                </div>
               {{/each}}
             </div>
           {{/let}}
@@ -234,6 +237,9 @@ export function getContainsManyComponent({
           }
           .containsMany-field.atom-format {
             display: contents;
+          }
+          .containsMany-field.atom-format > .containsMany-item {
+            display: inline;
           }
         }
       </style>

--- a/packages/base/contains-many-component.gts
+++ b/packages/base/contains-many-component.gts
@@ -208,30 +208,33 @@ export function getContainsManyComponent({
                 {{unless arrayField.children.length "empty"}}'
               data-test-plural-view={{field.fieldType}}
               data-test-plural-view-format={{effectiveFormat}}
+              ...attributes
             >
               {{#each (getComponents) as |Item i|}}
-                <div
-                  class='boxel-contents-only'
+                <span
+                  class='containsMany-item'
                   data-test-plural-view-item={{i}}
                 >
                   <Item
                     @format={{getPluralChildFormat effectiveFormat model}}
                   />
-                </div>
+                </span>
               {{/each}}
             </div>
           {{/let}}
         {{/if}}
       </DefaultFormatsConsumer>
       <style scoped>
-        .containsMany-field.edit-format {
-          padding: var(--boxel-sp-sm);
-          background-color: var(--boxel-100);
-          border: none !important;
-          border-radius: var(--boxel-border-radius);
-        }
-        .containsMany-field.atom-format {
-          display: contents;
+        @layer {
+          .containsMany-field.edit-format {
+            padding: var(--boxel-sp-sm);
+            background-color: var(--boxel-100);
+            border: none !important;
+            border-radius: var(--boxel-border-radius);
+          }
+          .containsMany-field.atom-format {
+            display: contents;
+          }
         }
       </style>
     </template>;

--- a/packages/base/contains-many-component.gts
+++ b/packages/base/contains-many-component.gts
@@ -210,7 +210,10 @@ export function getContainsManyComponent({
               data-test-plural-view-format={{effectiveFormat}}
             >
               {{#each (getComponents) as |Item i|}}
-                <div data-test-plural-view-item={{i}}>
+                <div
+                  class='boxel-contents-only'
+                  data-test-plural-view-item={{i}}
+                >
                   <Item
                     @format={{getPluralChildFormat effectiveFormat model}}
                   />
@@ -226,6 +229,9 @@ export function getContainsManyComponent({
           background-color: var(--boxel-100);
           border: none !important;
           border-radius: var(--boxel-border-radius);
+        }
+        .containsMany-field.atom-format {
+          display: contents;
         }
       </style>
     </template>;

--- a/packages/base/default-templates/atom.gts
+++ b/packages/base/default-templates/atom.gts
@@ -21,10 +21,12 @@ export default class DefaultAtomViewTemplate extends GlimmerComponent<{
     <span class='atom-default-template'>
       {{this.text}}
     </span>
-    <style scoped>
-      .atom-default-template {
-        font: 600 var(--boxel-font-sm);
-        letter-spacing: var(--boxel-lsp-xs);
+    <style>
+      @layer {
+        .atom-default-template {
+          font: 600 var(--boxel-font-sm);
+          letter-spacing: var(--boxel-lsp-xs);
+        }
       }
     </style>
   </template>

--- a/packages/base/default-templates/atom.gts
+++ b/packages/base/default-templates/atom.gts
@@ -21,7 +21,7 @@ export default class DefaultAtomViewTemplate extends GlimmerComponent<{
     <span class='atom-default-template'>
       {{this.text}}
     </span>
-    <style>
+    <style scoped>
       @layer {
         .atom-default-template {
           font: 600 var(--boxel-font-sm);

--- a/packages/base/default-templates/atom.gts
+++ b/packages/base/default-templates/atom.gts
@@ -18,6 +18,14 @@ export default class DefaultAtomViewTemplate extends GlimmerComponent<{
       : `Untitled ${this.args.model.constructor.displayName}`;
   }
   <template>
-    {{this.text}}
+    <span class='atom-default-template'>
+      {{this.text}}
+    </span>
+    <style scoped>
+      .atom-default-template {
+        font: 600 var(--boxel-font-sm);
+        letter-spacing: var(--boxel-lsp-xs);
+      }
+    </style>
   </template>
 }

--- a/packages/base/default-templates/isolated-and-edit.gts
+++ b/packages/base/default-templates/isolated-and-edit.gts
@@ -43,13 +43,18 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
       }
       /* this aligns edit fields with containsMany, linksTo, and linksToMany fields */
       .default-card-template.edit
-        > .boxel-field
         > :deep(
-          *:nth-child(2):not(.links-to-many-editor):not(
-              .contains-many-editor
-            ):not(.links-to-editor)
+          .boxel-field
+            > .content
+            > *:not(.links-to-many-editor):not(.contains-many-editor):not(
+              .links-to-editor
+            )
         ) {
         padding-right: var(--boxel-icon-lg);
+      }
+      .default-card-template.edit
+        > :deep(.boxel-field > .content > *:not(.links-to-many-editor)) {
+        padding-left: var(--boxel-icon-lg);
       }
     </style>
   </template>

--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -247,10 +247,7 @@ export function getBoxComponent(
                   @value={{defaultFieldFormats effectiveFormats.fieldDef}}
                 >
                   <div
-                    class={{if
-                      (eq effectiveFormats.fieldDef 'atom')
-                      'boxel-contents-only'
-                    }}
+                    class='compound-field {{effectiveFormats.fieldDef}}-format'
                     data-test-compound-field-format={{effectiveFormats.fieldDef}}
                     data-test-compound-field-component
                     {{! @glint-ignore  Argument of type 'unknown' is not assignable to parameter of type 'Element'}}
@@ -338,6 +335,9 @@ export function getBoxComponent(
       }
       .field-component-card.atom-format > :deep(*) {
         vertical-align: middle;
+      }
+      .compound-field.atom-format {
+        display: inline;
       }
     </style>
   </template>;

--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -247,7 +247,10 @@ export function getBoxComponent(
                   @value={{defaultFieldFormats effectiveFormats.fieldDef}}
                 >
                   <div
-                    class='boxel-contents-only'
+                    class={{if
+                      (eq effectiveFormats.fieldDef 'atom')
+                      'boxel-contents-only'
+                    }}
                     data-test-compound-field-format={{effectiveFormats.fieldDef}}
                     data-test-compound-field-component
                     {{! @glint-ignore  Argument of type 'unknown' is not assignable to parameter of type 'Element'}}
@@ -331,7 +334,10 @@ export function getBoxComponent(
         display: inline-block;
         width: auto;
         height: auto;
-        padding: 4px var(--boxel-sp-sm);
+        padding: var(--boxel-sp-4xs) var(--boxel-sp-xs);
+      }
+      .field-component-card.atom-format > :deep(*) {
+        vertical-align: middle;
       }
     </style>
   </template>;

--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -247,6 +247,7 @@ export function getBoxComponent(
                   @value={{defaultFieldFormats effectiveFormats.fieldDef}}
                 >
                   <div
+                    class='boxel-contents-only'
                     data-test-compound-field-format={{effectiveFormats.fieldDef}}
                     data-test-compound-field-component
                     {{! @glint-ignore  Argument of type 'unknown' is not assignable to parameter of type 'Element'}}
@@ -323,13 +324,14 @@ export function getBoxComponent(
         overflow: hidden;
       }
 
-      /*
-        TODO: regarding the atom format styling below, we probably want to refactor to move
-        any styles that effect the inside of the card boundary into the CardDef's atom template
-      */
+      .field-component-card.atom-format.display-container-false {
+        display: contents;
+      }
       .field-component-card.atom-format.display-container-true {
+        display: inline-block;
+        width: auto;
+        height: auto;
         padding: 4px var(--boxel-sp-sm);
-        background-color: var(--boxel-light);
       }
     </style>
   </template>;

--- a/packages/base/links-to-editor.gts
+++ b/packages/base/links-to-editor.gts
@@ -86,10 +86,9 @@ export class LinksToEditor extends GlimmerComponent<Signature> {
     </PermissionsConsumer>
     <style scoped>
       .links-to-editor {
-        --remove-icon-size: var(--boxel-icon-lg);
         position: relative;
         display: grid;
-        grid-template-columns: 1fr var(--remove-icon-size);
+        grid-template-columns: 1fr max-content;
       }
       .links-to-editor > :deep(.boxel-card-container.embedded-format) {
         order: -1;

--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -447,9 +447,6 @@ export function getLinksToManyComponent({
           .linksToMany-field.atom-effectiveFormat.display-container-true {
             display: inline-flex;
             gap: var(--boxel-sp-sm);
-            padding: var(--boxel-sp-sm);
-            border: var(--boxel-border);
-            border-radius: var(--boxel-border-radius);
           }
         }
       </style>

--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -196,6 +196,8 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
         <AddButton
           class='add-new'
           @variant='full-width'
+          @iconWidth='12px'
+          @iconHeight='12px'
           {{on 'click' @add}}
           data-test-add-new
         >
@@ -318,6 +320,7 @@ class LinksToManyCompactEditor extends GlimmerComponent<LinksToManyCompactEditor
         flex-wrap: wrap;
         gap: var(--boxel-sp-xs);
         padding: var(--boxel-sp-xs) 0 var(--boxel-sp-xs) var(--boxel-sp-sm);
+        background-color: var(--boxel-light);
         border: 1px solid var(--boxel-form-control-border-color);
         border-radius: var(--boxel-form-control-border-radius);
       }

--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -17,7 +17,7 @@ import {
   PermissionsConsumer,
   getBoxComponent,
 } from './field-component';
-import { AddButton, IconButton } from '@cardstack/boxel-ui/components';
+import { AddButton, IconButton, Pill } from '@cardstack/boxel-ui/components';
 import {
   restartableTask,
   type EncapsulatedTaskDescriptor as Descriptor,
@@ -283,10 +283,8 @@ class LinksToManyCompactEditor extends GlimmerComponent<LinksToManyCompactEditor
           )
           as |Item|
         }}
-          <div class='boxel-pills-container' data-test-pill-item={{i}}>
-            <div class='boxel-pill'>
-              <Item @format='atom' />
-            </div>
+          <Pill class='item-pill' data-test-pill-item={{i}}>
+            <Item @format='atom' @displayContainer={{false}} />
             <IconButton
               @variant='primary'
               @icon={{IconX}}
@@ -298,7 +296,7 @@ class LinksToManyCompactEditor extends GlimmerComponent<LinksToManyCompactEditor
               data-test-remove-card
               data-test-remove={{i}}
             />
-          </div>
+          </Pill>
         {{/let}}
       {{/each}}
       <AddButton
@@ -315,37 +313,30 @@ class LinksToManyCompactEditor extends GlimmerComponent<LinksToManyCompactEditor
     </div>
     <style scoped>
       .boxel-pills {
+        --boxel-add-button-pill-font: var(--boxel-font-sm);
         display: flex;
         flex-wrap: wrap;
-
+        gap: var(--boxel-sp-xs);
         padding: var(--boxel-sp-xs) 0 var(--boxel-sp-xs) var(--boxel-sp-sm);
         border: 1px solid var(--boxel-form-control-border-color);
         border-radius: var(--boxel-form-control-border-radius);
-        --boxel-add-button-pill-font: var(--boxel-font-sm);
-        gap: var(--boxel-sp-xs);
-      }
-      .boxel-pills-container {
-        position: relative;
-        height: fit-content;
-      }
-      .boxel-pill .atom-format.display-container-true {
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        padding-right: var(--boxel-sp-lg);
-        color: var(--boxel-dark);
       }
       .remove-item-button {
-        --icon-color: var(--boxel-dark);
-        position: absolute;
-        right: 0;
-        top: 0;
-
-        width: 22px;
-        height: 100%;
-        display: flex;
+        width: 18px;
+        height: 18px;
+        display: inline-flex;
         align-items: center;
-        padding-right: var(--boxel-sp-xxs);
+      }
+      .remove-item-button:hover {
+        --icon-color: var(--boxel-600);
+        color: var(--boxel-600);
+      }
+      .item-pill :deep(.atom-default-template:hover) {
+        text-decoration: underline;
+      }
+      .item-pill:has(button:hover) {
+        color: var(--boxel-600);
+        border-color: var(--boxel-600);
       }
     </style>
   </template>
@@ -416,12 +407,14 @@ export function getLinksToManyComponent({
         {{else}}
           {{#let
             (coalesce @format defaultFormats.cardDef)
-            as |effectiveFormat|
+            (if (eq @displayContainer false) false true)
+            as |effectiveFormat displayContainer|
           }}
             <div
               class='plural-field linksToMany-field
                 {{effectiveFormat}}-effectiveFormat
-                {{unless arrayField.children.length "empty"}}'
+                {{unless arrayField.children.length "empty"}}
+                display-container-{{displayContainer}}'
               data-test-plural-view={{field.fieldType}}
               data-test-plural-view-format={{effectiveFormat}}
               ...attributes
@@ -429,6 +422,7 @@ export function getLinksToManyComponent({
               {{#each (getComponents) as |Item i|}}
                 <Item
                   @format={{effectiveFormat}}
+                  @displayContainer={{@displayContainer}}
                   class='linksToMany-item'
                   data-test-plural-view-item={{i}}
                 />
@@ -446,8 +440,11 @@ export function getLinksToManyComponent({
           + .linksToMany-item {
           margin-top: var(--boxel-sp);
         }
-        .linksToMany-field.atom-effectiveFormat {
-          display: flex;
+        .linksToMany-field.atom-effectiveFormat.display-container-false {
+          display: contents;
+        }
+        .linksToMany-field.atom-effectiveFormat.display-container-true {
+          display: inline-flex;
           gap: var(--boxel-sp-sm);
           padding: var(--boxel-sp-sm);
           border: var(--boxel-border);

--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -432,23 +432,25 @@ export function getLinksToManyComponent({
         {{/if}}
       </DefaultFormatsConsumer>
       <style scoped>
-        .linksToMany-field.fitted-effectiveFormat
-          > .linksToMany-item
-          + .linksToMany-item,
-        .linksToMany-field.embedded-effectiveFormat
-          > .linksToMany-item
-          + .linksToMany-item {
-          margin-top: var(--boxel-sp);
-        }
-        .linksToMany-field.atom-effectiveFormat.display-container-false {
-          display: contents;
-        }
-        .linksToMany-field.atom-effectiveFormat.display-container-true {
-          display: inline-flex;
-          gap: var(--boxel-sp-sm);
-          padding: var(--boxel-sp-sm);
-          border: var(--boxel-border);
-          border-radius: var(--boxel-border-radius);
+        @layer {
+          .linksToMany-field.fitted-effectiveFormat
+            > .linksToMany-item
+            + .linksToMany-item,
+          .linksToMany-field.embedded-effectiveFormat
+            > .linksToMany-item
+            + .linksToMany-item {
+            margin-top: var(--boxel-sp);
+          }
+          .linksToMany-field.atom-effectiveFormat.display-container-false {
+            display: contents;
+          }
+          .linksToMany-field.atom-effectiveFormat.display-container-true {
+            display: inline-flex;
+            gap: var(--boxel-sp-sm);
+            padding: var(--boxel-sp-sm);
+            border: var(--boxel-border);
+            border-radius: var(--boxel-border-radius);
+          }
         }
       </style>
     </template>

--- a/packages/experiments-realm/AtomExamples/d7aa387b-6514-47c0-ace2-7de011453e51.json
+++ b/packages/experiments-realm/AtomExamples/d7aa387b-6514-47c0-ace2-7de011453e51.json
@@ -1,0 +1,217 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "name": "Lila",
+      "names": [
+        "Evie",
+        "Lila",
+        "Marco"
+      ],
+      "date": "2024-12-04",
+      "dates": [
+        "2024-12-11",
+        "2024-12-25",
+        "2024-12-31"
+      ],
+      "trip": {
+        "title": "Trip 1"
+      },
+      "trips": [
+        {
+          "title": "Trip 1"
+        },
+        {
+          "title": "Trip 2"
+        },
+        {
+          "title": "Trip 3"
+        }
+      ],
+      "contactLink": {
+        "label": "Email",
+        "value": "a@email.com"
+      },
+      "contactLinks": [
+        {
+          "label": "Email",
+          "value": "a@email.com"
+        },
+        {
+          "label": "Phone",
+          "value": "13472345678"
+        },
+        {
+          "label": "Other",
+          "value": "mywebsite-boxel.io"
+        }
+      ],
+      "title": "Samples 1",
+      "description": null,
+      "thumbnailURL": null
+    },
+    "relationships": {
+      "author": {
+        "links": {
+          "self": "../Author/alice-enwunder"
+        }
+      },
+      "authors.0": {
+        "links": {
+          "self": "../Author/alice-enwunder"
+        }
+      },
+      "authors.1": {
+        "links": {
+          "self": "../Author/0b9c06fd-3833-4947-a0b8-ac24b8e71ee7"
+        }
+      },
+      "authors.2": {
+        "links": {
+          "self": "../Author/jane-doe"
+        }
+      },
+      "pet": {
+        "links": {
+          "self": "../Pet/2"
+        }
+      },
+      "pets.0": {
+        "links": {
+          "self": "../Pet/2"
+        }
+      },
+      "pets.1": {
+        "links": {
+          "self": "../Pet/1"
+        }
+      },
+      "pets.2": {
+        "links": {
+          "self": "../Pet/3"
+        }
+      },
+      "trip.country": {
+        "links": {
+          "self": "http://localhost:4201/experiments/Country/argentina"
+        }
+      },
+      "trip.countries.0": {
+        "links": {
+          "self": "http://localhost:4201/experiments/Country/brazil"
+        }
+      },
+      "trip.countries.1": {
+        "links": {
+          "self": "http://localhost:4201/experiments/Country/4"
+        }
+      },
+      "trip.countries.2": {
+        "links": {
+          "self": "http://localhost:4201/experiments/Country/1"
+        }
+      },
+      "trips.0.country": {
+        "links": {
+          "self": "../Country/1"
+        }
+      },
+      "trips.0.countries.0": {
+        "links": {
+          "self": "../Country/3"
+        }
+      },
+      "trips.0.countries.1": {
+        "links": {
+          "self": "../Country/4"
+        }
+      },
+      "trips.1.country": {
+        "links": {
+          "self": null
+        }
+      },
+      "trips.1.countries": {
+        "links": {
+          "self": null
+        }
+      },
+      "trips.2.country": {
+        "links": {
+          "self": null
+        }
+      },
+      "trips.2.countries": {
+        "links": {
+          "self": null
+        }
+      },
+      "teamMember": {
+        "links": {
+          "self": "../TeamMember/847c1f4e-e0ae-43d3-a012-8ffaa66f5925"
+        }
+      },
+      "teamMembers.0": {
+        "links": {
+          "self": "../TeamMember/5c42e6e9-59c8-4585-a721-e3414d7e7c9e"
+        }
+      },
+      "teamMembers.1": {
+        "links": {
+          "self": "../TeamMember/03e293b9-e4c1-4592-b8d1-e6f963829086"
+        }
+      },
+      "teamMembers.2": {
+        "links": {
+          "self": "../TeamMember/4c9614cd-ecda-42cf-bc18-37903019a7be"
+        }
+      },
+      "company": {
+        "links": {
+          "self": "../Company/9203c173-3420-44b3-863d-90defd7c57c8"
+        }
+      },
+      "companies.0": {
+        "links": {
+          "self": "../Company/141f3e15-cfd5-4b61-bd4c-37ea31dbeeab"
+        }
+      },
+      "companies.1": {
+        "links": {
+          "self": "../Company/e1856419-27b0-4ce3-98fe-759d21c7144f"
+        }
+      },
+      "companies.2": {
+        "links": {
+          "self": "../Company/9203c173-3420-44b3-863d-90defd7c57c8"
+        }
+      },
+      "contact": {
+        "links": {
+          "self": "../Contact/a01fc5c9-d70d-4b9c-aae4-384cf2b79b25"
+        }
+      },
+      "contacts.0": {
+        "links": {
+          "self": "../Customer/0e5aec99-798b-4417-9426-a338432e0ee5"
+        }
+      },
+      "contacts.1": {
+        "links": {
+          "self": "../Lead/1dbcc3e8-fe3c-4c4a-ba66-ff7d637a7358"
+        }
+      },
+      "contacts.2": {
+        "links": {
+          "self": "../Customer/67e87a6c-00d0-4c48-9318-f0c96daa4cae"
+        }
+      }
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../atom-examples",
+        "name": "AtomExamples"
+      }
+    }
+  }
+}

--- a/packages/experiments-realm/atom-examples.gts
+++ b/packages/experiments-realm/atom-examples.gts
@@ -1,0 +1,225 @@
+import { on } from '@ember/modifier';
+import { tracked } from '@glimmer/tracking';
+import {
+  contains,
+  containsMany,
+  field,
+  linksTo,
+  linksToMany,
+  CardDef,
+  Component,
+  FieldDef,
+  StringField,
+} from 'https://cardstack.com/base/card-api';
+import DateField from 'https://cardstack.com/base/date';
+import AtomIcon from '@cardstack/boxel-icons/atom';
+import { Button } from '@cardstack/boxel-ui/components';
+import { Author } from './author';
+import { Pet } from './pet';
+import { Country } from './country';
+import { TeamMember } from './productivity/task';
+import { Company } from './crm/company';
+import { Contact } from './crm/contact';
+import { ContactLinkField } from './fields/contact-link';
+
+class Isolated extends Component<typeof AtomExamples> {
+  <template>
+    <div class='atom-examples'>
+      <h2>Atom Template</h2>
+      <hr />
+      <section>
+        <h3>Contains & ContainsMany:</h3>
+        <div>
+          Name:
+          <@fields.name @format='atom' />
+        </div>
+        <div>
+          Names:
+          <@fields.names @format='atom' />
+        </div>
+        <div>
+          Date:
+          <@fields.date @format='atom' />
+        </div>
+        <div>
+          Dates:
+          <@fields.dates @format='atom' />
+        </div>
+      </section>
+      <hr />
+      <section>
+        <h3>Contains & ContainsMany - Compound Field:</h3>
+        <div>
+          Trip:
+          <@fields.trip @format='atom' />
+        </div>
+        <div>
+          Trips:
+          <@fields.trips @format='atom' />
+        </div>
+        <h4>Custom atom template:</h4>
+        <div>
+          Contact Link:
+          <@fields.contactLink @format='atom' />
+        </div>
+        <div>
+          Contact Links:
+          <@fields.contactLinks @format='atom' />
+        </div>
+      </section>
+      <hr />
+      <section>
+        <h3>LinksTo & LinksToMany:</h3>
+        <section>
+          <h4>Using default atom template for Pet card:</h4>
+          <div>
+            Pet:
+            {{#if @model.pet}}
+              <@fields.pet @format='atom' />
+            {{else}}
+              (Bug: CS-7734)
+            {{/if}}
+          </div>
+          <div>
+            Pets:
+            {{#if @model.pets}}
+              <@fields.pets @format='atom' />
+            {{else}}
+              (Bug: CS-7734)
+            {{/if}}
+          </div>
+          <h4>Default atom template without container:</h4>
+          <div>
+            Pet:
+            {{#if @model.pet}}
+              <@fields.pet @format='atom' @displayContainer={{false}} />
+            {{/if}}
+          </div>
+          <div>
+            Pets:
+            {{#if @model.pets}}
+              <@fields.pets @format='atom' @displayContainer={{false}} />
+            {{/if}}
+          </div>
+        </section>
+        <section>
+          <h4>Using custom atom template for Author card:</h4>
+          <div>
+            Author:
+            <@fields.author @format='atom' />
+          </div>
+          <div>
+            Authors:
+            <@fields.authors @format='atom' />
+          </div>
+          <h4>Custom atom template without container:</h4>
+          <div>
+            Author:
+            <@fields.author @format='atom' @displayContainer={{false}} />
+          </div>
+          <div>
+            Authors:
+            <@fields.authors @format='atom' @displayContainer={{false}} />
+          </div>
+        </section>
+      </section>
+      <hr />
+      <section>
+        <h3>More examples with custom atom template:</h3>
+        <Button {{on 'click' this.toggleContainer}}>Toggle Container</Button>
+        <div>
+          Team Member:
+          <@fields.teamMember
+            @format='atom'
+            @displayContainer={{this.displayContainer}}
+          />
+        </div>
+        <div>
+          Team Members:
+          <@fields.teamMembers
+            @format='atom'
+            @displayContainer={{this.displayContainer}}
+          />
+        </div>
+        <div>
+          Company:
+          <@fields.company
+            @format='atom'
+            @displayContainer={{this.displayContainer}}
+          />
+        </div>
+        <div>
+          Companies:
+          <@fields.companies
+            @format='atom'
+            @displayContainer={{this.displayContainer}}
+          />
+        </div>
+        <div>
+          Contact:
+          <@fields.contact
+            @format='atom'
+            @displayContainer={{this.displayContainer}}
+          />
+        </div>
+        <div>
+          Contacts:
+          <@fields.contacts
+            @format='atom'
+            @displayContainer={{this.displayContainer}}
+          />
+        </div>
+      </section>
+      <hr />
+    </div>
+    <style scoped>
+      .atom-examples {
+        padding: var(--boxel-sp-xl);
+        background-color: var(--boxel-100);
+      }
+      .atom-examples div + div {
+        margin-top: 1em;
+      }
+      button {
+        margin-bottom: 1em;
+      }
+    </style>
+  </template>
+
+  @tracked displayContainer = false;
+  toggleContainer = () => {
+    this.displayContainer = !this.displayContainer;
+  };
+}
+
+class Trip extends FieldDef {
+  static displayName = 'Trip';
+  @field title = contains(StringField);
+  @field country = linksTo(Country);
+  @field countries = linksToMany(Country);
+}
+
+export class AtomExamples extends CardDef {
+  static displayName = 'Atom Examples';
+  static icon = AtomIcon;
+  @field name = contains(StringField);
+  @field names = containsMany(StringField);
+  @field date = contains(DateField);
+  @field dates = containsMany(DateField);
+  @field author = linksTo(Author);
+  @field authors = linksToMany(Author);
+  @field pet = linksTo(Pet);
+  @field pets = linksToMany(Pet);
+  @field trip = contains(Trip);
+  @field trips = containsMany(Trip);
+  @field teamMember = linksTo(TeamMember);
+  @field teamMembers = linksToMany(TeamMember);
+  @field company = linksTo(Company);
+  @field companies = linksToMany(Company);
+  @field contact = linksTo(Contact);
+  @field contacts = linksToMany(Contact);
+  @field contactLink = contains(ContactLinkField);
+  @field contactLinks = containsMany(ContactLinkField);
+
+  static isolated = Isolated;
+}

--- a/packages/host/app/components/card-pill.gts
+++ b/packages/host/app/components/card-pill.gts
@@ -97,18 +97,10 @@ export default class CardPill extends Component<CardPillSignature> {
         display: none;
       }
       .card-content {
-        display: flex;
         max-width: 100px;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-      }
-      .card-content > :deep(.atom-format) {
-        background: none;
-        border-radius: 0;
-        white-space: inherit;
-        overflow: inherit;
-        text-overflow: inherit;
       }
       .remove-button {
         --boxel-icon-button-width: var(--boxel-icon-sm);

--- a/packages/host/app/components/card-pill.gts
+++ b/packages/host/app/components/card-pill.gts
@@ -54,7 +54,7 @@ export default class CardPill extends Component<CardPillSignature> {
       </:iconLeft>
       <:default>
         <div class='card-content' title={{@card.title}}>
-          <this.component @format='atom' @displayContainer={{false}} />
+          {{@card.title}}
         </div>
       </:default>
       <:iconRight>
@@ -89,6 +89,7 @@ export default class CardPill extends Component<CardPillSignature> {
         --boxel-realm-icon-size: var(--pill-icon-size);
         border: 1px solid var(--boxel-400);
         height: var(--pill-height, 1.875rem);
+        overflow: hidden;
       }
       .is-autoattached {
         border-style: dashed;
@@ -98,6 +99,7 @@ export default class CardPill extends Component<CardPillSignature> {
       }
       .card-content {
         max-width: 100px;
+        max-height: 100%;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;


### PR DESCRIPTION
- updated atom template styles for each field type:
  - linksTo and linksToMany atom fields have `displayContainer={{true | false}}` option
  - atom field is inline, inline-block, or display: contents; based on field type/mode
- updated atom template for edit mode (use Pill component and fix spacing between text and remove button)
- better field alignments for edit mode

Card with all atom template types:
### Before Changes:
- atom template is not inline
- container is not always controllable
<img width="739" alt="before-1" src="https://github.com/user-attachments/assets/ba81a897-92bb-49bc-bd5f-ec999ab2cb81" />
<img width="715" alt="before-2" src="https://github.com/user-attachments/assets/afd28bfc-1b48-4d79-b112-66f8e9c6ea82" />
<img width="709" alt="before-3" src="https://github.com/user-attachments/assets/3d548454-c31d-4076-a87d-ee0f8adf6533" />
<img width="715" alt="before-4" src="https://github.com/user-attachments/assets/4ad3308a-371b-482a-9203-de39296b5b4b" />

### After Changes:
<img width="744" alt="atom-1" src="https://github.com/user-attachments/assets/51d75954-f6cd-4105-ba3b-83ab30c9c02c" />
<img width="750" alt="atom-2" src="https://github.com/user-attachments/assets/dfa8d242-a8a0-4c8c-ba5c-14ec12b2e664" />

Edit mode better alignment:
<img width="729" alt="edit-view-alignments" src="https://github.com/user-attachments/assets/668baab9-c8ad-425d-a1dc-35a115ea3a9a" />

Nested atom field edit mode style fixes:
<img width="744" alt="edit-view-nested-field" src="https://github.com/user-attachments/assets/9fe2867f-c1be-4843-87a4-ccb457366d14" />