### PR TITLE
make auto save occur only when write access is available

### DIFF
--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -836,6 +836,13 @@ export default class StoreService extends Service implements StoreInterface {
     } else {
       instance = idOrInstance;
     }
+    let realmToWrite = instance[realmURLSymbol]?.href;
+    let permissionToWrite = realmToWrite
+      ? this.realm.permissions(realmToWrite).canWrite
+      : false;
+    if (!permissionToWrite) {
+      return;
+    }
     let autoSaveState = this.initOrGetAutoSaveState(instance);
     let queueName = instance.id ?? instance[localIdSymbol];
     let autoSaveQueue = this.autoSaveQueues.get(queueName);

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -35,6 +35,7 @@ import type LoaderService from '@cardstack/host/services/loader-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 import type RealmService from '@cardstack/host/services/realm';
 import type StoreService from '@cardstack/host/services/store';
+import RealmServiceClass from '@cardstack/host/services/realm';
 import { type CardErrorJSONAPI } from '@cardstack/host/services/store';
 
 import { CardDef as CardDefType } from 'https://cardstack.com/base/card-api';
@@ -779,7 +780,18 @@ module('Integration | Store', function (hooks) {
   });
 
   test<TestContextWithSave>('an instance will NOT auto save when its data changes, if the user does not have write permissions', async function (assert) {
-    await realmService.logout(); //logout means store does not have write access to the realm
+    class StubRealmService extends RealmServiceClass {
+      permissions = () => ({
+        get canRead() {
+          return true;
+        },
+        get canWrite() {
+          return false;
+        },
+      });
+    }
+    //inject stub service
+    (store as any).realm = new StubRealmService(this.owner);
     let instance = await store.get(`${testRealmURL}Person/hassan`);
     this.onSave(() => {
       assert.ok(false, 'should not save');

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -35,7 +35,6 @@ import type LoaderService from '@cardstack/host/services/loader-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 import type RealmService from '@cardstack/host/services/realm';
 import type StoreService from '@cardstack/host/services/store';
-import RealmServiceClass from '@cardstack/host/services/realm';
 import { type CardErrorJSONAPI } from '@cardstack/host/services/store';
 
 import { CardDef as CardDefType } from 'https://cardstack.com/base/card-api';
@@ -780,18 +779,14 @@ module('Integration | Store', function (hooks) {
   });
 
   test<TestContextWithSave>('an instance will NOT auto save when its data changes, if the user does not have write permissions', async function (assert) {
-    class StubRealmService extends RealmServiceClass {
-      permissions = () => ({
-        get canRead() {
-          return true;
-        },
-        get canWrite() {
-          return false;
-        },
-      });
-    }
-    //inject stub service
-    (store as any).realm = new StubRealmService(this.owner);
+    (store as any).realm.permissions = () => ({
+      get canRead() {
+        return true;
+      },
+      get canWrite() {
+        return false;
+      },
+    });
     let instance = await store.get(`${testRealmURL}Person/hassan`);
     this.onSave(() => {
       assert.ok(false, 'should not save');

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -33,8 +33,8 @@ import { getCard } from '@cardstack/host/resources/card-resource';
 import { getSearch } from '@cardstack/host/resources/search';
 import type LoaderService from '@cardstack/host/services/loader-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
-import type StoreService from '@cardstack/host/services/store';
 import type RealmService from '@cardstack/host/services/realm';
+import type StoreService from '@cardstack/host/services/store';
 import { type CardErrorJSONAPI } from '@cardstack/host/services/store';
 
 import { CardDef as CardDefType } from 'https://cardstack.com/base/card-api';


### PR DESCRIPTION
we get 403 forbidden when people are playing with examples inside the catalog realm that essentially write to card state using `this.args.model.set` 

<img width="1889" height="789" alt="Screenshot 2025-07-21 at 21 00 08" src="https://github.com/user-attachments/assets/bf1402b9-d562-4884-b010-0377b9e756d5" />


<img width="1406" height="715" alt="Screenshot 2025-07-21 at 20 59 26" src="https://github.com/user-attachments/assets/3b59bb40-cda1-45d9-aae7-353d1421a9ca" />
