### PR TITLE
host: Add getService to no longer need service typecasting

### DIFF
--- a/packages/boxel-motion/test-app/package.json
+++ b/packages/boxel-motion/test-app/package.json
@@ -32,7 +32,7 @@
     "@ember/string": "^3.1.1",
     "@ember/test-helpers": "^3.3.1",
     "@embroider/compat": "^3.5.5",
-    "@embroider/core": "^3.4.14",
+    "@embroider/core": "^3.4.15",
     "@embroider/macros": "^1.16.5",
     "@embroider/test-setup": "^4.0.0",
     "@embroider/webpack": "^4.0.4",

--- a/packages/boxel-ui/test-app/package.json
+++ b/packages/boxel-ui/test-app/package.json
@@ -34,7 +34,7 @@
     "@ember/string": "^3.1.1",
     "@ember/test-helpers": "^3.3.1",
     "@embroider/compat": "^3.5.5",
-    "@embroider/core": "^3.4.14",
+    "@embroider/core": "^3.4.15",
     "@embroider/macros": "^1.16.5",
     "@embroider/test-setup": "^4.0.0",
     "@embroider/webpack": "^4.0.4",

--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -272,3 +272,9 @@ export default class CardService extends Service {
     return (await response.json()).data.attributes;
   }
 }
+
+declare module '@ember/service' {
+  interface Registry {
+    'card-service': CardService;
+  }
+}

--- a/packages/host/app/services/command-service.ts
+++ b/packages/host/app/services/command-service.ts
@@ -398,3 +398,9 @@ function hasPatchData(payload: any): payload is PatchPayload {
       payload.attributes?.patch?.relationships)
   );
 }
+
+declare module '@ember/service' {
+  interface Registry {
+    'command-service': CommandService;
+  }
+}

--- a/packages/host/app/services/environment-service.ts
+++ b/packages/host/app/services/environment-service.ts
@@ -14,3 +14,9 @@ export default class EnvironmentService extends Service {
     this.autoSaveDelayMs = autoSaveDelayMs;
   }
 }
+
+declare module '@ember/service' {
+  interface Registry {
+    'environment-service': EnvironmentService;
+  }
+}

--- a/packages/host/app/services/loader-service.ts
+++ b/packages/host/app/services/loader-service.ts
@@ -105,3 +105,9 @@ export default class LoaderService extends Service {
     return loader;
   }
 }
+
+declare module '@ember/service' {
+  interface Registry {
+    'loader-service': LoaderService;
+  }
+}

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -1672,3 +1672,9 @@ function getAuth(): LoginResponse | undefined {
   }
   return JSON.parse(auth) as LoginResponse;
 }
+
+declare module '@ember/service' {
+  interface Registry {
+    'matrix-service': MatrixService;
+  }
+}

--- a/packages/host/app/services/message-service.ts
+++ b/packages/host/app/services/message-service.ts
@@ -47,3 +47,9 @@ export default class MessageService extends Service {
     });
   }
 }
+
+declare module '@ember/service' {
+  interface Registry {
+    'message-service': MessageService;
+  }
+}

--- a/packages/host/app/services/monaco-service.ts
+++ b/packages/host/app/services/monaco-service.ts
@@ -192,3 +192,9 @@ export default class MonacoService extends Service {
     return this.editor?.getContentHeight();
   }
 }
+
+declare module '@ember/service' {
+  interface Registry {
+    'monaco-service': MonacoService;
+  }
+}

--- a/packages/host/app/services/network.ts
+++ b/packages/host/app/services/network.ts
@@ -95,3 +95,9 @@ export default class NetworkService extends Service {
     this.virtualNetwork = this.makeVirtualNetwork();
   };
 }
+
+declare module '@ember/service' {
+  interface Registry {
+    network: NetworkService;
+  }
+}

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -794,3 +794,9 @@ export default class OperatorModeStateService extends Service {
     return controller;
   }
 }
+
+declare module '@ember/service' {
+  interface Registry {
+    'operator-mode-state-service': OperatorModeStateService;
+  }
+}

--- a/packages/host/app/services/realm-server.ts
+++ b/packages/host/app/services/realm-server.ts
@@ -356,3 +356,9 @@ function claimsFromRawToken(rawToken: string): RealmServerJWTPayload {
   let [_header, payload] = rawToken.split('.');
   return JSON.parse(atob(payload)) as RealmServerJWTPayload;
 }
+
+declare module '@ember/service' {
+  interface Registry {
+    'realm-server': RealmServerService;
+  }
+}

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -697,3 +697,9 @@ let SessionStorage = {
     }
   },
 };
+
+declare module '@ember/service' {
+  interface Registry {
+    realm: RealmService;
+  }
+}

--- a/packages/host/app/services/recent-cards-service.ts
+++ b/packages/host/app/services/recent-cards-service.ts
@@ -145,3 +145,9 @@ export default class RecentCardsService extends Service {
     );
   }
 }
+
+declare module '@ember/service' {
+  interface Registry {
+    'recent-cards-service': RecentCardsService;
+  }
+}

--- a/packages/host/app/services/recent-files-service.ts
+++ b/packages/host/app/services/recent-files-service.ts
@@ -193,3 +193,9 @@ export default class RecentFilesService extends Service {
     }
   }
 }
+
+declare module '@ember/service' {
+  interface Registry {
+    'recent-files-service': RecentFilesService;
+  }
+}

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -1245,3 +1245,9 @@ function resolveDocUrl(id?: string, realm?: string, local?: string) {
   }
   return path.url;
 }
+
+declare module '@ember/service' {
+  interface Registry {
+    store: StoreService;
+  }
+}

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -77,6 +77,7 @@
     "@types/uuid": "catalog:",
     "@typescript-eslint/eslint-plugin": "catalog:",
     "@typescript-eslint/parser": "catalog:",
+    "@universal-ember/test-support": "catalog:",
     "broccoli-asset-rev": "catalog:",
     "broccoli-funnel": "catalog:",
     "broccoli-merge-trees": "catalog:",

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -47,7 +47,7 @@
     "@ember/test-helpers": "^3.3.1",
     "@ember/test-waiters": "^3.0.2",
     "@embroider/compat": "^3.5.5",
-    "@embroider/core": "^3.4.14",
+    "@embroider/core": "^3.4.15",
     "@embroider/macros": "^1.16.5",
     "@embroider/webpack": "^4.0.4",
     "@floating-ui/dom": "catalog:",

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -1,5 +1,7 @@
 import { click, fillIn, waitFor, waitUntil, visit } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
+
 import { module, test } from 'qunit';
 import stringify from 'safe-stable-stringify';
 
@@ -12,9 +14,6 @@ import {
   DEFAULT_LLM,
   DEFAULT_LLM_LIST,
 } from '@cardstack/runtime-common/matrix-constants';
-
-import MatrixService from '@cardstack/host/services/matrix-service';
-import { OperatorModeState } from '@cardstack/host/services/operator-mode-state-service';
 
 import {
   setupLocalIndexing,
@@ -311,9 +310,7 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     );
 
     // Download the card file def
-    const matrixService = this.owner.lookup(
-      'service:matrix-service',
-    ) as MatrixService;
+    const matrixService = getService('matrix-service');
 
     let cardContent = await matrixService.downloadCardFileDef(attachedCard);
 
@@ -653,9 +650,7 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     assert.dom('[data-test-ai-assistant-panel]').exists();
 
     // Verify URL contains updated state with aiAssistantOpen: true
-    let operatorModeStateService = this.owner.lookup(
-      'service:operator-mode-state-service',
-    ) as OperatorModeState;
+    let operatorModeStateService = getService('operator-mode-state-service');
     assert.true(
       operatorModeStateService.aiAssistantOpen,
       'URL state should have aiAssistantOpen: true',

--- a/packages/host/tests/acceptance/basic-test.gts
+++ b/packages/host/tests/acceptance/basic-test.gts
@@ -1,5 +1,6 @@
 import { click, find, visit } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
@@ -7,7 +8,6 @@ import { baseRealm } from '@cardstack/runtime-common';
 import {
   setupLocalIndexing,
   setupAcceptanceTestRealm,
-  lookupLoaderService,
   testRealmURL,
   setupUserSubscription,
 } from '../helpers';
@@ -33,7 +33,7 @@ module('Acceptance | basic tests', function (hooks) {
     });
     setupUserSubscription(matrixRoomId);
 
-    let loaderService = lookupLoaderService();
+    let loaderService = getService('loader-service');
     let loader = loaderService.loader;
     let { field, contains, CardDef, Component } = await loader.import<
       typeof import('https://cardstack.com/base/card-api')

--- a/packages/host/tests/acceptance/catalog-app-test.gts
+++ b/packages/host/tests/acceptance/catalog-app-test.gts
@@ -1,16 +1,14 @@
 import { click, waitFor, waitUntil } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
 import { module, skip, test } from 'qunit';
 
 import ListingRemixCommand from '@cardstack/host/commands/listing-remix';
 import { SearchCardsByQueryCommand } from '@cardstack/host/commands/search-cards';
-import type CommandService from '@cardstack/host/services/command-service';
-import type StoreService from '@cardstack/host/services/store';
 
 import { CardDef } from 'https://cardstack.com/base/card-api';
 
 import {
-  lookupService,
   setupLocalIndexing,
   setupOnSave,
   testRealmURL,
@@ -119,7 +117,7 @@ const authorCardSource = `
         return [this.firstName, this.lastName].filter(Boolean).join(' ');
       },
     });
-  } 
+  }
 `;
 
 let matrixRoomId: string;
@@ -301,7 +299,7 @@ module('Acceptance | catalog app tests', function (hooks) {
           ?.textContent?.includes('Created Instances');
       });
 
-      let commandService = lookupService<CommandService>('command-service');
+      let commandService = getService('command-service');
       let searchCommand = new SearchCardsByQueryCommand(
         commandService.commandContext,
       );
@@ -415,8 +413,8 @@ module('Acceptance | catalog app tests', function (hooks) {
       stacks: [[]],
     });
 
-    let commandService = lookupService<CommandService>('command-service');
-    let store = lookupService<StoreService>('store');
+    let commandService = getService('command-service');
+    let store = getService('store');
 
     let remixCommand = new ListingRemixCommand(commandService.commandContext);
     const listingUrl = testRealmURL + 'Listing/author.json';

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -9,6 +9,7 @@ import {
   settled,
 } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
 import window from 'ember-window-mock';
 import * as MonacoSDK from 'monaco-editor';
 import { module, skip, test } from 'qunit';
@@ -23,7 +24,6 @@ import {
 import { Realm } from '@cardstack/runtime-common/realm';
 
 import type MonacoService from '@cardstack/host/services/monaco-service';
-import type RealmServerService from '@cardstack/host/services/realm-server';
 
 import { CodeModePanelSelections } from '@cardstack/host/utils/local-storage-keys';
 
@@ -436,9 +436,7 @@ module('Acceptance | code submode tests', function (_hooks) {
       });
       setupUserSubscription(matrixRoomId);
 
-      let realmServerService = this.owner.lookup(
-        'service:realm-server',
-      ) as RealmServerService;
+      let realmServerService = getService('realm-server');
       personalRealmURL = `${realmServerService.url}testuser/personal/`;
       additionalRealmURL = `${realmServerService.url}testuser/aaa/`; // writeable realm that is lexically before the personal realm
       catalogRealmURL = `${realmServerService.url}catalog/`;
@@ -549,9 +547,7 @@ module('Acceptance | code submode tests', function (_hooks) {
       });
       setupUserSubscription(matrixRoomId);
 
-      monacoService = this.owner.lookup(
-        'service:monaco-service',
-      ) as MonacoService;
+      monacoService = getService('monaco-service');
 
       // this seeds the loader used during index which obtains url mappings
       // from the global loader

--- a/packages/host/tests/acceptance/code-submode/card-playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/card-playground-test.gts
@@ -21,7 +21,6 @@ import {
   setupUserSubscription,
   testRealmURL,
   visitOperatorMode,
-  lookupLoaderService,
   withoutLoaderMonitoring,
   type TestContextWithSave,
   assertMessages,
@@ -1479,7 +1478,7 @@ module('Acceptance | code-submode | card playground', function (_hooks) {
       await withoutLoaderMonitoring(async () => {
         // The loader service is shared between the realm server and the host.
         // need to reset the loader to pick up the changed module in the indexer
-        lookupLoaderService().resetLoader();
+        getService('loader-service').resetLoader();
         // fix error
         await realm.write(
           'boom-person.gts',

--- a/packages/host/tests/acceptance/code-submode/card-playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/card-playground-test.gts
@@ -8,11 +8,11 @@ import {
 
 import { triggerEvent } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { trimJsonExtension, type Realm } from '@cardstack/runtime-common';
 
-import type RealmServerService from '@cardstack/host/services/realm-server';
 import type RecentFilesService from '@cardstack/host/services/recent-files-service';
 
 import {
@@ -1245,9 +1245,7 @@ module('Acceptance | code-submode | card playground', function (_hooks) {
       });
       setupUserSubscription(matrixRoomId);
 
-      let realmServerService = this.owner.lookup(
-        'service:realm-server',
-      ) as RealmServerService;
+      let realmServerService = getService('realm-server');
       personalRealmURL = `${realmServerService.url}testuser/personal/`;
       additionalRealmURL = `${realmServerService.url}testuser/aaa/`; // writeable realm that is lexically before the personal realm
       setActiveRealms([additionalRealmURL, personalRealmURL]);

--- a/packages/host/tests/acceptance/code-submode/card-playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/card-playground-test.gts
@@ -13,8 +13,6 @@ import { module, test } from 'qunit';
 
 import { trimJsonExtension, type Realm } from '@cardstack/runtime-common';
 
-import type RecentFilesService from '@cardstack/host/services/recent-files-service';
-
 import {
   percySnapshot,
   setupAcceptanceTestRealm,
@@ -701,9 +699,7 @@ module('Acceptance | code-submode | card playground', function (_hooks) {
 
     test('can choose another instance to be opened in playground panel', async function (assert) {
       removeRecentFiles();
-      let recentFilesService = this.owner.lookup(
-        'service:recent-files-service',
-      ) as RecentFilesService;
+      let recentFilesService = getService('recent-files-service');
       assert.strictEqual(recentFilesService.recentFiles?.length, 0);
 
       await openFileInPlayground('blog-post.gts', testRealmURL, {
@@ -745,9 +741,7 @@ module('Acceptance | code-submode | card playground', function (_hooks) {
 
     test<TestContextWithSave>('can create new instance', async function (assert) {
       removeRecentFiles();
-      let recentFilesService = this.owner.lookup(
-        'service:recent-files-service',
-      ) as RecentFilesService;
+      let recentFilesService = getService('recent-files-service');
       assert.strictEqual(recentFilesService.recentFiles?.length, 0);
 
       await visitOperatorMode({

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -1,5 +1,6 @@
 import { click, fillIn, waitFor } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { baseRealm, Deferred } from '@cardstack/runtime-common';
@@ -14,7 +15,6 @@ import {
   getMonacoContent,
   visitOperatorMode as _visitOperatorMode,
   type TestContextWithSave,
-  lookupNetworkService,
   setupUserSubscription,
 } from '../../helpers';
 import { TestRealmAdapter } from '../../helpers/adapter';
@@ -224,7 +224,7 @@ module('Acceptance | code submode | create-file tests', function (hooks) {
     });
     setupUserSubscription(matrixRoomId);
 
-    lookupNetworkService().mount(
+    getService('network').mount(
       async (req: Request) => {
         // Some tests need a simulated creation failure
         if (req.url.includes('fetch-failure')) {

--- a/packages/host/tests/acceptance/code-submode/editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/editor-test.ts
@@ -1,5 +1,7 @@
 import { click, waitFor, fillIn, find, settled } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
+
 import window from 'ember-window-mock';
 import * as MonacoSDK from 'monaco-editor';
 import { module, test } from 'qunit';
@@ -10,8 +12,6 @@ import {
   Deferred,
   baseRealm,
 } from '@cardstack/runtime-common';
-
-import type EnvironmentService from '@cardstack/host/services/environment-service';
 
 import type MonacoService from '@cardstack/host/services/monaco-service';
 
@@ -58,9 +58,7 @@ module('Acceptance | code submode | editor tests', function (hooks) {
     });
     setupUserSubscription(matrixRoomId);
 
-    monacoService = this.owner.lookup(
-      'service:monaco-service',
-    ) as MonacoService;
+    monacoService = getService('monaco-service');
 
     window.localStorage.setItem(
       RecentFiles,
@@ -588,9 +586,7 @@ module('Acceptance | code submode | editor tests', function (hooks) {
   });
 
   test<TestContextWithSave>('unsaved changes made in monaco editor are saved when opening a different file', async function (assert) {
-    let environment = this.owner.lookup(
-      'service:environment-service',
-    ) as EnvironmentService;
+    let environment = getService('environment-service');
     environment.autoSaveDelayMs = 1000; // slowdown the auto save so it doesn't interfere with this test
     assert.expect(2);
     await visitOperatorMode({
@@ -616,9 +612,7 @@ module('Acceptance | code submode | editor tests', function (hooks) {
   });
 
   test<TestContextWithSave>('unsaved changes made in card editor are saved when switching out of code submode', async function (assert) {
-    let environment = this.owner.lookup(
-      'service:environment-service',
-    ) as EnvironmentService;
+    let environment = getService('environment-service');
     environment.autoSaveDelayMs = 1000; // slowdown the auto save so it doesn't interfere with this test
     let numSaves = 0;
     assert.expect(2);

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -9,6 +9,8 @@ import {
   visit,
 } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
+
 import * as MonacoSDK from 'monaco-editor';
 import { module, test } from 'qunit';
 
@@ -20,8 +22,6 @@ import { Submodes } from '@cardstack/host/components/submode-switcher';
 
 import type MonacoService from '@cardstack/host/services/monaco-service';
 import { SerializedState } from '@cardstack/host/services/operator-mode-state-service';
-import type RecentCardsService from '@cardstack/host/services/recent-cards-service';
-import RecentFilesService from '@cardstack/host/services/recent-files-service';
 
 import {
   elementIsVisible,
@@ -548,9 +548,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
       },
     }));
 
-    monacoService = this.owner.lookup(
-      'service:monaco-service',
-    ) as MonacoService;
+    monacoService = getService('monaco-service');
   });
 
   test('inspector will show json instance definition and module definition in card inheritance panel', async function (assert) {
@@ -965,12 +963,8 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
   });
 
   test('can delete a card instance from code submode with no recent files to fall back on', async function (assert) {
-    let recentCardsService = this.owner.lookup(
-      'service:recent-cards-service',
-    ) as RecentCardsService;
-    let recentFilesService = this.owner.lookup(
-      'service:recent-files-service',
-    ) as RecentFilesService;
+    let recentCardsService = getService('recent-cards-service');
+    let recentFilesService = getService('recent-files-service');
 
     [`${testRealmURL}Pet/vangogh`, `${testRealmURL}Person/1`].map((url) =>
       recentCardsService.add(url),
@@ -1046,9 +1040,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
   });
 
   test('Can delete a card instance from code submode and fall back to recent file', async function (assert) {
-    let recentFilesService = this.owner.lookup(
-      'service:recent-files-service',
-    ) as RecentFilesService;
+    let recentFilesService = getService('recent-files-service');
 
     await visitOperatorMode({
       stacks: [
@@ -1119,9 +1111,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
   });
 
   test('can delete a card definition and fallback to recent file', async function (assert) {
-    let recentFilesService = this.owner.lookup(
-      'service:recent-files-service',
-    ) as RecentFilesService;
+    let recentFilesService = getService('recent-files-service');
 
     await visitOperatorMode({
       submode: 'code',
@@ -1157,9 +1147,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
   });
 
   test('can delete a card definition with no recent files to fall back on', async function (assert) {
-    let recentFilesService = this.owner.lookup(
-      'service:recent-files-service',
-    ) as RecentFilesService;
+    let recentFilesService = getService('recent-files-service');
 
     await visitOperatorMode({
       stacks: [[]],

--- a/packages/host/tests/acceptance/code-submode/recent-files-test.ts
+++ b/packages/host/tests/acceptance/code-submode/recent-files-test.ts
@@ -8,6 +8,8 @@ import {
 
 import { waitUntil } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
+
 import * as MonacoSDK from 'monaco-editor';
 import { module, test } from 'qunit';
 
@@ -205,9 +207,7 @@ module('Acceptance | code submode | recent files tests', function (hooks) {
       name: 'room-test',
     });
     setupUserSubscription(matrixRoomId);
-    monacoService = this.owner.lookup(
-      'service:monaco-service',
-    ) as MonacoService;
+    monacoService = getService('monaco-service');
 
     // this seeds the loader used during index which obtains url mappings
     // from the global loader

--- a/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
@@ -6,6 +6,8 @@ import {
   waitUntil,
 } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
+
 import { module, test } from 'qunit';
 
 import { baseRealm, Deferred } from '@cardstack/runtime-common';
@@ -319,9 +321,7 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
       },
     });
 
-    monacoService = this.owner.lookup(
-      'service:monaco-service',
-    ) as MonacoService;
+    monacoService = getService('monaco-service');
   });
 
   test('schema editor lists the inheritance chain', async function (assert) {

--- a/packages/host/tests/acceptance/code-submode/spec-test.gts
+++ b/packages/host/tests/acceptance/code-submode/spec-test.gts
@@ -8,11 +8,10 @@ import {
   waitUntil,
 } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { baseRealm, Deferred } from '@cardstack/runtime-common';
-
-import MessageService from '@cardstack/host/services/message-service';
 
 import {
   setupLocalIndexing,
@@ -21,7 +20,6 @@ import {
   visitOperatorMode,
   setupUserSubscription,
   percySnapshot,
-  lookupService,
   setupOnSave,
   withSlowSave,
   type TestContextWithSave,
@@ -667,7 +665,7 @@ module('Acceptance | Spec preview', function (hooks) {
   });
   test('does not lose input field focus when editing spec', async function (assert) {
     const receivedEventDeferred = new Deferred<void>();
-    const messageService = lookupService<MessageService>('message-service');
+    const messageService = getService('message-service');
 
     messageService.listenerCallbacks.get(testRealmURL)!.push((e) => {
       if (

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -43,8 +43,6 @@ import {
   testRealmURL,
   setupAcceptanceTestRealm,
   visitOperatorMode,
-  lookupLoaderService,
-  lookupNetworkService,
   setupUserSubscription,
   type TestContextWithSave,
 } from '../helpers';
@@ -77,7 +75,7 @@ module('Acceptance | interact submode tests', function (hooks) {
     });
     setupUserSubscription(matrixRoomId);
 
-    let loader = lookupLoaderService().loader;
+    let loader = getService('loader-service').loader;
     let cardApi: typeof import('https://cardstack.com/base/card-api');
     let string: typeof import('https://cardstack.com/base/string');
     let spec: typeof import('https://cardstack.com/base/spec');
@@ -1581,7 +1579,7 @@ module('Acceptance | interact submode tests', function (hooks) {
         ],
       });
 
-      lookupNetworkService().mount(
+      getService('network').mount(
         async (req) => {
           if (req.method !== 'GET' && req.method !== 'HEAD') {
             let token = req.headers.get('Authorization');

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -11,6 +11,7 @@ import {
 
 import { triggerEvent } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
 import window from 'ember-window-mock';
 import { module, test } from 'qunit';
 import stringify from 'safe-stable-stringify';
@@ -26,11 +27,7 @@ import {
 } from '@cardstack/runtime-common';
 import { Realm } from '@cardstack/runtime-common/realm';
 
-import type CardService from '@cardstack/host/services/card-service';
-import type MessageService from '@cardstack/host/services/message-service';
-import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 import { claimsFromRawToken } from '@cardstack/host/services/realm';
-import type RecentCardsService from '@cardstack/host/services/recent-cards-service';
 
 import { RecentCards } from '@cardstack/host/utils/local-storage-keys';
 
@@ -611,9 +608,8 @@ module('Acceptance | interact submode tests', function (hooks) {
       await deferred.promise;
       await click('[data-test-edit-button]');
 
-      let knownClientRequestIds = (
-        this.owner.lookup('service:card-service') as CardService
-      ).clientRequestIds.values();
+      let knownClientRequestIds =
+        getService('card-service').clientRequestIds.values();
 
       let knownClientRequestId = knownClientRequestIds.next().value;
 
@@ -671,12 +667,8 @@ module('Acceptance | interact submode tests', function (hooks) {
         ],
       });
 
-      let operatorModeStateService = this.owner.lookup(
-        'service:operator-mode-state-service',
-      ) as OperatorModeStateService;
-      let recentCardsService = this.owner.lookup(
-        'service:recent-cards-service',
-      ) as RecentCardsService;
+      let operatorModeStateService = getService('operator-mode-state-service');
+      let recentCardsService = getService('recent-cards-service');
 
       operatorModeStateService.state.stacks[0].map((item) =>
         recentCardsService.add(item.id),
@@ -776,12 +768,8 @@ module('Acceptance | interact submode tests', function (hooks) {
         ],
       });
 
-      let operatorModeStateService = this.owner.lookup(
-        'service:operator-mode-state-service',
-      ) as OperatorModeStateService;
-      let recentCardsService = this.owner.lookup(
-        'service:recent-cards-service',
-      ) as RecentCardsService;
+      let operatorModeStateService = getService('operator-mode-state-service');
+      let recentCardsService = getService('recent-cards-service');
 
       operatorModeStateService.state.stacks[0].map((item) =>
         recentCardsService.add(item.id),
@@ -1823,9 +1811,7 @@ module('Acceptance | interact submode tests', function (hooks) {
 
     test('Clicking search panel (without left and right buttons activated) replaces all cards in the rightmost stack', async function (assert) {
       // creates a recent search
-      let recentCardsService = this.owner.lookup(
-        'service:recent-cards-service',
-      ) as RecentCardsService;
+      let recentCardsService = getService('recent-cards-service');
       recentCardsService.add(`${testRealmURL}Person/fadhlan`);
 
       await visitOperatorMode({
@@ -2085,9 +2071,7 @@ module('Acceptance | interact submode tests', function (hooks) {
           ],
         ],
       });
-      const messageService = this.owner.lookup(
-        'service:message-service',
-      ) as MessageService;
+      const messageService = getService('message-service');
       const receivedEventDeferred = new Deferred<void>();
       messageService.listenerCallbacks
         .get(testRealmURL)!

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -8,6 +8,7 @@ import {
   triggerEvent,
 } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
 import { getPageTitle } from 'ember-page-title/test-support';
 import window from 'ember-window-mock';
 import { module, test } from 'qunit';
@@ -39,8 +40,6 @@ import {
   testRealmURL,
   setupAcceptanceTestRealm,
   visitOperatorMode,
-  lookupLoaderService,
-  lookupNetworkService,
   createJWT,
   testRealmSecretSeed,
   setupUserSubscription,
@@ -83,7 +82,7 @@ module('Acceptance | operator mode tests', function (hooks) {
 
     setExpiresInSec(60 * 60);
 
-    let loader = lookupLoaderService().loader;
+    let loader = getService('loader-service').loader;
     let cardApi: typeof import('https://cardstack.com/base/card-api');
     let string: typeof import('https://cardstack.com/base/string');
     cardApi = await loader.import(`${baseRealm.url}card-api`);
@@ -680,7 +679,7 @@ module('Acceptance | operator mode tests', function (hooks) {
   });
 
   test('open workspace chooser when boxel icon is clicked', async function (assert) {
-    lookupNetworkService().mount(
+    getService('network').mount(
       async (req: Request) => {
         let isOnWorkspaceChooser = document.querySelector(
           '[data-test-workspace-chooser]',

--- a/packages/host/tests/acceptance/permissioned-realm-test.gts
+++ b/packages/host/tests/acceptance/permissioned-realm-test.gts
@@ -1,3 +1,4 @@
+import { getService } from '@universal-ember/test-support';
 import { module } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
@@ -6,7 +7,6 @@ import {
   setupLocalIndexing,
   setupAcceptanceTestRealm,
   testRealmURL,
-  lookupLoaderService,
   setupUserSubscription,
 } from '../helpers';
 import { setupMockMatrix } from '../helpers/mock-matrix';
@@ -31,7 +31,7 @@ module('Acceptance | permissioned realm tests', function (hooks) {
     });
     setupUserSubscription(matrixRoomId);
 
-    let loader = lookupLoaderService().loader;
+    let loader = getService('loader-service').loader;
     let { field, contains, CardDef, Component } = await loader.import<
       typeof import('https://cardstack.com/base/card-api')
     >(`${baseRealm.url}card-api`);

--- a/packages/host/tests/helpers/base-realm.ts
+++ b/packages/host/tests/helpers/base-realm.ts
@@ -1,8 +1,6 @@
-import { type TestContext, getContext } from '@ember/test-helpers';
+import { getService } from '@universal-ember/test-support';
 
 import { baseRealm } from '@cardstack/runtime-common';
-
-import type LoaderService from '@cardstack/host/services/loader-service';
 
 import type * as Base64ImageFieldModule from 'https://cardstack.com/base/base64-image';
 import type * as BigIntegerModule from 'https://cardstack.com/base/big-integer';
@@ -83,8 +81,7 @@ let ReadOnlyField: (typeof CardAPIModule)['ReadOnlyField'];
 let instanceOf: (typeof CardAPIModule)['instanceOf'];
 
 async function initialize() {
-  let owner = (getContext() as TestContext).owner;
-  let loader = (owner.lookup('service:loader-service') as LoaderService).loader;
+  let loader = getService('loader-service').loader;
 
   StringField = (
     await loader.import<typeof StringFieldModule>(`${baseRealm.url}string`)

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -46,9 +46,7 @@ import type LoaderService from '@cardstack/host/services/loader-service';
 import MonacoService from '@cardstack/host/services/monaco-service';
 import type NetworkService from '@cardstack/host/services/network';
 
-import RealmServerService, {
-  RealmServerTokenClaims,
-} from '@cardstack/host/services/realm-server';
+import { RealmServerTokenClaims } from '@cardstack/host/services/realm-server';
 
 import type StoreService from '@cardstack/host/services/store';
 import type { CardSaveSubscriber } from '@cardstack/host/services/store';
@@ -395,7 +393,7 @@ async function setupTestRealm({
 
   realmURL = realmURL ?? testRealmURL;
 
-  let realmServer = owner.lookup('service:realm-server') as RealmServerService;
+  let realmServer = getService('realm-server');
   if (!realmServer.availableRealmURLs.includes(realmURL)) {
     realmServer.setAvailableRealmURLs([realmURL]);
   }

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -8,6 +8,8 @@ import {
 import { findAll, waitUntil, waitFor, click } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 
+import { getService } from '@universal-ember/test-support';
+
 import ms from 'ms';
 
 import {
@@ -43,8 +45,6 @@ import SQLiteAdapter from '@cardstack/host/lib/sqlite-adapter';
 import type LoaderService from '@cardstack/host/services/loader-service';
 import MonacoService from '@cardstack/host/services/monaco-service';
 import type NetworkService from '@cardstack/host/services/network';
-
-import type QueueService from '@cardstack/host/services/queue';
 
 import RealmServerService, {
   RealmServerTokenClaims,
@@ -391,7 +391,7 @@ async function setupTestRealm({
 }) {
   let owner = (getContext() as TestContext).owner;
   let { virtualNetwork } = lookupNetworkService();
-  let { queue } = owner.lookup('service:queue') as QueueService;
+  let { queue } = getService('queue');
 
   realmURL = realmURL ?? testRealmURL;
 

--- a/packages/host/tests/helpers/mock-matrix.ts
+++ b/packages/host/tests/helpers/mock-matrix.ts
@@ -1,9 +1,9 @@
 import Owner from '@ember/owner';
 
+import { getService } from '@universal-ember/test-support';
 import window from 'ember-window-mock';
 
 import type MatrixService from '@cardstack/host/services/matrix-service';
-import MessageService from '@cardstack/host/services/message-service';
 
 import { MockSDK } from './mock-matrix/_sdk';
 import { MockSlidingSync } from './mock-matrix/_sliding-sync';
@@ -56,7 +56,7 @@ export function setupMockMatrix(
     testState.sdk = sdk;
 
     // Needed for realm event subscriptions to receive events
-    (this.owner.lookup('service:message-service') as MessageService).register();
+    getService('message-service').register();
 
     const { loggedInAs } = opts;
     if (loggedInAs) {

--- a/packages/host/tests/helpers/mock-matrix/_client.ts
+++ b/packages/host/tests/helpers/mock-matrix/_client.ts
@@ -1,5 +1,7 @@
 import Owner from '@ember/owner';
 
+import { getService } from '@universal-ember/test-support';
+
 import { MatrixEvent } from 'matrix-js-sdk';
 
 import * as MatrixSDK from 'matrix-js-sdk';
@@ -28,7 +30,6 @@ import type { FileDefManager } from '@cardstack/host/lib/file-def-manager';
 import FileDefManagerImpl from '@cardstack/host/lib/file-def-manager';
 import type { ExtendedClient } from '@cardstack/host/services/matrix-sdk-loader';
 
-import MatrixService from '@cardstack/host/services/matrix-service';
 import { assertNever } from '@cardstack/host/utils/assert-never';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
@@ -66,12 +67,10 @@ export class MockClient implements ExtendedClient {
     private clientOpts: MatrixSDK.ICreateClientOpts,
     private sdkOpts: Config,
   ) {
-    let matrixService = this.owner.lookup(
-      'service:matrix-service',
-    ) as MatrixService;
+    let matrixService = getService('matrix-service');
     this.fileDefManager = new FileDefManagerImpl({
       client: this as unknown as MatrixSDK.MatrixClient,
-      owner,
+      owner: this.owner,
       getCardAPI: () => matrixService.cardAPI,
       getFileAPI: () => matrixService.fileAPI,
     });

--- a/packages/host/tests/integration/card-prerender-test.gts
+++ b/packages/host/tests/integration/card-prerender-test.gts
@@ -1,5 +1,6 @@
 import { RenderingTestContext } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
@@ -13,7 +14,6 @@ import {
   cleanWhiteSpace,
   setupLocalIndexing,
   setupIntegrationTestRealm,
-  lookupLoaderService,
 } from '../helpers';
 import { setupMockMatrix } from '../helpers/mock-matrix';
 import { setupRenderingTest } from '../helpers/setup';
@@ -26,7 +26,7 @@ module('Integration | card-prerender', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {
-    loader = lookupLoaderService().loader;
+    loader = getService('loader-service').loader;
   });
 
   setupLocalIndexing(hooks);

--- a/packages/host/tests/integration/commands/add-field-to-card-definition-command-test.gts
+++ b/packages/host/tests/integration/commands/add-field-to-card-definition-command-test.gts
@@ -1,18 +1,16 @@
 import { getOwner } from '@ember/owner';
 import { RenderingTestContext } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import AddFieldToCardDefinitionCommand from '@cardstack/host/commands/add-field-to-card-definition';
-import CardService from '@cardstack/host/services/card-service';
-import type CommandService from '@cardstack/host/services/command-service';
 
 import RealmService from '@cardstack/host/services/realm';
 
 import {
   setupIntegrationTestRealm,
   setupLocalIndexing,
-  lookupService,
   testRealmURL,
   testRealmInfo,
 } from '../../helpers';
@@ -57,8 +55,8 @@ module(
     });
 
     test('adds a field to a card definition', async function (assert) {
-      let commandService = lookupService<CommandService>('command-service');
-      let cardService = lookupService<CardService>('card-service');
+      let commandService = getService('command-service');
+      let cardService = getService('card-service');
       let addFieldToCardDefinitionCommand = new AddFieldToCardDefinitionCommand(
         commandService.commandContext,
       );
@@ -95,8 +93,8 @@ module(
     });
 
     test('can add a computed field', async function (assert) {
-      let commandService = lookupService<CommandService>('command-service');
-      let cardService = lookupService<CardService>('card-service');
+      let commandService = getService('command-service');
+      let cardService = getService('card-service');
       let addFieldToCardDefinitionCommand = new AddFieldToCardDefinitionCommand(
         commandService.commandContext,
       );

--- a/packages/host/tests/integration/commands/apply-search-replace-block-test.gts
+++ b/packages/host/tests/integration/commands/apply-search-replace-block-test.gts
@@ -1,3 +1,4 @@
+import { getService } from '@universal-ember/test-support';
 import { module, test, skip } from 'qunit';
 
 import {
@@ -7,16 +8,14 @@ import {
 } from '@cardstack/runtime-common';
 
 import ApplySearchReplaceBlockCommand from '@cardstack/host/commands/apply-search-replace-block';
-import type CommandService from '@cardstack/host/services/command-service';
 
-import { lookupService } from '../../helpers';
 import { setupRenderingTest } from '../../helpers/setup';
 
 module('Integration | commands | apply-search-replace-block', function (hooks) {
   setupRenderingTest(hooks);
 
   test('handles basic search and replace pattern', async function (assert) {
-    let commandService = lookupService<CommandService>('command-service');
+    let commandService = getService('command-service');
     let applyCommand = new ApplySearchReplaceBlockCommand(
       commandService.commandContext,
     );
@@ -72,7 +71,7 @@ export class Task extends CardDef {
   });
 
   test('handles multiple occurrences of the search pattern, only replacing the first', async function (assert) {
-    let commandService = lookupService<CommandService>('command-service');
+    let commandService = getService('command-service');
     let applyCommand = new ApplySearchReplaceBlockCommand(
       commandService.commandContext,
     );
@@ -136,7 +135,7 @@ class EmbeddedTemplate extends Component<typeof BlogPost> {
   });
 
   test('handles search pattern with whitespace differences', async function (assert) {
-    let commandService = lookupService<CommandService>('command-service');
+    let commandService = getService('command-service');
     let applyCommand = new ApplySearchReplaceBlockCommand(
       commandService.commandContext,
     );
@@ -174,7 +173,7 @@ ${REPLACE_MARKER}`;
   });
 
   test('handles no match found', async function (assert) {
-    let commandService = lookupService<CommandService>('command-service');
+    let commandService = getService('command-service');
     let applyCommand = new ApplySearchReplaceBlockCommand(
       commandService.commandContext,
     );
@@ -210,7 +209,7 @@ ${REPLACE_MARKER}`;
 
   // Skipping this test for now as throwing errors causes issues
   skip('handles malformed search/replace block', async function (assert) {
-    let commandService = lookupService<CommandService>('command-service');
+    let commandService = getService('command-service');
     let applyCommand = new ApplySearchReplaceBlockCommand(
       commandService.commandContext,
     );
@@ -247,7 +246,7 @@ ${REPLACE_MARKER}`;
   });
 
   test('handles search with additional context for clarity', async function (assert) {
-    let commandService = lookupService<CommandService>('command-service');
+    let commandService = getService('command-service');
     let applyCommand = new ApplySearchReplaceBlockCommand(
       commandService.commandContext,
     );
@@ -313,7 +312,7 @@ ${REPLACE_MARKER}`;
   });
 
   test('handles different indentation in search pattern', async function (assert) {
-    let commandService = lookupService<CommandService>('command-service');
+    let commandService = getService('command-service');
     let applyCommand = new ApplySearchReplaceBlockCommand(
       commandService.commandContext,
     );
@@ -409,7 +408,7 @@ class CardTemplate extends Component<typeof ContactCard> {
   });
 
   test('handles tabs vs spaces in search pattern', async function (assert) {
-    let commandService = lookupService<CommandService>('command-service');
+    let commandService = getService('command-service');
     let applyCommand = new ApplySearchReplaceBlockCommand(
       commandService.commandContext,
     );
@@ -464,7 +463,7 @@ ${REPLACE_MARKER}`;
   });
 
   test('handles spurious blank lines in search pattern', async function (assert) {
-    let commandService = lookupService<CommandService>('command-service');
+    let commandService = getService('command-service');
     let applyCommand = new ApplySearchReplaceBlockCommand(
       commandService.commandContext,
     );
@@ -524,7 +523,7 @@ ${REPLACE_MARKER}`;
   });
 
   test('handles spurious blank lines in the middle of the search pattern', async function (assert) {
-    let commandService = lookupService<CommandService>('command-service');
+    let commandService = getService('command-service');
     let applyCommand = new ApplySearchReplaceBlockCommand(
       commandService.commandContext,
     );
@@ -583,7 +582,7 @@ ${REPLACE_MARKER}`;
   });
 
   test('handles carriage return differences in search pattern', async function (assert) {
-    let commandService = lookupService<CommandService>('command-service');
+    let commandService = getService('command-service');
     let applyCommand = new ApplySearchReplaceBlockCommand(
       commandService.commandContext,
     );
@@ -627,7 +626,7 @@ ${REPLACE_MARKER}`;
   });
 
   test('handles trailing whitespace differences', async function (assert) {
-    let commandService = lookupService<CommandService>('command-service');
+    let commandService = getService('command-service');
     let applyCommand = new ApplySearchReplaceBlockCommand(
       commandService.commandContext,
     );
@@ -693,7 +692,7 @@ ${REPLACE_MARKER}`;
   });
 
   test('it applies search/replace block when replace block is empty', async function (assert) {
-    let commandService = lookupService<CommandService>('command-service');
+    let commandService = getService('command-service');
     let applyCommand = new ApplySearchReplaceBlockCommand(
       commandService.commandContext,
     );

--- a/packages/host/tests/integration/commands/commands-calling-test.gts
+++ b/packages/host/tests/integration/commands/commands-calling-test.gts
@@ -1,15 +1,14 @@
 import { getOwner } from '@ember/owner';
 import { RenderingTestContext } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { Command, CommandContext } from '@cardstack/runtime-common';
 
-import type CommandService from '@cardstack/host/services/command-service';
-
 import RealmService from '@cardstack/host/services/realm';
 
-import { lookupService, testRealmURL, testRealmInfo } from '../../helpers';
+import { testRealmURL, testRealmInfo } from '../../helpers';
 import {
   CardDef,
   StringField,
@@ -36,7 +35,7 @@ module('Integration | commands | commands-calling', function (hooks) {
   hooks.beforeEach(function (this: RenderingTestContext) {
     getOwner(this)!.register('service:realm', StubRealmService);
 
-    let commandService = lookupService<CommandService>('command-service');
+    let commandService = getService('command-service');
     commandContext = commandService.commandContext;
   });
 

--- a/packages/host/tests/integration/commands/copy-source-test.gts
+++ b/packages/host/tests/integration/commands/copy-source-test.gts
@@ -1,10 +1,10 @@
 import { getOwner } from '@ember/owner';
 import { RenderingTestContext } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import CopySourceCommand from '@cardstack/host/commands/copy-source';
-import type CommandService from '@cardstack/host/services/command-service';
 import type NetworkService from '@cardstack/host/services/network';
 
 import RealmService from '@cardstack/host/services/realm';
@@ -12,8 +12,6 @@ import RealmService from '@cardstack/host/services/realm';
 import {
   setupIntegrationTestRealm,
   setupLocalIndexing,
-  lookupNetworkService,
-  lookupService,
   testRealmURL,
   testRealmInfo,
 } from '../../helpers';
@@ -39,7 +37,7 @@ module('Integration | commands | copy-source', function (hooks) {
 
   hooks.beforeEach(function (this: RenderingTestContext) {
     getOwner(this)!.register('service:realm', StubRealmService);
-    fetch = lookupNetworkService().fetch;
+    fetch = getService('network').fetch;
   });
 
   hooks.beforeEach(async function () {
@@ -60,7 +58,7 @@ module('Integration | commands | copy-source', function (hooks) {
   });
 
   test('able to copy source or file', async function (assert) {
-    let commandService = lookupService<CommandService>('command-service');
+    let commandService = getService('command-service');
     let copySourceCommand = new CopySourceCommand(
       commandService.commandContext,
     );

--- a/packages/host/tests/integration/commands/patch-code-test.gts
+++ b/packages/host/tests/integration/commands/patch-code-test.gts
@@ -1,3 +1,4 @@
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import {
@@ -9,11 +10,8 @@ import {
 import { LintResult } from '@cardstack/runtime-common/lint';
 
 import PatchCodeCommand from '@cardstack/host/commands/patch-code';
-import type CommandService from '@cardstack/host/services/command-service';
-import type RealmService from '@cardstack/host/services/realm';
 
 import {
-  lookupService,
   testRealmURL,
   setupIntegrationTestRealm,
   setupLocalIndexing,
@@ -64,12 +62,12 @@ export class Task extends CardDef {
         messages: [],
       };
     };
-    let realmService = lookupService<RealmService>('realm');
+    let realmService = getService('realm');
     await realmService.login(testRealmURL);
   });
 
   test('lint-fixes contents before returning them', async function (assert) {
-    let commandService = lookupService<CommandService>('command-service');
+    let commandService = getService('command-service');
     let patchCodeCommand = new PatchCodeCommand(commandService.commandContext);
 
     // note that `eq` import will be missing after this is applied

--- a/packages/host/tests/integration/commands/patch-instance-test.gts
+++ b/packages/host/tests/integration/commands/patch-instance-test.gts
@@ -1,5 +1,6 @@
 import { waitUntil } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { localId } from '@cardstack/runtime-common';
@@ -8,12 +9,10 @@ import { type RealmIndexQueryEngine } from '@cardstack/runtime-common/realm-inde
 import PatchCardInstanceCommand from '@cardstack/host/commands/patch-card-instance';
 
 import type CommandService from '@cardstack/host/services/command-service';
-import type StoreService from '@cardstack/host/services/store';
 
 import { CardDef as CardDefType } from 'https://cardstack.com/base/card-api';
 
 import {
-  lookupService,
   testRealmURL,
   setupIntegrationTestRealm,
   setupLocalIndexing,
@@ -42,7 +41,7 @@ module('Integration | commands | patch-instance', function (hooks) {
   let indexQuery: RealmIndexQueryEngine;
 
   hooks.beforeEach(async function () {
-    commandService = lookupService<CommandService>('command-service');
+    commandService = getService('command-service');
     class Person extends CardDef {
       @field name = contains(StringField);
       @field nickNames = containsMany(StringField);
@@ -275,7 +274,7 @@ module('Integration | commands | patch-instance', function (hooks) {
   });
 
   test('can patch an unsaved instance', async function (assert) {
-    let store = lookupService<StoreService>('store');
+    let store = getService('store');
     let andrea = new PersonDef({ name: 'Andrea' });
     await store.add(andrea, { realm: testRealmURL, doNotPersist: true });
 

--- a/packages/host/tests/integration/commands/read-text-file-test.gts
+++ b/packages/host/tests/integration/commands/read-text-file-test.gts
@@ -1,17 +1,16 @@
 import { getOwner } from '@ember/owner';
 import { RenderingTestContext } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
 import { module, skip, test } from 'qunit';
 
 import ReadTextFileCommand from '@cardstack/host/commands/read-text-file';
-import type CommandService from '@cardstack/host/services/command-service';
 
 import RealmService from '@cardstack/host/services/realm';
 
 import {
   setupIntegrationTestRealm,
   setupLocalIndexing,
-  lookupService,
   testRealmURL,
   testRealmInfo,
 } from '../../helpers';
@@ -49,7 +48,7 @@ module('Integration | commands | read-text-file', function (hooks) {
         'component.gts': `import Component from '@glimmer/component';\n\nexport default class TestComponent extends Component {}`,
       },
     });
-    let commandService = lookupService<CommandService>('command-service');
+    let commandService = getService('command-service');
     readTextFileCommand = new ReadTextFileCommand(
       commandService.commandContext,
     );

--- a/packages/host/tests/integration/commands/search-command-test.gts
+++ b/packages/host/tests/integration/commands/search-command-test.gts
@@ -1,3 +1,4 @@
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
@@ -7,16 +8,13 @@ import {
   SearchCardsByQueryCommand,
   SearchCardsByTypeAndTitleCommand,
 } from '@cardstack/host/commands/search-cards';
-import type CommandService from '@cardstack/host/services/command-service';
 
 import {
   testRealmURL,
-  lookupService,
   setupCardLogs,
   setupIntegrationTestRealm,
   setupLocalIndexing,
   setupOnSave,
-  lookupLoaderService,
 } from '../../helpers';
 import { setupMockMatrix } from '../../helpers/mock-matrix';
 import { setupRenderingTest } from '../../helpers/setup';
@@ -28,7 +26,7 @@ module('Integration | commands | search', function (hooks) {
   let loader: Loader;
 
   hooks.beforeEach(function () {
-    loader = lookupLoaderService().loader;
+    loader = getService('loader-service').loader;
   });
 
   setupLocalIndexing(hooks);
@@ -45,7 +43,7 @@ module('Integration | commands | search', function (hooks) {
   });
 
   hooks.beforeEach(async function () {
-    loader = lookupLoaderService().loader;
+    loader = getService('loader-service').loader;
     let cardApi: typeof import('https://cardstack.com/base/card-api');
     let string: typeof import('https://cardstack.com/base/string');
 
@@ -80,7 +78,7 @@ module('Integration | commands | search', function (hooks) {
   });
 
   test('search for a title', async function (assert) {
-    let commandService = lookupService<CommandService>('command-service');
+    let commandService = getService('command-service');
     let searchCommand = new SearchCardsByTypeAndTitleCommand(
       commandService.commandContext,
     );
@@ -93,7 +91,7 @@ module('Integration | commands | search', function (hooks) {
   });
 
   test('search for a card type', async function (assert) {
-    let commandService = lookupService<CommandService>('command-service');
+    let commandService = getService('command-service');
     let searchCommand = new SearchCardsByTypeAndTitleCommand(
       commandService.commandContext,
     );
@@ -109,7 +107,7 @@ module('Integration | commands | search', function (hooks) {
   });
 
   test('search with a query', async function (assert) {
-    let commandService = lookupService<CommandService>('command-service');
+    let commandService = getService('command-service');
     let searchCommand = new SearchCardsByQueryCommand(
       commandService.commandContext,
     );

--- a/packages/host/tests/integration/commands/send-ai-assistant-message-test.gts
+++ b/packages/host/tests/integration/commands/send-ai-assistant-message-test.gts
@@ -1,20 +1,19 @@
 import { getOwner } from '@ember/owner';
 import { RenderingTestContext } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { APP_BOXEL_MESSAGE_MSGTYPE } from '@cardstack/runtime-common/matrix-constants';
 
 import SendAiAssistantMessageCommand from '@cardstack/host/commands/send-ai-assistant-message';
 import SwitchSubmodeCommand from '@cardstack/host/commands/switch-submode';
-import type CommandService from '@cardstack/host/services/command-service';
 
 import RealmService from '@cardstack/host/services/realm';
 
 import {
   setupIntegrationTestRealm,
   setupLocalIndexing,
-  lookupService,
   testRealmURL,
   testRealmInfo,
 } from '../../helpers';
@@ -58,7 +57,7 @@ module('Integration | commands | send-ai-assistant-message', function (hooks) {
       sender: '@testuser:localhost',
       name: 'room-test',
     });
-    let commandService = lookupService<CommandService>('command-service');
+    let commandService = getService('command-service');
 
     let sendAiAssistantMessageCommand = new SendAiAssistantMessageCommand(
       commandService.commandContext,
@@ -78,7 +77,7 @@ module('Integration | commands | send-ai-assistant-message', function (hooks) {
       sender: '@testuser:localhost',
       name: 'room-test',
     });
-    let commandService = lookupService<CommandService>('command-service');
+    let commandService = getService('command-service');
 
     let sendAiAssistantMessageCommand = new SendAiAssistantMessageCommand(
       commandService.commandContext,
@@ -104,7 +103,7 @@ module('Integration | commands | send-ai-assistant-message', function (hooks) {
       sender: '@testuser:localhost',
       name: 'room-test',
     });
-    let commandService = lookupService<CommandService>('command-service');
+    let commandService = getService('command-service');
 
     let sendAiAssistantMessageCommand = new SendAiAssistantMessageCommand(
       commandService.commandContext,
@@ -131,7 +130,7 @@ module('Integration | commands | send-ai-assistant-message', function (hooks) {
       sender: '@testuser:localhost',
       name: 'room-test',
     });
-    let commandService = lookupService<CommandService>('command-service');
+    let commandService = getService('command-service');
 
     let sendAiAssistantMessageCommand = new SendAiAssistantMessageCommand(
       commandService.commandContext,
@@ -158,7 +157,7 @@ module('Integration | commands | send-ai-assistant-message', function (hooks) {
       sender: '@testuser:localhost',
       name: 'room-test',
     });
-    let commandService = lookupService<CommandService>('command-service');
+    let commandService = getService('command-service');
 
     let sendAiAssistantMessageCommand = new SendAiAssistantMessageCommand(
       commandService.commandContext,

--- a/packages/host/tests/integration/commands/switch-submode-test.gts
+++ b/packages/host/tests/integration/commands/switch-submode-test.gts
@@ -1,13 +1,12 @@
 import { getOwner } from '@ember/owner';
 import { RenderingTestContext } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { localId } from '@cardstack/runtime-common';
 
 import SwitchSubmodeCommand from '@cardstack/host/commands/switch-submode';
-import type CommandService from '@cardstack/host/services/command-service';
-import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 import RealmService from '@cardstack/host/services/realm';
 import type StoreService from '@cardstack/host/services/store';
 
@@ -16,7 +15,6 @@ import { CardDef as CardDefType } from 'https://cardstack.com/base/card-api';
 import {
   setupIntegrationTestRealm,
   setupLocalIndexing,
-  lookupService,
   testRealmURL,
   testRealmInfo,
 } from '../../helpers';
@@ -48,7 +46,7 @@ module('Integration | commands | switch-submode', function (hooks) {
 
   hooks.beforeEach(function (this: RenderingTestContext) {
     getOwner(this)!.register('service:realm', StubRealmService);
-    store = lookupService<StoreService>('store');
+    store = getService('store');
   });
 
   hooks.beforeEach(async function () {
@@ -60,10 +58,8 @@ module('Integration | commands | switch-submode', function (hooks) {
 
   test('switch to code submode by local id of a saved instance', async function (assert) {
     let instance = (await store.add(new CardDef())) as CardDefType;
-    let commandService = lookupService<CommandService>('command-service');
-    let operatorModeStateService = lookupService<OperatorModeStateService>(
-      'operator-mode-state-service',
-    );
+    let commandService = getService('command-service');
+    let operatorModeStateService = getService('operator-mode-state-service');
     operatorModeStateService.restore({
       stacks: [[{ id: instance[localId], format: 'isolated' }]],
       submode: 'interact',
@@ -84,10 +80,8 @@ module('Integration | commands | switch-submode', function (hooks) {
 
   test('switch to code submode by remote id of a saved instance', async function (assert) {
     let instance = await store.add(new CardDef());
-    let commandService = lookupService<CommandService>('command-service');
-    let operatorModeStateService = lookupService<OperatorModeStateService>(
-      'operator-mode-state-service',
-    );
+    let commandService = getService('command-service');
+    let operatorModeStateService = getService('operator-mode-state-service');
     operatorModeStateService.restore({
       stacks: [[{ id: instance.id!, format: 'isolated' }]],
       submode: 'interact',

--- a/packages/host/tests/integration/commands/use-ai-assistant-test.gts
+++ b/packages/host/tests/integration/commands/use-ai-assistant-test.gts
@@ -1,6 +1,7 @@
 import { getOwner } from '@ember/owner';
 import { RenderingTestContext } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { skillCardRef } from '@cardstack/runtime-common';
@@ -14,7 +15,6 @@ import UseAiAssistantCommand from '@cardstack/host/commands/ai-assistant';
 import OpenAiAssistantRoomCommand from '@cardstack/host/commands/open-ai-assistant-room';
 import type CommandService from '@cardstack/host/services/command-service';
 import RealmService from '@cardstack/host/services/realm';
-import type StoreService from '@cardstack/host/services/store';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 
@@ -23,7 +23,6 @@ import type { Skill } from 'https://cardstack.com/base/skill';
 import {
   setupIntegrationTestRealm,
   setupLocalIndexing,
-  lookupService,
   testRealmURL,
   testRealmInfo,
 } from '../../helpers';
@@ -125,7 +124,7 @@ module('Integration | commands | ai-assistant', function (hooks) {
         },
       },
     });
-    commandService = lookupService<CommandService>('command-service');
+    commandService = getService('command-service');
   });
 
   test('creates a new room when no roomId is provided', async function (assert) {
@@ -205,7 +204,7 @@ module('Integration | commands | ai-assistant', function (hooks) {
       name: 'room-with-attached-cards',
     });
 
-    let store = lookupService<StoreService>('store');
+    let store = getService('store');
 
     // Attach simple cards
     const card1 = (await store.get(`${testRealmURL}empty1.json`)) as CardDef;
@@ -347,7 +346,7 @@ module('Integration | commands | ai-assistant', function (hooks) {
       name: 'room-with-skills',
     });
 
-    let store = lookupService<StoreService>('store');
+    let store = getService('store');
 
     // Load skill cards
     const skillCard1 = (await store.get(`${testRealmURL}skill1.json`)) as Skill;
@@ -509,7 +508,7 @@ module('Integration | commands | ai-assistant', function (hooks) {
 
     const openCardIds = [`${testRealmURL}empty1`, `${testRealmURL}empty2`];
 
-    let store = lookupService<StoreService>('store');
+    let store = getService('store');
 
     // Attach simple cards
     const card1 = (await store.get(`${testRealmURL}empty1.json`)) as CardDef;

--- a/packages/host/tests/integration/commands/write-text-file-test.gts
+++ b/packages/host/tests/integration/commands/write-text-file-test.gts
@@ -1,10 +1,10 @@
 import { getOwner } from '@ember/owner';
 import { RenderingTestContext } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import WriteTextFileCommand from '@cardstack/host/commands/write-text-file';
-import type CommandService from '@cardstack/host/services/command-service';
 import type NetworkService from '@cardstack/host/services/network';
 
 import RealmService from '@cardstack/host/services/realm';
@@ -12,8 +12,6 @@ import RealmService from '@cardstack/host/services/realm';
 import {
   setupIntegrationTestRealm,
   setupLocalIndexing,
-  lookupNetworkService,
-  lookupService,
   testRealmURL,
   testRealmInfo,
 } from '../../helpers';
@@ -39,7 +37,7 @@ module('Integration | commands | write-text-file', function (hooks) {
 
   hooks.beforeEach(function (this: RenderingTestContext) {
     getOwner(this)!.register('service:realm', StubRealmService);
-    fetch = lookupNetworkService().fetch;
+    fetch = getService('network').fetch;
   });
 
   hooks.beforeEach(async function () {
@@ -50,7 +48,7 @@ module('Integration | commands | write-text-file', function (hooks) {
   });
 
   test('writes a text file', async function (assert) {
-    let commandService = lookupService<CommandService>('command-service');
+    let commandService = getService('command-service');
     let writeTextFileCommand = new WriteTextFileCommand(
       commandService.commandContext,
     );
@@ -65,7 +63,7 @@ module('Integration | commands | write-text-file', function (hooks) {
   });
 
   test('fails if the file already exists', async function (assert) {
-    let commandService = lookupService<CommandService>('command-service');
+    let commandService = getService('command-service');
     let writeTextFileCommand = new WriteTextFileCommand(
       commandService.commandContext,
     );
@@ -93,7 +91,7 @@ module('Integration | commands | write-text-file', function (hooks) {
   });
 
   test('is able to overwrite a file', async function (assert) {
-    let commandService = lookupService<CommandService>('command-service');
+    let commandService = getService('command-service');
     let writeTextFileCommand = new WriteTextFileCommand(
       commandService.commandContext,
     );

--- a/packages/host/tests/integration/components/ai-assistant-panel/codeblocks-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/codeblocks-test.gts
@@ -2,6 +2,8 @@ import { waitFor, waitUntil, click } from '@ember/test-helpers';
 import { settled } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 
+import { getService } from '@universal-ember/test-support';
+
 import { module, test } from 'qunit';
 
 import {
@@ -16,7 +18,6 @@ import { Loader } from '@cardstack/runtime-common/loader';
 import CardPrerender from '@cardstack/host/components/card-prerender';
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
 
-import type CardService from '@cardstack/host/services/card-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 import {
@@ -78,12 +79,10 @@ module('Integration | ai-assistant-panel | codeblocks', function (hooks) {
   let noop = () => {};
 
   hooks.beforeEach(async function () {
-    operatorModeStateService = this.owner.lookup(
-      'service:operator-mode-state-service',
-    ) as OperatorModeStateService;
+    operatorModeStateService = getService('operator-mode-state-service');
 
     // Add cardService mock for example.com/component.gts
-    let cardService = this.owner.lookup('service:card-service') as CardService;
+    let cardService = getService('card-service');
     cardService.getSource = async (url: URL) => {
       if (url.toString() === 'https://example.com/component.gts') {
         return {

--- a/packages/host/tests/integration/components/ai-assistant-panel/codeblocks-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/codeblocks-test.gts
@@ -28,7 +28,6 @@ import {
   setupLocalIndexing,
   setupOnSave,
   getMonacoContent,
-  lookupLoaderService,
 } from '../../../helpers';
 import {
   CardDef,
@@ -52,7 +51,7 @@ module('Integration | ai-assistant-panel | codeblocks', function (hooks) {
   setupBaseRealm(hooks);
 
   hooks.beforeEach(function () {
-    loader = lookupLoaderService().loader;
+    loader = getService('loader-service').loader;
   });
 
   setupLocalIndexing(hooks);

--- a/packages/host/tests/integration/components/ai-assistant-panel/commands-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/commands-test.gts
@@ -2,6 +2,8 @@ import { waitFor, click, fillIn } from '@ember/test-helpers';
 import { settled } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 
+import { getService } from '@universal-ember/test-support';
+
 import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
@@ -82,9 +84,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
   let noop = () => {};
 
   hooks.beforeEach(async function () {
-    operatorModeStateService = this.owner.lookup(
-      'service:operator-mode-state-service',
-    ) as OperatorModeStateService;
+    operatorModeStateService = getService('operator-mode-state-service');
 
     class Pet extends CardDef {
       static displayName = 'Pet';

--- a/packages/host/tests/integration/components/ai-assistant-panel/commands-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/commands-test.gts
@@ -30,7 +30,6 @@ import {
   setupLocalIndexing,
   setupOnSave,
   type TestContextWithSave,
-  lookupLoaderService,
 } from '../../../helpers';
 import {
   CardDef,
@@ -56,7 +55,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
   setupBaseRealm(hooks);
 
   hooks.beforeEach(function () {
-    loader = lookupLoaderService().loader;
+    loader = getService('loader-service').loader;
   });
 
   setupLocalIndexing(hooks);

--- a/packages/host/tests/integration/components/ai-assistant-panel/general-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/general-test.gts
@@ -9,6 +9,8 @@ import { settled } from '@ember/test-helpers';
 import { fillIn } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 
+import { getService } from '@universal-ember/test-support';
+
 import { format, subMinutes } from 'date-fns';
 
 import window from 'ember-window-mock';
@@ -28,7 +30,6 @@ import {
 import CardPrerender from '@cardstack/host/components/card-prerender';
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
 
-import type MatrixService from '@cardstack/host/services/matrix-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 import { CurrentRoomIdPersistenceKey } from '@cardstack/host/utils/local-storage-keys';
@@ -101,9 +102,7 @@ module('Integration | ai-assistant-panel | general', function (hooks) {
   let noop = () => {};
 
   hooks.beforeEach(async function () {
-    operatorModeStateService = this.owner.lookup(
-      'service:operator-mode-state-service',
-    ) as OperatorModeStateService;
+    operatorModeStateService = getService('operator-mode-state-service');
 
     class Pet extends CardDef {
       static displayName = 'Pet';
@@ -687,9 +686,7 @@ module('Integration | ai-assistant-panel | general', function (hooks) {
     await click(`[data-test-enter-room="${anotherRoomId}"]`);
     await waitFor('[data-test-message-idx="0"]');
 
-    let matrixService = this.owner.lookup(
-      'service:matrix-service',
-    ) as MatrixService;
+    let matrixService = getService('matrix-service');
     assert.deepEqual(
       Array.from(matrixService.currentUserEventReadReceipts.keys()),
       [eventId2, eventId3],

--- a/packages/host/tests/integration/components/ai-assistant-panel/general-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/general-test.gts
@@ -41,7 +41,6 @@ import {
   setupIntegrationTestRealm,
   setupLocalIndexing,
   setupOnSave,
-  lookupLoaderService,
   getMonacoContent,
   setMonacoContent,
 } from '../../../helpers';
@@ -70,7 +69,7 @@ module('Integration | ai-assistant-panel | general', function (hooks) {
   setupBaseRealm(hooks);
 
   hooks.beforeEach(function () {
-    loader = lookupLoaderService().loader;
+    loader = getService('loader-service').loader;
   });
 
   setupLocalIndexing(hooks);

--- a/packages/host/tests/integration/components/ai-assistant-panel/past-sessions-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/past-sessions-test.gts
@@ -21,7 +21,6 @@ import {
   setupIntegrationTestRealm,
   setupLocalIndexing,
   setupOnSave,
-  lookupLoaderService,
 } from '../../../helpers';
 import {
   CardDef,
@@ -47,7 +46,7 @@ module('Integration | ai-assistant-panel | past sessions', function (hooks) {
   setupBaseRealm(hooks);
 
   hooks.beforeEach(function () {
-    loader = lookupLoaderService().loader;
+    loader = getService('loader-service').loader;
   });
 
   setupLocalIndexing(hooks);

--- a/packages/host/tests/integration/components/ai-assistant-panel/past-sessions-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/past-sessions-test.gts
@@ -1,6 +1,8 @@
 import { waitFor, click } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 
+import { getService } from '@universal-ember/test-support';
+
 import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
@@ -72,9 +74,7 @@ module('Integration | ai-assistant-panel | past sessions', function (hooks) {
   let noop = () => {};
 
   hooks.beforeEach(async function () {
-    operatorModeStateService = this.owner.lookup(
-      'service:operator-mode-state-service',
-    ) as OperatorModeStateService;
+    operatorModeStateService = getService('operator-mode-state-service');
 
     class Pet extends CardDef {
       static displayName = 'Pet';

--- a/packages/host/tests/integration/components/ai-assistant-panel/reasoning-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/reasoning-test.gts
@@ -22,7 +22,6 @@ import {
   setupIntegrationTestRealm,
   setupLocalIndexing,
   setupOnSave,
-  lookupLoaderService,
 } from '../../../helpers';
 import {
   CardDef,
@@ -45,7 +44,7 @@ module('Integration | ai-assistant-panel | reasoning', function (hooks) {
   setupBaseRealm(hooks);
 
   hooks.beforeEach(function () {
-    loader = lookupLoaderService().loader;
+    loader = getService('loader-service').loader;
   });
 
   setupLocalIndexing(hooks);

--- a/packages/host/tests/integration/components/ai-assistant-panel/reasoning-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/reasoning-test.gts
@@ -2,6 +2,8 @@ import { waitFor, waitUntil, click } from '@ember/test-helpers';
 import { settled } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 
+import { getService } from '@universal-ember/test-support';
+
 import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
@@ -70,9 +72,7 @@ module('Integration | ai-assistant-panel | reasoning', function (hooks) {
   let noop = () => {};
 
   hooks.beforeEach(async function () {
-    operatorModeStateService = this.owner.lookup(
-      'service:operator-mode-state-service',
-    ) as OperatorModeStateService;
+    operatorModeStateService = getService('operator-mode-state-service');
 
     class Person extends CardDef {
       static displayName = 'Person';

--- a/packages/host/tests/integration/components/ai-assistant-panel/scrolling-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/scrolling-test.gts
@@ -2,6 +2,8 @@ import { waitFor, click, triggerEvent } from '@ember/test-helpers';
 import { settled } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 
+import { getService } from '@universal-ember/test-support';
+
 import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
@@ -71,9 +73,7 @@ module('Integration | ai-assistant-panel | scrolling', function (hooks) {
   let noop = () => {};
 
   hooks.beforeEach(async function () {
-    operatorModeStateService = this.owner.lookup(
-      'service:operator-mode-state-service',
-    ) as OperatorModeStateService;
+    operatorModeStateService = getService('operator-mode-state-service');
 
     class Person extends CardDef {
       static displayName = 'Person';

--- a/packages/host/tests/integration/components/ai-assistant-panel/scrolling-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/scrolling-test.gts
@@ -22,7 +22,6 @@ import {
   setupIntegrationTestRealm,
   setupLocalIndexing,
   setupOnSave,
-  lookupLoaderService,
 } from '../../../helpers';
 import {
   CardDef,
@@ -45,7 +44,7 @@ module('Integration | ai-assistant-panel | scrolling', function (hooks) {
   setupBaseRealm(hooks);
 
   hooks.beforeEach(function () {
-    loader = lookupLoaderService().loader;
+    loader = getService('loader-service').loader;
   });
 
   setupLocalIndexing(hooks);

--- a/packages/host/tests/integration/components/ai-assistant-panel/sending-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/sending-test.gts
@@ -28,7 +28,6 @@ import {
   setupIntegrationTestRealm,
   setupLocalIndexing,
   setupOnSave,
-  lookupLoaderService,
 } from '../../../helpers';
 import {
   CardDef,
@@ -51,7 +50,7 @@ module('Integration | ai-assistant-panel | sending', function (hooks) {
   setupBaseRealm(hooks);
 
   hooks.beforeEach(function () {
-    loader = lookupLoaderService().loader;
+    loader = getService('loader-service').loader;
   });
 
   setupLocalIndexing(hooks);

--- a/packages/host/tests/integration/components/ai-assistant-panel/sending-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/sending-test.gts
@@ -8,6 +8,8 @@ import {
 import { settled } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 
+import { getService } from '@universal-ember/test-support';
+
 import window from 'ember-window-mock';
 import { module, test } from 'qunit';
 
@@ -74,9 +76,7 @@ module('Integration | ai-assistant-panel | sending', function (hooks) {
   let noop = () => {};
 
   hooks.beforeEach(async function () {
-    operatorModeStateService = this.owner.lookup(
-      'service:operator-mode-state-service',
-    ) as OperatorModeStateService;
+    operatorModeStateService = getService('operator-mode-state-service');
 
     class Person extends CardDef {
       static displayName = 'Person';

--- a/packages/host/tests/integration/components/ai-assistant-panel/skills-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/skills-test.gts
@@ -1,6 +1,8 @@
 import { waitFor, click, fillIn, settled } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 
+import { getService } from '@universal-ember/test-support';
+
 import { module, test } from 'qunit';
 
 import {
@@ -84,9 +86,7 @@ module('Integration | ai-assistant-panel | skills', function (hooks) {
   let noop = () => {};
 
   hooks.beforeEach(async function () {
-    operatorModeStateService = this.owner.lookup(
-      'service:operator-mode-state-service',
-    ) as OperatorModeStateService;
+    operatorModeStateService = getService('operator-mode-state-service');
 
     class Pet extends CardDef {
       static displayName = 'Pet';

--- a/packages/host/tests/integration/components/ai-assistant-panel/skills-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/skills-test.gts
@@ -31,7 +31,6 @@ import {
   setupIntegrationTestRealm,
   setupLocalIndexing,
   setupOnSave,
-  lookupLoaderService,
   getMonacoContent,
   setMonacoContent,
 } from '../../../helpers';
@@ -59,7 +58,7 @@ module('Integration | ai-assistant-panel | skills', function (hooks) {
   setupBaseRealm(hooks);
 
   hooks.beforeEach(function () {
-    loader = lookupLoaderService().loader;
+    loader = getService('loader-service').loader;
   });
 
   setupLocalIndexing(hooks);

--- a/packages/host/tests/integration/components/ai-module-creation-test.gts
+++ b/packages/host/tests/integration/components/ai-module-creation-test.gts
@@ -2,6 +2,8 @@ import Service from '@ember/service';
 import { waitFor, click, findAll } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 
+import { getService } from '@universal-ember/test-support';
+
 import { module, skip } from 'qunit';
 
 import { baseRealm, Loader, type Realm } from '@cardstack/runtime-common';
@@ -63,9 +65,7 @@ module('Integration | create app module via ai-assistant', function (hooks) {
   );
 
   hooks.beforeEach(async function () {
-    operatorModeStateService = this.owner.lookup(
-      'service:operator-mode-state-service',
-    ) as OperatorModeStateService;
+    operatorModeStateService = getService('operator-mode-state-service');
   });
 
   // TODO: extract test helper

--- a/packages/host/tests/integration/components/ai-module-creation-test.gts
+++ b/packages/host/tests/integration/components/ai-module-creation-test.gts
@@ -26,7 +26,6 @@ import {
   setupCardLogs,
   setupIntegrationTestRealm,
   setupLocalIndexing,
-  lookupLoaderService,
 } from '../../helpers';
 import { setupMockMatrix } from '../../helpers/mock-matrix';
 import { renderComponent } from '../../helpers/render-component';
@@ -54,7 +53,7 @@ module('Integration | create app module via ai-assistant', function (hooks) {
   let { getRoomEvents, simulateRemoteMessage, getRoomState } = mockMatrixUtils;
 
   hooks.beforeEach(function () {
-    loader = lookupLoaderService().loader;
+    loader = getService('loader-service').loader;
     this.owner.register('service:router', MockRouterService);
   });
 

--- a/packages/host/tests/integration/components/ask-ai-test.gts
+++ b/packages/host/tests/integration/components/ask-ai-test.gts
@@ -19,7 +19,6 @@ import {
   setupIntegrationTestRealm,
   setupLocalIndexing,
   setupOnSave,
-  lookupLoaderService,
   assertMessages,
 } from '../../helpers';
 import { setupBaseRealm } from '../../helpers/base-realm';
@@ -36,7 +35,7 @@ module('Integration | ask-ai', function (hooks) {
   setupBaseRealm(hooks);
 
   hooks.beforeEach(function () {
-    loader = lookupLoaderService().loader;
+    loader = getService('loader-service').loader;
   });
 
   setupLocalIndexing(hooks);

--- a/packages/host/tests/integration/components/ask-ai-test.gts
+++ b/packages/host/tests/integration/components/ask-ai-test.gts
@@ -1,6 +1,8 @@
 import { click, fillIn, triggerEvent } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 
+import { getService } from '@universal-ember/test-support';
+
 import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
@@ -53,9 +55,7 @@ module('Integration | ask-ai', function (hooks) {
   let noop = () => {};
 
   hooks.beforeEach(async function () {
-    operatorModeStateService = this.owner.lookup(
-      'service:operator-mode-state-service',
-    ) as OperatorModeStateService;
+    operatorModeStateService = getService('operator-mode-state-service');
 
     const petCard = `import { CardDef, Component } from "https://cardstack.com/base/card-api";
       export class Pet extends CardDef {

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -13,10 +13,10 @@ import {
 import { tracked } from '@glimmer/tracking';
 
 import percySnapshot from '@percy/ember';
+import { getService } from '@universal-ember/test-support';
 import format from 'date-fns/format';
 import parseISO from 'date-fns/parseISO';
 
-import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { BoxelInput } from '@cardstack/boxel-ui/components';

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -16,6 +16,7 @@ import percySnapshot from '@percy/ember';
 import format from 'date-fns/format';
 import parseISO from 'date-fns/parseISO';
 
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { BoxelInput } from '@cardstack/boxel-ui/components';
@@ -41,7 +42,6 @@ import {
   setupCardLogs,
   saveCard,
   provideConsumeContext,
-  lookupLoaderService,
 } from '../../helpers';
 import {
   Base64ImageField,
@@ -86,7 +86,7 @@ module('Integration | card-basics', function (hooks) {
   setupBaseRealm(hooks);
 
   hooks.beforeEach(function (this: RenderingTestContext) {
-    loader = lookupLoaderService().loader;
+    loader = getService('loader-service').loader;
   });
 
   setupCardLogs(hooks, async () => {
@@ -188,7 +188,7 @@ module('Integration | card-basics', function (hooks) {
       class Baz extends Bar {}
       loader.shimModule(`${testRealmURL}test-cards`, { Foo, Bar, Baz });
 
-      lookupLoaderService().resetLoader();
+      getService('loader-service').resetLoader();
 
       assert.true(
         instanceOf(new Baz(), Foo),

--- a/packages/host/tests/integration/components/card-catalog-test.gts
+++ b/packages/host/tests/integration/components/card-catalog-test.gts
@@ -7,14 +7,14 @@ import {
 } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 
+import { getService } from '@universal-ember/test-support';
+
 import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
 
 import CardPrerender from '@cardstack/host/components/card-prerender';
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
-
-import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 import {
   testRealmURL,
@@ -180,9 +180,7 @@ module('Integration | card-catalog', function (hooks) {
       },
     });
 
-    let operatorModeStateService = this.owner.lookup(
-      'service:operator-mode-state-service',
-    ) as OperatorModeStateService;
+    let operatorModeStateService = getService('operator-mode-state-service');
 
     operatorModeStateService.restore({
       stacks: [

--- a/packages/host/tests/integration/components/card-catalog-test.gts
+++ b/packages/host/tests/integration/components/card-catalog-test.gts
@@ -20,7 +20,6 @@ import {
   testRealmURL,
   setupLocalIndexing,
   setupIntegrationTestRealm,
-  lookupLoaderService,
 } from '../../helpers';
 import { setupMockMatrix } from '../../helpers/mock-matrix';
 import { renderComponent } from '../../helpers/render-component';
@@ -42,7 +41,7 @@ module('Integration | card-catalog', function (hooks) {
   const noop = () => {};
 
   hooks.beforeEach(async function () {
-    let loader = lookupLoaderService().loader;
+    let loader = getService('loader-service').loader;
     let cardApi: typeof import('https://cardstack.com/base/card-api');
     let string: typeof import('https://cardstack.com/base/string');
     let textArea: typeof import('https://cardstack.com/base/text-area');

--- a/packages/host/tests/integration/components/card-copy-test.gts
+++ b/packages/host/tests/integration/components/card-copy-test.gts
@@ -3,6 +3,7 @@ import { waitUntil, waitFor, click, triggerEvent } from '@ember/test-helpers';
 import { buildWaiter } from '@ember/test-waiters';
 import GlimmerComponent from '@glimmer/component';
 
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 import { validate as uuidValidate } from 'uuid';
 
@@ -17,8 +18,6 @@ import { Realm } from '@cardstack/runtime-common/realm';
 
 import CardPrerender from '@cardstack/host/components/card-prerender';
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
-
-import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 import {
   IncrementalIndexEventContent,
@@ -78,9 +77,7 @@ module('Integration | card-copy', function (hooks) {
       leftCards: string[],
       rightCards: string[] = [],
     ) => {
-      let operatorModeStateService = this.owner.lookup(
-        'service:operator-mode-state-service',
-      ) as OperatorModeStateService;
+      let operatorModeStateService = getService('operator-mode-state-service');
 
       let stacks = [
         leftCards.map((url) => ({

--- a/packages/host/tests/integration/components/card-copy-test.gts
+++ b/packages/host/tests/integration/components/card-copy-test.gts
@@ -32,8 +32,6 @@ import {
   setupOnSave,
   type TestContextWithSave,
   setupIntegrationTestRealm,
-  lookupLoaderService,
-  lookupNetworkService,
 } from '../../helpers';
 import { setupMockMatrix } from '../../helpers/mock-matrix';
 import { renderComponent } from '../../helpers/render-component';
@@ -52,7 +50,7 @@ module('Integration | card-copy', function (hooks) {
 
   setupRenderingTest(hooks);
   hooks.beforeEach(function () {
-    loader = lookupLoaderService().loader;
+    loader = getService('loader-service').loader;
   });
   setupLocalIndexing(hooks);
   setupOnSave(hooks);
@@ -905,7 +903,7 @@ module('Integration | card-copy', function (hooks) {
 
     let waiter = buildWaiter('body-interception-middleware');
 
-    lookupNetworkService().mount(
+    getService('network').mount(
       async (req) => {
         if (
           req.method !== 'GET' &&
@@ -1050,7 +1048,7 @@ module('Integration | card-copy', function (hooks) {
 
     let waiter = buildWaiter('body-interception-middleware');
 
-    lookupNetworkService().mount(
+    getService('network').mount(
       async (req) => {
         if (
           req.method !== 'GET' &&

--- a/packages/host/tests/integration/components/card-def-field-def-relationships-test.gts
+++ b/packages/host/tests/integration/components/card-def-field-def-relationships-test.gts
@@ -20,7 +20,6 @@ import {
   testRealmURL,
   setupIntegrationTestRealm,
   provideConsumeContext,
-  lookupLoaderService,
 } from '../../helpers';
 import {
   CardDef,
@@ -74,7 +73,7 @@ module('Integration | CardDef-FieldDef relationships test', function (hooks) {
       canRead: true,
     };
     provideConsumeContext(PermissionsContextName, permissions);
-    loader = lookupLoaderService().loader;
+    loader = getService('loader-service').loader;
 
     setCardInOperatorModeState = async (
       cardURL?: string,

--- a/packages/host/tests/integration/components/card-def-field-def-relationships-test.gts
+++ b/packages/host/tests/integration/components/card-def-field-def-relationships-test.gts
@@ -1,5 +1,6 @@
 import { click, waitFor, triggerEvent } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import {
@@ -11,7 +12,6 @@ import { type Loader } from '@cardstack/runtime-common/loader';
 
 import CardPrerender from '@cardstack/host/components/card-prerender';
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
-import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 import {
   percySnapshot,
@@ -80,9 +80,7 @@ module('Integration | CardDef-FieldDef relationships test', function (hooks) {
       cardURL?: string,
       format: 'isolated' | 'edit' = 'isolated',
     ) => {
-      let operatorModeStateService = this.owner.lookup(
-        'service:operator-mode-state-service',
-      ) as OperatorModeStateService;
+      let operatorModeStateService = getService('operator-mode-state-service');
       operatorModeStateService.restore({
         stacks: cardURL ? [[{ id: cardURL, format }]] : [[]],
       });

--- a/packages/host/tests/integration/components/card-delete-test.gts
+++ b/packages/host/tests/integration/components/card-delete-test.gts
@@ -1,6 +1,8 @@
 import { waitUntil, waitFor, click, triggerEvent } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 
+import { getService } from '@universal-ember/test-support';
+
 import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
@@ -9,9 +11,6 @@ import { Realm } from '@cardstack/runtime-common/realm';
 
 import CardPrerender from '@cardstack/host/components/card-prerender';
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
-
-import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
-import RecentCardsService from '@cardstack/host/services/recent-cards-service';
 
 import { CardDef } from 'https://cardstack.com/base/card-api';
 
@@ -81,9 +80,7 @@ module('Integration | card-delete', function (hooks) {
       leftCards: string[],
       rightCards: string[] = [],
     ) => {
-      let operatorModeStateService = this.owner.lookup(
-        'service:operator-mode-state-service',
-      ) as OperatorModeStateService;
+      let operatorModeStateService = getService('operator-mode-state-service');
 
       let stacks = [
         leftCards.map((url) => ({
@@ -532,9 +529,7 @@ module('Integration | card-delete', function (hooks) {
 
   test('can delete a card that is a recent item', async function (assert) {
     // creates a recent item
-    let recentCardsService = this.owner.lookup(
-      'service:recent-cards-service',
-    ) as RecentCardsService;
+    let recentCardsService = getService('recent-cards-service');
     let mango = await loadCard(`${testRealmURL}Pet/mango`);
     recentCardsService.add(mango.id);
 

--- a/packages/host/tests/integration/components/card-delete-test.gts
+++ b/packages/host/tests/integration/components/card-delete-test.gts
@@ -21,7 +21,6 @@ import {
   setupLocalIndexing,
   setupOnSave,
   setupIntegrationTestRealm,
-  lookupLoaderService,
 } from '../../helpers';
 import { TestRealmAdapter } from '../../helpers/adapter';
 import { setupMockMatrix } from '../../helpers/mock-matrix';
@@ -59,7 +58,7 @@ module('Integration | card-delete', function (hooks) {
   }
   setupRenderingTest(hooks);
   hooks.beforeEach(async function () {
-    loader = lookupLoaderService().loader;
+    loader = getService('loader-service').loader;
     cardApi = await loader.import(`${baseRealm.url}card-api`);
   });
   setupLocalIndexing(hooks);

--- a/packages/host/tests/integration/components/computed-test.gts
+++ b/packages/host/tests/integration/components/computed-test.gts
@@ -1,5 +1,6 @@
 import { RenderingTestContext } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import {
@@ -16,7 +17,6 @@ import {
   provideConsumeContext,
   setupIntegrationTestRealm,
   setupLocalIndexing,
-  lookupLoaderService,
 } from '../../helpers';
 import {
   setupBaseRealm,
@@ -52,7 +52,7 @@ module('Integration | computeds', function (hooks) {
     };
     provideConsumeContext(PermissionsContextName, permissions);
 
-    loader = lookupLoaderService().loader;
+    loader = getService('loader-service').loader;
   });
   setupLocalIndexing(hooks);
 

--- a/packages/host/tests/integration/components/formatted-aibot-message-test.gts
+++ b/packages/host/tests/integration/components/formatted-aibot-message-test.gts
@@ -12,6 +12,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 import percySnapshot from '@percy/ember';
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import {
@@ -38,11 +39,9 @@ module('Integration | Component | FormattedAiBotMessage', function (hooks) {
   let eventId = '1234';
 
   hooks.beforeEach(async function (this: RenderingTestContext) {
-    monacoService = this.owner.lookup(
-      'service:monaco-service',
-    ) as MonacoService;
+    monacoService = getService('monaco-service');
 
-    cardService = this.owner.lookup('service:card-service') as CardService;
+    cardService = getService('card-service');
 
     cardService.getSource = async () => {
       return Promise.resolve({

--- a/packages/host/tests/integration/components/loading-test.gts
+++ b/packages/host/tests/integration/components/loading-test.gts
@@ -1,3 +1,4 @@
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
@@ -11,7 +12,6 @@ import {
   setupIntegrationTestRealm,
   setupLocalIndexing,
   setupOnSave,
-  lookupLoaderService,
 } from '../../helpers';
 import { setupMockMatrix } from '../../helpers/mock-matrix';
 import { renderCard } from '../../helpers/render-component';
@@ -25,7 +25,7 @@ module('Integration | loading', function (hooks) {
   let cardApi: typeof import('https://cardstack.com/base/card-api');
 
   hooks.beforeEach(function () {
-    loader = lookupLoaderService().loader;
+    loader = getService('loader-service').loader;
   });
 
   setupLocalIndexing(hooks);

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -12,6 +12,7 @@ import {
 } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { FieldContainer } from '@cardstack/boxel-ui/components';
@@ -27,7 +28,6 @@ import { Loader } from '@cardstack/runtime-common/loader';
 import CardPrerender from '@cardstack/host/components/card-prerender';
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
 
-import type NetworkService from '@cardstack/host/services/network';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 import {
@@ -929,7 +929,7 @@ module('Integration | operator-mode', function (hooks) {
   });
 
   test('a 403 from Web Application Firewall is handled gracefully when auto-saving', async function (assert) {
-    let networkService = this.owner.lookup('service:network') as NetworkService;
+    let networkService = getService('network');
     networkService.virtualNetwork.mount(
       async (req: Request) => {
         if (req.method === 'PATCH' && req.url.includes('test/Pet/buzz')) {

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -38,8 +38,6 @@ import {
   setupLocalIndexing,
   setupOnSave,
   type TestContextWithSave,
-  lookupLoaderService,
-  lookupService,
   withSlowSave,
 } from '../../helpers';
 import { TestRealmAdapter } from '../../helpers/adapter';
@@ -57,10 +55,8 @@ module('Integration | operator-mode', function (hooks) {
   let operatorModeStateService: OperatorModeStateService;
 
   hooks.beforeEach(function () {
-    loader = lookupLoaderService().loader;
-    operatorModeStateService = lookupService<OperatorModeStateService>(
-      'operator-mode-state-service',
-    );
+    loader = getService('loader-service').loader;
+    operatorModeStateService = getService('operator-mode-state-service');
   });
 
   setupLocalIndexing(hooks);

--- a/packages/host/tests/integration/components/prerendered-card-search-test.gts
+++ b/packages/host/tests/integration/components/prerendered-card-search-test.gts
@@ -1,13 +1,8 @@
-import {
-  RenderingTestContext,
-  type TestContext,
-  getContext,
-  render,
-  waitFor,
-} from '@ember/test-helpers';
+import { RenderingTestContext, render, waitFor } from '@ember/test-helpers';
 
 import { waitUntil } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import {
@@ -19,8 +14,6 @@ import {
 
 import CardPrerender from '@cardstack/host/components/card-prerender';
 import PrerenderedCardSearch from '@cardstack/host/components/prerendered-card-search';
-
-import type CardService from '@cardstack/host/services/card-service';
 
 import {
   CardDocFiles,
@@ -489,8 +482,7 @@ module(`Integration | prerendered-card-search`, function (hooks) {
     await waitFor('.card-container');
     assert.dom('.card-container').exists({ count: 2 });
 
-    let owner = (getContext() as TestContext).owner;
-    let cardService = owner.lookup('service:card-service') as CardService;
+    let cardService = getService('card-service');
     await cardService.deleteSource(new URL(`${testRealmURL}card-2.json`));
 
     await waitUntil(() => {

--- a/packages/host/tests/integration/components/preview-test.gts
+++ b/packages/host/tests/integration/components/preview-test.gts
@@ -2,6 +2,7 @@ import Service from '@ember/service';
 import { waitFor } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
@@ -9,7 +10,7 @@ import { Loader } from '@cardstack/runtime-common/loader';
 
 import CardRenderer from '@cardstack/host/components/card-renderer';
 
-import { lookupLoaderService, testRealmURL } from '../../helpers';
+import { testRealmURL } from '../../helpers';
 import { renderComponent } from '../../helpers/render-component';
 import { setupRenderingTest } from '../../helpers/setup';
 
@@ -25,7 +26,7 @@ module('Integration | preview', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(async function () {
-    loader = lookupLoaderService().loader;
+    loader = getService('loader-service').loader;
     cardApi = await loader.import(`${baseRealm.url}card-api`);
     string = await loader.import(`${baseRealm.url}string`);
     this.owner.register('service:local-indexer', MockLocalIndexer);

--- a/packages/host/tests/integration/components/serialization-test.gts
+++ b/packages/host/tests/integration/components/serialization-test.gts
@@ -28,7 +28,6 @@ import {
   setupIntegrationTestRealm,
   setupLocalIndexing,
   testRealmURL,
-  lookupLoaderService,
 } from '../../helpers';
 
 import {
@@ -76,7 +75,7 @@ module('Integration | serialization', function (hooks) {
     };
     provideConsumeContext(PermissionsContextName, permissions);
 
-    loader = lookupLoaderService().loader;
+    loader = getService('loader-service').loader;
   });
   setupLocalIndexing(hooks);
 

--- a/packages/host/tests/integration/components/serialization-test.gts
+++ b/packages/host/tests/integration/components/serialization-test.gts
@@ -1,5 +1,6 @@
 import { fillIn, RenderingTestContext } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
 import formatISO from 'date-fns/formatISO';
 import parseISO from 'date-fns/parseISO';
 
@@ -15,8 +16,6 @@ import {
   type Permissions,
 } from '@cardstack/runtime-common';
 import { Loader } from '@cardstack/runtime-common/loader';
-
-import type StoreService from '@cardstack/host/services/store';
 
 import { type CardDef as CardDefType } from 'https://cardstack.com/base/card-api';
 
@@ -4303,7 +4302,7 @@ module('Integration | serialization', function (hooks) {
       },
     });
 
-    let store = this.owner.lookup('service:store') as StoreService;
+    let store = getService('store');
     let captainMango = await store.get(`${testRealmURL}Captain/mango`);
     let mangoTheBoat = (captainMango as Captain).createEponymousBoat();
 

--- a/packages/host/tests/integration/components/text-input-validator-test.gts
+++ b/packages/host/tests/integration/components/text-input-validator-test.gts
@@ -2,13 +2,14 @@ import { fillIn, typeIn, focus, settled } from '@ember/test-helpers';
 
 import GlimmerComponent from '@glimmer/component';
 
+import { getService } from '@universal-ember/test-support';
+
 import { module, test } from 'qunit';
 
 import { type Realm } from '@cardstack/runtime-common';
 
 import CardPrerender from '@cardstack/host/components/card-prerender';
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
-import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 import {
   testRealmURL,
@@ -43,9 +44,7 @@ module('Integration | text-input-validator', function (hooks) {
   });
 
   hooks.beforeEach(async function () {
-    let operatorModeStateService = this.owner.lookup(
-      'service:operator-mode-state-service',
-    ) as OperatorModeStateService;
+    let operatorModeStateService = getService('operator-mode-state-service');
 
     class Sample extends CardDef {
       static displayName = 'Sample';

--- a/packages/host/tests/integration/components/text-suggestion-test.gts
+++ b/packages/host/tests/integration/components/text-suggestion-test.gts
@@ -1,5 +1,6 @@
 import { RenderingTestContext } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { baseRealm, Loader } from '@cardstack/runtime-common';
@@ -13,7 +14,6 @@ import {
   testRealmURL,
   setupIntegrationTestRealm,
   setupLocalIndexing,
-  lookupLoaderService,
 } from '../../helpers';
 import { setupMockMatrix } from '../../helpers/mock-matrix';
 import { setupRenderingTest } from '../../helpers/setup';
@@ -29,7 +29,7 @@ module('Integration | text-suggestion | card-chooser-title', function (hooks) {
   let mockMatrixUtils = setupMockMatrix(hooks);
 
   hooks.beforeEach(function (this: RenderingTestContext) {
-    loader = lookupLoaderService().loader;
+    loader = getService('loader-service').loader;
   });
 
   hooks.beforeEach(async function () {

--- a/packages/host/tests/integration/message-service-subscription-test.gts
+++ b/packages/host/tests/integration/message-service-subscription-test.gts
@@ -5,6 +5,7 @@ import GlimmerComponent from '@glimmer/component';
 // @ts-expect-error says unused but the component uses it
 import { tracked } from '@glimmer/tracking';
 
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
@@ -23,7 +24,6 @@ import {
   setupCardLogs,
   setupLocalIndexing,
   setupIntegrationTestRealm,
-  lookupLoaderService,
 } from '../helpers';
 import { setupMockMatrix } from '../helpers/mock-matrix';
 import { setupRenderingTest } from '../helpers/setup';
@@ -34,7 +34,7 @@ module('Integration | message service subscription', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {
-    loader = lookupLoaderService().loader;
+    loader = getService('loader-service').loader;
   });
 
   setupLocalIndexing(hooks);

--- a/packages/host/tests/integration/realm-indexing-test.gts
+++ b/packages/host/tests/integration/realm-indexing-test.gts
@@ -1,6 +1,7 @@
 import { RenderingTestContext } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import {
@@ -22,7 +23,6 @@ import {
   setupCardLogs,
   setupLocalIndexing,
   setupIntegrationTestRealm,
-  lookupLoaderService,
 } from '../helpers';
 import {
   CardDef,
@@ -49,7 +49,7 @@ module(`Integration | realm indexing`, function (hooks) {
   setupBaseRealm(hooks);
 
   hooks.beforeEach(function (this: RenderingTestContext) {
-    loader = lookupLoaderService().loader;
+    loader = getService('loader-service').loader;
   });
 
   setupLocalIndexing(hooks);

--- a/packages/host/tests/integration/realm-querying-test.gts
+++ b/packages/host/tests/integration/realm-querying-test.gts
@@ -1,5 +1,6 @@
 import { RenderingTestContext } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import {
@@ -18,7 +19,6 @@ import {
   setupLocalIndexing,
   type CardDocFiles,
   setupIntegrationTestRealm,
-  lookupLoaderService,
 } from '../helpers';
 import { setupMockMatrix } from '../helpers/mock-matrix';
 import { setupRenderingTest } from '../helpers/setup';
@@ -32,7 +32,7 @@ module(`Integration | realm querying`, function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function (this: RenderingTestContext) {
-    loader = lookupLoaderService().loader;
+    loader = getService('loader-service').loader;
   });
 
   setupLocalIndexing(hooks);

--- a/packages/host/tests/integration/realm-test.ts
+++ b/packages/host/tests/integration/realm-test.ts
@@ -1,5 +1,6 @@
 import { RenderingTestContext } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
 import { stringify } from 'qs';
 import { module, test } from 'qunit';
 
@@ -24,7 +25,6 @@ import {
   setupCardLogs,
   setupLocalIndexing,
   setupIntegrationTestRealm,
-  lookupLoaderService,
 } from '../helpers';
 import {
   setupBaseRealm,
@@ -46,7 +46,7 @@ module('Integration | realm', function (hooks) {
   setupBaseRealm(hooks);
 
   hooks.beforeEach(function (this: RenderingTestContext) {
-    loader = lookupLoaderService().loader;
+    loader = getService('loader-service').loader;
   });
 
   let mockMatrixUtils = setupMockMatrix(hooks);

--- a/packages/host/tests/integration/resources/search-test.ts
+++ b/packages/host/tests/integration/resources/search-test.ts
@@ -23,7 +23,6 @@ import type StoreService from '@cardstack/host/services/store';
 
 import {
   CardDocFiles,
-  lookupLoaderService,
   setupIntegrationTestRealm,
   setupLocalIndexing,
   testRealmURL,
@@ -62,7 +61,7 @@ module(`Integration | search resource`, function (hooks) {
   setupRenderingTest(hooks);
   hooks.beforeEach(function () {
     getOwner(this)!.register('service:realm', StubRealmService);
-    loaderService = lookupLoaderService();
+    loaderService = getService('loader-service');
     loader = loaderService.loader;
     storeService = getService('store');
   });

--- a/packages/host/tests/integration/resources/search-test.ts
+++ b/packages/host/tests/integration/resources/search-test.ts
@@ -1,6 +1,7 @@
 import { getOwner } from '@ember/owner';
 import { settled, RenderingTestContext, waitUntil } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import {
@@ -63,7 +64,7 @@ module(`Integration | search resource`, function (hooks) {
     getOwner(this)!.register('service:realm', StubRealmService);
     loaderService = lookupLoaderService();
     loader = loaderService.loader;
-    storeService = getOwner(this)!.lookup('service:store') as StoreService;
+    storeService = getService('store');
   });
 
   setupLocalIndexing(hooks);

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -9,6 +9,7 @@ import {
 import GlimmerComponent from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import {
@@ -31,9 +32,7 @@ import { getCardCollection } from '@cardstack/host/resources/card-collection';
 import { getCard } from '@cardstack/host/resources/card-resource';
 import { getSearch } from '@cardstack/host/resources/search';
 import type LoaderService from '@cardstack/host/services/loader-service';
-import type MessageService from '@cardstack/host/services/message-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
-import type RealmService from '@cardstack/host/services/realm';
 import type StoreService from '@cardstack/host/services/store';
 import { type CardErrorJSONAPI } from '@cardstack/host/services/store';
 
@@ -42,8 +41,6 @@ import type * as CardAPI from 'https://cardstack.com/base/card-api';
 import type { RealmEventContent } from 'https://cardstack.com/base/matrix-event';
 
 import {
-  lookupLoaderService,
-  lookupService,
   testRealmURL,
   setupLocalIndexing,
   setupOnSave,
@@ -143,13 +140,11 @@ module('Integration | Store', function (hooks) {
       };
     }
     BoomPersonDef = BoomPerson;
-    loaderService = lookupLoaderService();
+    loaderService = getService('loader-service');
     loader = loaderService.loader;
     api = await loader.import(`${baseRealm.url}card-api`);
-    store = lookupService<StoreService>('store');
-    operatorModeStateService = lookupService<OperatorModeStateService>(
-      'operator-mode-state-service',
-    );
+    store = getService('store');
+    operatorModeStateService = getService('operator-mode-state-service');
     identityContext = (store as any).identityContext as IdentityContext;
 
     ({ adapter: testRealmAdapter, realm: testRealm } =
@@ -165,7 +160,7 @@ module('Integration | Store', function (hooks) {
           'Person/boris.json': new Person({ name: 'Boris' }),
         },
       }));
-    let realmService = lookupService<RealmService>('realm');
+    let realmService = getService('realm');
     await realmService.login(testRealmURL);
   });
 
@@ -1681,7 +1676,7 @@ module('Integration | Store', function (hooks) {
     );
 
     let deferred = new Deferred<void>();
-    lookupService<MessageService>('message-service')
+    getService('message-service')
       .listenerCallbacks.get(testRealmURL)!
       .push((ev: RealmEventContent) => {
         if (ev.eventName === 'index' && ev.indexType === 'incremental') {
@@ -1776,7 +1771,7 @@ module('Integration | Store', function (hooks) {
     );
 
     let deferred = new Deferred<void>();
-    lookupService<MessageService>('message-service')
+    getService('message-service')
       .listenerCallbacks.get(testRealmURL)!
       .push((ev: RealmEventContent) => {
         if (ev.eventName === 'index' && ev.indexType === 'incremental') {
@@ -1868,7 +1863,7 @@ module('Integration | Store', function (hooks) {
     );
 
     let deferred = new Deferred<void>();
-    lookupService<MessageService>('message-service')
+    getService('message-service')
       .listenerCallbacks.get(testRealmURL)!
       .push((ev: RealmEventContent) => {
         if (ev.eventName === 'index' && ev.indexType === 'incremental') {

--- a/packages/host/tests/unit/ai-function-generation-test.ts
+++ b/packages/host/tests/unit/ai-function-generation-test.ts
@@ -1,5 +1,6 @@
 import { RenderingTestContext } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
@@ -15,12 +16,7 @@ import { Loader } from '@cardstack/runtime-common/loader';
 
 import { primitive as primitiveType } from 'https://cardstack.com/base/card-api';
 
-import {
-  setupLocalIndexing,
-  setupOnSave,
-  setupCardLogs,
-  lookupLoaderService,
-} from '../helpers';
+import { setupLocalIndexing, setupOnSave, setupCardLogs } from '../helpers';
 import { setupRenderingTest } from '../helpers/setup';
 
 let cardApi: typeof import('https://cardstack.com/base/card-api');
@@ -38,7 +34,7 @@ let loader: Loader;
 module('Unit | ai-function-generation-test', function (hooks) {
   setupRenderingTest(hooks);
   hooks.beforeEach(function (this: RenderingTestContext) {
-    loader = lookupLoaderService().loader;
+    loader = getService('loader-service').loader;
   });
   hooks.beforeEach(async function () {
     cardApi = await loader.import(`${baseRealm.url}card-api`);

--- a/packages/host/tests/unit/box-test.ts
+++ b/packages/host/tests/unit/box-test.ts
@@ -1,10 +1,10 @@
 import { RenderingTestContext } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { Loader, baseRealm } from '@cardstack/runtime-common';
 
-import { lookupLoaderService } from '../helpers';
 import { setupRenderingTest } from '../helpers/setup';
 
 let cardApi: typeof import('https://cardstack.com/base/card-api');
@@ -14,7 +14,7 @@ let loader: Loader;
 module('Unit | box', function (hooks) {
   setupRenderingTest(hooks);
   hooks.beforeEach(function (this: RenderingTestContext) {
-    loader = lookupLoaderService().loader;
+    loader = getService('loader-service').loader;
   });
   hooks.beforeEach(async function () {
     cardApi = await loader.import(`${baseRealm.url}card-api`);

--- a/packages/host/tests/unit/garbage-collection-test.ts
+++ b/packages/host/tests/unit/garbage-collection-test.ts
@@ -1,5 +1,6 @@
 import { type RenderingTestContext } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import {
@@ -18,7 +19,7 @@ import IdentityContext, {
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
 import { type CardDef as CardInstance } from 'https://cardstack.com/base/card-api';
 
-import { saveCard, lookupLoaderService, testRealmURL } from '../helpers';
+import { saveCard, testRealmURL } from '../helpers';
 import {
   CardDef,
   contains,
@@ -38,7 +39,7 @@ module('Unit | identity-context garbage collection', function (hooks) {
   let api: typeof CardAPI;
 
   hooks.beforeEach(async function (this: RenderingTestContext) {
-    loader = lookupLoaderService().loader;
+    loader = getService('loader-service').loader;
     api = await loader.import(`${baseRealm.url}card-api`);
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1163,19 +1163,19 @@ importers:
         version: 3.3.1(@babel/core@7.26.10)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))(webpack@5.99.6)
       '@embroider/compat':
         specifier: ^3.5.5
-        version: 3.5.6(patch_hash=db8df3cd3be93909d4ddbc1eace0a46dd23639f38332d9eb4c500c534687c7b2)(@embroider/core@3.4.14(@glint/template@1.3.0))(@glint/template@1.3.0)
+        version: 3.5.6(patch_hash=db8df3cd3be93909d4ddbc1eace0a46dd23639f38332d9eb4c500c534687c7b2)(@embroider/core@3.5.6(@glint/template@1.3.0))(@glint/template@1.3.0)
       '@embroider/core':
-        specifier: ^3.4.14
-        version: 3.4.14(@glint/template@1.3.0)
+        specifier: ^3.4.15
+        version: 3.5.6(@glint/template@1.3.0)
       '@embroider/macros':
         specifier: ^1.16.5
         version: 1.16.9(@glint/template@1.3.0)
       '@embroider/test-setup':
         specifier: ^4.0.0
-        version: 4.0.0(@embroider/compat@3.5.6(patch_hash=db8df3cd3be93909d4ddbc1eace0a46dd23639f38332d9eb4c500c534687c7b2)(@embroider/core@3.4.14(@glint/template@1.3.0))(@glint/template@1.3.0))(@embroider/core@3.4.14(@glint/template@1.3.0))(@embroider/webpack@4.0.4(@embroider/core@3.4.14(@glint/template@1.3.0))(webpack@5.99.6))
+        version: 4.0.0(@embroider/compat@3.5.6(patch_hash=db8df3cd3be93909d4ddbc1eace0a46dd23639f38332d9eb4c500c534687c7b2)(@embroider/core@3.5.6(@glint/template@1.3.0))(@glint/template@1.3.0))(@embroider/core@3.5.6(@glint/template@1.3.0))(@embroider/webpack@4.0.4(@embroider/core@3.5.6(@glint/template@1.3.0))(webpack@5.99.6))
       '@embroider/webpack':
         specifier: ^4.0.4
-        version: 4.0.4(@embroider/core@3.4.14(@glint/template@1.3.0))(webpack@5.99.6)
+        version: 4.0.4(@embroider/core@3.5.6(@glint/template@1.3.0))(webpack@5.99.6)
       '@glimmer/component':
         specifier: ^1.1.2
         version: 1.1.2(@babel/core@7.26.10)
@@ -1597,19 +1597,19 @@ importers:
         version: 3.3.1(@babel/core@7.26.10)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))(webpack@5.99.6)
       '@embroider/compat':
         specifier: ^3.5.5
-        version: 3.5.6(patch_hash=db8df3cd3be93909d4ddbc1eace0a46dd23639f38332d9eb4c500c534687c7b2)(@embroider/core@3.4.14(@glint/template@1.3.0))(@glint/template@1.3.0)
+        version: 3.5.6(patch_hash=db8df3cd3be93909d4ddbc1eace0a46dd23639f38332d9eb4c500c534687c7b2)(@embroider/core@3.5.6(@glint/template@1.3.0))(@glint/template@1.3.0)
       '@embroider/core':
-        specifier: ^3.4.14
-        version: 3.4.14(@glint/template@1.3.0)
+        specifier: ^3.4.15
+        version: 3.5.6(@glint/template@1.3.0)
       '@embroider/macros':
         specifier: ^1.16.5
         version: 1.16.9(@glint/template@1.3.0)
       '@embroider/test-setup':
         specifier: ^4.0.0
-        version: 4.0.0(@embroider/compat@3.5.6(patch_hash=db8df3cd3be93909d4ddbc1eace0a46dd23639f38332d9eb4c500c534687c7b2)(@embroider/core@3.4.14(@glint/template@1.3.0))(@glint/template@1.3.0))(@embroider/core@3.4.14(@glint/template@1.3.0))(@embroider/webpack@4.0.4(@embroider/core@3.4.14(@glint/template@1.3.0))(webpack@5.99.6))
+        version: 4.0.0(@embroider/compat@3.5.6(patch_hash=db8df3cd3be93909d4ddbc1eace0a46dd23639f38332d9eb4c500c534687c7b2)(@embroider/core@3.5.6(@glint/template@1.3.0))(@glint/template@1.3.0))(@embroider/core@3.5.6(@glint/template@1.3.0))(@embroider/webpack@4.0.4(@embroider/core@3.5.6(@glint/template@1.3.0))(webpack@5.99.6))
       '@embroider/webpack':
         specifier: ^4.0.4
-        version: 4.0.4(@embroider/core@3.4.14(@glint/template@1.3.0))(webpack@5.99.6)
+        version: 4.0.4(@embroider/core@3.5.6(@glint/template@1.3.0))(webpack@5.99.6)
       '@glimmer/component':
         specifier: ^1.1.2
         version: 1.1.2(@babel/core@7.26.10)
@@ -2011,16 +2011,16 @@ importers:
         version: 3.1.0
       '@embroider/compat':
         specifier: ^3.5.5
-        version: 3.5.6(patch_hash=db8df3cd3be93909d4ddbc1eace0a46dd23639f38332d9eb4c500c534687c7b2)(@embroider/core@3.4.14(@glint/template@1.3.0))(@glint/template@1.3.0)
+        version: 3.5.6(patch_hash=db8df3cd3be93909d4ddbc1eace0a46dd23639f38332d9eb4c500c534687c7b2)(@embroider/core@3.5.6(@glint/template@1.3.0))(@glint/template@1.3.0)
       '@embroider/core':
-        specifier: ^3.4.14
-        version: 3.4.14(@glint/template@1.3.0)
+        specifier: ^3.4.15
+        version: 3.5.6(@glint/template@1.3.0)
       '@embroider/macros':
         specifier: ^1.16.5
         version: 1.16.9(@glint/template@1.3.0)
       '@embroider/webpack':
         specifier: ^4.0.4
-        version: 4.0.4(@embroider/core@3.4.14(@glint/template@1.3.0))(webpack@5.99.6)
+        version: 4.0.4(@embroider/core@3.5.6(@glint/template@1.3.0))(webpack@5.99.6)
       '@floating-ui/dom':
         specifier: 'catalog:'
         version: 1.6.3
@@ -3842,6 +3842,10 @@ packages:
     resolution: {integrity: sha512-WVVKup9j1LzciQDL3jfvADJIyLTPe3+cWKzZwqwSnDkYIx2Nsq5a/drKcjJZPJtwU1ddbMpDnUVgGtOurN1VcA==}
     engines: {node: 12.* || 14.* || >= 16}
 
+  '@embroider/core@3.5.6':
+    resolution: {integrity: sha512-yCTed4fjX4ZK3baFN4qay8zvER6MB75peCHN0WxfxX4esK/Lgjh8aANLYPsZ/7kmSlKcq4qYnBmBD7peIMh6dA==}
+    engines: {node: 12.* || 14.* || >= 16}
+
   '@embroider/core@4.0.2':
     resolution: {integrity: sha512-ht7wXUKaDI4FrMiQ+yYOnao1oJIPMJnpj4xrMINa7YCTi8G7WFs5o+exIQ//h2UmsqU0IgyiV5rHv/eOnpMvfQ==}
     engines: {node: 12.* || 14.* || >= 16}
@@ -3852,6 +3856,15 @@ packages:
     peerDependencies:
       '@embroider/core': ^3.4.0
       webpack: ^5
+
+  '@embroider/macros@1.16.13':
+    resolution: {integrity: sha512-2oGZh0m1byBYQFWEa8b2cvHJB2LzaF3DdMCLCqcRAccABMROt1G3sultnNCT30NhfdGWMEsJOT3Jm4nFxXmTRw==}
+    engines: {node: 12.* || 14.* || >= 16}
+    peerDependencies:
+      '@glint/template': ^1.0.0
+    peerDependenciesMeta:
+      '@glint/template':
+        optional: true
 
   '@embroider/macros@1.16.5':
     resolution: {integrity: sha512-Oz8bUZvZzOV1Gk3qSgIzZJJzs6acclSTcEFyB+KdKbKqjTC3uebn53aU2gAlLU7/YdTRZrg2gNbQuwAp+tGkGg==}
@@ -14500,16 +14513,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@embroider/babel-loader-9@3.1.1(@embroider/core@3.4.14(@glint/template@1.3.0))(supports-color@8.1.1)(webpack@5.99.6)':
+  '@embroider/babel-loader-9@3.1.1(@embroider/core@3.5.6(@glint/template@1.3.0))(supports-color@8.1.1)(webpack@5.99.6)':
     dependencies:
       '@babel/core': 7.26.10(supports-color@8.1.1)
-      '@embroider/core': 3.4.14(@glint/template@1.3.0)
+      '@embroider/core': 3.5.6(@glint/template@1.3.0)
       babel-loader: 9.1.3(@babel/core@7.26.10)(webpack@5.99.6)
     transitivePeerDependencies:
       - supports-color
       - webpack
 
-  '@embroider/compat@3.5.6(patch_hash=db8df3cd3be93909d4ddbc1eace0a46dd23639f38332d9eb4c500c534687c7b2)(@embroider/core@3.4.14(@glint/template@1.3.0))(@glint/template@1.3.0)':
+  '@embroider/compat@3.5.6(patch_hash=db8df3cd3be93909d4ddbc1eace0a46dd23639f38332d9eb4c500c534687c7b2)(@embroider/core@3.5.6(@glint/template@1.3.0))(@glint/template@1.3.0)':
     dependencies:
       '@babel/code-frame': 7.26.2
       '@babel/core': 7.26.10(supports-color@8.1.1)
@@ -14518,7 +14531,7 @@ snapshots:
       '@babel/preset-env': 7.26.9(@babel/core@7.26.10)(supports-color@8.1.1)
       '@babel/runtime': 7.22.11
       '@babel/traverse': 7.27.0(supports-color@8.1.1)
-      '@embroider/core': 3.4.14(@glint/template@1.3.0)
+      '@embroider/core': 3.5.6(@glint/template@1.3.0)
       '@embroider/macros': 1.16.5(@glint/template@1.3.0)
       '@types/babel__code-frame': 7.0.5
       '@types/yargs': 17.0.10
@@ -14593,6 +14606,40 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@embroider/core@3.5.6(@glint/template@1.3.0)':
+    dependencies:
+      '@babel/core': 7.26.10(supports-color@8.1.1)
+      '@babel/parser': 7.27.0
+      '@babel/traverse': 7.27.0(supports-color@8.1.1)
+      '@embroider/macros': 1.16.13(@glint/template@1.3.0)
+      '@embroider/shared-internals': 2.9.0
+      assert-never: 1.4.0
+      babel-plugin-ember-template-compilation: 2.3.0
+      broccoli-node-api: 1.7.0
+      broccoli-persistent-filter: 3.1.3
+      broccoli-plugin: 4.0.7
+      broccoli-source: 3.0.1
+      debug: 4.4.0(supports-color@8.1.1)
+      fast-sourcemap-concat: 2.1.1
+      filesize: 10.0.12
+      fs-extra: 9.1.0
+      fs-tree-diff: 2.0.1
+      handlebars: 4.7.8
+      js-string-escape: 1.0.1
+      jsdom: 25.0.1
+      lodash: 4.17.21
+      resolve: 1.22.10
+      resolve-package-path: 4.0.3
+      semver: 7.7.1
+      typescript-memoize: 1.1.1
+      walk-sync: 3.0.0
+    transitivePeerDependencies:
+      - '@glint/template'
+      - bufferutil
+      - canvas
+      - supports-color
+      - utf-8-validate
+
   '@embroider/core@4.0.2(@glint/template@1.3.0)':
     dependencies:
       '@babel/core': 7.26.10(supports-color@8.1.1)
@@ -14629,10 +14676,25 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@embroider/hbs-loader@3.0.3(@embroider/core@3.4.14(@glint/template@1.3.0))(webpack@5.99.6)':
+  '@embroider/hbs-loader@3.0.3(@embroider/core@3.5.6(@glint/template@1.3.0))(webpack@5.99.6)':
     dependencies:
-      '@embroider/core': 3.4.14(@glint/template@1.3.0)
+      '@embroider/core': 3.5.6(@glint/template@1.3.0)
       webpack: 5.99.6
+
+  '@embroider/macros@1.16.13(@glint/template@1.3.0)':
+    dependencies:
+      '@embroider/shared-internals': 2.9.0
+      assert-never: 1.4.0
+      babel-import-util: 2.1.1
+      ember-cli-babel: 7.26.11
+      find-up: 5.0.0
+      lodash: 4.17.21
+      resolve: 1.22.10
+      semver: 7.7.1
+    optionalDependencies:
+      '@glint/template': 1.3.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@embroider/macros@1.16.5(@glint/template@1.3.0)':
     dependencies:
@@ -14761,14 +14823,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@embroider/test-setup@4.0.0(@embroider/compat@3.5.6(patch_hash=db8df3cd3be93909d4ddbc1eace0a46dd23639f38332d9eb4c500c534687c7b2)(@embroider/core@3.4.14(@glint/template@1.3.0))(@glint/template@1.3.0))(@embroider/core@3.4.14(@glint/template@1.3.0))(@embroider/webpack@4.0.4(@embroider/core@3.4.14(@glint/template@1.3.0))(webpack@5.99.6))':
+  '@embroider/test-setup@4.0.0(@embroider/compat@3.5.6(patch_hash=db8df3cd3be93909d4ddbc1eace0a46dd23639f38332d9eb4c500c534687c7b2)(@embroider/core@3.5.6(@glint/template@1.3.0))(@glint/template@1.3.0))(@embroider/core@3.5.6(@glint/template@1.3.0))(@embroider/webpack@4.0.4(@embroider/core@3.5.6(@glint/template@1.3.0))(webpack@5.99.6))':
     dependencies:
       lodash: 4.17.21
       resolve: 1.22.10
     optionalDependencies:
-      '@embroider/compat': 3.5.6(patch_hash=db8df3cd3be93909d4ddbc1eace0a46dd23639f38332d9eb4c500c534687c7b2)(@embroider/core@3.4.14(@glint/template@1.3.0))(@glint/template@1.3.0)
-      '@embroider/core': 3.4.14(@glint/template@1.3.0)
-      '@embroider/webpack': 4.0.4(@embroider/core@3.4.14(@glint/template@1.3.0))(webpack@5.99.6)
+      '@embroider/compat': 3.5.6(patch_hash=db8df3cd3be93909d4ddbc1eace0a46dd23639f38332d9eb4c500c534687c7b2)(@embroider/core@3.5.6(@glint/template@1.3.0))(@glint/template@1.3.0)
+      '@embroider/core': 3.5.6(@glint/template@1.3.0)
+      '@embroider/webpack': 4.0.4(@embroider/core@3.5.6(@glint/template@1.3.0))(webpack@5.99.6)
 
   '@embroider/util@1.13.1(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))))(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))':
     dependencies:
@@ -14782,13 +14844,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@embroider/webpack@4.0.4(@embroider/core@3.4.14(@glint/template@1.3.0))(webpack@5.99.6)':
+  '@embroider/webpack@4.0.4(@embroider/core@3.5.6(@glint/template@1.3.0))(webpack@5.99.6)':
     dependencies:
       '@babel/core': 7.26.10(supports-color@8.1.1)
       '@babel/preset-env': 7.26.9(@babel/core@7.26.10)(supports-color@8.1.1)
-      '@embroider/babel-loader-9': 3.1.1(@embroider/core@3.4.14(@glint/template@1.3.0))(supports-color@8.1.1)(webpack@5.99.6)
-      '@embroider/core': 3.4.14(@glint/template@1.3.0)
-      '@embroider/hbs-loader': 3.0.3(@embroider/core@3.4.14(@glint/template@1.3.0))(webpack@5.99.6)
+      '@embroider/babel-loader-9': 3.1.1(@embroider/core@3.5.6(@glint/template@1.3.0))(supports-color@8.1.1)(webpack@5.99.6)
+      '@embroider/core': 3.5.6(@glint/template@1.3.0)
+      '@embroider/hbs-loader': 3.0.3(@embroider/core@3.5.6(@glint/template@1.3.0))(webpack@5.99.6)
       '@embroider/shared-internals': 2.6.2(supports-color@8.1.1)
       '@types/supports-color': 8.1.2
       assert-never: 1.4.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,6 +231,9 @@ catalogs:
     '@typescript-eslint/parser':
       specifier: ^7.18.0
       version: 7.18.0
+    '@universal-ember/test-support':
+      specifier: ^0.5.1
+      version: 0.5.1
     '@vscode/vsce':
       specifier: ^3.1.0
       version: 3.1.1
@@ -654,7 +657,7 @@ importers:
         version: 1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)))
       '@glint/environment-ember-template-imports':
         specifier: 1.3.0
-        version: 1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))))(@glint/template@1.3.0)
+        version: 1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))))(@glint/template@1.3.0)
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.48.0
@@ -775,7 +778,7 @@ importers:
     dependencies:
       ember-provide-consume-context:
         specifier: ^0.7.0
-        version: 0.7.0(@babel/core@7.26.10)(@ember/test-helpers@3.3.1(@babel/core@7.26.10)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))(webpack@5.99.6))(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
+        version: 0.7.0(@babel/core@7.26.10)(@ember/test-helpers@5.2.2(@babel/core@7.26.10)(@glint/template@1.3.0))(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
       ember-source:
         specifier: ~5.4.0
         version: 5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)
@@ -815,7 +818,7 @@ importers:
         version: 6.3.0
       ember-concurrency:
         specifier: 'catalog:'
-        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
+        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-css-url:
         specifier: ^1.0.0
         version: 1.0.0(patch_hash=0e5253a008cc7bf02424d786e7a8fb2397bc48962f3cd1443f2c0fdd8200c96d)
@@ -824,7 +827,7 @@ importers:
         version: 4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-resources:
         specifier: ^6.5.1
-        version: 6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-concurrency@4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)))(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
+        version: 6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-concurrency@4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)))(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
       ember-template-lint:
         specifier: ^5.11.2
         version: 5.11.2
@@ -1009,7 +1012,7 @@ importers:
         version: 5.2.1
       ember-concurrency:
         specifier: 'catalog:'
-        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
+        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-load-initializers:
         specifier: ^2.1.2
         version: 2.1.2(@babel/core@7.26.10)
@@ -1058,7 +1061,7 @@ importers:
         version: 1.3.0(typescript@5.1.6)
       '@glint/environment-ember-template-imports':
         specifier: 1.3.0
-        version: 1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))))(@glint/template@1.3.0)
+        version: 1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))))(@glint/template@1.3.0)
       '@rollup/plugin-babel':
         specifier: 'catalog:'
         version: 6.0.4(@babel/core@7.26.10)(@types/babel__core@7.1.19)(rollup@4.40.0)
@@ -1187,7 +1190,7 @@ importers:
         version: 1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)))
       '@glint/environment-ember-template-imports':
         specifier: 1.3.0
-        version: 1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))))(@glint/template@1.3.0)
+        version: 1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))))(@glint/template@1.3.0)
       '@glint/template':
         specifier: 1.3.0
         version: 1.3.0
@@ -1394,10 +1397,10 @@ importers:
         version: 1.11.7
       ember-basic-dropdown:
         specifier: ^8.0.0
-        version: 8.0.4(patch_hash=19b0fc5d4bd8b9aa296c4065fa5e33bdbb965db0b277810b596eacd0b9e2f428)(2ae94f35bd5e6e6dafa095817afdf7bd)
+        version: 8.0.4(patch_hash=19b0fc5d4bd8b9aa296c4065fa5e33bdbb965db0b277810b596eacd0b9e2f428)(@ember/string@3.1.1)(@ember/test-helpers@5.2.2(@babel/core@7.26.10)(@glint/template@1.3.0))(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glimmer/tracking@1.1.2)(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))))(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-concurrency:
         specifier: 'catalog:'
-        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
+        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-concurrency-ts:
         specifier: 'catalog:'
         version: 0.3.1(ember-concurrency@4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)))
@@ -1424,13 +1427,13 @@ importers:
         version: 4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-power-calendar:
         specifier: ^1.2.0
-        version: 1.2.0(ae73f78346344bda7976042daa3e7280)
+        version: 1.2.0(23f2a85894f1cabd8378488477fc3ced)
       ember-power-calendar-moment:
         specifier: ^1.0.2
-        version: 1.0.2(@babel/core@7.26.10)(@glint/template@1.3.0)(ember-power-calendar@1.2.0(ae73f78346344bda7976042daa3e7280))
+        version: 1.0.2(@babel/core@7.26.10)(@glint/template@1.3.0)(ember-power-calendar@1.2.0(23f2a85894f1cabd8378488477fc3ced))
       ember-power-select:
         specifier: ^8.0.0
-        version: 8.1.0(7051d9587fa15cd41be1a83112217b32)
+        version: 8.1.0(543e302a9fcdd631e93f7c8af86c3fa6)
       ember-resize-modifier:
         specifier: ^0.7.1
         version: 0.7.1(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))(webpack@5.99.6)
@@ -1439,7 +1442,7 @@ importers:
         version: 1.0.2
       ember-sortable:
         specifier: ^5.0.2
-        version: 5.0.2(@ember/test-helpers@3.3.1(@babel/core@7.26.10)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))(webpack@5.99.6))(@ember/test-waiters@3.1.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)))(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
+        version: 5.0.2(@ember/test-helpers@5.2.2(@babel/core@7.26.10)(@glint/template@1.3.0))(@ember/test-waiters@3.1.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)))(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-source:
         specifier: ^5.4.0
         version: 5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)
@@ -1618,7 +1621,7 @@ importers:
         version: 1.3.0(typescript@5.1.6)
       '@glint/environment-ember-template-imports':
         specifier: 1.3.0
-        version: 1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))))(@glint/template@1.3.0)
+        version: 1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))))(@glint/template@1.3.0)
       '@glint/template':
         specifier: 1.3.0
         version: 1.3.0
@@ -1807,7 +1810,7 @@ importers:
         version: 8.2.2
       ember-concurrency:
         specifier: 'catalog:'
-        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
+        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-modifier:
         specifier: ^4.1.0
         version: 4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
@@ -1843,7 +1846,7 @@ importers:
         version: 8.2.2
       ember-concurrency:
         specifier: 'catalog:'
-        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
+        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-modifier:
         specifier: ^4.1.0
         version: 4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
@@ -1948,7 +1951,7 @@ importers:
         version: 8.2.2
       ember-concurrency:
         specifier: 'catalog:'
-        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
+        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-modifier:
         specifier: ^4.1.0
         version: 4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
@@ -2035,7 +2038,7 @@ importers:
         version: 1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)))
       '@glint/environment-ember-template-imports':
         specifier: 1.3.0
-        version: 1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))))(@glint/template@1.3.0)
+        version: 1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))))(@glint/template@1.3.0)
       '@glint/template':
         specifier: 1.3.0
         version: 1.3.0
@@ -2099,6 +2102,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: 'catalog:'
         version: 7.18.0(eslint@8.57.1)(typescript@5.1.6)
+      '@universal-ember/test-support':
+        specifier: 'catalog:'
+        version: 0.5.1(@babel/core@7.26.10)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))(qunit@2.24.1)
       broccoli-asset-rev:
         specifier: 'catalog:'
         version: 3.0.0
@@ -2206,7 +2212,7 @@ importers:
         version: 6.0.1(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-concurrency:
         specifier: 'catalog:'
-        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
+        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-css-url:
         specifier: ^1.0.0
         version: 1.0.0(patch_hash=0e5253a008cc7bf02424d786e7a8fb2397bc48962f3cd1443f2c0fdd8200c96d)
@@ -2251,7 +2257,7 @@ importers:
         version: 11.0.1(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-resources:
         specifier: ^6.5.1
-        version: 6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-concurrency@4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)))(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
+        version: 6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-concurrency@4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)))(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
       ember-route-template:
         specifier: ^1.0.3
         version: 1.0.3
@@ -2877,7 +2883,7 @@ importers:
         version: 1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)))
       '@glint/environment-ember-template-imports':
         specifier: 1.3.0
-        version: 1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))))(@glint/template@1.3.0)
+        version: 1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))))(@glint/template@1.3.0)
       '@types/dompurify':
         specifier: 'catalog:'
         version: 3.0.2
@@ -2925,7 +2931,7 @@ importers:
         version: 8.2.2
       ember-concurrency:
         specifier: 'catalog:'
-        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
+        version: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-modifier:
         specifier: ^4.1.0
         version: 4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
@@ -2965,7 +2971,7 @@ importers:
         version: 1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)))
       '@glint/environment-ember-template-imports':
         specifier: ^1.3.0
-        version: 1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))))(@glint/template@1.3.0)
+        version: 1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))))(@glint/template@1.3.0)
       '@glint/template':
         specifier: ^1.3.0
         version: 1.3.0
@@ -3783,6 +3789,9 @@ packages:
     engines: {node: 16.* || >= 18}
     peerDependencies:
       ember-source: ^4.0.0 || ^5.0.0
+
+  '@ember/test-helpers@5.2.2':
+    resolution: {integrity: sha512-Cclqeh0j6RnYvoaElAVC3Nd1fsSUkc3oUTwTsLlNiC3riyPq8lNYxh96VM59/yji2ntrd/cJQ7qhhSZWd6hsEw==}
 
   '@ember/test-waiters@3.1.0':
     resolution: {integrity: sha512-bb9h95ktG2wKY9+ja1sdsFBdOms2lB19VWs8wmNpzgHv1NCetonBoV5jHBV4DHt0uS1tg9z66cZqhUVlYs96KQ==}
@@ -5625,6 +5634,12 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@universal-ember/test-support@0.5.1':
+    resolution: {integrity: sha512-U9rCGb5TqDoudDFVbXafrZsIkMC22YWVU3zRqNckt0ne07+ZgQivQSgctXVpFIW6cnM6NbXy2i3x0CeJKg8bzw==}
+    peerDependencies:
+      ember-source: '>= 3.28'
+      qunit: ^2.20.1
 
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
@@ -14409,6 +14424,19 @@ snapshots:
       - supports-color
       - webpack
 
+  '@ember/test-helpers@5.2.2(@babel/core@7.26.10)(@glint/template@1.3.0)':
+    dependencies:
+      '@ember/test-waiters': 3.1.0
+      '@embroider/addon-shim': 1.8.9
+      '@embroider/macros': 1.16.9(@glint/template@1.3.0)
+      '@simple-dom/interface': 1.4.0
+      decorator-transforms: 2.3.0(@babel/core@7.26.10)
+      dom-element-descriptors: 0.5.1
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+
   '@ember/test-waiters@3.1.0':
     dependencies:
       calculate-cache-key-for-tree: 2.0.0
@@ -15243,7 +15271,7 @@ snapshots:
       ember-cli-htmlbars: 6.3.0
       ember-modifier: 4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
 
-  '@glint/environment-ember-template-imports@1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))))(@glint/template@1.3.0)':
+  '@glint/environment-ember-template-imports@1.3.0(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))))(@glint/template@1.3.0)':
     dependencies:
       '@glint/environment-ember-loose': 1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)))
       '@glint/template': 1.3.0
@@ -16597,6 +16625,17 @@ snapshots:
       eslint-visitor-keys: 3.4.3
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@universal-ember/test-support@0.5.1(@babel/core@7.26.10)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))(qunit@2.24.1)':
+    dependencies:
+      '@ember/test-helpers': 5.2.2(@babel/core@7.26.10)(@glint/template@1.3.0)
+      '@embroider/addon-shim': 1.8.9
+      ember-source: 5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)
+      qunit: 2.24.1
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
 
   '@vitest/expect@2.1.9':
     dependencies:
@@ -19128,6 +19167,27 @@ snapshots:
       - '@glint/template'
       - supports-color
 
+  ember-basic-dropdown@8.0.4(patch_hash=19b0fc5d4bd8b9aa296c4065fa5e33bdbb965db0b277810b596eacd0b9e2f428)(@ember/string@3.1.1)(@ember/test-helpers@5.2.2(@babel/core@7.26.10)(@glint/template@1.3.0))(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glimmer/tracking@1.1.2)(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))))(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)):
+    dependencies:
+      '@babel/core': 7.26.10(supports-color@8.1.1)
+      '@ember/test-helpers': 5.2.2(@babel/core@7.26.10)(@glint/template@1.3.0)
+      '@embroider/addon-shim': 1.8.9
+      '@embroider/macros': 1.16.9(@glint/template@1.3.0)
+      '@embroider/util': 1.13.1(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))))(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
+      '@glimmer/component': 1.1.2(@babel/core@7.26.10)
+      '@glimmer/tracking': 1.1.2
+      decorator-transforms: 1.1.0(@babel/core@7.26.10)
+      ember-element-helper: 0.8.6(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))))(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
+      ember-modifier: 4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
+      ember-source: 5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)
+      ember-style-modifier: 4.3.1(@babel/core@7.26.10)(@ember/string@3.1.1)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
+      ember-truth-helpers: 4.0.3(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
+    transitivePeerDependencies:
+      - '@ember/string'
+      - '@glint/environment-ember-loose'
+      - '@glint/template'
+      - supports-color
+
   ember-cli-app-version@6.0.1(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)):
     dependencies:
       ember-cli-babel: 7.26.11
@@ -19746,11 +19806,11 @@ snapshots:
     dependencies:
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 4.5.0
-      ember-concurrency: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
+      ember-concurrency: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
     transitivePeerDependencies:
       - supports-color
 
-  ember-concurrency@3.1.1(@babel/core@7.26.10)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)):
+  ember-concurrency@3.1.1(@babel/core@7.26.10)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)):
     dependencies:
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/types': 7.27.0
@@ -19765,7 +19825,7 @@ snapshots:
       - supports-color
     optional: true
 
-  ember-concurrency@4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)):
+  ember-concurrency@4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)):
     dependencies:
       '@babel/helper-module-imports': 7.25.9(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.26.5
@@ -19985,20 +20045,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-power-calendar-moment@1.0.2(@babel/core@7.26.10)(@glint/template@1.3.0)(ember-power-calendar@1.2.0(ae73f78346344bda7976042daa3e7280)):
+  ember-power-calendar-moment@1.0.2(@babel/core@7.26.10)(@glint/template@1.3.0)(ember-power-calendar@1.2.0(23f2a85894f1cabd8378488477fc3ced)):
     dependencies:
       '@embroider/addon-shim': 1.8.9
       '@embroider/macros': 1.16.9(@glint/template@1.3.0)
       decorator-transforms: 1.1.0(@babel/core@7.26.10)
-      ember-power-calendar: 1.2.0(ae73f78346344bda7976042daa3e7280)
+      ember-power-calendar: 1.2.0(23f2a85894f1cabd8378488477fc3ced)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  ember-power-calendar@1.2.0(ae73f78346344bda7976042daa3e7280):
+  ember-power-calendar@1.2.0(23f2a85894f1cabd8378488477fc3ced):
     dependencies:
-      '@ember/test-helpers': 3.3.1(@babel/core@7.26.10)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))(webpack@5.99.6)
+      '@ember/test-helpers': 5.2.2(@babel/core@7.26.10)(@glint/template@1.3.0)
       '@embroider/addon-shim': 1.8.9
       '@embroider/macros': 1.16.9(@glint/template@1.3.0)
       '@embroider/util': 1.13.1(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))))(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
@@ -20006,7 +20066,7 @@ snapshots:
       '@glimmer/tracking': 1.1.2
       decorator-transforms: 2.3.0(@babel/core@7.26.10)
       ember-assign-helper: 0.5.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
-      ember-concurrency: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
+      ember-concurrency: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-element-helper: 0.8.6(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))))(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-source: 5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)
       ember-truth-helpers: 4.0.3(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
@@ -20016,18 +20076,18 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  ember-power-select@8.1.0(7051d9587fa15cd41be1a83112217b32):
+  ember-power-select@8.1.0(543e302a9fcdd631e93f7c8af86c3fa6):
     dependencies:
       '@ember/render-modifiers': 2.1.0(@babel/core@7.26.10)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
-      '@ember/test-helpers': 3.3.1(@babel/core@7.26.10)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))(webpack@5.99.6)
+      '@ember/test-helpers': 5.2.2(@babel/core@7.26.10)(@glint/template@1.3.0)
       '@embroider/addon-shim': 1.8.9
       '@embroider/util': 1.13.1(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))))(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       '@glimmer/component': 1.1.2(@babel/core@7.26.10)
       '@glimmer/tracking': 1.1.2
       decorator-transforms: 1.1.0(@babel/core@7.26.10)
       ember-assign-helper: 0.5.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
-      ember-basic-dropdown: 8.0.4(patch_hash=19b0fc5d4bd8b9aa296c4065fa5e33bdbb965db0b277810b596eacd0b9e2f428)(2ae94f35bd5e6e6dafa095817afdf7bd)
-      ember-concurrency: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
+      ember-basic-dropdown: 8.0.4(patch_hash=19b0fc5d4bd8b9aa296c4065fa5e33bdbb965db0b277810b596eacd0b9e2f428)(@ember/string@3.1.1)(@ember/test-helpers@5.2.2(@babel/core@7.26.10)(@glint/template@1.3.0))(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glimmer/tracking@1.1.2)(@glint/environment-ember-loose@1.3.0(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-cli-htmlbars@6.3.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))))(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
+      ember-concurrency: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-source: 5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)
       ember-truth-helpers: 4.0.3(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
     transitivePeerDependencies:
@@ -20039,6 +20099,16 @@ snapshots:
   ember-provide-consume-context@0.7.0(@babel/core@7.26.10)(@ember/test-helpers@3.3.1(@babel/core@7.26.10)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))(webpack@5.99.6))(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)):
     dependencies:
       '@ember/test-helpers': 3.3.1(@babel/core@7.26.10)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))(webpack@5.99.6)
+      '@embroider/addon-shim': 1.8.9
+      '@glimmer/component': 1.1.2(@babel/core@7.26.10)
+      ember-source: 5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
+  ember-provide-consume-context@0.7.0(@babel/core@7.26.10)(@ember/test-helpers@5.2.2(@babel/core@7.26.10)(@glint/template@1.3.0))(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)):
+    dependencies:
+      '@ember/test-helpers': 5.2.2(@babel/core@7.26.10)(@glint/template@1.3.0)
       '@embroider/addon-shim': 1.8.9
       '@glimmer/component': 1.1.2(@babel/core@7.26.10)
       ember-source: 5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)
@@ -20090,11 +20160,11 @@ snapshots:
     optionalDependencies:
       '@ember/test-waiters': 3.1.0
       '@glimmer/component': 1.1.2(@babel/core@7.26.10)
-      ember-concurrency: 3.1.1(@babel/core@7.26.10)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
+      ember-concurrency: 3.1.1(@babel/core@7.26.10)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
     transitivePeerDependencies:
       - supports-color
 
-  ember-resources@6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-concurrency@4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)))(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)):
+  ember-resources@6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-concurrency@4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)))(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)):
     dependencies:
       '@babel/runtime': 7.22.11
       '@embroider/addon-shim': 1.8.9
@@ -20106,7 +20176,7 @@ snapshots:
     optionalDependencies:
       '@ember/test-waiters': 3.1.0
       '@glimmer/component': 1.1.2(@babel/core@7.26.10)
-      ember-concurrency: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
+      ember-concurrency: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
     transitivePeerDependencies:
       - supports-color
 
@@ -20132,9 +20202,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-sortable@5.0.2(@ember/test-helpers@3.3.1(@babel/core@7.26.10)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))(webpack@5.99.6))(@ember/test-waiters@3.1.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)))(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)):
+  ember-sortable@5.0.2(@ember/test-helpers@5.2.2(@babel/core@7.26.10)(@glint/template@1.3.0))(@ember/test-waiters@3.1.0)(ember-modifier@4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)))(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)):
     dependencies:
-      '@ember/test-helpers': 3.3.1(@babel/core@7.26.10)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))(webpack@5.99.6)
+      '@ember/test-helpers': 5.2.2(@babel/core@7.26.10)(@glint/template@1.3.0)
       '@ember/test-waiters': 3.1.0
       '@embroider/addon-shim': 1.8.9
       ember-modifier: 4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -84,6 +84,7 @@ catalog:
   "@types/yargs": ^17.0.10
   "@typescript-eslint/eslint-plugin": ^7.18.0
   "@typescript-eslint/parser": ^7.18.0
+  "@universal-ember/test-support": ^0.5.1
   "@vscode/vsce": ^3.1.0
   awesome-phonenumber: ^7.2.0
   babel-eslint: ^10.1.0


### PR DESCRIPTION
We have something like this with the `lookupService` and service-specific versions of it (`lookupLoaderService` etc), but `getService` is community-maintained and uses the Ember Typescript registry so typecasts are no longer necessary.