### PR TITLE
Playground create-instance bug

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
@@ -244,8 +244,12 @@ export default class PlaygroundPanel extends Component<Signature> {
     }
   }
 
+  private get currentRealm() {
+    return this.operatorModeStateService.realmURL.href;
+  }
+
   private get canWriteRealm() {
-    return this.realm.canWrite(this.operatorModeStateService.realmURL.href);
+    return this.realm.canWrite(this.currentRealm);
   }
 
   @action handleClick(e: MouseEvent) {
@@ -361,7 +365,7 @@ export default class PlaygroundPanel extends Component<Signature> {
               ],
             },
             adoptsFrom: specRef,
-            realmURL: this.operatorModeStateService.realmURL.href,
+            realmURL: this.currentRealm,
           },
         },
       };
@@ -370,12 +374,16 @@ export default class PlaygroundPanel extends Component<Signature> {
         data: {
           meta: {
             adoptsFrom: this.args.codeRef,
-            realmURL: this.operatorModeStateService.realmURL.href,
+            realmURL: this.currentRealm,
           },
         },
       };
     }
-    let cardId = await this.store.create(newCardJSON, undefined);
+    let cardId = await this.store.create(
+      newCardJSON,
+      undefined,
+      this.currentRealm,
+    );
     if (typeof cardId === 'string') {
       this.recentFilesService.addRecentFileUrl(`${cardId}.json`);
       this.persistSelections(

--- a/packages/host/tests/acceptance/code-submode/card-playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/card-playground-test.gts
@@ -6,6 +6,8 @@ import { module, test } from 'qunit';
 
 import type { Realm } from '@cardstack/runtime-common';
 
+import type RealmServerService from '@cardstack/host/services/realm-server';
+
 import {
   percySnapshot,
   setupAcceptanceTestRealm,
@@ -35,680 +37,624 @@ import {
 } from '../../helpers/playground';
 import { setupApplicationTest } from '../../helpers/setup';
 
-let matrixRoomId: string;
-module('Acceptance | code-submode | card playground', function (hooks) {
-  let realm: Realm;
-  setupApplicationTest(hooks);
-  setupLocalIndexing(hooks);
+const codeRefDriverCard = `import { CardDef, field, contains } from 'https://cardstack.com/base/card-api';
+  import { Component } from 'https://cardstack.com/base/card-api';
+  import CodeRefField from 'https://cardstack.com/base/code-ref';
+  export class CodeRefDriver extends CardDef {
+    static displayName = "Code Ref Driver";
+    @field ref = contains(CodeRefField);
+}`;
 
-  let mockMatrixUtils = setupMockMatrix(hooks, {
-    loggedInAs: '@testuser:localhost',
-    activeRealms: [testRealmURL],
-  });
-
-  let { setRealmPermissions, setActiveRealms, createAndJoinRoom } =
-    mockMatrixUtils;
-
-  setupOnSave(hooks);
-
-  const codeRefDriverCard = `import { CardDef, field, contains } from 'https://cardstack.com/base/card-api';
-    import { Component } from 'https://cardstack.com/base/card-api';
-    import CodeRefField from 'https://cardstack.com/base/code-ref';
-    export class CodeRefDriver extends CardDef {
-      static displayName = "Code Ref Driver";
-      @field ref = contains(CodeRefField);
-  }`;
-
-  const authorCard = `import { contains, field, CardDef, Component } from "https://cardstack.com/base/card-api";
-    import MarkdownField from 'https://cardstack.com/base/markdown';
-    import StringField from "https://cardstack.com/base/string";
-    export class Author extends CardDef {
-      static displayName = 'Author';
-      @field firstName = contains(StringField);
-      @field lastName = contains(StringField);
-      @field bio = contains(MarkdownField);
-      @field title = contains(StringField, {
-        computeVia: function (this: Author) {
-          return [this.firstName, this.lastName].filter(Boolean).join(' ');
-        },
-      });
-      static isolated = class Isolated extends Component<typeof this> {
-      <template>
-        <article>
-          <header>
-            <h1 data-test-author-title><@fields.title /></h1>
-          </header>
-          <div data-test-author-bio><@fields.bio /></div>
-        </article>
-        <style scoped>
-          article {
-            margin-inline: 20px;
-          }
-        </style>
-      </template>
-      }
-  }`;
-
-  const blogPostCard = `import { contains, field, linksTo, linksToMany, CardDef, Component } from "https://cardstack.com/base/card-api";
-    import DatetimeField from 'https://cardstack.com/base/datetime';
-    import MarkdownField from 'https://cardstack.com/base/markdown';
-    import { Author } from './author';
-
-    export class Category extends CardDef {
-      static displayName = 'Category';
-      static fitted = class Fitted extends Component<typeof this> {
-      <template>
-        <div data-test-category-fitted><@fields.title /></div>
-      </template>
-      }
-    }
-
-    class LocalCategoryCard extends Category {}
-
-    export class RandomClass {}
-
-    export class BlogPost extends CardDef {
-      static displayName = 'Blog Post';
-      @field publishDate = contains(DatetimeField);
-      @field author = linksTo(Author);
-      @field categories = linksToMany(Category);
-      @field localCategories = linksToMany(LocalCategoryCard);
-      @field body = contains(MarkdownField);
-
-      static isolated = class Isolated extends Component<typeof this> {
-      <template>
-        <article>
-          <header>
-            <h1 data-test-post-title><@fields.title /></h1>
-          </header>
-          <div data-test-byline><@fields.author /></div>
-          <div data-test-post-body><@fields.body /></div>
-        </article>
-        <style scoped>
-          article {
-            margin-inline: 20px;
-          }
-        </style>
-      </template>
-      }
-  }`;
-
-  hooks.beforeEach(async function () {
-    matrixRoomId = createAndJoinRoom({
-      sender: '@testuser:localhost',
-      name: 'room-test',
-    });
-    setupUserSubscription(matrixRoomId);
-
-    ({ realm } = await setupAcceptanceTestRealm({
-      mockMatrixUtils,
-      realmURL: testRealmURL,
-      contents: {
-        'author.gts': authorCard,
-        'blog-post.gts': blogPostCard,
-        'code-ref-driver.gts': codeRefDriverCard,
-        'Author/jane-doe.json': {
-          data: {
-            attributes: {
-              firstName: 'Jane',
-              lastName: 'Doe',
-              bio: "Jane Doe is the Senior Managing Editor at <em>Ramped.com</em>, where she leads content strategy, editorial direction, and ensures the highest standards of quality across all publications. With over a decade of experience in digital media and editorial management, Jane has a proven track record of shaping impactful narratives, growing engaged audiences, and collaborating with cross-functional teams to deliver compelling content. When she's not editing, you can find her exploring new books, hiking, or indulging in her love of photography.",
-            },
-            meta: {
-              adoptsFrom: {
-                module: `${testRealmURL}author`,
-                name: 'Author',
-              },
-            },
-          },
-        },
-        'BlogPost/remote-work.json': {
-          data: {
-            attributes: {
-              title: 'The Ultimate Guide to Remote Work',
-              description:
-                'In today’s digital age, remote work has transformed from a luxury to a necessity. This comprehensive guide will help you navigate the world of remote work, offering tips, tools, and best practices for success.',
-            },
-            relationships: {
-              author: {
-                links: {
-                  self: `${testRealmURL}Author/jane-doe`,
-                },
-              },
-            },
-            meta: {
-              adoptsFrom: {
-                module: `${testRealmURL}blog-post`,
-                name: 'BlogPost',
-              },
-            },
-          },
-        },
-        'BlogPost/mad-hatter.json': {
-          data: {
-            attributes: { title: 'Mad As a Hatter' },
-            relationships: {
-              author: {
-                links: {
-                  self: `${testRealmURL}Author/jane-doe`,
-                },
-              },
-            },
-            meta: {
-              adoptsFrom: {
-                module: `${testRealmURL}blog-post`,
-                name: 'BlogPost',
-              },
-            },
-          },
-        },
-        'BlogPost/urban-living.json': {
-          data: {
-            attributes: {
-              title:
-                'The Future of Urban Living: Skyscrapers or Sustainable Communities?',
-            },
-            relationships: {
-              author: {
-                links: {
-                  self: `${testRealmURL}Author/jane-doe`,
-                },
-              },
-            },
-            meta: {
-              adoptsFrom: {
-                module: `${testRealmURL}blog-post`,
-                name: 'BlogPost',
-              },
-            },
-          },
-        },
-        'Category/city-design.json': {
-          data: {
-            attributes: { title: 'City Design' },
-            meta: {
-              adoptsFrom: {
-                module: `${testRealmURL}blog-post`,
-                name: 'Category',
-              },
-            },
-          },
-        },
-        'Category/future-tech.json': {
-          data: {
-            attributes: { title: 'Future Tech' },
-            meta: {
-              adoptsFrom: {
-                module: `${testRealmURL}blog-post`,
-                name: 'Category',
-              },
-            },
-          },
-        },
+const authorCard = `import { contains, field, CardDef, Component } from "https://cardstack.com/base/card-api";
+  import MarkdownField from 'https://cardstack.com/base/markdown';
+  import StringField from "https://cardstack.com/base/string";
+  export class Author extends CardDef {
+    static displayName = 'Author';
+    @field firstName = contains(StringField);
+    @field lastName = contains(StringField);
+    @field bio = contains(MarkdownField);
+    @field title = contains(StringField, {
+      computeVia: function (this: Author) {
+        return [this.firstName, this.lastName].filter(Boolean).join(' ');
       },
-    }));
-    setRecentFiles([
-      [testRealmURL, 'blog-post.gts'],
-      [testRealmURL, 'author.gts'],
-      [testRealmURL, 'BlogPost/mad-hatter.json'],
-      [testRealmURL, 'Category/city-design.json'],
-      [testRealmURL, 'Category/future-tech.json'],
-      [testRealmURL, 'BlogPost/remote-work.json'],
-      [testRealmURL, 'BlogPost/urban-living.json'],
-      [testRealmURL, 'Author/jane-doe.json'],
-    ]);
-    removePlaygroundSelections();
-
-    setActiveRealms([testRealmURL]);
-    setRealmPermissions({
-      [testRealmURL]: ['read', 'write'],
     });
-  });
+    static isolated = class Isolated extends Component<typeof this> {
+    <template>
+      <article>
+        <header>
+          <h1 data-test-author-title><@fields.title /></h1>
+        </header>
+        <div data-test-author-bio><@fields.bio /></div>
+      </article>
+      <style scoped>
+        article {
+          margin-inline: 20px;
+        }
+      </style>
+    </template>
+    }
+}`;
 
-  test('can render playground panel when an exported card def is selected', async function (assert) {
-    await visitOperatorMode({
-      submode: 'code',
-      codePath: `${testRealmURL}blog-post.gts`,
+const blogPostCard = `import { contains, field, linksTo, linksToMany, CardDef, Component } from "https://cardstack.com/base/card-api";
+  import DatetimeField from 'https://cardstack.com/base/datetime';
+  import MarkdownField from 'https://cardstack.com/base/markdown';
+  import { Author } from './author';
+
+  export class Category extends CardDef {
+    static displayName = 'Category';
+    static fitted = class Fitted extends Component<typeof this> {
+    <template>
+      <div data-test-category-fitted><@fields.title /></div>
+    </template>
+    }
+  }
+
+  class LocalCategoryCard extends Category {}
+
+  export class RandomClass {}
+
+  export class BlogPost extends CardDef {
+    static displayName = 'Blog Post';
+    @field publishDate = contains(DatetimeField);
+    @field author = linksTo(Author);
+    @field categories = linksToMany(Category);
+    @field localCategories = linksToMany(LocalCategoryCard);
+    @field body = contains(MarkdownField);
+
+    static isolated = class Isolated extends Component<typeof this> {
+    <template>
+      <article>
+        <header>
+          <h1 data-test-post-title><@fields.title /></h1>
+        </header>
+        <div data-test-byline><@fields.author /></div>
+        <div data-test-post-body><@fields.body /></div>
+      </article>
+      <style scoped>
+        article {
+          margin-inline: 20px;
+        }
+      </style>
+    </template>
+    }
+}`;
+
+let matrixRoomId: string;
+
+module('Acceptance | code-submode | card playground', function (_hooks) {
+  module('single realm', function (hooks) {
+    let realm: Realm;
+
+    setupApplicationTest(hooks);
+    setupLocalIndexing(hooks);
+
+    let mockMatrixUtils = setupMockMatrix(hooks, {
+      loggedInAs: '@testuser:localhost',
+      activeRealms: [testRealmURL],
     });
-    assert
-      .dom('[data-test-selected-accordion-item="schema-editor"]')
-      .exists('schema editor is open by default');
-    assert
-      .dom('[data-test-playground-panel]')
-      .doesNotExist('do not load playground unless panel is open');
 
-    await selectDeclaration('Category');
-    await togglePlaygroundPanel();
-    assert
-      .dom('[data-test-playground-panel]')
-      .exists('playground panel exists for Category (exported card def)');
+    let { setRealmPermissions, setActiveRealms, createAndJoinRoom } =
+      mockMatrixUtils;
 
-    await click('[data-test-accordion-item="schema-editor"] > button');
-    await selectDeclaration('LocalCategoryCard');
-    assert.dom('[data-test-incompatible-nonexports]').doesNotExist();
-    await togglePlaygroundPanel();
-    assert
-      .dom('[data-test-playground-panel]')
-      .doesNotExist(
-        'playground preview is not available for LocalCategory (local card def)',
+    setupOnSave(hooks);
+
+    hooks.beforeEach(async function () {
+      matrixRoomId = createAndJoinRoom({
+        sender: '@testuser:localhost',
+        name: 'room-test',
+      });
+      setupUserSubscription(matrixRoomId);
+
+      ({ realm } = await setupAcceptanceTestRealm({
+        mockMatrixUtils,
+        realmURL: testRealmURL,
+        contents: {
+          'author.gts': authorCard,
+          'blog-post.gts': blogPostCard,
+          'code-ref-driver.gts': codeRefDriverCard,
+          'Author/jane-doe.json': {
+            data: {
+              attributes: {
+                firstName: 'Jane',
+                lastName: 'Doe',
+                bio: "Jane Doe is the Senior Managing Editor at <em>Ramped.com</em>, where she leads content strategy, editorial direction, and ensures the highest standards of quality across all publications. With over a decade of experience in digital media and editorial management, Jane has a proven track record of shaping impactful narratives, growing engaged audiences, and collaborating with cross-functional teams to deliver compelling content. When she's not editing, you can find her exploring new books, hiking, or indulging in her love of photography.",
+              },
+              meta: {
+                adoptsFrom: {
+                  module: `${testRealmURL}author`,
+                  name: 'Author',
+                },
+              },
+            },
+          },
+          'BlogPost/remote-work.json': {
+            data: {
+              attributes: {
+                title: 'The Ultimate Guide to Remote Work',
+                description:
+                  'In today’s digital age, remote work has transformed from a luxury to a necessity. This comprehensive guide will help you navigate the world of remote work, offering tips, tools, and best practices for success.',
+              },
+              relationships: {
+                author: {
+                  links: {
+                    self: `${testRealmURL}Author/jane-doe`,
+                  },
+                },
+              },
+              meta: {
+                adoptsFrom: {
+                  module: `${testRealmURL}blog-post`,
+                  name: 'BlogPost',
+                },
+              },
+            },
+          },
+          'BlogPost/mad-hatter.json': {
+            data: {
+              attributes: { title: 'Mad As a Hatter' },
+              relationships: {
+                author: {
+                  links: {
+                    self: `${testRealmURL}Author/jane-doe`,
+                  },
+                },
+              },
+              meta: {
+                adoptsFrom: {
+                  module: `${testRealmURL}blog-post`,
+                  name: 'BlogPost',
+                },
+              },
+            },
+          },
+          'BlogPost/urban-living.json': {
+            data: {
+              attributes: {
+                title:
+                  'The Future of Urban Living: Skyscrapers or Sustainable Communities?',
+              },
+              relationships: {
+                author: {
+                  links: {
+                    self: `${testRealmURL}Author/jane-doe`,
+                  },
+                },
+              },
+              meta: {
+                adoptsFrom: {
+                  module: `${testRealmURL}blog-post`,
+                  name: 'BlogPost',
+                },
+              },
+            },
+          },
+          'Category/city-design.json': {
+            data: {
+              attributes: { title: 'City Design' },
+              meta: {
+                adoptsFrom: {
+                  module: `${testRealmURL}blog-post`,
+                  name: 'Category',
+                },
+              },
+            },
+          },
+          'Category/future-tech.json': {
+            data: {
+              attributes: { title: 'Future Tech' },
+              meta: {
+                adoptsFrom: {
+                  module: `${testRealmURL}blog-post`,
+                  name: 'Category',
+                },
+              },
+            },
+          },
+        },
+      }));
+
+      setRecentFiles([
+        [testRealmURL, 'blog-post.gts'],
+        [testRealmURL, 'author.gts'],
+        [testRealmURL, 'BlogPost/mad-hatter.json'],
+        [testRealmURL, 'Category/city-design.json'],
+        [testRealmURL, 'Category/future-tech.json'],
+        [testRealmURL, 'BlogPost/remote-work.json'],
+        [testRealmURL, 'BlogPost/urban-living.json'],
+        [testRealmURL, 'Author/jane-doe.json'],
+      ]);
+      removePlaygroundSelections();
+
+      setActiveRealms([testRealmURL]);
+      setRealmPermissions({
+        [testRealmURL]: ['read', 'write'],
+      });
+    });
+
+    test('can render playground panel when an exported card def is selected', async function (assert) {
+      await visitOperatorMode({
+        submode: 'code',
+        codePath: `${testRealmURL}blog-post.gts`,
+      });
+      assert
+        .dom('[data-test-selected-accordion-item="schema-editor"]')
+        .exists('schema editor is open by default');
+      assert
+        .dom('[data-test-playground-panel]')
+        .doesNotExist('do not load playground unless panel is open');
+
+      await selectDeclaration('Category');
+      await togglePlaygroundPanel();
+      assert
+        .dom('[data-test-playground-panel]')
+        .exists('playground panel exists for Category (exported card def)');
+
+      await click('[data-test-accordion-item="schema-editor"] > button');
+      await selectDeclaration('LocalCategoryCard');
+      assert.dom('[data-test-incompatible-nonexports]').doesNotExist();
+      await togglePlaygroundPanel();
+      assert
+        .dom('[data-test-playground-panel]')
+        .doesNotExist(
+          'playground preview is not available for LocalCategory (local card def)',
+        );
+      assert.dom('[data-test-incompatible-nonexports]').exists();
+
+      await selectDeclaration('RandomClass');
+      assert
+        .dom('[data-test-accordion-item="playground"]')
+        .doesNotExist(
+          'does not exist for RandomClass (not a card or field def)',
+        );
+
+      await selectDeclaration('BlogPost');
+      assert
+        .dom('[data-test-playground-panel]')
+        .exists('exists for BlogPost (exported card def)');
+    });
+
+    test('can populate instance chooser dropdown options from recent files', async function (assert) {
+      removeRecentFiles();
+      setRecentFiles([
+        [testRealmURL, 'BlogPost/mad-hatter.json'],
+        [testRealmURL, 'Category/future-tech.json'],
+        [testRealmURL, 'Category/city-design.json'],
+        [testRealmURL, 'BlogPost/remote-work.json'],
+        [testRealmURL, 'BlogPost/urban-living.json'],
+        [testRealmURL, 'Author/jane-doe.json'],
+      ]);
+      await openFileInPlayground('blog-post.gts', testRealmURL, 'Category');
+      assert.dom('[data-test-instance-chooser]').hasText('Please Select');
+
+      await click('[data-test-instance-chooser]');
+      assert
+        .dom('[data-option-index] [data-test-category-fitted]')
+        .exists({ count: 2 });
+
+      await click('[data-option-index="1"]');
+      assert.dom('[data-test-selected-item]').hasText('Future Tech');
+
+      await percySnapshot(assert);
+    });
+
+    test('can update the instance chooser when selected card def changes (same file)', async function (assert) {
+      await openFileInPlayground('blog-post.gts', testRealmURL, 'Category');
+      await click('[data-test-instance-chooser]');
+      assert.dom('[data-option-index]').exists({ count: 2 });
+      assert.dom('[data-option-index="0"]').containsText('City Design');
+      await click('[data-option-index="0"]');
+      assert.dom('[data-test-selected-item]').containsText('City Design');
+
+      await selectDeclaration('BlogPost');
+      await click('[data-test-instance-chooser]');
+      assert.dom('[data-option-index]').exists({ count: 3 });
+      assert.dom('[data-option-index="0"]').containsText('Mad As a Hatter');
+      await click('[data-option-index="0"]');
+      assert.dom('[data-test-selected-item]').containsText('Mad As a Hatter');
+    });
+
+    test('can update the instance chooser when a different file is opened', async function (assert) {
+      await openFileInPlayground('blog-post.gts', testRealmURL, 'Category');
+      await click('[data-test-instance-chooser]');
+      assert.dom('[data-option-index]').exists({ count: 2 });
+      assert.dom('[data-option-index="0"]').containsText('City Design');
+      await click('[data-option-index="0"]');
+      assert.dom('[data-test-selected-item]').containsText('City Design');
+
+      await click('[data-test-file-browser-toggle]');
+      await click('[data-test-file="author.gts"]');
+      await togglePlaygroundPanel();
+      assert.dom('[data-test-instance-chooser]').hasText('Please Select');
+      await click('[data-test-instance-chooser]');
+      assert.dom('li.ember-power-select-option').exists({ count: 1 });
+      assert.dom('[data-option-index="0"]').containsText('Jane Doe');
+      await click('[data-option-index="0"]');
+      assert.dom('[data-test-selected-item]').containsText('Jane Doe');
+    });
+
+    test('can use the header context menu to open instance in code mode', async function (assert) {
+      await openFileInPlayground('author.gts', testRealmURL, 'Author');
+      await click('[data-test-instance-chooser]');
+      await click('[data-option-index="0"]');
+      await click('[data-test-more-options-button]');
+      assert
+        .dom('[data-test-boxel-dropdown-content] [data-test-boxel-menu-item]')
+        .exists({ count: 3 });
+
+      await click('[data-test-boxel-menu-item-text="Open in Code Mode"]');
+      assert
+        .dom(
+          `[data-test-code-mode-card-preview-header="${testRealmURL}Author/jane-doe"]`,
+        )
+        .exists();
+      assert.dom('[data-test-accordion-item="playground"]').doesNotExist();
+    });
+
+    test('can use the header context menu to open instance in interact mode', async function (assert) {
+      await openFileInPlayground('author.gts', testRealmURL, 'Author');
+      await click('[data-test-instance-chooser]');
+      await click('[data-option-index="0"]');
+      await click('[data-test-more-options-button]');
+      await click('[data-test-boxel-menu-item-text="Open in Interact Mode"]');
+      assert
+        .dom(
+          `[data-test-stack-card-index="0"][data-test-stack-card="${testRealmURL}Author/jane-doe"]`,
+        )
+        .exists();
+      assert.dom('[data-test-author-title]').hasText('Jane Doe');
+    });
+
+    test('can display selected card in the chosen format', async function (assert) {
+      const cardId = `${testRealmURL}Author/jane-doe`;
+      await openFileInPlayground('author.gts', testRealmURL, 'Author');
+      await click('[data-test-instance-chooser]');
+      await click('[data-option-index="0"]');
+      assert
+        .dom('[data-test-playground-panel] [data-test-boxel-card-header-title]')
+        .hasText('Author');
+      assertCardExists(assert, cardId, 'isolated');
+      assert.dom('[data-test-author-title]').hasText('Jane Doe');
+      assert
+        .dom('[data-test-author-bio]')
+        .containsText('Jane Doe is the Senior Managing Editor');
+      assert.dom('[data-test-format-chooser="isolated"]').hasClass('active');
+
+      await selectFormat('embedded');
+      assert.dom('[data-test-format-chooser="isolated"]').hasNoClass('active');
+      assert.dom('[data-test-format-chooser="embedded"]').hasClass('active');
+      assert
+        .dom('[data-test-playground-panel] [data-test-boxel-card-header-title]')
+        .doesNotExist();
+      assertCardExists(assert, cardId, 'embedded');
+
+      await selectFormat('edit');
+      assert.dom('[data-test-format-chooser="embedded"]').hasNoClass('active');
+      assert.dom('[data-test-format-chooser="edit"]').hasClass('active');
+      assert
+        .dom('[data-test-playground-panel] [data-test-boxel-card-header-title]')
+        .hasText('Author');
+      assertCardExists(assert, cardId, 'edit');
+
+      await selectFormat('atom');
+      assert.dom('[data-test-format-chooser="edit"]').hasNoClass('active');
+      assert.dom('[data-test-format-chooser="atom"]').hasClass('active');
+
+      assert
+        .dom('[data-test-atom-preview]')
+        .hasText(
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do Jane Doe tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+        );
+
+      await selectFormat('fitted');
+      assert.dom('[data-test-format-chooser="atom"]').hasNoClass('active');
+      assert.dom('[data-test-format-chooser="fitted"]').hasClass('active');
+      assert
+        .dom('[data-test-playground-panel] [data-test-card-format="fitted"]')
+        .exists({ count: 16 });
+    });
+
+    test('can toggle edit format via button on card header', async function (assert) {
+      const cardId = `${testRealmURL}Author/jane-doe`;
+      await openFileInPlayground('author.gts', testRealmURL, 'Author');
+      await click('[data-test-instance-chooser]');
+      await click('[data-option-index="0"]');
+      assert
+        .dom('[data-test-playground-panel] [data-test-boxel-card-header-title]')
+        .hasText('Author');
+      assertCardExists(assert, cardId, 'isolated');
+      assert.dom('[data-test-author-title]').hasText('Jane Doe');
+      assert.dom('[data-test-format-chooser="isolated"]').hasClass('active');
+
+      await click(
+        '[data-test-boxel-card-header-actions] [data-test-edit-button]',
       );
-    assert.dom('[data-test-incompatible-nonexports]').exists();
+      assertCardExists(assert, cardId, 'edit');
+      assert.dom('[data-test-card-header]').hasClass('is-editing');
+      assert.dom('[data-test-format-chooser="isolated"]').hasNoClass('active');
+      assert.dom('[data-test-format-chooser="edit"]').hasClass('active');
 
-    await selectDeclaration('RandomClass');
-    assert
-      .dom('[data-test-accordion-item="playground"]')
-      .doesNotExist('does not exist for RandomClass (not a card or field def)');
+      await click(
+        '[data-test-boxel-card-header-actions] [data-test-edit-button]',
+      );
+      assertCardExists(assert, cardId, 'isolated');
+      assert.dom('[data-test-card-header]').hasNoClass('is-editing');
+      assert.dom('[data-test-format-chooser="edit"]').hasNoClass('active');
+      assert.dom('[data-test-format-chooser="isolated"]').hasClass('active');
+    });
 
-    await selectDeclaration('BlogPost');
-    assert
-      .dom('[data-test-playground-panel]')
-      .exists('exists for BlogPost (exported card def)');
-  });
+    test('can use the header context menu to open instance in edit format in interact mode', async function (assert) {
+      await openFileInPlayground('author.gts', testRealmURL, 'Author');
+      await click('[data-test-instance-chooser]');
+      await click('[data-option-index="0"]');
+      await selectFormat('edit');
+      await click('[data-test-more-options-button]');
+      await click('[data-test-boxel-menu-item-text="Open in Interact Mode"]');
+      assert
+        .dom(
+          `[data-test-stack-card-index="0"][data-test-stack-card="${testRealmURL}Author/jane-doe"]`,
+        )
+        .exists();
+      assert
+        .dom(`[data-test-stack-item-content] [data-test-card-format="edit"]`)
+        .exists();
+    });
 
-  test('can populate instance chooser dropdown options from recent files', async function (assert) {
-    removeRecentFiles();
-    setRecentFiles([
-      [testRealmURL, 'BlogPost/mad-hatter.json'],
-      [testRealmURL, 'Category/future-tech.json'],
-      [testRealmURL, 'Category/city-design.json'],
-      [testRealmURL, 'BlogPost/remote-work.json'],
-      [testRealmURL, 'BlogPost/urban-living.json'],
-      [testRealmURL, 'Author/jane-doe.json'],
-    ]);
-    await openFileInPlayground('blog-post.gts', testRealmURL, 'Category');
-    assert.dom('[data-test-instance-chooser]').hasText('Please Select');
+    test('can choose another instance to be opened in playground panel', async function (assert) {
+      removeRecentFiles();
+      await openFileInPlayground('blog-post.gts', testRealmURL, 'BlogPost');
+      await chooseAnotherInstance();
+      assert.dom('[data-test-card-catalog-modal]').exists();
+      assert.dom('[data-test-card-catalog-item]').exists({ count: 3 });
+      assert
+        .dom(
+          `[data-test-card-catalog-item="${testRealmURL}BlogPost/mad-hatter"]`,
+        )
+        .exists();
+      assert
+        .dom(
+          `[data-test-card-catalog-item="${testRealmURL}BlogPost/urban-living"]`,
+        )
+        .exists();
+      assert
+        .dom(
+          `[data-test-card-catalog-item="${testRealmURL}BlogPost/remote-work"]`,
+        )
+        .exists();
 
-    await click('[data-test-instance-chooser]');
-    assert
-      .dom('[data-option-index] [data-test-category-fitted]')
-      .exists({ count: 2 });
+      await click(
+        `[data-test-card-catalog-item="${testRealmURL}BlogPost/mad-hatter"]`,
+      );
+      await click('[data-test-card-catalog-go-button]');
+      assertCardExists(
+        assert,
+        `${testRealmURL}BlogPost/mad-hatter`,
+        'isolated',
+      );
+      assert.deepEqual(getRecentFiles()?.[0], [
+        testRealmURL,
+        'BlogPost/mad-hatter.json',
+        null,
+      ]);
+    });
 
-    await click('[data-option-index="1"]');
-    assert.dom('[data-test-selected-item]').hasText('Future Tech');
+    test('can create new instance', async function (assert) {
+      removeRecentFiles();
+      await visitOperatorMode({
+        submode: 'code',
+        codePath: `${testRealmURL}blog-post.gts`,
+      });
+      assert.deepEqual(getRecentFiles()?.[0], [
+        testRealmURL,
+        'blog-post.gts',
+        { line: 6, column: 40 },
+      ]);
+      await click('[data-boxel-selector-item-text="BlogPost"]');
+      await togglePlaygroundPanel();
+      assert
+        .dom('[data-test-instance-chooser] [data-test-selected-item]')
+        .doesNotExist();
 
-    await percySnapshot(assert);
-  });
+      await createNewInstance();
 
-  test('can update the instance chooser when selected card def changes (same file)', async function (assert) {
-    await openFileInPlayground('blog-post.gts', testRealmURL, 'Category');
-    await click('[data-test-instance-chooser]');
-    assert.dom('[data-option-index]').exists({ count: 2 });
-    assert.dom('[data-option-index="0"]').containsText('City Design');
-    await click('[data-option-index="0"]');
-    assert.dom('[data-test-selected-item]').containsText('City Design');
-
-    await selectDeclaration('BlogPost');
-    await click('[data-test-instance-chooser]');
-    assert.dom('[data-option-index]').exists({ count: 3 });
-    assert.dom('[data-option-index="0"]').containsText('Mad As a Hatter');
-    await click('[data-option-index="0"]');
-    assert.dom('[data-test-selected-item]').containsText('Mad As a Hatter');
-  });
-
-  test('can update the instance chooser when a different file is opened', async function (assert) {
-    await openFileInPlayground('blog-post.gts', testRealmURL, 'Category');
-    await click('[data-test-instance-chooser]');
-    assert.dom('[data-option-index]').exists({ count: 2 });
-    assert.dom('[data-option-index="0"]').containsText('City Design');
-    await click('[data-option-index="0"]');
-    assert.dom('[data-test-selected-item]').containsText('City Design');
-
-    await click('[data-test-file-browser-toggle]');
-    await click('[data-test-file="author.gts"]');
-    await togglePlaygroundPanel();
-    assert.dom('[data-test-instance-chooser]').hasText('Please Select');
-    await click('[data-test-instance-chooser]');
-    assert.dom('li.ember-power-select-option').exists({ count: 1 });
-    assert.dom('[data-option-index="0"]').containsText('Jane Doe');
-    await click('[data-option-index="0"]');
-    assert.dom('[data-test-selected-item]').containsText('Jane Doe');
-  });
-
-  test('can use the header context menu to open instance in code mode', async function (assert) {
-    await openFileInPlayground('author.gts', testRealmURL, 'Author');
-    await click('[data-test-instance-chooser]');
-    await click('[data-option-index="0"]');
-    await click('[data-test-more-options-button]');
-    assert
-      .dom('[data-test-boxel-dropdown-content] [data-test-boxel-menu-item]')
-      .exists({ count: 3 });
-
-    await click('[data-test-boxel-menu-item-text="Open in Code Mode"]');
-    assert
-      .dom(
-        `[data-test-code-mode-card-preview-header="${testRealmURL}Author/jane-doe"]`,
-      )
-      .exists();
-    assert.dom('[data-test-accordion-item="playground"]').doesNotExist();
-  });
-
-  test('can use the header context menu to open instance in interact mode', async function (assert) {
-    await openFileInPlayground('author.gts', testRealmURL, 'Author');
-    await click('[data-test-instance-chooser]');
-    await click('[data-option-index="0"]');
-    await click('[data-test-more-options-button]');
-    await click('[data-test-boxel-menu-item-text="Open in Interact Mode"]');
-    assert
-      .dom(
-        `[data-test-stack-card-index="0"][data-test-stack-card="${testRealmURL}Author/jane-doe"]`,
-      )
-      .exists();
-    assert.dom('[data-test-author-title]').hasText('Jane Doe');
-  });
-
-  test('can display selected card in the chosen format', async function (assert) {
-    const cardId = `${testRealmURL}Author/jane-doe`;
-    await openFileInPlayground('author.gts', testRealmURL, 'Author');
-    await click('[data-test-instance-chooser]');
-    await click('[data-option-index="0"]');
-    assert
-      .dom('[data-test-playground-panel] [data-test-boxel-card-header-title]')
-      .hasText('Author');
-    assertCardExists(assert, cardId, 'isolated');
-    assert.dom('[data-test-author-title]').hasText('Jane Doe');
-    assert
-      .dom('[data-test-author-bio]')
-      .containsText('Jane Doe is the Senior Managing Editor');
-    assert.dom('[data-test-format-chooser="isolated"]').hasClass('active');
-
-    await selectFormat('embedded');
-    assert.dom('[data-test-format-chooser="isolated"]').hasNoClass('active');
-    assert.dom('[data-test-format-chooser="embedded"]').hasClass('active');
-    assert
-      .dom('[data-test-playground-panel] [data-test-boxel-card-header-title]')
-      .doesNotExist();
-    assertCardExists(assert, cardId, 'embedded');
-
-    await selectFormat('edit');
-    assert.dom('[data-test-format-chooser="embedded"]').hasNoClass('active');
-    assert.dom('[data-test-format-chooser="edit"]').hasClass('active');
-    assert
-      .dom('[data-test-playground-panel] [data-test-boxel-card-header-title]')
-      .hasText('Author');
-    assertCardExists(assert, cardId, 'edit');
-
-    await selectFormat('atom');
-    assert.dom('[data-test-format-chooser="edit"]').hasNoClass('active');
-    assert.dom('[data-test-format-chooser="atom"]').hasClass('active');
-
-    assert
-      .dom('[data-test-atom-preview]')
-      .hasText(
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do Jane Doe tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+      let recentFiles = getRecentFiles();
+      assert.strictEqual(
+        recentFiles?.length,
+        2,
+        'recent file count is correct',
+      );
+      let newCardId = `${recentFiles?.[0][0]}${recentFiles?.[0][1]}`.replace(
+        '.json',
+        '',
+      );
+      assert
+        .dom('[data-test-instance-chooser] [data-test-selected-item]')
+        .hasText('Untitled Blog Post', 'created instance is selected');
+      assertCardExists(
+        assert,
+        newCardId,
+        'edit',
+        'new card is rendered in edit format',
       );
 
-    await selectFormat('fitted');
-    assert.dom('[data-test-format-chooser="atom"]').hasNoClass('active');
-    assert.dom('[data-test-format-chooser="fitted"]').hasClass('active');
-    assert
-      .dom('[data-test-playground-panel] [data-test-card-format="fitted"]')
-      .exists({ count: 16 });
-  });
-
-  test('can toggle edit format via button on card header', async function (assert) {
-    const cardId = `${testRealmURL}Author/jane-doe`;
-    await openFileInPlayground('author.gts', testRealmURL, 'Author');
-    await click('[data-test-instance-chooser]');
-    await click('[data-option-index="0"]');
-    assert
-      .dom('[data-test-playground-panel] [data-test-boxel-card-header-title]')
-      .hasText('Author');
-    assertCardExists(assert, cardId, 'isolated');
-    assert.dom('[data-test-author-title]').hasText('Jane Doe');
-    assert.dom('[data-test-format-chooser="isolated"]').hasClass('active');
-
-    await click(
-      '[data-test-boxel-card-header-actions] [data-test-edit-button]',
-    );
-    assertCardExists(assert, cardId, 'edit');
-    assert.dom('[data-test-card-header]').hasClass('is-editing');
-    assert.dom('[data-test-format-chooser="isolated"]').hasNoClass('active');
-    assert.dom('[data-test-format-chooser="edit"]').hasClass('active');
-
-    await click(
-      '[data-test-boxel-card-header-actions] [data-test-edit-button]',
-    );
-    assertCardExists(assert, cardId, 'isolated');
-    assert.dom('[data-test-card-header]').hasNoClass('is-editing');
-    assert.dom('[data-test-format-chooser="edit"]').hasNoClass('active');
-    assert.dom('[data-test-format-chooser="isolated"]').hasClass('active');
-  });
-
-  test('can use the header context menu to open instance in edit format in interact mode', async function (assert) {
-    await openFileInPlayground('author.gts', testRealmURL, 'Author');
-    await click('[data-test-instance-chooser]');
-    await click('[data-option-index="0"]');
-    await selectFormat('edit');
-    await click('[data-test-more-options-button]');
-    await click('[data-test-boxel-menu-item-text="Open in Interact Mode"]');
-    assert
-      .dom(
-        `[data-test-stack-card-index="0"][data-test-stack-card="${testRealmURL}Author/jane-doe"]`,
-      )
-      .exists();
-    assert
-      .dom(`[data-test-stack-item-content] [data-test-card-format="edit"]`)
-      .exists();
-  });
-
-  test('can choose another instance to be opened in playground panel', async function (assert) {
-    removeRecentFiles();
-    await openFileInPlayground('blog-post.gts', testRealmURL, 'BlogPost');
-    await chooseAnotherInstance();
-    assert.dom('[data-test-card-catalog-modal]').exists();
-    assert.dom('[data-test-card-catalog-item]').exists({ count: 3 });
-    assert
-      .dom(`[data-test-card-catalog-item="${testRealmURL}BlogPost/mad-hatter"]`)
-      .exists();
-    assert
-      .dom(
-        `[data-test-card-catalog-item="${testRealmURL}BlogPost/urban-living"]`,
-      )
-      .exists();
-    assert
-      .dom(
-        `[data-test-card-catalog-item="${testRealmURL}BlogPost/remote-work"]`,
-      )
-      .exists();
-
-    await click(
-      `[data-test-card-catalog-item="${testRealmURL}BlogPost/mad-hatter"]`,
-    );
-    await click('[data-test-card-catalog-go-button]');
-    assertCardExists(assert, `${testRealmURL}BlogPost/mad-hatter`, 'isolated');
-    assert.deepEqual(getRecentFiles()?.[0], [
-      testRealmURL,
-      'BlogPost/mad-hatter.json',
-      null,
-    ]);
-  });
-
-  test('can create new instance', async function (assert) {
-    removeRecentFiles();
-    await visitOperatorMode({
-      submode: 'code',
-      codePath: `${testRealmURL}blog-post.gts`,
+      await click('[data-test-instance-chooser]');
+      assert
+        .dom('[data-option-index]')
+        .exists({ count: 1 }, 'dropdown instance count is correct');
+      assert.dom('[data-option-index]').containsText('Blog Post');
     });
-    assert.deepEqual(getRecentFiles()?.[0], [
-      testRealmURL,
-      'blog-post.gts',
-      { line: 6, column: 42 },
-    ]);
-    await click('[data-boxel-selector-item-text="BlogPost"]');
-    await togglePlaygroundPanel();
-    assert
-      .dom('[data-test-instance-chooser] [data-test-selected-item]')
-      .doesNotExist();
 
-    await createNewInstance();
+    test('can create new instance with CodeRef field', async function (assert) {
+      await openFileInPlayground(
+        'code-ref-driver.gts',
+        testRealmURL,
+        'CodeRefDriver',
+      );
+      await createNewInstance();
 
-    let recentFiles = getRecentFiles();
-    assert.strictEqual(recentFiles?.length, 2, 'recent file count is correct');
-    let newCardId = `${recentFiles?.[0][0]}${recentFiles?.[0][1]}`.replace(
-      '.json',
-      '',
-    );
-    assert
-      .dom('[data-test-instance-chooser] [data-test-selected-item]')
-      .hasText('Untitled Blog Post', 'created instance is selected');
-    assertCardExists(
-      assert,
-      newCardId,
-      'edit',
-      'new card is rendered in edit format',
-    );
+      assert
+        .dom('[data-test-instance-chooser] [data-test-selected-item]')
+        .hasText('Untitled Code Ref Driver', 'created instance is selected');
+      assert
+        .dom(
+          `[data-test-playground-panel] [data-test-card][data-test-card-format="edit"]`,
+        )
+        .exists('new card is rendered in edit format');
+      assert
+        .dom(
+          '[data-test-playground-panel] [data-test-card] [data-test-field="ref"] input',
+        )
+        .hasNoValue('code ref field is empty');
+    });
 
-    await click('[data-test-instance-chooser]');
-    assert
-      .dom('[data-option-index]')
-      .exists({ count: 1 }, 'dropdown instance count is correct');
-    assert.dom('[data-option-index]').containsText('Blog Post');
-  });
+    test('can set relative CodeRef field', async function (assert) {
+      await openFileInPlayground(
+        'code-ref-driver.gts',
+        testRealmURL,
+        'CodeRefDriver',
+      );
+      await createNewInstance();
 
-  test('can create new instance with CodeRef field', async function (assert) {
-    await openFileInPlayground(
-      'code-ref-driver.gts',
-      testRealmURL,
-      'CodeRefDriver',
-    );
-    await createNewInstance();
-
-    assert
-      .dom('[data-test-instance-chooser] [data-test-selected-item]')
-      .hasText('Untitled Code Ref Driver', 'created instance is selected');
-    assert
-      .dom(
-        `[data-test-playground-panel] [data-test-card][data-test-card-format="edit"]`,
-      )
-      .exists('new card is rendered in edit format');
-    assert
-      .dom(
+      assert
+        .dom(
+          '[data-test-playground-panel] [data-test-card] [data-test-ref] [data-test-boxel-input-validation-state="valid"]',
+        )
+        .doesNotExist('code ref validity is not set');
+      await fillIn(
         '[data-test-playground-panel] [data-test-card] [data-test-field="ref"] input',
-      )
-      .hasNoValue('code ref field is empty');
-  });
+        `../blog-post/BlogPost`,
+      );
+      await waitFor(
+        '[data-test-playground-panel] [data-test-card] [data-test-hasValidated]',
+      );
+      assert
+        .dom(
+          '[data-test-playground-panel] [data-test-card] [data-test-field="ref"] [data-test-boxel-input-validation-state="valid"]',
+        )
+        .exists('code ref is valid');
+    });
 
-  test('can set relative CodeRef field', async function (assert) {
-    await openFileInPlayground(
-      'code-ref-driver.gts',
-      testRealmURL,
-      'CodeRefDriver',
-    );
-    await createNewInstance();
-
-    assert
-      .dom(
-        '[data-test-playground-panel] [data-test-card] [data-test-ref] [data-test-boxel-input-validation-state="valid"]',
-      )
-      .doesNotExist('code ref validity is not set');
-    await fillIn(
-      '[data-test-playground-panel] [data-test-card] [data-test-field="ref"] input',
-      `../blog-post/BlogPost`,
-    );
-    await waitFor(
-      '[data-test-playground-panel] [data-test-card] [data-test-hasValidated]',
-    );
-    assert
-      .dom(
-        '[data-test-playground-panel] [data-test-card] [data-test-field="ref"] [data-test-boxel-input-validation-state="valid"]',
-      )
-      .exists('code ref is valid');
-  });
-
-  test('playground preview for card with contained fields can live update when module changes', async function (assert) {
-    // change: added "Hello" before rendering title on the template
-    const authorCard = `import { contains, field, CardDef, Component } from "https://cardstack.com/base/card-api";
-      import MarkdownField from 'https://cardstack.com/base/markdown';
-      import StringField from "https://cardstack.com/base/string";
-      export class Author extends CardDef {
-        static displayName = 'Author';
-        @field firstName = contains(StringField);
-        @field lastName = contains(StringField);
-        @field bio = contains(MarkdownField);
-        @field title = contains(StringField, {
-          computeVia: function (this: Author) {
-            return [this.firstName, this.lastName].filter(Boolean).join(' ');
-          },
-        });
-        static isolated = class Isolated extends Component<typeof this> {
-      <template>
-        <article>
-          <header>
-            <h1 data-test-author-title>Hello <@fields.title /></h1>
-          </header>
-          <div data-test-author-bio><@fields.bio /></div>
-        </article>
-        <style scoped>
-          article {
-            margin-inline: 20px;
-          }
-        </style>
-      </template>
-        }
-      }`;
-    await openFileInPlayground('author.gts', testRealmURL, 'Author');
-    await click('[data-test-instance-chooser]');
-    await click('[data-option-index="0"]');
-    assert.dom('[data-test-author-title]').containsText('Jane Doe');
-
-    await realm.write('author.gts', authorCard);
-
-    await waitUntil(() =>
-      document
-        .querySelector('[data-test-author-title]')
-        ?.textContent?.includes('Hello'),
-    );
-
-    assert.dom('[data-test-author-title]').containsText('Hello Jane Doe');
-  });
-
-  test('playground preview for card with linked fields can live update when module changes', async function (assert) {
-    // change: added "Hello" before rendering title on the template
-    const blogPostCard = `import { contains, field, linksTo, linksToMany, CardDef, Component } from "https://cardstack.com/base/card-api";
-      import DatetimeField from 'https://cardstack.com/base/datetime';
-      import MarkdownField from 'https://cardstack.com/base/markdown';
-      import StringField from "https://cardstack.com/base/string";
-      import { Author } from './author';
-
-      export class Category extends CardDef {
-        static displayName = 'Category';
-        static fitted = class Fitted extends Component<typeof this> {
-        <template>
-          <div data-test-category-fitted><@fields.title /></div>
-        </template>
-        }
-      }
-
-      class Status extends StringField {
-        static displayName = 'Status';
-      }
-
-      export class BlogPost extends CardDef {
-        static displayName = 'Blog Post';
-        @field publishDate = contains(DatetimeField);
-        @field author = linksTo(Author);
-        @field categories = linksToMany(Category);
-        @field body = contains(MarkdownField);
-        @field status = contains(Status, {
-          computeVia: function (this: BlogPost) {
-            if (!this.publishDate) {
-              return 'Draft';
-            }
-            if (Date.now() >= Date.parse(String(this.publishDate))) {
-              return 'Published';
-            }
-            return 'Scheduled';
-          },
-        });
-
-        static isolated = class Isolated extends Component<typeof this> {
+    test('playground preview for card with contained fields can live update when module changes', async function (assert) {
+      // change: added "Hello" before rendering title on the template
+      const authorCard = `import { contains, field, CardDef, Component } from "https://cardstack.com/base/card-api";
+        import MarkdownField from 'https://cardstack.com/base/markdown';
+        import StringField from "https://cardstack.com/base/string";
+        export class Author extends CardDef {
+          static displayName = 'Author';
+          @field firstName = contains(StringField);
+          @field lastName = contains(StringField);
+          @field bio = contains(MarkdownField);
+          @field title = contains(StringField, {
+            computeVia: function (this: Author) {
+              return [this.firstName, this.lastName].filter(Boolean).join(' ');
+            },
+          });
+          static isolated = class Isolated extends Component<typeof this> {
         <template>
           <article>
             <header>
-              <h1 data-test-post-title>Hello <@fields.title /></h1>
+              <h1 data-test-author-title>Hello <@fields.title /></h1>
             </header>
-            <div data-test-byline><@fields.author /></div>
-            <div data-test-post-body><@fields.body /></div>
+            <div data-test-author-bio><@fields.bio /></div>
           </article>
           <style scoped>
             article {
@@ -716,188 +662,368 @@ module('Acceptance | code-submode | card playground', function (hooks) {
             }
           </style>
         </template>
+          }
+        }`;
+      await openFileInPlayground('author.gts', testRealmURL, 'Author');
+      await click('[data-test-instance-chooser]');
+      await click('[data-option-index="0"]');
+      assert.dom('[data-test-author-title]').containsText('Jane Doe');
+
+      await realm.write('author.gts', authorCard);
+
+      await waitUntil(() =>
+        document
+          .querySelector('[data-test-author-title]')
+          ?.textContent?.includes('Hello'),
+      );
+
+      assert.dom('[data-test-author-title]').containsText('Hello Jane Doe');
+    });
+
+    test('playground preview for card with linked fields can live update when module changes', async function (assert) {
+      // change: added "Hello" before rendering title on the template
+      const blogPostCard = `import { contains, field, linksTo, linksToMany, CardDef, Component } from "https://cardstack.com/base/card-api";
+        import DatetimeField from 'https://cardstack.com/base/datetime';
+        import MarkdownField from 'https://cardstack.com/base/markdown';
+        import StringField from "https://cardstack.com/base/string";
+        import { Author } from './author';
+
+        export class Category extends CardDef {
+          static displayName = 'Category';
+          static fitted = class Fitted extends Component<typeof this> {
+          <template>
+            <div data-test-category-fitted><@fields.title /></div>
+          </template>
+          }
         }
-    }`;
 
-    await openFileInPlayground('blog-post.gts', testRealmURL, 'BlogPost');
-    await click('[data-test-instance-chooser]');
-    await click('[data-option-index="0"]');
-    assert.dom('[data-test-post-title]').hasText('Mad As a Hatter');
+        class Status extends StringField {
+          static displayName = 'Status';
+        }
 
-    await realm.write('blog-post.gts', blogPostCard);
+        export class BlogPost extends CardDef {
+          static displayName = 'Blog Post';
+          @field publishDate = contains(DatetimeField);
+          @field author = linksTo(Author);
+          @field categories = linksToMany(Category);
+          @field body = contains(MarkdownField);
+          @field status = contains(Status, {
+            computeVia: function (this: BlogPost) {
+              if (!this.publishDate) {
+                return 'Draft';
+              }
+              if (Date.now() >= Date.parse(String(this.publishDate))) {
+                return 'Published';
+              }
+              return 'Scheduled';
+            },
+          });
 
-    await waitUntil(() =>
-      document
-        .querySelector('[data-test-post-title]')
-        ?.textContent?.includes('Hello'),
-    );
+          static isolated = class Isolated extends Component<typeof this> {
+          <template>
+            <article>
+              <header>
+                <h1 data-test-post-title>Hello <@fields.title /></h1>
+              </header>
+              <div data-test-byline><@fields.author /></div>
+              <div data-test-post-body><@fields.body /></div>
+            </article>
+            <style scoped>
+              article {
+                margin-inline: 20px;
+              }
+            </style>
+          </template>
+          }
+      }`;
 
-    assert.dom('[data-test-post-title]').includesText('Hello Mad As a Hatter');
-  });
+      await openFileInPlayground('blog-post.gts', testRealmURL, 'BlogPost');
+      await click('[data-test-instance-chooser]');
+      await click('[data-option-index="0"]');
+      assert.dom('[data-test-post-title]').hasText('Mad As a Hatter');
 
-  test('can remember playground selections and format choices via local storage', async function (assert) {
-    const authorModuleId = `${testRealmURL}author/Author`;
-    const categoryModuleId = `${testRealmURL}blog-post/Category`;
-    const blogPostModuleId = `${testRealmURL}blog-post/BlogPost`;
-    const authorId = `${testRealmURL}Author/jane-doe`;
-    const categoryId1 = `${testRealmURL}Category/city-design`;
-    const categoryId2 = `${testRealmURL}Category/future-tech`;
-    const blogPostId1 = `${testRealmURL}BlogPost/mad-hatter`;
-    const blogPostId2 = `${testRealmURL}BlogPost/remote-work`;
+      await realm.write('blog-post.gts', blogPostCard);
 
-    setPlaygroundSelections({
-      [`${authorModuleId}`]: {
-        cardId: authorId,
-        format: 'edit',
-      },
-      [`${categoryModuleId}`]: {
-        cardId: categoryId1,
-        format: 'embedded',
-      },
-      [`${blogPostModuleId}`]: {
-        cardId: blogPostId1,
-        format: 'isolated',
-      },
+      await waitUntil(() =>
+        document
+          .querySelector('[data-test-post-title]')
+          ?.textContent?.includes('Hello'),
+      );
+
+      assert
+        .dom('[data-test-post-title]')
+        .includesText('Hello Mad As a Hatter');
     });
 
-    await openFileInPlayground('author.gts', testRealmURL, 'Author');
-    assert.dom('[data-test-selected-item]').hasText('Jane Doe');
-    assertCardExists(assert, authorId, 'edit');
-    await selectFormat('atom'); // change selected format
-    assertCardExists(assert, authorId, 'atom');
-    assert.deepEqual(
-      getPlaygroundSelections()?.[authorModuleId],
-      {
-        cardId: authorId,
-        format: 'atom',
-      },
-      'local storage is updated',
-    );
+    test('can remember playground selections and format choices via local storage', async function (assert) {
+      const authorModuleId = `${testRealmURL}author/Author`;
+      const categoryModuleId = `${testRealmURL}blog-post/Category`;
+      const blogPostModuleId = `${testRealmURL}blog-post/BlogPost`;
+      const authorId = `${testRealmURL}Author/jane-doe`;
+      const categoryId1 = `${testRealmURL}Category/city-design`;
+      const categoryId2 = `${testRealmURL}Category/future-tech`;
+      const blogPostId1 = `${testRealmURL}BlogPost/mad-hatter`;
+      const blogPostId2 = `${testRealmURL}BlogPost/remote-work`;
 
-    await click(`[data-test-recent-file="${testRealmURL}blog-post.gts"]`); // change open file
-    await togglePlaygroundPanel();
-    assert.dom('[data-test-selected-item]').hasText('City Design');
-    assertCardExists(assert, categoryId1, 'embedded');
-
-    await click('[data-test-instance-chooser]');
-    await click('[data-option-index="1"]'); // change selected instance
-    assert.dom('[data-test-selected-item]').hasText('Future Tech');
-    assertCardExists(assert, categoryId2, 'embedded');
-    assert.deepEqual(
-      getPlaygroundSelections()?.[categoryModuleId],
-      {
-        cardId: categoryId2,
-        format: 'embedded',
-      },
-      'local storage is updated',
-    );
-
-    await click('[data-test-inspector-toggle]');
-    await click('[data-test-boxel-selector-item-text="BlogPost"]'); // change selected module
-    assertCardExists(assert, blogPostId1, 'isolated');
-    await selectFormat('fitted'); // change selected format
-    assert.deepEqual(getPlaygroundSelections()?.[blogPostModuleId], {
-      cardId: blogPostId1,
-      format: 'fitted',
-    });
-    await click('[data-test-instance-chooser]');
-    await click('[data-option-index="1"]'); // change selected instance
-    assertCardExists(assert, blogPostId2, 'fitted');
-    assert.deepEqual(getPlaygroundSelections()?.[blogPostModuleId], {
-      cardId: blogPostId2,
-      format: 'fitted',
-    });
-
-    assert.strictEqual(
-      JSON.stringify(getPlaygroundSelections()),
-      JSON.stringify({
+      setPlaygroundSelections({
         [`${authorModuleId}`]: {
           cardId: authorId,
-          format: 'atom',
+          format: 'edit',
         },
         [`${categoryModuleId}`]: {
-          cardId: categoryId2,
+          cardId: categoryId1,
           format: 'embedded',
         },
         [`${blogPostModuleId}`]: {
-          cardId: blogPostId2,
-          format: 'fitted',
+          cardId: blogPostId1,
+          format: 'isolated',
         },
-      }),
-    );
-  });
+      });
 
-  test<TestContextWithSave>('trigger auto saved in edit format', async function (assert) {
-    await openFileInPlayground('author.gts', testRealmURL, 'Author');
-    await click('[data-test-instance-chooser]');
-    await click('[data-option-index="0"]');
-    await click('[data-test-edit-button]');
-    assert.dom('[data-test-card-format="edit"]').exists();
+      await openFileInPlayground('author.gts', testRealmURL, 'Author');
+      assert.dom('[data-test-selected-item]').hasText('Jane Doe');
+      assertCardExists(assert, authorId, 'edit');
+      await selectFormat('atom'); // change selected format
+      assertCardExists(assert, authorId, 'atom');
+      assert.deepEqual(
+        getPlaygroundSelections()?.[authorModuleId],
+        {
+          cardId: authorId,
+          format: 'atom',
+        },
+        'local storage is updated',
+      );
 
-    let newFirstName = 'John';
-    this.onSave((_, json) => {
-      if (typeof json === 'string') {
-        throw new Error('expected JSON save data');
-      }
-      assert.strictEqual(json.data.attributes?.firstName, newFirstName);
+      await click(`[data-test-recent-file="${testRealmURL}blog-post.gts"]`); // change open file
+      await togglePlaygroundPanel();
+      assert.dom('[data-test-selected-item]').hasText('City Design');
+      assertCardExists(assert, categoryId1, 'embedded');
+
+      await click('[data-test-instance-chooser]');
+      await click('[data-option-index="1"]'); // change selected instance
+      assert.dom('[data-test-selected-item]').hasText('Future Tech');
+      assertCardExists(assert, categoryId2, 'embedded');
+      assert.deepEqual(
+        getPlaygroundSelections()?.[categoryModuleId],
+        {
+          cardId: categoryId2,
+          format: 'embedded',
+        },
+        'local storage is updated',
+      );
+
+      await click('[data-test-inspector-toggle]');
+      await click('[data-test-boxel-selector-item-text="BlogPost"]'); // change selected module
+      assertCardExists(assert, blogPostId1, 'isolated');
+      await selectFormat('fitted'); // change selected format
+      assert.deepEqual(getPlaygroundSelections()?.[blogPostModuleId], {
+        cardId: blogPostId1,
+        format: 'fitted',
+      });
+      await click('[data-test-instance-chooser]');
+      await click('[data-option-index="1"]'); // change selected instance
+      assertCardExists(assert, blogPostId2, 'fitted');
+      assert.deepEqual(getPlaygroundSelections()?.[blogPostModuleId], {
+        cardId: blogPostId2,
+        format: 'fitted',
+      });
+
+      assert.strictEqual(
+        JSON.stringify(getPlaygroundSelections()),
+        JSON.stringify({
+          [`${authorModuleId}`]: {
+            cardId: authorId,
+            format: 'atom',
+          },
+          [`${categoryModuleId}`]: {
+            cardId: categoryId2,
+            format: 'embedded',
+          },
+          [`${blogPostModuleId}`]: {
+            cardId: blogPostId2,
+            format: 'fitted',
+          },
+        }),
+      );
     });
-    await fillIn(
-      '[data-test-field="firstName"] [data-test-boxel-input]',
-      newFirstName,
-    );
+
+    test<TestContextWithSave>('trigger auto saved in edit format', async function (assert) {
+      await openFileInPlayground('author.gts', testRealmURL, 'Author');
+      await click('[data-test-instance-chooser]');
+      await click('[data-option-index="0"]');
+      await click('[data-test-edit-button]');
+      assert.dom('[data-test-card-format="edit"]').exists();
+
+      let newFirstName = 'John';
+      this.onSave((_, json) => {
+        if (typeof json === 'string') {
+          throw new Error('expected JSON save data');
+        }
+        assert.strictEqual(json.data.attributes?.firstName, newFirstName);
+      });
+      await fillIn(
+        '[data-test-field="firstName"] [data-test-boxel-input]',
+        newFirstName,
+      );
+    });
+
+    test<TestContextWithSave>('automatically attaches the selected card to the AI message', async function (assert) {
+      await openFileInPlayground('author.gts', testRealmURL, 'Author');
+      await click('[data-test-instance-chooser]');
+      await click('[data-option-index="0"]');
+      await click('[data-test-open-ai-assistant]');
+      assert.dom(`[data-test-card="${testRealmURL}Author/jane-doe"]`).exists();
+      assert.dom('[data-test-autoattached-card]').hasText('Jane Doe');
+      await triggerEvent(`[data-test-autoattached-card]`, 'mouseenter');
+      assert
+        .dom('[data-test-tooltip-content]')
+        .hasText('Current card is shared automatically');
+
+      await click('[data-test-file-browser-toggle]');
+      await click('[data-test-file="blog-post.gts"]');
+      await click('[data-test-accordion-item="playground"] button');
+      await click('[data-test-instance-chooser]');
+      await click('[data-option-index="1"]');
+      assert
+        .dom(`[data-test-card="${testRealmURL}Category/future-tech"]`)
+        .exists();
+      assert.dom('[data-test-autoattached-card]').hasText('Future Tech');
+      await click('[data-test-remove-card-btn]');
+      assert.dom('[data-test-autoattached-card]').doesNotExist();
+
+      await click('[data-test-instance-chooser]');
+      await click('[data-option-index="0"]');
+      assert
+        .dom(`[data-test-card="${testRealmURL}Category/city-design"]`)
+        .exists();
+      assert.dom('[data-test-autoattached-card]').hasText('City Design');
+      await fillIn('[data-test-message-field]', `Message With Card and File`);
+      await click('[data-test-send-message-btn]');
+
+      assertMessages(assert, [
+        {
+          from: 'testuser',
+          message: 'Message With Card and File',
+          files: [
+            {
+              sourceUrl: `${testRealmURL}blog-post.gts`,
+              name: 'blog-post.gts',
+            },
+          ],
+          cards: [
+            { id: `${testRealmURL}Category/city-design`, title: 'City Design' },
+          ],
+        },
+      ]);
+    });
+
+    test<TestContextWithSave>('instance chooser only appears when panel is opened', async function (assert) {
+      await openFileInPlayground('author.gts', testRealmURL, 'Author');
+      assert.dom('[data-test-instance-chooser]').exists();
+      await click('[data-test-accordion-item="playground"] button');
+      assert.dom('[data-test-instance-chooser]').doesNotExist();
+    });
   });
 
-  test<TestContextWithSave>('automatically attaches the selected card to the AI message', async function (assert) {
-    await openFileInPlayground('author.gts', testRealmURL, 'Author');
-    await click('[data-test-instance-chooser]');
-    await click('[data-option-index="0"]');
-    await click('[data-test-open-ai-assistant]');
-    assert.dom(`[data-test-card="${testRealmURL}Author/jane-doe"]`).exists();
-    assert.dom('[data-test-autoattached-card]').hasText('Jane Doe');
-    await triggerEvent(`[data-test-autoattached-card]`, 'mouseenter');
-    assert
-      .dom('[data-test-tooltip-content]')
-      .hasText('Current card is shared automatically');
+  module('multiple realms', function (hooks) {
+    let personalRealmURL: string;
+    let additionalRealmURL: string;
 
-    await click('[data-test-file-browser-toggle]');
-    await click('[data-test-file="blog-post.gts"]');
-    await click('[data-test-accordion-item="playground"] button');
-    await click('[data-test-instance-chooser]');
-    await click('[data-option-index="1"]');
-    assert
-      .dom(`[data-test-card="${testRealmURL}Category/future-tech"]`)
-      .exists();
-    assert.dom('[data-test-autoattached-card]').hasText('Future Tech');
-    await click('[data-test-remove-card-btn]');
-    assert.dom('[data-test-autoattached-card]').doesNotExist();
+    setupApplicationTest(hooks);
+    setupLocalIndexing(hooks);
 
-    await click('[data-test-instance-chooser]');
-    await click('[data-option-index="0"]');
-    assert
-      .dom(`[data-test-card="${testRealmURL}Category/city-design"]`)
-      .exists();
-    assert.dom('[data-test-autoattached-card]').hasText('City Design');
-    await fillIn('[data-test-message-field]', `Message With Card and File`);
-    await click('[data-test-send-message-btn]');
+    let mockMatrixUtils = setupMockMatrix(hooks, {
+      loggedInAs: '@testuser:localhost',
+    });
 
-    assertMessages(assert, [
-      {
-        from: 'testuser',
-        message: 'Message With Card and File',
-        files: [
-          { sourceUrl: `${testRealmURL}blog-post.gts`, name: 'blog-post.gts' },
-        ],
-        cards: [
-          { id: `${testRealmURL}Category/city-design`, title: 'City Design' },
-        ],
-      },
-    ]);
-  });
+    let { setActiveRealms, setRealmPermissions, createAndJoinRoom } =
+      mockMatrixUtils;
 
-  test<TestContextWithSave>('instance chooser only appears when panel is opened', async function (assert) {
-    await openFileInPlayground('author.gts', testRealmURL, 'Author');
-    assert.dom('[data-test-instance-chooser]').exists();
-    await click('[data-test-accordion-item="playground"] button');
-    assert.dom('[data-test-instance-chooser]').doesNotExist();
+    hooks.beforeEach(async function () {
+      matrixRoomId = createAndJoinRoom({
+        sender: '@testuser:localhost',
+        name: 'room-test',
+      });
+      setupUserSubscription(matrixRoomId);
+
+      let realmServerService = this.owner.lookup(
+        'service:realm-server',
+      ) as RealmServerService;
+      personalRealmURL = `${realmServerService.url}testuser/personal/`;
+      additionalRealmURL = `${realmServerService.url}testuser/aaa/`; // writeable realm that is lexically before the personal realm
+      setActiveRealms([additionalRealmURL, personalRealmURL]);
+
+      await setupAcceptanceTestRealm({
+        mockMatrixUtils,
+        realmURL: personalRealmURL,
+        contents: {
+          'author-card.gts': authorCard,
+          '.realm.json': {
+            name: `Test User's Workspace`,
+            backgroundURL: 'https://i.postimg.cc/NjcjbyD3/4k-origami-flock.jpg',
+            iconURL: 'https://i.postimg.cc/Rq550Bwv/T.png',
+          },
+        },
+      });
+
+      await setupAcceptanceTestRealm({
+        mockMatrixUtils,
+        realmURL: additionalRealmURL,
+        contents: {
+          'author-card.gts': authorCard,
+          '.realm.json': {
+            name: `Additional Workspace`,
+            backgroundURL: 'https://i.postimg.cc/4ycXQZ94/4k-powder-puff.jpg',
+            iconURL: 'https://i.postimg.cc/BZwv0LyC/A.png',
+          },
+        },
+      });
+
+      setRealmPermissions({
+        [additionalRealmURL]: ['read', 'write', 'realm-owner'],
+        [personalRealmURL]: ['read', 'write', 'realm-owner'],
+      });
+    });
+
+    test('can create new instance in currently open realm', async function (assert) {
+      removeRecentFiles();
+      await openFileInPlayground(
+        'author-card.gts',
+        additionalRealmURL,
+        'Author',
+      );
+      assert.deepEqual(getRecentFiles()?.[0], [
+        additionalRealmURL,
+        'author-card.gts',
+        { line: 4, column: 38 },
+      ]);
+      assert.dom('[data-test-card]').doesNotExist();
+
+      await createNewInstance();
+
+      let recentFiles = getRecentFiles();
+      assert.strictEqual(
+        recentFiles?.length,
+        2,
+        'recent file count is correct',
+      );
+      let newCardId = document
+        .querySelector('[data-test-card]')
+        ?.getAttribute('data-test-card');
+      assert.ok(newCardId?.startsWith(additionalRealmURL));
+      assert.notOk(newCardId?.startsWith(personalRealmURL));
+
+      let recentCardId = `${recentFiles?.[0][0]}${recentFiles?.[0][1]}`.replace(
+        '.json',
+        '',
+      );
+      assert.strictEqual(newCardId, recentCardId);
+      assertCardExists(
+        assert,
+        recentCardId,
+        'edit',
+        'new card is rendered in edit format',
+      );
+    });
   });
 });

--- a/packages/host/tests/acceptance/code-submode/field-playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/field-playground-test.gts
@@ -2,7 +2,9 @@ import { click, fillIn, settled } from '@ember/test-helpers';
 
 import { module, test } from 'qunit';
 
-import type { Realm } from '@cardstack/runtime-common';
+import { specRef, type Realm } from '@cardstack/runtime-common';
+
+import type RealmServerService from '@cardstack/host/services/realm-server';
 
 import {
   percySnapshot,
@@ -32,862 +34,905 @@ import {
 } from '../../helpers/playground';
 import { setupApplicationTest } from '../../helpers/setup';
 
-let matrixRoomId: string;
-module('Acceptance | code-submode | field playground', function (hooks) {
-  let realm: Realm;
-  setupApplicationTest(hooks);
-  setupLocalIndexing(hooks);
-
-  let mockMatrixUtils = setupMockMatrix(hooks, {
-    loggedInAs: '@testuser:localhost',
-    activeRealms: [testRealmURL],
-  });
-
-  let { setRealmPermissions, setActiveRealms, createAndJoinRoom } =
-    mockMatrixUtils;
-
-  setupOnSave(hooks);
-
-  const authorCard = `import { contains, field, CardDef, Component, FieldDef } from "https://cardstack.com/base/card-api";
-    import MarkdownField from 'https://cardstack.com/base/markdown';
-    import StringField from "https://cardstack.com/base/string";
-    export class Author extends CardDef {
-      static displayName = 'Author';
-      @field firstName = contains(StringField);
-      @field lastName = contains(StringField);
-      @field bio = contains(MarkdownField);
-      @field title = contains(StringField, {
-        computeVia: function (this: Author) {
-          return [this.firstName, this.lastName].filter(Boolean).join(' ');
-        },
-      });
-      static isolated = class Isolated extends Component<typeof this> {
-      <template>
-        <article>
-          <header>
-            <h1 data-test-author-title><@fields.title /></h1>
-          </header>
-          <div data-test-author-bio><@fields.bio /></div>
-        </article>
-        <style scoped>
-          article {
-            margin-inline: 20px;
-          }
-        </style>
-      </template>
-      }
-    }
-
-    export class Quote extends FieldDef {
-      static displayName = 'Quote';
-      @field quote = contains(StringField);
-      @field attribution = contains(StringField);
-      static embedded = class Embedded extends Component<typeof this> {
-        <template>
-          <div data-test-quote-field-embedded>
-            <blockquote data-test-quote>
-              <p><@fields.quote /></p>
-            </blockquote>
-            <p data-test-attribution><@fields.attribution /></p>
-          </div>
-        </template>
-      }
-    }
-
-    export class FullNameField extends FieldDef {
-      static displayName = 'Full Name';
-      @field firstName = contains(StringField);
-      @field lastName = contains(StringField);
-      static embedded = class Embedded extends Component<typeof this> {
-        <template>
-          <div data-test-full-name-embedded>
-            <@fields.firstName /> <@fields.lastName />
-          </div>
-        </template>
-      }
-  }`;
-
-  const blogPostCard = `import { contains, containsMany, field, linksTo, CardDef, Component, FieldDef } from "https://cardstack.com/base/card-api";
-    import DatetimeField from 'https://cardstack.com/base/datetime';
-    import MarkdownField from 'https://cardstack.com/base/markdown';
-    import StringField from "https://cardstack.com/base/string";
-    import { Author } from './author';
-
-    export class Status extends StringField {
-      static displayName = 'Status';
-    }
-
-    class LocalStatusField extends Status {}
-
-    export class Comment extends FieldDef {
-      static displayName = 'Comment';
-      @field title = contains(StringField);
-      @field name = contains(StringField);
-      @field message = contains(StringField);
-
-      static embedded = class Embedded extends Component<typeof this> {
-        <template>
-          <div data-test-embedded-comment>
-            <h4 data-test-embedded-comment-title><@fields.title /></h4>
-            <p><@fields.message /> - by <@fields.name /></p>
-          </div>
-        </template>
-      }
-
-      static fitted = class Fitted extends Component<typeof this> {
-        <template>
-          <div data-test-fitted-comment><@fields.title /> - by <@fields.name /></div>
-        </template>
-      }
-    }
-
-    class LocalCommentField extends Comment {}
-
-    export class ContactInfo extends FieldDef {
-      @field email = contains(StringField);
-      static atom = class Atom extends Component<typeof this> {
-        <template>
-          <div data-test-atom-contact-info>
-            <@fields.email />
-          </div>
-        </template>
-      }
-      static embedded = class Embedded extends Component<typeof this> {
-        <template>
-          <div data-test-embedded-contact-info>
-            <@fields.email />
-          </div>
-        </template>
-      }
-    }
-
-    export class BlogPost extends CardDef {
-      static displayName = 'Blog Post';
-      @field publishDate = contains(DatetimeField);
-      @field author = linksTo(Author);
-      @field comments = containsMany(Comment);
-      @field localComments = containsMany(LocalCommentField);
-      @field body = contains(MarkdownField);
-      @field status = contains(Status, {
-        computeVia: function (this: BlogPost) {
-          if (!this.publishDate) {
-            return 'Draft';
-          }
-          if (Date.now() >= Date.parse(String(this.publishDate))) {
-            return 'Published';
-          }
-          return 'Scheduled';
-        },
-      });
-      @field localStatus = contains(LocalStatusField);
-
-      static isolated = class Isolated extends Component<typeof this> {
-      <template>
-        <article>
-          <header>
-            <h1 data-test-post-title><@fields.title /></h1>
-          </header>
-          <div data-test-byline><@fields.author /></div>
-          <div data-test-post-body><@fields.body /></div>
-        </article>
-        <style scoped>
-          article {
-            margin-inline: 20px;
-          }
-        </style>
-      </template>
-      }
-  }`;
-
-  const petCard = `import { contains, containsMany, field, CardDef, Component, FieldDef, StringField } from 'https://cardstack.com/base/card-api';
-    export class ToyField extends FieldDef {
-      static displayName = 'Toy';
-      @field title = contains(StringField);
-    }
-    export class TreatField extends FieldDef {
-      static displayName = 'Treat';
-      @field title = contains(StringField);
-    }
-    export class PetCard extends CardDef {
-      static displayName = 'Pet';
-      @field firstName = contains(StringField);
-      @field favoriteToys = containsMany(ToyField);
-    }
-  `;
-
-  hooks.beforeEach(async function () {
-    matrixRoomId = createAndJoinRoom({
-      sender: '@testuser:localhost',
-      name: 'room-test',
-    });
-    setupUserSubscription(matrixRoomId);
-
-    ({ realm } = await setupAcceptanceTestRealm({
-      mockMatrixUtils,
-      realmURL: testRealmURL,
-      contents: {
-        'author.gts': authorCard,
-        'blog-post.gts': blogPostCard,
-        'pet.gts': petCard,
-        'Author/jane-doe.json': {
-          data: {
-            attributes: {
-              firstName: 'Jane',
-              lastName: 'Doe',
-              bio: "Jane Doe is the Senior Managing Editor at <em>Ramped.com</em>, where she leads content strategy, editorial direction, and ensures the highest standards of quality across all publications. With over a decade of experience in digital media and editorial management, Jane has a proven track record of shaping impactful narratives, growing engaged audiences, and collaborating with cross-functional teams to deliver compelling content. When she's not editing, you can find her exploring new books, hiking, or indulging in her love of photography.",
-            },
-            meta: {
-              adoptsFrom: {
-                module: `${testRealmURL}author`,
-                name: 'Author',
-              },
-            },
-          },
-        },
-        'BlogPost/remote-work.json': {
-          data: {
-            attributes: {
-              title: 'The Ultimate Guide to Remote Work',
-              description:
-                'In today’s digital age, remote work has transformed from a luxury to a necessity. This comprehensive guide will help you navigate the world of remote work, offering tips, tools, and best practices for success.',
-            },
-            relationships: {
-              author: {
-                links: {
-                  self: `${testRealmURL}Author/jane-doe`,
-                },
-              },
-            },
-            meta: {
-              adoptsFrom: {
-                module: `${testRealmURL}blog-post`,
-                name: 'BlogPost',
-              },
-            },
-          },
-        },
-        'Spec/comment-1.json': {
-          data: {
-            type: 'card',
-            attributes: {
-              ref: {
-                name: 'Comment',
-                module: '../blog-post',
-              },
-              specType: 'field',
-              containedExamples: [
-                {
-                  title: 'Terrible product',
-                  name: 'Marco',
-                  message: 'I would give 0 stars if I could. Do not buy!',
-                },
-                {
-                  title: 'Needs better packaging',
-                  name: 'Harry',
-                  message: 'Arrived broken',
-                },
-              ],
-              title: 'Comment spec',
-            },
-            meta: {
-              fields: {
-                containedExamples: [
-                  {
-                    adoptsFrom: {
-                      module: '../blog-post',
-                      name: 'Comment',
-                    },
-                  },
-                  {
-                    adoptsFrom: {
-                      module: '../blog-post',
-                      name: 'Comment',
-                    },
-                  },
-                ],
-              },
-              adoptsFrom: {
-                module: 'https://cardstack.com/base/spec',
-                name: 'Spec',
-              },
-            },
-          },
-        },
-        'Spec/comment-2.json': {
-          data: {
-            type: 'card',
-            attributes: {
-              ref: {
-                name: 'Comment',
-                module: '../blog-post',
-              },
-              specType: 'field',
-              containedExamples: [
-                {
-                  title: 'Spec 2 Example 1',
-                },
-              ],
-              title: 'Comment spec II',
-            },
-            meta: {
-              fields: {
-                containedExamples: [
-                  {
-                    adoptsFrom: {
-                      module: '../blog-post',
-                      name: 'Comment',
-                    },
-                  },
-                ],
-              },
-              adoptsFrom: {
-                module: 'https://cardstack.com/base/spec',
-                name: 'Spec',
-              },
-            },
-          },
-        },
-        'Spec/full-name.json': {
-          data: {
-            type: 'card',
-            attributes: {
-              ref: {
-                name: 'FullNameField',
-                module: '../author',
-              },
-              specType: 'field',
-              containedExamples: [],
-              title: 'FullNameField spec',
-            },
-            meta: {
-              adoptsFrom: {
-                module: 'https://cardstack.com/base/spec',
-                name: 'Spec',
-              },
-            },
-          },
-        },
-        'Spec/contact-info.json': {
-          data: {
-            type: 'card',
-            attributes: {
-              ref: {
-                name: 'ContactInfo',
-                module: '../blog-post',
-              },
-              specType: 'field',
-              containedExamples: [
-                { email: 'marcelius@email.com' },
-                { email: 'lilian@email.com' },
-                { email: 'susie@email.com' },
-              ],
-              title: 'Contact Info',
-            },
-            meta: {
-              fields: {
-                containedExamples: [
-                  {
-                    adoptsFrom: {
-                      module: '../blog-post',
-                      name: 'ContactInfo',
-                    },
-                  },
-                  {
-                    adoptsFrom: {
-                      module: '../blog-post',
-                      name: 'ContactInfo',
-                    },
-                  },
-                  {
-                    adoptsFrom: {
-                      module: '../blog-post',
-                      name: 'ContactInfo',
-                    },
-                  },
-                ],
-              },
-              adoptsFrom: {
-                module: 'https://cardstack.com/base/spec',
-                name: 'Spec',
-              },
-            },
-          },
-        },
-        'Spec/toy.json': {
-          data: {
-            type: 'card',
-            attributes: {
-              ref: {
-                name: 'ToyField',
-                module: '../pet',
-              },
-              specType: 'field',
-              containedExamples: [{ title: 'Tug rope' }, { title: 'Lambchop' }],
-              title: 'Toy',
-            },
-            meta: {
-              fields: {
-                containedExamples: [
-                  {
-                    adoptsFrom: {
-                      module: '../pet',
-                      name: 'ToyField',
-                    },
-                  },
-                  {
-                    adoptsFrom: {
-                      module: '../pet',
-                      name: 'ToyField',
-                    },
-                  },
-                ],
-              },
-              adoptsFrom: {
-                module: 'https://cardstack.com/base/spec',
-                name: 'Spec',
-              },
-            },
-          },
-        },
-        'Pet/mango.json': {
-          data: {
-            attributes: {
-              firstName: 'Mango',
-              title: 'Mango',
-              favoriteToys: [{ title: 'Tug rope' }, { title: 'Lambchop' }],
-            },
-            meta: {
-              adoptsFrom: {
-                module: `${testRealmURL}pet`,
-                name: 'PetCard',
-              },
-            },
-          },
-        },
+const authorCard = `import { contains, field, CardDef, Component, FieldDef } from "https://cardstack.com/base/card-api";
+  import MarkdownField from 'https://cardstack.com/base/markdown';
+  import StringField from "https://cardstack.com/base/string";
+  export class Author extends CardDef {
+    static displayName = 'Author';
+    @field firstName = contains(StringField);
+    @field lastName = contains(StringField);
+    @field bio = contains(MarkdownField);
+    @field title = contains(StringField, {
+      computeVia: function (this: Author) {
+        return [this.firstName, this.lastName].filter(Boolean).join(' ');
       },
-    }));
-    setRecentFiles([
-      [testRealmURL, 'blog-post.gts'],
-      [testRealmURL, 'author.gts'],
-      [testRealmURL, 'BlogPost/remote-work.json'],
-      [testRealmURL, 'Author/jane-doe.json'],
-    ]);
-    removePlaygroundSelections();
-
-    setActiveRealms([testRealmURL]);
-    setRealmPermissions({
-      [testRealmURL]: ['read', 'write'],
     });
-  });
+    static isolated = class Isolated extends Component<typeof this> {
+    <template>
+      <article>
+        <header>
+          <h1 data-test-author-title><@fields.title /></h1>
+        </header>
+        <div data-test-author-bio><@fields.bio /></div>
+      </article>
+      <style scoped>
+        article {
+          margin-inline: 20px;
+        }
+      </style>
+    </template>
+    }
+  }
 
-  test('can preview compound field instance', async function (assert) {
-    await openFileInPlayground('blog-post.gts', testRealmURL, 'Comment');
-    assert
-      .dom('[data-test-playground-format-chooser] button')
-      .exists({ count: 4 });
-    assert.dom('[data-test-format-chooser="isolated"]').doesNotExist();
-    assert.dom('[data-test-format-chooser="embedded"]').hasClass('active');
-    assert
-      .dom('[data-test-embedded-comment-title]')
-      .hasText('Terrible product');
-    assert.dom('[data-test-embedded-comment]').containsText('0 stars');
-    await percySnapshot(assert);
+  export class Quote extends FieldDef {
+    static displayName = 'Quote';
+    @field quote = contains(StringField);
+    @field attribution = contains(StringField);
+    static embedded = class Embedded extends Component<typeof this> {
+      <template>
+        <div data-test-quote-field-embedded>
+          <blockquote data-test-quote>
+            <p><@fields.quote /></p>
+          </blockquote>
+          <p data-test-attribution><@fields.attribution /></p>
+        </div>
+      </template>
+    }
+  }
 
-    await selectFormat('atom');
-    assert.dom('[data-test-format-chooser="embedded"]').hasNoClass('active');
-    assert.dom('[data-test-format-chooser="atom"]').hasClass('active');
-    assertFieldExists(assert, 'atom');
+  export class FullNameField extends FieldDef {
+    static displayName = 'Full Name';
+    @field firstName = contains(StringField);
+    @field lastName = contains(StringField);
+    static embedded = class Embedded extends Component<typeof this> {
+      <template>
+        <div data-test-full-name-embedded>
+          <@fields.firstName /> <@fields.lastName />
+        </div>
+      </template>
+    }
+}`;
 
-    await selectFormat('edit');
-    assertFieldExists(assert, 'edit');
-    assert
-      .dom('[data-test-field-preview-card] [data-test-field]')
-      .exists({ count: 3 });
-    assert
-      .dom('[data-test-field-preview-card] [data-test-field="name"] input')
-      .hasValue('Marco');
+const blogPostCard = `import { contains, containsMany, field, linksTo, CardDef, Component, FieldDef } from "https://cardstack.com/base/card-api";
+  import DatetimeField from 'https://cardstack.com/base/datetime';
+  import MarkdownField from 'https://cardstack.com/base/markdown';
+  import StringField from "https://cardstack.com/base/string";
+  import { Author } from './author';
 
-    await selectFormat('fitted');
-    assertFieldExists(assert, 'fitted');
-    assert.dom('[data-test-fitted-comment]').containsText('by Marco');
-  });
+  export class Status extends StringField {
+    static displayName = 'Status';
+  }
 
-  test('can not preview non-exports or primitives', async function (assert) {
-    await openFileInPlayground('blog-post.gts', testRealmURL, 'Comment');
-    assert.dom('[data-test-playground-panel]').exists();
+  class LocalStatusField extends Status {}
 
-    await selectDeclaration('Status');
-    assert.dom('[data-test-playground-panel]').doesNotExist('primitive field');
-    assert.dom('[data-test-incompatible-primitives]').exists();
+  export class Comment extends FieldDef {
+    static displayName = 'Comment';
+    @field title = contains(StringField);
+    @field name = contains(StringField);
+    @field message = contains(StringField);
 
-    await selectDeclaration('LocalStatusField');
-    assert
-      .dom('[data-test-playground-panel]')
-      .doesNotExist('local primitive field');
-    assert.dom('[data-test-incompatible-primitives]').exists();
+    static embedded = class Embedded extends Component<typeof this> {
+      <template>
+        <div data-test-embedded-comment>
+          <h4 data-test-embedded-comment-title><@fields.title /></h4>
+          <p><@fields.message /> - by <@fields.name /></p>
+        </div>
+      </template>
+    }
 
-    await selectDeclaration('LocalCommentField');
-    assert
-      .dom('[data-test-playground-panel]')
-      .doesNotExist('local compound field');
-    assert.dom('[data-test-incompatible-nonexports]').exists();
-  });
+    static fitted = class Fitted extends Component<typeof this> {
+      <template>
+        <div data-test-fitted-comment><@fields.title /> - by <@fields.name /></div>
+      </template>
+    }
+  }
 
-  test('can populate instance chooser dropdown options with containedExamples from Spec', async function (assert) {
-    await openFileInPlayground('blog-post.gts', testRealmURL, 'ContactInfo');
-    assertFieldExists(assert, 'embedded');
-    assert.dom('[data-test-selected-item]').hasText('Contact Info - Example 1');
-    assert
-      .dom('[data-test-embedded-contact-info]')
-      .hasText('marcelius@email.com');
+  class LocalCommentField extends Comment {}
 
-    await click('[data-test-instance-chooser]');
-    assert.dom('[data-option-index]').exists({ count: 3 });
-    assert.dom('[data-option-index="0"]').hasText('marcelius@email.com');
-    assert.dom('[data-option-index="1"]').hasText('lilian@email.com');
-    assert.dom('[data-option-index="2"]').hasText('susie@email.com');
+  export class ContactInfo extends FieldDef {
+    @field email = contains(StringField);
+    static atom = class Atom extends Component<typeof this> {
+      <template>
+        <div data-test-atom-contact-info>
+          <@fields.email />
+        </div>
+      </template>
+    }
+    static embedded = class Embedded extends Component<typeof this> {
+      <template>
+        <div data-test-embedded-contact-info>
+          <@fields.email />
+        </div>
+      </template>
+    }
+  }
 
-    await click('[data-option-index="2"]');
-    assert.dom('[data-test-selected-item]').hasText('Contact Info - Example 3');
-    assert.dom('[data-test-embedded-contact-info]').hasText('susie@email.com');
-  });
-
-  test('can update the instance chooser when selected declaration changes', async function (assert) {
-    await openFileInPlayground('blog-post.gts', testRealmURL, 'ContactInfo');
-    assertFieldExists(assert, 'embedded');
-    assert.dom('[data-test-selected-item]').hasText('Contact Info - Example 1');
-    assert
-      .dom('[data-test-embedded-contact-info]')
-      .hasText('marcelius@email.com');
-    await click('[data-test-instance-chooser]');
-    assert.dom('[data-option-index]').exists({ count: 3 });
-    assert.dom('[data-option-index="0"]').hasText('marcelius@email.com');
-
-    await selectDeclaration('Comment');
-    assert.dom('[data-test-selected-item]').hasText('Comment spec - Example 1');
-    assert
-      .dom('[data-test-embedded-comment-title]')
-      .hasText('Terrible product');
-    await click('[data-test-instance-chooser]');
-    assert.dom('[data-option-index]').exists({ count: 2 });
-    assert.dom('[data-option-index="0"]').hasText('Terrible product');
-    assert.dom('[data-option-index="1"]').hasText('Needs better packaging');
-
-    await selectDeclaration('BlogPost'); // card def selected
-    assert.dom('[data-test-selected-item]').doesNotExist();
-    assert.dom('[data-test-instance-chooser]').hasText('Please Select');
-  });
-
-  test('changing the selected spec in Boxel Spec panel changes selected spec in playground', async function (assert) {
-    await openFileInPlayground('blog-post.gts', testRealmURL, 'Comment');
-    assert.dom('[data-test-selected-item]').hasText('Comment spec - Example 1');
-    assert
-      .dom('[data-test-embedded-comment-title]')
-      .hasText('Terrible product');
-    let selection =
-      getPlaygroundSelections()?.[`${testRealmURL}blog-post/Comment`];
-    assert.deepEqual(selection, {
-      cardId: `${testRealmURL}Spec/comment-1`,
-      format: 'embedded',
-      fieldIndex: 0,
+  export class BlogPost extends CardDef {
+    static displayName = 'Blog Post';
+    @field publishDate = contains(DatetimeField);
+    @field author = linksTo(Author);
+    @field comments = containsMany(Comment);
+    @field localComments = containsMany(LocalCommentField);
+    @field body = contains(MarkdownField);
+    @field status = contains(Status, {
+      computeVia: function (this: BlogPost) {
+        if (!this.publishDate) {
+          return 'Draft';
+        }
+        if (Date.now() >= Date.parse(String(this.publishDate))) {
+          return 'Published';
+        }
+        return 'Scheduled';
+      },
     });
+    @field localStatus = contains(LocalStatusField);
 
-    await toggleSpecPanel();
-    assert
-      .dom(
-        `[data-test-card="${testRealmURL}Spec/comment-1"] [data-test-boxel-input-id="spec-title"]`,
-      )
-      .hasValue('Comment spec');
-    assert
-      .dom('[data-test-spec-selector] [data-test-spec-selector-item-path]')
-      .containsText('Spec/comment-1');
-    await click('[data-test-spec-selector] > div');
-    assert
-      .dom('[data-option-index="1"] [data-test-spec-selector-item-path]')
-      .hasText('Spec/comment-2');
-    await click('[data-option-index="1"]');
-    assert
-      .dom('[data-test-spec-selector] [data-test-spec-selector-item-path]')
-      .containsText('Spec/comment-2');
-    assert
-      .dom(
-        `[data-test-card="${testRealmURL}Spec/comment-2"] [data-test-boxel-input-id="spec-title"]`,
-      )
-      .hasValue('Comment spec II');
+    static isolated = class Isolated extends Component<typeof this> {
+    <template>
+      <article>
+        <header>
+          <h1 data-test-post-title><@fields.title /></h1>
+        </header>
+        <div data-test-byline><@fields.author /></div>
+        <div data-test-post-body><@fields.body /></div>
+      </article>
+      <style scoped>
+        article {
+          margin-inline: 20px;
+        }
+      </style>
+    </template>
+    }
+}`;
 
-    await togglePlaygroundPanel();
-    assert
-      .dom('[data-test-selected-item]')
-      .hasText('Comment spec II - Example 1');
-    assert
-      .dom('[data-test-embedded-comment-title]')
-      .hasText('Spec 2 Example 1');
-    selection = getPlaygroundSelections()?.[`${testRealmURL}blog-post/Comment`];
-    assert.deepEqual(selection, {
-      cardId: `${testRealmURL}Spec/comment-2`,
-      format: 'embedded',
-      fieldIndex: 0,
-    });
-  });
+const petCard = `import { contains, containsMany, field, CardDef, Component, FieldDef, StringField } from 'https://cardstack.com/base/card-api';
+  export class ToyField extends FieldDef {
+    static displayName = 'Toy';
+    @field title = contains(StringField);
+  }
+  export class TreatField extends FieldDef {
+    static displayName = 'Treat';
+    @field title = contains(StringField);
+  }
+  export class PetCard extends CardDef {
+    static displayName = 'Pet';
+    @field firstName = contains(StringField);
+    @field favoriteToys = containsMany(ToyField);
+  }
+`;
 
-  test("can select a different instance to preview from the spec's containedExamples collection", async function (assert) {
-    await openFileInPlayground('blog-post.gts', testRealmURL, 'Comment');
-    assert.dom('[data-test-selected-item]').hasText('Comment spec - Example 1');
-    assert
-      .dom('[data-test-embedded-comment-title]')
-      .hasText('Terrible product');
-    let selection =
-      getPlaygroundSelections()?.[`${testRealmURL}blog-post/Comment`];
-    assert.deepEqual(selection, {
-      cardId: `${testRealmURL}Spec/comment-1`,
-      format: 'embedded',
-      fieldIndex: 0,
+let matrixRoomId: string;
+
+module('Acceptance | code-submode | field playground', function (_hooks) {
+  module('single realm', function (hooks) {
+    let realm: Realm;
+    setupApplicationTest(hooks);
+    setupLocalIndexing(hooks);
+
+    let mockMatrixUtils = setupMockMatrix(hooks, {
+      loggedInAs: '@testuser:localhost',
+      activeRealms: [testRealmURL],
     });
 
-    await chooseAnotherInstance();
-    assert
-      .dom('[data-test-field-chooser] [data-test-boxel-header-title]')
-      .hasText('Choose a Comment Instance');
-    assert.dom('[data-test-field-instance]').exists({ count: 2 });
-    assert.dom('[data-test-field-instance="0"]').hasClass('selected');
-    assert.dom('[data-test-field-instance="1"]').doesNotHaveClass('selected');
+    let { setRealmPermissions, setActiveRealms, createAndJoinRoom } =
+      mockMatrixUtils;
 
-    await click('[data-test-field-instance="1"]');
-    assert
-      .dom('[data-test-field-chooser]')
-      .doesNotExist('field chooser modal is closed');
-    assert
-      .dom('[data-test-embedded-comment-title]')
-      .hasText('Needs better packaging');
-    selection = getPlaygroundSelections()?.[`${testRealmURL}blog-post/Comment`];
-    assert.deepEqual(selection, {
-      cardId: `${testRealmURL}Spec/comment-1`,
-      format: 'embedded',
-      fieldIndex: 1,
+    setupOnSave(hooks);
+
+    hooks.beforeEach(async function () {
+      matrixRoomId = createAndJoinRoom({
+        sender: '@testuser:localhost',
+        name: 'room-test',
+      });
+      setupUserSubscription(matrixRoomId);
+
+      ({ realm } = await setupAcceptanceTestRealm({
+        mockMatrixUtils,
+        realmURL: testRealmURL,
+        contents: {
+          'author.gts': authorCard,
+          'blog-post.gts': blogPostCard,
+          'pet.gts': petCard,
+          'Author/jane-doe.json': {
+            data: {
+              attributes: {
+                firstName: 'Jane',
+                lastName: 'Doe',
+                bio: "Jane Doe is the Senior Managing Editor at <em>Ramped.com</em>, where she leads content strategy, editorial direction, and ensures the highest standards of quality across all publications. With over a decade of experience in digital media and editorial management, Jane has a proven track record of shaping impactful narratives, growing engaged audiences, and collaborating with cross-functional teams to deliver compelling content. When she's not editing, you can find her exploring new books, hiking, or indulging in her love of photography.",
+              },
+              meta: {
+                adoptsFrom: {
+                  module: `${testRealmURL}author`,
+                  name: 'Author',
+                },
+              },
+            },
+          },
+          'BlogPost/remote-work.json': {
+            data: {
+              attributes: {
+                title: 'The Ultimate Guide to Remote Work',
+                description:
+                  'In today’s digital age, remote work has transformed from a luxury to a necessity. This comprehensive guide will help you navigate the world of remote work, offering tips, tools, and best practices for success.',
+              },
+              relationships: {
+                author: {
+                  links: {
+                    self: `${testRealmURL}Author/jane-doe`,
+                  },
+                },
+              },
+              meta: {
+                adoptsFrom: {
+                  module: `${testRealmURL}blog-post`,
+                  name: 'BlogPost',
+                },
+              },
+            },
+          },
+          'Spec/comment-1.json': {
+            data: {
+              type: 'card',
+              attributes: {
+                ref: {
+                  name: 'Comment',
+                  module: '../blog-post',
+                },
+                specType: 'field',
+                containedExamples: [
+                  {
+                    title: 'Terrible product',
+                    name: 'Marco',
+                    message: 'I would give 0 stars if I could. Do not buy!',
+                  },
+                  {
+                    title: 'Needs better packaging',
+                    name: 'Harry',
+                    message: 'Arrived broken',
+                  },
+                ],
+                title: 'Comment spec',
+              },
+              meta: {
+                fields: {
+                  containedExamples: [
+                    {
+                      adoptsFrom: {
+                        module: '../blog-post',
+                        name: 'Comment',
+                      },
+                    },
+                    {
+                      adoptsFrom: {
+                        module: '../blog-post',
+                        name: 'Comment',
+                      },
+                    },
+                  ],
+                },
+                adoptsFrom: {
+                  module: 'https://cardstack.com/base/spec',
+                  name: 'Spec',
+                },
+              },
+            },
+          },
+          'Spec/comment-2.json': {
+            data: {
+              type: 'card',
+              attributes: {
+                ref: {
+                  name: 'Comment',
+                  module: '../blog-post',
+                },
+                specType: 'field',
+                containedExamples: [
+                  {
+                    title: 'Spec 2 Example 1',
+                  },
+                ],
+                title: 'Comment spec II',
+              },
+              meta: {
+                fields: {
+                  containedExamples: [
+                    {
+                      adoptsFrom: {
+                        module: '../blog-post',
+                        name: 'Comment',
+                      },
+                    },
+                  ],
+                },
+                adoptsFrom: {
+                  module: 'https://cardstack.com/base/spec',
+                  name: 'Spec',
+                },
+              },
+            },
+          },
+          'Spec/full-name.json': {
+            data: {
+              type: 'card',
+              attributes: {
+                ref: {
+                  name: 'FullNameField',
+                  module: '../author',
+                },
+                specType: 'field',
+                containedExamples: [],
+                title: 'FullNameField spec',
+              },
+              meta: {
+                adoptsFrom: {
+                  module: 'https://cardstack.com/base/spec',
+                  name: 'Spec',
+                },
+              },
+            },
+          },
+          'Spec/contact-info.json': {
+            data: {
+              type: 'card',
+              attributes: {
+                ref: {
+                  name: 'ContactInfo',
+                  module: '../blog-post',
+                },
+                specType: 'field',
+                containedExamples: [
+                  { email: 'marcelius@email.com' },
+                  { email: 'lilian@email.com' },
+                  { email: 'susie@email.com' },
+                ],
+                title: 'Contact Info',
+              },
+              meta: {
+                fields: {
+                  containedExamples: [
+                    {
+                      adoptsFrom: {
+                        module: '../blog-post',
+                        name: 'ContactInfo',
+                      },
+                    },
+                    {
+                      adoptsFrom: {
+                        module: '../blog-post',
+                        name: 'ContactInfo',
+                      },
+                    },
+                    {
+                      adoptsFrom: {
+                        module: '../blog-post',
+                        name: 'ContactInfo',
+                      },
+                    },
+                  ],
+                },
+                adoptsFrom: {
+                  module: 'https://cardstack.com/base/spec',
+                  name: 'Spec',
+                },
+              },
+            },
+          },
+          'Spec/toy.json': {
+            data: {
+              type: 'card',
+              attributes: {
+                ref: {
+                  name: 'ToyField',
+                  module: '../pet',
+                },
+                specType: 'field',
+                containedExamples: [
+                  { title: 'Tug rope' },
+                  { title: 'Lambchop' },
+                ],
+                title: 'Toy',
+              },
+              meta: {
+                fields: {
+                  containedExamples: [
+                    {
+                      adoptsFrom: {
+                        module: '../pet',
+                        name: 'ToyField',
+                      },
+                    },
+                    {
+                      adoptsFrom: {
+                        module: '../pet',
+                        name: 'ToyField',
+                      },
+                    },
+                  ],
+                },
+                adoptsFrom: {
+                  module: 'https://cardstack.com/base/spec',
+                  name: 'Spec',
+                },
+              },
+            },
+          },
+          'Pet/mango.json': {
+            data: {
+              attributes: {
+                firstName: 'Mango',
+                title: 'Mango',
+                favoriteToys: [{ title: 'Tug rope' }, { title: 'Lambchop' }],
+              },
+              meta: {
+                adoptsFrom: {
+                  module: `${testRealmURL}pet`,
+                  name: 'PetCard',
+                },
+              },
+            },
+          },
+        },
+      }));
+      setRecentFiles([
+        [testRealmURL, 'blog-post.gts'],
+        [testRealmURL, 'author.gts'],
+        [testRealmURL, 'BlogPost/remote-work.json'],
+        [testRealmURL, 'Author/jane-doe.json'],
+      ]);
+      removePlaygroundSelections();
+
+      setActiveRealms([testRealmURL]);
+      setRealmPermissions({
+        [testRealmURL]: ['read', 'write'],
+      });
     });
-  });
 
-  test('preview the next available example if the previously selected one has been deleted', async function (assert) {
-    setPlaygroundSelections({
-      [`${testRealmURL}blog-post/Comment`]: {
+    test('can preview compound field instance', async function (assert) {
+      await openFileInPlayground('blog-post.gts', testRealmURL, 'Comment');
+      assert
+        .dom('[data-test-playground-format-chooser] button')
+        .exists({ count: 4 });
+      assert.dom('[data-test-format-chooser="isolated"]').doesNotExist();
+      assert.dom('[data-test-format-chooser="embedded"]').hasClass('active');
+      assert
+        .dom('[data-test-embedded-comment-title]')
+        .hasText('Terrible product');
+      assert.dom('[data-test-embedded-comment]').containsText('0 stars');
+      await percySnapshot(assert);
+
+      await selectFormat('atom');
+      assert.dom('[data-test-format-chooser="embedded"]').hasNoClass('active');
+      assert.dom('[data-test-format-chooser="atom"]').hasClass('active');
+      assertFieldExists(assert, 'atom');
+
+      await selectFormat('edit');
+      assertFieldExists(assert, 'edit');
+      assert
+        .dom('[data-test-field-preview-card] [data-test-field]')
+        .exists({ count: 3 });
+      assert
+        .dom('[data-test-field-preview-card] [data-test-field="name"] input')
+        .hasValue('Marco');
+
+      await selectFormat('fitted');
+      assertFieldExists(assert, 'fitted');
+      assert.dom('[data-test-fitted-comment]').containsText('by Marco');
+    });
+
+    test('can not preview non-exports or primitives', async function (assert) {
+      await openFileInPlayground('blog-post.gts', testRealmURL, 'Comment');
+      assert.dom('[data-test-playground-panel]').exists();
+
+      await selectDeclaration('Status');
+      assert
+        .dom('[data-test-playground-panel]')
+        .doesNotExist('primitive field');
+      assert.dom('[data-test-incompatible-primitives]').exists();
+
+      await selectDeclaration('LocalStatusField');
+      assert
+        .dom('[data-test-playground-panel]')
+        .doesNotExist('local primitive field');
+      assert.dom('[data-test-incompatible-primitives]').exists();
+
+      await selectDeclaration('LocalCommentField');
+      assert
+        .dom('[data-test-playground-panel]')
+        .doesNotExist('local compound field');
+      assert.dom('[data-test-incompatible-nonexports]').exists();
+    });
+
+    test('can populate instance chooser dropdown options with containedExamples from Spec', async function (assert) {
+      await openFileInPlayground('blog-post.gts', testRealmURL, 'ContactInfo');
+      assertFieldExists(assert, 'embedded');
+      assert
+        .dom('[data-test-selected-item]')
+        .hasText('Contact Info - Example 1');
+      assert
+        .dom('[data-test-embedded-contact-info]')
+        .hasText('marcelius@email.com');
+
+      await click('[data-test-instance-chooser]');
+      assert.dom('[data-option-index]').exists({ count: 3 });
+      assert.dom('[data-option-index="0"]').hasText('marcelius@email.com');
+      assert.dom('[data-option-index="1"]').hasText('lilian@email.com');
+      assert.dom('[data-option-index="2"]').hasText('susie@email.com');
+
+      await click('[data-option-index="2"]');
+      assert
+        .dom('[data-test-selected-item]')
+        .hasText('Contact Info - Example 3');
+      assert
+        .dom('[data-test-embedded-contact-info]')
+        .hasText('susie@email.com');
+    });
+
+    test('can update the instance chooser when selected declaration changes', async function (assert) {
+      await openFileInPlayground('blog-post.gts', testRealmURL, 'ContactInfo');
+      assertFieldExists(assert, 'embedded');
+      assert
+        .dom('[data-test-selected-item]')
+        .hasText('Contact Info - Example 1');
+      assert
+        .dom('[data-test-embedded-contact-info]')
+        .hasText('marcelius@email.com');
+      await click('[data-test-instance-chooser]');
+      assert.dom('[data-option-index]').exists({ count: 3 });
+      assert.dom('[data-option-index="0"]').hasText('marcelius@email.com');
+
+      await selectDeclaration('Comment');
+      assert
+        .dom('[data-test-selected-item]')
+        .hasText('Comment spec - Example 1');
+      assert
+        .dom('[data-test-embedded-comment-title]')
+        .hasText('Terrible product');
+      await click('[data-test-instance-chooser]');
+      assert.dom('[data-option-index]').exists({ count: 2 });
+      assert.dom('[data-option-index="0"]').hasText('Terrible product');
+      assert.dom('[data-option-index="1"]').hasText('Needs better packaging');
+
+      await selectDeclaration('BlogPost'); // card def selected
+      assert.dom('[data-test-selected-item]').doesNotExist();
+      assert.dom('[data-test-instance-chooser]').hasText('Please Select');
+    });
+
+    test('changing the selected spec in Boxel Spec panel changes selected spec in playground', async function (assert) {
+      await openFileInPlayground('blog-post.gts', testRealmURL, 'Comment');
+      assert
+        .dom('[data-test-selected-item]')
+        .hasText('Comment spec - Example 1');
+      assert
+        .dom('[data-test-embedded-comment-title]')
+        .hasText('Terrible product');
+      let selection =
+        getPlaygroundSelections()?.[`${testRealmURL}blog-post/Comment`];
+      assert.deepEqual(selection, {
+        cardId: `${testRealmURL}Spec/comment-1`,
+        format: 'embedded',
+        fieldIndex: 0,
+      });
+
+      await toggleSpecPanel();
+      assert
+        .dom(
+          `[data-test-card="${testRealmURL}Spec/comment-1"] [data-test-boxel-input-id="spec-title"]`,
+        )
+        .hasValue('Comment spec');
+      assert
+        .dom('[data-test-spec-selector] [data-test-spec-selector-item-path]')
+        .containsText('Spec/comment-1');
+      await click('[data-test-spec-selector] > div');
+      assert
+        .dom('[data-option-index="1"] [data-test-spec-selector-item-path]')
+        .hasText('Spec/comment-2');
+      await click('[data-option-index="1"]');
+      assert
+        .dom('[data-test-spec-selector] [data-test-spec-selector-item-path]')
+        .containsText('Spec/comment-2');
+      assert
+        .dom(
+          `[data-test-card="${testRealmURL}Spec/comment-2"] [data-test-boxel-input-id="spec-title"]`,
+        )
+        .hasValue('Comment spec II');
+
+      await togglePlaygroundPanel();
+      assert
+        .dom('[data-test-selected-item]')
+        .hasText('Comment spec II - Example 1');
+      assert
+        .dom('[data-test-embedded-comment-title]')
+        .hasText('Spec 2 Example 1');
+      selection =
+        getPlaygroundSelections()?.[`${testRealmURL}blog-post/Comment`];
+      assert.deepEqual(selection, {
+        cardId: `${testRealmURL}Spec/comment-2`,
+        format: 'embedded',
+        fieldIndex: 0,
+      });
+    });
+
+    test("can select a different instance to preview from the spec's containedExamples collection", async function (assert) {
+      await openFileInPlayground('blog-post.gts', testRealmURL, 'Comment');
+      assert
+        .dom('[data-test-selected-item]')
+        .hasText('Comment spec - Example 1');
+      assert
+        .dom('[data-test-embedded-comment-title]')
+        .hasText('Terrible product');
+      let selection =
+        getPlaygroundSelections()?.[`${testRealmURL}blog-post/Comment`];
+      assert.deepEqual(selection, {
+        cardId: `${testRealmURL}Spec/comment-1`,
+        format: 'embedded',
+        fieldIndex: 0,
+      });
+
+      await chooseAnotherInstance();
+      assert
+        .dom('[data-test-field-chooser] [data-test-boxel-header-title]')
+        .hasText('Choose a Comment Instance');
+      assert.dom('[data-test-field-instance]').exists({ count: 2 });
+      assert.dom('[data-test-field-instance="0"]').hasClass('selected');
+      assert.dom('[data-test-field-instance="1"]').doesNotHaveClass('selected');
+
+      await click('[data-test-field-instance="1"]');
+      assert
+        .dom('[data-test-field-chooser]')
+        .doesNotExist('field chooser modal is closed');
+      assert
+        .dom('[data-test-embedded-comment-title]')
+        .hasText('Needs better packaging');
+      selection =
+        getPlaygroundSelections()?.[`${testRealmURL}blog-post/Comment`];
+      assert.deepEqual(selection, {
         cardId: `${testRealmURL}Spec/comment-1`,
         format: 'embedded',
         fieldIndex: 1,
-      },
-    });
-    await openFileInPlayground('blog-post.gts', testRealmURL, 'Comment');
-    assert.dom('[data-test-selected-item]').hasText('Comment spec - Example 2');
-    assert
-      .dom('[data-test-embedded-comment-title]')
-      .hasText('Needs better packaging');
-
-    await toggleSpecPanel();
-    assert
-      .dom(
-        '[data-test-contains-many="containedExamples"] [data-test-item="1"] [data-test-field="title"] input',
-      )
-      .hasValue('Needs better packaging');
-    await click(
-      '[data-test-contains-many="containedExamples"] [data-test-remove="1"]',
-    );
-    assert
-      .dom('[data-test-contains-many="containedExamples"] [data-test-item="1"]')
-      .doesNotExist();
-    assert
-      .dom('[data-test-contains-many="containedExamples"] [data-test-item="0"]')
-      .exists();
-
-    await togglePlaygroundPanel();
-    assert
-      .dom('[data-test-embedded-comment-title]')
-      .hasText('Terrible product');
-
-    await toggleSpecPanel();
-    await click(
-      '[data-test-contains-many="containedExamples"] [data-test-remove="0"]',
-    ); // remove remaining contained example from spec
-    assert
-      .dom('[data-test-contains-many="containedExamples"] [data-test-item]')
-      .doesNotExist();
-
-    await togglePlaygroundPanel();
-    assert.dom('[data-test-selected-item]').hasText('Comment spec - Example 1');
-    assertFieldExists(assert, 'edit', 'new field instance is autogenerated');
-  });
-
-  test('can autogenerate new Spec and field instance (no preexisting Spec)', async function (assert) {
-    await openFileInPlayground('author.gts', testRealmURL, 'Quote');
-    assert.dom('[data-test-instance-chooser]').hasText('Quote - Example 1');
-    assertFieldExists(assert, 'edit');
-    assert.dom('[data-test-field="quote"] input').hasNoValue();
-
-    await toggleSpecPanel();
-    assert
-      .dom('[data-test-spec-selector] > .ember-basic-dropdown-trigger')
-      .hasAttribute('aria-disabled', 'true', 'has only 1 spec instance');
-    assert.dom('[data-test-boxel-input-id="spec-title"]').hasValue('Quote');
-    assert
-      .dom(
-        '[data-test-contains-many="containedExamples"] [data-test-item="0"] [data-test-field="quote"] input',
-      )
-      .hasNoValue();
-
-    await togglePlaygroundPanel();
-    assertFieldExists(assert, 'edit');
-    await toggleSpecPanel();
-    assert
-      .dom('[data-test-spec-selector] > .ember-basic-dropdown-trigger')
-      .hasAttribute('aria-disabled', 'true', 'still has only 1 spec instance');
-  });
-
-  test('can create new field instance (has preexisting Spec)', async function (assert) {
-    await openFileInPlayground('blog-post.gts', testRealmURL, 'Comment');
-    assert.dom('[data-test-selected-item]').hasText('Comment spec - Example 1');
-    assert
-      .dom('[data-test-embedded-comment-title]')
-      .hasText('Terrible product');
-    let selection =
-      getPlaygroundSelections()?.[`${testRealmURL}blog-post/Comment`];
-    assert.deepEqual(selection, {
-      cardId: `${testRealmURL}Spec/comment-1`,
-      format: 'embedded',
-      fieldIndex: 0,
+      });
     });
 
-    await createNewInstance();
-    assert
-      .dom('[data-test-field-preview-card] [data-test-field="title"] input')
-      .hasNoValue();
-    selection = getPlaygroundSelections()?.[`${testRealmURL}blog-post/Comment`];
-    assert.deepEqual(selection, {
-      cardId: `${testRealmURL}Spec/comment-1`,
-      format: 'edit',
-      fieldIndex: 2,
+    test('preview the next available example if the previously selected one has been deleted', async function (assert) {
+      setPlaygroundSelections({
+        [`${testRealmURL}blog-post/Comment`]: {
+          cardId: `${testRealmURL}Spec/comment-1`,
+          format: 'embedded',
+          fieldIndex: 1,
+        },
+      });
+      await openFileInPlayground('blog-post.gts', testRealmURL, 'Comment');
+      assert
+        .dom('[data-test-selected-item]')
+        .hasText('Comment spec - Example 2');
+      assert
+        .dom('[data-test-embedded-comment-title]')
+        .hasText('Needs better packaging');
+
+      await toggleSpecPanel();
+      assert
+        .dom(
+          '[data-test-contains-many="containedExamples"] [data-test-item="1"] [data-test-field="title"] input',
+        )
+        .hasValue('Needs better packaging');
+      await click(
+        '[data-test-contains-many="containedExamples"] [data-test-remove="1"]',
+      );
+      assert
+        .dom(
+          '[data-test-contains-many="containedExamples"] [data-test-item="1"]',
+        )
+        .doesNotExist();
+      assert
+        .dom(
+          '[data-test-contains-many="containedExamples"] [data-test-item="0"]',
+        )
+        .exists();
+
+      await togglePlaygroundPanel();
+      assert
+        .dom('[data-test-embedded-comment-title]')
+        .hasText('Terrible product');
+
+      await toggleSpecPanel();
+      await click(
+        '[data-test-contains-many="containedExamples"] [data-test-remove="0"]',
+      ); // remove remaining contained example from spec
+      assert
+        .dom('[data-test-contains-many="containedExamples"] [data-test-item]')
+        .doesNotExist();
+
+      await togglePlaygroundPanel();
+      assert
+        .dom('[data-test-selected-item]')
+        .hasText('Comment spec - Example 1');
+      assertFieldExists(assert, 'edit', 'new field instance is autogenerated');
     });
 
-    await toggleSpecPanel();
-    assert
-      .dom('[data-test-contains-many="containedExamples"] [data-test-item]')
-      .exists({ count: 3 });
-    assert
-      .dom(
-        '[data-test-contains-many="containedExamples"] [data-test-item="2"] [data-test-field="title"] input',
-      )
-      .hasNoValue();
+    test('can autogenerate new Spec and field instance (no preexisting Spec)', async function (assert) {
+      await openFileInPlayground('author.gts', testRealmURL, 'Quote');
+      assert.dom('[data-test-instance-chooser]').hasText('Quote - Example 1');
+      assertFieldExists(assert, 'edit');
+      assert.dom('[data-test-field="quote"] input').hasNoValue();
 
-    await togglePlaygroundPanel();
-    await chooseAnotherInstance();
-    assert
-      .dom('[data-test-field-chooser] [data-test-field-instance]')
-      .exists({ count: 3 });
-  });
+      await toggleSpecPanel();
+      assert
+        .dom('[data-test-spec-selector] > .ember-basic-dropdown-trigger')
+        .hasAttribute('aria-disabled', 'true', 'has only 1 spec instance');
+      assert.dom('[data-test-boxel-input-id="spec-title"]').hasValue('Quote');
+      assert
+        .dom(
+          '[data-test-contains-many="containedExamples"] [data-test-item="0"] [data-test-field="quote"] input',
+        )
+        .hasNoValue();
 
-  test('can autogenerate new field instance when spec exists but has no examples', async function (assert) {
-    let selection =
-      getPlaygroundSelections()?.[`${testRealmURL}author/FullNameField`];
-    assert.strictEqual(selection, undefined);
-    await openFileInPlayground('author.gts', testRealmURL, 'FullNameField');
-    assert
-      .dom('[data-test-selected-item]')
-      .hasText('FullNameField spec - Example 1');
-    assertFieldExists(assert, 'edit');
-    assert
-      .dom('[data-test-field-preview-card] [data-test-field="firstName"] input')
-      .hasNoValue();
-    await fillIn('[data-test-field="firstName"] input', 'Marco');
-    await fillIn('[data-test-field="lastName"] input', 'N.');
-
-    await chooseAnotherInstance();
-    assert
-      .dom('[data-test-field-chooser] [data-test-field-instance]')
-      .exists({ count: 1 });
-    assert
-      .dom('[data-test-field-chooser] [data-test-full-name-embedded]')
-      .hasText('Marco N.');
-    await click('[data-test-field-chooser] [data-test-close-modal]');
-
-    await toggleSpecPanel();
-    assert
-      .dom('[data-test-spec-selector] > .ember-basic-dropdown-trigger')
-      .hasAttribute('aria-disabled', 'true', 'has only 1 spec instance');
-    assert
-      .dom('[data-test-contains-many="containedExamples"] [data-test-item]')
-      .exists({ count: 1 });
-    assert
-      .dom(
-        '[data-test-contains-many="containedExamples"] [data-test-item="0"] [data-test-field="firstName"] input',
-      )
-      .hasValue('Marco');
-
-    selection =
-      getPlaygroundSelections()?.[`${testRealmURL}author/FullNameField`];
-    assert.deepEqual(selection, {
-      cardId: `${testRealmURL}Spec/full-name`,
-      format: 'edit',
-      fieldIndex: 0,
+      await togglePlaygroundPanel();
+      assertFieldExists(assert, 'edit');
+      await toggleSpecPanel();
+      assert
+        .dom('[data-test-spec-selector] > .ember-basic-dropdown-trigger')
+        .hasAttribute(
+          'aria-disabled',
+          'true',
+          'still has only 1 spec instance',
+        );
     });
-  });
 
-  test('has default templates when a format template is not provided', async function (assert) {
-    await openFileInPlayground('pet.gts', testRealmURL, 'TreatField');
-    assert
-      .dom('[data-test-instance-chooser]')
-      .hasText('TreatField - Example 1');
-    assertFieldExists(assert, 'edit'); // spec was autogenerated
-    await selectFormat('embedded');
-    assert
-      .dom('[data-test-missing-template-text="embedded"]')
-      .hasText('Missing embedded component for FieldDef: Treat');
-    await selectFormat('fitted');
-    assert
-      .dom('[data-test-missing-template-text="fitted"]')
-      .hasText('Missing fitted component for FieldDef: Treat');
-    await selectFormat('atom');
-    assert
-      .dom('[data-test-compound-field-format="atom"]')
-      .hasText('Untitled Treat');
-  });
-
-  test('does not persist the wrong card for field', async function (assert) {
-    const cardId = `${testRealmURL}Pet/mango`;
-    const specId = `${testRealmURL}Spec/toy`;
-    let selections: Record<string, PlaygroundSelection> = {
-      [`${testRealmURL}pet/PetCard`]: { cardId, format: 'isolated' as Format },
-    };
-    setRecentFiles([[testRealmURL, 'Pet/mango.json']]);
-    setPlaygroundSelections(selections);
-
-    await openFileInPlayground('pet.gts', testRealmURL, 'ToyField');
-    assert.dom('[data-test-instance-chooser]').hasText('Toy - Example 1');
-    assertFieldExists(assert, 'embedded');
-    selections = {
-      ...selections,
-      [`${testRealmURL}pet/ToyField`]: {
-        cardId: specId,
-        fieldIndex: 0,
+    test('can create new field instance (has preexisting Spec)', async function (assert) {
+      await openFileInPlayground('blog-post.gts', testRealmURL, 'Comment');
+      assert
+        .dom('[data-test-selected-item]')
+        .hasText('Comment spec - Example 1');
+      assert
+        .dom('[data-test-embedded-comment-title]')
+        .hasText('Terrible product');
+      let selection =
+        getPlaygroundSelections()?.[`${testRealmURL}blog-post/Comment`];
+      assert.deepEqual(selection, {
+        cardId: `${testRealmURL}Spec/comment-1`,
         format: 'embedded',
-      },
-    };
-    assert.deepEqual(
-      getPlaygroundSelections(),
-      selections,
-      'persisted selections are correct',
-    );
+        fieldIndex: 0,
+      });
 
-    await selectDeclaration('PetCard');
-    assertCardExists(assert, cardId, 'isolated');
-    await selectDeclaration('ToyField');
-    assert.dom('[data-test-instance-chooser]').hasText('Toy - Example 1');
-    assertFieldExists(assert, 'embedded');
-    assert.deepEqual(
-      getPlaygroundSelections(),
-      selections,
-      'persisted selections are still correct',
-    );
-  });
+      await createNewInstance();
+      assert
+        .dom('[data-test-field-preview-card] [data-test-field="title"] input')
+        .hasNoValue();
+      selection =
+        getPlaygroundSelections()?.[`${testRealmURL}blog-post/Comment`];
+      assert.deepEqual(selection, {
+        cardId: `${testRealmURL}Spec/comment-1`,
+        format: 'edit',
+        fieldIndex: 2,
+      });
 
-  test('editing compound field instance live updates the preview', async function (assert) {
-    const updatedCommentField = `import { contains, field, Component, FieldDef } from "https://cardstack.com/base/card-api";
+      await toggleSpecPanel();
+      assert
+        .dom('[data-test-contains-many="containedExamples"] [data-test-item]')
+        .exists({ count: 3 });
+      assert
+        .dom(
+          '[data-test-contains-many="containedExamples"] [data-test-item="2"] [data-test-field="title"] input',
+        )
+        .hasNoValue();
+
+      await togglePlaygroundPanel();
+      await chooseAnotherInstance();
+      assert
+        .dom('[data-test-field-chooser] [data-test-field-instance]')
+        .exists({ count: 3 });
+    });
+
+    test('can autogenerate new field instance when spec exists but has no examples', async function (assert) {
+      let selection =
+        getPlaygroundSelections()?.[`${testRealmURL}author/FullNameField`];
+      assert.strictEqual(selection, undefined);
+      await openFileInPlayground('author.gts', testRealmURL, 'FullNameField');
+      assert
+        .dom('[data-test-selected-item]')
+        .hasText('FullNameField spec - Example 1');
+      assertFieldExists(assert, 'edit');
+      assert
+        .dom(
+          '[data-test-field-preview-card] [data-test-field="firstName"] input',
+        )
+        .hasNoValue();
+      await fillIn('[data-test-field="firstName"] input', 'Marco');
+      await fillIn('[data-test-field="lastName"] input', 'N.');
+
+      await chooseAnotherInstance();
+      assert
+        .dom('[data-test-field-chooser] [data-test-field-instance]')
+        .exists({ count: 1 });
+      assert
+        .dom('[data-test-field-chooser] [data-test-full-name-embedded]')
+        .hasText('Marco N.');
+      await click('[data-test-field-chooser] [data-test-close-modal]');
+
+      await toggleSpecPanel();
+      assert
+        .dom('[data-test-spec-selector] > .ember-basic-dropdown-trigger')
+        .hasAttribute('aria-disabled', 'true', 'has only 1 spec instance');
+      assert
+        .dom('[data-test-contains-many="containedExamples"] [data-test-item]')
+        .exists({ count: 1 });
+      assert
+        .dom(
+          '[data-test-contains-many="containedExamples"] [data-test-item="0"] [data-test-field="firstName"] input',
+        )
+        .hasValue('Marco');
+
+      selection =
+        getPlaygroundSelections()?.[`${testRealmURL}author/FullNameField`];
+      assert.deepEqual(selection, {
+        cardId: `${testRealmURL}Spec/full-name`,
+        format: 'edit',
+        fieldIndex: 0,
+      });
+    });
+
+    test('has default templates when a format template is not provided', async function (assert) {
+      await openFileInPlayground('pet.gts', testRealmURL, 'TreatField');
+      assert
+        .dom('[data-test-instance-chooser]')
+        .hasText('TreatField - Example 1');
+      assertFieldExists(assert, 'edit'); // spec was autogenerated
+      await selectFormat('embedded');
+      assert
+        .dom('[data-test-missing-template-text="embedded"]')
+        .hasText('Missing embedded component for FieldDef: Treat');
+      await selectFormat('fitted');
+      assert
+        .dom('[data-test-missing-template-text="fitted"]')
+        .hasText('Missing fitted component for FieldDef: Treat');
+      await selectFormat('atom');
+      assert
+        .dom('[data-test-compound-field-format="atom"]')
+        .hasText('Untitled Treat');
+    });
+
+    test('does not persist the wrong card for field', async function (assert) {
+      const cardId = `${testRealmURL}Pet/mango`;
+      const specId = `${testRealmURL}Spec/toy`;
+      let selections: Record<string, PlaygroundSelection> = {
+        [`${testRealmURL}pet/PetCard`]: {
+          cardId,
+          format: 'isolated' as Format,
+        },
+      };
+      setRecentFiles([[testRealmURL, 'Pet/mango.json']]);
+      setPlaygroundSelections(selections);
+
+      await openFileInPlayground('pet.gts', testRealmURL, 'ToyField');
+      assert.dom('[data-test-instance-chooser]').hasText('Toy - Example 1');
+      assertFieldExists(assert, 'embedded');
+      selections = {
+        ...selections,
+        [`${testRealmURL}pet/ToyField`]: {
+          cardId: specId,
+          fieldIndex: 0,
+          format: 'embedded',
+        },
+      };
+      assert.deepEqual(
+        getPlaygroundSelections(),
+        selections,
+        'persisted selections are correct',
+      );
+
+      await selectDeclaration('PetCard');
+      assertCardExists(assert, cardId, 'isolated');
+      await selectDeclaration('ToyField');
+      assert.dom('[data-test-instance-chooser]').hasText('Toy - Example 1');
+      assertFieldExists(assert, 'embedded');
+      assert.deepEqual(
+        getPlaygroundSelections(),
+        selections,
+        'persisted selections are still correct',
+      );
+    });
+
+    test('editing compound field instance live updates the preview', async function (assert) {
+      const updatedCommentField = `import { contains, field, Component, FieldDef } from "https://cardstack.com/base/card-api";
       import StringField from "https://cardstack.com/base/string";
 
       export class Comment extends FieldDef {
@@ -904,15 +949,290 @@ module('Acceptance | code-submode | field playground', function (hooks) {
       </template>
       }
     }`;
-    await openFileInPlayground('blog-post.gts', testRealmURL, 'Comment');
-    assertFieldExists(assert, 'embedded');
-    assert
-      .dom('[data-test-embedded-comment-title]')
-      .hasText('Terrible product');
+      await openFileInPlayground('blog-post.gts', testRealmURL, 'Comment');
+      assertFieldExists(assert, 'embedded');
+      assert
+        .dom('[data-test-embedded-comment-title]')
+        .hasText('Terrible product');
 
-    await realm.write('blog-post.gts', updatedCommentField);
-    await settled();
-    assertFieldExists(assert, 'embedded');
-    assert.dom('[data-test-embedded-comment-title]').doesNotExist();
+      await realm.write('blog-post.gts', updatedCommentField);
+      await settled();
+      assertFieldExists(assert, 'embedded');
+      assert.dom('[data-test-embedded-comment-title]').doesNotExist();
+    });
+  });
+
+  module('multiple realms', function (hooks) {
+    let realm: Realm;
+    let personalRealmURL: string;
+    let additionalRealmURL: string;
+
+    setupApplicationTest(hooks);
+    setupLocalIndexing(hooks);
+
+    let mockMatrixUtils = setupMockMatrix(hooks, {
+      loggedInAs: '@testuser:localhost',
+    });
+
+    let { setActiveRealms, setRealmPermissions, createAndJoinRoom } =
+      mockMatrixUtils;
+
+    hooks.beforeEach(async function () {
+      matrixRoomId = createAndJoinRoom({
+        sender: '@testuser:localhost',
+        name: 'room-test',
+      });
+      setupUserSubscription(matrixRoomId);
+
+      let realmServerService = this.owner.lookup(
+        'service:realm-server',
+      ) as RealmServerService;
+      personalRealmURL = `${realmServerService.url}testuser/personal/`;
+      additionalRealmURL = `${realmServerService.url}testuser/aaa/`; // writeable realm that is lexically before the personal realm
+      setActiveRealms([additionalRealmURL, personalRealmURL]);
+
+      await setupAcceptanceTestRealm({
+        mockMatrixUtils,
+        realmURL: personalRealmURL,
+        contents: {
+          'author.gts': authorCard,
+          '.realm.json': {
+            name: `Test User's Workspace`,
+            backgroundURL: 'https://i.postimg.cc/NjcjbyD3/4k-origami-flock.jpg',
+            iconURL: 'https://i.postimg.cc/Rq550Bwv/T.png',
+          },
+        },
+      });
+
+      ({ realm } = await setupAcceptanceTestRealm({
+        mockMatrixUtils,
+        realmURL: additionalRealmURL,
+        contents: {
+          'author.gts': authorCard,
+          'pet.gts': petCard,
+          'Spec/toy.json': {
+            data: {
+              type: 'card',
+              attributes: {
+                ref: {
+                  name: 'ToyField',
+                  module: '../pet',
+                },
+                specType: 'field',
+                containedExamples: [{ title: 'Tug rope' }],
+                title: 'Toy',
+              },
+              meta: {
+                fields: {
+                  containedExamples: [
+                    {
+                      adoptsFrom: {
+                        module: '../pet',
+                        name: 'ToyField',
+                      },
+                    },
+                  ],
+                },
+                adoptsFrom: {
+                  module: 'https://cardstack.com/base/spec',
+                  name: 'Spec',
+                },
+              },
+            },
+          },
+          'Spec/full-name.json': {
+            data: {
+              type: 'card',
+              attributes: {
+                ref: {
+                  name: 'FullNameField',
+                  module: '../author',
+                },
+                specType: 'field',
+                containedExamples: [],
+                title: 'FullNameField spec',
+              },
+              meta: {
+                adoptsFrom: {
+                  module: 'https://cardstack.com/base/spec',
+                  name: 'Spec',
+                },
+              },
+            },
+          },
+          '.realm.json': {
+            name: `Additional Workspace`,
+            backgroundURL: 'https://i.postimg.cc/4ycXQZ94/4k-powder-puff.jpg',
+            iconURL: 'https://i.postimg.cc/BZwv0LyC/A.png',
+          },
+        },
+      }));
+
+      setRealmPermissions({
+        [additionalRealmURL]: ['read', 'write', 'realm-owner'],
+        [personalRealmURL]: ['read', 'write', 'realm-owner'],
+      });
+    });
+
+    test('can autogenerate new Spec and field instance (no preexisting Spec)', async function (assert) {
+      let queryEngine = realm.realmIndexQueryEngine;
+      let { data: matching } = await queryEngine.search({
+        filter: {
+          on: specRef,
+          eq: {
+            specType: 'field',
+            isField: true,
+            title: 'Quote',
+            moduleHref: `${additionalRealmURL}author`,
+          },
+        },
+      });
+      assert.strictEqual(matching.length, 0);
+
+      await openFileInPlayground('author.gts', additionalRealmURL, 'Quote');
+      assert.dom('[data-test-instance-chooser]').hasText('Quote - Example 1');
+      assertFieldExists(assert, 'edit');
+      assert.dom('[data-test-field="quote"] input').hasNoValue();
+
+      ({ data: matching } = await queryEngine.search({
+        filter: {
+          on: specRef,
+          eq: {
+            specType: 'field',
+            isField: true,
+            title: 'Quote',
+            moduleHref: `${additionalRealmURL}author`,
+          },
+        },
+      }));
+      assert.strictEqual(matching.length, 1);
+      assert.ok(matching[0].id.startsWith(`${additionalRealmURL}Spec/`));
+
+      // TODO: Bug: spec panel does not show the newly created spec
+      // await toggleSpecPanel();
+      // assert
+      //   .dom('[data-test-spec-selector] > .ember-basic-dropdown-trigger')
+      //   .hasAttribute('aria-disabled', 'true', 'has only 1 spec instance');
+      // assert.dom('[data-test-boxel-input-id="spec-title"]').hasValue('Quote');
+      // assert
+      //   .dom(
+      //     '[data-test-contains-many="containedExamples"] [data-test-item="0"] [data-test-field="quote"] input',
+      //   )
+      //   .hasNoValue();
+
+      // await togglePlaygroundPanel();
+      // assertFieldExists(assert, 'edit');
+      // await toggleSpecPanel();
+      // assert
+      //   .dom('[data-test-spec-selector] > .ember-basic-dropdown-trigger')
+      //   .hasAttribute(
+      //     'aria-disabled',
+      //     'true',
+      //     'still has only 1 spec instance',
+      //   );
+    });
+
+    test('can create new field instance (has preexisting Spec)', async function (assert) {
+      await openFileInPlayground('pet.gts', additionalRealmURL, 'ToyField');
+      assert.dom('[data-test-selected-item]').hasText('Toy - Example 1');
+      await selectFormat('atom');
+      assertFieldExists(assert, 'atom');
+      assert
+        .dom(
+          '[data-test-playground-panel] [data-test-compound-field-format="atom"]',
+        )
+        .hasText('Tug rope');
+      let selection =
+        getPlaygroundSelections()?.[`${additionalRealmURL}pet/ToyField`];
+      assert.deepEqual(selection, {
+        cardId: `${additionalRealmURL}Spec/toy`,
+        format: 'atom',
+        fieldIndex: 0,
+      });
+
+      await createNewInstance();
+      assert
+        .dom('[data-test-field-preview-card] [data-test-field="title"] input')
+        .hasNoValue();
+      selection =
+        getPlaygroundSelections()?.[`${additionalRealmURL}pet/ToyField`];
+      assert.deepEqual(selection, {
+        cardId: `${additionalRealmURL}Spec/toy`,
+        format: 'edit',
+        fieldIndex: 1,
+      });
+
+      await toggleSpecPanel();
+      assert
+        .dom('[data-test-contains-many="containedExamples"] [data-test-item]')
+        .exists({ count: 2 });
+      assert
+        .dom(
+          '[data-test-contains-many="containedExamples"] [data-test-item="1"] [data-test-field="title"] input',
+        )
+        .hasNoValue();
+
+      await togglePlaygroundPanel();
+      await chooseAnotherInstance();
+      assert
+        .dom('[data-test-field-chooser] [data-test-field-instance]')
+        .exists({ count: 2 });
+    });
+
+    test('can autogenerate new field instance when spec exists but has no examples', async function (assert) {
+      let selection =
+        getPlaygroundSelections()?.[
+          `${additionalRealmURL}author/FullNameField`
+        ];
+      assert.strictEqual(selection, undefined);
+      await openFileInPlayground(
+        'author.gts',
+        additionalRealmURL,
+        'FullNameField',
+      );
+      assert
+        .dom('[data-test-selected-item]')
+        .hasText('FullNameField spec - Example 1');
+      assertFieldExists(assert, 'edit');
+      assert
+        .dom(
+          '[data-test-field-preview-card] [data-test-field="firstName"] input',
+        )
+        .hasNoValue();
+      await fillIn('[data-test-field="firstName"] input', 'Marco');
+      await fillIn('[data-test-field="lastName"] input', 'N.');
+
+      await chooseAnotherInstance();
+      assert
+        .dom('[data-test-field-chooser] [data-test-field-instance]')
+        .exists({ count: 1 });
+      assert
+        .dom('[data-test-field-chooser] [data-test-full-name-embedded]')
+        .hasText('Marco N.');
+      await click('[data-test-field-chooser] [data-test-close-modal]');
+
+      await toggleSpecPanel();
+      assert
+        .dom('[data-test-spec-selector] > .ember-basic-dropdown-trigger')
+        .hasAttribute('aria-disabled', 'true', 'has only 1 spec instance');
+      assert
+        .dom('[data-test-contains-many="containedExamples"] [data-test-item]')
+        .exists({ count: 1 });
+      assert
+        .dom(
+          '[data-test-contains-many="containedExamples"] [data-test-item="0"] [data-test-field="firstName"] input',
+        )
+        .hasValue('Marco');
+
+      selection =
+        getPlaygroundSelections()?.[
+          `${additionalRealmURL}author/FullNameField`
+        ];
+      assert.deepEqual(selection, {
+        cardId: `${additionalRealmURL}Spec/full-name`,
+        format: 'edit',
+        fieldIndex: 0,
+      });
+    });
   });
 });


### PR DESCRIPTION
- `this.store.create` call was missing the realm url and defaulting to personal realm, not the currently open realm.
- was able to reproduce the error in multiple-realm tests. Moved all existing card and field playground tests to nested module named `single realm` and added the new tests in `multiple realms` module. 

Note: Discovered a different bug -- when creating new field spec in multiple-realm situation, the spec is generated but it does not show up on spec panel until refreshed. --> Update: After merging in latest main, this is no longer an issue when I try it in the app, however, can't replicate the success in tests somehow