### PR TITLE
matrix: Fix flaky room message test

### DIFF
--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -49,7 +49,7 @@ test.describe('Room messages', () => {
     await realmServer.stop();
   });
 
-  test.skip(`it can send a message in a room`, async ({ page }) => {
+  test(`it can send a message in a room`, async ({ page }) => {
     await login(page, 'user1', 'pass', { url: appURL });
     let room1 = await getRoomId(page);
     await expect(page.locator('[data-test-new-session]')).toHaveCount(1);
@@ -77,13 +77,13 @@ test.describe('Room messages', () => {
 
     await writeMessage(page, room1, 'Message 2');
     await page.keyboard.press('Shift+Enter');
-    await page.keyboard.type('Hello World!');
+    await page.keyboard.type('!');
     await assertMessages(page, [{ from: 'user1', message: 'Message 1' }]);
 
     await page.keyboard.press('Enter');
     const messages = [
       { from: 'user1', message: 'Message 1' },
-      { from: 'user1', message: 'Message 2\n\nHello World!' },
+      { from: 'user1', message: 'Message 2\n\n!' },
     ];
     await assertMessages(page, messages);
 

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -49,7 +49,7 @@ test.describe('Room messages', () => {
     await realmServer.stop();
   });
 
-  test(`it can send a message in a room`, async ({ page }) => {
+  test.skip(`it can send a message in a room`, async ({ page }) => {
     await login(page, 'user1', 'pass', { url: appURL });
     let room1 = await getRoomId(page);
     await expect(page.locator('[data-test-new-session]')).toHaveCount(1);


### PR DESCRIPTION
See failures [here](https://github.com/cardstack/boxel/actions/runs/16331698282/job/46135567055#step:11:6690), [here](https://github.com/cardstack/boxel/actions/runs/16330936332/job/46133073987), [here](https://github.com/cardstack/boxel/actions/runs/16317481267/job/46086785630).

The failure look like these:

<img width="521" height="131" alt="Test Workspace A 2025-07-17 09-54-08" src="https://github.com/user-attachments/assets/48f0fc22-ecd6-4a0f-ac3b-a716fdcafd5c" />
<img width="521" height="131" alt="Test Workspace A 2025-07-17 09-59-20" src="https://github.com/user-attachments/assets/740bbeeb-fde4-4a78-9227-6a19af271763" />

We aren’t seeing any evidence that typing in the field has changed, I believe this started being flaky when I updated Playwright in #2913. Changing to type only one character should eliminate the variation.