### PR TITLE
AI assistant: Fix creating new files when there is a name conflict

### DIFF
--- a/packages/host/app/commands/patch-code.ts
+++ b/packages/host/app/commands/patch-code.ts
@@ -12,12 +12,19 @@ import LintAndFixCommand from './lint-and-fix';
 import type CardService from '../services/card-service';
 import type RealmService from '../services/realm';
 
+interface FileInfo {
+  exists: boolean;
+  hasContent: boolean;
+  content: string;
+}
+
 export default class PatchCodeCommand extends HostBaseCommand<
   typeof BaseCommandModule.PatchCodeInput,
   typeof BaseCommandModule.LintAndFixResult
 > {
   @service declare private cardService: CardService;
   @service declare private realm: RealmService;
+
   description = `Apply code changes to file and then apply lint fixes`;
   static actionVerb = 'Apply';
 
@@ -32,74 +39,117 @@ export default class PatchCodeCommand extends HostBaseCommand<
   ): Promise<BaseCommandModule.LintAndFixResult> {
     let { fileUrl, codeBlocks } = input;
 
-    let getSourceResult = await this.cardService.getSource(new URL(fileUrl));
-    let fileExists = getSourceResult.status !== 404;
-    let fileHasContent = fileExists && getSourceResult.content.trim() !== '';
-    let isCreatingANewFileOrWritingToABlankFile = false;
-    if (codeBlocks.length === 1) {
-      let searchReplaceBlock = codeBlocks[0];
-      let searchPortion = parseSearchReplace(searchReplaceBlock).searchContent;
-      if (searchPortion.trim() === '') {
-        isCreatingANewFileOrWritingToABlankFile = true;
-      }
-    }
-    let source = isCreatingANewFileOrWritingToABlankFile
-      ? ''
-      : getSourceResult.content;
-
-    let applySearchReplaceBlockCommand = new ApplySearchReplaceBlockCommand(
-      this.commandContext,
+    let fileInfo = await this.getFileInfo(fileUrl);
+    let hasEmptySearchPortion = this.hasEmptySearchPortion(codeBlocks);
+    let sourceContent = hasEmptySearchPortion ? '' : fileInfo.content;
+    let patchedCode = await this.applyCodeBlocks(sourceContent, codeBlocks);
+    let lintResult = await this.lintAndFix(fileUrl, patchedCode);
+    let finalFileUrl = await this.determineFinalFileUrl(
+      fileUrl,
+      fileInfo,
+      hasEmptySearchPortion,
     );
 
-    let patchedCode = source;
-    for (const codeBlock of codeBlocks) {
-      let { resultContent } = await applySearchReplaceBlockCommand.execute({
-        fileContent: patchedCode,
-        codeBlock: codeBlock,
-      });
-      patchedCode = resultContent;
-    }
-
-    // lint and fix the final result
-    let lintAndFixCommand = new LintAndFixCommand(this.commandContext);
-    let realmURL = this.realm.url(fileUrl);
-
-    let lintAndFixResult = await lintAndFixCommand.execute({
-      realm: realmURL,
-      fileContent: patchedCode,
-    });
-
-    if (
-      isCreatingANewFileOrWritingToABlankFile &&
-      fileExists &&
-      fileHasContent
-    ) {
-      let counter = 1;
-      let baseFileName = fileUrl.replace(/\.([^.]+)$/, '');
-      let extension = fileUrl.match(/\.([^.]+)$/)?.[0] || '';
-
-      let newFileUrl = '';
-      // eslint-disable-next-line no-constant-condition
-      while (true) {
-        newFileUrl = `${baseFileName}-${counter}${extension}`;
-        let getSourceResult = await this.cardService.getSource(
-          new URL(newFileUrl),
-        );
-        if (counter < 100 && getSourceResult.status !== 404) {
-          counter++;
-        } else {
-          fileUrl = newFileUrl;
-          break;
-        }
-      }
-    }
-
     await this.cardService.saveSource(
-      new URL(fileUrl),
-      lintAndFixResult.output,
+      new URL(finalFileUrl),
+      lintResult.output,
       'bot-patch',
     );
 
-    return lintAndFixResult;
+    return lintResult;
+  }
+
+  private async getFileInfo(fileUrl: string): Promise<FileInfo> {
+    let getSourceResult = await this.cardService.getSource(new URL(fileUrl));
+    let exists = getSourceResult.status !== 404;
+    let content = exists ? getSourceResult.content : '';
+    let hasContent = exists && content.trim() !== '';
+
+    return { exists, hasContent, content };
+  }
+
+  private hasEmptySearchPortion(codeBlocks: string[]): boolean {
+    if (codeBlocks.length !== 1) {
+      return false;
+    }
+
+    let searchReplaceBlock = codeBlocks[0];
+    let { searchContent } = parseSearchReplace(searchReplaceBlock);
+    return searchContent.trim() === '';
+  }
+
+  private async applyCodeBlocks(
+    initialContent: string,
+    codeBlocks: string[],
+  ): Promise<string> {
+    let applyCommand = new ApplySearchReplaceBlockCommand(this.commandContext);
+
+    let content = initialContent;
+    for (let codeBlock of codeBlocks) {
+      let { resultContent } = await applyCommand.execute({
+        fileContent: content,
+        codeBlock: codeBlock,
+      });
+      content = resultContent;
+    }
+
+    return content;
+  }
+
+  private async lintAndFix(
+    fileUrl: string,
+    content: string,
+  ): Promise<BaseCommandModule.LintAndFixResult> {
+    let lintCommand = new LintAndFixCommand(this.commandContext);
+    let realmURL = this.realm.url(fileUrl);
+
+    return await lintCommand.execute({
+      realm: realmURL,
+      fileContent: content,
+    });
+  }
+
+  private async determineFinalFileUrl(
+    originalUrl: string,
+    fileInfo: FileInfo,
+    hasEmptySearchPortion: boolean,
+  ): Promise<string> {
+    if (!hasEmptySearchPortion || !fileInfo.exists || !fileInfo.hasContent) {
+      return originalUrl;
+    }
+
+    return await this.findNonConflictingFilename(originalUrl);
+  }
+
+  private async findNonConflictingFilename(fileUrl: string): Promise<string> {
+    let MAX_ATTEMPTS = 100;
+    let { baseName, extension } = this.parseFilename(fileUrl);
+
+    for (let counter = 1; counter < MAX_ATTEMPTS; counter++) {
+      let candidateUrl = `${baseName}-${counter}${extension}`;
+      let exists = await this.fileExists(candidateUrl);
+
+      if (!exists) {
+        return candidateUrl;
+      }
+    }
+
+    return `${baseName}-${MAX_ATTEMPTS}${extension}`;
+  }
+
+  private parseFilename(fileUrl: string): {
+    baseName: string;
+    extension: string;
+  } {
+    let extensionMatch = fileUrl.match(/\.([^.]+)$/);
+    let extension = extensionMatch?.[0] || '';
+    let baseName = fileUrl.replace(/\.([^.]+)$/, '');
+
+    return { baseName, extension };
+  }
+
+  private async fileExists(fileUrl: string): Promise<boolean> {
+    let getSourceResult = await this.cardService.getSource(new URL(fileUrl));
+    return getSourceResult.status !== 404;
   }
 }

--- a/packages/host/tests/acceptance/code-patches-test.gts
+++ b/packages/host/tests/acceptance/code-patches-test.gts
@@ -342,5 +342,13 @@ I am a newly created hi.txt file but I will get a suffix because hi.txt already 
 
     // hi-1.txt got created because hi.txt already exists
     assert.dom('[data-test-file="hi-1.txt"]').exists();
+
+    await click('[data-test-file="hi-1.txt"]');
+
+    assert.equal(
+      (document.getElementsByClassName('view-lines')[0] as HTMLElement)
+        .innerText,
+      'I am a newly \ncreated hi.txt file \nbut I will get a \nsuffix because hi.\ntxt already exists!',
+    );
   });
 });

--- a/packages/host/tests/acceptance/code-patches-test.gts
+++ b/packages/host/tests/acceptance/code-patches-test.gts
@@ -302,7 +302,7 @@ I am a newly created file2
 http://test-realm/test/hi.txt
 <<<<<<< SEARCH
 =======
-I am a newly created hi.txt file but I will get a suffix because hi.txt already exists!
+This file was supposed to be hi.txt but it got a suffix because hi.txt already exists
 >>>>>>> REPLACE
 \`\`\``;
 
@@ -346,9 +346,12 @@ I am a newly created hi.txt file but I will get a suffix because hi.txt already 
     await click('[data-test-file="hi-1.txt"]');
 
     assert.equal(
-      (document.getElementsByClassName('view-lines')[0] as HTMLElement)
-        .innerText,
-      'I am a newly \ncreated hi.txt file \nbut I will get a \nsuffix because hi.\ntxt already exists!',
+      (
+        document.getElementsByClassName('view-lines')[0] as HTMLElement
+      ).innerText
+        .replace(/\s+/g, ' ')
+        .trim(),
+      'This file was supposed to be hi.txt but it got a suffix because hi.txt already exists',
     );
   });
 });


### PR DESCRIPTION
There was a bug where if the assistant was trying to create a file with a file name that already exists (e.g. `something.gts`), it would create a new file with a prefix but it would merge the new content and the existing file file content and write it into the newly created file (`something-1.gts`). This fixes it so that It only writes the new content. 