### PR TITLE
Add option to close the popover with most recent unseen AI assistant message

### DIFF
--- a/packages/host/app/components/ai-assistant/toast.gts
+++ b/packages/host/app/components/ai-assistant/toast.gts
@@ -9,8 +9,6 @@ import Component from '@glimmer/component';
 import { format as formatDate, formatISO, isAfter, subMinutes } from 'date-fns';
 import { cancelPoll, pollTask, runTask } from 'ember-lifeline';
 
-import { MatrixEvent } from 'matrix-js-sdk';
-
 import { TrackedObject } from 'tracked-built-ins';
 
 import { BoxelButton, IconButton } from '@cardstack/boxel-ui/components';
@@ -261,13 +259,12 @@ export default class AiAssistantToast extends Component<Signature> {
 
   private closeToast = () => {
     let message = this.unseenMessage;
-    // Real MatrixEvent is not available to us here, but we can masquerade as one
-    // by adding the necessary methods
+
     let matrixEvent = {
       getId: () => message.eventId,
       getRoomId: () => this.roomId,
       getTs: () => message.created.getTime(),
-    } as MatrixEvent;
+    };
     this.matrixService.sendReadReceipt(matrixEvent);
   };
 }

--- a/packages/host/app/components/ai-assistant/toast.gts
+++ b/packages/host/app/components/ai-assistant/toast.gts
@@ -9,6 +9,8 @@ import Component from '@glimmer/component';
 import { format as formatDate, formatISO, isAfter, subMinutes } from 'date-fns';
 import { cancelPoll, pollTask, runTask } from 'ember-lifeline';
 
+import { MatrixEvent } from 'matrix-js-sdk';
+
 import { TrackedObject } from 'tracked-built-ins';
 
 import { BoxelButton, IconButton } from '@cardstack/boxel-ui/components';
@@ -21,7 +23,6 @@ import LocalPersistenceService from '@cardstack/host/services/local-persistence-
 import MatrixService from '@cardstack/host/services/matrix-service';
 
 import assistantIcon from './ai-assist-icon.webp';
-import { MatrixEvent } from 'matrix-js-sdk';
 
 interface Signature {
   Element: HTMLDivElement;
@@ -47,8 +48,8 @@ export default class AiAssistantToast extends Component<Signature> {
 
         <IconButton
           @icon={{IconX}}
-          @width='12'
-          @height='12'
+          @width='10'
+          @height='10'
           {{on 'click' this.closeToast}}
           class='toast-close-button'
           aria-label='close toast'
@@ -117,9 +118,13 @@ export default class AiAssistantToast extends Component<Signature> {
         --icon-color: var(--boxel-450);
         border: none;
         background: none;
-        padding: 2px;
+        padding: 1px;
         border-radius: var(--boxel-border-radius-xs);
         transition: background-color 0.2s ease;
+        width: 16px;
+        height: 16px;
+        min-width: 16px;
+        min-height: 16px;
       }
       .toast-close-button:hover {
         --icon-color: var(--boxel-light);

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -1237,8 +1237,12 @@ export default class MatrixService extends Service {
     return await this.client.registerRequest(data, kind);
   }
 
-  async sendReadReceipt(matrixEvent: MatrixEvent) {
-    return await this.client.sendReadReceipt(matrixEvent);
+  // Type of matrixEvent is a partial MatrixEvent because a couple of places
+  // where this method is called don't have the full MatrixEvent type available
+  async sendReadReceipt(
+    matrixEvent: Pick<MatrixEvent, 'getId' | 'getRoomId' | 'getTs'>,
+  ) {
+    return await this.client.sendReadReceipt(matrixEvent as MatrixEvent);
   }
 
   async isUsernameAvailable(username: string) {

--- a/packages/host/tests/integration/components/ai-assistant-panel/general-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/general-test.gts
@@ -885,8 +885,14 @@ module('Integration | ai-assistant-panel | general', function (hooks) {
       },
     );
     await waitFor('[data-test-ai-assistant-toast]');
-    assert.dom('[data-test-ai-assistant-toast]').containsText('Toasty!');
+
+    assert.dom('[data-test-ai-assistant-toast]').exists();
+    await settled();
+    await waitFor('[data-test-close-toast]');
     await click('[data-test-close-toast]');
+    await waitUntil(
+      () => !document.querySelector('[data-test-ai-assistant-toast]'),
+    );
     assert.dom('[data-test-ai-assistant-toast]').doesNotExist();
   });
 

--- a/packages/host/tests/integration/components/ai-assistant-panel/general-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/general-test.gts
@@ -868,6 +868,26 @@ module('Integration | ai-assistant-panel | general', function (hooks) {
     assert
       .dom('[data-test-message-idx="1"] [data-test-ai-message-content]')
       .containsText('I sent a message from the background.');
+
+    // Send another message that will open a toast
+    await click('[data-test-close-ai-assistant]');
+    simulateRemoteMessage(
+      anotherRoomId,
+      '@aibot:localhost',
+      {
+        body: 'Toasty!',
+        msgtype: 'm.text',
+        format: 'org.matrix.custom.html',
+        isStreamingFinished: true,
+      },
+      {
+        origin_server_ts: fourteenMinutesAgo.getTime(),
+      },
+    );
+    await waitFor('[data-test-ai-assistant-toast]');
+    assert.dom('[data-test-ai-assistant-toast]').containsText('Toasty!');
+    await click('[data-test-close-toast]');
+    assert.dom('[data-test-ai-assistant-toast]').doesNotExist();
   });
 
   test('continuation events should be combined into one message that uses `created` from the oldest message', async function (assert) {


### PR DESCRIPTION
There is now a new button to close the toast:

<img width="595" height="338" alt="image" src="https://github.com/user-attachments/assets/3a4a1f7e-f40c-4a28-b946-e50e42432617" />
