### PR TITLE
add white-space and word-break property on boxel-button component lvl

### DIFF
--- a/packages/boxel-ui/addon/src/components/button/index.gts
+++ b/packages/boxel-ui/addon/src/components/button/index.gts
@@ -103,7 +103,8 @@ export default class ButtonComponent extends Component<Signature> {
           height: min-content;
           align-items: center;
           border-radius: 100px;
-          white-space: nowrap;
+          white-space: var(--boxel-button-white-space, normal);
+          word-break: var(--boxel-button-word-break, break-word);
           transition:
             background-color var(--boxel-transition),
             border var(--boxel-transition);

--- a/packages/boxel-ui/addon/src/components/button/index.gts
+++ b/packages/boxel-ui/addon/src/components/button/index.gts
@@ -103,7 +103,6 @@ export default class ButtonComponent extends Component<Signature> {
           height: min-content;
           align-items: center;
           border-radius: 100px;
-          white-space: var(--boxel-button-white-space, normal);
           word-break: var(--boxel-button-word-break, break-word);
           transition:
             background-color var(--boxel-transition),


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-8100/improve-boxel-button-ui-to-handle-long-text

Before:
![image](https://github.com/user-attachments/assets/ff93d89e-8767-4838-861c-90bb413d199e)


After:
<img width="471" alt="Screenshot 2025-03-06 at 23 34 23" src="https://github.com/user-attachments/assets/6b4ff3c4-1511-43d5-bc95-7b803cc1beb5" />
