### PR TITLE
Fix `_catalog-realms` endpoint to exclude published realms

### DIFF
--- a/packages/realm-server/handlers/handle-fetch-catalog-realms.ts
+++ b/packages/realm-server/handlers/handle-fetch-catalog-realms.ts
@@ -1,6 +1,6 @@
 import Koa from 'koa';
 import {
-  fetchPublicRealms,
+  fetchCatalogRealms,
   logger,
   RealmInfo,
   SupportedMimeType,
@@ -22,10 +22,10 @@ export default function handleFetchCatalogRealmsRequest({
 }: CreateRoutesArgs): (ctxt: Koa.Context, next: Koa.Next) => Promise<void> {
   return async function (ctxt: Koa.Context, _next: Koa.Next) {
     if (!catalogRealms) {
-      let publicRealms = await fetchPublicRealms(dbAdapter);
+      let catalogRealmURLs = await fetchCatalogRealms(dbAdapter);
       catalogRealms = (
         await Promise.all(
-          publicRealms.map(async ({ realm_url: realmURL }) => {
+          catalogRealmURLs.map(async ({ realm_url: realmURL }) => {
             let realmInfoResponse = await virtualNetwork.handle(
               new Request(`${realmURL}_info`, {
                 headers: {

--- a/packages/realm-server/tests/publish-unpublish-realm-test.ts
+++ b/packages/realm-server/tests/publish-unpublish-realm-test.ts
@@ -240,6 +240,23 @@ module(basename(__filename), function () {
           'index entries should reference the published realm URL',
         );
 
+        let catalogResponse = await request
+          .get('/_catalog-realms')
+          .set('Accept', 'application/vnd.api+json');
+
+        assert.strictEqual(
+          catalogResponse.status,
+          200,
+          'catalog realms HTTP 200 status',
+        );
+        let catalogRealmIds = catalogResponse.body.data.map(
+          (item: { id: string }) => item.id,
+        );
+        assert.false(
+          catalogRealmIds.includes(publishedRealmURL),
+          'catalog realms should not include the published realm',
+        );
+
         let sourceRealmPath = new URL(sourceRealmUrlString).pathname;
         let sourceRealmInfoPath = `${sourceRealmPath}_info`;
 

--- a/packages/runtime-common/realm-permission-queries.ts
+++ b/packages/runtime-common/realm-permission-queries.ts
@@ -190,9 +190,12 @@ export async function fetchUserPermissions(
   );
 }
 
-export async function fetchPublicRealms(dbAdapter: DBAdapter) {
+export async function fetchCatalogRealms(dbAdapter: DBAdapter) {
   let results = (await query(dbAdapter, [
-    `SELECT realm_url FROM realm_user_permissions WHERE username = '*' AND read = true`,
+    `SELECT rup.realm_url
+     FROM realm_user_permissions rup
+     LEFT JOIN published_realms pr ON rup.realm_url = pr.published_realm_url
+     WHERE rup.username = '*' AND rup.read = true AND pr.published_realm_url IS NULL`,
   ])) as {
     realm_url: string;
   }[];


### PR DESCRIPTION
Previously, we treated a realm with publicly readable permission as a catalog realm. However, this criterion is no longer correct, since published realms are also publicly readable, but we don’t want to include them as catalog realms. In this PR, I updated the query used to retrieve catalog realms.