### PR TITLE
ci: Add namespace for realm server log artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -138,7 +138,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: realm-server-log-${{ matrix.shardIndex }}
+          name: matrix-test-realm-server-log-${{ matrix.shardIndex }}
           path: /tmp/server.log
           retention-days: 30
 
@@ -291,7 +291,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: realm-server-log-${{matrix.testModule}}
+          name: realm-server-test-realm-server-log-${{matrix.testModule}}
           path: /tmp/server.log
           retention-days: 30
 


### PR DESCRIPTION
The main workflow has a lot of artifacts attached, this should help clarify what jobs produced them. Before:

<img width="738" alt="boxel@88164a5 2025-02-12 12-13-08" src="https://github.com/user-attachments/assets/cad4330e-7e62-44a7-960e-fe3bd384d034" />

After:

<img width="740" alt="boxel@881d5d1 2025-02-12 12-35-05" src="https://github.com/user-attachments/assets/e0d182cd-d65e-420c-9b2e-d9624c2e8a3d" />
