### PR TITLE
Bug fix for compound field subscriptions not notifying on enclosing instance

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -201,6 +201,10 @@ const subscribers = initSharedState(
   'subscribers',
   () => new WeakMap<BaseDef, Set<CardChangeSubscriber>>(),
 );
+const subscriberConsumer = initSharedState(
+  'subscriberConsumer',
+  () => new WeakMap<BaseDef, { fieldOrCard: BaseDef; fieldName: string }>(),
+);
 const fieldDescriptions = initSharedState(
   'fieldDescriptions',
   () => new WeakMap<typeof BaseDef, Map<string, string>>(),
@@ -2035,10 +2039,20 @@ export type FieldDefConstructor = typeof FieldDef;
 export function subscribeToChanges(
   fieldOrCard: BaseDef | BaseDef[],
   subscriber: CardChangeSubscriber,
+  enclosing?: { fieldOrCard: BaseDef; fieldName: string },
 ) {
   if (isArrayOfCardOrField(fieldOrCard)) {
-    fieldOrCard.forEach((item) => {
-      subscribeToChanges(item, subscriber);
+    fieldOrCard.forEach((item, i) => {
+      subscribeToChanges(
+        item,
+        subscriber,
+        enclosing
+          ? {
+              fieldOrCard: enclosing.fieldOrCard,
+              fieldName: `${enclosing.fieldName}.${i}`,
+            }
+          : undefined,
+      );
     });
     return;
   }
@@ -2054,6 +2068,9 @@ export function subscribeToChanges(
   }
 
   changeSubscribers.add(subscriber);
+  if (enclosing) {
+    subscriberConsumer.set(fieldOrCard, enclosing);
+  }
 
   let fields = getFields(fieldOrCard, {
     usedLinksToFieldsOnly: true,
@@ -2069,7 +2086,12 @@ export function subscribeToChanges(
     ) {
       let value = peekAtField(fieldOrCard, fieldName);
       if (isCardOrField(value) || isArrayOfCardOrField(value)) {
-        subscribeToChanges(value, subscriber);
+        subscribeToChanges(value, subscriber, {
+          fieldOrCard: enclosing?.fieldOrCard ?? fieldOrCard,
+          fieldName: enclosing?.fieldName
+            ? `${enclosing.fieldName}.${fieldName}`
+            : fieldName,
+        });
       }
     }
   });
@@ -2157,9 +2179,12 @@ function applySubscribersToInstanceValue(
   let addedItems = newItems.filter((item) => !oldItems.includes(item));
   let removedItems = oldItems.filter((item) => !newItems.includes(item));
 
-  addedItems.forEach((item) =>
+  addedItems.forEach((item, i) =>
     changeSubscribers!.forEach((subscriber) =>
-      subscribeToChanges(item, subscriber),
+      subscribeToChanges(item, subscriber, {
+        fieldOrCard: instance,
+        fieldName: `${field.name}.${i}`,
+      }),
     ),
   );
 
@@ -2808,12 +2833,30 @@ function makeDescriptor<
   return descriptor;
 }
 
-function notifySubscribers(instance: BaseDef, fieldName: string, value: any) {
+function notifySubscribers(
+  instance: BaseDef,
+  fieldName: string,
+  value: any,
+  visited = new WeakSet<BaseDef>(),
+) {
+  if (visited.has(instance)) {
+    return;
+  }
+  visited.add(instance);
   let changeSubscribers = subscribers.get(instance);
   if (changeSubscribers) {
     for (let subscriber of changeSubscribers) {
       subscriber(instance, fieldName, value);
     }
+  }
+  let consumer = subscriberConsumer.get(instance);
+  if (consumer) {
+    notifySubscribers(
+      consumer.fieldOrCard,
+      `${consumer.fieldName}.${fieldName}`,
+      value,
+      visited,
+    );
   }
 }
 


### PR DESCRIPTION
This fixes an issue where when a change is made in an instance that has a compound field, we were not sending a notification on the enclosing instance. This manifested itself as the inability to auto-save when a property within a compound field changes (e.g. the command field of a Skill card) as the notification event sent didn't include the enclosing instance.