### PR TITLE
Update ember-template-lint to 7.8.1

### DIFF
--- a/packages/base/country.gts
+++ b/packages/base/country.gts
@@ -81,7 +81,7 @@ class CountryFieldEdit extends Component<typeof CountryField> {
       Loading countries...
     {{else}}
       <BoxelSelect
-        @placeholder={{'Choose a country'}}
+        @placeholder='Choose a country'
         @options={{this.countries}}
         @selected={{this.country}}
         @onChange={{this.onSelectCountry}}

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -19,7 +19,7 @@
     "ember-css-url": "^1.0.0",
     "ember-modifier": "^3.2.1",
     "ember-resources": "^6.5.1",
-    "ember-template-lint": "^5.11.2",
+    "ember-template-lint": "catalog:",
     "ethers": "catalog:",
     "matrix-js-sdk": "catalog:",
     "super-fast-md5": "catalog:",

--- a/packages/boxel-icons/package.json
+++ b/packages/boxel-icons/package.json
@@ -58,7 +58,7 @@
     "concurrently": "catalog:",
     "ember-source": "~5.4.0",
     "ember-template-imports": "^4.1.1",
-    "ember-template-lint": "^5.11.2",
+    "ember-template-lint": "catalog:",
     "ember-template-lint-plugin-prettier": "^5.0.0",
     "eslint": "catalog:",
     "eslint-config-prettier": "catalog:",

--- a/packages/boxel-motion/addon/package.json
+++ b/packages/boxel-motion/addon/package.json
@@ -72,7 +72,7 @@
     "concurrently": "catalog:",
     "ember-source": "~5.4.0",
     "ember-template-imports": "^4.1.1",
-    "ember-template-lint": "^5.11.2",
+    "ember-template-lint": "catalog:",
     "ember-template-lint-plugin-prettier": "^5.0.0",
     "eslint": "catalog:",
     "eslint-config-prettier": "catalog:",

--- a/packages/boxel-motion/test-app/package.json
+++ b/packages/boxel-motion/test-app/package.json
@@ -79,7 +79,7 @@
     "ember-source": "^5.4.0",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-imports": "^4.1.1",
-    "ember-template-lint": "^5.11.2",
+    "ember-template-lint": "catalog:",
     "ember-try": "^2.0.0",
     "eslint": "catalog:",
     "eslint-config-prettier": "catalog:",

--- a/packages/boxel-ui/addon/package.json
+++ b/packages/boxel-ui/addon/package.json
@@ -87,7 +87,7 @@
     "babel-plugin-ember-template-compilation": "~2.2.1",
     "concurrently": "catalog:",
     "ember-template-imports": "^4.1.1",
-    "ember-template-lint": "^5.11.2",
+    "ember-template-lint": "catalog:",
     "ember-template-lint-plugin-prettier": "^5.0.0",
     "eslint": "catalog:",
     "eslint-config-prettier": "catalog:",

--- a/packages/boxel-ui/addon/src/components/button/usage.gts
+++ b/packages/boxel-ui/addon/src/components/button/usage.gts
@@ -107,7 +107,7 @@ export default class ButtonUsage extends Component {
           @name='kind'
           @optional={{true}}
           @description='Controls the colors of the button'
-          @defaultValue={{'secondary-light'}}
+          @defaultValue='secondary-light'
           @options={{this.kindVariants.all}}
           @onInput={{fn (mut this.kind)}}
           @value={{this.kind}}
@@ -116,7 +116,7 @@ export default class ButtonUsage extends Component {
           @name='size'
           @optional={{true}}
           @description='Controls the size of the button'
-          @defaultValue={{'base'}}
+          @defaultValue='base'
           @options={{this.sizeVariants}}
           @onInput={{fn (mut this.size)}}
           @value={{this.size}}

--- a/packages/boxel-ui/addon/src/components/entity-thumbnail-display/usage.gts
+++ b/packages/boxel-ui/addon/src/components/entity-thumbnail-display/usage.gts
@@ -21,9 +21,9 @@ export default class EntityThumbnailDisplayUsage extends Component {
         <EntityDisplayWithThumbnail @title={{this.title}}>
           <:thumbnail>
             <Avatar
-              @userId={{'user123'}}
+              @userId='user123'
               @displayName={{this.title}}
-              @thumbnailURL={{'https://images.pexels.com/photos/4571943/pexels-photo-4571943.jpeg?auto=compress&cs=tinysrgb&w=300&h=300&dpr=1'}}
+              @thumbnailURL='https://images.pexels.com/photos/4571943/pexels-photo-4571943.jpeg?auto=compress&cs=tinysrgb&w=300&h=300&dpr=1'
               @isReady={{true}}
               class='avatar'
             />

--- a/packages/boxel-ui/addon/src/components/icon-button/usage.gts
+++ b/packages/boxel-ui/addon/src/components/icon-button/usage.gts
@@ -79,14 +79,14 @@ export default class IconButtonUsage extends Component {
         <Args.String
           @name='width'
           @description='used to size the SVG rendering (only accepts px values)'
-          @defaultValue={{'16px'}}
+          @defaultValue='16px'
           @value={{this.width}}
           @onInput={{fn (mut this.width)}}
         />
         <Args.String
           @name='height'
           @description='used to size the SVG rendering (only accepts px values)'
-          @defaultValue={{'16px'}}
+          @defaultValue='16px'
           @value={{this.height}}
           @onInput={{fn (mut this.height)}}
         />

--- a/packages/boxel-ui/addon/src/components/modal/usage.gts
+++ b/packages/boxel-ui/addon/src/components/modal/usage.gts
@@ -116,7 +116,7 @@ export default class ModalUsage extends Component {
           @name='layer'
           @description="Which of Boxel's z-index layers should be used for this modal"
           @value={{this.layer}}
-          @defaultValue={{'default'}}
+          @defaultValue='default'
           @options={{array 'default' 'urgent'}}
           @onInput={{fn (mut this.layer)}}
           @optional={{true}}

--- a/packages/boxel-ui/addon/src/components/multi-select/index.gts
+++ b/packages/boxel-ui/addon/src/components/multi-select/index.gts
@@ -73,7 +73,7 @@ export class BoxelMultiSelectBasic<ItemT> extends Component<Signature<ItemT>> {
       @registerAPI={{@registerAPI}}
       @initiallyOpened={{@initiallyOpened}}
       @extra={{@extra}}
-      @dropdownClass={{'boxel-multi-select__dropdown'}}
+      @dropdownClass='boxel-multi-select__dropdown'
       {{! actions  }}
       @onOpen={{@onOpen}}
       @onClose={{@onClose}}
@@ -82,7 +82,7 @@ export class BoxelMultiSelectBasic<ItemT> extends Component<Signature<ItemT>> {
       @selectedItemComponent={{@selectedItemComponent}}
       @triggerComponent={{@triggerComponent}}
       @afterOptionsComponent={{@afterOptionsComponent}}
-      @beforeOptionsComponent={{(component BeforeOptions)}}
+      @beforeOptionsComponent={{component BeforeOptions}}
       ...attributes
       as |option|
     >

--- a/packages/boxel-ui/addon/src/components/multi-select/usage.gts
+++ b/packages/boxel-ui/addon/src/components/multi-select/usage.gts
@@ -358,7 +358,7 @@ export default class BoxelMultiSelectUsage extends Component {
             @searchEnabled={{true}}
             @closeOnSelect={{false}}
             @ariaLabel='Select countries'
-            @selectedItemComponent={{(component SelectedCountry)}}
+            @selectedItemComponent={{component SelectedCountry}}
             as |option|
           >
             {{option.name}}

--- a/packages/boxel-ui/addon/src/components/radio-input/usage.gts
+++ b/packages/boxel-ui/addon/src/components/radio-input/usage.gts
@@ -194,8 +194,8 @@ export default class RadioInputUsage extends Component {
           @name='example-radio-usage'
           @checkedId={{this.checkedIdItems}}
           @disabled={{this.disabled}}
-          @orientation={{'vertical'}}
-          @spacing={{'compact'}}
+          @orientation='vertical'
+          @spacing='compact'
           @hideRadio={{false}}
           @hideBorder={{true}}
           style={{cssVar
@@ -219,8 +219,8 @@ export default class RadioInputUsage extends Component {
           @name='example-radio-usage'
           @checkedId={{this.checkedIdTshirts}}
           @disabled={{this.disabled}}
-          @orientation={{'horizontal'}}
-          @spacing={{'default'}}
+          @orientation='horizontal'
+          @spacing='default'
           @hideRadio={{true}}
           @hideBorder={{false}}
           style={{cssVar

--- a/packages/boxel-ui/addon/src/components/select/index.gts
+++ b/packages/boxel-ui/addon/src/components/select/index.gts
@@ -37,13 +37,13 @@ const BoxelSelect: TemplateOnlyComponent<Signature> = <template>
     @loadingMessage={{@loadingMessage}}
     {{! We can avoid providing arguments to the triggerComponent as long as they are specified here https://github.com/cibernox/ember-power-select/blob/913c85ec82d5c6aeb80a7a3b9d9c21ca9613e900/ember-power-select/src/components/power-select.hbs#L79-L106 }}
     {{! Even the custom BoxelTriggerWrapper will receive these arguments }}
-    @triggerComponent={{(if
+    @triggerComponent={{if
       @triggerComponent
       @triggerComponent
       (component
         BoxelSelectDefaultTrigger invertIcon=(eq @verticalPosition 'above')
       )
-    )}}
+    }}
     @disabled={{@disabled}}
     @matchTriggerWidth={{@matchTriggerWidth}}
     @eventType='click'

--- a/packages/boxel-ui/addon/src/components/switch/usage.gts
+++ b/packages/boxel-ui/addon/src/components/switch/usage.gts
@@ -35,7 +35,7 @@ export default class SwitchUsage extends Component {
         </:description>
         <:example>
           <Switch
-            @label={{'Switch'}}
+            @label='Switch'
             @isEnabled={{this.isEnabled}}
             @onChange={{this.handleChange}}
             @disabled={{this.isDisabled}}

--- a/packages/boxel-ui/test-app/package.json
+++ b/packages/boxel-ui/test-app/package.json
@@ -81,7 +81,7 @@
     "ember-source": "^5.4.0",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-imports": "^4.1.1",
-    "ember-template-lint": "^5.11.2",
+    "ember-template-lint": "catalog:",
     "ember-try": "^2.0.0",
     "eslint": "catalog:",
     "eslint-config-prettier": "catalog:",

--- a/packages/catalog-realm/crm-app/components/base-task-planner.gts
+++ b/packages/catalog-realm/crm-app/components/base-task-planner.gts
@@ -440,7 +440,7 @@ export class TaskPlanner extends GlimmerComponent<TaskPlannerArgs> {
               @selected={{this.selectedFilter}}
               @options={{this.filterTypes}}
               @onChange={{this.onSelectFilter}}
-              @placeholder={{'Choose a Filter'}}
+              @placeholder='Choose a Filter'
               @matchTriggerWidth={{false}}
               @triggerComponent={{FilterTrigger}}
               as |item|
@@ -462,7 +462,7 @@ export class TaskPlanner extends GlimmerComponent<TaskPlannerArgs> {
               <FilterDisplay
                 @key={{filterType}}
                 @items={{items}}
-                @removeItem={{(fn this.removeFilter filterType)}}
+                @removeItem={{fn this.removeFilter filterType}}
                 @icon={{this.getFilterIcon filterType}}
                 as |item|
               >

--- a/packages/catalog-realm/crm-app/components/filter/filter-dropdown.gts
+++ b/packages/catalog-realm/crm-app/components/filter/filter-dropdown.gts
@@ -25,7 +25,7 @@ export class FilterDropdown extends GlimmerComponent<FilterDropdownSignature> {
       @options={{@options}}
       @selected={{@selected}}
       @onChange={{@onChange}}
-      @triggerComponent={{(component FilterTrigger isLoading=@isLoading)}}
+      @triggerComponent={{component FilterTrigger isLoading=@isLoading}}
       @initiallyOpened={{true}}
       @searchEnabled={{true}}
       @searchField={{@searchField}}

--- a/packages/catalog-realm/crm-app/deal-event.gts
+++ b/packages/catalog-realm/crm-app/deal-event.gts
@@ -179,7 +179,7 @@ class EditTemplate extends Component<typeof DealEvent> {
       </FieldContainer>
       <FieldContainer @label='Event type'>
         <BoxelSelect
-          @placeholder={{'Select Item'}}
+          @placeholder='Select Item'
           @selected={{this.selectedEventType}}
           @onChange={{this.updateEventType}}
           @options={{this.eventTypeItems}}

--- a/packages/catalog-realm/crm-app/fields/currency.gts
+++ b/packages/catalog-realm/crm-app/fields/currency.gts
@@ -66,7 +66,7 @@ class CurrencyFieldEdit extends Component<typeof CurrencyField> {
       Loading currencies...
     {{else}}
       <BoxelSelect
-        @placeholder={{'Choose a currency'}}
+        @placeholder='Choose a currency'
         @options={{this.currencies}}
         @selected={{this.currency}}
         @onChange={{this.onSelectCurrency}}

--- a/packages/catalog-realm/package.json
+++ b/packages/catalog-realm/package.json
@@ -13,7 +13,7 @@
     "concurrently": "catalog:",
     "ember-concurrency": "catalog:",
     "ember-modifier": "^4.1.0",
-    "ember-template-lint": "^5.11.2",
+    "ember-template-lint": "catalog:",
     "tracked-built-ins": "^3.3.0"
   },
   "scripts": {

--- a/packages/catalog-realm/sprint-planner/components/base-task-planner.gts
+++ b/packages/catalog-realm/sprint-planner/components/base-task-planner.gts
@@ -440,7 +440,7 @@ export class TaskPlanner extends GlimmerComponent<TaskPlannerArgs> {
               @selected={{this.selectedFilter}}
               @options={{this.filterTypes}}
               @onChange={{this.onSelectFilter}}
-              @placeholder={{'Choose a Filter'}}
+              @placeholder='Choose a Filter'
               @matchTriggerWidth={{false}}
               @triggerComponent={{FilterTrigger}}
               as |item|
@@ -462,7 +462,7 @@ export class TaskPlanner extends GlimmerComponent<TaskPlannerArgs> {
               <FilterDisplay
                 @key={{filterType}}
                 @items={{items}}
-                @removeItem={{(fn this.removeFilter filterType)}}
+                @removeItem={{fn this.removeFilter filterType}}
                 @icon={{this.getFilterIcon filterType}}
                 as |item|
               >

--- a/packages/catalog-realm/sprint-planner/components/filter/filter-dropdown.gts
+++ b/packages/catalog-realm/sprint-planner/components/filter/filter-dropdown.gts
@@ -25,7 +25,7 @@ export class FilterDropdown extends GlimmerComponent<FilterDropdownSignature> {
       @options={{@options}}
       @selected={{@selected}}
       @onChange={{@onChange}}
-      @triggerComponent={{(component FilterTrigger isLoading=@isLoading)}}
+      @triggerComponent={{component FilterTrigger isLoading=@isLoading}}
       @initiallyOpened={{true}}
       @searchEnabled={{true}}
       @searchField={{@searchField}}

--- a/packages/experiments-realm/components/base-task-planner.gts
+++ b/packages/experiments-realm/components/base-task-planner.gts
@@ -440,7 +440,7 @@ export class TaskPlanner extends GlimmerComponent<TaskPlannerArgs> {
               @selected={{this.selectedFilter}}
               @options={{this.filterTypes}}
               @onChange={{this.onSelectFilter}}
-              @placeholder={{'Choose a Filter'}}
+              @placeholder='Choose a Filter'
               @matchTriggerWidth={{false}}
               @triggerComponent={{FilterTrigger}}
               as |item|
@@ -462,7 +462,7 @@ export class TaskPlanner extends GlimmerComponent<TaskPlannerArgs> {
               <FilterDisplay
                 @key={{filterType}}
                 @items={{items}}
-                @removeItem={{(fn this.removeFilter filterType)}}
+                @removeItem={{fn this.removeFilter filterType}}
                 @icon={{this.getFilterIcon filterType}}
                 as |item|
               >

--- a/packages/experiments-realm/components/filter/filter-dropdown.gts
+++ b/packages/experiments-realm/components/filter/filter-dropdown.gts
@@ -25,7 +25,7 @@ export class FilterDropdown extends GlimmerComponent<FilterDropdownSignature> {
       @options={{@options}}
       @selected={{@selected}}
       @onChange={{@onChange}}
-      @triggerComponent={{(component FilterTrigger isLoading=@isLoading)}}
+      @triggerComponent={{component FilterTrigger isLoading=@isLoading}}
       @initiallyOpened={{true}}
       @searchEnabled={{true}}
       @searchField={{@searchField}}

--- a/packages/experiments-realm/country.gts
+++ b/packages/experiments-realm/country.gts
@@ -87,7 +87,7 @@ class CountryFieldEdit extends Component<typeof CountryField> {
       Loading countries...
     {{else}}
       <BoxelSelect
-        @placeholder={{'Choose a country'}}
+        @placeholder='Choose a country'
         @options={{this.countries}}
         @selected={{this.country}}
         @onChange={{this.onSelectCountry}}

--- a/packages/experiments-realm/crm/deal-event.gts
+++ b/packages/experiments-realm/crm/deal-event.gts
@@ -179,7 +179,7 @@ class EditTemplate extends Component<typeof DealEvent> {
       </FieldContainer>
       <FieldContainer @label='Event type'>
         <BoxelSelect
-          @placeholder={{'Select Item'}}
+          @placeholder='Select Item'
           @selected={{this.selectedEventType}}
           @onChange={{this.updateEventType}}
           @options={{this.eventTypeItems}}

--- a/packages/experiments-realm/event.gts
+++ b/packages/experiments-realm/event.gts
@@ -47,7 +47,7 @@ class Edit extends Component<typeof Event> {
         </FieldContainer>
         <FieldContainer @label='Event type' @tag='label' class='field'>
           <BoxelSelect
-            @placeholder={{'Select Item'}}
+            @placeholder='Select Item'
             @selected={{this.selectedEventType}}
             @onChange={{this.updateEventType}}
             @options={{this.eventTypeItems}}

--- a/packages/experiments-realm/fields/currency.gts
+++ b/packages/experiments-realm/fields/currency.gts
@@ -66,7 +66,7 @@ class CurrencyFieldEdit extends Component<typeof CurrencyField> {
       Loading currencies...
     {{else}}
       <BoxelSelect
-        @placeholder={{'Choose a currency'}}
+        @placeholder='Choose a currency'
         @options={{this.currencies}}
         @selected={{this.currency}}
         @onChange={{this.onSelectCurrency}}

--- a/packages/experiments-realm/package.json
+++ b/packages/experiments-realm/package.json
@@ -12,7 +12,7 @@
     "concurrently": "catalog:",
     "ember-concurrency": "catalog:",
     "ember-modifier": "^4.1.0",
-    "ember-template-lint": "^5.11.2",
+    "ember-template-lint": "catalog:",
     "tracked-built-ins": "^3.3.0"
   },
   "scripts": {

--- a/packages/host/app/components/ai-assistant/attachment-picker/usage.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/usage.gts
@@ -63,7 +63,7 @@ export default class AiAssistantCardPickerUsage extends Component {
           @maxNumberOfItemsToAttach={{this.maxNumberOfCards}}
           @autoAttachedFile={{this.autoAttachedFile}}
           @filesToAttach={{this.filesToAttach}}
-          @submode={{'interact'}}
+          @submode='interact'
         />
         <CardCatalogModal />
       </:example>

--- a/packages/host/app/components/ai-assistant/message/index.gts
+++ b/packages/host/app/components/ai-assistant/message/index.gts
@@ -269,7 +269,8 @@ export default class AiAssistantMessage extends Component<Signature> {
                 Thinking...
               {{else}}
                 <details open={{this.isReasoningExpanded}} data-test-reasoning>
-                  {{! template-lint-disable no-invalid-interactive}}
+                  {{! template-lint-disable no-invalid-interactive }}
+                  {{! template-lint-disable no-nested-interactive }}
                   <summary
                     {{on 'click' this.updateReasoningExpanded}}
                   >Thinking...</summary>

--- a/packages/host/app/components/ai-assistant/message/usage.gts
+++ b/packages/host/app/components/ai-assistant/message/usage.gts
@@ -156,7 +156,7 @@ export default class AiAssistantMessageUsage extends Component {
             <AiAssistantMessage
               @messageHTML='Culpa fugiat ex ipsum commodo anim. Cillum reprehenderit eu consectetur laboris dolore in cupidatat. Deserunt ipsum voluptate sit velit aute ad velit exercitation sint. Velit esse velit est et amet labore velit nisi magna ea elit nostrud quis anim..'
               @index={{1}}
-              @eventId={{'125'}}
+              @eventId='125'
               @roomId='!abcd'
               @monacoSDK={{this.noopMonacoSDK}}
               @registerScroller={{this.noop}}

--- a/packages/host/app/components/card-catalog/index.gts
+++ b/packages/host/app/components/card-catalog/index.gts
@@ -191,7 +191,7 @@ export default class CardCatalog extends Component<Signature> {
                 as |isSelected|
               }}
                 <ItemButton
-                  @newCard={{(this.newCardArgs realmUrl)}}
+                  @newCard={{this.newCardArgs realmUrl}}
                   @isSelected={{isSelected}}
                   @select={{@select}}
                   @handleEnterKey={{this.handleEnterKey}}
@@ -274,7 +274,7 @@ export default class CardCatalog extends Component<Signature> {
                 as |isSelected|
               }}
                 <ItemButton
-                  @newCard={{(this.newCardArgs realmUrl)}}
+                  @newCard={{this.newCardArgs realmUrl}}
                   @isSelected={{isSelected}}
                   @select={{@select}}
                   @handleEnterKey={{this.handleEnterKey}}

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -88,14 +88,14 @@ export default class Room extends Component<Signature> {
     {{#if (not this.doMatrixEventFlush.isRunning)}}
       <section
         class='room'
-        data-room-settled={{(and
+        data-room-settled={{and
           this.doWhenRoomChanges.isIdle
           (not this.matrixService.isLoadingTimeline)
-        )}}
-        data-test-room-settled={{(and
+        }}
+        data-test-room-settled={{and
           this.doWhenRoomChanges.isIdle
           (not this.matrixService.isLoadingTimeline)
-        )}}
+        }}
         data-test-room-name={{@roomResource.name}}
         data-test-room={{@roomId}}
         data-room-id={{@roomId}}

--- a/packages/host/app/components/operator-mode/attach-file-modal.gts
+++ b/packages/host/app/components/operator-mode/attach-file-modal.gts
@@ -186,7 +186,7 @@ export default class AttachFileModal extends Component<Signature> {
     {{#if this.deferred}}
       <ModalContainer
         @title='Attach File'
-        @onClose={{(fn this.pick undefined)}}
+        @onClose={{fn this.pick undefined}}
         @size='medium'
         @centered={{true}}
         {{on 'keydown' this.handleKeydown}}

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -440,7 +440,7 @@ export default class DetailPanel extends Component<Signature> {
             {{#if this.cardInstanceType.type}}
               {{#let (getCodeRef this.cardInstanceType.type) as |codeRef|}}
                 <ClickableModuleDefinitionContainer
-                  @title={{'Card Definition'}}
+                  @title='Card Definition'
                   @fileURL={{this.cardInstanceType.type.module}}
                   @name={{this.cardInstanceType.type.displayName}}
                   @fileExtension={{this.cardInstanceType.type.moduleInfo.extension}}

--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -76,7 +76,7 @@ export default class OperatorModeOverlays extends Overlays {
                     @height='100%'
                     @icon={{if isSelected IconCircleSelected IconCircle}}
                     aria-label='select card'
-                    data-test-overlay-select={{(removeFileExtension cardId)}}
+                    data-test-overlay-select={{removeFileExtension cardId}}
                   />
                 </div>
               {{/if}}
@@ -110,7 +110,7 @@ export default class OperatorModeOverlays extends Overlays {
                   {{#if (this.isButtonDisplayed 'more-options' renderedCard)}}
                     <div>
                       <BoxelDropdown
-                        @registerAPI={{(this.registerDropdownAPI renderedCard)}}
+                        @registerAPI={{this.registerDropdownAPI renderedCard}}
                       >
                         <:trigger as |bindings|>
                           <Tooltip @placement='top'>

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -132,7 +132,7 @@
     "ember-route-template": "^1.0.3",
     "ember-source": "~5.4.0",
     "ember-template-imports": "^4.1.1",
-    "ember-template-lint": "^5.11.2",
+    "ember-template-lint": "catalog:",
     "ember-test-selectors": "^6.0.0",
     "ember-velcro": "^2.1.3",
     "ember-window-mock": "^1.0.1",

--- a/packages/seed-realm/components/base-task-planner.gts
+++ b/packages/seed-realm/components/base-task-planner.gts
@@ -440,7 +440,7 @@ export class TaskPlanner extends GlimmerComponent<TaskPlannerArgs> {
               @selected={{this.selectedFilter}}
               @options={{this.filterTypes}}
               @onChange={{this.onSelectFilter}}
-              @placeholder={{'Choose a Filter'}}
+              @placeholder='Choose a Filter'
               @matchTriggerWidth={{false}}
               @triggerComponent={{FilterTrigger}}
               as |item|
@@ -462,7 +462,7 @@ export class TaskPlanner extends GlimmerComponent<TaskPlannerArgs> {
               <FilterDisplay
                 @key={{filterType}}
                 @items={{items}}
-                @removeItem={{(fn this.removeFilter filterType)}}
+                @removeItem={{fn this.removeFilter filterType}}
                 @icon={{this.getFilterIcon filterType}}
                 as |item|
               >

--- a/packages/seed-realm/components/filter/filter-dropdown.gts
+++ b/packages/seed-realm/components/filter/filter-dropdown.gts
@@ -25,7 +25,7 @@ export class FilterDropdown extends GlimmerComponent<FilterDropdownSignature> {
       @options={{@options}}
       @selected={{@selected}}
       @onChange={{@onChange}}
-      @triggerComponent={{(component FilterTrigger isLoading=@isLoading)}}
+      @triggerComponent={{component FilterTrigger isLoading=@isLoading}}
       @initiallyOpened={{true}}
       @searchEnabled={{true}}
       @searchField={{@searchField}}

--- a/packages/seed-realm/country.gts
+++ b/packages/seed-realm/country.gts
@@ -87,7 +87,7 @@ class CountryFieldEdit extends Component<typeof CountryField> {
       Loading countries...
     {{else}}
       <BoxelSelect
-        @placeholder={{'Choose a country'}}
+        @placeholder='Choose a country'
         @options={{this.countries}}
         @selected={{this.country}}
         @onChange={{this.onSelectCountry}}

--- a/packages/seed-realm/crm/deal-event.gts
+++ b/packages/seed-realm/crm/deal-event.gts
@@ -179,7 +179,7 @@ class EditTemplate extends Component<typeof DealEvent> {
       </FieldContainer>
       <FieldContainer @label='Event type'>
         <BoxelSelect
-          @placeholder={{'Select Item'}}
+          @placeholder='Select Item'
           @selected={{this.selectedEventType}}
           @onChange={{this.updateEventType}}
           @options={{this.eventTypeItems}}

--- a/packages/seed-realm/fields/currency.gts
+++ b/packages/seed-realm/fields/currency.gts
@@ -66,7 +66,7 @@ class CurrencyFieldEdit extends Component<typeof CurrencyField> {
       Loading currencies...
     {{else}}
       <BoxelSelect
-        @placeholder={{'Choose a currency'}}
+        @placeholder='Choose a currency'
         @options={{this.currencies}}
         @selected={{this.currency}}
         @onChange={{this.onSelectCurrency}}

--- a/packages/seed-realm/package.json
+++ b/packages/seed-realm/package.json
@@ -12,7 +12,7 @@
     "concurrently": "catalog:",
     "ember-concurrency": "catalog:",
     "ember-modifier": "^4.1.0",
-    "ember-template-lint": "^5.11.2",
+    "ember-template-lint": "catalog:",
     "tracked-built-ins": "^3.3.0"
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,8 +307,8 @@ catalogs:
       specifier: ^8.0.1
       version: 8.0.2
     ember-template-lint:
-      specifier: ^5.11.2
-      version: 5.11.2
+      specifier: ^6.0.0
+      version: 6.1.0
     esbuild:
       specifier: ^0.24.0
       version: 0.24.0
@@ -833,7 +833,7 @@ importers:
         version: 6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-concurrency@4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)))(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
       ember-template-lint:
         specifier: 'catalog:'
-        version: 5.11.2
+        version: 6.1.0
       ethers:
         specifier: 'catalog:'
         version: 6.6.2
@@ -943,10 +943,10 @@ importers:
         version: 4.1.1
       ember-template-lint:
         specifier: 'catalog:'
-        version: 5.11.2
+        version: 6.1.0
       ember-template-lint-plugin-prettier:
         specifier: ^5.0.0
-        version: 5.0.0(ember-template-lint@5.11.2)(prettier@3.5.3)
+        version: 5.0.0(ember-template-lint@6.1.0)(prettier@3.5.3)
       eslint:
         specifier: 'catalog:'
         version: 8.57.1
@@ -1100,10 +1100,10 @@ importers:
         version: 4.1.1
       ember-template-lint:
         specifier: 'catalog:'
-        version: 5.11.2
+        version: 6.1.0
       ember-template-lint-plugin-prettier:
         specifier: ^5.0.0
-        version: 5.0.0(ember-template-lint@5.11.2)(prettier@3.5.3)
+        version: 5.0.0(ember-template-lint@6.1.0)(prettier@3.5.3)
       eslint:
         specifier: 'catalog:'
         version: 8.57.1
@@ -1310,7 +1310,7 @@ importers:
         version: 4.1.1
       ember-template-lint:
         specifier: 'catalog:'
-        version: 5.11.2
+        version: 6.1.0
       ember-try:
         specifier: ^2.0.0
         version: 2.0.0
@@ -1527,10 +1527,10 @@ importers:
         version: 4.1.1
       ember-template-lint:
         specifier: 'catalog:'
-        version: 5.11.2
+        version: 6.1.0
       ember-template-lint-plugin-prettier:
         specifier: ^5.0.0
-        version: 5.0.0(ember-template-lint@5.11.2)(prettier@3.5.3)
+        version: 5.0.0(ember-template-lint@6.1.0)(prettier@3.5.3)
       eslint:
         specifier: 'catalog:'
         version: 8.57.1
@@ -1744,7 +1744,7 @@ importers:
         version: 4.1.1
       ember-template-lint:
         specifier: 'catalog:'
-        version: 5.11.2
+        version: 6.1.0
       ember-try:
         specifier: ^2.0.0
         version: 2.0.0
@@ -1822,7 +1822,7 @@ importers:
         version: 4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-template-lint:
         specifier: 'catalog:'
-        version: 5.11.2
+        version: 6.1.0
       tracked-built-ins:
         specifier: ^3.3.0
         version: 3.3.0
@@ -1927,7 +1927,7 @@ importers:
         version: 4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-template-lint:
         specifier: 'catalog:'
-        version: 5.11.2
+        version: 6.1.0
       tracked-built-ins:
         specifier: ^3.3.0
         version: 3.3.0
@@ -2239,7 +2239,7 @@ importers:
         version: 4.1.1
       ember-template-lint:
         specifier: 'catalog:'
-        version: 5.11.2
+        version: 6.1.0
       ember-test-selectors:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2907,7 +2907,7 @@ importers:
         version: 4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-template-lint:
         specifier: 'catalog:'
-        version: 5.11.2
+        version: 6.1.0
       tracked-built-ins:
         specifier: ^3.3.0
         version: 3.3.0
@@ -5155,6 +5155,10 @@ packages:
     resolution: {integrity: sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==}
     engines: {node: '>=6'}
 
+  '@sindresorhus/merge-streams@2.3.0':
+    resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
+    engines: {node: '>=18'}
+
   '@sinonjs/commons@3.0.1':
     resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
 
@@ -7358,6 +7362,9 @@ packages:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
     engines: {node: '>=0.11'}
 
+  date-fns@3.6.0:
+    resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
+
   dayjs@1.11.7:
     resolution: {integrity: sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==}
 
@@ -8147,6 +8154,11 @@ packages:
     engines: {node: ^14.18.0 || ^16.0.0 || >= 18.0.0}
     hasBin: true
 
+  ember-template-lint@6.1.0:
+    resolution: {integrity: sha512-UyzLPcyneG3mnbBfewyYIlV7fy6JKHQVAJy5a9+URdJKkZKN+3vQkQzIIlsz6dP/GpoXVB+datns5HlfMfliSA==}
+    engines: {node: ^18.18.0 || >= 20.9.0}
+    hasBin: true
+
   ember-template-recast@6.1.5:
     resolution: {integrity: sha512-VnRN8FzEHQnw/5rCv6Wnq8MVYXbGQbFY+rEufvWV+FO/IsxMahGEud4MYWtTA2q8iG+qJFrDQefNvQ//7MI7Qw==}
     engines: {node: 12.* || 14.* || >= 16.*}
@@ -8653,6 +8665,10 @@ packages:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
     engines: {node: '>=8.6.0'}
 
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
@@ -8788,6 +8804,10 @@ packages:
   find-up@6.3.0:
     resolution: {integrity: sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  find-up@7.0.0:
+    resolution: {integrity: sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==}
+    engines: {node: '>=18'}
 
   find-yarn-workspace-root@1.2.1:
     resolution: {integrity: sha512-dVtfb0WuQG+8Ag2uWkbG79hOUzEsRrhBzgfn86g2sJPkzmcpGdghbNTfUKGTxymFrY/tLIodDzLoW9nOJ4FY8Q==}
@@ -8976,6 +8996,10 @@ packages:
     resolution: {integrity: sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==}
     engines: {node: '>=10'}
 
+  fuse.js@7.1.0:
+    resolution: {integrity: sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==}
+    engines: {node: '>=10'}
+
   gauge@4.0.4:
     resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -9142,6 +9166,10 @@ packages:
   globby@13.2.2:
     resolution: {integrity: sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  globby@14.1.0:
+    resolution: {integrity: sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==}
+    engines: {node: '>=18'}
 
   globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
@@ -9405,6 +9433,10 @@ packages:
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
   image-size@1.0.2:
@@ -11105,6 +11137,10 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  path-type@6.0.0:
+    resolution: {integrity: sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==}
+    engines: {node: '>=18'}
+
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
 
@@ -12019,6 +12055,10 @@ packages:
     resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
     engines: {node: '>=12'}
 
+  slash@5.1.0:
+    resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
+    engines: {node: '>=14.16'}
+
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
@@ -12780,6 +12820,14 @@ packages:
   unicode-property-aliases-ecmascript@2.1.0:
     resolution: {integrity: sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==}
     engines: {node: '>=4'}
+
+  unicorn-magic@0.1.0:
+    resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
+    engines: {node: '>=18'}
+
+  unicorn-magic@0.3.0:
+    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
+    engines: {node: '>=18'}
 
   union-value@1.0.1:
     resolution: {integrity: sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==}
@@ -16125,6 +16173,8 @@ snapshots:
 
   '@sindresorhus/is@0.14.0': {}
 
+  '@sindresorhus/merge-streams@2.3.0': {}
+
   '@sinonjs/commons@3.0.1':
     dependencies:
       type-detect: 4.0.8
@@ -18824,6 +18874,8 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.22.11
 
+  date-fns@3.6.0: {}
+
   dayjs@1.11.7: {}
 
   debug@2.6.9:
@@ -20339,10 +20391,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-template-lint-plugin-prettier@5.0.0(ember-template-lint@5.11.2)(prettier@3.5.3):
+  ember-template-lint-plugin-prettier@5.0.0(ember-template-lint@6.1.0)(prettier@3.5.3):
     dependencies:
       '@prettier/sync': 0.2.1(prettier@3.5.3)
-      ember-template-lint: 5.11.2
+      ember-template-lint: 6.1.0
       prettier: 3.5.3
       prettier-linter-helpers: 1.0.0
 
@@ -20360,6 +20412,29 @@ snapshots:
       fuse.js: 6.6.2
       get-stdin: 9.0.0
       globby: 13.2.2
+      is-glob: 4.0.3
+      language-tags: 1.0.9
+      micromatch: 4.0.8
+      resolve: 1.22.10
+      v8-compile-cache: 2.4.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - supports-color
+
+  ember-template-lint@6.1.0:
+    dependencies:
+      '@lint-todo/utils': 13.1.1
+      aria-query: 5.3.0
+      chalk: 5.3.0
+      ci-info: 4.2.0
+      date-fns: 3.6.0
+      ember-template-imports: 3.4.2
+      ember-template-recast: 6.1.5
+      eslint-formatter-kakoune: 1.0.0
+      find-up: 7.0.0
+      fuse.js: 7.1.0
+      get-stdin: 9.0.0
+      globby: 14.1.0
       is-glob: 4.0.3
       language-tags: 1.0.9
       micromatch: 4.0.8
@@ -21213,6 +21288,14 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
@@ -21406,6 +21489,12 @@ snapshots:
     dependencies:
       locate-path: 7.2.0
       path-exists: 5.0.0
+
+  find-up@7.0.0:
+    dependencies:
+      locate-path: 7.2.0
+      path-exists: 5.0.0
+      unicorn-magic: 0.1.0
 
   find-yarn-workspace-root@1.2.1:
     dependencies:
@@ -21667,6 +21756,8 @@ snapshots:
 
   fuse.js@6.6.2: {}
 
+  fuse.js@7.1.0: {}
+
   gauge@4.0.4:
     dependencies:
       aproba: 2.0.0
@@ -21908,6 +21999,15 @@ snapshots:
       ignore: 5.3.2
       merge2: 1.4.1
       slash: 4.0.0
+
+  globby@14.1.0:
+    dependencies:
+      '@sindresorhus/merge-streams': 2.3.0
+      fast-glob: 3.3.3
+      ignore: 7.0.5
+      path-type: 6.0.0
+      slash: 5.1.0
+      unicorn-magic: 0.3.0
 
   globrex@0.1.2: {}
 
@@ -22231,6 +22331,8 @@ snapshots:
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
 
   image-size@1.0.2:
     dependencies:
@@ -24098,6 +24200,8 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  path-type@6.0.0: {}
+
   pathe@1.1.2: {}
 
   pathval@2.0.0: {}
@@ -25123,6 +25227,8 @@ snapshots:
 
   slash@4.0.0: {}
 
+  slash@5.1.0: {}
+
   smart-buffer@4.2.0: {}
 
   snake-case@3.0.4:
@@ -26074,6 +26180,10 @@ snapshots:
   unicode-match-property-value-ecmascript@2.2.0: {}
 
   unicode-property-aliases-ecmascript@2.1.0: {}
+
+  unicorn-magic@0.1.0: {}
+
+  unicorn-magic@0.3.0: {}
 
   union-value@1.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,6 +306,9 @@ catalogs:
     ember-qunit:
       specifier: ^8.0.1
       version: 8.0.2
+    ember-template-lint:
+      specifier: ^5.11.2
+      version: 5.11.2
     esbuild:
       specifier: ^0.24.0
       version: 0.24.0
@@ -829,7 +832,7 @@ importers:
         specifier: ^6.5.1
         version: 6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-concurrency@4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)))(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
       ember-template-lint:
-        specifier: ^5.11.2
+        specifier: 'catalog:'
         version: 5.11.2
       ethers:
         specifier: 'catalog:'
@@ -939,7 +942,7 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1
       ember-template-lint:
-        specifier: ^5.11.2
+        specifier: 'catalog:'
         version: 5.11.2
       ember-template-lint-plugin-prettier:
         specifier: ^5.0.0
@@ -1096,7 +1099,7 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1
       ember-template-lint:
-        specifier: ^5.11.2
+        specifier: 'catalog:'
         version: 5.11.2
       ember-template-lint-plugin-prettier:
         specifier: ^5.0.0
@@ -1306,7 +1309,7 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1
       ember-template-lint:
-        specifier: ^5.11.2
+        specifier: 'catalog:'
         version: 5.11.2
       ember-try:
         specifier: ^2.0.0
@@ -1523,7 +1526,7 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1
       ember-template-lint:
-        specifier: ^5.11.2
+        specifier: 'catalog:'
         version: 5.11.2
       ember-template-lint-plugin-prettier:
         specifier: ^5.0.0
@@ -1740,7 +1743,7 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1
       ember-template-lint:
-        specifier: ^5.11.2
+        specifier: 'catalog:'
         version: 5.11.2
       ember-try:
         specifier: ^2.0.0
@@ -1818,7 +1821,7 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-template-lint:
-        specifier: ^5.11.2
+        specifier: 'catalog:'
         version: 5.11.2
       tracked-built-ins:
         specifier: ^3.3.0
@@ -1923,7 +1926,7 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-template-lint:
-        specifier: ^5.11.2
+        specifier: 'catalog:'
         version: 5.11.2
       tracked-built-ins:
         specifier: ^3.3.0
@@ -2235,7 +2238,7 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1
       ember-template-lint:
-        specifier: ^5.11.2
+        specifier: 'catalog:'
         version: 5.11.2
       ember-test-selectors:
         specifier: ^6.0.0
@@ -2903,7 +2906,7 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-template-lint:
-        specifier: ^5.11.2
+        specifier: 'catalog:'
         version: 5.11.2
       tracked-built-ins:
         specifier: ^3.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,8 +307,8 @@ catalogs:
       specifier: ^8.0.1
       version: 8.0.2
     ember-template-lint:
-      specifier: ^6.0.0
-      version: 6.1.0
+      specifier: ^7.8.1
+      version: 7.8.1
     esbuild:
       specifier: ^0.24.0
       version: 0.24.0
@@ -833,7 +833,7 @@ importers:
         version: 6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-concurrency@4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)))(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
       ember-template-lint:
         specifier: 'catalog:'
-        version: 6.1.0
+        version: 7.8.1
       ethers:
         specifier: 'catalog:'
         version: 6.6.2
@@ -943,10 +943,10 @@ importers:
         version: 4.1.1
       ember-template-lint:
         specifier: 'catalog:'
-        version: 6.1.0
+        version: 7.8.1
       ember-template-lint-plugin-prettier:
         specifier: ^5.0.0
-        version: 5.0.0(ember-template-lint@6.1.0)(prettier@3.5.3)
+        version: 5.0.0(ember-template-lint@7.8.1)(prettier@3.5.3)
       eslint:
         specifier: 'catalog:'
         version: 8.57.1
@@ -1100,10 +1100,10 @@ importers:
         version: 4.1.1
       ember-template-lint:
         specifier: 'catalog:'
-        version: 6.1.0
+        version: 7.8.1
       ember-template-lint-plugin-prettier:
         specifier: ^5.0.0
-        version: 5.0.0(ember-template-lint@6.1.0)(prettier@3.5.3)
+        version: 5.0.0(ember-template-lint@7.8.1)(prettier@3.5.3)
       eslint:
         specifier: 'catalog:'
         version: 8.57.1
@@ -1310,7 +1310,7 @@ importers:
         version: 4.1.1
       ember-template-lint:
         specifier: 'catalog:'
-        version: 6.1.0
+        version: 7.8.1
       ember-try:
         specifier: ^2.0.0
         version: 2.0.0
@@ -1527,10 +1527,10 @@ importers:
         version: 4.1.1
       ember-template-lint:
         specifier: 'catalog:'
-        version: 6.1.0
+        version: 7.8.1
       ember-template-lint-plugin-prettier:
         specifier: ^5.0.0
-        version: 5.0.0(ember-template-lint@6.1.0)(prettier@3.5.3)
+        version: 5.0.0(ember-template-lint@7.8.1)(prettier@3.5.3)
       eslint:
         specifier: 'catalog:'
         version: 8.57.1
@@ -1744,7 +1744,7 @@ importers:
         version: 4.1.1
       ember-template-lint:
         specifier: 'catalog:'
-        version: 6.1.0
+        version: 7.8.1
       ember-try:
         specifier: ^2.0.0
         version: 2.0.0
@@ -1822,7 +1822,7 @@ importers:
         version: 4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-template-lint:
         specifier: 'catalog:'
-        version: 6.1.0
+        version: 7.8.1
       tracked-built-ins:
         specifier: ^3.3.0
         version: 3.3.0
@@ -1927,7 +1927,7 @@ importers:
         version: 4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-template-lint:
         specifier: 'catalog:'
-        version: 6.1.0
+        version: 7.8.1
       tracked-built-ins:
         specifier: ^3.3.0
         version: 3.3.0
@@ -2239,7 +2239,7 @@ importers:
         version: 4.1.1
       ember-template-lint:
         specifier: 'catalog:'
-        version: 6.1.0
+        version: 7.8.1
       ember-test-selectors:
         specifier: ^6.0.0
         version: 6.0.0
@@ -2907,7 +2907,7 @@ importers:
         version: 4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-template-lint:
         specifier: 'catalog:'
-        version: 6.1.0
+        version: 7.8.1
       tracked-built-ins:
         specifier: ^3.3.0
         version: 3.3.0
@@ -5155,10 +5155,6 @@ packages:
     resolution: {integrity: sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==}
     engines: {node: '>=6'}
 
-  '@sindresorhus/merge-streams@2.3.0':
-    resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
-    engines: {node: '>=18'}
-
   '@sinonjs/commons@3.0.1':
     resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
 
@@ -7362,9 +7358,6 @@ packages:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
     engines: {node: '>=0.11'}
 
-  date-fns@3.6.0:
-    resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
-
   dayjs@1.11.7:
     resolution: {integrity: sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==}
 
@@ -8154,8 +8147,8 @@ packages:
     engines: {node: ^14.18.0 || ^16.0.0 || >= 18.0.0}
     hasBin: true
 
-  ember-template-lint@6.1.0:
-    resolution: {integrity: sha512-UyzLPcyneG3mnbBfewyYIlV7fy6JKHQVAJy5a9+URdJKkZKN+3vQkQzIIlsz6dP/GpoXVB+datns5HlfMfliSA==}
+  ember-template-lint@7.8.1:
+    resolution: {integrity: sha512-SFVTR6YdxvldbBL3ArphAbDhYOXyD8Tt9rTKEWKYpQTilq7Hl9mTrKP59q3GOcnDaR/rNk0cg4rJHYAg6/SCGw==}
     engines: {node: ^18.18.0 || >= 20.9.0}
     hasBin: true
 
@@ -8665,10 +8658,6 @@ packages:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
     engines: {node: '>=8.6.0'}
 
-  fast-glob@3.3.3:
-    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
-    engines: {node: '>=8.6.0'}
-
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
@@ -8804,10 +8793,6 @@ packages:
   find-up@6.3.0:
     resolution: {integrity: sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  find-up@7.0.0:
-    resolution: {integrity: sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==}
-    engines: {node: '>=18'}
 
   find-yarn-workspace-root@1.2.1:
     resolution: {integrity: sha512-dVtfb0WuQG+8Ag2uWkbG79hOUzEsRrhBzgfn86g2sJPkzmcpGdghbNTfUKGTxymFrY/tLIodDzLoW9nOJ4FY8Q==}
@@ -8996,10 +8981,6 @@ packages:
     resolution: {integrity: sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==}
     engines: {node: '>=10'}
 
-  fuse.js@7.1.0:
-    resolution: {integrity: sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==}
-    engines: {node: '>=10'}
-
   gauge@4.0.4:
     resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -9166,10 +9147,6 @@ packages:
   globby@13.2.2:
     resolution: {integrity: sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  globby@14.1.0:
-    resolution: {integrity: sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==}
-    engines: {node: '>=18'}
 
   globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
@@ -9433,10 +9410,6 @@ packages:
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
-    engines: {node: '>= 4'}
-
-  ignore@7.0.5:
-    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
   image-size@1.0.2:
@@ -11137,10 +11110,6 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
-  path-type@6.0.0:
-    resolution: {integrity: sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==}
-    engines: {node: '>=18'}
-
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
 
@@ -12055,10 +12024,6 @@ packages:
     resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
     engines: {node: '>=12'}
 
-  slash@5.1.0:
-    resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
-    engines: {node: '>=14.16'}
-
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
@@ -12820,14 +12785,6 @@ packages:
   unicode-property-aliases-ecmascript@2.1.0:
     resolution: {integrity: sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==}
     engines: {node: '>=4'}
-
-  unicorn-magic@0.1.0:
-    resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
-    engines: {node: '>=18'}
-
-  unicorn-magic@0.3.0:
-    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
-    engines: {node: '>=18'}
 
   union-value@1.0.1:
     resolution: {integrity: sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==}
@@ -16173,8 +16130,6 @@ snapshots:
 
   '@sindresorhus/is@0.14.0': {}
 
-  '@sindresorhus/merge-streams@2.3.0': {}
-
   '@sinonjs/commons@3.0.1':
     dependencies:
       type-detect: 4.0.8
@@ -18874,8 +18829,6 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.22.11
 
-  date-fns@3.6.0: {}
-
   dayjs@1.11.7: {}
 
   debug@2.6.9:
@@ -20391,10 +20344,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-template-lint-plugin-prettier@5.0.0(ember-template-lint@6.1.0)(prettier@3.5.3):
+  ember-template-lint-plugin-prettier@5.0.0(ember-template-lint@7.8.1)(prettier@3.5.3):
     dependencies:
       '@prettier/sync': 0.2.1(prettier@3.5.3)
-      ember-template-lint: 6.1.0
+      ember-template-lint: 7.8.1
       prettier: 3.5.3
       prettier-linter-helpers: 1.0.0
 
@@ -20421,28 +20374,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-template-lint@6.1.0:
+  ember-template-lint@7.8.1:
     dependencies:
       '@lint-todo/utils': 13.1.1
-      aria-query: 5.3.0
-      chalk: 5.3.0
-      ci-info: 4.2.0
-      date-fns: 3.6.0
-      ember-template-imports: 3.4.2
-      ember-template-recast: 6.1.5
-      eslint-formatter-kakoune: 1.0.0
-      find-up: 7.0.0
-      fuse.js: 7.1.0
-      get-stdin: 9.0.0
-      globby: 14.1.0
-      is-glob: 4.0.3
-      language-tags: 1.0.9
-      micromatch: 4.0.8
-      resolve: 1.22.10
-      v8-compile-cache: 2.4.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - supports-color
+      content-tag: 3.1.2
 
   ember-template-recast@6.1.5:
     dependencies:
@@ -21288,14 +21223,6 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
-  fast-glob@3.3.3:
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.8
-
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
@@ -21489,12 +21416,6 @@ snapshots:
     dependencies:
       locate-path: 7.2.0
       path-exists: 5.0.0
-
-  find-up@7.0.0:
-    dependencies:
-      locate-path: 7.2.0
-      path-exists: 5.0.0
-      unicorn-magic: 0.1.0
 
   find-yarn-workspace-root@1.2.1:
     dependencies:
@@ -21756,8 +21677,6 @@ snapshots:
 
   fuse.js@6.6.2: {}
 
-  fuse.js@7.1.0: {}
-
   gauge@4.0.4:
     dependencies:
       aproba: 2.0.0
@@ -21999,15 +21918,6 @@ snapshots:
       ignore: 5.3.2
       merge2: 1.4.1
       slash: 4.0.0
-
-  globby@14.1.0:
-    dependencies:
-      '@sindresorhus/merge-streams': 2.3.0
-      fast-glob: 3.3.3
-      ignore: 7.0.5
-      path-type: 6.0.0
-      slash: 5.1.0
-      unicorn-magic: 0.3.0
 
   globrex@0.1.2: {}
 
@@ -22331,8 +22241,6 @@ snapshots:
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
-
-  ignore@7.0.5: {}
 
   image-size@1.0.2:
     dependencies:
@@ -24200,8 +24108,6 @@ snapshots:
 
   path-type@4.0.0: {}
 
-  path-type@6.0.0: {}
-
   pathe@1.1.2: {}
 
   pathval@2.0.0: {}
@@ -25227,8 +25133,6 @@ snapshots:
 
   slash@4.0.0: {}
 
-  slash@5.1.0: {}
-
   smart-buffer@4.2.0: {}
 
   snake-case@3.0.4:
@@ -26180,10 +26084,6 @@ snapshots:
   unicode-match-property-value-ecmascript@2.2.0: {}
 
   unicode-property-aliases-ecmascript@2.1.0: {}
-
-  unicorn-magic@0.1.0: {}
-
-  unicorn-magic@0.3.0: {}
 
   union-value@1.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -110,6 +110,7 @@ catalog:
   dompurify: ^3.0.3
   ember-concurrency: ^4.0.3
   ember-concurrency-ts: ^0.3.1
+  ember-template-lint: ^5.11.2
   ember-qunit: ^8.0.1
   esbuild: ^0.24.0
   eslint: ^8.57.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -110,7 +110,7 @@ catalog:
   dompurify: ^3.0.3
   ember-concurrency: ^4.0.3
   ember-concurrency-ts: ^0.3.1
-  ember-template-lint: ^5.11.2
+  ember-template-lint: ^6.0.0
   ember-qunit: ^8.0.1
   esbuild: ^0.24.0
   eslint: ^8.57.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -110,7 +110,7 @@ catalog:
   dompurify: ^3.0.3
   ember-concurrency: ^4.0.3
   ember-concurrency-ts: ^0.3.1
-  ember-template-lint: ^6.0.0
+  ember-template-lint: ^7.8.1
   ember-qunit: ^8.0.1
   esbuild: ^0.24.0
   eslint: ^8.57.1


### PR DESCRIPTION
According to [this Ember Discord message](https://discord.com/channels/480462759797063690/480499624663056390/1379731547237912668), it’s a 2✖️ performance gain; in our context that doesn’t appear to be true, but we might as well be on the newest version:

<img width="898" alt="boxel 2025-06-04 10-05-37" src="https://github.com/user-attachments/assets/b925efce-d675-4d58-878b-4901f82ea691" />
