### PR TITLE
Avoid reprocessing matrix events

### DIFF
--- a/packages/host/app/resources/room.ts
+++ b/packages/host/app/resources/room.ts
@@ -138,7 +138,7 @@ export class RoomResource extends Resource<Args> {
     return this.members.filter((m) => m.membership === 'join');
   }
 
-  private get events() {
+  private get events(): DiscreteMatrixEvent[] {
     return this.matrixRoom?.events ?? [];
   }
 

--- a/packages/host/app/resources/room.ts
+++ b/packages/host/app/resources/room.ts
@@ -99,6 +99,7 @@ export class RoomResource extends Resource<Args> {
   }
 
   private resetCache() {
+    this._processedEvents.clear();
     this._messageCache = new TrackedMap();
     this._memberCache = new TrackedMap();
     this._fragmentCache = new TrackedMap();


### PR DESCRIPTION
Currently a single message to the bot and single chunk reply results in reprocessing the entire event list 14-15 times for a room. This skips which events we've processed before.

To deal with things that are out of order, this actually just reprocesses events from the first unseen event. 

Even with this we still seem to try calling load room quite a lot, this PR just lowers the cost of doing so, and makes it a bit simpler where we want to start doing auto calling of commands.

Potentially this needs to change to more strictly process the events once.

