### PR TITLE
Fix card creation NOT returning in pre-rendered search for apps

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -57,7 +57,7 @@ import {
   type getCards,
   type getCardCollection,
   type Store,
-  type Query,
+  type PrerenderedCardComponentSignature,
 } from '@cardstack/runtime-common';
 import type { ComponentLike } from '@glint/template';
 import { initSharedState } from './shared-state';
@@ -133,35 +133,6 @@ interface Options {
 interface NotLoadedValue {
   type: 'not-loaded';
   reference: string;
-}
-
-export interface PrerenderedCardData {
-  url: string;
-  realmUrl: string;
-  html: string;
-  isError: boolean;
-}
-
-export interface PrerenderedCardLike {
-  url: string;
-  isError: boolean;
-  realmUrl: string;
-  component: ComponentLike<{ Args: {} }>;
-}
-
-export interface PrerenderedCardComponentSignature {
-  Element: undefined;
-  Args: {
-    query: Query;
-    format: Format;
-    cardUrls?: string[];
-    realms: string[];
-    isLive?: boolean;
-  };
-  Blocks: {
-    loading: [];
-    response: [cards: PrerenderedCardLike[]];
-  };
 }
 
 export interface CardContext<T extends CardDef = CardDef> {

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -57,6 +57,7 @@ import {
   type getCards,
   type getCardCollection,
   type Store,
+  type Query,
 } from '@cardstack/runtime-common';
 import type { ComponentLike } from '@glint/template';
 import { initSharedState } from './shared-state';
@@ -134,6 +135,35 @@ interface NotLoadedValue {
   reference: string;
 }
 
+export interface PrerenderedCardData {
+  url: string;
+  realmUrl: string;
+  html: string;
+  isError: boolean;
+}
+
+export interface PrerenderedCardLike {
+  url: string;
+  isError: boolean;
+  realmUrl: string;
+  component: ComponentLike<{ Args: {} }>;
+}
+
+export interface PrerenderedCardComponentSignature {
+  Element: undefined;
+  Args: {
+    query: Query;
+    format: Format;
+    cardUrls?: string[];
+    realms: string[];
+    isLive?: boolean;
+  };
+  Blocks: {
+    loading: [];
+    response: [cards: PrerenderedCardLike[]];
+  };
+}
+
 export interface CardContext<T extends CardDef = CardDef> {
   actions?: Actions;
   commandContext?: CommandContext;
@@ -148,7 +178,7 @@ export interface CardContext<T extends CardDef = CardDef> {
       };
     };
   }>;
-  prerenderedCardSearchComponent: any;
+  prerenderedCardSearchComponent: typeof GlimmerComponent<PrerenderedCardComponentSignature>;
   getCard: getCard<T>;
   getCards: getCards;
   getCardCollection: getCardCollection;

--- a/packages/catalog-realm-dev/blog-app/components/card-list.gts
+++ b/packages/catalog-realm-dev/blog-app/components/card-list.gts
@@ -1,15 +1,13 @@
 import GlimmerComponent from '@glimmer/component';
 
-import { type CardContext } from 'https://cardstack.com/base/card-api';
+import {
+  type CardContext,
+  type PrerenderedCardLike,
+} from 'https://cardstack.com/base/card-api';
 
 import { type Query } from '@cardstack/runtime-common';
 
 import { CardContainer } from '@cardstack/boxel-ui/components';
-
-interface PrerenderedCard {
-  url: string;
-  component: any;
-}
 
 interface CardListSignature {
   Args: {
@@ -18,7 +16,7 @@ interface CardListSignature {
     context?: CardContext;
   };
   Blocks: {
-    meta: [card: PrerenderedCard];
+    meta: [card: PrerenderedCardLike];
   };
   Element: HTMLElement;
 }

--- a/packages/catalog-realm-dev/blog-app/components/card-list.gts
+++ b/packages/catalog-realm-dev/blog-app/components/card-list.gts
@@ -1,11 +1,11 @@
 import GlimmerComponent from '@glimmer/component';
 
-import {
-  type CardContext,
-  type PrerenderedCardLike,
-} from 'https://cardstack.com/base/card-api';
+import { type CardContext } from 'https://cardstack.com/base/card-api';
 
-import { type Query } from '@cardstack/runtime-common';
+import {
+  type Query,
+  type PrerenderedCardLike,
+} from '@cardstack/runtime-common';
 
 import { CardContainer } from '@cardstack/boxel-ui/components';
 

--- a/packages/catalog-realm-dev/catalog-app/components/grid.gts
+++ b/packages/catalog-realm-dev/catalog-app/components/grid.gts
@@ -7,10 +7,11 @@ import { tracked } from '@glimmer/tracking';
 import {
   type CardContext,
   type BaseDef,
+  type PrerenderedCardLike,
 } from 'https://cardstack.com/base/card-api';
 import { and } from '@cardstack/boxel-ui/helpers';
 
-import { type Query, type PrerenderedCard } from '@cardstack/runtime-common';
+import { type Query } from '@cardstack/runtime-common';
 
 import { CardContainer } from '@cardstack/boxel-ui/components';
 
@@ -29,7 +30,7 @@ export class CardsGrid extends GlimmerComponent<CardsGridSignature> {
   cardResource = this.args.context?.getCard(this, () => this.hydratedCardId);
 
   @action
-  async hydrateCard(card: PrerenderedCard | undefined) {
+  async hydrateCard(card: PrerenderedCardLike | undefined) {
     if (!card) {
       this.hydratedCardId = undefined;
       return;
@@ -39,7 +40,7 @@ export class CardsGrid extends GlimmerComponent<CardsGridSignature> {
   }
 
   @action
-  viewCard(card: PrerenderedCard) {
+  viewCard(card: PrerenderedCardLike) {
     if (!this.args.context?.actions?.viewCard) {
       throw new Error('viewCard action is not available');
     }

--- a/packages/catalog-realm-dev/catalog-app/components/grid.gts
+++ b/packages/catalog-realm-dev/catalog-app/components/grid.gts
@@ -7,11 +7,13 @@ import { tracked } from '@glimmer/tracking';
 import {
   type CardContext,
   type BaseDef,
-  type PrerenderedCardLike,
 } from 'https://cardstack.com/base/card-api';
 import { and } from '@cardstack/boxel-ui/helpers';
 
-import { type Query } from '@cardstack/runtime-common';
+import {
+  type PrerenderedCardLike,
+  type Query,
+} from '@cardstack/runtime-common';
 
 import { CardContainer } from '@cardstack/boxel-ui/components';
 

--- a/packages/catalog-realm-dev/crm-app/app-card.gts
+++ b/packages/catalog-realm-dev/crm-app/app-card.gts
@@ -12,11 +12,10 @@ import {
   StringField,
   type CardContext,
   FieldsTypeFor,
-  type PrerenderedCardLike,
 } from 'https://cardstack.com/base/card-api';
 import { CardContainer } from '@cardstack/boxel-ui/components';
 import { and, bool, cn } from '@cardstack/boxel-ui/helpers';
-import { baseRealm } from '@cardstack/runtime-common';
+import { baseRealm, type PrerenderedCardLike } from '@cardstack/runtime-common';
 import { hash } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/packages/catalog-realm-dev/crm-app/app-card.gts
+++ b/packages/catalog-realm-dev/crm-app/app-card.gts
@@ -12,6 +12,7 @@ import {
   StringField,
   type CardContext,
   FieldsTypeFor,
+  type PrerenderedCardLike,
 } from 'https://cardstack.com/base/card-api';
 import { CardContainer } from '@cardstack/boxel-ui/components';
 import { and, bool, cn } from '@cardstack/boxel-ui/helpers';
@@ -49,11 +50,6 @@ export interface DefaultTabSignature extends TabComponentSignature {
   context?: CardContext;
 }
 
-interface PrerenderedCard {
-  url: string;
-  component: typeof GlimmerComponent;
-}
-
 export class Tab extends FieldDef {
   @field displayName = contains(StringField);
   @field tabId = contains(StringField);
@@ -62,7 +58,7 @@ export class Tab extends FieldDef {
 }
 
 class TableView extends GlimmerComponent<{
-  Args: { cards: PrerenderedCard[]; context?: CardContext };
+  Args: { cards: PrerenderedCardLike[]; context?: CardContext };
 }> {
   <template>
     {{#if this.isLoaded}}
@@ -481,7 +477,7 @@ export class AppCard extends CardDef {
 
 export class CardsGrid extends GlimmerComponent<{
   Args: {
-    cards: PrerenderedCard[];
+    cards: PrerenderedCardLike[];
     context?: CardContext;
     isListFormat?: boolean;
   };

--- a/packages/catalog-realm-dev/crm-app/components/card-list.gts
+++ b/packages/catalog-realm-dev/crm-app/components/card-list.gts
@@ -1,15 +1,13 @@
 import GlimmerComponent from '@glimmer/component';
 
-import { type CardContext } from 'https://cardstack.com/base/card-api';
+import {
+  type CardContext,
+  type PrerenderedCardLike,
+} from 'https://cardstack.com/base/card-api';
 
 import { type Query } from '@cardstack/runtime-common';
 
 import { CardContainer } from '@cardstack/boxel-ui/components';
-
-interface PrerenderedCard {
-  url: string;
-  component: any;
-}
 
 interface CardListSignature {
   Args: {
@@ -18,7 +16,7 @@ interface CardListSignature {
     context?: CardContext;
   };
   Blocks: {
-    meta: [card: PrerenderedCard];
+    meta: [card: PrerenderedCardLike];
   };
   Element: HTMLElement;
 }

--- a/packages/catalog-realm-dev/crm-app/components/card-list.gts
+++ b/packages/catalog-realm-dev/crm-app/components/card-list.gts
@@ -1,11 +1,11 @@
 import GlimmerComponent from '@glimmer/component';
 
-import {
-  type CardContext,
-  type PrerenderedCardLike,
-} from 'https://cardstack.com/base/card-api';
+import { type CardContext } from 'https://cardstack.com/base/card-api';
 
-import { type Query } from '@cardstack/runtime-common';
+import {
+  type Query,
+  type PrerenderedCardLike,
+} from '@cardstack/runtime-common';
 
 import { CardContainer } from '@cardstack/boxel-ui/components';
 

--- a/packages/experiments-realm/app-card.gts
+++ b/packages/experiments-realm/app-card.gts
@@ -12,11 +12,14 @@ import {
   StringField,
   type CardContext,
   FieldsTypeFor,
-  type PrerenderedCardLike,
 } from 'https://cardstack.com/base/card-api';
 import { CardContainer } from '@cardstack/boxel-ui/components';
 import { and, bool, cn } from '@cardstack/boxel-ui/helpers';
-import { baseRealm } from '@cardstack/runtime-common';
+import {
+  type Query,
+  baseRealm,
+  type PrerenderedCardLike,
+} from '@cardstack/runtime-common';
 import { hash } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
@@ -164,21 +167,23 @@ class DefaultTabTemplate extends GlimmerComponent<DefaultTabSignature> {
   <template>
     <div class='app-card-content'>
       {{#if this.activeTabRef}}
-        <@context.prerenderedCardSearchComponent
-          @query={{this.query}}
-          @format='fitted'
-          @realms={{@realms}}
-          @isLive={{true}}
-        >
-          <:loading>Loading...</:loading>
-          <:response as |cards|>
-            {{#if @activeTab.isTable}}
-              <TableView @cards={{cards}} @context={{@context}} />
-            {{else}}
-              <CardsGrid @cards={{cards}} @context={{@context}} />
-            {{/if}}
-          </:response>
-        </@context.prerenderedCardSearchComponent>
+        {{#if this.query}}
+          <@context.prerenderedCardSearchComponent
+            @query={{this.query}}
+            @format='fitted'
+            @realms={{@realms}}
+            @isLive={{true}}
+          >
+            <:loading>Loading...</:loading>
+            <:response as |cards|>
+              {{#if @activeTab.isTable}}
+                <TableView @cards={{cards}} @context={{@context}} />
+              {{else}}
+                <CardsGrid @cards={{cards}} @context={{@context}} />
+              {{/if}}
+            </:response>
+          </@context.prerenderedCardSearchComponent>
+        {{/if}}
       {{else}}
         <p>No cards available</p>
       {{/if}}
@@ -312,7 +317,7 @@ class DefaultTabTemplate extends GlimmerComponent<DefaultTabSignature> {
           by: 'title',
         },
       ],
-    };
+    } as Query;
   }
 
   @action createNew(value: unknown) {

--- a/packages/experiments-realm/app-card.gts
+++ b/packages/experiments-realm/app-card.gts
@@ -12,6 +12,7 @@ import {
   StringField,
   type CardContext,
   FieldsTypeFor,
+  type PrerenderedCardLike,
 } from 'https://cardstack.com/base/card-api';
 import { CardContainer } from '@cardstack/boxel-ui/components';
 import { and, bool, cn } from '@cardstack/boxel-ui/helpers';
@@ -49,11 +50,6 @@ export interface DefaultTabSignature extends TabComponentSignature {
   context?: CardContext;
 }
 
-interface PrerenderedCard {
-  url: string;
-  component: typeof GlimmerComponent;
-}
-
 export class Tab extends FieldDef {
   @field displayName = contains(StringField);
   @field tabId = contains(StringField);
@@ -62,7 +58,7 @@ export class Tab extends FieldDef {
 }
 
 class TableView extends GlimmerComponent<{
-  Args: { cards: PrerenderedCard[]; context?: CardContext };
+  Args: { cards: PrerenderedCardLike[]; context?: CardContext };
 }> {
   <template>
     {{#if this.isLoaded}}
@@ -481,7 +477,7 @@ export class AppCard extends CardDef {
 
 export class CardsGrid extends GlimmerComponent<{
   Args: {
-    cards: PrerenderedCard[];
+    cards: PrerenderedCardLike[];
     context?: CardContext;
     isListFormat?: boolean;
   };

--- a/packages/experiments-realm/blog-app.gts
+++ b/packages/experiments-realm/blog-app.gts
@@ -225,7 +225,7 @@ class BlogAppTemplate extends Component<typeof BlogApp> {
             <CardList
               @context={{@context}}
               @query={{this.query}}
-              @realms={{this.realms}}
+              @realms={{this.realmHrefs}}
               class='blog-app-card-list {{this.gridClass}}'
             >
               <:meta as |card|>
@@ -242,7 +242,7 @@ class BlogAppTemplate extends Component<typeof BlogApp> {
               @selectedView={{this.selectedView}}
               @context={{@context}}
               @query={{this.query}}
-              @realms={{this.realms}}
+              @realms={{this.realmHrefs}}
               class={{this.gridClass}}
             />
           {{/if}}
@@ -352,6 +352,10 @@ class BlogAppTemplate extends Component<typeof BlogApp> {
 
   private get realms() {
     return [this.args.model[realmURL]!];
+  }
+
+  private get realmHrefs() {
+    return this.realms.map((url) => url.href);
   }
 
   private get query() {

--- a/packages/experiments-realm/components/card-list.gts
+++ b/packages/experiments-realm/components/card-list.gts
@@ -1,15 +1,13 @@
 import GlimmerComponent from '@glimmer/component';
 
-import { type CardContext } from 'https://cardstack.com/base/card-api';
+import {
+  type CardContext,
+  type PrerenderedCardLike,
+} from 'https://cardstack.com/base/card-api';
 
 import { type Query } from '@cardstack/runtime-common';
 
 import { CardContainer } from '@cardstack/boxel-ui/components';
-
-interface PrerenderedCard {
-  url: string;
-  component: any;
-}
 
 interface CardListSignature {
   Args: {
@@ -18,7 +16,7 @@ interface CardListSignature {
     context?: CardContext;
   };
   Blocks: {
-    meta: [card: PrerenderedCard];
+    meta: [card: PrerenderedCardLike];
   };
   Element: HTMLElement;
 }

--- a/packages/experiments-realm/components/card-list.gts
+++ b/packages/experiments-realm/components/card-list.gts
@@ -1,18 +1,18 @@
 import GlimmerComponent from '@glimmer/component';
 
-import {
-  type CardContext,
-  type PrerenderedCardLike,
-} from 'https://cardstack.com/base/card-api';
+import { type CardContext } from 'https://cardstack.com/base/card-api';
 
-import { type Query } from '@cardstack/runtime-common';
+import {
+  type Query,
+  type PrerenderedCardLike,
+} from '@cardstack/runtime-common';
 
 import { CardContainer } from '@cardstack/boxel-ui/components';
 
 interface CardListSignature {
   Args: {
     query: Query;
-    realms: URL[];
+    realms: string[];
     context?: CardContext;
   };
   Blocks: {

--- a/packages/experiments-realm/components/grid.gts
+++ b/packages/experiments-realm/components/grid.gts
@@ -9,7 +9,7 @@ import { CardContainer } from '@cardstack/boxel-ui/components';
 interface CardsGridSignature {
   Args: {
     query: Query;
-    realms: URL[];
+    realms: string[];
     selectedView: string;
     context?: CardContext;
   };

--- a/packages/experiments-realm/crm-app.gts
+++ b/packages/experiments-realm/crm-app.gts
@@ -653,13 +653,13 @@ class CrmAppTemplate extends Component<typeof CrmApp> {
             <CardList
               @context={{@context}}
               @query={{this.query}}
-              @realms={{this.realms}}
+              @realms={{this.realmHrefs}}
               class='crm-app-grid'
             />
           {{else}}
             <CardsGrid
               @query={{this.query}}
-              @realms={{this.realms}}
+              @realms={{this.realmHrefs}}
               @selectedView={{this.selectedView}}
               @context={{@context}}
               class='crm-app-grid'

--- a/packages/host/app/components/card-catalog/index.gts
+++ b/packages/host/app/components/card-catalog/index.gts
@@ -16,13 +16,15 @@ import { Button } from '@cardstack/boxel-ui/components';
 import { add, cn, eq, gt, lt, subtract } from '@cardstack/boxel-ui/helpers';
 import { IconPlus } from '@cardstack/boxel-ui/icons';
 
-import type { RealmInfo, CodeRef } from '@cardstack/runtime-common';
+import type {
+  RealmInfo,
+  CodeRef,
+  PrerenderedCardLike,
+} from '@cardstack/runtime-common';
 
 import RestoreScrollPosition from '@cardstack/host/modifiers/restore-scroll-position';
 import scrollIntoViewModifier from '@cardstack/host/modifiers/scroll-into-view';
 import type RealmService from '@cardstack/host/services/realm';
-
-import { type PrerenderedCard } from '../prerendered-card-search';
 
 import { removeFileExtension } from '../search-sheet/utils';
 
@@ -36,7 +38,7 @@ export interface NewCardArgs {
 
 interface ButtonSignature {
   Args: {
-    card?: PrerenderedCard;
+    card?: PrerenderedCardLike;
     newCard?: NewCardArgs;
     isSelected: boolean;
     select: (
@@ -149,7 +151,7 @@ const ItemButton: TemplateOnlyComponent<ButtonSignature> = <template>
 
 interface Signature {
   Args: {
-    cards: PrerenderedCard[];
+    cards: PrerenderedCardLike[];
     select: (
       card?: string | NewCardArgs,
       ev?: KeyboardEvent | MouseEvent,
@@ -347,7 +349,7 @@ export default class CardCatalog extends Component<Signature> {
   private get groupedCardsByRealm(): Record<
     string,
     {
-      cards: PrerenderedCard[];
+      cards: PrerenderedCardLike[];
       cardsTotal: number;
       displayedCardsCount: number;
       realmInfo: RealmInfo;
@@ -377,7 +379,7 @@ export default class CardCatalog extends Component<Signature> {
       {} as Record<
         string,
         {
-          cards: PrerenderedCard[];
+          cards: PrerenderedCardLike[];
           realmInfo: RealmInfo;
           cardsTotal: number;
           displayedCardsCount: number;

--- a/packages/host/app/components/operator-mode/code-submode/playground/instance-chooser-dropdown.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/instance-chooser-dropdown.gts
@@ -18,6 +18,7 @@ import {
   trimJsonExtension,
   type Format,
   type Query,
+  type PrerenderedCardLike,
 } from '@cardstack/runtime-common';
 
 import CardRenderer from '@cardstack/host/components/card-renderer';
@@ -25,9 +26,7 @@ import CardRenderer from '@cardstack/host/components/card-renderer';
 import type PlaygroundPanelService from '@cardstack/host/services/playground-panel-service';
 import type RecentFilesService from '@cardstack/host/services/recent-files-service';
 
-import PrerenderedCardSearch, {
-  type PrerenderedCard,
-} from '../../../prerendered-card-search';
+import PrerenderedCardSearch from '../../../prerendered-card-search';
 
 import type { FieldOption, SelectedInstance } from './playground-panel';
 
@@ -159,7 +158,7 @@ interface Signature {
     expandedSearchQuery?: { query?: Query; realms: string[] };
     fieldOptions?: FieldOption[];
     selection: SelectedInstance | undefined;
-    onSelect: (item: PrerenderedCard | FieldOption) => void;
+    onSelect: (item: PrerenderedCardLike | FieldOption) => void;
     chooseCard: () => void;
     createNew?: () => void;
     createNewIsRunning?: boolean;
@@ -172,10 +171,10 @@ interface Signature {
 interface OptionsDropdownSignature {
   Args: {
     isField?: boolean;
-    options: PrerenderedCard[] | FieldOption[] | undefined;
-    selected?: PrerenderedCard | FieldOption | SelectedInstance;
+    options: PrerenderedCardLike[] | FieldOption[] | undefined;
+    selected?: PrerenderedCardLike | FieldOption | SelectedInstance;
     selection: SelectedInstance | undefined;
-    onSelect: (item: PrerenderedCard | FieldOption) => void;
+    onSelect: (item: PrerenderedCardLike | FieldOption) => void;
     chooseCard: () => void;
     createNew?: () => void;
     createNewIsRunning?: boolean;
@@ -338,7 +337,7 @@ export default class InstanceSelectDropdown extends Component<Signature> {
     return this.args.moduleId === `${baseCardRef.module}/${baseCardRef.name}`;
   }
 
-  private showResults = (cards: PrerenderedCard[] | undefined) => {
+  private showResults = (cards: PrerenderedCardLike[] | undefined) => {
     return (
       cards?.length ||
       this.persistedCardId ||
@@ -348,11 +347,11 @@ export default class InstanceSelectDropdown extends Component<Signature> {
   };
 
   // sort prerendered-search card results by most recently viewed
-  private getSortedCards = (cards: PrerenderedCard[]) => {
+  private getSortedCards = (cards: PrerenderedCardLike[]) => {
     if (!this.args.recentCardIds?.length) {
       return;
     }
-    let sortedCards: PrerenderedCard[] = [];
+    let sortedCards: PrerenderedCardLike[] = [];
     for (let id of this.args.recentCardIds) {
       let card = cards.find((c) => trimJsonExtension(c.url) === id);
       if (card) {
@@ -367,7 +366,7 @@ export default class InstanceSelectDropdown extends Component<Signature> {
       ?.cardId;
   }
 
-  private findSelectedCard = (prerenderedCards?: PrerenderedCard[]) => {
+  private findSelectedCard = (prerenderedCards?: PrerenderedCardLike[]) => {
     if (!prerenderedCards?.length) {
       // it is possible that there's a persisted cardId in playground-selections local storage
       // but that the card is no longer in recent-files local storage
@@ -404,7 +403,7 @@ export default class InstanceSelectDropdown extends Component<Signature> {
     return fields.find((f) => f.index === selection.fieldIndex);
   };
 
-  private handleResults = (results?: PrerenderedCard[]) => {
+  private handleResults = (results?: PrerenderedCardLike[]) => {
     if (!results?.length) {
       // if expanded search returns no instances, create new instance
       this.args.createNew?.();

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
@@ -20,6 +20,7 @@ import {
   type LooseSingleCardDocument,
   type Query,
   type CardErrorJSONAPI,
+  type PrerenderedCardLike,
 } from '@cardstack/runtime-common';
 
 import type LoaderService from '@cardstack/host/services/loader-service';
@@ -41,8 +42,6 @@ import type { Spec } from 'https://cardstack.com/base/spec';
 
 import PlaygroundContent from './playground-content';
 import PlaygroundTitle from './playground-title';
-
-import type { PrerenderedCard } from '../../../prerendered-card-search';
 
 import type { WithBoundArgs } from '@glint/template';
 
@@ -280,7 +279,7 @@ export default class PlaygroundPanel extends Component<Signature> {
     };
   }
 
-  @action private onSelect(item: PrerenderedCard | FieldOption) {
+  @action private onSelect(item: PrerenderedCardLike | FieldOption) {
     if (this.args.isFieldDef) {
       this.persistSelections(
         this.card!.id,
@@ -288,7 +287,7 @@ export default class PlaygroundPanel extends Component<Signature> {
         (item as FieldOption).index,
       );
     } else {
-      this.persistSelections((item as PrerenderedCard).url);
+      this.persistSelections((item as PrerenderedCardLike).url);
     }
   }
 

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-title.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-title.gts
@@ -7,7 +7,11 @@ import ToElsewhere from 'ember-elsewhere/components/to-elsewhere';
 
 import { cardTypeDisplayName } from '@cardstack/runtime-common';
 
-import type { Format, Query } from '@cardstack/runtime-common';
+import type {
+  Format,
+  Query,
+  PrerenderedCardLike,
+} from '@cardstack/runtime-common';
 
 import consumeContext from '@cardstack/host/helpers/consume-context';
 
@@ -18,7 +22,6 @@ import FieldPickerModal from './field-chooser-modal';
 import InstanceSelectDropdown from './instance-chooser-dropdown';
 
 import type { FieldOption, SelectedInstance } from './playground-panel';
-import type { PrerenderedCard } from '../../../prerendered-card-search';
 
 interface Signature {
   Args: {
@@ -29,7 +32,7 @@ interface Signature {
     availableRealmURLs: string[];
     fieldOptions: FieldOption[] | undefined;
     selection: SelectedInstance | undefined;
-    onSelect: (item: PrerenderedCard | FieldOption) => void;
+    onSelect: (item: PrerenderedCardLike | FieldOption) => void;
     chooseCard: () => void;
     chooseField: (index: number) => void;
     createNew: () => void;

--- a/packages/host/app/components/prerendered-card-search.gts
+++ b/packages/host/app/components/prerendered-card-search.gts
@@ -11,13 +11,18 @@ import { flatMap, isEqual } from 'lodash';
 
 import { TrackedSet } from 'tracked-built-ins';
 
-import { Query, RealmPaths } from '@cardstack/runtime-common';
+import { type Query, RealmPaths } from '@cardstack/runtime-common';
 import {
   PrerenderedCardCollectionDocument,
   isPrerenderedCardCollectionDocument,
 } from '@cardstack/runtime-common/card-document';
 
-import { type Format } from 'https://cardstack.com/base/card-api';
+import {
+  type Format,
+  type PrerenderedCardData,
+  type PrerenderedCardLike,
+  type PrerenderedCardComponentSignature,
+} from 'https://cardstack.com/base/card-api';
 
 import type { RealmEventContent } from 'https://cardstack.com/base/matrix-event';
 
@@ -29,14 +34,7 @@ import type LoaderService from '../services/loader-service';
 
 const waiter = buildWaiter('prerendered-card-search:waiter');
 
-export interface PrerenderedCardData {
-  url: string;
-  realmUrl: string;
-  html: string;
-  isError: boolean;
-}
-
-export class PrerenderedCard {
+export class PrerenderedCard implements PrerenderedCardLike {
   component: HTMLComponent;
   constructor(private data: PrerenderedCardData) {
     if (data.isError && !data.html) {
@@ -98,22 +96,7 @@ function getErrorComponent(realmURL: string, url: string) {
   return DefaultErrorResultComponent;
 }
 
-interface Signature {
-  Element: undefined;
-  Args: {
-    query: Query;
-    format: Format;
-    cardUrls?: string[];
-    realms: string[];
-    isLive?: boolean;
-  };
-  Blocks: {
-    loading: [];
-    response: [cards: PrerenderedCard[]];
-  };
-}
-
-export default class PrerenderedCardSearch extends Component<Signature> {
+export default class PrerenderedCardSearch extends Component<PrerenderedCardComponentSignature> {
   @service declare cardService: CardService;
   @service declare loaderService: LoaderService;
   _lastSearchQuery: Query | null = null;
@@ -122,7 +105,7 @@ export default class PrerenderedCardSearch extends Component<Signature> {
   _lastRealms: string[] | undefined;
   realmsNeedingRefresh = new TrackedSet<string>();
 
-  constructor(owner: unknown, args: Signature['Args']) {
+  constructor(owner: unknown, args: PrerenderedCardComponentSignature['Args']) {
     super(owner, args);
     for (const realm of this.args.realms) {
       this.realmsNeedingRefresh.add(realm);

--- a/packages/host/app/components/prerendered-card-search.gts
+++ b/packages/host/app/components/prerendered-card-search.gts
@@ -11,18 +11,19 @@ import { flatMap, isEqual } from 'lodash';
 
 import { TrackedSet } from 'tracked-built-ins';
 
-import { type Query, RealmPaths } from '@cardstack/runtime-common';
+import {
+  type Query,
+  RealmPaths,
+  type PrerenderedCardLike,
+  type PrerenderedCardData,
+  type PrerenderedCardComponentSignature,
+} from '@cardstack/runtime-common';
 import {
   PrerenderedCardCollectionDocument,
   isPrerenderedCardCollectionDocument,
 } from '@cardstack/runtime-common/card-document';
 
-import {
-  type Format,
-  type PrerenderedCardData,
-  type PrerenderedCardLike,
-  type PrerenderedCardComponentSignature,
-} from 'https://cardstack.com/base/card-api';
+import { type Format } from 'https://cardstack.com/base/card-api';
 
 import type { RealmEventContent } from 'https://cardstack.com/base/matrix-event';
 
@@ -36,7 +37,7 @@ const waiter = buildWaiter('prerendered-card-search:waiter');
 
 export class PrerenderedCard implements PrerenderedCardLike {
   component: HTMLComponent;
-  constructor(private data: PrerenderedCardData) {
+  constructor(public data: PrerenderedCardData) {
     if (data.isError && !data.html) {
       this.component = getErrorComponent(data.realmUrl, data.url);
     } else {

--- a/packages/realm-server/tests/cards/person-with-error.gts
+++ b/packages/realm-server/tests/cards/person-with-error.gts
@@ -38,7 +38,10 @@ export class PersonCard extends CardDef {
       };
     }
     get realms() {
-      return [this.args.model[realmURL]];
+      return [this.args.model[realmURL]!];
+    }
+    get realmHrefs() {
+      return this.realms.map((url) => url.href);
     }
     <template>
       <style>
@@ -56,7 +59,7 @@ export class PersonCard extends CardDef {
         <PrerenderedCardSearch
           @query={{this.query}}
           @format='fitted'
-          @realms={{this.realms}}
+          @realms={{this.realmHrefs}}
           @isLive={{true}}
         >
 

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -571,3 +571,5 @@ export function unixTime(epochTimeMs: number) {
 export function isLocalId(id: string) {
   return !id.startsWith('http');
 }
+
+export * from './prerendered-card-search';

--- a/packages/runtime-common/package.json
+++ b/packages/runtime-common/package.json
@@ -15,6 +15,7 @@
     "@babel/types": "^7.20.0",
     "@cardstack/boxel-ui": "workspace:*",
     "@cardstack/eslint-plugin-boxel": "workspace:*",
+    "@glint/template": "1.3.0",
     "@lukeed/uuid": "catalog:",
     "@types/babel__core": "catalog:",
     "@types/babel__generator": "catalog:",

--- a/packages/runtime-common/prerendered-card-search.ts
+++ b/packages/runtime-common/prerendered-card-search.ts
@@ -1,0 +1,32 @@
+import type { ComponentLike } from '@glint/template';
+import { type Query } from './query';
+import { type Format } from './formats';
+
+export interface PrerenderedCardData {
+  url: string;
+  realmUrl: string;
+  html: string;
+  isError: boolean;
+}
+
+export interface PrerenderedCardLike {
+  url: string;
+  isError: boolean;
+  realmUrl: string;
+  component: ComponentLike<{ Args: {} }>;
+}
+
+export interface PrerenderedCardComponentSignature {
+  Element: undefined;
+  Args: {
+    query: Query;
+    format: Format;
+    realms: string[];
+    cardUrls?: string[];
+    isLive?: boolean;
+  };
+  Blocks: {
+    loading: [];
+    response: [cards: PrerenderedCardLike[]];
+  };
+}

--- a/packages/seed-realm/app-card.gts
+++ b/packages/seed-realm/app-card.gts
@@ -12,11 +12,14 @@ import {
   StringField,
   type CardContext,
   FieldsTypeFor,
-  type PrerenderedCardLike,
 } from 'https://cardstack.com/base/card-api';
 import { CardContainer } from '@cardstack/boxel-ui/components';
 import { and, bool, cn } from '@cardstack/boxel-ui/helpers';
-import { baseRealm } from '@cardstack/runtime-common';
+import {
+  type Query,
+  baseRealm,
+  type PrerenderedCardLike,
+} from '@cardstack/runtime-common';
 import { hash } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
@@ -164,21 +167,23 @@ class DefaultTabTemplate extends GlimmerComponent<DefaultTabSignature> {
   <template>
     <div class='app-card-content'>
       {{#if this.activeTabRef}}
-        <@context.prerenderedCardSearchComponent
-          @query={{this.query}}
-          @format='fitted'
-          @realms={{@realms}}
-          @isLive={{true}}
-        >
-          <:loading>Loading...</:loading>
-          <:response as |cards|>
-            {{#if @activeTab.isTable}}
-              <TableView @cards={{cards}} @context={{@context}} />
-            {{else}}
-              <CardsGrid @cards={{cards}} @context={{@context}} />
-            {{/if}}
-          </:response>
-        </@context.prerenderedCardSearchComponent>
+        {{#if this.query}}
+          <@context.prerenderedCardSearchComponent
+            @query={{this.query}}
+            @format='fitted'
+            @realms={{@realms}}
+            @isLive={{true}}
+          >
+            <:loading>Loading...</:loading>
+            <:response as |cards|>
+              {{#if @activeTab.isTable}}
+                <TableView @cards={{cards}} @context={{@context}} />
+              {{else}}
+                <CardsGrid @cards={{cards}} @context={{@context}} />
+              {{/if}}
+            </:response>
+          </@context.prerenderedCardSearchComponent>
+        {{/if}}
       {{else}}
         <p>No cards available</p>
       {{/if}}
@@ -312,7 +317,7 @@ class DefaultTabTemplate extends GlimmerComponent<DefaultTabSignature> {
           by: 'title',
         },
       ],
-    };
+    } as Query;
   }
 
   @action createNew(value: unknown) {

--- a/packages/seed-realm/app-card.gts
+++ b/packages/seed-realm/app-card.gts
@@ -12,6 +12,7 @@ import {
   StringField,
   type CardContext,
   FieldsTypeFor,
+  type PrerenderedCardLike,
 } from 'https://cardstack.com/base/card-api';
 import { CardContainer } from '@cardstack/boxel-ui/components';
 import { and, bool, cn } from '@cardstack/boxel-ui/helpers';
@@ -49,11 +50,6 @@ export interface DefaultTabSignature extends TabComponentSignature {
   context?: CardContext;
 }
 
-interface PrerenderedCard {
-  url: string;
-  component: typeof GlimmerComponent;
-}
-
 export class Tab extends FieldDef {
   @field displayName = contains(StringField);
   @field tabId = contains(StringField);
@@ -62,7 +58,7 @@ export class Tab extends FieldDef {
 }
 
 class TableView extends GlimmerComponent<{
-  Args: { cards: PrerenderedCard[]; context?: CardContext };
+  Args: { cards: PrerenderedCardLike[]; context?: CardContext };
 }> {
   <template>
     {{#if this.isLoaded}}
@@ -481,7 +477,7 @@ export class AppCard extends CardDef {
 
 export class CardsGrid extends GlimmerComponent<{
   Args: {
-    cards: PrerenderedCard[];
+    cards: PrerenderedCardLike[];
     context?: CardContext;
     isListFormat?: boolean;
   };

--- a/packages/seed-realm/blog-app.gts
+++ b/packages/seed-realm/blog-app.gts
@@ -225,7 +225,7 @@ class BlogAppTemplate extends Component<typeof BlogApp> {
             <CardList
               @context={{@context}}
               @query={{this.query}}
-              @realms={{this.realms}}
+              @realms={{this.realmHrefs}}
               class='blog-app-card-list {{this.gridClass}}'
             >
               <:meta as |card|>
@@ -242,7 +242,7 @@ class BlogAppTemplate extends Component<typeof BlogApp> {
               @selectedView={{this.selectedView}}
               @context={{@context}}
               @query={{this.query}}
-              @realms={{this.realms}}
+              @realms={{this.realmHrefs}}
               class={{this.gridClass}}
             />
           {{/if}}
@@ -352,6 +352,10 @@ class BlogAppTemplate extends Component<typeof BlogApp> {
 
   private get realms() {
     return [this.args.model[realmURL]!];
+  }
+
+  private get realmHrefs() {
+    return this.realms.map((url) => url.href);
   }
 
   private get query() {

--- a/packages/seed-realm/components/card-list.gts
+++ b/packages/seed-realm/components/card-list.gts
@@ -1,15 +1,13 @@
 import GlimmerComponent from '@glimmer/component';
 
-import { type CardContext } from 'https://cardstack.com/base/card-api';
+import {
+  type CardContext,
+  type PrerenderedCardLike,
+} from 'https://cardstack.com/base/card-api';
 
 import { type Query } from '@cardstack/runtime-common';
 
 import { CardContainer } from '@cardstack/boxel-ui/components';
-
-interface PrerenderedCard {
-  url: string;
-  component: any;
-}
 
 interface CardListSignature {
   Args: {
@@ -18,7 +16,7 @@ interface CardListSignature {
     context?: CardContext;
   };
   Blocks: {
-    meta: [card: PrerenderedCard];
+    meta: [card: PrerenderedCardLike];
   };
   Element: HTMLElement;
 }

--- a/packages/seed-realm/components/card-list.gts
+++ b/packages/seed-realm/components/card-list.gts
@@ -1,18 +1,18 @@
 import GlimmerComponent from '@glimmer/component';
 
-import {
-  type CardContext,
-  type PrerenderedCardLike,
-} from 'https://cardstack.com/base/card-api';
+import { type CardContext } from 'https://cardstack.com/base/card-api';
 
-import { type Query } from '@cardstack/runtime-common';
+import {
+  type Query,
+  type PrerenderedCardLike,
+} from '@cardstack/runtime-common';
 
 import { CardContainer } from '@cardstack/boxel-ui/components';
 
 interface CardListSignature {
   Args: {
     query: Query;
-    realms: URL[];
+    realms: string[];
     context?: CardContext;
   };
   Blocks: {

--- a/packages/seed-realm/components/grid.gts
+++ b/packages/seed-realm/components/grid.gts
@@ -9,7 +9,7 @@ import { CardContainer } from '@cardstack/boxel-ui/components';
 interface CardsGridSignature {
   Args: {
     query: Query;
-    realms: URL[];
+    realms: string[];
     selectedView: string;
     context?: CardContext;
   };

--- a/packages/seed-realm/crm-app.gts
+++ b/packages/seed-realm/crm-app.gts
@@ -653,13 +653,13 @@ class CrmAppTemplate extends Component<typeof CrmApp> {
             <CardList
               @context={{@context}}
               @query={{this.query}}
-              @realms={{this.realms}}
+              @realms={{this.realmHrefs}}
               class='crm-app-grid'
             />
           {{else}}
             <CardsGrid
               @query={{this.query}}
-              @realms={{this.realms}}
+              @realms={{this.realmHrefs}}
               @selectedView={{this.selectedView}}
               @context={{@context}}
               class='crm-app-grid'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -654,7 +654,7 @@ importers:
         version: 1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)))
       '@glint/environment-ember-template-imports':
         specifier: 1.3.0
-        version: 1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))))(@glint/template@1.3.0)
+        version: 1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))))(@glint/template@1.3.0)
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.48.0
@@ -815,7 +815,7 @@ importers:
         version: 6.3.0
       ember-concurrency:
         specifier: 'catalog:'
-        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
+        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
       ember-css-url:
         specifier: ^1.0.0
         version: 1.0.0(patch_hash=0e5253a008cc7bf02424d786e7a8fb2397bc48962f3cd1443f2c0fdd8200c96d)
@@ -824,7 +824,7 @@ importers:
         version: 4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-resources:
         specifier: ^6.5.1
-        version: 6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-concurrency@4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)))(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
+        version: 6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-concurrency@4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)))(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-template-lint:
         specifier: ^5.11.2
         version: 5.11.2
@@ -1009,7 +1009,7 @@ importers:
         version: 5.2.1
       ember-concurrency:
         specifier: 'catalog:'
-        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
+        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
       ember-load-initializers:
         specifier: ^2.1.2
         version: 2.1.2(@babel/core@7.26.10)
@@ -1058,7 +1058,7 @@ importers:
         version: 1.3.0(typescript@5.1.6)
       '@glint/environment-ember-template-imports':
         specifier: 1.3.0
-        version: 1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))))(@glint/template@1.3.0)
+        version: 1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))))(@glint/template@1.3.0)
       '@rollup/plugin-babel':
         specifier: 'catalog:'
         version: 6.0.4(@babel/core@7.26.10)(@types/babel__core@7.1.19)(rollup@4.40.0)
@@ -1187,7 +1187,7 @@ importers:
         version: 1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)))
       '@glint/environment-ember-template-imports':
         specifier: 1.3.0
-        version: 1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))))(@glint/template@1.3.0)
+        version: 1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))))(@glint/template@1.3.0)
       '@glint/template':
         specifier: 1.3.0
         version: 1.3.0
@@ -1397,7 +1397,7 @@ importers:
         version: 8.0.4(patch_hash=19b0fc5d4bd8b9aa296c4065fa5e33bdbb965db0b277810b596eacd0b9e2f428)(2ae94f35bd5e6e6dafa095817afdf7bd)
       ember-concurrency:
         specifier: 'catalog:'
-        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
+        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
       ember-concurrency-ts:
         specifier: 'catalog:'
         version: 0.3.1(ember-concurrency@4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)))
@@ -1618,7 +1618,7 @@ importers:
         version: 1.3.0(typescript@5.1.6)
       '@glint/environment-ember-template-imports':
         specifier: 1.3.0
-        version: 1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))))(@glint/template@1.3.0)
+        version: 1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))))(@glint/template@1.3.0)
       '@glint/template':
         specifier: 1.3.0
         version: 1.3.0
@@ -1807,7 +1807,7 @@ importers:
         version: 8.2.2
       ember-concurrency:
         specifier: 'catalog:'
-        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
+        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
       ember-modifier:
         specifier: ^4.1.0
         version: 4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
@@ -1843,7 +1843,7 @@ importers:
         version: 8.2.2
       ember-concurrency:
         specifier: 'catalog:'
-        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
+        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
       ember-modifier:
         specifier: ^4.1.0
         version: 4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
@@ -1948,7 +1948,7 @@ importers:
         version: 8.2.2
       ember-concurrency:
         specifier: 'catalog:'
-        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
+        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
       ember-modifier:
         specifier: ^4.1.0
         version: 4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
@@ -2035,7 +2035,7 @@ importers:
         version: 1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)))
       '@glint/environment-ember-template-imports':
         specifier: 1.3.0
-        version: 1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))))(@glint/template@1.3.0)
+        version: 1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))))(@glint/template@1.3.0)
       '@glint/template':
         specifier: 1.3.0
         version: 1.3.0
@@ -2206,7 +2206,7 @@ importers:
         version: 6.0.1(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-concurrency:
         specifier: 'catalog:'
-        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
+        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
       ember-css-url:
         specifier: ^1.0.0
         version: 1.0.0(patch_hash=0e5253a008cc7bf02424d786e7a8fb2397bc48962f3cd1443f2c0fdd8200c96d)
@@ -2251,7 +2251,7 @@ importers:
         version: 11.0.1(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-resources:
         specifier: ^6.5.1
-        version: 6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-concurrency@4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)))(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
+        version: 6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-concurrency@4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)))(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-route-template:
         specifier: ^1.0.3
         version: 1.0.3
@@ -2739,6 +2739,9 @@ importers:
       '@cardstack/eslint-plugin-boxel':
         specifier: workspace:*
         version: link:../eslint-plugin-boxel
+      '@glint/template':
+        specifier: 1.3.0
+        version: 1.3.0
       '@lukeed/uuid':
         specifier: 'catalog:'
         version: 2.0.1
@@ -2874,7 +2877,7 @@ importers:
         version: 1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)))
       '@glint/environment-ember-template-imports':
         specifier: 1.3.0
-        version: 1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))))(@glint/template@1.3.0)
+        version: 1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))))(@glint/template@1.3.0)
       '@types/dompurify':
         specifier: 'catalog:'
         version: 3.0.2
@@ -2922,7 +2925,7 @@ importers:
         version: 8.2.2
       ember-concurrency:
         specifier: 'catalog:'
-        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
+        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
       ember-modifier:
         specifier: ^4.1.0
         version: 4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
@@ -2962,7 +2965,7 @@ importers:
         version: 1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)))
       '@glint/environment-ember-template-imports':
         specifier: ^1.3.0
-        version: 1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))))(@glint/template@1.3.0)
+        version: 1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))))(@glint/template@1.3.0)
       '@glint/template':
         specifier: ^1.3.0
         version: 1.3.0
@@ -11059,6 +11062,7 @@ packages:
 
   path-match@1.2.4:
     resolution: {integrity: sha512-UWlehEdqu36jmh4h5CWJ7tARp1OEVKGHKm6+dg9qMq5RKUTV5WJrGgaZ3dN2m7WFAXDbjlHzvJvL/IUpy84Ktw==}
+    deprecated: This package is archived and no longer maintained. For support, visit https://github.com/expressjs/express/discussions
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -15239,7 +15243,7 @@ snapshots:
       ember-cli-htmlbars: 6.3.0
       ember-modifier: 4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
 
-  '@glint/environment-ember-template-imports@1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))))(@glint/template@1.3.0)':
+  '@glint/environment-ember-template-imports@1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))))(@glint/template@1.3.0)':
     dependencies:
       '@glint/environment-ember-loose': 1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)))
       '@glint/template': 1.3.0
@@ -19742,11 +19746,11 @@ snapshots:
     dependencies:
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 4.5.0
-      ember-concurrency: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
+      ember-concurrency: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
     transitivePeerDependencies:
       - supports-color
 
-  ember-concurrency@3.1.1(@babel/core@7.26.10)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)):
+  ember-concurrency@3.1.1(@babel/core@7.26.10)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)):
     dependencies:
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/types': 7.27.0
@@ -19761,7 +19765,7 @@ snapshots:
       - supports-color
     optional: true
 
-  ember-concurrency@4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)):
+  ember-concurrency@4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)):
     dependencies:
       '@babel/helper-module-imports': 7.25.9(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.26.5
@@ -20002,7 +20006,7 @@ snapshots:
       '@glimmer/tracking': 1.1.2
       decorator-transforms: 2.3.0(@babel/core@7.26.10)
       ember-assign-helper: 0.5.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
-      ember-concurrency: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
+      ember-concurrency: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
       ember-element-helper: 0.8.6(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))))(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-source: 5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)
       ember-truth-helpers: 4.0.3(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
@@ -20023,7 +20027,7 @@ snapshots:
       decorator-transforms: 1.1.0(@babel/core@7.26.10)
       ember-assign-helper: 0.5.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-basic-dropdown: 8.0.4(patch_hash=19b0fc5d4bd8b9aa296c4065fa5e33bdbb965db0b277810b596eacd0b9e2f428)(2ae94f35bd5e6e6dafa095817afdf7bd)
-      ember-concurrency: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
+      ember-concurrency: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
       ember-source: 5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)
       ember-truth-helpers: 4.0.3(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
     transitivePeerDependencies:
@@ -20086,11 +20090,11 @@ snapshots:
     optionalDependencies:
       '@ember/test-waiters': 3.1.0
       '@glimmer/component': 1.1.2(@babel/core@7.26.10)
-      ember-concurrency: 3.1.1(@babel/core@7.26.10)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
+      ember-concurrency: 3.1.1(@babel/core@7.26.10)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
     transitivePeerDependencies:
       - supports-color
 
-  ember-resources@6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-concurrency@4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)))(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)):
+  ember-resources@6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-concurrency@4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)))(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)):
     dependencies:
       '@babel/runtime': 7.22.11
       '@embroider/addon-shim': 1.8.9
@@ -20102,7 +20106,7 @@ snapshots:
     optionalDependencies:
       '@ember/test-waiters': 3.1.0
       '@glimmer/component': 1.1.2(@babel/core@7.26.10)
-      ember-concurrency: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
+      ember-concurrency: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
https://linear.app/cardstack/issue/CS-8660/card-creationdeletion-doesnt-update-live-search-cards

The issue is that realmURL set in the subscription was a URL and not a string

**Changes**

- add types to pre-rendered card search
-Moved pre-rendered card search types to runtime-common 
  - can be consumed by card-api
  - can be consumed by host 
- change lint errors that follow the change
