### PR TITLE
Fix AI assistant toast blocks playground format chooser buttons

### DIFF
--- a/packages/host/app/components/ai-assistant/toast.gts
+++ b/packages/host/app/components/ai-assistant/toast.gts
@@ -66,7 +66,7 @@ export default class AiAssistantToast extends Component<Signature> {
         gap: var(--boxel-sp);
         background-color: var(--boxel-ai-purple);
         border-radius: var(--boxel-border-radius);
-        padding: var(--boxel-sp);
+        padding: 0;
 
         overflow: hidden;
 
@@ -85,6 +85,7 @@ export default class AiAssistantToast extends Component<Signature> {
         transform: translateY(100%);
       }
       .visible {
+        padding: var(--boxel-sp);
         opacity: 1;
         height: fit-content;
         transform: translateY(0);


### PR DESCRIPTION
Refer to https://linear.app/cardstack/issue/CS-8882/fix-issue-where-content-on-bottom-right-can-get-hidden-behind-an

**Issue**
![image](https://github.com/user-attachments/assets/698552e3-1696-4695-b0db-c85292a70c58)
- The playground format chooser is not clickable at certain browser widths.
- This is caused by the AI assistant toast component, which retains padding even when empty, blocking click interactions.

**Fix**

https://github.com/user-attachments/assets/548fce13-ed07-4a11-9385-a747818d0077


- Removed padding from the toast component when it has no visible content.
