### PR TITLE
host: Remove pill gradient magic numbers

### DIFF
--- a/packages/host/app/components/ai-assistant/skill-menu/index.gts
+++ b/packages/host/app/components/ai-assistant/skill-menu/index.gts
@@ -88,6 +88,9 @@ export default class AiAssistantSkillMenu extends Component<Signature> {
         padding: 0;
         margin: 0;
         overflow-y: auto;
+        max-height: 100px;
+
+        scroll-timeline: --pill-menu-content-scroll-timeline;
       }
       .skill-list :deep(.card-pill) {
         --pill-gap: var(--boxel-sp-xxxs);

--- a/packages/host/app/components/ai-assistant/skill-menu/index.gts
+++ b/packages/host/app/components/ai-assistant/skill-menu/index.gts
@@ -88,9 +88,6 @@ export default class AiAssistantSkillMenu extends Component<Signature> {
         padding: 0;
         margin: 0;
         overflow-y: auto;
-        max-height: 100px;
-
-        scroll-timeline: --pill-menu-content-scroll-timeline;
       }
       .skill-list :deep(.card-pill) {
         --pill-gap: var(--boxel-sp-xxxs);

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -255,6 +255,8 @@ export default class Room extends Component<Signature> {
         --boxel-pill-menu-footer-padding: 0;
         --boxel-pill-menu-button-padding: 2px 6px;
 
+        --chat-input-area-bottom-padding: var(--boxel-sp-sm);
+
         background-color: var(--boxel-light);
         border-radius: var(--chat-input-area-border-radius);
 
@@ -264,7 +266,7 @@ export default class Room extends Component<Signature> {
       .chat-input-area__bottom-actions {
         display: flex;
         align-items: center;
-        padding: var(--boxel-sp-sm);
+        padding: var(--chat-input-area-bottom-padding);
         gap: var(--boxel-sp-sm);
         background-color: var(--boxel-light-100);
         border-top: 1px solid var(--boxel-200);
@@ -274,6 +276,10 @@ export default class Room extends Component<Signature> {
 
       .chat-input-area__bottom-actions:not(:has(.menu-content)) {
         height: 40px;
+      }
+
+      .chat-input-area__bottom-actions:has(.menu-content) {
+        padding: 0;
       }
 
       :deep(.ai-assistant-conversation > *:first-child) {

--- a/packages/host/app/components/pill-menu/index.gts
+++ b/packages/host/app/components/pill-menu/index.gts
@@ -92,6 +92,7 @@ export default class PillMenu extends Component<Signature> {
         --boxel-header-letter-spacing: var(--boxel-lsp);
         --button-outline: 2px;
         --boxel-header-min-height: fit-content;
+        --pill-menu-gradient-height: 5px;
 
         display: grid;
         grid-template-rows: auto 1fr auto;
@@ -175,7 +176,7 @@ export default class PillMenu extends Component<Signature> {
         content: '';
         display: block;
         width: 100%;
-        height: 5px;
+        height: var(--pill-menu-gradient-height);
         position: absolute;
         left: 0;
         opacity: 0;
@@ -224,7 +225,15 @@ export default class PillMenu extends Component<Signature> {
         animation: scroll-pill-menu-content reverse linear backwards;
         animation-timeline: --pill-menu-content-scroll-timeline;
 
-        bottom: 60px;
+        transform: translateY(
+          calc(
+            -1 *
+              (
+                var(--pill-menu-gradient-height) +
+                  var(--chat-input-area-bottom-padding)
+              )
+          )
+        );
       }
 
       .pill-menu :deep(.menu-header .detail) {

--- a/packages/host/app/components/pill-menu/index.gts
+++ b/packages/host/app/components/pill-menu/index.gts
@@ -129,10 +129,7 @@ export default class PillMenu extends Component<Signature> {
       }
       .menu-header {
         overflow: hidden;
-        padding: var(
-          --boxel-pill-menu-header-padding,
-          var(--pill-menu-spacing)
-        );
+        padding: var(--chat-input-area-bottom-padding);
       }
       .menu-header :deep(.title) {
         font: 600 var(--boxel-font);
@@ -161,14 +158,15 @@ export default class PillMenu extends Component<Signature> {
         text-transform: uppercase;
       }
       .menu-content {
-        padding: var(
-          --boxel-pill-menu-content-padding,
-          var(--pill-menu-spacing)
-        );
+        padding: 0 var(--chat-input-area-bottom-padding);
         display: grid;
         gap: var(--pill-menu-spacing);
         overflow-y: auto;
         min-height: 0;
+      }
+
+      .pill-menu:not(:has(.menu-footer)) .menu-content {
+        padding-bottom: var(--chat-input-area-bottom-padding);
       }
 
       .menu-content::before,
@@ -209,15 +207,11 @@ export default class PillMenu extends Component<Signature> {
         animation: scroll-pill-menu-content reverse linear backwards;
         animation-timeline: --pill-menu-content-scroll-timeline;
 
-        bottom: var(--boxel-sp-sm);
-        margin-bottom: 16px;
+        bottom: var(--chat-input-area-bottom-padding);
       }
 
       .menu-footer {
-        padding: var(
-          --boxel-pill-menu-footer-padding,
-          var(--pill-menu-spacing)
-        );
+        padding: var(--chat-input-area-bottom-padding);
       }
 
       .menu-footer::before {


### PR DESCRIPTION
This distributes the spacing differently so the gradients can be positioned with compositional variables instead of magic numbers (16px, 60px). The skills menu doesn’t yet have overflow but when I introduce it you can see the gradients are correct both with and without a footer:

<img width="708" alt="index json in Experiments Workspace 2025-07-09 15-41-46" src="https://github.com/user-attachments/assets/84288ef5-d6ba-4683-bb5f-b5a3e2692e81" />

<img width="708" alt="index json in Experiments Workspace 2025-07-09 15-42-12" src="https://github.com/user-attachments/assets/97b29e40-29c4-431f-9dac-1fdec3d3fea3" />

When the skills menu is updated to the new design the button will be smaller, a hackish approximation here required no adjustment to the gradient thanks to the removal of the magic numbers:

<img width="707" alt="index json in Experiments Workspace 2025-07-09 15-47-06" src="https://github.com/user-attachments/assets/f8490ecf-9b61-4c0a-8014-41ba3fbfb3ff" />
