### PR TITLE
Fix: Apply grid template column css layout in editor only when user has write permissions

### DIFF
--- a/packages/base/contains-many-component.gts
+++ b/packages/base/contains-many-component.gts
@@ -74,7 +74,7 @@ class ContainsManyEditor extends GlimmerComponent<ContainsManyEditorSignature> {
           >
             {{#each @arrayField.children as |boxedElement i|}}
               <li
-                class='editor'
+                class='editor {{if permissions.canWrite "can-write"}}'
                 data-test-item={{i}}
                 {{sortableItem
                   groupName=this.sortableGroupId
@@ -148,7 +148,9 @@ class ContainsManyEditor extends GlimmerComponent<ContainsManyEditorSignature> {
       .editor {
         position: relative;
         display: grid;
-        grid-template-columns: var(--boxel-icon-lg) 1fr var(--remove-icon-size);
+      }
+      .editor.can-write {
+        grid-template-columns: var(--boxel-icon-lg) 1fr var(--boxel-icon-lg);
       }
       .editor :deep(.boxel-input:hover) {
         border-color: var(--boxel-form-control-border-color);

--- a/packages/base/contains-many-component.gts
+++ b/packages/base/contains-many-component.gts
@@ -150,7 +150,7 @@ class ContainsManyEditor extends GlimmerComponent<ContainsManyEditorSignature> {
         display: grid;
       }
       .editor.can-write {
-        grid-template-columns: var(--boxel-icon-lg) 1fr var(--boxel-icon-lg);
+        grid-template-columns: var(--boxel-icon-lg) 1fr var(--remove-icon-size);
       }
       .editor :deep(.boxel-input:hover) {
         border-color: var(--boxel-form-control-border-color);

--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -180,7 +180,7 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
         >
           {{#each @arrayField.children as |boxedElement i|}}
             <li
-              class='editor'
+              class='editor {{if permissions.canWrite "can-write"}}'
               data-test-item={{i}}
               {{sortableItem
                 groupName=this.sortableGroupId
@@ -250,6 +250,8 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
       .editor {
         position: relative;
         display: grid;
+      }
+      .editor.can-write {
         grid-template-columns: var(--boxel-icon-lg) 1fr var(--boxel-icon-lg);
       }
       .remove {


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-9119/ui-issue-with-whole-div-when-accessing-edit-mode-in-read-only-realm

As a result:
When users did not have write permissions, the icon buttons were not displayed, but the grid still reserved space for them.
This led to extra empty space on either side of the main content, causing the layout to appear misaligned or less visually balanced in read-only mode.
**The improvement:**
By applying the **grid-template-columns** style only when the user has write permissions (using a conditional class such as .can-write), the layout now adapts appropriately:

- Three columns are used when the icon buttons are present (editable state).
- A single column is used when the buttons are absent (read-only state).

This approach ensures a consistent and visually balanced layout for all users.

Before:
<img width="1005" height="809" alt="Screenshot 2025-07-21 at 1 59 40 PM" src="https://github.com/user-attachments/assets/9f6271b1-c465-450b-bc23-fea9dd8e4610" />

After:
<img width="735" height="818" alt="Screenshot 2025-07-21 at 2 05 57 PM" src="https://github.com/user-attachments/assets/6195f45c-d418-448e-84fe-0bf54b144922" />

