### PR TITLE
Improve diff-skills check

### DIFF
--- a/.github/workflows/diff-skills.yaml
+++ b/.github/workflows/diff-skills.yaml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   diff-skills:
+    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
@@ -26,6 +27,7 @@ jobs:
 
       - name: Process skill card changes
         id: process-changes
+        continue-on-error: true
         run: |
           # Create a temporary directory for processing
           mkdir -p /tmp/skill-diffs
@@ -86,22 +88,32 @@ jobs:
           DIFF_CONTENT=$(printf "%s\n" "${DIFFS[@]}")
 
           # Set output
-          echo "diff_content<<EOF" >> $GITHUB_OUTPUT
-          echo "$DIFF_CONTENT" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-          echo "DIFF_CONTENT: $DIFF_CONTENT"
+          diff_file="$RUNNER_TEMP/skill-card-diff.md"   # $RUNNER_TEMP survives the job
+          printf '%s\n' "$DIFF_CONTENT" > "$diff_file"
+
+          echo "diff_file=$diff_file" >> "$GITHUB_OUTPUT"
 
       - name: Create comment if there are changes
-        if: steps.process-changes.outputs.diff_content != ''
+        if: steps.process-changes.outputs.diff_file != ''
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |
-            const diffContent = ${{ toJSON(steps.process-changes.outputs.diff_content) }}; // Get output directly
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
+            const fs = require('fs');
+            const diffPath = '${{ steps.process-changes.outputs.diff_file }}';
+            const diffContent = fs.readFileSync(diffPath, 'utf8');
+
+            // (optionally truncate to stay within GitHub’s 65 536-char comment limit)
+            const MAX = 60000;
+            const bodyText =
+              diffContent.length > MAX
+            ? diffContent.slice(0, MAX) + '\n\n*(truncated — see artifact for full diff)*'
+            : diffContent;
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+              });
 
             // Check if we already have a comment from this workflow
             const existingComment = comments.find(comment =>
@@ -129,3 +141,10 @@ jobs:
               });
             }
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload artifact if there are changes
+        if: steps.process-changes.outputs.diff_file != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: skill-card-full-diff
+          path: ${{ steps.process-changes.outputs.diff_file }}

--- a/.github/workflows/diff-skills.yaml
+++ b/.github/workflows/diff-skills.yaml
@@ -88,7 +88,7 @@ jobs:
           DIFF_CONTENT=$(printf "%s\n" "${DIFFS[@]}")
 
           # Set output
-          if [[ -n "$DIFF_CONTENT" ]]; then 
+          if [[ -n "$DIFF_CONTENT" ]]; then
             diff_file="$RUNNER_TEMP/skill-card-diff.md"   # $RUNNER_TEMP survives the job
             printf '%s\n' "$DIFF_CONTENT" > "$diff_file"
 

--- a/.github/workflows/diff-skills.yaml
+++ b/.github/workflows/diff-skills.yaml
@@ -88,10 +88,12 @@ jobs:
           DIFF_CONTENT=$(printf "%s\n" "${DIFFS[@]}")
 
           # Set output
-          diff_file="$RUNNER_TEMP/skill-card-diff.md"   # $RUNNER_TEMP survives the job
-          printf '%s\n' "$DIFF_CONTENT" > "$diff_file"
+          if [[ -n "$DIFF_CONTENT" ]]; then 
+            diff_file="$RUNNER_TEMP/skill-card-diff.md"   # $RUNNER_TEMP survives the job
+            printf '%s\n' "$DIFF_CONTENT" > "$diff_file"
 
-          echo "diff_file=$diff_file" >> "$GITHUB_OUTPUT"
+            echo "diff_file=$diff_file" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Create comment if there are changes
         if: steps.process-changes.outputs.diff_file != ''


### PR DESCRIPTION
Check is not required (if it breaks it'll not mark the build as red)

Large diffs are safe now as well, as now we use a file to pass the diff from one step to the next.

Example output fixing the issue, and the build just before shows it not marking the build as red https://github.com/cardstack/boxel/pull/2554