### PR TITLE
worker: Add URL to error log when available

### DIFF
--- a/packages/realm-server/worker-manager.ts
+++ b/packages/realm-server/worker-manager.ts
@@ -431,7 +431,10 @@ async function startWorker(priority: number, urlMappings: URL[][]) {
   if (worker.stderr) {
     worker.stderr.on('data', (data: Buffer) => {
       let message = data.toString();
-      log.error(`[worker ${name} priority ${priority}]: ${message}`);
+      let maybeLogUrl = currentState?.url ? ` (for ${currentState.url})` : '';
+      log.error(
+        `[worker ${name} priority ${priority}]${maybeLogUrl}: ${message}`,
+      );
       if (message.includes('FATAL ERROR')) {
         (async () => {
           if (currentState?.url && currentState?.realm) {


### PR DESCRIPTION
This adds context to worker logs, so this unhelpful warning:

```
[worker 12257 priority 0]: Error: "var(--boxel-yellow)" is not a valid hex color code.
```

becomes one that includes somewhere to start investigation:

```
[worker 12257 priority 0] (for http://localhost:4201/experiments/SprintTask/48630c9d-2849-43d1-b356-890b016fffe9.json): Error: "var(--boxel-yellow)" is not a valid hex color code.
```