### PR TITLE
Cs 6799 eliminate dialog creating spec

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -1015,8 +1015,6 @@ export default class CodeSubmode extends Component<Signature> {
                       {{#if this.showSpecPreview}}
                         <SpecPreview
                           @selectedDeclaration={{this.selectedDeclaration}}
-                          @createFile={{perform this.createFile}}
-                          @isCreateModalShown={{bool this.isCreateModalOpen}}
                           as |SpecPreviewTitle SpecPreviewContent|
                         >
                           <A.Item

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -57,7 +57,6 @@ interface Signature {
   Element: HTMLElement;
   Args: {
     selectedDeclaration?: ModuleDeclaration;
-    isCreateSpecInstanceRunning: boolean;
   };
   Blocks: {
     default: [

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -11,7 +11,7 @@ import DotIcon from '@cardstack/boxel-icons/dot';
 
 import LayoutList from '@cardstack/boxel-icons/layout-list';
 import StackIcon from '@cardstack/boxel-icons/stack';
-import { restartableTask } from 'ember-concurrency';
+import { task } from 'ember-concurrency';
 
 import {
   BoxelButton,
@@ -319,7 +319,7 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
     };
   }
 
-  private createSpecInstance = restartableTask(
+  private createSpecInstance = task(
     async (ref: ResolvedCodeRef, specType: SpecType) => {
       let relativeTo = new URL(ref.module);
       let maybeRef = codeRefWithAbsoluteURL(ref, relativeTo);

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -11,6 +11,7 @@ import DotIcon from '@cardstack/boxel-icons/dot';
 
 import LayoutList from '@cardstack/boxel-icons/layout-list';
 import StackIcon from '@cardstack/boxel-icons/stack';
+import { restartableTask } from 'ember-concurrency';
 
 import {
   BoxelButton,
@@ -23,30 +24,29 @@ import { LoadingIndicator } from '@cardstack/boxel-ui/components';
 
 import {
   type ResolvedCodeRef,
+  type Query,
+  type LooseSingleCardDocument,
   specRef,
   getCards,
-  type Query,
   isCardDef,
   isFieldDef,
 } from '@cardstack/runtime-common';
+import { codeRefWithAbsoluteURL } from '@cardstack/runtime-common/code-ref';
 
 import {
   CardOrFieldDeclaration,
   isCardOrFieldDeclaration,
   type ModuleDeclaration,
 } from '@cardstack/host/resources/module-contents';
-import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
+import CardService from '@cardstack/host/services/card-service';
+import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 import RealmService, {
   EnhancedRealmInfo,
 } from '@cardstack/host/services/realm';
-
 import type RealmServerService from '@cardstack/host/services/realm-server';
 
-import { type CardDef } from 'https://cardstack.com/base/card-api';
 import { Spec, type SpecType } from 'https://cardstack.com/base/spec';
-
-import { type FileType } from '../create-file-modal';
 
 import type { WithBoundArgs } from '@glint/template';
 
@@ -54,16 +54,7 @@ interface Signature {
   Element: HTMLElement;
   Args: {
     selectedDeclaration?: ModuleDeclaration;
-    createFile: (
-      fileType: FileType,
-      definitionClass?: {
-        displayName: string;
-        ref: ResolvedCodeRef;
-        specType?: SpecType;
-      },
-      sourceInstance?: CardDef,
-    ) => Promise<void>;
-    isCreateModalShown: boolean;
+    isCreateSpecInstanceRunning: boolean;
   };
   Blocks: {
     default: [
@@ -73,7 +64,7 @@ interface Signature {
         | 'specInstances'
         | 'selectedInstance'
         | 'createSpec'
-        | 'isCreateModalShown'
+        | 'isCreateSpecInstanceRunning'
       >,
       WithBoundArgs<
         typeof SpecPreviewContent,
@@ -92,8 +83,8 @@ interface TitleSignature {
     specInstances: Spec[];
     selectedInstance: Spec | null;
     showCreateSpecIntent: boolean;
-    createSpec: () => void;
-    isCreateModalShown: boolean;
+    createSpec: (event: MouseEvent) => void;
+    isCreateSpecInstanceRunning: boolean;
   };
 }
 
@@ -114,7 +105,7 @@ class SpecPreviewTitle extends GlimmerComponent<TitleSignature> {
         <BoxelButton
           @kind='primary'
           @size='small'
-          @disabled={{@isCreateModalShown}}
+          @loading={{@isCreateSpecInstanceRunning}}
           {{on 'click' @createSpec}}
           data-test-create-spec-button
         >
@@ -265,6 +256,8 @@ class SpecPreviewContent extends GlimmerComponent<ContentSignature> {
         gap: var(--boxel-sp-sm);
         height: 100%;
         width: 100%;
+      }
+      .spec-preview {
         padding: var(--boxel-sp-sm);
       }
       .create-spec-intent-message {
@@ -307,11 +300,8 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
   @service private declare operatorModeStateService: OperatorModeStateService;
   @service private declare realm: RealmService;
   @service private declare realmServer: RealmServerService;
+  @service private declare cardService: CardService;
   @tracked _selectedInstance?: Spec;
-
-  get realms() {
-    return this.realmServer.availableRealmURLs;
-  }
 
   private get getSelectedDeclarationAsCodeRef(): ResolvedCodeRef {
     if (!this.args.selectedDeclaration?.exportName) {
@@ -327,6 +317,44 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
         '',
       )}`,
     };
+  }
+
+  private createSpecInstance = restartableTask(
+    async (ref: ResolvedCodeRef, specType: SpecType) => {
+      let relativeTo = new URL(ref.module);
+      let maybeRef = codeRefWithAbsoluteURL(ref, relativeTo);
+      let realmURL = this.operatorModeStateService.realmURL;
+      if ('name' in maybeRef && 'module' in maybeRef) {
+        ref = maybeRef;
+      }
+      let doc: LooseSingleCardDocument = {
+        data: {
+          attributes: {
+            specType,
+            ref,
+          },
+          meta: {
+            adoptsFrom: specRef,
+            realmURL: realmURL.href,
+          },
+        },
+      };
+      try {
+        let card = await this.cardService.createFromSerialized(doc.data, doc);
+        if (!card) {
+          throw new Error(
+            `Failed to create card from ref "${ref.name}" from "${ref.module}"`,
+          );
+        }
+        await this.cardService.saveModel(card);
+      } catch (e: any) {
+        console.log('Error saving', e);
+      }
+    },
+  );
+
+  get realms() {
+    return this.realmServer.availableRealmURLs;
   }
 
   private get specQuery(): Query {
@@ -415,7 +443,8 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
     throw new Error('Unidentified spec');
   }
 
-  @action private createSpec() {
+  @action createSpec(event: MouseEvent) {
+    event.stopPropagation();
     if (!this.args.selectedDeclaration) {
       throw new Error('bug: no selected declaration');
     }
@@ -423,17 +452,9 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
       throw new Error('bug: no code ref');
     }
     let specType = this.guessSpecType(this.args.selectedDeclaration);
-    let displayName = this.getSelectedDeclarationAsCodeRef.name;
-    this.args.createFile(
-      {
-        id: 'spec-instance',
-        displayName: 'Boxel Specification', //display name in modal
-      },
-      {
-        displayName: displayName,
-        ref: this.getSelectedDeclarationAsCodeRef,
-        specType,
-      },
+    this.createSpecInstance.perform(
+      this.getSelectedDeclarationAsCodeRef,
+      specType,
     );
   }
 
@@ -456,7 +477,7 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
         specInstances=this.specInstances
         selectedInstance=this.selectedInstance
         createSpec=this.createSpec
-        isCreateModalShown=@isCreateModalShown
+        isCreateSpecInstanceRunning=this.createSpecInstance.isRunning
       )
       (component
         SpecPreviewContent

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -31,7 +31,10 @@ import {
   isCardDef,
   isFieldDef,
 } from '@cardstack/runtime-common';
-import { codeRefWithAbsoluteURL } from '@cardstack/runtime-common/code-ref';
+import {
+  codeRefWithAbsoluteURL,
+  isResolvedCodeRef,
+} from '@cardstack/runtime-common/code-ref';
 
 import {
   CardOrFieldDeclaration,
@@ -324,7 +327,7 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
       let relativeTo = new URL(ref.module);
       let maybeRef = codeRefWithAbsoluteURL(ref, relativeTo);
       let realmURL = this.operatorModeStateService.realmURL;
-      if ('name' in maybeRef && 'module' in maybeRef) {
+      if (isResolvedCodeRef(maybeRef)) {
         ref = maybeRef;
       }
       let doc: LooseSingleCardDocument = {

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -18,9 +18,9 @@ import {
   Pill,
   BoxelSelect,
   RealmIcon,
+  LoadingIndicator,
 } from '@cardstack/boxel-ui/components';
-
-import { LoadingIndicator } from '@cardstack/boxel-ui/components';
+import { not } from '@cardstack/boxel-ui/helpers';
 
 import {
   type ResolvedCodeRef,
@@ -75,6 +75,7 @@ interface Signature {
         | 'selectedInstance'
         | 'selectSpec'
         | 'isLoading'
+        | 'canWrite'
       >,
     ];
   };
@@ -162,6 +163,7 @@ interface ContentSignature {
     selectSpec: (spec: Spec) => void;
     showCreateSpecIntent: boolean;
     isLoading: boolean;
+    canWrite: boolean;
   };
 }
 
@@ -211,11 +213,12 @@ class SpecPreviewContent extends GlimmerComponent<ContentSignature> {
           Loading...
         </div>
       {{else if @showCreateSpecIntent}}
-        <div
-          class='create-spec-intent-message'
-          data-test-create-spec-intent-message
-        >
+        <div class='spec-intent-message' data-test-create-spec-intent-message>
           Create a Boxel Specification to be able to create new instances
+        </div>
+      {{else if (not @canWrite)}}
+        <div class='spec-intent-message' data-test-cannot-write-intent-message>
+          Cannot create Boxel Specification inside this realm
         </div>
       {{else}}
         <div class='spec-preview'>
@@ -262,7 +265,7 @@ class SpecPreviewContent extends GlimmerComponent<ContentSignature> {
       .spec-preview {
         padding: var(--boxel-sp-sm);
       }
-      .create-spec-intent-message {
+      .spec-intent-message {
         background-color: var(--boxel-200);
         color: var(--boxel-450);
         font-weight: 500;
@@ -389,7 +392,11 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
   }
 
   private get showCreateSpecIntent() {
-    return !this.specSearch.isLoading && this.specInstances.length === 0;
+    return (
+      !this.specSearch.isLoading &&
+      this.specInstances.length === 0 &&
+      this.canWrite
+    );
   }
 
   //TODO: Improve identification of isApp and isSkill
@@ -471,6 +478,10 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
     );
   }
 
+  get canWrite() {
+    return this.realm.canWrite(this.operatorModeStateService.realmURL.href);
+  }
+
   <template>
     {{yield
       (component
@@ -488,6 +499,7 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
         selectedInstance=this.selectedInstance
         selectSpec=this.selectSpec
         isLoading=this.specSearch.isLoading
+        canWrite=this.canWrite
       )
     }}
   </template>

--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -235,17 +235,6 @@ export default class CreateFileModal extends Component<Signature> {
                     >
                       Duplicate
                     </Button>
-                  {{else if (eq this.fileType.id 'spec-instance')}}
-                    <Button
-                      @kind='primary'
-                      @size='tall'
-                      @loading={{this.createSpecInstance.isRunning}}
-                      {{on 'click' (perform this.createSpecInstance)}}
-                      {{onKeyMod 'Enter'}}
-                      data-test-create-spec-instance
-                    >
-                      Create
-                    </Button>
                   {{else if
                     (or
                       (eq this.fileType.id 'card-definition')
@@ -762,58 +751,6 @@ export class ${className} extends ${exportName} {
       data: {
         meta: {
           adoptsFrom: ref,
-          realmURL: this.selectedRealmURL.href,
-        },
-      },
-    };
-
-    try {
-      let card = await this.cardService.createFromSerialized(doc.data, doc);
-
-      if (!card) {
-        throw new Error(
-          `Failed to create card from ref "${ref.name}" from "${ref.module}"`,
-        );
-      }
-      await this.cardService.saveModel(card);
-      this.currentRequest.newFileDeferred.fulfill(new URL(`${card.id}.json`));
-    } catch (e: any) {
-      console.log('Error saving', e);
-      this.saveError = `Error creating card instance: ${e.message}`;
-    }
-  });
-
-  private createSpecInstance = restartableTask(async () => {
-    if (!this.currentRequest) {
-      throw new Error(
-        `Cannot createCardInstance when there is no this.currentRequest`,
-      );
-    }
-    if (!this.definitionClass || !this.selectedRealmURL) {
-      throw new Error(
-        `bug: cannot create card instance without adoptsFrom ref and selected realm URL`,
-      );
-    }
-
-    let { ref, specType } = this.definitionClass;
-
-    let relativeTo = new URL(specRef.module);
-    let maybeRef = codeRefWithAbsoluteURL(ref, relativeTo);
-    if ('name' in maybeRef && 'module' in maybeRef) {
-      ref = maybeRef;
-    }
-    if (!ref) {
-      throw new Error(`bug: cannot create spec instance without a ref`);
-    }
-
-    let doc: LooseSingleCardDocument = {
-      data: {
-        attributes: {
-          specType,
-          ref,
-        },
-        meta: {
-          adoptsFrom: specRef,
           realmURL: this.selectedRealmURL.href,
         },
       },

--- a/packages/host/tests/acceptance/code-submode/spec-test.gts
+++ b/packages/host/tests/acceptance/code-submode/spec-test.gts
@@ -330,7 +330,10 @@ module('Spec preview', function (hooks) {
         await click('[data-test-create-spec-button]');
       },
     });
+    assert.dom('[data-test-title]').hasText('NewSkill');
     assert.dom('[data-test-exported-type]').hasText('card');
+    assert.dom('[data-test-exported-name]').hasText('NewSkill');
+    assert.dom('[data-test-module-href]').hasText(`${testRealmURL}new-skill`);
   });
   test('title does not default to "default"', async function (assert) {
     await visitOperatorMode({


### PR DESCRIPTION
Previously, when clicking Create for the boxel spec we navigated the user to a create-file-modal that gave the user the option which realm to create the spec at. Now, we just create it on-on-the-spot

For cards/fields that have no boxel spec, simply create spec instance in the same realm and not navigate the create-file-modal

