### PR TITLE
Code block: fix case when the whole code block is a single URL

### DIFF
--- a/packages/host/app/lib/formatted-message/utils.ts
+++ b/packages/host/app/lib/formatted-message/utils.ts
@@ -86,7 +86,9 @@ export function extractCodeData(
   let firstLineIsUrl = lines.length == 1 && lines[0].startsWith('http');
 
   let codeToDisplay = '';
-  if (
+  if (firstLineIsUrl && lines.length === 1) {
+    codeToDisplay = lines[0];
+  } else if (
     firstLineIsUrl ||
     (isBeginningOfSearchReplaceBlock && !parsedContent.searchContent)
   ) {

--- a/packages/host/tests/integration/components/formatted-aibot-message-test.gts
+++ b/packages/host/tests/integration/components/formatted-aibot-message-test.gts
@@ -449,6 +449,28 @@ ${REPLACE_MARKER}
     );
   });
 
+  test('it will text code clocks as they are sent, without hiding the first line url as it streams', async function (assert) {
+    await renderFormattedAiBotMessage({
+      htmlParts: parseHtmlContent(
+        `<pre data-code-language="text">https://example.com/some-url</pre>`,
+        roomId,
+        eventId,
+      ),
+      isStreaming: false,
+      isLastAssistantMessage: true,
+    });
+
+    assert.dom('.code-block').exists();
+    assert.dom('.code-block-diff').doesNotExist();
+    await waitUntil(() => document.querySelectorAll('.view-line').length == 1);
+
+    assert.equal(
+      (document.getElementsByClassName('view-lines')[0] as HTMLElement)
+        .innerText,
+      'https://example.com/some-url',
+    );
+  });
+
   test('it will render an error message when file url is missing', async function (assert) {
     await renderFormattedAiBotMessage({
       htmlParts: parseHtmlContent(


### PR DESCRIPTION
Before:

<img width="317" height="403" alt="image" src="https://github.com/user-attachments/assets/17a23a95-2886-43fa-a744-348409d8bcb0" />


After:

<img width="309" height="309" alt="image" src="https://github.com/user-attachments/assets/f7e2376b-c0fe-4354-9696-5deb10860f07" />
