### PR TITLE
Add FileDef for purpose of uploading/attaching files

### DIFF
--- a/packages/base/file-api.gts
+++ b/packages/base/file-api.gts
@@ -1,0 +1,39 @@
+import FileIcon from '@cardstack/boxel-icons/file';
+import {
+  BaseDef,
+  BaseDefComponent,
+  Component,
+  StringField,
+  contains,
+  field,
+} from './card-api';
+
+class View extends Component<typeof FileDef> {
+  <template>
+    {{@model.name}}
+  </template>
+}
+
+export class FileDef extends BaseDef {
+  static displayName = 'File';
+  static icon = FileIcon;
+
+  @field sourceUrl = contains(StringField);
+  @field url = contains(StringField);
+  @field name = contains(StringField);
+  @field type = contains(StringField);
+
+  static embedded: BaseDefComponent = View;
+  static fitted: BaseDefComponent = View;
+  static isolated: BaseDefComponent = View;
+  static atom: BaseDefComponent = View;
+
+  serialize() {
+    return {
+      sourceUrl: this.sourceUrl,
+      url: this.url,
+      name: this.name,
+      type: this.type,
+    };
+  }
+}


### PR DESCRIPTION
This is extracted from https://github.com/cardstack/boxel/pull/2128 to break it down into more manageable PRs.

It introduces `FileDef`, which we have planned to be a part of the indexing process when uploading files to the realm, but currently the use case for this is narrowed down to simply be be a container for representing files that will be attached to the AI Assistant (these do not have to be indexed). The advantage of having `FileDef` for this case  is to have delegated rendering so that we can pass the files around and make use of different rendering formats (for example the atom view will probably be used in the file pill, and embedded in the room thread history)

We have already reviewed this with @lukemelia in a pairing session and we thought it was a good first step towards eventually supporting a full fledged `FileDef` as described in the document attached in [CS-7938](https://linear.app/cardstack/issue/CS-7938/introduce-basic-filedef-as-api-for-attaching-files)