### PR TITLE
Fix: lastPublishedAt of published realm is not shown

### DIFF
--- a/packages/host/app/components/operator-mode/publish-realm-modal.gts
+++ b/packages/host/app/components/operator-mode/publish-realm-modal.gts
@@ -64,17 +64,22 @@ export default class PublishRealmModal extends Component<Signature> {
     }
 
     const publishedUrl = this.generatedUrl;
-    const publishedAtValue = realmInfo.lastPublishedAt[publishedUrl];
+    const publishedAt = realmInfo.lastPublishedAt[publishedUrl]
+      ? Number(realmInfo.lastPublishedAt[publishedUrl])
+      : null;
 
-    if (!publishedAtValue) {
+    if (!publishedAt) {
       return null;
     }
 
     try {
-      let publishedAt = new Date(publishedAtValue);
       return formatDistanceToNow(publishedAt, { addSuffix: true });
     } catch (error) {
-      console.warn('Failed to parse published date:', publishedAtValue, error);
+      console.warn(
+        'Failed to parse published date:',
+        new Date(publishedAt),
+        error,
+      );
       return null;
     }
   }

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -402,9 +402,8 @@ class RealmResource {
         let lastPublishedAt = results.reduce(
           (acc, result) => {
             if (result.status === 'fulfilled' && result.value) {
-              acc[result.value.data.attributes.publishedRealmURL] = Number(
-                result.value.data.attributes.lastPublishedAt,
-              );
+              acc[result.value.data.attributes.publishedRealmURL] =
+                result.value.data.attributes.lastPublishedAt;
             }
             return acc;
           },

--- a/packages/host/tests/acceptance/host-submode-test.gts
+++ b/packages/host/tests/acceptance/host-submode-test.gts
@@ -330,8 +330,10 @@ module('Acceptance | host submode', function (hooks) {
                 attributes: {
                   ...testRealmInfo,
                   lastPublishedAt: {
-                    ['http://testuser.localhost:4201/test/']:
-                      new Date().getTime() - 3 * 24 * 60 * 60 * 1000, //3 days ago,
+                    ['http://testuser.localhost:4201/test/']: (
+                      new Date().getTime() -
+                      3 * 24 * 60 * 60 * 1000
+                    ).toString(), //3 days ago,
                   },
                 },
               },

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -143,7 +143,7 @@ export default function handlePublishRealm({
         publishedRealmData = results[0];
         realmUsername = `realm/${PUBLISHED_DIRECTORY_NAME}_${publishedRealmData.id}`;
 
-        let lastPublishedAt = Date.now();
+        let lastPublishedAt = Date.now().toString();
         await query(dbAdapter, [
           `UPDATE published_realms SET last_published_at =`,
           param(lastPublishedAt),
@@ -159,7 +159,7 @@ export default function handlePublishRealm({
           owner_username: realmUsername,
           source_realm_url: sourceRealmURL,
           published_realm_url: publishedRealmURL,
-          last_published_at: Date.now(),
+          last_published_at: Date.now().toString(),
         });
 
         let results = (await query(

--- a/packages/runtime-common/index-structure.ts
+++ b/packages/runtime-common/index-structure.ts
@@ -92,5 +92,5 @@ export interface PublishedRealmTable {
   owner_username: string;
   source_realm_url: string;
   published_realm_url: string;
-  last_published_at: number;
+  last_published_at: string;
 }


### PR DESCRIPTION
This PR fixes an issue where the `lastPublishedAt` value of an already published realm was not shown in the publish realm modal after reloading the page. The problem was that we did not consistently handle `lastPublishedAt`: the value is a string, and while we cast the one returned from the `/publish-realm` endpoint, we did not cast the one returned when fetching realm info. I also fixed the test mock by using the correct type for `lastPublishedAt` to ensure it is handled properly in the publish realm modal.