### PR TITLE
ci: Add steps to print realm server logs

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -80,6 +80,9 @@ jobs:
           name: host-test-report-${{ matrix.shardIndex }}
           path: junit/host-${{ matrix.shardIndex }}.xml
           retention-days: 30
+      - name: Print realm server logs
+        if: always()
+        run: cat /tmp/server.log
       - name: Upload realm server log
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
         if: always()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -389,6 +389,9 @@ jobs:
         working-directory: packages/realm-server
         env:
           TEST_MODULE: ${{matrix.testModule}}
+      - name: Print realm server logs
+        if: always()
+        run: cat /tmp/server.log
       - name: Prepare artifact name
         id: artifact_name
         if: always()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -219,6 +219,9 @@ jobs:
       - name: Run Playwright tests
         run: pnpm test:group ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
         working-directory: packages/matrix
+      - name: Print realm server logs
+        if: always()
+        run: cat /tmp/server.log
       - name: Upload realm server log
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
         if: always()


### PR DESCRIPTION
When looking into the problem #2853 is meant to solve yesterday, I found it useful to be able to peek at the realm server logs without needing to download them as an artifact. It let me quickly identify when the `500` from `/_session` was the cause of a job failure (which it always was).

<img width="814" alt="boxel@c78c933 2025-06-27 09-38-31" src="https://github.com/user-attachments/assets/d46980f8-5ebb-428a-b69a-54a3ee126f1c" />
