### PR TITLE
Add the "New card of this type" to stack item's menu

### DIFF
--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -12,6 +12,7 @@ import Component from '@glimmer/component';
 
 import { tracked, cached } from '@glimmer/tracking';
 
+import Captions from '@cardstack/boxel-icons/captions';
 import {
   restartableTask,
   timeout,
@@ -49,6 +50,7 @@ import {
   cardTypeIcon,
   CommandContext,
   realmURL,
+  identifyCard,
 } from '@cardstack/runtime-common';
 
 import { type StackItem } from '@cardstack/host/lib/stack-item';
@@ -311,6 +313,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
     if (this.isBuried) {
       return undefined;
     }
+
     let menuItems: MenuItem[] = [
       new MenuItem('Copy Card URL', 'action', {
         action: () =>
@@ -327,6 +330,22 @@ export default class OperatorModeStackItem extends Component<Signature> {
       this.realm.canWrite(this.url)
     ) {
       menuItems.push(
+        new MenuItem('New Card of This Type', 'action', {
+          action: () => {
+            if (!this.card) {
+              return;
+            }
+            let ref = identifyCard(this.card.constructor);
+            if (!ref) {
+              return;
+            }
+            this.args.publicAPI.createCard(ref, undefined, {
+              realmURL: this.operatorModeStateService.getWritableRealmURL(),
+            });
+          },
+          icon: this.card ? (cardTypeIcon(this.card) as any) : Captions,
+          disabled: !this.card,
+        }),
         new MenuItem('Delete', 'action', {
           action: () =>
             this.card ? this.args.publicAPI.delete(this.card) : undefined,

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -1230,6 +1230,44 @@ module('Acceptance | interact submode tests', function (hooks) {
       await click(`[data-test-card-catalog-go-button]`);
       await consumerSaved.promise;
     });
+
+    test<TestContextWithSave>('open a stack item of a new card instance when the "New Card of This Type" is clicked', async function (assert) {
+      await visitOperatorMode({
+        stacks: [
+          [
+            {
+              id: `${testRealm2URL}`,
+              format: 'isolated',
+            },
+          ],
+        ],
+      });
+
+      assert.dom('[data-test-operator-mode-stack]').exists({ count: 1 });
+      assert.dom('[data-test-stack-card-index]').exists({ count: 1 });
+      await click('[data-test-more-options-button]');
+      assert
+        .dom('[data-test-boxel-menu-item-text="New Card of This Type"]')
+        .doesNotExist();
+      await click(`[data-cards-grid-item="${testRealm2URL}Pet/ringo"]`);
+      assert.dom('[data-test-stack-card-index]').exists({ count: 2 });
+
+      await click('[data-test-more-options-button]');
+      assert
+        .dom('[data-test-boxel-menu-item-text="New Card of This Type"]')
+        .exists();
+
+      await click('[data-test-boxel-menu-item-text="New Card of This Type"]');
+      assert.dom('[data-test-stack-card-index]').exists({ count: 3 });
+      assert
+        .dom('[data-test-stack-card-index="2"] [data-test-card-format="edit"]')
+        .exists();
+      assert
+        .dom(
+          '[data-test-stack-card-index="2"] [data-test-boxel-card-header-title]',
+        )
+        .containsText('Pet');
+    });
   });
 
   module('1 stack, when the user lacks write permissions', function (hooks) {


### PR DESCRIPTION
This PR adds a new menu item to the stack item's '...' menu that creates a new card instance of the same type. When clicked, it opens a new stack item containing the new card instance.

https://github.com/user-attachments/assets/7c5fed6d-8ce1-48cc-bfb4-b80f10b501b2

