### PR TITLE
increase catalog sidebar width

### DIFF
--- a/packages/catalog-realm/catalog-app/layouts/catalog-layout.gts
+++ b/packages/catalog-realm/catalog-app/layouts/catalog-layout.gts
@@ -56,7 +56,7 @@ export default class CatalogLayout extends GlimmerComponent<CatalogLayoutSignatu
       }
 
       .sidebar {
-        width: var(--sidebar-width, 255px);
+        width: var(--sidebar-width, 290px);
         display: flex;
         flex-direction: column;
         gap: var(--boxel-sp-lg);


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-8968/make-sidebar-slightly-wider

before: 
<img width="1265" alt="Screenshot 2025-06-26 at 10 20 15 AM" src="https://github.com/user-attachments/assets/4df368f0-7f89-432d-9539-9ca21765079b" />

after:
<img width="1265" alt="Screenshot 2025-06-26 at 10 22 46 AM" src="https://github.com/user-attachments/assets/826cb473-ce41-42ca-9331-151f19e9883e" />
