### PR TITLE
Fix worker connection leakage inside matrix tests

### DIFF
--- a/packages/realm-server/package.json
+++ b/packages/realm-server/package.json
@@ -112,6 +112,7 @@
     "lint:test-shards": "ts-node --transpileOnly scripts/lint-test-shards.ts",
     "full-reset": "./scripts/full-reset.sh",
     "full-reindex": "./scripts/full-reindex.sh",
+    "check-user-pg-connections": "./scripts/check-user-pg-connections.sh",
     "sync-stripe-products": "NODE_NO_WARNINGS=1 PGDATABASE=boxel PGPORT=5435 ts-node --transpileOnly scripts/sync-stripe-products.ts",
     "stripe": "docker run --rm --add-host=host.docker.internal:host-gateway -it stripe/stripe-cli:latest"
   },

--- a/packages/realm-server/scripts/check-user-pg-connections.sh
+++ b/packages/realm-server/scripts/check-user-pg-connections.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+echo "Active PostgreSQL connections:"
+docker exec boxel-pg psql -U postgres -c "
+SELECT 
+  COUNT(*) as total_connections,
+  COUNT(CASE WHEN state = 'active' THEN 1 END) as active,
+  COUNT(CASE WHEN state = 'idle' THEN 1 END) as idle,
+  COUNT(CASE WHEN state = 'idle in transaction' THEN 1 END) as idle_in_transaction
+FROM pg_stat_activity 
+WHERE pid <> pg_backend_pid() AND datname IS NOT NULL;
+"
+
+echo ""
+echo "Connections by database:"
+docker exec boxel-pg psql -U postgres -c "
+SELECT 
+  datname,
+  COUNT(*) as connections,
+  string_agg(DISTINCT state, ', ') as states
+FROM pg_stat_activity 
+WHERE pid <> pg_backend_pid() AND datname IS NOT NULL
+GROUP BY datname 
+ORDER BY connections DESC;
+"

--- a/packages/realm-server/worker-manager.ts
+++ b/packages/realm-server/worker-manager.ts
@@ -161,18 +161,18 @@ if (port) {
 
 const shutdown = async (onShutdown?: () => void) => {
   log.info(`Shutting down server for worker manager...`);
-  
+
   // Stop all workers
   if (workers.length > 0) {
     log.info(`Stopping ${workers.length} worker(s)...`);
-    workers.forEach(worker => {
+    workers.forEach((worker) => {
       if (!worker.killed && worker.pid) {
         worker.send?.('stop');
       }
     });
     log.info(`All workers stopped.`);
   }
-  
+
   webServerInstance?.closeAllConnections();
   webServerInstance?.close((err?: Error) => {
     if (err) {
@@ -391,7 +391,7 @@ async function startWorker(priority: number, urlMappings: URL[][]) {
   let currentState: IndexState | undefined;
 
   workers.push(worker);
-  
+
   worker.on('exit', () => {
     clearInterval(watchdog);
     // Remove from workers array
@@ -399,7 +399,7 @@ async function startWorker(priority: number, urlMappings: URL[][]) {
     if (index > -1) {
       workers.splice(index, 1);
     }
-    
+
     if (!isExiting) {
       log.info(`worker ${name} exited. spawning replacement worker`);
       startWorker(priority, urlMappings);

--- a/packages/realm-server/worker-manager.ts
+++ b/packages/realm-server/worker-manager.ts
@@ -159,7 +159,7 @@ if (port) {
   log.info(`worker manager HTTP listening on port ${port}`);
 }
 
-const shutdown = async (onShutdown?: () => void) => {
+const shutdown = (onShutdown?: () => void) => {
   log.info(`Shutting down server for worker manager...`);
 
   // Stop all workers
@@ -170,7 +170,6 @@ const shutdown = async (onShutdown?: () => void) => {
         worker.send?.('stop');
       }
     });
-    log.info(`All workers stopped.`);
   }
 
   webServerInstance?.closeAllConnections();

--- a/packages/realm-server/worker.ts
+++ b/packages/realm-server/worker.ts
@@ -157,7 +157,7 @@ let autoMigrate = migrateDB || undefined;
   process.on('SIGTERM', shutdown);
   process.on('message', (message) => {
     if (message === 'stop') {
-      shutdown();
+      shutdown(); // warning this is async
     }
   });
 })().catch((e: any) => {

--- a/packages/realm-server/worker.ts
+++ b/packages/realm-server/worker.ts
@@ -139,6 +139,27 @@ let autoMigrate = migrateDB || undefined;
   if (process.send) {
     process.send(`ready:${workerId}`);
   }
+
+  // Handle graceful shutdown
+  const shutdown = async () => {
+    log.info(`Shutting down worker ${workerId}...`);
+    try {
+      await queue.destroy();
+      await dbAdapter.close();
+      log.info(`Worker ${workerId} shut down gracefully`);
+      process.exit(0);
+    } catch (err) {
+      log.error(`Error during worker shutdown:`, err);
+      process.exit(1);
+    }
+  };
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+  process.on('message', (message) => {
+    if (message === 'stop') {
+      shutdown();
+    }
+  });
 })().catch((e: any) => {
   Sentry.captureException(e);
   log.error(


### PR DESCRIPTION
When running matrix test locally, we get "too many clients connected" error. 

I managed to get matrix test to run "mostly" green except 2 tests. The other 2 tests might be flaky since they pass when run isolated

<img width="592" height="982" alt="Screenshot 2025-08-02 at 16 41 39" src="https://github.com/user-attachments/assets/04434150-8239-44f6-81b2-ff2766a5c5d3" />

There are all these connections 



<img width="570" height="703" alt="Screenshot 2025-08-02 at 16 49 15" src="https://github.com/user-attachments/assets/14bceca7-9bdf-4a57-a04c-61529ac3490d" />

