### PR TITLE
Add displayName with counter inside of cards grid LHS

### DIFF
--- a/packages/base/cards-grid.gts
+++ b/packages/base/cards-grid.gts
@@ -224,6 +224,7 @@ class Isolated extends Component<typeof CardsGrid> {
       id: string;
       attributes: {
         displayName: string;
+        uniqueDisplayName: string;
         total: number;
         iconHTML: string | null;
       };
@@ -241,7 +242,7 @@ class Isolated extends Component<typeof CardsGrid> {
       }
       const lastIndex = summary.id.lastIndexOf('/');
       this.cardTypeFilters.push({
-        displayName: summary.attributes.displayName,
+        displayName: summary.attributes.uniqueDisplayName,
         icon: summary.attributes.iconHTML ?? Captions,
         query: {
           filter: {

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -603,7 +603,9 @@ module('Integration | operator-mode', function (hooks) {
           'person-dup.gts': { PersonDup1, PersonDup2 },
           'PersonDup1/justin.json': {
             data: {
-              attributes: {},
+              attributes: {
+                title: 'Justin',
+              },
               meta: {
                 adoptsFrom: {
                   module: '../person-dup',
@@ -614,7 +616,9 @@ module('Integration | operator-mode', function (hooks) {
           },
           'PersonDup2/daren.json': {
             data: {
-              attributes: {},
+              attributes: {
+                title: 'Daren',
+              },
               meta: {
                 adoptsFrom: {
                   module: '../person-dup',
@@ -1097,16 +1101,26 @@ module('Integration | operator-mode', function (hooks) {
     assert.dom(`[data-test-filter-list-item="Person"]`).exists({ count: 1 });
     assert.dom(`[data-test-filter-list-item="Person 1"]`).exists({ count: 1 });
     assert.dom(`[data-test-filter-list-item="Person 2"]`).exists({ count: 1 });
-    await click(`[data-test-filter-list-item="Person"]`);
-    assert.dom(`[data-test-cards-grid-cards]`).exists({ count: 14 });
-    await click(`[data-test-filter-list-item="Person 1"]`);
+    await click(`[data-test-boxel-filter-list-button="Person"]`);
+    await waitFor(`[data-test-cards-grid-cards]`);
+    assert
+      .dom(`[data-test-cards-grid-cards] [data-test-cards-grid-item]`)
+      .exists({ count: 14 });
+    await click(`[data-test-boxel-filter-list-button="Person 1"]`);
+    await waitFor(`[data-test-cards-grid-cards]`);
     assert
       .dom(`[data-test-cards-grid-item="${testRealmURL}PersonDup1/justin"]`)
       .exists({ count: 1 });
-    await click(`[data-test-filter-list-item="Person 2"]`);
+    await click(`[data-test-boxel-filter-list-button="Person 2"]`);
+    await waitFor(`[data-test-cards-grid-cards]`);
     assert
       .dom(`[data-test-cards-grid-item="${testRealmURL}PersonDup2/daren"]`)
       .exists({ count: 1 });
+    await click(`[data-test-boxel-filter-list-button="Person 2"]`);
+    await waitFor(`[data-test-cards-grid-cards]`);
+    assert
+      .dom(`[data-test-cards-grid-cards] [data-test-cards-grid-item]`)
+      .exists({ count: 14 });
   });
 
   test<TestContextWithSave>('can optimistically create a card using the cards-grid', async function (assert) {
@@ -3264,7 +3278,7 @@ module('Integration | operator-mode', function (hooks) {
       .dom(`[data-test-cards-grid-item="${testRealmURL}CardDef/1"]`)
       .exists();
 
-    assert.dom(`[data-test-boxel-filter-list-button]`).exists({ count: 12 });
+    assert.dom(`[data-test-boxel-filter-list-button]`).exists({ count: 14 });
     assert.dom(`[data-test-boxel-filter-list-button="Skill"]`).doesNotExist();
 
     await click('[data-test-create-new-card-button]');
@@ -3278,7 +3292,7 @@ module('Integration | operator-mode', function (hooks) {
     await fillIn('[data-test-field="title"] input', 'New Skill');
     await click('[data-test-close-button]');
 
-    assert.dom(`[data-test-boxel-filter-list-button]`).exists({ count: 13 });
+    assert.dom(`[data-test-boxel-filter-list-button]`).exists({ count: 15 });
     assert.dom(`[data-test-boxel-filter-list-button="Skill"]`).exists();
 
     await click('[data-test-boxel-filter-list-button="Skill"]');
@@ -3288,7 +3302,7 @@ module('Integration | operator-mode', function (hooks) {
 
     await click('[data-test-confirm-delete-button]');
 
-    assert.dom(`[data-test-boxel-filter-list-button]`).exists({ count: 12 });
+    assert.dom(`[data-test-boxel-filter-list-button]`).exists({ count: 14 });
     assert.dom(`[data-test-boxel-filter-list-button="Skill"]`).doesNotExist();
     assert
       .dom(`[data-test-filter-list-item="All Cards"] > span`)

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -1117,10 +1117,6 @@ module('Integration | operator-mode', function (hooks) {
       .dom(`[data-test-cards-grid-item="${testRealmURL}PersonDup2/daren"]`)
       .exists({ count: 1 });
     await click(`[data-test-boxel-filter-list-button="Person 2"]`);
-    await waitFor(`[data-test-cards-grid-cards]`);
-    assert
-      .dom(`[data-test-cards-grid-cards] [data-test-cards-grid-item]`)
-      .exists({ count: 14 });
   });
 
   test<TestContextWithSave>('can optimistically create a card using the cards-grid', async function (assert) {

--- a/packages/realm-server/tests/types-endpoint-test.ts
+++ b/packages/realm-server/tests/types-endpoint-test.ts
@@ -137,6 +137,7 @@ module(basename(__filename), function () {
               displayName: 'Friend',
               total: 2,
               iconHTML,
+              uniqueDisplayName: 'Friend',
             },
           },
           {
@@ -146,6 +147,7 @@ module(basename(__filename), function () {
               displayName: 'FriendWithUsedLink',
               total: 2,
               iconHTML,
+              uniqueDisplayName: 'FriendWithUsedLink',
             },
           },
           {
@@ -155,6 +157,7 @@ module(basename(__filename), function () {
               displayName: 'Home',
               total: 1,
               iconHTML,
+              uniqueDisplayName: 'Home',
             },
           },
           {
@@ -164,6 +167,7 @@ module(basename(__filename), function () {
               displayName: 'Person',
               total: 3,
               iconHTML,
+              uniqueDisplayName: 'Person',
             },
           },
           {
@@ -173,6 +177,7 @@ module(basename(__filename), function () {
               displayName: 'TimersCard',
               total: 1,
               iconHTML,
+              uniqueDisplayName: 'TimersCard',
             },
           },
         ],

--- a/packages/runtime-common/card-document.ts
+++ b/packages/runtime-common/card-document.ts
@@ -378,6 +378,7 @@ export function makeCardTypeSummaryDoc(summaries: CardTypeSummary[]) {
       displayName: summary.display_name,
       total: summary.total,
       iconHTML: summary.icon_html,
+      uniqueDisplayName: summary.unique_display_name,
     },
   }));
 

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -625,6 +625,7 @@ export class IndexQueryEngine {
        FROM realm_meta rm
        WHERE`,
       ...every([['rm.realm_url =', param(realmURL.href)]]),
+      `ORDER BY indexed_at DESC`,
     ] as Expression)) as Pick<RealmMetaTable, 'value'>[];
 
     return (results[0]?.value ?? []) as unknown as CardTypeSummary[];

--- a/packages/runtime-common/index-structure.ts
+++ b/packages/runtime-common/index-structure.ts
@@ -42,6 +42,7 @@ export interface CardTypeSummary {
   display_name: string;
   total: number;
   icon_html: string;
+  unique_display_name: string;
 }
 
 export interface RealmMetaTable {

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -403,13 +403,13 @@ export class Batch {
               CASE 
                 WHEN ROW_NUMBER() OVER (
                   PARTITION BY i.display_names->>0 
-                  ORDER BY i.types->>0
+                  ORDER BY MIN(i.indexed_at)
                 ) = 1 
                 THEN i.display_names->>0
                 ELSE i.display_names->>0 || ' ' || (
                   ROW_NUMBER() OVER (
                     PARTITION BY i.display_names->>0 
-                    ORDER BY i.types->>0
+                    ORDER BY MIN(i.indexed_at)
                   ) - 1)
               END as unique_display_name
        FROM boxel_index_working as i

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -396,7 +396,15 @@ export class Batch {
 
   private async updateRealmMeta() {
     let results = await this.#query([
-      `SELECT CAST(count(i.url) AS INTEGER) as total, i.display_names->>0 as display_name, i.types->>0 as code_ref, MAX(i.icon_html) as icon_html
+      `SELECT CAST(count(i.url) AS INTEGER) as total, 
+              i.display_names->>0 as display_name, 
+              i.types->>0 as code_ref, 
+              MAX(i.icon_html) as icon_html,
+              CASE 
+                WHEN ROW_NUMBER() OVER (PARTITION BY i.display_names->>0 ORDER BY i.types->>0) = 1 
+                THEN i.display_names->>0
+                ELSE i.display_names->>0 || ' ' || (ROW_NUMBER() OVER (PARTITION BY i.display_names->>0 ORDER BY i.types->>0) - 1)
+              END as unique_display_name
        FROM boxel_index_working as i
           WHERE`,
       ...every([

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -401,9 +401,16 @@ export class Batch {
               i.types->>0 as code_ref, 
               MAX(i.icon_html) as icon_html,
               CASE 
-                WHEN ROW_NUMBER() OVER (PARTITION BY i.display_names->>0 ORDER BY i.types->>0) = 1 
+                WHEN ROW_NUMBER() OVER (
+                  PARTITION BY i.display_names->>0 
+                  ORDER BY i.types->>0
+                ) = 1 
                 THEN i.display_names->>0
-                ELSE i.display_names->>0 || ' ' || (ROW_NUMBER() OVER (PARTITION BY i.display_names->>0 ORDER BY i.types->>0) - 1)
+                ELSE i.display_names->>0 || ' ' || (
+                  ROW_NUMBER() OVER (
+                    PARTITION BY i.display_names->>0 
+                    ORDER BY i.types->>0
+                  ) - 1)
               END as unique_display_name
        FROM boxel_index_working as i
           WHERE`,

--- a/packages/runtime-common/tests/index-writer-test.ts
+++ b/packages/runtime-common/tests/index-writer-test.ts
@@ -1412,6 +1412,7 @@ const tests = Object.freeze({
         display_name: string;
         icon_html: string;
         total: number;
+        unique_display_name: string;
       },
     ];
     assert.strictEqual(
@@ -1427,12 +1428,14 @@ const tests = Object.freeze({
           code_ref: `${testRealmURL}fancy-person/FancyPerson`,
           display_name: 'Fancy Person',
           icon_html: iconHTML,
+          unique_display_name: 'Fancy Person',
         },
         {
           total: 1,
           code_ref: `${testRealmURL}person/Person`,
           display_name: 'Person',
           icon_html: iconHTML,
+          unique_display_name: 'Person',
         },
       ],
       'correct card type summary after indexing is done',
@@ -1521,6 +1524,7 @@ const tests = Object.freeze({
         display_name: string;
         total: number;
         icon_html: string;
+        unique_display_name: string;
       },
     ];
     assert.strictEqual(
@@ -1537,18 +1541,21 @@ const tests = Object.freeze({
           code_ref: `${testRealmURL}fancy-person/FancyPerson`,
           display_name: 'Fancy Person',
           icon_html: iconHTML,
+          unique_display_name: 'Fancy Person',
         },
         {
           total: 1,
           code_ref: `${testRealmURL}person/Person`,
           display_name: 'Person',
           icon_html: iconHTML,
+          unique_display_name: 'Person',
         },
         {
           total: 1,
           code_ref: `${testRealmURL}pet/Pet`,
           display_name: 'Pet',
           icon_html: iconHTML,
+          unique_display_name: 'Pet',
         },
       ],
       'correct card type summary after indexing is done',


### PR DESCRIPTION
**Old**
<img width="790" height="577" alt="Screenshot 2025-07-12 at 12 29 51" src="https://github.com/user-attachments/assets/f31636a4-514e-459b-99be-a6f617238139" />

**New**
<img width="518" height="306" alt="Screenshot 2025-07-12 at 12 25 03" src="https://github.com/user-attachments/assets/93b18864-973c-4e19-8e1d-981eb65b4b0d" />

**Change**
- we add a counter to duplicate display names
- the latest indexed will be the ones that have counters. this uses the earliest index time across code ref types to decide
- one thing it doesn't seem to cover is the icon to the left of the display name so counter will appear even tho its different icon
- this counter is not unique and persistent. So we dont expect if Author2 is seen to always exist if Author1's display name changes; Author2 will become Author 1

