### PR TITLE
Use fieldSerializer string to specify serializer for primitive fields

### DIFF
--- a/packages/base/date.gts
+++ b/packages/base/date.gts
@@ -4,7 +4,12 @@ import { fn } from '@ember/helper';
 import { BoxelInput } from '@cardstack/boxel-ui/components';
 import { not } from '@cardstack/boxel-ui/helpers';
 import CalendarIcon from '@cardstack/boxel-icons/calendar';
-import { DateSerializer, fieldSerializer } from '@cardstack/runtime-common';
+import {
+  type SerializerName,
+  DateSerializer,
+  fieldSerializer,
+  getSerializer,
+} from '@cardstack/runtime-common';
 
 // The Intl API is supported in all modern browsers. In older ones, we polyfill
 // it in the application route at app startup.
@@ -31,7 +36,7 @@ class View extends Component<typeof DateField> {
 export default class DateField extends FieldDef {
   static icon = CalendarIcon;
   static [primitive]: Date;
-  static [fieldSerializer] = 'date';
+  static [fieldSerializer]: SerializerName = 'date';
   static displayName = 'Date';
   static embedded = View;
   static atom = View;
@@ -59,7 +64,9 @@ export default class DateField extends FieldDef {
       if (!this.args.model) {
         return;
       }
-      return DateSerializer.serialize(this.args.model);
+      return getSerializer(DateField[fieldSerializer]).serialize(
+        this.args.model,
+      );
     }
   };
 }

--- a/packages/base/date.gts
+++ b/packages/base/date.gts
@@ -1,17 +1,10 @@
-import {
-  Component,
-  primitive,
-  serialize,
-  deserialize,
-  queryableValue,
-  FieldDef,
-} from './card-api';
+import { Component, primitive, FieldDef } from './card-api';
 import { parse } from 'date-fns';
 import { fn } from '@ember/helper';
 import { BoxelInput } from '@cardstack/boxel-ui/components';
 import { not } from '@cardstack/boxel-ui/helpers';
 import CalendarIcon from '@cardstack/boxel-icons/calendar';
-import { DateSerializer } from '@cardstack/runtime-common';
+import { DateSerializer, fieldSerializer } from '@cardstack/runtime-common';
 
 // The Intl API is supported in all modern browsers. In older ones, we polyfill
 // it in the application route at app startup.
@@ -38,12 +31,8 @@ class View extends Component<typeof DateField> {
 export default class DateField extends FieldDef {
   static icon = CalendarIcon;
   static [primitive]: Date;
+  static [fieldSerializer] = 'date';
   static displayName = 'Date';
-
-  static [serialize] = DateSerializer.serialize;
-  static [deserialize] = DateSerializer.deserialize;
-  static [queryableValue] = DateSerializer.queryableValue;
-
   static embedded = View;
   static atom = View;
 
@@ -70,7 +59,7 @@ export default class DateField extends FieldDef {
       if (!this.args.model) {
         return;
       }
-      return DateField[serialize](this.args.model);
+      return DateSerializer.serialize(this.args.model);
     }
   };
 }

--- a/packages/base/date.gts
+++ b/packages/base/date.gts
@@ -5,7 +5,6 @@ import { BoxelInput } from '@cardstack/boxel-ui/components';
 import { not } from '@cardstack/boxel-ui/helpers';
 import CalendarIcon from '@cardstack/boxel-icons/calendar';
 import {
-  type SerializerName,
   DateSerializer,
   fieldSerializer,
   getSerializer,
@@ -36,7 +35,7 @@ class View extends Component<typeof DateField> {
 export default class DateField extends FieldDef {
   static icon = CalendarIcon;
   static [primitive]: Date;
-  static [fieldSerializer]: SerializerName = 'date';
+  static [fieldSerializer] = 'date' as const;
   static displayName = 'Date';
   static embedded = View;
   static atom = View;

--- a/packages/runtime-common/constants.ts
+++ b/packages/runtime-common/constants.ts
@@ -30,6 +30,7 @@ export const realmURL = Symbol.for('cardstack-realm-url');
 export const localId = Symbol.for('cardstack-local-id');
 export const meta = Symbol.for('cardstack-meta');
 export const fields = Symbol.for('cardstack-fields');
+export const fieldSerializer = Symbol.for('cardstack-field-serializer');
 export const fieldsUntracked = Symbol.for('cardstack-fields-untracked');
 export const isBaseInstance = Symbol.for('isBaseInstance');
 

--- a/packages/runtime-common/serializers/index.ts
+++ b/packages/runtime-common/serializers/index.ts
@@ -58,7 +58,7 @@ const serializerMapping: { [name: string]: Serializer } = {
   'image-size': ImageSizeSerializer,
 };
 
-export type SerializerName =
+type SerializerName =
   | 'date'
   | 'datetime'
   | 'big-integer'

--- a/packages/runtime-common/serializers/index.ts
+++ b/packages/runtime-common/serializers/index.ts
@@ -1,8 +1,85 @@
-export * as DateSerializer from './date';
-export * as DatetimeSerializer from './datetime';
-export * as BigIntegerSerializer from './big-integer';
-export * as BooleanSerializer from './boolean';
-export * as CodeRefSerializer from './code-ref';
-export * as EthereumAddressSerializer from './ethereum-address';
-export * as NumberSerializer from './number';
-export * as ImageSizeSerializer from './image-size';
+import * as DateSerializer from './date';
+import * as DatetimeSerializer from './datetime';
+import * as BigIntegerSerializer from './big-integer';
+import * as BooleanSerializer from './boolean';
+import * as CodeRefSerializer from './code-ref';
+import * as EthereumAddressSerializer from './ethereum-address';
+import * as NumberSerializer from './number';
+import * as ImageSizeSerializer from './image-size';
+
+import { type CardDocument } from '../index';
+import {
+  type JSONAPISingleResourceDocument,
+  type SerializeOpts,
+  type BaseDef,
+  type BaseDefConstructor,
+  type BaseInstanceType,
+  type IdentityContext,
+  type DeserializeOpts,
+} from 'https://cardstack.com/base/card-api';
+
+export {
+  DateSerializer,
+  DatetimeSerializer,
+  BigIntegerSerializer,
+  BooleanSerializer,
+  CodeRefSerializer,
+  EthereumAddressSerializer,
+  NumberSerializer,
+  ImageSizeSerializer,
+};
+
+interface Serializer {
+  serialize(
+    value: any,
+    doc: JSONAPISingleResourceDocument,
+    visited?: Set<string>,
+    opts?: SerializeOpts,
+  ): any;
+  deserialize<T extends BaseDefConstructor>(
+    data: any,
+    relativeTo: URL | undefined,
+    doc?: CardDocument,
+    identityContext?: IdentityContext,
+    opts?: DeserializeOpts,
+  ): Promise<BaseInstanceType<T>>;
+  queryableValue(value: any, stack: BaseDef[]): any;
+  formatQuery?(value: any): any;
+}
+
+const serializerMapping: { [name: string]: Serializer } = {
+  date: DateSerializer,
+  datetime: DatetimeSerializer,
+  'big-integer': BigIntegerSerializer,
+  boolean: BooleanSerializer,
+  'code-ref': CodeRefSerializer,
+  'ethereum-address': EthereumAddressSerializer,
+  number: NumberSerializer,
+  'image-size': ImageSizeSerializer,
+};
+
+export type SerializerName =
+  | 'date'
+  | 'datetime'
+  | 'big-integer'
+  | 'boolean'
+  | 'code-ref'
+  | 'ethereum-address'
+  | 'number'
+  | 'image-size';
+
+export function getSerializer(name: SerializerName): Serializer {
+  assertIsSerializerName(name);
+  return serializerMapping[name];
+}
+
+export function assertIsSerializerName(
+  name: any,
+): asserts name is SerializerName {
+  if (
+    typeof name !== 'string' ||
+    !Object.keys(serializerMapping).includes(name)
+  ) {
+    throw new Error(`the name '${name}' is not a valid serializer name`);
+  }
+}

--- a/packages/runtime-common/serializers/index.ts
+++ b/packages/runtime-common/serializers/index.ts
@@ -32,7 +32,7 @@ export {
 interface Serializer {
   serialize(
     value: any,
-    doc: JSONAPISingleResourceDocument,
+    doc?: JSONAPISingleResourceDocument,
     visited?: Set<string>,
     opts?: SerializeOpts,
   ): any;


### PR DESCRIPTION
This PR adds the capability for a primitive FieldDef to provide a serializer's name instead of the actual code when specifying a serializer. We will lookup the named serializer from among our known serializers and use that. In this PR I've updated only the Date field to use this approach. After merging this PR we'll followup with all the other primitives. This capability will ultimately allow us to no longer run cards in the Realm server in subsequent PRs.