### PR TITLE
host: Add optional id to mock createAndJoinRoom

### DIFF
--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -133,7 +133,10 @@ module('Acceptance | AI Assistant tests', function (hooks) {
   setupBaseRealm(hooks);
 
   hooks.beforeEach(async function () {
-    matrixRoomId = createAndJoinRoom('@testuser:localhost', 'room-test');
+    matrixRoomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'room-test',
+    });
     setupUserSubscription(matrixRoomId);
 
     class Pet extends CardDef {
@@ -366,7 +369,10 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     await click('[data-test-open-ai-assistant]');
     assert.dom('[data-test-llm-select-selected]').hasText('claude-3.5-sonnet');
 
-    createAndJoinRoom('@testuser:localhost', 'room-test-2');
+    createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'room-test-2',
+    });
 
     await click('[data-test-past-sessions-button]');
     await waitFor("[data-test-enter-room='mock_room_2']");

--- a/packages/host/tests/acceptance/basic-test.gts
+++ b/packages/host/tests/acceptance/basic-test.gts
@@ -26,7 +26,10 @@ module('Acceptance | basic tests', function (hooks) {
   });
 
   hooks.beforeEach(async function () {
-    matrixRoomId = createAndJoinRoom('@testuser:localhost', 'room-test');
+    matrixRoomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'room-test',
+    });
     setupUserSubscription(matrixRoomId);
 
     let loaderService = lookupLoaderService();

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -428,7 +428,10 @@ module('Acceptance | code submode tests', function (_hooks) {
     }
 
     hooks.beforeEach(async function () {
-      matrixRoomId = createAndJoinRoom('@testuser:localhost', 'room-test');
+      matrixRoomId = createAndJoinRoom({
+        sender: '@testuser:localhost',
+        name: 'room-test',
+      });
       setupUserSubscription(matrixRoomId);
 
       let realmServerService = this.owner.lookup(
@@ -533,7 +536,10 @@ module('Acceptance | code submode tests', function (_hooks) {
     });
 
     hooks.beforeEach(async function () {
-      matrixRoomId = createAndJoinRoom('@testuser:localhost', 'room-test');
+      matrixRoomId = createAndJoinRoom({
+        sender: '@testuser:localhost',
+        name: 'room-test',
+      });
       setupUserSubscription(matrixRoomId);
 
       monacoService = this.owner.lookup(

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -215,7 +215,10 @@ module('Acceptance | code submode | create-file tests', function (hooks) {
       contents: files,
     }));
 
-    matrixRoomId = createAndJoinRoom('@testuser:localhost', 'room-test');
+    matrixRoomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'room-test',
+    });
     setupUserSubscription(matrixRoomId);
 
     lookupNetworkService().mount(

--- a/packages/host/tests/acceptance/code-submode/editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/editor-test.ts
@@ -52,7 +52,10 @@ module('Acceptance | code submode | editor tests', function (hooks) {
   hooks.beforeEach(async function () {
     setRealmPermissions({ [testRealmURL]: ['read', 'write'] });
 
-    matrixRoomId = createAndJoinRoom('@testuser:localhost', 'room-test');
+    matrixRoomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'room-test',
+    });
     setupUserSubscription(matrixRoomId);
 
     monacoService = this.owner.lookup(

--- a/packages/host/tests/acceptance/code-submode/file-tree-test.ts
+++ b/packages/host/tests/acceptance/code-submode/file-tree-test.ts
@@ -199,7 +199,10 @@ module('Acceptance | code submode | file-tree tests', function (hooks) {
   hooks.beforeEach(async function () {
     setRealmPermissions({ [testRealmURL]: ['read', 'write'] });
 
-    matrixRoomId = createAndJoinRoom('@testuser:localhost', 'room-test');
+    matrixRoomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'room-test',
+    });
     setupUserSubscription(matrixRoomId);
 
     const numStubFiles = 100;

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -414,7 +414,10 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
       [testRealmURL2]: ['read', 'write'],
     });
 
-    matrixRoomId = createAndJoinRoom('@testuser:localhost', 'room-test');
+    matrixRoomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'room-test',
+    });
     setupUserSubscription(matrixRoomId);
 
     // this seeds the loader used during index which obtains url mappings

--- a/packages/host/tests/acceptance/code-submode/playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/playground-test.gts
@@ -131,7 +131,10 @@ export class BlogPost extends CardDef {
 }`;
 
   hooks.beforeEach(async function () {
-    matrixRoomId = createAndJoinRoom('@testuser:localhost', 'room-test');
+    matrixRoomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'room-test',
+    });
     setupUserSubscription(matrixRoomId);
 
     ({ realm } = await setupAcceptanceTestRealm({

--- a/packages/host/tests/acceptance/code-submode/recent-files-test.ts
+++ b/packages/host/tests/acceptance/code-submode/recent-files-test.ts
@@ -194,7 +194,10 @@ module('Acceptance | code submode | recent files tests', function (hooks) {
   });
 
   hooks.beforeEach(async function () {
-    matrixRoomId = createAndJoinRoom('@testuser:localhost', 'room-test');
+    matrixRoomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'room-test',
+    });
     setupUserSubscription(matrixRoomId);
     monacoService = this.owner.lookup(
       'service:monaco-service',

--- a/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
@@ -234,7 +234,10 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
   });
 
   hooks.beforeEach(async function () {
-    matrixRoomId = createAndJoinRoom('@testuser:localhost', 'room-test');
+    matrixRoomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'room-test',
+    });
     setupUserSubscription(matrixRoomId);
 
     // this seeds the loader used during index which obtains url mappings

--- a/packages/host/tests/acceptance/code-submode/spec-test.gts
+++ b/packages/host/tests/acceptance/code-submode/spec-test.gts
@@ -128,7 +128,10 @@ module('Acceptance | Spec preview', function (hooks) {
     });
 
   hooks.beforeEach(async function () {
-    matrixRoomId = createAndJoinRoom('@testuser:localhost', 'room-test');
+    matrixRoomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'room-test',
+    });
     setupUserSubscription(matrixRoomId);
 
     // this seeds the loader used during index which obtains url mappings

--- a/packages/host/tests/acceptance/commands-test.gts
+++ b/packages/host/tests/acceptance/commands-test.gts
@@ -75,7 +75,10 @@ module('Acceptance | Commands tests', function (hooks) {
   setupBaseRealm(hooks);
 
   hooks.beforeEach(async function () {
-    matrixRoomId = await createAndJoinRoom('@testuser:localhost', 'room-test');
+    matrixRoomId = await createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'room-test',
+    });
     setupUserSubscription(matrixRoomId);
 
     class Pet extends CardDef {

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -61,7 +61,10 @@ module('Acceptance | interact submode tests', function (hooks) {
     });
 
   hooks.beforeEach(async function () {
-    matrixRoomId = createAndJoinRoom('@testuser:localhost', 'room-test');
+    matrixRoomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'room-test',
+    });
     setupUserSubscription(matrixRoomId);
 
     let loader = lookupLoaderService().loader;

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -62,7 +62,10 @@ module('Acceptance | operator mode tests', function (hooks) {
     });
 
   hooks.beforeEach(async function () {
-    matrixRoomId = createAndJoinRoom('@testuser:localhost', 'room-test');
+    matrixRoomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'room-test',
+    });
     setupUserSubscription(matrixRoomId);
 
     setExpiresInSec(60 * 60);

--- a/packages/host/tests/acceptance/permissioned-realm-test.gts
+++ b/packages/host/tests/acceptance/permissioned-realm-test.gts
@@ -24,7 +24,10 @@ module('Acceptance | permissioned realm tests', function (hooks) {
   });
 
   hooks.beforeEach(async function () {
-    matrixRoomId = createAndJoinRoom('@testuser:localhost', 'room-test');
+    matrixRoomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'room-test',
+    });
     setupUserSubscription(matrixRoomId);
 
     let loader = lookupLoaderService().loader;

--- a/packages/host/tests/helpers/mock-matrix/_server-state.ts
+++ b/packages/host/tests/helpers/mock-matrix/_server-state.ts
@@ -42,12 +42,13 @@ export class ServerState {
     sender: string,
     name?: string,
     timestamp: number = this.#now(),
+    id?: string,
   ): string {
     if (document.querySelector('[data-test-throw-room-error]')) {
       throw new Error('Intentional error thrown');
     }
 
-    let roomId = `mock_room_${this.#roomCounter++}`;
+    let roomId = id ?? `mock_room_${this.#roomCounter++}`;
 
     if (this.#rooms.has(roomId)) {
       throw new Error(`room ${roomId} already exists`);

--- a/packages/host/tests/helpers/mock-matrix/_utils.ts
+++ b/packages/host/tests/helpers/mock-matrix/_utils.ts
@@ -65,11 +65,22 @@ export class MockUtils {
   setActiveRealms = (realmURLs: string[]) => {
     this.testState.opts!.activeRealms = realmURLs;
   };
-  createAndJoinRoom = (sender: string, name: string, timestamp?: number) => {
+  createAndJoinRoom = ({
+    sender,
+    name,
+    id,
+    timestamp,
+  }: {
+    sender: string;
+    name: string;
+    id?: string;
+    timestamp?: number;
+  }) => {
     let roomId = this.testState.sdk!.serverState.createRoom(
       sender,
       name,
       timestamp,
+      id,
     );
     return roomId;
   };

--- a/packages/host/tests/integration/commands/send-ai-assistant-message-test.gts
+++ b/packages/host/tests/integration/commands/send-ai-assistant-message-test.gts
@@ -56,7 +56,10 @@ module('Integration | commands | send-ai-assistant-message', function (hooks) {
   });
 
   test('send an ai assistant message', async function (assert) {
-    let roomId = createAndJoinRoom('@testuser:localhost', 'room-test');
+    let roomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'room-test',
+    });
     let commandService = lookupService<CommandService>('command-service');
 
     let sendAiAssistantMessageCommand = new SendAiAssistantMessageCommand(
@@ -73,7 +76,10 @@ module('Integration | commands | send-ai-assistant-message', function (hooks) {
   });
 
   test('send an ai assistant message with command call, not required to be called', async function (assert) {
-    let roomId = createAndJoinRoom('@testuser:localhost', 'room-test');
+    let roomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'room-test',
+    });
     let commandService = lookupService<CommandService>('command-service');
 
     let sendAiAssistantMessageCommand = new SendAiAssistantMessageCommand(
@@ -96,7 +102,10 @@ module('Integration | commands | send-ai-assistant-message', function (hooks) {
   });
 
   test('send an ai assistant message with command call, explicitly not required to be called', async function (assert) {
-    let roomId = createAndJoinRoom('@testuser:localhost', 'room-test');
+    let roomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'room-test',
+    });
     let commandService = lookupService<CommandService>('command-service');
 
     let sendAiAssistantMessageCommand = new SendAiAssistantMessageCommand(
@@ -120,7 +129,10 @@ module('Integration | commands | send-ai-assistant-message', function (hooks) {
   });
 
   test('send an ai assistant message with command call, explicitly required to be called', async function (assert) {
-    let roomId = createAndJoinRoom('@testuser:localhost', 'room-test');
+    let roomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'room-test',
+    });
     let commandService = lookupService<CommandService>('command-service');
 
     let sendAiAssistantMessageCommand = new SendAiAssistantMessageCommand(
@@ -144,7 +156,10 @@ module('Integration | commands | send-ai-assistant-message', function (hooks) {
   });
 
   test('multiple commands are allowed if not required to be called', async function (assert) {
-    let roomId = createAndJoinRoom('@testuser:localhost', 'room-test');
+    let roomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'room-test',
+    });
     let commandService = lookupService<CommandService>('command-service');
 
     let sendAiAssistantMessageCommand = new SendAiAssistantMessageCommand(

--- a/packages/host/tests/integration/components/ai-assistant-panel-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel-test.gts
@@ -436,8 +436,14 @@ module('Integration | ai-assistant-panel', function (hooks) {
       },
     );
     await waitFor('[data-test-person="Fadhlan"]');
-    let room1Id = createAndJoinRoom('@testuser:localhost', 'test room 1');
-    let room2Id = createAndJoinRoom('@testuser:localhost', 'test room 2');
+    let room1Id = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'test room 1',
+    });
+    let room2Id = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'test room 2',
+    });
     simulateRemoteMessage(room2Id, '@aibot:localhost', {
       msgtype: APP_BOXEL_COMMAND_MSGTYPE,
       body: 'Incorrect command',
@@ -1250,11 +1256,19 @@ module('Integration | ai-assistant-panel', function (hooks) {
         },
       );
 
-      createAndJoinRoom('@testuser:localhost', 'test room 0');
-      let room1Id = createAndJoinRoom('@testuser:localhost', 'test room 1');
-      const room2Id = createAndJoinRoom('@testuser:localhost', 'test room 2');
+      createAndJoinRoom({
+        sender: '@testuser:localhost',
+        name: 'test room 0',
+      });
+      let room1Id = createAndJoinRoom({
+        sender: '@testuser:localhost',
+        name: 'test room 1',
+      });
+      const room2Id = createAndJoinRoom({
+        sender: '@testuser:localhost',
+        name: 'test room 2',
+      });
       await settled();
-
       await openAiAssistant();
       await waitFor(`[data-room-settled]`);
 
@@ -1487,10 +1501,10 @@ module('Integration | ai-assistant-panel', function (hooks) {
 
     // Create a new room with some activity (this could happen when we will have a feature that interacts with AI outside of the AI pannel, i.e. "commands")
 
-    let anotherRoomId = createAndJoinRoom(
-      '@testuser:localhost',
-      'Another Room',
-    );
+    let anotherRoomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'Another Room',
+    });
 
     simulateRemoteMessage(
       anotherRoomId,
@@ -1651,7 +1665,10 @@ module('Integration | ai-assistant-panel', function (hooks) {
       },
     );
     await waitFor('[data-test-person="Fadhlan"]');
-    let roomId = createAndJoinRoom('@testuser:localhost', 'test room 1');
+    let roomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'test room 1',
+    });
     fillRoomWithReadMessages(roomId, false);
     await settled();
     await click('[data-test-open-ai-assistant]');
@@ -1673,7 +1690,10 @@ module('Integration | ai-assistant-panel', function (hooks) {
       },
     );
     await waitFor('[data-test-person="Fadhlan"]');
-    let roomId = createAndJoinRoom('@testuser:localhost', 'test room 1');
+    let roomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'test room 1',
+    });
     fillRoomWithReadMessages(roomId);
     await settled();
     await click('[data-test-open-ai-assistant]');
@@ -1695,7 +1715,10 @@ module('Integration | ai-assistant-panel', function (hooks) {
       },
     );
     await waitFor('[data-test-person="Fadhlan"]');
-    let roomId = createAndJoinRoom('@testuser:localhost', 'test room 1');
+    let roomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'test room 1',
+    });
     fillRoomWithReadMessages(roomId);
     await settled();
     await click('[data-test-open-ai-assistant]');
@@ -1760,10 +1783,10 @@ module('Integration | ai-assistant-panel', function (hooks) {
       .dom(`[data-test-enter-room='${roomId}'] [data-test-is-streaming]`)
       .doesNotExist();
 
-    let anotherRoomId = createAndJoinRoom(
-      '@testuser:localhost',
-      'Another Room',
-    );
+    let anotherRoomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'Another Room',
+    });
 
     let eventId3 = simulateRemoteMessage(
       anotherRoomId,
@@ -2134,10 +2157,10 @@ module('Integration | ai-assistant-panel', function (hooks) {
     await click('[data-test-close-ai-assistant]');
 
     // Create a new room with some activity
-    let anotherRoomId = await createAndJoinRoom(
-      '@testuser:localhost',
-      'Another Room',
-    );
+    let anotherRoomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'Another Room',
+    });
 
     // A message that hasn't been seen and was sent more than fifteen minutes ago must not be shown in the toast.
     let sixteenMinutesAgo = subMinutes(new Date(), 16);
@@ -2232,7 +2255,10 @@ module('Integration | ai-assistant-panel', function (hooks) {
       },
     );
     await waitFor('[data-test-person="Fadhlan"]');
-    let roomId = createAndJoinRoom('@testuser:localhost', 'test room 1');
+    let roomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'test room 1',
+    });
     simulateRemoteMessage(roomId, '@aibot:localhost', {
       msgtype: APP_BOXEL_COMMAND_MSGTYPE,
       body: 'Changing first name to Evie',
@@ -2305,7 +2331,10 @@ module('Integration | ai-assistant-panel', function (hooks) {
       },
     );
     await waitFor('[data-test-person="Fadhlan"]');
-    let roomId = createAndJoinRoom('@testuser:localhost', 'test room 1');
+    let roomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'test room 1',
+    });
     simulateRemoteMessage(roomId, '@aibot:localhost', {
       body: 'Changing first name to Evie',
       msgtype: APP_BOXEL_COMMAND_MSGTYPE,
@@ -2673,7 +2702,10 @@ module('Integration | ai-assistant-panel', function (hooks) {
       },
     );
     await waitFor('[data-test-person="Fadhlan"]');
-    let room1Id = createAndJoinRoom('@testuser:localhost', 'test room 1');
+    let room1Id = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'test room 1',
+    });
 
     simulateRemoteMessage(room1Id, '@aibot:localhost', {
       msgtype: APP_BOXEL_COMMAND_MSGTYPE,

--- a/packages/host/tests/integration/components/room-message-test.gts
+++ b/packages/host/tests/integration/components/room-message-test.gts
@@ -34,7 +34,10 @@ module('Integration | Component | RoomMessage', function (hooks) {
     };
 
     let testScenario = {
-      roomId: await createAndJoinRoom('@testuser:localhost', 'Test Room'),
+      roomId: createAndJoinRoom({
+        sender: '@testuser:localhost',
+        name: 'Test Room',
+      }),
       message,
       messages: [message],
       isStreaming,


### PR DESCRIPTION
This is extracted from #2116, where it’s necessary to specify the id of a mock Matrix room.