### PR TITLE
Add warning for developers who expect to see ContainsMany component when nested in fieldDef

### DIFF
--- a/packages/base/contains-many-component.gts
+++ b/packages/base/contains-many-component.gts
@@ -290,7 +290,7 @@ export function getContainsManyComponent({
       model.value.constructor.isFieldDef
     ) {
       console.warn(
-        'We intentionally do not render a contains-many editor when the plural field is nested inside another field. The decision of what to display is complex and should be user-defined',
+        'We intentionally DO NOT render a contains-many editor when the plural field is nested inside another field. The decision of what to display is complex and should be user-defined',
       );
       return false;
     }

--- a/packages/base/contains-many-component.gts
+++ b/packages/base/contains-many-component.gts
@@ -289,6 +289,9 @@ export function getContainsManyComponent({
       'isFieldDef' in model.value.constructor &&
       model.value.constructor.isFieldDef
     ) {
+      console.warn(
+        'We intentionally do not render a contains-many editor when the plural field is nested inside another field. The decision of what to display is complex and should be user-defined',
+      );
       return false;
     }
     if (isComputed) {


### PR DESCRIPTION
We intentionally do not display the contains many editor -- I didn't know this. Hopefully, other developers can see this warning