### PR TITLE
CS-8272-clean-up-catalog-app-code-and-make-it-composable

### DIFF
--- a/packages/boxel-ui/addon/src/components.ts
+++ b/packages/boxel-ui/addon/src/components.ts
@@ -58,7 +58,9 @@ import SkeletonPlaceholder from './components/skeleton-placeholder/index.gts';
 import Switch from './components/switch/index.gts';
 import TabbedHeader from './components/tabbed-header/index.gts';
 import Tooltip from './components/tooltip/index.gts';
-import ViewSelector from './components/view-selector/index.gts';
+import ViewSelector, {
+  type ViewItem,
+} from './components/view-selector/index.gts';
 
 export {
   Accordion,
@@ -117,5 +119,6 @@ export {
   Switch,
   TabbedHeader,
   Tooltip,
+  ViewItem,
   ViewSelector,
 };

--- a/packages/catalog-realm/catalog-app/catalog.gts
+++ b/packages/catalog-realm/catalog-app/catalog.gts
@@ -7,17 +7,24 @@ import {
   field,
   Component,
   CardDef,
+  CardContext,
   realmInfo,
   type BaseDef,
   linksToMany,
   realmURL,
 } from 'https://cardstack.com/base/card-api';
-import { isCardInstance, Query } from '@cardstack/runtime-common';
+import { Query, isCardInstance } from '@cardstack/runtime-common';
 import StringField from 'https://cardstack.com/base/string';
+import GlimmerComponent from '@glimmer/component';
 
 import FilterSection from './components/filter-section';
-import CardsDisplaySection from './components/cards-display-section';
+import CardsDisplaySection, {
+  CardsIntancesGrid,
+} from './components/cards-display-section';
+
 import ContentContainer from './components/content-container';
+
+import { CardsGrid } from '../components/grid';
 
 import CatalogLayout from './layouts/catalog-layout';
 
@@ -34,54 +41,213 @@ import {
 } from '@cardstack/boxel-ui/components';
 
 import { Listing } from './listing/listing';
-import { CardsGrid } from '../components/grid';
 
-type ViewOption = 'card' | 'strip' | 'grid';
+type ViewOption = 'strip' | 'grid';
 
+// ShowcaseView
+interface ShowcaseViewArgs {
+  Args: {
+    startHereListings?: CardDef[];
+    newListings?: CardDef[];
+    featuredListings?: CardDef[];
+    context?: CardContext;
+  };
+  Element: HTMLElement;
+}
+
+class ShowcaseView extends GlimmerComponent<ShowcaseViewArgs> {
+  get startHereListings() {
+    return this.args.startHereListings;
+  }
+
+  get newListings() {
+    return this.args.newListings;
+  }
+
+  get featuredListings() {
+    return this.args.featuredListings;
+  }
+
+  <template>
+    <div class='showcase-display-container' ...attributes>
+      <CardsDisplaySection class='showcase-cards-display'>
+        <:intro>
+          <div class='intro-title'>
+            <h2>Start Here</h2>
+            <p>The starter stack — Install these first</p>
+          </div>
+          <p class='intro-description'>These are the foundational tools we think
+            every builder should have. Whether you’re just exploring or setting
+            up your workspace for serious work, start with these must-haves.</p>
+        </:intro>
+        <:content>
+          <CardsIntancesGrid
+            @cards={{this.startHereListings}}
+            @context={{@context}}
+          />
+        </:content>
+      </CardsDisplaySection>
+
+      <CardsDisplaySection class='new-this-week-cards-display'>
+        <:intro>
+          <div class='intro-title'>
+            <h2>New this Week</h2>
+            <p>Hand-picked by our editors — What’s buzzing right now</p>
+          </div>
+          <p class='intro-description'>These new entries have caught the
+            community’s eye, whether for creative flair, clever utility, or just
+            plain polish.</p>
+        </:intro>
+        <:content>
+          <CardsIntancesGrid
+            @cards={{this.newListings}}
+            @context={{@context}}
+          />
+        </:content>
+      </CardsDisplaySection>
+
+      <CardsDisplaySection class='featured-cards-display'>
+        <:intro>
+          <div class='intro-title'>
+            <h2>Feature Collection</h2>
+            <p>:Personal Organization</p>
+          </div>
+          <p class='intro-description'>A hand-picked duo of focused, flexible
+            tools for personal</p>
+        </:intro>
+        <:content>
+          <CardsIntancesGrid
+            @cards={{this.featuredListings}}
+            @context={{@context}}
+          />
+        </:content>
+      </CardsDisplaySection>
+    </div>
+
+    <style scoped>
+      h2,
+      p {
+        margin-block: 0;
+        margin-bottom: var(--boxel-sp);
+      }
+      .showcase-display-container {
+        display: flex;
+        flex-direction: column;
+        gap: var(--boxel-sp-xxxl);
+        container-name: showcase-display-container;
+        container-type: inline-size;
+      }
+      .showcase-cards-display :deep(.cards),
+      .featured-cards-display :deep(.cards) {
+        --grid-view-height: 390px;
+        grid-template-columns: repeat(2, 1fr);
+      }
+      .new-this-week-cards-display :deep(.cards) {
+        --grid-view-height: 270px;
+        grid-template-columns: repeat(4, 1fr);
+      }
+
+      .intro-title {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: var(--boxel-sp-sm);
+      }
+      .intro-title h2 {
+        font: 700 var(--boxel-font-xl);
+      }
+      .intro-title p {
+        font: var(--boxel-font-lg);
+        font-style: italic;
+      }
+      .intro-description {
+        font: var(--boxel-font);
+      }
+
+      @container showcase-display-container (inline-size <= 768px) {
+        .new-this-week-cards-display :deep(.cards) {
+          grid-template-columns: repeat(2, 1fr);
+        }
+
+        @container showcase-display-container (inline-size <= 500px) {
+          .showcase-cards-display :deep(.cards),
+          .new-this-week-cards-display :deep(.cards),
+          .featured-cards-display :deep(.cards) {
+            grid-template-columns: 1fr;
+          }
+        }
+      }
+    </style>
+  </template>
+}
+
+// CatalogListView
 const CATALOG_VIEW_OPTIONS: ViewItem[] = [
   { id: 'strip', icon: StripIcon },
   { id: 'grid', icon: GridIcon },
 ];
 
+interface CatalogListViewArgs {
+  Args: {
+    tabTitle?: string;
+    listingQuery: Query;
+    realms: URL[];
+    context?: CardContext;
+  };
+  Element: HTMLElement;
+}
+
+class CatalogListView extends GlimmerComponent<CatalogListViewArgs> {
+  @tracked private selectedView: ViewOption = 'grid';
+
+  @action private onChangeView(id: ViewOption) {
+    this.selectedView = id;
+  }
+
+  get tabTitle() {
+    return this.args.tabTitle;
+  }
+
+  <template>
+    <CardsDisplaySection>
+      <:intro>
+        <header class='catalog-list-header'>
+          <h2>{{this.tabTitle}}</h2>
+          <ViewSelector
+            @selectedId={{this.selectedView}}
+            @onChange={{this.onChangeView}}
+            @items={{CATALOG_VIEW_OPTIONS}}
+          />
+        </header>
+      </:intro>
+      <:content>
+        <CardsGrid
+          @query={{@listingQuery}}
+          @realms={{@realms}}
+          @selectedView={{this.selectedView}}
+          @context={{@context}}
+        />
+      </:content>
+    </CardsDisplaySection>
+
+    <style scoped>
+      h2 {
+        margin-block: 0;
+        margin-bottom: var(--boxel-sp);
+      }
+      .catalog-list-header {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--boxel-sp-sm);
+      }
+    </style>
+  </template>
+}
+
+// Catalog App
 class Isolated extends Component<typeof Catalog> {
-  mockShowcaseCards = [
-    {
-      name: 'Blog Post App',
-    },
-    {
-      name: 'Black Jack',
-    },
-  ];
-
-  mockNewToThisWeekCards = [
-    {
-      name: 'Basic CV',
-    },
-    {
-      name: 'Daily Feed',
-    },
-    { name: 'Card 3' },
-    { name: 'Card 4' },
-    { name: 'Card 5' },
-    { name: 'Card 6' },
-    { name: 'Card 7' },
-    { name: 'Card 8' },
-  ];
-  mockFeaturedCards = [
-    {
-      name: 'Sprint Tracker',
-    },
-    {
-      name: 'Todo List',
-    },
-  ];
-  mockCards = [
-    { name: 'Card 1' },
-    { name: 'Card 2' },
-    { name: 'Card 3' },
-    { name: 'Card 4' },
-  ];
-
   tabFilterOptions = [
     {
       tabId: 'showcase',
@@ -106,15 +272,19 @@ class Isolated extends Component<typeof Catalog> {
   ];
 
   @tracked activeTabId: string = this.tabFilterOptions[0].tabId;
-  @tracked private selectedView: ViewOption = 'grid';
 
   @action
   setActiveTab(tabId: string) {
     this.activeTabId = tabId;
   }
 
-  @action private onChangeView(id: ViewOption) {
-    this.selectedView = id;
+  // TODO: Remove this after testing
+  @action goToGrid() {
+    if (!this.args.context?.actions?.viewCard) {
+      throw new Error('viewCard action is not available');
+    }
+    let gridUrl = new URL('http://localhost:4201/catalog/grid.json');
+    this.args.context?.actions?.viewCard(gridUrl);
   }
 
   get shouldShowTab() {
@@ -132,15 +302,6 @@ class Isolated extends Component<typeof Catalog> {
       Object.getPrototypeOf(this.args.model).constructor.headerColor ??
       undefined
     );
-  }
-
-  // TODO: Remove this after testing
-  @action goToGrid() {
-    if (!this.args.context?.actions?.viewCard) {
-      throw new Error('viewCard action is not available');
-    }
-    let gridUrl = new URL('http://localhost:4201/catalog/grid.json');
-    this.args.context?.actions?.viewCard(gridUrl);
   }
 
   get startHereListings() {
@@ -204,76 +365,24 @@ class Isolated extends Component<typeof Catalog> {
         <FilterSection />
       </:sidebar>
       <:content>
-        {{! Note: Content will be display 2 columns: Content Listing Display and Related Listing Cards in the same time }}
         <div class='content-area-container {{this.activeTabId}}'>
           <div class='content-area'>
-            {{! Column 1: Card Listing Section }}
             <div class='catalog-content'>
               <ContentContainer class='catalog-listing'>
                 {{#if (this.shouldShowTab 'showcase')}}
-                  <CardsDisplaySection
-                    @cards={{this.startHereListings}}
+                  <ShowcaseView
+                    @startHereListings={{this.startHereListings}}
+                    @newListings={{this.newListings}}
+                    @featuredListings={{this.featuredListings}}
                     @context={{@context}}
-                    class='showcase-cards-display'
-                  >
-                    <:intro>
-                      <div class='intro-title'>
-                        <h2>Start Here</h2>
-                        <p>The starter stack — Install these first</p>
-                      </div>
-                      <p class='intro-description'>These are the foundational
-                        tools we think every builder should have. Whether you’re
-                        just exploring or setting up your workspace for serious
-                        work, start with these must-haves.</p>
-                    </:intro>
-                  </CardsDisplaySection>
-
-                  <CardsDisplaySection
-                    @cards={{this.newListings}}
-                    @context={{@context}}
-                  >
-                    <:intro>
-                      <div class='intro-title'>
-                        <h2>New this Week</h2>
-                        <p>Hand-picked by our editors — What’s buzzing right now</p>
-                      </div>
-                      <p class='intro-description'>These new entries have caught
-                        the community’s eye, whether for creative flair, clever
-                        utility, or just plain polish.</p>
-                    </:intro>
-                  </CardsDisplaySection>
-
-                  <CardsDisplaySection
-                    @cards={{this.featuredListings}}
-                    @context={{@context}}
-                    class='featured-cards-display'
-                  >
-                    <:intro>
-                      <div class='intro-title'>
-                        <h2>Feature Collection</h2>
-                        <p>:Personal Organization</p>
-                      </div>
-                      <p class='intro-description'>A hand-picked duo of focused,
-                        flexible tools for personal</p>
-                    </:intro>
-                  </CardsDisplaySection>
-                {{else}}
-                  <ViewSelector
-                    @selectedId={{this.selectedView}}
-                    @onChange={{this.onChangeView}}
-                    @items={{CATALOG_VIEW_OPTIONS}}
                   />
-
-                  <CardsDisplaySection @title={{this.tabTitle}}>
-                    <:content>
-                      <CardsGrid
-                        @query={{this.listingQuery}}
-                        @realms={{this.realms}}
-                        @selectedView={{this.selectedView}}
-                        @context={{@context}}
-                      />
-                    </:content>
-                  </CardsDisplaySection>
+                {{else}}
+                  <CatalogListView
+                    @tabTitle={{this.tabTitle}}
+                    @listingQuery={{this.listingQuery}}
+                    @realms={{this.realms}}
+                    @context={{@context}}
+                  />
                 {{/if}}
               </ContentContainer>
             </div>
@@ -330,48 +439,6 @@ class Isolated extends Component<typeof Catalog> {
         gap: var(--boxel-sp-xxl);
       }
 
-      /* Mock data display */
-      .showcase-cards-display :deep(.cards),
-      .featured-cards-display :deep(.cards) {
-        --grid-view-height: 390px;
-        grid-template-columns: 1fr 1fr;
-      }
-
-      h2,
-      p {
-        margin-block: 0;
-        margin-bottom: var(--boxel-sp);
-      }
-
-      .intro-title {
-        display: flex;
-        flex-wrap: wrap;
-        align-items: center;
-        gap: var(--boxel-sp-sm);
-      }
-      .intro-title h2 {
-        font: 700 var(--boxel-font-xl);
-      }
-      .intro-title p {
-        font: var(--boxel-font-lg);
-        font-style: italic;
-      }
-      .intro-description {
-        font: var(--boxel-font);
-      }
-      /* End of Mock data display */
-
-      .related-card-listing {
-        display: flex;
-        flex-direction: column;
-        gap: var(--boxel-sp-lg);
-      }
-      .listing-title {
-        margin: 0;
-        padding: var(--boxel-sp-sm);
-        font-weight: 600;
-      }
-
       .operator-mode .buried .cards,
       .operator-mode .buried .add-button {
         display: none;
@@ -395,25 +462,16 @@ class Isolated extends Component<typeof Catalog> {
         box-shadow: 0 0 0 1px var(--boxel-dark);
       }
 
+      /* TODO: Remove this after testing */
+      .go-to-grid {
+        font-weight: 600;
+      }
+
       @container content-area-container (inline-size <= 768px) {
         .content-area {
           grid-template-columns: 1fr;
           overflow-y: auto;
         }
-        .catalog-content {
-          overflow-y: unset;
-        }
-      }
-
-      @container content-area-container (inline-size <= 500px) {
-        .showcase-cards-display :deep(.cards),
-        .featured-cards-display :deep(.cards) {
-          grid-template-columns: 1fr;
-        }
-      }
-
-      .go-to-grid {
-        font-weight: 600;
       }
     </style>
   </template>

--- a/packages/catalog-realm/catalog-app/catalog.gts
+++ b/packages/catalog-realm/catalog-app/catalog.gts
@@ -56,18 +56,6 @@ interface ShowcaseViewArgs {
 }
 
 class ShowcaseView extends GlimmerComponent<ShowcaseViewArgs> {
-  get startHereListings() {
-    return this.args.startHereListings;
-  }
-
-  get newListings() {
-    return this.args.newListings;
-  }
-
-  get featuredListings() {
-    return this.args.featuredListings;
-  }
-
   <template>
     <div class='showcase-display-container' ...attributes>
       <CardsDisplaySection class='showcase-cards-display'>
@@ -82,7 +70,7 @@ class ShowcaseView extends GlimmerComponent<ShowcaseViewArgs> {
         </:intro>
         <:content>
           <CardsIntancesGrid
-            @cards={{this.startHereListings}}
+            @cards={{@startHereListings}}
             @context={{@context}}
           />
         </:content>
@@ -99,10 +87,7 @@ class ShowcaseView extends GlimmerComponent<ShowcaseViewArgs> {
             plain polish.</p>
         </:intro>
         <:content>
-          <CardsIntancesGrid
-            @cards={{this.newListings}}
-            @context={{@context}}
-          />
+          <CardsIntancesGrid @cards={{@newListings}} @context={{@context}} />
         </:content>
       </CardsDisplaySection>
 
@@ -117,7 +102,7 @@ class ShowcaseView extends GlimmerComponent<ShowcaseViewArgs> {
         </:intro>
         <:content>
           <CardsIntancesGrid
-            @cards={{this.featuredListings}}
+            @cards={{@featuredListings}}
             @context={{@context}}
           />
         </:content>
@@ -462,7 +447,6 @@ class Isolated extends Component<typeof Catalog> {
         box-shadow: 0 0 0 1px var(--boxel-dark);
       }
 
-      /* TODO: Remove this after testing */
       .go-to-grid {
         font-weight: 600;
       }

--- a/packages/catalog-realm/catalog-app/components/cards-display-section.gts
+++ b/packages/catalog-realm/catalog-app/components/cards-display-section.gts
@@ -4,7 +4,7 @@ import type { CardContext } from 'https://cardstack.com/base/card-api';
 
 type SelectedView = 'grid' | 'strip' | undefined;
 
-interface CardsIntancesLayoutArgs {
+interface CardsIntancesGridArgs {
   Args: {
     cards?: CardDef[];
     context?: CardContext;
@@ -16,8 +16,7 @@ interface CardsIntancesLayoutArgs {
 
 // This is only make for common grid/strip view, means we not need to pass extra format args, it strictly use fitted-format
 // This is different from the CardsGrid component, which is just display links to Many Components without using prerendersearch
-class CardsIntancesLayout extends GlimmerComponent<CardsIntancesLayoutArgs> {
-  // Always use grid view as default
+export class CardsIntancesGrid extends GlimmerComponent<CardsIntancesGridArgs> {
   get view() {
     return this.args.selectedView || 'grid';
   }
@@ -126,7 +125,7 @@ export default class CardsDisplaySection extends GlimmerComponent<CardSectionArg
       {{#if (has-block 'content')}}
         {{yield to='content'}}
       {{else}}
-        <CardsIntancesLayout
+        <CardsIntancesGrid
           @cards={{@cards}}
           @selectedView={{@selectedView}}
           @context={{@context}}


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-8272/clean-up-catalog-app-code-and-make-it-composable

-- Enhance the readability of code

-- Cleanup the stale mock code since we already have real data

--Separate the showcase view and catalog list view, each view has its own responsibility and controllable container query 

Demo:

https://github.com/user-attachments/assets/350ed770-9281-4236-be49-3a2c2b3ccc7a

