### PR TITLE
Re-ordering linksToMany doesn't preserve templates (and UI component state)

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -3100,6 +3100,7 @@ export class Box<T> {
   }
 
   private prevChildren: Box<ElementType<T>>[] = [];
+  private prevValues: ElementType<T>[] = [];
 
   get children(): Box<ElementType<T>>[] {
     if (this.state.type === 'root') {
@@ -3117,10 +3118,10 @@ export class Box<T> {
       );
     }
 
-    let { prevChildren, state } = this;
+    let { prevChildren, prevValues, state } = this;
     let newChildren: Box<ElementType<T>>[] = value.map((element, index) => {
-      let found = prevChildren.find((oldBox, i) =>
-        state.useIndexBasedKeys ? index === i : oldBox.value === element,
+      let found = prevChildren.find((_oldBox, i) =>
+        state.useIndexBasedKeys ? index === i : this.prevValues[i] === element,
       );
       if (found) {
         if (state.useIndexBasedKeys) {
@@ -3129,7 +3130,9 @@ export class Box<T> {
           // mutating a watched array in a rerender will spawn another rerender which
           // infinitely recurses.
         } else {
-          prevChildren.splice(prevChildren.indexOf(found), 1);
+          let toRemoveIndex = prevChildren.indexOf(found);
+          prevChildren.splice(toRemoveIndex, 1);
+          prevValues.splice(toRemoveIndex, 1);
           if (found.state.type === 'root') {
             throw new Error('bug');
           }
@@ -3146,6 +3149,7 @@ export class Box<T> {
       }
     });
     this.prevChildren = newChildren;
+    this.prevValues = newChildren.map((child) => child.value);
     return newChildren;
   }
 }

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -10,6 +10,8 @@ import {
   triggerEvent,
 } from '@ember/test-helpers';
 
+import { tracked } from '@glimmer/tracking';
+
 import percySnapshot from '@percy/ember';
 import format from 'date-fns/format';
 import parseISO from 'date-fns/parseISO';
@@ -74,7 +76,6 @@ import {
 import { mango } from '../../helpers/image-fixture';
 import { renderCard } from '../../helpers/render-component';
 import { setupRenderingTest } from '../../helpers/setup';
-import { tracked } from '@glimmer/tracking';
 
 let loader: Loader;
 const testModuleRealm = 'http://localhost:4202/test/';
@@ -2292,7 +2293,7 @@ module('Integration | card-basics', function (hooks) {
           this.counter++;
         };
         <template>
-          {{this.args.model.name}}
+          {{@model.name}}
           <button
             {{on 'click' this.incrementCounter}}
             data-test-increment-counter
@@ -2311,7 +2312,7 @@ module('Integration | card-basics', function (hooks) {
         };
         <template>
           <div data-test-different-template>Different Template</div>
-          {{this.args.model.name}}
+          {{@model.name}}
           <button
             {{on 'click' this.incrementCounter}}
             data-test-increment-counter

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -2285,7 +2285,7 @@ module('Integration | card-basics', function (hooks) {
       await waitUntil(() => cleanWhiteSpace(root.textContent!) === 'Quint');
     });
 
-    test('Re-order linksToMany fields action will use the cached template that UI state', async function (assert) {
+    test('Re-order items in a linksToMany field will preserve the template type and box component state', async function (assert) {
       class Fitted extends Component<typeof Pet1> {
         @tracked counter = 0;
 

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -2285,7 +2285,7 @@ module('Integration | card-basics', function (hooks) {
       await waitUntil(() => cleanWhiteSpace(root.textContent!) === 'Quint');
     });
 
-    test('Re-order items in a linksToMany field will preserve the template type and box component state', async function (assert) {
+    test('Re-ordering items in a linksToMany field will preserve the template and box component state', async function (assert) {
       class Fitted extends Component<typeof Pet1> {
         @tracked counter = 0;
 

--- a/packages/host/tests/unit/box-test.ts
+++ b/packages/host/tests/unit/box-test.ts
@@ -2,12 +2,12 @@ import { RenderingTestContext } from '@ember/test-helpers';
 
 import { module, test } from 'qunit';
 
+import { Loader, baseRealm } from '@cardstack/runtime-common';
+
 import { lookupLoaderService } from '../helpers';
+import { setupRenderingTest } from '../helpers/setup';
 
 let cardApi: typeof import('https://cardstack.com/base/card-api');
-
-import { Loader, baseRealm } from '@cardstack/runtime-common';
-import { setupRenderingTest } from '../helpers/setup';
 
 let loader: Loader;
 

--- a/packages/host/tests/unit/box-test.ts
+++ b/packages/host/tests/unit/box-test.ts
@@ -1,0 +1,50 @@
+import { RenderingTestContext } from '@ember/test-helpers';
+
+import { module, test } from 'qunit';
+
+import { lookupLoaderService } from '../helpers';
+
+let cardApi: typeof import('https://cardstack.com/base/card-api');
+
+import { Loader, baseRealm } from '@cardstack/runtime-common';
+import { setupRenderingTest } from '../helpers/setup';
+
+let loader: Loader;
+
+module('Unit | box', function (hooks) {
+  setupRenderingTest(hooks);
+  hooks.beforeEach(function (this: RenderingTestContext) {
+    loader = lookupLoaderService().loader;
+  });
+  hooks.beforeEach(async function () {
+    cardApi = await loader.import(`${baseRealm.url}card-api`);
+  });
+
+  test('Box children maintain object strict equality after re-ordering', async function (assert) {
+    let { Box } = cardApi;
+    let parentCardModel = {
+      someField: [],
+    };
+    let childCard1Model = {
+      name: 'Adam Sandler',
+    };
+    let childCard2Model = {
+      name: 'Owen Wilson',
+      age: 20,
+    };
+    let box = Box.create(parentCardModel);
+    let boxArr = box.field('someField');
+    let childValues: any = [childCard1Model, childCard2Model];
+    boxArr.set(childValues);
+    assert.strictEqual(boxArr.children[0].value, childCard1Model);
+    assert.strictEqual(boxArr.children[1].value, childCard2Model);
+    assert.strictEqual(boxArr.children[0].name, '0');
+    assert.strictEqual(boxArr.children[1].name, '1');
+    let childValuesReordered: any = [childCard2Model, childCard1Model];
+    boxArr.set(childValuesReordered);
+    assert.strictEqual(boxArr.children[0].value, childCard2Model);
+    assert.strictEqual(boxArr.children[1].value, childCard1Model);
+    assert.strictEqual(boxArr.children[0].name, '0');
+    assert.strictEqual(boxArr.children[1].name, '1');
+  });
+});

--- a/packages/host/tests/unit/box-test.ts
+++ b/packages/host/tests/unit/box-test.ts
@@ -25,26 +25,31 @@ module('Unit | box', function (hooks) {
     let parentCardModel = {
       someField: [],
     };
-    let childCard1Model = {
-      name: 'Adam Sandler',
-    };
-    let childCard2Model = {
-      name: 'Owen Wilson',
-      age: 20,
-    };
+    let childCard1Model = {};
+    let childCard2Model = {};
+    let childCard3Model = {};
     let box = Box.create(parentCardModel);
     let boxArr = box.field('someField');
-    let childValues: any = [childCard1Model, childCard2Model];
+    let childValues: any = [childCard1Model, childCard2Model, childCard3Model];
     boxArr.set(childValues);
     assert.strictEqual(boxArr.children[0].value, childCard1Model);
     assert.strictEqual(boxArr.children[1].value, childCard2Model);
+    assert.strictEqual(boxArr.children[2].value, childCard3Model);
     assert.strictEqual(boxArr.children[0].name, '0');
     assert.strictEqual(boxArr.children[1].name, '1');
-    let childValuesReordered: any = [childCard2Model, childCard1Model];
+    assert.strictEqual(boxArr.children[2].name, '2');
+
+    let childValuesReordered: any = [
+      childCard2Model,
+      childCard3Model,
+      childCard1Model,
+    ];
     boxArr.set(childValuesReordered);
     assert.strictEqual(boxArr.children[0].value, childCard2Model);
-    assert.strictEqual(boxArr.children[1].value, childCard1Model);
+    assert.strictEqual(boxArr.children[1].value, childCard3Model);
+    assert.strictEqual(boxArr.children[2].value, childCard1Model);
     assert.strictEqual(boxArr.children[0].name, '0');
     assert.strictEqual(boxArr.children[1].name, '1');
+    assert.strictEqual(boxArr.children[2].name, '2');
   });
 });


### PR DESCRIPTION
https://linear.app/cardstack/issue/CS-7936/reordering-linkstomany-cards-results-in-incorrect-fitted-components

Now template and component state should be preserved



https://github.com/user-attachments/assets/3afcc82b-48cc-4820-8923-10dd379a58a5

