### PR TITLE
Fix position of the unread messages button

### DIFF
--- a/packages/host/app/components/ai-assistant/action-bar.gts
+++ b/packages/host/app/components/ai-assistant/action-bar.gts
@@ -172,6 +172,7 @@ export default class AiAssistantActionBar extends Component<Signature> {
         width: 100%;
         display: flex;
         justify-content: space-between;
+        margin-bottom: 10px;
       }
       .unread-btn__icon {
         height: 18px;


### PR DESCRIPTION
Simple fix for fixing the position of the unread messages button:

Before:
<img width="361" alt="image" src="https://github.com/user-attachments/assets/165773d1-8c7f-4adf-9080-68c491c58256" />


After:
<img width="335" alt="image" src="https://github.com/user-attachments/assets/9eb7c42b-1382-4139-bc3e-f711898dc00a" />
