### PR TITLE
Eagerly log realm into matrix

### DIFF
--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -637,8 +637,8 @@ export class Realm {
   }
 
   async #startup() {
-    await Promise.resolve();
     let startTime = Date.now();
+    await this.logInToMatrix();
     let isNewIndex = await this.#realmIndexUpdater.isNewIndex();
     if (isNewIndex || this.#fullIndexOnStartup) {
       let promise = this.#realmIndexUpdater.fullIndex();


### PR DESCRIPTION
This PR is a reaction to the CI issues we've seen where the realm is trying to auth requests, but the realm is not actually logged into matrix yet. So we eagerly log the realm into matrix as part of realm startup instead of lazily logging into matrix.