### PR TITLE
CS-7991 Sort crm edit fields

### DIFF
--- a/packages/experiments-realm/crm/account.gts
+++ b/packages/experiments-realm/crm/account.gts
@@ -11,6 +11,7 @@ import {
   linksToMany,
   StringField,
 } from 'https://cardstack.com/base/card-api';
+import { FieldContainer } from '@cardstack/boxel-ui/components';
 import { Address as AddressField } from '../address';
 import { Company } from './company';
 import { Contact } from './contact';
@@ -41,6 +42,39 @@ const taskSource = {
   module: new URL('./task', import.meta.url).href,
   name: 'CRMTask',
 };
+
+class EditTemplate extends Component<typeof Account> {
+  <template>
+    <div class='account-form'>
+      <FieldContainer @label='Company Name'>
+        <@fields.company />
+      </FieldContainer>
+      <FieldContainer @label='Primary Contact'>
+        <@fields.primaryContact />
+      </FieldContainer>
+      <FieldContainer @label='Contacts'>
+        <@fields.contacts />
+      </FieldContainer>
+      <FieldContainer @label='Shipping Address'>
+        <@fields.shippingAddress />
+      </FieldContainer>
+      <FieldContainer @label='Billing Address'>
+        <@fields.billingAddress />
+      </FieldContainer>
+      <FieldContainer @label='Urgency Tag'>
+        <@fields.urgencyTag />
+      </FieldContainer>
+    </div>
+    <style scoped>
+      .account-form {
+        display: flex;
+        flex-direction: column;
+        gap: var(--boxel-sp-lg);
+        padding: var(--boxel-sp-xl);
+      }
+    </style>
+  </template>
+}
 
 class IsolatedTemplate extends Component<typeof Account> {
   get hasCompanyInfo() {
@@ -1309,6 +1343,7 @@ export class Account extends CardDef {
     },
   });
 
+  static edit = EditTemplate;
   static isolated = IsolatedTemplate;
   static embedded = EmbeddedTemplate;
   static fitted = FittedTemplate;

--- a/packages/experiments-realm/crm/company.gts
+++ b/packages/experiments-realm/crm/company.gts
@@ -10,6 +10,7 @@ import {
   field,
   contains,
 } from 'https://cardstack.com/base/card-api';
+import { FieldContainer } from '@cardstack/boxel-ui/components';
 import BuildingIcon from '@cardstack/boxel-icons/building';
 
 class CompanyEditTemplate extends Component<typeof Company> {

--- a/packages/experiments-realm/crm/company.gts
+++ b/packages/experiments-realm/crm/company.gts
@@ -12,6 +12,39 @@ import {
 } from 'https://cardstack.com/base/card-api';
 import BuildingIcon from '@cardstack/boxel-icons/building';
 
+class CompanyEditTemplate extends Component<typeof Company> {
+  <template>
+    <div class='company-form'>
+      <FieldContainer @label='Name'>
+        <@fields.name />
+      </FieldContainer>
+      <FieldContainer @label='Industry'>
+        <@fields.industry />
+      </FieldContainer>
+      <FieldContainer @label='Headquarters Address'>
+        <@fields.headquartersAddress />
+      </FieldContainer>
+      <FieldContainer @label='Phone Number'>
+        <@fields.phone />
+      </FieldContainer>
+      <FieldContainer @label='Website'>
+        <@fields.website />
+      </FieldContainer>
+      <FieldContainer @label='Stock Symbol'>
+        <@fields.stockSymbol />
+      </FieldContainer>
+    </div>
+    <style scoped>
+      .company-form {
+        display: flex;
+        flex-direction: column;
+        gap: var(--boxel-sp-lg);
+        padding: var(--boxel-sp-xl);
+      }
+    </style>
+  </template>
+}
+
 class ViewCompanyTemplate extends Component<typeof Company> {
   <template>
     <div class='company-group'>
@@ -39,6 +72,7 @@ export class Company extends CardDef {
     },
   });
 
+  static edit = CompanyEditTemplate;
   static embedded = ViewCompanyTemplate;
   static atom = ViewCompanyTemplate;
 }

--- a/packages/experiments-realm/crm/contact.gts
+++ b/packages/experiments-realm/crm/contact.gts
@@ -8,7 +8,7 @@ import {
   containsMany,
 } from 'https://cardstack.com/base/card-api';
 
-import { Avatar } from '@cardstack/boxel-ui/components';
+import { Avatar, FieldContainer } from '@cardstack/boxel-ui/components';
 import AvatarGroup from '../components/avatar-group';
 
 import ContactIcon from '@cardstack/boxel-icons/contact';
@@ -46,6 +46,54 @@ export class SocialLinkField extends ContactLinkField {
       cta: 'Contact',
     },
   ];
+}
+
+class EditTemplate extends Component<typeof Contact> {
+  <template>
+    <div class='contact-form'>
+      <FieldContainer @label='First Name'>
+        <@fields.firstName />
+      </FieldContainer>
+      <FieldContainer @label='Last Name'>
+        <@fields.lastName />
+      </FieldContainer>
+      <FieldContainer @label='Position'>
+        <@fields.position />
+      </FieldContainer>
+      <FieldContainer @label='Company'>
+        <@fields.company />
+      </FieldContainer>
+      <FieldContainer @label='Department'>
+        <@fields.department />
+      </FieldContainer>
+      <FieldContainer @label='Primary Email'>
+        <@fields.primaryEmail />
+      </FieldContainer>
+      <FieldContainer @label='Secondary Email'>
+        <@fields.secondaryEmail />
+      </FieldContainer>
+      <FieldContainer @label='Phone Number'>
+        <@fields.phoneMobile />
+      </FieldContainer>
+      <FieldContainer @label='Office Phone Number'>
+        <@fields.phoneOffice />
+      </FieldContainer>
+      <FieldContainer @label='Social Links'>
+        <@fields.socialLinks />
+      </FieldContainer>
+      <FieldContainer @label='Status'>
+        <@fields.statusTag />
+      </FieldContainer>
+    </div>
+    <style scoped>
+      .contact-form {
+        display: flex;
+        flex-direction: column;
+        gap: var(--boxel-sp-lg);
+        padding: var(--boxel-sp-xl);
+      }
+    </style>
+  </template>
 }
 
 class EmbeddedTemplate extends Component<typeof Contact> {
@@ -710,6 +758,7 @@ export class Contact extends CardDef {
     },
   });
 
+  static edit = EditTemplate;
   static embedded = EmbeddedTemplate;
   static fitted = FittedTemplate;
   static atom = AtomTemplate;

--- a/packages/experiments-realm/crm/deal.gts
+++ b/packages/experiments-realm/crm/deal.gts
@@ -15,7 +15,11 @@ import DateField from 'https://cardstack.com/base/date';
 import GlimmerComponent from '@glimmer/component';
 import SummaryCard from '../components/summary-card';
 import SummaryGridContainer from '../components/summary-grid-container';
-import { Pill, BoxelButton } from '@cardstack/boxel-ui/components';
+import {
+  Pill,
+  BoxelButton,
+  FieldContainer,
+} from '@cardstack/boxel-ui/components';
 import { cn, not } from '@cardstack/boxel-ui/helpers';
 import Info from '@cardstack/boxel-icons/info';
 import AccountHeader from '../components/account-header';
@@ -53,6 +57,57 @@ const taskSource = {
   module: new URL('./task', import.meta.url).href,
   name: 'CRMTask',
 };
+
+class EditTemplate extends Component<typeof Deal> {
+  <template>
+    <div class='deal-form'>
+      <FieldContainer @label='Name'>
+        <@fields.name />
+      </FieldContainer>
+      <FieldContainer @label='Account'>
+        <@fields.account />
+      </FieldContainer>
+      <FieldContainer @label='Status'>
+        <@fields.status />
+      </FieldContainer>
+      <FieldContainer @label='Priority'>
+        <@fields.priority />
+      </FieldContainer>
+      <FieldContainer @label='Close Date'>
+        <@fields.closeDate />
+      </FieldContainer>
+      <FieldContainer @label='Current Value'>
+        <@fields.currentValue />
+      </FieldContainer>
+      <FieldContainer @label='Predicted Revenue'>
+        <@fields.predictedRevenue />
+      </FieldContainer>
+      <FieldContainer @label='Primary Stakeholder'>
+        <@fields.primaryStakeholder />
+      </FieldContainer>
+      <FieldContainer @label='Stakeholders'>
+        <@fields.stakeholders />
+      </FieldContainer>
+      <FieldContainer @label='Value Breakdown'>
+        <@fields.valueBreakdown />
+      </FieldContainer>
+      <FieldContainer @label='Health Score'>
+        <@fields.healthScore />
+      </FieldContainer>
+      <FieldContainer @label='Event'>
+        <@fields.event />
+      </FieldContainer>
+    </div>
+    <style scoped>
+      .deal-form {
+        display: flex;
+        flex-direction: column;
+        gap: var(--boxel-sp-lg);
+        padding: var(--boxel-sp-xl);
+      }
+    </style>
+  </template>
+}
 
 class IsolatedTemplate extends Component<typeof Deal> {
   get logoURL() {
@@ -1161,6 +1216,7 @@ export class Deal extends CardDef {
     },
   });
 
+  static edit = EditTemplate;
   static isolated = IsolatedTemplate;
   static fitted = FittedTemplate;
 }

--- a/packages/experiments-realm/crm/task.gts
+++ b/packages/experiments-realm/crm/task.gts
@@ -8,6 +8,7 @@ import {
   linksToMany,
 } from 'https://cardstack.com/base/card-api';
 import {
+  FieldContainer,
   Pill,
   ProgressBar,
   ProgressRadial,
@@ -43,6 +44,57 @@ function shortenId(id: string): string {
   const shortUuid = id.slice(0, 8);
   const decimal = parseInt(shortUuid, 16);
   return decimal.toString(36).padStart(6, '0');
+}
+
+class TaskEdit extends Component<typeof CRMTask> {
+  <template>
+    <div class='task-form'>
+      <FieldContainer @label='Name'>
+        <@fields.name />
+      </FieldContainer>
+      <FieldContainer @label='Crm App'>
+        <@fields.crmApp />
+      </FieldContainer>
+      <FieldContainer @label='Assignee'>
+        <@fields.assignee />
+      </FieldContainer>
+      <FieldContainer @label='Contact'>
+        <@fields.contact />
+      </FieldContainer>
+      <FieldContainer @label='Account'>
+        <@fields.account />
+      </FieldContainer>
+      <FieldContainer @label='Deal'>
+        <@fields.deal />
+      </FieldContainer>
+      <FieldContainer @label='Status'>
+        <@fields.status />
+      </FieldContainer>
+      <FieldContainer @label='Date Range'>
+        <@fields.dateRange />
+      </FieldContainer>
+      <FieldContainer @label='Details'>
+        <@fields.details />
+      </FieldContainer>
+      <FieldContainer @label='Priority'>
+        <@fields.priority />
+      </FieldContainer>
+      <FieldContainer @label='Subtasks'>
+        <@fields.subtasks />
+      </FieldContainer>
+      <FieldContainer @label='Tags'>
+        <@fields.tags />
+      </FieldContainer>
+    </div>
+    <style scoped>
+      .task-form {
+        display: flex;
+        flex-direction: column;
+        gap: var(--boxel-sp-lg);
+        padding: var(--boxel-sp-xl);
+      }
+    </style>
+  </template>
 }
 
 class TaskIsolated extends Component<typeof CRMTask> {
@@ -561,6 +613,7 @@ export class CRMTask extends Task {
     },
   });
 
+  static edit = TaskEdit;
   static isolated = TaskIsolated;
   static embedded = TaskEmbedded;
 }


### PR DESCRIPTION
Refer to https://linear.app/cardstack/issue/CS-7991/sorting-of-all-crm-edit-fields-with-custom-edit-template

What is changing
- sort edit fields within the crm cards with custom edit template
- this can avoid those computed value to be displayed and causes confusion that is editable