### PR TITLE
ci: Add icons build for vscode-boxel-tools

### DIFF
--- a/.github/workflows/manual-vscode-boxel-tools.yml
+++ b/.github/workflows/manual-vscode-boxel-tools.yml
@@ -88,6 +88,9 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - uses: ./.github/actions/init
+      - name: Build boxel-icons
+        run: pnpm build
+        working-directory: packages/boxel-icons
       - name: Build boxel-ui
         run: pnpm build
         working-directory: packages/boxel-ui/addon


### PR DESCRIPTION
The [extension build failed](https://github.com/cardstack/boxel/actions/runs/15764104195/job/44437116810#step:4:33) because `boxel-ui` now needs `boxel-icons` to be built first.