### PR TITLE
common: Remove diagnostic logging

### DIFF
--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -292,10 +292,6 @@ export class Realm {
     this.backfillRetentionPolicies();
 
     this.#disableMatrixRealmEvents = disableMatrixRealmEvents ?? false;
-    console.log(
-      `disableMatrixRealmEvents for realm url ${url}`,
-      this.#disableMatrixRealmEvents,
-    );
 
     let loader = new Loader(fetch, virtualNetwork.resolveImport);
     adapter.setLoader?.(loader);


### PR DESCRIPTION
This is leftover from #2296 when I was trying to understand why some realms weren’t catching the flag.