### PR TITLE
host: Fix workspace name assertions

### DIFF
--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -1491,7 +1491,7 @@ module('Acceptance | AI Assistant tests', function (hooks) {
           url: 'http://localhost:4201/catalog/',
         },
         {
-          name: 'Cardstack Skills',
+          name: 'Boxel Skills',
           type: 'catalog-workspace',
           url: 'http://localhost:4201/skills/',
         },

--- a/packages/host/tests/integration/components/card-catalog-test.gts
+++ b/packages/host/tests/integration/components/card-catalog-test.gts
@@ -249,10 +249,7 @@ module('Integration | card-catalog', function (hooks) {
       await click(`[data-test-boxel-menu-item-text="Local Workspace"]`); // Unselect Local Workspace
       assert
         .dom('[data-test-realm-filter-button]')
-        .hasText(
-          `Workspace: Base Workspace, Cardstack Catalog, Cardstack Skills`,
-          'base realm, cardstack catalog and cardstack skills are selected',
-        );
+        .hasText(`Workspace: Base Workspace, Cardstack Catalog, Boxel Skills`);
       assert
         .dom(`[data-test-realm="Base Workspace"] [data-test-card-catalog-item]`)
         .exists({ count: baseRealmCardCount });


### PR DESCRIPTION
This fixes the failures seen [here](https://github.com/cardstack/boxel/actions/runs/16505796872/job/46677125458) due to [this `boxel-skills` change](https://github.com/cardstack/boxel-skills/commit/385e0c3140965380967544cbe24f57ff747de787). I removed an assertion text because it didn’t sufficiently differ from the assertion.