### PR TITLE
Fix broken auto-generate spec test

### DIFF
--- a/packages/host/tests/acceptance/code-submode/field-playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/field-playground-test.gts
@@ -4,13 +4,12 @@ import { module, test } from 'qunit';
 
 import { specRef, type Realm } from '@cardstack/runtime-common';
 
-import type RealmServerService from '@cardstack/host/services/realm-server';
+import ENV from '@cardstack/host/config/environment';
 
 import {
   percySnapshot,
   setupAcceptanceTestRealm,
   setupLocalIndexing,
-  setupOnSave,
   setupUserSubscription,
   testRealmURL,
 } from '../../helpers';
@@ -33,6 +32,8 @@ import {
 } from '../../helpers/playground';
 import { setRecentFiles } from '../../helpers/recent-files-cards';
 import { setupApplicationTest } from '../../helpers/setup';
+
+const { resolvedBaseRealmURL } = ENV;
 
 const authorCard = `import { contains, field, CardDef, Component, FieldDef } from "https://cardstack.com/base/card-api";
   import MarkdownField from 'https://cardstack.com/base/markdown';
@@ -216,8 +217,6 @@ module('Acceptance | code-submode | field playground', function (_hooks) {
 
     let { setRealmPermissions, setActiveRealms, createAndJoinRoom } =
       mockMatrixUtils;
-
-    setupOnSave(hooks);
 
     hooks.beforeEach(async function () {
       matrixRoomId = createAndJoinRoom({
@@ -998,18 +997,18 @@ module('Acceptance | code-submode | field playground', function (_hooks) {
 
   module('multiple realms', function (hooks) {
     let realm: Realm;
-    let personalRealmURL: string;
-    let additionalRealmURL: string;
+    let origin = new URL(resolvedBaseRealmURL).origin;
+    let personalRealmURL = `${origin}/testuser/personal/`;
+    let additionalRealmURL = `${origin}/testuser/aaa/`; // writeable realm that is lexically before the personal realm
 
     setupApplicationTest(hooks);
     setupLocalIndexing(hooks);
 
     let mockMatrixUtils = setupMockMatrix(hooks, {
       loggedInAs: '@testuser:localhost',
+      activeRealms: [personalRealmURL, additionalRealmURL],
     });
-
-    let { setActiveRealms, setRealmPermissions, createAndJoinRoom } =
-      mockMatrixUtils;
+    let { setRealmPermissions, createAndJoinRoom } = mockMatrixUtils;
 
     hooks.beforeEach(async function () {
       matrixRoomId = createAndJoinRoom({
@@ -1017,13 +1016,6 @@ module('Acceptance | code-submode | field playground', function (_hooks) {
         name: 'room-test',
       });
       setupUserSubscription(matrixRoomId);
-
-      let realmServerService = this.owner.lookup(
-        'service:realm-server',
-      ) as RealmServerService;
-      personalRealmURL = `${realmServerService.url}testuser/personal/`;
-      additionalRealmURL = `${realmServerService.url}testuser/aaa/`; // writeable realm that is lexically before the personal realm
-      setActiveRealms([additionalRealmURL, personalRealmURL]);
 
       await setupAcceptanceTestRealm({
         mockMatrixUtils,
@@ -1144,27 +1136,26 @@ module('Acceptance | code-submode | field playground', function (_hooks) {
       assert.strictEqual(matching.length, 1);
       assert.ok(matching[0].id!.startsWith(`${additionalRealmURL}Spec/`));
 
-      // await toggleSpecPanel();
-      // assert
-      //   .dom('[data-test-spec-selector] > .ember-basic-dropdown-trigger')
-      //   .hasAttribute('aria-disabled', 'true', 'has only 1 spec instance');
-      // assert.dom('[data-test-boxel-input-id="spec-title"]').hasValue('Quote');
-      // assert
-      //   .dom(
-      //     '[data-test-contains-many="containedExamples"] [data-test-item="0"] [data-test-field="quote"] input',
-      //   )
-      //   .hasNoValue();
-
-      // await togglePlaygroundPanel();
-      // assertFieldExists(assert, 'edit');
-      // await toggleSpecPanel();
-      // assert
-      //   .dom('[data-test-spec-selector] > .ember-basic-dropdown-trigger')
-      //   .hasAttribute(
-      //     'aria-disabled',
-      //     'true',
-      //     'still has only 1 spec instance',
-      //   );
+      await toggleSpecPanel();
+      assert
+        .dom('[data-test-spec-selector] > .ember-basic-dropdown-trigger')
+        .hasAttribute('aria-disabled', 'true', 'has only 1 spec instance');
+      assert.dom('[data-test-boxel-input-id="spec-title"]').hasValue('Quote');
+      assert
+        .dom(
+          '[data-test-contains-many="containedExamples"] [data-test-item="0"] [data-test-field="quote"] input',
+        )
+        .hasNoValue();
+      await togglePlaygroundPanel();
+      assertFieldExists(assert, 'edit');
+      await toggleSpecPanel();
+      assert
+        .dom('[data-test-spec-selector] > .ember-basic-dropdown-trigger')
+        .hasAttribute(
+          'aria-disabled',
+          'true',
+          'still has only 1 spec instance',
+        );
     });
 
     test('can create new field instance (has preexisting Spec)', async function (assert) {


### PR DESCRIPTION
This PR un-comments the auto generated spec test assertions. The issue was actually around the test setup, specifically the active realms were being marked as active too late in the test setup and as such the realm matrix rooms used to broadcast realm events were never created. Feeding into this  was an unnecessary dependency on the realm-server service that made the timing of the active realm setup awkward.