### PR TITLE
Update grid layout in command header for better responsiveness

### DIFF
--- a/packages/host/app/components/ai-assistant/code-block/command-header.gts
+++ b/packages/host/app/components/ai-assistant/code-block/command-header.gts
@@ -44,7 +44,7 @@ const CodeBlockCommandHeader: TemplateOnlyComponent<CodeBlockCommandHeaderSignat
     <style scoped>
       .code-block-header {
         display: grid;
-        grid-template-columns: 1fr auto;
+        grid-template-columns: minmax(0, 1fr) max-content;
         gap: var(--boxel-sp-xxxs);
         align-items: center;
         min-height: 3.125rem; /* 50px */
@@ -61,6 +61,7 @@ const CodeBlockCommandHeader: TemplateOnlyComponent<CodeBlockCommandHeaderSignat
         letter-spacing: var(--boxel-lsp-xs);
         line-height: 1.5em;
         text-wrap: pretty;
+        overflow-wrap: break-word;
       }
       .actions {
         margin-left: auto;


### PR DESCRIPTION
The problem:

<img width="379" height="266" alt="image" src="https://github.com/user-attachments/assets/23c3fc5f-7fa6-4c88-8b31-548a20c56956" />

With the solution:

<img width="426" height="454" alt="image" src="https://github.com/user-attachments/assets/47368882-d9df-4170-9e8e-f47e817c0773" />
