### PR TITLE
server: Remove `_publish-realm` publishability check

### DIFF
--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -118,29 +118,30 @@ export default function handlePublishRealm({
     }
 
     try {
-      let realmInfoResponse = await virtualNetwork.handle(
-        new Request(`${sourceRealmURL}_info`, {
-          headers: {
-            Accept: SupportedMimeType.RealmInfo,
-          },
-        }),
-      );
+      // TODO restore in CS-9468
+      // let realmInfoResponse = await virtualNetwork.handle(
+      //   new Request(`${sourceRealmURL}_info`, {
+      //     headers: {
+      //       Accept: SupportedMimeType.RealmInfo,
+      //     },
+      //   }),
+      // );
 
-      if (!realmInfoResponse || realmInfoResponse.status !== 200) {
-        log.warn(
-          `Failed to fetch realm info for realm ${sourceRealmURL}: ${realmInfoResponse?.status}`,
-        );
-        throw new Error(`Could not fetch info for realm ${sourceRealmURL}`);
-      }
+      // if (!realmInfoResponse || realmInfoResponse.status !== 200) {
+      //   log.warn(
+      //     `Failed to fetch realm info for realm ${sourceRealmURL}: ${realmInfoResponse?.status}`,
+      //   );
+      //   throw new Error(`Could not fetch info for realm ${sourceRealmURL}`);
+      // }
 
-      let realmInfoJson = await realmInfoResponse.json();
+      // let realmInfoJson = await realmInfoResponse.json();
 
-      if (realmInfoJson.data.attributes.publishable !== true) {
-        return sendResponseForUnprocessableEntity(
-          ctxt,
-          `Realm ${sourceRealmURL} is not publishable`,
-        );
-      }
+      // if (realmInfoJson.data.attributes.publishable !== true) {
+      //   return sendResponseForUnprocessableEntity(
+      //     ctxt,
+      //     `Realm ${sourceRealmURL} is not publishable`,
+      //   );
+      // }
 
       let existingPublishedRealm = realms.find(
         (r) => r.url === publishedRealmURL,

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -19,7 +19,6 @@ import {
   fetchRequestFromContext,
   sendResponseForBadRequest,
   sendResponseForForbiddenRequest,
-  sendResponseForUnprocessableEntity,
   sendResponseForSystemError,
   setContextResponse,
 } from '../middleware';

--- a/packages/realm-server/tests/publish-unpublish-realm-test.ts
+++ b/packages/realm-server/tests/publish-unpublish-realm-test.ts
@@ -1,4 +1,4 @@
-import { module, test } from 'qunit';
+import { module, skip, test } from 'qunit';
 import supertest, { SuperTest, Test } from 'supertest';
 import { v4 as uuidv4 } from 'uuid';
 import {
@@ -99,7 +99,8 @@ module(basename(__filename), function () {
       },
     });
 
-    test('POST /_publish-realm cannot publish a realm that is not publishable', async function (assert) {
+    // TODO restore in CS-9468
+    skip('POST /_publish-realm cannot publish a realm that is not publishable', async function (assert) {
       let response = await request
         .post('/_publish-realm')
         .set('Accept', 'application/vnd.api+json')


### PR DESCRIPTION
Only public realms can be published at the moment, which is a bug. What’s a reliable way to check publishability in a realm server route handler?

As part of restoring this I’ll add a Matrix test that properly exercises this end-to-end.