### PR TITLE
replace custom max-width with 100%

### DIFF
--- a/packages/experiments-realm/blog-app.gts
+++ b/packages/experiments-realm/blog-app.gts
@@ -165,6 +165,7 @@ class BlogAppTemplate extends Component<typeof BlogApp> {
       @filters={{this.filters}}
       @activeFilter={{this.activeFilter}}
       @onFilterChange={{this.onFilterChange}}
+      class='blog-app'
     >
       <:sidebar>
         <TitleGroup
@@ -232,6 +233,9 @@ class BlogAppTemplate extends Component<typeof BlogApp> {
       </:grid>
     </Layout>
     <style scoped>
+      .blog-app {
+        --content-max-width: 1040px;
+      }
       .sidebar-create-button {
         --icon-color: currentColor;
         --boxel-loading-indicator-size: 15px;

--- a/packages/experiments-realm/components/layout.gts
+++ b/packages/experiments-realm/components/layout.gts
@@ -146,7 +146,6 @@ export class Layout extends GlimmerComponent<LayoutSignature> {
       .layout {
         --layout-padding: var(--boxel-sp-lg);
         --sidebar-width: 255px;
-        --content-max-width: 1040px;
         --layout-background-color: var(--boxel-light);
         display: flex;
         width: 100%;
@@ -208,7 +207,7 @@ export class Layout extends GlimmerComponent<LayoutSignature> {
         gap: var(--boxel-sp-xs) var(--boxel-sp-lg);
       }
       .content-grid {
-        max-width: var(--content-max-width);
+        max-width: var(--content-max-width, 100%);
         padding-left: var(--layout-padding);
         padding-bottom: var(--layout-padding);
       }


### PR DESCRIPTION
linear:  https://linear.app/cardstack/issue/CS-7787/crm-grid-max-width-should-be-100percent

- Remove any hardcoded max-width values
- Use CSS variables for flexible width control if required by design
- Let the content naturally fill the available space

Before:
<img width="856" alt="Screenshot 2025-01-13 at 15 30 38" src="https://github.com/user-attachments/assets/a781a903-97dc-4ad5-825d-cd326f2f7cb8" />

After:
<img width="852" alt="Screenshot 2025-01-13 at 15 31 21" src="https://github.com/user-attachments/assets/00639c48-8b39-4873-8bd0-83ca389a05e8" />
