### PR TITLE
Cs 9097 fix catalog test error

### DIFF
--- a/packages/host/tests/acceptance/catalog-app-test.gts
+++ b/packages/host/tests/acceptance/catalog-app-test.gts
@@ -744,7 +744,7 @@ module('Acceptance | Catalog | catalog app tests', function (hooks) {
         await click('[data-test-boxel-filter-list-button="LIFE"]');
         assert
           .dom('[data-test-cards-grid-cards] [data-test-cards-grid-item]')
-          .exists({ count: 4 });
+          .exists({ count: 5 });
       });
 
       test('updates the card count correctly when filtering by a category', async function (assert) {


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-9097/fix-catalog-test-error

fix acceptance error: Acceptance | Catalog | catalog app tests > catalog > filters: updates the card count correctly when filtering by a sphere group