### PR TITLE
Do not display stack-trigger buttons when workspace-chooser is open

### DIFF
--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -525,7 +525,11 @@ export default class InteractSubmode extends Component {
   // This determines whether we show the left and right button that trigger the search sheet whose card selection will go to the left or right stack
   // (there is a single stack with at least one card in it)
   private get canCreateNeighborStack() {
-    return this.allStackItems.length > 0 && this.stacks.length === 1;
+    return (
+      this.allStackItems.length > 0 &&
+      this.stacks.length === 1 &&
+      !this.operatorModeStateService.workspaceChooserOpened
+    );
   }
 
   private openSelectedSearchResultInStack = restartableTask(

--- a/packages/host/app/components/operator-mode/interact-submode/neighbor-stack-trigger.gts
+++ b/packages/host/app/components/operator-mode/interact-submode/neighbor-stack-trigger.gts
@@ -47,6 +47,7 @@ export default class NeighborStackTriggerButton extends Component<Signature> {
             @triggerSide
             SearchSheetTriggers.DropCardToLeftNeighborStackButton
           }}
+          data-test-neighbor-stack-trigger
         >
           <span class='icon-container'>
             <IconPlus class='add-icon' width='10' height='10' />

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -754,6 +754,11 @@ module('Acceptance | interact submode tests', function (hooks) {
 
       // There is still only 1 stack
       assert.dom('[data-test-operator-mode-stack]').exists({ count: 1 });
+      assert.dom('[data-test-neighbor-stack-trigger]').exists({ count: 2 });
+
+      await click('[data-test-workspace-chooser-toggle]');
+      assert.dom('[data-test-workspace-chooser]').exists();
+      assert.dom('[data-test-neighbor-stack-trigger]').doesNotExist();
     });
 
     test('Clicking search panel (without left and right buttons activated) replaces open card on existing stack', async function (assert) {


### PR DESCRIPTION
Updated display logic to not display these when workspace-chooser is opened in interact mode:

<img width="711" height="426" alt="buttons" src="https://github.com/user-attachments/assets/322bf2b1-0756-45d5-b20a-4dfa9ee13566" />
