### PR TITLE
common: Fix construction of write-tracking key

### DIFF
--- a/packages/matrix/tests/card-chooser.spec.ts
+++ b/packages/matrix/tests/card-chooser.spec.ts
@@ -112,7 +112,7 @@ test.describe('Card Chooser', () => {
 
   // Skipping this test, as it flaky
   // https://linear.app/cardstack/issue/CS-8126/flaky-test-matrix-test-card-chooser-it-can-add-realm-read-permissions
-  test('it can add realm read permissions when linking a new card', async ({
+  test.skip('it can add realm read permissions when linking a new card', async ({
     page,
   }) => {
     await setupRealms(page);

--- a/packages/matrix/tests/card-chooser.spec.ts
+++ b/packages/matrix/tests/card-chooser.spec.ts
@@ -112,7 +112,7 @@ test.describe('Card Chooser', () => {
 
   // Skipping this test, as it flaky
   // https://linear.app/cardstack/issue/CS-8126/flaky-test-matrix-test-card-chooser-it-can-add-realm-read-permissions
-  test.skip('it can add realm read permissions when linking a new card', async ({
+  test('it can add realm read permissions when linking a new card', async ({
     page,
   }) => {
     await setupRealms(page);

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -520,7 +520,7 @@ export class Realm {
     } else {
       return;
     }
-    let messageHash = `${type}-${JSON.stringify(data)}`;
+    let messageHash = `${type}-${JSON.stringify({ [type]: file })}`;
     let url = this.paths.fileURL(file);
     let timeout = this.#recentWrites.get(messageHash);
     if (timeout) {


### PR DESCRIPTION
[This skipped test](https://github.com/cardstack/boxel/blob/7ced2c84ad1b1025a8789a85d4c36ed2a6f4568d/packages/matrix/tests/card-chooser.spec.ts#L115) _was_ failing because file watcher-produced events were producing extra invalidations. This manifested as a filled-in field immediately being erased, as the invalidation led the card to be reloaded:

![screencast 2025-03-20 10-51-26](https://github.com/user-attachments/assets/9880b27b-e328-4c04-9695-f8f07595e0bb)

The invalidation-after-write was meant to be suppressed by realm code that tracked writes using a key composed of the event type and file path, but the flattened realm events with the Matrix migration meant the keys were no longer matching. This extracts a function to generate the map key so the map works as expected.

Unfortunately the test is still flaky, as it failed [here](https://github.com/cardstack/boxel/actions/runs/13974927685/job/39126177445?pr=2312#step:12:16829). But it’s a different failure at least:

![screencast 2025-03-20 10-40-55](https://github.com/user-attachments/assets/1859c918-789a-45be-9cfa-36786d8fc803)

I’ll look further into it but this key mismatch is an obvious data-losing bug that should be fixed regardless.