### PR TITLE
Allow getCards to be reactive wrt to changes in query arg

### DIFF
--- a/packages/experiments-realm/components/base-task-planner.gts
+++ b/packages/experiments-realm/components/base-task-planner.gts
@@ -206,16 +206,22 @@ export class BaseTaskPlannerIsolated<
     };
 
     // Initialize cards and assignee query
-    this.cards = getCards(this.getTaskQuery, this.realmHrefs, {
-      isLive: true,
-    });
-    this.assigneeQuery = getCards(
+    this.cards = getCards(
+      () => this.getTaskQuery,
+      () => this.realmHrefs,
       {
-        filter: {
-          type: this.config.filters.assignee.codeRef,
-        },
+        isLive: true,
       },
-      this.realmHrefs,
+    );
+    this.assigneeQuery = getCards(
+      () => {
+        return {
+          filter: {
+            type: this.config.filters.assignee.codeRef,
+          },
+        };
+      },
+      () => this.realmHrefs,
       { isLive: true },
     );
   }

--- a/packages/experiments-realm/crm-app.gts
+++ b/packages/experiments-realm/crm-app.gts
@@ -184,9 +184,13 @@ class CrmAppTemplate extends Component<typeof AppCard> {
       return;
     }
 
-    const result = getCards(this.query, this.realmHrefs, {
-      isLive: true,
-    });
+    const result = getCards(
+      () => this.query,
+      () => this.realmHrefs,
+      {
+        isLive: true,
+      },
+    );
 
     await result.loaded;
     this.deals = result.instances as Deal[];

--- a/packages/experiments-realm/crm-app.gts
+++ b/packages/experiments-realm/crm-app.gts
@@ -140,7 +140,6 @@ class CrmAppTemplate extends Component<typeof AppCard> {
   @tracked private activeFilter: LayoutFilter = CONTACT_FILTERS[0];
   @action private onFilterChange(filter: LayoutFilter) {
     this.activeFilter = filter;
-    this.loadDealCards.perform();
   }
   //tabs
   @tracked activeTabId: string | undefined = this.args.model.tabs?.[0]?.tabId;
@@ -170,7 +169,6 @@ class CrmAppTemplate extends Component<typeof AppCard> {
   }
 
   @tracked private searchKey = '';
-  @tracked private deals: Deal[] = [];
 
   constructor(owner: Owner, args: any) {
     super(owner, args);
@@ -216,23 +214,17 @@ class CrmAppTemplate extends Component<typeof AppCard> {
     }
   });
 
-  private loadDealCards = restartableTask(async () => {
-    if (!this.query || this.activeTabId !== 'Deal') {
-      return;
-    }
+  get deals() {
+    return this.dealSearch.instances as Deal[];
+  }
 
-    const result = getCards(
-      () => this.query,
-      () => this.realmHrefs,
-      {
-        isLive: true,
-      },
-    );
-
-    await result.loaded;
-    this.deals = result.instances as Deal[];
-    return result;
-  });
+  dealSearch = getCards(
+    () => this.query,
+    () => this.realmHrefs,
+    {
+      isLive: true,
+    },
+  );
 
   get filters() {
     return this.filterMap.get(this.activeTabId!)!;
@@ -248,7 +240,6 @@ class CrmAppTemplate extends Component<typeof AppCard> {
     this.activeTabId = id;
     this.searchKey = '';
     this.setActiveFilter();
-    this.loadDealCards.perform();
   }
 
   get headerColor() {

--- a/packages/experiments-realm/crm/account.gts
+++ b/packages/experiments-realm/crm/account.gts
@@ -186,13 +186,21 @@ class IsolatedTemplate extends Component<typeof Account> {
     };
   }
 
-  deals = getCards(this.dealQuery, this.realmHrefs, {
-    isLive: true,
-  });
+  deals = getCards(
+    () => this.dealQuery,
+    () => this.realmHrefs,
+    {
+      isLive: true,
+    },
+  );
 
-  activeTasks = getCards(this.activeTasksQuery, this.realmHrefs, {
-    isLive: true,
-  });
+  activeTasks = getCards(
+    () => this.activeTasksQuery,
+    () => this.realmHrefs,
+    {
+      isLive: true,
+    },
+  );
 
   private _createNewTask = restartableTask(async () => {
     let doc: LooseSingleCardDocument = {
@@ -313,9 +321,13 @@ class IsolatedTemplate extends Component<typeof Account> {
     };
   }
 
-  lifetimeValueDeals = getCards(this.lifetimeValueQuery, this.realmHrefs, {
-    isLive: true,
-  });
+  lifetimeValueDeals = getCards(
+    () => this.lifetimeValueQuery,
+    () => this.realmHrefs,
+    {
+      isLive: true,
+    },
+  );
 
   get lifetimeMetrics() {
     if (!this.lifetimeValueDeals) {
@@ -764,13 +776,21 @@ class EmbeddedTemplate extends Component<typeof Account> {
     };
   }
 
-  deals = getCards(this.dealQuery, this.realmHrefs, {
-    isLive: true,
-  });
+  deals = getCards(
+    () => this.dealQuery,
+    () => this.realmHrefs,
+    {
+      isLive: true,
+    },
+  );
 
-  activeTasks = getCards(this.activeTasksQuery, this.realmHrefs, {
-    isLive: true,
-  });
+  activeTasks = getCards(
+    () => this.activeTasksQuery,
+    () => this.realmHrefs,
+    {
+      isLive: true,
+    },
+  );
 
   get activeTasksCount() {
     const tasks = this.activeTasks;
@@ -840,9 +860,13 @@ class EmbeddedTemplate extends Component<typeof Account> {
     };
   }
 
-  lifetimeValueDeals = getCards(this.lifetimeValueQuery, this.realmHrefs, {
-    isLive: true,
-  });
+  lifetimeValueDeals = getCards(
+    () => this.lifetimeValueQuery,
+    () => this.realmHrefs,
+    {
+      isLive: true,
+    },
+  );
 
   get lifetimeMetrics() {
     if (!this.lifetimeValueDeals) {

--- a/packages/experiments-realm/crm/deal.gts
+++ b/packages/experiments-realm/crm/deal.gts
@@ -130,13 +130,21 @@ class IsolatedTemplate extends Component<typeof Deal> {
     };
   }
 
-  query = getCards(this.dealQuery, this.realmHrefs, {
-    isLive: true,
-  });
+  query = getCards(
+    () => this.dealQuery,
+    () => this.realmHrefs,
+    {
+      isLive: true,
+    },
+  );
 
-  activeTasks = getCards(this.activeTasksQuery, this.realmHrefs, {
-    isLive: true,
-  });
+  activeTasks = getCards(
+    () => this.activeTasksQuery,
+    () => this.realmHrefs,
+    {
+      isLive: true,
+    },
+  );
 
   get activeTasksCount() {
     const tasks = this.activeTasks;

--- a/packages/experiments-realm/crm/task-planner.gts
+++ b/packages/experiments-realm/crm/task-planner.gts
@@ -163,12 +163,14 @@ export class CRMTaskPlannerIsolated extends BaseTaskPlannerIsolated<
   }
 
   assigneeQuery = getCards(
-    {
-      filter: {
-        type: this.config.filters.assignee.codeRef,
-      },
+    () => {
+      return {
+        filter: {
+          type: this.config.filters.assignee.codeRef,
+        },
+      };
     },
-    this.realmHrefs,
+    () => this.realmHrefs,
     { isLive: true },
   );
 

--- a/packages/experiments-realm/garden-design.gts
+++ b/packages/experiments-realm/garden-design.gts
@@ -215,23 +215,28 @@ class Isolated extends Component<typeof GardenDesign> {
     this.updateGridModel();
     // TODO refactor to use <PrerenderedCardSearch> component from the @context if you want live search
     this.liveQuery = getCards(
-      {
-        filter: {
-          eq: {
-            _cardType: 'Garden Item',
-          },
-        },
-        sort: [
-          {
-            on: {
-              module: `${baseRealm.url}card-api`,
-              name: 'CardDef',
+      () => {
+        return {
+          filter: {
+            eq: {
+              _cardType: 'Garden Item',
             },
-            by: 'title',
           },
-        ],
+          sort: [
+            {
+              on: {
+                module: `${baseRealm.url}card-api`,
+                name: 'CardDef',
+              },
+              by: 'title',
+            },
+          ],
+        };
       },
-      this.args.model[realmURL] ? [this.args.model[realmURL].href] : undefined,
+      () =>
+        this.args.model[realmURL]
+          ? [this.args.model[realmURL].href]
+          : undefined,
     );
   }
 

--- a/packages/experiments-realm/monetary-amount.gts
+++ b/packages/experiments-realm/monetary-amount.gts
@@ -38,24 +38,26 @@ class Edit extends Component<typeof MonetaryAmount> {
 
   // TODO refactor to use <PrerenderedCardSearch> component from the @context if you want live search
   liveCurrencyQuery = getCards(
-    {
-      filter: {
-        type: {
-          module: new URL('./asset', import.meta.url).href,
-          name: 'Currency',
-        },
-      },
-      sort: [
-        {
-          on: {
+    () => {
+      return {
+        filter: {
+          type: {
             module: new URL('./asset', import.meta.url).href,
             name: 'Currency',
           },
-          by: 'name',
         },
-      ],
+        sort: [
+          {
+            on: {
+              module: new URL('./asset', import.meta.url).href,
+              name: 'Currency',
+            },
+            by: 'name',
+          },
+        ],
+      };
     },
-    [new URL('./', import.meta.url).href],
+    () => [new URL('./', import.meta.url).href],
   );
 
   @action

--- a/packages/experiments-realm/sprint-planner.gts
+++ b/packages/experiments-realm/sprint-planner.gts
@@ -75,12 +75,14 @@ class SprintPlannerIsolated extends Component<typeof SprintPlanner> {
   }
 
   assigneeQuery = getCards(
-    {
-      filter: {
-        type: this.config.filters.assignee.codeRef,
-      },
+    () => {
+      return {
+        filter: {
+          type: this.config.filters.assignee.codeRef,
+        },
+      };
     },
-    this.realmHrefs,
+    () => this.realmHrefs,
     { isLive: true },
   );
 

--- a/packages/host/app/components/card-catalog/modal.gts
+++ b/packages/host/app/components/card-catalog/modal.gts
@@ -43,7 +43,7 @@ import {
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 
-import { getSearchResults, Search } from '../../resources/search';
+import { getSearch, type SearchQuery } from '../../resources/search';
 
 import {
   suggestCardChooserTitle,
@@ -71,7 +71,7 @@ interface Signature {
 }
 
 type Request = {
-  search: Search;
+  search: SearchQuery;
   deferred: Deferred<CardDef | undefined>;
   opts?: {
     offerToCreate?: {
@@ -358,7 +358,7 @@ export default class CardCatalogModal extends Component<Signature> {
         opts?.multiSelect,
       );
       let request = new TrackedObject<Request>({
-        search: getSearchResults(this, query),
+        search: getSearch(this, () => query),
         deferred: new Deferred(),
         opts,
       });

--- a/packages/host/app/components/operator-mode/code-submode/boxel-spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/boxel-spec-preview.gts
@@ -304,9 +304,13 @@ export default class BoxelSpecPreview extends GlimmerComponent<Signature> {
     };
   }
 
-  boxelSpecSearch = getCards(this.boxelSpecQuery, this.realms, {
-    isLive: true,
-  });
+  boxelSpecSearch = getCards(
+    () => this.boxelSpecQuery,
+    () => this.realms,
+    {
+      isLive: true,
+    },
+  );
 
   get boxelSpecInstances() {
     return this.boxelSpecSearch.instances as CatalogEntry[];

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -68,8 +68,8 @@ export default class OperatorModeContainer extends Component<Signature> {
   // public API
   @action
   getCards(
-    getQuery: () => Query,
-    getRealms: () => string[],
+    getQuery: () => Query | undefined,
+    getRealms: () => string[] | undefined,
     opts: {
       isLive?: true;
       doWhileRefreshing?: (ready: Promise<void> | undefined) => Promise<void>;

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -14,7 +14,7 @@ import { Modal, LoadingIndicator } from '@cardstack/boxel-ui/components';
 
 import { or, not, and } from '@cardstack/boxel-ui/helpers';
 
-import type { Loader, Query } from '@cardstack/runtime-common';
+import { type Loader, type Query } from '@cardstack/runtime-common';
 
 import Auth from '@cardstack/host/components/matrix/auth';
 import PaymentSetup from '@cardstack/host/components/matrix/payment-setup';
@@ -22,10 +22,7 @@ import CodeSubmode from '@cardstack/host/components/operator-mode/code-submode';
 import InteractSubmode from '@cardstack/host/components/operator-mode/interact-submode';
 import { getCard } from '@cardstack/host/resources/card-resource';
 
-import {
-  getSearchResults,
-  type Search,
-} from '@cardstack/host/resources/search';
+import { getSearch, type SearchQuery } from '@cardstack/host/resources/search';
 
 import MessageService from '@cardstack/host/services/message-service';
 
@@ -71,14 +68,14 @@ export default class OperatorModeContainer extends Component<Signature> {
   // public API
   @action
   getCards(
-    query: Query,
-    realms?: string[],
-    opts?: {
+    getQuery: () => Query,
+    getRealms: () => string[],
+    opts: {
       isLive?: true;
       doWhileRefreshing?: (ready: Promise<void> | undefined) => Promise<void>;
     },
-  ): Search {
-    return getSearchResults(this, query, realms, opts);
+  ): SearchQuery {
+    return getSearch(this, getQuery, getRealms, opts);
   }
 
   // public API

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -353,8 +353,8 @@ export default class InteractSubmode extends Component<Signature> {
         here.operatorModeStateService.updateSubmode(submode);
       },
       getCards: (
-        getQuery: () => Query,
-        getRealms: () => string[],
+        getQuery: () => Query | undefined,
+        getRealms: () => string[] | undefined,
       ): SearchQuery => {
         return getSearch(here, getQuery, getRealms);
       },

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -30,12 +30,14 @@ import {
   type Actions,
   type CodeRef,
   type LooseSingleCardDocument,
+  type Query,
 } from '@cardstack/runtime-common';
 
 import CopyCardCommand from '@cardstack/host/commands/copy-card';
 import config from '@cardstack/host/config/environment';
 import { StackItem } from '@cardstack/host/lib/stack-item';
 
+import { SearchQuery, getSearch } from '@cardstack/host/resources/search';
 import { stackBackgroundsResource } from '@cardstack/host/resources/stack-backgrounds';
 
 import type MatrixService from '@cardstack/host/services/matrix-service';
@@ -349,6 +351,12 @@ export default class InteractSubmode extends Component<Signature> {
       changeSubmode: (url: URL, submode: Submode = 'code'): void => {
         here.operatorModeStateService.updateCodePath(url);
         here.operatorModeStateService.updateSubmode(submode);
+      },
+      getCards: (
+        getQuery: () => Query,
+        getRealms: () => string[],
+      ): SearchQuery => {
+        return getSearch(here, getQuery, getRealms);
       },
     };
   }

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -202,32 +202,27 @@ export class Search extends Resource<Args> {
   }
 }
 
-export function getSearchResults(
+export interface SearchQuery {
+  instances: CardDef[];
+  isLoading: boolean;
+  loaded: Promise<void>;
+}
+
+export function getSearch(
   parent: object,
-  query: Query,
-  realms?: string[],
+  getQuery: () => Query,
+  getRealms: () => string[],
   opts?: {
     isLive?: true;
-    // it is probably desirable that dynamic context action `doWithStableScroll()`
-    // is used here. For example:
-    //
-    //   async (ready: Promise<void> | undefined) => {
-    //     if (this.args.context?.actions) {
-    //       this.args.context.actions.doWithStableScroll(
-    //         this.args.model as CardDef,
-    //         async () => { await ready; }
-    //       );
-    //     }
-    //   }
     doWhileRefreshing?: (ready: Promise<void> | undefined) => Promise<void>;
   },
 ) {
   return Search.from(parent, () => ({
     named: {
-      query,
-      realms: realms ?? undefined,
+      query: getQuery(),
+      realms: getRealms(),
       isLive: opts?.isLive,
       doWhileRefreshing: opts?.doWhileRefreshing,
     },
-  })) as Search;
+  })) as SearchQuery;
 }

--- a/packages/host/tests/integration/components/card-api-test.gts
+++ b/packages/host/tests/integration/components/card-api-test.gts
@@ -1,0 +1,258 @@
+import { action } from '@ember/object';
+import { RenderingTestContext } from '@ember/test-helpers';
+
+import { fillIn } from '@ember/test-helpers';
+import GlimmerComponent from '@glimmer/component';
+
+import { tracked } from '@glimmer/tracking';
+
+import { provide, consume } from 'ember-provide-consume-context';
+import { module, test } from 'qunit';
+
+import { BoxelInput } from '@cardstack/boxel-ui/components';
+
+import { Loader, CardContextName, type Query } from '@cardstack/runtime-common';
+
+import { getSearch } from '@cardstack/host/resources/search';
+import LoaderService from '@cardstack/host/services/loader-service';
+
+import {
+  CardDocFiles,
+  lookupLoaderService,
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  setupServerSentEvents,
+  testRealmURL,
+} from '../../helpers';
+import {
+  CardDef,
+  StringField,
+  contains,
+  field,
+  setupBaseRealm,
+  Component,
+  // realmURL,
+} from '../../helpers/base-realm';
+import { renderComponent } from '../../helpers/render-component';
+import { setupRenderingTest } from '../../helpers/setup';
+
+interface CardContextProviderSignature {
+  Args: {};
+  Blocks: { default: [] };
+}
+
+class CardContextProvider extends GlimmerComponent<CardContextProviderSignature> {
+  @provide(CardContextName)
+  get context() {
+    return {
+      actions: {
+        getCards: (getQuery: () => Query, getRealms: () => string[]) => {
+          return getSearch(this, getQuery, getRealms);
+        },
+      },
+    };
+  }
+}
+
+interface CardContext {
+  actions: any;
+}
+
+interface CardContextConsumerSignature {
+  Blocks: { default: [CardContext] };
+}
+
+class CardContextConsumer extends GlimmerComponent<CardContextConsumerSignature> {
+  @consume(CardContextName) declare dynamicCardContext: CardContext;
+
+  get context() {
+    return {
+      ...this.dynamicCardContext,
+    };
+  }
+
+  <template>
+    {{yield this.context}}
+  </template>
+}
+
+module('Integration | card api (Usage of publicAPI actions)', function (hooks) {
+  let loader: Loader;
+  let loaderService: LoaderService;
+
+  setupRenderingTest(hooks);
+  hooks.beforeEach(function () {
+    loaderService = lookupLoaderService();
+    loader = loaderService.loader;
+  });
+
+  setupLocalIndexing(hooks);
+  setupServerSentEvents(hooks);
+  setupBaseRealm(hooks);
+
+  module('getCards', function (hooks) {
+    hooks.beforeEach(async function (this: RenderingTestContext) {
+      class Author extends CardDef {
+        static displayName = 'Author';
+        @field firstName = contains(StringField);
+        @field lastName = contains(StringField);
+        @field title = contains(StringField, {
+          computeVia: function (this: Author) {
+            return [this.firstName, this.lastName].filter(Boolean).join(' ');
+          },
+        });
+      }
+
+      const authorCards: CardDocFiles = {
+        'jane.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              firstName: 'Jane',
+              lastName: 'Doe',
+            },
+            meta: {
+              adoptsFrom: {
+                module: `${testRealmURL}author`,
+                name: 'Author',
+              },
+            },
+          },
+        },
+        'hassan.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              firstName: 'Justin',
+              lastName: 'Bieber',
+            },
+            meta: {
+              adoptsFrom: {
+                module: `${testRealmURL}author`,
+                name: 'Author',
+              },
+            },
+          },
+        },
+        'justin.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              firstName: 'Justin',
+              lastName: 'T',
+            },
+            meta: {
+              adoptsFrom: {
+                module: `${testRealmURL}author`,
+                name: 'Author',
+              },
+            },
+          },
+        },
+      };
+      await setupIntegrationTestRealm({
+        loader,
+        contents: {
+          'author.gts': { Author },
+          ...authorCards,
+        },
+      });
+    });
+
+    test(`changing query updates search resource`, async function (assert) {
+      class Isolated extends Component<typeof AuthorSearch> {
+        @tracked name = 'Jane';
+        get query() {
+          return {
+            filter: {
+              on: {
+                module: `${testRealmURL}author`,
+                name: 'Author',
+              },
+              eq: {
+                firstName: this.name,
+              },
+            },
+          };
+        }
+        get realms() {
+          return [testRealmURL]; //TODO: Investigate where meta is returned. Offer a context where the symbol exists
+        }
+        resource = this.args.context?.actions?.getCards
+          ? this.args.context.actions.getCards(
+              () => this.query,
+              () => this.realms,
+            )
+          : undefined;
+
+        get authors() {
+          return this.resource?.instances ?? [];
+        }
+        @action setName(name: string) {
+          this.name = name;
+        }
+        get queryString() {
+          return JSON.stringify(this.query, null, 2);
+        }
+        <template>
+          <div data-test-author-search>
+            <BoxelInput
+              @value={{this.name}}
+              @onInput={{this.setName}}
+              @placeholder='Search for an author'
+              data-test-search-input
+            />
+            {{#if this.resource.isLoading}}
+              Loading...
+            {{else}}
+              <h2> Query </h2>
+              {{this.queryString}}
+              <h2> Search Results </h2>
+              {{#each this.authors as |author|}}
+                <div data-test-title>{{author.title}}</div>
+              {{/each}}
+            {{/if}}
+          </div>
+        </template>
+      }
+      class AuthorSearch extends CardDef {
+        static displayName = 'AuthorSearch';
+        static isolated = Isolated;
+      }
+      let card = new AuthorSearch();
+      await renderComponent(
+        class TestDriver extends GlimmerComponent {
+          <template>
+            <CardContextProvider>
+              <CardContextConsumer>
+                {{#let (getComponent card) as |Card|}}
+                  <Card />
+                {{/let}}
+              </CardContextConsumer>
+            </CardContextProvider>
+          </template>
+        },
+      );
+      assert
+        .dom('[data-test-author-search] [data-test-title]')
+        .hasText('Jane Doe');
+      assert
+        .dom('[data-test-author-search] [data-test-title]')
+        .exists({ count: 1 });
+      await fillIn(
+        '[data-test-author-search] [data-test-search-input]',
+        'Justin',
+      );
+      assert
+        .dom('[data-test-author-search] [data-test-title]')
+        .containsText('Justin');
+      assert
+        .dom('[data-test-author-search] [data-test-title]')
+        .exists({ count: 2 });
+    });
+  });
+});
+
+function getComponent(cardOrField: any) {
+  return cardOrField.constructor.getComponent(cardOrField);
+}

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -222,8 +222,8 @@ export async function chooseCard<T extends BaseDef>(
 
 export interface CardSearch {
   getCards(
-    query: Query,
-    realms?: string[],
+    getQuery: () => Query,
+    getRealms: () => string[],
     opts?: {
       isLive?: true;
       doWhileRefreshing?: (ready: Promise<void> | undefined) => Promise<void>;
@@ -248,8 +248,8 @@ export interface CardCatalogQuery extends Query {
 }
 
 export function getCards(
-  query: Query,
-  realms?: string[],
+  getQuery: () => Query,
+  getRealms: () => string[],
   opts?: {
     isLive?: true;
     doWhileRefreshing?: (ready: Promise<void> | undefined) => Promise<void>;
@@ -257,7 +257,7 @@ export function getCards(
 ) {
   let here = globalThis as any;
   let finder: CardSearch = here._CARDSTACK_CARD_SEARCH;
-  return finder?.getCards(query, realms, opts);
+  return finder?.getCards(getQuery, getRealms, opts);
 }
 
 export function getCard<T extends CardDef>(
@@ -324,6 +324,11 @@ export function subscribeToRealm(
   }
 }
 
+export interface SearchQuery {
+  instances: CardDef[];
+  isLoading: boolean;
+}
+
 export interface Actions {
   createCard: (
     ref: CodeRef,
@@ -355,6 +360,14 @@ export interface Actions {
     changeSizeCallback: () => Promise<void>,
   ) => Promise<void>;
   changeSubmode: (url: URL, submode: 'code' | 'interact') => void;
+  getCards: (
+    getQuery: () => Query,
+    getRealms: () => string[],
+    opts?: {
+      isLive?: true;
+      doWhileRefreshing?: (ready: Promise<void> | undefined) => Promise<void>;
+    },
+  ) => SearchQuery;
 }
 
 export function hasExecutableExtension(path: string): boolean {

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -222,8 +222,8 @@ export async function chooseCard<T extends BaseDef>(
 
 export interface CardSearch {
   getCards(
-    getQuery: () => Query,
-    getRealms: () => string[],
+    getQuery: () => Query | undefined,
+    getRealms: () => string[] | undefined,
     opts?: {
       isLive?: true;
       doWhileRefreshing?: (ready: Promise<void> | undefined) => Promise<void>;
@@ -248,8 +248,8 @@ export interface CardCatalogQuery extends Query {
 }
 
 export function getCards(
-  getQuery: () => Query,
-  getRealms: () => string[],
+  getQuery: () => Query | undefined,
+  getRealms: () => string[] | undefined,
   opts?: {
     isLive?: true;
     doWhileRefreshing?: (ready: Promise<void> | undefined) => Promise<void>;
@@ -361,8 +361,8 @@ export interface Actions {
   ) => Promise<void>;
   changeSubmode: (url: URL, submode: 'code' | 'interact') => void;
   getCards: (
-    getQuery: () => Query,
-    getRealms: () => string[],
+    getQuery: () => Query | undefined,
+    getRealms: () => string[] | undefined,
     opts?: {
       isLive?: true;
       doWhileRefreshing?: (ready: Promise<void> | undefined) => Promise<void>;

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -361,6 +361,10 @@ export interface Actions {
   ) => Promise<void>;
   changeSubmode: (url: URL, submode: 'code' | 'interact') => void;
   getCards: (
+    // The reason (getQuery, getRealms) is a thunk is to ensure that the arguments are reactive wrt to ember resource
+    // This is the expectation of ember-resources ie`.from` method should be instantiated at the root of the component and expect a thunk
+    // The issue is when we wrap `getCards` as an api, we tend to model it as a function that takes arguments (values) thereby enclosing in a scoped context
+    // We acknowledge that this is not the "perfect" api but it is a pragmatic solution for now to resolve the tension between card api usage and ember-resources
     getQuery: () => Query | undefined,
     getRealms: () => string[] | undefined,
     opts?: {

--- a/packages/seed-realm/monetary-amount.gts
+++ b/packages/seed-realm/monetary-amount.gts
@@ -38,24 +38,26 @@ class Edit extends Component<typeof MonetaryAmount> {
 
   // TODO refactor to use <PrerenderedCardSearch> component from the @context if you want live search
   liveCurrencyQuery = getCards(
-    {
-      filter: {
-        type: {
-          module: new URL('./asset', import.meta.url).href,
-          name: 'Currency',
-        },
-      },
-      sort: [
-        {
-          on: {
+    () => {
+      return {
+        filter: {
+          type: {
             module: new URL('./asset', import.meta.url).href,
             name: 'Currency',
           },
-          by: 'name',
         },
-      ],
+        sort: [
+          {
+            on: {
+              module: new URL('./asset', import.meta.url).href,
+              name: 'Currency',
+            },
+            by: 'name',
+          },
+        ],
+      };
     },
-    [new URL('./', import.meta.url).href],
+    () => [new URL('./', import.meta.url).href],
   );
 
   @action

--- a/packages/seed-realm/sprint-planner.gts
+++ b/packages/seed-realm/sprint-planner.gts
@@ -83,15 +83,21 @@ class SprintPlannerIsolated extends Component<typeof SprintPlanner> {
     return Object.keys(this.filters) as FilterType[];
   }
 
-  cards = getCards(this.getTaskQuery, this.realmHrefs, { isLive: true });
+  cards = getCards(
+    () => this.getTaskQuery,
+    () => this.realmHrefs,
+    { isLive: true },
+  );
 
   assigneeQuery = getCards(
-    {
-      filter: {
-        type: this.filters.assignee.codeRef,
-      },
+    () => {
+      return {
+        filter: {
+          type: this.filters.assignee.codeRef,
+        },
+      };
     },
-    this.realmHrefs,
+    () => this.realmHrefs,
     { isLive: true },
   );
 


### PR DESCRIPTION
Ecosystem team had trouble using `getCards` like a resource. Particularly, changing query argument causse the search resource to recompute -- this did not work. This let to some confusing workarounds that force the re-instantiation of the resource. The main issue is for `ember-resources` we expect `Search.from(this,()=> objectWithArgs)` to exist in the root of the componet but we are wrapping it in a function and each arg item is passed as a value -- I  changed the expected reactive arg item into thunks





**Note**
- **Adding card api test**: this PR introduce some test to the usage of card api of card users. I added this test suite with the intent of making clear what card authors have access to and the correct way to use it
- **Promote getCards as a publicAPI**: I intentionally promoted since card users would want to use it
- **Suspicion**: My suspicion is that other resources use the same pattern and maybe accidentally re-instantiating as opposed to sitting on the component and recomputing

