### PR TITLE
stop run away search in code mode

### DIFF
--- a/packages/base/cards-grid.gts
+++ b/packages/base/cards-grid.gts
@@ -137,6 +137,7 @@ class Isolated extends Component<typeof CardsGrid> {
               @query={{this.query}}
               @format='fitted'
               @realms={{this.realms}}
+              @isLive={{true}}
             >
 
               <:loading>

--- a/packages/experiments-realm/ai-app-generator.gts
+++ b/packages/experiments-realm/ai-app-generator.gts
@@ -140,6 +140,7 @@ class CardListSidebar extends GlimmerComponent<{
         @query={{@query}}
         @format='fitted'
         @realms={{@realms}}
+        @isLive={{true}}
       >
         <:loading>Loading...</:loading>
         <:response as |cards|>
@@ -412,6 +413,7 @@ class RequirementsTab extends GlimmerComponent<{
           @query={{getCardTypeQuery this.cardRef}}
           @format='fitted'
           @realms={{@realms}}
+          @isLive={{true}}
         >
           <:loading>Loading...</:loading>
           <:response as |cards|>

--- a/packages/experiments-realm/app-card.gts
+++ b/packages/experiments-realm/app-card.gts
@@ -173,6 +173,7 @@ class DefaultTabTemplate extends GlimmerComponent<DefaultTabSignature> {
           @query={{this.query}}
           @format='fitted'
           @realms={{@realms}}
+          @isLive={{true}}
         >
           <:loading>Loading...</:loading>
           <:response as |cards|>

--- a/packages/experiments-realm/components/card-list.gts
+++ b/packages/experiments-realm/components/card-list.gts
@@ -33,6 +33,7 @@ export class CardList extends GlimmerComponent<CardListSignature> {
           @query={{@query}}
           @format='embedded'
           @realms={{@realms}}
+          @isLive={{true}}
         >
           <:loading>
             Loading...

--- a/packages/experiments-realm/components/grid.gts
+++ b/packages/experiments-realm/components/grid.gts
@@ -30,6 +30,7 @@ export class CardsGrid extends GlimmerComponent<CardsGridSignature> {
           @query={{@query}}
           @format='fitted'
           @realms={{@realms}}
+          @isLive={{true}}
         >
           <:loading>
             Loading...

--- a/packages/host/app/components/card-catalog/modal.gts
+++ b/packages/host/app/components/card-catalog/modal.gts
@@ -9,7 +9,6 @@ import Component from '@glimmer/component';
 
 import { restartableTask, task, timeout } from 'ember-concurrency';
 import focusTrap from 'ember-focus-trap/modifiers/focus-trap';
-import { consume } from 'ember-provide-consume-context';
 
 import flatMap from 'lodash/flatMap';
 
@@ -21,8 +20,6 @@ import { eq, not } from '@cardstack/boxel-ui/helpers';
 import {
   type CodeRef,
   type CreateNewCard,
-  type getCards,
-  type getCard,
   createNewCard,
   baseRealm,
   Deferred,
@@ -30,8 +27,6 @@ import {
   RealmInfo,
   CardCatalogQuery,
   isCardInstance,
-  GetCardContextName,
-  GetCardsContextName,
 } from '@cardstack/runtime-common';
 
 import type {
@@ -75,7 +70,6 @@ interface Signature {
 }
 
 type Request = {
-  search: ReturnType<getCards>;
   deferred: Deferred<string | undefined>;
   opts?: {
     offerToCreate?: {
@@ -235,9 +229,6 @@ export default class CardCatalogModal extends Component<Signature> {
     </style>
   </template>
 
-  @consume(GetCardContextName) private declare getCard: getCard;
-  @consume(GetCardsContextName) private declare getCards: getCards;
-
   private stateStack: State[] = new TrackedArray<State>();
   private stateId = 0;
   @service private declare cardService: CardService;
@@ -366,7 +357,6 @@ export default class CardCatalogModal extends Component<Signature> {
         opts?.multiSelect,
       );
       let request = new TrackedObject<Request>({
-        search: this.getCards(this, () => query),
         deferred: new Deferred(),
         opts,
       });

--- a/packages/host/app/components/operator-mode/code-submode/playground/spec-search.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/spec-search.gts
@@ -42,7 +42,6 @@ export default class SpecSearch extends Component<Signature> {
       this,
       () => this.args.query,
       () => this.args.realms,
-      { isLive: true },
     );
   };
 

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -5,6 +5,7 @@ import { next } from '@ember/runloop';
 import { service } from '@ember/service';
 import { htmlSafe } from '@ember/template';
 import GlimmerComponent from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 
 import AppsIcon from '@cardstack/boxel-icons/apps';
 import Brain from '@cardstack/boxel-icons/brain';
@@ -45,13 +46,13 @@ import {
 } from '@cardstack/runtime-common/code-ref';
 
 import Preview from '@cardstack/host/components/preview';
+import consumeContext from '@cardstack/host/helpers/consume-context';
 
 import {
   CardOrFieldDeclaration,
   isCardOrFieldDeclaration,
   type ModuleDeclaration,
 } from '@cardstack/host/resources/module-contents';
-import { getSearch } from '@cardstack/host/resources/search';
 
 import type CardService from '@cardstack/host/services/card-service';
 import type EnvironmentService from '@cardstack/host/services/environment-service';
@@ -456,6 +457,7 @@ const SpecPreviewLoading: TemplateOnlyComponent<SpecPreviewLoadingSignature> =
   </template>;
 
 export default class SpecPreview extends GlimmerComponent<Signature> {
+  @consume(GetCardsContextName) private declare getCards: getCards;
   @service private declare operatorModeStateService: OperatorModeStateService;
   @service private declare environmentService: EnvironmentService;
   @service private declare realm: RealmService;
@@ -466,6 +468,7 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
   @service private declare recentFilesService: RecentFilesService;
   @service private declare specPanelService: SpecPanelService;
   @service private declare store: StoreService;
+  @tracked private search: ReturnType<getCards<Spec>> | undefined;
 
   private get getSelectedDeclarationAsCodeRef(): ResolvedCodeRef {
     if (!this.args.selectedDeclaration?.exportName) {
@@ -613,36 +616,37 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
     return this.realm.canWrite(this.operatorModeStateService.realmURL.href);
   }
 
-  private search = getSearch(
-    this,
-    () => this.specQuery,
-    () => this.realms,
-    { isLive: true, isAutoSaved: true },
-  );
+  private makeSearch = () => {
+    this.search = this.getCards(
+      this,
+      () => this.specQuery,
+      () => this.realms,
+    ) as ReturnType<getCards<Spec>>;
+  };
 
   get _selectedCard() {
     let selectedCardId = this.specPanelService.specSelection;
     if (selectedCardId) {
-      return this.cards.find((card) => card.id === selectedCardId) as Spec;
+      return this.cards?.find((card) => card.id === selectedCardId);
     }
-    return this.cards?.[0] as Spec;
+    return this.cards?.[0];
   }
 
   get cards() {
-    return this.search.instances as unknown as Spec[];
+    return this.search?.instances ?? [];
   }
 
   private get card() {
     if (this._selectedCard) {
       return this._selectedCard;
     }
-    return this.cards?.[0] as Spec;
+    return this.cards?.[0];
   }
 
   get showCreateSpec() {
     return (
       Boolean(this.args.selectedDeclaration?.exportName) &&
-      !this.search.isLoading &&
+      !this.search?.isLoading &&
       this.cards.length === 0 &&
       this.canWrite
     );
@@ -714,6 +718,7 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
   };
 
   <template>
+    {{consumeContext this.makeSearch}}
     {{#if this.isLoading}}
       {{yield
         (component

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -621,6 +621,7 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
       this,
       () => this.specQuery,
       () => this.realms,
+      { isLive: true },
     ) as ReturnType<getCards<Spec>>;
   };
 

--- a/packages/host/app/components/prerendered-card-search.gts
+++ b/packages/host/app/components/prerendered-card-search.gts
@@ -188,8 +188,10 @@ export default class PrerenderedCardSearch extends Component<Signature> {
     if (
       // we want to only run the search when there is a deep equality
       // difference, not a strict equality difference
-      (!realmsChanged && !queryChanged && !this.args.isLive) ||
-      (this.args.isLive && this.realmsNeedingRefresh.size === 0)
+      !realmsChanged &&
+      !queryChanged &&
+      (!this.args.isLive ||
+        (this.args.isLive && this.realmsNeedingRefresh.size === 0))
     ) {
       return (
         this.runSearchTask.lastSuccessful?.value ?? {

--- a/packages/host/app/components/prerendered-card-search.gts
+++ b/packages/host/app/components/prerendered-card-search.gts
@@ -105,6 +105,7 @@ interface Signature {
     format: Format;
     cardUrls?: string[];
     realms: string[];
+    isLive?: boolean;
   };
   Blocks: {
     loading: [];
@@ -265,7 +266,9 @@ export default class PrerenderedCardSearch extends Component<Signature> {
   };
 
   <template>
-    {{SubscribeToRealms @realms this.markRealmNeedsRefreshing}}
+    {{#if @isLive}}
+      {{SubscribeToRealms @realms this.markRealmNeedsRefreshing}}
+    {{/if}}
     {{#if this.searchResults.isLoading}}
       {{yield to='loading'}}
     {{else}}

--- a/packages/host/app/components/prerendered-card-search.gts
+++ b/packages/host/app/components/prerendered-card-search.gts
@@ -117,6 +117,7 @@ export default class PrerenderedCardSearch extends Component<Signature> {
   @service declare cardService: CardService;
   @service declare loaderService: LoaderService;
   _lastSearchQuery: Query | null = null;
+  _lastCardUrls: string[] | undefined;
   _lastSearchResults: PrerenderedCard[] | undefined;
   _lastRealms: string[] | undefined;
   realmsNeedingRefresh = new TrackedSet<string>();
@@ -177,6 +178,7 @@ export default class PrerenderedCardSearch extends Component<Signature> {
 
     let realmsChanged = !isEqual(realms, this._lastRealms);
     let queryChanged = !isEqual(query, this._lastSearchQuery);
+    let cardUrlsChanged = !isEqual(cardUrls, this._lastSearchQuery);
     if (realmsChanged) {
       this._lastSearchResults = this._lastSearchResults?.filter((r) =>
         realms.includes(r.realmUrl),
@@ -190,6 +192,7 @@ export default class PrerenderedCardSearch extends Component<Signature> {
       // difference, not a strict equality difference
       !realmsChanged &&
       !queryChanged &&
+      !cardUrlsChanged &&
       (!this.args.isLive ||
         (this.args.isLive && this.realmsNeedingRefresh.size === 0))
     ) {
@@ -225,6 +228,10 @@ export default class PrerenderedCardSearch extends Component<Signature> {
       this._lastSearchResults = undefined;
       this._lastSearchQuery = query;
     }
+    if (!isEqual(cardUrls, this._lastCardUrls)) {
+      this._lastCardUrls = cardUrls;
+    }
+
     let results = [...(this._lastSearchResults || [])];
     let realmsNeedingRefresh = Array.from(this.realmsNeedingRefresh);
     let token = waiter.beginAsync();

--- a/packages/host/tests/integration/commands/use-ai-assistant-test.gts
+++ b/packages/host/tests/integration/commands/use-ai-assistant-test.gts
@@ -317,7 +317,6 @@ module('Integration | commands | ai-assistant', function (hooks) {
     );
   });
 
-
   test('sets active LLM model when llmModel is provided', async function (assert) {
     let roomId = createAndJoinRoom({
       sender: '@testuser:localhost',

--- a/packages/host/tests/integration/components/prerendered-card-search-test.gts
+++ b/packages/host/tests/integration/components/prerendered-card-search-test.gts
@@ -456,7 +456,7 @@ module(`Integration | prerendered-card-search`, function (hooks) {
     assert.dom('.card-container .author').hasStyle({ color: 'rgb(0, 0, 255)' });
   });
 
-  test(`refreshes when a queried realm changes`, async function (assert) {
+  test(`refreshes when a queried realm changes when configured to perform live search`, async function (assert) {
     let query: Query = {
       filter: {
         on: {
@@ -480,6 +480,7 @@ module(`Integration | prerendered-card-search`, function (hooks) {
         @query={{query}}
         @format='fitted'
         @realms={{realms}}
+        @isLive={{true}}
       >
         <:loading>
           Loading...

--- a/packages/realm-server/tests/cards/person-with-error.gts
+++ b/packages/realm-server/tests/cards/person-with-error.gts
@@ -57,6 +57,7 @@ export class PersonCard extends CardDef {
           @query={{this.query}}
           @format='fitted'
           @realms={{this.realms}}
+          @isLive={{true}}
         >
 
           <:loading>

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -286,7 +286,7 @@ export type getCard<T extends CardDef = CardDef> = (
   api: typeof CardAPI;
 };
 
-export type getCards = (
+export type getCards<T extends CardDef = CardDef> = (
   parent: object,
   getQuery: () => Query | undefined,
   getRealms?: () => string[] | undefined,
@@ -296,8 +296,8 @@ export type getCards = (
   },
 ) => // This is a duck type of the SearchResource
 {
-  instances: CardDef[];
-  instancesByRealm: { realm: string; cards: CardDef[] }[];
+  instances: T[];
+  instancesByRealm: { realm: string; cards: T[] }[];
   isLoading: boolean;
 };
 

--- a/packages/seed-realm/app-card.gts
+++ b/packages/seed-realm/app-card.gts
@@ -173,6 +173,7 @@ class DefaultTabTemplate extends GlimmerComponent<DefaultTabSignature> {
           @query={{this.query}}
           @format='fitted'
           @realms={{@realms}}
+          @isLive={{true}}
         >
           <:loading>Loading...</:loading>
           <:response as |cards|>

--- a/packages/seed-realm/components/card-list.gts
+++ b/packages/seed-realm/components/card-list.gts
@@ -33,6 +33,7 @@ export class CardList extends GlimmerComponent<CardListSignature> {
           @query={{@query}}
           @format='embedded'
           @realms={{@realms}}
+          @isLive={{true}}
         >
           <:loading>
             Loading...

--- a/packages/seed-realm/components/grid.gts
+++ b/packages/seed-realm/components/grid.gts
@@ -30,6 +30,7 @@ export class CardsGrid extends GlimmerComponent<CardsGridSignature> {
           @query={{@query}}
           @format='fitted'
           @realms={{@realms}}
+          @isLive={{true}}
         >
           <:loading>
             Loading...


### PR DESCRIPTION
So the issue that triggered all the searches in code mode was a very subtle issue around reactivity. Ultimately the ModuleContentsResource was rebuilding the declaration on the code changes from the module. that resulted in a bunch of calls to rebuild the declarations within this resource. reactivity in glimmer is triggered based on strict equality. think of `strictEquals()` vs `deepEquals()` in our unit tests. you can have 2 instances of `{blah: "foo"}` and `{blah: "foo"}`. These are not strictly equal, but they are deeply equal. This was basically the issue. about 6 degrees of separation live between the ModuleContentsResource.declations and the resulting search query for the spec in `SpecPreviewComponent`, all chained together using getters that are reactive. the module declaration would change each time there was an edit in code mode to the module source code, but ultimately the module declarations were deeply equal. Regardless, that is not how glimmer reactivity works. So even though the search query never changed from a deep equality standpoint, it was not strictly equal after each code change, and as a result the search would re-run (against all the realms). 

Compounding this issue was that this is  set as a live search in `SpecPreviewComponent`, and a new live search callback would be registered with each query object change triggered in the `modify()` hook of the search resource--which compounded the searches resulting in a geometric expansion of all the searches being run.

Also, as part of this I noticed that we were forcing all prerendered searches to be live bound. there are many scenarios where we don't want that actually, so i made this a param for prerendered search. As well as Prerendered Search had the same vulnerability where it would re-run for queries that were not stricty equal, but were deeply equal.

After this change, there is still a series of search queries made after each update, but it is very much under control. Specifically we search in each realm for the spec of the selected declaration after each realm indexing event is received. This is used for the spec preview (which i think shows the spec detail in the accordion panel header and is responsive to code changes). We also removed all the prerendered searches triggering on realm index events, as well as queries that were deeply equal but not strictly equal that were occurring after each code change in code mode
