### PR TITLE
Hide actions button on carousel component when container height is below 140px

### DIFF
--- a/packages/catalog-realm/catalog-app/components/listing-fitted.gts
+++ b/packages/catalog-realm/catalog-app/components/listing-fitted.gts
@@ -361,7 +361,8 @@ class CarouselComponent extends GlimmerComponent<Signature> {
           }
         }
 
-        @container (max-height: 100px) {
+        @container (max-height: 140px) {
+          .actions-buttons-container,
           .carousel-nav,
           .carousel-dots {
             display: none;


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/ECO-250/on-hover-for-cardlisting-fitted-view-in-linkstomany-shows

Problem:
Preview/Details show up when hovering over Fitted View in LinksToMany CardListing

Before:
<img width="1022" height="360" alt="image" src="https://github.com/user-attachments/assets/aceb4771-7551-41cb-a753-ccdebc056f03" />

After:
<img width="1016" height="330" alt="image" src="https://github.com/user-attachments/assets/b35be451-3396-4af1-9faf-633d0dc9e4e2" />
