### PR TITLE
Update boxel-ui color components and base ColorField template

### DIFF
--- a/packages/base/color.gts
+++ b/packages/base/color.gts
@@ -1,17 +1,21 @@
 import { Component, StringField } from './card-api';
-import { ColorPalette } from '@cardstack/boxel-ui/components';
-import { ColorPicker } from '@cardstack/boxel-ui/components';
+import { ColorPalette, Swatch } from '@cardstack/boxel-ui/components';
+import { not } from '@cardstack/boxel-ui/helpers';
 import PaintBucket from '@cardstack/boxel-icons/paint-bucket';
 
-class View extends Component<typeof ColorPalette> {
+class View extends Component<typeof ColorField> {
   <template>
-    <ColorPicker @color={{@model}} @disabled={{true}} @showHexString={{true}} />
+    <Swatch @color={{@model}} @style='round' />
   </template>
 }
 
-class EditView extends Component<typeof ColorPalette> {
+class EditView extends Component<typeof ColorField> {
   <template>
-    <ColorPalette @color={{@model}} @onChange={{@set}} />
+    <ColorPalette
+      @color={{@model}}
+      @onChange={{@set}}
+      @disabled={{not @canEdit}}
+    />
   </template>
 }
 

--- a/packages/boxel-ui/addon/src/components.ts
+++ b/packages/boxel-ui/addon/src/components.ts
@@ -59,6 +59,7 @@ import SkeletonPlaceholder from './components/skeleton-placeholder/index.gts';
 import SortDropdown, {
   type SortOption,
 } from './components/sort-dropdown/index.gts';
+import Swatch from './components/swatch/index.gts';
 import Switch from './components/switch/index.gts';
 import TabbedHeader from './components/tabbed-header/index.gts';
 import BoxelTag from './components/tag/index.gts';
@@ -127,6 +128,7 @@ export {
   ResizeHandle,
   SkeletonPlaceholder,
   SortDropdown,
+  Swatch,
   Switch,
   TabbedHeader,
   TagList,

--- a/packages/boxel-ui/addon/src/components/color-palette/index.gts
+++ b/packages/boxel-ui/addon/src/components/color-palette/index.gts
@@ -58,6 +58,7 @@ export default class ColorPalette extends Component<Signature> {
                   class={{cn 'swatch-button' selected=(eq color this.color)}}
                   style={{cssVar swatch-color=color}}
                   {{on 'click' (fn @onChange color)}}
+                  aria-label={{color}}
                 />
               </:trigger>
               <:content>
@@ -76,7 +77,7 @@ export default class ColorPalette extends Component<Signature> {
     </div>
 
     <style scoped>
-      @layer boxelComponentL4 {
+      @layer boxelComponentL3 {
         .color-palette-group {
           max-width: var(--boxel-palette-max-width, 18.75rem);
           display: grid;

--- a/packages/boxel-ui/addon/src/components/color-palette/index.gts
+++ b/packages/boxel-ui/addon/src/components/color-palette/index.gts
@@ -1,22 +1,24 @@
-import { eq } from '@cardstack/boxel-ui/helpers';
-import { concat, fn } from '@ember/helper';
+import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
-import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 
-import IconTrash from '../../icons/icon-trash.gts';
+import { cn, cssVar, eq } from '../../helpers.ts';
 import ColorPicker from '../color-picker/index.gts';
 import IconButton from '../icon-button/index.gts';
+import Tooltip from '../tooltip/index.gts';
 
 interface Signature {
   Args: {
     color: string | null;
+    disabled?: boolean;
     onChange: (color: string | null) => void;
+    paletteColors?: string[];
   };
-  Element: HTMLDivElement;
+  Element: HTMLElement;
 }
 
-const DEFAULT_PALETTE_COLORS = [
+export const DEFAULT_PALETTE_COLORS = [
   // Row 1
   '#000000',
   '#777777',
@@ -38,150 +40,93 @@ const DEFAULT_PALETTE_COLORS = [
 ];
 
 export default class ColorPalette extends Component<Signature> {
-  colors = DEFAULT_PALETTE_COLORS;
+  private get color() {
+    return this.args.color?.toUpperCase();
+  }
+  @tracked private colors = (
+    this.args.paletteColors ?? DEFAULT_PALETTE_COLORS
+  ).map((c) => c?.toUpperCase());
 
   <template>
-    <div class='color-palette-container' ...attributes>
-      <div class='palette-group'>
+    <div class='color-palette-group' ...attributes>
+      {{#unless @disabled}}
         <div class='color-palette'>
           {{#each this.colors as |color|}}
-            <button
-              type='button'
-              class='swatch {{if (eq color @color) "selected"}}'
-              style={{htmlSafe (concat '--swatch-color: ' color)}}
-              {{on 'click' (fn @onChange color)}}
-              title={{color}}
-            />
+            <Tooltip @placement='top'>
+              <:trigger>
+                <IconButton
+                  class={{cn 'swatch-button' selected=(eq color this.color)}}
+                  style={{cssVar swatch-color=color}}
+                  {{on 'click' (fn @onChange color)}}
+                />
+              </:trigger>
+              <:content>
+                {{color}}
+              </:content>
+            </Tooltip>
           {{/each}}
         </div>
-        {{#if @color}}
-          <div>
-            <code class='selected-color'>{{@color}}</code>
-            <IconButton
-              @icon={{IconTrash}}
-              @width='16px'
-              @height='16px'
-              class='remove'
-              {{on 'click' (fn @onChange null)}}
-              aria-label='Unset color'
-            />
-          </div>
-        {{/if}}
-      </div>
-
-      <label class='color-picker-container'>
-        <span class='custom-color-label'>Custom Color</span>
-        <ColorPicker @color={{@color}} @onChange={{@onChange}} />
-      </label>
+      {{/unless}}
+      <ColorPicker
+        @color={{@color}}
+        @onChange={{@onChange}}
+        @placeholder='Custom Color'
+        @disabled={{@disabled}}
+      />
     </div>
 
     <style scoped>
-      .custom-color-label {
-        margin-left: var(--boxel-sp-sm);
-        color: var(--boxel-450);
-      }
-
-      .color-palette-container {
-        --boxel-icon-button-width: var(--boxel-icon-sm);
-        --boxel-icon-button-height: var(--boxel-icon-sm);
-        display: flex;
-        gap: var(--boxel-sp);
-        align-items: flex-start;
-        flex-direction: column;
-      }
-
-      .palette-group {
-        display: flex;
-        gap: var(--boxel-sp) var(--boxel-sp-lg);
-        align-items: center;
-        flex-wrap: wrap;
-      }
-
-      .selected-color {
-        text-transform: uppercase;
-      }
-
-      .color-picker-container {
-        --swatch-size: 1.8rem;
-        border: 1px solid var(--boxel-border-color);
-        border-radius: var(--boxel-border-radius);
-        padding: var(--boxel-sp-sm);
-        background: none;
-        display: flex;
-        align-items: center;
-        cursor: pointer;
-        flex-direction: row-reverse;
-        width: 18rem;
-        justify-content: flex-end;
-      }
-
-      .color-picker-container:hover {
-        background-color: var(--boxel-light-100);
-        color: var(--boxel-600);
-      }
-
-      .color-palette {
-        --swatch-size: 1.8rem;
-        display: grid;
-        grid-template-columns: repeat(8, var(--swatch-size));
-        gap: var(--boxel-sp-xs);
-      }
-
-      .swatch {
-        width: var(--swatch-size);
-        height: var(--swatch-size);
-        border: 2px solid transparent;
-        border-radius: 50%;
-        padding: 2px;
-        cursor: pointer;
-        transition: transform 0.1s ease;
-        background-color: transparent;
-      }
-
-      .swatch::before {
-        content: '';
-        display: block;
-        width: 100%;
-        height: 100%;
-        border-radius: 50%;
-        background-color: var(--swatch-color);
-      }
-
-      .swatch:hover:not(:disabled) {
-        transform: scale(1.1);
-      }
-
-      .swatch.selected {
-        background-color: white;
-        border-color: var(--boxel-800);
-      }
-
-      .color-input {
-        width: 1.35rem;
-        height: 1.35rem;
-        padding: 0;
-        border: none;
-        cursor: pointer;
-        border-radius: 50%;
-      }
-
-      .color-input::-webkit-color-swatch-wrapper {
-        padding: 0;
-      }
-
-      .color-input::-webkit-color-swatch {
-        border: 1px solid transparent;
-        border-radius: 50%;
-      }
-
-      .remove {
-        vertical-align: text-bottom;
-        margin-left: var(--boxel-sp-xxxs);
-      }
-      .remove:focus,
-      .remove:hover {
-        --icon-color: var(--boxel-red);
-        outline: 0;
+      @layer boxelComponentL4 {
+        .color-palette-group {
+          max-width: var(--boxel-palette-max-width, 18.75rem);
+          display: grid;
+          gap: var(--boxel-sp);
+        }
+        .color-palette {
+          --swatch-size: 1.8rem;
+          display: grid;
+          grid-template-columns: repeat(auto-fill, var(--swatch-size));
+          gap: var(--boxel-sp-xs);
+        }
+        .swatch-button {
+          --_swatch-border: color-mix(
+            in oklab,
+            var(--swatch-color),
+            var(--foreground, var(--boxel-dark)) 10%
+          );
+          --_swatch-border-selected: color-mix(
+            in oklab,
+            var(--border, var(--boxel-border-color)),
+            var(--foreground, var(--boxel-dark)) 80%
+          );
+          width: var(--swatch-size);
+          height: var(--swatch-size);
+          aspect-ratio: 1;
+          border: 2px solid transparent;
+          border-radius: 50%;
+          padding: 2px;
+          transition: transform 0.1s ease;
+          background-color: transparent;
+        }
+        .swatch-button::before {
+          content: '';
+          display: block;
+          width: 100%;
+          height: 100%;
+          border-radius: 50%;
+          background-color: var(--swatch-color);
+          box-shadow: inset 0 0 0 1px var(--_swatch-border);
+        }
+        .swatch-button:hover:not(:disabled) {
+          cursor: pointer;
+          transform: scale(1.1);
+        }
+        .swatch-button.selected {
+          border-color: var(--_swatch-border-selected);
+        }
+        .swatch-button.selected::before {
+          box-shadow: none;
+        }
       }
     </style>
   </template>

--- a/packages/boxel-ui/addon/src/components/color-palette/usage.gts
+++ b/packages/boxel-ui/addon/src/components/color-palette/usage.gts
@@ -3,24 +3,32 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
 
-import ColorPalette from './index.gts';
+import ColorPalette, { DEFAULT_PALETTE_COLORS } from './index.gts';
 
 export default class ColorPaletteUsage extends Component {
-  @tracked color: string | null = null;
+  @tracked private color: string | null = null;
+  @tracked private paletteColors?: string[];
+  @tracked private disabled?: boolean;
 
   private handleColorChange = (newColor: string | null) => {
-    this.color = newColor;
+    if (this.color === newColor) {
+      this.color = null;
+    } else {
+      this.color = newColor;
+    }
   };
 
   <template>
     <FreestyleUsage
       @name='ColorPalette'
-      @description='A color palette component that provides a set of predefined colors and a custom color picker.'
+      @description='A color palette component that provides predefined colors and a custom color input.'
     >
       <:example>
         <ColorPalette
           @color={{this.color}}
           @onChange={{this.handleColorChange}}
+          @paletteColors={{this.paletteColors}}
+          @disabled={{this.disabled}}
         />
       </:example>
 
@@ -28,7 +36,7 @@ export default class ColorPaletteUsage extends Component {
         <Args.String
           @name='color'
           @optional={{false}}
-          @description='Currently selected color in hex format.'
+          @description='Currently selected color.'
           @value={{this.color}}
           @onInput={{fn (mut this.color)}}
         />
@@ -38,7 +46,24 @@ export default class ColorPaletteUsage extends Component {
           @value={{this.handleColorChange}}
           @onInput={{fn (mut this.handleColorChange)}}
         />
+        <Args.Bool
+          @name='disabled'
+          @description='Selection is disabled'
+          @value={{this.disabled}}
+          @onInput={{fn (mut this.disabled)}}
+        />
+        <Args.Object
+          @name='paletteColors'
+          @description='An array of colors (optional)'
+          @value={{this.paletteColors}}
+          @defaultValue={{DEFAULT_PALETTE_COLORS}}
+        />
       </:api>
     </FreestyleUsage>
+    <style scoped>
+      :deep(.FreestyleUsageArgument-default.u-codePill) {
+        word-break: break-word;
+      }
+    </style>
   </template>
 }

--- a/packages/boxel-ui/addon/src/components/color-picker/index.gts
+++ b/packages/boxel-ui/addon/src/components/color-picker/index.gts
@@ -1,70 +1,122 @@
+import IconX from '@cardstack/boxel-icons/x';
 import { on } from '@ember/modifier';
 import Component from '@glimmer/component';
+
+import cn from '../../helpers/cn.ts';
+import IconButton from '../icon-button/index.gts';
+import BoxelInput from '../input/index.gts';
+import Swatch from '../swatch/index.gts';
 
 interface Signature {
   Args: {
     color: string | null;
     disabled?: boolean;
     onChange: (color: string | null) => void;
-    showHexString?: boolean;
+    placeholder?: string;
   };
   Element: HTMLDivElement;
 }
 
 export default class ColorPicker extends Component<Signature> {
-  private handleColorChange = (event: Event) => {
-    let input = event.target as HTMLInputElement;
-    this.args.onChange(input.value);
-  };
-
   <template>
     <div class='color-picker' ...attributes>
-      <input
-        type='color'
-        value={{if @color @color '#ffffff'}}
-        class='input'
-        disabled={{@disabled}}
-        aria-label='Choose color'
-        {{on 'input' this.handleColorChange}}
+      <label class={{cn 'color-input-container' disabled=@disabled}}>
+        <span class='boxel-sr-only'>Color Picker</span>
+        <Swatch
+          class='color-preview'
+          @color={{@color}}
+          @hideLabel={{true}}
+          @style='round'
+        />
+        <BoxelInput
+          type='color'
+          @value={{@color}}
+          @onInput={{@onChange}}
+          @disabled={{@disabled}}
+        />
+      </label>
+
+      <BoxelInput
+        class='color-text-input'
+        @value={{@color}}
+        @onInput={{@onChange}}
+        @disabled={{@disabled}}
+        @placeholder={{@placeholder}}
       />
-      {{#if @showHexString}}
-        <code class='hex-value'>{{@color}}</code>
+
+      {{#if @color}}
+        {{#unless @disabled}}
+          <IconButton
+            class='remove'
+            @icon={{IconX}}
+            @width='16px'
+            @height='16px'
+            {{on 'click' this.remove}}
+            aria-label='Unset color'
+          />
+        {{/unless}}
       {{/if}}
     </div>
 
     <style scoped>
-      .color-picker {
-        --swatch-size: 1.4rem;
-        display: inline-flex;
-        align-items: center;
-        gap: var(--boxel-sp-xs);
-      }
-
-      .input {
-        width: var(--swatch-size);
-        height: var(--swatch-size);
-        padding: 0;
-        cursor: pointer;
-        border: var(--boxel-border);
-        border-radius: 50%;
-      }
-
-      .input:disabled {
-        pointer-events: none;
-      }
-
-      .input::-webkit-color-swatch-wrapper {
-        padding: 0;
-      }
-
-      .input::-webkit-color-swatch {
-        border: 1px solid transparent;
-        border-radius: 50%;
-      }
-
-      .hex-value {
-        text-transform: uppercase;
+      @layer boxelComponentL3 {
+        .color-picker {
+          --color-picker-width: 2.5rem;
+          --color-picker-height: 2.5rem;
+          position: relative;
+        }
+        .color-text-input {
+          padding-inline: var(--color-picker-width);
+          transition: none;
+        }
+        .color-input-container {
+          position: absolute;
+          top: 0;
+          left: 0;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          width: var(--color-picker-width);
+          height: var(--color-picker-height);
+          z-index: 1;
+        }
+        .color-input-container > :deep(.input-container) {
+          visibility: collapse;
+          position: absolute;
+          top: 0;
+          left: 0;
+          display: block;
+        }
+        .color-input-container:not(.disabled):hover {
+          cursor: pointer;
+        }
+        .color-input-container:not(.disabled):hover :deep(.preview) {
+          box-shadow: var(--shadow-xs, var(--boxel-box-shadow));
+        }
+        .remove {
+          position: absolute;
+          top: 0;
+          right: 0;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          width: var(--color-picker-width);
+          height: var(--color-picker-height);
+          z-index: 1;
+          opacity: 0.5;
+        }
+        .remove:focus,
+        .remove:hover {
+          opacity: 1;
+          outline: 0;
+        }
       }
     </style>
   </template>
+
+  private remove = (ev: Event) => {
+    ev.preventDefault();
+    ev.stopPropagation();
+    this.args.onChange?.(null);
+  };
 }

--- a/packages/boxel-ui/addon/src/components/color-picker/usage.gts
+++ b/packages/boxel-ui/addon/src/components/color-picker/usage.gts
@@ -6,9 +6,8 @@ import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
 import ColorPicker from './index.gts';
 
 export default class ColorPickerUsage extends Component {
-  @tracked color: string | null = null;
+  @tracked color: string | null = 'oklch(59.69% 0.56 49.77 / .5)';
   @tracked disabled = false;
-  @tracked showHexString = true;
 
   private onChange = (newColor: string | null) => {
     this.color = newColor;
@@ -17,22 +16,24 @@ export default class ColorPickerUsage extends Component {
   <template>
     <FreestyleUsage
       @name='ColorPicker'
-      @description='A color picker that allows users to select a color from the color spectrum.'
+      @description='Color input field that allows users to select a color from the color spectrum or type in a color code.'
     >
       <:example>
-        <ColorPicker
-          @color={{this.color}}
-          @onChange={{this.onChange}}
-          @showHexString={{this.showHexString}}
-          @disabled={{this.disabled}}
-        />
+        <label>
+          <span class='boxel-sr-only'>Color</span>
+          <ColorPicker
+            @color={{this.color}}
+            @onChange={{this.onChange}}
+            @disabled={{this.disabled}}
+          />
+        </label>
       </:example>
 
       <:api as |Args|>
         <Args.String
           @name='color'
           @optional={{false}}
-          @description='Hex color value.'
+          @description='Color value'
           @value={{this.color}}
           @onInput={{fn (mut this.color)}}
         />
@@ -48,13 +49,6 @@ export default class ColorPickerUsage extends Component {
           @value={{this.disabled}}
           @onInput={{fn (mut this.disabled)}}
           @defaultValue={{false}}
-        />
-        <Args.Bool
-          @name='showHexString'
-          @description='Whether to show the hex color value next to the picker.'
-          @value={{this.showHexString}}
-          @onInput={{fn (mut this.showHexString)}}
-          @defaultValue={{true}}
         />
       </:api>
     </FreestyleUsage>

--- a/packages/boxel-ui/addon/src/components/icon-button/index.gts
+++ b/packages/boxel-ui/addon/src/components/icon-button/index.gts
@@ -47,7 +47,7 @@ const IconButton: TemplateOnlyComponent<Signature> = <template>
     {{yield}}
   </BoxelButton>
   <style scoped>
-    @layer {
+    @layer boxelComponentL2 {
       .boxel-icon-button {
         --icon-color: var(--boxel-icon-button-icon-color, currentColor);
         width: var(--boxel-icon-button-width, var(--boxel-icon-lg));

--- a/packages/boxel-ui/addon/src/components/input/index.gts
+++ b/packages/boxel-ui/addon/src/components/input/index.gts
@@ -221,202 +221,207 @@ export default class BoxelInput extends Component<Signature> {
       {{/let}}
     </div>
     <style scoped>
-      .input-container {
-        --icon-size: var(--boxel-icon-sm);
-        --icon-space: var(--boxel-sp-xs);
-        --icon-full-length: calc(var(--boxel-icon-sm) + var(--boxel-sp-xs) * 2);
-
-        display: grid;
-        grid-template-columns: var(--icon-full-length) 1fr var(
-            --icon-full-length
+      @layer boxelComponentL1 {
+        .input-container {
+          --icon-size: var(--boxel-icon-sm);
+          --icon-space: var(--boxel-sp-xs);
+          --icon-full-length: calc(
+            var(--boxel-icon-sm) + var(--boxel-sp-xs) * 2
           );
-        grid-template-areas:
-          'optional optional optional'
-          'pre-icon input post-icon'
-          'error error error'
-          'helper helper helper';
-        width: 100%;
-      }
 
-      .boxel-input {
-        --boxel-input-height: var(--boxel-form-control-height);
+          display: grid;
+          grid-template-columns: var(--icon-full-length) 1fr var(
+              --icon-full-length
+            );
+          grid-template-areas:
+            'optional optional optional'
+            'pre-icon input post-icon'
+            'error error error'
+            'helper helper helper';
+          width: 100%;
+        }
 
-        grid-column: 1 / span 3;
-        grid-row: 2;
+        .boxel-input {
+          --boxel-input-height: var(--boxel-form-control-height);
 
-        box-sizing: border-box;
-        width: 100%;
-        max-width: 100%;
-        min-height: var(--boxel-input-height);
-        padding: var(--boxel-sp-xs) 0 var(--boxel-sp-xs) var(--boxel-sp-sm);
-        background-color: var(--background, var(--boxel-light));
-        color: var(--foreground, var(--boxel-dark));
-        border: 1px solid var(--border, var(--boxel-form-control-border-color));
-        border-radius: var(--boxel-form-control-border-radius);
-        box-shadow: var(--shadow);
-        outline: 1px solid transparent;
-        transition:
-          var(--boxel-transition-properties),
-          outline-color var(--boxel-transition);
-      }
+          grid-column: 1 / span 3;
+          grid-row: 2;
 
-      .boxel-input--large {
-        --boxel-form-control-height: 4.375rem;
-        font-size: var(--boxel-font-size);
-      }
+          box-sizing: border-box;
+          width: 100%;
+          max-width: 100%;
+          min-height: var(--boxel-input-height);
+          padding: var(--boxel-sp-xs) 0 var(--boxel-sp-xs) var(--boxel-sp-sm);
+          background-color: var(--background, var(--boxel-light));
+          color: var(--foreground, var(--boxel-dark));
+          border: 1px solid
+            var(--border, var(--boxel-form-control-border-color));
+          border-radius: var(--boxel-form-control-border-radius);
+          box-shadow: var(--shadow);
+          outline: 1px solid transparent;
+          transition:
+            var(--boxel-transition-properties),
+            outline-color var(--boxel-transition);
+        }
 
-      .boxel-text-area {
-        --boxel-input-height: 10rem;
-      }
+        .boxel-input--large {
+          --boxel-form-control-height: 4.375rem;
+          font-size: var(--boxel-font-size);
+        }
 
-      .boxel-input:disabled {
-        opacity: 0.5;
-      }
+        .boxel-text-area {
+          --boxel-input-height: 10rem;
+        }
 
-      .boxel-input:focus-visible {
-        outline-color: var(--ring, var(--boxel-highlight));
-        border-color: var(--ring, var(--boxel-highlight));
-      }
+        .boxel-input:not([type='color']):disabled {
+          opacity: 0.5;
+        }
 
-      .boxel-input::placeholder {
-        color: var(--muted-foreground, var(--boxel-450));
-      }
+        .boxel-input:focus-visible {
+          outline-color: var(--ring, var(--boxel-highlight));
+          border-color: var(--ring, var(--boxel-highlight));
+        }
 
-      .boxel-input:hover:not(:focus-visible):not(:disabled):not(.invalid):not(
-          :invalid
-        ):not(.search) {
-        border-color: var(--border, currentColor);
-      }
+        .boxel-input::placeholder {
+          color: var(--muted-foreground, var(--boxel-450));
+        }
 
-      .invalid:not(:disabled),
-      :invalid:not(:disabled) {
-        border-color: var(--destructive, var(--boxel-error-100));
-        box-shadow: 0 0 0 1px var(--destructive, var(--boxel-error-100));
-      }
+        .boxel-input:hover:not(:focus-visible):not(:disabled):not(.invalid):not(
+            :invalid
+          ):not(.search) {
+          border-color: var(--border, currentColor);
+        }
 
-      .invalid:focus-visible,
-      :invalid:focus-visible {
-        outline: 1px solid transparent; /* Make sure that we make the invalid state visible */
-        box-shadow: 0 0 0 1.5px var(--destructive, var(--boxel-error-100));
-      }
+        .invalid:not(:disabled),
+        :invalid:not(:disabled) {
+          border-color: var(--destructive, var(--boxel-error-100));
+          box-shadow: 0 0 0 1px var(--destructive, var(--boxel-error-100));
+        }
 
-      .invalid:hover:not(:disabled),
-      :invalid:hover:not(:disabled) {
-        border-color: var(--destructive, var(--boxel-error-100));
-      }
+        .invalid:focus-visible,
+        :invalid:focus-visible {
+          outline: 1px solid transparent; /* Make sure that we make the invalid state visible */
+          box-shadow: 0 0 0 1.5px var(--destructive, var(--boxel-error-100));
+        }
 
-      .search {
-        --search-input-color: var(
-          --boxel-input-search-color,
-          var(--background, var(--boxel-light))
-        );
+        .invalid:hover:not(:disabled),
+        :invalid:hover:not(:disabled) {
+          border-color: var(--destructive, var(--boxel-error-100));
+        }
 
-        --search-input-background-color: var(
-          --boxel-input-search-background-color,
-          var(--foreground, var(--boxel-dark))
-        );
+        .search {
+          --search-input-color: var(
+            --boxel-input-search-color,
+            var(--background, var(--boxel-light))
+          );
 
-        --boxel-form-control-border-color: var(--border, var(--boxel-dark));
-        --boxel-form-control-border-radius: var(--boxel-border-radius-xl);
+          --search-input-background-color: var(
+            --boxel-input-search-background-color,
+            var(--foreground, var(--boxel-dark))
+          );
 
-        background-color: var(--search-input-background-color);
-        color: var(--search-input-color);
-        padding-top: var(--boxel-sp-xxxs);
-        padding-right: var(--boxel-sp-xl);
-        padding-bottom: var(--boxel-sp-xxxs);
-        /* to account for the icon being on the left */
-        padding-right: unset;
-        padding-left: var(--boxel-sp-xxl); /* leave room for icon */
-        outline-width: 1px;
-      }
+          --boxel-form-control-border-color: var(--border, var(--boxel-dark));
+          --boxel-form-control-border-radius: var(--boxel-border-radius-xl);
 
-      .boxel-input--bottom-flat {
-        --boxel-form-control-border-radius: var(--boxel-border-radius-xl)
-          var(--boxel-border-radius-xl) 0 0;
-      }
+          background-color: var(--search-input-background-color);
+          color: var(--search-input-color);
+          padding-top: var(--boxel-sp-xxxs);
+          padding-right: var(--boxel-sp-xl);
+          padding-bottom: var(--boxel-sp-xxxs);
+          /* to account for the icon being on the left */
+          padding-right: unset;
+          padding-left: var(--boxel-sp-xxl); /* leave room for icon */
+          outline-width: 1px;
+        }
 
-      .search-icon {
-        --icon-color: var(
-          --boxel-input-search-icon-color,
-          var(--boxel-highlight)
-        );
-      }
+        .boxel-input--bottom-flat {
+          --boxel-form-control-border-radius: var(--boxel-border-radius-xl)
+            var(--boxel-border-radius-xl) 0 0;
+        }
 
-      .search-icon-container {
-        grid-area: pre-icon;
+        .search-icon {
+          --icon-color: var(
+            --boxel-input-search-icon-color,
+            var(--boxel-highlight)
+          );
+        }
 
-        display: flex;
-        height: 100%;
-        align-items: center;
-        justify-content: center;
-      }
+        .search-icon-container {
+          grid-area: pre-icon;
 
-      .validation-icon-container {
-        grid-area: post-icon;
+          display: flex;
+          height: 100%;
+          align-items: center;
+          justify-content: center;
+        }
 
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        user-select: none;
-      }
+        .validation-icon-container {
+          grid-area: post-icon;
 
-      .search ~ .validation-icon-container .validation-icon-loading {
-        color: var(--primary, var(--boxel-highlight));
-        --icon-color: currentColor;
-      }
-      .search ~ .search-icon-container .search-icon {
-        color: var(
-          --boxel-input-search-icon-color,
-          var(--primary, var(--boxel-highlight))
-        );
-        --icon-color: currentColor;
-      }
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          user-select: none;
+        }
 
-      .optional {
-        grid-area: optional;
-        justify-self: end;
+        .search ~ .validation-icon-container .validation-icon-loading {
+          color: var(--primary, var(--boxel-highlight));
+          --icon-color: currentColor;
+        }
+        .search ~ .search-icon-container .search-icon {
+          color: var(
+            --boxel-input-search-icon-color,
+            var(--primary, var(--boxel-highlight))
+          );
+          --icon-color: currentColor;
+        }
 
-        margin-bottom: var(--boxel-sp-xxxs);
-        font-size: var(--boxel-font-size-xs);
-        font-style: oblique;
-        letter-spacing: var(--boxel-lsp);
-        opacity: 0.75;
-      }
+        .optional {
+          grid-area: optional;
+          justify-self: end;
 
-      .error-message {
-        grid-area: error;
+          margin-bottom: var(--boxel-sp-xxxs);
+          font-size: var(--boxel-font-size-xs);
+          font-style: oblique;
+          letter-spacing: var(--boxel-lsp);
+          opacity: 0.75;
+        }
 
-        margin-top: var(--boxel-sp-xxxs);
-        margin-left: calc(var(--boxel-sp-sm) + 1px);
-        color: var(--destructive, var(--boxel-error-200));
-        font-size: var(--boxel-font-size-sm);
-        font-weight: 500;
-        letter-spacing: var(--boxel-lsp);
-      }
+        .error-message {
+          grid-area: error;
 
-      .helper-text {
-        grid-area: helper;
+          margin-top: var(--boxel-sp-xxxs);
+          margin-left: calc(var(--boxel-sp-sm) + 1px);
+          color: var(--destructive, var(--boxel-error-200));
+          font-size: var(--boxel-font-size-sm);
+          font-weight: 500;
+          letter-spacing: var(--boxel-lsp);
+        }
 
-        margin-top: var(--boxel-sp-xs);
-        margin-left: calc(var(--boxel-sp-sm) + 1px);
-        font-size: var(--boxel-font-size-sm);
-        letter-spacing: var(--boxel-lsp);
-        opacity: 0.75;
-      }
+        .helper-text {
+          grid-area: helper;
 
-      .boxel-input:disabled ~ .error-message,
-      .boxel-input:disabled ~ .helper-text {
-        display: none;
-      }
+          margin-top: var(--boxel-sp-xs);
+          margin-left: calc(var(--boxel-sp-sm) + 1px);
+          font-size: var(--boxel-font-size-sm);
+          letter-spacing: var(--boxel-lsp);
+          opacity: 0.75;
+        }
 
-      .boxel-input.search::placeholder {
-        color: inherit;
-        opacity: 0.6;
-      }
+        .boxel-input:disabled ~ .error-message,
+        .boxel-input:disabled ~ .helper-text {
+          display: none;
+        }
 
-      @media (prefers-reduced-motion: no-preference) {
-        .validation-icon-loading {
-          animation: var(--boxel-infinite-spin-animation);
+        .boxel-input.search::placeholder {
+          color: inherit;
+          opacity: 0.6;
+        }
+
+        @media (prefers-reduced-motion: no-preference) {
+          .validation-icon-loading {
+            animation: var(--boxel-infinite-spin-animation);
+          }
         }
       }
     </style>

--- a/packages/boxel-ui/addon/src/components/swatch/index.gts
+++ b/packages/boxel-ui/addon/src/components/swatch/index.gts
@@ -1,0 +1,74 @@
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
+
+import { cn, cssVar, eq } from '../../helpers.ts';
+
+interface Signature {
+  Args: {
+    color?: string | null;
+    hideLabel?: boolean;
+    label?: string | null;
+    style?: 'round' | 'default';
+  };
+  Element: HTMLElement;
+}
+
+const Swatch: TemplateOnlyComponent<Signature> = <template>
+  <div class={{cn 'swatch' small=(eq @style 'round')}} ...attributes>
+    {{#unless @hideLabel}}
+      <div class='label'>
+        {{#if @label}}
+          <div>{{@label}}</div>
+        {{/if}}
+        <code class='value'>{{@color}}</code>
+      </div>
+    {{/unless}}
+    <div
+      class={{cn 'preview' round=(eq @style 'round')}}
+      style={{cssVar swatch-background=@color}}
+    />
+  </div>
+  <style scoped>
+    @layer boxelComponentL1 {
+      .swatch {
+        --swatch-width: 7rem;
+        --swatch-height: 3.375rem;
+        --_swatch-border: color-mix(
+          in oklab,
+          var(--border, var(--boxel-border-color)),
+          var(--foreground, var(--boxel-dark)) 10%
+        );
+        display: inline-flex;
+        flex-direction: column;
+        gap: var(--boxel-sp-xs);
+      }
+      .small {
+        --swatch-width: 1.4rem;
+        --swatch-height: 1.4rem;
+        flex-direction: row;
+        align-items: center;
+      }
+      .preview {
+        width: var(--swatch-width);
+        height: var(--swatch-height);
+        max-width: 100%;
+        padding: 0;
+        background-color: var(--swatch-background, transparent);
+        border: 1px solid
+          var(--boxel-swatch-border-color, var(--_swatch-border));
+        border-radius: var(--boxel-border-radius);
+      }
+      .preview.round {
+        flex-shrink: 0;
+        aspect-ratio: 1;
+        border-radius: 50%;
+        order: -1;
+      }
+      .value {
+        font-family: var(--font-mono, var(--boxel-monospace-font-family));
+        text-transform: uppercase;
+      }
+    }
+  </style>
+</template>;
+
+export default Swatch;

--- a/packages/boxel-ui/addon/src/components/swatch/usage.gts
+++ b/packages/boxel-ui/addon/src/components/swatch/usage.gts
@@ -1,0 +1,57 @@
+import { fn } from '@ember/helper';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
+
+import Swatch from './index.gts';
+
+export default class SwatchUsage extends Component {
+  private swatchStyles = ['default', 'round'];
+  @tracked private color?: string = '#AC00FF';
+  @tracked private label?: string;
+  @tracked private hideLabel?: boolean;
+  @tracked private style?: 'round' | 'default';
+
+  <template>
+    <FreestyleUsage @name='Swatch'>
+      <:example>
+        <Swatch
+          @color={{this.color}}
+          @label={{this.label}}
+          @hideLabel={{this.hideLabel}}
+          @style={{this.style}}
+        />
+      </:example>
+      <:api as |Args|>
+        <Args.String
+          @name='color'
+          @defaultValue={{null}}
+          @onInput={{fn (mut this.color)}}
+          @value={{this.color}}
+        />
+        <Args.String
+          @name='label'
+          @description='optional additional label'
+          @defaultValue={{null}}
+          @onInput={{fn (mut this.label)}}
+          @value={{this.label}}
+        />
+        <Args.Bool
+          @name='hideLabel'
+          @optional={{true}}
+          @defaultValue={{false}}
+          @onInput={{fn (mut this.hideLabel)}}
+          @value={{this.hideLabel}}
+        />
+        <Args.String
+          @name='style'
+          @description='round or default'
+          @options={{this.swatchStyles}}
+          @onInput={{fn (mut this.style)}}
+          @value={{this.style}}
+          @defaultValue=''
+        />
+      </:api>
+    </FreestyleUsage>
+  </template>
+}

--- a/packages/boxel-ui/addon/src/styles/global.css
+++ b/packages/boxel-ui/addon/src/styles/global.css
@@ -1,4 +1,4 @@
-@layer reset, utilities, boxelComponentL1, boxelComponentL2, boxelComponentL3, boxelComponentL4;
+@layer reset, utilities, boxelComponentL1, boxelComponentL2, boxelComponentL3;
 
 @layer reset {
   * {

--- a/packages/boxel-ui/addon/src/styles/global.css
+++ b/packages/boxel-ui/addon/src/styles/global.css
@@ -1,3 +1,14 @@
+/* Note on css layers: css @layer rules are used to create a layering system for the css.
+   The order of the layers is important as it determines the precedence of the styles.
+   The layers are defined in the following order:
+   1. reset: for resetting default browser styles
+   2. utilities: for utility classes that can be used throughout the application
+   3. boxelComponentL1: for base component styles
+   4. boxelComponentL2: for component styles that build on top of base styles
+   5. boxelComponentL3: for component styles that build on top of L2 styles
+   This layering system allows for easier overrides and customizations of styles at different levels.
+   More info: https://developer.mozilla.org/en-US/docs/Web/CSS/@layer
+*/
 @layer reset, utilities, boxelComponentL1, boxelComponentL2, boxelComponentL3;
 
 @layer reset {

--- a/packages/boxel-ui/addon/src/styles/global.css
+++ b/packages/boxel-ui/addon/src/styles/global.css
@@ -1,4 +1,4 @@
-@layer reset, utilities, boxelComponentL1, boxelComponentL2;
+@layer reset, utilities, boxelComponentL1, boxelComponentL2, boxelComponentL3, boxelComponentL4;
 
 @layer reset {
   * {
@@ -93,10 +93,14 @@
     letter-spacing: inherit;
   }
 
-  input:disabled,
+  input:not([type='color']):disabled,
   select:disabled,
   textarea:disabled {
     opacity: 0.5;
+    pointer-events: none;
+  }
+
+  input[type='color']:disabled {
     pointer-events: none;
   }
 

--- a/packages/boxel-ui/addon/src/usage.ts
+++ b/packages/boxel-ui/addon/src/usage.ts
@@ -42,6 +42,7 @@ import ResizablePanelGroupUsage from './components/resizable-panel-group/usage.g
 import SelectUsage from './components/select/usage.gts';
 import SkeletonPlaceholderUsage from './components/skeleton-placeholder/usage.gts';
 import SortDropdownUsage from './components/sort-dropdown/usage.gts';
+import SwatchUsage from './components/swatch/usage.gts';
 import SwitchUsage from './components/switch/usage.gts';
 import TabbedHeaderUsage from './components/tabbed-header/usage.gts';
 import TagListUsage from './components/tag-list/usage.gts';
@@ -91,6 +92,7 @@ export const ALL_USAGE_COMPONENTS = [
   ['Select', SelectUsage],
   ['SkeletonPlaceholder', SkeletonPlaceholderUsage],
   ['SortDropdown', SortDropdownUsage],
+  ['Swatch', SwatchUsage],
   ['Switch', SwitchUsage],
   ['TabbedHeader', TabbedHeaderUsage],
   ['TagList', TagListUsage],


### PR DESCRIPTION
Changes:
- Enable theming
- Create `Swatch` component with different view styles
- Add text input field to the ColorPicker component. This enables colors in `okchl` color space to be able to use this component. The color preview icon still opens browser's default color-picker, but the value is also editable via the input field. Clicking X icon clears the input.
- Update ColorPalette component with the new ColorPicker and also add tooltips on color buttons.
- Add disabled state
- Update `base` package `ColorField` templates

<img width="744" height="573" alt="color-picker" src="https://github.com/user-attachments/assets/0e9e9487-f792-4785-af47-e569f4a1cbc9" />

<img width="730" height="821" alt="color-palette" src="https://github.com/user-attachments/assets/69d8d142-3911-419f-8419-ed4c69c0812f" />

<img width="729" height="438" alt="swatch-default" src="https://github.com/user-attachments/assets/47fd1ef3-dda0-4975-af40-3a5056fe4f7a" />

<img width="725" height="375" alt="swatch-round" src="https://github.com/user-attachments/assets/de5e264c-d2d2-405d-8cd1-2d129e9ceaea" />

