### PR TITLE
Fix issue where realm server tests were not exiting promptly

### DIFF
--- a/packages/postgres/pg-queue.ts
+++ b/packages/postgres/pg-queue.ts
@@ -93,7 +93,7 @@ class WorkLoop {
       return;
     }
     let timerPromise = new Promise((resolve) => {
-      this.timeout = setTimeout(resolve, this.pollInterval);
+      this.timeout = setTimeout(resolve, this.pollInterval).unref();
     });
     log.debug(`[workloop %s] entering promise race`, this.label);
     await Promise.race([this.waker.promise, timerPromise]);
@@ -354,7 +354,7 @@ export class PgQueueRunner implements QueueRunner {
               new Promise<'timeout'>((r) =>
                 setTimeout(() => {
                   r('timeout');
-                }, this.#maxTimeoutSec * 1000),
+                }, this.#maxTimeoutSec * 1000).unref(),
               ),
             ]);
             if (result === 'timeout') {

--- a/packages/realm-server/scripts/remove-test-dbs.sh
+++ b/packages/realm-server/scripts/remove-test-dbs.sh
@@ -5,6 +5,10 @@ isolated_realm_processes=$(ps -ef | grep ts-node | grep '\-\-port=4205' | awk '{
 for pid in $isolated_realm_processes; do
   kill -9 $pid
 done
+isolated_realm_processes=$(ps -ef | grep ts-node | grep '\-\-port=4212' | awk '{print $2}')
+for pid in $isolated_realm_processes; do
+  kill -9 $pid
+done
 
 databases=$(docker exec boxel-pg psql -U postgres -w -lqt | cut -d \| -f 1 | grep -E 'test_db_' | tr -d ' ')
 echo "cleaning up old test databases..."

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -13,29 +13,3 @@ import './realm-endpoints-test';
 import './server-endpoints-test';
 import './virtual-network-test';
 import './billing-test';
-
-// There is some timer that is preventing the node process from ending promptly.
-// This forces the test to end with the correct response code. Note that a
-// message "Error: Process exited before tests finished running" will be
-// displayed because of this approach.
-import QUnit from 'qunit';
-(QUnit as any).on(
-  'runEnd',
-  ({
-    testCounts,
-  }: {
-    testCounts: {
-      passed: number;
-      failed: number;
-      total: number;
-      skipped: number;
-      todo: number;
-    };
-  }) => {
-    if (testCounts.failed > 0) {
-      process.exit(1);
-    } else {
-      process.exit(0);
-    }
-  },
-);

--- a/packages/realm-server/worker-manager.ts
+++ b/packages/realm-server/worker-manager.ts
@@ -253,7 +253,7 @@ async function startWorker(priority: number, urlMappings: URL[][]) {
         }
       });
     }),
-    new Promise<true>((r) => setTimeout(() => r(true), 30_000)),
+    new Promise<true>((r) => setTimeout(() => r(true), 30_000).unref()),
   ]);
   if (timeout) {
     console.error(

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -728,14 +728,15 @@ export class Realm {
         if (!request.headers.get('X-Boxel-Building-Index')) {
           let timeout = await Promise.race<void | Error>([
             this.#startedUp.promise,
-            new Promise((resolve) =>
-              setTimeout(() => {
-                resolve(
-                  new Error(
-                    `Timeout waiting for realm ${this.url} to become ready`,
-                  ),
-                );
-              }, 60 * 1000),
+            new Promise(
+              (resolve) =>
+                setTimeout(() => {
+                  resolve(
+                    new Error(
+                      `Timeout waiting for realm ${this.url} to become ready`,
+                    ),
+                  );
+                }, 60 * 1000).unref?.(),
             ),
           ]);
           if (timeout) {


### PR DESCRIPTION
I was able to use `wtfnode` to identify the timers that were preventing the node tests from exiting promptly and used `.unref()` to inform node not to wait on the timer to finish before it can exit.