### PR TITLE
Start listening for realm events synchronously when adding reference to the store

### DIFF
--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -183,9 +183,22 @@ export default class StoreService extends Service implements StoreInterface {
       `adding reference to ${id}, current reference count: ${this.referenceCount.get(id)}`,
     );
 
-    // intentionally not awaiting this. we keep track of the promise in
-    // this.newReferencePromises
-    this.wireUpNewReference(id);
+    if (isLocalId(id)) {
+      let instanceOrError = this.peek(id);
+      if (instanceOrError) {
+        let realmURL = isCardInstance(instanceOrError)
+          ? instanceOrError[realmURLSymbol]?.href
+          : instanceOrError.realm;
+        if (realmURL) {
+          this.subscribeToRealm(new URL(realmURL));
+        }
+      }
+    } else {
+      this.subscribeToRealm(new URL(id));
+      // intentionally not awaiting this. we keep track of the promise in
+      // this.newReferencePromises
+      this.wireUpNewReference(id);
+    }
   }
 
   // This method creates a new instance in the store and return the new card ID
@@ -423,32 +436,18 @@ export default class StoreService extends Service implements StoreInterface {
     return this.referenceCount.get(id) ?? 0;
   }
 
-  private async wireUpNewReference(id: string) {
+  private async wireUpNewReference(url: string) {
     let deferred = new Deferred<void>();
     await this.withTestWaiters(async () => {
       this.newReferencePromises.push(deferred.promise);
       try {
         await this.ready;
-        let instanceOrError = this.peek(id);
-        if (isLocalId(id)) {
-          if (instanceOrError) {
-            let realmURL = isCardInstance(instanceOrError)
-              ? instanceOrError[realmURLSymbol]?.href
-              : instanceOrError.realm;
-            if (realmURL) {
-              this.subscribeToRealm(new URL(realmURL));
-            }
-          }
-          deferred.fulfill();
-          return;
-        }
-
+        let instanceOrError = this.peek(url);
         if (!instanceOrError) {
           instanceOrError = await this.getInstance({
-            urlOrDoc: id,
+            urlOrDoc: url,
           });
         }
-        this.subscribeToRealm(new URL(id));
         await this.updateInstanceChangeSubscription(
           'start-tracking',
           instanceOrError,
@@ -456,12 +455,12 @@ export default class StoreService extends Service implements StoreInterface {
 
         if (!instanceOrError.id) {
           // keep track of urls for cards that are missing
-          this.identityContext.addInstanceOrError(id, instanceOrError);
+          this.identityContext.addInstanceOrError(url, instanceOrError);
         }
         deferred.fulfill();
       } catch (e) {
         console.error(
-          `error encountered wiring up new reference for ${JSON.stringify(id)}`,
+          `error encountered wiring up new reference for ${JSON.stringify(url)}`,
           e,
         );
         deferred.reject(e);

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -491,6 +491,8 @@ module('Acceptance | operator mode tests', function (hooks) {
     });
 
     await click(`[data-test-cards-grid-item="${testRealmURL}Pet/mango"]`);
+    await waitFor(`[data-test-stack-card="${testRealmURL}Pet/mango"]`);
+
     await percySnapshot(assert); /* snapshot for special styling */
     assert.operatorModeParametersMatch(currentURL(), {
       stacks: [


### PR DESCRIPTION
This addresses a concern that @tintinthong has around when we start listening to a realm when adding a  reference to the store. This way there is no async between wiring up a reference and listening for realm events 