### PR TITLE
reduce full index timeout to 3 minutes

### DIFF
--- a/packages/runtime-common/realm-index-updater.ts
+++ b/packages/runtime-common/realm-index-updater.ts
@@ -106,7 +106,7 @@ export class RealmIndexUpdater {
       let job = await this.#queue.publish<FromScratchResult>({
         jobType: `from-scratch-index`,
         concurrencyGroup: `indexing:${this.#realm.url}`,
-        timeout: 5 * 60,
+        timeout: 3 * 60,
         priority: systemInitiatedPriority,
         args,
       });


### PR DESCRIPTION
Based on analysis of current full-index run times in production, most full index jobs finish in 40 seconds or less. reducing the timeout to 3 minutes to save on worker resources