### PR TITLE
AI assistant: fix for sometimes not seeing the attached file

### DIFF
--- a/packages/ai-bot/helpers.ts
+++ b/packages/ai-bot/helpers.ts
@@ -748,9 +748,11 @@ ${attachedFilesToPrompt(attachedFiles)}
     systemMessage += '\n';
   }
 
-  if (tools.length == 0) {
+  let cardPatchTool = tools.find((tool) => tool.function.name === 'patchCard');
+
+  if (attachedFiles.length == 0 && attachedCards.length > 0 && !cardPatchTool) {
     systemMessage +=
-      'You are unable to edit any cards, the user has not given you access, they need to open the card on the stack and let it be auto-attached.';
+      'You are unable to edit any cards, the user has not given you access, they need to open the card and let it be auto-attached.';
   }
 
   let messages: OpenAIPromptMessage[] = [


### PR DESCRIPTION
This bug was reported several times but was really hard to reproduce 😵‍💫. It turns out that in code mode, when attaching files, we were always adding the "'You are unable to edit any cards..." message and in some cases AI took that very seriously even though there was an attached gts file and the user wanted to edit templates, for example. 

<img width="333" alt="image" src="https://github.com/user-attachments/assets/91e92e05-af36-413c-8541-3db01f1a4f5c" />

The fix is to not include the "no cards to edit" system prompt message when there is an attached file present. 
