### PR TITLE
ci: Add missing package dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,6 +69,7 @@ jobs:
               - 'packages/boxel-icons/**'
               - 'packages/boxel-ui/**'
               - 'packages/host/**'
+              - 'packages/matrix/**'
               - 'packages/realm-server/**'
             realm-server:
               - *shared
@@ -77,6 +78,7 @@ jobs:
               - 'packages/boxel-ui/**'
               - 'packages/eslint-plugin-boxel/**'
               - 'packages/postgres/**'
+              - 'packages/realm-server/**'
             vscode-boxel-tools:
               - *shared
               - 'packages/vscode-boxel-tools/**'


### PR DESCRIPTION
These are significant oversights from #2677, as I was looking at `package.json` to see what _other_ packages were consumed, but forgot to include the packages themselves in these two cases. I noticed this in #2753 where I wanted specifically to run a Matrix test.