### PR TITLE
host: Add scrollability to error container

### DIFF
--- a/packages/host/app/components/operator-mode/error-display.gts
+++ b/packages/host/app/components/operator-mode/error-display.gts
@@ -168,7 +168,7 @@ export default class ErrorDisplay
         min-width: fit-content;
         width: 100%;
         box-shadow: var(--boxel-deep-box-shadow);
-        overflow: hidden;
+        overflow: auto;
         display: flex;
         flex-direction: column;
         gap: var(--boxel-sp-xs);


### PR DESCRIPTION
I was unable to scroll when I encountered this error:

<img width="3568" height="2452" alt="image" src="https://github.com/user-attachments/assets/069fb330-431f-48c3-9ad5-6f53058b45e2" />

I wasn’t able to reproduce the error so I worked on this by overriding [this test error text](https://github.com/cardstack/boxel/blob/11d731814e95d91940850966716e909f739a42c8/packages/host/tests/acceptance/code-submode/card-playground-test.gts#L1441):

![screencast 2025-10-10 13-40-43](https://github.com/user-attachments/assets/251b1822-c808-4ebe-8430-764af43a95bf)
