### PR TITLE
Playground instance previewed in edit view should save changes

### DIFF
--- a/packages/experiments-realm/Review/7f3c8694-7fa8-41d6-a449-14337c51fa29.json
+++ b/packages/experiments-realm/Review/7f3c8694-7fa8-41d6-a449-14337c51fa29.json
@@ -3,7 +3,7 @@
     "type": "card",
     "attributes": {
       "rating": {
-        "average": 4.5,
+        "average": 3,
         "count": null,
         "isEditable": false
       },

--- a/packages/experiments-realm/Review/7f3c8694-7fa8-41d6-a449-14337c51fa29.json
+++ b/packages/experiments-realm/Review/7f3c8694-7fa8-41d6-a449-14337c51fa29.json
@@ -3,7 +3,7 @@
     "type": "card",
     "attributes": {
       "rating": {
-        "average": 3,
+        "average": 4.5,
         "count": null,
         "isEditable": false
       },

--- a/packages/host/app/components/operator-mode/code-submode/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground-panel.gts
@@ -288,9 +288,8 @@ class PlaygroundPanelContent extends Component<PlaygroundContentSignature> {
         max-height: 20rem;
       }
       :deep(
-          .boxel-select__dropdown
-            .ember-power-select-option[aria-current='true']
-        ),
+        .boxel-select__dropdown .ember-power-select-option[aria-current='true']
+      ),
       :deep(.instances-dropdown-content .ember-power-select-option) {
         background-color: var(--boxel-light);
       }

--- a/packages/host/app/components/operator-mode/code-submode/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground-panel.gts
@@ -489,12 +489,19 @@ class PlaygroundPanelContent extends Component<PlaygroundContentSignature> {
   });
 
   private get canEdit() {
-    return this.format !== 'edit' && this.realm.canWrite(this.card.id);
+    return (
+      this.format !== 'edit' &&
+      this.card?.id &&
+      this.realm.canWrite(this.card.id)
+    );
   }
 
   @action
   private setEditFormat() {
-    this.format = 'edit';
+    if (!this.card?.id) {
+      return;
+    }
+    this.persistSelections(this.card.id, 'edit');
   }
 }
 

--- a/packages/host/app/components/operator-mode/code-submode/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground-panel.gts
@@ -213,6 +213,7 @@ class PlaygroundPanelContent extends Component<PlaygroundContentSignature> {
                   @cardTypeDisplayName={{cardTypeDisplayName this.card}}
                   @cardTypeIcon={{cardTypeIcon this.card}}
                   @realmInfo={{realmInfo}}
+                  @onEdit={{if this.canEdit this.setEditFormat}}
                   @isTopCard={{true}}
                   @moreOptionsMenuItems={{this.contextMenuItems}}
                 />
@@ -284,8 +285,9 @@ class PlaygroundPanelContent extends Component<PlaygroundContentSignature> {
         max-height: 20rem;
       }
       :deep(
-        .boxel-select__dropdown .ember-power-select-option[aria-current='true']
-      ),
+          .boxel-select__dropdown
+            .ember-power-select-option[aria-current='true']
+        ),
       :deep(.instances-dropdown-content .ember-power-select-option) {
         background-color: var(--boxel-light);
       }
@@ -403,8 +405,10 @@ class PlaygroundPanelContent extends Component<PlaygroundContentSignature> {
     };
   }
 
-  private cardResource = getCard(this, () =>
-    this.playgroundSelections[this.args.moduleId]?.replace(/\.json$/, ''),
+  private cardResource = getCard(
+    this,
+    () => this.playgroundSelections[this.args.moduleId]?.replace(/\.json$/, ''),
+    { isAutoSave: () => true },
   );
 
   private get card(): CardDef | undefined {
@@ -472,6 +476,15 @@ class PlaygroundPanelContent extends Component<PlaygroundContentSignature> {
       this.persistSelections(chosenCard.id);
     }
   });
+
+  private get canEdit() {
+    return this.format !== 'edit' && this.realm.canWrite(this.card.id);
+  }
+
+  @action
+  private setEditFormat() {
+    this.format = 'edit';
+  }
 }
 
 interface Signature {

--- a/packages/host/app/lib/stack-item.ts
+++ b/packages/host/app/lib/stack-item.ts
@@ -48,10 +48,13 @@ export class StackItem {
     if (cardResource) {
       this.cardResource = cardResource;
     } else if (url) {
-      this.cardResource = getCard(owner, () => url!.href);
+      this.cardResource = getCard(owner, () => url!.href, {
+        isAutoSave: () => true,
+      });
     } else if (newCard) {
       this.cardResource = getCard(owner, () => newCard!.doc, {
         relativeTo: newCard.relativeTo,
+        isAutoSave: () => true,
       });
     }
 
@@ -75,6 +78,10 @@ export class StackItem {
     }
 
     throw new Error(`This StackItem has no card set`);
+  }
+
+  get autoSaveState() {
+    return this.cardResource?.autoSaveState;
   }
 
   get title() {

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -254,7 +254,7 @@ export default class MatrixService extends Service {
   get fileAPI() {
     if (this.fileAPIModule.error) {
       throw new Error(
-        `Error loading File API: ${JSON.stringify(this.cardAPIModule.error)}`,
+        `Error loading File API: ${JSON.stringify(this.fileAPIModule.error)}`,
       );
     }
     if (!this.fileAPIModule.module) {

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -529,7 +529,9 @@ export default class OperatorModeStateService extends Service {
       let newStack: Stack = new TrackedArray([]);
       for (let item of stack) {
         let { format } = item;
-        let cardResource = getCard(this, () => item.id);
+        let cardResource = getCard(this, () => item.id, {
+          isAutoSave: () => true,
+        });
         let stackItem = new StackItem({
           owner: this, // ugh, not a great owner...
           cardResource,

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -112,11 +112,11 @@ export default class StoreService extends Service {
       const index = resources.findIndex(
         (s) => s.resourceState.resource === resource,
       );
-      let { onCardChange } = resources[index].resourceState;
+      let { onCardChange } = resources[index]?.resourceState || {};
       if (onCardChange && resource.card) {
         let autoSaveState = this.getAutoSaveState(resource.card);
         if (autoSaveState?.hasUnsavedChanges) {
-          onCardChange();
+          this.saveCard.perform(resource.card);
         }
 
         resource.api.unsubscribeFromChanges(resource.card, onCardChange);

--- a/packages/host/tests/acceptance/code-submode/playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/playground-test.gts
@@ -1,5 +1,7 @@
 import { click } from '@ember/test-helpers';
 
+import { fillIn } from '@ember/test-helpers';
+
 import window from 'ember-window-mock';
 import { module, test } from 'qunit';
 
@@ -14,22 +16,28 @@ import {
   setupAcceptanceTestRealm,
   setupLocalIndexing,
   setupServerSentEvents,
+  setupOnSave,
+  setupUserSubscription,
   testRealmURL,
   visitOperatorMode,
   type TestContextWithSSE,
+  type TestContextWithSave,
 } from '../../helpers';
 import { setupMockMatrix } from '../../helpers/mock-matrix';
 import { setupApplicationTest } from '../../helpers/setup';
 
+let matrixRoomId: string;
 module('Acceptance | code-submode | playground panel', function (hooks) {
   let realm: Realm;
   setupApplicationTest(hooks);
   setupLocalIndexing(hooks);
   setupServerSentEvents(hooks);
-  setupMockMatrix(hooks, {
-    loggedInAs: '@testuser:staging',
-    activeRealms: [testRealmURL],
-  });
+  let { setRealmPermissions, setActiveRealms, createAndJoinRoom } =
+    setupMockMatrix(hooks, {
+      loggedInAs: '@testuser:staging',
+      activeRealms: [testRealmURL],
+    });
+  setupOnSave(hooks);
 
   const authorCard = `import { contains, field, CardDef, Component } from "https://cardstack.com/base/card-api";
 import MarkdownField from 'https://cardstack.com/base/markdown';
@@ -117,7 +125,11 @@ export class BlogPost extends CardDef {
 }`;
 
   hooks.beforeEach(async function () {
+    matrixRoomId = createAndJoinRoom('@testuser:staging', 'room-test');
+    setupUserSubscription(matrixRoomId);
+
     ({ realm } = await setupAcceptanceTestRealm({
+      realmURL: testRealmURL,
       contents: {
         'author.gts': authorCard,
         'blog-post.gts': blogPostCard,
@@ -235,6 +247,11 @@ export class BlogPost extends CardDef {
       ]),
     );
     window.localStorage.setItem(PlaygroundSelections, '');
+
+    setActiveRealms([testRealmURL]);
+    setRealmPermissions({
+      [testRealmURL]: ['read', 'write'],
+    });
   });
 
   test('can render playground panel when a card def is selected', async function (assert) {
@@ -837,6 +854,30 @@ export class BlogPost extends CardDef {
           format: 'fitted',
         },
       }),
+    );
+  });
+
+  test<TestContextWithSave>('trigger auto saved in edit format', async function (assert) {
+    await visitOperatorMode({
+      submode: 'code',
+      codePath: `${testRealmURL}author.gts`,
+    });
+    await click('[data-test-accordion-item="playground"] button');
+    await click('[data-test-instance-chooser]');
+    await click('[data-option-index="0"]');
+    await click('[data-test-edit-button]');
+    assert.dom('[data-test-card-format="edit"]').exists();
+
+    let newFirstName = 'John';
+    this.onSave((_, json) => {
+      if (typeof json === 'string') {
+        throw new Error('expected JSON save data');
+      }
+      assert.strictEqual(json.data.attributes?.firstName, newFirstName);
+    });
+    await fillIn(
+      '[data-test-field="firstName"] [data-test-boxel-input]',
+      newFirstName,
     );
   });
 });


### PR DESCRIPTION
- [x] Refactored the auto-save handler by moving it to the store service, based on @habdelra's suggestion.  
- [x] Made `cardResource` in the playground panel an auto-saving card. 