### PR TITLE
ci: Add timeouts when waiting for Ember CLI

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -47,7 +47,7 @@ jobs:
           NODE_OPTIONS: --max_old_space_size=4096
         working-directory: packages/host
       - name: Wait for ember-cli to be ready
-        run: pnpm npx wait-for-localhost 4200
+        run: timeout 3m pnpm npx wait-for-localhost 4200
         working-directory: packages/host
       - name: Start realm servers
         run: pnpm start:all &> /tmp/server.log &

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -126,7 +126,7 @@ jobs:
           NODE_OPTIONS: --max_old_space_size=4096
         working-directory: packages/host
       - name: Wait for ember-cli to be ready
-        run: pnpm npx wait-for-localhost 4200
+        run: timeout 3m pnpm npx wait-for-localhost 4200
         working-directory: packages/host
       - name: Start realm servers
         run: MATRIX_REGISTRATION_SHARED_SECRET='xxxx' pnpm start:services-for-matrix-tests &> /tmp/server.log &
@@ -286,7 +286,7 @@ jobs:
           NODE_OPTIONS: --max_old_space_size=4096
         working-directory: packages/host
       - name: Wait for ember-cli to be ready
-        run: pnpm npx wait-for-localhost 4200
+        run: timeout 3m pnpm npx wait-for-localhost 4200
         working-directory: packages/realm-server
       - name: Start realm servers
         run: pnpm start:all &> /tmp/server.log &


### PR DESCRIPTION
This prevents a PR with a build error from holding up the entire Actions queue like this:

<img width="1002" alt="boxel@0b9ebe9 2025-04-15 09-08-19" src="https://github.com/user-attachments/assets/82a42ef4-7c30-4043-8c08-8f44e4b8c28e" />

**But** would it be better to add timeouts to the entire job instead of on this command only? 🤔