### PR TITLE
Fix: Schema editor not refreshing after applying a code patch

### DIFF
--- a/packages/host/app/commands/patch-code.ts
+++ b/packages/host/app/commands/patch-code.ts
@@ -1,5 +1,7 @@
 import { inject as service } from '@ember/service';
 
+import { hasExecutableExtension } from '@cardstack/runtime-common';
+
 import type * as BaseCommandModule from 'https://cardstack.com/base/command';
 
 import HostBaseCommand from '../lib/host-base-command';
@@ -62,6 +64,7 @@ export default class PatchCodeCommand extends HostBaseCommand<
         new URL(finalFileUrl),
         patchedCode,
         'bot-patch',
+        { resetLoader: hasExecutableExtension(finalFileUrl) },
       );
     }
 

--- a/packages/host/app/components/ai-assistant/attached-file-dropdown-menu.gts
+++ b/packages/host/app/components/ai-assistant/attached-file-dropdown-menu.gts
@@ -22,6 +22,8 @@ import { MenuItem } from '@cardstack/boxel-ui/helpers';
 
 import { ThreeDotsHorizontal, IconCode } from '@cardstack/boxel-ui/icons';
 
+import { hasExecutableExtension } from '@cardstack/runtime-common';
+
 import RestorePatchedFileModal from '@cardstack/host/components/ai-assistant/restore-file-modal';
 import CardService from '@cardstack/host/services/card-service';
 import MatrixService from '@cardstack/host/services/matrix-service';
@@ -111,6 +113,7 @@ export default class AttachedFileDropdownMenu extends Component<{
       new URL(this.args.file.sourceUrl!),
       content,
       'bot-patch',
+      { resetLoader: hasExecutableExtension(this.args.file.sourceUrl!) },
     );
 
     this.isRestorePatchedFileModalOpen = false;

--- a/packages/host/app/resources/file.ts
+++ b/packages/host/app/resources/file.ts
@@ -278,6 +278,7 @@ class _FileResource extends Resource<Args> {
         new URL(this._url),
         content,
         opts?.saveType ?? 'editor',
+        { resetLoader: opts?.flushLoader },
       );
       if (this.innerState.state === 'not-found') {
         // TODO think about the "unauthorized" scenario
@@ -297,10 +298,6 @@ class _FileResource extends Resource<Args> {
         write: state.write,
         realmURL: state.realmURL,
       });
-
-      if (opts?.flushLoader) {
-        this.loaderService.resetLoader();
-      }
     },
   );
 

--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -48,6 +48,10 @@ export type SaveType =
   | 'copy'
   | 'instance';
 
+export interface SaveSourceOptions {
+  resetLoader?: boolean;
+}
+
 export default class CardService extends Service {
   @service declare private loaderService: LoaderService;
   @service declare private messageService: MessageService;
@@ -177,7 +181,12 @@ export default class CardService extends Service {
     };
   }
 
-  async saveSource(url: URL, content: string, type: SaveType) {
+  async saveSource(
+    url: URL,
+    content: string,
+    type: SaveType,
+    options?: SaveSourceOptions,
+  ) {
     try {
       let clientRequestId = `${type}:${uuidv4()}`;
       this.clientRequestIds.add(clientRequestId);
@@ -199,6 +208,11 @@ export default class CardService extends Service {
         throw new Error(errorMessage);
       }
       this.subscriber?.(url, content);
+
+      if (options?.resetLoader) {
+        this.loaderService.resetLoader();
+      }
+
       return response;
     } catch (e: any) {
       let error = formattedError(undefined, e)?.errors?.[0];


### PR DESCRIPTION
This PR fixes an issue where applying a code patch does not refresh the schema editor because the refresh mechanism relies on whether the loader is reset. The same issue also exists in restore content.