### PR TITLE
Add code copy button to AI assistant

### DIFF
--- a/packages/ai-bot/helpers.ts
+++ b/packages/ai-bot/helpers.ts
@@ -42,7 +42,8 @@ You may make multiple function calls, all calls are gated by the user so multipl
 If a user asks you about things in the world, use your existing knowledge to help them. Only if necessary, add a *small* caveat at the end of your message to explain that you do not have live external data. \
 \
 If you need access to the cards the user can see, you can ask them to attach the cards. \
-If you encounter JSON structures, please enclose them within backticks to ensure they are displayed stylishly in Markdown.';
+If you encounter JSON structures, please enclose them within backticks to ensure they are displayed stylishly in Markdown. \
+If you encounter code, please enclose the code within triple backticks and indicate the language after the opening backticks so that the code is displayed stylishly in Markdown. ';
 
 export const SKILL_INSTRUCTIONS_MESSAGE =
   '\nThe user has given you the following instructions. You must obey these instructions when responding to the user:\n';

--- a/packages/ai-bot/helpers.ts
+++ b/packages/ai-bot/helpers.ts
@@ -43,7 +43,7 @@ If a user asks you about things in the world, use your existing knowledge to hel
 \
 If you need access to the cards the user can see, you can ask them to attach the cards. \
 If you encounter JSON structures, please enclose them within backticks to ensure they are displayed stylishly in Markdown. \
-If you encounter code, please enclose the code within triple backticks and indicate the language after the opening backticks so that the code is displayed stylishly in Markdown. ';
+If you encounter code, please enclose the code within triple backticks and indicate the language after the opening backticks so that the code is displayed stylishly in Markdown.';
 
 export const SKILL_INSTRUCTIONS_MESSAGE =
   '\nThe user has given you the following instructions. You must obey these instructions when responding to the user:\n';

--- a/packages/ai-bot/helpers.ts
+++ b/packages/ai-bot/helpers.ts
@@ -43,7 +43,7 @@ If a user asks you about things in the world, use your existing knowledge to hel
 \
 If you need access to the cards the user can see, you can ask them to attach the cards. \
 If you encounter JSON structures, please enclose them within backticks to ensure they are displayed stylishly in Markdown. \
-If you encounter code, please enclose the code within triple backticks and indicate the language after the opening backticks so that the code is displayed stylishly in Markdown.';
+If you encounter code, please indent code using 2 spaces per tab stop and enclose the code within triple backticks and indicate the language after the opening backticks so that the code is displayed stylishly in Markdown.';
 
 export const SKILL_INSTRUCTIONS_MESSAGE =
   '\nThe user has given you the following instructions. You must obey these instructions when responding to the user:\n';

--- a/packages/host/app/components/matrix/room-message.gts
+++ b/packages/host/app/components/matrix/room-message.gts
@@ -166,11 +166,7 @@ export default class RoomMessage extends Component<Signature> {
         justify-content: center;
         height: min-content;
         align-items: center;
-        border-radius: 100px;
         white-space: nowrap;
-        transition:
-          background-color var(--boxel-transition),
-          border var(--boxel-transition);
         min-height: var(--boxel-button-min-height);
         min-width: var(--boxel-button-min-width, 5rem);
       }

--- a/packages/host/app/components/matrix/room-message.gts
+++ b/packages/host/app/components/matrix/room-message.gts
@@ -1,3 +1,4 @@
+import { hash } from '@ember/helper';
 import { service } from '@ember/service';
 import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
@@ -104,7 +105,9 @@ export default class RoomMessage extends Component<Signature> {
         id='message-container-{{@index}}'
         class='room-message'
         @formattedMessage={{htmlSafe
-          (markdownToHtml @message.formattedMessage)
+          (markdownToHtml
+            @message.formattedMessage (hash includeCodeCopyButton=true)
+          )
         }}
         @datetime={{@message.created}}
         @index={{@index}}

--- a/packages/host/app/components/matrix/room-message.gts
+++ b/packages/host/app/components/matrix/room-message.gts
@@ -15,6 +15,7 @@ import { bool } from '@cardstack/boxel-ui/helpers';
 import { markdownToHtml } from '@cardstack/runtime-common';
 
 import { Message } from '@cardstack/host/lib/matrix-classes/message';
+import interactiveMarkdown from '@cardstack/host/modifiers/interactive-markdown';
 import CommandService from '@cardstack/host/services/command-service';
 import type MatrixService from '@cardstack/host/services/matrix-service';
 import { type MonacoSDK } from '@cardstack/host/services/monaco-service';
@@ -99,6 +100,7 @@ export default class RoomMessage extends Component<Signature> {
     }}
     {{#if this.resources}}
       <AiAssistantMessage
+        {{interactiveMarkdown}}
         id='message-container-{{@index}}'
         class='room-message'
         @formattedMessage={{htmlSafe
@@ -144,6 +146,39 @@ export default class RoomMessage extends Component<Signature> {
     <style scoped>
       .room-message {
         --ai-assistant-message-padding: var(--boxel-sp);
+      }
+
+      /* we are cribbing the boxel-ui style here as we have a rather 
+      awkward way that we insert the copy button */
+      :deep(.code-copy-button) {
+        --spacing: calc(1rem / 1.333);
+
+        color: var(--boxel-highlight);
+        background: none;
+        border: none;
+        font: 600 var(--boxel-font-xs);
+        padding: 0;
+        margin-bottom: var(--spacing);
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: var(--spacing);
+        letter-spacing: var(--boxel-lsp-xs);
+        justify-content: center;
+        height: min-content;
+        align-items: center;
+        border-radius: 100px;
+        white-space: nowrap;
+        transition:
+          background-color var(--boxel-transition),
+          border var(--boxel-transition);
+        min-height: var(--boxel-button-min-height);
+        min-width: var(--boxel-button-min-width, 5rem);
+      }
+      :deep(.code-copy-button .copy-text) {
+        color: transparent;
+      }
+      :deep(.code-copy-button .copy-text:hover) {
+        color: var(--boxel-highlight);
       }
     </style>
   </template>

--- a/packages/host/app/modifiers/interactive-markdown.ts
+++ b/packages/host/app/modifiers/interactive-markdown.ts
@@ -1,0 +1,50 @@
+import Modifier from 'ember-modifier';
+
+export default class InteractiveMarkdownModifier extends Modifier {
+  async modify(element: Element): Promise<void> {
+    let codeBlocks = document.querySelectorAll(
+      `#${element.id} pre[data-codeblock]`,
+    );
+    if (!codeBlocks) {
+      return;
+    }
+
+    for (let codeBlock of codeBlocks) {
+      let copyButton = document.createElement('button') as HTMLButtonElement;
+      copyButton.setAttribute('class', 'code-copy-button');
+      copyButton.onclick = () =>
+        navigator.clipboard.writeText((codeBlock as HTMLPreElement).innerText);
+      copyButton.insertBefore(createCopyIcon(), null);
+      let text = document.createElement('span') as HTMLSpanElement;
+      text.setAttribute('class', 'copy-text');
+      text.innerText = 'Copy to clipboard';
+      copyButton.insertBefore(text, null);
+      codeBlock.parentElement?.insertBefore(copyButton, codeBlock);
+    }
+  }
+}
+
+// not sure how we could use a component here instead, so using the raw HTML
+function createCopyIcon() {
+  let html = `<svg
+    xmlns='http://www.w3.org/2000/svg'
+    width='16'
+    height='16'
+    fill='none'
+    stroke='currentColor'
+    stroke-linecap='round'
+    stroke-linejoin='round'
+    stroke-width='3'
+    class='lucide lucide-copy'
+    viewBox='0 0 24 24'
+    ...attributes
+  ><rect width='14' height='14' x='8' y='8' rx='2' ry='2' /><path
+      d='M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2'
+    /></svg>`;
+  const template = document.createElement('template');
+  template.innerHTML = html;
+  let copyIcon = template.content.childNodes.item(0) as HTMLElement;
+  copyIcon.setAttribute('role', 'presentation');
+  copyIcon.setAttribute('aria-hidden', 'true');
+  return copyIcon;
+}

--- a/packages/host/app/modifiers/interactive-markdown.ts
+++ b/packages/host/app/modifiers/interactive-markdown.ts
@@ -1,50 +1,34 @@
 import Modifier from 'ember-modifier';
 
 export default class InteractiveMarkdownModifier extends Modifier {
-  async modify(element: Element): Promise<void> {
-    let codeBlocks = document.querySelectorAll(
-      `#${element.id} pre[data-codeblock]`,
-    );
-    if (!codeBlocks) {
+  async modify(): Promise<void> {
+    let copyButtons = document.querySelectorAll(`.code-copy-button`);
+    if (!copyButtons || copyButtons.length === 0) {
       return;
     }
-
-    for (let codeBlock of codeBlocks) {
-      let copyButton = document.createElement('button') as HTMLButtonElement;
-      copyButton.setAttribute('class', 'code-copy-button');
-      copyButton.onclick = () =>
-        navigator.clipboard.writeText((codeBlock as HTMLPreElement).innerText);
-      copyButton.insertBefore(createCopyIcon(), null);
-      let text = document.createElement('span') as HTMLSpanElement;
-      text.setAttribute('class', 'copy-text');
-      text.innerText = 'Copy to clipboard';
-      copyButton.insertBefore(text, null);
-      codeBlock.parentElement?.insertBefore(copyButton, codeBlock);
+    for (let copyButton of copyButtons) {
+      if ((copyButton as HTMLButtonElement).onclick === null) {
+        (copyButton as HTMLButtonElement).onclick = (event) => {
+          let buttonElement = event.currentTarget as HTMLElement;
+          let codeBlock = buttonElement.nextElementSibling;
+          if (codeBlock) {
+            navigator.clipboard
+              .writeText((codeBlock as HTMLPreElement).innerText)
+              .then(() => {
+                let svg = buttonElement.children[0];
+                let copyText = buttonElement.children[1];
+                buttonElement.replaceChildren(
+                  svg,
+                  document.createTextNode('Copied'),
+                );
+                setTimeout(
+                  () => buttonElement.replaceChildren(svg, copyText),
+                  2000,
+                );
+              });
+          }
+        };
+      }
     }
   }
-}
-
-// not sure how we could use a component here instead, so using the raw HTML
-function createCopyIcon() {
-  let html = `<svg
-    xmlns='http://www.w3.org/2000/svg'
-    width='16'
-    height='16'
-    fill='none'
-    stroke='currentColor'
-    stroke-linecap='round'
-    stroke-linejoin='round'
-    stroke-width='3'
-    class='lucide lucide-copy'
-    viewBox='0 0 24 24'
-    ...attributes
-  ><rect width='14' height='14' x='8' y='8' rx='2' ry='2' /><path
-      d='M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2'
-    /></svg>`;
-  const template = document.createElement('template');
-  template.innerHTML = html;
-  let copyIcon = template.content.childNodes.item(0) as HTMLElement;
-  copyIcon.setAttribute('role', 'presentation');
-  copyIcon.setAttribute('aria-hidden', 'true');
-  return copyIcon;
 }

--- a/packages/host/tests/integration/components/ai-assistant-panel-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel-test.gts
@@ -2597,11 +2597,7 @@ module('Integration | ai-assistant-panel', function (hooks) {
       .exists('View Code panel should remain open');
   });
 
-  // WARNING DUE TO CHROME SECURITY CONSTRAINTS THIS TEST
-  // ONLY WORKS WHEN THE DEV CONSOLE IS CLOSED AND THE
-  // WINDOW RUNNING THE TESTS IS FOCUSED!!
-  test('it can copy code blocks to the clipboard (make sure window is focused and dev console is closed)', async function (assert) {
-    await navigator.clipboard.writeText(''); // pardon this troll, clearing the clipboard for the test
+  test('it shows the copy code to clipboard button', async function (assert) {
     let roomId = await renderAiAssistantPanel(`${testRealmURL}Person/fadhlan`);
     await simulateRemoteMessage(
       roomId,
@@ -2623,12 +2619,9 @@ module('Integration | ai-assistant-panel', function (hooks) {
     assert
       .dom('button.code-copy-button')
       .exists('the copy code to clipboard button exists');
-    await click('button.code-copy-button');
-    let clipboard = await navigator.clipboard.readText();
-    assert.strictEqual(
-      clipboard,
-      `console.log("hello world");`,
-      'the clipboard was updated with the code',
-    );
+
+    // the chrome security model prevents the clipboard API
+    // from working when tests are run in a headless mode, so we are unable to
+    // assert the button actually copies contents to the clipboard
   });
 });

--- a/packages/runtime-common/marked-sync.ts
+++ b/packages/runtime-common/marked-sync.ts
@@ -2,7 +2,17 @@ import { marked } from 'marked';
 import { sanitizeHtml } from './dompurify-runtime';
 
 export function markedSync(markdown: string) {
-  return marked(markdown, { async: false }) as string;
+  return marked
+    .use({
+      renderer: {
+        code(code, language) {
+          return `
+            <pre class="language-${language}" data-codeblock>${code}</pre>
+          `;
+        },
+      },
+    })
+    .parse(markdown, { async: false }) as string;
 }
 
 export function markdownToHtml(markdown: string | null | undefined): string {

--- a/packages/runtime-common/marked-sync.ts
+++ b/packages/runtime-common/marked-sync.ts
@@ -1,20 +1,53 @@
 import { marked } from 'marked';
 import { sanitizeHtml } from './dompurify-runtime';
 
-export function markedSync(markdown: string) {
+interface Options {
+  includeCodeCopyButton?: true;
+}
+
+export function markedSync(markdown: string, opts?: Options) {
   return marked
     .use({
       renderer: {
         code(code, language) {
-          return `
-            <pre class="language-${language}" data-codeblock>${code}</pre>
-          `;
+          let html: string[] = [];
+          if (opts?.includeCodeCopyButton) {
+            html.push(`
+              <button class="code-copy-button">
+                <svg
+                  xmlns='http://www.w3.org/2000/svg'
+                  width='16'
+                  height='16'
+                  fill='none'
+                  stroke='currentColor'
+                  stroke-linecap='round'
+                  stroke-linejoin='round'
+                  stroke-width='3'
+                  class='lucide lucide-copy'
+                  viewBox='0 0 24 24'
+                  role='presentation'
+                  aria-hidden='true'
+                  ...attributes
+                ><rect width='14' height='14' x='8' y='8' rx='2' ry='2' /><path
+                    d='M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2'
+                  />
+                </svg>
+                <span class="copy-text">Copy to clipboard</span>
+              </button>`);
+          }
+          html.push(
+            `<pre class="language-${language}" data-codeblock>${code}</pre>`,
+          );
+          return html.join('\n');
         },
       },
     })
     .parse(markdown, { async: false }) as string;
 }
 
-export function markdownToHtml(markdown: string | null | undefined): string {
-  return markdown ? sanitizeHtml(markedSync(markdown)) : '';
+export function markdownToHtml(
+  markdown: string | null | undefined,
+  opts?: Options,
+): string {
+  return markdown ? sanitizeHtml(markedSync(markdown, opts)) : '';
 }


### PR DESCRIPTION
We use a modifier to add a copy button into the AI assistant when code blocks exist.

The API for the clipboard has security requirements prevent the ability to use the clipboard API when chrome is run in headless mode (when it is not run in headless mode there are also other silly constraints that make automated testing awkward). so our tests just assert that the button appears.

![copy-button](https://github.com/user-attachments/assets/2a82c7c3-7b69-49a8-a9ee-af18bed984e4)
