### PR TITLE
Make example cards use tile size within listing isolated

### DIFF
--- a/packages/catalog-realm/catalog-app/listing/listing.gts
+++ b/packages/catalog-realm/catalog-app/listing/listing.gts
@@ -457,6 +457,7 @@ class EmbeddedTemplate extends Component<typeof Listing> {
         margin: 0;
         margin-bottom: var(--boxel-sp);
       }
+
       .no-data-text {
         color: var(--boxel-400);
       }

--- a/packages/catalog-realm/catalog-app/listing/listing.gts
+++ b/packages/catalog-realm/catalog-app/listing/listing.gts
@@ -313,12 +313,14 @@ class EmbeddedTemplate extends Component<typeof Listing> {
           class='license-section'
           data-test-catalog-listing-embedded-license-section
         >
-          <h2>License</h2>
-          {{#if @model.license.name}}
-            {{@model.license.name}}
-          {{else}}
-            <p class='no-data-text'>No License Provided</p>
-          {{/if}}
+          <div class='info-box'>
+            <h2>License</h2>
+            {{#if @model.license.name}}
+              {{@model.license.name}}
+            {{else}}
+              <p class='no-data-text'>No License Provided</p>
+            {{/if}}
+          </div>
         </div>
       </section>
 
@@ -350,8 +352,8 @@ class EmbeddedTemplate extends Component<typeof Listing> {
         {{#if this.hasExamples}}
           <ul class='examples-list' data-test-catalog-listing-embedded-examples>
             {{#each @fields.examples as |Example|}}
-              <li>
-                <Example />
+              <li class='example-item'>
+                <Example class='example-card' />
               </li>
             {{/each}}
           </ul>
@@ -453,7 +455,7 @@ class EmbeddedTemplate extends Component<typeof Listing> {
       h2 {
         font-weight: 600;
         margin: 0;
-        margin-bottom: var(--boxel-sp-sm);
+        margin-bottom: var(--boxel-sp);
       }
       .no-data-text {
         color: var(--boxel-400);
@@ -462,20 +464,24 @@ class EmbeddedTemplate extends Component<typeof Listing> {
         width: 100%;
         height: auto;
         border-radius: var(--boxel-border-radius);
-        background-color: var(--boxel-light);
+        padding: var(--boxel-sp);
+        background-color: var(--boxel-100);
+      }
+      .info-box :deep(.markdown-content p) {
+        margin-top: 0;
       }
 
       /* container */
       .app-listing-embedded {
         container-name: app-listing-embedded;
         container-type: inline-size;
-        padding: var(--boxel-sp);
+        padding: var(--boxel-sp-lg);
       }
       .app-listing-info {
         display: flex;
         flex-direction: column;
         gap: var(--boxel-sp-xl);
-        margin-left: 60px;
+        margin-left: 72px;
         margin-top: var(--boxel-sp-lg);
       }
       .app-listing-price-plan {
@@ -503,10 +509,6 @@ class EmbeddedTemplate extends Component<typeof Listing> {
       .app-listing-embedded
         :deep(.ember-basic-dropdown-content-wormhole-origin) {
         position: absolute;
-      }
-      .app-listing-summary {
-        padding: var(--boxel-sp);
-        background-color: var(--boxel-100);
       }
 
       .divider {
@@ -551,11 +553,14 @@ class EmbeddedTemplate extends Component<typeof Listing> {
       }
       .examples-list {
         display: grid;
-        grid-template-columns: repeat(4, 1fr);
+        grid-template-columns: repeat(5, 1fr);
         gap: var(--boxel-sp);
         list-style: none;
         margin-block: 0;
         padding-inline-start: 0;
+      }
+      .example-card {
+        min-height: 180px;
       }
 
       .categories-list {


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-9139/make-example-cards-use-tile-size-within-listing-isolated

<img width="717" height="739" alt="Screenshot 2025-08-05 at 11 46 51 AM" src="https://github.com/user-attachments/assets/a027ee3c-d2d6-4bd4-90d5-fc5ecf903b72" />
