### PR TITLE
Add lockfile change for skills realm

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2909,6 +2909,8 @@ importers:
         specifier: 'catalog:'
         version: 2.0.1
 
+  packages/skills-realm: {}
+
   packages/template-lint:
     devDependencies:
       ember-template-lint:


### PR DESCRIPTION
I have a diff when running `pnpm install` and that’s causing [CI failures too](https://github.com/cardstack/boxel/actions/runs/16034262767/job/45242109664?pr=2877).

![image](https://github.com/user-attachments/assets/e56b17a5-4558-4488-8920-e360ddbf2f9f)

That job should probably only check the correct subdirectory but the lockfile needs to be updated regardless.