### PR TITLE
Don't treat non-URL CodeRef modules as URLs

### DIFF
--- a/packages/base/code-ref.gts
+++ b/packages/base/code-ref.gts
@@ -16,6 +16,14 @@ import {
 import { ResolvedCodeRef } from '@cardstack/runtime-common';
 import CodeIcon from '@cardstack/boxel-icons/code';
 
+function moduleIsUrlLike(module: string) {
+  return (
+    module.startsWith('http') ||
+    module.startsWith('.') ||
+    module.startsWith('/')
+  );
+}
+
 class BaseView extends Component<typeof CodeRefField> {
   <template>
     <div data-test-ref>
@@ -37,11 +45,11 @@ export default class CodeRefField extends FieldDef {
     _visited?: Set<string>,
     opts?: SerializeOpts,
   ) {
-    const moduleIsUrlLike =
-      codeRef.module.startsWith('http') || codeRef.module.startsWith('.');
     return {
       ...codeRef,
-      ...(opts?.maybeRelativeURL && !opts?.useAbsoluteURL && moduleIsUrlLike
+      ...(opts?.maybeRelativeURL &&
+      !opts?.useAbsoluteURL &&
+      moduleIsUrlLike(codeRef.module)
         ? { module: opts.maybeRelativeURL(codeRef.module) }
         : {}),
     };
@@ -72,9 +80,7 @@ function maybeSerializeCodeRef(
   stack: CardDef[] = [],
 ) {
   if (codeRef) {
-    const moduleIsUrlLike =
-      codeRef.module.startsWith('http') || codeRef.module.startsWith('.');
-    if (moduleIsUrlLike) {
+    if (moduleIsUrlLike(codeRef.module)) {
       // if a stack is passed in, use the containing card to resolve relative references
       let moduleHref =
         stack.length > 0

--- a/packages/base/code-ref.gts
+++ b/packages/base/code-ref.gts
@@ -37,9 +37,11 @@ export default class CodeRefField extends FieldDef {
     _visited?: Set<string>,
     opts?: SerializeOpts,
   ) {
+    const moduleIsUrlLike =
+      codeRef.module.startsWith('http') || codeRef.module.startsWith('.');
     return {
       ...codeRef,
-      ...(opts?.maybeRelativeURL && !opts?.useAbsoluteURL
+      ...(opts?.maybeRelativeURL && !opts?.useAbsoluteURL && moduleIsUrlLike
         ? { module: opts.maybeRelativeURL(codeRef.module) }
         : {}),
     };
@@ -70,12 +72,18 @@ function maybeSerializeCodeRef(
   stack: CardDef[] = [],
 ) {
   if (codeRef) {
-    // if a stack is passed in, use the containing card to resolve relative references
-    let moduleHref =
-      stack.length > 0
-        ? new URL(codeRef.module, stack[0][relativeTo]).href
-        : codeRef.module;
-    return `${moduleHref}/${codeRef.name}`;
+    const moduleIsUrlLike =
+      codeRef.module.startsWith('http') || codeRef.module.startsWith('.');
+    if (moduleIsUrlLike) {
+      // if a stack is passed in, use the containing card to resolve relative references
+      let moduleHref =
+        stack.length > 0
+          ? new URL(codeRef.module, stack[0][relativeTo]).href
+          : codeRef.module;
+      return `${moduleHref}/${codeRef.name}`;
+    } else {
+      return `${codeRef.module}/${codeRef.name}`;
+    }
   }
   return undefined;
 }

--- a/packages/base/skill-card.gts
+++ b/packages/base/skill-card.gts
@@ -1,11 +1,66 @@
+import {
+  CardDef,
+  Component,
+  FieldDef,
+  field,
+  contains,
+  containsMany,
+} from './card-api';
+import BooleanField from './boolean';
+import CodeRefField from './code-ref';
 import MarkdownField from './markdown';
-import { CardDef, Component, field, contains } from './card-api';
+import StringField from './string';
 import RobotIcon from '@cardstack/boxel-icons/robot';
+
+function djb2_xor(str: string) {
+  let len = str.length;
+  let h = 5381;
+
+  for (let i = 0; i < len; i++) {
+    h = (h * 33) ^ str.charCodeAt(i);
+  }
+  return (h >>> 0).toString(16);
+}
+
+function friendlyModuleName(fullModuleUrl: string) {
+  return fullModuleUrl
+    .split('/')
+    .slice(-1)[0]
+    .replace(/\.gts$/, ' ');
+}
+
+export class CommandField extends FieldDef {
+  static displayName = 'CommandField';
+  @field codeRef = contains(CodeRefField, {
+    description: 'An absolute code reference to the command to be executed',
+  });
+  @field requiresApproval = contains(BooleanField, {
+    description:
+      'If true, this command will require human approval before it is executed in the host.',
+  });
+
+  @field functionName = contains(StringField, {
+    description: 'The name of the function to be executed',
+    computeVia: function (this: CommandField) {
+      if (!this.codeRef?.module || !this.codeRef?.name) {
+        return '';
+      }
+
+      const hashed = djb2_xor(`${this.codeRef.module}#${this.codeRef.name}`);
+      let name =
+        this.codeRef.name === 'default'
+          ? friendlyModuleName(this.codeRef.module)
+          : this.codeRef.name;
+      return `${name}_${hashed.slice(0, 4)}`;
+    },
+  });
+}
 
 export class SkillCard extends CardDef {
   static displayName = 'Skill';
   static icon = RobotIcon;
   @field instructions = contains(MarkdownField);
+  @field commands = containsMany(CommandField);
   static embedded = class Embedded extends Component<typeof this> {
     <template>
       <@fields.title />

--- a/packages/base/skill-card.gts
+++ b/packages/base/skill-card.gts
@@ -11,22 +11,13 @@ import CodeRefField from './code-ref';
 import MarkdownField from './markdown';
 import StringField from './string';
 import RobotIcon from '@cardstack/boxel-icons/robot';
-
-function djb2_xor(str: string) {
-  let len = str.length;
-  let h = 5381;
-
-  for (let i = 0; i < len; i++) {
-    h = (h * 33) ^ str.charCodeAt(i);
-  }
-  return (h >>> 0).toString(16);
-}
+import { simpleHash } from '@cardstack/runtime-common';
 
 function friendlyModuleName(fullModuleUrl: string) {
   return fullModuleUrl
     .split('/')
-    .slice(-1)[0]
-    .replace(/\.gts$/, ' ');
+    .pop()!
+    .replace(/\.gts$/, '');
 }
 
 export class CommandField extends FieldDef {
@@ -46,7 +37,7 @@ export class CommandField extends FieldDef {
         return '';
       }
 
-      const hashed = djb2_xor(`${this.codeRef.module}#${this.codeRef.name}`);
+      const hashed = simpleHash(`${this.codeRef.module}#${this.codeRef.name}`);
       let name =
         this.codeRef.name === 'default'
           ? friendlyModuleName(this.codeRef.module)

--- a/packages/host/tests/integration/realm-indexing-and-querying-test.gts
+++ b/packages/host/tests/integration/realm-indexing-and-querying-test.gts
@@ -734,6 +734,27 @@ module(`Integration | realm indexing and querying`, function (hooks) {
             },
           },
         },
+        'people-skill.json': {
+          data: {
+            attributes: {
+              instructions: 'How to win friends and influence people',
+              commands: [
+                {
+                  codeRef: {
+                    module: `@cardstack/boxel-host/commands/switch-submode`,
+                    name: 'default',
+                  },
+                },
+              ],
+            },
+            meta: {
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/skill-card',
+                name: 'SkillCard',
+              },
+            },
+          },
+        },
       },
     });
     let indexer = realm.realmIndexQueryEngine;
@@ -800,6 +821,66 @@ module(`Integration | realm indexing and querying`, function (hooks) {
         containedExamples: null,
         isCard: true,
         isField: false,
+      });
+    } else {
+      assert.ok(
+        false,
+        `search entry was an error: ${entry?.error.errorDetail.message}`,
+      );
+    }
+    entry = await indexer.cardDocument(new URL(`${testRealmURL}people-skill`));
+    if (entry?.type === 'doc') {
+      assert.deepEqual(entry.doc.data, {
+        id: `${testRealmURL}people-skill`,
+        type: 'card',
+        links: {
+          self: `${testRealmURL}people-skill`,
+        },
+        attributes: {
+          commands: [
+            {
+              codeRef: {
+                module: '@cardstack/boxel-host/commands/switch-submode',
+                name: 'default',
+              },
+              functionName: 'switch-submode_dd88',
+              requiresApproval: null,
+            },
+          ],
+          description: null,
+          instructions: 'How to win friends and influence people',
+          thumbnailURL: null,
+          title: null,
+        },
+        meta: {
+          adoptsFrom: {
+            module: 'https://cardstack.com/base/skill-card',
+            name: 'SkillCard',
+          },
+          lastModified: adapter.lastModifiedMap.get(
+            `${testRealmURL}people-skill.json`,
+          ),
+          resourceCreatedAt: adapter.resourceCreatedAtMap.get(
+            `${testRealmURL}people-skill.json`,
+          ),
+          realmInfo: testRealmInfo,
+          realmURL: testRealmURL,
+        },
+      });
+      let instance = await indexer.instance(
+        new URL(`${testRealmURL}people-skill`),
+      );
+      assert.deepEqual(instance?.searchDoc, {
+        _cardType: 'Skill',
+        id: `${testRealmURL}people-skill`,
+        instructions: 'How to win friends and influence people',
+        commands: [
+          {
+            codeRef: `@cardstack/boxel-host/commands/switch-submode/default`,
+            functionName: 'switch-submode_dd88',
+            requiresApproval: false,
+          },
+        ],
       });
     } else {
       assert.ok(


### PR DESCRIPTION
The issue I ran into is that a recent change assumed that a CodeRef's module would always be a URL. However, ours can be something like: @cardstack/boxel-host/commands/create-ai-assistant-room

This PR above accommodates this while retaining the relative URL behavior change.
