### PR TITLE
within a computed field, we should load missing field that have `isUsed=true`

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -3054,10 +3054,10 @@ export async function getIfReady<T extends BaseDef, K extends keyof T>(
       let card = Reflect.getPrototypeOf(instance)!
         .constructor as typeof BaseDef;
       let field: Field = getField(card, fieldName as string)!;
-      return (await field.handleNotLoadedError(instance, e, opts)) as
-        | T[K]
-        | T[K][]
-        | undefined;
+      return (await field.handleNotLoadedError(instance, e, {
+        ...(field.isUsed ? { loadFields: true } : {}),
+        ...opts,
+      })) as T[K] | T[K][] | undefined;
     } else {
       throw e;
     }

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -787,7 +787,7 @@ module(basename(__filename), function () {
         { ...realm.realmIndexUpdater.stats },
         {
           instancesIndexed: 1,
-          instanceErrors: 1,
+          instanceErrors: 0,
           moduleErrors: 0,
           modulesIndexed: 1,
           totalIndexEntries: 13,
@@ -829,7 +829,7 @@ module(basename(__filename), function () {
         { ...realm.realmIndexUpdater.stats },
         {
           instancesIndexed: 3,
-          instanceErrors: 1,
+          instanceErrors: 0,
           moduleErrors: 0,
           modulesIndexed: 3,
           totalIndexEntries: 13,
@@ -880,7 +880,7 @@ module(basename(__filename), function () {
         { ...realm.realmIndexUpdater.stats },
         {
           instancesIndexed: 0,
-          instanceErrors: 2,
+          instanceErrors: 1,
           moduleErrors: 0,
           modulesIndexed: 0,
           totalIndexEntries: 11,
@@ -933,7 +933,7 @@ module(basename(__filename), function () {
     // Note this particular test should only be a server test as the nature of
     // the TestAdapter in the host tests will trigger the linked card to be
     // already loaded when in fact in the real world it is not.
-    test('it can index a card with a contains computed that consumes a linksTo field', async function (assert) {
+    only('it can index a card with a contains computed that consumes a linksTo field', async function (assert) {
       const hassanId = `${testRealm}hassan`;
       let queryEngine = realm.realmIndexQueryEngine;
       let hassan = await queryEngine.cardDocument(new URL(hassanId));
@@ -995,7 +995,7 @@ module(basename(__filename), function () {
         { ...realm.realmIndexUpdater.stats },
         {
           moduleErrors: 0,
-          instanceErrors: 3,
+          instanceErrors: 2,
           modulesIndexed: 7,
           instancesIndexed: 6,
           totalIndexEntries: 13,

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -523,7 +523,7 @@ module(basename(__filename), function () {
         { ...realm.realmIndexUpdater.stats },
         {
           instancesIndexed: 0,
-          instanceErrors: 3, // 1 post, 2 persons, 1 bad-link post
+          instanceErrors: 3, // 1 post, 2 persons
           moduleErrors: 3, // post, fancy person, person
           modulesIndexed: 0,
           totalIndexEntries: 3,
@@ -1032,7 +1032,7 @@ module(basename(__filename), function () {
                 },
               });
 
-              //breaks when u have a custom template
+              //template with no reference to shortId
               static isolated = class TaskIsolated extends Component<typeof this> {
               <template>
               </template>

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -523,7 +523,7 @@ module(basename(__filename), function () {
         { ...realm.realmIndexUpdater.stats },
         {
           instancesIndexed: 0,
-          instanceErrors: 4, // 1 post, 2 persons, 1 bad-link post
+          instanceErrors: 3, // 1 post, 2 persons, 1 bad-link post
           moduleErrors: 3, // post, fancy person, person
           modulesIndexed: 0,
           totalIndexEntries: 3,
@@ -921,7 +921,7 @@ module(basename(__filename), function () {
         { ...realm.realmIndexUpdater.stats },
         {
           instancesIndexed: 1,
-          instanceErrors: 1,
+          instanceErrors: 0,
           moduleErrors: 0,
           modulesIndexed: 1,
           totalIndexEntries: 13,
@@ -930,7 +930,7 @@ module(basename(__filename), function () {
       );
     });
 
-    // Note this particular test should only be a server test as the nature of
+    // Note this particular test should test be a server test as the nature of
     // the TestAdapter in the host tests will trigger the linked card to be
     // already loaded when in fact in the real world it is not.
     test('it can index a card with a contains computed that consumes a linksTo field', async function (assert) {
@@ -1004,7 +1004,7 @@ module(basename(__filename), function () {
       );
     });
 
-    test('it can index a card with a contains computed that consumes a linksTo field that is NOT in template but uses "isUsed" option', async function(assert){
+    test('it can index a card with a contains computed that consumes a linksTo field that is NOT in template but uses "isUsed" option', async function (assert) {
       await realm.write(
         'task.gts',
         `
@@ -1038,57 +1038,52 @@ module(basename(__filename), function () {
               </template>
               }
             }
-            `
+            `,
       );
       await realm.write(
         'team.json',
-        JSON.stringify(
-          {
-            "data": {
-              "type": "card",
-              "attributes": {
-                "name": "Team B",
-                "description": null,
-                "thumbnailURL": null
+        JSON.stringify({
+          data: {
+            type: 'card',
+            attributes: {
+              name: 'Team B',
+              description: null,
+              thumbnailURL: null,
+            },
+            meta: {
+              adoptsFrom: {
+                module: './task',
+                name: 'Team',
               },
-              "meta": {
-                "adoptsFrom": {
-                  "module": "./task",
-                  "name": "Team"
-                }
-              }
-            }
-          }
-        )
+            },
+          },
+        }),
       );
       await realm.write(
         'task.json',
-        JSON.stringify(
-          {
-            "data": {
-              "type": "card",
-              "attributes": {
-                "title": null,
-                "description": null,
-                "thumbnailURL": null
+        JSON.stringify({
+          data: {
+            type: 'card',
+            attributes: {
+              title: null,
+              description: null,
+              thumbnailURL: null,
+            },
+            relationships: {
+              team: {
+                links: {
+                  self: './team',
+                },
               },
-              "relationships": {
-                "team": {
-                  "links": {
-                    "self": "./team"
-                  }
-                }
+            },
+            meta: {
+              adoptsFrom: {
+                module: './task',
+                name: 'Task',
               },
-              "meta": {
-                "adoptsFrom": {
-                  "module": "./task",
-                  "name": "Task"
-                }
-              }
-            }
-          }
-
-        )
+            },
+          },
+        }),
       );
       let taskInstance = (await realm.realmIndexQueryEngine.instance(
         new URL(`${testRealm}task`),
@@ -1096,9 +1091,9 @@ module(basename(__filename), function () {
       assert.strictEqual(
         taskInstance?.type,
         'instance',
-        'task instance created without any error'
-      )
-    })
+        'task instance created without any error',
+      );
+    });
 
     test('sets resource_created_at for modules and instances', async function (assert) {
       let entry = (await realm.realmIndexQueryEngine.module(

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -556,7 +556,7 @@ module(basename(__filename), function () {
         { ...realm.realmIndexUpdater.stats },
         {
           instancesIndexed: 3, // 1 post and 2 persons
-          instanceErrors: 1,
+          instanceErrors: 0,
           moduleErrors: 0,
           modulesIndexed: 3,
           totalIndexEntries: 9,

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -1004,7 +1004,7 @@ module(basename(__filename), function () {
       );
     });
 
-    only('random behaviour where linked field only resolves for default isolated templates but not custom isolated templates', async function(assert){
+    test('it can index a card with a contains computed that consumes a linksTo field that is NOT in template but uses "isUsed" option', async function(assert){
       await realm.write(
         'task.gts',
         `
@@ -1037,36 +1037,6 @@ module(basename(__filename), function () {
               <template>
               </template>
               }
-            }
-            `
-      );
-
-      await realm.write(
-        'task-without-custom-isolated-template.gts',
-        `
-            import StringField from 'https://cardstack.com/base/string';
-            import {
-              Component,
-              CardDef,
-              contains,
-              field,
-              linksTo,
-            } from 'https://cardstack.com/base/card-api';
-
-
-            export class Team extends CardDef {
-              static displayName = 'Team'
-              @field name = contains(StringField, {isUsed: true});
-            }
-
-            export class SimpleTask extends CardDef {
-              static displayName = 'Sprint Task';
-              @field team = linksTo(() => Team, {isUsed: true}); //even using isUsed doesn't fix this
-              @field shortId = contains(StringField, {
-                computeVia: function (this: Task) {
-                  return this.team?.name
-                },
-              });
             }
             `
       );
@@ -1120,48 +1090,13 @@ module(basename(__filename), function () {
 
         )
       );
-
-      await realm.write(
-        'task-without-custom-isolated-template.json',
-        JSON.stringify(
-          {
-            "data": {
-              "type": "card",
-              "attributes": {
-                "title": null,
-                "description": null,
-                "thumbnailURL": null
-              },
-              "relationships": {
-                "team": {
-                  "links": {
-                    "self": "./team"
-                  }
-                }
-              },
-              "meta": {
-                "adoptsFrom": {
-                  "module": "./task-without-custom-isolated-template",
-                  "name": "SimpleTask"
-                }
-              }
-            }
-          }
-
-        )
-      );
       let taskInstance = (await realm.realmIndexQueryEngine.instance(
         new URL(`${testRealm}task`),
       )) as any;
-      let taskInstanceWithoutCustomIsolatedTemplate = (await realm.realmIndexQueryEngine.instance(
-        new URL(`${testRealm}task-without-custom-isolated-template`),
-      )) as any;
       assert.strictEqual(
-        taskInstance?.error.message,
-        'The field Task.team refers to the card instance ./team which is not loaded'
-      )
-      assert.strictEqual(
-        taskInstanceWithoutCustomIsolatedTemplate.type, 'instance'
+        taskInstance?.type,
+        'instance',
+        'task instance created without any error'
       )
     })
 

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -1025,7 +1025,7 @@ module(basename(__filename), function () {
 
             export class Task extends CardDef {
               static displayName = 'Sprint Task';
-              @field team = linksTo(() => Team, {isUsed: true}); //even using isUsed doesn't fix this
+              @field team = linksTo(() => Team, {isUsed: true}); 
               @field shortId = contains(StringField, {
                 computeVia: function (this: Task) {
                   return this.team?.name

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -277,6 +277,26 @@ module(basename(__filename), function () {
                 },
               },
             },
+            'bad-link.json': {
+              data: {
+                attributes: {
+                  message: 'I have a bad link',
+                },
+                relationships: {
+                  author: {
+                    links: {
+                      self: 'http://localhost:9000/this-is-a-link-to-nowhere',
+                    },
+                  },
+                },
+                meta: {
+                  adoptsFrom: {
+                    module: './post',
+                    name: 'Post',
+                  },
+                },
+              },
+            },
             'boom.json': {
               data: {
                 attributes: {
@@ -523,7 +543,7 @@ module(basename(__filename), function () {
         { ...realm.realmIndexUpdater.stats },
         {
           instancesIndexed: 0,
-          instanceErrors: 3, // 1 post, 2 persons
+          instanceErrors: 4, // 1 post, 2 persons, 1 bad-link post
           moduleErrors: 3, // post, fancy person, person
           modulesIndexed: 0,
           totalIndexEntries: 3,
@@ -556,7 +576,7 @@ module(basename(__filename), function () {
         { ...realm.realmIndexUpdater.stats },
         {
           instancesIndexed: 3, // 1 post and 2 persons
-          instanceErrors: 0,
+          instanceErrors: 1,
           moduleErrors: 0,
           modulesIndexed: 3,
           totalIndexEntries: 9,
@@ -787,7 +807,7 @@ module(basename(__filename), function () {
         { ...realm.realmIndexUpdater.stats },
         {
           instancesIndexed: 1,
-          instanceErrors: 0,
+          instanceErrors: 1,
           moduleErrors: 0,
           modulesIndexed: 1,
           totalIndexEntries: 13,
@@ -829,7 +849,7 @@ module(basename(__filename), function () {
         { ...realm.realmIndexUpdater.stats },
         {
           instancesIndexed: 3,
-          instanceErrors: 0,
+          instanceErrors: 1,
           moduleErrors: 0,
           modulesIndexed: 3,
           totalIndexEntries: 13,
@@ -880,7 +900,7 @@ module(basename(__filename), function () {
         { ...realm.realmIndexUpdater.stats },
         {
           instancesIndexed: 0,
-          instanceErrors: 1,
+          instanceErrors: 2,
           moduleErrors: 0,
           modulesIndexed: 0,
           totalIndexEntries: 11,
@@ -921,7 +941,7 @@ module(basename(__filename), function () {
         { ...realm.realmIndexUpdater.stats },
         {
           instancesIndexed: 1,
-          instanceErrors: 0,
+          instanceErrors: 1,
           moduleErrors: 0,
           modulesIndexed: 1,
           totalIndexEntries: 13,
@@ -930,7 +950,7 @@ module(basename(__filename), function () {
       );
     });
 
-    // Note this particular test should test be a server test as the nature of
+    // Note this particular test should only be a server test as the nature of
     // the TestAdapter in the host tests will trigger the linked card to be
     // already loaded when in fact in the real world it is not.
     test('it can index a card with a contains computed that consumes a linksTo field', async function (assert) {
@@ -995,7 +1015,7 @@ module(basename(__filename), function () {
         { ...realm.realmIndexUpdater.stats },
         {
           moduleErrors: 0,
-          instanceErrors: 2,
+          instanceErrors: 3,
           modulesIndexed: 7,
           instancesIndexed: 6,
           totalIndexEntries: 13,

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -1,4 +1,4 @@
-import { module, test, only } from 'qunit';
+import { module, test } from 'qunit';
 import { dirSync } from 'tmp';
 import {
   baseRealm,

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -933,7 +933,7 @@ module(basename(__filename), function () {
     // Note this particular test should only be a server test as the nature of
     // the TestAdapter in the host tests will trigger the linked card to be
     // already loaded when in fact in the real world it is not.
-    only('it can index a card with a contains computed that consumes a linksTo field', async function (assert) {
+    test('it can index a card with a contains computed that consumes a linksTo field', async function (assert) {
       const hassanId = `${testRealm}hassan`;
       let queryEngine = realm.realmIndexQueryEngine;
       let hassan = await queryEngine.cardDocument(new URL(hassanId));


### PR DESCRIPTION
**Getting rid of this** 

<img width="1422" alt="Screenshot 2025-05-12 at 20 37 16" src="https://github.com/user-attachments/assets/76eb5265-250a-4b5b-8a0e-1822e8acff59" />

I have confirmed this fixes this

**Reason this happens** 

If a computed field depends of a link, even if the link uses `isUsed`, it is not trying to load the missing field bcos we handle computeds differently from other fields and may have missed it

**Coding pattern that is causing this (`isUsed` in team is not working for computeds)**

<img width="1125" alt="Screenshot 2025-05-12 at 17 27 12" src="https://github.com/user-attachments/assets/84762051-5709-4dad-b837-01a571bc4bf1" />
