### PR TITLE
host: Fix linting of test `.gts` files

### DIFF
--- a/packages/host/.eslintrc.js
+++ b/packages/host/.eslintrc.js
@@ -133,7 +133,7 @@ module.exports = {
     },
     {
       // test files
-      files: ['tests/**/*-test.{js,ts}'],
+      files: ['tests/**/*-test.{gjs,gts,js,ts}'],
       extends: ['plugin:qunit/recommended'],
       rules: {
         'qunit/require-expect': 'off',

--- a/packages/host/tests/acceptance/catalog-app-test.gts
+++ b/packages/host/tests/acceptance/catalog-app-test.gts
@@ -831,7 +831,7 @@ module('Acceptance | Catalog | catalog app tests', function (hooks) {
     });
   }
 
-  module('catalog index', async function (hooks) {
+  module('catalog index', function (hooks) {
     hooks.beforeEach(async function () {
       await visitOperatorMode({
         stacks: [
@@ -846,7 +846,7 @@ module('Acceptance | Catalog | catalog app tests', function (hooks) {
       await waitForShowcase();
     });
 
-    module('listing fitted', async function () {
+    module('listing fitted', function () {
       test('after clicking "Remix" button, the ai room is initiated, and prompt is given correctly', async function (assert) {
         await selectTab('Cards');
         await waitForGrid();
@@ -1093,9 +1093,9 @@ module('Acceptance | Catalog | catalog app tests', function (hooks) {
       });
     });
 
-    module('navigation', async function () {
+    module('navigation', function () {
       // showcase tab has different behavior compared to other tabs (apps, cards, fields, skills)
-      module('show results as per catalog tab selected', async function () {
+      module('show results as per catalog tab selected', function () {
         test('switch to showcase tab', async function (assert) {
           await selectTab('Showcase');
           await waitForShowcase();
@@ -1352,7 +1352,7 @@ module('Acceptance | Catalog | catalog app tests', function (hooks) {
     });
   });
 
-  module('listing isolated', async function (hooks) {
+  module('listing isolated', function (hooks) {
     hooks.beforeEach(async function () {
       await visitOperatorMode({
         stacks: [
@@ -1601,14 +1601,14 @@ module('Acceptance | Catalog | catalog app tests', function (hooks) {
     });
   });
 
-  module('listing commands', async function (hooks) {
+  module('listing commands', function (hooks) {
     hooks.beforeEach(async function () {
       // we always run a command inside interact mode
       await visitOperatorMode({
         stacks: [[]],
       });
     });
-    module('"build"', async function () {
+    module('"build"', function () {
       test('card listing', async function (assert) {
         await visitOperatorMode({
           stacks: [
@@ -1628,7 +1628,7 @@ module('Acceptance | Catalog | catalog app tests', function (hooks) {
           .containsText('Build', 'Build button exist in listing');
       });
     });
-    module('"create"', async function () {
+    module('"create"', function () {
       test('card listing with single dependency module', async function (assert) {
         const cardId = mockCatalogURL + 'author/Author/example';
         const commandService = getService('command-service');
@@ -1797,7 +1797,7 @@ module('Acceptance | Catalog | catalog app tests', function (hooks) {
         await verifyJSONWithUUIDInFolder(assert, instanceFolder);
       });
     });
-    module('"install"', async function () {
+    module('"install"', function () {
       test('card listing', async function (assert) {
         const listingName = 'author';
 
@@ -1873,7 +1873,7 @@ module('Acceptance | Catalog | catalog app tests', function (hooks) {
         await verifyFileInFileTree(assert, instancePath);
       });
     });
-    module('"remix"', async function () {
+    module('"remix"', function () {
       test('card listing: installs the card and redirects to code mode with persisted playground selection for first example successfully', async function (assert) {
         const listingName = 'author';
         const listingId = `${mockCatalogURL}Listing/${listingName}`;

--- a/packages/host/tests/acceptance/catalog-app-test.gts
+++ b/packages/host/tests/acceptance/catalog-app-test.gts
@@ -1658,14 +1658,12 @@ module('Acceptance | Catalog | catalog app tests', function (hooks) {
             2,
             'Listing should have two specs',
           );
-          assert.strictEqual(
+          assert.true(
             listing.specs.some((spec) => spec.ref.name === 'Author'),
-            true,
             'Listing should have an Author spec',
           );
-          assert.strictEqual(
+          assert.true(
             listing.specs.some((spec) => spec.ref.name === 'AuthorCompany'),
-            true,
             'Listing should have an AuthorCompany spec',
           );
         }
@@ -1695,12 +1693,11 @@ module('Acceptance | Catalog | catalog app tests', function (hooks) {
             listingId,
           )) as CardListing;
           assert.ok(listing, 'Listing should be created');
-          assert.strictEqual(
+          assert.true(
             listing.specs.every(
               (spec) =>
                 spec.ref.module != 'https://cdn.jsdelivr.net/npm/chess.js/+esm',
             ),
-            true,
             'Listing should does not have unrecognised import',
           );
         }
@@ -1738,9 +1735,8 @@ module('Acceptance | Catalog | catalog app tests', function (hooks) {
           );
           ['Author', 'AuthorCompany', 'BlogPost', 'BlogApp', 'AppCard'].forEach(
             (specName) => {
-              assert.strictEqual(
+              assert.true(
                 listing.specs.some((spec) => spec.ref.name === specName),
-                true,
                 `Listing should have a ${specName} spec`,
               );
             },

--- a/packages/host/tests/acceptance/code-patches-test.gts
+++ b/packages/host/tests/acceptance/code-patches-test.gts
@@ -44,10 +44,10 @@ import StringField from 'https://cardstack.com/base/string';
 
 export class TestCard extends CardDef {
   static displayName = 'Test Card';
-  
+
   @field name = contains(StringField);
   @field description = contains(StringField);
-  
+
   static isolated = class Isolated extends Component<typeof this> {
     <template>
       <div data-test-test-card>
@@ -208,7 +208,7 @@ ${REPLACE_MARKER}\n\`\`\``;
         event.content['m.relates_to']?.event_id === eventId &&
         event.content['m.relates_to']?.key === 'applied',
     );
-    assert.equal(
+    assert.strictEqual(
       codePatchResultEvents.length,
       1,
       'code patch result event is dispatched',
@@ -448,7 +448,7 @@ ${REPLACE_MARKER}
           APP_BOXEL_CODE_PATCH_RESULT_REL_TYPE &&
         event.content['m.relates_to']?.key === 'applied',
     );
-    assert.equal(
+    assert.strictEqual(
       codePatchResultEvents.length,
       3,
       'code patch result events are dispatched',
@@ -493,7 +493,7 @@ ${REPLACE_MARKER}\n\`\`\``;
         event.content['m.relates_to']?.event_id === eventId &&
         event.content['m.relates_to']?.key === 'failed',
     );
-    assert.equal(
+    assert.strictEqual(
       codePatchResultEvents.length,
       1,
       'code patch result event is dispatched',
@@ -725,7 +725,7 @@ ${REPLACE_MARKER}
     let successfulCodePatchResultEvents = codePatchResultEvents.filter(
       (event) => event.content['m.relates_to']?.key === 'applied',
     );
-    assert.equal(
+    assert.strictEqual(
       successfulCodePatchResultEvents.length,
       2,
       'successful code patch result events are dispatched',
@@ -733,7 +733,7 @@ ${REPLACE_MARKER}
     let failedCodePatchResultEvents = codePatchResultEvents.filter(
       (event) => event.content['m.relates_to']?.key === 'failed',
     );
-    assert.equal(
+    assert.strictEqual(
       failedCodePatchResultEvents.length,
       1,
       'failed code patch result events are dispatched',
@@ -1637,7 +1637,7 @@ ${REPLACE_MARKER}\n\`\`\``;
         event.content['m.relates_to']?.event_id === eventId &&
         event.content['m.relates_to']?.key === 'applied',
     );
-    assert.equal(
+    assert.strictEqual(
       codePatchResultEvents.length,
       1,
       'code patch result event is dispatched',
@@ -1749,7 +1749,7 @@ ${REPLACE_MARKER}\n\`\`\``;
         event.content['m.relates_to']?.event_id === eventId &&
         event.content['m.relates_to']?.key === 'applied',
     );
-    assert.equal(
+    assert.strictEqual(
       codePatchResultEvents.length,
       1,
       'code patch result event is dispatched',

--- a/packages/host/tests/acceptance/commands-test.gts
+++ b/packages/host/tests/acceptance/commands-test.gts
@@ -1337,7 +1337,7 @@ module('Acceptance | Commands tests', function (hooks) {
       let commandResultEvents = await getRoomEvents(roomId).filter(
         (event) => event.type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
       );
-      assert.equal(
+      assert.strictEqual(
         commandResultEvents.length,
         0,
         'No command result event dispatched',
@@ -1347,7 +1347,7 @@ module('Acceptance | Commands tests', function (hooks) {
       commandResultEvents = await getRoomEvents(roomId).filter(
         (event) => event.type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
       );
-      assert.equal(
+      assert.strictEqual(
         commandResultEvents.length,
         1,
         'Command result event was dispatched',

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -851,6 +851,7 @@ module('Acceptance | interact submode tests', function (hooks) {
         }
         if (json.data.attributes?.firstName === null) {
           // Because we create an empty card, upon choosing a catalog item, we must skip the scenario where attributes null
+          // eslint-disable-next-line qunit/no-early-return
           return;
         }
         id = url.href;
@@ -2036,6 +2037,7 @@ module('Acceptance | interact submode tests', function (hooks) {
             ev.eventName === 'index' &&
             ev.indexType === 'incremental-index-initiation'
           ) {
+            // eslint-disable-next-line qunit/no-early-return
             return; // ignore the index initiation event
           }
           ev = ev as IncrementalIndexEventContent;

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -748,9 +748,9 @@ module('Acceptance | operator mode tests', function (hooks) {
     urlParameters = new URLSearchParams(url);
     let operatorModeStateParam = urlParameters.get('operatorModeState');
 
+    assert.true(operatorModeStateParam);
     assert.true(
-      operatorModeStateParam &&
-        JSON.parse(operatorModeStateParam).workspaceChooserOpened,
+      JSON.parse(operatorModeStateParam ?? '{}').workspaceChooserOpened,
     );
     await percySnapshot(assert);
   });

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -1134,17 +1134,17 @@ module('Acceptance | operator mode tests', function (hooks) {
       stripeCheckoutLinkExample =
         'https://checkout.stripe.com/c/pay/2500-credits';
       await click('[data-test-buy-more-credits-button="2500"]');
-      assert.equal(redirectedToUrl, stripeCheckoutLinkExample);
+      assert.strictEqual(redirectedToUrl, stripeCheckoutLinkExample);
 
       stripeCheckoutLinkExample =
         'https://checkout.stripe.com/c/pay/20000-credits';
       await click('[data-test-buy-more-credits-button="20000"]');
-      assert.equal(redirectedToUrl, stripeCheckoutLinkExample);
+      assert.strictEqual(redirectedToUrl, stripeCheckoutLinkExample);
 
       stripeCheckoutLinkExample =
         'https://checkout.stripe.com/c/pay/80000-credits';
       await click('[data-test-buy-more-credits-button="80000"]');
-      assert.equal(redirectedToUrl, stripeCheckoutLinkExample);
+      assert.strictEqual(redirectedToUrl, stripeCheckoutLinkExample);
 
       await click('[data-test-close-modal]');
       await click('[data-test-profile-icon-button]');
@@ -1153,17 +1153,17 @@ module('Acceptance | operator mode tests', function (hooks) {
       stripeCheckoutLinkExample =
         'https://checkout.stripe.com/c/pay/starter-plan';
       await click('[data-test-starter-plan-button]');
-      assert.equal(redirectedToUrl, stripeCheckoutLinkExample);
+      assert.strictEqual(redirectedToUrl, stripeCheckoutLinkExample);
 
       stripeCheckoutLinkExample =
         'https://checkout.stripe.com/c/pay/creator-plan';
       await click('[data-test-creator-plan-button]');
-      assert.equal(redirectedToUrl, stripeCheckoutLinkExample);
+      assert.strictEqual(redirectedToUrl, stripeCheckoutLinkExample);
 
       stripeCheckoutLinkExample =
         'https://checkout.stripe.com/c/pay/power-user-plan';
       await click('[data-test-power-user-plan-button]');
-      assert.equal(redirectedToUrl, stripeCheckoutLinkExample);
+      assert.strictEqual(redirectedToUrl, stripeCheckoutLinkExample);
     });
 
     test(`displays credit info in account popover`, async function (assert) {

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -748,7 +748,7 @@ module('Acceptance | operator mode tests', function (hooks) {
     urlParameters = new URLSearchParams(url);
     let operatorModeStateParam = urlParameters.get('operatorModeState');
 
-    assert.true(operatorModeStateParam);
+    assert.ok(operatorModeStateParam);
     assert.true(
       JSON.parse(operatorModeStateParam ?? '{}').workspaceChooserOpened,
     );

--- a/packages/host/tests/acceptance/workspace-delete-multiple-test.gts
+++ b/packages/host/tests/acceptance/workspace-delete-multiple-test.gts
@@ -162,7 +162,7 @@ module('Acceptance | workspace-delete-multiple', function (hooks) {
 
     // Verify cards were deleted
     let remainingCards = findAll('[data-test-cards-grid-item]');
-    assert.equal(remainingCards.length, 1, 'Two cards were deleted');
+    assert.strictEqual(remainingCards.length, 1, 'Two cards were deleted');
 
     // Verify selection mode is cleared
     assert
@@ -319,7 +319,7 @@ module('Acceptance | workspace-delete-multiple', function (hooks) {
 
     // Verify no cards were deleted
     let remainingCards = findAll('[data-test-cards-grid-item]');
-    assert.equal(
+    assert.strictEqual(
       remainingCards.length,
       initialCardCount,
       'No cards were deleted after canceling',

--- a/packages/host/tests/integration/commands/search-google-images-test.gts
+++ b/packages/host/tests/integration/commands/search-google-images-test.gts
@@ -175,7 +175,7 @@ module('Integration | commands | search-google-images', function (hooks) {
       '0.50',
       'Should have correct formatted search time',
     );
-    assert.strictEqual(result.hasNextPage, true, 'Should have next page');
+    assert.true(result.hasNextPage, 'Should have next page');
     assert.strictEqual(
       result.nextPageStartIndex,
       3,

--- a/packages/host/tests/integration/commands/show-card-test.gts
+++ b/packages/host/tests/integration/commands/show-card-test.gts
@@ -326,9 +326,8 @@ module('Integration | Command | show-card', function (hooks) {
 
       await command.execute({ cardId });
 
-      assert.strictEqual(
+      assert.false(
         mockOperatorModeStateService.state.workspaceChooserOpened,
-        false,
         'Workspace chooser is closed after showing card',
       );
     });

--- a/packages/host/tests/integration/commands/summarize-session-test.gts
+++ b/packages/host/tests/integration/commands/summarize-session-test.gts
@@ -269,8 +269,7 @@ module('Integration | commands | summarize-session', function (hooks) {
       assert.ok(error instanceof Error, 'Error should be an Error instance');
       const errorMessage = (error as Error).message;
       assert.true(
-        errorMessage.includes('OpenRouter API error') ||
-          errorMessage.includes('Failed to generate summary'),
+        errorMessage.includes('OpenRouter API error'),
         'Error message should indicate API failure',
       );
     }
@@ -293,9 +292,7 @@ module('Integration | commands | summarize-session', function (hooks) {
       // The error could be about room not found or other matrix-related errors
       const errorMessage = (error as Error).message;
       assert.true(
-        errorMessage.includes('room') ||
-          errorMessage.includes('Room') ||
-          errorMessage.includes('matrix'),
+        errorMessage.includes('room'),
         'Error message should indicate room-related issue',
       );
     }

--- a/packages/host/tests/integration/commands/summarize-session-test.gts
+++ b/packages/host/tests/integration/commands/summarize-session-test.gts
@@ -269,7 +269,7 @@ module('Integration | commands | summarize-session', function (hooks) {
       assert.ok(error instanceof Error, 'Error should be an Error instance');
       const errorMessage = (error as Error).message;
       assert.true(
-        errorMessage.includes('OpenRouter API error'),
+        errorMessage.includes('Failed to generate summary'),
         'Error message should indicate API failure',
       );
     }

--- a/packages/host/tests/integration/components/ai-assistant-panel/codeblocks-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/codeblocks-test.gts
@@ -435,7 +435,7 @@ const data = {
     );
 
     await waitUntil(() => document.getElementsByClassName('view-lines')[1]);
-    assert.equal(
+    assert.strictEqual(
       (document.getElementsByClassName('view-lines')[1] as HTMLElement)
         .innerText,
       '// existing code ... \nlet a = 1;\nlet c = 3;\n// new code ... \nlet a = 2;',

--- a/packages/host/tests/integration/components/ai-assistant-panel/commands-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/commands-test.gts
@@ -541,7 +541,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
           APP_BOXEL_COMMAND_RESULT_REL_TYPE &&
         event.content['m.relates_to']?.key === 'applied',
     );
-    assert.equal(
+    assert.strictEqual(
       commandResultEvents.length,
       0,
       'command result event is not dispatched',
@@ -566,7 +566,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
           APP_BOXEL_COMMAND_RESULT_REL_TYPE &&
         event.content['m.relates_to']?.key === 'applied',
     );
-    assert.equal(
+    assert.strictEqual(
       commandResultEvents.length,
       1,
       'command result event is dispatched',
@@ -625,7 +625,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
     let commandResultEvents = getRoomEvents(roomId).filter(
       (event) => event.type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
     );
-    assert.equal(
+    assert.strictEqual(
       commandResultEvents.length,
       0,
       'command result event is not dispatched',
@@ -644,7 +644,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
     commandResultEvents = getRoomEvents(roomId).filter(
       (event) => event.type === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
     );
-    assert.equal(
+    assert.strictEqual(
       commandResultEvents.length,
       1,
       'command result event is dispatched',
@@ -1227,7 +1227,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
           APP_BOXEL_COMMAND_RESULT_REL_TYPE &&
         event.content['m.relates_to']?.key === 'applied',
     );
-    assert.equal(
+    assert.strictEqual(
       commandResultEvents.length,
       0,
       'command result event is not dispatched',
@@ -1250,7 +1250,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
           APP_BOXEL_COMMAND_RESULT_REL_TYPE &&
         event.content['m.relates_to']?.key === 'applied',
     );
-    assert.equal(
+    assert.strictEqual(
       commandResultEvents.length,
       1,
       'command result event is dispatched',
@@ -1325,7 +1325,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
           APP_BOXEL_COMMAND_RESULT_REL_TYPE &&
         event.content['m.relates_to']?.key === 'applied',
     );
-    assert.equal(
+    assert.strictEqual(
       commandResultEvents.length,
       0,
       'command result event is not dispatched',
@@ -1348,7 +1348,7 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
           APP_BOXEL_COMMAND_RESULT_REL_TYPE &&
         event.content['m.relates_to']?.key === 'applied',
     );
-    assert.equal(
+    assert.strictEqual(
       commandResultEvents.length,
       1,
       'command result event is dispatched',

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -377,7 +377,7 @@ module('Integration | card-basics', function (hooks) {
         name: 'Person',
       });
       let readBoolean: boolean = card.boolean;
-      assert.deepEqual(readBoolean, true);
+      assert.true(readBoolean);
     });
 
     test('access @model for primitive and composite fields', async function (assert) {
@@ -3309,16 +3309,8 @@ module('Integration | card-basics', function (hooks) {
       assertRadioInput(assert, 'isHuman', 'true', true);
       assertRadioInput(assert, 'isHuman', 'false', false);
 
-      assert.strictEqual(
-        mango.isCool,
-        true,
-        'the isCool field has the correct value',
-      );
-      assert.strictEqual(
-        mango.isHuman,
-        true,
-        'the isHuman field has the correct value',
-      );
+      assert.true(mango.isCool, 'the isCool field has the correct value');
+      assert.true(mango.isHuman, 'the isHuman field has the correct value');
     });
 
     test('can adopt a card', async function (assert) {
@@ -3776,9 +3768,8 @@ module('Integration | card-basics', function (hooks) {
         1,
         'The queryable value from user supplied data is correct (number)',
       );
-      assert.strictEqual(
+      assert.true(
         getQueryableValue(TestField, { firstName: true, age: 6 }),
-        true,
         'The queryable value from user supplied data is correct (boolean)',
       );
       assert.strictEqual(
@@ -3917,8 +3908,8 @@ module('Integration | card-basics', function (hooks) {
       }
 
       assert.strictEqual(
-        'The place where the person was born',
         getFieldDescription(Person, 'hometown'),
+        'The place where the person was born',
       );
     });
 

--- a/packages/host/tests/integration/components/formatted-aibot-message-test.gts
+++ b/packages/host/tests/integration/components/formatted-aibot-message-test.gts
@@ -105,17 +105,17 @@ puts "💎"
       '.message',
     ) as HTMLElement;
     let directChildren = messageElement.children;
-    assert.ok(directChildren[0]?.tagName == 'P');
+    assert.equal(directChildren[0]?.tagName, 'P');
     assert.ok(
       directChildren[1]?.tagName == 'SECTION' &&
         directChildren[1]?.classList.contains('code-block'),
     );
-    assert.ok(directChildren[2]?.tagName == 'P');
+    assert.equal(directChildren[2]?.tagName, 'P');
     assert.ok(
       directChildren[3]?.tagName == 'SECTION' &&
         directChildren[3]?.classList.contains('code-block'),
     );
-    assert.ok(directChildren[4]?.tagName == 'P');
+    assert.equal(directChildren[4]?.tagName, 'P');
 
     assert.dom('.monaco-editor').exists({ count: 2 });
     assert.dom('pre').doesNotExist();

--- a/packages/host/tests/integration/components/formatted-aibot-message-test.gts
+++ b/packages/host/tests/integration/components/formatted-aibot-message-test.gts
@@ -106,15 +106,12 @@ puts "💎"
     ) as HTMLElement;
     let directChildren = messageElement.children;
     assert.strictEqual(directChildren[0]?.tagName, 'P');
-    assert.ok(
-      directChildren[1]?.tagName == 'SECTION' &&
-        directChildren[1]?.classList.contains('code-block'),
-    );
+    assert.true(directChildren[1]?.tagName == 'SECTION');
+    assert.true(directChildren[1]?.classList.contains('code-block'));
+
     assert.strictEqual(directChildren[2]?.tagName, 'P');
-    assert.ok(
-      directChildren[3]?.tagName == 'SECTION' &&
-        directChildren[3]?.classList.contains('code-block'),
-    );
+    assert.true(directChildren[3]?.tagName == 'SECTION');
+    assert.true(directChildren[3]?.classList.contains('code-block'));
     assert.strictEqual(directChildren[4]?.tagName, 'P');
 
     assert.dom('.monaco-editor').exists({ count: 2 });

--- a/packages/host/tests/integration/components/formatted-aibot-message-test.gts
+++ b/packages/host/tests/integration/components/formatted-aibot-message-test.gts
@@ -105,17 +105,17 @@ puts "💎"
       '.message',
     ) as HTMLElement;
     let directChildren = messageElement.children;
-    assert.equal(directChildren[0]?.tagName, 'P');
+    assert.strictEqual(directChildren[0]?.tagName, 'P');
     assert.ok(
       directChildren[1]?.tagName == 'SECTION' &&
         directChildren[1]?.classList.contains('code-block'),
     );
-    assert.equal(directChildren[2]?.tagName, 'P');
+    assert.strictEqual(directChildren[2]?.tagName, 'P');
     assert.ok(
       directChildren[3]?.tagName == 'SECTION' &&
         directChildren[3]?.classList.contains('code-block'),
     );
-    assert.equal(directChildren[4]?.tagName, 'P');
+    assert.strictEqual(directChildren[4]?.tagName, 'P');
 
     assert.dom('.monaco-editor').exists({ count: 2 });
     assert.dom('pre').doesNotExist();
@@ -156,7 +156,7 @@ ${SEARCH_MARKER}
     });
     await waitUntil(() => document.querySelectorAll('.view-line').length > 3);
 
-    assert.equal(
+    assert.strictEqual(
       (document.getElementsByClassName('view-lines')[0] as HTMLElement)
         .innerText,
       '// existing code ... \nlet a = 1;\nlet b = 2;\nlet c = 3;',
@@ -185,7 +185,7 @@ ${SEPARATOR_MARKER}
 
     await waitUntil(() => document.querySelectorAll('.view-line').length > 4);
 
-    assert.equal(
+    assert.strictEqual(
       (document.getElementsByClassName('view-lines')[0] as HTMLElement)
         .innerText,
       '// existing code ... \nlet a = 1;\nlet c = 3;\n// new code ... \nlet a = 2;',
@@ -464,7 +464,7 @@ ${REPLACE_MARKER}
     assert.dom('.code-block-diff').doesNotExist();
     await waitUntil(() => document.querySelectorAll('.view-line').length == 1);
 
-    assert.equal(
+    assert.strictEqual(
       (document.getElementsByClassName('view-lines')[0] as HTMLElement)
         .innerText,
       'https://example.com/some-url',

--- a/packages/host/tests/integration/components/formatted-aibot-message-test.gts
+++ b/packages/host/tests/integration/components/formatted-aibot-message-test.gts
@@ -106,11 +106,11 @@ puts "💎"
     ) as HTMLElement;
     let directChildren = messageElement.children;
     assert.strictEqual(directChildren[0]?.tagName, 'P');
-    assert.true(directChildren[1]?.tagName == 'SECTION');
+    assert.strictEqual(directChildren[1]?.tagName, 'SECTION');
     assert.true(directChildren[1]?.classList.contains('code-block'));
 
     assert.strictEqual(directChildren[2]?.tagName, 'P');
-    assert.true(directChildren[3]?.tagName == 'SECTION');
+    assert.strictEqual(directChildren[3]?.tagName, 'SECTION');
     assert.true(directChildren[3]?.classList.contains('code-block'));
     assert.strictEqual(directChildren[4]?.tagName, 'P');
 

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -831,22 +831,14 @@ module('Integration | operator-mode', function (hooks) {
           ?.textContent?.trim() === 'Saving…',
     );
     assert.dom('[data-test-auto-save-indicator]').containsText('Saving…');
-    assert.strictEqual(
-      finishedSaving,
-      false,
-      'save in-flight message is correct',
-    );
+    assert.false(finishedSaving, 'save in-flight message is correct');
     await waitUntil(
       () =>
         document
           .querySelector('[data-test-auto-save-indicator]')
           ?.textContent?.trim() == 'Saved less than a minute ago',
     );
-    assert.strictEqual(
-      finishedSaving,
-      true,
-      'finished saving message is correct',
-    );
+    assert.true(finishedSaving, 'finished saving message is correct');
     assert
       .dom('[data-test-auto-save-indicator]')
       .containsText('Saved less than a minute ago');

--- a/packages/host/tests/integration/components/serialization-test.gts
+++ b/packages/host/tests/integration/components/serialization-test.gts
@@ -222,18 +222,10 @@ module('Integration | serialization', function (hooks) {
       `${testRealmURL}Person/mango`,
       'instance id is set',
     );
-    assert.strictEqual(
-      isSaved(savedCard),
-      true,
-      'API recognizes card as saved',
-    );
+    assert.true(isSaved(savedCard), 'API recognizes card as saved');
 
     let unsavedCard = new Person();
-    assert.strictEqual(
-      isSaved(unsavedCard),
-      false,
-      'API recognizes card as unsaved',
-    );
+    assert.false(isSaved(unsavedCard), 'API recognizes card as unsaved');
   });
 
   test('can deserialize a card with a local id', async function (assert) {
@@ -382,7 +374,7 @@ module('Integration | serialization', function (hooks) {
       firstName: 'Mango',
     });
 
-    assert.strictEqual(isSaved(card), false, 'card is not saved');
+    assert.false(isSaved(card), 'card is not saved');
 
     let result = await updateFromSerialized(card, {
       data: {
@@ -399,7 +391,7 @@ module('Integration | serialization', function (hooks) {
       },
     });
 
-    assert.strictEqual(isSaved(card), true, 'card is saved');
+    assert.true(isSaved(card), 'card is saved');
     assert.strictEqual(result, card, 'returns the same instance provided');
     assert.strictEqual(
       card.id,
@@ -503,8 +495,9 @@ module('Integration | serialization', function (hooks) {
       { data: resource },
       undefined,
     );
-    assert.ok(
-      driver.ref !== ref,
+    assert.notStrictEqual(
+      driver.ref,
+      ref,
       'the card ref value is not strict equals to its serialized counter part',
     );
     assert.deepEqual(
@@ -535,8 +528,9 @@ module('Integration | serialization', function (hooks) {
     let driver = new DriverCard({ ref });
     let serializedRef = serializeCard(driver, { includeUnrenderedFields: true })
       .data.attributes?.ref;
-    assert.ok(
-      serializedRef !== ref,
+    assert.notStrictEqual(
+      serializedRef,
+      ref,
       'the card ref value is not strict equals to its serialized counter part',
     );
     assert.deepEqual(
@@ -967,11 +961,11 @@ module('Integration | serialization', function (hooks) {
     assert.strictEqual(card.firstName, 'Hassan');
     let { pet } = card;
     if (pet instanceof Pet) {
-      assert.strictEqual(isSaved(pet), true, 'Pet card is saved');
+      assert.true(isSaved(pet), 'Pet card is saved');
       assert.strictEqual(pet.firstName, 'Mango');
       let { favoriteToy } = pet;
       if (favoriteToy instanceof Toy) {
-        assert.strictEqual(isSaved(favoriteToy), true, 'Toy card is saved');
+        assert.true(isSaved(favoriteToy), 'Toy card is saved');
         assert.strictEqual(
           favoriteToy.description,
           'Toilet paper ghost: Poooo!',
@@ -992,11 +986,7 @@ module('Integration | serialization', function (hooks) {
     } else {
       if (relationship?.type === 'loaded') {
         let relatedCard = relationship.card;
-        assert.strictEqual(
-          relatedCard instanceof Pet,
-          true,
-          'related card is a Pet',
-        );
+        assert.true(relatedCard instanceof Pet, 'related card is a Pet');
         assert.strictEqual(relatedCard?.id, `${testRealmURL}Pet/mango`);
       } else {
         assert.ok(false, 'relationship type was not "loaded"');
@@ -1075,8 +1065,8 @@ module('Integration | serialization', function (hooks) {
     } catch (err: any) {
       assert.ok(err instanceof NotLoaded, 'NotLoaded error thrown');
       assert.strictEqual(
-        'The field Person.pet refers to the card instance http://test-realm/test/Pet/mango which is not loaded',
         err.message,
+        'The field Person.pet refers to the card instance http://test-realm/test/Pet/mango which is not loaded',
         'NotLoaded error describes field not loaded',
       );
     }
@@ -1321,7 +1311,7 @@ module('Integration | serialization', function (hooks) {
 
     let { owner, favoriteToy, toys } = card;
     if (owner instanceof Person) {
-      assert.strictEqual(isSaved(owner), true, 'Person card is saved');
+      assert.true(isSaved(owner), 'Person card is saved');
       assert.strictEqual(owner.firstName, 'Burcu');
     } else {
       assert.ok(false, '"owner" field value is not an instance of Person');
@@ -1347,11 +1337,7 @@ module('Integration | serialization', function (hooks) {
     } else {
       if (relationship?.type === 'loaded') {
         let relatedCard = relationship.card;
-        assert.strictEqual(
-          relatedCard instanceof Person,
-          true,
-          'related card is a Person',
-        );
+        assert.true(relatedCard instanceof Person, 'related card is a Person');
         assert.strictEqual(relatedCard?.id, `${testRealmURL}Person/burcu`);
       } else {
         assert.ok(false, 'relationship type was not "loaded"');
@@ -2863,7 +2849,7 @@ module('Integration | serialization', function (hooks) {
       assert.strictEqual(card.firstName, 'Burcu');
       let { friendPet } = card;
       if (friendPet instanceof Pet) {
-        assert.strictEqual(isSaved(friendPet), true, 'Pet card is saved');
+        assert.true(isSaved(friendPet), 'Pet card is saved');
         assert.strictEqual(friendPet.name, 'Mango');
       } else {
         assert.ok(false, '"friendPet" field value is not an instance of Pet');
@@ -2878,11 +2864,7 @@ module('Integration | serialization', function (hooks) {
       } else {
         if (relationship?.type === 'loaded') {
           let relatedCard = relationship.card;
-          assert.strictEqual(
-            relatedCard instanceof Pet,
-            true,
-            'related card is a Pet',
-          );
+          assert.true(relatedCard instanceof Pet, 'related card is a Pet');
           assert.strictEqual(relatedCard?.id, `${testRealmURL}Pet/mango`);
         } else {
           assert.ok(false, 'relationship type was not "loaded"');
@@ -4026,7 +4008,7 @@ module('Integration | serialization', function (hooks) {
     assert.strictEqual(card.firstName, 'Hassan');
     let { pet } = card;
     assert.ok(pet instanceof Pet, '"pet" field value is an instance of Pet');
-    assert.strictEqual(isSaved(pet), true, 'Pet card is saved');
+    assert.true(isSaved(pet), 'Pet card is saved');
     assert.strictEqual(pet.firstName, 'Mango');
     let { favorite } = pet;
     assert.ok(
@@ -5061,13 +5043,13 @@ module('Integration | serialization', function (hooks) {
       assert.strictEqual(pets.length, 2, 'pets has 2 items');
       let [mango, vanGogh] = pets;
       if (mango instanceof Pet) {
-        assert.strictEqual(isSaved(mango), true, 'Pet[0] card is saved');
+        assert.true(isSaved(mango), 'Pet[0] card is saved');
         assert.strictEqual(mango.firstName, 'Mango');
       } else {
         assert.ok(false, '"pets[0]" is not an instance of Pet');
       }
       if (vanGogh instanceof Pet) {
-        assert.strictEqual(isSaved(vanGogh), true, 'Pet[1] card is saved');
+        assert.true(isSaved(vanGogh), 'Pet[1] card is saved');
         assert.strictEqual(vanGogh.firstName, 'Van Gogh');
       } else {
         assert.ok(false, '"pets[1]" is not an instance of Pet');
@@ -5079,22 +5061,14 @@ module('Integration | serialization', function (hooks) {
 
         if (mangoRelationship?.type === 'loaded') {
           let relatedCard = mangoRelationship.card;
-          assert.strictEqual(
-            relatedCard instanceof Pet,
-            true,
-            'related card is a Pet',
-          );
+          assert.true(relatedCard instanceof Pet, 'related card is a Pet');
           assert.strictEqual(relatedCard?.id, `${testRealmURL}Pet/mango`);
         } else {
           assert.ok(false, 'relationship type was not "loaded" for mango');
         }
         if (vanGoghRelationship?.type === 'loaded') {
           let relatedCard = vanGoghRelationship.card;
-          assert.strictEqual(
-            relatedCard instanceof Pet,
-            true,
-            'related card is a Pet',
-          );
+          assert.true(relatedCard instanceof Pet, 'related card is a Pet');
           assert.strictEqual(relatedCard?.id, `${testRealmURL}Pet/vanGogh`);
         } else {
           assert.ok(false, 'relationship type was not "loaded" for vanGogh');
@@ -5960,13 +5934,13 @@ module('Integration | serialization', function (hooks) {
       assert.strictEqual(friendPets.length, 2, 'pets has 2 items');
       let [mango, vanGogh] = friendPets;
       if (mango instanceof Pet) {
-        assert.strictEqual(isSaved(mango), true, 'Pet[0] card is saved');
+        assert.true(isSaved(mango), 'Pet[0] card is saved');
         assert.strictEqual(mango.name, 'Mango');
       } else {
         assert.ok(false, '"pets[0]" is not an instance of Pet');
       }
       if (vanGogh instanceof Pet) {
-        assert.strictEqual(isSaved(vanGogh), true, 'Pet[1] card is saved');
+        assert.true(isSaved(vanGogh), 'Pet[1] card is saved');
         assert.strictEqual(vanGogh.name, 'Van Gogh');
       } else {
         assert.ok(false, '"pets[1]" is not an instance of Pet');
@@ -6312,12 +6286,12 @@ module('Integration | serialization', function (hooks) {
         });
 
         assert.strictEqual(
-          typeof serialized?.data?.attributes?.someNumber === 'number',
-          true,
+          typeof serialized?.data?.attributes?.someNumber,
+          'number',
         );
-        assert.strictEqual(
-          typeof serialized?.data?.attributes?.someNumber !== 'string',
-          true,
+        assert.notStrictEqual(
+          typeof serialized?.data?.attributes?.someNumber,
+          'string',
         );
         assert.strictEqual(serialized?.data?.attributes?.someNumber, 42);
         assert.strictEqual(serialized?.data?.attributes?.someNull, null);
@@ -6370,10 +6344,10 @@ module('Integration | serialization', function (hooks) {
           undefined,
         );
 
-        assert.strictEqual(isBigInt(sample.someBigInt), true);
-        assert.strictEqual(isBigInt(sample.someNumber), true);
-        assert.strictEqual(isBigInt(sample.someNegativeNumber), true);
-        assert.strictEqual(isBigInt(sample.someZeroString), true);
+        assert.true(isBigInt(sample.someBigInt));
+        assert.true(isBigInt(sample.someNumber));
+        assert.true(isBigInt(sample.someNegativeNumber));
+        assert.true(isBigInt(sample.someZeroString));
 
         // failed to deserialize
         assert.strictEqual(sample.someNull, null);
@@ -6405,12 +6379,12 @@ module('Integration | serialization', function (hooks) {
         });
 
         assert.strictEqual(
-          typeof serialized?.data?.attributes?.someBigInt === 'string',
-          true,
+          typeof serialized?.data?.attributes?.someBigInt,
+          'string',
         );
-        assert.strictEqual(
-          typeof serialized?.data?.attributes?.someBigInt !== 'number',
-          true,
+        assert.notStrictEqual(
+          typeof serialized?.data?.attributes?.someBigInt,
+          'number',
         );
         assert.strictEqual(
           serialized?.data?.attributes?.someBigInt,
@@ -6523,11 +6497,8 @@ module('Integration | serialization', function (hooks) {
           undefined,
         );
 
-        assert.strictEqual(isEthAddress(sample.someAddress), true);
-        assert.strictEqual(
-          isEthAddress(sample.checksummedAddressThatDontLookLikeOne),
-          true,
-        );
+        assert.true(isEthAddress(sample.someAddress));
+        assert.true(isEthAddress(sample.checksummedAddressThatDontLookLikeOne));
 
         // failed to deserialize
         assert.strictEqual(sample.faultyAddress, null);
@@ -6563,12 +6534,12 @@ module('Integration | serialization', function (hooks) {
         });
 
         assert.strictEqual(
-          typeof serialized?.data?.attributes?.someAddress === 'string',
-          true,
+          typeof serialized?.data?.attributes?.someAddress,
+          'string',
         );
-        assert.strictEqual(
-          typeof serialized?.data?.attributes?.someAddress !== 'number',
-          true,
+        assert.notStrictEqual(
+          typeof serialized?.data?.attributes?.someAddress,
+          'number',
         );
         assert.strictEqual(
           serialized?.data?.attributes?.someAddress,

--- a/packages/host/tests/integration/message-service-subscription-test.gts
+++ b/packages/host/tests/integration/message-service-subscription-test.gts
@@ -111,6 +111,6 @@ module('Integration | message service subscription', function (hooks) {
 
     await settled();
 
-    assert.equal(messageCount, messageCountAfterRender);
+    assert.strictEqual(messageCount, messageCountAfterRender);
   });
 });

--- a/packages/host/tests/integration/realm-indexing-render-route-test.gts
+++ b/packages/host/tests/integration/realm-indexing-render-route-test.gts
@@ -296,8 +296,7 @@ module(`Integration | realm indexing - using /render route`, function (hooks) {
       cleanWhiteSpace(`<div class="atom">Van Gogh</div>`),
       'atom html is correct',
     );
-    assert.strictEqual(
-      false,
+    assert.false(
       atomHtml!.includes('id="ember'),
       `atom HTML does not include ember ID's`,
     );
@@ -354,8 +353,7 @@ module(`Integration | realm indexing - using /render route`, function (hooks) {
 
     let { embeddedHtml } =
       (await getInstance(realm, new URL(`${testRealmURL}germaine`))) ?? {};
-    assert.strictEqual(
-      false,
+    assert.false(
       Object.values(embeddedHtml!).join('').includes('id="ember'),
       `Embedded HTML does not include ember ID's`,
     );
@@ -401,8 +399,7 @@ module(`Integration | realm indexing - using /render route`, function (hooks) {
         data-test-field-component-card> <h1> Person Embedded Card: Germaine </h1> </div>`),
       `${testRealmURL}person/Person embedded HTML is correct`,
     );
-    assert.strictEqual(
-      false,
+    assert.false(
       embeddedHtml![`${testRealmURL}person/Person`].includes('id="ember'),
       `${testRealmURL}person/Person embedded HTML does not include ember ID's`,
     );
@@ -435,8 +432,7 @@ module(`Integration | realm indexing - using /render route`, function (hooks) {
       `${cardDefRefURL} embedded HTML is correct`,
     );
 
-    assert.strictEqual(
-      false,
+    assert.false(
       embeddedHtml![cardDefRefURL].includes('id="ember'),
       `${cardDefRefURL} fitted HTML does not include ember ID's`,
     );
@@ -493,8 +489,7 @@ module(`Integration | realm indexing - using /render route`, function (hooks) {
 
     let { embeddedHtml, fittedHtml } =
       (await getInstance(realm, new URL(`${testRealmURL}germaine`))) ?? {};
-    assert.strictEqual(
-      false,
+    assert.false(
       Object.values(fittedHtml!).join('').includes('id="ember'),
       `Fitted HTML does not include ember ID's`,
     );
@@ -540,8 +535,7 @@ module(`Integration | realm indexing - using /render route`, function (hooks) {
       data-test-field-component-card> <h1> Person Fitted Card: Germaine </h1> </div>`),
       `${testRealmURL}person/Person fitted HTML is correct`,
     );
-    assert.strictEqual(
-      false,
+    assert.false(
       fittedHtml![`${testRealmURL}person/Person`].includes('id="ember'),
       `${testRealmURL}person/Person fitted HTML does not include ember ID's`,
     );
@@ -571,8 +565,7 @@ module(`Integration | realm indexing - using /render route`, function (hooks) {
       `${cardDefRefURL} embedded HTML is correct`,
     );
 
-    assert.strictEqual(
-      false,
+    assert.false(
       embeddedHtml![cardDefRefURL].includes('id="ember'),
       `${cardDefRefURL} embedded HTML does not include ember ID's`,
     );

--- a/packages/host/tests/integration/realm-indexing-test.gts
+++ b/packages/host/tests/integration/realm-indexing-test.gts
@@ -1320,8 +1320,7 @@ module(`Integration | realm indexing`, function (hooks) {
         (await getInstance(realm, new URL(`${testRealmURL}working-vangogh`))) ??
         {};
       assertInnerHtmlMatches(assert, isolatedHtml!, `<h1> Van Gogh </h1>`);
-      assert.strictEqual(
-        false,
+      assert.false(
         isolatedHtml!.includes('id="ember'),
         `isolated HTML does not include ember ID's`,
       );
@@ -1335,13 +1334,11 @@ module(`Integration | realm indexing`, function (hooks) {
         fittedHtml![`${testRealmURL}person/Person`],
         `<h1> Person Fitted Card: Van Gogh </h1>`,
       );
-      assert.strictEqual(
-        false,
+      assert.false(
         Object.values(embeddedHtml!).join('').includes('id="ember'),
         `embeddedHtml HTML does not include ember ID's`,
       );
-      assert.strictEqual(
-        false,
+      assert.false(
         Object.values(fittedHtml!).join('').includes('id="ember'),
         `fittedHtml HTML does not include ember ID's`,
       );
@@ -1394,8 +1391,7 @@ module(`Integration | realm indexing`, function (hooks) {
       cleanWhiteSpace(`<div class="atom">Van Gogh</div>`),
       'atom html is correct',
     );
-    assert.strictEqual(
-      false,
+    assert.false(
       atomHtml!.includes('id="ember'),
       `atom HTML does not include ember ID's`,
     );
@@ -1452,8 +1448,7 @@ module(`Integration | realm indexing`, function (hooks) {
 
     let { embeddedHtml } =
       (await getInstance(realm, new URL(`${testRealmURL}germaine`))) ?? {};
-    assert.strictEqual(
-      false,
+    assert.false(
       Object.values(embeddedHtml!).join('').includes('id="ember'),
       `Embedded HTML does not include ember ID's`,
     );
@@ -1499,8 +1494,7 @@ module(`Integration | realm indexing`, function (hooks) {
         data-test-field-component-card> <h1> Person Embedded Card: Germaine </h1> </div>`),
       `${testRealmURL}person/Person embedded HTML is correct`,
     );
-    assert.strictEqual(
-      false,
+    assert.false(
       embeddedHtml![`${testRealmURL}person/Person`].includes('id="ember'),
       `${testRealmURL}person/Person embedded HTML does not include ember ID's`,
     );
@@ -1533,8 +1527,7 @@ module(`Integration | realm indexing`, function (hooks) {
       `${cardDefRefURL} embedded HTML is correct`,
     );
 
-    assert.strictEqual(
-      false,
+    assert.false(
       embeddedHtml![cardDefRefURL].includes('id="ember'),
       `${cardDefRefURL} fitted HTML does not include ember ID's`,
     );
@@ -1591,8 +1584,7 @@ module(`Integration | realm indexing`, function (hooks) {
 
     let { embeddedHtml, fittedHtml } =
       (await getInstance(realm, new URL(`${testRealmURL}germaine`))) ?? {};
-    assert.strictEqual(
-      false,
+    assert.false(
       Object.values(fittedHtml!).join('').includes('id="ember'),
       `Fitted HTML does not include ember ID's`,
     );
@@ -1638,8 +1630,7 @@ module(`Integration | realm indexing`, function (hooks) {
       data-test-field-component-card> <h1> Person Fitted Card: Germaine </h1> </div>`),
       `${testRealmURL}person/Person fitted HTML is correct`,
     );
-    assert.strictEqual(
-      false,
+    assert.false(
       fittedHtml![`${testRealmURL}person/Person`].includes('id="ember'),
       `${testRealmURL}person/Person fitted HTML does not include ember ID's`,
     );
@@ -1669,8 +1660,7 @@ module(`Integration | realm indexing`, function (hooks) {
       `${cardDefRefURL} embedded HTML is correct`,
     );
 
-    assert.strictEqual(
-      false,
+    assert.false(
       embeddedHtml![cardDefRefURL].includes('id="ember'),
       `${cardDefRefURL} embedded HTML does not include ember ID's`,
     );

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -409,7 +409,7 @@ module('Integration | Store', function (hooks) {
         },
       },
     });
-    assert.ok(typeof url === 'string', 'received a url for new instance');
+    assert.strictEqual(typeof url, 'string', 'received a url for new instance');
     let instance = storeService.peek(url as string);
     assert.strictEqual((instance as CardDefType).id, url);
     assert.strictEqual((instance as any).name, 'Andrea');
@@ -437,7 +437,11 @@ module('Integration | Store', function (hooks) {
         },
       },
     });
-    assert.ok(typeof error === 'object', 'received a error for new instance');
+    assert.strictEqual(
+      typeof error,
+      'object',
+      'received a error for new instance',
+    );
     assert.ok(
       (error as any).message.includes(
         'intentional error thrown',


### PR DESCRIPTION
The [lint override for tests](https://github.com/cardstack/boxel/pull/3307/files#diff-c4549e1c141b06d121530cbae33686caa605a90001f8609373327b6a59558ac1L136) should have been amended when we started using templated extensions. These are mostly autofixes with some judgment calls when removing the use of `&&` or `||` in assertions.

The test report is broken, I had to rerun failed jobs many times to finally get them [all green](https://github.com/cardstack/boxel/actions/runs/18094409291?pr=3307), but the report is running on every job instead of just the most recent ones.