### PR TITLE
ui: Change select icon to invert on vertical above

### DIFF
--- a/packages/boxel-ui/addon/src/components/select/index.gts
+++ b/packages/boxel-ui/addon/src/components/select/index.gts
@@ -4,6 +4,8 @@ import PowerSelect, {
 } from 'ember-power-select/components/power-select';
 import BeforeOptions from 'ember-power-select/components/power-select/before-options';
 
+import { eq } from '@cardstack/boxel-ui/helpers';
+
 import cn from '../../helpers/cn.ts';
 import { BoxelSelectDefaultTrigger } from './trigger.gts';
 
@@ -37,7 +39,11 @@ const BoxelSelect: TemplateOnlyComponent<Signature> = <template>
     {{! We can avoid providing arguments to the triggerComponent as long as they are specified here https://github.com/cibernox/ember-power-select/blob/913c85ec82d5c6aeb80a7a3b9d9c21ca9613e900/ember-power-select/src/components/power-select.hbs#L79-L106 }}
     {{! Even the custom BoxelTriggerWrapper will receive these arguments }}
     @triggerComponent={{(if
-      @triggerComponent @triggerComponent (component BoxelSelectDefaultTrigger)
+      @triggerComponent
+      @triggerComponent
+      (component
+        BoxelSelectDefaultTrigger invertIcon=(eq @verticalPosition 'above')
+      )
     )}}
     @disabled={{@disabled}}
     @matchTriggerWidth={{@matchTriggerWidth}}

--- a/packages/boxel-ui/addon/src/components/select/index.gts
+++ b/packages/boxel-ui/addon/src/components/select/index.gts
@@ -1,10 +1,9 @@
+import { eq } from '@cardstack/boxel-ui/helpers';
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import PowerSelect, {
   type PowerSelectArgs,
 } from 'ember-power-select/components/power-select';
 import BeforeOptions from 'ember-power-select/components/power-select/before-options';
-
-import { eq } from '@cardstack/boxel-ui/helpers';
 
 import cn from '../../helpers/cn.ts';
 import { BoxelSelectDefaultTrigger } from './trigger.gts';

--- a/packages/boxel-ui/addon/src/components/select/trigger.gts
+++ b/packages/boxel-ui/addon/src/components/select/trigger.gts
@@ -7,10 +7,10 @@ import CaretDown from '../../icons/caret-down.gts';
 
 export interface TriggerSignature {
   Args: {
+    invertIcon?: boolean;
     placeholder?: string;
     select: Select;
     selectedItemComponent?: any;
-    invertIcon?: boolean;
   };
   Blocks: {
     default: [Select['selected'], Select];

--- a/packages/boxel-ui/addon/src/components/select/trigger.gts
+++ b/packages/boxel-ui/addon/src/components/select/trigger.gts
@@ -10,6 +10,7 @@ export interface TriggerSignature {
     placeholder?: string;
     select: Select;
     selectedItemComponent?: any;
+    invertIcon?: boolean;
   };
   Blocks: {
     default: [Select['selected'], Select];
@@ -93,7 +94,11 @@ export class BoxelSelectDefaultTrigger extends Component<TriggerSignature> {
       </:default>
       <:icon>
         <CaretDown
-          class={{cn 'icon' (if @select.isOpen 'is-open')}}
+          class={{cn
+            'icon'
+            (if @select.isOpen 'is-open')
+            (if @invertIcon 'is-inverted')
+          }}
           data-test-caret-down
         />
       </:icon>
@@ -106,6 +111,14 @@ export class BoxelSelectDefaultTrigger extends Component<TriggerSignature> {
       }
       .is-open {
         transform: rotate(180deg);
+      }
+
+      .icon.is-inverted {
+        transform: rotate(180deg);
+      }
+
+      .icon.is-inverted.is-open {
+        transform: rotate(0deg);
       }
     </style>
   </template>


### PR DESCRIPTION
From Chris Gardella:

> Maybe we make both chevron and triangle orient in direction of panel/dropdown opening?

This extracts styling [like this](https://github.com/cardstack/boxel/pull/2563/files#diff-6a914ab5a25c7ef89e33bb1b807e777908d2c60bec93998adf923b4495fcf40aR240-R248) into Boxel UI.

![screencast 2025-05-22 09-59-11](https://github.com/user-attachments/assets/cdc968c6-8fe0-4b9a-a4c9-982586e74742)
