### PR TITLE
Playground instance chooser updates

### DIFF
--- a/packages/boxel-ui/addon/src/components/loading-indicator/index.gts
+++ b/packages/boxel-ui/addon/src/components/loading-indicator/index.gts
@@ -28,6 +28,7 @@ const LoadingIndicator: TemplateOnlyComponent<Signature> = <template>
         --boxel-loading-indicator-size,
         var(--boxel-icon-sm)
       );
+      display: inline-block;
       width: var(--loading-indicator-size);
       height: var(--loading-indicator-size);
       flex-shrink: 0;

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -501,11 +501,7 @@ export default class CodeSubmode extends Component<Signature> {
     if (!isPlaygroundEnabled) {
       return false;
     }
-    let declaration = this.selectedDeclaration;
-    if (!declaration || !('cardOrField' in declaration)) {
-      return false;
-    }
-    return isCardDef(declaration.cardOrField);
+    return isCardDef(this.selectedCardOrField?.cardOrField);
   }
 
   get showSpecPreview() {

--- a/packages/host/app/components/operator-mode/code-submode/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground-panel.gts
@@ -91,19 +91,16 @@ interface PlaygroundContentSignature {
 class PlaygroundPanelContent extends Component<PlaygroundContentSignature> {
   <template>
     <div class='playground-panel-content'>
-      <div class='instance-chooser-container'>
-        <PrerenderedCardSearch
-          @query={{this.query}}
-          @format='fitted'
-          @realms={{this.recentRealms}}
-        >
-          <:loading>
-            <LoadingIndicator
-              class='loading-icon'
-              @color='var(--boxel-light)'
-            />
-          </:loading>
-          <:response as |cards|>
+      <PrerenderedCardSearch
+        @query={{this.query}}
+        @format='fitted'
+        @realms={{this.recentRealms}}
+      >
+        <:loading>
+          <LoadingIndicator class='loading-icon' @color='var(--boxel-light)' />
+        </:loading>
+        <:response as |cards|>
+          <div class='instance-chooser-container'>
             <BoxelSelect
               class='instance-chooser'
               @options={{cards}}
@@ -121,9 +118,9 @@ class PlaygroundPanelContent extends Component<PlaygroundContentSignature> {
             >
               <card.component />
             </BoxelSelect>
-          </:response>
-        </PrerenderedCardSearch>
-      </div>
+          </div>
+        </:response>
+      </PrerenderedCardSearch>
       <div class='preview-area'>
         {{#if this.card}}
           {{#if (or (eq this.format 'isolated') (eq this.format 'edit'))}}

--- a/packages/host/app/components/operator-mode/code-submode/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground-panel.gts
@@ -103,6 +103,7 @@ class PlaygroundPanelContent extends Component<PlaygroundContentSignature> {
           <div class='instance-chooser-container'>
             <BoxelSelect
               class='instance-chooser'
+              @dropdownClass='instances-dropdown-content'
               @options={{cards}}
               @selected={{this.card}}
               @selectedItemComponent={{if
@@ -111,12 +112,15 @@ class PlaygroundPanelContent extends Component<PlaygroundContentSignature> {
                   SelectedItem title=(getItemTitle this.card @displayName)
                 )
               }}
+              @renderInPlace={{true}}
               @onChange={{this.onSelect}}
               @placeholder='Please Select'
               data-test-instance-chooser
               as |card|
             >
-              <card.component />
+              <CardContainer class='card' @displayBoundaries={{true}}>
+                <card.component />
+              </CardContainer>
             </BoxelSelect>
           </div>
         </:response>
@@ -175,10 +179,24 @@ class PlaygroundPanelContent extends Component<PlaygroundContentSignature> {
         display: flex;
         justify-content: center;
       }
+      .instance-chooser-container > :deep(.ember-basic-dropdown) {
+        max-width: 100%;
+      }
       .instance-chooser {
-        max-width: 405px;
+        width: 405px;
+        max-width: 100%;
         height: var(--boxel-form-control-height);
         box-shadow: 0 5px 10px 0 rgba(0 0 0 / 40%);
+      }
+      :deep(.instances-dropdown-content > .ember-power-select-options) {
+        max-height: 20rem;
+      }
+      .card {
+        height: 75px;
+        width: 375px;
+        max-width: 100%;
+        container-name: fitted-card;
+        container-type: size;
       }
       .preview-area {
         flex-grow: 1;

--- a/packages/host/app/components/operator-mode/code-submode/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground-panel.gts
@@ -127,7 +127,7 @@ class PlaygroundPanelContent extends Component<PlaygroundContentSignature> {
       <div class='preview-area'>
         {{#if this.card}}
           {{#if (or (eq this.format 'isolated') (eq this.format 'edit'))}}
-            <CardContainer class='preview-container'>
+            <CardContainer class='preview-container full-height-preview'>
               {{#let (this.realm.info this.card.id) as |realmInfo|}}
                 <CardHeader
                   class='preview-header'
@@ -165,7 +165,11 @@ class PlaygroundPanelContent extends Component<PlaygroundContentSignature> {
       .playground-panel-content {
         display: flex;
         flex-direction: column;
+        gap: var(--boxel-sp);
         min-height: 100%;
+      }
+      .loading-icon {
+        height: var(--boxel-form-control-height);
       }
       .instance-chooser-container {
         position: sticky;
@@ -179,12 +183,19 @@ class PlaygroundPanelContent extends Component<PlaygroundContentSignature> {
         height: var(--boxel-form-control-height);
         box-shadow: 0 5px 10px 0 rgba(0 0 0 / 40%);
       }
-      .loading-icon {
-        height: var(--boxel-form-control-height);
+      .preview-area {
+        flex-grow: 1;
+        z-index: 0;
+        display: flex;
+        flex-direction: column;
       }
       .preview-container {
         height: auto;
-        z-index: 0;
+      }
+      .full-height-preview {
+        flex-grow: 1;
+        display: grid;
+        grid-auto-rows: max-content 1fr;
       }
       .preview-header {
         background-color: var(--boxel-100);
@@ -194,12 +205,6 @@ class PlaygroundPanelContent extends Component<PlaygroundContentSignature> {
       .preview {
         box-shadow: none;
         border-radius: 0;
-      }
-      .playground-panel-content {
-        display: flex;
-        flex-direction: column;
-        gap: var(--boxel-sp);
-        min-height: 100%;
       }
       .format-chooser {
         position: sticky;

--- a/packages/host/app/components/operator-mode/code-submode/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground-panel.gts
@@ -6,6 +6,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 import { task } from 'ember-concurrency';
+import window from 'ember-window-mock';
 import { TrackedObject } from 'tracked-built-ins';
 
 import {
@@ -20,11 +21,11 @@ import { Eye, IconCode, IconLink } from '@cardstack/boxel-ui/icons';
 import {
   cardTypeDisplayName,
   cardTypeIcon,
-  identifyCard,
   type Query,
   type ResolvedCodeRef,
 } from '@cardstack/runtime-common';
-import { getCard as getCardResource } from '@cardstack/host/resources/card-resource';
+
+import { getCard } from '@cardstack/host/resources/card-resource';
 
 import { getCodeRef, type CardType } from '@cardstack/host/resources/card-type';
 import { ModuleContentsResource } from '@cardstack/host/resources/module-contents';
@@ -33,11 +34,12 @@ import type OperatorModeStateService from '@cardstack/host/services/operator-mod
 import type RealmService from '@cardstack/host/services/realm';
 import type RealmServerService from '@cardstack/host/services/realm-server';
 import type RecentFilesService from '@cardstack/host/services/recent-files-service';
+
+import type { CardDef, Format } from 'https://cardstack.com/base/card-api';
+
 import PrerenderedCardSearch, {
   type PrerenderedCard,
 } from '../../prerendered-card-search';
-
-import type { CardDef, Format } from 'https://cardstack.com/base/card-api';
 
 import Preview from '../../preview';
 
@@ -263,7 +265,7 @@ class PlaygroundPanelContent extends Component<PlaygroundContentSignature> {
     };
   }
 
-  private cardResource = getCardResource(this, () =>
+  private cardResource = getCard(this, () =>
     this.playgroundSelections[this.args.moduleId]?.replace(/\.json$/, ''),
   );
 

--- a/packages/host/tests/acceptance/code-submode/playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/playground-test.gts
@@ -1,5 +1,5 @@
 import { click } from '@ember/test-helpers';
-
+import window from 'ember-window-mock';
 import { module, test } from 'qunit';
 
 import {
@@ -193,6 +193,17 @@ module('Acceptance | code-submode | playground panel', function (hooks) {
         },
       },
     });
+    window.localStorage.setItem(
+      'recent-files',
+      JSON.stringify([
+        [testRealmURL, 'BlogPost/mad-hatter.json'],
+        [testRealmURL, 'Category/city-design.json'],
+        [testRealmURL, 'Category/future-tech.json'],
+        [testRealmURL, 'BlogPost/remote-work.json'],
+        [testRealmURL, 'BlogPost/urban-living.json'],
+        [testRealmURL, 'Author/jane-doe.json'],
+      ]),
+    );
   });
 
   test('can render playground panel when a card def is selected', async function (assert) {
@@ -247,18 +258,18 @@ module('Acceptance | code-submode | playground panel', function (hooks) {
     await click('[data-test-accordion-item="playground"] button');
     await click('[data-test-instance-chooser]');
     assert.dom('[data-option-index]').exists({ count: 2 });
-    assert.dom('[data-option-index="0"]').hasText('City Design');
+    assert.dom('[data-option-index="0"]').containsText('City Design');
     await click('[data-option-index="0"]');
-    assert.dom('[data-test-selected-item]').hasText('City Design');
+    assert.dom('[data-test-selected-item]').containsText('City Design');
 
     await click(
       '[data-test-in-this-file-selector] [data-test-boxel-selector-item-text="BlogPost"]',
     );
     await click('[data-test-instance-chooser]');
     assert.dom('[data-option-index]').exists({ count: 3 });
-    assert.dom('[data-option-index="0"]').hasText('Mad As a Hatter');
+    assert.dom('[data-option-index="0"]').containsText('Mad As a Hatter');
     await click('[data-option-index="0"]');
-    assert.dom('[data-test-selected-item]').hasText('Mad As a Hatter');
+    assert.dom('[data-test-selected-item]').containsText('Mad As a Hatter');
   });
 
   test('can update the instance chooser when a different file is opened', async function (assert) {
@@ -269,17 +280,17 @@ module('Acceptance | code-submode | playground panel', function (hooks) {
     await click('[data-test-accordion-item="playground"] button');
     await click('[data-test-instance-chooser]');
     assert.dom('[data-option-index]').exists({ count: 2 });
-    assert.dom('[data-option-index="0"]').hasText('City Design');
+    assert.dom('[data-option-index="0"]').containsText('City Design');
     await click('[data-option-index="0"]');
-    assert.dom('[data-test-selected-item]').hasText('City Design');
+    assert.dom('[data-test-selected-item]').containsText('City Design');
 
     await click('[data-test-file-browser-toggle]');
     await click('[data-test-file="author.gts"]');
     await click('[data-test-instance-chooser]');
     assert.dom('li.ember-power-select-option').exists({ count: 1 });
-    assert.dom('[data-option-index="0"]').hasText('Jane Doe');
+    assert.dom('[data-option-index="0"]').containsText('Jane Doe');
     await click('[data-option-index="0"]');
-    assert.dom('[data-test-selected-item]').hasText('Jane Doe');
+    assert.dom('[data-test-selected-item]').containsText('Jane Doe');
   });
 
   test('can display selected card in isolated format', async function (assert) {


### PR DESCRIPTION
- Populate instance chooser via recent files of the correct card type
- Persist selected instances in local storage
- Display fitted view of cards in instance chooser dropdown

Note: Added a skipped test for the live preview issue seen on cards with linked fields

<img width="659" alt="playground-latest" src="https://github.com/user-attachments/assets/6ba60d2d-e8fe-4fce-bedc-4bff23db7999" />