### PR TITLE
ci: Add playground feature flag for host previews

### DIFF
--- a/.github/workflows/pr-boxel-host.yml
+++ b/.github/workflows/pr-boxel-host.yml
@@ -64,6 +64,7 @@ jobs:
           AWS_S3_BUCKET: boxel-host-preview.stack.cards
           AWS_REGION: us-east-1
           AWS_CLOUDFRONT_DISTRIBUTION: EU4RGLH4EOCHJ
+          ENABLE_PLAYGROUND: true
         with:
           package: boxel-host
           environment: staging
@@ -94,6 +95,7 @@ jobs:
           AWS_S3_BUCKET: boxel-host-preview.boxel.ai
           AWS_REGION: us-east-1
           AWS_CLOUDFRONT_DISTRIBUTION: E2PZR9CIAW093B
+          ENABLE_PLAYGROUND: true
         with:
           package: boxel-host
           environment: production


### PR DESCRIPTION
I wished for this for ease of exercising #2122.

![hello-world gts in buck 2025-02-06 10-26-15](https://github.com/user-attachments/assets/c743639c-3f4a-4f84-b90b-a47b243b2927)

I couldn’t find an issue for the removal of the feature flag but this could be removed alongside that.