### PR TITLE
More cssVar customization on summary card

### DIFF
--- a/packages/experiments-realm/components/summary-card.gts
+++ b/packages/experiments-realm/components/summary-card.gts
@@ -13,18 +13,24 @@ export default class SummaryCard extends GlimmerComponent<SummaryCardArgs> {
   <template>
     <article class='summary-card' ...attributes>
       <header class='summary-card-header'>
-        <div class='summary-card-title'>
-          {{yield to='title'}}
-        </div>
-        <div class='summary-card-icon'>
-          {{yield to='icon'}}
-        </div>
-      </header>
-      <div class='summary-card-content'>
-        {{#if (has-block 'content')}}
-          {{yield to='content'}}
+        {{#if (has-block 'title')}}
+          <div class='summary-card-title'>
+            {{yield to='title'}}
+          </div>
         {{/if}}
-      </div>
+
+        {{#if (has-block 'icon')}}
+          <div class='summary-card-icon'>
+            {{yield to='icon'}}
+          </div>
+        {{/if}}
+      </header>
+
+      {{#if (has-block 'content')}}
+        <div class='summary-card-content'>
+          {{yield to='content'}}
+        </div>
+      {{/if}}
     </article>
 
     <style scoped>
@@ -63,6 +69,11 @@ export default class SummaryCard extends GlimmerComponent<SummaryCardArgs> {
       }
       .summary-card-icon {
         flex-shrink: 0;
+      }
+      .summary-card-content {
+        display: var(--summary-card-content-display, flex);
+        flex-direction: var(--summary-card-content-direction, column);
+        gap: var(--summary-card-content-gap, var(--boxel-sp-xxs));
       }
     </style>
   </template>

--- a/packages/experiments-realm/crm/account.gts
+++ b/packages/experiments-realm/crm/account.gts
@@ -396,19 +396,17 @@ class IsolatedTemplate extends Component<typeof Account> {
             {{/if}}
           </:name>
           <:content>
-            <div class='description content-container'>
-              {{#if @model.primaryContact}}
-                <@fields.primaryContact
-                  @format='atom'
-                  @displayContainer={{false}}
-                  class='primary-contact'
-                />
-                <div class='tag-container'>
-                  <@fields.statusTag @format='atom' />
-                  <@fields.urgencyTag @format='atom' />
-                </div>
-              {{/if}}
-            </div>
+            {{#if @model.primaryContact}}
+              <@fields.primaryContact
+                @format='atom'
+                @displayContainer={{false}}
+                class='primary-contact'
+              />
+              <div class='tag-container'>
+                <@fields.statusTag @format='atom' />
+                <@fields.urgencyTag @format='atom' />
+              </div>
+            {{/if}}
           </:content>
         </AccountHeader>
       </:header>
@@ -423,16 +421,14 @@ class IsolatedTemplate extends Component<typeof Account> {
               <BuildingIcon class='header-icon' />
             </:icon>
             <:content>
-              <div class='description content-container'>
-                {{#if this.hasCompanyInfo}}
-                  <@fields.headquartersAddress @format='atom' />
-                  <@fields.website @format='atom' />
-                {{else}}
-                  <div class='default-value'>
-                    Missing Company Info
-                  </div>
-                {{/if}}
-              </div>
+              {{#if this.hasCompanyInfo}}
+                <@fields.headquartersAddress @format='atom' />
+                <@fields.website @format='atom' />
+              {{else}}
+                <div class='default-value'>
+                  Missing Company Info
+                </div>
+              {{/if}}
             </:content>
           </SummaryCard>
 
@@ -444,28 +440,23 @@ class IsolatedTemplate extends Component<typeof Account> {
               <ContactIcon class='header-icon' />
             </:icon>
             <:content>
-              <div class='description content-container'>
-                {{#if this.hasContacts}}
-                  <div class='primary-contact-group'>
-                    <@fields.primaryContact
-                      @format='atom'
-                      @displayContainer={{false}}
-                    />
-                    <Pill class='primary-tag' @pillBackgroundColor='#e8e8e8'>
-                      Primary
-                    </Pill>
-                  </div>
-
-                  <@fields.contacts
+              {{#if this.hasContacts}}
+                <div class='primary-contact-group'>
+                  <@fields.primaryContact
                     @format='atom'
                     @displayContainer={{false}}
                   />
-                {{else}}
-                  <div class='default-value'>
-                    Missing Contacts
-                  </div>
-                {{/if}}
-              </div>
+                  <Pill class='primary-tag' @pillBackgroundColor='#e8e8e8'>
+                    Primary
+                  </Pill>
+                </div>
+
+                <@fields.contacts @format='atom' @displayContainer={{false}} />
+              {{else}}
+                <div class='default-value'>
+                  Missing Contacts
+                </div>
+              {{/if}}
             </:content>
           </SummaryCard>
 
@@ -641,12 +632,6 @@ class IsolatedTemplate extends Component<typeof Account> {
         font: 500 var(--boxel-font-sm);
         letter-spacing: var(--boxel-lsp-xs);
       }
-      .content-container {
-        margin: 0;
-        display: flex;
-        flex-direction: column;
-        gap: var(--boxel-sp-xs);
-      }
       .tag-container {
         display: flex;
         flex-wrap: wrap;
@@ -778,12 +763,6 @@ class FittedTemplate extends Component<typeof Account> {
       .description {
         font: 500 var(--boxel-font-sm);
         letter-spacing: var(--boxel-lsp-xs);
-      }
-      .content-container {
-        margin: 0;
-        display: flex;
-        flex-direction: column;
-        gap: var(--boxel-sp-xs);
       }
       .tag-container {
         margin-top: auto;

--- a/packages/experiments-realm/crm/deal.gts
+++ b/packages/experiments-realm/crm/deal.gts
@@ -454,15 +454,14 @@ class IsolatedTemplate extends Component<typeof Deal> {
             </:icon>
             <:content>
               {{#if this.activeTasks.isLoading}}
-                  Loading...
-                {{else if this.activeTasks.instances}}
-                  {{this.activeTasks.instances.length}}
+                Loading...
+              {{else if this.activeTasks.instances}}
+                {{this.activeTasks.instances.length}}
               {{else}}
-                  <div class='default-value'>
-                    No Active Tasks
-                  </div>
-                {{/if}}
-              </div>
+                <div class='default-value'>
+                  No Active Tasks
+                </div>
+              {{/if}}
             </:content>
           </SummaryCard>
         </SummaryGridContainer>
@@ -603,7 +602,6 @@ class IsolatedTemplate extends Component<typeof Deal> {
         margin-left: auto;
       }
     </style>
-
   </template>
 }
 

--- a/packages/experiments-realm/crm/deal.gts
+++ b/packages/experiments-realm/crm/deal.gts
@@ -37,7 +37,6 @@ import FilePen from '@cardstack/boxel-icons/file-pen';
 import ArrowLeftRight from '@cardstack/boxel-icons/arrow-left-right';
 import Award from '@cardstack/boxel-icons/award';
 import AwardOff from '@cardstack/boxel-icons/award-off';
-import { Document } from './document';
 import { AmountWithCurrency as AmountWithCurrencyField } from '../fields/amount-with-currency';
 import BooleanField from 'https://cardstack.com/base/boolean';
 import { getCards } from '@cardstack/runtime-common';
@@ -394,16 +393,14 @@ class IsolatedTemplate extends Component<typeof Deal> {
               <World class='header-icon' />
             </:icon>
             <:content>
-              <div class='description'>
-                {{#if this.hasCompanyInfo}}
-                  <@fields.headquartersAddress @format='atom' />
-                  <@fields.website @format='atom' />
-                {{else}}
-                  <div class='default-value'>
-                    Missing Company Info
-                  </div>
-                {{/if}}
-              </div>
+              {{#if this.hasCompanyInfo}}
+                <@fields.headquartersAddress @format='atom' />
+                <@fields.website @format='atom' />
+              {{else}}
+                <div class='default-value'>
+                  Missing Company Info
+                </div>
+              {{/if}}
             </:content>
           </SummaryCard>
 
@@ -415,31 +412,28 @@ class IsolatedTemplate extends Component<typeof Deal> {
               <Users class='header-icon' />
             </:icon>
             <:content>
-              <div class='description'>
-                {{#if this.hasStakeholders}}
-                  {{#if @model.primaryStakeholder}}
-                    <ContactRow
-                      @userID={{@model.primaryStakeholder.id}}
-                      @name={{@model.primaryStakeholder.name}}
-                      @thumbnailURL={{@model.primaryStakeholder.thumbnailURL}}
-                      @tagLabel='primary'
-                    />
-                  {{/if}}
-                  {{#each @model.stakeholders as |stakeholder|}}
-                    <ContactRow
-                      @userID={{stakeholder.id}}
-                      @name={{stakeholder.name}}
-                      @thumbnailURL={{stakeholder.thumbnailURL}}
-                      @tagLabel={{stakeholder.position}}
-                    />
-                  {{/each}}
-                {{else}}
-                  <div class='default-value'>
-                    No Stakeholders
-                  </div>
+              {{#if this.hasStakeholders}}
+                {{#if @model.primaryStakeholder}}
+                  <ContactRow
+                    @userID={{@model.primaryStakeholder.id}}
+                    @name={{@model.primaryStakeholder.name}}
+                    @thumbnailURL={{@model.primaryStakeholder.thumbnailURL}}
+                    @tagLabel='primary'
+                  />
                 {{/if}}
-
-              </div>
+                {{#each @model.stakeholders as |stakeholder|}}
+                  <ContactRow
+                    @userID={{stakeholder.id}}
+                    @name={{stakeholder.name}}
+                    @thumbnailURL={{stakeholder.thumbnailURL}}
+                    @tagLabel={{stakeholder.position}}
+                  />
+                {{/each}}
+              {{else}}
+                <div class='default-value'>
+                  No Stakeholders
+                </div>
+              {{/if}}
             </:content>
           </SummaryCard>
 
@@ -449,7 +443,6 @@ class IsolatedTemplate extends Component<typeof Deal> {
             </:title>
             <:icon>
               <BoxelButton
-                class='sidebar-create-button content-header-row-1'
                 @kind='primary'
                 @size='extra-small'
                 @disabled={{this.activeTasks.isLoading}}
@@ -460,12 +453,11 @@ class IsolatedTemplate extends Component<typeof Deal> {
               </BoxelButton>
             </:icon>
             <:content>
-              <div>
-                {{#if this.activeTasks.isLoading}}
+              {{#if this.activeTasks.isLoading}}
                   Loading...
                 {{else if this.activeTasks.instances}}
                   {{this.activeTasks.instances.length}}
-                {{else}}
+              {{else}}
                   <div class='default-value'>
                     No Active Tasks
                   </div>
@@ -473,7 +465,6 @@ class IsolatedTemplate extends Component<typeof Deal> {
               </div>
             </:content>
           </SummaryCard>
-
         </SummaryGridContainer>
       </:summary>
     </DealPageLayout>
@@ -592,12 +583,6 @@ class IsolatedTemplate extends Component<typeof Deal> {
         gap: var(--boxel-sp-sm);
         font-weight: 600;
       }
-      .view-document-btn {
-        font-weight: 600;
-        padding: 2px 5px;
-        min-width: 0px;
-        min-height: 0px;
-      }
       @container (max-width: 447px) {
         .progress-container {
           flex-direction: column-reverse;
@@ -618,6 +603,7 @@ class IsolatedTemplate extends Component<typeof Deal> {
         margin-left: auto;
       }
     </style>
+
   </template>
 }
 
@@ -1128,7 +1114,6 @@ export class Deal extends CardDef {
   });
   @field healthScore = contains(PercentageField);
   @field notes = contains(MarkdownField);
-  @field document = linksTo(() => Document);
   @field primaryStakeholder = linksTo(() => Contact);
   @field stakeholders = linksToMany(() => Contact);
   @field valueBreakdown = containsMany(ValueLineItem);


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-7901/more-cssvar-customization-on-summary-card

Refer: https://linear.app/cardstack/issue/CS-7897/deal-active-task-ui

Before:
<img width="719" alt="Screenshot 2025-01-22 at 09 22 15" src="https://github.com/user-attachments/assets/69915757-4f39-4028-bc67-5801888f91bc" />

After:
<img width="734" alt="Screenshot 2025-01-22 at 09 39 00" src="https://github.com/user-attachments/assets/7eb18782-8b78-4918-8ae1-02ae85ec8ccd" />


