### PR TITLE
Remove places where we run custom card code

### DIFF
--- a/packages/base/boolean.gts
+++ b/packages/base/boolean.gts
@@ -35,9 +35,7 @@ export default class BooleanField extends FieldDef {
   static [fieldSerializer] = 'boolean';
   static [useIndexBasedKey]: never;
 
-  static get [emptyValue]() {
-    return false;
-  }
+  static [emptyValue] = false;
 
   static embedded = View;
   static atom = View;

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -2048,9 +2048,7 @@ export class BaseDef {
     return instance.constructor.icon;
   }
 
-  static get [emptyValue](): any {
-    return undefined;
-  }
+  static [emptyValue]: object | string | number | null | boolean | undefined;
 
   static [serialize](
     value: any,

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -708,13 +708,7 @@ class ContainsMany<FieldT extends FieldDefConstructor>
                 opts,
               );
             }
-            return this.card[deserialize](
-              entry,
-              relativeTo,
-              doc,
-              identityContext,
-              opts,
-            );
+            return entry;
           } else {
             let meta = metas[index];
             let resource: LooseCardResource = {
@@ -957,13 +951,7 @@ class Contains<CardT extends FieldDefConstructor> implements Field<CardT, any> {
           opts,
         );
       }
-      return this.card[deserialize](
-        value,
-        relativeTo,
-        doc,
-        identityContext,
-        opts,
-      );
+      return value;
     }
     if (fieldMeta && Array.isArray(fieldMeta)) {
       throw new Error(
@@ -2150,7 +2138,6 @@ export class BaseDef {
     opts?: DeserializeOpts,
   ): Promise<BaseInstanceType<T>> {
     if (primitive in this) {
-      // primitive cards can override this as need be
       return data;
     }
     return _createFromSerialized(

--- a/packages/experiments-realm/carving-turn-diagram.gts
+++ b/packages/experiments-realm/carving-turn-diagram.gts
@@ -39,9 +39,6 @@ import {
   CardDef,
   FieldDef,
   primitive,
-  deserialize,
-  BaseDefConstructor,
-  BaseInstanceType,
   contains,
   containsMany,
   field,
@@ -62,15 +59,6 @@ class DiagramType extends FieldDef {
   static displayName = 'Carving Turn Diagram Type';
   static [primitive]: 'heel' | 'toe' | 'toe-heel';
 
-  static async [deserialize]<T extends BaseDefConstructor>(
-    this: T,
-    val: any,
-  ): Promise<BaseInstanceType<T>> {
-    if (val === undefined || val === null) {
-      return 'toe-heel' as BaseInstanceType<T>;
-    }
-    return val as BaseInstanceType<T>;
-  }
   static embedded = class Embedded extends Component<typeof this> {
     <template>
       {{@model}}
@@ -125,6 +113,7 @@ class IsolatedView extends Component<typeof CarvingTurnDiagram> {
   constructor(owner: Owner, args: any) {
     super(owner, args);
     (globalThis as any).__carvingDiagram = this;
+    this.args.model.diagramType = 'toe-heel';
   }
 
   get showToeTurn() {

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -17,7 +17,6 @@ import { FieldContainer } from '@cardstack/boxel-ui/components';
 
 import {
   baseRealm,
-  primitive,
   type Realm,
   type LooseSingleCardDocument,
 } from '@cardstack/runtime-common';
@@ -96,21 +95,13 @@ module('Acceptance | operator mode tests', function (hooks) {
     let {
       field,
       contains,
-      deserialize,
       linksTo,
       linksToMany,
-      BaseDef,
-      CardDef,
       Component,
       FieldDef,
+      CardDef,
     } = cardApi;
     let { default: StringField } = string;
-    type BaseDefConstructor = typeof BaseDef;
-    type BaseInstanceType<T extends BaseDefConstructor> = T extends {
-      [primitive]: infer P;
-    }
-      ? P
-      : InstanceType<T>;
 
     class Pet extends CardDef {
       static displayName = 'Pet';
@@ -279,24 +270,14 @@ module('Acceptance | operator mode tests', function (hooks) {
       };
     }
 
-    class BoomField extends FieldDef {
-      static [primitive]: string;
-      static async [deserialize]<T extends BaseDefConstructor>(
-        this: T,
-      ): Promise<BaseInstanceType<T>> {
-        throw new Error('Boom!');
-      }
-      static embedded = class Embedded extends Component<typeof this> {
-        <template>
-          {{@model}}
-        </template>
-      };
-    }
-
     class BoomPerson extends CardDef {
       static displayName = 'Boom Person';
       @field firstName = contains(StringField);
-      @field boom = contains(BoomField);
+      @field boom = contains(StringField, {
+        computeVia: function (this: BoomPerson) {
+          throw new Error('Boom!');
+        },
+      });
       @field title = contains(StringField, {
         computeVia: function (this: BoomPerson) {
           return this.firstName;
@@ -308,7 +289,6 @@ module('Acceptance | operator mode tests', function (hooks) {
       mockMatrixUtils,
       contents: {
         'address.gts': { Address },
-        'boom-field.gts': { BoomField },
         'boom-person.gts': { BoomPerson },
         'country-with-no-embedded-template.gts': { CountryWithNoEmbedded },
         'address-with-no-embedded-template.gts': { AddressWithNoEmbedded },


### PR DESCRIPTION
This removes running the `[deserialize]` custom card function, as well as running the `[emptyValue]` custom card function.