### PR TITLE
host: Fix host mode detection of card-fetch errors

### DIFF
--- a/packages/host/app/templates/card.gts
+++ b/packages/host/app/templates/card.gts
@@ -17,6 +17,7 @@ import {
   GetCardContextName,
   GetCardsContextName,
   GetCardCollectionContextName,
+  isCardErrorJSONAPI,
 } from '@cardstack/runtime-common';
 import { meta } from '@cardstack/runtime-common/constants';
 
@@ -120,7 +121,3 @@ class HostModeComponent extends Component<HostModeComponentSignature> {
 }
 
 export default RouteTemplate(HostModeComponent);
-
-function isCardErrorJSONAPI(model: any): model is CardErrorJSONAPI {
-  return model.status;
-}


### PR DESCRIPTION
This uses the existing function to determine a `getCard` failure, as `status` is an attribute on this card so it was rendering as an error:

<img width="2828" height="2108" alt="84ebb780-67dd-4e7e-a7c2-8fe817aade35 2025-07-31 09-52-14" src="https://github.com/user-attachments/assets/20c4f968-091c-4735-950b-e2923db94796" />
