### PR TITLE
Handle empty linked fields in atom template

### DIFF
--- a/packages/base/default-templates/atom.gts
+++ b/packages/base/default-templates/atom.gts
@@ -1,5 +1,6 @@
 import GlimmerComponent from '@glimmer/component';
-import type { CardDef } from '../card-api';
+import { type CardDef, isCompoundField } from '../card-api';
+import { cn, not } from '@cardstack/boxel-ui/helpers';
 
 export default class DefaultAtomViewTemplate extends GlimmerComponent<{
   Args: {
@@ -8,26 +9,20 @@ export default class DefaultAtomViewTemplate extends GlimmerComponent<{
   };
 }> {
   get text() {
-    let title =
-      typeof this.args.model.title === 'string'
-        ? this.args.model.title.trim()
-        : null;
-
-    return title
-      ? title
-      : `Untitled ${this.args.model.constructor.displayName}`;
+    if (!this.args.model) {
+      return;
+    }
+    if (typeof this.args.model.title === 'string') {
+      return this.args.model.title.trim();
+    }
+    if (isCompoundField(this.args.model)) {
+      return;
+    }
+    return `Untitled ${this.args.model.constructor.displayName}`;
   }
   <template>
-    <span class='atom-default-template'>
+    <span class={{cn 'atom-default-template' empty-field=(not @model)}}>
       {{this.text}}
     </span>
-    <style scoped>
-      @layer {
-        .atom-default-template {
-          font: 600 var(--boxel-font-sm);
-          letter-spacing: var(--boxel-lsp-xs);
-        }
-      }
-    </style>
   </template>
 }

--- a/packages/experiments-realm/AtomExamples/d7aa387b-6514-47c0-ace2-7de011453e51.json
+++ b/packages/experiments-realm/AtomExamples/d7aa387b-6514-47c0-ace2-7de011453e51.json
@@ -193,7 +193,7 @@
       },
       "contacts.0": {
         "links": {
-          "self": "../Customer/0e5aec99-798b-4417-9426-a338432e0ee5"
+          "self": "../Customer/1274acf3-5b66-4373-89a2-fe8106c3d586"
         }
       },
       "contacts.1": {
@@ -203,7 +203,7 @@
       },
       "contacts.2": {
         "links": {
-          "self": "../Customer/67e87a6c-00d0-4c48-9318-f0c96daa4cae"
+          "self": "../Customer/0c71bda7-f4d8-451a-97cb-567a8fa31763"
         }
       }
     },

--- a/packages/experiments-realm/atom-examples.gts
+++ b/packages/experiments-realm/atom-examples.gts
@@ -74,32 +74,20 @@ class Isolated extends Component<typeof AtomExamples> {
           <h4>Using default atom template for Pet card:</h4>
           <div>
             Pet:
-            {{#if @model.pet}}
-              <@fields.pet @format='atom' />
-            {{else}}
-              (Bug: CS-7734)
-            {{/if}}
+            <@fields.pet @format='atom' />
           </div>
           <div>
             Pets:
-            {{#if @model.pets}}
-              <@fields.pets @format='atom' />
-            {{else}}
-              (Bug: CS-7734)
-            {{/if}}
+            <@fields.pets @format='atom' />
           </div>
           <h4>Default atom template without container:</h4>
           <div>
             Pet:
-            {{#if @model.pet}}
-              <@fields.pet @format='atom' @displayContainer={{false}} />
-            {{/if}}
+            <@fields.pet @format='atom' @displayContainer={{false}} />
           </div>
           <div>
             Pets:
-            {{#if @model.pets}}
-              <@fields.pets @format='atom' @displayContainer={{false}} />
-            {{/if}}
+            <@fields.pets @format='atom' @displayContainer={{false}} />
           </div>
         </section>
         <section>


### PR DESCRIPTION
Before: If a linked field model was null, the app crashed as seen below. This was due to an unhandled null case in a getter for the default atom template.
<img width="1504" alt="bef-atom-null" src="https://github.com/user-attachments/assets/ae6ad00b-3cac-4fed-a553-52cc143d2edc" />

After: Behavior is now consistent with how all other fields render when they are null.
<img width="788" alt="after-atom-null" src="https://github.com/user-attachments/assets/6e1b04c9-727f-466e-b4b8-71dab5da4977" />

