### PR TITLE
Don't crash the assistant if it can't load skills

### DIFF
--- a/packages/host/app/resources/room.ts
+++ b/packages/host/app/resources/room.ts
@@ -133,6 +133,10 @@ export class RoomResource extends Resource<Args> {
       if (!memberIds || !memberIds.includes(this.matrixService.aiBotUserId)) {
         return;
       }
+      // TODO: enabledSkillCards can have references to skills whose URL
+      // does not exist anymore (i.e. skill has been deleted or renamed). In
+      // this case we should probably remove/update the reference from the skillConfig.
+      // CS-8776
       await this.loadSkills(this.matrixRoom.skillsConfig.enabledSkillCards);
 
       let index = this._messageCache.size;
@@ -396,7 +400,8 @@ export class RoomResource extends Resource<Args> {
     if (isCardInstance(skillCard)) {
       return skillCard;
     } else {
-      throw new Error(`Cannot find skill ${cardId}`);
+      // A known reason for this is that the skill has been renamed
+      return undefined;
     }
   }
 


### PR DESCRIPTION
This is a hot fix for situations where old matrix sessions are referencing skills that do not exist anymore (deleted or renamed). In that case the unhandled error results in an unfunctioning AI assistant (can't send messages). 

<img width="793" alt="image" src="https://github.com/user-attachments/assets/2dd0a64f-5959-4f21-9d13-70166c9c8391" />

This fix enables users to continue using old sessions with broken skill references but they need to start a new session for the updated skills to be picked up. I made a new ticket for handling outdated skills (renamed/deleted) and make sure they get updated in the matrix config. 
