### PR TITLE
Remove any 'future' events from the event list to avoid double responses

### DIFF
--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -218,7 +218,8 @@ Common issues are:
         }
 
         let promptParts: PromptParts;
-        let eventList = await getRoomEvents(room.roomId, client);
+        let eventList = await getRoomEvents(room.roomId, client, event.getId());
+
         try {
           promptParts = await getPromptParts(eventList, aiBotUserId, client);
           if (!promptParts.shouldRespond) {
@@ -344,7 +345,7 @@ Common issues are:
     );
     try {
       //TODO: optimise this so we don't need to sync room events within a reaction event
-      let eventList = await getRoomEvents(room.roomId, client);
+      let eventList = await getRoomEvents(room.roomId, client, event.getId());
       if (roomTitleAlreadySet(eventList)) {
         return;
       }

--- a/packages/ai-bot/tests/helpers/fake-matrix-client.ts
+++ b/packages/ai-bot/tests/helpers/fake-matrix-client.ts
@@ -1,5 +1,6 @@
 import type { IContent } from 'matrix-js-sdk';
 import type { MatrixClient } from '../../lib/matrix/util';
+import { Method } from 'matrix-js-sdk';
 
 export class FakeMatrixClient implements MatrixClient {
   private eventId = 0;
@@ -9,6 +10,23 @@ export class FakeMatrixClient implements MatrixClient {
     eventType: string;
     content: IContent;
   }[] = [];
+
+  // Add http property for testing
+  http: {
+    authedRequest: (
+      method: Method,
+      path: string,
+      queryParams: any,
+    ) => Promise<any>;
+  } = {
+    authedRequest: async (
+      _method: Method,
+      _path: string,
+      _queryParams: any,
+    ) => {
+      return { chunk: [] };
+    },
+  };
 
   async sendEvent(
     roomId: string,

--- a/packages/ai-bot/tests/index.ts
+++ b/packages/ai-bot/tests/index.ts
@@ -4,3 +4,4 @@ import './history-construction-test';
 import './prompt-construction-test';
 import './chat-titling-test';
 import './responding-test';
+import './matrix-util-test';

--- a/packages/ai-bot/tests/matrix-util-test.ts
+++ b/packages/ai-bot/tests/matrix-util-test.ts
@@ -2,13 +2,47 @@ import { test } from 'qunit';
 import { FakeMatrixClient } from './helpers/fake-matrix-client';
 import { getRoomEvents } from '../lib/matrix/util';
 import { Method } from 'matrix-js-sdk';
+import type {
+  CardMessageEvent,
+  MatrixEvent as DiscreteMatrixEvent,
+} from 'https://cardstack.com/base/matrix-event';
+import { APP_BOXEL_MESSAGE_MSGTYPE } from '@cardstack/runtime-common/matrix-constants';
+
+/**
+ * Creates a mock Matrix event with all required properties
+ * @param id - Event ID
+ * @param body - Message body content
+ * @param roomId - Room ID where event occurred
+ * @returns A properly typed MatrixEvent object
+ */
+function createMockEvent(
+  id: string,
+  body: string,
+  roomId = 'test-room-id',
+): CardMessageEvent {
+  return {
+    event_id: id,
+    content: {
+      body,
+      msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+      format: 'org.matrix.custom.html',
+      data: {},
+    },
+    type: 'm.room.message',
+    sender: '@test-user:matrix.org',
+    origin_server_ts: 102030,
+    room_id: roomId,
+    unsigned: { age: 1000, transaction_id: '123' },
+    status: null,
+  };
+}
 
 /**
  * Creates a mocked Matrix client that returns the specified events
  * @param mockEvents - Array of events to return in response
  * @returns A configured FakeMatrixClient
  */
-function createMockedClient(mockEvents: any[] = []) {
+function createMockedClient(mockEvents: DiscreteMatrixEvent[] = []) {
   const client = new FakeMatrixClient();
   client.http = {
     authedRequest: async (
@@ -25,8 +59,8 @@ function createMockedClient(mockEvents: any[] = []) {
 test('getRoomEvents - returns all events when no lastEventId provided', async function (assert) {
   // Setup mock events
   const mockEvents = [
-    { event_id: 'event1', content: { body: 'message 1' } },
-    { event_id: 'event2', content: { body: 'message 2' } },
+    createMockEvent('event1', 'message 1'),
+    createMockEvent('event2', 'message 2'),
   ];
 
   // Create fake client with mocked HTTP response
@@ -46,9 +80,9 @@ test('getRoomEvents - returns all events when no lastEventId provided', async fu
 test('getRoomEvents - returns events up to and including lastEventId', async function (assert) {
   // Setup mock events
   const mockEvents = [
-    { event_id: 'event1', content: { body: 'message 1' } },
-    { event_id: 'event2', content: { body: 'message 2' } },
-    { event_id: 'event3', content: { body: 'message 3' } },
+    createMockEvent('event1', 'message 1'),
+    createMockEvent('event2', 'message 2'),
+    createMockEvent('event3', 'message 3'),
   ];
 
   // Create fake client with mocked HTTP response
@@ -61,8 +95,8 @@ test('getRoomEvents - returns events up to and including lastEventId', async fun
   assert.deepEqual(
     result,
     [
-      { event_id: 'event1', content: { body: 'message 1' } },
-      { event_id: 'event2', content: { body: 'message 2' } },
+      createMockEvent('event1', 'message 1'),
+      createMockEvent('event2', 'message 2'),
     ],
     'Returns events up to and including lastEventId',
   );
@@ -71,8 +105,8 @@ test('getRoomEvents - returns events up to and including lastEventId', async fun
 test('getRoomEvents - returns all events when lastEventId is not found', async function (assert) {
   // Setup mock events
   const mockEvents = [
-    { event_id: 'event1', content: { body: 'message 1' } },
-    { event_id: 'event2', content: { body: 'message 2' } },
+    createMockEvent('event1', 'message 1'),
+    createMockEvent('event2', 'message 2'),
   ];
 
   // Create fake client with mocked HTTP response
@@ -86,41 +120,6 @@ test('getRoomEvents - returns all events when lastEventId is not found', async f
     result,
     mockEvents,
     'Returns all events when lastEventId is not found',
-  );
-});
-
-test('getRoomEvents - verifies correct request parameters', async function (assert) {
-  // Setup to capture the request parameters
-  let capturedMethod: Method | null = null;
-  let capturedPath: string | null = null;
-  let capturedParams: any = null;
-
-  // Create fake client with custom authedRequest implementation
-  const client = new FakeMatrixClient();
-  client.http = {
-    authedRequest: async (method: Method, path: string, queryParams: any) => {
-      capturedMethod = method;
-      capturedPath = path;
-      capturedParams = queryParams;
-      return { chunk: [] };
-    },
-  } as any;
-
-  // Call function
-  await getRoomEvents('test-room-id', client);
-
-  // Assertions
-  assert.equal(capturedMethod, Method.Get, 'Uses GET method');
-  assert.equal(
-    capturedPath,
-    '/rooms/test-room-id/messages',
-    'Constructs correct path',
-  );
-  assert.equal(capturedParams.dir, 'f', 'Uses forward direction');
-  assert.equal(capturedParams.limit, '1000', 'Limits to 1000 events');
-  assert.ok(
-    capturedParams.filter.includes('m.replace'),
-    'Filter includes replace relation type',
   );
 });
 

--- a/packages/ai-bot/tests/matrix-util-test.ts
+++ b/packages/ai-bot/tests/matrix-util-test.ts
@@ -1,0 +1,134 @@
+import { test } from 'qunit';
+import { FakeMatrixClient } from './helpers/fake-matrix-client';
+import { getRoomEvents } from '../lib/matrix/util';
+import { Method } from 'matrix-js-sdk';
+
+/**
+ * Creates a mocked Matrix client that returns the specified events
+ * @param mockEvents - Array of events to return in response
+ * @returns A configured FakeMatrixClient
+ */
+function createMockedClient(mockEvents: any[] = []) {
+  const client = new FakeMatrixClient();
+  client.http = {
+    authedRequest: async (
+      _method: Method,
+      _path: string,
+      _queryParams: any,
+    ) => {
+      return { chunk: mockEvents };
+    },
+  } as any;
+  return client;
+}
+
+test('getRoomEvents - returns all events when no lastEventId provided', async function (assert) {
+  // Setup mock events
+  const mockEvents = [
+    { event_id: 'event1', content: { body: 'message 1' } },
+    { event_id: 'event2', content: { body: 'message 2' } },
+  ];
+
+  // Create fake client with mocked HTTP response
+  const client = createMockedClient(mockEvents);
+
+  // Test function
+  const result = await getRoomEvents('room123', client);
+
+  // Assertions
+  assert.deepEqual(
+    result,
+    mockEvents,
+    'Returns all events when no lastEventId provided',
+  );
+});
+
+test('getRoomEvents - returns events up to and including lastEventId', async function (assert) {
+  // Setup mock events
+  const mockEvents = [
+    { event_id: 'event1', content: { body: 'message 1' } },
+    { event_id: 'event2', content: { body: 'message 2' } },
+    { event_id: 'event3', content: { body: 'message 3' } },
+  ];
+
+  // Create fake client with mocked HTTP response
+  const client = createMockedClient(mockEvents);
+
+  // Test function with lastEventId of 'event2'
+  const result = await getRoomEvents('room123', client, 'event2');
+
+  // Assertions
+  assert.deepEqual(
+    result,
+    [
+      { event_id: 'event1', content: { body: 'message 1' } },
+      { event_id: 'event2', content: { body: 'message 2' } },
+    ],
+    'Returns events up to and including lastEventId',
+  );
+});
+
+test('getRoomEvents - returns all events when lastEventId is not found', async function (assert) {
+  // Setup mock events
+  const mockEvents = [
+    { event_id: 'event1', content: { body: 'message 1' } },
+    { event_id: 'event2', content: { body: 'message 2' } },
+  ];
+
+  // Create fake client with mocked HTTP response
+  const client = createMockedClient(mockEvents);
+
+  // Test function with non-existent lastEventId
+  const result = await getRoomEvents('room123', client, 'non-existent-id');
+
+  // Assertions
+  assert.deepEqual(
+    result,
+    mockEvents,
+    'Returns all events when lastEventId is not found',
+  );
+});
+
+test('getRoomEvents - verifies correct request parameters', async function (assert) {
+  // Setup to capture the request parameters
+  let capturedMethod: Method | null = null;
+  let capturedPath: string | null = null;
+  let capturedParams: any = null;
+
+  // Create fake client with custom authedRequest implementation
+  const client = new FakeMatrixClient();
+  client.http = {
+    authedRequest: async (method: Method, path: string, queryParams: any) => {
+      capturedMethod = method;
+      capturedPath = path;
+      capturedParams = queryParams;
+      return { chunk: [] };
+    },
+  } as any;
+
+  // Call function
+  await getRoomEvents('test-room-id', client);
+
+  // Assertions
+  assert.equal(capturedMethod, Method.Get, 'Uses GET method');
+  assert.equal(
+    capturedPath,
+    '/rooms/test-room-id/messages',
+    'Constructs correct path',
+  );
+  assert.equal(capturedParams.dir, 'f', 'Uses forward direction');
+  assert.equal(capturedParams.limit, '1000', 'Limits to 1000 events');
+  assert.ok(
+    capturedParams.filter.includes('m.replace'),
+    'Filter includes replace relation type',
+  );
+});
+
+test('getRoomEvents - handles empty response', async function (assert) {
+  // Create fake client with empty response
+  const client = createMockedClient([]);
+
+  const result = await getRoomEvents('room123', client);
+
+  assert.deepEqual(result, [], 'Returns empty array when no events are found');
+});


### PR DESCRIPTION
Repro:

please run two searches, for anything, in one message. It must be two tool calls in one message. You have to have at least something in the title in the query

Using gpt-4o in interact mode with no cards attached. You need to have two auto run commands in one message.

Previously what would happen is we'd get the command result for one of the commands, and between the bot triggering and getting the room events *the other command result* would come in. Now the code that checks all the command results are present says "yes" because it would see *both* command results. The other command result *also* triggers this check, and again both results are present so it runs as well. Now we have two going in parallel.

This fix removes anything in the event list *after* the event we're responding to.

This also fixes the problem of seeing "thinking" in the last message in the event list the bot is working with.