### PR TITLE
host: Change chat avatars and spacing to be smaller

### DIFF
--- a/packages/host/app/components/ai-assistant/message/index.gts
+++ b/packages/host/app/components/ai-assistant/message/index.gts
@@ -390,6 +390,7 @@ export default class AiAssistantMessage extends Component<Signature> {
           text on dark background (otherwise not good for accessibility) */
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
+        padding: 0;
       }
 
       .is-from-assistant .content :deep(pre) {

--- a/packages/host/app/components/ai-assistant/message/index.gts
+++ b/packages/host/app/components/ai-assistant/message/index.gts
@@ -312,8 +312,8 @@ export default class AiAssistantMessage extends Component<Signature> {
     <style scoped>
       .ai-assistant-message {
         --ai-bot-message-background-color: #3b394b;
-        --ai-assistant-message-avatar-size: 1.25rem; /* 20px. */
-        --ai-assistant-message-meta-height: 1.25rem; /* 20px */
+        --ai-assistant-message-avatar-size: 0.75rem; /* 20px. */
+        --ai-assistant-message-meta-height: 0.75rem; /* 20px */
         --ai-assistant-message-gap: var(--boxel-sp-xs);
         --profile-avatar-icon-size: var(--ai-assistant-message-avatar-size);
         --profile-avatar-icon-border: 1px solid var(--boxel-400);

--- a/packages/host/app/components/ai-assistant/message/index.gts
+++ b/packages/host/app/components/ai-assistant/message/index.gts
@@ -314,7 +314,7 @@ export default class AiAssistantMessage extends Component<Signature> {
         --ai-bot-message-background-color: #3b394b;
         --ai-assistant-message-avatar-size: 0.75rem; /* 20px. */
         --ai-assistant-message-meta-height: 0.75rem; /* 20px */
-        --ai-assistant-message-gap: var(--boxel-sp-xs);
+        --ai-assistant-message-gap: var(--boxel-sp-xxxs);
         --profile-avatar-icon-size: var(--ai-assistant-message-avatar-size);
         --profile-avatar-icon-border: 1px solid var(--boxel-400);
       }
@@ -366,7 +366,7 @@ export default class AiAssistantMessage extends Component<Signature> {
       }
 
       .content-container {
-        margin-top: var(--boxel-sp-xs);
+        margin-top: var(--boxel-sp-xxxs);
         border-radius: var(--boxel-border-radius-xxs)
           var(--boxel-border-radius-xl) var(--boxel-border-radius-xl)
           var(--boxel-border-radius-xl);

--- a/packages/host/app/components/ai-assistant/message/index.gts
+++ b/packages/host/app/components/ai-assistant/message/index.gts
@@ -312,8 +312,8 @@ export default class AiAssistantMessage extends Component<Signature> {
     <style scoped>
       .ai-assistant-message {
         --ai-bot-message-background-color: #3b394b;
-        --ai-assistant-message-avatar-size: 0.75rem; /* 20px. */
-        --ai-assistant-message-meta-height: 0.75rem; /* 20px */
+        --ai-assistant-message-avatar-size: 0.75rem; /* 12px. */
+        --ai-assistant-message-meta-height: 0.75rem; /* 12px */
         --ai-assistant-message-gap: var(--boxel-sp-xxxs);
         --profile-avatar-icon-size: var(--ai-assistant-message-avatar-size);
         --profile-avatar-icon-border: 1px solid var(--boxel-400);


### PR DESCRIPTION
<table>
<tr>
<td>Before</td>
<td>Now</td>
</tr>
<tr>
<td>
<img width="368" alt="garden-design gts in Experiments Workspace 2025-06-23 10-14-16" src="https://github.com/user-attachments/assets/9e1d8ee2-9540-423a-baf2-be2844af2e89" />
</td>
<td>
<img width="369" alt="garden-design gts in Experiments Workspace 2025-06-23 10-22-21" src="https://github.com/user-attachments/assets/800cebd7-b70e-4728-b674-d5bb7237e745" />
</td>
</tr>
<tr>
<td colspan=2>
Design
</td>
</tr>
<tr>
<td colspan=2>
<img width="557" alt="LATEST UI Jun 17 - LATEST UI Jun 17 - Zeplin 2025-06-23 10-16-06" src="https://github.com/user-attachments/assets/a1f0acae-6d7b-4e64-a287-947e03a6d0c0" />
</td>
</tr>
</table>