### PR TITLE
CS-9178 making create listing command to be more scripted oriented

### DIFF
--- a/packages/host/app/commands/listing-create.ts
+++ b/packages/host/app/commands/listing-create.ts
@@ -30,6 +30,9 @@ import * as BaseCommandModule from 'https://cardstack.com/base/command';
 import { Spec, type SpecType } from 'https://cardstack.com/base/spec';
 
 import HostBaseCommand from '../lib/host-base-command';
+import { skillCardURL } from '../lib/utils';
+
+import UseAiAssistantCommand from './ai-assistant';
 
 import type CardService from '../services/card-service';
 import type NetworkService from '../services/network';
@@ -294,9 +297,19 @@ export default class ListingCreateCommand extends HostBaseCommand<
       },
     };
 
-    await this.store.add(listingDoc, {
+    const listing = await this.store.add(listingDoc, {
       realm: targetRealm,
-      doNotWaitForPersist: true,
+    });
+
+    await new UseAiAssistantCommand(this.commandContext).execute({
+      prompt: `Update information for the listing and redirect to the listing`,
+      roomId: 'new',
+      openRoom: true,
+      llmModel: 'anthropic/claude-sonnet-4',
+      llmMode: 'act',
+      openCardIds: [listing.id!],
+      attachedCards: [listing as CardAPI.CardDef],
+      skillCardIds: [skillCardURL('boxel-environment')],
     });
   }
 }

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
@@ -45,7 +45,7 @@ import {
   type PrerenderedCardLike,
 } from '@cardstack/runtime-common';
 
-import ListingInitCommand from '@cardstack/host/commands/listing-action-init';
+import ListingCreateCommand from '@cardstack/host/commands/listing-create';
 import SendAiAssistantMessageCommand from '@cardstack/host/commands/send-ai-assistant-message';
 import consumeContext from '@cardstack/host/helpers/consume-context';
 
@@ -825,9 +825,8 @@ export default class PlaygroundPanel extends Component<Signature> {
 
   private createListingWithAI = restartableTask(async () => {
     let { commandContext } = this.commandService;
-    await new ListingInitCommand(commandContext).execute({
-      actionType: 'create',
-      attachedCard: this.card ? this.card : undefined,
+    await new ListingCreateCommand(commandContext).execute({
+      openCardId: this.card?.id,
     });
   });
 

--- a/packages/host/tests/acceptance/catalog-app-test.gts
+++ b/packages/host/tests/acceptance/catalog-app-test.gts
@@ -149,26 +149,6 @@ module('Acceptance | Catalog | catalog app tests', function (hooks) {
                   self: '../Spec/author',
                 },
               },
-              publisher: {
-                links: {
-                  self: null,
-                },
-              },
-              'categories.0': {
-                links: {
-                  self: null,
-                },
-              },
-              'tags.0': {
-                links: {
-                  self: null,
-                },
-              },
-              license: {
-                links: {
-                  self: null,
-                },
-              },
               'examples.0': {
                 links: {
                   self: '../author/Author/example',


### PR DESCRIPTION
Refer to https://linear.app/cardstack/issue/CS-9178/create-listing-command-to-be-scripted-until-the-need-of-ai-bot

### What is changing
- get rid the need of catalog skill in order to trigger create listing command
- only ask AI operation when needed, eg: update card details