### PR TITLE
AI bot: Fix process crashing by not processing old events (it's wasteful and unneeded)

### DIFF
--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -158,7 +158,10 @@ Common issues are:
   let assistant = new Assistant(client, aiBotUserId);
   await assistant.loadToolCallCapableModels();
 
-  client.on(RoomMemberEvent.Membership, function (_event, member) {
+  client.on(RoomMemberEvent.Membership, function (event, member) {
+    if (event.event.origin_server_ts! < startTime) {
+      return;
+    }
     if (member.membership === 'invite' && member.userId === aiBotUserId) {
       client
         .joinRoom(member.roomId)
@@ -326,12 +329,14 @@ Common issues are:
 
   //handle set title by commands
   client.on(RoomEvent.Timeline, async function (event, room) {
-    if (!room) {
+    if (
+      event.event.origin_server_ts! < startTime ||
+      !room ||
+      !isCommandResultStatusApplied(event)
+    ) {
       return;
     }
-    if (!isCommandResultStatusApplied(event)) {
-      return;
-    }
+
     log.info(
       '(%s) (Room: "%s" %s) (Message: %s %s)',
       event.getType(),


### PR DESCRIPTION
On AI bot process boot, it tried to process old events, because we were missing the time check. That lead to massive amount of fetching from synapse server, especially in the `client.on(RoomEvent.Timeline)` handler where it called `roomInitialSync` for each of the room of the old events. 

Since the ai bot resources are tiny ( .25 vCPU .5 GB) this quickly resulted in a crash. The container kept being restarted every ~5mins due to container being out of memory.

I tested this by deploying to prod and crashes are not happening anymore. Bot is up and running. 