### PR TITLE
Fixed bug where deferred's resolve was being thrown away in error scenarios causing indexer hang

### DIFF
--- a/packages/realm-server/tests/cards/ChessGallery/2059b2be-791e-47a5-9a9c-be59dee4ea83.json
+++ b/packages/realm-server/tests/cards/ChessGallery/2059b2be-791e-47a5-9a9c-be59dee4ea83.json
@@ -1,0 +1,20 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "pgn": "1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Nb8 10. d4 Nbd7 11. c4 c6 12. Nc3 Bb7 13. Bg5 h6 14. Bh4 Re8 15. cxb5 axb5 16. a3 Bf8 17. Rc1 Qb6 18. Bg3 Rad8 19. d5 c5 20. Nd2 g6 21. Bc2 Bg7 22. Bd3 c4 23. Bc2 Nc5 24. b4 cxb3 25. Nxb3 Nxb3 26. Bxb3 Rc8 27. Qd3 Ba6 28. Na2 Nd7 29. Nb4 Nc5 30. Qb1 Bb7 31. Kh1 Re7 32. f3 Rec7 33. Bf2 Bf8 34. Rc3 Qa7 35. Rec1 Qa8 36. Qa2 Be7 37. Be3 Bf8 38. Kh2 Be7 39. R1c2 Qa7 40. Qb1 Bg5 41. Bxg5 hxg5 42. Nd3 Kg7 43. Ba2 f5 44. Qc1 fxe4 45. Qxg5 Ba6 46. Nb4 Bb7 47. fxe4 Qa8 48. Rg3 Kh7 49. Qxg6+ Kh8 50. Qh6+ Rh7 51. Qf6+ Rg7 52. Rg4 Ba6 53. Nc6 Re8 54. Bb3 Bc8 55. Rg5 Rf8 56. Qxd6 Nxe4 57. Qxe5 Nxg5 58. Qxg5 Rxg5 59. d6 Bd7 60. Ne5 Be8 61. d7 Bxd7 62. Nxd7 Rff2 63. Rc8+ Kh7 64. Nf6+ Kg6 65. Bd5 Rxf6 66. Be4+ Kh5 67. Rc3 Rf2 68. Re3 Ra2 69. Bf3+ Kg6 70. Bg4 Qxg2#",
+      "dateOfGame": "2022-12-12",
+      "whitePlayer": "Magnus Carlsen",
+      "blackPlayer": "Ian Nepomniachtchi",
+      "title": "Magnus Carlsen vs Ian Nepomniachtchi - 2022 World Championship",
+      "description": "A thrilling game in the 2022 World Championship where Magnus Carlsen faced Ian Nepomniachtchi. An intense battle showcasing advanced strategies.",
+      "thumbnailURL": "https://www.chessdom.com/wp-content/uploads/2022/09/nepo-magnus-end-nr.jpeg"
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../chess-gallery",
+        "name": "ChessGallery"
+      }
+    }
+  }
+}

--- a/packages/realm-server/tests/cards/ChessGallery/401aa8da-7559-41b5-ae4d-74e455087bd6.json
+++ b/packages/realm-server/tests/cards/ChessGallery/401aa8da-7559-41b5-ae4d-74e455087bd6.json
@@ -1,0 +1,20 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "pgn": "1. e4 c5 2. Nf3 Nc6 3. Bb5 g6 4. O-O Bg7 5. Re1 e5 6. c3 Nge7 7. d4 cxd4 8. cxd4 exd4 9. e5 a6 10. Bf1 O-O 11. Na3 d6 12. exd6 Qxd6 13. Nc4 Qc7 14. g3 Nd5 15. Bg2 Rd8 16. Bg5 f6 17. Bd2 b5 18. Na3 Kh8 19. Rc1 Qb6 20. Qb3 Bf8 21. Nh4 Nde7 22. Qf7 Bg7 23. Rxc6 Qxc6 24. Rxe7 Qxg2+ 25. Kxg2 Rg8 26. Bh6 Bh3+ 27. Kxh3 Ra7 28. Bxg7+ Rxg7 29. Re8+ Rg8 30. Rxg8#",
+      "dateOfGame": "2022-08-06",
+      "whitePlayer": "Gukesh D",
+      "blackPlayer": "Alexei Shirov",
+      "title": "Gukesh D vs Alexei Shirov - 2022 Chess Olympiad",
+      "description": "A remarkable victory by Gukesh over Alexei Shirov at the 2022 Chess Olympiad, showcasing his extraordinary talent and strategic prowess.",
+      "thumbnailURL": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRqPDi__ejymzQm5Ho7m6zWAOExXkYS-DcAmw&s"
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../chess-gallery",
+        "name": "ChessGallery"
+      }
+    }
+  }
+}

--- a/packages/realm-server/tests/cards/ChessGallery/4a46ad31-357f-42fa-8618-0e96f35d1ab9.json
+++ b/packages/realm-server/tests/cards/ChessGallery/4a46ad31-357f-42fa-8618-0e96f35d1ab9.json
@@ -1,0 +1,20 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "pgn": "1. e4 d6 2. d4 Nf6 3. Nc3 g6 4. f4 Bg7 5. Nf3 O-O 6. Bd3 c5 7. dxc5 Qa5 8. O-O Qxc5+ 9. Kh1 Nc6 10. Qe1 Bg4 11. Be3 Qa5 12. Nd2 Be6 13. f5 Bd7 14. Qh4 Ne5 15. Bh6 Bxh6 16. Qxh6 Neg4 17. Qh4 Kg7 18. Nc4 Qc5 19. Rae1 Bc6 20. h3 Ne5 21. Nxe5 Qxe5 22. Nd5 Bxd5 23. exd5 Qxb2 24. Rxe7 b5 25. a4 a6 26. Qg5 Rae8 27. Re6 bxa4 28. Rxd6 Qe5 29. Rxa6 Nxd5 30. f6+ Kh8 31. Qh6 Rg8 32. Rxa4 Nxf6 33. Rh4 Rg7 34. c4 Nh5 35. c5 Ng3+ 36. Kg1 Nxf1 37. Bxf1 Qxc5+ 38. Kh2 Qd6+ 39. Kg1 Qc5+ 40. Kh2 Re1 41. Qf4 Qe5 42. Rg4 Qxf4+ 43. Rxf4 f5 44. h4 Ra7 45. Kg3 Ra3+ 46. Kh2 Raa1 47. Bc4 Re4 48. Rxe4 fxe4 49. Kg3 Kg7 50. Kf4 Ra3 51. Be2 e3 52. Kf3 Kf6 53. g4 Ke5 54. h5 g5 55. Bc4 Rc3 56. Bg8 h6 57. Bf7 Kd4 58. Bg6 Rc6 59. Be4 Rf6+ 60. Bf5 Ke5 61. Kxe3 Rxf5 62. gxf5 Kxf5 63. Kf3 g4+ 64. Kg3 Kg5 65. Kg2 Kxh5 66. Kg3 Kg5 67. Kg2 h5 68. Kg3 h4+ 69. Kg2 h3+ 70. Kg3 Kh5 71. f3 gxf3 72. Kxh3 Kg5 73. Kg3 Kf5 74. Kf2 Ke4 75. Ke1 Kd3 76. Kf2 Ke4 77. Ke1 Kf4 78. Kf2",
+      "dateOfGame": "1999-10-23",
+      "whitePlayer": "Garry Kasparov",
+      "blackPlayer": "Veselin Topalov",
+      "title": "Kasparov's Immortal Game - 1999",
+      "description": "Garry Kasparov's stunning victory against Veselin Topalov at the 1999 Wijk aan Zee tournament, often referred to as Kasparov's Immortal.",
+      "thumbnailURL": "https://i.ytimg.com/vi/9PwSa7hkiKc/maxresdefault.jpg"
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../chess-gallery",
+        "name": "ChessGallery"
+      }
+    }
+  }
+}

--- a/packages/realm-server/tests/cards/chess-gallery.gts
+++ b/packages/realm-server/tests/cards/chess-gallery.gts
@@ -1,0 +1,60 @@
+import DateField from 'https://cardstack.com/base/date';
+import {
+  FieldDef,
+  field,
+  contains,
+  StringField,
+} from 'https://cardstack.com/base/card-api';
+import { Component } from 'https://cardstack.com/base/card-api';
+
+// This is intentionally using a FieldDef so it can replicate the error in
+// https://linear.app/cardstack/issue/CS-7797/indexer-hangs-when-encountering-instance-json-that-refers-to-a-field
+export class ChessGallery extends FieldDef {
+  @field pgn = contains(StringField);
+  @field dateOfGame = contains(DateField);
+  @field whitePlayer = contains(StringField);
+  @field blackPlayer = contains(StringField);
+  static displayName = 'Chess Gallery';
+
+  static edit = class Edit extends Component<typeof this> {
+    <template>
+      <div class='chess-gallery-edit'>
+        <@fields.whitePlayer />
+        <@fields.blackPlayer />
+        <@fields.dateOfGame />
+        <@fields.pgn />
+      </div>
+      <style scoped>
+        .chess-gallery-edit {
+          display: grid;
+          gap: var(--boxel-sp);
+        }
+      </style>
+    </template>
+  };
+
+  static embedded = class Embedded extends Component<typeof this> {
+    <template>
+      <div class='chess-gallery-view'>
+        <div class='players'>
+          <span class='white'>{{@model.whitePlayer}}</span>
+          vs
+          <span class='black'>{{@model.blackPlayer}}</span>
+        </div>
+      </div>
+      <style scoped>
+        .chess-gallery-view {
+          padding: var(--boxel-sp);
+        }
+        .players {
+          font-weight: 600;
+          margin-bottom: var(--boxel-sp-xxs);
+        }
+        .white,
+        .black {
+          color: var(--boxel-purple-600);
+        }
+      </style>
+    </template>
+  };
+}

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -4849,6 +4849,22 @@ module(basename(__filename), function () {
                   kind: 'file',
                 },
               },
+              'chess-gallery.gts': {
+                links: {
+                  related: `${testRealmHref}chess-gallery.gts`,
+                },
+                meta: {
+                  kind: 'file',
+                },
+              },
+              'ChessGallery/': {
+                links: {
+                  related: `${testRealmHref}ChessGallery/`,
+                },
+                meta: {
+                  kind: 'directory',
+                },
+              },
               'code-ref-test.gts': {
                 links: {
                   related: `${testRealmHref}code-ref-test.gts`,


### PR DESCRIPTION
This PR solves a problem that has been plaguing us in the production environment where the indexing would hang in certain circumstances. The issue was that the indexer's logic to derive the types for the instances was inadvertently throwing away the resolve for a deferred in various error scenarios. This means that the promise for this method would never be fulfilled leading to the indexing hang. In this fix we make sure to always fulfill the deferred for this method.

We are using the literal data that triggered this issue in production as a means to test the fix which proves that the indexer no longer hangs when it encounters these particular type related instance errors.