### PR TITLE
increase max-old-space-size in worker script

### DIFF
--- a/packages/realm-server/scripts/start-worker-base.sh
+++ b/packages/realm-server/scripts/start-worker-base.sh
@@ -9,7 +9,7 @@ wait_for_prerender "$PRERENDER_URL"
 
 NODE_ENV=development \
   NODE_NO_WARNINGS=1 \
-  NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=16384}" \
+  NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=4096}" \
   PGPORT=5435 \
   PGDATABASE=boxel_base \
   REALM_SECRET_SEED="shhh! it's a secret" \

--- a/packages/realm-server/scripts/start-worker-base.sh
+++ b/packages/realm-server/scripts/start-worker-base.sh
@@ -9,6 +9,7 @@ wait_for_prerender "$PRERENDER_URL"
 
 NODE_ENV=development \
   NODE_NO_WARNINGS=1 \
+  NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=16384}" \
   PGPORT=5435 \
   PGDATABASE=boxel_base \
   REALM_SECRET_SEED="shhh! it's a secret" \

--- a/packages/realm-server/scripts/start-worker-development.sh
+++ b/packages/realm-server/scripts/start-worker-development.sh
@@ -9,6 +9,7 @@ wait_for_prerender "$PRERENDER_URL"
 
 NODE_ENV=development \
   NODE_NO_WARNINGS=1 \
+  NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=16384}" \
   PGPORT=5435 \
   PGDATABASE=boxel \
   LOG_LEVELS='*=info' \

--- a/packages/realm-server/scripts/start-worker-development.sh
+++ b/packages/realm-server/scripts/start-worker-development.sh
@@ -9,7 +9,7 @@ wait_for_prerender "$PRERENDER_URL"
 
 NODE_ENV=development \
   NODE_NO_WARNINGS=1 \
-  NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=16384}" \
+  NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=4096}" \
   PGPORT=5435 \
   PGDATABASE=boxel \
   LOG_LEVELS='*=info' \

--- a/packages/realm-server/scripts/start-worker-production.sh
+++ b/packages/realm-server/scripts/start-worker-production.sh
@@ -1,7 +1,7 @@
 #! /bin/sh
 
 NODE_NO_WARNINGS=1 \
-  NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=16384}" \
+  NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=4096}" \
   REALM_SERVER_MATRIX_USERNAME=realm_server \
   ts-node \
   --transpileOnly worker-manager \

--- a/packages/realm-server/scripts/start-worker-production.sh
+++ b/packages/realm-server/scripts/start-worker-production.sh
@@ -1,6 +1,7 @@
 #! /bin/sh
 
 NODE_NO_WARNINGS=1 \
+  NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=16384}" \
   REALM_SERVER_MATRIX_USERNAME=realm_server \
   ts-node \
   --transpileOnly worker-manager \
@@ -20,4 +21,3 @@ NODE_NO_WARNINGS=1 \
   \
   --fromUrl='https://app.boxel.ai/skills/' \
   --toUrl='https://app.boxel.ai/skills/'
-

--- a/packages/realm-server/scripts/start-worker-staging.sh
+++ b/packages/realm-server/scripts/start-worker-staging.sh
@@ -1,7 +1,7 @@
 #! /bin/sh
 
 NODE_NO_WARNINGS=1 \
-  NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=16384}" \
+  NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=4096}" \
   REALM_SERVER_MATRIX_USERNAME=realm_server \
   ts-node \
   --transpileOnly worker-manager \

--- a/packages/realm-server/scripts/start-worker-staging.sh
+++ b/packages/realm-server/scripts/start-worker-staging.sh
@@ -1,6 +1,7 @@
 #! /bin/sh
 
 NODE_NO_WARNINGS=1 \
+  NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=16384}" \
   REALM_SERVER_MATRIX_USERNAME=realm_server \
   ts-node \
   --transpileOnly worker-manager \
@@ -21,4 +22,3 @@ NODE_NO_WARNINGS=1 \
   --fromUrl='https://realms-staging.stack.cards/skills/' \
   --toUrl='https://realms-staging.stack.cards/skills/' \
   
-

--- a/packages/realm-server/scripts/start-worker-test.sh
+++ b/packages/realm-server/scripts/start-worker-test.sh
@@ -11,6 +11,7 @@ NODE_ENV=test \
   PGPORT=5435 \
   PGDATABASE=boxel_test \
   NODE_NO_WARNINGS=1 \
+  NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=16384}" \
   REALM_SECRET_SEED="shhh! it's a secret" \
   REALM_SERVER_MATRIX_USERNAME=realm_server \
   ts-node \

--- a/packages/realm-server/scripts/start-worker-test.sh
+++ b/packages/realm-server/scripts/start-worker-test.sh
@@ -11,7 +11,7 @@ NODE_ENV=test \
   PGPORT=5435 \
   PGDATABASE=boxel_test \
   NODE_NO_WARNINGS=1 \
-  NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=16384}" \
+  NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=4096}" \
   REALM_SECRET_SEED="shhh! it's a secret" \
   REALM_SERVER_MATRIX_USERNAME=realm_server \
   ts-node \


### PR DESCRIPTION
This PR seems sufficient in handling the current-run javascript heap oom errors