### PR TITLE
Make playground loading state more stable

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
@@ -731,14 +731,14 @@ export default class PlaygroundPanel extends Component<Signature> {
       />
     {{/if}}
 
-    {{#if this.isLoading}}
-      <LoadingIndicator @color='var(--boxel-light)' />
-    {{else}}
-      <section class='playground-panel' data-test-playground-panel>
-        <div
-          class='playground-panel-content'
-          style={{this.styleForPlaygroundContent}}
-        >
+    <section class='playground-panel' data-test-playground-panel>
+      <div
+        class='playground-panel-content'
+        style={{this.styleForPlaygroundContent}}
+      >
+        {{#if this.isLoading}}
+          <LoadingIndicator @color='var(--boxel-light)' />
+        {{else}}
           {{#let (if @isFieldDef this.field this.card) as |card|}}
             {{#let
               (component
@@ -828,9 +828,9 @@ export default class PlaygroundPanel extends Component<Signature> {
               {{/if}}
             {{/let}}
           {{/let}}
-        </div>
-      </section>
-    {{/if}}
+        {{/if}}
+      </div>
+    </section>
 
     <style scoped>
       .instance-chooser-container {


### PR DESCRIPTION
The reported bug https://linear.app/cardstack/issue/CS-8255/avoid-flashing-of-field-playground-items was kind of ambiguous as to what the flashing is. after a bunch of investigation i think the _real_ issue here is that there is a beig difference between when you edit a card instance and the visual artifacts that you see as it updates and when you edit a field and the visual artifacts that you see as it updates. specifically editing a field looks like this:

https://github.com/user-attachments/assets/7634ce36-ea80-448e-83c3-11ea172a2a60

Note the blank white background as the updated code is reloaded. this is inconsistent with that it looks like to edit a card:

https://github.com/user-attachments/assets/0a30f266-d50d-44f8-af4e-bb6a0ba7b834

When you edit a card there is no blank white background. rather the dark playground background is consistent as the code is reloaded.

The fix here was to readjust the DOM so that we see a consistent code loading state for both field and card edits. Now when you date a field it looks like this:


https://github.com/user-attachments/assets/89d801f4-1cd9-48ce-865e-02e3faf4f2b7

There could be deeper work to prevent the either the field or the card from disappearing as the code is reloaded which would probably entail hot module loading. but i think this is probably an acceptable solution for now.

