### PR TITLE
ci: Fix host preview workflow name

### DIFF
--- a/.github/workflows/pr-boxel-host.yml
+++ b/.github/workflows/pr-boxel-host.yml
@@ -1,4 +1,4 @@
-name: CI [boxel-host]
+name: CI Preview Host
 
 on:
   pull_request:


### PR DESCRIPTION
The preview workflow’s name doesn’t currently distinguish it from the test workflow:

<img width="590" alt="boxel 2025-05-14 13-48-52" src="https://github.com/user-attachments/assets/cf943020-dfec-461a-aa57-cb140e356c38" />

Maybe some higher-level nomenclature attention is needed but that probably requires more discussion:

<img width="275" alt="boxel 2025-05-14 14-08-13" src="https://github.com/user-attachments/assets/8c707809-f7a2-42f0-8e08-b5997d5cd568" />

I’m leaving the Percy diff unapproved, it’s the same Monaco noise.