### PR TITLE
Hide stack trace from Percy since it's not deterministic

### DIFF
--- a/packages/host/app/components/operator-mode/error-display.gts
+++ b/packages/host/app/components/operator-mode/error-display.gts
@@ -124,7 +124,7 @@ export default class ErrorDisplay extends Component<Signature> {
           <div class='detail-item'>
             <div class='detail-title'>Stack trace:</div>
             {{#if @stack}}
-              <pre data-test-error-stack>{{@stack}}</pre>
+              <pre data-test-error-stack data-test-percy-hide>{{@stack}}</pre>
             {{else}}
               <p class='no-stack-message'>No stack trace is available. This
                 could be because the error occurred in a context where stack


### PR DESCRIPTION
This is likely to change between Percy runs so let's hide it from Percy:

<img width="511" height="553" alt="image" src="https://github.com/user-attachments/assets/7155bcb0-27e8-4899-b742-18be3a423bd3" />
