### PR TITLE
Make card error detail sticky and scrollable

### DIFF
--- a/packages/host/app/components/operator-mode/card-error-detail.gts
+++ b/packages/host/app/components/operator-mode/card-error-detail.gts
@@ -49,9 +49,8 @@ export default class CardErrorDetail extends Component<Signature> {
         display: flex;
         flex-direction: column;
         gap: var(--boxel-sp-lg);
-        flex: 1.5;
         overflow: visible;
-        max-height: fit-content;
+        max-height: 100%;
         margin: auto var(--boxel-sp) var(--boxel-sp) var(--boxel-sp);
       }
       @media (min-height: 800px) {

--- a/packages/host/app/components/operator-mode/card-error.gts
+++ b/packages/host/app/components/operator-mode/card-error.gts
@@ -76,11 +76,7 @@ export default class CardErrorComponent extends Component<Signature> {
           @viewInCodeMode={{@viewInCodeMode}}
           @fileToFixWithAi={{@fileToFixWithAi}}
           class='card-error-detail'
-        >
-          <:error>
-            {{yield to='error'}}
-          </:error>
-        </CardErrorDetail>
+        />
       {{/unless}}
     </div>
 

--- a/packages/host/app/components/operator-mode/card-error.gts
+++ b/packages/host/app/components/operator-mode/card-error.gts
@@ -29,13 +29,11 @@ interface Signature {
       moreOptionsMenuItems?: MenuItem[];
       onClose?: () => void;
     };
+    hideErrorDetail?: boolean;
     fileToFixWithAi?: FileDef;
     message?: string;
   };
   Element: HTMLElement;
-  Blocks: {
-    error: [];
-  };
 }
 
 export default class CardErrorComponent extends Component<Signature> {
@@ -52,35 +50,39 @@ export default class CardErrorComponent extends Component<Signature> {
       />
     {{/unless}}
 
-    <div class='card-error' data-test-card-error>
-      {{#if this.lastKnownGoodHtml}}
-        <this.lastKnownGoodHtml />
-      {{else}}
-        <div class='card-error-default'>
-          <FileAlert class='icon' />
-          <div class='message'>
-            {{#if @message}}
-              {{@message}}
-            {{else if @cardCreationError}}
-              Failed to create card.
-            {{else}}
-              This card contains an error.
-            {{/if}}
+    <div class='card-error-container'>
+      <div class='card-error' data-test-card-error>
+        {{#if this.lastKnownGoodHtml}}
+          <this.lastKnownGoodHtml />
+        {{else}}
+          <div class='card-error-default'>
+            <FileAlert class='icon' />
+            <div class='message'>
+              {{#if @message}}
+                {{@message}}
+              {{else if @cardCreationError}}
+                Failed to create card.
+              {{else}}
+                This card contains an error.
+              {{/if}}
+            </div>
           </div>
-        </div>
-      {{/if}}
+        {{/if}}
+      </div>
+      {{#unless @hideErrorDetail}}
+        <CardErrorDetail
+          @error={{@error}}
+          @title={{this.errorTitle}}
+          @viewInCodeMode={{@viewInCodeMode}}
+          @fileToFixWithAi={{@fileToFixWithAi}}
+          class='card-error-detail'
+        >
+          <:error>
+            {{yield to='error'}}
+          </:error>
+        </CardErrorDetail>
+      {{/unless}}
     </div>
-
-    <CardErrorDetail
-      @error={{@error}}
-      @title={{this.errorTitle}}
-      @viewInCodeMode={{@viewInCodeMode}}
-      @fileToFixWithAi={{@fileToFixWithAi}}
-    >
-      <:error>
-        {{yield to='error'}}
-      </:error>
-    </CardErrorDetail>
 
     <style scoped>
       .icon {
@@ -114,6 +116,16 @@ export default class CardErrorComponent extends Component<Signature> {
         min-height: var(--boxel-form-control-height);
         background-color: var(--boxel-100);
         box-shadow: 0 1px 0 0 rgba(0 0 0 / 15%);
+      }
+      .card-error-container {
+        position: relative;
+        overflow: auto;
+      }
+      .card-error-detail {
+        position: sticky;
+        bottom: var(--boxel-sp);
+        margin: var(--boxel-sp);
+        max-height: calc(100% - var(--boxel-sp-lg));
       }
     </style>
   </template>

--- a/packages/host/app/components/operator-mode/card-error.gts
+++ b/packages/host/app/components/operator-mode/card-error.gts
@@ -29,11 +29,13 @@ interface Signature {
       moreOptionsMenuItems?: MenuItem[];
       onClose?: () => void;
     };
-    hideErrorDetail?: boolean;
     fileToFixWithAi?: FileDef;
     message?: string;
   };
   Element: HTMLElement;
+  Blocks: {
+    error: [];
+  };
 }
 
 export default class CardErrorComponent extends Component<Signature> {
@@ -50,36 +52,35 @@ export default class CardErrorComponent extends Component<Signature> {
       />
     {{/unless}}
 
-    <div class='card-error-container'>
-      <div class='card-error' data-test-card-error>
-        {{#if this.lastKnownGoodHtml}}
-          <this.lastKnownGoodHtml />
-        {{else}}
-          <div class='card-error-default'>
-            <FileAlert class='icon' />
-            <div class='message'>
-              {{#if @message}}
-                {{@message}}
-              {{else if @cardCreationError}}
-                Failed to create card.
-              {{else}}
-                This card contains an error.
-              {{/if}}
-            </div>
+    <div class='card-error' data-test-card-error>
+      {{#if this.lastKnownGoodHtml}}
+        <this.lastKnownGoodHtml />
+      {{else}}
+        <div class='card-error-default'>
+          <FileAlert class='icon' />
+          <div class='message'>
+            {{#if @message}}
+              {{@message}}
+            {{else if @cardCreationError}}
+              Failed to create card.
+            {{else}}
+              This card contains an error.
+            {{/if}}
           </div>
-        {{/if}}
-      </div>
-      {{#unless @hideErrorDetail}}
-        <CardErrorDetail
-          @error={{@error}}
-          @title={{this.errorTitle}}
-          @viewInCodeMode={{@viewInCodeMode}}
-          @fileToFixWithAi={{@fileToFixWithAi}}
-          class='card-error-detail'
-        />
-      {{/unless}}
+        </div>
+      {{/if}}
     </div>
-
+    <CardErrorDetail
+      @error={{@error}}
+      @title={{this.errorTitle}}
+      @viewInCodeMode={{@viewInCodeMode}}
+      @fileToFixWithAi={{@fileToFixWithAi}}
+      class='card-error-detail'
+    >
+      <:error>
+        {{yield to='error'}}
+      </:error>
+    </CardErrorDetail>
     <style scoped>
       .icon {
         height: 100px;
@@ -113,15 +114,23 @@ export default class CardErrorComponent extends Component<Signature> {
         background-color: var(--boxel-100);
         box-shadow: 0 1px 0 0 rgba(0 0 0 / 15%);
       }
-      .card-error-container {
-        position: relative;
-        overflow: auto;
-      }
       .card-error-detail {
-        position: sticky;
+        position: absolute;
         bottom: var(--boxel-sp);
-        margin: var(--boxel-sp);
-        max-height: calc(100% - var(--boxel-sp-lg));
+        left: var(--boxel-sp);
+        right: var(--boxel-sp);
+        max-height: calc(
+          100% -
+            calc(
+              calc(var(--boxel-sp) * 2) +
+                var(
+                  --card-error-header-height,
+                  var(--boxel-form-control-height)
+                )
+            )
+        );
+        z-index: 10;
+        margin: 0;
       }
     </style>
   </template>

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
@@ -73,6 +73,7 @@ import type { Spec } from 'https://cardstack.com/base/spec';
 
 import PrerenderedCardSearch from '../../../prerendered-card-search';
 import CardError from '../../card-error';
+import CardErrorDetail from '../../card-error-detail';
 import FormatChooser from '../format-chooser';
 
 import AiAssistantIcon from './ai-assistant-icon-bw';
@@ -83,7 +84,6 @@ import InstanceSelectDropdown, {
 } from './instance-chooser-dropdown';
 import PlaygroundPreview from './playground-preview';
 import SpecSearch from './spec-search';
-import CardErrorDetail from '../../card-error-detail';
 
 export type SelectedInstance = {
   card: CardDef;

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
@@ -83,6 +83,7 @@ import InstanceSelectDropdown, {
 } from './instance-chooser-dropdown';
 import PlaygroundPreview from './playground-preview';
 import SpecSearch from './spec-search';
+import CardErrorDetail from '../../card-error-detail';
 
 export type SelectedInstance = {
   card: CardDef;
@@ -900,14 +901,20 @@ export default class PlaygroundPanel extends Component<Signature> {
                       @error={{this.cardError}}
                       @cardCreationError={{this.cardError.meta.isCreationError}}
                       @fileToFixWithAi={{this.currentFileDef}}
-                    >
-                      <:error>
-                        <div class='instance-chooser-container'>
-                          <InstanceChooser />
-                        </div>
-                      </:error>
-                    </CardError>
+                      @hideErrorDetail={{true}}
+                    />
                   </CardContainer>
+                  <CardErrorDetail
+                    @error={{this.cardError}}
+                    @fileToFixWithAi={{this.currentFileDef}}
+                    class='card-error-detail'
+                  >
+                    <:error>
+                      <div class='instance-chooser-container'>
+                        <InstanceChooser />
+                      </div>
+                    </:error>
+                  </CardErrorDetail>
                 {{/if}}
               {{else if card}}
                 <div
@@ -1009,6 +1016,15 @@ export default class PlaygroundPanel extends Component<Signature> {
       .error-container :deep(.instance-chooser) {
         border-radius: var(--boxel-border-radius);
         box-shadow: var(--boxel-deep-box-shadow);
+      }
+      .card-error-detail {
+        position: sticky;
+        bottom: var(--boxel-sp);
+        margin: var(--boxel-sp);
+        max-height: calc(100% - var(--boxel-sp-lg));
+      }
+      .card-error-detail :deep(.instance-chooser) {
+        border-radius: var(--boxel-border-radius);
       }
     </style>
   </template>

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
@@ -73,7 +73,6 @@ import type { Spec } from 'https://cardstack.com/base/spec';
 
 import PrerenderedCardSearch from '../../../prerendered-card-search';
 import CardError from '../../card-error';
-import CardErrorDetail from '../../card-error-detail';
 import FormatChooser from '../format-chooser';
 
 import AiAssistantIcon from './ai-assistant-icon-bw';
@@ -901,20 +900,14 @@ export default class PlaygroundPanel extends Component<Signature> {
                       @error={{this.cardError}}
                       @cardCreationError={{this.cardError.meta.isCreationError}}
                       @fileToFixWithAi={{this.currentFileDef}}
-                      @hideErrorDetail={{true}}
-                    />
+                    >
+                      <:error>
+                        <div class='instance-chooser-container'>
+                          <InstanceChooser />
+                        </div>
+                      </:error>
+                    </CardError>
                   </CardContainer>
-                  <CardErrorDetail
-                    @error={{this.cardError}}
-                    @fileToFixWithAi={{this.currentFileDef}}
-                    class='card-error-detail'
-                  >
-                    <:error>
-                      <div class='instance-chooser-container'>
-                        <InstanceChooser />
-                      </div>
-                    </:error>
-                  </CardErrorDetail>
                 {{/if}}
               {{else if card}}
                 <div
@@ -961,7 +954,6 @@ export default class PlaygroundPanel extends Component<Signature> {
 
     <style scoped>
       .playground-panel {
-        position: relative;
         background-image: url('./playground-background.png');
         background-position: left top;
         background-repeat: repeat;
@@ -1012,16 +1004,15 @@ export default class PlaygroundPanel extends Component<Signature> {
         flex-grow: 1;
         display: grid;
         grid-template-rows: max-content 1fr;
+        position: unset;
+
+        --card-error-header-height: calc(
+          40px + var(--boxel-form-control-height) + var(--boxel-sp)
+        );
       }
       .error-container :deep(.instance-chooser) {
         border-radius: var(--boxel-border-radius);
         box-shadow: var(--boxel-deep-box-shadow);
-      }
-      .card-error-detail {
-        position: sticky;
-        bottom: var(--boxel-sp);
-        margin: var(--boxel-sp);
-        max-height: calc(100% - var(--boxel-sp-lg));
       }
       .card-error-detail :deep(.instance-chooser) {
         border-radius: var(--boxel-border-radius);

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -575,6 +575,9 @@ export default class OperatorModeStackItem extends Component<Signature> {
     >
       <CardContainer
         class='stack-item-card'
+        style={{cssVar
+          card-error-header-height='var(--stack-item-header-height)'
+        }}
         {{ContentElement onSetup=this.setupContainerEl}}
       >
         {{#if (not this.cardResource.isLoaded)}}


### PR DESCRIPTION
In this PR, I address an issue where the card error detail could not be scrolled. I also improved its positioning — instead of placing it at the bottom, I made it sticky.

Before:

https://github.com/user-attachments/assets/4094bd5b-8aed-42dd-a150-47f08d3ee4e8

After:

https://github.com/user-attachments/assets/4f64c61c-98d2-48ed-a8d8-8ffdec0199a8


