### PR TITLE
fix filename overflow in code-block

### DIFF
--- a/packages/host/app/components/ai-assistant/code-block/diff-editor-header.gts
+++ b/packages/host/app/components/ai-assistant/code-block/diff-editor-header.gts
@@ -79,6 +79,7 @@ export default class CodeBlockDiffEditorHeader extends Component<CodeBlockDiffEd
         display: flex;
         align-items: center;
         justify-content: space-between;
+        gap: var(--boxel-sp-xs);
         background-color: var(--boxel-650);
         color: var(--boxel-light);
         padding: 8px 12px;
@@ -89,14 +90,17 @@ export default class CodeBlockDiffEditorHeader extends Component<CodeBlockDiffEd
       .code-block-diff-header .left-section {
         display: flex;
         align-items: center;
-        gap: 8px;
         flex: 1;
         min-width: 0;
       }
 
+      .mode + .file-info-button {
+        margin-left: var(--boxel-sp-xs);
+      }
+
       .file-info-button {
-        --boxel-button-min-width: auto;
-        --boxel-button-min-height: auto;
+        --boxel-button-min-width: unset;
+        --boxel-button-min-height: unset;
         --boxel-button-padding: var(--boxel-sp-xxxs);
         --boxel-button-letter-spacing: var(--boxel-lsp-xs);
         --icon-color: currentColor;

--- a/packages/host/app/components/ai-assistant/message/aibot-message.gts
+++ b/packages/host/app/components/ai-assistant/message/aibot-message.gts
@@ -71,7 +71,7 @@ export default class FormattedAiBotMessage extends Component<Signature> {
   };
 
   <template>
-    <Message class='ai-bot-message'>
+    <Message class='ai-bot-message' ...attributes>
       {{#if @reasoning}}
         <div class='reasoning-content'>
           {{#if (eq 'Thinking...' @reasoning.content)}}

--- a/packages/host/tests/integration/components/formatted-aibot-message-test.gts
+++ b/packages/host/tests/integration/components/formatted-aibot-message-test.gts
@@ -60,6 +60,7 @@ module('Integration | Component | FormattedAiBotMessage', function (hooks) {
 
     await render(<template>
       <FormattedAiBotMessage
+        class='test-component'
         @monacoSDK={{monacoSDK}}
         @roomId={{testScenario.roomId}}
         @eventId={{testScenario.eventId}}
@@ -67,6 +68,11 @@ module('Integration | Component | FormattedAiBotMessage', function (hooks) {
         @isStreaming={{testScenario.isStreaming}}
         @isLastAssistantMessage={{testScenario.isLastAssistantMessage}}
       />
+      <style scoped>
+        .test-component {
+          max-width: 350px; /* to observe overflow */
+        }
+      </style>
     </template>);
   }
 
@@ -224,7 +230,7 @@ ${REPLACE_MARKER}
       htmlParts: parseHtmlContent(
         `
 <pre data-code-language="typescript">
-https://example.com/file.ts
+https://example.com/diff-editor-preview-code-block-file.ts
 ${SEARCH_MARKER}
 let a = 1;
 let b = 2;
@@ -234,7 +240,7 @@ ${REPLACE_MARKER}
 </pre>
 <p>the above block is now complete, now I am sending you another one:</p>
 <pre data-code-language="typescript">
-https://example.com/file.ts
+https://example.com/code-editor-preview-code-block-file.ts
 ${SEARCH_MARKER}
 let a = 1;
 let c = 3;
@@ -256,7 +262,7 @@ let c = 3;
       .hasText('Edit');
     assert
       .dom('[data-test-code-block-index="0"] [data-test-file-name]')
-      .hasText('file.ts');
+      .containsText('file.ts');
     await waitFor('[data-test-code-block-index="0"] [data-test-removed-lines]');
     assert
       .dom('[data-test-code-block-index="0"] [data-test-removed-lines]')
@@ -281,7 +287,7 @@ let c = 3;
       .doesNotExist();
     assert
       .dom('[data-test-code-block-index="1"] [data-test-file-name]')
-      .hasText('file.ts');
+      .containsText('file.ts');
     assert
       .dom('[data-test-code-block-index="1"] [data-test-apply-code-button]')
       .doesNotExist();


### PR DESCRIPTION
button `min-width: auto;` was causing ellipses to not appear

<img width="561" alt="filename" src="https://github.com/user-attachments/assets/b8c2e07d-819e-47cc-8676-3b7e4501da8e" />
