### PR TITLE
Fix serialization for nested polymorphic plural fields

### DIFF
--- a/packages/host/tests/integration/components/serialization-test.gts
+++ b/packages/host/tests/integration/components/serialization-test.gts
@@ -3765,32 +3765,35 @@ module('Integration | serialization', function (hooks) {
       serialized,
       undefined,
     );
-    
+
     if (deserializedArticle instanceof Article) {
-      assert.strictEqual(deserializedArticle.title, 'How to Test Nested Fields');
+      assert.strictEqual(
+        deserializedArticle.title,
+        'How to Test Nested Fields',
+      );
       let { category } = deserializedArticle;
-      
+
       if (category instanceof Category) {
         assert.strictEqual(category.title, 'Programming');
         assert.strictEqual(category.priority, 1);
         assert.strictEqual(category.tags.length, 3, 'correct number of tags');
-        
+
         // Check first tag (PriorityTag)
-        let tag0 = category.tags[0];
+        let tag0 = category.tags[0] as PriorityTag;
         assert.ok(tag0 instanceof PriorityTag, 'first tag is PriorityTag');
         assert.strictEqual(tag0.name, 'javascript');
         assert.strictEqual(tag0.color, 'yellow');
         assert.strictEqual(tag0.priority, 5);
-        
+
         // Check second tag (StatusTag)
-        let tag1 = category.tags[1];
+        let tag1 = category.tags[1] as StatusTag;
         assert.ok(tag1 instanceof StatusTag, 'second tag is StatusTag');
         assert.strictEqual(tag1.name, 'testing');
         assert.strictEqual(tag1.color, 'green');
         assert.strictEqual(tag1.isActive, 1);
-        
+
         // Check third tag (base Tag)
-        let tag2 = category.tags[2];
+        let tag2 = category.tags[2] as Tag;
         assert.ok(tag2 instanceof Tag, 'third tag is base Tag');
         assert.strictEqual(tag2.name, 'serialization');
         assert.strictEqual(tag2.color, 'blue');

--- a/packages/host/tests/test-helper.js
+++ b/packages/host/tests/test-helper.js
@@ -8,6 +8,8 @@ import start from 'ember-exam/test-support/start';
 import { useTestWaiters } from '@cardstack/runtime-common';
 import * as TestWaiters from '@ember/test-waiters';
 
+QUnit.dump.maxDepth = 20;
+
 useTestWaiters(TestWaiters);
 setApplication(Application.create(config.APP));
 

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -4,7 +4,7 @@ import {
   transformResultsToPrerenderedCardsDoc,
   type SingleCardDocument,
 } from './document-types';
-import { type CardResource } from './resource-types';
+import { isMeta, type CardResource } from './resource-types';
 import { RealmPaths, LocalPath, join } from './paths';
 import {
   systemError,
@@ -2659,7 +2659,7 @@ export class Realm {
   ): Promise<void> {
     for (const [fieldName, fieldValue] of Object.entries(fields)) {
       const fieldPath = basePath ? `${basePath}.${fieldName}` : fieldName;
-      if ('fields' in fieldValue) {
+      if (isMeta(fieldValue) && fieldValue?.fields) {
         // if we have nested fields, we need to recurse into them
         await this.buildCustomFieldDefinitions(
           fieldValue.fields,

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -2659,7 +2659,16 @@ export class Realm {
   ): Promise<void> {
     for (const [fieldName, fieldValue] of Object.entries(fields)) {
       const fieldPath = basePath ? `${basePath}.${fieldName}` : fieldName;
-
+      if ('fields' in fieldValue) {
+        // if we have nested fields, we need to recurse into them
+        await this.buildCustomFieldDefinitions(
+          fieldValue.fields,
+          fieldPath,
+          customFieldDefinitions,
+          relativeTo,
+        );
+        continue;
+      }
       if (Array.isArray(fieldValue)) {
         for (const item of fieldValue) {
           if (item.adoptsFrom) {


### PR DESCRIPTION
This issue occurs when we have a card > field in card > plural field in field. 

The behaviour that can be observed is `fileSerialization` will break ie editing a field will not serialize the json properly upon save based upon the subtype. 

However, its not easy to test or see at this point bcos contains-many editor is not rendering these nested fields -- probably needs discussion

