### PR TITLE
realm: Add HEAD support for card source requests

### DIFF
--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -469,8 +469,8 @@ export default class OperatorModeStateService extends Service {
 
     let response;
     try {
-      // TODO Change to HEAD in CS-8846
       response = await this.network.authedFetch(codePath, {
+        method: 'HEAD',
         headers: { Accept: SupportedMimeType.CardSource },
       });
 

--- a/packages/realm-server/tests/card-source-endpoints-test.ts
+++ b/packages/realm-server/tests/card-source-endpoints-test.ts
@@ -312,53 +312,6 @@ module(basename(__filename), function () {
           assert.strictEqual(response.headers['location'], '/person.gts');
         });
       });
-
-      module('permissioned realm', function (hooks) {
-        setupPermissionedRealm(hooks, {
-          permissions: {
-            john: ['read'],
-          },
-          onRealmSetup,
-        });
-
-        test('401 with invalid JWT', async function (assert) {
-          let response = await request
-            .head('/person.gts')
-            .set('Accept', 'application/vnd.card+source')
-            .set('Authorization', `Bearer invalid-token`);
-
-          assert.strictEqual(response.status, 401, 'HTTP 401 status');
-        });
-
-        test('401 without a JWT', async function (assert) {
-          let response = await request
-            .head('/person.gts')
-            .set('Accept', 'application/vnd.card+source'); // no Authorization header
-
-          assert.strictEqual(response.status, 401, 'HTTP 401 status');
-        });
-
-        test('403 without permission', async function (assert) {
-          let response = await request
-            .head('/person.gts')
-            .set('Accept', 'application/vnd.card+source')
-            .set('Authorization', `Bearer ${createJWT(testRealm, 'not-john')}`);
-
-          assert.strictEqual(response.status, 403, 'HTTP 403 status');
-        });
-
-        test('200 with permission', async function (assert) {
-          let response = await request
-            .head('/person.gts')
-            .set('Accept', 'application/vnd.card+source')
-            .set(
-              'Authorization',
-              `Bearer ${createJWT(testRealm, 'john', ['read'])}`,
-            );
-
-          assert.strictEqual(response.status, 200, 'HTTP 200 status');
-        });
-      });
     });
 
     module('card-source DELETE request', function (_hooks) {

--- a/packages/realm-server/tests/card-source-endpoints-test.ts
+++ b/packages/realm-server/tests/card-source-endpoints-test.ts
@@ -106,6 +106,25 @@ module(basename(__filename), function () {
           );
         });
 
+        test('serves a card-source HEAD request that results in redirect', async function (assert) {
+          let response = await request
+            .head('/person')
+            .set('Accept', 'application/vnd.card+source');
+
+          assert.strictEqual(response.status, 302, 'HTTP 302 status');
+          assert.strictEqual(
+            response.get('X-boxel-realm-url'),
+            testRealmHref,
+            'realm url header is correct',
+          );
+          assert.strictEqual(
+            response.get('X-boxel-realm-public-readable'),
+            'true',
+            'realm is public readable',
+          );
+          assert.strictEqual(response.headers['location'], '/person.gts');
+        });
+
         test('serves a card-source GET request that results in redirect', async function (assert) {
           let response = await request
             .get('/person')

--- a/packages/realm-server/tests/card-source-endpoints-test.ts
+++ b/packages/realm-server/tests/card-source-endpoints-test.ts
@@ -290,11 +290,7 @@ module(basename(__filename), function () {
             'true',
             'realm is public readable',
           );
-          assert.strictEqual(
-            response.text.trim(),
-            '',
-            'no body in HEAD response',
-          );
+          assert.notOk(response.text, 'no body in HEAD response');
         });
 
         test('serves a card-source HEAD request that results in redirect', async function (assert) {

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -369,6 +369,11 @@ export class Realm {
         SupportedMimeType.CardSource,
         this.upsertCardSource.bind(this),
       )
+      .head(
+        '/.*',
+        SupportedMimeType.CardSource,
+        this.getSourceOrRedirect.bind(this),
+      )
       .get(
         '/.*',
         SupportedMimeType.CardSource,
@@ -386,10 +391,12 @@ export class Realm {
       );
 
     Object.values(SupportedMimeType).forEach((mimeType) => {
-      this.#router.head('/.*', mimeType as SupportedMimeType, async () => {
-        let requestContext = await this.createRequestContext();
-        return createResponse({ init: { status: 200 }, requestContext });
-      });
+      if (mimeType !== SupportedMimeType.CardSource) {
+        this.#router.head('/.*', mimeType as SupportedMimeType, async () => {
+          let requestContext = await this.createRequestContext();
+          return createResponse({ init: { status: 200 }, requestContext });
+        });
+      }
     });
   }
 


### PR DESCRIPTION
This is an improvement for #2704 to avoid fetching module bodies twice.