### PR TITLE
Remove `isLoadingNewModule`

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -307,10 +307,6 @@ export default class CodeSubmode extends Component<Signature> {
       declarations: this.codeSemanticsService.getDeclarations(file, isModule),
       moduleError: this.codeSemanticsService.getModuleError(file, isModule),
       isLoading: this.codeSemanticsService.getIsLoading(file, isModule),
-      isLoadingNewModule: this.codeSemanticsService.getIsLoadingNewModule(
-        file,
-        isModule,
-      ),
     };
   }
 

--- a/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
+++ b/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
@@ -487,7 +487,6 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
           {{else if (eq this.activePanel 'spec')}}
             <SpecPreview
               @selectedDeclaration={{@selectedDeclaration}}
-              @isLoadingNewModule={{@moduleAnalysis.isLoadingNewModule}}
               @setActiveModuleInspectorPanel={{this.setActivePanel}}
               @isPanelOpen={{eq this.activePanel 'spec'}}
               @selectedDeclarationAsCodeRef={{this.selectedDeclarationAsCodeRef}}

--- a/packages/host/app/components/operator-mode/code-submode/schema-editor.gts
+++ b/packages/host/app/components/operator-mode/code-submode/schema-editor.gts
@@ -121,10 +121,7 @@ export default class SchemaEditor extends Component<Signature> {
   }
 
   get isLoading() {
-    return (
-      this.args.moduleAnalysis.isLoadingNewModule ||
-      this.cardInheritanceChain.isLoading
-    );
+    return this.cardInheritanceChain.isLoading;
   }
 
   <template>

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -56,7 +56,6 @@ interface Signature {
   Element: HTMLElement;
   Args: {
     activeSpec: Spec | undefined;
-    isLoadingNewModule: boolean;
     isPanelOpen: boolean;
     selectedDeclaration?: ModuleDeclaration;
     selectedDeclarationAsCodeRef: ResolvedCodeRef;
@@ -348,7 +347,7 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
   }
 
   get isLoading() {
-    return this.args.isLoadingNewModule;
+    return false;
   }
 
   private viewSpecInPlayground = (spec: CardDefOrId) => {

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -154,10 +154,7 @@ export default class DetailPanel extends Component<Signature> {
   }
 
   private get isLoading() {
-    return (
-      this.args.moduleAnalysis.isLoadingNewModule ||
-      this.cardInstanceType?.isLoading
-    );
+    return this.cardInstanceType?.isLoading;
   }
 
   private get definitionActions() {

--- a/packages/host/app/resources/module-contents.ts
+++ b/packages/host/app/resources/module-contents.ts
@@ -45,7 +45,6 @@ export interface ModuleAnalysis {
   declarations: ModuleDeclaration[];
   moduleError: { type: 'runtime' | 'compile'; message: string } | undefined;
   isLoading: boolean;
-  isLoadingNewModule: boolean;
 }
 
 export class ModuleContentsResource
@@ -64,17 +63,6 @@ export class ModuleContentsResource
 
   get isLoading() {
     return this.load.isRunning;
-  }
-
-  // this resource is aware of loading new modules (ie it stores previous urls)
-  // it has to know this to distinguish the act of editing of a file and switching between definitions
-  // when editing a file we don't want to introduce loading state, whereas when switching between definitions we do
-  get isLoadingNewModule() {
-    if (!this.executableFile) {
-      return false;
-    }
-
-    return this.executableFile.url !== this.state?.url;
   }
 
   get declarations() {

--- a/packages/host/app/services/code-semantics-service.ts
+++ b/packages/host/app/services/code-semantics-service.ts
@@ -52,7 +52,6 @@ export default class CodeSemanticsService extends Service {
         declarations: [],
         moduleError: undefined,
         isLoading: false,
-        isLoadingNewModule: false,
       };
     }
 
@@ -89,12 +88,6 @@ export default class CodeSemanticsService extends Service {
     if (!isModule) return false;
     let resource = this.getResourceForFile(file);
     return resource.isLoading;
-  }
-
-  getIsLoadingNewModule(file: Ready | undefined, isModule: boolean): boolean {
-    if (!isModule) return false;
-    let resource = this.getResourceForFile(file);
-    return resource.isLoadingNewModule;
   }
 
   getSelectedDeclaration(

--- a/packages/host/tests/unit/services/code-semantics-service-test.ts
+++ b/packages/host/tests/unit/services/code-semantics-service-test.ts
@@ -120,7 +120,6 @@ module('Unit | Service | code-semantics', function (hooks) {
     service.getSelectedDeclaration(undefined, 'TestClass', true);
     service.getModuleError(undefined, true);
     service.getIsLoading(undefined, true);
-    service.getIsLoadingNewModule(undefined, true);
 
     assert.ok(declarations, 'getDeclarations handles undefined file');
     assert.ok(true, 'all methods handle undefined file without error');


### PR DESCRIPTION
last time the module-contents resource used to understand if you switch between modules but since the code-semantics service now delegates to the correct module-contents resources. We can safely assume its only ever a single url on the resource

This PR more importantly removes the usage of this faulty loading state in  components. They are not needed


Making this a pre-requisite of https://linear.app/cardstack/issue/CS-8763/change-module-inspector-loading-animations-to-be-consistent

Note: I took away one of the loading states from spec. Will assess whether to re-include loading state in the follow-up PR