### PR TITLE
CI-assisted git bisect for flakiness

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,10 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - ci-bisect
+      - ci-bisect-**
   pull_request:
   workflow_dispatch:
 
@@ -26,6 +29,8 @@ jobs:
       realm-server: ${{ steps.filter.outputs.realm-server }}
       vscode-boxel-tools: ${{ steps.filter.outputs.vscode-boxel-tools }}
       workspace-sync-cli: ${{ steps.filter.outputs.workspace-sync-cli }}
+      # Force all tests to run when on ci-bisect* branches
+      run_all: ${{ steps.force-run-all.outputs.run_all }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # 3.0.2
@@ -87,11 +92,16 @@ jobs:
             workspace-sync-cli:
               - *shared
               - 'packages/workspace-sync-cli/**'
+      - name: Force run all jobs on ci-bisect branches
+        id: force-run-all
+        shell: bash
+        run: |
+          echo "run_all=${{ startsWith(github.ref, 'refs/heads/ci-bisect') || startsWith(github.ref, 'refs/heads/ci-bisect-') || startsWith(github.head_ref || '', 'ci-bisect') }}" >> "$GITHUB_OUTPUT"
 
   ai-bot-test:
     name: AI bot Tests
     needs: change-check
-    if: needs.change-check.outputs.ai-bot == 'true' || github.ref == 'refs/heads/main'
+    if: needs.change-check.outputs.ai-bot == 'true' || github.ref == 'refs/heads/main' || needs.change-check.outputs.run_all == 'true'
     runs-on: ubuntu-latest
     concurrency:
       group: ai-bot-test-${{ github.head_ref || github.run_id }}
@@ -106,7 +116,7 @@ jobs:
   boxel-motion-test:
     name: Boxel Motion Tests
     needs: change-check
-    if: needs.change-check.outputs.boxel-motion == 'true' || github.ref == 'refs/heads/main'
+    if: needs.change-check.outputs.boxel-motion == 'true' || github.ref == 'refs/heads/main' || needs.change-check.outputs.run_all == 'true'
     runs-on: ubuntu-latest
     concurrency:
       group: boxel-motion-test-${{ github.head_ref || github.run_id }}
@@ -124,7 +134,7 @@ jobs:
   boxel-ui-test:
     name: Boxel UI Tests
     needs: change-check
-    if: needs.change-check.outputs.boxel-ui == 'true' || github.ref == 'refs/heads/main'
+    if: needs.change-check.outputs.boxel-ui == 'true' || github.ref == 'refs/heads/main' || needs.change-check.outputs.run_all == 'true'
     runs-on: ubuntu-latest
     concurrency:
       group: boxel-ui-test-${{ github.head_ref || github.run_id }}
@@ -145,7 +155,7 @@ jobs:
   boxel-ui-raw-icon-changes-only:
     name: Boxel UI ensure raw icon changes only
     needs: change-check
-    if: needs.change-check.outputs.boxel-ui == 'true' || github.ref == 'refs/heads/main'
+    if: needs.change-check.outputs.boxel-ui == 'true' || github.ref == 'refs/heads/main' || needs.change-check.outputs.run_all == 'true'
     runs-on: ubuntu-latest
     concurrency:
       group: boxel-ui-raw-icon-changes-only-${{ github.head_ref || github.run_id }}
@@ -162,7 +172,7 @@ jobs:
   boxel-icons-raw-icon-changes-only:
     name: Boxel Icons ensure raw icon changes only
     needs: change-check
-    if: needs.change-check.outputs.boxel-icons == 'true' || github.ref == 'refs/heads/main'
+    if: needs.change-check.outputs.boxel-icons == 'true' || github.ref == 'refs/heads/main' || needs.change-check.outputs.run_all == 'true'
     runs-on: ubuntu-latest
     concurrency:
       group: boxel-icons-raw-icon-changes-only-${{ github.head_ref || github.run_id }}
@@ -179,7 +189,7 @@ jobs:
   matrix-client-test:
     name: Matrix Client Tests
     needs: change-check
-    if: needs.change-check.outputs.matrix == 'true' || github.ref == 'refs/heads/main'
+    if: needs.change-check.outputs.matrix == 'true' || github.ref == 'refs/heads/main' || needs.change-check.outputs.run_all == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -254,7 +264,7 @@ jobs:
       - change-check
       - matrix-client-test
     # always() makes it run even if a matrix-client-test shard fails
-    if: always() && (needs.change-check.outputs.matrix == 'true' || github.ref == 'refs/heads/main')
+    if: always() && (needs.change-check.outputs.matrix == 'true' || github.ref == 'refs/heads/main' || needs.change-check.outputs.run_all == 'true')
     runs-on: ubuntu-latest
 
     permissions:
@@ -328,7 +338,7 @@ jobs:
   realm-server-test:
     name: Realm Server Tests
     needs: change-check
-    if: needs.change-check.outputs.realm-server == 'true' || github.ref == 'refs/heads/main'
+    if: needs.change-check.outputs.realm-server == 'true' || github.ref == 'refs/heads/main' || needs.change-check.outputs.run_all == 'true'
     runs-on: ubuntu-latest
     concurrency:
       group: realm-server-test-${{ matrix.testModule }}-${{ github.head_ref || github.run_id }}
@@ -419,7 +429,7 @@ jobs:
   vscode-boxel-tools-package:
     name: Boxel Tools VS Code Extension package
     needs: change-check
-    if: needs.change-check.outputs.vscode-boxel-tools == 'true' || github.ref == 'refs/heads/main'
+    if: needs.change-check.outputs.vscode-boxel-tools == 'true' || github.ref == 'refs/heads/main' || needs.change-check.outputs.run_all == 'true'
     runs-on: ubuntu-latest
     concurrency:
       group: vscode-boxel-tools-test-${{ github.head_ref || github.run_id }}
@@ -448,7 +458,7 @@ jobs:
   workspace-sync-cli-build:
     name: Workspace Sync CLI Build
     needs: change-check
-    if: needs.change-check.outputs.workspace-sync-cli == 'true' || github.ref == 'refs/heads/main'
+    if: needs.change-check.outputs.workspace-sync-cli == 'true' || github.ref == 'refs/heads/main' || needs.change-check.outputs.run_all == 'true'
     runs-on: ubuntu-latest
     concurrency:
       group: workspace-sync-cli-build-${{ github.head_ref || github.run_id }}
@@ -463,7 +473,7 @@ jobs:
   workspace-sync-cli-test:
     name: Workspace Sync CLI Integration Tests
     needs: change-check
-    if: needs.change-check.outputs.workspace-sync-cli == 'true' || github.ref == 'refs/heads/main'
+    if: needs.change-check.outputs.workspace-sync-cli == 'true' || github.ref == 'refs/heads/main' || needs.change-check.outputs.run_all == 'true'
     runs-on: ubuntu-latest
     concurrency:
       group: workspace-sync-cli-test-${{ github.head_ref || github.run_id }}

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -27,7 +27,7 @@
     "test": "concurrently \"pnpm:lint\" \"pnpm:test:*\" --names \"lint,test:\"",
     "test-with-percy": "percy exec --parallel -- pnpm test:wait-for-servers",
     "test:wait-for-servers": "./scripts/test-wait-for-servers.sh",
-    "ember-test-pre-built": "ember exam --path ./dist --split $HOST_TEST_PARTITION_COUNT --partition $HOST_TEST_PARTITION --preserve-test-name",
+    "ember-test-pre-built": "sleep 15 && ember exam --path ./dist --split $HOST_TEST_PARTITION_COUNT --partition $HOST_TEST_PARTITION --preserve-test-name",
     "wait": "sleep 10000000"
   },
   "devDependencies": {

--- a/packages/host/scripts/test-wait-for-servers.sh
+++ b/packages/host/scripts/test-wait-for-servers.sh
@@ -3,4 +3,5 @@
 NODE_NO_WARNINGS=1 start-server-and-test \
   'pnpm run wait' \
   'http-get://localhost:4201/base/_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson|http-get://localhost:4202/test/_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson|http://localhost:8008|http://localhost:5001' \
+  'sleep 15' \
   'ember-test-pre-built'

--- a/packages/host/scripts/test-wait-for-servers.sh
+++ b/packages/host/scripts/test-wait-for-servers.sh
@@ -3,5 +3,4 @@
 NODE_NO_WARNINGS=1 start-server-and-test \
   'pnpm run wait' \
   'http-get://localhost:4201/base/_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson|http-get://localhost:4202/test/_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson|http://localhost:8008|http://localhost:5001' \
-  'sleep 15' \
   'ember-test-pre-built'

--- a/scripts/ci-bisect.sh
+++ b/scripts/ci-bisect.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ci-bisect.sh — assist git bisect by pushing each step to CI
+# Usage:
+#   ./scripts/ci-bisect.sh start <good_commit> [<bad_ref>]
+#   ./scripts/ci-bisect.sh step good|bad|skip
+#   ./scripts/ci-bisect.sh status
+#   ./scripts/ci-bisect.sh abort
+#
+# It uses the branch name 'ci-bisect' on origin. Change via $BISect_BRANCH
+#
+# Implementation detail:
+# - For every tested revision, we create an empty commit with message
+#   "ci-bisect: test <sha>" on top of the checked-out candidate. We push this
+#   marker commit to ensure GitHub sees a new commit on the branch and runs CI.
+# - When you later run `step good|bad|skip`, we attribute the verdict to the
+#   underlying tested commit (the parent of the marker), not the marker itself.
+
+BRANCH_NAME=${BISect_BRANCH:-ci-bisect}
+REMOTE=${BISect_REMOTE:-origin}
+DEFAULT_REMOTE_HEAD=$(git remote show "$REMOTE" | sed -n 's/^\s*HEAD branch: //p')
+REPO_URL_BASE=$(git remote get-url "$REMOTE" | sed -E 's#^git@github.com:#https://github.com/#; s#\.git$##')
+
+ensure_clean() {
+  if ! git diff --quiet; then
+    echo "Working tree has unstaged changes. Commit or stash first." >&2
+    exit 1
+  fi
+  if ! git diff --cached --quiet; then
+    echo "Index has staged changes. Commit or stash first." >&2
+    exit 1
+  fi
+}
+
+tested_sha() {
+  # If HEAD is a marker commit, extract the tested SHA from its subject.
+  local subj
+  subj=$(git show -s --format=%s HEAD 2>/dev/null || true)
+  case "$subj" in
+    "ci-bisect: test "*) echo "${subj#ci-bisect: test }" ;;
+    *) git rev-parse HEAD ;;
+  esac
+}
+
+make_marker_commit() {
+  local base_sha
+  base_sha=$(git rev-parse --short=12 HEAD)
+  # Create a unique empty commit so GH Actions always runs
+  GIT_COMMITTER_DATE="$(date -u)" GIT_AUTHOR_DATE="$(date -u)" \
+    git commit --allow-empty -m "ci-bisect: test $(git rev-parse HEAD)" >/dev/null
+  echo "Created marker commit on top of $base_sha"
+}
+
+push_current() {
+  # Ensure we push a new commit so GH treats it as new work
+  make_marker_commit
+  local push_sha branch_head tested
+  push_sha=$(git rev-parse --short=12 HEAD)
+  tested=$(tested_sha)
+  echo "Pushing $push_sha (tests for $tested) -> $REMOTE/$BRANCH_NAME"
+  git push -f "$REMOTE" HEAD:"refs/heads/$BRANCH_NAME"
+  echo "Pushed. Branch head commit: $REPO_URL_BASE/commit/$(git rev-parse HEAD)"
+  echo "Branch checks: $REPO_URL_BASE/actions?query=branch%3A$BRANCH_NAME"
+  echo "Tested revision: $REPO_URL_BASE/commit/$tested"
+}
+
+cmd_start() {
+  local good bad
+  good=${1:?"Provide known-good commit (sha or ref)"}
+  bad=${2:-HEAD}
+  ensure_clean
+  echo "Starting bisect: good=$good bad=$bad"
+  git bisect reset || true
+  git bisect start "$bad" "$good"
+  push_current
+}
+
+cmd_step() {
+  local verdict=${1:?"Provide one of: good|bad|skip"}
+  # Attribute verdict to the actual tested commit (parent of our marker if present)
+  local tested
+  tested=$(tested_sha)
+  case "$verdict" in
+    good) git bisect good "$tested";;
+    bad) git bisect bad "$tested";;
+    skip) git bisect skip "$tested";;
+    *) echo "Unknown: $verdict"; exit 2;;
+  esac
+  # After stepping, bisect will check out the next candidate.
+  if git rev-parse -q --verify HEAD >/dev/null; then
+    push_current
+  fi
+}
+
+cmd_status() {
+  git bisect log || true
+  local tested
+  tested=$(tested_sha)
+  echo "Current head: $(git rev-parse --short=12 HEAD)"
+  echo "Tested commit: $(git rev-parse --short=12 "$tested")"
+}
+
+cmd_abort() {
+  git bisect reset || true
+}
+
+case "${1:-}" in
+  start) shift; cmd_start "$@";;
+  step) shift; cmd_step "$@";;
+  status) shift; cmd_status "$@";;
+  abort) shift; cmd_abort "$@";;
+  *) cat <<USAGE
+ci-bisect.sh help
+  start <good_commit> [bad]
+  step good|bad|skip
+  status
+  abort
+Environment:
+  BISect_BRANCH (default: ci-bisect)
+  BISect_REMOTE (default: origin)
+USAGE
+     ;;
+ esac

--- a/scripts/ci-bisect.sh
+++ b/scripts/ci-bisect.sh
@@ -32,9 +32,21 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 # Enable by setting BISect_COPY_CI=1. Paths can be customized below.
 OVERLAY_ENABLE=${BISect_COPY_CI:-0}
 OVERLAY_PATH=${BISect_CI_PATH:-.github/workflows/ci.yaml}
-OVERLAY_STORE=${BISect_CI_STORE:-.git/ci-bisect/ci.yaml}
 OVERLAY_SCRIPT_PATH=${BISect_SCRIPT_PATH:-scripts/ci-bisect.sh}
-OVERLAY_SCRIPT_STORE=${BISect_SCRIPT_STORE:-.git/ci-bisect/ci-bisect.sh}
+
+# Derive default STORE locations from the PATHs under .git/ci-bisect/<PATH>,
+# while allowing explicit overrides via BISect_CI_STORE and BISect_SCRIPT_STORE.
+derive_store_path() {
+  local p="$1"
+  # strip leading ./ if present
+  p="${p#./}"
+  echo ".git/ci-bisect/$p"
+}
+
+DEFAULT_OVERLAY_STORE=$(derive_store_path "$OVERLAY_PATH")
+DEFAULT_OVERLAY_SCRIPT_STORE=$(derive_store_path "$OVERLAY_SCRIPT_PATH")
+OVERLAY_STORE=${BISect_CI_STORE:-$DEFAULT_OVERLAY_STORE}
+OVERLAY_SCRIPT_STORE=${BISect_SCRIPT_STORE:-$DEFAULT_OVERLAY_SCRIPT_STORE}
 
 ensure_clean() {
   if ! git diff --quiet; then
@@ -261,9 +273,9 @@ Environment:
   BISect_REMOTE (default: origin)
   BISect_COPY_CI=1 to enable overlay of workflow and script
   BISect_CI_PATH (default: .github/workflows/ci.yaml)
-  BISect_CI_STORE (default: .git/ci-bisect/ci.yaml)
+  BISect_CI_STORE (default: derived from path => .git/ci-bisect/<C I PATH>)
   BISect_SCRIPT_PATH (default: scripts/ci-bisect.sh)
-  BISect_SCRIPT_STORE (default: .git/ci-bisect/ci-bisect.sh)
+  BISect_SCRIPT_STORE (default: derived from path => .git/ci-bisect/<SCRIPT PATH>)
   BISect_TEST_BRANCH_PREFIX (default: ci-test)
 USAGE
      ;;

--- a/scripts/ci-bisect.sh
+++ b/scripts/ci-bisect.sh
@@ -394,17 +394,10 @@ cmd_step() {
     if bisect_active; then
       push_current
     else
-      # Bisect has concluded (often due to only skipped commits). First, push HEAD if it's a valid
-      # merges-only candidate so CI runs, then automatically reseed a new bisect using the most
-      # recent good/bad bounds gleaned from the bisect log, and continue.
+      # Bisect has concluded (often due to only skipped commits). Automatically reseed a new bisect
+      # using the most recent good/bad bounds gleaned from the bisect log, and continue.
       # Also print a decorated classification of the final candidate set for quick inspection.
       cmd_classify_final || true
-      if git rev-parse -q --verify HEAD >/dev/null; then
-        if [[ "$PR_MERGES_ONLY" != "1" ]] || is_pr_merge_commit HEAD; then
-          echo "Bisect ended, but pushing last candidate $(git rev-parse --short=12 HEAD) to CI for visibility."
-          push_current || true
-        fi
-      fi
       echo "Bisect ended (likely only skipped commits left). Attempting to reseed with latest good/bad bounds..."
       local good_bound bad_bound
       good_bound=$(bisect_log_last_good); bad_bound=$(bisect_log_last_bad)

--- a/scripts/ci-bisect.sh
+++ b/scripts/ci-bisect.sh
@@ -366,7 +366,8 @@ cmd_step() {
           done
         fi
         if git rev-parse -q --verify HEAD >/dev/null; then
-          push_current
+          echo "Reseed complete. Next candidate is at $(git rev-parse --short=12 HEAD)."
+          echo "No push performed on reseed to keep one-CI-push-per-step. Run 'step good|bad|skip' next."
         else
           echo "Reseed found no candidates."
         fi

--- a/scripts/ci-bisect.sh
+++ b/scripts/ci-bisect.sh
@@ -287,12 +287,6 @@ cmd_start() {
   if git rev-parse -q --verify HEAD >/dev/null; then
     push_current
   fi
-  # If bisect appears to have concluded immediately (e.g., only skipped remained), add context
-  if ! bisect_active; then
-    echo "Note: bisect appears concluded after start (likely only skipped commits remained)."
-    echo "Decorating final candidates before you decide next steps:"
-    cmd_classify_final || true
-  fi
 }
 
 cmd_step() {

--- a/scripts/ci-bisect.sh
+++ b/scripts/ci-bisect.sh
@@ -22,6 +22,12 @@ REMOTE=${BISect_REMOTE:-origin}
 DEFAULT_REMOTE_HEAD=$(git remote show "$REMOTE" | sed -n 's/^\s*HEAD branch: //p')
 REPO_URL_BASE=$(git remote get-url "$REMOTE" | sed -E 's#^git@github.com:#https://github.com/#; s#\.git$##')
 
+# Optional: overlay a workflow file into each tested revision so CI always runs as intended.
+# Enable by setting BISect_COPY_CI=1. Path can be set with BISect_CI_PATH (default .github/workflows/ci.yaml)
+OVERLAY_ENABLE=${BISect_COPY_CI:-0}
+OVERLAY_PATH=${BISect_CI_PATH:-.github/workflows/ci.yaml}
+OVERLAY_STORE=${BISect_CI_STORE:-.git/ci-bisect/ci.yaml}
+
 ensure_clean() {
   if ! git diff --quiet; then
     echo "Working tree has unstaged changes. Commit or stash first." >&2
@@ -31,6 +37,32 @@ ensure_clean() {
     echo "Index has staged changes. Commit or stash first." >&2
     exit 1
   fi
+}
+
+overlay_capture() {
+  # Capture the current ci.yaml content into .git, for reuse on every step
+  if [[ "$OVERLAY_ENABLE" != "1" ]]; then
+    return 0
+  fi
+  mkdir -p "$(dirname "$OVERLAY_STORE")"
+  if [[ -f "$OVERLAY_PATH" ]]; then
+    cp "$OVERLAY_PATH" "$OVERLAY_STORE"
+    echo "Captured overlay from $OVERLAY_PATH -> $OVERLAY_STORE"
+  else
+    echo "Warning: BISect_COPY_CI=1 but $OVERLAY_PATH not found; skipping overlay capture" >&2
+  fi
+}
+
+overlay_apply_if_present() {
+  # Apply stored overlay to working tree before committing marker
+  if [[ -f "$OVERLAY_STORE" ]]; then
+    mkdir -p "$(dirname "$OVERLAY_PATH")"
+    cp "$OVERLAY_STORE" "$OVERLAY_PATH"
+    git add "$OVERLAY_PATH"
+    echo "Applied overlay to $OVERLAY_PATH"
+    return 0
+  fi
+  return 1
 }
 
 tested_sha() {
@@ -46,9 +78,18 @@ tested_sha() {
 make_marker_commit() {
   local base_sha
   base_sha=$(git rev-parse --short=12 HEAD)
-  # Create a unique empty commit so GH Actions always runs
-  GIT_COMMITTER_DATE="$(date -u)" GIT_AUTHOR_DATE="$(date -u)" \
-    git commit --allow-empty -m "ci-bisect: test $(git rev-parse HEAD)" >/dev/null
+  local tested_full
+  tested_full=$(git rev-parse HEAD)
+  local msg_suffix=""
+  if overlay_apply_if_present; then
+    msg_suffix=" [ci-overlay]"
+    GIT_COMMITTER_DATE="$(date -u)" GIT_AUTHOR_DATE="$(date -u)" \
+      git commit -m "ci-bisect: test $tested_full$msg_suffix" >/dev/null
+  else
+    # Create a unique empty commit so GH Actions always runs
+    GIT_COMMITTER_DATE="$(date -u)" GIT_AUTHOR_DATE="$(date -u)" \
+      git commit --allow-empty -m "ci-bisect: test $tested_full" >/dev/null
+  fi
   echo "Created marker commit on top of $base_sha"
 }
 
@@ -70,6 +111,7 @@ cmd_start() {
   good=${1:?"Provide known-good commit (sha or ref)"}
   bad=${2:-HEAD}
   ensure_clean
+  overlay_capture
   echo "Starting bisect: good=$good bad=$bad"
   git bisect reset || true
   git bisect start "$bad" "$good"

--- a/scripts/ci-bisect.sh
+++ b/scripts/ci-bisect.sh
@@ -323,11 +323,6 @@ cmd_start() {
   if [[ "$PR_MERGES_ONLY" == "1" ]]; then
     while git rev-parse -q --verify HEAD >/dev/null && ! is_pr_merge_commit HEAD; do
       desc=$(classify_commit HEAD 2>/dev/null || true)
-      if [[ -n "${desc:-}" ]]; then
-        echo "--merges-only: start skipping candidate ${desc}"
-      else
-        echo "--merges-only: start skipping non-merge candidate $(git rev-parse --short=12 HEAD)"
-      fi
       if ! git bisect skip; then
         cmd_classify_final || true
         break


### PR DESCRIPTION
This adds ci-bisect.sh, a helper to drive `git bisect` using GitHub Actions. Each bisected revision is pushed to a temporary branch so CI runs the full test matrix, making it practical to isolate CI-only flakes.

### What it does

- Automates `git bisect` steps and pushes each candidate to a branch.
- Forces CI to run by:
  - Creating a marker commit per step.
  - Building a synthetic commit whose parent is the latest `origin/main`, so GitHub treats it as a new update on top of main (not “behind main”).
  - Naming branches as `ci-bisect-<tested-short-sha>` to keep runs distinct.
- Optional “overlay” mode copies your current ci.yaml (and this script) into each tested commit to bypass change-detection skips and ensure all jobs run. (this allows you to bisect commits from before this particular script was introduced)

### How it works

- Start: initializes `git bisect` with your good/bad range, captures overlays (optional), checks out the first candidate, creates a marker commit, builds a synthetic “rebased-on-main” commit, and pushes it to `origin/ci-bisect-<sha>`.
- Step: you mark the outcome (`good|bad|skip`), and the script attributes the verdict to the underlying tested commit (not the marker), then repeats the push flow for the next candidate.
- Status: prints the bisect log, current head, and the tested commit it’s evaluating.

### Usage

- Start from a known-good commit (e.g., from ~7 days ago):

```bash
# Enable overlay so CI always evaluates the full workflow and script
BISect_COPY_CI=1 ./scripts/ci-bisect.sh start <good-sha> [bad-ref]
```

- Continue as CI finishes:

```bash
./scripts/ci-bisect.sh step bad   # flake observed
./scripts/ci-bisect.sh step good  # clean
./scripts/ci-bisect.sh step skip  # inconclusive
```

- Check progress:

```bash
./scripts/ci-bisect.sh status
```

- If you edit ci.yaml or this script mid-bisect, refresh the captured overlay for subsequent steps:

```bash
./scripts/ci-bisect.sh refresh-overlay
```

### Environment variables

- BISect_BRANCH: base name for branches (default: `ci-bisect`). Actual pushed branch is `BISect_BRANCH-<sha>`.
- BISect_REMOTE: remote to push to (default: `origin`).
- BISect_COPY_CI: set to `1` to enable overlay mode.
- BISect_CI_PATH: path to workflow file (default: ci.yaml).
- BISect_CI_STORE: stored copy location (default: ci.yaml).
- BISect_SCRIPT_PATH: path to this script (default: ci-bisect.sh).
- BISect_SCRIPT_STORE: stored copy location (default: ci-bisect.sh).

### Output and links

Each step prints:
- Branch head commit URL (synthetic commit on top of main)
- Branch checks URL
- Tested revision URL

### Notes

- Requires a clean working tree (no unstaged/staged changes).
- Script force-pushes new branches per step (cleanup `ci-bisect-*` branches when done).
- You’ll need push permissions to the repo remote.