### PR TITLE
Remove redundant throw for allowed cyclic relationship

### DIFF
--- a/packages/host/app/components/operator-mode/card-schema-editor.gts
+++ b/packages/host/app/components/operator-mode/card-schema-editor.gts
@@ -29,7 +29,7 @@ import {
   type Type,
   type CodeRefType,
   type FieldOfType,
-  getCodeRef,
+  getResolvedCodeRef,
 } from '@cardstack/host/resources/card-type';
 
 import type { Ready } from '@cardstack/host/resources/file';
@@ -247,7 +247,7 @@ export default class CardSchemaEditor extends Component<Signature> {
       class='schema-editor-container'
       data-test-card-schema={{@cardType.displayName}}
     >
-      {{#let (getCodeRef @cardType) as |codeRef|}}
+      {{#let (getResolvedCodeRef @cardType) as |codeRef|}}
         <div class='header'>
           <Tooltip @placement='bottom'>
             <:trigger>
@@ -323,7 +323,7 @@ export default class CardSchemaEditor extends Component<Signature> {
               </div>
               <div class='right'>
                 {{#let (this.fieldModuleURL field) as |moduleUrl|}}
-                  {{#let (getCodeRef field) as |codeRef|}}
+                  {{#let (getResolvedCodeRef field) as |codeRef|}}
                     {{#if (this.isOverridden field)}}
                       <BoxelButton
                         @kind='text-only'
@@ -580,7 +580,7 @@ export default class CardSchemaEditor extends Component<Signature> {
       return;
     }
 
-    let codeRef = getCodeRef(this.args.cardType);
+    let codeRef = getResolvedCodeRef(this.args.cardType);
     if (!codeRef) {
       return undefined;
     }

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -30,7 +30,10 @@ import {
   type ResolvedCodeRef,
 } from '@cardstack/runtime-common';
 
-import { getCodeRef, getCardType } from '@cardstack/host/resources/card-type';
+import {
+  getResolvedCodeRef,
+  getCardType,
+} from '@cardstack/host/resources/card-type';
 import { type Ready } from '@cardstack/host/resources/file';
 
 import {
@@ -439,7 +442,10 @@ export default class DetailPanel extends Component<Signature> {
             />
             <Divider @label='Adopts From' />
             {{#if this.cardInstanceType.type}}
-              {{#let (getCodeRef this.cardInstanceType.type) as |codeRef|}}
+              {{#let
+                (getResolvedCodeRef this.cardInstanceType.type)
+                as |codeRef|
+              }}
                 <ClickableModuleDefinitionContainer
                   @title='Card Definition'
                   @fileURL={{this.cardInstanceType.type.module}}
@@ -468,7 +474,10 @@ export default class DetailPanel extends Component<Signature> {
                   @actions={{this.definitionActions}}
                 />
                 {{#if this.cardType.type.super}}
-                  {{#let (getCodeRef this.cardType.type.super) as |codeRef|}}
+                  {{#let
+                    (getResolvedCodeRef this.cardType.type.super)
+                    as |codeRef|
+                  }}
                     <Divider @label='Inherits From' />
                     <ClickableModuleDefinitionContainer
                       @title={{definitionTitle}}
@@ -483,7 +492,7 @@ export default class DetailPanel extends Component<Signature> {
                 {{/if}}
               {{else if (isReexportCardOrField @selectedDeclaration)}}
                 {{#if this.cardType.type}}
-                  {{#let (getCodeRef this.cardType.type) as |codeRef|}}
+                  {{#let (getResolvedCodeRef this.cardType.type) as |codeRef|}}
                     <ClickableModuleDefinitionContainer
                       @title={{definitionTitle}}
                       @fileURL={{this.cardType.type.module}}

--- a/packages/host/app/components/operator-mode/edit-field-modal.gts
+++ b/packages/host/app/components/operator-mode/edit-field-modal.gts
@@ -26,14 +26,18 @@ import {
   loadCardDef,
   identifyCard,
   specRef,
-  CodeRef,
+  type CodeRef,
   isCardInstance,
+  moduleFrom,
 } from '@cardstack/runtime-common';
 
 import type { ModuleSyntax } from '@cardstack/runtime-common/module-syntax';
 
 import ModalContainer from '@cardstack/host/components/modal-container';
-import { FieldOfType, Type } from '@cardstack/host/resources/card-type';
+import {
+  getCodeRef,
+  type FieldOfType,
+} from '@cardstack/host/resources/card-type';
 
 import { Ready } from '@cardstack/host/resources/file';
 import LoaderService from '@cardstack/host/services/loader-service';
@@ -147,23 +151,15 @@ export default class EditFieldModal extends Component<Signature> {
       ? 'many'
       : 'one';
 
-    let ref: { module: string; name: string };
-
-    let fieldCardType = field.card;
-    let isCardType = 'codeRef' in fieldCardType; // To see whether we are dealing with Type or CodeRefType
-
-    if (isCardType) {
-      ref = (fieldCardType as Type).codeRef as typeof ref;
-    } else {
-      ref = fieldCardType as typeof ref;
-    }
+    let ref = getCodeRef(field);
 
     this.fieldCard = await loadCardDef(ref, {
       loader: this.loaderService.loader,
     });
 
-    this.fieldModuleURL = new URL(ref.module);
-    this.cardURL = new URL(ref.module);
+    let moduleRef = moduleFrom(ref);
+    this.fieldModuleURL = new URL(moduleRef);
+    this.cardURL = new URL(moduleRef);
     this.fieldRef = ref;
 
     // Field's card can descend from a FieldDef or a CardDef, so we need to determine which one it is. We do this by checking the field's type -

--- a/packages/host/app/resources/card-type.ts
+++ b/packages/host/app/resources/card-type.ts
@@ -135,16 +135,7 @@ export class CardType extends Resource<Args> {
     if (superCard && card !== superCard) {
       superType = await this.toType(superCard, [card, ...stack]);
     }
-    if (isCodeRefType(superType)) {
-      throw new Error(
-        `bug: encountered cycle in card ancestor: ${[
-          superType,
-          ...stack.map((c) => identifyCard(c)),
-        ]
-          .map((r) => JSON.stringify(r))
-          .join()}`,
-      );
-    }
+
     let fieldTypes: FieldOfType[] = await Promise.all(
       Object.entries(fields).map(
         async ([name, field]: [string, Field<typeof BaseDef, any>]) => ({
@@ -159,7 +150,7 @@ export class CardType extends Resource<Args> {
     let type: Type = {
       id,
       module: moduleIdentifier,
-      super: superType,
+      super: isCodeRefType(superType) ? undefined : superType,
       displayName: card.prototype.constructor.displayName || 'Card',
       fields: fieldTypes,
       moduleInfo,
@@ -250,13 +241,20 @@ export function isFieldOfType(obj: any): obj is FieldOfType {
   return obj && 'card' in obj;
 }
 
-export function getCodeRef(t: Type | FieldOfType): ResolvedCodeRef | undefined {
+export function getCodeRef(t: Type | FieldOfType): CodeRef {
   let codeRef: CodeRef;
   if (isFieldOfType(t)) {
-    codeRef = isCodeRefType(t.card) ? t.card : t.card.codeRef;
+    codeRef = isCodeRefType(t.card) ? t.card : (t.card as Type).codeRef;
   } else {
     codeRef = t.codeRef;
   }
+  return codeRef;
+}
+
+export function getResolvedCodeRef(
+  t: Type | FieldOfType,
+): ResolvedCodeRef | undefined {
+  let codeRef = getCodeRef(t);
   if (!isResolvedCodeRef(codeRef)) {
     return undefined;
   }

--- a/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
@@ -901,7 +901,7 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
   });
 
   test<TestContextWithSave>('editing a local field from schema editor', async function (assert) {
-    assert.expect(5);
+    assert.expect(4);
     await visitOperatorMode({
       submode: 'code',
       codePath: `${testRealmURL}employee.gts`,
@@ -932,11 +932,9 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
     });
     await click('[data-test-save-field-button]');
 
-    assert
-      .dom(
-        '[data-test-card-schema="Employee"] [data-test-field-name="supervisedBy"] [data-test-card-display-name="Person"]',
-      )
-      .exists();
+    await waitFor(
+      '[data-test-card-schema="Employee"] [data-test-field-name="supervisedBy"] [data-test-card-display-name="Person"]',
+    );
     assert
       .dom(
         `[data-test-card-schema="Employee"] [data-test-field-name="supervisedBy"] [data-test-field-types]`,

--- a/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
@@ -83,23 +83,56 @@ const employeeCardSource = `
   import {
     contains,
     field,
+    linksTo,
     Component,
+    FieldDef,
   } from 'https://cardstack.com/base/card-api';
   import StringField from 'https://cardstack.com/base/string';
+  import BooleanField from 'https://cardstack.com/base/boolean';
+  import DateField from 'https://cardstack.com/base/date';
   import { Person } from './person';
+
+  class Supervisor extends Person {
+    static displayName = 'Supervisor';
+    @field canApproveTimesheets = contains(BooleanField);
+  }
+
+  export class EmploymentInfo extends FieldDef {
+    static displayName = 'Employment Info';
+    @field startDate = contains(DateField);
+    @field role = contains(StringField);
+    @field hiringManager = linksTo(() => Manager);
+    static embedded = class Embedded extends Component<typeof this> {
+      <template>
+        <div>Start Date: <@fields.startDate /></div>
+        <div>Role: <@fields.role /></div>
+        <div>Hiring Manager: <@fields.hiringManager /></div>
+      </template>
+    };
+  }
 
   export class Employee extends Person {
     static displayName = 'Employee';
     @field employeeId = contains(StringField);
     @field department = contains(StringField);
+    @field supervisor = linksTo(Supervisor);
+    @field employmentInfo = contains(EmploymentInfo);
 
     static isolated = class Isolated extends Component<typeof this> {
       <template>
         <@fields.firstName /> <@fields.lastName />
 
         Department: <@fields.department />
+        Supervisor: <@fields.supervisor />
+        <hr>
+        Employment Details: <@fields.employmentInfo />
       </template>
     };
+  }
+
+  export class Manager extends Employee {
+    static displayName = 'Manager';
+    @field departmentSize = contains(StringField);
   }
 `;
 
@@ -454,6 +487,21 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
     assert
       .dom(`[data-test-card-schema="Card"] [data-test-realm-icon-url]`)
       .hasAttribute('data-test-realm-icon-url', realm2IconUrl);
+  });
+
+  test('can list the inheritance chain of a card with complex cyclic relationships', async function (assert) {
+    await visitOperatorMode({
+      submode: 'code',
+      codePath: `${testRealmURL}employee.gts`,
+    });
+    await click('[data-test-boxel-selector-item-text="Employee"]');
+    assert.dom('[data-test-definition-name]').containsText('Employee');
+    assert
+      .dom('[data-test-card-schema="Employee"] [data-test-total-fields]')
+      .containsText('4');
+    assert
+      .dom('[data-field-name="employmentInfo"]')
+      .hasText('employmentInfo Employment Info');
   });
 
   test('when selecting card definition from a card instance in code mode, the right hand panel changes from card preview to schema mode', async function (assert) {
@@ -850,6 +898,50 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
     await waitFor(
       '[data-test-card-schema="Person"] [data-test-field-name="friendCount"] [data-test-card-display-name="BigInteger"]',
     );
+  });
+
+  test<TestContextWithSave>('editing a local field from schema editor', async function (assert) {
+    assert.expect(5);
+    await visitOperatorMode({
+      submode: 'code',
+      codePath: `${testRealmURL}employee.gts`,
+    });
+    assert
+      .dom(
+        `[data-test-card-schema="Employee"] [data-test-field-name="supervisor"] [data-test-field-types]`,
+      )
+      .hasText('Link');
+
+    await click(
+      '[data-test-card-schema="Employee"] [data-test-field-name="supervisor"] [data-test-schema-editor-field-contextual-button]',
+    );
+    await click('[data-test-boxel-menu-item-text="Edit Field Settings"]');
+    assert.dom('[data-test-selected-type="Supervisor"]').exists();
+
+    await click('[data-test-choose-card-button]');
+    await click(`[data-test-select="${testRealmURL}person-entry"]`);
+    await click('[data-test-card-catalog-go-button]');
+    await fillIn('[data-test-field-name-input]', 'supervisedBy');
+    await click('[data-test-boxel-radio-option-id="many"]');
+
+    this.onSave((_, content) => {
+      if (typeof content !== 'string') {
+        throw new Error('expected string save data');
+      }
+      assert.ok(content.includes('supervisedBy = linksToMany(Person)'));
+    });
+    await click('[data-test-save-field-button]');
+
+    assert
+      .dom(
+        '[data-test-card-schema="Employee"] [data-test-field-name="supervisedBy"] [data-test-card-display-name="Person"]',
+      )
+      .exists();
+    assert
+      .dom(
+        `[data-test-card-schema="Employee"] [data-test-field-name="supervisedBy"] [data-test-field-types]`,
+      )
+      .hasText('Link, Collection');
   });
 
   test<TestContextWithSave>('adding a "default" field type from the schema editor', async function (assert) {


### PR DESCRIPTION
The "cycle in ancestor" error thrown in below example seems redundant, and causes various parts of the code-submode to break. If there is a legit "max stack size exceeded" error, it is caught elsewhere and the error reporting appears on the UI, the error-causing code is not saved to card.

Before: Follow the `employmentInfo` field trail in Employee card def

<img width="1899" height="953" alt="bug" src="https://github.com/user-attachments/assets/20b6740f-9b53-4ae0-ab2b-f9f51f8cf26a" />

After:
<img width="1900" height="954" alt="fixed" src="https://github.com/user-attachments/assets/f4080c4f-47a8-45ca-8aa1-1a751bdbfb51" />

## Bonus bug fix: 
As I was working on the above, came across a bug in schema field-edit-modal, where the card-type was not calculated for local (non-exported) types.

Before: No field type

<img width="500" height="585" alt="local-field-edit-bug" src="https://github.com/user-attachments/assets/34e8f8a2-fdfa-4579-bc5d-c6e67d9a3c25" />
After:
<img width="750" height="823" alt="field-edit-fixed" src="https://github.com/user-attachments/assets/8c3ceb98-9da6-4f10-a0e9-583635fd655a" />
Code:
<img width="462" height="272" alt="local-class-code" src="https://github.com/user-attachments/assets/77e6316b-162b-4f0e-a6d0-356bd1a411db" />
