### PR TITLE
Multi-card delete

### DIFF
--- a/packages/boxel-ui/addon/src/components/card-header/index.gts
+++ b/packages/boxel-ui/addon/src/components/card-header/index.gts
@@ -1,3 +1,5 @@
+import type { MenuDivider } from '@cardstack/boxel-ui/helpers.ts';
+import { DropdownArrowDown } from '@cardstack/boxel-ui/icons';
 import { on } from '@ember/modifier';
 import Component from '@glimmer/component';
 import type { ComponentLike } from '@glint/template';
@@ -10,11 +12,17 @@ import { and } from '../../helpers/truth-helpers.ts';
 import { bool, or } from '../../helpers/truth-helpers.ts';
 import { IconPencil, IconX, ThreeDotsHorizontal } from '../../icons.gts';
 import setCssVar from '../../modifiers/set-css-var.ts';
+import Button from '../button/index.gts';
 import BoxelDropdown from '../dropdown/index.gts';
 import IconButton from '../icon-button/index.gts';
 import Menu from '../menu/index.gts';
 import RealmIcon, { type RealmDisplayInfo } from '../realm-icon/index.gts';
 import Tooltip from '../tooltip/index.gts';
+
+export interface CardHeaderUtilityMenu {
+  menuItems: (MenuItem | MenuDivider)[];
+  triggerText: string;
+}
 
 interface Signature {
   Args: {
@@ -30,6 +38,7 @@ interface Signature {
     onEdit?: () => void;
     onFinishEditing?: () => void;
     realmInfo?: RealmDisplayInfo;
+    utilityMenu?: CardHeaderUtilityMenu;
   };
   Element: HTMLElement;
 }
@@ -105,6 +114,30 @@ export default class CardHeader extends Component<Signature> {
       </div>
 
       <div class='actions' data-test-boxel-card-header-actions>
+        {{#if @utilityMenu}}
+          <div class='utility-menu-positioner'>
+            <BoxelDropdown @autoClose={{true}}>
+              <:trigger as |ddModifier|>
+                <Button class='utility-menu-trigger' {{ddModifier}}>
+                  <span>
+                    {{@utilityMenu.triggerText}}
+                  </span>
+                  <DropdownArrowDown
+                    class='utility-menu-dropdown-arrow'
+                    width='13px'
+                    height='13px'
+                  />
+                </Button>
+              </:trigger>
+              <:content as |dd|>
+                <Menu
+                  @items={{@utilityMenu.menuItems}}
+                  @closeMenu={{dd.close}}
+                />
+              </:content>
+            </BoxelDropdown>
+          </div>
+        {{/if}}
         {{#if @onEdit}}
           <Tooltip @placement='top'>
             <:trigger>
@@ -335,6 +368,30 @@ export default class CardHeader extends Component<Signature> {
 
         header .icon-save:hover {
           --icon-color: var(--boxel-dark);
+        }
+        .utility-menu-positioner {
+          --utility-menu-trigger-height: 26px;
+          position: relative;
+          margin-right: var(--boxel-sp);
+          width: 1px;
+          height: var(--utility-menu-trigger-height);
+        }
+        .utility-menu-trigger {
+          --boxel-button-min-height: var(--utility-menu-trigger-height);
+          --boxel-button-padding: 0 var(--boxel-sp-xxs);
+          --boxel-button-border-radius: calc(var(--boxel-border-radius) - 4px);
+          --boxel-button-font: var(--boxel-font-sm);
+          --boxel-button-box-shadow: 0 3px 3px 0 rgba(0, 0, 0, 0.5);
+          --boxel-button-border: solid 1px rgba(0, 0, 0, 0.35);
+
+          position: absolute;
+          top: 0;
+          right: 0;
+          width: max-content;
+        }
+        .utility-menu-dropdown-arrow {
+          margin-left: var(--boxel-sp-xl);
+          vertical-align: middle;
         }
       }
     </style>

--- a/packages/boxel-ui/addon/src/components/card-header/usage.gts
+++ b/packages/boxel-ui/addon/src/components/card-header/usage.gts
@@ -1,3 +1,5 @@
+import DeselectIcon from '@cardstack/boxel-icons/deselect';
+import SelectAllIcon from '@cardstack/boxel-icons/select-all';
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { array, fn } from '@ember/helper';
 import Component from '@glimmer/component';
@@ -11,9 +13,9 @@ import {
 
 import cssVar from '../../helpers/css-var.ts';
 import { MenuItem } from '../../helpers/menu-item.ts';
-import { IconLink } from '../../icons.gts';
+import { IconLink, IconTrash } from '../../icons.gts';
 import CardContainer from '../card-container/index.gts';
-import CardHeader from './index.gts';
+import CardHeader, { CardHeaderUtilityMenu } from './index.gts';
 
 interface CardTypeIconSignature {
   Element: SVGElement;
@@ -68,6 +70,32 @@ export default class CardHeaderUsage extends Component {
     this.isEditing = false;
   };
 
+  @tracked utilityMenu?: CardHeaderUtilityMenu = {
+    triggerText: '2 Selected',
+    menuItems: [
+      new MenuItem('Deselect All', 'action', {
+        icon: DeselectIcon,
+        action: () => {
+          console.log('Deselect all');
+          console.log('Delete 2 items');
+        },
+      }),
+      new MenuItem('Select All', 'action', {
+        icon: SelectAllIcon,
+        action: () => {
+          console.log('Select all');
+        },
+      }),
+      new MenuItem('Delete 2 items', 'action', {
+        dangerous: true,
+        icon: IconTrash,
+        action: () => {
+          console.log('Delete 2 items');
+        },
+      }),
+    ],
+  };
+
   @cssVariable({ cssClassName: 'header-freestyle-container' })
   declare cardHeaderTextFont: CSSVariableInfo;
   @cssVariable({ cssClassName: 'header-freestyle-container' })
@@ -116,6 +144,7 @@ export default class CardHeaderUsage extends Component {
               @onEdit={{unless this.isEditing this.onEdit}}
               @onFinishEditing={{if this.isEditing this.onFinishEditing}}
               @onClose={{this.close}}
+              @utilityMenu={{this.utilityMenu}}
             />
           </CardContainer>
         </:example>
@@ -166,6 +195,11 @@ export default class CardHeaderUsage extends Component {
             @name='realmInfo'
             @description='realm information'
             @value={{this.realmInfo}}
+          />
+          <Args.Object
+            @name='utilityMenu'
+            @description='when present, renders as a dropdown menu'
+            @value={{this.utilityMenu}}
           />
         </:api>
         <:cssVars as |Css|>

--- a/packages/host/tests/acceptance/workspace-delete-multiple-test.gts
+++ b/packages/host/tests/acceptance/workspace-delete-multiple-test.gts
@@ -1,0 +1,329 @@
+import { click, findAll, triggerEvent, waitFor } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { pauseTest } from 'ember-testing/lib/helpers/pause_test';
+import { module, test } from 'qunit';
+
+import { baseRealm } from '@cardstack/runtime-common';
+
+import {
+  setupLocalIndexing,
+  setupAcceptanceTestRealm,
+  testRealmURL,
+  setupUserSubscription,
+  visitOperatorMode,
+} from '../helpers';
+import { setupBaseRealm, CardsGrid } from '../helpers/base-realm';
+import { setupMockMatrix } from '../helpers/mock-matrix';
+import { setupApplicationTest } from '../helpers/setup';
+
+let matrixRoomId: string;
+
+module('Acceptance | workspace-delete-multiple', function (hooks) {
+  setupApplicationTest(hooks);
+  setupLocalIndexing(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [testRealmURL],
+  });
+
+  let { createAndJoinRoom } = mockMatrixUtils;
+
+  setupBaseRealm(hooks);
+
+  hooks.beforeEach(async function () {
+    matrixRoomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'room-test',
+    });
+    setupUserSubscription(matrixRoomId);
+
+    let loaderService = getService('loader-service');
+    let loader = loaderService.loader;
+    let { field, contains, CardDef, Component } = await loader.import<
+      typeof import('https://cardstack.com/base/card-api')
+    >(`${baseRealm.url}card-api`);
+    let { default: StringField } = await loader.import<
+      typeof import('https://cardstack.com/base/string')
+    >(`${baseRealm.url}string`);
+
+    class Pet extends CardDef {
+      static displayName = 'Pet';
+      @field name = contains(StringField);
+      @field species = contains(StringField);
+      @field title = contains(StringField, {
+        computeVia: function (this: Pet) {
+          return this.name;
+        },
+      });
+
+      static isolated = class Isolated extends Component<typeof this> {
+        <template>
+          <div data-test-pet>
+            <h1><@fields.name /></h1>
+            <p>Species: <@fields.species /></p>
+          </div>
+        </template>
+      };
+    }
+
+    await setupAcceptanceTestRealm({
+      mockMatrixUtils,
+      contents: {
+        'index.json': new CardsGrid(),
+        'pet.gts': { Pet },
+        'Pet/1.json': new Pet({
+          name: 'Fluffy',
+          species: 'Cat',
+        }),
+        'Pet/2.json': new Pet({
+          name: 'Buddy',
+          species: 'Dog',
+        }),
+        'Pet/3.json': new Pet({
+          name: 'Charlie',
+          species: 'Bird',
+        }),
+        '.realm.json': {
+          name: 'Test Realm',
+          backgroundURL: null,
+          iconURL: null,
+        },
+      },
+    });
+  });
+
+  async function selectCard(cardPath: string) {
+    await triggerEvent(
+      `[data-test-cards-grid-item="${testRealmURL}${cardPath}"]`,
+      'mouseenter',
+    );
+    await click(
+      `[data-test-overlay-card="${testRealmURL}${cardPath}"] button.actions-item__button`,
+    );
+    await triggerEvent(
+      `[data-test-cards-grid-item="${testRealmURL}${cardPath}"]`,
+      'mouseleave',
+    );
+  }
+
+  test('can select multiple cards and delete them via bulk delete', async function (assert) {
+    await visitOperatorMode({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}index`,
+            format: 'isolated',
+          },
+        ],
+      ],
+    });
+
+    // Wait for cards to load
+    await waitFor('[data-test-cards-grid-item]');
+
+    let cards = findAll('[data-test-cards-grid-item]');
+    assert.ok(cards.length >= 3, 'Multiple cards are available');
+
+    // Enter selection mode by clicking the first card's checkbox
+    await selectCard('Pet/1');
+
+    // Verify selection state is active
+    assert
+      .dom('.utility-menu-trigger')
+      .containsText('1 Selected', 'Selection menu appears');
+
+    // Select additional cards
+    await selectCard('Pet/2');
+
+    // Verify selection count
+    assert.dom('.utility-menu-trigger').containsText('2 Selected');
+
+    // Open utility menu
+    await click('.utility-menu-trigger');
+
+    // Click bulk delete option
+    await click('[data-test-boxel-menu-item-text="Delete 2 items"]');
+
+    // Verify confirmation dialog appears
+    assert
+      .dom('[data-test-delete-modal="bulk-delete"]')
+      .exists('Delete confirmation modal appears');
+    assert
+      .dom('[data-test-delete-modal="bulk-delete"]')
+      .containsText('2 cards');
+
+    await click('[data-test-confirm-delete-button]');
+
+    // Wait for deletion to complete
+    await waitFor('[data-test-cards-grid-item]', { count: 1 });
+
+    // Verify cards were deleted
+    let remainingCards = findAll('[data-test-cards-grid-item]');
+    assert.equal(remainingCards.length, 1, 'Two cards were deleted');
+
+    // Verify selection mode is cleared
+    assert
+      .dom('.utility-menu-trigger')
+      .doesNotExist('Selection summary is cleared');
+  });
+
+  test('can deselect selected cards from menu', async function (assert) {
+    await visitOperatorMode({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}index`,
+            format: 'isolated',
+          },
+        ],
+      ],
+    });
+
+    // Wait for cards to load
+    await waitFor('[data-test-cards-grid-item]');
+
+    let cards = findAll('[data-test-cards-grid-item]');
+    assert.ok(cards.length >= 3, 'Multiple cards are available');
+
+    // Enter selection mode by selecting multiple cards
+    await selectCard('Pet/1');
+    await selectCard('Pet/2');
+    await selectCard('Pet/3');
+
+    // Verify selection count
+    assert.dom('.utility-menu-trigger').containsText('3 Selected');
+
+    // Open utility menu
+    await click('.utility-menu-trigger');
+
+    // Click "Deselect All" option
+    await click('[data-test-boxel-menu-item-text="Deselect All"]');
+
+    // Verify selection is cleared
+    assert
+      .dom('.utility-menu-trigger')
+      .doesNotExist('Selection summary is cleared after deselect');
+
+    pauseTest();
+    // Verify overlay checkboxes are not checked
+    assert.dom('[data-test-overlay-card]').doesNotExist();
+  });
+
+  test('can select all cards', async function (assert) {
+    await visitOperatorMode({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}index`,
+            format: 'isolated',
+          },
+        ],
+      ],
+    });
+
+    // Wait for cards to load
+    await waitFor('[data-test-cards-grid-item]');
+
+    let cards = findAll('[data-test-cards-grid-item]');
+    assert.ok(cards.length >= 3, 'Multiple cards are available');
+    let totalCardCount = cards.length;
+
+    // Enter selection mode by selecting one card first
+    await selectCard('Pet/1');
+
+    // Verify selection state is active
+    assert
+      .dom('.utility-menu-trigger')
+      .containsText('1 Selected', 'Selection menu appears');
+
+    // Open utility menu
+    await click('.utility-menu-trigger');
+
+    // Click "Select All" option
+    await click('[data-test-boxel-menu-item-text="Select All"]');
+
+    // Verify all cards are selected
+    assert
+      .dom('.utility-menu-trigger')
+      .containsText(`${totalCardCount} Selected`, 'All cards are now selected');
+
+    // Open utility menu again to verify "Select All" is no longer available
+    await click('.utility-menu-trigger');
+
+    // "Select All" should not be available when all cards are selected
+    assert
+      .dom('[data-test-boxel-menu-item-text="Select All"]')
+      .doesNotExist(
+        'Select All option is not available when all cards are selected',
+      );
+
+    // But "Deselect All" should be available
+    assert
+      .dom('[data-test-boxel-menu-item-text="Deselect All"]')
+      .exists('Deselect All option is available');
+  });
+
+  test('can cancel bulk delete operation', async function (assert) {
+    await visitOperatorMode({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}index`,
+            format: 'isolated',
+          },
+        ],
+      ],
+    });
+
+    // Wait for cards to load
+    await waitFor('[data-test-cards-grid-item]');
+
+    let cards = findAll('[data-test-cards-grid-item]');
+    assert.ok(cards.length >= 3, 'Multiple cards are available');
+    let initialCardCount = cards.length;
+
+    // Enter selection mode by selecting multiple cards
+    await selectCard('Pet/1');
+    await selectCard('Pet/2');
+
+    // Verify selection count
+    assert.dom('.utility-menu-trigger').containsText('2 Selected');
+
+    // Open utility menu
+    await click('.utility-menu-trigger');
+
+    // Click bulk delete option
+    await click('[data-test-boxel-menu-item-text="Delete 2 items"]');
+
+    // Verify confirmation dialog appears
+    assert
+      .dom('[data-test-delete-modal="bulk-delete"]')
+      .exists('Delete confirmation modal appears');
+    assert
+      .dom('[data-test-delete-modal="bulk-delete"]')
+      .containsText('2 cards');
+
+    // Cancel the delete operation
+    await click('[data-test-confirm-cancel-button]');
+
+    // Verify modal is closed
+    assert
+      .dom('[data-test-delete-modal="bulk-delete"]')
+      .doesNotExist('Delete confirmation modal is closed');
+
+    // Verify no cards were deleted
+    let remainingCards = findAll('[data-test-cards-grid-item]');
+    assert.equal(
+      remainingCards.length,
+      initialCardCount,
+      'No cards were deleted after canceling',
+    );
+
+    // Verify selection is still active
+    assert
+      .dom('.utility-menu-trigger')
+      .containsText('2 Selected', 'Selection remains active after cancel');
+  });
+});


### PR DESCRIPTION
This pull request introduces multi-card selection and bulk actions to the operator mode stack item UI, via a utility menu dropdown in CardHeader. The changes improve the user experience by allowing users to select multiple cards, perform bulk deletes, and manage selections through a dropdown menu.

* Introduced a reusable `utilityMenu` dropdown to `CardHeader`, supporting dynamic menu items and integration into operator mode stack items for selection management.
* Added bulk selection actions: "Select All", "Deselect All", and "Delete N items" to the new utility menu, with corresponding logic for confirming and performing bulk deletes, including error handling and a confirmation modal.
* Update CardHeader usage component


https://github.com/user-attachments/assets/98b14898-a2b7-48cb-bd59-e88a2e0701e6

