### PR TITLE
Indexing error catching

### DIFF
--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -321,11 +321,14 @@ export class CurrentRun {
         skipList.push(url);
       }
     }
-    if (skipList.length === 0) {
-      // the whole realm needs to be visited, no need to calculate
-      // invalidations--it's everything
-      return invalidationList;
-    }
+    // back this out until we can figure out why it gets trapped in a loop in
+    // experiments realm indexing
+
+    // if (skipList.length === 0) {
+    //   // the whole realm needs to be visited, no need to calculate
+    //   // invalidations--it's everything
+    //   return invalidationList;
+    // }
 
     let invalidationStart = Date.now();
     for (let invalidationURL of invalidationList) {

--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -188,11 +188,8 @@ export class CurrentRun {
         );
       });
     } catch (e: any) {
-      log.error(
-        `Encountered error during full scratch indexing of realm ${current.realmURL.href}: ${e.message} - ${e.stack}`,
-      );
       console.error(
-        `Encountered error during full scratch indexing of ${current.realmURL.href}`,
+        `Encountered error during from-scratch indexing of ${current.realmURL.href}`,
         e,
       );
     }
@@ -241,9 +238,6 @@ export class CurrentRun {
         );
       });
     } catch (e: any) {
-      log.error(
-        `Encountered error during incremental indexing of realm ${url.href}: ${e.message} - ${e.stack}`,
-      );
       console.error(
         `Encountered error during incremental indexing of ${url.href}`,
         e,


### PR DESCRIPTION
This is to hopefully catch the scenarios where indexing seems to drop off a cliff in production and our jobs never complete. We wrap a try/catch around the entire indexing functions and always make sure to return something. and log errors if they occur.