### PR TITLE
Add POST boxel-site-hostname endpoint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -391,6 +391,7 @@ jobs:
             "realm-endpoints-test.ts",
             "search-prerendered-test.ts",
             "site-name-availability-test.ts",
+            "claim-boxel-site-hostname-test.ts",
             "types-endpoint-test.ts",
             "server-endpoints-test.ts",
             "virtual-network-test.ts",

--- a/packages/postgres/migrations/1759232510123_create-claimed-domains-for-sites.js
+++ b/packages/postgres/migrations/1759232510123_create-claimed-domains-for-sites.js
@@ -29,7 +29,11 @@ exports.up = (pgm) => {
     },
   });
 
-  pgm.createIndex('claimed_domains_for_sites', ['hostname'], { unique: true });
+  pgm.createIndex('claimed_domains_for_sites', ['hostname'], {
+    unique: true,
+    where: 'removed_at IS NULL',
+    name: 'claimed_domains_for_sites_hostname_unique_index',
+  });
   pgm.createIndex('claimed_domains_for_sites', ['removed_at']);
   pgm.createIndex('claimed_domains_for_sites', ['user_id']);
   pgm.createIndex('claimed_domains_for_sites', ['source_realm_url']);
@@ -37,7 +41,10 @@ exports.up = (pgm) => {
 
 exports.down = (pgm) => {
   pgm.dropIndex('claimed_domains_for_sites', ['removed_at']);
-  pgm.dropIndex('claimed_domains_for_sites', ['hostname']);
+  pgm.dropIndex(
+    'claimed_domains_for_sites',
+    'claimed_domains_for_sites_hostname_unique_index',
+  );
   pgm.dropIndex('claimed_domains_for_sites', ['user_id']);
   pgm.dropIndex('claimed_domains_for_sites', ['source_realm_url']);
   pgm.dropTable('claimed_domains_for_sites');

--- a/packages/realm-server/handlers/handle-claim-boxel-site-hostname.ts
+++ b/packages/realm-server/handlers/handle-claim-boxel-site-hostname.ts
@@ -21,7 +21,7 @@ import { validateSubdomain } from '../lib/user-subdomain-validation';
 
 interface ClaimBoxelSiteHostnameJSON {
   data: {
-    type: 'claimed-domain';
+    type: 'claimed-site-hostname';
     attributes: {
       source_realm_url: string;
       hostname: string;
@@ -165,7 +165,7 @@ export default function handleClaimBoxelSiteHostnameRequest({
           JSON.stringify(
             {
               data: {
-                type: 'claimed-domain',
+                type: 'claimed-site-hostname',
                 id: claimId,
                 attributes: {
                   hostname: normalizedHostname,
@@ -202,8 +202,8 @@ function assertIsClaimBoxelSiteHostnameJSON(
     throw new Error(`json is missing "data" object`);
   }
   let { data } = json;
-  if (!('type' in data) || data.type !== 'claimed-domain') {
-    throw new Error('json.data.type must be "claimed-domain"');
+  if (!('type' in data) || data.type !== 'claimed-site-hostname') {
+    throw new Error('json.data.type must be "claimed-site-hostname"');
   }
   if (!('attributes' in data) || typeof data.attributes !== 'object') {
     throw new Error(`json.data is missing "attributes" object`);

--- a/packages/realm-server/handlers/handle-claim-boxel-site-hostname.ts
+++ b/packages/realm-server/handlers/handle-claim-boxel-site-hostname.ts
@@ -1,0 +1,225 @@
+import Koa from 'koa';
+import {
+  asExpressions,
+  insert,
+  param,
+  query,
+  SupportedMimeType,
+} from '@cardstack/runtime-common';
+import { getUserByMatrixUserId } from '@cardstack/billing/billing-queries';
+import {
+  fetchRequestFromContext,
+  sendResponseForBadRequest,
+  sendResponseForNotFound,
+  sendResponseForSystemError,
+  sendResponseForUnprocessableEntity,
+  setContextResponse,
+} from '../middleware';
+import { RealmServerTokenClaim } from '../utils/jwt';
+import { CreateRoutesArgs } from '../routes';
+import { validateSubdomain } from '../lib/user-subdomain-validation';
+
+interface ClaimBoxelSiteHostnameJSON {
+  data: {
+    type: 'claimed-domain';
+    attributes: {
+      source_realm_url: string;
+      hostname: string;
+    };
+  };
+}
+
+export default function handleClaimBoxelSiteHostnameRequest({
+  dbAdapter,
+  domainsForPublishedRealms,
+}: CreateRoutesArgs): (ctxt: Koa.Context, next: Koa.Next) => Promise<void> {
+  let boxelSiteDomain = domainsForPublishedRealms?.boxelSite;
+
+  return async function (ctxt: Koa.Context, _next: Koa.Next) {
+    try {
+      if (!boxelSiteDomain) {
+        throw new Error('domainsForPublishedRealms.boxelSite is required');
+      }
+      const token = ctxt.state.token as RealmServerTokenClaim;
+      if (!token) {
+        await sendResponseForSystemError(
+          ctxt,
+          'token is required to claim site hostname',
+        );
+        return;
+      }
+
+      const { user: matrixUserId } = token;
+      const user = await getUserByMatrixUserId(dbAdapter, matrixUserId);
+      if (!user) {
+        await sendResponseForNotFound(ctxt, 'user is not found');
+        return;
+      }
+
+      const request = await fetchRequestFromContext(ctxt);
+      const rawBody = await request.text();
+
+      let json: Record<string, any>;
+      try {
+        json = JSON.parse(rawBody);
+      } catch (_error) {
+        await sendResponseForBadRequest(
+          ctxt,
+          'Request body is not valid JSON-API - invalid JSON',
+        );
+        return;
+      }
+
+      try {
+        assertIsClaimBoxelSiteHostnameJSON(json);
+      } catch (e: any) {
+        await sendResponseForBadRequest(
+          ctxt,
+          `Request body is not valid JSON-API - ${e.message}`,
+        );
+        return;
+      }
+
+      const { source_realm_url: sourceRealmURL, hostname } =
+        json.data.attributes;
+
+      const trimmedHostname = hostname.trim();
+      const normalizedHostname = trimmedHostname.toLowerCase();
+
+      // Reject if hostname contains uppercase letters
+      if (trimmedHostname !== normalizedHostname) {
+        await sendResponseForUnprocessableEntity(
+          ctxt,
+          'Hostname must be lowercase',
+        );
+        return;
+      }
+      const suffix = `.${boxelSiteDomain}`;
+
+      if (normalizedHostname === boxelSiteDomain) {
+        await sendResponseForUnprocessableEntity(
+          ctxt,
+          'Hostname must include a subdomain',
+        );
+        return;
+      }
+
+      if (!normalizedHostname.endsWith(suffix)) {
+        await sendResponseForUnprocessableEntity(
+          ctxt,
+          `Hostname must end with ${suffix}`,
+        );
+        return;
+      }
+
+      const subdomain = normalizedHostname.slice(
+        0,
+        normalizedHostname.length - suffix.length,
+      );
+
+      if (!subdomain) {
+        await sendResponseForUnprocessableEntity(
+          ctxt,
+          'Hostname must include a subdomain',
+        );
+        return;
+      }
+
+      const validation = validateSubdomain(subdomain);
+      if (!validation.valid) {
+        await sendResponseForUnprocessableEntity(ctxt, validation.error ?? '');
+        return;
+      }
+
+      const existingClaims = await query(dbAdapter, [
+        `SELECT id FROM claimed_domains_for_sites WHERE hostname = `,
+        param(normalizedHostname),
+        ` AND removed_at IS NULL`,
+      ]);
+
+      if (existingClaims.length > 0) {
+        await sendResponseForUnprocessableEntity(
+          ctxt,
+          'Hostname is already claimed',
+        );
+        return;
+      }
+
+      const { valueExpressions, nameExpressions } = asExpressions({
+        user_id: user.id,
+        hostname: normalizedHostname,
+        source_realm_url: sourceRealmURL,
+        claimed_at: Math.floor(Date.now() / 1000),
+      });
+
+      const result = await query(
+        dbAdapter,
+        insert('claimed_domains_for_sites', nameExpressions, valueExpressions),
+      );
+
+      const claimId = result[0]?.id;
+
+      await setContextResponse(
+        ctxt,
+        new Response(
+          JSON.stringify(
+            {
+              data: {
+                type: 'claimed-domain',
+                id: claimId,
+                attributes: {
+                  hostname: normalizedHostname,
+                  subdomain,
+                  sourceRealmURL,
+                },
+              },
+            },
+            null,
+            2,
+          ),
+          {
+            status: 201,
+            headers: {
+              'content-type': SupportedMimeType.JSONAPI,
+            },
+          },
+        ),
+      );
+    } catch (error) {
+      console.error('Error claiming site hostname:', error);
+      await sendResponseForSystemError(ctxt, 'Internal server error');
+    }
+  };
+}
+
+function assertIsClaimBoxelSiteHostnameJSON(
+  json: any,
+): asserts json is ClaimBoxelSiteHostnameJSON {
+  if (typeof json !== 'object') {
+    throw new Error(`json must be an object`);
+  }
+  if (!('data' in json) || typeof json.data !== 'object') {
+    throw new Error(`json is missing "data" object`);
+  }
+  let { data } = json;
+  if (!('type' in data) || data.type !== 'claimed-domain') {
+    throw new Error('json.data.type must be "claimed-domain"');
+  }
+  if (!('attributes' in data) || typeof data.attributes !== 'object') {
+    throw new Error(`json.data is missing "attributes" object`);
+  }
+  let { attributes } = data;
+  if (
+    !('source_realm_url' in attributes) ||
+    typeof attributes.source_realm_url !== 'string'
+  ) {
+    throw new Error(
+      `json.data.attributes.source_realm_url is required and must be a string`,
+    );
+  }
+  if (!('hostname' in attributes) || typeof attributes.hostname !== 'string') {
+    throw new Error(
+      `json.data.attributes.hostname is required and must be a string`,
+    );
+  }
+}

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -32,6 +32,7 @@ import handleRequestForward from './handlers/handle-request-forward';
 import handlePostDeployment from './handlers/handle-post-deployment';
 import { handleCheckSiteNameAvailabilityRequest } from './handlers/handle-check-site-name-availability';
 import handleRealmAuth from './handlers/handle-realm-auth';
+import handleClaimBoxelSiteHostnameRequest from './handlers/handle-claim-boxel-site-hostname';
 
 export type CreateRoutesArgs = {
   serverURL: string;
@@ -157,6 +158,11 @@ export function createRoutes(args: CreateRoutesArgs) {
     '/_realm-auth',
     jwtMiddleware(args.realmSecretSeed),
     handleRealmAuth(args),
+  );
+  router.post(
+    '/_claim-boxel-site-hostname',
+    jwtMiddleware(args.realmSecretSeed),
+    handleClaimBoxelSiteHostnameRequest(args),
   );
 
   return router.routes();

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -160,7 +160,7 @@ export function createRoutes(args: CreateRoutesArgs) {
     handleRealmAuth(args),
   );
   router.post(
-    '/_claim-boxel-site-hostname',
+    '/_boxel-site-hostname',
     jwtMiddleware(args.realmSecretSeed),
     handleClaimBoxelSiteHostnameRequest(args),
   );

--- a/packages/realm-server/tests/claim-boxel-site-hostname-test.ts
+++ b/packages/realm-server/tests/claim-boxel-site-hostname-test.ts
@@ -29,6 +29,10 @@ module(basename(__filename), function () {
         dbAdapter,
         domainsForPublishedRealms: { boxelSite: boxelSiteDomain },
       } as any);
+
+      // Clean up any existing claims to ensure clean state
+      await query(dbAdapter, ['DELETE FROM claimed_domains_for_sites']);
+
       user = await insertUser(dbAdapter, 'matrix-user-id', 'test-user');
       defaultToken = {
         user: 'matrix-user-id',

--- a/packages/realm-server/tests/claim-boxel-site-hostname-test.ts
+++ b/packages/realm-server/tests/claim-boxel-site-hostname-test.ts
@@ -1,0 +1,381 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import { PgAdapter } from '@cardstack/postgres';
+import {
+  query,
+  insert,
+  asExpressions,
+  User,
+  insertUser,
+} from '@cardstack/runtime-common';
+import { prepareTestDB } from './helpers';
+import handleClaimBoxelSiteHostnameRequest from '../handlers/handle-claim-boxel-site-hostname';
+import Koa from 'koa';
+import { RealmServerTokenClaim } from '../utils/jwt';
+import { Readable } from 'stream';
+
+module(basename(__filename), function () {
+  module('claim boxel site hostname endpoint', function (hooks) {
+    let dbAdapter: PgAdapter;
+    let handler: (ctxt: Koa.Context, next: Koa.Next) => Promise<void>;
+    let user: User;
+    let boxelSiteDomain = 'boxel.site';
+    let defaultToken: RealmServerTokenClaim;
+
+    hooks.beforeEach(async function () {
+      prepareTestDB();
+      dbAdapter = new PgAdapter({ autoMigrate: true });
+      handler = handleClaimBoxelSiteHostnameRequest({
+        dbAdapter,
+        domainsForPublishedRealms: { boxelSite: boxelSiteDomain },
+      } as any);
+      user = await insertUser(dbAdapter, 'matrix-user-id', 'test-user');
+      defaultToken = {
+        user: 'matrix-user-id',
+        sessionRoom: 'test-session',
+      };
+    });
+
+    hooks.afterEach(async function () {
+      await dbAdapter.close();
+    });
+
+    async function callHandler(
+      token: RealmServerTokenClaim | null,
+      attributes?: any,
+    ) {
+      const jsonApiBody = attributes
+        ? {
+            data: {
+              type: 'claimed-domain',
+              attributes,
+            },
+          }
+        : {};
+      const bodyText = JSON.stringify(jsonApiBody);
+      const stream = Readable.from([bodyText]);
+      const ctx: any = {
+        state: { token },
+        status: undefined,
+        body: undefined,
+        method: 'POST',
+        req: Object.assign(stream, {
+          headers: {
+            host: 'localhost:4200',
+            'content-length': bodyText.length.toString(),
+          },
+          url: '/_claim-boxel-site-hostname',
+          method: 'POST',
+        }),
+        request: {
+          text: async () => bodyText,
+        },
+        set: () => {},
+        res: {
+          getHeaders: () => ({}),
+          end: () => {},
+        },
+      };
+
+      await handler(ctx, async () => {});
+      return ctx;
+    }
+
+    async function callHandlerWithInvalidJSON(
+      token: RealmServerTokenClaim | null,
+      invalidJSON: string,
+    ) {
+      const stream = Readable.from([invalidJSON]);
+      const ctx: any = {
+        state: { token },
+        status: undefined,
+        body: undefined,
+        method: 'POST',
+        req: Object.assign(stream, {
+          headers: {
+            host: 'localhost:4200',
+            'content-length': invalidJSON.length.toString(),
+          },
+          url: '/_claim-boxel-site-hostname',
+          method: 'POST',
+        }),
+        request: {
+          text: async () => invalidJSON,
+        },
+        set: () => {},
+        res: {
+          getHeaders: () => ({}),
+          end: () => {},
+        },
+      };
+
+      await handler(ctx, async () => {});
+      return ctx;
+    }
+
+    function assertErrorIncludes(ctx: any, message: string) {
+      const body = JSON.parse(ctx.body);
+      return body.errors && body.errors[0].includes(message);
+    }
+
+    test('should return 400 when body is not valid JSON', async function (assert) {
+      const ctx = await callHandlerWithInvalidJSON(
+        defaultToken,
+        'invalid json{',
+      );
+
+      assert.strictEqual(ctx.status, 400, 'Should return 400 for invalid JSON');
+      assert.ok(
+        assertErrorIncludes(ctx, 'Request body is not valid JSON'),
+        'Should have error message about invalid JSON',
+      );
+    });
+
+    test('should return 400 for invalid JSON-API format', async function (assert) {
+      const ctx = await callHandlerWithInvalidJSON(
+        defaultToken,
+        JSON.stringify({ hostname: 'test.boxel.site' }),
+      );
+
+      assert.strictEqual(
+        ctx.status,
+        400,
+        'Should return 400 for invalid JSON-API',
+      );
+      assert.ok(
+        assertErrorIncludes(ctx, 'json is missing "data" object'),
+        'Should have error message about missing data object',
+      );
+    });
+
+    test('should return 400 when source_realm_url is missing', async function (assert) {
+      const ctx = await callHandler(defaultToken, {
+        hostname: 'test.boxel.site',
+      });
+
+      assert.strictEqual(
+        ctx.status,
+        400,
+        'Should return 400 for missing source_realm_url',
+      );
+      assert.ok(
+        assertErrorIncludes(ctx, 'source_realm_url is required'),
+        'Should have error message about missing source_realm_url',
+      );
+    });
+
+    test('should return 400 when hostname is missing', async function (assert) {
+      const ctx = await callHandler(defaultToken, {
+        source_realm_url: 'https://test-realm.com',
+      });
+
+      assert.strictEqual(
+        ctx.status,
+        400,
+        'Should return 400 for missing hostname',
+      );
+      assert.ok(
+        assertErrorIncludes(ctx, 'hostname is required'),
+        'Should have error message about missing hostname',
+      );
+    });
+
+    test('should return 422 when hostname is just the domain without subdomain', async function (assert) {
+      const ctx = await callHandler(defaultToken, {
+        source_realm_url: 'https://test-realm.com',
+        hostname: boxelSiteDomain,
+      });
+
+      assert.strictEqual(
+        ctx.status,
+        422,
+        'Should return 422 for hostname without subdomain',
+      );
+      assert.ok(
+        assertErrorIncludes(ctx, 'Hostname must include a subdomain'),
+        'Should have error message about missing subdomain',
+      );
+    });
+
+    test('should return 422 when hostname does not end with the correct domain', async function (assert) {
+      const ctx = await callHandler(defaultToken, {
+        source_realm_url: 'https://test-realm.com',
+        hostname: 'something.not-boxel.site',
+      });
+
+      assert.strictEqual(
+        ctx.status,
+        422,
+        'Should return 422 for incorrect domain',
+      );
+      assert.ok(
+        assertErrorIncludes(ctx, `Hostname must end with .boxel.site`),
+        'Should have error message about incorrect domain',
+      );
+    });
+
+    test('should return 422 for invalid subdomain names', async function (assert) {
+      const invalidSubdomains = [
+        'api',
+        'admin',
+        'test',
+        '-invalid',
+        'invalid-',
+        'a',
+        'a'.repeat(64),
+        'test@domain',
+        'test.domain',
+        'MyApp',
+        'TEST',
+        'xn--test',
+        'tëst',
+      ];
+
+      for (const subdomain of invalidSubdomains) {
+        const ctx = await callHandler(defaultToken, {
+          source_realm_url: 'https://test-realm.com',
+          hostname: `${subdomain}.${boxelSiteDomain}`,
+        });
+
+        assert.strictEqual(
+          ctx.status,
+          422,
+          `Should return 422 for invalid subdomain: ${subdomain}`,
+        );
+        assert.ok(
+          ctx.body,
+          `Should have error message for subdomain: ${subdomain}`,
+        );
+      }
+    });
+
+    test('should return 422 when hostname is already claimed', async function (assert) {
+      const hostname = 'claimed-site.boxel.site';
+
+      let { valueExpressions, nameExpressions } = asExpressions({
+        user_id: user.id,
+        source_realm_url: 'https://existing-realm.com',
+        hostname: hostname,
+        claimed_at: Math.floor(Date.now() / 1000),
+      });
+      await query(
+        dbAdapter,
+        insert('claimed_domains_for_sites', nameExpressions, valueExpressions),
+      );
+
+      const ctx = await callHandler(defaultToken, {
+        source_realm_url: 'https://test-realm.com',
+        hostname: hostname,
+      });
+
+      assert.strictEqual(
+        ctx.status,
+        422,
+        'Should return 422 for already claimed hostname',
+      );
+      assert.ok(
+        assertErrorIncludes(ctx, 'Hostname is already claimed'),
+        'Should have error message about hostname already claimed',
+      );
+    });
+
+    test('should successfully claim a valid hostname', async function (assert) {
+      const hostname = 'my-site.boxel.site';
+      const sourceRealmURL = 'https://test-realm.com';
+
+      const ctx = await callHandler(defaultToken, {
+        source_realm_url: sourceRealmURL,
+        hostname: hostname,
+      });
+
+      assert.strictEqual(
+        ctx.status,
+        201,
+        'Should return 201 for successful claim',
+      );
+
+      // Parse and check JSON-API response body
+      const responseBody = JSON.parse(ctx.body);
+      assert.ok(responseBody.data, 'Should have data object');
+      assert.strictEqual(
+        responseBody.data.type,
+        'claimed-domain',
+        'Should have correct type',
+      );
+      assert.ok(responseBody.data.id, 'Should have an ID');
+      assert.strictEqual(
+        responseBody.data.attributes.hostname,
+        hostname,
+        'Should return normalized hostname',
+      );
+      assert.strictEqual(
+        responseBody.data.attributes.subdomain,
+        'my-site',
+        'Should return correct subdomain',
+      );
+      assert.strictEqual(
+        responseBody.data.attributes.sourceRealmURL,
+        sourceRealmURL,
+        'Should return source realm URL',
+      );
+
+      // Verify the claim was saved to database
+      const claims = await query(dbAdapter, [
+        `SELECT * FROM claimed_domains_for_sites WHERE hostname = '${hostname}'`,
+      ]);
+      assert.strictEqual(claims.length, 1, 'Should have one claim in database');
+      assert.strictEqual(
+        claims[0].user_id,
+        user.id,
+        'Should have correct user ID',
+      );
+      assert.strictEqual(
+        claims[0].source_realm_url,
+        sourceRealmURL,
+        'Should have correct source realm URL',
+      );
+      assert.ok(claims[0].claimed_at, 'Should have claimed_at timestamp');
+      assert.strictEqual(claims[0].removed_at, null, 'Should not be removed');
+    });
+
+    test('should allow claiming a hostname that was previously removed', async function (assert) {
+      const hostname = 'removed-site.boxel.site';
+
+      // Insert a removed claim
+      let { valueExpressions, nameExpressions } = asExpressions({
+        user_id: user.id,
+        source_realm_url: 'https://old-realm.com',
+        hostname: hostname,
+        claimed_at: Math.floor(Date.now() / 1000) - 86400,
+        removed_at: Math.floor(Date.now() / 1000) - 3600,
+      });
+      await query(
+        dbAdapter,
+        insert('claimed_domains_for_sites', nameExpressions, valueExpressions),
+      );
+
+      const sourceRealmURL = 'https://new-realm.com';
+      const ctx = await callHandler(defaultToken, {
+        source_realm_url: sourceRealmURL,
+        hostname: hostname,
+      });
+
+      assert.strictEqual(
+        ctx.status,
+        201,
+        'Should return 201 for successful claim of previously removed hostname',
+      );
+
+      // Verify the new claim was saved
+      const claims = await query(dbAdapter, [
+        `SELECT * FROM claimed_domains_for_sites WHERE hostname = '${hostname}' AND removed_at IS NULL`,
+      ]);
+      assert.strictEqual(claims.length, 1, 'Should have one active claim');
+      assert.strictEqual(
+        claims[0].source_realm_url,
+        sourceRealmURL,
+        'Should have new source realm URL',
+      );
+    });
+  });
+});

--- a/packages/realm-server/tests/claim-boxel-site-hostname-test.ts
+++ b/packages/realm-server/tests/claim-boxel-site-hostname-test.ts
@@ -51,7 +51,7 @@ module(basename(__filename), function () {
       const jsonApiBody = attributes
         ? {
             data: {
-              type: 'claimed-domain',
+              type: 'claimed-site-hostname',
               attributes,
             },
           }
@@ -303,7 +303,7 @@ module(basename(__filename), function () {
       assert.ok(responseBody.data, 'Should have data object');
       assert.strictEqual(
         responseBody.data.type,
-        'claimed-domain',
+        'claimed-site-hostname',
         'Should have correct type',
       );
       assert.ok(responseBody.data.id, 'Should have an ID');

--- a/packages/realm-server/tests/claim-boxel-site-hostname-test.ts
+++ b/packages/realm-server/tests/claim-boxel-site-hostname-test.ts
@@ -68,7 +68,7 @@ module(basename(__filename), function () {
             host: 'localhost:4200',
             'content-length': bodyText.length.toString(),
           },
-          url: '/_claim-boxel-site-hostname',
+          url: '/_boxel-site-hostname',
           method: 'POST',
         }),
         request: {
@@ -100,7 +100,7 @@ module(basename(__filename), function () {
             host: 'localhost:4200',
             'content-length': invalidJSON.length.toString(),
           },
-          url: '/_claim-boxel-site-hostname',
+          url: '/_boxel-site-hostname',
           method: 'POST',
         }),
         request: {

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -32,3 +32,4 @@ import './types-endpoint-test';
 import './virtual-network-test';
 import './request-forward-test';
 import './publish-unpublish-realm-test';
+import './claim-boxel-site-hostname-test';

--- a/packages/realm-server/tests/server-endpoints-test.ts
+++ b/packages/realm-server/tests/server-endpoints-test.ts
@@ -1679,6 +1679,66 @@ module(basename(__filename), function () {
 
           assert.strictEqual(response.status, 200, 'HTTP 200 status');
         });
+
+        test('POST /_claim-boxel-site-hostname without JWT returns 401', async function (assert) {
+          let response = await request2
+            .post('/_claim-boxel-site-hostname')
+            .set('Accept', 'application/json')
+            .send({
+              data: {
+                type: 'claimed-domain',
+                attributes: {
+                  source_realm_url: 'https://test-realm.com',
+                  hostname: 'test-site.boxel.site',
+                },
+              },
+            });
+
+          assert.strictEqual(response.status, 401, 'HTTP 401 status');
+        });
+
+        test('POST /_claim-boxel-site-hostname with invalid JWT returns 401', async function (assert) {
+          let response = await request2
+            .post('/_claim-boxel-site-hostname')
+            .set('Accept', 'application/json')
+            .set('Authorization', 'Bearer invalid-jwt')
+            .send({
+              data: {
+                type: 'claimed-domain',
+                attributes: {
+                  source_realm_url: 'https://test-realm.com',
+                  hostname: 'test-site.boxel.site',
+                },
+              },
+            });
+
+          assert.strictEqual(response.status, 401, 'HTTP 401 status');
+        });
+
+        test('POST /_claim-boxel-site-hostname with valid JWT returns 201', async function (assert) {
+          let ownerUserId = '@mango:localhost';
+          let response = await request2
+            .post('/_claim-boxel-site-hostname')
+            .set('Accept', 'application/json')
+            .set(
+              'Authorization',
+              `Bearer ${createRealmServerJWT(
+                { user: ownerUserId, sessionRoom: 'session-room-test' },
+                realmSecretSeed,
+              )}`,
+            )
+            .send({
+              data: {
+                type: 'claimed-domain',
+                attributes: {
+                  source_realm_url: 'https://test-realm.com',
+                  hostname: 'valid-site.boxel.site',
+                },
+              },
+            });
+
+          assert.strictEqual(response.status, 201, 'HTTP 201 status');
+        });
       });
 
       module('stripe webhook handler', function (hooks) {

--- a/packages/realm-server/tests/server-endpoints-test.ts
+++ b/packages/realm-server/tests/server-endpoints-test.ts
@@ -1686,7 +1686,7 @@ module(basename(__filename), function () {
             .set('Accept', 'application/json')
             .send({
               data: {
-                type: 'claimed-domain',
+                type: 'claimed-site-hostname',
                 attributes: {
                   source_realm_url: 'https://test-realm.com',
                   hostname: 'test-site.localhost',
@@ -1704,7 +1704,7 @@ module(basename(__filename), function () {
             .set('Authorization', 'Bearer invalid-jwt')
             .send({
               data: {
-                type: 'claimed-domain',
+                type: 'claimed-site-hostname',
                 attributes: {
                   source_realm_url: 'https://test-realm.com',
                   hostname: 'test-site.localhost',
@@ -1733,7 +1733,7 @@ module(basename(__filename), function () {
             )
             .send({
               data: {
-                type: 'claimed-domain',
+                type: 'claimed-site-hostname',
                 attributes: {
                   source_realm_url: 'https://test-realm.com',
                   hostname: 'valid-site.localhost',

--- a/packages/realm-server/tests/server-endpoints-test.ts
+++ b/packages/realm-server/tests/server-endpoints-test.ts
@@ -1680,9 +1680,9 @@ module(basename(__filename), function () {
           assert.strictEqual(response.status, 200, 'HTTP 200 status');
         });
 
-        test('POST /_claim-boxel-site-hostname without JWT returns 401', async function (assert) {
+        test('POST /_boxel-site-hostname without JWT returns 401', async function (assert) {
           let response = await request2
-            .post('/_claim-boxel-site-hostname')
+            .post('/_boxel-site-hostname')
             .set('Accept', 'application/json')
             .send({
               data: {
@@ -1697,9 +1697,9 @@ module(basename(__filename), function () {
           assert.strictEqual(response.status, 401, 'HTTP 401 status');
         });
 
-        test('POST /_claim-boxel-site-hostname with invalid JWT returns 401', async function (assert) {
+        test('POST /_boxel-site-hostname with invalid JWT returns 401', async function (assert) {
           let response = await request2
-            .post('/_claim-boxel-site-hostname')
+            .post('/_boxel-site-hostname')
             .set('Accept', 'application/json')
             .set('Authorization', 'Bearer invalid-jwt')
             .send({
@@ -1715,14 +1715,14 @@ module(basename(__filename), function () {
           assert.strictEqual(response.status, 401, 'HTTP 401 status');
         });
 
-        test('POST /_claim-boxel-site-hostname with valid JWT returns 201', async function (assert) {
+        test('POST /_boxel-site-hostname with valid JWT returns 201', async function (assert) {
           let ownerUserId = '@mango:localhost';
 
           // Create user in database
           await insertUser(dbAdapter, ownerUserId, '', '');
 
           let response = await request2
-            .post('/_claim-boxel-site-hostname')
+            .post('/_boxel-site-hostname')
             .set('Accept', 'application/json')
             .set(
               'Authorization',

--- a/packages/realm-server/tests/server-endpoints-test.ts
+++ b/packages/realm-server/tests/server-endpoints-test.ts
@@ -1689,7 +1689,7 @@ module(basename(__filename), function () {
                 type: 'claimed-domain',
                 attributes: {
                   source_realm_url: 'https://test-realm.com',
-                  hostname: 'test-site.boxel.site',
+                  hostname: 'test-site.localhost',
                 },
               },
             });
@@ -1707,7 +1707,7 @@ module(basename(__filename), function () {
                 type: 'claimed-domain',
                 attributes: {
                   source_realm_url: 'https://test-realm.com',
-                  hostname: 'test-site.boxel.site',
+                  hostname: 'test-site.localhost',
                 },
               },
             });
@@ -1717,6 +1717,10 @@ module(basename(__filename), function () {
 
         test('POST /_claim-boxel-site-hostname with valid JWT returns 201', async function (assert) {
           let ownerUserId = '@mango:localhost';
+
+          // Create user in database
+          await insertUser(dbAdapter, ownerUserId, '', '');
+
           let response = await request2
             .post('/_claim-boxel-site-hostname')
             .set('Accept', 'application/json')
@@ -1732,7 +1736,7 @@ module(basename(__filename), function () {
                 type: 'claimed-domain',
                 attributes: {
                   source_realm_url: 'https://test-realm.com',
-                  hostname: 'valid-site.boxel.site',
+                  hostname: 'valid-site.localhost',
                 },
               },
             });


### PR DESCRIPTION
To be used with this:

<img width="671" height="200" alt="image" src="https://github.com/user-attachments/assets/ef4492f1-d31e-4925-a75e-225c123f86b1" />

Usage:

```
POST /_claim-boxel-site-hostname

Headers:
  Accept: application/json
  Authorization: Bearer <JWT token>
    (containing: user: ownerUserId, sessionRoom: 'session-room-test')

Body:
  {
    "data": {
      "type": "claimed-site-hostname",
      "attributes": {
        "source_realm_url": "https://test-realm.com",
        "hostname": "mike.boxel.site"
      }
    }
  }
```

This should also work for custom domains when we add that feature. 


