### PR TITLE
Fix timing for starting matrix in tests

### DIFF
--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -423,16 +423,10 @@ async function setupTestRealm({
 
   // TODO this is the only use of Realm.maybeHandle left--can we get rid of it?
   virtualNetwork.mount(realm.maybeHandle);
+  await mockMatrixUtils.start();
   await adapter.ready;
   await worker.run();
   await realm.start();
-
-  // Workaround to refetch realm info, as it is first fetched before the virtual network
-  // is present, and the fetch fails, leading to realmUserId being undefined.
-  let realmResource = (
-    owner.lookup('service:realm') as any
-  ).getOrCreateRealmResource(realmURL);
-  await realmResource.fetchInfo();
 
   return { realm, adapter };
 }

--- a/packages/host/tests/helpers/mock-matrix.ts
+++ b/packages/host/tests/helpers/mock-matrix.ts
@@ -34,7 +34,20 @@ export function setupMockMatrix(
     opts: undefined,
   };
 
-  let mockUtils = new MockUtils(testState);
+  let mockUtils = new MockUtils(testState, async () => {
+    if (opts?.autostart) {
+      if (!testState?.owner) {
+        throw new Error(`Cannot start mock matrix without a test state owner`);
+      }
+      let matrixService = testState.owner.lookup(
+        'service:matrix-service',
+      ) as MatrixService;
+      await matrixService.ready;
+      await matrixService.start();
+    } else {
+      console.warn(`auto starting of mock matrix is disabled`);
+    }
+  });
 
   hooks.beforeEach(async function () {
     testState.owner = this.owner;
@@ -99,13 +112,6 @@ export function setupMockMatrix(
         instantiate: false,
       },
     );
-    if (opts.autostart) {
-      let matrixService = this.owner.lookup(
-        'service:matrix-service',
-      ) as MatrixService;
-      await matrixService.ready;
-      await matrixService.start();
-    }
   });
   return mockUtils;
 }

--- a/packages/host/tests/helpers/mock-matrix/_utils.ts
+++ b/packages/host/tests/helpers/mock-matrix/_utils.ts
@@ -16,6 +16,7 @@ type IEvent = MatrixSDK.IEvent;
 export class MockUtils {
   constructor(
     private testState: { owner?: Owner; sdk?: MockSDK; opts?: Config },
+    readonly start: () => Promise<void>,
   ) {}
   getRoomEvents = (roomId: string) => {
     return this.testState.sdk!.getRoomEvents(roomId);


### PR DESCRIPTION
Currently there is an issue where in host tests there are requests for `/_info` that hit the network stack instead of being handled internally. This is a result of the fact that we are starting the matrix service in our tests before we have mounted the realm on the virtual network when `setupMockMatrix()` has the `autostart` option set to `true`. This PR synchronizes the starting of the matrix service so that it only happens after the test realm has been mounted.