### PR TITLE
Synchronize monaco edits of instances with store

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -49,7 +49,7 @@ jobs:
           wait-for: 3m
           wait-on: http-get://localhost:4200
       - name: Start realm servers
-        run: pnpm start:all | tee -a /tmp/server.log &
+        run: pnpm start:skip-experiments | tee -a /tmp/server.log &
         working-directory: packages/realm-server
       - name: create realm users
         run: pnpm register-realm-users

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -288,7 +288,7 @@ jobs:
           wait-for: 3m
           wait-on: http-get://localhost:4200
       - name: Start realm servers
-        run: pnpm start:all | tee -a /tmp/server.log &
+        run: pnpm start:skip-experiments | tee -a /tmp/server.log &
         working-directory: packages/realm-server
       - name: create realm users
         run: pnpm register-realm-users

--- a/packages/host/app/components/operator-mode/edit-field-modal.gts
+++ b/packages/host/app/components/operator-mode/edit-field-modal.gts
@@ -291,7 +291,7 @@ export default class EditFieldModal extends Component<Signature> {
     // any code after this write will not be executed since the component will
     // get torn down before subsequent code can execute
 
-    await this.args.file.write(src, true);
+    await this.args.file.write(src, { flushLoader: true });
     this.args.onClose();
   });
 

--- a/packages/host/app/components/operator-mode/remove-field-modal.gts
+++ b/packages/host/app/components/operator-mode/remove-field-modal.gts
@@ -35,7 +35,7 @@ export default class RemoveFieldModal extends Component<Signature> {
 
     this.args.moduleSyntax.removeField(identifiedCard, field.name);
 
-    await file.write(moduleSyntax.code(), true);
+    await file.write(moduleSyntax.code(), { flushLoader: true });
     this.args.onClose();
   });
 

--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -35,6 +35,14 @@ export type CardSaveSubscriber = (
   content: SingleCardDocument | string,
 ) => void;
 
+export type SaveType =
+  | 'bot-patch'
+  | 'editor'
+  | 'editor-with-instance'
+  | 'create-file'
+  | 'copy'
+  | 'instance';
+
 export default class CardService extends Service {
   @service declare private loaderService: LoaderService;
   @service declare private messageService: MessageService;
@@ -164,7 +172,7 @@ export default class CardService extends Service {
     };
   }
 
-  async saveSource(url: URL, content: string, type: string) {
+  async saveSource(url: URL, content: string, type: SaveType) {
     try {
       let clientRequestId = `${type}:${uuidv4()}`;
       this.clientRequestIds.add(clientRequestId);

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -10,7 +10,7 @@ import { task } from 'ember-concurrency';
 
 import cloneDeep from 'lodash/cloneDeep';
 import isEqual from 'lodash/isEqual';
-import mergeWith from 'lodash/mergeWith';
+import merge from 'lodash/merge';
 
 import { stringify } from 'qs';
 
@@ -317,15 +317,19 @@ export default class StoreService extends Service implements StoreInterface {
   async patch<T extends CardDef = CardDef>(
     id: string,
     patch: PatchData,
+    opts?: { doNotPersist?: true },
   ): Promise<T | CardErrorJSONAPI | undefined> {
     // eslint-disable-next-line ember/classic-decorator-no-classic-methods
     let instance = await this.get<T>(id);
     if (!instance || !isCardInstance(instance)) {
       return;
     }
+    if (opts?.doNotPersist) {
+      await this.stopAutoSaving(instance);
+    }
     let doc = await this.cardService.serializeCard(instance);
     if (patch.attributes) {
-      doc.data.attributes = mergeWith(doc.data.attributes, patch.attributes);
+      doc.data.attributes = merge(doc.data.attributes, patch.attributes);
     }
     if (patch.relationships) {
       let mergedRel = mergeRelationships(
@@ -335,6 +339,9 @@ export default class StoreService extends Service implements StoreInterface {
       if (mergedRel && Object.keys(mergedRel).length !== 0) {
         doc.data.relationships = mergedRel;
       }
+    }
+    if (patch.meta) {
+      doc.data.meta = merge(doc.data.meta, patch.meta);
     }
     let linkedCards = await this.loadPatchedInstances(
       patch,
@@ -353,16 +360,17 @@ export default class StoreService extends Service implements StoreInterface {
         }
         (inner as any)[leaf.match(/^\d+$/) ? Number(leaf) : leaf] = value;
       } else {
-        // TODO this could trigger a save. perhaps instead we could
-        // introduce a new option to updateFromSerialized to accept a list of
-        // fields to pre-load? which in this case would be any relationships that
-        // were patched in
         (instance as any)[field] = value;
       }
     }
     let api = await this.cardService.getAPI();
     await api.updateFromSerialized(instance, doc, this.identityContext);
-    return (await this.persistAndUpdate(instance)) as T | CardErrorJSONAPI;
+    if (opts?.doNotPersist) {
+      await this.startAutoSaving(instance);
+    } else {
+      await this.persistAndUpdate(instance);
+    }
+    return instance as T | CardErrorJSONAPI;
   }
 
   async search(query: Query, realmURL: URL): Promise<CardDef[]> {
@@ -552,7 +560,10 @@ export default class StoreService extends Service implements StoreInterface {
             `reloading file resource ${invalidation} because event has no clientRequestId`,
           );
         } else if (this.cardService.clientRequestIds.has(clientRequestId)) {
-          if (clientRequestId.startsWith('instance:')) {
+          if (
+            clientRequestId.startsWith('instance:') ||
+            clientRequestId.startsWith('editor-with-instance')
+          ) {
             realmEventsLogger.debug(
               `ignoring invalidation for card ${invalidation} because request id ${clientRequestId} is ours and an instance type`,
             );

--- a/packages/realm-server/package.json
+++ b/packages/realm-server/package.json
@@ -93,6 +93,7 @@
     "start:base": "./scripts/start-base.sh --workerManagerPort=4213",
     "start:test-realms": "./scripts/start-test-realms.sh --workerManagerPort=4211",
     "start:all": "./scripts/start-all.sh",
+    "start:skip-experiments": "./scripts/start-all-except-experiments.sh",
     "start:without-matrix": "./scripts/start-without-matrix.sh",
     "start:staging": "./scripts/start-staging.sh",
     "start:development": "./scripts/start-development.sh --workerManagerPort=4210",

--- a/packages/realm-server/scripts/start-all-except-experiments.sh
+++ b/packages/realm-server/scripts/start-all-except-experiments.sh
@@ -1,0 +1,8 @@
+#! /bin/sh
+
+NODE_NO_WARNINGS=1 start-server-and-test \
+  'run-p start:pg start:matrix start:smtp start:worker-development start:development' \
+  'http-get://localhost:4201/base/_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson|http://localhost:8008|http://localhost:5001' \
+  'run-p start:worker-test start:test-realms' \
+  'http-get://localhost:4202/node-test/_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson' \
+  'wait'

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -1,4 +1,4 @@
-import { CardResource } from './card-document';
+import { CardResource, Meta } from './card-document';
 import type { ResolvedCodeRef } from './code-ref';
 
 import type { RealmEventContent } from 'https://cardstack.com/base/matrix-event';
@@ -17,6 +17,9 @@ export interface LooseSingleCardDocument {
 export type PatchData = {
   attributes?: CardResource['attributes'];
   relationships?: CardResource['relationships'];
+  meta?: {
+    fields: Meta['fields'];
+  };
 };
 
 export { Deferred } from './deferred';

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -310,12 +310,6 @@ export class Realm {
     this.#dbAdapter = dbAdapter;
 
     this.#router = new Router(new URL(url))
-      .post('(/|/.+/)', SupportedMimeType.CardJson, this.createCard.bind(this))
-      .patch(
-        '/.+(?<!.json)',
-        SupportedMimeType.CardJson,
-        this.patchCardInstance.bind(this),
-      )
       .get('/_info', SupportedMimeType.RealmInfo, this.realmInfo.bind(this))
       .query('/_lint', SupportedMimeType.JSON, this.lint.bind(this))
       .get('/_mtimes', SupportedMimeType.Mtimes, this.realmMtimes.bind(this))
@@ -352,9 +346,20 @@ export class Realm {
         this.patchRealmPermissions.bind(this),
       )
       .get(
+        '/_readiness-check',
+        SupportedMimeType.RealmInfo,
+        this.readinessCheck.bind(this),
+      )
+      .post('(/|/.+/)', SupportedMimeType.CardJson, this.createCard.bind(this))
+      .get(
         '/|/.+(?<!.json)',
         SupportedMimeType.CardJson,
         this.getCard.bind(this),
+      )
+      .patch(
+        '/.+(?<!.json)',
+        SupportedMimeType.CardJson,
+        this.patchCardInstance.bind(this),
       )
       .delete(
         '/|/.+(?<!.json)',
@@ -380,11 +385,6 @@ export class Realm {
         '.*/',
         SupportedMimeType.DirectoryListing,
         this.getDirectoryListing.bind(this),
-      )
-      .get(
-        '/_readiness-check',
-        SupportedMimeType.RealmInfo,
-        this.readinessCheck.bind(this),
       );
 
     Object.values(SupportedMimeType).forEach((mimeType) => {


### PR DESCRIPTION
This PR synchronizes monaco edits of valid card instance JSON with the store so that we don't have to round trip thru the server in order to see monaco updates be reflected in any cards that are rendered from the store.