### PR TITLE
Create spec by resource

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -353,7 +353,7 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
       if (isResolvedCodeRef(maybeRef)) {
         ref = maybeRef;
       }
-      let doc: LooseSingleCardDocument = {
+      this.newCardJSON = {
         data: {
           attributes: {
             specType,
@@ -365,7 +365,11 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
           },
         },
       };
-      this._selectedId = undefined;
+      await this.cardResource.loaded;
+      if (this.card) {
+        this._selectedId = undefined;
+        this.newCardJSON = undefined;
+      }
     },
   );
 

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -22,6 +22,7 @@ import {
   LoadingIndicator,
 } from '@cardstack/boxel-ui/components';
 import { not } from '@cardstack/boxel-ui/helpers';
+import { cn } from '@cardstack/boxel-ui/helpers';
 
 import {
   type ResolvedCodeRef,
@@ -192,13 +193,13 @@ class SpecPreviewContent extends GlimmerComponent<ContentSignature> {
   };
 
   <template>
-    <div class='container'>
+    <div class={{cn 'container' spec-intent-message=@showCreateSpecIntent}}>
       {{#if @showCreateSpecIntent}}
-        <div class='spec-intent-message' data-test-create-spec-intent-message>
+        <div data-test-create-spec-intent-message>
           Create a Boxel Specification to be able to create new instances
         </div>
       {{else if (not @canWrite)}}
-        <div class='spec-intent-message' data-test-cannot-write-intent-message>
+        <div data-test-cannot-write-intent-message>
           Cannot create Boxel Specification inside this realm
         </div>
       {{else}}
@@ -250,10 +251,7 @@ class SpecPreviewContent extends GlimmerComponent<ContentSignature> {
         display: flex;
         flex-direction: column;
         gap: var(--boxel-sp-sm);
-        height: 100%;
         width: 100%;
-      }
-      .spec-preview {
         padding: var(--boxel-sp-sm);
       }
       .spec-intent-message {

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -316,9 +316,9 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
   @service private declare realm: RealmService;
   @service private declare realmServer: RealmServerService;
   @service private declare cardService: CardService;
-  @tracked _selectedId?: string;
+  @tracked private _selectedId?: string;
+  @tracked private newCardJSON: LooseSingleCardDocument | undefined;
   @tracked ids: string[] = [];
-  @tracked newCardJSON: LooseSingleCardDocument | undefined;
 
   // We must do this so cardIds are available in the root for usage with getCard
   @action setCardIds(cards: PrerenderedCard[]) {

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -318,6 +318,7 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
   @service private declare cardService: CardService;
   @tracked _selectedId?: string;
   @tracked ids: string[] = [];
+  @tracked newCardJSON: LooseSingleCardDocument | undefined;
 
   // We must do this so cardIds are available in the root for usage with getCard
   @action setCardIds(cards: PrerenderedCard[]) {
@@ -364,17 +365,7 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
           },
         },
       };
-      try {
-        let card = await this.cardService.createFromSerialized(doc.data, doc);
-        if (!card) {
-          throw new Error(
-            `Failed to create card from ref "${ref.name}" from "${ref.module}"`,
-          );
-        }
-        await this.cardService.saveModel(card);
-      } catch (e: any) {
-        console.log('Error saving', e);
-      }
+      this._selectedId = undefined;
     },
   );
 
@@ -479,9 +470,13 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
     return this.realm.canWrite(this.operatorModeStateService.realmURL.href);
   }
 
-  private cardResource = getCard(this, () => this.selectedId, {
-    isAutoSave: () => true,
-  });
+  private cardResource = getCard(
+    this,
+    () => this.newCardJSON ?? this.selectedId,
+    {
+      isAutoSave: () => true,
+    },
+  );
 
   get card() {
     if (!this.cardResource.card) {

--- a/packages/host/tests/acceptance/code-submode/spec-test.gts
+++ b/packages/host/tests/acceptance/code-submode/spec-test.gts
@@ -334,6 +334,7 @@ module('Acceptance | Spec preview', function (hooks) {
     assert.dom('[data-test-accordion-item="spec-preview"]').exists();
     assert.dom('[data-test-create-spec-button]').exists();
     assert.dom('[data-test-create-spec-intent-message]').exists();
+    await percySnapshot(assert);
   });
   test('view when users cannot write', async function (assert) {
     await visitOperatorMode({
@@ -346,6 +347,7 @@ module('Acceptance | Spec preview', function (hooks) {
     assert.dom('[data-test-create-spec-button]').doesNotExist();
     assert.dom('[data-test-create-spec-intent-message]').doesNotExist();
     assert.dom('[data-test-cannot-write-intent-message]').exists();
+    await percySnapshot(assert);
   });
   test<TestContextWithSSE>('have ability to create new spec instances', async function (assert) {
     await visitOperatorMode({


### PR DESCRIPTION
**Create Spec card by resource**

I noticed Spec not using create by resource so I updated to use same pattern in playground

**Made a UI change here**
<img width="589" alt="Screenshot 2025-02-26 at 09 05 40" src="https://github.com/user-attachments/assets/d44073b7-278a-416e-97f6-429349084bcc" />

<img width="485" alt="Screenshot 2025-02-26 at 09 56 24" src="https://github.com/user-attachments/assets/d52061ac-d734-48bb-a677-8bee4fa5295c" />

