### PR TITLE
Fix panel display

### DIFF
--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/index.gts
@@ -161,7 +161,7 @@ export default class ResizablePanelGroup extends Component<Signature> {
       }
 
       return htmlSafe(
-        `flex: 0; flex-grow: ${flexGrow}; flex-shrink: 1; overflow: hidden; pointer-events: ${
+        `flex: 0; flex-grow: ${flexGrow}; flex-shrink: 1; pointer-events: ${
           this.dragState !== null ? 'none' : undefined
         };`,
       );

--- a/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
+++ b/packages/boxel-ui/addon/src/components/resizable-panel-group/panel.gts
@@ -49,6 +49,11 @@ export default class Panel extends Component<Signature> {
     >
       {{yield}}
     </div>
+    <style scoped>
+      .boxel-panel {
+        overflow: hidden;
+      }
+    </style>
   </template>
 
   element!: HTMLDivElement;

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -327,6 +327,7 @@ export default class SubmodeLayout extends Component<Signature> {
           )
         }}
           <ResizablePanel
+            class='ai-assistant-resizable-panel'
             @defaultSize={{this.aiPanelWidths.defaultWidth}}
             @minSize={{this.aiPanelWidths.minWidth}}
             @collapsible={{false}}
@@ -366,6 +367,10 @@ export default class SubmodeLayout extends Component<Signature> {
 
       .submode-layout > .boxel-panel-group {
         width: 100%;
+      }
+
+      .ai-assistant-resizable-panel {
+        overflow: initial;
       }
 
       .main-panel {


### PR DESCRIPTION
On safari, at a certain window size, the Past Sessions panel gets cropped, even though there's no change in the style. Here is a workaround. I haven't come across any repercussions for making this specific panel not be `overflow: hidden`.

Before:
<img width="1296" alt="before-past-sessions" src="https://github.com/user-attachments/assets/10b63dfa-849e-4561-aeb1-f8e64ea42774" />

After:
<img width="1298" alt="after-past-sessions" src="https://github.com/user-attachments/assets/02888906-4843-4058-8b72-21799a8724df" />
