### PR TITLE
Can add a link in a null links to many field

### DIFF
--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -98,8 +98,11 @@ class LinksToManyEditor extends GlimmerComponent<Signature> {
   private chooseCard = restartableTask(async () => {
     let selectedCards = (this.args.model.value as any)[this.args.field.name];
     let selectedCardsQuery =
-      selectedCards?.map((card: any) => ({ not: { eq: { id: card.id } } })) ??
-      [];
+      selectedCards
+        ?.map((card: any) =>
+          card ? { not: { eq: { id: card.id } } } : undefined,
+        )
+        .filter(Boolean) ?? [];
     let type = identifyCard(this.args.field.card) ?? baseCardRef;
     if (this.args.typeConstraint) {
       type = await getNarrowestType(this.args.typeConstraint, type, myLoader());

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -469,6 +469,24 @@ module('Integration | operator-mode', function (hooks) {
             }),
             pet: petMango,
           }),
+          'Person/hassan.json': {
+            data: {
+              attributes: {
+                firstName: 'Hassan',
+              },
+              relationships: {
+                friends: {
+                  links: { self: null },
+                },
+              },
+              meta: {
+                adoptsFrom: {
+                  module: '../person',
+                  name: 'Person',
+                },
+              },
+            },
+          },
           'Person/burcu.json': new Person({
             firstName: 'Burcu',
             friends: [petJackie, petWoody, petBuzz],
@@ -1515,6 +1533,33 @@ module('Integration | operator-mode', function (hooks) {
     assert.dom('[data-test-field="friends"] [data-test-pet]').doesNotExist();
     assert.dom('[data-test-add-new]').hasText('Add Pets');
     await click('[data-test-add-new]');
+    await waitFor(`[data-test-card-catalog-item="${testRealmURL}Pet/mango"]`);
+    await click(`[data-test-select="${testRealmURL}Pet/jackie"]`);
+    await click('[data-test-card-catalog-go-button]');
+
+    await waitUntil(() => !document.querySelector('[card-catalog-modal]'));
+    assert.dom('[data-test-field="friends"]').containsText('Jackie');
+  });
+
+  test('can add a card to linksToMany field that has a null value for relationship', async function (assert) {
+    setCardInOperatorModeState(`${testRealmURL}Person/hassan`);
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template>
+          <OperatorMode @onClose={{noop}} />
+          <CardPrerender />
+        </template>
+      },
+    );
+
+    await waitFor(`[data-test-stack-card="${testRealmURL}Person/hassan"]`);
+    await click('[data-test-edit-button]');
+
+    assert.dom('[data-test-field="friends"] [data-test-pet]').doesNotExist();
+    assert
+      .dom('[data-test-field="friends"] [data-test-add-new]')
+      .hasText('Add Pets');
+    await click('[data-test-field="friends"] [data-test-add-new]');
     await waitFor(`[data-test-card-catalog-item="${testRealmURL}Pet/mango"]`);
     await click(`[data-test-select="${testRealmURL}Pet/jackie"]`);
     await click('[data-test-card-catalog-go-button]');


### PR DESCRIPTION
This fixes an issue where if a links to many relationship is set to null the add link button will still work.