### PR TITLE
Re-render issue when accessing property inside of a getter

### DIFF
--- a/packages/host/tests/integration/components/card-api-test.gts
+++ b/packages/host/tests/integration/components/card-api-test.gts
@@ -306,12 +306,6 @@ module('Integration | card api (Usage of publicAPI actions)', function (hooks) {
     test('accessing property of card in getter should not cause re-render of the component', async function (assert) {
       class SampleUsageWithGetCard extends CardDef {
         static displayName = 'SampleUsageWithGetCard';
-        @field name = contains(StringField);
-        @field title = contains(StringField, {
-          computeVia: function (this: SampleUsageWithGetCard) {
-            return this.name;
-          },
-        });
 
         static edit = class Edit extends Component<
           typeof SampleUsageWithGetCard
@@ -354,6 +348,7 @@ module('Integration | card api (Usage of publicAPI actions)', function (hooks) {
           </template>
         },
       );
+      await this.pauseTest();
       assert.ok(true);
     });
   });

--- a/packages/host/tests/integration/components/card-api-test.gts
+++ b/packages/host/tests/integration/components/card-api-test.gts
@@ -317,7 +317,7 @@ module('Integration | card api (Usage of publicAPI actions)', function (hooks) {
           private resource = getCard(this, () => this.id);
 
           get card() {
-            // console.log(this.resource.card.name); //<- this will cause a re-render
+            console.log(this.resource?.card?.name); //<- this will cause a re-render
             return this.resource.card;
           }
 


### PR DESCRIPTION
This PR reveals something very simple. 

When reactivity forces you to call `Box.create`, our component will be re-rendered. This is bcos the `Box` identity is lost entirely and we cannot leverage the stability of componentCache in `getBoxComponent` 

In the example showed, a simple property access within a console.log triggeres this re-render.

