### PR TITLE
Eco 293 create new contactlinksfield field listing

### DIFF
--- a/packages/catalog-realm/fields/contact-link.gts
+++ b/packages/catalog-realm/fields/contact-link.gts
@@ -86,19 +86,19 @@ export class ContactLinkField extends FieldDef {
 
   static edit = class Edit extends Component<typeof this> {
     <template>
-      <FieldContainer @vertical={{true}} @label='Type' @tag='label'>
-        <BoxelSelect
-          @options={{this.options}}
-          @selected={{this.selectedOption}}
-          @onChange={{this.onSelect}}
-          @placeholder='Please Select'
-          as |item|
-        >
-          <div>{{item.label}}</div>
-        </BoxelSelect>
-      </FieldContainer>
+      <div class='contact-link-container'>
+        <FieldContainer @vertical={{true}} @label='Type' @tag='label'>
+          <BoxelSelect
+            @options={{this.options}}
+            @selected={{this.selectedOption}}
+            @onChange={{this.onSelect}}
+            @placeholder='Please Select'
+            as |item|
+          >
+            <div>{{item.label}}</div>
+          </BoxelSelect>
+        </FieldContainer>
 
-      <FieldContainer @vertical={{true}} @label={{this.label}} @tag='label'>
         {{#if (eq this.selectedOption.type 'email')}}
           <@fields.email />
         {{else if (eq this.selectedOption.type 'tel')}}
@@ -106,25 +106,16 @@ export class ContactLinkField extends FieldDef {
         {{else}}
           <@fields.link />
         {{/if}}
-      </FieldContainer>
+      </div>
 
       <style scoped>
-        label + * {
-          margin-top: var(--boxel-sp-sm);
+        .contact-link-container {
+          display: flex;
+          flex-direction: column;
+          gap: var(--boxel-sp-sm);
         }
       </style>
     </template>
-
-    get label() {
-      switch (this.selectedOption?.type) {
-        case 'email':
-          return 'Email Address';
-        case 'tel':
-          return 'Phone Number';
-        default:
-          return 'Link';
-      }
-    }
 
     options = this.args.model.items;
 

--- a/packages/catalog-realm/online-customer/OnlineCustomer/elena-vasquez.json
+++ b/packages/catalog-realm/online-customer/OnlineCustomer/elena-vasquez.json
@@ -9,22 +9,35 @@
     "type": "card",
     "attributes": {
       "email": {
+        "link": null,
+        "email": "elena@gmail.com",
         "label": "Email",
-        "value": "elena.vasquez@artgallery.org"
+        "phone": {
+          "number": null,
+          "countryCode": null
+        }
       },
       "phone": {
+        "link": null,
+        "email": null,
         "label": "Phone",
-        "value": "+1-212-555-3847"
+        "phone": {
+          "number": "12052012312",
+          "countryCode": "60"
+        }
       },
-      "cardInfo": {},
+      "cardInfo": {
+        "notes": null,
+        "title": null,
+        "description": null,
+        "thumbnailURL": null
+      },
       "totalSpent": 12389.5,
-      "description": null,
       "loyaltyTier": {
         "name": "Silver"
       },
       "totalOrders": 45,
       "customerName": "Elena Vasquez",
-      "thumbnailURL": null,
       "customerSince": "2023-09-12T16:20:00.000Z"
     },
     "relationships": {

--- a/packages/catalog-realm/online-customer/OnlineCustomer/james-mitchell-brown.json
+++ b/packages/catalog-realm/online-customer/OnlineCustomer/james-mitchell-brown.json
@@ -9,22 +9,35 @@
     "type": "card",
     "attributes": {
       "email": {
+        "link": null,
+        "email": "james@org.com",
         "label": "Email",
-        "value": "j.brown@quantumdev.io"
+        "phone": {
+          "number": null,
+          "countryCode": null
+        }
       },
       "phone": {
+        "link": null,
+        "email": null,
         "label": "Phone",
-        "value": "+1-206-555-9204"
+        "phone": {
+          "number": "109003499",
+          "countryCode": "60"
+        }
       },
-      "cardInfo": {},
+      "cardInfo": {
+        "notes": null,
+        "title": null,
+        "description": null,
+        "thumbnailURL": null
+      },
       "totalSpent": 67823.94,
-      "description": null,
       "loyaltyTier": {
         "name": "Platinum"
       },
       "totalOrders": 238,
       "customerName": "James Mitchell-Brown",
-      "thumbnailURL": null,
       "customerSince": "2021-11-03T08:45:00.000Z"
     },
     "relationships": {

--- a/packages/catalog-realm/online-customer/OnlineCustomer/zara-ahmed.json
+++ b/packages/catalog-realm/online-customer/OnlineCustomer/zara-ahmed.json
@@ -9,22 +9,35 @@
     "type": "card",
     "attributes": {
       "email": {
+        "link": null,
+        "email": "ahmed@cardstack.com",
         "label": "Email",
-        "value": "zara.ahmed@healthtechstartup.com"
+        "phone": {
+          "number": null,
+          "countryCode": null
+        }
       },
       "phone": {
+        "link": null,
+        "email": null,
         "label": "Phone",
-        "value": "+1-647-555-1286"
+        "phone": {
+          "number": "93409012332",
+          "countryCode": "93"
+        }
       },
-      "cardInfo": {},
+      "cardInfo": {
+        "notes": null,
+        "title": null,
+        "description": null,
+        "thumbnailURL": null
+      },
       "totalSpent": 2847.33,
-      "description": null,
       "loyaltyTier": {
         "name": "Bronze"
       },
       "totalOrders": 12,
       "customerName": "Zara Ahmed",
-      "thumbnailURL": null,
       "customerSince": "2024-02-28T13:10:00.000Z"
     },
     "relationships": {

--- a/packages/catalog-realm/online-customer/online-customer.gts
+++ b/packages/catalog-realm/online-customer/online-customer.gts
@@ -129,13 +129,15 @@ class IsolatedTemplate extends Component<typeof OnlineCustomer> {
           {{#if @model.email}}
             <div class='contact-info'>
               <@fields.email @format='atom' />
-              <span class='contact-value'>{{@model.email.value}}</span>
+              <span class='contact-value'>{{@model.email.email}}</span>
             </div>
           {{/if}}
           {{#if @model.phone}}
             <div class='contact-info'>
               <@fields.phone @format='atom' />
-              <span class='contact-value'>{{@model.phone.value}}</span>
+              <span class='contact-value'>
+                +{{@model.phone.phone.countryCode}}{{@model.phone.phone.number}}
+              </span>
             </div>
           {{/if}}
         </div>
@@ -433,22 +435,25 @@ class EmbeddedTemplate extends Component<typeof OnlineCustomer> {
         </div>
 
         <div class='customer-info'>
-          <div class='customer-name'>{{if
+          <h1 class='customer-name'>{{if
               @model.customerName
               @model.customerName
               'Unknown Customer'
-            }}</div>
-          <div class='customer-tier'>{{this.customerTier}} Customer</div>
+            }}</h1>
+
+          <div class='customer-tier'>{{this.customerTier}} Status Customer</div>
           {{#if @model.email}}
             <div class='contact-info'>
               <@fields.email @format='atom' />
-              <span class='contact-value'>{{@model.email.value}}</span>
+              <span class='contact-value'>{{@model.email.email}}</span>
             </div>
           {{/if}}
           {{#if @model.phone}}
             <div class='contact-info'>
               <@fields.phone @format='atom' />
-              <span class='contact-value'>{{@model.phone.value}}</span>
+              <span class='contact-value'>
+                +{{@model.phone.phone.countryCode}}{{@model.phone.phone.number}}
+              </span>
             </div>
           {{/if}}
         </div>
@@ -580,11 +585,15 @@ class EmbeddedTemplate extends Component<typeof OnlineCustomer> {
       }
 
       .customer-tier {
-        font-size: 0.9375rem;
+        font-size: 1rem;
         color: #6366f1;
         font-weight: 600;
-        margin-top: 0.25rem;
-        margin-bottom: 0.25rem;
+        background: linear-gradient(135deg, #ede9fe 0%, #ddd6fe 100%);
+        padding: 0.5rem 1rem;
+        border-radius: 0.75rem;
+        display: inline-block;
+        border: 1px solid rgba(99, 102, 241, 0.2);
+        margin-bottom: 0.5rem;
       }
 
       .contact-info {

--- a/packages/catalog-realm/online-customer/online-customer.gts
+++ b/packages/catalog-realm/online-customer/online-customer.gts
@@ -923,7 +923,6 @@ class FittedTemplate extends Component<typeof OnlineCustomer> {
             {{#if @model.email}}
               <div class='card-contact'>
                 <@fields.email @format='atom' />
-                <span class='contact-value'>{{@model.email.value}}</span>
               </div>
             {{/if}}
           </div>


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/ECO-293/create-new-contactlinksfield-field-listing

For the catalog realm contact-link field:

1. Make the phone field use a PhoneNumberField.
2. Make the email field use an EmailField.

This way, validation will work correctly in the contact link.

Result:
<img width="1396" height="502" alt="image" src="https://github.com/user-attachments/assets/ca08b969-ab9e-497d-818e-70fdefae4a49" />
