### PR TITLE
set default LLM to GPT-4.1 Nano for remix

### DIFF
--- a/packages/host/app/commands/listing-action-init.ts
+++ b/packages/host/app/commands/listing-action-init.ts
@@ -1,6 +1,7 @@
 import { service } from '@ember/service';
 
 import { baseRealm, isCardInstance } from '@cardstack/runtime-common';
+import { DEFAULT_REMIX_LLM } from '@cardstack/runtime-common/matrix-constants';
 
 import * as BaseCommandModule from 'https://cardstack.com/base/command';
 
@@ -12,6 +13,7 @@ import AddSkillsToRoomCommand from './add-skills-to-room';
 import CreateAiAssistantRoomCommand from './create-ai-assistant-room';
 import OpenAiAssistantRoomCommand from './open-ai-assistant-room';
 import SendAiAssistantMessageCommand from './send-ai-assistant-message';
+import SetActiveLLMCommand from './set-active-llm';
 
 import type RealmServerService from '../services/realm-server';
 import type StoreService from '../services/store';
@@ -74,6 +76,13 @@ export default class ListingActionInitCommand extends HostBaseCommand<
     }
 
     if (roomId) {
+      let setActiveLLMCommand = new SetActiveLLMCommand(this.commandContext);
+
+      await setActiveLLMCommand.execute({
+        roomId,
+        model: DEFAULT_REMIX_LLM,
+      });
+
       await new SendAiAssistantMessageCommand(this.commandContext).execute({
         roomId,
         prompt: `I would like to ${actionType} this ${listing.name} under the following realm: ${realmUrl}`,

--- a/packages/runtime-common/matrix-constants.ts
+++ b/packages/runtime-common/matrix-constants.ts
@@ -27,6 +27,7 @@ export const APP_BOXEL_CONTINUATION_OF_CONTENT_KEY =
   'app.boxel.continuation-of';
 export const DEFAULT_LLM = 'openai/gpt-4.1';
 export const DEFAULT_CODING_LLM = 'anthropic/claude-sonnet-4';
+export const DEFAULT_REMIX_LLM = 'openai/gpt-4.1-nano';
 export const DEFAULT_LLM_LIST = [
   'anthropic/claude-3.5-sonnet',
   'anthropic/claude-3.7-sonnet',


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-8684/set-default-model-for-remix

- set default LLM to GPT-4.1 Nano for remix 
- add an acceptance test after clicking "Remix" button

![image](https://github.com/user-attachments/assets/97f3b432-4dd4-4a09-9e7a-a3d2f903c0b6)
