### PR TITLE
Make sure card types in index card are ordered by display_name

### DIFF
--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -305,6 +305,7 @@ export class Batch {
         any([['i.is_deleted = false'], ['i.is_deleted IS NULL']]),
       ]),
       `GROUP BY i.display_names->>0, i.types->>0`,
+      `ORDER BY i.display_names->>0 ASC`,
     ] as Expression);
 
     let { nameExpressions, valueExpressions } = asExpressions(


### PR DESCRIPTION
The bug ticket specifies that the order of the card types is wrong:

<img width="388" alt="image" src="https://github.com/user-attachments/assets/25d96cb7-2a81-461b-bc7f-5ca40c6b1c3a" />

However, during testing, I was not able to reproduce this. Even by creating new realms and checking the list - it was all perfectly in alphabetical order... These items are stored as a json array in realm_meta table in the following form:

```
realm_url             | realm_version | value                                                     
'https://example.com' | 1             | [{total:2, display_name: "Author",...}] 
```

It looks like the query that writes this data is not reliable and the sort by display name was "accidental" for most of the time–adding an explicit order should solve this rare bug. 

There is already a test that tests for the order of the display names: https://github.com/cardstack/boxel/blob/1a322fa545a781e0f7993457cf7d2b6bbd6382f9/packages/realm-server/tests/realm-server-test.ts#L4099-L4134
