### PR TITLE
Add feature flag to revert to SSE for realm events

### DIFF
--- a/.github/workflows/build-host.yml
+++ b/.github/workflows/build-host.yml
@@ -29,6 +29,7 @@ jobs:
             echo "MATRIX_URL=https://matrix.boxel.ai" >> $GITHUB_ENV
             echo "MATRIX_SERVER_NAME=boxel.ai" >> $GITHUB_ENV
             echo "EXPERIMENTAL_AI_ENABLED=true" >> $GITHUB_ENV
+            echo "DISABLE_MATRIX_REALM_EVENTS=true" >> $GITHUB_ENV
           elif [ "$INPUT_ENVIRONMENT" = "staging" ]; then
             echo "RESOLVED_BASE_REALM_URL=https://realms-staging.stack.cards/base/" >> $GITHUB_ENV
             echo "MATRIX_URL=https://matrix-staging.stack.cards" >> $GITHUB_ENV

--- a/.github/workflows/deploy-host.yml
+++ b/.github/workflows/deploy-host.yml
@@ -31,6 +31,7 @@ jobs:
             echo "AWS_ROLE_ARN=arn:aws:iam::120317779495:role/boxel-host" >> $GITHUB_ENV
             echo "AWS_S3_BUCKET=cardstack-boxel-host-production" >> $GITHUB_ENV
             echo "AWS_CLOUDFRONT_DISTRIBUTION=EIY7A542TLTVQ" >> $GITHUB_ENV
+            echo "DISABLE_MATRIX_REALM_EVENTS=true" >> $GITHUB_ENV
           elif [ "$INPUT_ENVIRONMENT" = "staging" ]; then
             echo "AWS_ROLE_ARN=arn:aws:iam::680542703984:role/boxel-host" >> $GITHUB_ENV
             echo "AWS_S3_BUCKET=cardstack-boxel-host-staging" >> $GITHUB_ENV

--- a/packages/host/app/config/environment.d.ts
+++ b/packages/host/app/config/environment.d.ts
@@ -28,5 +28,7 @@ declare const config: {
   sqlSchema: string;
   assetsURL: string;
   stripePaymentLink: string;
-  featureFlags?: {};
+  featureFlags?: {
+    DISABLE_MATRIX_REALM_EVENTS?: boolean;
+  };
 };

--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -53,7 +53,6 @@ module.exports = function (environment) {
     // ENV.APP.LOG_TRANSITIONS = true;
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
-    ENV.featureFlags = {};
   }
 
   if (environment === 'test') {

--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -41,7 +41,10 @@ module.exports = function (environment) {
     hostsOwnAssets: true,
     resolvedBaseRealmURL:
       process.env.RESOLVED_BASE_REALM_URL || 'http://localhost:4201/base/',
-    featureFlags: {},
+    featureFlags: {
+      DISABLE_MATRIX_REALM_EVENTS:
+        process.env.DISABLE_MATRIX_REALM_EVENTS === 'true',
+    },
   };
 
   if (environment === 'development') {

--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -64,6 +64,9 @@ if (process.env.DISABLE_MODULE_CACHING === 'true') {
   );
 }
 
+const DISABLE_MATRIX_REALM_EVENTS =
+  process.env.DISABLE_MATRIX_REALM_EVENTS === 'true';
+
 let {
   port,
   matrixURL,
@@ -228,6 +231,7 @@ let autoMigrate = migrateDB || undefined;
         virtualNetwork,
         dbAdapter,
         queue,
+        disableMatrixRealmEvents: DISABLE_MATRIX_REALM_EVENTS,
       },
       {
         ...(process.env.DISABLE_MODULE_CACHING === 'true'
@@ -271,6 +275,7 @@ let autoMigrate = migrateDB || undefined;
     seedPath,
     seedRealmURL: seedRealmURL ? new URL(seedRealmURL) : undefined,
     matrixRegistrationSecret: MATRIX_REGISTRATION_SHARED_SECRET,
+    disableMatrixRealmEvents: DISABLE_MATRIX_REALM_EVENTS,
     getRegistrationSecret: useRegistrationSecretFunction
       ? getRegistrationSecret
       : undefined,

--- a/packages/realm-server/scripts/start-production.sh
+++ b/packages/realm-server/scripts/start-production.sh
@@ -6,6 +6,7 @@ pnpm setup:catalog-in-deployment
 NODE_NO_WARNINGS=1 \
   MATRIX_URL=https://matrix.boxel.ai \
   REALM_SERVER_MATRIX_USERNAME=realm_server \
+  DISABLE_MATRIX_REALM_EVENTS=true \
   ts-node \
   --transpileOnly main \
   --port=3000 \

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -75,7 +75,7 @@ export class RealmServer {
   private getRegistrationSecret:
     | (() => Promise<string | undefined>)
     | undefined;
-
+  private disableMatrixRealmEvents: boolean;
   constructor({
     serverURL,
     realms,
@@ -92,6 +92,7 @@ export class RealmServer {
     getRegistrationSecret,
     seedPath,
     seedRealmURL,
+    disableMatrixRealmEvents,
   }: {
     serverURL: URL;
     realms: Realm[];
@@ -108,6 +109,7 @@ export class RealmServer {
     seedRealmURL?: URL;
     matrixRegistrationSecret?: string;
     getRegistrationSecret?: () => Promise<string | undefined>;
+    disableMatrixRealmEvents?: boolean;
   }) {
     if (!matrixRegistrationSecret && !getRegistrationSecret) {
       throw new Error(
@@ -131,6 +133,7 @@ export class RealmServer {
     this.getIndexHTML = getIndexHTML;
     this.matrixRegistrationSecret = matrixRegistrationSecret;
     this.getRegistrationSecret = getRegistrationSecret;
+    this.disableMatrixRealmEvents = disableMatrixRealmEvents ?? false;
     this.realms = [...realms, ...this.loadRealms()];
   }
 
@@ -385,6 +388,7 @@ export class RealmServer {
           url: this.matrixClient.matrixURL,
           username,
         },
+        disableMatrixRealmEvents: this.disableMatrixRealmEvents,
       },
       {
         ...(this.seedRealmURL && copyFromSeedRealm
@@ -445,6 +449,7 @@ export class RealmServer {
               url: this.matrixClient.matrixURL,
               username,
             },
+            disableMatrixRealmEvents: this.disableMatrixRealmEvents,
           });
           this.virtualNetwork.mount(realm.handle);
           realms.push(realm);

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -1999,16 +1999,16 @@ export class Realm {
     });
   }
 
-  private async sendServerEvent(event: ServerEvents): Promise<void> {
+  private async sendServerEvent(event: Partial<MessageEvent>): Promise<void> {
     this.#log.info(
       `sending updates to ${this.listeningClients.length} clients`,
     );
-    let { type, data, id } = event;
+    let { type, data } = event;
     let chunkArr = [];
     for (let item in data) {
       chunkArr.push(`"${item}": ${JSON.stringify((data as any)[item])}`);
     }
-    let chunk = sseToChunkData(type, `{${chunkArr.join(', ')}}`, id);
+    let chunk = sseToChunkData(type!, `{${chunkArr.join(', ')}}`);
     await Promise.allSettled(
       this.listeningClients.map((client) => writeToStream(client, chunk)),
     );

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -46,6 +46,7 @@ import {
   readFileAsText,
   getFileWithFallbacks,
   waitForClose,
+  writeToStream,
   type TextFileRef,
 } from './stream';
 import { transpileJS } from './transpile';
@@ -228,6 +229,8 @@ export class Realm {
   ]);
   #dbAdapter: DBAdapter;
 
+  #disableMatrixRealmEvents = false;
+
   // This loader is not meant to be used operationally, rather it serves as a
   // template that we clone for each indexing operation
   readonly loaderTemplate: Loader;
@@ -248,6 +251,7 @@ export class Realm {
       dbAdapter,
       queue,
       virtualNetwork,
+      disableMatrixRealmEvents,
     }: {
       url: string;
       adapter: RealmAdapter;
@@ -256,6 +260,7 @@ export class Realm {
       dbAdapter: DBAdapter;
       queue: QueuePublisher;
       virtualNetwork: VirtualNetwork;
+      disableMatrixRealmEvents?: boolean;
     },
     opts?: Options,
   ) {
@@ -286,6 +291,12 @@ export class Realm {
 
     // TODO: remove after running in all environments; CS-7875
     this.backfillRetentionPolicies();
+
+    this.#disableMatrixRealmEvents = disableMatrixRealmEvents ?? false;
+    console.log(
+      `disableMatrixRealmEvents for realm url ${url}`,
+      this.#disableMatrixRealmEvents,
+    );
 
     let loader = new Loader(fetch, virtualNetwork.resolveImport);
     adapter.setLoader?.(loader);
@@ -1988,8 +1999,30 @@ export class Realm {
     });
   }
 
+  private async sendServerEvent(event: ServerEvents): Promise<void> {
+    this.#log.info(
+      `sending updates to ${this.listeningClients.length} clients`,
+    );
+    let { type, data, id } = event;
+    let chunkArr = [];
+    for (let item in data) {
+      chunkArr.push(`"${item}": ${JSON.stringify((data as any)[item])}`);
+    }
+    let chunk = sseToChunkData(type, `{${chunkArr.join(', ')}}`, id);
+    await Promise.allSettled(
+      this.listeningClients.map((client) => writeToStream(client, chunk)),
+    );
+  }
+
   private async broadcastRealmEvent(event: RealmEventContent): Promise<void> {
-    this.#adapter.broadcastRealmEvent(event, this.#matrixClient);
+    if (this.#disableMatrixRealmEvents) {
+      this.sendServerEvent({
+        type: 'realm-event',
+        data: event,
+      });
+    } else {
+      this.#adapter.broadcastRealmEvent(event, this.#matrixClient);
+    }
   }
 
   private async createRequestContext(): Promise<RequestContext> {
@@ -2112,4 +2145,12 @@ function assertRealmPermissions(
       }
     }
   }
+}
+
+function sseToChunkData(type: string, data: string, id?: string): string {
+  let info = [`event: ${type}`, `data: ${data}`];
+  if (id) {
+    info.push(`id: ${id}`);
+  }
+  return info.join('\n') + '\n\n';
 }


### PR DESCRIPTION
This adds a `DISABLE_MATRIX_REALM_EVENTS` feature flag for both `host` and `realm-server` that switches back to using SSE for realm events while we address data being trampled. It’s only set for use in the production environment, where it’s currently deployed.

You can see the SSE coming in here when I edit a file in another tab, and eventually the card reloads:

![screencast 2025-03-17 14-17-45](https://github.com/user-attachments/assets/3fc651e5-a8f4-46d8-aab1-f901f6b27ed6)
