### PR TITLE
realm: Extract realm server test duplication

### DIFF
--- a/packages/realm-server/tests/card-endpoints-test.ts
+++ b/packages/realm-server/tests/card-endpoints-test.ts
@@ -1,16 +1,15 @@
 import { module, test } from 'qunit';
-import supertest, { Test, SuperTest } from 'supertest';
-import { join, resolve, basename } from 'path';
+import { Test, SuperTest } from 'supertest';
+import { join, basename } from 'path';
 import { Server } from 'http';
-import { dirSync, setGracefulCleanup, type DirResult } from 'tmp';
+import { type DirResult } from 'tmp';
 import { validate as uuidValidate } from 'uuid';
-import { copySync, existsSync, ensureDirSync, readJSONSync } from 'fs-extra';
+import { existsSync, readJSONSync } from 'fs-extra';
 import {
   isSingleCardDocument,
   baseRealm,
   Realm,
   RealmPermissions,
-  type LooseSingleCardDocument,
 } from '@cardstack/runtime-common';
 import { stringify } from 'qs';
 import { Query } from '@cardstack/runtime-common/query';
@@ -18,16 +17,15 @@ import {
   findRealmEvent,
   setupCardLogs,
   setupBaseRealmServer,
-  runTestRealmServer,
-  setupDB,
+  setupPermissionedRealm,
   setupMatrixRoom,
-  createVirtualNetwork,
   createVirtualNetworkAndLoader,
   matrixURL,
   closeServer,
   testRealmInfo,
   cleanWhiteSpace,
   waitUntil,
+  testRealmHref,
 } from './helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 import { resetCatalogRealms } from '../handlers/handle-fetch-catalog-realms';
@@ -36,12 +34,6 @@ import type {
   IncrementalIndexEventContent,
   MatrixEvent,
 } from 'https://cardstack.com/base/matrix-event';
-
-setGracefulCleanup();
-const testRealmURL = new URL('http://127.0.0.1:4444/');
-const testRealmHref = testRealmURL.href;
-const distDir = resolve(join(__dirname, '..', '..', 'host', 'dist'));
-console.log(`using host dist dir: ${distDir}`);
 
 let createJWT = (
   realm: Realm,
@@ -66,53 +58,26 @@ module(basename(__filename), function () {
     let request: SuperTest<Test>;
     let dir: DirResult;
 
-    function setTestRequest(newRequest: SuperTest<Test>) {
-      request = newRequest;
+    function onRealmSetup(args: {
+      testRealm: Realm;
+      testRealmHttpServer: Server;
+      request: SuperTest<Test>;
+      dir: DirResult;
+    }) {
+      testRealm = args.testRealm;
+      testRealmHttpServer = args.testRealmHttpServer;
+      request = args.request;
+      dir = args.dir;
     }
 
-    function getTestRequest() {
-      return request;
+    function getRealmSetup() {
+      return {
+        testRealm,
+        testRealmHttpServer,
+        request,
+        dir,
+      };
     }
-
-    function setupPermissionedRealm(
-      hooks: NestedHooks,
-      permissions: RealmPermissions,
-      setTestRequest: (newRequest: SuperTest<Test>) => void,
-      fileSystem?: Record<string, string | LooseSingleCardDocument>,
-    ) {
-      setupDB(hooks, {
-        beforeEach: async (_dbAdapter, publisher, runner) => {
-          dir = dirSync();
-          let testRealmDir = join(dir.name, 'realm_server_1', 'test');
-          ensureDirSync(testRealmDir);
-          // If a fileSystem is provided, use it to populate the test realm, otherwise copy the default cards
-          if (!fileSystem) {
-            copySync(join(__dirname, 'cards'), testRealmDir);
-          }
-
-          let virtualNetwork = createVirtualNetwork();
-
-          ({ testRealm, testRealmHttpServer } = await runTestRealmServer({
-            virtualNetwork,
-            testRealmDir,
-            realmsRootPath: join(dir.name, 'realm_server_1'),
-            realmURL: testRealmURL,
-            permissions,
-            dbAdapter: _dbAdapter,
-            runner,
-            publisher,
-            matrixURL,
-            fileSystem,
-          }));
-
-          setTestRequest(supertest(testRealmHttpServer));
-        },
-      });
-    }
-
-    hooks.beforeEach(function () {
-      request = getTestRequest();
-    });
 
     let { virtualNetwork, loader } = createVirtualNetworkAndLoader();
 
@@ -123,11 +88,6 @@ module(basename(__filename), function () {
 
     setupBaseRealmServer(hooks, virtualNetwork, matrixURL);
 
-    hooks.beforeEach(async function () {
-      dir = dirSync();
-      copySync(join(__dirname, 'cards'), dir.name);
-    });
-
     hooks.afterEach(async function () {
       await closeServer(testRealmHttpServer);
       resetCatalogRealms();
@@ -135,13 +95,12 @@ module(basename(__filename), function () {
 
     module('card GET request', function (_hooks) {
       module('public readable realm', function (hooks) {
-        setupPermissionedRealm(
-          hooks,
-          {
+        setupPermissionedRealm(hooks, {
+          permissions: {
             '*': ['read'],
           },
-          setTestRequest,
-        );
+          onRealmSetup,
+        });
 
         test('serves the request', async function (assert) {
           let response = await request
@@ -155,7 +114,7 @@ module(basename(__filename), function () {
           delete json.data.meta.resourceCreatedAt;
           assert.strictEqual(
             response.get('X-boxel-realm-url'),
-            testRealmURL.href,
+            testRealmHref,
             'realm url header is correct',
           );
           assert.strictEqual(
@@ -183,7 +142,7 @@ module(basename(__filename), function () {
                   ...testRealmInfo,
                   realmUserId: '@node-test_realm:localhost',
                 },
-                realmURL: testRealmURL.href,
+                realmURL: testRealmHref,
               },
               links: {
                 self: `${testRealmHref}person-1`,
@@ -201,7 +160,7 @@ module(basename(__filename), function () {
           let json = response.body;
           assert.strictEqual(
             response.get('X-boxel-realm-url'),
-            testRealmURL.href,
+            testRealmHref,
             'realm url header is correct',
           );
           assert.strictEqual(
@@ -230,13 +189,12 @@ module(basename(__filename), function () {
 
       // using public writable realm to make it easy for test setup for the error tests
       module('public writable realm', function (hooks) {
-        setupPermissionedRealm(
-          hooks,
-          {
+        setupPermissionedRealm(hooks, {
+          permissions: {
             '*': ['read', 'write'],
           },
-          setTestRequest,
-        );
+          onRealmSetup,
+        });
 
         test('serves a card error request with last known good state', async function (assert) {
           await request
@@ -269,7 +227,7 @@ module(basename(__filename), function () {
           let json = response.body;
           assert.strictEqual(
             response.get('X-boxel-realm-url'),
-            testRealmURL.href,
+            testRealmHref,
             'realm url header is correct',
           );
           assert.strictEqual(
@@ -302,13 +260,12 @@ module(basename(__filename), function () {
       });
 
       module('permissioned realm', function (hooks) {
-        setupPermissionedRealm(
-          hooks,
-          {
+        setupPermissionedRealm(hooks, {
+          permissions: {
             john: ['read'],
           },
-          setTestRequest,
-        );
+          onRealmSetup,
+        });
 
         test('401 with invalid JWT', async function (assert) {
           let response = await request
@@ -372,15 +329,14 @@ module(basename(__filename), function () {
 
     module('card POST request', function (_hooks) {
       module('public writable realm', function (hooks) {
-        setupPermissionedRealm(
-          hooks,
-          {
+        setupPermissionedRealm(hooks, {
+          permissions: {
             '*': ['read', 'write'],
           },
-          setTestRequest,
-        );
+          onRealmSetup,
+        });
 
-        let { getMessagesSince } = setupMatrixRoom(hooks, getTestRequest);
+        let { getMessagesSince } = setupMatrixRoom(hooks, getRealmSetup);
 
         test('serves the request', async function (assert) {
           let id: string | undefined;
@@ -418,7 +374,7 @@ module(basename(__filename), function () {
           assert.true(uuidValidate(id!), 'card identifier is a UUID');
           assert.strictEqual(
             incrementalEvent.invalidations[0],
-            `${testRealmURL}CardDef/${id}`,
+            `${testRealmHref}CardDef/${id}`,
           );
 
           if (!id) {
@@ -427,7 +383,7 @@ module(basename(__filename), function () {
           assert.strictEqual(response.status, 201, 'HTTP 201 status');
           assert.strictEqual(
             response.get('X-boxel-realm-url'),
-            testRealmURL.href,
+            testRealmHref,
             'realm url header is correct',
           );
           assert.strictEqual(
@@ -481,13 +437,12 @@ module(basename(__filename), function () {
       });
 
       module('permissioned realm', function (hooks) {
-        setupPermissionedRealm(
-          hooks,
-          {
+        setupPermissionedRealm(hooks, {
+          permissions: {
             john: ['read', 'write'],
           },
-          setTestRequest,
-        );
+          onRealmSetup,
+        });
 
         test('401 with invalid JWT', async function (assert) {
           let response = await request
@@ -559,15 +514,14 @@ module(basename(__filename), function () {
 
     module('card PATCH request', function (_hooks) {
       module('public writable realm', function (hooks) {
-        setupPermissionedRealm(
-          hooks,
-          {
+        setupPermissionedRealm(hooks, {
+          permissions: {
             '*': ['read', 'write'],
           },
-          setTestRequest,
-        );
+          onRealmSetup,
+        });
 
-        let { getMessagesSince } = setupMatrixRoom(hooks, getTestRequest);
+        let { getMessagesSince } = setupMatrixRoom(hooks, getRealmSetup);
 
         test('serves the request', async function (assert) {
           let entry = 'person-1.json';
@@ -593,7 +547,7 @@ module(basename(__filename), function () {
           assert.strictEqual(response.status, 200, 'HTTP 200 status');
           assert.strictEqual(
             response.get('X-boxel-realm-url'),
-            testRealmURL.href,
+            testRealmHref,
             'realm url header is correct',
           );
           assert.strictEqual(
@@ -704,26 +658,25 @@ module(basename(__filename), function () {
           assert.deepEqual(incrementalIndexInitiationEvent!.content, {
             eventName: 'index',
             indexType: 'incremental-index-initiation',
-            updatedFile: `${testRealmURL}person-1.json`,
+            updatedFile: `${testRealmHref}person-1.json`,
           });
 
           assert.deepEqual(incrementalEvent!.content, {
             eventName: 'index',
             indexType: 'incremental',
-            invalidations: [`${testRealmURL}person-1`],
+            invalidations: [`${testRealmHref}person-1`],
             clientRequestId: null,
           });
         });
       });
 
       module('permissioned realm', function (hooks) {
-        setupPermissionedRealm(
-          hooks,
-          {
+        setupPermissionedRealm(hooks, {
+          permissions: {
             john: ['read', 'write'],
           },
-          setTestRequest,
-        );
+          onRealmSetup,
+        });
 
         test('401 with invalid JWT', async function (assert) {
           let response = await request
@@ -788,15 +741,14 @@ module(basename(__filename), function () {
 
     module('card DELETE request', function (_hooks) {
       module('public writable realm', function (hooks) {
-        setupPermissionedRealm(
-          hooks,
-          {
+        setupPermissionedRealm(hooks, {
+          permissions: {
             '*': ['read', 'write'],
           },
-          setTestRequest,
-        );
+          onRealmSetup,
+        });
 
-        let { getMessagesSince } = setupMatrixRoom(hooks, getTestRequest);
+        let { getMessagesSince } = setupMatrixRoom(hooks, getRealmSetup);
 
         test('serves the request', async function (assert) {
           let entry = 'person-1.json';
@@ -808,7 +760,7 @@ module(basename(__filename), function () {
           assert.strictEqual(response.status, 204, 'HTTP 204 status');
           assert.strictEqual(
             response.get('X-boxel-realm-url'),
-            testRealmURL.href,
+            testRealmHref,
             'realm url header is correct',
           );
           assert.strictEqual(
@@ -848,13 +800,13 @@ module(basename(__filename), function () {
           assert.deepEqual(incrementalIndexInitiationEvent!.content, {
             eventName: 'index',
             indexType: 'incremental-index-initiation',
-            updatedFile: `${testRealmURL}person-1.json`,
+            updatedFile: `${testRealmHref}person-1.json`,
           });
 
           assert.deepEqual(incrementalEvent!.content, {
             eventName: 'index',
             indexType: 'incremental',
-            invalidations: [`${testRealmURL}person-1`],
+            invalidations: [`${testRealmHref}person-1`],
           });
         });
 
@@ -868,7 +820,7 @@ module(basename(__filename), function () {
           assert.strictEqual(response.status, 204, 'HTTP 204 status');
           assert.strictEqual(
             response.get('X-boxel-realm-url'),
-            testRealmURL.href,
+            testRealmHref,
             'realm url header is correct',
           );
           assert.strictEqual(
@@ -882,13 +834,12 @@ module(basename(__filename), function () {
       });
 
       module('permissioned realm', function (hooks) {
-        setupPermissionedRealm(
-          hooks,
-          {
+        setupPermissionedRealm(hooks, {
+          permissions: {
             john: ['read', 'write'],
           },
-          setTestRequest,
-        );
+          onRealmSetup,
+        });
 
         test('401 with invalid JWT', async function (assert) {
           let response = await request

--- a/packages/realm-server/tests/card-endpoints-test.ts
+++ b/packages/realm-server/tests/card-endpoints-test.ts
@@ -9,7 +9,6 @@ import {
   isSingleCardDocument,
   baseRealm,
   Realm,
-  RealmPermissions,
 } from '@cardstack/runtime-common';
 import { stringify } from 'qs';
 import { Query } from '@cardstack/runtime-common/query';
@@ -26,6 +25,7 @@ import {
   cleanWhiteSpace,
   waitUntil,
   testRealmHref,
+  createJWT,
 } from './helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 import { resetCatalogRealms } from '../handlers/handle-fetch-catalog-realms';
@@ -34,22 +34,6 @@ import type {
   IncrementalIndexEventContent,
   MatrixEvent,
 } from 'https://cardstack.com/base/matrix-event';
-
-let createJWT = (
-  realm: Realm,
-  user: string,
-  permissions: RealmPermissions['user'] = [],
-) => {
-  return realm.createJWT(
-    {
-      user,
-      realm: realm.url,
-      permissions,
-      sessionRoom: `test-session-room-for-${user}`,
-    },
-    '7d',
-  );
-};
 
 module(basename(__filename), function () {
   module('Realm-specific Endpoints | card URLs', function (hooks) {

--- a/packages/realm-server/tests/card-source-endpoints-test.ts
+++ b/packages/realm-server/tests/card-source-endpoints-test.ts
@@ -12,7 +12,6 @@ import {
   baseRealm,
   RealmPaths,
   Realm,
-  RealmPermissions,
   type LooseSingleCardDocument,
 } from '@cardstack/runtime-common';
 import {
@@ -25,6 +24,7 @@ import {
   waitUntil,
   testRealmHref,
   testRealmURL,
+  createJWT,
 } from './helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 import stripScopedCSSGlimmerAttributes from '@cardstack/runtime-common/helpers/strip-scoped-css-glimmer-attributes';
@@ -36,22 +36,6 @@ import type {
   RealmEventContent,
 } from 'https://cardstack.com/base/matrix-event';
 import isEqual from 'lodash/isEqual';
-
-let createJWT = (
-  realm: Realm,
-  user: string,
-  permissions: RealmPermissions['user'] = [],
-) => {
-  return realm.createJWT(
-    {
-      user,
-      realm: realm.url,
-      permissions,
-      sessionRoom: `test-session-room-for-${user}`,
-    },
-    '7d',
-  );
-};
 
 module(basename(__filename), function () {
   module('Realm-specific Endpoints | card source requests', function (hooks) {

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -828,3 +828,19 @@ export function setupPermissionedRealm(
     resetCatalogRealms();
   });
 }
+
+export function createJWT(
+  realm: Realm,
+  user: string,
+  permissions: RealmPermissions['user'] = [],
+) {
+  return realm.createJWT(
+    {
+      user,
+      realm: realm.url,
+      permissions,
+      sessionRoom: `test-session-room-for-${user}`,
+    },
+    '7d',
+  );
+}

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -1,4 +1,12 @@
-import { writeFileSync, writeJSONSync, readdirSync, statSync } from 'fs-extra';
+import {
+  writeFileSync,
+  writeJSONSync,
+  readdirSync,
+  statSync,
+  ensureDirSync,
+  copySync,
+} from 'fs-extra';
+import eventSource from 'eventsource';
 import { NodeAdapter } from '../../node-realm';
 import { resolve, join } from 'path';
 import {
@@ -25,7 +33,8 @@ import {
   type QueueRunner,
   type IndexRunner,
 } from '@cardstack/runtime-common';
-import { dirSync } from 'tmp';
+import { resetCatalogRealms } from '../../handlers/handle-fetch-catalog-realms';
+import { dirSync, setGracefulCleanup, type DirResult } from 'tmp';
 import { getLocalConfig as getSynapseConfig } from '../../synapse';
 import { makeFastBootIndexRunner } from '../../fastboot';
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
@@ -39,7 +48,7 @@ import { Server } from 'http';
 import { MatrixClient } from '@cardstack/runtime-common/matrix-client';
 import { shimExternals } from '../../lib/externals';
 import { Plan, Subscription, User } from '@cardstack/billing/billing-queries';
-import { SuperTest, Test } from 'supertest';
+import supertest, { SuperTest, Test } from 'supertest';
 import { APP_BOXEL_REALM_EVENT_TYPE } from '@cardstack/runtime-common/matrix-constants';
 import type {
   IncrementalIndexEventContent,
@@ -47,6 +56,11 @@ import type {
   RealmEvent,
   RealmEventContent,
 } from 'https://cardstack.com/base/matrix-event';
+
+const testRealmURL = new URL('http://127.0.0.1:4444/');
+const testRealmHref = testRealmURL.href;
+
+export { testRealmHref, testRealmURL };
 
 export async function waitUntil<T>(
   condition: () => Promise<T>,
@@ -633,7 +647,12 @@ export async function insertJob(
 
 export function setupMatrixRoom(
   hooks: NestedHooks,
-  getTestRequest: () => SuperTest<Test>,
+  getRealmSetup: () => {
+    testRealm: Realm;
+    testRealmHttpServer: Server;
+    request: SuperTest<Test>;
+    dir: DirResult;
+  },
 ) {
   let matrixClient = new MatrixClient({
     matrixURL: realmServerTestMatrix.url,
@@ -647,8 +666,8 @@ export function setupMatrixRoom(
     await matrixClient.login();
     let userId = matrixClient.getUserId()!;
 
-    let response = await getTestRequest()
-      .post('/_server-session')
+    let response = await getRealmSetup()
+      .request.post('/_server-session')
       .send(JSON.stringify({ user: userId }))
       .set('Accept', 'application/json')
       .set('Content-Type', 'application/json');
@@ -666,8 +685,8 @@ export function setupMatrixRoom(
       msgtype: 'm.text',
     });
 
-    response = await getTestRequest()
-      .post('/_server-session')
+    response = await getRealmSetup()
+      .request.post('/_server-session')
       .send(JSON.stringify({ user: userId, challenge: json.challenge }))
       .set('Accept', 'application/json')
       .set('Content-Type', 'application/json');
@@ -719,4 +738,93 @@ function realmEventIsIndex(
   event: RealmEventContent,
 ): event is IncrementalIndexEventContent {
   return event.eventName === 'index';
+}
+
+export function setupPermissionedRealm(
+  hooks: NestedHooks,
+  {
+    permissions,
+    fileSystem,
+    onRealmSetup,
+    subscribeToRealmEvents = false,
+  }: {
+    permissions: RealmPermissions;
+    fileSystem?: Record<string, string | LooseSingleCardDocument>;
+    onRealmSetup?: (args: {
+      dbAdapter: PgAdapter;
+      testRealm: Realm;
+      testRealmPath: string;
+      testRealmHttpServer: Server;
+      request: SuperTest<Test>;
+      dir: DirResult;
+    }) => void;
+    subscribeToRealmEvents?: boolean;
+  },
+) {
+  let testRealmServer: Awaited<ReturnType<typeof runTestRealmServer>>;
+  let testRealmEventSource: eventSource;
+
+  setGracefulCleanup();
+
+  setupDB(hooks, {
+    beforeEach: async (dbAdapter, publisher, runner) => {
+      let dir = dirSync();
+      let testRealmDir = join(dir.name, 'realm_server_1', 'test');
+
+      ensureDirSync(testRealmDir);
+
+      // If a fileSystem is provided, use it to populate the test realm, otherwise copy the default cards
+      if (!fileSystem) {
+        copySync(join(__dirname, '..', 'cards'), testRealmDir);
+      }
+
+      let virtualNetwork = createVirtualNetwork();
+
+      testRealmServer = await runTestRealmServer({
+        virtualNetwork,
+        testRealmDir,
+        realmsRootPath: join(dir.name, 'realm_server_1'),
+        realmURL: testRealmURL,
+        permissions,
+        dbAdapter,
+        runner,
+        publisher,
+        matrixURL,
+        fileSystem,
+        enableFileWatcher: subscribeToRealmEvents,
+      });
+
+      let request = supertest(testRealmServer.testRealmHttpServer);
+
+      if (subscribeToRealmEvents) {
+        testRealmEventSource = new eventSource(
+          `${testRealmHref}_message?testFileWatcher=node`,
+        );
+
+        await new Promise<void>((resolve) => {
+          testRealmEventSource.onopen = () => {
+            resolve();
+          };
+        });
+      }
+
+      onRealmSetup?.({
+        dbAdapter,
+        testRealm: testRealmServer.testRealm,
+        testRealmPath: testRealmServer.testRealmDir,
+        testRealmHttpServer: testRealmServer.testRealmHttpServer,
+        request,
+        dir,
+      });
+    },
+  });
+
+  hooks.afterEach(async function () {
+    if (testRealmEventSource) {
+      testRealmEventSource.close();
+    }
+
+    await closeServer(testRealmServer.testRealmHttpServer);
+    resetCatalogRealms();
+  });
 }

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { dirSync, setGracefulCleanup } from 'tmp';
+import { dirSync } from 'tmp';
 import {
   baseRealm,
   DBAdapter,
@@ -33,8 +33,6 @@ function trimCardContainer(text: string) {
 }
 
 let testDbAdapter: DBAdapter;
-
-setGracefulCleanup();
 
 // Using the node tests for indexing as it is much easier to support the dynamic
 // loading of cards necessary for indexing and the ability to manipulate the

--- a/packages/realm-server/tests/loader-test.ts
+++ b/packages/realm-server/tests/loader-test.ts
@@ -6,7 +6,7 @@ import {
   fetcher,
   maybeHandleScopedCSSRequest,
 } from '@cardstack/runtime-common';
-import { dirSync, setGracefulCleanup, DirResult } from 'tmp';
+import { dirSync, DirResult } from 'tmp';
 import {
   createRealm,
   setupBaseRealmServer,
@@ -14,16 +14,13 @@ import {
   setupDB,
   matrixURL,
   closeServer,
+  testRealmHref,
+  testRealmURL,
 } from './helpers';
 import { copySync } from 'fs-extra';
 import { shimExternals } from '../lib/externals';
 import { Server } from 'http';
 import { join, basename } from 'path';
-
-setGracefulCleanup();
-
-const testRealmURL = new URL('http://127.0.0.1:4444/');
-const testRealmHref = testRealmURL.href;
 
 module(basename(__filename), function () {
   module('loader', function (hooks) {

--- a/packages/realm-server/tests/realm-endpoints-test.ts
+++ b/packages/realm-server/tests/realm-endpoints-test.ts
@@ -8,7 +8,6 @@ import {
   baseRealm,
   loadCard,
   Realm,
-  RealmPermissions,
   type LooseSingleCardDocument,
   type QueuePublisher,
   type QueueRunner,
@@ -35,6 +34,7 @@ import {
   waitUntil,
   testRealmHref,
   testRealmURL,
+  createJWT,
 } from './helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 import { RealmServer } from '../server';
@@ -51,22 +51,6 @@ import type {
 
 const testRealm2URL = new URL('http://127.0.0.1:4445/test/');
 const testRealm2Href = testRealm2URL.href;
-
-let createJWT = (
-  realm: Realm,
-  user: string,
-  permissions: RealmPermissions['user'] = [],
-) => {
-  return realm.createJWT(
-    {
-      user,
-      realm: realm.url,
-      permissions,
-      sessionRoom: `test-session-room-for-${user}`,
-    },
-    '7d',
-  );
-};
 
 module(basename(__filename), function () {
   module('Realm-specific Endpoints', function (hooks) {

--- a/packages/realm-server/tests/realm-endpoints/directory-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/directory-test.ts
@@ -1,33 +1,18 @@
 import { module, test } from 'qunit';
-import supertest, { Test, SuperTest } from 'supertest';
-import { join, resolve, basename } from 'path';
-import { Server } from 'http';
-import { dirSync, setGracefulCleanup, type DirResult } from 'tmp';
-import { copySync, ensureDirSync } from 'fs-extra';
-import {
-  baseRealm,
-  Realm,
-  RealmPermissions,
-  type LooseSingleCardDocument,
-} from '@cardstack/runtime-common';
+import { Test, SuperTest } from 'supertest';
+import { join, basename } from 'path';
+import { dirSync, type DirResult } from 'tmp';
+import { copySync } from 'fs-extra';
+import { baseRealm, Realm, RealmPermissions } from '@cardstack/runtime-common';
 import {
   setupCardLogs,
   setupBaseRealmServer,
-  runTestRealmServer,
-  setupDB,
-  createVirtualNetwork,
+  setupPermissionedRealm,
   createVirtualNetworkAndLoader,
   matrixURL,
-  closeServer,
+  testRealmHref,
 } from '../helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
-import { resetCatalogRealms } from '../../handlers/handle-fetch-catalog-realms';
-
-setGracefulCleanup();
-const testRealmURL = new URL('http://127.0.0.1:4444/');
-const testRealmHref = testRealmURL.href;
-const distDir = resolve(join(__dirname, '..', '..', '..', 'host', 'dist'));
-console.log(`using host dist dir: ${distDir}`);
 
 let createJWT = (
   realm: Realm,
@@ -48,44 +33,8 @@ let createJWT = (
 module(`realm-endpoints/${basename(__filename)}`, function () {
   module('Realm-specific Endpoints | GET directory path', function (hooks) {
     let testRealm: Realm;
-    let testRealmHttpServer: Server;
     let request: SuperTest<Test>;
     let dir: DirResult;
-
-    function setupPermissionedRealm(
-      hooks: NestedHooks,
-      permissions: RealmPermissions,
-      fileSystem?: Record<string, string | LooseSingleCardDocument>,
-    ) {
-      setupDB(hooks, {
-        beforeEach: async (_dbAdapter, publisher, runner) => {
-          dir = dirSync();
-          let testRealmDir = join(dir.name, '..', 'realm_server_1', 'test');
-          ensureDirSync(testRealmDir);
-          // If a fileSystem is provided, use it to populate the test realm, otherwise copy the default cards
-          if (!fileSystem) {
-            copySync(join(__dirname, '..', 'cards'), testRealmDir);
-          }
-
-          let virtualNetwork = createVirtualNetwork();
-
-          ({ testRealm, testRealmHttpServer } = await runTestRealmServer({
-            virtualNetwork,
-            testRealmDir,
-            realmsRootPath: join(dir.name, '..', 'realm_server_1'),
-            realmURL: testRealmURL,
-            permissions,
-            dbAdapter: _dbAdapter,
-            runner,
-            publisher,
-            matrixURL,
-            fileSystem,
-          }));
-
-          request = supertest(testRealmHttpServer);
-        },
-      });
-    }
 
     let { virtualNetwork, loader } = createVirtualNetworkAndLoader();
 
@@ -101,14 +50,22 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
       copySync(join(__dirname, '..', 'cards'), dir.name);
     });
 
-    hooks.afterEach(async function () {
-      await closeServer(testRealmHttpServer);
-      resetCatalogRealms();
-    });
+    function onRealmSetup(args: {
+      testRealm: Realm;
+      request: SuperTest<Test>;
+      dir: DirResult;
+    }) {
+      testRealm = args.testRealm;
+      request = args.request;
+      dir = args.dir;
+    }
 
     module('public readable realm', function (hooks) {
       setupPermissionedRealm(hooks, {
-        '*': ['read'],
+        permissions: {
+          '*': ['read'],
+        },
+        onRealmSetup,
       });
 
       test('serves the request', async function (assert) {
@@ -119,7 +76,7 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
         assert.strictEqual(response.status, 200, 'HTTP 200 status');
         assert.strictEqual(
           response.get('X-boxel-realm-url'),
-          testRealmURL.href,
+          testRealmHref,
           'realm url header is correct',
         );
         assert.strictEqual(
@@ -172,7 +129,10 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
 
     module('permissioned realm', function (hooks) {
       setupPermissionedRealm(hooks, {
-        john: ['read'],
+        permissions: {
+          john: ['read'],
+        },
+        onRealmSetup,
       });
 
       test('401 with invalid JWT', async function (assert) {

--- a/packages/realm-server/tests/realm-endpoints/directory-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/directory-test.ts
@@ -3,7 +3,7 @@ import { Test, SuperTest } from 'supertest';
 import { join, basename } from 'path';
 import { dirSync, type DirResult } from 'tmp';
 import { copySync } from 'fs-extra';
-import { baseRealm, Realm, RealmPermissions } from '@cardstack/runtime-common';
+import { baseRealm, Realm } from '@cardstack/runtime-common';
 import {
   setupCardLogs,
   setupBaseRealmServer,
@@ -11,24 +11,9 @@ import {
   createVirtualNetworkAndLoader,
   matrixURL,
   testRealmHref,
+  createJWT,
 } from '../helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
-
-let createJWT = (
-  realm: Realm,
-  user: string,
-  permissions: RealmPermissions['user'] = [],
-) => {
-  return realm.createJWT(
-    {
-      user,
-      realm: realm.url,
-      permissions,
-      sessionRoom: `test-session-room-for-${user}`,
-    },
-    '7d',
-  );
-};
 
 module(`realm-endpoints/${basename(__filename)}`, function () {
   module('Realm-specific Endpoints | GET directory path', function (hooks) {

--- a/packages/realm-server/tests/realm-endpoints/info-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/info-test.ts
@@ -4,7 +4,7 @@ import { join, basename } from 'path';
 import { Server } from 'http';
 import { dirSync, type DirResult } from 'tmp';
 import { copySync } from 'fs-extra';
-import { baseRealm, Realm, RealmPermissions } from '@cardstack/runtime-common';
+import { baseRealm, Realm } from '@cardstack/runtime-common';
 import {
   setupCardLogs,
   setupBaseRealmServer,
@@ -14,25 +14,10 @@ import {
   closeServer,
   testRealmInfo,
   testRealmHref,
+  createJWT,
 } from '../helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 import { resetCatalogRealms } from '../../handlers/handle-fetch-catalog-realms';
-
-let createJWT = (
-  realm: Realm,
-  user: string,
-  permissions: RealmPermissions['user'] = [],
-) => {
-  return realm.createJWT(
-    {
-      user,
-      realm: realm.url,
-      permissions,
-      sessionRoom: `test-session-room-for-${user}`,
-    },
-    '7d',
-  );
-};
 
 module(`realm-endpoints/${basename(__filename)}`, function () {
   module('Realm-specific Endpoints | GET _info', function (hooks) {

--- a/packages/realm-server/tests/realm-endpoints/mtimes-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/mtimes-test.ts
@@ -1,33 +1,18 @@
 import { module, test } from 'qunit';
-import supertest, { Test, SuperTest } from 'supertest';
-import { join, resolve, basename } from 'path';
-import { Server } from 'http';
-import { dirSync, setGracefulCleanup, type DirResult } from 'tmp';
-import { copySync, ensureDirSync } from 'fs-extra';
-import {
-  baseRealm,
-  Realm,
-  RealmPermissions,
-  type LooseSingleCardDocument,
-} from '@cardstack/runtime-common';
+import { Test, SuperTest } from 'supertest';
+import { basename } from 'path';
+import { baseRealm, Realm, RealmPermissions } from '@cardstack/runtime-common';
 import {
   setupCardLogs,
   setupBaseRealmServer,
-  runTestRealmServer,
-  setupDB,
-  createVirtualNetwork,
+  setupPermissionedRealm,
   createVirtualNetworkAndLoader,
   matrixURL,
-  closeServer,
   mtimes,
+  testRealmHref,
+  testRealmURL,
 } from '../helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
-
-setGracefulCleanup();
-const testRealmURL = new URL('http://127.0.0.1:4444/');
-const testRealmHref = testRealmURL.href;
-const distDir = resolve(join(__dirname, '..', '..', '..', 'host', 'dist'));
-console.log(`using host dist dir: ${distDir}`);
 
 let createJWT = (
   realm: Realm,
@@ -49,50 +34,19 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
   module('Realm-specific Endpoints | GET _mtimes', function (hooks) {
     let testRealm: Realm;
     let testRealmPath: string;
-    let testRealmHttpServer: Server;
     let request: SuperTest<Test>;
-    let dir: DirResult;
-
-    function setupPermissionedRealm(
-      hooks: NestedHooks,
-      permissions: RealmPermissions,
-      fileSystem?: Record<string, string | LooseSingleCardDocument>,
-    ) {
-      setupDB(hooks, {
-        beforeEach: async (_dbAdapter, publisher, runner) => {
-          dir = dirSync();
-          let testRealmDir = join(dir.name, '..', 'realm_server_1', 'test');
-          ensureDirSync(testRealmDir);
-          // If a fileSystem is provided, use it to populate the test realm, otherwise copy the default cards
-          if (!fileSystem) {
-            copySync(join(__dirname, '..', 'cards'), testRealmDir);
-          }
-
-          let virtualNetwork = createVirtualNetwork();
-
-          ({
-            testRealm,
-            testRealmHttpServer,
-            testRealmDir: testRealmPath,
-          } = await runTestRealmServer({
-            virtualNetwork,
-            testRealmDir,
-            realmsRootPath: join(dir.name, '..', 'realm_server_1'),
-            realmURL: testRealmURL,
-            permissions,
-            dbAdapter: _dbAdapter,
-            runner,
-            publisher,
-            matrixURL,
-            fileSystem,
-          }));
-
-          request = supertest(testRealmHttpServer);
-        },
-      });
-    }
 
     let { virtualNetwork, loader } = createVirtualNetworkAndLoader();
+
+    function onRealmSetup(args: {
+      testRealm: Realm;
+      testRealmPath: string;
+      request: SuperTest<Test>;
+    }) {
+      testRealm = args.testRealm;
+      testRealmPath = args.testRealmPath;
+      request = args.request;
+    }
 
     setupCardLogs(
       hooks,
@@ -102,16 +56,10 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
     setupBaseRealmServer(hooks, virtualNetwork, matrixURL);
 
     setupPermissionedRealm(hooks, {
-      mary: ['read'],
-    });
-
-    hooks.beforeEach(async function () {
-      dir = dirSync();
-      copySync(join(__dirname, '..', 'cards'), dir.name);
-    });
-
-    hooks.afterEach(async function () {
-      await closeServer(testRealmHttpServer);
+      permissions: {
+        mary: ['read'],
+      },
+      onRealmSetup,
     });
 
     test('non read permission GET /_mtimes', async function (assert) {

--- a/packages/realm-server/tests/realm-endpoints/mtimes-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/mtimes-test.ts
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { Test, SuperTest } from 'supertest';
 import { basename } from 'path';
-import { baseRealm, Realm, RealmPermissions } from '@cardstack/runtime-common';
+import { baseRealm, Realm } from '@cardstack/runtime-common';
 import {
   setupCardLogs,
   setupBaseRealmServer,
@@ -11,24 +11,9 @@ import {
   mtimes,
   testRealmHref,
   testRealmURL,
+  createJWT,
 } from '../helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
-
-let createJWT = (
-  realm: Realm,
-  user: string,
-  permissions: RealmPermissions['user'] = [],
-) => {
-  return realm.createJWT(
-    {
-      user,
-      realm: realm.url,
-      permissions,
-      sessionRoom: `test-session-room-for-${user}`,
-    },
-    '7d',
-  );
-};
 
 module(`realm-endpoints/${basename(__filename)}`, function () {
   module('Realm-specific Endpoints | GET _mtimes', function (hooks) {

--- a/packages/realm-server/tests/realm-endpoints/permissions-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/permissions-test.ts
@@ -1,35 +1,25 @@
 import { module, test } from 'qunit';
-import supertest, { Test, SuperTest } from 'supertest';
-import { join, resolve, basename } from 'path';
-import { Server } from 'http';
-import { dirSync, setGracefulCleanup, type DirResult } from 'tmp';
-import { copySync, ensureDirSync } from 'fs-extra';
+import { Test, SuperTest } from 'supertest';
+import { join, basename } from 'path';
+import { dirSync, type DirResult } from 'tmp';
+import { copySync } from 'fs-extra';
 import {
   baseRealm,
   Realm,
   RealmPermissions,
   fetchUserPermissions,
-  type LooseSingleCardDocument,
 } from '@cardstack/runtime-common';
 import {
   setupCardLogs,
   setupBaseRealmServer,
-  runTestRealmServer,
-  setupDB,
-  createVirtualNetwork,
+  setupPermissionedRealm,
   createVirtualNetworkAndLoader,
   matrixURL,
-  closeServer,
+  testRealmHref,
+  testRealmURL,
 } from '../helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 import { type PgAdapter } from '@cardstack/postgres';
-import { resetCatalogRealms } from '../../handlers/handle-fetch-catalog-realms';
-
-setGracefulCleanup();
-const testRealmURL = new URL('http://127.0.0.1:4444/');
-const testRealmHref = testRealmURL.href;
-const distDir = resolve(join(__dirname, '..', '..', '..', 'host', 'dist'));
-console.log(`using host dist dir: ${distDir}`);
 
 let createJWT = (
   realm: Realm,
@@ -50,48 +40,23 @@ let createJWT = (
 module(`realm-endpoints/${basename(__filename)}`, function () {
   module('Realm-specific Endpoints | _permissions', function (hooks) {
     let testRealm: Realm;
-    let testRealmHttpServer: Server;
     let request: SuperTest<Test>;
     let dir: DirResult;
     let dbAdapter: PgAdapter;
 
-    function setupPermissionedRealm(
-      hooks: NestedHooks,
-      permissions: RealmPermissions,
-      fileSystem?: Record<string, string | LooseSingleCardDocument>,
-    ) {
-      setupDB(hooks, {
-        beforeEach: async (_dbAdapter, publisher, runner) => {
-          dbAdapter = _dbAdapter;
-          dir = dirSync();
-          let testRealmDir = join(dir.name, '..', 'realm_server_1', 'test');
-          ensureDirSync(testRealmDir);
-          // If a fileSystem is provided, use it to populate the test realm, otherwise copy the default cards
-          if (!fileSystem) {
-            copySync(join(__dirname, '..', 'cards'), testRealmDir);
-          }
-
-          let virtualNetwork = createVirtualNetwork();
-
-          ({ testRealm, testRealmHttpServer } = await runTestRealmServer({
-            virtualNetwork,
-            testRealmDir,
-            realmsRootPath: join(dir.name, '..', 'realm_server_1'),
-            realmURL: testRealmURL,
-            permissions,
-            dbAdapter: _dbAdapter,
-            runner,
-            publisher,
-            matrixURL,
-            fileSystem,
-          }));
-
-          request = supertest(testRealmHttpServer);
-        },
-      });
-    }
-
     let { virtualNetwork, loader } = createVirtualNetworkAndLoader();
+
+    function onRealmSetup(args: {
+      testRealm: Realm;
+      request: SuperTest<Test>;
+      dbAdapter: PgAdapter;
+      dir: DirResult;
+    }) {
+      testRealm = args.testRealm;
+      request = args.request;
+      dbAdapter = args.dbAdapter;
+      dir = args.dir;
+    }
 
     setupCardLogs(
       hooks,
@@ -105,15 +70,13 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
       copySync(join(__dirname, '..', 'cards'), dir.name);
     });
 
-    hooks.afterEach(async function () {
-      await closeServer(testRealmHttpServer);
-      resetCatalogRealms();
-    });
-
     module('permissions requests', function (hooks) {
       setupPermissionedRealm(hooks, {
-        mary: ['read', 'write', 'realm-owner'],
-        bob: ['read', 'write'],
+        permissions: {
+          mary: ['read', 'write', 'realm-owner'],
+          bob: ['read', 'write'],
+        },
+        onRealmSetup,
       });
 
       test('non-owner GET /_permissions', async function (assert) {

--- a/packages/realm-server/tests/realm-endpoints/permissions-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/permissions-test.ts
@@ -6,7 +6,6 @@ import { copySync } from 'fs-extra';
 import {
   baseRealm,
   Realm,
-  RealmPermissions,
   fetchUserPermissions,
 } from '@cardstack/runtime-common';
 import {
@@ -17,25 +16,10 @@ import {
   matrixURL,
   testRealmHref,
   testRealmURL,
+  createJWT,
 } from '../helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 import { type PgAdapter } from '@cardstack/postgres';
-
-let createJWT = (
-  realm: Realm,
-  user: string,
-  permissions: RealmPermissions['user'] = [],
-) => {
-  return realm.createJWT(
-    {
-      user,
-      realm: realm.url,
-      permissions,
-      sessionRoom: `test-session-room-for-${user}`,
-    },
-    '7d',
-  );
-};
 
 module(`realm-endpoints/${basename(__filename)}`, function () {
   module('Realm-specific Endpoints | _permissions', function (hooks) {

--- a/packages/realm-server/tests/realm-endpoints/search-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/search-test.ts
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { Test, SuperTest } from 'supertest';
 import { basename } from 'path';
-import { baseRealm, Realm, RealmPermissions } from '@cardstack/runtime-common';
+import { baseRealm, Realm } from '@cardstack/runtime-common';
 import { stringify } from 'qs';
 import { Query } from '@cardstack/runtime-common/query';
 import {
@@ -11,24 +11,9 @@ import {
   createVirtualNetworkAndLoader,
   matrixURL,
   testRealmHref,
+  createJWT,
 } from '../helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
-
-let createJWT = (
-  realm: Realm,
-  user: string,
-  permissions: RealmPermissions['user'] = [],
-) => {
-  return realm.createJWT(
-    {
-      user,
-      realm: realm.url,
-      permissions,
-      sessionRoom: `test-session-room-for-${user}`,
-    },
-    '7d',
-  );
-};
 
 module(`realm-endpoints/${basename(__filename)}`, function () {
   module('Realm-specific Endpoints | _search', function (hooks) {

--- a/packages/realm-server/tests/realm-endpoints/search-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/search-test.ts
@@ -1,35 +1,18 @@
 import { module, test } from 'qunit';
-import supertest, { Test, SuperTest } from 'supertest';
-import { join, resolve, basename } from 'path';
-import { Server } from 'http';
-import { dirSync, setGracefulCleanup, type DirResult } from 'tmp';
-import { copySync, ensureDirSync } from 'fs-extra';
-import {
-  baseRealm,
-  Realm,
-  RealmPermissions,
-  type LooseSingleCardDocument,
-} from '@cardstack/runtime-common';
+import { Test, SuperTest } from 'supertest';
+import { basename } from 'path';
+import { baseRealm, Realm, RealmPermissions } from '@cardstack/runtime-common';
 import { stringify } from 'qs';
 import { Query } from '@cardstack/runtime-common/query';
 import {
   setupCardLogs,
   setupBaseRealmServer,
-  runTestRealmServer,
-  setupDB,
-  createVirtualNetwork,
+  setupPermissionedRealm,
   createVirtualNetworkAndLoader,
   matrixURL,
-  closeServer,
+  testRealmHref,
 } from '../helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
-import { resetCatalogRealms } from '../../handlers/handle-fetch-catalog-realms';
-
-setGracefulCleanup();
-const testRealmURL = new URL('http://127.0.0.1:4444/');
-const testRealmHref = testRealmURL.href;
-const distDir = resolve(join(__dirname, '..', '..', '..', 'host', 'dist'));
-console.log(`using host dist dir: ${distDir}`);
 
 let createJWT = (
   realm: Realm,
@@ -50,44 +33,7 @@ let createJWT = (
 module(`realm-endpoints/${basename(__filename)}`, function () {
   module('Realm-specific Endpoints | _search', function (hooks) {
     let testRealm: Realm;
-    let testRealmHttpServer: Server;
     let request: SuperTest<Test>;
-    let dir: DirResult;
-
-    function setupPermissionedRealm(
-      hooks: NestedHooks,
-      permissions: RealmPermissions,
-      fileSystem?: Record<string, string | LooseSingleCardDocument>,
-    ) {
-      setupDB(hooks, {
-        beforeEach: async (_dbAdapter, publisher, runner) => {
-          dir = dirSync();
-          let testRealmDir = join(dir.name, '..', 'realm_server_1', 'test');
-          ensureDirSync(testRealmDir);
-          // If a fileSystem is provided, use it to populate the test realm, otherwise copy the default cards
-          if (!fileSystem) {
-            copySync(join(__dirname, '..', 'cards'), testRealmDir);
-          }
-
-          let virtualNetwork = createVirtualNetwork();
-
-          ({ testRealm, testRealmHttpServer } = await runTestRealmServer({
-            virtualNetwork,
-            testRealmDir,
-            realmsRootPath: join(dir.name, '..', 'realm_server_1'),
-            realmURL: testRealmURL,
-            permissions,
-            dbAdapter: _dbAdapter,
-            runner,
-            publisher,
-            matrixURL,
-            fileSystem,
-          }));
-
-          request = supertest(testRealmHttpServer);
-        },
-      });
-    }
 
     let { virtualNetwork, loader } = createVirtualNetworkAndLoader();
 
@@ -98,15 +44,13 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
 
     setupBaseRealmServer(hooks, virtualNetwork, matrixURL);
 
-    hooks.beforeEach(async function () {
-      dir = dirSync();
-      copySync(join(__dirname, '..', 'cards'), dir.name);
-    });
-
-    hooks.afterEach(async function () {
-      await closeServer(testRealmHttpServer);
-      resetCatalogRealms();
-    });
+    function onRealmSetup(args: {
+      testRealm: Realm;
+      request: SuperTest<Test>;
+    }) {
+      testRealm = args.testRealm;
+      request = args.request;
+    }
 
     module('GET request', function (_hooks) {
       let query: Query = {
@@ -123,7 +67,10 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
 
       module('public readable realm', function (hooks) {
         setupPermissionedRealm(hooks, {
-          '*': ['read'],
+          permissions: {
+            '*': ['read'],
+          },
+          onRealmSetup,
         });
 
         test('serves a /_search GET request', async function (assert) {
@@ -134,7 +81,7 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
           assert.strictEqual(response.status, 200, 'HTTP 200 status');
           assert.strictEqual(
             response.get('X-boxel-realm-url'),
-            testRealmURL.href,
+            testRealmHref,
             'realm url header is correct',
           );
           assert.strictEqual(
@@ -158,7 +105,10 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
 
       module('permissioned realm', function (hooks) {
         setupPermissionedRealm(hooks, {
-          john: ['read'],
+          permissions: {
+            john: ['read'],
+          },
+          onRealmSetup,
         });
 
         test('401 with invalid JWT', async function (assert) {
@@ -215,7 +165,10 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
 
       module('public readable realm', function (hooks) {
         setupPermissionedRealm(hooks, {
-          '*': ['read'],
+          permissions: {
+            '*': ['read'],
+          },
+          onRealmSetup,
         });
 
         test('serves a /_search QUERY request', async function (assert) {
@@ -229,7 +182,7 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
           assert.strictEqual(response.status, 200, 'HTTP 200 status');
           assert.strictEqual(
             response.get('X-boxel-realm-url'),
-            testRealmURL.href,
+            testRealmHref,
             'realm url header is correct',
           );
           assert.strictEqual(
@@ -285,7 +238,10 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
 
       module('permissioned realm', function (hooks) {
         setupPermissionedRealm(hooks, {
-          john: ['read'],
+          permissions: {
+            john: ['read'],
+          },
+          onRealmSetup,
         });
 
         test('401 with invalid JWT', async function (assert) {
@@ -337,7 +293,10 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
 
       module('search query validation', function (hooks) {
         setupPermissionedRealm(hooks, {
-          '*': ['read'],
+          permissions: {
+            '*': ['read'],
+          },
+          onRealmSetup,
         });
 
         test('400 with invalid query schema', async function (assert) {

--- a/packages/realm-server/tests/realm-endpoints/user-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/user-test.ts
@@ -1,21 +1,14 @@
 import { module, test } from 'qunit';
-import supertest, { Test, SuperTest } from 'supertest';
-import { join, resolve, basename } from 'path';
+import { Test, SuperTest } from 'supertest';
+import { join, basename } from 'path';
 import { Server } from 'http';
-import { dirSync, setGracefulCleanup, type DirResult } from 'tmp';
-import { copySync, ensureDirSync } from 'fs-extra';
-import {
-  baseRealm,
-  Realm,
-  RealmPermissions,
-  type LooseSingleCardDocument,
-} from '@cardstack/runtime-common';
+import { dirSync, type DirResult } from 'tmp';
+import { copySync } from 'fs-extra';
+import { baseRealm, Realm, RealmPermissions } from '@cardstack/runtime-common';
 import {
   setupCardLogs,
   setupBaseRealmServer,
-  runTestRealmServer,
-  setupDB,
-  createVirtualNetwork,
+  setupPermissionedRealm,
   createVirtualNetworkAndLoader,
   matrixURL,
   closeServer,
@@ -30,11 +23,6 @@ import {
   insertSubscription,
 } from '@cardstack/billing/billing-queries';
 import { resetCatalogRealms } from '../../handlers/handle-fetch-catalog-realms';
-
-setGracefulCleanup();
-const testRealmURL = new URL('http://127.0.0.1:4444/');
-const distDir = resolve(join(__dirname, '..', '..', '..', 'host', 'dist'));
-console.log(`using host dist dir: ${distDir}`);
 
 let createJWT = (
   realm: Realm,
@@ -60,43 +48,21 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
     let dir: DirResult;
     let dbAdapter: PgAdapter;
 
-    function setupPermissionedRealm(
-      hooks: NestedHooks,
-      permissions: RealmPermissions,
-      fileSystem?: Record<string, string | LooseSingleCardDocument>,
-    ) {
-      setupDB(hooks, {
-        beforeEach: async (_dbAdapter, publisher, runner) => {
-          dbAdapter = _dbAdapter;
-          dir = dirSync();
-          let testRealmDir = join(dir.name, '..', 'realm_server_1', 'test');
-          ensureDirSync(testRealmDir);
-          // If a fileSystem is provided, use it to populate the test realm, otherwise copy the default cards
-          if (!fileSystem) {
-            copySync(join(__dirname, '..', 'cards'), testRealmDir);
-          }
-
-          let virtualNetwork = createVirtualNetwork();
-
-          ({ testRealm, testRealmHttpServer } = await runTestRealmServer({
-            virtualNetwork,
-            testRealmDir,
-            realmsRootPath: join(dir.name, '..', 'realm_server_1'),
-            realmURL: testRealmURL,
-            permissions,
-            dbAdapter: _dbAdapter,
-            runner,
-            publisher,
-            matrixURL,
-            fileSystem,
-          }));
-
-          request = supertest(testRealmHttpServer);
-        },
-      });
-    }
-
     let { virtualNetwork, loader } = createVirtualNetworkAndLoader();
+
+    function onRealmSetup(args: {
+      testRealm: Realm;
+      testRealmHttpServer: Server;
+      request: SuperTest<Test>;
+      dbAdapter: PgAdapter;
+      dir: DirResult;
+    }) {
+      testRealm = args.testRealm;
+      testRealmHttpServer = args.testRealmHttpServer;
+      request = args.request;
+      dbAdapter = args.dbAdapter;
+      dir = args.dir;
+    }
 
     setupCardLogs(
       hooks,
@@ -116,7 +82,10 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
     });
 
     setupPermissionedRealm(hooks, {
-      john: ['read', 'write'],
+      permissions: {
+        john: ['read', 'write'],
+      },
+      onRealmSetup,
     });
 
     test('responds with 404 if user is not found', async function (assert) {

--- a/packages/realm-server/tests/realm-endpoints/user-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/user-test.ts
@@ -4,7 +4,7 @@ import { join, basename } from 'path';
 import { Server } from 'http';
 import { dirSync, type DirResult } from 'tmp';
 import { copySync } from 'fs-extra';
-import { baseRealm, Realm, RealmPermissions } from '@cardstack/runtime-common';
+import { baseRealm, Realm } from '@cardstack/runtime-common';
 import {
   setupCardLogs,
   setupBaseRealmServer,
@@ -14,6 +14,7 @@ import {
   closeServer,
   insertUser,
   insertPlan,
+  createJWT,
 } from '../helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 import { type PgAdapter } from '@cardstack/postgres';
@@ -23,22 +24,6 @@ import {
   insertSubscription,
 } from '@cardstack/billing/billing-queries';
 import { resetCatalogRealms } from '../../handlers/handle-fetch-catalog-realms';
-
-let createJWT = (
-  realm: Realm,
-  user: string,
-  permissions: RealmPermissions['user'] = [],
-) => {
-  return realm.createJWT(
-    {
-      user,
-      realm: realm.url,
-      permissions,
-      sessionRoom: `test-session-room-for-${user}`,
-    },
-    '7d',
-  );
-};
 
 module(`realm-endpoints/${basename(__filename)}`, function () {
   module('Realm-specific Endpoints | GET _user', function (hooks) {

--- a/packages/realm-server/tests/search-prerendered-test.ts
+++ b/packages/realm-server/tests/search-prerendered-test.ts
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { Test, SuperTest } from 'supertest';
 import { basename } from 'path';
-import { baseRealm, Realm, RealmPermissions } from '@cardstack/runtime-common';
+import { baseRealm, Realm } from '@cardstack/runtime-common';
 import { stringify } from 'qs';
 import { Query } from '@cardstack/runtime-common/query';
 import {
@@ -11,24 +11,9 @@ import {
   createVirtualNetworkAndLoader,
   matrixURL,
   testRealmHref,
+  createJWT,
 } from './helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
-
-let createJWT = (
-  realm: Realm,
-  user: string,
-  permissions: RealmPermissions['user'] = [],
-) => {
-  return realm.createJWT(
-    {
-      user,
-      realm: realm.url,
-      permissions,
-      sessionRoom: `test-session-room-for-${user}`,
-    },
-    '7d',
-  );
-};
 
 module(basename(__filename), function () {
   module('Realm-specific Endpoints | _search-prerendered', function (hooks) {

--- a/packages/realm-server/tests/search-prerendered-test.ts
+++ b/packages/realm-server/tests/search-prerendered-test.ts
@@ -1,35 +1,18 @@
 import { module, test } from 'qunit';
-import supertest, { Test, SuperTest } from 'supertest';
-import { join, resolve, basename } from 'path';
-import { Server } from 'http';
-import { dirSync, setGracefulCleanup, type DirResult } from 'tmp';
-import { copySync, ensureDirSync } from 'fs-extra';
-import {
-  baseRealm,
-  Realm,
-  RealmPermissions,
-  type LooseSingleCardDocument,
-} from '@cardstack/runtime-common';
+import { Test, SuperTest } from 'supertest';
+import { basename } from 'path';
+import { baseRealm, Realm, RealmPermissions } from '@cardstack/runtime-common';
 import { stringify } from 'qs';
 import { Query } from '@cardstack/runtime-common/query';
 import {
   setupCardLogs,
   setupBaseRealmServer,
-  runTestRealmServer,
-  setupDB,
-  createVirtualNetwork,
+  setupPermissionedRealm,
   createVirtualNetworkAndLoader,
   matrixURL,
-  closeServer,
+  testRealmHref,
 } from './helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
-import { resetCatalogRealms } from '../handlers/handle-fetch-catalog-realms';
-
-setGracefulCleanup();
-const testRealmURL = new URL('http://127.0.0.1:4444/');
-const testRealmHref = testRealmURL.href;
-const distDir = resolve(join(__dirname, '..', '..', 'host', 'dist'));
-console.log(`using host dist dir: ${distDir}`);
 
 let createJWT = (
   realm: Realm,
@@ -50,43 +33,14 @@ let createJWT = (
 module(basename(__filename), function () {
   module('Realm-specific Endpoints | _search-prerendered', function (hooks) {
     let testRealm: Realm;
-    let testRealmHttpServer: Server;
     let request: SuperTest<Test>;
-    let dir: DirResult;
 
-    function setupPermissionedRealm(
-      hooks: NestedHooks,
-      permissions: RealmPermissions,
-      fileSystem?: Record<string, string | LooseSingleCardDocument>,
-    ) {
-      setupDB(hooks, {
-        beforeEach: async (_dbAdapter, publisher, runner) => {
-          dir = dirSync();
-          let testRealmDir = join(dir.name, 'realm_server_1', 'test');
-          ensureDirSync(testRealmDir);
-          // If a fileSystem is provided, use it to populate the test realm, otherwise copy the default cards
-          if (!fileSystem) {
-            copySync(join(__dirname, 'cards'), testRealmDir);
-          }
-
-          let virtualNetwork = createVirtualNetwork();
-
-          ({ testRealm, testRealmHttpServer } = await runTestRealmServer({
-            virtualNetwork,
-            testRealmDir,
-            realmsRootPath: join(dir.name, 'realm_server_1'),
-            realmURL: testRealmURL,
-            permissions,
-            dbAdapter: _dbAdapter,
-            runner,
-            publisher,
-            matrixURL,
-            fileSystem,
-          }));
-
-          request = supertest(testRealmHttpServer);
-        },
-      });
+    function onRealmSetup(args: {
+      testRealm: Realm;
+      request: SuperTest<Test>;
+    }) {
+      testRealm = args.testRealm;
+      request = args.request;
     }
 
     let { virtualNetwork, loader } = createVirtualNetworkAndLoader();
@@ -98,26 +52,15 @@ module(basename(__filename), function () {
 
     setupBaseRealmServer(hooks, virtualNetwork, matrixURL);
 
-    hooks.beforeEach(async function () {
-      dir = dirSync();
-      copySync(join(__dirname, 'cards'), dir.name);
-    });
-
-    hooks.afterEach(async function () {
-      await closeServer(testRealmHttpServer);
-      resetCatalogRealms();
-    });
-
     module('GET request', function (_hooks) {
       module(
         'instances with no embedded template css of its own',
         function (hooks) {
-          setupPermissionedRealm(
-            hooks,
-            {
+          setupPermissionedRealm(hooks, {
+            permissions: {
               '*': ['read'],
             },
-            {
+            fileSystem: {
               'person.gts': `
               import { contains, field, CardDef, Component } from "https://cardstack.com/base/card-api";
               import StringCard from "https://cardstack.com/base/string";
@@ -155,7 +98,8 @@ module(basename(__filename), function () {
                 },
               },
             },
-          );
+            onRealmSetup,
+          });
 
           test('endpoint will respond with a bad request if html format is not provided', async function (assert) {
             let response = await request
@@ -191,7 +135,7 @@ module(basename(__filename), function () {
             assert.strictEqual(response.status, 200, 'HTTP 200 status');
             assert.strictEqual(
               response.get('X-boxel-realm-url'),
-              testRealmURL.href,
+              testRealmHref,
               'realm url header is correct',
             );
             assert.strictEqual(
@@ -232,12 +176,11 @@ module(basename(__filename), function () {
       );
 
       module('instances whose embedded template has css', function (hooks) {
-        setupPermissionedRealm(
-          hooks,
-          {
+        setupPermissionedRealm(hooks, {
+          permissions: {
             '*': ['read'],
           },
-          {
+          fileSystem: {
             'person.gts': `
           import { contains, field, CardDef, Component } from "https://cardstack.com/base/card-api";
           import StringCard from "https://cardstack.com/base/string";
@@ -342,7 +285,8 @@ module(basename(__filename), function () {
               },
             },
           },
-        );
+          onRealmSetup,
+        });
 
         test('returns instances with CardDef prerendered embedded html + css when there is no "on" filter', async function (assert) {
           let response = await request
@@ -352,7 +296,7 @@ module(basename(__filename), function () {
           assert.strictEqual(response.status, 200, 'HTTP 200 status');
           assert.strictEqual(
             response.get('X-boxel-realm-url'),
-            testRealmURL.href,
+            testRealmHref,
             'realm url header is correct',
           );
           assert.strictEqual(
@@ -592,12 +536,11 @@ module(basename(__filename), function () {
       module(
         'instances with no embedded template css of its own',
         function (hooks) {
-          setupPermissionedRealm(
-            hooks,
-            {
+          setupPermissionedRealm(hooks, {
+            permissions: {
               '*': ['read'],
             },
-            {
+            fileSystem: {
               'person.gts': `
               import { contains, field, CardDef, Component } from "https://cardstack.com/base/card-api";
               import StringCard from "https://cardstack.com/base/string";
@@ -635,7 +578,8 @@ module(basename(__filename), function () {
                 },
               },
             },
-          );
+            onRealmSetup,
+          });
 
           test('endpoint will respond with a bad request if html format is not provided', async function (assert) {
             let response = await request
@@ -675,7 +619,7 @@ module(basename(__filename), function () {
             assert.strictEqual(response.status, 200, 'HTTP 200 status');
             assert.strictEqual(
               response.get('X-boxel-realm-url'),
-              testRealmURL.href,
+              testRealmHref,
               'realm url header is correct',
             );
             assert.strictEqual(
@@ -716,12 +660,11 @@ module(basename(__filename), function () {
       );
 
       module('instances whose embedded template has css', function (hooks) {
-        setupPermissionedRealm(
-          hooks,
-          {
+        setupPermissionedRealm(hooks, {
+          permissions: {
             '*': ['read'],
           },
-          {
+          fileSystem: {
             'person.gts': `
           import { contains, field, CardDef, Component } from "https://cardstack.com/base/card-api";
           import StringCard from "https://cardstack.com/base/string";
@@ -826,7 +769,8 @@ module(basename(__filename), function () {
               },
             },
           },
-        );
+          onRealmSetup,
+        });
 
         test('returns instances with CardDef prerendered embedded html + css using QUERY method', async function (assert) {
           let response = await request
@@ -840,7 +784,7 @@ module(basename(__filename), function () {
           assert.strictEqual(response.status, 200, 'HTTP 200 status');
           assert.strictEqual(
             response.get('X-boxel-realm-url'),
-            testRealmURL.href,
+            testRealmHref,
             'realm url header is correct',
           );
           assert.strictEqual(
@@ -1008,12 +952,11 @@ module(basename(__filename), function () {
       });
 
       module('permissioned realm', function (hooks) {
-        setupPermissionedRealm(
-          hooks,
-          {
+        setupPermissionedRealm(hooks, {
+          permissions: {
             john: ['read'],
           },
-          {
+          fileSystem: {
             'person.gts': `
           import { contains, field, CardDef, Component } from "https://cardstack.com/base/card-api";
           import StringCard from "https://cardstack.com/base/string";
@@ -1041,7 +984,8 @@ module(basename(__filename), function () {
               },
             },
           },
-        );
+          onRealmSetup,
+        });
 
         test('401 with invalid JWT', async function (assert) {
           let response = await request
@@ -1092,7 +1036,10 @@ module(basename(__filename), function () {
 
       module('search query validation', function (hooks) {
         setupPermissionedRealm(hooks, {
-          '*': ['read'],
+          permissions: {
+            '*': ['read'],
+          },
+          onRealmSetup,
         });
 
         test('400 with invalid query schema', async function (assert) {

--- a/packages/realm-server/tests/server-endpoints-test.ts
+++ b/packages/realm-server/tests/server-endpoints-test.ts
@@ -8,7 +8,6 @@ import {
   baseRealm,
   Deferred,
   Realm,
-  RealmPermissions,
   fetchUserPermissions,
   baseCardRef,
   type SingleCardDocument,
@@ -37,6 +36,7 @@ import {
   fetchSubscriptionsByUserId,
   insertJob,
   testRealmURL,
+  createJWT,
 } from './helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 import { RealmServer } from '../server';
@@ -60,21 +60,6 @@ import type {
 import { monitoringAuthToken } from '../utils/monitoring';
 
 const testRealm2URL = new URL('http://127.0.0.1:4445/test/');
-let createJWT = (
-  realm: Realm,
-  user: string,
-  permissions: RealmPermissions['user'] = [],
-) => {
-  return realm.createJWT(
-    {
-      user,
-      realm: realm.url,
-      permissions,
-      sessionRoom: `test-session-room-for-${user}`,
-    },
-    '7d',
-  );
-};
 
 module(basename(__filename), function () {
   module(

--- a/packages/realm-server/tests/server-endpoints-test.ts
+++ b/packages/realm-server/tests/server-endpoints-test.ts
@@ -36,6 +36,7 @@ import {
   insertPlan,
   fetchSubscriptionsByUserId,
   insertJob,
+  testRealmURL,
 } from './helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 import { RealmServer } from '../server';
@@ -58,7 +59,6 @@ import type {
 } from 'https://cardstack.com/base/matrix-event';
 import { monitoringAuthToken } from '../utils/monitoring';
 
-const testRealmURL = new URL('http://127.0.0.1:4444/');
 const testRealm2URL = new URL('http://127.0.0.1:4445/test/');
 let createJWT = (
   realm: Realm,


### PR DESCRIPTION
This extracts `setupPermissionedRealm` with `onRealmSetup` and `getRealmSetup` callbacks for containing test realm server properties needed by future hooks (only `setupMatrixRoom` for now). It also extracts `createJWT`, some shared variables, and removes some repetitive logging.