### PR TITLE
make loading indicators consistent

### DIFF
--- a/packages/base/components/card-list.gts
+++ b/packages/base/components/card-list.gts
@@ -40,7 +40,9 @@ export default class CardList extends Component<Signature> {
           @isLive={{@isLive}}
         >
           <:loading>
-            <LoadingIndicator />
+            <div class='loading-container'>
+              <LoadingIndicator />
+            </div>
           </:loading>
           <:response as |cards|>
             {{#each cards key='url' as |card|}}
@@ -132,6 +134,11 @@ export default class CardList extends Component<Signature> {
       }
       .instance-error:hover .boundaries {
         box-shadow: 0 0 0 1px var(--boxel-dark);
+      }
+      .loading-container {
+        grid-column: 1 / -1;
+        justify-content: center;
+        min-height: 50vh;
       }
     </style>
   </template>

--- a/packages/host/app/components/operator-mode/card-adoption-chain.gts
+++ b/packages/host/app/components/operator-mode/card-adoption-chain.gts
@@ -38,8 +38,7 @@ export default class CardAdoptionChain extends Component<Signature> {
     <div ...attributes>
       {{#if @isLoading}}
         <div class='loading'>
-          <LoadingIndicator class='loading-icon' />
-          Loading...
+          <LoadingIndicator />
         </div>
       {{else}}
         {{#each @cardInheritanceChain as |data index|}}
@@ -64,12 +63,9 @@ export default class CardAdoptionChain extends Component<Signature> {
     </div>
     <style scoped>
       .loading {
-        display: inline-flex;
-      }
-      .loading-icon {
-        display: inline-block;
-        margin-right: var(--boxel-sp-xxxs);
-        vertical-align: middle;
+        display: flex;
+        justify-content: center;
+        margin: 30vh auto;
       }
     </style>
   </template>

--- a/packages/host/app/components/operator-mode/code-editor.gts
+++ b/packages/host/app/components/operator-mode/code-editor.gts
@@ -517,7 +517,10 @@ export default class CodeEditor extends Component<Signature> {
         border-color: #454545;
       }
       .loading {
-        margin: 40vh auto;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 100%;
       }
     </style>
   </template>

--- a/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
+++ b/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
@@ -425,9 +425,15 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
               @activeSpec={{this.activeSpec}}
               @specsForSelectedDefinition={{this.specsForSelectedDefinition}}
               @showCreateSpec={{this.showCreateSpec}}
-              as |SpecPreviewContent|
             >
-              <SpecPreviewContent class='non-preview-panel-content' />
+              <:loading as |SpecPreviewLoading|>
+                <div class='non-preview-panel-content'>
+                  <SpecPreviewLoading />
+                </div>
+              </:loading>
+              <:content as |SpecPreviewContent|>
+                <SpecPreviewContent class='non-preview-panel-content' />
+              </:content>
             </SpecPreview>
           {{/if}}
         </section>
@@ -464,6 +470,7 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
 
       .module-inspector-content {
         overflow: auto;
+        padding: var(--boxel-sp-xs);
         height: 100%;
         background-color: var(--boxel-light);
       }

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
@@ -881,7 +881,9 @@ export default class PlaygroundPanel extends Component<Signature> {
     <section class='playground-panel' data-test-playground-panel>
       <div class='playground-panel-content' style={{this.setMaxWidth}}>
         {{#if this.isLoading}}
-          <LoadingIndicator @color='var(--boxel-light)' />
+          <div class='loading'>
+            <LoadingIndicator @color='var(--boxel-light)' />
+          </div>
         {{else}}
           {{#let (if @isFieldDef this.field this.card) as |card|}}
             {{#let
@@ -1029,6 +1031,11 @@ export default class PlaygroundPanel extends Component<Signature> {
       }
       .card-error-detail :deep(.instance-chooser) {
         border-radius: var(--boxel-border-radius);
+      }
+      .loading {
+        display: flex;
+        justify-content: center;
+        margin: 30vh auto;
       }
     </style>
   </template>

--- a/packages/host/app/components/operator-mode/code-submode/schema-editor.gts
+++ b/packages/host/app/components/operator-mode/code-submode/schema-editor.gts
@@ -177,7 +177,7 @@ export default class SchemaEditor extends Component<Signature> {
   }
 
   get isLoading() {
-    return true; // Temporarily set to true to show loading state
+    return this.cardInheritanceChain.isLoading;
   }
 
   get shouldRender() {

--- a/packages/host/app/components/operator-mode/code-submode/schema-editor.gts
+++ b/packages/host/app/components/operator-mode/code-submode/schema-editor.gts
@@ -177,7 +177,7 @@ export default class SchemaEditor extends Component<Signature> {
   }
 
   get isLoading() {
-    return this.cardInheritanceChain.isLoading;
+    return true; // Temporarily set to true to show loading state
   }
 
   get shouldRender() {

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -65,18 +65,18 @@ interface Signature {
     updatePlaygroundSelections(id: string, fieldDefOnly?: boolean): void;
   };
   Blocks: {
-    default: [
-      | WithBoundArgs<
-          typeof SpecPreviewContent,
-          | 'showCreateSpec'
-          | 'canWrite'
-          | 'onSelectSpec'
-          | 'activeSpec'
-          | 'isLoading'
-          | 'allSpecs'
-          | 'viewSpecInPlayground'
-        >
-      | WithBoundArgs<typeof SpecPreviewLoading, never>,
+    loading: [WithBoundArgs<typeof SpecPreviewLoading, never>];
+    content: [
+      WithBoundArgs<
+        typeof SpecPreviewContent,
+        | 'showCreateSpec'
+        | 'canWrite'
+        | 'onSelectSpec'
+        | 'activeSpec'
+        | 'isLoading'
+        | 'allSpecs'
+        | 'viewSpecInPlayground'
+      >,
     ];
   };
 }
@@ -305,28 +305,14 @@ interface SpecPreviewLoadingSignature {
 
 const SpecPreviewLoading: TemplateOnlyComponent<SpecPreviewLoadingSignature> =
   <template>
-    <div class='container'>
-      <div class='loading'>
-        <LoadingIndicator class='loading-icon' />
-        Loading...
-      </div>
+    <div class='loading'>
+      <LoadingIndicator />
     </div>
     <style scoped>
-      .container {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        flex-direction: column;
-        height: 100%;
-        width: 100%;
-      }
       .loading {
-        display: inline-flex;
-      }
-      .loading-icon {
-        display: inline-block;
-        margin-right: var(--boxel-sp-xxxs);
-        vertical-align: middle;
+        display: flex;
+        justify-content: center;
+        margin: 30vh auto;
       }
     </style>
   </template>;
@@ -360,7 +346,7 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
 
   <template>
     {{#if this.isLoading}}
-      {{yield (component SpecPreviewLoading)}}
+      {{yield (component SpecPreviewLoading) to='loading'}}
     {{else}}
       {{yield
         (component
@@ -373,6 +359,7 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
           allSpecs=@specsForSelectedDefinition
           viewSpecInPlayground=this.viewSpecInPlayground
         )
+        to='content'
       }}
     {{/if}}
   </template>

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -537,6 +537,8 @@ export default class DetailPanel extends Component<Signature> {
       .loading {
         display: flex;
         justify-content: center;
+        align-items: center;
+        height: 100%;
       }
       .delete-module-button {
         --icon-stroke-width: 1.2px;


### PR DESCRIPTION
**Before Code Mode Playground**
<img width="1451" height="966" alt="code-playground" src="https://github.com/user-attachments/assets/fa8f224f-fc1a-4ecc-8017-6be63c08c4a8" />


**After Code Mode Playground**
<img width="1915" height="913" alt="code-playground-after" src="https://github.com/user-attachments/assets/7ad77d6c-9d59-4412-b461-02b661867a5b" />

**Before Code Mode Schema**
<img width="1445" height="966" alt="code-schema" src="https://github.com/user-attachments/assets/a0ea1f8b-3116-4e0b-a16f-cdd99a734e91" />

**After Code Mode Schema**
<img width="1919" height="914" alt="code-schema-after" src="https://github.com/user-attachments/assets/64c8f0f5-752b-4e17-a8b8-5550508caaca" />


**Before Code Mode Spec**
<img width="1448" height="965" alt="code-spec" src="https://github.com/user-attachments/assets/de318091-719d-4cc1-a229-38a966e50b35" />

**After Code Mode Spec**
<img width="1918" height="915" alt="code-spec-after" src="https://github.com/user-attachments/assets/fed1e324-4e0b-49c6-b93a-143225abdcdc" />

**Before Interact Search**
<img width="1910" height="953" alt="interact-search" src="https://github.com/user-attachments/assets/368f280d-31ff-42ee-9c04-4e19b60cb0bc" />

**After Interact Search**
<img width="1914" height="910" alt="interact-search-after" src="https://github.com/user-attachments/assets/21496e2f-217b-4ea4-b22d-92674f7405cc" />

