### PR TITLE
Create instance when CardsGrid filtered to a type

### DIFF
--- a/packages/base/cards-grid.gts
+++ b/packages/base/cards-grid.gts
@@ -161,7 +161,7 @@ class Isolated extends Component<typeof CardsGrid> {
 
     let spec: Spec | CardErrorJSONAPI | undefined;
     if (activeFilterRef) {
-      let preselectedCardTypeQuery = {
+      let instances = await this.args.context?.store.search({
         filter: {
           on: specRef,
           eq: { ref: activeFilterRef },
@@ -172,10 +172,7 @@ class Isolated extends Component<typeof CardsGrid> {
             direction: 'desc',
           },
         ],
-      } as Query;
-      let instances = await this.args.context?.store.search(
-        preselectedCardTypeQuery,
-      );
+      } as Query);
       if (instances?.[0]?.id) {
         spec = instances[0] as Spec;
       }

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -8,6 +8,7 @@ import { isTesting } from '@embroider/macros';
 import { formatDistanceToNow } from 'date-fns';
 import { task } from 'ember-concurrency';
 
+import { flatMap } from 'lodash';
 import cloneDeep from 'lodash/cloneDeep';
 import isEqual from 'lodash/isEqual';
 import merge from 'lodash/merge';
@@ -67,9 +68,8 @@ import type LoaderService from './loader-service';
 import type MessageService from './message-service';
 import type OperatorModeStateService from './operator-mode-state-service';
 import type RealmService from './realm';
-import type ResetService from './reset';
 import type RealmServerService from './realm-server';
-import { flatMap } from 'lodash';
+import type ResetService from './reset';
 
 export { CardErrorJSONAPI, CardSaveSubscriber };
 

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -911,139 +911,28 @@ module('Acceptance | interact submode tests', function (hooks) {
         );
     });
 
-    test<TestContextWithSave>('card-catalog can pre-select the current filtered card type', async function (assert) {
-      assert.expect(14);
+    test<TestContextWithSave>('create a new card instance when type is seleted in CardsGrid', async function (assert) {
       await visitOperatorMode({
         stacks: [[{ id: `${testRealmURL}index`, format: 'isolated' }]],
       });
-      let deferred: Deferred<SingleCardDocument<string>> | undefined;
-      this.onSave((_, json) => {
-        if (typeof json === 'string') {
-          throw new Error('expected JSON save data');
-        }
-        deferred?.fulfill(json);
-      });
+
+      assert.dom('[data-test-stack-card-index]').exists({ count: 1 });
+      await click('[data-test-create-new-card-button]');
+      assert.dom('[data-test-card-catalog-item]').exists();
+      await click('[data-test-card-catalog-cancel-button]');
 
       await click('[data-test-boxel-filter-list-button="Person"]');
       await click('[data-test-create-new-card-button]');
-      assert.dom('[data-test-card-catalog-item]').exists();
-      assert
-        .dom('[data-test-show-more-cards]')
-        .doesNotExist('All cards are visible');
+      assert.dom('[data-test-card-catalog-item]').doesNotExist();
+      assert.dom('[data-test-stack-card-index]').exists({ count: 2 });
       assert
         .dom(
-          `[data-test-card-catalog-item="${testRealmURL}person-entry"][data-test-card-catalog-item-selected]`,
+          '[data-test-stack-card-index="1"] [data-test-boxel-card-header-title]',
         )
-        .exists('Person spec is pre-selected');
+        .hasText('Person');
       assert
-        .dom('[data-test-card-catalog-item-selected]')
-        .exists({ count: 1 }, 'Only 1 card is selected');
-
-      await click('[data-test-card-catalog-cancel-button]');
-      await click('[data-test-boxel-filter-list-button="All Cards"]');
-      await click('[data-test-create-new-card-button]');
-      assert
-        .dom('[data-test-card-catalog-item-selected]')
-        .doesNotExist(
-          'Pre-selection is cleared when filter does not specify card type',
-        );
-      assert.dom('[data-test-card-catalog-item]').exists();
-      assert
-        .dom('[data-test-show-more-cards]')
-        .containsText('not shown', 'Entries are paginated');
-      await click('[data-test-card-catalog-cancel-button]');
-
-      await click('[data-test-boxel-filter-list-button="Puppy"]');
-      await click('[data-test-create-new-card-button]');
-      assert.dom('[data-test-card-catalog-item]').exists();
-      assert
-        .dom('[data-test-show-more-cards]')
-        .doesNotExist('All cards are visible');
-      assert
-        .dom(
-          `[data-test-card-catalog-item="${testRealmURL}puppy-entry"][data-test-card-catalog-item-selected]`,
-        )
-        .exists('Puppy spec is pre-selected');
-      assert
-        .dom('[data-test-card-catalog-item-selected]')
-        .exists({ count: 1 }, 'Only 1 card is selected');
-      await click('[data-test-card-catalog-go-button]');
-
-      deferred = new Deferred<SingleCardDocument<string>>();
-      await fillIn(`[data-test-field="name"] input`, 'Snoopy');
-      await click('[data-test-stack-card-index="1"] [data-test-close-button]');
-
-      let json = await deferred.promise;
-      assert.strictEqual(json.data.attributes?.name, 'Snoopy');
-      assert.strictEqual(json.data.meta.realmURL, testRealmURL);
-      assert.deepEqual(
-        json.data.meta.adoptsFrom,
-        {
-          module: '../pet',
-          name: 'Puppy',
-        },
-        'Created card type is correct',
-      );
-    });
-
-    test<TestContextWithSave>('can change selection on card catalog after a card was pre-selected', async function (assert) {
-      assert.expect(10);
-      await visitOperatorMode({
-        stacks: [[{ id: `${testRealmURL}index`, format: 'isolated' }]],
-      });
-
-      let deferred: Deferred<SingleCardDocument<string>> | undefined;
-      this.onSave((_, json) => {
-        if (typeof json === 'string') {
-          throw new Error('expected JSON save data');
-        }
-        deferred?.fulfill(json);
-      });
-
-      await click('[data-test-boxel-filter-list-button="Puppy"]');
-      await click('[data-test-create-new-card-button]');
-      assert.dom('[data-test-card-catalog-item]').exists();
-      assert
-        .dom('[data-test-show-more-cards]')
-        .doesNotExist('All cards are visible');
-      assert
-        .dom(
-          `[data-test-card-catalog-item="${testRealmURL}puppy-entry"][data-test-card-catalog-item-selected]`,
-        )
-        .exists('Puppy spec is pre-selected');
-      assert
-        .dom('[data-test-card-catalog-item-selected]')
-        .exists({ count: 1 }, 'Only 1 card is selected');
-
-      await click(`[data-test-select="${baseRealm.url}types/card"]`); // changing card selection
-      assert
-        .dom(
-          `[data-test-card-catalog-item="${baseRealm.url}types/card"][data-test-card-catalog-item-selected]`,
-        )
-        .exists('Card selection has changed');
-      assert
-        .dom('[data-test-card-catalog-item-selected]')
-        .exists({ count: 1 }, 'Only 1 card is selected');
-      assert
-        .dom('[data-test-card-catalog-item]')
-        .exists('All cards are still visible');
-      await click('[data-test-card-catalog-go-button]');
-
-      deferred = new Deferred<SingleCardDocument<string>>();
-      await fillIn(`[data-test-field="title"] input`, 'Hello World');
-      await click('[data-test-stack-card-index="1"] [data-test-close-button]');
-
-      let json = await deferred.promise;
-      assert.strictEqual(json.data.attributes?.title, 'Hello World');
-      assert.strictEqual(json.data.meta.realmURL, testRealmURL);
-      assert.deepEqual(
-        json.data.meta.adoptsFrom,
-        {
-          module: `${baseRealm.url}card-api`,
-          name: 'CardDef',
-        },
-        'Created card type is correct',
-      );
+        .dom('[data-test-stack-card-index="1"] [data-test-card-format="edit"]')
+        .exists();
     });
 
     test('duplicate card in a stack is not allowed', async function (assert) {

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -355,7 +355,7 @@ export interface Store {
     id: string,
     patchData: PatchData,
   ): Promise<T | CardErrorJSONAPI | undefined>;
-  search(query: Query, realmURL: URL): Promise<CardDef[]>;
+  search(query: Query, realmURL?: URL): Promise<CardDef[]>;
   getSaveState(id: string): AutoSaveState | undefined;
 }
 


### PR DESCRIPTION
This PR updates the '+' button behavior in the CardsGrid. When a type filter is selected, it creates a new card instance instead of opening the card catalog modal.


https://github.com/user-attachments/assets/26d043f7-f1ce-46da-a565-a965dae7ee49

