### PR TITLE
Theme boxel-ui Button component

### DIFF
--- a/packages/boxel-ui/addon/src/components/button/index.gts
+++ b/packages/boxel-ui/addon/src/components/button/index.gts
@@ -144,7 +144,7 @@ const ButtonComponent: TemplateOnlyComponent<Signature> = <template>
         min-height: var(--boxel-button-min-height);
         min-width: var(--boxel-button-min-width);
         padding: var(--boxel-button-padding);
-        letter-spacing: var(--boxel-button-letter-spacing, var(--boxel-lsp-sm));
+        letter-spacing: var(--boxel-button-letter-spacing, var(--boxel-lsp));
         box-shadow: var(--boxel-button-box-shadow);
       }
       .boxel-button:not(:disabled):hover {
@@ -335,6 +335,7 @@ const ButtonComponent: TemplateOnlyComponent<Signature> = <template>
         --boxel-button-min-width: 5rem;
         --boxel-button-loading-icon-size: var(--boxel-icon-xxs);
         --boxel-button-font: 600 var(--boxel-font-xs);
+        --boxel-button-letter-spacing: var(--boxel-lsp-lg);
       }
 
       /* thinner base button */

--- a/packages/boxel-ui/addon/src/components/button/index.gts
+++ b/packages/boxel-ui/addon/src/components/button/index.gts
@@ -1,6 +1,6 @@
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { array, concat, hash } from '@ember/helper';
 import { LinkTo } from '@ember/routing';
-import Component from '@glimmer/component';
 
 import cn from '../../helpers/cn.ts';
 import { eq, not, or } from '../../helpers/truth-helpers.ts';
@@ -62,147 +62,140 @@ interface Signature {
   };
   Element: HTMLButtonElement | HTMLAnchorElement;
 }
-export default class ButtonComponent extends Component<Signature> {
-  <template>
-    {{#let
-      (cn
-        'boxel-button'
-        @class
-        (concat 'size-' (if @size @size 'base'))
-        (concat 'kind-' (if @kind @kind 'secondary'))
-        loading=@loading
-      )
-      as |classes|
-    }}
-      {{#if (or (not @as) (eq @as 'button'))}}
-        <button
-          class={{classes}}
-          tabindex={{if @loading -1 0}}
-          disabled={{@disabled}}
-          data-test-boxel-button
-          ...attributes
-        >
-          {{#if @loading}}
-            <LoadingIndicator
-              class='loading-indicator'
-              @color='var(--boxel-button-text-color)'
-              data-test-boxel-button-loading-indicator
-            />
-          {{/if}}
-          {{yield}}
-        </button>
-      {{else if (eq @as 'anchor')}}
-        <a
-          class={{classes}}
-          href={{unless @disabled @href}}
-          data-test-boxel-button
-          ...attributes
-        >
-          {{yield}}
-        </a>
-      {{else if (eq @as 'link-to')}}
-        <LinkTo
-          class={{classes}}
-          @route={{@route}}
-          @models={{if @models @models (array)}}
-          @query={{if @query @query (hash)}}
-          @disabled={{@disabled}}
-          data-test-boxel-button
-          tabindex={{if @disabled -1 0}}
-          ...attributes
-        >
-          {{yield}}
-        </LinkTo>
-      {{/if}}
-    {{/let}}
-    <style scoped>
-      @layer {
-        /* Button */
-        .boxel-button {
-          --boxel-loading-indicator-size: var(
-            --boxel-button-loading-icon-size,
-            var(--boxel-icon-xs)
-          );
+const ButtonComponent: TemplateOnlyComponent<Signature> = <template>
+  {{#let
+    (cn
+      'boxel-button'
+      @class
+      (concat 'size-' (if @size @size 'base'))
+      (concat 'kind-' (if @kind @kind 'secondary'))
+      loading=@loading
+    )
+    as |classes|
+  }}
+    {{#if (or (not @as) (eq @as 'button'))}}
+      <button
+        class={{classes}}
+        tabindex={{if @loading -1 0}}
+        disabled={{@disabled}}
+        data-test-boxel-button
+        ...attributes
+      >
+        {{#if @loading}}
+          <LoadingIndicator
+            class='loading-indicator'
+            @color='var(--boxel-button-text-color)'
+            data-test-boxel-button-loading-indicator
+          />
+        {{/if}}
+        {{yield}}
+      </button>
+    {{else if (eq @as 'anchor')}}
+      <a
+        class={{classes}}
+        href={{unless @disabled @href}}
+        data-test-boxel-button
+        ...attributes
+      >
+        {{yield}}
+      </a>
+    {{else if (eq @as 'link-to')}}
+      <LinkTo
+        class={{classes}}
+        @route={{@route}}
+        @models={{if @models @models (array)}}
+        @query={{if @query @query (hash)}}
+        @disabled={{@disabled}}
+        data-test-boxel-button
+        tabindex={{if @disabled -1 0}}
+        ...attributes
+      >
+        {{yield}}
+      </LinkTo>
+    {{/if}}
+  {{/let}}
+  <style scoped>
+    @layer {
+      /* Button */
+      .boxel-button {
+        --boxel-loading-indicator-size: var(
+          --boxel-button-loading-icon-size,
+          var(--boxel-icon-xs)
+        );
 
-          display: inline-flex;
-          justify-content: center;
-          height: min-content;
-          align-items: center;
-          border-radius: var(--radius, 100px);
-          transition: var(
-            --boxel-button-transition,
-            var(--boxel-transition-properties)
-          );
+        display: inline-flex;
+        justify-content: center;
+        height: min-content;
+        align-items: center;
+        border-radius: var(--boxel-button-border-radius, var(--radius, 100px));
+        transition: var(
+          --boxel-button-transition,
+          var(--boxel-transition-properties)
+        );
 
-          /* kind variants + disabled state */
-          border: var(
-            --boxel-button-border,
-            1px solid var(--boxel-button-color)
-          );
-          color: var(--boxel-button-text-color);
-          background-color: var(--boxel-button-color);
+        /* kind variants + disabled state */
+        border: var(--boxel-button-border, 1px solid var(--boxel-button-color));
+        color: var(--boxel-button-text-color);
+        background-color: var(--boxel-button-color);
 
-          /* size variants */
-          font: var(--boxel-button-font, 600 var(--boxel-font-sm));
-          font-family: inherit;
-          min-height: var(--boxel-button-min-height);
-          min-width: var(--boxel-button-min-width);
-          padding: var(--boxel-button-padding);
-          letter-spacing: var(
-            --boxel-button-letter-spacing,
-            var(--boxel-lsp-sm)
-          );
-          box-shadow: var(--boxel-button-box-shadow);
-        }
+        /* size variants */
+        font: var(--boxel-button-font, 600 var(--boxel-font-sm));
+        font-family: inherit;
+        min-height: var(--boxel-button-min-height);
+        min-width: var(--boxel-button-min-width);
+        padding: var(--boxel-button-padding);
+        letter-spacing: var(--boxel-button-letter-spacing, var(--boxel-lsp-sm));
+        box-shadow: var(--boxel-button-box-shadow);
+      }
 
-        .loading-indicator {
-          margin-right: var(
-            --boxel-button-loading-indicator-gap,
-            var(--boxel-sp-xxs)
-          );
-        }
+      .loading-indicator {
+        margin-right: var(
+          --boxel-button-loading-indicator-gap,
+          var(--boxel-sp-xxs)
+        );
+      }
 
-        /* select disabled buttons and links that don't have href */
+      /* select disabled buttons and links that don't have href */
 
-        /*
+      /*
         a.disabled-link is a special case for an automatically appended class by the LinkTo component
         the LinkTo component appends the href regardless, so we have to select it in other ways.
         Removing the chained classes will make kind-variants overwrite the disabled style on the LinkTo (specificity issues)
       */
-        .boxel-button:disabled,
-        a.boxel-button:not([href]),
-        a.boxel-button[href=''],
-        a.boxel-button.disabled-link {
-          --boxel-button-color: var(--muted, var(--boxel-border-color));
-          --boxel-button-border: 1px solid var(--boxel-button-color);
-          --boxel-button-text-color: var(--muted-foreground, var(--boxel-450));
-          --boxel-button-box-shadow: none;
+      .boxel-button:disabled,
+      a.boxel-button:not([href]),
+      a.boxel-button[href=''],
+      a.boxel-button.disabled-link {
+        --boxel-button-color: var(--muted, var(--boxel-border-color));
+        --boxel-button-border: 1px solid var(--boxel-button-color);
+        --boxel-button-text-color: var(--muted-foreground, var(--boxel-450));
+        --boxel-button-box-shadow: none;
 
-          cursor: default;
-        }
+        cursor: default;
+      }
 
-        /* the a element does not have a disabled attribute. Clicking will still trigger event listeners */
-        a.boxel-button:not([href]),
-        a.boxel-button[href=''],
-        a.boxel-button.disabled-link {
-          pointer-events: none;
-        }
+      /* the a element does not have a disabled attribute. Clicking will still trigger event listeners */
+      a.boxel-button:not([href]),
+      a.boxel-button[href=''],
+      a.boxel-button.disabled-link {
+        pointer-events: none;
+      }
 
-        /*
+      /*
         loading state.
         this should only be relevant for buttons - links shouldn't need it.
         We want to preserve the "normal" styling of the button but not allow interaction
       */
-        .loading {
-          pointer-events: none;
-        }
+      .loading {
+        pointer-events: none;
+      }
 
-        /* overwrite the global style for links in global.css */
-        a.boxel-button:hover {
-          color: var(--boxel-button-text-color);
-        }
+      /* overwrite the global style for links in global.css */
+      a.boxel-button:hover {
+        color: var(--boxel-button-text-color);
+      }
 
-        /**
+      /**
       * Kind variants - variants that control the colors on a button
       *
       * The @kind argument on the button component should create a corresponding class with format
@@ -215,122 +208,113 @@ export default class ButtonComponent extends Component<Signature> {
       * --boxel-button-text-color (css "color" property)
       *
       */
-        .kind-primary {
-          --boxel-button-color: var(--primary, var(--boxel-highlight));
-          --boxel-button-text-color: var(
-            --primary-foreground,
-            var(--boxel-dark)
-          );
-          --boxel-button-box-shadow: var(--shadow);
-        }
-        .kind-primary:not(:disabled):hover,
-        .kind-primary:not(:disabled):active {
-          --boxel-button-color: color-mix(
-            in oklab,
-            var(--primary, var(--boxel-highlight)) 95%,
-            var(--boxel-dark)
-          );
-        }
+      .kind-primary {
+        --boxel-button-color: var(--primary, var(--boxel-highlight));
+        --boxel-button-text-color: var(--primary-foreground, var(--boxel-dark));
+        --boxel-button-box-shadow: var(--shadow);
+      }
+      .kind-primary:not(:disabled):hover,
+      .kind-primary:not(:disabled):active {
+        --boxel-button-color: color-mix(
+          in oklab,
+          var(--primary, var(--boxel-highlight)) 95%,
+          var(--boxel-dark)
+        );
+      }
 
-        .kind-secondary {
-          --boxel-button-color: var(--secondary, var(--boxel-light));
-          --boxel-button-text-color: var(
-            --secondary-foreground,
-            var(--boxel-dark)
-          );
-          --boxel-button-border: 1px solid
-            var(--secondary, var(--boxel-button-border-color));
-          --boxel-button-box-shadow: var(--shadow);
-        }
-        .kind-secondary:not(:disabled):hover,
-        .kind-secondary:not(:disabled):active {
-          --boxel-button-border: 1px solid
-            var(--boxel-button-text-color, var(--boxel-dark));
-        }
+      .kind-secondary {
+        --boxel-button-color: var(--secondary, var(--boxel-light));
+        --boxel-button-text-color: var(
+          --secondary-foreground,
+          var(--boxel-dark)
+        );
+        --boxel-button-border: 1px solid
+          var(--secondary, var(--boxel-button-border-color));
+        --boxel-button-box-shadow: var(--shadow);
+      }
+      .kind-secondary:not(:disabled):hover,
+      .kind-secondary:not(:disabled):active {
+        --boxel-button-border: 1px solid
+          var(--boxel-button-text-color, var(--boxel-dark));
+      }
 
-        .kind-outline {
-          --boxel-button-color: var(--background, var(--boxel-light));
-          --boxel-button-text-color: var(--foreground, var(--boxel-dark));
-          --boxel-button-border: 1px solid
-            var(--border, var(--boxel-button-border-color));
-        }
-        .kind-outline:not(:disabled):hover,
-        .kind-outline:not(:disabled):active {
-          --boxel-button-color: var(--accent, var(--boxel-200));
-          --boxel-button-text-color: var(
-            --accent-foreground,
-            var(--boxel-dark)
-          );
-        }
+      .kind-outline {
+        --boxel-button-color: var(--background, var(--boxel-light));
+        --boxel-button-text-color: var(--foreground, var(--boxel-dark));
+        --boxel-button-border: 1px solid
+          var(--border, var(--boxel-button-border-color));
+      }
+      .kind-outline:not(:disabled):hover,
+      .kind-outline:not(:disabled):active {
+        --boxel-button-color: var(--accent, var(--boxel-200));
+        --boxel-button-text-color: var(--accent-foreground, var(--boxel-dark));
+      }
 
-        .kind-secondary-light {
-          /* transparent on light background */
-          --boxel-button-color: transparent;
-          --boxel-button-text-color: var(--foreground, var(--boxel-dark));
-          --boxel-button-border: 1px solid
-            var(--border, var(--boxel-button-border-color));
-          --boxel-button-box-shadow: var(--shadow);
-        }
-        .kind-secondary-dark {
-          /* transparent on dark background */
-          --boxel-button-color: transparent;
-          --boxel-button-text-color: var(--background, var(--boxel-light));
-          --boxel-button-border: 1px solid
-            var(--border, var(--boxel-button-border-color));
-          --boxel-button-box-shadow: var(--shadow);
-        }
-        .kind-secondary-light:not(:disabled):hover,
-        .kind-secondary-light:not(:disabled):active,
-        .kind-secondary-dark:not(:disabled):hover,
-        .kind-secondary-dark:not(:disabled):active {
-          --boxel-button-border: 1px solid var(--boxel-button-text-color);
-        }
+      .kind-secondary-light {
+        /* transparent on light background */
+        --boxel-button-color: transparent;
+        --boxel-button-text-color: var(--foreground, var(--boxel-dark));
+        --boxel-button-border: 1px solid
+          var(--border, var(--boxel-button-border-color));
+        --boxel-button-box-shadow: var(--shadow);
+      }
+      .kind-secondary-dark {
+        /* transparent on dark background */
+        --boxel-button-color: transparent;
+        --boxel-button-text-color: var(--background, var(--boxel-light));
+        --boxel-button-border: 1px solid
+          var(--border, var(--boxel-button-border-color));
+        --boxel-button-box-shadow: var(--shadow);
+      }
+      .kind-secondary-light:not(:disabled):hover,
+      .kind-secondary-light:not(:disabled):active,
+      .kind-secondary-dark:not(:disabled):hover,
+      .kind-secondary-dark:not(:disabled):active {
+        --boxel-button-border: 1px solid var(--boxel-button-text-color);
+      }
 
-        .kind-danger {
-          --boxel-button-color: var(--destructive, var(--boxel-danger));
-          --boxel-button-text-color: var(
-            --destructive-foreground,
-            var(--boxel-light-100)
-          );
-          --boxel-button-box-shadow: var(--shadow);
-        }
-        .kind-danger:not(:disabled):hover,
-        .kind-danger:not(:disabled):active {
-          --boxel-button-color: color-mix(
-            in oklab,
-            var(--destructive, var(--boxel-danger)) 95%,
-            var(--boxel-dark)
-          );
-        }
+      .kind-danger {
+        --boxel-button-color: var(--destructive, var(--boxel-danger));
+        --boxel-button-text-color: var(
+          --destructive-foreground,
+          var(--boxel-light-100)
+        );
+        --boxel-button-box-shadow: var(--shadow);
+      }
+      .kind-danger:not(:disabled):hover,
+      .kind-danger:not(:disabled):active {
+        --boxel-button-color: color-mix(
+          in oklab,
+          var(--destructive, var(--boxel-danger)) 95%,
+          var(--boxel-dark)
+        );
+      }
 
-        .kind-primary-dark {
-          --boxel-button-color: var(--secondary-foreground, var(--boxel-dark));
-          --boxel-button-text-color: var(--secondary, var(--boxel-light));
-          --boxel-button-box-shadow: var(--shadow);
-        }
-        .kind-primary-dark:not(:disabled):hover,
-        .kind-primary-dark:not(:disabled):active {
-          --boxel-button-color: color-mix(
-            in oklab,
-            var(--secondary-foreground, var(--boxel-dark)) 85%,
-            transparent
-          );
-        }
+      .kind-primary-dark {
+        --boxel-button-color: var(--secondary-foreground, var(--boxel-dark));
+        --boxel-button-text-color: var(--secondary, var(--boxel-light));
+        --boxel-button-box-shadow: var(--shadow);
+      }
+      .kind-primary-dark:not(:disabled):hover,
+      .kind-primary-dark:not(:disabled):active {
+        --boxel-button-color: color-mix(
+          in oklab,
+          var(--secondary-foreground, var(--boxel-dark)) 85%,
+          transparent
+        );
+      }
 
-        .kind-text-only {
-          --boxel-button-color: transparent;
-          --boxel-button-text-color: inherit;
-        }
-        .kind-text-only:not(:disabled):hover,
-        .kind-text-only:not(:disabled):active {
-          --boxel-button-color: var(--accent, var(--boxel-200));
-          --boxel-button-text-color: var(
-            --accent-foreground,
-            var(--boxel-dark)
-          );
-        }
+      .kind-text-only {
+        --boxel-button-color: transparent;
+        --boxel-button-text-color: inherit;
+      }
+      .kind-text-only:not(:disabled):hover,
+      .kind-text-only:not(:disabled):active {
+        --boxel-button-color: var(--accent, var(--boxel-200));
+        --boxel-button-text-color: var(--accent-foreground, var(--boxel-dark));
+      }
 
-        /**
+      /**
       * Size variants - variants that control the size and spacing of a button
       *
       * The @size argument on the button component should create a corresponding class with format
@@ -347,52 +331,53 @@ export default class ButtonComponent extends Component<Signature> {
       *
       */
 
-        .size-extra-small {
-          --boxel-button-padding: var(--boxel-sp-5xs) var(--boxel-sp-sm);
-          --boxel-button-min-height: 1.5rem;
-          --boxel-button-min-width: 5rem;
-          --boxel-button-loading-icon-size: var(--boxel-icon-xxs);
-          --boxel-button-font: 600 var(--boxel-font-xs);
-        }
+      .size-extra-small {
+        --boxel-button-padding: var(--boxel-sp-5xs) var(--boxel-sp-sm);
+        --boxel-button-min-height: 1.5rem;
+        --boxel-button-min-width: 5rem;
+        --boxel-button-loading-icon-size: var(--boxel-icon-xxs);
+        --boxel-button-font: 600 var(--boxel-font-xs);
+      }
 
-        /* thinner base button */
-        .size-small {
-          --boxel-button-padding: var(--boxel-sp-xxxs) var(--boxel-sp-sm);
-          --boxel-button-min-height: 2rem;
-          --boxel-button-min-width: 5rem;
-        }
+      /* thinner base button */
+      .size-small {
+        --boxel-button-padding: var(--boxel-sp-xxxs) var(--boxel-sp-sm);
+        --boxel-button-min-height: 2rem;
+        --boxel-button-min-width: 5rem;
+      }
 
-        .size-base {
-          --boxel-button-padding: var(--boxel-sp-xxxs) var(--boxel-sp-xl);
-          --boxel-button-min-height: 2rem;
-          --boxel-button-min-width: 5rem;
-        }
+      .size-base {
+        --boxel-button-padding: var(--boxel-sp-xxxs) var(--boxel-sp-xl);
+        --boxel-button-min-height: 2rem;
+        --boxel-button-min-width: 5rem;
+      }
 
-        /* tall but thinner button */
-        .size-tall {
-          --boxel-button-padding: var(--boxel-sp-xxs) var(--boxel-sp);
-          --boxel-button-min-height: 2.5rem;
-          --boxel-button-min-width: 5rem;
-        }
+      /* tall but thinner button */
+      .size-tall {
+        --boxel-button-padding: var(--boxel-sp-xxs) var(--boxel-sp);
+        --boxel-button-min-height: 2.5rem;
+        --boxel-button-min-width: 5rem;
+      }
 
-        /*
+      /*
         extra tall button mainly used in mobile screens
         touchable as it's bigger
         */
-        .size-touch {
-          --boxel-button-padding: var(--boxel-sp-xs) var(--boxel-sp-lg);
-          --boxel-button-min-height: 3rem;
-          --boxel-button-min-width: 5rem;
-          --boxel-button-loading-icon-size: var(--boxel-icon-sm);
-          --boxel-button-font: 600 var(--boxel-font);
-          --boxel-button-letter-spacing: var(--boxel-lsp-xs);
-        }
-
-        /* auto size properties & smallest padding size */
-        .size-auto {
-          --boxel-button-padding: var(--boxel-sp-6xs);
-        }
+      .size-touch {
+        --boxel-button-padding: var(--boxel-sp-xs) var(--boxel-sp-lg);
+        --boxel-button-min-height: 3rem;
+        --boxel-button-min-width: 5rem;
+        --boxel-button-loading-icon-size: var(--boxel-icon-sm);
+        --boxel-button-font: 600 var(--boxel-font);
+        --boxel-button-letter-spacing: var(--boxel-lsp-xs);
       }
-    </style>
-  </template>
-}
+
+      /* auto size properties & smallest padding size */
+      .size-auto {
+        --boxel-button-padding: var(--boxel-sp-6xs);
+      }
+    }
+  </style>
+</template>;
+
+export default ButtonComponent;

--- a/packages/boxel-ui/addon/src/components/button/index.gts
+++ b/packages/boxel-ui/addon/src/components/button/index.gts
@@ -147,6 +147,13 @@ const ButtonComponent: TemplateOnlyComponent<Signature> = <template>
         letter-spacing: var(--boxel-button-letter-spacing, var(--boxel-lsp-sm));
         box-shadow: var(--boxel-button-box-shadow);
       }
+      .boxel-button:not(:disabled):hover {
+        background-color: color-mix(
+          in oklab,
+          var(--boxel-button-color) 90%,
+          transparent
+        );
+      }
 
       .loading-indicator {
         margin-right: var(
@@ -215,11 +222,7 @@ const ButtonComponent: TemplateOnlyComponent<Signature> = <template>
       }
       .kind-primary:not(:disabled):hover,
       .kind-primary:not(:disabled):active {
-        --boxel-button-color: color-mix(
-          in oklab,
-          var(--primary, var(--boxel-highlight)) 95%,
-          var(--boxel-dark)
-        );
+        --boxel-button-color: var(--primary, var(--boxel-highlight-hover));
       }
 
       .kind-secondary {
@@ -234,8 +237,7 @@ const ButtonComponent: TemplateOnlyComponent<Signature> = <template>
       }
       .kind-secondary:not(:disabled):hover,
       .kind-secondary:not(:disabled):active {
-        --boxel-button-border: 1px solid
-          var(--boxel-button-text-color, var(--boxel-dark));
+        --boxel-button-border: 1px solid var(--secondary, var(--boxel-dark));
       }
 
       .kind-outline {
@@ -283,11 +285,7 @@ const ButtonComponent: TemplateOnlyComponent<Signature> = <template>
       }
       .kind-danger:not(:disabled):hover,
       .kind-danger:not(:disabled):active {
-        --boxel-button-color: color-mix(
-          in oklab,
-          var(--destructive, var(--boxel-danger)) 95%,
-          var(--boxel-dark)
-        );
+        --boxel-button-color: var(--destructive, var(--boxel-danger-hover));
       }
 
       .kind-primary-dark {

--- a/packages/boxel-ui/addon/src/components/button/usage.gts
+++ b/packages/boxel-ui/addon/src/components/button/usage.gts
@@ -10,27 +10,18 @@ import { eq } from '../../helpers/truth-helpers.ts';
 import BoxelButton, {
   type BoxelButtonKind,
   type BoxelButtonSize,
+  buttonKindOptions,
+  buttonSizeOptions,
 } from './index.gts';
 
 export default class ButtonUsage extends Component {
-  sizeVariants = ['extra-small', 'small', 'base', 'tall', 'touch'];
-  kindVariants = {
-    all: [
-      'primary',
-      'primary-dark',
-      'secondary-light',
-      'secondary-dark',
-      'danger',
-      'text-only',
-    ],
-    light: ['primary', 'secondary-light'],
-    dark: ['primary', 'secondary-dark'],
-  };
+  sizeVariants = buttonSizeOptions;
+  kindVariants = buttonKindOptions;
 
   // base button arguments
   @tracked as = 'button';
-  @tracked size: BoxelButtonSize = 'tall';
-  @tracked kind: BoxelButtonKind = 'primary';
+  @tracked size: BoxelButtonSize = 'base';
+  @tracked kind: BoxelButtonKind = 'secondary';
   @tracked disabled = false;
   @tracked loading = false;
 
@@ -47,7 +38,7 @@ export default class ButtonUsage extends Component {
   }
 
   <template>
-    <FreestyleUsage @name='Button'>
+    <FreestyleUsage @name='Button' class='boxel-button-usage'>
       <:example>
         <div
           class={{cn
@@ -65,7 +56,7 @@ export default class ButtonUsage extends Component {
             @route={{this.route}}
             {{on 'click' this.alert}}
           >
-            Button Text
+            Sample CTA
           </BoxelButton>
         </div>
       </:example>
@@ -107,8 +98,8 @@ export default class ButtonUsage extends Component {
           @name='kind'
           @optional={{true}}
           @description='Controls the colors of the button'
-          @defaultValue='secondary-light'
-          @options={{this.kindVariants.all}}
+          @defaultValue='secondary'
+          @options={{this.kindVariants}}
           @onInput={{fn (mut this.kind)}}
           @value={{this.kind}}
         />
@@ -220,6 +211,7 @@ export default class ButtonUsage extends Component {
     <FreestyleUsage
       @name='LinkTo button'
       @description='This button links you to the index page'
+      class='boxel-button-usage'
     >
       <:example>
         <div
@@ -235,20 +227,22 @@ export default class ButtonUsage extends Component {
             @route='index'
             @query=''
           >
-            Button Text
+            Sample CTA
           </BoxelButton>
         </div>
       </:example>
     </FreestyleUsage>
     <style scoped>
+      .boxel-button-usage {
+        --boxel-border-radius: 100px;
+      }
+      :deep(.FreestyleUsage-preview) {
+        border-radius: 10px;
+      }
+
       .usage-button-container {
         display: flex;
         flex-wrap: wrap;
-      }
-
-      .usage-button-dark-mode-background {
-        background-color: var(--boxel-purple-600);
-        padding: 4px;
       }
 
       .usage-button-explanation {
@@ -270,6 +264,13 @@ export default class ButtonUsage extends Component {
         align-items: center;
         min-height: 100%;
         padding: 2rem;
+        background-color: var(--background, var(--boxel-light));
+        color: var(--foreground, var(--boxel-dark));
+      }
+
+      .usage-button-dark-mode-background {
+        background-color: var(--foreground, var(--boxel-700));
+        color: var(--background, var(--boxel-light));
       }
     </style>
   </template>

--- a/packages/boxel-ui/addon/src/components/button/usage.gts
+++ b/packages/boxel-ui/addon/src/components/button/usage.gts
@@ -205,7 +205,47 @@ export default class ButtonUsage extends Component {
             </tr>
           </tbody>
         </table>
+
+        <p>Note: All css-variables below can be set at the top-level element.</p>
       </:description>
+      <:cssVars as |Css|>
+        <Css.Basic @name='--boxel-button-text-color' @type='color' />
+        <Css.Basic @name='--boxel-button-color' @type='background-color' />
+        <Css.Basic
+          @name='--boxel-button-border'
+          @type='border'
+          @description='(css shorthand property)'
+        />
+        <Css.Basic @name='--boxel-button-border-radius' @type='border-radius' />
+        <Css.Basic
+          @name='--boxel-button-font'
+          @type='font'
+          @description='(css shorthand property)'
+        />
+        <Css.Basic
+          @name='--boxel-button-letter-spacing'
+          @type='letter-spacing'
+        />
+        <Css.Basic
+          @name='--boxel-button-transition'
+          @type='transition'
+          @description='(css shorthand property)'
+        />
+        <Css.Basic @name='--boxel-button-min-height' @type='min-height' />
+        <Css.Basic @name='--boxel-button-min-width' @type='min-width' />
+        <Css.Basic @name='--boxel-button-padding' @type='padding' />
+        <Css.Basic @name='--boxel-button-box-shadow' @type='box-shadow' />
+        <Css.Basic
+          @name='--boxel-button-loading-icon-size'
+          @type='width, height'
+          @description='loading-indicator size'
+        />
+        <Css.Basic
+          @name='--boxel-button-loading-indicator-gap'
+          @type='margin-right'
+          @description='for loading-indicator icon'
+        />
+      </:cssVars>
     </FreestyleUsage>
 
     <FreestyleUsage
@@ -222,12 +262,12 @@ export default class ButtonUsage extends Component {
         >
           <BoxelButton
             @as='link-to'
-            @kind='primary'
-            @size='base'
+            @kind={{this.kind}}
+            @size={{this.size}}
             @route='index'
             @query=''
           >
-            Sample CTA
+            Link CTA
           </BoxelButton>
         </div>
       </:example>
@@ -271,6 +311,10 @@ export default class ButtonUsage extends Component {
       .usage-button-dark-mode-background {
         background-color: var(--foreground, var(--boxel-700));
         color: var(--background, var(--boxel-light));
+      }
+
+      :deep(.FreestyleUsageCssVar input) {
+        display: none;
       }
     </style>
   </template>

--- a/packages/boxel-ui/test-app/app/templates/index.gts
+++ b/packages/boxel-ui/test-app/app/templates/index.gts
@@ -98,6 +98,9 @@ class IndexComponent extends Component {
         --radius: var(--boxel-border-radius);
         --border-color: var(--boxel-border-color);
       }
+      .FreestyleUsageCssVar-name {
+        width: 40%;
+      }
     </style>
   </template>
 

--- a/packages/host/app/components/operator-mode/error-display.gts
+++ b/packages/host/app/components/operator-mode/error-display.gts
@@ -222,8 +222,10 @@ export default class ErrorDisplay
         display: flex;
         align-items: center;
         gap: var(--boxel-sp-xxs);
-        width: 95px;
+        width: 100px;
         justify-content: flex-end;
+        font-weight: 400;
+        border: none;
       }
 
       .toggle-details-button:hover {


### PR DESCRIPTION
Updates:
- Kept pre-existing button kind and size variants but added some new ones
- Some changes to `extra-small` size styling and `disabled` button styling based on this design: https://app.zeplin.io/project/687e6476950590c5570a1cec/screen/687e64cc6e540965d28ae846

New variants: 
- `@size='auto'` : useful when you don't want min-width or min-height or padding set on boxel button component 
- `@kind='secondary'`: similar to `secondary-light` and `secondary-dark` but has a background-color instead of transparent background (uses theme `secondary` background-color and `secondary-foreground` color)
- `@kind='outline'`: uses main `background` and `foreground` colors, displays `accent` colors on hover

We use `@kind='text-only'` instead of `ghost` and `@kind='danger'` instead of the `destructive` variant. Interested to hear opinions on if I should add those names along with keeping the existing ones (for backwards-compatibility reasons).

Preview link: https://cs-9271-button-theming.boxel-ui-preview.stack.cards/?s=Components&ss=%3CButton%3E