### PR TITLE
Add full reindex script and grafana endpoint

### DIFF
--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -7,6 +7,7 @@ import {
   triggerKeyEvent,
   settled,
   waitUntil,
+  waitFor,
 } from '@ember/test-helpers';
 
 import { triggerEvent } from '@ember/test-helpers';
@@ -2118,6 +2119,7 @@ module('Acceptance | interact submode tests', function (hooks) {
       await click('[data-test-stack-card-index="0"] [data-test-close-button]');
 
       // Verify that the workspace chooser opens
+      await waitFor('[data-test-workspace-chooser]');
       assert.dom('[data-test-workspace-chooser]').exists();
       assert.dom('[data-test-operator-mode-stack]').doesNotExist();
     });

--- a/packages/realm-server/handlers/handle-full-reindex.ts
+++ b/packages/realm-server/handlers/handle-full-reindex.ts
@@ -1,5 +1,8 @@
 import Koa from 'koa';
-import { SupportedMimeType } from '@cardstack/runtime-common';
+import {
+  SupportedMimeType,
+  systemInitiatedPriority,
+} from '@cardstack/runtime-common';
 import { setContextResponse } from '../middleware';
 import { type CreateRoutesArgs } from '../routes';
 import { reindex } from './handle-reindex';
@@ -11,7 +14,12 @@ export default function handleFullReindex({
 }: CreateRoutesArgs): (ctxt: Koa.Context, next: Koa.Next) => Promise<void> {
   return async function (ctxt: Koa.Context, _next: Koa.Next) {
     for (let realm of realms) {
-      await reindex({ realm, queue, dbAdapter });
+      await reindex({
+        realm,
+        queue,
+        dbAdapter,
+        priority: systemInitiatedPriority,
+      });
     }
     await setContextResponse(
       ctxt,

--- a/packages/realm-server/handlers/handle-full-reindex.ts
+++ b/packages/realm-server/handlers/handle-full-reindex.ts
@@ -1,0 +1,26 @@
+import Koa from 'koa';
+import { SupportedMimeType } from '@cardstack/runtime-common';
+import { setContextResponse } from '../middleware';
+import { type CreateRoutesArgs } from '../routes';
+import { reindex } from './handle-reindex';
+
+export default function handleFullReindex({
+  queue,
+  dbAdapter,
+  realms,
+}: CreateRoutesArgs): (ctxt: Koa.Context, next: Koa.Next) => Promise<void> {
+  return async function (ctxt: Koa.Context, _next: Koa.Next) {
+    for (let realm of realms) {
+      await reindex({ realm, queue, dbAdapter });
+    }
+    await setContextResponse(
+      ctxt,
+      new Response(
+        JSON.stringify({ realms: realms.map((r) => r.url) }, null, 2),
+        {
+          headers: { 'content-type': SupportedMimeType.JSON },
+        },
+      ),
+    );
+  };
+}

--- a/packages/realm-server/handlers/handle-reindex.ts
+++ b/packages/realm-server/handlers/handle-reindex.ts
@@ -2,12 +2,17 @@ import Koa from 'koa';
 import {
   type FromScratchResult,
   type FromScratchArgs,
-  fetchUserPermissions,
+  type QueuePublisher,
+  type Job,
+  type Expression,
+  type Realm,
+  query as _query,
+  param,
   userInitiatedPriority,
   SupportedMimeType,
   RealmPaths,
+  DBAdapter,
 } from '@cardstack/runtime-common';
-import { getMatrixUsername } from '@cardstack/runtime-common/matrix-client';
 import {
   sendResponseForBadRequest,
   sendResponseForSystemError,
@@ -19,6 +24,7 @@ export default function handleReindex({
   queue,
   serverURL,
   dbAdapter,
+  realms,
 }: CreateRoutesArgs): (ctxt: Koa.Context, next: Koa.Next) => Promise<void> {
   return async function (ctxt: Koa.Context, _next: Koa.Next) {
     let realmPath = ctxt.URL.searchParams.get('realm')?.replace(/\/$/, '');
@@ -29,41 +35,30 @@ export default function handleReindex({
       );
       return;
     }
-    let realm = new RealmPaths(new URL(serverURL)).directoryURL(realmPath).href;
-
-    let permissions = await fetchUserPermissions(dbAdapter, new URL(realm));
-    let owners = Object.entries(permissions)
-      .filter(([_, permissions]) => permissions?.includes('realm-owner'))
-      .map(([userId]) => userId);
-    let realmUserId =
-      owners.length === 1
-        ? owners[0]
-        : owners.find((userId) => !userId.startsWith('@realm/'));
-    let realmUsername = realmUserId?.startsWith('@')
-      ? getMatrixUsername(realmUserId)
-      : realmUserId;
-    if (!realmUsername) {
-      await sendResponseForSystemError(
+    let realmURL = new RealmPaths(new URL(serverURL)).directoryURL(
+      realmPath,
+    ).href;
+    let realm = realms.find((r) => r.url === realmURL);
+    if (!realm) {
+      await sendResponseForBadRequest(
         ctxt,
-        `Could not determine user to index as for realm ${realm}`,
+        `realm ${realmURL} does not exist on this server`,
       );
       return;
     }
 
-    let args: FromScratchArgs = {
-      realmURL: realm,
-      realmUsername,
-    };
-
-    let job = await queue.publish<FromScratchResult>({
-      jobType: `from-scratch-index`,
-      concurrencyGroup: `indexing:${realm}`,
-      timeout: 3 * 60,
-      priority: userInitiatedPriority,
-      args,
-    });
+    let job: Job<FromScratchResult>;
+    try {
+      job = await reindex({
+        queue,
+        dbAdapter,
+        realm,
+      });
+    } catch (e: any) {
+      await sendResponseForSystemError(ctxt, e.message);
+      return;
+    }
     let { stats } = await job.done;
-
     await setContextResponse(
       ctxt,
       new Response(JSON.stringify(stats, null, 2), {
@@ -71,4 +66,36 @@ export default function handleReindex({
       }),
     );
   };
+}
+
+export async function reindex({
+  realm,
+  queue,
+  dbAdapter,
+}: {
+  realm: Realm;
+  queue: QueuePublisher;
+  dbAdapter: DBAdapter;
+}) {
+  let realmUsername = await realm.getRealmOwnerUsername();
+  let args: FromScratchArgs = {
+    realmURL: realm.url,
+    realmUsername,
+  };
+  await query(dbAdapter, [
+    `UPDATE boxel_index SET last_modified = NULL WHERE realm_url =`,
+    param(realm.url),
+  ]);
+  let job = await queue.publish<FromScratchResult>({
+    jobType: `from-scratch-index`,
+    concurrencyGroup: `indexing:${realm.url}`,
+    timeout: 3 * 60,
+    priority: userInitiatedPriority,
+    args,
+  });
+  return job;
+}
+
+async function query(dbAdapter: DBAdapter, expression: Expression) {
+  return await _query(dbAdapter, expression);
 }

--- a/packages/realm-server/handlers/handle-reindex.ts
+++ b/packages/realm-server/handlers/handle-reindex.ts
@@ -72,10 +72,12 @@ export async function reindex({
   realm,
   queue,
   dbAdapter,
+  priority = userInitiatedPriority,
 }: {
   realm: Realm;
   queue: QueuePublisher;
   dbAdapter: DBAdapter;
+  priority?: number;
 }) {
   let realmUsername = await realm.getRealmOwnerUsername();
   let args: FromScratchArgs = {
@@ -89,8 +91,10 @@ export async function reindex({
   let job = await queue.publish<FromScratchResult>({
     jobType: `from-scratch-index`,
     concurrencyGroup: `indexing:${realm.url}`,
-    timeout: 3 * 60,
-    priority: userInitiatedPriority,
+    // allow this to run longer than normal as we are forcing all files to be
+    // revisited regardless of mtime
+    timeout: 6 * 60,
+    priority,
     args,
   });
   return job;

--- a/packages/realm-server/package.json
+++ b/packages/realm-server/package.json
@@ -111,6 +111,7 @@
     "lint:glint": "glint",
     "lint:test-shards": "ts-node --transpileOnly scripts/lint-test-shards.ts",
     "full-reset": "./scripts/full-reset.sh",
+    "full-reindex": "./scripts/full-reindex.sh",
     "sync-stripe-products": "NODE_NO_WARNINGS=1 PGDATABASE=boxel PGPORT=5435 ts-node --transpileOnly scripts/sync-stripe-products.ts",
     "stripe": "docker run --rm --add-host=host.docker.internal:host-gateway -it stripe/stripe-cli:latest"
   },

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -22,6 +22,7 @@ import handleStripeLinksRequest from './handlers/handle-stripe-links';
 import handleCreateUserRequest from './handlers/handle-create-user';
 import handleQueueStatusRequest from './handlers/handle-queue-status';
 import handleReindex from './handlers/handle-reindex';
+import handleFullReindex from './handlers/handle-full-reindex';
 import handleRemoveJob from './handlers/handle-remove-job';
 import handleAddCredit from './handlers/handle-add-credit';
 
@@ -34,6 +35,7 @@ export type CreateRoutesArgs = {
   realmSecretSeed: string;
   virtualNetwork: VirtualNetwork;
   queue: QueuePublisher;
+  realms: Realm[];
   createRealm: ({
     ownerUserId,
     endpoint,
@@ -93,6 +95,11 @@ export function createRoutes(args: CreateRoutesArgs) {
     '/_grafana-add-credit',
     grafanaAuthorization(args.grafanaSecret),
     handleAddCredit(args),
+  );
+  router.get(
+    '/_grafana-full-reindex',
+    grafanaAuthorization(args.grafanaSecret),
+    handleFullReindex(args),
   );
 
   return router.routes();

--- a/packages/realm-server/scripts/full-reindex.sh
+++ b/packages/realm-server/scripts/full-reindex.sh
@@ -1,0 +1,6 @@
+#! /bin/sh
+
+echo "Starting full reindex of all realms..."
+response=$(curl -s "http://localhost:4201/_grafana-full-reindex?authHeader=shhh!%20it%27s%20a%20secret")
+echo "Indexing started for realms:"
+echo "$response" | grep -o '"http://[^"]*"' | sed 's/"//g'

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -176,6 +176,7 @@ export class RealmServer {
           serveFromRealm: this.serveFromRealm,
           sendEvent: this.sendEvent,
           queue: this.queue,
+          realms: this.realms,
         }),
       )
       .use(this.serveIndex)


### PR DESCRIPTION
This PR adds a full reindex script and grafana endpoint to allow all the realms to be fully reindexed. This will be necessary in order to generate the card-def meta documents in the index in order to allow searching.

you can use the script from packages/realm-server to do a full reindex on your dev env:
```
pnpm full-reindex
```

TODO:
- [x] deploy https://github.com/cardstack/infra/pull/611 to staging
- [x] deploy https://github.com/cardstack/infra/pull/611 to prod