### PR TITLE
CS-7891 Introduce sorting parameter at kanban resources helper

### DIFF
--- a/packages/experiments-realm/components/base-task-planner.gts
+++ b/packages/experiments-realm/components/base-task-planner.gts
@@ -110,6 +110,7 @@ export interface CardOperations {
     targetColumn: DndColumn;
   }) => Promise<void>;
   hasColumnKey: (card: TaskCard, key: string) => boolean;
+  orderBy?: <T extends CardDef>(a: T, b: T) => number;
 }
 
 // Configuration for the task source
@@ -387,6 +388,7 @@ export class TaskPlanner extends GlimmerComponent<TaskPlannerArgs> {
     () => this.cardInstances,
     () => this.args.config.status.values.map((status) => status.label) ?? [],
     () => this.args.config.cardOperations.hasColumnKey,
+    () => this.args.config.cardOperations.orderBy,
   );
 
   @action async createNewTask(statusLabel: string) {

--- a/packages/experiments-realm/components/sort.gts
+++ b/packages/experiments-realm/components/sort.gts
@@ -13,20 +13,6 @@ import { DropdownArrowFilled } from '@cardstack/boxel-ui/icons';
 import ArrowDown from '@cardstack/boxel-icons/arrow-down';
 import ArrowUp from '@cardstack/boxel-icons/arrow-up';
 
-export const sortByDueDateDesc: Sort = [
-  {
-    by: 'dueDate',
-    direction: 'desc',
-  },
-];
-
-export const sortByPriorityDesc: Sort = [
-  {
-    by: 'priority',
-    direction: 'desc',
-  },
-];
-
 export const sortByCardTitleAsc: Sort = [
   {
     on: {
@@ -127,7 +113,9 @@ export class SortMenu extends GlimmerComponent<SortMenuSignature> {
       return new MenuItem(option.displayName, 'action', {
         action: () => this.args.onSort(option),
         icon: option.sort?.[0].direction === 'desc' ? ArrowDown : ArrowUp,
-        selected: option.displayName === this.args.selected.displayName,
+        selected:
+          option.displayName === this.args.selected.displayName &&
+          option.sort?.[0].direction === this.args.selected.sort?.[0].direction,
       });
     });
   }

--- a/packages/experiments-realm/crm-app.gts
+++ b/packages/experiments-realm/crm-app.gts
@@ -551,6 +551,8 @@ class CrmAppTemplate extends Component<typeof CrmApp> {
             @viewCard={{this.viewCard}}
             @searchFilter={{this.searchFilter}}
             @taskFilter={{this.taskFilter}}
+            @sortBy='priority'
+            @sortOrder='desc'
           />
         {{else if this.query}}
           {{#if (eq this.selectedView 'card')}}

--- a/packages/experiments-realm/crm-app.gts
+++ b/packages/experiments-realm/crm-app.gts
@@ -48,7 +48,7 @@ import { DEAL_STATUS_VALUES } from './crm/deal-status';
 import DealSummary from './crm/deal-summary';
 import { CRMTaskPlanner } from './crm/task-planner';
 import type { LooseSingleCardDocument, Sort } from '@cardstack/runtime-common';
-
+import type { TaskSortBy, TaskSortOrder } from './crm/task-planner';
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import {
   Card as CardIcon,
@@ -65,8 +65,8 @@ interface ViewItem {
   id: ViewOption;
 }
 
-const sortByDueDate: (direction: 'asc' | 'desc') => Sort = (
-  direction: 'asc' | 'desc',
+const sortByDueDate: (direction: TaskSortOrder) => Sort = (
+  direction: TaskSortOrder,
 ) => [
   {
     by: 'dueDate',
@@ -74,8 +74,8 @@ const sortByDueDate: (direction: 'asc' | 'desc') => Sort = (
   },
 ];
 
-const sortByPriority: (direction: 'asc' | 'desc') => Sort = (
-  direction: 'asc' | 'desc',
+const sortByPriority: (direction: TaskSortOrder) => Sort = (
+  direction: TaskSortOrder,
 ) => [
   {
     by: 'priority',
@@ -470,15 +470,11 @@ class CrmAppTemplate extends Component<typeof CrmApp> {
     return taskFilter;
   }
 
-  get taskSortBy() {
-    return this.selectedSort?.sort?.[0]?.by as
-      | 'dueDate'
-      | 'priority'
-      | undefined;
-  }
-
-  get taskSortOrder() {
-    return this.selectedSort?.sort?.[0]?.direction ?? 'desc';
+  get taskSort() {
+    return {
+      by: this.selectedSort?.sort?.[0]?.by as TaskSortBy | undefined,
+      order: this.selectedSort?.sort?.[0]?.direction,
+    };
   }
 
   get searchPlaceholder() {
@@ -604,8 +600,7 @@ class CrmAppTemplate extends Component<typeof CrmApp> {
             @viewCard={{this.viewCard}}
             @searchFilter={{this.searchFilter}}
             @taskFilter={{this.taskFilter}}
-            @sortBy={{this.taskSortBy}}
-            @sortOrder={{this.taskSortOrder}}
+            @sort={{this.taskSort}}
           />
         {{else if this.query}}
           {{#if (eq this.selectedView 'card')}}

--- a/packages/experiments-realm/crm-app.gts
+++ b/packages/experiments-realm/crm-app.gts
@@ -5,8 +5,6 @@ import {
   SortMenu,
   type SortOption,
   sortByCardTitleAsc,
-  sortByDueDateDesc,
-  sortByPriorityDesc,
 } from './components/sort';
 import { SearchInput } from './components/search-input';
 import { action } from '@ember/object';
@@ -49,7 +47,7 @@ import { URGENCY_TAG_VALUES } from './crm/urgency-tag';
 import { DEAL_STATUS_VALUES } from './crm/deal-status';
 import DealSummary from './crm/deal-summary';
 import { CRMTaskPlanner } from './crm/task-planner';
-import type { LooseSingleCardDocument } from '@cardstack/runtime-common';
+import type { LooseSingleCardDocument, Sort } from '@cardstack/runtime-common';
 
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import {
@@ -66,6 +64,24 @@ interface ViewItem {
   }>;
   id: ViewOption;
 }
+
+const sortByDueDate: (direction: 'asc' | 'desc') => Sort = (
+  direction: 'asc' | 'desc',
+) => [
+  {
+    by: 'dueDate',
+    direction,
+  },
+];
+
+const sortByPriority: (direction: 'asc' | 'desc') => Sort = (
+  direction: 'asc' | 'desc',
+) => [
+  {
+    by: 'priority',
+    direction,
+  },
+];
 
 const CONTACT_FILTERS: LayoutFilter[] = [
   {
@@ -139,12 +155,22 @@ const TASK_FILTERS: LayoutFilter[] = [
       {
         id: 'dueDateDesc',
         displayName: 'Due Date',
-        sort: sortByDueDateDesc,
+        sort: sortByDueDate('desc'),
+      },
+      {
+        id: 'dueDateAsc',
+        displayName: 'Due Date',
+        sort: sortByDueDate('asc'),
       },
       {
         id: 'priorityDesc',
         displayName: 'Priority',
-        sort: sortByPriorityDesc,
+        sort: sortByPriority('desc'),
+      },
+      {
+        id: 'priorityAsc',
+        displayName: 'Priority',
+        sort: sortByPriority('asc'),
       },
     ],
   },
@@ -444,6 +470,17 @@ class CrmAppTemplate extends Component<typeof CrmApp> {
     return taskFilter;
   }
 
+  get taskSortBy() {
+    return this.selectedSort?.sort?.[0]?.by as
+      | 'dueDate'
+      | 'priority'
+      | undefined;
+  }
+
+  get taskSortOrder() {
+    return this.selectedSort?.sort?.[0]?.direction ?? 'desc';
+  }
+
   get searchPlaceholder() {
     return `Search ${this.activeFilter.displayName}`;
   }
@@ -567,8 +604,8 @@ class CrmAppTemplate extends Component<typeof CrmApp> {
             @viewCard={{this.viewCard}}
             @searchFilter={{this.searchFilter}}
             @taskFilter={{this.taskFilter}}
-            @sortBy='priority'
-            @sortOrder='desc'
+            @sortBy={{this.taskSortBy}}
+            @sortOrder={{this.taskSortOrder}}
           />
         {{else if this.query}}
           {{#if (eq this.selectedView 'card')}}

--- a/packages/experiments-realm/crm/task-planner.gts
+++ b/packages/experiments-realm/crm/task-planner.gts
@@ -9,6 +9,13 @@ import { DndItem } from '@cardstack/boxel-ui/components';
 import { AppCard } from '../app-card';
 import { CRMTask } from './task';
 
+export type TaskSortBy = 'dueDate' | 'priority';
+export type TaskSortOrder = 'asc' | 'desc';
+type TaskSort = {
+  by?: TaskSortBy;
+  order?: TaskSortOrder;
+};
+
 interface CRMTaskPlannerArgs {
   Args: {
     model: Partial<AppCard>;
@@ -17,8 +24,7 @@ interface CRMTaskPlannerArgs {
     viewCard: () => void;
     searchFilter?: Filter[];
     taskFilter?: Filter[];
-    sortBy?: 'dueDate' | 'priority';
-    sortOrder?: 'asc' | 'desc';
+    sort?: TaskSort;
   };
   Element: HTMLElement;
 }
@@ -26,7 +32,7 @@ interface CRMTaskPlannerArgs {
 const sortByDueDate = (
   a: CardDef,
   b: CardDef,
-  order: 'asc' | 'desc' = 'asc',
+  order: TaskSortOrder = 'asc',
 ) => {
   const crmTaskA = a as CRMTask;
   const crmTaskB = b as CRMTask;
@@ -44,7 +50,7 @@ const sortByDueDate = (
 const sortByPriority = (
   a: CardDef,
   b: CardDef,
-  order: 'asc' | 'desc' = 'asc',
+  order: TaskSortOrder = 'asc',
 ) => {
   const crmTaskA = a as CRMTask;
   const crmTaskB = b as CRMTask;
@@ -152,13 +158,13 @@ export class CRMTaskPlanner extends GlimmerComponent<CRMTaskPlannerArgs> {
   }
 
   getOrderBy() {
-    if (this.args.sortBy === 'dueDate') {
+    if (this.args.sort?.by === 'dueDate') {
       return (a: CardDef, b: CardDef) =>
-        sortByDueDate(a, b, this.args.sortOrder);
+        sortByDueDate(a, b, this.args.sort?.order);
     }
-    if (this.args.sortBy === 'priority') {
+    if (this.args.sort?.by === 'priority') {
       return (a: CardDef, b: CardDef) =>
-        sortByPriority(a, b, this.args.sortOrder);
+        sortByPriority(a, b, this.args.sort?.order);
     }
     return undefined;
   }

--- a/packages/experiments-realm/crm/task-planner.gts
+++ b/packages/experiments-realm/crm/task-planner.gts
@@ -7,6 +7,7 @@ import type { Query, Filter } from '@cardstack/runtime-common/query';
 import { getCards } from '@cardstack/runtime-common';
 import { DndItem } from '@cardstack/boxel-ui/components';
 import { AppCard } from '../app-card';
+import { CRMTask } from './task';
 
 interface CRMTaskPlannerArgs {
   Args: {
@@ -16,9 +17,62 @@ interface CRMTaskPlannerArgs {
     viewCard: () => void;
     searchFilter?: Filter[];
     taskFilter?: Filter[];
+    sortBy?: 'dueDate' | 'priority';
+    sortOrder?: 'asc' | 'desc';
   };
   Element: HTMLElement;
 }
+
+const sortByDueDate = (
+  a: CardDef,
+  b: CardDef,
+  order: 'asc' | 'desc' = 'asc',
+) => {
+  const crmTaskA = a as CRMTask;
+  const crmTaskB = b as CRMTask;
+
+  // Handle cases where one or both items don't have dates
+  if (!crmTaskA.dateRange?.end && !crmTaskB.dateRange?.end) return 0;
+  if (!crmTaskA.dateRange?.end) return 1; // null dates always go last
+  if (!crmTaskB.dateRange?.end) return -1; // non-null dates always go first
+
+  const comparison =
+    crmTaskA.dateRange.end.getTime() - crmTaskB.dateRange.end.getTime();
+  return order === 'asc' ? comparison : -comparison;
+};
+
+const sortByPriority = (
+  a: CardDef,
+  b: CardDef,
+  order: 'asc' | 'desc' = 'asc',
+) => {
+  const crmTaskA = a as CRMTask;
+  const crmTaskB = b as CRMTask;
+
+  // Handle cases where one or both items don't have priority
+  // Check if priority or index is undefined/null, but allow 0 as valid value
+  if (
+    (crmTaskA.priority?.index === undefined ||
+      crmTaskA.priority?.index === null) &&
+    (crmTaskB.priority?.index === undefined ||
+      crmTaskB.priority?.index === null)
+  )
+    return 0;
+
+  if (
+    crmTaskA.priority?.index === undefined ||
+    crmTaskA.priority?.index === null
+  )
+    return 1;
+  if (
+    crmTaskB.priority?.index === undefined ||
+    crmTaskB.priority?.index === null
+  )
+    return -1;
+
+  const comparison = crmTaskA.priority.index - crmTaskB.priority.index;
+  return order === 'asc' ? comparison : -comparison;
+};
 
 export class CRMTaskPlanner extends GlimmerComponent<CRMTaskPlannerArgs> {
   get parentId() {
@@ -95,6 +149,18 @@ export class CRMTaskPlanner extends GlimmerComponent<CRMTaskPlannerArgs> {
 
   get assigneeCards() {
     return this.assigneeQuery?.instances ?? [];
+  }
+
+  getOrderBy() {
+    if (this.args.sortBy === 'dueDate') {
+      return (a: CardDef, b: CardDef) =>
+        sortByDueDate(a, b, this.args.sortOrder);
+    }
+    if (this.args.sortBy === 'priority') {
+      return (a: CardDef, b: CardDef) =>
+        sortByPriority(a, b, this.args.sortOrder);
+    }
+    return undefined;
   }
 
   get config() {
@@ -181,6 +247,7 @@ export class CRMTaskPlanner extends GlimmerComponent<CRMTaskPlannerArgs> {
             await this.args.context?.actions?.saveCard?.(cardInNewCol);
           }
         },
+        orderBy: this.getOrderBy(),
       },
       taskSource: {
         module: new URL('./task', import.meta.url).href,


### PR DESCRIPTION
Refer to https://linear.app/cardstack/issue/CS-7891/kanban-resource-resources-api-to-deal-with-sorting

### What is changing
- add new optional `orderBy` function parameter so we can freely define sorting mechanism by dnd column
- crm task planner to consume sort by and sort order from crm app level
- implement sort option value from UI to crm task planner

**Screenshot**

https://github.com/user-attachments/assets/124e0424-ea15-437f-bcce-87e6c6bedc67



**Examples**
| Order by | Sort By | Result |
| ------------- | ------------- | ------------- |
| Due Date | Asc  |  ![duedate-asc](https://github.com/user-attachments/assets/bc4581ef-8263-4209-b917-f144b9d04942) |
| Due Date | Desc  | ![duedate-desc](https://github.com/user-attachments/assets/c752a9b9-eaa9-43cd-bc4d-92f427fec92c) |
| Priority | Asc |  ![priority-asc](https://github.com/user-attachments/assets/ffa1036a-80a3-4688-9238-de4f0e1374f4) |
| Priority | Desc | ![prority-desc](https://github.com/user-attachments/assets/06921baf-0d06-4afd-9b9b-bf707ebc9964) |