### PR TITLE
increase browser timeout

### DIFF
--- a/packages/host/testem.js
+++ b/packages/host/testem.js
@@ -10,7 +10,7 @@ const config = {
   disable_watching: true,
   launch_in_ci: ['Chrome'],
   launch_in_dev: ['Chrome'],
-  browser_start_timeout: 120,
+  browser_start_timeout: 240,
   browser_args: {
     Chrome: {
       ci: [


### PR DESCRIPTION
main has a test that timeouts. seeing errors like this. Im not sure if increasing this timeout is the right way?

<img width="1224" alt="Screenshot 2025-05-12 at 20 33 13" src="https://github.com/user-attachments/assets/fc9ca50d-555d-42bd-b1ed-7ea68f2a1b12" />

This probably very related to https://github.com/cardstack/boxel/pull/2568


