### PR TITLE
Prerender meta testing, card format testing, and more robust error handling

### DIFF
--- a/packages/host/app/router.ts
+++ b/packages/host/app/router.ts
@@ -9,6 +9,7 @@ export default class Router extends EmberRouter {
 Router.map(function () {
   this.route('host-freestyle', { path: '/_freestyle' });
   this.route('indexer', { path: '/indexer/:id' });
+  this.route('render-error', { path: '/render-error/:reason' });
   this.route('render', { path: '/render/:id' }, function () {
     this.route('html', { path: '/html/:format/:ancestor_level' });
     this.route('icon');

--- a/packages/host/app/templates/render-error.gts
+++ b/packages/host/app/templates/render-error.gts
@@ -1,0 +1,14 @@
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
+
+import RouteTemplate from 'ember-route-template';
+
+export default RouteTemplate(<template>
+  <pre
+    data-prerender
+    data-prerender-status='error'
+  >
+     {{@model.reason}}
+  </pre>
+</template> satisfies TemplateOnlyComponent<{
+  Args: { model: { reason: string } };
+}>);

--- a/packages/host/tests/acceptance/prerender-meta-test.gts
+++ b/packages/host/tests/acceptance/prerender-meta-test.gts
@@ -1,0 +1,515 @@
+import { visit } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+
+import { module, test } from 'qunit';
+
+import { baseRealm, type PrerenderMeta } from '@cardstack/runtime-common';
+
+import {
+  setupLocalIndexing,
+  setupOnSave,
+  testRealmURL,
+  setupAcceptanceTestRealm,
+  capturePrerenderResult,
+} from '../helpers';
+import { setupMockMatrix } from '../helpers/mock-matrix';
+import { setupApplicationTest } from '../helpers/setup';
+
+module('Acceptance | prerender | meta', function (hooks) {
+  setupApplicationTest(hooks);
+  setupLocalIndexing(hooks);
+  setupOnSave(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+  });
+
+  hooks.beforeEach(async function () {
+    let loader = getService('loader-service').loader;
+    let cardApi: typeof import('https://cardstack.com/base/card-api');
+    cardApi = await loader.import(`${baseRealm.url}card-api`);
+
+    let {
+      field,
+      contains,
+      containsMany,
+      linksTo,
+      linksToMany,
+      CardDef,
+      FieldDef,
+      StringField,
+      Component,
+    } = cardApi;
+
+    class EmergencyContact extends FieldDef {
+      @field phone = contains(StringField);
+      @field contact = linksTo(() => Person);
+      static embedded = class Embedded extends Component<
+        typeof EmergencyContact
+      > {
+        <template>
+          <@fields.contact />
+          <@fields.phone />
+        </template>
+      };
+    }
+
+    class Pet extends CardDef {
+      static displayName = 'Pet';
+      @field name = contains(StringField);
+      @field title = contains(StringField, {
+        computeVia(this: Pet) {
+          return `${this.name}`;
+        },
+      });
+    }
+
+    class Cat extends Pet {
+      static displayName = 'Cat';
+      @field aliases = containsMany(StringField);
+      @field emergencyContacts = containsMany(EmergencyContact);
+    }
+
+    class Person extends CardDef {
+      static displayName = 'Person';
+      @field name = contains(StringField);
+      @field pets = linksToMany(() => Pet);
+      @field friend = linksTo(() => Person);
+      @field title = contains(StringField, {
+        computeVia(this: Person) {
+          return this.name;
+        },
+      });
+      @field numOfPets = contains(StringField, {
+        computeVia(this: Person) {
+          return String(Array.isArray(this.pets) ? this.pets.length : 0);
+        },
+      });
+    }
+
+    await setupAcceptanceTestRealm({
+      mockMatrixUtils,
+      contents: {
+        'person.gts': { Person },
+        'pet.gts': { Pet },
+        'cat.gts': { Cat },
+        'Pet/mango.json': {
+          data: {
+            attributes: { name: 'Mango' },
+            meta: {
+              adoptsFrom: {
+                module: '../pet',
+                name: 'Pet',
+              },
+            },
+          },
+        },
+        'Pet/vangogh.json': {
+          data: {
+            attributes: { name: 'Van Gogh' },
+            meta: {
+              adoptsFrom: {
+                module: '../pet',
+                name: 'Pet',
+              },
+            },
+          },
+        },
+        'Pet/paper.json': {
+          data: {
+            attributes: {
+              name: 'Paper',
+              aliases: ['Satan', "Satan's Mistress"],
+            },
+            meta: {
+              adoptsFrom: {
+                module: '../cat',
+                name: 'Cat',
+              },
+            },
+          },
+        },
+        'Pet/broken.json': {
+          data: {
+            attributes: {
+              name: 'Bad Serialization',
+            },
+            meta: {
+              adoptsFrom: {
+                module: '../cat',
+                // intentionally missing "name" prop
+              },
+            },
+          },
+        },
+        'Pet/molly.json': {
+          data: {
+            attributes: {
+              name: 'Molly',
+              emergencyContacts: [{ phone: '01234' }, { phone: '56789' }],
+            },
+            relationships: {
+              'emergencyContacts.0.contact': {
+                links: {
+                  self: '../Person/jade',
+                },
+              },
+              'emergencyContacts.1.contact': {
+                links: {
+                  self: '../Person/hassan',
+                },
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: '../cat',
+                name: 'Cat',
+              },
+            },
+          },
+        },
+        'Person/hassan.json': {
+          data: {
+            attributes: {
+              name: 'Hassan',
+            },
+            relationships: {
+              'pets.0': {
+                links: {
+                  self: '../Pet/mango',
+                },
+              },
+              'pets.1': {
+                links: {
+                  self: '../Pet/vangogh',
+                },
+              },
+              'pets.2': {
+                links: {
+                  self: '../Pet/paper',
+                },
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: '../person',
+                name: 'Person',
+              },
+            },
+          },
+        },
+        'Person/jade.json': {
+          data: {
+            attributes: {
+              name: 'Jade',
+            },
+            relationships: {
+              friend: {
+                links: {
+                  self: './hassan',
+                },
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: '../person',
+                name: 'Person',
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  hooks.afterEach(function () {
+    delete (globalThis as any).__lazilyLoadLinks;
+  });
+
+  test('can generate serialized instance', async function (assert) {
+    let url = `${testRealmURL}Person/hassan.json`;
+    await visit(`/render/${encodeURIComponent(url)}/meta`);
+    let { value } = await capturePrerenderResult('textContent');
+    let meta: PrerenderMeta = JSON.parse(value);
+    assert.deepEqual(
+      meta.serialized,
+      {
+        data: {
+          type: 'card',
+          id: `${testRealmURL}Person/hassan`,
+          attributes: {
+            name: 'Hassan',
+            title: 'Hassan',
+            cardInfo: {
+              title: null,
+              description: null,
+              thumbnailURL: null,
+              notes: null,
+            },
+            description: null,
+            thumbnailURL: null,
+            numOfPets: '3',
+          },
+          relationships: {
+            'pets.0': {
+              links: {
+                self: '../Pet/mango',
+              },
+              data: {
+                type: 'card',
+                id: '../Pet/mango',
+              },
+            },
+            'pets.1': {
+              links: {
+                self: '../Pet/vangogh',
+              },
+              data: {
+                type: 'card',
+                id: '../Pet/vangogh',
+              },
+            },
+            'pets.2': {
+              links: {
+                self: '../Pet/paper',
+              },
+              data: {
+                type: 'card',
+                id: '../Pet/paper',
+              },
+            },
+          },
+          meta: {
+            adoptsFrom: {
+              module: '../person',
+              name: 'Person',
+            },
+            realmURL: testRealmURL,
+          },
+        },
+      },
+      'serialized instance is correct',
+    );
+  });
+
+  test('can generate display name', async function (assert) {
+    let url = `${testRealmURL}Pet/paper.json`;
+    await visit(`/render/${encodeURIComponent(url)}/meta`);
+    let { value } = await capturePrerenderResult('textContent');
+    let meta: PrerenderMeta = JSON.parse(value);
+    assert.strictEqual(meta.displayName, 'Cat', 'display name is correct');
+  });
+
+  test('can generate type hierarchy', async function (assert) {
+    let url = `${testRealmURL}Pet/paper.json`;
+    await visit(`/render/${encodeURIComponent(url)}/meta`);
+    let { value } = await capturePrerenderResult('textContent');
+    let meta: PrerenderMeta = JSON.parse(value);
+    assert.deepEqual(
+      meta.types,
+      [
+        `${testRealmURL}cat/Cat`,
+        `${testRealmURL}pet/Pet`,
+        `${baseRealm.url}card-api/CardDef`,
+      ],
+      'types are correct',
+    );
+  });
+
+  test('can generate search doc that includes contains field', async function (assert) {
+    let url = `${testRealmURL}Pet/mango.json`;
+    await visit(`/render/${encodeURIComponent(url)}/meta`);
+    let { value } = await capturePrerenderResult('textContent');
+    let meta: PrerenderMeta = JSON.parse(value);
+    assert.deepEqual(
+      meta.searchDoc,
+      {
+        id: `${testRealmURL}Pet/mango`,
+        _cardType: 'Pet',
+        cardInfo: {},
+        name: 'Mango',
+        title: 'Mango',
+      },
+      'search doc is correct',
+    );
+  });
+
+  test('can generate search doc that includes containsMany field', async function (assert) {
+    let url = `${testRealmURL}Pet/paper.json`;
+    await visit(`/render/${encodeURIComponent(url)}/meta`);
+    let { value } = await capturePrerenderResult('textContent');
+    let meta: PrerenderMeta = JSON.parse(value);
+    assert.deepEqual(
+      meta.searchDoc,
+      {
+        id: `${testRealmURL}Pet/paper`,
+        _cardType: 'Cat',
+        cardInfo: {},
+        name: 'Paper',
+        title: 'Paper',
+        aliases: ['Satan', "Satan's Mistress"],
+        emergencyContacts: null,
+      },
+      'search doc is correct',
+    );
+  });
+
+  test('can generate search doc that includes linksTo field', async function (assert) {
+    let url = `${testRealmURL}Person/jade.json`;
+    // note that you need to visit the html route first which will pull on all the linked fields
+    await visit(`/render/${encodeURIComponent(url)}/html/isolated/0`);
+    await visit(`/render/${encodeURIComponent(url)}/meta`);
+    let { value } = await capturePrerenderResult('textContent');
+    let meta: PrerenderMeta = JSON.parse(value);
+    assert.deepEqual(
+      meta.searchDoc,
+      {
+        id: `${testRealmURL}Person/jade`,
+        _cardType: 'Person',
+        cardInfo: {
+          theme: null,
+        },
+        name: 'Jade',
+        title: 'Jade',
+        pets: null,
+        numOfPets: '0',
+        friend: {
+          id: `${testRealmURL}Person/hassan`,
+          cardInfo: {
+            theme: null,
+          },
+          name: 'Hassan',
+          title: 'Hassan',
+          numOfPets: '3',
+          pets: [
+            {
+              id: `${testRealmURL}Pet/mango`,
+            },
+            {
+              id: `${testRealmURL}Pet/vangogh`,
+            },
+            {
+              id: `${testRealmURL}Pet/paper`,
+            },
+          ],
+        },
+      },
+      'search doc is correct',
+    );
+  });
+
+  test('can generate search doc that includes linksToMany field', async function (assert) {
+    let url = `${testRealmURL}Person/hassan.json`;
+    await visit(`/render/${encodeURIComponent(url)}/html/isolated/0`);
+    await visit(`/render/${encodeURIComponent(url)}/meta`);
+    let { value } = await capturePrerenderResult('textContent');
+    let meta: PrerenderMeta = JSON.parse(value);
+    assert.deepEqual(
+      meta.searchDoc,
+      {
+        id: `${testRealmURL}Person/hassan`,
+        _cardType: 'Person',
+        cardInfo: {
+          theme: null,
+        },
+        name: 'Hassan',
+        title: 'Hassan',
+        friend: null,
+        numOfPets: '3',
+        pets: [
+          {
+            id: `${testRealmURL}Pet/mango`,
+            name: 'Mango',
+            title: 'Mango',
+            cardInfo: {
+              theme: null,
+            },
+          },
+          {
+            id: `${testRealmURL}Pet/vangogh`,
+            name: 'Van Gogh',
+            title: 'Van Gogh',
+            cardInfo: {
+              theme: null,
+            },
+          },
+          {
+            id: `${testRealmURL}Pet/paper`,
+            name: 'Paper',
+            title: 'Paper',
+            aliases: ['Satan', "Satan's Mistress"],
+            emergencyContacts: null,
+            cardInfo: {
+              theme: null,
+            },
+          },
+        ],
+      },
+      'search doc is correct',
+    );
+  });
+
+  test('can generate search doc that includes compound field', async function (assert) {
+    let url = `${testRealmURL}Pet/molly.json`;
+    await visit(`/render/${encodeURIComponent(url)}/html/isolated/0`);
+    await visit(`/render/${encodeURIComponent(url)}/meta`);
+    let { value } = await capturePrerenderResult('textContent');
+    let meta: PrerenderMeta = JSON.parse(value);
+    assert.deepEqual(
+      meta.searchDoc,
+      {
+        _cardType: 'Cat',
+        aliases: null,
+        cardInfo: {
+          theme: null,
+        },
+        emergencyContacts: [
+          {
+            phone: '01234',
+            contact: {
+              id: `${testRealmURL}Person/jade`,
+              name: 'Jade',
+              title: 'Jade',
+              numOfPets: '0',
+              pets: null,
+              cardInfo: {
+                theme: null,
+              },
+              friend: {
+                id: `${testRealmURL}Person/hassan`,
+              },
+            },
+          },
+          {
+            phone: '56789',
+            contact: {
+              id: `${testRealmURL}Person/hassan`,
+              name: 'Hassan',
+              title: 'Hassan',
+              cardInfo: {
+                theme: null,
+              },
+              numOfPets: '3',
+              pets: [
+                {
+                  id: `${testRealmURL}Pet/mango`,
+                },
+                {
+                  id: `${testRealmURL}Pet/vangogh`,
+                },
+                {
+                  id: `${testRealmURL}Pet/paper`,
+                },
+              ],
+            },
+          },
+        ],
+        id: `${testRealmURL}Pet/molly`,
+        name: 'Molly',
+        title: 'Molly',
+      },
+      'search doc is correct',
+    );
+  });
+});

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -210,6 +210,21 @@ export interface TestContextWithSave extends TestContext {
   unregisterOnSave: () => void;
 }
 
+export async function capturePrerenderResult(
+  capture: 'textContent' | 'innerHTML' | 'outerHTML',
+  expectedStatus: 'ready' | 'error' = 'ready',
+): Promise<{ status: 'ready' | 'error'; value: string }> {
+  await waitFor(`[data-prerender-status="${expectedStatus}"]`);
+  let element = document.querySelector('[data-prerender]') as HTMLElement;
+  let status = element.dataset.prerenderStatus as 'ready' | 'error';
+  if (status === 'error') {
+    // there is a strange <anonymous> tag that is being appended to the innerHTML that this strips out
+    return { status, value: element.innerHTML!.replace(/}[^}].*$/, '}') };
+  } else {
+    return { status, value: element.children[0][capture]! };
+  }
+}
+
 async function makeRenderer() {
   // This emulates the application.hbs
   await renderComponent(


### PR DESCRIPTION
This PR adds tests for prerender meta generation, various prerender card formats, as well as more robust error handling, so any errors thrown in the model hook of the /render route can be processed (previously only errors thrown _after_ the model hook were handled)