### PR TITLE
Improve code patching test with an edge case

### DIFF
--- a/packages/host/tests/acceptance/code-patches-test.gts
+++ b/packages/host/tests/acceptance/code-patches-test.gts
@@ -214,7 +214,13 @@ ${REPLACE_MARKER}\n\`\`\``;
     // 2. hi.txt: Hi, world! -> Greetings, world!
     // 3. hi.txt: How are you? -> We are one!
 
-    let codeBlock = `\`\`\`
+    let codeBlock = `\`\`\`ruby
+def hello
+  "I am just a simple code block, not a code patch. Even if I am here, it should not affect the 'Accept All' functionality related to code patches."
+end
+\`\`\`
+
+\`\`\`
 http://test-realm/test/hello.txt
 ${SEARCH_MARKER}
 Hello, world!


### PR DESCRIPTION
There was a bug reported where if there was a normal code block (not a code patch) present among code patches, the "Accept all" button is missing. However now that I tried to reproduce it, the issue does not exist. Perhaps it went away with the new "Accept all" button which is now in the action chin above the prompt. I added an improvement to the tests that asserts the problem is not there (anymore) 