### PR TITLE
Fix issue where we cannot switch to code mode from newly created card

### DIFF
--- a/packages/host/app/commands/switch-submode.ts
+++ b/packages/host/app/commands/switch-submode.ts
@@ -7,11 +7,13 @@ import { Submodes } from '../components/submode-switcher';
 import HostBaseCommand from '../lib/host-base-command';
 
 import type OperatorModeStateService from '../services/operator-mode-state-service';
+import type StoreService from '../services/store';
 
 export default class SwitchSubmodeCommand extends HostBaseCommand<
   typeof BaseCommandModule.SwitchSubmodeInput
 > {
   @service declare private operatorModeStateService: OperatorModeStateService;
+  @service declare private store: StoreService;
 
   description =
     'Navigate the UI to another submode. Possible values for submode are "interact" and "code".';
@@ -31,7 +33,8 @@ export default class SwitchSubmodeCommand extends HostBaseCommand<
       return null;
     }
 
-    return this.allStackItems[this.allStackItems.length - 1].id;
+    return this.store.peek(this.allStackItems[this.allStackItems.length - 1].id)
+      ?.id;
   }
 
   protected async run(

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -45,6 +45,7 @@ import WorkspaceChooser from './workspace-chooser';
 import type CommandService from '../../services/command-service';
 import type MatrixService from '../../services/matrix-service';
 import type OperatorModeStateService from '../../services/operator-mode-state-service';
+import type StoreService from '../../services/store';
 
 interface Signature {
   Element: HTMLDivElement;
@@ -97,6 +98,7 @@ export default class SubmodeLayout extends Component<Signature> {
   @service private declare operatorModeStateService: OperatorModeStateService;
   @service private declare matrixService: MatrixService;
   @service private declare router: RouterService;
+  @service private declare store: StoreService;
 
   private searchElement: HTMLElement | null = null;
   private suppressSearchClose = false;
@@ -133,7 +135,7 @@ export default class SubmodeLayout extends Component<Signature> {
     }
 
     let stackItem = this.allStackItems[this.allStackItems.length - 1];
-    return stackItem.id;
+    return this.store.peek(stackItem.id)?.id;
   }
 
   private get isToggleWorkspaceChooserDisabled() {

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -865,6 +865,42 @@ module('Acceptance | interact submode tests', function (hooks) {
       await deferred.promise;
     });
 
+    // TODO we don't yet support viewing an unsaved card in code mode since it has no URL
+    test<TestContextWithSave>('can switch to submode after newly created card is saved', async function (assert) {
+      await visitOperatorMode({
+        stacks: [[{ id: `${testRealmURL}index`, format: 'isolated' }]],
+      });
+
+      let id: string | undefined;
+      this.onSave((url) => {
+        id = url.href;
+      });
+
+      await click('[data-test-create-new-card-button]');
+      assert
+        .dom('[data-test-card-catalog-item-selected]')
+        .doesNotExist('No card is pre-selected');
+      assert.dom('[data-test-card-catalog-item]').exists();
+      assert
+        .dom('[data-test-show-more-cards]')
+        .containsText('not shown', 'Entries are paginated');
+      await click(`[data-test-select="${testRealmURL}person-entry"]`);
+      await click('[data-test-card-catalog-go-button]');
+
+      await fillIn(`[data-test-field="firstName"] input`, 'Hassan');
+
+      await click('[data-test-submode-switcher] button');
+      await click('[data-test-boxel-menu-item-text="Code"]');
+      assert.ok(id, 'new card has been assign an id');
+
+      assert
+        .dom(`[data-test-card-url-bar-input]`)
+        .hasValue(
+          `${id}.json`,
+          "the new card's url appears in the card URL field",
+        );
+    });
+
     test<TestContextWithSave>('card-catalog can pre-select the current filtered card type', async function (assert) {
       assert.expect(14);
       await visitOperatorMode({


### PR DESCRIPTION
This PR fixes a bug where we cannot switch to code mode from a newly created card. There is still the deeper issue that code mode does not know how to handle new unsaved cards. So this only supports the scenario where the new card has been autosaved. we still have work to do to make code mode support new unsaved cards before this will work for switching to code mode for new unsaved cards too.