### PR TITLE
server: Update @koa/router to 14.0.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ catalogs:
       specifier: ^4.0.0
       version: 4.0.0
     '@koa/router':
-      specifier: ^12.0.2
-      version: 12.0.2
+      specifier: ^14.0.0
+      version: 14.0.0
     '@lukeed/uuid':
       specifier: ^2.0.1
       version: 2.0.1
@@ -2629,7 +2629,7 @@ importers:
         version: 4.0.0
       '@koa/router':
         specifier: 'catalog:'
-        version: 12.0.2
+        version: 14.0.0
       '@sentry/node':
         specifier: 'catalog:'
         version: 8.31.0
@@ -4891,9 +4891,9 @@ packages:
     resolution: {integrity: sha512-Y4RrbvGTlAaa04DBoPBWJqDR5gPj32OOz827ULXfgB1F7piD1MB/zwn8JR2LAnvdILhxUbXbkXGWuNVsFuVFCQ==}
     engines: {node: '>= 14.0.0'}
 
-  '@koa/router@12.0.2':
-    resolution: {integrity: sha512-sYcHglGKTxGF+hQ6x67xDfkE9o+NhVlRHBqq6gLywaMc6CojK/5vFZByphdonKinYlMLkEkacm+HEse9HzwgTA==}
-    engines: {node: '>= 12'}
+  '@koa/router@14.0.0':
+    resolution: {integrity: sha512-LBSu5K0qAaaQcXX/0WIB9PGDevyCxxpnc1uq13vV/CgObaVxuis5hKl3Eboq/8gcb6ebnkAStW9NB/Em2eYyFA==}
+    engines: {node: '>= 20'}
 
   '@kwsites/file-exists@1.1.1':
     resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
@@ -15824,13 +15824,12 @@ snapshots:
     dependencies:
       vary: 1.1.2
 
-  '@koa/router@12.0.2':
+  '@koa/router@14.0.0':
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       http-errors: 2.0.0
       koa-compose: 4.1.0
-      methods: 1.1.2
-      path-to-regexp: 6.3.0
+      path-to-regexp: 8.2.0
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ catalogs:
       specifier: ^4.0.0
       version: 4.0.0
     '@koa/router':
-      specifier: ^12.0.0
-      version: 12.0.0
+      specifier: ^12.0.2
+      version: 12.0.2
     '@lukeed/uuid':
       specifier: ^2.0.1
       version: 2.0.1
@@ -2629,7 +2629,7 @@ importers:
         version: 4.0.0
       '@koa/router':
         specifier: 'catalog:'
-        version: 12.0.0
+        version: 12.0.2
       '@sentry/node':
         specifier: 'catalog:'
         version: 8.31.0
@@ -4891,10 +4891,9 @@ packages:
     resolution: {integrity: sha512-Y4RrbvGTlAaa04DBoPBWJqDR5gPj32OOz827ULXfgB1F7piD1MB/zwn8JR2LAnvdILhxUbXbkXGWuNVsFuVFCQ==}
     engines: {node: '>= 14.0.0'}
 
-  '@koa/router@12.0.0':
-    resolution: {integrity: sha512-cnnxeKHXlt7XARJptflGURdJaO+ITpNkOHmQu7NHmCoRinPbyvFzce/EG/E8Zy81yQ1W9MoSdtklc3nyaDReUw==}
+  '@koa/router@12.0.2':
+    resolution: {integrity: sha512-sYcHglGKTxGF+hQ6x67xDfkE9o+NhVlRHBqq6gLywaMc6CojK/5vFZByphdonKinYlMLkEkacm+HEse9HzwgTA==}
     engines: {node: '>= 12'}
-    deprecated: '**IMPORTANT 10x+ PERFORMANCE UPGRADE**: Please upgrade to v12.0.1+ as we have fixed an issue with debuglog causing 10x slower router benchmark performance, see https://github.com/koajs/router/pull/173'
 
   '@kwsites/file-exists@1.1.1':
     resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
@@ -15825,12 +15824,15 @@ snapshots:
     dependencies:
       vary: 1.1.2
 
-  '@koa/router@12.0.0':
+  '@koa/router@12.0.2':
     dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
       http-errors: 2.0.0
       koa-compose: 4.1.0
       methods: 1.1.2
       path-to-regexp: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@kwsites/file-exists@1.1.1':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,7 +31,7 @@ catalog:
   "@floating-ui/dom": ^1.6.3
   "@glint/environment-ember-loose": ^1.5.2
   "@koa/cors": ^4.0.0
-  "@koa/router": ^12.0.2
+  "@koa/router": ^14.0.0
   "@lucide/lab": ^0.1.2
   "@lukeed/uuid": ^2.0.1
   "@percy/cli": ^1.31.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,7 +31,7 @@ catalog:
   "@floating-ui/dom": ^1.6.3
   "@glint/environment-ember-loose": ^1.5.2
   "@koa/cors": ^4.0.0
-  "@koa/router": ^12.0.0
+  "@koa/router": ^12.0.2
   "@lucide/lab": ^0.1.2
   "@lukeed/uuid": ^2.0.1
   "@percy/cli": ^1.31.1


### PR DESCRIPTION
How long have we not seen this:

<img width="1131" height="196" alt="realm-server 2025-10-08 10-05-25" src="https://github.com/user-attachments/assets/b30a649f-128b-401b-96a1-15fe313308c4" />

I saw no breaking changes so I chose to update to the latest version: 14.0.0.

I’m giving up on getting proper Percy feedback, which has nothing to do with this.