### PR TITLE
Tweak prompt input behaviour

### DIFF
--- a/packages/host/app/components/ai-assistant/attachment-picker/attach-button.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/attach-button.gts
@@ -1,0 +1,99 @@
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+
+import { restartableTask } from 'ember-concurrency';
+
+import { AddButton } from '@cardstack/boxel-ui/components';
+import { cn, eq } from '@cardstack/boxel-ui/helpers';
+
+import { chooseCard, baseCardRef, chooseFile } from '@cardstack/runtime-common';
+
+import { type CardDef } from 'https://cardstack.com/base/card-api';
+import { type FileDef } from 'https://cardstack.com/base/file-api';
+
+import { Submode } from '../../submode-switcher';
+
+interface Signature {
+  Element: HTMLDivElement;
+  Args: {
+    submode: Submode;
+    files: FileDef[];
+    cards: CardDef[];
+    chooseCard: (cardId: string) => void;
+    chooseFile: (file: FileDef) => void;
+    width?: string;
+    height?: string;
+  };
+}
+
+export default class AttachButton extends Component<Signature> {
+  <template>
+    {{#if (eq @submode 'code')}}
+      <AddButton
+        class={{cn 'attach-button'}}
+        @variant='pill'
+        @iconWidth={{unless @width '14'}}
+        @iconHeight={{unless @height '14'}}
+        {{on 'click' this.chooseFile}}
+        @disabled={{this.doChooseFile.isRunning}}
+        data-test-choose-file-btn
+      />
+    {{else}}
+      <AddButton
+        class={{cn 'attach-button'}}
+        @variant='pill'
+        @iconWidth={{unless @width '14'}}
+        @iconHeight={{unless @height '14'}}
+        {{on 'click' this.chooseCard}}
+        @disabled={{this.chooseCardTask.isRunning}}
+        data-test-choose-card-btn
+      />
+    {{/if}}
+    <style scoped>
+      .attach-button {
+        height: 30px;
+        padding: 0;
+        gap: var(--boxel-sp-xs);
+        background: none;
+      }
+      .attach-button:hover:not(:disabled),
+      .attach-button:focus:not(:disabled) {
+        --icon-color: var(--boxel-600);
+        color: var(--boxel-600);
+        background: none;
+        box-shadow: none;
+      }
+      .attach-button > :deep(svg > path) {
+        stroke: none;
+      }
+    </style>
+  </template>
+
+  @action
+  private chooseCard() {
+    this.chooseCardTask.perform();
+  }
+
+  private chooseCardTask = restartableTask(async () => {
+    let cardId = await chooseCard({
+      filter: { type: baseCardRef },
+    });
+    if (cardId) {
+      this.args.chooseCard(cardId);
+    }
+  });
+
+  @action
+  private async chooseFile() {
+    let file = await this.doChooseFile.perform();
+    if (file) {
+      this.args.chooseFile(file);
+    }
+  }
+
+  private doChooseFile = restartableTask(async () => {
+    let chosenFile: FileDef | undefined = await chooseFile();
+    return chosenFile;
+  });
+}

--- a/packages/host/app/components/ai-assistant/attachment-picker/attach-button.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/attach-button.gts
@@ -5,7 +5,7 @@ import Component from '@glimmer/component';
 import { restartableTask } from 'ember-concurrency';
 
 import { AddButton } from '@cardstack/boxel-ui/components';
-import { cn, eq } from '@cardstack/boxel-ui/helpers';
+import { eq } from '@cardstack/boxel-ui/helpers';
 
 import { chooseCard, baseCardRef, chooseFile } from '@cardstack/runtime-common';
 
@@ -22,8 +22,6 @@ interface Signature {
     cards: CardDef[];
     chooseCard: (cardId: string) => void;
     chooseFile: (file: FileDef) => void;
-    width?: string;
-    height?: string;
   };
 }
 
@@ -31,20 +29,16 @@ export default class AttachButton extends Component<Signature> {
   <template>
     {{#if (eq @submode 'code')}}
       <AddButton
-        class={{cn 'attach-button'}}
+        class='attach-button'
         @variant='pill'
-        @iconWidth={{unless @width '14'}}
-        @iconHeight={{unless @height '14'}}
         {{on 'click' this.chooseFile}}
         @disabled={{this.doChooseFile.isRunning}}
         data-test-choose-file-btn
       />
     {{else}}
       <AddButton
-        class={{cn 'attach-button'}}
+        class='attach-button'
         @variant='pill'
-        @iconWidth={{unless @width '14'}}
-        @iconHeight={{unless @height '14'}}
         {{on 'click' this.chooseCard}}
         @disabled={{this.chooseCardTask.isRunning}}
         data-test-choose-card-btn
@@ -52,7 +46,8 @@ export default class AttachButton extends Component<Signature> {
     {{/if}}
     <style scoped>
       .attach-button {
-        height: 30px;
+        height: var(--attach-button-height, 30px);
+        width: var(--attach-button-width, auto);
         padding: 0;
         gap: var(--boxel-sp-xs);
         background: none;

--- a/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
@@ -1,0 +1,147 @@
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import { TrackedSet } from 'tracked-built-ins';
+
+import { Tooltip, Pill } from '@cardstack/boxel-ui/components';
+import { and, gt, not } from '@cardstack/boxel-ui/helpers';
+
+import { localId, isCardInstance } from '@cardstack/runtime-common';
+
+import CardPill from '@cardstack/host/components/card-pill';
+import FilePill from '@cardstack/host/components/file-pill';
+import { urlForRealmLookup } from '@cardstack/host/lib/utils';
+
+import { type CardDef } from 'https://cardstack.com/base/card-api';
+import { type FileDef } from 'https://cardstack.com/base/file-api';
+
+const MAX_ITEMS_TO_DISPLAY = 4;
+
+interface Signature {
+  Element: HTMLDivElement;
+  Args: {
+    items: (CardDef | FileDef)[];
+    autoAttachedCardIds?: TrackedSet<string>;
+    autoAttachedFile?: FileDef;
+    removeCard: (cardId: string) => void;
+    removeFile: (file: FileDef) => void;
+    isLoaded: boolean;
+    autoAttachedCardTooltipMessage?: string;
+  };
+}
+
+export default class AttachedItems extends Component<Signature> {
+  @tracked areAllItemsDisplayed = false;
+
+  get itemsToDisplay() {
+    return this.areAllItemsDisplayed
+      ? this.args.items
+      : this.args.items.slice(0, MAX_ITEMS_TO_DISPLAY);
+  }
+
+  private isCard = (item: CardDef | FileDef): item is CardDef => {
+    return isCardInstance(item);
+  };
+
+  private isAutoAttachedCard = (card: CardDef): boolean => {
+    return this.args.autoAttachedCardIds?.has(card.id) ?? false;
+  };
+
+  private isAutoAttachedFile = (file: FileDef): boolean => {
+    return this.args.autoAttachedFile?.sourceUrl === file.sourceUrl;
+  };
+
+  @action
+  private toggleViewAllAttachedCards() {
+    this.areAllItemsDisplayed = !this.areAllItemsDisplayed;
+  }
+
+  <template>
+    <div class='attached-items'>
+      {{#if @isLoaded}}
+        {{#each this.itemsToDisplay as |item|}}
+          {{#if (this.isCard item)}}
+            {{#if (this.isAutoAttachedCard item)}}
+              <Tooltip @placement='top'>
+                <:trigger>
+                  <CardPill
+                    @cardId={{idFor item}}
+                    @isAutoAttachedCard={{true}}
+                    @removeCard={{@removeCard}}
+                    @urlForRealmLookup={{urlForRealmLookup item}}
+                  />
+                </:trigger>
+
+                <:content>
+                  {{#if @autoAttachedCardTooltipMessage}}
+                    {{@autoAttachedCardTooltipMessage}}
+                  {{else if (this.isAutoAttachedCard item)}}
+                    Topmost card is shared automatically
+                  {{/if}}
+                </:content>
+              </Tooltip>
+            {{else}}
+              <CardPill
+                @cardId={{idFor item}}
+                @isAutoAttachedCard={{false}}
+                @removeCard={{@removeCard}}
+                @urlForRealmLookup={{urlForRealmLookup item}}
+              />
+            {{/if}}
+          {{else}}
+            {{#if (this.isAutoAttachedFile item)}}
+              <Tooltip @placement='top'>
+                <:trigger>
+                  <FilePill
+                    @file={{item}}
+                    @isAutoAttachedFile={{true}}
+                    @removeFile={{@removeFile}}
+                  />
+                </:trigger>
+                <:content>
+                  Currently opened file is shared automatically
+                </:content>
+              </Tooltip>
+            {{else}}
+              <FilePill
+                @file={{item}}
+                @isAutoAttachedFile={{false}}
+                @removeFile={{@removeFile}}
+              />
+            {{/if}}
+          {{/if}}
+        {{/each}}
+        {{#if
+          (and
+            (gt @items.length MAX_ITEMS_TO_DISPLAY)
+            (not this.areAllItemsDisplayed)
+          )
+        }}
+          <Pill
+            @kind='button'
+            {{on 'click' this.toggleViewAllAttachedCards}}
+            data-test-view-all
+          >
+            View All ({{@items.length}})
+          </Pill>
+        {{/if}}
+      {{/if}}
+    </div>
+    <style scoped>
+      .attached-items {
+        background-color: var(--boxel-light);
+        color: var(--boxel-dark);
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--boxel-sp-xxs);
+        padding: var(--boxel-sp-xs);
+      }
+    </style>
+  </template>
+}
+
+function idFor(instance: CardDef) {
+  return instance.id ?? instance[localId];
+}

--- a/packages/host/app/components/ai-assistant/attachment-picker/index.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/index.gts
@@ -1,36 +1,25 @@
-import { on } from '@ember/modifier';
-import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-
-import { restartableTask } from 'ember-concurrency';
 
 import { consume } from 'ember-provide-consume-context';
 
 import { TrackedSet } from 'tracked-built-ins';
 
-import { AddButton, Tooltip, Pill } from '@cardstack/boxel-ui/components';
-import { and, cn, eq, gt, not } from '@cardstack/boxel-ui/helpers';
-
 import {
-  chooseCard,
-  baseCardRef,
-  isCardInstance,
-  chooseFile,
   GetCardCollectionContextName,
-  localId,
   type getCardCollection,
 } from '@cardstack/runtime-common';
 
-import CardPill from '@cardstack/host/components/card-pill';
-import FilePill from '@cardstack/host/components/file-pill';
 import consumeContext from '@cardstack/host/helpers/consume-context';
-import { urlForRealmLookup } from '@cardstack/host/lib/utils';
 
-import { type CardDef } from 'https://cardstack.com/base/card-api';
 import { type FileDef } from 'https://cardstack.com/base/file-api';
 
 import { Submode } from '../../submode-switcher';
+
+import AttachButton from './attach-button';
+import AttachedItems from './attached-items';
+
+import type { WithBoundArgs } from '@glint/template';
 
 interface Signature {
   Element: HTMLDivElement;
@@ -44,175 +33,60 @@ interface Signature {
     chooseFile: (file: FileDef) => void;
     removeFile: (file: FileDef) => void;
     submode: Submode;
-    maxNumberOfItemsToAttach?: number;
     autoAttachedCardTooltipMessage?: string;
   };
+  Blocks: {
+    default: [
+      WithBoundArgs<
+        typeof AttachedItems,
+        | 'items'
+        | 'autoAttachedCardIds'
+        | 'autoAttachedFile'
+        | 'removeCard'
+        | 'removeFile'
+        | 'autoAttachedCardTooltipMessage'
+        | 'isLoaded'
+      >,
+      WithBoundArgs<
+        typeof AttachButton,
+        'submode' | 'files' | 'cards' | 'chooseCard' | 'chooseFile'
+      >,
+    ];
+  };
 }
-
-const MAX_ITEMS_TO_DISPLAY = 4;
 
 export default class AiAssistantAttachmentPicker extends Component<Signature> {
   <template>
     {{consumeContext this.makeCardResources}}
-    <div class='item-picker'>
-      {{#if this.isLoaded}}
-        {{#each this.itemsToDisplay as |item|}}
-          {{#if (this.isCard item)}}
-            {{#if (this.isAutoAttachedCard item)}}
-              <Tooltip @placement='top'>
-                <:trigger>
-                  <CardPill
-                    @cardId={{idFor item}}
-                    @isAutoAttachedCard={{true}}
-                    @removeCard={{@removeCard}}
-                    @urlForRealmLookup={{urlForRealmLookup item}}
-                  />
-                </:trigger>
-
-                <:content>
-                  {{#if @autoAttachedCardTooltipMessage}}
-                    {{@autoAttachedCardTooltipMessage}}
-                  {{else if (this.isAutoAttachedCard item)}}
-                    Topmost card is shared automatically
-                  {{/if}}
-                </:content>
-              </Tooltip>
-            {{else}}
-              <CardPill
-                @cardId={{idFor item}}
-                @isAutoAttachedCard={{false}}
-                @removeCard={{@removeCard}}
-                @urlForRealmLookup={{urlForRealmLookup item}}
-              />
-            {{/if}}
-          {{else}}
-            {{#if (this.isAutoAttachedFile item)}}
-              <Tooltip @placement='top'>
-                <:trigger>
-                  <FilePill
-                    @file={{item}}
-                    @isAutoAttachedFile={{true}}
-                    @removeFile={{@removeFile}}
-                  />
-                </:trigger>
-                <:content>
-                  Currently opened file is shared automatically
-                </:content>
-              </Tooltip>
-            {{else}}
-              <FilePill
-                @file={{item}}
-                @isAutoAttachedFile={{false}}
-                @removeFile={{@removeFile}}
-              />
-            {{/if}}
-          {{/if}}
-        {{/each}}
-        {{#if
-          (and
-            (gt this.items.length MAX_ITEMS_TO_DISPLAY)
-            (not this.areAllItemsDisplayed)
-          )
-        }}
-          <Pill
-            @kind='button'
-            {{on 'click' this.toggleViewAllAttachedCards}}
-            data-test-view-all
-          >
-            View All ({{this.items.length}})
-          </Pill>
-        {{/if}}
-        {{#if this.canDisplayAddButton}}
-          {{#if (eq @submode 'code')}}
-            <AddButton
-              class={{cn 'attach-button' icon-only=this.files.length}}
-              @variant='pill'
-              @iconWidth='14'
-              @iconHeight='14'
-              {{on 'click' this.chooseFile}}
-              @disabled={{this.doChooseFile.isRunning}}
-              data-test-choose-file-btn
-            >
-              <span class={{if this.files.length 'boxel-sr-only'}}>
-                Attach File
-              </span>
-            </AddButton>
-          {{else}}
-            <AddButton
-              class={{cn 'attach-button' icon-only=this.cards.length}}
-              @variant='pill'
-              @iconWidth='14'
-              @iconHeight='14'
-              {{on 'click' this.chooseCard}}
-              @disabled={{this.chooseCardTask.isRunning}}
-              data-test-choose-card-btn
-            >
-              <span class={{if this.cards.length 'boxel-sr-only'}}>
-                Add Card
-              </span>
-            </AddButton>
-          {{/if}}
-        {{/if}}
-      {{/if}}
-    </div>
-    <style scoped>
-      .item-picker {
-        background-color: var(--boxel-light);
-        color: var(--boxel-dark);
-        display: flex;
-        flex-wrap: wrap;
-        gap: var(--boxel-sp-xxs);
-        padding: var(--boxel-sp-xxs);
-      }
-      .attach-button {
-        --boxel-add-button-pill-font: var(--boxel-font-sm);
-        height: var(--pill-height);
-        padding: var(--boxel-sp-4xs) var(--boxel-sp-xxxs);
-        gap: var(--boxel-sp-xs);
-        background: none;
-      }
-      .attach-button:hover:not(:disabled),
-      .attach-button:focus:not(:disabled) {
-        --icon-color: var(--boxel-600);
-        color: var(--boxel-600);
-        background: none;
-        box-shadow: none;
-      }
-      .attach-button.icon-only {
-        width: 30px;
-        height: var(--pill-height, 30px);
-      }
-      .attach-button > :deep(svg > path) {
-        stroke: none;
-      }
-    </style>
+    {{yield
+      (component
+        AttachedItems
+        isLoaded=this.isLoaded
+        items=this.items
+        autoAttachedCardIds=@autoAttachedCardIds
+        autoAttachedFile=@autoAttachedFile
+        removeCard=@removeCard
+        removeFile=@removeFile
+        autoAttachedCardTooltipMessage=@autoAttachedCardTooltipMessage
+      )
+      (component
+        AttachButton
+        submode=@submode
+        files=this.files
+        cards=this.cards
+        chooseCard=@chooseCard
+        chooseFile=@chooseFile
+      )
+    }}
   </template>
 
   @consume(GetCardCollectionContextName)
   private declare getCardCollection: getCardCollection;
 
-  @tracked areAllItemsDisplayed = false;
   @tracked private cardCollection: ReturnType<getCardCollection> | undefined;
-
-  @action
-  private toggleViewAllAttachedCards() {
-    this.areAllItemsDisplayed = !this.areAllItemsDisplayed;
-  }
 
   private makeCardResources = () => {
     this.cardCollection = this.getCardCollection(this, () => this.cardIds);
-  };
-
-  private isCard = (item: CardDef | FileDef): item is CardDef => {
-    return isCardInstance(item);
-  };
-
-  private isAutoAttachedCard = (card: CardDef) => {
-    return this.args.autoAttachedCardIds?.has(card.id);
-  };
-
-  private isAutoAttachedFile = (file: FileDef) => {
-    return this.args.autoAttachedFile?.sourceUrl === file.sourceUrl;
   };
 
   private get items() {
@@ -247,50 +121,4 @@ export default class AiAssistantAttachmentPicker extends Component<Signature> {
 
     return files;
   }
-
-  private get itemsToDisplay() {
-    return this.areAllItemsDisplayed
-      ? this.items
-      : this.items.slice(0, MAX_ITEMS_TO_DISPLAY);
-  }
-
-  private get canDisplayAddButton() {
-    if (!this.args.maxNumberOfItemsToAttach || !this.args.cardIdsToAttach) {
-      return true;
-    }
-    return (
-      this.args.cardIdsToAttach.length < this.args.maxNumberOfItemsToAttach
-    );
-  }
-
-  @action
-  private chooseCard() {
-    this.chooseCardTask.perform();
-  }
-
-  private chooseCardTask = restartableTask(async () => {
-    let cardId = await chooseCard({
-      filter: { type: baseCardRef },
-    });
-    if (cardId) {
-      this.args.chooseCard(cardId);
-    }
-  });
-
-  @action
-  private async chooseFile() {
-    let file = await this.doChooseFile.perform();
-    if (file) {
-      this.args.chooseFile(file);
-    }
-  }
-
-  private doChooseFile = restartableTask(async () => {
-    let chosenFile: FileDef | undefined = await chooseFile();
-    return chosenFile;
-  });
-}
-
-function idFor(instance: CardDef) {
-  return instance.id ?? instance[localId];
 }

--- a/packages/host/app/components/ai-assistant/attachment-picker/usage.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/usage.gts
@@ -60,7 +60,6 @@ export default class AiAssistantCardPickerUsage extends Component {
           @removeCard={{this.removeCard}}
           @chooseFile={{this.chooseFile}}
           @removeFile={{this.removeFile}}
-          @maxNumberOfItemsToAttach={{this.maxNumberOfCards}}
           @autoAttachedFile={{this.autoAttachedFile}}
           @filesToAttach={{this.filesToAttach}}
           @submode='interact'

--- a/packages/host/app/components/ai-assistant/attachment-picker/usage.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/usage.gts
@@ -63,7 +63,11 @@ export default class AiAssistantCardPickerUsage extends Component {
           @autoAttachedFile={{this.autoAttachedFile}}
           @filesToAttach={{this.filesToAttach}}
           @submode='interact'
-        />
+          as |AttachedItems AttachButton|
+        >
+          <AttachedItems />
+          <AttachButton />
+        </AiAssistantAttachmentPicker>
         <CardCatalogModal />
       </:example>
       <:api as |Args|>

--- a/packages/host/app/components/ai-assistant/chat-input/index.gts
+++ b/packages/host/app/components/ai-assistant/chat-input/index.gts
@@ -35,7 +35,7 @@ export default class AiAssistantChatInput extends Component<Signature> {
         Enter text to chat with AI Assistant
       </label>
       {{#if @attachButton}}
-        <@attachButton @width='30' @height='30' />
+        <@attachButton />
       {{/if}}
       <BoxelInput
         class='chat-input'

--- a/packages/host/app/components/ai-assistant/chat-input/index.gts
+++ b/packages/host/app/components/ai-assistant/chat-input/index.gts
@@ -10,6 +10,10 @@ import { not } from '@cardstack/boxel-ui/helpers';
 import { Send } from '@cardstack/boxel-ui/icons';
 import { setCssVar } from '@cardstack/boxel-ui/modifiers';
 
+import AttachButton from '../attachment-picker/attach-button';
+
+import type { WithBoundArgs } from '@glint/template';
+
 interface Signature {
   Element: HTMLDivElement;
   Args: {
@@ -17,6 +21,10 @@ interface Signature {
     onInput: (val: string) => void;
     onSend: () => void;
     canSend: boolean;
+    attachButton?: WithBoundArgs<
+      typeof AttachButton,
+      'submode' | 'files' | 'cards' | 'chooseCard' | 'chooseFile'
+    >;
   };
 }
 
@@ -26,6 +34,9 @@ export default class AiAssistantChatInput extends Component<Signature> {
       <label for='ai-chat-input' class='boxel-sr-only'>
         Enter text to chat with AI Assistant
       </label>
+      {{#if @attachButton}}
+        <@attachButton @width='30' @height='30' />
+      {{/if}}
       <BoxelInput
         class='chat-input'
         @id='ai-chat-input'
@@ -54,7 +65,7 @@ export default class AiAssistantChatInput extends Component<Signature> {
     <style scoped>
       .chat-input-container {
         display: grid;
-        grid-template-columns: 1fr auto;
+        grid-template-columns: auto 1fr auto;
         gap: var(--boxel-sp-xxs);
         padding: var(--boxel-sp-xxs) var(--boxel-sp-xxs) var(--boxel-sp-xxs)
           var(--boxel-sp-xs);
@@ -83,7 +94,7 @@ export default class AiAssistantChatInput extends Component<Signature> {
         height: var(--boxel-icon-med);
         background-color: var(--boxel-highlight);
         border-radius: var(--boxel-border-radius-sm);
-        align-self: flex-end;
+        align-self: flex-start;
       }
       .send-button:hover:not(:disabled),
       .send-button:focus:not(:disabled) {
@@ -138,7 +149,7 @@ export default class AiAssistantChatInput extends Component<Signature> {
     const lineHeight = 20;
     const padding = 8;
     const minLines = 1;
-    const maxLines = 15;
+    const maxLines = 6;
 
     // Calculate actual line count from newlines in the content
     let newlineCount = (this.args.value.match(/\n/g) ?? []).length;

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -158,7 +158,7 @@ export default class Room extends Component<Signature> {
               'Current card is shared automatically'
               'Topmost card is shared automatically'
             }}
-            as |Pills AttachButton|
+            as |AttachedItems AttachButton|
           >
             <div class='chat-input-area' data-test-chat-input-area>
               <AiAssistantChatInput
@@ -169,11 +169,9 @@ export default class Room extends Component<Signature> {
                 @canSend={{this.canSend}}
                 data-test-message-field={{@roomId}}
               />
-              {{! TODO: Remove this bottom section after we move the attachment picker to chat input 
-                  and llm chooser to area__actions }}
-              <div class='chat-input-area__bottom-section'>
-                <Pills />
-              </div>
+              {{#if this.displayAttachedItems}}
+                <AttachedItems />
+              {{/if}}
 
               <div class='chat-input-area__actions'>
                 {{#if this.displaySkillMenu}}
@@ -231,16 +229,6 @@ export default class Room extends Component<Signature> {
         background-color: var(--boxel-light);
         border-radius: var(--boxel-border-radius);
         overflow: hidden;
-      }
-      .chat-input-area__bottom-section {
-        display: flex;
-        justify-content: space-between;
-        padding-right: var(--boxel-sp-xxs);
-        gap: var(--boxel-sp-xxl);
-      }
-      .chat-input-area__bottom-section
-        :deep(.ember-basic-dropdown-content-wormhole-origin) {
-        position: absolute; /* This prevents layout shift when menu opens */
       }
       .chat-input-area__actions {
         display: flex;
@@ -907,6 +895,15 @@ export default class Room extends Component<Signature> {
 
   private get displayLLMSelect() {
     return !this.selectedAction || this.selectedAction === 'llm-select';
+  }
+
+  private get displayAttachedItems() {
+    return (
+      this.filesToAttach?.length ||
+      this.cardIdsToAttach?.length ||
+      this.autoAttachedFile ||
+      this.autoAttachedCardIds?.size
+    );
   }
 }
 

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -143,61 +143,66 @@ export default class Room extends Component<Signature> {
         </AiAssistantConversation>
 
         <footer class='room-actions'>
-          <div class='chat-input-area' data-test-chat-input-area>
-            <AiAssistantChatInput
-              @value={{this.messageToSend}}
-              @onInput={{this.setMessage}}
-              @onSend={{this.sendMessage}}
-              @canSend={{this.canSend}}
-              data-test-message-field={{@roomId}}
-            />
-            {{! TODO: Remove this bottom section after we move the attachment picker to chat input 
-                  and llm chooser to area__actions }}
-            <div class='chat-input-area__bottom-section'>
-              <AiAssistantAttachmentPicker
-                @autoAttachedCardIds={{this.autoAttachedCardIds}}
-                @cardIdsToAttach={{this.cardIdsToAttach}}
-                @chooseCard={{this.chooseCard}}
-                @removeCard={{this.removeCard}}
-                @chooseFile={{this.chooseFile}}
-                @removeFile={{this.removeFile}}
-                @submode={{this.operatorModeStateService.state.submode}}
-                @autoAttachedFile={{this.autoAttachedFile}}
-                @filesToAttach={{this.filesToAttach}}
-                @autoAttachedCardTooltipMessage={{if
-                  (eq this.operatorModeStateService.state.submode Submodes.Code)
-                  'Current card is shared automatically'
-                  'Topmost card is shared automatically'
-                }}
+          <AiAssistantAttachmentPicker
+            @autoAttachedCardIds={{this.autoAttachedCardIds}}
+            @cardIdsToAttach={{this.cardIdsToAttach}}
+            @chooseCard={{this.chooseCard}}
+            @removeCard={{this.removeCard}}
+            @chooseFile={{this.chooseFile}}
+            @removeFile={{this.removeFile}}
+            @submode={{this.operatorModeStateService.state.submode}}
+            @autoAttachedFile={{this.autoAttachedFile}}
+            @filesToAttach={{this.filesToAttach}}
+            @autoAttachedCardTooltipMessage={{if
+              (eq this.operatorModeStateService.state.submode Submodes.Code)
+              'Current card is shared automatically'
+              'Topmost card is shared automatically'
+            }}
+            as |Pills AttachButton|
+          >
+            <div class='chat-input-area' data-test-chat-input-area>
+              <AiAssistantChatInput
+                @attachButton={{AttachButton}}
+                @value={{this.messageToSend}}
+                @onInput={{this.setMessage}}
+                @onSend={{this.sendMessage}}
+                @canSend={{this.canSend}}
+                data-test-message-field={{@roomId}}
               />
+              {{! TODO: Remove this bottom section after we move the attachment picker to chat input 
+                  and llm chooser to area__actions }}
+              <div class='chat-input-area__bottom-section'>
+                <Pills />
+              </div>
+
+              <div class='chat-input-area__actions'>
+                {{#if this.displaySkillMenu}}
+                  <AiAssistantSkillMenu
+                    class='skill-menu'
+                    @skills={{this.sortedSkills}}
+                    @onChooseCard={{perform this.attachSkillTask}}
+                    @onUpdateSkillIsActive={{perform
+                      this.updateSkillIsActiveTask
+                    }}
+                    @onExpand={{fn this.setSelectedAction 'skill-menu'}}
+                    @onCollapse={{fn this.setSelectedAction undefined}}
+                    data-test-skill-menu
+                  />
+                {{/if}}
+                {{#if this.displayLLMSelect}}
+                  <LLMSelect
+                    class='llm-select'
+                    @selected={{@roomResource.activeLLM}}
+                    @onChange={{perform @roomResource.activateLLMTask}}
+                    @options={{this.llmsForSelectMenu}}
+                    @disabled={{@roomResource.isActivatingLLM}}
+                    @onExpand={{fn this.setSelectedAction 'llm-select'}}
+                    @onCollapse={{fn this.setSelectedAction undefined}}
+                  />
+                {{/if}}
+              </div>
             </div>
-            <div class='chat-input-area__actions'>
-              {{#if this.displaySkillMenu}}
-                <AiAssistantSkillMenu
-                  class='skill-menu'
-                  @skills={{this.sortedSkills}}
-                  @onChooseCard={{perform this.attachSkillTask}}
-                  @onUpdateSkillIsActive={{perform
-                    this.updateSkillIsActiveTask
-                  }}
-                  @onExpand={{fn this.setSelectedAction 'skill-menu'}}
-                  @onCollapse={{fn this.setSelectedAction undefined}}
-                  data-test-skill-menu
-                />
-              {{/if}}
-              {{#if this.displayLLMSelect}}
-                <LLMSelect
-                  class='llm-select'
-                  @selected={{@roomResource.activeLLM}}
-                  @onChange={{perform @roomResource.activateLLMTask}}
-                  @options={{this.llmsForSelectMenu}}
-                  @disabled={{@roomResource.isActivatingLLM}}
-                  @onExpand={{fn this.setSelectedAction 'llm-select'}}
-                  @onCollapse={{fn this.setSelectedAction undefined}}
-                />
-              {{/if}}
-            </div>
-          </div>
+          </AiAssistantAttachmentPicker>
         </footer>
       </section>
     {{/if}}

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -526,7 +526,6 @@ module('Acceptance | AI Assistant tests', function (hooks) {
 
     await click('[data-test-open-ai-assistant]');
     await waitFor(`[data-room-settled]`);
-    assert.dom('[data-test-choose-file-btn]').hasText('Attach File');
 
     await click('[data-test-choose-file-btn]');
     assert.dom('[data-test-attach-file-modal]').exists();
@@ -591,8 +590,6 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     });
     await click('[data-test-open-ai-assistant]');
     await waitFor(`[data-room-settled]`);
-    assert.dom('[data-test-choose-file-btn]').hasText('Attach File');
-
     await click('[data-test-file="person.gts"]');
     assert.dom('[data-test-autoattached-file]').exists();
     assert.dom(`[data-test-autoattached-file]`).hasText('person.gts');

--- a/packages/host/tests/integration/components/ai-assistant-panel/sending-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/sending-test.gts
@@ -256,7 +256,7 @@ module('Integration | ai-assistant-panel | sending', function (hooks) {
       : 0;
 
     assert.true(
-      newHeight >= 300,
+      newHeight >= 130,
       'input box grows when entering/pasting lots of text',
     );
   });


### PR DESCRIPTION
In this PR, I updated the maximum height of the chat input to 136px. The requirement is actually 134px; however, it's a bit tricky since we calculate the height based on the maximum number of lines in the text area, so I think a 2px difference is acceptable. I also moved the attach button inline with the chat input, while the attached items remain in the same position.

Before:

<img width="398" alt="Screenshot 2025-06-12 at 15 24 11" src="https://github.com/user-attachments/assets/19f57922-4021-481f-8cbb-2bd3ed59c911" />


After:

<img width="375" alt="Screenshot 2025-06-12 at 15 17 19" src="https://github.com/user-attachments/assets/2059360f-a8d7-46cf-9dce-9d4de7608524" />
