### PR TITLE
Split out prompt/events in aibot debug, add a help message.

### DIFF
--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -21,7 +21,7 @@ import {
 import {
   getRoomEvents,
   type MatrixClient,
-  sendPromptAndEventList,
+  sendPromptAsDebugMessage,
 } from './lib/matrix/util';
 import type {
   MatrixEvent as DiscreteMatrixEvent,
@@ -255,7 +255,7 @@ Common issues are:
           // if debug, send message with promptParts and event list
           if (isInDebugMode(eventList, aiBotUserId)) {
             // create files in memory
-            sendPromptAndEventList(client, room.roomId, promptParts, eventList);
+            sendPromptAsDebugMessage(client, room.roomId, promptParts);
           }
           await responder.ensureThinkingMessageSent();
         } catch (e) {


### PR DESCRIPTION
Also cuts down the hassle when getting the last sent prompt, as now it automatically goes back to the last non-debug user message.

Note - does not address storing previously sent prompts, this can be done as a separate pr.