### PR TITLE
realm: Add session room property to realm JWTs

### DIFF
--- a/packages/matrix/tests/login.spec.ts
+++ b/packages/matrix/tests/login.spec.ts
@@ -112,10 +112,12 @@ test.describe('Login', () => {
     let claims = jwt.verify(token, REALM_SECRET_SEED) as {
       user: string;
       realm: string;
+      sessionRoom: string;
       permissions: ('read' | 'write' | 'realm-owner')[];
     };
     expect(claims.user).toStrictEqual('@user1:localhost');
     expect(claims.realm).toStrictEqual(`${appURL}/`);
+    expect(claims.sessionRoom).toMatch(/!\w*:localhost/);
     expect(claims.permissions).toMatchObject(['read', 'write']);
 
     // reload to page to show that the access token persists

--- a/packages/realm-server/tests/realm-server-test.ts
+++ b/packages/realm-server/tests/realm-server-test.ts
@@ -97,7 +97,15 @@ let createJWT = (
   user: string,
   permissions: RealmPermissions['user'] = [],
 ) => {
-  return realm.createJWT({ user, realm: realm.url, permissions }, '7d');
+  return realm.createJWT(
+    {
+      user,
+      realm: realm.url,
+      permissions,
+      sessionRoom: `test-session-room-for-${user}`,
+    },
+    '7d',
+  );
 };
 
 module(basename(__filename), function () {

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -109,6 +109,7 @@ export interface FileRef {
 export interface TokenClaims {
   user: string;
   realm: string;
+  sessionRoom: string;
   permissions: RealmPermissions['user'];
 }
 
@@ -654,7 +655,7 @@ export class Realm {
             requestContext,
           });
         },
-        createJWT: async (user: string) => {
+        createJWT: async (user: string, sessionRoom: string) => {
           let permissions = requestContext.permissions;
 
           let userPermissions = await new RealmPermissionChecker(
@@ -666,6 +667,7 @@ export class Realm {
             {
               user,
               realm: this.url,
+              sessionRoom,
               permissions: userPermissions,
             },
             '7d',


### PR DESCRIPTION
This includes the realm-to-user room id when encoding the JWT. This will let us verify provenance when processing events that have moved from SSE to Matrix.

The issue called for the property to be called `roomId` but since the realm server JWT uses `sessionRoom`, I used that instead.