### PR TITLE
GCCardStore should use authed fetch

### DIFF
--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -105,7 +105,7 @@ export default class StoreService extends Service implements StoreInterface {
 
   constructor(owner: Owner) {
     super(owner);
-    this.store = new CardStore(this.referenceCount, this.network.fetch);
+    this.store = new CardStore(this.referenceCount, this.network.authedFetch);
     this.reset.register(this);
     this.ready = this.setup();
     registerDestructor(this, () => {
@@ -136,7 +136,7 @@ export default class StoreService extends Service implements StoreInterface {
     this.inflightCardMutations = new Map();
     this.autoSaveQueues = new Map();
     this.autoSavePromises = new Map();
-    this.store = new CardStore(this.referenceCount, this.network.fetch);
+    this.store = new CardStore(this.referenceCount, this.network.authedFetch);
     this.ready = this.setup();
   }
 

--- a/packages/host/testem.js
+++ b/packages/host/testem.js
@@ -11,7 +11,7 @@ const config = {
   launch_in_ci: ['Chrome'],
   launch_in_dev: ['Chrome'],
   browser_start_timeout: 240,
-  timeout: 120,
+  timeout: 300,
   browser_args: {
     Chrome: {
       ci: [

--- a/packages/host/testem.js
+++ b/packages/host/testem.js
@@ -10,10 +10,7 @@ const config = {
   disable_watching: true,
   launch_in_ci: ['Chrome'],
   launch_in_dev: ['Chrome'],
-
-  // Give Chrome time to boot/connect (values are generous by design)
-  browser_start_timeout: 120,
-
+  browser_start_timeout: 240,
   browser_args: {
     Chrome: {
       ci: [

--- a/packages/host/testem.js
+++ b/packages/host/testem.js
@@ -10,8 +10,6 @@ const config = {
   disable_watching: true,
   launch_in_ci: ['Chrome'],
   launch_in_dev: ['Chrome'],
-  browser_start_timeout: 240,
-  timeout: 300,
   browser_args: {
     Chrome: {
       ci: [

--- a/packages/host/testem.js
+++ b/packages/host/testem.js
@@ -11,6 +11,7 @@ const config = {
   launch_in_ci: ['Chrome'],
   launch_in_dev: ['Chrome'],
   browser_start_timeout: 240,
+  timeout: 120,
   browser_args: {
     Chrome: {
       ci: [

--- a/packages/host/testem.js
+++ b/packages/host/testem.js
@@ -10,7 +10,7 @@ const config = {
   disable_watching: true,
   launch_in_ci: ['Chrome'],
   launch_in_dev: ['Chrome'],
-  browser_start_timeout: 240,
+  browser_start_timeout: 72,
   browser_args: {
     Chrome: {
       ci: [

--- a/packages/host/testem.js
+++ b/packages/host/testem.js
@@ -10,7 +10,7 @@ const config = {
   disable_watching: true,
   launch_in_ci: ['Chrome'],
   launch_in_dev: ['Chrome'],
-  browser_start_timeout: 72,
+  browser_start_timeout: 720,
   browser_args: {
     Chrome: {
       ci: [

--- a/packages/host/testem.js
+++ b/packages/host/testem.js
@@ -10,7 +10,12 @@ const config = {
   disable_watching: true,
   launch_in_ci: ['Chrome'],
   launch_in_dev: ['Chrome'],
-  browser_start_timeout: 720,
+
+  // Give Chrome time to boot/connect (values are generous by design)
+  browser_start_timeout: 120000, // 120s
+  browser_disconnect_timeout: 120000, // 120s
+  timeout: 120, // Testem test timeout (seconds)
+
   browser_args: {
     Chrome: {
       ci: [

--- a/packages/host/testem.js
+++ b/packages/host/testem.js
@@ -16,6 +16,7 @@ const config = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
+        '--disable-dbus',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',

--- a/packages/host/testem.js
+++ b/packages/host/testem.js
@@ -14,7 +14,6 @@ const config = {
   // Give Chrome time to boot/connect (values are generous by design)
   browser_start_timeout: 120000, // 120s
   browser_disconnect_timeout: 120000, // 120s
-  timeout: 120, // Testem test timeout (seconds)
 
   browser_args: {
     Chrome: {

--- a/packages/host/testem.js
+++ b/packages/host/testem.js
@@ -12,8 +12,7 @@ const config = {
   launch_in_dev: ['Chrome'],
 
   // Give Chrome time to boot/connect (values are generous by design)
-  browser_start_timeout: 120000, // 120s
-  browser_disconnect_timeout: 120000, // 120s
+  browser_start_timeout: 120,
 
   browser_args: {
     Chrome: {


### PR DESCRIPTION
This came about when I noticed that spec in the RHS panel was missing inspite of having search return network request for specs

<img width="610" height="250" alt="Screenshot 2025-08-25 at 18 40 18" src="https://github.com/user-attachments/assets/1ed9eb81-a785-43c3-817b-b4251c473fd3" />

Callstack will hit `loadCardDocument` which is from the GCCardStore (when loadMissingField)

<img width="490" height="326" alt="Screenshot 2025-08-25 at 19 49 14" src="https://github.com/user-attachments/assets/ad9eb0f8-b8d5-4c84-8a05-ded168f0eb3c" />



I saw this as part of the `getCard` resource which uses the store to fetch. Particularly, in the spec panel where the spec was not loading

 But the fetch instantiated is not the authedFetch from the network service and I get authorization errors when loading missing fields from card-api
 
 The most recent PR to touch this https://github.com/cardstack/boxel/pull/3118