### PR TITLE
Default Button Text with line-clamp and text-overflow ellipsis

### DIFF
--- a/packages/boxel-ui/addon/src/components/button/index.gts
+++ b/packages/boxel-ui/addon/src/components/button/index.gts
@@ -103,7 +103,6 @@ export default class ButtonComponent extends Component<Signature> {
           height: min-content;
           align-items: center;
           border-radius: 100px;
-          word-break: var(--boxel-button-word-break, break-word);
           transition:
             background-color var(--boxel-transition),
             border var(--boxel-transition);

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -287,7 +287,7 @@ class SpecPreviewContent extends GlimmerComponent<ContentSignature> {
                 {{on 'click' this.viewSpecInstance}}
                 data-test-view-spec-instance
               >
-                View Instance
+                <span class='view-instance-btn-text'>View Instance</span>
               </BoxelButton>
             </div>
             {{#if this.displayIsolated}}
@@ -339,6 +339,14 @@ class SpecPreviewContent extends GlimmerComponent<ContentSignature> {
         display: flex;
         align-items: center;
         gap: var(--boxel-sp-xxxs);
+      }
+      .view-instance-btn-text {
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        word-break: break-word;
       }
     </style>
   </template>


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-8117/default-button-text-with-line-clamp-and-text-overflow-ellipsis

Before: 
![image](https://github.com/user-attachments/assets/2b039f51-8f84-4d1d-9bd7-f70448238ee7)

Expected :
![image](https://github.com/user-attachments/assets/63e61735-0be0-47cf-9452-bee9b81cb1b0)

Result If the resize panel is smaller, we expect it will handle the text-overflow ellipsis:
![image](https://github.com/user-attachments/assets/ff1cc1b1-55c1-4734-96b4-92a1e94994a4)

