### PR TITLE
Optimization: when logging into realms in bulk, do not authenticate to published realms

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -402,6 +402,7 @@ jobs:
             "delete-boxel-claimed-domain-test.ts",
             "get-boxel-claimed-domain-test.ts",
             "realm-auth-test.ts",
+            "queries-test.ts",
           ]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -37,3 +37,4 @@ import './get-boxel-claimed-domain-test';
 import './claim-boxel-domain-test';
 import './delete-boxel-claimed-domain-test';
 import './realm-auth-test';
+import './queries-test';

--- a/packages/realm-server/tests/queries-test.ts
+++ b/packages/realm-server/tests/queries-test.ts
@@ -1,0 +1,144 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import { v4 as uuidv4 } from 'uuid';
+
+import { PgAdapter } from '@cardstack/postgres';
+import {
+  asExpressions,
+  fetchUserPermissions,
+  insert,
+  insertPermissions,
+  query,
+} from '@cardstack/runtime-common';
+
+import { setupDB } from './helpers';
+
+module(basename(__filename), function () {
+  module('fetchUserPermissions', function (hooks) {
+    let dbAdapter: PgAdapter;
+
+    setupDB(hooks, {
+      beforeEach: async (
+        _dbAdapter: PgAdapter,
+        _publisher,
+        _runner,
+      ): Promise<void> => {
+        dbAdapter = _dbAdapter;
+      },
+    });
+
+    async function insertPublishedRealm({
+      sourceRealmURL,
+      publishedRealmURL,
+    }: {
+      sourceRealmURL: string;
+      publishedRealmURL: string;
+    }) {
+      let publishedRealmId = uuidv4();
+      let { nameExpressions, valueExpressions } = asExpressions({
+        id: publishedRealmId,
+        owner_username: '@realm/published-owner',
+        source_realm_url: sourceRealmURL,
+        published_realm_url: publishedRealmURL,
+        last_published_at: Date.now().toString(),
+      });
+      await query(
+        dbAdapter,
+        insert('published_realms', nameExpressions, valueExpressions),
+      );
+    }
+
+    test('can fetch only own realms, filtering out public and published realms', async function (assert) {
+      const ownerUserId = '@owner:localhost';
+      const sourceRealmURL = 'http://example.com/source/';
+      const publishedRealmURL = 'http://example.com/published/';
+      const publicRealmURL = 'http://example.com/public/';
+
+      await insertPermissions(dbAdapter, new URL(sourceRealmURL), {
+        [ownerUserId]: ['read', 'write', 'realm-owner'],
+      });
+
+      await insertPermissions(dbAdapter, new URL(publicRealmURL), {
+        '*': ['read'],
+      });
+
+      await insertPublishedRealm({ sourceRealmURL, publishedRealmURL });
+      await insertPermissions(dbAdapter, new URL(publishedRealmURL), {
+        [ownerUserId]: ['read', 'realm-owner'],
+        '*': ['read'],
+      });
+
+      let permissions = await fetchUserPermissions(dbAdapter, {
+        userId: ownerUserId,
+        onlyOwnRealms: true,
+      });
+
+      assert.deepEqual(
+        permissions[sourceRealmURL],
+        ['read', 'write', 'realm-owner'],
+        'includes owner realm permissions',
+      );
+      assert.false(
+        publicRealmURL in permissions,
+        'filters out public realms when onlyOwnRealms is true',
+      );
+      assert.false(
+        publishedRealmURL in permissions,
+        'filters out published realms for owner',
+      );
+    });
+
+    test('can fetch own and public realms together while filtering published realms', async function (assert) {
+      const ownerUserId = '@owner:localhost';
+      const sourceRealmURL = 'http://example.com/source/';
+      const publicRealmURL = 'http://example.com/public/';
+      const publishedRealmURL = 'http://example.com/published/';
+      const sourceRealmPublicURL = 'http://example.com/source-public/';
+
+      await insertPermissions(dbAdapter, new URL(sourceRealmURL), {
+        [ownerUserId]: ['read', 'write', 'realm-owner'],
+      });
+
+      await insertPermissions(dbAdapter, new URL(sourceRealmPublicURL), {
+        [ownerUserId]: ['read'],
+      });
+
+      await insertPermissions(dbAdapter, new URL(publicRealmURL), {
+        '*': ['read'],
+      });
+
+      await insertPublishedRealm({
+        sourceRealmURL,
+        publishedRealmURL,
+      });
+      await insertPermissions(dbAdapter, new URL(publishedRealmURL), {
+        [ownerUserId]: ['read', 'realm-owner'],
+        '*': ['read'],
+      });
+
+      let permissions = await fetchUserPermissions(dbAdapter, {
+        userId: ownerUserId,
+      });
+
+      assert.deepEqual(
+        permissions[sourceRealmURL],
+        ['read', 'write', 'realm-owner'],
+        'includes owner realm with full permissions',
+      );
+      assert.deepEqual(
+        permissions[publicRealmURL],
+        ['read'],
+        'includes public realm permissions',
+      );
+      assert.deepEqual(
+        permissions[sourceRealmPublicURL],
+        ['read'],
+        'includes direct read permissions for owned realm without write access',
+      );
+      assert.false(
+        publishedRealmURL in permissions,
+        'filters out published realms when fetching all permissions',
+      );
+    });
+  });
+});

--- a/packages/runtime-common/db-queries/realm-permission-queries.ts
+++ b/packages/runtime-common/db-queries/realm-permission-queries.ts
@@ -145,7 +145,8 @@ export async function fetchUserPermissions(
     permissions = (await query(dbAdapter, [
       `SELECT realm_url, read, write, realm_owner FROM realm_user_permissions WHERE username =`,
       param(userId),
-      `AND realm_owner = true`,
+      `AND realm_owner = true
+       AND realm_url NOT IN (SELECT published_realm_url FROM published_realms)`,
     ])) as {
       realm_url: string;
       read: boolean;
@@ -158,11 +159,13 @@ export async function fetchUserPermissions(
     permissions = (await query(dbAdapter, [
       `SELECT realm_url, read, write, realm_owner FROM realm_user_permissions WHERE username =`,
       param(userId),
-      `UNION
+      `AND realm_url NOT IN (SELECT published_realm_url FROM published_realms)
+       UNION
        SELECT realm_url, true as read, false as write, false as realm_owner FROM realm_user_permissions WHERE username = '*' AND read = true
        AND realm_url NOT IN (SELECT realm_url FROM realm_user_permissions WHERE username =`,
       param(userId),
-      `)`,
+      `)
+       AND realm_url NOT IN (SELECT published_realm_url FROM published_realms)`,
     ])) as {
       realm_url: string;
       read: boolean;


### PR DESCRIPTION
Previously, when logging into multiple realms, it tried to get jwts for all realms with public read, which included published realms. I think this is not a good idea since the amount of published realms will grow, resulting in choking the login process. So now we only login to own realms and catalog realms.