### PR TITLE
Display card title after card type in the preview header

### DIFF
--- a/packages/boxel-ui/addon/src/components/card-header/index.gts
+++ b/packages/boxel-ui/addon/src/components/card-header/index.gts
@@ -4,9 +4,9 @@ import type { ComponentLike } from '@glint/template';
 
 import cssVar from '../..//helpers/css-var.ts';
 import cn from '../../helpers/cn.ts';
-import { and } from '../../helpers/truth-helpers.ts';
 import { getContrastColor } from '../../helpers/contrast-color.ts';
 import { MenuItem } from '../../helpers/menu-item.ts';
+import { and } from '../../helpers/truth-helpers.ts';
 import { bool, or } from '../../helpers/truth-helpers.ts';
 import { IconPencil, IconX, ThreeDotsHorizontal } from '../../icons.gts';
 import setCssVar from '../../modifiers/set-css-var.ts';

--- a/packages/boxel-ui/addon/src/components/card-header/index.gts
+++ b/packages/boxel-ui/addon/src/components/card-header/index.gts
@@ -4,6 +4,7 @@ import type { ComponentLike } from '@glint/template';
 
 import cssVar from '../..//helpers/css-var.ts';
 import cn from '../../helpers/cn.ts';
+import { and } from '../../helpers/truth-helpers.ts';
 import { getContrastColor } from '../../helpers/contrast-color.ts';
 import { MenuItem } from '../../helpers/menu-item.ts';
 import { bool, or } from '../../helpers/truth-helpers.ts';
@@ -17,6 +18,7 @@ import Tooltip from '../tooltip/index.gts';
 
 interface Signature {
   Args: {
+    cardTitle?: string;
     cardTypeDisplayName?: string;
     cardTypeIcon?: ComponentLike<{ Element: Element }>;
     headerColor?: string;
@@ -80,7 +82,15 @@ export default class CardHeader extends Component<Signature> {
 
       <div class='card-type-display-name' data-test-boxel-card-header-title>
         {{#if @cardTypeIcon}}<@cardTypeIcon />{{/if}}
-        {{#if @cardTypeDisplayName}}{{@cardTypeDisplayName}}{{/if}}
+        {{#if @cardTypeDisplayName}}<span
+            class='card-type-display-name-text'
+          >{{@cardTypeDisplayName}}</span>{{/if}}
+        {{#if (and @cardTypeDisplayName @cardTitle)}}<span
+            class='card-title-text'
+          >-</span>
+        {{/if}}
+        {{#if @cardTitle}}<span class='card-title-text'>
+            {{@cardTitle}}</span>{{/if}}
         {{#if (or @isSaving (bool @lastSavedMessage))}}
           <div class='save-indicator' data-test-auto-save-indicator>
             {{#if @isSaving}}
@@ -201,6 +211,9 @@ export default class CardHeader extends Component<Signature> {
           display: flex;
           align-items: center;
           min-height: var(--boxel-card-header-min-height, 1.875rem); /* 30px */
+          width: 100%;
+          box-sizing: border-box;
+          overflow: hidden;
           color: var(--boxel-card-header-text-color, var(--boxel-dark));
           background-color: var(
             --boxel-card-header-background-color,
@@ -237,7 +250,16 @@ export default class CardHeader extends Component<Signature> {
           overflow: hidden;
           text-wrap: nowrap;
           flex-grow: 1;
+          flex-shrink: 1;
+          min-width: 0;
           text-align: center;
+          padding: 0 30px;
+        }
+        .card-type-display-name-text {
+          font: 600 var(--boxel-font-sm);
+        }
+        .card-title-text {
+          font: 500 var(--boxel-font-sm);
         }
 
         header .card-type-display-name > :deep(svg) {

--- a/packages/host/app/components/matrix/room-message-command.gts
+++ b/packages/host/app/components/matrix/room-message-command.gts
@@ -236,7 +236,6 @@ export default class RoomMessageCommand extends Component<Signature> {
             <CardHeader
               @cardTypeDisplayName={{this.headerTitle}}
               @cardTypeIcon={{cardTypeIcon this.commandResultCard.card}}
-              @cardTitle={{this.commandResultCard.card.title}}
               @moreOptionsMenuItems={{this.moreOptionsMenuItems}}
               class='header'
               data-test-command-result-header

--- a/packages/host/app/components/matrix/room-message-command.gts
+++ b/packages/host/app/components/matrix/room-message-command.gts
@@ -236,6 +236,7 @@ export default class RoomMessageCommand extends Component<Signature> {
             <CardHeader
               @cardTypeDisplayName={{this.headerTitle}}
               @cardTypeIcon={{cardTypeIcon this.commandResultCard.card}}
+              @cardTitle={{this.commandResultCard.card.title}}
               @moreOptionsMenuItems={{this.moreOptionsMenuItems}}
               class='header'
               data-test-command-result-header

--- a/packages/host/app/components/operator-mode/card-renderer-panel/index.gts
+++ b/packages/host/app/components/operator-mode/card-renderer-panel/index.gts
@@ -95,6 +95,7 @@ export default class CardRendererPanel extends Component<Signature> {
       class='card-renderer-header'
       @cardTypeDisplayName={{cardTypeDisplayName @card}}
       @cardTypeIcon={{cardTypeIcon @card}}
+      @cardTitle={{@card.title}}
       @realmInfo={{this.realmInfo}}
       @onEdit={{if this.canEditCard (fn @setFormat 'edit')}}
       @onFinishEditing={{if (eq this.format 'edit') (fn @setFormat 'isolated')}}

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-preview.gts
@@ -3,7 +3,11 @@ import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { CardContainer, CardHeader } from '@cardstack/boxel-ui/components';
 import { eq, or, MenuItem } from '@cardstack/boxel-ui/helpers';
 
-import { cardTypeDisplayName, cardTypeIcon } from '@cardstack/runtime-common';
+import {
+  cardTypeDisplayName,
+  cardTypeIcon,
+  isCardInstance,
+} from '@cardstack/runtime-common';
 
 import CardRenderer from '@cardstack/host/components/card-renderer';
 import FittedFormatGallery from '@cardstack/host/components/operator-mode/card-renderer-panel/fitted-format-gallery';
@@ -40,6 +44,7 @@ const PlaygroundPreview: TemplateOnlyComponent<Signature> = <template>
           class='preview-header'
           @cardTypeDisplayName={{cardTypeDisplayName @card}}
           @cardTypeIcon={{cardTypeIcon @card}}
+          @cardTitle={{if (isCardInstance @card) @card.title undefined}}
           @realmInfo={{@realmInfo}}
           @onEdit={{@onEdit}}
           @onFinishEditing={{@onFinishEditing}}
@@ -83,6 +88,7 @@ const PlaygroundPreview: TemplateOnlyComponent<Signature> = <template>
       flex-grow: 1;
       display: grid;
       grid-auto-rows: max-content 1fr;
+      min-width: 0;
     }
     .preview-header {
       box-shadow: 0 1px 0 0 rgba(0 0 0 / 15%);

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -622,6 +622,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
             <CardHeader
               @cardTypeDisplayName={{this.headerTitle}}
               @cardTypeIcon={{cardTypeIcon this.card}}
+              @cardTitle={{this.card.title}}
               @isSaving={{this.cardResource.autoSaveState.isSaving}}
               @isTopCard={{this.isTopCard}}
               @lastSavedMessage={{this.cardResource.autoSaveState.lastSavedErrorMsg}}

--- a/packages/host/tests/acceptance/catalog-app-test.gts
+++ b/packages/host/tests/acceptance/catalog-app-test.gts
@@ -670,7 +670,7 @@ module('Acceptance | Catalog | catalog app tests', function (hooks) {
           .dom(
             '[data-test-playground-panel] [data-test-boxel-card-header-title]',
           )
-          .hasText('Author');
+          .hasText('Author - Mike Dane');
       });
       test('skill listing: installs the card and redirects to code mode with preview on first skill successfully', async function (assert) {
         const listingName = 'talk-like-a-pirate';
@@ -790,7 +790,7 @@ module('Acceptance | Catalog | catalog app tests', function (hooks) {
       await waitForCodeEditor();
       assert
         .dom('[data-test-playground-panel] [data-test-boxel-card-header-title]')
-        .hasText('Author');
+        .hasText('Author - Mike Dane');
     });
   });
 });

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -1085,7 +1085,7 @@ module('Acceptance | code submode tests', function (_hooks) {
 
       assert
         .dom('[data-test-code-mode-card-renderer-header]')
-        .hasText('Person');
+        .hasText('Person - Fadhlan');
       assert
         .dom('[data-test-code-mode-card-renderer-body]')
         .includesText('Fadhlan');

--- a/packages/host/tests/acceptance/code-submode/card-playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/card-playground-test.gts
@@ -631,7 +631,7 @@ module('Acceptance | code-submode | card playground', function (_hooks) {
       });
       assert
         .dom('[data-test-playground-panel] [data-test-boxel-card-header-title]')
-        .hasText('Author');
+        .hasText('Author - Jane Doe');
       assertCardExists(assert, cardId, 'isolated');
       assert.dom('[data-test-author-title]').hasText('Jane Doe');
       assert
@@ -652,7 +652,7 @@ module('Acceptance | code-submode | card playground', function (_hooks) {
       assert.dom('[data-test-format-chooser="edit"]').hasClass('active');
       assert
         .dom('[data-test-playground-panel] [data-test-boxel-card-header-title]')
-        .hasText('Author');
+        .hasText('Author - Jane Doe');
       assertCardExists(assert, cardId, 'edit');
 
       await selectFormat('atom');
@@ -680,7 +680,7 @@ module('Acceptance | code-submode | card playground', function (_hooks) {
       });
       assert
         .dom('[data-test-playground-panel] [data-test-boxel-card-header-title]')
-        .hasText('Author');
+        .hasText('Author - Jane Doe');
       assertCardExists(assert, cardId, 'isolated');
       assert.dom('[data-test-author-title]').hasText('Jane Doe');
       assert.dom('[data-test-format-chooser="isolated"]').hasClass('active');

--- a/packages/host/tests/acceptance/commands-test.gts
+++ b/packages/host/tests/acceptance/commands-test.gts
@@ -1076,7 +1076,7 @@ module('Acceptance | Commands tests', function (hooks) {
       .dom(
         '[data-test-operator-mode-stack="1"] [data-test-stack-card-index="0"]',
       )
-      .includesText('Person Hassan');
+      .includesText('Person - Hassan Abdel-Rahman');
 
     // verify that command result event was created correctly
     await waitUntil(() => getRoomIds().length > 0);
@@ -1165,7 +1165,7 @@ module('Acceptance | Commands tests', function (hooks) {
       .dom(
         '[data-test-operator-mode-stack="1"] [data-test-stack-card-index="0"]',
       )
-      .includesText('Person Hassan');
+      .includesText('Person - Hassan Abdel-Rahman');
 
     // verify that command result event was created correctly
     await waitUntil(() => getRoomIds().length > 0);

--- a/packages/host/tests/integration/components/ai-assistant-panel/commands-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/commands-test.gts
@@ -233,7 +233,9 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
     let roomId = await renderAiAssistantPanel(`${testRealmURL}Person/fadhlan`);
 
     await waitFor('[data-test-person]');
-    assert.dom('[data-test-boxel-card-header-title]').hasText('Person');
+    assert
+      .dom('[data-test-boxel-card-header-title]')
+      .hasText('Person - Fadhlan');
     assert.dom('[data-test-person]').hasText('Fadhlan');
 
     simulateRemoteMessage(roomId, '@aibot:localhost', {
@@ -844,7 +846,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
     await click('[data-test-boxel-menu-item-text="Copy to Workspace"]');
     assert
       .dom(`${rightStackItem} [data-test-boxel-card-header-title]`)
-      .hasText('Search Results');
+      .hasText('Search Results - Search Results');
 
     const savedCardId = document
       .querySelector(rightStackItem)
@@ -924,7 +926,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
     await click('[data-test-boxel-menu-item-text="Copy to Workspace"]');
     assert
       .dom(`${stackItem} [data-test-boxel-card-header-title]`)
-      .hasText('Search Results');
+      .hasText('Search Results - Search Results');
 
     const savedCardId = document
       .querySelector(stackItem)

--- a/packages/host/tests/integration/components/card-catalog-test.gts
+++ b/packages/host/tests/integration/components/card-catalog-test.gts
@@ -309,7 +309,7 @@ module('Integration | card-catalog', function (hooks) {
         .dom(
           `[data-test-stack-card-index="0"] [data-test-boxel-card-header-title]`,
         )
-        .hasText('Local Workspace');
+        .hasText('Local Workspace - Local Workspace');
       assert.dom('[data-test-stack-card-index="1"]').doesNotExist();
 
       await waitFor('[data-test-card-catalog-modal]');
@@ -332,7 +332,7 @@ module('Integration | card-catalog', function (hooks) {
         .dom(
           `[data-test-stack-card-index="0"] [data-test-boxel-card-header-title]`,
         )
-        .hasText('Local Workspace');
+        .hasText('Local Workspace - Local Workspace');
       assert.dom('[data-test-stack-card-index="1"]').doesNotExist();
 
       await waitFor('[data-test-card-catalog-modal]');
@@ -361,7 +361,7 @@ module('Integration | card-catalog', function (hooks) {
         .dom(
           `[data-test-stack-card-index="0"] [data-test-boxel-card-header-title]`,
         )
-        .hasText('Local Workspace');
+        .hasText('Local Workspace - Local Workspace');
       assert.dom('[data-test-stack-card-index="1"]').doesNotExist();
 
       await waitFor('[data-test-card-catalog-modal]');
@@ -395,7 +395,7 @@ module('Integration | card-catalog', function (hooks) {
         .dom(
           `[data-test-stack-card-index="0"] [data-test-boxel-card-header-title]`,
         )
-        .hasText('Local Workspace');
+        .hasText('Local Workspace - Local Workspace');
       assert.dom('[data-test-stack-card-index="1"]').doesNotExist();
 
       await waitFor('[data-test-card-catalog-modal]');
@@ -417,7 +417,7 @@ module('Integration | card-catalog', function (hooks) {
         .dom(
           `[data-test-stack-card-index="0"] [data-test-boxel-card-header-title]`,
         )
-        .hasText('Local Workspace');
+        .hasText('Local Workspace - Local Workspace');
       assert.dom('[data-test-stack-card-index="1"]').doesNotExist();
 
       await waitFor('[data-test-card-catalog-modal]');

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -617,7 +617,9 @@ module('Integration | operator-mode', function (hooks) {
         </template>
       },
     );
-    assert.dom('[data-test-boxel-card-header-title]').hasText('Person');
+    assert
+      .dom('[data-test-boxel-card-header-title]')
+      .hasText('Person - Fadhlan');
     assert
       .dom(
         `[data-test-card-header-realm-icon="https://boxel-images.boxel.ai/icons/Letter-o.png"]`,
@@ -2436,7 +2438,9 @@ module('Integration | operator-mode', function (hooks) {
     );
 
     await waitFor('[data-test-card-header-realm-icon]');
-    assert.dom('[data-test-boxel-card-header-title]').hasText('Person');
+    assert
+      .dom('[data-test-boxel-card-header-title]')
+      .hasText('Person - Fadhlan');
     assert
       .dom(
         `[data-test-card-header-realm-icon="https://boxel-images.boxel.ai/icons/Letter-o.png"]`,
@@ -2447,7 +2451,9 @@ module('Integration | operator-mode', function (hooks) {
       .dom('[data-test-tooltip-content]')
       .hasText('In Operator Mode Workspace');
     await triggerEvent(`[data-test-card-header-realm-icon]`, 'mouseleave');
-    assert.dom('[data-test-boxel-card-header-title]').hasText('Person');
+    assert
+      .dom('[data-test-boxel-card-header-title]')
+      .hasText('Person - Fadhlan');
   });
 
   test(`it has an option to copy the card url`, async function (assert) {


### PR DESCRIPTION
In interact mode:

<img width="845" alt="Screenshot 2025-06-26 at 15 38 01" src="https://github.com/user-attachments/assets/25dd8e21-27a7-46f8-9eb2-6e3495558546" />

In preview panel:

<img width="390" alt="Screenshot 2025-06-26 at 15 36 42" src="https://github.com/user-attachments/assets/44df8149-546b-4674-bfb5-49a857581124" />

In playground panel:

<img width="622" alt="Screenshot 2025-06-26 at 15 36 27" src="https://github.com/user-attachments/assets/85873a35-5c91-4f0c-913a-409f9c270d87" />

