### PR TITLE
Having an issue where PrerenderedCardSearch is not showing query data inside embedded/other formats

### DIFF
--- a/packages/experiments-realm/SuperProjectAccount/1d5b6e71-067c-44bf-982e-d41285f5d53f.json
+++ b/packages/experiments-realm/SuperProjectAccount/1d5b6e71-067c-44bf-982e-d41285f5d53f.json
@@ -1,0 +1,23 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "name": "Super Tech Solutions",
+      "description": null,
+      "thumbnailURL": null
+    },
+    "relationships": {
+      "superProjectApp": {
+        "links": {
+          "self": "../SuperProjectApp/65cf8a72-61d0-438a-a37a-71b57058aff6"
+        }
+      }
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../super-project/account",
+        "name": "SuperProjectAccount"
+      }
+    }
+  }
+}

--- a/packages/experiments-realm/SuperProjectApp/65cf8a72-61d0-438a-a37a-71b57058aff6.json
+++ b/packages/experiments-realm/SuperProjectApp/65cf8a72-61d0-438a-a37a-71b57058aff6.json
@@ -1,0 +1,16 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "title": "Super Project Management",
+      "description": null,
+      "thumbnailURL": null
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../super-project-app",
+        "name": "SuperProjectApp"
+      }
+    }
+  }
+}

--- a/packages/experiments-realm/SuperProjectTask/41e87867-459f-474d-ba89-ee16d61ab42d.json
+++ b/packages/experiments-realm/SuperProjectTask/41e87867-459f-474d-ba89-ee16d61ab42d.json
@@ -1,0 +1,23 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "name": "Testing Super App Bug",
+      "description": null,
+      "thumbnailURL": null
+    },
+    "relationships": {
+      "account": {
+        "links": {
+          "self": "../SuperProjectAccount/1d5b6e71-067c-44bf-982e-d41285f5d53f"
+        }
+      }
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../super-project/task",
+        "name": "SuperProjectTask"
+      }
+    }
+  }
+}

--- a/packages/experiments-realm/components/card-list-without-prerendered.gts
+++ b/packages/experiments-realm/components/card-list-without-prerendered.gts
@@ -1,0 +1,82 @@
+import GlimmerComponent from '@glimmer/component';
+
+import { type CardContext } from 'https://cardstack.com/base/card-api';
+
+import { type Query } from '@cardstack/runtime-common';
+
+import { CardContainer } from '@cardstack/boxel-ui/components';
+
+import { getCards } from '@cardstack/runtime-common';
+
+interface CardListWithoutPrerenderedSignature {
+  Args: {
+    query: Query;
+    realms: URL[];
+    context?: CardContext;
+  };
+  Element: HTMLElement;
+}
+
+export class CardListWithoutPrerendered extends GlimmerComponent<CardListWithoutPrerenderedSignature> {
+  cards = getCards(
+    () => this.args.query,
+    () => this.args.realms.map((url) => url.href),
+    {
+      isLive: true,
+    },
+  );
+
+  <template>
+    <ul class='card-list' ...attributes>
+      {{#if this.cards.isLoading}}
+        <div>Loading...</div>
+      {{else}}
+        {{#each this.cards.instances as |card|}}
+          {{#let (getComponent card) as |Component|}}
+            <li class='card-list-item'>
+              <CardContainer
+                {{@context.cardComponentModifier
+                  cardId=card.id
+                  format='data'
+                  fieldType=undefined
+                  fieldName=undefined
+                }}
+                class='card'
+                @displayBoundaries={{true}}
+              >
+                <Component @format='embedded' @displayContainer={{false}} />
+              </CardContainer>
+            </li>
+          {{/let}}
+        {{/each}}
+      {{/if}}
+    </ul>
+    <style scoped>
+      .card-list {
+        display: grid;
+        gap: var(--boxel-sp);
+        list-style-type: none;
+        margin: 0;
+        padding: var(--boxel-sp-6xs);
+      }
+      .card-list-item {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--boxel-sp) var(--boxel-sp-lg);
+      }
+      .card {
+        height: auto;
+        min-height: var(--embedded-card-min-height, 345px);
+        max-width: var(--embedded-card-max-width, 100%);
+      }
+      .bordered-items > .card-list-item > * {
+        border-radius: var(--boxel-border-radius);
+        box-shadow: inset 0 0 0 1px var(--boxel-light-500);
+      }
+    </style>
+  </template>
+}
+
+function getComponent(cardOrField: BaseDef) {
+  return cardOrField.constructor.getComponent(cardOrField);
+}

--- a/packages/experiments-realm/components/card-list-without-prerendered.gts
+++ b/packages/experiments-realm/components/card-list-without-prerendered.gts
@@ -1,6 +1,6 @@
 import GlimmerComponent from '@glimmer/component';
 
-import { type CardContext } from 'https://cardstack.com/base/card-api';
+import { type CardContext, BaseDef } from 'https://cardstack.com/base/card-api';
 
 import { type Query } from '@cardstack/runtime-common';
 

--- a/packages/experiments-realm/super-project-app.gts
+++ b/packages/experiments-realm/super-project-app.gts
@@ -85,7 +85,7 @@ class SuperProjectAppTemplate extends Component<typeof SuperProjectApp> {
     if (filters) {
       for (let filter of filters) {
         let summary = cardTypeSummaries.find(
-          (s) => s.attributes.displayName === filter.cardTypeName,
+          (s: any) => s.attributes.displayName === filter.cardTypeName,
         );
         if (!summary) {
           return;

--- a/packages/experiments-realm/super-project-app.gts
+++ b/packages/experiments-realm/super-project-app.gts
@@ -1,0 +1,257 @@
+import { CardList } from './components/card-list';
+import { CardListWithoutPrerendered } from './components/card-list-without-prerendered';
+import { Layout, TitleGroup, type LayoutFilter } from './components/layout';
+import { sortByCardTitleAsc } from './components/sort';
+import { action } from '@ember/object';
+import type Owner from '@ember/owner';
+import { tracked } from '@glimmer/tracking';
+import { TrackedMap } from 'tracked-built-ins';
+import { restartableTask } from 'ember-concurrency';
+
+import {
+  Component,
+  realmURL,
+  CardDef,
+} from 'https://cardstack.com/base/card-api';
+
+import { Query, CardError, SupportedMimeType } from '@cardstack/runtime-common';
+import CalendarExclamation from '@cardstack/boxel-icons/calendar-exclamation';
+import {
+  Card as CardIcon,
+  Grid3x3 as GridIcon,
+  Rows4 as StripIcon,
+} from '@cardstack/boxel-ui/icons';
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
+
+type ViewOption = 'card' | 'strip' | 'grid';
+
+interface ViewItem {
+  icon: TemplateOnlyComponent<{
+    Element: SVGElement;
+  }>;
+  id: ViewOption;
+}
+
+const ACCOUNT_FILTERS: LayoutFilter[] = [
+  {
+    displayName: 'All Super Project Accounts',
+    icon: CalendarExclamation,
+    cardTypeName: 'Super Project Account',
+    createNewButtonText: 'Create Account',
+  },
+  // Add any additional filters based on your needs
+];
+
+class SuperProjectAppTemplate extends Component<typeof SuperProjectApp> {
+  //filters
+  filterMap: TrackedMap<string, LayoutFilter[]> = new TrackedMap([
+    ['Super Project Account', ACCOUNT_FILTERS],
+  ]);
+  @tracked private activeFilter: LayoutFilter = ACCOUNT_FILTERS[0];
+  @action private onFilterChange(filter: LayoutFilter) {
+    this.activeFilter = filter;
+  }
+
+  get commonViews(): ViewItem[] {
+    return [
+      { id: 'card', icon: CardIcon },
+      { id: 'strip', icon: StripIcon },
+      { id: 'grid', icon: GridIcon },
+    ];
+  }
+
+  constructor(owner: Owner, args: any) {
+    super(owner, args);
+    this.loadAllFilters.perform();
+  }
+
+  private loadAllFilters = restartableTask(async () => {
+    let url = `${this.realms[0]}_types`;
+    let response = await fetch(url, {
+      headers: {
+        Accept: SupportedMimeType.CardTypeSummary,
+      },
+    });
+    if (!response.ok) {
+      let err = await CardError.fromFetchResponse(url, response);
+      throw err;
+    }
+    let cardTypeSummaries = (await response.json()).data;
+    console.log('cardTypeSummaries:', cardTypeSummaries);
+
+    let filters = this.filterMap.get('Super Project Account');
+    console.log('filters:', filters);
+
+    if (filters) {
+      for (let filter of filters) {
+        let summary = cardTypeSummaries.find(
+          (s) => s.attributes.displayName === filter.cardTypeName,
+        );
+        if (!summary) {
+          return;
+        }
+        const lastIndex = summary.id.lastIndexOf('/');
+        let cardRef = {
+          module: summary.id.substring(0, lastIndex),
+          name: summary.id.substring(lastIndex + 1),
+        };
+        filter.cardRef = cardRef;
+        filter.query = { filter: { type: cardRef } };
+        this.filterMap.set('Super Project Account', filters);
+      }
+    }
+  });
+
+  get filters() {
+    return this.filterMap.get('Super Project Account')!;
+  }
+
+  //misc
+  get currentRealm() {
+    return this.args.model[realmURL];
+  }
+  private get realms() {
+    return [this.currentRealm!];
+  }
+
+  //query for filters
+  get query() {
+    const { loadAllFilters, activeFilter } = this;
+
+    if (!loadAllFilters.isIdle || !activeFilter?.query) {
+      return;
+    }
+
+    const defaultFilter = [
+      {
+        type: activeFilter.cardRef,
+      },
+      {
+        on: activeFilter.cardRef,
+        eq: {
+          'superProjectApp.id': this.args.model.id,
+        },
+      },
+    ];
+
+    const query = {
+      filter: {
+        on: activeFilter.cardRef,
+        every: [...defaultFilter],
+      },
+      sort: sortByCardTitleAsc,
+    } as Query;
+
+    return query;
+  }
+
+  <template>
+    <Layout
+      class='super-project-app'
+      @filters={{this.filters}}
+      @activeFilter={{this.activeFilter}}
+      @onFilterChange={{this.onFilterChange}}
+    >
+      <:sidebar>
+        <TitleGroup
+          @title={{@model.title}}
+          @tagline={{@model.description}}
+          @thumbnailURL={{@model.thumbnailURL}}
+          @element='header'
+          aria-label='Sidebar Header'
+        />
+      </:sidebar>
+      <:contentHeader>
+        <h2 class='content-title content-header-row-1'>
+          <this.activeFilter.icon
+            class='content-title-icon'
+            width='35'
+            height='35'
+          />
+          {{this.activeFilter.displayName}}
+        </h2>
+      </:contentHeader>
+      <:grid>
+        {{#if this.query}}
+          <h2>1. Original CardList (with PrerenderedCardSearch)</h2>
+          <h3>Issue of this Method: Couldn't show query data inside
+            embedded/other formats</h3>
+          <ul>
+            <li>Pros:
+              <ul>
+                <li>Better performance for static content due to prerendered
+                  HTML</li>
+                <li>Faster initial page load</li>
+                <li>Has meta function support for additional data</li>
+              </ul>
+            </li>
+            <li>Cons:
+              <ul>
+                <li>Cannot handle dynamic queries in embedded formats</li>
+              </ul>
+            </li>
+          </ul>
+          <CardList
+            @context={{@context}}
+            @query={{this.query}}
+            @realms={{this.realms}}
+            class='super-project-app-grid'
+          />
+
+          <hr />
+
+          <h2>2. CardListWithoutPrerendered (using getCards API)</h2>
+          <ul>
+            <li>Pros:
+              <ul>
+                <li>Works consistently across all formats (embedded, isolated)</li>
+                <li>Handles dynamic queries effectively</li>
+                <li>Real-time data updates possible</li>
+              </ul>
+            </li>
+            <li>Cons:
+              <ul>
+                <li>Slightly slower initial load compared to prerendered content
+                  when a lot of cards are loaded</li>
+                <li>Higher server load due to direct queries</li>
+                <li>Currently lacks meta function support</li>
+              </ul>
+            </li>
+          </ul>
+          <CardListWithoutPrerendered
+            @context={{@context}}
+            @query={{this.query}}
+            @realms={{this.realms}}
+            class='super-project-app-grid'
+          />
+        {{/if}}
+      </:grid>
+    </Layout>
+    <style scoped>
+      .super-project-app {
+        display: flex;
+        width: 100%;
+        max-width: 100%;
+        height: 100%;
+        max-height: 100vh;
+        background-color: var(--boxel-light);
+        overflow: hidden;
+      }
+
+      .super-project-app-grid {
+        display: flex;
+        flex-direction: column;
+        gap: var(--boxel-sp-xl);
+      }
+      hr {
+        margin: var(--boxel-sp-xl) 0;
+      }
+    </style>
+  </template>
+}
+
+export class SuperProjectApp extends CardDef {
+  static displayName = 'Super Project App';
+  static prefersWideFormat = true;
+  static isolated = SuperProjectAppTemplate;
+}

--- a/packages/experiments-realm/super-project/account.gts
+++ b/packages/experiments-realm/super-project/account.gts
@@ -8,8 +8,6 @@ import { Component, BaseDef } from 'https://cardstack.com/base/card-api';
 import GlimmerComponent from '@glimmer/component';
 import { field } from 'https://cardstack.com/base/card-api';
 import { SuperProjectApp } from '../super-project-app';
-import BuildingIcon from '@cardstack/boxel-icons/building';
-import AccountHeader from '../components/account-header';
 import { Query } from '@cardstack/runtime-common/query';
 import { getCards } from '@cardstack/runtime-common';
 import { SkeletonPlaceholder } from '@cardstack/boxel-ui/components';

--- a/packages/experiments-realm/super-project/account.gts
+++ b/packages/experiments-realm/super-project/account.gts
@@ -1,0 +1,176 @@
+import {
+  CardDef,
+  linksTo,
+  realmURL,
+} from 'https://cardstack.com/base/card-api';
+import { contains, StringField } from 'https://cardstack.com/base/card-api';
+import { Component, BaseDef } from 'https://cardstack.com/base/card-api';
+import GlimmerComponent from '@glimmer/component';
+import { field } from 'https://cardstack.com/base/card-api';
+import { SuperProjectApp } from '../super-project-app';
+import BuildingIcon from '@cardstack/boxel-icons/building';
+import AccountHeader from '../components/account-header';
+import { Query } from '@cardstack/runtime-common/query';
+import { getCards } from '@cardstack/runtime-common';
+import { SkeletonPlaceholder } from '@cardstack/boxel-ui/components';
+
+const taskSource = {
+  module: new URL('./task', import.meta.url).href,
+  name: 'SuperProjectTask',
+};
+
+class EmbeddedTemplate extends Component<typeof SuperProjectAccount> {
+  get realmURL(): URL {
+    return this.args.model[realmURL]!;
+  }
+
+  get realmHrefs() {
+    return [this.realmURL?.href];
+  }
+
+  get accountId() {
+    return this.args.model.id;
+  }
+
+  get activeTasksQuery(): Query {
+    let everyArr = [];
+    if (this.accountId) {
+      everyArr.push({
+        eq: {
+          'account.id': this.accountId,
+        },
+      });
+    }
+    return {
+      filter: {
+        on: taskSource,
+        every: everyArr,
+      },
+    };
+  }
+
+  activeTasks = getCards(
+    () => this.activeTasksQuery,
+    () => this.realmHrefs,
+    {
+      isLive: true,
+    },
+  );
+
+  get activeTasksCount() {
+    const tasks = this.activeTasks;
+    if (!tasks || tasks.isLoading) {
+      return 0;
+    }
+    return tasks.instances?.length ?? 0;
+  }
+
+  get hasActiveTasks() {
+    return this.activeTasksCount > 0;
+  }
+
+  <template>
+    <AccountPageLayout>
+      <:header>
+        {{#if @model.name}}
+          <h1 class='account-name'>{{@model.name}}</h1>
+        {{else}}
+          <h1 class='account-name default-value'>Missing Account Name</h1>
+        {{/if}}
+      </:header>
+      <:summary>
+        <article>
+          {{#if this.activeTasks.isLoading}}
+            <SkeletonPlaceholder class='skeleton-placeholder-task' />
+          {{else}}
+            <div class='task-container'>
+              {{#if this.hasActiveTasks}}
+                {{#each this.activeTasks.instances as |task|}}
+                  {{#let (getComponent task) as |Component|}}
+                    <Component
+                      @format='embedded'
+                      @displayContainer={{false}}
+                      class='task-card-embedded'
+                    />
+                  {{/let}}
+                {{/each}}
+              {{else}}
+                <div class='empty-card'>
+                  <p class='description'>No Upcoming Tasks</p>
+                </div>
+              {{/if}}
+            </div>
+          {{/if}}
+        </article>
+      </:summary>
+    </AccountPageLayout>
+    <style scoped>
+      h1,
+      p {
+        margin: 0;
+      }
+      .skeleton-placeholder-task {
+        --skeleton-height: 55px;
+      }
+      .task-card-embedded,
+      .empty-card {
+        border: 1px solid var(--boxel-200);
+        border-radius: var(--boxel-radius);
+        padding: var(--boxel-sp);
+      }
+      .task-card-fitted {
+        background-color: var(--boxel-teal);
+      }
+      .empty-card {
+        background-color: var(--boxel-300);
+      }
+    </style>
+  </template>
+}
+
+export class SuperProjectAccount extends CardDef {
+  static displayName = 'Super Project Account';
+  @field superProjectApp = linksTo(() => SuperProjectApp);
+  @field name = contains(StringField);
+  @field title = contains(StringField, {
+    computeVia: function (this: SuperProjectAccount) {
+      return this.name ?? `Untitled ${this.constructor.displayName}`;
+    },
+  });
+
+  static embedded = EmbeddedTemplate;
+}
+
+interface AccountPageLayoutArgs {
+  Blocks: {
+    header: [];
+    summary: [];
+    tasks: [];
+  };
+  Element: HTMLElement;
+}
+
+class AccountPageLayout extends GlimmerComponent<AccountPageLayoutArgs> {
+  <template>
+    <div class='account-page-layout' ...attributes>
+      {{yield to='header'}}
+      {{yield to='summary'}}
+      {{yield to='tasks'}}
+    </div>
+
+    <style scoped>
+      .account-page-layout {
+        display: flex;
+        flex-direction: column;
+        gap: var(--boxel-sp-lg);
+        width: 100%;
+        padding: var(--account-page-layout-padding, 20px);
+        box-sizing: border-box;
+      }
+    </style>
+  </template>
+}
+
+function getComponent(cardOrField: BaseDef) {
+  return cardOrField.constructor.getComponent(cardOrField);
+}

--- a/packages/experiments-realm/super-project/task.gts
+++ b/packages/experiments-realm/super-project/task.gts
@@ -12,7 +12,7 @@ import EntityDisplayWithIcon from '../components/entity-icon-display';
 
 class EmbeddedTemplate extends Component<typeof SuperProjectTask> {
   <template>
-    <EntityDisplayWithIcon @title={{this.args.model.name}}>
+    <EntityDisplayWithIcon @title={{@model.name}}>
       <:icon>
         <FolderOpen />
       </:icon>

--- a/packages/experiments-realm/super-project/task.gts
+++ b/packages/experiments-realm/super-project/task.gts
@@ -1,0 +1,36 @@
+import {
+  StringField,
+  contains,
+  field,
+  linksTo,
+  CardDef,
+} from 'https://cardstack.com/base/card-api';
+import { SuperProjectAccount } from './account';
+import { Component } from 'https://cardstack.com/base/card-api';
+import FolderOpen from '@cardstack/boxel-icons/folder-open';
+import EntityDisplayWithIcon from '../components/entity-icon-display';
+
+class EmbeddedTemplate extends Component<typeof SuperProjectTask> {
+  <template>
+    <EntityDisplayWithIcon @title={{this.args.model.name}}>
+      <:icon>
+        <FolderOpen />
+      </:icon>
+    </EntityDisplayWithIcon>
+  </template>
+}
+
+export class SuperProjectTask extends CardDef {
+  static displayName = 'Super Project Task';
+
+  @field name = contains(StringField);
+  @field account = linksTo(() => SuperProjectAccount);
+
+  @field title = contains(StringField, {
+    computeVia: function (this: SuperProjectTask) {
+      return this.name ?? `Untitled ${this.constructor.displayName}`;
+    },
+  });
+
+  static embedded = EmbeddedTemplate;
+}


### PR DESCRIPTION
As per today’s sprint planning, we discussed the issue of displaying nested query data in an embedded format within the CRM App.

Issue:
**In the Account.gts Embedded Format, everything appears to be working correctly:**
<img width="1431" alt="Screenshot 2025-02-19 at 14 51 06" src="https://github.com/user-attachments/assets/0cb4a5a6-97b3-4efb-be71-933d4bb893ff" />

**However, in the CRM App, the nested query data is not displaying:**
<img width="1432" alt="Screenshot 2025-02-19 at 14 37 59" src="https://github.com/user-attachments/assets/90f0db2a-6e09-4af9-8b0a-01cd370635b1" />

---------------------------

To address this issue,I created a **super-project-app** that replicates the same problem to make it easier to visualize the issue . I have outlined two methods:

- Using the original approach, PrerenderedCardSearch, which has the issue of not displaying the query data correctly.
- Using the getCards API, which temporarily resolves the issue.

Both methods have their pros and cons, which are detailed below:

https://github.com/user-attachments/assets/d2259c7d-60e2-48cb-ad39-f428d5596e75






