### PR TITLE
Fixing run away search issues in code mode

### DIFF
--- a/packages/base/cards-grid.gts
+++ b/packages/base/cards-grid.gts
@@ -137,6 +137,7 @@ class Isolated extends Component<typeof CardsGrid> {
               @query={{this.query}}
               @format='fitted'
               @realms={{this.realms}}
+              @isLive={{true}}
             >
 
               <:loading>

--- a/packages/experiments-realm/ai-app-generator.gts
+++ b/packages/experiments-realm/ai-app-generator.gts
@@ -140,6 +140,7 @@ class CardListSidebar extends GlimmerComponent<{
         @query={{@query}}
         @format='fitted'
         @realms={{@realms}}
+        @isLive={{true}}
       >
         <:loading>Loading...</:loading>
         <:response as |cards|>
@@ -412,6 +413,7 @@ class RequirementsTab extends GlimmerComponent<{
           @query={{getCardTypeQuery this.cardRef}}
           @format='fitted'
           @realms={{@realms}}
+          @isLive={{true}}
         >
           <:loading>Loading...</:loading>
           <:response as |cards|>

--- a/packages/experiments-realm/app-card.gts
+++ b/packages/experiments-realm/app-card.gts
@@ -173,6 +173,7 @@ class DefaultTabTemplate extends GlimmerComponent<DefaultTabSignature> {
           @query={{this.query}}
           @format='fitted'
           @realms={{@realms}}
+          @isLive={{true}}
         >
           <:loading>Loading...</:loading>
           <:response as |cards|>

--- a/packages/experiments-realm/components/card-list.gts
+++ b/packages/experiments-realm/components/card-list.gts
@@ -33,6 +33,7 @@ export class CardList extends GlimmerComponent<CardListSignature> {
           @query={{@query}}
           @format='embedded'
           @realms={{@realms}}
+          @isLive={{true}}
         >
           <:loading>
             Loading...

--- a/packages/experiments-realm/components/grid.gts
+++ b/packages/experiments-realm/components/grid.gts
@@ -30,6 +30,7 @@ export class CardsGrid extends GlimmerComponent<CardsGridSignature> {
           @query={{@query}}
           @format='fitted'
           @realms={{@realms}}
+          @isLive={{true}}
         >
           <:loading>
             Loading...

--- a/packages/host/app/components/card-catalog/modal.gts
+++ b/packages/host/app/components/card-catalog/modal.gts
@@ -9,7 +9,6 @@ import Component from '@glimmer/component';
 
 import { restartableTask, task, timeout } from 'ember-concurrency';
 import focusTrap from 'ember-focus-trap/modifiers/focus-trap';
-import { consume } from 'ember-provide-consume-context';
 
 import flatMap from 'lodash/flatMap';
 
@@ -21,8 +20,6 @@ import { eq, not } from '@cardstack/boxel-ui/helpers';
 import {
   type CodeRef,
   type CreateNewCard,
-  type getCards,
-  type getCard,
   createNewCard,
   baseRealm,
   Deferred,
@@ -30,8 +27,6 @@ import {
   RealmInfo,
   CardCatalogQuery,
   isCardInstance,
-  GetCardContextName,
-  GetCardsContextName,
 } from '@cardstack/runtime-common';
 
 import type {
@@ -75,7 +70,6 @@ interface Signature {
 }
 
 type Request = {
-  search: ReturnType<getCards>;
   deferred: Deferred<string | undefined>;
   opts?: {
     offerToCreate?: {
@@ -235,9 +229,6 @@ export default class CardCatalogModal extends Component<Signature> {
     </style>
   </template>
 
-  @consume(GetCardContextName) private declare getCard: getCard;
-  @consume(GetCardsContextName) private declare getCards: getCards;
-
   private stateStack: State[] = new TrackedArray<State>();
   private stateId = 0;
   @service private declare cardService: CardService;
@@ -366,7 +357,6 @@ export default class CardCatalogModal extends Component<Signature> {
         opts?.multiSelect,
       );
       let request = new TrackedObject<Request>({
-        search: this.getCards(this, () => query),
         deferred: new Deferred(),
         opts,
       });

--- a/packages/host/app/components/operator-mode/code-submode/playground/spec-search.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/spec-search.gts
@@ -42,7 +42,6 @@ export default class SpecSearch extends Component<Signature> {
       this,
       () => this.args.query,
       () => this.args.realms,
-      { isLive: true },
     );
   };
 

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -473,8 +473,8 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
   @tracked private search: ReturnType<getCards<Spec>> | undefined;
 
   // We need a way to shield ourselves from the fact that ultimately the
-  // ModuleContentsResource's declarations are not strict equal after a loader reset,
-  // but still structurally the same (like a strictEqual vs deepEqual). This value
+  // ModuleContentsResource's declarations are not strict equal after a source file change,
+  // but may still be structurally the same (like a strictEqual vs deepEqual). This value
   // ultimately is consumed by the search resource, and even though the value never
   // changes from a deepEqual perspective, because of reactivity the search thunk is
   // triggered because it is not equivalent in a strict equality sense. So we use a

--- a/packages/host/app/components/prerendered-card-search.gts
+++ b/packages/host/app/components/prerendered-card-search.gts
@@ -176,6 +176,8 @@ export default class PrerenderedCardSearch extends Component<Signature> {
     let { query, format, cardUrls, realms } = this.args;
 
     let realmsChanged = !isEqual(realms, this._lastRealms);
+    // guard against a query that is deeply equal to the last query, but not strictly equal
+    let queryChanged = !isEqual(query, this._lastSearchQuery);
     if (realmsChanged) {
       this._lastSearchResults = this._lastSearchResults?.filter((r) =>
         realms.includes(r.realmUrl),
@@ -186,6 +188,7 @@ export default class PrerenderedCardSearch extends Component<Signature> {
 
     if (
       query &&
+      queryChanged &&
       format &&
       (realmsChanged || this.realmsNeedingRefresh.size > 0)
     ) {

--- a/packages/host/app/components/prerendered-card-search.gts
+++ b/packages/host/app/components/prerendered-card-search.gts
@@ -105,6 +105,7 @@ interface Signature {
     format: Format;
     cardUrls?: string[];
     realms: string[];
+    isLive?: boolean;
   };
   Blocks: {
     loading: [];
@@ -265,7 +266,9 @@ export default class PrerenderedCardSearch extends Component<Signature> {
   };
 
   <template>
-    {{SubscribeToRealms @realms this.markRealmNeedsRefreshing}}
+    {{#if @isLive}}
+      {{SubscribeToRealms @realms this.markRealmNeedsRefreshing}}
+    {{/if}}
     {{#if this.searchResults.isLoading}}
       {{yield to='loading'}}
     {{else}}

--- a/packages/host/tests/integration/commands/use-ai-assistant-test.gts
+++ b/packages/host/tests/integration/commands/use-ai-assistant-test.gts
@@ -317,7 +317,6 @@ module('Integration | commands | ai-assistant', function (hooks) {
     );
   });
 
-
   test('sets active LLM model when llmModel is provided', async function (assert) {
     let roomId = createAndJoinRoom({
       sender: '@testuser:localhost',

--- a/packages/realm-server/tests/cards/person-with-error.gts
+++ b/packages/realm-server/tests/cards/person-with-error.gts
@@ -57,6 +57,7 @@ export class PersonCard extends CardDef {
           @query={{this.query}}
           @format='fitted'
           @realms={{this.realms}}
+          @isLive={{true}}
         >
 
           <:loading>

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -286,7 +286,7 @@ export type getCard<T extends CardDef = CardDef> = (
   api: typeof CardAPI;
 };
 
-export type getCards = (
+export type getCards<T extends CardDef = CardDef> = (
   parent: object,
   getQuery: () => Query | undefined,
   getRealms?: () => string[] | undefined,
@@ -296,8 +296,8 @@ export type getCards = (
   },
 ) => // This is a duck type of the SearchResource
 {
-  instances: CardDef[];
-  instancesByRealm: { realm: string; cards: CardDef[] }[];
+  instances: T[];
+  instancesByRealm: { realm: string; cards: T[] }[];
   isLoading: boolean;
 };
 

--- a/packages/seed-realm/app-card.gts
+++ b/packages/seed-realm/app-card.gts
@@ -173,6 +173,7 @@ class DefaultTabTemplate extends GlimmerComponent<DefaultTabSignature> {
           @query={{this.query}}
           @format='fitted'
           @realms={{@realms}}
+          @isLive={{true}}
         >
           <:loading>Loading...</:loading>
           <:response as |cards|>

--- a/packages/seed-realm/components/card-list.gts
+++ b/packages/seed-realm/components/card-list.gts
@@ -33,6 +33,7 @@ export class CardList extends GlimmerComponent<CardListSignature> {
           @query={{@query}}
           @format='embedded'
           @realms={{@realms}}
+          @isLive={{true}}
         >
           <:loading>
             Loading...

--- a/packages/seed-realm/components/grid.gts
+++ b/packages/seed-realm/components/grid.gts
@@ -30,6 +30,7 @@ export class CardsGrid extends GlimmerComponent<CardsGridSignature> {
           @query={{@query}}
           @format='fitted'
           @realms={{@realms}}
+          @isLive={{true}}
         >
           <:loading>
             Loading...


### PR DESCRIPTION
So the issue that triggered all the searches in code mode was a very subtle yet super pathological issue around reactivity resulting in a geometric expansion in the number of search queries run after each indexing event. Ultimately the ModuleContentsResource was rebuilding the declaration on the code changes from the module. that resulted in a bunch of calls to rebuild the declarations within this resource. reactivity in glimmer is triggered based on strict equality. think of strictEquals() vs deepEquals() in our unit tests. you can have 2 instances of `{blah: "foo"}` and `{blah: "foo"}`. These are not strictly equal, but they are deeply equal. This was basically the issue. about 8 degrees of separation live between the ModuleContentsResource.declations and the resulting search query for the spec, all chained together using getters that are reactive. the module declaration would change each time there was an edit in code module to the module source code, but ultimately the module declarations were deeply equal. Regardless, that is not how glimmer reactivity works. So even though the search query never changed from a deep equality standpoint, it was not strictly equal after each code change, and as a result the search would re-run (against all the realms). Moreover, this was set as a live search, and a new live search callback would be registered with each "query change"--which compounded the searches resulting in a geometric expansion of all the searches being run.

Also, as part of this I noticed that we were forcing all prerendered searches to be live bound. there are many scenarios where we don't want that actually, so i made this a param for prerendered search. As well as Prerendered Search had the same vulnerability where it would re-run for queries that were not stricty equal, but were deeply equal

Also, i removed the getSearch and used the provided/consume pattern instead.

After this change, there are no search queries that are issued after each code change  made in code mode:

https://github.com/user-attachments/assets/fda69d1f-e100-4c62-935c-08fe7abd716d

