### PR TITLE
host: Add cross-port CORS development middleware

### DIFF
--- a/packages/host/lib/development-cors-middleware/index.js
+++ b/packages/host/lib/development-cors-middleware/index.js
@@ -1,0 +1,23 @@
+/* eslint-env node */
+'use strict';
+
+// Without this, CORS errors show when using other ports in development, especially Matrix tests (4205)
+
+module.exports = {
+  name: 'development-cors-middleware',
+
+  serverMiddleware({ app }) {
+    app.use((req, res, next) => {
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      res.setHeader(
+        'Access-Control-Allow-Methods',
+        'GET, POST, PUT, DELETE, OPTIONS',
+      );
+      res.setHeader(
+        'Access-Control-Allow-Headers',
+        'Content-Type, Authorization',
+      );
+      next();
+    });
+  },
+};

--- a/packages/host/lib/development-cors-middleware/package.json
+++ b/packages/host/lib/development-cors-middleware/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "development-cors-middleware",
+  "ember-addon": {
+    "before": "broccoli-serve-files"
+  },
+  "keywords": [
+    "ember-addon"
+  ],
+  "dependencies": {
+    "ember-cli-babel": "*",
+    "ember-cli-typescript": "*"
+  }
+}

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -199,6 +199,7 @@
   },
   "ember-addon": {
     "paths": [
+      "lib/development-cors-middleware",
       "lib/setup-ast-transforms"
     ]
   }


### PR DESCRIPTION
CORS errors in Matrix test logs are confusing red herrings, and maybe they actually cause problems:

<img width="1281" height="800" alt="Playwright Trace Viewer 2025-08-18 13-15-14" src="https://github.com/user-attachments/assets/e96dc8c5-d3f3-4362-a285-556df9b3abf1" />

With this in-repo addon, they no longer happen:

<img width="1281" height="800" alt="Playwright Trace Viewer 2025-08-18 13-19-26" src="https://github.com/user-attachments/assets/467a57ac-685c-4054-8280-5e958cc70f1a" />

This is a development-only change, as the realm server that serves `index.html` is responsible for setting these headers in deployed environments.