### PR TITLE
add spacing around neighbor-stack triggers

### DIFF
--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -905,10 +905,10 @@ export default class InteractSubmode extends Component {
         z-index: var(--boxel-layer-floating-button);
       }
       .stack-trigger-right {
-        right: 0;
+        right: 2px;
       }
       .stack-trigger-left {
-        left: 0;
+        left: 2px;
       }
     </style>
   </template>

--- a/packages/host/app/components/operator-mode/interact-submode/neighbor-stack-trigger.gts
+++ b/packages/host/app/components/operator-mode/interact-submode/neighbor-stack-trigger.gts
@@ -49,7 +49,7 @@ export default class NeighborStackTriggerButton extends Component<Signature> {
           }}
         >
           <span class='icon-container'>
-            <IconPlus class='add-icon' width='12' height='12' />
+            <IconPlus class='add-icon' width='10' height='10' />
           </span>
         </Button>
       </:trigger>
@@ -63,7 +63,7 @@ export default class NeighborStackTriggerButton extends Component<Signature> {
       .add-card-to-neighbor-stack {
         --minimized-width: 8px;
         --minimized-height: 20px;
-        --expanded-width: 20px;
+        --expanded-width: 16px;
         --expanded-height: 66px;
         --boxel-transition: 100ms ease;
         --boxel-button-min-width: var(--expanded-width);


### PR DESCRIPTION
Before:
<img width="63" height="178" alt="no-space" src="https://github.com/user-attachments/assets/22342fab-a0a8-4c97-a74a-132c844f2da5" />

After:
Add 2px spacing to the right and left of each stack trigger:
<img width="800" height="225" alt="stack-trigger-expanded" src="https://github.com/user-attachments/assets/c52de9ef-8d53-4a5c-9ce8-a160a82842be" />
