### PR TITLE
Set default skills in initial_state of room creation

### DIFF
--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -96,6 +96,7 @@ export class PatchCodeInput extends CardDef {
 
 export class CreateAIAssistantRoomInput extends CardDef {
   @field name = contains(StringField);
+  @field defaultSkills = linksToMany(SkillCard);
 }
 
 export class CreateAIAssistantRoomResult extends CardDef {

--- a/packages/host/app/commands/create-ai-assistant-room.ts
+++ b/packages/host/app/commands/create-ai-assistant-room.ts
@@ -10,10 +10,11 @@ import {
 
 import type * as BaseCommandModule from 'https://cardstack.com/base/command';
 
+import type { FileDef } from 'https://cardstack.com/base/file-api';
+
 import HostBaseCommand from '../lib/host-base-command';
 
 import type MatrixService from '../services/matrix-service';
-import type { FileDef } from 'https://cardstack.com/base/file-api';
 
 export default class CreateAiAssistantRoomCommand extends HostBaseCommand<
   typeof BaseCommandModule.CreateAIAssistantRoomInput,

--- a/packages/host/app/commands/create-ai-assistant-room.ts
+++ b/packages/host/app/commands/create-ai-assistant-room.ts
@@ -4,6 +4,7 @@ import format from 'date-fns/format';
 
 import {
   APP_BOXEL_ACTIVE_LLM,
+  APP_BOXEL_ROOM_SKILLS_EVENT_TYPE,
   DEFAULT_LLM,
 } from '@cardstack/runtime-common/matrix-constants';
 
@@ -12,6 +13,7 @@ import type * as BaseCommandModule from 'https://cardstack.com/base/command';
 import HostBaseCommand from '../lib/host-base-command';
 
 import type MatrixService from '../services/matrix-service';
+import type { FileDef } from 'https://cardstack.com/base/file-api';
 
 export default class CreateAiAssistantRoomCommand extends HostBaseCommand<
   typeof BaseCommandModule.CreateAIAssistantRoomInput,
@@ -37,6 +39,16 @@ export default class CreateAiAssistantRoomCommand extends HostBaseCommand<
         'Requires userId to execute CreateAiAssistantRoomCommand',
       );
     }
+    let { defaultSkills } = input;
+    let skillFileDefs: FileDef[] | undefined;
+    let commandFileDefs: FileDef[] | undefined;
+    if (defaultSkills) {
+      let skills = input.defaultSkills;
+      skillFileDefs = await matrixService.uploadCards(input.defaultSkills);
+      const commandDefinitions = skills.flatMap((skill) => skill.commands);
+      commandFileDefs =
+        await matrixService.uploadCommandDefinitions(commandDefinitions);
+    }
 
     // Run room creation and module loading in parallel
     const [roomResult, commandModule] = await Promise.all([
@@ -61,6 +73,20 @@ export default class CreateAiAssistantRoomCommand extends HostBaseCommand<
             type: APP_BOXEL_ACTIVE_LLM,
             content: {
               model: DEFAULT_LLM,
+            },
+          },
+          {
+            type: APP_BOXEL_ROOM_SKILLS_EVENT_TYPE,
+            content: {
+              enabledSkillCards:
+                skillFileDefs?.map((skillFileDef) =>
+                  skillFileDef.serialize(),
+                ) ?? [],
+              disabledSkillCards: [],
+              commandDefinitions:
+                commandFileDefs?.map((commandFileDef) =>
+                  commandFileDef.serialize(),
+                ) ?? [],
             },
           },
         ],

--- a/packages/host/app/components/ai-assistant/panel.gts
+++ b/packages/host/app/components/ai-assistant/panel.gts
@@ -462,26 +462,17 @@ export default class AiAssistantPanel extends Component<Signature> {
 
   private doCreateRoom = restartableTask(async (name: string) => {
     try {
-      console.time('Total room creation time');
-      console.time('Load default skills');
       const defaultSkills = await this.matrixService.loadDefaultSkills(
         this.operatorModeStateService.state.submode,
       );
-      console.timeEnd('Load default skills');
-
-      console.time('CreateAiAssistantRoomCommand execution');
       let createRoomCommand = new CreateAiAssistantRoomCommand(
         this.commandService.commandContext,
       );
       let { roomId } = await createRoomCommand.execute({ name, defaultSkills });
-      console.timeEnd('CreateAiAssistantRoomCommand execution');
 
       window.localStorage.setItem(NewSessionIdPersistenceKey, roomId);
       this.enterRoom(roomId);
-
-      console.timeEnd('Total room creation time');
     } catch (e) {
-      console.timeEnd('Total room creation time');
       console.log(e);
       this.displayRoomError = true;
       this.matrixService.currentRoomId = undefined;

--- a/packages/host/app/components/ai-assistant/panel.gts
+++ b/packages/host/app/components/ai-assistant/panel.gts
@@ -26,7 +26,6 @@ import ENV from '@cardstack/host/config/environment';
 
 import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
-import AddSkillsToRoomCommand from '../../commands/add-skills-to-room';
 import CreateAiAssistantRoomCommand from '../../commands/create-ai-assistant-room';
 import { Message } from '../../lib/matrix-classes/message';
 import { isMatrixError, eventDebounceMs } from '../../lib/matrix-utils';
@@ -464,29 +463,18 @@ export default class AiAssistantPanel extends Component<Signature> {
   private doCreateRoom = restartableTask(async (name: string) => {
     try {
       console.time('Total room creation time');
-
-      console.time('CreateAiAssistantRoomCommand execution');
-      let createRoomCommand = new CreateAiAssistantRoomCommand(
-        this.commandService.commandContext,
-      );
-      let { roomId } = await createRoomCommand.execute({ name });
-      console.timeEnd('CreateAiAssistantRoomCommand execution');
-
       console.time('Load default skills');
       const defaultSkills = await this.matrixService.loadDefaultSkills(
         this.operatorModeStateService.state.submode,
       );
       console.timeEnd('Load default skills');
 
-      console.time('AddSkillsToRoomCommand execution');
-      let addSkillsToRoomCommand = new AddSkillsToRoomCommand(
+      console.time('CreateAiAssistantRoomCommand execution');
+      let createRoomCommand = new CreateAiAssistantRoomCommand(
         this.commandService.commandContext,
       );
-      await addSkillsToRoomCommand.execute({
-        roomId,
-        skills: defaultSkills,
-      });
-      console.timeEnd('AddSkillsToRoomCommand execution');
+      let { roomId } = await createRoomCommand.execute({ name, defaultSkills });
+      console.timeEnd('CreateAiAssistantRoomCommand execution');
 
       window.localStorage.setItem(NewSessionIdPersistenceKey, roomId);
       this.enterRoom(roomId);

--- a/packages/host/tests/helpers/mock-matrix/_client.ts
+++ b/packages/host/tests/helpers/mock-matrix/_client.ts
@@ -599,9 +599,21 @@ export class MockClient implements ExtendedClient {
 
   async createRoom({
     name,
+    initial_state,
   }: MatrixSDK.ICreateRoomOpts): Promise<{ room_id: string }> {
     let sender = this.loggedInAs || 'unknown_user';
     let roomId = this.serverState.createRoom(sender, name);
+
+    if (initial_state) {
+      for (let event of initial_state) {
+        this.serverState.setRoomState(
+          sender,
+          roomId,
+          event.type,
+          event.content,
+        );
+      }
+    }
 
     return { room_id: roomId };
   }


### PR DESCRIPTION
This is another part of the effort to improve room creation time. The idea here is to set the default skill during room creation, instead of making a separate call after the room is created. Before this PR, room creation time was around 5–6 seconds. It has improved now, as shown in the screenshot below.

![Screenshot 2025-04-29 at 15 21 21](https://github.com/user-attachments/assets/da951f48-8d9e-48de-9920-106e3e3f5fd7)


