### PR TITLE
host: Fix post-merge test failure

### DIFF
--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -869,15 +869,17 @@ module('Acceptance | interact submode tests', function (hooks) {
       });
       id = id!;
 
-      let recentCards: string[] = JSON.parse(
-        window.localStorage.getItem(RecentCards) ?? '[]',
-      );
+      let recentCardsService = this.owner.lookup(
+        'service:recent-cards-service',
+      ) as RecentCardsService;
+
+      let recentCards = recentCardsService.recentCards;
       assert.ok(
-        recentCards.find((i) => i === id),
+        recentCards.find((card) => card.cardId === id),
         `the newly created card's remote id is in recent cards`,
       );
       assert.notOk(
-        recentCards.find((i) => isLocalId(i)),
+        recentCards.find((card) => isLocalId(card.cardId)),
         `no local ID's are in recent cards`,
       );
     });


### PR DESCRIPTION
#2581 changed how recent cards are asserted on but #2596 used the old way.

This is failing on `main` in [linting](https://github.com/cardstack/boxel/actions/runs/15070296557/job/42364672463#step:15:28) and [tests](https://github.com/cardstack/boxel/actions/runs/15071740025/job/42369539627#step:11:343).