### PR TITLE
Increase host test shards (10)

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -19,8 +19,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1, 2, 3, 4, 5, 6]
-        shardTotal: [6]
+        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        shardTotal: [10]
     concurrency:
       group: boxel-host-test${{ github.head_ref || github.run_id }}-shard${{ matrix.shardIndex }}
       cancel-in-progress: true


### PR DESCRIPTION
host test 4/6 is running more than twice as long as all the rest of the host tests. increasing shards to make the distribution more even.