### PR TITLE
Make textarea field readonly instead of disabled when it's not editable

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -2175,7 +2175,7 @@ export class TextAreaField extends StringField {
         @value={{@model}}
         @onInput={{@set}}
         @type='textarea'
-        @disabled={{not @canEdit}}
+        @readonly={{not @canEdit}}
       />
     </template>
   };

--- a/packages/base/markdown.gts
+++ b/packages/base/markdown.gts
@@ -230,7 +230,7 @@ export default class MarkdownField extends StringField {
         @type='textarea'
         @value={{@model}}
         @onInput={{@set}}
-        @disabled={{not @canEdit}}
+        @readonly={{not @canEdit}}
       />
     </template>
   };

--- a/packages/boxel-ui/addon/src/components/input/index.gts
+++ b/packages/boxel-ui/addon/src/components/input/index.gts
@@ -58,7 +58,6 @@ export interface Signature {
     autocomplete?: string;
     bottomTreatment?: InputBottomTreatment;
     disabled?: boolean;
-    readonly?: boolean;
     errorMessage?: string;
     helperText?: string;
     id?: string;
@@ -70,6 +69,7 @@ export interface Signature {
     onKeyPress?: (ev: KeyboardEvent) => Promise<void> | void;
     optional?: boolean;
     placeholder?: string;
+    readonly?: boolean;
     required?: boolean;
     size?: 'large' | 'default';
     state?: InputValidationState;

--- a/packages/boxel-ui/addon/src/components/input/index.gts
+++ b/packages/boxel-ui/addon/src/components/input/index.gts
@@ -58,6 +58,7 @@ export interface Signature {
     autocomplete?: string;
     bottomTreatment?: InputBottomTreatment;
     disabled?: boolean;
+    readonly?: boolean;
     errorMessage?: string;
     helperText?: string;
     id?: string;
@@ -163,6 +164,7 @@ export default class BoxelInput extends Component<Signature> {
           max={{@max}}
           required={{@required}}
           disabled={{@disabled}}
+          readonly={{@readonly}}
           autocomplete={{@autocomplete}}
           aria-describedby={{if
             @helperText
@@ -242,15 +244,16 @@ export default class BoxelInput extends Component<Signature> {
         }
 
         .boxel-input {
-          --boxel-input-height: var(--boxel-form-control-height);
-
           grid-column: 1 / span 3;
           grid-row: 2;
 
           box-sizing: border-box;
           width: 100%;
           max-width: 100%;
-          min-height: var(--boxel-input-height);
+          min-height: var(
+            --boxel-input-height,
+            var(--boxel-form-control-height)
+          );
           padding: var(--boxel-sp-xs) 0 var(--boxel-sp-xs) var(--boxel-sp-sm);
           background-color: var(--background, var(--boxel-light));
           color: var(--foreground, var(--boxel-dark));
@@ -269,11 +272,18 @@ export default class BoxelInput extends Component<Signature> {
           font-size: var(--boxel-font-size);
         }
 
-        .boxel-text-area {
+        textarea {
           --boxel-input-height: 10rem;
+          resize: both;
+          overflow: auto;
         }
 
         .boxel-input:not([type='color']):disabled {
+          opacity: 0.5;
+          resize: none; /* do not display resize toggle since it's disabled */
+        }
+
+        .boxel-input:not([type='color'])[readonly] {
           opacity: 0.5;
         }
 

--- a/packages/boxel-ui/addon/src/components/input/usage.gts
+++ b/packages/boxel-ui/addon/src/components/input/usage.gts
@@ -28,6 +28,7 @@ export default class InputUsage extends Component {
   @tracked id = 'sample-input';
   @tracked value = '';
   @tracked disabled = false;
+  @tracked readonly = false;
   @tracked required = false;
   @tracked optional = false;
   @tracked placeholder = 'Please enter';
@@ -81,6 +82,7 @@ export default class InputUsage extends Component {
           @value={{this.value}}
           @onInput={{this.logValue}}
           @disabled={{this.disabled}}
+          @readonly={{this.readonly}}
           @required={{this.required}}
           @optional={{this.optional}}
           @type={{this.type}}
@@ -126,6 +128,11 @@ export default class InputUsage extends Component {
           @name='disabled'
           @value={{this.disabled}}
           @onInput={{fn (mut this.disabled)}}
+        />
+        <Args.Bool
+          @name='readonly'
+          @value={{this.readonly}}
+          @onInput={{fn (mut this.readonly)}}
         />
         <Args.Bool
           @name='required'

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -799,8 +799,6 @@ module('Acceptance | operator mode tests', function (hooks) {
 
     await click('[data-test-workspace-chooser-toggle]');
 
-    await percySnapshot(assert);
-
     await click('[data-test-workspace="Cardstack Catalog"]');
     await click('[data-test-submode-switcher] button');
     await click('[data-test-boxel-menu-item-text="Code"]');

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -100,7 +100,7 @@ module('Integration | card-basics', function (hooks) {
   });
 
   module('cards are read-only', function (_hooks) {
-    test('input fields are disabled', async function (assert) {
+    test('input fields are disabled or readonly', async function (assert) {
       class Person extends CardDef {
         @field string = contains(StringField);
         @field number = contains(NumberField);
@@ -141,10 +141,10 @@ module('Integration | card-basics', function (hooks) {
         .hasAttribute('disabled');
       assert
         .dom('[data-test-field="markdown"] textarea')
-        .hasAttribute('disabled');
+        .hasAttribute('readonly');
       assert
         .dom('[data-test-field="textArea"] textarea')
-        .hasAttribute('disabled');
+        .hasAttribute('readonly');
     });
 
     test('linksToMany field with computeVia is not editable in edit format', async function (assert) {


### PR DESCRIPTION
Previously, textarea input type content was getting cropped because `disabled` input does not allow any interaction. Making the textarea to be `readonly` allows being able to scroll the content or resize the box to be able to read the contents.