### PR TITLE
Cleanup copy card command code

### DIFF
--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -30,10 +30,15 @@ export class SaveCardInput extends CardDef {
   @field localDir = contains(StringField);
 }
 
-export class CopyCardInput extends CardDef {
+export class CopyCardToRealmInput extends CardDef {
+  @field sourceCard = linksTo(CardDef);
+  @field targetRealm = contains(StringField);
+  @field localDir = contains(StringField);
+}
+
+export class CopyCardToStackInput extends CardDef {
   @field sourceCard = linksTo(CardDef);
   @field targetStackIndex = contains(NumberField);
-  @field targetRealm = contains(StringField);
   @field localDir = contains(StringField);
 }
 

--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -33,9 +33,8 @@ export class SaveCardInput extends CardDef {
 export class CopyCardInput extends CardDef {
   @field sourceCard = linksTo(CardDef);
   @field targetStackIndex = contains(NumberField);
-  @field realm = contains(StringField);
+  @field targetRealm = contains(StringField);
   @field localDir = contains(StringField);
-  @field codeRef = contains(CodeRefField);
 }
 
 export class CopyCardResult extends CardDef {

--- a/packages/host/app/commands/copy-card-to-stack.ts
+++ b/packages/host/app/commands/copy-card-to-stack.ts
@@ -1,0 +1,70 @@
+import { service } from '@ember/service';
+
+import { isCardInstance, realmURL } from '@cardstack/runtime-common';
+
+import type * as BaseCommandModule from 'https://cardstack.com/base/command';
+
+import HostBaseCommand from '../lib/host-base-command';
+
+import CopyCardToRealmCommand from './copy-card-to-realm';
+
+import type CardService from '../services/card-service';
+import type OperatorModeStateService from '../services/operator-mode-state-service';
+import type RealmService from '../services/realm';
+import type StoreService from '../services/store';
+
+export default class CopyCardToStackCommand extends HostBaseCommand<
+  typeof BaseCommandModule.CopyCardToStackInput,
+  typeof BaseCommandModule.CopyCardResult
+> {
+  @service declare private cardService: CardService;
+  @service declare private operatorModeStateService: OperatorModeStateService;
+  @service declare private realm: RealmService;
+  @service declare private store: StoreService;
+
+  description = 'Copy a card to a stack';
+  static actionVerb = 'Copy';
+
+  async getInputType() {
+    let commandModule = await this.loadCommandModule();
+    const { CopyCardToStackInput } = commandModule;
+    return CopyCardToStackInput;
+  }
+
+  requireInputFields = ['sourceCard', 'targetStackIndex'];
+
+  protected async run(
+    input: BaseCommandModule.CopyCardToStackInput,
+  ): Promise<BaseCommandModule.CopyCardResult> {
+    let realmToCopyTo = await this.determineTargetRealm(input.targetStackIndex);
+    if (!realmToCopyTo) {
+      throw new Error('Cannot determine target realm to copy card to');
+    }
+    let copyCardToRealmCommand = new CopyCardToRealmCommand(
+      this.commandContext,
+    );
+    return await copyCardToRealmCommand.execute({
+      sourceCard: input.sourceCard,
+      targetRealm: realmToCopyTo,
+    });
+  }
+
+  private async determineTargetRealm(targetStackIndex: number) {
+    let item =
+      this.operatorModeStateService.topMostStackItems()[targetStackIndex];
+    if (!item) {
+      throw new Error('Cannot find topmost card in target stack');
+    }
+    if (!item.id) {
+      throw new Error('Topmost item in target stack has no id');
+    }
+    let topCard = await this.store.get(item.id);
+    if (isCardInstance(topCard)) {
+      let url = topCard[realmURL];
+      if (url) {
+        return url.href;
+      }
+    }
+    return;
+  }
+}

--- a/packages/host/app/commands/copy-card-to-stack.ts
+++ b/packages/host/app/commands/copy-card-to-stack.ts
@@ -6,7 +6,7 @@ import type * as BaseCommandModule from 'https://cardstack.com/base/command';
 
 import HostBaseCommand from '../lib/host-base-command';
 
-import CopyCardToRealmCommand from './copy-card-to-realm';
+import CopyCardToRealmCommand from './copy-card';
 
 import type CardService from '../services/card-service';
 import type OperatorModeStateService from '../services/operator-mode-state-service';

--- a/packages/host/app/commands/copy-card.ts
+++ b/packages/host/app/commands/copy-card.ts
@@ -1,22 +1,18 @@
 import { service } from '@ember/service';
 
-import { isCardInstance, realmURL } from '@cardstack/runtime-common';
-
 import type * as BaseCommandModule from 'https://cardstack.com/base/command';
 
 import HostBaseCommand from '../lib/host-base-command';
 
 import type CardService from '../services/card-service';
-import type OperatorModeStateService from '../services/operator-mode-state-service';
 import type RealmService from '../services/realm';
 import type StoreService from '../services/store';
 
-export default class CopyCardCommand extends HostBaseCommand<
-  typeof BaseCommandModule.CopyCardInput,
+export default class CopyCardToRealmCommand extends HostBaseCommand<
+  typeof BaseCommandModule.CopyCardToRealmInput,
   typeof BaseCommandModule.CopyCardResult
 > {
   @service declare private cardService: CardService;
-  @service declare private operatorModeStateService: OperatorModeStateService;
   @service declare private realm: RealmService;
   @service declare private store: StoreService;
 
@@ -25,29 +21,28 @@ export default class CopyCardCommand extends HostBaseCommand<
 
   async getInputType() {
     let commandModule = await this.loadCommandModule();
-    const { CopyCardInput } = commandModule;
-    return CopyCardInput;
+    const { CopyCardToRealmInput } = commandModule;
+    return CopyCardToRealmInput;
   }
 
-  requireInputFields = ['sourceCard'];
+  requireInputFields = ['sourceCard', 'targetRealm'];
 
   // Instances that are created via this method are eligible for garbage
   // collection--meaning that it will be detached from the store. This means you
   // MUST consume the instance IMMEDIATELY! it should not live in the state of
   // the consumer.
   protected async run(
-    input: BaseCommandModule.CopyCardInput,
+    input: BaseCommandModule.CopyCardToRealmInput,
   ): Promise<BaseCommandModule.CopyCardResult> {
-    let realmToCopyTo = await this.determineTargetRealm(input);
-    if (!realmToCopyTo) {
-      throw new Error('Cannot determine target realm to copy card to');
+    if (!this.realm.canWrite(input.targetRealm)) {
+      throw new Error(`Do not have write permissions to ${input.targetRealm}`);
     }
     let doc = await this.cardService.serializeCard(input.sourceCard, {
       useAbsoluteURL: true,
     });
     delete doc.data.id;
     let newCardId = await this.store.create(doc, {
-      realm: realmToCopyTo,
+      realm: input.targetRealm,
       localDir: input.localDir,
     });
     if (typeof newCardId !== 'string') {
@@ -62,37 +57,5 @@ export default class CopyCardCommand extends HostBaseCommand<
     let commandModule = await this.loadCommandModule();
     const { CopyCardResult } = commandModule;
     return new CopyCardResult({ newCardId });
-  }
-
-  private async determineTargetRealm({
-    targetStackIndex,
-    targetRealm,
-  }: BaseCommandModule.CopyCardInput) {
-    if (targetRealm == undefined && targetStackIndex == undefined) {
-      throw new Error(
-        'Both targetStackIndex and targetRealm are set; only one should be set -- using targetRealm',
-      );
-    }
-    if (targetRealm) {
-      return targetRealm;
-    }
-    // use existing card in stack to determine realm url,
-    let item =
-      this.operatorModeStateService.topMostStackItems()[targetStackIndex];
-    if (!item) {
-      throw new Error('Cannot find topmost card in target stack');
-    }
-    if (!item.id) {
-      throw new Error('Topmost item in target stack has no id');
-    }
-    let topCard = await this.store.get(item.id);
-    if (isCardInstance(topCard)) {
-      let url = topCard[realmURL];
-      // open card might be from a realm in which we don't have write permissions
-      if (url && this.realm.canWrite(url.href)) {
-        return url.href;
-      }
-    }
-    return;
   }
 }

--- a/packages/host/app/commands/index.ts
+++ b/packages/host/app/commands/index.ts
@@ -7,7 +7,8 @@ import * as AddSkillsToRoomCommandModule from './add-skills-to-room';
 import * as UseAiAssistantCommandModule from './ai-assistant';
 import * as ApplySearchReplaceBlockCommandModule from './apply-search-replace-block';
 import * as AskAiCommandModule from './ask-ai';
-import * as CopyCardCommandModule from './copy-card';
+import * as CopyCardToRealmModule from './copy-card-to-realm';
+import * as CopyCardToStackCommandModule from './copy-card-to-stack';
 import * as CopySourceCommandModule from './copy-source';
 import * as CreateAIAssistantRoomCommandModule from './create-ai-assistant-room';
 import * as CreateSpecCommandModule from './create-specs';
@@ -61,8 +62,12 @@ export function shimHostCommands(virtualNetwork: VirtualNetwork) {
     ApplySearchReplaceBlockCommandModule,
   );
   virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/copy-card',
-    CopyCardCommandModule,
+    '@cardstack/boxel-host/commands/copy-card-to-realm',
+    CopyCardToRealmModule,
+  );
+  virtualNetwork.shimModule(
+    '@cardstack/boxel-host/commands/copy-card-to-stack',
+    CopyCardToStackCommandModule,
   );
   virtualNetwork.shimModule(
     '@cardstack/boxel-host/commands/copy-source',
@@ -215,6 +220,7 @@ export const HostCommandClasses: (typeof HostBaseCommand<any, any>)[] = [
   AddSkillsToRoomCommandModule.default,
   AskAiCommandModule.default,
   ApplySearchReplaceBlockCommandModule.default,
+  CopyCardToStackCommandModule.default,
   CreateAIAssistantRoomCommandModule.default,
   CreateSpecCommandModule.default,
   GetCardCommandModule.default,

--- a/packages/host/app/commands/index.ts
+++ b/packages/host/app/commands/index.ts
@@ -7,7 +7,7 @@ import * as AddSkillsToRoomCommandModule from './add-skills-to-room';
 import * as UseAiAssistantCommandModule from './ai-assistant';
 import * as ApplySearchReplaceBlockCommandModule from './apply-search-replace-block';
 import * as AskAiCommandModule from './ask-ai';
-import * as CopyCardToRealmModule from './copy-card-to-realm';
+import * as CopyCardToRealmModule from './copy-card';
 import * as CopyCardToStackCommandModule from './copy-card-to-stack';
 import * as CopySourceCommandModule from './copy-source';
 import * as CreateAIAssistantRoomCommandModule from './create-ai-assistant-room';
@@ -62,7 +62,7 @@ export function shimHostCommands(virtualNetwork: VirtualNetwork) {
     ApplySearchReplaceBlockCommandModule,
   );
   virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/copy-card-to-realm',
+    '@cardstack/boxel-host/commands/copy-card',
     CopyCardToRealmModule,
   );
   virtualNetwork.shimModule(

--- a/packages/host/app/commands/listing-use.ts
+++ b/packages/host/app/commands/listing-use.ts
@@ -15,7 +15,7 @@ import type { Skill } from 'https://cardstack.com/base/skill';
 
 import HostBaseCommand from '../lib/host-base-command';
 
-import CopyCardCommand from './copy-card';
+import CopyCardToRealmCommand from './copy-card-to-realm';
 import SaveCardCommand from './save-card';
 
 import type RealmServerService from '../services/realm-server';
@@ -83,7 +83,7 @@ export default class ListingUseCommand extends HostBaseCommand<
         (example) => example,
       );
       for (const card of sourceCards) {
-        await new CopyCardCommand(this.commandContext).execute({
+        await new CopyCardToRealmCommand(this.commandContext).execute({
           sourceCard: card,
           targetRealm: realmUrl,
           localDir,
@@ -94,7 +94,7 @@ export default class ListingUseCommand extends HostBaseCommand<
     if ('skills' in listing && Array.isArray(listing.skills)) {
       await Promise.all(
         listing.skills.map((skill: Skill) =>
-          new CopyCardCommand(this.commandContext).execute({
+          new CopyCardToRealmCommand(this.commandContext).execute({
             sourceCard: skill,
             targetRealm: realmUrl,
             localDir,

--- a/packages/host/app/commands/listing-use.ts
+++ b/packages/host/app/commands/listing-use.ts
@@ -85,7 +85,7 @@ export default class ListingUseCommand extends HostBaseCommand<
       for (const card of sourceCards) {
         await new CopyCardCommand(this.commandContext).execute({
           sourceCard: card,
-          realm: realmUrl,
+          targetRealm: realmUrl,
           localDir,
         });
       }
@@ -96,7 +96,7 @@ export default class ListingUseCommand extends HostBaseCommand<
         listing.skills.map((skill: Skill) =>
           new CopyCardCommand(this.commandContext).execute({
             sourceCard: skill,
-            realm: realmUrl,
+            targetRealm: realmUrl,
             localDir,
           }),
         ),

--- a/packages/host/app/commands/listing-use.ts
+++ b/packages/host/app/commands/listing-use.ts
@@ -15,7 +15,7 @@ import type { Skill } from 'https://cardstack.com/base/skill';
 
 import HostBaseCommand from '../lib/host-base-command';
 
-import CopyCardToRealmCommand from './copy-card-to-realm';
+import CopyCardToRealmCommand from './copy-card';
 import SaveCardCommand from './save-card';
 
 import type RealmServerService from '../services/realm-server';

--- a/packages/host/app/components/matrix/room-message-command.gts
+++ b/packages/host/app/components/matrix/room-message-command.gts
@@ -24,7 +24,7 @@ import { cardTypeDisplayName, cardTypeIcon } from '@cardstack/runtime-common';
 
 import type { CommandRequest } from '@cardstack/runtime-common/commands';
 
-import CopyCardToRealmCommand from '@cardstack/host/commands/copy-card-to-realm';
+import CopyCardToRealmCommand from '@cardstack/host/commands/copy-card';
 import ShowCardCommand from '@cardstack/host/commands/show-card';
 import MessageCommand from '@cardstack/host/lib/matrix-classes/message-command';
 

--- a/packages/host/app/components/matrix/room-message-command.gts
+++ b/packages/host/app/components/matrix/room-message-command.gts
@@ -33,6 +33,7 @@ import type CommandService from '@cardstack/host/services/command-service';
 import type MatrixService from '@cardstack/host/services/matrix-service';
 
 import { type MonacoSDK } from '@cardstack/host/services/monaco-service';
+import type RealmService from '@cardstack/host/services/realm';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 
@@ -59,6 +60,7 @@ interface Signature {
 export default class RoomMessageCommand extends Component<Signature> {
   @service private declare commandService: CommandService;
   @service private declare matrixService: MatrixService;
+  @service private declare realm: RealmService;
 
   private get previewCommandCode() {
     let { name, arguments: payload } = this.args.messageCommand;
@@ -139,8 +141,13 @@ export default class RoomMessageCommand extends Component<Signature> {
 
   @action async copyToWorkspace() {
     let { commandContext } = this.commandService;
+    let defaultWritableRealm = this.realm.defaultWritableRealm;
+    if (!defaultWritableRealm) {
+      throw new Error('No writable realm available to copy card to');
+    }
     const { newCardId } = await new CopyCardCommand(commandContext).execute({
       sourceCard: this.commandResultCard.card as CardDef,
+      targetRealm: defaultWritableRealm.path,
     });
 
     let showCardCommand = new ShowCardCommand(commandContext);

--- a/packages/host/app/components/matrix/room-message-command.gts
+++ b/packages/host/app/components/matrix/room-message-command.gts
@@ -24,7 +24,7 @@ import { cardTypeDisplayName, cardTypeIcon } from '@cardstack/runtime-common';
 
 import type { CommandRequest } from '@cardstack/runtime-common/commands';
 
-import CopyCardCommand from '@cardstack/host/commands/copy-card';
+import CopyCardToRealmCommand from '@cardstack/host/commands/copy-card-to-realm';
 import ShowCardCommand from '@cardstack/host/commands/show-card';
 import MessageCommand from '@cardstack/host/lib/matrix-classes/message-command';
 
@@ -145,7 +145,9 @@ export default class RoomMessageCommand extends Component<Signature> {
     if (!defaultWritableRealm) {
       throw new Error('No writable realm available to copy card to');
     }
-    const { newCardId } = await new CopyCardCommand(commandContext).execute({
+    const { newCardId } = await new CopyCardToRealmCommand(
+      commandContext,
+    ).execute({
       sourceCard: this.commandResultCard.card as CardDef,
       targetRealm: defaultWritableRealm.path,
     });

--- a/packages/host/app/components/operator-mode/copy-button.gts
+++ b/packages/host/app/components/operator-mode/copy-button.gts
@@ -48,7 +48,7 @@ export default class CopyButton extends Component<Signature> {
       {{#if this.topMostCardCollection.isLoaded}}
         {{#if this.state}}
           <BoxelButton
-            class='copy-button'
+            class='copy-button {{if @isCopying "copying"}}'
             @kind={{this.buttonKind}}
             @loading={{@isCopying}}
             @size='tall'
@@ -107,6 +107,9 @@ export default class CopyButton extends Component<Signature> {
       }
       .arrow-icon {
         --icon-color: var(--boxel-dark);
+      }
+      .copying {
+        color: var(--boxel-light);
       }
     </style>
   </template>

--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -47,7 +47,7 @@ import {
 } from '@cardstack/runtime-common';
 import { codeRefWithAbsoluteURL } from '@cardstack/runtime-common/code-ref';
 
-import CopyCardToRealmCommand from '@cardstack/host/commands/copy-card-to-realm';
+import CopyCardToRealmCommand from '@cardstack/host/commands/copy-card';
 
 import type RealmService from '@cardstack/host/services/realm';
 

--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -47,7 +47,7 @@ import {
 } from '@cardstack/runtime-common';
 import { codeRefWithAbsoluteURL } from '@cardstack/runtime-common/code-ref';
 
-import CopyCardCommand from '@cardstack/host/commands/copy-card';
+import CopyCardToRealmCommand from '@cardstack/host/commands/copy-card-to-realm';
 
 import type RealmService from '@cardstack/host/services/realm';
 
@@ -751,7 +751,7 @@ export class ${className} extends ${exportName} {
         `Cannot duplicateCardInstance where where is no selected realm URL`,
       );
     }
-    let { newCardId } = await new CopyCardCommand(
+    let { newCardId } = await new CopyCardToRealmCommand(
       this.commandService.commandContext,
     ).execute({
       sourceCard: this.currentRequest.sourceInstance,

--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -755,7 +755,7 @@ export class ${className} extends ${exportName} {
       this.commandService.commandContext,
     ).execute({
       sourceCard: this.currentRequest.sourceInstance,
-      realm: this.selectedRealmURL.href,
+      targetRealm: this.selectedRealmURL.href,
     });
     this.currentRequest.newFileDeferred.fulfill(new URL(`${newCardId}.json`));
   });

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -40,7 +40,6 @@ import {
   CardError,
   loadCardDef,
   localId as localIdSymbol,
-  realmURL as realmURLSymbol,
   specRef,
   type getCard,
   type getCards,
@@ -54,7 +53,7 @@ import {
   type Filter,
 } from '@cardstack/runtime-common';
 
-import CopyCardCommand from '@cardstack/host/commands/copy-card';
+import CopyCardToStackCommand from '@cardstack/host/commands/copy-card-to-stack';
 
 import { StackItem } from '@cardstack/host/lib/stack-item';
 
@@ -349,17 +348,15 @@ export default class InteractSubmode extends Component {
             `destination index card ${destinationIndexCardUrl} is not a card`,
           );
         }
-        let destinationRealmURL = destinationIndexCard[realmURLSymbol];
         sources.sort((a, b) => a.title.localeCompare(b.title));
         let scrollToCardId: string | undefined;
         let newCardId: string | undefined;
         let targetStackIndex = destinationItem.stackIndex;
         for (let [index, card] of sources.entries()) {
-          ({ newCardId } = await new CopyCardCommand(
+          ({ newCardId } = await new CopyCardToStackCommand(
             this.commandService.commandContext,
           ).execute({
             sourceCard: card,
-            targetRealm: destinationRealmURL?.href,
             targetStackIndex,
           }));
           if (index === 0) {

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -350,19 +350,17 @@ export default class InteractSubmode extends Component {
           );
         }
         let destinationRealmURL = destinationIndexCard[realmURLSymbol];
-        if (!destinationRealmURL) {
-          throw new Error('Could not determine the copy destination realm');
-        }
-        let realmURL = destinationRealmURL;
         sources.sort((a, b) => a.title.localeCompare(b.title));
         let scrollToCardId: string | undefined;
         let newCardId: string | undefined;
+        let targetStackIndex = destinationItem.stackIndex;
         for (let [index, card] of sources.entries()) {
           ({ newCardId } = await new CopyCardCommand(
             this.commandService.commandContext,
           ).execute({
             sourceCard: card,
-            realm: realmURL.href,
+            targetRealm: destinationRealmURL?.href,
+            targetStackIndex,
           }));
           if (index === 0) {
             scrollToCardId = newCardId; // we scroll to the first card lexically by title

--- a/packages/host/tests/integration/commands/copy-card-test.gts
+++ b/packages/host/tests/integration/commands/copy-card-test.gts
@@ -1,0 +1,170 @@
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import { realmURL as realmURLSymbol } from '@cardstack/runtime-common';
+
+import CopyCardCommand from '@cardstack/host/commands/copy-card';
+
+import { CardDef } from 'https://cardstack.com/base/card-api';
+
+import {
+  setupIntegrationTestRealm,
+  setupLocalIndexing,
+  testRealmURL,
+} from '../../helpers';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupRenderingTest } from '../../helpers/setup';
+
+const testRealm2URL = 'http://test-realm/test2/';
+
+module('Integration | commands | copy-card', function (hooks) {
+  setupRenderingTest(hooks);
+  setupLocalIndexing(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [testRealmURL, testRealm2URL],
+  });
+
+  hooks.beforeEach(async function () {
+    await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      realmURL: testRealmURL,
+      contents: {
+        'pet.gts': `
+          import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
+          import StringField from "https://cardstack.com/base/string";
+          export class Pet extends CardDef {
+            static displayName = 'Pet';
+            @field firstName = contains(StringField);
+          }
+        `,
+        'Pet/mango.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              firstName: 'Mango',
+            },
+            meta: {
+              adoptsFrom: {
+                module: '../pet',
+                name: 'Pet',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      realmURL: testRealm2URL,
+      contents: {
+        'index.json': {
+          data: {
+            type: 'card',
+            meta: {
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/cards-grid',
+                name: 'CardsGrid',
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  test('copies card to target realm', async function (assert) {
+    let commandService = getService('command-service');
+    let copyCardCommand = new CopyCardCommand(commandService.commandContext);
+
+    let sourceCardUrl = `${testRealmURL}Pet/mango`;
+    let targetRealm = testRealm2URL;
+
+    // Get the source card using the store
+    let store = getService('store');
+    let sourceCard = (await store.get(sourceCardUrl)) as CardDef;
+    assert.ok(sourceCard, 'source card exists');
+    assert.strictEqual(
+      sourceCard[realmURLSymbol]?.href,
+      testRealmURL,
+      'source card is from expected realm',
+    );
+
+    let result = await copyCardCommand.execute({
+      sourceCard,
+      targetRealm,
+    });
+
+    assert.ok(result.newCardId, 'new card URL is returned');
+    assert.true(
+      result.newCardId.startsWith(targetRealm),
+      'new card is created in target realm',
+    );
+    assert.notEqual(
+      result.newCardId,
+      sourceCardUrl,
+      'new card has different URL than source',
+    );
+
+    // Verify the card was actually copied by getting it from the store
+    let copiedCard = (await store.get(result.newCardId)) as CardDef;
+    assert.ok(copiedCard, 'copied card exists in store');
+    assert.strictEqual(
+      copiedCard[realmURLSymbol]?.href,
+      targetRealm,
+      'copied card is in target realm',
+    );
+  });
+
+  test('errors when stackIndex is provided but does not exist', async function (assert) {
+    let commandService = getService('command-service');
+    let copyCardCommand = new CopyCardCommand(commandService.commandContext);
+
+    let sourceCardUrl = `${testRealmURL}Pet/mango`;
+    let targetStackIndex = 99; // Non-existent stack index
+
+    // Get the source card using the store
+    let store = getService('store');
+    let sourceCard = (await store.get(sourceCardUrl)) as CardDef;
+
+    try {
+      await copyCardCommand.execute({
+        sourceCard,
+        targetStackIndex,
+      });
+      assert.ok(false, 'should have thrown an error');
+    } catch (error: any) {
+      assert.ok(error instanceof Error, 'throws an error');
+      assert.true(
+        error.message.includes('Cannot find topmost card in target stack'),
+      );
+    }
+  });
+
+  test('errors when neither stackIndex nor targetRealm is provided', async function (assert) {
+    let commandService = getService('command-service');
+    let copyCardCommand = new CopyCardCommand(commandService.commandContext);
+
+    let sourceCardUrl = `${testRealmURL}Pet/mango`;
+
+    // Get the source card using the store
+    let store = getService('store');
+    let sourceCard = (await store.get(sourceCardUrl)) as CardDef;
+
+    try {
+      await copyCardCommand.execute({
+        sourceCard,
+      });
+      assert.ok(false, 'should have thrown an error');
+    } catch (error: any) {
+      assert.ok(error instanceof Error, 'throws an error');
+      assert.true(
+        error.message.includes(
+          'Both targetStackIndex and targetRealm are set; only one should be set -- using targetRealm',
+        ),
+      );
+    }
+  });
+});

--- a/packages/host/tests/integration/commands/copy-card-test.gts
+++ b/packages/host/tests/integration/commands/copy-card-test.gts
@@ -3,7 +3,9 @@ import { module, test } from 'qunit';
 
 import { realmURL as realmURLSymbol } from '@cardstack/runtime-common';
 
-import CopyCardCommand from '@cardstack/host/commands/copy-card';
+import CopyCardToRealmCommand from '@cardstack/host/commands/copy-card';
+import CopyCardToStackCommand from '@cardstack/host/commands/copy-card-to-stack';
+import { StackItem } from '@cardstack/host/lib/stack-item';
 
 import { CardDef } from 'https://cardstack.com/base/card-api';
 
@@ -71,100 +73,193 @@ module('Integration | commands | copy-card', function (hooks) {
             },
           },
         },
+        'Pet/fluffy.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              firstName: 'Fluffy',
+            },
+            meta: {
+              adoptsFrom: {
+                module: `${testRealmURL}pet`,
+                name: 'Pet',
+              },
+            },
+          },
+        },
       },
     });
+
+    // Ensure realms are logged in with write permissions
+    let realmService = getService('realm');
+    await realmService.login(testRealmURL);
+    await realmService.login(testRealm2URL);
   });
 
-  test('copies card to target realm', async function (assert) {
-    let commandService = getService('command-service');
-    let copyCardCommand = new CopyCardCommand(commandService.commandContext);
+  module('CopyCardToRealmCommand', function () {
+    test('copies card to target realm', async function (assert) {
+      let commandService = getService('command-service');
+      let copyCardCommand = new CopyCardToRealmCommand(
+        commandService.commandContext,
+      );
 
-    let sourceCardUrl = `${testRealmURL}Pet/mango`;
-    let targetRealm = testRealm2URL;
+      let sourceCardUrl = `${testRealmURL}Pet/mango`;
+      let targetRealm = testRealm2URL;
 
-    // Get the source card using the store
-    let store = getService('store');
-    let sourceCard = (await store.get(sourceCardUrl)) as CardDef;
-    assert.ok(sourceCard, 'source card exists');
-    assert.strictEqual(
-      sourceCard[realmURLSymbol]?.href,
-      testRealmURL,
-      'source card is from expected realm',
-    );
+      // Get the source card using the store
+      let store = getService('store');
+      let sourceCard = (await store.get(sourceCardUrl)) as CardDef;
+      assert.ok(sourceCard, 'source card exists');
+      assert.strictEqual(
+        sourceCard[realmURLSymbol]?.href,
+        testRealmURL,
+        'source card is from expected realm',
+      );
 
-    let result = await copyCardCommand.execute({
-      sourceCard,
-      targetRealm,
+      let result = await copyCardCommand.execute({
+        sourceCard,
+        targetRealm,
+      });
+
+      assert.ok(result.newCardId, 'new card URL is returned');
+      assert.true(
+        result.newCardId.startsWith(targetRealm),
+        'new card is created in target realm',
+      );
+      assert.notEqual(
+        result.newCardId,
+        sourceCardUrl,
+        'new card has different URL than source',
+      );
+
+      // Verify the card was actually copied by getting it from the store
+      let copiedCard = (await store.get(result.newCardId)) as CardDef;
+      assert.ok(copiedCard, 'copied card exists in store');
+      assert.strictEqual(
+        copiedCard[realmURLSymbol]?.href,
+        targetRealm,
+        'copied card is in target realm',
+      );
     });
 
-    assert.ok(result.newCardId, 'new card URL is returned');
-    assert.true(
-      result.newCardId.startsWith(targetRealm),
-      'new card is created in target realm',
-    );
-    assert.notEqual(
-      result.newCardId,
-      sourceCardUrl,
-      'new card has different URL than source',
-    );
+    test('errors when user does not have write permissions to target realm', async function (assert) {
+      let commandService = getService('command-service');
+      let copyCardCommand = new CopyCardToRealmCommand(
+        commandService.commandContext,
+      );
 
-    // Verify the card was actually copied by getting it from the store
-    let copiedCard = (await store.get(result.newCardId)) as CardDef;
-    assert.ok(copiedCard, 'copied card exists in store');
-    assert.strictEqual(
-      copiedCard[realmURLSymbol]?.href,
-      targetRealm,
-      'copied card is in target realm',
-    );
+      let sourceCardUrl = `${testRealmURL}Pet/mango`;
+      let targetRealm = testRealm2URL;
+
+      // Log out from all realms, then log back into source realm only
+      let realmService = getService('realm');
+      realmService.logout();
+      await realmService.login(testRealmURL);
+
+      // Get the source card using the store
+      let store = getService('store');
+      let sourceCard = (await store.get(sourceCardUrl)) as CardDef;
+      assert.ok(sourceCard, 'source card exists');
+
+      try {
+        await copyCardCommand.execute({
+          sourceCard,
+          targetRealm,
+        });
+        assert.ok(false, 'should have thrown an error');
+      } catch (error: any) {
+        assert.ok(error instanceof Error, 'throws an error');
+        assert.strictEqual(
+          error.message,
+          `Do not have write permissions to ${targetRealm}`,
+          'error message indicates write permission issue',
+        );
+      }
+    });
   });
 
-  test('errors when stackIndex is provided but does not exist', async function (assert) {
-    let commandService = getService('command-service');
-    let copyCardCommand = new CopyCardCommand(commandService.commandContext);
+  module('CopyCardToStackCommand', function () {
+    test('copies card to stack when valid targetStackIndex is provided', async function (assert) {
+      let commandService = getService('command-service');
+      let copyCardToStackCommand = new CopyCardToStackCommand(
+        commandService.commandContext,
+      );
 
-    let sourceCardUrl = `${testRealmURL}Pet/mango`;
-    let targetStackIndex = 99; // Non-existent stack index
+      let sourceCardUrl = `${testRealmURL}Pet/mango`;
+      let targetStackIndex = 0;
+      let targetCardUrl = `${testRealm2URL}Pet/fluffy`;
 
-    // Get the source card using the store
-    let store = getService('store');
-    let sourceCard = (await store.get(sourceCardUrl)) as CardDef;
+      // Mock the operator mode state service to return a card in the target stack
+      let operatorModeStateService = getService('operator-mode-state-service');
+      operatorModeStateService.topMostStackItems = () => [
+        new StackItem({
+          id: targetCardUrl,
+          format: 'isolated',
+          stackIndex: 0,
+        }),
+      ];
 
-    try {
-      await copyCardCommand.execute({
+      // Get the source card using the store
+      let store = getService('store');
+      let sourceCard = (await store.get(sourceCardUrl)) as CardDef;
+      assert.ok(sourceCard, 'source card exists');
+      assert.strictEqual(
+        sourceCard[realmURLSymbol]?.href,
+        testRealmURL,
+        'source card is from expected realm',
+      );
+
+      let result = await copyCardToStackCommand.execute({
         sourceCard,
         targetStackIndex,
       });
-      assert.ok(false, 'should have thrown an error');
-    } catch (error: any) {
-      assert.ok(error instanceof Error, 'throws an error');
+
+      assert.ok(result.newCardId, 'new card URL is returned');
       assert.true(
-        error.message.includes('Cannot find topmost card in target stack'),
+        result.newCardId.startsWith(testRealm2URL),
+        'new card is created in target realm',
       );
-    }
-  });
-
-  test('errors when neither stackIndex nor targetRealm is provided', async function (assert) {
-    let commandService = getService('command-service');
-    let copyCardCommand = new CopyCardCommand(commandService.commandContext);
-
-    let sourceCardUrl = `${testRealmURL}Pet/mango`;
-
-    // Get the source card using the store
-    let store = getService('store');
-    let sourceCard = (await store.get(sourceCardUrl)) as CardDef;
-
-    try {
-      await copyCardCommand.execute({
-        sourceCard,
-      });
-      assert.ok(false, 'should have thrown an error');
-    } catch (error: any) {
-      assert.ok(error instanceof Error, 'throws an error');
-      assert.true(
-        error.message.includes(
-          'Both targetStackIndex and targetRealm are set; only one should be set -- using targetRealm',
-        ),
+      assert.notEqual(
+        result.newCardId,
+        sourceCardUrl,
+        'new card has different URL than source',
       );
-    }
+
+      // Verify the card was actually copied by getting it from the store
+      let copiedCard = (await store.get(result.newCardId)) as CardDef;
+      assert.ok(copiedCard, 'copied card exists in store');
+      assert.strictEqual(
+        copiedCard[realmURLSymbol]?.href,
+        testRealm2URL,
+        'copied card is in target realm',
+      );
+    });
+    test('errors when targetStackIndex does not exist', async function (assert) {
+      let commandService = getService('command-service');
+      let copyCardToStackCommand = new CopyCardToStackCommand(
+        commandService.commandContext,
+      );
+
+      let sourceCardUrl = `${testRealmURL}Pet/mango`;
+      let targetStackIndex = 99; // Non-existent stack index
+
+      // Get the source card using the store
+      let store = getService('store');
+      let sourceCard = (await store.get(sourceCardUrl)) as CardDef;
+
+      try {
+        await copyCardToStackCommand.execute({
+          sourceCard,
+          targetStackIndex,
+        });
+        assert.ok(false, 'should have thrown an error');
+      } catch (error: any) {
+        assert.ok(error instanceof Error, 'throws an error');
+        assert.true(
+          error.message.includes('Cannot find topmost card in target stack'),
+          'error message mentions missing stack',
+        );
+      }
+    });
   });
 });


### PR DESCRIPTION
- This cleans up the command copy-card api that previously was using an additional arg (code ref) that made this api confusing to use 
- this pr also revive some bulk copy functionality that was not working at all. Now at least if you copy from a public realm u have permissions to, the copy works as expected (but I think in the past there were still some quirks about permissions of copying from a private realm which I did not handle) 
