### PR TITLE
Retry realm auth when server responds with 500 error

### DIFF
--- a/packages/runtime-common/realm-auth-client.ts
+++ b/packages/runtime-common/realm-auth-client.ts
@@ -191,5 +191,5 @@ export class RealmAuthClient {
   }
 }
 
-const maxAttempts = 3;
+const maxAttempts = 5;
 const backOffMs = 100;


### PR DESCRIPTION
we believe that realm is sometimes unable to login to matrix in CI which results in failed auth requests because the realm doesn't know who it is. in these cases the realm responds with a 500 error, so we try again...