### PR TITLE
Be reactive to searchReplaceBlock value since it's set during message streaming

### DIFF
--- a/packages/host/app/components/ai-assistant/formatted-message.gts
+++ b/packages/host/app/components/ai-assistant/formatted-message.gts
@@ -5,7 +5,7 @@ import { service } from '@ember/service';
 import type { SafeString } from '@ember/template';
 import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
+import { cached, tracked } from '@glimmer/tracking';
 
 import { dropTask } from 'ember-concurrency';
 import perform from 'ember-concurrency/helpers/perform';
@@ -333,13 +333,16 @@ interface HtmlGroupCodeBlockSignature {
 }
 
 class HtmlGroupCodeBlock extends Component<HtmlGroupCodeBlockSignature> {
-  private codeDiffResource = this.args.codeData.searchReplaceBlock
-    ? getCodeDiffResultResource(
-        this,
-        this.args.codeData.fileUrl,
-        this.args.codeData.searchReplaceBlock,
-      )
-    : undefined;
+  @cached
+  get codeDiffResource() {
+    return this.args.codeData.searchReplaceBlock
+      ? getCodeDiffResultResource(
+          this,
+          this.args.codeData.fileUrl,
+          this.args.codeData.searchReplaceBlock,
+        )
+      : undefined;
+  }
 
   <template>
     <CodeBlock @monacoSDK={{@monacoSDK}} @codeData={{@codeData}} as |codeBlock|>


### PR DESCRIPTION
Fixes a regression from https://github.com/cardstack/boxel/pull/2546/

The bug was that once the message stopped streaming, the diff did not show up
<img width="431" alt="image" src="https://github.com/user-attachments/assets/bbbc698f-c7c8-413c-944d-3d707d95c21d" />

The issue is that `codeData.searchReplaceBlock` will change value. This is because there can be multiple search/replace blocks inside a single message and they each get set when we recognize them during streaming. 

This fixes the bug by making `codeDiffResource` a cached getter which reacts to when `codeData.searchReplaceBlock` gets set during streaming. 