### PR TITLE
server: Fix clash detection on published realms

### DIFF
--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -302,14 +302,18 @@ export class RealmServer {
     backgroundURL?: string;
     iconURL?: string;
   }): Promise<Realm> => {
-    let conflictingRealm = this.realms.find(
-      (r) => new URL(r.url).href.replace(/\/$/, '') === new URL(r.url).origin,
-    );
-    if (conflictingRealm) {
-      this.log.error(`Realm mounted at origin ${conflictingRealm.url}`);
+    let realmAtServerRoot = this.realms.find((r) => {
+      let realmUrl = new URL(r.url);
+
+      return (
+        realmUrl.href.replace(/\/$/, '') === realmUrl.origin &&
+        realmUrl.hostname === this.serverURL.hostname
+      );
+    });
+    if (realmAtServerRoot) {
       throw errorWithStatus(
         400,
-        `Cannot create a realm: a realm is already mounted at the origin of this server`,
+        `Cannot create a realm: a realm is already mounted at the origin of this server: ${realmAtServerRoot.url}`,
       );
     }
     if (!endpoint.match(/^[a-z0-9-]+$/)) {

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -310,6 +310,7 @@ export class RealmServer {
         realmUrl.hostname === this.serverURL.hostname
       );
     });
+
     if (realmAtServerRoot) {
       throw errorWithStatus(
         400,

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -302,11 +302,11 @@ export class RealmServer {
     backgroundURL?: string;
     iconURL?: string;
   }): Promise<Realm> => {
-    if (
-      this.realms.find(
-        (r) => new URL(r.url).href.replace(/\/$/, '') === new URL(r.url).origin,
-      )
-    ) {
+    let conflictingRealm = this.realms.find(
+      (r) => new URL(r.url).href.replace(/\/$/, '') === new URL(r.url).origin,
+    );
+    if (conflictingRealm) {
+      this.log.error(`Realm mounted at origin ${conflictingRealm.url}`);
       throw errorWithStatus(
         400,
         `Cannot create a realm: a realm is already mounted at the origin of this server`,


### PR DESCRIPTION
We can’t currently create new realms as published realms are interpreted as being served from the realm server’s root despite actually being at different hostnames:

<img width="709" height="459" alt="Boxel 2025-09-11 12-30-55" src="https://github.com/user-attachments/assets/50a6614d-d655-41f6-a346-056528b4caeb" />

I added logging to confirm a published realm was the problem:

<img width="831" height="135" alt="Service logs | Elastic Container Service | us-east-1 2025-09-11 10-21-00" src="https://github.com/user-attachments/assets/599246e9-05f0-496c-b75d-7a687830d6e4" />

This adds a hostname comparison to the code that searches for a realm served at `/`.

The realm server test failure is [also on `main`](https://github.com/cardstack/boxel/actions/runs/17642021964/job/50131086553#step:10:102), so a red herring.