### PR TITLE
Fixing dollar curly parsing bug

### DIFF
--- a/packages/realm-server/tests/module-syntax-test.ts
+++ b/packages/realm-server/tests/module-syntax-test.ts
@@ -1,5 +1,9 @@
 import { module, test } from 'qunit';
-import { ModuleSyntax } from '@cardstack/runtime-common/module-syntax';
+import {
+  ModuleSyntax,
+  gjsToPlaceholderJS,
+  placeholderJSToGJS,
+} from '@cardstack/runtime-common/module-syntax';
 
 import { baseCardRef, baseFieldRef } from '@cardstack/runtime-common';
 import { testRealm } from './helpers';
@@ -1347,5 +1351,22 @@ module(basename(__filename), function () {
         );
       }
     });
+  });
+  module('gjs-to-placeholder', function () {
+    const examples = [
+      `<template>Greetings ")]</template>`,
+      '<template>${{stuff}}</template>',
+      `<template>
+        Hello
+       </template>`,
+    ];
+    for (let example of examples) {
+      test('round-trip gjs placeholders', async function (assert) {
+        assert.strictEqual(
+          placeholderJSToGJS(gjsToPlaceholderJS(example)),
+          example,
+        );
+      });
+    }
   });
 });

--- a/packages/realm-server/tests/module-syntax-test.ts
+++ b/packages/realm-server/tests/module-syntax-test.ts
@@ -1368,5 +1368,21 @@ module(basename(__filename), function () {
         );
       });
     }
+
+    test('preserves line numbers', function (assert) {
+      let src = `
+        console.log(
+          <template>
+            Hi
+          </template>
+        );
+        console.log('after');
+      `;
+      assert.strictEqual(
+        gjsToPlaceholderJS(src).split('\n')[6],
+        src.split('\n')[6],
+        `expecting lines to be preserved in:\n${gjsToPlaceholderJS(src)}`,
+      );
+    });
   });
 });

--- a/packages/realm-server/tests/module-syntax-test.ts
+++ b/packages/realm-server/tests/module-syntax-test.ts
@@ -86,7 +86,7 @@ module(basename(__filename), function () {
         @field firstName = contains(StringField);
         @field age = contains(NumberField);
         static embedded = class Embedded extends Component<typeof this> {
-          <template><h1><@fields.firstName/></h1></template>                
+          <template><h1><@fields.firstName/></h1></template>
         }
       }
       `,
@@ -187,7 +187,7 @@ module(basename(__filename), function () {
             @field firstName = contains(StringField);
             @field age = contains(NumberField);
             static embedded = class Embedded extends Component<typeof this> {
-                <template><h1><@fields.firstName/></h1></template>                
+                <template><h1><@fields.firstName/></h1></template>
             }
         }
       `,
@@ -217,7 +217,7 @@ module(basename(__filename), function () {
         export class Person extends CardDef {
           @field age = contains(NumberField);
           static embedded = class Embedded extends Component<typeof this> {
-            <template><h1><@fields.firstName/></h1></template>                
+            <template><h1><@fields.firstName/></h1></template>
           }
         }
       `,
@@ -251,7 +251,7 @@ module(basename(__filename), function () {
         `
         import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
         import StringField from "https://cardstack.com/base/string";
-        export class Person extends CardDef { }
+        export class Person extends CardDef {}
       `,
       );
 
@@ -261,7 +261,7 @@ module(basename(__filename), function () {
         import NumberField from "https://cardstack.com/base/number";
         import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
         import StringField from "https://cardstack.com/base/string";
-        export class Person extends CardDef { 
+        export class Person extends CardDef {
           @field age = contains(NumberField);
         }
       `,
@@ -315,7 +315,7 @@ module(basename(__filename), function () {
             @field age = contains(NumberField);
             @field firstName = contains(StringField);
             static embedded = class Embedded extends Component<typeof this> {
-                <template><h1><@fields.firstName/></h1></template>                
+                <template><h1><@fields.firstName/></h1></template>
             }
         }
       `,

--- a/packages/runtime-common/module-syntax.ts
+++ b/packages/runtime-common/module-syntax.ts
@@ -352,7 +352,12 @@ export function gjsToPlaceholderJS(
     output.push(srcArray.slice(offset, match.range.startChar).join(''));
     output.push(`[${placeholder}(`);
     output.push(JSON.stringify(match.contents));
-    output.push(`,"${placeholder}")]`);
+    output.push(',');
+    // Adding newlines to preserve the overall line numbers in the file
+    for (let line = 0; line < match.contents.split('\n').length - 1; line++) {
+      output.push('\n');
+    }
+    output.push(`"${placeholder}")]`);
     offset = match.range.endChar;
   }
   output.push(srcArray.slice(offset).join(''));
@@ -361,7 +366,7 @@ export function gjsToPlaceholderJS(
 
 export function placeholderJSToGJS(src: string): string {
   return src.replace(
-    /\[templatePlaceholder\((".*?"),"templatePlaceholder"\)\]/g,
+    /\[templatePlaceholder\((".*?"),\n*"templatePlaceholder"\)\]/g,
     (_m, group) => `<template>${JSON.parse(group)}</template>`,
   );
 }

--- a/packages/runtime-common/module-syntax.ts
+++ b/packages/runtime-common/module-syntax.ts
@@ -352,7 +352,7 @@ export function gjsToPlaceholderJS(
     output.push(srcArray.slice(offset, match.range.startChar).join(''));
     output.push(`[${placeholder}(`);
     output.push(JSON.stringify(match.contents));
-    output.push(')]');
+    output.push(`,"${placeholder}")]`);
     offset = match.range.endChar;
   }
   output.push(srcArray.slice(offset).join(''));
@@ -361,7 +361,7 @@ export function gjsToPlaceholderJS(
 
 export function placeholderJSToGJS(src: string): string {
   return src.replace(
-    /\[templatePlaceholder\((".*?")\)\]/g,
+    /\[templatePlaceholder\((".*?"),"templatePlaceholder"\)\]/g,
     (_m, group) => `<template>${JSON.parse(group)}</template>`,
   );
 }


### PR DESCRIPTION
This replaces the whole JS-representation with one that hopefully isn't sensitive to string escaping problems.

~The previous implementation looks like it attempted to preserve offsets, but it definitely didn't actually, and we confirmed that it doesn't matter if it does.~

The previous implementation attempted to preserve offsets, but had off-by-some-small-amount errors when escaping backticks inside templates. Our new implementation only preserve lines, not exact offsets, which is good enough for our present use cases.

It would be good to refactor ModuleSyntax to have a more explicit API for asking about source locations, because we could fairly easily give precise, adjusted answers. At present it leaks a lot of AST internals instead, which are inconvenient to try to wrap/mutate.