### PR TITLE
fix dual scroll

### DIFF
--- a/packages/catalog-realm-dev/catalog-app/catalog.gts
+++ b/packages/catalog-realm-dev/catalog-app/catalog.gts
@@ -500,18 +500,19 @@ class Isolated extends Component<typeof Catalog> {
   getComponent = (card: CardDef) => card.constructor.getComponent(card);
 
   <template>
-    <TabbedHeader
-      @tabs={{this.tabFilterOptions}}
-      @setActiveTab={{this.setActiveTab}}
-      @activeTabId={{this.activeTabId}}
-      @headerBackgroundColor={{this.headerColor}}
-      class='catalog-tab-header'
-    />
-
     <CatalogLayout
       @showSidebar={{this.shouldShowSidebar}}
       class='catalog-layout {{this.activeTabId}}'
     >
+      <:header>
+        <TabbedHeader
+          @tabs={{this.tabFilterOptions}}
+          @setActiveTab={{this.setActiveTab}}
+          @activeTabId={{this.activeTabId}}
+          @headerBackgroundColor={{this.headerColor}}
+          class='catalog-tab-header'
+        />
+      </:header>
       <:sidebar>
         <div class='sidebar-content'>
           <BoxelButton
@@ -577,6 +578,11 @@ class Isolated extends Component<typeof Catalog> {
     </CatalogLayout>
 
     <style scoped>
+      .catalog-tab-header {
+        position: sticky;
+        top: 0;
+        z-index: 10;
+      }
       .catalog-tab-header :deep(.app-title-group) {
         display: none;
       }
@@ -632,7 +638,6 @@ class Isolated extends Component<typeof Catalog> {
       }
       .catalog-content {
         display: block;
-        overflow-y: auto;
       }
       .catalog-listing {
         background-color: transparent;

--- a/packages/catalog-realm-dev/catalog-app/layouts/catalog-layout.gts
+++ b/packages/catalog-realm-dev/catalog-app/layouts/catalog-layout.gts
@@ -7,6 +7,7 @@ interface CatalogLayoutSignature {
     showSidebar?: boolean; // Control visibility of sidebar
   };
   Blocks: {
+    header?: []; //  header content
     sidebar?: []; //  sidebar content
     content: []; // Main content (required)
   };
@@ -20,6 +21,8 @@ export default class CatalogLayout extends GlimmerComponent<CatalogLayoutSignatu
 
   <template>
     <div class='layout-container' ...attributes>
+      {{yield to='header'}}
+
       <div class='layout-body'>
         {{#if (and (has-block 'sidebar') this.showSidebar)}}
           <aside class='sidebar'>


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-8497/quirky-dual-scroller-inside-of-catalog

_Moving the header into CatalogLayout fixed the dual scroll problem by:_
1. Creating a single scroll context
2. Properly containing all scrollable areas
3. Preventing unwanted scroll propagation

Before: 
https://uploads.linear.app/2904cb2e-331e-40f8-bec3-2da5f31f2a8a/c7d8a591-7108-41ab-b736-329340394f3d/9d909135-1432-4fbc-bee0-3dfa0b883fcb

After:
https://www.loom.com/share/04916a09907d4dbcbdcced5a0a175f33?sid=e3d9c5cb-4e92-4c96-ace3-589bcbd91c48