### PR TITLE
don't show focus pill for line number when no text is selected

### DIFF
--- a/packages/host/app/services/ai-assistant-panel-service.ts
+++ b/packages/host/app/services/ai-assistant-panel-service.ts
@@ -116,6 +116,16 @@ export default class AiAssistantPanelService extends Service {
     if (!selection) {
       return undefined;
     }
+
+    // Check if there's an actual selection (not just cursor position)
+    const hasSelection =
+      selection.startLineNumber !== selection.endLineNumber ||
+      selection.startColumn !== selection.endColumn;
+
+    if (!hasSelection) {
+      return undefined;
+    }
+
     if (selection.startLineNumber === selection.endLineNumber) {
       return `Line ${selection.startLineNumber}`;
     }

--- a/packages/host/app/services/ai-assistant-panel-service.ts
+++ b/packages/host/app/services/ai-assistant-panel-service.ts
@@ -614,3 +614,9 @@ export default class AiAssistantPanelService extends Service {
     }
   });
 }
+
+declare module '@ember/service' {
+  interface Registry {
+    'ai-assistant-panel-service': AiAssistantPanelService;
+  }
+}

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -1318,18 +1318,12 @@ module('Acceptance | AI Assistant tests', function (hooks) {
       .containsText('Plant', 'FocusPill shows selected code label');
     assert
       .dom('[data-test-focus-pill-meta]')
-      .exists({ count: 2 }, 'FocusPill shows two meta pills');
+      .exists({ count: 1 }, 'FocusPill shows one meta pill');
     {
       const metaEls = document.querySelectorAll('[data-test-focus-pill-meta]');
       assert
         .dom(metaEls[0] as Element)
         .hasText('Schema', 'FocusPill shows item type "Schema"');
-      assert
-        .dom(metaEls[1] as Element)
-        .hasText(
-          'Line 3',
-          'FocusPill shows single-line selection range "Line 3"',
-        );
     }
 
     await fillIn('[data-test-message-field]', `Message - 2`);

--- a/packages/host/tests/unit/services/ai-assistant-panel-service-test.ts
+++ b/packages/host/tests/unit/services/ai-assistant-panel-service-test.ts
@@ -1,0 +1,124 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import AiAssistantPanelService from '@cardstack/host/services/ai-assistant-panel-service';
+import type MonacoService from '@cardstack/host/services/monaco-service';
+
+module('Unit | Service | ai-assistant-panel-service', function (hooks) {
+  setupTest(hooks);
+
+  test('focusPillCodeRange returns undefined when there is no selection', function (assert) {
+    let service = this.owner.lookup(
+      'service:ai-assistant-panel-service',
+    ) as AiAssistantPanelService;
+
+    let monacoService = this.owner.lookup(
+      'service:monaco-service',
+    ) as MonacoService;
+
+    // Mock no selection
+    monacoService.trackedSelection = null;
+
+    assert.strictEqual(
+      service.focusPillCodeRange,
+      undefined,
+      'returns undefined when trackedSelection is null',
+    );
+  });
+
+  test('focusPillCodeRange returns undefined when there is only a cursor position (no actual selection)', function (assert) {
+    let service = this.owner.lookup(
+      'service:ai-assistant-panel-service',
+    ) as AiAssistantPanelService;
+
+    let monacoService = this.owner.lookup(
+      'service:monaco-service',
+    ) as MonacoService;
+
+    // Mock cursor position at line 5, column 10 (no text selected)
+    monacoService.trackedSelection = {
+      startLineNumber: 5,
+      startColumn: 10,
+      endLineNumber: 5,
+      endColumn: 10,
+    } as any;
+
+    assert.strictEqual(
+      service.focusPillCodeRange,
+      undefined,
+      'returns undefined when there is only a cursor position',
+    );
+  });
+
+  test('focusPillCodeRange returns "Line X" when selection is on a single line', function (assert) {
+    let service = this.owner.lookup(
+      'service:ai-assistant-panel-service',
+    ) as AiAssistantPanelService;
+
+    let monacoService = this.owner.lookup(
+      'service:monaco-service',
+    ) as MonacoService;
+
+    // Mock selection on line 3, columns 5-15
+    monacoService.trackedSelection = {
+      startLineNumber: 3,
+      startColumn: 5,
+      endLineNumber: 3,
+      endColumn: 15,
+    } as any;
+
+    assert.strictEqual(
+      service.focusPillCodeRange,
+      'Line 3',
+      'returns "Line X" when selection is on a single line',
+    );
+  });
+
+  test('focusPillCodeRange returns "Lines X-Y" when selection spans multiple lines', function (assert) {
+    let service = this.owner.lookup(
+      'service:ai-assistant-panel-service',
+    ) as AiAssistantPanelService;
+
+    let monacoService = this.owner.lookup(
+      'service:monaco-service',
+    ) as MonacoService;
+
+    // Mock selection from line 2 to line 5
+    monacoService.trackedSelection = {
+      startLineNumber: 2,
+      startColumn: 10,
+      endLineNumber: 5,
+      endColumn: 20,
+    } as any;
+
+    assert.strictEqual(
+      service.focusPillCodeRange,
+      'Lines 2-5',
+      'returns "Lines X-Y" when selection spans multiple lines',
+    );
+  });
+
+  test('focusPillCodeRange handles single character selection on same line', function (assert) {
+    let service = this.owner.lookup(
+      'service:ai-assistant-panel-service',
+    ) as AiAssistantPanelService;
+
+    let monacoService = this.owner.lookup(
+      'service:monaco-service',
+    ) as MonacoService;
+
+    // Mock single character selection on line 1 (column 5 to 6)
+    monacoService.trackedSelection = {
+      startLineNumber: 1,
+      startColumn: 5,
+      endLineNumber: 1,
+      endColumn: 6,
+    } as any;
+
+    assert.strictEqual(
+      service.focusPillCodeRange,
+      'Line 1',
+      'returns "Line 1" for single character selection',
+    );
+  });
+});

--- a/packages/host/tests/unit/services/ai-assistant-panel-service-test.ts
+++ b/packages/host/tests/unit/services/ai-assistant-panel-service-test.ts
@@ -1,21 +1,22 @@
+import { getService } from '@universal-ember/test-support';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 import AiAssistantPanelService from '@cardstack/host/services/ai-assistant-panel-service';
-import type MonacoService from '@cardstack/host/services/monaco-service';
+import MonacoService from '@cardstack/host/services/monaco-service';
 
 module('Unit | Service | ai-assistant-panel-service', function (hooks) {
   setupTest(hooks);
 
+  let service: AiAssistantPanelService;
+  let monacoService: MonacoService;
+
+  hooks.beforeEach(function () {
+    service = getService('ai-assistant-panel-service');
+    monacoService = getService('monaco-service');
+  });
+
   test('focusPillCodeRange returns undefined when there is no selection', function (assert) {
-    let service = this.owner.lookup(
-      'service:ai-assistant-panel-service',
-    ) as AiAssistantPanelService;
-
-    let monacoService = this.owner.lookup(
-      'service:monaco-service',
-    ) as MonacoService;
-
     // Mock no selection
     monacoService.trackedSelection = null;
 
@@ -27,14 +28,6 @@ module('Unit | Service | ai-assistant-panel-service', function (hooks) {
   });
 
   test('focusPillCodeRange returns undefined when there is only a cursor position (no actual selection)', function (assert) {
-    let service = this.owner.lookup(
-      'service:ai-assistant-panel-service',
-    ) as AiAssistantPanelService;
-
-    let monacoService = this.owner.lookup(
-      'service:monaco-service',
-    ) as MonacoService;
-
     // Mock cursor position at line 5, column 10 (no text selected)
     monacoService.trackedSelection = {
       startLineNumber: 5,
@@ -51,14 +44,6 @@ module('Unit | Service | ai-assistant-panel-service', function (hooks) {
   });
 
   test('focusPillCodeRange returns "Line X" when selection is on a single line', function (assert) {
-    let service = this.owner.lookup(
-      'service:ai-assistant-panel-service',
-    ) as AiAssistantPanelService;
-
-    let monacoService = this.owner.lookup(
-      'service:monaco-service',
-    ) as MonacoService;
-
     // Mock selection on line 3, columns 5-15
     monacoService.trackedSelection = {
       startLineNumber: 3,
@@ -75,14 +60,6 @@ module('Unit | Service | ai-assistant-panel-service', function (hooks) {
   });
 
   test('focusPillCodeRange returns "Lines X-Y" when selection spans multiple lines', function (assert) {
-    let service = this.owner.lookup(
-      'service:ai-assistant-panel-service',
-    ) as AiAssistantPanelService;
-
-    let monacoService = this.owner.lookup(
-      'service:monaco-service',
-    ) as MonacoService;
-
     // Mock selection from line 2 to line 5
     monacoService.trackedSelection = {
       startLineNumber: 2,
@@ -99,14 +76,6 @@ module('Unit | Service | ai-assistant-panel-service', function (hooks) {
   });
 
   test('focusPillCodeRange handles single character selection on same line', function (assert) {
-    let service = this.owner.lookup(
-      'service:ai-assistant-panel-service',
-    ) as AiAssistantPanelService;
-
-    let monacoService = this.owner.lookup(
-      'service:monaco-service',
-    ) as MonacoService;
-
     // Mock single character selection on line 1 (column 5 to 6)
     monacoService.trackedSelection = {
       startLineNumber: 1,


### PR DESCRIPTION
- Only show line range when text is actually selected, not just cursor positioning
- Add unit tests for all selection scenarios