### PR TITLE
Ai panel: fix out of place spinner

### DIFF
--- a/packages/host/app/components/ai-assistant/panel.gts
+++ b/packages/host/app/components/ai-assistant/panel.gts
@@ -351,7 +351,10 @@ export default class AiAssistantPanel extends Component<Signature> {
       }
 
       .loading-new-session {
-        margin: auto;
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
       }
 
       .room {


### PR DESCRIPTION
Spinner was out of place for a second when opening the AI panel

Before | After
-- | --
<img width="336" height="696" alt="image" src="https://github.com/user-attachments/assets/e0250af1-58f7-4448-a432-6e4173c25240" /> | <img width="337" height="961" alt="image" src="https://github.com/user-attachments/assets/54e42570-1c8d-46f0-a087-77da0ca91999" />

</body></html>