### PR TITLE
Add missing cardInfo and broken catalog blog-app layout

### DIFF
--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -386,8 +386,9 @@ export function getBoxComponent(
         background-color: var(--muted, var(--boxel-100));
       }
 
-      .field-component-card.fitted-format {
-        /*
+      @layer baseComponent {
+        .field-component-card.fitted-format {
+          /*
         The cards themselves need to be in charge of the styles within the card boundary
         in order for the container queries to make sense--otherwise we need to do style
         math to figure out what the actual breakpoints are. please resist the urge to add
@@ -397,13 +398,14 @@ export function getBoxComponent(
         works if we use up all the space horizontally and vertically that is available
         to the card since some of our queries are height queries
       */
-        width: 100%;
-        height: 100%;
-        min-height: 40px;
-        max-height: 600px;
-        container-name: fitted-card;
-        container-type: size;
-        overflow: hidden;
+          width: 100%;
+          height: 100%;
+          min-height: 40px;
+          max-height: 600px;
+          container-name: fitted-card;
+          container-type: size;
+          overflow: hidden;
+        }
       }
 
       .field-component-card.embedded-format {

--- a/packages/catalog-realm/blog-app/Author/alice-enwunder.json
+++ b/packages/catalog-realm/blog-app/Author/alice-enwunder.json
@@ -31,8 +31,10 @@
         "height": null,
         "width": null
       },
-      "description": null,
-      "thumbnailURL": "https://boxel-images.boxel.ai/app-assets/portraits/photo-1509868918748-a554ad25f858.jpeg"
+      "cardInfo": {
+        "description": null,
+        "thumbnailURL": "https://boxel-images.boxel.ai/app-assets/portraits/photo-1509868918748-a554ad25f858.jpeg"
+      }
     },
     "relationships": {
       "blog": {

--- a/packages/catalog-realm/blog-app/Author/jane-doe.json
+++ b/packages/catalog-realm/blog-app/Author/jane-doe.json
@@ -31,8 +31,10 @@
         "height": null,
         "width": null
       },
-      "description": "Senior Managing Editor at Ramped.com",
-      "thumbnailURL": "https://boxel-images.boxel.ai/app-assets/portraits/photo-1481214110143-ed630356e1bb.jpeg"
+      "cardInfo": {
+        "description": "Senior Managing Editor at Ramped.com",
+        "thumbnailURL": "https://boxel-images.boxel.ai/app-assets/portraits/photo-1481214110143-ed630356e1bb.jpeg"
+      }
     },
     "relationships": {
       "blog": {

--- a/packages/catalog-realm/blog-app/BlogApp/ramped.json
+++ b/packages/catalog-realm/blog-app/BlogApp/ramped.json
@@ -5,7 +5,12 @@
       "website": "ramped.com",
       "title": "Ramped",
       "description": "Urban insights",
-      "thumbnailURL": "https://boxel-images.boxel.ai/icons/ramped.png"
+      "thumbnailURL": "https://boxel-images.boxel.ai/icons/ramped.png",
+      "cardInfo": {
+        "title": "Ramped",
+        "description": "Urban insights",
+        "thumbnailURL": "https://boxel-images.boxel.ai/icons/ramped.png"
+      }
     },
     "meta": {
       "adoptsFrom": {

--- a/packages/catalog-realm/blog-app/BlogCategory/city-design.json
+++ b/packages/catalog-realm/blog-app/BlogCategory/city-design.json
@@ -6,9 +6,11 @@
       "shortName": "Design",
       "slug": "city-design",
       "pillColor": "#1EDF67",
-      "description": "Showcasing architecture and urban planning brilliance.",
-      "title": "City Design",
-      "thumbnailURL": null
+      "cardInfo": {
+        "description": "Showcasing architecture and urban planning brilliance.",
+        "title": "City Design",
+        "thumbnailURL": null
+      }
     },
     "relationships": {
       "blog": {

--- a/packages/catalog-realm/blog-app/BlogCategory/cultural-scenes.json
+++ b/packages/catalog-realm/blog-app/BlogCategory/cultural-scenes.json
@@ -6,9 +6,11 @@
       "shortName": "Culture",
       "slug": "cultural-scenes",
       "pillColor": "#FA7F01",
-      "description": "Capturing the vibrant art, food, and music of cities.",
-      "title": "Cultural Scenes",
-      "thumbnailURL": null
+      "cardInfo": {
+        "description": "Capturing the vibrant art, food, and music of cities.",
+        "title": "Cultural Scenes",
+        "thumbnailURL": null
+      }
     },
     "relationships": {
       "blog": {

--- a/packages/catalog-realm/blog-app/BlogCategory/future-tech.json
+++ b/packages/catalog-realm/blog-app/BlogCategory/future-tech.json
@@ -6,9 +6,11 @@
       "shortName": "Tech",
       "slug": "future-tech",
       "pillColor": "#000000",
-      "description": "Highlighting technology shaping tomorrow’s cities.",
-      "title": "Future Tech",
-      "thumbnailURL": null
+      "cardInfo": {
+        "description": "Highlighting technology shaping tomorrow’s cities.",
+        "title": "Future Tech",
+        "thumbnailURL": null
+      }
     },
     "relationships": {
       "blog": {

--- a/packages/catalog-realm/blog-app/BlogCategory/street-life.json
+++ b/packages/catalog-realm/blog-app/BlogCategory/street-life.json
@@ -6,9 +6,11 @@
       "shortName": "Streets",
       "slug": "street-life",
       "pillColor": "#39B1FF",
-      "description": "Discovering the stories of streets and public spaces.",
-      "title": "Street Life",
-      "thumbnailURL": null
+      "cardInfo": {
+        "description": "Discovering the stories of streets and public spaces.",
+        "title": "Street Life",
+        "thumbnailURL": null
+      }
     },
     "relationships": {
       "blog": {

--- a/packages/catalog-realm/blog-app/BlogCategory/urban-work.json
+++ b/packages/catalog-realm/blog-app/BlogCategory/urban-work.json
@@ -6,9 +6,11 @@
       "shortName": "Work",
       "slug": "urban-work",
       "pillColor": "#A6F4CA",
-      "description": "Exploring work trends in the evolving city landscape.",
-      "title": "Work",
-      "thumbnailURL": null
+      "cardInfo": {
+        "description": "Exploring work trends in the evolving city landscape.",
+        "title": "Work",
+        "thumbnailURL": null
+      }
     },
     "relationships": {
       "blog": {

--- a/packages/catalog-realm/blog-app/BlogPost/ultimate-guide-remote-work.json
+++ b/packages/catalog-realm/blog-app/BlogPost/ultimate-guide-remote-work.json
@@ -15,8 +15,10 @@
         "height": null,
         "width": null
       },
-      "description": "In today's digital age, remote work has transformed from a luxury to a necessity. This comprehensive guide will help you navigate the world of remote work, offering tips, tools, and best practices for success.",
-      "thumbnailURL": "https://images.unsplash.com/photo-1614624532983-4ce03382d63d?q=80&w=3131&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+      "cardInfo": {
+        "description": "In today's digital age, remote work has transformed from a luxury to a necessity. This comprehensive guide will help you navigate the world of remote work, offering tips, tools, and best practices for success.",
+        "thumbnailURL": "https://images.unsplash.com/photo-1614624532983-4ce03382d63d?q=80&w=3131&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+      }
     },
     "relationships": {
       "authors.0": {

--- a/packages/catalog-realm/blog-app/BlogPost/urban-living-future-sustainable.json
+++ b/packages/catalog-realm/blog-app/BlogPost/urban-living-future-sustainable.json
@@ -15,8 +15,10 @@
         "height": null,
         "width": null
       },
-      "description": "As our cities grow ever upward, should we continue to build, or focus on creating? This article explores the pros and cons of both approaches.",
-      "thumbnailURL": "https://images.unsplash.com/photo-1548182880-8b7b2af2caa2?q=80&w=2970&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+      "cardInfo": {
+        "description": "As our cities grow ever upward, should we continue to build, or focus on creating? This article explores the pros and cons of both approaches.",
+        "thumbnailURL": "https://images.unsplash.com/photo-1548182880-8b7b2af2caa2?q=80&w=2970&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+      }
     },
     "relationships": {
       "authors.0": {

--- a/packages/catalog-realm/blog-app/ReviewBlog/583df6bb-5739-418a-9186-978bd72816c1.json
+++ b/packages/catalog-realm/blog-app/ReviewBlog/583df6bb-5739-418a-9186-978bd72816c1.json
@@ -3,9 +3,11 @@
     "type": "card",
     "attributes": {
       "website": "www.cinereview.com",
-      "title": "CineReview",
-      "description": null,
-      "thumbnailURL": null
+      "cardInfo": {
+        "title": "CineReview",
+        "description": null,
+        "thumbnailURL": null
+      }
     },
     "meta": {
       "adoptsFrom": {

--- a/packages/catalog-realm/blog-app/blog-app.gts
+++ b/packages/catalog-realm/blog-app/blog-app.gts
@@ -172,6 +172,7 @@ class BlogAppTemplate extends Component<typeof BlogApp> {
       @filters={{this.filters}}
       @activeFilter={{this.activeFilter}}
       @onFilterChange={{this.onFilterChange}}
+      class='blog-app'
     >
       <:sidebar>
         <TitleGroup
@@ -186,7 +187,6 @@ class BlogAppTemplate extends Component<typeof BlogApp> {
           <BoxelButton
             class='sidebar-create-button'
             @kind='primary'
-            @size='large'
             @disabled={{this.activeFilter.isCreateNewDisabled}}
             @loading={{this.createCard.isRunning}}
             {{on 'click' this.createNew}}

--- a/packages/catalog-realm/blog-app/blog-post.gts
+++ b/packages/catalog-realm/blog-app/blog-post.gts
@@ -805,6 +805,7 @@ export class BlogPost extends CardDef {
           overflow: hidden;
         }
         .blog {
+          height: 65px;
           background-color: inherit;
         }
         .blog + .featured-image {

--- a/packages/catalog-realm/components/card-list.gts
+++ b/packages/catalog-realm/components/card-list.gts
@@ -36,16 +36,16 @@ export class CardList extends GlimmerComponent<CardListSignature> {
           </:loading>
           <:response as |cards|>
             {{#each cards key='url' as |card|}}
-              <li
-                class='card-list-item'
-                {{@context.cardComponentModifier
-                  cardId=card.url
-                  format='data'
-                  fieldType=undefined
-                  fieldName=undefined
-                }}
-              >
-                <card.component />
+              <li class='card-list-item'>
+                <card.component
+                  {{@context.cardComponentModifier
+                    cardId=card.url
+                    format='data'
+                    fieldType=undefined
+                    fieldName=undefined
+                  }}
+                  class='card'
+                />
                 {{#if (has-block 'meta')}}
                   {{yield card to='meta'}}
                 {{/if}}

--- a/packages/catalog-realm/components/grid.gts
+++ b/packages/catalog-realm/components/grid.gts
@@ -35,16 +35,16 @@ export class CardsGrid extends GlimmerComponent<CardsGridSignature> {
           </:loading>
           <:response as |cards|>
             {{#each cards key='url' as |card|}}
-              <li
-                class='{{@selectedView}}-view-container'
-                {{@context.cardComponentModifier
-                  cardId=card.url
-                  format='data'
-                  fieldType=undefined
-                  fieldName=undefined
-                }}
-              >
-                <card.component />
+              <li class='{{@selectedView}}-view-container'>
+                <card.component
+                  {{@context.cardComponentModifier
+                    cardId=card.url
+                    format='data'
+                    fieldType=undefined
+                    fieldName=undefined
+                  }}
+                  class='card'
+                />
               </li>
             {{/each}}
           </:response>
@@ -98,8 +98,6 @@ export class CardsGrid extends GlimmerComponent<CardsGridSignature> {
       .card {
         container-name: fitted-card;
         container-type: size;
-        width: 100%;
-        height: 100%;
       }
     </style>
   </template>

--- a/packages/experiments-realm/Author/0b9c06fd-3833-4947-a0b8-ac24b8e71ee7.json
+++ b/packages/experiments-realm/Author/0b9c06fd-3833-4947-a0b8-ac24b8e71ee7.json
@@ -31,8 +31,10 @@
         "height": null,
         "width": null
       },
-      "description": "Senior Film Critic & Cultural Commentator",
-      "thumbnailURL": "https://boxel-images.boxel.ai/app-assets/portraits/photo-1556474835-b0f3ac40d4d1.jpeg"
+      "cardInfo": {
+        "description": "Senior Film Critic & Cultural Commentator",
+        "thumbnailURL": "https://boxel-images.boxel.ai/app-assets/portraits/photo-1556474835-b0f3ac40d4d1.jpeg"
+      }
     },
     "relationships": {
       "blog": {

--- a/packages/experiments-realm/Author/3a655a91-98b5-4f33-a071-b62d39218b33.json
+++ b/packages/experiments-realm/Author/3a655a91-98b5-4f33-a071-b62d39218b33.json
@@ -27,8 +27,10 @@
         "height": null,
         "width": null
       },
-      "description": "Senior Film Critic & Cultural Commentator",
-      "thumbnailURL": "https://boxel-images.boxel.ai/app-assets/portraits/photo-1512485694743-9c9538b4e6e0.jpeg"
+      "cardInfo": {
+        "description": "Senior Film Critic & Cultural Commentator",
+        "thumbnailURL": "https://boxel-images.boxel.ai/app-assets/portraits/photo-1512485694743-9c9538b4e6e0.jpeg"
+      }
     },
     "relationships": {
       "blog": {

--- a/packages/experiments-realm/Author/ad28d989-68a8-4bad-a8dc-05f9f724489c.json
+++ b/packages/experiments-realm/Author/ad28d989-68a8-4bad-a8dc-05f9f724489c.json
@@ -2,10 +2,10 @@
   "data": {
     "type": "card",
     "attributes": {
-      "firstName": "Alexandra Maximiliana",
+      "firstName": "Zi Alexandra Maximiliana",
       "lastName": "Montgomery-Barrington IV",
-      "bio": "A distinguished editorial leader with over a decade of experience shaping content strategies that captivate and engage audiences across digital platforms, Alexandra Maximiliana Montgomery-Barrington IV is renowned for her visionary approach to storytelling and editorial excellence. She has led high-performing teams to produce impactful narratives while driving innovation in the publishing industry. Alexandra is a strategic thinker with a passion for fostering collaboration, ensuring that every project delivers both creative quality and measurable results. When not overseeing editorial initiatives, she enjoys hiking through scenic landscapes, capturing moments through her lens, and immersing herself in a good book.",
-      "fullBio": "Alexandra Maximiliana Montgomery-Barrington IV is a highly respected editorial leader with more than a decade of experience in digital media and content strategy. Known for her keen eye for detail and her ability to craft compelling narratives, she has consistently delivered high-quality content that resonates with diverse audiences. Throughout her career, Alexandra has demonstrated a deep understanding of the evolving digital landscape, balancing creative vision with data-driven insights to produce work that not only engages but also drives measurable results. Her expertise spans editorial direction, content curation, and cross-functional team leadership, enabling her to oversee complex projects from conception to execution.\n\nA strategic thinker and innovative problem solver, Alexandra has a proven track record of building and leading editorial teams that thrive in dynamic environments. She has worked with industry-leading brands, shaping content strategies that align with business goals while maintaining a strong focus on storytelling and audience connection. Her leadership style is rooted in collaboration and fostering a culture of creativity and excellence, ensuring that every project exceeds expectations. Alexandra is also passionate about mentoring and developing talent, helping her teams grow both professionally and personally.\n\nOutside of her professional life, Alexandra is an avid outdoors enthusiast, finding inspiration in nature through hiking and photography. Her love of storytelling extends beyond the written word—capturing moments through her lens allows her to explore new perspectives and deepen her connection to the world around her. When she’s not leading editorial initiatives, you’ll find her immersed in a good book, seeking out new ideas and inspiration to fuel her next project. Alexandra's unique blend of editorial expertise, leadership, and creative passion has made her a trailblazer in the publishing world, constantly pushing the boundaries of what’s possible in digital content.",
+      "bio": "A distinguished editorial leader with over a decade of experience shaping content strategies that captivate and engage audiences across digital platforms, Zi Alexandra Maximiliana Montgomery-Barrington IV is renowned for her visionary approach to storytelling and editorial excellence. She has led high-performing teams to produce impactful narratives while driving innovation in the publishing industry. Alexandra is a strategic thinker with a passion for fostering collaboration, ensuring that every project delivers both creative quality and measurable results. When not overseeing editorial initiatives, she enjoys hiking through scenic landscapes, capturing moments through her lens, and immersing herself in a good book.",
+      "fullBio": "Zi Alexandra Maximiliana Montgomery-Barrington IV is a highly respected editorial leader with more than a decade of experience in digital media and content strategy. Known for her keen eye for detail and her ability to craft compelling narratives, she has consistently delivered high-quality content that resonates with diverse audiences. Throughout her career, Alexandra has demonstrated a deep understanding of the evolving digital landscape, balancing creative vision with data-driven insights to produce work that not only engages but also drives measurable results. Her expertise spans editorial direction, content curation, and cross-functional team leadership, enabling her to oversee complex projects from conception to execution.\n\nA strategic thinker and innovative problem solver, Alexandra has a proven track record of building and leading editorial teams that thrive in dynamic environments. She has worked with industry-leading brands, shaping content strategies that align with business goals while maintaining a strong focus on storytelling and audience connection. Her leadership style is rooted in collaboration and fostering a culture of creativity and excellence, ensuring that every project exceeds expectations. Alexandra is also passionate about mentoring and developing talent, helping her teams grow both professionally and personally.\n\nOutside of her professional life, Alexandra is an avid outdoors enthusiast, finding inspiration in nature through hiking and photography. Her love of storytelling extends beyond the written word—capturing moments through her lens allows her to explore new perspectives and deepen her connection to the world around her. When she’s not leading editorial initiatives, you’ll find her immersed in a good book, seeking out new ideas and inspiration to fuel her next project. Alexandra's unique blend of editorial expertise, leadership, and creative passion has made her a trailblazer in the publishing world, constantly pushing the boundaries of what’s possible in digital content.",
       "quote": "\"Storytelling is the bridge that connects ideas with impact, and great content is the foundation that makes it last.\"",
       "contactLinks": [
         {
@@ -22,17 +22,10 @@
         }
       ],
       "email": "alexandra.montgomery-barrington@companyname.com",
-      "featuredImage": {
-        "imageUrl": "https://boxel-images.boxel.ai/app-assets/portraits/photo-1521227889351-bf6f5b2e4e37.jpeg",
-        "credit": "Photo via Unsplash",
-        "caption": "Alexandra Maximiliana Montgomery-Barrington IV",
-        "altText": "Alexandra Maximiliana Montgomery-Barrington IV",
-        "size": "actual",
-        "height": null,
-        "width": null
-      },
-      "description": "Editor-in-Chief and Senior Director of Content Strategy, Editorial Innovation, and Cross-Platform Publishing Initiatives",
-      "thumbnailURL": "https://boxel-images.boxel.ai/app-assets/portraits/photo-1521227889351-bf6f5b2e4e37.jpeg"
+      "cardInfo": {
+        "description": "Editor-in-Chief and Senior Director of Content Strategy, Editorial Innovation, and Cross-Platform Publishing Initiatives",
+        "thumbnailURL": null
+      }
     },
     "relationships": {
       "blog": {

--- a/packages/experiments-realm/Author/alice-enwunder.json
+++ b/packages/experiments-realm/Author/alice-enwunder.json
@@ -31,8 +31,10 @@
         "height": null,
         "width": null
       },
-      "description": null,
-      "thumbnailURL": "https://boxel-images.boxel.ai/app-assets/portraits/photo-1509868918748-a554ad25f858.jpeg"
+      "cardInfo": {
+        "description": null,
+        "thumbnailURL": "https://boxel-images.boxel.ai/app-assets/portraits/photo-1509868918748-a554ad25f858.jpeg"
+      }
     },
     "relationships": {
       "blog": {

--- a/packages/experiments-realm/Author/jane-doe.json
+++ b/packages/experiments-realm/Author/jane-doe.json
@@ -31,8 +31,10 @@
         "height": null,
         "width": null
       },
-      "description": "Senior Managing Editor at Ramped.com",
-      "thumbnailURL": "https://boxel-images.boxel.ai/app-assets/portraits/photo-1481214110143-ed630356e1bb.jpeg"
+      "cardInfo": {
+        "description": "Senior Managing Editor at Ramped.com",
+        "thumbnailURL": "https://boxel-images.boxel.ai/app-assets/portraits/photo-1481214110143-ed630356e1bb.jpeg"
+      }
     },
     "relationships": {
       "blog": {

--- a/packages/experiments-realm/BlogApp/ramped.json
+++ b/packages/experiments-realm/BlogApp/ramped.json
@@ -5,7 +5,12 @@
       "website": "ramped.com",
       "title": "Ramped",
       "description": "Urban insights",
-      "thumbnailURL": "https://boxel-images.boxel.ai/icons/ramped.png"
+      "thumbnailURL": "https://boxel-images.boxel.ai/icons/ramped.png",
+      "cardInfo": {
+        "title": "Ramped",
+        "description": "Urban insights",
+        "thumbnailURL": "https://boxel-images.boxel.ai/icons/ramped.png"
+      }
     },
     "meta": {
       "adoptsFrom": {

--- a/packages/experiments-realm/BlogCategory/5c529dbb-bc16-41ee-9c31-a2b28e07b79d.json
+++ b/packages/experiments-realm/BlogCategory/5c529dbb-bc16-41ee-9c31-a2b28e07b79d.json
@@ -6,9 +6,11 @@
       "shortName": "Movies",
       "slug": "movies",
       "pillColor": "#fff500",
-      "description": null,
-      "title": "Movie Review",
-      "thumbnailURL": null
+      "cardInfo": {
+        "description": null,
+        "title": "Movie Review",
+        "thumbnailURL": null
+      }
     },
     "relationships": {
       "blog": {

--- a/packages/experiments-realm/BlogCategory/a4ee8a18-182b-47ff-b557-ef2e529c97ec.json
+++ b/packages/experiments-realm/BlogCategory/a4ee8a18-182b-47ff-b557-ef2e529c97ec.json
@@ -6,9 +6,11 @@
       "shortName": "TV",
       "slug": "tv-series",
       "pillColor": "#fff500",
-      "description": null,
-      "title": "TV Series",
-      "thumbnailURL": null
+      "cardInfo": {
+        "description": null,
+        "title": "TV Series",
+        "thumbnailURL": null
+      }
     },
     "relationships": {
       "blog": {

--- a/packages/experiments-realm/BlogCategory/crypto.json
+++ b/packages/experiments-realm/BlogCategory/crypto.json
@@ -6,9 +6,11 @@
       "shortName": "Crypto",
       "slug": "crypto",
       "pillColor": "#FA2200",
-      "description": "News about cryptocurrencies, price predictions, charts and everything about Satoshi Nakamoto",
-      "title": "Cryptocurrency",
-      "thumbnailURL": null
+      "cardInfo": {
+        "description": "News about cryptocurrencies, price predictions, charts and everything about Satoshi Nakamoto",
+        "title": "Cryptocurrency",
+        "thumbnailURL": null
+      }
     },
     "relationships": {
       "blog": {

--- a/packages/experiments-realm/BlogCategory/home-decor.json
+++ b/packages/experiments-realm/BlogCategory/home-decor.json
@@ -6,9 +6,11 @@
       "shortName": "Home Decor",
       "slug": "home",
       "pillColor": "#FCF8A6",
-      "description": "Articles about the aesthetic side of home building and renovation",
-      "title": "Home decoration & interior design",
-      "thumbnailURL": null
+      "cardInfo": {
+        "description": "Articles about the aesthetic side of home building and renovation",
+        "title": "Home decoration & interior design",
+        "thumbnailURL": null
+      }
     },
     "relationships": {
       "blog": {

--- a/packages/experiments-realm/BlogCategory/productivity.json
+++ b/packages/experiments-realm/BlogCategory/productivity.json
@@ -6,9 +6,11 @@
       "shortName": "Productivity",
       "slug": "productivity",
       "pillColor": "#9D00FF",
-      "description": "Tips and tricks for better organization and effectiveness at work",
-      "title": "Productivity",
-      "thumbnailURL": null
+      "cardInfo": {
+        "description": "Tips and tricks for better organization and effectiveness at work",
+        "title": "Productivity",
+        "thumbnailURL": null
+      }
     },
     "relationships": {
       "blog": {

--- a/packages/experiments-realm/BlogPost/mad-as-a-hatter.json
+++ b/packages/experiments-realm/BlogPost/mad-as-a-hatter.json
@@ -15,8 +15,10 @@
         "height": 400,
         "width": null
       },
-      "description": null,
-      "thumbnailURL": "https://images.unsplash.com/photo-1551422788-18e2a1f5bb88?q=80&w=3087&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+      "cardInfo": {
+        "description": null,
+        "thumbnailURL": "https://images.unsplash.com/photo-1551422788-18e2a1f5bb88?q=80&w=3087&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+      }
     },
     "relationships": {
       "authors.0": {

--- a/packages/experiments-realm/BlogPost/ultimate-guide-remote-work.json
+++ b/packages/experiments-realm/BlogPost/ultimate-guide-remote-work.json
@@ -15,8 +15,10 @@
         "height": null,
         "width": null
       },
-      "description": "In today's digital age, remote work has transformed from a luxury to a necessity. This comprehensive guide will help you navigate the world of remote work, offering tips, tools, and best practices for success.",
-      "thumbnailURL": "https://images.unsplash.com/photo-1614624532983-4ce03382d63d?q=80&w=3131&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+      "cardInfo": {
+        "description": "In today's digital age, remote work has transformed from a luxury to a necessity. This comprehensive guide will help you navigate the world of remote work, offering tips, tools, and best practices for success.",
+        "thumbnailURL": "https://images.unsplash.com/photo-1614624532983-4ce03382d63d?q=80&w=3131&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+      }
     },
     "relationships": {
       "authors.0": {

--- a/packages/experiments-realm/BlogPost/urban-living-future-sustainable.json
+++ b/packages/experiments-realm/BlogPost/urban-living-future-sustainable.json
@@ -4,19 +4,21 @@
     "attributes": {
       "headline": "The Future of Urban Living: Skyscrapers or Sustainable Communities?",
       "slug": "urban-living-future-sustainable",
-      "body": null,
+      "body": "As urban populations swell and space becomes increasingly limited, the debate between vertical development and sustainable community-building intensifies. Skyscrapers promise to accommodate more people in a smaller footprint, enhancing density and reducing urban sprawl. However, this vertical approach can strain infrastructure and may lack the sense of community that many residents crave. On the other hand, sustainable communities emphasize green spaces, local resources, and human-scale development, fostering a stronger connection between people and their environment. While both paths offer solutions to urban challenges, the future of cities may lie in blending these two concepts—integrating smart skyscrapers with sustainable, community-oriented design to create harmonious, livable urban ecosystems.",
       "publishDate": "2024-12-06T22:29:00.000Z",
       "featuredImage": {
-        "imageUrl": null,
-        "credit": null,
+        "imageUrl": "https://images.unsplash.com/photo-1548182880-8b7b2af2caa2?q=80&w=2970&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+        "credit": "Photo via Unsplash",
         "caption": null,
-        "altText": null,
+        "altText": "Times Square, New York",
         "size": "actual",
         "height": null,
         "width": null
       },
-      "description": "As our cities grow ever upward, should we continue to build, or focus on creating? This article explores the pros and cons of both approaches.",
-      "thumbnailURL": "https://images.unsplash.com/photo-1548182880-8b7b2af2caa2?q=80&w=2970&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+      "cardInfo": {
+        "description": "As our cities grow ever upward, should we continue to build, or focus on creating? This article explores the pros and cons of both approaches.",
+        "thumbnailURL": "https://images.unsplash.com/photo-1548182880-8b7b2af2caa2?q=80&w=2970&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+      }
     },
     "relationships": {
       "authors.0": {

--- a/packages/experiments-realm/CrmApp/4e73712d-2a31-4ffe-9c22-d3de277257a6.json
+++ b/packages/experiments-realm/CrmApp/4e73712d-2a31-4ffe-9c22-d3de277257a6.json
@@ -4,7 +4,12 @@
     "attributes": {
       "title": "Vibeverse",
       "description": "Feel the moment",
-      "thumbnailURL": "https://boxel-images.boxel.ai/icons/vibeverse.jpg"
+      "thumbnailURL": "https://boxel-images.boxel.ai/icons/vibeverse.jpg",
+      "cardInfo": {
+        "title": "Vibeverse",
+        "description": "Feel the moment",
+        "thumbnailURL": "https://boxel-images.boxel.ai/icons/vibeverse.jpg"
+      }
     },
     "meta": {
       "adoptsFrom": {

--- a/packages/experiments-realm/Review/7f3c8694-7fa8-41d6-a449-14337c51fa29.json
+++ b/packages/experiments-realm/Review/7f3c8694-7fa8-41d6-a449-14337c51fa29.json
@@ -25,8 +25,10 @@
         "height": 400,
         "width": null
       },
-      "description": "In an era hungry for originality, \"Singularity’s Echo\" emerges as a luminous beacon in the cosmic darkness—an audacious journey that redefines what viewers can expect from the genre. Directed by the elusive auteur Oruni Kilrain, this film harnesses the raw power of interstellar wonder and transforms it into a multilayered narrative tapestry. Blending heart-stirring drama with disorienting visuals, \"Singularity’s Echo\" reminds us that true cinematic frontiers remain ripe for exploration, stretching beyond the gravitational pull of safe storytelling.",
-      "thumbnailURL": "https://boxel-images.boxel.ai/app-assets/blog-posts/space-movie-thumb.jpeg"
+      "cardInfo": {
+        "description": "In an era hungry for originality, \"Singularity’s Echo\" emerges as a luminous beacon in the cosmic darkness—an audacious journey that redefines what viewers can expect from the genre. Directed by the elusive auteur Oruni Kilrain, this film harnesses the raw power of interstellar wonder and transforms it into a multilayered narrative tapestry. Blending heart-stirring drama with disorienting visuals, \"Singularity’s Echo\" reminds us that true cinematic frontiers remain ripe for exploration, stretching beyond the gravitational pull of safe storytelling.",
+        "thumbnailURL": "https://boxel-images.boxel.ai/app-assets/blog-posts/space-movie-thumb.jpeg"
+      }
     },
     "relationships": {
       "authors.0": {

--- a/packages/experiments-realm/ReviewBlog/583df6bb-5739-418a-9186-978bd72816c1.json
+++ b/packages/experiments-realm/ReviewBlog/583df6bb-5739-418a-9186-978bd72816c1.json
@@ -3,9 +3,11 @@
     "type": "card",
     "attributes": {
       "website": "www.cinereview.com",
-      "title": "CineReview",
-      "description": null,
-      "thumbnailURL": null
+      "cardInfo": {
+        "title": "CineReview",
+        "description": null,
+        "thumbnailURL": null
+      }
     },
     "meta": {
       "adoptsFrom": {

--- a/packages/experiments-realm/blog-app.gts
+++ b/packages/experiments-realm/blog-app.gts
@@ -186,7 +186,6 @@ class BlogAppTemplate extends Component<typeof BlogApp> {
           <BoxelButton
             class='sidebar-create-button'
             @kind='primary'
-            @size='large'
             @disabled={{this.activeFilter.isCreateNewDisabled}}
             @loading={{this.createCard.isRunning}}
             {{on 'click' this.createNew}}

--- a/packages/experiments-realm/blog-post.gts
+++ b/packages/experiments-realm/blog-post.gts
@@ -805,6 +805,7 @@ export class BlogPost extends CardDef {
           overflow: hidden;
         }
         .blog {
+          height: 65px;
           background-color: inherit;
         }
         .blog + .featured-image {

--- a/packages/experiments-realm/review.gts
+++ b/packages/experiments-realm/review.gts
@@ -203,6 +203,7 @@ export class Review extends BlogPost {
           position: absolute;
           top: 0;
           min-height: var(--banner-height);
+          height: var(--banner-height);
           background-color: rgba(0 0 0 / 70%);
           color: var(--boxel-light);
           border-radius: 0;


### PR DESCRIPTION
- Some sample apps and cards on catalog and experiments-realms were using the card's default title, description, thumbnailURL fields are now missing data for those. Updated by wrapping the field json data in `cardInfo`.
- Restore blog app layout on catalog that was broken.

Before:
<img width="1028" height="1267" alt="before-1" src="https://github.com/user-attachments/assets/45563610-72ac-415a-9839-cbbd2d881e57" />

After:
<img width="1028" height="1261" alt="after-1" src="https://github.com/user-attachments/assets/7bf2f55d-623a-4b08-886f-938124d49560" />

- Base fitted-component css had too high of a css specificity, making it not possible to specify height value from outside.

Before:
<img width="1026" height="1031" alt="before-2" src="https://github.com/user-attachments/assets/d8250ca5-8923-4bdc-bf10-0bda2078ad73" />

After:
<img width="1026" height="1257" alt="after-2" src="https://github.com/user-attachments/assets/46c309c6-7fdc-4ad5-89e0-4631b8e3c613" />

