### PR TITLE
Include recent-cards in playground dropdown, ordered by last-viewed timestamp

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode/playground/instance-chooser-dropdown.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/instance-chooser-dropdown.gts
@@ -165,6 +165,7 @@ interface Signature {
     createNewIsRunning?: boolean;
     moduleId: string;
     persistSelections?: (cardId: string, format: Format) => void;
+    recentCardIds: string[];
   };
 }
 
@@ -270,15 +271,17 @@ export default class InstanceSelectDropdown extends Component<Signature> {
         </:loading>
         <:response as |cards|>
           {{#if (this.showResults cards)}}
-            <OptionsDropdown
-              @options={{cards}}
-              @selected={{this.findSelectedCard cards}}
-              @selection={{@selection}}
-              @onSelect={{@onSelect}}
-              @chooseCard={{@chooseCard}}
-              @createNew={{@createNew}}
-              @createNewIsRunning={{@createNewIsRunning}}
-            />
+            {{#let (this.getSortedCards cards) as |sortedCards|}}
+              <OptionsDropdown
+                @options={{sortedCards}}
+                @selected={{this.findSelectedCard sortedCards}}
+                @selection={{@selection}}
+                @onSelect={{@onSelect}}
+                @chooseCard={{@chooseCard}}
+                @createNew={{@createNew}}
+                @createNewIsRunning={{@createNewIsRunning}}
+              />
+            {{/let}}
           {{else if @expandedSearchQuery.query}}
             <PrerenderedCardSearch
               @query={{@expandedSearchQuery.query}}
@@ -342,6 +345,21 @@ export default class InstanceSelectDropdown extends Component<Signature> {
       this.args.createNewIsRunning ||
       this.isBaseCardModule // means we do not conduct the expanded search for baseCardModule
     );
+  };
+
+  // sort prerendered-search card results by most recently viewed
+  private getSortedCards = (cards: PrerenderedCard[]) => {
+    if (!this.args.recentCardIds?.length) {
+      return;
+    }
+    let sortedCards: PrerenderedCard[] = [];
+    for (let id of this.args.recentCardIds) {
+      let card = cards.find((c) => trimJsonExtension(c.url) === id);
+      if (card) {
+        sortedCards.push(card);
+      }
+    }
+    return sortedCards;
   };
 
   private get persistedCardId() {

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-title.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-title.gts
@@ -41,6 +41,7 @@ interface Signature {
     fieldChooserIsOpen: boolean;
     moduleId: string;
     persistSelections?: (cardId: string, format: Format) => void;
+    recentCardIds: string[];
   };
 }
 
@@ -74,6 +75,7 @@ export default class PlaygroundTitle extends Component<Signature> {
         @createNewIsRunning={{@createNewIsRunning}}
         @moduleId={{@moduleId}}
         @persistSelections={{@persistSelections}}
+        @recentCardIds={{@recentCardIds}}
       />
     </button>
 

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground.gts
@@ -97,6 +97,7 @@ interface Signature {
             | 'chooseField'
             | 'moduleId'
             | 'availableRealmURLs'
+            | 'recentCardIds'
           >
         | typeof DefaultTitle
       ),

--- a/packages/host/tests/acceptance/code-submode/card-playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/card-playground-test.gts
@@ -10,9 +10,10 @@ import { triggerEvent } from '@ember/test-helpers';
 
 import { module, test } from 'qunit';
 
-import type { Realm } from '@cardstack/runtime-common';
+import { trimJsonExtension, type Realm } from '@cardstack/runtime-common';
 
 import type RealmServerService from '@cardstack/host/services/realm-server';
+import type RecentFilesService from '@cardstack/host/services/recent-files-service';
 
 import {
   percySnapshot,
@@ -33,16 +34,21 @@ import {
   chooseAnotherInstance,
   createNewInstance,
   getPlaygroundSelections,
-  getRecentFiles,
   openFileInPlayground,
   removePlaygroundSelections,
-  removeRecentFiles,
   selectDeclaration,
   selectFormat,
   setPlaygroundSelections,
-  setRecentFiles,
   togglePlaygroundPanel,
 } from '../../helpers/playground';
+import {
+  getRecentFiles,
+  removeRecentFiles,
+  setRecentFiles,
+  setRecentCards,
+  removeRecentCards,
+  assertRecentFileURLs,
+} from '../../helpers/recent-files-cards';
 import { setupApplicationTest } from '../../helpers/setup';
 
 const codeRefDriverCard = `import { CardDef, field, contains } from 'https://cardstack.com/base/card-api';
@@ -269,6 +275,39 @@ module('Acceptance | code-submode | card playground', function (_hooks) {
               },
             },
           },
+          'Category/interior-design.json': {
+            data: {
+              attributes: { title: 'Interior Design' },
+              meta: {
+                adoptsFrom: {
+                  module: `${testRealmURL}blog-post`,
+                  name: 'Category',
+                },
+              },
+            },
+          },
+          'Category/landscaping.json': {
+            data: {
+              attributes: { title: 'Landscaping' },
+              meta: {
+                adoptsFrom: {
+                  module: `${testRealmURL}blog-post`,
+                  name: 'Category',
+                },
+              },
+            },
+          },
+          'Category/home-gym.json': {
+            data: {
+              attributes: { title: 'Home Gym' },
+              meta: {
+                adoptsFrom: {
+                  module: `${testRealmURL}blog-post`,
+                  name: 'Category',
+                },
+              },
+            },
+          },
           'Person/pet-mango.json': {
             data: {
               attributes: { title: 'Mango' },
@@ -348,8 +387,8 @@ module('Acceptance | code-submode | card playground', function (_hooks) {
       removeRecentFiles();
       setRecentFiles([
         [testRealmURL, 'BlogPost/mad-hatter.json'],
-        [testRealmURL, 'Category/future-tech.json'],
         [testRealmURL, 'Category/city-design.json'],
+        [testRealmURL, 'Category/future-tech.json'],
         [testRealmURL, 'BlogPost/remote-work.json'],
         [testRealmURL, 'BlogPost/urban-living.json'],
         [testRealmURL, 'Author/jane-doe.json'],
@@ -407,6 +446,88 @@ module('Acceptance | code-submode | card playground', function (_hooks) {
       assertCardExists(assert, `${testRealmURL}Category/future-tech`);
 
       await percySnapshot(assert);
+    });
+
+    test('can populate instance chooser options from recent-files and recent-cards, ordered by last viewed timestamp', async function (assert) {
+      removePlaygroundSelections();
+      removeRecentFiles();
+      removeRecentCards();
+
+      let ts = Date.now();
+      setRecentFiles([
+        [testRealmURL, 'Category/home-gym.json', null, ts],
+        [testRealmURL, 'BlogPost/remote-work.json', null, ts],
+        [testRealmURL, 'Category/future-tech.json', null, ts - 2],
+        [testRealmURL, 'Category/city-design.json', null, ts - 5], // duplicate
+      ]);
+      setRecentCards([
+        [`${testRealmURL}Category/landscaping.json`, ts - 1],
+        [`${testRealmURL}BlogPost/mad-hatter.json`, ts - 1],
+        [`${testRealmURL}Category/city-design.json`, ts - 3],
+        [`${testRealmURL}Category/future-tech.json`, ts - 4], // duplicate
+      ]);
+
+      await openFileInPlayground('blog-post.gts', testRealmURL, 'Category');
+      assert
+        .dom('[data-test-selected-item]')
+        .hasText('Home Gym', 'most recent category instance is pre-selected');
+      assertCardExists(assert, `${testRealmURL}Category/home-gym`);
+
+      await click('[data-test-instance-chooser]');
+      assert.dom('[data-option-index]').exists({ count: 4 });
+      assert.dom('[data-option-index="0"]').containsText('Home Gym');
+      assert.dom('[data-option-index="1"]').containsText('Landscaping');
+      assert.dom('[data-option-index="2"]').containsText('Future Tech');
+      assert.dom('[data-option-index="3"]').containsText('City Design');
+
+      await click(
+        `[data-test-recent-file="${testRealmURL}Category/future-tech.json"]`,
+      );
+      await click('[data-test-clickable-definition-container]');
+      // opened future-tech in code mode and then came back to playground
+
+      assert
+        .dom('[data-test-selected-item]')
+        .hasText('Home Gym', 'selected card has not changed');
+      assertCardExists(assert, `${testRealmURL}Category/home-gym`);
+
+      await click('[data-test-instance-chooser]');
+      assert.dom('[data-option-index]').exists({ count: 4 });
+      assert
+        .dom('[data-option-index="0"]')
+        .containsText('Future Tech', 'recent card order is updated');
+      assert.dom('[data-option-index="1"]').containsText('Home Gym');
+      assert.dom('[data-option-index="2"]').containsText('Landscaping');
+      assert.dom('[data-option-index="3"]').containsText('City Design');
+
+      await click('[data-test-more-options-button]');
+      await click('[data-test-boxel-menu-item-text="Open in Interact Mode"]');
+      assert
+        .dom(`[data-test-stack-card="${testRealmURL}Category/home-gym"]`)
+        .exists();
+
+      await click('[data-test-search-field]');
+      await click('[data-test-search-result-index="4"]');
+      assert
+        .dom(`[data-test-stack-card="${testRealmURL}Category/landscaping"]`)
+        .exists();
+      // opened home-gym and landscaping in interact-mode and back to playground
+
+      await openFileInPlayground('blog-post.gts', testRealmURL, 'Category');
+      await togglePlaygroundPanel();
+      assert
+        .dom('[data-test-selected-item]')
+        .hasText('Home Gym', 'selected card has not changed');
+      assertCardExists(assert, `${testRealmURL}Category/home-gym`);
+
+      await click('[data-test-instance-chooser]');
+      assert.dom('[data-option-index]').exists({ count: 4 });
+      assert
+        .dom('[data-option-index="0"]')
+        .containsText('Landscaping', 'recent card order is updated');
+      assert.dom('[data-option-index="1"]').containsText('Home Gym');
+      assert.dom('[data-option-index="2"]').containsText('Future Tech');
+      assert.dom('[data-option-index="3"]').containsText('City Design');
     });
 
     test('can update the instance chooser when selected card def changes (same file)', async function (assert) {
@@ -560,6 +681,11 @@ module('Acceptance | code-submode | card playground', function (_hooks) {
 
     test('can choose another instance to be opened in playground panel', async function (assert) {
       removeRecentFiles();
+      let recentFilesService = this.owner.lookup(
+        'service:recent-files-service',
+      ) as RecentFilesService;
+      assert.strictEqual(recentFilesService.recentFiles?.length, 0);
+
       await openFileInPlayground('blog-post.gts', testRealmURL, 'BlogPost');
       await chooseAnotherInstance();
       assert.dom('[data-test-card-catalog-modal]').exists();
@@ -589,24 +715,27 @@ module('Acceptance | code-submode | card playground', function (_hooks) {
         `${testRealmURL}BlogPost/mad-hatter`,
         'isolated',
       );
-      assert.deepEqual(getRecentFiles()?.[0], [
-        testRealmURL,
-        'BlogPost/mad-hatter.json',
-        null,
+      assertRecentFileURLs(assert, recentFilesService.recentFiles, [
+        `${testRealmURL}BlogPost/mad-hatter.json`,
+        `${testRealmURL}blog-post.gts`,
       ]);
     });
 
     test<TestContextWithSave>('can create new instance', async function (assert) {
       removeRecentFiles();
+      let recentFilesService = this.owner.lookup(
+        'service:recent-files-service',
+      ) as RecentFilesService;
+      assert.strictEqual(recentFilesService.recentFiles?.length, 0);
+
       await visitOperatorMode({
         submode: 'code',
         codePath: `${testRealmURL}blog-post.gts`,
       });
-      assert.deepEqual(getRecentFiles()?.[0], [
-        testRealmURL,
-        'blog-post.gts',
-        { line: 6, column: 40 },
+      assertRecentFileURLs(assert, recentFilesService.recentFiles, [
+        `${testRealmURL}blog-post.gts`,
       ]);
+
       await click('[data-boxel-selector-item-text="BlogPost"]');
       await togglePlaygroundPanel();
       assert
@@ -621,9 +750,8 @@ module('Acceptance | code-submode | card playground', function (_hooks) {
       await createNewInstance();
       await waitUntil(() => id);
 
-      let recentFiles = getRecentFiles();
       assert.strictEqual(
-        recentFiles?.length,
+        recentFilesService.recentFiles?.length,
         2,
         'recent file count is correct',
       );
@@ -1017,9 +1145,8 @@ module('Acceptance | code-submode | card playground', function (_hooks) {
         2,
         'new card is added to recent files',
       );
-      let newCardId = `${testRealmURL}${recentFiles[0][1]}`.replace(
-        '.json',
-        '',
+      let newCardId = trimJsonExtension(
+        `${testRealmURL}${recentFiles?.[0][1]}`,
       );
       assertCardExists(assert, newCardId, 'edit');
 
@@ -1141,7 +1268,7 @@ module('Acceptance | code-submode | card playground', function (_hooks) {
         additionalRealmURL,
         'realm is correct',
       );
-      assert.strictEqual(recentFiles.length, 2);
+      assert.strictEqual(recentFiles?.length, 2);
 
       await createNewInstance();
 
@@ -1157,9 +1284,8 @@ module('Acceptance | code-submode | card playground', function (_hooks) {
       assert.ok(newCardId?.startsWith(additionalRealmURL));
       assert.notOk(newCardId?.startsWith(personalRealmURL));
 
-      let recentCardId = `${recentFiles?.[0][0]}${recentFiles?.[0][1]}`.replace(
-        '.json',
-        '',
+      let recentCardId = trimJsonExtension(
+        `${recentFiles?.[0][0]}${recentFiles?.[0][1]}`,
       );
       assert.strictEqual(newCardId, recentCardId);
       assertCardExists(

--- a/packages/host/tests/acceptance/code-submode/field-playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/field-playground-test.gts
@@ -26,12 +26,12 @@ import {
   selectDeclaration,
   selectFormat,
   setPlaygroundSelections,
-  setRecentFiles,
   togglePlaygroundPanel,
   toggleSpecPanel,
   type PlaygroundSelection,
   type Format,
 } from '../../helpers/playground';
+import { setRecentFiles } from '../../helpers/recent-files-cards';
 import { setupApplicationTest } from '../../helpers/setup';
 
 const authorCard = `import { contains, field, CardDef, Component, FieldDef } from "https://cardstack.com/base/card-api";

--- a/packages/host/tests/acceptance/code-submode/spec-test.gts
+++ b/packages/host/tests/acceptance/code-submode/spec-test.gts
@@ -18,10 +18,10 @@ import {
 import { setupMockMatrix } from '../../helpers/mock-matrix';
 import {
   getPlaygroundSelections,
-  getRecentFiles,
   assertCardExists,
   selectDeclaration,
 } from '../../helpers/playground';
+import { getRecentFiles } from '../../helpers/recent-files-cards';
 
 import { setupApplicationTest } from '../../helpers/setup';
 
@@ -935,11 +935,13 @@ module('Acceptance | Spec preview', function (hooks) {
     await click(`[data-test-card="${petId}"]`);
 
     // Verify the card was added to recent files
-    assert.deepEqual(
-      getRecentFiles()?.[0],
-      [testRealmURL, 'Pet/mango.json', null],
+    let recentFile = getRecentFiles()?.[0];
+    assert.strictEqual(
+      `${recentFile?.[0]}${recentFile?.[1]}`,
+      `${testRealmURL}Pet/mango.json`,
       'Card is added to recent files storage',
     );
+
     // Verify the card appears in the playground
     assertCardExists(
       assert,

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -11,7 +11,6 @@ import {
 
 import { triggerEvent } from '@ember/test-helpers';
 
-import window from 'ember-window-mock';
 import { module, test } from 'qunit';
 import stringify from 'safe-stable-stringify';
 
@@ -30,8 +29,6 @@ import type MessageService from '@cardstack/host/services/message-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 import { claimsFromRawToken } from '@cardstack/host/services/realm';
 import type RecentCardsService from '@cardstack/host/services/recent-cards-service';
-
-import { RecentCards } from '@cardstack/host/utils/local-storage-keys';
 
 import type {
   IncrementalIndexEventContent,
@@ -677,10 +674,8 @@ module('Acceptance | interact submode tests', function (hooks) {
         'service:recent-cards-service',
       ) as RecentCardsService;
 
-      let firstStack = operatorModeStateService.state.stacks[0];
-      // @ts-ignore Property '#private' is missing in type 'Card[]' but required in type 'TrackedArray<Card>'.glint(2741) - don't care about this error here, just stubbing
-      recentCardsService.ascendingRecentCardIds = firstStack.map(
-        (item) => item.id,
+      operatorModeStateService.state.stacks[0].map((item) =>
+        recentCardsService.add(item.id),
       );
 
       assert.dom('[data-test-operator-mode-stack]').exists({ count: 1 });
@@ -784,9 +779,9 @@ module('Acceptance | interact submode tests', function (hooks) {
         'service:recent-cards-service',
       ) as RecentCardsService;
 
-      // @ts-ignore Property '#private' is missing in type 'Card[]' but required in type 'TrackedArray<Card>'.glint(2741) - don't care about this error here, just stubbing
-      recentCardsService.ascendingRecentCardIds =
-        operatorModeStateService.state.stacks[0].map((item) => item.id);
+      operatorModeStateService.state.stacks[0].map((item) =>
+        recentCardsService.add(item.id),
+      );
 
       assert.dom('[data-test-operator-mode-stack]').exists({ count: 1 });
       assert.dom('[data-test-add-card-left-stack]').exists();
@@ -1806,10 +1801,10 @@ module('Acceptance | interact submode tests', function (hooks) {
 
     test('Clicking search panel (without left and right buttons activated) replaces all cards in the rightmost stack', async function (assert) {
       // creates a recent search
-      window.localStorage.setItem(
-        RecentCards,
-        JSON.stringify([`${testRealmURL}Person/fadhlan`]),
-      );
+      let recentCardsService = this.owner.lookup(
+        'service:recent-cards-service',
+      ) as RecentCardsService;
+      recentCardsService.add(`${testRealmURL}Person/fadhlan`);
 
       await visitOperatorMode({
         stacks: [

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -28,9 +28,6 @@ import { Submodes } from '@cardstack/host/components/submode-switcher';
 import { tokenRefreshPeriodSec } from '@cardstack/host/services/realm';
 
 import {
-  PlaygroundSelections,
-  RecentCards,
-  RecentFiles,
   ScrollPositions,
   SessionLocalStorageKey,
 } from '@cardstack/host/utils/local-storage-keys';
@@ -50,6 +47,16 @@ import {
   setupRealmServerEndpoints,
 } from '../helpers';
 import { setupMockMatrix } from '../helpers/mock-matrix';
+import {
+  getPlaygroundSelections,
+  setPlaygroundSelections,
+} from '../helpers/playground';
+import {
+  getRecentCards,
+  setRecentCards,
+  getRecentFiles,
+  setRecentFiles,
+} from '../helpers/recent-files-cards';
 import { setupApplicationTest } from '../helpers/setup';
 
 let matrixRoomId: string;
@@ -1218,45 +1225,27 @@ module('Acceptance | operator mode tests', function (hooks) {
       await visitOperatorMode({
         stacks: [[{ id: `${testRealmURL}Person/fadhlan`, format: 'isolated' }]],
       });
-      window.localStorage.setItem(
-        RecentCards,
-        JSON.stringify(`${testRealmURL}Pet/mango.json`),
-      );
-      window.localStorage.setItem(
-        RecentFiles,
-        JSON.stringify([
-          [
-            testRealmURL,
-            'Pet/mango.json',
-            {
-              line: 1,
-              column: 2,
-            },
-          ],
-        ]),
-      );
+      setRecentCards([[`${testRealmURL}Pet/mango.json`, Date.now()]]);
+      setRecentFiles([
+        [testRealmURL, 'Pet/mango.json', { line: 1, column: 2 }, Date.now()],
+      ]);
+      setPlaygroundSelections({
+        [`${testRealmURL}Pet/mango.json`]: {
+          cardId: `${testRealmURL}Pet/mango.json`,
+          format: 'edit',
+        },
+      });
       window.localStorage.setItem(
         ScrollPositions,
         JSON.stringify({ 'file-tree': [`${testRealmURL}Pet/mango.json`, 2] }),
       );
-      window.localStorage.setItem(
-        PlaygroundSelections,
-        JSON.stringify({
-          [`${testRealmURL}Pet/mango.json`]: {
-            cardId: `${testRealmURL}Pet/mango.json`,
-            format: 'edit',
-          },
-        }),
-      );
+
       await click('[data-test-profile-icon-button]');
       await click('[data-test-signout-button]');
-      assert.strictEqual(window.localStorage.getItem(RecentCards), null);
-      assert.strictEqual(window.localStorage.getItem(RecentFiles), null);
+      assert.strictEqual(getRecentCards(), null);
+      assert.strictEqual(getRecentFiles(), null);
       assert.strictEqual(window.localStorage.getItem(ScrollPositions), null);
-      assert.strictEqual(
-        window.localStorage.getItem(PlaygroundSelections),
-        null,
-      );
+      assert.strictEqual(getPlaygroundSelections(), null);
 
       assert.dom('[data-test-login-btn]').exists();
     });

--- a/packages/host/tests/helpers/playground.ts
+++ b/packages/host/tests/helpers/playground.ts
@@ -3,10 +3,7 @@ import { click } from '@ember/test-helpers';
 import window from 'ember-window-mock';
 
 import type { PlaygroundSelection } from '@cardstack/host/services/playground-panel-service';
-import {
-  PlaygroundSelections,
-  RecentFiles,
-} from '@cardstack/host/utils/local-storage-keys';
+import { PlaygroundSelections } from '@cardstack/host/utils/local-storage-keys';
 
 import type { Format } from 'https://cardstack.com/base/card-api';
 
@@ -78,12 +75,13 @@ export const toggleSpecPanel = async () =>
   await click('[data-test-accordion-item="spec-preview"] button');
 
 // PlaygroundSelections
-export function getPlaygroundSelections():
-  | Record<string, PlaygroundSelection>
-  | undefined {
+export function getPlaygroundSelections(): Record<
+  string,
+  PlaygroundSelection
+> | null {
   let selections = window.localStorage.getItem(PlaygroundSelections);
   if (!selections) {
-    return;
+    return null;
   }
   return JSON.parse(selections);
 }
@@ -96,21 +94,4 @@ export function setPlaygroundSelections(
 
 export function removePlaygroundSelections() {
   window.localStorage.removeItem(PlaygroundSelections);
-}
-
-// RecentFiles
-export function getRecentFiles() {
-  let files = window.localStorage.getItem(RecentFiles);
-  if (!files) {
-    return;
-  }
-  return JSON.parse(files);
-}
-
-export function setRecentFiles(files: [string, string][]) {
-  window.localStorage.setItem(RecentFiles, JSON.stringify(files));
-}
-
-export function removeRecentFiles() {
-  window.localStorage.removeItem(RecentFiles);
 }

--- a/packages/host/tests/helpers/recent-files-cards.ts
+++ b/packages/host/tests/helpers/recent-files-cards.ts
@@ -1,0 +1,84 @@
+import window from 'ember-window-mock';
+
+import type { RecentFile } from '@cardstack/host/services/recent-files-service';
+import {
+  RecentFiles,
+  RecentCards,
+} from '@cardstack/host/utils/local-storage-keys';
+
+export function getRecentFileURL(recentFile: RecentFile) {
+  if (!recentFile) {
+    throw new Error(`recent file was not provided`);
+  }
+  return `${recentFile.realmURL}${recentFile.filePath}`;
+}
+
+export function assertRecentFileURLs(
+  assert: Assert,
+  recentFiles: RecentFile[],
+  fileURLs: string[],
+  message?: string,
+) {
+  assert.strictEqual(
+    recentFiles.length,
+    fileURLs.length,
+    'recent file count is correct',
+  );
+  recentFiles.map((recentFile, i) =>
+    assert.strictEqual(
+      getRecentFileURL(recentFile),
+      fileURLs[i],
+      message ?? `url is correct for recent file at index ${i}`,
+    ),
+  );
+}
+
+// direct manipulation of local storage:
+type RecentFiles =
+  | [string, string][]
+  | [string, string, { line: number; column: number } | null, number][];
+
+// RecentFiles
+export function getRecentFiles(): RecentFiles | null {
+  let files = window.localStorage.getItem(RecentFiles);
+  if (!files) {
+    return null;
+  }
+  return JSON.parse(files);
+}
+
+export function setRecentFiles(files: RecentFiles) {
+  let recentFiles = files.map(
+    ([realmURL, filePath, cursorPosition, timestamp]) => [
+      realmURL,
+      filePath,
+      cursorPosition ?? null,
+      timestamp ?? Date.now(),
+    ],
+  );
+  window.localStorage.setItem(RecentFiles, JSON.stringify(recentFiles));
+}
+
+export function removeRecentFiles() {
+  window.localStorage.removeItem(RecentFiles);
+}
+
+// RecentCards
+export function getRecentCards():
+  | { cardId: string; timestamp: number }[]
+  | null {
+  let cards = window.localStorage.getItem(RecentCards);
+  if (!cards) {
+    return null;
+  }
+  return JSON.parse(cards);
+}
+
+export function setRecentCards(cards: [string, number][]) {
+  let recentCards = cards.map(([cardId, timestamp]) => ({ cardId, timestamp }));
+  window.localStorage.setItem(RecentCards, JSON.stringify(recentCards));
+}
+
+export function removeRecentCards() {
+  window.localStorage.removeItem(RecentCards);
+}


### PR DESCRIPTION
- Include `timestamp` when persisting cards in RecentFilesService and RecentCardsService (had to update many tests due to this change)
- Combine recent-cards and recent-files ids in playground, order ids by timestamp, use the latest version if there are duplicates
- Sort prerendered-card search results by the same order provided by recentCardIds
- Moved recent-card and recent-file test helpers to a separate file from playground helpers