### PR TITLE
host: Fix host mode index card filters via context

### DIFF
--- a/packages/host/app/templates/card.gts
+++ b/packages/host/app/templates/card.gts
@@ -46,19 +46,16 @@ export class HostModeComponent extends Component<HostModeComponentSignature> {
   @service private declare store: StoreService;
 
   @provide(GetCardContextName)
-  // @ts-ignore "getCard" is declared but not used
   private get getCard() {
     return getCard;
   }
 
   @provide(GetCardsContextName)
-  // @ts-ignore "getCards" is declared but not used
   private get getCards() {
     return getSearch;
   }
 
   @provide(GetCardCollectionContextName)
-  // @ts-ignore "getCardCollection" is declared but not used
   private get getCardCollection() {
     return getCardCollection;
   }

--- a/packages/host/app/templates/card.gts
+++ b/packages/host/app/templates/card.gts
@@ -95,7 +95,7 @@ export class HostModeComponent extends Component<HostModeComponentSignature> {
   }
 
   @provide(CardContextName)
-  // @ts-ignore "context" is declared but not used
+  // @ts-expect-error 'context' is declared but not used
   private get context(): CardContext {
     return {
       getCard: this.getCard,


### PR DESCRIPTION
The filters weren’t working in host mode because the context was set up incorrectly:

<img width="2246" height="1808" alt="mar10 2025-09-10 13-01-55" src="https://github.com/user-attachments/assets/ef5a2da3-36bb-44e4-8e6b-0b02ff10b28f" />

Now they work:

<img width="2246" height="1808" alt="mar10 2025-09-10 13-03-58" src="https://github.com/user-attachments/assets/eb9ce1df-22b9-4d71-b9ac-287d3108ca28" />

(You can see host mode in preview deployments by adding `?host-mode-origin=REALM_URL`, like [this](https://hostcontext-host-mode-cs-9370.boxel-host-preview.stack.cards/?host-mode-origin=https://buckmar10.staging.boxel.build). But I needed to remove the training slash in the realm URL 😳)