### PR TITLE
handle copying code refs correctly in index copy operation

### DIFF
--- a/packages/host/tests/integration/components/card-catalog-test.gts
+++ b/packages/host/tests/integration/components/card-catalog-test.gts
@@ -245,9 +245,7 @@ module('Integration | card-catalog', function (hooks) {
       await click(`[data-test-boxel-menu-item-text="Local Workspace"]`); // Unselect Local Workspace
       assert
         .dom('[data-test-realm-filter-button]')
-        .hasText(
-          `Workspace: Base Workspace, Cardstack Catalog, Cardstack Skills`,
-        );
+        .hasText(`Workspace: Base Workspace, Cardstack Catalog, Boxel Skills`);
       assert
         .dom(`[data-test-realm="Base Workspace"] [data-test-card-catalog-item]`)
         .exists();

--- a/packages/host/tests/integration/components/card-catalog-test.gts
+++ b/packages/host/tests/integration/components/card-catalog-test.gts
@@ -245,7 +245,9 @@ module('Integration | card-catalog', function (hooks) {
       await click(`[data-test-boxel-menu-item-text="Local Workspace"]`); // Unselect Local Workspace
       assert
         .dom('[data-test-realm-filter-button]')
-        .hasText(`Workspace: Base Workspace, Cardstack Catalog, Boxel Skills`);
+        .hasText(
+          `Workspace: Base Workspace, Cardstack Catalog, Cardstack Skills`,
+        );
       assert
         .dom(`[data-test-realm="Base Workspace"] [data-test-card-catalog-item]`)
         .exists();

--- a/packages/host/tests/unit/index-writer-test.ts
+++ b/packages/host/tests/unit/index-writer-test.ts
@@ -703,8 +703,12 @@ module('Unit | index-writer', function (hooks) {
                 isPrimitive: true,
                 isComputed: false,
                 fieldOrCard: {
-                  module: `${testRealmURL}fancy-string`,
-                  name: 'StringField',
+                  card: {
+                    module: `${testRealmURL}fancy-string`,
+                    name: 'StringField',
+                  },
+                  type: 'fieldOf',
+                  field: 'fancy',
                 },
               },
             },
@@ -859,8 +863,12 @@ module('Unit | index-writer', function (hooks) {
               isPrimitive: true,
               isComputed: false,
               fieldOrCard: {
-                module: `${testRealmURL2}fancy-string`,
-                name: 'StringField',
+                card: {
+                  module: `${testRealmURL2}fancy-string`,
+                  name: 'StringField',
+                },
+                type: 'fieldOf',
+                field: 'fancy',
               },
             },
           },

--- a/packages/runtime-common/definitions.ts
+++ b/packages/runtime-common/definitions.ts
@@ -3,7 +3,6 @@ import {
   identifyCard,
   primitive,
   fieldSerializer,
-  type ResolvedCodeRef,
   type Definition,
   type SerializerName,
 } from './index';
@@ -23,10 +22,7 @@ export function getFieldDefinitions(
   prefix = '',
   visited: string[] = [],
 ) {
-  let cardKey = internalKeyFor(
-    identifyCard(cardDef) as ResolvedCodeRef,
-    undefined,
-  );
+  let cardKey = internalKeyFor(identifyCard(cardDef)!, undefined);
   let fields = api.getFields(cardDef, { includeComputeds: true });
   for (let [fieldName, field] of Object.entries(fields)) {
     let fullFieldName = `${prefix ? prefix + '.' : ''}${fieldName}`;
@@ -35,7 +31,7 @@ export function getFieldDefinitions(
       type: field.fieldType,
       isPrimitive,
       isComputed: Boolean(field.computeVia),
-      fieldOrCard: identifyCard(field.card) as ResolvedCodeRef,
+      fieldOrCard: identifyCard(field.card)!,
       serializerName:
         fieldSerializer in field.card
           ? (field.card[fieldSerializer] as SerializerName)

--- a/packages/runtime-common/index-structure.ts
+++ b/packages/runtime-common/index-structure.ts
@@ -1,8 +1,4 @@
-import {
-  ResolvedCodeRef,
-  type CardResource,
-  type SerializerName,
-} from './index';
+import { type CardResource, type SerializerName, type CodeRef } from './index';
 import { type SerializedError } from './error';
 import { type PgPrimitive } from './expression';
 import { type FieldType } from 'https://cardstack.com/base/card-api';
@@ -61,13 +57,13 @@ export interface FieldDefinition {
   type: FieldType;
   isPrimitive: boolean;
   isComputed: boolean;
-  fieldOrCard: ResolvedCodeRef;
+  fieldOrCard: CodeRef;
   serializerName?: SerializerName;
 }
 
 export interface Definition {
   type: 'card-def' | 'field-def';
-  codeRef: ResolvedCodeRef;
+  codeRef: CodeRef;
   displayName: string | null;
   fields: {
     [fieldName: string]: FieldDefinition;

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -5,12 +5,14 @@ import {
   type CardResource,
   type RealmInfo,
   type JobInfo,
+  type CodeRef,
   jobIdentity,
   hasExecutableExtension,
   trimExecutableExtension,
   RealmPaths,
   unixTime,
   logger,
+  isUrlLike,
 } from './index';
 import { transpileJS } from './transpile';
 import {
@@ -249,13 +251,10 @@ export class Batch {
         ? {
             type: entry.definition.type,
             displayName: entry.definition.displayName,
-            codeRef: {
-              module: this.copiedRealmURL(
-                sourceRealmURL,
-                new URL(entry.definition.codeRef.module),
-              ).href,
-              name: entry.definition.codeRef.name,
-            },
+            codeRef: this.copiedCodeRef(
+              sourceRealmURL,
+              entry.definition.codeRef,
+            ),
             fields: this.fieldDefinitionsWithCopiedCodeRefs(
               sourceRealmURL,
               entry.definition.fields,
@@ -767,16 +766,28 @@ export class Batch {
         fieldName,
         {
           ...fieldDefinition,
-          fieldOrCard: {
-            module: this.copiedRealmURL(
-              fromRealm,
-              new URL(fieldDefinition.fieldOrCard.module),
-            ).href,
-            name: fieldDefinition.fieldOrCard.name,
-          },
+          fieldOrCard: this.copiedCodeRef(
+            fromRealm,
+            fieldDefinition.fieldOrCard,
+          ),
         },
       ]),
     );
+  }
+
+  private copiedCodeRef(fromRealm: URL, codeRef: CodeRef): CodeRef {
+    if (!('type' in codeRef)) {
+      if (isUrlLike(codeRef.module)) {
+        let module = this.copiedRealmURL(
+          fromRealm,
+          new URL(codeRef.module),
+        ).href;
+        return { ...codeRef, module };
+      } else {
+        return { ...codeRef };
+      }
+    }
+    return { ...codeRef, card: this.copiedCodeRef(fromRealm, codeRef.card) };
   }
 
   private updateIds(obj: any, fromRealm: URL) {


### PR DESCRIPTION
This PR fixes a bad assumption where we were assuming that the code refs captured in our definitions within the index were resolved code refs. these code ref can actually be unexported code refs too.