### PR TITLE
Cleanup unused `private declare` class fields

### DIFF
--- a/packages/host/app/components/ai-assistant/panel.gts
+++ b/packages/host/app/components/ai-assistant/panel.gts
@@ -1,7 +1,6 @@
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import type Owner from '@ember/owner';
-import RouterService from '@ember/routing/router-service';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked, cached } from '@glimmer/tracking';
@@ -24,9 +23,7 @@ import { ResolvedCodeRef, aiBotUsername } from '@cardstack/runtime-common';
 import ENV from '@cardstack/host/config/environment';
 
 import AiAssistantPanelService from '@cardstack/host/services/ai-assistant-panel-service';
-import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
-import CommandService from '../../services/command-service';
 import { type MonacoSDK } from '../../services/monaco-service';
 import NewSession from '../ai-assistant/new-session';
 
@@ -395,9 +392,6 @@ export default class AiAssistantPanel extends Component<Signature> {
 
   @service private declare matrixService: MatrixService;
   @service private declare monacoService: MonacoService;
-  @service private declare router: RouterService;
-  @service private declare commandService: CommandService;
-  @service private declare operatorModeStateService: OperatorModeStateService;
   @service private declare aiAssistantPanelService: AiAssistantPanelService;
 
   @tracked private maybeMonacoSDK: MonacoSDK | undefined;

--- a/packages/host/app/components/card-catalog/modal.gts
+++ b/packages/host/app/components/card-catalog/modal.gts
@@ -57,7 +57,6 @@ import CardCatalogFilters from './filters';
 
 import CardCatalog, { type NewCardArgs } from './index';
 
-import type CardService from '../../services/card-service';
 import type LoaderService from '../../services/loader-service';
 import type OperatorModeStateService from '../../services/operator-mode-state-service';
 import type RealmService from '../../services/realm';
@@ -230,7 +229,6 @@ export default class CardCatalogModal extends Component<Signature> {
 
   private stateStack: State[] = new TrackedArray<State>();
   private stateId = 0;
-  @service private declare cardService: CardService;
   @service private declare loaderService: LoaderService;
   @service private declare operatorModeStateService: OperatorModeStateService;
   @service private declare realmServer: RealmServerService;

--- a/packages/host/app/components/card-prerender.gts
+++ b/packages/host/app/components/card-prerender.gts
@@ -17,7 +17,6 @@ import {
 
 import { CurrentRun } from '../lib/current-run';
 
-import type LoaderService from '../services/loader-service';
 import type LocalIndexer from '../services/local-indexer';
 import type NetworkService from '../services/network';
 import type RenderService from '../services/render-service';
@@ -26,7 +25,6 @@ import type RenderService from '../services/render-service';
 // server-side rendering for indexing as well as by the TestRealm
 // to perform rendering for indexing in Ember test contexts.
 export default class CardPrerender extends Component {
-  @service private declare loaderService: LoaderService;
   @service private declare network: NetworkService;
   @service private declare renderService: RenderService;
   @service private declare fastboot: { isFastBoot: boolean };

--- a/packages/host/app/components/editor/file-tree.gts
+++ b/packages/host/app/components/editor/file-tree.gts
@@ -52,7 +52,6 @@ export default class FileTree extends Component<Signature> {
     </style>
   </template>
 
-
   @tracked private showMask = true;
 
   constructor(owner: Owner, args: Signature['Args']) {

--- a/packages/host/app/components/editor/file-tree.gts
+++ b/packages/host/app/components/editor/file-tree.gts
@@ -1,15 +1,11 @@
 import type Owner from '@ember/owner';
-import type RouterService from '@ember/routing/router-service';
 
-import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 import { restartableTask, timeout } from 'ember-concurrency';
 
 import { type LocalPath } from '@cardstack/runtime-common';
-
-import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 import Directory from './directory';
 
@@ -56,8 +52,6 @@ export default class FileTree extends Component<Signature> {
     </style>
   </template>
 
-  @service private declare router: RouterService;
-  @service private declare operatorModeStateService: OperatorModeStateService;
 
   @tracked private showMask = true;
 

--- a/packages/host/app/components/matrix/register-user.gts
+++ b/packages/host/app/components/matrix/register-user.gts
@@ -3,7 +3,6 @@ import { on } from '@ember/modifier';
 
 import { action } from '@ember/object';
 
-import RouterService from '@ember/routing/router-service';
 
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -307,7 +306,6 @@ export default class RegisterUser extends Component<Signature> {
       }
     </style>
   </template>
-  @service private declare router: RouterService;
   @tracked private email = '';
   @tracked private name = '';
   @tracked private username = '';

--- a/packages/host/app/components/matrix/register-user.gts
+++ b/packages/host/app/components/matrix/register-user.gts
@@ -3,7 +3,6 @@ import { on } from '@ember/modifier';
 
 import { action } from '@ember/object';
 
-
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 

--- a/packages/host/app/components/matrix/room-message.gts
+++ b/packages/host/app/components/matrix/room-message.gts
@@ -22,9 +22,7 @@ import consumeContext from '@cardstack/host/helpers/consume-context';
 import MessageCommand from '@cardstack/host/lib/matrix-classes/message-command';
 import { type RoomResource } from '@cardstack/host/resources/room';
 import CommandService from '@cardstack/host/services/command-service';
-import type MatrixService from '@cardstack/host/services/matrix-service';
 import { type MonacoSDK } from '@cardstack/host/services/monaco-service';
-import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 import AiAssistantMessage from '../ai-assistant/message';
 import { aiBotUserId } from '../ai-assistant/panel';
@@ -184,8 +182,6 @@ export default class RoomMessage extends Component<Signature> {
     {{/if}}
   </template>
 
-  @service private declare operatorModeStateService: OperatorModeStateService;
-  @service private declare matrixService: MatrixService;
   @service declare commandService: CommandService;
 
   knownErrorMessagePrefixes: { [errorMessagePrefix: string]: string }[] = [

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -52,7 +52,6 @@ import { RoomResource } from '@cardstack/host/resources/room';
 
 import type CardService from '@cardstack/host/services/card-service';
 import type CommandService from '@cardstack/host/services/command-service';
-import type LoaderService from '@cardstack/host/services/loader-service';
 import type MatrixService from '@cardstack/host/services/matrix-service';
 import { type MonacoSDK } from '@cardstack/host/services/monaco-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
@@ -342,7 +341,6 @@ export default class Room extends Component<Signature> {
   @service private declare commandService: CommandService;
   @service private declare matrixService: MatrixService;
   @service private declare operatorModeStateService: OperatorModeStateService;
-  @service private declare loaderService: LoaderService;
   @service private declare playgroundPanelService: PlaygroundPanelService;
   @service private declare specPanelService: SpecPanelService;
 

--- a/packages/host/app/components/operator-mode/card-url-bar.gts
+++ b/packages/host/app/components/operator-mode/card-url-bar.gts
@@ -14,7 +14,6 @@ import URLBarResource, {
 
 import type RealmService from '@cardstack/host/services/realm';
 
-import type CardService from '../../services/card-service';
 import type OperatorModeStateService from '../../services/operator-mode-state-service';
 
 interface Signature {
@@ -180,7 +179,6 @@ export default class CardURLBar extends Component<Signature> {
   </template>
 
   @service private declare operatorModeStateService: OperatorModeStateService;
-  @service private declare cardService: CardService;
   @service private declare realm: RealmService;
 
   private urlBar: URLBarResource = urlBarResource(this, () => ({

--- a/packages/host/app/components/operator-mode/code-editor.gts
+++ b/packages/host/app/components/operator-mode/code-editor.gts
@@ -36,7 +36,6 @@ import {
 } from '@cardstack/host/resources/module-contents';
 
 import { type ModuleAnalysis } from '@cardstack/host/resources/module-contents';
-import type CardService from '@cardstack/host/services/card-service';
 import type { SaveType } from '@cardstack/host/services/card-service';
 import type EnvironmentService from '@cardstack/host/services/environment-service';
 import type MonacoService from '@cardstack/host/services/monaco-service';
@@ -67,7 +66,6 @@ const log = logger('component:code-editor');
 export default class CodeEditor extends Component<Signature> {
   @service private declare monacoService: MonacoService;
   @service private declare operatorModeStateService: OperatorModeStateService;
-  @service private declare cardService: CardService;
   @service private declare environmentService: EnvironmentService;
   @service private declare recentFilesService: RecentFilesService;
   @service private declare store: StoreService;

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -50,8 +50,6 @@ import {
 } from '@cardstack/host/resources/module-contents';
 import type CardService from '@cardstack/host/services/card-service';
 import type CodeSemanticsService from '@cardstack/host/services/code-semantics-service';
-import type EnvironmentService from '@cardstack/host/services/environment-service';
-import type LoaderService from '@cardstack/host/services/loader-service';
 import type { FileView } from '@cardstack/host/services/operator-mode-state-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 import type PlaygroundPanelService from '@cardstack/host/services/playground-panel-service';
@@ -137,9 +135,7 @@ export default class CodeSubmode extends Component<Signature> {
   @service private declare operatorModeStateService: OperatorModeStateService;
   @service private declare playgroundPanelService: PlaygroundPanelService;
   @service private declare recentFilesService: RecentFilesService;
-  @service private declare environmentService: EnvironmentService;
   @service private declare realm: RealmService;
-  @service private declare loaderService: LoaderService;
   @service private declare specPanelService: SpecPanelService;
 
   @tracked private loadFileError: string | null = null;

--- a/packages/host/app/components/operator-mode/code-submode/left-panel-toggle.gts
+++ b/packages/host/app/components/operator-mode/code-submode/left-panel-toggle.gts
@@ -12,7 +12,6 @@ import RealmDropdown from '@cardstack/host/components/realm-dropdown';
 import RestoreScrollPosition from '@cardstack/host/modifiers/restore-scroll-position';
 import type { FileView } from '@cardstack/host/services/operator-mode-state-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
-import RealmService from '@cardstack/host/services/realm';
 import type RecentFilesService from '@cardstack/host/services/recent-files-service';
 
 import InnerContainer from './inner-container';
@@ -35,7 +34,6 @@ interface Signature {
 
 export default class CodeSubmodeLeftPanelToggle extends Component<Signature> {
   @service declare operatorModeStateService: OperatorModeStateService;
-  @service private declare realm: RealmService;
   @service private declare recentFilesService: RecentFilesService;
 
   private notifyFileBrowserIsVisible: (() => void) | undefined;

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -33,7 +33,6 @@ import CardRenderer from '@cardstack/host/components/card-renderer';
 import { urlForRealmLookup } from '@cardstack/host/lib/utils';
 import { type ModuleDeclaration } from '@cardstack/host/resources/module-contents';
 
-import type LoaderService from '@cardstack/host/services/loader-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 import type { ModuleInspectorView } from '@cardstack/host/services/operator-mode-state-service';
 import type RealmService from '@cardstack/host/services/realm';
@@ -348,7 +347,6 @@ const SpecPreviewLoading: TemplateOnlyComponent<SpecPreviewLoadingSignature> =
 export default class SpecPreview extends GlimmerComponent<Signature> {
   @service private declare operatorModeStateService: OperatorModeStateService;
   @service private declare realm: RealmService;
-  @service private declare loaderService: LoaderService;
   @service private declare recentFilesService: RecentFilesService;
   @service private declare specPanelService: SpecPanelService;
   @service private declare store: StoreService;

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -37,7 +37,6 @@ import { Submodes } from '../submode-switcher';
 
 import ChooseFileModal from './choose-file-modal';
 
-import type BillingService from '../../services/billing-service';
 import type CardService from '../../services/card-service';
 import type MatrixService from '../../services/matrix-service';
 import type OperatorModeStateService from '../../services/operator-mode-state-service';
@@ -52,7 +51,6 @@ interface Signature {
 }
 
 export default class OperatorModeContainer extends Component<Signature> {
-  @service private declare billingService: BillingService;
   @service private declare cardService: CardService;
   @service declare matrixService: MatrixService;
   @service private declare operatorModeStateService: OperatorModeStateService;

--- a/packages/host/app/components/operator-mode/copy-button.gts
+++ b/packages/host/app/components/operator-mode/copy-button.gts
@@ -24,8 +24,6 @@ import type { CardDef } from 'https://cardstack.com/base/card-api';
 
 import consumeContext from '../../helpers/consume-context';
 
-import type CardService from '../../services/card-service';
-import type LoaderService from '../../services/loader-service';
 import type OperatorModeStateService from '../../services/operator-mode-state-service';
 
 interface Signature {
@@ -115,8 +113,6 @@ export default class CopyButton extends Component<Signature> {
 
   @consume(GetCardCollectionContextName)
   private declare getCardCollection: getCardCollection;
-  @service private declare loaderService: LoaderService;
-  @service private declare cardService: CardService;
   @service private declare operatorModeStateService: OperatorModeStateService;
   @tracked private topMostCardCollection:
     | ReturnType<getCardCollection>

--- a/packages/host/app/components/operator-mode/host-submode.gts
+++ b/packages/host/app/components/operator-mode/host-submode.gts
@@ -6,7 +6,6 @@ import Component from '@glimmer/component';
 import { BoxelButton, CardContainer } from '@cardstack/boxel-ui/components';
 
 import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
-import Store from '@cardstack/host/services/store';
 
 import SubmodeLayout from './submode-layout';
 
@@ -17,7 +16,6 @@ interface HostSubmodeSignature {
 
 export default class HostSubmode extends Component<HostSubmodeSignature> {
   @service private declare operatorModeStateService: OperatorModeStateService;
-  @service private declare store: Store;
 
   <template>
     <SubmodeLayout

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -62,8 +62,6 @@ import { StackItem } from '@cardstack/host/lib/stack-item';
 
 import { stackBackgroundsResource } from '@cardstack/host/resources/stack-backgrounds';
 
-import type MatrixService from '@cardstack/host/services/matrix-service';
-
 import type {
   CardContext,
   CardDef,
@@ -133,7 +131,6 @@ export default class InteractSubmode extends Component {
 
   @service private declare cardService: CardService;
   @service private declare commandService: CommandService;
-  @service private declare matrixService: MatrixService;
   @service private declare operatorModeStateService: OperatorModeStateService;
   @service private declare store: StoreService;
   @service private declare realm: Realm;

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -69,8 +69,6 @@ import CardError from './card-error';
 import OperatorModeOverlays from './operator-mode-overlays';
 
 import type CardService from '../../services/card-service';
-import type EnvironmentService from '../../services/environment-service';
-import type LoaderService from '../../services/loader-service';
 import type OperatorModeStateService from '../../services/operator-mode-state-service';
 import type RealmService from '../../services/realm';
 import type StoreService from '../../services/store';
@@ -120,10 +118,8 @@ export default class OperatorModeStackItem extends Component<Signature> {
   private declare getCardCollection: getCardCollection;
 
   @service private declare cardService: CardService;
-  @service private declare environmentService: EnvironmentService;
   @service private declare operatorModeStateService: OperatorModeStateService;
   @service private declare realm: RealmService;
-  @service private declare loaderService: LoaderService;
   @service private declare store: StoreService;
 
   @tracked private selectedCards = new TrackedArray<CardDefOrId>([]);

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -2,7 +2,6 @@ import { hash } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 
-import type RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
 
 import Component from '@glimmer/component';
@@ -52,7 +51,6 @@ import NewFileButton, { type NewFileOptions } from './new-file-button';
 import WorkspaceChooser from './workspace-chooser';
 
 import type AiAssistantPanelService from '../../services/ai-assistant-panel-service';
-import type CommandService from '../../services/command-service';
 import type MatrixService from '../../services/matrix-service';
 import type OperatorModeStateService from '../../services/operator-mode-state-service';
 import type StoreService from '../../services/store';
@@ -105,10 +103,8 @@ export default class SubmodeLayout extends Component<Signature> {
     defaultWidth: 30,
     minWidth: 25,
   });
-  @service private declare commandService: CommandService;
   @service private declare operatorModeStateService: OperatorModeStateService;
   @service private declare matrixService: MatrixService;
-  @service private declare router: RouterService;
   @service private declare store: StoreService;
   @service private declare aiAssistantPanelService: AiAssistantPanelService;
 

--- a/packages/host/app/components/operator-mode/workspace-chooser/workspace.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/workspace.gts
@@ -10,7 +10,6 @@ import { RealmIcon } from '@cardstack/boxel-ui/components';
 import { cssVar } from '@cardstack/boxel-ui/helpers';
 import { Group, IconGlobe, Lock } from '@cardstack/boxel-ui/icons';
 
-import CardService from '@cardstack/host/services/card-service';
 import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 import RealmService from '@cardstack/host/services/realm';
 
@@ -121,7 +120,6 @@ export default class Workspace extends Component<Signature> {
     </style>
   </template>
 
-  @service private declare cardService: CardService;
   @service private declare operatorModeStateService: OperatorModeStateService;
   @service private declare realm: RealmService;
 

--- a/packages/host/app/components/pill-menu/usage.gts
+++ b/packages/host/app/components/pill-menu/usage.gts
@@ -5,13 +5,11 @@ import { tracked } from '@glimmer/tracking';
 
 import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
 
-
 import headerIcon from '../ai-assistant/ai-assist-icon@2x.webp';
 
 import PillMenu from './index';
 
 export default class PillMenuUsage extends Component {
-
   @tracked private title = 'Pill Menu';
   private headerIconURL = headerIcon;
 

--- a/packages/host/app/components/pill-menu/usage.gts
+++ b/packages/host/app/components/pill-menu/usage.gts
@@ -1,19 +1,16 @@
 import { fn } from '@ember/helper';
 import { action } from '@ember/object';
-import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
 
-import type StoreService from '@cardstack/host/services/store';
 
 import headerIcon from '../ai-assistant/ai-assist-icon@2x.webp';
 
 import PillMenu from './index';
 
 export default class PillMenuUsage extends Component {
-  @service private declare store: StoreService;
 
   @tracked private title = 'Pill Menu';
   private headerIconURL = headerIcon;

--- a/packages/host/app/components/search-sheet/index.gts
+++ b/packages/host/app/components/search-sheet/index.gts
@@ -25,7 +25,6 @@ import { IconSearch } from '@cardstack/boxel-ui/icons';
 
 import { type getCard, GetCardContextName } from '@cardstack/runtime-common';
 
-
 import RealmServerService from '@cardstack/host/services/realm-server';
 
 import CardQueryResults from './card-query-results';
@@ -33,7 +32,6 @@ import CardURLResults from './card-url-results';
 
 import RecentCardsSection from './recent-cards-section';
 import { getCodeRefFromSearchKey } from './utils';
-
 
 import type StoreService from '../../services/store';
 

--- a/packages/host/app/components/search-sheet/index.gts
+++ b/packages/host/app/components/search-sheet/index.gts
@@ -25,7 +25,6 @@ import { IconSearch } from '@cardstack/boxel-ui/icons';
 
 import { type getCard, GetCardContextName } from '@cardstack/runtime-common';
 
-import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 import RealmServerService from '@cardstack/host/services/realm-server';
 
@@ -35,7 +34,6 @@ import CardURLResults from './card-url-results';
 import RecentCardsSection from './recent-cards-section';
 import { getCodeRefFromSearchKey } from './utils';
 
-import type LoaderService from '../../services/loader-service';
 
 import type StoreService from '../../services/store';
 
@@ -78,8 +76,6 @@ export default class SearchSheet extends Component<Signature> {
 
   @tracked private searchKey = '';
 
-  @service private declare operatorModeStateService: OperatorModeStateService;
-  @service private declare loaderService: LoaderService;
   @service private declare realmServer: RealmServerService;
   @service private declare store: StoreService;
 

--- a/packages/host/tests/acceptance/commands-test.gts
+++ b/packages/host/tests/acceptance/commands-test.gts
@@ -1,6 +1,5 @@
 import { on } from '@ember/modifier';
 import { getOwner, setOwner } from '@ember/owner';
-import { service } from '@ember/service';
 import {
   click,
   waitFor,
@@ -43,9 +42,6 @@ import {
   waitForCompletedCommandRequest,
   waitForRealmState,
 } from '@cardstack/host/commands/utils';
-import type LoaderService from '@cardstack/host/services/loader-service';
-
-import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 import type { SearchCardsByTypeAndTitleInput } from 'https://cardstack.com/base/command';
 
@@ -156,9 +152,6 @@ module('Acceptance | Commands tests', function (hooks) {
     }
 
     class ScheduleMeetingCommand extends Command<typeof ScheduleMeetingInput> {
-      @service private declare loaderService: LoaderService;
-      @service
-      private declare operatorModeStateService: OperatorModeStateService;
       static displayName = 'ScheduleMeetingCommand';
       static actionVerb = 'Schedule';
 


### PR DESCRIPTION
I noticed we have a lot of unused private class fields because (1) to use class field decorators you generally need to add the `declare` keyword, but (2) the `declare` keyword seems to opt you out of getting an error from typescript if the resulting private field is unused.

I generated this PR by asking Claude code to find and fix them all. Going to let CI run to see if it did a good job.