### PR TITLE
Add selectionRange to context sent to AI

### DIFF
--- a/packages/ai-bot/helpers.ts
+++ b/packages/ai-bot/helpers.ts
@@ -573,7 +573,15 @@ export function attachedFilesToMessage(
       }
 
       if (f.content) {
-        return `${hyperlink}: ${f.content}`;
+        // Add line numbers to file content to make selection ranges clearer
+        let lines = f.content.split('\n');
+        let numberedContent = lines
+          .map(
+            (line, index) =>
+              `${(index + 1).toString().padStart(3, ' ')}: ${line}`,
+          )
+          .join('\n');
+        return `${hyperlink}:\n${numberedContent}`;
       } else {
         return `${hyperlink}`;
       }
@@ -1003,6 +1011,16 @@ export const buildContextMessage = async (
       result += `File open in code editor: ${context.codeMode.currentFile}\n`;
       if (context?.codeMode?.selectedCodeRef) {
         result += `  Selected declaration: ${humanReadable(context.codeMode.selectedCodeRef)}\n`;
+      }
+      if (context?.codeMode?.selectionRange) {
+        const { startLine, startColumn, endLine, endColumn } =
+          context.codeMode.selectionRange;
+        if (startLine === endLine) {
+          result += `  Selected text: line ${startLine} (1-based), columns ${startColumn}-${endColumn} (1-based)\n`;
+        } else {
+          result += `  Selected text: lines ${startLine}-${endLine} (1-based), columns ${startColumn}-${endColumn} (1-based)\n`;
+        }
+        result += `  Note: Line numbers in selection refer to the original file. Attached file contents below show line numbers for reference.\n`;
       }
     }
     if (context?.codeMode?.moduleInspectorPanel) {

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -190,6 +190,12 @@ Current date and time: 2025-06-11T11:43:00.533Z
                   module: 'http://localhost:4201/experiments/author',
                   name: 'Address',
                 },
+                selectionRange: {
+                  startLine: 10,
+                  startColumn: 5,
+                  endLine: 12,
+                  endColumn: 20,
+                },
                 moduleInspectorPanel: 'preview',
                 previewPanelSelection: {
                   cardId: 'http://localhost:4201/experiments/Author/1',
@@ -234,6 +240,8 @@ Workspace: http://localhost:4201/experiments
 The user has no open cards.
 File open in code editor: http://localhost:4201/experiments/author.gts
   Selected declaration: Address from http://localhost:4201/experiments/author
+  Selected text: lines 10-12 (1-based), columns 5-20 (1-based)
+  Note: Line numbers in selection refer to the original file. Attached file contents below show line numbers for reference.
 Module inspector panel: preview
 Viewing card instance: http://localhost:4201/experiments/Author/1
 In format: isolated
@@ -834,8 +842,10 @@ Attached Files (files with newer versions don't show their content):
       userMessages[2]?.content?.includes(
         `
 Attached Files (files with newer versions don't show their content):
-[spaghetti-recipe.gts](http://test-realm-server/my-realm/spaghetti-recipe.gts): this is the content of the spaghetti-recipe.gts file
-[best-friends.txt](http://test-realm-server/my-realm/best-friends.txt): this is the content of the best-friends.txt file
+[spaghetti-recipe.gts](http://test-realm-server/my-realm/spaghetti-recipe.gts):
+  1: this is the content of the spaghetti-recipe.gts file
+[best-friends.txt](http://test-realm-server/my-realm/best-friends.txt):
+  1: this is the content of the best-friends.txt file
       `.trim(),
       ),
     );
@@ -2080,7 +2090,6 @@ Attached Files (files with newer versions don't show their content):
       '@aibot:localhost',
       fakeMatrixClient,
     );
-    console.log(messages);
     assert.true(messages!.length > 0);
     assert.equal(messages![0].role, 'system');
     assert.true(messages![0].content?.includes(SKILL_INSTRUCTIONS_MESSAGE));
@@ -3662,7 +3671,8 @@ Current date and time: 2025-06-11T11:43:00.533Z
       toolCallMessage!.content!.includes(
         `
 Attached Files (files with newer versions don't show their content):
-[postcard.gts](http://test-realm-server/user/test-realm/postcard.gts): export default Postcard extends CardDef {}
+[postcard.gts](http://test-realm-server/user/test-realm/postcard.gts):
+  1: export default Postcard extends CardDef {}
       `.trim(),
       ),
       'Tool call result should include attached files',
@@ -3752,7 +3762,8 @@ Attached Cards (cards with newer versions don't show their content):
       lastUserMessage!.content!.includes(
         `
 Attached Files (files with newer versions don't show their content):
-[postcard.gts](http://test-realm-server/user/test-realm/postcard.gts): export default Postcard extends CardDef { /* after */ }
+[postcard.gts](http://test-realm-server/user/test-realm/postcard.gts):
+  1: export default Postcard extends CardDef { /* after */ }
       `.trim(),
       ),
       'Code patch result should include attached files',

--- a/packages/base/matrix-event.gts
+++ b/packages/base/matrix-event.gts
@@ -193,6 +193,12 @@ export interface BoxelContext {
       format: string;
     };
     selectedCodeRef?: CodeRef;
+    selectionRange?: {
+      startLine: number;
+      startColumn: number;
+      endLine: number;
+      endColumn: number;
+    };
   };
   debug?: boolean;
   requireToolCall?: boolean;

--- a/packages/host/app/components/operator-mode/code-editor.gts
+++ b/packages/host/app/components/operator-mode/code-editor.gts
@@ -503,6 +503,11 @@ export default class CodeEditor extends Component<Signature> {
       }
       .monaco-container :deep(.monaco-editor) {
         --vscode-editor-background: var(--monaco-background);
+        --vscode-editor-selectionBackground: var(--monaco-selection-background);
+        --vscode-editor-inactiveSelectionBackground: var(
+          --monaco-inactive-selection-background
+        );
+
         --vscode-editorStickyScroll-background: var(--monaco-background);
         --vscode-editorGutter-background: var(--monaco-background);
         --vscode-editorStickyScroll-shadow: rgba(0 0 0 / 40%);

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -825,6 +825,8 @@ export default class CodeSubmode extends Component<Signature> {
             (2 * (var(--operator-mode-spacing)))
         );
         --monaco-background: var(--boxel-600);
+        --monaco-selection-background: var(--boxel-500);
+        --monaco-inactive-selection-background: var(--boxel-550);
         --monaco-readonly-background: #606060;
       }
 

--- a/packages/host/app/services/monaco-service.ts
+++ b/packages/host/app/services/monaco-service.ts
@@ -191,6 +191,10 @@ export default class MonacoService extends Service {
   getContentHeight() {
     return this.editor?.getContentHeight();
   }
+
+  getSelection() {
+    return this.editor?.getSelection();
+  }
 }
 
 declare module '@ember/service' {

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -33,6 +33,7 @@ import {
 import { maybe } from '@cardstack/host/resources/maybe';
 import type LoaderService from '@cardstack/host/services/loader-service';
 import type MessageService from '@cardstack/host/services/message-service';
+import type MonacoService from '@cardstack/host/services/monaco-service';
 import type PlaygroundPanelService from '@cardstack/host/services/playground-panel-service';
 import { PlaygroundSelection } from '@cardstack/host/services/playground-panel-service';
 import type Realm from '@cardstack/host/services/realm';
@@ -136,6 +137,7 @@ export default class OperatorModeStateService extends Service {
   @service declare private codeSemanticsService: CodeSemanticsService;
   @service declare private loaderService: LoaderService;
   @service declare private messageService: MessageService;
+  @service declare private monacoService: MonacoService;
   @service declare private realm: Realm;
   @service declare private realmServer: RealmServer;
   @service declare private recentCardsService: RecentCardsService;
@@ -1058,6 +1060,18 @@ export default class OperatorModeStateService extends Service {
       codeMode = {
         currentFile: this.codePathString,
       };
+
+      // Add selection range information when in code mode
+      let selection = this.monacoService.getSelection();
+      if (selection) {
+        codeMode.selectionRange = {
+          startLine: selection.startLineNumber,
+          startColumn: selection.startColumn,
+          endLine: selection.endLineNumber,
+          endColumn: selection.endColumn,
+        };
+      }
+
       if (this.isViewingCardInCodeMode) {
         codeMode.moduleInspectorPanel = 'preview';
         codeMode.previewPanelSelection = {

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -1117,6 +1117,16 @@ module('Acceptance | AI Assistant tests', function (hooks) {
       `${testRealmURL}Plant/highbush-blueberry.json`,
       'Context sent with message contains correct currentFile',
     );
+    assert.deepEqual(
+      contextSent.codeMode.selectionRange,
+      {
+        startLine: 1,
+        startColumn: 1,
+        endLine: 1,
+        endColumn: 1,
+      },
+      'Context sent with message contains correct selectionRange',
+    );
     assert.strictEqual(
       contextSent.codeMode.moduleInspectorPanel,
       'preview',
@@ -1172,6 +1182,16 @@ module('Acceptance | AI Assistant tests', function (hooks) {
       `${testRealmURL}plant.gts`,
       'Context sent with message contains correct currentFile',
     );
+    assert.deepEqual(
+      contextSent.codeMode.selectionRange,
+      {
+        startLine: 3,
+        startColumn: 45,
+        endLine: 3,
+        endColumn: 45,
+      },
+      'Context sent with message contains correct selectionRange',
+    );
     assert.strictEqual(
       contextSent.codeMode.moduleInspectorPanel,
       'schema',
@@ -1202,6 +1222,17 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     await click(
       '[data-test-boxel-button][data-test-module-inspector-view="preview"]',
     );
+    // Select some text in the monaco editor for testing selectionRange
+    let monacoService = getService('monaco-service');
+    let editor = monacoService.editor;
+    if (editor?.setSelection) {
+      editor.setSelection({
+        startLineNumber: 3,
+        startColumn: 45,
+        endLineNumber: 6,
+        endColumn: 1,
+      });
+    }
 
     await fillIn('[data-test-message-field]', `Message - 3`);
     await click('[data-test-send-message-btn]');
@@ -1229,6 +1260,16 @@ module('Acceptance | AI Assistant tests', function (hooks) {
       contextSent.codeMode.currentFile,
       `${testRealmURL}plant.gts`,
       'Context sent with message contains correct currentFile',
+    );
+    assert.deepEqual(
+      contextSent.codeMode.selectionRange,
+      {
+        startLine: 3,
+        startColumn: 45,
+        endLine: 6,
+        endColumn: 1,
+      },
+      'Context sent with message contains correct selectionRange',
     );
     assert.strictEqual(
       contextSent.codeMode.moduleInspectorPanel,

--- a/packages/host/tests/acceptance/code-patches-test.gts
+++ b/packages/host/tests/acceptance/code-patches-test.gts
@@ -170,6 +170,12 @@ ${REPLACE_MARKER}\n\`\`\``;
         agentId: getService('matrix-service').agentId,
         codeMode: {
           currentFile: 'http://test-realm/test/hello.txt',
+          selectionRange: {
+            endColumn: 1,
+            endLine: 1,
+            startColumn: 1,
+            startLine: 1,
+          },
           moduleInspectorPanel: 'schema',
         },
         submode: 'code',
@@ -419,6 +425,12 @@ ${REPLACE_MARKER}\n\`\`\``;
         agentId: getService('matrix-service').agentId,
         codeMode: {
           currentFile: 'http://test-realm/test/hello.txt',
+          selectionRange: {
+            endColumn: 1,
+            endLine: 1,
+            startColumn: 1,
+            startLine: 1,
+          },
           moduleInspectorPanel: 'schema',
         },
         submode: 'code',


### PR DESCRIPTION
https://www.loom.com/share/0cebc3de1cb64be98152f26351670f0e

This pull request adds a selectionRange to the context we send to the LLM

### Enhancements to Code Selection and Context Handling:
* Added a `selectionRange` property to the `BoxelContext` interface to capture the start and end line/column numbers of selected text in the code editor. (`packages/base/matrix-event.gts`)
* Integrated `selectionRange` into the `OperatorModeStateService` to extract and include the selection range from the Monaco editor when in code mode. (`packages/host/app/services/operator-mode-state-service.ts`)
* Updated the `buildContextMessage` function to include selection range details in the context message, specifying line and column ranges in a human-readable format. (`packages/ai-bot/helpers.ts`)

### Improvements to Attached File serialization:
* Enhanced the `attachedFilesToMessage` function to include line numbers for file contents, making it easier for the LLM to reference specific lines. (`packages/ai-bot/helpers.ts`)

### Updates to UI and Editor Behavior:
* Added new CSS variables to customize the appearance of selection and inactive selection backgrounds in the Monaco editor. (`packages/host/app/components/operator-mode/code-editor.gts`, `packages/host/app/components/operator-mode/code-submode.gts`) [[1]](diffhunk://#diff-ba30949ecc056c55c9a1e78be81277ed73e84bc3f3ada10771d7f731808c78e7R506-R510) [[2]](diffhunk://#diff-fb4a08a6507f3f59dffededa5954c8726c6fbdda5d1bd01b9340cffca2b8b37cR828-R829)
* Introduced a `getSelection` method in the `MonacoService` to retrieve the current text selection from the editor. (`packages/host/app/services/monaco-service.ts`)

These changes collectively improve the assistant's ability to provide precise context for code-related prompts.