### PR TITLE
prevent collision in the realmsRootPath when starting base realm server for matrix tests

### DIFF
--- a/packages/realm-server/scripts/start-base.sh
+++ b/packages/realm-server/scripts/start-base.sh
@@ -20,7 +20,7 @@ NODE_ENV=development \
   --transpileOnly main \
   --port=4201 \
   --matrixURL='http://localhost:8008' \
-  --realmsRootPath='./realms/localhost_4201' \
+  --realmsRootPath='./realms/localhost_4201_base' \
   --migrateDB \
   $1 \
   \


### PR DESCRIPTION
This PR prevents the base realm server (a realm server that only hosts the base realm) used for matrix testing from colliding with the normal development realm server in regards to the `realmRootPath`. This collision prevents us from running matrix tests locally.