### PR TITLE
Fix loader dependency state leak

### DIFF
--- a/packages/realm-server/tests/cards/f.js
+++ b/packages/realm-server/tests/cards/f.js
@@ -1,0 +1,6 @@
+import { b } from './b';
+import { g } from './g';
+
+export function f() {
+  return b() + g();
+}

--- a/packages/realm-server/tests/cards/g.js
+++ b/packages/realm-server/tests/cards/g.js
@@ -1,0 +1,3 @@
+export function g() {
+  return 'g';
+}

--- a/packages/realm-server/tests/loader-test.ts
+++ b/packages/realm-server/tests/loader-test.ts
@@ -94,7 +94,14 @@ module(basename(__filename), function () {
 
     test('can determine consumed modules', async function (assert) {
       let loader = createLoader();
-      await loader.import<{ a(): string }>(`${testRealmHref}a`);
+      await loader.import(`${testRealmHref}f`);
+      assert.deepEqual(await loader.getConsumedModules(`${testRealmHref}f`), [
+        `${testRealmHref}b`,
+        `${testRealmHref}c`,
+        `${testRealmHref}g`,
+      ]);
+      // assert deps from f don't leak into a's deps (fixes CS-9159)
+      await loader.import(`${testRealmHref}a`);
       assert.deepEqual(await loader.getConsumedModules(`${testRealmHref}a`), [
         `${testRealmHref}b`,
         `${testRealmHref}c`,

--- a/packages/realm-server/tests/realm-endpoints-test.ts
+++ b/packages/realm-server/tests/realm-endpoints-test.ts
@@ -688,6 +688,14 @@ module(basename(__filename), function () {
                   kind: 'file',
                 },
               },
+              'f.js': {
+                links: {
+                  related: `${testRealmHref}f.js`,
+                },
+                meta: {
+                  kind: 'file',
+                },
+              },
               'family_photo_card.gts': {
                 links: {
                   related: `${testRealmHref}family_photo_card.gts`,

--- a/packages/realm-server/tests/realm-endpoints-test.ts
+++ b/packages/realm-server/tests/realm-endpoints-test.ts
@@ -728,6 +728,14 @@ module(basename(__filename), function () {
                   kind: 'file',
                 },
               },
+              'g.js': {
+                links: {
+                  related: `${testRealmHref}g.js`,
+                },
+                meta: {
+                  kind: 'file',
+                },
+              },
               'hassan-x.json': {
                 links: {
                   related: `${testRealmHref}hassan-x.json`,

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -102,7 +102,6 @@ export class Loader {
     Function,
     { module: string; name: string }
   >();
-  private consumptionCache = new WeakMap<object, string[]>();
   private static loaders = new WeakMap<Function, Loader>();
 
   private fetchImplementation: Fetch;
@@ -165,11 +164,6 @@ export class Loader {
       }
     }
     if (module?.state === 'evaluated' || module?.state === 'broken') {
-      let cached = this.consumptionCache.get(module);
-      if (cached) {
-        consumed.push(...cached);
-        return [...new Set(consumed)];
-      }
       for (let consumedModule of module?.consumedModules ?? []) {
         await this.getConsumedModules(
           consumedModule,
@@ -177,10 +171,7 @@ export class Loader {
           initialIdentifier,
         );
       }
-      cached = consumed;
-      this.consumptionCache.set(module, cached);
-
-      return [...new Set(cached)]; // Get rid of duplicates
+      return [...new Set(consumed)]; // Get rid of duplicates
     }
     return [];
   }


### PR DESCRIPTION
This PR fixes a state leak in our loader consumption graph. specifically we were caching consumption state, but that state is all predicated on what path you took to get to a specified consumed module. you can't necessarily share the same results when you are taking different paths thru the consumption graph. Also, i don't really think the consumption cache was saving much work, since we are already separately caching deps for each module (that the consumption cache was trying to optimize).