### PR TITLE
Fix padding in ai assistant

### DIFF
--- a/packages/host/app/components/ai-assistant/code-block.gts
+++ b/packages/host/app/components/ai-assistant/code-block.gts
@@ -703,7 +703,6 @@ let CodeBlockActionsComponent: TemplateOnlyComponent<CodeBlockActionsSignature> 
         gap: var(--boxel-sp-xs);
         border-bottom-left-radius: 12px;
         border-bottom-right-radius: 12px;
-        margin-top: -5px;
       }
     </style>
     <div class='code-block-actions'>

--- a/packages/host/app/components/ai-assistant/message/index.gts
+++ b/packages/host/app/components/ai-assistant/message/index.gts
@@ -296,15 +296,15 @@ export default class AiAssistantMessage extends Component<Signature> {
             </div>
           {{/if}}
 
-          <div class='error-footer'>
-            {{#if this.errorMessages.length}}
+          {{#if this.errorMessages.length}}
+            <div class='error-footer'>
               <Alert
                 @type='error'
                 @messages={{this.errorMessages}}
                 @retryAction={{@retryAction}}
               />
-            {{/if}}
-          </div>
+            </div>
+          {{/if}}
         </div>
       </div>
     </div>
@@ -366,7 +366,7 @@ export default class AiAssistantMessage extends Component<Signature> {
       }
 
       .content-container {
-        margin-top: var(--boxel-sp-xs);
+        margin-top: 13px;
         border-radius: var(--boxel-border-radius-xxs)
           var(--boxel-border-radius-xl) var(--boxel-border-radius-xl)
           var(--boxel-border-radius-xl);
@@ -390,6 +390,11 @@ export default class AiAssistantMessage extends Component<Signature> {
           text on dark background (otherwise not good for accessibility) */
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
+        padding: 0;
+      }
+
+      .is-from-assistant .content :deep(p:last-of-type) {
+        margin-bottom: 0;
       }
 
       .is-from-assistant .content :deep(pre) {
@@ -398,6 +403,10 @@ export default class AiAssistantMessage extends Component<Signature> {
 
       .is-from-assistant .content :deep(pre code) {
         overflow-wrap: break-word;
+      }
+
+      .is-from-assistant .content-container {
+        margin-top: 9px;
       }
 
       .is-pending .content,

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -252,9 +252,7 @@ export default class Room extends Component<Signature> {
       :deep(.ai-assistant-conversation > *:first-child) {
         margin-top: auto;
       }
-      :deep(.ai-assistant-conversation > *:nth-last-of-type(2)) {
-        padding-bottom: var(--boxel-sp-xl);
-      }
+
       .loading-indicator {
         margin-top: auto;
         margin-bottom: auto;


### PR DESCRIPTION
The current padding in various subcontainers the AI assistant feels a bit off visually. Here's an updated version that should be easier on the eyes IMO. I tried to follow the padding in this design: [Zeplin](https://app.zeplin.io/project/680fe3eceb309637e988b232/screen/680fe4362947a1ed0b8b91d2)

Before:
<img width="226" alt="image" src="https://github.com/user-attachments/assets/7574246f-994a-4482-ad3b-beebc57edb36" />

After:
<img width="226" alt="image" src="https://github.com/user-attachments/assets/1726cd23-444f-451e-8ad0-c83898488e77" />

