### PR TITLE
Add substring helper

### DIFF
--- a/packages/boxel-ui/addon/src/helpers.ts
+++ b/packages/boxel-ui/addon/src/helpers.ts
@@ -10,6 +10,7 @@ import menuDivider, { MenuDivider } from './helpers/menu-divider.ts';
 import menuItem, { MenuItem, menuItemFunc } from './helpers/menu-item.ts';
 import optional from './helpers/optional.ts';
 import pick from './helpers/pick.ts';
+import { substring } from './helpers/string.ts';
 import { and, bool, eq, gt, lt, not, or } from './helpers/truth-helpers.ts';
 
 export {
@@ -37,5 +38,6 @@ export {
   optional,
   or,
   pick,
+  substring,
   subtract,
 };

--- a/packages/boxel-ui/addon/src/helpers/string.ts
+++ b/packages/boxel-ui/addon/src/helpers/string.ts
@@ -1,0 +1,3 @@
+export function substring(str: string, start: number, end?: number) {
+  return str.substring(start, end);
+}

--- a/packages/runtime-common/etc/eslint/missing-invokables-config.js
+++ b/packages/runtime-common/etc/eslint/missing-invokables-config.js
@@ -20,6 +20,7 @@ module.exports = {
     not: ['not', '@cardstack/boxel-ui/helpers'],
     on: ['on', '@ember/modifier'],
     or: ['or', '@cardstack/boxel-ui/helpers'],
+    substring: ['substring', '@cardstack/boxel-ui/helpers'],
     subtract: ['subtract', '@cardstack/boxel-ui/helpers'],
   },
 };


### PR DESCRIPTION
AI hallucinated a `substring` helper in recent coding session:

```  gts
            <p class='procedure-overview'>
              {{if
                (gt @model.overview.length 160)
                (concat (substring @model.overview 0 160) '...')
                @model.overview
              }}
            </p> 
```
This PR adds the helper and the missing-invokable-config setting