### PR TITLE
host: Update LLM chooser design

### DIFF
--- a/packages/host/app/components/ai-assistant/llm-select.gts
+++ b/packages/host/app/components/ai-assistant/llm-select.gts
@@ -91,6 +91,7 @@ export default class LLMSelect extends Component<Signature> {
       }
 
       .llm-option {
+        background: var(--boxel-light);
         border-radius: var(--boxel-border-radius);
         border: 1px solid var(--boxel-400);
       }

--- a/packages/host/app/components/ai-assistant/llm-select.gts
+++ b/packages/host/app/components/ai-assistant/llm-select.gts
@@ -13,7 +13,7 @@ import scrollIntoViewModifier from '@cardstack/host/modifiers/scroll-into-view';
 interface Signature {
   Args: {
     selected: string;
-    options: string[];
+    options: Record<string, string>;
     onChange: (selectedLLM: string) => void;
     disabled?: boolean;
     onExpand?: () => void;
@@ -42,28 +42,28 @@ export default class LLMSelect extends Component<Signature> {
       </:headerDetail>
       <:content>
         <ul class='llm-list'>
-          {{#each @options as |option|}}
+          {{#each-in @options as |id name|}}
             <li
-              class='llm-option {{if (eq @selected option) "selected"}}'
-              data-test-llm-select-item={{option}}
+              class='llm-option {{if (eq @selected id) "selected"}}'
+              data-test-llm-select-item={{id}}
               {{scrollIntoViewModifier
-                (eq @selected option)
+                (eq @selected id)
                 container='llm-select'
-                key=option
+                key=id
               }}
             >
               <button
                 type='button'
                 class='llm-button'
-                {{on 'click' (fn this.handleOptionClick option)}}
+                {{on 'click' (fn this.handleOptionClick id)}}
               >
-                {{option}}
-                {{#if (eq @selected option)}}
+                {{name}}
+                {{#if (eq @selected id)}}
                   <Check class='selected-icon' />
                 {{/if}}
               </button>
             </li>
-          {{/each}}
+          {{/each-in}}
         </ul>
       </:content>
     </PillMenu>
@@ -136,7 +136,7 @@ export default class LLMSelect extends Component<Signature> {
   </template>
 
   private get displayName() {
-    return this.args.selected.split('/')[1] ?? this.args.selected;
+    return this.args.options[this.args.selected];
   }
 
   @action

--- a/packages/host/app/components/ai-assistant/llm-select.gts
+++ b/packages/host/app/components/ai-assistant/llm-select.gts
@@ -85,7 +85,7 @@ export default class LLMSelect extends Component<Signature> {
         padding: 0;
         margin: 0;
         display: grid;
-        gap: var(--boxel-sp-xs);
+        gap: var(--boxel-sp-xxxs);
         max-height: 300px;
         overflow-y: auto;
       }

--- a/packages/host/app/components/ai-assistant/llm-select.gts
+++ b/packages/host/app/components/ai-assistant/llm-select.gts
@@ -3,6 +3,8 @@ import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 
+import Check from '@cardstack/boxel-icons/check';
+
 import { eq } from '@cardstack/boxel-ui/helpers';
 
 import PillMenu from '@cardstack/host/components/pill-menu';
@@ -56,6 +58,9 @@ export default class LLMSelect extends Component<Signature> {
                 {{on 'click' (fn this.handleOptionClick option)}}
               >
                 {{option}}
+                {{#if (eq @selected option)}}
+                  <Check class='selected-icon' />
+                {{/if}}
               </button>
             </li>
           {{/each}}
@@ -104,15 +109,28 @@ export default class LLMSelect extends Component<Signature> {
         background-color: var(--boxel-teal);
       }
 
+      .selected-icon {
+        width: var(--boxel-font-size);
+        height: auto;
+        stroke-width: 3px;
+      }
+
       .llm-button {
         width: 100%;
         padding: var(--boxel-sp-xs) var(--boxel-sp-sm);
-        text-align: left;
         background: none;
         border: none;
         color: var(--boxel-dark);
         font: 500 var(--boxel-font-xs);
         cursor: pointer;
+
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+
+      .llm-option.selected .llm-button {
+        font-weight: 600;
       }
     </style>
   </template>

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -38,7 +38,10 @@ import {
   internalKeyFor,
   isCardInstance,
 } from '@cardstack/runtime-common';
-import { DEFAULT_LLM_LIST } from '@cardstack/runtime-common/matrix-constants';
+import {
+  DEFAULT_LLM_LIST,
+  DEFAULT_LLM_ID_TO_NAME,
+} from '@cardstack/runtime-common/matrix-constants';
 
 import AddSkillsToRoomCommand from '@cardstack/host/commands/add-skills-to-room';
 import UpdateSkillActivationCommand from '@cardstack/host/commands/update-skill-activation';
@@ -658,11 +661,16 @@ export default class Room extends Component<Signature> {
   }
 
   private get llmsForSelectMenu() {
-    return [
+    let ids = [
       ...new Set([...DEFAULT_LLM_LIST, ...this.args.roomResource.usedLLMs]),
     ]
       .filter(Boolean)
       .sort();
+
+    return ids.reduce((acc: Record<string, string>, id) => {
+      acc[id] = DEFAULT_LLM_ID_TO_NAME[id] ?? id;
+      return acc;
+    }, {});
   }
 
   private get sortedSkills(): RoomSkill[] {

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -295,7 +295,7 @@ export default class Room extends Component<Signature> {
 
       .llm-select :deep(.menu-content) {
         margin-right: calc(-2 * var(--boxel-sp-sm));
-        padding-right: var(--boxel-sp-sm);
+        width: 100%;
       }
 
       .chat-input-area :deep(.minimized-arrow) {

--- a/packages/host/app/components/pill-menu/index.gts
+++ b/packages/host/app/components/pill-menu/index.gts
@@ -7,10 +7,7 @@ import onClickOutside from 'ember-click-outside/modifiers/on-click-outside';
 
 import { Header } from '@cardstack/boxel-ui/components';
 
-import {
-  DropdownArrowFilled,
-  DropdownArrowUp,
-} from '@cardstack/boxel-ui/icons';
+import { DropdownArrowFilled } from '@cardstack/boxel-ui/icons';
 
 export type PillMenuItem = {
   cardId: string;
@@ -57,7 +54,7 @@ export default class PillMenu extends Component<Signature> {
               class='header-button'
               data-test-pill-menu-button
             >
-              <DropdownArrowUp class='rotate-left' width='8px' height='8px' />
+              <DropdownArrowFilled width='8px' height='8px' />
             </button>
           </:actions>
         </Header>
@@ -87,7 +84,7 @@ export default class PillMenu extends Component<Signature> {
     {{/if}}
     <style scoped>
       .pill-menu {
-        --boxel-header-gap: var(--boxel-sp-xxs);
+        --boxel-header-gap: var(--boxel-sp-4xs);
         --boxel-header-detail-margin-left: 0;
         --pill-menu-spacing: var(--boxel-pill-menu-spacing, var(--boxel-sp-xs));
         --boxel-header-padding: 0 0 0 var(--pill-menu-spacing);
@@ -189,10 +186,6 @@ export default class PillMenu extends Component<Signature> {
       .pill-menu :deep(.menu-header .content) {
         order: 1;
         margin-left: 0;
-      }
-      .rotate-left {
-        transform: rotate(-90deg);
-        transform-origin: center;
       }
       .minimized-arrow {
         transform: rotate(180deg);

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -14,6 +14,7 @@ import {
   APP_BOXEL_MESSAGE_MSGTYPE,
   DEFAULT_LLM,
   DEFAULT_LLM_LIST,
+  DEFAULT_LLM_ID_TO_NAME,
   APP_BOXEL_REASONING_CONTENT_KEY,
 } from '@cardstack/runtime-common/matrix-constants';
 
@@ -382,26 +383,31 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     await waitFor(`[data-room-settled]`);
     assert
       .dom('[data-test-llm-select-selected]')
-      .hasText(DEFAULT_LLM.split('/')[1]);
+      .hasText(DEFAULT_LLM_ID_TO_NAME[DEFAULT_LLM]);
     await click('[data-test-llm-select-selected]');
 
     assert.dom('[data-test-llm-select-item]').exists({
       count: DEFAULT_LLM_LIST.length,
     });
+
+    let llmIdToChangeTo = 'anthropic/claude-3.7-sonnet';
+    let llmName = DEFAULT_LLM_ID_TO_NAME[llmIdToChangeTo];
+
     assert
-      .dom('[data-test-llm-select-item="anthropic/claude-3.7-sonnet"]')
-      .hasText('anthropic/claude-3.7-sonnet');
-    await click(
-      '[data-test-llm-select-item="anthropic/claude-3.7-sonnet"] button',
-    );
+      .dom(`[data-test-llm-select-item="${llmIdToChangeTo}"]`)
+      .hasText(llmName);
+    await click(`[data-test-llm-select-item="${llmIdToChangeTo}"] button`);
     await click('[data-test-pill-menu-button]');
-    assert.dom('[data-test-llm-select-selected]').hasText('claude-3.7-sonnet');
+    assert.dom('[data-test-llm-select-selected]').hasText(llmName);
 
     let roomState = getRoomState(matrixRoomId, APP_BOXEL_ACTIVE_LLM, '');
-    assert.strictEqual(roomState.model, 'anthropic/claude-3.7-sonnet');
+    assert.strictEqual(roomState.model, llmIdToChangeTo);
   });
 
   test('defaults to anthropic/claude-sonnet-4 in code mode', async function (assert) {
+    let defaultCodeLLMId = 'anthropic/claude-sonnet-4';
+    let defaultCodeLLMName = DEFAULT_LLM_ID_TO_NAME[defaultCodeLLMId];
+
     await visitOperatorMode({
       stacks: [
         [
@@ -417,7 +423,7 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     await waitFor(`[data-room-settled]`);
     await click('[data-test-submode-switcher] button');
     await click('[data-test-boxel-menu-item-text="Code"]');
-    assert.dom('[data-test-llm-select-selected]').hasText('claude-sonnet-4');
+    assert.dom('[data-test-llm-select-selected]').hasText(defaultCodeLLMName);
 
     createAndJoinRoom({
       sender: '@testuser:localhost',
@@ -427,7 +433,7 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     await click('[data-test-past-sessions-button]');
     await waitFor("[data-test-enter-room='mock_room_1']");
     await click('[data-test-enter-room="mock_room_1"]');
-    assert.dom('[data-test-llm-select-selected]').hasText('claude-sonnet-4');
+    assert.dom('[data-test-llm-select-selected]').hasText(defaultCodeLLMName);
   });
 
   test('auto-attached file is not displayed in interact mode', async function (assert) {

--- a/packages/runtime-common/matrix-constants.ts
+++ b/packages/runtime-common/matrix-constants.ts
@@ -28,24 +28,27 @@ export const APP_BOXEL_CONTINUATION_OF_CONTENT_KEY =
 export const DEFAULT_LLM = 'openai/gpt-4.1';
 export const DEFAULT_CODING_LLM = 'anthropic/claude-sonnet-4';
 export const DEFAULT_REMIX_LLM = 'openai/gpt-4.1-nano';
-export const DEFAULT_LLM_LIST = [
-  'anthropic/claude-3.5-sonnet',
-  'anthropic/claude-3.7-sonnet',
-  'anthropic/claude-3.7-sonnet:thinking',
-  'anthropic/claude-sonnet-4',
-  'anthropic/claude-opus-4',
-  'deepseek/deepseek-chat-v3-0324',
-  'google/gemini-2.0-flash-001',
-  'google/gemini-2.0-flash-lite-001',
-  'google/gemini-2.5-pro-preview',
-  'meta-llama/llama-3.2-3b-instruct',
-  'openai/gpt-4.1-nano',
-  'openai/gpt-4.1-mini',
-  'openai/gpt-4.1',
-  'openai/gpt-4o',
-  'openai/gpt-4o-mini',
-  'x-ai/grok-3-mini-beta',
-];
+
+export const DEFAULT_LLM_ID_TO_NAME = {
+  'anthropic/claude-3.5-sonnet': 'Anthropic: Claude 3.5 Sonnet',
+  'anthropic/claude-3.7-sonnet': 'Anthropic: Claude 3.7 Sonnet',
+  'anthropic/claude-3.7-sonnet:thinking':
+    'Anthropic: Claude 3.7 Sonnet (thinking)',
+  'anthropic/claude-sonnet-4': 'Anthropic: Claude Sonnet 4',
+  'anthropic/claude-opus-4': 'Anthropic: Claude Opus 4',
+  'deepseek/deepseek-chat-v3-0324': 'DeepSeek: DeepSeek V3 0324',
+  'google/gemini-2.0-flash-001': 'Google: Gemini 2.0 Flash',
+  'google/gemini-2.0-flash-lite-001': 'Google: Gemini 2.0 Flash Lite',
+  'google/gemini-2.5-pro-preview': 'Google: Gemini 2.5 Pro Preview 06-05',
+  'meta-llama/llama-3.2-3b-instruct': 'Meta: Llama 3.2 3B Instruct',
+  'openai/gpt-4.1-nano': 'OpenAI: GPT-4.1 Nano',
+  'openai/gpt-4.1-mini': 'OpenAI: GPT-4.1 Mini',
+  'openai/gpt-4.1': 'OpenAI: GPT-4.1',
+  'openai/gpt-4o': 'OpenAI: GPT-4o',
+  'openai/gpt-4o-mini': 'OpenAI: GPT-4o-mini',
+};
+
+export const DEFAULT_LLM_LIST = Object.keys(DEFAULT_LLM_ID_TO_NAME);
 
 export const SLIDING_SYNC_AI_ROOM_LIST_NAME = 'ai-room';
 export const SLIDING_SYNC_AUTH_ROOM_LIST_NAME = 'auth-room';

--- a/packages/runtime-common/matrix-constants.ts
+++ b/packages/runtime-common/matrix-constants.ts
@@ -29,7 +29,7 @@ export const DEFAULT_LLM = 'openai/gpt-4.1';
 export const DEFAULT_CODING_LLM = 'anthropic/claude-sonnet-4';
 export const DEFAULT_REMIX_LLM = 'openai/gpt-4.1-nano';
 
-export const DEFAULT_LLM_ID_TO_NAME = {
+export const DEFAULT_LLM_ID_TO_NAME: Record<string, string> = {
   'anthropic/claude-3.5-sonnet': 'Anthropic: Claude 3.5 Sonnet',
   'anthropic/claude-3.7-sonnet': 'Anthropic: Claude 3.7 Sonnet',
   'anthropic/claude-3.7-sonnet:thinking':


### PR DESCRIPTION
Design:

<img width="475" alt="LATEST UI Jun 17 - LATEST UI Jun 17 - Zeplin 2025-07-08 10-05-40" src="https://github.com/user-attachments/assets/e87a0c72-47a8-4d2b-a6bf-5d1c183aca35" />

I just noticed the gradient at the scroll boundary and have opened another issue for it, as it’s applicable to more than just the LLM chooser.

<table>
<thead>
<tr>
<th>
Current
</th>
<th>
This PR
</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="371" alt="d5e20c02-469e-4ff9-9f7c-e3211cddad0b json in Cardstack Skills 2025-07-08 10-08-49" src="https://github.com/user-attachments/assets/71edaae2-62a5-4939-abe3-ddd1d64f54c9" />
</td>
<td>
<img width="371" alt="d5e20c02-469e-4ff9-9f7c-e3211cddad0b json in Cardstack Skills 2025-07-08 10-08-32" src="https://github.com/user-attachments/assets/eba2f9a5-1f6f-4d7a-b909-adfbbc12a5fd" />
</td>
</tr>
</tbody>
</table>