### PR TITLE
realm: Restore skipped realm event tests

### DIFF
--- a/packages/realm-server/tests/realm-endpoints-test.ts
+++ b/packages/realm-server/tests/realm-endpoints-test.ts
@@ -984,7 +984,7 @@ async function waitForIncrementalIndexEvent(
   } catch (e) {
     let matrixMessages = await getMessagesSince(since);
 
-    console.log(e);
+    console.log('waitForIncrementalIndexEvent failed, no event found. Events:');
     console.log(JSON.stringify(matrixMessages, null, 2));
     throw e;
   }

--- a/packages/realm-server/tests/realm-endpoints-test.ts
+++ b/packages/realm-server/tests/realm-endpoints-test.ts
@@ -1,9 +1,9 @@
-import { module, skip, test } from 'qunit';
+import { module, test } from 'qunit';
 import supertest, { Test, SuperTest } from 'supertest';
 import { join, resolve, basename } from 'path';
 import { Server } from 'http';
 import { dirSync, type DirResult } from 'tmp';
-import { copySync, ensureDirSync, removeSync, writeJSONSync } from 'fs-extra';
+import { copySync, ensureDirSync } from 'fs-extra';
 import {
   baseRealm,
   loadCard,

--- a/packages/realm-server/tests/realm-endpoints-test.ts
+++ b/packages/realm-server/tests/realm-endpoints-test.ts
@@ -234,7 +234,7 @@ module(basename(__filename), function () {
       assert.deepEqual(testCard.ref, ref, 'card data is correct');
     });
 
-    test('can index a newly added file to the filesystem', async function (assert) {
+    test('can index a newly added file', async function (assert) {
       let realmEventTimestampStart = Date.now();
 
       let postResponse = await request
@@ -338,7 +338,7 @@ module(basename(__filename), function () {
       }
     });
 
-    test('can index a changed file in the filesystem', async function (assert) {
+    test('can index a changed file', async function (assert) {
       let realmEventTimestampStart = Date.now();
 
       {


### PR DESCRIPTION
This restores skipped tests with updated expectations. It removes direct filesystem manipulation as file-watching is no longer present in test environments. A helper now has diagnostic logging to show what realm events have been received when waiting for an incremental indexing event fails.