### PR TITLE
Fix: Prevent localStorage leak

### DIFF
--- a/packages/eslint-plugin-boxel/lib/index.js
+++ b/packages/eslint-plugin-boxel/lib/index.js
@@ -2,7 +2,7 @@
 
 const requireIndex = require('requireindex');
 const noop = require('ember-eslint-parser/noop');
-const pkg = require('../package.json'); // eslint-disable-line import/extensions
+const pkg = require('../package.json');  
 
 module.exports = {
   meta: {

--- a/packages/eslint-plugin-boxel/scripts/update-rules.js
+++ b/packages/eslint-plugin-boxel/scripts/update-rules.js
@@ -26,12 +26,12 @@ function generate(filename, filter) {
     .readdirSync(root)
     .filter((file) => path.extname(file) === '.js')
     .map((file) => path.basename(file, '.js'))
-    .map((fileName) => [fileName, require(path.join(root, fileName))]); // eslint-disable-line import/no-dynamic-require
+    .map((fileName) => [fileName, require(path.join(root, fileName))]);  
 
   const recommendedRules = rules.reduce((obj, entry) => {
     const name = `@cardstack/boxel/${entry[0]}`;
     if (filter(entry)) {
-      obj[name] = 'error'; // eslint-disable-line no-param-reassign
+      obj[name] = 'error';  
     }
     return obj;
   }, {});

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -87,11 +87,7 @@ import { RoomResource, getRoom } from '../resources/room';
 
 import {
   CurrentRoomIdPersistenceKey,
-  NewSessionIdPersistenceKey,
-  CodeModePanelSelections,
-  CodeModePanelWidths,
-  CodeModePanelHeights,
-  PlaygroundSelections,
+  clearLocalStorage,
 } from '../utils/local-storage-keys';
 
 import { type SerializedState as OperatorModeSerializedState } from './operator-mode-state-service';
@@ -928,21 +924,10 @@ export default class MatrixService extends Service {
     this.filesToSend = new TrackedMap();
     this.currentUserEventReadReceipts = new TrackedMap();
 
-    window.localStorage.removeItem(NewSessionIdPersistenceKey);
-    window.localStorage.removeItem(CodeModePanelSelections);
-    window.localStorage.removeItem(CodeModePanelWidths);
-    window.localStorage.removeItem(CodeModePanelHeights);
     // Reset it here rather than in the reset function of each service
     // because it is possible that
     // there are some services that are not initialized yet
-    window.localStorage.removeItem(PlaygroundSelections);
-    window.localStorage.removeItem('recent-cards');
-    window.localStorage.removeItem('recent-files');
-    window.localStorage.removeItem('scroll-positions');
-    // Remove all codeblock_ prefixed items
-    Object.keys(window.localStorage)
-      .filter((key) => key.startsWith('codeblock_'))
-      .forEach((key) => window.localStorage.removeItem(key));
+    clearLocalStorage();
   }
 
   private bindEventListeners() {

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -85,7 +85,14 @@ import { importResource } from '../resources/import';
 
 import { RoomResource, getRoom } from '../resources/room';
 
-import { CurrentRoomIdPersistenceKey } from '../utils/local-storage-keys';
+import {
+  CurrentRoomIdPersistenceKey,
+  NewSessionIdPersistenceKey,
+  CodeModePanelSelections,
+  CodeModePanelWidths,
+  CodeModePanelHeights,
+  PlaygroundSelections,
+} from '../utils/local-storage-keys';
 
 import { type SerializedState as OperatorModeSerializedState } from './operator-mode-state-service';
 
@@ -920,6 +927,22 @@ export default class MatrixService extends Service {
     this.cardsToSend = new TrackedMap();
     this.filesToSend = new TrackedMap();
     this.currentUserEventReadReceipts = new TrackedMap();
+
+    window.localStorage.removeItem(NewSessionIdPersistenceKey);
+    window.localStorage.removeItem(CodeModePanelSelections);
+    window.localStorage.removeItem(CodeModePanelWidths);
+    window.localStorage.removeItem(CodeModePanelHeights);
+    // Reset it here rather than in the reset function of each service
+    // because it is possible that
+    // there are some services that are not initialized yet
+    window.localStorage.removeItem(PlaygroundSelections);
+    window.localStorage.removeItem('recent-cards');
+    window.localStorage.removeItem('recent-files');
+    window.localStorage.removeItem('scroll-positions');
+    // Remove all codeblock_ prefixed items
+    Object.keys(window.localStorage)
+      .filter((key) => key.startsWith('codeblock_'))
+      .forEach((key) => window.localStorage.removeItem(key));
   }
 
   private bindEventListeners() {

--- a/packages/host/app/services/recent-cards-service.ts
+++ b/packages/host/app/services/recent-cards-service.ts
@@ -5,6 +5,8 @@ import { tracked, cached } from '@glimmer/tracking';
 import window from 'ember-window-mock';
 import { TrackedArray } from 'tracked-built-ins';
 
+import { RecentCards } from '../utils/local-storage-keys';
+
 import type ResetService from './reset';
 
 export default class RecentCardsService extends Service {
@@ -16,7 +18,7 @@ export default class RecentCardsService extends Service {
     this.resetState();
     this.reset.register(this);
 
-    const recentCardIdsString = window.localStorage.getItem('recent-cards');
+    const recentCardIdsString = window.localStorage.getItem(RecentCards);
     if (recentCardIdsString) {
       const recentCardIds = JSON.parse(recentCardIdsString) as string[];
       this.ascendingRecentCardIds.push(...recentCardIds);
@@ -46,7 +48,7 @@ export default class RecentCardsService extends Service {
       this.ascendingRecentCardIds.splice(0, 1);
     }
     window.localStorage.setItem(
-      'recent-cards',
+      RecentCards,
       JSON.stringify(this.ascendingRecentCardIds),
     );
   }

--- a/packages/host/app/services/recent-files-service.ts
+++ b/packages/host/app/services/recent-files-service.ts
@@ -10,6 +10,8 @@ import { TrackedArray } from 'tracked-built-ins';
 import { RealmPaths } from '@cardstack/runtime-common';
 import { LocalPath } from '@cardstack/runtime-common/paths';
 
+import { RecentFiles } from '../utils/local-storage-keys';
+
 import type OperatorModeStateService from './operator-mode-state-service';
 import type ResetService from './reset';
 
@@ -127,7 +129,7 @@ export default class RecentFilesService extends Service {
 
   private persistRecentFiles() {
     window.localStorage.setItem(
-      'recent-files',
+      RecentFiles,
       JSON.stringify(
         this.recentFiles.map((recentFile) => [
           recentFile.realmURL.toString(),
@@ -156,7 +158,7 @@ export default class RecentFilesService extends Service {
   }
 
   private extractRecentFilesFromStorage() {
-    let recentFilesString = window.localStorage.getItem('recent-files');
+    let recentFilesString = window.localStorage.getItem(RecentFiles);
 
     if (recentFilesString) {
       try {

--- a/packages/host/app/services/scroll-position-service.ts
+++ b/packages/host/app/services/scroll-position-service.ts
@@ -6,6 +6,8 @@ import { tracked } from '@glimmer/tracking';
 import window from 'ember-window-mock';
 import { TrackedMap } from 'tracked-built-ins';
 
+import { ScrollPositions } from '../utils/local-storage-keys';
+
 import type ResetService from './reset';
 
 export default class ScrollPositionService extends Service {
@@ -58,13 +60,13 @@ export default class ScrollPositionService extends Service {
 
   private persist() {
     window.localStorage.setItem(
-      'scroll-positions',
+      ScrollPositions,
       JSON.stringify(Object.fromEntries(this.keyToScrollPosition)),
     );
   }
 
   private extractFromStorage() {
-    let scrollPositionsString = window.localStorage.getItem('scroll-positions');
+    let scrollPositionsString = window.localStorage.getItem(ScrollPositions);
 
     if (scrollPositionsString) {
       try {

--- a/packages/host/app/utils/local-storage-keys.ts
+++ b/packages/host/app/utils/local-storage-keys.ts
@@ -22,8 +22,4 @@ export function clearLocalStorage() {
   window.localStorage.removeItem(RecentCards);
   window.localStorage.removeItem(RecentFiles);
   window.localStorage.removeItem(ScrollPositions);
-  // Remove all codeblock_ prefixed items
-  Object.keys(window.localStorage)
-    .filter((key) => key.startsWith('codeblock_'))
-    .forEach((key) => window.localStorage.removeItem(key));
 }

--- a/packages/host/app/utils/local-storage-keys.ts
+++ b/packages/host/app/utils/local-storage-keys.ts
@@ -1,3 +1,5 @@
+import window from 'ember-window-mock';
+
 export const CurrentRoomIdPersistenceKey = 'aiPanelCurrentRoomId';
 export const NewSessionIdPersistenceKey = 'aiPanelNewSessionId';
 export const CodeModePanelWidths = 'code-mode-panel-widths';
@@ -6,3 +8,22 @@ export const CodeModePanelSelections = 'code-mode-panel-selections';
 export const SessionLocalStorageKey = 'boxel-session';
 export const PlaygroundSelections = 'playground-selections';
 export const SpecSelection = 'spec-selection';
+export const RecentCards = 'recent-cards';
+export const RecentFiles = 'recent-files';
+export const ScrollPositions = 'scroll-positions';
+
+export function clearLocalStorage() {
+  window.localStorage.removeItem(CurrentRoomIdPersistenceKey);
+  window.localStorage.removeItem(NewSessionIdPersistenceKey);
+  window.localStorage.removeItem(CodeModePanelWidths);
+  window.localStorage.removeItem(CodeModePanelHeights);
+  window.localStorage.removeItem(CodeModePanelSelections);
+  window.localStorage.removeItem(PlaygroundSelections);
+  window.localStorage.removeItem(RecentCards);
+  window.localStorage.removeItem(RecentFiles);
+  window.localStorage.removeItem(ScrollPositions);
+  // Remove all codeblock_ prefixed items
+  Object.keys(window.localStorage)
+    .filter((key) => key.startsWith('codeblock_'))
+    .forEach((key) => window.localStorage.removeItem(key));
+}

--- a/packages/host/tests/acceptance/code-submode/editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/editor-test.ts
@@ -15,6 +15,8 @@ import type EnvironmentService from '@cardstack/host/services/environment-servic
 
 import type MonacoService from '@cardstack/host/services/monaco-service';
 
+import { RecentFiles } from '@cardstack/host/utils/local-storage-keys';
+
 import {
   setupLocalIndexing,
   setupOnSave,
@@ -60,7 +62,7 @@ module('Acceptance | code submode | editor tests', function (hooks) {
     ) as MonacoService;
 
     window.localStorage.setItem(
-      'recent-files',
+      RecentFiles,
       JSON.stringify([[testRealmURL, 'Pet/mango.json']]),
     );
 

--- a/packages/host/tests/acceptance/code-submode/file-tree-test.ts
+++ b/packages/host/tests/acceptance/code-submode/file-tree-test.ts
@@ -13,6 +13,8 @@ import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
 
+import { ScrollPositions } from '@cardstack/host/utils/local-storage-keys';
+
 import {
   elementIsVisible,
   setupLocalIndexing,
@@ -789,7 +791,7 @@ module('Acceptance | code submode | file-tree tests', function (hooks) {
 
   test('persisted scroll position is restored on refresh', async function (assert) {
     window.localStorage.setItem(
-      'scroll-positions',
+      ScrollPositions,
       JSON.stringify({
         'file-tree': ['http://test-realm/test/Person/1.json', 300],
       }),

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -23,6 +23,11 @@ import type MonacoService from '@cardstack/host/services/monaco-service';
 import { SerializedState } from '@cardstack/host/services/operator-mode-state-service';
 
 import {
+  RecentCards,
+  RecentFiles,
+} from '@cardstack/host/utils/local-storage-keys';
+
+import {
   elementIsVisible,
   getMonacoContent,
   percySnapshot,
@@ -967,11 +972,11 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
 
   test('can delete a card instance from code submode with no recent files to fall back on', async function (assert) {
     window.localStorage.setItem(
-      'recent-cards',
+      RecentCards,
       JSON.stringify([`${testRealmURL}Pet/vangogh`, `${testRealmURL}Person/1`]),
     );
     window.localStorage.setItem(
-      'recent-files',
+      RecentFiles,
       JSON.stringify([[testRealmURL, 'Pet/vangogh.json', null]]),
     );
     await visitOperatorMode({
@@ -997,7 +1002,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await click('[data-test-boxel-menu-item-text="Code"]');
     await waitForCodeEditor();
     assert.strictEqual(
-      window.localStorage.getItem('recent-files'),
+      window.localStorage.getItem(RecentFiles),
       JSON.stringify([[testRealmURL, 'Pet/vangogh.json', null]]),
     );
     assert.dom('[data-test-delete-modal-container]').doesNotExist();
@@ -1024,12 +1029,12 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
       .dom(`[data-test-stack-card="${testRealmURL}Pet/vangogh"`)
       .doesNotExist('stack item removed');
     assert.deepEqual(
-      window.localStorage.getItem('recent-cards'),
+      window.localStorage.getItem(RecentCards),
       JSON.stringify([`${testRealmURL}Person/1`]),
       'the deleted card has been removed from recent cards',
     );
     assert.deepEqual(
-      window.localStorage.getItem('recent-files'),
+      window.localStorage.getItem(RecentFiles),
       '[]',
       'the deleted card has been removed from recent files',
     );
@@ -1041,7 +1046,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
 
   test('Can delete a card instance from code submode and fall back to recent file', async function (assert) {
     window.localStorage.setItem(
-      'recent-files',
+      RecentFiles,
       JSON.stringify([
         [testRealmURL, 'Pet/vangogh.json'],
         [testRealmURL, 'Pet/mango.json'],
@@ -1072,7 +1077,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
 
     await waitForCodeEditor();
     assert.strictEqual(
-      window.localStorage.getItem('recent-files'),
+      window.localStorage.getItem(RecentFiles),
       JSON.stringify([
         [testRealmURL, 'Pet/vangogh.json', null],
         [testRealmURL, 'Pet/mango.json', null],
@@ -1111,7 +1116,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
       .dom(`[data-test-stack-card="${testRealmURL}Pet/vangogh"`)
       .doesNotExist('stack item removed');
     assert.deepEqual(
-      window.localStorage.getItem('recent-files'),
+      window.localStorage.getItem(RecentFiles),
       JSON.stringify([[testRealmURL, 'Pet/mango.json', null]]),
       'the deleted card has been removed from recent files',
     );
@@ -1119,7 +1124,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
 
   test('can delete a card definition and fallback to recent file', async function (assert) {
     window.localStorage.setItem(
-      'recent-files',
+      RecentFiles,
       JSON.stringify([
         [testRealmURL, 'pet.gts', null],
         [testRealmURL, 'Pet/mango.json', null],
@@ -1131,7 +1136,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     });
     await waitForCodeEditor();
     assert.strictEqual(
-      window.localStorage.getItem('recent-files'),
+      window.localStorage.getItem(RecentFiles),
       JSON.stringify([
         [testRealmURL, 'pet.gts', { line: 5, column: 35 }],
         [testRealmURL, 'Pet/mango.json', null],
@@ -1151,7 +1156,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
       .hasValue(`${testRealmURL}Pet/mango.json`);
 
     assert.deepEqual(
-      window.localStorage.getItem('recent-files'),
+      window.localStorage.getItem(RecentFiles),
       JSON.stringify([[testRealmURL, 'Pet/mango.json', null]]),
       'the deleted card has been removed from recent files',
     );
@@ -1168,12 +1173,12 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
       codePath: `${testRealmURL}pet.gts`,
     });
     window.localStorage.setItem(
-      'recent-files',
+      RecentFiles,
       JSON.stringify([[testRealmURL, 'pet.gts', null]]),
     );
     await waitForCodeEditor();
     assert.strictEqual(
-      window.localStorage.getItem('recent-files'),
+      window.localStorage.getItem(RecentFiles),
       JSON.stringify([[testRealmURL, 'pet.gts', null]]),
     );
 
@@ -1185,7 +1190,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await waitFor('[data-test-empty-code-mode]');
 
     assert.deepEqual(
-      window.localStorage.getItem('recent-files'),
+      window.localStorage.getItem(RecentFiles),
       '[]',
       'the deleted card has been removed from recent files',
     );

--- a/packages/host/tests/acceptance/code-submode/recent-files-test.ts
+++ b/packages/host/tests/acceptance/code-submode/recent-files-test.ts
@@ -16,6 +16,8 @@ import { baseRealm } from '@cardstack/runtime-common';
 
 import MonacoService from '@cardstack/host/services/monaco-service';
 
+import { RecentFiles } from '@cardstack/host/utils/local-storage-keys';
+
 import {
   percySnapshot,
   setupLocalIndexing,
@@ -299,7 +301,7 @@ module('Acceptance | code submode | recent files tests', function (hooks) {
 
   test('recent file links are shown', async function (assert) {
     window.localStorage.setItem(
-      'recent-files',
+      RecentFiles,
       JSON.stringify([
         [testRealmURL, 'index.json'],
         ['http://localhost:4202/test/', 'français.json'],
@@ -386,7 +388,7 @@ module('Acceptance | code submode | recent files tests', function (hooks) {
       .containsText('Person/1.json');
 
     assert.deepEqual(
-      JSON.parse(window.localStorage.getItem('recent-files') || '[]'),
+      JSON.parse(window.localStorage.getItem(RecentFiles) || '[]'),
       [
         [testRealmURL, 'index.json', null],
         [testRealmURL, 'français.json', null],
@@ -404,7 +406,7 @@ module('Acceptance | code submode | recent files tests', function (hooks) {
     }
 
     window.localStorage.setItem(
-      'recent-files',
+      RecentFiles,
       JSON.stringify(recentFilesEntries),
     );
 
@@ -507,7 +509,7 @@ module('Acceptance | code submode | recent files tests', function (hooks) {
 
   test('displays recent files in base realm', async function (assert) {
     window.localStorage.setItem(
-      'recent-files',
+      RecentFiles,
       JSON.stringify([
         ['https://cardstack.com/base/', 'code-ref.gts'],
         ['https://cardstack.com/base/', 'spec.gts'],
@@ -570,7 +572,7 @@ module('Acceptance | code submode | recent files tests', function (hooks) {
 
     // the cursor positions seem to be different in CI than locally
     let removedCursorPositions = (
-      JSON.parse(window.localStorage.getItem('recent-files') || '[]') as [
+      JSON.parse(window.localStorage.getItem(RecentFiles) || '[]') as [
         string,
         string,
         { column: number; line: number } | null,
@@ -587,7 +589,7 @@ module('Acceptance | code submode | recent files tests', function (hooks) {
 
   test('set cursor based on the position in recent file', async function (assert) {
     window.localStorage.setItem(
-      'recent-files',
+      RecentFiles,
       JSON.stringify([
         [testRealmURL, 'index.json', null],
         [testRealmURL, 'friend.gts', { line: 14, column: 1 }],
@@ -608,7 +610,7 @@ module('Acceptance | code submode | recent files tests', function (hooks) {
 
     monacoService.updateCursorPosition(new MonacoSDK.Position(22, 3));
     assert.deepEqual(
-      JSON.parse(window.localStorage.getItem('recent-files') || '[]'),
+      JSON.parse(window.localStorage.getItem(RecentFiles) || '[]'),
       [
         [testRealmURL, 'friend.gts', { column: 3, line: 22 }],
         [testRealmURL, 'index.json', null],

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -30,6 +30,8 @@ import type OperatorModeStateService from '@cardstack/host/services/operator-mod
 import { claimsFromRawToken } from '@cardstack/host/services/realm';
 import type RecentCardsService from '@cardstack/host/services/recent-cards-service';
 
+import { RecentCards } from '@cardstack/host/utils/local-storage-keys';
+
 import type {
   IncrementalIndexEventContent,
   RealmEventContent,
@@ -1790,7 +1792,7 @@ module('Acceptance | interact submode tests', function (hooks) {
     test('Clicking search panel (without left and right buttons activated) replaces all cards in the rightmost stack', async function (assert) {
       // creates a recent search
       window.localStorage.setItem(
-        'recent-cards',
+        RecentCards,
         JSON.stringify([`${testRealmURL}Person/fadhlan`]),
       );
 

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -27,7 +27,13 @@ import { APP_BOXEL_REALM_SERVER_EVENT_MSGTYPE } from '@cardstack/runtime-common/
 import { Submodes } from '@cardstack/host/components/submode-switcher';
 import { tokenRefreshPeriodSec } from '@cardstack/host/services/realm';
 
-import { SessionLocalStorageKey } from '@cardstack/host/utils/local-storage-keys';
+import {
+  PlaygroundSelections,
+  RecentCards,
+  RecentFiles,
+  ScrollPositions,
+  SessionLocalStorageKey,
+} from '@cardstack/host/utils/local-storage-keys';
 
 import {
   percySnapshot,
@@ -1211,11 +1217,11 @@ module('Acceptance | operator mode tests', function (hooks) {
         stacks: [[{ id: `${testRealmURL}Person/fadhlan`, format: 'isolated' }]],
       });
       window.localStorage.setItem(
-        'recent-cards',
+        RecentCards,
         JSON.stringify(`${testRealmURL}Pet/mango.json`),
       );
       window.localStorage.setItem(
-        'recent-files',
+        RecentFiles,
         JSON.stringify([
           [
             testRealmURL,
@@ -1228,11 +1234,11 @@ module('Acceptance | operator mode tests', function (hooks) {
         ]),
       );
       window.localStorage.setItem(
-        'scroll-positions',
+        ScrollPositions,
         JSON.stringify({ 'file-tree': [`${testRealmURL}Pet/mango.json`, 2] }),
       );
       window.localStorage.setItem(
-        'playground-selections',
+        PlaygroundSelections,
         JSON.stringify({
           [`${testRealmURL}Pet/mango.json`]: {
             cardId: `${testRealmURL}Pet/mango.json`,
@@ -1242,11 +1248,11 @@ module('Acceptance | operator mode tests', function (hooks) {
       );
       await click('[data-test-profile-icon-button]');
       await click('[data-test-signout-button]');
-      assert.strictEqual(window.localStorage.getItem('recent-cards'), null);
-      assert.strictEqual(window.localStorage.getItem('recent-files'), null);
-      assert.strictEqual(window.localStorage.getItem('scroll-positions'), null);
+      assert.strictEqual(window.localStorage.getItem(RecentCards), null);
+      assert.strictEqual(window.localStorage.getItem(RecentFiles), null);
+      assert.strictEqual(window.localStorage.getItem(ScrollPositions), null);
       assert.strictEqual(
-        window.localStorage.getItem('playground-selections'),
+        window.localStorage.getItem(PlaygroundSelections),
         null,
       );
 

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -1205,5 +1205,52 @@ module('Acceptance | operator mode tests', function (hooks) {
       await click('[data-test-open-ai-assistant]');
       assert.dom('[data-test-ai-assistant-panel]').doesNotExist();
     });
+
+    test(`removes local storage when logging out`, async function (assert) {
+      await visitOperatorMode({
+        stacks: [[{ id: `${testRealmURL}Person/fadhlan`, format: 'isolated' }]],
+      });
+      window.localStorage.setItem(
+        'recent-cards',
+        JSON.stringify(`${testRealmURL}Pet/mango.json`),
+      );
+      window.localStorage.setItem(
+        'recent-files',
+        JSON.stringify([
+          [
+            testRealmURL,
+            'Pet/mango.json',
+            {
+              line: 1,
+              column: 2,
+            },
+          ],
+        ]),
+      );
+      window.localStorage.setItem(
+        'scroll-positions',
+        JSON.stringify({ 'file-tree': [`${testRealmURL}Pet/mango.json`, 2] }),
+      );
+      window.localStorage.setItem(
+        'playground-selections',
+        JSON.stringify({
+          [`${testRealmURL}Pet/mango.json`]: {
+            cardId: `${testRealmURL}Pet/mango.json`,
+            format: 'edit',
+          },
+        }),
+      );
+      await click('[data-test-profile-icon-button]');
+      await click('[data-test-signout-button]');
+      assert.strictEqual(window.localStorage.getItem('recent-cards'), null);
+      assert.strictEqual(window.localStorage.getItem('recent-files'), null);
+      assert.strictEqual(window.localStorage.getItem('scroll-positions'), null);
+      assert.strictEqual(
+        window.localStorage.getItem('playground-selections'),
+        null,
+      );
+
+      assert.dom('[data-test-login-btn]').exists();
+    });
   });
 });

--- a/packages/host/tests/helpers/playground.ts
+++ b/packages/host/tests/helpers/playground.ts
@@ -3,7 +3,10 @@ import { click } from '@ember/test-helpers';
 import window from 'ember-window-mock';
 
 import type { PlaygroundSelection } from '@cardstack/host/services/playground-panel-service';
-import { PlaygroundSelections } from '@cardstack/host/utils/local-storage-keys';
+import {
+  PlaygroundSelections,
+  RecentFiles,
+} from '@cardstack/host/utils/local-storage-keys';
 
 import type { Format } from 'https://cardstack.com/base/card-api';
 
@@ -97,7 +100,7 @@ export function removePlaygroundSelections() {
 
 // RecentFiles
 export function getRecentFiles() {
-  let files = window.localStorage.getItem('recent-files');
+  let files = window.localStorage.getItem(RecentFiles);
   if (!files) {
     return;
   }
@@ -105,9 +108,9 @@ export function getRecentFiles() {
 }
 
 export function setRecentFiles(files: [string, string][]) {
-  window.localStorage.setItem('recent-files', JSON.stringify(files));
+  window.localStorage.setItem(RecentFiles, JSON.stringify(files));
 }
 
 export function removeRecentFiles() {
-  window.localStorage.removeItem('recent-files');
+  window.localStorage.removeItem(RecentFiles);
 }


### PR DESCRIPTION
When logging in with account B after previously logging in with account A, the new session incorrectly attempts to fetch account A’s realms. This happens because we didn’t properly clean up local storage during logout.