### PR TITLE
Fix recent bugs in field playground

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-content.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-content.gts
@@ -7,19 +7,17 @@ import Component from '@glimmer/component';
 
 import { task } from 'ember-concurrency';
 
-import { consume } from 'ember-provide-consume-context';
-
 import { LoadingIndicator } from '@cardstack/boxel-ui/components';
 import { eq, MenuItem } from '@cardstack/boxel-ui/helpers';
 import { Eye, IconCode, IconLink } from '@cardstack/boxel-ui/icons';
 
 import {
-  GetCardContextName,
-  type getCard,
   type Query,
   type ResolvedCodeRef,
   specRef,
 } from '@cardstack/runtime-common';
+
+import consumeContext from '@cardstack/host/helpers/consume-context';
 
 import type CardService from '@cardstack/host/services/card-service';
 import type LoaderService from '@cardstack/host/services/loader-service';
@@ -49,6 +47,7 @@ export type SelectedInstance = {
 
 interface Signature {
   Args: {
+    makeCardResource: () => void;
     moduleId: string;
     codeRef: ResolvedCodeRef;
     createNew: () => void;
@@ -61,6 +60,7 @@ interface Signature {
 
 export default class PlaygroundContent extends Component<Signature> {
   <template>
+    {{consumeContext @makeCardResource}}
     <section class='playground-panel' data-test-playground-panel>
       <div class='playground-panel-content'>
         {{#let (if @isFieldDef @field @card) as |card|}}
@@ -141,8 +141,6 @@ export default class PlaygroundContent extends Component<Signature> {
       }
     </style>
   </template>
-
-  @consume(GetCardContextName) private declare getCard: getCard;
 
   @service private declare cardService: CardService;
   @service private declare loaderService: LoaderService;

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
@@ -74,6 +74,7 @@ interface Signature {
       (
         | WithBoundArgs<
             typeof PlaygroundContent,
+            | 'makeCardResource'
             | 'card'
             | 'field'
             | 'moduleId'
@@ -125,6 +126,23 @@ export default class PlaygroundPanel extends Component<Signature> {
     return this.cardResource?.card;
   }
 
+  private get specCard(): Spec | undefined {
+    let card = this.card;
+    if (!card || !this.args.isFieldDef) {
+      return undefined;
+    }
+    if (!('ref' in card) || !('moduleHref' in card)) {
+      return undefined;
+    }
+    if (
+      card.moduleHref !== this.args.codeRef.module ||
+      (card.ref as ResolvedCodeRef).name !== this.args.codeRef.name
+    ) {
+      return undefined;
+    }
+    return card as Spec;
+  }
+
   private get recentCardIds() {
     return this.recentFilesService.recentFiles
       .map((f) => `${f.realmURL}${f.filePath}`)
@@ -165,10 +183,10 @@ export default class PlaygroundPanel extends Component<Signature> {
   }
 
   private get fieldInstances(): FieldOption[] | undefined {
-    if (!this.args.isFieldDef || !this.card) {
+    if (!this.args.isFieldDef || !this.specCard) {
       return undefined;
     }
-    let spec = this.card as Spec;
+    let spec = this.specCard;
     let instances = spec.containedExamples;
     if (!instances?.length) {
       this.createNewField.perform(spec);
@@ -412,6 +430,7 @@ export default class PlaygroundPanel extends Component<Signature> {
         (component LoadingIndicator color='var(--boxel-light)')
         (component
           PlaygroundContent
+          makeCardResource=this.makeCardResource
           card=this.card
           field=this.field
           moduleId=this.moduleId

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -670,11 +670,12 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
 
     if (selections) {
       const selection = JSON.parse(selections)[moduleId];
-      // If we already have selections for this module, preserve the format
-      existingFormat = selection?.format as Format;
-
       if (selection?.cardId === cardId) {
         return;
+      }
+      // If we already have selections for this module, preserve the format
+      if (selection?.format) {
+        existingFormat = selection?.format;
       }
     }
 

--- a/packages/host/tests/acceptance/code-submode/field-playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/field-playground-test.gts
@@ -409,6 +409,42 @@ module('Acceptance | code-submode | field playground', function (hooks) {
             },
           },
         },
+        'Spec/toy.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              ref: {
+                name: 'ToyField',
+                module: '../pet',
+              },
+              specType: 'field',
+              containedExamples: [{ title: 'Tug rope' }, { title: 'Lambchop' }],
+              title: 'Toy',
+            },
+            meta: {
+              fields: {
+                containedExamples: [
+                  {
+                    adoptsFrom: {
+                      module: '../pet',
+                      name: 'ToyField',
+                    },
+                  },
+                  {
+                    adoptsFrom: {
+                      module: '../pet',
+                      name: 'ToyField',
+                    },
+                  },
+                ],
+              },
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/spec',
+                name: 'Spec',
+              },
+            },
+          },
+        },
         'Pet/mango.json': {
           data: {
             attributes: {
@@ -790,30 +826,21 @@ module('Acceptance | code-submode | field playground', function (hooks) {
 
   test('does not persist the wrong card for field', async function (assert) {
     const cardId = `${testRealmURL}Pet/mango`;
+    const specId = `${testRealmURL}Spec/toy`;
     let selections: Record<string, PlaygroundSelection> = {
       [`${testRealmURL}pet/PetCard`]: { cardId, format: 'isolated' as Format },
     };
     setRecentFiles([[testRealmURL, 'Pet/mango.json']]);
     setPlaygroundSelections(selections);
-    await openFileInPlayground('pet.gts', testRealmURL, 'PetCard');
-    assert.dom('[data-test-instance-chooser]').hasText('Mango');
-    assertCardExists(assert, cardId, 'isolated');
-    await selectDeclaration('ToyField');
-    assert.dom('[data-test-instance-chooser]').hasText('ToyField - Example 1');
-    assertFieldExists(assert, 'edit');
-    await toggleSpecPanel();
-    let specId =
-      testRealmURL +
-      document
-        .querySelector('[data-test-spec-selector-item-path]')
-        ?.textContent?.trim();
-    await togglePlaygroundPanel();
+    await openFileInPlayground('pet.gts', testRealmURL, 'ToyField');
+    assert.dom('[data-test-instance-chooser]').hasText('Toy - Example 1');
+    assertFieldExists(assert, 'embedded');
     selections = {
       ...selections,
       [`${testRealmURL}pet/ToyField`]: {
         cardId: specId,
         fieldIndex: 0,
-        format: 'edit',
+        format: 'embedded',
       },
     };
     assert.deepEqual(
@@ -821,11 +848,12 @@ module('Acceptance | code-submode | field playground', function (hooks) {
       selections,
       'persisted selections are correct',
     );
+    // await this.pauseTest();
 
     await selectDeclaration('PetCard');
     await selectDeclaration('ToyField');
-    assert.dom('[data-test-instance-chooser]').hasText('ToyField - Example 1');
-    assertFieldExists(assert, 'edit');
+    assert.dom('[data-test-instance-chooser]').hasText('Toy - Example 1');
+    assertFieldExists(assert, 'embedded');
     assert.deepEqual(
       getPlaygroundSelections(),
       selections,

--- a/packages/host/tests/acceptance/code-submode/field-playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/field-playground-test.gts
@@ -1,4 +1,4 @@
-import { click, fillIn, waitUntil } from '@ember/test-helpers';
+import { click, fillIn, settled } from '@ember/test-helpers';
 
 import { module, test } from 'qunit';
 
@@ -881,14 +881,14 @@ module('Acceptance | code-submode | field playground', function (hooks) {
       }
     }`;
     await openFileInPlayground('blog-post.gts', testRealmURL, 'Comment');
+    assertFieldExists(assert, 'embedded');
     assert
       .dom('[data-test-embedded-comment-title]')
       .hasText('Terrible product');
-    await realm.write('blog-post.gts', updatedCommentField),
-      await waitUntil(
-        () =>
-          document.querySelector('[data-test-embedded-comment-title]') === null,
-      );
+
+    await realm.write('blog-post.gts', updatedCommentField);
+    await settled();
+    assertFieldExists(assert, 'embedded');
     assert.dom('[data-test-embedded-comment-title]').doesNotExist();
   });
 });

--- a/packages/host/tests/acceptance/code-submode/field-playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/field-playground-test.gts
@@ -832,6 +832,7 @@ module('Acceptance | code-submode | field playground', function (hooks) {
     };
     setRecentFiles([[testRealmURL, 'Pet/mango.json']]);
     setPlaygroundSelections(selections);
+
     await openFileInPlayground('pet.gts', testRealmURL, 'ToyField');
     assert.dom('[data-test-instance-chooser]').hasText('Toy - Example 1');
     assertFieldExists(assert, 'embedded');
@@ -848,9 +849,9 @@ module('Acceptance | code-submode | field playground', function (hooks) {
       selections,
       'persisted selections are correct',
     );
-    // await this.pauseTest();
 
     await selectDeclaration('PetCard');
+    assertCardExists(assert, cardId, 'isolated');
     await selectDeclaration('ToyField');
     assert.dom('[data-test-instance-chooser]').hasText('Toy - Example 1');
     assertFieldExists(assert, 'embedded');

--- a/packages/host/tests/helpers/playground.ts
+++ b/packages/host/tests/helpers/playground.ts
@@ -9,6 +9,8 @@ import type { Format } from 'https://cardstack.com/base/card-api';
 
 import { testRealmURL, visitOperatorMode } from './index';
 
+export type { Format, PlaygroundSelection };
+
 export const assertCardExists = (
   assert: Assert,
   cardId: string,


### PR DESCRIPTION
The PR fixes these recently-introduced errors and brings the field playground back to an acceptable state:
- After previewing a card in playground, switching to a field-def preview persists the last viewed card instead of persisting the spec card
- Making an edit to field module caused a blank screen in field playground preview
- Spec panel could override the persisted format as `undefined`