### PR TITLE
realm: Add missing await for watcher subscription

### DIFF
--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -1979,7 +1979,7 @@ export class Realm {
   }
 
   private async startFileWatcher() {
-    this.#adapter.subscribe((data) => {
+    await this.#adapter.subscribe((data) => {
       let tracked = this.getTrackedWrite(data);
       if (!tracked || tracked.isTracked) {
         return;


### PR DESCRIPTION
As noted by @habdelra [here](https://github.com/cardstack/boxel/pull/2372#discussion_r2037587404).