### PR TITLE
host: Add provenance check for realm events

### DIFF
--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -1461,12 +1461,11 @@ export default class MatrixService extends Service {
           'Ignoring realm event because no realm found',
           event,
         );
-        // TODO CS-8097
-        // } else if (realmResourceForEvent.info?.realmUserId !== event.sender) {
-        //   realmEventsLogger.debug(
-        //     `Ignoring realm event because sender ${event.sender} is not the realm user ${realmResourceForEvent.info?.realmUserId}`,
-        //     event,
-        //   );
+      } else if (realmResourceForEvent.info?.realmUserId !== event.sender) {
+        realmEventsLogger.debug(
+          `Ignoring realm event because sender ${event.sender} is not the realm user ${realmResourceForEvent.info?.realmUserId}`,
+          event,
+        );
       } else {
         this.messageService.relayMatrixSSE(
           realmResourceForEvent.url,

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -410,6 +410,13 @@ async function setupTestRealm({
   await worker.run();
   await realm.start();
 
+  // Workaround to refetch realm info, as it is first fetched before the virtual network
+  // is present, and the fetch fails, leading to realmUserId being undefined.
+  let realmResource = (
+    owner.lookup('service:realm') as any
+  ).getOrCreateRealmResource(realmURL);
+  await realmResource.fetchInfo();
+
   return { realm, adapter };
 }
 


### PR DESCRIPTION
This verifies that an incoming realm event comes from the correct realm’s Matrix user.

I’d love to find a way to fix the underlying problem that led me to include the workaround, which fixes test failures [like these](https://github.com/cardstack/boxel/runs/38527509504). In those tests, the expected realm events aren’t broadcast because the test realm’s `realmInfo` has `undefined` for `realmUserId`, so the realm event is ignored. It seems like the realm’s `_info` message is called too soon, before the virtual network is set up, because it shows up as a real query in the network tools. The `fetchInfo()` in the test setup fetches it properly and allows provenance to be verified.