### PR TITLE
Make computed linksTo/linksToMany uneditable in edit format

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -1223,15 +1223,20 @@ class LinksTo<CardT extends CardDefConstructor> implements Field<CardT> {
     ) {
       return (format ?? defaultFormat) === 'edit' && !isComputed;
     }
-    function getChildFormat(format: Format | undefined, model: Box<FieldDef>) {
+    function getChildFormat(
+      format: Format | undefined,
+      defaultFormat: Format,
+      model: Box<FieldDef>,
+    ) {
+      let effectiveFormat = format ?? defaultFormat;
       if (
-        format === 'edit' &&
+        effectiveFormat === 'edit' &&
         'isCardDef' in model.value.constructor &&
         model.value.constructor.isCardDef
       ) {
         return 'fitted';
       }
-      return format;
+      return effectiveFormat;
     }
     return class LinksToComponent extends GlimmerComponent<{
       Element: HTMLElement;
@@ -1256,7 +1261,7 @@ class LinksTo<CardT extends CardDefConstructor> implements Field<CardT> {
           {{else}}
             {{#let (fieldComponent linksToField model) as |FieldComponent|}}
               <FieldComponent
-                @format={{getChildFormat @format model}}
+                @format={{getChildFormat @format defaultFormats.cardDef model}}
                 @displayContainer={{@displayContainer}}
                 ...attributes
               />

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -1223,6 +1223,16 @@ class LinksTo<CardT extends CardDefConstructor> implements Field<CardT> {
     ) {
       return (format ?? defaultFormat) === 'edit' && !isComputed;
     }
+    function getChildFormat(format: Format | undefined, model: Box<FieldDef>) {
+      if (
+        format === 'edit' &&
+        'isCardDef' in model.value.constructor &&
+        model.value.constructor.isCardDef
+      ) {
+        return 'fitted';
+      }
+      return format;
+    }
     return class LinksToComponent extends GlimmerComponent<{
       Element: HTMLElement;
       Args: {
@@ -1246,7 +1256,7 @@ class LinksTo<CardT extends CardDefConstructor> implements Field<CardT> {
           {{else}}
             {{#let (fieldComponent linksToField model) as |FieldComponent|}}
               <FieldComponent
-                @format={{@format}}
+                @format={{getChildFormat @format model}}
                 @displayContainer={{@displayContainer}}
                 ...attributes
               />

--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -389,6 +389,17 @@ function getEditorChildFormat(
   return 'fitted';
 }
 
+function getPluralChildFormat(effectiveFormat: Format, model: Box<FieldDef>) {
+  if (
+    effectiveFormat === 'edit' &&
+    'isCardDef' in model.value.constructor &&
+    model.value.constructor.isCardDef
+  ) {
+    return 'fitted';
+  }
+  return effectiveFormat;
+}
+
 function coalesce<T>(arg1: T | undefined, arg2: T): T {
   return arg1 ?? arg2;
 }
@@ -464,7 +475,7 @@ export function getLinksToManyComponent({
             >
               {{#each (getComponents) as |Item i|}}
                 <Item
-                  @format={{effectiveFormat}}
+                  @format={{getPluralChildFormat effectiveFormat model}}
                   @displayContainer={{@displayContainer}}
                   class='linksToMany-item'
                   data-test-plural-view-item={{i}}

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -142,6 +142,127 @@ module('Integration | card-basics', function (hooks) {
         .dom('[data-test-field="textArea"] textarea')
         .hasAttribute('disabled');
     });
+
+    test('linksToMany field with computeVia is not editable in edit format', async function (assert) {
+      class Pet extends CardDef {
+        @field name = contains(StringField);
+      }
+
+      class Friend extends CardDef {
+        @field firstName = contains(StringField);
+        @field pets = linksToMany(Pet);
+      }
+
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field friend = linksTo(Friend);
+        @field friendPetNames = containsMany(StringField);
+        @field friendPets = linksToMany(Pet, {
+          computeVia: function (this: Person) {
+            return this.friend?.pets;
+          },
+        });
+      }
+
+      loader.shimModule(`${testRealmURL}test-cards`, { Person, Friend, Pet });
+
+      let pet1 = new Pet({ name: 'Mango' });
+      let pet2 = new Pet({ name: 'Van Gogh' });
+      let friend = new Friend({
+        firstName: 'Hassan',
+        pets: [pet1, pet2],
+      });
+      let person = new Person({
+        firstName: 'Arthur',
+        friend: friend,
+      });
+
+      await saveCard(pet1, `${testRealmURL}Pet/pet1`, loader);
+      await saveCard(pet2, `${testRealmURL}Pet/pet2`, loader);
+      await saveCard(friend, `${testRealmURL}Friend/friend1`, loader);
+
+      await renderCard(loader, person, 'edit');
+
+      // The friendPets field should be read-only (not editable) because it has computeVia
+      assert
+        .dom('[data-test-field="friendPets"] [data-test-add-new]')
+        .doesNotExist('computed linksToMany field should not have add button');
+      assert
+        .dom('[data-test-field="friendPets"] [data-test-remove]')
+        .doesNotExist(
+          'computed linksToMany field should not have remove buttons',
+        );
+      assert
+        .dom(
+          '[data-test-plural-view-field="friendPets"] [data-test-plural-view-item]',
+        )
+        .exists({ count: 2 }, 'computed linksToMany child fields are rendered');
+      assert
+        .dom(
+          '[data-test-plural-view-field="friendPets"] [data-test-plural-view-item="0"][data-test-card-format="fitted"]',
+        )
+        .exists(
+          'computed linksToMany child fields are rendered in fitted format',
+        );
+      assert
+        .dom(
+          '[data-test-plural-view-field="friendPets"] [data-test-plural-view-item="1"][data-test-card-format="fitted"]',
+        )
+        .exists(
+          'computed linksToMany child fields are rendered in fitted format',
+        );
+    });
+
+    test('linksTo field with computeVia is not editable in edit format', async function (assert) {
+      class Pet extends CardDef {
+        @field name = contains(StringField);
+      }
+
+      class Friend extends CardDef {
+        @field firstName = contains(StringField);
+        @field favoritePet = linksTo(Pet);
+      }
+
+      class Person extends CardDef {
+        @field firstName = contains(StringField);
+        @field friend = linksTo(Friend);
+        @field friendFavoritePet = linksTo(Pet, {
+          computeVia: function (this: Person) {
+            return this.friend?.favoritePet;
+          },
+        });
+      }
+
+      loader.shimModule(`${testRealmURL}test-cards`, { Person, Friend, Pet });
+
+      let pet1 = new Pet({ name: 'Mango' });
+      let friend = new Friend({
+        firstName: 'Hassan',
+        favoritePet: pet1,
+      });
+      let person = new Person({
+        firstName: 'Arthur',
+        friend: friend,
+      });
+
+      await saveCard(pet1, `${testRealmURL}Pet/pet1`, loader);
+      await saveCard(friend, `${testRealmURL}Friend/friend1`, loader);
+
+      await renderCard(loader, person, 'edit');
+
+      // The friendFavoritePet field should be read-only (not editable) because it has computeVia
+      assert
+        .dom('[data-test-field="friendFavoritePet"] [data-test-add-new]')
+        .doesNotExist('computed linksTo field should not have add button');
+      assert
+        .dom('[data-test-field="friendFavoritePet"] [data-test-remove]')
+        .doesNotExist('computed linksTo field should not have remove button');
+      assert
+        .dom(
+          '[data-test-field="friendFavoritePet"] [data-test-card-format="fitted"]',
+        )
+        .exists('computed linksTo field is rendered in fitted format');
+    });
   });
 
   module('cards allowed to be edited', function (hooks) {
@@ -3472,76 +3593,6 @@ module('Integration | card-basics', function (hooks) {
           '[data-test-field="isPresent"] [data-test-boxel-radio-option-id="true"] input',
         )
         .isNotChecked();
-    });
-
-    test('linksToMany field with computeVia is not editable in edit format', async function (assert) {
-      class Pet extends CardDef {
-        @field name = contains(StringField);
-      }
-
-      class Friend extends CardDef {
-        @field firstName = contains(StringField);
-        @field pets = linksToMany(Pet);
-      }
-
-      class Person extends CardDef {
-        @field firstName = contains(StringField);
-        @field friend = linksTo(Friend);
-        @field friendPetNames = containsMany(StringField);
-        @field friendPets = linksToMany(Pet, {
-          computeVia: function (this: Person) {
-            return this.friend?.pets;
-          },
-        });
-      }
-
-      loader.shimModule(`${testRealmURL}test-cards`, { Person, Friend, Pet });
-
-      let pet1 = new Pet({ name: 'Mango' });
-      let pet2 = new Pet({ name: 'Van Gogh' });
-      let friend = new Friend({
-        firstName: 'Hassan',
-        pets: [pet1, pet2],
-      });
-      let person = new Person({
-        firstName: 'Arthur',
-        friend: friend,
-      });
-
-      await saveCard(pet1, `${testRealmURL}Pet/pet1`, loader);
-      await saveCard(pet2, `${testRealmURL}Pet/pet2`, loader);
-      await saveCard(friend, `${testRealmURL}Friend/friend1`, loader);
-
-      await renderCard(loader, person, 'edit');
-
-      // The friendPets field should be read-only (not editable) because it has computeVia
-      assert
-        .dom('[data-test-field="friendPets"] [data-test-add-new]')
-        .doesNotExist('computed linksToMany field should not have add button');
-      assert
-        .dom('[data-test-field="friendPets"] [data-test-remove]')
-        .doesNotExist(
-          'computed linksToMany field should not have remove buttons',
-        );
-      assert
-        .dom(
-          '[data-test-plural-view-field="friendPets"] [data-test-plural-view-item]',
-        )
-        .exists({ count: 2 }, 'computed linksToMany child fields are rendered');
-      assert
-        .dom(
-          '[data-test-plural-view-field="friendPets"] [data-test-plural-view-item="0"][data-test-card-format="fitted"]',
-        )
-        .exists(
-          'computed linksToMany child fields are rendered in fitted format',
-        );
-      assert
-        .dom(
-          '[data-test-plural-view-field="friendPets"] [data-test-plural-view-item="1"][data-test-card-format="fitted"]',
-        )
-        .exists(
-          'computed linksToMany child fields are rendered in fitted format',
-        );
     });
   });
 });


### PR DESCRIPTION
This PR ensures that the linksTo/linksToMany field uses the 'fitted' format, even when the card is in the 'edit' format, if the field is a computed field.