### PR TITLE
Refactor CardResource.loaded out of pill menu freestyle usage

### DIFF
--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -222,8 +222,7 @@ export default class StoreService extends Service {
 
   // This method is used for specific scenarios where you just want an instance
   // that is _not_ part of the identity map and detached from the store. This
-  // may include things like tests, freestyle guide, perhaps you just need a
-  // couple attributes from an instance and that's it, etc.
+  // may include things like tests, freestyle guide, etc.
   async getInstanceDetachedFromStore(
     url: string,
   ): Promise<CardDef | undefined> {

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -222,7 +222,7 @@ export default class StoreService extends Service {
 
   // This method is used for specific scenarios where you just want an instance
   // that is _not_ part of the identity map and detached from the store. This
-  // may include things like tests, freestyle guide, etc.
+  // may include things like tests, freestyle usage guide, etc.
   async getInstanceDetachedFromStore(
     url: string,
   ): Promise<CardDef | undefined> {

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -11,6 +11,7 @@ import {
   hasExecutableExtension,
   isCardInstance,
   isSingleCardDocument,
+  type LooseCardResource,
   type AutoSaveState,
   type SingleCardDocument,
   type LooseSingleCardDocument,
@@ -217,6 +218,24 @@ export default class StoreService extends Service {
     }
     await this.handleUpdatedCard(undefined, cardOrError);
     return { url, card, error };
+  }
+
+  // This method is used for specific scenarios where you just want an instance
+  // that is _not_ part of the identity map and detached from the store. This
+  // may include things like tests, freestyle guide, perhaps you just need a
+  // couple attributes from an instance and that's it, etc.
+  async getInstanceDetachedFromStore(
+    url: string,
+  ): Promise<CardDef | undefined> {
+    let doc = await this.cardService.fetchJSON(url);
+    if (!doc) {
+      return undefined;
+    }
+    return await this.cardService.createFromSerialized(
+      doc.data as LooseCardResource,
+      doc,
+      new URL(url),
+    );
   }
 
   private handleInvalidations = (event: RealmEventContent) => {


### PR DESCRIPTION
This refactors `CardResource.loaded` out of pill menu freestyle usage. in this case it's totally not necessary to load a card from the store as we are just showing the freestyle usage. As part of this I added a method to get card instances that are detached from the store.

![image](https://github.com/user-attachments/assets/6a463cd3-8d82-4bfb-a517-a85d1d955572)
