### PR TITLE
Fix code patch filename when code patch belongs to a different realm

### DIFF
--- a/packages/host/app/components/ai-assistant/code-block.gts
+++ b/packages/host/app/components/ai-assistant/code-block.gts
@@ -500,10 +500,9 @@ class CodeBlockDiffEditor extends Component<Signature> {
 class CodeBlockHeader extends Component<CodeBlockHeaderSignature> {
   @service private declare operatorModeStateService: OperatorModeStateService;
   get fileName() {
-    let realmUrl = this.operatorModeStateService.realmURL.href;
-    let fileUrl = this.args.codeData.fileUrl;
-
-    return fileUrl?.replace(realmUrl, '');
+    return (
+      new URL(this.args.codeData.fileUrl ?? '').pathname.split('/').pop() || ''
+    );
   }
 
   <template>

--- a/packages/host/tests/integration/components/formatted-aibot-message-test.gts
+++ b/packages/host/tests/integration/components/formatted-aibot-message-test.gts
@@ -30,8 +30,6 @@ import {
 import CardService from '@cardstack/host/services/card-service';
 import MonacoService from '@cardstack/host/services/monaco-service';
 
-import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
-
 import { renderComponent } from '../../helpers/render-component';
 import { setupRenderingTest } from '../../helpers/setup';
 

--- a/packages/host/tests/integration/components/formatted-aibot-message-test.gts
+++ b/packages/host/tests/integration/components/formatted-aibot-message-test.gts
@@ -40,13 +40,13 @@ module('Integration | Component | FormattedAiBotMessage', function (hooks) {
 
   let monacoService: MonacoService;
   let cardService: CardService;
-  let operatorModeStateService: OperatorModeStateService;
+
   let roomId = '!abcd';
   let eventId = '1234';
 
   hooks.beforeEach(async function (this: RenderingTestContext) {
     monacoService = getService('monaco-service');
-    operatorModeStateService = getService('operator-mode-state-service');
+
     cardService = getService('card-service');
 
     cardService.getSource = async () => {
@@ -55,10 +55,6 @@ module('Integration | Component | FormattedAiBotMessage', function (hooks) {
         content: 'let a = 1;\nlet b = 2;',
       });
     };
-
-    (operatorModeStateService as any).cachedRealmURL = new URL(
-      'https://example.com/',
-    );
   });
 
   async function renderFormattedAiBotMessage(testScenario: any) {


### PR DESCRIPTION
Fixes a bug where the currently selected realm does not match the realm of the code patch file (this can happen if you do some work in the ai assistant in one realm and then switch to another one while keeping the AI assistant open). It was actually not a good decision to parse the file name like it was previously–it's totally sufficient to just take the file name from the url and be done with it)

The bug:

<img width="313" alt="image" src="https://github.com/user-attachments/assets/94d00e63-8e40-4a1a-bc42-a6f71bf1d1ef" />

Fixed:

<img width="296" alt="image" src="https://github.com/user-attachments/assets/735513f6-2ce2-46cb-aa58-2c34aea5801b" />

