### PR TITLE
Do not reset loader for clientRequest prefixed with copy:

### DIFF
--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -488,7 +488,10 @@ export default class StoreService extends Service implements StoreInterface {
     }
     let invalidations = event.invalidations as string[];
 
-    if (invalidations.find((i) => hasExecutableExtension(i))) {
+    if (
+      invalidations.find((i) => hasExecutableExtension(i)) &&
+      !event.clientRequestId?.startsWith('copy:')
+    ) {
       // the invalidation included code changes too. in this case we
       // need to flush the loader so that we can pick up any updated
       // code before re-running the card


### PR DESCRIPTION
When we save source, it causes a loader reset so instances that depend on the source can be updated
This caused a scenario when we click "install" in st 2 stacks will re-render and have all identity context get destroyed

<img width="1302" alt="Screenshot 2025-04-28 at 20 38 06" src="https://github.com/user-attachments/assets/6781359e-0144-4248-a9a9-37a862af1cb2" />

<img width="1481" alt="Screenshot 2025-04-28 at 20 32 37" src="https://github.com/user-attachments/assets/3903991c-384c-489b-8b03-105a01ff6e08" />

**More Thoughts**

So rightfully, there certainly is some race condition occuring in how validations are handled but I can't pin point it
- this error doesn't occur when a single stack item is used
- this error typically occurs whenever you "install" a listing for a 2nd time

This may mean "a deeper issue"??

**Solution**
However, I believe it is not a "possible" scenario that the source that is newly copied will have instances that depend on it. So I executed a change to ignore all clientRequestIds prefixed with 'copy:' from handleInvalidations; this comes from copySource in the card service