### PR TITLE
Separate extensions in Recent Files

### DIFF
--- a/packages/host/app/components/editor/recent-files.gts
+++ b/packages/host/app/components/editor/recent-files.gts
@@ -77,11 +77,8 @@ class File extends Component<FileArgs> {
 
   get fileName() {
     const path = this.args.recentFile.filePath;
-    const lastSlashIndex = path.lastIndexOf('/');
-    const fileName =
-      lastSlashIndex !== -1 ? path.substring(lastSlashIndex + 1) : path;
-    const lastDotIndex = fileName.lastIndexOf('.');
-    return lastDotIndex !== -1 ? fileName.substring(0, lastDotIndex) : fileName;
+    const lastDotIndex = path.lastIndexOf('.');
+    return lastDotIndex !== -1 ? path.substring(0, lastDotIndex) : path;
   }
 
   get fileExtension() {

--- a/packages/host/app/components/editor/recent-files.gts
+++ b/packages/host/app/components/editor/recent-files.gts
@@ -75,6 +75,24 @@ class File extends Component<FileArgs> {
     );
   }
 
+  get fileName() {
+    const path = this.args.recentFile.filePath;
+    const lastSlashIndex = path.lastIndexOf('/');
+    const fileName =
+      lastSlashIndex !== -1 ? path.substring(lastSlashIndex + 1) : path;
+    const lastDotIndex = fileName.lastIndexOf('.');
+    return lastDotIndex !== -1 ? fileName.substring(0, lastDotIndex) : fileName;
+  }
+
+  get fileExtension() {
+    const path = this.args.recentFile.filePath;
+    const lastSlashIndex = path.lastIndexOf('/');
+    const fileName =
+      lastSlashIndex !== -1 ? path.substring(lastSlashIndex + 1) : path;
+    const lastDotIndex = fileName.lastIndexOf('.');
+    return lastDotIndex !== -1 ? fileName.substring(lastDotIndex) : '';
+  }
+
   <template>
     {{#unless this.isSelected}}
       {{! template-lint-disable require-presentational-children }}
@@ -86,7 +104,10 @@ class File extends Component<FileArgs> {
           {{on 'click' this.openFile}}
         >
           <RealmIcon @realmInfo={{realm.info}} />
-          {{@recentFile.filePath}}
+          <span class='file-name'>{{this.fileName}}</span>
+          {{#if this.fileExtension}}
+            <span class='file-extension'>{{this.fileExtension}}</span>
+          {{/if}}
         </li>
       </WithLoadedRealm>
     {{/unless}}
@@ -102,6 +123,21 @@ class File extends Component<FileArgs> {
         gap: var(--boxel-sp-xxxs);
         overflow-wrap: anywhere;
         overflow: hidden;
+        --boxel-realm-icon-size: 18px;
+      }
+
+      .file-name {
+        flex: 1;
+        min-width: 0;
+        font: 600 var(--boxel-font-xs);
+      }
+
+      .file-extension {
+        color: var(--boxel-450);
+        font-weight: 400;
+        flex-shrink: 0;
+        text-transform: uppercase;
+        font: 500 var(--boxel-font-xs);
       }
     </style>
   </template>

--- a/packages/host/app/components/editor/recent-files.gts
+++ b/packages/host/app/components/editor/recent-files.gts
@@ -113,7 +113,7 @@ class File extends Component<FileArgs> {
         background-color: var(--boxel-light);
         padding: var(--boxel-sp-xxs);
         font-weight: 600;
-        margin-bottom: var(--boxel-sp-xs);
+        margin-bottom: 4px;
         border-radius: var(--code-mode-container-border-radius);
         display: flex;
         align-items: center;

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -894,10 +894,6 @@ export default class CodeSubmode extends Component<Signature> {
         --boxel-panel-resize-separator-background-color: var(--boxel-dark);
       }
 
-      .recent-files-panel {
-        background-color: var(--code-mode-panel-background-color);
-      }
-
       .monaco-editor-panel {
         background-color: var(--monaco-background);
       }

--- a/packages/host/app/components/operator-mode/code-submode/inner-container.gts
+++ b/packages/host/app/components/operator-mode/code-submode/inner-container.gts
@@ -32,7 +32,7 @@ class InnerContainerContent extends Component<ContentSignature> {
         padding: var(--boxel-sp-xs) var(--boxel-sp-xs) var(--boxel-sp-sm);
         overflow-y: auto;
         height: 100%;
-        background-color: var(--boxel-light);
+        background-color: var(--boxel-200);
       }
       .inner-container__header + .inner-container__content {
         padding-top: 0;
@@ -114,7 +114,7 @@ const CodeSubmodeInnerContainer: TemplateOnlyComponent<Signature> = <template>
       position: relative;
       display: flex;
       flex-direction: column;
-      background-color: var(--boxel-light);
+      background-color: var(--boxel-200);
       overflow: hidden;
     }
   </style>

--- a/packages/host/tests/acceptance/code-submode/recent-files-test.ts
+++ b/packages/host/tests/acceptance/code-submode/recent-files-test.ts
@@ -363,35 +363,35 @@ module('Acceptance | code submode | recent files tests', function (hooks) {
     await click('[data-test-file="index.json"]');
     assert
       .dom('[data-test-recent-file]:nth-child(1)')
-      .containsText('Person/1.json');
+      .containsText('Person/1 .json');
 
     await waitFor('[data-test-file="Person/1.json"]');
     await click('[data-test-file="Person/1.json"]');
 
     assert
       .dom('[data-test-recent-file]:nth-child(1)')
-      .containsText('index.json');
+      .containsText('index .json');
 
     await waitFor('[data-test-file="français.json"]');
     await click('[data-test-file="français.json"]');
 
     assert
       .dom('[data-test-recent-file]:first-child')
-      .containsText('Person/1.json')
+      .containsText('Person/1 .json')
       .doesNotContainText(testRealmURL, 'expected realm root to be hidden');
     assert
       .dom('[data-test-recent-file]:nth-child(2)')
-      .containsText('index.json');
+      .containsText('index .json');
 
     await click('[data-test-recent-file]:nth-child(2)');
     assert.dom('[data-test-index-card]').exists('index card is rendered');
 
     assert
       .dom('[data-test-recent-file]:first-child')
-      .containsText('français.json');
+      .containsText('français .json');
     assert
       .dom('[data-test-recent-file]:nth-child(2)')
-      .containsText('Person/1.json');
+      .containsText('Person/1 .json');
 
     assert.deepEqual(recentFilesWoTimestamp(), [
       [testRealmURL, 'index.json', null],
@@ -432,21 +432,21 @@ module('Acceptance | code submode | recent files tests', function (hooks) {
 
     assert
       .dom('[data-test-recent-file]:nth-child(1)')
-      .containsText('file-0.txt');
+      .containsText('file-0 .txt');
 
     assert
       .dom('[data-test-recent-file]:nth-child(99)')
-      .containsText('file-98.txt');
+      .containsText('file-98 .txt');
 
     await click('[data-test-file="index.json"]');
 
     assert
       .dom('[data-test-recent-file]:nth-child(1)')
-      .containsText('Person/1.json');
+      .containsText('Person/1 .json');
 
     assert
       .dom('[data-test-recent-file]:nth-child(99)')
-      .containsText('file-97.txt');
+      .containsText('file-97 .txt');
   });
 
   test('recent files section does not list files not-found', async function (assert) {
@@ -483,7 +483,7 @@ module('Acceptance | code submode | recent files tests', function (hooks) {
     assert.dom(`[data-test-recent-file="${testRealmURL}person.gts"]`).exists();
     assert
       .dom(`[data-test-recent-file]:first-child`)
-      .containsText('person.gts');
+      .containsText('person .gts');
 
     await fillIn(
       '[data-test-card-url-bar-input]',
@@ -503,7 +503,7 @@ module('Acceptance | code submode | recent files tests', function (hooks) {
     assert.dom(`[data-test-recent-file="${testRealmURL}pers"]`).doesNotExist();
     assert
       .dom(`[data-test-recent-file]:first-child`)
-      .containsText('person.gts');
+      .containsText('person .gts');
   });
 
   test('displays recent files in base realm', async function (assert) {
@@ -561,11 +561,15 @@ module('Acceptance | code submode | recent files tests', function (hooks) {
     await click('[data-test-file="field-component.gts"]');
     await waitFor('[data-test-file="field-component.gts"].selected');
 
-    assert.dom('[data-test-recent-file]:nth-child(1)').containsText('date.gts');
+    assert
+      .dom('[data-test-recent-file]:nth-child(1)')
+      .containsText('date .gts');
     assert
       .dom('[data-test-recent-file]:nth-child(2)')
-      .containsText('code-ref.gts');
-    assert.dom('[data-test-recent-file]:nth-child(3)').containsText('spec.gts');
+      .containsText('code-ref .gts');
+    assert
+      .dom('[data-test-recent-file]:nth-child(3)')
+      .containsText('spec .gts');
 
     // the cursor positions seem to be different in CI than locally
     let removedCursorPositions = recentFilesWoTimestamp()?.map(


### PR DESCRIPTION
Other than separating extensions in recent files, I also update the icon and font size. And I update the background color following this design https://app.zeplin.io/project/67ec7489d7c2a4f4eef02226/screen/67ec74b4248c7aa0c104ceb2. Here is the implementation:

<img width="439" alt="Screenshot 2025-06-23 at 19 21 11" src="https://github.com/user-attachments/assets/4aa35a0e-e5ac-41df-a255-1370d0b5e680" />

