### PR TITLE
ci: Fix realm server log artifact naming

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -389,7 +389,7 @@ jobs:
         working-directory: packages/realm-server
         env:
           TEST_MODULE: ${{matrix.testModule}}
-      - name: prepare_artifact_name
+      - name: Prepare artifact name
         id: artifact_name
         run: |
           export SAFE_ARTIFACT_NAME=$(echo ${{ matrix.testModule }} |  sed 's/[/]/_/g')

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -391,6 +391,7 @@ jobs:
           TEST_MODULE: ${{matrix.testModule}}
       - name: Prepare artifact name
         id: artifact_name
+        if: always()
         run: |
           export SAFE_ARTIFACT_NAME=$(echo ${{ matrix.testModule }} |  sed 's/[/]/_/g')
           echo "artifact_name=$SAFE_ARTIFACT_NAME" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This adds a matching `if: always()` for the artifact naming step because the artifact upload step that follows it expects a name. [Here](https://github.com/cardstack/boxel/actions/runs/15896914967/job/44830608703) is an example job where the lack of artifact name causes the upload to fail because the name has already been used:

<img width="815" alt="boxel@c06f506 2025-06-26 09-07-37" src="https://github.com/user-attachments/assets/9a0a55e2-640f-4197-8439-1b2c43e8e5f0" />

I also renamed the step because there’s no need to use a variable-like name, the other steps are all sentence-like.

The realm server test failures are unrelated to this but do demonstrate its correctness:

<img width="1101" alt="boxel@d74194e 2025-06-26 09-35-10" src="https://github.com/user-attachments/assets/36b7f704-5ba9-44d4-b428-5d54e5672ab6" />