### PR TITLE
Avoid search returning 500 due to unknown card type

### DIFF
--- a/packages/realm-server/tests/atomic-endpoints-test.ts
+++ b/packages/realm-server/tests/atomic-endpoints-test.ts
@@ -703,10 +703,9 @@ module(basename(__filename), function () {
           assert.strictEqual(response.status, 500);
           assert.strictEqual(response.body.errors.length, 1);
           assert.strictEqual(response.body.errors[0].title, 'Write Error');
-          assert.ok(
-            response.body.errors[0].detail.includes(
-              `Error: tried to get definition for {"module":"${testRealmHref}place-modules/place","name":"Place"}, but got 404`,
-            ),
+          assert.strictEqual(
+            response.body.errors[0].detail,
+            `Your filter refers to a nonexistent type: import { Place } from "${testRealmHref}place-modules/place"`,
             'error message is correct',
           );
         });

--- a/packages/realm-server/tests/realm-endpoints/search-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/search-test.ts
@@ -79,6 +79,34 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
           assert.strictEqual(json.meta.page.total, 1, 'total count is correct');
         });
 
+        test('gets no results when asking for a type that the realm does not have knowledge of', async function (assert) {
+          let unknownTypeQuery: Query = {
+            filter: {
+              on: {
+                module: 'http://some-realm-server/some-realm/some-card',
+                name: 'SomeCard',
+              },
+              eq: {
+                firstName: 'Mango',
+              },
+            },
+          };
+
+          let response = await request
+            .get(`/_search?${stringify(unknownTypeQuery)}`)
+            .set('Accept', 'application/vnd.card+json');
+
+          assert.strictEqual(response.status, 200, 'HTTP 200 status');
+          let json = response.body;
+
+          assert.strictEqual(
+            json.data.length,
+            0,
+            'returned results count is correct',
+          );
+          assert.strictEqual(json.meta.page.total, 0, 'total count is correct');
+        });
+
         test('can paginate search results', async function (assert) {
           // Query for all persons to get multiple results
           let paginationQuery: Query = {

--- a/packages/realm-server/tests/search-prerendered-test.ts
+++ b/packages/realm-server/tests/search-prerendered-test.ts
@@ -939,6 +939,38 @@ module(basename(__filename), function () {
           ]);
         });
 
+        test('gets no results when asking for a type that the realm does not have knowledge of', async function (assert) {
+          let complexQuery = {
+            filter: {
+              on: {
+                module: `http://some-realm-server/some-realm/some-card`,
+                name: 'SomeCard',
+              },
+              not: {
+                eq: {
+                  firstName: 'Peter',
+                },
+              },
+            },
+            prerenderedHtmlFormat: 'embedded',
+          };
+
+          let response = await request
+            .post('/_search-prerendered')
+            .set('Accept', 'application/vnd.card+json')
+            .set('X-HTTP-Method-Override', 'QUERY')
+            .send(complexQuery);
+
+          assert.strictEqual(response.status, 200, 'HTTP 200 status');
+          let json = response.body;
+
+          assert.strictEqual(
+            json.data.length,
+            0,
+            'returned results count is correct',
+          );
+        });
+
         test('can sort prerendered instances using QUERY method', async function (assert) {
           let query = {
             sort: [

--- a/packages/runtime-common/definitions-cache.ts
+++ b/packages/runtime-common/definitions-cache.ts
@@ -19,6 +19,7 @@ export class FilterRefersToNonexistentTypeError extends Error {
     if (opts?.cause !== undefined) {
       (this as any).cause = opts.cause;
     }
+    // make sure instances of this Error subclass behave like instances of the subclass should
     Object.setPrototypeOf(this, new.target.prototype);
   }
 }

--- a/packages/runtime-common/definitions-cache.ts
+++ b/packages/runtime-common/definitions-cache.ts
@@ -7,9 +7,32 @@ import {
 import stringify from 'safe-stable-stringify';
 import qs from 'qs';
 
+export class FilterRefersToNonexistentTypeError extends Error {
+  codeRef: ResolvedCodeRef;
+
+  constructor(codeRef: ResolvedCodeRef, opts?: { cause?: unknown }) {
+    super(
+      `Your filter refers to a nonexistent type: import { ${codeRef.name} } from "${codeRef.module}"`,
+    );
+    this.name = 'FilterRefersToNonexistentTypeError';
+    this.codeRef = codeRef;
+    if (opts?.cause !== undefined) {
+      (this as any).cause = opts.cause;
+    }
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export function isFilterRefersToNonexistentTypeError(
+  error: unknown,
+): error is FilterRefersToNonexistentTypeError {
+  return error instanceof FilterRefersToNonexistentTypeError;
+}
+
 export class DefinitionsCache {
   #fetch: typeof globalThis.fetch;
   #cache = new Map<string, Definition>();
+  #missing = new Map<string, FilterRefersToNonexistentTypeError>();
 
   constructor(fetch: typeof globalThis.fetch) {
     this.#fetch = fetch;
@@ -17,6 +40,7 @@ export class DefinitionsCache {
 
   invalidate() {
     this.#cache = new Map();
+    this.#missing = new Map();
   }
 
   // for tests
@@ -26,13 +50,25 @@ export class DefinitionsCache {
 
   async getDefinition(codeRef: ResolvedCodeRef): Promise<Definition> {
     let key = internalKeyFor(codeRef, undefined);
+    let missing = this.#missing.get(key);
+    if (missing) {
+      throw missing;
+    }
     let cached = this.#cache.get(key);
     if (cached) {
       return cached;
     }
-    let definition = await this.fetchDefinition(codeRef);
-    this.#cache.set(key, definition);
-    return definition;
+    try {
+      let definition = await this.fetchDefinition(codeRef);
+      this.#cache.set(key, definition);
+      this.#missing.delete(key);
+      return definition;
+    } catch (error) {
+      if (isFilterRefersToNonexistentTypeError(error)) {
+        this.#missing.set(key, error);
+      }
+      throw error;
+    }
   }
 
   private async fetchDefinition(codeRef: ResolvedCodeRef): Promise<Definition> {
@@ -42,12 +78,13 @@ export class DefinitionsCache {
         method: 'HEAD',
       });
     } catch (e) {
-      throw new Error(
-        `Your filter refers to a nonexistent type: import { ${codeRef.name} } from "${codeRef.module}"`,
-      );
+      throw new FilterRefersToNonexistentTypeError(codeRef, { cause: e });
     }
     if (!head.ok) {
       let message = await head.text();
+      if (head.status === 404) {
+        throw new FilterRefersToNonexistentTypeError(codeRef);
+      }
       throw new Error(
         `tried to get definition for ${stringify(codeRef)}, but got ${head.status}: ${message} for HEAD ${codeRef.module}`,
       );
@@ -65,12 +102,13 @@ export class DefinitionsCache {
         headers: { accept: SupportedMimeType.JSONAPI },
       });
     } catch (e) {
-      throw new Error(
-        `Your filter refers to a nonexistent type: import { ${codeRef.name} } from "${codeRef.module}"`,
-      );
+      throw new FilterRefersToNonexistentTypeError(codeRef, { cause: e });
     }
     if (!response.ok) {
       let message = await response.text();
+      if (response.status === 404) {
+        throw new FilterRefersToNonexistentTypeError(codeRef);
+      }
       throw new Error(
         `tried to get definition for ${stringify(codeRef)}, but got ${response.status}: ${message} for ${url}`,
       );

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -101,7 +101,10 @@ import {
   AtomicPayloadValidationError,
   filterAtomicOperations,
 } from './atomic-document';
-import { DefinitionsCache } from './definitions-cache';
+import {
+  DefinitionsCache,
+  isFilterRefersToNonexistentTypeError,
+} from './definitions-cache';
 
 export const REALM_ROOM_RETENTION_POLICY_MAX_LIFETIME = 60 * 60 * 1000;
 
@@ -588,8 +591,11 @@ export class Realm {
           content = JSON.stringify(serialized, null, 2);
         }
       } catch (e: any) {
-        if (e.message.includes('not found')) {
-          throw new Error(e);
+        if (
+          e.message?.includes?.('not found') ||
+          isFilterRefersToNonexistentTypeError(e)
+        ) {
+          throw e;
         }
       }
       let { lastModified, created, isNew } = await this.#adapter.write(


### PR DESCRIPTION
- Adds negative caching for missing card definitions in query engine
- Affects realm's _search and _prerendered-search endpoints