### PR TITLE
Display isolated card preview on playground

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground-panel.gts
@@ -173,7 +173,7 @@ class PlaygroundPanelContent extends Component<PlaygroundContentSignature> {
 
   private get contextMenuItems() {
     if (!this.card?.id) {
-      return;
+      return undefined;
     }
     let cardId = this.card.id;
     let menuItems: MenuItem[] = [


### PR DESCRIPTION
- Add isolated format preview in playground panel and header context actions

Note: Preview does not live update when template or css changes -- captured in CS-7950

<img width="1495" alt="playground-preview-isolated-format" src="https://github.com/user-attachments/assets/283f0374-3223-4ea1-b7e1-57140aff18af" />