### PR TITLE
set etag only for resources that come from realm server

### DIFF
--- a/packages/runtime-common/cached-fetch.ts
+++ b/packages/runtime-common/cached-fetch.ts
@@ -31,8 +31,6 @@ export async function cachedFetch(
         ? urlOrRequest.href
         : urlOrRequest.url;
   let cached = cache.get(key);
-  if (urlOrRequest instanceof Request) {
-  }
   if (cached?.etag) {
     if (urlOrRequest instanceof Request) {
       urlOrRequest.headers.set('If-None-Match', cached.etag);

--- a/packages/runtime-common/cached-fetch.ts
+++ b/packages/runtime-common/cached-fetch.ts
@@ -31,6 +31,8 @@ export async function cachedFetch(
         ? urlOrRequest.href
         : urlOrRequest.url;
   let cached = cache.get(key);
+  if (urlOrRequest instanceof Request) {
+  }
   if (cached?.etag) {
     if (urlOrRequest instanceof Request) {
       urlOrRequest.headers.set('If-None-Match', cached.etag);
@@ -55,7 +57,8 @@ export async function cachedFetch(
     return new Response(cached.body);
   } else if (response.ok) {
     let maybeETag = response.headers.get('ETag');
-    if (maybeETag) {
+    let maybeRealmURL = response.headers.get('X-boxel-realm-url');
+    if (maybeETag && maybeRealmURL) {
       let etag = maybeETag;
       response.cacheResponse = (body: string) => {
         cache.set(key, { etag, body });


### PR DESCRIPTION
https://linear.app/cardstack/issue/CS-8599/if-none-match-etag-causing-cors-errors-when-loading-from-cdn
https://discord.com/channels/584043165066199050/1369914319017480222