### PR TITLE
Display instances in field playground dropdown

### DIFF
--- a/packages/base/default-templates/atom.gts
+++ b/packages/base/default-templates/atom.gts
@@ -1,5 +1,5 @@
 import GlimmerComponent from '@glimmer/component';
-import { type CardDef, isCompoundField } from '../card-api';
+import { type CardDef } from '../card-api';
 import { cn, not } from '@cardstack/boxel-ui/helpers';
 
 export default class DefaultAtomViewTemplate extends GlimmerComponent<{
@@ -14,9 +14,6 @@ export default class DefaultAtomViewTemplate extends GlimmerComponent<{
     }
     if (typeof this.args.model.title === 'string') {
       return this.args.model.title.trim();
-    }
-    if (isCompoundField(this.args.model)) {
-      return;
     }
     return `Untitled ${this.args.model.constructor.displayName}`;
   }

--- a/packages/boxel-ui/addon/src/components/select/index.gts
+++ b/packages/boxel-ui/addon/src/components/select/index.gts
@@ -65,10 +65,12 @@ const BoxelSelect: TemplateOnlyComponent<Signature> = <template>
       border-radius: var(--boxel-border-radius-sm);
       max-width: 100%;
       width: 100%;
-      padding: var(--boxel-sp-xs);
     }
     .boxel-select:hover {
       cursor: pointer;
+    }
+    .ember-power-select-trigger {
+      padding: 0;
     }
   </style>
   {{! template-lint-disable require-scoped-style }}

--- a/packages/boxel-ui/addon/src/components/select/index.gts
+++ b/packages/boxel-ui/addon/src/components/select/index.gts
@@ -65,9 +65,10 @@ const BoxelSelect: TemplateOnlyComponent<Signature> = <template>
       border-radius: var(--boxel-border-radius-sm);
       max-width: 100%;
       width: 100%;
+      padding: var(--boxel-sp-xs);
     }
-    .ember-power-select-trigger {
-      padding: 0;
+    .boxel-select:hover {
+      cursor: pointer;
     }
   </style>
   {{! template-lint-disable require-scoped-style }}
@@ -85,14 +86,20 @@ const BoxelSelect: TemplateOnlyComponent<Signature> = <template>
       overflow: auto;
     }
     .boxel-select__dropdown .ember-power-select-option {
-      padding: var(--boxel-sp-xxs) var(--boxel-sp-xs);
+      padding: var(--boxel-sp-xs);
+      background-color: var(--boxel-light);
+      color: var(--boxel-dark);
+      transition: background-color var(--boxel-transition);
     }
     .boxel-select__dropdown .ember-power-select-option[aria-selected='true'] {
-      background-color: var(--boxel-100);
+      background-color: var(--boxel-highlight);
     }
-    .boxel-select__dropdown .ember-power-select-option[aria-current='true'] {
+    .boxel-select__dropdown
+      .ember-power-select-option[aria-selected='true']:hover {
+      background-color: var(--boxel-highlight-hover);
+    }
+    .boxel-select__dropdown .ember-power-select-option:hover {
       background-color: var(--boxel-100);
-      color: black;
     }
     .boxel-select__dropdown .ember-power-select-search-input:focus {
       border: 1px solid var(--boxel-outline-color);
@@ -100,7 +107,7 @@ const BoxelSelect: TemplateOnlyComponent<Signature> = <template>
       outline: var(--boxel-outline);
     }
     .boxel-select__dropdown .ember-power-select-option--no-matches-message {
-      padding: var(--boxel-sp-xxs) var(--boxel-sp-sm);
+      padding: var(--boxel-sp-sm);
     }
   </style>
 </template>;

--- a/packages/boxel-ui/addon/src/components/select/trigger.gts
+++ b/packages/boxel-ui/addon/src/components/select/trigger.gts
@@ -55,7 +55,7 @@ export class BoxelTriggerWrapper extends Component<TriggerSignature> {
         justify-content: space-between;
         width: 100%;
         gap: var(--boxel-sp-xxxs);
-        padding: var(--boxel-sp-xxxs);
+        padding: var(--boxel-sp-xs);
       }
       .boxel-trigger-content {
         display: flex;

--- a/packages/experiments-realm/Spec/a0bd867f-e0fc-46fb-9a0e-c4f5ee2953c6.json
+++ b/packages/experiments-realm/Spec/a0bd867f-e0fc-46fb-9a0e-c4f5ee2953c6.json
@@ -1,0 +1,62 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "readMe": null,
+      "ref": {
+        "name": "Toy",
+        "module": "../pet"
+      },
+      "specType": "field",
+      "containedExamples": [
+        {
+          "title": "Dragon"
+        },
+        {
+          "title": "Tug rope"
+        },
+        {
+          "title": "Lambchop"
+        }
+      ],
+      "title": "Toy Spec I",
+      "description": null,
+      "thumbnailURL": null
+    },
+    "relationships": {
+      "linkedExamples": {
+        "links": {
+          "self": null
+        }
+      }
+    },
+    "meta": {
+      "fields": {
+        "containedExamples": [
+          {
+            "adoptsFrom": {
+              "module": "../pet",
+              "name": "Toy"
+            }
+          },
+          {
+            "adoptsFrom": {
+              "module": "../pet",
+              "name": "Toy"
+            }
+          },
+          {
+            "adoptsFrom": {
+              "module": "../pet",
+              "name": "Toy"
+            }
+          }
+        ]
+      },
+      "adoptsFrom": {
+        "module": "https://cardstack.com/base/spec",
+        "name": "Spec"
+      }
+    }
+  }
+}

--- a/packages/experiments-realm/Spec/fc715f41-c280-4b0c-a732-e8e1a85a97dd.json
+++ b/packages/experiments-realm/Spec/fc715f41-c280-4b0c-a732-e8e1a85a97dd.json
@@ -1,0 +1,62 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "readMe": null,
+      "ref": {
+        "name": "Toy",
+        "module": "../pet"
+      },
+      "specType": "field",
+      "containedExamples": [
+        {
+          "title": "Orange ball"
+        },
+        {
+          "title": "Large yellow ball"
+        },
+        {
+          "title": "Small red ball"
+        }
+      ],
+      "title": "Toy Spec II",
+      "description": null,
+      "thumbnailURL": null
+    },
+    "relationships": {
+      "linkedExamples": {
+        "links": {
+          "self": null
+        }
+      }
+    },
+    "meta": {
+      "fields": {
+        "containedExamples": [
+          {
+            "adoptsFrom": {
+              "module": "../pet",
+              "name": "Toy"
+            }
+          },
+          {
+            "adoptsFrom": {
+              "module": "../pet",
+              "name": "Toy"
+            }
+          },
+          {
+            "adoptsFrom": {
+              "module": "../pet",
+              "name": "Toy"
+            }
+          }
+        ]
+      },
+      "adoptsFrom": {
+        "module": "https://cardstack.com/base/spec",
+        "name": "Spec"
+      }
+    }
+  }
+}

--- a/packages/experiments-realm/pet.gts
+++ b/packages/experiments-realm/pet.gts
@@ -3,153 +3,53 @@ import {
   field,
   CardDef,
   Component,
+  FieldDef,
 } from 'https://cardstack.com/base/card-api';
-import BooleanCard from 'https://cardstack.com/base/boolean';
-import NumberCard from 'https://cardstack.com/base/number';
-import StringCard from 'https://cardstack.com/base/string';
+import BooleanField from 'https://cardstack.com/base/boolean';
+import NumberField from 'https://cardstack.com/base/number';
+import StringField from 'https://cardstack.com/base/string';
 import { GridContainer } from '@cardstack/boxel-ui/components';
 import PawPrintIcon from '@cardstack/boxel-icons/paw-print';
 
-class FittedTemplate extends Component<typeof Pet> {
-  <template>
-    <div class='fitted-template'>
-      {{#if @model}}
-        <h3 class='title'><@fields.firstName /></h3>
-        <div class='content'>
-          <div class='info'>
-            <div class='info-item'>
-              <span class='label'>Sleeps On The Couch</span>
-              <span><@fields.sleepsOnTheCouch /></span>
-            </div>
-            <div class='info-item'>
-              <span class='label'>Favorite Toy</span>
-              <span><@fields.favoriteToy /></span>
-            </div>
-            <div class='info-item'>
-              <span class='label'>Favorite Treat</span>
-              <span><@fields.favoriteTreat /></span>
-            </div>
-          </div>
-        </div>
-      {{else}}
-        {{! empty links-to field }}
-        <div data-test-empty-field class='empty-field'></div>
-      {{/if}}
-    </div>
-    <style scoped>
-      .fitted-template {
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
-        padding: var(--boxel-sp-xxs);
-        gap: var(--boxel-sp-xxs);
-        height: 100%;
-        padding: 5px;
-      }
-      .title {
-        overflow: hidden;
-        text-overflow: ellipsis;
-        display: -webkit-box;
-        -webkit-box-orient: vertical;
-        -webkit-line-clamp: 2;
-        text-align: center;
-        margin: 0;
-        width: 100%;
-      }
-      .content {
-        width: 100%;
-        padding: var(--boxel-sp-xs);
-      }
-      .info {
-        display: flex;
-        justify-content: center;
-        gap: var(--boxel-sp-xs);
-      }
-      .info-item {
-        display: flex;
-        flex-direction: column;
-        gap: var(--boxel-sp-sm);
-      }
-      .info-item > span {
-        width: fit-content;
-        white-space: nowrap;
-      }
-      .label {
-        font: 500 var(--boxel-font-xs);
-        color: var(--boxel-450);
-        line-height: 1.27;
-        letter-spacing: 0.11px;
-      }
+export class FullName extends FieldDef {
+  @field firstName = contains(StringField);
+  @field lastName = contains(StringField);
+  @field title = contains(StringField, {
+    computeVia: function (this: FullName) {
+      let fullName = [this.firstName, this.lastName].filter(Boolean).join(' ');
+      return fullName.length ? fullName : 'Pet';
+    },
+  });
+  static embedded = class Embedded extends Component<typeof this> {
+    <template>
+      <@fields.title />
+    </template>
+  };
+}
 
-      @container fitted-card (aspect-ratio <= 1.0) {
-        .info-item:not(:first-child) {
-          display: none;
-        }
-
-        .info-item {
-          width: 100%;
-        }
-
-        .info-item > span {
-          white-space: wrap;
-        }
-      }
-
-      @container fitted-card (aspect-ratio <= 1.0) and ((width < 150px) and (height < 150px)) {
-        .content {
-          display: none;
-        }
-      }
-
-      @container fitted-card (1.0 < aspect-ratio <= 2.0) and (width < 200px) {
-        .content {
-          display: none;
-        }
-      }
-
-      @container fitted-card (2.0 < aspect-ratio) {
-        .title {
-          font: 700 var(--boxel-font-sm);
-          line-height: 1.27;
-          letter-spacing: 0.11px;
-        }
-      }
-
-      @container fitted-card (2.0 < aspect-ratio) and (height <= 58px) {
-        .fitted-template {
-          padding: 0;
-        }
-        .title {
-          font: 700 var(--boxel-font-xs);
-          line-height: 1.27;
-          letter-spacing: 0.11px;
-        }
-      }
-
-      @container fitted-card (2.0 < aspect-ratio) and (height < 115px) {
-        .content {
-          display: none;
-        }
-      }
-    </style>
-  </template>
+export class Toy extends FieldDef {
+  @field title = contains(StringField);
+  static embedded = class Embedded extends Component<typeof this> {
+    <template>
+      <@fields.title />
+    </template>
+  };
 }
 
 export class Pet extends CardDef {
   static displayName = 'Pet';
   static icon = PawPrintIcon;
-  @field firstName = contains(StringCard);
-  @field favoriteToy = contains(StringCard);
-  @field favoriteTreat = contains(StringCard);
-  @field cutenessRating = contains(NumberCard);
-  @field sleepsOnTheCouch = contains(BooleanCard);
-  @field title = contains(StringCard, {
+  @field firstName = contains(StringField);
+  @field favoriteToy = contains(StringField);
+  @field favoriteTreat = contains(StringField);
+  @field cutenessRating = contains(NumberField);
+  @field sleepsOnTheCouch = contains(BooleanField);
+  @field title = contains(StringField, {
     computeVia: function (this: Pet) {
       return this.firstName;
     },
   });
-  @field description = contains(StringCard, {
+  @field description = contains(StringField, {
     computeVia: function (this: Pet) {
       return `${this.firstName} the Pet`;
     },
@@ -184,5 +84,129 @@ export class Pet extends CardDef {
     </template>
   };
 
-  static fitted = FittedTemplate;
+  static fitted = class FittedTemplate extends Component<typeof this> {
+    <template>
+      <div class='fitted-template'>
+        {{#if @model}}
+          <h3 class='title'><@fields.firstName /></h3>
+          <div class='content'>
+            <div class='info'>
+              <div class='info-item'>
+                <span class='label'>Sleeps On The Couch</span>
+                <span><@fields.sleepsOnTheCouch /></span>
+              </div>
+              <div class='info-item'>
+                <span class='label'>Favorite Toy</span>
+                <span><@fields.favoriteToy /></span>
+              </div>
+              <div class='info-item'>
+                <span class='label'>Favorite Treat</span>
+                <span><@fields.favoriteTreat /></span>
+              </div>
+            </div>
+          </div>
+        {{else}}
+          {{! empty links-to field }}
+          <div data-test-empty-field class='empty-field'></div>
+        {{/if}}
+      </div>
+      <style scoped>
+        .fitted-template {
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          align-items: center;
+          padding: var(--boxel-sp-xxs);
+          gap: var(--boxel-sp-xxs);
+          height: 100%;
+          padding: 5px;
+        }
+        .title {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          display: -webkit-box;
+          -webkit-box-orient: vertical;
+          -webkit-line-clamp: 2;
+          text-align: center;
+          margin: 0;
+          width: 100%;
+        }
+        .content {
+          width: 100%;
+          padding: var(--boxel-sp-xs);
+        }
+        .info {
+          display: flex;
+          justify-content: center;
+          gap: var(--boxel-sp-xs);
+        }
+        .info-item {
+          display: flex;
+          flex-direction: column;
+          gap: var(--boxel-sp-sm);
+        }
+        .info-item > span {
+          width: fit-content;
+          white-space: nowrap;
+        }
+        .label {
+          font: 500 var(--boxel-font-xs);
+          color: var(--boxel-450);
+          line-height: 1.27;
+          letter-spacing: 0.11px;
+        }
+
+        @container fitted-card (aspect-ratio <= 1.0) {
+          .info-item:not(:first-child) {
+            display: none;
+          }
+
+          .info-item {
+            width: 100%;
+          }
+
+          .info-item > span {
+            white-space: wrap;
+          }
+        }
+
+        @container fitted-card (aspect-ratio <= 1.0) and ((width < 150px) and (height < 150px)) {
+          .content {
+            display: none;
+          }
+        }
+
+        @container fitted-card (1.0 < aspect-ratio <= 2.0) and (width < 200px) {
+          .content {
+            display: none;
+          }
+        }
+
+        @container fitted-card (2.0 < aspect-ratio) {
+          .title {
+            font: 700 var(--boxel-font-sm);
+            line-height: 1.27;
+            letter-spacing: 0.11px;
+          }
+        }
+
+        @container fitted-card (2.0 < aspect-ratio) and (height <= 58px) {
+          .fitted-template {
+            padding: 0;
+          }
+          .title {
+            font: 700 var(--boxel-font-xs);
+            line-height: 1.27;
+            letter-spacing: 0.11px;
+          }
+        }
+
+        @container fitted-card (2.0 < aspect-ratio) and (height < 115px) {
+          .content {
+            display: none;
+          }
+        }
+      </style>
+    </template>
+  }
 }

--- a/packages/experiments-realm/trips.gts
+++ b/packages/experiments-realm/trips.gts
@@ -12,26 +12,9 @@ export class Trips extends FieldDef {
 
   static embedded = class Embedded extends Component<typeof this> {
     <template>
-      <@fields.countriesVisited />
-    </template>
-  };
-
-  static fitted = class Fitted extends Component<typeof this> {
-    <template>
-      <div class='trips-fitted'>
-        Trips: <@fields.countriesVisited class='countries' @format='atom' @displayContainer={{false}} />
-      </div>
-      <style>
-        .trips-fitted {
-          display: flex;
-          align-items: center;
-          gap: var(--boxel-sp-xs);
-          padding: var(--boxel-sp-xs);
-          overflow: hidden;
-          white-space: nowrap;
-          text-overflow: ellipsis;
-        }
-      </style>
+      <address>
+        <@fields.countriesVisited />
+      </address>
     </template>
   };
 }

--- a/packages/experiments-realm/trips.gts
+++ b/packages/experiments-realm/trips.gts
@@ -12,9 +12,26 @@ export class Trips extends FieldDef {
 
   static embedded = class Embedded extends Component<typeof this> {
     <template>
-      <address>
-        <@fields.countriesVisited />
-      </address>
+      <@fields.countriesVisited />
+    </template>
+  };
+
+  static fitted = class Fitted extends Component<typeof this> {
+    <template>
+      <div class='trips-fitted'>
+        Trips: <@fields.countriesVisited class='countries' @format='atom' @displayContainer={{false}} />
+      </div>
+      <style>
+        .trips-fitted {
+          display: flex;
+          align-items: center;
+          gap: var(--boxel-sp-xs);
+          padding: var(--boxel-sp-xs);
+          overflow: hidden;
+          white-space: nowrap;
+          text-overflow: ellipsis;
+        }
+      </style>
     </template>
   };
 }

--- a/packages/host/app/components/operator-mode/card-preview-panel/fitted-format-gallery.gts
+++ b/packages/host/app/components/operator-mode/card-preview-panel/fitted-format-gallery.gts
@@ -15,7 +15,7 @@ interface Signature {
   Args: {
     card: BaseDef;
     isDarkMode?: boolean;
-    isField?: boolean;
+    isFieldDef?: boolean;
   };
 }
 
@@ -156,7 +156,7 @@ export default class FittedFormatGallery extends Component<Signature> {
                   -
                   {{spec.width}}x{{spec.height}}
                 </div>
-                {{#if @isField}}
+                {{#if @isFieldDef}}
                   <CardContainer
                     class='item'
                     @displayBoundaries={{true}}

--- a/packages/host/app/components/operator-mode/card-preview-panel/fitted-format-gallery.gts
+++ b/packages/host/app/components/operator-mode/card-preview-panel/fitted-format-gallery.gts
@@ -4,6 +4,7 @@ import { cached } from '@glimmer/tracking';
 
 import { provide } from 'ember-provide-consume-context';
 
+import { CardContainer } from '@cardstack/boxel-ui/components';
 import { cn } from '@cardstack/boxel-ui/helpers';
 
 import { DefaultFormatsContextName } from '@cardstack/runtime-common';
@@ -14,6 +15,7 @@ interface Signature {
   Args: {
     card: BaseDef;
     isDarkMode?: boolean;
+    isField?: boolean;
   };
 }
 
@@ -154,11 +156,21 @@ export default class FittedFormatGallery extends Component<Signature> {
                   -
                   {{spec.width}}x{{spec.height}}
                 </div>
-                <this.renderedCard
-                  class='item'
-                  @displayContainer={{true}}
-                  style={{setContainerSize spec}}
-                />
+                {{#if @isField}}
+                  <CardContainer
+                    class='item'
+                    @displayBoundaries={{true}}
+                    style={{setContainerSize spec}}
+                  >
+                    <this.renderedCard class='field' />
+                  </CardContainer>
+                {{else}}
+                  <this.renderedCard
+                    class='item'
+                    @displayContainer={{true}}
+                    style={{setContainerSize spec}}
+                  />
+                {{/if}}
               </li>
             {{/each}}
           </ul>
@@ -201,6 +213,9 @@ export default class FittedFormatGallery extends Component<Signature> {
       }
       .item {
         color: initial;
+      }
+      .item > .field {
+        height: 100%;
       }
 
       /* Dark mode */

--- a/packages/host/app/components/operator-mode/code-submode/playground/field-chooser-modal.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/field-chooser-modal.gts
@@ -38,7 +38,7 @@ const FieldChooser: TemplateOnlyComponent<Signature> = <template>
         <ol class='instances'>
           {{#each @instances as |instance i|}}
             <li class='field-option'>
-              {{instance.displayIndex}}.
+              <span class='field-option-index'>{{instance.displayIndex}}.</span>
               <CardContainer
                 class={{cn 'instance-container' selected=(eq i @selectedIndex)}}
                 @tag='button'
@@ -86,6 +86,10 @@ const FieldChooser: TemplateOnlyComponent<Signature> = <template>
     .field-option {
       display: flex;
       gap: var(--boxel-sp-xs);
+    }
+    .field-option-index {
+      width: var(--boxel-sp);
+      text-align: center;
     }
   </style>
 </template>;

--- a/packages/host/app/components/operator-mode/code-submode/playground/field-chooser-modal.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/field-chooser-modal.gts
@@ -10,11 +10,11 @@ import { add, cn, eq } from '@cardstack/boxel-ui/helpers';
 import ModalContainer from '@cardstack/host/components/modal-container';
 import Preview from '@cardstack/host/components/preview';
 
-import type { FieldDef } from 'https://cardstack.com/base/card-api';
+import type { FieldOption } from './playground-content';
 
 interface Signature {
   Args: {
-    instances: FieldDef[] | undefined;
+    instances: FieldOption[] | undefined;
     selectedIndex: number;
     onSelect: (index: number) => void;
     onClose: () => void;
@@ -34,22 +34,27 @@ const FieldChooser: TemplateOnlyComponent<Signature> = <template>
     data-test-field-chooser
   >
     <:content>
-      <div class='instances'>
-        {{#each @instances as |instance i|}}
-          <CardContainer
-            class={{cn 'instance-container' selected=(eq i @selectedIndex)}}
-            @tag='button'
-            @displayBoundaries={{true}}
-            {{on 'click' (fn @onSelect i)}}
-            aria-label='Select instance {{add i 1}}'
-            data-test-field-instance={{i}}
-          >
-            <Preview @card={{instance}} @format='embedded' />
-          </CardContainer>
-        {{else}}
-          <p>No field instances available</p>
-        {{/each}}
-      </div>
+      {{#if @instances.length}}
+        <ol class='instances'>
+          {{#each @instances as |instance i|}}
+            <li class='field-option'>
+              {{instance.displayIndex}}.
+              <CardContainer
+                class={{cn 'instance-container' selected=(eq i @selectedIndex)}}
+                @tag='button'
+                @displayBoundaries={{true}}
+                {{on 'click' (fn @onSelect i)}}
+                aria-label='Select instance {{add i 1}}'
+                data-test-field-instance={{i}}
+              >
+                <Preview @card={{instance.field}} @format='embedded' />
+              </CardContainer>
+            </li>
+          {{/each}}
+        </ol>
+      {{else}}
+        <p>No field instances available</p>
+      {{/if}}
     </:content>
   </ModalContainer>
 
@@ -63,6 +68,8 @@ const FieldChooser: TemplateOnlyComponent<Signature> = <template>
     .instances {
       display: grid;
       gap: var(--boxel-sp);
+      margin-block: 0;
+      padding-inline-start: 0;
     }
     .instance-container {
       appearance: none;
@@ -75,6 +82,10 @@ const FieldChooser: TemplateOnlyComponent<Signature> = <template>
     .instance-container:hover,
     .instance-container:focus {
       box-shadow: 0 0 0 2px var(--boxel-highlight-hover);
+    }
+    .field-option {
+      display: flex;
+      gap: var(--boxel-sp-xs);
     }
   </style>
 </template>;

--- a/packages/host/app/components/operator-mode/code-submode/playground/instance-chooser-dropdown.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/instance-chooser-dropdown.gts
@@ -14,8 +14,6 @@ import { cardTypeDisplayName, type Query } from '@cardstack/runtime-common';
 
 import Preview from '@cardstack/host/components/preview';
 
-import type { CardDef } from 'https://cardstack.com/base/card-api';
-
 import PrerenderedCardSearch, {
   type PrerenderedCard,
 } from '../../../prerendered-card-search';
@@ -146,7 +144,7 @@ interface Signature {
   Args: {
     prerenderedCardQuery?: { query: Query | undefined; realms: string[] };
     fieldOptions?: FieldOption[];
-    selection: { card: CardDef; fieldIndex: number | undefined } | undefined;
+    selection: SelectedInstance | undefined;
     onSelect: (item: PrerenderedCard | FieldOption) => void;
     chooseCard: () => void;
     createNew?: () => void;
@@ -170,9 +168,9 @@ const InstanceSelectDropdown: TemplateOnlyComponent<Signature> = <template>
           @dropdownClass='instances-dropdown-content'
           @options={{cards}}
           @selected={{findSelected @selection cards}}
-          @selectedItemComponent={{if
-            @selection
-            (component SelectedItem title=(getItemTitle @selection))
+          @selectedItemComponent={{component
+            SelectedItem
+            title=(getItemTitle @selection)
           }}
           @renderInPlace={{true}}
           @onChange={{@onSelect}}
@@ -200,9 +198,9 @@ const InstanceSelectDropdown: TemplateOnlyComponent<Signature> = <template>
       @dropdownClass='instances-dropdown-content'
       @options={{@fieldOptions}}
       @selected={{findSelected @selection undefined @fieldOptions}}
-      @selectedItemComponent={{if
-        @selection
-        (component SelectedItem title=(getItemTitle @selection))
+      @selectedItemComponent={{component
+        SelectedItem
+        title=(getItemTitle @selection)
       }}
       @renderInPlace={{true}}
       @onChange={{@onSelect}}
@@ -215,7 +213,7 @@ const InstanceSelectDropdown: TemplateOnlyComponent<Signature> = <template>
         createNewIsRunning=@createNewIsRunning
       }}
       data-playground-instance-chooser
-      data-test-field-instance-chooser
+      data-test-instance-chooser
       as |item|
     >
       <div class='field-option'>
@@ -269,7 +267,7 @@ const InstanceSelectDropdown: TemplateOnlyComponent<Signature> = <template>
 </template>;
 
 function findSelected(
-  selection: { card: CardDef; fieldIndex?: number } | undefined,
+  selection: SelectedInstance | undefined,
   cards: PrerenderedCard[] | undefined,
   fields?: FieldOption[],
 ) {

--- a/packages/host/app/components/operator-mode/code-submode/playground/instance-chooser-dropdown.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/instance-chooser-dropdown.gts
@@ -149,7 +149,7 @@ interface Signature {
   Args: {
     prerenderedCardQuery?: { query: Query | undefined; realms: string[] };
     fieldOptions?: FieldOption[];
-    selection: { card?: CardDef; fieldIndex?: number };
+    selection: { card: CardDef; fieldIndex?: number } | undefined;
     onSelect: (item: PrerenderedCard | FieldOption) => void;
     chooseCard: () => void;
     createNew?: () => void;
@@ -172,7 +172,7 @@ const InstanceSelectDropdown: TemplateOnlyComponent<Signature> = <template>
           class='instance-chooser'
           @dropdownClass='instances-dropdown-content'
           @options={{cards}}
-          @selected={{@selection.card}}
+          @selected={{findSelected @selection cards}}
           @selectedItemComponent={{if
             @selection
             (component SelectedItem title=(getItemTitle @selection))
@@ -202,7 +202,7 @@ const InstanceSelectDropdown: TemplateOnlyComponent<Signature> = <template>
       class='instance-chooser'
       @dropdownClass='instances-dropdown-content'
       @options={{@fieldOptions}}
-      @selected={{@selection}}
+      @selected={{findSelected @selection undefined @fieldOptions}}
       @selectedItemComponent={{if
         @selection
         (component SelectedItem title=(getItemTitle @selection))
@@ -265,5 +265,23 @@ const InstanceSelectDropdown: TemplateOnlyComponent<Signature> = <template>
     }
   </style>
 </template>;
+
+function findSelected(
+  selection: { card: CardDef; fieldIndex?: number } | undefined,
+  cards: PrerenderedCard[] | undefined,
+  fields?: FieldOption[],
+) {
+  if (!selection || !selection.card) {
+    return;
+  }
+  if (cards) {
+    return cards.find(
+      (c) => c.url.replace(/\.json$/, '') === selection.card.id,
+    );
+  } else if (fields) {
+    return fields.find((f) => f.index === selection.fieldIndex);
+  }
+  return;
+}
 
 export default InstanceSelectDropdown;

--- a/packages/host/app/components/operator-mode/code-submode/playground/instance-chooser-dropdown.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/instance-chooser-dropdown.gts
@@ -216,12 +216,9 @@ const InstanceSelectDropdown: TemplateOnlyComponent<Signature> = <template>
       data-test-instance-chooser
       as |item|
     >
-      <div class='field-option'>
-        <span class='field-option-index'>{{item.displayIndex}}.</span>
-        <CardContainer class='field' @displayBoundaries={{true}}>
-          <Preview @card={{item.field}} @format='atom' />
-        </CardContainer>
-      </div>
+      <CardContainer class='field' @displayBoundaries={{true}}>
+        <Preview @card={{item.field}} @format='atom' />
+      </CardContainer>
     </BoxelSelect>
   {{/if}}
 
@@ -237,17 +234,6 @@ const InstanceSelectDropdown: TemplateOnlyComponent<Signature> = <template>
     }
     .instance-chooser :deep(.boxel-trigger-content) {
       overflow: hidden;
-    }
-    .field-option {
-      display: flex;
-      align-items: center;
-      gap: var(--boxel-sp-xs);
-      width: 375px;
-      max-width: 100%;
-    }
-    .field-option-index {
-      width: var(--boxel-sp);
-      text-align: center;
     }
     .card,
     .field {

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-content.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-content.gts
@@ -1,4 +1,4 @@
-import { fn } from '@ember/helper';
+import { fn, hash } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 
@@ -53,6 +53,12 @@ import FieldPickerModal from './field-chooser-modal';
 import InstanceSelectDropdown from './instance-chooser-dropdown';
 import PlaygroundPreview from './playground-preview';
 
+export type FieldOption = {
+  index: number;
+  displayIndex: number;
+  field: FieldDef;
+};
+
 interface Signature {
   Args: {
     codeRef: ResolvedCodeRef;
@@ -69,9 +75,12 @@ export default class PlaygroundContent extends Component<Signature> {
     >
       <div class='instance-chooser-container'>
         <InstanceSelectDropdown
-          @query={{this.query}}
-          @realms={{this.recentRealms}}
-          @card={{this.card}}
+          @prerenderedCardQuery={{hash
+            query=this.query
+            realms=this.recentRealms
+          }}
+          @fieldOptions={{this.fieldInstances}}
+          @selection={{hash card=this.card fieldIndex=this.fieldIndex}}
           @onSelect={{this.onSelect}}
           @chooseCard={{this.chooseInstance}}
           @createNew={{if this.canWriteRealm this.createNew}}
@@ -210,9 +219,9 @@ export default class PlaygroundContent extends Component<Signature> {
     ];
   }
 
-  private get query(): Query {
+  private get query(): Query | undefined {
     if (this.args.isFieldDef) {
-      // TODO
+      return undefined;
     }
     return {
       filter: {
@@ -263,15 +272,22 @@ export default class PlaygroundContent extends Component<Signature> {
     return this.args.isFieldDef ? 0 : undefined;
   }
 
-  private get fieldInstances(): FieldDef[] | undefined {
+  private get fieldInstances(): FieldOption[] | undefined {
     if (!this.args.isFieldDef) {
       return undefined;
     }
-    let instances = (this.card as Spec)?.containedExamples;
+    let instances = (this.card as Spec | undefined)?.containedExamples;
     if (!instances?.length) {
       return undefined;
     }
-    return instances;
+    return instances.map((field, i) => {
+      let option: FieldOption = {
+        index: i,
+        displayIndex: i + 1,
+        field,
+      };
+      return option;
+    });
   }
 
   private get field(): FieldDef | undefined {
@@ -283,7 +299,7 @@ export default class PlaygroundContent extends Component<Signature> {
       // display the next available instance if item was deleted
       index = this.fieldInstances.length - 1;
     }
-    return this.fieldInstances[index];
+    return this.fieldInstances[index].field;
   }
 
   private copyToClipboard = task(async (id: string) => {
@@ -349,8 +365,18 @@ export default class PlaygroundContent extends Component<Signature> {
     );
   };
 
-  @action private onSelect(card: PrerenderedCard) {
-    this.persistSelections(card.url.replace(/\.json$/, ''));
+  @action private onSelect(item: PrerenderedCard | FieldOption) {
+    if (this.args.isFieldDef) {
+      this.persistSelections(
+        this.card!.id,
+        this.format,
+        (item as FieldOption).index,
+      );
+    } else {
+      this.persistSelections(
+        (item as PrerenderedCard).url.replace(/\.json$/, ''),
+      );
+    }
   }
 
   @action private setFormat(format: Format) {

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-content.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-content.gts
@@ -59,6 +59,11 @@ export type FieldOption = {
   field: FieldDef;
 };
 
+export type SelectedInstance = {
+  card: CardDef;
+  fieldIndex: number | undefined;
+};
+
 interface Signature {
   Args: {
     codeRef: ResolvedCodeRef;
@@ -80,7 +85,7 @@ export default class PlaygroundContent extends Component<Signature> {
             realms=this.recentRealms
           }}
           @fieldOptions={{this.fieldInstances}}
-          @selection={{hash card=this.card fieldIndex=this.fieldIndex}}
+          @selection={{this.dropdownSelection}}
           @onSelect={{this.onSelect}}
           @chooseCard={{this.chooseInstance}}
           @createNew={{if this.canWriteRealm this.createNew}}
@@ -377,6 +382,22 @@ export default class PlaygroundContent extends Component<Signature> {
         (item as PrerenderedCard).url.replace(/\.json$/, ''),
       );
     }
+  }
+
+  private get dropdownSelection(): SelectedInstance | undefined {
+    if (!this.card) {
+      return undefined;
+    }
+    if (this.args.isFieldDef) {
+      return {
+        card: this.card,
+        fieldIndex: this.fieldIndex,
+      };
+    }
+    return {
+      card: this.card,
+      fieldIndex: undefined,
+    };
   }
 
   @action private setFormat(format: Format) {

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-preview.gts
@@ -67,7 +67,7 @@ const PlaygroundPreview: TemplateOnlyComponent<Signature> = <template>
     <FittedFormatGallery
       @card={{@card}}
       @isDarkMode={{true}}
-      @isField={{@isFieldDef}}
+      @isFieldDef={{@isFieldDef}}
     />
   {{/if}}
 

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-preview.gts
@@ -64,7 +64,11 @@ const PlaygroundPreview: TemplateOnlyComponent<Signature> = <template>
       veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
       commodo consequat.</div>
   {{else if (eq @format 'fitted')}}
-    <FittedFormatGallery @card={{@card}} @isDarkMode={{true}} />
+    <FittedFormatGallery
+      @card={{@card}}
+      @isDarkMode={{true}}
+      @isField={{@isFieldDef}}
+    />
   {{/if}}
 
   <style scoped>

--- a/packages/host/tests/acceptance/code-submode/field-playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/field-playground-test.gts
@@ -1,6 +1,6 @@
 import { click, fillIn, waitUntil } from '@ember/test-helpers';
 
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 
 import type { Realm } from '@cardstack/runtime-common';
 
@@ -481,8 +481,7 @@ module('Acceptance | code-submode | field playground', function (hooks) {
     assert.dom('[data-test-embedded-contact-info]').hasText('susie@email.com');
   });
 
-  // TODO: this currently does not work because it requires the spec panel to update when selected declaration changes
-  skip('can update the instance chooser when selected declaration changes', async function (assert) {
+  test('can update the instance chooser when selected declaration changes', async function (assert) {
     await openFileInPlayground('blog-post.gts', testRealmURL, 'ContactInfo');
     assertFieldExists(assert, 'embedded');
     assert.dom('[data-test-selected-item]').hasText('Contact Info - Example 1');
@@ -502,6 +501,10 @@ module('Acceptance | code-submode | field playground', function (hooks) {
     assert.dom('[data-option-index]').exists({ count: 2 });
     assert.dom('[data-option-index="0"]').hasText('1. Terrible product');
     assert.dom('[data-option-index="1"]').hasText('2. Needs better packaging');
+
+    await selectDeclaration('BlogPost'); // card def selected
+    assert.dom('[data-test-selected-item]').doesNotExist();
+    assert.dom('[data-test-instance-chooser]').hasText('Please Select');
   });
 
   test('changing the selected spec in Boxel Spec panel changes selected spec in playground', async function (assert) {
@@ -653,14 +656,13 @@ module('Acceptance | code-submode | field playground', function (hooks) {
     assert.dom('[data-test-field="quote"] input').hasNoValue();
     assert.dom('[data-test-create-spec-button]').doesNotExist();
 
-    // TODO: spec panel updates when spec is created from playground
-    // await toggleAccordionPanel('spec-preview');
-    // assert.dom('[data-test-boxel-input-id="spec-title"]').hasValue('Quote');
-    // assert
-    //   .dom(
-    //     '[data-test-contains-many="containedExamples"] [data-test-item="0"] [data-test-field="quote"] input',
-    //   )
-    //   .hasNoValue();
+    await toggleSpecPanel();
+    assert.dom('[data-test-boxel-input-id="spec-title"]').hasValue('Quote');
+    assert
+      .dom(
+        '[data-test-contains-many="containedExamples"] [data-test-item="0"] [data-test-field="quote"] input',
+      )
+      .hasNoValue();
   });
 
   test('can create new field instance (has preexisting Spec)', async function (assert) {

--- a/packages/host/tests/acceptance/code-submode/field-playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/field-playground-test.gts
@@ -406,7 +406,7 @@ module('Acceptance | code-submode | field playground', function (hooks) {
 
   test('changing the selected spec in Boxel Spec panel changes selected spec in playground', async function (assert) {
     await openFileInPlayground('blog-post.gts', testRealmURL, 'Comment');
-    assert.dom('[data-test-selected-item]').hasText('Comment spec');
+    assert.dom('[data-test-selected-item]').hasText('Comment spec - Example 1');
     assert
       .dom('[data-test-embedded-comment-title]')
       .hasText('Terrible product');
@@ -442,7 +442,9 @@ module('Acceptance | code-submode | field playground', function (hooks) {
       .hasValue('Comment spec II');
 
     await togglePlaygroundPanel();
-    assert.dom('[data-test-selected-item]').hasText('Comment spec II');
+    assert
+      .dom('[data-test-selected-item]')
+      .hasText('Comment spec II - Example 1');
     assert
       .dom('[data-test-embedded-comment-title]')
       .hasText('Spec 2 Example 1');
@@ -456,7 +458,7 @@ module('Acceptance | code-submode | field playground', function (hooks) {
 
   test("can select a different instance to preview from the spec's containedExamples collection", async function (assert) {
     await openFileInPlayground('blog-post.gts', testRealmURL, 'Comment');
-    assert.dom('[data-test-selected-item]').hasText('Comment spec');
+    assert.dom('[data-test-selected-item]').hasText('Comment spec - Example 1');
     assert
       .dom('[data-test-embedded-comment-title]')
       .hasText('Terrible product');
@@ -500,7 +502,7 @@ module('Acceptance | code-submode | field playground', function (hooks) {
       },
     });
     await openFileInPlayground('blog-post.gts', testRealmURL, 'Comment');
-    assert.dom('[data-test-selected-item]').hasText('Comment spec');
+    assert.dom('[data-test-selected-item]').hasText('Comment spec - Example 2');
     assert
       .dom('[data-test-embedded-comment-title]')
       .hasText('Needs better packaging');
@@ -546,7 +548,7 @@ module('Acceptance | code-submode | field playground', function (hooks) {
     assert.dom('[data-test-create-spec-button]').exists();
 
     await createNewInstance();
-    assert.dom('[data-test-selected-item]').hasText('Quote');
+    assert.dom('[data-test-selected-item]').hasText('Quote - Example 1');
     assertFieldExists(assert, 'edit');
     assert.dom('[data-test-field="quote"] input').hasNoValue();
     assert.dom('[data-test-create-spec-button]').doesNotExist();
@@ -563,7 +565,7 @@ module('Acceptance | code-submode | field playground', function (hooks) {
 
   test('can create new field instance (has preexisting Spec)', async function (assert) {
     await openFileInPlayground('blog-post.gts', testRealmURL, 'Comment');
-    assert.dom('[data-test-selected-item]').hasText('Comment spec');
+    assert.dom('[data-test-selected-item]').hasText('Comment spec - Example 1');
     assert
       .dom('[data-test-embedded-comment-title]')
       .hasText('Terrible product');
@@ -605,7 +607,7 @@ module('Acceptance | code-submode | field playground', function (hooks) {
 
   test('can create new field instance when spec exists but has no examples', async function (assert) {
     await openFileInPlayground('author.gts', testRealmURL, 'FullNameField');
-    assert.dom('[data-test-selected-item]').hasText('FullNameField spec');
+    assert.dom('[data-test-instance-chooser]').hasText('Please Select');
 
     await click('[data-test-add-field-instance]');
     assertFieldExists(assert, 'edit');

--- a/packages/host/tests/acceptance/code-submode/field-playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/field-playground-test.gts
@@ -472,9 +472,9 @@ module('Acceptance | code-submode | field playground', function (hooks) {
 
     await click('[data-test-instance-chooser]');
     assert.dom('[data-option-index]').exists({ count: 3 });
-    assert.dom('[data-option-index="0"]').hasText('1. marcelius@email.com');
-    assert.dom('[data-option-index="1"]').hasText('2. lilian@email.com');
-    assert.dom('[data-option-index="2"]').hasText('3. susie@email.com');
+    assert.dom('[data-option-index="0"]').hasText('marcelius@email.com');
+    assert.dom('[data-option-index="1"]').hasText('lilian@email.com');
+    assert.dom('[data-option-index="2"]').hasText('susie@email.com');
 
     await click('[data-option-index="2"]');
     assert.dom('[data-test-selected-item]').hasText('Contact Info - Example 3');
@@ -490,7 +490,7 @@ module('Acceptance | code-submode | field playground', function (hooks) {
       .hasText('marcelius@email.com');
     await click('[data-test-instance-chooser]');
     assert.dom('[data-option-index]').exists({ count: 3 });
-    assert.dom('[data-option-index="0"]').hasText('1. marcelius@email.com');
+    assert.dom('[data-option-index="0"]').hasText('marcelius@email.com');
 
     await selectDeclaration('Comment');
     assert.dom('[data-test-selected-item]').hasText('Comment spec - Example 1');
@@ -499,8 +499,8 @@ module('Acceptance | code-submode | field playground', function (hooks) {
       .hasText('Terrible product');
     await click('[data-test-instance-chooser]');
     assert.dom('[data-option-index]').exists({ count: 2 });
-    assert.dom('[data-option-index="0"]').hasText('1. Terrible product');
-    assert.dom('[data-option-index="1"]').hasText('2. Needs better packaging');
+    assert.dom('[data-option-index="0"]').hasText('Terrible product');
+    assert.dom('[data-option-index="1"]').hasText('Needs better packaging');
 
     await selectDeclaration('BlogPost'); // card def selected
     assert.dom('[data-test-selected-item]').doesNotExist();

--- a/packages/host/tests/acceptance/code-submode/field-playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/field-playground-test.gts
@@ -400,6 +400,10 @@ module('Acceptance | code-submode | field playground', function (hooks) {
     assert.dom('[data-test-incompatible-nonexports]').exists();
   });
 
+  // TODO
+  test('can populate instance chooser dropdown options with containedExamples from Spec', async function (_assert) {});
+  test('can update the instance chooser when selected declaration changes', async function (_assert) {});
+
   test('changing the selected spec in Boxel Spec panel changes selected spec in playground', async function (assert) {
     await openFileInPlayground('blog-post.gts', testRealmURL, 'Comment');
     assert.dom('[data-test-selected-item]').hasText('Comment spec');


### PR DESCRIPTION
Changes:
- Display field instances from selected spec on playground panel's instance chooser dropdown. Dropdown items are numbered and use the atom template of field instances. (default to title field if there's one, fallback to card display name)
- Update dropdown display and `onSelect` behavior for fields
- Selected dropdown item name appears as `[spec title] - Example [index + 1]`
- Examples in Field chooser modal are also numbered now (cs-8151)

<img width="1048" alt="field-dropdown" src="https://github.com/user-attachments/assets/15a0b5f6-c496-437c-91e8-78f10ab6808a" />