### PR TITLE
Fix failing lint-fix test

### DIFF
--- a/packages/host/tests/acceptance/catalog-app-test.gts
+++ b/packages/host/tests/acceptance/catalog-app-test.gts
@@ -75,7 +75,7 @@ module('Acceptance | catalog app tests', function (hooks) {
         ],
       });
 
-      await waitFor('[data-test-catalog-listing--button]');
+      await waitFor('[data-test-catalog-listing-use-button]');
       assert
         .dom('[data-test-catalog-listing-use-button]')
         .containsText('Use', '"Use" button exist in listing');

--- a/packages/host/tests/acceptance/catalog-app-test.gts
+++ b/packages/host/tests/acceptance/catalog-app-test.gts
@@ -75,6 +75,7 @@ module('Acceptance | catalog app tests', function (hooks) {
         ],
       });
 
+      await waitFor('[data-test-catalog-listing--button]');
       assert
         .dom('[data-test-catalog-listing-use-button]')
         .containsText('Use', '"Use" button exist in listing');
@@ -126,6 +127,7 @@ module('Acceptance | catalog app tests', function (hooks) {
         ],
       });
 
+      await waitFor('[data-test-catalog-listing-install-button]');
       await click('[data-test-catalog-listing-install-button]');
       await click('[data-test-boxel-menu-item-text="http://test-realm/test/"]');
 

--- a/packages/host/tests/integration/commands/patch-code-test.gts
+++ b/packages/host/tests/integration/commands/patch-code-test.gts
@@ -4,6 +4,7 @@ import { LintResult } from '@cardstack/runtime-common/lint';
 
 import PatchCodeCommand from '@cardstack/host/commands/patch-code';
 import type CommandService from '@cardstack/host/services/command-service';
+import type RealmService from '@cardstack/host/services/realm';
 
 import {
   lookupLoaderService,
@@ -21,7 +22,7 @@ module('Integration | commands | patch-code', function (hooks) {
   setupBaseRealm(hooks);
 
   setupLocalIndexing(hooks);
-  let mockMatrixUtils = setupMockMatrix(hooks);
+  let mockMatrixUtils = setupMockMatrix(hooks, { autostart: true });
 
   const testFileName = 'task.gts';
   const fileUrl = `${testRealmURL}${testFileName}`;
@@ -60,6 +61,8 @@ export class Task extends CardDef {
         messages: [],
       };
     };
+    let realmService = lookupService<RealmService>('realm');
+    await realmService.login(testRealmURL);
   });
 
   test('lint-fixes contents before returning them', async function (assert) {


### PR DESCRIPTION
This PR fixes a test that is failing on main: "Integration | commands | patch-code: lint-fixes contents before returning them"