### PR TITLE
use pure js hash function for marked code block generation

### DIFF
--- a/packages/runtime-common/marked-sync.ts
+++ b/packages/runtime-common/marked-sync.ts
@@ -1,6 +1,6 @@
 import { marked } from 'marked';
 import { sanitizeHtml } from './dompurify-runtime';
-import { md5 } from 'super-fast-md5';
+import { simpleHash } from '.';
 
 const CODEBLOCK_KEY_PREFIX = 'codeblock_';
 
@@ -12,7 +12,7 @@ export function markedSync(markdown: string) {
         // markdown, please use the `CodeBlock` modifier to render the
         // markdown.
         code(code, language = '') {
-          let id = `${CODEBLOCK_KEY_PREFIX}${md5(Date.now() + language + code)}`;
+          let id = `${CODEBLOCK_KEY_PREFIX}${simpleHash(Date.now() + language + code)}`;
           // we pass the code thru using localstorage instead of in the DOM,
           // that way we don't have to worry about escaping code. note that the
           // DOM wants to render "<template>" strings when we put them in the

--- a/packages/runtime-common/utils.ts
+++ b/packages/runtime-common/utils.ts
@@ -61,3 +61,14 @@ export function decodeWebSafeBase64(encoded: string): string {
 
   return Buffer.from(base64, 'base64').toString('utf-8');
 }
+
+// This is the djb2_xor hash function from http://www.cse.yorku.ca/~oz/hash.html
+export function simpleHash(str: string) {
+  let len = str.length;
+  let h = 5381;
+
+  for (let i = 0; i < len; i++) {
+    h = (h * 33) ^ str.charCodeAt(i);
+  }
+  return (h >>> 0).toString(16);
+}


### PR DESCRIPTION
This fixes a bug where the md5 hash function was not running in the Fastboot env of the worker during indexing. we have replaced this with a pure js hash function.

This solves the indexing error:
```
[worker 109608 priority 0]: Promise rejected TypeError: Cannot read properties of undefined (reading 'encode')
Please report this to https://github.com/markedjs/marked.
    at getUInt8Buffer (/tmp/tmp-109608-FsRSCx8brLfb/assets/chunk.ba6f521a38934cbdb921.js:412524:24)
    at calculate (/tmp/tmp-109608-FsRSCx8brLfb/assets/chunk.ba6f521a38934cbdb921.js:412562:18)
    at md5 (/tmp/tmp-109608-FsRSCx8brLfb/assets/chunk.ba6f521a38934cbdb921.js:412585:10)
    at _Renderer.code (/tmp/tmp-109608-FsRSCx8brLfb/assets/chunk.2a0fc7d9e4a377bfdb0a.js:19687:95)
    at renderer.<computed> [as code] (/tmp/tmp-109608-FsRSCx8brLfb/assets/chunk.ba6f521a38934cbdb921.js:595221:36)
    at _Parser.parse (/tmp/tmp-109608-FsRSCx8brLfb/assets/chunk.ba6f521a38934cbdb921.js:594850:34)
    at parse (/tmp/tmp-109608-FsRSCx8brLfb/assets/chunk.ba6f521a38934cbdb921.js:594804:19)
    at Marked.parse (/tmp/tmp-109608-FsRSCx8brLfb/assets/chunk.ba6f521a38934cbdb921.js:595367:20)
    at Function.marked [as parse] (/tmp/tmp-109608-FsRSCx8brLfb/assets/chunk.ba6f521a38934cbdb921.js:595396:25)
    at markedSync
```

h/t @IanCal :pray: 