### PR TITLE
Add JWT verification failure logging

### DIFF
--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -1408,11 +1408,17 @@ export class Realm {
           'Insufficient permissions to perform this action',
         );
       }
-    } catch (e) {
+    } catch (e: any) {
       if (e instanceof TokenExpiredError) {
+        this.#log.warn(
+          `JWT verification failed for ${request.method} ${request.url} with token string ${tokenString}. ${e.message}, expired at ${e.expiredAt}`,
+        );
         throw new AuthenticationError(AuthenticationErrorMessages.TokenExpired);
       }
       if (e instanceof JsonWebTokenError) {
+        this.#log.warn(
+          `JWT verification failed for ${request.method} ${request.url} with token string ${tokenString}. ${e.message}`,
+        );
         throw new AuthenticationError(AuthenticationErrorMessages.TokenInvalid);
       }
       throw e;


### PR DESCRIPTION
This PR adds JWT verification failure logging, and makes it very loud. The next time we encounter a scenario where JWT's fail to verify after a period that is too short (less than 7 days) use the grafana logs to inspect the realm server for this log message to get more insight on why the JWTs are prematurely failing to verify