### PR TITLE
Fix: error card instance is not auto-attached

### DIFF
--- a/packages/host/app/components/ai-assistant/attachment-picker/attach-button.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/attach-button.gts
@@ -11,7 +11,6 @@ import { eq } from '@cardstack/boxel-ui/helpers';
 
 import { chooseCard, baseCardRef, chooseFile } from '@cardstack/runtime-common';
 
-import { type CardDef } from 'https://cardstack.com/base/card-api';
 import { type FileDef } from 'https://cardstack.com/base/file-api';
 
 interface AttachButtonTriggerSignature {
@@ -54,8 +53,6 @@ const AttachButtonTrigger: TemplateOnlyComponent<AttachButtonTriggerSignature> =
 interface Signature {
   Element: HTMLDivElement;
   Args: {
-    files: FileDef[];
-    cards: CardDef[];
     chooseCard: (cardId: string) => void;
     chooseFile: (file: FileDef) => void;
   };

--- a/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
@@ -1,5 +1,6 @@
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
@@ -8,11 +9,18 @@ import { TrackedSet } from 'tracked-built-ins';
 import { Tooltip, Pill } from '@cardstack/boxel-ui/components';
 import { and, gt, not } from '@cardstack/boxel-ui/helpers';
 
-import { localId, isCardInstance } from '@cardstack/runtime-common';
+import {
+  localId,
+  isCardInstance,
+  CardErrorJSONAPI,
+  isCardErrorJSONAPI,
+} from '@cardstack/runtime-common';
 
 import CardPill from '@cardstack/host/components/card-pill';
 import FilePill from '@cardstack/host/components/file-pill';
 import { urlForRealmLookup } from '@cardstack/host/lib/utils';
+
+import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 import { type CardDef } from 'https://cardstack.com/base/card-api';
 import { type FileDef } from 'https://cardstack.com/base/file-api';
@@ -22,7 +30,7 @@ const MAX_ITEMS_TO_DISPLAY = 4;
 interface Signature {
   Element: HTMLDivElement;
   Args: {
-    items: (CardDef | FileDef)[];
+    items: (CardDef | FileDef | CardErrorJSONAPI)[];
     autoAttachedCardIds?: TrackedSet<string>;
     autoAttachedFile?: FileDef;
     removeCard: (cardId: string) => void;
@@ -35,6 +43,8 @@ interface Signature {
 export default class AttachedItems extends Component<Signature> {
   @tracked areAllItemsDisplayed = false;
 
+  @service private declare operatorModeStateService: OperatorModeStateService;
+
   get itemsToDisplay() {
     return this.areAllItemsDisplayed
       ? this.args.items
@@ -45,8 +55,8 @@ export default class AttachedItems extends Component<Signature> {
     return isCardInstance(item);
   };
 
-  private isAutoAttachedCard = (card: CardDef): boolean => {
-    return this.args.autoAttachedCardIds?.has(card.id) ?? false;
+  private isAutoAttachedCard = (cardId: string): boolean => {
+    return this.args.autoAttachedCardIds?.has(cardId) ?? false;
   };
 
   private isAutoAttachedFile = (file: FileDef): boolean => {
@@ -58,12 +68,50 @@ export default class AttachedItems extends Component<Signature> {
     this.areAllItemsDisplayed = !this.areAllItemsDisplayed;
   }
 
+  private getCardErrorId(cardError: CardErrorJSONAPI) {
+    return cardError.id ?? '';
+  }
+
+  private getCardErrorRealm(cardError: CardErrorJSONAPI) {
+    return cardError.realm ?? this.operatorModeStateService.realmURL.href;
+  }
+
   <template>
     <div class='attached-items'>
       {{#if @isLoaded}}
         {{#each this.itemsToDisplay as |item|}}
-          {{#if (this.isCard item)}}
-            {{#if (this.isAutoAttachedCard item)}}
+          {{#if (isCardErrorJSONAPI item)}}
+            {{#if (this.isAutoAttachedCard (this.getCardErrorId item))}}
+              <Tooltip @placement='top'>
+                <:trigger>
+                  <CardPill
+                    @cardId={{this.getCardErrorId item}}
+                    @isAutoAttachedCard={{true}}
+                    @removeCard={{@removeCard}}
+                    @urlForRealmLookup={{this.getCardErrorRealm item}}
+                  />
+                </:trigger>
+
+                <:content>
+                  {{#if @autoAttachedCardTooltipMessage}}
+                    {{@autoAttachedCardTooltipMessage}}
+                  {{else if
+                    (this.isAutoAttachedCard (this.getCardErrorId item))
+                  }}
+                    Topmost card is shared automatically
+                  {{/if}}
+                </:content>
+              </Tooltip>
+            {{else}}
+              <CardPill
+                @cardId={{this.getCardErrorId item}}
+                @isAutoAttachedCard={{true}}
+                @removeCard={{@removeCard}}
+                @urlForRealmLookup={{this.getCardErrorRealm item}}
+              />
+            {{/if}}
+          {{else if (this.isCard item)}}
+            {{#if (this.isAutoAttachedCard item.id)}}
               <Tooltip @placement='top'>
                 <:trigger>
                   <CardPill
@@ -77,7 +125,7 @@ export default class AttachedItems extends Component<Signature> {
                 <:content>
                   {{#if @autoAttachedCardTooltipMessage}}
                     {{@autoAttachedCardTooltipMessage}}
-                  {{else if (this.isAutoAttachedCard item)}}
+                  {{else if (this.isAutoAttachedCard item.id)}}
                     Topmost card is shared automatically
                   {{/if}}
                 </:content>

--- a/packages/host/app/components/ai-assistant/attachment-picker/index.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/index.gts
@@ -44,10 +44,7 @@ interface Signature {
         | 'autoAttachedCardTooltipMessage'
         | 'isLoaded'
       >,
-      WithBoundArgs<
-        typeof AttachButton,
-        'files' | 'cards' | 'chooseCard' | 'chooseFile'
-      >,
+      WithBoundArgs<typeof AttachButton, 'chooseCard' | 'chooseFile'>,
     ];
   };
 }
@@ -66,13 +63,7 @@ export default class AiAssistantAttachmentPicker extends Component<Signature> {
         removeFile=@removeFile
         autoAttachedCardTooltipMessage=@autoAttachedCardTooltipMessage
       )
-      (component
-        AttachButton
-        files=this.files
-        cards=this.cards
-        chooseCard=@chooseCard
-        chooseFile=@chooseFile
-      )
+      (component AttachButton chooseCard=@chooseCard chooseFile=@chooseFile)
     }}
   </template>
 
@@ -86,7 +77,7 @@ export default class AiAssistantAttachmentPicker extends Component<Signature> {
   };
 
   private get items() {
-    return [...this.cards, ...this.files];
+    return [...this.cards, ...this.cardErrors, ...this.files];
   }
 
   private get isLoaded() {
@@ -95,6 +86,10 @@ export default class AiAssistantAttachmentPicker extends Component<Signature> {
 
   private get cards() {
     return this.cardCollection?.cards ?? [];
+  }
+
+  private get cardErrors() {
+    return this.cardCollection?.cardErrors ?? [];
   }
 
   private get cardIds() {

--- a/packages/host/app/components/ai-assistant/chat-input/index.gts
+++ b/packages/host/app/components/ai-assistant/chat-input/index.gts
@@ -23,7 +23,7 @@ interface Signature {
     canSend: boolean;
     attachButton?: WithBoundArgs<
       typeof AttachButton,
-      'files' | 'cards' | 'chooseCard' | 'chooseFile'
+      'chooseCard' | 'chooseFile'
     >;
   };
 }

--- a/packages/host/app/components/card-pill.gts
+++ b/packages/host/app/components/card-pill.gts
@@ -64,42 +64,40 @@ export default class CardPill extends Component<CardPillSignature> {
 
   <template>
     {{consumeContext this.makeCardResource}}
-    {{#if this.cardTitle}}
-      {{#if this.isCreating}}
-        <LoadingIndicator />
-      {{else}}
-        <Pill
-          class={{cn
-            'card-pill'
-            is-autoattached=@isAutoAttachedCard
-            hide-icon-right=this.hideIconRight
-          }}
-          data-test-attached-card={{@cardId}}
-          data-test-autoattached-card={{@isAutoAttachedCard}}
-          ...attributes
-        >
-          <:iconLeft>
-            <RealmIcon @realmInfo={{this.realm.info @urlForRealmLookup}} />
-          </:iconLeft>
-          <:default>
-            <div class='card-content' title={{this.cardTitle}}>
-              {{this.cardTitle}}
-            </div>
-          </:default>
-          <:iconRight>
-            {{#if @removeCard}}
-              <IconButton
-                class='remove-button'
-                @icon={{IconX}}
-                @height='10'
-                @width='10'
-                {{on 'click' (fn @removeCard @cardId)}}
-                data-test-remove-card-btn
-              />
-            {{/if}}
-          </:iconRight>
-        </Pill>
-      {{/if}}
+    {{#if this.isCreating}}
+      <LoadingIndicator />
+    {{else}}
+      <Pill
+        class={{cn
+          'card-pill'
+          is-autoattached=@isAutoAttachedCard
+          hide-icon-right=this.hideIconRight
+        }}
+        data-test-attached-card={{@cardId}}
+        data-test-autoattached-card={{@isAutoAttachedCard}}
+        ...attributes
+      >
+        <:iconLeft>
+          <RealmIcon @realmInfo={{this.realm.info @urlForRealmLookup}} />
+        </:iconLeft>
+        <:default>
+          <div class='card-content' title={{this.cardTitle}}>
+            {{this.cardTitle}}
+          </div>
+        </:default>
+        <:iconRight>
+          {{#if @removeCard}}
+            <IconButton
+              class='remove-button'
+              @icon={{IconX}}
+              @height='10'
+              @width='10'
+              {{on 'click' (fn @removeCard @cardId)}}
+              data-test-remove-card-btn
+            />
+          {{/if}}
+        </:iconRight>
+      </Pill>
     {{/if}}
     <style scoped>
       .card-pill {

--- a/packages/host/app/components/card-pill.gts
+++ b/packages/host/app/components/card-pill.gts
@@ -46,17 +46,25 @@ export default class CardPill extends Component<CardPillSignature> {
     return !this.args.removeCard;
   }
 
+  private get cardTitle() {
+    return this.card?.title || this.cardError?.meta.cardTitle;
+  }
+
   private get card() {
     return this.cardResource?.card;
   }
 
+  private get cardError() {
+    return this.cardResource?.cardError;
+  }
+
   private get isCreating() {
-    return this.card && !this.card.id;
+    return this.card && !this.card.id && !this.cardError;
   }
 
   <template>
     {{consumeContext this.makeCardResource}}
-    {{#if this.card}}
+    {{#if this.cardTitle}}
       {{#if this.isCreating}}
         <LoadingIndicator />
       {{else}}
@@ -74,8 +82,8 @@ export default class CardPill extends Component<CardPillSignature> {
             <RealmIcon @realmInfo={{this.realm.info @urlForRealmLookup}} />
           </:iconLeft>
           <:default>
-            <div class='card-content' title={{this.card.title}}>
-              {{this.card.title}}
+            <div class='card-content' title={{this.cardTitle}}>
+              {{this.cardTitle}}
             </div>
           </:default>
           <:iconRight>

--- a/packages/runtime-common/error.ts
+++ b/packages/runtime-common/error.ts
@@ -244,7 +244,12 @@ export class CardError extends Error implements SerializedError {
 }
 
 export function isCardErrorJSONAPI(err: any): err is CardErrorJSONAPI {
-  return err != null && typeof err === 'object' && err.meta.lastKnownGoodHtml;
+  return (
+    err != null &&
+    typeof err === 'object' &&
+    err.meta &&
+    err.meta.lastKnownGoodHtml
+  );
 }
 
 export function isCardError(err: any): err is CardError {

--- a/packages/runtime-common/error.ts
+++ b/packages/runtime-common/error.ts
@@ -243,6 +243,10 @@ export class CardError extends Error implements SerializedError {
   }
 }
 
+export function isCardErrorJSONAPI(err: any): err is CardErrorJSONAPI {
+  return err != null && typeof err === 'object' && err.meta.lastKnownGoodHtml;
+}
+
 export function isCardError(err: any): err is CardError {
   return err != null && typeof err === 'object' && err.isCardError;
 }

--- a/packages/runtime-common/error.ts
+++ b/packages/runtime-common/error.ts
@@ -247,8 +247,9 @@ export function isCardErrorJSONAPI(err: any): err is CardErrorJSONAPI {
   return (
     err != null &&
     typeof err === 'object' &&
-    err.meta &&
-    err.meta.lastKnownGoodHtml
+    err.status &&
+    err.title &&
+    err.meta
   );
 }
 

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -38,6 +38,7 @@ export {
   formattedError,
   type CardErrorJSONAPI,
   type CardErrorsJSONAPI,
+  isCardErrorJSONAPI,
 } from './error';
 
 export interface ResourceObject {


### PR DESCRIPTION
This PR fixes a bug where a card instance with an error would not be displayed as auto-attached in the AI input panel.

Before:
<img width="1024" height="757" alt="Screenshot 2025-07-14 at 10 17 58" src="https://github.com/user-attachments/assets/3dad6dab-bd79-404e-82bf-1f41d01ea6f9" />

After:
<img width="1022" height="798" alt="Screenshot 2025-07-14 at 10 59 46" src="https://github.com/user-attachments/assets/856604d9-1043-4d36-b483-f3671f0dbcfa" />
