### PR TITLE
Requires approval on catalog listing skill command

### DIFF
--- a/packages/base/Skill/catalog-listing.json
+++ b/packages/base/Skill/catalog-listing.json
@@ -9,21 +9,21 @@
             "name": "default",
             "module": "@cardstack/boxel-host/commands/listing-use"
           },
-          "requiresApproval": false
+          "requiresApproval": true
         },
         {
           "codeRef": {
             "name": "default",
             "module": "@cardstack/boxel-host/commands/listing-install"
           },
-          "requiresApproval": false
+          "requiresApproval": true
         },
         {
           "codeRef": {
             "name": "default",
             "module": "@cardstack/boxel-host/commands/listing-remix"
           },
-          "requiresApproval": false
+          "requiresApproval": true
         }
       ],
       "title": "Catalog Listing",


### PR DESCRIPTION
Refer to https://linear.app/cardstack/issue/CS-8870/requires-approval-on-catalog-listing-skill-command

Make catalog listing action - eg. remix command requires approval instead of running automatically

<img width="380" alt="Screenshot 2025-06-17 at 6 12 54 PM" src="https://github.com/user-attachments/assets/e652bcf9-c77d-4ac5-b466-02a126647d64" />
