### PR TITLE
ci: Change all Actions uses to pinned SHAs

### DIFF
--- a/.github/.yamllint.yml
+++ b/.github/.yamllint.yml
@@ -1,6 +1,8 @@
 extends: default
 
 rules:
+  comments:
+    min-spaces-from-content: 1
   line-length: disable
   document-start: disable
   quoted-strings:

--- a/.github/actions/init/action.yml
+++ b/.github/actions/init/action.yml
@@ -4,7 +4,7 @@ description: Setup common dependencies
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # 4.3.0
       with:
         node-version-file: "package.json"
 
@@ -16,7 +16,7 @@ runs:
       run: |
         echo "STORE_PATH=$(pnpm store path -s)" >> $GITHUB_OUTPUT
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # 4.2.2
       name: Setup pnpm cache
       id: cache
       with:

--- a/.github/workflows/build-host.yml
+++ b/.github/workflows/build-host.yml
@@ -15,7 +15,7 @@ jobs:
       group: build-host-${{ inputs.environment }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
 
       - name: Init
         uses: ./.github/actions/init
@@ -52,7 +52,7 @@ jobs:
         run: pnpm deploy:boxel-host build-only --verbose
 
       - name: Save dist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
         with:
           name: host-dist
           path: packages/host/tmp/deploy-dist

--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -25,7 +25,7 @@ jobs:
       group: boxel-host-test${{ github.head_ref || github.run_id }}-shard${{ matrix.shardIndex }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - uses: ./.github/actions/init
       - name: Build boxel-icons
         run: pnpm build
@@ -64,21 +64,21 @@ jobs:
           HOST_TEST_PARTITION_COUNT: ${{ matrix.shardTotal }}
         working-directory: packages/host
       - name: Upload junit report to GitHub Actions Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
         if: always()
         with:
           name: host-test-report-${{ matrix.shardIndex }}
           path: junit/host-${{ matrix.shardIndex }}.xml
           retention-days: 30
       - name: Upload realm server log
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
         if: always()
         with:
           name: realm-server-log-${{ matrix.shardIndex }}
           path: /tmp/server.log
           retention-days: 30
       - name: Upload icon server log
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
         if: always()
         with:
           name: icon-server-log-${{ matrix.shardIndex }}
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - uses: ./.github/actions/init
 
       - name: Finalise Percy
@@ -103,7 +103,7 @@ jobs:
           PERCY_PARALLEL_NONCE: ${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Download JUnit reports from GitHub Actions Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # 4.2.0
         with:
           path: all-host-reports
           pattern: host-test-report-*
@@ -116,7 +116,7 @@ jobs:
         run: npx junit-report-merger host.xml "./all-host-reports/*.xml"
 
       - name: Upload merged report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
         if: always()
         with:
           name: host-test-report-merged
@@ -124,7 +124,7 @@ jobs:
           retention-days: 30
 
       - name: Publish test results
-        uses: EnricoMi/publish-unit-test-result-action@v2.9.0
+        uses: EnricoMi/publish-unit-test-result-action@170bf24d20d201b842d7a52403b73ed297e6645b # 2.18.0
         if: always()
         with:
           junit_files: host.xml

--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -19,7 +19,7 @@ jobs:
       group: lint-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - uses: ./.github/actions/init
       - name: Lint AI Bot
         if: always()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
       group: ai-bot-test-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - uses: ./.github/actions/init
       - name: AI Bot test suite
         run: pnpm test
@@ -33,7 +33,7 @@ jobs:
       group: boxel-motion-test-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - uses: ./.github/actions/init
       - name: Build boxel-motion
         run: pnpm build
@@ -49,7 +49,7 @@ jobs:
       group: boxel-ui-test-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - uses: ./.github/actions/init
       - name: Build boxel-icons
         run: pnpm build
@@ -68,7 +68,7 @@ jobs:
       group: boxel-ui-raw-icon-changes-only-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - uses: ./.github/actions/init
       - name: Rebuild boxel-ui icons
         run: pnpm rebuild:icons
@@ -83,7 +83,7 @@ jobs:
       group: boxel-icons-raw-icon-changes-only-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - uses: ./.github/actions/init
       - name: Rebuild boxel-icons icons
         run: pnpm rebuild:all
@@ -103,7 +103,7 @@ jobs:
       group: matrix-client-test-${{ matrix.shardIndex }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - uses: ./.github/actions/init
       - name: Install Playwright Browsers
         run: pnpm exec playwright install --with-deps
@@ -135,7 +135,7 @@ jobs:
         run: pnpm test:group ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
         working-directory: packages/matrix
       - name: Upload realm server log
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
         if: always()
         with:
           name: matrix-test-realm-server-log-${{ matrix.shardIndex }}
@@ -144,7 +144,7 @@ jobs:
 
       - name: Upload blob report to GitHub Actions Artifacts
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
         with:
           name: blob-report-${{ matrix.shardIndex }}
           path: packages/matrix/blob-report
@@ -152,7 +152,7 @@ jobs:
 
       - name: Upload Playwright traces
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
         with:
           name: playwright-traces-${{ matrix.shardIndex }}
           path: packages/matrix/test-results/**/trace.zip
@@ -178,11 +178,11 @@ jobs:
       - name: Create a timestamp as a directory to store reports in
         id: timestampid
         run: echo "timestamp=$(date --utc +%Y%m%d_%H%M%SZ)" >> "$GITHUB_OUTPUT"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - uses: ./.github/actions/init
 
       - name: Download blob reports from GitHub Actions Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # 4.2.0
         with:
           path: all-blob-reports
           pattern: blob-report-*
@@ -192,7 +192,7 @@ jobs:
         run: pnpm exec playwright merge-reports --reporter html ./all-blob-reports
 
       - name: Upload HTML report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
         with:
           name: html-report--attempt-${{ github.run_attempt }}
           path: playwright-report
@@ -207,7 +207,7 @@ jobs:
           echo "AWS_S3_BUCKET=cardstack-boxel-matrix-playwright-reports-staging" >> $GITHUB_ENV
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # 4.1.0
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: us-east-1
@@ -257,7 +257,7 @@ jobs:
             "virtual-network-test.ts",
           ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - uses: ./.github/actions/init
       - name: Build boxel-icons
         run: pnpm build
@@ -292,7 +292,7 @@ jobs:
         env:
           TEST_MODULE: ${{matrix.testModule}}
       - name: Upload realm server log
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
         if: always()
         with:
           name: realm-server-test-realm-server-log-${{matrix.testModule}}
@@ -306,7 +306,7 @@ jobs:
       group: vscode-boxel-tools-test-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - uses: ./.github/actions/init
       - name: Build boxel-icons
         run: pnpm build
@@ -321,7 +321,7 @@ jobs:
         run: pnpm vscode:package
         working-directory: packages/vscode-boxel-tools
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
         with:
           name: vscode-boxel-tools
           path: packages/vscode-boxel-tools/boxel-tools*vsix
@@ -333,8 +333,8 @@ jobs:
     outputs:
       boxel: ${{ steps.filter.outputs.boxel }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # 3.0.2
         id: filter
         with:
           filters: |

--- a/.github/workflows/deploy-host.yml
+++ b/.github/workflows/deploy-host.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     concurrency: deploy-host-${{ inputs.environment }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
 
       - name: Init
         uses: ./.github/actions/init
@@ -42,13 +42,13 @@ jobs:
           fi
 
       - name: Download dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # 4.2.0
         with:
           name: host-dist
           path: packages/host/tmp/deploy-dist
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # 4.1.0
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/deploy-motion.yml
+++ b/.github/workflows/deploy-motion.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     concurrency: deploy-motion-${{ inputs.environment }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
 
       - name: Init
         uses: ./.github/actions/init
@@ -40,7 +40,7 @@ jobs:
         working-directory: packages/boxel-motion/addon
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # 4.1.0
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     concurrency: deploy-ui-${{ inputs.environment }}-${{ github.head_ref || github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
 
       - name: Init
         uses: ./.github/actions/init
@@ -40,7 +40,7 @@ jobs:
         working-directory: packages/boxel-ui/addon
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # 4.1.0
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/manual-vscode-boxel-tools.yml
+++ b/.github/workflows/manual-vscode-boxel-tools.yml
@@ -18,11 +18,11 @@ jobs:
     name: Check for changes since last version update
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # 4.3.0
         with:
           node-version: "20"
       - name: Install vsce
@@ -86,7 +86,7 @@ jobs:
     needs: check-version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - uses: ./.github/actions/init
       - name: Build boxel-ui
         run: pnpm build

--- a/.github/workflows/pr-boxel-host.yml
+++ b/.github/workflows/pr-boxel-host.yml
@@ -25,10 +25,10 @@ jobs:
     outputs:
       boxel-host-files-changed: ${{ steps.boxel-host-files-that-changed.outputs.any_changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - name: Get boxel-host files that changed
         id: boxel-host-files-that-changed
-        uses: tj-actions/changed-files@v39
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # 46.0.1
         with:
           files: |
             .github/workflows/build-host.yml
@@ -47,9 +47,9 @@ jobs:
     needs: check-if-requires-preview
     concurrency: deploy-host-preview-staging-${{ github.head_ref || github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # 4.1.0
         with:
           role-to-assume: arn:aws:iam::680542703984:role/boxel-host
           aws-region: us-east-1
@@ -76,9 +76,9 @@ jobs:
     needs: check-if-requires-preview
     concurrency: deploy-host-preview-production-${{ github.head_ref || github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # 4.1.0
         with:
           role-to-assume: arn:aws:iam::120317779495:role/boxel-host
           aws-region: us-east-1

--- a/.github/workflows/pr-boxel-motion.yml
+++ b/.github/workflows/pr-boxel-motion.yml
@@ -23,10 +23,10 @@ jobs:
     outputs:
       boxel-motion-files-changed: ${{ steps.boxel-motion-files-that-changed.outputs.any_changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - name: Get boxel-motion files that changed
         id: boxel-motion-files-that-changed
-        uses: tj-actions/changed-files@v39
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # 46.0.1
         with:
           files: |
             packages/boxel-motion/**
@@ -40,9 +40,9 @@ jobs:
     needs: check-if-requires-preview
     concurrency: deploy-motion-preview-staging-${{ github.head_ref || github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # 4.1.0
         with:
           role-to-assume: arn:aws:iam::680542703984:role/boxel-motion
           aws-region: us-east-1

--- a/.github/workflows/pr-boxel-ui.yml
+++ b/.github/workflows/pr-boxel-ui.yml
@@ -24,10 +24,10 @@ jobs:
     outputs:
       boxel-ui-files-changed: ${{ steps.boxel-ui-files-that-changed.outputs.any_changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - name: Get boxel-ui files that changed
         id: boxel-ui-files-that-changed
-        uses: tj-actions/changed-files@v39
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # 46.0.1
         with:
           files: |
             packages/boxel-ui/**
@@ -42,9 +42,9 @@ jobs:
     needs: check-if-requires-preview
     concurrency: deploy-ui-preview-staging-${{ github.head_ref || github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # 4.1.0
         with:
           role-to-assume: arn:aws:iam::680542703984:role/boxel-ui
           aws-region: us-east-1

--- a/.github/workflows/sync-synapse-templates.yml
+++ b/.github/workflows/sync-synapse-templates.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     concurrency: sync-synapse-templates-${{ inputs.environment || 'staging' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
 
       - name: Set up env
         env:
@@ -47,7 +47,7 @@ jobs:
           fi
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # 4.1.0
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -11,8 +11,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
-      - uses: ibiqlik/action-yamllint@v3.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+      - uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c # 3.1.1
         with:
           config_file: ".github/.yamllint.yml"
           file_or_dir: ".github"


### PR DESCRIPTION
This is [recommended by Github](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).