### PR TITLE
matrix: Change login helper to store credentials

### DIFF
--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -269,11 +269,20 @@ export async function login(
   password: string,
   opts?: LoginOptions,
 ) {
-  await openRoot(page, opts?.url);
+  let credentials = await loginUser(username, password);
 
-  await page.locator('[data-test-username-field]').fill(username);
-  await page.locator('[data-test-password-field]').fill(password);
-  await page.locator('[data-test-login-btn]').click();
+  let localStorageAuth = {
+    access_token: credentials.accessToken,
+    user_id: credentials.userId,
+    device_id: credentials.deviceId,
+    home_server: credentials.homeServer,
+  };
+
+  await page.context().addInitScript((authData) => {
+    window.localStorage.setItem('auth', JSON.stringify(authData));
+  }, localStorageAuth);
+
+  await openRoot(page, opts?.url);
 }
 
 export async function enterWorkspace(


### PR DESCRIPTION
This skips the login dialog in Matrix tests by writing credentials to `localStorage['auth']` directly.

I ran this three times in CI with Playwright durations of 5.9min, 5.8min, and 5.9min. That’s not a statistically significant speed increase compared to `main`, whose recent runs have been 6.0min, 5.8min, 5.8min, 6.2min, and 7.5min, with the last two having had flaky tests. However, I think this is still an improvement because the login and registration test files exercise login, when tests use the `login` helper it’s a setup requirement, not a desire for assertion.