### PR TITLE
Finer grained logging during indexing in production build

### DIFF
--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -79,7 +79,7 @@ module.exports = function (environment) {
 
   if (environment === 'production') {
     // here you can enable a production-specific feature
-    ENV.logLevels = '*=warn,current-run=error';
+    ENV.logLevels = '*=warn,current-run=debug';
   }
 
   return ENV;

--- a/packages/realm-server/setup-logger.ts
+++ b/packages/realm-server/setup-logger.ts
@@ -1,4 +1,4 @@
 import { makeLogDefinitions } from '@cardstack/runtime-common';
 (globalThis as any)._logDefinitions = makeLogDefinitions(
-  process.env.LOG_LEVELS || '*=info',
+  process.env.WORKER_LOG_LEVELS || process.env.LOG_LEVELS || '*=info',
 );

--- a/packages/realm-server/setup-logger.ts
+++ b/packages/realm-server/setup-logger.ts
@@ -1,4 +1,4 @@
 import { makeLogDefinitions } from '@cardstack/runtime-common';
 (globalThis as any)._logDefinitions = makeLogDefinitions(
-  process.env.WORKER_LOG_LEVELS || process.env.LOG_LEVELS || '*=info',
+  process.env.LOG_LEVELS || '*=info',
 );


### PR DESCRIPTION
This PR allows us to see more detailed traces of indexing progress in the grafana dashboard. dev and testing builds should be unaffected.