### PR TITLE
host: Fix design of Ask/Act toggle

### DIFF
--- a/packages/host/app/components/ai-assistant/llm-mode-toggle.gts
+++ b/packages/host/app/components/ai-assistant/llm-mode-toggle.gts
@@ -68,7 +68,7 @@ export default class LLMModeToggle extends Component<Signature> {
         background: var(--boxel-650);
         border-radius: var(--boxel-pill-radius, 999px);
         overflow: hidden;
-        border: 1px solid var(--boxel-400);
+        border-width: 0;
         box-shadow: none;
         padding: 3px;
       }

--- a/packages/host/app/components/ai-assistant/llm-mode-toggle.gts
+++ b/packages/host/app/components/ai-assistant/llm-mode-toggle.gts
@@ -70,8 +70,6 @@ export default class LLMModeToggle extends Component<Signature> {
         overflow: hidden;
         border: 1px solid var(--boxel-400);
         box-shadow: none;
-        width: 84px;
-        height: 30px;
         padding: 3px;
       }
       .llm-mode-option {

--- a/packages/host/app/components/ai-assistant/llm-mode-toggle.gts
+++ b/packages/host/app/components/ai-assistant/llm-mode-toggle.gts
@@ -76,6 +76,7 @@ export default class LLMModeToggle extends Component<Signature> {
         flex: 1 1 0;
         background: none;
         border: none;
+        border-radius: var(--boxel-border-radius);
         color: var(--boxel-light);
         font: 500 var(--boxel-font-xs);
         cursor: pointer;
@@ -88,7 +89,6 @@ export default class LLMModeToggle extends Component<Signature> {
         color: var(--boxel-dark);
         font-weight: 600;
         height: 100%;
-        border-radius: var(--boxel-border-radius);
       }
       .llm-mode-option:disabled {
         opacity: 0.5;

--- a/packages/host/app/components/ai-assistant/llm-mode-toggle.gts
+++ b/packages/host/app/components/ai-assistant/llm-mode-toggle.gts
@@ -70,7 +70,7 @@ export default class LLMModeToggle extends Component<Signature> {
         overflow: hidden;
         border-width: 0;
         box-shadow: none;
-        padding: 3px;
+        padding: 1.5px 2px 2px 2px;
       }
       .llm-mode-option {
         flex: 1 1 0;

--- a/packages/host/app/components/ai-assistant/llm-mode-toggle.gts
+++ b/packages/host/app/components/ai-assistant/llm-mode-toggle.gts
@@ -77,6 +77,7 @@ export default class LLMModeToggle extends Component<Signature> {
         background: none;
         border: none;
         border-radius: var(--boxel-border-radius);
+        padding-block: 2px;
         color: var(--boxel-light);
         font: 500 var(--boxel-font-xs);
         cursor: pointer;

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -295,6 +295,7 @@ export default class Room extends Component<Signature> {
 
       .llm-mode-toggle {
         margin-left: auto;
+        flex-shrink: 0;
       }
 
       :deep(.ai-assistant-conversation > *:first-child) {

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -293,6 +293,10 @@ export default class Room extends Component<Signature> {
         padding: 0;
       }
 
+      .llm-mode-toggle {
+        margin-left: auto;
+      }
+
       :deep(.ai-assistant-conversation > *:first-child) {
         margin-top: auto;
       }

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -295,6 +295,7 @@ export default class Room extends Component<Signature> {
 
       .llm-mode-toggle {
         margin-left: auto;
+        border-width: 0;
       }
 
       :deep(.ai-assistant-conversation > *:first-child) {

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -295,7 +295,6 @@ export default class Room extends Component<Signature> {
 
       .llm-mode-toggle {
         margin-left: auto;
-        border-width: 0;
       }
 
       :deep(.ai-assistant-conversation > *:first-child) {

--- a/packages/host/app/components/pill-menu/index.gts
+++ b/packages/host/app/components/pill-menu/index.gts
@@ -258,6 +258,7 @@ export default class PillMenu extends Component<Signature> {
         transform: rotate(180deg);
         transform-origin: center;
         margin-left: var(--boxel-sp-xs);
+        flex-shrink: 0;
       }
 
       @keyframes scroll-pill-menu-content {


### PR DESCRIPTION
Design:

<img width="729" height="254" alt="LATEST UI Jun 17 - LATEST UI Jun 17 - Zeplin 2025-07-28 12-42-40" src="https://github.com/user-attachments/assets/eb443c0b-a7b8-4ea5-af2c-c3ec23118f8a" />

Current implementation with 10% animation speed:

![screencast 2025-07-28 12-36-30](https://github.com/user-attachments/assets/db1bb971-e8cf-4839-950b-e547a41016ae)

Problems and discrepancies:
* flash of non-rounded background as it becomes inactive
* excessive spacing around toggle choices
* slightly-lower-than-centre-ness of choices
* light grey outer border
* element not being right-aligned

With this PR:

![screencast 2025-07-28 12-57-12](https://github.com/user-attachments/assets/71ab6c87-004a-4289-9f28-6a401201f34c)

I also included a fix for the pill menu disclosure triangle shrinking, which I noticed while working on this:

![screencast 2025-07-28 12-54-39](https://github.com/user-attachments/assets/e1c1e26d-ae25-4040-8185-1b5a34d411cc)
