### PR TITLE
Fixes the bug where switching from module to an instance in code mode would show a loading indicator that never dismisses

### DIFF
--- a/packages/host/app/resources/module-contents.ts
+++ b/packages/host/app/resources/module-contents.ts
@@ -99,7 +99,11 @@ export class ModuleContentsResource extends Resource<Args> {
   // it has to know this to distinguish the act of editing of a file and switching between definitions
   // when editing a file we don't want to introduce loading state, whereas when switching between definitions we do
   get isLoadingNewModule() {
-    return this.executableFile?.url !== this.state?.url ?? false;
+    if (!this.executableFile) {
+      return false;
+    }
+
+    return this.executableFile.url !== this.state?.url;
   }
 
   get declarations() {

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -650,6 +650,39 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     assert.dom('[data-test-card-instance-definition]').doesNotExist();
   });
 
+  test('can switch between inspector showing module definition and inspector showing json instance definition in card inheritance panel', async function (assert) {
+    await visitOperatorMode({
+      stacks: [[]],
+      submode: 'code',
+      codePath: `${testRealmURL}person.gts`,
+    });
+
+    await waitForCodeEditor();
+    await waitFor('[data-test-card-inspector-panel]');
+    await waitFor('[data-test-card-module-definition]');
+
+    assert.dom('[data-test-card-module-definition]').includesText('Card');
+    assert.dom('[data-test-card-instance-definition]').doesNotExist();
+
+    await click('[data-test-file-browser-toggle]');
+    await click('[data-test-directory="Person/"]');
+    await waitFor('[data-test-file="Person/1.json"]');
+    await click('[data-test-file="Person/1.json"]');
+
+    await click('[data-test-inspector-toggle]');
+    await waitFor('[data-test-card-inspector-panel]');
+    await waitFor('[data-test-card-module-definition]');
+
+    assert
+      .dom('[data-test-card-instance-definition]')
+      .includesText('Hassan Abdel-Rahman');
+    assert
+      .dom(
+        '[data-test-card-instance-definition] [data-test-definition-file-extension]',
+      )
+      .includesText('.JSON');
+  });
+
   test('"in-this-file" panel displays all elements and re-highlights upon selection', async function (assert) {
     await visitOperatorMode({
       stacks: [[]],


### PR DESCRIPTION
Fixes this bug where switching from a module to an instance in code module would show a loading indicator that never dismisses.

Before:

![loading-bug-before](https://github.com/user-attachments/assets/cc8c3870-4f7d-4bb2-8a22-749dc3680a03)

After:

![loading-bug-after2](https://github.com/user-attachments/assets/e2c74d3f-86d2-4e96-9fc2-bb7fe2b286df)

