### PR TITLE
server: Add assets override environment variable

### DIFF
--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -274,7 +274,9 @@ let autoMigrate = migrateDB || undefined;
     grafanaSecret: GRAFANA_SECRET,
     dbAdapter,
     queue,
-    assetsURL: dist,
+    assetsURL: process.env.ASSETS_URL_OVERRIDE
+      ? new URL(process.env.ASSETS_URL_OVERRIDE)
+      : dist,
     getIndexHTML,
     serverURL: new URL(serverURL),
     matrixRegistrationSecret: MATRIX_REGISTRATION_SHARED_SECRET,


### PR DESCRIPTION
This helps with host mode development as an HTTP asset host can’t be accessed from an HTTPS host mode endpoint.