### PR TITLE
Better error message for scenario when response is not JSON

### DIFF
--- a/packages/runtime-common/matrix-client.ts
+++ b/packages/runtime-common/matrix-client.ts
@@ -301,11 +301,21 @@ export class MatrixClient {
       throw new Error(`Missing matrix access token`);
     }
     let response = await this.request('_matrix/client/v3/account/whoami');
-    let json = (await response.json()) as {
-      user_id: string;
-      device_id: string;
-    };
-    if (!response.ok) {
+    let json:
+      | {
+          user_id: string;
+          device_id: string;
+        }
+      | undefined;
+    let text = await response.text();
+    try {
+      json = JSON.parse(text);
+    } catch (e) {
+      throw new Error(
+        `unable to parse response from ${this.matrixURL.href}_matrix/client/v3/account/whoami, response was not JSON: ${text}`,
+      );
+    }
+    if (!json || !response.ok) {
       return undefined;
     } else {
       return json.user_id;


### PR DESCRIPTION
This is to get better error messages based on the sentry emails that we've been getting that look like:

```
SyntaxError: Unexpected token < in JSON at position 0
  File "/realm-server/packages/runtime-common/matrix-client.ts", line 304, in MatrixClient.whoami
    let json = (await response.json()) as {
  File "/realm-server/packages/runtime-common/matrix-client.ts", line 292, in MatrixClient.isTokenValid
    let userId = await this.whoami();
  File "/realm-server/packages/runtime-common/worker.ts", line 195, in Worker.makeAuthedFetch
    if (!(await matrixClient.isTokenValid())) {
  File "/realm-server/packages/runtime-common/worker.ts", line 231, in Worker.prepareAndRunJob
    let _fetch = await this.makeAuthedFetch(args);
  File "/realm-server/packages/runtime-common/worker.ts", line 330, in Worker.incremental
```