### PR TITLE
local-types is supposed to only need a single top-level module

### DIFF
--- a/packages/ai-bot/tsconfig.json
+++ b/packages/ai-bot/tsconfig.json
@@ -29,7 +29,7 @@
       "@cardstack/boxel-ui": ["../boxel-ui/addon"],
       "@cardstack/boxel-ui/*": ["../boxel-ui/addon/*"]
     },
-    "types": ["@cardstack/local-types","@cardstack/local-types/matrix-js-sdk"]
+    "types": ["@cardstack/local-types"]
   },
   "glint": {
     "environment": ["ember-loose", "ember-template-imports"]

--- a/packages/billing/tsconfig.json
+++ b/packages/billing/tsconfig.json
@@ -30,7 +30,7 @@
       "@cardstack/boxel-ui/*": ["../boxel-ui/addon/*"],
       "*": ["types/*"]
     },
-    "types": ["@cardstack/local-types","@cardstack/local-types/matrix-js-sdk"]
+    "types": ["@cardstack/local-types"]
   },
   "glint": {
     "environment": ["ember-loose", "ember-template-imports"]

--- a/packages/catalog-realm/tsconfig.json
+++ b/packages/catalog-realm/tsconfig.json
@@ -25,7 +25,7 @@
       "https://cardstack.com/base/*": ["../base/*"],
       "@cardstack/boxel-host/commands/*": ["../host/app/commands/*"]
     },
-    "types": ["@cardstack/local-types","@cardstack/local-types/matrix-js-sdk"]
+    "types": ["@cardstack/local-types"]
   },
   "glint": {
     "environment": ["ember-loose", "ember-template-imports"]

--- a/packages/experiments-realm/tsconfig.json
+++ b/packages/experiments-realm/tsconfig.json
@@ -24,7 +24,7 @@
     "paths": {
       "https://cardstack.com/base/*": ["../base/*"]
     },
-    "types": ["@cardstack/local-types","@cardstack/local-types/matrix-js-sdk"]
+    "types": ["@cardstack/local-types"]
   },
   "glint": {
     "environment": ["ember-loose", "ember-template-imports"]

--- a/packages/host/tsconfig.json
+++ b/packages/host/tsconfig.json
@@ -30,7 +30,7 @@
       "@cardstack/catalog/*": ["../catalog-realm/catalog-app/*"],
       "*": ["types/*"]
     },
-    "types": ["@cardstack/local-types","@cardstack/local-types/matrix-js-sdk"]
+    "types": ["@cardstack/local-types"]
   },
   "glint": {
     "environment": ["ember-loose", "ember-template-imports"]

--- a/packages/local-types/index.d.ts
+++ b/packages/local-types/index.d.ts
@@ -47,3 +47,5 @@ declare module '@ember/component' {
 // runtime-common has its own global type declaration that we need to
 // incorporate
 import '../../runtime-common/global';
+
+import './matrix-js-sdk';

--- a/packages/postgres/tsconfig.json
+++ b/packages/postgres/tsconfig.json
@@ -29,7 +29,7 @@
       "@cardstack/boxel-ui/*": ["../boxel-ui/addon/*"],
       "*": ["types/*"]
     },
-    "types": ["@cardstack/local-types","@cardstack/local-types/matrix-js-sdk"]
+    "types": ["@cardstack/local-types"]
   },
   "glint": {
     "environment": ["ember-loose", "ember-template-imports"]

--- a/packages/realm-server/tsconfig.json
+++ b/packages/realm-server/tsconfig.json
@@ -28,7 +28,7 @@
       "@cardstack/boxel-ui": ["../boxel-ui/addon"],
       "@cardstack/boxel-ui/*": ["../boxel-ui/addon/*"]
     },
-    "types": ["@cardstack/local-types","@cardstack/local-types/matrix-js-sdk"]
+    "types": ["@cardstack/local-types"]
   },
   "glint": {
     "environment": ["ember-loose", "ember-template-imports"]

--- a/packages/runtime-common/tsconfig.json
+++ b/packages/runtime-common/tsconfig.json
@@ -27,7 +27,7 @@
       "@cardstack/boxel-ui": ["../boxel-ui/addon"],
       "@cardstack/boxel-ui/*": ["../boxel-ui/addon/*"]
     },
-    "types": ["@cardstack/local-types","@cardstack/local-types/matrix-js-sdk"]
+    "types": ["@cardstack/local-types"]
   },
   "glint": {
     "environment": ["ember-loose", "ember-template-imports"]

--- a/packages/vscode-boxel-tools/tsconfig.json
+++ b/packages/vscode-boxel-tools/tsconfig.json
@@ -17,7 +17,7 @@
         "node_modules/babel-plugin-ember-template-compilation/*"
       ]
     },
-    "types": ["@cardstack/local-types","@cardstack/local-types/matrix-js-sdk"]
+    "types": ["@cardstack/local-types"]
   },
   "glint": {
     "environment": ["ember-loose", "ember-template-imports"]

--- a/packages/workspace-sync-cli/tsconfig.json
+++ b/packages/workspace-sync-cli/tsconfig.json
@@ -31,7 +31,7 @@
       "https://cardstack.com/base/*": ["../base/*"],
       "*": ["types/*"]
     },
-    "types": ["@cardstack/local-types","@cardstack/local-types/matrix-js-sdk"]
+    "types": ["@cardstack/local-types"]
   },
   "include": ["./**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
This is an extraction from my typescript / glint upgrade and simplification work.