### PR TITLE
Workspace header bug

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -821,6 +821,7 @@ export default class CodeSubmode extends Component<Signature> {
 
     <style scoped>
       :global(:root) {
+        --code-submode-background: #74707d;
         --code-mode-panel-background-color: #ebeaed;
         --code-mode-container-border-radius: 10px;
         --code-mode-realm-icon-size: 1.125rem;
@@ -839,7 +840,7 @@ export default class CodeSubmode extends Component<Signature> {
       .code-mode {
         overflow: auto;
         flex: 1;
-        background-color: #74707d;
+        background-color: var(--code-submode-background);
       }
 
       .columns {
@@ -876,12 +877,14 @@ export default class CodeSubmode extends Component<Signature> {
         letter-spacing: var(--boxel-lsp-xs);
       }
 
-      .code-submode-layout :deep(.top-bar) {
-        background-color: #74707d;
+      .code-submode-layout :deep(.submode-layout-top-bar) {
+        background-color: var(--code-submode-background);
       }
 
       .code-submode-layout
-        :deep(.top-bar .ember-basic-dropdown-content-wormhole-origin) {
+        :deep(
+          .submode-layout-top-bar .ember-basic-dropdown-content-wormhole-origin
+        ) {
         position: absolute;
       }
 

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -835,6 +835,7 @@ export default class CodeSubmode extends Component<Signature> {
       .code-submode-layout {
         --submode-bar-item-outline: 2px solid transparent;
         --submode-bar-item-box-shadow: none;
+        background-color: var(--code-submode-background);
       }
 
       .code-mode {
@@ -875,10 +876,6 @@ export default class CodeSubmode extends Component<Signature> {
         padding: var(--boxel-sp);
         font: 600 var(--boxel-font);
         letter-spacing: var(--boxel-lsp-xs);
-      }
-
-      .code-submode-layout :deep(.submode-layout-top-bar) {
-        background-color: var(--code-submode-background);
       }
 
       .code-submode-layout

--- a/packages/host/app/components/operator-mode/host-submode.gts
+++ b/packages/host/app/components/operator-mode/host-submode.gts
@@ -235,12 +235,14 @@ export default class HostSubmode extends Component<HostSubmodeSignature> {
 
     <style scoped>
       .host-submode-layout {
+        --host-submode-background: var(--boxel-700);
         --submode-bar-item-border-radius: var(--boxel-border-radius);
         --submode-bar-item-box-shadow: var(--boxel-deep-box-shadow);
         --submode-bar-item-outline: var(--boxel-border-flexible);
         --operator-mode-left-column: calc(
           21.5rem - var(--submode-new-file-button-width)
         );
+        background-color: var(--host-submode-background);
       }
 
       .host-submode {
@@ -250,12 +252,6 @@ export default class HostSubmode extends Component<HostSubmodeSignature> {
         width: 100%;
         background-position: center;
         background-size: cover;
-      }
-
-      .host-submode-layout :deep(.submode-layout-top-bar) {
-        position: relative;
-        background-color: var(--boxel-700);
-        width: 100%;
       }
 
       .host-submode-layout

--- a/packages/host/app/components/operator-mode/host-submode.gts
+++ b/packages/host/app/components/operator-mode/host-submode.gts
@@ -252,7 +252,7 @@ export default class HostSubmode extends Component<HostSubmodeSignature> {
         background-size: cover;
       }
 
-      .host-submode-layout :deep(.top-bar) {
+      .host-submode-layout :deep(.submode-layout-top-bar) {
         position: relative;
         background-color: var(--boxel-700);
         width: 100%;

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -786,7 +786,7 @@ export default class InteractSubmode extends Component {
         --submode-bar-item-box-shadow: var(--boxel-deep-box-shadow);
       }
 
-      .interact-submode-layout :deep(.top-bar) {
+      .interact-submode-layout :deep(.submode-layout-top-bar) {
         position: absolute;
       }
 

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -385,7 +385,7 @@ export default class SubmodeLayout extends Component<Signature> {
         as |ResizablePanel ResizeHandle|
       >
         <ResizablePanel class='main-panel'>
-          <div class='top-bar'>
+          <div class='submode-layout-top-bar'>
             <IconButton
               @icon={{BoxelIcon}}
               @width='40px'
@@ -562,7 +562,7 @@ export default class SubmodeLayout extends Component<Signature> {
         z-index: var(--host-ai-panel-z-index);
       }
 
-      .top-bar {
+      .submode-layout-top-bar {
         width: 100%;
         padding: var(--operator-mode-spacing);
         z-index: var(--host-top-bar-z-index);

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -563,7 +563,9 @@ export default class SubmodeLayout extends Component<Signature> {
       }
 
       .submode-layout-top-bar {
+        position: relative;
         width: 100%;
+        max-width: 100%;
         padding: var(--operator-mode-spacing);
         z-index: var(--host-top-bar-z-index);
 

--- a/packages/host/app/components/operator-mode/workspace-chooser/index.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/index.gts
@@ -65,7 +65,6 @@ export default class WorkspaceChooser extends Component<Signature> {
         background-color: var(--boxel-700);
         height: 100%;
         width: 100%;
-        padding: 5.5rem 0 5.5rem 11.5rem;
         animation: fadeIn 0.5s ease-in forwards;
         z-index: var(--host-workspace-chooser-z-index);
       }
@@ -74,8 +73,8 @@ export default class WorkspaceChooser extends Component<Signature> {
         flex-direction: column;
         gap: var(--boxel-sp-lg);
         height: 100%;
+        padding: 5rem;
         overflow: auto;
-        padding-right: 5.5rem;
       }
       .workspace-chooser__title {
         color: var(--boxel-light);

--- a/packages/host/app/components/operator-mode/workspace-chooser/item-container.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/item-container.gts
@@ -24,6 +24,9 @@ const WorkspaceChooserItemContainer: TemplateOnlyComponent<Signature> =
         overflow: hidden;
         padding: 0;
       }
+      .workspace:focus-visible {
+        outline-offset: -1px;
+      }
     </style>
   </template>;
 

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -798,6 +798,9 @@ module('Acceptance | operator mode tests', function (hooks) {
       .exists();
 
     await click('[data-test-workspace-chooser-toggle]');
+
+    await percySnapshot(assert);
+
     await click('[data-test-workspace="Cardstack Catalog"]');
     await click('[data-test-submode-switcher] button');
     await click('[data-test-boxel-menu-item-text="Code"]');


### PR DESCRIPTION
Fixes:
- keep header without background, let the submode/workspace container set the background
- rename `top-bar` class, used with `:deep` selector (it collided with a card template)
- reduce padding on workspace chooser

Before (when opening from code-mode):
<img width="1219" height="130" alt="bef" src="https://github.com/user-attachments/assets/ad161684-042f-495b-80e2-f12a4462c966" />

After:
<img width="1221" height="116" alt="after" src="https://github.com/user-attachments/assets/c7189568-d633-47cd-a849-5982fcaff270" />

