### PR TITLE
Update add-to-neighbor-stack-button UI

### DIFF
--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -1,6 +1,5 @@
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { concat, fn } from '@ember/helper';
-import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { htmlSafe } from '@ember/template';
@@ -24,12 +23,7 @@ import {
   MenuItem,
   MenuDivider,
 } from '@cardstack/boxel-ui/helpers';
-import {
-  Download,
-  IconCode,
-  IconSearch,
-  type Icon,
-} from '@cardstack/boxel-ui/icons';
+import { IconCode, IconSearch, type Icon } from '@cardstack/boxel-ui/icons';
 
 import {
   chooseCard,
@@ -99,6 +93,7 @@ import type RealmServer from '../../services/realm-server';
 import type RecentCardsService from '../../services/recent-cards-service';
 import type StoreService from '../../services/store';
 
+import NeighborStackTriggerButton from './interact-submode/neighbor-stack-trigger';
 import type { Submode } from '../submode-switcher';
 
 const waiter = buildWaiter('operator-mode:interact-submode-waiter');
@@ -115,65 +110,6 @@ type SearchSheetTrigger = Values<typeof SearchSheetTriggers>;
 
 const cardSelections = new TrackedWeakMap<StackItem, TrackedSet<CardDef>>();
 const stackItemComponentAPI = new WeakMap<StackItem, StackItemComponentAPI>();
-
-interface NeighborStackTriggerButtonSignature {
-  Element: HTMLButtonElement;
-  Args: {
-    triggerSide: SearchSheetTrigger;
-    activeTrigger: SearchSheetTrigger | null;
-    onTrigger: (triggerSide: SearchSheetTrigger) => void;
-  };
-}
-
-class NeighborStackTriggerButton extends Component<NeighborStackTriggerButtonSignature> {
-  get triggerSideClass() {
-    switch (this.args.triggerSide) {
-      case SearchSheetTriggers.DropCardToLeftNeighborStackButton:
-        return 'add-card-to-neighbor-stack--left';
-      case SearchSheetTriggers.DropCardToRightNeighborStackButton:
-        return 'add-card-to-neighbor-stack--right';
-      default:
-        return undefined;
-    }
-  }
-
-  <template>
-    <button
-      class={{cn
-        'add-card-to-neighbor-stack'
-        this.triggerSideClass
-        add-card-to-neighbor-stack--active=(eq @activeTrigger @triggerSide)
-      }}
-      {{on 'click' (fn @onTrigger @triggerSide)}}
-      ...attributes
-    >
-      <Download width='19' height='19' />
-    </button>
-    <style scoped>
-      .add-card-to-neighbor-stack {
-        --icon-color: var(--boxel-highlight-hover);
-        width: var(--container-button-size);
-        height: var(--container-button-size);
-        padding: 0;
-        border-radius: 50%;
-        background-color: var(--boxel-700);
-        border: var(--boxel-border-flexible);
-        box-shadow: var(--boxel-deep-box-shadow);
-        z-index: var(--boxel-layer-floating-button);
-      }
-      .add-card-to-neighbor-stack:hover,
-      .add-card-to-neighbor-stack--active {
-        --icon-color: var(--boxel-highlight);
-      }
-      .add-card-to-neighbor-stack--left {
-        margin-left: var(--operator-mode-spacing);
-      }
-      .add-card-to-neighbor-stack--right {
-        margin-right: var(--operator-mode-spacing);
-      }
-    </style>
-  </template>
-}
 
 const CodeSubmodeNewFileOptions: TemplateOnlyComponent = <template>
   <ul class='code-mode-file-options'>
@@ -842,22 +778,24 @@ export default class InteractSubmode extends Component {
     >
       <div class='interact-submode' style={{this.backgroundImageStyle}}>
         {{#if this.canCreateNeighborStack}}
-          <Tooltip @placement='right'>
-            <:trigger>
-              <NeighborStackTriggerButton
-                data-test-add-card-left-stack
-                @triggerSide={{SearchSheetTriggers.DropCardToLeftNeighborStackButton}}
-                @activeTrigger={{this.searchSheetTrigger}}
-                @onTrigger={{fn
-                  this.showSearchWithTrigger
-                  search.openSearchToPrompt
-                }}
-              />
-            </:trigger>
-            <:content>
-              {{neighborStackTooltipMessage 'left'}}
-            </:content>
-          </Tooltip>
+          <div class='left-edge'>
+            <Tooltip @placement='right'>
+              <:trigger>
+                <NeighborStackTriggerButton
+                  data-test-add-card-left-stack
+                  @triggerSide={{SearchSheetTriggers.DropCardToLeftNeighborStackButton}}
+                  @activeTrigger={{this.searchSheetTrigger}}
+                  @onTrigger={{fn
+                    this.showSearchWithTrigger
+                    search.openSearchToPrompt
+                  }}
+                />
+              </:trigger>
+              <:content>
+                {{neighborStackTooltipMessage 'left'}}
+              </:content>
+            </Tooltip>
+          </div>
         {{/if}}
         <div class='stacks'>
           {{#each this.stacks as |stack stackIndex|}}
@@ -903,23 +841,25 @@ export default class InteractSubmode extends Component {
           />
         </div>
         {{#if this.canCreateNeighborStack}}
-          <Tooltip @placement='left'>
-            <:trigger>
-              <NeighborStackTriggerButton
-                class='neighbor-stack-trigger'
-                data-test-add-card-right-stack
-                @triggerSide={{SearchSheetTriggers.DropCardToRightNeighborStackButton}}
-                @activeTrigger={{this.searchSheetTrigger}}
-                @onTrigger={{fn
-                  this.showSearchWithTrigger
-                  search.openSearchToPrompt
-                }}
-              />
-            </:trigger>
-            <:content>
-              {{neighborStackTooltipMessage 'right'}}
-            </:content>
-          </Tooltip>
+          <div class='right-edge'>
+            <Tooltip @placement='left'>
+              <:trigger>
+                <NeighborStackTriggerButton
+                  class='neighbor-stack-trigger'
+                  data-test-add-card-right-stack
+                  @triggerSide={{SearchSheetTriggers.DropCardToRightNeighborStackButton}}
+                  @activeTrigger={{this.searchSheetTrigger}}
+                  @onTrigger={{fn
+                    this.showSearchWithTrigger
+                    search.openSearchToPrompt
+                  }}
+                />
+              </:trigger>
+              <:content>
+                {{neighborStackTooltipMessage 'right'}}
+              </:content>
+            </Tooltip>
+          </div>
         {{/if}}
         {{#if this.cardToDelete}}
           <DeleteModal

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -76,6 +76,7 @@ import consumeContext from '../../helpers/consume-context';
 
 import CopyButton from './copy-button';
 import DeleteModal from './delete-modal';
+import NeighborStackTriggerButton from './interact-submode/neighbor-stack-trigger';
 import OperatorModeStack from './stack';
 import { CardDefOrId } from './stack-item';
 import SubmodeLayout from './submode-layout';
@@ -93,7 +94,6 @@ import type RealmServer from '../../services/realm-server';
 import type RecentCardsService from '../../services/recent-cards-service';
 import type StoreService from '../../services/store';
 
-import NeighborStackTriggerButton from './interact-submode/neighbor-stack-trigger';
 import type { Submode } from '../submode-switcher';
 
 const waiter = buildWaiter('operator-mode:interact-submode-waiter');
@@ -778,24 +778,23 @@ export default class InteractSubmode extends Component {
     >
       <div class='interact-submode' style={{this.backgroundImageStyle}}>
         {{#if this.canCreateNeighborStack}}
-          <div class='left-edge'>
-            <Tooltip @placement='right'>
-              <:trigger>
-                <NeighborStackTriggerButton
-                  data-test-add-card-left-stack
-                  @triggerSide={{SearchSheetTriggers.DropCardToLeftNeighborStackButton}}
-                  @activeTrigger={{this.searchSheetTrigger}}
-                  @onTrigger={{fn
-                    this.showSearchWithTrigger
-                    search.openSearchToPrompt
-                  }}
-                />
-              </:trigger>
-              <:content>
-                {{neighborStackTooltipMessage 'left'}}
-              </:content>
-            </Tooltip>
-          </div>
+          <Tooltip @placement='right'>
+            <:trigger>
+              <NeighborStackTriggerButton
+                data-test-add-card-left-stack
+                @triggerSide={{SearchSheetTriggers.DropCardToLeftNeighborStackButton}}
+                @activeTrigger={{this.searchSheetTrigger}}
+                @onTrigger={{fn
+                  this.showSearchWithTrigger
+                  search.openSearchToPrompt
+                }}
+                aria-label='Add card to left stack'
+              />
+            </:trigger>
+            <:content>
+              {{neighborStackTooltipMessage 'left'}}
+            </:content>
+          </Tooltip>
         {{/if}}
         <div class='stacks'>
           {{#each this.stacks as |stack stackIndex|}}
@@ -841,25 +840,24 @@ export default class InteractSubmode extends Component {
           />
         </div>
         {{#if this.canCreateNeighborStack}}
-          <div class='right-edge'>
-            <Tooltip @placement='left'>
-              <:trigger>
-                <NeighborStackTriggerButton
-                  class='neighbor-stack-trigger'
-                  data-test-add-card-right-stack
-                  @triggerSide={{SearchSheetTriggers.DropCardToRightNeighborStackButton}}
-                  @activeTrigger={{this.searchSheetTrigger}}
-                  @onTrigger={{fn
-                    this.showSearchWithTrigger
-                    search.openSearchToPrompt
-                  }}
-                />
-              </:trigger>
-              <:content>
-                {{neighborStackTooltipMessage 'right'}}
-              </:content>
-            </Tooltip>
-          </div>
+          <Tooltip @placement='left'>
+            <:trigger>
+              <NeighborStackTriggerButton
+                class='neighbor-stack-trigger'
+                data-test-add-card-right-stack
+                @triggerSide={{SearchSheetTriggers.DropCardToRightNeighborStackButton}}
+                @activeTrigger={{this.searchSheetTrigger}}
+                @onTrigger={{fn
+                  this.showSearchWithTrigger
+                  search.openSearchToPrompt
+                }}
+                aria-label='Add card to right stack'
+              />
+            </:trigger>
+            <:content>
+              {{neighborStackTooltipMessage 'right'}}
+            </:content>
+          </Tooltip>
         {{/if}}
         {{#if this.cardToDelete}}
           <DeleteModal

--- a/packages/host/app/components/operator-mode/interact-submode/neighbor-stack-trigger.gts
+++ b/packages/host/app/components/operator-mode/interact-submode/neighbor-stack-trigger.gts
@@ -1,0 +1,73 @@
+import Component from '@glimmer/component';
+import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
+
+import { cn, eq } from '@cardstack/boxel-ui/helpers';
+import { Download } from '@cardstack/boxel-ui/icons';
+
+const SearchSheetTriggers = {
+  DropCardToLeftNeighborStackButton: 'drop-card-to-left-neighbor-stack-button',
+  DropCardToRightNeighborStackButton:
+    'drop-card-to-right-neighbor-stack-button',
+} as const;
+type Values<T> = T[keyof T];
+type SearchSheetTrigger = Values<typeof SearchSheetTriggers>;
+
+interface Signature {
+  Element: HTMLButtonElement;
+  Args: {
+    triggerSide: SearchSheetTrigger;
+    activeTrigger: SearchSheetTrigger | null;
+    onTrigger: (triggerSide: SearchSheetTrigger) => void;
+  };
+}
+
+export default class NeighborStackTriggerButton extends Component<Signature> {
+  get triggerSideClass() {
+    switch (this.args.triggerSide) {
+      case SearchSheetTriggers.DropCardToLeftNeighborStackButton:
+        return 'add-card-to-neighbor-stack--left';
+      case SearchSheetTriggers.DropCardToRightNeighborStackButton:
+        return 'add-card-to-neighbor-stack--right';
+      default:
+        return undefined;
+    }
+  }
+
+  <template>
+    <button
+      class={{cn
+        'add-card-to-neighbor-stack'
+        this.triggerSideClass
+        add-card-to-neighbor-stack--active=(eq @activeTrigger @triggerSide)
+      }}
+      {{on 'click' (fn @onTrigger @triggerSide)}}
+      ...attributes
+    >
+      <Download width='19' height='19' />
+    </button>
+    <style scoped>
+      .add-card-to-neighbor-stack {
+        --icon-color: var(--boxel-highlight-hover);
+        width: var(--container-button-size);
+        height: var(--container-button-size);
+        padding: 0;
+        border-radius: 50%;
+        background-color: var(--boxel-700);
+        border: var(--boxel-border-flexible);
+        box-shadow: var(--boxel-deep-box-shadow);
+        z-index: var(--boxel-layer-floating-button);
+      }
+      .add-card-to-neighbor-stack:hover,
+      .add-card-to-neighbor-stack--active {
+        --icon-color: var(--boxel-highlight);
+      }
+      .add-card-to-neighbor-stack--left {
+        margin-left: var(--operator-mode-spacing);
+      }
+      .add-card-to-neighbor-stack--right {
+        margin-right: var(--operator-mode-spacing);
+      }
+    </style>
+  </template>
+}

--- a/packages/host/app/components/operator-mode/interact-submode/neighbor-stack-trigger.gts
+++ b/packages/host/app/components/operator-mode/interact-submode/neighbor-stack-trigger.gts
@@ -1,9 +1,10 @@
-import Component from '@glimmer/component';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
+import Component from '@glimmer/component';
 
+import { Button } from '@cardstack/boxel-ui/components';
 import { cn, eq } from '@cardstack/boxel-ui/helpers';
-import { Download } from '@cardstack/boxel-ui/icons';
+import { IconPlus } from '@cardstack/boxel-ui/icons';
 
 const SearchSheetTriggers = {
   DropCardToLeftNeighborStackButton: 'drop-card-to-left-neighbor-stack-button',
@@ -35,7 +36,7 @@ export default class NeighborStackTriggerButton extends Component<Signature> {
   }
 
   <template>
-    <button
+    <Button
       class={{cn
         'add-card-to-neighbor-stack'
         this.triggerSideClass
@@ -44,29 +45,63 @@ export default class NeighborStackTriggerButton extends Component<Signature> {
       {{on 'click' (fn @onTrigger @triggerSide)}}
       ...attributes
     >
-      <Download width='19' height='19' />
-    </button>
+      <span class='icon-container'>
+        <IconPlus class='add-icon' width='12' height='12' />
+      </span>
+    </Button>
     <style scoped>
       .add-card-to-neighbor-stack {
-        --icon-color: var(--boxel-highlight-hover);
-        width: var(--container-button-size);
-        height: var(--container-button-size);
+        --boxel-transition: 100ms ease;
+        --boxel-button-min-width: auto;
+        --boxel-button-min-height: auto;
+        height: 35px;
+        width: 20px;
+        background: none;
+        border: none;
         padding: 0;
-        border-radius: 50%;
-        background-color: var(--boxel-700);
-        border: var(--boxel-border-flexible);
-        box-shadow: var(--boxel-deep-box-shadow);
         z-index: var(--boxel-layer-floating-button);
       }
+      .icon-container {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 8px;
+        height: 20px;
+        border-radius: inherit;
+        background-color: var(--boxel-highlight);
+        border: 2px solid rgba(0 0 0 / 50%);
+        box-shadow: var(--boxel-deep-box-shadow);
+        transition:
+          height var(--boxel-transition),
+          width var(--boxel-transition);
+      }
       .add-card-to-neighbor-stack:hover,
+      .add-card-to-neighbor-stack:focus:focus-visible,
       .add-card-to-neighbor-stack--active {
-        --icon-color: var(--boxel-highlight);
+        padding: 0;
+        height: 66px;
+        outline-offset: 2px;
+      }
+      .add-icon {
+        visibility: collapse;
+        transition: visibility var(--boxel-transition);
+      }
+      .add-card-to-neighbor-stack:hover .icon-container,
+      .add-card-to-neighbor-stack:focus:focus-visible .icon-container,
+      .add-card-to-neighbor-stack--active .icon-container {
+        width: 20px;
+        height: 66px;
+      }
+      .add-card-to-neighbor-stack:hover .add-icon,
+      .add-card-to-neighbor-stack:focus:focus-visible .add-icon,
+      .add-card-to-neighbor-stack--active .add-icon {
+        visibility: visible;
       }
       .add-card-to-neighbor-stack--left {
-        margin-left: var(--operator-mode-spacing);
+        margin-left: calc(var(--operator-mode-spacing) / 2);
       }
       .add-card-to-neighbor-stack--right {
-        margin-right: var(--operator-mode-spacing);
+        margin-right: calc(var(--operator-mode-spacing) / 2);
       }
     </style>
   </template>

--- a/packages/host/app/components/operator-mode/stack.gts
+++ b/packages/host/app/components/operator-mode/stack.gts
@@ -110,8 +110,9 @@ export default class OperatorModeStack extends Component<Signature> {
         width: 100%;
         background-position: center;
         background-size: cover;
-        padding: var(--stack-padding-top) var(--operator-mode-spacing)
-          var(--stack-padding-bottom);
+        padding-top: var(--stack-padding-top);
+        padding-inline: calc(var(--operator-mode-spacing) / 2);
+        padding-bottom: var(--stack-padding-bottom);
         position: relative;
         transition: padding-top var(--boxel-transition);
       }


### PR DESCRIPTION
Updated UI for buttons at the very right and left for adding new stack. Smaller buttons, grow larger on hover.

Before:
<img width="1200" height="807" alt="before" src="https://github.com/user-attachments/assets/ed35d912-98f8-44ca-b828-6855c19d1e91" />

After:
<img width="1200" height="805" alt="after" src="https://github.com/user-attachments/assets/dd51a547-c60d-4600-976c-b1decdf332fd" />

On hover:
<img width="389" height="393" alt="hover" src="https://github.com/user-attachments/assets/7221b05c-37fa-4631-ba30-7a6f76ef8b7d" />

