### PR TITLE
Fix path normalize in listing install

### DIFF
--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -52,6 +52,10 @@ export class CopySourceInput extends CardDef {
   @field toRealmUrl = contains(StringField);
 }
 
+export class CopySourceResult extends CardDef {
+  @field url = contains(StringField);
+}
+
 export class PatchCardInput extends CardDef {
   @field cardId = contains(StringField);
   @field patch = contains(JsonField);

--- a/packages/catalog-realm/catalog-app/listing/listing.gts
+++ b/packages/catalog-realm/catalog-app/listing/listing.gts
@@ -468,7 +468,8 @@ export class Listing extends CardDef {
   @field tags = linksToMany(() => Tag);
   @field license = linksTo(() => License);
   @field images = containsMany(StringField);
-  @field examples = linksToMany(CardDef);
+  @field examples = linksToMany(() => CardDef);
+  @field skills = linksToMany(() => Skill);
 
   @field title = contains(StringField, {
     computeVia(this: Listing) {
@@ -495,7 +496,6 @@ export class FieldListing extends Listing {
 
 export class SkillListing extends Listing {
   static displayName = 'SkillListing';
-  @field skills = linksToMany(() => Skill);
 }
 
 function specBreakdown(specs: Spec[]): Record<SpecType, Spec[]> {

--- a/packages/host/app/commands/copy-source.ts
+++ b/packages/host/app/commands/copy-source.ts
@@ -31,5 +31,6 @@ export default class CopySourceCommand extends HostBaseCommand<
     if (r.ok && r.url) {
       return new CopySourceResult({ url: r.url });
     }
+    return new CopySourceResult({});
   }
 }

--- a/packages/host/app/commands/copy-source.ts
+++ b/packages/host/app/commands/copy-source.ts
@@ -7,7 +7,8 @@ import HostBaseCommand from '../lib/host-base-command';
 import type CardService from '../services/card-service';
 
 export default class CopySourceCommand extends HostBaseCommand<
-  typeof BaseCommandModule.CopySourceInput
+  typeof BaseCommandModule.CopySourceInput,
+  typeof BaseCommandModule.CopySourceResult
 > {
   @service declare private cardService: CardService;
 
@@ -21,9 +22,14 @@ export default class CopySourceCommand extends HostBaseCommand<
 
   protected async run(
     input: BaseCommandModule.CopySourceInput,
-  ): Promise<undefined> {
+  ): Promise<BaseCommandModule.CopySourceResult> {
     const fromRealmUrl = new URL(input.fromRealmUrl);
     const toRealmUrl = new URL(input.toRealmUrl);
-    await this.cardService.copySource(fromRealmUrl, toRealmUrl);
+    let r = await this.cardService.copySource(fromRealmUrl, toRealmUrl);
+    let commandModule = await this.loadCommandModule();
+    const { CopySourceResult } = commandModule;
+    if (r.ok && r.url) {
+      return new CopySourceResult({ url: r.url });
+    }
   }
 }

--- a/packages/host/app/commands/listing-install.ts
+++ b/packages/host/app/commands/listing-install.ts
@@ -2,18 +2,22 @@ import { service } from '@ember/service';
 
 import {
   type ResolvedCodeRef,
-  codeRefWithAbsoluteURL,
-  isResolvedCodeRef,
-  type CopyCardsWithCodeRef,
   type Command,
-  listingNameWithUuid,
+  CommandContext,
   RealmPaths,
+  join,
+  type InstallPlan,
+  InstallOptions,
+  planModuleInstall,
+  planInstanceInstall,
+  PlanBuilder,
+  LocalPath,
 } from '@cardstack/runtime-common';
+
+import { logger } from '@cardstack/runtime-common';
 
 import * as CardAPI from 'https://cardstack.com/base/card-api';
 import * as BaseCommandModule from 'https://cardstack.com/base/command';
-
-import type { Skill } from 'https://cardstack.com/base/skill';
 
 import HostBaseCommand from '../lib/host-base-command';
 
@@ -23,10 +27,7 @@ import CopySourceCommand from './copy-source';
 import type RealmServerService from '../services/realm-server';
 import type { Listing } from '@cardstack/catalog/listing/listing';
 
-interface CopyMeta {
-  sourceCodeRef: ResolvedCodeRef;
-  targetCodeRef: ResolvedCodeRef;
-}
+const log = logger('catalog:install');
 
 interface InstallListingInput {
   realmUrl: string;
@@ -41,125 +42,93 @@ interface InstallListingResult {
   selectedCodeRef?: ResolvedCodeRef;
   shouldPersistPlaygroundSelection: boolean;
   firstExampleCardId?: string;
-  skillCardIds?: string[];
+  firstSkillCardId?: string;
+}
+
+interface InstallResults {
+  modules: string[];
+  instances: string[];
+}
+
+async function install(
+  plan: InstallPlan,
+  opts: InstallOptions,
+  commandContext: CommandContext,
+): Promise<InstallResults> {
+  let r: InstallResults = {
+    modules: [],
+    instances: [],
+  };
+  for (const { sourceCodeRef, targetCodeRef } of plan.modulesCopy) {
+    let { url } = await new CopySourceCommand(commandContext).execute({
+      fromRealmUrl: sourceCodeRef.module,
+      toRealmUrl: targetCodeRef.module,
+    });
+    r.modules.push(url);
+  }
+
+  for (const { sourceCard, localDir, targetCodeRef } of plan.instancesCopy) {
+    let { newCardId } = await new CopyCardCommand(commandContext).execute({
+      sourceCard,
+      realm: opts.targetRealm,
+      localDir,
+      codeRef: targetCodeRef,
+    });
+    r.instances.push(newCardId);
+  }
+  return r;
 }
 
 export async function installListing({
   realmUrl,
   listing,
   commandContext,
-  cardAPI,
 }: InstallListingInput): Promise<InstallListingResult> {
-  const copyMeta: CopyMeta[] = [];
+  let installOpts = new InstallOptions(realmUrl, listing);
 
-  const localDir = listingNameWithUuid(listing.name);
-
-  // first spec as the selected code ref with new url
-  // if there are examples, take the first example's code ref
-  let selectedCodeRef;
+  // side-effects
   let shouldPersistPlaygroundSelection = false;
-  let firstExampleCardId;
+  let firstExampleCardId: string | undefined;
+  let selectedCodeRef: ResolvedCodeRef | undefined;
+  let skillLocalDir: LocalPath | undefined;
 
-  // Copy the gts file based on the attached spec's moduleHref
-  for (const spec of listing.specs ?? []) {
-    const absoluteModulePath = spec.moduleHref;
-    const relativeModulePath = spec.ref.module;
-    const normalizedPath = relativeModulePath.split('/').slice(2).join('/');
-    const newPath = localDir.concat('/').concat(normalizedPath);
-    const fileTargetUrl = new URL(newPath, realmUrl).href;
-    const targetFilePath = fileTargetUrl.concat('.gts');
+  const builder = new PlanBuilder(installOpts);
 
-    await new CopySourceCommand(commandContext).execute({
-      fromRealmUrl: absoluteModulePath,
-      toRealmUrl: targetFilePath,
+  builder
+    .addIf(listing.specs?.length > 0, (opts) => {
+      let r = planModuleInstall(listing.specs, opts);
+      selectedCodeRef = r.modulesCopy[0].targetCodeRef;
+      shouldPersistPlaygroundSelection = true;
+      return r;
+    })
+    .addIf(listing.examples?.length > 0, (opts) => {
+      let r = planInstanceInstall(listing.examples, opts);
+      firstExampleCardId = r.instancesCopy[0].sourceCard.id;
+      return r;
+    })
+    .addIf(listing.skills?.length > 0, (opts) => {
+      let r = planInstanceInstall(listing.skills, opts);
+      skillLocalDir = r.instancesCopy[0].localDir;
+      return r;
     });
 
-    copyMeta.push({
-      sourceCodeRef: {
-        module: absoluteModulePath,
-        name: spec.ref.name,
-      },
-      targetCodeRef: {
-        module: fileTargetUrl,
-        name: spec.ref.name,
-      },
-    });
+  const finalPlan = builder.build();
+  let results = await install(finalPlan, installOpts, commandContext);
+  log.debug('=== Final Results ===');
+  log.debug(JSON.stringify(results, null, 2));
 
-    if (!selectedCodeRef) {
-      selectedCodeRef = {
-        module: fileTargetUrl,
-        name: spec.ref.name,
-      };
-    }
-  }
-
-  if (listing.examples) {
-    // Create serialized objects for each example with modified adoptsFrom
-    const results = listing.examples.map((instance) => {
-      let adoptsFrom = instance[cardAPI.meta]?.adoptsFrom;
-      if (!adoptsFrom) {
-        return null;
-      }
-      let exampleCodeRef = instance.id
-        ? codeRefWithAbsoluteURL(adoptsFrom, new URL(instance.id))
-        : adoptsFrom;
-      if (!isResolvedCodeRef(exampleCodeRef)) {
-        throw new Error('exampleCodeRef is NOT resolved');
-      }
-      let maybeCopyMeta = copyMeta.find(
-        (meta) =>
-          meta.sourceCodeRef.module ===
-            (exampleCodeRef as ResolvedCodeRef).module &&
-          meta.sourceCodeRef.name === (exampleCodeRef as ResolvedCodeRef).name,
-      );
-      if (maybeCopyMeta) {
-        if (!shouldPersistPlaygroundSelection) {
-          selectedCodeRef = maybeCopyMeta.targetCodeRef;
-          shouldPersistPlaygroundSelection = true;
-        }
-
-        return {
-          sourceCard: instance,
-          codeRef: maybeCopyMeta.targetCodeRef,
-        };
-      }
-      return null;
-    });
-    const copyCardsWithCodeRef = results.filter(
-      (result) => result !== null,
-    ) as CopyCardsWithCodeRef[];
-    for (const cardWithNewCodeRef of copyCardsWithCodeRef) {
-      const { newCardId } = await new CopyCardCommand(commandContext).execute({
-        sourceCard: cardWithNewCodeRef.sourceCard,
-        realm: realmUrl,
-        localDir,
-        codeRef: cardWithNewCodeRef.codeRef,
-      });
-      if (!firstExampleCardId) {
-        firstExampleCardId = newCardId;
-      }
-    }
-  }
-
-  let skillCardIds: string[] | undefined;
-  if ('skills' in listing && Array.isArray(listing.skills)) {
-    let results = await Promise.all(
-      listing.skills.map((skill: Skill) => {
-        return new CopyCardCommand(commandContext).execute({
-          sourceCard: skill,
-          realm: realmUrl,
-          localDir,
-        });
-      }),
-    );
-    skillCardIds = results.map((r) => r.newCardId);
-  }
+  let firstSkillCardId = skillLocalDir
+    ? results.instances.find((id) => {
+        let root = join(realmUrl, skillLocalDir ?? '');
+        return new RealmPaths(new URL(root)).inRealm(new URL(id));
+      })
+    : undefined;
 
   return {
     selectedCodeRef,
     shouldPersistPlaygroundSelection,
     firstExampleCardId,
-    skillCardIds,
+    firstSkillCardId,
   };
 }
 

--- a/packages/host/app/commands/listing-remix.ts
+++ b/packages/host/app/commands/listing-remix.ts
@@ -66,7 +66,7 @@ export default class RemixCommand extends HostBaseCommand<
       selectedCodeRef,
       shouldPersistPlaygroundSelection,
       firstExampleCardId,
-      skillCardIds,
+      firstSkillCardId,
     } = await installListing({
       realmUrl,
       listing,
@@ -74,7 +74,7 @@ export default class RemixCommand extends HostBaseCommand<
       cardAPI,
     });
     if (selectedCodeRef && isResolvedCodeRef(selectedCodeRef)) {
-      const codePath = selectedCodeRef.module.concat('.gts');
+      const codePath = selectedCodeRef.module;
       if (shouldPersistPlaygroundSelection && firstExampleCardId) {
         const moduleId = [selectedCodeRef.module, selectedCodeRef.name].join(
           '/',
@@ -113,8 +113,6 @@ export default class RemixCommand extends HostBaseCommand<
     } else if ('skills' in listing) {
       // A listing can have more than one skill
       // The most optimum way for remixing is still to display only the first instance
-      let firstSkillCardId =
-        skillCardIds && skillCardIds.length > 0 ? skillCardIds[0] : undefined;
       if (firstSkillCardId) {
         await new SwitchSubmodeCommand(this.commandContext).execute({
           submode: 'code',

--- a/packages/host/app/commands/listing-use.ts
+++ b/packages/host/app/commands/listing-use.ts
@@ -4,7 +4,7 @@ import {
   codeRefWithAbsoluteURL,
   isResolvedCodeRef,
   loadCardDef,
-  listingNameWithUuid,
+  generateInstallFolderName,
   RealmPaths,
 } from '@cardstack/runtime-common';
 
@@ -54,7 +54,7 @@ export default class ListingUseCommand extends HostBaseCommand<
       (spec) => spec.specType !== 'field',
     );
 
-    const localDir = listingNameWithUuid(listing.name);
+    const localDir = generateInstallFolderName(listing.name);
 
     for (const spec of specsWithoutFields) {
       if (spec.isComponent) {

--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -213,8 +213,7 @@ export default class CardService extends Service {
     });
 
     const content = await response.text();
-    await this.saveSource(toUrl, content, 'copy');
-    return response;
+    return await this.saveSource(toUrl, content, 'copy');
   }
 
   async deleteSource(url: URL) {

--- a/packages/host/tests/acceptance/catalog-app-test.gts
+++ b/packages/host/tests/acceptance/catalog-app-test.gts
@@ -48,7 +48,7 @@ const authorCardSource = `
 `;
 
 let matrixRoomId: string;
-module('Acceptance | catalog app tests', function (hooks) {
+module('Acceptance | Catalog | catalog app tests', function (hooks) {
   setupApplicationTest(hooks);
   setupLocalIndexing(hooks);
   setupOnSave(hooks);
@@ -578,7 +578,7 @@ module('Acceptance | catalog app tests', function (hooks) {
          */
         // When I install the listing into my selected realm, it should be:
         /*
-         * contact-link-[uuid]/contact-link.gts
+         * contact-link-[uuid]/fields/contact-link.gts
          */
 
         const listingName = 'contact-link';
@@ -606,8 +606,9 @@ module('Acceptance | catalog app tests', function (hooks) {
         if (outerFolder) {
           await openDir(assert, outerFolder);
         }
-        let gtsFilePath = outerFolder + 'contact-link.gts';
-        // contact-link-[uuid]/contact-link.gts
+        await openDir(assert, `${outerFolder}fields/`);
+        let gtsFilePath = `${outerFolder}fields/contact-link.gts`;
+        // contact-link-[uuid]/fields/contact-link.gts
         await verifyFileInFileTree(assert, gtsFilePath);
       });
 

--- a/packages/host/tests/unit/plan-install-test.ts
+++ b/packages/host/tests/unit/plan-install-test.ts
@@ -1,0 +1,837 @@
+import { module, test } from 'qunit';
+
+import {
+  PlanBuilder,
+  planModuleInstall,
+  planInstanceInstall,
+  realmURL,
+  InstallOptions,
+  meta,
+} from '@cardstack/runtime-common';
+
+import type { Spec } from 'https://cardstack.com/base/spec';
+import type { CardDef } from 'https://cardstack.com/base/card-api';
+
+const sourceRealmURL = new URL('https://localhost:4201/catalog/');
+const targetRealmURL = new URL('https://localhost:4201/experiments/');
+const baseRealmURL = new URL('https://cardstack.com/base/');
+
+module('Unit | Catalog | Install Plan Builder', function () {
+  module('planModuleInstall()', function () {
+    test('specs are in same organizing folder', function (assert) {
+      const specs = [
+        {
+          ref: { name: 'Some Ref Name' },
+          moduleHref: `${sourceRealmURL.href}some-folder/some`,
+          [realmURL]: sourceRealmURL,
+        },
+        {
+          ref: { name: 'Some Ref Name 2' },
+          moduleHref: `${sourceRealmURL.href}some-folder/some-2`,
+          [realmURL]: sourceRealmURL,
+        },
+      ] as Spec[];
+      const listing = {
+        name: 'Some Folder',
+        specs,
+        examples: [],
+        skills: [],
+        [realmURL]: sourceRealmURL,
+      } as any;
+      const { modulesCopy } = planModuleInstall(
+        specs,
+        new InstallOptions(targetRealmURL.href, listing, 'xyz'),
+      );
+
+      assert.strictEqual(modulesCopy.length, 2);
+      assert.deepEqual(modulesCopy[0], {
+        sourceCodeRef: {
+          name: 'Some Ref Name',
+          module: `${sourceRealmURL.href}some-folder/some`,
+        },
+        targetCodeRef: {
+          name: 'Some Ref Name',
+          module: `${targetRealmURL}some-folder-xyz/some.gts`,
+        },
+      });
+
+      assert.deepEqual(modulesCopy[1], {
+        sourceCodeRef: {
+          name: 'Some Ref Name 2',
+          module: `${sourceRealmURL.href}some-folder/some-2`,
+        },
+        targetCodeRef: {
+          name: 'Some Ref Name 2',
+          module: `${targetRealmURL}some-folder-xyz/some-2.gts`,
+        },
+      });
+    });
+
+    test('listing name not provided & specs are in root of realm', function (assert) {
+      const specs = [
+        {
+          ref: { name: 'Some Ref Name' },
+          moduleHref: `${sourceRealmURL.href}some`,
+          [realmURL]: sourceRealmURL,
+        },
+        {
+          ref: { name: 'Some Ref Name 2' },
+          moduleHref: `${sourceRealmURL.href}some-2`,
+          [realmURL]: sourceRealmURL,
+        },
+      ] as Spec[];
+
+      const listing = {
+        specs,
+        examples: [],
+        skills: [],
+        [realmURL]: sourceRealmURL,
+      } as any;
+      const { modulesCopy } = planModuleInstall(
+        specs,
+        new InstallOptions(targetRealmURL.href, listing, 'xyz'),
+      );
+
+      assert.strictEqual(modulesCopy.length, 2);
+      assert.deepEqual(modulesCopy[0], {
+        sourceCodeRef: {
+          name: 'Some Ref Name',
+          module: `${sourceRealmURL.href}some`,
+        },
+        targetCodeRef: {
+          name: 'Some Ref Name',
+          module: `${targetRealmURL}xyz/some.gts`,
+        },
+      });
+      assert.deepEqual(modulesCopy[1], {
+        sourceCodeRef: {
+          name: 'Some Ref Name 2',
+          module: `${sourceRealmURL.href}some-2`,
+        },
+        targetCodeRef: {
+          name: 'Some Ref Name 2',
+          module: `${targetRealmURL}xyz/some-2.gts`,
+        },
+      });
+    });
+
+    test('listing name not provided & specs are in same organizing folder', function (assert) {
+      const specs = [
+        {
+          ref: { name: 'Some Ref Name' },
+          moduleHref: `${sourceRealmURL.href}some-folder/some`,
+          [realmURL]: sourceRealmURL,
+        },
+        {
+          ref: { name: 'Some Ref Name 2' },
+          moduleHref: `${sourceRealmURL.href}some-folder/some-2`,
+          [realmURL]: sourceRealmURL,
+        },
+      ] as Spec[];
+      const listing = {
+        specs,
+        examples: [],
+        skills: [],
+        [realmURL]: sourceRealmURL,
+      } as any;
+      const { modulesCopy } = planModuleInstall(
+        specs,
+        new InstallOptions(targetRealmURL.href, listing, 'xyz'),
+      );
+      assert.strictEqual(modulesCopy.length, 2);
+      assert.deepEqual(modulesCopy[0], {
+        sourceCodeRef: {
+          name: 'Some Ref Name',
+          module: `${sourceRealmURL.href}some-folder/some`,
+        },
+        targetCodeRef: {
+          name: 'Some Ref Name',
+          module: `${targetRealmURL}xyz/some-folder/some.gts`,
+        },
+      });
+      assert.deepEqual(modulesCopy[1], {
+        sourceCodeRef: {
+          name: 'Some Ref Name 2',
+          module: `${sourceRealmURL.href}some-folder/some-2`,
+        },
+        targetCodeRef: {
+          name: 'Some Ref Name 2',
+          module: `${targetRealmURL}xyz/some-folder/some-2.gts`,
+        },
+      });
+    });
+
+    test('listing name not provided & specs are in separate organizing folders', function (assert) {
+      const specs = [
+        {
+          ref: { name: 'Some Ref Name' },
+          moduleHref: `${sourceRealmURL.href}some-folder/some`,
+          [realmURL]: sourceRealmURL,
+        },
+        {
+          ref: { name: 'Some Ref Name 2' },
+          moduleHref: `${sourceRealmURL.href}some-folder-2/some-2`,
+          [realmURL]: sourceRealmURL,
+        },
+      ] as Spec[];
+
+      const listing = {
+        // note: we never provide listing name
+        specs,
+        examples: [],
+        skills: [],
+        [realmURL]: sourceRealmURL,
+      } as any;
+      const { modulesCopy } = planModuleInstall(
+        specs,
+        new InstallOptions(targetRealmURL.href, listing, 'xyz'),
+      );
+
+      assert.strictEqual(modulesCopy.length, 2);
+      assert.deepEqual(modulesCopy[0], {
+        sourceCodeRef: {
+          name: 'Some Ref Name',
+          module: `${sourceRealmURL.href}some-folder/some`,
+        },
+        targetCodeRef: {
+          name: 'Some Ref Name',
+          module: `${targetRealmURL}xyz/some-folder/some.gts`,
+        },
+      });
+      assert.deepEqual(modulesCopy[1], {
+        sourceCodeRef: {
+          name: 'Some Ref Name 2',
+          module: `${sourceRealmURL.href}some-folder-2/some-2`,
+        },
+        targetCodeRef: {
+          name: 'Some Ref Name 2',
+          module: `${targetRealmURL}xyz/some-folder-2/some-2.gts`,
+        },
+      });
+    });
+
+    test('specs are outside organizing folder', function (assert) {
+      const specs = [
+        {
+          ref: { name: 'Some Ref Name' },
+          moduleHref: `${sourceRealmURL.href}some-other-folder/some`,
+          [realmURL]: sourceRealmURL,
+        },
+      ] as Spec[];
+      const listing = {
+        name: 'Some Folder',
+        specs,
+        examples: [],
+        skills: [],
+        [realmURL]: sourceRealmURL,
+      } as any;
+      let { modulesCopy } = planModuleInstall(
+        specs,
+        new InstallOptions(targetRealmURL.href, listing, 'xyz'),
+      );
+      assert.deepEqual(modulesCopy[0], {
+        sourceCodeRef: {
+          name: 'Some Ref Name',
+          module: `${sourceRealmURL.href}some-other-folder/some`,
+        },
+        targetCodeRef: {
+          name: 'Some Ref Name',
+          module: `${targetRealmURL}some-folder-xyz/some-other-folder/some.gts`,
+        },
+      });
+    });
+  });
+
+  module('planInstanceInstall()', function () {
+    test('instance adoptsFrom code in an organizing folder', function (assert) {
+      const instances = [
+        {
+          id: `${sourceRealmURL.href}some-folder/Example/1`,
+          [meta]: {
+            adoptsFrom: {
+              name: 'Some Ref Name',
+              module: `${sourceRealmURL.href}some-folder/some`,
+            },
+          },
+          [realmURL]: sourceRealmURL,
+        },
+      ] as CardDef[];
+      const listing = {
+        name: 'Some Folder',
+        specs: [],
+        examples: instances,
+        skills: [],
+        [realmURL]: sourceRealmURL,
+      } as any;
+      let { modulesCopy, instancesCopy } = planInstanceInstall(
+        instances,
+        new InstallOptions(targetRealmURL.href, listing, 'xyz'),
+      );
+      assert.strictEqual(modulesCopy.length, 1);
+      assert.strictEqual(instancesCopy.length, 1);
+      assert.deepEqual(modulesCopy[0], {
+        sourceCodeRef: {
+          name: 'Some Ref Name',
+          module: `${sourceRealmURL.href}some-folder/some`,
+        },
+        targetCodeRef: {
+          name: 'Some Ref Name',
+          module: `${targetRealmURL}some-folder-xyz/some.gts`,
+        },
+      });
+      assert.strictEqual(instancesCopy[0].localDir, 'some-folder-xyz');
+      assert.deepEqual(instancesCopy[0].targetCodeRef, {
+        name: 'Some Ref Name',
+        module: `${targetRealmURL}some-folder-xyz/some.gts`,
+      });
+    });
+    test('listing name not provided & instance adoptsFrom code in an organizing folder', function (assert) {
+      const instances = [
+        {
+          id: `${sourceRealmURL.href}some-folder/Example/1`,
+          [meta]: {
+            adoptsFrom: {
+              name: 'Some Ref Name',
+              module: `${sourceRealmURL.href}some-folder/some`,
+            },
+          },
+          [realmURL]: sourceRealmURL,
+        },
+      ] as CardDef[];
+      const listing = {
+        specs: [],
+        examples: instances,
+        skills: [],
+        [realmURL]: sourceRealmURL,
+      } as any;
+      let { modulesCopy, instancesCopy } = planInstanceInstall(
+        instances,
+        new InstallOptions(targetRealmURL.href, listing, 'xyz'),
+      );
+      assert.strictEqual(modulesCopy.length, 1);
+      assert.strictEqual(instancesCopy.length, 1);
+      assert.deepEqual(modulesCopy[0], {
+        sourceCodeRef: {
+          name: 'Some Ref Name',
+          module: `${sourceRealmURL.href}some-folder/some`,
+        },
+        targetCodeRef: {
+          name: 'Some Ref Name',
+          module: `${targetRealmURL}xyz/some-folder/some.gts`,
+        },
+      });
+
+      assert.strictEqual(instancesCopy[0].localDir, 'xyz');
+      assert.deepEqual(instancesCopy[0].targetCodeRef, {
+        name: 'Some Ref Name',
+        module: `${targetRealmURL}xyz/some-folder/some.gts`,
+      });
+    });
+    test('listing name not provided & instance adoptsFrom code inside root of realm', function (assert) {
+      const instances = [
+        {
+          id: `${sourceRealmURL.href}Example/1`,
+          [meta]: {
+            adoptsFrom: {
+              name: 'Some Ref Name',
+              module: `${sourceRealmURL.href}some`,
+            },
+          },
+          [realmURL]: sourceRealmURL,
+        },
+      ] as CardDef[];
+      const listing = {
+        specs: [],
+        examples: instances,
+        skills: [],
+        [realmURL]: sourceRealmURL,
+      } as any;
+      let { modulesCopy, instancesCopy } = planInstanceInstall(
+        instances,
+        new InstallOptions(targetRealmURL.href, listing, 'xyz'),
+      );
+      assert.strictEqual(modulesCopy.length, 1);
+      assert.strictEqual(instancesCopy.length, 1);
+      assert.deepEqual(modulesCopy[0], {
+        sourceCodeRef: {
+          name: 'Some Ref Name',
+          module: `${sourceRealmURL.href}some`,
+        },
+        targetCodeRef: {
+          name: 'Some Ref Name',
+          module: `${targetRealmURL}xyz/some.gts`,
+        },
+      });
+      assert.strictEqual(instancesCopy[0].localDir, `xyz`);
+      assert.deepEqual(instancesCopy[0].targetCodeRef, {
+        name: 'Some Ref Name',
+        module: `${targetRealmURL}xyz/some.gts`,
+      });
+    });
+
+    test('instance adoptsFrom from code inside base realm', function (assert) {
+      const instances = [
+        {
+          id: `${sourceRealmURL.href}some-folder/Example/1`,
+          [meta]: {
+            adoptsFrom: {
+              name: 'Some Ref Name',
+              module: `${baseRealmURL}skill`,
+            },
+          },
+          [realmURL]: sourceRealmURL,
+        },
+      ] as CardDef[];
+      const listing = {
+        name: 'Some Folder',
+        specs: [],
+        examples: instances,
+        skills: [],
+        [realmURL]: sourceRealmURL,
+      } as any;
+      let { modulesCopy, instancesCopy } = planInstanceInstall(
+        instances,
+        new InstallOptions(targetRealmURL.href, listing, 'xyz'),
+      );
+      assert.strictEqual(modulesCopy.length, 0);
+      assert.strictEqual(instancesCopy[0].localDir, 'some-folder-xyz');
+      assert.strictEqual(instancesCopy[0].targetCodeRef, undefined);
+    });
+    test('listing name is not provided & instance adoptsFrom code that is outside of organizing folder', function (assert) {
+      const instances = [
+        {
+          id: `${sourceRealmURL.href}Example/1`,
+          [meta]: {
+            adoptsFrom: {
+              name: 'Some Ref Name',
+              module: `${sourceRealmURL.href}some-folder/some`,
+            },
+          },
+          [realmURL]: sourceRealmURL,
+        },
+      ] as CardDef[];
+      const listing = {
+        specs: [],
+        examples: instances,
+        skills: [],
+        [realmURL]: sourceRealmURL,
+      } as any;
+      let { modulesCopy, instancesCopy } = planInstanceInstall(
+        instances,
+        new InstallOptions(targetRealmURL.href, listing, 'xyz'),
+      );
+      assert.strictEqual(modulesCopy.length, 1);
+      assert.deepEqual(modulesCopy[0], {
+        sourceCodeRef: {
+          name: 'Some Ref Name',
+          module: `${sourceRealmURL.href}some-folder/some`,
+        },
+        targetCodeRef: {
+          name: 'Some Ref Name',
+          module: `${targetRealmURL}xyz/some-folder/some.gts`,
+        },
+      });
+      assert.strictEqual(instancesCopy[0].localDir, `xyz`);
+      assert.deepEqual(instancesCopy[0].targetCodeRef, {
+        name: 'Some Ref Name',
+        module: `${targetRealmURL}xyz/some-folder/some.gts`,
+      });
+    });
+
+    test('instance adoptsFrom code outside of organizing folder', function (assert) {
+      const instances = [
+        {
+          id: `${sourceRealmURL.href}some-folder/Example/1`,
+          [meta]: {
+            adoptsFrom: {
+              name: 'Some Ref Name',
+              module: `${sourceRealmURL.href}some-folder-2/some`,
+            },
+          },
+          [realmURL]: sourceRealmURL,
+        },
+      ] as CardDef[];
+      const listing = {
+        name: 'Some Folder',
+        specs: [],
+        examples: instances,
+        skills: [],
+        [realmURL]: sourceRealmURL,
+      } as any;
+      let { modulesCopy, instancesCopy } = planInstanceInstall(
+        instances,
+        new InstallOptions(targetRealmURL.href, listing, 'xyz'),
+      );
+      assert.strictEqual(modulesCopy.length, 1);
+      assert.deepEqual(modulesCopy[0], {
+        sourceCodeRef: {
+          name: 'Some Ref Name',
+          module: `${sourceRealmURL.href}some-folder-2/some`,
+        },
+        targetCodeRef: {
+          name: 'Some Ref Name',
+          module: `${targetRealmURL}some-folder-xyz/some-folder-2/some.gts`,
+        },
+      });
+      assert.strictEqual(instancesCopy[0].localDir, `some-folder-xyz`);
+      assert.deepEqual(instancesCopy[0].targetCodeRef, {
+        name: 'Some Ref Name',
+        module: `${targetRealmURL}some-folder-xyz/some-folder-2/some.gts`,
+      });
+    });
+
+    test('more than one instances adoptsFrom code in separate organizing folder', function (assert) {
+      const instances = [
+        {
+          id: `${sourceRealmURL.href}some-folder/Example/1`,
+          [meta]: {
+            adoptsFrom: {
+              name: 'Some Ref Name',
+              module: `${sourceRealmURL.href}some-folder/some`,
+            },
+          },
+          [realmURL]: sourceRealmURL,
+        },
+        {
+          id: `${sourceRealmURL.href}some-folder/Example/2`,
+          [meta]: {
+            adoptsFrom: {
+              name: 'Some Ref Name',
+              module: `${sourceRealmURL.href}some-folder-2/some-2`,
+            },
+          },
+          [realmURL]: sourceRealmURL,
+        },
+      ] as CardDef[];
+      const listing = {
+        name: 'Some Folder',
+        specs: [],
+        examples: instances,
+        skills: [],
+        [realmURL]: sourceRealmURL,
+      } as any;
+      let { modulesCopy, instancesCopy } = planInstanceInstall(
+        instances,
+        new InstallOptions(targetRealmURL.href, listing, 'xyz'),
+      );
+      assert.strictEqual(modulesCopy.length, 2);
+      assert.strictEqual(instancesCopy.length, 2);
+      assert.deepEqual(modulesCopy[0], {
+        sourceCodeRef: {
+          name: 'Some Ref Name',
+          module: `${sourceRealmURL.href}some-folder/some`,
+        },
+        targetCodeRef: {
+          name: 'Some Ref Name',
+          module: `${targetRealmURL}some-folder-xyz/some-folder/some.gts`,
+        },
+      });
+      assert.deepEqual(modulesCopy[1], {
+        sourceCodeRef: {
+          name: 'Some Ref Name',
+          module: `${sourceRealmURL.href}some-folder-2/some-2`,
+        },
+        targetCodeRef: {
+          name: 'Some Ref Name',
+          module: `${targetRealmURL}some-folder-xyz/some-folder-2/some-2.gts`,
+        },
+      });
+      assert.deepEqual(instancesCopy[0].localDir, 'some-folder-xyz');
+      assert.deepEqual(instancesCopy[0].targetCodeRef, {
+        name: 'Some Ref Name',
+        module: `${targetRealmURL}some-folder-xyz/some-folder/some.gts`,
+      });
+      assert.deepEqual(instancesCopy[1].localDir, 'some-folder-xyz');
+      assert.deepEqual(instancesCopy[1].targetCodeRef, {
+        name: 'Some Ref Name',
+        module: `${targetRealmURL}some-folder-xyz/some-folder-2/some-2.gts`,
+      });
+    });
+
+    test('no listing name provided & instance adoptsFrom code in separate organizing folder', function (assert) {
+      const instances = [
+        {
+          id: `${sourceRealmURL.href}some-folder/Example/1`,
+          [meta]: {
+            adoptsFrom: {
+              name: 'Some Ref Name',
+              module: `${sourceRealmURL.href}some-folder/some`,
+            },
+          },
+          [realmURL]: sourceRealmURL,
+        },
+        {
+          id: `${sourceRealmURL.href}some-folder/Example/2`,
+          [meta]: {
+            adoptsFrom: {
+              name: 'Some Ref Name',
+              module: `${sourceRealmURL.href}some-folder-2/some-2`,
+            },
+          },
+          [realmURL]: sourceRealmURL,
+        },
+      ] as CardDef[];
+      const listing = {
+        specs: [],
+        examples: instances,
+        skills: [],
+        [realmURL]: sourceRealmURL,
+      } as any;
+      let { modulesCopy, instancesCopy } = planInstanceInstall(
+        instances,
+        new InstallOptions(targetRealmURL.href, listing, 'xyz'),
+      );
+      assert.strictEqual(modulesCopy.length, 2);
+      assert.strictEqual(instancesCopy.length, 2);
+      assert.deepEqual(modulesCopy[0], {
+        sourceCodeRef: {
+          name: 'Some Ref Name',
+          module: `${sourceRealmURL.href}some-folder/some`,
+        },
+        targetCodeRef: {
+          name: 'Some Ref Name',
+          module: `${targetRealmURL}xyz/some-folder/some.gts`,
+        },
+      });
+      assert.deepEqual(modulesCopy[1], {
+        sourceCodeRef: {
+          name: 'Some Ref Name',
+          module: `${sourceRealmURL.href}some-folder-2/some-2`,
+        },
+        targetCodeRef: {
+          name: 'Some Ref Name',
+          module: `${targetRealmURL}xyz/some-folder-2/some-2.gts`,
+        },
+      });
+      assert.deepEqual(instancesCopy[0].localDir, 'xyz');
+      assert.deepEqual(instancesCopy[0].targetCodeRef, {
+        name: 'Some Ref Name',
+        module: `${targetRealmURL}xyz/some-folder/some.gts`,
+      });
+      assert.deepEqual(instancesCopy[1].localDir, 'xyz');
+      assert.deepEqual(instancesCopy[1].targetCodeRef, {
+        name: 'Some Ref Name',
+        module: `${targetRealmURL}xyz/some-folder-2/some-2.gts`,
+      });
+    });
+  });
+  module('InstallOptions()', function () {
+    test('listing name derives source directory', function (assert) {
+      const specs = [
+        {
+          ref: { name: 'Some Ref Name' },
+          moduleHref: `${sourceRealmURL.href}some-folder/some`,
+          [realmURL]: sourceRealmURL,
+        },
+      ] as Spec[];
+      const listing = {
+        name: 'Some Folder',
+        specs,
+        examples: [],
+        skills: [],
+        [realmURL]: sourceRealmURL,
+      } as any;
+      const opts = new InstallOptions(targetRealmURL.href, listing, 'xyz');
+      assert.strictEqual(
+        opts.sourceDirectory,
+        `${sourceRealmURL.href}some-folder/`,
+      );
+      assert.strictEqual(
+        opts.targetDirectory,
+        `${targetRealmURL.href}some-folder-xyz/`,
+      );
+    });
+
+    test('when no listing name is provided, source directory defaults to source realm', function (assert) {
+      const specs = [
+        {
+          ref: { name: 'Some Ref Name' },
+          moduleHref: `${sourceRealmURL.href}some-folder/some`,
+          [realmURL]: sourceRealmURL,
+        },
+      ] as Spec[];
+      const listing = {
+        specs,
+        examples: [],
+        skills: [],
+        [realmURL]: sourceRealmURL,
+      } as any;
+      const opts = new InstallOptions(targetRealmURL.href, listing, 'xyz');
+      assert.strictEqual(opts.sourceDirectory, sourceRealmURL.href);
+      assert.strictEqual(opts.targetDirectory, `${targetRealmURL.href}xyz/`);
+    });
+
+    test('instance exist in different organizing directory as code but adoptsFrom code from organizing directory', function (assert) {
+      const specs = [
+        {
+          ref: { name: 'Some Ref Name' },
+          moduleHref: `${sourceRealmURL.href}some-folder/some`,
+          [realmURL]: sourceRealmURL,
+        },
+      ] as Spec[];
+      const instances = [
+        {
+          id: `${sourceRealmURL.href}Example/1`,
+          [meta]: {
+            adoptsFrom: {
+              name: 'Some Ref Name',
+              module: `${sourceRealmURL.href}some-folder/some`,
+            },
+          },
+          [realmURL]: sourceRealmURL,
+        },
+      ];
+      const listing = {
+        name: 'Some Folder',
+        specs,
+        examples: instances,
+        skills: [],
+        [realmURL]: sourceRealmURL,
+      } as any;
+      const opts = new InstallOptions(targetRealmURL.href, listing, 'xyz');
+      assert.strictEqual(
+        opts.sourceDirectory,
+        `${sourceRealmURL.href}some-folder/`,
+      );
+      assert.strictEqual(
+        opts.targetDirectory,
+        `${targetRealmURL.href}some-folder-xyz/`,
+      );
+    });
+
+    test('instance exist inside organizing directory as code but adoptsFrom from code outside organizing directory', function (assert) {
+      const specs = [
+        {
+          ref: { name: 'Some Ref Name' },
+          moduleHref: `${sourceRealmURL.href}some-folder/some`,
+          [realmURL]: sourceRealmURL,
+        },
+      ] as Spec[];
+      const instances = [
+        {
+          id: `${sourceRealmURL.href}some-folder/Example/1`,
+          [meta]: {
+            adoptsFrom: {
+              name: 'Some Ref Name',
+              module: `${sourceRealmURL.href}some-other-folder/some`,
+            },
+          },
+          [realmURL]: sourceRealmURL,
+        },
+      ];
+      const listing = {
+        name: 'Some Folder',
+        specs,
+        examples: instances,
+        skills: [],
+        [realmURL]: sourceRealmURL,
+      } as any;
+      const opts = new InstallOptions(targetRealmURL.href, listing, 'xyz');
+      assert.strictEqual(opts.sourceDirectory, `${sourceRealmURL.href}`);
+      assert.strictEqual(
+        opts.targetDirectory,
+        `${targetRealmURL.href}some-folder-xyz/`,
+      );
+    });
+  });
+  module('PlanBuilder', function (hooks) {
+    let builder: PlanBuilder;
+    const listing = {
+      name: 'Some Folder',
+      specs: [],
+      examples: [],
+      skills: [],
+      [realmURL]: sourceRealmURL,
+    } as any;
+    hooks.beforeEach(function () {
+      const opts = new InstallOptions(targetRealmURL.href, listing, 'xyz');
+      builder = new PlanBuilder(opts);
+    });
+    test('each modulesCopy is unique', function (assert) {
+      builder.add(() => {
+        return {
+          modulesCopy: [
+            {
+              sourceCodeRef: {
+                name: 'Some Ref Name',
+                module: `${sourceRealmURL.href}some-folder/some`,
+              },
+              targetCodeRef: {
+                name: 'Some Ref Name',
+                module: `${targetRealmURL}xyz/some-folder/some.gts`,
+              },
+            },
+          ],
+          instancesCopy: [],
+        };
+      });
+      builder.add(() => {
+        return {
+          modulesCopy: [
+            {
+              sourceCodeRef: {
+                name: 'Some Ref Name',
+                module: `${sourceRealmURL.href}some-folder/some`,
+              },
+              targetCodeRef: {
+                name: 'Some Ref Name',
+                module: `${targetRealmURL}xyz/some-folder/some.gts`,
+              },
+            },
+          ],
+          instancesCopy: [],
+        };
+      });
+      let plan = builder.build();
+      assert.deepEqual(plan, {
+        instancesCopy: [],
+        modulesCopy: [
+          {
+            sourceCodeRef: {
+              module: `${sourceRealmURL.href}some-folder/some`,
+              name: 'Some Ref Name',
+            },
+            targetCodeRef: {
+              module: `${targetRealmURL}xyz/some-folder/some.gts`,
+              name: 'Some Ref Name',
+            },
+          },
+        ],
+      });
+    });
+    test('each instanceCopy is unique', function (assert) {
+      builder.add(() => {
+        return {
+          modulesCopy: [],
+          instancesCopy: [
+            {
+              sourceCard: {} as CardDef,
+              localDir: `xyz/some-folder`,
+            },
+          ],
+        };
+      });
+      builder.add(() => {
+        return {
+          modulesCopy: [],
+          instancesCopy: [
+            {
+              sourceCard: {} as CardDef,
+              localDir: `xyz/some-folder`,
+            },
+          ],
+        };
+      });
+      let plan = builder.build();
+      assert.deepEqual(plan, {
+        instancesCopy: [
+          {
+            sourceCard: {} as CardDef,
+            localDir: `xyz/some-folder`,
+          },
+        ],
+        modulesCopy: [],
+      });
+    });
+  });
+});

--- a/packages/host/tests/unit/plan-install-test.ts
+++ b/packages/host/tests/unit/plan-install-test.ts
@@ -9,8 +9,8 @@ import {
   meta,
 } from '@cardstack/runtime-common';
 
-import type { Spec } from 'https://cardstack.com/base/spec';
 import type { CardDef } from 'https://cardstack.com/base/card-api';
+import type { Spec } from 'https://cardstack.com/base/spec';
 
 const sourceRealmURL = new URL('https://localhost:4201/catalog/');
 const targetRealmURL = new URL('https://localhost:4201/experiments/');

--- a/packages/runtime-common/catalog.ts
+++ b/packages/runtime-common/catalog.ts
@@ -1,14 +1,273 @@
-import { deburr } from 'lodash';
+import { isEqual, uniqWith, kebabCase } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
+import { Spec } from 'https://cardstack.com/base/spec';
+import { CardDef } from 'https://cardstack.com/base/card-api';
+import { RealmPaths, join } from './paths';
+import { ResolvedCodeRef, resolveAdoptedCodeRef } from './code-ref';
+import { realmURL } from './constants';
+import { logger } from './log';
 
-export function listingNameWithUuid(listingName?: string) {
-  if (!listingName) {
-    return '';
+import type { Listing } from '@cardstack/catalog/listing/listing';
+
+const baseRealmPath = new RealmPaths(new URL('https://cardstack.com/base/'));
+
+// sourceCodeRef -- (installs module) --> targetCodeRef
+export interface CopyMeta {
+  sourceCodeRef: ResolvedCodeRef;
+  targetCodeRef: ResolvedCodeRef;
+}
+
+export interface CopyInstanceMeta {
+  sourceCard: CardDef;
+  localDir: string;
+  targetCodeRef?: ResolvedCodeRef | undefined;
+}
+
+export interface InstallPlan {
+  modulesCopy: CopyMeta[];
+  instancesCopy: CopyInstanceMeta[];
+}
+
+export function generateInstallFolderName(
+  name?: string,
+  installDirId?: string,
+): string {
+  if (name && installDirId) {
+    return `${kebabCase(name)}-${installDirId}`;
+  } else if (!name && installDirId) {
+    return installDirId;
+  } else if (name && !installDirId) {
+    return `${kebabCase(name)}-${uuidv4()}`;
+  } else {
+    return uuidv4();
   }
-  // sanitize the listing name, eg: Blog App -> blog-app
-  const sanitizedListingName = deburr(listingName.toLocaleLowerCase())
-    .replace(/ /g, '-')
-    .replace(/'/g, '');
-  const newPackageName = `${sanitizedListingName}-${uuidv4()}`;
-  return newPackageName;
+}
+
+export class InstallOptions {
+  targetRealm: string;
+  private sourceRealmPath: RealmPaths;
+  private listingDirectoryPath: RealmPaths; // organizing folder of listing
+  installDirectoryName: string; //name of outer uuid  folder
+  sourceDirectoryPath: RealmPaths; // (best guess) listing folder of listing
+  removeListingDirectory: boolean = true; // if true, remove listting directory from source directory
+  targetLocalDirectory: string;
+
+  constructor(targetRealm: string, listing: Listing, installDirId?: string) {
+    this.targetRealm = targetRealm;
+
+    const listingDirectoryName = kebabCase(listing.name);
+
+    this.installDirectoryName = generateInstallFolderName(
+      listingDirectoryName,
+      installDirId,
+    );
+
+    const sourceRealmURL = listing[realmURL];
+    if (!sourceRealmURL) {
+      throw new Error('Cannot derive realm from listing');
+    }
+
+    this.sourceRealmPath = new RealmPaths(sourceRealmURL);
+    this.listingDirectoryPath = new RealmPaths(
+      new URL(join(this.sourceRealmPath.url, listingDirectoryName)),
+    );
+    this.removeListingDirectory = allCodeRefsInSameDirectory(
+      listing,
+      this.listingDirectory,
+    );
+    //use source directory
+    this.sourceDirectoryPath = this.removeListingDirectory
+      ? this.listingDirectoryPath
+      : this.sourceRealmPath;
+    this.targetLocalDirectory = this.installDirectoryName;
+  }
+
+  get sourceRealm(): string {
+    return this.sourceRealmPath.url;
+  }
+
+  get listingDirectory(): string {
+    return this.listingDirectoryPath.url;
+  }
+  get targetDirectory(): string {
+    return new RealmPaths(
+      new URL(join(this.targetRealm, this.installDirectoryName)),
+    ).url;
+  }
+
+  get sourceDirectory(): string {
+    return this.sourceDirectoryPath.url;
+  }
+}
+
+export function allCodeRefsInSameDirectory(
+  listing: Listing,
+  dir: string,
+  ignoreBaseRealm: boolean = true,
+) {
+  const codeRefs: ResolvedCodeRef[] = [];
+  listing.specs.forEach((c: Spec) => {
+    codeRefs.push({ module: c.moduleHref, name: c.ref.name });
+  });
+  listing.examples.forEach((c: CardDef) => {
+    let codeRef = resolveAdoptedCodeRef(c);
+    codeRefs.push(codeRef);
+  });
+  listing.skills.forEach((c: CardDef) => {
+    let codeRef = resolveAdoptedCodeRef(c);
+    codeRefs.push(codeRef);
+  });
+  let moduleIds = codeRefs.map((r) => r.module);
+  let sourceDirPath = new RealmPaths(new URL(dir));
+  return moduleIds.every((id: string) => {
+    let url = new URL(id);
+    let inRealm = sourceDirPath.inRealm(url);
+    let inBaseRealm = baseRealmPath.inRealm(url);
+    if (ignoreBaseRealm && inBaseRealm) {
+      return inBaseRealm;
+    }
+    return inRealm;
+  });
+}
+
+function resolveTargetCodeRef(
+  codeRef: ResolvedCodeRef,
+  opts: InstallOptions,
+): ResolvedCodeRef {
+  if (baseRealmPath.inRealm(new URL(codeRef.module))) {
+    return codeRef;
+  } else {
+    let local = opts.sourceDirectoryPath.local(new URL(codeRef.module));
+    let targetModule = join(
+      opts.targetRealm,
+      opts.installDirectoryName ?? '',
+      local + '.gts',
+    ); //we assume .gts extension for now
+    return {
+      name: codeRef.name,
+      module: targetModule,
+    };
+  }
+}
+
+type PlanBuilderStep = (opts: InstallOptions, plan: InstallPlan) => InstallPlan;
+
+export class PlanBuilder {
+  private steps: PlanBuilderStep[] = [];
+  private log = logger('catalog:plan');
+
+  constructor(private opts: InstallOptions) {}
+
+  add(step: PlanBuilderStep): this {
+    this.steps.push(step);
+    return this;
+  }
+
+  addIf(condition: boolean, step: PlanBuilderStep): this {
+    if (condition) {
+      this.steps.push(step);
+    }
+    return this;
+  }
+
+  build(): InstallPlan {
+    let finalPlan = this.steps.reduce(
+      (plan: InstallPlan, step: PlanBuilderStep, i) => {
+        this.log.debug(`=== Plan Step ${i} ===`);
+        this.log.debug(JSON.stringify(plan, null, 2));
+        return mergePlans(plan, step(this.opts, plan));
+      },
+      {
+        modulesCopy: [],
+        instancesCopy: [],
+      },
+    );
+    this.log.debug(`=== Final Plan ===`);
+    this.log.debug(JSON.stringify(finalPlan, null, 2));
+    return finalPlan;
+  }
+}
+
+export function planModuleInstall(
+  specs: Spec[],
+  opts: InstallOptions,
+): InstallPlan {
+  if (specs.length == 0) {
+    return {
+      modulesCopy: [],
+      instancesCopy: [],
+    };
+  }
+  let codeRefs: ResolvedCodeRef[] = specs.map((s) => {
+    return { module: s.moduleHref, name: s.ref.name };
+  });
+  let modulesCopy = codeRefs.flatMap((sourceCodeRef: ResolvedCodeRef) => {
+    if (baseRealmPath.inRealm(new URL(sourceCodeRef.module))) {
+      return [];
+    }
+    let targetCodeRef = resolveTargetCodeRef(sourceCodeRef, opts);
+    let copyMeta = {
+      sourceCodeRef,
+      targetCodeRef,
+    };
+    return [copyMeta];
+  });
+  return {
+    modulesCopy,
+    instancesCopy: [],
+  };
+}
+
+export function planInstanceInstall(
+  instances: CardDef[],
+  opts: InstallOptions,
+): InstallPlan {
+  let copyInstanceMeta: CopyInstanceMeta[] = [];
+  let copySourceMeta: CopyMeta[] = [];
+  for (let instance of instances) {
+    let sourceCodeRef = resolveAdoptedCodeRef(instance);
+    let targetCodeRef = resolveTargetCodeRef(sourceCodeRef, opts);
+    if (!baseRealmPath.inRealm(new URL(sourceCodeRef.module))) {
+      copySourceMeta.push({
+        sourceCodeRef,
+        targetCodeRef,
+      });
+      copyInstanceMeta.push({
+        sourceCard: instance,
+        targetCodeRef,
+        localDir: opts.targetLocalDirectory,
+      });
+    } else {
+      copyInstanceMeta.push({
+        sourceCard: instance,
+        localDir: opts.targetLocalDirectory,
+      });
+    }
+  }
+  return {
+    modulesCopy: copySourceMeta,
+    instancesCopy: copyInstanceMeta,
+  };
+}
+
+function dedupeCopyMeta(array: CopyMeta[]): CopyMeta[] {
+  return uniqWith(
+    array,
+    (a: CopyMeta, b: CopyMeta) =>
+      isEqual(a.sourceCodeRef, b.sourceCodeRef) &&
+      isEqual(a.targetCodeRef, b.targetCodeRef),
+  );
+}
+function dedupeCopyInstanceMeta(array: CopyInstanceMeta[]): CopyInstanceMeta[] {
+  return uniqWith(array, (a: CopyInstanceMeta, b: CopyInstanceMeta) =>
+    isEqual(a.sourceCard, b.sourceCard),
+  );
+}
+export function mergePlans(...plans: InstallPlan[]): InstallPlan {
+  return {
+    modulesCopy: dedupeCopyMeta(plans.flatMap((p) => p.modulesCopy)),
+    instancesCopy: dedupeCopyInstanceMeta(
+      plans.flatMap((p) => p.instancesCopy),
+    ),
+  };
 }

--- a/packages/runtime-common/catalog.ts
+++ b/packages/runtime-common/catalog.ts
@@ -7,11 +7,14 @@ import { ResolvedCodeRef, resolveAdoptedCodeRef } from './code-ref';
 import { realmURL } from './constants';
 import { logger } from './log';
 
+// @ts-ignore TODO: fix catalog types in runtime-common
 import type { Listing } from '@cardstack/catalog/listing/listing';
 
 const baseRealmPath = new RealmPaths(new URL('https://cardstack.com/base/'));
 
 // sourceCodeRef -- (installs module) --> targetCodeRef
+// sourceCodeRef: code ref of the code from the source realm
+// targetCodeRef: code ref of the code from the target realm
 export interface CopyMeta {
   sourceCodeRef: ResolvedCodeRef;
   targetCodeRef: ResolvedCodeRef;
@@ -48,8 +51,8 @@ export class InstallOptions {
   private sourceRealmPath: RealmPaths;
   private listingDirectoryPath: RealmPaths; // organizing folder of listing
   installDirectoryName: string; //name of outer uuid  folder
-  sourceDirectoryPath: RealmPaths; // (best guess) listing folder of listing
-  removeListingDirectory: boolean = true; // if true, remove listting directory from source directory
+  sourceDirectoryPath: RealmPaths; // (best guess) listing folder of distributed code; typically, fallsback to realm when not all code is self-contained in this folder
+  removeListingDirectory: boolean = true; // if true, remove listting directory from source directory.
   targetLocalDirectory: string;
 
   constructor(targetRealm: string, listing: Listing, installDirId?: string) {
@@ -75,7 +78,7 @@ export class InstallOptions {
       listing,
       this.listingDirectory,
     );
-    //use source directory
+
     this.sourceDirectoryPath = this.removeListingDirectory
       ? this.listingDirectoryPath
       : this.sourceRealmPath;

--- a/packages/runtime-common/code-ref.ts
+++ b/packages/runtime-common/code-ref.ts
@@ -8,6 +8,7 @@ import {
 import { Loader } from './loader';
 import { isField, primitive } from './constants';
 import { CardError } from './error';
+import { meta } from './constants';
 import { isUrlLike, trimExecutableExtension } from './index';
 
 export type ResolvedCodeRef = {
@@ -280,4 +281,16 @@ export async function getNarrowestType(
   let narrowestType =
     narrowTypeExists && typeConstraint ? typeConstraint : type;
   return narrowestType;
+}
+
+export function resolveAdoptedCodeRef(instance: CardDef) {
+  let adoptsFrom = instance[meta]?.adoptsFrom as CodeRef;
+  if (!adoptsFrom) {
+    throw new Error('Instance missing adoptsFrom');
+  }
+  let resolved = codeRefWithAbsoluteURL(adoptsFrom, new URL(instance.id));
+  if (!isResolvedCodeRef(resolved)) {
+    throw new Error('code ref is not resolved');
+  }
+  return resolved;
 }

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -72,9 +72,10 @@ export interface RealmPrerenderedCards {
 // TODO should we use the secure form once we start letting lid's drive the id
 // on the server? address in CS-8343
 export { v4 as uuidv4 } from '@lukeed/uuid'; // isomorphic UUID's using Math.random
-import { RealmPaths, type LocalPath } from './paths';
+import { type LocalPath } from './paths';
 import { CardTypeFilter, Query, EveryFilter } from './query';
 import { Loader } from './loader';
+export * from './paths';
 export * from './cached-fetch';
 export * from './catalog';
 export * from './commands';
@@ -99,7 +100,7 @@ export * from './query';
 export * from './formats';
 export { mergeRelationships } from './merge-relationships';
 export { makeLogDefinitions, logger } from './log';
-export { RealmPaths, Loader, type LocalPath };
+export { Loader };
 export { NotLoaded, isNotLoadedError } from './not-loaded';
 export {
   cardTypeDisplayName,

--- a/packages/runtime-common/tsconfig.json
+++ b/packages/runtime-common/tsconfig.json
@@ -24,7 +24,6 @@
     "skipLibCheck": true,
     "paths": {
       "https://cardstack.com/base/*": ["../base/*"],
-      "@cardstack/catalog/*": ["../catalog-realm/catalog-app/*"],
       "@cardstack/boxel-ui": ["../boxel-ui/addon"],
       "@cardstack/boxel-ui/*": ["../boxel-ui/addon/*"],
       "*": ["types/*"]

--- a/packages/runtime-common/tsconfig.json
+++ b/packages/runtime-common/tsconfig.json
@@ -24,6 +24,7 @@
     "skipLibCheck": true,
     "paths": {
       "https://cardstack.com/base/*": ["../base/*"],
+      "@cardstack/catalog/*": ["../catalog-realm/catalog-app/*"],
       "@cardstack/boxel-ui": ["../boxel-ui/addon"],
       "@cardstack/boxel-ui/*": ["../boxel-ui/addon/*"],
       "*": ["types/*"]


### PR DESCRIPTION
The point of this PR is to normalize paths CONSISTENTLY when we install resources specified in a listing

The original issue was that resources were being installed in the wrong place. This PR also covers https://linear.app/cardstack/issue/CS-8685/should-not-have-source-files-determine-where-the-file-is-copied-to since now we have a opiniated strategy on how/where to install