### PR TITLE
drop glint.transform.include

### DIFF
--- a/packages/ai-bot/tsconfig.json
+++ b/packages/ai-bot/tsconfig.json
@@ -32,10 +32,7 @@
     }
   },
   "glint": {
-    "environment": ["ember-loose", "ember-template-imports"],
-    "transform": {
-      "include": ["../base/**", "./**", "../boxel-ui/addon/**"]
-    }
+    "environment": ["ember-loose", "ember-template-imports"]
   },
   "include": ["../base/**/*", "./**/*", "../runtime-common/types/*"],
   "exclude": ["../base/**/__boxel/**"]

--- a/packages/billing/tsconfig.json
+++ b/packages/billing/tsconfig.json
@@ -32,10 +32,7 @@
     }
   },
   "glint": {
-    "environment": ["ember-loose", "ember-template-imports"],
-    "transform": {
-      "include": ["../base/**", "./**", "../boxel-ui/addon/**"]
-    }
+    "environment": ["ember-loose", "ember-template-imports"]
   },
   "include": ["../base/**/*", "./**/*", "../runtime-common/types/*"],
   "exclude": ["../base/**/__boxel/**"]

--- a/packages/host/tsconfig.json
+++ b/packages/host/tsconfig.json
@@ -32,17 +32,7 @@
     }
   },
   "glint": {
-    "environment": ["ember-loose", "ember-template-imports"],
-    "transform": {
-      "include": [
-        "../experiments-realm/**",
-        "../catalog-realm/**/*",
-        "../base/**",
-        "app/**",
-        "tests/**",
-        "types/**/*"
-      ]
-    }
+    "environment": ["ember-loose", "ember-template-imports"]
   },
   "include": [
     "../base/**/*",

--- a/packages/matrix/tsconfig.json
+++ b/packages/matrix/tsconfig.json
@@ -30,10 +30,7 @@
     }
   },
   "glint": {
-    "environment": ["ember-loose", "ember-template-imports"],
-    "transform": {
-      "include": ["./**"]
-    }
+    "environment": ["ember-loose", "ember-template-imports"]
   },
   "include": ["./**/*"]
 }

--- a/packages/postgres/tsconfig.json
+++ b/packages/postgres/tsconfig.json
@@ -31,10 +31,7 @@
     }
   },
   "glint": {
-    "environment": ["ember-loose", "ember-template-imports"],
-    "transform": {
-      "include": ["../base/**", "./**", "../boxel-ui/addon/**"]
-    }
+    "environment": ["ember-loose", "ember-template-imports"]
   },
   "include": ["../base/**/*", "./**/*", "../runtime-common/types/*"],
   "exclude": ["../base/**/__boxel/**"]

--- a/packages/realm-server/tsconfig.json
+++ b/packages/realm-server/tsconfig.json
@@ -31,11 +31,7 @@
     }
   },
   "glint": {
-    "environment": ["ember-loose", "ember-template-imports"],
-    "transform": {
-      "include": ["../base/**", "./**", "../boxel-ui/addon/**"],
-      "exclude": ["./tests/fixtures/**"]
-    }
+    "environment": ["ember-loose", "ember-template-imports"]
   },
   "include": ["../base/**/*", "./**/*", "../runtime-common/types/*"],
   "exclude": ["../base/**/__boxel/**", "./realms/**", "./tests/fixtures/**"]

--- a/packages/runtime-common/tsconfig.json
+++ b/packages/runtime-common/tsconfig.json
@@ -30,14 +30,6 @@
     }
   },
   "glint": {
-    "environment": ["ember-loose", "ember-template-imports"],
-    "transform": {
-      "include": [
-        "../experiments-realm/**",
-        "../base/**",
-        "../catalog-realm/**",
-        "../boxel-ui/addon/**"
-      ]
-    }
+    "environment": ["ember-loose", "ember-template-imports"]
   }
 }


### PR DESCRIPTION
This is a preliminary cleanup I found while working on refactoring all the tsconfigs.

This configuration setting stopped having any effect at `@glint/core` 1.0.