### PR TITLE
host: Add loading state for account creation

### DIFF
--- a/packages/host/app/components/matrix/register-user.gts
+++ b/packages/host/app/components/matrix/register-user.gts
@@ -59,7 +59,7 @@ interface Signature {
 
 export default class RegisterUser extends Component<Signature> {
   <template>
-    {{#if (eq this.currentPage 'waiting-page')}}
+    {{#if (eq this.currentPage 'awaiting-validation')}}
       <span class='title' data-test-email-validation>Please check your email to
         complete registration.</span>
       <ul class='email-validation-instruction'>
@@ -398,7 +398,7 @@ export default class RegisterUser extends Component<Signature> {
     } else if (this.state.type === 'waitForAccountCreation') {
       return 'account-creation';
     } else {
-      return 'waiting-page';
+      return 'awaiting-validation';
     }
   }
 

--- a/packages/host/app/components/matrix/register-user.gts
+++ b/packages/host/app/components/matrix/register-user.gts
@@ -10,8 +10,6 @@ import Component from '@glimmer/component';
 
 import { tracked } from '@glimmer/tracking';
 
-import { LoadingIndicator } from '@cardstack/boxel-ui/components';
-
 import { restartableTask, timeout } from 'ember-concurrency';
 
 import {
@@ -20,6 +18,8 @@ import {
   type LoginResponse,
 } from 'matrix-js-sdk';
 import { v4 as uuidv4 } from 'uuid';
+
+import { LoadingIndicator } from '@cardstack/boxel-ui/components';
 
 import {
   BoxelInput,

--- a/packages/host/app/components/matrix/register-user.gts
+++ b/packages/host/app/components/matrix/register-user.gts
@@ -45,6 +45,7 @@ import { AuthMode } from './auth';
 const MATRIX_REGISTRATION_TYPES = {
   sendToken: 'm.login.registration_token',
   login: 'm.login.dummy',
+  waitForAccountCreation: undefined,
   waitForEmailValidation: 'm.login.email.identity',
   askForToken: undefined,
   register: undefined,


### PR DESCRIPTION
This state is entered before workspace creation so the user knows something is happening:

<img width="582" height="246" alt="Boxel 2025-07-14 10-34-52" src="https://github.com/user-attachments/assets/d6b5318d-298f-4a20-9ee3-f31a33de287d" />
