### PR TITLE
Add grafana endpoint to force job completion

### DIFF
--- a/packages/realm-server/handlers/handle-remove-job.ts
+++ b/packages/realm-server/handlers/handle-remove-job.ts
@@ -1,0 +1,86 @@
+import Koa from 'koa';
+import {
+  type Expression,
+  query as _query,
+  param,
+  separatedByCommas,
+} from '@cardstack/runtime-common';
+import { sendResponseForBadRequest, setContextResponse } from '../middleware';
+import { type CreateRoutesArgs } from '../routes';
+
+export default function handleReindex({
+  dbAdapter,
+}: CreateRoutesArgs): (ctxt: Koa.Context, next: Koa.Next) => Promise<void> {
+  async function query(expression: Expression) {
+    return await _query(dbAdapter, expression);
+  }
+
+  async function forceJobCompletion(jobId: string, jobReservationId?: string) {
+    async function query(expression: Expression) {
+      return await _query(dbAdapter, expression);
+    }
+
+    await query([
+      `UPDATE jobs SET `,
+      ...separatedByCommas([
+        [
+          `result =`,
+          param({
+            status: 418,
+            message: `User initiated job cancellation`,
+          }),
+        ],
+        [`status = 'rejected'`],
+        [`finished_at = NOW()`],
+      ]),
+      'WHERE id =',
+      param(jobId),
+    ] as Expression);
+    if (jobReservationId) {
+      await query([
+        `UPDATE job_reservations SET completed_at = NOW() WHERE id =`,
+        param(jobReservationId),
+      ]);
+    }
+    await query([`NOTIFY jobs_finished`]);
+  }
+
+  return async function (ctxt: Koa.Context, _next: Koa.Next) {
+    let jobId = ctxt.URL.searchParams.get('job_id');
+    let jobReservationId = ctxt.URL.searchParams.get('reservation_id');
+    if (!jobId && !jobReservationId) {
+      await sendResponseForBadRequest(
+        ctxt,
+        'Request missing "job_id" or "reservation_id" query param',
+      );
+      return;
+    }
+
+    if (jobReservationId) {
+      let [{ job_id: jobId }] = (await query([
+        `SELECT job_id FROM job_reservations WHERE id =`,
+        param(jobReservationId),
+      ])) as [{ job_id: string }];
+      if (!jobId) {
+        await sendResponseForBadRequest(
+          ctxt,
+          `Cannot find job id for reservation id "${jobReservationId}"`,
+        );
+        return;
+      }
+      await forceJobCompletion(jobId, jobReservationId);
+    } else if (jobId) {
+      let results = (await query([
+        'SELECT id FROM job_reservations WHERE job_id =',
+        param(jobId),
+        'AND completed_at IS NULL',
+      ])) as { id: string }[];
+      let reservationId: string | undefined;
+      if (results.length > 0) {
+        reservationId = results[0].id;
+      }
+      await forceJobCompletion(jobId, reservationId);
+    }
+    return setContextResponse(ctxt, new Response(null, { status: 204 }));
+  };
+}

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -22,6 +22,7 @@ import handleStripeLinksRequest from './handlers/handle-stripe-links';
 import handleCreateUserRequest from './handlers/handle-create-user';
 import handleQueueStatusRequest from './handlers/handle-queue-status';
 import handleReindex from './handlers/handle-reindex';
+import handleRemoveJob from './handlers/handle-remove-job';
 
 export type CreateRoutesArgs = {
   serverURL: string;
@@ -82,7 +83,11 @@ export function createRoutes(args: CreateRoutesArgs) {
     grafanaAuthorization(args.grafanaSecret),
     handleReindex(args),
   );
-  // TODO add grafana endpoint to remove job
+  router.get(
+    '/_grafana-complete-job',
+    grafanaAuthorization(args.grafanaSecret),
+    handleRemoveJob(args),
+  );
 
   return router.routes();
 }


### PR DESCRIPTION
This PR adds a realm server endpoint that grafana can call that will force a job to be completed (with a user initiated cancel message).

TODO:
- [x] deploy https://github.com/cardstack/infra/pull/599 to staging
- [x] deploy https://github.com/cardstack/infra/pull/599 to production