### PR TITLE
Prerender data loading

### DIFF
--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -2,11 +2,17 @@ import Route from '@ember/routing/route';
 import RouterService from '@ember/routing/router-service';
 import { service } from '@ember/service';
 
-import { isCardInstance } from '@cardstack/runtime-common';
+import {
+  isCardInstance,
+  LooseSingleCardDocument,
+} from '@cardstack/runtime-common';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 
 import LoaderService from '../services/loader-service';
+import NetworkService from '../services/network';
+import RealmService from '../services/realm';
+import RealmServerService from '../services/realm-server';
 import StoreService from '../services/store';
 
 export type Model = CardDef;
@@ -15,6 +21,9 @@ export default class RenderRoute extends Route<Model> {
   @service declare store: StoreService;
   @service declare router: RouterService;
   @service declare loaderService: LoaderService;
+  @service declare realm: RealmService;
+  @service declare realmServer: RealmServerService;
+  @service declare private network: NetworkService;
 
   async model({ id }: { id: string }) {
     // Make it easy for Puppeteer to do regular Ember transitions
@@ -24,10 +33,44 @@ export default class RenderRoute extends Route<Model> {
       this.router.transitionTo(...args);
     };
 
-    // Opt in to reading the in-progress index, as opposed to the last completed index.
+    // Opt in to reading the in-progress index, as opposed to the last completed
+    // index. This matters for any related cards that we will be loading, not
+    // for our own card, which we're going to load directly from source.
     this.loaderService.setIsIndexing(true);
 
-    let instance = await this.store.get(id);
+    let response = await this.network.authedFetch(id, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/vnd.card+source',
+      },
+    });
+
+    let realmURL = response.headers.get('x-boxel-realm-url')!;
+    let lastModified = new Date(response.headers.get('last-modified')!);
+    let doc: LooseSingleCardDocument = await response.json();
+
+    await this.realm.ensureRealmMeta(realmURL);
+
+    let enhancedDoc: LooseSingleCardDocument = {
+      ...doc,
+      data: {
+        ...doc.data,
+        id,
+        type: 'card',
+        meta: {
+          ...doc.data.meta,
+          lastModified: lastModified.getTime(),
+          realmURL,
+          realmInfo: { ...this.realm.info(id) },
+        },
+      },
+    };
+
+    let localId = await this.store.create(enhancedDoc);
+    if (typeof localId !== 'string') {
+      throw new Error('todo: failed to instantiate');
+    }
+    let instance = await this.store.get(localId);
     if (!isCardInstance(instance)) {
       throw new Error('todo: failed to load');
     }

--- a/packages/host/app/routes/render/html.ts
+++ b/packages/host/app/routes/render/html.ts
@@ -26,7 +26,7 @@ export default class RenderRoute extends Route<Model> {
     format: string;
     ancestor_level: string;
   }) {
-    let instance = this.modelFor('render') as ParentModel;
+    let { instance } = this.modelFor('render') as ParentModel;
     if (!isValidFormat(format)) {
       throw new Error('todo: invalid format');
     }

--- a/packages/host/app/routes/render/icon.ts
+++ b/packages/host/app/routes/render/icon.ts
@@ -12,7 +12,7 @@ export interface Model {
 
 export default class RenderRoute extends Route<Model> {
   async model() {
-    let instance = this.modelFor('render') as ParentModel;
+    let { instance } = this.modelFor('render') as ParentModel;
     return { Component: cardTypeIcon(instance) };
   }
 }

--- a/packages/host/app/routes/render/meta.ts
+++ b/packages/host/app/routes/render/meta.ts
@@ -25,7 +25,7 @@ export default class RenderRoute extends Route<Model> {
 
   async model() {
     let api = await this.cardService.getAPI();
-    let instance = this.modelFor('render') as ParentModel;
+    let { instance } = this.modelFor('render') as ParentModel;
 
     let serialized = api.serializeCard(instance, {
       includeComputeds: true,

--- a/packages/host/app/templates/render.gts
+++ b/packages/host/app/templates/render.gts
@@ -1,4 +1,5 @@
 import RouteTemplate from 'ember-route-template';
+
 import { Model } from '../routes/render';
 
 export default RouteTemplate<{ model: Model }>(

--- a/packages/host/app/templates/render.gts
+++ b/packages/host/app/templates/render.gts
@@ -1,11 +1,15 @@
+import { TemplateOnlyComponent } from '@ember/component/template-only';
+
 import RouteTemplate from 'ember-route-template';
 
 import { Model } from '../routes/render';
 
-export default RouteTemplate<{ model: Model }>(
-  <template>
-  <div data-prerender data-prerender-status={{if @model.ready "ready" "loading"}}>
+const Render = <template>
+  <div
+    data-prerender
+    data-prerender-status={{if @model.ready 'ready' 'loading'}}
+  >
     {{outlet}}
   </div>
-</template>,
-);
+</template> satisfies TemplateOnlyComponent<{ model: Model }>;
+export default RouteTemplate(Render);

--- a/packages/host/app/templates/render.gts
+++ b/packages/host/app/templates/render.gts
@@ -1,0 +1,10 @@
+import RouteTemplate from 'ember-route-template';
+import { Model } from '../routes/render';
+
+export default RouteTemplate<{ model: Model }>(
+  <template>
+  <div data-prerender data-prerender-status={{if @model.ready "ready" "loading"}}>
+    {{outlet}}
+  </div>
+</template>,
+);

--- a/packages/host/app/templates/render/html.gts
+++ b/packages/host/app/templates/render/html.gts
@@ -5,5 +5,5 @@ import RouteTemplate from 'ember-route-template';
 import { Model } from '../../routes/render/html';
 
 export default RouteTemplate(<template>
-  <@model.Component @format={{@model.format}} data-render-output='ready' />
+  <@model.Component @format={{@model.format}} />
 </template> satisfies TemplateOnlyComponent<{ Args: { model: Model } }>);

--- a/packages/host/app/templates/render/icon.gts
+++ b/packages/host/app/templates/render/icon.gts
@@ -5,7 +5,7 @@ import RouteTemplate from 'ember-route-template';
 import { Model } from '../../routes/render/icon';
 
 export default RouteTemplate(<template>
-  <@model.Component data-render-output='ready' />
+  <@model.Component />
 </template> satisfies TemplateOnlyComponent<{
   Args: { model: Model };
 }>);

--- a/packages/host/app/templates/render/meta.gts
+++ b/packages/host/app/templates/render/meta.gts
@@ -7,5 +7,5 @@ import { Model } from '../../routes/render/meta';
 const { stringify } = JSON;
 
 export default RouteTemplate(<template>
-  <pre data-render-output='ready'>{{stringify @model null 2}}</pre>
+  <pre>{{stringify @model null 2}}</pre>
 </template> satisfies TemplateOnlyComponent<{ Args: { model: Model } }>);

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -11,7 +11,7 @@ import {
 } from './helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 
-module.only(basename(__filename), function () {
+module(basename(__filename), function () {
   module('prerender', function (hooks) {
     let { virtualNetwork } = createVirtualNetworkAndLoader();
     let realmURL: string;

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -146,18 +146,14 @@ module.only(basename(__filename), function () {
       });
     });
 
-    module('errors', function (hooks) {
-      let result: RenderResponse;
-
-      hooks.before(async () => {
+    module('errors', function () {
+      test('error during render', async function (assert) {
         const testCardURL = `${realmURL}2`;
-        result = await prerenderCard(testCardURL);
-      });
-
-      QUnit.skip('error during render', function (assert) {
-        assert.ok(
-          /TODO: error result here/.test(result.isolatedHTML),
-          `failed to match embedded html:${JSON.stringify(result.isolatedHTML)}`,
+        assert.rejects(
+          (async () => {
+            await prerenderCard(testCardURL);
+          })(),
+          /todo: error doc/,
         );
       });
     });

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -11,7 +11,7 @@ import {
 } from './helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 
-module(basename(__filename), function () {
+module.only(basename(__filename), function () {
   module('prerender', function (hooks) {
     let { virtualNetwork } = createVirtualNetworkAndLoader();
     let realmURL: string;


### PR DESCRIPTION
Closes https://linear.app/cardstack/issue/CS-8900/consume-card-source-api-to-load-card-in-render-route and starts on the infrastructure for https://linear.app/cardstack/issue/CS-8805/capture-errordocuments-like-we-do-today-under-headless-browser