### PR TITLE
Add "Send Error to AI" button to card error component in code submode

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
+++ b/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
@@ -53,8 +53,9 @@ import ToggleButton from '@cardstack/host/components/operator-mode/code-submode/
 import SyntaxErrorDisplay from '@cardstack/host/components/operator-mode/syntax-error-display';
 import consumeContext from '@cardstack/host/helpers/consume-context';
 
-import { type Ready } from '@cardstack/host/resources/file';
 import type { FileResource } from '@cardstack/host/resources/file';
+import { type Ready } from '@cardstack/host/resources/file';
+import { isReady } from '@cardstack/host/resources/file';
 import {
   type CardOrFieldDeclaration,
   type ModuleAnalysis,
@@ -155,12 +156,7 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
   }
 
   private get sourceFileForCard(): FileDef | undefined {
-    if (
-      !this.args.cardError ||
-      !this.args.currentOpenFile ||
-      !('url' in this.args.currentOpenFile) ||
-      !('content' in this.args.currentOpenFile)
-    ) {
+    if (!this.args.cardError || !isReady(this.args.currentOpenFile)) {
       return undefined;
     }
 
@@ -171,9 +167,15 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
       return undefined;
     }
 
+    let moduleURLWithExtension = new URL(
+      adoptsFrom.module.endsWith('.gts')
+        ? adoptsFrom.module
+        : `${adoptsFrom.module}.gts`,
+      this.args.currentOpenFile.url,
+    );
     return this.matrixService.fileAPI.createFileDef({
-      sourceUrl: new URL(adoptsFrom.module, this.args.currentOpenFile.url).href,
-      name: `${adoptsFrom.name}.gts`,
+      sourceUrl: moduleURLWithExtension.href,
+      name: moduleURLWithExtension.href.split('/').pop()!,
     });
   }
 

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -712,6 +712,20 @@ module('Acceptance | code submode tests', function (_hooks) {
               },
             },
           },
+          'BrokenCountry/broken-country.json': {
+            data: {
+              type: 'card',
+              attributes: {
+                name: 'Broken Country',
+              },
+              meta: {
+                adoptsFrom: {
+                  module: '../broken-country',
+                  name: 'Country',
+                },
+              },
+            },
+          },
           'hello.txt': txtSource,
           'z00.json': '{}',
           'z01.json': '{}',
@@ -943,6 +957,34 @@ module('Acceptance | code submode tests', function (_hooks) {
         },
       ]);
       assert.dom('[data-test-send-error-to-ai-assistant]').exists();
+    });
+
+    test('it shows card preview errors and fix it button in module inspector', async function (assert) {
+      await visitOperatorMode({
+        submode: 'code',
+        codePath: `${testRealmURL}BrokenCountry/broken-country.json`,
+      });
+
+      assert.dom('[data-test-error-display]').exists();
+      assert
+        .dom('[data-test-error-display] [data-test-error-message]')
+        .hasText('intentionalError is not defined');
+
+      assert.dom('[data-test-ai-assistant-panel]').doesNotExist();
+      await click('[data-test-send-error-to-ai-assistant]');
+      assert.dom('[data-test-ai-assistant-panel]').exists();
+      assertMessages(assert, [
+        {
+          from: 'testuser',
+          message: `In the attachment file, I encountered an error that needs fixing: Card Error intentionalError is not defined`,
+          files: [
+            {
+              name: 'broken-country.gts',
+              sourceUrl: `${testRealmURL}broken-country.gts`,
+            },
+          ],
+        },
+      ]);
     });
 
     test('empty state displays default realm info', async function (assert) {


### PR DESCRIPTION
Currently, the "Send to AI" button is only available in the playground panel and for syntax errors. In this PR, I added the button to card errors that appear when a user previews a card instance in code submode.


https://github.com/user-attachments/assets/84d547a1-bc56-4d64-80c3-bf5744e8c6b2


