### PR TITLE
Elide "deps" from the error message for module errors

### DIFF
--- a/packages/host/app/components/operator-mode/syntax-error-display.gts
+++ b/packages/host/app/components/operator-mode/syntax-error-display.gts
@@ -1,11 +1,12 @@
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
+import { type CardError } from '@cardstack/runtime-common';
+
 import MatrixService from '@cardstack/host/services/matrix-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 import ErrorDisplay from './error-display';
-import { type CardError } from '@cardstack/runtime-common';
 
 interface Signature {
   Element: HTMLElement;

--- a/packages/host/app/components/operator-mode/syntax-error-display.gts
+++ b/packages/host/app/components/operator-mode/syntax-error-display.gts
@@ -5,6 +5,7 @@ import MatrixService from '@cardstack/host/services/matrix-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 import ErrorDisplay from './error-display';
+import { type CardError } from '@cardstack/runtime-common';
 
 interface Signature {
   Element: HTMLElement;
@@ -16,6 +17,18 @@ interface Signature {
 export default class SyntaxErrorDisplay extends Component<Signature> {
   @service private declare operatorModeStateService: OperatorModeStateService;
   @service private declare matrixService: MatrixService;
+
+  get stack() {
+    let stack = this.removeSourceMappingURL(this.args.syntaxErrors);
+    let json: CardError | undefined;
+    try {
+      json = JSON.parse(stack);
+    } catch (e) {
+      return stack;
+    }
+    delete json!.deps; // definitely json exists at this point
+    return JSON.stringify(json, null, 2);
+  }
 
   removeSourceMappingURL(syntaxErrors: string): string {
     return syntaxErrors.replace(/\/\/# sourceMappingURL=.*/g, '');
@@ -35,7 +48,7 @@ export default class SyntaxErrorDisplay extends Component<Signature> {
     <div class='syntax-error-container' data-test-syntax-error>
       <ErrorDisplay
         @type='syntax'
-        @stack={{this.removeSourceMappingURL @syntaxErrors}}
+        @stack={{this.stack}}
         @fileToAttach={{this.fileToAttach}}
         @openDetails={{true}}
       />


### PR DESCRIPTION
This PR removes the "deps" field in the module error display which was uninformative (it's use is specifically for the index) and wastes AI prompt tokens.