### PR TITLE
Cs 8542 dropdown realm shud have icons

### DIFF
--- a/packages/catalog-realm-dev/catalog-app/components/listing-fitted.gts
+++ b/packages/catalog-realm-dev/catalog-app/components/listing-fitted.gts
@@ -341,7 +341,8 @@ class CarouselComponent extends GlimmerComponent<Signature> {
 
 export class ListingFittedTemplate extends Component<typeof Listing> {
   @tracked installedListing = false;
-  @tracked writableRealms: string[] = [];
+  @tracked writableRealms: { name: string; url: string; iconURL?: string }[] =
+    [];
   roomId: string | null = null;
 
   constructor(owner: any, args: any) {
@@ -354,11 +355,12 @@ export class ListingFittedTemplate extends Component<typeof Listing> {
   });
 
   get remixRealmOptions() {
-    return this.writableRealms.map((realmUrl) => {
-      return new MenuItem(realmUrl, 'action', {
+    return this.writableRealms.map((realm) => {
+      return new MenuItem(realm.name, 'action', {
         action: () => {
-          this.remix(realmUrl);
+          this.remix(realm.url);
         },
+        iconURL: realm.iconURL ?? undefined,
       });
     });
   }
@@ -495,8 +497,10 @@ export class ListingFittedTemplate extends Component<typeof Listing> {
             </:trigger>
             <:content as |dd|>
               <BoxelMenu
+                class='realm-dropdown-menu'
                 @closeMenu={{dd.close}}
                 @items={{this.remixRealmOptions}}
+                data-test-catalog-listing-remix-dropdown
               />
             </:content>
           </BoxelDropdown>
@@ -577,6 +581,14 @@ export class ListingFittedTemplate extends Component<typeof Listing> {
           --boxel-button-font: 600 var(--boxel-font-sm);
           margin-left: auto;
           flex: 0 0 auto;
+        }
+        .realm-dropdown-menu {
+          --boxel-menu-item-content-padding: var(--boxel-sp-xs);
+          --boxel-menu-item-gap: var(--boxel-sp-xs);
+          min-width: 13rem;
+        }
+        .realm-dropdown-menu :deep(.menu-item__icon-url) {
+          border-radius: var(--boxel-border-radius-xs);
         }
       }
 

--- a/packages/catalog-realm-dev/catalog-app/components/listing-fitted.gts
+++ b/packages/catalog-realm-dev/catalog-app/components/listing-fitted.gts
@@ -586,6 +586,8 @@ export class ListingFittedTemplate extends Component<typeof Listing> {
           --boxel-menu-item-content-padding: var(--boxel-sp-xs);
           --boxel-menu-item-gap: var(--boxel-sp-xs);
           min-width: 13rem;
+          max-height: 13rem;
+          overflow-y: scroll;
         }
         .realm-dropdown-menu :deep(.menu-item__icon-url) {
           border-radius: var(--boxel-border-radius-xs);

--- a/packages/catalog-realm-dev/catalog-app/listing/listing.gts
+++ b/packages/catalog-realm-dev/catalog-app/listing/listing.gts
@@ -394,6 +394,7 @@ class EmbeddedTemplate extends Component<typeof Listing> {
                     class='realm-dropdown-menu'
                     @closeMenu={{dd.close}}
                     @items={{this.useRealmOptions}}
+                    data-test-catalog-listing-use-dropdown
                   />
                 </:content>
               </BoxelDropdown>
@@ -419,6 +420,7 @@ class EmbeddedTemplate extends Component<typeof Listing> {
                     class='realm-dropdown-menu'
                     @closeMenu={{dd.close}}
                     @items={{this.installRealmOptions}}
+                    data-test-catalog-listing-install-dropdown
                   />
                 </:content>
               </BoxelDropdown>

--- a/packages/catalog-realm-dev/catalog-app/listing/listing.gts
+++ b/packages/catalog-realm-dev/catalog-app/listing/listing.gts
@@ -391,6 +391,7 @@ class EmbeddedTemplate extends Component<typeof Listing> {
                 </:trigger>
                 <:content as |dd|>
                   <BoxelMenu
+                    class='realm-dropdown-menu'
                     @closeMenu={{dd.close}}
                     @items={{this.useRealmOptions}}
                   />
@@ -415,6 +416,7 @@ class EmbeddedTemplate extends Component<typeof Listing> {
                 </:trigger>
                 <:content as |dd|>
                   <BoxelMenu
+                    class='realm-dropdown-menu'
                     @closeMenu={{dd.close}}
                     @items={{this.installRealmOptions}}
                   />
@@ -584,6 +586,16 @@ class EmbeddedTemplate extends Component<typeof Listing> {
       }
       .action-button {
         flex: 1;
+      }
+      .realm-dropdown-menu {
+        --boxel-menu-item-content-padding: var(--boxel-sp-xs);
+        --boxel-menu-item-gap: var(--boxel-sp-xs);
+        min-width: 13rem;
+        max-height: 13rem;
+        overflow-y: scroll;
+      }
+      .realm-dropdown-menu :deep(.menu-item__icon-url) {
+        border-radius: var(--boxel-border-radius-xs);
       }
       .app-listing-embedded
         :deep(.ember-basic-dropdown-content-wormhole-origin) {

--- a/packages/catalog-realm-dev/catalog-app/listing/listing.gts
+++ b/packages/catalog-realm-dev/catalog-app/listing/listing.gts
@@ -170,14 +170,19 @@ export async function installListing(args: any, realmUrl: string) {
 export async function setupAllRealmsInfo(args: any) {
   let allRealmsInfo =
     (await (args.context?.actions as Actions)?.allRealmsInfo?.()) ?? {};
-  let writableRealms: string[] = [];
+  let writableRealms: { name: string; url: string; iconURL?: string }[] = [];
   if (allRealmsInfo) {
     Object.entries(allRealmsInfo).forEach(([realmUrl, realmInfo]) => {
       if (realmInfo.canWrite) {
-        writableRealms.push(realmUrl);
+        writableRealms.push({
+          name: realmInfo.info.name,
+          url: realmUrl,
+          iconURL: realmInfo.info.iconURL ?? '/default-realm-icon.png',
+        });
       }
     });
   }
+  writableRealms.sort((a, b) => a.name.localeCompare(b.name));
   return writableRealms;
 }
 
@@ -185,7 +190,8 @@ class EmbeddedTemplate extends Component<typeof Listing> {
   @tracked selectedAccordionItem: string | undefined;
   @tracked createdInstances = false;
   @tracked installedListing = false;
-  @tracked writableRealms: string[] = [];
+  @tracked writableRealms: { name: string; url: string; iconURL?: string }[] =
+    [];
 
   constructor(owner: any, args: any) {
     super(owner, args);
@@ -193,21 +199,23 @@ class EmbeddedTemplate extends Component<typeof Listing> {
   }
 
   get useRealmOptions() {
-    return this.writableRealms.map((realmUrl) => {
-      return new MenuItem(realmUrl, 'action', {
+    return this.writableRealms.map((realm) => {
+      return new MenuItem(realm.name, 'action', {
         action: () => {
-          this.use(realmUrl);
+          this.use(realm.url);
         },
+        iconURL: realm.iconURL ?? undefined,
       });
     });
   }
 
   get installRealmOptions() {
-    return this.writableRealms.map((realmUrl) => {
-      return new MenuItem(realmUrl, 'action', {
+    return this.writableRealms.map((realm) => {
+      return new MenuItem(realm.name, 'action', {
         action: () => {
-          this.install(realmUrl);
+          this.install(realm.url);
         },
+        iconURL: realm.iconURL ?? undefined,
       });
     });
   }


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-8542/dropdown-realm-shud-have-icons

1. add realm icon and display realm name to remix dropdown
2. add max-height for the dropdown



Result:
![image](https://github.com/user-attachments/assets/bb6bb174-8776-4a9e-8cea-4a7536b89b0d)
