### PR TITLE
host: Remove module inspector permanent scrollbar

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
+++ b/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
@@ -553,7 +553,7 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
       }
 
       .module-inspector-content {
-        overflow: scroll;
+        overflow: auto;
         height: 100%;
         background-color: var(--boxel-light);
       }


### PR DESCRIPTION
I wasn’t able to get the scrollbar to show (I even plugged a mouse in?) but this was just a mistake on my part when I worked on the accordion-to-button change.