### PR TITLE
Don't full index private realms at boot

### DIFF
--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -225,6 +225,7 @@ let autoMigrate = migrateDB || undefined;
         queue,
       },
       {
+        fullIndexOnStartup: true,
         ...(process.env.DISABLE_MODULE_CACHING === 'true'
           ? { disableModuleCaching: true }
           : {}),

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -431,6 +431,32 @@ module(basename(__filename), function () {
       },
     });
 
+    test('realm is full indexed at boot', async function (assert) {
+      let jobs = await testDbAdapter.execute('select * from jobs');
+      assert.strictEqual(
+        jobs.length,
+        1,
+        'there is one job that was run in the queue',
+      );
+      let [job] = jobs;
+      assert.strictEqual(
+        job.job_type,
+        'from-scratch-index',
+        'the job is a from scratch index job',
+      );
+      assert.strictEqual(
+        job.concurrency_group,
+        `indexing:${testRealm}`,
+        'the job is an index of the test realm',
+      );
+      assert.strictEqual(
+        job.status,
+        'resolved',
+        'the job completed successfully',
+      );
+      assert.ok(job.finished_at, 'the job was marked with a finish time');
+    });
+
     test('can store card pre-rendered html in the index', async function (assert) {
       let entry = await realm.realmIndexQueryEngine.instance(
         new URL(`${testRealm}mango`),

--- a/packages/realm-server/tests/server-endpoints-test.ts
+++ b/packages/realm-server/tests/server-endpoints-test.ts
@@ -553,11 +553,20 @@ module(basename(__filename), function () {
             id = response.body.data.id;
           }
 
+          let jobsBeforeRestart = await dbAdapter.execute('select * from jobs');
+
           // Stop and restart the server
           testRealmServer2.testingOnlyUnmountRealms();
           await closeServer(testRealmHttpServer2);
           await startRealmServer(dbAdapter, publisher, runner);
           await testRealmServer2.start();
+
+          let jobsAfterRestart = await dbAdapter.execute('select * from jobs');
+          assert.strictEqual(
+            jobsBeforeRestart.length,
+            jobsAfterRestart.length,
+            'no new indexing jobs were created on boot for the created realm',
+          );
 
           {
             let response = await request2

--- a/packages/runtime-common/realm-index-updater.ts
+++ b/packages/runtime-common/realm-index-updater.ts
@@ -85,10 +85,6 @@ export class RealmIndexUpdater {
     return await this.#indexWriter.isNewIndex(this.realmURL);
   }
 
-  async run() {
-    await this.fullIndex();
-  }
-
   indexing() {
     return this.#indexingDeferred?.promise;
   }

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -185,6 +185,7 @@ export interface RealmAdapter {
 interface Options {
   disableModuleCaching?: true;
   copiedFromRealm?: URL;
+  fullIndexOnStartup?: true;
 }
 
 interface UpdateItem {
@@ -218,6 +219,7 @@ export class Realm {
   #recentWrites: Map<string, number> = new Map();
   #realmSecretSeed: string;
   #disableModuleCaching = false;
+  #fullIndexOnStartup = false;
 
   #publicEndpoints: RouteTable<true> = new Map([
     [
@@ -266,6 +268,7 @@ export class Realm {
     this.paths = new RealmPaths(new URL(url));
     let { username, url: matrixURL } = matrix;
     this.#realmSecretSeed = secretSeed;
+    this.#fullIndexOnStartup = opts?.fullIndexOnStartup ?? false;
     this.#matrixClient = new MatrixClient({
       matrixURL,
       username,
@@ -595,7 +598,7 @@ export class Realm {
   }
 
   async reindex() {
-    await this.#realmIndexUpdater.run();
+    await this.#realmIndexUpdater.fullIndex();
     this.broadcastRealmEvent({
       eventName: 'index',
       indexType: 'full',
@@ -606,15 +609,19 @@ export class Realm {
     await Promise.resolve();
     let startTime = Date.now();
     let isNewIndex = await this.#realmIndexUpdater.isNewIndex();
-    let promise = this.#realmIndexUpdater.run();
-    if (isNewIndex) {
-      // we only await the full indexing at boot if this is a brand new index
-      await promise;
+    if (isNewIndex || this.#fullIndexOnStartup) {
+      let promise = this.#realmIndexUpdater.fullIndex();
+      if (isNewIndex) {
+        // we only await the full indexing at boot if this is a brand new index
+        await promise;
+      }
+      // not sure how useful this event is--nothing is currently listening for
+      // it, and it may happen during or after the full index...
+      this.broadcastRealmEvent({
+        eventName: 'index',
+        indexType: 'full',
+      });
     }
-    this.broadcastRealmEvent({
-      eventName: 'index',
-      indexType: 'full',
-    });
     this.#perfLog.debug(
       `realm server ${this.url} startup in ${Date.now() - startTime} ms`,
     );


### PR DESCRIPTION
There is still a significant matrix performance hit at boot even after we are using a single user to do matrix indexing. specifically the realm auth dance requires the realm server to login with its bot creds. at boot when we do full index of all realms that triggers every single realm to have it's realm server login with its bot during the full indexing. Really private realms should never change in between realm server restarts. if they do it is because of manual intervention by staff--and we can make a special mechanism to support that instead. So this PR removes full indexing at boot for all the private realms.