### PR TITLE
host: Update chat input design

### DIFF
--- a/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
@@ -131,7 +131,6 @@ export default class AttachedItems extends Component<Signature> {
     </div>
     <style scoped>
       .attached-items {
-        border-top: 1px solid var(--boxel-400);
         background-color: var(--boxel-light);
         color: var(--boxel-dark);
         display: flex;

--- a/packages/host/app/components/ai-assistant/chat-input/index.gts
+++ b/packages/host/app/components/ai-assistant/chat-input/index.gts
@@ -46,6 +46,7 @@ export default class AiAssistantChatInput extends Component<Signature> {
           {{on 'input' (pick 'target.value' @onInput)}}
           {{onKeyMod 'Shift+Enter' this.insertNewLine}}
           {{onKeyMod 'Enter' this.onSend}}
+          data-test-boxel-input-id='ai-chat-input'
           ...attributes
         />
         <div class='clone'>{{@value}}</div>

--- a/packages/host/app/components/ai-assistant/chat-input/index.gts
+++ b/packages/host/app/components/ai-assistant/chat-input/index.gts
@@ -42,11 +42,11 @@ export default class AiAssistantChatInput extends Component<Signature> {
         @id='ai-chat-input'
         @type='textarea'
         @value={{@value}}
-        @onInput={{@onInput}}
+        @onInput={{this.onInput}}
         @placeholder='Enter a prompt'
         {{onKeyMod 'Shift+Enter' this.insertNewLine}}
         {{onKeyMod 'Enter' this.onSend}}
-        {{setCssVar chat-input-height=this.height}}
+        {{setCssVar chat-input-heixxght=this.height}}
         ...attributes
       />
       <IconButton
@@ -91,10 +91,43 @@ export default class AiAssistantChatInput extends Component<Signature> {
             var(--border-bottom-color-no-overflow)
           );
       }
+
+      /* Autoexpanding textarea: https://chriscoyier.net/2023/09/29/css-solves-auto-expanding-textareas-probably-eventually/ */
+      .chat-input-container :deep(.input-container) {
+        display: grid;
+        grid-template-columns: unset;
+        grid-template-areas: unset;
+      }
+
+      .chat-input-container :deep(.input-container::after) {
+        content: attr(data-replicated-value) ' ';
+        white-space: pre-wrap;
+        visibility: hidden;
+
+        overflow-y: auto;
+
+        scroll-timeline: --chat-input-scroll-timeline block;
+
+        /* The pseudoelement is rendering 14px taller than the one it clones! */
+        max-height: 136px;
+      }
+
+      .chat-input,
+      .chat-input-container :deep(.input-container::after) {
+        padding: var(--boxel-sp-4xs);
+        padding-top: 10px;
+
+        font: var(--boxel-font-sm);
+        font-weight: 400;
+        letter-spacing: var(--boxel-lsp-xs);
+
+        grid-area: 1 / 1 / 2 / 2;
+      }
+
       .chat-input {
-        height: var(--chat-input-height);
-        min-height: var(--chat-input-height);
-        max-height: 300px;
+        max-height: 150px;
+
+        background: transparent;
         border: 0;
         border-radius: 0;
         font-weight: 400;
@@ -102,10 +135,7 @@ export default class AiAssistantChatInput extends Component<Signature> {
         padding-top: 10px;
         resize: none;
         outline: 0;
-        transition: height 0.2s ease-in-out;
         overflow-y: auto;
-
-        scroll-timeline: --chat-input-scroll-timeline block;
       }
 
       @keyframes detect-input-overflow {
@@ -143,6 +173,12 @@ export default class AiAssistantChatInput extends Component<Signature> {
       }
     </style>
   </template>
+
+  @action onInput(value: string) {
+    let inputContainer = document.querySelector('#ai-chat-input').parentNode;
+    inputContainer.dataset.replicatedValue = value;
+    this.args.onInput(value);
+  }
 
   @action onSend(ev: Event) {
     ev.preventDefault();

--- a/packages/host/app/components/ai-assistant/chat-input/index.gts
+++ b/packages/host/app/components/ai-assistant/chat-input/index.gts
@@ -69,7 +69,7 @@ export default class AiAssistantChatInput extends Component<Signature> {
         align-items: center;
         min-height: 54px;
         gap: var(--boxel-sp-xxs);
-        padding: var(--boxel-sp-xs) var(--boxel-sp-sm);
+        padding: 0 var(--boxel-sp-sm);
         background-color: var(--boxel-light);
         border-top-left-radius: var(--chat-input-area-border-radius);
         border-top-right-radius: var(--chat-input-area-border-radius);

--- a/packages/host/app/components/ai-assistant/chat-input/index.gts
+++ b/packages/host/app/components/ai-assistant/chat-input/index.gts
@@ -122,8 +122,6 @@ export default class AiAssistantChatInput extends Component<Signature> {
       }
 
       .chat-input {
-        max-height: 150px;
-
         background: transparent;
         border: 0;
         border-radius: 0;

--- a/packages/host/app/components/ai-assistant/chat-input/index.gts
+++ b/packages/host/app/components/ai-assistant/chat-input/index.gts
@@ -14,7 +14,7 @@ import AttachButton from '../attachment-picker/attach-button';
 import type { WithBoundArgs } from '@glint/template';
 
 interface Signature {
-  Element: HTMLDivElement;
+  Element: HTMLTextAreaElement;
   Args: {
     value: string;
     onInput: (val: string) => void;

--- a/packages/host/app/components/ai-assistant/chat-input/index.gts
+++ b/packages/host/app/components/ai-assistant/chat-input/index.gts
@@ -78,7 +78,8 @@ export default class AiAssistantChatInput extends Component<Signature> {
         height: var(--chat-input-height);
         min-height: var(--chat-input-height);
         max-height: 300px;
-        border-color: transparent;
+        border: 0;
+        border-radius: 0;
         font-weight: 400;
         padding: var(--boxel-sp-4xs);
         padding-top: 10px;

--- a/packages/host/app/components/ai-assistant/chat-input/index.gts
+++ b/packages/host/app/components/ai-assistant/chat-input/index.gts
@@ -79,7 +79,7 @@ export default class AiAssistantChatInput extends Component<Signature> {
           This adds a bottom border to this container when the input has overflowed.
         */
 
-        animation: detect-input-overflow linear;
+        animation: detect-input-overflow linear forwards;
         animation-timeline: --chat-input-scroll-timeline;
 
         --border-bottom-color-if-overflow: var(--has-overflow) var(--boxel-400);

--- a/packages/host/app/components/ai-assistant/chat-input/index.gts
+++ b/packages/host/app/components/ai-assistant/chat-input/index.gts
@@ -73,6 +73,23 @@ export default class AiAssistantChatInput extends Component<Signature> {
         background-color: var(--boxel-light);
         border-top-left-radius: var(--chat-input-area-border-radius);
         border-top-right-radius: var(--chat-input-area-border-radius);
+
+        /*
+          Detecting overflow with CSS: https://csscade.com/can-you-detect-overflow-with-css/
+          This adds a bottom border to this container when the input has overflowed.
+        */
+
+        animation: detect-input-overflow linear;
+        animation-timeline: --chat-input-scroll-timeline;
+
+        --border-bottom-color-if-overflow: var(--has-overflow) var(--boxel-400);
+        --border-bottom-color-no-overflow: transparent;
+
+        border-bottom: 1px solid
+          var(
+            --border-bottom-color-if-overflow,
+            var(--border-bottom-color-no-overflow)
+          );
       }
       .chat-input {
         height: var(--chat-input-height);
@@ -87,7 +104,17 @@ export default class AiAssistantChatInput extends Component<Signature> {
         outline: 0;
         transition: height 0.2s ease-in-out;
         overflow-y: auto;
+
+        scroll-timeline: --chat-input-scroll-timeline block;
       }
+
+      @keyframes detect-input-overflow {
+        from,
+        to {
+          --has-overflow: ;
+        }
+      }
+
       .chat-input::placeholder {
         color: var(--boxel-400);
       }

--- a/packages/host/app/components/ai-assistant/chat-input/index.gts
+++ b/packages/host/app/components/ai-assistant/chat-input/index.gts
@@ -79,7 +79,7 @@ export default class AiAssistantChatInput extends Component<Signature> {
         min-height: var(--chat-input-height);
         max-height: 300px;
         border-color: transparent;
-        font-weight: 500;
+        font-weight: 400;
         padding: var(--boxel-sp-4xs);
         padding-top: 10px;
         resize: none;

--- a/packages/host/app/components/ai-assistant/chat-input/index.gts
+++ b/packages/host/app/components/ai-assistant/chat-input/index.gts
@@ -179,17 +179,17 @@ export default class AiAssistantChatInput extends Component<Signature> {
   }
 
   get height() {
-    const lineHeight = 20;
+    const lineHeight = 18;
     const padding = 8;
     const minLines = 1;
-    const maxLines = 6;
+    const maxLines = 7;
 
     // Calculate actual line count from newlines in the content
     let newlineCount = (this.args.value.match(/\n/g) ?? []).length;
 
     // Also consider content length for lines that might wrap
     // This is a rough estimate that can be adjusted
-    const charsPerLine = 60;
+    const charsPerLine = 35;
     let charLineCount = Math.ceil(this.args.value.length / charsPerLine);
 
     // Use whichever count is higher (newlines or character-based estimate)

--- a/packages/host/app/components/ai-assistant/chat-input/index.gts
+++ b/packages/host/app/components/ai-assistant/chat-input/index.gts
@@ -5,7 +5,7 @@ import Component from '@glimmer/component';
 
 import onKeyMod from 'ember-keyboard/modifiers/on-key';
 
-import { BoxelInput, IconButton } from '@cardstack/boxel-ui/components';
+import { IconButton } from '@cardstack/boxel-ui/components';
 import { not, pick } from '@cardstack/boxel-ui/helpers';
 import { ArrowUp } from '@cardstack/boxel-ui/icons';
 

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -262,6 +262,8 @@ export default class Room extends Component<Signature> {
 
         position: relative;
         z-index: 2;
+
+        timeline-scope: --chat-input-scroll-timeline;
       }
       .chat-input-area__bottom-actions {
         display: flex;
@@ -269,7 +271,6 @@ export default class Room extends Component<Signature> {
         padding: var(--chat-input-area-bottom-padding);
         gap: var(--boxel-sp-sm);
         background-color: var(--boxel-light-100);
-        border-top: 1px solid var(--boxel-200);
         border-bottom-left-radius: var(--chat-input-area-border-radius);
         border-bottom-right-radius: var(--chat-input-area-border-radius);
       }


### PR DESCRIPTION
Designs:

<img width="1303" height="966" alt="LATEST UI Jun 17 - LATEST UI Jun 17 - Zeplin 2025-07-10 16-34-22" src="https://github.com/user-attachments/assets/490b572d-5e58-4bb0-ba44-199e97bb41cd" />

In order to meet the requirement of adding the divider when the input exceeds 150px, I removed the modifier that set element height by estimating how many lines the input value would render as, as it was not calculating reliably, causing the divider to appear and disappear as the height was set by the modifier:

![screencast 2025-07-11 11-56-29](https://github.com/user-attachments/assets/56578e05-e23c-46eb-9058-7f56eea1044f)

That technique looks similiar to [this](https://css-tricks.com/auto-growing-inputs-textareas/#aa-resizing-actual-input-elements).

Instead, the textarea is now contained within an element that also has a clone of the input value but in a `div`, which grows with the value automatically. Grid properties cause the two elements to render on top of each other, and `visibility: hidden` hides the clone element. It’s adapted from [this technique](https://css-tricks.com/the-cleanest-trick-for-autogrowing-textareas/), there’s no need to hook into `input` events to copy the value via `dataset` as Ember lets us just use the same `@value` for both elements.

See the divider appear and disappear here based on the textarea overflowing:

![screencast 2025-07-11 11-45-43](https://github.com/user-attachments/assets/f78f1bed-a10d-484c-b816-6374e144891e)