### PR TITLE
indexing uses realm's creator's permissions

### DIFF
--- a/packages/realm-server/tests/server-endpoints-test.ts
+++ b/packages/realm-server/tests/server-endpoints-test.ts
@@ -158,7 +158,7 @@ module(basename(__filename), function () {
           // test state--there is no "delete user" matrix API
           let endpoint = `test-realm-${uuidv4()}`;
           let owner = 'mango';
-          let ownerUserId = '@mango:boxel.ai';
+          let ownerUserId = '@mango:localhost';
           let response = await request2
             .post('/_create-realm')
             .set('Accept', 'application/vnd.api+json')
@@ -324,7 +324,7 @@ module(basename(__filename), function () {
         test('dynamically created realms are not publicly readable or writable', async function (assert) {
           let endpoint = `test-realm-${uuidv4()}`;
           let owner = 'mango';
-          let ownerUserId = '@mango:boxel.ai';
+          let ownerUserId = '@mango:localhost';
           let response = await request2
             .post('/_create-realm')
             .set('Accept', 'application/vnd.api+json')
@@ -397,7 +397,7 @@ module(basename(__filename), function () {
         test('can restart a realm that was created dynamically', async function (assert) {
           let endpoint = `test-realm-${uuidv4()}`;
           let owner = 'mango';
-          let ownerUserId = '@mango:boxel.ai';
+          let ownerUserId = '@mango:localhost';
           let realmURL: string;
           {
             let response = await request2
@@ -407,7 +407,10 @@ module(basename(__filename), function () {
               .set(
                 'Authorization',
                 `Bearer ${createRealmServerJWT(
-                  { user: '@mango:boxel.ai', sessionRoom: 'session-room-test' },
+                  {
+                    user: '@mango:localhost',
+                    sessionRoom: 'session-room-test',
+                  },
                   realmSecretSeed,
                 )}`,
               )
@@ -551,7 +554,7 @@ module(basename(__filename), function () {
             .set(
               'Authorization',
               `Bearer ${createRealmServerJWT(
-                { user: '@mango:boxel.ai', sessionRoom: 'session-room-test' },
+                { user: '@mango:localhost', sessionRoom: 'session-room-test' },
                 realmSecretSeed,
               )}`,
             )
@@ -572,7 +575,7 @@ module(basename(__filename), function () {
             .set(
               'Authorization',
               `Bearer ${createRealmServerJWT(
-                { user: '@mango:boxel.ai', sessionRoom: 'session-room-test' },
+                { user: '@mango:localhost', sessionRoom: 'session-room-test' },
                 realmSecretSeed,
               )}`,
             )
@@ -597,7 +600,7 @@ module(basename(__filename), function () {
             .set(
               'Authorization',
               `Bearer ${createRealmServerJWT(
-                { user: '@mango:boxel.ai', sessionRoom: 'session-room-test' },
+                { user: '@mango:localhost', sessionRoom: 'session-room-test' },
                 realmSecretSeed,
               )}`,
             )
@@ -628,7 +631,7 @@ module(basename(__filename), function () {
             .set(
               'Authorization',
               `Bearer ${createRealmServerJWT(
-                { user: '@mango:boxel.ai', sessionRoom: 'session-room-test' },
+                { user: '@mango:localhost', sessionRoom: 'session-room-test' },
                 realmSecretSeed,
               )}`,
             )
@@ -658,7 +661,7 @@ module(basename(__filename), function () {
             .set(
               'Authorization',
               `Bearer ${createRealmServerJWT(
-                { user: '@mango:boxel.ai', sessionRoom: 'session-room-test' },
+                { user: '@mango:localhost', sessionRoom: 'session-room-test' },
                 realmSecretSeed,
               )}`,
             )
@@ -685,7 +688,7 @@ module(basename(__filename), function () {
 
         test('cannot create a new realm that collides with an existing realm', async function (assert) {
           let endpoint = `test-realm-${uuidv4()}`;
-          let ownerUserId = '@mango:boxel.ai';
+          let ownerUserId = '@mango:localhost';
           let response = await request2
             .post('/_create-realm')
             .set('Accept', 'application/vnd.api+json')
@@ -742,7 +745,7 @@ module(basename(__filename), function () {
         });
 
         test('cannot create a realm with invalid characters in endpoint', async function (assert) {
-          let ownerUserId = '@mango:boxel.ai';
+          let ownerUserId = '@mango:localhost';
           {
             let response = await request2
               .post('/_create-realm')
@@ -811,7 +814,7 @@ module(basename(__filename), function () {
         });
 
         test('can create a user', async function (assert) {
-          let ownerUserId = '@mango:boxel.ai';
+          let ownerUserId = '@mango:localhost';
           let response = await request2
             .post('/_user')
             .set('Accept', 'application/json')

--- a/packages/runtime-common/realm-index-updater.ts
+++ b/packages/runtime-common/realm-index-updater.ts
@@ -216,13 +216,11 @@ export class RealmIndexUpdater {
       this.#dbAdapter,
       this.realmURL,
     );
-    let owners = Object.entries(permissions)
+    let [realmUserId] = Object.entries(permissions)
       .filter(([_, permissions]) => permissions?.includes('realm-owner'))
-      .map(([userId]) => userId);
-    let realmUserId =
-      owners.length === 1
-        ? owners[0]
-        : owners.find((userId) => userId.startsWith('@realm/'));
+      .map(([userId]) => userId)
+      // we want to use the realm's human owner for the realm and not the bot
+      .filter((userId) => !userId.startsWith('@realm/'));
     // real matrix user ID's always start with an '@', if it doesn't that
     // means we are testing
     if (realmUserId?.startsWith('@')) {

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -220,7 +220,7 @@ export class Realm {
   #recentWrites: Map<string, number> = new Map();
   #realmSecretSeed: string;
   #disableModuleCaching = false;
-  realmServerMatrixUserId: string;
+  #realmServerMatrixUserId: string;
 
   #publicEndpoints: RouteTable<true> = new Map([
     [
@@ -271,7 +271,7 @@ export class Realm {
     this.paths = new RealmPaths(new URL(url));
     let { username, url: matrixURL } = matrix;
     this.#realmSecretSeed = secretSeed;
-    this.realmServerMatrixUserId = realmServerMatrixUserId;
+    this.#realmServerMatrixUserId = realmServerMatrixUserId;
     this.#matrixClient = new MatrixClient({
       matrixURL,
       username,
@@ -2230,7 +2230,7 @@ export class Realm {
 
   private async createRequestContext(): Promise<RequestContext> {
     let permissions = {
-      [this.realmServerMatrixUserId]: ['assume-user'] as RealmAction[],
+      [this.#realmServerMatrixUserId]: ['assume-user'] as RealmAction[],
       ...(await fetchUserPermissions(this.#dbAdapter, new URL(this.url))),
     };
     return {


### PR DESCRIPTION
This PR uses the actual realm's creator's permissions during indexing instead of the realm bot's permissions. this addresses surprising behavior where the indexer cannot read other private realms owned by the same user. This also removes a band-aid that we added to try to work around this problem. 