### PR TITLE
Ignore broken links when performing file serialization

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -352,7 +352,7 @@ export interface Field<
     instancePromise: Promise<BaseDef>,
     loadedValue: any,
     relativeTo: URL | undefined,
-    opts: DeserializeOpts,
+    opts?: DeserializeOpts,
   ): Promise<any>;
   emptyValue(instance: BaseDef): any;
   validate(instance: BaseDef, value: any): void;
@@ -2493,6 +2493,7 @@ async function getDeserializedValue<CardT extends BaseDefConstructor>({
   doc,
   identityContext,
   relativeTo,
+  opts,
 }: {
   card: CardT;
   loadedValue: any;
@@ -2503,6 +2504,7 @@ async function getDeserializedValue<CardT extends BaseDefConstructor>({
   doc: LooseSingleCardDocument | CardDocument;
   identityContext: IdentityContext;
   relativeTo: URL | undefined;
+  opts?: DeserializeOpts;
 }): Promise<any> {
   let field = getField(card, fieldName);
   if (!field) {
@@ -2517,6 +2519,7 @@ async function getDeserializedValue<CardT extends BaseDefConstructor>({
     modelPromise,
     loadedValue,
     relativeTo,
+    opts,
   );
   return result;
 }
@@ -2806,6 +2809,7 @@ async function _updateFromSerialized<T extends BaseDefConstructor>({
           doc,
           identityContext,
           relativeTo: relativeToVal,
+          opts,
         }),
       ];
     }),

--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -545,6 +545,8 @@ export class CurrentRun {
         new URL(fileURL),
         {
           identityContext,
+          // we'll deal with broken links during rendering
+          ignoreBrokenLinks: true,
         },
       );
       await api.flushLogs();

--- a/packages/realm-server/tests/card-endpoints-test.ts
+++ b/packages/realm-server/tests/card-endpoints-test.ts
@@ -1953,6 +1953,292 @@ module(basename(__filename), function () {
           }
         });
 
+        test('creates card instances when it encounters "lid" in the request for requests that has "isUsed: true" links', async function (assert) {
+          let response = await request
+            .patch('/hassan-x')
+            .send({
+              data: {
+                type: 'card',
+                attributes: {
+                  firstName: 'Paper',
+                },
+                relationships: {
+                  friend: {
+                    data: {
+                      lid: 'local-id-1',
+                      type: 'card',
+                    },
+                  },
+                },
+                meta: {
+                  adoptsFrom: {
+                    module: './friend-with-used-link.gts',
+                    name: 'FriendWithUsedLink',
+                  },
+                },
+              },
+              included: [
+                {
+                  lid: 'local-id-1',
+                  type: 'card',
+                  attributes: {
+                    firstName: 'Jade',
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module:
+                        'http://localhost:4202/node-test/friend-with-used-link',
+                      name: 'FriendWithUsedLink',
+                    },
+                  },
+                },
+              ],
+            } as LooseSingleCardDocument)
+            .set('Accept', 'application/vnd.card+json');
+
+          assert.strictEqual(response.status, 200, 'HTTP 200 status');
+          assert.strictEqual(
+            response.get('X-boxel-realm-url'),
+            testRealmHref,
+            'realm url header is correct',
+          );
+          assert.strictEqual(
+            response.get('X-boxel-realm-public-readable'),
+            'true',
+            'realm is public readable',
+          );
+
+          let json = response.body;
+          assert.ok(json.data.meta.lastModified, 'lastModified exists');
+
+          assert.true(
+            isSingleCardDocument(json),
+            'response body is a card document',
+          );
+
+          assert.strictEqual(
+            json.data.attributes?.firstName,
+            'Paper',
+            'the field data is correct',
+          );
+          assert.ok(json.data.meta.lastModified, 'lastModified is populated');
+          delete json.data.meta.lastModified;
+          delete json.data.meta.resourceCreatedAt;
+          {
+            let cardFile = join(
+              dir.name,
+              'realm_server_1',
+              'test',
+              'hassan-x.json',
+            );
+            assert.ok(existsSync(cardFile), 'card json exists');
+            let card = readJSONSync(cardFile);
+            assert.deepEqual(
+              card,
+              {
+                data: {
+                  type: 'card',
+                  attributes: {
+                    firstName: 'Paper',
+                    description: null,
+                    thumbnailURL: null,
+                  },
+                  relationships: {
+                    friend: {
+                      links: {
+                        self: './FriendWithUsedLink/local-id-1',
+                      },
+                    },
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: `./friend-with-used-link`,
+                      name: 'FriendWithUsedLink',
+                    },
+                  },
+                },
+              },
+              'file contents are correct',
+            );
+          }
+          {
+            let cardFile = join(
+              dir.name,
+              'realm_server_1',
+              'test',
+              'FriendWithUsedLink',
+              `local-id-1.json`,
+            );
+            assert.ok(existsSync(cardFile), `card json ${cardFile} exists`);
+            let card = readJSONSync(cardFile);
+            assert.deepEqual(
+              card,
+              {
+                data: {
+                  type: 'card',
+                  attributes: {
+                    firstName: 'Jade',
+                    description: null,
+                    thumbnailURL: null,
+                  },
+                  relationships: {
+                    friend: {
+                      links: {
+                        self: null,
+                      },
+                    },
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module:
+                        'http://localhost:4202/node-test/friend-with-used-link',
+                      name: 'FriendWithUsedLink',
+                    },
+                  },
+                },
+              } as LooseSingleCardDocument,
+              `file contents ${cardFile} are correct`,
+            );
+          }
+          {
+            let response = await request
+              .get(`/hassan-x`)
+              .set('Accept', 'application/vnd.card+json');
+
+            assert.strictEqual(response.status, 200, 'HTTP 200 status');
+            let json = response.body;
+            assert.ok(json.data.meta.lastModified, 'lastModified exists');
+            delete json.data.meta.lastModified;
+            delete json.data.meta.resourceCreatedAt;
+            assert.strictEqual(
+              response.get('X-boxel-realm-url'),
+              testRealmHref,
+              'realm url header is correct',
+            );
+            assert.deepEqual(json.data, {
+              id: `${testRealmHref}hassan-x`,
+              type: 'card',
+              attributes: {
+                firstName: 'Paper',
+                title: 'Paper',
+                description: null,
+                thumbnailURL: null,
+              },
+              relationships: {
+                friend: {
+                  links: {
+                    self: './FriendWithUsedLink/local-id-1',
+                  },
+                  data: {
+                    type: 'card',
+                    id: `${testRealmHref}FriendWithUsedLink/local-id-1`,
+                  },
+                },
+              },
+              meta: {
+                adoptsFrom: {
+                  name: 'FriendWithUsedLink',
+                  module: './friend-with-used-link',
+                },
+                realmInfo: {
+                  ...testRealmInfo,
+                  realmUserId: '@node-test_realm:localhost',
+                },
+                realmURL: testRealmHref,
+              },
+              links: {
+                self: `${testRealmHref}hassan-x`,
+              },
+            });
+
+            for (let resource of json.included!) {
+              delete resource.meta.realmURL;
+              delete resource.meta.realmInfo;
+              delete resource.meta.lastModified;
+              delete resource.meta.resourceCreatedAt;
+              delete resource.links;
+            }
+            assert.deepEqual(
+              json.included,
+              [
+                {
+                  id: `${testRealmHref}FriendWithUsedLink/local-id-1`,
+                  type: 'card',
+                  attributes: {
+                    firstName: 'Jade',
+                    title: 'Jade',
+                    description: null,
+                    thumbnailURL: null,
+                  },
+                  relationships: {
+                    friend: {
+                      links: {
+                        self: null,
+                      },
+                    },
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module:
+                        'http://localhost:4202/node-test/friend-with-used-link',
+                      name: 'FriendWithUsedLink',
+                    },
+                  },
+                },
+              ],
+              'included is correct',
+            );
+          }
+          {
+            let response = await request
+              .get(`/FriendWithUsedLink/local-id-1`)
+              .set('Accept', 'application/vnd.card+json');
+
+            assert.strictEqual(response.status, 200, 'HTTP 200 status');
+            let json = response.body;
+            assert.ok(json.data.meta.lastModified, 'lastModified exists');
+            delete json.data.meta.lastModified;
+            delete json.data.meta.resourceCreatedAt;
+            assert.strictEqual(
+              response.get('X-boxel-realm-url'),
+              testRealmHref,
+              'realm url header is correct',
+            );
+            assert.deepEqual(json.data, {
+              id: `${testRealmHref}FriendWithUsedLink/local-id-1`,
+              type: 'card',
+              attributes: {
+                firstName: 'Jade',
+                title: 'Jade',
+                description: null,
+                thumbnailURL: null,
+              },
+              relationships: {
+                friend: {
+                  links: {
+                    self: null,
+                  },
+                },
+              },
+              meta: {
+                adoptsFrom: {
+                  name: 'FriendWithUsedLink',
+                  module:
+                    'http://localhost:4202/node-test/friend-with-used-link',
+                },
+                realmInfo: {
+                  ...testRealmInfo,
+                  realmUserId: '@node-test_realm:localhost',
+                },
+                realmURL: testRealmHref,
+              },
+              links: {
+                self: `${testRealmHref}FriendWithUsedLink/local-id-1`,
+              },
+            });
+          }
+        });
+
         test('ignores "lid" for other realms', async function (assert) {
           let response = await request
             .patch('/hassan')

--- a/packages/realm-server/tests/cards/friend-with-used-link.gts
+++ b/packages/realm-server/tests/cards/friend-with-used-link.gts
@@ -1,0 +1,39 @@
+import {
+  contains,
+  linksTo,
+  linksToMany,
+  field,
+  CardDef,
+  Component,
+} from 'https://cardstack.com/base/card-api';
+import StringField from 'https://cardstack.com/base/string';
+
+export class FriendWithUsedLink extends CardDef {
+  @field firstName = contains(StringField);
+  @field friend = linksTo(() => FriendWithUsedLink, { isUsed: true }); // using isUsed: true will throw when recompute encounters broken links
+  @field friends = linksToMany(() => FriendWithUsedLink);
+  @field title = contains(StringField, {
+    computeVia: function (this: FriendWithUsedLink) {
+      return this.firstName;
+    },
+  });
+  static embedded = class Embedded extends Component<typeof this> {
+    <template>
+      <@fields.firstName />
+    </template>
+  };
+  static isolated = class Isolated extends Component<typeof this> {
+    <template>
+      <div class='friend'>
+        <@fields.firstName />
+        has a friend
+        <@fields.friend />
+      </div>
+      <style scoped>
+        .friend {
+          color: red;
+        }
+      </style>
+    </template>
+  };
+}

--- a/packages/realm-server/tests/cards/hassan-x.json
+++ b/packages/realm-server/tests/cards/hassan-x.json
@@ -1,0 +1,21 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "firstName": "Hassan X"
+    },
+    "relationships": {
+      "friend": {
+        "links": {
+          "self": "./jade-x"
+        }
+      }
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "./friend-with-used-link.gts",
+        "name": "FriendWithUsedLink"
+      }
+    }
+  }
+}

--- a/packages/realm-server/tests/cards/jade-x.json
+++ b/packages/realm-server/tests/cards/jade-x.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "firstName": "Jade X"
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "./friend-with-used-link.gts",
+        "name": "FriendWithUsedLink"
+      }
+    }
+  }
+}

--- a/packages/realm-server/tests/realm-endpoints-test.ts
+++ b/packages/realm-server/tests/realm-endpoints-test.ts
@@ -727,9 +727,25 @@ module(basename(__filename), function () {
                   kind: 'directory',
                 },
               },
+              'friend-with-used-link.gts': {
+                links: {
+                  related: `${testRealmHref}friend-with-used-link.gts`,
+                },
+                meta: {
+                  kind: 'file',
+                },
+              },
               'friend.gts': {
                 links: {
                   related: `${testRealmHref}friend.gts`,
+                },
+                meta: {
+                  kind: 'file',
+                },
+              },
+              'hassan-x.json': {
+                links: {
+                  related: `${testRealmHref}hassan-x.json`,
                 },
                 meta: {
                   kind: 'file',
@@ -754,6 +770,14 @@ module(basename(__filename), function () {
               'index.json': {
                 links: {
                   related: `${testRealmHref}index.json`,
+                },
+                meta: {
+                  kind: 'file',
+                },
+              },
+              'jade-x.json': {
+                links: {
+                  related: `${testRealmHref}jade-x.json`,
                 },
                 meta: {
                   kind: 'file',

--- a/packages/realm-server/tests/types-endpoint-test.ts
+++ b/packages/realm-server/tests/types-endpoint-test.ts
@@ -148,6 +148,15 @@ module(basename(__filename), function () {
           },
           {
             type: 'card-type-summary',
+            id: `${testRealm.url}friend-with-used-link/FriendWithUsedLink`,
+            attributes: {
+              displayName: 'FriendWithUsedLink',
+              total: 2,
+              iconHTML,
+            },
+          },
+          {
+            type: 'card-type-summary',
             id: `${testRealm.url}home/Home`,
             attributes: {
               displayName: 'Home',

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -2143,11 +2143,9 @@ export class Realm {
     let api = await this.loader.import<typeof CardAPI>(
       'https://cardstack.com/base/card-api',
     );
-    let card = (await api.createFromSerialized(
-      doc.data,
-      doc,
-      relativeTo,
-    )) as CardDef;
+    let card = (await api.createFromSerialized(doc.data, doc, relativeTo, {
+      ignoreBrokenLinks: true,
+    })) as CardDef;
     await api.flushLogs();
     let data: LooseSingleCardDocument = api.serializeCard(card); // this strips out computeds
     delete data.data.id; // the ID is derived from the filename, so we don't serialize it on disk


### PR DESCRIPTION
The field option `{ isUsed: true }` will throw when it encounters a broken link during recompute--which is what we expect it to do. instances are recomputed after they are deserialized, however, there are scenarios where we really don't care about broken links as part of deserialization. Specifically when serializing an instance to the file system. Also when indexing, immediately before we begin the rendering process, we don't actually care about broken links yet. (the rendering process actually is what we use to deal with broken links).