### PR TITLE
Fix: Cannot read properties of undefined (reading 'id') when publishing realm

### DIFF
--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -207,6 +207,7 @@ export default function handlePublishRealm({
       ensureDirSync(publishedRealmPath);
 
       if (existingPublishedRealm) {
+        realms.splice(realms.indexOf(existingPublishedRealm), 1);
         virtualNetwork.unmount(existingPublishedRealm.handle);
       }
       let realm = createAndMountRealm(


### PR DESCRIPTION
There was a bug that @backspace encountered when publishing a realm. The issue occurs because the `publish-realm` endpoint does not remove the realm instance from `server.realms`, which allows multiple instances of the same realm to exist in `server.realms` while only one record is present in the `published_realms` table. When unpublishing, only one instance and the corresponding record in the `published_realms` table are removed. As a result, if the user tries to publish the realm again, an error occurs because the instance still exists in memory but no data exists in the table.