### PR TITLE
server: Restore publishability check before publishing

### DIFF
--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -39,11 +39,10 @@ module.exports = function (environment) {
     minSaveTaskDurationMs: 1000,
     renderTimeoutMs: 30_000,
     iconsURL: process.env.ICONS_URL || 'https://boxel-icons.boxel.ai',
-    defaultPublishedRealmDomain:
-      // FIXME how to use 4205 in Matrix tests only?
-      process.env.DEFAULT_PUBLISHED_REALM_DOMAIN || 'localhost:4205',
 
     // the fields below may be rewritten by the realm server
+    defaultPublishedRealmDomain:
+      process.env.DEFAULT_PUBLISHED_REALM_DOMAIN || 'localhost:4201',
     hostsOwnAssets: true,
     realmServerURL: process.env.REALM_SERVER_DOMAIN || 'http://localhost:4201/',
     resolvedBaseRealmURL:

--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -40,7 +40,8 @@ module.exports = function (environment) {
     renderTimeoutMs: 30_000,
     iconsURL: process.env.ICONS_URL || 'https://boxel-icons.boxel.ai',
     defaultPublishedRealmDomain:
-      process.env.DEFAULT_PUBLISHED_REALM_DOMAIN || 'localhost:4201',
+      // FIXME how to use 4205 in Matrix tests only?
+      process.env.DEFAULT_PUBLISHED_REALM_DOMAIN || 'localhost:4205',
 
     // the fields below may be rewritten by the realm server
     hostsOwnAssets: true,

--- a/packages/matrix/tests/publish-realm.spec.ts
+++ b/packages/matrix/tests/publish-realm.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test';
+import {
+  synapseStart,
+  synapseStop,
+  type SynapseInstance,
+  registerUser,
+} from '../docker/synapse';
+import {
+  startServer as startRealmServer,
+  type IsolatedRealmServer,
+  appURL,
+} from '../helpers/isolated-realm-server';
+import {
+  clearLocalStorage,
+  createRealm,
+  login,
+  registerRealmUsers,
+  setupUserSubscribed,
+} from '../helpers';
+
+test.describe('Publish realm', () => {
+  let synapse: SynapseInstance;
+  let realmServer: IsolatedRealmServer;
+
+  test.beforeEach(async () => {
+    // synapse defaults to 30s for beforeEach to finish, we need a bit more time
+    // to safely start the realm
+    test.setTimeout(120_000);
+    synapse = await synapseStart({
+      template: 'test',
+    });
+    await registerRealmUsers(synapse);
+    realmServer = await startRealmServer();
+    await registerUser(synapse, 'user1', 'pass');
+  });
+
+  test.afterEach(async () => {
+    await realmServer?.stop();
+    await synapseStop(synapse.synapseId);
+  });
+
+  test('it can publish a realm', async ({ page }) => {
+    let serverIndexUrl = new URL(appURL).origin;
+    await clearLocalStorage(page, serverIndexUrl);
+
+    await setupUserSubscribed('@user1:localhost', realmServer);
+
+    await login(page, 'user1', 'pass', {
+      url: serverIndexUrl,
+    });
+
+    await createRealm(page, 'new-workspace', '1New Workspace');
+    await page.locator('[data-test-workspace="1New Workspace"]').click();
+
+    await page.locator('[data-test-submode-switcher] button').click();
+    await page.locator('[data-test-boxel-menu-item-text="Host"]').click();
+
+    await page.locator('[data-test-publish-realm-button]').click();
+    await page.locator('[data-test-default-domain-checkbox]').click();
+    await page.locator('[data-test-publish-button]').click();
+
+    let newTabPromise = page.waitForEvent('popup');
+
+    await page.locator('[data-test-open-site-button]').click();
+
+    let newTab = await newTabPromise;
+    await newTab.waitForLoadState();
+
+    await expect(newTab).toHaveURL(
+      'http://user1.localhost:4205/new-workspace/',
+    );
+  });
+});

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -20,6 +20,7 @@ import {
   sendResponseForBadRequest,
   sendResponseForForbiddenRequest,
   sendResponseForSystemError,
+  sendResponseForUnprocessableEntity,
   setContextResponse,
 } from '../middleware';
 import { type CreateRoutesArgs } from '../routes';
@@ -117,30 +118,29 @@ export default function handlePublishRealm({
     }
 
     try {
-      // TODO restore in CS-9468
-      // let realmInfoResponse = await virtualNetwork.handle(
-      //   new Request(`${sourceRealmURL}_info`, {
-      //     headers: {
-      //       Accept: SupportedMimeType.RealmInfo,
-      //     },
-      //   }),
-      // );
+      let realmInfoResponse = await virtualNetwork.handle(
+        new Request(`${sourceRealmURL}_info`, {
+          headers: {
+            Accept: SupportedMimeType.RealmInfo,
+          },
+        }),
+      );
 
-      // if (!realmInfoResponse || realmInfoResponse.status !== 200) {
-      //   log.warn(
-      //     `Failed to fetch realm info for realm ${sourceRealmURL}: ${realmInfoResponse?.status}`,
-      //   );
-      //   throw new Error(`Could not fetch info for realm ${sourceRealmURL}`);
-      // }
+      if (!realmInfoResponse || realmInfoResponse.status !== 200) {
+        log.warn(
+          `Failed to fetch realm info for realm ${sourceRealmURL}: ${realmInfoResponse?.status}`,
+        );
+        throw new Error(`Could not fetch info for realm ${sourceRealmURL}`);
+      }
 
-      // let realmInfoJson = await realmInfoResponse.json();
+      let realmInfoJson = await realmInfoResponse.json();
 
-      // if (realmInfoJson.data.attributes.publishable !== true) {
-      //   return sendResponseForUnprocessableEntity(
-      //     ctxt,
-      //     `Realm ${sourceRealmURL} is not publishable`,
-      //   );
-      // }
+      if (realmInfoJson.data.attributes.publishable !== true) {
+        return sendResponseForUnprocessableEntity(
+          ctxt,
+          `Realm ${sourceRealmURL} is not publishable`,
+        );
+      }
 
       let existingPublishedRealm = realms.find(
         (r) => r.url === publishedRealmURL,

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -147,7 +147,7 @@ export default function handlePublishRealm({
           permissions: permissionsForAllRealms[sourceRealmURL],
           sessionRoom: sessionRoomId,
         },
-        '7d',
+        '1h',
         realmSecretSeed,
       );
 

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -293,8 +293,14 @@ export class RealmServer {
       /(<meta name="@cardstack\/host\/config\/environment" content=")([^"].*)(">)/,
       (_match, g1, g2, g3) => {
         let config = JSON.parse(decodeURIComponent(g2));
+
+        if (config.defaultPublishedRealmDomain === 'localhost:4201') {
+          // if this is the default, this needs to be the realm server’s host
+          // to work in Matrix tests
+          config.defaultPublishedRealmDomain = this.serverURL.host;
+        }
+
         config = merge({}, config, {
-          defaultPublishedRealmDomain: this.serverURL.host,
           hostsOwnAssets: false,
           assetsURL: this.assetsURL.href,
           realmServerURL: this.serverURL.href,

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -294,6 +294,7 @@ export class RealmServer {
       (_match, g1, g2, g3) => {
         let config = JSON.parse(decodeURIComponent(g2));
         config = merge({}, config, {
+          defaultPublishedRealmDomain: this.serverURL.host,
           hostsOwnAssets: false,
           assetsURL: this.assetsURL.href,
           realmServerURL: this.serverURL.href,

--- a/packages/realm-server/tests/publish-unpublish-realm-test.ts
+++ b/packages/realm-server/tests/publish-unpublish-realm-test.ts
@@ -1,4 +1,4 @@
-import { module, skip, test } from 'qunit';
+import { module, test } from 'qunit';
 import supertest, { SuperTest, Test } from 'supertest';
 import { v4 as uuidv4 } from 'uuid';
 import {
@@ -100,7 +100,7 @@ module(basename(__filename), function () {
     });
 
     // TODO restore in CS-9468
-    skip('POST /_publish-realm cannot publish a realm that is not publishable', async function (assert) {
+    test('POST /_publish-realm cannot publish a realm that is not publishable', async function (assert) {
       let response = await request
         .post('/_publish-realm')
         .set('Accept', 'application/vnd.api+json')

--- a/packages/realm-server/tests/publish-unpublish-realm-test.ts
+++ b/packages/realm-server/tests/publish-unpublish-realm-test.ts
@@ -158,12 +158,6 @@ module(basename(__filename), function () {
           );
 
         sourceRealmUrlString = createSourceRealmResponse.body.data.id;
-
-        // Make the published realm public so reading _info doesn’t need a token
-        dbAdapter.execute(`
-          INSERT INTO realm_user_permissions (realm_url, username, read, write, realm_owner)
-          VALUES ('${sourceRealmUrlString}', '*', true, true, true)
-        `);
       });
 
       test('POST /_publish-realm can publish realm successfully', async function (assert) {

--- a/packages/realm-server/tests/publish-unpublish-realm-test.ts
+++ b/packages/realm-server/tests/publish-unpublish-realm-test.ts
@@ -158,6 +158,12 @@ module(basename(__filename), function () {
           );
 
         sourceRealmUrlString = createSourceRealmResponse.body.data.id;
+
+        // Make the published realm public so reading _info doesn’t need a token
+        dbAdapter.execute(`
+          INSERT INTO realm_user_permissions (realm_url, username, read, write, realm_owner)
+          VALUES ('${sourceRealmUrlString}', '*', true, true, true)
+        `);
       });
 
       test('POST /_publish-realm can publish realm successfully', async function (assert) {

--- a/packages/realm-server/tests/publish-unpublish-realm-test.ts
+++ b/packages/realm-server/tests/publish-unpublish-realm-test.ts
@@ -99,7 +99,6 @@ module(basename(__filename), function () {
       },
     });
 
-    // TODO restore in CS-9468
     test('POST /_publish-realm cannot publish a realm that is not publishable', async function (assert) {
       let response = await request
         .post('/_publish-realm')


### PR DESCRIPTION
This restores the publishability check to `POST /_publish-realm` with a Matrix test to exercise it, you can see the test failing [here](https://boxel-matrix-playwright-reports.stack.cards/server/restore-publishability-check-cs-9468/20251001_134736Z/index.html#?testId=66a8561acd7006dadeb0-98bb66392ea58d902f77) when I brought the check back without fixing the permissions.