### PR TITLE
server: Add multipart support for proxy

### DIFF
--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -311,6 +311,7 @@ export class SendRequestViaProxyInput extends CardDef {
   @field method = contains(StringField);
   @field requestBody = contains(StringField);
   @field headers = contains(JsonField); // optional
+  @field multipart = contains(BooleanField); // optional
 }
 
 export class SendRequestViaProxyResult extends CardDef {

--- a/packages/host/app/commands/send-request-via-proxy.ts
+++ b/packages/host/app/commands/send-request-via-proxy.ts
@@ -34,6 +34,7 @@ export default class SendRequestViaProxyCommand extends HostBaseCommand<
         method: input.method,
         requestBody: input.requestBody,
         headers: input.headers,
+        multipart: input.multipart,
       });
 
       return new SendRequestViaProxyResult({

--- a/packages/host/app/services/realm-server.ts
+++ b/packages/host/app/services/realm-server.ts
@@ -443,11 +443,13 @@ export default class RealmServerService extends Service {
     return response;
   }
 
+  // args is of type `RequestForwardBody` in realm-server/handlers/handle-request-forward
   async requestForward(args: {
     url: string;
     method: string;
     requestBody: string;
     headers?: Record<string, string>;
+    multipart?: boolean;
   }) {
     await this.login();
 

--- a/packages/realm-server/handlers/handle-request-forward.ts
+++ b/packages/realm-server/handlers/handle-request-forward.ts
@@ -16,14 +16,12 @@ import * as Sentry from '@sentry/node';
 
 const log = logger('request-forward');
 
-type ProxyRequestBody = string | Uint8Array;
-
 async function handleStreamingRequest(
   ctxt: Koa.Context,
   url: string,
   method: string,
   headers: Record<string, string>,
-  requestBody: ProxyRequestBody | undefined,
+  requestBody: BodyInit | undefined,
   endpointConfig: any,
   dbAdapter: DBAdapter,
   matrixUserId: string,
@@ -186,7 +184,7 @@ function isMultipartFileField(value: unknown): value is MultipartFileField {
 }
 
 function jsonToMultipartFormData(jsonData: Record<string, unknown>): {
-  body: Uint8Array;
+  body: BodyInit;
   boundary: string;
 } {
   const boundary = `----WebKitFormBoundary${Math.random()
@@ -385,7 +383,7 @@ export default function handleRequestForward({
         headers.Authorization = `Bearer ${destinationConfig.apiKey}`;
       }
 
-      let finalBody: RequestInit['body'] | undefined;
+      let finalBody: BodyInit | undefined;
       if (json.multipart) {
         const multipartPayload = (parsedRequestBody ?? {}) as Record<
           string,
@@ -405,7 +403,6 @@ export default function handleRequestForward({
 
         try {
           const { body, boundary } = jsonToMultipartFormData(multipartPayload);
-          // TODO convert this with proper typing
           finalBody = body;
           setContentTypeHeader(
             headers,

--- a/packages/realm-server/handlers/handle-request-forward.ts
+++ b/packages/realm-server/handlers/handle-request-forward.ts
@@ -16,12 +16,14 @@ import * as Sentry from '@sentry/node';
 
 const log = logger('request-forward');
 
+type ProxyRequestBody = string | Uint8Array;
+
 async function handleStreamingRequest(
   ctxt: Koa.Context,
   url: string,
   method: string,
   headers: Record<string, string>,
-  requestBody: any,
+  requestBody: ProxyRequestBody | undefined,
   endpointConfig: any,
   dbAdapter: DBAdapter,
   matrixUserId: string,
@@ -29,11 +31,15 @@ async function handleStreamingRequest(
   try {
     setupSSEHeaders(ctxt);
 
-    const externalResponse = await fetch(url, {
+    const fetchInit: RequestInit = {
       method,
       headers,
-      body: JSON.stringify(requestBody),
-    });
+    };
+    if (requestBody !== undefined) {
+      fetchInit.body = requestBody;
+    }
+
+    const externalResponse = await fetch(url, fetchInit);
 
     ctxt.res.write(': connected\n\n');
 
@@ -162,12 +168,105 @@ function extractSSELines(buffer: string): string[] {
   return lines;
 }
 
+interface MultipartFileField {
+  filename: string;
+  content: string;
+  contentType?: string;
+}
+
+function isMultipartFileField(value: unknown): value is MultipartFileField {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'filename' in value &&
+    'content' in value &&
+    typeof (value as { filename: unknown }).filename === 'string' &&
+    typeof (value as { content: unknown }).content === 'string'
+  );
+}
+
+function jsonToMultipartFormData(jsonData: Record<string, unknown>): {
+  body: Uint8Array;
+  boundary: string;
+} {
+  const boundary = `----WebKitFormBoundary${Math.random()
+    .toString(36)
+    .slice(2)}`;
+  const parts: Uint8Array[] = [];
+  const encoder = new TextEncoder();
+
+  const pushString = (value: string) => {
+    parts.push(encoder.encode(value));
+  };
+
+  for (const [key, value] of Object.entries(jsonData)) {
+    pushString(`--${boundary}\r\n`);
+
+    if (isMultipartFileField(value)) {
+      const fileField = value;
+      const contentType = fileField.contentType || 'application/octet-stream';
+      pushString(
+        `Content-Disposition: form-data; name="${key}"; filename="${fileField.filename}"\r\n`,
+      );
+      pushString(`Content-Type: ${contentType}\r\n\r\n`);
+      parts.push(Buffer.from(fileField.content, 'base64'));
+      pushString('\r\n');
+      continue;
+    }
+
+    const normalisedValue =
+      value === null || value === undefined
+        ? ''
+        : typeof value === 'object'
+          ? JSON.stringify(value)
+          : String(value);
+
+    pushString(`Content-Disposition: form-data; name="${key}"\r\n\r\n`);
+    pushString(normalisedValue);
+    pushString('\r\n');
+  }
+
+  pushString(`--${boundary}--\r\n`);
+
+  const totalLength = parts.reduce((sum, part) => sum + part.byteLength, 0);
+  const body = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const part of parts) {
+    body.set(part, offset);
+    offset += part.byteLength;
+  }
+
+  return {
+    body,
+    boundary,
+  };
+}
+
+function hasContentTypeHeader(headers: Record<string, string>): boolean {
+  return Object.keys(headers).some(
+    (header) => header.toLowerCase() === 'content-type',
+  );
+}
+
+function setContentTypeHeader(
+  headers: Record<string, string>,
+  value: string,
+): void {
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === 'content-type') {
+      delete headers[key];
+    }
+  }
+  headers['Content-Type'] = value;
+}
+
 interface RequestForwardBody {
   url: string;
   method: string;
   requestBody: string;
   headers?: Record<string, string>;
   stream?: boolean;
+  multipart?: boolean;
 }
 
 export default function handleRequestForward({
@@ -250,10 +349,10 @@ export default function handleRequestForward({
       }
 
       // 5. Forward request to external endpoint
-      let requestBody;
+      let parsedRequestBody: unknown;
       if (json.requestBody) {
         try {
-          requestBody = JSON.parse(json.requestBody);
+          parsedRequestBody = JSON.parse(json.requestBody);
         } catch (e) {
           await sendResponseForBadRequest(
             ctxt,
@@ -266,8 +365,7 @@ export default function handleRequestForward({
       // Build headers and URL based on authentication method
       let finalUrl = json.url;
       const headers: Record<string, string> = {
-        'Content-Type': 'application/json',
-        ...json.headers,
+        ...(json.headers ?? {}),
       };
 
       // Add authentication based on the configured method
@@ -287,6 +385,55 @@ export default function handleRequestForward({
         headers.Authorization = `Bearer ${destinationConfig.apiKey}`;
       }
 
+      // FIXME a hack to make the proxy always be multipart
+      json.multipart = true;
+
+      let finalBody: RequestInit['body'] | undefined;
+      if (json.multipart) {
+        const multipartPayload = (parsedRequestBody ?? {}) as Record<
+          string,
+          unknown
+        >;
+        if (
+          typeof multipartPayload !== 'object' ||
+          multipartPayload === null ||
+          Array.isArray(multipartPayload)
+        ) {
+          await sendResponseForBadRequest(
+            ctxt,
+            'requestBody must be a JSON object when multipart is true',
+          );
+          return;
+        }
+
+        try {
+          const { body, boundary } = jsonToMultipartFormData(multipartPayload);
+          // TODO convert this with proper typing
+          finalBody = body;
+          setContentTypeHeader(
+            headers,
+            `multipart/form-data; boundary=${boundary}`,
+          );
+        } catch (error) {
+          log.error(
+            'Error converting request body to multipart form-data:',
+            error,
+          );
+          await sendResponseForBadRequest(
+            ctxt,
+            'Failed to convert request body to multipart form-data',
+          );
+          return;
+        }
+      } else if (parsedRequestBody !== undefined) {
+        finalBody = JSON.stringify(parsedRequestBody);
+        if (!hasContentTypeHeader(headers)) {
+          setContentTypeHeader(headers, 'application/json');
+        }
+      } else if (!hasContentTypeHeader(headers)) {
+        setContentTypeHeader(headers, 'application/json');
+      }
+
       // Handle streaming requests
       if (json.stream) {
         if (!(await destinationsConfig.supportsStreaming(json.url))) {
@@ -302,7 +449,7 @@ export default function handleRequestForward({
           finalUrl,
           json.method,
           headers,
-          requestBody,
+          finalBody,
           destinationConfig,
           dbAdapter,
           matrixUserId,
@@ -317,11 +464,17 @@ export default function handleRequestForward({
       };
 
       // Only add body for non-GET requests or when requestBody is provided
-      if (json.method !== 'GET' && requestBody !== undefined) {
-        fetchOptions.body = JSON.stringify(requestBody);
+      if (json.method !== 'GET' && finalBody !== undefined) {
+        fetchOptions.body = finalBody;
       }
 
-      const externalResponse = await fetch(finalUrl, fetchOptions);
+      // FIXME undici or something is swallowing the errors, making them useless:
+      /*
+        Error in request forward handler: TypeError: fetch failed
+          at node:internal/deps/undici/undici:13510:13
+          at processTicksAndRejections (node:internal/process/task_queues:105:5)
+      */
+      const externalResponse = await globalThis.fetch(finalUrl, fetchOptions);
 
       const responseData = await externalResponse.json();
 

--- a/packages/realm-server/handlers/handle-request-forward.ts
+++ b/packages/realm-server/handlers/handle-request-forward.ts
@@ -385,9 +385,6 @@ export default function handleRequestForward({
         headers.Authorization = `Bearer ${destinationConfig.apiKey}`;
       }
 
-      // FIXME a hack to make the proxy always be multipart
-      json.multipart = true;
-
       let finalBody: RequestInit['body'] | undefined;
       if (json.multipart) {
         const multipartPayload = (parsedRequestBody ?? {}) as Record<


### PR DESCRIPTION
This is from Codex, only modified to fix/bypass some problems, which I’ll comment on directly in the code.

How to exercise this:

1. create Cloudflare API key, I used this template: Read and write to Cloudflare Stream and Images API

2. put the card definition in the Gist Chris posted in a local realm (see the comment for a required patch)

3. add to proxy_endpoints safelist in local database, replace `[API KEY]` with step 1 and `[CLOUDFLARE ENDPOINT]` with url from step 2 Gist
```
INSERT INTO "public"."proxy_endpoints"("id","url","api_key","credit_strategy","supports_streaming","auth_method","auth_parameter_name","created_at","updated_at")
VALUES
('a33d9ba4-3f5c-4a4e-ac6f-057521950d57',[CLOUDFLARE ENDPOINT],[API KEY],'no-credit',FALSE,'header','Authorization','now()','now()');
```

4. use playground to get an instance

5. press Generate URL

6. wait for Upload URL to show

7. choose image to upload (10MB or less, Cloudflare limitation)

8. press Upload Direct (FormData)