### PR TITLE
Implement rendering of card in host submode

### DIFF
--- a/packages/host/app/components/operator-mode/host-submode.gts
+++ b/packages/host/app/components/operator-mode/host-submode.gts
@@ -8,14 +8,7 @@ import { consume } from 'ember-provide-consume-context';
 
 import { BoxelButton, CardContainer } from '@cardstack/boxel-ui/components';
 
-import {
-  type getCard,
-  type getCards,
-  type getCardCollection,
-  GetCardContextName,
-  GetCardsContextName,
-  GetCardCollectionContextName,
-} from '@cardstack/runtime-common';
+import { type getCard, GetCardContextName } from '@cardstack/runtime-common';
 import { meta } from '@cardstack/runtime-common/constants';
 
 import CardRenderer from '@cardstack/host/components/card-renderer';
@@ -24,11 +17,9 @@ import OperatorModeStateService from '@cardstack/host/services/operator-mode-sta
 
 import type StoreService from '@cardstack/host/services/store';
 
-import type { CardContext, CardDef } from 'https://cardstack.com/base/card-api';
+import type { CardDef } from 'https://cardstack.com/base/card-api';
 
 import SubmodeLayout from './submode-layout';
-
-type HostModeCardContext = Omit<CardContext, 'prerenderedCardSearchComponent'>;
 
 interface HostSubmodeSignature {
   Element: HTMLElement;
@@ -37,9 +28,6 @@ interface HostSubmodeSignature {
 
 export default class HostSubmode extends Component<HostSubmodeSignature> {
   @consume(GetCardContextName) private declare getCard: getCard;
-  @consume(GetCardsContextName) private declare getCards: getCards;
-  @consume(GetCardCollectionContextName)
-  private declare getCardCollection: getCardCollection;
 
   @service private declare operatorModeStateService: OperatorModeStateService;
   @service private declare store: StoreService;
@@ -97,15 +85,6 @@ export default class HostSubmode extends Component<HostSubmodeSignature> {
     return 'container';
   }
 
-  private get cardContext(): HostModeCardContext {
-    return {
-      getCard: this.getCard,
-      getCards: this.getCards,
-      getCardCollection: this.getCardCollection,
-      store: this.store,
-    };
-  }
-
   <template>
     <SubmodeLayout
       class='host-submode-layout'
@@ -127,7 +106,6 @@ export default class HostSubmode extends Component<HostSubmodeSignature> {
                     class='card-preview'
                     @card={{this.currentCard}}
                     @format='isolated'
-                    @cardContext={{this.cardContext}}
                     data-test-host-submode-card={{this.currentCard.id}}
                   />
                 </CardContainer>

--- a/packages/host/app/components/operator-mode/host-submode.gts
+++ b/packages/host/app/components/operator-mode/host-submode.gts
@@ -24,7 +24,7 @@ import OperatorModeStateService from '@cardstack/host/services/operator-mode-sta
 
 import type StoreService from '@cardstack/host/services/store';
 
-import type { CardContext } from 'https://cardstack.com/base/card-api';
+import type { CardContext, CardDef } from 'https://cardstack.com/base/card-api';
 
 import SubmodeLayout from './submode-layout';
 
@@ -86,7 +86,7 @@ export default class HostSubmode extends Component<HostSubmodeSignature> {
     }
 
     // Check if the card prefers wide format
-    if (this.currentCard.constructor.prefersWideFormat) {
+    if ((this.currentCard.constructor as typeof CardDef).prefersWideFormat) {
       return 'host-mode-content is-wide';
     }
 

--- a/packages/host/app/components/operator-mode/host-submode.gts
+++ b/packages/host/app/components/operator-mode/host-submode.gts
@@ -4,11 +4,8 @@ import { service } from '@ember/service';
 import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
 
-import { consume } from 'ember-provide-consume-context';
-
 import { BoxelButton, CardContainer } from '@cardstack/boxel-ui/components';
 
-import { type getCard, GetCardContextName } from '@cardstack/runtime-common';
 import { meta } from '@cardstack/runtime-common/constants';
 
 import CardRenderer from '@cardstack/host/components/card-renderer';
@@ -20,6 +17,7 @@ import type StoreService from '@cardstack/host/services/store';
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 
 import SubmodeLayout from './submode-layout';
+import { getCard } from '@cardstack/host/resources/card-resource';
 
 interface HostSubmodeSignature {
   Element: HTMLElement;
@@ -27,8 +25,6 @@ interface HostSubmodeSignature {
 }
 
 export default class HostSubmode extends Component<HostSubmodeSignature> {
-  @consume(GetCardContextName) private declare getCard: getCard;
-
   @service private declare operatorModeStateService: OperatorModeStateService;
   @service private declare store: StoreService;
 
@@ -40,7 +36,7 @@ export default class HostSubmode extends Component<HostSubmodeSignature> {
     if (!this.currentCardId) {
       return undefined;
     }
-    return this.getCard(this, () => this.currentCardId);
+    return getCard(this, () => this.currentCardId);
   }
 
   get currentCard() {

--- a/packages/host/app/components/operator-mode/host-submode.gts
+++ b/packages/host/app/components/operator-mode/host-submode.gts
@@ -186,7 +186,6 @@ export default class HostSubmode extends Component<HostSubmodeSignature> {
         flex: 1;
         overflow-y: auto;
         overflow-x: hidden;
-        padding: var(--boxel-sp);
       }
 
       .host-mode-content.is-wide .container {

--- a/packages/host/app/components/operator-mode/host-submode.gts
+++ b/packages/host/app/components/operator-mode/host-submode.gts
@@ -1,13 +1,34 @@
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { service } from '@ember/service';
+import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
+
+import { consume } from 'ember-provide-consume-context';
 
 import { BoxelButton, CardContainer } from '@cardstack/boxel-ui/components';
 
+import {
+  type getCard,
+  type getCards,
+  type getCardCollection,
+  GetCardContextName,
+  GetCardsContextName,
+  GetCardCollectionContextName,
+} from '@cardstack/runtime-common';
+import { meta } from '@cardstack/runtime-common/constants';
+
+import CardRenderer from '@cardstack/host/components/card-renderer';
+
 import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
+import type StoreService from '@cardstack/host/services/store';
+
+import type { CardContext } from 'https://cardstack.com/base/card-api';
+
 import SubmodeLayout from './submode-layout';
+
+type HostModeCardContext = Omit<CardContext, 'prerenderedCardSearchComponent'>;
 
 interface HostSubmodeSignature {
   Element: HTMLElement;
@@ -15,7 +36,75 @@ interface HostSubmodeSignature {
 }
 
 export default class HostSubmode extends Component<HostSubmodeSignature> {
+  @consume(GetCardContextName) private declare getCard: getCard;
+  @consume(GetCardsContextName) private declare getCards: getCards;
+  @consume(GetCardCollectionContextName)
+  private declare getCardCollection: getCardCollection;
+
   @service private declare operatorModeStateService: OperatorModeStateService;
+  @service private declare store: StoreService;
+
+  get currentCardId() {
+    return this.operatorModeStateService.currentTrailItem?.replace('.json', '');
+  }
+
+  get currentCardResource() {
+    if (!this.currentCardId) {
+      return undefined;
+    }
+    return this.getCard(this, () => this.currentCardId);
+  }
+
+  get currentCard() {
+    return this.currentCardResource?.card;
+  }
+
+  get isError() {
+    return this.currentCardResource?.cardError;
+  }
+
+  get isLoading() {
+    return this.currentCardId && !this.currentCard && !this.isError;
+  }
+
+  get backgroundImageStyle() {
+    if (!this.currentCard) {
+      return false;
+    }
+
+    let backgroundImageUrl = this.currentCard[meta]?.realmInfo?.backgroundURL;
+
+    if (backgroundImageUrl) {
+      return htmlSafe(`background-image: url(${backgroundImageUrl});`);
+    }
+    return false;
+  }
+
+  get hostModeContentClass() {
+    if (!this.currentCard) {
+      return 'host-mode-content';
+    }
+
+    // Check if the card prefers wide format
+    if (this.currentCard.constructor.prefersWideFormat) {
+      return 'host-mode-content is-wide';
+    }
+
+    return 'host-mode-content';
+  }
+
+  get containerClass() {
+    return 'container';
+  }
+
+  private get cardContext(): HostModeCardContext {
+    return {
+      getCard: this.getCard,
+      getCards: this.getCards,
+      getCardCollection: this.getCardCollection,
+      store: this.store,
+    };
+  }
 
   <template>
     <SubmodeLayout
@@ -23,45 +112,138 @@ export default class HostSubmode extends Component<HostSubmodeSignature> {
       data-test-host-submode
       as |layout|
     >
-      <div class='host-submode'>
-        <CardContainer @displayBoundaries={{true}} class='container'>
-          {{#if this.operatorModeStateService.currentRealmInfo.publishable}}
-            <p
-              data-test-host-submode-card={{this.operatorModeStateService.currentTrailItem}}
-            >
-              Host submode:
-              {{this.operatorModeStateService.currentTrailItem}}
-            </p>
-          {{else}}
-            <p>
-              This file is not in a publishable realm.
-            </p>
-            <BoxelButton
-              {{on 'click' (fn layout.updateSubmode 'interact')}}
-              data-test-switch-to-interact
-            >View in Interact mode</BoxelButton>
-          {{/if}}
-        </CardContainer>
+      <div class='host-submode' style={{this.backgroundImageStyle}}>
+        <div class='host-mode-top-bar'>
+        </div>
+        <div class={{this.hostModeContentClass}}>
+          <CardContainer
+            @displayBoundaries={{true}}
+            class={{this.containerClass}}
+          >
+            {{#if this.operatorModeStateService.currentRealmInfo.publishable}}
+              {{#if this.currentCard}}
+                <CardContainer class='card'>
+                  <CardRenderer
+                    class='card-preview'
+                    @card={{this.currentCard}}
+                    @format='isolated'
+                    @cardContext={{this.cardContext}}
+                    data-test-host-submode-card={{this.currentCard.id}}
+                  />
+                </CardContainer>
+              {{else if this.isError}}
+                <div data-test-host-submode-error class='error-message'>
+                  <p>Card not found: {{this.currentCardId}}</p>
+                </div>
+              {{else if this.isLoading}}
+                <div class='loading-message'>
+                  <p>Loading card...</p>
+                </div>
+              {{/if}}
+            {{else}}
+              <div class='non-publishable-message'>
+                <p>This file is not in a publishable realm.</p>
+                <BoxelButton
+                  {{on 'click' (fn layout.updateSubmode 'interact')}}
+                  data-test-switch-to-interact
+                >View in Interact mode</BoxelButton>
+              </div>
+            {{/if}}
+          </CardContainer>
+        </div>
       </div>
     </SubmodeLayout>
 
     <style scoped>
+      .host-submode-layout :deep(.submode-switcher),
+      .host-submode-layout :deep(.workspace-button) {
+        border: 1px solid #ffffff59;
+      }
+
       .host-submode {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        width: 100%;
+        background-position: center;
+        background-size: cover;
+      }
+
+      .host-mode-top-bar {
+        background-color: var(--boxel-700);
+        padding: var(--boxel-sp);
+        border-bottom: 1px solid var(--boxel-600);
+        flex-shrink: 0;
+        height: 60px;
+      }
+
+      .host-mode-top-bar-content {
         display: flex;
         align-items: center;
         justify-content: center;
-        height: 100%;
-        width: 100%;
+      }
+
+      .host-mode-title {
+        color: var(--boxel-light);
+        font-weight: 600;
+        font-size: var(--boxel-font-size-sm);
+      }
+
+      .host-mode-content {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        flex: 1;
+        overflow: hidden;
+        padding: var(--boxel-sp);
+      }
+
+      .host-mode-content.is-wide {
+        padding: 0;
       }
 
       .container {
+        width: 50rem;
+        flex: 1;
+        overflow-y: auto;
+        overflow-x: hidden;
+        padding: var(--boxel-sp);
+      }
+
+      .host-mode-content.is-wide .container {
+        width: 100%;
+        max-width: 100%;
+        padding: 0;
+      }
+
+      .card {
+        width: 50rem;
+      }
+
+      .host-mode-content.is-wide .card {
+        width: 100%;
+        max-width: 100%;
+      }
+
+      .error-message,
+      .loading-message,
+      .non-publishable-message,
+      .no-card-message {
         display: flex;
         flex-direction: column;
-        gap: var(--boxel-sp);
         align-items: center;
         justify-content: center;
-        width: 30rem;
-        height: 80%;
+        gap: var(--boxel-sp);
+        text-align: center;
+      }
+
+      .error-message {
+        color: var(--boxel-error-100);
+      }
+
+      .host-submode :deep(.boxel-card-container) {
+        overflow: auto;
       }
     </style>
   </template>

--- a/packages/host/app/components/operator-mode/host-submode.gts
+++ b/packages/host/app/components/operator-mode/host-submode.gts
@@ -10,6 +10,7 @@ import { meta } from '@cardstack/runtime-common/constants';
 
 import CardRenderer from '@cardstack/host/components/card-renderer';
 
+import { getCard } from '@cardstack/host/resources/card-resource';
 import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 import type StoreService from '@cardstack/host/services/store';
@@ -17,7 +18,6 @@ import type StoreService from '@cardstack/host/services/store';
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 
 import SubmodeLayout from './submode-layout';
-import { getCard } from '@cardstack/host/resources/card-resource';
 
 interface HostSubmodeSignature {
   Element: HTMLElement;

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -53,6 +53,7 @@ import WorkspaceChooser from './workspace-chooser';
 import type AiAssistantPanelService from '../../services/ai-assistant-panel-service';
 import type MatrixService from '../../services/matrix-service';
 import type OperatorModeStateService from '../../services/operator-mode-state-service';
+import type RecentCardsService from '../../services/recent-cards-service';
 import type StoreService from '../../services/store';
 
 interface Signature {
@@ -107,6 +108,7 @@ export default class SubmodeLayout extends Component<Signature> {
   @service private declare matrixService: MatrixService;
   @service private declare store: StoreService;
   @service private declare aiAssistantPanelService: AiAssistantPanelService;
+  @service private declare recentCardsService: RecentCardsService;
 
   private searchElement: HTMLElement | null = null;
   private suppressSearchClose = false;
@@ -166,7 +168,39 @@ export default class SubmodeLayout extends Component<Signature> {
         let currentSubmode = this.operatorModeStateService.state.submode;
 
         if (currentSubmode === Submodes.Code) {
-          this.operatorModeStateService.updateTrail([]);
+          // Check if current code path is a card instance ID
+          let codePathString = this.operatorModeStateService.codePathString;
+          if (codePathString) {
+            let cardId = codePathString.replace(/\.json$/, '');
+            let card = this.store.peek(cardId);
+
+            if (card && this.isCardInstance(card)) {
+              // Current code path is a card instance, use it directly
+              this.operatorModeStateService.updateTrail([codePathString]);
+            } else {
+              // Current code path is a card definition, try to get card ID from playground panel
+              let playgroundSelection =
+                this.operatorModeStateService.playgroundPanelSelection;
+              if (playgroundSelection?.cardId) {
+                this.operatorModeStateService.updateTrail([
+                  playgroundSelection.cardId + '.json',
+                ]);
+              } else {
+                // Try to find any card instance related to this definition
+                let relatedCardId =
+                  await this.findRelatedCardInstance(codePathString);
+                if (relatedCardId) {
+                  this.operatorModeStateService.updateTrail([
+                    relatedCardId + '.json',
+                  ]);
+                } else {
+                  this.operatorModeStateService.updateTrail([]);
+                }
+              }
+            }
+          } else {
+            this.operatorModeStateService.updateTrail([]);
+          }
         } else if (currentSubmode === Submodes.Interact) {
           this.operatorModeStateService.updateTrail(
             this.lastCardIdInRightMostStack
@@ -182,6 +216,45 @@ export default class SubmodeLayout extends Component<Signature> {
     }
 
     this.operatorModeStateService.updateSubmode(submode);
+  }
+
+  private isCardInstance(card: any): boolean {
+    return card && typeof card === 'object' && 'id' in card && card.id;
+  }
+
+  private async findRelatedCardInstance(
+    definitionPath: string,
+  ): Promise<string | null> {
+    try {
+      // Try to find any card instance that adopts from this definition
+      // This is a simplified approach - in a real implementation you might want to
+      // search through recent cards or use a more sophisticated lookup
+      let recentCards = this.recentCardsService.recentCards;
+
+      for (let recentCard of recentCards) {
+        let card = this.store.peek(recentCard.cardId);
+        if (card && this.isCardInstance(card)) {
+          // Check if this card adopts from the definition we're looking at
+          // This is a simplified check - you might need more sophisticated logic
+          let definitionName = definitionPath
+            .split('/')
+            .pop()
+            ?.replace('.json', '');
+          if (
+            definitionName &&
+            card.constructor.name === definitionName &&
+            card.id
+          ) {
+            return card.id;
+          }
+        }
+      }
+
+      return null;
+    } catch (error) {
+      console.warn('Error finding related card instance:', error);
+      return null;
+    }
   }
 
   @action private closeSearchSheet() {

--- a/packages/host/tests/acceptance/host-submode-test.gts
+++ b/packages/host/tests/acceptance/host-submode-test.gts
@@ -150,13 +150,8 @@ module('Acceptance | host submode', function (hooks) {
 
       await click('[data-test-submode-switcher] button');
       await click('[data-test-boxel-menu-item-text="Host"]');
-      assert
-        .dom('[data-test-host-submode-card]')
-        .hasAttribute(
-          'data-test-host-submode-card',
-          `${testRealmURL}Person/1.json`,
-        )
-        .exists();
+      assert.dom('[data-test-host-submode-card]').exists();
+      assert.dom('[data-test-host-submode-card]').hasText('Title: A B');
     });
 
     test('entering from code mode shows the index card', async function (assert) {
@@ -167,13 +162,60 @@ module('Acceptance | host submode', function (hooks) {
 
       await click('[data-test-submode-switcher] button');
       await click('[data-test-boxel-menu-item-text="Host"]');
+      assert.dom('[data-test-host-submode-card]').exists();
+      // CardsGrid should be rendered (index card)
+      assert.dom('.boxel-card-container').exists();
+    });
+
+    test('entering from code mode with card instance shows the same card', async function (assert) {
+      await visitOperatorMode({
+        submode: 'code',
+        codePath: `${testRealmURL}Person/1.json`,
+      });
+
+      await click('[data-test-submode-switcher] button');
+      await click('[data-test-boxel-menu-item-text="Host"]');
+      assert.dom('[data-test-host-submode-card]').exists();
+      assert.dom('[data-test-host-submode-card]').hasText('Title: A B');
+    });
+
+    test('wide format cards use full width', async function (assert) {
+      await visitOperatorMode({
+        submode: 'host',
+        trail: [`${testRealmURL}index.json`], // CardsGrid has prefersWideFormat = true
+      });
+
+      assert.dom('.host-mode-content').hasClass('is-wide');
+      assert.dom('.container').hasClass('container');
+      // The width is applied via CSS class, not inline style
+      assert.dom('.host-mode-content.is-wide').exists();
+    });
+
+    test('regular format cards use standard width', async function (assert) {
+      await visitOperatorMode({
+        submode: 'host',
+        trail: [`${testRealmURL}Person/1.json`],
+      });
+
+      assert.dom('.host-mode-content').doesNotHaveClass('is-wide');
+      assert.dom('.container').hasClass('container');
+      // The width is applied via CSS class, not inline style
+      assert.dom('.host-mode-content:not(.is-wide)').exists();
+    });
+
+    test('shows error state when card is not found', async function (assert) {
+      await visitOperatorMode({
+        submode: 'host',
+        trail: [`${testRealmURL}nonexistent.json`],
+      });
+
+      // Wait for loading to complete and error to show
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      assert.dom('[data-test-host-submode-error]').exists();
       assert
-        .dom('[data-test-host-submode-card]')
-        .hasAttribute(
-          'data-test-host-submode-card',
-          `${testRealmURL}index.json`,
-        )
-        .exists();
+        .dom('[data-test-host-submode-error]')
+        .hasText(`Card not found: ${testRealmURL}nonexistent`);
     });
   });
 });

--- a/packages/host/tests/helpers/visit-operator-mode.ts
+++ b/packages/host/tests/helpers/visit-operator-mode.ts
@@ -12,6 +12,7 @@ export default async function visitOperatorMode({
   openDirs,
   moduleInspector,
   workspaceChooserOpened,
+  trail,
 }: Partial<SerializedState>) {
   let operatorModeState = {
     stacks: stacks || [],
@@ -23,6 +24,7 @@ export default async function visitOperatorMode({
     ...(fileView ? { fileView } : {}),
     ...(openDirs ? { openDirs } : {}),
     ...(moduleInspector ? { moduleInspector } : {}),
+    ...(trail ? { trail } : {}),
   };
 
   let operatorModeStateParam = stringify(operatorModeState)!;


### PR DESCRIPTION
This PR implements card rendering in host submode to provide a preview of the public host mode. Key changes:

- **Card Rendering**: Host submode now displays actual rendered cards instead of just showing card IDs or trails
- **Wide Format Support**: Uses the `prefersWideFormat` field to automatically adjust card width (full width vs standard width)
- **Improved Code-to-Host Logic**: Enhanced logic when switching from code submode to host submode to determine which card to display based on context (card instances, playground selections, or related cards)

https://github.com/user-attachments/assets/c8286d48-c934-4448-9b37-01dd1692da6e

