### PR TITLE
Incorporate CardContainer in pre-rendering

### DIFF
--- a/packages/base/components/card-list.gts
+++ b/packages/base/components/card-list.gts
@@ -1,9 +1,6 @@
 import Component from '@glimmer/component';
 
-import {
-  CardContainer,
-  LoadingIndicator,
-} from '@cardstack/boxel-ui/components';
+import { LoadingIndicator } from '@cardstack/boxel-ui/components';
 
 import { cn, eq } from '@cardstack/boxel-ui/helpers';
 
@@ -60,12 +57,7 @@ export default class CardList extends Component<Signature> {
                 {{! In order to support scrolling cards into view we use a selector that is not pruned out in production builds }}
                 data-cards-grid-item={{removeFileExtension card.url}}
               >
-                <CardContainer
-                  class='card-item {{@format}}-card-item'
-                  @displayBoundaries={{true}}
-                >
-                  <card.component />
-                </CardContainer>
+                <card.component />
               </li>
             {{else}}
               <p>No results were found</p>
@@ -116,20 +108,8 @@ export default class CardList extends Component<Signature> {
         width: var(--item-width);
         height: var(--item-height);
       }
-      .boxel-card-list-item > :deep(.fitted-card-item) {
-        width: 100%;
-        height: 100%;
-        min-height: 40px;
-        max-height: 600px;
-        container-name: fitted-card;
-        container-type: size;
-        overflow: hidden;
-      }
-      .boxel-card-list-item > :deep(.atom-card-item) {
-        width: fit-content;
-        max-width: 100%;
-      }
-      .boxel-card-list-item > :deep(.embedded-card-item) {
+
+      .boxel-card-list-item > :deep(.field-component-card.embedded-format) {
         width: 100%;
         height: auto;
         max-width: var(--embedded-card-max-width);

--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -40,6 +40,7 @@ import { consume, provide } from 'ember-provide-consume-context';
 import Component from '@glimmer/component';
 import sanitizedHtml from './helpers/sanitized-html';
 import { concat } from '@ember/helper';
+import { htmlSafe } from '@ember/template';
 
 export interface BoxComponentSignature {
   Element: HTMLElement; // This may not be true for some field components, but it's true more often than not
@@ -271,7 +272,7 @@ export function getBoxComponent(
                         fieldType=field.fieldType
                         fieldName=field.name
                       }}
-                      style={{getThemeStyles model.value}}
+                      style={{htmlSafe (getThemeStyles model.value)}}
                       data-test-card={{card.id}}
                       data-test-card-format={{effectiveFormats.cardDef}}
                       data-test-field-component-card

--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -30,15 +30,16 @@ import type { ComponentLike } from '@glint/template';
 import { CardContainer } from '@cardstack/boxel-ui/components';
 import {
   extractCssVariables,
-  styleConversions,
+  getStyleConversions,
 } from '@cardstack/boxel-ui/helpers';
 import Modifier from 'ember-modifier';
 import { isEqual, flatMap } from 'lodash';
 import { initSharedState } from './shared-state';
-import { and, eq, not } from '@cardstack/boxel-ui/helpers';
+import { and, cn, eq, not } from '@cardstack/boxel-ui/helpers';
 import { consume, provide } from 'ember-provide-consume-context';
 import Component from '@glimmer/component';
 import sanitizedHtml from './helpers/sanitized-html';
+import { concat } from '@ember/helper';
 
 export interface BoxComponentSignature {
   Element: HTMLElement; // This may not be true for some field components, but it's true more often than not
@@ -219,7 +220,11 @@ export function getBoxComponent(
       cardDef && 'cssVariables' in cardDef
         ? (cardDef as Theme).cssVariables
         : cardDef?.cardInfo?.theme?.cssVariables;
-    return sanitizedHtml(styleConversions + extractCssVariables(css));
+    return sanitizedHtml(
+      [getStyleConversions(), extractCssVariables(css)]
+        .filter(Boolean)
+        .join(''),
+    );
   }
 
   let component: TemplateOnlyComponent<{
@@ -255,8 +260,11 @@ export function getBoxComponent(
                   >
                     <CardContainer
                       @displayBoundaries={{displayContainer}}
-                      class='field-component-card
-                        {{effectiveFormats.cardDef}}-format display-container-{{displayContainer}}'
+                      class={{cn
+                        'field-component-card'
+                        (concat effectiveFormats.cardDef '-format')
+                        (concat 'display-container-' displayContainer)
+                      }}
                       {{context.cardComponentModifier
                         card=card
                         format=effectiveFormats.cardDef

--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -215,7 +215,7 @@ export function getBoxComponent(
 
   function getThemeStyles(cardDef?: CardDef) {
     if (!extractCssVariables) {
-      return;
+      return htmlSafe('');
     }
     let css =
       cardDef && 'cssVariables' in cardDef
@@ -272,7 +272,7 @@ export function getBoxComponent(
                         fieldType=field.fieldType
                         fieldName=field.name
                       }}
-                      style={{htmlSafe (getThemeStyles model.value)}}
+                      style={{getThemeStyles model.value}}
                       data-test-card={{card.id}}
                       data-test-card-format={{effectiveFormats.cardDef}}
                       data-test-field-component-card

--- a/packages/base/helpers/sanitized-html.gts
+++ b/packages/base/helpers/sanitized-html.gts
@@ -2,9 +2,9 @@ import { htmlSafe, type SafeString } from '@ember/template';
 
 import { sanitizeHtml } from '@cardstack/runtime-common';
 
-export default function sanitizedHtml(html?: string): SafeString | undefined {
+export default function sanitizedHtml(html?: string): SafeString {
   if (!html) {
-    return;
+    return htmlSafe('');
   }
   return htmlSafe(sanitizeHtml(html));
 }

--- a/packages/boxel-ui/addon/src/components/card-container/index.gts
+++ b/packages/boxel-ui/addon/src/components/card-container/index.gts
@@ -17,42 +17,48 @@ interface Signature {
 const CardContainer: TemplateOnlyComponent<Signature> = <template>
   {{#let (element @tag) as |Tag|}}
     <Tag
-      class={{cn 'boxel-card-container' boundaries=@displayBoundaries}}
+      class={{cn
+        'boxel-card-container'
+        boxel-card-container--boundaries=@displayBoundaries
+      }}
       data-test-boxel-card-container
       ...attributes
     >
       {{yield}}
     </Tag>
   {{/let}}
+
+  {{! Note: styles for this component use :global to avoid issues with
+      cached HTML if this component changes. This is important because it
+      ends up in nearly every card's prerendered HTML
+  }}
   <style scoped>
-    @layer {
-      .boxel-card-container {
-        position: relative;
-        background-color: var(--background, var(--boxel-light));
-        border-radius: var(--radius, var(--boxel-border-radius));
-        color: var(--foreground, var(--boxel-dark));
-        font-family: var(--font-sans, var(--boxel-font-family));
-        transition:
-          max-width var(--boxel-transition),
-          box-shadow var(--boxel-transition);
-        height: 100%;
-        width: 100%;
-        overflow: hidden;
-        box-shadow: var(--shadow);
-      }
-      .boundaries {
-        box-shadow:
-          0 0 0 1px var(--border, var(--boxel-border-color)),
-          var(--shadow, 0 0 0 1px var(--boxel-border-color));
-      }
-      .boundaries.hide-boundaries {
-        box-shadow: none;
-      }
-      :deep(.boxel-card-container .boxel-card-container) {
-        background-color: var(--card, var(--boxel-light));
-        border-radius: var(--radius, var(--boxel-border-radius));
-        color: var(--card-foreground, var(--boxel-dark));
-      }
+    :global(.boxel-card-container) {
+      position: relative;
+      background-color: var(--background, var(--boxel-light));
+      border-radius: var(--radius, var(--boxel-border-radius));
+      color: var(--foreground, var(--boxel-dark));
+      font-family: var(--font-sans, var(--boxel-font-family));
+      transition:
+        max-width var(--boxel-transition),
+        box-shadow var(--boxel-transition);
+      height: 100%;
+      width: 100%;
+      overflow: hidden;
+      box-shadow: var(--shadow);
+    }
+    :global(.boxel-card-container--boundaries) {
+      box-shadow:
+        0 0 0 1px var(--border, var(--boxel-border-color)),
+        var(--shadow, 0 0 0 1px var(--boxel-border-color));
+    }
+    :global(.boxel-card-container--boundaries.hide-boundaries) {
+      box-shadow: none;
+    }
+    :global(.boxel-card-container .boxel-card-container) {
+      background-color: var(--card, var(--boxel-light));
+      border-radius: var(--radius, var(--boxel-border-radius));
+      color: var(--card-foreground, var(--boxel-dark));
     }
   </style>
 </template>;

--- a/packages/boxel-ui/addon/src/components/card-container/index.gts
+++ b/packages/boxel-ui/addon/src/components/card-container/index.gts
@@ -45,6 +45,9 @@ const CardContainer: TemplateOnlyComponent<Signature> = <template>
           0 0 0 1px var(--border, var(--boxel-border-color)),
           var(--shadow, 0 0 0 1px var(--boxel-border-color));
       }
+      .boundaries.hide-boundaries {
+        box-shadow: none;
+      }
       :deep(.boxel-card-container .boxel-card-container) {
         background-color: var(--card, var(--boxel-light));
         border-radius: var(--radius, var(--boxel-border-radius));

--- a/packages/boxel-ui/addon/src/helpers.ts
+++ b/packages/boxel-ui/addon/src/helpers.ts
@@ -7,7 +7,7 @@ import { dayjsFormat } from './helpers/dayjs-format.ts';
 import element from './helpers/element.ts';
 import {
   extractCssVariables,
-  styleConversions,
+  getStyleConversions,
 } from './helpers/extract-css-variables.ts';
 import formatAge from './helpers/format-age.ts';
 import formatCountdown from './helpers/format-countdown.ts';
@@ -79,7 +79,7 @@ export {
   optional,
   or,
   pick,
-  styleConversions,
+  getStyleConversions,
   substring,
   subtract,
 };

--- a/packages/boxel-ui/addon/src/helpers.ts
+++ b/packages/boxel-ui/addon/src/helpers.ts
@@ -65,6 +65,7 @@ export {
   formatPeriod,
   formatRelativeTime,
   getContrastColor,
+  getStyleConversions,
   gt,
   gte,
   lt,
@@ -79,7 +80,6 @@ export {
   optional,
   or,
   pick,
-  getStyleConversions,
   substring,
   subtract,
 };

--- a/packages/boxel-ui/addon/src/helpers/extract-css-variables.ts
+++ b/packages/boxel-ui/addon/src/helpers/extract-css-variables.ts
@@ -1,3 +1,5 @@
+import { isTesting } from '@embroider/macros';
+
 function normalizeSelector(selectorName: string): string {
   const selector = selectorName.trim();
   if (selector === ':root' || selector === 'root') {
@@ -88,7 +90,11 @@ export function extractCssVariables(cssString?: string | null) {
   }
 }
 
-export const styleConversions = `/* spacing */
+export function getStyleConversions() {
+  if (isTesting()) {
+    return '--boxel-example: 1px;'; // stable, concise output for matching in tests
+  }
+  return `/* spacing */
 --boxel-spacing: calc(var(--spacing, var(--_boxel-sp-unit)) * 4);
 --boxel-sp-6xs: calc(var(--boxel-sp-5xs) / var(--boxel-ratio));
 --boxel-sp-5xs: calc(var(--boxel-sp-4xs) / var(--boxel-ratio));
@@ -111,3 +117,4 @@ export const styleConversions = `/* spacing */
 --boxel-border-radius-xl: calc(var(--boxel-border-radius-lg) + 3px);
 --boxel-border-radius-xxl: calc(var(--boxel-border-radius-xl) + 5px);
 --boxel-form-control-border-radius: var(--radius, var(--_boxel-radius));`;
+}

--- a/packages/boxel-ui/test-app/app/themes/index.ts
+++ b/packages/boxel-ui/test-app/app/themes/index.ts
@@ -1,6 +1,6 @@
 import {
   extractCssVariables,
-  styleConversions,
+  getStyleConversions,
 } from '@cardstack/boxel-ui/helpers';
 
 import { Bubblegum } from './bubblegum.ts';
@@ -28,7 +28,9 @@ function getThemeStyles(cssString: string) {
   if (!extractCssVariables) {
     return;
   }
-  return styleConversions + extractCssVariables(cssString);
+  return [getStyleConversions(), extractCssVariables(cssString)]
+    .filter(Boolean)
+    .join('');
 }
 
 const Themes: Theme[] = Object.entries(THEMES).map(([name, vars]) => ({

--- a/packages/catalog-realm/catalog-app/components/card-with-hydration.gts
+++ b/packages/catalog-realm/catalog-app/components/card-with-hydration.gts
@@ -11,8 +11,6 @@ import {
 
 import { type PrerenderedCardLike } from '@cardstack/runtime-common';
 
-import { CardContainer } from '@cardstack/boxel-ui/components';
-
 interface CardWithHydrationSignature {
   Args: {
     card: PrerenderedCardLike;
@@ -43,37 +41,28 @@ export class CardWithHydration extends GlimmerComponent<CardWithHydrationSignatu
     {{#if this.isHydrated}}
       {{#if this.cardResource.card}}
         {{#let (getComponent this.cardResource.card) as |Component|}}
-          <CardContainer
+          <Component
             class='card'
-            @displayBoundaries={{true}}
             data-test-cards-grid-item={{removeFileExtension @card.url}}
             data-cards-grid-item={{removeFileExtension @card.url}}
             data-test-hydrated-card
-          >
-            <Component />
-          </CardContainer>
+          />
         {{/let}}
       {{/if}}
     {{else if @card.isError}}
-      <CardContainer
+      <@card.component
         class='card instance-error'
-        @displayBoundaries={{true}}
         data-test-instance-error={{@card.isError}}
         data-test-cards-grid-item={{removeFileExtension @card.url}}
         data-cards-grid-item={{removeFileExtension @card.url}}
-      >
-        <@card.component />
-      </CardContainer>
+      />
     {{else}}
-      <CardContainer
+      <@card.component
         class='card'
-        @displayBoundaries={{true}}
         data-test-cards-grid-item={{removeFileExtension @card.url}}
         data-cards-grid-item={{removeFileExtension @card.url}}
         {{on 'mouseenter' (fn this.hydrateCard @card)}}
-      >
-        <@card.component />
-      </CardContainer>
+      />
     {{/if}}
 
     <style scoped>

--- a/packages/catalog-realm/components/card-list.gts
+++ b/packages/catalog-realm/components/card-list.gts
@@ -7,8 +7,6 @@ import {
   type PrerenderedCardLike,
 } from '@cardstack/runtime-common';
 
-import { CardContainer } from '@cardstack/boxel-ui/components';
-
 interface CardListSignature {
   Args: {
     query: Query;
@@ -38,19 +36,16 @@ export class CardList extends GlimmerComponent<CardListSignature> {
           </:loading>
           <:response as |cards|>
             {{#each cards key='url' as |card|}}
-              <li class='card-list-item'>
-                <CardContainer
-                  {{@context.cardComponentModifier
-                    cardId=card.url
-                    format='data'
-                    fieldType=undefined
-                    fieldName=undefined
-                  }}
-                  class='card'
-                  @displayBoundaries={{true}}
-                >
-                  <card.component />
-                </CardContainer>
+              <li
+                class='card-list-item'
+                {{@context.cardComponentModifier
+                  cardId=card.url
+                  format='data'
+                  fieldType=undefined
+                  fieldName=undefined
+                }}
+              >
+                <card.component />
                 {{#if (has-block 'meta')}}
                   {{yield card to='meta'}}
                 {{/if}}

--- a/packages/catalog-realm/components/grid.gts
+++ b/packages/catalog-realm/components/grid.gts
@@ -4,8 +4,6 @@ import { type CardContext } from 'https://cardstack.com/base/card-api';
 
 import { type Query } from '@cardstack/runtime-common';
 
-import { CardContainer } from '@cardstack/boxel-ui/components';
-
 interface CardsGridSignature {
   Args: {
     query: Query;
@@ -37,19 +35,16 @@ export class CardsGrid extends GlimmerComponent<CardsGridSignature> {
           </:loading>
           <:response as |cards|>
             {{#each cards key='url' as |card|}}
-              <li class='{{@selectedView}}-view-container'>
-                <CardContainer
-                  {{@context.cardComponentModifier
-                    cardId=card.url
-                    format='data'
-                    fieldType=undefined
-                    fieldName=undefined
-                  }}
-                  class='card'
-                  @displayBoundaries={{true}}
-                >
-                  <card.component />
-                </CardContainer>
+              <li
+                class='{{@selectedView}}-view-container'
+                {{@context.cardComponentModifier
+                  cardId=card.url
+                  format='data'
+                  fieldType=undefined
+                  fieldName=undefined
+                }}
+              >
+                <card.component />
               </li>
             {{/each}}
           </:response>

--- a/packages/catalog-realm/daily-report-dashboard/daily-report-dashboard.gts
+++ b/packages/catalog-realm/daily-report-dashboard/daily-report-dashboard.gts
@@ -210,8 +210,7 @@ class Isolated extends Component<typeof DailyReportDashboard> {
                           </div>
                         {{else}}
                           <card.component
-                            @displayBoundaries={{false}}
-                            class='report-card-container'
+                            class='report-card-container hide-boundaries'
                           />
                         {{/if}}
                       {{/each}}

--- a/packages/catalog-realm/daily-report-dashboard/daily-report-dashboard.gts
+++ b/packages/catalog-realm/daily-report-dashboard/daily-report-dashboard.gts
@@ -2,11 +2,7 @@ import { array } from '@ember/helper';
 import { gt } from '@cardstack/boxel-ui/helpers';
 import { CardDef, field, linksTo } from 'https://cardstack.com/base/card-api';
 import { Component, realmURL } from 'https://cardstack.com/base/card-api';
-import {
-  Button,
-  CardContainer,
-  BoxelInput,
-} from '@cardstack/boxel-ui/components';
+import { Button, BoxelInput } from '@cardstack/boxel-ui/components';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
@@ -213,18 +209,10 @@ class Isolated extends Component<typeof DailyReportDashboard> {
                             <div class='error-text'>Failed to load report</div>
                           </div>
                         {{else}}
-                          <CardContainer
-                            {{@context.cardComponentModifier
-                              cardId=card.url
-                              format='data'
-                              fieldType=undefined
-                              fieldName=undefined
-                            }}
+                          <card.component
                             @displayBoundaries={{false}}
                             class='report-card-container'
-                          >
-                            <card.component />
-                          </CardContainer>
+                          />
                         {{/if}}
                       {{/each}}
                     </div>

--- a/packages/catalog-realm/online-store/online-store.gts
+++ b/packages/catalog-realm/online-store/online-store.gts
@@ -12,7 +12,7 @@ import TextAreaField from 'https://cardstack.com/base/text-area';
 import ColorField from 'https://cardstack.com/base/color';
 import EmailField from 'https://cardstack.com/base/email';
 
-import { Button, CardContainer } from '@cardstack/boxel-ui/components';
+import { Button } from '@cardstack/boxel-ui/components';
 import { eq, gt, formatNumber } from '@cardstack/boxel-ui/helpers';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
@@ -591,18 +591,15 @@ class IsolatedTemplate extends Component<typeof OnlineStore> {
                               <p>Failed to load: {{card.url}}</p>
                             </div>
                           {{else}}
-                            <CardContainer
+                            <card.component
+                              class='product-card-container'
                               {{@context.cardComponentModifier
                                 cardId=card.url
                                 format='data'
                                 fieldType=undefined
                                 fieldName=undefined
                               }}
-                              @displayBoundaries={{true}}
-                              class='product-card-container'
-                            >
-                              <card.component />
-                            </CardContainer>
+                            />
                           {{/if}}
                         {{/each}}
                       </div>
@@ -678,18 +675,15 @@ class IsolatedTemplate extends Component<typeof OnlineStore> {
                               <p>Failed to load: {{card.url}}</p>
                             </div>
                           {{else}}
-                            <CardContainer
+                            <card.component
                               {{@context.cardComponentModifier
                                 cardId=card.url
                                 format='data'
                                 fieldType=undefined
                                 fieldName=undefined
                               }}
-                              @displayBoundaries={{true}}
                               class='order-card-container'
-                            >
-                              <card.component />
-                            </CardContainer>
+                            />
                           {{/if}}
                         {{/each}}
                       </div>
@@ -767,7 +761,7 @@ class IsolatedTemplate extends Component<typeof OnlineStore> {
                               <p>Failed to load: {{card.url}}</p>
                             </div>
                           {{else}}
-                            <CardContainer
+                            <card.component
                               {{@context.cardComponentModifier
                                 cardId=card.url
                                 format='data'
@@ -776,9 +770,7 @@ class IsolatedTemplate extends Component<typeof OnlineStore> {
                               }}
                               @displayBoundaries={{true}}
                               class='customer-card-container'
-                            >
-                              <card.component />
-                            </CardContainer>
+                            />
                           {{/if}}
                         {{/each}}
                       </div>

--- a/packages/catalog-realm/online-store/online-store.gts
+++ b/packages/catalog-realm/online-store/online-store.gts
@@ -768,7 +768,6 @@ class IsolatedTemplate extends Component<typeof OnlineStore> {
                                 fieldType=undefined
                                 fieldName=undefined
                               }}
-                              @displayBoundaries={{true}}
                               class='customer-card-container'
                             />
                           {{/if}}

--- a/packages/experiments-realm/components/card-list.gts
+++ b/packages/experiments-realm/components/card-list.gts
@@ -7,8 +7,6 @@ import {
   type PrerenderedCardLike,
 } from '@cardstack/runtime-common';
 
-import { CardContainer } from '@cardstack/boxel-ui/components';
-
 interface CardListSignature {
   Args: {
     query: Query;

--- a/packages/experiments-realm/components/card-list.gts
+++ b/packages/experiments-realm/components/card-list.gts
@@ -39,7 +39,7 @@ export class CardList extends GlimmerComponent<CardListSignature> {
           <:response as |cards|>
             {{#each cards key='url' as |card|}}
               <li class='card-list-item'>
-                <CardContainer
+                <card.component
                   {{@context.cardComponentModifier
                     cardId=card.url
                     format='data'
@@ -47,10 +47,7 @@ export class CardList extends GlimmerComponent<CardListSignature> {
                     fieldName=undefined
                   }}
                   class='card'
-                  @displayBoundaries={{true}}
-                >
-                  <card.component />
-                </CardContainer>
+                />
                 {{#if (has-block 'meta')}}
                   {{yield card to='meta'}}
                 {{/if}}

--- a/packages/experiments-realm/components/grid.gts
+++ b/packages/experiments-realm/components/grid.gts
@@ -4,8 +4,6 @@ import { type CardContext } from 'https://cardstack.com/base/card-api';
 
 import { type Query } from '@cardstack/runtime-common';
 
-import { CardContainer } from '@cardstack/boxel-ui/components';
-
 interface CardsGridSignature {
   Args: {
     query: Query;
@@ -38,7 +36,7 @@ export class CardsGrid extends GlimmerComponent<CardsGridSignature> {
           <:response as |cards|>
             {{#each cards key='url' as |card|}}
               <li class='{{@selectedView}}-view-container'>
-                <CardContainer
+                <card.component
                   {{@context.cardComponentModifier
                     cardId=card.url
                     format='data'
@@ -46,10 +44,7 @@ export class CardsGrid extends GlimmerComponent<CardsGridSignature> {
                     fieldName=undefined
                   }}
                   class='card'
-                  @displayBoundaries={{true}}
-                >
-                  <card.component />
-                </CardContainer>
+                />
               </li>
             {{/each}}
           </:response>

--- a/packages/host/app/components/card-catalog/index.gts
+++ b/packages/host/app/components/card-catalog/index.gts
@@ -68,7 +68,7 @@ const ItemButton: TemplateOnlyComponent<ButtonSignature> = <template>
         key=@card.url
       }}
     >
-      <@card.component />
+      <@card.component @displayBoundaries={{false}} />
     </Button>
   {{else if @newCard}}
     <Button

--- a/packages/host/app/components/card-catalog/index.gts
+++ b/packages/host/app/components/card-catalog/index.gts
@@ -68,7 +68,7 @@ const ItemButton: TemplateOnlyComponent<ButtonSignature> = <template>
         key=@card.url
       }}
     >
-      <@card.component @displayBoundaries={{false}} />
+      <@card.component class='hide-boundaries' />
     </Button>
   {{else if @newCard}}
     <Button

--- a/packages/host/app/components/prerendered-card-search.gts
+++ b/packages/host/app/components/prerendered-card-search.gts
@@ -11,6 +11,8 @@ import { trackedFunction } from 'reactiveweb/function';
 
 import { TrackedSet } from 'tracked-built-ins';
 
+import { CardContainer } from '@cardstack/boxel-ui/components';
+
 import {
   type Query,
   RealmPaths,
@@ -57,14 +59,22 @@ export class PrerenderedCard implements PrerenderedCardLike {
 function getErrorComponent(realmURL: string, url: string) {
   let name = new RealmPaths(new URL(realmURL)).local(new URL(url));
   const DefaultErrorResultComponent: TemplateOnlyComponent<{
-    Element: Element;
+    Element: HTMLDivElement;
   }> = <template>
-    <div class='error' ...attributes>
-      <div class='thumbnail'>
-        <TriangleAlert />
+    <CardContainer
+      class='card instance-error'
+      @displayBoundaries={{true}}
+      data-test-instance-error={{true}}
+      data-test-card={{url}}
+      ...attributes
+    >
+      <div class='error'>
+        <div class='thumbnail'>
+          <TriangleAlert />
+        </div>
+        <div class='name' data-test-instance-error-name>{{name}}</div>
       </div>
-      <div class='name' data-test-instance-error-name>{{name}}</div>
-    </div>
+    </CardContainer>
     <style scoped>
       .error {
         display: flex;
@@ -96,7 +106,7 @@ function getErrorComponent(realmURL: string, url: string) {
       }
     </style>
   </template>;
-  return DefaultErrorResultComponent;
+  return DefaultErrorResultComponent as unknown as HTMLComponent;
 }
 
 export default class PrerenderedCardSearch extends Component<PrerenderedCardComponentSignature> {

--- a/packages/host/app/components/prerendered-card-search.gts
+++ b/packages/host/app/components/prerendered-card-search.gts
@@ -43,7 +43,11 @@ export class PrerenderedCard implements PrerenderedCardLike {
     if (data.isError && !data.html) {
       this.component = getErrorComponent(data.realmUrl, data.url);
     } else {
-      this.component = htmlComponent(data.html);
+      let extraAttributes: Record<string, string> = {};
+      if (data.isError) {
+        extraAttributes['data-is-error'] = 'true';
+      }
+      this.component = htmlComponent(data.html, extraAttributes);
     }
   }
   get url() {

--- a/packages/host/app/components/search-sheet/results-section.gts
+++ b/packages/host/app/components/search-sheet/results-section.gts
@@ -5,7 +5,7 @@ import Component from '@glimmer/component';
 
 import { ComponentLike } from '@glint/template';
 
-import { CardContainer, Label } from '@cardstack/boxel-ui/components';
+import { Label } from '@cardstack/boxel-ui/components';
 import { cn } from '@cardstack/boxel-ui/helpers';
 
 import { urlForRealmLookup } from '@cardstack/host/lib/utils';
@@ -45,14 +45,11 @@ class SearchResult extends Component<SearchResultSignature> {
   <template>
     <div class={{cn 'container' is-compact=@isCompact}}>
       {{#if @component}}
-        <CardContainer
-          @displayBoundaries={{true}}
-          data-test-search-result={{removeFileExtension @cardId}}
+        <@component
           class='search-result'
+          data-test-search-result={{removeFileExtension @cardId}}
           ...attributes
-        >
-          <@component />
-        </CardContainer>
+        />
 
       {{else if @card}}
         <CardRenderer

--- a/packages/host/app/components/search-sheet/results-section.gts
+++ b/packages/host/app/components/search-sheet/results-section.gts
@@ -18,7 +18,7 @@ import CardRenderer from '../card-renderer';
 import { removeFileExtension } from './utils';
 
 interface SearchResultSignature {
-  Element: HTMLElement;
+  Element: Element;
   Args: {
     component?: ComponentLike<{ Element: Element }>;
     card?: CardDef;

--- a/packages/host/app/components/search-sheet/results-section.gts
+++ b/packages/host/app/components/search-sheet/results-section.gts
@@ -20,7 +20,7 @@ import { removeFileExtension } from './utils';
 interface SearchResultSignature {
   Element: HTMLElement;
   Args: {
-    component?: ComponentLike<{}>;
+    component?: ComponentLike<{ Element: Element }>;
     card?: CardDef;
     cardId: string | undefined;
     isCompact: boolean;

--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -698,16 +698,14 @@ export class CurrentRun {
           },
         );
         await api.flushLogs();
-        isolatedHtml = unwrap(
-          sanitizeHTML(
-            await this.renderCard({
-              card,
-              format: 'isolated',
-              visit: this.visitFile.bind(this),
-              store,
-              realmPath: this.#realmPaths,
-            }),
-          ),
+        isolatedHtml = sanitizeHTML(
+          await this.renderCard({
+            card,
+            format: 'isolated',
+            visit: this.visitFile.bind(this),
+            store,
+            realmPath: this.#realmPaths,
+          }),
         );
         atomHtml = unwrap(
           sanitizeHTML(
@@ -889,17 +887,15 @@ export class CurrentRun {
   ): Promise<{ [refURL: string]: string }> {
     let result: { [refURL: string]: string } = {};
     for (let { codeRef: componentCodeRef, refURL } of types) {
-      let html = unwrap(
-        sanitizeHTML(
-          await this.renderCard({
-            card,
-            format,
-            visit: this.visitFile.bind(this),
-            store,
-            realmPath: this.#realmPaths,
-            componentCodeRef,
-          }),
-        ),
+      let html = sanitizeHTML(
+        await this.renderCard({
+          card,
+          format,
+          visit: this.visitFile.bind(this),
+          store,
+          realmPath: this.#realmPaths,
+          componentCodeRef,
+        }),
       );
       result[refURL] = html;
     }
@@ -1018,7 +1014,7 @@ function assertURLEndsWithJSON(url: URL): URL {
 // we unwrap the outer div (and cleanup empty html comments) as the
 // outer div is actually the container that the card HTML is
 // rendering into
-function unwrap(html: string): string {
+export function unwrap(html: string): string {
   return html
     .trim()
     .replace(/^<div ([^>]*>)/, '')

--- a/packages/host/app/lib/html-component.ts
+++ b/packages/host/app/lib/html-component.ts
@@ -3,7 +3,7 @@ import { capabilities } from '@ember/component';
 import { setComponentTemplate } from '@ember/component';
 
 import templateOnly from '@ember/component/template-only';
-import { htmlSafe } from '@ember/template';
+import { htmlSafe, type SafeString } from '@ember/template';
 import { precompileTemplate } from '@ember/template-compilation';
 
 import { ComponentLike } from '@glint/template';
@@ -14,7 +14,7 @@ import { compiler } from '@cardstack/runtime-common/etc';
 class _DynamicHTMLComponent {
   constructor(
     readonly component: TopElement,
-    readonly attrs: Record<string, string>,
+    readonly attrs: Record<string, string | SafeString>,
     readonly children: Node[],
   ) {}
 }
@@ -46,12 +46,16 @@ export function htmlComponent(
     let tagName = cardElement.tagName.toLowerCase();
 
     let sourceParts: string[] = [];
-    let attrs: Record<string, string> = {};
+    let attrs: Record<string, string | SafeString> = {};
 
     sourceParts.push(`<${tagName} `);
 
     for (let { name, value } of cardElement.attributes) {
-      attrs[name] = value;
+      if (name === 'style') {
+        attrs[name] = htmlSafe(value);
+      } else {
+        attrs[name] = value;
+      }
       sourceParts.push(`${name}={{@attrs.${name}}} `);
     }
 

--- a/packages/host/app/lib/html-component.ts
+++ b/packages/host/app/lib/html-component.ts
@@ -32,7 +32,10 @@ type TopElement = ComponentLike<{
   Element: Element;
 }>;
 
-export function htmlComponent(html: string): HTMLComponent {
+export function htmlComponent(
+  html: string,
+  extraAttributes: Record<string, string> = {},
+): HTMLComponent {
   let testContainer = document.createElement('div');
   testContainer.innerHTML = html;
   if (
@@ -48,6 +51,11 @@ export function htmlComponent(html: string): HTMLComponent {
     sourceParts.push(`<${tagName} `);
 
     for (let { name, value } of cardElement.attributes) {
+      attrs[name] = value;
+      sourceParts.push(`${name}={{@attrs.${name}}} `);
+    }
+
+    for (let [name, value] of Object.entries(extraAttributes)) {
       attrs[name] = value;
       sourceParts.push(`${name}={{@attrs.${name}}} `);
     }

--- a/packages/host/app/services/render-service.ts
+++ b/packages/host/app/services/render-service.ts
@@ -124,7 +124,10 @@ export default class RenderService extends Service {
       realmPath,
       componentCodeRef,
     } = params;
-    let component = card.constructor.getComponent(card, undefined, {
+    const cardApi = await this.loaderService.loader.import<typeof CardAPI>(
+      `${baseRealm.url}card-api`,
+    );
+    let component = cardApi.getComponent(card, undefined, {
       componentCodeRef,
     });
 

--- a/packages/host/tests/integration/card-prerender-test.gts
+++ b/packages/host/tests/integration/card-prerender-test.gts
@@ -8,6 +8,8 @@ import stripScopedCSSAttributes from '@cardstack/runtime-common/helpers/strip-sc
 import { Loader } from '@cardstack/runtime-common/loader';
 import { Realm } from '@cardstack/runtime-common/realm';
 
+import { unwrap } from '@cardstack/host/lib/current-run';
+
 import {
   testRealmURL,
   setupCardLogs,
@@ -185,7 +187,15 @@ module('Integration | card-prerender', function (hooks) {
       if (entry?.type === 'instance') {
         assert.strictEqual(
           cleanWhiteSpace(stripScopedCSSAttributes(entry!.isolatedHtml!)),
-          cleanWhiteSpace(`<h3> Mango </h3>`),
+          cleanWhiteSpace(`<div
+            class="ember-view boxel-card-container boundaries field-component-card isolated-format display-container-true"
+            data-test-boxel-card-container
+            style="--boxel-example: 1px;"
+            data-test-card="http://test-realm/test/Pet/mango"
+            data-test-card-format="isolated"
+            data-test-field-component-card>
+              <h3> Mango </h3>
+          </div>`),
           'the pre-rendered HTML is correct',
         );
       } else {
@@ -199,7 +209,15 @@ module('Integration | card-prerender', function (hooks) {
       if (entry?.type === 'instance') {
         assert.strictEqual(
           cleanWhiteSpace(stripScopedCSSAttributes(entry!.isolatedHtml!)),
-          cleanWhiteSpace(`<h3> Van Gogh </h3>`),
+          cleanWhiteSpace(`<div
+            class="ember-view boxel-card-container boundaries field-component-card isolated-format display-container-true"
+            data-test-boxel-card-container
+            style="--boxel-example: 1px;"
+            data-test-card="http://test-realm/test/Pet/vangogh"
+            data-test-card-format="isolated"
+            data-test-field-component-card>
+              <h3> Van Gogh </h3>
+            </div>`),
           'the pre-rendered HTML is correct',
         );
       } else {
@@ -274,7 +292,9 @@ module('Integration | card-prerender', function (hooks) {
     ].forEach(([title, type], index) => {
       assert.strictEqual(
         cleanWhiteSpace(
-          stripScopedCSSAttributes(results.prerenderedCards[index].html!),
+          stripScopedCSSAttributes(
+            unwrap(results.prerenderedCards[index].html!),
+          ),
         ),
         cleanWhiteSpace(`
           <div class="fitted-template">

--- a/packages/host/tests/integration/card-prerender-test.gts
+++ b/packages/host/tests/integration/card-prerender-test.gts
@@ -188,7 +188,7 @@ module('Integration | card-prerender', function (hooks) {
         assert.strictEqual(
           cleanWhiteSpace(stripScopedCSSAttributes(entry!.isolatedHtml!)),
           cleanWhiteSpace(`<div
-            class="ember-view boxel-card-container boundaries field-component-card isolated-format display-container-true"
+            class="ember-view boxel-card-container boxel-card-container--boundaries field-component-card isolated-format display-container-true"
             data-test-boxel-card-container
             style="--boxel-example: 1px;"
             data-test-card="http://test-realm/test/Pet/mango"
@@ -210,7 +210,7 @@ module('Integration | card-prerender', function (hooks) {
         assert.strictEqual(
           cleanWhiteSpace(stripScopedCSSAttributes(entry!.isolatedHtml!)),
           cleanWhiteSpace(`<div
-            class="ember-view boxel-card-container boundaries field-component-card isolated-format display-container-true"
+            class="ember-view boxel-card-container boxel-card-container--boundaries field-component-card isolated-format display-container-true"
             data-test-boxel-card-container
             style="--boxel-example: 1px;"
             data-test-card="http://test-realm/test/Pet/vangogh"

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -1257,13 +1257,15 @@ module('Integration | operator-mode', function (hooks) {
 
     await click('[data-test-stack-card-index="1"] [data-test-edit-button]');
 
-    await waitUntil(() =>
-      document
-        .querySelector(`[data-test-card="${packetId}"]`)
+    await waitUntil(() => {
+      return document
+        .querySelector(
+          `[data-test-stack-item-content] >[data-test-card="${packetId}"]`,
+        )
         ?.textContent?.includes(
           'Everyone knows that Alice ran the show in the Brady household.',
-        ),
-    );
+        );
+    });
   });
 
   test('can choose a card for a linksTo field that has an existing value', async function (assert) {

--- a/packages/host/tests/integration/components/prerendered-card-search-test.gts
+++ b/packages/host/tests/integration/components/prerendered-card-search-test.gts
@@ -335,18 +335,22 @@ module(`Integration | prerendered-card-search`, function (hooks) {
         </:response>
       </PrerenderedCardSearch>
     </template>);
-    await waitFor('.card-container');
-    assert.dom('.card-container').exists({ count: 2 });
+    await waitFor('#ember-testing > [data-test-boxel-card-container]');
     assert
-      .dom('.card-container:nth-child(1)')
+      .dom('#ember-testing > [data-test-boxel-card-container]')
+      .exists({ count: 2 });
+    assert
+      .dom('#ember-testing > [data-test-boxel-card-container]:nth-child(1)')
       .containsText('Card 2 by Cardy Jones');
     assert
-      .dom('.card-container:nth-child(2)')
+      .dom('#ember-testing > [data-test-boxel-card-container]:nth-child(2)')
       .containsText('Cardy Stackington Jr. III');
     assert
-      .dom('.card-container .book')
+      .dom('#ember-testing > [data-test-boxel-card-container] .book')
       .hasStyle({ backgroundColor: 'rgb(255, 255, 0)' });
-    assert.dom('.card-container .author').hasStyle({ color: 'rgb(0, 0, 255)' });
+    assert
+      .dom('#ember-testing > [data-test-boxel-card-container] .author')
+      .hasStyle({ color: 'rgb(0, 0, 255)' });
   });
 
   test(`can include last known good state for instances in error state`, async function (assert) {
@@ -416,24 +420,32 @@ module(`Integration | prerendered-card-search`, function (hooks) {
         </:response>
       </PrerenderedCardSearch>
     </template>);
-    await waitFor('.card-container');
-    assert.dom('.card-container').exists({ count: 2 });
+    await waitFor('#ember-testing > [data-test-boxel-card-container]');
     assert
-      .dom('.card-container:nth-child(1)')
+      .dom('#ember-testing > [data-test-boxel-card-container]')
+      .exists({ count: 2 });
+    assert
+      .dom('#ember-testing > [data-test-boxel-card-container]:nth-child(1)')
       .containsText('Card 2 by Cardy Jones');
     assert
-      .dom('.card-container:nth-child(1)[data-test-is-error]')
+      .dom(
+        '#ember-testing > [data-test-boxel-card-container]:nth-child(1)[data-test-is-error]',
+      )
       .doesNotExist('the result is not an instance in an error state');
     assert
-      .dom('.card-container:nth-child(2)')
+      .dom('#ember-testing > [data-test-boxel-card-container]:nth-child(2)')
       .containsText('Cardy Stackington Jr. III');
     assert
-      .dom('.card-container:nth-child(2)[data-test-is-error]')
+      .dom(
+        '#ember-testing > [data-test-boxel-card-container]:nth-child(2)[data-is-error]',
+      )
       .exists('the result is an instance in an error state');
     assert
-      .dom('.card-container .book')
+      .dom('#ember-testing > [data-test-boxel-card-container] .book')
       .hasStyle({ backgroundColor: 'rgb(255, 255, 0)' });
-    assert.dom('.card-container .author').hasStyle({ color: 'rgb(0, 0, 255)' });
+    assert
+      .dom('#ember-testing > [data-test-boxel-card-container] .author')
+      .hasStyle({ color: 'rgb(0, 0, 255)' });
   });
 
   test(`refreshes when a queried realm changes when configured to perform live search`, async function (assert) {
@@ -475,18 +487,26 @@ module(`Integration | prerendered-card-search`, function (hooks) {
       {{! to support incremental indexing }}
       <CardPrerender />
     </template>);
-    await waitFor('.card-container');
-    assert.dom('.card-container').exists({ count: 2 });
+    await waitFor('#ember-testing > [data-test-boxel-card-container]');
+    assert
+      .dom('#ember-testing > [data-test-boxel-card-container]')
+      .exists({ count: 2 });
 
     let cardService = getService('card-service');
     await cardService.deleteSource(new URL(`${testRealmURL}card-2.json`));
 
     await waitUntil(() => {
-      return document.querySelectorAll('.card-container').length === 1;
+      return (
+        document.querySelectorAll(
+          '#ember-testing > [data-test-boxel-card-container]',
+        ).length === 1
+      );
     });
-    assert.dom('.card-container').exists({ count: 1 });
     assert
-      .dom('.card-container:nth-child(1)')
+      .dom('#ember-testing > [data-test-boxel-card-container]')
+      .exists({ count: 1 });
+    assert
+      .dom('#ember-testing > [data-test-boxel-card-container]:nth-child(1)')
       .containsText('Cardy Stackington Jr. III');
   });
 });

--- a/packages/host/tests/integration/components/prerendered-card-search-test.gts
+++ b/packages/host/tests/integration/components/prerendered-card-search-test.gts
@@ -330,9 +330,7 @@ module(`Integration | prerendered-card-search`, function (hooks) {
         </:loading>
         <:response as |cards|>
           {{#each cards as |card|}}
-            <div class='card-container'>
-              <card.component />
-            </div>
+            <card.component />
           {{/each}}
         </:response>
       </PrerenderedCardSearch>
@@ -413,9 +411,7 @@ module(`Integration | prerendered-card-search`, function (hooks) {
         </:loading>
         <:response as |cards|>
           {{#each cards as |card|}}
-            <div class='card-container' data-test-is-error={{card.isError}}>
-              <card.component />
-            </div>
+            <card.component />
           {{/each}}
         </:response>
       </PrerenderedCardSearch>
@@ -471,9 +467,7 @@ module(`Integration | prerendered-card-search`, function (hooks) {
         </:loading>
         <:response as |cards|>
           {{#each cards as |card|}}
-            <div class='card-container'>
-              <card.component />
-            </div>
+            <card.component />
           {{/each}}
         </:response>
       </PrerenderedCardSearch>

--- a/packages/host/tests/integration/realm-indexing-test.gts
+++ b/packages/host/tests/integration/realm-indexing-test.gts
@@ -16,6 +16,8 @@ import {
 import stripScopedCSSAttributes from '@cardstack/runtime-common/helpers/strip-scoped-css-attributes';
 import { Loader } from '@cardstack/runtime-common/loader';
 
+import { unwrap } from '@cardstack/host/lib/current-run';
+
 import {
   testRealmURL,
   testRealmInfo,
@@ -43,6 +45,19 @@ import { setupMockMatrix } from '../helpers/mock-matrix';
 import { setupRenderingTest } from '../helpers/setup';
 
 let loader: Loader;
+
+function assertInnerHtmlMatches(
+  assert: Assert,
+  actual: string | null | undefined,
+  expected: string | null | undefined,
+  message?: string,
+) {
+  let cleanedActual = cleanWhiteSpace(
+    stripScopedCSSAttributes(unwrap(actual!)),
+  );
+  let cleanedExpected = cleanWhiteSpace(expected!);
+  assert.strictEqual(cleanedActual, cleanedExpected, message);
+}
 
 module(`Integration | realm indexing`, function (hooks) {
   setupRenderingTest(hooks);
@@ -1024,25 +1039,16 @@ module(`Integration | realm indexing`, function (hooks) {
           assert.deepEqual(entry.doc.data.attributes?.firstName, 'Van Gogh');
           let { isolatedHtml, embeddedHtml, fittedHtml } =
             (await getInstance(realm, new URL(`${testRealmURL}vangogh`))) ?? {};
-          assert.strictEqual(
-            cleanWhiteSpace(stripScopedCSSAttributes(isolatedHtml!)),
-            cleanWhiteSpace(`<h1> Van Gogh </h1>`),
+          assertInnerHtmlMatches(assert, isolatedHtml, `<h1> Van Gogh </h1>`);
+          assertInnerHtmlMatches(
+            assert,
+            embeddedHtml![`${testRealmURL}person/Person`],
+            `<h1> Person Embedded Card: Van Gogh </h1>`,
           );
-          assert.strictEqual(
-            cleanWhiteSpace(
-              stripScopedCSSAttributes(
-                embeddedHtml![`${testRealmURL}person/Person`],
-              ),
-            ),
-            cleanWhiteSpace(`<h1> Person Embedded Card: Van Gogh </h1>`),
-          );
-          assert.strictEqual(
-            cleanWhiteSpace(
-              stripScopedCSSAttributes(
-                fittedHtml![`${testRealmURL}person/Person`],
-              ),
-            ),
-            cleanWhiteSpace(`<h1> Person Fitted Card: Van Gogh </h1>`),
+          assertInnerHtmlMatches(
+            assert,
+            fittedHtml![`${testRealmURL}person/Person`],
+            `<h1> Person Fitted Card: Van Gogh </h1>`,
           );
         } else {
           assert.ok(
@@ -1061,25 +1067,16 @@ module(`Integration | realm indexing`, function (hooks) {
           assert.deepEqual(entry.doc.data.attributes?.firstName, 'Van Gogh');
           let { isolatedHtml, embeddedHtml, fittedHtml } =
             (await getInstance(realm, new URL(`${testRealmURL}vangogh`))) ?? {};
-          assert.strictEqual(
-            cleanWhiteSpace(stripScopedCSSAttributes(isolatedHtml!)),
-            cleanWhiteSpace(`<h1> Van Gogh </h1>`),
+          assertInnerHtmlMatches(assert, isolatedHtml, `<h1> Van Gogh </h1>`);
+          assertInnerHtmlMatches(
+            assert,
+            embeddedHtml![`${testRealmURL}person/Person`],
+            `<h1> Person Embedded Card: Van Gogh </h1>`,
           );
-          assert.strictEqual(
-            cleanWhiteSpace(
-              stripScopedCSSAttributes(
-                embeddedHtml![`${testRealmURL}person/Person`],
-              ),
-            ),
-            cleanWhiteSpace(`<h1> Person Embedded Card: Van Gogh </h1>`),
-          );
-          assert.strictEqual(
-            cleanWhiteSpace(
-              stripScopedCSSAttributes(
-                fittedHtml![`${testRealmURL}person/Person`],
-              ),
-            ),
-            cleanWhiteSpace(`<h1> Person Fitted Card: Van Gogh </h1>`),
+          assertInnerHtmlMatches(
+            assert,
+            fittedHtml![`${testRealmURL}person/Person`],
+            `<h1> Person Fitted Card: Van Gogh </h1>`,
           );
         } else {
           assert.ok(
@@ -1195,23 +1192,16 @@ module(`Integration | realm indexing`, function (hooks) {
           realm,
           new URL(`${testRealmURL}working-van-gogh`),
         )) ?? {};
-      assert.strictEqual(
-        cleanWhiteSpace(stripScopedCSSAttributes(isolatedHtml!)),
-        cleanWhiteSpace(`<h1> Van Gogh </h1>`),
+      assertInnerHtmlMatches(assert, isolatedHtml!, `<h1> Van Gogh </h1>`);
+      assertInnerHtmlMatches(
+        assert,
+        embeddedHtml![`${testRealmURL}person/Person`],
+        `<h1> Person Embedded Card: Van Gogh </h1>`,
       );
-      assert.strictEqual(
-        cleanWhiteSpace(
-          stripScopedCSSAttributes(
-            embeddedHtml![`${testRealmURL}person/Person`],
-          ),
-        ),
-        cleanWhiteSpace(`<h1> Person Embedded Card: Van Gogh </h1>`),
-      );
-      assert.strictEqual(
-        cleanWhiteSpace(
-          stripScopedCSSAttributes(fittedHtml![`${testRealmURL}person/Person`]),
-        ),
-        cleanWhiteSpace(`<h1> Person Fitted Card: Van Gogh </h1>`),
+      assertInnerHtmlMatches(
+        assert,
+        fittedHtml![`${testRealmURL}person/Person`],
+        `<h1> Person Fitted Card: Van Gogh </h1>`,
       );
     } else {
       assert.ok(
@@ -1329,28 +1319,21 @@ module(`Integration | realm indexing`, function (hooks) {
       let { isolatedHtml, embeddedHtml, fittedHtml } =
         (await getInstance(realm, new URL(`${testRealmURL}working-vangogh`))) ??
         {};
-      assert.strictEqual(
-        cleanWhiteSpace(stripScopedCSSAttributes(isolatedHtml!)),
-        cleanWhiteSpace(`<h1> Van Gogh </h1>`),
-      );
+      assertInnerHtmlMatches(assert, isolatedHtml!, `<h1> Van Gogh </h1>`);
       assert.strictEqual(
         false,
         isolatedHtml!.includes('id="ember'),
         `isolated HTML does not include ember ID's`,
       );
-      assert.strictEqual(
-        cleanWhiteSpace(
-          stripScopedCSSAttributes(
-            embeddedHtml![`${testRealmURL}person/Person`],
-          ),
-        ),
-        cleanWhiteSpace(`<h1> Person Embedded Card: Van Gogh </h1>`),
+      assertInnerHtmlMatches(
+        assert,
+        embeddedHtml![`${testRealmURL}person/Person`],
+        `<h1> Person Embedded Card: Van Gogh </h1>`,
       );
-      assert.strictEqual(
-        cleanWhiteSpace(
-          stripScopedCSSAttributes(fittedHtml![`${testRealmURL}person/Person`]),
-        ),
-        cleanWhiteSpace(`<h1> Person Fitted Card: Van Gogh </h1>`),
+      assertInnerHtmlMatches(
+        assert,
+        fittedHtml![`${testRealmURL}person/Person`],
+        `<h1> Person Fitted Card: Van Gogh </h1>`,
       );
       assert.strictEqual(
         false,
@@ -1481,7 +1464,13 @@ module(`Integration | realm indexing`, function (hooks) {
         ),
       ),
       cleanWhiteSpace(
-        `<h1> Fancy Person Embedded Card: Germaine - hot pink </h1>`,
+        `<div
+          class="ember-view boxel-card-container boundaries field-component-card embedded-format display-container-true"
+          data-test-boxel-card-container
+          style="--boxel-example: 1px;"
+          data-test-card="http://test-realm/test/germaine"
+          data-test-card-format="embedded"
+          data-test-field-component-card> <h1> Fancy Person Embedded Card: Germaine - hot pink </h1> </div>`,
       ),
       'default embedded HTML is correct',
     );
@@ -1501,7 +1490,13 @@ module(`Integration | realm indexing`, function (hooks) {
       cleanWhiteSpace(
         stripScopedCSSAttributes(embeddedHtml![`${testRealmURL}person/Person`]),
       ),
-      cleanWhiteSpace(`<h1> Person Embedded Card: Germaine </h1>`),
+      cleanWhiteSpace(`<div
+        class="ember-view boxel-card-container boundaries field-component-card embedded-format display-container-true"
+        data-test-boxel-card-container
+        style="--boxel-example: 1px;"
+        data-test-card="http://test-realm/test/germaine"
+        data-test-card-format="embedded"
+        data-test-field-component-card> <h1> Person Embedded Card: Germaine </h1> </div>`),
       `${testRealmURL}person/Person embedded HTML is correct`,
     );
     assert.strictEqual(
@@ -1512,7 +1507,13 @@ module(`Integration | realm indexing`, function (hooks) {
 
     assert.strictEqual(
       cleanWhiteSpace(stripScopedCSSAttributes(embeddedHtml![cardDefRefURL])),
-      cleanWhiteSpace(`
+      cleanWhiteSpace(`<div
+        class="ember-view boxel-card-container boundaries field-component-card embedded-format display-container-true"
+        data-test-boxel-card-container
+        style="--boxel-example: 1px;"
+        data-test-card="http://test-realm/test/germaine"
+        data-test-card-format="embedded"
+        data-test-field-component-card>
           <div class="embedded-template">
             <div class="thumbnail-section">
               <div class="card-thumbnail">
@@ -1527,6 +1528,7 @@ module(`Integration | realm indexing`, function (hooks) {
             </div>
             <div class="card-description" data-test-card-description>Fancy Germaine</div>
           </div>
+        </div>
       `),
       `${cardDefRefURL} embedded HTML is correct`,
     );
@@ -1587,7 +1589,7 @@ module(`Integration | realm indexing`, function (hooks) {
       },
     });
 
-    let { fittedHtml } =
+    let { embeddedHtml, fittedHtml } =
       (await getInstance(realm, new URL(`${testRealmURL}germaine`))) ?? {};
     assert.strictEqual(
       false,
@@ -1601,7 +1603,13 @@ module(`Integration | realm indexing`, function (hooks) {
         ),
       ),
       cleanWhiteSpace(
-        `<h1> Fancy Person Fitted Card: Germaine - hot pink </h1>`,
+        `<div
+          class="ember-view boxel-card-container boundaries field-component-card fitted-format display-container-true"
+          data-test-boxel-card-container
+          style="--boxel-example: 1px;"
+          data-test-card="http://test-realm/test/germaine"
+          data-test-card-format="fitted"
+          data-test-field-component-card> <h1> Fancy Person Fitted Card: Germaine - hot pink </h1> </div>`,
       ),
       'default fitted HTML is correct',
     );
@@ -1621,7 +1629,13 @@ module(`Integration | realm indexing`, function (hooks) {
       cleanWhiteSpace(
         stripScopedCSSAttributes(fittedHtml![`${testRealmURL}person/Person`]),
       ),
-      cleanWhiteSpace(`<h1> Person Fitted Card: Germaine </h1>`),
+      cleanWhiteSpace(`<div
+      class="ember-view boxel-card-container boundaries field-component-card fitted-format display-container-true"
+      data-test-boxel-card-container
+      style="--boxel-example: 1px;"
+      data-test-card="http://test-realm/test/germaine"
+      data-test-card-format="fitted"
+      data-test-field-component-card> <h1> Person Fitted Card: Germaine </h1> </div>`),
       `${testRealmURL}person/Person fitted HTML is correct`,
     );
     assert.strictEqual(
@@ -1631,28 +1645,34 @@ module(`Integration | realm indexing`, function (hooks) {
     );
 
     assert.strictEqual(
-      cleanWhiteSpace(stripScopedCSSAttributes(fittedHtml![cardDefRefURL])),
-      cleanWhiteSpace(`
-          <div class="fitted-template">
-            <div class="thumbnail-section">
-              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="lucide lucide-captions card-type-icon" viewBox="0 0 24 24" data-test-card-type-icon><rect width="18" height="14" x="3" y="5" rx="2" ry="2"></rect><path d="M7 15h4m4 0h2M7 11h2m4 0h4"></path></svg>
+      cleanWhiteSpace(stripScopedCSSAttributes(embeddedHtml![cardDefRefURL])),
+      cleanWhiteSpace(`<div
+      class="ember-view boxel-card-container boundaries field-component-card embedded-format display-container-true"
+      data-test-boxel-card-container
+      style="--boxel-example: 1px;"
+      data-test-card="http://test-realm/test/germaine"
+      data-test-card-format="embedded"
+      data-test-field-component-card>
+        <div class="embedded-template">
+          <div class="thumbnail-section">
+            <div class="card-thumbnail">
+              <div class="card-thumbnail-placeholder" data-test-card-thumbnail-placeholder></div>
             </div>
-            <div class="info-section">
-              <h3 class="card-title" data-test-card-title>Untitled Fancy Person</h3>
-              <h4 class="card-display-name" data-test-card-display-name>
-                Fancy Person
-              </h4>
-            </div>
-            <div class="card-description" data-test-card-description>Fancy Germaine</div>
           </div>
-      `),
+          <div class="info-section">
+            <h3 class="card-title" data-test-card-title>Untitled Fancy Person</h3>
+            <h4 class="card-display-name" data-test-card-display-name> Fancy Person </h4>
+          </div>
+          <div class="card-description" data-test-card-description>Fancy Germaine</div>
+        </div>
+      </div>`),
       `${cardDefRefURL} embedded HTML is correct`,
     );
 
     assert.strictEqual(
       false,
-      fittedHtml![cardDefRefURL].includes('id="ember'),
-      `${cardDefRefURL} fitted HTML does not include ember ID's`,
+      embeddedHtml![cardDefRefURL].includes('id="ember'),
+      `${cardDefRefURL} embedded HTML does not include ember ID's`,
     );
   });
 

--- a/packages/host/tests/integration/realm-indexing-test.gts
+++ b/packages/host/tests/integration/realm-indexing-test.gts
@@ -1465,7 +1465,7 @@ module(`Integration | realm indexing`, function (hooks) {
       ),
       cleanWhiteSpace(
         `<div
-          class="ember-view boxel-card-container boundaries field-component-card embedded-format display-container-true"
+          class="ember-view boxel-card-container boxel-card-container--boundaries field-component-card embedded-format display-container-true"
           data-test-boxel-card-container
           style="--boxel-example: 1px;"
           data-test-card="http://test-realm/test/germaine"
@@ -1491,7 +1491,7 @@ module(`Integration | realm indexing`, function (hooks) {
         stripScopedCSSAttributes(embeddedHtml![`${testRealmURL}person/Person`]),
       ),
       cleanWhiteSpace(`<div
-        class="ember-view boxel-card-container boundaries field-component-card embedded-format display-container-true"
+        class="ember-view boxel-card-container boxel-card-container--boundaries field-component-card embedded-format display-container-true"
         data-test-boxel-card-container
         style="--boxel-example: 1px;"
         data-test-card="http://test-realm/test/germaine"
@@ -1508,7 +1508,7 @@ module(`Integration | realm indexing`, function (hooks) {
     assert.strictEqual(
       cleanWhiteSpace(stripScopedCSSAttributes(embeddedHtml![cardDefRefURL])),
       cleanWhiteSpace(`<div
-        class="ember-view boxel-card-container boundaries field-component-card embedded-format display-container-true"
+        class="ember-view boxel-card-container boxel-card-container--boundaries field-component-card embedded-format display-container-true"
         data-test-boxel-card-container
         style="--boxel-example: 1px;"
         data-test-card="http://test-realm/test/germaine"
@@ -1604,7 +1604,7 @@ module(`Integration | realm indexing`, function (hooks) {
       ),
       cleanWhiteSpace(
         `<div
-          class="ember-view boxel-card-container boundaries field-component-card fitted-format display-container-true"
+          class="ember-view boxel-card-container boxel-card-container--boundaries field-component-card fitted-format display-container-true"
           data-test-boxel-card-container
           style="--boxel-example: 1px;"
           data-test-card="http://test-realm/test/germaine"
@@ -1630,7 +1630,7 @@ module(`Integration | realm indexing`, function (hooks) {
         stripScopedCSSAttributes(fittedHtml![`${testRealmURL}person/Person`]),
       ),
       cleanWhiteSpace(`<div
-      class="ember-view boxel-card-container boundaries field-component-card fitted-format display-container-true"
+      class="ember-view boxel-card-container boxel-card-container--boundaries field-component-card fitted-format display-container-true"
       data-test-boxel-card-container
       style="--boxel-example: 1px;"
       data-test-card="http://test-realm/test/germaine"
@@ -1647,7 +1647,7 @@ module(`Integration | realm indexing`, function (hooks) {
     assert.strictEqual(
       cleanWhiteSpace(stripScopedCSSAttributes(embeddedHtml![cardDefRefURL])),
       cleanWhiteSpace(`<div
-      class="ember-view boxel-card-container boundaries field-component-card embedded-format display-container-true"
+      class="ember-view boxel-card-container boxel-card-container--boundaries field-component-card embedded-format display-container-true"
       data-test-boxel-card-container
       style="--boxel-example: 1px;"
       data-test-card="http://test-realm/test/germaine"

--- a/packages/realm-server/tests/card-source-endpoints-test.ts
+++ b/packages/realm-server/tests/card-source-endpoints-test.ts
@@ -137,7 +137,7 @@ module(basename(__filename), function () {
 
           assert.strictEqual(
             response.headers['content-type'],
-            'text/plain; charset=utf-8',
+            'text/plain;charset=UTF-8',
             'content type is correct',
           );
           assert.strictEqual(

--- a/packages/realm-server/tests/cards/person-with-error.gts
+++ b/packages/realm-server/tests/cards/person-with-error.gts
@@ -79,11 +79,7 @@ export class PersonCard extends CardDef {
                 {{! In order to support scrolling cards into view we use a selector that is not pruned out in production builds }}
                 data-cards-grid-item={{removeFileExtension card.url}}
               >
-                {{! @glint-ignore the error in this module is that 'CardContainer' is not imported !}}
-                <CardContainer @displayBoundaries='true'>
-                  {{card.component}}
-                  {{! @glint-ignore the error is this module is that 'CardContainer' is not imported !}}
-                </CardContainer>
+                {{card.component}}
               </li>
             {{/each}}
           </:response>

--- a/packages/realm-server/tests/types-endpoint-test.ts
+++ b/packages/realm-server/tests/types-endpoint-test.ts
@@ -124,6 +124,15 @@ module(basename(__filename), function () {
         data: [
           {
             type: 'card-type-summary',
+            id: 'http://127.0.0.1:4444/family_photo_card/FamilyPhotoCard',
+            attributes: {
+              displayName: 'Family Photo Card',
+              total: 2,
+              iconHTML,
+            },
+          },
+          {
+            type: 'card-type-summary',
             id: `${testRealm.url}friend/Friend`,
             attributes: {
               displayName: 'Friend',
@@ -155,6 +164,15 @@ module(basename(__filename), function () {
             attributes: {
               displayName: 'Person',
               total: 3,
+              iconHTML,
+            },
+          },
+          {
+            type: 'card-type-summary',
+            id: 'http://127.0.0.1:4444/person-with-error/PersonCard',
+            attributes: {
+              displayName: 'Person',
+              total: 4,
               iconHTML,
             },
           },

--- a/packages/runtime-common/prerendered-card-search.ts
+++ b/packages/runtime-common/prerendered-card-search.ts
@@ -13,7 +13,7 @@ export interface PrerenderedCardLike {
   url: string;
   isError: boolean;
   realmUrl: string;
-  component: ComponentLike<{ Args: {} }>;
+  component: ComponentLike<{ Args: {}; Element: Element }>;
 }
 
 export interface PrerenderedCardComponentSignature {


### PR DESCRIPTION
Previous to this PR, our indexing process' prerendering step did not capture the card container element typically rendered around an isolated, embedded or fitted card HTML. This was annoying, because it meant you had to treat rendering of PrerenderedCardSearch results differently than when you render the same cards dynamically. We lived with the annoyance, but recently we started relying on the card-container element to set theme CSS variables. In order for theming to work with prerendering, something had to change.

With this change, we now include the card container element when prerendering. It adds the ability for the components yielded by PrerenderedCardSearch to support `...attributes`, too.

It also adds a `hide-boundaries` CSS class to CardContainer, which suppresses box shadows. (Prerendering captures HTML/CSS with boundaries visible and sometimes consumers need to render without them.)

The rest of the PR removes the extra CardContainers we were explicitly rendering when using PrerenderedCardSearch and updates tests accordingly.

Lastly, we replaced the static `styleConversions` export with a new `getStyleConversions()` function, which provides stable output for tests improving test reliability for style-related assertions.

After deployment, we will need to perform a full re-index of all realms.