### PR TITLE
Remove redundant calls to shimExternals

### DIFF
--- a/packages/realm-server/tests/realm-endpoints-test.ts
+++ b/packages/realm-server/tests/realm-endpoints-test.ts
@@ -33,7 +33,6 @@ import {
   waitUntil,
 } from './helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
-import { shimExternals } from '../lib/externals';
 import { RealmServer } from '../server';
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
 import { MatrixClient } from '@cardstack/runtime-common/matrix-client';
@@ -199,10 +198,6 @@ module(basename(__filename), function () {
     hooks.afterEach(async function () {
       await closeServer(testRealmHttpServer);
       resetCatalogRealms();
-    });
-
-    hooks.beforeEach(async function () {
-      shimExternals(virtualNetwork);
     });
 
     setupPermissionedRealm(hooks, {

--- a/packages/realm-server/tests/server-endpoints-test.ts
+++ b/packages/realm-server/tests/server-endpoints-test.ts
@@ -38,7 +38,6 @@ import {
   insertJob,
 } from './helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
-import { shimExternals } from '../lib/externals';
 import { RealmServer } from '../server';
 import { MatrixClient } from '@cardstack/runtime-common/matrix-client';
 import jwt from 'jsonwebtoken';
@@ -155,10 +154,6 @@ module(basename(__filename), function () {
         let request2: SuperTest<Test>;
         let testRealmDir: string;
         let seedRealm: Realm | undefined;
-
-        hooks.beforeEach(async function () {
-          shimExternals(virtualNetwork);
-        });
 
         setupPermissionedRealm(hooks, {
           '*': ['read', 'write'],
@@ -1133,7 +1128,6 @@ module(basename(__filename), function () {
         });
 
         hooks.beforeEach(async function () {
-          shimExternals(virtualNetwork);
           let stripe = getStripe();
           createSubscriptionStub = sinon.stub(stripe.subscriptions, 'create');
           fetchPriceListStub = sinon.stub(stripe.prices, 'list');
@@ -1685,10 +1679,6 @@ module(basename(__filename), function () {
       module('_queue-status', function (hooks) {
         setupPermissionedRealm(hooks, {
           '*': ['read', 'write'],
-        });
-
-        hooks.beforeEach(async function () {
-          shimExternals(virtualNetwork);
         });
 
         test('returns 200 with JSON-API doc', async function (assert) {

--- a/packages/realm-server/tests/types-endpoint-test.ts
+++ b/packages/realm-server/tests/types-endpoint-test.ts
@@ -25,7 +25,6 @@ import {
   closeServer,
 } from './helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
-import { shimExternals } from '../lib/externals';
 import { MatrixClient } from '@cardstack/runtime-common/matrix-client';
 import { type PgAdapter } from '@cardstack/postgres';
 import { resetCatalogRealms } from '../handlers/handle-fetch-catalog-realms';
@@ -162,10 +161,6 @@ module(basename(__filename), function () {
     hooks.afterEach(async function () {
       await closeServer(testRealmHttpServer);
       resetCatalogRealms();
-    });
-
-    hooks.beforeEach(async function () {
-      shimExternals(virtualNetwork);
     });
 
     setupPermissionedRealm(hooks, {


### PR DESCRIPTION
In these tests, we already shimExternals in the factory method that creates the VirtualNetwork for us