### PR TITLE
Fix: command result dont show

### DIFF
--- a/packages/host/app/resources/room.ts
+++ b/packages/host/app/resources/room.ts
@@ -387,7 +387,8 @@ export class RoomResource extends Resource<Args> {
       (e: any) =>
         e.type === 'm.room.message' &&
         e.content.msgtype === APP_BOXEL_COMMAND_MSGTYPE &&
-        (e.event_id === effectiveEventId || e.content['m.relates_to']?.event_id === effectiveEventId),
+        (e.event_id === effectiveEventId ||
+          e.content['m.relates_to']?.event_id === effectiveEventId),
     )! as CommandEvent | undefined;
     let message = this._messageCache.get(effectiveEventId);
     if (!message || !commandEvent) {

--- a/packages/host/app/resources/room.ts
+++ b/packages/host/app/resources/room.ts
@@ -387,7 +387,7 @@ export class RoomResource extends Resource<Args> {
       (e: any) =>
         e.type === 'm.room.message' &&
         e.content.msgtype === APP_BOXEL_COMMAND_MSGTYPE &&
-        e.content['m.relates_to']?.event_id === effectiveEventId,
+        (e.event_id === effectiveEventId || e.content['m.relates_to']?.event_id === effectiveEventId),
     )! as CommandEvent | undefined;
     let message = this._messageCache.get(effectiveEventId);
     if (!message || !commandEvent) {


### PR DESCRIPTION
We didn't handle cases where command messages were not replacement messages. This caused the command result to be unprocessed and not displayed. The fix is simple: add a condition in the `updateMessageCommandResult` function.