### PR TITLE
host: Update inspector appearance

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -845,7 +845,7 @@ export default class CodeSubmode extends Component<Signature> {
         --code-mode-panel-background-color: #ebeaed;
         --code-mode-container-border-radius: 10px;
         --code-mode-realm-icon-size: 1.125rem;
-        --code-mode-active-box-shadow: 0 3px 5px 0 rgba(0, 0, 0, 0.35);
+        --code-mode-active-box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.16);
         --code-mode-padding-top: calc(
           var(--operator-mode-top-bar-item-height) +
             (2 * (var(--operator-mode-spacing)))

--- a/packages/host/app/components/operator-mode/definition-container/base.gts
+++ b/packages/host/app/components/operator-mode/definition-container/base.gts
@@ -47,7 +47,7 @@ const BaseContainerHeader: TemplateOnlyComponent<BaseContainerHeaderSignature> =
         --boxel-header-text-transform: uppercase;
         --boxel-header-letter-spacing: var(--boxel-lsp-xl);
         --boxel-header-detail-max-width: none;
-        --boxel-header-background-color: var(--boxel-100);
+        --boxel-header-background-color: var(--boxel-300);
         --boxel-header-text-color: var(--boxel-dark);
         --boxel-header-detail-max-width: 100%;
         height: var(

--- a/packages/host/app/components/operator-mode/definition-container/base.gts
+++ b/packages/host/app/components/operator-mode/definition-container/base.gts
@@ -100,9 +100,7 @@ export interface BaseArgs {
 interface BaseSignature {
   Element: HTMLElement;
   Args: BaseArgs;
-  Blocks: {
-    activeContent: [];
-  };
+  Blocks: {};
 }
 
 class BaseDefinitionContainer extends Component<BaseSignature> {
@@ -137,9 +135,6 @@ class BaseDefinitionContainer extends Component<BaseSignature> {
           <div data-test-definition-name class='definition-name'>{{@name}}</div>
 
         </div>
-        {{#if @isActive}}
-          {{yield to='activeContent'}}
-        {{/if}}
       </div>
     </BaseContainer>
 

--- a/packages/host/app/components/operator-mode/definition-container/base.gts
+++ b/packages/host/app/components/operator-mode/definition-container/base.gts
@@ -79,6 +79,7 @@ export const BaseContainer: TemplateOnlyComponent<BaseContainerSignature> =
         overflow-wrap: break-word;
       }
       .base-container.active {
+        border: 1px solid var(--boxel-400);
         box-shadow: var(--code-mode-active-box-shadow);
       }
     </style>

--- a/packages/host/app/components/operator-mode/definition-container/index.gts
+++ b/packages/host/app/components/operator-mode/definition-container/index.gts
@@ -22,9 +22,9 @@ const FileDefinitionContainer: TemplateOnlyComponent<FileSignature> = <template>
     data-test-file-definition
   >
     <:activeContent>
-      <Active @actions={{@actions}} @infoText={{@infoText}} />
     </:activeContent>
   </BaseDefinitionContainer>
+  <Active @actions={{@actions}} @infoText={{@infoText}} />
 </template>;
 
 interface ModuleArgs extends BaseArgs, ActiveArgs {}
@@ -44,9 +44,9 @@ const ModuleDefinitionContainer: TemplateOnlyComponent<ModSig> = <template>
     data-test-card-module-definition
   >
     <:activeContent>
-      <Active @actions={{@actions}} @infoText={{@infoText}} />
     </:activeContent>
   </BaseDefinitionContainer>
+  <Active @actions={{@actions}} @infoText={{@infoText}} />
 </template>;
 
 interface InstanceArgs
@@ -68,9 +68,9 @@ const InstanceDefinitionContainer: TemplateOnlyComponent<InstSig> = <template>
     data-test-card-instance-definition
   >
     <:activeContent>
-      <Active @actions={{@actions}} @infoText={{@infoText}} />
     </:activeContent>
   </BaseDefinitionContainer>
+  <Active @actions={{@actions}} @infoText={{@infoText}} />
 </template>;
 
 interface ClickableModuleArgs

--- a/packages/host/app/components/operator-mode/definition-container/index.gts
+++ b/packages/host/app/components/operator-mode/definition-container/index.gts
@@ -20,10 +20,7 @@ const FileDefinitionContainer: TemplateOnlyComponent<FileSignature> = <template>
     @isActive={{true}}
     @fileURL={{@fileURL}}
     data-test-file-definition
-  >
-    <:activeContent>
-    </:activeContent>
-  </BaseDefinitionContainer>
+  />
   <Active @actions={{@actions}} @infoText={{@infoText}} />
 </template>;
 
@@ -42,10 +39,7 @@ const ModuleDefinitionContainer: TemplateOnlyComponent<ModSig> = <template>
     @isActive={{@isActive}}
     @fileURL={{@fileURL}}
     data-test-card-module-definition
-  >
-    <:activeContent>
-    </:activeContent>
-  </BaseDefinitionContainer>
+  />
   <Active @actions={{@actions}} @infoText={{@infoText}} />
 </template>;
 
@@ -66,10 +60,7 @@ const InstanceDefinitionContainer: TemplateOnlyComponent<InstSig> = <template>
     @isActive={{true}}
     @fileURL={{@fileURL}}
     data-test-card-instance-definition
-  >
-    <:activeContent>
-    </:activeContent>
-  </BaseDefinitionContainer>
+  />
   <Active @actions={{@actions}} @infoText={{@infoText}} />
 </template>;
 

--- a/packages/host/app/components/operator-mode/definition-container/index.gts
+++ b/packages/host/app/components/operator-mode/definition-container/index.gts
@@ -40,7 +40,9 @@ const ModuleDefinitionContainer: TemplateOnlyComponent<ModSig> = <template>
     @fileURL={{@fileURL}}
     data-test-card-module-definition
   />
-  <Active @actions={{@actions}} @infoText={{@infoText}} />
+  {{#if @isActive}}
+    <Active @actions={{@actions}} @infoText={{@infoText}} />
+  {{/if}}
 </template>;
 
 interface InstanceArgs

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -603,9 +603,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
       )
       .includesText('Test Workspace B');
     assert
-      .dom(
-        '[data-test-card-instance-definition] [data-test-definition-info-text]',
-      )
+      .dom('[data-test-definition-info-text]')
       .includesText('Last saved just now');
     assert
       .dom('[data-test-card-instance-definition] [data-test-definition-header]')


### PR DESCRIPTION
Current:

<img width="269" alt="garden-design gts in Experiments Workspace 2025-06-18 15-38-37" src="https://github.com/user-attachments/assets/2c6034de-a869-415a-a14f-27b946bfd7e7" />

With this PR:

<img width="278" alt="garden-design gts in Experiments Workspace 2025-06-18 15-39-06" src="https://github.com/user-attachments/assets/2a7e37de-4478-45a0-99e1-73d16f009f72" />

Compare to design:

<img width="393" alt="Code Mode - Instance preview - Code Mode - Realm Chooser - Zeplin 2025-06-18 15-39-27" src="https://github.com/user-attachments/assets/e9398f13-5b36-47c7-9c4d-af43e22e7e0f" />

The “edgeless” look is in #2775, still in progress. The failing `host` test is in `main`.