### PR TITLE
Ensure commands play well if invoked from dashboard

### DIFF
--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -68,6 +68,10 @@ export class FileUrlCard extends CardDef {
   @field fileUrl = contains(StringField);
 }
 
+export class RealmUrlCard extends CardDef {
+  @field realmUrl = contains(StringField);
+}
+
 export class ReadTextFileInput extends CardDef {
   @field realm = contains(StringField);
   @field path = contains(StringField);

--- a/packages/host/app/commands/index.ts
+++ b/packages/host/app/commands/index.ts
@@ -12,6 +12,7 @@ import * as ListingInstallCommandModule from './listing-install';
 import * as ListingRemixCommandModule from './listing-remix';
 import * as ListingUseCommandModule from './listing-use';
 import * as OpenAiAssistantRoomCommandModule from './open-ai-assistant-room';
+import * as OpenWorkspaceCommandModule from './open-workspace';
 import * as PatchCardInstanceCommandModule from './patch-card-instance';
 import * as PatchCodeCommandModule from './patch-code';
 import * as ReadCardForAiAssistantCommandModule from './read-card-for-ai-assistant';
@@ -101,6 +102,10 @@ export function shimHostCommands(virtualNetwork: VirtualNetwork) {
   virtualNetwork.shimModule(
     '@cardstack/boxel-host/commands/open-ai-assistant-room',
     OpenAiAssistantRoomCommandModule,
+  );
+  virtualNetwork.shimModule(
+    '@cardstack/boxel-host/commands/open-workspace',
+    OpenWorkspaceCommandModule,
   );
   virtualNetwork.shimModule(
     '@cardstack/boxel-host/commands/send-ai-assistant-message',

--- a/packages/host/app/commands/open-workspace.ts
+++ b/packages/host/app/commands/open-workspace.ts
@@ -1,0 +1,36 @@
+import { inject as service } from '@ember/service';
+
+import type * as BaseCommandModule from 'https://cardstack.com/base/command';
+
+import HostBaseCommand from '../lib/host-base-command';
+
+import type OperatorModeStateService from '../services/operator-mode-state-service';
+
+export default class OpenWorkspaceCommand extends HostBaseCommand<
+  typeof BaseCommandModule.RealmUrlCard
+> {
+  @service declare private operatorModeStateService: OperatorModeStateService;
+
+  static actionVerb = 'Open';
+
+  description = 'Open the main index card of a workspace.';
+
+  async getInputType() {
+    let commandModule = await this.loadCommandModule();
+    const { RealmUrlCard } = commandModule;
+    return RealmUrlCard;
+  }
+
+  protected async run(
+    input: BaseCommandModule.RealmUrlCard,
+  ): Promise<undefined> {
+    let { realmUrl } = input;
+    if (!realmUrl) {
+      throw new Error('Realm URL is required to open a workspace.');
+    }
+
+    await this.operatorModeStateService.openWorkspace(realmUrl);
+
+    return undefined;
+  }
+}

--- a/packages/host/app/commands/show-card.ts
+++ b/packages/host/app/commands/show-card.ts
@@ -35,6 +35,9 @@ export default class ShowCardCommand extends HostBaseCommand<
 
   protected async run(input: BaseCommandModule.CardIdCard): Promise<undefined> {
     let { operatorModeStateService, store } = this;
+    if (operatorModeStateService.workspaceChooserOpened) {
+      operatorModeStateService.closeWorkspaceChooser();
+    }
     if (operatorModeStateService.state?.submode === 'interact') {
       let newStackIndex = Math.min(
         operatorModeStateService.numberOfStacks(),

--- a/packages/host/app/commands/switch-submode.ts
+++ b/packages/host/app/commands/switch-submode.ts
@@ -64,5 +64,8 @@ export default class SwitchSubmodeCommand extends HostBaseCommand<
     }
 
     await this.operatorModeStateService.updateSubmode(input.submode);
+    if (this.operatorModeStateService.workspaceChooserOpened) {
+      this.operatorModeStateService.closeWorkspaceChooser();
+    }
   }
 }

--- a/packages/host/tests/integration/commands/open-workspace-test.gts
+++ b/packages/host/tests/integration/commands/open-workspace-test.gts
@@ -1,37 +1,16 @@
-import { getOwner } from '@ember/owner';
-import { RenderingTestContext } from '@ember/test-helpers';
-
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
-import { localId } from '@cardstack/runtime-common';
-
 import OpenWorkspaceCommand from '@cardstack/host/commands/open-workspace';
-import RealmService from '@cardstack/host/services/realm';
-import type StoreService from '@cardstack/host/services/store';
-
-import { CardDef as CardDefType } from 'https://cardstack.com/base/card-api';
 
 import {
   setupIntegrationTestRealm,
   setupLocalIndexing,
   testRealmURL,
-  testRealmInfo,
 } from '../../helpers';
-import { CardDef, setupBaseRealm } from '../../helpers/base-realm';
+import { setupBaseRealm } from '../../helpers/base-realm';
 import { setupMockMatrix } from '../../helpers/mock-matrix';
 import { setupRenderingTest } from '../../helpers/setup';
-
-let store: StoreService;
-
-class StubRealmService extends RealmService {
-  get defaultReadableRealm() {
-    return {
-      path: testRealmURL,
-      info: testRealmInfo,
-    };
-  }
-}
 
 module('Integration | commands | open-workspace', function (hooks) {
   setupRenderingTest(hooks);
@@ -42,11 +21,6 @@ module('Integration | commands | open-workspace', function (hooks) {
     loggedInAs: '@testuser:localhost',
     activeRealms: [testRealmURL],
     autostart: true,
-  });
-
-  hooks.beforeEach(function (this: RenderingTestContext) {
-    getOwner(this)!.register('service:realm', StubRealmService);
-    store = getService('store');
   });
 
   hooks.beforeEach(async function () {

--- a/packages/host/tests/integration/commands/open-workspace-test.gts
+++ b/packages/host/tests/integration/commands/open-workspace-test.gts
@@ -1,0 +1,86 @@
+import { getOwner } from '@ember/owner';
+import { RenderingTestContext } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import { localId } from '@cardstack/runtime-common';
+
+import OpenWorkspaceCommand from '@cardstack/host/commands/open-workspace';
+import RealmService from '@cardstack/host/services/realm';
+import type StoreService from '@cardstack/host/services/store';
+
+import { CardDef as CardDefType } from 'https://cardstack.com/base/card-api';
+
+import {
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  testRealmURL,
+  testRealmInfo,
+} from '../../helpers';
+import { CardDef, setupBaseRealm } from '../../helpers/base-realm';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupRenderingTest } from '../../helpers/setup';
+
+let store: StoreService;
+
+class StubRealmService extends RealmService {
+  get defaultReadableRealm() {
+    return {
+      path: testRealmURL,
+      info: testRealmInfo,
+    };
+  }
+}
+
+module('Integration | commands | open-workspace', function (hooks) {
+  setupRenderingTest(hooks);
+  setupBaseRealm(hooks);
+  setupLocalIndexing(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [testRealmURL],
+    autostart: true,
+  });
+
+  hooks.beforeEach(function (this: RenderingTestContext) {
+    getOwner(this)!.register('service:realm', StubRealmService);
+    store = getService('store');
+  });
+
+  hooks.beforeEach(async function () {
+    await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      contents: {},
+    });
+  });
+
+  test('opens specified workspace in interact submode', async function (assert) {
+    let commandService = getService('command-service');
+    let operatorModeStateService = getService('operator-mode-state-service');
+    operatorModeStateService.restore({
+      stacks: [],
+      submode: 'interact',
+      workspaceChooserOpened: true,
+    });
+    let openWorkspaceCommand = new OpenWorkspaceCommand(
+      commandService.commandContext,
+    );
+    assert.strictEqual(operatorModeStateService.state?.submode, 'interact');
+    await openWorkspaceCommand.execute({
+      realmUrl: testRealmURL,
+    });
+    assert.strictEqual(operatorModeStateService.state?.submode, 'interact');
+    assert.strictEqual(operatorModeStateService.state?.stacks.length, 1);
+    assert.strictEqual(operatorModeStateService.state?.stacks[0].length, 1);
+    assert.strictEqual(
+      operatorModeStateService.state?.stacks[0][0].id,
+      `${testRealmURL}index`,
+    );
+    assert.strictEqual(
+      operatorModeStateService.state?.stacks[0][0].format,
+      'isolated',
+    );
+  });
+});

--- a/packages/host/tests/integration/commands/show-card-test.gts
+++ b/packages/host/tests/integration/commands/show-card-test.gts
@@ -15,6 +15,7 @@ import { Loader } from '@cardstack/runtime-common/loader';
 import ShowCardCommand from '@cardstack/host/commands/show-card';
 import { StackItem } from '@cardstack/host/lib/stack-item';
 
+import type { OperatorModeState } from '@cardstack/host/services/operator-mode-state-service';
 import RealmService from '@cardstack/host/services/realm';
 
 import {
@@ -27,7 +28,6 @@ import {
 } from '../../helpers';
 import { setupMockMatrix } from '../../helpers/mock-matrix';
 import { setupRenderingTest } from '../../helpers/setup';
-import type { OperatorModeState } from '@cardstack/host/services/operator-mode-state-service';
 
 class StubRealmService extends RealmService {
   get defaultReadableRealm() {

--- a/packages/host/tests/integration/commands/show-card-test.gts
+++ b/packages/host/tests/integration/commands/show-card-test.gts
@@ -27,6 +27,7 @@ import {
 } from '../../helpers';
 import { setupMockMatrix } from '../../helpers/mock-matrix';
 import { setupRenderingTest } from '../../helpers/setup';
+import type { OperatorModeState } from '@cardstack/host/services/operator-mode-state-service';
 
 class StubRealmService extends RealmService {
   get defaultReadableRealm() {
@@ -38,7 +39,7 @@ class StubRealmService extends RealmService {
 }
 
 class MockOperatorModeStateService extends Service {
-  @tracked state = {
+  @tracked state: Partial<OperatorModeState> = {
     submode: 'interact' as 'interact' | 'code',
     codeSelection: undefined as string | undefined,
   };
@@ -78,6 +79,14 @@ class MockOperatorModeStateService extends Service {
     this.updatedCodePaths = [];
     this.state = { submode: 'interact', codeSelection: undefined };
     this.codePathString = undefined;
+  }
+
+  get workspaceChooserOpened() {
+    return this.state.workspaceChooserOpened ?? false;
+  }
+
+  closeWorkspaceChooser() {
+    this.state.workspaceChooserOpened = false;
   }
 }
 
@@ -301,6 +310,23 @@ module('Integration | Command | show-card', function (hooks) {
         mockOperatorModeStateService.addedStackItems[0].stackIndex,
         1,
         'Stack index is 1 when numberOfStacks returns 3 (minimum of 3 and 1)',
+      );
+    });
+
+    test('closes workspace chooser, if open', async function (assert) {
+      const cardId = `${testRealmURL}Person/alice`;
+      mockOperatorModeStateService.state = {
+        submode: 'interact',
+        codeSelection: undefined,
+        workspaceChooserOpened: true,
+      };
+
+      await command.execute({ cardId });
+
+      assert.strictEqual(
+        mockOperatorModeStateService.state.workspaceChooserOpened,
+        false,
+        'Workspace chooser is closed after showing card',
       );
     });
   });

--- a/packages/host/tests/integration/commands/switch-submode-test.gts
+++ b/packages/host/tests/integration/commands/switch-submode-test.gts
@@ -99,4 +99,28 @@ module('Integration | commands | switch-submode', function (hooks) {
       `${instance.id}.json`,
     );
   });
+
+  test('when workspace chooser is open, close it when switching', async function (assert) {
+    let instance = (await store.add(new CardDef())) as CardDefType;
+    let commandService = getService('command-service');
+    let operatorModeStateService = getService('operator-mode-state-service');
+    operatorModeStateService.restore({
+      stacks: [[{ id: instance[localId], format: 'isolated' }]],
+      submode: 'interact',
+      workspaceChooserOpened: true,
+    });
+    let switchSubmodeCommand = new SwitchSubmodeCommand(
+      commandService.commandContext,
+    );
+    assert.strictEqual(operatorModeStateService.state?.submode, 'interact');
+    assert.true(operatorModeStateService.workspaceChooserOpened);
+    await switchSubmodeCommand.execute({
+      submode: 'code',
+    });
+    assert.strictEqual(operatorModeStateService.state?.submode, 'code');
+    assert.false(
+      operatorModeStateService.workspaceChooserOpened,
+      'Workspace chooser should be closed after switching submode',
+    );
+  });
 });


### PR DESCRIPTION
This pull request introduces a new command, `OpenWorkspaceCommand`, to open a workspace in the application, along with related updates to the codebase and tests. It also adds functionality to close the workspace chooser under specific conditions, ensuring smoother transitions between actions.

### New Command Implementation:
* **`OpenWorkspaceCommand` class added**: Implements a command to open the main index card of a workspace, requiring a `realmUrl` input. Includes integration with the `operatorModeStateService` to handle workspace opening. (`packages/host/app/commands/open-workspace.ts`)

### Workspace Chooser Management:
* **Workspace chooser auto-close in `ShowCardCommand`**: Ensures the workspace chooser is closed before showing a card. (`packages/host/app/commands/show-card.ts`)
* **Workspace chooser auto-close in `SwitchSubmodeCommand`**: Closes the workspace chooser when switching submodes. (`packages/host/app/commands/switch-submode.ts`)