### PR TITLE
Open index card when bottom-most card is closed

### DIFF
--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -309,12 +309,9 @@ export default class OperatorModeStateService extends Service {
         });
     }
 
-    const realmURL =
-      this.realm.realmOfURL(new URL(item.id))?.href ?? this.realmURL.href;
-    // Check if the trimmed item is an index card
-    const isIndexCard = this.isIndexCard(realmURL, item);
-
     if (this._state.stacks.length === 0) {
+      const realmURL = this.getRealmURLFromItemId(item.id);
+      const isIndexCard = this.isIndexCard(realmURL, item);
       if (isIndexCard) {
         // Only open workspace chooser if the trimmed item was an index card
         this._state.workspaceChooserOpened = true;
@@ -395,6 +392,15 @@ export default class OperatorModeStateService extends Service {
     }
 
     return this._state.trail[this._state.trail.length - 1];
+  }
+
+  private getRealmURLFromItemId(itemId: string): string {
+    try {
+      const url = new URL(itemId);
+      return this.realm.realmOfURL(url)?.href ?? this.realmURL.href;
+    } catch (error) {
+      return this.realmURL.href;
+    }
   }
 
   private isIndexCard(realmURL: string, item: StackItem): boolean {

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -309,8 +309,10 @@ export default class OperatorModeStateService extends Service {
         });
     }
 
+    const realmURL =
+      this.realm.realmOfURL(new URL(item.id))?.href ?? this.realmURL.href;
     // Check if the trimmed item is an index card
-    const isIndexCard = this.isIndexCard(item);
+    const isIndexCard = this.isIndexCard(realmURL, item);
 
     if (this._state.stacks.length === 0) {
       if (isIndexCard) {
@@ -318,8 +320,6 @@ export default class OperatorModeStateService extends Service {
         this._state.workspaceChooserOpened = true;
       } else {
         // If the trimmed item was not an index card, add an index card to the stack
-        let realmURL =
-          this.realm.realmOfURL(new URL(item.id))?.href ?? this.realmURL.href;
         const indexCardId = `${realmURL}index`;
         const indexCardItem = this.createStackItem(indexCardId, 0);
         this.addItemToStack(indexCardItem);
@@ -397,9 +397,9 @@ export default class OperatorModeStateService extends Service {
     return this._state.trail[this._state.trail.length - 1];
   }
 
-  private isIndexCard(item: StackItem): boolean {
+  private isIndexCard(realmURL: string, item: StackItem): boolean {
     const itemUrl = item.id;
-    return itemUrl === `${this.realmURL.href}index`;
+    return itemUrl === `${realmURL}index`;
   }
 
   get isViewingCardInCodeMode() {

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -318,7 +318,9 @@ export default class OperatorModeStateService extends Service {
         this._state.workspaceChooserOpened = true;
       } else {
         // If the trimmed item was not an index card, add an index card to the stack
-        const indexCardId = `${this.realmURL.href}index`;
+        let realmURL =
+          this.realm.realmOfURL(new URL(item.id))?.href ?? this.realmURL.href;
+        const indexCardId = `${realmURL}index`;
         const indexCardItem = this.createStackItem(indexCardId, 0);
         this.addItemToStack(indexCardItem);
       }

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -309,8 +309,19 @@ export default class OperatorModeStateService extends Service {
         });
     }
 
+    // Check if the trimmed item is an index card
+    const isIndexCard = this.isIndexCard(item);
+
     if (this._state.stacks.length === 0) {
-      this._state.workspaceChooserOpened = true;
+      if (isIndexCard) {
+        // Only open workspace chooser if the trimmed item was an index card
+        this._state.workspaceChooserOpened = true;
+      } else {
+        // If the trimmed item was not an index card, add an index card to the stack
+        const indexCardId = `${this.realmURL.href}index`;
+        const indexCardItem = this.createStackItem(indexCardId, 0);
+        this.addItemToStack(indexCardItem);
+      }
     }
 
     this.schedulePersist();
@@ -382,6 +393,11 @@ export default class OperatorModeStateService extends Service {
     }
 
     return this._state.trail[this._state.trail.length - 1];
+  }
+
+  private isIndexCard(item: StackItem): boolean {
+    const itemUrl = item.id;
+    return itemUrl === `${this.realmURL.href}index`;
   }
 
   get isViewingCardInCodeMode() {

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -1675,7 +1675,10 @@ module('Acceptance | interact submode tests', function (hooks) {
         '[data-test-operator-mode-stack="0"] [data-test-close-button]',
       );
 
-      assert.dom('[data-test-workspace-chooser]').exists();
+      assert
+        .dom(`[data-test-stack-card="${testRealmURL}Person/fadhlan"]`)
+        .doesNotExist();
+      assert.dom(`[data-test-stack-card="${testRealmURL}index"]`).exists();
     });
 
     test<TestContextWithSave>('can create a card when 2 stacks are present', async function (assert) {

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -2111,7 +2111,7 @@ module('Acceptance | interact submode tests', function (hooks) {
         .dom(
           '[data-test-stack-card-index="0"] [data-test-boxel-card-header-title]',
         )
-        .hasText('Workspace - Test Workspace A');
+        .hasText('Workspace - Test Workspace B');
       assert.dom('[data-test-workspace-chooser]').doesNotExist();
 
       // Close the index card

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -2081,5 +2081,42 @@ module('Acceptance | interact submode tests', function (hooks) {
       await click('[data-test-more-options-button]');
       assert.dom('[data-test-boxel-menu-item-text="Delete"]').doesNotExist();
     });
+
+    test('opens index card when non-index card is closed and workspace chooser opens when index card is closed', async function (assert) {
+      // Start with a non-index card in the stack
+      await visitOperatorMode({
+        stacks: [
+          [
+            {
+              id: `${testRealmURL}Person/fadhlan`,
+              format: 'isolated',
+            },
+          ],
+        ],
+      });
+
+      // Verify the non-index card is displayed
+      assert.dom('[data-test-stack-card-index="0"]').includesText('Fadhlan');
+      assert.dom('[data-test-workspace-chooser]').doesNotExist();
+
+      // Close the non-index card
+      await click('[data-test-stack-card-index="0"] [data-test-close-button]');
+
+      // Verify that an index card is automatically added to the stack
+      assert.dom('[data-test-stack-card-index="0"]').exists();
+      assert
+        .dom(
+          '[data-test-stack-card-index="0"] [data-test-boxel-card-header-title]',
+        )
+        .hasText('Workspace - Test Workspace A');
+      assert.dom('[data-test-workspace-chooser]').doesNotExist();
+
+      // Close the index card
+      await click('[data-test-stack-card-index="0"] [data-test-close-button]');
+
+      // Verify that the workspace chooser opens
+      assert.dom('[data-test-workspace-chooser]').exists();
+      assert.dom('[data-test-operator-mode-stack]').doesNotExist();
+    });
   });
 });

--- a/packages/host/tests/integration/components/ai-assistant-panel/commands-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/commands-test.gts
@@ -910,7 +910,8 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
     assert.dom(`[data-test-stack-card="${id}"]`).exists();
     await click('[data-test-close-button]'); // close the last open card
     assert.dom(`[data-test-stack-card="${id}"]`).doesNotExist();
-    assert.dom('[data-test-workspace-chooser]').exists();
+    assert.dom(`[data-test-stack-card="${testRealmURL}index"]`).exists();
+    await click('[data-test-close-button]'); // close index card
     assert
       .dom('[data-test-message-idx="0"] [data-test-boxel-card-header-title]')
       .containsText('Search Results');

--- a/packages/host/tests/integration/components/ask-ai-test.gts
+++ b/packages/host/tests/integration/components/ask-ai-test.gts
@@ -156,7 +156,7 @@ module('Integration | ask-ai', function (hooks) {
 
   test('can send message to AI Assistant from workspace chooser', async function (assert) {
     operatorModeStateService.restore({
-      stacks: [[{ id: `${testRealmURL}Pet/marco`, format: 'isolated' }]],
+      stacks: [[{ id: `${testRealmURL}index`, format: 'isolated' }]],
     });
     await renderComponent(
       class TestDriver extends GlimmerComponent {
@@ -166,7 +166,7 @@ module('Integration | ask-ai', function (hooks) {
         </template>
       },
     );
-    await click('[data-test-close-button]');
+    await click('[data-test-close-button]'); // close last card
     assert.dom('[data-test-workspace-chooser]').exists();
     assert.dom('[data-test-ask-ai-label]').exists();
     assert.dom('[data-test-ask-ai-input]').hasNoValue();

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -782,11 +782,10 @@ module('Integration | operator-mode', function (hooks) {
           .includesText('Delete the card Hassan?');
         await click('[data-test-confirm-delete-button]');
 
-        await waitUntil(
-          () => !document.querySelector('[data-test-stack-card]'),
-        );
-        assert.dom('[data-test-stack-card]').doesNotExist();
-        assert.dom('[data-test-workspace-list]').exists();
+        assert
+          .dom(`[data-test-stack-card="${testRealmURL}FriendWithCSS/friend-a"]`)
+          .doesNotExist();
+        assert.dom(`[data-test-stack-card="${testRealmURL}index"]`).exists();
       });
     },
   );
@@ -1013,9 +1012,10 @@ module('Integration | operator-mode', function (hooks) {
     assert.dom('[data-test-person]').isVisible();
 
     await click('[data-test-close-button]');
-    await waitUntil(() => !document.querySelector('[data-test-stack-card]'));
-    assert.dom('[data-test-person]').isNotVisible();
-    assert.dom('[data-test-workspace-chooser]').isVisible();
+    assert
+      .dom(`[data-test-stack-card="${testRealmURL}Person/fadhlan"]`)
+      .doesNotExist();
+    assert.dom(`[data-test-stack-card="${testRealmURL}index"]`).exists();
     await percySnapshot(assert);
   });
 


### PR DESCRIPTION
Modified workspace chooser behavior to only open when index cards are closed. When non-index cards are closed, an index card is automatically added to the stack instead. Added test coverage for this new behavior.


https://github.com/user-attachments/assets/7d13ab65-cca0-4562-8775-f8e0a7c8024a

