### PR TITLE
commandDefinitions are created without a sourceUrl, so we should check for matches by name

### DIFF
--- a/packages/host/app/commands/add-skills-to-room.ts
+++ b/packages/host/app/commands/add-skills-to-room.ts
@@ -53,8 +53,7 @@ export default class AddSkillsToRoomCommand extends HostBaseCommand<
             (newCommandDefinition) =>
               !commandDefinitions.some(
                 (commandDefinition) =>
-                  commandDefinition.sourceUrl ===
-                  newCommandDefinition.sourceUrl,
+                  commandDefinition.name === newCommandDefinition.name,
               ),
           );
         const updatedCommandDefinitions = [


### PR DESCRIPTION
I will follow up with a regression test for this. I want to get this to prod to unblock skills testing.