### PR TITLE
fix listing button move when hover

### DIFF
--- a/packages/catalog-realm-dev/catalog-app/components/listing-fitted.gts
+++ b/packages/catalog-realm-dev/catalog-app/components/listing-fitted.gts
@@ -458,6 +458,12 @@ export class ListingFittedTemplate extends Component<typeof Listing> {
           display: flex;
           overflow: hidden;
         }
+        .fitted-template :deep(.ember-basic-dropdown-content-placeholder) {
+          display: none;
+        }
+        .fitted-template :deep(.ember-basic-dropdown-content-wormhole-origin) {
+          position: absolute;
+        }
         .display-section {
           flex-shrink: 0;
           display: flex;


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-8702/fix-remix-button-position-run-after-hover

Before: 

https://github.com/user-attachments/assets/20b79fd4-5dfd-4f68-ab20-6edcd6ca22c6



Result:
https://www.loom.com/share/28280faada4c4b909ce1884680dba6f2?sid=2966c548-3e10-45cb-b197-fa2a5de5605f