### PR TITLE
Fixed bug switching new card into edit mode

### DIFF
--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -391,10 +391,13 @@ export default class InteractSubmode extends Component {
 
   private findCardInStack(card: CardDef, stackIndex: number): StackItem {
     let item = this.stacks[stackIndex].find(
-      (item: StackItem) => item.id === card.id,
+      (item: StackItem) =>
+        item.id === card.id || item.id === card[localIdSymbol],
     );
     if (!item) {
-      throw new Error(`Could not find card ${card.id} in stack ${stackIndex}`);
+      throw new Error(
+        `Could not find card ${card.id} (localId ${card[localIdSymbol]}) in stack ${stackIndex}`,
+      );
     }
     return item;
   }

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -1237,6 +1237,41 @@ module('Acceptance | interact submode tests', function (hooks) {
       await click(`[data-test-card-catalog-go-button]`);
     });
 
+    test<TestContextWithSave>('new card can enter edit mode', async function (assert) {
+      await visitOperatorMode({
+        stacks: [
+          [
+            {
+              id: `${testRealmURL}index`,
+              format: 'isolated',
+            },
+          ],
+        ],
+      });
+      await click('[data-test-create-new-card-button]');
+      await click(
+        `[data-test-select="https://cardstack.com/base/cards/skill"]`,
+      );
+
+      let id: string | undefined;
+      this.onSave((url) => {
+        id = url.href;
+      });
+
+      await click(`[data-test-card-catalog-go-button]`);
+      await waitUntil(() => id);
+      await click(`[data-test-edit-button]`);
+      assert
+        .dom(
+          `[data-test-stack-card="${id}"] [data-test-card-format="isolated"]`,
+        )
+        .exists('new card is in isolated format');
+      await click(`[data-test-edit-button]`);
+      assert
+        .dom(`[data-test-stack-card="${id}"] [data-test-card-format="edit"]`)
+        .exists('new card is in edit format');
+    });
+
     test<TestContextWithSave>('new linked card is created in a different realm than its consuming reference', async function (assert) {
       assert.expect(5);
       await visitOperatorMode({


### PR DESCRIPTION
Fixes a bug where a new card could not re-renter edit mode.