### PR TITLE
host: Fix toggle buttons in narrow containers

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode/toggle-button.gts
+++ b/packages/host/app/components/operator-mode/code-submode/toggle-button.gts
@@ -43,12 +43,13 @@ const ToggleButton: TemplateOnlyComponent<ToggleButtonSignature> = <template>
       --boxel-button-border: 1px solid var(--boxel-400);
       --boxel-button-font: 600 var(--boxel-font-xs);
       --boxel-button-letter-spacing: var(--boxel-lsp-xs);
-      --boxel-button-min-width: 4rem;
+      --boxel-button-min-width: 6rem;
       --boxel-button-padding: 0;
       --boxel-button-color: var(--boxel-light);
       border-radius: var(--boxel-border-radius);
       flex: 1;
       justify-content: space-between;
+      white-space: nowrap;
     }
     .toggle-button:hover:not(:disabled) {
       border-color: var(--boxel-dark);
@@ -69,6 +70,7 @@ const ToggleButton: TemplateOnlyComponent<ToggleButtonSignature> = <template>
     .icon {
       transform: scale(0.75);
       margin: 2px -6px 0 4px;
+      flex-shrink: 0;
     }
   </style>
 </template>;


### PR DESCRIPTION
Before, the icons would shrink and button text was wrapping, weird appearance:

![screencast 2025-06-23 10-50-58](https://github.com/user-attachments/assets/644ee315-708d-408b-8e5e-b6ef9379c220)

Now the icons don’t shrink, text doesn’t wrap, but buttons wrap earlier:

![screencast 2025-06-23 10-47-41](https://github.com/user-attachments/assets/ecb4f4b3-05c7-4bb9-91bb-326480b087bb)
