### PR TITLE
Improve playground card rendering

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -29,6 +29,7 @@ import { File } from '@cardstack/boxel-ui/icons';
 
 import {
   identifyCard,
+  internalKeyFor,
   isCardDef,
   isCardDocumentString,
   hasExecutableExtension,
@@ -469,11 +470,11 @@ export default class CodeSubmode extends Component<Signature> {
   private get selectedCardRef(): ResolvedCodeRef | undefined {
     let baseDefType = this.selectedCardOrField?.cardOrField;
     if (!isCardDef(baseDefType)) {
-      return;
+      return undefined;
     }
     let codeRef = identifyCard(baseDefType);
     if (!isResolvedCodeRef(codeRef)) {
-      return;
+      return undefined;
     }
     return codeRef;
   }
@@ -974,9 +975,18 @@ export default class CodeSubmode extends Component<Signature> {
                         >
                           <:title>Playground</:title>
                           <:content>
-                            <PlaygroundPanel
-                              @codeRef={{this.selectedCardRef}}
-                            />
+                            <section
+                              class='playground-panel'
+                              data-test-playground-panel
+                            >
+                              <PlaygroundPanel
+                                @codeRef={{this.selectedCardRef}}
+                                @moduleId={{internalKeyFor
+                                  this.selectedCardRef
+                                  undefined
+                                }}
+                              />
+                            </section>
                           </:content>
                         </A.Item>
                       {{/if}}
@@ -1193,6 +1203,21 @@ export default class CodeSubmode extends Component<Signature> {
         padding: var(--boxel-sp-xs);
         background-color: var(--code-mode-panel-background-color);
         min-height: 100%;
+      }
+
+      .playground-panel {
+        position: relative;
+        background-image: url('./code-submode/playground-background.png');
+        background-position: left top;
+        background-repeat: repeat;
+        background-size: 22.5px;
+        height: 100%;
+        width: 100%;
+        padding: var(--boxel-sp);
+        background-color: var(--boxel-dark);
+        font: var(--boxel-font-sm);
+        letter-spacing: var(--boxel-lsp-xs);
+        overflow: auto;
       }
 
       .preview-error-container {

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -976,7 +976,6 @@ export default class CodeSubmode extends Component<Signature> {
                           <:content>
                             <PlaygroundPanel
                               @codeRef={{this.selectedCardRef}}
-                              @isLoading={{this.moduleContentsResource.isLoading}}
                             />
                           </:content>
                         </A.Item>

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -28,10 +28,12 @@ import { and, not, bool, eq } from '@cardstack/boxel-ui/helpers';
 import { File } from '@cardstack/boxel-ui/icons';
 
 import {
+  identifyCard,
   isCardDef,
   isCardDocumentString,
   hasExecutableExtension,
   RealmPaths,
+  isResolvedCodeRef,
   type ResolvedCodeRef,
   PermissionsContextName,
 } from '@cardstack/runtime-common';
@@ -464,15 +466,20 @@ export default class CodeSubmode extends Component<Signature> {
     return undefined;
   }
 
-  private get shouldDisplayPlayground() {
-    return isCardDef(this.selectedCardOrField?.cardOrField);
+  private get selectedCardRef(): ResolvedCodeRef | undefined {
+    let baseDefType = this.selectedCardOrField?.cardOrField;
+    if (!isCardDef(baseDefType)) {
+      return;
+    }
+    let codeRef = identifyCard(baseDefType);
+    if (!isResolvedCodeRef(codeRef)) {
+      return;
+    }
+    return codeRef;
   }
 
   get showSpecPreview() {
-    return (
-      !this.moduleContentsResource.isLoading &&
-      this.selectedDeclaration?.exportName
-    );
+    return this.selectedCardOrField?.exportName;
   }
 
   private get itemToDeleteAsCard() {
@@ -957,7 +964,7 @@ export default class CodeSubmode extends Component<Signature> {
                           </:content>
                         </A.Item>
                       </SchemaEditor>
-                      {{#if this.shouldDisplayPlayground}}
+                      {{#if this.selectedCardRef}}
                         <A.Item
                           class='accordion-item'
                           @contentClass='accordion-item-content'
@@ -968,8 +975,8 @@ export default class CodeSubmode extends Component<Signature> {
                           <:title>Playground</:title>
                           <:content>
                             <PlaygroundPanel
-                              @moduleContentsResource={{this.moduleContentsResource}}
-                              @cardType={{this.selectedCardOrField.cardType}}
+                              @codeRef={{this.selectedCardRef}}
+                              @isLoading={{this.moduleContentsResource.isLoading}}
                             />
                           </:content>
                         </A.Item>

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -29,7 +29,6 @@ import { File } from '@cardstack/boxel-ui/icons';
 
 import {
   identifyCard,
-  internalKeyFor,
   isCardDef,
   isCardDocumentString,
   hasExecutableExtension,
@@ -975,18 +974,10 @@ export default class CodeSubmode extends Component<Signature> {
                         >
                           <:title>Playground</:title>
                           <:content>
-                            <section
-                              class='playground-panel'
-                              data-test-playground-panel
-                            >
-                              <PlaygroundPanel
-                                @codeRef={{this.selectedCardRef}}
-                                @moduleId={{internalKeyFor
-                                  this.selectedCardRef
-                                  undefined
-                                }}
-                              />
-                            </section>
+                            <PlaygroundPanel
+                              @codeRef={{this.selectedCardRef}}
+                              @isLoadingNewModule={{this.moduleContentsResource.isLoadingNewModule}}
+                            />
                           </:content>
                         </A.Item>
                       {{/if}}
@@ -1203,21 +1194,6 @@ export default class CodeSubmode extends Component<Signature> {
         padding: var(--boxel-sp-xs);
         background-color: var(--code-mode-panel-background-color);
         min-height: 100%;
-      }
-
-      .playground-panel {
-        position: relative;
-        background-image: url('./code-submode/playground-background.png');
-        background-position: left top;
-        background-repeat: repeat;
-        background-size: 22.5px;
-        height: 100%;
-        width: 100%;
-        padding: var(--boxel-sp);
-        background-color: var(--boxel-dark);
-        font: var(--boxel-font-sm);
-        letter-spacing: var(--boxel-lsp-xs);
-        overflow: auto;
       }
 
       .preview-error-container {

--- a/packages/host/app/components/operator-mode/code-submode/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground-panel.gts
@@ -545,21 +545,16 @@ class PlaygroundPanelContent extends Component<PlaygroundContentSignature> {
 interface Signature {
   Args: {
     codeRef: ResolvedCodeRef;
-    isLoading?: boolean;
   };
   Element: HTMLElement;
 }
 export default class PlaygroundPanel extends Component<Signature> {
   <template>
     <section class='playground-panel' data-test-playground-panel>
-      {{#if @isLoading}}
-        <LoadingIndicator @color='var(--boxel-light)' />
-      {{else}}
-        <PlaygroundPanelContent
-          @codeRef={{@codeRef}}
-          @moduleId={{internalKeyFor @codeRef undefined}}
-        />
-      {{/if}}
+      <PlaygroundPanelContent
+        @codeRef={{@codeRef}}
+        @moduleId={{internalKeyFor @codeRef undefined}}
+      />
     </section>
     <style scoped>
       .playground-panel {
@@ -575,10 +570,6 @@ export default class PlaygroundPanel extends Component<Signature> {
         font: var(--boxel-font-sm);
         letter-spacing: var(--boxel-lsp-xs);
         overflow: auto;
-      }
-      .error {
-        margin: 0;
-        color: var(--boxel-light);
       }
     </style>
   </template>

--- a/packages/host/app/components/operator-mode/code-submode/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground-panel.gts
@@ -31,6 +31,7 @@ import {
   cardTypeDisplayName,
   cardTypeIcon,
   chooseCard,
+  internalKeyFor,
   type Query,
   type LooseSingleCardDocument,
   type ResolvedCodeRef,
@@ -332,13 +333,13 @@ const PlaygroundPreview: TemplateOnlyComponent<PlaygroundPreviewSignature> =
     </style>
   </template>;
 
-interface Signature {
+interface PlaygroundContentSignature {
   Args: {
     codeRef: ResolvedCodeRef;
     moduleId: string;
   };
 }
-export default class PlaygroundPanel extends Component<Signature> {
+class PlaygroundPanelContent extends Component<PlaygroundContentSignature> {
   <template>
     <div class='playground-panel-content'>
       <div class='instance-chooser-container'>
@@ -416,7 +417,7 @@ export default class PlaygroundPanel extends Component<Signature> {
     { cardId: string; format: Format }
   >; // TrackedObject
 
-  constructor(owner: Owner, args: Signature['Args']) {
+  constructor(owner: Owner, args: PlaygroundContentSignature['Args']) {
     super(owner, args);
     let selections = window.localStorage.getItem(PlaygroundSelections);
 
@@ -578,5 +579,47 @@ export default class PlaygroundPanel extends Component<Signature> {
         this.card?.id &&
         this.realm.canWrite(this.card.id),
     );
+  }
+}
+
+interface Signature {
+  Args: {
+    codeRef: ResolvedCodeRef;
+    isLoadingNewModule?: boolean;
+  };
+  Element: HTMLElement;
+}
+export default class PlaygroundPanel extends Component<Signature> {
+  <template>
+    <section class='playground-panel' data-test-playground-panel>
+      {{#if @isLoadingNewModule}}
+        <LoadingIndicator @color='var(--boxel-light)' />
+      {{else}}
+        <PlaygroundPanelContent
+          @codeRef={{@codeRef}}
+          @moduleId={{this.moduleId}}
+        />
+      {{/if}}
+    </section>
+    <style scoped>
+      .playground-panel {
+        position: relative;
+        background-image: url('./playground-background.png');
+        background-position: left top;
+        background-repeat: repeat;
+        background-size: 22.5px;
+        height: 100%;
+        width: 100%;
+        padding: var(--boxel-sp);
+        background-color: var(--boxel-dark);
+        font: var(--boxel-font-sm);
+        letter-spacing: var(--boxel-lsp-xs);
+        overflow: auto;
+      }
+    </style>
+  </template>
+
+  get moduleId() {
+    return internalKeyFor(this.args.codeRef, undefined);
   }
 }

--- a/packages/host/app/components/operator-mode/code-submode/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground-panel.gts
@@ -30,7 +30,6 @@ import {
   cardTypeDisplayName,
   cardTypeIcon,
   chooseCard,
-  internalKeyFor,
   type Query,
   type LooseSingleCardDocument,
   type ResolvedCodeRef,
@@ -169,13 +168,13 @@ const AfterOptions: TemplateOnlyComponent<AfterOptionsSignature> = <template>
   </style>
 </template>;
 
-interface PlaygroundContentSignature {
+interface Signature {
   Args: {
     codeRef: ResolvedCodeRef;
     moduleId: string;
   };
 }
-class PlaygroundPanelContent extends Component<PlaygroundContentSignature> {
+export default class PlaygroundPanel extends Component<Signature> {
   <template>
     <div class='playground-panel-content'>
       <PrerenderedCardSearch
@@ -376,7 +375,7 @@ class PlaygroundPanelContent extends Component<PlaygroundContentSignature> {
     { cardId: string; format: Format }
   >; // TrackedObject
 
-  constructor(owner: Owner, args: PlaygroundContentSignature['Args']) {
+  constructor(owner: Owner, args: Signature['Args']) {
     super(owner, args);
     let selections = window.localStorage.getItem(PlaygroundSelections);
 
@@ -540,37 +539,4 @@ class PlaygroundPanelContent extends Component<PlaygroundContentSignature> {
     }
     this.persistSelections(this.card.id, 'edit');
   }
-}
-
-interface Signature {
-  Args: {
-    codeRef: ResolvedCodeRef;
-  };
-  Element: HTMLElement;
-}
-export default class PlaygroundPanel extends Component<Signature> {
-  <template>
-    <section class='playground-panel' data-test-playground-panel>
-      <PlaygroundPanelContent
-        @codeRef={{@codeRef}}
-        @moduleId={{internalKeyFor @codeRef undefined}}
-      />
-    </section>
-    <style scoped>
-      .playground-panel {
-        position: relative;
-        background-image: url('./playground-background.png');
-        background-position: left top;
-        background-repeat: repeat;
-        background-size: 22.5px;
-        height: 100%;
-        width: 100%;
-        padding: var(--boxel-sp);
-        background-color: var(--boxel-dark);
-        font: var(--boxel-font-sm);
-        letter-spacing: var(--boxel-lsp-xs);
-        overflow: auto;
-      }
-    </style>
-  </template>
 }

--- a/packages/host/app/components/operator-mode/code-submode/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground-panel.gts
@@ -1,4 +1,5 @@
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
+import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import type Owner from '@ember/owner';
@@ -40,6 +41,7 @@ import { getCard } from '@cardstack/host/resources/card-resource';
 import type CardService from '@cardstack/host/services/card-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 import type RealmService from '@cardstack/host/services/realm';
+import type { EnhancedRealmInfo } from '@cardstack/host/services/realm';
 import type RealmServerService from '@cardstack/host/services/realm-server';
 import type RecentFilesService from '@cardstack/host/services/recent-files-service';
 
@@ -168,127 +170,60 @@ const AfterOptions: TemplateOnlyComponent<AfterOptionsSignature> = <template>
   </style>
 </template>;
 
-interface Signature {
+interface DropdownSignature {
   Args: {
-    codeRef: ResolvedCodeRef;
-    moduleId: string;
+    query: Query;
+    realms: string[];
+    card: CardDef | undefined;
+    onSelect: (card: PrerenderedCard) => void;
+    chooseCard: () => void;
+    createNew: () => void;
+    createNewIsRunning?: boolean;
   };
 }
-export default class PlaygroundPanel extends Component<Signature> {
+const InstanceSelectDropdown: TemplateOnlyComponent<DropdownSignature> =
   <template>
-    <div class='playground-panel-content'>
-      <PrerenderedCardSearch
-        @query={{this.query}}
-        @format='fitted'
-        @realms={{this.recentRealms}}
-      >
-        <:loading>
-          <LoadingIndicator class='loading-icon' @color='var(--boxel-light)' />
-        </:loading>
-        <:response as |cards|>
-          <div class='instance-chooser-container'>
-            <BoxelSelect
-              class='instance-chooser'
-              @dropdownClass='instances-dropdown-content'
-              @options={{cards}}
-              @selected={{this.card}}
-              @selectedItemComponent={{if
-                this.card
-                (component SelectedItem title=(getItemTitle this.card))
-              }}
-              @renderInPlace={{true}}
-              @onChange={{this.onSelect}}
-              @placeholder='Please Select'
-              @beforeOptionsComponent={{component BeforeOptions}}
-              @afterOptionsComponent={{component
-                AfterOptions
-                chooseCard=(perform this.chooseCard)
-                createNew=(perform this.createNew)
-                createNewIsRunning=this.createNew.isRunning
-              }}
-              data-test-instance-chooser
-              as |card|
-            >
-              <CardContainer class='card' @displayBoundaries={{true}}>
-                <card.component />
-              </CardContainer>
-            </BoxelSelect>
-          </div>
-        </:response>
-      </PrerenderedCardSearch>
-      <div class='preview-area'>
-        {{#if this.card}}
-          {{#if (or (eq this.format 'isolated') (eq this.format 'edit'))}}
-            <CardContainer class='preview-container full-height-preview'>
-              {{#let (this.realm.info this.card.id) as |realmInfo|}}
-                <CardHeader
-                  class='preview-header'
-                  @cardTypeDisplayName={{cardTypeDisplayName this.card}}
-                  @cardTypeIcon={{cardTypeIcon this.card}}
-                  @realmInfo={{realmInfo}}
-                  @onEdit={{if this.canEdit this.setEditFormat}}
-                  @isTopCard={{true}}
-                  @moreOptionsMenuItems={{this.contextMenuItems}}
-                />
-              {{/let}}
-              <Preview
-                class='preview'
-                @card={{this.card}}
-                @format={{this.format}}
-              />
-            </CardContainer>
-          {{else if (eq this.format 'embedded')}}
-            <CardContainer class='preview-container'>
-              <Preview
-                class='preview'
-                @card={{this.card}}
-                @format={{this.format}}
-              />
-            </CardContainer>
-          {{else if (eq this.format 'atom')}}
-            <div class='atom-preview-container' data-test-atom-preview>Lorem
-              ipsum dolor sit amet, consectetur adipiscing elit, sed do
-              <Preview
-                class='atom-preview'
-                @card={{this.card}}
-                @format={{this.format}}
-                @displayContainer={{false}}
-              />
-              tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-              minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-              aliquip ex ea commodo consequat.</div>
-          {{else if (eq this.format 'fitted')}}
-            <FittedFormatGallery @card={{this.card}} @isDarkMode={{true}} />
-          {{/if}}
-        {{/if}}
-      </div>
-      {{#if this.card}}
-        <FormatChooser
-          class='format-chooser'
-          @format={{this.format}}
-          @setFormat={{this.setFormat}}
-        />
-      {{/if}}
-    </div>
+    <PrerenderedCardSearch
+      @query={{@query}}
+      @format='fitted'
+      @realms={{@realms}}
+    >
+      <:loading>
+        <LoadingIndicator class='loading-icon' @color='var(--boxel-light)' />
+      </:loading>
+      <:response as |cards|>
+        <BoxelSelect
+          class='instance-chooser'
+          @dropdownClass='instances-dropdown-content'
+          @options={{cards}}
+          @selected={{@card}}
+          @selectedItemComponent={{if
+            @card
+            (component SelectedItem title=(getItemTitle @card))
+          }}
+          @renderInPlace={{true}}
+          @onChange={{@onSelect}}
+          @placeholder='Please Select'
+          @beforeOptionsComponent={{component BeforeOptions}}
+          @afterOptionsComponent={{component
+            AfterOptions
+            chooseCard=@chooseCard
+            createNew=@createNew
+            createNewIsRunning=@createNewIsRunning
+          }}
+          data-test-instance-chooser
+          as |card|
+        >
+          <CardContainer class='card' @displayBoundaries={{true}}>
+            <card.component />
+          </CardContainer>
+        </BoxelSelect>
+      </:response>
+    </PrerenderedCardSearch>
+
     <style scoped>
-      .playground-panel-content {
-        display: flex;
-        flex-direction: column;
-        gap: var(--boxel-sp);
-        min-height: 100%;
-      }
       .loading-icon {
         height: var(--boxel-form-control-height);
-      }
-      .instance-chooser-container {
-        position: sticky;
-        z-index: 1;
-        top: 0;
-        display: flex;
-        justify-content: center;
-      }
-      .instance-chooser-container > :deep(.ember-basic-dropdown) {
-        max-width: 100%;
       }
       .instance-chooser {
         width: 405px;
@@ -313,12 +248,54 @@ export default class PlaygroundPanel extends Component<Signature> {
         container-type: size;
         background-color: var(--boxel-light);
       }
-      .preview-area {
-        flex-grow: 1;
-        z-index: 0;
-        display: flex;
-        flex-direction: column;
-      }
+    </style>
+  </template>;
+
+interface PlaygroundPreviewSignature {
+  Args: {
+    format: Format;
+    card: CardDef;
+    realmInfo?: EnhancedRealmInfo;
+    contextMenuItems?: MenuItem[];
+    onEdit?: () => void;
+  };
+}
+const PlaygroundPreview: TemplateOnlyComponent<PlaygroundPreviewSignature> =
+  <template>
+    {{#if (or (eq @format 'isolated') (eq @format 'edit'))}}
+      <CardContainer class='preview-container full-height-preview'>
+        <CardHeader
+          class='preview-header'
+          @cardTypeDisplayName={{cardTypeDisplayName @card}}
+          @cardTypeIcon={{cardTypeIcon @card}}
+          @realmInfo={{@realmInfo}}
+          @onEdit={{@onEdit}}
+          @isTopCard={{true}}
+          @moreOptionsMenuItems={{@contextMenuItems}}
+        />
+        <Preview class='preview' @card={{@card}} @format={{@format}} />
+      </CardContainer>
+    {{else if (eq @format 'embedded')}}
+      <CardContainer class='preview-container'>
+        <Preview class='preview' @card={{@card}} @format={{@format}} />
+      </CardContainer>
+    {{else if (eq @format 'atom')}}
+      <div class='atom-preview-container' data-test-atom-preview>Lorem ipsum
+        dolor sit amet, consectetur adipiscing elit, sed do
+        <Preview
+          class='atom-preview'
+          @card={{@card}}
+          @format={{@format}}
+          @displayContainer={{false}}
+        />
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.</div>
+    {{else if (eq @format 'fitted')}}
+      <FittedFormatGallery @card={{@card}} @isDarkMode={{true}} />
+    {{/if}}
+
+    <style scoped>
       .preview-container {
         height: auto;
       }
@@ -336,15 +313,6 @@ export default class PlaygroundPanel extends Component<Signature> {
         box-shadow: none;
         border-radius: 0;
       }
-      .format-chooser {
-        position: sticky;
-        bottom: 0;
-        margin-top: auto;
-
-        --boxel-format-chooser-button-bg-color: var(--boxel-light);
-        --boxel-format-chooser-button-width: 80px;
-        --boxel-format-chooser-button-min-width: 80px;
-      }
       .atom-preview-container {
         color: #c7c7c7;
         font: 500 var(--boxel-font-sm);
@@ -360,6 +328,79 @@ export default class PlaygroundPanel extends Component<Signature> {
         font: 600 var(--boxel-font-xs);
         line-height: 1.27;
         letter-spacing: 0.17px;
+      }
+    </style>
+  </template>;
+
+interface Signature {
+  Args: {
+    codeRef: ResolvedCodeRef;
+    moduleId: string;
+  };
+}
+export default class PlaygroundPanel extends Component<Signature> {
+  <template>
+    <div class='playground-panel-content'>
+      <div class='instance-chooser-container'>
+        <InstanceSelectDropdown
+          @query={{this.query}}
+          @realms={{this.recentRealms}}
+          @card={{this.card}}
+          @onSelect={{this.onSelect}}
+          @chooseCard={{perform this.chooseCard}}
+          @createNew={{perform this.createNew}}
+          @createNewIsRunning={{this.createNew.isRunning}}
+        />
+      </div>
+      {{#if this.card}}
+        <div class='preview-area'>
+          <PlaygroundPreview
+            @card={{this.card}}
+            @format={{this.format}}
+            @realmInfo={{this.realmInfo}}
+            @contextMenuItems={{this.contextMenuItems}}
+            @onEdit={{if this.canEdit (fn this.setFormat 'edit')}}
+          />
+        </div>
+        <FormatChooser
+          class='format-chooser'
+          @format={{this.format}}
+          @setFormat={{this.setFormat}}
+        />
+      {{/if}}
+    </div>
+
+    <style scoped>
+      .playground-panel-content {
+        display: flex;
+        flex-direction: column;
+        gap: var(--boxel-sp);
+        min-height: 100%;
+      }
+      .instance-chooser-container {
+        position: sticky;
+        z-index: 1;
+        top: 0;
+        display: flex;
+        justify-content: center;
+      }
+      .instance-chooser-container > :deep(.ember-basic-dropdown) {
+        max-width: 100%;
+      }
+      .preview-area {
+        flex-grow: 1;
+        z-index: 0;
+        display: flex;
+        flex-direction: column;
+      }
+      .format-chooser {
+        position: sticky;
+        bottom: 0;
+        margin-top: auto;
+
+        --boxel-format-chooser-button-bg-color: var(--boxel-light);
+        --boxel-format-chooser-button-width: 80px;
+        --boxel-format-chooser-button-min-width: 80px;
       }
     </style>
   </template>
@@ -524,19 +565,18 @@ export default class PlaygroundPanel extends Component<Signature> {
     }
   });
 
-  private get canEdit() {
-    return (
-      this.format !== 'edit' &&
-      this.card?.id &&
-      this.realm.canWrite(this.card.id)
-    );
+  private get realmInfo() {
+    if (!this.card?.id) {
+      return undefined;
+    }
+    return this.realm.info(this.card.id);
   }
 
-  @action
-  private setEditFormat() {
-    if (!this.card?.id) {
-      return;
-    }
-    this.persistSelections(this.card.id, 'edit');
+  private get canEdit() {
+    return Boolean(
+      this.format !== 'edit' &&
+        this.card?.id &&
+        this.realm.canWrite(this.card.id),
+    );
   }
 }

--- a/packages/host/tests/acceptance/code-submode/playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/playground-test.gts
@@ -357,6 +357,7 @@ export class BlogPost extends CardDef {
 
     await click('[data-test-file-browser-toggle]');
     await click('[data-test-file="author.gts"]');
+    await click('[data-test-accordion-item="playground"] button');
     assert.dom('[data-test-instance-chooser]').hasText('Please Select');
     await click('[data-test-instance-chooser]');
     assert.dom('li.ember-power-select-option').exists({ count: 1 });


### PR DESCRIPTION
Changes:
- Previously, we were changing the args to card resource each time `persistSelections` was called. Now, we're only changing the args if they have actually changed.
- Stop relying on `cardType` resource, which was async. Instead now getting the card-ref and moduleId via available sync methods. This simplified the isLoading state.

Now I'm left with these options: 

Option 1: More elegant, with no screen flash, but the card-resource ends up loading the resource multiple times.
https://github.com/user-attachments/assets/5d4acf6f-666e-4a22-8ae3-cba67e8ee1d7

Option 2: Ensures that the card resource is only loaded once (when code mode's `moduleContentsResource` loading state is false), but because we're re-rendering the component, there's 1 screen flash with loading indicator shown.
https://github.com/user-attachments/assets/33ee53a2-a821-4a8f-8f51-18a9635dea5a

Note: Still planning on improving the dropdown by separating the trigger component and limiting the prerendered card search to the dropdown list component only.




