### PR TITLE
ci: Change Playwright to only install Chromium

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -193,7 +193,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - uses: ./.github/actions/init
       - name: Install Playwright Browsers
-        run: pnpm exec playwright install --with-deps
+        run: pnpm exec playwright install --with-deps chromium
         working-directory: packages/matrix
       - name: Build boxel-icons
         run: pnpm build


### PR DESCRIPTION
I looked into this because [this job](https://github.com/cardstack/boxel/actions/runs/17102784911/job/48503673390?pr=3137) took a very long time to install Playwright browsers:

<img width="801" height="262" alt="boxel@9e1e5a6 2025-08-20 11-03-28" src="https://github.com/user-attachments/assets/75f69269-27ce-4b0e-ab2a-0c8f15a466a3" />

While that’s surely an outlier (though here’s [another](https://github.com/cardstack/boxel/actions/runs/17093712783/job/48473135153)), since we’re only using Chromium in Matrix tests, why not skip installing other browsers?

[This run on `main`](https://github.com/cardstack/boxel/actions/runs/17051748251) had an average of 1m13s to install Playwright browsers. [This run on `main`](https://github.com/cardstack/boxel/actions/runs/17093712783) had an average of 2m14s, including an anomalous job with 12min+ browser installation. The [run for this PR](https://github.com/cardstack/boxel/actions/runs/17103494448?pr=3145) averaged 1m4s. So it’s not a definitive savings but it seems like it can’t hurt.