### PR TITLE
Add caching to card-def meta

### DIFF
--- a/packages/host/tests/unit/index-query-engine-test.ts
+++ b/packages/host/tests/unit/index-query-engine-test.ts
@@ -15,6 +15,7 @@ import {
   type ResolvedCodeRef,
   type CardDefMeta,
 } from '@cardstack/runtime-common';
+import { DefinitionsCache } from '@cardstack/runtime-common/definitions-cache';
 
 import { runSharedTest } from '@cardstack/runtime-common/helpers';
 // eslint-disable-next-line ember/no-test-import-export
@@ -45,6 +46,7 @@ module('Unit | query', function (hooks) {
   let indexQueryEngine: IndexQueryEngine;
   let loader: Loader;
   let testCards: { [name: string]: CardDef } = {};
+  let definitionsCache: DefinitionsCache;
 
   hooks.before(async function () {
     dbAdapter = await getDbAdapter();
@@ -238,13 +240,15 @@ module('Unit | query', function (hooks) {
     });
 
     await dbAdapter.reset();
-    indexQueryEngine = new IndexQueryEngine(dbAdapter, virtualNetwork.fetch);
+    definitionsCache = new DefinitionsCache(virtualNetwork.fetch);
+    indexQueryEngine = new IndexQueryEngine(dbAdapter, definitionsCache);
   });
 
   test('can get all cards with empty filter', async function (assert) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -253,6 +257,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -261,6 +266,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -269,6 +275,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -277,6 +284,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -285,6 +293,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -293,6 +302,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -301,6 +311,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -309,6 +320,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -317,6 +329,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -325,6 +338,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -333,6 +347,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -341,6 +356,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -349,6 +365,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -357,6 +374,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -365,6 +383,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -373,6 +392,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -381,6 +401,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -389,6 +410,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -397,6 +419,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -405,6 +428,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -413,6 +437,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -421,6 +446,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -429,6 +455,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -437,6 +464,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -445,6 +473,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -453,6 +482,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -461,6 +491,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -469,6 +500,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -477,6 +509,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -485,6 +518,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -493,6 +527,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -501,6 +536,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -509,6 +545,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -517,6 +554,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -525,6 +563,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -533,6 +572,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -541,6 +581,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -549,6 +590,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -557,6 +599,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -565,6 +608,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -573,6 +617,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -581,6 +626,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -589,6 +635,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });
@@ -597,6 +644,7 @@ module('Unit | query', function (hooks) {
     await runSharedTest(indexQueryEngineTests, assert, {
       indexQueryEngine,
       dbAdapter,
+      definitionsCache,
       testCards,
     });
   });

--- a/packages/host/tests/unit/index-writer-test.ts
+++ b/packages/host/tests/unit/index-writer-test.ts
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 
 import { IndexWriter, IndexQueryEngine } from '@cardstack/runtime-common';
+import { DefinitionsCache } from '@cardstack/runtime-common/definitions-cache';
 import { runSharedTest } from '@cardstack/runtime-common/helpers';
 // eslint-disable-next-line ember/no-test-import-export
 import indexWriterTests from '@cardstack/runtime-common/tests/index-writer-test';
@@ -21,7 +22,10 @@ module('Unit | index-writer', function (hooks) {
   hooks.beforeEach(async function () {
     await adapter.reset();
     indexWriter = new IndexWriter(adapter);
-    indexQueryEngine = new IndexQueryEngine(adapter, fetch);
+    indexQueryEngine = new IndexQueryEngine(
+      adapter,
+      new DefinitionsCache(fetch),
+    );
   });
 
   test('can perform invalidations for a instance entry', async function (assert) {

--- a/packages/realm-server/tests/index-query-engine-test.ts
+++ b/packages/realm-server/tests/index-query-engine-test.ts
@@ -8,6 +8,7 @@ import {
   fetcher,
   maybeHandleScopedCSSRequest,
 } from '@cardstack/runtime-common';
+import { DefinitionsCache } from '@cardstack/runtime-common/definitions-cache';
 import { runSharedTest, p } from '@cardstack/runtime-common/helpers';
 import { testRealmURL } from '@cardstack/runtime-common/helpers/const';
 import { PgAdapter } from '@cardstack/postgres';
@@ -105,6 +106,7 @@ module(basename(__filename), function () {
     let dbAdapter: PgAdapter;
     let indexQueryEngine: IndexQueryEngine;
     let loader: Loader;
+    let definitionsCache: DefinitionsCache;
 
     hooks.beforeEach(async function () {
       prepareTestDB();
@@ -122,7 +124,8 @@ module(basename(__filename), function () {
       loader = new Loader(fetch, virtualNetwork.resolveImport);
 
       dbAdapter = new PgAdapter({ autoMigrate: true });
-      indexQueryEngine = new IndexQueryEngine(dbAdapter, virtualNetwork.fetch);
+      definitionsCache = new DefinitionsCache(virtualNetwork.fetch);
+      indexQueryEngine = new IndexQueryEngine(dbAdapter, definitionsCache);
     });
 
     hooks.afterEach(async function () {
@@ -133,6 +136,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -141,6 +145,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -149,6 +154,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -157,6 +163,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -165,6 +172,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -173,6 +181,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -181,6 +190,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -189,6 +199,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -197,6 +208,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -205,6 +217,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -213,6 +226,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -221,6 +235,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -229,6 +244,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -237,6 +253,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -245,6 +262,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -253,6 +271,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -261,6 +280,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -269,6 +289,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -277,6 +298,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -285,6 +307,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -293,6 +316,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -301,6 +325,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -309,6 +334,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -317,6 +343,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -325,6 +352,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -333,6 +361,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -341,6 +370,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -349,6 +379,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -357,6 +388,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -365,6 +397,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -373,6 +406,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -381,6 +415,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -389,6 +424,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -397,6 +433,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -405,6 +442,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -413,6 +451,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -421,6 +460,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -429,6 +469,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -437,6 +478,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -445,6 +487,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -453,6 +496,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -461,6 +505,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -469,6 +514,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -477,6 +523,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });
@@ -485,6 +532,7 @@ module(basename(__filename), function () {
       await runSharedTest(indexQueryEngineTests, assert, {
         indexQueryEngine,
         dbAdapter,
+        definitionsCache,
         testCards: await makeTestCards(loader),
       });
     });

--- a/packages/realm-server/tests/index-writer-test.ts
+++ b/packages/realm-server/tests/index-writer-test.ts
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { prepareTestDB } from './helpers';
 import { IndexWriter, IndexQueryEngine } from '@cardstack/runtime-common';
+import { DefinitionsCache } from '@cardstack/runtime-common/definitions-cache';
 import { runSharedTest } from '@cardstack/runtime-common/helpers';
 import { PgAdapter } from '@cardstack/postgres';
 import indexWriterTests from '@cardstack/runtime-common/tests/index-writer-test';
@@ -16,7 +17,10 @@ module(basename(__filename), function () {
       prepareTestDB();
       adapter = new PgAdapter({ autoMigrate: true });
       indexWriter = new IndexWriter(adapter);
-      indexQueryEngine = new IndexQueryEngine(adapter, fetch);
+      indexQueryEngine = new IndexQueryEngine(
+        adapter,
+        new DefinitionsCache(fetch),
+      );
     });
 
     hooks.afterEach(async function () {

--- a/packages/runtime-common/definitions-cache.ts
+++ b/packages/runtime-common/definitions-cache.ts
@@ -1,0 +1,83 @@
+import {
+  type ResolvedCodeRef,
+  type CardDefMeta,
+  SupportedMimeType,
+  internalKeyFor,
+} from './index';
+import stringify from 'safe-stable-stringify';
+import qs from 'qs';
+
+export class DefinitionsCache {
+  #fetch: typeof globalThis.fetch;
+  #cache = new Map<string, CardDefMeta>();
+
+  constructor(fetch: typeof globalThis.fetch) {
+    this.#fetch = fetch;
+  }
+
+  invalidate() {
+    this.#cache = new Map();
+  }
+
+  // for tests
+  get cachedKeys() {
+    return [...this.#cache.keys()];
+  }
+
+  async getDefinition(codeRef: ResolvedCodeRef): Promise<CardDefMeta> {
+    let key = internalKeyFor(codeRef, undefined);
+    let cached = this.#cache.get(key);
+    if (cached) {
+      return cached;
+    }
+    let definition = await this.fetchDefinition(codeRef);
+    this.#cache.set(key, definition);
+    return definition;
+  }
+
+  private async fetchDefinition(
+    codeRef: ResolvedCodeRef,
+  ): Promise<CardDefMeta> {
+    let head: Response;
+    try {
+      head = await this.#fetch(codeRef.module, {
+        method: 'HEAD',
+      });
+    } catch (e) {
+      throw new Error(
+        `Your filter refers to a nonexistent type: import { ${codeRef.name} } from "${codeRef.module}"`,
+      );
+    }
+    if (!head.ok) {
+      let message = await head.text();
+      throw new Error(
+        `tried to get card def meta for ${stringify(codeRef)}, but got ${head.status}: ${message} for HEAD ${codeRef.module}`,
+      );
+    }
+    let realmURL = head.headers.get('X-Boxel-Realm-Url');
+    if (!realmURL) {
+      throw new Error(
+        `could not determine realm URL for ${codeRef.module} when getting card def meta for ${stringify(codeRef)}`,
+      );
+    }
+    let url = `${realmURL}_card-def?${qs.stringify({ codeRef })}`;
+    let response: Response;
+    try {
+      response = await this.#fetch(url, {
+        headers: { accept: SupportedMimeType.JSONAPI },
+      });
+    } catch (e) {
+      throw new Error(
+        `Your filter refers to a nonexistent type: import { ${codeRef.name} } from "${codeRef.module}"`,
+      );
+    }
+    if (!response.ok) {
+      let message = await response.text();
+      throw new Error(
+        `tried to get card def meta for ${stringify(codeRef)}, but got ${response.status}: ${message} for ${url}`,
+      );
+    }
+    let json = await response.json();
+    return json.data.attributes as CardDefMeta;
+  }
+}

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -1,6 +1,5 @@
 import * as JSONTypes from 'json-typescript';
 import flatten from 'lodash/flatten';
-import qs from 'qs';
 import stringify from 'safe-stable-stringify';
 import {
   type CardResource,
@@ -10,7 +9,6 @@ import {
   isResolvedCodeRef,
   ResolvedCodeRef,
   trimExecutableExtension,
-  SupportedMimeType,
   baseRealm,
   getSerializer,
 } from './index';
@@ -60,6 +58,7 @@ import {
   type CardDefMeta,
   type CardDefFieldMeta,
 } from './index-structure';
+import { DefinitionsCache } from './definitions-cache';
 import { isScopedCSSRequest } from 'glimmer-scoped-css';
 
 interface IndexedModule {
@@ -176,10 +175,11 @@ export function isValidPrerenderedHtmlFormat(
 
 export class IndexQueryEngine {
   #dbAdapter: DBAdapter;
-  #fetch: typeof globalThis.fetch;
-  constructor(dbAdapter: DBAdapter, fetch: typeof globalThis.fetch) {
+  #definitionsCache: DefinitionsCache;
+
+  constructor(dbAdapter: DBAdapter, definitionsCache: DefinitionsCache) {
     this.#dbAdapter = dbAdapter;
-    this.#fetch = fetch;
+    this.#definitionsCache = definitionsCache;
   }
 
   async #query(expression: Expression) {
@@ -382,55 +382,13 @@ export class IndexQueryEngine {
     };
   }
 
-  // the code ref we are looking for might not reside on this server so we need
-  // to use the public Realm API to retrieve it
   private async getCardDefMeta(codeRef: CodeRef): Promise<CardDefMeta> {
     if (!isResolvedCodeRef(codeRef)) {
       throw new Error(
         `Your filter refers to a nonexistent type: ${stringify(codeRef)}`,
       );
     }
-    let head: Response;
-    try {
-      head = await this.#fetch(codeRef.module, {
-        method: 'HEAD',
-      });
-    } catch (e) {
-      throw new Error(
-        `Your filter refers to a nonexistent type: import { ${codeRef.name} } from "${codeRef.module}"`,
-      );
-    }
-    if (!head.ok) {
-      let message = await head.text();
-      throw new Error(
-        `tried to get card def meta for ${stringify(codeRef)}, but got ${head.status}: ${message} for HEAD ${codeRef.module}`,
-      );
-    }
-    let realmURL = head.headers.get('X-Boxel-Realm-Url');
-    if (!realmURL) {
-      throw new Error(
-        `could not determine realm URL for ${codeRef.module} when getting card def meta for ${stringify(codeRef)}`,
-      );
-    }
-    let url = `${realmURL}_card-def?${qs.stringify({ codeRef })}`;
-    let response: Response;
-    try {
-      response = await this.#fetch(url, {
-        headers: { accept: SupportedMimeType.JSONAPI },
-      });
-    } catch (e) {
-      throw new Error(
-        `Your filter refers to a nonexistent type: import { ${codeRef.name} } from "${codeRef.module}"`,
-      );
-    }
-    if (!response.ok) {
-      let message = await response.text();
-      throw new Error(
-        `tried to get card def meta for ${stringify(codeRef)}, but got ${response.status}: ${message} for ${url}`,
-      );
-    }
-    let json = await response.json();
-    return json.data.attributes as CardDefMeta;
+    return await this.#definitionsCache.getDefinition(codeRef);
   }
 
   // we pass the loader in so there is no ambiguity which loader to use as this

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -23,6 +23,7 @@ import {
   type CardCollectionDocument,
 } from './document-types';
 import { type CardResource, type Saved } from './resource-types';
+import { type DefinitionsCache } from './definitions-cache';
 
 type Options = {
   loadLinks?: true;
@@ -52,17 +53,19 @@ export class RealmIndexQueryEngine {
     realm,
     dbAdapter,
     fetch,
+    definitionsCache,
   }: {
     realm: Realm;
     dbAdapter: DBAdapter;
     fetch: typeof globalThis.fetch;
+    definitionsCache: DefinitionsCache;
   }) {
     if (!dbAdapter) {
       throw new Error(
         `DB Adapter was not provided to SearchIndex constructor--this is required when using a db based index`,
       );
     }
-    this.#indexQueryEngine = new IndexQueryEngine(dbAdapter, fetch);
+    this.#indexQueryEngine = new IndexQueryEngine(dbAdapter, definitionsCache);
     this.#realm = realm;
     this.#fetch = fetch;
   }

--- a/packages/runtime-common/tests/index-query-engine-test.ts
+++ b/packages/runtime-common/tests/index-query-engine-test.ts
@@ -9,6 +9,7 @@ import {
   type ResolvedCodeRef,
   DBAdapter,
 } from '../index';
+import { DefinitionsCache } from '../definitions-cache';
 import { serializeCard } from '../helpers/indexer';
 import { testRealmURL } from '../helpers/const';
 import { type SharedTests } from '../helpers';
@@ -133,7 +134,7 @@ const tests = Object.freeze({
 
   "can filter using 'eq'": async (
     assert,
-    { indexQueryEngine, dbAdapter, testCards },
+    { indexQueryEngine, dbAdapter, testCards, definitionsCache },
   ) => {
     let { mango, vangogh, paper } = testCards;
     await setupIndex(dbAdapter, [
@@ -157,6 +158,11 @@ const tests = Object.freeze({
 
     assert.strictEqual(meta.page.total, 1, 'the total results meta is correct');
     assert.deepEqual(getIds(results), [mango.id], 'results are correct');
+
+    assert.ok(
+      definitionsCache.cachedKeys.includes(internalKeyFor(type, undefined)),
+      'definition was cached',
+    );
   },
 
   "can filter using 'eq' thru nested fields": async (
@@ -2728,6 +2734,7 @@ const tests = Object.freeze({
   indexQueryEngine: IndexQueryEngine;
   dbAdapter: DBAdapter;
   testCards: TestCards;
+  definitionsCache: DefinitionsCache;
 }>);
 
 export default tests;


### PR DESCRIPTION
This PR adds a caching layer to our card def meta access. Which similar to the now removed Loader will invalidate whenever modules change in the index.