### PR TITLE
Refactor SearchResource to use Store Service

### DIFF
--- a/packages/host/app/components/card-catalog/modal.gts
+++ b/packages/host/app/components/card-catalog/modal.gts
@@ -43,7 +43,7 @@ import {
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 
-import { getSearch, type SearchQuery } from '../../resources/search';
+import { getSearch, type SearchResource } from '../../resources/search';
 
 import {
   suggestCardChooserTitle,
@@ -71,7 +71,7 @@ interface Signature {
 }
 
 type Request = {
-  search: SearchQuery;
+  search: SearchResource;
   deferred: Deferred<CardDef | undefined>;
   opts?: {
     offerToCreate?: {

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -41,7 +41,10 @@ import CopyCardCommand from '@cardstack/host/commands/copy-card';
 import config from '@cardstack/host/config/environment';
 import { StackItem } from '@cardstack/host/lib/stack-item';
 
-import { SearchQuery, getSearch } from '@cardstack/host/resources/search';
+import {
+  type SearchResource,
+  getSearch,
+} from '@cardstack/host/resources/search';
 import { stackBackgroundsResource } from '@cardstack/host/resources/stack-backgrounds';
 
 import type MatrixService from '@cardstack/host/services/matrix-service';
@@ -366,7 +369,7 @@ export default class InteractSubmode extends Component<Signature> {
       getCards: (
         getQuery: () => Query | undefined,
         getRealms: () => string[] | undefined,
-      ): SearchQuery => {
+      ): SearchResource => {
         return getSearch(here, getQuery, getRealms);
       },
     };

--- a/packages/host/app/resources/card-resource.ts
+++ b/packages/host/app/resources/card-resource.ts
@@ -32,7 +32,14 @@ interface Args {
     // different instances don't result in re-running the resource
     urlOrDoc: string | LooseSingleCardDocument | undefined;
     isLive: boolean;
-    // this is not always constructed within a container so we pass in our services
+
+    // TODO the fact this is not always constructed in a container is super
+    // problematic since only components should be consuming this. After we have
+    // refactored this so that it is not consumed by things outside of a
+    // container, then start injecting our services instead of passing them in.
+
+    // this is not always constructed within a container so we pass in our
+    // services
     storeService: StoreService;
     cardService: CardService;
     relativeTo?: URL;

--- a/packages/host/app/resources/card-resource.ts
+++ b/packages/host/app/resources/card-resource.ts
@@ -150,6 +150,8 @@ export class CardResource extends Resource<Args> {
             resource: this,
             urlOrDoc,
             relativeTo,
+            isAutoSaved: this.isAutoSaved,
+            isLive: this.isLive,
             setCard: (card) => {
               if (card !== this.card) {
                 this._card = card;

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -1,4 +1,5 @@
 import { registerDestructor } from '@ember/destroyable';
+import { getOwner } from '@ember/owner';
 
 import { service } from '@ember/service';
 import { buildWaiter } from '@ember/test-waiters';
@@ -8,26 +9,22 @@ import { restartableTask } from 'ember-concurrency';
 import { Resource } from 'ember-resources';
 import flatMap from 'lodash/flatMap';
 
-import { TrackedMap } from 'tracked-built-ins';
+import { TrackedArray } from 'tracked-built-ins';
 
 import {
   subscribeToRealm,
   isCardCollectionDocument,
-  SingleCardDocument,
 } from '@cardstack/runtime-common';
 
 import type { Query } from '@cardstack/runtime-common/query';
 
-import type { CardDef } from 'https://cardstack.com/base/card-api';
+import { CardDef } from 'https://cardstack.com/base/card-api';
 
 import type { RealmEventContent } from 'https://cardstack.com/base/matrix-event';
 
-import { asURL } from '../services/store';
-
-import { type CardResource, getCard } from './card-resource';
-
 import type CardService from '../services/card-service';
 import type RealmServerService from '../services/realm-server';
+import type StoreService from '../services/store';
 
 const waiter = buildWaiter('search-resource:search-waiter');
 
@@ -35,29 +32,41 @@ interface Args {
   named: {
     query: Query | undefined;
     realms: string[] | undefined;
-    isLive?: true;
+    isLive: boolean;
+    isAutoSaved: boolean;
     doWhileRefreshing?: (ready: Promise<void> | undefined) => Promise<void>;
+    storeService: StoreService;
   };
 }
 
-// TODO refactor this so that it is a resource that holds a list of CardDefs,
-// not a resource that holds a list of CardResources. All the loading should
-// happen at the same time. Please make a ticket for this.
-export class Search extends Resource<Args> {
+export class SearchResource extends Resource<Args> {
   @service declare private cardService: CardService;
   @service declare private realmServer: RealmServerService;
   @tracked private realmsToSearch: string[] = [];
+  // This is deprecated. consumers of this resource need to be reactive such
+  // that they can deal with a resource that doesn't have a search results yet.
   loaded: Promise<void> | undefined;
   private subscriptions: { url: string; unsubscribe: () => void }[] = [];
-  private cardResources = new Map<string, CardResource>();
-  private seenCardResource = new TrackedMap<string, CardResource>();
-  private currentResults = new TrackedMap<string, CardResource>();
+  declare private store: StoreService;
+  private _instances = new TrackedArray<CardDef>();
+  #isLive = false;
+  #isAutoSaved = false;
 
   modify(_positional: never[], named: Args['named']) {
-    let { query, realms, isLive, doWhileRefreshing } = named;
+    let {
+      query,
+      realms,
+      isLive,
+      doWhileRefreshing,
+      storeService,
+      isAutoSaved,
+    } = named;
     if (query === undefined) {
       return;
     }
+    this.store = storeService;
+    this.#isLive = isLive;
+    this.#isAutoSaved = isAutoSaved;
     this.realmsToSearch =
       realms === undefined || realms.length === 0
         ? this.realmServer.availableRealmURLs
@@ -94,11 +103,17 @@ export class Search extends Resource<Args> {
     }
   }
 
+  get isLive() {
+    return this.#isLive;
+  }
+
+  get isAutoSaved() {
+    return this.#isAutoSaved;
+  }
+
   @cached
   get instances() {
-    return [...this.currentResults.values()]
-      .filter((r) => r.card)
-      .map((r) => r.card) as CardDef[];
+    return this._instances;
   }
 
   @cached
@@ -118,49 +133,6 @@ export class Search extends Resource<Args> {
       await doWhileRefreshing(this.loaded);
     },
   );
-
-  // By default, this does a tracked read from seenCards so that your
-  // answer can be invalidated if a new card is discovered. Internally, we also
-  // use it untracked to implement the read-through cache.
-  private seenCard(url: string, tracked = true): CardResource | undefined {
-    let resource = this.cardResources.get(url);
-    if (resource) {
-      return resource;
-    }
-    if (tracked) {
-      this.seenCardResource.has(url);
-    }
-    return undefined;
-  }
-
-  private getOrCreateCardResource(
-    urlOrDoc: string | SingleCardDocument,
-  ): CardResource {
-    let url = asURL(urlOrDoc);
-    if (!url) {
-      throw new Error(
-        `bug: expected card doc to have an id: ${JSON.stringify(
-          urlOrDoc,
-          null,
-          2,
-        )}`,
-      );
-    }
-    // this should be the only place we do the untracked read. It needs to be
-    // untracked so our `this.cardResources.set` below will not be an assertion.
-    let resource = this.seenCard(url, false);
-    if (!resource) {
-      // TODO refactor this out--we don't want to hold CardResources at this layer
-      resource = getCard(this, () => urlOrDoc, {
-        isLive: true,
-      });
-      this.cardResources.set(url, resource);
-      // only after the set has happened can we safely do the tracked read to
-      // establish our dependency.
-      this.seenCardResource.set(url, resource);
-    }
-    return resource;
-  }
 
   private search = restartableTask(async (query: Query) => {
     // we cannot use the `waitForPromise` test waiter helper as that will cast
@@ -191,35 +163,29 @@ export class Search extends Resource<Args> {
               (
                 (
                   await Promise.allSettled(
-                    collectionDoc.data.map(async (doc) =>
-                      this.getOrCreateCardResource({ data: doc }),
+                    collectionDoc.data.map(async (jsonAPIResource) =>
+                      this.store.createSubscriber({
+                        resource: this,
+                        urlOrDoc: { data: jsonAPIResource },
+                        relativeTo: undefined,
+                        isAutoSaved: this.isAutoSaved,
+                        isLive: this.isLive,
+                      }),
                     ),
                   )
                 ).filter(
                   (p) => p.status === 'fulfilled',
-                ) as PromiseFulfilledResult<CardResource>[]
+                ) as PromiseFulfilledResult<{ card: CardDef }>[]
               ).map((p) => p.value)
             );
           }),
         ),
       );
-
-      await Promise.all(results.map((r) => r.loaded));
-      let resultsWithoutErrors = results.filter((r) => r.card && r.url);
-      let resultMap = new Map<string, CardResource>();
-      for (let resource of resultsWithoutErrors) {
-        resultMap.set(resource.url!, resource);
-      }
-      for (let url of this.currentResults.keys()) {
-        if (!resultMap.has(url)) {
-          this.currentResults.delete(url);
-        }
-      }
-      for (let [url, resource] of resultMap) {
-        if (!this.currentResults.has(url)) {
-          this.currentResults.set(url, resource);
-        }
-      }
+      this._instances.splice(
+        0,
+        this._instances.length,
+        ...results.map(({ card }) => card),
+      );
     } finally {
       waiter.endAsync(token);
     }
@@ -230,27 +196,27 @@ export class Search extends Resource<Args> {
   }
 }
 
-export interface SearchQuery {
-  instances: CardDef[];
-  isLoading: boolean;
-  loaded: Promise<void>;
-}
-
 export function getSearch(
   parent: object,
   getQuery: () => Query | undefined,
   getRealms?: () => string[] | undefined,
   opts?: {
-    isLive?: true;
+    isLive?: boolean;
+    isAutoSaved?: boolean;
     doWhileRefreshing?: (ready: Promise<void> | undefined) => Promise<void>;
   },
 ) {
-  return Search.from(parent, () => ({
+  return SearchResource.from(parent, () => ({
     named: {
       query: getQuery(),
       realms: getRealms ? getRealms() : undefined,
-      isLive: opts?.isLive,
+      isLive: opts?.isLive != null ? opts.isLive : true,
+      isAutoSaved: opts?.isAutoSaved != null ? opts.isAutoSaved : false,
+      storeService: (getOwner(parent) as any).lookup(
+        'service:store',
+      ) as StoreService,
+      // TODO refactor this out
       doWhileRefreshing: opts?.doWhileRefreshing,
     },
-  })) as SearchQuery;
+  }));
 }

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -1,5 +1,4 @@
 import { registerDestructor } from '@ember/destroyable';
-import { getOwner } from '@ember/owner';
 
 import { service } from '@ember/service';
 import { buildWaiter } from '@ember/test-waiters';
@@ -35,36 +34,28 @@ interface Args {
     isLive: boolean;
     isAutoSaved: boolean;
     doWhileRefreshing?: (ready: Promise<void> | undefined) => Promise<void>;
-    storeService: StoreService;
   };
 }
 
 export class SearchResource extends Resource<Args> {
   @service declare private cardService: CardService;
   @service declare private realmServer: RealmServerService;
+  @service declare private store: StoreService;
   @tracked private realmsToSearch: string[] = [];
   // This is deprecated. consumers of this resource need to be reactive such
   // that they can deal with a resource that doesn't have a search results yet.
   loaded: Promise<void> | undefined;
   private subscriptions: { url: string; unsubscribe: () => void }[] = [];
-  declare private store: StoreService;
+  // declare private store: StoreService;
   private _instances = new TrackedArray<CardDef>();
   #isLive = false;
   #isAutoSaved = false;
 
   modify(_positional: never[], named: Args['named']) {
-    let {
-      query,
-      realms,
-      isLive,
-      doWhileRefreshing,
-      storeService,
-      isAutoSaved,
-    } = named;
+    let { query, realms, isLive, doWhileRefreshing, isAutoSaved } = named;
     if (query === undefined) {
       return;
     }
-    this.store = storeService;
     this.#isLive = isLive;
     this.#isAutoSaved = isAutoSaved;
     this.realmsToSearch =
@@ -181,6 +172,18 @@ export class SearchResource extends Resource<Args> {
           }),
         ),
       );
+
+      // Please note 3 things there:
+      // 1. we are mutating this._instances, not replacing it
+      // 2. the items in this array come from an identity map, so we are never
+      //    recreating an instance that already exist.
+      // 3. The ordering of the results is important, we need to retain that.
+      //
+      //  As such, removing all the items in-place in our tracked
+      //  this._instances array, and then re-adding the new results back into
+      //  the array in the correct order synchronously is a stable operation.
+      //  glimmer understands the delta and will only rerender the components
+      //  tied to the instances that are added (or removed) from the array
       this._instances.splice(
         0,
         this._instances.length,
@@ -212,9 +215,6 @@ export function getSearch(
       realms: getRealms ? getRealms() : undefined,
       isLive: opts?.isLive != null ? opts.isLive : true,
       isAutoSaved: opts?.isAutoSaved != null ? opts.isAutoSaved : false,
-      storeService: (getOwner(parent) as any).lookup(
-        'service:store',
-      ) as StoreService,
       // TODO refactor this out
       doWhileRefreshing: opts?.doWhileRefreshing,
     },

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -34,6 +34,7 @@ import type MessageService from './message-service';
 import type RealmService from './realm';
 
 import type { CardResource } from '../resources/card-resource';
+import type { SearchResource } from '../resources/search';
 
 export { CardError };
 
@@ -75,9 +76,12 @@ export default class StoreService extends Service {
       // it's possible to have the same card instance used in different
       // resources as the owners of the resources can differ
       resources: {
-        resourceState: { resource: CardResource; onCardChange?: () => void };
-        setCard: (card: CardDef | undefined) => void;
-        setCardError: (error: CardError | undefined) => void;
+        resourceState: {
+          resource: CardResource | SearchResource;
+          onCardChange?: () => void;
+        };
+        setCard?: (card: CardDef | undefined) => void;
+        setCardError?: (error: CardError | undefined) => void;
       }[];
       realm: string;
     }
@@ -136,12 +140,16 @@ export default class StoreService extends Service {
     setCard,
     setCardError,
     relativeTo,
+    isLive,
+    isAutoSaved,
   }: {
-    resource: CardResource;
+    resource: CardResource | SearchResource;
     urlOrDoc: string | LooseSingleCardDocument;
-    setCard: (card: CardDef | undefined) => void;
-    setCardError: (error: CardError | undefined) => void;
+    setCard?: (card: CardDef | undefined) => void;
+    setCardError?: (error: CardError | undefined) => void;
     relativeTo?: URL;
+    isLive?: boolean;
+    isAutoSaved?: boolean;
   }): Promise<{
     url: string | undefined;
     card: CardDef | undefined;
@@ -152,17 +160,18 @@ export default class StoreService extends Service {
     let error = !isCardInstance(cardOrError) ? cardOrError : undefined;
 
     let url = cardOrError.id;
-    if (!url || !resource.isLive) {
+    if (!url || !isLive) {
       await this.handleUpdatedCard(undefined, cardOrError);
       // when there is no 'url' it is likely a card error for a doc without an ID
-      return { url: url ?? resource.url, card, error };
+      return {
+        url: url ?? ('url' in resource ? resource.url : undefined),
+        card,
+        error,
+      };
     }
 
     if (!isCardInstance(cardOrError)) {
-      console.warn(
-        `cannot load card ${cardOrError.id ?? resource.url}`,
-        cardOrError,
-      );
+      console.warn(`cannot load card ${url}`, cardOrError);
     }
 
     let realmURL = this.realm.realmOfURL(new URL(url));
@@ -183,7 +192,7 @@ export default class StoreService extends Service {
       subscriber.resources.push({
         resourceState: {
           resource,
-          onCardChange: resource.isAutoSaved
+          onCardChange: isAutoSaved
             ? () => {
                 if (card) {
                   // Using the card ID instead, so this function doesn't need to be updated
@@ -340,6 +349,9 @@ export default class StoreService extends Service {
   ) {
     for (let { setCard, setCardError } of this.subscribers.get(url)
       ?.resources ?? []) {
+      if (!setCard || !setCardError) {
+        continue;
+      }
       if (!maybeCard) {
         setCard(undefined);
         setCardError(undefined);

--- a/packages/host/tests/integration/resources/search-test.ts
+++ b/packages/host/tests/integration/resources/search-test.ts
@@ -11,11 +11,11 @@ import {
   type LooseSingleCardDocument,
 } from '@cardstack/runtime-common';
 
-import { Search } from '@cardstack/host/resources/search';
+import { SearchResource } from '@cardstack/host/resources/search';
 
-import LoaderService from '@cardstack/host/services/loader-service';
-
+import type LoaderService from '@cardstack/host/services/loader-service';
 import RealmService from '@cardstack/host/services/realm';
+import type StoreService from '@cardstack/host/services/store';
 
 import {
   CardDocFiles,
@@ -37,6 +37,7 @@ class StubRealmService extends RealmService {
 module(`Integration | search resource`, function (hooks) {
   let loader: Loader;
   let loaderService: LoaderService;
+  let storeService: StoreService;
   let realm: Realm;
   let cardApi: typeof import('https://cardstack.com/base/card-api');
   let string: typeof import('https://cardstack.com/base/string');
@@ -46,6 +47,7 @@ module(`Integration | search resource`, function (hooks) {
     getOwner(this)!.register('service:realm', StubRealmService);
     loaderService = lookupLoaderService();
     loader = loaderService.loader;
+    storeService = getOwner(this)!.lookup('service:store') as StoreService;
   });
 
   setupLocalIndexing(hooks);
@@ -294,12 +296,15 @@ module(`Integration | search resource`, function (hooks) {
         },
       },
     };
-    let search = Search.from(loaderService, () => ({
+    let search = SearchResource.from(loaderService, () => ({
       named: {
         query,
         realms: [testRealmURL],
+        isLive: false,
+        isAutoSaved: false,
+        storeService,
       },
-    })) as Search;
+    })) as SearchResource;
     await search.loaded;
     assert.strictEqual(search.instances[0].id, `${testRealmURL}card-2`);
     assert.strictEqual(search.instances[0].constructor.name, 'Book');
@@ -317,13 +322,15 @@ module(`Integration | search resource`, function (hooks) {
         },
       },
     };
-    let search = Search.from(loaderService, () => ({
+    let search = SearchResource.from(loaderService, () => ({
       named: {
         query,
         realms: [testRealmURL],
         isLive: true,
+        isAutoSaved: false,
+        storeService,
       },
-    })) as Search;
+    })) as SearchResource;
     await search.loaded;
     assert.strictEqual(search.instances.length, 2);
     assert.strictEqual(search.instances[0].id, `${testRealmURL}books/1`);
@@ -372,13 +379,15 @@ module(`Integration | search resource`, function (hooks) {
         },
       },
     };
-    let search = Search.from(loaderService, () => ({
+    let search = SearchResource.from(loaderService, () => ({
       named: {
         query,
         realms: [testRealmURL],
         isLive: true,
+        isAutoSaved: false,
+        storeService,
       },
-    })) as Search;
+    })) as SearchResource;
     await search.loaded;
     assert.strictEqual(search.instances.length, 2);
     assert.strictEqual((search.instances[0] as any).author.firstName, `Mango`);


### PR DESCRIPTION
This PR refactors the SearchResource to internally use the StoreService to instantiate the search results instead of using CardResource.