### PR TITLE
Dont rely on card ID when determining if card is in writable realm

### DIFF
--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -494,9 +494,10 @@ export default class OperatorModeStackItem extends Component<Signature> {
   private get canEdit() {
     return (
       this.card &&
+      this.card[realmURL] &&
       !this.isBuried &&
       !this.isEditing &&
-      this.realm.canWrite(this.card.id)
+      this.realm.canWrite(this.card[realmURL].href)
     );
   }
 


### PR DESCRIPTION
This solves a race condition where we were relying on a card's remote ID in order to determine if the card lives in a writable realm. because cards are optimistically created, we can't be sure that the card has a remote ID assigned yet. A more reliable way to determine the realm of a card is to use the `realmURL` symbol on the running instance. instances that have not yet been assigned a remote ID will have a `realmURL` symbol specified with the realm that the newly created card will live within.