### PR TITLE
Revert invalidation SQL txn--this was causing sporadic CI indexer testing hangs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Boxel Runtime
 
+
 For a quickstart, see [here](./QUICKSTART.md)
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Boxel Runtime
 
-
 For a quickstart, see [here](./QUICKSTART.md)
 
 ## Setup

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -515,7 +515,8 @@ export class Batch {
     let alias = trimExecutableExtension(url).href;
     let visited = new Set<string>();
 
-    // await this.#query(['BEGIN']);
+    console.log(`staring invalidation txn for ${url.href}`);
+    await this.#query(['BEGIN']);
     let invalidations: string[] = [];
     try {
       invalidations = [
@@ -528,7 +529,10 @@ export class Batch {
       ];
 
       if (invalidations.length === 0) {
-        // await this.#query(['COMMIT']);
+        await this.#query(['COMMIT']);
+        console.log(
+          `committing invalidation txn for ${url.href} (0 invalidations nothing to do)`,
+        );
         return [];
       }
 
@@ -561,7 +565,8 @@ export class Batch {
           rows,
         ),
       ]);
-      // await this.#query(['COMMIT']);
+      console.log(`committing invalidation txn for ${url.href}`);
+      await this.#query(['COMMIT']);
 
       this.#perfLog.debug(
         `inserted invalidated rows for  ${url.href} in ${
@@ -569,7 +574,8 @@ export class Batch {
         } ms`,
       );
     } catch (e) {
-      // await this.#query(['ROLLBACK']);
+      console.log(`rollback invalidation txn for ${url.href}`);
+      await this.#query(['ROLLBACK']);
       throw e;
     }
 

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -515,8 +515,8 @@ export class Batch {
     let alias = trimExecutableExtension(url).href;
     let visited = new Set<string>();
 
-    console.log(`staring invalidation txn for ${url.href}`);
-    await this.#query(['BEGIN']);
+    // console.log(`staring invalidation txn for ${url.href}`);
+    // await this.#query(['BEGIN']);
     let invalidations: string[] = [];
     try {
       invalidations = [
@@ -529,10 +529,10 @@ export class Batch {
       ];
 
       if (invalidations.length === 0) {
-        await this.#query(['COMMIT']);
-        console.log(
-          `committing invalidation txn for ${url.href} (0 invalidations nothing to do)`,
-        );
+        // await this.#query(['COMMIT']);
+        // console.log(
+        //   `committing invalidation txn for ${url.href} (0 invalidations nothing to do)`,
+        // );
         return [];
       }
 
@@ -565,8 +565,8 @@ export class Batch {
           rows,
         ),
       ]);
-      console.log(`committing invalidation txn for ${url.href}`);
-      await this.#query(['COMMIT']);
+      // console.log(`committing invalidation txn for ${url.href}`);
+      // await this.#query(['COMMIT']);
 
       this.#perfLog.debug(
         `inserted invalidated rows for  ${url.href} in ${
@@ -574,8 +574,8 @@ export class Batch {
         } ms`,
       );
     } catch (e) {
-      console.log(`rollback invalidation txn for ${url.href}`);
-      await this.#query(['ROLLBACK']);
+      // console.log(`rollback invalidation txn for ${url.href}`);
+      // await this.#query(['ROLLBACK']);
       throw e;
     }
 

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -515,7 +515,7 @@ export class Batch {
     let alias = trimExecutableExtension(url).href;
     let visited = new Set<string>();
 
-    await this.#query(['BEGIN']);
+    // await this.#query(['BEGIN']);
     let invalidations: string[] = [];
     try {
       invalidations = [
@@ -528,7 +528,7 @@ export class Batch {
       ];
 
       if (invalidations.length === 0) {
-        await this.#query(['COMMIT']);
+        // await this.#query(['COMMIT']);
         return [];
       }
 
@@ -561,7 +561,7 @@ export class Batch {
           rows,
         ),
       ]);
-      await this.#query(['COMMIT']);
+      // await this.#query(['COMMIT']);
 
       this.#perfLog.debug(
         `inserted invalidated rows for  ${url.href} in ${
@@ -569,7 +569,7 @@ export class Batch {
         } ms`,
       );
     } catch (e) {
-      await this.#query(['ROLLBACK']);
+      // await this.#query(['ROLLBACK']);
       throw e;
     }
 


### PR DESCRIPTION
I was able to track down the sporadic CI realm server indexer test hangs to the work that introduced SQL transaction to the invalidation mechanism. Reverting this for now until we can figure out why this interfered with tests.