### PR TITLE
Refactor MenuItem to reflect usage to-date, and reduce coupling from card-api

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -3,7 +3,7 @@ import GlimmerComponent from '@glimmer/component';
 import { isEqual } from 'lodash';
 import { WatchedArray } from './watched-array';
 import { BoxelInput } from '@cardstack/boxel-ui/components';
-import { MenuItem, not } from '@cardstack/boxel-ui/helpers';
+import { type MenuItemOptions, not } from '@cardstack/boxel-ui/helpers';
 import {
   getBoxComponent,
   type BoxComponent,
@@ -148,6 +148,7 @@ export {
   serializeCard,
   type BoxComponent,
   type DeserializeOpts,
+  type GetCardMenuItemParams,
   type JSONAPISingleResourceDocument,
   type ResourceID,
   type SerializeOpts,
@@ -2347,7 +2348,7 @@ export class CardDef extends BaseDef {
     return realmURLString ? new URL(realmURLString) : undefined;
   }
 
-  [getCardMenuItems](params: GetCardMenuItemParams): MenuItem[] {
+  [getCardMenuItems](params: GetCardMenuItemParams): MenuItemOptions[] {
     return getDefaultCardMenuItems(this, params);
   }
 }

--- a/packages/base/card-menu-items.ts
+++ b/packages/base/card-menu-items.ts
@@ -1,5 +1,8 @@
 import type { BaseDef, CardCrudFunctions, CardDef } from './card-api';
-import { copyCardURLToClipboard, MenuItem } from '@cardstack/boxel-ui/helpers';
+import {
+  copyCardURLToClipboard,
+  type MenuItemOptions,
+} from '@cardstack/boxel-ui/helpers';
 
 import CopyCardCommand from '@cardstack/boxel-host/commands/copy-card';
 import GenerateExampleCardsCommand from '@cardstack/boxel-host/commands/generate-example-cards';
@@ -42,21 +45,20 @@ export interface GetCardMenuItemParams {
 export function getDefaultCardMenuItems(
   card: CardDef,
   params: GetCardMenuItemParams,
-): MenuItem[] {
+): MenuItemOptions[] {
   let cardId = card.id as unknown as string;
-  let menuItems: MenuItem[] = [];
+  let menuItems: MenuItemOptions[] = [];
   if (
     ['interact', 'code-mode-preview', 'code-mode-playground'].includes(
       params.menuContext,
     )
   ) {
-    menuItems.push(
-      new MenuItem('Copy Card URL', 'action', {
-        action: () => copyCardURLToClipboard(cardId),
-        icon: LinkIcon,
-        disabled: !cardId,
-      }),
-    );
+    menuItems.push({
+      label: 'Copy Card URL',
+      action: () => copyCardURLToClipboard(cardId),
+      icon: LinkIcon,
+      disabled: !cardId,
+    });
   }
   if (params.menuContext === 'interact') {
     if (
@@ -65,7 +67,8 @@ export function getDefaultCardMenuItems(
       params.canEdit
     ) {
       menuItems.push(
-        new MenuItem('New Card of This Type', 'action', {
+        {
+          label: 'New Card of This Type',
           action: () => {
             if (!card) {
               return;
@@ -80,76 +83,73 @@ export function getDefaultCardMenuItems(
           },
           icon: cardTypeIcon(card as BaseDef),
           disabled: !card,
-        }),
-        new MenuItem('Delete', 'action', {
+        },
+        {
+          label: 'Delete',
           action: () => params.cardCrudFunctions.deleteCard?.(card),
           icon: Trash2Icon,
           dangerous: true,
           disabled: !card.id,
-        }),
+        },
       );
     }
   }
   if (params.menuContext === 'ai-assistant') {
-    menuItems.push(
-      new MenuItem('Copy to Workspace', 'action', {
-        action: async () => {
-          const { newCardId } = await new CopyCardCommand(
-            params.commandContext,
-          ).execute({
-            sourceCard: card,
-          });
+    menuItems.push({
+      label: 'Copy to Workspace',
+      action: async () => {
+        const { newCardId } = await new CopyCardCommand(
+          params.commandContext,
+        ).execute({
+          sourceCard: card,
+        });
 
-          let showCardCommand = new ShowCardCommand(params.commandContext);
-          await showCardCommand.execute({
-            cardId: newCardId,
-          });
-        },
-        icon: ArrowLeft,
-      }),
-    );
+        let showCardCommand = new ShowCardCommand(params.commandContext);
+        await showCardCommand.execute({
+          cardId: newCardId,
+        });
+      },
+      icon: ArrowLeft,
+    });
   }
   if (
     ['code-mode-preview', 'code-mode-playground'].includes(params.menuContext)
   ) {
-    menuItems.push(
-      new MenuItem('Open in Interact Mode', 'action', {
-        action: () => {
-          new OpenInInteractModeCommand(params.commandContext).execute({
-            cardId,
-            format: params.format === 'edit' ? 'edit' : 'isolated',
-          });
-        },
-        icon: Eye,
-        disabled: !card.id,
-      }),
-    );
+    menuItems.push({
+      label: 'Open in Interact Mode',
+      action: () => {
+        new OpenInInteractModeCommand(params.commandContext).execute({
+          cardId,
+          format: params.format === 'edit' ? 'edit' : 'isolated',
+        });
+      },
+      icon: Eye,
+      disabled: !card.id,
+    });
   }
   if (params.menuContext === 'code-mode-playground') {
-    menuItems.push(
-      new MenuItem('Open in Code Mode', 'action', {
-        action: async () => {
-          await new SwitchSubmodeCommand(params.commandContext).execute({
-            submode: 'code',
-            codePath: cardId ? new URL(cardId).href : undefined,
-          });
-        },
-        icon: CodeIcon,
-        disabled: !cardId,
-      }),
-    );
+    menuItems.push({
+      label: 'Open in Code Mode',
+      action: async () => {
+        await new SwitchSubmodeCommand(params.commandContext).execute({
+          submode: 'code',
+          codePath: cardId ? new URL(cardId).href : undefined,
+        });
+      },
+      icon: CodeIcon,
+      disabled: !cardId,
+    });
     menuItems = [...menuItems, ...getSampleDataMenuItems(card, params)];
-    menuItems.push(
-      new MenuItem(`Create listing with AI`, 'action', {
-        action: async () => {
-          await new ListingCreateCommand(params.commandContext).execute({
-            openCardId: cardId,
-          });
-        },
-        icon: AiBwIcon,
-        disabled: !params.canEdit,
-      }),
-    );
+    menuItems.push({
+      label: `Create listing with AI`,
+      action: async () => {
+        await new ListingCreateCommand(params.commandContext).execute({
+          openCardId: cardId,
+        });
+      },
+      icon: AiBwIcon,
+      disabled: !params.canEdit,
+    });
   }
   return menuItems;
 }
@@ -157,41 +157,35 @@ export function getDefaultCardMenuItems(
 function getSampleDataMenuItems(
   card: CardDef,
   { commandContext }: Pick<GetCardMenuItemParams, 'commandContext'>,
-): MenuItem[] {
+): MenuItemOptions[] {
   let cardId = card.id as unknown as string;
-  let menuItems: MenuItem[] = [];
+  let menuItems: MenuItemOptions[] = [];
   if (cardId) {
-    menuItems.push(
-      new MenuItem(`Fill in sample data with AI`, 'action', {
-        action: async () =>
-          await new PopulateWithSampleDataCommand(commandContext).execute({
-            cardId: card.id,
-          }),
-        icon: AiBwIcon,
-        tags: ['playground-sample-data'],
-      }),
-    );
+    menuItems.push({
+      label: `Fill in sample data with AI`,
+      action: async () =>
+        await new PopulateWithSampleDataCommand(commandContext).execute({
+          cardId: card.id,
+        }),
+      icon: AiBwIcon,
+      tags: ['playground-sample-data'],
+    });
   }
   let codeRef = identifyCard(card.constructor);
   if (codeRef && isResolvedCodeRef(codeRef)) {
-    menuItems.push(
-      new MenuItem(
-        `Generate ${GENERATED_EXAMPLE_COUNT} examples with AI`,
-        'action',
-        {
-          action: async () => {
-            await new GenerateExampleCardsCommand(commandContext).execute({
-              count: GENERATED_EXAMPLE_COUNT,
-              codeRef: codeRef as ResolvedCodeRef,
-              realm: card[realmURL]?.href,
-              exampleCard: card,
-            });
-          },
-          icon: AiBwIcon,
-          tags: ['playground-sample-data'],
-        },
-      ),
-    );
+    menuItems.push({
+      label: `Generate ${GENERATED_EXAMPLE_COUNT} examples with AI`,
+      action: async () => {
+        await new GenerateExampleCardsCommand(commandContext).execute({
+          count: GENERATED_EXAMPLE_COUNT,
+          codeRef: codeRef as ResolvedCodeRef,
+          realm: card[realmURL]?.href,
+          exampleCard: card,
+        });
+      },
+      icon: AiBwIcon,
+      tags: ['playground-sample-data'],
+    });
   }
   return menuItems;
 }

--- a/packages/base/spec.gts
+++ b/packages/base/spec.gts
@@ -34,7 +34,7 @@ import {
   type CommandContext,
   type ResolvedCodeRef,
 } from '@cardstack/runtime-common';
-import { eq, MenuItem } from '@cardstack/boxel-ui/helpers';
+import { eq, type MenuItemOptions } from '@cardstack/boxel-ui/helpers';
 import { AiBw as AiBwIcon } from '@cardstack/boxel-ui/icons';
 
 import GlimmerComponent from '@glimmer/component';
@@ -1079,22 +1079,23 @@ export class Spec extends CardDef {
   @field title = contains(SpecTitleField);
   @field description = contains(SpecDescriptionField);
 
-  [getCardMenuItems](params: GetCardMenuItemParams): MenuItem[] {
+  [getCardMenuItems](params: GetCardMenuItemParams): MenuItemOptions[] {
     let menuItems = super[getCardMenuItems](params);
     if (this.specType !== 'field') {
       return menuItems;
     }
-    let sampleDataStartIndex = menuItems.findIndex((item: MenuItem) =>
-      item.tags.includes('playground-sample-data'),
+    let sampleDataStartIndex = menuItems.findIndex((item: MenuItemOptions) =>
+      item.tags?.includes('playground-sample-data'),
     );
-    let sampleDataItemCount = menuItems.filter((item: MenuItem) =>
-      item.tags.includes('playground-sample-data'),
+    let sampleDataItemCount = menuItems.filter((item: MenuItemOptions) =>
+      item.tags?.includes('playground-sample-data'),
     ).length;
     menuItems.splice(
       sampleDataStartIndex,
       sampleDataItemCount,
       ...[
-        new MenuItem(`Fill in sample data with AI`, 'action', {
+        {
+          label: 'Fill in sample data with AI',
           action: async () => {
             await new PopulateFieldSpecExampleCommand(
               params.commandContext,
@@ -1104,28 +1105,25 @@ export class Spec extends CardDef {
           },
           icon: AiBwIcon,
           tags: ['playground-sample-data'],
-        }),
-        new MenuItem(
-          `Generate ${GENERATED_EXAMPLE_COUNT} examples with AI`,
-          'action',
-          {
-            action: async () => {
-              await new GenerateExamplesForFieldSpecCommand(
-                params.commandContext,
-              ).execute({
-                count: GENERATED_EXAMPLE_COUNT,
-                codeRef: codeRefWithAbsoluteURL(
-                  this.ref,
-                  new URL(this.id),
-                ) as ResolvedCodeRef,
-                realm: this[realmURL]?.href,
-                exampleCard: this,
-              });
-            },
-            icon: AiBwIcon,
-            tags: ['playground-sample-data'],
+        },
+        {
+          label: `Generate ${GENERATED_EXAMPLE_COUNT} examples with AI`,
+          action: async () => {
+            await new GenerateExamplesForFieldSpecCommand(
+              params.commandContext,
+            ).execute({
+              count: GENERATED_EXAMPLE_COUNT,
+              codeRef: codeRefWithAbsoluteURL(
+                this.ref,
+                new URL(this.id),
+              ) as ResolvedCodeRef,
+              realm: this[realmURL]?.href,
+              exampleCard: this,
+            });
           },
-        ),
+          icon: AiBwIcon,
+          tags: ['playground-sample-data'],
+        },
       ],
     );
     return menuItems;

--- a/packages/boxel-ui/addon/package.json
+++ b/packages/boxel-ui/addon/package.json
@@ -52,7 +52,6 @@
     "ember-draggable-modifiers": "^1.0.0",
     "ember-focus-trap": "^1.0.1",
     "ember-freestyle": "^0.20.0",
-    "ember-link": "^2.1.0",
     "ember-load-initializers": "^2.1.2",
     "ember-modifier": "^4.1.0",
     "ember-power-calendar": "^1.2.0",

--- a/packages/boxel-ui/addon/src/components/card-header/usage.gts
+++ b/packages/boxel-ui/addon/src/components/card-header/usage.gts
@@ -56,7 +56,8 @@ export default class CardHeaderUsage extends Component {
     publishable: null,
   };
   @tracked moreOptionsMenuItems: MenuItem[] = [
-    new MenuItem('Copy Card URL', 'action', {
+    new MenuItem({
+      label: 'Copy Card URL',
       action: () => console.log('Copy Card URL'),
       icon: IconLink,
       disabled: false,
@@ -73,20 +74,23 @@ export default class CardHeaderUsage extends Component {
   @tracked utilityMenu?: CardHeaderUtilityMenu = {
     triggerText: '2 Selected',
     menuItems: [
-      new MenuItem('Deselect All', 'action', {
+      new MenuItem({
+        label: 'Deselect All',
         icon: DeselectIcon,
         action: () => {
           console.log('Deselect all');
           console.log('Delete 2 items');
         },
       }),
-      new MenuItem('Select All', 'action', {
+      new MenuItem({
+        label: 'Select All',
         icon: SelectAllIcon,
         action: () => {
           console.log('Select all');
         },
       }),
-      new MenuItem('Delete 2 items', 'action', {
+      new MenuItem({
+        label: 'Delete 2 items',
         dangerous: true,
         icon: IconTrash,
         action: () => {

--- a/packages/boxel-ui/addon/src/components/menu/index.gts
+++ b/packages/boxel-ui/addon/src/components/menu/index.gts
@@ -3,13 +3,11 @@ import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import cssUrl from 'ember-css-url';
-import { Link } from 'ember-link';
 
 import cn from '../../helpers/cn.ts';
 import compact from '../../helpers/compact.ts';
 import type { MenuDivider } from '../../helpers/menu-divider.ts';
-import type { MenuItem } from '../../helpers/menu-item.ts';
-import { eq } from '../../helpers/truth-helpers.ts';
+import type { MenuAction, MenuItem } from '../../helpers/menu-item.ts';
 import CheckMark from '../../icons/check-mark.gts';
 import LoadingIndicator from '../loading-indicator/index.gts';
 
@@ -25,7 +23,7 @@ class MenuItemRenderer extends Component<{
     return this.args.menuItem as MenuItem;
   }
   <template>
-    {{#if (eq @menuItem.type 'divider')}}
+    {{#if @menuItem.isDivider}}
       {{yield to='divider'}}
     {{else}}
       {{yield this.asMenuItem to='item'}}
@@ -46,7 +44,7 @@ interface Signature {
 
 export default class Menu extends Component<Signature> {
   @action invokeMenuItemAction(
-    actionOrLink: unknown,
+    action: MenuAction,
     e: Event | KeyboardEvent,
   ): void {
     e.preventDefault();
@@ -54,14 +52,8 @@ export default class Menu extends Component<Signature> {
     if (e.type === 'keypress' && (e as KeyboardEvent).key !== 'Enter') {
       return;
     }
-
-    if (actionOrLink instanceof Link && actionOrLink.transitionTo) {
-      actionOrLink.transitionTo();
-    } else {
-      (actionOrLink as () => never)();
-    }
-    let { closeMenu } = this.args;
-    closeMenu && closeMenu();
+    action();
+    this.args.closeMenu?.();
   }
 
   <template>
@@ -92,19 +84,19 @@ export default class Menu extends Component<Signature> {
                   @itemClass
                   boxel-menu__item--dangerous=menuItem.dangerous
                   boxel-menu__item--has-icon=(if menuItem.icon true false)
-                  boxel-menu__item--selected=menuItem.selected
+                  boxel-menu__item--checked=menuItem.checked
                   boxel-menu__item--disabled=menuItem.disabled
                 }}
                 data-test-boxel-menu-item
-                data-test-boxel-menu-item-selected={{menuItem.selected}}
+                data-test-boxel-menu-item-selected={{menuItem.checked}}
               >
                 {{! template-lint-disable require-context-role }}
                 <div
                   class='boxel-menu__item__content'
                   role='menuitem'
                   href='#'
-                  data-test-boxel-menu-item-text={{menuItem.text}}
-                  tabindex={{menuItem.tabindex}}
+                  data-test-boxel-menu-item-text={{menuItem.label}}
+                  tabindex='0'
                   {{on 'click' (fn this.invokeMenuItemAction menuItem.action)}}
                   {{on
                     'keypress'
@@ -121,7 +113,7 @@ export default class Menu extends Component<Signature> {
                         style={{cssUrl 'background-image' menuItem.iconURL}}
                       />
                     {{/if}}
-                    {{menuItem.text}}
+                    {{menuItem.label}}
                     {{#if menuItem.subtext}}
                       <span class='subtext'>
                         {{menuItem.subtext}}
@@ -138,7 +130,7 @@ export default class Menu extends Component<Signature> {
                   <span
                     class={{cn
                       'check-icon'
-                      check-icon--selected=menuItem.selected
+                      check-icon--selected=menuItem.checked
                     }}
                   >
                     <CheckMark class='checkmark' width='12' height='12' />
@@ -176,12 +168,12 @@ export default class Menu extends Component<Signature> {
           letter-spacing: var(--boxel-lsp-sm);
         }
 
-        .boxel-menu__item--selected {
+        .boxel-menu__item--checked {
           background-color: var(--boxel-menu-selected-background-color);
           color: var(--boxel-menu-selected-font-color);
         }
 
-        .boxel-menu__item--selected:not(.boxel-menu__item--disabled):hover {
+        .boxel-menu__item--checked:not(.boxel-menu__item--disabled):hover {
           color: var(--boxel-menu-selected-hover-font-color);
         }
 

--- a/packages/boxel-ui/addon/src/components/menu/usage.gts
+++ b/packages/boxel-ui/addon/src/components/menu/usage.gts
@@ -62,7 +62,7 @@ export default class MenuUsage extends Component {
       <:api as |Args|>
         <Args.Object
           @name='items'
-          @description="An array of MenuItems, created using the 'menu-item' helper. The menu-item helper accepts the menu item text as its first argument, and an action or link (as created using ember-link) as the second argument."
+          @description="An array of MenuItems, created using the 'menu-item' helper. The menu-item helper accepts the menu item text as its first argument, and an action as the second argument."
         />
         <Args.Action
           @name='closeMenu'

--- a/packages/boxel-ui/addon/src/components/sort-dropdown/index.gts
+++ b/packages/boxel-ui/addon/src/components/sort-dropdown/index.gts
@@ -79,7 +79,8 @@ export default class SortDropdown extends Component<Signature> {
     }
     return (this.args.options as SortOption[]).map(
       (option) =>
-        new MenuItem(option.displayName, 'action', {
+        new MenuItem({
+          label: option.displayName,
           action: () => this.args.onSelect(option),
         }),
     );

--- a/packages/boxel-ui/addon/src/helpers.ts
+++ b/packages/boxel-ui/addon/src/helpers.ts
@@ -24,7 +24,12 @@ import formatPeriod from './helpers/format-period.ts';
 import formatRelativeTime from './helpers/format-relative-time.ts';
 import { add, divide, multiply, subtract } from './helpers/math-helpers.ts';
 import menuDivider, { MenuDivider } from './helpers/menu-divider.ts';
-import menuItem, { MenuItem, menuItemFunc } from './helpers/menu-item.ts';
+import menuItem, {
+  type MenuItemOptions,
+  MenuItem,
+  menuItemFunc,
+  toMenuItems,
+} from './helpers/menu-item.ts';
 import optional from './helpers/optional.ts';
 import pick from './helpers/pick.ts';
 import { sanitizeHtml, sanitizeHtmlSafe } from './helpers/sanitize-html.ts';
@@ -42,6 +47,7 @@ import {
 } from './helpers/truth-helpers.ts';
 
 export {
+  type MenuItemOptions,
   add,
   and,
   bool,
@@ -87,4 +93,5 @@ export {
   sanitizeHtmlSafe,
   substring,
   subtract,
+  toMenuItems,
 };

--- a/packages/boxel-ui/addon/src/helpers/menu-divider.ts
+++ b/packages/boxel-ui/addon/src/helpers/menu-divider.ts
@@ -7,10 +7,7 @@ interface Signature {
   Return: MenuDivider;
 }
 export class MenuDivider {
-  type: string;
-  constructor() {
-    this.type = 'divider';
-  }
+  isDivider = true;
 }
 
 export default helper<Signature>(function (): MenuDivider {

--- a/packages/boxel-ui/addon/src/helpers/menu-item.ts
+++ b/packages/boxel-ui/addon/src/helpers/menu-item.ts
@@ -1,61 +1,56 @@
 import { helper } from '@ember/component/helper';
 import type { ComponentLike } from '@glint/template';
-import type { Link } from 'ember-link';
 
 import type { Icon } from '../icons/types.ts';
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-type ActionType = Link | Function;
+export type MenuAction = () => void;
 
-interface MenuItemOptions {
-  action: ActionType;
-  dangerous: boolean;
-  disabled: boolean;
-  header: boolean;
-  icon: Icon;
-  iconURL: string;
+export interface MenuItemOptions {
+  action: MenuAction;
+  checked?: boolean;
+  dangerous?: boolean;
+  disabled?: boolean;
+  header?: boolean;
+  icon?: Icon;
+  iconURL?: string;
   id?: string;
-  inactive: boolean;
+  inactive?: boolean;
+  label: string;
   postscript?: string;
-  selected: boolean;
   subtext?: string;
   subtextComponent?: ComponentLike;
-  tabindex: number | string;
-  tags: string[];
-  url: string;
+  tags?: string[];
 }
+
 export class MenuItem {
-  text: string;
-  type: string;
+  label: string;
+  action: MenuAction;
   dangerous: boolean;
-  selected: boolean;
+  checked: boolean;
   disabled: boolean;
   header: boolean;
   icon: Icon | undefined;
   iconURL: string | undefined;
-  action: ActionType | undefined;
   url: string | undefined;
   inactive: boolean | undefined;
-  tabindex: number | string | undefined;
   id?: string;
   subtext?: string;
   postscript?: string;
   subtextComponent?: ComponentLike;
   tags: string[];
+  isDivider = false;
 
-  constructor(text: string, type: string, options: Partial<MenuItemOptions>) {
-    this.text = text;
-    this.type = type;
+  constructor(options: MenuItemOptions) {
+    this.label = options.label;
     this.action = options.action;
     this.id = options.id;
     this.dangerous = options.dangerous || false;
-    this.selected = options.selected || false;
+    this.checked = options.checked || false;
     this.disabled = options.disabled || false;
     this.header = options.header || false;
     this.icon = options.icon || undefined;
     this.iconURL = options.iconURL || undefined;
     this.inactive = options.inactive;
-    this.tabindex = options.tabindex || 0;
     this.subtext = options.subtext;
     this.postscript = options.postscript;
     this.subtextComponent = options.subtextComponent;
@@ -63,14 +58,19 @@ export class MenuItem {
   }
 }
 
+export function toMenuItems(options: MenuItemOptions[]): MenuItem[] {
+  return options.map((opts) => new MenuItem(opts));
+}
+
 export function menuItemFunc(
-  params: [string, ActionType],
-  named: Partial<MenuItemOptions>,
+  params: [string, MenuAction],
+  named: Omit<MenuItemOptions, 'label' | 'action'>,
 ): MenuItem {
-  let text = params[0];
-  let opts = Object.assign({}, named);
-  opts.action = params[1];
-  return new MenuItem(text, 'action', opts);
+  let opts: MenuItemOptions = Object.assign(
+    { label: params[0], action: params[1] },
+    named,
+  );
+  return new MenuItem(opts);
 }
 
 export default helper(menuItemFunc);

--- a/packages/boxel-ui/test-app/tests/integration/components/dropdown-test.gts
+++ b/packages/boxel-ui/test-app/tests/integration/components/dropdown-test.gts
@@ -12,9 +12,9 @@ module('Integration | Component | dropdown', function (hooks) {
 
   test('dropdown auto-close behavior: auto-close when enabled, stays open when disabled', async function (assert) {
     const menuOptions = [
-      new MenuItem('Option 1', 'action', { action: () => {} }),
-      new MenuItem('Option 2', 'action', { action: () => {} }),
-      new MenuItem('Option 3', 'action', { action: () => {} }),
+      new MenuItem({ label: 'Option 1', action: () => {} }),
+      new MenuItem({ label: 'Option 2', action: () => {} }),
+      new MenuItem({ label: 'Option 3', action: () => {} }),
     ];
 
     // Scenario 1

--- a/packages/catalog-realm/catalog-app/components/choose-realm-action.gts
+++ b/packages/catalog-realm/catalog-app/components/choose-realm-action.gts
@@ -25,7 +25,8 @@ interface ChooseRealmActionSignature {
 export default class ChooseRealmAction extends GlimmerComponent<ChooseRealmActionSignature> {
   get realmOptions() {
     return this.args.writableRealms.map((realm) => {
-      return new MenuItem(realm.name, 'action', {
+      return new MenuItem({
+        label: realm.name,
         action: () => {
           this.runAction.perform(realm.url);
         },

--- a/packages/catalog-realm/components/sort.gts
+++ b/packages/catalog-realm/components/sort.gts
@@ -110,10 +110,11 @@ export class SortMenu extends GlimmerComponent<SortMenuSignature> {
 
   private get sortOptions() {
     return this.args.options.map((option) => {
-      return new MenuItem(option.displayName, 'action', {
+      return new MenuItem({
+        label: option.displayName,
         action: () => this.args.onSort(option),
         icon: option.sort?.[0].direction === 'desc' ? ArrowDown : ArrowUp,
-        selected:
+        checked:
           option.displayName === this.args.selected.displayName &&
           option.sort?.[0].direction === this.args.selected.sort?.[0].direction,
       });

--- a/packages/experiments-realm/components/sort.gts
+++ b/packages/experiments-realm/components/sort.gts
@@ -110,10 +110,11 @@ export class SortMenu extends GlimmerComponent<SortMenuSignature> {
 
   private get sortOptions() {
     return this.args.options.map((option) => {
-      return new MenuItem(option.displayName, 'action', {
+      return new MenuItem({
+        label: option.displayName,
         action: () => this.args.onSort(option),
         icon: option.sort?.[0].direction === 'desc' ? ArrowDown : ArrowUp,
-        selected:
+        checked:
           option.displayName === this.args.selected.displayName &&
           option.sort?.[0].direction === this.args.selected.sort?.[0].direction,
       });

--- a/packages/experiments-realm/plant-info.gts
+++ b/packages/experiments-realm/plant-info.gts
@@ -41,7 +41,7 @@ class Edit extends Component<typeof DropdownField> {
   get menuItems() {
     return this.args.model.options?.map((v: string) =>
       menuItemFunc([v, () => (this.args.model.selectedValue = v)], {
-        selected: this.args.model.selectedValue === v,
+        checked: this.args.model.selectedValue === v,
       }),
     );
   }
@@ -128,6 +128,7 @@ export class PlantInfo extends CardDef {
   static edit = class Edit extends Component<typeof this> {
     <template></template>
   }
+
 
 
 

--- a/packages/host/app/components/ai-assistant/attached-file-dropdown-menu.gts
+++ b/packages/host/app/components/ai-assistant/attached-file-dropdown-menu.gts
@@ -79,17 +79,20 @@ export default class AttachedFileDropdownMenu extends Component<{
       this.args.version === 'diff-editor' ? 'Generated' : 'Submitted';
 
     const items = [
-      new MenuItem('Open in Code Mode', 'action', {
+      new MenuItem({
+        label: 'Open in Code Mode',
         action: this.openInCodeMode,
         icon: IconCode,
         disabled: !this.args.file?.sourceUrl,
       }),
-      new MenuItem(`Copy ${submittedOrGenerated} Content`, 'action', {
+      new MenuItem({
+        label: `Copy ${submittedOrGenerated} Content`,
         action: this.copySubmittedContentTask.perform,
         icon: Copy,
         disabled: !this.args.file?.sourceUrl || this.args.isNewFile,
       }),
-      new MenuItem(`Restore ${submittedOrGenerated} Content`, 'action', {
+      new MenuItem({
+        label: `Restore ${submittedOrGenerated} Content`,
         action: this.toggleRestorePatchedFileModal,
         icon: Undo2,
         dangerous: true,

--- a/packages/host/app/components/card-catalog/filters.gts
+++ b/packages/host/app/components/card-catalog/filters.gts
@@ -21,7 +21,8 @@ export default class CardCatalogFilters extends Component<Signature> {
     }
     return Object.entries(this.args.availableRealms).map(
       ([realmUrl, realmInfo]) => {
-        return new MenuItem(realmInfo.name, 'action', {
+        return new MenuItem({
+          label: realmInfo.name,
           action: () => {
             let isSelected = this.args.selectedRealmUrls.includes(realmUrl);
 
@@ -33,7 +34,7 @@ export default class CardCatalogFilters extends Component<Signature> {
 
             return false;
           },
-          selected: this.args.selectedRealmUrls.includes(realmUrl),
+          checked: this.args.selectedRealmUrls.includes(realmUrl),
           iconURL: realmInfo.iconURL ?? 'default-realm-icon.png',
         });
       },

--- a/packages/host/app/components/matrix/room-message-command.gts
+++ b/packages/host/app/components/matrix/room-message-command.gts
@@ -16,7 +16,7 @@ import {
   CardHeader,
 } from '@cardstack/boxel-ui/components';
 
-import { bool, cn, eq, not } from '@cardstack/boxel-ui/helpers';
+import { bool, cn, eq, not, toMenuItems } from '@cardstack/boxel-ui/helpers';
 
 import {
   cardTypeDisplayName,
@@ -137,7 +137,7 @@ export default class RoomMessageCommand extends Component<Signature> {
         menuContext: 'ai-assistant',
         commandContext: this.commandService.commandContext,
       }) ?? [];
-    return menuItems;
+    return toMenuItems(menuItems);
   }
 
   @cached

--- a/packages/host/app/components/operator-mode/card-renderer-panel/index.gts
+++ b/packages/host/app/components/operator-mode/card-renderer-panel/index.gts
@@ -11,7 +11,7 @@ import {
   BoxelButton,
   CardContainer,
 } from '@cardstack/boxel-ui/components';
-import { eq } from '@cardstack/boxel-ui/helpers';
+import { eq, toMenuItems } from '@cardstack/boxel-ui/helpers';
 import { Eye, IconCode } from '@cardstack/boxel-ui/icons';
 
 import {
@@ -94,12 +94,14 @@ export default class CardRendererPanel extends Component<Signature> {
     if (!this.args.card) {
       return [];
     }
-    return this.args.card[getCardMenuItems]?.({
-      canEdit: this.realm.canWrite(this.args.card.id),
-      cardCrudFunctions: {},
-      menuContext: 'code-mode-preview',
-      commandContext: this.commandService.commandContext,
-    });
+    return toMenuItems(
+      this.args.card[getCardMenuItems]({
+        canEdit: this.realm.canWrite(this.args.card.id),
+        cardCrudFunctions: {},
+        menuContext: 'code-mode-preview',
+        commandContext: this.commandService.commandContext,
+      }),
+    );
   }
 
   private get canEditCard() {

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -408,7 +408,8 @@ export default class CodeSubmode extends Component<Signature> {
       }
       let displayName = capitalize(startCase(id));
       return [
-        new MenuItem(displayName, 'action', {
+        new MenuItem({
+          label: displayName,
           action: () => this.createFile.perform({ id, displayName }),
           subtext: description,
           icon,

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
@@ -17,7 +17,7 @@ import {
   CardContainer,
   LoadingIndicator,
 } from '@cardstack/boxel-ui/components';
-import { eq, MenuItem } from '@cardstack/boxel-ui/helpers';
+import { eq, MenuItem, toMenuItems } from '@cardstack/boxel-ui/helpers';
 import { Folder, IconPlusThin } from '@cardstack/boxel-ui/icons';
 
 import {
@@ -153,25 +153,27 @@ export default class PlaygroundPanel extends Component<Signature> {
     if (!cardId) {
       return [];
     }
-    return (
+    return toMenuItems(
       this.card?.[getCardMenuItems]?.({
         canEdit: this.realm.canWrite(cardId),
         cardCrudFunctions: {},
         menuContext: 'code-mode-playground',
         commandContext: this.commandService.commandContext,
         format: this.format,
-      }) || []
+      }) || [],
     );
   }
 
   private get afterMenuOptions(): MenuItem[] {
     let menuItems: MenuItem[] = [
-      new MenuItem('Create new instance', 'action', {
+      new MenuItem({
+        label: 'Create new instance',
         action: () => this.createNew(),
         icon: this.createNewIsRunning ? LoadingIndicator : IconPlusThin,
         disabled: this.createNewIsRunning || !this.canWriteRealm,
       }),
-      new MenuItem('Choose another instance', 'action', {
+      new MenuItem({
+        label: 'Choose another instance',
         action: () => this.chooseInstance(),
         icon: Folder,
       }),

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -600,7 +600,8 @@ export default class InteractSubmode extends Component {
     if (cardTypes.length) {
       cardTypes.map(({ name, icon, ref }) => {
         menuItems.push(
-          new MenuItem(name, 'action', {
+          new MenuItem({
+            label: name,
             action: () => this.createNewFromRecentType.perform(ref),
             icon,
           }),
@@ -613,12 +614,14 @@ export default class InteractSubmode extends Component {
   private get createNewMenuItems(): (MenuItem | MenuDivider)[] {
     let recentCardMenuItems = this.getRecentCardMenuItems();
     let menuItems = [
-      new MenuItem('Choose a card type...', 'action', {
+      new MenuItem({
+        label: 'Choose a card type...',
         action: () => this.createCardInstance.perform(),
         icon: IconSearch,
       }),
       new MenuDivider(),
-      new MenuItem('Open Code Mode', 'action', {
+      new MenuItem({
+        label: 'Open Code Mode',
         action: this.createFileInCodeSubmode,
         subtextComponent: CodeSubmodeNewFileOptions,
         icon: IconCode,

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -27,7 +27,11 @@ import {
   CardHeader,
   LoadingIndicator,
 } from '@cardstack/boxel-ui/components';
-import { MenuItem, getContrastColor } from '@cardstack/boxel-ui/helpers';
+import {
+  MenuItem,
+  getContrastColor,
+  toMenuItems,
+} from '@cardstack/boxel-ui/helpers';
 import { cssVar, optional, not } from '@cardstack/boxel-ui/helpers';
 
 import { IconTrash } from '@cardstack/boxel-ui/icons';
@@ -379,7 +383,8 @@ export default class OperatorModeStackItem extends Component<Signature> {
     // Add "Select All" option if not all cards are selected
     if (!allSelected && totalAvailableCount > selectedCount) {
       menuItems.push(
-        new MenuItem('Select All', 'action', {
+        new MenuItem({
+          label: 'Select All',
           icon: SelectAllIcon,
           action: this.selectAll,
           disabled: false,
@@ -389,7 +394,8 @@ export default class OperatorModeStackItem extends Component<Signature> {
 
     // Add "Deselect All" option
     menuItems.push(
-      new MenuItem('Deselect All', 'action', {
+      new MenuItem({
+        label: 'Deselect All',
         icon: DeselectIcon,
         action: this.clearSelections,
       }),
@@ -400,15 +406,12 @@ export default class OperatorModeStackItem extends Component<Signature> {
 
     // Add "Delete N items" option
     menuItems.push(
-      new MenuItem(
-        `Delete ${selectedCount} item${selectedCount > 1 ? 's' : ''}`,
-        'action',
-        {
-          action: this.confirmAndDeleteSelected,
-          icon: IconTrash,
-          dangerous: true,
-        },
-      ),
+      new MenuItem({
+        label: `Delete ${selectedCount} item${selectedCount > 1 ? 's' : ''}`,
+        action: this.confirmAndDeleteSelected,
+        icon: IconTrash,
+        dangerous: true,
+      }),
     );
 
     return {
@@ -439,7 +442,8 @@ export default class OperatorModeStackItem extends Component<Signature> {
       return undefined;
     }
     return [
-      new MenuItem('Delete Card', 'action', {
+      new MenuItem({
+        label: 'Delete Card',
         action: () =>
           this.cardIdentifier &&
           this.cardCrudFunctions.deleteCard?.(this.cardIdentifier),
@@ -455,13 +459,13 @@ export default class OperatorModeStackItem extends Component<Signature> {
       return undefined;
     }
 
-    return (
+    return toMenuItems(
       this.card?.[getCardMenuItems]?.({
         canEdit: this.url ? this.realm.canWrite(this.url as string) : false,
         cardCrudFunctions: this.cardCrudFunctions,
         menuContext: 'interact',
         commandContext: this.args.commandContext,
-      }) ?? []
+      }) ?? [],
     );
   }
 

--- a/packages/host/app/components/realm-dropdown.gts
+++ b/packages/host/app/components/realm-dropdown.gts
@@ -172,9 +172,10 @@ export default class RealmDropdown extends Component<Signature> {
   get menuItems(): MenuItem[] {
     return this.realms.map(
       (realm) =>
-        new MenuItem(realm.name, 'action', {
+        new MenuItem({
+          label: realm.name,
           action: () => this.args.onSelect(realm),
-          selected: realm.name === this.selectedRealm?.name,
+          checked: realm.name === this.selectedRealm?.name,
           iconURL: realm.iconURL ?? undefined,
           subtext: !realm.canWrite ? 'READ ONLY' : undefined,
         }),

--- a/packages/host/tests/unit/card-menu-items-test.ts
+++ b/packages/host/tests/unit/card-menu-items-test.ts
@@ -1,13 +1,21 @@
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
+import { type MenuItemOptions } from '@cardstack/boxel-ui/helpers';
+
 import { baseRealm, type Loader } from '@cardstack/runtime-common';
 
-import type { CardDef } from 'https://cardstack.com/base/card-api';
+import type {
+  CardDef,
+  GetCardMenuItemParams,
+} from 'https://cardstack.com/base/card-api';
 
 import { setupRenderingTest } from '../helpers/setup';
 
-let getDefaultCardMenuItems: any;
+let getDefaultCardMenuItems: (
+  card: CardDef,
+  params: GetCardMenuItemParams,
+) => MenuItemOptions[];
 
 class DummyCard {
   constructor(
@@ -40,7 +48,7 @@ module('Unit | card-menu-items', function (hooks) {
       commandContext: {} as any,
     });
 
-    let texts = items.map((i: any) => i.text);
+    let texts = items.map((i: MenuItemOptions) => i.label);
     assert.ok(texts.includes('Copy Card URL'), 'contains Copy Card URL');
     assert.ok(
       texts.includes('New Card of This Type'),
@@ -61,7 +69,7 @@ module('Unit | card-menu-items', function (hooks) {
       commandContext: {} as any,
     });
 
-    let texts = items.map((i: any) => i.text);
+    let texts = items.map((i: MenuItemOptions) => i.label);
     assert.ok(
       texts.includes('Copy to Workspace'),
       'contains Copy to Workspace',
@@ -81,10 +89,10 @@ module('Unit | card-menu-items', function (hooks) {
       format: 'isolated',
     });
 
-    let hasCreateListing = items.some((i: any) =>
-      i.text.includes('Create listing with AI'),
+    let hasCreateListing = items.some((i: MenuItemOptions) =>
+      i.label.includes('Create listing with AI'),
     );
-    let hasSampleDataTagged = items.some((i: any) =>
+    let hasSampleDataTagged = items.some((i: MenuItemOptions) =>
       (i.tags || []).includes('playground-sample-data'),
     );
 
@@ -108,7 +116,7 @@ module('Unit | card-menu-items', function (hooks) {
       format: 'isolated',
     });
 
-    let texts = items.map((i: any) => i.text);
+    let texts = items.map((i: MenuItemOptions) => i.label);
     assert.ok(texts.includes('Copy Card URL'), 'contains Copy Card URL');
     assert.ok(
       texts.includes('Open in Interact Mode'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1452,9 +1452,6 @@ importers:
       ember-freestyle:
         specifier: ^0.20.0
         version: 0.20.0(@babel/core@7.26.10)(@ember/string@3.1.1)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))(webpack@5.99.6)
-      ember-link:
-        specifier: ^2.1.0
-        version: 2.1.0
       ember-load-initializers:
         specifier: ^2.1.2
         version: 2.1.2(@babel/core@7.26.10)
@@ -5306,56 +5303,67 @@ packages:
     resolution: {integrity: sha512-y/qUMOpJxBMy8xCXD++jeu8t7kzjlOCkoxxajL58G62PJGBZVl/Gwpm7JK9+YvlB701rcQTzjUZ1JgUoPTnoQA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.40.0':
     resolution: {integrity: sha512-GoCsPibtVdJFPv/BOIvBKO/XmwZLwaNWdyD8TKlXuqp0veo2sHE+A/vpMQ5iSArRUz/uaoj4h5S6Pn0+PdhRjg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.40.0':
     resolution: {integrity: sha512-L5ZLphTjjAD9leJzSLI7rr8fNqJMlGDKlazW2tX4IUF9P7R5TMQPElpH82Q7eNIDQnQlAyiNVfRPfP2vM5Avvg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.40.0':
     resolution: {integrity: sha512-ATZvCRGCDtv1Y4gpDIXsS+wfFeFuLwVxyUBSLawjgXK2tRE6fnsQEkE4csQQYWlBlsFztRzCnBvWVfcae/1qxQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.40.0':
     resolution: {integrity: sha512-wG9e2XtIhd++QugU5MD9i7OnpaVb08ji3P1y/hNbxrQ3sYEelKJOq1UJ5dXczeo6Hj2rfDEL5GdtkMSVLa/AOg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.40.0':
     resolution: {integrity: sha512-vgXfWmj0f3jAUvC7TZSU/m/cOE558ILWDzS7jBhiCAFpY2WEBn5jqgbqvmzlMjtp8KlLcBlXVD2mkTSEQE6Ixw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.40.0':
     resolution: {integrity: sha512-uJkYTugqtPZBS3Z136arevt/FsKTF/J9dEMTX/cwR7lsAW4bShzI2R0pJVw+hcBTWF4dxVckYh72Hk3/hWNKvA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.40.0':
     resolution: {integrity: sha512-rKmSj6EXQRnhSkE22+WvrqOqRtk733x3p5sWpZilhmjnkHkpeCgWsFFo0dGnUGeA+OZjRl3+VYq+HyCOEuwcxQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.40.0':
     resolution: {integrity: sha512-SpnYlAfKPOoVsQqmTFJ0usx0z84bzGOS9anAC0AZ3rdSo3snecihbhFTlJZ8XMwzqAcodjFU4+/SM311dqE5Sw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.40.0':
     resolution: {integrity: sha512-RcDGMtqF9EFN8i2RYN2W+64CdHruJ5rPqrlYw+cgM3uOVPSsnAQps7cpjXe9be/yDp8UC7VLoCoKC8J3Kn2FkQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.40.0':
     resolution: {integrity: sha512-HZvjpiUmSNx5zFgwtQAV1GaGazT2RWvqeDi0hV+AtC8unqqDSsaFjPxfsO6qPtKRRg25SisACWnJ37Yio8ttaw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.40.0':
     resolution: {integrity: sha512-UtZQQI5k/b8d7d3i9AZmA/t+Q4tk3hOC0tMOMSq2GlMYOfxbesxG4mJSeDp0EHs30N9bsfwUvs3zF4v/RzOeTQ==}
@@ -8284,10 +8292,6 @@ packages:
     peerDependenciesMeta:
       '@ember/test-helpers':
         optional: true
-
-  ember-link@2.1.0:
-    resolution: {integrity: sha512-j2huXQzWrlj8LtslWuoqsgT0/dUtASxtGtCQqd8XdXLoMyN8JYYRifNpp/iFmsxPyYuRMIaokfXSB00+Ztmofw==}
-    engines: {node: '>= 12.*'}
 
   ember-load-initializers@2.1.2:
     resolution: {integrity: sha512-CYR+U/wRxLbrfYN3dh+0Tb6mFaxJKfdyz+wNql6cqTrA0BBi9k6J3AaKXj273TqvEpyyXegQFFkZEiuZdYtgJw==}
@@ -20528,15 +20532,6 @@ snapshots:
       '@embroider/addon-shim': 1.8.9
     optionalDependencies:
       '@ember/test-helpers': 3.3.1(@babel/core@7.26.10)(@glint/template@1.3.0)(ember-source@5.4.1(patch_hash=f4d53cc0efd30368b913bdc898f342658768eaf0a8fb44678c0a07cf3aac24c1)(@babel/core@7.26.10)(@glimmer/component@1.1.2(@babel/core@7.26.10))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.99.6))(webpack@5.99.6)
-    transitivePeerDependencies:
-      - supports-color
-
-  ember-link@2.1.0:
-    dependencies:
-      '@glimmer/tracking': 1.1.2
-      ember-cli-babel: 7.26.11
-      ember-cli-htmlbars: 6.3.0
-      ember-cli-typescript: 4.2.1
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
* Updated signature of CardDef#[getCardMenuItems] to return a POJO confirming to the MenuItemOptions interface instead of a concrete MenuItem. This reduce coupling.
* Renamed MenuItem#text to MenuItem#label for clarity
* Renamed MenuItem#selected to MenuItem#checked for clarity
* Remove unused support for "link" type of MenuItem
* Removes the now unused `ember-link` dependency from `boxel-ui/package.json`.