### PR TITLE
CRM app consistent search bar behavior

### DIFF
--- a/packages/experiments-realm/Deal/4fdd3053-14f1-4800-827f-d3e2a5c44ae8.json
+++ b/packages/experiments-realm/Deal/4fdd3053-14f1-4800-827f-d3e2a5c44ae8.json
@@ -74,7 +74,6 @@
           }
         }
       ],
-      "title": null,
       "description": null,
       "thumbnailURL": "https://picsum.photos/id/500/200/300"
     },

--- a/packages/experiments-realm/Deal/50b65110-8335-4391-84ec-28cc9c0f22b3.json
+++ b/packages/experiments-realm/Deal/50b65110-8335-4391-84ec-28cc9c0f22b3.json
@@ -2,7 +2,7 @@
   "data": {
     "type": "card",
     "attributes": {
-      "name": null,
+      "name": "",
       "status": {
         "index": 1,
         "label": "Proposal",
@@ -37,7 +37,6 @@
       "healthScore": null,
       "notes": "",
       "valueBreakdown": [],
-      "title": null,
       "description": null,
       "thumbnailURL": null
     },

--- a/packages/experiments-realm/Deal/f0d769bd-e347-4203-9a96-89332cfba0e2.json
+++ b/packages/experiments-realm/Deal/f0d769bd-e347-4203-9a96-89332cfba0e2.json
@@ -2,7 +2,7 @@
   "data": {
     "type": "card",
     "attributes": {
-      "name": null,
+      "name": "",
       "status": {
         "index": 3,
         "label": "Closed Won",
@@ -37,7 +37,6 @@
       "healthScore": null,
       "notes": null,
       "valueBreakdown": [],
-      "title": null,
       "description": null,
       "thumbnailURL": null
     },

--- a/packages/experiments-realm/crm-app.gts
+++ b/packages/experiments-realm/crm-app.gts
@@ -289,10 +289,6 @@ class CrmAppTemplate extends Component<typeof AppCard> {
                 on: activeFilter.cardRef,
                 contains: { name: searchKey },
               },
-              {
-                on: activeFilter.cardRef,
-                contains: { 'company.name': searchKey },
-              },
             ],
           },
         ]

--- a/packages/experiments-realm/crm/deal.gts
+++ b/packages/experiments-realm/crm/deal.gts
@@ -982,6 +982,12 @@ export class Deal extends CardDef {
       return this.account?.company;
     },
   });
+  @field title = contains(StringField, {
+    computeVia: function (this: Deal) {
+      return this.name;
+    },
+  });
+
   static isolated = IsolatedTemplate;
   static fitted = FittedTemplate;
 }


### PR DESCRIPTION
Refer to https://linear.app/cardstack/issue/CS-7705/search-bar-functionality-in-deal-and-account

### What is changing
- remove company name search
- search from the computed title (eg. account title computed from `account.company.name` )