### PR TITLE
Elevate context provision into container

### DIFF
--- a/packages/host/app/components/card-renderer.gts
+++ b/packages/host/app/components/card-renderer.gts
@@ -1,5 +1,3 @@
-import { service } from '@ember/service';
-
 import Component from '@glimmer/component';
 
 import { provide, consume } from 'ember-provide-consume-context';
@@ -17,15 +15,12 @@ import {
   type getCardCollection,
 } from '@cardstack/runtime-common';
 
-import type StoreService from '@cardstack/host/services/store';
-
 import type {
   BaseDef,
   Format,
   Field,
+  CardContext,
 } from 'https://cardstack.com/base/card-api';
-
-import PrerenderedCardSearch from './prerendered-card-search';
 
 interface Signature {
   Element: any;
@@ -34,7 +29,6 @@ interface Signature {
     format?: Format;
     field?: Field;
     codeRef?: ResolvedCodeRef;
-    cardContext?: Record<string, any>;
     displayContainer?: boolean;
   };
 }
@@ -44,7 +38,7 @@ export default class CardRenderer extends Component<Signature> {
   @consume(GetCardsContextName) private declare getCards: getCards;
   @consume(GetCardCollectionContextName)
   private declare getCardCollection: getCardCollection;
-  @service private declare store: StoreService;
+  @consume(CardContextName) private declare cardContext: CardContext;
 
   @provide(DefaultFormatsContextName)
   // @ts-ignore "defaultFormat is declared but not used"
@@ -52,19 +46,6 @@ export default class CardRenderer extends Component<Signature> {
     let { format } = this.args;
     format = format ?? 'isolated';
     return { cardDef: format, fieldDef: format };
-  }
-
-  @provide(CardContextName)
-  // @ts-ignore "context is declared but not used"
-  private get context() {
-    return {
-      prerenderedCardSearchComponent: PrerenderedCardSearch,
-      getCard: this.getCard,
-      getCards: this.getCards,
-      getCardCollection: this.getCardCollection,
-      store: this.store,
-      ...this.args.cardContext,
-    };
   }
 
   @provide(CardURLContextName)

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -35,6 +35,7 @@ import {
   CodeRef,
   type ResolvedCodeRef,
   type getCard,
+  CardContextName,
 } from '@cardstack/runtime-common';
 import { isEquivalentBodyPosition } from '@cardstack/runtime-common/schema-analysis-plugin';
 
@@ -57,7 +58,11 @@ import type RealmService from '@cardstack/host/services/realm';
 import type RecentFilesService from '@cardstack/host/services/recent-files-service';
 import type SpecPanelService from '@cardstack/host/services/spec-panel-service';
 
-import type { CardDef, Format } from 'https://cardstack.com/base/card-api';
+import type {
+  CardDef,
+  Format,
+  CardContext,
+} from 'https://cardstack.com/base/card-api';
 import { type SpecType } from 'https://cardstack.com/base/spec';
 
 import {
@@ -129,6 +134,7 @@ function urlToFilename(url: URL) {
 
 export default class CodeSubmode extends Component<Signature> {
   @consume(GetCardContextName) private declare getCard: getCard;
+  @consume(CardContextName) private declare cardContext: CardContext;
 
   @service private declare cardService: CardService;
   @service private declare codeSemanticsService: CodeSemanticsService;

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -118,8 +118,8 @@ class SpecPreviewContent extends GlimmerComponent<ContentSignature> {
   }
 
   @provide(CardContextName)
+  // @ts-ignore "context" is declared but not used
   private get context(): SpecPreviewCardContext {
-    // @ts-ignore "context" is declared but not used
     return {
       ...this.cardContext,
       cardComponentModifier: this.cardTracker.trackElement,

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -5,7 +5,7 @@ import { service } from '@ember/service';
 import { htmlSafe } from '@ember/template';
 import GlimmerComponent from '@glimmer/component';
 
-import { consume } from 'ember-provide-consume-context';
+import { consume, provide } from 'ember-provide-consume-context';
 
 import {
   BoxelButton,
@@ -26,6 +26,7 @@ import {
   realmURL as realmURLSymbol,
   localId,
   isLocalId,
+  CardContextName,
 } from '@cardstack/runtime-common';
 
 import CardRenderer from '@cardstack/host/components/card-renderer';
@@ -104,6 +105,7 @@ class SpecPreviewContent extends GlimmerComponent<ContentSignature> {
   @consume(GetCardsContextName) private declare getCards: getCards;
   @consume(GetCardCollectionContextName)
   private declare getCardCollection: getCardCollection;
+  @consume(CardContextName) private declare cardContext: CardContext;
   @service private declare realm: RealmService;
   @service private declare operatorModeStateService: OperatorModeStateService;
   @service private declare specPanelService: SpecPanelService;
@@ -115,12 +117,11 @@ class SpecPreviewContent extends GlimmerComponent<ContentSignature> {
     return this.args.allSpecs.length === 1;
   }
 
-  private get cardContext(): SpecPreviewCardContext {
+  @provide(CardContextName)
+  private get context(): SpecPreviewCardContext {
+    // @ts-ignore "context" is declared but not used
     return {
-      getCard: this.getCard,
-      getCards: this.getCards,
-      getCardCollection: this.getCardCollection,
-      store: this.store,
+      ...this.cardContext,
       cardComponentModifier: this.cardTracker.trackElement,
     };
   }
@@ -238,17 +239,9 @@ class SpecPreviewContent extends GlimmerComponent<ContentSignature> {
               @onSelectCard={{@viewSpecInPlayground}}
             />
             {{#if this.displayIsolated}}
-              <CardRenderer
-                @card={{@activeSpec}}
-                @format='isolated'
-                @cardContext={{this.cardContext}}
-              />
+              <CardRenderer @card={{@activeSpec}} @format='isolated' />
             {{else}}
-              <CardRenderer
-                @card={{@activeSpec}}
-                @format='edit'
-                @cardContext={{this.cardContext}}
-              />
+              <CardRenderer @card={{@activeSpec}} @format='edit' />
             {{/if}}
           </div>
         {{/if}}

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -91,8 +91,8 @@ export default class OperatorModeContainer extends Component<Signature> {
   }
 
   @provide(CardContextName)
-  // @ts-ignore "getCardCollection" is declared but not used
-  private get cardContext(): Omit<CardContext> {
+  // @ts-ignore "context" is declared but not used
+  private get context(): Omit<CardContext> {
     return {
       getCard: this.getCard,
       getCards: this.getCards,

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -16,6 +16,7 @@ import { provide } from 'ember-provide-consume-context';
 import { or, not } from '@cardstack/boxel-ui/helpers';
 
 import {
+  CardContextName,
   GetCardContextName,
   GetCardsContextName,
   GetCardCollectionContextName,
@@ -32,16 +33,20 @@ import { getSearch } from '@cardstack/host/resources/search';
 
 import MessageService from '@cardstack/host/services/message-service';
 
+import { type CardContext } from 'https://cardstack.com/base/card-api';
+
 import CardCatalogModal from '../card-catalog/modal';
+import PrerenderedCardSearch from '../prerendered-card-search';
 import { Submodes } from '../submode-switcher';
 
 import ChooseFileModal from './choose-file-modal';
 
 import type CardService from '../../services/card-service';
+import type CommandService from '../../services/command-service';
 import type MatrixService from '../../services/matrix-service';
 import type OperatorModeStateService from '../../services/operator-mode-state-service';
 import type RealmServerService from '../../services/realm-server';
-
+import type StoreService from '../../services/store';
 const waiter = buildWaiter('operator-mode-container:saveCard-waiter');
 
 interface Signature {
@@ -56,6 +61,8 @@ export default class OperatorModeContainer extends Component<Signature> {
   @service private declare operatorModeStateService: OperatorModeStateService;
   @service private declare messageService: MessageService;
   @service declare realmServer: RealmServerService;
+  @service private declare commandService: CommandService;
+  @service private declare store: StoreService;
 
   constructor(owner: Owner, args: Signature['Args']) {
     super(owner, args);
@@ -65,7 +72,6 @@ export default class OperatorModeContainer extends Component<Signature> {
       this.operatorModeStateService.clearStacks();
     });
   }
-
   @provide(GetCardContextName)
   // @ts-ignore "getCard" is declared but not used
   private get getCard() {
@@ -82,6 +88,19 @@ export default class OperatorModeContainer extends Component<Signature> {
   // @ts-ignore "getCardCollection" is declared but not used
   private get getCardCollection() {
     return getCardCollection;
+  }
+
+  @provide(CardContextName)
+  // @ts-ignore "getCardCollection" is declared but not used
+  private get cardContext(): Omit<CardContext> {
+    return {
+      getCard: this.getCard,
+      getCards: this.getCards,
+      getCardCollection: this.getCardCollection,
+      store: this.store,
+      commandContext: this.commandService.commandContext,
+      prerenderedCardSearchComponent: PrerenderedCardSearch,
+    };
   }
 
   private saveSource = task(async (url: URL, content: string) => {

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -92,7 +92,7 @@ export default class OperatorModeContainer extends Component<Signature> {
 
   @provide(CardContextName)
   // @ts-ignore "context" is declared but not used
-  private get context(): Omit<CardContext> {
+  private get context(): CardContext {
     return {
       getCard: this.getCard,
       getCards: this.getCards,

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -51,6 +51,7 @@ import {
   CommandContext,
   realmURL,
   identifyCard,
+  CardContextName,
 } from '@cardstack/runtime-common';
 
 import { type StackItem } from '@cardstack/host/lib/stack-item';
@@ -116,6 +117,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
   @consume(GetCardsContextName) private declare getCards: getCards;
   @consume(GetCardCollectionContextName)
   private declare getCardCollection: getCardCollection;
+  @consume(CardContextName) private declare cardContext: CardContext;
 
   @service private declare cardService: CardService;
   @service private declare operatorModeStateService: OperatorModeStateService;
@@ -246,15 +248,13 @@ export default class OperatorModeStackItem extends Component<Signature> {
     return this.url === `${this.realmURL.href}index`;
   }
 
-  private get cardContext(): StackItemCardContext {
+  @provide(CardContextName)
+  private get context(): StackItemCardContext {
+    // @ts-ignore "context" is declared but not used
     return {
+      ...this.cardContext,
       cardComponentModifier: this.cardTracker.trackElement,
-      actions: this.args.publicAPI,
-      commandContext: this.args.commandContext,
-      getCard: this.getCard,
-      getCards: this.getCards,
-      getCardCollection: this.getCardCollection,
-      store: this.store,
+      actions: this.args.publicAPI, //we put this last to overwrite card context so stackIndex is correct
     };
   }
 
@@ -694,7 +694,6 @@ export default class OperatorModeStackItem extends Component<Signature> {
               class='stack-item-preview'
               @card={{this.card}}
               @format={{@item.format}}
-              @cardContext={{this.cardContext}}
             />
             <OperatorModeOverlays
               @renderedCardsForOverlayActions={{this.renderedCardsForOverlayActions}}

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -110,8 +110,6 @@ export interface StackItemRenderedCardForOverlayActions
   stackItem: StackItem;
 }
 
-type StackItemCardContext = Omit<CardContext, 'prerenderedCardSearchComponent'>;
-
 export default class OperatorModeStackItem extends Component<Signature> {
   @consume(GetCardContextName) private declare getCard: getCard;
   @consume(GetCardsContextName) private declare getCards: getCards;

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -249,8 +249,8 @@ export default class OperatorModeStackItem extends Component<Signature> {
   }
 
   @provide(CardContextName)
+  // @ts-ignore "context" is declared but not used
   private get context(): StackItemCardContext {
-    // @ts-ignore "context" is declared but not used
     return {
       ...this.cardContext,
       cardComponentModifier: this.cardTracker.trackElement,

--- a/packages/host/app/templates/card.gts
+++ b/packages/host/app/templates/card.gts
@@ -4,7 +4,7 @@ import Component from '@glimmer/component';
 
 import { pageTitle } from 'ember-page-title';
 
-import { consume } from 'ember-provide-consume-context';
+import { consume, provide } from 'ember-provide-consume-context';
 import RouteTemplate from 'ember-route-template';
 
 import { CardContainer } from '@cardstack/boxel-ui/components';
@@ -18,6 +18,7 @@ import {
   GetCardsContextName,
   GetCardCollectionContextName,
   isCardErrorJSONAPI,
+  CardContextName,
 } from '@cardstack/runtime-common';
 import { meta } from '@cardstack/runtime-common/constants';
 
@@ -68,6 +69,7 @@ class HostModeComponent extends Component<HostModeComponentSignature> {
     return false;
   }
 
+  @provide(CardContextName)
   private get cardContext(): HostModeCardContext {
     return {
       getCard: this.getCard,
@@ -95,7 +97,6 @@ class HostModeComponent extends Component<HostModeComponentSignature> {
             class='stack-item-preview'
             @card={{this.card}}
             @format='isolated'
-            @cardContext={{this.cardContext}}
           />
 
         </CardContainer>

--- a/packages/host/app/templates/card.gts
+++ b/packages/host/app/templates/card.gts
@@ -70,7 +70,8 @@ class HostModeComponent extends Component<HostModeComponentSignature> {
   }
 
   @provide(CardContextName)
-  private get cardContext(): HostModeCardContext {
+  // @ts-ignore "context" is declared but not used
+  private get context(): HostModeCardContext {
     return {
       getCard: this.getCard,
       getCards: this.getCards,


### PR DESCRIPTION
Most important change is to elevate the context provision into container so code-submode can consume from it

- just provide entire context without explicitly breaking them into keys
- ensure overrides occur at the bottom of the context getter 
- remove cardContext arg from card renderer

This will be followed up by the PRs such as https://linear.app/cardstack/issue/CS-9195/allrealmsinfo and the general project of moving commands and context accesible in code mode