### PR TITLE
Restore Matrix realm events in production

### DIFF
--- a/.github/workflows/build-host.yml
+++ b/.github/workflows/build-host.yml
@@ -29,7 +29,6 @@ jobs:
             echo "MATRIX_URL=https://matrix.boxel.ai" >> $GITHUB_ENV
             echo "MATRIX_SERVER_NAME=boxel.ai" >> $GITHUB_ENV
             echo "EXPERIMENTAL_AI_ENABLED=true" >> $GITHUB_ENV
-            echo "DISABLE_MATRIX_REALM_EVENTS=true" >> $GITHUB_ENV
           elif [ "$INPUT_ENVIRONMENT" = "staging" ]; then
             echo "RESOLVED_BASE_REALM_URL=https://realms-staging.stack.cards/base/" >> $GITHUB_ENV
             echo "MATRIX_URL=https://matrix-staging.stack.cards" >> $GITHUB_ENV

--- a/.github/workflows/deploy-host.yml
+++ b/.github/workflows/deploy-host.yml
@@ -31,7 +31,6 @@ jobs:
             echo "AWS_ROLE_ARN=arn:aws:iam::120317779495:role/boxel-host" >> $GITHUB_ENV
             echo "AWS_S3_BUCKET=cardstack-boxel-host-production" >> $GITHUB_ENV
             echo "AWS_CLOUDFRONT_DISTRIBUTION=EIY7A542TLTVQ" >> $GITHUB_ENV
-            echo "DISABLE_MATRIX_REALM_EVENTS=true" >> $GITHUB_ENV
           elif [ "$INPUT_ENVIRONMENT" = "staging" ]; then
             echo "AWS_ROLE_ARN=arn:aws:iam::680542703984:role/boxel-host" >> $GITHUB_ENV
             echo "AWS_S3_BUCKET=cardstack-boxel-host-staging" >> $GITHUB_ENV

--- a/packages/realm-server/scripts/start-production.sh
+++ b/packages/realm-server/scripts/start-production.sh
@@ -6,7 +6,6 @@ pnpm setup:catalog-in-deployment
 NODE_NO_WARNINGS=1 \
   MATRIX_URL=https://matrix.boxel.ai \
   REALM_SERVER_MATRIX_USERNAME=realm_server \
-  DISABLE_MATRIX_REALM_EVENTS=true \
   ts-node \
   --transpileOnly main \
   --port=3000 \


### PR DESCRIPTION
This doesn’t remove the feature flag in case we need to switch back to SSE.

There were [three “new” Percy snapshots](https://percy.io/Cardstack-1/web/-cardstack-host/builds/39506875/changed/2134793452?browser=firefox&browser_ids=64%2C65&group_snapshots_by=similar_diff&subcategories=unreviewed%2Cchanges_requested&utm_source=github_status_private&viewLayout=overlay&viewMode=new&width=1280&widths=1280) that I approved, spurious removals must have been approved…?