### PR TITLE
Run code in realm using the authority of the realm's owner

### DIFF
--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -35,7 +35,7 @@ import {
   testRealmURLToUsername,
 } from '@cardstack/runtime-common/helpers/const';
 import { Loader } from '@cardstack/runtime-common/loader';
-
+import { MatrixClient } from '@cardstack/runtime-common/matrix-client';
 import { Realm } from '@cardstack/runtime-common/realm';
 
 import CardPrerender from '@cardstack/host/components/card-prerender';
@@ -53,10 +53,7 @@ import {
 } from 'https://cardstack.com/base/card-api';
 
 import { TestRealmAdapter } from './adapter';
-import {
-  testRealmServerMatrixUserId,
-  testRealmServerMatrixUsername,
-} from './mock-matrix';
+import { testRealmServerMatrixUsername } from './mock-matrix';
 import percySnapshot from './percy-snapshot';
 import { renderComponent } from './render-component';
 import visitOperatorMode from './visit-operator-mode';
@@ -431,7 +428,11 @@ async function setupTestRealm({
     virtualNetwork,
     dbAdapter,
     queue,
-    realmServerMatrixUserId: testRealmServerMatrixUserId,
+    realmServerMatrixClient: new MatrixClient({
+      matrixURL: baseTestMatrix.url,
+      username: testRealmServerMatrixUsername,
+      seed: testRealmSecretSeed,
+    }),
   });
 
   // TODO this is the only use of Realm.maybeHandle left--can we get rid of it?

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -7,7 +7,6 @@ import {
   SupportedMimeType,
   insertPermissions,
   Deferred,
-  userIdFromUsername,
   type VirtualNetwork,
   type DBAdapter,
   type QueuePublisher,
@@ -66,7 +65,6 @@ export class RealmServer {
     | (() => Promise<string | undefined>)
     | undefined;
   private enableFileWatcher: boolean;
-  private matrixUserId: string;
 
   constructor({
     serverURL,
@@ -108,11 +106,6 @@ export class RealmServer {
     }
     detectRealmCollision(realms);
     ensureDirSync(realmsRootPath);
-
-    this.matrixUserId = userIdFromUsername(
-      matrixClient.username,
-      matrixClient.matrixURL.href,
-    );
 
     this.serverURL = serverURL;
     this.virtualNetwork = virtualNetwork;
@@ -378,7 +371,7 @@ export class RealmServer {
         url: this.matrixClient.matrixURL,
         username,
       },
-      realmServerMatrixUserId: this.matrixUserId,
+      realmServerMatrixClient: this.matrixClient,
     });
     this.realms.push(realm);
     this.virtualNetwork.mount(realm.handle);
@@ -431,7 +424,7 @@ export class RealmServer {
               url: this.matrixClient.matrixURL,
               username,
             },
-            realmServerMatrixUserId: this.matrixUserId,
+            realmServerMatrixClient: this.matrixClient,
           });
           this.virtualNetwork.mount(realm.handle);
           realms.push(realm);

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -294,6 +294,11 @@ export async function createRealm({
       realmServerMatrixUsername: testRealmServerMatrixUsername,
     });
   }
+  let realmServerMatrixClient = new MatrixClient({
+    matrixURL: realmServerTestMatrix.url,
+    username: realmServerTestMatrix.username,
+    seed: realmSecretSeed,
+  });
   let realm = new Realm({
     url: realmURL,
     adapter,
@@ -302,7 +307,7 @@ export async function createRealm({
     virtualNetwork,
     dbAdapter,
     queue: publisher,
-    realmServerMatrixUserId: testRealmServerMatrixUserId,
+    realmServerMatrixClient,
   });
   if (worker) {
     virtualNetwork.mount(realm.handle);


### PR DESCRIPTION
This PR updates the realm such that when we run code in the realm we run it using the authority of the realm's owner via the assume-user permission granted to the realm server. This logic should be temporary. When the headless chrome logic lands we should be able to back this all out as the realm will hopefully no longer be using the loader at that point.