### PR TITLE
host: Fix question mark alignment in assistant

### DIFF
--- a/packages/host/app/components/ai-assistant/new-session.gts
+++ b/packages/host/app/components/ai-assistant/new-session.gts
@@ -97,7 +97,8 @@ export default class NewSession extends Component<Signature> {
       .prompt::before {
         display: inline-block;
         margin-right: var(--boxel-sp-sm);
-        padding: 0 0 1px 1px;
+        /* 1.5px for both values causes a build failure TODO fix in CS-8981 */
+        padding: 0 0 1.49px 1.5px;
         content: '?';
         width: 1.25rem;
         height: 1.25rem;

--- a/packages/host/app/components/ai-assistant/new-session.gts
+++ b/packages/host/app/components/ai-assistant/new-session.gts
@@ -97,6 +97,7 @@ export default class NewSession extends Component<Signature> {
       .prompt::before {
         display: inline-block;
         margin-right: var(--boxel-sp-sm);
+        padding: 0 0 1px 1px;
         content: '?';
         width: 1.25rem;
         height: 1.25rem;


### PR DESCRIPTION
<table>
<thead>
<tr>
<th>
Before
</th>
<th>
Now
</th>
</tr>
</thead>
<tr>
<td>
<img width="270" alt="garden-design gts in Experiments Workspace 2025-06-26 10-08-06" src="https://github.com/user-attachments/assets/791558ce-0849-48a3-9e12-5bae9607c178" />
</td>
<td>
<img width="270" alt="garden-design gts in Experiments Workspace 2025-06-26 10-28-18" src="https://github.com/user-attachments/assets/6b7103b2-249e-4ee7-8191-b0e264f12bda" />
</td>
</tr>
</table>