### PR TITLE
Avoid re-executing already executed commands

### DIFF
--- a/packages/host/app/services/command-service.ts
+++ b/packages/host/app/services/command-service.ts
@@ -147,7 +147,7 @@ export default class CommandService extends Service {
         if (this.executedCommandRequestIds.has(messageCommand.id!)) {
           continue;
         }
-        if (messageCommand.commandResultFileDef) {
+        if (messageCommand.status === 'applied') {
           continue;
         }
         if (!messageCommand.name) {


### PR DESCRIPTION
- commands with requiresApproval === false and no result card would be re-executed on load, wreaking havok