### PR TITLE
Actually switch to Code mode when clicking Open in Code Mode

### DIFF
--- a/packages/host/app/components/ai-assistant/code-block/diff-editor-header.gts
+++ b/packages/host/app/components/ai-assistant/code-block/diff-editor-header.gts
@@ -28,6 +28,7 @@ import MatrixService from '@cardstack/host/services/matrix-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 import { CodePatchStatus } from 'https://cardstack.com/base/matrix-event';
+
 import { Submodes } from '../../submode-switcher';
 
 export interface CodeBlockDiffEditorHeaderSignature {

--- a/packages/host/app/components/ai-assistant/code-block/diff-editor-header.gts
+++ b/packages/host/app/components/ai-assistant/code-block/diff-editor-header.gts
@@ -28,6 +28,7 @@ import MatrixService from '@cardstack/host/services/matrix-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 import { CodePatchStatus } from 'https://cardstack.com/base/matrix-event';
+import { Submodes } from '../../submode-switcher';
 
 export interface CodeBlockDiffEditorHeaderSignature {
   Args: {
@@ -213,6 +214,7 @@ export default class CodeBlockDiffEditorHeader extends Component<CodeBlockDiffEd
   }
 
   private openInCodeMode = () => {
+    this.operatorModeStateService.updateSubmode(Submodes.Code);
     this.operatorModeStateService.updateCodePath(new URL(this.fileUrl!));
   };
 

--- a/packages/host/tests/acceptance/code-patches-test.gts
+++ b/packages/host/tests/acceptance/code-patches-test.gts
@@ -966,13 +966,20 @@ ${REPLACE_MARKER}
     assert.dom('[data-code-patch-dropdown-button="file2.gts"]').exists();
     assert.dom('[data-code-patch-dropdown-button="hi-1.txt"]').exists();
 
-    await click('[data-code-patch-dropdown-button="file1.gts"]');
     assert
       .dom('[data-test-boxel-menu-item-text="Restore Content"]')
       .doesNotExist(
         'Restore Content menu item should not be shown for new files',
       );
+
+    // Switch to interact mode so that we can test that "Open in Code Mode" works
+    await click('[data-test-submode-switcher] > [data-test-boxel-button]');
+    await click('[data-test-boxel-menu-item-text="Interact"]');
+    await click('[data-test-workspace="Test Workspace B"]');
+    await waitFor('[data-test-submode-switcher="interact"]');
+    await click('[data-code-patch-dropdown-button="file1.gts"]');
     await click('[data-test-boxel-menu-item-text="Open in Code Mode"]');
+    await waitFor('[data-test-submode-switcher="code"]');
 
     assert.strictEqual(
       getMonacoContent(),


### PR DESCRIPTION
Previously, clicking on "Open in Code Mode" only set the path - which worked ok if you already were in code mode. But if you were in interact mode, nothing happened - this PR fixes it. 

<img width="270" height="174" alt="image" src="https://github.com/user-attachments/assets/01c26cb6-65e8-4acc-8724-57f9df6d4ac9" />
