### PR TITLE
lint: Add patch to fail on zero gjs/gts

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
       "ember-basic-dropdown@8.0.4": "patches/ember-basic-dropdown@8.0.4.patch",
       "ember-source@5.4.1": "patches/ember-source@5.4.1.patch",
       "monaco-editor@0.52.2": "patches/monaco-editor@0.52.2.patch",
-      "monaco-editor-webpack-plugin@7.1.0": "patches/monaco-editor-webpack-plugin@7.1.0.patch"
+      "monaco-editor-webpack-plugin@7.1.0": "patches/monaco-editor-webpack-plugin@7.1.0.patch",
+      "ember-eslint-parser": "patches/ember-eslint-parser.patch"
     }
   },
   "devDependencies": {

--- a/packages/eslint-plugin-boxel/package.json
+++ b/packages/eslint-plugin-boxel/package.json
@@ -37,7 +37,7 @@
     "eslint": "^8.57.1"
   },
   "dependencies": {
-    "ember-eslint-parser": "^0.5.9",
+    "ember-eslint-parser": "0.5.8",
     "requireindex": "^1.2.0"
   },
   "devDependencies": {

--- a/packages/eslint-plugin-boxel/package.json
+++ b/packages/eslint-plugin-boxel/package.json
@@ -37,7 +37,7 @@
     "eslint": "^8.57.1"
   },
   "dependencies": {
-    "ember-eslint-parser": "0.5.8",
+    "ember-eslint-parser": "^0.5.9",
     "requireindex": "^1.2.0"
   },
   "devDependencies": {

--- a/patches/ember-eslint-parser.patch
+++ b/patches/ember-eslint-parser.patch
@@ -1,0 +1,13 @@
+diff --git a/src/preprocessor/noop.js b/src/preprocessor/noop.js
+index b173262bd1f52e657ce41799cbb32e7ee5a0a27e..feb7c67f111f62993a41397ee6528e4986680159 100644
+--- a/src/preprocessor/noop.js
++++ b/src/preprocessor/noop.js
+@@ -24,6 +24,8 @@ module.exports = {
+       msgs[0].message +=
+         'To lint Gjs/Gts files please follow the setup guide at https://github.com/ember-cli/eslint-plugin-ember#gtsgjs' +
+         '\nNote that this error can also happen if you have multiple versions of eslint-plugin-ember in your node_modules';
++      // We want this to fail in CI so we notice if linting is broken
++      msgs[0].fatal = true;
+     }
+     parsedFiles.delete(fileName); // required for tests
+     return msgs;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1278,8 +1278,8 @@ importers:
   packages/eslint-plugin-boxel:
     dependencies:
       ember-eslint-parser:
-        specifier: ^0.5.9
-        version: 0.5.9(patch_hash=0db1e9515cbf9f5b3d3c6509af8967c918c176106e534408441992dd448f2545)(@babel/core@7.26.10)(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint@8.57.1)
+        specifier: 0.5.8
+        version: 0.5.8(patch_hash=0db1e9515cbf9f5b3d3c6509af8967c918c176106e534408441992dd448f2545)(@babel/core@7.26.10)(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint@8.57.1)
       requireindex:
         specifier: ^1.2.0
         version: 1.2.0
@@ -8953,6 +8953,16 @@ packages:
   ember-elsewhere@2.0.0:
     resolution: {integrity: sha512-663e57ghtYCZsqIWpmfa9o2XfbI9vHt8qAiVWOFsdRuFF1FDVKZr3moAY2xNTQ2u2FH0ELh6ResCDUIiyh1d+A==}
     engines: {node: 12.* || 14.* || >= 16}
+
+  ember-eslint-parser@0.5.8:
+    resolution: {integrity: sha512-THbt/XCE2twgfG6GXNFOU6oHrsPTPc3fQ4DvHhtj/8u6s2pAYexiZt0RWQhhCiBTQT1kNrNoKbiq/9O7U61yNA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@babel/core': ^7.23.6
+      '@typescript-eslint/parser': '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
 
   ember-eslint-parser@0.5.9:
     resolution: {integrity: sha512-IW4/3cEiFp49M2LiKyzi7VcT1egogOe8UxQ9eUKTooenC7Q4qNhzTD6rOZ8j51m8iJC+8hCzjbNCa3K4CN0Hhg==}
@@ -24465,6 +24475,21 @@ snapshots:
       - '@glint/template'
       - ember-source
       - supports-color
+
+  ember-eslint-parser@0.5.8(patch_hash=0db1e9515cbf9f5b3d3c6509af8967c918c176106e534408441992dd448f2545)(@babel/core@7.26.10)(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint@8.57.1):
+    dependencies:
+      '@babel/core': 7.26.10(supports-color@8.1.1)
+      '@babel/eslint-parser': 7.27.0(@babel/core@7.26.10)(eslint@8.57.1)
+      '@glimmer/syntax': 0.92.3
+      content-tag: 2.0.3
+      eslint-scope: 7.2.2
+      html-tags: 3.3.1
+      mathml-tag-names: 2.1.3
+      svg-tags: 1.0.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.1.6)
+    transitivePeerDependencies:
+      - eslint
 
   ember-eslint-parser@0.5.9(patch_hash=0db1e9515cbf9f5b3d3c6509af8967c918c176106e534408441992dd448f2545)(@babel/core@7.26.10)(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint@8.57.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ patchedDependencies:
   ember-css-url@1.0.0:
     hash: 0e5253a008cc7bf02424d786e7a8fb2397bc48962f3cd1443f2c0fdd8200c96d
     path: patches/ember-css-url@1.0.0.patch
+  ember-eslint-parser:
+    hash: 0db1e9515cbf9f5b3d3c6509af8967c918c176106e534408441992dd448f2545
+    path: patches/ember-eslint-parser.patch
   ember-source@5.4.1:
     hash: f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1
     path: patches/ember-source@5.4.1.patch
@@ -1276,7 +1279,7 @@ importers:
     dependencies:
       ember-eslint-parser:
         specifier: ^0.5.9
-        version: 0.5.9(@babel/core@7.26.10)(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint@8.57.1)
+        version: 0.5.9(patch_hash=0db1e9515cbf9f5b3d3c6509af8967c918c176106e534408441992dd448f2545)(@babel/core@7.26.10)(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint@8.57.1)
       requireindex:
         specifier: ^1.2.0
         version: 1.2.0
@@ -1997,7 +2000,7 @@ importers:
         version: 2.3.0(@babel/core@7.26.10)
       ember-eslint-parser:
         specifier: 0.5.9
-        version: 0.5.9(@babel/core@7.26.10)(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint@8.57.1)
+        version: 0.5.9(patch_hash=0db1e9515cbf9f5b3d3c6509af8967c918c176106e534408441992dd448f2545)(@babel/core@7.26.10)(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint@8.57.1)
       eslint-plugin-qunit:
         specifier: ^7.3.4
         version: 7.3.4(eslint@8.57.1)
@@ -2207,7 +2210,7 @@ importers:
         version: link:../../vendor/ember-concurrency-async-plugin
       ember-eslint-parser:
         specifier: 0.5.9
-        version: 0.5.9(@babel/core@7.26.10)(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint@8.57.1)
+        version: 0.5.9(patch_hash=0db1e9515cbf9f5b3d3c6509af8967c918c176106e534408441992dd448f2545)(@babel/core@7.26.10)(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint@8.57.1)
       ember-source:
         specifier: ~5.4.0
         version: 5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)
@@ -24463,7 +24466,7 @@ snapshots:
       - ember-source
       - supports-color
 
-  ember-eslint-parser@0.5.9(@babel/core@7.26.10)(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint@8.57.1):
+  ember-eslint-parser@0.5.9(patch_hash=0db1e9515cbf9f5b3d3c6509af8967c918c176106e534408441992dd448f2545)(@babel/core@7.26.10)(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint@8.57.1):
     dependencies:
       '@babel/core': 7.26.10(supports-color@8.1.1)
       '@babel/eslint-parser': 7.27.0(@babel/core@7.26.10)(eslint@8.57.1)
@@ -25571,7 +25574,7 @@ snapshots:
     dependencies:
       '@ember-data/rfc395-data': 0.0.4
       css-tree: 3.1.0
-      ember-eslint-parser: 0.5.9(@babel/core@7.26.10)(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint@8.57.1)
+      ember-eslint-parser: 0.5.9(patch_hash=0db1e9515cbf9f5b3d3c6509af8967c918c176106e534408441992dd448f2545)(@babel/core@7.26.10)(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint@8.57.1)
       ember-rfc176-data: 0.3.18
       eslint: 8.57.1
       eslint-utils: 3.0.0(eslint@8.57.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1278,8 +1278,8 @@ importers:
   packages/eslint-plugin-boxel:
     dependencies:
       ember-eslint-parser:
-        specifier: 0.5.8
-        version: 0.5.8(patch_hash=0db1e9515cbf9f5b3d3c6509af8967c918c176106e534408441992dd448f2545)(@babel/core@7.26.10)(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint@8.57.1)
+        specifier: ^0.5.9
+        version: 0.5.9(patch_hash=0db1e9515cbf9f5b3d3c6509af8967c918c176106e534408441992dd448f2545)(@babel/core@7.26.10)(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint@8.57.1)
       requireindex:
         specifier: ^1.2.0
         version: 1.2.0
@@ -8953,16 +8953,6 @@ packages:
   ember-elsewhere@2.0.0:
     resolution: {integrity: sha512-663e57ghtYCZsqIWpmfa9o2XfbI9vHt8qAiVWOFsdRuFF1FDVKZr3moAY2xNTQ2u2FH0ELh6ResCDUIiyh1d+A==}
     engines: {node: 12.* || 14.* || >= 16}
-
-  ember-eslint-parser@0.5.8:
-    resolution: {integrity: sha512-THbt/XCE2twgfG6GXNFOU6oHrsPTPc3fQ4DvHhtj/8u6s2pAYexiZt0RWQhhCiBTQT1kNrNoKbiq/9O7U61yNA==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      '@babel/core': ^7.23.6
-      '@typescript-eslint/parser': '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
 
   ember-eslint-parser@0.5.9:
     resolution: {integrity: sha512-IW4/3cEiFp49M2LiKyzi7VcT1egogOe8UxQ9eUKTooenC7Q4qNhzTD6rOZ8j51m8iJC+8hCzjbNCa3K4CN0Hhg==}
@@ -24475,21 +24465,6 @@ snapshots:
       - '@glint/template'
       - ember-source
       - supports-color
-
-  ember-eslint-parser@0.5.8(patch_hash=0db1e9515cbf9f5b3d3c6509af8967c918c176106e534408441992dd448f2545)(@babel/core@7.26.10)(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint@8.57.1):
-    dependencies:
-      '@babel/core': 7.26.10(supports-color@8.1.1)
-      '@babel/eslint-parser': 7.27.0(@babel/core@7.26.10)(eslint@8.57.1)
-      '@glimmer/syntax': 0.92.3
-      content-tag: 2.0.3
-      eslint-scope: 7.2.2
-      html-tags: 3.3.1
-      mathml-tag-names: 2.1.3
-      svg-tags: 1.0.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.1.6)
-    transitivePeerDependencies:
-      - eslint
 
   ember-eslint-parser@0.5.9(patch_hash=0db1e9515cbf9f5b3d3c6509af8967c918c176106e534408441992dd448f2545)(@babel/core@7.26.10)(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.1.6))(eslint@8.57.1):
     dependencies:


### PR DESCRIPTION
This is extracted from #2481 which I’m not confident will be recoverable.

This converts a warning in `ember-eslint-parser` to an error so we don’t experience false positives for linting in CI. You can see an example of this [here](https://github.com/cardstack/boxel/actions/runs/14600507659/job/40957251685#step:9:33), where all `.gts` files were being skipped in the lint job. It produces a warning but the job doesn’t fail, so it’s easy to miss.

#2472 fixed there being multiple versions, but this patch should alert us if it happens again. You can see it work [here](https://github.com/ember-tooling/ember-eslint-parser/blob/a0a656181088fd182390e8c8f0b71e6d5e006140/src/preprocessor/noop.js#L10) when I changed one package to use an older version.