### PR TITLE
host: Add close function to pill menu header text

### DIFF
--- a/packages/host/app/components/pill-menu/index.gts
+++ b/packages/host/app/components/pill-menu/index.gts
@@ -40,7 +40,13 @@ export default class PillMenu extends Component<Signature> {
             {{yield to='headerIcon'}}
           </:icon>
           <:detail>
-            {{yield to='headerDetail'}}
+            <button
+              {{on 'click' this.collapseMenu}}
+              class='detail-close-button'
+              data-test-pill-menu-detail-close
+            >
+              {{yield to='headerDetail'}}
+            </button>
           </:detail>
           <:actions>
             <button
@@ -144,6 +150,11 @@ export default class PillMenu extends Component<Signature> {
       .header-button:focus:focus-visible {
         outline-color: var(--boxel-highlight);
       }
+
+      .detail-close-button {
+        border: none;
+      }
+
       .expandable-header-button {
         width: var(
           --boxel-pill-menu-expandable-header-button-width,

--- a/packages/matrix/tests/skills.spec.ts
+++ b/packages/matrix/tests/skills.spec.ts
@@ -150,6 +150,7 @@ test.describe('Skills', () => {
       'Skills: 3 of 4 active',
     );
 
+    await page.locator('[data-test-pill-menu-detail-close]').click();
     await expect(page.locator('[data-test-active-skills-count]')).toContainText(
       '3 Skills',
     );

--- a/packages/matrix/tests/skills.spec.ts
+++ b/packages/matrix/tests/skills.spec.ts
@@ -149,6 +149,10 @@ test.describe('Skills', () => {
     await expect(page.locator('[data-test-pill-menu-header]')).toContainText(
       'Skills: 3 of 4 active',
     );
+
+    await expect(page.locator('[data-test-active-skills-count]')).toContainText(
+      '3 Skills',
+    );
   });
 
   test('it will attach code editing skills in code mode by default', async ({


### PR DESCRIPTION
> to dismiss the skill expanded. you should be able click on the whole v Skills: 3 of 4 active, not just the caret

![screencast 2025-07-24 11-04-48](https://github.com/user-attachments/assets/e926fa86-2238-4e9b-87c2-caf37fd41b60)

I would have preferred to make the button take up the entire `header` element but the current structure gets in the way and it seemed too involved to go further.

The Percy diff is spurious and the test failures are [here too](https://github.com/cardstack/boxel/runs/46668397394).