### PR TITLE
AI coding assistant: Add support for deleting a block of code

### DIFF
--- a/packages/host/app/commands/apply-search-replace-block.ts
+++ b/packages/host/app/commands/apply-search-replace-block.ts
@@ -31,9 +31,10 @@ export default class ApplySearchReplaceBlockCommand extends HostBaseCommand<
       input.codeBlock,
     );
 
-    // If parsing failed, return the original content
-    if (!searchPattern || !replacePattern) {
-      throw new Error('Invalid search/replace block');
+    if (searchPattern == null) {
+      throw new Error("Can't parse SEARCH block");
+    } else if (replacePattern == null) {
+      throw new Error("Can't parse REPLACE block");
     }
 
     // Apply the search/replace operation
@@ -139,6 +140,11 @@ export default class ApplySearchReplaceBlockCommand extends HostBaseCommand<
         while (i < contentLines.length) {
           resultLines.push(contentLines[i]);
           i++;
+        }
+
+        // Case when replace pattern is empty (deleting code) - don't produce an uneccesary empty line at the beginning of the result
+        if (replacePattern === '' && resultLines[0] === '') {
+          return resultLines.slice(1).join('\n');
         }
         return resultLines.join('\n');
       } else {

--- a/packages/host/tests/integration/commands/apply-search-replace-block-test.gts
+++ b/packages/host/tests/integration/commands/apply-search-replace-block-test.gts
@@ -539,7 +539,7 @@ class CardTemplate extends Component<typeof ContactCard> {
     // Search pattern has spurious blank
     const codeBlock = `<<<<<<< SEARCH
   @field bio = contains(StringField);
-  
+
   @field avatar = linksTo(ImageAsset);
 =======
   @field bio = contains(StringField);
@@ -644,9 +644,9 @@ class CardTemplate extends Component<typeof ContactCard> {
 
     // Search pattern has trailing spaces on some lines
     const codeBlock = `<<<<<<< SEARCH
-      <div class="form-group">  
+      <div class="form-group">
         <label for="date">Date:</label>
-        <Input @value={{@model.date}} id="date" type="date" />  
+        <Input @value={{@model.date}} id="date" type="date" />
       </div>
 =======
       <div class="form-group">
@@ -684,5 +684,35 @@ class CardTemplate extends Component<typeof ContactCard> {
   </template>
 }`;
     assert.strictEqual(result.resultContent, expectedResult);
+  });
+
+  test('it applies search/replace block when replace block is empty', async function (assert) {
+    let commandService = lookupService<CommandService>('command-service');
+    let applyCommand = new ApplySearchReplaceBlockCommand(
+      commandService.commandContext,
+    );
+
+    const fileContent = `class Task extends CardDef {
+  static displayName = 'Task';
+  @field title = contains(StringField);
+  @field description = contains(StringField);
+}`;
+    const codeBlock = `<<<<<<< SEARCH
+  class Task extends CardDef {
+    static displayName = 'Task';
+    @field title = contains(StringField);
+=======
+>>>>>>> REPLACE`;
+
+    let result = await applyCommand.execute({
+      fileContent,
+      codeBlock,
+    });
+
+    assert.strictEqual(
+      result.resultContent,
+      `  @field description = contains(StringField);
+}`,
+    );
   });
 });


### PR DESCRIPTION
AI assistant can respond with a search/replace block where the replace block is empty, which means the the specified block of code should be deleted. This resulted in an error because our search/replace block command didn't know how to deal with that. This was visible as a broken editor, like this:

<img width="358" alt="image" src="https://github.com/user-attachments/assets/3c2bb7e9-1c56-4166-869f-5a3eadc94183" />

With an error: 
<img width="606" alt="image" src="https://github.com/user-attachments/assets/b6ab9c41-bb77-42c3-b29f-b7e9aae7f2e2" />

After the fix in this PR, we can now see a block of code for deletion:

<img width="359" alt="image" src="https://github.com/user-attachments/assets/daf712b0-860a-44c5-8a57-cb7527f71112" />

