### PR TITLE
Copy card command returns a card id and not a running card

### DIFF
--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -35,7 +35,7 @@ export class CopyCardInput extends CardDef {
 }
 
 export class CopyCardResult extends CardDef {
-  @field newCard = linksTo(CardDef);
+  @field newCardId = contains(StringField);
 }
 
 export class CopySourceInput extends CardDef {

--- a/packages/host/app/commands/copy-card.ts
+++ b/packages/host/app/commands/copy-card.ts
@@ -50,25 +50,19 @@ export default class CopyCardCommand extends HostBaseCommand<
       }
       doc.data.meta.adoptsFrom = input.codeRef;
     }
-    let maybeId = await this.store.create(doc, undefined, targetUrl);
-    if (typeof maybeId !== 'string') {
+    let newCardId = await this.store.create(doc, undefined, targetUrl);
+    if (typeof newCardId !== 'string') {
       throw new Error(
         `unable to save copied card instance: ${JSON.stringify(
-          maybeId,
+          newCardId,
           null,
           2,
         )}`,
       );
     }
-    let newCard = await this.store.get(maybeId);
-    if (!isCardInstance(newCard)) {
-      throw new Error(
-        `unable to get instance ${maybeId}: ${JSON.stringify(newCard, null, 2)}`,
-      );
-    }
     let commandModule = await this.loadCommandModule();
     const { CopyCardResult } = commandModule;
-    return new CopyCardResult({ newCard });
+    return new CopyCardResult({ newCardId });
   }
 
   private async determineTargetUrl({

--- a/packages/host/app/components/matrix/room-message-command.gts
+++ b/packages/host/app/components/matrix/room-message-command.gts
@@ -137,13 +137,13 @@ export default class RoomMessageCommand extends Component<Signature> {
 
   @action async copyToWorkspace() {
     let { commandContext } = this.commandService;
-    const { newCard } = await new CopyCardCommand(commandContext).execute({
+    const { newCardId } = await new CopyCardCommand(commandContext).execute({
       sourceCard: this.commandResultCard.card as CardDef,
     });
 
     let showCardCommand = new ShowCardCommand(commandContext);
     await showCardCommand.execute({
-      cardIdToShow: newCard.id,
+      cardIdToShow: newCardId,
     });
   }
 

--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -703,13 +703,13 @@ export class ${className} extends ${exportName} {
         `Cannot duplicateCardInstance where where is no selected realm URL`,
       );
     }
-    let { newCard } = await new CopyCardCommand(
+    let { newCardId } = await new CopyCardCommand(
       this.commandService.commandContext,
     ).execute({
       sourceCard: this.currentRequest.sourceInstance,
       targetUrl: this.selectedRealmURL.href,
     });
-    this.currentRequest.newFileDeferred.fulfill(new URL(`${newCard.id}.json`));
+    this.currentRequest.newFileDeferred.fulfill(new URL(`${newCardId}.json`));
   });
 
   private createCardInstance = restartableTask(async () => {

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -478,11 +478,10 @@ export default class InteractSubmode extends Component {
       let newCardId: string | undefined;
       try {
         let { commandContext } = this.commandService;
-        const { newCard } = await new CopyCardCommand(commandContext).execute({
+        ({ newCardId } = await new CopyCardCommand(commandContext).execute({
           sourceCard,
           targetStackIndex: stackIndex,
-        });
-        newCardId = newCard.id;
+        }));
       } catch (e) {
         done.reject(e);
       } finally {
@@ -493,7 +492,6 @@ export default class InteractSubmode extends Component {
     },
   );
 
-  //==catalog actions==
   private _createFromSpec = task(async (spec: Spec, targetRealm: string) => {
     if (spec.isComponent) {
       return;
@@ -552,7 +550,6 @@ export default class InteractSubmode extends Component {
       );
     },
   );
-  // END ==catalog actions==
 
   // dropTask will ignore any subsequent copy requests until the one in progress is done
   private copy = dropTask(
@@ -586,15 +583,16 @@ export default class InteractSubmode extends Component {
         let realmURL = destinationRealmURL;
         sources.sort((a, b) => a.title.localeCompare(b.title));
         let scrollToCardId: string | undefined;
+        let newCardId: string | undefined;
         for (let [index, card] of sources.entries()) {
-          let { newCard } = await new CopyCardCommand(
+          ({ newCardId } = await new CopyCardCommand(
             this.commandService.commandContext,
           ).execute({
             sourceCard: card,
             targetUrl: realmURL.href,
-          });
+          }));
           if (index === 0) {
-            scrollToCardId = newCard.id; // we scroll to the first card lexically by title
+            scrollToCardId = newCardId; // we scroll to the first card lexically by title
           }
         }
         let clearSelection =


### PR DESCRIPTION
it's problematic returning a running card from a command as creates an opportunity for mishandling the card (i.e. the running card could end up in the state of a consumer). a better pattern is to return a card ID, and the consumer of the command can use the store to load the card (which will absolutely be cached in the store after the command runs--which means that a consumer of this command can actually just get the card synchronously from the store). Also, for card copying, all the consumers of this command only want the id of the copied card anyways, so its also unnecessary to do this.

@tintinthong @richardhjtan this should fix the field validation errors that you are seeing. i think the negative reference count is not related to this issue actually.