### PR TITLE
Make playground preview use available space

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-preview.gts
@@ -29,7 +29,11 @@ interface Signature {
 const PlaygroundPreview: TemplateOnlyComponent<Signature> = <template>
   {{#if (or (eq @format 'isolated') (eq @format 'edit'))}}
     <CardContainer
-      class={{if @isFieldDef 'field-preview-container' 'full-height-preview'}}
+      class={{if
+        @isFieldDef
+        'field-preview-container isolated-and-edit-preview'
+        'full-height-preview isolated-and-edit-preview'
+      }}
     >
       {{#unless @isFieldDef}}
         <CardHeader
@@ -106,6 +110,11 @@ const PlaygroundPreview: TemplateOnlyComponent<Signature> = <template>
       font: 600 var(--boxel-font-xs);
       line-height: 1.27;
       letter-spacing: 0.17px;
+    }
+    .isolated-and-edit-preview {
+      margin-left: calc(-1 * var(--boxel-sp));
+      width: calc(100% + calc(2 * var(--boxel-sp)));
+      margin-right: calc(-1 * var(--boxel-sp));
     }
   </style>
 </template>;

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-preview.gts
@@ -31,7 +31,7 @@ const PlaygroundPreview: TemplateOnlyComponent<Signature> = <template>
     <CardContainer
       class={{if
         @isFieldDef
-        'field-preview-container isolated-and-edit-preview'
+        'field-preview-container'
         'full-height-preview isolated-and-edit-preview'
       }}
     >


### PR DESCRIPTION
In this PR, the isolated and edit preview in playground panel will fill all available horizontal space.


https://github.com/user-attachments/assets/f953e96b-8872-4325-a4fb-a9f1137b1a47




