### PR TITLE
Fix race condition where we try to make realm session before matrix SDK loaded

### DIFF
--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -32,6 +32,7 @@ import {
   logger,
   ResolvedCodeRef,
   isCardInstance,
+  Deferred,
 } from '@cardstack/runtime-common';
 
 import {
@@ -174,6 +175,7 @@ export default class MatrixService extends Service {
   private timelineQueue: { event: MatrixEvent; oldEventId?: string }[] = [];
   private roomStateQueue: MatrixSDK.RoomState[] = [];
   #ready: Promise<void>;
+  #clientReadyDeferred = new Deferred<void>();
   #matrixSDK: ExtendedMatrixSDK | undefined;
   #eventBindings: [EmittedEvents, (...arg: any[]) => void][] | undefined;
   currentUserEventReadReceipts: TrackedMap<string, { readAt: Date }> =
@@ -239,6 +241,7 @@ export default class MatrixService extends Service {
     this._client = this.matrixSDK.createClient({
       baseUrl: matrixURL,
     });
+    this.#clientReadyDeferred.fulfill();
 
     // building the event bindings like this so that we can consistently bind
     // and unbind these events programmatically--this way if we add a new event
@@ -606,7 +609,7 @@ export default class MatrixService extends Service {
   }
 
   async createRealmSession(realmURL: URL) {
-    await this.loadSDK();
+    await this.#clientReadyDeferred.promise;
     return this.client.createRealmSession(realmURL);
   }
 

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -606,6 +606,7 @@ export default class MatrixService extends Service {
   }
 
   async createRealmSession(realmURL: URL) {
+    await this.loadSDK();
     return this.client.createRealmSession(realmURL);
   }
 


### PR DESCRIPTION
This fixes a race condition I saw locally

![image](https://github.com/user-attachments/assets/61383955-5288-453c-9cf1-2b0d603b37df)
