### PR TITLE
host: Add handling for host mode root request

### DIFF
--- a/packages/host/app/routes/index.ts
+++ b/packages/host/app/routes/index.ts
@@ -23,7 +23,7 @@ import type StoreService from '../services/store';
 
 const { hostsOwnAssets } = ENV;
 
-export default class Index extends Route<void> {
+export default class Index extends Route {
   queryParams = {
     operatorModeState: {
       refreshModel: true, // Enabled so that back-forward navigation works in operator mode
@@ -55,7 +55,7 @@ export default class Index extends Route<void> {
     cardPath?: string;
     path: string;
     operatorModeState: string;
-  }): Promise<void | ReturnType<typeof CardService.prototype.get>> {
+  }) {
     if (this.hostModeService.isActive) {
       // Duplicated from routes/card
       await this.realmServer.ready;
@@ -136,6 +136,8 @@ export default class Index extends Route<void> {
       await this.operatorModeStateService.restore(
         operatorModeStateObject || { stacks: [] },
       );
+
+      return;
     }
   }
 

--- a/packages/host/app/services/host-mode-service.ts
+++ b/packages/host/app/services/host-mode-service.ts
@@ -33,7 +33,7 @@ export default class HostModeService extends Service {
       let currentHost = window.location.hostname;
 
       return (
-        currentHost.endsWith(`.${realmServerDomain}`) &&
+        currentHost.endsWith(realmServerDomain) &&
         // Using a submdomain of localhost indicates host mode
         !currentHost.endsWith('.localhost')
       );

--- a/packages/host/app/templates/card.gts
+++ b/packages/host/app/templates/card.gts
@@ -32,13 +32,13 @@ import type { CardContext, CardDef } from 'https://cardstack.com/base/card-api';
 
 type HostModeCardContext = Omit<CardContext, 'prerenderedCardSearchComponent'>;
 
-interface HostModeComponentSignature {
+export interface HostModeComponentSignature {
   Args: {
     model: CardDef | CardErrorJSONAPI;
   };
 }
 
-class HostModeComponent extends Component<HostModeComponentSignature> {
+export class HostModeComponent extends Component<HostModeComponentSignature> {
   @consume(GetCardContextName) private declare getCard: getCard;
   @consume(GetCardsContextName) private declare getCards: getCards;
   @consume(GetCardCollectionContextName)

--- a/packages/host/app/templates/index.gts
+++ b/packages/host/app/templates/index.gts
@@ -6,12 +6,12 @@ import { pageTitle } from 'ember-page-title';
 
 import RouteTemplate from 'ember-route-template';
 
+import { HostModeComponent, HostModeComponentSignature } from './card';
+
 import OperatorModeContainer from '../components/operator-mode/container';
 
 import type HostModeService from '../services/host-mode-service';
 import type OperatorModeStateService from '../services/operator-mode-state-service';
-
-import { HostModeComponent, HostModeComponentSignature } from './card';
 
 class IndexComponent extends Component<HostModeComponentSignature> {
   @service private declare hostModeService: HostModeService;

--- a/packages/host/app/templates/index.gts
+++ b/packages/host/app/templates/index.gts
@@ -6,9 +6,9 @@ import { pageTitle } from 'ember-page-title';
 
 import RouteTemplate from 'ember-route-template';
 
-import { HostModeComponent, HostModeComponentSignature } from './card';
-
 import OperatorModeContainer from '../components/operator-mode/container';
+
+import { HostModeComponent, HostModeComponentSignature } from './card';
 
 import type HostModeService from '../services/host-mode-service';
 import type OperatorModeStateService from '../services/operator-mode-state-service';

--- a/packages/host/app/templates/index.gts
+++ b/packages/host/app/templates/index.gts
@@ -8,9 +8,13 @@ import RouteTemplate from 'ember-route-template';
 
 import OperatorModeContainer from '../components/operator-mode/container';
 
+import type HostModeService from '../services/host-mode-service';
 import type OperatorModeStateService from '../services/operator-mode-state-service';
 
-class IndexComponent extends Component<void> {
+import { HostModeComponent, HostModeComponentSignature } from './card';
+
+class IndexComponent extends Component<HostModeComponentSignature> {
+  @service private declare hostModeService: HostModeService;
   @service private declare operatorModeStateService: OperatorModeStateService;
   // Remove this and onClose argument in OperatorModeContainer once we remove host mode and the card route, where closing operator mode will not be a thing anymore
   @action closeOperatorMode() {
@@ -18,8 +22,12 @@ class IndexComponent extends Component<void> {
   }
 
   <template>
-    {{pageTitle this.operatorModeStateService.title}}
-    <OperatorModeContainer @onClose={{this.closeOperatorMode}} />
+    {{#if this.hostModeService.isActive}}
+      <HostModeComponent @model={{@model}} />
+    {{else}}
+      {{pageTitle this.operatorModeStateService.title}}
+      <OperatorModeContainer @onClose={{this.closeOperatorMode}} />
+    {{/if}}
   </template>
 }
 


### PR DESCRIPTION
Without this to view the index card you had to request `/index`, not just `/`:

<img width="3270" height="2114" alt="Boxel 2025-09-08 14-42-37" src="https://github.com/user-attachments/assets/1d909413-87b1-4888-a4d2-4a4a337916a2" />

<img width="3824" height="2264" alt="image" src="https://github.com/user-attachments/assets/2b54bc44-bdfc-4344-84ad-18db106c66d8" />

With this branch deployed, it renders the index card at `/`:

<img width="3270" height="2114" alt="mar10 2025-09-08 16-56-56" src="https://github.com/user-attachments/assets/40058aae-3ce3-4c4b-8995-ef053f799b19" />