### PR TITLE
Close ai panel before taking snapshot for index card hightlights

### DIFF
--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -2143,6 +2143,7 @@ module('Acceptance | interact submode tests', function (hooks) {
     test('displays highlights filter with special layout and community cards', async function (assert) {
       await visitOperatorMode({
         stacks: [[{ id: `${testRealmURL}index`, format: 'isolated' }]],
+        aiAssistantOpen: false,
         selectAllCardsFilter: false,
       });
 
@@ -2204,6 +2205,7 @@ module('Acceptance | interact submode tests', function (hooks) {
       assert.dom('[data-test-community-link]').exists({ count: 4 }); // Discord, Twitter, YouTube, Reddit
 
       // Take a snapshot of the highlights layout
+      await click('[data-test-close-ai-assistant]');
       await percySnapshot(assert);
 
       // Verify the community cards have the correct content

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -2143,7 +2143,6 @@ module('Acceptance | interact submode tests', function (hooks) {
     test('displays highlights filter with special layout and community cards', async function (assert) {
       await visitOperatorMode({
         stacks: [[{ id: `${testRealmURL}index`, format: 'isolated' }]],
-        aiAssistantOpen: false,
         selectAllCardsFilter: false,
       });
 


### PR DESCRIPTION
This is a follow up PR to this [chat](https://discord.com/channels/584043165066199050/900021750367129641/1414717541842157640) where index card highlight is not captured properly because the ai panel is opened.