### PR TITLE
CS-8091 on click handler on links to many editor card / spec example card 

### DIFF
--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -203,12 +203,6 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
                 <button
                   type='button'
                   class='card-button'
-                  {{this.cardContext.cardComponentModifier
-                    card=boxedElement.value
-                    format='fitted'
-                    fieldType='linksToMany'
-                    fieldName=@field.name
-                  }}
                   {{on 'click' (fn this.viewCard boxedElement.value)}}
                 >
                   <Item @format='fitted' />

--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -200,7 +200,9 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
                 )
                 as |Item|
               }}
-                <div
+                <button
+                  type='button'
+                  class='card-button'
                   {{this.cardContext.cardComponentModifier
                     card=boxedElement.value
                     format='fitted'
@@ -210,7 +212,7 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
                   {{on 'click' (fn this.viewCard boxedElement.value)}}
                 >
                   <Item @format='fitted' />
-                </div>
+                </button>
               {{/let}}
             </li>
           {{/each}}
@@ -279,6 +281,12 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
       :deep(.is-dragging) {
         z-index: 99;
         transform: translateY(var(--boxel-sp));
+      }
+      .card-button {
+        all: unset;
+        display: block;
+        width: 100%;
+        cursor: pointer;
       }
     </style>
   </template>

--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -155,6 +155,11 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
     this.args.arrayField.set(items);
   }
 
+  @action
+  viewCard(card: CardDef) {
+    this.cardContext.actions?.viewCard(card);
+  }
+
   <template>
     <PermissionsConsumer as |permissions|>
       {{#if @arrayField.children.length}}
@@ -195,7 +200,17 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
                 )
                 as |Item|
               }}
-                <Item @format='fitted' />
+                <div
+                  {{this.cardContext.cardComponentModifier
+                    card=boxedElement.value
+                    format='fitted'
+                    fieldType='linksToMany'
+                    fieldName=@field.name
+                  }}
+                  {{on 'click' (fn this.viewCard boxedElement.value)}}
+                >
+                  <Item @format='fitted' />
+                </div>
               {{/let}}
             </li>
           {{/each}}

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -57,15 +57,8 @@ import OperatorModeStateService from '@cardstack/host/services/operator-mode-sta
 import RealmService from '@cardstack/host/services/realm';
 import type RealmServerService from '@cardstack/host/services/realm-server';
 
-import {
-  CardContext,
-  CardDef,
-  type Format,
-  type FieldType,
-} from 'https://cardstack.com/base/card-api';
+import { CardContext, CardDef } from 'https://cardstack.com/base/card-api';
 import { Spec, type SpecType } from 'https://cardstack.com/base/spec';
-
-import ElementTracker from '../../../resources/element-tracker';
 
 import type { WithBoundArgs } from '@glint/template';
 
@@ -193,21 +186,11 @@ class SpecPreviewContent extends GlimmerComponent<ContentSignature> {
     this.initializeCardSelection();
   }
 
-  cardTracker = new ElementTracker<{
-    cardId?: string;
-    card?: CardDef;
-    format: Format | 'data';
-    fieldType: FieldType | undefined;
-    fieldName: string | undefined;
-  }>();
-
   get cardContext(): Omit<CardContext, 'prerenderedCardSearchComponent'> {
     return {
-      cardComponentModifier: this.cardTracker.trackElement,
       actions: {
         viewCard: (card: CardDef) => this.viewCard(card),
       } as Actions,
-      commandContext: undefined,
     };
   }
 

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -57,17 +57,17 @@ import OperatorModeStateService from '@cardstack/host/services/operator-mode-sta
 import RealmService from '@cardstack/host/services/realm';
 import type RealmServerService from '@cardstack/host/services/realm-server';
 
-import { Spec, type SpecType } from 'https://cardstack.com/base/spec';
 import {
   CardContext,
   CardDef,
   type Format,
   type FieldType,
 } from 'https://cardstack.com/base/card-api';
-
-import type { WithBoundArgs } from '@glint/template';
+import { Spec, type SpecType } from 'https://cardstack.com/base/spec';
 
 import ElementTracker from '../../../resources/element-tracker';
+
+import type { WithBoundArgs } from '@glint/template';
 
 interface Signature {
   Element: HTMLElement;


### PR DESCRIPTION
Refer to https://linear.app/cardstack/issue/CS-8091/create-a-component-with-modifier-to-target-cards-inside-of-spec

### What is changing
- add card context and modifier to handle selected card action in links to component editor
- add cardComponentModifier at LinksToManyStandardEditor

Screenshot

https://github.com/user-attachments/assets/94530f10-fdda-450c-b61f-7c2e0c8d633d


