### PR TITLE
Fix sprint planner edit card in stack issue

### DIFF
--- a/packages/catalog-realm/crm-app/components/base-task-planner.gts
+++ b/packages/catalog-realm/crm-app/components/base-task-planner.gts
@@ -157,7 +157,7 @@ interface TaskPlannerArgs {
     parentId: string | undefined;
     context: CardContext | undefined;
     emptyStateMessage?: string;
-    viewCard: () => void;
+    editCard: () => void;
   };
   Element: HTMLElement;
 }
@@ -403,7 +403,7 @@ export class TaskPlanner extends GlimmerComponent<TaskPlannerArgs> {
     <div class='task-app'>
       {{#if (not @parentId)}}
         <div class='disabled'>
-          <BoxelButton @kind='primary' {{on 'click' @viewCard}}>
+          <BoxelButton @kind='primary' {{on 'click' @editCard}}>
             {{this.emptyStateMessage}}
           </BoxelButton>
         </div>

--- a/packages/catalog-realm/crm-app/crm-app.gts
+++ b/packages/catalog-realm/crm-app/crm-app.gts
@@ -539,11 +539,11 @@ class CrmAppTemplate extends Component<typeof CrmApp> {
     this.activeFilter = this.activeFilter;
   }
 
-  @action viewCard() {
+  @action editCard() {
     if (!this.args.model.id) {
       throw new Error('No card id');
     }
-    this.args.context?.actions?.viewCard?.(new URL(this.args.model.id), 'edit');
+    this.args.context?.actions?.editCard?.(this.args.model as CardDef);
   }
 
   <template>
@@ -643,7 +643,7 @@ class CrmAppTemplate extends Component<typeof CrmApp> {
             @model={{@model}}
             @context={{@context}}
             @realmURL={{this.currentRealm}}
-            @viewCard={{this.viewCard}}
+            @editCard={{this.editCard}}
             @searchFilter={{this.searchFilter}}
             @taskFilter={{this.taskFilter}}
             @sort={{this.taskSort}}

--- a/packages/catalog-realm/crm-app/task-planner.gts
+++ b/packages/catalog-realm/crm-app/task-planner.gts
@@ -20,7 +20,7 @@ interface CRMTaskPlannerArgs {
     model: Partial<AppCard>;
     context: CardContext | undefined;
     realmURL: URL | undefined;
-    viewCard: () => void;
+    editCard: () => void;
     searchFilter?: Filter[];
     taskFilter?: Filter[];
     sort?: TaskSort;
@@ -290,7 +290,7 @@ export class CRMTaskPlanner extends GlimmerComponent<CRMTaskPlannerArgs> {
       @parentId={{this.parentId}}
       @context={{@context}}
       @emptyStateMessage={{this.emptyStateMessage}}
-      @viewCard={{@viewCard}}
+      @editCard={{@editCard}}
     />
   </template>
 }

--- a/packages/catalog-realm/sprint-planner/components/base-task-planner.gts
+++ b/packages/catalog-realm/sprint-planner/components/base-task-planner.gts
@@ -157,7 +157,7 @@ interface TaskPlannerArgs {
     parentId: string | undefined;
     context: CardContext | undefined;
     emptyStateMessage?: string;
-    viewCard: () => void;
+    editCard: () => void;
   };
   Element: HTMLElement;
 }
@@ -403,7 +403,7 @@ export class TaskPlanner extends GlimmerComponent<TaskPlannerArgs> {
     <div class='task-app'>
       {{#if (not @parentId)}}
         <div class='disabled'>
-          <BoxelButton @kind='primary' {{on 'click' @viewCard}}>
+          <BoxelButton @kind='primary' {{on 'click' @editCard}}>
             {{this.emptyStateMessage}}
           </BoxelButton>
         </div>

--- a/packages/catalog-realm/sprint-planner/sprint-planner.gts
+++ b/packages/catalog-realm/sprint-planner/sprint-planner.gts
@@ -206,11 +206,11 @@ class SprintPlannerIsolated extends Component<typeof SprintPlanner> {
     };
   }
 
-  @action viewCard() {
+  @action editCard() {
     if (!this.args.model.id) {
       throw new Error('No card id');
     }
-    this.args.context?.actions?.viewCard?.(new URL(this.args.model.id), 'edit');
+    this.args.context?.actions?.editCard?.(this.args.model as CardDef);
   }
 
   <template>
@@ -220,7 +220,7 @@ class SprintPlannerIsolated extends Component<typeof SprintPlanner> {
       @parentId={{this.parentId}}
       @context={{@context}}
       @emptyStateMessage={{this.emptyStateMessage}}
-      @viewCard={{this.viewCard}}
+      @editCard={{this.editCard}}
     />
   </template>
 }

--- a/packages/experiments-realm/components/base-task-planner.gts
+++ b/packages/experiments-realm/components/base-task-planner.gts
@@ -157,7 +157,7 @@ interface TaskPlannerArgs {
     parentId: string | undefined;
     context: CardContext | undefined;
     emptyStateMessage?: string;
-    viewCard: () => void;
+    editCard: () => void;
   };
   Element: HTMLElement;
 }
@@ -403,7 +403,7 @@ export class TaskPlanner extends GlimmerComponent<TaskPlannerArgs> {
     <div class='task-app'>
       {{#if (not @parentId)}}
         <div class='disabled'>
-          <BoxelButton @kind='primary' {{on 'click' @viewCard}}>
+          <BoxelButton @kind='primary' {{on 'click' @editCard}}>
             {{this.emptyStateMessage}}
           </BoxelButton>
         </div>

--- a/packages/experiments-realm/crm-app.gts
+++ b/packages/experiments-realm/crm-app.gts
@@ -539,11 +539,11 @@ class CrmAppTemplate extends Component<typeof CrmApp> {
     this.activeFilter = this.activeFilter;
   }
 
-  @action viewCard() {
+  @action editCard() {
     if (!this.args.model.id) {
       throw new Error('No card id');
     }
-    this.args.context?.actions?.viewCard?.(new URL(this.args.model.id), 'edit');
+    this.args.context?.actions?.editCard?.(this.args.model as CardDef);
   }
 
   <template>
@@ -643,7 +643,7 @@ class CrmAppTemplate extends Component<typeof CrmApp> {
             @model={{@model}}
             @context={{@context}}
             @realmURL={{this.currentRealm}}
-            @viewCard={{this.viewCard}}
+            @editCard={{this.editCard}}
             @searchFilter={{this.searchFilter}}
             @taskFilter={{this.taskFilter}}
             @sort={{this.taskSort}}

--- a/packages/experiments-realm/crm/task-planner.gts
+++ b/packages/experiments-realm/crm/task-planner.gts
@@ -20,7 +20,7 @@ interface CRMTaskPlannerArgs {
     model: Partial<AppCard>;
     context: CardContext | undefined;
     realmURL: URL | undefined;
-    viewCard: () => void;
+    editCard: () => void;
     searchFilter?: Filter[];
     taskFilter?: Filter[];
     sort?: TaskSort;
@@ -290,7 +290,7 @@ export class CRMTaskPlanner extends GlimmerComponent<CRMTaskPlannerArgs> {
       @parentId={{this.parentId}}
       @context={{@context}}
       @emptyStateMessage={{this.emptyStateMessage}}
-      @viewCard={{@viewCard}}
+      @editCard={{@editCard}}
     />
   </template>
 }

--- a/packages/experiments-realm/sprint-planner.gts
+++ b/packages/experiments-realm/sprint-planner.gts
@@ -206,11 +206,11 @@ class SprintPlannerIsolated extends Component<typeof SprintPlanner> {
     };
   }
 
-  @action viewCard() {
+  @action editCard() {
     if (!this.args.model.id) {
       throw new Error('No card id');
     }
-    this.args.context?.actions?.viewCard?.(new URL(this.args.model.id), 'edit');
+    this.args.context?.actions?.editCard?.(this.args.model as CardDef);
   }
 
   <template>
@@ -220,7 +220,7 @@ class SprintPlannerIsolated extends Component<typeof SprintPlanner> {
       @parentId={{this.parentId}}
       @context={{@context}}
       @emptyStateMessage={{this.emptyStateMessage}}
-      @viewCard={{this.viewCard}}
+      @editCard={{this.editCard}}
     />
   </template>
 }


### PR DESCRIPTION
Refer to https://linear.app/cardstack/issue/CS-8917/sprint-planner-link-a-project-to-continue-not-working, more findings inside the linear ticket comment


**Solution**
We shall use `editCard` action exists in the interact submode, which already has the logic to change the card to edit mode from the existing stack item. 

