### PR TITLE
BoxelInput theming

### DIFF
--- a/packages/base/components/add-button.gts
+++ b/packages/base/components/add-button.gts
@@ -41,37 +41,39 @@ const AddButton: TemplateOnlyComponent<Signature> = <template>
     </Button>
   {{/if}}
   <style scoped>
-    .base-add-button {
-      --_ab-gap: var(--add-button-gap, var(--boxel-sp-xxxs));
-      --_ab-padding: var(
-        --add-button-padding,
-        var(--boxel-sp-5xs) var(--boxel-sp-sm)
-      );
-      --icon-color: var(--add-button-icon-color, currentColor);
-    }
-    .base-add-button:not(:disabled):hover {
-      box-shadow: var(--shadow, var(--boxel-box-shadow));
-    }
-    .icon {
-      color: var(--icon-color);
-    }
+    @layer baseAddButton {
+      .base-add-button {
+        --_ab-gap: var(--add-button-gap, var(--boxel-sp-xxxs));
+        --_ab-padding: var(
+          --add-button-padding,
+          var(--boxel-sp-5xs) var(--boxel-sp-sm)
+        );
+        --icon-color: var(--add-button-icon-color, currentColor);
+      }
+      .base-add-button:not(:disabled):hover {
+        box-shadow: var(--shadow, var(--boxel-box-shadow));
+      }
+      .icon {
+        color: var(--icon-color);
+      }
 
-    .add-button--pill {
-      --pill-gap: var(--_ab-gap);
-      --pill-padding: var(--_ab-padding);
-      --pill-font: var(--add-button-pill-font, 600 var(--boxel-font-xs));
-    }
+      .add-button--pill {
+        --pill-gap: var(--_ab-gap);
+        --pill-padding: var(--_ab-padding);
+        --pill-font: var(--add-button-pill-font, 600 var(--boxel-font-xs));
+      }
 
-    .add-button--full-width {
-      --boxel-button-border-radius: var(--boxel-form-control-border-radius);
-      --boxel-button-padding: var(--_ab-padding);
-      --boxel-button-min-height: 3.75rem;
-      --boxel-button-letter-spacing: var(--boxel-lsp-xs);
-      width: 100%;
-      max-width: 100%;
-      display: flex;
-      justify-content: center;
-      gap: var(--_ab-gap);
+      .add-button--full-width {
+        --boxel-button-border-radius: var(--boxel-form-control-border-radius);
+        --boxel-button-padding: var(--_ab-padding);
+        --boxel-button-min-height: 3.75rem;
+        --boxel-button-letter-spacing: var(--boxel-lsp-xs);
+        width: 100%;
+        max-width: 100%;
+        display: flex;
+        justify-content: center;
+        gap: var(--_ab-gap);
+      }
     }
   </style>
 </template>;

--- a/packages/base/contains-many-component.gts
+++ b/packages/base/contains-many-component.gts
@@ -149,9 +149,6 @@ class ContainsManyEditor extends GlimmerComponent<ContainsManyEditorSignature> {
       .editor.can-write {
         grid-template-columns: var(--boxel-icon-lg) 1fr var(--remove-icon-size);
       }
-      .editor :deep(.boxel-input:hover) {
-        border-color: var(--boxel-form-control-border-color);
-      }
       .editor + .editor {
         margin-top: var(--boxel-sp-xs);
       }

--- a/packages/boxel-ui/addon/src/components/add-button/index.gts
+++ b/packages/boxel-ui/addon/src/components/add-button/index.gts
@@ -33,7 +33,7 @@ const AddButton: TemplateOnlyComponent<Signature> = <template>
       --boxel-icon-button-color: var(--foreground, var(--boxel-dark));
       --icon-color: var(--boxel-icon-button-color);
       border-radius: 50%;
-      border: none;
+      border: 1px solid var(--border);
       box-shadow: var(--shadow, 0 4px 6px 0px rgb(0 0 0 / 35%));
     }
     .boxel-add-button:not(:disabled):hover {

--- a/packages/boxel-ui/addon/src/components/button/index.gts
+++ b/packages/boxel-ui/addon/src/components/button/index.gts
@@ -157,6 +157,9 @@ const ButtonComponent: TemplateOnlyComponent<Signature> = <template>
           transparent
         );
       }
+      .boxel-button:focus-visible {
+        outline-color: var(--ring, var(--boxel-highlight));
+      }
 
       .loading-indicator {
         margin-right: var(

--- a/packages/boxel-ui/addon/src/components/entity-thumbnail-display/index.gts
+++ b/packages/boxel-ui/addon/src/components/entity-thumbnail-display/index.gts
@@ -36,9 +36,9 @@ export default class EntityDisplayWithThumbnail extends GlimmerComponent<EntityD
       ...attributes
     >
       {{#if (has-block 'thumbnail')}}
-        <aside class='entity-thumbnail'>
+        <div class='entity-thumbnail'>
           {{yield to='thumbnail'}}
-        </aside>
+        </div>
       {{/if}}
 
       <div class='entity-info'>

--- a/packages/boxel-ui/addon/src/components/icon-button/index.gts
+++ b/packages/boxel-ui/addon/src/components/icon-button/index.gts
@@ -92,13 +92,7 @@ const IconButton: TemplateOnlyComponent<Signature> = <template>
 
       @media (prefers-reduced-motion: no-preference) {
         .loading-icon {
-          animation: spin 6000ms linear infinite;
-        }
-      }
-
-      @keyframes spin {
-        to {
-          transform: rotate(360deg);
+          animation: var(--boxel-infinite-spin-animation);
         }
       }
     }

--- a/packages/boxel-ui/addon/src/components/input-group/accessories/index.gts
+++ b/packages/boxel-ui/addon/src/components/input-group/accessories/index.gts
@@ -32,13 +32,13 @@ export const Button: TemplateOnlyComponent<ButtonSignature> = <template>
     .accessory {
       border: 1px solid var(--boxel-input-group-border-color);
       border-radius: var(--boxel-input-group-border-radius);
-      transition: border-color var(--boxel-transition);
       margin: 0;
       min-height: var(--boxel-input-group-height);
       outline-offset: 0;
     }
 
     .button-accessory {
+      box-shadow: none;
       z-index: 2;
     }
 
@@ -177,6 +177,7 @@ export const Select: TemplateOnlyComponent<SelectAccessorySignature> =
       }
 
       .boxel-input-group__select-accessory :deep(.boxel-select) {
+        border: none;
         font-weight: 600;
       }
 

--- a/packages/boxel-ui/addon/src/components/input-group/accessories/index.gts
+++ b/packages/boxel-ui/addon/src/components/input-group/accessories/index.gts
@@ -76,6 +76,7 @@ export const IconButton: TemplateOnlyComponent<IconButtonSignature> = <template>
     }
 
     .icon-button-accessory {
+      box-shadow: none;
       z-index: 2;
     }
   </style>
@@ -105,11 +106,9 @@ export const Text: TemplateOnlyComponent<TextSignature> = <template>
 
     .text-accessory {
       align-items: center;
-      background-color: var(--boxel-light);
-      color: var(--boxel-purple-900);
+      color: var(--muted-foreground, var(--boxel-700));
       display: flex;
       font-size: var(--boxel-font-size-sm);
-      line-height: var(--boxel-ratio);
       padding: var(--boxel-input-group-padding-y)
         var(--boxel-input-group-padding-x);
       text-align: center;
@@ -178,15 +177,11 @@ export const Select: TemplateOnlyComponent<SelectAccessorySignature> =
       }
 
       .boxel-input-group__select-accessory :deep(.boxel-select) {
-        font: var(--boxel-button-font, var(--boxel-font-sm));
         font-weight: 600;
-        padding: var(--boxel-sp-xs) var(--boxel-sp-xs) var(--boxel-sp-xs)
-          var(--boxel-sp-xs);
       }
 
       .boxel-input-group__select-accessory
         :deep(.boxel-select .ember-power-select-placeholder) {
-        font: var(--boxel-button-font, var(--boxel-font-sm));
         font-weight: 600;
       }
       .boxel-input-group__select-accessory
@@ -195,13 +190,12 @@ export const Select: TemplateOnlyComponent<SelectAccessorySignature> =
       }
 
       .boxel-input-group__select-accessory--disabled {
-        border-color: var(--boxel-input-group-border-color);
-        color: rgb(0 0 0 / 50%);
+        border: 1px solid var(--boxel-input-group-border-color);
         opacity: 0.5;
       }
 
       .boxel-input-group--invalid .boxel-input-group__select-accessory {
-        border-color: var(--boxel-error-100);
+        border-color: var(--destructive, var(--boxel-error-100));
       }
 
       .boxel-input-group__select-accessory
@@ -213,7 +207,6 @@ export const Select: TemplateOnlyComponent<SelectAccessorySignature> =
         .boxel-input-group__select-accessory__dropdown
           .ember-power-select-option
       ) {
-        font: var(--boxel-button-font, var(--boxel-font-sm));
         padding: var(--boxel-sp-xs) var(--boxel-sp-xs) var(--boxel-sp-xs)
           var(--boxel-sp-xs);
       }

--- a/packages/boxel-ui/addon/src/components/input-group/controls/index.gts
+++ b/packages/boxel-ui/addon/src/components/input-group/controls/index.gts
@@ -39,23 +39,19 @@ export const Input: TemplateOnlyComponent<InputSignature> = <template>
       -webkit-appearance: none;
       appearance: none;
       background-clip: padding-box;
-      background-color: var(--boxel-light);
-      color: var(--boxel-text-dark);
       display: block;
       flex: 1 1 auto;
-      font: var(--boxel-font-sm);
-      font-weight: 400;
-      letter-spacing: var(--boxel-lsp-xs);
       margin: 0;
       min-width: 0;
       padding: var(--boxel-input-group-padding-y)
         var(--boxel-input-group-padding-x);
       position: relative;
       width: 1%;
-      border: 1px solid var(--boxel-form-control-border-color);
+      border: 1px solid var(--border, var(--boxel-form-control-border-color));
     }
     .form-control:focus {
       outline: none;
+      border-color: var(--ring, var(--boxel-highlight));
     }
   </style>
 </template>;
@@ -77,13 +73,8 @@ export const Textarea: TemplateOnlyComponent<TextareaSignature> = <template>
       -webkit-appearance: none;
       appearance: none;
       background-clip: padding-box;
-      background-color: var(--boxel-light);
-      color: var(--boxel-text-dark);
       display: block;
       flex: 1 1 auto;
-      font: var(--boxel-font-sm);
-      font-weight: 400;
-      letter-spacing: var(--boxel-lsp-xs);
       margin: 0;
       min-width: 0;
       padding: var(--boxel-input-group-padding-y)
@@ -93,7 +84,7 @@ export const Textarea: TemplateOnlyComponent<TextareaSignature> = <template>
     }
 
     .form-control {
-      border: 1px solid var(--boxel-form-control-border-color);
+      border: 1px solid var(--boxel-input-group-border-color);
       border-radius: var(--boxel-input-group-border-radius);
       transition: border-color var(--boxel-transition);
       margin: 0;
@@ -107,8 +98,7 @@ export const Textarea: TemplateOnlyComponent<TextareaSignature> = <template>
     }
 
     .form-control:disabled {
-      background-color: var(--boxel-light);
-      color: rgb(0 0 0 / 50%);
+      opacity: 0.5;
     }
   </style>
 </template>;

--- a/packages/boxel-ui/addon/src/components/input-group/index.gts
+++ b/packages/boxel-ui/addon/src/components/input-group/index.gts
@@ -169,7 +169,8 @@ export default class InputGroup extends Component<Signature> {
         --boxel-input-group-padding-x: var(--boxel-sp-sm);
         --boxel-input-group-padding-y: var(--boxel-sp-xxs);
         --boxel-input-group-border-color: var(
-          --boxel-form-control-border-color
+          --border,
+          var(--boxel-form-control-border-color)
         );
         --boxel-input-group-border-radius: var(
           --boxel-form-control-border-radius
@@ -185,10 +186,6 @@ export default class InputGroup extends Component<Signature> {
 
         border-radius: var(--boxel-input-group-border-radius);
         cursor: text;
-        font-family: var(--boxel-font-family);
-        font-size: var(--boxel-font-size);
-        line-height: var(--boxel-ratio);
-        letter-spacing: var(--boxel-lsp-xs);
         position: relative;
         display: flex;
         flex-wrap: wrap;
@@ -202,14 +199,9 @@ export default class InputGroup extends Component<Signature> {
         --boxel-button-min-height: var(--boxel-input-group-height);
       }
 
-      .boxel-input-group:not(:focus-within):not(
-          .boxel-input-group--invalid
-        ):not(.boxel-input-group--disabled):hover {
-        outline: 1px solid var(--boxel-dark) !important;
-      }
-
       .boxel-input-group:not(.boxel-input-group--invalid):focus-within {
-        outline: 2px solid var(--boxel-highlight);
+        outline: 1px solid var(--ring, var(--boxel-highlight));
+        --boxel-input-group-border-color: var(--ring, var(--boxel-highlight));
       }
 
       .boxel-input-group--disabled :deep(.form-control),
@@ -217,7 +209,6 @@ export default class InputGroup extends Component<Signature> {
       .boxel-input-group--disabled :deep(.icon-button-accessory),
       .boxel-input-group--disabled :deep(.button-accessory) {
         border-color: var(--boxel-input-group-border-color);
-        color: rgb(0 0 0 / 50%);
         opacity: 0.5;
       }
 
@@ -247,13 +238,13 @@ export default class InputGroup extends Component<Signature> {
       .helper-text {
         margin-top: var(--boxel-sp-xs);
         margin-left: var(--boxel-sp-xs);
-        color: rgb(0 0 0 / 75%);
-        font: var(--boxel-font-sm);
+        opacity: 0.75;
+        font-size: var(--boxel-font-size-sm);
         letter-spacing: var(--boxel-lsp);
       }
 
       .boxel-input-group--invalid:not(.boxel-input-group--disabled) {
-        box-shadow: 0 0 0 1px var(--boxel-error-100);
+        box-shadow: 0 0 0 1px var(--destructive, var(--boxel-error-100));
       }
 
       .boxel-input-group--invalid:not(.boxel-input-group--disabled)
@@ -266,7 +257,7 @@ export default class InputGroup extends Component<Signature> {
         :deep(.icon-button-accessory),
       .boxel-input-group--invalid:not(.boxel-input-group--disabled)
         :deep(.button-accessory) {
-        border-color: var(--boxel-error-100);
+        border-color: var(--destructive, var(--boxel-error-100));
       }
 
       .boxel-input-group--disabled ~ .error-message,
@@ -277,8 +268,9 @@ export default class InputGroup extends Component<Signature> {
       .error-message {
         margin-top: var(--boxel-sp-xxxs);
         margin-left: calc(var(--boxel-sp-sm) + 1px);
-        color: var(--boxel-error-200);
-        font: 500 var(--boxel-font-sm);
+        color: var(--destructive, var(--boxel-error-200));
+        font-size: var(--boxel-font-size-sm);
+        font-weight: 500;
         letter-spacing: var(--boxel-lsp);
       }
 
@@ -289,9 +281,6 @@ export default class InputGroup extends Component<Signature> {
         justify-content: center;
         user-select: none;
         width: var(--boxel-input-group-icon-length);
-      }
-      .validation-icon-container.valid {
-        --icon-color: var(--boxel-dark-green);
       }
     </style>
   </template>

--- a/packages/boxel-ui/addon/src/components/input-group/usage.gts
+++ b/packages/boxel-ui/addon/src/components/input-group/usage.gts
@@ -277,27 +277,39 @@ export default class BoxelInputGroupUsage extends Component {
       class='boxel-input-usage-examples'
     >
       <:example>
-        <BoxelInputGroup @placeholder='Username'>
+        <BoxelInputGroup
+          @placeholder='Username'
+          @state={{this.state}}
+          @disabled={{this.disabled}}
+        >
           <:before as |Accessories|>
             <Accessories.Text>@</Accessories.Text>
           </:before>
         </BoxelInputGroup>
 
-        <BoxelInputGroup @placeholder="Recipient's username">
+        <BoxelInputGroup
+          @placeholder="Recipient's username"
+          @state={{this.state}}
+          @disabled={{this.disabled}}
+        >
           <:after as |Accessories|>
             <Accessories.Text>@example.com</Accessories.Text>
           </:after>
         </BoxelInputGroup>
 
         <BoxelField @tag='label' @label='Your vanity URL' @vertical={{true}}>
-          <BoxelInputGroup>
+          <BoxelInputGroup @state={{this.state}} @disabled={{this.disabled}}>
             <:before as |Accessories|>
               <Accessories.Text>https://example.com/users/</Accessories.Text>
             </:before>
           </BoxelInputGroup>
         </BoxelField>
 
-        <BoxelInputGroup @placeholder='Amount'>
+        <BoxelInputGroup
+          @placeholder='Amount'
+          @state={{this.state}}
+          @disabled={{this.disabled}}
+        >
           <:before as |Accessories|>
             <Accessories.Text>$</Accessories.Text>
           </:before>
@@ -306,7 +318,7 @@ export default class BoxelInputGroupUsage extends Component {
           </:after>
         </BoxelInputGroup>
 
-        <BoxelInputGroup>
+        <BoxelInputGroup @state={{this.state}} @disabled={{this.disabled}}>
           <:default as |Controls Accessories|>
             <Controls.Input @placeholder='Username' />
             <Accessories.Text>@</Accessories.Text>
@@ -316,7 +328,7 @@ export default class BoxelInputGroupUsage extends Component {
 
         <label>Example overriding default block to use a textarea instead of a
           text input<br />
-          <BoxelInputGroup>
+          <BoxelInputGroup @state={{this.state}} @disabled={{this.disabled}}>
             <:default as |Controls Accessories inputGroup|>
               <Accessories.Text>With textarea</Accessories.Text>
               <Controls.Textarea id={{inputGroup.elementId}} />
@@ -325,7 +337,7 @@ export default class BoxelInputGroupUsage extends Component {
         </label>
 
         <label>Example showing multiple accessories before the input<br />
-          <BoxelInputGroup>
+          <BoxelInputGroup @state={{this.state}} @disabled={{this.disabled}}>
             <:before as |Accessories|>
               <Accessories.Text>$</Accessories.Text>
               <Accessories.Text>0.00</Accessories.Text>
@@ -334,7 +346,7 @@ export default class BoxelInputGroupUsage extends Component {
         </label>
 
         <label>Example showing multiple accessories after the input<br />
-          <BoxelInputGroup>
+          <BoxelInputGroup @state={{this.state}} @disabled={{this.disabled}}>
             <:after as |Accessories|>
               <Accessories.Text>$</Accessories.Text>
               <Accessories.Text>0.00</Accessories.Text>
@@ -343,45 +355,66 @@ export default class BoxelInputGroupUsage extends Component {
         </label>
 
         <label>Example showing a button accessories after the input<br />
-          <BoxelInputGroup>
+          <BoxelInputGroup @state={{this.state}} @disabled={{this.disabled}}>
             <:before as |Accessories|>
               <Accessories.Button>Button</Accessories.Button>
             </:before>
           </BoxelInputGroup>
         </label>
 
-        <BoxelInputGroup @placeholder="Recipient's username">
+        <BoxelInputGroup
+          @placeholder="Recipient's username"
+          @state={{this.state}}
+          @disabled={{this.disabled}}
+        >
           <:after as |Accessories|>
             <Accessories.Button>Button</Accessories.Button>
           </:after>
         </BoxelInputGroup>
 
-        <BoxelInputGroup @placeholder="The button has a 'kind' of 'primary'">
+        <BoxelInputGroup
+          @placeholder="The button has a 'kind' of 'primary'"
+          @state={{this.state}}
+          @disabled={{this.disabled}}
+        >
           <:after as |Accessories|>
             <Accessories.Button @kind='primary'>Button</Accessories.Button>
           </:after>
         </BoxelInputGroup>
 
-        <BoxelInputGroup @placeholder='Example with two buttons before'>
+        <BoxelInputGroup
+          @placeholder='Example with two buttons before'
+          @state={{this.state}}
+          @disabled={{this.disabled}}
+        >
           <:before as |Accessories|>
             <Accessories.Button>Button</Accessories.Button>
             <Accessories.Button>Button</Accessories.Button>
           </:before>
         </BoxelInputGroup>
 
-        <BoxelInputGroup @placeholder='Example with two buttons after'>
+        <BoxelInputGroup
+          @placeholder='Example with two buttons after'
+          @state={{this.state}}
+          @disabled={{this.disabled}}
+        >
           <:after as |Accessories|>
             <Accessories.Button>Button</Accessories.Button>
             <Accessories.Button>Button</Accessories.Button>
           </:after>
         </BoxelInputGroup>
-        <BoxelInputGroup @placeholder='Input with a select menu'>
+        <BoxelInputGroup
+          @placeholder='Input with a select menu'
+          @state={{this.state}}
+          @disabled={{this.disabled}}
+        >
           <:after as |Accessories|>
             <Accessories.Select
               @placeholder={{this.selectExamplePlaceholder}}
               @selected={{this.selectExampleSelectedItem}}
               @onChange={{this.selectExampleOnSelectItem}}
               @options={{this.selectExampleItems}}
+              @disabled={{this.disabled}}
               @dropdownClass='boxel-select-usage-dropdown'
               aria-label='Select an item'
               as |item|

--- a/packages/boxel-ui/addon/src/components/input/index.gts
+++ b/packages/boxel-ui/addon/src/components/input/index.gts
@@ -70,10 +70,10 @@ export interface Signature {
     optional?: boolean;
     placeholder?: string;
     required?: boolean;
+    size?: 'large' | 'default';
     state?: InputValidationState;
     type?: InputType;
     value: string | number | null | undefined;
-    variant?: 'large' | 'default';
   };
   Element: HTMLInputElement | HTMLTextAreaElement | HTMLDivElement;
 }
@@ -151,7 +151,8 @@ export default class BoxelInput extends Component<Signature> {
             has-validation=this.hasValidation
             invalid=this.isInvalid
             search=this.isSearch
-            boxel-input--large=(eq @variant 'large')
+            loading=(eq @state 'loading')
+            boxel-input--large=(eq @size 'large')
             boxel-input--bottom-flat=(eq @bottomTreatment 'flat')
           }}
           id={{this.id}}
@@ -196,7 +197,10 @@ export default class BoxelInput extends Component<Signature> {
         {{/if}}
         {{#if this.validationIcon}}
           <div class='validation-icon-container'>
-            <this.validationIcon role='presentation' />
+            <this.validationIcon
+              class='validation-icon-{{@state}}'
+              role='presentation'
+            />
           </div>
         {{/if}}
         {{#if this.shouldShowErrorMessage}}
@@ -242,21 +246,21 @@ export default class BoxelInput extends Component<Signature> {
 
         box-sizing: border-box;
         width: 100%;
+        max-width: 100%;
         min-height: var(--boxel-input-height);
         padding: var(--boxel-sp-xs) 0 var(--boxel-sp-xs) var(--boxel-sp-sm);
-        border: 1px solid var(--boxel-form-control-border-color);
+        border: 1px solid var(--border, var(--boxel-form-control-border-color));
         border-radius: var(--boxel-form-control-border-radius);
-        font: var(--boxel-font-sm);
-        font-weight: 400;
-        letter-spacing: var(--boxel-lsp-xs);
-        transition: border-color var(--boxel-transition);
+        box-shadow: var(--shadow);
+        outline: 1px solid transparent;
+        transition:
+          var(--boxel-transition-properties),
+          outline-color var(--boxel-transition);
       }
 
       .boxel-input--large {
         --boxel-form-control-height: 4.375rem;
-
-        font: var(--boxel-font);
-        letter-spacing: var(--boxel-lsp-xs);
+        font-size: var(--boxel-font-size);
       }
 
       .boxel-text-area {
@@ -264,42 +268,60 @@ export default class BoxelInput extends Component<Signature> {
       }
 
       .boxel-input:disabled {
-        background-color: var(--boxel-light);
-        border-color: var(--boxel-purple-300);
-        color: rgb(0 0 0 / 50%);
         opacity: 0.5;
       }
 
-      .boxel-input:hover:not(:disabled) {
-        border-color: var(--boxel-dark);
+      .boxel-input:focus-visible {
+        outline-color: var(--ring, var(--boxel-highlight));
+        border-color: var(--ring, var(--boxel-highlight));
+      }
+      .boxel-input:focus-visible:not(.search) {
+        background-color: color-mix(
+          in oklab,
+          var(--background, var(--boxel-light)) 20%,
+          transparent
+        );
       }
 
-      .invalid {
-        border-color: var(--boxel-error-100);
-        box-shadow: 0 0 0 1px var(--boxel-error-100);
+      .boxel-input::placeholder {
+        color: var(--muted-foreground, var(--boxel-450));
       }
 
-      .invalid:focus {
+      .boxel-input:hover:not(:focus-visible):not(:disabled):not(.invalid):not(
+          :invalid
+        ):not(.search) {
+        border-color: var(--border, currentColor);
+      }
+
+      .invalid:not(:disabled),
+      :invalid:not(:disabled) {
+        border-color: var(--destructive, var(--boxel-error-100));
+        box-shadow: 0 0 0 1px var(--destructive, var(--boxel-error-100));
+      }
+
+      .invalid:focus-visible,
+      :invalid:focus-visible {
         outline: 1px solid transparent; /* Make sure that we make the invalid state visible */
-        box-shadow: 0 0 0 1.5px var(--boxel-error-100);
+        box-shadow: 0 0 0 1.5px var(--destructive, var(--boxel-error-100));
       }
 
-      .invalid:hover:not(:disabled) {
-        border-color: var(--boxel-error-100);
+      .invalid:hover:not(:disabled),
+      :invalid:hover:not(:disabled) {
+        border-color: var(--destructive, var(--boxel-error-100));
       }
 
       .search {
         --search-input-color: var(
           --boxel-input-search-color,
-          var(--boxel-light)
+          var(--background, var(--boxel-light))
         );
 
         --search-input-background-color: var(
           --boxel-input-search-background-color,
-          var(--boxel-dark)
+          var(--foreground, var(--boxel-dark))
         );
 
-        --boxel-form-control-border-color: var(--boxel-dark);
+        --boxel-form-control-border-color: var(--border, var(--boxel-dark));
         --boxel-form-control-border-radius: var(--boxel-border-radius-xl);
 
         background-color: var(--search-input-background-color);
@@ -310,6 +332,7 @@ export default class BoxelInput extends Component<Signature> {
         /* to account for the icon being on the left */
         padding-right: unset;
         padding-left: var(--boxel-sp-xxl); /* leave room for icon */
+        outline-width: 1px;
       }
 
       .boxel-input--bottom-flat {
@@ -342,15 +365,27 @@ export default class BoxelInput extends Component<Signature> {
         user-select: none;
       }
 
+      .search ~ .validation-icon-container .validation-icon-loading {
+        color: var(--primary, var(--boxel-highlight));
+        --icon-color: currentColor;
+      }
+      .search ~ .search-icon-container .search-icon {
+        color: var(
+          --boxel-input-search-icon-color,
+          var(--primary, var(--boxel-highlight))
+        );
+        --icon-color: currentColor;
+      }
+
       .optional {
         grid-area: optional;
+        justify-self: end;
 
         margin-bottom: var(--boxel-sp-xxxs);
-        color: rgb(0 0 0 / 75%);
-        font: var(--boxel-font-sm);
+        font-size: var(--boxel-font-size-xs);
         font-style: oblique;
         letter-spacing: var(--boxel-lsp);
-        text-align: right;
+        opacity: 0.75;
       }
 
       .error-message {
@@ -358,8 +393,9 @@ export default class BoxelInput extends Component<Signature> {
 
         margin-top: var(--boxel-sp-xxxs);
         margin-left: calc(var(--boxel-sp-sm) + 1px);
-        color: var(--boxel-error-200);
-        font: 500 var(--boxel-font-sm);
+        color: var(--destructive, var(--boxel-error-200));
+        font-size: var(--boxel-font-size-sm);
+        font-weight: 500;
         letter-spacing: var(--boxel-lsp);
       }
 
@@ -368,9 +404,9 @@ export default class BoxelInput extends Component<Signature> {
 
         margin-top: var(--boxel-sp-xs);
         margin-left: calc(var(--boxel-sp-sm) + 1px);
-        color: rgb(0 0 0 / 75%);
-        font: var(--boxel-font-sm);
+        font-size: var(--boxel-font-size-sm);
         letter-spacing: var(--boxel-lsp);
+        opacity: 0.75;
       }
 
       .boxel-input:disabled ~ .error-message,
@@ -381,6 +417,12 @@ export default class BoxelInput extends Component<Signature> {
       .boxel-input.search::placeholder {
         color: inherit;
         opacity: 0.6;
+      }
+
+      @media (prefers-reduced-motion: no-preference) {
+        .validation-icon-loading {
+          animation: var(--boxel-infinite-spin-animation);
+        }
       }
     </style>
   </template>

--- a/packages/boxel-ui/addon/src/components/input/usage.gts
+++ b/packages/boxel-ui/addon/src/components/input/usage.gts
@@ -10,6 +10,8 @@ import {
 } from 'ember-freestyle/decorators/css-variable';
 
 import cssVar from '../../helpers/css-var.ts';
+import CardContainer from '../card-container/index.gts';
+import BoxelContainer from '../container/index.gts';
 import BoxelInput from './index.gts';
 import {
   type InputValidationState,
@@ -28,12 +30,12 @@ export default class InputUsage extends Component {
   @tracked disabled = false;
   @tracked required = false;
   @tracked optional = false;
-  @tracked placeholder = '';
-  @tracked errorMessage = '';
+  @tracked placeholder = 'Please enter';
+  @tracked errorMessage = 'There was an unknown error.';
   @tracked helperText = '';
   @tracked max = '';
   @tracked state: InputValidationState = 'initial';
-  @tracked variant: 'large' | 'default' = 'default';
+  @tracked size: 'large' | 'default' = 'default';
 
   defaultType = InputTypes.Text;
   @tracked type = this.defaultType;
@@ -85,7 +87,7 @@ export default class InputUsage extends Component {
           @state={{this.state}}
           @placeholder={{this.placeholder}}
           @bottomTreatment={{this.bottomTreatment}}
-          @variant={{this.variant}}
+          @size={{this.size}}
           @errorMessage={{this.errorMessage}}
           @helperText={{this.helperText}}
           @max={{this.max}}
@@ -168,12 +170,12 @@ export default class InputUsage extends Component {
           @defaultValue={{this.defaultBottomTreatment}}
         />
         <Args.String
-          @name='variant'
+          @name='size'
           @description='Optional larger size'
-          @onInput={{fn (mut this.variant)}}
+          @onInput={{fn (mut this.size)}}
           @options={{Array 'default' 'large'}}
-          @value={{this.variant}}
-          @defaultValue={{this.variant}}
+          @value={{this.size}}
+          @defaultValue={{this.size}}
         />
         <Args.Action
           @name='onInput'
@@ -185,14 +187,103 @@ export default class InputUsage extends Component {
       </:api>
       <:cssVars as |Css|>
         <Css.Basic
-          @name='boxel-input-height'
-          @type='dimension'
-          @description='Used to set the height of the field'
-          @defaultValue={{this.boxelInputHeight.defaults}}
-          @value={{this.boxelInputHeight.value}}
-          @onInput={{this.boxelInputHeight.update}}
+          @name='--boxel-input-height'
+          @type='min-height'
+          @description='Used to set the min-height of the field'
+        />
+        <Css.Basic
+          @name='--boxel-input-search-color'
+          @type='color'
+          @description='Search input text color'
+        />
+        <Css.Basic
+          @name='--boxel-input-search-background-color'
+          @type='background-color'
+          @description='Search input background-color'
+        />
+        <Css.Basic
+          @name='--boxel-input-search-icon-color'
+          @type='color'
+          @description='Search icon svg color'
         />
       </:cssVars>
+    </FreestyleUsage>
+
+    <FreestyleUsage class='remove-in-percy' @name='Usage on nested card'>
+      <:example>
+        <CardContainer @displayBoundaries={{true}}>
+          <BoxelContainer @display='grid'>
+            Nested card:
+            <CardContainer @displayBoundaries={{true}}>
+              <BoxelContainer @display='grid'>
+                <label for='usage-input-card' class='boxel-sr-only'>Sample label</label>
+                <BoxelInput
+                  @id='usage-input-card'
+                  @value={{this.value}}
+                  @disabled={{this.disabled}}
+                  @required={{this.required}}
+                  @optional={{this.optional}}
+                  @type={{this.type}}
+                  @state={{this.state}}
+                  @placeholder={{this.placeholder}}
+                  @bottomTreatment={{this.bottomTreatment}}
+                  @size={{this.size}}
+                  @errorMessage={{this.errorMessage}}
+                  @helperText={{this.helperText}}
+                  @onBlur={{this.validate}}
+                  {{on 'input' this.set}}
+                />
+                <label
+                  for='usage-input-card-disabled'
+                  class='boxel-sr-only'
+                >Sample label</label>
+                <BoxelInput
+                  @id='usage-input-card-disabled'
+                  @size={{this.size}}
+                  disabled
+                  @value='Disabled state'
+                />
+              </BoxelContainer>
+            </CardContainer>
+          </BoxelContainer>
+        </CardContainer>
+      </:example>
+    </FreestyleUsage>
+
+    <FreestyleUsage class='remove-in-percy' @name='Usage on sidebar'>
+      <:example>
+        <BoxelContainer
+          for='usage-input-sidebar'
+          @tag='aside'
+          @display='grid'
+          class='sidebar-container'
+        >
+          Sidebar:
+          <BoxelInput
+            @id='usage-input-sidebar'
+            @value={{this.value}}
+            @disabled={{this.disabled}}
+            @required={{this.required}}
+            @optional={{this.optional}}
+            @type={{this.type}}
+            @state={{this.state}}
+            @placeholder={{this.placeholder}}
+            @bottomTreatment={{this.bottomTreatment}}
+            @size={{this.size}}
+            @errorMessage={{this.errorMessage}}
+            @helperText={{this.helperText}}
+            @onBlur={{this.validate}}
+            {{on 'input' this.set}}
+          />
+          <label for='usage-input-sidebar-d' class='boxel-sr-only'>Sample label</label>
+          <BoxelInput
+            @id='usage-input-sidebar-d'
+            @size={{this.size}}
+            @value='Disabled state'
+            disabled
+          />
+        </BoxelContainer>
+      </:example>
     </FreestyleUsage>
 
     <FreestyleUsage
@@ -237,5 +328,18 @@ export default class InputUsage extends Component {
         />
       </:example>
     </FreestyleUsage>
+    <style scoped>
+      .card-container {
+        background-color: var(--card);
+        color: var(--card-foreground);
+      }
+      .sidebar-container {
+        background-color: var(--sidebar);
+        color: var(--sidebar-foreground);
+      }
+      :deep(.FreestyleUsageCssVar input) {
+        display: none;
+      }
+    </style>
   </template>
 }

--- a/packages/boxel-ui/addon/src/components/loading-indicator/index.gts
+++ b/packages/boxel-ui/addon/src/components/loading-indicator/index.gts
@@ -67,15 +67,9 @@ const LoadingIndicator: TemplateOnlyComponent<Signature> = <template>
     */
     @media (prefers-reduced-motion: no-preference) {
       .boxel-loading-indicator :deep(svg) {
-        animation: spin 6000ms linear infinite;
+        animation: var(--boxel-infinite-spin-animation);
         width: var(--loading-indicator-size);
         height: var(--loading-indicator-size);
-      }
-    }
-
-    @keyframes spin {
-      to {
-        transform: rotate(360deg);
       }
     }
   </style>

--- a/packages/boxel-ui/addon/src/styles/global.css
+++ b/packages/boxel-ui/addon/src/styles/global.css
@@ -85,11 +85,38 @@
     outline-color: transparent;
   }
 
+  button,
+  input,
+  select,
+  textarea {
+    color: inherit;
+    background-color: transparent;
+    font: inherit;
+    letter-spacing: inherit;
+  }
+
+  input:disabled,
+  select:disabled,
+  textarea:disabled {
+    opacity: 0.5;
+    pointer-events: none;
+  }
+
   input:focus,
-  select:focus,
   textarea:focus {
+    outline-width: var(--boxel-outline-width);
     outline-color: var(--boxel-highlight);
-    outline-style: var(--boxel-outline-style, solid);
+    outline-style: solid;
+  }
+
+  input:focus:not(:focus-visible),
+  textarea:focus:not(:focus-visible) {
+    outline-color: transparent;
+  }
+
+  input:focus-visible,
+  textarea:focus-visible {
+    outline-color: var(--boxel-highlight);
   }
 }
 
@@ -118,6 +145,19 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  /* can be used via `--boxel-infinite-spin-animation` css-variable. example:
+    @media (prefers-reduced-motion: no-preference) {
+      .loading-icon {
+        animation: var(--boxel-infinite-spin-animation);
+      }
+    }
+  */
+  @keyframes boxel-spin {
+    to {
+      transform: rotate(360deg);
+    }
   }
 }
 

--- a/packages/boxel-ui/addon/src/styles/variables.css
+++ b/packages/boxel-ui/addon/src/styles/variables.css
@@ -80,6 +80,9 @@
   --boxel-border-radius-xl: calc(var(--boxel-border-radius-lg) + 3px);
   --boxel-border-radius-xxl: calc(var(--boxel-border-radius-xl) + 5px);
 
+  /* animations */
+  --boxel-infinite-spin-animation: boxel-spin 6000ms linear infinite;
+
   /* transition */
   --boxel-transition: 0.2s ease;
   --boxel-transition-properties:

--- a/packages/host/app/components/ai-assistant/attached-file-dropdown-menu.gts
+++ b/packages/host/app/components/ai-assistant/attached-file-dropdown-menu.gts
@@ -137,7 +137,7 @@ export default class AttachedFileDropdownMenu extends Component<{
         rotate: 90deg;
         flex-shrink: 0;
 
-        --inner-boxel-icon-button-width: 20px;
+        --boxel-icon-button-width: 20px;
       }
 
       button.context-menu-button:hover {

--- a/packages/host/app/components/card-catalog/modal.gts
+++ b/packages/host/app/components/card-catalog/modal.gts
@@ -120,7 +120,7 @@ export default class CardCatalogModal extends Component<Signature> {
             <BoxelInput
               class='card-catalog-search'
               @type='search'
-              @variant='large'
+              @size='large'
               @value={{this.state.searchKey}}
               @onInput={{this.setSearchKey}}
               @onKeyPress={{this.onSearchFieldKeypress}}

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -175,7 +175,10 @@ export default class OperatorModeContainer extends Component<Signature> {
         --operator-mode-bottom-bar-item-height: var(--container-button-size);
       }
       :global(button:focus:not(:disabled)) {
-        outline-color: var(--boxel-header-text-color, var(--boxel-highlight));
+        outline-color: var(
+          --boxel-header-text-color,
+          var(--ring, var(--boxel-highlight))
+        );
         outline-offset: -2px;
       }
       :global(button:focus:not(:focus-visible)) {

--- a/packages/host/app/components/search-sheet/index.gts
+++ b/packages/host/app/components/search-sheet/index.gts
@@ -242,7 +242,7 @@ export default class SearchSheet extends Component<Signature> {
       {{else}}
         <BoxelInput
           @type='search'
-          @variant='large'
+          @size='large'
           @bottomTreatment={{this.inputBottomTreatment}}
           @value={{this.searchKey}}
           @state={{this.inputValidationState}}


### PR DESCRIPTION
Preview:
- Input: https://cs-9313-input-theming.boxel-ui-preview.stack.cards/?s=Components&ss=%3CInput%3E&theme=%3CNone%3E
- InputGroup: https://cs-9313-input-theming.boxel-ui-preview.stack.cards/?s=Components&ss=%3CInputGroup%3E&theme=%3CNone%3E

- This PR also fixes the UI issues in cs-9261 regarding the InputGroup component:
<img width="667" height="68" alt="phone-input" src="https://github.com/user-attachments/assets/9308bbe9-4e9e-4fbd-b7a0-ea6ec57d8348" />


- Created tickets under "Next Sprint?" for input types that need designs (ie. `type='file'`)