### PR TITLE
host: Remove unused Matrix registry declarations

### DIFF
--- a/packages/host/app/components/matrix/auth.gts
+++ b/packages/host/app/components/matrix/auth.gts
@@ -68,9 +68,3 @@ export default class Auth extends Component {
     this.resetPasswordParams = undefined;
   }
 }
-
-declare module '@glint/environment-ember-loose/registry' {
-  export default interface Login {
-    'Matrix::Login': typeof Login;
-  }
-}

--- a/packages/host/app/components/matrix/login.gts
+++ b/packages/host/app/components/matrix/login.gts
@@ -234,9 +234,3 @@ export function extractMatrixErrorMessage(e: MatrixError) {
     return `Unknown error ${e.httpStatus}: ${e.data.error}`;
   }
 }
-
-declare module '@glint/environment-ember-loose/registry' {
-  export default interface Login {
-    'Matrix::Login': typeof Login;
-  }
-}

--- a/packages/host/app/components/matrix/register-user.gts
+++ b/packages/host/app/components/matrix/register-user.gts
@@ -836,9 +836,3 @@ function extractTokenErrorMessage(error: Error) {
 
   return false;
 }
-
-declare module '@glint/environment-ember-loose/registry' {
-  export default interface RegisterUser {
-    'Matrix::RegisterUser': typeof RegisterUser;
-  }
-}

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -1210,9 +1210,3 @@ export default class Room extends Component<Signature> {
     await this.matrixService.sendStopGeneratingEvent(this.args.roomId);
   });
 }
-
-declare module '@glint/environment-ember-loose/registry' {
-  export default interface Room {
-    'Matrix::Room': typeof Room;
-  }
-}

--- a/packages/host/app/components/matrix/user-profile.gts
+++ b/packages/host/app/components/matrix/user-profile.gts
@@ -97,9 +97,3 @@ export default class UserProfile extends Component {
     this.displayName = displayName;
   });
 }
-
-declare module '@glint/environment-ember-loose/registry' {
-  export default interface UserProfile {
-    'Matrix::UserProfile': typeof UserProfile;
-  }
-}


### PR DESCRIPTION
These are needed for type-checking when using components in `*.hbs` files, but we’re using `ember-route-template`, so we no longer have those.