### PR TITLE
AI message: Prevent premature end of streaming indicator when streaming takes longer than 1min

### DIFF
--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -31,7 +31,6 @@ import { v4 as uuidv4 } from 'uuid';
 import { BoxelButton } from '@cardstack/boxel-ui/components';
 import { not } from '@cardstack/boxel-ui/helpers';
 
-import { unixTime } from '@cardstack/runtime-common';
 import { DEFAULT_LLM_LIST } from '@cardstack/runtime-common/matrix-constants';
 
 import AddSkillsToRoomCommand from '@cardstack/host/commands/add-skills-to-room';

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -94,7 +94,7 @@ export default class Room extends Component<Signature> {
               @registerScroller={{this.registerMessageScroller}}
               @isPending={{this.isPendingMessage message}}
               @monacoSDK={{@monacoSDK}}
-              @isStreaming={{this.isMessageStreaming message i}}
+              @isStreaming={{this.isMessageStreaming message}}
               @isDisplayingCode={{this.isDisplayingCode message}}
               @onToggleViewCode={{fn this.toggleViewCode message}}
               @currentEditor={{this.currentMonacoContainer}}
@@ -499,16 +499,8 @@ export default class Room extends Component<Signature> {
     return undefined;
   };
 
-  private isMessageStreaming = (message: Message, messageIndex: number) => {
-    return (
-      !message.isStreamingFinished &&
-      this.isLastMessage(messageIndex) &&
-      // Older events do not come with isStreamingFinished property so we have
-      // no other way to determine if the message is done streaming other than
-      // checking if they are old messages (older than 60 seconds as an arbitrary
-      // threshold)
-      unixTime(new Date().getTime() - message.created.getTime()) < 60
-    );
+  private isMessageStreaming = (message: Message) => {
+    return !message.isStreamingFinished;
   };
 
   private isDisplayingCode = (message: Message) => {

--- a/packages/host/tests/integration/components/ai-assistant-panel-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel-test.gts
@@ -2734,6 +2734,7 @@ module('Integration | ai-assistant-panel', function (hooks) {
           'This is a code snippet that I made for you\n```javascript\nconsole.log("hello world");\n```\nWhat do you think about it?',
         msgtype: 'org.text',
         format: 'org.matrix.custom.html',
+        isStreamingFinished: true,
       },
       {
         origin_server_ts: new Date(2024, 0, 3, 12, 30).getTime(),
@@ -2781,6 +2782,7 @@ module('Integration | ai-assistant-panel', function (hooks) {
           'This is a code snippet that I made for you\n```javascript\nconsole.log("hello world");\n```\nWhat do you think about it?',
         msgtype: 'org.text',
         format: 'org.matrix.custom.html',
+        isStreamingFinished: true,
       },
       {
         origin_server_ts: new Date(2024, 0, 3, 12, 30).getTime(),

--- a/packages/host/tests/integration/components/ai-assistant-panel-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel-test.gts
@@ -2755,6 +2755,7 @@ module('Integration | ai-assistant-panel', function (hooks) {
         formatted_body: 'this is another message',
         msgtype: 'org.text',
         format: 'org.matrix.custom.html',
+        isStreamingFinished: true,
       },
       {
         origin_server_ts: new Date(2024, 0, 3, 13, 30).getTime(),

--- a/packages/host/tests/integration/components/ai-assistant-panel-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel-test.gts
@@ -1038,6 +1038,7 @@ module('Integration | ai-assistant-panel', function (hooks) {
       data: JSON.stringify({
         attachedCardsEventIds: [event1Id],
       }),
+      isStreamingFinished: true,
     });
 
     await waitFor('[data-test-card-error]');
@@ -2807,6 +2808,7 @@ module('Integration | ai-assistant-panel', function (hooks) {
         formatted_body: 'this is another message',
         msgtype: 'org.text',
         format: 'org.matrix.custom.html',
+        isStreamingFinished: true,
       },
       {
         origin_server_ts: new Date(2024, 0, 3, 13, 30).getTime(),


### PR DESCRIPTION
Some context - the code that this PR removes is a time based check that we added when we introduced `isStreamingFinished` property on the event, to have a best effort backwards compatibility for older events that lacked this property.

Turns out this code is actually buggy in case when the streaming takes longer than 1 minute. We are observing this now that we are using the assistant for coding. Sometimes it will respond with a lot of code where streaming takes more than 1 minute, but this code will mark every event as "finished streaming" after 1 minute. 

This is problematic with our current behaviour where we show streaming code as code text, and once it ends streaming, we turn it into a readonly monaco editor. So when the message with code has been streaming for more than a minute, the
`isStreaming` will incorrectly and prematurely become `false`, and any code will be rendered in a monaco editor which causes a ton of visual annoyances - code editor flashing, growing, rerendering,...

I opted into simply removing that piece of code. Granted, it's purpose is to act as a backwards compatibility for events before we introduced `isStreamingFinished`, but this is for events older than 11 months and I don't think anyone is interacting with such old events anymore...

The visual bug this fixes (monaco editor will get rendered too soon, before the streaming is actually done, causing rerendering and flickering):

https://github.com/user-attachments/assets/274a6d19-8bd1-4905-9ff6-dc658dbcabb3


