### PR TITLE
host: Add QUnit feature to pause on Percy snapshot

### DIFF
--- a/packages/host/tests/helpers/percy-snapshot.ts
+++ b/packages/host/tests/helpers/percy-snapshot.ts
@@ -2,7 +2,7 @@ import { pauseTest, settled } from '@ember/test-helpers';
 
 import originalPercySnapshot from '@percy/ember';
 
-import * as QUnit from 'qunit';
+import QUnit from 'qunit';
 
 QUnit.config.urlConfig.push({
   id: 'percypause',

--- a/packages/host/tests/helpers/percy-snapshot.ts
+++ b/packages/host/tests/helpers/percy-snapshot.ts
@@ -4,8 +4,10 @@ import originalPercySnapshot from '@percy/ember';
 
 import QUnit from 'qunit';
 
+const PERCY_PAUSE_PARAMETER = 'percypause';
+
 QUnit.config.urlConfig.push({
-  id: 'percypause',
+  id: PERCY_PAUSE_PARAMETER,
   label: 'Pause on Percy snapshot',
 });
 
@@ -31,7 +33,7 @@ export default async function percySnapshot(
     }
   });
 
-  if (window.location.search.includes('percypause')) {
+  if (window.location.search.includes(PERCY_PAUSE_PARAMETER)) {
     await pauseTest();
   }
 

--- a/packages/host/tests/helpers/percy-snapshot.ts
+++ b/packages/host/tests/helpers/percy-snapshot.ts
@@ -1,6 +1,13 @@
-import { settled } from '@ember/test-helpers';
+import { pauseTest, settled } from '@ember/test-helpers';
 
 import originalPercySnapshot from '@percy/ember';
+
+import * as QUnit from 'qunit';
+
+QUnit.config.urlConfig.push({
+  id: 'percypause',
+  label: 'Pause on Percy snapshot',
+});
 
 export default async function percySnapshot(
   ...args: Parameters<typeof originalPercySnapshot>
@@ -23,6 +30,10 @@ export default async function percySnapshot(
       throw new Error('Not ready: Poppins font could not be loaded');
     }
   });
+
+  if (window.location.search.includes('percypause')) {
+    await pauseTest();
+  }
 
   await originalPercySnapshot(...args);
 }


### PR DESCRIPTION
This adds a checkbox (and related query parameter) to easily pause tests when a Percy snapshot is requested:

![new-skill gts in Unnamed Workspace 2025-06-02 15-49-29](https://github.com/user-attachments/assets/6941bc6b-bf19-4647-a643-c5a2ab16a541)

This is useful to me in cases such as this where I’m looking into an unexpected diff, I don’t have to make any changes to the test file to have it pause at the moment of the snapshot:

<img width="1630" alt="Build #13490 - Cardstack - Percy | Visual testing as a service 2025-06-02 15-50-19" src="https://github.com/user-attachments/assets/0fc46c6b-7e4c-4cb8-a3e4-31231ec87872" />
