### PR TITLE
Change monaco-editor theme to be dark

### DIFF
--- a/packages/host/app/components/ai-assistant/code-block.gts
+++ b/packages/host/app/components/ai-assistant/code-block.gts
@@ -352,6 +352,7 @@ class CodeBlockEditor extends Component<Signature> {
     padding: {
       bottom: 8,
     },
+    theme: 'vs-dark',
   };
 
   <template>
@@ -397,6 +398,7 @@ class CodeBlockDiffEditor extends Component<Signature> {
     padding: {
       bottom: 8,
     },
+    theme: 'vs-dark',
   };
 
   <template>

--- a/packages/host/app/components/ai-assistant/formatted-aibot-message.gts
+++ b/packages/host/app/components/ai-assistant/formatted-aibot-message.gts
@@ -221,16 +221,16 @@ export default class FormattedAiBotMessage extends Component<FormattedAiBotMessa
         max-height: 30vh;
       }
 
-      /*
-        This filter is a best-effort approximation of a good looking dark theme that is a function of the white theme that
-        we use for code previews in the AI panel. While Monaco editor does support multiple themes, it does not support
-        monaco instances with different themes *on the same page*. This is why we are using a filter to approximate the
-        dark theme. More details here: https://github.com/Microsoft/monaco-editor/issues/338 (monaco uses global style tags
-        with hardcoded colors; any instance will override the global style tag, making all code editors look the same,
-        effectively disabling multiple themes to be used on the same page)
-      */
+      /* our dark-mode background-color is too similar to AI-Assistant message background,
+        so we are using a darker background for code-blocks */
       :global(.code-block .monaco-editor) {
-        filter: invert(1) hue-rotate(151deg) brightness(0.8) grayscale(0.1);
+        --vscode-editor-background: var(--boxel-dark);
+        --vscode-editorGutter-background: var(--boxel-dark);
+      }
+
+      /* this improves inserted-line legibility by reducing green background overlay opacity */
+      :global(.code-block .monaco-editor .line-insert) {
+        opacity: 0.4;
       }
     </style>
   </template>

--- a/packages/host/app/components/operator-mode/code-editor.gts
+++ b/packages/host/app/components/operator-mode/code-editor.gts
@@ -395,21 +395,31 @@ export default class CodeEditor extends Component<Signature> {
 
     <style scoped>
       .monaco-container {
-        --monaco-background: var(--boxel-600);
-        --monaco-readonly-background: #606060;
         height: 100%;
         min-height: 100%;
         width: 100%;
         min-width: 100%;
-        padding-block: var(--boxel-sp);
+        padding-top: var(--boxel-sp);
         background-color: var(--monaco-background);
       }
       .monaco-container:not(.readonly) {
         filter: contrast(1.05) brightness(1.05);
       }
       .monaco-container.readonly {
-        background-color: var(--monaco-readonly-background);
+        --monaco-background: var(--monaco-readonly-background);
         filter: contrast(1.1) saturate(1.1);
+      }
+      .monaco-container :deep(.monaco-editor) {
+        --vscode-editor-background: var(--monaco-background);
+        --vscode-editorStickyScroll-background: var(--monaco-background);
+        --vscode-editorGutter-background: var(--monaco-background);
+      }
+      .monaco-container.readonly :deep(.monaco-editor) {
+        --vscode-editorStickyScroll-shadow: #393939;
+      }
+      .monaco-container.readonly
+        :deep(.monaco-editor .view-overlays .current-line-exact) {
+        border-color: #454545;
       }
       .loading {
         margin: 40vh auto;

--- a/packages/host/app/components/operator-mode/code-editor.gts
+++ b/packages/host/app/components/operator-mode/code-editor.gts
@@ -399,7 +399,7 @@ export default class CodeEditor extends Component<Signature> {
         min-height: 100%;
         width: 100%;
         min-width: 100%;
-        padding-top: var(--boxel-sp);
+        padding-top: var(--boxel-sp-xxs);
         background-color: var(--monaco-background);
       }
       .monaco-container:not(.readonly) {
@@ -413,9 +413,11 @@ export default class CodeEditor extends Component<Signature> {
         --vscode-editor-background: var(--monaco-background);
         --vscode-editorStickyScroll-background: var(--monaco-background);
         --vscode-editorGutter-background: var(--monaco-background);
+        --vscode-editorStickyScroll-shadow: rgba(0 0 0 / 40%);
+        --vscode-scrollbar-shadow: rgba(0 0 0 / 20%);
       }
-      .monaco-container.readonly :deep(.monaco-editor) {
-        --vscode-editorStickyScroll-shadow: #393939;
+      .monaco-container :deep(.monaco-editor .sticky-widget) {
+        box-shadow: 0 1px 25px -2px var(--vscode-editorStickyScroll-shadow);
       }
       .monaco-container.readonly
         :deep(.monaco-editor .view-overlays .current-line-exact) {

--- a/packages/host/app/components/operator-mode/code-editor.gts
+++ b/packages/host/app/components/operator-mode/code-editor.gts
@@ -395,25 +395,22 @@ export default class CodeEditor extends Component<Signature> {
 
     <style scoped>
       .monaco-container {
+        --monaco-background: var(--boxel-600);
+        --monaco-readonly-background: #606060;
         height: 100%;
         min-height: 100%;
         width: 100%;
         min-width: 100%;
-        padding: var(--boxel-sp) 0;
+        padding-block: var(--boxel-sp);
+        background-color: var(--monaco-background);
       }
-
-      :global(.monaco-container.readonly) {
-        background-color: #ebeaed;
+      .monaco-container:not(.readonly) {
+        filter: contrast(1.05) brightness(1.05);
       }
-
-      :global(.monaco-container.readonly .margin) {
-        background-color: #ebeaed;
+      .monaco-container.readonly {
+        background-color: var(--monaco-readonly-background);
+        filter: contrast(1.1) saturate(1.1);
       }
-
-      :global(.monaco-container.readonly .monaco-editor-background) {
-        background-color: #ebeaed;
-      }
-
       .loading {
         margin: 40vh auto;
       }

--- a/packages/host/app/components/operator-mode/code-editor.gts
+++ b/packages/host/app/components/operator-mode/code-editor.gts
@@ -417,7 +417,7 @@ export default class CodeEditor extends Component<Signature> {
         --vscode-scrollbar-shadow: rgba(0 0 0 / 20%);
       }
       .monaco-container :deep(.monaco-editor .sticky-widget) {
-        box-shadow: 0 1px 25px -2px var(--vscode-editorStickyScroll-shadow);
+        box-shadow: 0 1px 15px -2px var(--vscode-editorStickyScroll-shadow);
       }
       .monaco-container.readonly
         :deep(.monaco-editor .view-overlays .current-line-exact) {

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -877,6 +877,10 @@ export default class CodeSubmode extends Component<Signature> {
       .monaco-editor-panel {
         background-color: var(--monaco-background);
       }
+      .monaco-editor-panel :deep(.binary-info) {
+        --icon-color: var(--boxel-light);
+        color: var(--boxel-light);
+      }
 
       .choose-file-prompt {
         margin: 0;

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -737,7 +737,7 @@ export default class CodeSubmode extends Component<Signature> {
               @defaultSize={{this.defaultPanelWidths.codeEditorPanel}}
               @minSize={{20}}
             >
-              <InnerContainer>
+              <InnerContainer class='monaco-editor-panel'>
                 {{#if this.isReady}}
                   <CodeEditor
                     @file={{this.currentOpenFile}}
@@ -831,6 +831,8 @@ export default class CodeSubmode extends Component<Signature> {
           var(--operator-mode-top-bar-item-height) +
             (2 * (var(--operator-mode-spacing)))
         );
+        --monaco-background: var(--boxel-600);
+        --monaco-readonly-background: #606060;
       }
 
       .code-mode {
@@ -870,6 +872,10 @@ export default class CodeSubmode extends Component<Signature> {
 
       .recent-files-panel {
         background-color: var(--code-mode-panel-background-color);
+      }
+
+      .monaco-editor-panel {
+        background-color: var(--monaco-background);
       }
 
       .choose-file-prompt {

--- a/packages/host/app/modifiers/monaco.ts
+++ b/packages/host/app/modifiers/monaco.ts
@@ -103,7 +103,7 @@ export default class Monaco extends Modifier<Signature> {
   }: Omit<Signature['Args']['Named'], 'initialCursorPosition'> & {
     element: HTMLElement;
   }) {
-    monacoSDK.editor.defineTheme('boxel-dark-theme', {
+    monacoSDK.editor.defineTheme('boxel-monaco-dark-theme', {
       base: 'vs-dark', // base themes: vs, vs-dark
       inherit: true,
       rules: [],
@@ -122,7 +122,7 @@ export default class Monaco extends Modifier<Signature> {
       minimap: {
         enabled: false,
       },
-      theme: 'boxel-dark-theme',
+      theme: 'boxel-monaco-dark-theme',
       ...editorDisplayOptions,
     };
 

--- a/packages/host/app/modifiers/monaco.ts
+++ b/packages/host/app/modifiers/monaco.ts
@@ -109,7 +109,6 @@ export default class Monaco extends Modifier<Signature> {
       rules: [],
       colors: {
         'editor.background': readOnly ? '#606060' : '#413e4e',
-        // see editor outer container styling in `components/operator-mode/code-editor.gts`
       },
     });
 

--- a/packages/host/app/modifiers/monaco.ts
+++ b/packages/host/app/modifiers/monaco.ts
@@ -103,17 +103,13 @@ export default class Monaco extends Modifier<Signature> {
   }: Omit<Signature['Args']['Named'], 'initialCursorPosition'> & {
     element: HTMLElement;
   }) {
-    // The light theme editor is used for the main editor in code mode,
-    // but we also have a dark themed editor for the preview editor in AI panel.
-    // The latter is themed using a CSS filter as opposed to defining a new monaco theme
-    // because monaco does not support multiple themes on the same page (check the comment in
-    // room-message-command.gts for more details)
-    monacoSDK.editor.defineTheme('boxel-monaco-light-theme', {
-      base: 'vs',
+    monacoSDK.editor.defineTheme('boxel-dark-theme', {
+      base: 'vs-dark', // base themes: vs, vs-dark
       inherit: true,
       rules: [],
       colors: {
-        'editor.background': '#FFFFFF',
+        'editor.background': readOnly ? '#606060' : '#413e4e',
+        // see editor outer container styling in `components/operator-mode/code-editor.gts`
       },
     });
 
@@ -121,12 +117,12 @@ export default class Monaco extends Modifier<Signature> {
       readOnly,
       value: content,
       language,
-      scrollBeyondLastLine: false,
+      scrollBeyondLastLine: true,
       automaticLayout: true,
       minimap: {
         enabled: false,
       },
-      theme: 'boxel-monaco-light-theme',
+      theme: 'boxel-dark-theme',
       ...editorDisplayOptions,
     };
 

--- a/packages/host/tests/acceptance/code-submode/editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/editor-test.ts
@@ -713,7 +713,7 @@ module('Acceptance | code submode | editor tests', function (hooks) {
         window
           .getComputedStyle(find('.monaco-editor-background')!)
           .getPropertyValue('background-color')!,
-        'rgb(235, 234, 237)', // equivalent to #ebeaed
+        'rgb(96, 96, 96)', // equivalent to #606060
         'monaco editor is greyed out when read-only',
       );
 


### PR DESCRIPTION
Switch to "vs-dark" base monaco theme:
- regular editor background: #413e4e 
 - read-only editor background: #606060
 - kept default dark for AI-panel code blocks because #413e4e is too similar to AI assistant message background
 
Monaco editor and AI Panel view-code block:
<img width="1867" alt="view-code" src="https://github.com/user-attachments/assets/42cc2490-6a3c-4d1f-8848-02a374e84cec" />

Diff editor:
<img width="1892" alt="diff-editor" src="https://github.com/user-attachments/assets/281683cc-323d-4785-87d3-395a207c838d" />

Read-only editor:
<img width="1618" alt="read-only-editor" src="https://github.com/user-attachments/assets/82726311-632a-4c92-adbb-b4ff0d7fbef9" />
