### PR TITLE
Fix cross-origin worker loading in monaco (patch until new version gets released)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
       "matrix-js-sdk@31.0.0": "patches/matrix-js-sdk@31.0.0.patch",
       "ember-basic-dropdown@8.0.4": "patches/ember-basic-dropdown@8.0.4.patch",
       "ember-source@5.4.1": "patches/ember-source@5.4.1.patch",
-      "monaco-editor@0.52.2": "patches/monaco-editor@0.52.2.patch"
+      "monaco-editor@0.52.2": "patches/monaco-editor@0.52.2.patch",
+      "monaco-editor-webpack-plugin@7.1.0": "patches/monaco-editor-webpack-plugin@7.1.0.patch"
     }
   },
   "devDependencies": {

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -155,7 +155,7 @@
     "moment": "^2.29.4",
     "moment-locales-webpack-plugin": "^1.2.0",
     "monaco-editor": "^0.52.2",
-    "monaco-editor-webpack-plugin": "^7.0.1",
+    "monaco-editor-webpack-plugin": "^7.1.0",
     "ms": "^2.1.3",
     "path-browserify": "^1.0.1",
     "pluralize": "^8.0.0",

--- a/packages/host/tests/integration/commands/use-ai-assistant-test.gts
+++ b/packages/host/tests/integration/commands/use-ai-assistant-test.gts
@@ -317,7 +317,6 @@ module('Integration | commands | ai-assistant', function (hooks) {
     );
   });
 
-
   test('sets active LLM model when llmModel is provided', async function (assert) {
     let roomId = createAndJoinRoom({
       sender: '@testuser:localhost',

--- a/patches/monaco-editor-webpack-plugin@7.1.0.patch
+++ b/patches/monaco-editor-webpack-plugin@7.1.0.patch
@@ -1,0 +1,455 @@
+diff --git a/out/index.js b/out/index.js
+index 2e61d97b15096b2b48492ef35aad6188e1f416b1..880dfa27773d8c58f50c4b529a4eda31d7917dab 100644
+--- a/out/index.js
++++ b/out/index.js
+@@ -3,162 +3,211 @@ const path = require("path");
+ const loaderUtils = require("loader-utils");
+ const fs = require("fs");
+ const AddWorkerEntryPointPlugin_1 = require("./plugins/AddWorkerEntryPointPlugin");
+-const INCLUDE_LOADER_PATH = require.resolve('./loaders/include');
++const INCLUDE_LOADER_PATH = require.resolve("./loaders/include");
+ const EDITOR_MODULE = {
+-    label: 'editorWorkerService',
+-    entry: undefined,
+-    worker: {
+-        id: 'vs/editor/editor',
+-        entry: 'vs/editor/editor.worker'
+-    }
++  label: "editorWorkerService",
++  entry: undefined,
++  worker: {
++    id: "vs/editor/editor",
++    entry: "vs/editor/editor.worker",
++  },
+ };
+ /**
+  * Return a resolved path for a given Monaco file.
+  */
+ function resolveMonacoPath(filePath, monacoEditorPath) {
+-    if (monacoEditorPath) {
+-        return require.resolve(path.join(monacoEditorPath, 'esm', filePath));
+-    }
+-    try {
+-        return require.resolve(path.join('monaco-editor/esm', filePath));
+-    }
+-    catch (err) { }
+-    try {
+-        return require.resolve(path.join(process.cwd(), 'node_modules/monaco-editor/esm', filePath));
+-    }
+-    catch (err) { }
+-    return require.resolve(filePath);
++  if (monacoEditorPath) {
++    return require.resolve(path.join(monacoEditorPath, "esm", filePath));
++  }
++  try {
++    return require.resolve(path.join("monaco-editor/esm", filePath));
++  } catch (err) {}
++  try {
++    return require.resolve(
++      path.join(process.cwd(), "node_modules/monaco-editor/esm", filePath)
++    );
++  } catch (err) {}
++  return require.resolve(filePath);
+ }
+ /**
+  * Return the interpolated final filename for a worker, respecting the file name template.
+  */
+ function getWorkerFilename(filename, entry, monacoEditorPath) {
+-    return loaderUtils.interpolateName({ resourcePath: entry }, filename, {
+-        content: fs.readFileSync(resolveMonacoPath(entry, monacoEditorPath))
+-    });
++  return loaderUtils.interpolateName({ resourcePath: entry }, filename, {
++    content: fs.readFileSync(resolveMonacoPath(entry, monacoEditorPath)),
++  });
+ }
+ function getEditorMetadata(monacoEditorPath) {
+-    const metadataPath = resolveMonacoPath('metadata.js', monacoEditorPath);
+-    return require(metadataPath);
++  const metadataPath = resolveMonacoPath("metadata.js", monacoEditorPath);
++  return require(metadataPath);
+ }
+ function resolveDesiredFeatures(metadata, userFeatures) {
+-    const featuresById = {};
+-    metadata.features.forEach((feature) => (featuresById[feature.label] = feature));
+-    function notContainedIn(arr) {
+-        return (element) => arr.indexOf(element) === -1;
+-    }
+-    let featuresIds;
+-    if (userFeatures && userFeatures.length) {
+-        const excludedFeatures = userFeatures.filter((f) => f[0] === '!').map((f) => f.slice(1));
+-        if (excludedFeatures.length) {
+-            featuresIds = Object.keys(featuresById).filter(notContainedIn(excludedFeatures));
+-        }
+-        else {
+-            featuresIds = userFeatures;
+-        }
++  const featuresById = {};
++  metadata.features.forEach(
++    (feature) => (featuresById[feature.label] = feature)
++  );
++  function notContainedIn(arr) {
++    return (element) => arr.indexOf(element) === -1;
++  }
++  let featuresIds;
++  if (userFeatures && userFeatures.length) {
++    const excludedFeatures = userFeatures
++      .filter((f) => f[0] === "!")
++      .map((f) => f.slice(1));
++    if (excludedFeatures.length) {
++      featuresIds = Object.keys(featuresById).filter(
++        notContainedIn(excludedFeatures)
++      );
++    } else {
++      featuresIds = userFeatures;
+     }
+-    else {
+-        featuresIds = Object.keys(featuresById);
+-    }
+-    return coalesce(featuresIds.map((id) => featuresById[id]));
++  } else {
++    featuresIds = Object.keys(featuresById);
++  }
++  return coalesce(featuresIds.map((id) => featuresById[id]));
+ }
+ function resolveDesiredLanguages(metadata, userLanguages, userCustomLanguages) {
+-    const languagesById = {};
+-    metadata.languages.forEach((language) => (languagesById[language.label] = language));
+-    const languages = userLanguages || Object.keys(languagesById);
+-    return coalesce(languages.map((id) => languagesById[id])).concat(userCustomLanguages || []);
++  const languagesById = {};
++  metadata.languages.forEach(
++    (language) => (languagesById[language.label] = language)
++  );
++  const languages = userLanguages || Object.keys(languagesById);
++  return coalesce(languages.map((id) => languagesById[id])).concat(
++    userCustomLanguages || []
++  );
+ }
+ class MonacoEditorWebpackPlugin {
+-    constructor(options = {}) {
+-        const monacoEditorPath = options.monacoEditorPath;
+-        const metadata = getEditorMetadata(monacoEditorPath);
+-        const languages = resolveDesiredLanguages(metadata, options.languages, options.customLanguages);
+-        const features = resolveDesiredFeatures(metadata, options.features);
+-        this.options = {
+-            languages,
+-            features,
+-            filename: options.filename || '[name].worker.js',
+-            monacoEditorPath,
+-            publicPath: options.publicPath || '',
+-            globalAPI: options.globalAPI || false
+-        };
+-    }
+-    apply(compiler) {
+-        const { languages, features, filename, monacoEditorPath, publicPath, globalAPI } = this.options;
+-        const compilationPublicPath = getCompilationPublicPath(compiler);
+-        const modules = [EDITOR_MODULE].concat(languages).concat(features);
+-        const workers = [];
+-        modules.forEach((module) => {
+-            if (module.worker) {
+-                workers.push({
+-                    label: module.label,
+-                    id: module.worker.id,
+-                    entry: module.worker.entry
+-                });
+-            }
++  constructor(options = {}) {
++    const monacoEditorPath = options.monacoEditorPath;
++    const metadata = getEditorMetadata(monacoEditorPath);
++    const languages = resolveDesiredLanguages(
++      metadata,
++      options.languages,
++      options.customLanguages
++    );
++    const features = resolveDesiredFeatures(metadata, options.features);
++    this.options = {
++      languages,
++      features,
++      filename: options.filename || "[name].worker.js",
++      monacoEditorPath,
++      publicPath: options.publicPath || "",
++      globalAPI: options.globalAPI || false,
++    };
++  }
++  apply(compiler) {
++    const {
++      languages,
++      features,
++      filename,
++      monacoEditorPath,
++      publicPath,
++      globalAPI,
++    } = this.options;
++    const compilationPublicPath = getCompilationPublicPath(compiler);
++    const modules = [EDITOR_MODULE].concat(languages).concat(features);
++    const workers = [];
++    modules.forEach((module) => {
++      if (module.worker) {
++        workers.push({
++          label: module.label,
++          id: module.worker.id,
++          entry: module.worker.entry,
+         });
+-        const rules = createLoaderRules(languages, features, workers, filename, monacoEditorPath, publicPath, compilationPublicPath, globalAPI);
+-        const plugins = createPlugins(compiler, workers, filename, monacoEditorPath);
+-        addCompilerRules(compiler, rules);
+-        addCompilerPlugins(compiler, plugins);
+-    }
++      }
++    });
++    const rules = createLoaderRules(
++      languages,
++      features,
++      workers,
++      filename,
++      monacoEditorPath,
++      publicPath,
++      compilationPublicPath,
++      globalAPI
++    );
++    const plugins = createPlugins(
++      compiler,
++      workers,
++      filename,
++      monacoEditorPath
++    );
++    addCompilerRules(compiler, rules);
++    addCompilerPlugins(compiler, plugins);
++  }
+ }
+ function addCompilerRules(compiler, rules) {
+-    const compilerOptions = compiler.options;
+-    if (!compilerOptions.module) {
+-        compilerOptions.module = { rules: rules };
+-    }
+-    else {
+-        const moduleOptions = compilerOptions.module;
+-        moduleOptions.rules = (moduleOptions.rules || []).concat(rules);
+-    }
++  const compilerOptions = compiler.options;
++  if (!compilerOptions.module) {
++    compilerOptions.module = { rules: rules };
++  } else {
++    const moduleOptions = compilerOptions.module;
++    moduleOptions.rules = (moduleOptions.rules || []).concat(rules);
++  }
+ }
+ function addCompilerPlugins(compiler, plugins) {
+-    plugins.forEach((plugin) => plugin.apply(compiler));
++  plugins.forEach((plugin) => plugin.apply(compiler));
+ }
+ function getCompilationPublicPath(compiler) {
+-    if (compiler.options.output && compiler.options.output.publicPath) {
+-        if (typeof compiler.options.output.publicPath === 'string') {
+-            return compiler.options.output.publicPath;
+-        }
+-        else {
+-            console.warn(`Cannot handle options.publicPath (expected a string)`);
+-        }
++  if (compiler.options.output && compiler.options.output.publicPath) {
++    if (typeof compiler.options.output.publicPath === "string") {
++      return compiler.options.output.publicPath;
++    } else {
++      console.warn(`Cannot handle options.publicPath (expected a string)`);
+     }
+-    return '';
++  }
++  return "";
+ }
+-function createLoaderRules(languages, features, workers, filename, monacoEditorPath, pluginPublicPath, compilationPublicPath, globalAPI) {
+-    if (!languages.length && !features.length) {
+-        return [];
+-    }
+-    const languagePaths = flatArr(coalesce(languages.map((language) => language.entry)));
+-    const featurePaths = flatArr(coalesce(features.map((feature) => feature.entry)));
+-    const workerPaths = fromPairs(workers.map(({ label, entry }) => [label, getWorkerFilename(filename, entry, monacoEditorPath)]));
+-    if (workerPaths['typescript']) {
+-        // javascript shares the same worker
+-        workerPaths['javascript'] = workerPaths['typescript'];
+-    }
+-    if (workerPaths['css']) {
+-        // scss and less share the same worker
+-        workerPaths['less'] = workerPaths['css'];
+-        workerPaths['scss'] = workerPaths['css'];
+-    }
+-    if (workerPaths['html']) {
+-        // handlebars, razor and html share the same worker
+-        workerPaths['handlebars'] = workerPaths['html'];
+-        workerPaths['razor'] = workerPaths['html'];
+-    }
+-    // Determine the public path from which to load worker JS files. In order of precedence:
+-    // 1. Plugin-specific public path.
+-    // 2. Dynamic runtime public path.
+-    // 3. Compilation public path.
+-    const pathPrefix = Boolean(pluginPublicPath)
+-        ? JSON.stringify(pluginPublicPath)
+-        : `typeof __webpack_public_path__ === 'string' ` +
+-            `? __webpack_public_path__ ` +
+-            `: ${JSON.stringify(compilationPublicPath)}`;
+-    const globals = {
+-        MonacoEnvironment: `(function (paths) {
++function createLoaderRules(
++  languages,
++  features,
++  workers,
++  filename,
++  monacoEditorPath,
++  pluginPublicPath,
++  compilationPublicPath,
++  globalAPI
++) {
++  if (!languages.length && !features.length) {
++    return [];
++  }
++  const languagePaths = flatArr(
++    coalesce(languages.map((language) => language.entry))
++  );
++  const featurePaths = flatArr(
++    coalesce(features.map((feature) => feature.entry))
++  );
++  const workerPaths = fromPairs(
++    workers.map(({ label, entry }) => [
++      label,
++      getWorkerFilename(filename, entry, monacoEditorPath),
++    ])
++  );
++  if (workerPaths["typescript"]) {
++    // javascript shares the same worker
++    workerPaths["javascript"] = workerPaths["typescript"];
++  }
++  if (workerPaths["css"]) {
++    // scss and less share the same worker
++    workerPaths["less"] = workerPaths["css"];
++    workerPaths["scss"] = workerPaths["css"];
++  }
++  if (workerPaths["html"]) {
++    // handlebars, razor and html share the same worker
++    workerPaths["handlebars"] = workerPaths["html"];
++    workerPaths["razor"] = workerPaths["html"];
++  }
++  // Determine the public path from which to load worker JS files. In order of precedence:
++  // 1. Plugin-specific public path.
++  // 2. Dynamic runtime public path.
++  // 3. Compilation public path.
++  const pathPrefix = Boolean(pluginPublicPath)
++    ? JSON.stringify(pluginPublicPath)
++    : `typeof __webpack_public_path__ === 'string' ` +
++      `? __webpack_public_path__ ` +
++      `: ${JSON.stringify(compilationPublicPath)}`;
++  const globals = {
++    MonacoEnvironment: `(function (paths) {
+       function stripTrailingSlash(str) {
+         return str.replace(/\\/$/, '');
+       }
+@@ -174,7 +223,14 @@ function createLoaderRules(languages, features, workers, filename, monacoEditorP
+               if(/^(\\/\\/)/.test(result)) {
+                 result = window.location.protocol + result
+               }
+-              var js = '/*' + label + '*/importScripts("' + result + '");';
++              var js = '/*' + label + '*/';
++              if (typeof import.meta !== 'undefined') {
++                // module worker
++                js += 'import "' + result + '";';
++              } else {
++                // classic worker
++                js += 'importScripts("' + result + '");';
++              }
+               var blob = new Blob([js], { type: 'application/javascript' });
+               return URL.createObjectURL(blob);
+             }
+@@ -182,47 +238,62 @@ function createLoaderRules(languages, features, workers, filename, monacoEditorP
+           return result;
+         }
+       };
+-    })(${JSON.stringify(workerPaths, null, 2)})`
+-    };
+-    const options = {
+-        globals,
+-        pre: featurePaths.map((importPath) => resolveMonacoPath(importPath, monacoEditorPath)),
+-        post: languagePaths.map((importPath) => resolveMonacoPath(importPath, monacoEditorPath))
+-    };
+-    return [
++    })(${JSON.stringify(workerPaths, null, 2)})`,
++  };
++  const options = {
++    globals,
++    pre: featurePaths.map((importPath) =>
++      resolveMonacoPath(importPath, monacoEditorPath)
++    ),
++    post: languagePaths.map((importPath) =>
++      resolveMonacoPath(importPath, monacoEditorPath)
++    ),
++  };
++  return [
++    {
++      test: /esm[/\\]vs[/\\]editor[/\\]editor.(api|main).js/,
++      use: [
+         {
+-            test: /esm[/\\]vs[/\\]editor[/\\]editor.(api|main).js/,
+-            use: [
+-                {
+-                    loader: INCLUDE_LOADER_PATH,
+-                    options
+-                }
+-            ]
+-        }
+-    ];
++          loader: INCLUDE_LOADER_PATH,
++          options,
++        },
++      ],
++    },
++  ];
+ }
+ function createPlugins(compiler, workers, filename, monacoEditorPath) {
+-    var _a;
+-    const webpack = (_a = compiler.webpack) !== null && _a !== void 0 ? _a : require('webpack');
+-    return [].concat(workers.map(({ id, entry }) => new AddWorkerEntryPointPlugin_1.AddWorkerEntryPointPlugin({
+-        id,
+-        entry: resolveMonacoPath(entry, monacoEditorPath),
+-        filename: getWorkerFilename(filename, entry, monacoEditorPath),
+-        plugins: [new webpack.optimize.LimitChunkCountPlugin({ maxChunks: 1 })]
+-    })));
++  var _a;
++  const webpack =
++    (_a = compiler.webpack) !== null && _a !== void 0 ? _a : require("webpack");
++  return [].concat(
++    workers.map(
++      ({ id, entry }) =>
++        new AddWorkerEntryPointPlugin_1.AddWorkerEntryPointPlugin({
++          id,
++          entry: resolveMonacoPath(entry, monacoEditorPath),
++          filename: getWorkerFilename(filename, entry, monacoEditorPath),
++          plugins: [
++            new webpack.optimize.LimitChunkCountPlugin({ maxChunks: 1 }),
++          ],
++        })
++    )
++  );
+ }
+ function flatArr(items) {
+-    return items.reduce((acc, item) => {
+-        if (Array.isArray(item)) {
+-            return [].concat(acc).concat(item);
+-        }
+-        return [].concat(acc).concat([item]);
+-    }, []);
++  return items.reduce((acc, item) => {
++    if (Array.isArray(item)) {
++      return [].concat(acc).concat(item);
++    }
++    return [].concat(acc).concat([item]);
++  }, []);
+ }
+ function fromPairs(values) {
+-    return values.reduce((acc, [key, value]) => Object.assign(acc, { [key]: value }), {});
++  return values.reduce(
++    (acc, [key, value]) => Object.assign(acc, { [key]: value }),
++    {}
++  );
+ }
+ function coalesce(array) {
+-    return array.filter(Boolean);
++  return array.filter(Boolean);
+ }
+ module.exports = MonacoEditorWebpackPlugin;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ patchedDependencies:
   matrix-js-sdk@31.0.0:
     hash: pec6np2mxojxgy6lq57qjhmiza
     path: patches/matrix-js-sdk@31.0.0.patch
+  monaco-editor-webpack-plugin@7.1.0:
+    hash: k6ujboxpvww4dvjwjx2x65djgy
+    path: patches/monaco-editor-webpack-plugin@7.1.0.patch
   monaco-editor@0.52.2:
     hash: uyv4zdjea2vpoe2ei5nvhe5qx4
     path: patches/monaco-editor@0.52.2.patch
@@ -1629,8 +1632,8 @@ importers:
         specifier: ^0.52.2
         version: 0.52.2(patch_hash=uyv4zdjea2vpoe2ei5nvhe5qx4)
       monaco-editor-webpack-plugin:
-        specifier: ^7.0.1
-        version: 7.0.1(monaco-editor@0.52.2)(webpack@5.89.0)
+        specifier: ^7.1.0
+        version: 7.1.0(patch_hash=k6ujboxpvww4dvjwjx2x65djgy)(monaco-editor@0.52.2)(webpack@5.89.0)
       ms:
         specifier: ^2.1.3
         version: 2.1.3
@@ -20084,8 +20087,8 @@ packages:
     resolution: {integrity: sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==}
     dev: true
 
-  /monaco-editor-webpack-plugin@7.0.1(monaco-editor@0.52.2)(webpack@5.89.0):
-    resolution: {integrity: sha512-M8qIqizltrPlIbrb73cZdTWfU9sIsUVFvAZkL3KGjAHmVWEJ0hZKa/uad14JuOckc0GwnCaoGHvMoYtJjVyCzw==}
+  /monaco-editor-webpack-plugin@7.1.0(patch_hash=k6ujboxpvww4dvjwjx2x65djgy)(monaco-editor@0.52.2)(webpack@5.89.0):
+    resolution: {integrity: sha512-ZjnGINHN963JQkFqjjcBtn1XBtUATDZBMgNQhDQwd78w2ukRhFXAPNgWuacaQiDZsUr4h1rWv5Mv6eriKuOSzA==}
     peerDependencies:
       monaco-editor: '>= 0.31.0'
       webpack: ^4.5.0 || 5.x
@@ -20094,6 +20097,7 @@ packages:
       monaco-editor: 0.52.2(patch_hash=uyv4zdjea2vpoe2ei5nvhe5qx4)
       webpack: 5.89.0
     dev: true
+    patched: true
 
   /monaco-editor@0.52.2(patch_hash=uyv4zdjea2vpoe2ei5nvhe5qx4):
     resolution: {integrity: sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==}


### PR DESCRIPTION
Yesterday when we were demoing code diffs in our sprint planning we noticed the code diffs in the AI panel weren't working. 

I was unable to reproduce locally, but then I saw this in staging and prod (we also noticed that yesterday):
<img width="991" alt="image" src="https://github.com/user-attachments/assets/13aee559-8939-4a67-8389-5a746ad0166b" />

Then I found that people are already tracking this issue in https://github.com/microsoft/monaco-editor/issues/4741, the fix has been merged in but the version is not released yet, so I opted into patching our monaco to include this fix: https://github.com/microsoft/monaco-editor/pull/4742

I deployed this fix to staging and saw the mentioned error is gone, and the diffs are working again (previously just code was shown, no diffs):

<img width="349" alt="image" src="https://github.com/user-attachments/assets/d35f6a06-1e2a-47ce-9acc-4b7759fa4376" />

