### PR TITLE
realm: Fix prerender searchDoc assertion on theme

### DIFF
--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -202,7 +202,7 @@ module(basename(__filename), function () {
             id: `${realmURL1}1`,
             name: 'Hassan',
             title: 'Hassan',
-            cardInfo: { theme: null },
+            cardInfo: {},
           },
           'linked field search doc is correct',
         );


### PR DESCRIPTION
This is failing on `main`, like [here](https://github.com/cardstack/boxel/actions/runs/17622929850/job/50072692602#step:10:102).