### PR TITLE
Isolated deal card style adjustments

### DIFF
--- a/packages/experiments-realm/Lead/9d7b2f20-c7da-4ddc-8e77-b75d88c97b48.json
+++ b/packages/experiments-realm/Lead/9d7b2f20-c7da-4ddc-8e77-b75d88c97b48.json
@@ -4,7 +4,7 @@
     "attributes": {
       "firstName": "Liam",
       "lastName": "O'Connor",
-      "position": "Data Analystic",
+      "position": "Data Analytics",
       "department": "app",
       "primaryEmail": "liam@gmail.com",
       "secondaryEmail": "liamOConnor@gmail.com",

--- a/packages/experiments-realm/components/entity-icon-display.gts
+++ b/packages/experiments-realm/components/entity-icon-display.gts
@@ -16,6 +16,7 @@ interface EntityDisplayWithIconArgs {
   Element: HTMLElement;
 }
 
+// TODO: refactor EntityDisplayWithIcon and EntityDisplayWithThumbnail
 export default class EntityDisplayWithIcon extends GlimmerComponent<EntityDisplayWithIconArgs> {
   get shouldAlignCenter() {
     return this.args.center;

--- a/packages/experiments-realm/components/entity-thumbnail-display.gts
+++ b/packages/experiments-realm/components/entity-thumbnail-display.gts
@@ -16,6 +16,7 @@ interface EntityDisplayWithThumbnailArgs {
   Element: HTMLElement;
 }
 
+// TODO: refactor EntityDisplayWithIcon and EntityDisplayWithThumbnail
 export default class EntityDisplayWithThumbnail extends GlimmerComponent<EntityDisplayWithThumbnailArgs> {
   get shouldAlignCenter() {
     return this.args.center;
@@ -90,7 +91,7 @@ export default class EntityDisplayWithThumbnail extends GlimmerComponent<EntityD
           var(--boxel-font-weight-normal)
         );
         --content-color: var(--entity-display-content-color, var(--boxel-400));
-        --content-gap: var(--entity-display-content-gap, var(--boxel-sp-xxxs));
+        --content-gap: var(--entity-display-content-gap, var(--boxel-sp-xxs));
         display: flex;
         align-items: flex-start;
         gap: var(--content-gap);

--- a/packages/experiments-realm/components/status-pill.gts
+++ b/packages/experiments-realm/components/status-pill.gts
@@ -1,7 +1,6 @@
 import GlimmerComponent from '@glimmer/component';
 import { Pill } from '@cardstack/boxel-ui/components';
-import { htmlSafe } from '@ember/template';
-import { concat } from '@ember/helper';
+import { cssVar } from '@cardstack/boxel-ui/helpers';
 import { CardorFieldTypeIcon } from 'https://cardstack.com/base/card-api';
 
 interface StatusPillSignature {
@@ -22,7 +21,7 @@ export class StatusPill extends GlimmerComponent<StatusPillSignature> {
       {{#if @icon}}
         <div
           class='status-icon'
-          style={{htmlSafe (concat 'background-color: ' @iconDarkColor ';')}}
+          style={{cssVar status-icon-background-color=@iconDarkColor}}
         >
           <@icon />
         </div>
@@ -30,7 +29,7 @@ export class StatusPill extends GlimmerComponent<StatusPillSignature> {
       <Pill
         class='status-pill'
         data-test-selected-type={{@label}}
-        style={{htmlSafe (concat 'background-color: ' @iconLightColor ';')}}
+        @pillBackgroundColor={{@iconLightColor}}
       >
         <:default>
           <span class='status-label-text'>
@@ -55,6 +54,7 @@ export class StatusPill extends GlimmerComponent<StatusPillSignature> {
         border-bottom-left-radius: 0;
       }
       .status-icon {
+        background-color: var(--status-icon-background-color);
         flex-shrink: 0;
         border-radius: 0;
         width: auto;

--- a/packages/experiments-realm/components/summary-card.gts
+++ b/packages/experiments-realm/components/summary-card.gts
@@ -11,12 +11,10 @@ interface SummaryCardArgs {
 
 export default class SummaryCard extends GlimmerComponent<SummaryCardArgs> {
   <template>
-    <article class='summary-card' ...attributes>
+    <div class='summary-card' ...attributes>
       <header class='summary-card-header'>
         {{#if (has-block 'title')}}
-          <div class='summary-card-title'>
-            {{yield to='title'}}
-          </div>
+          {{yield to='title'}}
         {{/if}}
 
         {{#if (has-block 'icon')}}
@@ -31,25 +29,27 @@ export default class SummaryCard extends GlimmerComponent<SummaryCardArgs> {
           {{yield to='content'}}
         </div>
       {{/if}}
-    </article>
+    </div>
 
     <style scoped>
       .summary-card {
         background: var(--summary-card-bg, var(--boxel-light));
-        border: 1px solid var(--summary-card-border, var(--boxel-border));
+        border: var(--summary-card-border, 1px solid rgba(0 0 0 / 10%));
         border-radius: var(
           --summary-card-border-radius,
           var(--boxel-border-radius-xl)
         );
-        box-shadow: var(--summary-card-box-shadow, var(--boxel-box-shadow));
+        box-shadow: var(
+          --summary-card-box-shadow,
+          0 2px 2px 0 rgba(0 0 0 / 16%)
+        );
         padding: var(--summary-card-padding, var(--boxel-sp-sm));
         display: flex;
         flex-direction: column;
         justify-content: space-between;
-        gap: var(--summary-card-gap, var(--boxel-sp-sm));
+        gap: var(--summary-card-gap, var(--boxel-sp-xs));
         overflow: hidden;
-        min-width: 0;
-        min-height: var(--summary-card-min-height, 120px);
+        min-height: var(--summary-card-min-height, 95px);
       }
       .summary-card-header {
         position: relative;
@@ -59,21 +59,13 @@ export default class SummaryCard extends GlimmerComponent<SummaryCardArgs> {
         justify-content: space-between;
         gap: var(--summary-card-header-gap, var(--boxel-sp-sm));
       }
-      .summary-card-title {
-        font-size: var(
-          --summary-card-title-font-size,
-          var(--boxel-font-size-sm)
-        );
-        font-weight: var(--summary-card-title-font-weight, 600);
-        margin: 0;
-      }
       .summary-card-icon {
         flex-shrink: 0;
       }
       .summary-card-content {
         display: var(--summary-card-content-display, flex);
         flex-direction: var(--summary-card-content-direction, column);
-        gap: var(--summary-card-content-gap, var(--boxel-sp-xxs));
+        gap: var(--summary-card-content-gap, var(--boxel-sp-xs));
       }
     </style>
   </template>

--- a/packages/experiments-realm/crm/deal-summary.gts
+++ b/packages/experiments-realm/crm/deal-summary.gts
@@ -133,8 +133,8 @@ export class DealSummary extends Component<Signature> {
         margin: 0;
       }
       .summary-title {
-        font: 600 var(--boxel-font-sm);
-        letter-spacing: var(--boxel-lsp-sm);
+        font: 600 var(--boxel-font);
+        letter-spacing: var(--boxel-lsp-xxs);
       }
       .header-icon {
         width: var(--boxel-icon-sm);
@@ -143,7 +143,7 @@ export class DealSummary extends Component<Signature> {
         margin-left: auto;
       }
       .value {
-        font: 600 var(--boxel-font-xl);
+        font: 600 var(--boxel-font-lg);
         letter-spacing: var(--boxel-lsp-xs);
       }
     </style>

--- a/packages/experiments-realm/crm/deal.gts
+++ b/packages/experiments-realm/crm/deal.gts
@@ -1,3 +1,4 @@
+// TODO: please organize imports
 import {
   CardDef,
   contains,
@@ -15,12 +16,11 @@ import GlimmerComponent from '@glimmer/component';
 import SummaryCard from '../components/summary-card';
 import SummaryGridContainer from '../components/summary-grid-container';
 import { Pill, BoxelButton } from '@cardstack/boxel-ui/components';
+import { cn, not } from '@cardstack/boxel-ui/helpers';
 import Info from '@cardstack/boxel-icons/info';
 import AccountHeader from '../components/account-header';
 import CrmProgressBar from '../components/crm-progress-bar';
 import EntityDisplayWithIcon from '../components/entity-icon-display';
-import { htmlSafe } from '@ember/template';
-import { concat } from '@ember/helper';
 import { LooseGooseyField } from '../loosey-goosey';
 import { Account } from './account';
 import { action } from '@ember/object';
@@ -217,16 +217,14 @@ class IsolatedTemplate extends Component<typeof Deal> {
   <template>
     <DealPageLayout>
       <:header>
-        <AccountHeader @logoURL={{this.logoURL}} @name={{@model.name}}>
-          <:name>
-            {{#if @model.name}}
-              <h1 class='account-name'>{{@model.name}}</h1>
-            {{else}}
-              <h1 class='account-name default-value'>Missing Deal Name</h1>
-            {{/if}}
-          </:name>
-          <:content>
-            <div class='description content-container'>
+        <div class='page-header'>
+          <AccountHeader @logoURL={{this.logoURL}} @name={{@model.name}}>
+            <:name>
+              <h1 class={{cn 'account-name' default-value=(not @model.name)}}>
+                {{#if @model.title}}<@fields.title />{{else}}Missing Deal Name{{/if}}
+              </h1>
+            </:name>
+            <:content>
               <div class='info-container'>
                 <@fields.company
                   @format='atom'
@@ -239,33 +237,29 @@ class IsolatedTemplate extends Component<typeof Deal> {
                   class='info-atom'
                 />
               </div>
-              <div class='tag-container'>
-                {{#if @model.status}}
-                  <Pill
-                    style={{htmlSafe
-                      (concat
-                        'background-color: '
-                        @model.status.colorScheme.backgroundColor
-                        '; border-color: transparent;'
-                      )
-                    }}
-                  >{{@model.status.label}}</Pill>
-                {{/if}}
-                {{#if @model.priority}}
-                  <Pill
-                    style={{htmlSafe
-                      (concat
-                        'background-color: '
-                        @model.priority.colorScheme.backgroundColor
-                        '; border-color: transparent;'
-                      )
-                    }}
-                  >{{@model.priority.label}}</Pill>
-                {{/if}}
-              </div>
-            </div>
-          </:content>
-        </AccountHeader>
+            </:content>
+          </AccountHeader>
+          <ul class='tags'>
+            {{#if @model.status}}
+              <Pill
+                class='tag'
+                @tag='li'
+                @pillBackgroundColor={{@model.status.colorScheme.backgroundColor}}
+              >
+                {{@model.status.label}}
+              </Pill>
+            {{/if}}
+            {{#if @model.priority}}
+              <Pill
+                class='tag'
+                @tag='li'
+                @pillBackgroundColor={{@model.priority.colorScheme.backgroundColor}}
+              >
+                {{@model.priority.label}}
+              </Pill>
+            {{/if}}
+          </ul>
+        </div>
       </:header>
 
       <:dashboard>
@@ -276,8 +270,9 @@ class IsolatedTemplate extends Component<typeof Deal> {
           <:icon>
             {{#if @model.healthScore}}
               <div class='progress-container'>
-                <label class='progress-label'>{{@model.healthScore}}% Health
-                  Score</label>
+                <span class='progress-label'>
+                  {{@model.healthScore}}% Health Score
+                </span>
                 <CrmProgressBar
                   @value={{@model.healthScore}}
                   @max={{100}}
@@ -287,9 +282,9 @@ class IsolatedTemplate extends Component<typeof Deal> {
             {{/if}}
           </:icon>
           <:content>
-            <article class='dashboard-cards'>
+            <div class='dashboard-cards'>
               <div class='block'>
-                <label>Current Value:</label>
+                Current Value
                 <@fields.computedValue class='highlight-value' @format='atom' />
                 {{#if this.query.isLoading}}
                   Loading...
@@ -310,10 +305,9 @@ class IsolatedTemplate extends Component<typeof Deal> {
                     </p>
                   {{/let}}
                 {{/if}}
-
               </div>
               <div class='block'>
-                <label>Predicted Revenue:</label>
+                Predicted Revenue
                 {{! TODO: compound fields have divs that wrap them. Seems a bit inconsistent.}}
                 <div class='highlight-value'>
                   {{#if @model.predictedRevenue.amount}}
@@ -327,10 +321,12 @@ class IsolatedTemplate extends Component<typeof Deal> {
                     </div>
                   {{/if}}
                 </div>
-                <p class='description secondary-value'>Based on similar events</p>
+                <span class='description'>
+                  Based on similar events
+                </span>
               </div>
               <div class='block'>
-                <label>Profit Margin:</label>
+                Profit Margin
                 {{! TODO: compound fields have divs that wrap them. Seems a bit inconsistent.}}
                 <div class='highlight-value'>
                   {{#if @model.profitMargin}}
@@ -341,21 +337,23 @@ class IsolatedTemplate extends Component<typeof Deal> {
                     </div>
                   {{/if}}
                 </div>
-                <p class='description secondary-value'>Estimated</p>
+                <span class='description'>
+                  Estimated
+                </span>
               </div>
-            </article>
+            </div>
 
             <hr />
 
             {{#if this.hasValueBreakdown}}
-              <article class='value-breakdown'>
+              <div class='value-breakdown'>
                 <header>
-                  <label>Value Breakdown</label>
+                  <h4 class='breakdown-title'>Value Breakdown</h4>
                 </header>
                 <div class='breakdown-table'>
                   <@fields.valueBreakdown />
                 </div>
-              </article>
+              </div>
 
               <hr />
             {{/if}}
@@ -368,7 +366,7 @@ class IsolatedTemplate extends Component<typeof Deal> {
                   </:icon>
                 </EntityDisplayWithIcon>
               </div>
-              <div class='description content-container'>
+              <div class='content-container'>
                 {{#if @model.notes}}
                   <@fields.notes />
                 {{else}}
@@ -378,16 +376,15 @@ class IsolatedTemplate extends Component<typeof Deal> {
                 {{/if}}
               </div>
             </footer>
-
           </:content>
         </SummaryCard>
       </:dashboard>
 
       <:summary>
         <SummaryGridContainer>
-          <SummaryCard>
+          <SummaryCard class='info-card'>
             <:title>
-              <label>Company Info</label>
+              <h3 class='info-card-title'>Company Info</h3>
             </:title>
             <:icon>
               <World class='header-icon' />
@@ -404,9 +401,9 @@ class IsolatedTemplate extends Component<typeof Deal> {
             </:content>
           </SummaryCard>
 
-          <SummaryCard>
+          <SummaryCard class='info-card'>
             <:title>
-              <label>Stakeholders</label>
+              <h3 class='info-card-title'>Stakeholders</h3>
             </:title>
             <:icon>
               <Users class='header-icon' />
@@ -437,12 +434,13 @@ class IsolatedTemplate extends Component<typeof Deal> {
             </:content>
           </SummaryCard>
 
-          <SummaryCard>
+          <SummaryCard class='info-card'>
             <:title>
-              <label>Active Tasks</label>
+              <h3 class='info-card-title'>Active Tasks</h3>
             </:title>
             <:icon>
               <BoxelButton
+                class='new-item-button'
                 @kind='primary'
                 @size='extra-small'
                 @disabled={{this.activeTasks.isLoading}}
@@ -477,21 +475,18 @@ class IsolatedTemplate extends Component<typeof Deal> {
         margin: 0;
       }
       hr {
-        border: 1px solid var(--boxel-200);
-        margin: 1.3rem 0;
+        border: 0.5px solid var(--boxel-200);
+        margin: var(--boxel-sp) 0;
       }
-      label {
-        font-weight: 500;
-      }
-      .mt-5 {
-        margin-top: 1rem;
+      .page-header {
+        display: flex;
+        justify-content: space-between;
+        flex-wrap: wrap;
+        gap: var(--boxel-sp-lg);
       }
       .highlight-value {
         font: 600 var(--boxel-font-xl);
-      }
-      .secondary-value {
-        font: 300 var(--boxel-font-sm);
-        color: var(--boxel-400);
+        white-space: nowrap;
       }
       .success-value {
         font: 300 var(--boxel-font-sm);
@@ -507,9 +502,10 @@ class IsolatedTemplate extends Component<typeof Deal> {
       .block {
         display: flex;
         flex-direction: column;
-        gap: var(--boxel-sp-xxxs);
+        gap: var(--boxel-sp-4xs);
       }
       .dashboard {
+        --summary-card-padding: var(--boxel-sp);
         container-type: inline-size;
       }
       .dashboard-cards {
@@ -520,6 +516,7 @@ class IsolatedTemplate extends Component<typeof Deal> {
       }
       .account-name {
         font: 600 var(--boxel-font-lg);
+        letter-spacing: var(--boxel-lsp-xxs);
       }
       .user-icon {
         margin-left: auto;
@@ -530,15 +527,30 @@ class IsolatedTemplate extends Component<typeof Deal> {
         flex-shrink: 0;
         margin-left: auto;
       }
-      .tag-container,
+      .tags,
       .info-container {
+        margin: 0;
+        padding: 0;
+        list-style-type: none;
         display: flex;
         flex-wrap: wrap;
         align-items: start;
-        gap: var(--boxel-sp-xxs);
+        gap: var(--boxel-sp-xs);
       }
-      .summary-title {
-        font: 600 var(--boxel-font-sm);
+      .tag {
+        --pill-border: none;
+        --pill-font: 600 var(--boxel-font-xs);
+        --pill-padding: var(--boxel-sp-xxxs) var(--boxel-sp-xs);
+      }
+      .info-container {
+        gap: var(--boxel-sp-xs) var(--boxel-sp-lg);
+      }
+      .info-field {
+        --entity-display-title-font-weight: 400;
+      }
+      .summary-title,
+      .info-card-title {
+        font: 600 var(--boxel-font);
         letter-spacing: var(--boxel-lsp-xxs);
         align-self: flex-start;
       }
@@ -546,8 +558,9 @@ class IsolatedTemplate extends Component<typeof Deal> {
         font: 600 var(--boxel-font-lg);
       }
       .description {
-        font: 500 var(--boxel-font-sm);
-        letter-spacing: var(--boxel-lsp-xs);
+        color: var(--boxel-450);
+        font: var(--boxel-font-sm);
+        letter-spacing: var(--boxel-lsp-sm);
       }
       .content-container {
         margin: 0;
@@ -558,10 +571,15 @@ class IsolatedTemplate extends Component<typeof Deal> {
       .progress-container {
         display: flex;
         align-items: start;
-        gap: var(--boxel-sp-xxs);
+        gap: var(--boxel-sp-xs);
       }
       .progress-label {
-        color: var(--boxel-500);
+        font: var(--boxel-font-xs);
+        letter-spacing: var(--boxel-lsp-xs);
+      }
+      .breakdown-title {
+        font: 600 var(--boxel-font-sm);
+        letter-spacing: var(--boxel-lsp-sm);
       }
       .breakdown-table {
         width: 90%;
@@ -600,6 +618,14 @@ class IsolatedTemplate extends Component<typeof Deal> {
         height: var(--boxel-icon-sm);
         flex-shrink: 0;
         margin-left: auto;
+      }
+      .info-card {
+        --summary-card-gap: var(--boxel-sp-xl);
+        --summary-card-padding: var(--boxel-sp);
+        --entity-display-title-font-weight: 400;
+      }
+      .new-item-button {
+        font-weight: 600;
       }
     </style>
   </template>
@@ -689,12 +715,12 @@ class FittedTemplate extends Component<typeof Deal> {
       <div class='deal-content'>
         <div class='deal-details'>
           <div class='deal-field'>
-            <label>Current Value</label>
+            <span class='label'>Current Value</span>
             <@fields.computedValue class='highlight-value' @format='atom' />
           </div>
 
           <div class='deal-field'>
-            <label>Close Date</label>
+            <span class='label'>Close Date</span>
             <div class='highlight-value'>
               <@fields.closeDate @format='atom' />
             </div>
@@ -702,7 +728,7 @@ class FittedTemplate extends Component<typeof Deal> {
 
           {{#if @model.healthScore}}
             <div class='deal-field'>
-              <label>Health Score</label>
+              <span class='label'>Health Score</span>
               <div class='progress-container'>
                 <CrmProgressBar
                   @value={{@model.healthScore}}
@@ -721,7 +747,6 @@ class FittedTemplate extends Component<typeof Deal> {
           {{! just serve the placeholder for grid system ,pending event card - https://linear.app/cardstack/issue/CS-7691/add-event-card }}
         </div>
       </div>
-
     </article>
 
     <style scoped>
@@ -729,10 +754,10 @@ class FittedTemplate extends Component<typeof Deal> {
       p {
         margin: 0;
       }
-      label {
-        color: var(--boxel-500);
-        font-size: var(--boxel-font-size-xs);
-        font-weight: 600;
+      .label {
+        color: var(--boxel-450);
+        font: 500 var(--boxel-font-xs);
+        letter-spacing: var(--boxel-lsp-sm);
       }
       .default-value {
         color: var(--boxel-400);
@@ -1082,6 +1107,7 @@ export class ValueLineItem extends FieldDef {
 
 export class Deal extends CardDef {
   static displayName = 'CRM Deal';
+  static headerColor = '#f8f7fa';
   @field name = contains(StringField);
   @field account = linksTo(() => Account);
   @field status = contains(DealStatus);
@@ -1181,8 +1207,9 @@ class DealPageLayout extends GlimmerComponent<DealPageLayoutArgs> {
         flex-direction: column;
         gap: var(--boxel-sp-lg);
         width: 100%;
-        padding: var(--boxel-sp-lg);
+        padding: var(--boxel-sp-xl);
         box-sizing: border-box;
+        background-color: var(--boxel-100);
       }
     </style>
   </template>


### PR DESCRIPTION
Changes:
- Updated deal card background color and other styles & spacing to match latest designs on zeplin
- Fixed broken border style
- Fix html elements that were used incorrectly (liberal use of `label` element, `article` wasn't always appropriate)
- Alignment for tags on the side of the header if there's space

<img width="661" alt="deal-isolated" src="https://github.com/user-attachments/assets/01c51531-1c28-46e4-984f-266e404b44c4" />