### PR TITLE
bot: Add span logging for OpenRouter calls

### DIFF
--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -429,6 +429,7 @@ Common issues are:
           const runner = assistant
             .getResponse(promptParts)
             .on('chunk', async (chunk, snapshot) => {
+              log.info(`[${eventId}] Received chunk %s`, chunk.id);
               generationId = chunk.id;
               let activeGeneration = activeGenerations.get(room.roomId);
               if (activeGeneration) {

--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -422,7 +422,10 @@ Common issues are:
 
           let chunkHandlingError: string | undefined;
           let generationId: string | undefined;
-          log.info('Starting generation with model %s', promptParts.model);
+          log.info(
+            `[${eventId}] Starting generation with model %s`,
+            promptParts.model,
+          );
           const runner = assistant
             .getResponse(promptParts)
             .on('chunk', async (chunk, snapshot) => {
@@ -464,11 +467,11 @@ Common issues are:
 
           try {
             await runner.finalChatCompletion();
-            log.info('Generation complete');
+            log.info(`[${eventId}] Generation complete`);
             await responder.finalize();
-            log.info('Response finalized');
+            log.info(`[${eventId}] Response finalized`);
           } catch (error) {
-            log.error('Error during generation or finalization');
+            log.error(`[${eventId}] Error during generation or finalization`);
             log.error(error);
             if (chunkHandlingError) {
               await responder.onError(chunkHandlingError); // E.g. MatrixError: [413] event too large

--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -422,6 +422,7 @@ Common issues are:
 
           let chunkHandlingError: string | undefined;
           let generationId: string | undefined;
+          log.info('Starting generation with model %s', promptParts.model);
           const runner = assistant
             .getResponse(promptParts)
             .on('chunk', async (chunk, snapshot) => {
@@ -463,8 +464,12 @@ Common issues are:
 
           try {
             await runner.finalChatCompletion();
+            log.info('Generation complete');
             await responder.finalize();
+            log.info('Response finalized');
           } catch (error) {
+            log.error('Error during generation or finalization');
+            log.error(error);
             if (chunkHandlingError) {
               await responder.onError(chunkHandlingError); // E.g. MatrixError: [413] event too large
             } else {


### PR DESCRIPTION
This shows when a call to OpenRouter starts and ends, and when chunks are received:

<img width="1115" height="864" alt="b4 2025-10-06 10-58-55" src="https://github.com/user-attachments/assets/17f366ff-6f61-4147-b27a-0b587f330814" />

Maybe logging for each chunk is excessive?

The timestamps show the request took ≈4.5s from start to finish. That’s probably reasonable, but maybe it‘s useful to have data on that? But maybe structured logging or other kinds of monitoring are preferable.