### PR TITLE
Open workspace command should not require trailing slashes

### DIFF
--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -1020,6 +1020,10 @@ export default class OperatorModeStateService extends Service {
   }
 
   openWorkspace = async (realmUrl: string) => {
+    // Ensure realmUrl has a trailing slash
+    if (!realmUrl.endsWith('/')) {
+      realmUrl = realmUrl + '/';
+    }
     let id = `${realmUrl}index`;
     let stackItem = new StackItem({
       id,

--- a/packages/host/tests/integration/commands/open-workspace-test.gts
+++ b/packages/host/tests/integration/commands/open-workspace-test.gts
@@ -56,5 +56,17 @@ module('Integration | commands | open-workspace', function (hooks) {
       operatorModeStateService.state?.stacks[0][0].format,
       'isolated',
     );
+
+    // We logged a case where the realm URL given by the AI assistant was missing a trailing slash.
+    // This test ensures that we handle that case correctly.
+    let realmUrlWithTrailingSlash = testRealmURL;
+    let realmUrlWithoutTrailingSlash = testRealmURL.replace(/\/$/, '');
+    await openWorkspaceCommand.execute({
+      realmUrl: realmUrlWithoutTrailingSlash,
+    });
+    assert.strictEqual(
+      operatorModeStateService.state?.stacks[0][0].id,
+      `${realmUrlWithTrailingSlash}index`,
+    );
   });
 });


### PR DESCRIPTION
Solving this problem:

<img width="789" height="411" alt="image" src="https://github.com/user-attachments/assets/ce7f4a08-7176-4d10-927c-fec4381dedcb" />
