### PR TITLE
Cs 8965 skeleton loader should show 10 cards

### DIFF
--- a/packages/catalog-realm/catalog-app/components/grid.gts
+++ b/packages/catalog-realm/catalog-app/components/grid.gts
@@ -43,6 +43,11 @@ export class CardsGrid extends GlimmerComponent<CardsGridSignature> {
     this.hydratedCardId = cardId;
   }
 
+  //default to rendering 10 skeletons
+  renderSkeletons(length: number = 10) {
+    return Array.from({ length }, (_, i) => i);
+  }
+
   isHydrated = (cardUrl: string) => {
     return removeFileExtension(cardUrl) == this.hydratedCardId;
   };
@@ -60,11 +65,13 @@ export class CardsGrid extends GlimmerComponent<CardsGridSignature> {
       >
         <:loading>
           <ul class='cards {{@selectedView}}-view' ...attributes>
-            <li class='{{@selectedView}}-view-container'>
-              <CardContainer class='card' @displayBoundaries={{true}}>
-                <ListingFittedSkeleton />
-              </CardContainer>
-            </li>
+            {{#each (this.renderSkeletons)}}
+              <li class='{{@selectedView}}-view-container'>
+                <CardContainer class='card' @displayBoundaries={{true}}>
+                  <ListingFittedSkeleton />
+                </CardContainer>
+              </li>
+            {{/each}}
           </ul>
         </:loading>
         <:response as |cards|>
@@ -200,8 +207,7 @@ export class CardsGrid extends GlimmerComponent<CardsGridSignature> {
         padding: var(--boxel-sp-xl);
         text-align: center;
       }
-
-      .no-results-icon {
+      p .no-results-icon {
         width: 64px;
         height: 64px;
         color: var(--layout-theme-color);

--- a/packages/catalog-realm/catalog-app/components/grid.gts
+++ b/packages/catalog-realm/catalog-app/components/grid.gts
@@ -207,7 +207,7 @@ export class CardsGrid extends GlimmerComponent<CardsGridSignature> {
         padding: var(--boxel-sp-xl);
         text-align: center;
       }
-      p .no-results-icon {
+      .no-results-icon {
         width: 64px;
         height: 64px;
         color: var(--layout-theme-color);

--- a/packages/catalog-realm/catalog-app/components/grid.gts
+++ b/packages/catalog-realm/catalog-app/components/grid.gts
@@ -44,8 +44,8 @@ export class CardsGrid extends GlimmerComponent<CardsGridSignature> {
   }
 
   //default to rendering 10 skeletons
-  renderSkeletons(length: number = 10) {
-    return Array.from({ length }, (_, i) => i);
+  get renderSkeletons() {
+    return Array.from({ length: 10 }, (_, i) => i);
   }
 
   isHydrated = (cardUrl: string) => {
@@ -65,7 +65,7 @@ export class CardsGrid extends GlimmerComponent<CardsGridSignature> {
       >
         <:loading>
           <ul class='cards {{@selectedView}}-view' ...attributes>
-            {{#each (this.renderSkeletons)}}
+            {{#each this.renderSkeletons}}
               <li class='{{@selectedView}}-view-container'>
                 <CardContainer class='card' @displayBoundaries={{true}}>
                   <ListingFittedSkeleton />


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-8965/skeleton-loader-should-show-10-cards

- Create a renderSkeletons function with configurable length
- Add default length of 10 skeletons
- Allow custom skeleton counts for different use cases


<img width="1383" alt="Screenshot 2025-06-26 at 10 55 12 AM" src="https://github.com/user-attachments/assets/00b495e6-fdcd-46f0-9732-a4abfe080c80" />
