### PR TITLE
Add meta info to serialized instance from /render route

### DIFF
--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -42,6 +42,7 @@ import {
   type StatusArgs,
   type Prerenderer,
   type RealmPermissions,
+  RenderResponse,
 } from '@cardstack/runtime-common';
 import { Deferred } from '@cardstack/runtime-common/deferred';
 import {
@@ -663,16 +664,60 @@ export class CurrentRun {
       }
       deferred = new Deferred<void>();
       this.#indexingInstances.set(fileURL, deferred.promise);
+      let uncaughtError: Error | undefined;
       if ((globalThis as any).__useHeadlessChromePrerender) {
-        let renderResult = await this.#prerenderer({
-          url: fileURL,
-          realm: this.#realmURL.href,
-          userId: this.#userId,
-          permissions: this.#permissions,
-        });
-        if ('error' in renderResult && renderResult.error) {
-          let renderError = renderResult.error;
+        let renderResult: RenderResponse | undefined;
+        try {
+          renderResult = await this.#prerenderer({
+            url: fileURL,
+            realm: this.#realmURL.href,
+            userId: this.#userId,
+            permissions: this.#permissions,
+          });
+
+          // we tack on data that can only be determined via access to underlying filesystem/DB
+          if (!this.#realmInfo) {
+            let realmInfoResponse = await this.network.authedFetch(
+              `${this.realmURL}_info`,
+              { headers: { Accept: SupportedMimeType.RealmInfo } },
+            );
+            this.#realmInfo = (
+              await realmInfoResponse.json()
+            )?.data?.attributes;
+          }
+
+          let serialized = renderResult?.serialized;
+          if (serialized) {
+            //Realm info may be used by a card to render field values.
+            //Example: spec-card
+            merge(serialized, {
+              data: {
+                meta: {
+                  lastModified,
+                  resourceCreatedAt,
+                  realmInfo: { ...this.#realmInfo },
+                  realmURL: this.realmURL.href,
+                },
+              },
+            });
+          }
+        } catch (err: any) {
+          uncaughtError = err;
+        }
+
+        if (!renderResult || ('error' in renderResult && renderResult.error)) {
+          let renderError = renderResult?.error;
+          if (!renderError && uncaughtError) {
+            renderError = {
+              type: 'error',
+              error:
+                uncaughtError instanceof CardError
+                  ? serializableError(uncaughtError)
+                  : { message: `${uncaughtError.message}` },
+            };
+          }
           if (
+            renderError &&
             renderError.error.id &&
             renderError.error.id.replace(/\.json$/, '') !== instanceURL.href
           ) {
@@ -683,6 +728,12 @@ export class CurrentRun {
             let deps = new Set(renderError.error.deps);
             deps.add(renderError.error.id);
             renderError.error.deps = [...deps];
+          }
+          if (!renderError) {
+            log.error(
+              `bug: should never get here - handling render error, but renderError is undefined`,
+            );
+            return;
           }
           log.warn(
             `${jobIdentity(this.#jobInfo)} encountered error indexing card instance ${path}: ${renderError.error.message}`,
@@ -723,7 +774,6 @@ export class CurrentRun {
       } else {
         let moduleDeps = directModuleDeps(resource, instanceURL);
         let typesMaybeError: TypesWithErrors | undefined;
-        let uncaughtError: Error | undefined;
         let doc: SingleCardDocument | undefined;
         let searchData: Record<string, any> | undefined;
         let cardType: typeof CardDef | undefined;

--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -688,8 +688,6 @@ export class CurrentRun {
 
           let serialized = renderResult?.serialized;
           if (serialized) {
-            //Realm info may be used by a card to render field values.
-            //Example: spec-card
             merge(serialized, {
               data: {
                 meta: {

--- a/packages/host/tests/integration/realm-indexing-render-route-test.gts
+++ b/packages/host/tests/integration/realm-indexing-render-route-test.gts
@@ -18,6 +18,7 @@ import { renderErrorHandler } from '@cardstack/host/lib/render-error-handler';
 
 import {
   testRealmURL,
+  testRealmInfo,
   cleanWhiteSpace,
   setupCardLogs,
   setupLocalIndexing,
@@ -89,7 +90,7 @@ module(`Integration | realm indexing - using /render route`, function (hooks) {
   }
 
   test('full indexing discovers card instances', async function (assert) {
-    let { realm } = await setupIntegrationTestRealm({
+    let { realm, adapter } = await setupIntegrationTestRealm({
       mockMatrixUtils,
       contents: {
         'empty.json': {
@@ -125,6 +126,13 @@ module(`Integration | realm indexing - using /render route`, function (hooks) {
             name: 'CardDef',
           },
           realmURL: 'http://test-realm/test/',
+          lastModified: adapter.lastModifiedMap.get(
+            `${testRealmURL}empty.json`,
+          ),
+          resourceCreatedAt: adapter.resourceCreatedAtMap.get(
+            `${testRealmURL}empty.json`,
+          ),
+          realmInfo: testRealmInfo,
         },
         links: {
           self: `${testRealmURL}empty`,
@@ -134,7 +142,7 @@ module(`Integration | realm indexing - using /render route`, function (hooks) {
   });
 
   test('can recover from indexing a card with a broken link', async function (assert) {
-    let { realm } = await setupIntegrationTestRealm({
+    let { realm, adapter } = await setupIntegrationTestRealm({
       mockMatrixUtils,
       contents: {
         'Pet/mango.json': {
@@ -226,6 +234,13 @@ module(`Integration | realm indexing - using /render route`, function (hooks) {
               module: 'http://localhost:4202/test/pet',
               name: 'Pet',
             },
+            lastModified: adapter.lastModifiedMap.get(
+              `${testRealmURL}Pet/mango.json`,
+            ),
+            resourceCreatedAt: adapter.resourceCreatedAtMap.get(
+              `${testRealmURL}Pet/mango.json`,
+            ),
+            realmInfo: testRealmInfo,
             realmURL: 'http://test-realm/test/',
           },
         });
@@ -252,7 +267,7 @@ module(`Integration | realm indexing - using /render route`, function (hooks) {
         </template>
       };
     }
-    let { realm } = await setupIntegrationTestRealm({
+    let { realm, adapter } = await setupIntegrationTestRealm({
       mockMatrixUtils,
       contents: {
         'person.gts': { Person },
@@ -320,6 +335,13 @@ module(`Integration | realm indexing - using /render route`, function (hooks) {
             module: './person',
             name: 'Person',
           },
+          lastModified: adapter.lastModifiedMap.get(
+            `${testRealmURL}vangogh.json`,
+          ),
+          resourceCreatedAt: adapter.resourceCreatedAtMap.get(
+            `${testRealmURL}vangogh.json`,
+          ),
+          realmInfo: testRealmInfo,
           realmURL: testRealmURL,
         },
       },


### PR DESCRIPTION
This PR adds meta info to the serialized card instance. The info being added is really external to the card and hence the prerenderer has no way of knowing it. moreover, deriving this additional meta requires access to the filesystem/DB which is not permitted in the prerenderer's security context. So the idea is that we patch this additional meta into the prerender result from within the worker after we receive it from the prerenderer