### PR TITLE
Adjust buried stack-item width ratio

### DIFF
--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -193,8 +193,12 @@ export default class OperatorModeStackItem extends Component<Signature> {
   }
 
   private get styleForStackedCard(): SafeString {
-    const stackItemMaxWidth = '50rem';
-    const widthReductionPercent = 5; // Every new card on the stack is 5% wider than the previous one
+    const stackItemMaxWidth = 50; // unit: rem, 800px for 16px base
+    const RATIO = 1.2;
+    //  top card: 800px / (1.2 ^ 0) = 800px;
+    //  buried card: 800px / (1.2 ^ 1) = ~666px;
+    //  next buried card: 800px / (1.2 ^ 2) = ~555px;
+    const maxWidthReductionPercent = 10; // Every new card on the stack is 10% wider than the previous one (for narrow viewport)
     const numberOfCards = this.args.stackItems.length;
     const invertedIndex = numberOfCards - this.args.index - 1;
     const isLastCard = this.args.index === numberOfCards - 1;
@@ -214,10 +218,10 @@ export default class OperatorModeStackItem extends Component<Signature> {
       }
     }
 
-    let maxWidthPercent = 100 - invertedIndex * widthReductionPercent;
+    let maxWidthPercent = 100 - invertedIndex * maxWidthReductionPercent;
     let width = this.isItemFullWidth
       ? '100%'
-      : `calc(${stackItemMaxWidth} * ${maxWidthPercent} / 100)`;
+      : `${stackItemMaxWidth / Math.pow(RATIO, invertedIndex)}rem`;
 
     let styles = `
       height: calc(100% - ${marginTopPx}px);


### PR DESCRIPTION
Slight adjustment to ratio using 1.2 modular scale for buried stack items to better match the designs. 

I used a scale for calculating the widths, but if we want exact pixel values as in the design, I can change to that.

Before:
<img width="1457" height="813" alt="before" src="https://github.com/user-attachments/assets/e941f56b-5ca3-4fac-9c79-0244fd60b471" />

After:
<img width="1456" height="813" alt="after" src="https://github.com/user-attachments/assets/38394e10-d531-4cea-8900-69e7a614985d" />

Designs:
<img width="894" height="299" alt="design-2" src="https://github.com/user-attachments/assets/7b870df5-6d9a-4798-81c5-7dfadf633c61" />
<img width="671" height="251" alt="design-1" src="https://github.com/user-attachments/assets/2aabefce-42f8-4aab-a5f2-500361c21d52" />


