### PR TITLE
Test correct template returned from plural components

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -350,12 +350,12 @@ function callSerializeHook(
 
 function cardTypeFor(
   field: Field<typeof BaseDef>,
-  boxedElement: Box<BaseDef>,
+  boxedElement?: Box<BaseDef>,
 ): typeof BaseDef {
   if (primitive in field.card) {
     return field.card;
   }
-  if (boxedElement.value == null) {
+  if (boxedElement === undefined || boxedElement.value == null) {
     return field.card;
   }
   return Reflect.getPrototypeOf(boxedElement.value)!

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -3145,7 +3145,6 @@ export class Box<T> {
         });
       }
     });
-    this.prevChildren = newChildren;
     return newChildren;
   }
 }

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -3145,6 +3145,9 @@ export class Box<T> {
         });
       }
     });
+    if (state.useIndexBasedKeys) {
+      this.prevChildren = newChildren;
+    }
     return newChildren;
   }
 }

--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -386,10 +386,6 @@ function fieldsComponentsFor<T extends BaseDef>(
   target: object,
   model: Box<T>,
 ): FieldsTypeFor<T> {
-  // This is a cache of the fields we've already created components for
-  // so that they do not get recreated
-  let stableComponents = new Map<string, BoxComponent>();
-
   return new Proxy(target, {
     get(target, property, received) {
       if (
@@ -399,11 +395,6 @@ function fieldsComponentsFor<T extends BaseDef>(
       ) {
         // don't handle symbols or nulls
         return Reflect.get(target, property, received);
-      }
-
-      let stable = stableComponents.get(property);
-      if (stable) {
-        return stable;
       }
 
       let modelValue = model.value as T; // TS is not picking up the fact we already filtered out nulls and undefined above
@@ -418,7 +409,6 @@ function fieldsComponentsFor<T extends BaseDef>(
       let field = maybeField;
 
       let result = field.component(model as unknown as Box<BaseDef>);
-      stableComponents.set(property, result);
       return result;
     },
     getPrototypeOf() {

--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -386,10 +386,6 @@ function fieldsComponentsFor<T extends BaseDef>(
   target: object,
   model: Box<T>,
 ): FieldsTypeFor<T> {
-  // // This is a cache of the fields we've already created components for
-  // // so that they do not get recreated
-  // let stableComponents = new Map<string, BoxComponent>();
-
   return new Proxy(target, {
     get(target, property, received) {
       if (
@@ -401,11 +397,6 @@ function fieldsComponentsFor<T extends BaseDef>(
         return Reflect.get(target, property, received);
       }
 
-      // let stable = stableComponents.get(property);
-      // if (stable) {
-      //   return stable;
-      // }
-
       let modelValue = model.value as T; // TS is not picking up the fact we already filtered out nulls and undefined above
       let maybeField: Field<BaseDefConstructor> | undefined = getField(
         modelValue.constructor,
@@ -416,11 +407,7 @@ function fieldsComponentsFor<T extends BaseDef>(
         return Reflect.get(target, property, received);
       }
       let field = maybeField;
-
-      let result = field.component(model as unknown as Box<BaseDef>);
-      // stableComponents.set(property, result);
-
-      return result;
+      return field.component(model as unknown as Box<BaseDef>);
     },
     getPrototypeOf() {
       // This is necessary for Ember to be able to locate the template associated

--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -225,12 +225,12 @@ export function getBoxComponent(
                       @displayBoundaries={{displayContainer}}
                       class='field-component-card
                         {{effectiveFormats.cardDef}}-format display-container-{{displayContainer}}'
-                      {{context.cardComponentModifier
+                      {{!-- {{context.cardComponentModifier
                         card=card
                         format=effectiveFormats.cardDef
                         fieldType=field.fieldType
                         fieldName=field.name
-                      }}
+                      }} --}}
                       data-test-card={{card.id}}
                       data-test-card-format={{effectiveFormats.cardDef}}
                       data-test-field-component-card
@@ -386,6 +386,10 @@ function fieldsComponentsFor<T extends BaseDef>(
   target: object,
   model: Box<T>,
 ): FieldsTypeFor<T> {
+  // // This is a cache of the fields we've already created components for
+  // // so that they do not get recreated
+  // let stableComponents = new Map<string, BoxComponent>();
+
   return new Proxy(target, {
     get(target, property, received) {
       if (
@@ -396,6 +400,11 @@ function fieldsComponentsFor<T extends BaseDef>(
         // don't handle symbols or nulls
         return Reflect.get(target, property, received);
       }
+
+      // let stable = stableComponents.get(property);
+      // if (stable) {
+      //   return stable;
+      // }
 
       let modelValue = model.value as T; // TS is not picking up the fact we already filtered out nulls and undefined above
       let maybeField: Field<BaseDefConstructor> | undefined = getField(
@@ -409,6 +418,8 @@ function fieldsComponentsFor<T extends BaseDef>(
       let field = maybeField;
 
       let result = field.component(model as unknown as Box<BaseDef>);
+      // stableComponents.set(property, result);
+
       return result;
     },
     getPrototypeOf() {

--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -225,12 +225,12 @@ export function getBoxComponent(
                       @displayBoundaries={{displayContainer}}
                       class='field-component-card
                         {{effectiveFormats.cardDef}}-format display-container-{{displayContainer}}'
-                      {{!-- {{context.cardComponentModifier
+                      {{context.cardComponentModifier
                         card=card
                         format=effectiveFormats.cardDef
                         fieldType=field.fieldType
                         fieldName=field.name
-                      }} --}}
+                      }}
                       data-test-card={{card.id}}
                       data-test-card-format={{effectiveFormats.cardDef}}
                       data-test-field-component-card

--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -381,7 +381,6 @@ function shouldRenderEditor(
 ) {
   return (format ?? defaultFormat) === 'edit' && !isComputed;
 }
-
 const componentCache = initSharedState(
   'linksToManyComponentCache',
   () =>

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -2089,7 +2089,6 @@ module('Integration | card-basics', function (hooks) {
       let person = new Person({ pets: [pet1, pet2] });
 
       await renderCard(loader, person, 'embedded');
-      await this.pauseTest();
 
       assert.ok(true);
     });
@@ -2154,7 +2153,6 @@ module('Integration | card-basics', function (hooks) {
         pets: [pet1, pet2],
       });
       await renderCard(loader, person, 'isolated');
-      await this.pauseTest();
       assert.ok(true);
     });
 

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -179,10 +179,10 @@ module('Integration | operator-mode', function (hooks) {
             this.args.model.pets[0] &&
             this.args.model.pets[1]
           ) {
-            // this.args.set();
-            let o = [this.args.model.pets[1], this.args.model.pets[0]];
-            this.args.model.pets = [...o];
-            // this.args.model.pets = [];
+            this.args.model.pets = [
+              this.args.model.pets[1],
+              this.args.model.pets[0],
+            ];
           }
         };
         <template>
@@ -858,11 +858,10 @@ module('Integration | operator-mode', function (hooks) {
         </template>
       },
     );
-    assert.ok(true);
     // this.onSave((subscriber) => {
     //   debugger;
     // });
-    // await this.pauseTest();
+    await this.pauseTest();
   });
 
   test<TestContextWithSave>('it does not auto save when exiting edit mode when there are no changes made', async function (assert) {

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -861,7 +861,6 @@ module('Integration | operator-mode', function (hooks) {
     // this.onSave((subscriber) => {
     //   debugger;
     // });
-    await this.pauseTest();
   });
 
   test<TestContextWithSave>('it does not auto save when exiting edit mode when there are no changes made', async function (assert) {


### PR DESCRIPTION
~This broke in auto-save~

~It didn't break otherwise in card-basics~ This broke in card-basics!

~I think different async re-renders when calling `.children` ie `getBoxComponent` and `recompute` (field hydration)~

I removing `.prevChildren` cache in box to see if test breaks. Im missing context why this actually is a thing, there are other caches that support it at the component level. Less cache good.

I believe this will make clearer the behaviour of what we see in https://github.com/cardstack/boxel/pull/2178

My notes: The modifier still getes torn down when we reorder links unless we still have a cahce. We need, additionally, to put the cache in linksToManyComponent. Still haven't proven that re-render torn down the modifier