### PR TITLE
Add embedded format for CommandField

### DIFF
--- a/packages/base/skill-card.gts
+++ b/packages/base/skill-card.gts
@@ -11,6 +11,7 @@ import CodeRefField from './code-ref';
 import MarkdownField from './markdown';
 import StringField from './string';
 import RobotIcon from '@cardstack/boxel-icons/robot';
+import SquareChevronRightIcon from '@cardstack/boxel-icons/square-chevron-right';
 import { simpleHash } from '@cardstack/runtime-common';
 
 function friendlyModuleName(fullModuleUrl: string) {
@@ -22,6 +23,8 @@ function friendlyModuleName(fullModuleUrl: string) {
 
 export class CommandField extends FieldDef {
   static displayName = 'CommandField';
+  static icon = SquareChevronRightIcon;
+
   @field codeRef = contains(CodeRefField, {
     description: 'An absolute code reference to the command to be executed',
   });
@@ -45,6 +48,55 @@ export class CommandField extends FieldDef {
       return `${name}_${hashed.slice(0, 4)}`;
     },
   });
+
+  static embedded = class Embedded extends Component<typeof this> {
+    <template>
+      <div class='command-embedded'>
+        <SquareChevronRightIcon class='icon' />
+        <div class='command-data'>
+          <div>
+            Module:
+            {{@model.codeRef.module}}
+          </div>
+          <div>
+            Name:
+            {{@model.codeRef.name}}
+          </div>
+          <div class='requires-approval'>
+            Requires Approval:
+            <@fields.requiresApproval />
+          </div>
+          <div class='function-name'>
+            Function Name (computed):
+            <@fields.functionName />
+          </div>
+        </div>
+      </div>
+      <style scoped>
+        .command-embedded {
+          display: flex;
+          align-items: top;
+          justify-content: stretch;
+          gap: var(--boxel-sp-xxs);
+        }
+        .command-data {
+          flex-grow: 1;
+          border-left: var(--boxel-sp-4xs) solid var(--boxel-purple-300);
+          padding-left: var(--boxel-sp-xxs);
+        }
+        .icon {
+          color: var(--boxel-purple-300);
+          margin-top: var(--boxel-sp-xxs);
+          width: 30px;
+          height: 30px;
+        }
+        .requires-approval,
+        .function-name {
+          margin-top: var(--boxel-sp-xxs);
+        }
+      </style>
+    </template>
+  };
 }
 
 export class SkillCard extends CardDef {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5bddc15e-cb12-46e9-a3b8-3d4221ef9624)

We can make it attractive in the future. I didn't want it to be missing.