### PR TITLE
Fix readonly field padding in default card template

### DIFF
--- a/packages/base/contains-many-component.gts
+++ b/packages/base/contains-many-component.gts
@@ -74,7 +74,8 @@ class ContainsManyEditor extends GlimmerComponent<ContainsManyEditorSignature> {
           >
             {{#each @arrayField.children as |boxedElement i|}}
               <li
-                class='editor {{if permissions.canWrite "can-write"}}'
+                class='editor
+                  {{if permissions.canWrite "can-write" "read-only"}}'
                 data-test-item={{i}}
                 {{sortableItem
                   groupName=this.sortableGroupId
@@ -148,6 +149,9 @@ class ContainsManyEditor extends GlimmerComponent<ContainsManyEditorSignature> {
       .editor {
         position: relative;
         display: grid;
+      }
+      .editor.read-only {
+        grid-template-columns: 1fr;
       }
       .editor.can-write {
         grid-template-columns: var(--boxel-icon-lg) 1fr var(--remove-icon-size);

--- a/packages/base/default-templates/isolated-and-edit.gts
+++ b/packages/base/default-templates/isolated-and-edit.gts
@@ -53,8 +53,17 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
         padding-right: var(--boxel-icon-lg);
       }
       .default-card-template.edit
-        > :deep(.boxel-field > .content > *:not(.links-to-many-editor)) {
+        > :deep(
+          .boxel-field
+            > .content
+            > *:not(.links-to-many-editor):not(.contains-many-editor)
+        ) {
         padding-left: var(--boxel-icon-lg);
+      }
+      /* Add padding for readonly fields */
+      .default-card-template.edit > :deep(.boxel-field > .content .read-only) {
+        padding-left: var(--boxel-icon-lg);
+        padding-right: var(--boxel-icon-lg);
       }
     </style>
   </template>

--- a/packages/base/links-to-editor.gts
+++ b/packages/base/links-to-editor.gts
@@ -48,7 +48,8 @@ export class LinksToEditor extends GlimmerComponent<Signature> {
   <template>
     <PermissionsConsumer as |permissions|>
       <div
-        class='links-to-editor'
+        class='links-to-editor
+          {{if permissions.canWrite "can-write" "read-only"}}'
         data-test-links-to-editor={{@field.name}}
         ...attributes
       >
@@ -93,7 +94,9 @@ export class LinksToEditor extends GlimmerComponent<Signature> {
       .links-to-editor {
         position: relative;
         display: grid;
-        grid-template-columns: 1fr max-content;
+      }
+      .links-to-editor.can-write {
+        grid-template-columns: 1fr var(--boxel-icon-lg);
       }
       .links-to-editor > :deep(.boxel-card-container.embedded-format) {
         order: -1;

--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -180,7 +180,7 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
         >
           {{#each @arrayField.children as |boxedElement i|}}
             <li
-              class='editor {{if permissions.canWrite "can-write"}}'
+              class='editor {{if permissions.canWrite "can-write" "read-only"}}'
               data-test-item={{i}}
               {{sortableItem
                 groupName=this.sortableGroupId
@@ -250,6 +250,9 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
       .editor {
         position: relative;
         display: grid;
+      }
+      .editor.read-only {
+        grid-template-columns: 1fr;
       }
       .editor.can-write {
         grid-template-columns: var(--boxel-icon-lg) 1fr var(--boxel-icon-lg);


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-9120/adjust-field-alignment-in-edit-mode-read-only-state

Problem:
When viewing cards in readonly mode, we notice that different fields display inconsistent padding and alignment.

Solution:
- Updated CSS so readonly fields get correct left and right padding
- Excluded links-to-many and contains-many editors from the default left padding for better alignment.
- Ensures all components display proper padding in readonly mode.


Before:
<img width="838" height="799" alt="Screenshot 2025-07-22 at 3 37 28 PM" src="https://github.com/user-attachments/assets/19692966-6c1a-4dea-ba1a-c5c4442407e9" />


After:
<img width="849" height="788" alt="Screenshot 2025-07-22 at 3 36 46 PM" src="https://github.com/user-attachments/assets/f16f44e3-53c1-4490-acaa-3df4b9f707c8" />

