### PR TITLE
Support for creating new instance of card that contains CodeRef field

### DIFF
--- a/packages/base/code-ref.gts
+++ b/packages/base/code-ref.gts
@@ -20,6 +20,7 @@ import { consume } from 'ember-provide-consume-context';
 import {
   type ResolvedCodeRef,
   CardURLContextName,
+  isResolvedCodeRef,
 } from '@cardstack/runtime-common';
 import { not } from '@cardstack/boxel-ui/helpers';
 import { BoxelInput } from '@cardstack/boxel-ui/components';
@@ -37,7 +38,7 @@ function maybeSerializeCodeRef(
   codeRef: ResolvedCodeRef | {} | undefined,
   stack: CardDef[] = [],
 ) {
-  if (codeRef && 'module' in codeRef) {
+  if (codeRef && isResolvedCodeRef(codeRef)) {
     if (moduleIsUrlLike(codeRef.module)) {
       // if a stack is passed in, use the containing card to resolve relative references
       let moduleHref =
@@ -141,7 +142,7 @@ export default class CodeRefField extends FieldDef {
       ...codeRef,
       ...(opts?.maybeRelativeURL &&
       codeRef &&
-      'module' in codeRef &&
+      isResolvedCodeRef(codeRef) &&
       !opts?.useAbsoluteURL &&
       moduleIsUrlLike(codeRef.module)
         ? { module: opts.maybeRelativeURL(codeRef.module) }

--- a/packages/host/tests/acceptance/code-submode/playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/playground-test.gts
@@ -39,6 +39,14 @@ module('Acceptance | code-submode | playground panel', function (hooks) {
     });
   setupOnSave(hooks);
 
+  const codeRefDriverCard = `import { CardDef, field, contains } from 'https://cardstack.com/base/card-api';
+import { Component } from 'https://cardstack.com/base/card-api';
+import CodeRefField from 'https://cardstack.com/base/code-ref';
+export class CodeRefDriver extends CardDef {
+  static displayName = "Code Ref Driver";
+  @field ref = contains(CodeRefField);
+}`;
+
   const authorCard = `import { contains, field, CardDef, Component } from "https://cardstack.com/base/card-api";
 import MarkdownField from 'https://cardstack.com/base/markdown';
 import StringField from "https://cardstack.com/base/string";
@@ -133,6 +141,7 @@ export class BlogPost extends CardDef {
       contents: {
         'author.gts': authorCard,
         'blog-post.gts': blogPostCard,
+        'code-ref-driver.gts': codeRefDriverCard,
         'Author/jane-doe.json': {
           data: {
             attributes: {
@@ -630,6 +639,37 @@ export class BlogPost extends CardDef {
       .dom('[data-option-index]')
       .exists({ count: 1 }, 'dropdown instance count is correct');
     assert.dom('[data-option-index]').containsText('Blog Post');
+  });
+
+  test<TestContextWithSSE>('can create new instance with CodeRef field', async function (assert) {
+    await visitOperatorMode({
+      submode: 'code',
+      codePath: `${testRealmURL}code-ref-driver.gts`,
+    });
+    await click('[data-boxel-selector-item-text="CodeRefDriver"]');
+    await click('[data-test-accordion-item="playground"] button');
+    await click('[data-test-instance-chooser]');
+    await this.expectEvents({
+      assert,
+      realm,
+      expectedNumberOfEvents: 2,
+      callback: async () => {
+        await click('[data-test-create-instance]');
+      },
+    });
+    assert
+      .dom('[data-test-instance-chooser] [data-test-selected-item]')
+      .hasText('Untitled Code Ref Driver', 'created instance is selected');
+    assert
+      .dom(
+        `[data-test-playground-panel] [data-test-card][data-test-card-format="edit"]`,
+      )
+      .exists('new card is rendered in edit format');
+    assert
+      .dom(
+        '[data-test-playground-panel] [data-test-card] [data-test-field="ref"] input',
+      )
+      .hasNoValue('code ref field is empty');
   });
 
   test<TestContextWithSSE>('playground preview for card with contained fields can live update when module changes', async function (assert) {

--- a/packages/host/tests/acceptance/code-submode/playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/playground-test.gts
@@ -641,7 +641,7 @@ export class BlogPost extends CardDef {
     assert.dom('[data-option-index]').containsText('Blog Post');
   });
 
-  test<TestContextWithSSE>('can create new instance with CodeRef field', async function (assert) {
+  test('can create new instance with CodeRef field', async function (assert) {
     await visitOperatorMode({
       submode: 'code',
       codePath: `${testRealmURL}code-ref-driver.gts`,
@@ -649,14 +649,8 @@ export class BlogPost extends CardDef {
     await click('[data-boxel-selector-item-text="CodeRefDriver"]');
     await click('[data-test-accordion-item="playground"] button');
     await click('[data-test-instance-chooser]');
-    await this.expectEvents({
-      assert,
-      realm,
-      expectedNumberOfEvents: 2,
-      callback: async () => {
-        await click('[data-test-create-instance]');
-      },
-    });
+    await click('[data-test-create-instance]');
+
     assert
       .dom('[data-test-instance-chooser] [data-test-selected-item]')
       .hasText('Untitled Code Ref Driver', 'created instance is selected');

--- a/packages/runtime-common/code-ref.ts
+++ b/packages/runtime-common/code-ref.ts
@@ -34,7 +34,7 @@ let localIdentities = new WeakMap<
   | { type: 'fieldOf'; card: typeof BaseDef; field: string }
 >();
 
-export function isResolvedCodeRef(ref?: CodeRef): ref is ResolvedCodeRef {
+export function isResolvedCodeRef(ref?: CodeRef | {}): ref is ResolvedCodeRef {
   if (ref && 'module' in ref && 'name' in ref) {
     return true;
   } else {


### PR DESCRIPTION
Fixes bug where new instance of code ref field was unable to be created from playground. Interestingly this came down to the fact that during deserialization, the empty code ref field's serialized form is `{}`. 