### PR TITLE
Update icon button component for theming

### DIFF
--- a/packages/base/contains-many-component.gts
+++ b/packages/base/contains-many-component.gts
@@ -86,7 +86,6 @@ class ContainsManyEditor extends GlimmerComponent<ContainsManyEditorSignature> {
                 {{#if permissions.canWrite}}
                   <IconButton
                     {{sortableHandle}}
-                    @variant='primary'
                     @icon={{FourLines}}
                     @width='18px'
                     @height='18px'

--- a/packages/base/links-to-editor.gts
+++ b/packages/base/links-to-editor.gts
@@ -76,7 +76,6 @@ export class LinksToEditor extends GlimmerComponent<Signature> {
           </DefaultFormatsProvider>
           {{#if permissions.canWrite}}
             <IconButton
-              @variant='primary'
               @icon={{IconMinusCircle}}
               @width='20px'
               @height='20px'

--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -191,7 +191,6 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
               {{#if permissions.canWrite}}
                 <IconButton
                   {{sortableHandle}}
-                  @variant='primary'
                   @icon={{FourLines}}
                   @width='18px'
                   @height='18px'
@@ -201,7 +200,6 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
                   data-test-sort={{i}}
                 />
                 <IconButton
-                  @variant='primary'
                   @icon={{IconMinusCircle}}
                   @width='20px'
                   @height='20px'
@@ -325,7 +323,6 @@ class LinksToManyCompactEditor extends GlimmerComponent<LinksToManyCompactEditor
           <Pill class='item-pill' data-test-pill-item={{i}}>
             <Item @format='atom' @displayContainer={{false}} />
             <IconButton
-              @variant='primary'
               @icon={{IconX}}
               @width='10px'
               @height='10px'

--- a/packages/boxel-ui/addon/src/components/button/index.gts
+++ b/packages/boxel-ui/addon/src/components/button/index.gts
@@ -219,14 +219,14 @@ const ButtonComponent: TemplateOnlyComponent<Signature> = <template>
       *
       */
       .kind-default {
-        --boxel-button-color: var(--background, transparent);
+        --boxel-button-color: var(--background, var(--boxel-light));
         --boxel-button-text-color: var(--foreground, var(--boxel-dark));
         --boxel-button-border: 1px solid var(--border, var(--boxel-400));
       }
       .kind-default:not(:disabled):hover,
       .kind-default:not(:disabled):active {
-        --boxel-button-color: var(--accent);
-        --boxel-button-text-color: var(--accent-foreground);
+        --boxel-button-color: var(--accent, var(--boxel-light));
+        --boxel-button-text-color: var(--accent-foreground, var(--boxel-dark));
         --boxel-button-border: 1px solid var(--border, var(--boxel-dark));
       }
 

--- a/packages/boxel-ui/addon/src/components/icon-button/index.gts
+++ b/packages/boxel-ui/addon/src/components/icon-button/index.gts
@@ -1,10 +1,9 @@
-import { on } from '@ember/modifier';
-import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
 import cn from '../../helpers/cn.ts';
+import LoadingIcon from '../../icons/loading-indicator.gts';
 import type { Icon } from '../../icons/types.ts';
-import LoadingIndicator from '../loading-indicator/index.gts';
+import BoxelButton, { type BoxelButtonKind } from '../button/index.gts';
 
 export interface Signature {
   Args: {
@@ -12,91 +11,74 @@ export interface Signature {
     height?: string;
     icon?: Icon;
     loading?: boolean;
-    variant?: string;
+    round?: boolean;
+    variant?: BoxelButtonKind;
     width?: string;
   };
   Blocks: {
     default: [];
   };
-  Element: HTMLButtonElement;
+  Element: HTMLButtonElement | HTMLAnchorElement;
 }
 
-class IconButton extends Component<Signature> {
-  @tracked isHoverOnButton = false;
+const IconButton: TemplateOnlyComponent<Signature> = <template>
+  <BoxelButton
+    class={{cn 'boxel-icon-button' is-round=@round loading=@loading}}
+    @class={{@class}}
+    @kind={{@variant}}
+    @size='auto'
+    ...attributes
+  >
+    {{#if @loading}}
+      <LoadingIcon
+        class='loading-icon'
+        width={{if @width @width '16px'}}
+        height={{if @height @height '16px'}}
+      />
+    {{else if @icon}}
+      <@icon
+        width={{if @width @width '16px'}}
+        height={{if @height @height '16px'}}
+        class='svg-icon'
+      />
+    {{/if}}
+  </BoxelButton>
+  <style scoped>
+    .boxel-icon-button {
+      --icon-color: var(--boxel-icon-button-icon-color, currentColor);
+      width: var(--boxel-icon-button-width, var(--boxel-icon-lg));
+      height: var(--boxel-icon-button-height, var(--boxel-icon-lg));
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: var(
+        --boxel-icon-button-background,
+        var(--boxel-button-color)
+      );
+      color: var(--boxel-icon-button-color, var(--boxel-button-text-color));
+      z-index: 0;
+      overflow: hidden;
+      transition: var(
+        --boxel-icon-button-transition,
+        var(--boxel-transition-properties)
+      );
+    }
+    .is-round {
+      border-radius: 50%;
+    }
 
-  onMouseEnterButton = (_e: MouseEvent) => {
-    this.isHoverOnButton = true;
-  };
+    @media (prefers-reduced-motion: no-preference) {
+      .loading-icon {
+        animation: spin 6000ms linear infinite;
+      }
+    }
 
-  onMouseLeaveButton = (_e: MouseEvent) => {
-    this.isHoverOnButton = false;
-  };
-
-  <template>
-    <button
-      class={{cn (if @variant @variant) @class loading=@loading}}
-      {{on 'mouseenter' this.onMouseEnterButton}}
-      {{on 'mouseleave' this.onMouseLeaveButton}}
-      ...attributes
-    >
-      {{#if @loading}}
-        <LoadingIndicator
-          width={{if @width @width '16px'}}
-          height={{if @height @height '16px'}}
-        />
-      {{else if @icon}}
-        <@icon
-          width={{if @width @width '16px'}}
-          height={{if @height @height '16px'}}
-          class='svg-icon'
-        />
-      {{/if}}
-    </button>
-    <style scoped>
-      button {
-        --inner-boxel-icon-button-width: var(--boxel-icon-button-width, 40px);
-        --inner-boxel-icon-button-height: var(--boxel-icon-button-height, 40px);
-        width: var(--inner-boxel-icon-button-width);
-        height: var(--inner-boxel-icon-button-height);
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        padding: 0;
-        background: var(--boxel-icon-button-background, none);
-        border: 1px solid transparent;
-        color: var(--boxel-icon-button-color, currentColor);
-        z-index: 0;
-        overflow: hidden;
-        transition: var(
-          --boxel-icon-button-transition,
-          var(--boxel-transition-properties)
-        );
+    @keyframes spin {
+      to {
+        transform: rotate(360deg);
       }
-      .loading,
-      :disabled {
-        pointer-events: none;
-      }
-      button:not(:disabled):hover {
-        cursor: pointer;
-      }
-
-      .primary {
-        --icon-bg: var(--boxel-highlight);
-        --icon-border: var(--boxel-highlight);
-      }
-
-      .secondary {
-        --icon-color: var(--boxel-highlight);
-        border: 1px solid rgb(255 255 255 / 35%);
-        border-radius: 100px;
-        background-color: var(--boxel-icon-button-background, #41404d);
-      }
-
-      .secondary:hover {
-        background-color: var(--boxel-purple-800);
-      }
-    </style>
-  </template>
-}
+    }
+  </style>
+</template>;
 
 export default IconButton;

--- a/packages/boxel-ui/addon/src/components/icon-button/index.gts
+++ b/packages/boxel-ui/addon/src/components/icon-button/index.gts
@@ -56,41 +56,40 @@ const IconButton: TemplateOnlyComponent<Signature> = <template>
         align-items: center;
         justify-content: center;
         padding: var(--boxel-icon-button-padding, 0);
-        background: var(
+        background-color: var(
           --boxel-icon-button-background,
           var(--boxel-button-color)
         );
         color: var(--boxel-icon-button-color, var(--boxel-button-text-color));
         z-index: 0;
         overflow: hidden;
-        transition: var(
-          --boxel-icon-button-transition,
-          var(--boxel-transition-properties)
-        );
       }
       .is-round {
         border-radius: 50%;
       }
 
       .kind-default {
-        --boxel-button-color: transparent;
-        --boxel-button-text-color: var(--foreground, var(--boxel-dark));
-        --boxel-button-border: var(
-          --boxel-icon-button-background,
-          var(--boxel-button-color)
+        background: var(--boxel-icon-button-background, none);
+        color: var(
+          --boxel-icon-button-color,
+          var(--foreground, var(--boxel-dark))
         );
-      }
-      .kind-default:not(:disabled):hover,
-      .kind-default:not(:disabled):active {
-        --boxel-button-color: transparent;
-        color: color-mix(
-          in oklab,
-          var(--boxel-icon-button-color, var(--boxel-button-text-color)) 90%,
-          transparent
-        );
+        border: none;
       }
       .kind-default:disabled {
-        --boxel-button-text-color: var(--muted-foreground, var(--boxel-450));
+        color: var(--muted, var(--boxel-400));
+      }
+
+      .kind-primary-dark:not(:disabled) {
+        --boxel-button-color: var(--primary-foreground, var(--boxel-dark));
+        --boxel-button-text-color: var(--primary, var(--boxel-highlight));
+      }
+      .kind-primary-dark:not(:disabled):hover {
+        --boxel-button-color: color-mix(
+          in oklab,
+          var(--primary-foreground, var(--boxel-dark)) 85%,
+          transparent
+        );
       }
 
       @media (prefers-reduced-motion: no-preference) {

--- a/packages/boxel-ui/addon/src/components/icon-button/index.gts
+++ b/packages/boxel-ui/addon/src/components/icon-button/index.gts
@@ -44,6 +44,7 @@ const IconButton: TemplateOnlyComponent<Signature> = <template>
         class='svg-icon'
       />
     {{/if}}
+    {{yield}}
   </BoxelButton>
   <style scoped>
     @layer {

--- a/packages/boxel-ui/addon/src/components/icon-button/index.gts
+++ b/packages/boxel-ui/addon/src/components/icon-button/index.gts
@@ -8,6 +8,7 @@ import BoxelButton, { type BoxelButtonKind } from '../button/index.gts';
 export interface Signature {
   Args: {
     class?: string;
+    disabled?: boolean;
     height?: string;
     icon?: Icon;
     loading?: boolean;
@@ -27,6 +28,7 @@ const IconButton: TemplateOnlyComponent<Signature> = <template>
     @class={{@class}}
     @kind={{@variant}}
     @size='auto'
+    @disabled={{@disabled}}
     ...attributes
   >
     {{#if @loading}}
@@ -44,38 +46,62 @@ const IconButton: TemplateOnlyComponent<Signature> = <template>
     {{/if}}
   </BoxelButton>
   <style scoped>
-    .boxel-icon-button {
-      --icon-color: var(--boxel-icon-button-icon-color, currentColor);
-      width: var(--boxel-icon-button-width, var(--boxel-icon-lg));
-      height: var(--boxel-icon-button-height, var(--boxel-icon-lg));
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      background: var(
-        --boxel-icon-button-background,
-        var(--boxel-button-color)
-      );
-      color: var(--boxel-icon-button-color, var(--boxel-button-text-color));
-      z-index: 0;
-      overflow: hidden;
-      transition: var(
-        --boxel-icon-button-transition,
-        var(--boxel-transition-properties)
-      );
-    }
-    .is-round {
-      border-radius: 50%;
-    }
-
-    @media (prefers-reduced-motion: no-preference) {
-      .loading-icon {
-        animation: spin 6000ms linear infinite;
+    @layer {
+      .boxel-icon-button {
+        --icon-color: var(--boxel-icon-button-icon-color, currentColor);
+        width: var(--boxel-icon-button-width, var(--boxel-icon-lg));
+        height: var(--boxel-icon-button-height, var(--boxel-icon-lg));
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: var(--boxel-icon-button-padding, 0);
+        background: var(
+          --boxel-icon-button-background,
+          var(--boxel-button-color)
+        );
+        color: var(--boxel-icon-button-color, var(--boxel-button-text-color));
+        z-index: 0;
+        overflow: hidden;
+        transition: var(
+          --boxel-icon-button-transition,
+          var(--boxel-transition-properties)
+        );
       }
-    }
+      .is-round {
+        border-radius: 50%;
+      }
 
-    @keyframes spin {
-      to {
-        transform: rotate(360deg);
+      .kind-default {
+        --boxel-button-color: transparent;
+        --boxel-button-text-color: var(--foreground, var(--boxel-dark));
+        --boxel-button-border: var(
+          --boxel-icon-button-background,
+          var(--boxel-button-color)
+        );
+      }
+      .kind-default:not(:disabled):hover,
+      .kind-default:not(:disabled):active {
+        --boxel-button-color: transparent;
+        color: color-mix(
+          in oklab,
+          var(--boxel-icon-button-color, var(--boxel-button-text-color)) 90%,
+          transparent
+        );
+      }
+      .kind-default:disabled {
+        --boxel-button-text-color: var(--muted-foreground, var(--boxel-450));
+      }
+
+      @media (prefers-reduced-motion: no-preference) {
+        .loading-icon {
+          animation: spin 6000ms linear infinite;
+        }
+      }
+
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
       }
     }
   </style>

--- a/packages/boxel-ui/addon/src/components/icon-button/index.gts
+++ b/packages/boxel-ui/addon/src/components/icon-button/index.gts
@@ -60,6 +60,7 @@ const IconButton: TemplateOnlyComponent<Signature> = <template>
           --boxel-icon-button-background,
           var(--boxel-button-color)
         );
+        border-radius: var(--boxel-border-radius);
         color: var(--boxel-icon-button-color, var(--boxel-button-text-color));
         z-index: 0;
         overflow: hidden;
@@ -70,10 +71,7 @@ const IconButton: TemplateOnlyComponent<Signature> = <template>
 
       .kind-default {
         background: var(--boxel-icon-button-background, none);
-        color: var(
-          --boxel-icon-button-color,
-          var(--foreground, var(--boxel-dark))
-        );
+        color: var(--boxel-icon-button-color, inherit);
         border: none;
       }
       .kind-default:disabled {
@@ -81,13 +79,13 @@ const IconButton: TemplateOnlyComponent<Signature> = <template>
       }
 
       .kind-primary-dark:not(:disabled) {
-        --boxel-button-color: var(--primary-foreground, var(--boxel-dark));
+        --boxel-button-color: var(--primary-foreground, var(--boxel-700));
         --boxel-button-text-color: var(--primary, var(--boxel-highlight));
       }
       .kind-primary-dark:not(:disabled):hover {
         --boxel-button-color: color-mix(
           in oklab,
-          var(--primary-foreground, var(--boxel-dark)) 85%,
+          var(--primary-foreground, var(--boxel-700)) 85%,
           transparent
         );
       }

--- a/packages/boxel-ui/addon/src/components/icon-button/usage.gts
+++ b/packages/boxel-ui/addon/src/components/icon-button/usage.gts
@@ -4,12 +4,8 @@ import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
-import {
-  type CSSVariableInfo,
-  cssVariable,
-} from 'ember-freestyle/decorators/css-variable';
 
-import { cn, cssVar, eq } from '../../helpers.ts';
+import { cn, eq } from '../../helpers.ts';
 import { ALL_ICON_COMPONENTS } from '../../icons.gts';
 import IconPlus from '../../icons/icon-plus.gts';
 import type { Icon } from '../../icons/types.ts';
@@ -23,15 +19,11 @@ export default class IconButtonUsage extends Component {
   @tracked private width?: string;
   @tracked private height?: string;
   @tracked private isLoading = false;
+  @tracked private isDisabled = false;
   @tracked private isRound = false;
 
   @tracked private showIconBorders = false;
   @tracked private hideIconOverflow = false;
-
-  cssClassName = 'boxel-icon-button';
-  @cssVariable declare boxelIconButtonWidth: CSSVariableInfo;
-  @cssVariable declare boxelIconButtonHeight: CSSVariableInfo;
-  @cssVariable declare boxelIconButtonBackground: CSSVariableInfo;
 
   @action log(message: string): void {
     console.log(message);
@@ -61,13 +53,9 @@ export default class IconButtonUsage extends Component {
             @width={{this.width}}
             @height={{this.height}}
             @round={{this.isRound}}
+            @disabled={{this.isDisabled}}
             aria-label='Special Button'
             {{on 'click' (fn this.log 'Button clicked')}}
-            style={{cssVar
-              boxel-icon-button-width=this.boxelIconButtonWidth.value
-              boxel-icon-button-height=this.boxelIconButtonHeight.value
-              boxel-icon-button-background=this.boxelIconButtonBackground.value
-            }}
           />
         </div>
       </:example>
@@ -102,6 +90,13 @@ export default class IconButtonUsage extends Component {
           @onInput={{fn (mut this.isRound)}}
           @defaultValue='false'
         />
+        <Args.Bool
+          @name='disabled'
+          @optional={{true}}
+          @value={{this.isDisabled}}
+          @onInput={{fn (mut this.isDisabled)}}
+          @defaultValue='false'
+        />
         <Args.String
           @name='width'
           @optional={{true}}
@@ -130,6 +125,11 @@ export default class IconButtonUsage extends Component {
           @type='height'
           @description='height of the button'
           @defaultValue='40px'
+        />
+        <Css.Basic
+          @name='--boxel-icon-button-padding'
+          @type='padding'
+          @defaultValue='0'
         />
         <Css.Basic
           @name='--boxel-icon-button-background'
@@ -187,13 +187,10 @@ export default class IconButtonUsage extends Component {
                 @width={{this.width}}
                 @height={{this.height}}
                 @round={{this.isRound}}
+                @disabled={{this.isDisabled}}
                 aria-label='Special Button'
                 {{on 'click' (fn this.log 'Button clicked')}}
                 class='icon'
-                style={{cssVar
-                  boxel-icon-button-width=this.boxelIconButtonWidth.value
-                  boxel-icon-button-height=this.boxelIconButtonHeight.value
-                }}
               />
               <span class='label'>{{icon.name}}</span>
             </div>

--- a/packages/boxel-ui/addon/src/components/icon-button/usage.gts
+++ b/packages/boxel-ui/addon/src/components/icon-button/usage.gts
@@ -38,14 +38,9 @@ export default class IconButtonUsage extends Component {
   }
 
   <template>
-    <FreestyleUsage @name='IconButton'>
-      <:example>
-        <div
-          class={{cn
-            'usage-icon-button-background'
-            usage-button-dark-mode-background=(eq this.variant 'secondary-dark')
-          }}
-        >
+    <div class={{cn dark-background=(eq this.variant 'secondary-dark')}}>
+      <FreestyleUsage @name='IconButton'>
+        <:example>
           <BoxelIconButton
             @icon={{this.icon}}
             @loading={{this.isLoading}}
@@ -57,147 +52,149 @@ export default class IconButtonUsage extends Component {
             aria-label='Special Button'
             {{on 'click' (fn this.log 'Button clicked')}}
           />
-        </div>
-      </:example>
+        </:example>
 
-      <:api as |Args|>
-        <Args.Component
-          @name='icon'
-          @description='Icon component reference'
-          @value={{this.icon}}
-          @options={{ALL_ICON_COMPONENTS}}
-          @onChange={{fn (mut this.icon)}}
-        />
-        <Args.String
-          @name='variant'
-          @optional={{true}}
-          @value={{this.variant}}
-          @options={{this.variants}}
-          @onInput={{fn (mut this.variant)}}
-          @defaultValue='default'
-        />
-        <Args.Bool
-          @name='loading'
-          @optional={{true}}
-          @value={{this.isLoading}}
-          @onInput={{fn (mut this.isLoading)}}
-          @defaultValue='false'
-        />
-        <Args.Bool
-          @name='round'
-          @optional={{true}}
-          @value={{this.isRound}}
-          @onInput={{fn (mut this.isRound)}}
-          @defaultValue='false'
-        />
-        <Args.Bool
-          @name='disabled'
-          @optional={{true}}
-          @value={{this.isDisabled}}
-          @onInput={{fn (mut this.isDisabled)}}
-          @defaultValue='false'
-        />
-        <Args.String
-          @name='width'
-          @optional={{true}}
-          @description='svg icon width'
-          @defaultValue='16px'
-          @value={{this.width}}
-          @onInput={{fn (mut this.width)}}
-        />
-        <Args.String
-          @name='height'
-          @description='svg icon height'
-          @defaultValue='16px'
-          @value={{this.height}}
-          @onInput={{fn (mut this.height)}}
-        />
-      </:api>
-      <:cssVars as |Css|>
-        <Css.Basic
-          @name='--boxel-icon-button-width'
-          @type='width'
-          @description='width of the button'
-          @defaultValue='40px'
-        />
-        <Css.Basic
-          @name='--boxel-icon-button-height'
-          @type='height'
-          @description='height of the button'
-          @defaultValue='40px'
-        />
-        <Css.Basic
-          @name='--boxel-icon-button-padding'
-          @type='padding'
-          @defaultValue='0'
-        />
-        <Css.Basic
-          @name='--boxel-icon-button-background'
-          @type='background-color'
-          @defaultValue='#fff'
-        />
-        <Css.Basic
-          @name='--boxel-icon-button-color'
-          @type='color'
-          @description='font color'
-          @defaultValue='#000'
-        />
-        <Css.Basic
-          @name='--boxel-icon-button-icon-color'
-          @type='color'
-          @description='icon color'
-          @defaultValue='currentColor'
-        />
-        <Css.Basic
-          @name='--boxel-icon-button-transition'
-          @type='transition'
-          @description='css shorthand "transition" property'
-        />
-      </:cssVars>
-    </FreestyleUsage>
+        <:api as |Args|>
+          <Args.Component
+            @name='icon'
+            @description='Icon component reference'
+            @value={{this.icon}}
+            @options={{ALL_ICON_COMPONENTS}}
+            @onChange={{fn (mut this.icon)}}
+          />
+          <Args.String
+            @name='variant'
+            @optional={{true}}
+            @value={{this.variant}}
+            @options={{this.variants}}
+            @onInput={{fn (mut this.variant)}}
+            @defaultValue='default'
+          />
+          <Args.Bool
+            @name='loading'
+            @optional={{true}}
+            @value={{this.isLoading}}
+            @onInput={{fn (mut this.isLoading)}}
+            @defaultValue='false'
+          />
+          <Args.Bool
+            @name='round'
+            @optional={{true}}
+            @value={{this.isRound}}
+            @onInput={{fn (mut this.isRound)}}
+            @defaultValue='false'
+          />
+          <Args.Bool
+            @name='disabled'
+            @optional={{true}}
+            @value={{this.isDisabled}}
+            @onInput={{fn (mut this.isDisabled)}}
+            @defaultValue='false'
+          />
+          <Args.String
+            @name='width'
+            @optional={{true}}
+            @description='icon size'
+            @defaultValue='16px'
+            @value={{this.width}}
+            @onInput={{fn (mut this.width)}}
+          />
+          <Args.String
+            @name='height'
+            @description='icon size'
+            @defaultValue='16px'
+            @value={{this.height}}
+            @onInput={{fn (mut this.height)}}
+          />
+          <Args.Yield @description='Yield for button content' />
+        </:api>
+        <:cssVars as |Css|>
+          <Css.Basic
+            @name='--boxel-icon-button-width'
+            @type='width'
+            @description='width of the button'
+            @defaultValue='40px'
+          />
+          <Css.Basic
+            @name='--boxel-icon-button-height'
+            @type='height'
+            @description='height of the button'
+            @defaultValue='40px'
+          />
+          <Css.Basic
+            @name='--boxel-icon-button-padding'
+            @type='padding'
+            @defaultValue='0'
+          />
+          <Css.Basic
+            @name='--boxel-icon-button-background'
+            @type='background'
+            @description='css shorthand "background" property'
+            @defaultValue='#fff'
+          />
+          <Css.Basic
+            @name='--boxel-icon-button-color'
+            @type='color'
+            @description='font color'
+            @defaultValue='#000'
+          />
+          <Css.Basic
+            @name='--boxel-icon-button-icon-color'
+            @type='color'
+            @description='icon color'
+            @defaultValue='currentColor'
+          />
+          <Css.Basic
+            @name='--boxel-icon-button-transition'
+            @type='transition'
+            @description='css shorthand "transition" property'
+          />
+        </:cssVars>
+      </FreestyleUsage>
 
-    <FreestyleUsage @name='All Icons'>
-      <:example>
-        <label class='checkbox-label'>
-          <input
-            type='checkbox'
-            checked={{this.showIconBorders}}
-            {{on 'change' this.toggleShowIconBorders}}
-          />
-          Show icon bounds
-        </label>
-        <label class='checkbox-label'>
-          <input
-            type='checkbox'
-            checked={{this.hideIconOverflow}}
-            {{on 'change' this.toggleHideIconOverflow}}
-          />
-          Hide icon overflow
-        </label>
-        <section class='all-icons'>
-          {{#each ALL_ICON_COMPONENTS as |icon|}}
-            <div
-              class='icon-and-label
-                {{if this.showIconBorders "show-borders"}}
-                {{if this.hideIconOverflow "hide-icon-overflow"}}'
-            >
-              <BoxelIconButton
-                @icon={{icon}}
-                @variant={{this.variant}}
-                @width={{this.width}}
-                @height={{this.height}}
-                @round={{this.isRound}}
-                @disabled={{this.isDisabled}}
-                aria-label='Special Button'
-                {{on 'click' (fn this.log 'Button clicked')}}
-                class='icon'
-              />
-              <span class='label'>{{icon.name}}</span>
-            </div>
-          {{/each}}
-        </section>
-      </:example>
-    </FreestyleUsage>
+      <FreestyleUsage @name='All Icons'>
+        <:example>
+          <label class='checkbox-label'>
+            <input
+              type='checkbox'
+              checked={{this.showIconBorders}}
+              {{on 'change' this.toggleShowIconBorders}}
+            />
+            Show icon bounds
+          </label>
+          <label class='checkbox-label'>
+            <input
+              type='checkbox'
+              checked={{this.hideIconOverflow}}
+              {{on 'change' this.toggleHideIconOverflow}}
+            />
+            Hide icon overflow
+          </label>
+          <section class='all-icons'>
+            {{#each ALL_ICON_COMPONENTS as |icon|}}
+              <div
+                class='icon-and-label
+                  {{if this.showIconBorders "show-borders"}}
+                  {{if this.hideIconOverflow "hide-icon-overflow"}}'
+              >
+                <BoxelIconButton
+                  @icon={{icon}}
+                  @variant={{this.variant}}
+                  @width={{this.width}}
+                  @height={{this.height}}
+                  @round={{this.isRound}}
+                  @disabled={{this.isDisabled}}
+                  aria-label='Special Button'
+                  {{on 'click' (fn this.log 'Button clicked')}}
+                  class='icon'
+                />
+                <span class='label'>{{icon.name}}</span>
+              </div>
+            {{/each}}
+          </section>
+        </:example>
+      </FreestyleUsage>
+    </div>
     <style scoped>
       .checkbox-label {
         display: flex;
@@ -229,10 +226,7 @@ export default class IconButtonUsage extends Component {
         height: calc(var(--boxel-icon-button-height) + 2px);
       }
 
-      .usage-icon-button-background {
-        padding: var(--boxel-sp-xs);
-      }
-      .usage-button-dark-mode-background {
+      .dark-background :deep(.FreestyleUsage-preview) {
         background-color: var(--foreground, var(--boxel-700));
         color: var(--background, var(--boxel-light));
       }

--- a/packages/boxel-ui/addon/src/components/icon-button/usage.gts
+++ b/packages/boxel-ui/addon/src/components/icon-button/usage.gts
@@ -128,9 +128,7 @@ export default class IconButtonUsage extends Component {
           />
           <Css.Basic
             @name='--boxel-icon-button-background'
-            @type='background'
-            @description='css shorthand "background" property'
-            @defaultValue='#fff'
+            @type='background-color'
           />
           <Css.Basic
             @name='--boxel-icon-button-color'
@@ -143,11 +141,6 @@ export default class IconButtonUsage extends Component {
             @type='color'
             @description='icon color'
             @defaultValue='currentColor'
-          />
-          <Css.Basic
-            @name='--boxel-icon-button-transition'
-            @type='transition'
-            @description='css shorthand "transition" property'
           />
         </:cssVars>
       </FreestyleUsage>

--- a/packages/boxel-ui/addon/src/components/input-group/accessories/index.gts
+++ b/packages/boxel-ui/addon/src/components/input-group/accessories/index.gts
@@ -53,7 +53,7 @@ interface IconButtonSignature {
   Blocks: {
     default: [];
   };
-  Element: HTMLButtonElement;
+  Element: HTMLButtonElement | HTMLAnchorElement;
 }
 
 export const IconButton: TemplateOnlyComponent<IconButtonSignature> = <template>

--- a/packages/host/app/components/ai-assistant/chat-input/index.gts
+++ b/packages/host/app/components/ai-assistant/chat-input/index.gts
@@ -57,6 +57,7 @@ export default class AiAssistantChatInput extends Component<Signature> {
         disabled={{not @canSend}}
         data-test-can-send-msg={{@canSend}}
         class='send-button'
+        @variant='primary'
         @icon={{ArrowUp}}
         @height='20'
         @width='25'
@@ -144,16 +145,10 @@ export default class AiAssistantChatInput extends Component<Signature> {
         border-color: transparent;
       }
       .send-button {
-        color: var(--boxel-dark);
         width: var(--boxel-icon-med);
         height: var(--boxel-icon-med);
-        background-color: var(--boxel-highlight);
         border-radius: var(--boxel-border-radius-sm);
         margin-top: 2px;
-      }
-      .send-button:hover:not(:disabled),
-      .send-button:focus:not(:disabled) {
-        background-color: var(--boxel-highlight-hover);
       }
       .send-button:disabled {
         color: var(--boxel-450);

--- a/packages/host/app/components/ai-assistant/new-session-button.gts
+++ b/packages/host/app/components/ai-assistant/new-session-button.gts
@@ -118,6 +118,7 @@ export default class NewSessionButton extends Component<Signature> {
         --boxel-button-min-height: 0;
         --boxel-loading-indicator-size: 16px;
 
+        border: none;
         border-radius: var(--boxel-border-radius-xs);
         transform: translateY(-1px);
       }

--- a/packages/host/app/components/ai-assistant/panel.gts
+++ b/packages/host/app/components/ai-assistant/panel.gts
@@ -301,6 +301,7 @@ export default class AiAssistantPanel extends Component<Signature> {
         --boxel-button-min-height: 0;
         --boxel-loading-indicator-size: 16px;
 
+        border: none;
         border-radius: var(--boxel-border-radius-xs);
         transform: translateY(-1px);
       }

--- a/packages/host/app/components/file-pill.gts
+++ b/packages/host/app/components/file-pill.gts
@@ -81,7 +81,11 @@ export default class FilePill extends Component<FilePillSignature> {
       ...attributes
     >
       <:iconLeft>
-        <FileCode style={{cssVar icon-color='#0031ff'}} />
+        <FileCode
+          width='18'
+          height='18'
+          style={{cssVar icon-color='#0031ff'}}
+        />
       </:iconLeft>
       <:default>
         <div class='file-content' title={{@file.name}}>

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview-badge.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview-badge.gts
@@ -49,6 +49,7 @@ const SpecPreviewBadge: TemplateOnlyComponent<SpecPreviewBadgeSignature> =
         --boxel-button-min-height: auto;
         --boxel-button-min-width: auto;
         padding: 4px;
+        border: none;
         border-radius: var(--boxel-border-radius-xs);
       }
 

--- a/packages/host/app/components/operator-mode/code-submode/toggle-button.gts
+++ b/packages/host/app/components/operator-mode/code-submode/toggle-button.gts
@@ -21,7 +21,7 @@ interface ToggleButtonSignature {
 const ToggleButton: TemplateOnlyComponent<ToggleButtonSignature> = <template>
   <Button
     @disabled={{@disabled}}
-    @kind={{if @isActive 'primary-dark' 'secondary'}}
+    @kind={{if @isActive 'primary-dark'}}
     @size='extra-small'
     class={{cn 'toggle-button' active=@isActive}}
     ...attributes
@@ -40,28 +40,17 @@ const ToggleButton: TemplateOnlyComponent<ToggleButtonSignature> = <template>
   </Button>
   <style scoped>
     .toggle-button {
-      --boxel-button-border: 1px solid var(--boxel-400);
       --boxel-button-font: 600 var(--boxel-font-xs);
       --boxel-button-letter-spacing: var(--boxel-lsp-xs);
       --boxel-button-min-width: 6rem;
       --boxel-button-padding: 0;
-      --boxel-button-color: var(--boxel-light);
-      border-radius: var(--boxel-border-radius);
+      border-radius: var(--boxel-border-radius-sm);
       flex: 1;
       justify-content: space-between;
       white-space: nowrap;
     }
 
-    .toggle-button:disabled {
-      --boxel-button-color: var(--boxel-button-border-color);
-    }
-
-    .toggle-button:hover:not(:disabled) {
-      border-color: var(--boxel-dark);
-    }
     .toggle-button.active {
-      border-color: var(--boxel-dark);
-      --boxel-button-color: var(--boxel-dark);
       --boxel-button-text-color: var(--boxel-highlight);
     }
 

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -615,6 +615,7 @@ export default class SubmodeLayout extends Component<Signature> {
       }
 
       .workspace-button {
+        --icon-color: var(--boxel-highlight);
         border: none;
         border-radius: var(--submode-bar-item-border-radius);
         box-shadow: var(--submode-bar-item-box-shadow);

--- a/packages/host/app/components/search-sheet/index.gts
+++ b/packages/host/app/components/search-sheet/index.gts
@@ -232,8 +232,10 @@ export default class SearchSheet extends Component<Signature> {
         <IconButton
           class='open-search-field'
           @icon={{IconSearch}}
-          @width='24'
+          @width='18'
           @height='24'
+          @round={{true}}
+          @variant='primary-dark'
           {{on 'click' @onFocus}}
           data-test-open-search-field
         />
@@ -405,13 +407,7 @@ export default class SearchSheet extends Component<Signature> {
       .prompt .search-sheet-content {
         overflow-x: auto;
       }
-      .open-search-field {
-        padding: var(--boxel-sp-xs);
-        border-radius: 50%;
-        background-color: var(--boxel-700);
 
-        --icon-color: var(--boxel-highlight);
-      }
       .open-search-field:focus:focus-visible {
         outline-offset: 0;
         outline-width: 2px;


### PR DESCRIPTION
- Use `Button` component and accept button `kind` arguments
- Update fallback styles for `default` variant to remain the same as before, while accepting theming variables

Preview: https://cs-9310-icon-button.boxel-ui-preview.stack.cards/?s=Components&ss=%3CIconButton%3E

API:
<img width="836" height="972" alt="icon-button" src="https://github.com/user-attachments/assets/26904911-0fc5-49aa-ae0d-851c053e4290" />

Themed example:
<img width="838" height="505" alt="themed" src="https://github.com/user-attachments/assets/4da25141-e5a8-4d6b-858e-73448c93dab1" />

