### PR TITLE
Better handling for contained computed that consumes linked field

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -57,11 +57,11 @@ import CaptionsIcon from '@cardstack/boxel-icons/captions';
 import RectangleEllipsisIcon from '@cardstack/boxel-icons/rectangle-ellipsis';
 import LetterCaseIcon from '@cardstack/boxel-icons/letter-case';
 
-interface CardorFieldTypeIconSignature {
+interface CardOrFieldTypeIconSignature {
   Element: Element;
 }
 
-export type CardorFieldTypeIcon = ComponentLike<CardorFieldTypeIconSignature>;
+export type CardOrFieldTypeIcon = ComponentLike<CardOrFieldTypeIconSignature>;
 
 export { primitive, isField, type BoxComponent };
 export const serialize = Symbol.for('cardstack-serialize');
@@ -120,7 +120,7 @@ interface Options {
   // the isolated renderer (RoomField), which means that we cannot
   // use the rendering mechanism to tell if a card is used or not,
   // in which case we need to tell the runtime that a card is
-  // explictly being used.
+  // explicitly being used.
   isUsed?: true;
 }
 
@@ -301,7 +301,7 @@ export interface Field<
   // the isolated renderer (RoomField), which means that we cannot
   // use the rendering mechanism to tell if a card is used or not,
   // in which case we need to tell the runtime that a card is
-  // explictly being used.
+  // explicitly being used.
   isUsed?: undefined | true;
   serialize(
     value: any,
@@ -1650,7 +1650,7 @@ export class BaseDef {
   static baseDef: undefined;
   static data?: Record<string, any>; // TODO probably refactor this away all together
   static displayName = 'Base';
-  static icon: CardorFieldTypeIcon;
+  static icon: CardOrFieldTypeIcon;
 
   static getDisplayName(instance: BaseDef) {
     return instance.constructor.displayName;
@@ -1821,7 +1821,7 @@ export type BaseDefComponent = ComponentLike<{
 
 export class FieldDef extends BaseDef {
   // this changes the shape of the class type FieldDef so that a CardDef
-  // class type cannot masquarade as a FieldDef class type
+  // class type cannot masquerade as a FieldDef class type
   static isFieldDef = true;
   static displayName = 'Field';
   static icon = RectangleEllipsisIcon;
@@ -2565,7 +2565,7 @@ async function _updateFromSerialized<T extends BaseDefConstructor>(
         // This happens when the instance has a field that is not in the definition. It can happen when
         // instance or definition is updated and the other is not. In this case we will just ignore the
         // mismatch and try to serialize it anyway so that the client can see still see the instance data
-        // and have a chance to fix it so that it adheres to the definiton
+        // and have a chance to fix it so that it adheres to the definition
         return [];
       }
       let relativeToVal = instance[relativeTo];

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -642,10 +642,8 @@ class ContainsMany<FieldT extends FieldDefConstructor>
     }, values);
   }
 
-  async handleNotLoadedError<T extends BaseDef>(instance: T, _e: NotLoaded) {
-    throw new Error(
-      `cannot load missing field for non-linksTo or non-linksToMany field ${instance.constructor.name}.${this.name}`,
-    );
+  async handleNotLoadedError<T extends BaseDef>(_instance: T, _e: NotLoaded) {
+    return undefined;
   }
 
   component(model: Box<BaseDef>): BoxComponent {
@@ -799,10 +797,8 @@ class Contains<CardT extends FieldDefConstructor> implements Field<CardT, any> {
     return value;
   }
 
-  async handleNotLoadedError<T extends BaseDef>(instance: T, _e: NotLoaded) {
-    throw new Error(
-      `cannot load missing field for non-linksTo or non-linksToMany field ${instance.constructor.name}.${this.name}`,
-    );
+  async handleNotLoadedError<T extends BaseDef>(_instance: T, _e: NotLoaded) {
+    return undefined;
   }
 
   component(model: Box<BaseDef>): BoxComponent {
@@ -2888,7 +2884,10 @@ export async function getIfReady<T extends BaseDef, K extends keyof T>(
     Reflect.getPrototypeOf(instance)!.constructor as typeof BaseDef,
     fieldName as string,
   );
-  if (isStaleValue(maybeStale)) {
+  if (
+    field.computeVia &&
+    (isStaleValue(maybeStale) || !deserialized.has(fieldName as string))
+  ) {
     if (!field) {
       throw new Error(
         `the field '${fieldName as string} does not exist in card ${

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -2884,17 +2884,17 @@ export async function getIfReady<T extends BaseDef, K extends keyof T>(
     Reflect.getPrototypeOf(instance)!.constructor as typeof BaseDef,
     fieldName as string,
   );
+  if (!field) {
+    throw new Error(
+      `the field '${fieldName as string} does not exist in card ${
+        instance.constructor.name
+      }'`,
+    );
+  }
   if (
     field.computeVia &&
     (isStaleValue(maybeStale) || !deserialized.has(fieldName as string))
   ) {
-    if (!field) {
-      throw new Error(
-        `the field '${fieldName as string} does not exist in card ${
-          instance.constructor.name
-        }'`,
-      );
-    }
     let { computeVia: _computeVia } = field;
     if (!_computeVia) {
       throw new Error(

--- a/packages/base/spec.gts
+++ b/packages/base/spec.gts
@@ -8,7 +8,7 @@ import {
   FieldDef,
   containsMany,
   getCardMeta,
-  type CardorFieldTypeIcon,
+  type CardOrFieldTypeIcon,
 } from './card-api';
 import StringField from './string';
 import BooleanField from './boolean';
@@ -82,7 +82,7 @@ export class Spec extends CardDef {
   });
 
   static isolated = class Isolated extends Component<typeof this> {
-    icon: CardorFieldTypeIcon | undefined;
+    icon: CardOrFieldTypeIcon | undefined;
 
     get defaultIcon() {
       return this.args.model.constructor?.icon;

--- a/packages/experiments-realm/components/layout.gts
+++ b/packages/experiments-realm/components/layout.gts
@@ -1,7 +1,7 @@
 import GlimmerComponent from '@glimmer/component';
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { htmlSafe } from '@ember/template';
-import { type CardorFieldTypeIcon } from 'https://cardstack.com/base/card-api';
+import { type CardOrFieldTypeIcon } from 'https://cardstack.com/base/card-api';
 import ImageIcon from '@cardstack/boxel-icons/image';
 import { FilterList } from '@cardstack/boxel-ui/components';
 import { element } from '@cardstack/boxel-ui/helpers';
@@ -10,7 +10,7 @@ import type { SortOption } from './sort';
 
 export interface LayoutFilter {
   displayName: string;
-  icon: CardorFieldTypeIcon;
+  icon: CardOrFieldTypeIcon;
   cardTypeName?: string;
   createNewButtonText?: string;
   isCreateNewDisabled?: boolean;

--- a/packages/experiments-realm/components/layout.gts
+++ b/packages/experiments-realm/components/layout.gts
@@ -50,7 +50,7 @@ interface TitleGroupSignature {
     title?: string;
     tagline?: string;
     thumbnailURL?: string;
-    icon?: CardorFieldTypeIcon;
+    icon?: CardOrFieldTypeIcon;
     element?: keyof HTMLElementTagNameMap;
   };
   Element: HTMLElement;

--- a/packages/experiments-realm/components/status-pill.gts
+++ b/packages/experiments-realm/components/status-pill.gts
@@ -1,14 +1,14 @@
 import GlimmerComponent from '@glimmer/component';
 import { Pill } from '@cardstack/boxel-ui/components';
 import { cssVar } from '@cardstack/boxel-ui/helpers';
-import { CardorFieldTypeIcon } from 'https://cardstack.com/base/card-api';
+import { CardOrFieldTypeIcon } from 'https://cardstack.com/base/card-api';
 
 interface StatusPillSignature {
   Args: {
     label: string;
     iconDarkColor: string | undefined;
     iconLightColor: string | undefined;
-    icon?: CardorFieldTypeIcon;
+    icon?: CardOrFieldTypeIcon;
   };
   Element: HTMLDivElement;
 }

--- a/packages/experiments-realm/sprint-task.gts
+++ b/packages/experiments-realm/sprint-task.gts
@@ -503,7 +503,7 @@ export class SprintTask extends Task {
   static displayName = 'Sprint Task';
   static icon = CheckboxIcon;
   @field project = linksTo(() => Project);
-  @field team = linksTo(() => Team);
+  @field team = linksTo(() => Team, { isUsed: true });
   @field subtasks = linksToMany(() => SprintTask);
   @field status = contains(SprintTaskStatusField);
 

--- a/packages/seed-realm/components/layout.gts
+++ b/packages/seed-realm/components/layout.gts
@@ -1,7 +1,7 @@
 import GlimmerComponent from '@glimmer/component';
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { htmlSafe } from '@ember/template';
-import { type CardorFieldTypeIcon } from 'https://cardstack.com/base/card-api';
+import { type CardOrFieldTypeIcon } from 'https://cardstack.com/base/card-api';
 import ImageIcon from '@cardstack/boxel-icons/image';
 import { FilterList } from '@cardstack/boxel-ui/components';
 import { element } from '@cardstack/boxel-ui/helpers';
@@ -10,7 +10,7 @@ import type { SortOption } from './sort';
 
 export interface LayoutFilter {
   displayName: string;
-  icon: CardorFieldTypeIcon;
+  icon: CardOrFieldTypeIcon;
   cardTypeName?: string;
   createNewButtonText?: string;
   isCreateNewDisabled?: boolean;
@@ -50,7 +50,7 @@ interface TitleGroupSignature {
     title?: string;
     tagline?: string;
     thumbnailURL?: string;
-    icon?: CardorFieldTypeIcon;
+    icon?: CardOrFieldTypeIcon;
     element?: keyof HTMLElementTagNameMap;
   };
   Element: HTMLElement;


### PR DESCRIPTION
This PR includes better handling for a contained computed that consumes a linked field. This issue started to appear after we forced all contained fields to be rendered regardless if they were used in a template. As part of this we started to see contained computed's that consume linked fields throw errors in our indexer. In production instances that contained these types of fields actually triggered an indexing cycle. It looks like the API machinery can handle these fields just fine, so long as we just get out of the way. So the update here was to stop throwing when we encounter this, and just let the field temporarily be undefined while the API tries to resolve the field value.

Additionally, our cycle detection logic in our renderer has a threshold value that is set absurdly high (it was set back before HTTP GET's were used to visit cards in the indexer--before workers even). I lowered this threshold to something more reasonable so that cycles could more quickly be detected in our indexer. I also added some better debugging messages what will allow us to more easily spot any cycles in the future.

I'm not 100% positive this solves the cycle issue in prod, but at the very least it should greatly mitigate it and provide better forensics for finding and fixing indexing cycles in the future.