### PR TITLE
Update playground incompatibility message

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode/playground/playground.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground.gts
@@ -21,7 +21,7 @@ class UnsupportedMessage extends Component<UnsupportedMessageSignature> {
     if (isPrimitive(this.args.cardOrField)) {
       return 'Playground is not currently supported for primitive fields.';
     }
-    return 'Playground is not currently supported for this file type.';
+    return 'Playground is not currently supported for this type.';
   }
 
   <template>

--- a/packages/host/tests/acceptance/code-patches-test.gts
+++ b/packages/host/tests/acceptance/code-patches-test.gts
@@ -423,6 +423,10 @@ ${REPLACE_MARKER}\n\`\`\``;
         submode: 'code',
         debug: false,
         openCardIds: [],
+        realmPermissions: {
+          canRead: true,
+          canWrite: true,
+        },
         realmUrl: 'http://test-realm/test/',
       },
       'patch code result event contains the context',


### PR DESCRIPTION
A minor update was made to the playground incompatibility message: "Playground is not currently supported for this file type," as the message was incorrect. File type incompatibilities are already handled by the module inspector component, so the issue in the playground was actually caused by an unsupported class type.