### PR TITLE
Loading indicator with theme variables

### DIFF
--- a/packages/boxel-ui/addon/src/components/loading-indicator/index.gts
+++ b/packages/boxel-ui/addon/src/components/loading-indicator/index.gts
@@ -1,4 +1,5 @@
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
+import { concat } from '@ember/helper';
 
 import cssVar from '../../helpers/css-var.ts';
 import LoadingIndicatorIcon from '../../icons/loading-indicator.gts';
@@ -6,18 +7,22 @@ import LoadingIndicatorIcon from '../../icons/loading-indicator.gts';
 interface Signature {
   Args: {
     color?: string;
+    variant?: 'primary' | 'secondary' | 'muted' | 'destructive' | 'default';
   };
   Element: HTMLSpanElement;
 }
 
 const LoadingIndicator: TemplateOnlyComponent<Signature> = <template>
   <span
-    class='boxel-loading-indicator'
+    class='boxel-loading-indicator
+      {{if @variant (concat "variant-" @variant) "variant-default"}}'
     data-test-loading-indicator
     ...attributes
   >
     <LoadingIndicatorIcon
-      style={{cssVar icon-color=@color}}
+      style={{cssVar
+        icon-color=(if @color @color 'var(--loading-indicator-color)')
+      }}
       role='presentation'
     />
   </span>
@@ -32,6 +37,26 @@ const LoadingIndicator: TemplateOnlyComponent<Signature> = <template>
       width: var(--loading-indicator-size);
       height: var(--loading-indicator-size);
       flex-shrink: 0;
+    }
+
+    .variant-default {
+      --loading-indicator-color: var(--foreground);
+    }
+
+    .variant-primary {
+      --loading-indicator-color: var(--primary-foreground);
+    }
+
+    .variant-secondary {
+      --loading-indicator-color: var(--secondary-foreground);
+    }
+
+    .variant-muted {
+      --loading-indicator-color: var(--muted-foreground);
+    }
+
+    .variant-destructive {
+      --loading-indicator-color: var(--destructive-foreground);
     }
 
     /*

--- a/packages/boxel-ui/addon/src/components/loading-indicator/index.gts
+++ b/packages/boxel-ui/addon/src/components/loading-indicator/index.gts
@@ -1,6 +1,7 @@
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { concat } from '@ember/helper';
 
+import cn from '../../helpers/cn.ts';
 import cssVar from '../../helpers/css-var.ts';
 import LoadingIndicatorIcon from '../../icons/loading-indicator.gts';
 
@@ -14,8 +15,10 @@ interface Signature {
 
 const LoadingIndicator: TemplateOnlyComponent<Signature> = <template>
   <span
-    class='boxel-loading-indicator
-      {{if @variant (concat "variant-" @variant) "variant-default"}}'
+    class={{cn
+      'boxel-loading-indicator'
+      (if @variant (concat 'variant-' @variant) 'variant-default')
+    }}
     data-test-loading-indicator
     ...attributes
   >

--- a/packages/boxel-ui/addon/src/components/loading-indicator/usage.gts
+++ b/packages/boxel-ui/addon/src/components/loading-indicator/usage.gts
@@ -11,7 +11,17 @@ import cssVars from '../../helpers/css-var.ts';
 import BoxelLoadingIndicator from './index.gts';
 
 export default class LoadingIndicatorUsage extends Component {
-  @tracked color = '#000';
+  @tracked color = '';
+  @tracked variant:
+    | undefined
+    | 'primary'
+    | 'secondary'
+    | 'muted'
+    | 'destructive'
+    | 'default';
+
+  variants = ['default', 'primary', 'secondary', 'muted', 'destructive'];
+
   @cssVariable({ cssClassName: 'boxel-loading-indicator-size' })
   declare boxelLoadingIndicatorSize: CSSVariableInfo;
 
@@ -27,15 +37,24 @@ export default class LoadingIndicatorUsage extends Component {
             boxel-loading-indicator-size=this.boxelLoadingIndicatorSize.value
           }}
           @color={{this.color}}
+          @variant={{this.variant}}
         />
       </:example>
       <:api as |Args|>
         <Args.String
           @name='color'
-          @description='The color of the loading indicator'
+          @description='Custom color override (CSS color value)'
           @value={{this.color}}
           @onInput={{fn (mut this.color)}}
-          @default='black'
+          @default='undefined'
+        />
+        <Args.String
+          @name='variant'
+          @description='Theme-based color variant'
+          @value={{this.variant}}
+          @onInput={{fn (mut this.variant)}}
+          @options={{this.variants}}
+          @default='undefined'
         />
       </:api>
       <:cssVars as |Css|>


### PR DESCRIPTION
### What is changing
- Loading indicator to use theme foreground variables 
- Override if `@color` is specified 

**Screenshot** (with trying bubblegum theme variables)


https://github.com/user-attachments/assets/84d6acbc-0bac-47a0-a5f1-f345eb726588

