### PR TITLE
Fix: LLM selector disappears when more than 1 attached item is shown

### DIFF
--- a/packages/host/app/components/ai-assistant/llm-select.gts
+++ b/packages/host/app/components/ai-assistant/llm-select.gts
@@ -42,6 +42,8 @@ const LLMSelect: TemplateOnlyComponent<Signature> = <template>
       border: none;
       padding: 0;
       width: auto;
+      min-width: 80px;
+      height: 43.5px;
       flex: 1;
       padding-right: var(--boxel-sp-xxs);
       cursor: pointer;

--- a/packages/host/app/components/ai-assistant/llm-select.gts
+++ b/packages/host/app/components/ai-assistant/llm-select.gts
@@ -42,12 +42,11 @@ const LLMSelect: TemplateOnlyComponent<Signature> = <template>
       border: none;
       padding: 0;
       width: auto;
-      min-width: 80px;
       height: 43.5px;
+      min-width: 120px;
       flex: 1;
       padding-right: var(--boxel-sp-xxs);
       cursor: pointer;
-      font:;
     }
     .llm-select :deep(.boxel-trigger) {
       padding: 0;

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -193,7 +193,6 @@ export default class Room extends Component<Signature> {
       .chat-input-area__bottom-section {
         display: flex;
         justify-content: space-between;
-        gap: 10px;
         padding-right: var(--boxel-sp-xxs);
         gap: var(--boxel-sp-xxl);
       }

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -194,7 +194,6 @@ export default class Room extends Component<Signature> {
         display: flex;
         justify-content: space-between;
         gap: 10px;
-        align-items: center;
         padding-right: var(--boxel-sp-xxs);
         gap: var(--boxel-sp-xxl);
       }


### PR DESCRIPTION
Before:
<img width="366" alt="Screenshot 2025-02-14 at 14 08 34" src="https://github.com/user-attachments/assets/86f33852-97b1-4b89-ad3e-ef33a457d849" />

After:
<img width="368" alt="Screenshot 2025-02-14 at 14 07 03" src="https://github.com/user-attachments/assets/b477a07b-315f-4183-a434-e33f6be77cfc" />
