### PR TITLE
matrix: Remove assertions from Playwright helpers

### DIFF
--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -258,9 +258,6 @@ export async function gotoForgotPassword(page: Page, appURL = testHost) {
   await openRoot(page, appURL);
 
   await page.locator('[data-test-forgot-password]').click();
-  await expect(page.locator('[data-test-reset-your-password-btn]')).toHaveCount(
-    1,
-  );
 }
 
 export async function login(

--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -280,9 +280,6 @@ export async function enterWorkspace(
 }
 
 export async function showAllCards(page: Page) {
-  await expect(
-    page.locator(`[data-test-boxel-filter-list-button="All Cards"]`),
-  ).toHaveCount(1);
   await page
     .locator(`[data-test-boxel-filter-list-button="All Cards"]`)
     .click();

--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -23,8 +23,7 @@ interface ProfileAssertions {
   email?: string;
 }
 interface LoginOptions {
-  url?: string;
-  expectFailure?: true;
+  url?: string;?: true;
 }
 
 export async function setSkillsRedirect(page: Page) {
@@ -268,14 +267,9 @@ export async function login(
 ) {
   await openRoot(page, opts?.url);
 
-  await expect(page.locator('[data-test-username-field]')).toBeEditable();
   await page.locator('[data-test-username-field]').fill(username);
   await page.locator('[data-test-password-field]').fill(password);
   await page.locator('[data-test-login-btn]').click();
-
-  if (opts?.expectFailure) {
-    await expect(page.locator('[data-test-login-error]')).toHaveCount(1);
-  }
 }
 
 export async function enterWorkspace(

--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -350,9 +350,6 @@ export async function openRenameMenu(page: Page, roomId: string) {
   await page
     .locator(`[data-test-past-session-options-button="${roomId}"]`)
     .click();
-  await expect(
-    page.locator(`[data-test-boxel-menu-item-text="Rename"]`),
-  ).toHaveCount(1);
   await page.locator(`[data-test-boxel-menu-item-text="Rename"]`).click();
   await page.locator(`[data-test-name-field]`).waitFor();
 }

--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -360,9 +360,6 @@ export async function writeMessage(
   message: string,
 ) {
   await page.locator(`[data-test-message-field="${roomId}"]`).fill(message);
-  await expect(
-    page.locator(`[data-test-message-field="${roomId}"]`),
-  ).toHaveValue(message);
 }
 
 export async function selectCardFromCatalog(

--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -99,6 +99,10 @@ export async function createRealm(
   await page.locator('[data-test-display-name-field]').fill(name);
   await page.locator('[data-test-endpoint-field]').fill(endpoint);
   await page.locator('[data-test-create-workspace-submit]').click();
+  await waitUntil(
+    async () =>
+      (await page.locator(`[data-test-workspace="${name}"]`).count()) === 1,
+  );
 }
 
 export async function openRoot(page: Page, url = testHost) {

--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -100,10 +100,6 @@ export async function createRealm(
   await page.locator('[data-test-display-name-field]').fill(name);
   await page.locator('[data-test-endpoint-field]').fill(endpoint);
   await page.locator('[data-test-create-workspace-submit]').click();
-  await expect(page.locator(`[data-test-workspace="${name}"]`)).toBeVisible();
-  await expect(page.locator('[data-test-create-workspace-modal]')).toHaveCount(
-    0,
-  );
 }
 
 export async function openRoot(page: Page, url = testHost) {

--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -276,16 +276,7 @@ export async function enterWorkspace(
   page: Page,
   workspace = 'Test Workspace A',
 ) {
-  await expect(page.locator('[data-test-workspace-chooser]')).toHaveCount(1);
-  await expect(
-    page.locator(`[data-test-workspace="${workspace}"]`),
-  ).toHaveCount(1);
   await page.locator(`[data-test-workspace="${workspace}"]`).click();
-  await expect(
-    page.locator(
-      `[data-test-stack-card-index="0"] [data-test-boxel-card-header-title]`,
-    ),
-  ).toContainText(workspace);
 }
 
 export async function showAllCards(page: Page) {

--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -288,7 +288,6 @@ export async function showAllCards(page: Page) {
 export async function logout(page: Page) {
   await page.locator('[data-test-profile-icon-button]').click();
   await page.locator('[data-test-signout-button]').click();
-  await expect(page.locator('[data-test-login-btn]')).toHaveCount(1);
 }
 
 export async function createRoom(page: Page) {

--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -23,7 +23,7 @@ interface ProfileAssertions {
   email?: string;
 }
 interface LoginOptions {
-  url?: string;?: true;
+  url?: string;
 }
 
 export async function setSkillsRedirect(page: Page) {

--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -252,7 +252,6 @@ export async function gotoRegistration(page: Page, appURL = testHost) {
   await openRoot(page, appURL);
 
   await page.locator('[data-test-register-user]').click();
-  await expect(page.locator('[data-test-register-btn]')).toHaveCount(1);
 }
 
 export async function gotoForgotPassword(page: Page, appURL = testHost) {

--- a/packages/matrix/tests/create-realm.spec.ts
+++ b/packages/matrix/tests/create-realm.spec.ts
@@ -50,6 +50,14 @@ test.describe('Create Realm via Dashboard', () => {
     });
 
     await createRealm(page, 'new-workspace', '1New Workspace');
+
+    await expect(
+      page.locator(`[data-test-workspace="1New Workspace"]`),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-test-create-workspace-modal]'),
+    ).toHaveCount(0);
+
     await page.locator('[data-test-workspace="1New Workspace"]').click();
     let newRealmURL = new URL('user1/new-workspace/', serverIndexUrl).href;
     await expect(

--- a/packages/matrix/tests/live-cards.spec.ts
+++ b/packages/matrix/tests/live-cards.spec.ts
@@ -115,6 +115,10 @@ test.describe('Live Cards', () => {
     await page.goto(realmURL);
     await showAllCards(page);
 
+    await expect(
+      page.locator(`[data-test-boxel-filter-list-button="All Cards"]`),
+    ).toHaveCount(1);
+
     await postCardSource(
       page,
       realmURL,

--- a/packages/matrix/tests/login.spec.ts
+++ b/packages/matrix/tests/login.spec.ts
@@ -61,6 +61,7 @@ test.describe('Login', () => {
     ).toHaveCount(1);
 
     await logout(page);
+    await expect(page.locator('[data-test-login-btn]')).toHaveCount(1);
     await assertLoggedOut(page);
     await page.reload();
     await assertLoggedOut(page);

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -69,6 +69,9 @@ test.describe('Room messages', () => {
     await assertMessages(page, []);
 
     await writeMessage(page, room1, 'Message 1');
+    await expect(
+      page.locator(`[data-test-message-field="${room1}"]`),
+    ).toHaveValue('Message 1');
     await page.locator('[data-test-send-message-btn]').click();
 
     await expect(page.locator('[data-test-message-field]')).toHaveValue('');

--- a/packages/matrix/tests/registration-with-token.spec.ts
+++ b/packages/matrix/tests/registration-with-token.spec.ts
@@ -61,6 +61,8 @@ test.describe('User Registration w/ Token - isolated realm server', () => {
     await clearLocalStorage(page, serverIndexUrl);
     await gotoRegistration(page, serverIndexUrl);
 
+    await expect(page.locator('[data-test-register-btn]')).toHaveCount(1);
+
     await expect(
       page.locator('[data-test-token-field]'),
       'token field is not displayed',

--- a/packages/matrix/tests/registration-with-token.spec.ts
+++ b/packages/matrix/tests/registration-with-token.spec.ts
@@ -154,7 +154,19 @@ test.describe('User Registration w/ Token - isolated realm server', () => {
     ).toHaveCount(1);
 
     let newRealmURL = new URL('user1/personal/', serverIndexUrl).href;
+
+    await expect(page.locator('[data-test-workspace-chooser]')).toHaveCount(1);
+    await expect(
+      page.locator(`[data-test-workspace="Test User's Workspace"]`),
+    ).toHaveCount(1);
+
     await enterWorkspace(page, "Test User's Workspace");
+
+    await expect(
+      page.locator(
+        `[data-test-stack-card-index="0"] [data-test-boxel-card-header-title]`,
+      ),
+    ).toContainText("Test User's Workspace");
 
     // assert workspace chooser toggle states
     await expect(


### PR DESCRIPTION
This moves assertions from helpers that are used repeatedly to tests where it makes sense to make those assertions only once. There are a few assertions still left in the helpers, they seemed load-bearing to me.