### PR TITLE
host: Hide Monaco diff sidebar in Percy

### DIFF
--- a/packages/host/.percy.js
+++ b/packages/host/.percy.js
@@ -3,7 +3,9 @@ module.exports = {
   snapshot: {
     widths: [1280],
     percyCSS: `
-      [data-test-percy-hide], .monaco-editor .decorationsOverviewRuler {
+      [data-test-percy-hide],
+      .monaco-editor .decorationsOverviewRuler,
+      .monaco-editor .margin-view-overlays {
         visibility: hidden;
       }
     `,


### PR DESCRIPTION
This removes spurious diffs such as [this](https://percy.io/Cardstack-1/web/-cardstack-host/builds/40152188/changed/2164207198?browser=firefox&browser_ids=64%2C65&group_snapshots_by=similar_diff&subcategories=unreviewed%2Cchanges_requested&utm_source=github_status_private&viewLayout=side-by-side&viewMode=new&width=1280&widths=1280):

<img width="174" alt="Build #12487 - Cardstack - Percy | Visual testing as a service 2025-04-30 12-53-41" src="https://github.com/user-attachments/assets/582f4e50-890a-4ef4-803a-1b146c2ba6c9" />

This is the [second thing I’m hiding on this snapshot](https://github.com/cardstack/boxel/pull/2503) which makes me wonder whether we need it at all! Is this a custom Monaco view that we need to check for visual regressions on?