### PR TITLE
Remove hostedURL from cardInfo

### DIFF
--- a/packages/base/default-templates/card-info.gts
+++ b/packages/base/default-templates/card-info.gts
@@ -157,13 +157,6 @@ class CardInfoEditor extends GlimmerComponent<EditSignature> {
             <@fields.description @format='embedded' />
           </FieldContainer>
           <FieldContainer
-            @label='Hosted URL'
-            @icon={{LinkIcon}}
-            data-test-edit-preview='cardHostedURL'
-          >
-            {{! TODO }}
-          </FieldContainer>
-          <FieldContainer
             @label='Thumbnail URL'
             @icon={{LinkIcon}}
             data-test-edit-preview='cardThumbnailURL'

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -1820,9 +1820,6 @@ module('Integration | card-basics', function (hooks) {
         .dom('[data-test-edit-preview="cardDescription"]')
         .containsText(description);
       assert
-        .dom('[data-test-edit-preview="cardHostedURL"]')
-        .hasText('Hosted URL');
-      assert
         .dom('[data-test-edit-preview="cardThumbnailURL"]')
         .hasText('Thumbnail URL');
       assert


### PR DESCRIPTION
Removed the "Hosted URL" display from cardInfo preview box. The CardInfo FieldDef already did not have that field added to the api.
<img width="838" height="522" alt="card-info" src="https://github.com/user-attachments/assets/b4c4a94e-001a-48b4-b580-3f4524fa581c" />
