### PR TITLE
AI bot: do not crash ai-bot if non-text attachments are encountered

### DIFF
--- a/packages/ai-bot/helpers.ts
+++ b/packages/ai-bot/helpers.ts
@@ -483,15 +483,15 @@ export async function getAttachedFiles(
         try {
           result.content = await downloadFile(client, attachedFile);
         } catch (error) {
-          if (error instanceof UnsupportedFileError) {
-            return null; // Gracefully ignore unsupported files for now
-          }
-          log.error(`Failed to fetch file ${attachedFile.url}:`, error);
-          Sentry.captureException(error, {
-            extra: { fileUrl: attachedFile.url, fileName: attachedFile.name },
-          });
           result.error = `Error loading attached file: ${(error as Error).message}`;
           result.content = undefined;
+          log.error(`Failed to fetch file ${attachedFile.url}:`, error);
+          if (!(error instanceof UnsupportedFileError)) {
+            // No need to report unsupported files to Sentry
+            Sentry.captureException(error, {
+              extra: { fileUrl: attachedFile.url, fileName: attachedFile.name },
+            });
+          }
         }
       }
       return result;

--- a/packages/ai-bot/lib/matrix/util.ts
+++ b/packages/ai-bot/lib/matrix/util.ts
@@ -27,6 +27,13 @@ import { SerializedFileDef } from 'https://cardstack.com/base/file-api';
 
 let log = logger('ai-bot');
 
+export class UnsupportedFileError extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = 'UnsupportedFileError';
+  }
+}
+
 export interface MatrixClient {
   baseUrl: string;
 
@@ -276,7 +283,7 @@ export async function downloadFile(
     !attachedFile?.contentType?.includes('text/') &&
     !attachedFile.contentType?.includes('application/vnd.card+json')
   ) {
-    throw new Error(
+    throw new UnsupportedFileError(
       `Unsupported file type: ${attachedFile.contentType}. For now, only text files are supported.`,
     );
   }

--- a/packages/host/app/lib/file-def-manager.ts
+++ b/packages/host/app/lib/file-def-manager.ts
@@ -315,7 +315,11 @@ export default class FileDefManagerImpl
           throw new Error('File needs a realm server source URL to upload');
         }
 
-        let response = await this.network.authedFetch(file.sourceUrl);
+        let response = await this.network.authedFetch(file.sourceUrl, {
+          headers: {
+            Accept: 'application/vnd.card+source',
+          },
+        });
 
         // We only support uploading text files (code) for now.
         // When we start supporting other file types (pdfs, images, etc)

--- a/packages/host/app/lib/file-def-manager.ts
+++ b/packages/host/app/lib/file-def-manager.ts
@@ -315,11 +315,7 @@ export default class FileDefManagerImpl
           throw new Error('File needs a realm server source URL to upload');
         }
 
-        let response = await this.network.authedFetch(file.sourceUrl, {
-          headers: {
-            Accept: 'application/vnd.card+source',
-          },
-        });
+        let response = await this.network.authedFetch(file.sourceUrl);
 
         // We only support uploading text files (code) for now.
         // When we start supporting other file types (pdfs, images, etc)


### PR DESCRIPTION
Gracefully ignores unsupported files without causing error noise 