### PR TITLE
host: Add gradient above chat form

### DIFF
--- a/packages/host/app/components/ai-assistant/action-bar.gts
+++ b/packages/host/app/components/ai-assistant/action-bar.gts
@@ -98,6 +98,9 @@ export default class AiAssistantActionBar extends Component<Signature> {
         border-top-left-radius: var(--chat-input-area-border-radius);
         align-items: center;
         border: 1px solid #777;
+
+        position: relative;
+        z-index: 1;
       }
       .ai-assistant-action-bar.unread-indicator {
         padding: 0;

--- a/packages/host/app/components/ai-assistant/message/index.gts
+++ b/packages/host/app/components/ai-assistant/message/index.gts
@@ -362,6 +362,9 @@ const AiAssistantConversation: TemplateOnlyComponent<AiAssistantConversationSign
         padding: 0 var(--ai-assistant-panel-padding)
           var(--ai-assistant-panel-padding) var(--ai-assistant-panel-padding);
         overflow-y: auto;
+
+        /* This lets the conversation be visible in the missing border radius of the form, with its gradient */
+        margin-bottom: calc(var(--chat-input-area-border-radius) * -1);
       }
       .ai-assistant-conversation > :deep(* + *) {
         margin-top: var(--boxel-sp-lg);

--- a/packages/host/app/components/ai-assistant/message/index.gts
+++ b/packages/host/app/components/ai-assistant/message/index.gts
@@ -360,7 +360,12 @@ const AiAssistantConversation: TemplateOnlyComponent<AiAssistantConversationSign
         display: flex;
         flex-direction: column;
         padding: 0 var(--ai-assistant-panel-padding)
-          var(--ai-assistant-panel-padding) var(--ai-assistant-panel-padding);
+          calc(
+            var(--ai-assistant-panel-padding) +
+              var(--chat-input-area-border-radius) +
+              var(--ai-assistant-panel-bottom-gradient-height)
+          )
+          var(--ai-assistant-panel-padding);
         overflow-y: auto;
 
         /* This lets the conversation be visible in the missing border radius of the form, with its gradient */

--- a/packages/host/app/components/ai-assistant/panel.gts
+++ b/packages/host/app/components/ai-assistant/panel.gts
@@ -193,7 +193,7 @@ export default class AiAssistantPanel extends Component<Signature> {
 
       .ai-assistant-panel {
         --ai-assistant-panel-header-height: 4.5rem;
-        --ai-assistant-panel-gradient-start-proportion: 0.6;
+        --ai-assistant-panel-top-gradient-start-proportion: 0.6;
         --ai-assistant-panel-padding: var(--boxel-sp-sm);
 
         background-color: var(--boxel-ai-purple);
@@ -235,7 +235,7 @@ export default class AiAssistantPanel extends Component<Signature> {
           to bottom,
           var(--boxel-ai-purple),
           var(--boxel-ai-purple)
-            calc(var(--ai-assistant-panel-gradient-start-proportion) * 100%),
+            calc(var(--ai-assistant-panel-top-gradient-start-proportion) * 100%),
           transparent 100%
         );
       }
@@ -273,7 +273,7 @@ export default class AiAssistantPanel extends Component<Signature> {
         position: absolute;
         height: calc(
           var(--ai-assistant-panel-header-height) *
-            var(--ai-assistant-panel-gradient-start-proportion) -
+            var(--ai-assistant-panel-top-gradient-start-proportion) -
             var(--ai-assistant-panel-padding)
         );
         width: 100%;

--- a/packages/host/app/components/ai-assistant/panel.gts
+++ b/packages/host/app/components/ai-assistant/panel.gts
@@ -196,6 +196,8 @@ export default class AiAssistantPanel extends Component<Signature> {
         --ai-assistant-panel-top-gradient-start-proportion: 0.6;
         --ai-assistant-panel-padding: var(--boxel-sp-sm);
 
+        --ai-assistant-panel-bottom-gradient-height: var(--boxel-sp-xl);
+
         background-color: var(--boxel-ai-purple);
         border-radius: 0;
         color: var(--boxel-light);

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -229,7 +229,10 @@ export default class Room extends Component<Signature> {
         position: absolute;
 
         width: 100%;
-        height: calc(var(--boxel-sp-xl) + var(--chat-input-area-border-radius));
+        height: calc(
+          var(--ai-assistant-panel-bottom-gradient-height) +
+            var(--chat-input-area-border-radius)
+        );
         left: 0;
         bottom: calc(100% - var(--chat-input-area-border-radius));
 

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -218,10 +218,31 @@ export default class Room extends Component<Signature> {
         --chat-input-area-border-radius: var(--boxel-border-radius-xxl);
       }
       .room-actions {
-        padding: var(--boxel-sp-xxs) var(--ai-assistant-panel-padding)
+        position: relative;
+        padding: 0 var(--ai-assistant-panel-padding)
           var(--ai-assistant-panel-padding);
         box-shadow: var(--boxel-box-shadow);
       }
+
+      .room-actions::before {
+        content: '';
+        position: absolute;
+
+        width: 100%;
+        height: calc(var(--boxel-sp-xl) + var(--chat-input-area-border-radius));
+        left: 0;
+        bottom: calc(100% - var(--chat-input-area-border-radius));
+
+        background: linear-gradient(
+          to top,
+          var(--boxel-ai-purple),
+          var(--boxel-ai-purple) 20%,
+          transparent 100%
+        );
+
+        z-index: 0;
+      }
+
       .chat-input-area {
         --boxel-pill-menu-header-padding: 0;
         --boxel-pill-menu-content-padding: var(--boxel-sp) 0;
@@ -230,6 +251,9 @@ export default class Room extends Component<Signature> {
 
         background-color: var(--boxel-light);
         border-radius: var(--chat-input-area-border-radius);
+
+        position: relative;
+        z-index: 2;
       }
       .chat-input-area__bottom-actions {
         display: flex;


### PR DESCRIPTION
The gradient applies even beneath the top of the container so the conversation is visible fading outside the border radius:

<img width="367" alt="Experiments Workspace 2025-06-27 14-54-24" src="https://github.com/user-attachments/assets/958dd867-df12-4c62-a1cd-10f288f299f5" />

The gradient is for the container so it also applies when the action bar is showing:

<img width="412" alt="Fitness First Gym 2025-06-27 15-10-10" src="https://github.com/user-attachments/assets/54c6b275-904f-4d69-ac70-518c17ac528d" />
