### PR TITLE
fix selected tag color on hover

### DIFF
--- a/packages/boxel-ui/addon/src/components/tag-list/index.gts
+++ b/packages/boxel-ui/addon/src/components/tag-list/index.gts
@@ -70,6 +70,10 @@ export default class TagList extends Component<TagListSignature> {
             --tag-list-pill-selected-background-color,
             var(--boxel-dark)
           );
+          --pill-background-color-hover: var(
+            --tag-list-pill-selected-background-color,
+            var(--boxel-dark)
+          );
           --pill-font-color: var(
             --tag-list-pill-selected-font-color,
             var(--boxel-light)


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-8960/fix-tag-on-hover-after-selected-color

Before:
![image](https://github.com/user-attachments/assets/34016dbd-537a-4d61-ba85-77ea3b35d8a0)

After:

https://github.com/user-attachments/assets/cf5da0fb-a78f-4b11-8f54-8f7b2fe1f97e


