### PR TITLE
Fix ember-resources deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@typescript-eslint/eslint-plugin": "catalog:",
     "@typescript-eslint/parser": "catalog:",
     "ember-cli-htmlbars": "^6.3.0",
-    "ember-resources": "^6.5.1",
+    "ember-resources": "catalog:",
     "ember-source": "~5.4.0",
     "ember-template-imports": "^4.1.1",
     "eslint": "catalog:",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -18,7 +18,7 @@
     "ember-concurrency": "catalog:",
     "ember-css-url": "^1.0.0",
     "ember-modifier": "^3.2.1",
-    "ember-resources": "^6.5.1",
+    "ember-resources": "catalog:",
     "ember-template-lint": "catalog:",
     "ethers": "catalog:",
     "matrix-js-sdk": "catalog:",

--- a/packages/boxel-motion/test-app/package.json
+++ b/packages/boxel-motion/test-app/package.json
@@ -75,7 +75,7 @@
     "ember-page-title": "^8.0.0",
     "ember-qunit": "catalog:",
     "ember-resolver": "^11.0.1",
-    "ember-resources": "^6.5.1",
+    "ember-resources": "catalog:",
     "ember-source": "^5.4.0",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-imports": "^4.1.1",

--- a/packages/boxel-ui/test-app/package.json
+++ b/packages/boxel-ui/test-app/package.json
@@ -77,7 +77,7 @@
     "ember-page-title": "^8.0.0",
     "ember-qunit": "catalog:",
     "ember-resolver": "^11.0.1",
-    "ember-resources": "^6.5.1",
+    "ember-resources": "catalog:",
     "ember-source": "^5.4.0",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-imports": "^4.1.1",

--- a/packages/catalog-realm/chess/chess.gts
+++ b/packages/catalog-realm/chess/chess.gts
@@ -40,7 +40,7 @@ import {
 } from 'https://cdn.jsdelivr.net/npm/cm-chessboard@8.7.3/src/extensions/markers/Markers.js/+esm';
 
 import Modifier from 'ember-modifier';
-import { Resource } from 'ember-modify-class-based-resource';
+import { Resource } from 'ember-modify-based-class-resource';
 
 import BooleanField from 'https://cardstack.com/base/boolean';
 import { tracked } from '@glimmer/tracking';

--- a/packages/catalog-realm/chess/chess.gts
+++ b/packages/catalog-realm/chess/chess.gts
@@ -40,7 +40,7 @@ import {
 } from 'https://cdn.jsdelivr.net/npm/cm-chessboard@8.7.3/src/extensions/markers/Markers.js/+esm';
 
 import Modifier from 'ember-modifier';
-import { Resource } from 'ember-resources';
+import { Resource } from 'ember-modify-class-based-resource';
 
 import BooleanField from 'https://cardstack.com/base/boolean';
 import { tracked } from '@glimmer/tracking';

--- a/packages/catalog-realm/crm-app/kanban-resource.gts
+++ b/packages/catalog-realm/crm-app/kanban-resource.gts
@@ -2,7 +2,7 @@ import { tracked } from '@glimmer/tracking';
 import { DndColumn } from '@cardstack/boxel-ui/components';
 import { CardDef } from 'https://cardstack.com/base/card-api';
 
-import { Resource } from 'ember-resources';
+import { Resource } from 'ember-modify-class-based-resource';
 
 interface Args {
   named: {

--- a/packages/catalog-realm/crm-app/kanban-resource.gts
+++ b/packages/catalog-realm/crm-app/kanban-resource.gts
@@ -2,7 +2,7 @@ import { tracked } from '@glimmer/tracking';
 import { DndColumn } from '@cardstack/boxel-ui/components';
 import { CardDef } from 'https://cardstack.com/base/card-api';
 
-import { Resource } from 'ember-modify-class-based-resource';
+import { Resource } from 'ember-modify-based-class-resource';
 
 interface Args {
   named: {

--- a/packages/catalog-realm/mortgage-calculator/mortgage-calculator.gts
+++ b/packages/catalog-realm/mortgage-calculator/mortgage-calculator.gts
@@ -599,5 +599,6 @@ export class MortgageCalculator extends CardDef {
     <template></template>
   }
 
+
   */
 }

--- a/packages/catalog-realm/package.json
+++ b/packages/catalog-realm/package.json
@@ -16,6 +16,9 @@
     "ember-template-lint": "catalog:",
     "tracked-built-ins": "^3.3.0"
   },
+  "dependencies": {
+    "ember-modify-based-class-resource": "catalog:"
+  },
   "scripts": {
     "lint": "concurrently \"pnpm:lint:*(!fix)\" --names \"lint:\"",
     "lint:hbs": "ember-template-lint . --no-error-on-unmatched-pattern",

--- a/packages/catalog-realm/sprint-planner/kanban-resource.gts
+++ b/packages/catalog-realm/sprint-planner/kanban-resource.gts
@@ -2,7 +2,7 @@ import { tracked } from '@glimmer/tracking';
 import { DndColumn } from '@cardstack/boxel-ui/components';
 import { CardDef } from 'https://cardstack.com/base/card-api';
 
-import { Resource } from 'ember-resources';
+import { Resource } from 'ember-modify-class-based-resource';
 
 interface Args {
   named: {

--- a/packages/catalog-realm/sprint-planner/kanban-resource.gts
+++ b/packages/catalog-realm/sprint-planner/kanban-resource.gts
@@ -2,7 +2,7 @@ import { tracked } from '@glimmer/tracking';
 import { DndColumn } from '@cardstack/boxel-ui/components';
 import { CardDef } from 'https://cardstack.com/base/card-api';
 
-import { Resource } from 'ember-modify-class-based-resource';
+import { Resource } from 'ember-modify-based-class-resource';
 
 interface Args {
   named: {

--- a/packages/experiments-realm/chess-game.gts
+++ b/packages/experiments-realm/chess-game.gts
@@ -40,7 +40,7 @@ import {
 } from 'https://cdn.jsdelivr.net/npm/cm-chessboard@8.7.3/src/extensions/markers/Markers.js/+esm';
 
 import Modifier from 'ember-modifier';
-import { Resource } from 'ember-modify-class-based-resource';
+import { Resource } from 'ember-modify-based-class-resource';
 
 import BooleanField from 'https://cardstack.com/base/boolean';
 import { tracked } from '@glimmer/tracking';

--- a/packages/experiments-realm/chess-game.gts
+++ b/packages/experiments-realm/chess-game.gts
@@ -40,7 +40,7 @@ import {
 } from 'https://cdn.jsdelivr.net/npm/cm-chessboard@8.7.3/src/extensions/markers/Markers.js/+esm';
 
 import Modifier from 'ember-modifier';
-import { Resource } from 'ember-resources';
+import { Resource } from 'ember-modify-class-based-resource';
 
 import BooleanField from 'https://cardstack.com/base/boolean';
 import { tracked } from '@glimmer/tracking';

--- a/packages/experiments-realm/kanban-resource.gts
+++ b/packages/experiments-realm/kanban-resource.gts
@@ -2,7 +2,7 @@ import { tracked } from '@glimmer/tracking';
 import { DndColumn } from '@cardstack/boxel-ui/components';
 import { CardDef } from 'https://cardstack.com/base/card-api';
 
-import { Resource } from 'ember-resources';
+import { Resource } from 'ember-modify-class-based-resource';
 
 interface Args {
   named: {

--- a/packages/experiments-realm/kanban-resource.gts
+++ b/packages/experiments-realm/kanban-resource.gts
@@ -2,7 +2,7 @@ import { tracked } from '@glimmer/tracking';
 import { DndColumn } from '@cardstack/boxel-ui/components';
 import { CardDef } from 'https://cardstack.com/base/card-api';
 
-import { Resource } from 'ember-modify-class-based-resource';
+import { Resource } from 'ember-modify-based-class-resource';
 
 interface Args {
   named: {

--- a/packages/experiments-realm/package.json
+++ b/packages/experiments-realm/package.json
@@ -15,6 +15,9 @@
     "ember-template-lint": "catalog:",
     "tracked-built-ins": "^3.3.0"
   },
+  "dependencies": {
+    "ember-modify-based-class-resource": "catalog:"
+  },
   "scripts": {
     "lint": "concurrently \"pnpm:lint:*(!fix)\" --names \"lint:\"",
     "lint:hbs": "ember-template-lint .",

--- a/packages/experiments-realm/utils/resources/metamask.gts
+++ b/packages/experiments-realm/utils/resources/metamask.gts
@@ -1,6 +1,6 @@
 import type Owner from '@ember/owner';
 import { tracked } from '@glimmer/tracking';
-import { Resource } from 'ember-modify-class-based-resource';
+import { Resource } from 'ember-modify-based-class-resource';
 // @ts-ignore
 import { enqueueTask, restartableTask } from 'ember-concurrency';
 // @ts-ignore

--- a/packages/experiments-realm/utils/resources/metamask.gts
+++ b/packages/experiments-realm/utils/resources/metamask.gts
@@ -1,6 +1,6 @@
 import type Owner from '@ember/owner';
 import { tracked } from '@glimmer/tracking';
-import { Resource } from 'ember-resources';
+import { Resource } from 'ember-modify-class-based-resource';
 // @ts-ignore
 import { enqueueTask, restartableTask } from 'ember-concurrency';
 // @ts-ignore

--- a/packages/host/app/components/matrix/room-message-command.gts
+++ b/packages/host/app/components/matrix/room-message-command.gts
@@ -8,7 +8,7 @@ import { cached } from '@glimmer/tracking';
 
 import { modifier } from 'ember-modifier';
 
-import { resource, use } from 'ember-resources';
+import { resource, use } from 'ember-resources'
 
 import { TrackedObject } from 'tracked-built-ins';
 

--- a/packages/host/app/components/matrix/room-message-command.gts
+++ b/packages/host/app/components/matrix/room-message-command.gts
@@ -8,7 +8,7 @@ import { cached } from '@glimmer/tracking';
 
 import { modifier } from 'ember-modifier';
 
-import { resource, use } from 'ember-resources'
+import { resource, use } from 'ember-resources';
 
 import { TrackedObject } from 'tracked-built-ins';
 

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -18,7 +18,7 @@ import {
 
 import perform from 'ember-concurrency/helpers/perform';
 import { consume } from 'ember-provide-consume-context';
-import { resource, use } from 'ember-resources'
+import { resource, use } from 'ember-resources';
 import max from 'lodash/max';
 
 import { MatrixEvent } from 'matrix-js-sdk';

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -18,7 +18,7 @@ import {
 
 import perform from 'ember-concurrency/helpers/perform';
 import { consume } from 'ember-provide-consume-context';
-import { resource, use } from 'ember-resources';
+import { resource, use } from 'ember-resources'
 import max from 'lodash/max';
 
 import { MatrixEvent } from 'matrix-js-sdk';

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -6,7 +6,7 @@ import { service } from '@ember/service';
 import { capitalize } from '@ember/string';
 import Component from '@glimmer/component';
 
-import { use, resource } from 'ember-resources'
+import { use, resource } from 'ember-resources';
 
 import startCase from 'lodash/startCase';
 

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -6,7 +6,7 @@ import { service } from '@ember/service';
 import { capitalize } from '@ember/string';
 import Component from '@glimmer/component';
 
-import { use, resource } from 'ember-resources';
+import { use, resource } from 'ember-resources'
 
 import startCase from 'lodash/startCase';
 

--- a/packages/host/app/components/prerendered-card-search.gts
+++ b/packages/host/app/components/prerendered-card-search.gts
@@ -6,7 +6,7 @@ import Component from '@glimmer/component';
 import TriangleAlert from '@cardstack/boxel-icons/triangle-alert';
 
 import { didCancel, restartableTask } from 'ember-concurrency';
-import { trackedFunction } from 'ember-resources/util/function';
+import { trackedFunction } from 'reactiveweb/function';
 import { flatMap, isEqual } from 'lodash';
 
 import { TrackedSet } from 'tracked-built-ins';

--- a/packages/host/app/components/prerendered-card-search.gts
+++ b/packages/host/app/components/prerendered-card-search.gts
@@ -6,8 +6,8 @@ import Component from '@glimmer/component';
 import TriangleAlert from '@cardstack/boxel-icons/triangle-alert';
 
 import { didCancel, restartableTask } from 'ember-concurrency';
-import { trackedFunction } from 'reactiveweb/function';
 import { flatMap, isEqual } from 'lodash';
+import { trackedFunction } from 'reactiveweb/function';
 
 import { TrackedSet } from 'tracked-built-ins';
 

--- a/packages/host/app/components/search-sheet/index.gts
+++ b/packages/host/app/components/search-sheet/index.gts
@@ -11,7 +11,7 @@ import onClickOutside from 'ember-click-outside/modifiers/on-click-outside';
 import { modifier } from 'ember-modifier';
 import { consume } from 'ember-provide-consume-context';
 
-import { trackedFunction } from 'ember-resources/util/function';
+import { trackedFunction } from 'reactiveweb/function';
 
 import {
   Button,

--- a/packages/host/app/lib/externals.ts
+++ b/packages/host/app/lib/externals.ts
@@ -15,6 +15,7 @@ import * as emberConcurrency from 'ember-concurrency';
 import * as emberConcurrencyAsyncArrowRuntime from 'ember-concurrency/-private/async-arrow-runtime';
 import * as cssUrl from 'ember-css-url';
 import * as emberModifier2 from 'ember-modifier';
+import * as emberModifyClassBasedResource from 'ember-modify-based-class-resource';
 import * as emberProvideConsumeContext from 'ember-provide-consume-context';
 import * as emberProvideConsumeContextContextConsumer from 'ember-provide-consume-context/components/context-consumer';
 import * as emberProvideConsumeContextContextProvider from 'ember-provide-consume-context/components/context-provider';
@@ -56,6 +57,10 @@ export function shimExternals(virtualNetwork: VirtualNetwork) {
   virtualNetwork.shimModule('@ember/object/internals', emberObjectInternals);
   virtualNetwork.shimModule('@ember/helper', emberHelper);
   virtualNetwork.shimModule('@ember/modifier', emberModifier);
+  virtualNetwork.shimModule(
+    'ember-modify-based-class-resource',
+    emberModifyClassBasedResource,
+  );
   virtualNetwork.shimModule('ember-resources', emberResources);
   virtualNetwork.shimModule('ember-concurrency', emberConcurrency);
   virtualNetwork.shimModule(

--- a/packages/host/app/lib/externals.ts
+++ b/packages/host/app/lib/externals.ts
@@ -9,6 +9,15 @@ import * as emberTemplate from '@ember/template';
 import * as emberTemplateFactory from '@ember/template-factory';
 import * as glimmerComponent from '@glimmer/component';
 import * as glimmerTracking from '@glimmer/tracking';
+
+import * as dateFns from 'date-fns';
+import * as emberConcurrency from 'ember-concurrency';
+import * as emberConcurrencyAsyncArrowRuntime from 'ember-concurrency/-private/async-arrow-runtime';
+import * as cssUrl from 'ember-css-url';
+import * as emberModifier2 from 'ember-modifier';
+import * as emberProvideConsumeContext from 'ember-provide-consume-context';
+import * as emberProvideConsumeContextContextConsumer from 'ember-provide-consume-context/components/context-consumer';
+import * as emberProvideConsumeContextContextProvider from 'ember-provide-consume-context/components/context-provider';
 import * as emberResources from 'ember-resources';
 import * as flat from 'flat';
 import * as lodash from 'lodash';

--- a/packages/host/app/lib/externals.ts
+++ b/packages/host/app/lib/externals.ts
@@ -9,15 +9,6 @@ import * as emberTemplate from '@ember/template';
 import * as emberTemplateFactory from '@ember/template-factory';
 import * as glimmerComponent from '@glimmer/component';
 import * as glimmerTracking from '@glimmer/tracking';
-
-import * as dateFns from 'date-fns';
-import * as emberConcurrency from 'ember-concurrency';
-import * as emberConcurrencyAsyncArrowRuntime from 'ember-concurrency/-private/async-arrow-runtime';
-import * as cssUrl from 'ember-css-url';
-import * as emberModifier2 from 'ember-modifier';
-import * as emberProvideConsumeContext from 'ember-provide-consume-context';
-import * as emberProvideConsumeContextContextConsumer from 'ember-provide-consume-context/components/context-consumer';
-import * as emberProvideConsumeContextContextProvider from 'ember-provide-consume-context/components/context-provider';
 import * as emberResources from 'ember-resources';
 import * as flat from 'flat';
 import * as lodash from 'lodash';

--- a/packages/host/app/resources/auto-attached-card.ts
+++ b/packages/host/app/resources/auto-attached-card.ts
@@ -1,7 +1,7 @@
 import { service } from '@ember/service';
 
 import { restartableTask } from 'ember-concurrency';
-import { Resource } from 'ember-resources';
+import { Resource } from 'ember-modify-based-class-resource';
 
 import { TrackedSet } from 'tracked-built-ins';
 

--- a/packages/host/app/resources/card-collection.ts
+++ b/packages/host/app/resources/card-collection.ts
@@ -6,7 +6,7 @@ import { tracked } from '@glimmer/tracking';
 
 import { restartableTask } from 'ember-concurrency';
 
-import { Resource } from 'ember-resources';
+import { Resource } from 'ember-modify-based-class-resource';
 
 import difference from 'lodash/difference';
 import isEqual from 'lodash/isEqual';

--- a/packages/host/app/resources/card-resource.ts
+++ b/packages/host/app/resources/card-resource.ts
@@ -5,7 +5,7 @@
 import { registerDestructor } from '@ember/destroyable';
 import { service } from '@ember/service';
 
-import { Resource } from 'ember-resources';
+import { Resource } from 'ember-modify-based-class-resource';
 
 import { isCardInstance } from '@cardstack/runtime-common';
 

--- a/packages/host/app/resources/card-type.ts
+++ b/packages/host/app/resources/card-type.ts
@@ -3,7 +3,7 @@ import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 import { restartableTask } from 'ember-concurrency';
-import { Resource } from 'ember-resources';
+import { Resource } from 'ember-modify-based-class-resource';
 
 import {
   identifyCard,

--- a/packages/host/app/resources/code-diff.ts
+++ b/packages/host/app/resources/code-diff.ts
@@ -2,7 +2,7 @@ import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 import { restartableTask } from 'ember-concurrency';
-import { Resource } from 'ember-resources';
+import { Resource } from 'ember-modify-based-class-resource';
 
 import type CardService from '@cardstack/host/services/card-service';
 import CommandService from '@cardstack/host/services/command-service';

--- a/packages/host/app/resources/directory.ts
+++ b/packages/host/app/resources/directory.ts
@@ -4,7 +4,7 @@ import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 import { restartableTask } from 'ember-concurrency';
-import { Resource } from 'ember-resources';
+import { Resource } from 'ember-modify-based-class-resource';
 
 import {
   logger,

--- a/packages/host/app/resources/file.ts
+++ b/packages/host/app/resources/file.ts
@@ -6,7 +6,7 @@ import { tracked } from '@glimmer/tracking';
 
 import { parse } from 'date-fns';
 import { restartableTask } from 'ember-concurrency';
-import { Resource } from 'ember-resources';
+import { Resource } from 'ember-modify-based-class-resource';
 
 import { SupportedMimeType, logger } from '@cardstack/runtime-common';
 

--- a/packages/host/app/resources/import.ts
+++ b/packages/host/app/resources/import.ts
@@ -4,7 +4,7 @@ import { isTesting } from '@embroider/macros';
 import { tracked } from '@glimmer/tracking';
 
 import { task } from 'ember-concurrency';
-import { Resource } from 'ember-resources';
+import { Resource } from 'ember-modify-based-class-resource';
 
 import { logger } from '@cardstack/runtime-common';
 import { Loader } from '@cardstack/runtime-common/loader';

--- a/packages/host/app/resources/inheritance-chain.ts
+++ b/packages/host/app/resources/inheritance-chain.ts
@@ -3,7 +3,7 @@ import { getOwner } from '@ember/owner';
 import { tracked } from '@glimmer/tracking';
 
 import { task } from 'ember-concurrency';
-import { Resource } from 'ember-resources';
+import { Resource } from 'ember-modify-based-class-resource';
 
 import { type Loader, loadCardDef } from '@cardstack/runtime-common';
 

--- a/packages/host/app/resources/last-modified-date.ts
+++ b/packages/host/app/resources/last-modified-date.ts
@@ -2,7 +2,7 @@ import { registerDestructor } from '@ember/destroyable';
 import { tracked } from '@glimmer/tracking';
 
 import { formatDistanceToNow } from 'date-fns';
-import { Resource } from 'ember-resources';
+import { Resource } from 'ember-modify-based-class-resource';
 
 import { Ready as ReadyFile } from '@cardstack/host/resources/file';
 

--- a/packages/host/app/resources/matrix-profile.ts
+++ b/packages/host/app/resources/matrix-profile.ts
@@ -2,7 +2,7 @@ import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 import { restartableTask, all } from 'ember-concurrency';
-import { Resource } from 'ember-resources';
+import { Resource } from 'ember-modify-based-class-resource';
 
 import MatrixService from '@cardstack/host/services/matrix-service';
 

--- a/packages/host/app/resources/module-contents.ts
+++ b/packages/host/app/resources/module-contents.ts
@@ -3,7 +3,7 @@ import { tracked } from '@glimmer/tracking';
 
 import { task } from 'ember-concurrency';
 
-import { Resource } from 'ember-resources';
+import { Resource } from 'ember-modify-based-class-resource';
 
 import { getAncestor, getField, isBaseDef } from '@cardstack/runtime-common';
 

--- a/packages/host/app/resources/room.ts
+++ b/packages/host/app/resources/room.ts
@@ -4,7 +4,7 @@ import { service } from '@ember/service';
 import { tracked, cached } from '@glimmer/tracking';
 
 import { TaskInstance, restartableTask, timeout } from 'ember-concurrency';
-import { Resource } from 'ember-resources';
+import { Resource } from 'ember-modify-based-class-resource';
 
 import difference from 'lodash/difference';
 

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -5,7 +5,7 @@ import { buildWaiter } from '@ember/test-waiters';
 import { tracked, cached } from '@glimmer/tracking';
 
 import { restartableTask } from 'ember-concurrency';
-import { Resource } from 'ember-resources';
+import { Resource } from 'ember-modify-based-class-resource';
 
 import difference from 'lodash/difference';
 import flatMap from 'lodash/flatMap';

--- a/packages/host/app/resources/stack-backgrounds.ts
+++ b/packages/host/app/resources/stack-backgrounds.ts
@@ -1,7 +1,7 @@
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
-import { Resource } from 'ember-resources';
+import { Resource } from 'ember-modify-based-class-resource';
 
 import { isCardInstance } from '@cardstack/runtime-common';
 

--- a/packages/host/app/resources/url-bar.ts
+++ b/packages/host/app/resources/url-bar.ts
@@ -1,6 +1,6 @@
 import { tracked } from '@glimmer/tracking';
 
-import { Resource } from 'ember-resources';
+import { Resource } from 'ember-modify-based-class-resource';
 
 interface Args {
   named: {

--- a/packages/host/app/services/billing-service.ts
+++ b/packages/host/app/services/billing-service.ts
@@ -3,7 +3,7 @@ import Service from '@ember/service';
 import { service } from '@ember/service';
 import { tracked, cached } from '@glimmer/tracking';
 
-import { trackedFunction } from 'ember-resources/util/function';
+import { trackedFunction } from 'reactiveweb/function';
 
 import {
   SupportedMimeType,

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -128,7 +128,7 @@
     "ember-provide-consume-context": "^0.7.0",
     "ember-qunit": "catalog:",
     "ember-resolver": "^11.0.1",
-    "ember-resources": "^7.0.2",
+    "ember-resources": "catalog:",
     "ember-route-template": "^1.0.3",
     "ember-source": "~5.4.0",
     "ember-template-imports": "^4.1.1",

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -182,6 +182,10 @@
     "wait-for-localhost-cli": "catalog:",
     "webpack": "catalog:"
   },
+  "dependencies": {
+    "reactiveweb": "catalog:",
+    "ember-modify-based-class-resource": "catalog:"
+  },
   "engines": {
     "node": ">= 20"
   },
@@ -195,9 +199,5 @@
     "paths": [
       "lib/setup-ast-transforms"
     ]
-  },
-  "dependencies": {
-    "reactiveweb": "catalog:",
-    "ember-modify-based-class-resource": "catalog:"
   }
 }

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -128,7 +128,7 @@
     "ember-provide-consume-context": "^0.7.0",
     "ember-qunit": "catalog:",
     "ember-resolver": "^11.0.1",
-    "ember-resources": "^6.5.1",
+    "ember-resources": "^7.0.2",
     "ember-route-template": "^1.0.3",
     "ember-source": "~5.4.0",
     "ember-template-imports": "^4.1.1",
@@ -195,5 +195,9 @@
     "paths": [
       "lib/setup-ast-transforms"
     ]
+  },
+  "dependencies": {
+    "reactiveweb": "^1.3.0",
+    "ember-modify-based-class-resource": "^1.1.0"
   }
 }

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -197,7 +197,7 @@
     ]
   },
   "dependencies": {
-    "reactiveweb": "^1.3.0",
-    "ember-modify-based-class-resource": "^1.1.0"
+    "reactiveweb": "catalog:",
+    "ember-modify-based-class-resource": "catalog:"
   }
 }

--- a/packages/realm-server/lib/externals.ts
+++ b/packages/realm-server/lib/externals.ts
@@ -77,9 +77,12 @@ export function shimExternals(virtualNetwork: VirtualNetwork) {
   virtualNetwork.shimModule('@ember/modifier', {
     on() {},
   });
+  // import * as emberModifyClassBasedResource from 'ember-modify-based-class-resource';
+  virtualNetwork.shimModule('ember-modify-based-class-resource', {
+    Resource: class {},
+  });
   // import * as emberResources from 'ember-resources';
   virtualNetwork.shimModule('ember-resources', {
-    Resource: class {},
     useResource() {},
   });
   // import * as emberConcurrency from 'ember-concurrency';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1933,6 +1933,13 @@ importers:
         version: 3.3.0
 
   packages/host:
+    dependencies:
+      ember-modify-based-class-resource:
+        specifier: ^1.1.0
+        version: 1.1.2(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-resources@7.0.4(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0))
+      reactiveweb:
+        specifier: ^1.3.0
+        version: 1.6.0(@babel/core@7.26.10)(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
     devDependencies:
       '@babel/core':
         specifier: 'catalog:'
@@ -2226,8 +2233,8 @@ importers:
         specifier: ^11.0.1
         version: 11.0.1(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-resources:
-        specifier: ^6.5.1
-        version: 6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-concurrency@4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)))(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
+        specifier: ^7.0.2
+        version: 7.0.4(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)
       ember-route-template:
         specifier: ^1.0.3
         version: 1.0.3
@@ -7956,6 +7963,15 @@ packages:
       ember-source:
         optional: true
 
+  ember-modify-based-class-resource@1.1.2:
+    resolution: {integrity: sha512-eruTLd+aMzrXaLDInQSYv3zTcG5+0Ttn69W31JtOp6nSR3T22ET3q+6zZjCVNxmlDufSAu6lSFd9EAtKaazCdA==}
+    peerDependencies:
+      '@glimmer/component': ^1.1.2 || >= 2.0.0
+      ember-resources: '>= 6.4.0'
+    peerDependenciesMeta:
+      '@glimmer/component':
+        optional: true
+
   ember-moment@10.0.0:
     resolution: {integrity: sha512-vpnWVn3QfVBVP0MUnOkFI8fqqjskTh2LxOxyBaaRY7Smbcymq3b8wVB9GSNRasmyaclQVGY8jZsqi5ue7O2TUw==}
     engines: {node: '>= 12'}
@@ -8052,6 +8068,15 @@ packages:
       '@glimmer/component':
         optional: true
       ember-concurrency:
+        optional: true
+
+  ember-resources@7.0.4:
+    resolution: {integrity: sha512-x/KJrfQCq8hrnOHDzdpSteUXdeqP4iAjeS4xWTxxtWDeP2KqOZYpAz4CvigzzBktWGZByPp+Y1Ysvlvl99SnFA==}
+    peerDependencies:
+      '@glimmer/component': '>= 1.1.2 || >= 2.0.0'
+      '@glint/template': '>= 1.0.0'
+    peerDependenciesMeta:
+      '@glimmer/component':
         optional: true
 
   ember-rfc176-data@0.3.18:
@@ -11461,6 +11486,11 @@ packages:
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  reactiveweb@1.6.0:
+    resolution: {integrity: sha512-kgkK1vZJ9NNKfQEn6V5ZrpdgcMx+ywqphkTEx2v9ygKaPvpeFozYUR0wmHHb+bPJ57bXeSYdQGEZPT6yuq6fqw==}
+    peerDependencies:
+      '@ember/test-waiters': '>= 3.1.0'
 
   read-pkg-up@7.0.1:
     resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
@@ -20028,6 +20058,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  ember-modify-based-class-resource@1.1.2(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-resources@7.0.4(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)):
+    dependencies:
+      '@babel/runtime': 7.22.11
+      '@embroider/addon-shim': 1.8.9
+      '@embroider/macros': 1.16.13(@glint/template@1.3.0)
+      ember-resources: 7.0.4(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)
+    optionalDependencies:
+      '@glimmer/component': 1.1.2(@babel/core@7.26.10)
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+
   ember-moment@10.0.0(moment@2.29.4):
     dependencies:
       '@embroider/addon-shim': 0.50.2
@@ -20181,6 +20223,16 @@ snapshots:
       '@ember/test-waiters': 3.1.0
       '@glimmer/component': 1.1.2(@babel/core@7.26.10)
       ember-concurrency: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
+    transitivePeerDependencies:
+      - supports-color
+
+  ember-resources@7.0.4(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0):
+    dependencies:
+      '@embroider/addon-shim': 1.8.9
+      '@embroider/macros': 1.16.13(@glint/template@1.3.0)
+      '@glint/template': 1.3.0
+    optionalDependencies:
+      '@glimmer/component': 1.1.2(@babel/core@7.26.10)
     transitivePeerDependencies:
       - supports-color
 
@@ -24453,6 +24505,21 @@ snapshots:
       strip-json-comments: 2.0.1
 
   react-is@18.3.1: {}
+
+  reactiveweb@1.6.0(@babel/core@7.26.10)(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)):
+    dependencies:
+      '@ember/test-waiters': 3.1.0
+      '@embroider/addon-shim': 1.8.9
+      '@embroider/macros': 1.16.13(@glint/template@1.3.0)
+      decorator-transforms: 2.3.0(@babel/core@7.26.10)
+      ember-async-data: 1.0.3(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
+      ember-resources: 7.0.4(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glimmer/component'
+      - '@glint/template'
+      - ember-source
+      - supports-color
 
   read-pkg-up@7.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1801,6 +1801,10 @@ importers:
         version: 5.99.6
 
   packages/catalog-realm:
+    dependencies:
+      ember-modify-based-class-resource:
+        specifier: 'catalog:'
+        version: 1.1.2(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-resources@7.0.4(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0))
     devDependencies:
       '@cardstack/boxel-icons':
         specifier: workspace:*
@@ -1909,6 +1913,10 @@ importers:
   packages/eslint-plugin-window-mock: {}
 
   packages/experiments-realm:
+    dependencies:
+      ember-modify-based-class-resource:
+        specifier: 'catalog:'
+        version: 1.1.2(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-resources@7.0.4(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0))
     devDependencies:
       '@cardstack/boxel-icons':
         specifier: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,6 +306,9 @@ catalogs:
     ember-qunit:
       specifier: ^8.0.1
       version: 8.0.2
+    ember-resources:
+      specifier: ^7.0.2
+      version: 7.0.4
     ember-template-lint:
       specifier: ^7.8.1
       version: 7.8.1
@@ -674,8 +677,8 @@ importers:
         specifier: ^6.3.0
         version: 6.3.0
       ember-resources:
-        specifier: ^6.5.1
-        version: 6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-concurrency@3.1.1(@babel/core@7.26.10)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)))(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
+        specifier: 'catalog:'
+        version: 7.0.4(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)
       ember-source:
         specifier: ~5.4.0
         version: 5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)
@@ -829,8 +832,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-resources:
-        specifier: ^6.5.1
-        version: 6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-concurrency@4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)))(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
+        specifier: 'catalog:'
+        version: 7.0.4(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)
       ember-template-lint:
         specifier: 'catalog:'
         version: 7.8.1
@@ -1297,8 +1300,8 @@ importers:
         specifier: ^11.0.1
         version: 11.0.1(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-resources:
-        specifier: ^6.5.1
-        version: 6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-concurrency@3.1.1(@babel/core@7.26.10)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)))(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
+        specifier: 'catalog:'
+        version: 7.0.4(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)
       ember-source:
         specifier: ^5.4.0
         version: 5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)
@@ -1731,8 +1734,8 @@ importers:
         specifier: ^11.0.1
         version: 11.0.1(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-resources:
-        specifier: ^6.5.1
-        version: 6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-concurrency@3.1.1(@babel/core@7.26.10)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)))(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
+        specifier: 'catalog:'
+        version: 7.0.4(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)
       ember-source:
         specifier: ^5.4.0
         version: 5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)
@@ -2233,7 +2236,7 @@ importers:
         specifier: ^11.0.1
         version: 11.0.1(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
       ember-resources:
-        specifier: ^7.0.2
+        specifier: 'catalog:'
         version: 7.0.4(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)
       ember-route-template:
         specifier: ^1.0.3
@@ -7855,12 +7858,6 @@ packages:
     peerDependencies:
       ember-concurrency: ^1.2.1 || ^2.0.0-rc.1
 
-  ember-concurrency@3.1.1:
-    resolution: {integrity: sha512-doXFYYfy1C7jez+jDDlfahTp03QdjXeSY/W3Zbnx/q3UNJ9g10Shf2d7M/HvWo/TC22eU+6dPLIpqd/6q4pR+Q==}
-    engines: {node: 16.* || >= 18}
-    peerDependencies:
-      ember-source: ^3.28.0 || ^4.0.0 || >=5.0.0
-
   ember-concurrency@4.0.3:
     resolution: {integrity: sha512-deDJiB5OBYtYYOiVSt2qe5YBC8/vj1HwXPXtcw2SHijjMVL3i8ZBUmnHcaFr4RGsZJkGUr7Fg0zM45P9yUqKmQ==}
     engines: {node: 16.* || >= 18}
@@ -8051,23 +8048,6 @@ packages:
       ember-source: ^4.8.3 || >= 5.0.0
     peerDependenciesMeta:
       ember-source:
-        optional: true
-
-  ember-resources@6.5.1:
-    resolution: {integrity: sha512-8eEdbSE0sioqjpB2CWw/dKF4Ftfe9tbebuSUfMDBmP3xxTIvxTDbvDnbd8A0IbQ0z/iQt6Va+/5cadzvkbMZtg==}
-    peerDependencies:
-      '@ember/test-waiters': ^3.0.0
-      '@glimmer/component': ^1.1.2
-      '@glimmer/tracking': ^1.1.2
-      '@glint/template': ^1.0.0-beta.3 || ^1.0.0
-      ember-concurrency: ^2.0.0 || ^3.0.0
-      ember-source: ^3.28.0 || ^4.0.0 || ^5.0.0
-    peerDependenciesMeta:
-      '@ember/test-waiters':
-        optional: true
-      '@glimmer/component':
-        optional: true
-      ember-concurrency:
         optional: true
 
   ember-resources@7.0.4:
@@ -19844,21 +19824,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-concurrency@3.1.1(@babel/core@7.26.10)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)):
-    dependencies:
-      '@babel/helper-plugin-utils': 7.26.5
-      '@babel/types': 7.27.0
-      '@glimmer/tracking': 1.1.2
-      ember-cli-babel: 7.26.11
-      ember-cli-babel-plugin-helpers: 1.1.1
-      ember-cli-htmlbars: 6.3.0
-      ember-compatibility-helpers: 1.2.6(@babel/core@7.26.10)
-      ember-source: 5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-    optional: true
-
   ember-concurrency@4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)):
     dependencies:
       '@babel/helper-module-imports': 7.25.9(supports-color@8.1.1)
@@ -20191,38 +20156,6 @@ snapshots:
       ember-cli-babel: 7.26.11
     optionalDependencies:
       ember-source: 5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)
-    transitivePeerDependencies:
-      - supports-color
-
-  ember-resources@6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-concurrency@3.1.1(@babel/core@7.26.10)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)))(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)):
-    dependencies:
-      '@babel/runtime': 7.22.11
-      '@embroider/addon-shim': 1.8.9
-      '@embroider/macros': 1.16.9(@glint/template@1.3.0)
-      '@glimmer/tracking': 1.1.2
-      '@glint/template': 1.3.0
-      ember-async-data: 1.0.3(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
-      ember-source: 5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)
-    optionalDependencies:
-      '@ember/test-waiters': 3.1.0
-      '@glimmer/component': 1.1.2(@babel/core@7.26.10)
-      ember-concurrency: 3.1.1(@babel/core@7.26.10)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5))
-    transitivePeerDependencies:
-      - supports-color
-
-  ember-resources@6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-concurrency@4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)))(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)):
-    dependencies:
-      '@babel/runtime': 7.22.11
-      '@embroider/addon-shim': 1.8.9
-      '@embroider/macros': 1.16.9(@glint/template@1.3.0)
-      '@glimmer/tracking': 1.1.2
-      '@glint/template': 1.3.0
-      ember-async-data: 1.0.3(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
-      ember-source: 5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6)
-    optionalDependencies:
-      '@ember/test-waiters': 3.1.0
-      '@glimmer/component': 1.1.2(@babel/core@7.26.10)
-      ember-concurrency: 4.0.3(@babel/core@7.26.10)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,6 +303,9 @@ catalogs:
     ember-concurrency-ts:
       specifier: ^0.3.1
       version: 0.3.1
+    ember-modify-based-class-resource:
+      specifier: ^1.1.0
+      version: 1.1.2
     ember-qunit:
       specifier: ^8.0.1
       version: 8.0.2
@@ -503,6 +506,9 @@ catalogs:
       version: 2.24.1
     qunit-dom:
       specifier: ^1.6.0
+      version: 1.6.0
+    reactiveweb:
+      specifier: ^1.3.0
       version: 1.6.0
     recast:
       specifier: ^0.23.4
@@ -1938,10 +1944,10 @@ importers:
   packages/host:
     dependencies:
       ember-modify-based-class-resource:
-        specifier: ^1.1.0
+        specifier: 'catalog:'
         version: 1.1.2(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-resources@7.0.4(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0))
       reactiveweb:
-        specifier: ^1.3.0
+        specifier: 'catalog:'
         version: 1.6.0(@babel/core@7.26.10)(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))
     devDependencies:
       '@babel/core':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -110,6 +110,7 @@ catalog:
   dompurify: ^3.0.3
   ember-concurrency: ^4.0.3
   ember-concurrency-ts: ^0.3.1
+  ember-resources: ^7.0.2
   ember-template-lint: ^7.8.1
   ember-qunit: ^8.0.1
   esbuild: ^0.24.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -110,6 +110,7 @@ catalog:
   dompurify: ^3.0.3
   ember-concurrency: ^4.0.3
   ember-concurrency-ts: ^0.3.1
+  ember-modify-based-class-resource: ^1.1.0
   ember-resources: ^7.0.2
   ember-template-lint: ^7.8.1
   ember-qunit: ^8.0.1
@@ -182,6 +183,7 @@ catalog:
   qs: ^6.13.0
   qunit: ^2.24.1
   qunit-dom: ^1.6.0
+  reactiveweb: ^1.3.0
   recast: ^0.23.4
   release-it: ^14.2.1
   requireindex: ^1.2.0


### PR DESCRIPTION
This applies the `ember-resources-codemod` to silence deprecation warnings as seen [here](https://github.com/cardstack/boxel/actions/runs/15712188411/job/44272870050#step:11:50), with dependencies moved to the pnpm catalog and externals shims updated.