### PR TITLE
Cs 7919 hide crm deal embedded format icon

### DIFF
--- a/packages/boxel-ui/addon/src/components/view-selector/index.gts
+++ b/packages/boxel-ui/addon/src/components/view-selector/index.gts
@@ -32,7 +32,10 @@ export default class ViewSelector extends Component<Signature> {
     { id: 'strip', icon: StripIcon },
     { id: 'grid', icon: GridIcon },
   ];
-  viewOptions = this.args.items ?? this.standardViewOptions;
+
+  get viewOptions() {
+    return this.args.items ?? this.standardViewOptions;
+  }
 
   get selectedId() {
     return this.args.selectedId ?? (this.viewOptions[0] as ViewItem).id;

--- a/packages/experiments-realm/crm-app.gts
+++ b/packages/experiments-realm/crm-app.gts
@@ -41,7 +41,19 @@ import type { Deal } from './crm/deal';
 import DealSummary from './crm/deal-summary';
 import { CRMTaskPlannerIsolated } from './crm/task-planner';
 
+import type { ComponentLike } from '@glint/template';
+import {
+  Card as CardIcon,
+  Grid3x3 as GridIcon,
+  Rows4 as StripIcon,
+} from '@cardstack/boxel-ui/icons';
+
 type ViewOption = 'card' | 'strip' | 'grid';
+
+interface ViewItem {
+  icon: ComponentLike;
+  id: string;
+}
 
 const CONTACT_FILTERS: LayoutFilter[] = [
   {
@@ -132,6 +144,29 @@ class CrmAppTemplate extends Component<typeof AppCard> {
   @tracked activeTabId: string | undefined = this.args.model.tabs?.[0]?.tabId;
   @tracked tabs = this.args.model.tabs;
   @tracked private selectedView: ViewOption = 'card';
+
+  // Only show strip and grid views for Deal tab for now
+  get dealView(): ViewItem[] {
+    return [
+      { id: 'strip', icon: StripIcon },
+      { id: 'grid', icon: GridIcon },
+    ];
+  }
+
+  get commonViews(): ViewItem[] {
+    return [
+      { id: 'card', icon: CardIcon },
+      { id: 'strip', icon: StripIcon },
+      { id: 'grid', icon: GridIcon },
+    ];
+  }
+
+  get tabViews(): ViewItem[] {
+    const views =
+      this.activeTabId === 'Deal' ? this.dealView : this.commonViews;
+    return views;
+  }
+
   @tracked private searchKey = '';
   @tracked private deals: Deal[] = [];
 
@@ -203,11 +238,13 @@ class CrmAppTemplate extends Component<typeof AppCard> {
 
   //Tabs
   @action setActiveTab(id: string) {
+    this.selectedView = id === 'Deal' ? 'strip' : 'card';
     this.activeTabId = id;
     this.searchKey = '';
     this.setActiveFilter();
     this.loadDealCards.perform();
   }
+
   get headerColor() {
     return (
       Object.getPrototypeOf(this.args.model).constructor.headerColor ??
@@ -418,6 +455,7 @@ class CrmAppTemplate extends Component<typeof AppCard> {
             class='view-menu content-header-row-2'
             @selectedId={{this.selectedView}}
             @onChange={{this.onChangeView}}
+            @items={{this.tabViews}}
           />
         {{/if}}
         {{#if this.activeFilter.sortOptions.length}}

--- a/packages/experiments-realm/crm-app.gts
+++ b/packages/experiments-realm/crm-app.gts
@@ -41,7 +41,7 @@ import type { Deal } from './crm/deal';
 import DealSummary from './crm/deal-summary';
 import { CRMTaskPlanner } from './crm/task-planner';
 
-import type { ComponentLike } from '@glint/template';
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import {
   Card as CardIcon,
   Grid3x3 as GridIcon,
@@ -51,8 +51,10 @@ import {
 type ViewOption = 'card' | 'strip' | 'grid';
 
 interface ViewItem {
-  icon: ComponentLike;
-  id: string;
+  icon: TemplateOnlyComponent<{
+    Element: SVGElement;
+  }>;
+  id: ViewOption;
 }
 
 const CONTACT_FILTERS: LayoutFilter[] = [


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-7919/hide-crm-deal-embedded-format-icon

From the previous team meeting, we have made a decision: 
1. to default CRM Deal view to strip format 
2. hide the embedded card view format for the deal tab 

Result:

https://github.com/user-attachments/assets/d87bf7ee-0c28-47aa-be2c-776ecc3f3031






