### PR TITLE
Fix: unable to jump the cursor in CardDef when clicking field row

### DIFF
--- a/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
@@ -1161,5 +1161,12 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
     assert.dom('[data-test-current-module-name="employee.gts"]').doesNotExist();
     assert.dom('[data-test-current-module-name="person.gts"]').exists();
     assert.true(monacoService.getLineCursorOn()?.includes('@field address'));
+
+    await click(
+      `[data-test-card-schema="Card"] [data-test-field-name-button="title"]`,
+    );
+    assert.dom('[data-test-current-module-name="person.gts"]').doesNotExist();
+    assert.dom('[data-test-current-module-name="card-api.gts"]').exists();
+    assert.true(monacoService.getLineCursorOn()?.includes('@field title'));
   });
 });

--- a/packages/runtime-common/babel-options.ts
+++ b/packages/runtime-common/babel-options.ts
@@ -3,6 +3,7 @@ import { ParserOptions, ParserPlugin } from '@babel/parser';
 export type Overrides = Partial<{
   sourceType: ParserOptions['sourceType'];
   strictMode: ParserOptions['strictMode'];
+  sourceFilename: ParserOptions['sourceFilename'];
 }>;
 
 export function getBabelOptions(

--- a/packages/runtime-common/babel-options.ts
+++ b/packages/runtime-common/babel-options.ts
@@ -16,6 +16,7 @@ export function getBabelOptions(
   return {
     sourceType: getOption(options, 'sourceType', 'module'),
     strictMode: getOption(options, 'strictMode', false),
+    sourceFilename: getOption(options, 'sourceFilename', undefined),
     allowImportExportEverywhere: true,
     allowReturnOutsideFunction: true,
     startLine: 1,

--- a/packages/runtime-common/module-syntax.ts
+++ b/packages/runtime-common/module-syntax.ts
@@ -70,15 +70,14 @@ export class ModuleSyntax {
       declarations: [],
     };
     let preprocessedSrc = preprocessTemplateTags(src);
-
     let ast: Babel.types.Node = parse(preprocessedSrc, {
       parser: {
-        parse(source: string) {
-          const options =
-            getBabelOptions(/*optionally pass in option overrides*/);
+        parse: (source: string) => {
+          const options = getBabelOptions({ sourceFilename: this.url.href });
           return babelParse(source, options);
         },
       },
+      sourceFileName: this.url.href,
     });
 
     let r = Babel.transformFromAstSync(ast, preprocessedSrc, {

--- a/packages/runtime-common/remove-field-plugin.ts
+++ b/packages/runtime-common/remove-field-plugin.ts
@@ -39,7 +39,10 @@ function maybeRemoveFieldDecoratorImport(
   path: NodePath<t.ImportDeclaration>,
   state: State,
 ) {
-  if (path.node.source.value !== state.opts.field.decorator.module) {
+  if (
+    state.opts.field.decorator.type === 'internal' ||
+    path.node.source.value !== state.opts.field.decorator.module
+  ) {
     return;
   }
   let specifier = getImportSpecifier(path, state.opts.field.decorator.name) as
@@ -62,7 +65,10 @@ function maybeRemoveFieldTypeImport(
   path: NodePath<t.ImportDeclaration>,
   state: State,
 ) {
-  if (path.node.source.value !== state.opts.field.type.module) {
+  if (
+    state.opts.field.type.type === 'internal' ||
+    path.node.source.value !== state.opts.field.type.module
+  ) {
     return;
   }
   let specifier = getImportSpecifier(path, state.opts.field.type.name) as


### PR DESCRIPTION
The new feature that moves the cursor to the field definition when clicking a field name in the schema editor didn’t work in the `CardDef` declaration. I discovered that `CardDef` lacks `possibleFields`, unlike other declarations. The issue lies in our schema analysis plugin, where we expected `@field` to be imported from `card-api`. However, in the case of `CardDef`, both `@field` and `CardDef` are defined in the same file.



https://github.com/user-attachments/assets/095c3afe-9219-4152-ba01-bd5caf8e3c00


