### PR TITLE
better error doc generation

### DIFF
--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -201,6 +201,54 @@ module(basename(__filename), function () {
               }
             }
           `,
+            'atom-boom.gts': `
+            import { contains, field, CardDef, Component } from "https://cardstack.com/base/card-api";
+            import StringField from "https://cardstack.com/base/string";
+
+            export class Boom extends CardDef {
+              @field firstName = contains(StringField);
+              static atom = class Atom extends Component<typeof this> {
+                <template>
+                  <h1><@fields.firstName/>{{this.boom}}</h1>
+                </template>
+                get boom() {
+                  throw new Error('intentional error');
+                }
+              }
+            }
+          `,
+            'embedded-boom.gts': `
+            import { contains, field, CardDef, Component } from "https://cardstack.com/base/card-api";
+            import StringField from "https://cardstack.com/base/string";
+
+            export class Boom extends CardDef {
+              @field firstName = contains(StringField);
+              static embedded = class Embedded extends Component<typeof this> {
+                <template>
+                  <h1><@fields.firstName/>{{this.boom}}</h1>
+                </template>
+                get boom() {
+                  throw new Error('intentional error');
+                }
+              }
+            }
+          `,
+            'fitted-boom.gts': `
+            import { contains, field, CardDef, Component } from "https://cardstack.com/base/card-api";
+            import StringField from "https://cardstack.com/base/string";
+
+            export class Boom extends CardDef {
+              @field firstName = contains(StringField);
+              static fitted = class Fitted extends Component<typeof this> {
+                <template>
+                  <h1><@fields.firstName/>{{this.boom}}</h1>
+                </template>
+                get boom() {
+                  throw new Error('intentional error');
+                }
+              }
+            }
+          `,
             'mango.json': {
               data: {
                 attributes: {
@@ -323,6 +371,45 @@ module(basename(__filename), function () {
                 },
               },
             },
+            'atom-boom.json': {
+              data: {
+                attributes: {
+                  firstName: 'Boom!',
+                },
+                meta: {
+                  adoptsFrom: {
+                    module: './atom-boom',
+                    name: 'Boom',
+                  },
+                },
+              },
+            },
+            'embedded-boom.json': {
+              data: {
+                attributes: {
+                  firstName: 'Boom!',
+                },
+                meta: {
+                  adoptsFrom: {
+                    module: './embedded-boom',
+                    name: 'Boom',
+                  },
+                },
+              },
+            },
+            'fitted-boom.json': {
+              data: {
+                attributes: {
+                  firstName: 'Boom!',
+                },
+                meta: {
+                  adoptsFrom: {
+                    module: './fitted-boom',
+                    name: 'Boom',
+                  },
+                },
+              },
+            },
             'empty.json': {
               data: {
                 attributes: {},
@@ -374,6 +461,57 @@ module(basename(__filename), function () {
         );
       } else {
         assert.ok(false, 'expected index entry not to be an error');
+      }
+    });
+
+    test('can store error doc in the index when atom view throws error', async function (assert) {
+      let entry = await realm.realmIndexQueryEngine.cardDocument(
+        new URL(`${testRealm}atom-boom`),
+      );
+      if (entry?.type === 'error') {
+        assert.strictEqual(
+          entry.error.errorDetail.message,
+          'Encountered error rendering HTML for card: intentional error',
+        );
+        assert.deepEqual(entry.error.errorDetail.deps, [
+          `${testRealm}atom-boom`,
+        ]);
+      } else {
+        assert.ok(false, 'expected index entry to be an error');
+      }
+    });
+
+    test('can store error doc in the index when embedded view throws error', async function (assert) {
+      let entry = await realm.realmIndexQueryEngine.cardDocument(
+        new URL(`${testRealm}embedded-boom`),
+      );
+      if (entry?.type === 'error') {
+        assert.strictEqual(
+          entry.error.errorDetail.message,
+          'Encountered error rendering HTML for card: intentional error',
+        );
+        assert.deepEqual(entry.error.errorDetail.deps, [
+          `${testRealm}embedded-boom`,
+        ]);
+      } else {
+        assert.ok(false, 'expected index entry to be an error');
+      }
+    });
+
+    test('can store error doc in the index when fitted view throws error', async function (assert) {
+      let entry = await realm.realmIndexQueryEngine.cardDocument(
+        new URL(`${testRealm}fitted-boom`),
+      );
+      if (entry?.type === 'error') {
+        assert.strictEqual(
+          entry.error.errorDetail.message,
+          'Encountered error rendering HTML for card: intentional error',
+        );
+        assert.deepEqual(entry.error.errorDetail.deps, [
+          `${testRealm}fitted-boom`,
+        ]);
+      } else {
+        assert.ok(false, 'expected index entry to be an error');
       }
     });
 


### PR DESCRIPTION
The criteria for writing an error doc into the index was not very complete and we were missing scenarios where errors were thrown during indexing (like errors during embedded and fitted rendering). This PR makes sure that any unhandled exception during indexing is captured as an error doc