### PR TITLE
Don't race worker manager job stuck job detection with job reattempt

### DIFF
--- a/packages/realm-server/worker-manager.ts
+++ b/packages/realm-server/worker-manager.ts
@@ -228,7 +228,7 @@ async function monitorWorker(workerId: string, worker: ChildProcess) {
   let stuckJobs = (await query([
     `SELECT id, job_id FROM job_reservations WHERE worker_id=`,
     param(workerId),
-    `AND completed_at IS NULL AND locked_until < NOW()`,
+    `AND completed_at IS NULL AND locked_until < NOW() - INTERVAL '30 seconds'`,
   ])) as { id: string; job_id: string }[];
 
   if (stuckJobs.length > 0) {


### PR DESCRIPTION
The worker manager's stuck job detection is a bit too aggressive. we need to make sure that it doesn't get in the way of job reattempting. The idea is that the worker manager should step in when it looks like the job cannot be handled from within its VM. let's give the job 30 seconds of grace after the locked_until time for the queue to try to deal with it organically before the worker manager intervenes