### PR TITLE
CS-9215 Improve generation of gts via stub

### DIFF
--- a/packages/host/app/commands/listing-action-build.ts
+++ b/packages/host/app/commands/listing-action-build.ts
@@ -40,7 +40,7 @@ export default class ListingActionBuildCommand extends HostBaseCommand<
 
     const listing = listingInput as Listing;
 
-    const prompt = `Generate .gts card definition for "${listing.name}" implementing all requirements from the attached listing specification, limit output to 1000 lines maximum. Do not switch code or preview until the code is fully generated. Generate incrementally after per response if needed, then preview the final code in playground panel.`;
+    const prompt = `Generate .gts card definition for "${listing.name}" implementing all requirements from the attached listing specification. Then preview the final code in playground panel.`;
 
     const { roomId } = await new CreateAiAssistantRoomCommand(
       this.commandContext,
@@ -49,8 +49,8 @@ export default class ListingActionBuildCommand extends HostBaseCommand<
     });
 
     const defaultSkills = [
-      skillCardURL('boxel-environment'),
       skillCardURL('boxel-development'),
+      skillCardURL('catalog-listing'),
       skillCardURL('source-code-editing'),
     ];
 

--- a/packages/host/tests/acceptance/catalog-app-test.gts
+++ b/packages/host/tests/acceptance/catalog-app-test.gts
@@ -412,7 +412,7 @@ module('Acceptance | Catalog | catalog app tests', function (hooks) {
           assert,
           `[data-test-card="${apiDocumentationStubId}"] [data-test-catalog-listing-embedded-build-button]`,
           'Build',
-          'Generate .gts card definition for "API Documentation" implementing all requirements from the attached listing specification, limit output to 1000 lines maximum. Do not switch code or preview until the code is fully generated. Generate incrementally after per response if needed, then preview the final code in playground panel.',
+          'Generate .gts card definition for "API Documentation" implementing all requirements from the attached listing specification. Then preview the final code in playground panel.',
         );
       });
 


### PR DESCRIPTION
Prerequisite
- https://github.com/cardstack/boxel-skills/pull/22

What is changing
- exclude boxel environment skill on generate because it leads to unexpected behaviour
- able to view the card in playground mode when generation is successful

Screenshot 1 

https://github.com/user-attachments/assets/5eb84086-1191-43ae-8f19-073f7d954a0b

Screenshot 2


https://github.com/user-attachments/assets/b908d7b9-4e2b-4a3c-a1d9-3f97ad71dab6



