### PR TITLE
Fix Connect iframe URL

### DIFF
--- a/packages/host/app/config/environment.d.ts
+++ b/packages/host/app/config/environment.d.ts
@@ -14,7 +14,7 @@ declare const config: {
   matrixURL: string;
   matrixServerName: string;
 
-  realmServerDomain: string;
+  realmServerURL: string;
   resolvedBaseRealmURL: string;
   resolvedSkillsRealmURL: string;
   hostsOwnAssets: boolean;

--- a/packages/host/app/services/host-mode-service.ts
+++ b/packages/host/app/services/host-mode-service.ts
@@ -28,8 +28,8 @@ export default class HostModeService extends Service {
       return false;
     }
 
-    if (config.realmServerDomain) {
-      let realmServerDomain = config.realmServerDomain;
+    if (config.realmServerURL) {
+      let realmServerDomain = new URL(config.realmServerURL).hostname;
       let currentHost = window.location.hostname;
 
       return (

--- a/packages/host/app/templates/card.gts
+++ b/packages/host/app/templates/card.gts
@@ -47,7 +47,7 @@ class HostModeComponent extends Component<HostModeComponentSignature> {
   @service private declare store: StoreService;
 
   get connectUrl() {
-    return `${config.assetsURL}/connect`;
+    return `${config.realmServerURL}connect`;
   }
 
   get isError() {

--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -42,7 +42,7 @@ module.exports = function (environment) {
 
     // the fields below may be rewritten by the realm server
     hostsOwnAssets: true,
-    realmServerDomain: process.env.REALM_SERVER_DOMAIN || 'localhost',
+    realmServerURL: process.env.REALM_SERVER_DOMAIN || 'http://localhost:4201/',
     resolvedBaseRealmURL:
       process.env.RESOLVED_BASE_REALM_URL || 'http://localhost:4201/base/',
     resolvedSkillsRealmURL:
@@ -73,7 +73,7 @@ module.exports = function (environment) {
     ENV.autoSaveDelayMs = 0;
     ENV.monacoDebounceMs = 0;
     ENV.monacoCursorDebounceMs = 0;
-    ENV.realmServerDomain = 'test-realm';
+    ENV.realmServerURL = 'http://test-realm';
     ENV.serverEchoDebounceMs = 0;
     ENV.loginMessageTimeoutMs = 0;
     ENV.minSaveTaskDurationMs = 0;

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -253,7 +253,7 @@ export class RealmServer {
         config = merge({}, config, {
           hostsOwnAssets: false,
           assetsURL: this.assetsURL.href,
-          realmServerDomain: this.serverURL.hostname,
+          realmServerURL: this.serverURL.href,
         });
         return `${g1}${encodeURIComponent(JSON.stringify(config))}${g3}`;
       },


### PR DESCRIPTION
This fixes a mistake I made in #3130, where I constructed the iframe URL from `assetsURL` when it really should be the realm server URL, which may be the same but may not be. Realm server URL wasn’t available in application config, so this repurposes what was `realmServerDomain`.