### PR TITLE
Fix opening animation when closing card

### DIFF
--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -972,6 +972,7 @@ module('Integration | operator-mode', function (hooks) {
       .includesText('Person');
 
     await click('[data-test-stack-card-index="1"] [data-test-close-button]');
+    await waitFor('[data-test-stack-card-index="1"]', { count: 0 });
     assert.dom(`[data-test-stack-card-index="1"]`).doesNotExist();
   });
 
@@ -1586,6 +1587,10 @@ module('Integration | operator-mode', function (hooks) {
       .exists();
     await click(`[data-test-search-sheet-cancel-button]`);
     await click(`[data-test-stack-card-index="1"] [data-test-close-button]`);
+
+    await waitUntil(
+      () => !document.querySelector('[data-test-stack-card-index="1"]'),
+    );
 
     await waitFor(`[data-test-cards-grid-item]`);
     await click(`[data-test-cards-grid-item="${testRealmURL}Person/burcu"]`);

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -3038,4 +3038,27 @@ module('Integration | operator-mode', function (hooks) {
       .dom(`[data-test-stack-card="${testRealmURL}Person/fadhlan"]`)
       .doesNotHaveClass('opening-animation');
   });
+
+  test('close card should not trigger opening animation again', async function (assert) {
+    await setCardInOperatorModeState(`${testRealmURL}grid`);
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template>
+          <OperatorMode @onClose={{noop}} />
+          <CardPrerender />
+        </template>
+      },
+    );
+    await waitFor(`[data-test-stack-card="${testRealmURL}grid"]`);
+
+    await click(`[data-test-boxel-filter-list-button="All Cards"]`);
+    await waitFor(`[data-test-cards-grid-item]`);
+    await click(`[data-test-cards-grid-item="${testRealmURL}Person/fadhlan"]`);
+    await click(`[data-test-stack-card-index="1"] [data-test-close-button]`);
+
+    await waitFor(`[data-test-stack-card-index="0"]`);
+    assert
+      .dom(`[data-test-stack-card-index="0"]`)
+      .doesNotHaveClass('opening-animation');
+  });
 });


### PR DESCRIPTION
Refer to https://linear.app/cardstack/issue/CS-7729/open-animation-gets-triggered-when-closing-card

### What is changing

**Before**

https://github.com/user-attachments/assets/87aaadf0-d43d-43f9-bbd8-dc9e920b752a

**After**


https://github.com/user-attachments/assets/77191b7f-6d9f-43a7-ac95-27d1b5fa36eb

