### PR TITLE
host: Hide Monaco decoration element in Percy

### DIFF
--- a/packages/host/.percy.js
+++ b/packages/host/.percy.js
@@ -3,7 +3,7 @@ module.exports = {
   snapshot: {
     widths: [1280],
     percyCSS: `
-      [data-test-percy-hide] {
+      [data-test-percy-hide], .monaco-editor .decorationsOverviewRuler {
         visibility: hidden;
       }
     `,


### PR DESCRIPTION
There are many instances of this diff or its reverse, I don’t think we care about the content of this “decorator overview” for Monaco:

![image](https://github.com/user-attachments/assets/ca1172fe-4590-4815-95cd-35f34bd350b8)
