### PR TITLE
Add default-preview section to card-info default edit template

### DIFF
--- a/packages/base/default-templates/card-info.gts
+++ b/packages/base/default-templates/card-info.gts
@@ -2,16 +2,21 @@ import GlimmerComponent from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { on } from '@ember/modifier';
 
+import CaptionsIcon from '@cardstack/boxel-icons/captions';
 import NameIcon from '@cardstack/boxel-icons/folder-pen';
 import SummaryIcon from '@cardstack/boxel-icons/notepad-text';
 import LinkIcon from '@cardstack/boxel-icons/link';
 import ThemeIcon from '@cardstack/boxel-icons/palette';
 
-import type { CardOrFieldTypeIcon, CardInfoField } from '../card-api';
+import type { CardOrFieldTypeIcon, CardDef, FieldsTypeFor } from '../card-api';
 
 import setBackgroundImage from '../helpers/set-background-image';
 
 import { FieldContainer, Button } from '@cardstack/boxel-ui/components';
+import { cn } from '@cardstack/boxel-ui/helpers';
+import { ChevronRight } from '@cardstack/boxel-ui/icons';
+
+import { getFieldIcon } from '@cardstack/runtime-common';
 
 class CardInfoImageContainer extends GlimmerComponent<{
   Args: {
@@ -103,9 +108,8 @@ class CardInfoView extends GlimmerComponent<ViewSignature> {
 
 interface EditSignature {
   Args: {
-    icon?: CardOrFieldTypeIcon;
-    fields?: Record<string, new () => GlimmerComponent>;
-    model?: CardInfoField;
+    fields?: FieldsTypeFor<CardDef>;
+    model?: CardDef;
     hideThemeChooser?: boolean;
   };
 }
@@ -113,13 +117,68 @@ interface EditSignature {
 class CardInfoEditor extends GlimmerComponent<EditSignature> {
   <template>
     <div class='cardInfo-editor'>
-      <FieldContainer>
+      <Button
+        class={{cn 'preview-toggle' is-preview-visible=this.isPreviewVisible}}
+        @size='extra-small'
+        @kind='text-only'
+        {{on 'click' this.togglePreview}}
+        data-test-toggle-preview
+      >
+        {{if this.isPreviewVisible 'Hide' 'Show'}}
+        Default Preview
+        <ChevronRight
+          class='preview-toggle-icon'
+          width='14'
+          height='14'
+          role='presentation'
+        />
+      </Button>
+      {{#if this.isPreviewVisible}}
+        <div class='default-preview'>
+          <FieldContainer
+            @label='Card Type'
+            @icon={{CaptionsIcon}}
+            data-test-edit-preview='cardType'
+          >
+            {{@model.constructor.displayName}}
+          </FieldContainer>
+          <FieldContainer
+            @label='Title'
+            @icon={{getFieldIcon @model 'title'}}
+            data-test-edit-preview='cardTitle'
+          >
+            <@fields.title @format='embedded' />
+          </FieldContainer>
+          <FieldContainer
+            @label='Description'
+            @icon={{getFieldIcon @model 'description'}}
+            data-test-edit-preview='cardDescription'
+          >
+            <@fields.description @format='embedded' />
+          </FieldContainer>
+          <FieldContainer
+            @label='Hosted URL'
+            @icon={{LinkIcon}}
+            data-test-edit-preview='cardHostedURL'
+          >
+            {{! TODO }}
+          </FieldContainer>
+          <FieldContainer
+            @label='Thumbnail URL'
+            @icon={{LinkIcon}}
+            data-test-edit-preview='cardThumbnailURL'
+          >
+            <@fields.thumbnailURL @format='embedded' />
+          </FieldContainer>
+        </div>
+      {{/if}}
+      <FieldContainer class='main-fields'>
         <:label>
           <div class='cardInfo-thumbnail-container'>
             <CardInfoImageContainer
               class='cardInfo-thumbnail-preview'
-              @thumbnailURL={{@model.thumbnailURL}}
-              @icon={{@icon}}
+              @thumbnailURL={{@model.cardInfo.thumbnailURL}}
+              @icon={{@model.constructor.icon}}
               data-test-thumbnail-image
             />
             <Button
@@ -145,7 +204,7 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
               @vertical={{true}}
               data-test-field='cardInfo-name'
             >
-              <@fields.title />
+              <@fields.cardInfo.title />
             </FieldContainer>
             <FieldContainer
               class='card-info-field'
@@ -156,7 +215,7 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
               @vertical={{true}}
               data-test-field='cardInfo-summary'
             >
-              <@fields.description />
+              <@fields.cardInfo.description />
             </FieldContainer>
           </div>
         </:default>
@@ -170,7 +229,7 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
             @icon={{LinkIcon}}
             data-test-field='cardInfo-thumbnailURL'
           >
-            <@fields.thumbnailURL />
+            <@fields.cardInfo.thumbnailURL />
           </FieldContainer>
           {{#unless @hideThemeChooser}}
             <FieldContainer
@@ -180,7 +239,7 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
               @icon={{ThemeIcon}}
               data-test-field='cardInfo-theme'
             >
-              <@fields.theme />
+              <@fields.cardInfo.theme />
             </FieldContainer>
           {{/unless}}
         </div>
@@ -192,6 +251,32 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
         position: relative;
         width: 100%;
         max-width: 100%;
+      }
+      .preview-toggle {
+        position: absolute;
+        top: calc(-1 * var(--boxel-sp-sm));
+        right: 0;
+        min-width: 9.5rem;
+        justify-content: space-between;
+        padding: var(--boxel-sp-4xs);
+      }
+      .preview-toggle-icon {
+        transform: rotate(90deg);
+      }
+      .is-preview-visible .preview-toggle-icon {
+        transform: rotate(-90deg);
+      }
+      .preview-toggle + .default-preview {
+        margin-top: var(--boxel-sp-lg);
+      }
+      .default-preview + .main-fields {
+        margin-top: var(--boxel-sp-lg);
+      }
+      .default-preview {
+        padding: var(--boxel-sp-lg);
+        background-color: var(--accent, var(--boxel-200));
+        border-radius: var(--radius, var(--boxel-border-radius));
+        color: var(--accent-foreground, var(--boxel-dark));
       }
       .cardInfo-thumbnail-container {
         display: flex;
@@ -218,7 +303,12 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
     </style>
   </template>
 
+  @tracked private isPreviewVisible = false;
   @tracked private isThumbnailEditorVisible = false;
+
+  private togglePreview = () => {
+    this.isPreviewVisible = !this.isPreviewVisible;
+  };
 
   private toggleThumbnailEditor = () => {
     this.isThumbnailEditorVisible = !this.isThumbnailEditorVisible;

--- a/packages/base/default-templates/isolated-and-edit.gts
+++ b/packages/base/default-templates/isolated-and-edit.gts
@@ -1,17 +1,15 @@
 import GlimmerComponent from '@glimmer/component';
-import type { CardDef, Format } from '../card-api';
+import type { CardDef, FieldsTypeFor, Format } from '../card-api';
 import { FieldContainer, Header } from '@cardstack/boxel-ui/components';
 import { cn, eq } from '@cardstack/boxel-ui/helpers';
 import { startCase } from 'lodash';
 import { getFieldIcon, getField } from '@cardstack/runtime-common';
 import CardInfoTemplates from './card-info';
 
-type Fields = Record<string, new () => GlimmerComponent>;
-
 export default class DefaultCardDefTemplate extends GlimmerComponent<{
   Args: {
     model: CardDef;
-    fields: Fields & { cardInfo: Fields };
+    fields: FieldsTypeFor<CardDef>;
     format: Format;
   };
 }> {
@@ -35,7 +33,7 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
   }
 
   // Fields to display in between the cardInfo header and notes footer
-  private get displayFields(): Fields | undefined {
+  private get displayFields(): FieldsTypeFor<CardDef> | undefined {
     let excludedFields = this.excludedFields.filter(
       (name) => !this.specialDisplayFieldNames?.includes(name),
     );
@@ -45,7 +43,7 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
     if (!fields.length) {
       return;
     }
-    return Object.fromEntries(fields) as Fields;
+    return Object.fromEntries(fields) as FieldsTypeFor<CardDef>;
   }
 
   private get isThemeCard() {
@@ -66,9 +64,8 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
           />
         {{else}}
           <CardInfoTemplates.edit
-            @fields={{@fields.cardInfo}}
-            @model={{@model.cardInfo}}
-            @icon={{@model.constructor.icon}}
+            @fields={{@fields}}
+            @model={{@model}}
             @hideThemeChooser={{this.isThemeCard}}
           />
         {{/if}}
@@ -81,7 +78,6 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
               @icon={{getFieldIcon @model key}}
               data-test-field={{key}}
             >
-              {{! @glint-ignore: unknown not assignable to type Element }}
               <Field class='in-isolated' />
             </FieldContainer>
           {{/each-in}}
@@ -104,7 +100,7 @@ export default class DefaultCardDefTemplate extends GlimmerComponent<{
       }
       .card-info-header {
         --boxel-header-min-height: 9.375rem; /* 150px */
-        --boxel-header-padding: var(--boxel-sp-lg);
+        --boxel-header-padding: var(--boxel-sp-xl);
         --boxel-header-gap: var(--boxel-sp-lg);
         --boxel-header-border-color: var(--hr-color);
         align-items: flex-start;

--- a/packages/boxel-ui/addon/src/components/card-container/index.gts
+++ b/packages/boxel-ui/addon/src/components/card-container/index.gts
@@ -66,11 +66,6 @@ const CardContainer: TemplateOnlyComponent<Signature> = <template>
     :global(.boxel-card-container--boundaries.hide-boundaries) {
       box-shadow: none;
     }
-    :global(.boxel-card-container .boxel-card-container) {
-      background-color: var(--card, var(--boxel-light));
-      border-radius: var(--radius, var(--boxel-border-radius));
-      color: var(--card-foreground, var(--boxel-dark));
-    }
   </style>
 </template>;
 

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -1783,6 +1783,8 @@ module('Integration | card-basics', function (hooks) {
             '## Meeting Notes\n\nDate: January 15, 2024<br>\nParticipants: John Doe, Jane Smith, Alice Johnson\n\n### Key Points Discussed\n<ul>\n<li>Project timeline was reviewed and adjusted for Q2</li>\n<li> Budget allocation confirmed</li>\n<li> Risk assessment introduced, with mitigation strategies \n   identified</li>\n</ul>\n\n### Actions Items\n<ol>\n<li> <strong>John Doe:</strong> Update project timeline by January 20</li>\n<li> <strong>Jane Smith:</strong> Finalize budget report by January 22</li>\n<li> <strong>Alice Johnson:</strong> Conduct a follow-up meeting with  \n    stakeholders by January 30</li>\n</ol>',
         }),
       });
+
+      // isolated format
       await renderCard(loader, instance, 'isolated');
       assert.dom('[data-test-thumbnail-icon]').exists();
       assert.dom('[data-test-field="cardTitle"]').hasText(title);
@@ -1791,6 +1793,7 @@ module('Integration | card-basics', function (hooks) {
         .dom('[data-test-field="cardInfo-notes"]')
         .containsText('Meeting Notes');
 
+      // edit format
       await renderCard(loader, instance, 'edit');
       assert.dom('[data-test-field="cardInfo-name"] input').hasValue(title);
       assert
@@ -1805,8 +1808,28 @@ module('Integration | card-basics', function (hooks) {
       await click('[data-test-toggle-thumbnail-editor]');
       assert.dom('[data-test-field="cardInfo-thumbnailURL"]').doesNotExist();
       assert.dom('[data-test-links-to-editor="theme"]').doesNotExist();
-
       assert.dom('[data-test-field="cardInfo-notes"] textarea').exists();
+
+      // default preview (on edit template)
+      await click('[data-test-toggle-preview]');
+      assert
+        .dom('[data-test-edit-preview="cardType"]')
+        .hasText('Card Type Card');
+      assert.dom('[data-test-edit-preview="cardTitle"]').containsText(title);
+      assert
+        .dom('[data-test-edit-preview="cardDescription"]')
+        .containsText(description);
+      assert
+        .dom('[data-test-edit-preview="cardHostedURL"]')
+        .hasText('Hosted URL');
+      assert
+        .dom('[data-test-edit-preview="cardThumbnailURL"]')
+        .hasText('Thumbnail URL');
+      assert
+        .dom('[data-test-edit-preview] input')
+        .doesNotExist('preview fields are not editable');
+      await click('[data-test-toggle-preview]');
+      assert.dom('[data-test-edit-preview]').doesNotExist();
     });
 
     test('render card-def instance with cardInfo overrides', async function (assert) {
@@ -1859,17 +1882,31 @@ module('Integration | card-basics', function (hooks) {
         .dom('[data-test-field="cardInfo-thumbnailURL"] input')
         .hasValue('http://pic/of/volleyball');
       assert.dom('[data-test-links-to-editor="theme"]').exists();
-      await click('[data-test-toggle-thumbnail-editor]');
       assert.dom('[data-test-field="cardInfo-notes"] textarea').exists();
       assert.dom('[data-test-field="firstName"] input').hasValue('John');
       assert
         .dom('[data-test-field="profilePic"] input')
         .hasValue('http://john/pic.jpg');
+
+      // default preview (on edit template)
+      await click('[data-test-toggle-preview]');
+      assert.dom('[data-test-edit-preview="cardType"]').containsText('Person');
+      assert
+        .dom('[data-test-edit-preview="cardTitle"]')
+        .containsText('John Doe');
+      assert
+        .dom('[data-test-edit-preview="cardDescription"]')
+        .containsText('Volleyball player');
+      assert
+        .dom('[data-test-edit-preview="cardThumbnailURL"]')
+        .containsText('http://john/pic.jpg');
+
+      await percySnapshot(assert);
     });
 
     test('render card-def instance with cardInfo overrides variation', async function (assert) {
       class Book extends CardDef {
-        static displayName = 'Person';
+        static displayName = 'Book';
         @field bookTitle = contains(StringField);
         @field blurb = contains(StringField);
         @field bookCoverImage = contains(StringField);
@@ -1923,11 +1960,24 @@ module('Integration | card-basics', function (hooks) {
       assert
         .dom('[data-test-field="bookCoverImage"] input')
         .hasValue('http://book/pic.jpg');
+
+      // default preview (on edit template)
+      await click('[data-test-toggle-preview]');
+      assert.dom('[data-test-edit-preview="cardType"]').containsText('Book');
+      assert
+        .dom('[data-test-edit-preview="cardTitle"]')
+        .containsText('Insomniac');
+      assert
+        .dom('[data-test-edit-preview="cardDescription"]')
+        .containsText('This book will keep you up at night');
+      assert
+        .dom('[data-test-edit-preview="cardThumbnailURL"]')
+        .containsText('http://book/pic.jpg');
     });
 
     test('render card-def instance with cardInfo overrides (not computed)', async function (assert) {
       class Book extends CardDef {
-        static displayName = 'Person';
+        static displayName = 'Book';
         @field title = contains(StringField);
         @field description = contains(StringField);
         @field thumbnailURL = contains(StringField);
@@ -1975,6 +2025,19 @@ module('Integration | card-basics', function (hooks) {
       assert
         .dom('[data-test-field="thumbnailURL"] input')
         .hasValue('http://book/pic.jpg');
+
+      // default preview (on edit template)
+      await click('[data-test-toggle-preview]');
+      assert.dom('[data-test-edit-preview="cardType"]').containsText('Book');
+      assert
+        .dom('[data-test-edit-preview="cardTitle"]')
+        .containsText('Insomniac');
+      assert
+        .dom('[data-test-edit-preview="cardDescription"]')
+        .containsText('This book will keep you up at night');
+      assert
+        .dom('[data-test-edit-preview="cardThumbnailURL"]')
+        .containsText('http://book/pic.jpg');
     });
 
     test('render card-def instance with cardInfo overrides (complex)', async function (assert) {
@@ -2053,6 +2116,20 @@ module('Integration | card-basics', function (hooks) {
         .hasNoValue();
       await click('[data-test-toggle-thumbnail-editor]');
       assert.dom('[data-test-field="destination"] input').hasValue('LAX');
+
+      // default preview (in edit mode)
+      await click('[data-test-toggle-preview]');
+      assert
+        .dom('[data-test-edit-preview="cardType"]')
+        .containsText('Flight Booking');
+      assert
+        .dom('[data-test-edit-preview="cardTitle"]')
+        .containsText('JFK to LAX (12/25/25) Flt. 101');
+      assert
+        .dom('[data-test-edit-preview="cardDescription"]')
+        .containsText(
+          'Smith Wedding Flight - John, Jane + kids to LA for holiday wedding',
+        );
     });
 
     test('render default isolated template', async function (assert) {


### PR DESCRIPTION
<img width="994" height="468" alt="default-preview-closed" src="https://github.com/user-attachments/assets/5ad20e22-718e-4b96-b86c-c7600841fce0" />

<img width="998" height="783" alt="default-preview-expanded" src="https://github.com/user-attachments/assets/c5db262f-f567-42ad-b4d7-7e06f48c0883" />
