### PR TITLE
fix navigation issues with spec

### DIFF
--- a/packages/host/app/services/spec-panel-service.ts
+++ b/packages/host/app/services/spec-panel-service.ts
@@ -1,0 +1,27 @@
+import Owner from '@ember/owner';
+import Service from '@ember/service';
+
+import { tracked } from '@glimmer/tracking';
+
+import window from 'ember-window-mock';
+
+import { SpecSelection } from '@cardstack/host/utils/local-storage-keys';
+
+export default class SpecPanelService extends Service {
+  @tracked specSelection?: string | null;
+
+  constructor(owner: Owner) {
+    super(owner);
+    let selection = window.localStorage.getItem(SpecSelection);
+    this.specSelection = selection;
+  }
+
+  setSelection = (id: string | null) => {
+    this.specSelection = id;
+    if (id == null) {
+      window.localStorage.removeItem(SpecSelection);
+    } else {
+      window.localStorage.setItem(SpecSelection, id);
+    }
+  };
+}

--- a/packages/host/app/utils/local-storage-keys.ts
+++ b/packages/host/app/utils/local-storage-keys.ts
@@ -5,3 +5,4 @@ export const CodeModePanelHeights = 'code-mode-panel-heights';
 export const CodeModePanelSelections = 'code-mode-panel-selections';
 export const SessionLocalStorageKey = 'boxel-session';
 export const PlaygroundSelections = 'playground-selections';
+export const SpecSelection = 'spec-selection';

--- a/packages/host/tests/acceptance/code-submode/field-playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/field-playground-test.gts
@@ -422,15 +422,15 @@ module('Acceptance | code-submode | field playground', function (hooks) {
       .hasValue('Comment spec');
     assert
       .dom('[data-test-spec-selector] [data-test-spec-selector-item-path]')
-      .containsText('Spec/comment-1.json');
+      .containsText('Spec/comment-1');
     await click('[data-test-spec-selector] > div');
     assert
       .dom('[data-option-index="1"] [data-test-spec-selector-item-path]')
-      .hasText('Spec/comment-2.json');
+      .hasText('Spec/comment-2');
     await click('[data-option-index="1"]');
     assert
       .dom('[data-test-spec-selector] [data-test-spec-selector-item-path]')
-      .containsText('Spec/comment-2.json');
+      .containsText('Spec/comment-2');
     assert
       .dom(
         `[data-test-card="${testRealmURL}Spec/comment-2"] [data-test-boxel-input-id="spec-title"]`,


### PR DESCRIPTION
This PR fixes the issue that if you change a selection on LHS, it doesn't remain stale (particularly after you have chosen something in the dropdown) See this [test](https://github.com/cardstack/boxel/blob/b50af37b4dd788845c9ea09bef94c3c6a968c406/packages/host/tests/acceptance/code-submode/spec-test.gts#L990)

Other changes 
-  moved out of pre-rendered card search bcos shudn't rely on pre-rendered card to return meta data (so I used getSearch)
- selected spec is persisted 
- any writes to playground service is done thru a modifier since we shudn't rely on the readiness of the search resource before commiting the persisted playground state
- once you create a spec, it will open the accordion if its not already opened 





As part of this PR there is a digression in auto-save. I do not have a good solution for that and have skipped the test. But, the structure that we want is closer to this. PLS REVIEW THIS INDEPENDENTLY OF THE AUTO_SAVE ISSUE