### PR TITLE
change route order to prevent greedy route matches

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -49,7 +49,7 @@ jobs:
           wait-for: 3m
           wait-on: http-get://localhost:4200
       - name: Start realm servers
-        run: pnpm start:all | tee -a /tmp/server.log &
+        run: pnpm start:skip-experiments | tee -a /tmp/server.log &
         working-directory: packages/realm-server
       - name: create realm users
         run: pnpm register-realm-users

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -288,7 +288,7 @@ jobs:
           wait-for: 3m
           wait-on: http-get://localhost:4200
       - name: Start realm servers
-        run: pnpm start:all | tee -a /tmp/server.log &
+        run: pnpm start:skip-experiments | tee -a /tmp/server.log &
         working-directory: packages/realm-server
       - name: create realm users
         run: pnpm register-realm-users

--- a/packages/realm-server/package.json
+++ b/packages/realm-server/package.json
@@ -93,6 +93,7 @@
     "start:base": "./scripts/start-base.sh --workerManagerPort=4213",
     "start:test-realms": "./scripts/start-test-realms.sh --workerManagerPort=4211",
     "start:all": "./scripts/start-all.sh",
+    "start:skip-experiments": "./scripts/start-all-except-experiments.sh",
     "start:without-matrix": "./scripts/start-without-matrix.sh",
     "start:staging": "./scripts/start-staging.sh",
     "start:development": "./scripts/start-development.sh --workerManagerPort=4210",

--- a/packages/realm-server/scripts/start-all-except-experiments.sh
+++ b/packages/realm-server/scripts/start-all-except-experiments.sh
@@ -1,0 +1,8 @@
+#! /bin/sh
+
+NODE_NO_WARNINGS=1 start-server-and-test \
+  'run-p start:pg start:matrix start:smtp start:worker-development start:development' \
+  'http-get://localhost:4201/base/_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson|http://localhost:8008|http://localhost:5001' \
+  'run-p start:worker-test start:test-realms' \
+  'http-get://localhost:4202/node-test/_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson' \
+  'wait'

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -310,12 +310,6 @@ export class Realm {
     this.#dbAdapter = dbAdapter;
 
     this.#router = new Router(new URL(url))
-      .post('(/|/.+/)', SupportedMimeType.CardJson, this.createCard.bind(this))
-      .patch(
-        '/.+(?<!.json)',
-        SupportedMimeType.CardJson,
-        this.patchCardInstance.bind(this),
-      )
       .get('/_info', SupportedMimeType.RealmInfo, this.realmInfo.bind(this))
       .query('/_lint', SupportedMimeType.JSON, this.lint.bind(this))
       .get('/_mtimes', SupportedMimeType.Mtimes, this.realmMtimes.bind(this))
@@ -352,9 +346,20 @@ export class Realm {
         this.patchRealmPermissions.bind(this),
       )
       .get(
+        '/_readiness-check',
+        SupportedMimeType.RealmInfo,
+        this.readinessCheck.bind(this),
+      )
+      .post('(/|/.+/)', SupportedMimeType.CardJson, this.createCard.bind(this))
+      .get(
         '/|/.+(?<!.json)',
         SupportedMimeType.CardJson,
         this.getCard.bind(this),
+      )
+      .patch(
+        '/.+(?<!.json)',
+        SupportedMimeType.CardJson,
+        this.patchCardInstance.bind(this),
       )
       .delete(
         '/|/.+(?<!.json)',
@@ -380,11 +385,6 @@ export class Realm {
         '.*/',
         SupportedMimeType.DirectoryListing,
         this.getDirectoryListing.bind(this),
-      )
-      .get(
-        '/_readiness-check',
-        SupportedMimeType.RealmInfo,
-        this.readinessCheck.bind(this),
       );
 
     Object.values(SupportedMimeType).forEach((mimeType) => {


### PR DESCRIPTION
This makes sure that greedy route matches are at the end of our realm route table. also don't wait for experiments realm to start up when running tests