### PR TITLE
ui: Fix deployment failures requiring icons build

### DIFF
--- a/.github/workflows/build-host.yml
+++ b/.github/workflows/build-host.yml
@@ -40,13 +40,13 @@ jobs:
             exit 1;
           fi
 
-      - name: Build boxel-ui
-        run: pnpm build
-        working-directory: packages/boxel-ui/addon
-
       - name: Build boxel-icons
         run: pnpm build
         working-directory: packages/boxel-icons
+
+      - name: Build boxel-ui
+        run: pnpm build
+        working-directory: packages/boxel-ui/addon
 
       - name: Build host
         run: pnpm deploy:boxel-host build-only --verbose

--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -35,6 +35,9 @@ jobs:
             echo "unrecognized environment"
             exit 1;
           fi
+      - name: Build boxel-icons
+        run: pnpm build
+        working-directory: packages/boxel-icons
       - name: Build boxel-ui addon
         run: pnpm build
         working-directory: packages/boxel-ui/addon

--- a/packages/boxel-ui/addon/tsconfig.json
+++ b/packages/boxel-ui/addon/tsconfig.json
@@ -29,9 +29,7 @@
       "https://cardstack.com/base/*": ["../../base/*"],
       "*": ["./src/types/*"],
       "@cardstack/boxel-ui": ["./src"],
-      "@cardstack/boxel-ui/*": ["./src/*"],
-      "@cardstack/boxel-icons": ["../../boxel-icons/src"],
-      "@cardstack/boxel-icons/*": ["../../boxel-icons/src/*"]
+      "@cardstack/boxel-ui/*": ["./src/*"]
     },
     "typeRoots": ["./src/types"]
   },

--- a/packages/boxel-ui/addon/tsconfig.json
+++ b/packages/boxel-ui/addon/tsconfig.json
@@ -29,7 +29,9 @@
       "https://cardstack.com/base/*": ["../../base/*"],
       "*": ["./src/types/*"],
       "@cardstack/boxel-ui": ["./src"],
-      "@cardstack/boxel-ui/*": ["./src/*"]
+      "@cardstack/boxel-ui/*": ["./src/*"],
+      "@cardstack/boxel-icons": ["../../boxel-icons/src"],
+      "@cardstack/boxel-icons/*": ["../../boxel-icons/src/*"]
     },
     "typeRoots": ["./src/types"]
   },


### PR DESCRIPTION
Since an [icon reference was added in `boxel-ui`](https://github.com/cardstack/boxel/blob/3dc3635712e615d6504cf562374c6e1c9d58a5fe/packages/boxel-ui/addon/src/components/entity-icon-display/usage.gts#L1), `boxel-ui` and `host` deployments have been [failing on `main`](https://github.com/cardstack/boxel/actions/runs/14044560329) during the `boxel-ui` build step. Adding a/moving the build step for `boxel-icons` allows those deployments to [succeed](https://github.com/cardstack/boxel/actions/runs/14044983169).

An unfortunate consequence of this is that the `host` build job now takes 1¼ minutes longer, and deployment slowness has already seemed worse to me lately:

<img width="911" alt="boxel@7a9850a 2025-03-24 13-44-09" src="https://github.com/user-attachments/assets/0da6152e-29b8-4dc8-88c3-76af4c2fb763" />