### PR TITLE
Set Default Active LLM on host side

### DIFF
--- a/packages/ai-bot/lib/matrix.ts
+++ b/packages/ai-bot/lib/matrix.ts
@@ -44,15 +44,6 @@ export async function sendEvent(
   return await client.sendEvent(roomId, eventType, content);
 }
 
-export async function updateStateEvent(
-  client: MatrixClient,
-  roomId: string,
-  eventType: string,
-  content: IContent,
-) {
-  return await client.sendStateEvent(roomId, eventType, content, '');
-}
-
 export async function sendMessage(
   client: MatrixClient,
   roomId: string,

--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -16,10 +16,6 @@ import {
   extractCardFragmentsFromEvents,
   eventRequiresResponse,
 } from './helpers';
-import {
-  APP_BOXEL_ACTIVE_LLM,
-  DEFAULT_LLM,
-} from '@cardstack/runtime-common/matrix-constants';
 
 import {
   shouldSetRoomTitle,
@@ -28,7 +24,7 @@ import {
 } from './lib/set-title';
 import { Responder } from './lib/send-response';
 import { handleDebugCommands } from './lib/debug';
-import { MatrixClient, updateStateEvent } from './lib/matrix';
+import { MatrixClient } from './lib/matrix';
 import type { MatrixEvent as DiscreteMatrixEvent } from 'https://cardstack.com/base/matrix-event';
 import * as Sentry from '@sentry/node';
 
@@ -125,12 +121,6 @@ class Assistant {
   ) {
     return setTitle(this.openai, this.client, roomId, history, this.id, event);
   }
-
-  async setDefaultLLM(roomId: string) {
-    await updateStateEvent(this.client, roomId, APP_BOXEL_ACTIVE_LLM, {
-      model: DEFAULT_LLM,
-    });
-  }
 }
 
 let startTime = Date.now();
@@ -171,9 +161,8 @@ Common issues are:
     if (member.membership === 'invite' && member.userId === aiBotUserId) {
       client
         .joinRoom(member.roomId)
-        .then(async function () {
+        .then(function () {
           log.info('%s auto-joined %s', member.name, member.roomId);
-          await assistant.setDefaultLLM(member.roomId);
         })
         .catch(function (err) {
           log.info(

--- a/packages/host/app/commands/create-ai-assistant-room.ts
+++ b/packages/host/app/commands/create-ai-assistant-room.ts
@@ -4,6 +4,11 @@ import format from 'date-fns/format';
 
 import { aiBotUsername } from '@cardstack/runtime-common';
 
+import {
+  APP_BOXEL_ACTIVE_LLM,
+  DEFAULT_LLM,
+} from '@cardstack/runtime-common/matrix-constants';
+
 import type * as BaseCommandModule from 'https://cardstack.com/base/command';
 
 import HostBaseCommand from '../lib/host-base-command';
@@ -51,6 +56,9 @@ export default class CreateAIAssistantRoomCommand extends HostBaseCommand<
       aiBotFullId,
       matrixService.aiBotPowerLevel,
     );
+    await this.matrixService.sendStateEvent(roomId, APP_BOXEL_ACTIVE_LLM, {
+      model: DEFAULT_LLM,
+    });
     let commandModule = await this.loadCommandModule();
     const { CreateAIAssistantRoomResult } = commandModule;
     return new CreateAIAssistantRoomResult({ roomId });


### PR DESCRIPTION
This PR moves the process of setting the default active LLM to the host side, whereas previously, it was handled by the AI bot when it joined the room.