### PR TITLE
Fix search-sheet overflow

### DIFF
--- a/packages/host/app/components/ai-assistant/toast.gts
+++ b/packages/host/app/components/ai-assistant/toast.gts
@@ -51,6 +51,7 @@ export default class AiAssistantToast extends Component<Signature> {
           {{on 'click' this.closeToast}}
           class='toast-close-button'
           aria-label='close toast'
+          tabindex={{unless this.isVisible '-1'}}
           data-test-close-toast
         />
       </header>
@@ -62,6 +63,7 @@ export default class AiAssistantToast extends Component<Signature> {
         @size='extra-small'
         class='view-in-chat-button'
         {{on 'click' this.viewInChat}}
+        tabindex={{unless this.isVisible '-1'}}
         data-test-ai-assistant-toast-button
       >
         View in chat

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -141,6 +141,7 @@ export default class OperatorModeContainer extends Component<Signature> {
 
     <style scoped>
       :global(:root) {
+        --boxel-sp-xxl: 2.5rem; /* 40px */
         --boxel-sp-lg: 1.25rem; /* 20px */
         --boxel-sp-xs: 0.625rem; /* 10px */
         --operator-mode-bg-color: #686283;

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -530,6 +530,11 @@ export default class SubmodeLayout extends Component<Signature> {
         outline-width: 2px;
         outline-offset: 0px;
       }
+
+      :deep(.open-search-field) {
+        box-shadow: var(--submode-bar-item-box-shadow);
+        outline: var(--submode-bar-item-outline);
+      }
     </style>
   </template>
 }

--- a/packages/host/app/components/search-sheet/index.gts
+++ b/packages/host/app/components/search-sheet/index.gts
@@ -324,6 +324,17 @@ export default class SearchSheet extends Component<Signature> {
           height var(--boxel-transition),
           width var(--boxel-transition);
       }
+      .search-sheet:not(.closed) {
+        border-top-right-radius: var(--boxel-border-radius-xxl);
+        border-top-left-radius: var(--boxel-border-radius-xxl);
+        border-bottom-right-radius: 0;
+        border-bottom-left-radius: 0;
+        overflow: hidden;
+      }
+      .search-sheet:not(.closed):deep(.input-container),
+      .search-sheet:not(.closed):deep(.search-sheet__search-input-group) {
+        border-radius: inherit;
+      }
 
       .search-sheet__search-input-group {
         transition:
@@ -334,11 +345,6 @@ export default class SearchSheet extends Component<Signature> {
       .closed {
         height: var(--search-sheet-closed-height);
         width: var(--search-sheet-closed-width);
-      }
-
-      .closed .search-sheet__search-input-group {
-        outline: var(--boxel-border-flexible);
-        border-radius: var(--boxel-border-radius-xxl);
       }
 
       .search-sheet.closed .search-sheet-content {
@@ -408,13 +414,15 @@ export default class SearchSheet extends Component<Signature> {
         overflow-x: auto;
       }
       .open-search-field {
-        padding: 10px;
-        border-radius: 20px;
-        box-shadow: 0 5px 15px 0 rgba(0, 0, 0, 0.75);
-        border: solid 1px rgba(255, 255, 255, 0.35);
+        padding: var(--boxel-sp-xs);
+        border-radius: 50%;
         background-color: var(--boxel-700);
 
-        --icon-color: var(--boxel-teal);
+        --icon-color: var(--boxel-highlight);
+      }
+      .open-search-field:focus:focus-visible {
+        outline-offset: 0;
+        outline-width: 2px;
       }
     </style>
   </template>


### PR DESCRIPTION
Fixed overflow in the top corners. This also seems to have fixed the janky opening animation.

Bonus unrelated change: do not allow tabbing over on ai-assistant toast buttons unless the toast is open

Before:
<img width="400" height="337" alt="search-before" src="https://github.com/user-attachments/assets/f813c47c-9917-437d-b23b-d00ea39279fc" />

After:
<img width="400" height="337" alt="after" src="https://github.com/user-attachments/assets/12decd56-43a5-4795-9209-ae97b78f461e" />
