### PR TITLE
Javascript out of memory on catalog indexing

### DIFF
--- a/packages/catalog-realm/llm-model-environment/Model/d4e5f6a7-b8c9-4012-d345-6789abcdef01.json
+++ b/packages/catalog-realm/llm-model-environment/Model/d4e5f6a7-b8c9-4012-d345-6789abcdef01.json
@@ -9,7 +9,7 @@
     },
     "meta": {
       "adoptsFrom": {
-        "module": "../model",
+        "module": "../llm-model-environment",
         "name": "Model"
       }
     }

--- a/packages/catalog-realm/music-album/MusicAlbumCard/electric-dreams.json
+++ b/packages/catalog-realm/music-album/MusicAlbumCard/electric-dreams.json
@@ -12,7 +12,7 @@
     "relationships": {},
     "meta": {
       "adoptsFrom": {
-        "module": "../music-album",
+        "module": "../music-album/music-album",
         "name": "MusicAlbumCard"
       }
     }

--- a/packages/catalog-realm/music-hub/MusicHubCard/music-hub-demo.json
+++ b/packages/catalog-realm/music-hub/MusicHubCard/music-hub-demo.json
@@ -3,7 +3,7 @@
     "meta": {
       "adoptsFrom": {
         "name": "MusicHubCard",
-        "module": "../music-hub"
+        "module": "../music-hub/music-hub"
       }
     },
     "type": "card",


### PR DESCRIPTION
But these are pointing to the wrong adoptsFrom

 https://realms-staging.stack.cards/catalog/music-hub/MusicHubCard/music-hub-dem
o.json
 https://realms-staging.stack.cards/catalog/music-album/MusicAlbumCard/electric-
dreams.json
 https://realms-staging.stack.cards/catalog/llm-model-environment/Model/d4e5f6a7
-b8c9-4012-d345-6789abcdef01.json
