### PR TITLE
support relative URL's in dynamic import transpile

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -343,6 +343,7 @@ jobs:
             "index-writer-test.ts",
             "indexing-test.ts",
             "loader-test.ts",
+            "transpile-test.ts",
             "module-syntax-test.ts",
             "permissions/permission-checker-test.ts",
             "queue-test.ts",

--- a/packages/base/code-ref.gts
+++ b/packages/base/code-ref.gts
@@ -98,10 +98,7 @@ class EditView extends Component<typeof CodeRefField> {
         } else {
           this.validationState = 'invalid';
         }
-      } catch (err: any) {
-        console.log(
-          `======> error testing for code ref validity for URL ${module} with export ${name}: err.message, ${err.stack}`,
-        );
+      } catch (err) {
         this.validationState = 'invalid';
       }
     },

--- a/packages/base/code-ref.gts
+++ b/packages/base/code-ref.gts
@@ -99,6 +99,10 @@ class EditView extends Component<typeof CodeRefField> {
           this.validationState = 'invalid';
         }
       } catch (err) {
+        console.log(
+          `======> error testing for code ref validity for URL ${module} with export ${name}`,
+          err,
+        );
         this.validationState = 'invalid';
       }
     },

--- a/packages/base/code-ref.gts
+++ b/packages/base/code-ref.gts
@@ -100,8 +100,7 @@ class EditView extends Component<typeof CodeRefField> {
         }
       } catch (err) {
         console.log(
-          `======> error testing for code ref validity for URL ${module} with export ${name}`,
-          err,
+          `======> error testing for code ref validity for URL ${module} with export ${name}: err.message, ${err.stack}`,
         );
         this.validationState = 'invalid';
       }

--- a/packages/base/code-ref.gts
+++ b/packages/base/code-ref.gts
@@ -98,7 +98,7 @@ class EditView extends Component<typeof CodeRefField> {
         } else {
           this.validationState = 'invalid';
         }
-      } catch (err) {
+      } catch (err: any) {
         console.log(
           `======> error testing for code ref validity for URL ${module} with export ${name}: err.message, ${err.stack}`,
         );

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -8,6 +8,7 @@ import './index-writer-test';
 import './indexing-test';
 import './loader-test';
 import './module-syntax-test';
+import './transpile-test';
 import './permissions/permission-checker-test';
 import './queue-test';
 import './card-endpoints-test';

--- a/packages/realm-server/tests/transpile-test.ts
+++ b/packages/realm-server/tests/transpile-test.ts
@@ -1,0 +1,42 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import { transpileJS } from '@cardstack/runtime-common/transpile';
+import '@cardstack/runtime-common/helpers/code-equality-assertion';
+
+module(basename(__filename), function () {
+  module('Transpile', function () {
+    test('can rewrite fetch()', async function (assert) {
+      let transpiled = transpileJS(
+        `
+        async function test() {
+          return await fetch('http://test.com');
+        }`,
+        'test-module.ts',
+      );
+      assert.codeEqual(
+        transpiled,
+        `
+        async function test() {
+          return await import.meta.loader.fetch('http://test.com');
+        }`,
+      );
+    });
+  });
+
+  test('can rewrite import()', async function (assert) {
+    let transpiled = transpileJS(
+      `
+      async function test() {
+        return await import('./x'); 
+      }`,
+      'test-module.ts',
+    );
+    assert.codeEqual(
+      transpiled,
+      `
+      async function test() {
+        return await import.meta.loader.import(new URL('./x', import.meta.url).href); 
+      }`,
+    );
+  });
+});

--- a/packages/realm-server/tests/transpile-test.ts
+++ b/packages/realm-server/tests/transpile-test.ts
@@ -23,7 +23,7 @@ module(basename(__filename), function () {
     });
   });
 
-  test('can rewrite import()', async function (assert) {
+  test('can rewrite import() that has url like argument', async function (assert) {
     let transpiled = transpileJS(
       `
       async function test() {
@@ -36,6 +36,23 @@ module(basename(__filename), function () {
       `
       async function test() {
         return await import.meta.loader.import(new URL('./x', import.meta.url).href); 
+      }`,
+    );
+  });
+
+  test('can rewrite import() that has module specifier argument', async function (assert) {
+    let transpiled = transpileJS(
+      `
+      async function test() {
+        return await import('lodash'); 
+      }`,
+      'test-module.ts',
+    );
+    assert.codeEqual(
+      transpiled,
+      `
+      async function test() {
+        return await import.meta.loader.import('lodash'); 
       }`,
     );
   });

--- a/packages/runtime-common/loader-plugin.ts
+++ b/packages/runtime-common/loader-plugin.ts
@@ -4,6 +4,42 @@ import type { NodePath } from '@babel/traverse';
 
 export function loaderPlugin(babel: typeof Babel) {
   let t = babel.types;
+
+  function createLoaderImportCall(
+    args: (t.Expression | t.SpreadElement | t.ArgumentPlaceholder)[],
+  ): t.CallExpression {
+    const firstArg = args[0];
+
+    // Only process if first argument is an Expression (not SpreadElement or ArgumentPlaceholder)
+    if (!t.isExpression(firstArg)) {
+      throw new Error(
+        'Dynamic import with spread or placeholder arguments is not supported',
+      );
+    }
+
+    // Always wrap in new URL() - it handles both relative and absolute URLs
+    const urlConstructor = t.newExpression(t.identifier('URL'), [
+      firstArg,
+      t.memberExpression(
+        t.metaProperty(t.identifier('import'), t.identifier('meta')),
+        t.identifier('url'),
+      ),
+    ]);
+
+    const hrefAccess = t.memberExpression(urlConstructor, t.identifier('href'));
+
+    return t.callExpression(
+      t.memberExpression(
+        t.memberExpression(
+          t.metaProperty(t.identifier('import'), t.identifier('meta')),
+          t.identifier('loader'),
+        ),
+        t.identifier('import'),
+      ),
+      [hrefAccess, ...args.slice(1).filter((arg) => t.isExpression(arg))], // Filter out non-Expression arguments
+    );
+  }
+
   return {
     visitor: {
       CallExpression(path: NodePath<t.CallExpression>) {
@@ -20,16 +56,8 @@ export function loaderPlugin(babel: typeof Babel) {
             ),
           );
         } else if (callee.node.type === 'Import') {
-          // import() => import.meta.loader.import
-          callee.replaceWith(
-            t.memberExpression(
-              t.memberExpression(
-                t.metaProperty(t.identifier('import'), t.identifier('meta')),
-                t.identifier('loader'),
-              ),
-              t.identifier('import'),
-            ),
-          );
+          // import('./x') => import.meta.loader.import(new URL('./x', import.meta.url).href)
+          path.replaceWith(createLoaderImportCall(path.node.arguments));
         }
       },
     },


### PR DESCRIPTION
This PR addresses an issue uncovered in one of the misbehaving realms. Specifically the ability to support relative URL's in our dynamic import rewriting. the `Loader.import()` function expects to be passed in a full URL, so when we rewrite the `import()` statements  we should do so with the understanding that the argument to the `import()` may be relative.