### PR TITLE
Ensure user record exists for default development users

### DIFF
--- a/packages/host/app/services/realm-server.ts
+++ b/packages/host/app/services/realm-server.ts
@@ -20,6 +20,8 @@ import { RealmAuthClient } from '@cardstack/runtime-common/realm-auth-client';
 
 import ENV from '@cardstack/host/config/environment';
 
+import config from '@cardstack/host/config/environment';
+
 import RealmService from './realm';
 
 import type { ExtendedClient } from './matrix-sdk-loader';
@@ -197,8 +199,19 @@ export default class RealmServerService extends Service {
     });
 
     if (!response.ok) {
+      let responseText = await response.text();
+
+      // Temporary development instruction to help with user setup
+      let isDevelopment = config.environment === 'development';
+      if (isDevelopment && responseText.includes('User in JWT not found')) {
+        console.error(
+          '\x1b[1m\x1b[31m%s\x1b[0m',
+          'Failed to login to realms due to missing entry in the users table. It is likely the user setup is incomplete - run pnpm register-all in matrix package',
+        );
+      }
+
       throw new Error(
-        `Failed to fetch tokens for accessible realms: ${response.status} - ${await response.text()}`,
+        `Failed to fetch tokens for accessible realms: ${response.status} - ${responseText}`,
       );
     }
 

--- a/packages/matrix/scripts/register-test-user.ts
+++ b/packages/matrix/scripts/register-test-user.ts
@@ -8,8 +8,71 @@ let username = process.env.MATRIX_USERNAME || adminUsername;
 let password = process.env.MATRIX_PASSWORD || adminPassword;
 let isAdmin = process.env.MATRIX_IS_ADMIN;
 
+async function ensureUserRecord(matrixUserId: string) {
+  const database = process.env.PGDATABASE || 'boxel';
+  const escapedMatrixUserId = matrixUserId.replace(/'/g, "''");
+  const sql = `INSERT INTO users (matrix_user_id) VALUES ('${escapedMatrixUserId}') ON CONFLICT (matrix_user_id) DO NOTHING;`;
+
+  await new Promise<void>((resolve, reject) => {
+    const dockerProcess = childProcess.spawn('docker', [
+      'exec',
+      'boxel-pg',
+      'psql',
+      '-U',
+      'postgres',
+      '-w',
+      '-d',
+      database,
+      '-c',
+      sql,
+    ]);
+
+    let stderr = '';
+    let stdout = '';
+
+    dockerProcess.stderr.on('data', (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    dockerProcess.stdout.on('data', (data: Buffer) => {
+      stdout += data.toString();
+    });
+
+    dockerProcess.on('error', (error) => {
+      reject(error);
+    });
+
+    dockerProcess.on('close', (code) => {
+      if (code === 0) {
+        const trimmedStdout = stdout.trim();
+        const inserted = trimmedStdout
+          .split('\n')
+          .some((line) => line.includes('INSERT 0 1'));
+        if (inserted) {
+          console.log(`Added an entry to the users table: ${matrixUserId}`);
+        } else {
+          console.log(
+            `Skipped adding entry to the users table because it already exists: ${matrixUserId}`,
+          );
+        }
+        resolve();
+      } else {
+        reject(
+          new Error(
+            `Failed to ensure user ${matrixUserId} in users table: ${stderr.trim()}`,
+          ),
+        );
+      }
+    });
+  });
+}
+
 (async () => {
   return new Promise<string>((resolve, reject) => {
+    const matrixUserId = username.startsWith('@')
+      ? username
+      : `@${username}:localhost`;
+    const shouldEnsureUserRecord = isAdmin !== 'TRUE';
     const command = `docker exec boxel-synapse register_new_matrix_user http://localhost:8008 -c /data/homeserver.yaml -u ${username} -p ${password} ${
       isAdmin === 'TRUE' ? `--admin` : `--no-admin`
     }`;
@@ -19,18 +82,24 @@ let isAdmin = process.env.MATRIX_IS_ADMIN;
           let cred = await loginUser(username, password);
           if (!cred.userId) {
             reject(
-              `User ${username} already exists, but the password does not match`,
+              `User ${username} already exists in matrix, but the password does not match`,
             );
             return;
           } else {
+            if (shouldEnsureUserRecord) {
+              await ensureUserRecord(matrixUserId);
+            }
             console.log(
-              `User ${username} already exists and the password matches`,
+              `User ${username} already exists in matrix and the password matches`,
             );
             resolve(`User already exists as ${cred.userId}`);
             return;
           }
         }
         reject(err);
+      }
+      if (shouldEnsureUserRecord) {
+        await ensureUserRecord(matrixUserId);
       }
       console.log(stdout.trim());
       resolve(stdout.trim());


### PR DESCRIPTION
After landing https://github.com/cardstack/boxel/pull/3260, developers who use our default development user started experiencing the error attached below. This is because our development user setup lacked inserting a record to the users table, which is needed for the bulk realms login. This PR adds that to the `register-test-user` script.

<img width="3308" height="2354" alt="image" src="https://github.com/user-attachments/assets/98ceb316-e122-4d66-83ab-ecc07dc9edf6" />
