### PR TITLE
Pill component with theme variables

### DIFF
--- a/packages/boxel-ui/addon/src/components/loading-indicator/usage.gts
+++ b/packages/boxel-ui/addon/src/components/loading-indicator/usage.gts
@@ -18,7 +18,7 @@ export default class LoadingIndicatorUsage extends Component {
     | 'secondary'
     | 'muted'
     | 'destructive'
-    | 'default';
+    | 'default' = undefined;
 
   variants = ['default', 'primary', 'secondary', 'muted', 'destructive'];
 

--- a/packages/boxel-ui/addon/src/components/pill/index.gts
+++ b/packages/boxel-ui/addon/src/components/pill/index.gts
@@ -85,6 +85,7 @@ const Pill: TemplateOnlyComponent<PillSignature> = <template>
         border: var(--pill-border, var(--default-pill-border));
         border-radius: var(--pill-border-radius, var(--boxel-border-radius-sm));
         font: var(--pill-font, var(--default-pill-font));
+        font-family: inherit;
         letter-spacing: var(--boxel-lsp-xs);
         word-break: break-word;
       }

--- a/packages/boxel-ui/addon/src/components/pill/index.gts
+++ b/packages/boxel-ui/addon/src/components/pill/index.gts
@@ -1,4 +1,5 @@
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
+import { concat } from '@ember/helper';
 import { hash } from '@ember/helper';
 
 import { cn, element, eq } from '../../helpers.ts';
@@ -14,6 +15,7 @@ export interface PillSignature {
     pillBorderColor?: string;
     pillFontColor?: string;
     tag?: keyof HTMLElementTagNameMap;
+    variant?: 'primary' | 'secondary' | 'muted' | 'destructive' | 'default';
   };
   Blocks: {
     default: [];
@@ -26,7 +28,11 @@ export interface PillSignature {
 const Pill: TemplateOnlyComponent<PillSignature> = <template>
   {{#let (element (if (eq @kind 'button') 'button' @tag)) as |Tag|}}
     <Tag
-      class={{cn 'pill' button-pill=(eq @kind 'button')}}
+      class={{cn
+        'pill'
+        (if (eq @kind 'button') 'button-pill')
+        (if @variant (concat 'variant-' @variant) 'variant-default')
+      }}
       style={{cssVar
         pill-background-color=@pillBackgroundColor
         pill-font-color=(if
@@ -59,16 +65,23 @@ const Pill: TemplateOnlyComponent<PillSignature> = <template>
   <style scoped>
     @layer {
       .pill {
+        --pill-background-color: var(
+          --boxel-pill-background-color,
+          var(--boxel-light)
+        );
+        --pill-font-color: var(--boxel-pill-font-color, var(--boxel-dark));
+        --pill-border-color: var(--boxel-pill-border-color, var(--boxel-400));
+
         --default-pill-font: 600 var(--boxel-font-sm);
         --default-pill-padding: var(--boxel-sp-5xs) var(--boxel-sp-xxxs);
-        --default-pill-border: 1px solid
-          var(--pill-border-color, var(--boxel-400));
+        --default-pill-border: 1px solid var(--pill-border-color);
+
         display: inline-flex;
         align-items: center;
         gap: var(--pill-gap, var(--boxel-sp-5xs));
         padding: var(--pill-padding, var(--default-pill-padding));
-        background-color: var(--pill-background-color, var(--boxel-light));
-        color: var(--pill-font-color, var(--boxel-dark));
+        background-color: var(--pill-background-color);
+        color: var(--pill-font-color);
         border: var(--pill-border, var(--default-pill-border));
         border-radius: var(--pill-border-radius, var(--boxel-border-radius-sm));
         font: var(--pill-font, var(--default-pill-font));
@@ -76,8 +89,98 @@ const Pill: TemplateOnlyComponent<PillSignature> = <template>
         word-break: break-word;
       }
 
-      .button-pill:not(:disabled):hover {
-        background-color: var(--pill-background-color-hover, var(--boxel-100));
+      .variant-default {
+        --pill-background-color: var(
+          --boxel-pill-background-color,
+          var(--background, var(--boxel-light))
+        );
+        --pill-font-color: var(
+          --boxel-pill-font-color,
+          var(--foreground, var(--boxel-dark))
+        );
+        --pill-border-color: var(
+          --boxel-pill-border-color,
+          var(--border, var(--boxel-400))
+        );
+      }
+
+      .variant-primary {
+        --pill-background-color: var(
+          --boxel-pill-background-color,
+          var(--primary, var(--boxel-600))
+        );
+        --pill-font-color: var(
+          --boxel-pill-font-color,
+          var(--primary-foreground, var(--boxel-light))
+        );
+        --pill-border-color: var(
+          --boxel-pill-border-color,
+          var(--primary, var(--boxel-600))
+        );
+      }
+
+      .variant-secondary {
+        --pill-background-color: var(
+          --boxel-pill-background-color,
+          var(--secondary, var(--boxel-400))
+        );
+        --pill-font-color: var(
+          --boxel-pill-font-color,
+          var(--secondary-foreground, var(--boxel-dark))
+        );
+        --pill-border-color: var(
+          --boxel-pill-border-color,
+          var(--secondary, var(--boxel-400))
+        );
+      }
+
+      .variant-muted {
+        --pill-background-color: var(
+          --boxel-pill-background-color,
+          var(--muted, var(--boxel-200))
+        );
+        --pill-font-color: var(
+          --boxel-pill-font-color,
+          var(--muted-foreground, var(--boxel-dark))
+        );
+        --pill-border-color: var(
+          --boxel-pill-border-color,
+          var(--muted, var(--boxel-200))
+        );
+      }
+
+      .variant-destructive {
+        --pill-background-color: var(
+          --boxel-pill-background-color,
+          var(--destructive, var(--boxel-600))
+        );
+        --pill-font-color: var(
+          --boxel-pill-font-color,
+          var(--destructive-foreground, var(--boxel-light))
+        );
+        --pill-border-color: var(
+          --boxel-pill-border-color,
+          var(--destructive, var(--boxel-600))
+        );
+      }
+
+      .button-pill.variant-default:not(:disabled):hover,
+      .button-pill.variant-primary:not(:disabled):hover,
+      .button-pill.variant-destructive:not(:disabled):hover {
+        --pill-background-color: color-mix(
+          in srgb,
+          var(--pill-background-color) 90%,
+          transparent
+        );
+      }
+
+      .button-pill.variant-secondary:not(:disabled):hover,
+      .button-pill.variant-muted:not(:disabled):hover {
+        --pill-background-color: color-mix(
+          in srgb,
+          var(--pill-background-color) 80%,
+          transparent
+        );
       }
 
       .icon {

--- a/packages/boxel-ui/addon/src/components/pill/usage.gts
+++ b/packages/boxel-ui/addon/src/components/pill/usage.gts
@@ -30,7 +30,7 @@ export default class PillUsage extends Component {
     | 'secondary'
     | 'muted'
     | 'destructive'
-    | 'default' = this.pillVariantDefault;
+    | 'default' = undefined;
   @tracked pillBackgroundColor?: string;
   @tracked borderColor?: string;
   @tracked fontColor?: string;
@@ -107,21 +107,21 @@ export default class PillUsage extends Component {
             @description='3-or-6 digit hex color code for background color (overrides variant)'
             @value={{this.pillBackgroundColor}}
             @onInput={{fn (mut this.pillBackgroundColor)}}
-            @defaultValue='undefined'
+            @defaultValue='variant-default'
           />
           <Args.String
             @name='pillBorderColor'
             @description='Border color for the pill (overrides variant)'
             @value={{this.borderColor}}
             @onInput={{fn (mut this.borderColor)}}
-            @defaultValue='undefined'
+            @defaultValue='variant-default'
           />
           <Args.String
             @name='pillFontColor'
             @description='Font color for the pill (overrides variant)'
             @value={{this.fontColor}}
             @onInput={{fn (mut this.fontColor)}}
-            @defaultValue='undefined'
+            @defaultValue='variant-default'
           />
         </:api>
         <:cssVars as |Css|>

--- a/packages/boxel-ui/addon/src/components/pill/usage.gts
+++ b/packages/boxel-ui/addon/src/components/pill/usage.gts
@@ -14,7 +14,23 @@ import Pill, { type BoxelPillKind } from './index.gts';
 export default class PillUsage extends Component {
   pillKinds = ['button', 'default'];
   pillKindDefault: BoxelPillKind = 'default';
+  pillVariants = ['default', 'primary', 'secondary', 'muted', 'destructive'];
+  pillVariantDefault:
+    | undefined
+    | 'primary'
+    | 'secondary'
+    | 'muted'
+    | 'destructive'
+    | 'default' = undefined;
+
   @tracked kind: BoxelPillKind = this.pillKindDefault;
+  @tracked variant:
+    | undefined
+    | 'primary'
+    | 'secondary'
+    | 'muted'
+    | 'destructive'
+    | 'default' = this.pillVariantDefault;
   @tracked pillBackgroundColor?: string;
   @tracked borderColor?: string;
   @tracked fontColor?: string;
@@ -25,6 +41,12 @@ export default class PillUsage extends Component {
   declare pillGap: CSSVariableInfo;
   @cssVariable({ cssClassName: 'header-freestyle-container' })
   declare pillIconSize: CSSVariableInfo;
+  @cssVariable({ cssClassName: 'header-freestyle-container' })
+  declare boxelPillBackgroundColor: CSSVariableInfo;
+  @cssVariable({ cssClassName: 'header-freestyle-container' })
+  declare boxelPillFontColor: CSSVariableInfo;
+  @cssVariable({ cssClassName: 'header-freestyle-container' })
+  declare boxelPillBorderColor: CSSVariableInfo;
 
   <template>
     <div
@@ -33,6 +55,9 @@ export default class PillUsage extends Component {
         pill-padding=this.pillPadding.value
         pill-gap=this.pillGap.value
         pill-icon-size=this.pillIconSize.value
+        boxel-pill-background-color=this.boxelPillBackgroundColor.value
+        boxel-pill-font-color=this.boxelPillFontColor.value
+        boxel-pill-border-color=this.boxelPillBorderColor.value
       }}
     >
       <FreestyleUsage @name='Pill'>
@@ -41,8 +66,10 @@ export default class PillUsage extends Component {
           appealing manner. Similar to a tag, badge or label.
         </:description>
         <:example>
+          {{! Main interactive example }}
           <Pill
             @kind={{this.kind}}
+            @variant={{this.variant}}
             @pillBackgroundColor={{this.pillBackgroundColor}}
             @pillBorderColor={{this.borderColor}}
             @pillFontColor={{this.fontColor}}
@@ -67,25 +94,34 @@ export default class PillUsage extends Component {
             @value={{this.kind}}
           />
           <Args.String
+            @name='variant'
+            @optional={{true}}
+            @description='Theme-based variant for consistent styling'
+            @defaultValue={{this.pillVariantDefault}}
+            @options={{this.pillVariants}}
+            @onInput={{fn (mut this.variant)}}
+            @value={{this.variant}}
+          />
+          <Args.String
             @name='pillBackgroundColor'
-            @description='3-or-6 digit hex color code for background color'
+            @description='3-or-6 digit hex color code for background color (overrides variant)'
             @value={{this.pillBackgroundColor}}
             @onInput={{fn (mut this.pillBackgroundColor)}}
-            @defaultValue='#ffffff'
+            @defaultValue='undefined'
           />
           <Args.String
             @name='pillBorderColor'
-            @description='Border color for the pill'
+            @description='Border color for the pill (overrides variant)'
             @value={{this.borderColor}}
             @onInput={{fn (mut this.borderColor)}}
-            @defaultValue='#afafb7'
+            @defaultValue='undefined'
           />
           <Args.String
             @name='pillFontColor'
-            @description='Font color for the pill'
+            @description='Font color for the pill (overrides variant)'
             @value={{this.fontColor}}
             @onInput={{fn (mut this.fontColor)}}
-            @defaultValue=' #000000 or #ffffff based on contrast if pillBackgroundColor is a hex value'
+            @defaultValue='undefined'
           />
         </:api>
         <:cssVars as |Css|>
@@ -109,6 +145,27 @@ export default class PillUsage extends Component {
             @description='Size of the icon'
             @value={{this.pillIconSize.value}}
             @onInput={{this.pillIconSize.update}}
+          />
+          <Css.Basic
+            @name='boxel-pill-background-color'
+            @type='color'
+            @description='Global override for pill background color (highest priority)'
+            @value={{this.boxelPillBackgroundColor.value}}
+            @onInput={{this.boxelPillBackgroundColor.update}}
+          />
+          <Css.Basic
+            @name='boxel-pill-font-color'
+            @type='color'
+            @description='Global override for pill font color (highest priority)'
+            @value={{this.boxelPillFontColor.value}}
+            @onInput={{this.boxelPillFontColor.update}}
+          />
+          <Css.Basic
+            @name='boxel-pill-border-color'
+            @type='color'
+            @description='Global override for pill border color (highest priority)'
+            @value={{this.boxelPillBorderColor.value}}
+            @onInput={{this.boxelPillBorderColor.update}}
           />
         </:cssVars>
       </FreestyleUsage>


### PR DESCRIPTION
### What is changing
- Pill component to use theme variables
- Override if variable of `--boxel-pill-background-color`, `--boxel-pill-font-color`, `--boxel-pill-border-color` specified

**Screenshot (with trying bubblegum theme variables)**

https://github.com/user-attachments/assets/e223f8ab-762a-43a3-9436-7fb7611aa5fa

https://github.com/user-attachments/assets/0e6f287e-8ee6-4e57-b5bf-929c5e7ead87

