### PR TITLE
add sanitization of realmUrl that is executed by AI when running actions of listing

### DIFF
--- a/packages/host/app/commands/listing-remix.ts
+++ b/packages/host/app/commands/listing-remix.ts
@@ -2,7 +2,7 @@ import { service } from '@ember/service';
 
 import { timeout } from 'ember-concurrency';
 
-import { isResolvedCodeRef } from '@cardstack/runtime-common';
+import { isResolvedCodeRef, RealmPaths } from '@cardstack/runtime-common';
 
 import * as CardAPI from 'https://cardstack.com/base/card-api';
 import * as BaseCommandModule from 'https://cardstack.com/base/command';
@@ -48,7 +48,13 @@ export default class RemixCommand extends HostBaseCommand<
     input: BaseCommandModule.ListingInput,
   ): Promise<undefined> {
     let realmUrls = this.realmServer.availableRealmURLs;
-    let { realm: realmUrl, listing: listingInput } = input;
+    let { realm, listing: listingInput } = input;
+    let realmUrl = new RealmPaths(new URL(realm)).url;
+
+    // Make sure realm is valid
+    if (!realmUrls.includes(realmUrl)) {
+      throw new Error(`Invalid realm: ${realmUrl}`);
+    }
 
     // this is intentionally to type because base command cannot interpret Listing type from catalog
     const listing = listingInput as Listing;
@@ -59,7 +65,6 @@ export default class RemixCommand extends HostBaseCommand<
       shouldPersistPlaygroundSelection,
       firstExampleCardId,
     } = await installListing({
-      realmUrls,
       realmUrl,
       listing,
       commandContext: this.commandContext,

--- a/packages/host/app/commands/listing-use.ts
+++ b/packages/host/app/commands/listing-use.ts
@@ -5,6 +5,7 @@ import {
   isResolvedCodeRef,
   loadCardDef,
   listingNameWithUuid,
+  RealmPaths,
 } from '@cardstack/runtime-common';
 
 import * as CardAPI from 'https://cardstack.com/base/card-api';
@@ -37,9 +38,11 @@ export default class ListingUseCommand extends HostBaseCommand<
     input: BaseCommandModule.ListingInput,
   ): Promise<undefined> {
     let realmUrls = this.realmServer.availableRealmURLs;
-    let { realm: realmUrl, listing: listingInput } = input;
+    let { realm, listing: listingInput } = input;
 
     const listing = listingInput as Listing;
+
+    let realmUrl = new RealmPaths(new URL(realm)).url;
 
     // Make sure realm is valid
     if (!realmUrls.includes(realmUrl)) {

--- a/packages/host/tests/acceptance/catalog-app-test.gts
+++ b/packages/host/tests/acceptance/catalog-app-test.gts
@@ -571,5 +571,58 @@ module('Acceptance | catalog app tests', function (hooks) {
         .dom('[data-test-playground-panel] [data-test-boxel-card-header-title]')
         .hasText('Author');
     });
+
+    test('use is succesful even if target realm does not have a trailing slash', async function (assert) {
+      await visitOperatorMode({
+        stacks: [[]],
+      });
+
+      await executeCommand(
+        ListingUseCommand,
+        testRealmURL + 'Listing/author.json',
+        removeTrailingSlash(testRealm2URL), //realm =  http//test-realm/test-2:
+      );
+
+      await verifyFolderWithUUID(testRealm2URL, 'author', assert);
+
+      await verifyInstanceExists(testRealm2URL, 'author', 'Author', assert);
+    });
+
+    test('install is succesful even if target realm does not have a trailing slash', async function (assert) {
+      await visitOperatorMode({
+        stacks: [[]],
+      });
+
+      await executeCommand(
+        ListingInstallCommand,
+        testRealmURL + 'Listing/author.json',
+        removeTrailingSlash(testRealm2URL), //realm =  http//test-realm/test-2:
+      );
+      await verifyInstanceExists(testRealm2URL, 'author', 'Author', assert);
+    });
+
+    test('remix is succesful even if target realm does not have a trailing slash', async function (assert) {
+      await visitOperatorMode({
+        stacks: [[]],
+      });
+
+      await executeCommand(
+        ListingRemixCommand,
+        testRealmURL + 'Listing/author.json',
+        removeTrailingSlash(testRealm2URL), //realm =  http//test-realm/test-2:
+      );
+
+      await waitFor('[data-test-module-inspector-view="preview"]', {
+        timeout: 5_000,
+      });
+      await click('[data-test-module-inspector-view="preview"]');
+      assert
+        .dom('[data-test-playground-panel] [data-test-boxel-card-header-title]')
+        .hasText('Author');
+    });
   });
 });
+
+function removeTrailingSlash(url: string): string {
+  return url.endsWith('/') && url.length > 1 ? url.slice(0, -1) : url;
+}

--- a/packages/host/tests/acceptance/catalog-app-test.gts
+++ b/packages/host/tests/acceptance/catalog-app-test.gts
@@ -572,7 +572,7 @@ module('Acceptance | catalog app tests', function (hooks) {
         .hasText('Author');
     });
 
-    test('use is succesful even if target realm does not have a trailing slash', async function (assert) {
+    test('use is successful even if target realm does not have a trailing slash', async function (assert) {
       await visitOperatorMode({
         stacks: [[]],
       });


### PR DESCRIPTION
The issue is that the AI constantly return thrown errors bcos realmUrl didn't have a trailing slash when attempting to run the remix command 

This fix uses RealmPaths abstraction to ensure the trailing slash is there



