### PR TITLE
host: Add JWT refetch for sessionRoom property

### DIFF
--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -333,7 +333,7 @@ class RealmResource {
     }
 
     if (!this.claims.sessionRoom) {
-      // Force JWT renewal to unsure presence of sessionRoom property
+      // Force JWT renewal to ensure presence of sessionRoom property
       console.log(`JWT for realm ${this.url} has no session room, renewing`);
     } else {
       // token expiration is unix time (seconds)

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -332,6 +332,8 @@ class RealmResource {
       return;
     }
 
+    let refreshMs = 0;
+
     if (!this.claims.sessionRoom) {
       // Force JWT renewal to ensure presence of sessionRoom property
       console.log(`JWT for realm ${this.url} has no session room, renewing`);
@@ -339,13 +341,13 @@ class RealmResource {
       // token expiration is unix time (seconds)
       let expirationMs = this.claims.exp * 1000;
 
-      let refreshMs = Math.max(
+      refreshMs = Math.max(
         expirationMs - Date.now() - tokenRefreshPeriodSec * 1000,
         0,
       );
-
-      await rawTimeout(refreshMs);
     }
+
+    await rawTimeout(refreshMs);
 
     if (!this.loggingIn) {
       this.loggingIn = this.loginTask.perform();

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -332,15 +332,20 @@ class RealmResource {
       return;
     }
 
-    // token expiration is unix time (seconds)
-    let expirationMs = this.claims.exp * 1000;
+    if (!this.claims.sessionRoom) {
+      console.log('JWT has no session room, renewing');
+    } else {
+      // token expiration is unix time (seconds)
+      let expirationMs = this.claims.exp * 1000;
 
-    let refreshMs = Math.max(
-      expirationMs - Date.now() - tokenRefreshPeriodSec * 1000,
-      0,
-    );
+      let refreshMs = Math.max(
+        expirationMs - Date.now() - tokenRefreshPeriodSec * 1000,
+        0,
+      );
 
-    await rawTimeout(refreshMs);
+      await rawTimeout(refreshMs);
+    }
+
     if (!this.loggingIn) {
       this.loggingIn = this.loginTask.perform();
       await this.loggingIn;

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -333,8 +333,8 @@ class RealmResource {
     }
 
     if (!this.claims.sessionRoom) {
-      console.log('JWT has no session room, renewing');
       // Force JWT renewal to unsure presence of sessionRoom property
+      console.log(`JWT for realm ${this.url} has no session room, renewing`);
     } else {
       // token expiration is unix time (seconds)
       let expirationMs = this.claims.exp * 1000;

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -334,6 +334,7 @@ class RealmResource {
 
     if (!this.claims.sessionRoom) {
       console.log('JWT has no session room, renewing');
+      // Force JWT renewal to unsure presence of sessionRoom property
     } else {
       // token expiration is unix time (seconds)
       let expirationMs = this.claims.exp * 1000;

--- a/packages/host/tests/helpers/mock-matrix/_client.ts
+++ b/packages/host/tests/helpers/mock-matrix/_client.ts
@@ -90,6 +90,7 @@ export class MockClient implements ExtendedClient {
       exp: expires,
       user: this.loggedInAs,
       realm: realmURL.href,
+      sessionRoom: `test-session-room-for-${this.loggedInAs}`,
       // adding a nonce to the test token so that we can tell the difference
       // between different tokens created in the same second
       nonce: nonce++,


### PR DESCRIPTION
This detects the absence of #2058’s new `sessionRoom` property in a realm JWT and triggers a refetch.

I deployed this to production where I had existing JWTs with no `sessionRoom` and the new JWTs had it:

<img width="359" alt="Boxel 2025-01-20 15-58-41" src="https://github.com/user-attachments/assets/47e46879-7473-421a-8a66-68770a1a5f42" />

<img width="459" alt="JSON Web Tokens - jwt io 2025-01-20 15-59-17" src="https://github.com/user-attachments/assets/78159ee8-001d-4e23-86f3-2d42b27c9ecf" />
