### PR TITLE
Add support for grafana to add boxel credit

### DIFF
--- a/packages/realm-server/handlers/handle-add-credit.ts
+++ b/packages/realm-server/handlers/handle-add-credit.ts
@@ -1,0 +1,56 @@
+import Koa from 'koa';
+import {
+  type Expression,
+  query as _query,
+  param,
+  SupportedMimeType,
+} from '@cardstack/runtime-common';
+import { sendResponseForBadRequest, setContextResponse } from '../middleware';
+import { type CreateRoutesArgs } from '../routes';
+
+export default function handleAddCredit({
+  dbAdapter,
+}: CreateRoutesArgs): (ctxt: Koa.Context, next: Koa.Next) => Promise<void> {
+  async function query(expression: Expression) {
+    return await _query(dbAdapter, expression);
+  }
+  return async function (ctxt: Koa.Context, _next: Koa.Next) {
+    let user = ctxt.URL.searchParams.get('user');
+    if (!user) {
+      await sendResponseForBadRequest(ctxt, `user param must be specified`);
+      return;
+    }
+
+    let creditStr = ctxt.URL.searchParams.get('credit') ?? '0';
+    let credit = parseInt(creditStr);
+    if (Number.isNaN(credit)) {
+      await sendResponseForBadRequest(
+        ctxt,
+        `Credit amount must be a number "${creditStr}"`,
+      );
+      return;
+    }
+
+    await query([
+      `INSERT INTO credits_ledger (user_id, credit_amount, credit_type)`,
+      `SELECT u.id as user_id,`,
+      param(credit),
+      `as credit_amount, 'extra_credit' as credit_type`,
+      `FROM users u`,
+      `WHERE u.matrix_user_id =`,
+      param(user),
+    ]);
+
+    return setContextResponse(
+      ctxt,
+      new Response(
+        JSON.stringify({
+          message: `Added ${creditStr} credits to user '${user}'`,
+        }),
+        {
+          headers: { 'content-type': SupportedMimeType.JSON },
+        },
+      ),
+    );
+  };
+}

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -23,6 +23,7 @@ import handleCreateUserRequest from './handlers/handle-create-user';
 import handleQueueStatusRequest from './handlers/handle-queue-status';
 import handleReindex from './handlers/handle-reindex';
 import handleRemoveJob from './handlers/handle-remove-job';
+import handleAddCredit from './handlers/handle-add-credit';
 
 export type CreateRoutesArgs = {
   serverURL: string;
@@ -87,6 +88,11 @@ export function createRoutes(args: CreateRoutesArgs) {
     '/_grafana-complete-job',
     grafanaAuthorization(args.grafanaSecret),
     handleRemoveJob(args),
+  );
+  router.get(
+    '/_grafana-add-credit',
+    grafanaAuthorization(args.grafanaSecret),
+    handleAddCredit(args),
   );
 
   return router.routes();

--- a/packages/realm-server/tests/server-endpoints-test.ts
+++ b/packages/realm-server/tests/server-endpoints-test.ts
@@ -1025,6 +1025,15 @@ module(basename(__filename), function () {
           assert.strictEqual(sum, 0, `user has 0 extra credit`);
         });
 
+        test("returns 400 when calling grafana add credit endpoint when user doesn't exist", async function (assert) {
+          let response = await request2
+            .get(
+              `/_grafana-add-credit?authHeader=${grafanaSecret}&user=nobody&credit=1000`,
+            )
+            .set('Content-Type', 'application/json');
+          assert.strictEqual(response.status, 400, 'HTTP 400 status');
+        });
+
         test('returns 401 when calling grafana add credit endpoint without a grafana secret', async function (assert) {
           let user = await insertUser(
             dbAdapter,

--- a/packages/realm-server/tests/server-endpoints-test.ts
+++ b/packages/realm-server/tests/server-endpoints-test.ts
@@ -45,7 +45,10 @@ import { MatrixClient } from '@cardstack/runtime-common/matrix-client';
 import jwt from 'jsonwebtoken';
 import { type CardCollectionDocument } from '@cardstack/runtime-common/card-document';
 import { type PgAdapter } from '@cardstack/postgres';
-import { getUserByMatrixUserId } from '@cardstack/billing/billing-queries';
+import {
+  getUserByMatrixUserId,
+  sumUpCreditsLedger,
+} from '@cardstack/billing/billing-queries';
 import {
   createJWT as createRealmServerJWT,
   RealmServerTokenClaim,
@@ -960,6 +963,84 @@ module(basename(__filename), function () {
             null,
             'job was not marked with finish time',
           );
+        });
+
+        test('can add user credit via grafana endpoint', async function (assert) {
+          let user = await insertUser(
+            dbAdapter,
+            'user@test',
+            'cus_123',
+            'user@test.com',
+          );
+          let sum = await sumUpCreditsLedger(dbAdapter, {
+            creditType: ['extra_credit', 'extra_credit_used'],
+            userId: user.id,
+          });
+          assert.strictEqual(sum, 0, `user has 0 extra credit`);
+
+          let response = await request2
+            .get(
+              `/_grafana-add-credit?authHeader=${grafanaSecret}&user=${user.matrixUserId}&credit=1000`,
+            )
+            .set('Content-Type', 'application/json');
+          assert.strictEqual(response.status, 200, 'HTTP 200 status');
+          assert.deepEqual(
+            response.body,
+            {
+              message: `Added 1000 credits to user '${user.matrixUserId}'`,
+            },
+            `response body is correct`,
+          );
+          sum = await sumUpCreditsLedger(dbAdapter, {
+            creditType: ['extra_credit', 'extra_credit_used'],
+            userId: user.id,
+          });
+          assert.strictEqual(sum, 1000, `user has 1000 extra credit`);
+        });
+
+        test('returns 400 when calling grafana add credit endpoint without a user', async function (assert) {
+          let response = await request2
+            .get(`/_grafana-add-credit?authHeader=${grafanaSecret}&credit=1000`)
+            .set('Content-Type', 'application/json');
+          assert.strictEqual(response.status, 400, 'HTTP 400 status');
+        });
+
+        test('returns 400 when calling grafana add credit endpoint with credit amount that is not a number', async function (assert) {
+          let user = await insertUser(
+            dbAdapter,
+            'user@test',
+            'cus_123',
+            'user@test.com',
+          );
+          let response = await request2
+            .get(
+              `/_grafana-add-credit?authHeader=${grafanaSecret}&user=${user.matrixUserId}&credit=a+million+dollars`,
+            )
+            .set('Content-Type', 'application/json');
+          assert.strictEqual(response.status, 400, 'HTTP 400 status');
+          let sum = await sumUpCreditsLedger(dbAdapter, {
+            creditType: ['extra_credit', 'extra_credit_used'],
+            userId: user.id,
+          });
+          assert.strictEqual(sum, 0, `user has 0 extra credit`);
+        });
+
+        test('returns 401 when calling grafana add credit endpoint without a grafana secret', async function (assert) {
+          let user = await insertUser(
+            dbAdapter,
+            'user@test',
+            'cus_123',
+            'user@test.com',
+          );
+          let response = await request2
+            .get(`/_grafana-add-credit?user=${user.matrixUserId}&credit=1000`)
+            .set('Content-Type', 'application/json');
+          assert.strictEqual(response.status, 401, 'HTTP 401 status');
+          let sum = await sumUpCreditsLedger(dbAdapter, {
+            creditType: ['extra_credit', 'extra_credit_used'],
+            userId: user.id,
+          });
+          assert.strictEqual(sum, 0, `user has 0 extra credit`);
         });
 
         test('can reindex a realm via grafana endpoint', async function (assert) {


### PR DESCRIPTION
This PR adds an endpoint that allows us to add boxel credit for users from grafana.

TODO: 
- [x] deploy https://github.com/cardstack/infra/pull/600 into staging
- [x] deploy https://github.com/cardstack/infra/pull/600 into prod