### PR TITLE
Fix code mode realm switcher alignment

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode/left-panel-toggle.gts
+++ b/packages/host/app/components/operator-mode/code-submode/left-panel-toggle.gts
@@ -1,4 +1,4 @@
-import { concat, fn } from '@ember/helper';
+import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -6,15 +6,14 @@ import Component from '@glimmer/component';
 import FileCheck from '@cardstack/boxel-icons/file-check';
 import FolderTree from '@cardstack/boxel-icons/folder-tree';
 
-import { Label, RealmIcon } from '@cardstack/boxel-ui/components';
 import { cn, not } from '@cardstack/boxel-ui/helpers';
 
+import RealmDropdown from '@cardstack/host/components/realm-dropdown';
 import RestoreScrollPosition from '@cardstack/host/modifiers/restore-scroll-position';
 import type { FileView } from '@cardstack/host/services/operator-mode-state-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 import RealmService from '@cardstack/host/services/realm';
 import type RecentFilesService from '@cardstack/host/services/recent-files-service';
-import RealmDropdown from '@cardstack/host/components/realm-dropdown';
 
 import InnerContainer from './inner-container';
 import ToggleButton from './toggle-button';

--- a/packages/host/app/components/operator-mode/code-submode/left-panel-toggle.gts
+++ b/packages/host/app/components/operator-mode/code-submode/left-panel-toggle.gts
@@ -6,22 +6,15 @@ import Component from '@glimmer/component';
 import FileCheck from '@cardstack/boxel-icons/file-check';
 import FolderTree from '@cardstack/boxel-icons/folder-tree';
 
-import {
-  Label,
-  RealmIcon,
-  BoxelDropdown,
-  Menu as BoxelMenu,
-} from '@cardstack/boxel-ui/components';
-import { cn, not, MenuItem } from '@cardstack/boxel-ui/helpers';
+import { Label, RealmIcon } from '@cardstack/boxel-ui/components';
+import { cn, not } from '@cardstack/boxel-ui/helpers';
 
-import { DropdownArrowDown } from '@cardstack/boxel-ui/icons';
-
-import WithLoadedRealm from '@cardstack/host/components/with-loaded-realm';
 import RestoreScrollPosition from '@cardstack/host/modifiers/restore-scroll-position';
 import type { FileView } from '@cardstack/host/services/operator-mode-state-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 import RealmService from '@cardstack/host/services/realm';
 import type RecentFilesService from '@cardstack/host/services/recent-files-service';
+import RealmDropdown from '@cardstack/host/components/realm-dropdown';
 
 import InnerContainer from './inner-container';
 import ToggleButton from './toggle-button';
@@ -83,19 +76,6 @@ export default class CodeSubmodeLeftPanelToggle extends Component<Signature> {
     this.notifyFileBrowserIsVisible = setVisible;
   };
 
-  get allRealms() {
-    const options = Object.entries(this.realm.allRealmsInfo).map((realm) => {
-      const [realmUrl, realmInfo] = realm;
-      return new MenuItem(realmInfo.info.name, 'action', {
-        iconURL: realmInfo.info.iconURL ?? '/default-realm-icon.png',
-        action: () => this.switchRealm(realmUrl),
-        subtext: !realmInfo.canWrite ? 'READ ONLY' : undefined,
-        selected: realmUrl === this.args.realmURL.href,
-      });
-    });
-    return options;
-  }
-
   switchRealm(realmUrl: string) {
     if (realmUrl) {
       const recentFile =
@@ -111,6 +91,10 @@ export default class CodeSubmodeLeftPanelToggle extends Component<Signature> {
       );
     }
   }
+
+  handleRealmSelect = (realmItem: any) => {
+    this.switchRealm(realmItem.path);
+  };
 
   <template>
     <InnerContainer
@@ -142,42 +126,13 @@ export default class CodeSubmodeLeftPanelToggle extends Component<Signature> {
         </ToggleButton>
       </header>
       {{#if this.isFileTreeShowing}}
-        <WithLoadedRealm @realmURL={{@realmURL.href}} as |realm|>
-          <BoxelDropdown @matchTriggerWidth={{true}}>
-            <:trigger as |bindings|>
-              <button
-                data-test-file-tree-realm-dropdown-button
-                class='realm-info'
-                {{bindings}}
-              >
-                <RealmIcon @realmInfo={{realm.info}} />
-                {{#let (concat 'In ' realm.info.name) as |realmTitle|}}
-                  <Label
-                    @ellipsize={{true}}
-                    title={{realmTitle}}
-                    data-test-realm-name={{realm.info.name}}
-                  >
-                    {{realmTitle}}
-                  </Label>
-                {{/let}}
-                <div class='realm-info-right'>
-                  {{#if (not realm.canWrite)}}
-                    <span class='read-only' data-test-realm-read-only>READ ONLY</span>
-                  {{/if}}
-                  <DropdownArrowDown class='caret' width='12' height='12' />
-                </div>
-              </button>
-            </:trigger>
-            <:content as |dd|>
-              <BoxelMenu
-                class='realm-dropdown-menu'
-                @closeMenu={{dd.close}}
-                @items={{this.allRealms}}
-                data-test-file-tree-realm-dropdown
-              />
-            </:content>
-          </BoxelDropdown>
-        </WithLoadedRealm>
+        <RealmDropdown
+          @selectedRealmURL={{@realmURL}}
+          @onSelect={{this.handleRealmSelect}}
+          @selectedRealmPrefix='In'
+          @displayReadOnlyTag={{true}}
+          @contentClass='realm-dropdown-menu'
+        />
       {{/if}}
       <InnerContainerContent
         class='content'
@@ -212,44 +167,13 @@ export default class CodeSubmodeLeftPanelToggle extends Component<Signature> {
       .file-browser .content {
         background-color: var(--boxel-light);
       }
-      .realm-info {
-        border: 0;
-        width: 100%;
-        text-align: inherit;
-
+      :deep(.realm-dropdown-trigger) {
+        background-color: #e9e9ec;
+        border-radius: 0;
+        border: none;
+        border-bottom: 1px solid var(--boxel-400);
         padding: var(--boxel-sp-xs);
-        background-color: var(--boxel-light);
-        box-shadow: var(--boxel-box-shadow);
-        z-index: 1;
-
-        display: grid;
-        grid-template-columns: auto 1fr auto;
-        align-items: center;
-        gap: var(--boxel-sp-xxxs);
-      }
-      .realm-info .read-only {
-        color: #777;
-        font: var(--boxel-font-size-xs);
-        font-weight: 500;
-        overflow: hidden;
-        white-space: nowrap;
-      }
-      .realm-info-right {
-        display: flex;
-        align-items: center;
-        gap: var(--boxel-sp-xxxs);
-      }
-      .realm-dropdown-menu {
-        --boxel-menu-item-content-padding: var(--boxel-sp-xs);
-        --boxel-menu-item-gap: var(--boxel-sp-xs);
-        max-height: 13rem;
-        overflow-y: scroll;
-      }
-      .realm-dropdown-menu :deep(.menu-item .subtext) {
-        margin-left: auto;
-        font: var(--boxel-font-size-xs);
-        font-weight: 500;
-        color: var(--boxel-secondary-text-color, #777);
+        height: fit-content;
       }
     </style>
   </template>

--- a/packages/host/app/components/realm-dropdown.gts
+++ b/packages/host/app/components/realm-dropdown.gts
@@ -1,6 +1,8 @@
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
+import { trackedFunction } from 'reactiveweb/function';
+
 import {
   BoxelDropdown,
   Button,
@@ -138,9 +140,19 @@ export default class RealmDropdown extends Component<Signature> {
     return this.selectedRealm?.name;
   }
 
+  allRealmsInfo = trackedFunction(this, async () => {
+    if (this.args.selectedRealmURL) {
+      await this.realm.ensureRealmMeta(this.args.selectedRealmURL.href);
+    }
+    return this.realm.allRealmsInfo;
+  });
+
   get realms(): RealmDropdownItem[] {
+    if (!this.allRealmsInfo.value) {
+      return [];
+    }
     let items: RealmDropdownItem[] | [] = [];
-    for (let [url, realmMeta] of Object.entries(this.realm.allRealmsInfo)) {
+    for (let [url, realmMeta] of Object.entries(this.allRealmsInfo.value)) {
       // Skip read-only realms unless explicitly displaying read-only tags
       if (!realmMeta.canWrite && !this.args.displayReadOnlyTag) {
         continue;

--- a/packages/host/tests/acceptance/code-submode/file-tree-test.ts
+++ b/packages/host/tests/acceptance/code-submode/file-tree-test.ts
@@ -419,7 +419,7 @@ module('Acceptance | code submode | file-tree tests', function (hooks) {
     await click('[data-test-boxel-menu-item-text="Base Workspace"]');
 
     await waitFor('[data-test-realm-name="Base Workspace"]');
-    assert.dom('[data-test-realm-name]').hasText('In Base Workspace');
+    assert.dom('[data-test-realm-name]').hasText('In Base Workspace READ ONLY');
     assert.dom('[data-test-realm-read-only]').exists();
   });
 
@@ -503,7 +503,9 @@ module('Acceptance | code submode | file-tree tests', function (hooks) {
         '[data-test-realm-icon-url="https://boxel-images.boxel.ai/icons/cardstack.png"]',
       )
       .exists();
-    assert.dom('[data-test-realm-name]').hasText('In Test Workspace A');
+    assert
+      .dom('[data-test-realm-name]')
+      .hasText('In Test Workspace A READ ONLY');
 
     await waitFor('[data-test-file="mango.png"]');
     assert.dom('[data-test-file="mango.png"]').hasClass('selected');

--- a/packages/host/tests/acceptance/code-submode/file-tree-test.ts
+++ b/packages/host/tests/acceptance/code-submode/file-tree-test.ts
@@ -412,8 +412,8 @@ module('Acceptance | code submode | file-tree tests', function (hooks) {
     await waitFor('[data-test-realm-name="Test Workspace B"]');
     assert.dom('[data-test-realm-name]').hasText('In Test Workspace B');
 
-    await waitFor('[data-test-file-tree-realm-dropdown-button]');
-    await click('[data-test-file-tree-realm-dropdown-button]');
+    await waitFor('[data-test-realm-dropdown-trigger]');
+    await click('[data-test-realm-dropdown-trigger]');
 
     assert.dom('[data-test-boxel-menu-item-text="Base Workspace"]').exists();
     await click('[data-test-boxel-menu-item-text="Base Workspace"]');
@@ -453,8 +453,8 @@ module('Acceptance | code submode | file-tree tests', function (hooks) {
       'Enter',
     );
 
-    await waitFor('[data-test-file-tree-realm-dropdown-button]');
-    await click('[data-test-file-tree-realm-dropdown-button]');
+    await waitFor('[data-test-realm-dropdown-trigger]');
+    await click('[data-test-realm-dropdown-trigger]');
 
     assert.dom('[data-test-boxel-menu-item-text="Test Workspace B"]').exists();
     await click('[data-test-boxel-menu-item-text="Test Workspace B"]');

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -817,7 +817,7 @@ module('Acceptance | operator mode tests', function (hooks) {
     await click('[data-test-workspace="Cardstack Catalog"]');
     await click('[data-test-submode-switcher] button');
     await click('[data-test-boxel-menu-item-text="Code"]');
-    assert.dom(`[data-test-realm-name]`).hasText('In Cardstack Catalog');
+    assert.dom(`[data-test-realm-name]`).includesText('In Cardstack Catalog');
     assert.dom(`[data-test-file="index.json"]`).hasClass('selected');
     assert.dom('[data-test-recent-file]').exists({ count: 4 });
     assert


### PR DESCRIPTION
In this PR, I fixed the alignment issue in the file tree's realm switcher. I also reused the realm dropdown component as @burieberry  suggested.

Before:

<img width="287" height="358" alt="image" src="https://github.com/user-attachments/assets/3180e6c1-0d5a-4517-8054-5ae53f786fae" />



After:

https://github.com/user-attachments/assets/3b6a4e61-86c1-47d0-9b72-6e3fb06fa2ef