### PR TITLE
host: Fix alignment of spec instance count

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -173,6 +173,7 @@ class SpecPreviewTitle extends GlimmerComponent<TitleSignature> {
 
     <style scoped>
       .has-spec {
+        display: flex;
         color: var(--boxel-450);
         font: 500 var(--boxel-font-xs);
         letter-spacing: var(--boxel-lsp-xl);


### PR DESCRIPTION
Before: 

<img width="1165" alt="address gts in Experiments Workspace 2025-04-25 16-15-39" src="https://github.com/user-attachments/assets/129bca9d-1cbf-4ede-9d11-6cd1cde869cf" />

After:

<img width="1168" alt="address gts in Experiments Workspace 2025-04-25 16-14-59" src="https://github.com/user-attachments/assets/cb9ac397-32d1-4c02-823b-4baa91af91e2" />
