### PR TITLE
Move log levels to SSM Parameter store

### DIFF
--- a/packages/realm-server/scripts/start-production.sh
+++ b/packages/realm-server/scripts/start-production.sh
@@ -4,7 +4,6 @@ pnpm setup:experiments-in-deployment
 pnpm setup:seed-in-deployment
 pnpm setup:catalog-in-deployment
 NODE_NO_WARNINGS=1 \
-  LOG_LEVELS='*=info' \
   MATRIX_URL=https://matrix.boxel.ai \
   REALM_SERVER_MATRIX_USERNAME=realm_server \
   ts-node \

--- a/packages/realm-server/scripts/start-staging.sh
+++ b/packages/realm-server/scripts/start-staging.sh
@@ -4,7 +4,6 @@ pnpm setup:experiments-in-deployment
 pnpm setup:seed-in-deployment
 pnpm setup:catalog-in-deployment
 NODE_NO_WARNINGS=1 \
-  LOG_LEVELS='perf=debug' \
   MATRIX_URL=https://matrix-staging.stack.cards \
   REALM_SERVER_MATRIX_USERNAME=realm_server \
   ts-node \

--- a/packages/realm-server/scripts/start-worker-production.sh
+++ b/packages/realm-server/scripts/start-worker-production.sh
@@ -1,7 +1,6 @@
 #! /bin/sh
 
 NODE_NO_WARNINGS=1 \
-  LOG_LEVELS='*=info' \
   ts-node \
   --transpileOnly worker-manager \
   --count="${WORKER_COUNT:-1}" \

--- a/packages/realm-server/scripts/start-worker-staging.sh
+++ b/packages/realm-server/scripts/start-worker-staging.sh
@@ -1,7 +1,6 @@
 #! /bin/sh
 
 NODE_NO_WARNINGS=1 \
-  LOG_LEVELS='perf=debug' \
   ts-node \
   --transpileOnly worker-manager \
   --count="${WORKER_COUNT:-1}" \

--- a/packages/realm-server/worker.Dockerfile
+++ b/packages/realm-server/worker.Dockerfile
@@ -3,7 +3,6 @@
 FROM node:18.6.0-slim
 ARG worker_script
 ENV worker_script=$worker_script
-ENV LOG_LEVELS='worker=debug'
 
 WORKDIR /realm-server
 


### PR DESCRIPTION
This PR moves the setting of the env var for `LOG_LEVELS` to the SSM Parameter store (really it just removes the places where we would otherwise stomp on top of this). It's a lot faster to change log levels from SSM and update the ECS task directly from AWS console than it is to go thru our build pipeline.

paired with https://github.com/cardstack/infra/pull/570