### PR TITLE
Follow-up to agentic command execution work

### DIFF
--- a/packages/ai-bot/helpers.ts
+++ b/packages/ai-bot/helpers.ts
@@ -25,7 +25,6 @@ import { logger } from '@cardstack/runtime-common';
 import {
   APP_BOXEL_ACTIVE_LLM,
   APP_BOXEL_CODE_PATCH_RESULT_REL_TYPE,
-  APP_BOXEL_CODE_PATCH_RESULT_EVENT_TYPE,
   APP_BOXEL_COMMAND_REQUESTS_KEY,
   APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
   APP_BOXEL_COMMAND_RESULT_REL_TYPE,
@@ -45,7 +44,6 @@ import {
 } from './lib/matrix/util';
 import { constructHistory } from './lib/history';
 import { isRecognisedDebugCommand } from './lib/debug';
-import { type } from '../runtime-common/index';
 import { APP_BOXEL_CODE_PATCH_RESULT_EVENT_TYPE } from '../runtime-common/matrix-constants';
 
 let log = logger('ai-bot');

--- a/packages/ai-bot/helpers.ts
+++ b/packages/ai-bot/helpers.ts
@@ -45,6 +45,8 @@ import {
 } from './lib/matrix/util';
 import { constructHistory } from './lib/history';
 import { isRecognisedDebugCommand } from './lib/debug';
+import { type } from '../runtime-common/index';
+import { APP_BOXEL_CODE_PATCH_RESULT_EVENT_TYPE } from '../runtime-common/matrix-constants';
 
 let log = logger('ai-bot');
 
@@ -298,7 +300,12 @@ export async function loadCurrentlySerializedFileDefs(
   aiBotUserId: string,
 ): Promise<SerializedFileDef[]> {
   let lastMessageEventByUser = history.findLast(
-    (event) => event.sender !== aiBotUserId,
+    (event) =>
+      event.sender !== aiBotUserId &&
+      ((event.type === 'm.room.message' &&
+        event.content.msgtype === APP_BOXEL_MESSAGE_MSGTYPE) ||
+        event.type === APP_BOXEL_CODE_PATCH_RESULT_EVENT_TYPE ||
+        event.type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE),
   );
 
   let mostRecentUserMessageContent = lastMessageEventByUser?.content as {
@@ -308,10 +315,7 @@ export async function loadCurrentlySerializedFileDefs(
     };
   };
 
-  if (
-    !mostRecentUserMessageContent ||
-    mostRecentUserMessageContent.msgtype !== APP_BOXEL_MESSAGE_MSGTYPE
-  ) {
+  if (!mostRecentUserMessageContent) {
     return [];
   }
 
@@ -354,7 +358,7 @@ export async function loadCurrentlySerializedFileDefs(
   );
 }
 
-export function attachedFilesToPrompt(
+export function attachedFilesToMessage(
   attachedFiles: SerializedFileDef[],
 ): string {
   if (!attachedFiles.length) {
@@ -747,7 +751,7 @@ export const buildContextMessage = async (
       result += `Cards: ${attachedCardsToMessage(mostRecentlyAttachedCard, attachedCards)}\n\n`;
     }
     if (attachedFiles.length > 0) {
-      result += `\n\nAttached files:\n${attachedFilesToPrompt(attachedFiles)}`;
+      result += `\n\nAttached files:\n${attachedFilesToMessage(attachedFiles)}`;
     }
   }
 

--- a/packages/ai-bot/lib/matrix/response-publisher.ts
+++ b/packages/ai-bot/lib/matrix/response-publisher.ts
@@ -66,6 +66,7 @@ export default class MatrixResponsePublisher {
   constructor(
     readonly client: MatrixClient,
     readonly roomId: string,
+    readonly agentId: string,
     readonly responseState: ResponseState,
   ) {}
 
@@ -95,6 +96,11 @@ export default class MatrixResponsePublisher {
           );
         let extraData: Partial<CardMessageContent> = {
           isStreamingFinished: true,
+          data: {
+            context: {
+              agentId: this.agentId,
+            },
+          },
           [APP_BOXEL_HAS_CONTINUATION_CONTENT_KEY]: true,
         };
         if (this.previousResponseEventId) {
@@ -129,6 +135,11 @@ export default class MatrixResponsePublisher {
 
       let extraData: any = {
         isStreamingFinished: responseStateSnapshot.isStreamingFinished,
+        data: {
+          context: {
+            agentId: this.agentId,
+          },
+        },
       };
       if (this.currentResponseEvent.needsContinuation) {
         extraData[APP_BOXEL_CONTINUATION_OF_CONTENT_KEY] =
@@ -180,7 +191,10 @@ export default class MatrixResponsePublisher {
       this.roomId,
       '',
       undefined,
-      { isStreamingFinished: false },
+      {
+        isStreamingFinished: false,
+        data: { context: { agentId: this.agentId } },
+      },
       [],
       thinkingMessage,
     );

--- a/packages/ai-bot/lib/responder.ts
+++ b/packages/ai-bot/lib/responder.ts
@@ -39,10 +39,11 @@ export class Responder {
     );
   }
 
-  constructor(client: MatrixClient, roomId: string) {
+  constructor(client: MatrixClient, roomId: string, agentId: string) {
     this.matrixResponsePublisher = new MatrixResponsePublisher(
       client,
       roomId,
+      agentId,
       this.responseState,
     );
   }

--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -236,7 +236,12 @@ Common issues are:
           );
         }
 
-        const responder = new Responder(client, room.roomId);
+        let contentData =
+          typeof event.getContent().data === 'string'
+            ? JSON.parse(event.getContent().data)
+            : event.getContent().data;
+        const agentId = contentData.context?.agentId;
+        const responder = new Responder(client, room.roomId, agentId);
 
         if (Responder.eventWillDefinitelyTriggerResponse(event)) {
           await responder.ensureThinkingMessageSent();

--- a/packages/ai-bot/tests/responding-test.ts
+++ b/packages/ai-bot/tests/responding-test.ts
@@ -96,7 +96,7 @@ module('Responding', (hooks) => {
   hooks.beforeEach(() => {
     clock = FakeTimers.install();
     fakeMatrixClient = new FakeMatrixClient();
-    responder = new Responder(fakeMatrixClient, 'room-id');
+    responder = new Responder(fakeMatrixClient, 'room-id', 'abc123agentId');
   });
 
   hooks.afterEach(() => {
@@ -128,6 +128,11 @@ module('Responding', (hooks) => {
       'Reasoning content should be thinking message',
     );
     assert.equal(sentEvents[0].content.body, '', 'Body should be empty');
+    assert.equal(
+      JSON.parse(sentEvents[0].content.data).context.agentId,
+      'abc123agentId',
+      'agentId should be sent',
+    );
 
     await responder.ensureThinkingMessageSent();
     sentEvents = fakeMatrixClient.getSentEvents();
@@ -176,6 +181,11 @@ module('Responding', (hooks) => {
         event_id: '0',
       },
       'The first content should replace the original thinking message',
+    );
+    assert.equal(
+      JSON.parse(sentEvents[1].content.data).context.agentId,
+      'abc123agentId',
+      'agentId should be sent',
     );
   });
 
@@ -318,6 +328,11 @@ module('Responding', (hooks) => {
       },
       'The tool call event should replace the thinking message',
     );
+    assert.equal(
+      JSON.parse(sentEvents[1].content.data).context.agentId,
+      'abc123agentId',
+      'agentId should be sent',
+    );
   });
 
   test('Sends tool call event with content when content is sent before tool call', async () => {
@@ -429,6 +444,11 @@ module('Responding', (hooks) => {
       true,
       'The tool call event should be sent together with isStreamingFinished set to true',
     );
+    assert.equal(
+      JSON.parse(sentEvents[3].content.data).context.agentId,
+      'abc123agentId',
+      'agentId should be sent',
+    );
   });
 
   test('Handles multiple tool calls', async () => {
@@ -533,6 +553,11 @@ module('Responding', (hooks) => {
         event_id: '0',
       },
       'The replacement event with the tool calls should replace the original message',
+    );
+    assert.equal(
+      JSON.parse(sentEvents[2].content.data).context.agentId,
+      'abc123agentId',
+      'agentId should be sent',
     );
   });
 

--- a/packages/base/matrix-event.gts
+++ b/packages/base/matrix-event.gts
@@ -167,6 +167,7 @@ export type EncodedCommandRequest = Omit<CommandRequest, 'arguments'> & {
 };
 
 export interface BoxelContext {
+  agentId?: string;
   openCardIds?: string[];
   realmUrl?: string;
   tools?: Tool[];

--- a/packages/host/app/lib/matrix-classes/message-builder.ts
+++ b/packages/host/app/lib/matrix-classes/message-builder.ts
@@ -87,6 +87,8 @@ export default class MessageBuilder {
     return new Message({
       roomId: this.builderContext.roomId,
       author: this.builderContext.author,
+      agentId: (this.event.content as CardMessageContent)?.data?.context
+        ?.agentId,
       created: new Date(this.event.origin_server_ts),
       updated: new Date(), // Changes every time an update from AI bot streaming is received, used for detecting timeouts
       body: this.event.content.body,

--- a/packages/host/app/lib/matrix-classes/message.ts
+++ b/packages/host/app/lib/matrix-classes/message.ts
@@ -49,6 +49,7 @@ interface RoomMessageOptional {
   isDebugMessage?: boolean;
   hasContinuation?: boolean;
   continuationOf?: string | null;
+  agentId?: string;
 }
 
 export class Message implements RoomMessageInterface {
@@ -76,6 +77,7 @@ export class Message implements RoomMessageInterface {
   _updated: Date;
   eventId: string;
   roomId: string;
+  agentId?: string;
 
   //This property is used for testing purpose
   instanceId: string;
@@ -90,6 +92,7 @@ export class Message implements RoomMessageInterface {
     this._updated = init.updated;
     this.status = init.status;
     this.roomId = init.roomId;
+    this.agentId = init.agentId;
     this.attachedFiles = init.attachedFiles;
     this.hasContinuation = init.hasContinuation;
     this.continuationOf = init.continuationOf;

--- a/packages/host/app/services/command-service.ts
+++ b/packages/host/app/services/command-service.ts
@@ -27,6 +27,7 @@ import type MatrixService from '@cardstack/host/services/matrix-service';
 import type Realm from '@cardstack/host/services/realm';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
+import { FileDef } from 'https://cardstack.com/base/file-api';
 import { CodePatchStatus } from 'https://cardstack.com/base/matrix-event';
 
 import { shortenUuid } from '../utils/uuid';
@@ -37,7 +38,6 @@ import type RealmServerService from './realm-server';
 import type StoreService from './store';
 import type MessageCodePatchResult from '../lib/matrix-classes/message-code-patch-result';
 import type MessageCommand from '../lib/matrix-classes/message-command';
-import { FileDef } from 'https://cardstack.com/base/file-api';
 
 const DELAY_FOR_APPLYING_UI = isTesting() ? 50 : 500;
 
@@ -142,6 +142,10 @@ export default class CommandService extends Service {
 
       let message = roomResource.messages.find((m) => m.eventId === eventId);
       if (!message) {
+        continue;
+      }
+      if (message.agentId !== this.matrixService.agentId) {
+        // This command was sent by another agent, so we will not auto-execute it
         continue;
       }
       for (let messageCommand of message.commands) {

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -177,6 +177,7 @@ export default class MatrixService extends Service {
   private slidingSync: SlidingSync | undefined;
   private aiRoomIds: Set<string> = new Set();
   @tracked private _isLoadingMoreAIRooms = false;
+  agentId = uuidv4();
 
   constructor(owner: Owner) {
     super(owner);

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -799,6 +799,7 @@ export default class OperatorModeStateService extends Service {
     openCardIds: Set<string> = new Set([...this.getOpenCardIds()]),
   ): BoxelContext {
     return {
+      agentId: this.matrixService.agentId,
       submode: this.state.submode,
       debug: this.operatorModeController.debug,
       openCardIds: this.makeRemoteIdsList([...openCardIds]),

--- a/packages/host/tests/acceptance/code-patches-test.gts
+++ b/packages/host/tests/acceptance/code-patches-test.gts
@@ -1,5 +1,6 @@
 import { click, waitFor, findAll, waitUntil } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import {
@@ -115,6 +116,7 @@ ${REPLACE_MARKER}\n\`\`\``;
     assert.deepEqual(
       JSON.parse(codePatchResultEvents[0].content?.data ?? '{}').context,
       {
+        agentId: getService('matrix-service').agentId,
         codeMode: {
           currentFile: 'http://test-realm/test/hello.txt',
         },

--- a/packages/host/tests/acceptance/commands-test.gts
+++ b/packages/host/tests/acceptance/commands-test.gts
@@ -12,6 +12,8 @@ import {
 
 import { fillIn } from '@ember/test-helpers';
 
+import { getService } from '@universal-ember/test-support';
+
 import { module, test } from 'qunit';
 
 import { GridContainer } from '@cardstack/boxel-ui/components';
@@ -71,7 +73,6 @@ import {
 import { setupMockMatrix } from '../helpers/mock-matrix';
 import { setupApplicationTest } from '../helpers/setup';
 import { suspendGlobalErrorHook } from '../helpers/uncaught-exceptions';
-import { getService } from '@universal-ember/test-support';
 
 let matrixRoomId = '';
 let maybeBoomShouldBoom = true;

--- a/packages/host/tests/integration/components/ai-assistant-panel/commands-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/commands-test.gts
@@ -562,6 +562,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
     assert.deepEqual(
       JSON.parse(commandResultEvents[0].content.data).context,
       {
+        agentId: getService('matrix-service').agentId,
         submode: 'interact',
         debug: false,
         openCardIds: ['http://test-realm/test/Person/fadhlan'],
@@ -646,6 +647,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
     assert.deepEqual(
       JSON.parse(commandResultEvents[0].content.data).context,
       {
+        agentId: getService('matrix-service').agentId,
         submode: 'interact',
         debug: false,
         openCardIds: ['http://test-realm/test/Person/fadhlan'],
@@ -679,6 +681,11 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
           }),
         },
       ],
+      data: {
+        context: {
+          agentId: getService('matrix-service').agentId,
+        },
+      },
     });
     await settled();
     assert
@@ -719,6 +726,11 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
           }),
         },
       ],
+      data: {
+        context: {
+          agentId: getService('matrix-service').agentId,
+        },
+      },
     });
     await settled();
     assert
@@ -758,6 +770,11 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
           }),
         },
       ],
+      data: {
+        context: {
+          agentId: getService('matrix-service').agentId,
+        },
+      },
     });
     await settled();
     assert.dom('.result-list li:nth-child(6)').doesNotExist();
@@ -810,6 +827,11 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
           arguments: JSON.stringify(toolArgs),
         },
       ],
+      data: {
+        context: {
+          agentId: getService('matrix-service').agentId,
+        },
+      },
     });
     await settled();
     assert.dom(`[data-test-stack-card="${id}"]`).exists();
@@ -877,6 +899,11 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
           arguments: JSON.stringify(toolArgs),
         },
       ],
+      data: {
+        context: {
+          agentId: getService('matrix-service').agentId,
+        },
+      },
     });
     await settled();
     assert.dom(`[data-test-stack-card="${id}"]`).exists();

--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -790,8 +790,7 @@ export function getAgentId(
     };
   }[],
 ) {
-  console.log('roomEvents', roomEvents);
-  // Iterate backwards and get the last agentId on a message
+  // Iterate backwards and get the most recent agentId
   for (let i = roomEvents.length - 1; i >= 0; i--) {
     let event = roomEvents[i];
     let data = event.content?.data as any;

--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -783,6 +783,27 @@ export async function getRoomEvents(
   return await getAllRoomEvents(roomId, accessToken);
 }
 
+export function getAgentId(
+  roomEvents: {
+    content?: {
+      data?: string;
+    };
+  }[],
+) {
+  console.log('roomEvents', roomEvents);
+  // Iterate backwards and get the last agentId on a message
+  for (let i = roomEvents.length - 1; i >= 0; i--) {
+    let event = roomEvents[i];
+    let data = event.content?.data as any;
+    if (data) {
+      let parsedData = JSON.parse(data);
+      if (parsedData.context?.agentId) {
+        return parsedData.context.agentId;
+      }
+    }
+  }
+}
+
 export async function getRoomsFromSync(username = 'user1', password = 'pass') {
   let { accessToken } = await loginUser(username, password);
   let response = (await sync(accessToken)) as any;

--- a/packages/matrix/tests/commands.spec.ts
+++ b/packages/matrix/tests/commands.spec.ts
@@ -17,6 +17,7 @@ import {
   showAllCards,
   waitUntil,
   setupUserSubscribed,
+  getAgentId,
 } from '../helpers';
 import {
   synapseStart,
@@ -357,14 +358,21 @@ test.describe('Commands', () => {
     await page.locator('[data-test-message-idx="0"]').waitFor();
 
     let roomId = await getRoomId(page);
-    let numEventsBeforeResponse = (await getRoomEvents('user1', 'pass', roomId))
-      .length;
+    let roomEvents = await getRoomEvents('user1', 'pass', roomId);
+    let numEventsBeforeResponse = roomEvents.length;
+    let agentId = getAgentId(roomEvents);
+    console.log('agentId', agentId);
     // Note: this should really be posted by the aibot user but we can't do that easily
     // in this test, and this reproduces the bug
     await putEvent(userCred.accessToken, roomId, 'm.room.message', '1', {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       format: 'org.matrix.custom.html',
       body: '',
+      data: JSON.stringify({
+        context: {
+          agentId,
+        },
+      }),
       isStreamingFinished: true,
       [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
         {
@@ -435,6 +443,11 @@ test.describe('Commands', () => {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
       format: 'org.matrix.custom.html',
       isStreamingFinished: true,
+      data: JSON.stringify({
+        context: {
+          agentId,
+        },
+      }),
       [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
         {
           id: 'a8fe43a4-7bd3-40a7-8455-50e31038e3a4',

--- a/packages/matrix/tests/commands.spec.ts
+++ b/packages/matrix/tests/commands.spec.ts
@@ -361,7 +361,6 @@ test.describe('Commands', () => {
     let roomEvents = await getRoomEvents('user1', 'pass', roomId);
     let numEventsBeforeResponse = roomEvents.length;
     let agentId = getAgentId(roomEvents);
-    console.log('agentId', agentId);
     // Note: this should really be posted by the aibot user but we can't do that easily
     // in this test, and this reproduces the bug
     await putEvent(userCred.accessToken, roomId, 'm.room.message', '1', {


### PR DESCRIPTION
The host's MatrixService generates a random "agentId" on instantiation. It includes this agent ID in the data.context.agentId node of message and result events sent to Matrix. The aibot captures this agentId when it responds to a matrix event and includes it in its own data.context.agentId node in all matrix events that it publishes, including messages with command requests and/or code patches. When the host's command service considers whether to automatically execute a command or automatically apply a patch, it will only do so if the agentId matches the matrix service's agentId. This should limit the agentic eagerness to one and only one tab while allowing multiple tabs to have their server state stay up-to-date via matrix broadcasts.