### PR TITLE
host: Remove chat top gradient at conversation start

### DIFF
--- a/packages/host/app/components/ai-assistant/message/index.gts
+++ b/packages/host/app/components/ai-assistant/message/index.gts
@@ -365,7 +365,7 @@ const AiAssistantConversation: TemplateOnlyComponent<AiAssistantConversationSign
       .ai-assistant-conversation {
         display: flex;
         flex-direction: column;
-        padding: 0 var(--ai-assistant-panel-padding)
+        padding: var(--boxel-sp) var(--ai-assistant-panel-padding)
           calc(
             var(--ai-assistant-panel-padding) +
               var(--chat-input-area-border-radius) +

--- a/packages/host/app/components/ai-assistant/message/index.gts
+++ b/packages/host/app/components/ai-assistant/message/index.gts
@@ -376,6 +376,8 @@ const AiAssistantConversation: TemplateOnlyComponent<AiAssistantConversationSign
 
         /* This lets the conversation be visible in the missing border radius of the form, with its gradient */
         margin-bottom: calc(var(--chat-input-area-border-radius) * -1);
+
+        scroll-timeline: --ai-assistant-chat-scroll-timeline;
       }
       .ai-assistant-conversation > :deep(* + *) {
         margin-top: var(--boxel-sp-lg);

--- a/packages/host/app/components/ai-assistant/panel.gts
+++ b/packages/host/app/components/ai-assistant/panel.gts
@@ -369,7 +369,11 @@ export default class AiAssistantPanel extends Component<Signature> {
       }
 
       .session-error {
-        padding: 0 var(--boxel-sp);
+        padding: var(--ai-assistant-panel-padding);
+      }
+
+      .session-error :deep(.intro) {
+        margin-top: calc(var(--ai-assistant-panel-header-height) * 0.5);
       }
 
       .ai-assistant-panel-resize-handle {

--- a/packages/host/app/components/ai-assistant/panel.gts
+++ b/packages/host/app/components/ai-assistant/panel.gts
@@ -208,6 +208,22 @@ export default class AiAssistantPanel extends Component<Signature> {
 
         --ai-assistant-panel-bottom-gradient-height: var(--boxel-sp-xl);
 
+        --top-gradient-hidden: linear-gradient(
+          to bottom,
+          transparent,
+          transparent
+            calc(var(--ai-assistant-panel-top-gradient-start-proportion) * 100%),
+          transparent 100%
+        );
+
+        --top-gradient-showing: linear-gradient(
+          to bottom,
+          var(--boxel-ai-purple),
+          var(--boxel-ai-purple)
+            calc(var(--ai-assistant-panel-top-gradient-start-proportion) * 100%),
+          transparent 100%
+        );
+
         background-color: var(--boxel-ai-purple);
         border-radius: 0;
         color: var(--boxel-light);
@@ -245,13 +261,7 @@ export default class AiAssistantPanel extends Component<Signature> {
         gap: var(--boxel-sp-xxxs);
 
         z-index: 10;
-        background: linear-gradient(
-          to bottom,
-          transparent,
-          transparent
-            calc(var(--ai-assistant-panel-top-gradient-start-proportion) * 100%),
-          transparent 100%
-        );
+        background: var(--top-gradient-hidden);
 
         animation: ai-assistant-chat-gradient-scroll-timeline linear forwards;
         animation-timeline: --ai-assistant-chat-scroll-timeline;
@@ -368,37 +378,15 @@ export default class AiAssistantPanel extends Component<Signature> {
 
       @keyframes ai-assistant-chat-gradient-scroll-timeline {
         0% {
-          background: linear-gradient(
-            to bottom,
-            transparent,
-            transparent
-              calc(
-                var(--ai-assistant-panel-top-gradient-start-proportion) * 100%
-              ),
-            transparent 100%
-          );
+          background: var(--top-gradient-hidden);
         }
+
         1% {
-          background: linear-gradient(
-            to bottom,
-            var(--boxel-ai-purple),
-            var(--boxel-ai-purple)
-              calc(
-                var(--ai-assistant-panel-top-gradient-start-proportion) * 100%
-              ),
-            transparent 100%
-          );
+          background: var(--top-gradient-showing);
         }
+
         100% {
-          background: linear-gradient(
-            to bottom,
-            var(--boxel-ai-purple),
-            var(--boxel-ai-purple)
-              calc(
-                var(--ai-assistant-panel-top-gradient-start-proportion) * 100%
-              ),
-            transparent 100%
-          );
+          background: var(--top-gradient-showing);
         }
       }
     </style>

--- a/packages/host/app/components/ai-assistant/panel.gts
+++ b/packages/host/app/components/ai-assistant/panel.gts
@@ -213,6 +213,8 @@ export default class AiAssistantPanel extends Component<Signature> {
         color: var(--boxel-light);
         height: 100%;
         position: relative;
+
+        timeline-scope: --ai-assistant-chat-scroll-timeline;
       }
       :deep(.arrow) {
         display: none;
@@ -245,11 +247,14 @@ export default class AiAssistantPanel extends Component<Signature> {
         z-index: 10;
         background: linear-gradient(
           to bottom,
-          var(--boxel-ai-purple),
-          var(--boxel-ai-purple)
+          transparent,
+          transparent
             calc(var(--ai-assistant-panel-top-gradient-start-proportion) * 100%),
           transparent 100%
         );
+
+        animation: ai-assistant-chat-gradient-scroll-timeline linear forwards;
+        animation-timeline: --ai-assistant-chat-scroll-timeline;
       }
 
       .panel-title-text {
@@ -359,6 +364,42 @@ export default class AiAssistantPanel extends Component<Signature> {
 
       .ai-assistant-panel-resize-handle {
         z-index: calc(var(--host-ai-panel-z-index) + 1);
+      }
+
+      @keyframes ai-assistant-chat-gradient-scroll-timeline {
+        0% {
+          background: linear-gradient(
+            to bottom,
+            transparent,
+            transparent
+              calc(
+                var(--ai-assistant-panel-top-gradient-start-proportion) * 100%
+              ),
+            transparent 100%
+          );
+        }
+        1% {
+          background: linear-gradient(
+            to bottom,
+            var(--boxel-ai-purple),
+            var(--boxel-ai-purple)
+              calc(
+                var(--ai-assistant-panel-top-gradient-start-proportion) * 100%
+              ),
+            transparent 100%
+          );
+        }
+        100% {
+          background: linear-gradient(
+            to bottom,
+            var(--boxel-ai-purple),
+            var(--boxel-ai-purple)
+              calc(
+                var(--ai-assistant-panel-top-gradient-start-proportion) * 100%
+              ),
+            transparent 100%
+          );
+        }
       }
     </style>
   </template>


### PR DESCRIPTION
This was an oversight in #2858, there shouldn’t be a gradient visible when the chat is scrolled to the top.

<table>
<thead>
<tr>
<th>
Current
</th>
<th>
With this PR
</th>
</tr>
</thead>
<tr>
<td>
<img width="369" alt="index json in Experiments Workspace 2025-07-09 13-10-07" src="https://github.com/user-attachments/assets/a0f922d1-96a8-43a8-b79f-99655969605f" />
</td>
<td>
<img width="369" alt="index json in Experiments Workspace 2025-07-09 13-10-19" src="https://github.com/user-attachments/assets/18736b29-e41f-4504-966b-f3b55ced6ad4" />
</td>
</tr>
</table>

I’ve learned of `scroll-timeline` since working on that so I’ve applied it here to declaratively show the gradient based on the scroll position of the conversation.

While I was here, I also noticed the error state looked weird so I adjusted it it look similar to the new chat state:

<table>
<tr>
<td>
<img width="1561" alt="Boxel 2025-07-09 13-55-12" src="https://github.com/user-attachments/assets/2b9cce09-c05d-44ac-b3bd-437e6906560a" />
</td>
<td>
<img width="1561" alt="Boxel 2025-07-09 14-07-15" src="https://github.com/user-attachments/assets/0147560b-4ab5-42d6-abe3-e93342625731" />
</td>
</tr>
</table>