### PR TITLE
remove modifier for catalog display grid

### DIFF
--- a/packages/catalog-realm-dev/catalog-app/components/grid.gts
+++ b/packages/catalog-realm-dev/catalog-app/components/grid.gts
@@ -38,6 +38,14 @@ export class CardsGrid extends GlimmerComponent<CardsGridSignature> {
     this.hydratedCardId = cardId;
   }
 
+  @action
+  viewCard(card: PrerenderedCard) {
+    if (!this.args.context?.actions?.viewCard) {
+      throw new Error('viewCard action is not available');
+    }
+    this.args.context?.actions?.viewCard?.(new URL(card.url), 'isolated');
+  }
+
   isHydrated = (cardUrl: string) => {
     return removeFileExtension(cardUrl) == this.hydratedCardId;
   };
@@ -65,12 +73,6 @@ export class CardsGrid extends GlimmerComponent<CardsGridSignature> {
               <li
                 class='{{@selectedView}}-view-container'
                 data-test-card-url={{card.url}}
-                {{@context.cardComponentModifier
-                  cardId=card.url
-                  format='data'
-                  fieldType=undefined
-                  fieldName=undefined
-                }}
               >
                 {{#if
                   (and (this.isHydrated card.url) this.cardResource.isLoaded)
@@ -82,10 +84,12 @@ export class CardsGrid extends GlimmerComponent<CardsGridSignature> {
                     }}
                       <CardContainer
                         class='card'
+                        @displayBoundaries={{true}}
                         data-test-cards-grid-item={{removeFileExtension
                           card.url
                         }}
                         data-cards-grid-item={{removeFileExtension card.url}}
+                        {{on 'click' (fn this.viewCard card)}}
                       >
                         <Component />
                       </CardContainer>
@@ -157,6 +161,13 @@ export class CardsGrid extends GlimmerComponent<CardsGridSignature> {
       .card {
         container-name: fitted-card;
         container-type: size;
+        transition: ease 0.2s;
+      }
+
+      .card:hover {
+        cursor: pointer;
+        border: 1px solid var(--boxel-purple);
+        transform: translateY(-1px);
       }
 
       .cards :deep(.field-component-card.fitted-format) {


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-8544/overlay-modifier-issue-due

- Opt out of operator mode overlay and make our own custom handling
- Add a viewCard action on hover the card

Result:
https://www.loom.com/share/85ecc419a72949aaa61e73b180464c78?sid=64bc640a-1965-4146-b6a2-5b29300d90b0)

