### PR TITLE
Remove the feature flag for attaching files in AI assistant 

### DIFF
--- a/.github/workflows/deploy-host.yml
+++ b/.github/workflows/deploy-host.yml
@@ -35,7 +35,6 @@ jobs:
             echo "AWS_ROLE_ARN=arn:aws:iam::680542703984:role/boxel-host" >> $GITHUB_ENV
             echo "AWS_S3_BUCKET=cardstack-boxel-host-staging" >> $GITHUB_ENV
             echo "AWS_CLOUDFRONT_DISTRIBUTION=E35TXLK9HIMESQ" >> $GITHUB_ENV
-            echo "AI_ASSISTANT_EXPERIMENTAL_ATTACHING_FILES_ENABLED=true" >> $GITHUB_ENV
           else
             echo "unrecognized environment"
             exit 1;

--- a/.github/workflows/deploy-host.yml
+++ b/.github/workflows/deploy-host.yml
@@ -35,6 +35,7 @@ jobs:
             echo "AWS_ROLE_ARN=arn:aws:iam::680542703984:role/boxel-host" >> $GITHUB_ENV
             echo "AWS_S3_BUCKET=cardstack-boxel-host-staging" >> $GITHUB_ENV
             echo "AWS_CLOUDFRONT_DISTRIBUTION=E35TXLK9HIMESQ" >> $GITHUB_ENV
+            echo "AI_ASSISTANT_EXPERIMENTAL_ATTACHING_FILES_ENABLED=true" >> $GITHUB_ENV
           else
             echo "unrecognized environment"
             exit 1;

--- a/.github/workflows/pr-boxel-host.yml
+++ b/.github/workflows/pr-boxel-host.yml
@@ -63,7 +63,6 @@ jobs:
           AWS_S3_BUCKET: boxel-host-preview.stack.cards
           AWS_REGION: us-east-1
           AWS_CLOUDFRONT_DISTRIBUTION: EU4RGLH4EOCHJ
-          AI_ASSISTANT_EXPERIMENTAL_ATTACHING_FILES_ENABLED: true
         with:
           package: boxel-host
           environment: staging
@@ -93,7 +92,6 @@ jobs:
           AWS_S3_BUCKET: boxel-host-preview.boxel.ai
           AWS_REGION: us-east-1
           AWS_CLOUDFRONT_DISTRIBUTION: E2PZR9CIAW093B
-          AI_ASSISTANT_EXPERIMENTAL_ATTACHING_FILES_ENABLED: true
         with:
           package: boxel-host
           environment: production

--- a/packages/host/app/components/ai-assistant/attachment-picker/index.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/index.gts
@@ -19,7 +19,6 @@ import {
 
 import CardPill from '@cardstack/host/components/card-pill';
 import FilePill from '@cardstack/host/components/file-pill';
-import ENV from '@cardstack/host/config/environment';
 
 import { type CardDef } from 'https://cardstack.com/base/card-api';
 import { type FileDef } from 'https://cardstack.com/base/file-api';
@@ -42,8 +41,6 @@ interface Signature {
   };
 }
 
-const isAttachingFilesEnabled =
-  ENV.featureFlags?.AI_ASSISTANT_EXPERIMENTAL_ATTACHING_FILES_ENABLED;
 const MAX_ITEMS_TO_DISPLAY = 4;
 
 export default class AiAssistantAttachmentPicker extends Component<Signature> {
@@ -74,7 +71,7 @@ export default class AiAssistantAttachmentPicker extends Component<Signature> {
               @removeCard={{@removeCard}}
             />
           {{/if}}
-        {{else if isAttachingFilesEnabled}}
+        {{else}}
           {{#if (this.isAutoAttachedFile item)}}
             <Tooltip @placement='top'>
               <:trigger>
@@ -112,7 +109,7 @@ export default class AiAssistantAttachmentPicker extends Component<Signature> {
         </Pill>
       {{/if}}
       {{#if this.canDisplayAddButton}}
-        {{#if (and (eq @submode 'code') isAttachingFilesEnabled)}}
+        {{#if (eq @submode 'code')}}
           <AddButton
             class={{cn 'attach-button' icon-only=this.files.length}}
             @variant='pill'

--- a/packages/host/app/config/environment.d.ts
+++ b/packages/host/app/config/environment.d.ts
@@ -28,7 +28,5 @@ declare const config: {
   sqlSchema: string;
   assetsURL: string;
   stripePaymentLink: string;
-  featureFlags?: {
-    AI_ASSISTANT_EXPERIMENTAL_ATTACHING_FILES_ENABLED: boolean;
-  };
+  featureFlags?: {};
 };

--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -41,10 +41,7 @@ module.exports = function (environment) {
     hostsOwnAssets: true,
     resolvedBaseRealmURL:
       process.env.RESOLVED_BASE_REALM_URL || 'http://localhost:4201/base/',
-    featureFlags: {
-      AI_ASSISTANT_EXPERIMENTAL_ATTACHING_FILES_ENABLED:
-        process.env.AI_ASSISTANT_EXPERIMENTAL_ATTACHING_FILES_ENABLED || false,
-    },
+    featureFlags: {},
   };
 
   if (environment === 'development') {
@@ -53,9 +50,7 @@ module.exports = function (environment) {
     // ENV.APP.LOG_TRANSITIONS = true;
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
-    ENV.featureFlags = {
-      AI_ASSISTANT_EXPERIMENTAL_ATTACHING_FILES_ENABLED: true,
-    };
+    ENV.featureFlags = {};
   }
 
   if (environment === 'test') {
@@ -75,9 +70,7 @@ module.exports = function (environment) {
     ENV.loginMessageTimeoutMs = 0;
     ENV.minSaveTaskDurationMs = 0;
     ENV.sqlSchema = sqlSchema;
-    ENV.featureFlags = {
-      AI_ASSISTANT_EXPERIMENTAL_ATTACHING_FILES_ENABLED: true,
-    };
+    ENV.featureFlags = {};
   }
 
   if (environment === 'production') {


### PR DESCRIPTION
The current capability of this is that the attached files are uploaded to matrix storage so that the AI bot can download them and put them in the prompt. When https://github.com/cardstack/boxel/pull/2192 is merged it will also be able to know about the basic anatomy of a card definition so that it can suggest changes.

Checked with Chris and he says this is OK do be deployed. 

<img width="459" alt="image" src="https://github.com/user-attachments/assets/cd45320e-5995-4783-9280-c7e71f6664bc" />

