### PR TITLE
Fix: Accept all appears when there is no code patch

### DIFF
--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -983,7 +983,7 @@ export default class Room extends Component<Signature> {
     for (let i = 0; i < lastMessage.htmlParts.length; i++) {
       let htmlPart = lastMessage.htmlParts[i];
       let codeData = htmlPart.codeData;
-      if (!codeData) continue;
+      if (!codeData || !codeData.searchReplaceBlock) continue;
       let status = this.commandService.getCodePatchStatus(codeData);
       if (status && status === 'ready') {
         result.push(codeData);

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -1031,6 +1031,41 @@ module('Acceptance | AI Assistant tests', function (hooks) {
       );
   });
 
+  test(`should not display action bar when there is no code patch block`, async function (assert) {
+    await visitOperatorMode({
+      submode: 'interact',
+      codePath: `${testRealmURL}index.json`,
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}index`,
+            format: 'isolated',
+          },
+        ],
+      ],
+    });
+
+    // In interact mode, auto-attached cards must be the top most cards in the stack
+    // unless the card is manually chosen
+    await click(`[data-test-cards-grid-item="${testRealmURL}Person/fadhlan"]`);
+    await click('[data-test-open-ai-assistant]');
+    await waitFor(`[data-room-settled]`);
+
+    let codeBlock = `\`\`\`
+  { "name": "test" }
+\`\`\``;
+
+    simulateRemoteMessage(matrixRoomId, '@aibot:localhost', {
+      body: codeBlock,
+      msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+      format: 'org.matrix.custom.html',
+      isStreamingFinished: true,
+    });
+
+    await waitFor('[data-test-ai-assistant-message]');
+    assert.dom('[data-test-ai-assistant-action-bar]').doesNotExist();
+  });
+
   test('code mode context sent with message', async function (assert) {
     await visitOperatorMode({
       submode: 'code',


### PR DESCRIPTION
This PR fixes an issue where the 'Accept All' button appears even when there is no code patch in the last message. This occurred because we didn't filter out code blocks that are not search-and-replace code blocks.

Before:

<img width="373" alt="Screenshot 2025-07-08 at 15 08 47" src="https://github.com/user-attachments/assets/aad27dd9-f446-48e4-b829-afc7ce614cba" />

After:

<img width="372" alt="Screenshot 2025-07-08 at 15 09 09" src="https://github.com/user-attachments/assets/f04173e2-0c5e-42ae-80f6-adf529002d65" />

