### PR TITLE
Refactor indexing to get mtimes for entire realm in a single HTTP request

### DIFF
--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -228,7 +228,7 @@ export class CurrentRun {
 
   private async discoverInvalidations(
     url: URL,
-    mtimes: LastModifiedTimes,
+    indexMtimes: LastModifiedTimes,
   ): Promise<void> {
     log.debug(`discovering invalidations in dir ${url.href}`);
     let ignorePatterns = await this.#reader.readFile(
@@ -239,35 +239,26 @@ export class CurrentRun {
       this.#ignoreData[url.href] = ignorePatterns.content;
     }
 
-    let entries = await this.#reader.directoryListing(url);
-
-    for (let { url, kind, lastModified } of entries) {
-      let innerURL = new URL(url);
-      if (isIgnored(this.#realmURL, this.ignoreMap, innerURL)) {
+    let filesystemMtimes = await this.#reader.mtimes();
+    for (let [url, lastModified] of Object.entries(filesystemMtimes)) {
+      if (!url.endsWith('.json') && !hasExecutableExtension(url)) {
+        // Only allow json and executable files to be invalidated so that we
+        // don't end up with invalidated files that weren't meant to be indexed
+        // (images, etc)
         continue;
       }
+      let indexEntry = indexMtimes.get(url);
 
-      if (kind === 'directory') {
-        await this.discoverInvalidations(innerURL, mtimes);
-      } else {
-        if (!url.endsWith('.json') && !hasExecutableExtension(url)) {
-          // Only allow json and executable files to be invalidated so that we don't end up with invalidated files that weren't meant to be indexed (images, etc)
-          continue;
-        }
-
-        let indexEntry = mtimes.get(innerURL.href);
-        if (
-          !indexEntry ||
-          indexEntry.type === 'error' ||
-          indexEntry.lastModified == null
-        ) {
-          await this.batch.invalidate(innerURL);
-          continue;
-        }
-
-        if (lastModified !== indexEntry.lastModified) {
-          await this.batch.invalidate(innerURL);
-        }
+      if (
+        !indexEntry ||
+        indexEntry.type === 'error' ||
+        indexEntry.lastModified == null
+      ) {
+        await this.batch.invalidate(new URL(url));
+        continue;
+      }
+      if (lastModified !== indexEntry.lastModified) {
+        await this.batch.invalidate(new URL(url));
       }
     }
   }

--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -252,12 +252,9 @@ export class CurrentRun {
       if (
         !indexEntry ||
         indexEntry.type === 'error' ||
-        indexEntry.lastModified == null
+        indexEntry.lastModified == null ||
+        lastModified !== indexEntry.lastModified
       ) {
-        await this.batch.invalidate(new URL(url));
-        continue;
-      }
-      if (lastModified !== indexEntry.lastModified) {
         await this.batch.invalidate(new URL(url));
       }
     }

--- a/packages/host/tests/integration/realm-indexing-and-querying-test.gts
+++ b/packages/host/tests/integration/realm-indexing-and-querying-test.gts
@@ -3401,6 +3401,12 @@ module(`Integration | realm indexing and querying`, function (hooks) {
                 { id: mangoID },
                 {
                   id: vanGoghID,
+                  firstName: 'Van Gogh',
+                  friends: [
+                    {
+                      id: hassanID,
+                    },
+                  ],
                 },
               ],
             },

--- a/packages/runtime-common/router.ts
+++ b/packages/runtime-common/router.ts
@@ -21,6 +21,7 @@ export enum SupportedMimeType {
   CardSource = 'application/vnd.card+source',
   DirectoryListing = 'application/vnd.api+json',
   RealmInfo = 'application/vnd.api+json',
+  Mtimes = 'application/vnd.api+json',
   Permissions = 'application/vnd.api+json',
   Session = 'application/json',
   EventStream = 'text/event-stream',


### PR DESCRIPTION
This PR refactors the index worker to only use a single request to get all the mtimes for the underlying Realm filesystem.