### PR TITLE
add a href to website field

### DIFF
--- a/packages/experiments-realm/email.gts
+++ b/packages/experiments-realm/email.gts
@@ -69,6 +69,11 @@ export class EmailField extends StringField {
     <template>
       {{#if @model}}
         <EntityDisplayWithIcon @title={{@model}} @underline={{false}}>
+          <:title>
+            <a href='mailto:{{@model}}' rel='noopener noreferrer'>
+              {{@model}}
+            </a>
+          </:title>
           <:icon>
             <MailIcon class='icon' />
           </:icon>
@@ -77,6 +82,10 @@ export class EmailField extends StringField {
       <style scoped>
         .icon {
           color: var(--boxel-400);
+        }
+        a:hover {
+          text-decoration: underline;
+          color: inherit;
         }
       </style>
     </template>

--- a/packages/experiments-realm/website.gts
+++ b/packages/experiments-realm/website.gts
@@ -20,6 +20,8 @@ export class WebsiteField extends UrlField {
     <template>
       <EntityDisplayWithIcon>
         <:title>
+          {{! Display only domain and path, unlike URLField's full URL representation }}
+          {{! Custom atom implementation for handling URL interactions }}
           {{#if @model}}
             {{#if (isValidUrl @model)}}
               <a href={{@model}} target='_blank' rel='noopener noreferrer'>

--- a/packages/experiments-realm/website.gts
+++ b/packages/experiments-realm/website.gts
@@ -18,17 +18,57 @@ export class WebsiteField extends UrlField {
 
   static atom = class Atom extends Component<typeof WebsiteField> {
     <template>
-      <EntityDisplayWithIcon @title={{domainWithPath @model}}>
+      <EntityDisplayWithIcon>
+        <:title>
+          {{#if @model}}
+            {{#if (isValidUrl @model)}}
+              <a href={{@model}} target='_blank' rel='noopener noreferrer'>
+                {{domainWithPath @model}}
+              </a>
+            {{else}}
+              Invalid URL
+            {{/if}}
+          {{/if}}
+        </:title>
         <:icon>
           <WorldWwwIcon />
         </:icon>
       </EntityDisplayWithIcon>
+      <style scoped>
+        a:hover {
+          text-decoration: underline;
+          color: inherit;
+        }
+      </style>
     </template>
   };
 
   static embedded = class Embedded extends Component<typeof WebsiteField> {
     <template>
-      {{domainWithPath @model}}
+      {{#if @model}}
+        {{#if (isValidUrl @model)}}
+          <a href={{@model}} target='_blank' rel='noopener noreferrer'>
+            {{domainWithPath @model}}
+          </a>
+        {{else}}
+          Invalid URL
+        {{/if}}
+      {{/if}}
+      <style scoped>
+        a:hover {
+          text-decoration: underline;
+          color: inherit;
+        }
+      </style>
     </template>
   };
+}
+
+function isValidUrl(urlString: string): boolean {
+  try {
+    new URL(urlString);
+    return true;
+  } catch (err) {
+    return false;
+  }
 }


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-7698/website-field-shud-not-need-to-https

Issue: The website field is not clickable because the atom format is overriding the URL field's atom format, which contains the href functionality for making links clickable.

Result:

https://github.com/user-attachments/assets/c72c5036-7c23-49a3-a15c-4d75bb7b45c8





