### PR TITLE
host: Fix background of inspector dividers

### DIFF
--- a/packages/host/app/components/operator-mode/definition-container/divider.gts
+++ b/packages/host/app/components/operator-mode/definition-container/divider.gts
@@ -34,7 +34,7 @@ export const Divider: TemplateOnlyComponent<Signature> = <template>
       align-items: center;
       gap: var(--boxel-sp-xxxs);
       padding: 0 var(--boxel-sp-xxxs);
-      background-color: var(--code-mode-panel-background-color);
+      background-color: var(--boxel-200);
       font: 500 var(--boxel-font-xs);
       letter-spacing: var(--divider-content-lsp, var(--boxel-lsp-xs));
       text-wrap: nowrap;


### PR DESCRIPTION
It’s subtle but the background shouldn’t be different:

<table>
<tr>
<td>
Before
</td>
<td>
Now
</td>
</tr>
<tr>
<td>
<img width="747" alt="index json in Experiments Workspace 2025-06-24 13-31-15" src="https://github.com/user-attachments/assets/51439678-112b-4afa-a1b7-c47ce4be5d5a" />
</td>
<td>
<img width="747" alt="index json in Experiments Workspace 2025-06-24 13-30-57" src="https://github.com/user-attachments/assets/096f3685-28bf-4424-8f1a-e86b42513c73" />
</td>
</tr>
</table>

Another way to accomplish this without needing to keep the values in sync would be inheriting the background down the hierarchy, better?

<img width="543" alt="bm3 (Git) 2025-06-24 13-34-32" src="https://github.com/user-attachments/assets/00b38744-503a-4a51-92ee-6d3ef4b9723d" />
