### PR TITLE
ci: Remove Chrome version number from host reports

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -115,6 +115,10 @@ jobs:
       - name: Merge reports
         run: npx junit-report-merger host.xml "./all-host-reports/*.xml"
 
+      # host.xml has classname="Chrome 134.0", change to classname="Chrome" to prevent false test removal/addition warnings
+      - name: Remove Chrome version number
+        run: sed -i -E 's/classname="Chrome [^"]*"/classname="Chrome"/' host.xml
+
       - name: Upload merged report
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
         if: always()


### PR DESCRIPTION
Having the Chrome version causes the test reporter to say [tests have been removed and added (renamed)](https://github.com/cardstack/boxel/pull/2279#issuecomment-2719058196) when the Actions environment just has a new browser version:

<img width="908" alt="boxel 2025-04-08 15-30-20" src="https://github.com/user-attachments/assets/2fe683a7-684c-4e3b-a7ae-11eaf671ae65" />

Naturally the report produced by this change has the same noise but once merged the removal/addition warning should become more reliably meaningful!

<img width="912" alt="boxel 2025-04-08 15-46-03" src="https://github.com/user-attachments/assets/977286e7-c124-48d5-b479-f11095d9b338" />
