### PR TITLE
host: Change diff editor to bubble scroll events

### DIFF
--- a/packages/host/app/components/ai-assistant/code-block.gts
+++ b/packages/host/app/components/ai-assistant/code-block.gts
@@ -457,6 +457,9 @@ class CodeBlockDiffEditor extends Component<Signature> {
       contextLineCount: 1,
     },
     readOnly: true,
+    scrollbar: {
+      alwaysConsumeMouseWheel: false,
+    },
     fontSize: 10,
     renderOverviewRuler: false,
     automaticLayout: true,

--- a/packages/host/app/components/ai-assistant/code-block.gts
+++ b/packages/host/app/components/ai-assistant/code-block.gts
@@ -45,6 +45,19 @@ import ApplyButton from '../ai-assistant/apply-button';
 import type { ComponentLike } from '@glint/template';
 import type * as _MonacoSDK from 'monaco-editor';
 
+const commonEditorOptions: MonacoEditorOptions = {
+  theme: 'vs-dark',
+
+  automaticLayout: true,
+  fontSize: 10,
+  lineNumbers: 'off',
+  readOnly: true,
+  scrollbar: {
+    alwaysConsumeMouseWheel: false,
+  },
+  scrollBeyondLastLine: false,
+};
+
 interface CopyCodeButtonSignature {
   Args: {
     code?: string | null;
@@ -395,28 +408,21 @@ class MonacoEditor extends Modifier<MonacoEditorSignature> {
 
 class CodeBlockEditor extends Component<Signature> {
   editorDisplayOptions: MonacoEditorOptions = {
+    ...commonEditorOptions,
+
     wordWrap: 'on',
     wrappingIndent: 'indent',
     fontWeight: 'bold',
-    scrollbar: {
-      alwaysConsumeMouseWheel: false,
-    },
-    lineNumbers: 'off',
     minimap: {
       enabled: false,
     },
-    readOnly: true,
-    automaticLayout: true,
     stickyScroll: {
       enabled: false,
     },
-    fontSize: 10,
-    scrollBeyondLastLine: false,
     padding: {
       top: 8,
       bottom: 8,
     },
-    theme: 'vs-dark',
   };
 
   <template>
@@ -446,6 +452,8 @@ class CodeBlockEditor extends Component<Signature> {
 
 class CodeBlockDiffEditor extends Component<Signature> {
   private editorDisplayOptions = {
+    ...commonEditorOptions,
+
     originalEditable: false,
     renderSideBySide: false,
     diffAlgorithm: 'advanced',
@@ -456,22 +464,13 @@ class CodeBlockDiffEditor extends Component<Signature> {
       minimumLineCount: 1,
       contextLineCount: 1,
     },
-    readOnly: true,
-    scrollbar: {
-      alwaysConsumeMouseWheel: false,
-    },
-    fontSize: 10,
     renderOverviewRuler: false,
-    automaticLayout: true,
-    scrollBeyondLastLine: false,
     padding: {
       bottom: 0,
       left: 8,
       right: 8,
       top: 8,
     },
-    theme: 'vs-dark',
-    lineNumbers: 'off' as _MonacoSDK.editor.LineNumbersType | undefined,
   };
 
   @tracked diffEditorStats: {


### PR DESCRIPTION
I noticed while working on #2820 that I had to place the cursor in a narrow strip to be able to scroll the chat sidebar freely. This adds `alwaysConsumeMouseWheel: false` for diff editors, which was already present for regular editors, and extracts shared editor settings.

It’s difficult to convey in a GIF because you can’t tell when I’m scrolling (on a trackpad) but you can see that on the left once the cursor is atop the editor, I can only scroll within it, I can’t escape it without moving the cursor outside the editor. On the right, when the editor has fully scrolled, the container then scrolls.

<table>
<tr>
<td>before</td>
<td>now</td>
</tr>
<tr>
<td>

![screencast 2025-06-24 10-08-58](https://github.com/user-attachments/assets/5ac9b22e-5b01-4c32-86cd-69aa82cbf963)

</td>
<td>

![screencast 2025-06-24 10-10-26](https://github.com/user-attachments/assets/dce7d6db-be98-4b36-89de-dc7b0f5e3fd3)

</td>
</tr>
</table>