### PR TITLE
Code patch: don't show error message when patch has been applied

### DIFF
--- a/packages/host/app/components/ai-assistant/message/aibot-message.gts
+++ b/packages/host/app/components/ai-assistant/message/aibot-message.gts
@@ -218,6 +218,7 @@ class HtmlGroupCodeBlock extends Component<HtmlGroupCodeBlockSignature> {
           this,
           this.args.codeData.fileUrl,
           this.args.codeData.searchReplaceBlock,
+          this.args.codePatchStatus as CodePatchStatus,
         )
       : undefined;
     return this._codeDiffResource;
@@ -271,6 +272,7 @@ class HtmlGroupCodeBlock extends Component<HtmlGroupCodeBlockSignature> {
     } else if (this.codeDiffResource?.errorMessage) {
       return this.codeDiffResource.errorMessage;
     }
+    return null;
   }
 
   <template>

--- a/packages/host/app/components/ai-assistant/message/aibot-message.gts
+++ b/packages/host/app/components/ai-assistant/message/aibot-message.gts
@@ -264,15 +264,13 @@ class HtmlGroupCodeBlock extends Component<HtmlGroupCodeBlockSignature> {
   }
 
   private get codePatchErrorMessage() {
-    if (this.args.codePatchStatus === 'failed') {
+    if (this.args.codePatchStatus === 'applied') {
+      return null;
+    } else if (this.args.codePatchStatus === 'failed') {
       return this.args.codePatchResult?.failureReason;
-    }
-
-    if (this.codeDiffResource?.errorMessage) {
+    } else if (this.codeDiffResource?.errorMessage) {
       return this.codeDiffResource.errorMessage;
     }
-
-    return null;
   }
 
   <template>

--- a/packages/host/tests/acceptance/code-patches-test.gts
+++ b/packages/host/tests/acceptance/code-patches-test.gts
@@ -1142,6 +1142,8 @@ ${REPLACE_MARKER}
     assert.dom('[data-test-code-diff-editor]').doesNotExist();
     assert.dom('[data-test-editor]').exists();
 
+    assert.dom('[data-test-error-message]').doesNotExist();
+
     await click('[data-test-attached-file-dropdown-button="hello.txt"]');
     assert
       .dom('[data-test-boxel-menu-item-text="Restore Generated Content"]')


### PR DESCRIPTION
Fixes the bug where an error would show for an applied code patch:

<img width="782" height="438" alt="image" src="https://github.com/user-attachments/assets/5ff9df48-43c1-4925-80d9-b36c87b1fd06" />
