### PR TITLE
Changed to a more specific selector to target only grid-view layouts

### DIFF
--- a/packages/catalog-realm-dev/catalog-app/catalog.gts
+++ b/packages/catalog-realm-dev/catalog-app/catalog.gts
@@ -177,12 +177,12 @@ class ShowcaseView extends GlimmerComponent<ShowcaseViewArgs> {
       .showcase-display-container > * + * {
         border-top: 1px solid #999999;
       }
-      .showcase-cards-display :deep(.cards),
-      .featured-cards-display :deep(.cards) {
+      .showcase-cards-display :deep(.cards.grid-view),
+      .featured-cards-display :deep(.cards.grid-view) {
         --grid-view-height: 440px;
         grid-template-columns: repeat(2, 1fr);
       }
-      .new-this-week-cards-display :deep(.cards) {
+      .new-this-week-cards-display :deep(.cards.grid-view) {
         --grid-view-height: 320px;
         grid-template-columns: repeat(4, 1fr);
       }
@@ -198,18 +198,18 @@ class ShowcaseView extends GlimmerComponent<ShowcaseViewArgs> {
       }
 
       @container showcase-display-container (inline-size <= 768px) {
-        .showcase-cards-display :deep(.cards),
-        .featured-cards-display :deep(.cards) {
+        .showcase-cards-display :deep(.cards.grid-view),
+        .featured-cards-display :deep(.cards.grid-view) {
           --grid-view-height: 380px;
         }
-        .new-this-week-cards-display :deep(.cards) {
+        .new-this-week-cards-display :deep(.cards.grid-view) {
           grid-template-columns: repeat(2, 1fr);
         }
 
         @container showcase-display-container (inline-size <= 500px) {
-          .showcase-cards-display :deep(.cards),
-          .new-this-week-cards-display :deep(.cards),
-          .featured-cards-display :deep(.cards) {
+          .showcase-cards-display :deep(.cards.grid-view),
+          .new-this-week-cards-display :deep(.cards.grid-view),
+          .featured-cards-display :deep(.cards.grid-view) {
             grid-template-columns: 1fr;
           }
         }


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-8637/fix-catalog-showcase-grid

Updated the selector from .showcase-cards-display :deep(.cards) to .showcase-cards-display :deep(.cards.grid-view) to apply styles only when the cards are displayed in grid view. This change makes the selector more specific

Before:
![image](https://github.com/user-attachments/assets/4922067d-9ba5-46e3-beb5-bb96ad98df3b)

Result:
![image](https://github.com/user-attachments/assets/bf7c7836-5134-444e-8d9c-15140075ff1c)
