### PR TITLE
Do not close all accordion panels in code submode

### DIFF
--- a/packages/boxel-ui/addon/src/components/accordion/item/index.gts
+++ b/packages/boxel-ui/addon/src/components/accordion/item/index.gts
@@ -2,6 +2,7 @@ import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { on } from '@ember/modifier';
 
 import cn from '../../../helpers/cn.ts';
+import optional from '../../../helpers/optional.ts';
 import DropdownArrowDown from '../../../icons/dropdown-arrow-down.gts';
 
 export interface AccordionItemSignature {
@@ -9,7 +10,7 @@ export interface AccordionItemSignature {
     className?: string;
     contentClass?: string;
     isOpen: boolean;
-    onClick: (event: MouseEvent) => void;
+    onClick?: (event: MouseEvent) => void;
   };
   Blocks: {
     content: [];
@@ -20,7 +21,11 @@ export interface AccordionItemSignature {
 
 const AccordionItem: TemplateOnlyComponent<AccordionItemSignature> = <template>
   <div class={{cn 'accordion-item' @className open=@isOpen}} ...attributes>
-    <button class='title' {{on 'click' @onClick}}>
+    <button
+      class='title'
+      {{on 'click' (optional @onClick)}}
+      disabled={{if @onClick false true}}
+    >
       <DropdownArrowDown class='caret' width='12' height='12' />
       {{yield to='title'}}
     </button>
@@ -62,13 +67,14 @@ const AccordionItem: TemplateOnlyComponent<AccordionItemSignature> = <template>
       align-items: center;
       gap: var(--boxel-sp-xxs);
       padding: var(--accordion-item-title-padding);
+      color: inherit;
       font: var(--accordion-item-title-font);
       letter-spacing: var(--accordion-item-title-letter-spacing);
       background-color: transparent;
       border: none;
       text-align: left;
     }
-    .title:hover {
+    .title:hover:not(:disabled) {
       cursor: pointer;
     }
     .caret {

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -756,7 +756,7 @@ export default class CodeSubmode extends Component<Signature> {
     return selection ?? 'schema-editor';
   }
 
-  @action private openAccordionItem(item: SelectedAccordionItem) {
+  @action private toggleAccordionItem(item: SelectedAccordionItem) {
     if (this.selectedAccordionItem === item) {
       let index = accordionItems.indexOf(item);
       if (index !== -1 && index === accordionItems.length - 1) {
@@ -983,7 +983,10 @@ export default class CodeSubmode extends Component<Signature> {
                         <A.Item
                           class='accordion-item'
                           @contentClass='accordion-item-content'
-                          @onClick={{fn this.openAccordionItem 'schema-editor'}}
+                          @onClick={{fn
+                            this.toggleAccordionItem
+                            'schema-editor'
+                          }}
                           @isOpen={{eq
                             this.selectedAccordionItem
                             'schema-editor'
@@ -1001,7 +1004,7 @@ export default class CodeSubmode extends Component<Signature> {
                       <A.Item
                         class='accordion-item'
                         @contentClass='accordion-item-content'
-                        @onClick={{fn this.openAccordionItem 'playground'}}
+                        @onClick={{fn this.toggleAccordionItem 'playground'}}
                         @isOpen={{eq this.selectedAccordionItem 'playground'}}
                         data-test-accordion-item='playground'
                       >
@@ -1042,13 +1045,20 @@ export default class CodeSubmode extends Component<Signature> {
                       <SpecPreview
                         @selectedDeclaration={{this.selectedDeclaration}}
                         @isLoadingNewModule={{this.moduleContentsResource.isLoadingNewModule}}
-                        @openAccordionItem={{this.openAccordionItem}}
+                        @toggleAccordionItem={{this.toggleAccordionItem}}
+                        @isPanelOpen={{eq
+                          this.selectedAccordionItem
+                          'spec-preview'
+                        }}
                         as |SpecPreviewTitle SpecPreviewContent|
                       >
                         <A.Item
                           class='accordion-item'
                           @contentClass='accordion-item-content'
-                          @onClick={{fn this.openAccordionItem 'spec-preview'}}
+                          @onClick={{fn
+                            this.toggleAccordionItem
+                            'spec-preview'
+                          }}
                           @isOpen={{eq
                             this.selectedAccordionItem
                             'spec-preview'

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -493,10 +493,7 @@ export default class CodeSubmode extends Component<Signature> {
   }
 
   get showSpecPreview() {
-    return (
-      this.selectedAccordionItem === 'spec-preview' &&
-      Boolean(this.selectedCardOrField?.exportName)
-    );
+    return Boolean(this.selectedCardOrField?.exportName);
   }
 
   private get itemToDeleteAsCard() {
@@ -1090,6 +1087,7 @@ export default class CodeSubmode extends Component<Signature> {
                         class='accordion-item'
                         @contentClass='accordion-item-content'
                         @isOpen={{true}}
+                        data-test-module-error-panel
                       >
                         <:title>
                           <SchemaEditorTitle @hasModuleError={{true}} />

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -86,7 +86,8 @@ interface Signature {
   Args: {
     selectedDeclaration?: ModuleDeclaration;
     isLoadingNewModule: boolean;
-    openAccordionItem: (item: SelectedAccordionItem) => void;
+    toggleAccordionItem: (item: SelectedAccordionItem) => void;
+    isPanelOpen: boolean;
   };
   Blocks: {
     default: [
@@ -494,7 +495,9 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
         await this.cardService.saveModel(card);
         if (card.id) {
           this.specPanelService.setSelection(card.id);
-          this.args.openAccordionItem('spec-preview');
+          if (!this.args.isPanelOpen) {
+            this.args.toggleAccordionItem('spec-preview');
+          }
         }
       } catch (e: any) {
         console.log('Error saving', e);
@@ -698,7 +701,7 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
     const fileUrl = id.endsWith('.json') ? id : `${id}.json`;
     this.recentFilesService.addRecentFileUrl(fileUrl);
     this.updatePlaygroundSelections(id);
-    this.args.openAccordionItem('playground');
+    this.args.toggleAccordionItem('playground');
   };
 
   <template>

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -629,7 +629,12 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
   }
 
   get showCreateSpec() {
-    return !this.search.isLoading && this.cards.length === 0 && this.canWrite;
+    return (
+      Boolean(this.args.selectedDeclaration?.exportName) &&
+      !this.search.isLoading &&
+      this.cards.length === 0 &&
+      this.canWrite
+    );
   }
 
   get isLoading() {

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -855,18 +855,16 @@ module('Acceptance | code submode tests', function (_hooks) {
         submode: 'code',
         codePath: `${testRealmURL}broken.gts`,
       })!;
-
       await visit(
         `/?operatorModeEnabled=true&operatorModeState=${encodeURIComponent(
           operatorModeStateParam,
         )}`,
       );
-
       await waitFor('[data-test-syntax-error]');
-
       assert
         .dom('[data-test-syntax-error]')
         .includesText('/broken.gts: Missing semicolon. (1:4)');
+      assert.dom('[data-test-module-error-panel] > button').isDisabled();
     });
 
     test('it shows card preview errors', async function (assert) {
@@ -1790,29 +1788,38 @@ module('Acceptance | code submode tests', function (_hooks) {
       assert
         .dom('[data-test-selected-accordion-item="schema-editor"]')
         .exists('defaults to schema-editor view');
-      await click('[data-test-accordion-item="spec-preview"] > button'); // select spec panel
+      await click('[data-test-accordion-item="playground"] > button');
+      assert.dom('[data-test-selected-accordion-item="playground"]').exists();
 
       await click('[data-test-file-browser-toggle]');
       await click('[data-test-file="address.gts"]');
       assert.dom('[data-test-selected-accordion-item="spec-preview"]').exists();
       assert.dom('[data-test-accordion-item="spec-preview"]').hasClass('open');
+      await click('[data-test-accordion-item="spec-preview"] > button');
+      assert
+        .dom('[data-test-selected-accordion-item="playground"]')
+        .exists('closing the final panel opens the previous panel');
 
       await click('[data-test-file="country.gts"]');
       assert.dom('[data-test-rhs-panel="card-or-field"]').exists();
-      assert.dom('[data-test-selected-accordion-item]').doesNotExist();
-      await click('[data-test-accordion-item="playground"] > button'); // open playground
-      assert.dom('[data-test-selected-accordion-item="playground"]').exists();
+      assert
+        .dom('[data-test-selected-accordion-item="schema-editor"]')
+        .exists();
+      await click('[data-test-accordion-item="spec-preview"] > button'); // open spec preview
+      assert.dom('[data-test-selected-accordion-item="spec-preview"]').exists();
 
       await click('[data-test-file="person.gts"]');
       assert
         .dom('[data-test-selected-accordion-item="schema-editor"]')
         .exists();
-      await click('[data-test-accordion-item="schema-editor"] > button'); // close schema-editor panel
-      assert.dom('[data-test-rhs-panel="card-or-field"]').exists();
-      assert.dom('[data-test-selected-accordion-item]').doesNotExist();
 
       await click('[data-test-file="pet-person.gts"]');
       assert.dom('[data-test-selected-accordion-item="playground"]').exists();
+      await click('[data-test-accordion-item="playground"] > button'); // toggle playground closed
+      assert.dom('[data-test-rhs-panel="card-or-field"]').exists();
+      assert
+        .dom('[data-test-selected-accordion-item="spec-preview"]')
+        .exists('closing panel toggles next panel open');
 
       let currentSelections = window.localStorage.getItem(
         CodeModePanelSelections,
@@ -1820,11 +1827,11 @@ module('Acceptance | code submode tests', function (_hooks) {
       assert.strictEqual(
         currentSelections,
         JSON.stringify({
-          [`${testRealmURL}address.gts`]: 'spec-preview',
-          [`${testRealmURL}country.gts`]: 'playground',
-          [`${testRealmURL}person.gts`]: null,
-          [`${testRealmURL}pet-person.gts`]: 'playground',
-          [`${testRealmURL}pet.gts`]: 'spec-preview',
+          [`${testRealmURL}address.gts`]: 'playground',
+          [`${testRealmURL}country.gts`]: 'spec-preview',
+          [`${testRealmURL}person.gts`]: 'schema-editor',
+          [`${testRealmURL}pet-person.gts`]: 'spec-preview',
+          [`${testRealmURL}pet.gts`]: 'playground',
         }),
       );
     });

--- a/packages/host/tests/acceptance/code-submode/spec-test.gts
+++ b/packages/host/tests/acceptance/code-submode/spec-test.gts
@@ -571,9 +571,10 @@ module('Acceptance | Spec preview', function (hooks) {
       submode: 'code',
       codePath: `${testRealmURL}new-skill.gts`,
     });
-    await waitFor('[data-test-accordion-item="spec-preview"]');
     assert.dom('[data-test-accordion-item="spec-preview"]').exists();
     assert.dom('[data-test-create-spec-button]').exists();
+    assert.dom('[data-test-create-spec-intent-message]').doesNotExist();
+    await click('[data-test-accordion-item="spec-preview"] button');
     assert.dom('[data-test-create-spec-intent-message]').exists();
     await percySnapshot(assert);
   });
@@ -610,12 +611,9 @@ module('Acceptance | Spec preview', function (hooks) {
       codePath: `${testRealmURL}person-1.gts`,
     });
     assert.dom('[data-test-create-spec-button]').exists();
-    await click('[data-test-accordion-item="spec-preview"] button');
     await click('[data-test-create-spec-button]');
     //spec is opened
-    await assert
-      .dom('[data-test-accordion-item="spec-preview"]')
-      .hasClass('open');
+    assert.dom('[data-test-accordion-item="spec-preview"]').hasClass('open');
     assert.dom('[data-test-title] [data-test-boxel-input]').hasValue('Person1');
     assert.dom('[data-test-exported-type]').hasText('card');
     assert.dom('[data-test-exported-name]').hasText('Person1');

--- a/packages/host/tests/acceptance/code-submode/spec-test.gts
+++ b/packages/host/tests/acceptance/code-submode/spec-test.gts
@@ -561,8 +561,6 @@ module('Acceptance | Spec preview', function (hooks) {
     });
     assert.dom('[data-test-accordion-item="spec-preview"]').exists();
     assert.dom('[data-test-create-spec-button]').exists();
-    assert.dom('[data-test-create-spec-intent-message]').doesNotExist();
-    await click('[data-test-accordion-item="spec-preview"] button');
     assert.dom('[data-test-create-spec-intent-message]').exists();
     await percySnapshot(assert);
   });

--- a/packages/host/tests/acceptance/code-submode/spec-test.gts
+++ b/packages/host/tests/acceptance/code-submode/spec-test.gts
@@ -1,10 +1,4 @@
-import {
-  click,
-  waitFor,
-  fillIn,
-  triggerEvent,
-  find,
-} from '@ember/test-helpers';
+import { click, fillIn, triggerEvent, find } from '@ember/test-helpers';
 
 import { module, test, skip } from 'qunit';
 
@@ -532,11 +526,9 @@ module('Acceptance | Spec preview', function (hooks) {
       submode: 'code',
       codePath: `${testRealmURL}person.gts`,
     });
-    await waitFor('[data-test-accordion-item="spec-preview"]');
     assert.dom('[data-test-accordion-item="spec-preview"]').exists();
     assert.dom('[data-test-has-spec]').containsText('card');
     await click('[data-test-accordion-item="spec-preview"] button');
-    await waitFor('[data-test-spec-selector]');
     assert.dom('[data-test-spec-selector]').exists();
     assert.dom('[data-test-spec-selector-item-path]').hasText('person-entry');
     await percySnapshot(assert);
@@ -547,7 +539,6 @@ module('Acceptance | Spec preview', function (hooks) {
     assert.dom('[data-test-module-href]').containsText(`${testRealmURL}person`);
     assert.dom('[data-test-exported-name]').containsText('Person');
     assert.dom('[data-test-exported-type]').containsText('card');
-    await waitFor('[data-test-view-spec-instance]');
     assert.dom('[data-test-view-spec-instance]').exists();
   });
   test('view when there are multiple spec instances', async function (assert) {
@@ -555,15 +546,12 @@ module('Acceptance | Spec preview', function (hooks) {
       submode: 'code',
       codePath: `${testRealmURL}pet.gts`,
     });
-    await waitFor('[data-test-accordion-item="spec-preview"]');
     assert.dom('[data-test-accordion-item="spec-preview"]').exists();
     assert.dom('[data-test-has-spec]').containsText('2 instances');
     await click('[data-test-accordion-item="spec-preview"] button');
-    await waitFor('[data-test-spec-selector]');
     assert.dom('[data-test-spec-selector]').exists();
     assert.dom('[data-test-caret-down]').exists();
     assert.dom('[data-test-spec-selector-item-path]').hasText('pet-entry-2');
-    await waitFor('[data-test-view-spec-instance]');
     assert.dom('[data-test-view-spec-instance]').exists();
   });
   test('view when there are no spec instances', async function (assert) {
@@ -583,7 +571,6 @@ module('Acceptance | Spec preview', function (hooks) {
       submode: 'code',
       codePath: `${testRealm2URL}new-skill.gts`,
     });
-    await waitFor('[data-test-accordion-item="spec-preview"]');
     await click('[data-test-accordion-item="spec-preview"] button');
     assert.dom('[data-test-accordion-item="spec-preview"]').exists();
     assert.dom('[data-test-create-spec-button]').doesNotExist();
@@ -597,7 +584,6 @@ module('Acceptance | Spec preview', function (hooks) {
       submode: 'code',
       codePath: `${testRealm2URL}person.gts`,
     });
-    await waitFor('[data-test-accordion-item="spec-preview"]');
     await click('[data-test-accordion-item="spec-preview"] button');
     assert.dom('[data-test-accordion-item="spec-preview"]').exists();
     assert.dom('[data-test-create-spec-button]').doesNotExist();
@@ -686,7 +672,6 @@ module('Acceptance | Spec preview', function (hooks) {
       submode: 'code',
       codePath: `${testRealmURL}employee.gts`,
     });
-    await waitFor('[data-test-accordion-item="spec-preview"]');
     assert.dom('[data-test-accordion-item="spec-preview"]').exists();
     await click('[data-test-accordion-item="spec-preview"] button');
     assert.dom('[data-test-title] [data-test-boxel-input]').hasValue('');
@@ -699,7 +684,6 @@ module('Acceptance | Spec preview', function (hooks) {
       submode: 'code',
       codePath: `${testRealmURL}person.gts`,
     });
-    await waitFor('[data-test-accordion-item="spec-preview"]');
     await click('[data-test-accordion-item="spec-preview"] button');
     let readMeInput = 'This is a spec for a person';
     this.onSave((_, json) => {
@@ -723,17 +707,12 @@ module('Acceptance | Spec preview', function (hooks) {
       submode: 'code',
       codePath: `${testRealmURL}person.gts`,
     });
-
-    await waitFor('[data-test-view-spec-instance]');
+    await click('[data-test-accordion-item="spec-preview"] button');
     assert.dom('[data-test-view-spec-instance]').exists();
     await click('[data-test-view-spec-instance]');
-
-    await waitFor('[data-test-card-url-bar-input]');
     assert
       .dom('[data-test-card-url-bar-input]')
       .hasValue(`${testRealmURL}person-entry.json`);
-
-    await waitFor('[data-test-editor]');
     assert.dom('[data-test-editor]').hasAnyText();
     assert.dom('[data-test-editor]').containsText('Person');
     assert.dom('[data-test-editor]').containsText('Spec');
@@ -751,20 +730,15 @@ module('Acceptance | Spec preview', function (hooks) {
       submode: 'code',
       codePath: `${testRealmURL}pet.gts`,
     });
-    await waitFor('[data-test-accordion-item="spec-preview"]');
     assert.dom('[data-test-accordion-item="spec-preview"]').exists();
+
     await click('[data-test-accordion-item="spec-preview"] button');
-
-    await waitFor('[data-test-spec-selector]');
-    assert.dom('[data-test-spec-selector]').exists();
-
     await click('[data-test-spec-selector] > div');
-
     assert
       .dom('[data-option-index="0"] [data-test-spec-selector-item-path]')
       .hasText('pet-entry-2');
-    await click('[data-option-index="0"]');
 
+    await click('[data-option-index="0"]');
     assert.dom(`[data-test-links-to-many="linkedExamples"]`).exists();
     assert.dom(`[data-test-card="${testRealmURL}Pet/mango"]`).exists();
 
@@ -772,14 +746,12 @@ module('Acceptance | Spec preview', function (hooks) {
       `[data-test-card="${testRealmURL}Pet/mango"]`,
       'mouseenter',
     );
-
     assert.dom('[data-test-card-overlay]').exists();
 
     await triggerEvent(
       `[data-test-card="${testRealmURL}Pet/mango"]`,
       'mouseleave',
     );
-
     assert.dom('[data-test-card-overlay]').doesNotExist();
   });
 
@@ -788,13 +760,11 @@ module('Acceptance | Spec preview', function (hooks) {
       submode: 'code',
       codePath: `${testRealmURL}polymorphic-field.gts`,
     });
-    await waitFor('[data-test-accordion-item="spec-preview"]');
     const elementName = 'SubTestField';
     await click(`[data-test-boxel-selector-item-text="${elementName}"]`);
     assert.dom('[data-test-accordion-item="spec-preview"]').exists();
     assert.dom('[data-test-has-spec]').containsText('field');
     await click('[data-test-accordion-item="spec-preview"] button');
-    await waitFor('[data-test-spec-selector]');
     assert.dom('[data-test-spec-selector]').exists();
     assert
       .dom('[data-test-module-href]')
@@ -838,13 +808,8 @@ module('Acceptance | Spec preview', function (hooks) {
       submode: 'code',
       codePath: `${testRealmURL}pet.gts`,
     });
-
-    // Open the spec preview panel
-    await waitFor('[data-test-accordion-item="spec-preview"]');
     await click('[data-test-accordion-item="spec-preview"] button');
-
     // Select the pet-entry-2 spec which has linked examples
-    await waitFor('[data-test-spec-selector]');
     await click('[data-test-spec-selector] > div');
     assert
       .dom('[data-option-index="0"] [data-test-spec-selector-item-path]')
@@ -853,12 +818,10 @@ module('Acceptance | Spec preview', function (hooks) {
 
     // Wait for linked examples to appear
     const petId = `${testRealmURL}Pet/mango`;
-    await waitFor(`[data-test-links-to-many="linkedExamples"]`);
     assert.dom(`[data-test-card="${petId}"]`).exists();
 
     // Click on the first linked example
     await triggerEvent(`[data-test-card="${petId}"]`, 'mouseenter');
-    await waitFor('[data-test-card-overlay]');
     await click(`[data-test-card="${petId}"]`);
 
     // Verify the card was persisted in playground selections
@@ -873,7 +836,6 @@ module('Acceptance | Spec preview', function (hooks) {
     );
 
     // Verify the playground panel shows the selected card
-    await waitFor('[data-test-selected-item]');
     assert.dom('[data-test-selected-item]').hasText('Mango');
     assertCardExists(
       assert,
@@ -884,31 +846,22 @@ module('Acceptance | Spec preview', function (hooks) {
   });
 
   test('updatePlaygroundSelections adds card to recent files storage when clicking an example card', async function (assert) {
+    const petId = `${testRealmURL}Pet/mango`;
     await visitOperatorMode({
       submode: 'code',
       codePath: `${testRealmURL}pet.gts`,
     });
-
-    // Open the spec preview panel
-    await waitFor('[data-test-accordion-item="spec-preview"]');
     await click('[data-test-accordion-item="spec-preview"] button');
-
     // Select the pet-entry-2 spec which has linked examples
-    await waitFor('[data-test-spec-selector]');
     await click('[data-test-spec-selector] > div');
     assert
       .dom('[data-option-index="0"] [data-test-spec-selector-item-path]')
       .hasText('pet-entry-2');
+
     await click('[data-option-index="0"]');
-
-    // Wait for linked examples to appear
-    const petId = `${testRealmURL}Pet/mango`;
-    await waitFor(`[data-test-links-to-many="linkedExamples"]`);
     assert.dom(`[data-test-card="${petId}"]`).exists();
-
     // Click on the first linked example
     await triggerEvent(`[data-test-card="${petId}"]`, 'mouseenter');
-    await waitFor('[data-test-card-overlay]');
     await click(`[data-test-card="${petId}"]`);
 
     // Verify the card was added to recent files
@@ -927,35 +880,24 @@ module('Acceptance | Spec preview', function (hooks) {
   });
 
   test('updatePlaygroundSelections preserves existing format when selecting different examples card', async function (assert) {
+    const firstPetId = `${testRealmURL}Pet/mango`;
+    const secondPetId = `${testRealmURL}Pet/pudding`;
     await visitOperatorMode({
       submode: 'code',
       codePath: `${testRealmURL}pet.gts`,
     });
-
-    // Open the spec preview panel
-    await waitFor('[data-test-accordion-item="spec-preview"]');
     await click('[data-test-accordion-item="spec-preview"] button');
-
-    // Select the pet-entry-2 spec which has linked examples
-    await waitFor('[data-test-spec-selector]');
     await click('[data-test-spec-selector] > div');
     assert
       .dom('[data-option-index="0"] [data-test-spec-selector-item-path]')
       .hasText('pet-entry-2');
     await click('[data-option-index="0"]');
-
-    // Wait for linked examples to appear
-    const firstPetId = `${testRealmURL}Pet/mango`;
-    const secondPetId = `${testRealmURL}Pet/pudding`;
-    await waitFor(`[data-test-links-to-many="linkedExamples"]`);
     assert.dom(`[data-test-card="${firstPetId}"]`).exists();
     assert.dom(`[data-test-card="${secondPetId}"]`).exists();
 
     // Click on the first linked example
     await triggerEvent(`[data-test-card="${firstPetId}"]`, 'mouseenter');
-    await waitFor('[data-test-card-overlay]');
     await click(`[data-test-card="${firstPetId}"]`);
-
     assertCardExists(
       assert,
       firstPetId,
@@ -985,7 +927,6 @@ module('Acceptance | Spec preview', function (hooks) {
     // Go back to spec preview and click the second card
     await click('[data-test-accordion-item="spec-preview"] button');
     await triggerEvent(`[data-test-card="${secondPetId}"]`, 'mouseenter');
-    await waitFor('[data-test-card-overlay]');
     await click(`[data-test-card="${secondPetId}"]`);
 
     // Verify the format was preserved when selecting the second card
@@ -999,7 +940,6 @@ module('Acceptance | Spec preview', function (hooks) {
     );
 
     // Verify the second card is shown in embedded format
-    await waitFor('[data-test-selected-item]');
     assert.dom('[data-test-selected-item]').hasText('Pudding');
     assertCardExists(
       assert,
@@ -1014,7 +954,6 @@ module('Acceptance | Spec preview', function (hooks) {
       submode: 'code',
       codePath: `${testRealmURL}pet.gts`,
     });
-    await waitFor('[data-test-accordion-item="spec-preview"]');
     await click('[data-test-accordion-item="spec-preview"] button');
     assert.dom('[data-test-title] [data-test-boxel-input]').hasValue('Pet2');
     assert.dom('[data-test-number-of-instance]').hasText('2 instances');


### PR DESCRIPTION
- Closing a panel toggles the next one open
- Closing the final panel toggles the previous one open
- If there's only 1 panel, it remains open
- Change to spec panel: follow similar logic to playground and display a 'not available' message instead of hiding the panel for non-exports