### PR TITLE
Cleanup LLM prompt content, which also fixes sonnet model related issues

### DIFF
--- a/packages/ai-bot/constants.ts
+++ b/packages/ai-bot/constants.ts
@@ -1,0 +1,1 @@
+export const thinkingMessage = 'Thinking...';

--- a/packages/ai-bot/helpers.ts
+++ b/packages/ai-bot/helpers.ts
@@ -29,6 +29,7 @@ import {
   DEFAULT_LLM,
   APP_BOXEL_ACTIVE_LLM,
 } from '@cardstack/runtime-common/matrix-constants';
+import { thinkingMessage } from './constants';
 
 let log = logger('ai-bot');
 
@@ -618,4 +619,23 @@ export function eventRequiresResponse(event: MatrixEvent) {
 
   // If it's a different type, or a command result without output, we should not respond
   return false;
+}
+
+// Helps reduce the prompt size (prompt token cost) by removing the thinking message indicators
+export function cleanupPromptParts(promptParts: PromptParts): PromptParts {
+  return {
+    ...promptParts,
+    history: promptParts.history.filter(
+      (item) =>
+        !(
+          item.sender === '@aibot:localhost' &&
+          'body' in item.content &&
+          item.content.body === thinkingMessage
+        ),
+    ),
+    messages: promptParts.messages.filter(
+      (message) =>
+        !(message.role === 'assistant' && message.content === thinkingMessage),
+    ),
+  };
 }

--- a/packages/ai-bot/helpers.ts
+++ b/packages/ai-bot/helpers.ts
@@ -29,7 +29,6 @@ import {
   DEFAULT_LLM,
   APP_BOXEL_ACTIVE_LLM,
 } from '@cardstack/runtime-common/matrix-constants';
-import { thinkingMessage } from './constants';
 
 let log = logger('ai-bot');
 

--- a/packages/ai-bot/helpers.ts
+++ b/packages/ai-bot/helpers.ts
@@ -452,6 +452,12 @@ export function getModifyPrompt(
     if (isCommandResultEvent(event)) {
       continue;
     }
+    if (
+      'isStreamingFinished' in event.content &&
+      event.content.isStreamingFinished === false
+    ) {
+      continue;
+    }
     let body = event.content.body;
     if (body) {
       if (event.sender === aiBotUserId) {
@@ -619,23 +625,4 @@ export function eventRequiresResponse(event: MatrixEvent) {
 
   // If it's a different type, or a command result without output, we should not respond
   return false;
-}
-
-// Helps reduce the prompt size (prompt token cost) by removing the thinking message indicators
-export function cleanupPromptParts(promptParts: PromptParts): PromptParts {
-  return {
-    ...promptParts,
-    history: promptParts.history.filter(
-      (item) =>
-        !(
-          item.sender === '@aibot:localhost' &&
-          'body' in item.content &&
-          item.content.body === thinkingMessage
-        ),
-    ),
-    messages: promptParts.messages.filter(
-      (message) =>
-        !(message.role === 'assistant' && message.content === thinkingMessage),
-    ),
-  };
 }

--- a/packages/ai-bot/lib/ai-billing.ts
+++ b/packages/ai-bot/lib/ai-billing.ts
@@ -89,7 +89,7 @@ async function fetchGenerationCost(generationId: string) {
     })
   ).json();
 
-  if (response.error && response.error.includes('not found')) {
+  if (response.error && response.error.message.includes('not found')) {
     return null;
   }
 

--- a/packages/ai-bot/lib/send-response.ts
+++ b/packages/ai-bot/lib/send-response.ts
@@ -58,6 +58,7 @@ export class Responder {
       this.roomId,
       thinkingMessage,
       undefined,
+      { isStreamingFinished: false },
     );
     this.initialMessageId = initialMessage.event_id;
   }

--- a/packages/ai-bot/lib/send-response.ts
+++ b/packages/ai-bot/lib/send-response.ts
@@ -8,6 +8,7 @@ import debounce from 'lodash/debounce';
 import { ISendEventResponse } from 'matrix-js-sdk/lib/matrix';
 import { ChatCompletionMessageToolCall } from 'openai/resources/chat/completions';
 import { FunctionToolCall } from '@cardstack/runtime-common/helpers/ai';
+import { thinkingMessage } from '../constants';
 
 let log = logger('ai-bot');
 
@@ -55,7 +56,7 @@ export class Responder {
     let initialMessage = await sendMessage(
       this.client,
       this.roomId,
-      'Thinking...',
+      thinkingMessage,
       undefined,
     );
     this.initialMessageId = initialMessage.event_id;

--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -15,6 +15,7 @@ import {
   getPromptParts,
   extractCardFragmentsFromEvents,
   eventRequiresResponse,
+  cleanupPromptParts,
 } from './helpers';
 import {
   APP_BOXEL_ACTIVE_LLM,
@@ -203,7 +204,9 @@ Common issues are:
         let eventList = (initial!.messages?.chunk ||
           []) as DiscreteMatrixEvent[];
         try {
-          promptParts = getPromptParts(eventList, aiBotUserId);
+          promptParts = cleanupPromptParts(
+            getPromptParts(eventList, aiBotUserId),
+          );
         } catch (e) {
           log.error(e);
           responder.finalize(

--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -15,7 +15,6 @@ import {
   getPromptParts,
   extractCardFragmentsFromEvents,
   eventRequiresResponse,
-  cleanupPromptParts,
 } from './helpers';
 import {
   APP_BOXEL_ACTIVE_LLM,
@@ -204,9 +203,7 @@ Common issues are:
         let eventList = (initial!.messages?.chunk ||
           []) as DiscreteMatrixEvent[];
         try {
-          promptParts = cleanupPromptParts(
-            getPromptParts(eventList, aiBotUserId),
-          );
+          promptParts = getPromptParts(eventList, aiBotUserId);
         } catch (e) {
           log.error(e);
           responder.finalize(

--- a/packages/ai-bot/tests/responding-test.ts
+++ b/packages/ai-bot/tests/responding-test.ts
@@ -139,7 +139,7 @@ module('Responding', (hooks) => {
     );
     assert.equal(
       sentEvents[0].content.body,
-      thinking,
+      thinkingMessage,
       'Just the thinking message sent',
     );
 
@@ -220,7 +220,7 @@ module('Responding', (hooks) => {
     );
     assert.equal(
       sentEvents[0].content.body,
-      thinking,
+      thinkingMessage,
       'Thinking message should be sent first',
     );
     assert.deepEqual(
@@ -299,7 +299,7 @@ module('Responding', (hooks) => {
     );
     assert.equal(
       sentEvents[0].content.body,
-      thinking,
+      thinkingMessage,
       'Thinking message should be sent first',
     );
     assert.deepEqual(

--- a/packages/ai-bot/tests/responding-test.ts
+++ b/packages/ai-bot/tests/responding-test.ts
@@ -3,6 +3,7 @@ import { Responder } from '../lib/send-response';
 import { IContent } from 'matrix-js-sdk';
 import { MatrixClient } from '../lib/matrix';
 import FakeTimers from '@sinonjs/fake-timers';
+import { thinkingMessage } from '../constants';
 
 class FakeMatrixClient implements MatrixClient {
   private eventId = 0;
@@ -82,7 +83,7 @@ module('Responding', (hooks) => {
     );
     assert.equal(
       sentEvents[0].content.body,
-      'Thinking...',
+      thinkingMessage,
       'Message body should match',
     );
   });
@@ -103,7 +104,7 @@ module('Responding', (hooks) => {
     );
     assert.equal(
       sentEvents[0].content.body,
-      'Thinking...',
+      thinkingMessage,
       'Just the thinking message sent',
     );
 
@@ -138,7 +139,7 @@ module('Responding', (hooks) => {
     );
     assert.equal(
       sentEvents[0].content.body,
-      'Thinking...',
+      thinking,
       'Just the thinking message sent',
     );
 
@@ -219,7 +220,7 @@ module('Responding', (hooks) => {
     );
     assert.equal(
       sentEvents[0].content.body,
-      'Thinking...',
+      thinking,
       'Thinking message should be sent first',
     );
     assert.deepEqual(
@@ -298,7 +299,7 @@ module('Responding', (hooks) => {
     );
     assert.equal(
       sentEvents[0].content.body,
-      'Thinking...',
+      thinking,
       'Thinking message should be sent first',
     );
     assert.deepEqual(


### PR DESCRIPTION
This PR cleans up the "Thinking..." messages that are sent to the LLM in every prompt. I think these are unnecessary to include, and they cost more tokens. 

Luckily, this optimization also fixes AI bot crashes when using sonnet 😳

<img width="758" alt="image" src="https://github.com/user-attachments/assets/56f0a0a9-c815-4fe1-8c89-e2d111fc0b03" />

The real reason behind these crashes is unknown - all we can get from OpenRouter is "internal server error". 
