### PR TITLE
matrix: Remove filesystem calls in tests

### DIFF
--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -805,3 +805,82 @@ export function decodeFromAlphanumeric(encodedString: string) {
   const base64 = encodedString.replace(/-/g, '+').replace(/_/g, '/');
   return Buffer.from(base64, 'base64').toString('utf8');
 }
+
+export async function postNewCard(
+  page: Page,
+  realmURL: string,
+  cardData: any,
+): Promise<string> {
+  const cardId = await page.evaluate(
+    async ({ realmURL, cardData }) => {
+      let token = JSON.parse(localStorage['boxel-session'])[realmURL];
+
+      let newCardResponse = await fetch(`${realmURL}`, {
+        headers: {
+          accept: 'application/vnd.card+json',
+          authorization: token,
+        },
+        body: JSON.stringify(cardData),
+        method: 'POST',
+        mode: 'cors',
+        credentials: 'include',
+      });
+
+      let newCard = await newCardResponse.json();
+      return newCard?.data?.id;
+    },
+    { realmURL, cardData },
+  );
+
+  return cardId;
+}
+
+export async function postCardSource(
+  page: Page,
+  realmURL: string,
+  filePath: string,
+  source: string,
+): Promise<void> {
+  await page.evaluate(
+    async ({ realmURL, filePath, source }) => {
+      let token = JSON.parse(localStorage['boxel-session'])[realmURL];
+
+      await fetch(`${realmURL}${filePath}`, {
+        headers: {
+          accept: 'application/vnd.card+source',
+          authorization: token,
+        },
+        body: source,
+        method: 'POST',
+        mode: 'cors',
+        credentials: 'include',
+      });
+    },
+    { realmURL, filePath, source },
+  );
+}
+
+export async function patchCard(
+  page: Page,
+  realmURL: string,
+  cardURL: string,
+  cardData: any,
+): Promise<void> {
+  await page.evaluate(
+    async ({ realmURL, cardURL, cardData }) => {
+      let token = JSON.parse(localStorage['boxel-session'])[realmURL];
+
+      await fetch(cardURL, {
+        headers: {
+          accept: 'application/vnd.card+json',
+          authorization: token,
+        },
+        body: JSON.stringify(cardData),
+        method: 'PATCH',
+        mode: 'cors',
+        credentials: 'include',
+      });
+    },
+    { realmURL, cardURL, cardData },
+  );
+}

--- a/packages/matrix/tests/card-chooser.spec.ts
+++ b/packages/matrix/tests/card-chooser.spec.ts
@@ -1,6 +1,4 @@
 import { test, expect, type Page } from '@playwright/test';
-import { writeJSONSync } from 'fs-extra';
-import { join } from 'path';
 import {
   synapseStart,
   synapseStop,
@@ -19,6 +17,7 @@ import {
   registerRealmUsers,
   showAllCards,
   setupUserSubscribed,
+  postNewCard,
 } from '../helpers';
 
 test.describe('Card Chooser', () => {
@@ -29,6 +28,9 @@ test.describe('Card Chooser', () => {
   const realm1URL = new URL(`user1/${realm1Name}/`, serverIndexUrl).href;
   const realm2Name = 'realm2';
   const realm2URL = new URL(`user1/${realm2Name}/`, serverIndexUrl).href;
+
+  let consumingCardURL: string;
+  let linkedCardURL: string;
 
   async function setupRealms(page: Page) {
     await clearLocalStorage(page, serverIndexUrl);
@@ -41,18 +43,12 @@ test.describe('Card Chooser', () => {
     await createRealm(page, realm2Name);
     await page.goto(realm1URL);
     await showAllCards(page);
-    let consumingCardPath = join(
-      realmServer.realmPath,
-      '..',
-      'user1',
-      realm1Name,
-      'consumer.json',
-    );
-    writeJSONSync(consumingCardPath, {
+
+    consumingCardURL = await postNewCard(page, realm1URL, {
       data: {
         type: 'card',
         attributes: {
-          title: 'Friend Consumer',
+          firstName: 'Friend Consumer',
           description: 'This is a test card instance.',
         },
         meta: {
@@ -63,18 +59,12 @@ test.describe('Card Chooser', () => {
         },
       },
     });
-    let linkedCardPath = join(
-      realmServer.realmPath,
-      '..',
-      'user1',
-      realm2Name,
-      'link.json',
-    );
-    writeJSONSync(linkedCardPath, {
+
+    linkedCardURL = await postNewCard(page, realm1URL, {
       data: {
         type: 'card',
         attributes: {
-          title: 'Friend Link',
+          firstName: 'Friend Link',
           description: 'This is a test card instance.',
         },
         meta: {
@@ -85,11 +75,12 @@ test.describe('Card Chooser', () => {
         },
       },
     });
+
     await expect(
-      page.locator(`[data-test-cards-grid-item="${realm1URL}consumer"]`),
+      page.locator(`[data-test-cards-grid-item="${consumingCardURL}"]`),
     ).toHaveCount(1);
     await page
-      .locator(`[data-test-cards-grid-item="${realm1URL}consumer"]`)
+      .locator(`[data-test-cards-grid-item="${consumingCardURL}"]`)
       .click();
   }
 
@@ -119,7 +110,7 @@ test.describe('Card Chooser', () => {
 
     await page
       .locator(
-        `[data-test-stack-card="${realm1URL}consumer"] [data-test-edit-button]`,
+        `[data-test-stack-card="${consumingCardURL}"] [data-test-edit-button]`,
       )
       .click();
     await page.locator('[data-test-add-new]').click();
@@ -149,18 +140,18 @@ test.describe('Card Chooser', () => {
       .click();
     await expect(
       page.locator(
-        `[data-test-stack-card="${realm1URL}consumer"] [data-test-links-to-editor="friend"]`,
+        `[data-test-stack-card="${consumingCardURL}"] [data-test-links-to-editor="friend"]`,
       ),
     ).toContainText('Mango');
 
     // revisit the card again to make sure the linked card value loads from the index
-    await page.goto(`${realm1URL}consumer`);
+    await page.goto(`${consumingCardURL}`);
     await expect(
-      page.locator(`[data-test-stack-card="${realm1URL}consumer"]`),
+      page.locator(`[data-test-stack-card="${consumingCardURL}"]`),
     ).toHaveCount(1);
     await expect(
       page.locator(
-        `[data-test-stack-card="${realm1URL}consumer"] [data-test-field="friend"]`,
+        `[data-test-stack-card="${consumingCardURL}"] [data-test-field="friend"]`,
       ),
     ).toContainText('Mango');
   });
@@ -172,36 +163,36 @@ test.describe('Card Chooser', () => {
 
     await page
       .locator(
-        `[data-test-stack-card="${realm1URL}consumer"] [data-test-edit-button]`,
+        `[data-test-stack-card="${consumingCardURL}"] [data-test-edit-button]`,
       )
       .click();
     await page.locator('[data-test-add-new]').click();
     await expect(
-      page.locator(`[data-test-select="${realm2URL}link"]`),
+      page.locator(`[data-test-select="${linkedCardURL}"]`),
     ).toHaveCount(1);
-    await page.locator(`[data-test-select="${realm2URL}link"]`).click();
+    await page.locator(`[data-test-select="${linkedCardURL}"]`).click();
     await page.locator(`[data-test-card-catalog-go-button]`).click();
     await expect(page.locator('[data-test-card-catalog-modal]')).toHaveCount(0);
 
     await expect(
       page.locator(
-        `[data-test-stack-card="${realm1URL}consumer"] [data-test-last-saved]`,
+        `[data-test-stack-card="${consumingCardURL}"] [data-test-last-saved]`,
       ),
     ).toHaveCount(1);
     await expect(
       page.locator(
-        `[data-test-stack-card="${realm1URL}consumer"] [data-test-links-to-editor="friend"]`,
+        `[data-test-stack-card="${consumingCardURL}"] [data-test-links-to-editor="friend"]`,
       ),
     ).toContainText('Friend Link');
 
     // revisit the card again to make sure the linked card value loads from the index
-    await page.goto(`${realm1URL}consumer`);
+    await page.goto(`${consumingCardURL}`);
     await expect(
-      page.locator(`[data-test-stack-card="${realm1URL}consumer"]`),
+      page.locator(`[data-test-stack-card="${consumingCardURL}"]`),
     ).toHaveCount(1);
     await expect(
       page.locator(
-        `[data-test-stack-card="${realm1URL}consumer"] [data-test-field="friend"]`,
+        `[data-test-stack-card="${consumingCardURL}"] [data-test-field="friend"]`,
       ),
     ).toContainText('Friend Link');
   });

--- a/packages/matrix/tests/live-cards.spec.ts
+++ b/packages/matrix/tests/live-cards.spec.ts
@@ -1,6 +1,4 @@
 import { test, expect } from '@playwright/test';
-import { writeJSONSync, writeFileSync } from 'fs-extra';
-import { join } from 'path';
 import {
   synapseStart,
   synapseStop,
@@ -19,6 +17,9 @@ import {
   registerRealmUsers,
   showAllCards,
   setupUserSubscribed,
+  patchCard,
+  postCardSource,
+  postNewCard,
 } from '../helpers';
 
 test.describe('Live Cards', () => {
@@ -65,39 +66,39 @@ test.describe('Live Cards', () => {
     ).toContainText('Some folks say');
 
     // assert that instance updates are live bound
-    let helloWorldPath = join(
-      realmServer.realmPath,
-      '..',
-      'user1',
-      realmName,
-      'HelloWorld/47c0fc54-5099-4e9c-ad0d-8a58572d05c0.json',
-    );
     await expect(
       page.locator('[data-test-realm-indexing-indicator]'),
     ).toHaveCount(0);
-    writeJSONSync(helloWorldPath, {
-      data: {
-        type: 'card',
-        attributes: {
-          fullName: 'Hello Mars',
-          heroUrl:
-            'https://boxel-images.boxel.ai/app-assets/hello-world/beach-volley-hero.jpg',
-          headshotUrl:
-            'https://boxel-images.boxel.ai/app-assets/hello-world/luke-vb-headshot.jpg',
-          bio: 'Luke Melia is a beach volleyball player living in downtown New York City. He is a left-side defender with a good serve and good court sense. What Luke lacks in height, he makes up in heart and craftiness.\n\nOutside of playing beach volleyball, Luke enjoys watching professional beach volleyball, primarily the AVP (the American domestic pro tour) and the FIVB (the world tour). He also enjoys surfing, skateboarding, parkour, and rock climbing.\n\nWhen Luke is not competing or challenging himself physically, he is usually writing code or creating digital products. His languages of choice are Ruby and Javascript.\n\nLuke lives in New York City with his wife and two daughters.',
-          quote:
-            "Some folks say I was born on the wrong coast, that I live a West Coast lifestyle in New York City. But I've found a way to integrate beach volleyball into my life as a New Yorker. I've been lucky enough to play plenty outside of New York, too, from Cali to Bali to Thailand and lots of spots in between. I guess you could say I'm poly-coastal!",
-          description: null,
-          thumbnailURL: null,
-        },
-        meta: {
-          adoptsFrom: {
-            module: '../hello-world',
-            name: 'HelloWorld',
+
+    await patchCard(
+      page,
+      realmURL,
+      `${realmURL}HelloWorld/47c0fc54-5099-4e9c-ad0d-8a58572d05c0`,
+      {
+        data: {
+          type: 'card',
+          attributes: {
+            fullName: 'Hello Mars',
+            heroUrl:
+              'https://boxel-images.boxel.ai/app-assets/hello-world/beach-volley-hero.jpg',
+            headshotUrl:
+              'https://boxel-images.boxel.ai/app-assets/hello-world/luke-vb-headshot.jpg',
+            bio: 'Luke Melia is a beach volleyball player living in downtown New York City. He is a left-side defender with a good serve and good court sense. What Luke lacks in height, he makes up in heart and craftiness.\n\nOutside of playing beach volleyball, Luke enjoys watching professional beach volleyball, primarily the AVP (the American domestic pro tour) and the FIVB (the world tour). He also enjoys surfing, skateboarding, parkour, and rock climbing.\n\nWhen Luke is not competing or challenging himself physically, he is usually writing code or creating digital products. His languages of choice are Ruby and Javascript.\n\nLuke lives in New York City with his wife and two daughters.',
+            quote:
+              "Some folks say I was born on the wrong coast, that I live a West Coast lifestyle in New York City. But I've found a way to integrate beach volleyball into my life as a New Yorker. I've been lucky enough to play plenty outside of New York, too, from Cali to Bali to Thailand and lots of spots in between. I guess you could say I'm poly-coastal!",
+            description: null,
+            thumbnailURL: null,
+          },
+          meta: {
+            adoptsFrom: {
+              module: '../hello-world',
+              name: 'HelloWorld',
+            },
           },
         },
       },
-    });
+    );
+
     await expect(
       page.locator('[data-test-realm-indexing-indicator]'),
     ).toHaveCount(1);
@@ -114,15 +115,10 @@ test.describe('Live Cards', () => {
     await page.goto(realmURL);
     await showAllCards(page);
 
-    let cardDefPath = join(
-      realmServer.realmPath,
-      '..',
-      'user1',
-      realmName,
+    await postCardSource(
+      page,
+      realmURL,
       'sample-card.gts',
-    );
-    writeFileSync(
-      cardDefPath,
       `
       import { CardDef, field, contains, StringField } from 'https://cardstack.com/base/card-api';
       import { Component } from 'https://cardstack.com/base/card-api';
@@ -135,14 +131,8 @@ test.describe('Live Cards', () => {
         };
       }`,
     );
-    let instancePath = join(
-      realmServer.realmPath,
-      '..',
-      'user1',
-      realmName,
-      'test.json',
-    );
-    writeJSONSync(instancePath, {
+
+    let newCardURL = await postNewCard(page, realmURL, {
       data: {
         type: 'card',
         attributes: {
@@ -151,7 +141,7 @@ test.describe('Live Cards', () => {
         },
         meta: {
           adoptsFrom: {
-            module: './sample-card',
+            module: '../sample-card',
             name: 'SampleCard',
           },
         },
@@ -159,30 +149,33 @@ test.describe('Live Cards', () => {
     });
 
     await expect(
-      page.locator(`[data-test-cards-grid-item="${realmURL}test"]`),
+      page.locator(`[data-test-cards-grid-item="${newCardURL}"]`),
     ).toHaveCount(1);
-    await page.locator(`[data-test-cards-grid-item="${realmURL}test"]`).click();
+    await page.locator(`[data-test-cards-grid-item="${newCardURL}"]`).click();
     await expect(
-      page.locator(`[data-test-stack-card="${realmURL}test"]`),
+      page.locator(`[data-test-stack-card="${newCardURL}"]`),
     ).toContainText('Hello Mango');
 
     // assert that instances that consume updated modules are live bound
-    writeFileSync(
-      cardDefPath,
+    await postCardSource(
+      page,
+      realmURL,
+      `${realmURL}sample-card.gts`,
       `
-      import { CardDef, field, contains, StringField } from 'https://cardstack.com/base/card-api';
-      import { Component } from 'https://cardstack.com/base/card-api';
-      export class SampleCard extends CardDef {
-        @field name = contains(StringField);
-        static isolated = class Isolated extends Component<typeof this> {
-          <template>
-            Hello <@fields.name /> !!!!
-          </template>
-        };
-      }`,
+          import { CardDef, field, contains, StringField } from 'https://cardstack.com/base/card-api';
+          import { Component } from 'https://cardstack.com/base/card-api';
+          export class SampleCard extends CardDef {
+            @field name = contains(StringField);
+            static isolated = class Isolated extends Component<typeof this> {
+              <template>
+                Hello <@fields.name /> !!!!
+              </template>
+            };
+          }`,
     );
+
     await expect(
-      page.locator(`[data-test-stack-card="${realmURL}test"]`),
+      page.locator(`[data-test-stack-card="${newCardURL}"]`),
     ).toContainText('Hello Mango !!!!');
 
     // assert that code mode file tree is live bound
@@ -197,15 +190,10 @@ test.describe('Live Cards', () => {
       )}`,
     );
     await expect(page.locator('[data-test-file="index.json"]')).toHaveCount(1);
-    await expect(page.locator('[data-test-file="hello.txt"]')).toHaveCount(0);
-    let instance2Path = join(
-      realmServer.realmPath,
-      '..',
-      'user1',
-      realmName,
-      'hello.txt',
-    );
-    writeFileSync(instance2Path, 'hi');
-    await expect(page.locator('[data-test-file="hello.txt"]')).toHaveCount(1);
+    await expect(page.locator('[data-test-file="hello.gts"]')).toHaveCount(0);
+
+    await postCardSource(page, realmURL, 'hello.gts', '// hi');
+
+    await expect(page.locator('[data-test-file="hello.gts"]')).toHaveCount(1);
   });
 });

--- a/packages/matrix/tests/live-cards.spec.ts
+++ b/packages/matrix/tests/live-cards.spec.ts
@@ -160,7 +160,7 @@ test.describe('Live Cards', () => {
     await postCardSource(
       page,
       realmURL,
-      `${realmURL}sample-card.gts`,
+      `sample-card.gts`,
       `
           import { CardDef, field, contains, StringField } from 'https://cardstack.com/base/card-api';
           import { Component } from 'https://cardstack.com/base/card-api';


### PR DESCRIPTION
This is extracted from #2356 as it’s self-contained. Since file-watching will become development-only, most tests should no longer rely on watcher-produced realm events, instead they should make changes via API endpoints.