### PR TITLE
Perform batch invalidations within a transaction

### DIFF
--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -514,6 +514,8 @@ export class Batch {
     this.#perfLog.debug(`starting invalidation of ${url.href}`);
     let alias = trimExecutableExtension(url).href;
     let visited = new Set<string>();
+
+    await this.#query(['BEGIN']);
     let invalidations = [
       ...new Set([
         ...(!this.nodeResolvedInvalidations.includes(alias) ? [url.href] : []),
@@ -522,6 +524,7 @@ export class Batch {
     ];
 
     if (invalidations.length === 0) {
+      await this.#query(['COMMIT']);
       return [];
     }
 
@@ -554,6 +557,8 @@ export class Batch {
         rows,
       ),
     ]);
+    await this.#query(['COMMIT']);
+
     this.#perfLog.debug(
       `inserted invalidated rows for  ${url.href} in ${
         Date.now() - insertStart


### PR DESCRIPTION
Wrap invalidation queries and updates for batched index changes in a single transaction. this should hopefully resolve the deadlock that has occasionally appeared during invalidation.