### PR TITLE
Refactor API to not use NotLoaded errors to load missing fields

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -238,6 +238,10 @@ const fieldDescriptions = initSharedState(
   'fieldDescriptions',
   () => new WeakMap<typeof BaseDef, Map<string, string>>(),
 );
+const inflightLinkLoads = initSharedState(
+  'inflightLinkLoads',
+  () => new WeakMap<CardDef, Map<string, Promise<unknown>>>(),
+);
 
 // our place for notifying Glimmer when a card is ready to re-render
 const cardTracking = initSharedState(
@@ -322,7 +326,9 @@ export interface CardStore {
   set(url: string, instance: CardDef): void;
   setNonTracked(id: string, instance: CardDef): void;
   makeTracked(id: string): void;
-  load(url: string): Promise<SingleCardDocument | CardError>;
+  loadDocument(url: string): Promise<SingleCardDocument | CardError>;
+  trackLoad(load: Promise<unknown>): void;
+  loaded(): Promise<void>;
 }
 
 type JSONAPIResource =
@@ -530,9 +536,7 @@ class ContainsMany<FieldT extends FieldDefConstructor>
     let maybeNotLoaded = deserialized.get(this.name);
     // a not loaded error can blow up thru a computed containsMany field that consumes a link
     if (isNotLoadedValue(maybeNotLoaded)) {
-      // TODO instead of throwing not loaded we trigger the load of this link.
-      // in this case we are dealing with a computed that is consuming a not loaded field
-      throw new NotLoaded(instance, maybeNotLoaded.reference, this.name);
+      lazilyLoadLink(instance as CardDef, this, maybeNotLoaded.reference);
     }
     return getter(instance, this);
   }
@@ -842,9 +846,7 @@ class Contains<CardT extends FieldDefConstructor> implements Field<CardT, any> {
     let maybeNotLoaded = deserialized.get(this.name);
     // a not loaded error can blow up thru a computed contains field that consumes a link
     if (isNotLoadedValue(maybeNotLoaded)) {
-      // TODO instead of throwing not loaded we trigger the load of this link.
-      // in this case we are dealing with a computed that is consuming a not loaded field
-      throw new NotLoaded(instance, maybeNotLoaded.reference, this.name);
+      lazilyLoadLink(instance as CardDef, this, maybeNotLoaded.reference);
     }
     return getter(instance, this);
   }
@@ -1042,25 +1044,7 @@ class LinksTo<CardT extends CardDefConstructor> implements Field<CardT> {
     cardTracking.get(instance);
     let maybeNotLoaded = deserialized.get(this.name);
     if (isNotLoadedValue(maybeNotLoaded)) {
-      // What happens to the visit() function that we were using in the render
-      // service as a result of catching this error that is being used to allow
-      // the indexer to visit the consumption graph for this unloaded link?
-      //
-      // is that something that we still care about? i think visit() is something that helps
-      // guide the order of the indexing such that we prioritize the links that the
-      // currently indexed card consumes--otherwise we would have to wait until the
-      // indexer eventually gets around to indexing our link... also, when we get to
-      // cross realm invalidation, the visit() could be a tool that allows us to trigger invalidation
-      // in a different realm
-      //
-      // should we trigger the visit of the unloaded link here instead? maybe the indexer
-      // visit() is part of the store?
-      //
-      // Perhaps we store an [isLoaded] meta for this field too in case the template
-      // wants to know about in-flight values?
-      // let store = getStore(instance);
-
-      throw new NotLoaded(instance, maybeNotLoaded.reference, this.name);
+      lazilyLoadLink(instance, this, maybeNotLoaded.reference);
     }
     return getter(instance, this);
   }
@@ -1280,6 +1264,7 @@ class LinksTo<CardT extends CardDefConstructor> implements Field<CardT> {
     return fieldValue as BaseInstanceType<CardT>;
   }
 
+  // TODO we should be able to get rid of this when we decommission the old prerender
   private async loadMissingField(
     instance: CardDef,
     notLoaded: NotLoadedValue | NotLoaded,
@@ -1291,7 +1276,7 @@ class LinksTo<CardT extends CardDefConstructor> implements Field<CardT> {
       maybeRelativeReference as string,
       instance.id ?? relativeTo, // new instances may not yet have an ID, in that case fallback to the relativeTo
     ).href;
-    let doc = await store.load(reference);
+    let doc = await store.loadDocument(reference);
     if (isCardError(doc)) {
       let cardError = doc;
       cardError.deps = [reference];
@@ -1425,8 +1410,10 @@ class LinksToMany<FieldT extends CardDefConstructor>
 
     // Handle the case where the field was set to a single NotLoadedValue during deserialization
     if (isNotLoadedValue(value)) {
-      // TODO instead of throwing not loaded we trigger the load of this field.
-      throw new NotLoaded(instance, value.reference, this.name);
+      value = this.emptyValue(instance);
+      deserialized.set(this.name, value);
+      lazilyLoadLink(instance, this, value.reference, { value, index: 0 });
+      return this.emptyValue as BaseInstanceType<FieldT>;
     }
 
     // Ensure we have an array - if not, something went wrong during deserialization
@@ -1446,8 +1433,9 @@ class LinksToMany<FieldT extends CardDefConstructor>
       }
     }
     if (notLoadedRefs.length > 0) {
-      // TODO instead of throwing not loaded we trigger the load of these links
-      throw new NotLoaded(instance, notLoadedRefs, this.name);
+      for (let [index, reference] of notLoadedRefs.entries()) {
+        lazilyLoadLink(instance, this, reference, { value, index });
+      }
     }
 
     return value as BaseInstanceType<FieldT>;
@@ -1795,6 +1783,7 @@ class LinksToMany<FieldT extends CardDefConstructor>
     return result;
   }
 
+  // TODO we should be able to get rid of this when we decommission the old prerender
   private async loadMissingFields(
     instance: CardDef,
     notLoaded: NotLoaded,
@@ -1813,7 +1802,7 @@ class LinksToMany<FieldT extends CardDefConstructor>
 
     const loadPromises = refs.map(async (reference) => {
       try {
-        let doc = await store.load(reference);
+        let doc = await store.loadDocument(reference);
         if (isCardError(doc)) {
           let cardError = doc;
           cardError.deps = [reference];
@@ -2630,6 +2619,66 @@ function getUsedFields(instance: BaseDef): string[] {
   return [...getDataBucket(instance)?.keys()];
 }
 
+function lazilyLoadLink(
+  instance: CardDef,
+  field: Field,
+  link: string,
+  pluralArgs?: { value: any[]; index: number },
+) {
+  if ((globalThis as any).__lazilyLoadLinks) {
+    let inflightLoads = inflightLinkLoads.get(instance);
+    if (!inflightLoads) {
+      inflightLoads = new Map();
+      inflightLinkLoads.set(instance, inflightLoads);
+    }
+    let promise = inflightLoads.get(`${field.name}/${link}`);
+    let store = getStore(instance);
+    if (promise) {
+      store.trackLoad(promise);
+      return;
+    }
+    let deferred = new Deferred<void>();
+    inflightLoads.set(`${field.name}/${link}`, deferred.promise);
+    store.trackLoad(deferred.promise);
+    let reference = new URL(link, instance.id ?? instance[relativeTo]).href;
+    (async () => {
+      try {
+        let doc = await store.loadDocument(reference);
+        if (isCardError(doc)) {
+          let cardError = doc;
+          cardError.deps = [reference];
+          throw cardError;
+        }
+        let fieldValue = (await createFromSerialized(
+          doc.data,
+          doc,
+          new URL(doc.data.id!),
+          {
+            store,
+          },
+        )) as CardDef;
+        if (pluralArgs) {
+          let { value, index } = pluralArgs;
+          value[index] = fieldValue;
+        } else {
+          (instance as any)[field.name] = fieldValue;
+        }
+        deferred.fulfill();
+      } catch (e) {
+        // TODO We need to handle this error in rendering....
+        deferred.reject(e);
+      } finally {
+        inflightLoads.delete(`${field.name}/${link}`);
+        if (inflightLoads.size === 0) {
+          inflightLinkLoads.delete(instance);
+        }
+      }
+    })();
+  } else {
+    throw new NotLoaded(instance, link, field.name);
+  }
+}
+
 type Scalar =
   | string
   | number
@@ -3426,6 +3475,7 @@ export function getComponent(
   return boxComponent;
 }
 
+// TODO we should be able to get rid of this when we decommission the old prerender
 export async function ensureLinksLoaded(card: BaseDef): Promise<void> {
   // Note that after each async step we check to see if we are still the
   // current promise, otherwise we bail
@@ -3759,18 +3809,28 @@ export function getCardMeta<K extends keyof CardResourceMeta>(
 
 class FallbackCardStore implements CardStore {
   #instances: Map<string, CardDef> = new Map();
+  #inFlight: Promise<unknown>[] = [];
+
   get(id: string) {
+    id = id.replace(/\.json$/, '');
     return this.#instances.get(id);
   }
   set(id: string, instance: CardDef) {
+    id = id.replace(/\.json$/, '');
     return this.#instances.set(id, instance);
   }
   setNonTracked(id: string, instance: CardDef) {
+    id = id.replace(/\.json$/, '');
     return this.#instances.set(id, instance);
   }
   makeTracked(_id: string) {}
-
-  async load(url: string) {
+  trackLoad(load: Promise<unknown>) {
+    this.#inFlight.push(load);
+  }
+  async loaded() {
+    await Promise.allSettled(this.#inFlight);
+  }
+  async loadDocument(url: string) {
     return await loadDocument(fetch, url);
   }
 }

--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -4,10 +4,7 @@ import { service } from '@ember/service';
 
 import { TrackedMap } from 'tracked-built-ins';
 
-import {
-  isCardInstance,
-  LooseSingleCardDocument,
-} from '@cardstack/runtime-common';
+import { LooseSingleCardDocument } from '@cardstack/runtime-common';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 
@@ -28,6 +25,7 @@ export default class RenderRoute extends Route<Model> {
   @service declare private network: NetworkService;
 
   errorHandler = (event: Event) => {
+    // TODO capture error details in event.reason (this is shaped as a CardError)
     let element: HTMLElement = document.querySelector('[data-prerender]')!;
     element.innerHTML = `
       it broke
@@ -43,8 +41,15 @@ export default class RenderRoute extends Route<Model> {
   }
 
   deactivate() {
+    (globalThis as any)._lazilyLoadLinks = undefined;
     window.removeEventListener('error', this.errorHandler);
     window.removeEventListener('unhandledrejection', this.errorHandler);
+  }
+
+  beforeModel() {
+    // activate() doesn't run early enough for this to be set before the model()
+    // hook is run
+    (globalThis as any).__lazilyLoadLinks = true;
   }
 
   async model({ id }: { id: string }) {
@@ -88,22 +93,18 @@ export default class RenderRoute extends Route<Model> {
       },
     };
 
-    // We are fetching links so deeply that it seems very unlikely that we'll
-    // ever have an unloaded link after awaiting the store.add
+    // TODO we'll need a try/catch here to handle serialization errors which
+    // should get rendered into the DOM
     let instance = await this.store.add(enhancedDoc, {
       relativeTo: new URL(id),
       doNotPersist: true,
     });
-    if (!isCardInstance(instance)) {
-      throw new Error('todo: failed to load');
-    }
 
-    // todo: Placeholder for checking in-flight loads
     let state = new TrackedMap();
     state.set('ready', false);
-    Promise.resolve().then(() => {
-      state.set('ready', true);
-    });
+    // TODO we should expose the rejected loads so we can capture in an error doc
+    await this.store.loaded();
+    state.set('ready', true);
 
     return {
       instance,

--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -88,11 +88,12 @@ export default class RenderRoute extends Route<Model> {
       },
     };
 
-    let localId = await this.store.create(enhancedDoc);
-    if (typeof localId !== 'string') {
-      throw new Error('todo: failed to instantiate');
-    }
-    let instance = await this.store.get(localId);
+    // We are fetching links so deeply that it seems very unlikely that we'll
+    // ever have an unloaded link after awaiting the store.add
+    let instance = await this.store.add(enhancedDoc, {
+      relativeTo: new URL(id),
+      doNotPersist: true,
+    });
     if (!isCardInstance(instance)) {
       throw new Error('todo: failed to load');
     }

--- a/packages/host/app/services/render-service.ts
+++ b/packages/host/app/services/render-service.ts
@@ -13,6 +13,7 @@ import {
   RealmPaths,
   loadDocument,
   type CodeRef,
+  type SingleCardDocument,
 } from '@cardstack/runtime-common';
 import { Deferred } from '@cardstack/runtime-common/deferred';
 import { isCardError, CardError } from '@cardstack/runtime-common/error';
@@ -45,26 +46,48 @@ const { environment } = config;
 export class CardStoreWithErrors implements CardStore {
   #cards = new Map<string, CardDef>();
   #fetch: typeof globalThis.fetch;
+  #inFlight: Promise<unknown>[] = [];
+  #docsInFlight: Map<string, Promise<SingleCardDocument | CardError>> =
+    new Map();
 
   constructor(fetch: typeof globalThis.fetch) {
     this.#fetch = fetch;
   }
 
-  get(url: string): CardDef | undefined {
-    return this.#cards.get(url);
+  get(id: string): CardDef | undefined {
+    id = id.replace(/\.json$/, '');
+    return this.#cards.get(id);
   }
-  set(url: string, instance: CardDef): void {
-    this.#cards.set(url, instance);
+  set(id: string, instance: CardDef): void {
+    id = id.replace(/\.json$/, '');
+    this.#cards.set(id, instance);
   }
   setNonTracked(id: string, instance: CardDef) {
+    id = id.replace(/\.json$/, '');
     return this.#cards.set(id, instance);
   }
   makeTracked(_id: string) {}
 
   readonly errors = new Set<string>();
 
-  async load(url: string) {
-    return await loadDocument(this.#fetch, url);
+  async loadDocument(url: string) {
+    let promise = this.#docsInFlight.get(url);
+    if (promise) {
+      return await promise;
+    }
+    try {
+      promise = loadDocument(this.#fetch, url);
+      this.#docsInFlight.set(url, promise);
+      return await promise;
+    } finally {
+      this.#docsInFlight.delete(url);
+    }
+  }
+  trackLoad(load: Promise<unknown>) {
+    this.#inFlight.push(load);
+  }
+  async loaded() {
+    await Promise.allSettled(this.#inFlight);
   }
 }
 

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -194,6 +194,10 @@ export default class StoreService extends Service implements StoreInterface {
     }
   }
 
+  loaded(): Promise<void> {
+    return this.store.loaded();
+  }
+
   // This method creates a new instance in the store and return the new card ID
   async create(
     doc: LooseSingleCardDocument,
@@ -483,12 +487,10 @@ export default class StoreService extends Service implements StoreInterface {
     let card = (await api.createFromSerialized(resource, doc, relativeTo, {
       store: this.store,
     })) as T;
-    // it's important that we absorb the field async here so that glimmer won't
-    // encounter NotLoaded errors, since we don't have the luxury of the indexer
-    // being able to inform us of which fields are used or not at this point.
-    // (this is something that the card compiler could optimize for us in the
-    // future)
-    await api.ensureLinksLoaded(card);
+    if (!(globalThis as any).__lazilyLoadLinks) {
+      // TODO we should be able to get rid of this when we decommission the old prerender
+      await api.ensureLinksLoaded(card);
+    }
     return card;
   }
 

--- a/packages/host/tests/acceptance/prerender-test.gts
+++ b/packages/host/tests/acceptance/prerender-test.gts
@@ -1,0 +1,171 @@
+import { visit, waitFor } from '@ember/test-helpers';
+import { getService } from '@universal-ember/test-support';
+import { baseRealm } from '@cardstack/runtime-common';
+
+import { module, test } from 'qunit';
+
+import {
+  setupLocalIndexing,
+  setupOnSave,
+  testRealmURL,
+  setupAcceptanceTestRealm,
+} from '../helpers';
+import { setupMockMatrix } from '../helpers/mock-matrix';
+import { setupApplicationTest } from '../helpers/setup';
+
+module('Acceptance | prerender', function (hooks) {
+  setupApplicationTest(hooks);
+  setupLocalIndexing(hooks);
+  setupOnSave(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+  });
+
+  async function captureResult(
+    capture: 'textContent' | 'innerHTML' | 'outerHTML',
+    expectedStatus: 'ready' | 'error' = 'ready',
+  ): Promise<{ status: 'ready' | 'error'; value: string }> {
+    await waitFor(`[data-prerender-status="${expectedStatus}"]`);
+    let element = document.querySelector('[data-prerender]') as HTMLElement;
+    let status = element.dataset.prerenderStatus as 'ready' | 'error';
+    if (status === 'error') {
+      return { status, value: element.innerHTML! };
+    } else {
+      return { status, value: element.children[0][capture]! };
+    }
+  }
+
+  hooks.beforeEach(async function () {
+    let loader = getService('loader-service').loader;
+    let cardApi: typeof import('https://cardstack.com/base/card-api');
+    cardApi = await loader.import(`${baseRealm.url}card-api`);
+
+    let { field, contains, linksTo, linksToMany, CardDef, StringField } =
+      cardApi;
+
+    class Pet extends CardDef {
+      static displayName = 'Pet';
+      @field name = contains(StringField);
+      @field petFriend = linksTo(() => Pet);
+      @field title = contains(StringField, {
+        computeVia(this: Pet) {
+          return this.name;
+        },
+      });
+    }
+
+    class Person extends CardDef {
+      static displayName = 'Person';
+      @field name = contains(StringField);
+      @field pets = linksToMany(() => Pet);
+      @field title = contains(StringField, {
+        computeVia(this: Person) {
+          return this.name;
+        },
+      });
+    }
+    await setupAcceptanceTestRealm({
+      mockMatrixUtils,
+      contents: {
+        'person.gts': { Person },
+        'pet.gts': { Pet },
+        'Pet/mango.json': {
+          data: {
+            attributes: { name: 'Mango' },
+            relationships: {
+              petFriend: {
+                links: {
+                  self: './vangogh',
+                },
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: '../pet',
+                name: 'Pet',
+              },
+            },
+          },
+        },
+        'Pet/vangogh.json': {
+          data: {
+            attributes: { name: 'Van Gogh' },
+            meta: {
+              adoptsFrom: {
+                module: '../pet',
+                name: 'Pet',
+              },
+            },
+          },
+        },
+        'Person/hassan.json': {
+          data: {
+            attributes: {
+              name: 'Hassan',
+            },
+            relationships: {
+              'pets.0': {
+                links: {
+                  self: '../Pet/mango',
+                },
+              },
+              'pets.1': {
+                links: {
+                  self: '../Pet/vangogh',
+                },
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: '../person',
+                name: 'Person',
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  // TODO set maxLinkDepth to 0 in order to test link loading properly
+
+  test('can prerender instance with contains field', async function (assert) {
+    let url = `${testRealmURL}Pet/vangogh.json`;
+    await visit(`/render/${encodeURIComponent(url)}/html/isolated/0`);
+    let { value } = await captureResult('innerHTML');
+    assert.ok(
+      /data-test-field="name"?.*Van Gogh/s.test(value),
+      'failed to find "Van Gogh" field value in isolated HTML',
+    );
+  });
+
+  test('can prerender instance with linksTo field', async function (assert) {
+    let url = `${testRealmURL}Pet/mango.json`;
+    await visit(`/render/${encodeURIComponent(url)}/html/isolated/0`);
+    let { value } = await captureResult('innerHTML');
+    assert.ok(
+      /data-test-field="petFriend"?.*Van Gogh/s.test(value),
+      'failed to find "Van Gogh" field value in isolated HTML',
+    );
+  });
+
+  test('can prerender instance with linksToMany field', async function (assert) {
+    let url = `${testRealmURL}Person/hassan.json`;
+    await visit(`/render/${encodeURIComponent(url)}/html/isolated/0`);
+    let { value } = await captureResult('innerHTML');
+    assert.ok(
+      /data-test-field="pets"?.*Mango?.*Van Gogh/s.test(value),
+      'failed to find "Mango" and "Van Gogh" field values in isolated HTML',
+    );
+  });
+
+  // TODO test prerender missing link in linksTo field
+  // TODO test prerender missing link in linksToMany field
+  // TODO test prerender computed that consumes linksTo
+  // TODO test prerender computed that consumes linksToMany
+  // TODO test prerender missing link in computed that consumes linksTo
+  // TODO test prerender missing link in computed that consumes linksToMany
+  // TODO test prerender linksTo cycle
+  // TODO test prerender linksToMany cycle
+});

--- a/packages/host/tests/acceptance/prerender-test.gts
+++ b/packages/host/tests/acceptance/prerender-test.gts
@@ -1,8 +1,10 @@
 import { visit, waitFor } from '@ember/test-helpers';
+
 import { getService } from '@universal-ember/test-support';
-import { baseRealm } from '@cardstack/runtime-common';
 
 import { module, test } from 'qunit';
+
+import { baseRealm } from '@cardstack/runtime-common';
 
 import {
   setupLocalIndexing,

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -289,7 +289,9 @@ export function setupLocalIndexing(hooks: NestedHooks) {
     // Without this, we have been experiencing test failures related to a destroyed owner, e.g.
     // "Cannot call .factoryFor('template:index-card_error') after the owner has been destroyed"
     await settled();
-    await getService('store').flushSaves();
+    let store = getService('store');
+    await store.flushSaves();
+    await store.loaded();
   });
 }
 

--- a/packages/runtime-common/constants.ts
+++ b/packages/runtime-common/constants.ts
@@ -67,7 +67,4 @@ export const EXTRA_TOKENS_PRICING: Record<number, number> = {
   80000: 100, // in USD
 };
 
-export const maxLinkDepth =
-  (globalThis as any).__boxelMaxLinkDepth != null
-    ? (globalThis as any).__boxelMaxLinkDepth
-    : 5;
+export const maxLinkDepth = 5;

--- a/packages/runtime-common/constants.ts
+++ b/packages/runtime-common/constants.ts
@@ -66,3 +66,8 @@ export const EXTRA_TOKENS_PRICING: Record<number, number> = {
   20000: 30,
   80000: 100, // in USD
 };
+
+export const maxLinkDepth =
+  (globalThis as any).__boxelMaxLinkDepth != null
+    ? (globalThis as any).__boxelMaxLinkDepth
+    : 5;

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -200,8 +200,6 @@ import type * as CardAPI from 'https://cardstack.com/base/card-api';
 import { RealmInfo } from './realm';
 import { PrerenderedCard } from './index-query-engine';
 
-export const maxLinkDepth = 5;
-
 export interface MatrixCardError {
   id?: string;
   error: Error;


### PR DESCRIPTION
When in the /render route we lazily load the missing fields instead of throwing NotLoaded errors when the link has not yet been loaded.