### PR TITLE
Fix omitted fieldIndex storage for playground preview

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
@@ -179,7 +179,7 @@ export default class PlaygroundPanel extends Component<Signature> {
     if (!this.card?.id) {
       return;
     }
-    this.persistToLocalStorage(this.card.id, format);
+    this.persistSelections(this.card.id, format);
   }
 
   private get realmInfo() {
@@ -413,23 +413,18 @@ export default class PlaygroundPanel extends Component<Signature> {
         format === selectedFormat &&
         fieldIndex === index
       ) {
+        // this is important for preventing some unnecessary screen flashes from happening
         return;
       }
     }
 
-    this.persistToLocalStorage(selectedCardId, selectedFormat, index);
-  };
-
-  private persistToLocalStorage = (
-    cardId: string,
-    format: Format,
-    index?: number,
-  ) => {
     this.playgroundPanelService.persistSelections(
       this.moduleId,
-      trimJsonExtension(cardId),
-      format,
-      index,
+      trimJsonExtension(selectedCardId),
+      selectedFormat,
+      index /* `undefined` means we are previewing a card instances. fields MUST have a corresponding index
+      based on their position on their spec's containedExamples field. otherwise, it means that we are previewing
+      a spec instance on playground instead of the field */,
     );
   };
 
@@ -629,7 +624,7 @@ export default class PlaygroundPanel extends Component<Signature> {
       }
       let recentCard = prerenderedCards[0];
       // if there's no selected card, choose the most recent card as selected
-      this.persistToLocalStorage(recentCard.url, 'isolated');
+      this.persistSelections(recentCard.url, 'isolated');
       return recentCard;
     }
 
@@ -752,7 +747,7 @@ export default class PlaygroundPanel extends Component<Signature> {
                 createNew=(if this.canWriteRealm this.createNew)
                 createNewIsRunning=this.createNewIsRunning
                 moduleId=this.moduleId
-                persistSelections=this.persistToLocalStorage
+                persistSelections=this.persistSelections
                 recentCardIds=this.recentCardIds
               )
               as |InstanceChooser|

--- a/packages/host/app/services/playground-panel-service.ts
+++ b/packages/host/app/services/playground-panel-service.ts
@@ -21,9 +21,12 @@ import type CardService from './card-service';
 import type StoreService from './store';
 
 export interface PlaygroundSelection {
-  cardId: string;
-  format: Format;
+  cardId: string; // for fields, this is their corresponding spec card's id, since fields do not have a card id
+  format: Format; // default is 'isolated' for cards, 'embedded' for fields
   fieldIndex?: number;
+  /* fieldIndex `undefined` means we are previewing a card instances. fields MUST have a corresponding index
+      based on their position on their spec's containedExamples field. otherwise, it means that we are previewing
+      a spec instance on playground instead of the field. */
 }
 
 export default class PlaygroundPanelService extends Service {

--- a/packages/host/tests/acceptance/code-submode/field-playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/field-playground-test.gts
@@ -1183,8 +1183,7 @@ module('Acceptance | code-submode | field playground', function (_hooks) {
       assert.deepEqual(selection, {
         cardId: `${additionalRealmURL}Spec/toy`,
         format: 'atom',
-        // TODO: restore assertion in CS-8738
-        // fieldIndex: 0,
+        fieldIndex: 0,
       });
 
       await createNewInstance();


### PR DESCRIPTION
For playground local storage, we know if we have a field or card based on the stored `fieldIndex` property. For cards, this is not set or is explicitly `undefined`. For fields, we do not have card Ids, so we store the spec's cardId with `fieldIndex` that corresponds to the field example's index on spec's `containedExamples`.

There was a mixup and `persistToLocalStorage` was used instead of `persistSelections`. This is my bad for not writing a comment and making it clearer. The tests did catch it. `persistSelections` ensures the right fieldIndex is set, as well as checking for currently stored selection and preventing some of the unnecessary screen flashes. `persistToLocalStorage` was created to circumvent infinite-revalidation error for a specific legitimate case. This is no longer a problem, thanks to the 
code-mode accordion to buttons refactor. I was able to combine the two functions into one. Now there's only one `persistSelections` method.

I added more comments in the code so hopefully that helps explain the `fieldIndex`.