### PR TITLE
Do not crash the process when matrix event fails to be sent (e.g. event too large)

### DIFF
--- a/packages/ai-bot/lib/matrix.ts
+++ b/packages/ai-bot/lib/matrix.ts
@@ -103,7 +103,7 @@ export async function sendErrorEvent(
     await sendMessageEvent(
       client,
       roomId,
-      'There was an error processing your request, please try again later',
+      'There was an error processing your request, please try again later.',
       eventIdToReplace,
       {
         isStreamingFinished: true,

--- a/packages/host/app/components/matrix/room-message.gts
+++ b/packages/host/app/components/matrix/room-message.gts
@@ -192,10 +192,24 @@ export default class RoomMessage extends Component<Signature> {
   @service private declare matrixService: MatrixService;
   @service declare commandService: CommandService;
 
+  knownErrorMessagePrefixes: { [errorMessagePrefix: string]: string }[] = [
+    {
+      'MatrixError: [413] event too large':
+        'Response from the AI assistant was too large to process',
+    },
+  ];
+
   @cached
   private get errorMessage() {
     if (this.message.errorMessage) {
-      return this.message.errorMessage;
+      let humanFriendlyErrorMessage = null;
+      for (let errorMessagePrefix of this.knownErrorMessagePrefixes) {
+        let key = Object.keys(errorMessagePrefix)[0];
+        if (this.message.errorMessage.startsWith(key)) {
+          humanFriendlyErrorMessage = errorMessagePrefix[key];
+        }
+      }
+      return humanFriendlyErrorMessage || this.message.errorMessage;
     }
     if (this.streamingTimeout) {
       return 'This message was processing for too long. Please try again.';

--- a/packages/host/app/lib/matrix-classes/message-builder.ts
+++ b/packages/host/app/lib/matrix-classes/message-builder.ts
@@ -171,6 +171,7 @@ export default class MessageBuilder {
         ? this.event.content.isStreamingFinished
         : undefined;
     message.updated = new Date();
+    message.errorMessage = this.errorMessage;
 
     let commandRequests =
       (this.event.content as CardMessageContent)[


### PR DESCRIPTION
Previously, the process died when event was too large to send (matrix 64KB limit). We are talking about the events that the bot sends to the room when it is receiving chunks from the AI model. If a chunk gets too large in a way that violates the event limit, then the process exited:

<img width="538" alt="image" src="https://github.com/user-attachments/assets/b427cc8a-d2e2-4005-870e-aa5d47a972f5" />

The change allows us to keep the bot alive when that happens and let the user know:
<img width="336" alt="image" src="https://github.com/user-attachments/assets/89195f0c-608c-45ee-84fd-a0677a3e58ed" />

We have further work planned that will normalize event sizes but for this fix only addresses the process crash. 


