### PR TITLE
Fix loading state rhs

### DIFF
--- a/packages/host/app/components/operator-mode/card-adoption-chain.gts
+++ b/packages/host/app/components/operator-mode/card-adoption-chain.gts
@@ -62,12 +62,7 @@ export default class CardAdoptionChain extends Component<Signature> {
     </div>
     <style scoped>
       .loading {
-        align-content: center;
-        text-align: center;
-        font-weight: 500;
-        padding: var(--boxel-sp-xl);
-        height: 100%;
-        width: 100%;
+        display: inline-flex;
       }
       .loading-icon {
         display: inline-block;

--- a/packages/host/app/components/operator-mode/card-adoption-chain.gts
+++ b/packages/host/app/components/operator-mode/card-adoption-chain.gts
@@ -14,6 +14,8 @@ import type { Ready } from '@cardstack/host/resources/file';
 
 import { isOwnField } from '@cardstack/host/utils/schema-editor';
 
+import { LoadingIndicator } from '@cardstack/boxel-ui/components';
+
 interface Signature {
   Element: HTMLDivElement;
   Args: {
@@ -25,31 +27,54 @@ interface Signature {
       codeRef: ResolvedCodeRef | undefined,
       localName: string | undefined,
     ) => void;
+    isLoading: boolean;
   };
 }
 
 export default class CardAdoptionChain extends Component<Signature> {
   <template>
     <div ...attributes>
-      {{#each @cardInheritanceChain as |data index|}}
-        <CardSchemaEditor
-          @card={{data.card}}
-          @cardType={{data.cardType}}
-          @file={{@file}}
-          @moduleSyntax={{@moduleSyntax}}
-          @childFields={{this.getFields index 'successors'}}
-          @parentFields={{this.getFields index 'ancestors'}}
-          @allowFieldManipulation={{this.allowFieldManipulation
-            @file
-            data.cardType
-          }}
-          @goToDefinition={{@goToDefinition}}
-        />
-        {{#unless (this.isLastItem index @cardInheritanceChain)}}
-          <Divider @label='Inherits From' />
-        {{/unless}}
-      {{/each}}
+      {{#if @isLoading}}
+        <div class='loading'>
+          <LoadingIndicator class='loading-icon' />
+          Loading...
+        </div>
+      {{else}}
+        {{#each @cardInheritanceChain as |data index|}}
+          <CardSchemaEditor
+            @card={{data.card}}
+            @cardType={{data.cardType}}
+            @file={{@file}}
+            @moduleSyntax={{@moduleSyntax}}
+            @childFields={{this.getFields index 'successors'}}
+            @parentFields={{this.getFields index 'ancestors'}}
+            @allowFieldManipulation={{this.allowFieldManipulation
+              @file
+              data.cardType
+            }}
+            @goToDefinition={{@goToDefinition}}
+          />
+          {{#unless (this.isLastItem index @cardInheritanceChain)}}
+            <Divider @label='Inherits From' />
+          {{/unless}}
+        {{/each}}
+      {{/if}}
     </div>
+    <style scoped>
+      .loading {
+        align-content: center;
+        text-align: center;
+        font-weight: 500;
+        padding: var(--boxel-sp-xl);
+        height: 100%;
+        width: 100%;
+      }
+      .loading-icon {
+        display: inline-block;
+        margin-right: var(--boxel-sp-xxxs);
+        vertical-align: middle;
+      }
+    </style>
   </template>
 
   isLastItem = (index: number, items: any[] = []) => index + 1 === items.length;

--- a/packages/host/app/components/operator-mode/card-adoption-chain.gts
+++ b/packages/host/app/components/operator-mode/card-adoption-chain.gts
@@ -1,6 +1,8 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 
+import { LoadingIndicator } from '@cardstack/boxel-ui/components';
+
 import { type ResolvedCodeRef } from '@cardstack/runtime-common/code-ref';
 import { ModuleSyntax } from '@cardstack/runtime-common/module-syntax';
 
@@ -13,8 +15,6 @@ import { Type } from '@cardstack/host/resources/card-type';
 import type { Ready } from '@cardstack/host/resources/file';
 
 import { isOwnField } from '@cardstack/host/utils/schema-editor';
-
-import { LoadingIndicator } from '@cardstack/boxel-ui/components';
 
 interface Signature {
   Element: HTMLDivElement;

--- a/packages/host/app/components/operator-mode/code-submode/schema-editor.gts
+++ b/packages/host/app/components/operator-mode/code-submode/schema-editor.gts
@@ -4,8 +4,6 @@ import Component from '@glimmer/component';
 
 import { cached } from '@glimmer/tracking';
 
-import { LoadingIndicator } from '@cardstack/boxel-ui/components';
-
 import { getPlural } from '@cardstack/runtime-common';
 import { type ResolvedCodeRef } from '@cardstack/runtime-common/code-ref';
 
@@ -46,6 +44,7 @@ interface Signature {
         | 'cardInheritanceChain'
         | 'goToDefinition'
         | 'isReadOnly'
+        | 'isLoading'
       >,
     ];
   };
@@ -84,6 +83,11 @@ const SchemaEditorTitle: TemplateOnlyComponent<TitleSignature> = <template>
       letter-spacing: var(--boxel-lsp-xl);
       text-transform: uppercase;
     }
+    .loading-icon {
+      display: inline-block;
+      margin-right: var(--boxel-sp-xxxs);
+      vertical-align: middle;
+    }
   </style>
 </template>;
 
@@ -120,35 +124,29 @@ export default class SchemaEditor extends Component<Signature> {
     return !!this.args?.moduleContentsResource?.moduleError?.message;
   }
 
-  <template>
-    <style scoped>
-      .loading {
-        display: flex;
-        justify-content: center;
-        padding: var(--boxel-sp-xl);
-      }
-    </style>
-    {{#if @moduleContentsResource.isLoadingNewModule}}
-      <div class='loading'>
-        <LoadingIndicator />
-      </div>
-    {{else}}
+  get isLoading() {
+    return (
+      this.args.moduleContentsResource.isLoadingNewModule ||
+      this.cardInheritanceChain.isLoading
+    );
+  }
 
-      {{yield
-        (component
-          SchemaEditorTitle
-          totalFields=this.totalFields
-          hasModuleError=this.hasModuleError
-        )
-        (component
-          CardAdoptionChain
-          file=@file
-          isReadOnly=@isReadOnly
-          moduleSyntax=this.moduleSyntax
-          cardInheritanceChain=this.cardInheritanceChain.value
-          goToDefinition=@goToDefinition
-        )
-      }}
-    {{/if}}
+  <template>
+    {{yield
+      (component
+        SchemaEditorTitle
+        totalFields=this.totalFields
+        hasModuleError=this.hasModuleError
+      )
+      (component
+        CardAdoptionChain
+        file=@file
+        isReadOnly=@isReadOnly
+        moduleSyntax=this.moduleSyntax
+        cardInheritanceChain=this.cardInheritanceChain.value
+        goToDefinition=@goToDefinition
+        isLoading=this.isLoading
+      )
+    }}
   </template>
 }

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -257,6 +257,7 @@ class SpecPreviewContent extends GlimmerComponent<ContentSignature> {
         gap: var(--boxel-sp-sm);
         height: 100%;
         width: 100%;
+        padding: var(--boxel-sp-sm);
       }
       .create-spec-intent-message {
         background-color: var(--boxel-200);
@@ -270,7 +271,6 @@ class SpecPreviewContent extends GlimmerComponent<ContentSignature> {
       .spec-selector {
         min-width: 40%;
         align-self: flex-start;
-        padding: var(--boxel-sp-sm);
       }
       .spec-selector-item {
         display: flex;

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -211,7 +211,7 @@ class SpecPreviewContent extends GlimmerComponent<ContentSignature> {
   }
 
   <template>
-    <section class='spec-preview'>
+    <section class='container'>
       {{#if @isLoading}}
         <div class='loading'>
           <LoadingIndicator class='loading-icon' />
@@ -225,31 +225,33 @@ class SpecPreviewContent extends GlimmerComponent<ContentSignature> {
           Create a Boxel Specification to be able to create new instances
         </div>
       {{else}}
-        <div class='spec-selector' data-test-spec-selector>
-          <BoxelSelect
-            @options={{this.dropdownData}}
-            @selected={{this.selectedDropdownData}}
-            @onChange={{this.selectDropdownData}}
-            @matchTriggerWidth={{true}}
-            @disabled={{this.onlyOneInstance}}
-            as |d|
-          >
-            <div class='spec-selector-item'>
-              <RealmIcon class='url-realm-icon' @realmInfo={{d.realmInfo}} />
-              {{d.localPath}}
-            </div>
-          </BoxelSelect>
+        <div class='spec-preview'>
+          <div class='spec-selector' data-test-spec-selector>
+            <BoxelSelect
+              @options={{this.dropdownData}}
+              @selected={{this.selectedDropdownData}}
+              @onChange={{this.selectDropdownData}}
+              @matchTriggerWidth={{true}}
+              @disabled={{this.onlyOneInstance}}
+              as |d|
+            >
+              <div class='spec-selector-item'>
+                <RealmIcon class='url-realm-icon' @realmInfo={{d.realmInfo}} />
+                {{d.localPath}}
+              </div>
+            </BoxelSelect>
+          </div>
+          {{#if @selectedInstance}}
+            {{#let (getComponent @selectedInstance) as |CardComponent|}}
+              <CardComponent />
+            {{/let}}
+          {{/if}}
         </div>
-        {{#if @selectedInstance}}
-          {{#let (getComponent @selectedInstance) as |CardComponent|}}
-            <CardComponent />
-          {{/let}}
-        {{/if}}
       {{/if}}
     </section>
 
     <style scoped>
-      .spec-preview {
+      .container {
         display: flex;
         align-items: center;
         justify-content: center;
@@ -257,6 +259,8 @@ class SpecPreviewContent extends GlimmerComponent<ContentSignature> {
         gap: var(--boxel-sp-sm);
         height: 100%;
         width: 100%;
+      }
+      .spec-preview {
         padding: var(--boxel-sp-sm);
       }
       .create-spec-intent-message {

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -211,7 +211,7 @@ class SpecPreviewContent extends GlimmerComponent<ContentSignature> {
   }
 
   <template>
-    <section class='container'>
+    <div class='container'>
       {{#if @isLoading}}
         <div class='loading'>
           <LoadingIndicator class='loading-icon' />
@@ -248,7 +248,7 @@ class SpecPreviewContent extends GlimmerComponent<ContentSignature> {
           {{/if}}
         </div>
       {{/if}}
-    </section>
+    </div>
 
     <style scoped>
       .container {
@@ -256,11 +256,15 @@ class SpecPreviewContent extends GlimmerComponent<ContentSignature> {
         align-items: center;
         justify-content: center;
         flex-direction: column;
-        gap: var(--boxel-sp-sm);
         height: 100%;
         width: 100%;
       }
       .spec-preview {
+        display: flex;
+        flex-direction: column;
+        gap: var(--boxel-sp-sm);
+        height: 100%;
+        width: 100%;
         padding: var(--boxel-sp-sm);
       }
       .create-spec-intent-message {

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -229,7 +229,7 @@ class SpecPreviewContent extends GlimmerComponent<ContentSignature> {
           <BoxelSelect
             @options={{this.dropdownData}}
             @selected={{this.selectedDropdownData}}
-            @onChange={{@selectSpec}}
+            @onChange={{this.selectDropdownData}}
             @matchTriggerWidth={{true}}
             @disabled={{this.onlyOneInstance}}
             as |d|
@@ -270,6 +270,7 @@ class SpecPreviewContent extends GlimmerComponent<ContentSignature> {
       .spec-selector {
         min-width: 40%;
         align-self: flex-start;
+        padding: var(--boxel-sp-sm);
       }
       .spec-selector-item {
         display: flex;
@@ -432,7 +433,7 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
     this._selectedInstance = spec;
   }
 
-  get selectedInstanceInDropdown() {
+  get selectedInstance() {
     return (
       this._selectedInstance ??
       (this.specInstances.length ? this.specInstances[0] : null)
@@ -445,7 +446,7 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
         SpecPreviewTitle
         showCreateSpecIntent=this.showCreateSpecIntent
         specInstances=this.specInstances
-        selectedInstance=this.selectedInstanceInDropdown
+        selectedInstance=this.selectedInstance
         createSpec=this.createSpec
         isCreateModalShown=@isCreateModalShown
       )
@@ -453,7 +454,7 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
         SpecPreviewContent
         showCreateSpecIntent=this.showCreateSpecIntent
         specInstances=this.specInstances
-        selectedInstance=this.selectedInstanceInDropdown
+        selectedInstance=this.selectedInstance
         selectSpec=this.selectSpec
         isLoading=this.specSearch.isLoading
       )

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -211,20 +211,20 @@ class SpecPreviewContent extends GlimmerComponent<ContentSignature> {
   }
 
   <template>
-    {{#if @isLoading}}
-      <div class='loading'>
-        <LoadingIndicator class='loading-icon' />
-        Loading...
-      </div>
-    {{else if @showCreateSpecIntent}}
-      <div
-        class='create-spec-intent-message'
-        data-test-create-spec-intent-message
-      >
-        Create a Boxel Specification to be able to create new instances
-      </div>
-    {{else}}
-      <div class='spec-preview'>
+    <section class='spec-preview'>
+      {{#if @isLoading}}
+        <div class='loading'>
+          <LoadingIndicator class='loading-icon' />
+          Loading...
+        </div>
+      {{else if @showCreateSpecIntent}}
+        <div
+          class='create-spec-intent-message'
+          data-test-create-spec-intent-message
+        >
+          Create a Boxel Specification to be able to create new instances
+        </div>
+      {{else}}
         <div class='spec-selector' data-test-spec-selector>
           <BoxelSelect
             @options={{this.dropdownData}}
@@ -245,27 +245,27 @@ class SpecPreviewContent extends GlimmerComponent<ContentSignature> {
             <CardComponent />
           {{/let}}
         {{/if}}
-      </div>
-    {{/if}}
+      {{/if}}
+    </section>
 
     <style scoped>
-      .create-spec-intent-message {
-        align-content: center;
-        text-align: center;
-        background-color: var(--boxel-200);
-        color: var(--boxel-450);
-        font-weight: 500;
-        padding: var(--boxel-sp-xl);
-        height: 100%;
-        width: 100%;
-      }
       .spec-preview {
         display: flex;
         align-items: center;
         justify-content: center;
         flex-direction: column;
         gap: var(--boxel-sp-sm);
-        padding: var(--boxel-sp-sm);
+        height: 100%;
+        width: 100%;
+      }
+      .create-spec-intent-message {
+        background-color: var(--boxel-200);
+        color: var(--boxel-450);
+        font-weight: 500;
+        height: 100%;
+        width: 100%;
+        align-content: center;
+        text-align: center;
       }
       .spec-selector {
         min-width: 40%;
@@ -277,12 +277,7 @@ class SpecPreviewContent extends GlimmerComponent<ContentSignature> {
         gap: var(--boxel-sp-xxxs);
       }
       .loading {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        flex-direction: column;
-        gap: var(--boxel-sp-sm);
-        padding: var(--boxel-sp-sm);
+        display: inline-flex;
       }
       .loading-icon {
         display: inline-block;

--- a/packages/host/app/resources/inheritance-chain.ts
+++ b/packages/host/app/resources/inheritance-chain.ts
@@ -41,6 +41,10 @@ export class InheritanceChainResource extends Resource<Args> {
     return this._value;
   }
 
+  get isLoading() {
+    return this.load.isRunning;
+  }
+
   private load = task(
     async (
       url: string,

--- a/packages/host/app/resources/module-contents.ts
+++ b/packages/host/app/resources/module-contents.ts
@@ -99,10 +99,7 @@ export class ModuleContentsResource extends Resource<Args> {
   // it has to know this to distinguish the act of editing of a file and switching between definitions
   // when editing a file we don't want to introduce loading state, whereas when switching between definitions we do
   get isLoadingNewModule() {
-    return (
-      (this.load.isRunning && this.executableFile?.url !== this.state?.url) ??
-      false
-    );
+    return this.executableFile?.url !== this.state?.url ?? false;
   }
 
   get declarations() {


### PR DESCRIPTION
The idea is of this PR

- get loading state of spec to work inside its content
- change schema editor to do the same 
- schema editor to have the same inline style for playground, spec-preview and schema editor (the positioning is not the same tho). I guess we can also make schema editor work like the other but I notice the outer div with ...attributes means a lot of styling is gotten from the parent


**Schema editor**

Before: 

<img width="687" alt="Screenshot 2025-02-05 at 16 40 18" src="https://github.com/user-attachments/assets/8b2fa135-95a5-4db5-a78f-4dcade63d67d" />

After:

<img width="470" alt="Screenshot 2025-02-05 at 20 46 36" src="https://github.com/user-attachments/assets/a8fa30f7-64a7-4a91-b544-7f977fa8ab37" />


**Spec**

Before: Spec also worked like this where  but I hid it in a previous PR. 

After: 

<img width="471" alt="Screenshot 2025-02-05 at 20 49 31" src="https://github.com/user-attachments/assets/313943db-ceb0-4b66-8a47-6948088cac98" />



