### PR TITLE
Handle unserializable linter worker result

### DIFF
--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -99,8 +99,6 @@ export class LintAndFixInput extends CardDef {
 
 export class LintAndFixResult extends CardDef {
   @field output = contains(StringField);
-  @field fixed = contains(BooleanField);
-  @field messages = containsMany(JsonField);
 }
 
 export class PatchCodeInput extends CardDef {

--- a/packages/host/app/commands/lint-and-fix.ts
+++ b/packages/host/app/commands/lint-and-fix.ts
@@ -40,8 +40,6 @@ export default class LintAndFixCommand extends HostBaseCommand<
       let result = await response.json();
       return new LintAndFixResult({
         output: result.output,
-        fixed: result.fixed,
-        messages: result.messages,
       });
     }
     let result = await response.json();

--- a/packages/host/tests/integration/commands/patch-code-test.gts
+++ b/packages/host/tests/integration/commands/patch-code-test.gts
@@ -104,7 +104,5 @@ export class Task extends CardDef {
   </template>
 }`;
     assert.strictEqual(result.output, expectedResult);
-    assert.strictEqual(result.fixed, true);
-    assert.deepEqual(result.messages, []);
   });
 });

--- a/packages/realm-server/tests/realm-endpoints/lint-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/lint-test.ts
@@ -78,8 +78,6 @@ import MyComponent from 'somewhere';
 </template>
 `,
       );
-      assert.true(responseJson.fixed, 'fixed is true when there are fixes');
-      assert.deepEqual(responseJson.messages, [], 'no linting errors found');
     });
 
     test('user can do a lint with no fix needed', async function (assert) {
@@ -109,11 +107,6 @@ import MyComponent from 'somewhere';
 </template>
 `,
       );
-      assert.false(
-        responseJson.fixed,
-        'fixed is false when there are no fixes',
-      );
-      assert.deepEqual(responseJson.messages, [], 'no linting errors found');
     });
   });
 });

--- a/packages/runtime-common/lint.ts
+++ b/packages/runtime-common/lint.ts
@@ -6,7 +6,9 @@ export interface LintArgs {
 
 export type LintResult = Linter.FixReport;
 
-export async function lintFix({ source }: LintArgs): Promise<LintResult> {
+export async function lintFix({
+  source,
+}: LintArgs): Promise<Pick<LintResult, 'output'>> {
   if (typeof (globalThis as any).document !== 'undefined') {
     throw new Error(
       'Linting is not supported in the browser environment. Please run this in a Node.js environment.',
@@ -73,6 +75,6 @@ export async function lintFix({ source }: LintArgs): Promise<LintResult> {
     },
   ];
   const linter = new eslintModule.Linter({ configType: 'flat' });
-  let fixReport = linter.verifyAndFix(source, CONFIG, 'input.gts');
-  return fixReport;
+  let { output } = linter.verifyAndFix(source, CONFIG, 'input.gts');
+  return { output };
 }

--- a/packages/runtime-common/worker.ts
+++ b/packages/runtime-common/worker.ts
@@ -264,6 +264,17 @@ export class Worker {
     });
     await this.#runner(optsId);
     let result = await deferred.promise;
+    try {
+      // the result needs to be safe to stringify
+      // so we check for issues here where we can gracefully handle it
+      JSON.stringify(result);
+    } catch (e: any) {
+      this.#log.error(
+        `${jobIdentity(args.jobInfo)} Unable to stringify the job result`,
+        e,
+      );
+      throw e;
+    }
     this.runnerOptsMgr.removeOptions(optsId);
     return result;
   }


### PR DESCRIPTION
The linter response is actually an object that seems to have problems serializing into a string, which we do in order to save the job output in our queue table. apparently there are some cycles in the object that `JSON.stringify` gets hung up on. instead we pluck out the only field we really care about from the results, `output`, which is simply a string. Also we add a guard in the worker to make sure that the worker result is serializable such that we can check this in a place where we can handle the error, as opposed to deeper in the machinery of the queue were we cannot easily deal with such an error.