### PR TITLE
Restore bot in staging, update Node everywhere

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-use-node-version=20.19.1
+use-node-version=22.20.0

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "pnpm": "^10"
   },
   "volta": {
-    "node": "20.19.1",
+    "node": "22.20.0",
     "pnpm": "10.17.0"
   },
   "dependencies": {

--- a/packages/ai-bot/Dockerfile
+++ b/packages/ai-bot/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.19.1-slim
+FROM node:22.20.0-slim
 ARG CI=1
 RUN apt-get update && apt-get install -y python3 build-essential
 RUN npm install -g pnpm@10.17.0

--- a/packages/host/app/lib/file-def-manager.ts
+++ b/packages/host/app/lib/file-def-manager.ts
@@ -208,7 +208,15 @@ export default class FileDefManagerImpl
     let storedUrl = url;
     if (canonicalKey.startsWith('mxc://')) {
       try {
-        const maybeHttp = this.client.mxcUrlToHttp(canonicalKey);
+        const maybeHttp = this.client.mxcUrlToHttp(
+          canonicalKey,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          true,
+        );
         if (maybeHttp) {
           storedUrl = maybeHttp;
         }

--- a/packages/postgres/Dockerfile
+++ b/packages/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.19.1-slim
+FROM node:22.20.0-slim
 ARG CI=1
 RUN apt-get update && apt-get install -y postgresql
 RUN npm install -g pnpm@10.17.0

--- a/packages/realm-server/realm-server.Dockerfile
+++ b/packages/realm-server/realm-server.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM node:20.19.1-slim
+FROM node:22.20.0-slim
 ARG realm_server_script
 ENV realm_server_script=$realm_server_script
 

--- a/packages/realm-server/worker.Dockerfile
+++ b/packages/realm-server/worker.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM node:20.19.1-slim
+FROM node:22.20.0-slim
 ARG worker_script
 ENV worker_script=$worker_script
 


### PR DESCRIPTION
This is about addressing a bot failure because the Matrix SDK is using `Promise.withResolvers` which doesn’t exist until Node 22. It also updates a call to the Matrix client that was missed because of disparate merges.

When deployed on staging, this branch made the bot respond again:

<img width="2650" height="1740" alt="Boxel 2025-10-02 19-04-14" src="https://github.com/user-attachments/assets/8f89a1af-4ed5-4084-b753-e94506c8906a" />
