### PR TITLE
Fix bug in reference counting in store and add new card collection resource

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -50,6 +50,7 @@ import {
   type ResolvedCodeRef,
   type getCard,
   type getCards,
+  type getCardCollection,
   type Store,
 } from '@cardstack/runtime-common';
 import type { ComponentLike } from '@glint/template';
@@ -152,6 +153,7 @@ export interface CardContext<T extends CardDef = CardDef> {
   prerenderedCardSearchComponent: any;
   getCard: getCard<T>;
   getCards: getCards;
+  getCardCollection: getCardCollection;
   store: Store;
 }
 

--- a/packages/base/commands/search-card-result.gts
+++ b/packages/base/commands/search-card-result.gts
@@ -77,9 +77,17 @@ class CardList extends GlimmerComponent<CardListSignature> {
             />
           {{/let}}
         </li>
-      {{else}}
-        No cards were found.
       {{/each}}
+      {{#each this.cardList.cardErrors as |error|}}
+        <li class='result-list-item' data-test-card-error={{error.id}}>
+          Error: cannot render card
+          {{error.id}}:
+          {{error.message}}
+        </li>
+      {{/each}}
+      {{#if this.hasNoResults}}
+        No cards were found.
+      {{/if}}
     </ol>
     <style scoped>
       .result-list {
@@ -117,6 +125,14 @@ class CardList extends GlimmerComponent<CardListSignature> {
     this,
     () => this.args.cardIds,
   );
+
+  get hasNoResults() {
+    return (
+      !this.cardList ||
+      (this.cardList.cards.length === 0 &&
+        this.cardList.cardErrors.length === 0)
+    );
+  }
 }
 
 class SearchCardsResultEmbeddedView extends Component<
@@ -165,7 +181,11 @@ class SearchCardsResultEmbeddedView extends Component<
 
   <template>
     <div class='command-result'>
-      <CardList @cardIds={{this.cardIdsToDisplay}} @format='atom' />
+      <CardList
+        @cardIds={{this.cardIdsToDisplay}}
+        @format='atom'
+        @context={{@context}}
+      />
       <div class='footer'>
         {{#if this.numberOfCardsGreaterThanPaginateSize}}
           <Button

--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -59,6 +59,7 @@ const DEFAULT_CARD_CONTEXT = {
   commandContext: undefined,
   getCard: () => {},
   getCards: () => {},
+  getCardCollection: () => {},
 };
 
 export class CardContextConsumer extends Component<CardContextConsumerSignature> {

--- a/packages/experiments-realm/app-card.gts
+++ b/packages/experiments-realm/app-card.gts
@@ -123,21 +123,20 @@ class TableView extends GlimmerComponent<{
 
   // explicitly setting this to @tracked since there is
   // a possibility it might be initialized as undefined
-  @tracked private cardResources = !this.args.context
-    ? []
-    : this.args.cards.map((c) => this.args.context!.getCard(this, () => c.url));
+  @tracked private cardCollection = this.args.context?.getCardCollection(
+    this,
+    () => this.args.cards.map((c) => c.url),
+  );
+
   private get isLoaded() {
-    return this.cardResources.map((r) => r.isLoaded).every((i) => i);
+    return this.cardCollection?.isLoaded;
   }
 
   get tableData() {
-    if (this.cardResources.length === 0) {
+    if (!this.cardCollection || this.cardCollection.cards.length === 0) {
       return;
     }
-    if (this.cardResources.find((r) => !r.card)) {
-      return;
-    }
-    let exampleCard = this.cardResources[0].card;
+    let exampleCard = this.cardCollection.cards[0];
     let headers: string[] = [];
     for (let fieldName in exampleCard) {
       if (
@@ -151,10 +150,10 @@ class TableView extends GlimmerComponent<{
     }
     headers.sort();
 
-    let rows = this.cardResources.map((cardResource) => {
+    let rows = this.cardCollection.cards.map((card) => {
       let row: string[] = [];
       for (let header of headers) {
-        row.push((cardResource.card as any)[header]);
+        row.push((card as any)[header]);
       }
       return row;
     });

--- a/packages/host/app/components/ai-assistant/message/index.gts
+++ b/packages/host/app/components/ai-assistant/message/index.gts
@@ -41,7 +41,7 @@ interface Signature {
     isFromAssistant: boolean;
     isStreaming: boolean;
     profileAvatar?: ComponentLike;
-    resources?: ReturnType<getCardCollection>;
+    collectionResource?: ReturnType<getCardCollection>;
     files?: FileDef[] | undefined;
     index: number;
     eventId: string;
@@ -279,6 +279,17 @@ export default class AiAssistantMessage extends Component<Signature> {
               {{/each}}
             </div>
           {{/if}}
+
+          {{#if @collectionResource.cardErrors.length}}
+            <div class='error-container error-footer'>
+              {{#each @collectionResource.cardErrors as |error|}}
+                <FailureBordered class='error-icon' />
+                <div class='error-message' data-test-card-error>
+                  <div>Cannot render {{error.id}}</div>
+                </div>
+              {{/each}}
+            </div>
+          {{/if}}
         </div>
       </div>
     </div>
@@ -475,7 +486,7 @@ export default class AiAssistantMessage extends Component<Signature> {
 
   private get items() {
     return [
-      ...(this.args.resources ? [this.args.resources] : []),
+      ...(this.args.collectionResource ? [this.args.collectionResource] : []),
       ...(this.args.files ?? []),
     ];
   }

--- a/packages/host/app/components/ai-assistant/message/index.gts
+++ b/packages/host/app/components/ai-assistant/message/index.gts
@@ -266,7 +266,7 @@ export default class AiAssistantMessage extends Component<Signature> {
 
           {{yield}}
 
-          {{#if this.items.length}}
+          {{#if this.hasItems}}
             <div class='items' data-test-message-items>
               {{#each this.items as |item|}}
                 {{#if (isCardCollectionResource item)}}
@@ -482,6 +482,15 @@ export default class AiAssistantMessage extends Component<Signature> {
 
   private get isAvatarAnimated() {
     return this.args.isStreaming && !this.args.errorMessage;
+  }
+
+  private get hasItems() {
+    return (
+      (this.args.files && this.args.files.length > 0) ||
+      (this.args.collectionResource &&
+        (this.args.collectionResource.cards.length > 0 ||
+          this.args.collectionResource.cardErrors.length > 0))
+    );
   }
 
   private get items() {

--- a/packages/host/app/components/matrix/room-message.gts
+++ b/packages/host/app/components/matrix/room-message.gts
@@ -136,7 +136,7 @@ export default class RoomMessage extends Component<Signature> {
           userId=this.message.author.userId
           displayName=this.message.author.displayName
         }}
-        @resources={{this.attachedCardCollection}}
+        @collectionResource={{this.attachedCardCollection}}
         @files={{this.message.attachedFiles}}
         @errorMessage={{this.errorMessage}}
         @isStreaming={{@isStreaming}}
@@ -180,6 +180,9 @@ export default class RoomMessage extends Component<Signature> {
     if (this.streamingTimeout) {
       return 'This message was processing for too long. Please try again.';
     }
-    return undefined;
+    if (this.attachedCardCollection?.cardErrors.length === 0) {
+      return undefined;
+    }
+    return 'Error rendering attached cards.';
   }
 }

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -32,8 +32,10 @@ import {
   type Query,
   type getCard,
   type getCards,
+  type getCardCollection,
   GetCardContextName,
   GetCardsContextName,
+  GetCardCollectionContextName,
   specRef,
   isCardDef,
   isFieldDef,
@@ -221,6 +223,8 @@ type SpecPreviewCardContext = Omit<
 class SpecPreviewContent extends GlimmerComponent<ContentSignature> {
   @consume(GetCardContextName) private declare getCard: getCard;
   @consume(GetCardsContextName) private declare getCards: getCards;
+  @consume(GetCardCollectionContextName)
+  private declare getCardCollection: getCardCollection;
   @service private declare realm: RealmService;
   @service private declare operatorModeStateService: OperatorModeStateService;
   @service private declare specPanelService: SpecPanelService;
@@ -236,6 +240,7 @@ class SpecPreviewContent extends GlimmerComponent<ContentSignature> {
     return {
       getCard: this.getCard,
       getCards: this.getCards,
+      getCardCollection: this.getCardCollection,
       store: this.store,
       cardComponentModifier: this.cardTracker.trackElement,
     };

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -18,14 +18,15 @@ import { or, not, and } from '@cardstack/boxel-ui/helpers';
 import {
   GetCardContextName,
   GetCardsContextName,
+  GetCardCollectionContextName,
 } from '@cardstack/runtime-common';
 
 import Auth from '@cardstack/host/components/matrix/auth';
 import PaymentSetup from '@cardstack/host/components/matrix/payment-setup';
 import CodeSubmode from '@cardstack/host/components/operator-mode/code-submode';
 import InteractSubmode from '@cardstack/host/components/operator-mode/interact-submode';
+import { getCardCollection } from '@cardstack/host/resources/card-collection';
 import { getCard } from '@cardstack/host/resources/card-resource';
-
 import { getSearch } from '@cardstack/host/resources/search';
 
 import MessageService from '@cardstack/host/services/message-service';
@@ -74,6 +75,12 @@ export default class OperatorModeContainer extends Component<Signature> {
   // @ts-ignore "getCards" is declared but not used
   private get getCards() {
     return getSearch;
+  }
+
+  @provide(GetCardCollectionContextName)
+  // @ts-ignore "getCardCollection" is declared but not used
+  private get getCardCollection() {
+    return getCardCollection;
   }
 
   private saveSource = task(async (url: URL, content: string) => {

--- a/packages/host/app/components/operator-mode/copy-button.gts
+++ b/packages/host/app/components/operator-mode/copy-button.gts
@@ -7,18 +7,14 @@ import { tracked } from '@glimmer/tracking';
 
 import { consume } from 'ember-provide-consume-context';
 
-import { trackedFunction } from 'ember-resources/util/function';
-
-import { TrackedArray } from 'tracked-built-ins';
-
 import { BoxelButton } from '@cardstack/boxel-ui/components';
 import { eq, gt } from '@cardstack/boxel-ui/helpers';
 
 import { ArrowLeft, ArrowRight } from '@cardstack/boxel-ui/icons';
 
 import {
-  type getCard,
-  GetCardContextName,
+  type getCardCollection,
+  GetCardCollectionContextName,
   realmURL as realmURLSymbol,
 } from '@cardstack/runtime-common';
 
@@ -51,7 +47,7 @@ export default class CopyButton extends Component<Signature> {
   <template>
     {{consumeContext this.makeCardResources}}
     {{#if (gt this.stacks.length 1)}}
-      {{#if this.hasLoadedTopMostCards}}
+      {{#if this.topMostCardCollection.isLoaded}}
         {{#if this.state}}
           <BoxelButton
             class='copy-button'
@@ -117,35 +113,25 @@ export default class CopyButton extends Component<Signature> {
     </style>
   </template>
 
-  @consume(GetCardContextName) private declare getCard: getCard;
+  @consume(GetCardCollectionContextName)
+  private declare getCardCollection: getCardCollection;
   @service private declare loaderService: LoaderService;
   @service private declare cardService: CardService;
   @service private declare operatorModeStateService: OperatorModeStateService;
-  @tracked private topMostCardCollectionResource:
-    | { value: TrackedArray<ReturnType<getCard>> | null }
+  @tracked private topMostCardCollection:
+    | ReturnType<getCardCollection>
     | undefined;
 
   private makeCardResources = () => {
-    this.topMostCardCollectionResource = trackedFunction(
+    this.topMostCardCollection = this.getCardCollection(
       this,
       () =>
-        new TrackedArray(
-          this.operatorModeStateService
-            .topMostStackItems()
-            .map((item) => this.getCard(this, () => item.url)),
-        ),
+        this.operatorModeStateService
+          .topMostStackItems()
+          .map((i) => i.url)
+          .filter(Boolean) as string[],
     );
   };
-
-  private get topMostCardResources() {
-    return this.topMostCardCollectionResource?.value ?? new TrackedArray();
-  }
-
-  private get hasLoadedTopMostCards() {
-    return this.topMostCardResources.length === 0
-      ? true
-      : this.topMostCardResources.every((r) => r.isLoaded);
-  }
 
   private get stacks() {
     return this.operatorModeStateService.state?.stacks ?? [];
@@ -165,18 +151,13 @@ export default class CopyButton extends Component<Signature> {
       return undefined;
     }
 
-    let indexCardIndicies = this.topMostCardResources.reduce(
-      (indexCards, item, index) => {
-        if (!item?.card) {
-          return indexCards;
-        }
-        let realmURL = item.card[realmURLSymbol];
+    let indexCardIndicies = (this.topMostCardCollection?.cards ?? []).reduce(
+      (indexCards, card, index) => {
+        let realmURL = card[realmURLSymbol];
         if (!realmURL) {
-          throw new Error(
-            `could not determine realm URL for card ${item.card.id}`,
-          );
+          throw new Error(`could not determine realm URL for card ${card.id}`);
         }
-        if (item.card.id === `${realmURL.href}index`) {
+        if (card.id === `${realmURL.href}index`) {
           return [...indexCards, index];
         }
         return indexCards;
@@ -200,9 +181,9 @@ export default class CopyButton extends Component<Signature> {
         }
         // eslint-disable-next-line no-case-declarations
         let sourceCard =
-          this.topMostCardResources[
+          this.topMostCardCollection?.cards[
             indexCardIndicies[0] === LEFT ? RIGHT : LEFT
-          ].card;
+          ];
         if (!sourceCard) {
           return undefined;
         }

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -24,6 +24,7 @@ import {
   CardContextName,
   GetCardContextName,
   GetCardsContextName,
+  GetCardCollectionContextName,
   Deferred,
   codeRefWithAbsoluteURL,
   moduleFrom,
@@ -33,6 +34,7 @@ import {
   realmURL as realmURLSymbol,
   type getCard,
   type getCards,
+  type getCardCollection,
   type Actions,
   type CodeRef,
   type LooseSingleCardDocument,
@@ -151,6 +153,8 @@ interface CardToDelete {
 export default class InteractSubmode extends Component {
   @consume(GetCardContextName) private declare getCard: getCard;
   @consume(GetCardsContextName) private declare getCards: getCards;
+  @consume(GetCardCollectionContextName)
+  private declare getCardCollection: getCardCollection;
 
   @service private declare cardService: CardService;
   @service private declare commandService: CommandService;
@@ -682,6 +686,7 @@ export default class InteractSubmode extends Component {
       actions: this.publicAPI(this, 0),
       getCard: this.getCard,
       getCards: this.getCards,
+      getCardCollection: this.getCardCollection,
       store: this.store,
       // TODO: should we include this here??
       commandContext: this.commandService.commandContext,

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -40,11 +40,13 @@ import {
   type Permissions,
   type getCard,
   type getCards,
+  type getCardCollection,
   cardTypeDisplayName,
   PermissionsContextName,
   RealmURLContextName,
   GetCardContextName,
   GetCardsContextName,
+  GetCardCollectionContextName,
   Deferred,
   cardTypeIcon,
   CommandContext,
@@ -115,6 +117,8 @@ type StackItemCardContext = Omit<CardContext, 'prerenderedCardSearchComponent'>;
 export default class OperatorModeStackItem extends Component<Signature> {
   @consume(GetCardContextName) private declare getCard: getCard;
   @consume(GetCardsContextName) private declare getCards: getCards;
+  @consume(GetCardCollectionContextName)
+  private declare getCardCollection: getCardCollection;
 
   @service private declare cardService: CardService;
   @service private declare environmentService: EnvironmentService;
@@ -248,6 +252,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
       commandContext: this.args.commandContext,
       getCard: this.getCard,
       getCards: this.getCards,
+      getCardCollection: this.getCardCollection,
       store: this.store,
     };
   }

--- a/packages/host/app/components/preview.gts
+++ b/packages/host/app/components/preview.gts
@@ -10,9 +10,11 @@ import {
   CardURLContextName,
   GetCardContextName,
   GetCardsContextName,
+  GetCardCollectionContextName,
   ResolvedCodeRef,
   type getCard,
   type getCards,
+  type getCardCollection,
 } from '@cardstack/runtime-common';
 
 import type StoreService from '@cardstack/host/services/store';
@@ -40,6 +42,8 @@ interface Signature {
 export default class Preview extends Component<Signature> {
   @consume(GetCardContextName) private declare getCard: getCard;
   @consume(GetCardsContextName) private declare getCards: getCards;
+  @consume(GetCardCollectionContextName)
+  private declare getCardCollection: getCardCollection;
   @service private declare store: StoreService;
 
   @provide(DefaultFormatsContextName)
@@ -57,6 +61,7 @@ export default class Preview extends Component<Signature> {
       prerenderedCardSearchComponent: PrerenderedCardSearch,
       getCard: this.getCard,
       getCards: this.getCards,
+      getCardCollection: this.getCardCollection,
       store: this.store,
       ...this.args.cardContext,
     };

--- a/packages/host/app/lib/gc-identity-context.ts
+++ b/packages/host/app/lib/gc-identity-context.ts
@@ -189,6 +189,9 @@ export default class IdentityContextWithGarbageCollection
             this.delete(instance.id);
           }
         } else {
+          console.debug(
+            `instance [local id:${instance[localIdSymbol]} remote id: ${instance.id}] is now eligible for garbage collection`,
+          );
           this.#gcCandidates.add(instance[localIdSymbol]);
         }
       } else {

--- a/packages/host/app/resources/card-collection.ts
+++ b/packages/host/app/resources/card-collection.ts
@@ -1,0 +1,84 @@
+import { registerDestructor } from '@ember/destroyable';
+import { service } from '@ember/service';
+
+import { tracked } from '@glimmer/tracking';
+
+import { Resource } from 'ember-resources';
+
+import isEqual from 'lodash/isEqual';
+
+import { isCardInstance } from '@cardstack/runtime-common';
+
+import type { CardDef } from 'https://cardstack.com/base/card-api';
+
+import type StoreService from '../services/store';
+
+interface Args {
+  named: {
+    ids: string[] | undefined;
+  };
+}
+
+export class CardCollectionResource<
+  T extends CardDef = CardDef,
+> extends Resource<Args> {
+  #ids: string[] | undefined;
+  @tracked isLoaded = false;
+  @service declare private store: StoreService;
+
+  modify(_positional: never[], named: Args['named']) {
+    let { ids } = named;
+    if (!isEqual(ids, this.#ids)) {
+      if (this.#ids) {
+        for (let id of this.#ids) {
+          this.store.dropReference(id);
+        }
+      }
+      this.#ids = ids;
+      for (let id of this.#ids ?? []) {
+        this.store.addReference(id);
+      }
+      (async () => {
+        this.isLoaded = false;
+        await this.store.flush();
+        this.isLoaded = true;
+      })();
+    }
+    registerDestructor(this, () => {
+      for (let id of this.#ids ?? []) {
+        this.store.dropReference(id);
+      }
+    });
+  }
+
+  get cards() {
+    return (this.#ids ?? [])
+      .map((id) => this.store.peek(id))
+      .filter((i) => isCardInstance(i)) as T[];
+  }
+
+  get ids() {
+    return this.#ids;
+  }
+}
+
+// WARNING! please don't import this directly into your component's module.
+// Rather please instead use:
+// ```
+//   import { consume } from 'ember-provide-consume-context';
+//   import { type getCardCollection, GetCardCollectionContextName } from '@cardstack/runtime-common';
+//    ...
+//   @consume(GetCardCollectionContextName) private declare getCardCollection: getCardCollection;
+// ```
+// If you need to use `getCardCollection()` in something that is not a Component, then
+// let's talk.
+export function getCardCollection<T extends CardDef = CardDef>(
+  parent: object,
+  ids: () => string[] | undefined,
+) {
+  return CardCollectionResource.from(parent, () => ({
+    named: {
+      ids: ids(),
+    },
+  })) as CardCollectionResource<T>;
+}

--- a/packages/host/app/resources/card-collection.ts
+++ b/packages/host/app/resources/card-collection.ts
@@ -1,13 +1,21 @@
 import { registerDestructor } from '@ember/destroyable';
 import { service } from '@ember/service';
+import { buildWaiter } from '@ember/test-waiters';
 
 import { tracked } from '@glimmer/tracking';
+
+import { restartableTask } from 'ember-concurrency';
 
 import { Resource } from 'ember-resources';
 
 import isEqual from 'lodash/isEqual';
 
-import { isCardInstance } from '@cardstack/runtime-common';
+import { TrackedArray } from 'tracked-built-ins';
+
+import {
+  isCardInstance,
+  type CardErrorJSONAPI as CardError,
+} from '@cardstack/runtime-common';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 
@@ -19,11 +27,15 @@ interface Args {
   };
 }
 
+let waiter = buildWaiter('card-collection-resource');
+
 export class CardCollectionResource<
   T extends CardDef = CardDef,
 > extends Resource<Args> {
   #ids: string[] | undefined;
-  @tracked isLoaded = false;
+  private _cards = new TrackedArray<T>();
+  private _cardErrors = new TrackedArray<CardError>();
+  @tracked private _isLoaded = false;
   @service declare private store: StoreService;
 
   modify(_positional: never[], named: Args['named']) {
@@ -38,11 +50,7 @@ export class CardCollectionResource<
       for (let id of this.#ids ?? []) {
         this.store.addReference(id);
       }
-      (async () => {
-        this.isLoaded = false;
-        await this.store.flush();
-        this.isLoaded = true;
-      })();
+      this.load.perform();
     }
     registerDestructor(this, () => {
       for (let id of this.#ids ?? []) {
@@ -51,10 +59,46 @@ export class CardCollectionResource<
     });
   }
 
+  private load = restartableTask(async () => {
+    let token = waiter.beginAsync();
+    try {
+      // await a micro task to prevent isLoaded from being read and set in same frame
+      await Promise.resolve();
+      this._isLoaded = false;
+      if (!this.#ids || this.#ids.length === 0) {
+        this.cards.splice(0);
+      }
+      await this.store.flush();
+      this.cards.splice(
+        0,
+        this.cards.length,
+        ...((this.#ids ?? [])
+          .map((id) => this.store.peek(id))
+          .filter((i) => isCardInstance(i)) as T[]),
+      );
+      this.cardErrors.splice(
+        0,
+        this.cards.length,
+        ...((this.#ids ?? [])
+          .map((id) => this.store.peek(id))
+          .filter((i) => i && !isCardInstance(i)) as CardError[]),
+      );
+    } finally {
+      waiter.endAsync(token);
+      this._isLoaded = true;
+    }
+  });
+
   get cards() {
-    return (this.#ids ?? [])
-      .map((id) => this.store.peek(id))
-      .filter((i) => isCardInstance(i)) as T[];
+    return this._cards;
+  }
+
+  get cardErrors() {
+    return this._cardErrors;
+  }
+
+  get isLoaded() {
+    return this._isLoaded;
   }
 
   get ids() {

--- a/packages/host/app/resources/card-collection.ts
+++ b/packages/host/app/resources/card-collection.ts
@@ -67,6 +67,7 @@ export class CardCollectionResource<
       this._isLoaded = false;
       if (!this.#ids || this.#ids.length === 0) {
         this.cards.splice(0);
+        this.cardErrors.splice(0);
       }
       await this.store.flush();
       this.cards.splice(

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -78,6 +78,9 @@ export class SearchResource extends Resource<Args> {
     this.#previousQuery = query;
     this.#previousRealms = realms;
 
+    for (let instance of this._instances) {
+      this.store.dropReference(instance.id);
+    }
     this.loaded = this.search.perform(query);
 
     if (isLive) {
@@ -156,9 +159,6 @@ export class SearchResource extends Resource<Args> {
     // the Task instance to a promise which makes it uncancellable. When this is
     // uncancellable it results in a flaky test.
     let token = waiter.beginAsync();
-    for (let instance of this._instances) {
-      this.store.dropReference(instance.id);
-    }
     try {
       let results = flatMap(
         await Promise.all(

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -78,9 +78,6 @@ export class SearchResource extends Resource<Args> {
     this.#previousQuery = query;
     this.#previousRealms = realms;
 
-    for (let instance of this._instances) {
-      this.store.dropReference(instance.id);
-    }
     this.loaded = this.search.perform(query);
 
     if (isLive) {
@@ -159,6 +156,9 @@ export class SearchResource extends Resource<Args> {
     // the Task instance to a promise which makes it uncancellable. When this is
     // uncancellable it results in a flaky test.
     let token = waiter.beginAsync();
+    for (let instance of this._instances) {
+      this.store.dropReference(instance.id);
+    }
     try {
       let results = flatMap(
         await Promise.all(

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -378,6 +378,7 @@ export default class StoreService extends Service implements StoreInterface {
     await this.withTestWaiters(async () => {
       this.newReferencePromises.push(deferred.promise);
       let maybeUrl: string | undefined;
+      let isDoc = typeof idOrDoc !== 'string';
       try {
         await this.ready;
         maybeUrl = asURL(idOrDoc);
@@ -391,8 +392,11 @@ export default class StoreService extends Service implements StoreInterface {
         let url = maybeUrl;
         let urlOrDoc = idOrDoc;
         let instanceOrError = this.peek(url);
-        if (!instanceOrError) {
-          instanceOrError = await this.getInstance({ urlOrDoc });
+        if (!instanceOrError || isDoc) {
+          instanceOrError = await this.getInstance({
+            urlOrDoc,
+            opts: { noCache: isDoc },
+          });
         }
         this.subscribeToRealm(new URL(url));
         await this.trackSavedInstance('start-tracking', instanceOrError);
@@ -604,7 +608,7 @@ export default class StoreService extends Service implements StoreInterface {
     urlOrDoc: string | LooseSingleCardDocument;
     relativeTo?: URL;
     realm?: string; // used for new cards
-    opts?: { noCache?: true };
+    opts?: { noCache?: boolean };
   }) {
     let deferred: Deferred<CardDef | CardError> | undefined;
     let url = asURL(urlOrDoc);

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -451,8 +451,7 @@ export default class StoreService extends Service implements StoreInterface {
     let api = await this.cardService.getAPI();
     this.gcInterval = setInterval(
       () => this.identityContext.sweep(api),
-      // 2 * 60_000,
-      10_000,
+      2 * 60_000,
     ) as unknown as number;
   }
 

--- a/packages/host/app/templates/host-freestyle.gts
+++ b/packages/host/app/templates/host-freestyle.gts
@@ -13,6 +13,7 @@ import RouteTemplate from 'ember-route-template';
 import {
   GetCardContextName,
   GetCardsContextName,
+  GetCardCollectionContextName,
 } from '@cardstack/runtime-common';
 
 import AiAssistantApplyButtonUsage from '@cardstack/host/components/ai-assistant/apply-button/usage';
@@ -24,6 +25,7 @@ import CardCatalogModal from '@cardstack/host/components/card-catalog/modal';
 import PillMenuUsage from '@cardstack/host/components/pill-menu/usage';
 import SearchSheetUsage from '@cardstack/host/components/search-sheet/usage';
 
+import { getCardCollection } from '@cardstack/host/resources/card-collection';
 import { getCard } from '@cardstack/host/resources/card-resource';
 import { getSearch } from '@cardstack/host/resources/search';
 
@@ -48,9 +50,15 @@ class HostFreestyleComponent extends Component<HostFreestyleSignature> {
   }
 
   @provide(GetCardsContextName)
-  // @ts-ignore "getCard" is declared but not used
+  // @ts-ignore "getCards" is declared but not used
   private get getCards() {
     return getSearch;
+  }
+
+  @provide(GetCardCollectionContextName)
+  // @ts-ignore "getCardCollection" is declared but not used
+  private get getCardCollection() {
+    return getCardCollection;
   }
 
   get usageComponents() {

--- a/packages/host/tests/integration/components/card-editor-test.gts
+++ b/packages/host/tests/integration/components/card-editor-test.gts
@@ -17,6 +17,7 @@ import {
   baseRealm,
   GetCardsContextName,
   GetCardContextName,
+  GetCardCollectionContextName,
 } from '@cardstack/runtime-common';
 import { Loader } from '@cardstack/runtime-common/loader';
 import { Realm } from '@cardstack/runtime-common/realm';
@@ -27,6 +28,7 @@ import CardEditor from '@cardstack/host/components/card-editor';
 import CardPrerender from '@cardstack/host/components/card-prerender';
 import CreateCardModal from '@cardstack/host/components/create-card-modal';
 
+import { getCardCollection } from '@cardstack/host/resources/card-collection';
 import { getCard } from '@cardstack/host/resources/card-resource';
 import { getSearch } from '@cardstack/host/resources/search';
 
@@ -63,6 +65,11 @@ class GetCardsContextProvider extends GlimmerComponent<{
   // @ts-ignore "getCards" is declared but not used
   private get getCards() {
     return getSearch;
+  }
+  @provide(GetCardCollectionContextName)
+  // @ts-ignore "getCardCollection" is declared but not used
+  private get getCardCollection() {
+    return getCardCollection;
   }
 }
 

--- a/packages/host/tests/integration/components/room-message-test.gts
+++ b/packages/host/tests/integration/components/room-message-test.gts
@@ -1,15 +1,47 @@
-import { waitUntil } from '@ember/test-helpers';
+import { waitUntil, render } from '@ember/test-helpers';
 
-import { render } from '@ember/test-helpers';
+import GlimmerComponent from '@glimmer/component';
+
+import { provide } from 'ember-provide-consume-context';
 
 import { module, test } from 'qunit';
 
+import {
+  GetCardsContextName,
+  GetCardContextName,
+  GetCardCollectionContextName,
+} from '@cardstack/runtime-common';
+
 import RoomMessage from '@cardstack/host/components/matrix/room-message';
 
+import { getCardCollection } from '@cardstack/host/resources/card-collection';
+import { getCard } from '@cardstack/host/resources/card-resource';
 import { type RoomResource } from '@cardstack/host/resources/room';
+import { getSearch } from '@cardstack/host/resources/search';
 
 import { setupMockMatrix } from '../../helpers/mock-matrix';
 import { setupRenderingTest } from '../../helpers/setup';
+
+class GetCardsContextProvider extends GlimmerComponent<{
+  Args: {};
+  Blocks: { default: [] };
+}> {
+  @provide(GetCardContextName)
+  // @ts-ignore "getCard" is declared but not used
+  private get getCard() {
+    return getCard;
+  }
+  @provide(GetCardsContextName)
+  // @ts-ignore "getCards" is declared but not used
+  private get getCards() {
+    return getSearch;
+  }
+  @provide(GetCardCollectionContextName)
+  // @ts-ignore "getCardCollection" is declared but not used
+  private get getCardCollection() {
+    return getCardCollection;
+  }
+}
 
 module('Integration | Component | RoomMessage', function (hooks) {
   setupRenderingTest(hooks);
@@ -59,16 +91,18 @@ module('Integration | Component | RoomMessage', function (hooks) {
 
     await render(<template>
       {{! @glint-ignore }}
-      <RoomMessage
-        @roomId={{testScenario.roomId}}
-        @roomResource={{testScenario}}
-        @monacoSDK={{testScenario.monacoSDK}}
-        @isStreaming={{testScenario.isStreaming}}
-        @registerScroller={{noop}}
-        @index={{0}}
-        @retryAction={{testScenario.maybeRetryAction}}
-        data-test-message-idx='1'
-      />
+      <GetCardsContextProvider>
+        <RoomMessage
+          @roomId={{testScenario.roomId}}
+          @roomResource={{testScenario}}
+          @monacoSDK={{testScenario.monacoSDK}}
+          @isStreaming={{testScenario.isStreaming}}
+          @registerScroller={{noop}}
+          @index={{0}}
+          @retryAction={{testScenario.maybeRetryAction}}
+          data-test-message-idx='1'
+        />
+      </GetCardsContextProvider>
     </template>);
   }
 

--- a/packages/host/tests/integration/store-test.ts
+++ b/packages/host/tests/integration/store-test.ts
@@ -117,7 +117,6 @@ module('Integration | Store', function (hooks) {
   // search
   // getSaveState
   // save
-  // dropReference
   // receive realm index event updates instance
   // receive realm index event with code changes updates instance and reloads the identity map (local ID's are different after reloading identity map)
   // receive realm index event can move a card into an error state
@@ -129,10 +128,10 @@ module('Integration | Store', function (hooks) {
     let instance = store.peek(`${testRealmURL}hassan`);
     assert.strictEqual(instance, undefined, 'instance is not in store yet');
 
-    store.addReference(`${testRealmURL}hassan`);
+    store.addReference(`${testRealmURL}Person/hassan`);
 
     await store.flush();
-    instance = store.peek(`${testRealmURL}hassan`);
+    instance = store.peek(`${testRealmURL}Person/hassan`);
     if (isCardInstance(instance)) {
       assert.strictEqual(
         (instance as any).name,
@@ -148,7 +147,7 @@ module('Integration | Store', function (hooks) {
 
     forceGC();
 
-    instance = store.peek(`${testRealmURL}hassan`);
+    instance = store.peek(`${testRealmURL}Person/hassan`);
     if (isCardInstance(instance)) {
       assert.strictEqual(
         (instance as any).name,
@@ -164,16 +163,16 @@ module('Integration | Store', function (hooks) {
   });
 
   test('can drop reference to a card url', async function (assert) {
-    let instance = store.peek(`${testRealmURL}hassan`);
-
-    store.addReference(`${testRealmURL}hassan`);
+    store.addReference(`${testRealmURL}Person/hassan`);
+    await store.flush();
+    let instance = store.peek(`${testRealmURL}Person/hassan`);
     assert.ok(instance, 'instance is in store');
-    store.dropReference(`${testRealmURL}hassan`);
+    store.dropReference(`${testRealmURL}Person/hassan`);
 
     forceGC();
 
     assert.strictEqual(
-      store.peek(`${testRealmURL}hassan`),
+      store.peek(`${testRealmURL}Person/hassan`),
       undefined,
       'instance has been garbage collected from the store',
     );

--- a/packages/runtime-common/constants.ts
+++ b/packages/runtime-common/constants.ts
@@ -31,6 +31,7 @@ export const CardContextName = 'card-context';
 export const DefaultFormatsContextName = 'default-format-context';
 export const GetCardContextName = 'get-card-context';
 export const GetCardsContextName = 'get-cards-context';
+export const GetCardCollectionContextName = 'get-card-collection-context';
 
 export const PermissionsContextName = 'permissions-context';
 

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -280,7 +280,15 @@ export type getCard<T extends CardDef = CardDef> = (
   isLoaded: boolean;
   autoSaveState: AutoSaveState | undefined;
 };
-
+export type getCardCollection<T extends CardDef = CardDef> = (
+  parent: object,
+  ids: () => string[] | undefined,
+) => // This is a duck type of the CardResource
+{
+  ids: string[] | undefined;
+  cards: T[];
+  isLoaded: boolean;
+};
 export type getCards<T extends CardDef = CardDef> = (
   parent: object,
   getQuery: () => Query | undefined,

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -287,6 +287,7 @@ export type getCardCollection<T extends CardDef = CardDef> = (
 {
   ids: string[] | undefined;
   cards: T[];
+  cardErrors: CardErrorJSONAPI[];
   isLoaded: boolean;
 };
 export type getCards<T extends CardDef = CardDef> = (

--- a/packages/seed-realm/app-card.gts
+++ b/packages/seed-realm/app-card.gts
@@ -123,21 +123,20 @@ class TableView extends GlimmerComponent<{
 
   // explicitly setting this to @tracked since there is
   // a possibility it might be initialized as undefined
-  @tracked private cardResources = !this.args.context
-    ? []
-    : this.args.cards.map((c) => this.args.context!.getCard(this, () => c.url));
+  @tracked private cardCollection = this.args.context?.getCardCollection(
+    this,
+    () => this.args.cards.map((c) => c.url),
+  );
+
   private get isLoaded() {
-    return this.cardResources.map((r) => r.isLoaded).every((i) => i);
+    return this.cardCollection?.isLoaded;
   }
 
   get tableData() {
-    if (this.cardResources.length === 0) {
+    if (!this.cardCollection || this.cardCollection.cards.length === 0) {
       return;
     }
-    if (this.cardResources.find((r) => !r.card)) {
-      return;
-    }
-    let exampleCard = this.cardResources[0].card;
+    let exampleCard = this.cardCollection.cards[0];
     let headers: string[] = [];
     for (let fieldName in exampleCard) {
       if (
@@ -151,10 +150,10 @@ class TableView extends GlimmerComponent<{
     }
     headers.sort();
 
-    let rows = this.cardResources.map((cardResource) => {
+    let rows = this.cardCollection.cards.map((card) => {
       let row: string[] = [];
       for (let header of headers) {
-        row.push((cardResource.card as any)[header]);
+        row.push((card as any)[header]);
       }
       return row;
     });


### PR DESCRIPTION
This PR fixes a bug in the StoreService were we were not incrementing the reference count when a reference was added. The resulted in all cards getting garbage collected regardless of whether they are being referenced in a component via a resource. this is a super nasty bug that prevents you from viewing a card after 4 minutes.

Also this fixes an issue where in scenarios where we create an array of card resource by mapping over a list of ids, the reference count is never decremented. To handle the scenario where we want to have a resource for an ad hoc list of card id's, I've added a new `CardCollectionResource` that can handle the Store service reference counting correctly in this scenario. All the places where we have the pattern mapping over an array to make a list of card resources have been retrofitted to use the new `CardCollectionResource`.

TODO:
- [x] Add unit test for Store.addReference()
- [x] Add unit test for Store.dropReference()
