### PR TITLE
Allow spec to be displayed in RHS 

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
+++ b/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
@@ -437,13 +437,6 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
       <SyntaxErrorDisplay
         @syntaxErrors={{@moduleAnalysis.moduleError.message}}
       />
-    {{else if @card}}
-      <CardRendererPanel
-        @card={{@card}}
-        @format={{@previewFormat}}
-        @setFormat={{@setPreviewFormat}}
-        data-test-card-resource-loaded
-      />
     {{else if @cardError}}
       <section class='module-inspector-content error'>
         <CardError
@@ -451,6 +444,13 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
           @fileToFixWithAi={{this.sourceFileForCard}}
         />
       </section>
+    {{else if @card}}
+      <CardRendererPanel
+        @card={{@card}}
+        @format={{@previewFormat}}
+        @setFormat={{@setPreviewFormat}}
+        data-test-card-resource-loaded
+      />
     {{/if}}
 
     <style scoped>

--- a/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
+++ b/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
@@ -438,21 +438,19 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
         @syntaxErrors={{@moduleAnalysis.moduleError.message}}
       />
     {{else if @card}}
-      {{#if @cardError}}
-        <section class='module-inspector-content error'>
-          <CardError
-            @error={{@cardError}}
-            @fileToFixWithAi={{this.sourceFileForCard}}
-          />
-        </section>
-      {{else}}
-        <CardRendererPanel
-          @card={{@card}}
-          @format={{@previewFormat}}
-          @setFormat={{@setPreviewFormat}}
-          data-test-card-resource-loaded
+      <CardRendererPanel
+        @card={{@card}}
+        @format={{@previewFormat}}
+        @setFormat={{@setPreviewFormat}}
+        data-test-card-resource-loaded
+      />
+    {{else if @cardError}}
+      <section class='module-inspector-content error'>
+        <CardError
+          @error={{@cardError}}
+          @fileToFixWithAi={{this.sourceFileForCard}}
         />
-      {{/if}}
+      </section>
     {{/if}}
 
     <style scoped>

--- a/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
+++ b/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
@@ -22,7 +22,6 @@ import {
   type getCards,
   type getCard,
   type Query,
-  isCardDocumentString,
   isFieldDef,
   internalKeyFor,
   CodeRef,
@@ -125,31 +124,8 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
   @tracked private specSearch: ReturnType<getCards<Spec>> | undefined;
   @tracked private cardResource: ReturnType<getCard> | undefined;
 
-  private get declarations() {
-    return this.args.moduleAnalysis?.declarations;
-  }
-
-  get showSpecPreview() {
-    return Boolean(this.args.selectedCardOrField?.exportName);
-  }
-
-  private get hasCardDefOrFieldDef() {
-    return this.declarations.some(isCardOrFieldDeclaration);
-  }
-
-  private get isCardPreviewError() {
-    return this.args.isCard && this.args.cardError;
-  }
-
   private get isEmptyFile() {
     return this.args.readyFile?.content.match(/^\s*$/);
-  }
-
-  private get isSelectedItemIncompatibleWithSchemaEditor() {
-    if (!this.args.selectedDeclaration) {
-      return undefined;
-    }
-    return !isCardOrFieldDeclaration(this.args.selectedDeclaration);
   }
 
   private get sourceFileForCard(): FileDef | undefined {
@@ -177,49 +153,9 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
   }
 
   private get fileIncompatibilityMessage() {
-    if (this.args.isCard) {
-      if (this.args.cardError) {
-        return `Card preview failed. Make sure both the card instance data and card definition files have no errors and that their data schema matches. `;
-      }
-    }
-
-    if (this.args.moduleAnalysis.moduleError) {
-      return null; // Handled in code-submode schema editor
-    }
-
     if (this.args.isIncompatibleFile) {
       return `No tools are available to be used with this file type. Choose a file representing a card instance or module.`;
     }
-
-    // If the module is incompatible
-    if (this.args.isModule) {
-      //this will prevent displaying message during a page refresh
-      if (this.args.moduleAnalysis.isLoading) {
-        return null;
-      }
-      if (!this.hasCardDefOrFieldDef) {
-        return `No tools are available to be used with these file contents. Choose a module that has a card or field definition inside of it.`;
-      } else if (this.isSelectedItemIncompatibleWithSchemaEditor) {
-        return `No tools are available for the selected item: ${this.args.selectedDeclaration?.type} "${this.args.selectedDeclaration?.localName}". Select a card or field definition in the inspector.`;
-      }
-    }
-    // If module inspector doesn't handle any case but we can't capture the error
-    if (!this.args.card && !this.args.selectedCardOrField) {
-      // this will prevent displaying message during a page refresh
-      if (isCardDocumentString(this.args.readyFile.content)) {
-        return null;
-      }
-      return 'No tools are available to inspect this file or its contents. Select a file with a .json, .gts or .ts extension.';
-    }
-
-    if (
-      !this.args.isModule &&
-      !this.args.readyFile?.name.endsWith('.json') &&
-      !this.args.card //for case of creating new card instance
-    ) {
-      return 'No tools are available to inspect this file or its contents. Select a file with a .json, .gts or .ts extension.';
-    }
-
     return null;
   }
 
@@ -401,28 +337,21 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
     );
   }
 
+  get displayInspector() {
+    return this.args.selectedDeclaration;
+  }
+
   <template>
-    {{#if this.isCardPreviewError}}
-      {{! this is here to make TS happy, this is always true }}
-      {{#if @cardError}}
-        <section class='module-inspector-content error'>
-          <CardError
-            @error={{@cardError}}
-            @fileToFixWithAi={{this.sourceFileForCard}}
-          />
-        </section>
-      {{/if}}
-    {{else if this.isEmptyFile}}
+    {{#if this.isEmptyFile}}
       <SyntaxErrorDisplay @syntaxErrors='File is empty' />
     {{else if this.fileIncompatibilityMessage}}
-
       <div
         class='file-incompatible-message'
         data-test-file-incompatibility-message
       >
         {{this.fileIncompatibilityMessage}}
       </div>
-    {{else if @selectedCardOrField.cardOrField}}
+    {{else if this.displayInspector}}
       {{consumeContext this.makeCardResource}}
       {{consumeContext this.findSpecsForSelectedDefinition}}
 
@@ -431,11 +360,11 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
         @moduleAnalysis={{@moduleAnalysis}}
         @card={{@selectedCardOrField.cardOrField}}
         @cardType={{@selectedCardOrField.cardType}}
+        @selectedDeclaration={{@selectedDeclaration}}
         @goToDefinition={{@goToDefinitionAndResetCursorPosition}}
         @isReadOnly={{@isReadOnly}}
         as |SchemaEditorBadge SchemaEditorPanel|
       >
-
         <header
           class='module-inspector-header'
           {{SpecUpdatedModifier
@@ -463,7 +392,9 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
                     @numberOfInstances={{this.specsForSelectedDefinition.length}}
                   />
                 {{else if (eq moduleInspectorView 'schema')}}
-                  <SchemaEditorBadge />
+                  {{#if @selectedCardOrField}}
+                    <SchemaEditorBadge />
+                  {{/if}}
                 {{/if}}
               </:annotation>
             </ToggleButton>
@@ -497,17 +428,7 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
               @showCreateSpec={{this.showCreateSpec}}
               as |SpecPreviewContent|
             >
-              {{#if this.showSpecPreview}}
-                <SpecPreviewContent class='non-preview-panel-content' />
-              {{else}}
-                <p
-                  class='file-incompatible-message'
-                  data-test-incompatible-spec-nonexports
-                >
-                  <span>Boxel Spec is not supported for card or field
-                    definitions that are not exported.</span>
-                </p>
-              {{/if}}
+              <SpecPreviewContent class='non-preview-panel-content' />
             </SpecPreview>
           {{/if}}
         </section>
@@ -517,12 +438,21 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
         @syntaxErrors={{@moduleAnalysis.moduleError.message}}
       />
     {{else if @card}}
-      <CardRendererPanel
-        @card={{@card}}
-        @format={{@previewFormat}}
-        @setFormat={{@setPreviewFormat}}
-        data-test-card-resource-loaded
-      />
+      {{#if @cardError}}
+        <section class='module-inspector-content error'>
+          <CardError
+            @error={{@cardError}}
+            @fileToFixWithAi={{this.sourceFileForCard}}
+          />
+        </section>
+      {{else}}
+        <CardRendererPanel
+          @card={{@card}}
+          @format={{@previewFormat}}
+          @setFormat={{@setPreviewFormat}}
+          data-test-card-resource-loaded
+        />
+      {{/if}}
     {{/if}}
 
     <style scoped>

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground.gts
@@ -27,6 +27,7 @@ class UnsupportedMessage extends Component<UnsupportedMessageSignature> {
   <template>
     <p
       class='file-incompatible-message'
+      data-test-playground-incompatible-message
       data-test-incompatible-nonexports={{not @codeRef}}
       data-test-incompatible-primitives={{isPrimitive @cardOrField}}
     >

--- a/packages/host/app/components/operator-mode/code-submode/schema-editor.gts
+++ b/packages/host/app/components/operator-mode/code-submode/schema-editor.gts
@@ -12,15 +12,70 @@ import { ModuleSyntax } from '@cardstack/runtime-common/module-syntax';
 import CardAdoptionChain from '@cardstack/host/components/operator-mode/card-adoption-chain';
 import { Ready } from '@cardstack/host/resources/file';
 import { inheritanceChain } from '@cardstack/host/resources/inheritance-chain';
-import type { ModuleAnalysis } from '@cardstack/host/resources/module-contents';
+import type {
+  ModuleAnalysis,
+  ModuleDeclaration,
+} from '@cardstack/host/resources/module-contents';
 import { type Type } from '@cardstack/host/services/card-type-service';
 import type LoaderService from '@cardstack/host/services/loader-service';
 
-import { calculateTotalOwnFields } from '@cardstack/host/utils/schema-editor';
+import {
+  calculateTotalOwnFields,
+  isSelectedItemIncompatibleWithSchemaEditor,
+} from '@cardstack/host/utils/schema-editor';
 
 import { BaseDef } from 'https://cardstack.com/base/card-api';
 
 import type { WithBoundArgs } from '@glint/template';
+
+interface UnsupportedMessageSignature {
+  Element: HTMLDivElement;
+  Args: {
+    selectedDeclaration?: ModuleDeclaration;
+  };
+}
+
+class UnsupportedMessage extends Component<UnsupportedMessageSignature> {
+  private get unsupportedMessage() {
+    if (
+      isSelectedItemIncompatibleWithSchemaEditor(this.args.selectedDeclaration)
+    ) {
+      return `No tools are available for the selected item: ${this.args.selectedDeclaration?.type} "${this.args.selectedDeclaration?.localName}". Select a card or field definition in the inspector.`;
+    }
+    return `No tools are available for the selected item. Select a card or field definition in the inspector.`;
+  }
+
+  <template>
+    <p
+      class='file-incompatible-message'
+      data-test-schema-editor-file-incompatibility-message
+    >
+      <span>
+        {{this.unsupportedMessage}}
+      </span>
+    </p>
+
+    <style scoped>
+      .file-incompatible-message {
+        display: flex;
+        flex-wrap: wrap;
+        align-content: center;
+        justify-content: center;
+        text-align: center;
+        height: 100%;
+        background-color: var(--boxel-200);
+        font: var(--boxel-font-sm);
+        color: var(--boxel-450);
+        font-weight: 500;
+        padding: var(--boxel-sp-xl);
+        margin-block: 0;
+      }
+      .file-incompatible-message > span {
+        max-width: 400px;
+      }
+    </style>
+  </template>
+}
 
 interface Signature {
   Element: HTMLElement;
@@ -28,8 +83,9 @@ interface Signature {
     file: Ready;
     moduleAnalysis: ModuleAnalysis;
     cardType?: Type;
-    card: typeof BaseDef;
+    card?: typeof BaseDef;
     isReadOnly: boolean;
+    selectedDeclaration?: ModuleDeclaration;
     goToDefinition: (
       codeRef: CodeRef | undefined,
       localName: string | undefined,
@@ -127,18 +183,29 @@ export default class SchemaEditor extends Component<Signature> {
     );
   }
 
+  get shouldRender() {
+    return this.args.card && this.args.cardType;
+  }
+
   <template>
-    {{yield
-      (component SchemaEditorBadge totalFields=this.totalFields)
-      (component
-        CardAdoptionChain
-        file=@file
-        isReadOnly=@isReadOnly
-        moduleSyntax=this.moduleSyntax
-        cardInheritanceChain=this.cardInheritanceChain.value
-        goToDefinition=@goToDefinition
-        isLoading=this.isLoading
-      )
-    }}
+    {{#if this.shouldRender}}
+      {{yield
+        (component SchemaEditorBadge totalFields=this.totalFields)
+        (component
+          CardAdoptionChain
+          file=@file
+          isReadOnly=@isReadOnly
+          moduleSyntax=this.moduleSyntax
+          cardInheritanceChain=this.cardInheritanceChain.value
+          goToDefinition=@goToDefinition
+          isLoading=this.isLoading
+        )
+      }}
+    {{else}}
+      {{yield
+        (component SchemaEditorBadge totalFields=this.totalFields)
+        (component UnsupportedMessage selectedDeclaration=@selectedDeclaration)
+      }}
+    {{/if}}
   </template>
 }

--- a/packages/host/app/resources/inheritance-chain.ts
+++ b/packages/host/app/resources/inheritance-chain.ts
@@ -14,7 +14,7 @@ import { BaseDef } from 'https://cardstack.com/base/card-api';
 interface Args {
   named: {
     url: string;
-    card: typeof BaseDef;
+    card?: typeof BaseDef;
     cardType?: Type;
   };
 }
@@ -30,7 +30,7 @@ export class InheritanceChainResource extends Resource<Args> {
 
   modify(_positional: never[], named: Args['named']) {
     let { cardType, card, url } = named;
-    if (cardType) {
+    if (cardType && card) {
       this.load.perform(url, card, cardType);
     }
   }
@@ -47,6 +47,9 @@ export class InheritanceChainResource extends Resource<Args> {
     async (url: string, card: typeof BaseDef, cardType?: Type) => {
       if (!cardType) {
         throw new Error('Card type not found');
+      }
+      if (!card) {
+        throw new Error('card not found');
       }
 
       let cardInheritanceChain = [
@@ -77,7 +80,7 @@ export class InheritanceChainResource extends Resource<Args> {
 export function inheritanceChain(
   parent: object,
   url: () => string,
-  card: () => typeof BaseDef,
+  card: () => typeof BaseDef | undefined,
   cardType: () => Type | undefined,
 ) {
   return InheritanceChainResource.from(parent, () => ({

--- a/packages/host/app/services/code-semantics-service.ts
+++ b/packages/host/app/services/code-semantics-service.ts
@@ -141,10 +141,7 @@ export default class CodeSemanticsService extends Service {
   }
 
   get isModule() {
-    return (
-      this.isReady &&
-      hasExecutableExtension(this.readyFile.url)
-    );
+    return this.isReady && hasExecutableExtension(this.readyFile.url);
   }
 
   get isReady() {

--- a/packages/host/app/services/code-semantics-service.ts
+++ b/packages/host/app/services/code-semantics-service.ts
@@ -143,8 +143,7 @@ export default class CodeSemanticsService extends Service {
   get isModule() {
     return (
       this.isReady &&
-      hasExecutableExtension(this.readyFile.url) &&
-      !this.isIncompatibleFile
+      hasExecutableExtension(this.readyFile.url)
     );
   }
 
@@ -153,7 +152,7 @@ export default class CodeSemanticsService extends Service {
   }
 
   get isIncompatibleFile() {
-    return this.readyFile.isBinary || this.isNonCardJson;
+    return this.readyFile.isBinary || (!this.isModule && this.isNonCardJson);
   }
 
   private get isNonCardJson() {

--- a/packages/host/app/services/code-semantics-service.ts
+++ b/packages/host/app/services/code-semantics-service.ts
@@ -157,9 +157,9 @@ export default class CodeSemanticsService extends Service {
   }
 
   private get isNonCardJson() {
-    return (
+    return !(
       this.readyFile.name.endsWith('.json') &&
-      !isCardDocumentString(this.readyFile.content)
+      isCardDocumentString(this.readyFile.content)
     );
   }
 

--- a/packages/host/app/utils/schema-editor.ts
+++ b/packages/host/app/utils/schema-editor.ts
@@ -1,3 +1,7 @@
+import {
+  isCardOrFieldDeclaration,
+  type ModuleDeclaration,
+} from '@cardstack/host/resources/module-contents';
 import { type Type } from '@cardstack/host/services/card-type-service';
 
 import type { BaseDef } from 'https://cardstack.com/base/card-api';
@@ -13,4 +17,13 @@ export function calculateTotalOwnFields(
   cardType: Type,
 ): number {
   return cardType.fields.filter((field) => isOwnField(card, field.name)).length;
+}
+
+export function isSelectedItemIncompatibleWithSchemaEditor(
+  selectedDeclaration: ModuleDeclaration | undefined,
+): boolean {
+  if (!selectedDeclaration) {
+    return false;
+  }
+  return !isCardOrFieldDeclaration(selectedDeclaration);
 }

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -1251,9 +1251,9 @@ module('Acceptance | code submode tests', function (_hooks) {
         )
         .hasText('isHourly function');
       assert
-        .dom('[data-test-file-incompatibility-message]')
+        .dom('[data-test-schema-editor-file-incompatibility-message]')
         .hasText(
-          'No tools are available for the selected item: function "isHourly". Select a card or field definition in the inspector.',
+          `No tools are available for the selected item: function "isHourly". Select a card or field definition in the inspector.`,
         );
 
       await click('[data-test-boxel-selector-item-text="Isolated"]');
@@ -1265,9 +1265,9 @@ module('Acceptance | code submode tests', function (_hooks) {
         )
         .hasText('Isolated class');
       assert
-        .dom('[data-test-file-incompatibility-message]')
+        .dom('[data-test-schema-editor-file-incompatibility-message]')
         .hasText(
-          'No tools are available for the selected item: class "Isolated". Select a card or field definition in the inspector.',
+          `No tools are available for the selected item: class "Isolated". Select a card or field definition in the inspector.`,
         );
 
       await visitOperatorMode({
@@ -1276,7 +1276,9 @@ module('Acceptance | code submode tests', function (_hooks) {
       });
 
       await waitFor('[data-test-loading-indicator]', { count: 0 });
-      assert.dom('[data-test-file-incompatibility-message]').exists();
+      assert
+        .dom('[data-test-schema-editor-file-incompatibility-message]')
+        .exists();
     });
 
     test('displays clear message on schema-editor when file is completely unsupported', async function (assert) {
@@ -1289,7 +1291,7 @@ module('Acceptance | code submode tests', function (_hooks) {
       assert
         .dom('[data-test-file-incompatibility-message]')
         .hasText(
-          'No tools are available to inspect this file or its contents. Select a file with a .json, .gts or .ts extension.',
+          'No tools are available to be used with this file type. Choose a file representing a card instance or module.',
         );
 
       await waitFor('[data-test-definition-file-extension]');

--- a/packages/host/tests/acceptance/code-submode/card-playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/card-playground-test.gts
@@ -106,7 +106,9 @@ const blogPostCard = `import { contains, field, linksTo, linksToMany, CardDef, C
     }
   }
 
-  class LocalCategoryCard extends Category {}
+  class LocalCategoryCard extends Category {
+    static displayName = 'Local Category'
+  }
 
   export class RandomClass {}
 
@@ -370,21 +372,25 @@ module('Acceptance | code-submode | card playground', function (_hooks) {
 
       await click('[data-test-module-inspector-view="schema"]');
       await selectDeclaration('LocalCategoryCard');
-      assert.dom('[data-test-incompatible-nonexports]').doesNotExist();
       await togglePlaygroundPanel();
       assert
         .dom('[data-test-playground-panel]')
         .doesNotExist(
-          'playground preview is not available for LocalCategory (local card def)',
+          'playground panel exists for Category (exported card def)',
         );
-      assert.dom('[data-test-incompatible-nonexports]').exists();
+      assert.dom('[data-test-playground-incompatible-message]').exists();
+      assert
+        .dom('[data-test-playground-incompatible-message] span')
+        .containsText('Playground is not currently supported for this type.');
 
       await selectDeclaration('RandomClass');
       assert
         .dom('[data-test-module-inspector-view="preview"]')
-        .doesNotExist(
-          'does not exist for RandomClass (not a card or field def)',
-        );
+        .exists('inspector exists for RandomClass (not a card or field def)');
+      assert.dom('[data-test-playground-incompatible-message]').exists();
+      assert
+        .dom('[data-test-playground-incompatible-message] span')
+        .containsText('Playground is not currently supported for this type.');
 
       await selectDeclaration('BlogPost');
       assert

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -780,9 +780,9 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     assert.dom('[data-test-inheritance-panel-header]').doesNotExist();
     assert.dom('[data-test-card-module-definition]').doesNotExist();
     assert
-      .dom('[data-test-file-incompatibility-message]')
+      .dom('[data-test-schema-editor-file-incompatibility-message]')
       .hasText(
-        'No tools are available for the selected item: function "exportedFunction". Select a card or field definition in the inspector.',
+        `No tools are available for the selected item: function "exportedFunction". Select a card or field definition in the inspector.`,
       );
     assert.true(monacoService.getLineCursorOn()?.includes(elementName));
   });
@@ -1444,11 +1444,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
       .includesText('Re-exported Base Definition');
     assert.dom('[data-test-card-module-definition]').includesText('Base');
     assert.true(monacoService.getLineCursorOn()?.includes('BDef'));
-    assert
-      .dom('[data-test-file-incompatibility-message]')
-      .hasText(
-        'No tools are available to be used with these file contents. Choose a module that has a card or field definition inside of it.',
-      );
+    assert.dom('[data-test-file-incompatibility-message]').doesNotExist();
 
     //clicking on re-export (which doesn't enter module scope)
     elementName = 'Person';
@@ -1464,11 +1460,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
       .includesText('Re-exported Card Definition');
     assert.dom('[data-test-card-module-definition]').includesText('Card');
     assert.true(monacoService.getLineCursorOn()?.includes('Human'));
-    assert
-      .dom('[data-test-file-incompatibility-message]')
-      .hasText(
-        'No tools are available to be used with these file contents. Choose a module that has a card or field definition inside of it.',
-      );
+    assert.dom('[data-test-file-incompatibility-message]').doesNotExist();
   });
 
   test('"in-this-file" panel displays local grandfather card. selection will move cursor and display card or field schema', async function (assert) {
@@ -1622,7 +1614,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     assert.dom('[data-test-inheritance-panel-header]').doesNotExist();
     assert.dom('[data-test-card-module-definition]').doesNotExist();
     assert
-      .dom('[data-test-file-incompatibility-message]')
+      .dom('[data-test-schema-editor-file-incompatibility-message]')
       .hasText(
         'No tools are available for the selected item: function "exportedFunction". Select a card or field definition in the inspector.',
       );
@@ -1659,7 +1651,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     assert.dom('[data-test-inheritance-panel-header]').doesNotExist();
     assert.dom('[data-test-card-module-definition]').doesNotExist();
     assert
-      .dom('[data-test-file-incompatibility-message]')
+      .dom('[data-test-schema-editor-file-incompatibility-message]')
       .hasText(
         `No tools are available for the selected item: function "${renamedElementName}". Select a card or field definition in the inspector.`,
       );


### PR DESCRIPTION
- spec is meant to support commands and classes but top-level file incompatibility message is preventing renders of the 3 col tab on rhs
- main issue is fileIncompatibility and itemIncompatibility (incompatibility related to the declaration) is handled at the top-level of module-inspector
- in this PR, I separated  fileIncompatibility with itemIncompatibility. 
   - fileIncompatibility remains at the top-level of module-inspector
   - itemIncompatibility calculated at the component. This means schema, playground preview and spec handle those in their own component (if needed)
   
   
<img width="927" height="601" alt="Screenshot 2025-09-15 at 12 39 21" src="https://github.com/user-attachments/assets/24eb4fd0-ec84-4ca4-88ff-be7ea1a74f42" />

   
**Before**
<img width="1317" height="919" alt="Screenshot 2025-09-15 at 12 34 12" src="https://github.com/user-attachments/assets/b082688b-0e5d-4d50-ae0c-b8a51ec54823" />

**After**
<img width="1322" height="968" alt="Screenshot 2025-09-15 at 12 25 30" src="https://github.com/user-attachments/assets/f28e5b76-fbc7-412a-ad3e-e04082e7bb10" />

**A command needs a spec**

Here are the UI treatments for a command

<img width="1320" height="862" alt="Screenshot 2025-09-15 at 12 45 55" src="https://github.com/user-attachments/assets/af35c35a-6b7b-4927-a79b-c4fee92a250f" />

<img width="1316" height="922" alt="Screenshot 2025-09-15 at 12 46 01" src="https://github.com/user-attachments/assets/93b99369-ac24-4ff9-9963-fa0db1ca2311" />

<img width="1316" height="915" alt="Screenshot 2025-09-15 at 12 46 07" src="https://github.com/user-attachments/assets/bf2476e8-c6f5-49b0-8d26-30ab372b2c0e" />
