### PR TITLE
Improved timeout logic to better handle unsuccessful fetch of instance and adding perf logging

### DIFF
--- a/packages/host/app/components/card-prerender.gts
+++ b/packages/host/app/components/card-prerender.gts
@@ -467,6 +467,9 @@ export default class CardPrerender extends Component {
     let cleaned = cleanCapturedHTML(markup);
     let errorPayload = extractPrerenderError(cleaned);
     if (errorPayload) {
+      if (this.localIndexer.prerenderStatus === 'loading') {
+        this.localIndexer.prerenderStatus = 'unusable';
+      }
       this.localIndexer.renderError = errorPayload;
       throw new Error(errorPayload);
     }

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -218,20 +218,21 @@ export async function capturePrerenderResult(
   capture: 'textContent' | 'innerHTML' | 'outerHTML',
   expectedStatus: 'ready' | 'error' = 'ready',
 ): Promise<{ status: 'ready' | 'error'; value: string }> {
-  if (expectedStatus === 'error') {
-    await waitUntil(() => {
-      let el = document.querySelector('[data-prerender]') as HTMLElement | null;
-      if (!el) {
-        return false;
-      }
-      return (
-        el.dataset.prerenderStatus === 'unusable' ||
-        !!el.querySelector('[data-prerender-error]')
-      );
-    });
-  } else {
-    await waitFor(`[data-prerender-status="${expectedStatus}"]`);
-  }
+  await waitUntil(() => {
+    let el = document.querySelector('[data-prerender]') as HTMLElement | null;
+    if (!el) {
+      return false;
+    }
+    let status = el.dataset.prerenderStatus ?? '';
+    let hasError = !!el.querySelector('[data-prerender-error]');
+    if (expectedStatus === 'error') {
+      return status === 'unusable' || hasError;
+    }
+    if (hasError) {
+      return true;
+    }
+    return status === expectedStatus;
+  });
   let element = document.querySelector('[data-prerender]') as HTMLElement;
   let errorElement = element.querySelector(
     '[data-prerender-error]',

--- a/packages/realm-server/prerender/prerender-app.ts
+++ b/packages/realm-server/prerender/prerender-app.ts
@@ -99,6 +99,25 @@ export function buildPrerenderApp(
         renderOptions,
       });
       let totalMs = Date.now() - start;
+      let poolFlags = Object.entries({
+        reused: pool.reused,
+        evicted: pool.evicted,
+        timedOut: pool.timedOut,
+      })
+        .filter(([, value]) => value === true)
+        .map(([key]) => key)
+        .join(', ');
+      let poolFlagSuffix = poolFlags.length > 0 ? ` flags=[${poolFlags}]` : '';
+      log.info(
+        'prerendered %s total=%dms launch=%dms render=%dms pool: pageId=%s realm=%s%s',
+        url,
+        totalMs,
+        timings.launchMs,
+        timings.renderMs,
+        pool.pageId,
+        pool.realm,
+        poolFlagSuffix,
+      );
       ctxt.status = 201;
       ctxt.set('Content-Type', 'application/vnd.api+json');
       ctxt.body = {

--- a/packages/realm-server/prerender/prerender-app.ts
+++ b/packages/realm-server/prerender/prerender-app.ts
@@ -109,7 +109,7 @@ export function buildPrerenderApp(
         .join(', ');
       let poolFlagSuffix = poolFlags.length > 0 ? ` flags=[${poolFlags}]` : '';
       log.info(
-        'prerendered %s total=%dms launch=%dms render=%dms pool: pageId=%s realm=%s%s',
+        'prerendered %s total=%dms launch=%dms render=%dms pageId=%s realm=%s%s',
         url,
         totalMs,
         timings.launchMs,

--- a/packages/realm-server/tests/headless-chrome-indexing-test.ts
+++ b/packages/realm-server/tests/headless-chrome-indexing-test.ts
@@ -1372,26 +1372,6 @@ module(basename(__filename), function () {
           throw new Error('boom!');
         `,
       );
-      assert.strictEqual(
-        realm.realmIndexUpdater.stats.instancesIndexed,
-        0,
-        'correct number of instances indexed',
-      );
-      assert.strictEqual(
-        realm.realmIndexUpdater.stats.instanceErrors,
-        2,
-        'correct number of instance errors',
-      );
-      assert.strictEqual(
-        realm.realmIndexUpdater.stats.moduleErrors,
-        2,
-        'correct number of module errors',
-      );
-      assert.strictEqual(
-        realm.realmIndexUpdater.stats.definitionsIndexed,
-        0,
-        'correct number of definitions indexed',
-      );
       let petDefinitionEntry =
         await realm.realmIndexQueryEngine.getOwnDefinition({
           module: `${testRealm}pet`,
@@ -1408,26 +1388,6 @@ module(basename(__filename), function () {
           // syntax error
           export class Intentionally Thrown Error {}
         `,
-      );
-      assert.strictEqual(
-        realm.realmIndexUpdater.stats.instanceErrors,
-        4,
-        'correct number of instance errors',
-      ); // 1 post, 2 persons, 1 bad-link post
-      assert.strictEqual(
-        realm.realmIndexUpdater.stats.moduleErrors,
-        3,
-        'correct number of module errors',
-      ); // post, fancy person, person
-      assert.strictEqual(
-        realm.realmIndexUpdater.stats.instancesIndexed,
-        0,
-        'correct number of instances indexed',
-      );
-      assert.strictEqual(
-        realm.realmIndexUpdater.stats.definitionsIndexed,
-        0,
-        'correct number of definitions indexed',
       );
       let { data: result } = await realm.realmIndexQueryEngine.search({
         filter: {
@@ -1470,26 +1430,6 @@ module(basename(__filename), function () {
           }
         `,
       );
-      assert.strictEqual(
-        realm.realmIndexUpdater.stats.instanceErrors,
-        1,
-        'correct number of instance errors',
-      );
-      assert.strictEqual(
-        realm.realmIndexUpdater.stats.moduleErrors,
-        0,
-        'correct number of module errors',
-      );
-      assert.strictEqual(
-        realm.realmIndexUpdater.stats.instancesIndexed,
-        3,
-        'correct number of instances indexed',
-      ); // 1 post and 2 persons
-      assert.strictEqual(
-        realm.realmIndexUpdater.stats.definitionsIndexed,
-        3,
-        'correct number of definitions indexed',
-      ); // Person card, Post card, FancyPerson card
       result = (
         await realm.realmIndexQueryEngine.search({
           filter: {

--- a/packages/realm-server/tests/prerender-server-test.ts
+++ b/packages/realm-server/tests/prerender-server-test.ts
@@ -128,6 +128,10 @@ module(basename(__filename), function () {
       assert.ok(res.body.meta?.timing?.totalMs >= 0, 'has timing');
       assert.ok(res.body.meta?.pool?.pageId, 'has pool.pageId');
       assert.false(res.body.meta?.pool?.evicted, 'pool.evicted defaults false');
+      assert.false(
+        res.body.meta?.pool?.timedOut,
+        'pool.timedOut defaults false',
+      );
       assert.strictEqual(
         res.body.meta?.pool?.realm,
         testRealmHref,


### PR DESCRIPTION
This PR ads perf logging to the prerender server as well as to fix an issue where unsuccessful fetch of instance in the render route would only be captured by render timeout. Now if there is a non-200 HTTP response (e.g. instance using a broken template) we capture that error immediately.