### PR TITLE
StructuredTheme card improvements

### DIFF
--- a/packages/base/contains-many-component.gts
+++ b/packages/base/contains-many-component.gts
@@ -348,6 +348,11 @@ export function getContainsManyComponent({
           .containsMany-field.atom-format > .containsMany-item {
             display: inline;
           }
+          .containsMany-field.embedded-format
+            > .containsMany-item
+            + .containsMany-item {
+            margin-top: var(--boxel-sp);
+          }
         }
       </style>
     </template>

--- a/packages/base/structured-theme-variables.gts
+++ b/packages/base/structured-theme-variables.gts
@@ -1,4 +1,8 @@
 import { CopyButton } from '@cardstack/boxel-ui/components';
+import {
+  entriesToCssRuleMap,
+  type CssVariableEntry,
+} from '@cardstack/boxel-ui/helpers';
 
 import {
   field,
@@ -11,6 +15,7 @@ import {
 } from './card-api';
 import ColorField from './color';
 import CSSValueField from './css-value';
+import type { CssRuleMap } from '@cardstack/boxel-ui/helpers';
 
 function dasherize(str: string): string {
   return str
@@ -21,15 +26,14 @@ function dasherize(str: string): string {
 
 type FieldNameType = keyof FieldsTypeFor<ThemeVarField> & string;
 
-interface CssVariableField {
+interface CssVariableField extends CssVariableEntry {
   fieldName: FieldNameType;
   cssVariableName: string;
   component?: BoxComponent;
-  value: string | undefined | null;
 }
 
 class Embedded extends Component<typeof ThemeVarField> {
-  private get cssFields() {
+  private get cssFields(): CssVariableField[] | undefined {
     let fields = this.args.fields;
     let cssFields = this.args.model.cssVariableFields;
     cssFields = cssFields?.map((f) => ({
@@ -192,19 +196,30 @@ export default class ThemeVarField extends FieldDef {
     if (!fields) {
       return;
     }
+
     let fieldNames = Object.keys(fields) as FieldNameType[];
     if (!fieldNames?.length) {
       return;
     }
     let cssVariableFields: CssVariableField[] = [];
     for (let fieldName of fieldNames) {
+      let cssVariableName = `--${dasherize(fieldName)}`;
+      let value = this?.[fieldName] as string | undefined | null;
       cssVariableFields.push({
         fieldName,
-        cssVariableName: `--${dasherize(fieldName)}`,
-        value: this?.[fieldName] as string | undefined | null,
+        cssVariableName,
+        name: cssVariableName,
+        value,
       });
     }
     return cssVariableFields;
+  }
+
+  get cssRuleMap(): CssRuleMap | undefined {
+    if (!entriesToCssRuleMap) {
+      return;
+    }
+    return entriesToCssRuleMap(this.cssVariableFields);
   }
 
   static embedded = Embedded;

--- a/packages/base/structured-theme-variables.gts
+++ b/packages/base/structured-theme-variables.gts
@@ -58,7 +58,10 @@ class Embedded extends Component<typeof ThemeVarField> {
         </div>
         <div class='code-preview'>
           {{#if field.value}}
-            <span class='css-value'><field.component /></span>
+            <span
+              class='css-value'
+              data-test-var-value={{field.fieldName}}
+            ><field.component /></span>
             <CopyButton
               class='copy-button'
               @textToCopy={{field.value}}

--- a/packages/base/structured-theme.gts
+++ b/packages/base/structured-theme.gts
@@ -1,3 +1,4 @@
+import GlimmerComponent from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
@@ -7,6 +8,7 @@ import {
   BoxelContainer,
   GridContainer,
   BoxelInput,
+  CopyButton,
 } from '@cardstack/boxel-ui/components';
 import {
   buildCssGroups,
@@ -14,6 +16,8 @@ import {
   parseCssGroups,
   type CssRuleMap,
 } from '@cardstack/boxel-ui/helpers';
+import CaretUp from '@cardstack/boxel-icons/chevron-up';
+import CaretDown from '@cardstack/boxel-icons/chevron-down';
 
 import {
   field,
@@ -24,6 +28,57 @@ import {
   type BaseDefComponent,
 } from './card-api';
 import ThemeVarField from './structured-theme-variables';
+
+interface SectionToggleSignature {
+  Args: {
+    expanded: boolean;
+    onToggle: (event: Event) => void;
+  };
+  Element: HTMLButtonElement;
+}
+
+class SectionToggleButton extends GlimmerComponent<SectionToggleSignature> {
+  <template>
+    <BoxelButton
+      class='section-toggle'
+      @kind='text-only'
+      @size='auto'
+      aria-expanded={{@expanded}}
+      {{on 'click' @onToggle}}
+      ...attributes
+    >
+      <span class='section-toggle__label'>{{if @expanded 'Hide' 'Show'}}</span>
+      {{#if @expanded}}
+        <CaretUp width='14' height='14' role='presentation' />
+      {{else}}
+        <CaretDown width='14' height='14' role='presentation' />
+      {{/if}}
+    </BoxelButton>
+
+    <style scoped>
+      @layer baseComponent {
+        .section-toggle {
+          display: inline-flex;
+          align-items: center;
+          gap: var(--boxel-sp-xxxs);
+          padding: var(--boxel-sp-5xs) var(--boxel-sp-xs);
+          background: none;
+          border: none;
+          min-height: 1.5rem;
+        }
+        .section-toggle:hover {
+          color: var(--primary);
+          text-decoration: underline;
+        }
+        .section-toggle__label {
+          font-size: var(--boxel-font-size-xs);
+          line-height: 1;
+          text-transform: uppercase;
+        }
+      }
+    </style>
+  </template>
+}
 
 // Applies parsed CSS rules back onto the card fields for editing.
 const applyCssRulesToField = (
@@ -50,29 +105,34 @@ const applyCssRulesToField = (
 };
 
 class Isolated extends Component<typeof StructuredTheme> {
-  @tracked isGeneratedCSSVisible = true;
+  @tracked isCssTextareaVisible = true;
   @tracked isRootVariablesVisible = true;
   @tracked isDarkVariablesVisible = true;
-  @tracked isCssTextareaVisible = true;
+  @tracked areCSSImportsVisible = true;
+  @tracked isGeneratedCSSVisible = true;
 
-  @action toggleGeneratedCSSVisibility() {
-    this.isGeneratedCSSVisible = !this.isGeneratedCSSVisible;
-  }
-
-  @action toggleRootVariablesVisibility() {
-    this.isRootVariablesVisible = !this.isRootVariablesVisible;
-  }
-
-  @action toggleDarkVariablesVisibility() {
-    this.isDarkVariablesVisible = !this.isDarkVariablesVisible;
-  }
-
-  @action toggleCssTextareaVisibility() {
+  @action toggleCssTextarea() {
     this.isCssTextareaVisible = !this.isCssTextareaVisible;
   }
 
+  @action toggleRootVariables() {
+    this.isRootVariablesVisible = !this.isRootVariablesVisible;
+  }
+
+  @action toggleDarkVariables() {
+    this.isDarkVariablesVisible = !this.isDarkVariablesVisible;
+  }
+
+  @action toggleCSSImports() {
+    this.areCSSImportsVisible = !this.areCSSImportsVisible;
+  }
+
+  @action toggleGeneratedCSS() {
+    this.isGeneratedCSSVisible = !this.isGeneratedCSSVisible;
+  }
+
   @action parseCss(content: string) {
-    if (!content) {
+    if (!content || !parseCssGroups) {
       return;
     }
     const groups = parseCssGroups(content);
@@ -86,6 +146,14 @@ class Isolated extends Component<typeof StructuredTheme> {
     );
   }
 
+  private cssPlaceholder = `:root {
+  /* ... */
+}
+
+.dark {
+  /* ... */
+}`;
+
   <template>
     <GridContainer @tag='article' class='structured-theme-card'>
       <BoxelContainer @tag='header' @display='flex' class='theme-header'>
@@ -97,41 +165,44 @@ class Isolated extends Component<typeof StructuredTheme> {
 
       <GridContainer @tag='section' class='content-section'>
         <GridContainer @tag='header' class='section-header'>
-          <h2>CSS Variables</h2>
-          <BoxelButton
-            @kind='text-only'
-            @size='extra-small'
-            class='section-toggle'
-            aria-expanded={{this.isCssTextareaVisible}}
-            aria-controls='css-variables-content'
-            {{on 'click' this.toggleCssTextareaVisibility}}
-          >
-            {{if this.isCssTextareaVisible 'Hide' 'Show'}}
-          </BoxelButton>
+          <h2>Insert CSS Variables</h2>
+          <SectionToggleButton
+            @expanded={{this.isCssTextareaVisible}}
+            @onToggle={{this.toggleCssTextarea}}
+            aria-controls='insert-css-content'
+          />
         </GridContainer>
         {{#if this.isCssTextareaVisible}}
-          <div id='css-variables-content' class='section-body'>
-            <BoxelInput @type='textarea' @onInput={{this.parseCss}} />
+          <div id='insert-css-content' class='section-body'>
+            <label for='css-textarea' class='boxel-sr-only'>Insert CSS Variables</label>
+            <BoxelInput
+              id='css-textarea'
+              @type='textarea'
+              @onInput={{this.parseCss}}
+              @placeholder={{this.cssPlaceholder}}
+              class='css-textarea'
+              data-test-custom-css-variables
+            />
           </div>
+
         {{/if}}
       </GridContainer>
 
       <GridContainer @tag='section' class='content-section'>
         <GridContainer @tag='header' class='section-header'>
           <h2>Root Variables (:root)</h2>
-          <BoxelButton
-            @kind='text-only'
-            @size='extra-small'
-            class='section-toggle'
-            aria-expanded={{this.isRootVariablesVisible}}
+          <SectionToggleButton
+            @expanded={{this.isRootVariablesVisible}}
+            @onToggle={{this.toggleRootVariables}}
             aria-controls='root-variables-content'
-            {{on 'click' this.toggleRootVariablesVisibility}}
-          >
-            {{if this.isRootVariablesVisible 'Hide' 'Show'}}
-          </BoxelButton>
+          />
         </GridContainer>
         {{#if this.isRootVariablesVisible}}
-          <div id='root-variables-content' class='section-body'>
+          <div
+            id='root-variables-content'
+            class='section-body'
+            data-test-root-vars
+          >
             <@fields.rootVariables />
           </div>
         {{/if}}
@@ -140,19 +211,18 @@ class Isolated extends Component<typeof StructuredTheme> {
       <GridContainer @tag='section' class='content-section'>
         <GridContainer @tag='header' class='section-header'>
           <h2>Dark Mode Variables (.dark)</h2>
-          <BoxelButton
-            @kind='text-only'
-            @size='extra-small'
-            class='section-toggle'
-            aria-expanded={{this.isDarkVariablesVisible}}
+          <SectionToggleButton
+            @expanded={{this.isDarkVariablesVisible}}
+            @onToggle={{this.toggleDarkVariables}}
             aria-controls='dark-variables-content'
-            {{on 'click' this.toggleDarkVariablesVisibility}}
-          >
-            {{if this.isDarkVariablesVisible 'Hide' 'Show'}}
-          </BoxelButton>
+          />
         </GridContainer>
         {{#if this.isDarkVariablesVisible}}
-          <div id='dark-variables-content' class='section-body'>
+          <div
+            id='dark-variables-content'
+            class='section-body'
+            data-test-dark-vars
+          >
             <@fields.darkModeVariables />
           </div>
         {{/if}}
@@ -160,17 +230,32 @@ class Isolated extends Component<typeof StructuredTheme> {
 
       <GridContainer @tag='section' class='content-section'>
         <GridContainer @tag='header' class='section-header'>
-          <h2>All CSS Variables</h2>
-          <BoxelButton
-            @kind='text-only'
-            @size='extra-small'
-            class='section-toggle'
-            aria-expanded={{this.isGeneratedCSSVisible}}
+          <h2>CSS Imports</h2>
+          <SectionToggleButton
+            @expanded={{this.areCSSImportsVisible}}
+            @onToggle={{this.toggleCSSImports}}
+            aria-controls='css-imports-content'
+          />
+        </GridContainer>
+        {{#if this.areCSSImportsVisible}}
+          <div id='css-imports-content' class='section-body'>
+            {{#if @model.cssImports}}
+              <@fields.cssImports />
+            {{else}}
+              <em>None</em>
+            {{/if}}
+          </div>
+        {{/if}}
+      </GridContainer>
+
+      <GridContainer @tag='section' class='content-section'>
+        <GridContainer @tag='header' class='section-header'>
+          <h2>Calculated CSS Variables</h2>
+          <SectionToggleButton
+            @expanded={{this.isGeneratedCSSVisible}}
+            @onToggle={{this.toggleGeneratedCSS}}
             aria-controls='generated-css-content'
-            {{on 'click' this.toggleGeneratedCSSVisibility}}
-          >
-            {{if this.isGeneratedCSSVisible 'Hide' 'Show'}}
-          </BoxelButton>
+          />
         </GridContainer>
         {{#if this.isGeneratedCSSVisible}}
           <div
@@ -178,7 +263,13 @@ class Isolated extends Component<typeof StructuredTheme> {
             class='section-body'
             data-test-css-vars
           >
-            <@fields.cssVariables />
+            <div class='generates-css-container'>
+              <CopyButton
+                class='copy-css-variables-button'
+                @textToCopy={{@model.cssVariables}}
+              />
+              <@fields.cssVariables />
+            </div>
           </div>
         {{/if}}
       </GridContainer>
@@ -192,17 +283,18 @@ class Isolated extends Component<typeof StructuredTheme> {
       h1,
       h2 {
         margin: 0;
-        font-weight: var(--boxel-font-weight-semibold);
       }
 
       h1 {
         font-size: var(--boxel-font-size-xl);
         line-height: var(--boxel-line-height-xl);
+        font-weight: var(--boxel-font-weight-semibold);
       }
 
       h2 {
         font-size: var(--boxel-font-size-lg);
         line-height: var(--boxel-line-height-lg);
+        font-weight: var(--boxel-font-weight-medium);
       }
 
       .structured-theme-card {
@@ -238,21 +330,25 @@ class Isolated extends Component<typeof StructuredTheme> {
         align-items: center;
       }
 
-      .section-toggle {
-        padding: var(--boxel-sp-5xs) var(--boxel-sp-xxxs);
-        color: var(--primary);
-        background: transparent;
-        border: none;
-        text-transform: uppercase;
-      }
-
-      .section-toggle:hover,
-      .section-toggle:focus-visible {
-        text-decoration: underline;
-      }
-
       .section-body {
         animation: fade-in 120ms ease-out;
+      }
+
+      .css-textarea {
+        font-family: var(
+          --font-mono,
+          var(--boxel-monospace-font-family, monospace)
+        );
+      }
+
+      .generates-css-container {
+        position: relative;
+      }
+      .copy-css-variables-button {
+        position: absolute;
+        top: 0;
+        right: 0;
+        color: var(--primary);
       }
 
       @keyframes fade-in {

--- a/packages/boxel-ui/addon/src/components/color-picker/index.gts
+++ b/packages/boxel-ui/addon/src/components/color-picker/index.gts
@@ -33,6 +33,7 @@ export default class ColorPicker extends Component<Signature> {
           @value={{@color}}
           @onInput={{@onChange}}
           @disabled={{@disabled}}
+          data-test-color-input
         />
       </label>
 
@@ -42,6 +43,7 @@ export default class ColorPicker extends Component<Signature> {
         @onInput={{@onChange}}
         @disabled={{@disabled}}
         @placeholder={{@placeholder}}
+        data-test-color-text-input
       />
 
       {{#if @color}}
@@ -53,6 +55,7 @@ export default class ColorPicker extends Component<Signature> {
             @height='16px'
             {{on 'click' this.remove}}
             aria-label='Unset color'
+            data-test-remove-color
           />
         {{/unless}}
       {{/if}}

--- a/packages/boxel-ui/addon/src/components/copy-button/index.gts
+++ b/packages/boxel-ui/addon/src/components/copy-button/index.gts
@@ -1,11 +1,10 @@
+import Copy from '@cardstack/boxel-icons/copy';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
+import type { MiddlewareState } from '@floating-ui/dom';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { task } from 'ember-concurrency';
-import { taskFor } from 'ember-concurrency-ts';
 
-import Copy from '../../icons/copy.gts';
 import IconButton from '../icon-button/index.gts';
 import Tooltip from '../tooltip/index.gts';
 
@@ -13,6 +12,8 @@ interface Signature {
   Args: {
     ariaLabel?: string;
     height?: string;
+    offset?: number;
+    placement?: MiddlewareState['placement'];
     textToCopy: string;
     width?: string;
   };
@@ -20,41 +21,43 @@ interface Signature {
 }
 
 export default class CopyButton extends Component<Signature> {
-  @tracked recentlyCopied = false;
+  @tracked private recentlyCopied = false;
 
-  @task
-  private *copyToClipboardTask(this: CopyButton) {
-    yield navigator.clipboard.writeText(this.args.textToCopy);
-    this.recentlyCopied = true;
+  @action private async copyToClipboard() {
+    try {
+      await navigator.clipboard.writeText(this.args.textToCopy);
+      this.recentlyCopied = true;
 
-    setTimeout(() => (this.recentlyCopied = false), 2000);
-  }
-
-  @action
-  private copyToClipboard() {
-    taskFor(this.copyToClipboardTask).perform();
+      setTimeout(() => (this.recentlyCopied = false), 2000);
+    } catch (error: unknown) {
+      console.error(error instanceof Error ? error.message : error);
+    }
   }
 
   <template>
-    <Tooltip @placement='top' class='copy-button-tooltip'>
+    <Tooltip
+      @placement={{@placement}}
+      @offset={{@offset}}
+      class='boxel-copy-button-tooltip'
+      ...attributes
+    >
       <:trigger>
         <IconButton
           @icon={{Copy}}
-          width={{unless @width '18px'}}
-          height={{unless @height '18px'}}
+          @width={{@width}}
+          @height={{@height}}
           {{on 'click' this.copyToClipboard}}
-          aria-label='{{if
+          class='boxel-copy-button'
+          aria-label={{if
             this.recentlyCopied
-            "Copied!"
-            (if @ariaLabel @ariaLabel "Copy to clipboard")
-          }}'
-          aria-labelledby='copy-button-content'
+            'Copied'
+            (if @ariaLabel @ariaLabel 'Copy to clipboard')
+          }}
           data-test-boxel-copy-button
-          ...attributes
         />
       </:trigger>
       <:content>
-        <span id='copy-button-content'>
+        <span>
           {{if this.recentlyCopied 'Copied!' 'Copy to clipboard'}}
         </span>
       </:content>

--- a/packages/boxel-ui/addon/src/components/swatch/index.gts
+++ b/packages/boxel-ui/addon/src/components/swatch/index.gts
@@ -13,7 +13,11 @@ interface Signature {
 }
 
 const Swatch: TemplateOnlyComponent<Signature> = <template>
-  <div class={{cn 'swatch' small=(eq @style 'round')}} ...attributes>
+  <div
+    class={{cn 'swatch' small=(eq @style 'round')}}
+    data-test-swatch={{@color}}
+    ...attributes
+  >
     {{#unless @hideLabel}}
       <div class='label'>
         {{#if @label}}

--- a/packages/boxel-ui/addon/src/helpers.ts
+++ b/packages/boxel-ui/addon/src/helpers.ts
@@ -6,7 +6,10 @@ import cssVar from './helpers/css-var.ts';
 import currencyFormat from './helpers/currency-format.ts';
 import { dayjsFormat } from './helpers/dayjs-format.ts';
 import element from './helpers/element.ts';
-import { extractCssVariables } from './helpers/extract-css-variables.ts';
+import {
+  extractCssVariables,
+  parseCssGroups,
+} from './helpers/extract-css-variables.ts';
 import formatAge from './helpers/format-age.ts';
 import formatCountdown from './helpers/format-countdown.ts';
 import formatCurrency from './helpers/format-currency.ts';
@@ -33,6 +36,15 @@ import pick from './helpers/pick.ts';
 import { sanitizeHtml, sanitizeHtmlSafe } from './helpers/sanitize-html.ts';
 import { substring } from './helpers/string.ts';
 import {
+  type CssGroupInput,
+  type CssGroups,
+  type CssRuleMap,
+  type CssVariableEntry,
+  buildCssGroups,
+  entriesToCssRuleMap,
+  normalizeCssRuleMap,
+} from './helpers/theme-css.ts';
+import {
   and,
   bool,
   eq,
@@ -45,10 +57,10 @@ import {
 } from './helpers/truth-helpers.ts';
 
 export {
-  type MenuItemOptions,
   add,
   and,
   bool,
+  buildCssGroups,
   cn,
   compact,
   copyCardURLToClipboard,
@@ -57,6 +69,7 @@ export {
   dayjsFormat,
   divide,
   element,
+  entriesToCssRuleMap,
   eq,
   extractCssVariables,
   formatAge,
@@ -83,13 +96,23 @@ export {
   menuItem,
   menuItemFunc,
   multiply,
+  normalizeCssRuleMap,
   not,
   optional,
   or,
+  parseCssGroups,
   pick,
   sanitizeHtml,
   sanitizeHtmlSafe,
   substring,
   subtract,
   toMenuItems,
+};
+
+export type {
+  CssGroupInput,
+  CssGroups,
+  CssRuleMap,
+  CssVariableEntry,
+  MenuItemOptions,
 };

--- a/packages/boxel-ui/addon/src/helpers/extract-css-variables.ts
+++ b/packages/boxel-ui/addon/src/helpers/extract-css-variables.ts
@@ -1,89 +1,109 @@
-function normalizeSelector(selectorName: string): string {
-  const selector = selectorName.trim();
-  if (selector === ':root' || selector === 'root') {
-    return ':root';
-  }
-  if (selector === '.dark') {
-    return '.dark';
-  }
-  if (selector.startsWith('@theme')) {
-    return selector;
-  }
-  return selector;
-}
+import {
+  type CssGroups,
+  type CssRuleMap,
+  normalizeCssValue,
+  normalizeSelector,
+} from './theme-css.ts';
 
-function parseCssRules(rules?: string): Map<string, string> | undefined {
+const COMMENT_PATTERN = /\/\*[\s\S]*?\*\//g;
+const BLOCK_PATTERN = /(.*?)\{([\s\S]*?)\}/g;
+const PROPERTY_PATTERN = /^[a-z-]+$/i;
+
+// Turns a CSS declaration block into a property-value map.
+const parseCssDeclarations = (rules?: string): CssRuleMap | undefined => {
   if (!rules?.trim()) {
     return;
   }
-  const cssMap = new Map<string, string>();
-  const declarations = rules.split(';').filter((decl) => decl.trim());
-  for (const declaration of declarations) {
-    const colonIndex = declaration.indexOf(':');
-    if (colonIndex > 0) {
-      const property = declaration.substring(0, colonIndex).trim();
-      const value = declaration.substring(colonIndex + 1).trim();
-      if (property.startsWith('--') || property.match(/^[a-z-]+$/)) {
-        cssMap.set(property, value);
-      }
+
+  const cssMap: CssRuleMap = new Map();
+  for (const declaration of rules.split(';')) {
+    if (!declaration.trim()) {
+      continue;
     }
+    const colonIndex = declaration.indexOf(':');
+    if (colonIndex <= 0) {
+      continue;
+    }
+    const property = declaration.slice(0, colonIndex).trim();
+    const value = declaration.slice(colonIndex + 1).trim();
+    if (
+      !property ||
+      (!property.startsWith('--') && !PROPERTY_PATTERN.test(property))
+    ) {
+      continue;
+    }
+    const normalizedValue = normalizeCssValue(value);
+    if (!normalizedValue) {
+      continue;
+    }
+    cssMap.set(property, normalizedValue);
   }
-  return cssMap;
-}
 
-function parseCSSGroups(
-  cssString: string,
-): Map<string, Map<string, string>> | undefined {
-  const groups = new Map<string, Map<string, string>>();
-  const css = cssString
-    .replace(/\/\*[\s\S]*?\*\//g, '') // remove comments
-    .replace(/\s+/g, ' ') // replace multiple spaces with a single space
-    .trim();
+  return cssMap.size ? cssMap : undefined;
+};
 
-  if (!css?.length) {
+// Groups selectors and their declaration maps from raw CSS text.
+export function parseCssGroups(
+  cssString?: string | null,
+): CssGroups | undefined {
+  const sanitized = cssString
+    ? cssString.replace(COMMENT_PATTERN, ' ').trim()
+    : '';
+  if (!sanitized) {
     return;
   }
 
-  const blockRegex = /(.*?)\{(.*?)\}/g;
-  let matches = [...css.matchAll(blockRegex)];
-  if (!matches?.length) {
-    const rules = parseCssRules(css);
-    if (rules) {
-      groups.set(':root', rules);
+  const groups: CssGroups = new Map();
+  for (const match of sanitized.matchAll(BLOCK_PATTERN)) {
+    const selectorSource = match[1]?.trim();
+    const selector = selectorSource
+      ? (normalizeSelector(selectorSource) ?? ':root')
+      : ':root';
+    const rules = parseCssDeclarations(match[2]);
+    if (!rules?.size) {
+      continue;
     }
-  } else {
-    for (let match of matches) {
-      const selector = match[1]?.trim()
-        ? normalizeSelector(match[1].trim())
-        : ':root';
-      const rules = parseCssRules(match[2]?.trim());
-      if (rules?.size) {
-        groups.set(selector, rules);
-      }
+    const existing = groups.get(selector) ?? new Map();
+    for (const [property, value] of rules) {
+      existing.set(property, value);
+    }
+    groups.set(selector, existing);
+  }
+
+  if (!groups.size) {
+    const fallbackRules = parseCssDeclarations(sanitized);
+    if (fallbackRules?.size) {
+      groups.set(':root', fallbackRules);
     }
   }
-  return groups;
+
+  return groups.size ? groups : undefined;
 }
 
-export function extractCssVariables(cssString?: string | null) {
+// Returns the variables for a requested selector as `--name: value;` string.
+export function extractCssVariables(
+  cssString?: string | null,
+  selector = ':root',
+): string | undefined {
   try {
-    if (!cssString?.trim()?.length) {
+    const groups = parseCssGroups(cssString);
+    if (!groups?.size) {
       return;
     }
-    const groups = parseCSSGroups(cssString);
-    const rootRules = groups?.get(':root'); // only considering :root for now
-    if (!rootRules?.size) {
+
+    const normalizedSelector = selector
+      ? (normalizeSelector(selector) ?? ':root')
+      : ':root';
+    const rules = groups.get(normalizedSelector);
+    if (!rules?.size) {
       return;
     }
-    const inlineDeclarations: string[] = [];
-    for (const [property, value] of rootRules) {
-      if (property.startsWith('--')) {
-        inlineDeclarations.push(`${property}: ${value}`);
-      }
-    }
-    return inlineDeclarations.join('; ');
-  } catch (e) {
-    console.error('Error extracting CSS variables:', e);
+    return [...rules.entries()]
+      .filter(([property]) => property.startsWith('--'))
+      .map(([property, value]) => `${property}: ${value}`)
+      .join('; ');
+  } catch (error) {
+    console.error('Error extracting CSS variables:', error);
     return;
   }
 }

--- a/packages/boxel-ui/addon/src/helpers/theme-css.ts
+++ b/packages/boxel-ui/addon/src/helpers/theme-css.ts
@@ -1,0 +1,111 @@
+export type CssRuleMap = Map<string, string>; // css property(css variable name)-value map
+export type CssGroups = Map<string, CssRuleMap>; // string is css selector (block name)
+
+export interface CssVariableEntry {
+  name?: string | null;
+  value?: string | null;
+}
+
+export interface CssGroupInput {
+  entries?: CssVariableEntry[] | null;
+  rules?: CssRuleMap | null;
+  selector?: string | null;
+}
+
+// Ensures every custom property name is trimmed and prefixed with `--`.
+export const normalizeCssVariableName = (
+  name?: string | null,
+): string | undefined => {
+  const trimmed = name?.trim();
+  if (!trimmed) {
+    return;
+  }
+  return trimmed.startsWith('--') ? trimmed : `--${trimmed}`;
+};
+
+// Standardizes rule values by trimming and removing trailing semicolons.
+export const normalizeCssValue = (
+  value?: string | null,
+): string | undefined => {
+  if (value == null) {
+    return;
+  }
+  const trimmed = `${value}`.trim().replace(/;+$/, '');
+  return trimmed ? trimmed : undefined;
+};
+
+// Collapses selector aliases (like `root`) into their canonical form.
+export const normalizeSelector = (
+  selector?: string | null,
+): string | undefined => {
+  const trimmed = selector?.trim();
+  if (!trimmed) {
+    return;
+  }
+  if (trimmed === 'root') {
+    return ':root';
+  }
+  if (trimmed === 'dark') {
+    return '.dark';
+  }
+  return trimmed;
+};
+
+// Adds a rule to the map only when both name and value normalize successfully.
+const addNormalizedRule = (
+  map: CssRuleMap,
+  name?: string | null,
+  value?: string | null,
+) => {
+  const normalizedName = normalizeCssVariableName(name);
+  const normalizedValue = normalizeCssValue(value);
+  if (!normalizedName || !normalizedValue) {
+    return;
+  }
+  map.set(normalizedName, normalizedValue);
+};
+
+export function entriesToCssRuleMap(
+  entries?: CssVariableEntry[] | null,
+): CssRuleMap {
+  if (!entries?.length) {
+    return new Map();
+  }
+  const map: CssRuleMap = new Map();
+  for (let entry of entries) {
+    addNormalizedRule(map, entry?.name, entry?.value);
+  }
+  return map;
+}
+
+export function normalizeCssRuleMap(rules?: CssRuleMap | null): CssRuleMap {
+  if (!rules?.size) {
+    return new Map();
+  }
+  const map: CssRuleMap = new Map();
+  for (let [name, value] of rules.entries()) {
+    addNormalizedRule(map, name, value);
+  }
+  return map;
+}
+
+// Converts loosely structured group inputs into normalized selector-rule pairs.
+export function buildCssGroups(inputs?: CssGroupInput[] | null): CssGroups {
+  const groups: CssGroups = new Map();
+  if (!inputs?.length) {
+    return groups;
+  }
+  for (let input of inputs) {
+    const selector = normalizeSelector(input?.selector);
+    if (!selector) {
+      continue;
+    }
+    const initialRules = input.rules?.size
+      ? normalizeCssRuleMap(input.rules)
+      : entriesToCssRuleMap(input.entries);
+    if (initialRules.size) {
+      groups.set(selector, initialRules);
+    }
+  }
+  return groups;
+}

--- a/packages/host/tests/acceptance/theme-card-test.gts
+++ b/packages/host/tests/acceptance/theme-card-test.gts
@@ -1,5 +1,9 @@
+import { click, fillIn } from '@ember/test-helpers';
+
 import window from 'ember-window-mock';
 import { module, test } from 'qunit';
+
+import { Deferred } from '@cardstack/runtime-common';
 
 import {
   percySnapshot,
@@ -10,6 +14,7 @@ import {
   setupAcceptanceTestRealm,
   visitOperatorMode,
   testRealmURL,
+  type TestContextWithSave,
 } from '../helpers';
 import { setupMockMatrix } from '../helpers/mock-matrix';
 import { setupApplicationTest } from '../helpers/setup';
@@ -79,6 +84,61 @@ const DARK_MODE_VARS = {
 const ROOT_STYLE_ATTRS =
   "--background: #0a0f23; --foreground: #f4f1e8; --card: #1a1f3a; --card-foreground: #e8e5d3; --popover: #242952; --popover-foreground: #f4f1e8; --primary: #ffd700; --primary-foreground: #0a0f23; --secondary: #2d3561; --secondary-foreground: #c5c2b0; --muted: #1e2347; --muted-foreground: #8a8772; --accent: #ffb347; --accent-foreground: #1a1f3a; --destructive: #cd5c5c; --destructive-foreground: #f4f1e8; --border: #3a4073; --input: #2d3561; --ring: #ffd700; --sidebar: #0f1428; --sidebar-foreground: #c5c2b0; --font-sans: 'Libre Baskerville', 'Georgia', serif; --font-serif: 'Crimson Text', 'Times New Roman', serif; --font-mono: 'Source Code Pro', 'Courier New', monospace; --radius: 0.75rem; --spacing: 0.3rem; --tracking-normal: 0.01em; --shadow: 0 6px 12px rgba(255, 215, 0, 0.3)";
 
+const SOFT_POP_VARS = `:root {
+  --background: oklch(0.9789 0.0082 121.6272);
+  --foreground: oklch(0 0 0);
+  --card: oklch(1.0000 0 0);
+  --card-foreground: oklch(0 0 0);
+  --popover: oklch(1.0000 0 0);
+  --popover-foreground: oklch(0 0 0);
+  --primary: oklch(0.5106 0.2301 276.9656);
+  --primary-foreground: oklch(1.0000 0 0);
+  --secondary: oklch(0.7038 0.1230 182.5025);
+  --secondary-foreground: oklch(1.0000 0 0);
+  --muted: oklch(0.9551 0 0);
+  --muted-foreground: oklch(0.3211 0 0);
+  --accent: oklch(0.7686 0.1647 70.0804);
+  --accent-foreground: oklch(0 0 0);
+  --destructive: oklch(0.6368 0.2078 25.3313);
+  --destructive-foreground: oklch(1.0000 0 0);
+  --border: oklch(0 0 0);
+  --input: oklch(0.5555 0 0);
+  --ring: oklch(0.7853 0.1041 274.7134);
+  --font-sans: DM Sans, sans-serif;
+  --font-serif: DM Sans, sans-serif;
+  --font-mono: Space Mono, monospace;
+  --radius: 1rem;
+  --tracking-normal: normal;
+  --spacing: 0.25rem;
+  }
+
+  .dark {
+    --background: oklch(0 0 0);
+    --foreground: oklch(1.0000 0 0);
+    --card: oklch(0.2455 0.0217 257.2823);
+    --card-foreground: oklch(1.0000 0 0);
+    --popover: oklch(0.2455 0.0217 257.2823);
+    --popover-foreground: oklch(1.0000 0 0);
+    --primary: oklch(0.6801 0.1583 276.9349);
+    --primary-foreground: oklch(0 0 0);
+    --secondary: oklch(0.7845 0.1325 181.9120);
+    --secondary-foreground: oklch(0 0 0);
+    --muted: oklch(0.3211 0 0);
+    --muted-foreground: oklch(0.8452 0 0);
+    --accent: oklch(0.8790 0.1534 91.6054);
+    --accent-foreground: oklch(0 0 0);
+    --destructive: oklch(0.7106 0.1661 22.2162);
+    --destructive-foreground: oklch(0 0 0);
+    --border: oklch(0.4459 0 0);
+    --input: oklch(1.0000 0 0);
+    --ring: oklch(0.6801 0.1583 276.9349);
+    --font-sans: DM Sans, sans-serif;
+    --font-serif: DM Sans, sans-serif;
+    --font-mono: Space Mono, monospace;
+    --radius: 1rem;
+    --shadow: 0px 0px 0px 0px hsl(0 0% 10.1961% / 0.05), 0px 1px 2px -1px hsl(0 0% 10.1961% / 0.05);
+}`;
+
 module('Acceptance | theme-card-test', function (hooks) {
   setupApplicationTest(hooks);
   setupLocalIndexing(hooks);
@@ -91,6 +151,7 @@ module('Acceptance | theme-card-test', function (hooks) {
 
   let { createAndJoinRoom } = mockMatrixUtils;
   const themeCardId = `${testRealmURL}starry-night`;
+  const softPopCardId = `${testRealmURL}soft-pop`;
   const styleRefCardId = `${testRealmURL}style-ref-starry-night`;
 
   hooks.beforeEach(async function () {
@@ -180,84 +241,304 @@ module('Acceptance | theme-card-test', function (hooks) {
             },
           },
         },
+        'soft-pop.json': {
+          data: {
+            meta: {
+              adoptsFrom: {
+                name: 'default',
+                module: 'https://cardstack.com/base/structured-theme',
+              },
+            },
+            type: 'card',
+            attributes: {
+              cardInfo: {
+                title: 'Soft Pop',
+                description: 'A theme with soft color pops',
+              },
+            },
+          },
+        },
       },
     });
   });
 
-  test('renders structured theme card with inline css variables', async function (assert) {
-    assert.expect(11);
-    await visitOperatorMode({
-      stacks: [[{ id: themeCardId, format: 'isolated' }]],
+  module('style-reference-card', () => {
+    test('renders with inline css variables', async function (assert) {
+      await visitOperatorMode({
+        stacks: [[{ id: styleRefCardId, format: 'isolated' }]],
+      });
+      assert
+        .dom(`[data-test-card="${styleRefCardId}"] h1`)
+        .hasText('Starry Night');
+      assert
+        .dom(`[data-test-card="${styleRefCardId}"]`)
+        .hasClass('boxel-card-container--themed');
+      assert
+        .dom(`[data-test-card="${styleRefCardId}"]`)
+        .hasAttribute('style', ROOT_STYLE_ATTRS);
+
+      let container = document.querySelector<HTMLElement>(
+        `[data-test-card="${styleRefCardId}"]`,
+      );
+      assert.ok(container, 'theme card container is present');
+      let computedFontFamily = window
+        .getComputedStyle(container!)
+        .getPropertyValue('font-family');
+      assert.ok(
+        computedFontFamily.includes('Libre Baskerville'),
+        `computed font-family includes themed value`,
+      );
     });
-    assert.dom(`[data-test-card="${themeCardId}"] h1`).hasText('Starry Night');
-    assert.dom('[data-test-css-vars]').containsText('--radius: 0.75rem;');
-    assert
-      .dom(`[data-test-card="${themeCardId}"]`)
-      .hasClass('boxel-card-container--themed');
-    assert
-      .dom(`[data-test-card="${themeCardId}"]`)
-      .hasAttribute('style', ROOT_STYLE_ATTRS);
-
-    let container = document.querySelector<HTMLElement>(
-      `[data-test-card="${themeCardId}"]`,
-    );
-    assert.ok(container, 'theme card container is present');
-    let styleAttr = container?.getAttribute('style') ?? '';
-    assert.ok(
-      styleAttr.includes('--background: #0a0f23'),
-      'inline style includes root background variable',
-    );
-    assert.false(
-      styleAttr.includes('--background: #050813'),
-      'dark mode value is not applied inline',
-    );
-    let computedFontFamily = window
-      .getComputedStyle(container!)
-      .getPropertyValue('font-family');
-    assert.ok(
-      computedFontFamily.includes('Libre Baskerville'),
-      `computed font-family includes themed value`,
-    );
-
-    await visitOperatorMode({
-      stacks: [],
-      codePath: themeCardId,
-      submode: 'code',
-    });
-    assert.dom(`[data-test-card="${themeCardId}"] h1`).hasText('Starry Night');
-    assert.dom('[data-test-css-vars]').containsText('--radius: 0.75rem;');
-    assert
-      .dom(`[data-test-card="${themeCardId}"]`)
-      .hasAttribute('style', ROOT_STYLE_ATTRS);
-
-    await percySnapshot(assert);
   });
 
-  test('renders StyleReference theme card with inline css variables', async function (assert) {
-    assert.expect(5);
-    await visitOperatorMode({
-      stacks: [[{ id: styleRefCardId, format: 'isolated' }]],
-    });
-    assert
-      .dom(`[data-test-card="${styleRefCardId}"] h1`)
-      .hasText('Starry Night');
-    assert
-      .dom(`[data-test-card="${styleRefCardId}"]`)
-      .hasClass('boxel-card-container--themed');
-    assert
-      .dom(`[data-test-card="${styleRefCardId}"]`)
-      .hasAttribute('style', ROOT_STYLE_ATTRS);
+  module('structured-theme-card', () => {
+    test('renders with inline css variables', async function (assert) {
+      await visitOperatorMode({
+        stacks: [[{ id: themeCardId, format: 'isolated' }]],
+      });
+      assert
+        .dom(`[data-test-card="${themeCardId}"] h1`)
+        .hasText('Starry Night');
+      assert.dom('[data-test-css-vars]').containsText('--radius: 0.75rem;');
+      assert
+        .dom(`[data-test-card="${themeCardId}"]`)
+        .hasClass('boxel-card-container--themed');
+      assert
+        .dom(`[data-test-card="${themeCardId}"]`)
+        .hasAttribute('style', ROOT_STYLE_ATTRS);
 
-    let container = document.querySelector<HTMLElement>(
-      `[data-test-card="${styleRefCardId}"]`,
-    );
-    assert.ok(container, 'theme card container is present');
-    let computedFontFamily = window
-      .getComputedStyle(container!)
-      .getPropertyValue('font-family');
-    assert.ok(
-      computedFontFamily.includes('Libre Baskerville'),
-      `computed font-family includes themed value`,
-    );
+      let container = document.querySelector<HTMLElement>(
+        `[data-test-card="${themeCardId}"]`,
+      );
+      assert.ok(container, 'theme card container is present');
+      let styleAttr = container?.getAttribute('style') ?? '';
+      assert.ok(
+        styleAttr.includes('--background: #0a0f23'),
+        'inline style includes root background variable',
+      );
+      assert.false(
+        styleAttr.includes('--background: #050813'),
+        'dark mode value is not applied inline',
+      );
+      let computedFontFamily = window
+        .getComputedStyle(container!)
+        .getPropertyValue('font-family');
+      assert.ok(
+        computedFontFamily.includes('Libre Baskerville'),
+        `computed font-family includes themed value`,
+      );
+
+      await visitOperatorMode({
+        stacks: [],
+        codePath: themeCardId,
+        submode: 'code',
+      });
+      assert
+        .dom(`[data-test-card="${themeCardId}"] h1`)
+        .hasText('Starry Night');
+      assert.dom('[data-test-css-vars]').containsText('--radius: 0.75rem;');
+      assert
+        .dom(`[data-test-card="${themeCardId}"]`)
+        .hasAttribute('style', ROOT_STYLE_ATTRS);
+
+      await percySnapshot(assert);
+    });
+
+    test<TestContextWithSave>('applies pasted custom CSS variables', async function (assert) {
+      assert.expect(12);
+
+      await visitOperatorMode({
+        stacks: [[{ id: softPopCardId, format: 'isolated' }]],
+      });
+
+      let deferred = new Deferred<void>();
+      this.onSave((url, json) => {
+        if (typeof json === 'string') {
+          throw new Error('expected JSON save data');
+        }
+        assert.strictEqual(url.href, softPopCardId);
+        assert.strictEqual(
+          json?.data.attributes?.rootVariables?.primary,
+          'oklch(0.5106 0.2301 276.9656)',
+          'primary root var is saved',
+        );
+        assert.strictEqual(
+          json?.data.attributes?.rootVariables?.fontSans,
+          'DM Sans, sans-serif',
+          'font-sans root var is saved',
+        );
+        assert.strictEqual(
+          json?.data.attributes?.darkModeVariables?.foreground,
+          'oklch(1.0000 0 0)',
+          'dark foreground is saved',
+        );
+        deferred.fulfill();
+      });
+
+      assert.dom('[data-test-css-vars]').containsText('No CSS defined');
+
+      await fillIn('[data-test-custom-css-variables]', SOFT_POP_VARS);
+
+      assert
+        .dom('[data-test-root-vars] [data-test-var-value="secondary"]')
+        .containsText('oklch(0.7038 0.1230 182.5025)');
+      assert
+        .dom('[data-test-dark-vars] [data-test-var-value="muted"]')
+        .containsText('oklch(0.3211 0 0)');
+      assert
+        .dom('[data-test-css-vars]')
+        .containsText(':root { --background: oklch(0.9789 0.0082 121.6272); ');
+      assert
+        .dom('[data-test-css-vars]')
+        .containsText(' .dark { --background: oklch(0 0 0); ');
+
+      await click('[data-test-edit-button]');
+
+      assert
+        .dom(
+          '[data-test-field="rootVariables"] [data-test-field="accent"] [data-test-swatch="oklch(0.7686 0.1647 70.0804)"]',
+        )
+        .exists();
+      assert
+        .dom(
+          '[data-test-field="rootVariables"] [data-test-field="accent"] [data-test-color-text-input]',
+        )
+        .hasValue('oklch(0.7686 0.1647 70.0804)');
+      assert
+        .dom(
+          '[data-test-field="darkModeVariables"] [data-test-field="accent"] [data-test-color-text-input]',
+        )
+        .hasValue('oklch(0.8790 0.1534 91.6054)');
+    });
+
+    test<TestContextWithSave>('updates CSS variables when editing textarea values', async function (assert) {
+      assert.expect(16);
+
+      await visitOperatorMode({
+        stacks: [[{ id: themeCardId, format: 'isolated' }]],
+      });
+
+      let deferred = new Deferred<void>();
+      this.onSave((url, json) => {
+        if (typeof json === 'string') {
+          throw new Error('expected JSON save data');
+        }
+        assert.strictEqual(url.href, themeCardId);
+        const rootVars = json?.data.attributes?.rootVariables;
+        const darkVars = json?.data.attributes?.darkModeVariables;
+        assert.strictEqual(
+          rootVars?.background,
+          '#455A68',
+          'background value is updated',
+        );
+        assert.strictEqual(
+          rootVars?.foreground,
+          '#FCD2A7',
+          'foreground value is updated',
+        );
+        assert.strictEqual(
+          rootVars?.card,
+          '#1a1f3a',
+          'card value did not change',
+        );
+        assert.strictEqual(
+          darkVars?.background,
+          '#050813',
+          'dark background did not change',
+        );
+        assert.strictEqual(
+          darkVars?.card,
+          'black',
+          'dark card background is updated',
+        );
+        deferred.fulfill();
+      });
+
+      assert
+        .dom('[data-test-root-vars] [data-test-var-value="background"]')
+        .containsText('#0a0f23');
+      assert
+        .dom('[data-test-root-vars] [data-test-var-value="card"]')
+        .containsText('#1a1f3a');
+      assert
+        .dom('[data-test-dark-vars] [data-test-var-value="background"]')
+        .containsText('#050813');
+
+      await fillIn(
+        '[data-test-custom-css-variables]',
+        ':root { --background: #455A68; --foreground: #FCD2A7; } .dark { --card: black; }',
+      );
+
+      assert
+        .dom('[data-test-root-vars] [data-test-var-value="background"]')
+        .containsText('#455A68', 'value is updated');
+      assert
+        .dom('[data-test-root-vars] [data-test-var-value="card"]')
+        .containsText('#1a1f3a', 'existing value remains');
+      assert.dom('[data-test-css-vars]').containsText('--background: #455A68;');
+      assert.dom('[data-test-css-vars]').containsText('--card: #1a1f3a;');
+
+      await click('[data-test-edit-button]');
+
+      assert
+        .dom(
+          '[data-test-field="rootVariables"] [data-test-field="foreground"] [data-test-color-text-input]',
+        )
+        .hasValue('#FCD2A7', 'foreground is updated in edit mode');
+      assert
+        .dom(
+          '[data-test-field="darkModeVariables"] [data-test-field="card"] [data-test-color-text-input]',
+        )
+        .hasValue('black', 'dark card background is updated in edit mode');
+      assert
+        .dom(
+          '[data-test-field="darkModeVariables"] [data-test-field="background"] [data-test-color-text-input]',
+        )
+        .hasValue('#050813', 'existing value remains in edit mode');
+    });
+
+    test<TestContextWithSave>('recomputes cssVariables after editing fields', async function (assert) {
+      assert.expect(4);
+
+      const NEW_FOREGROUND = '#a6f4ca';
+
+      await visitOperatorMode({
+        stacks: [[{ id: themeCardId, format: 'edit' }]],
+      });
+
+      let deferred = new Deferred<void>();
+
+      this.onSave((url, json) => {
+        if (typeof json === 'string') {
+          throw new Error('expected JSON save data');
+        }
+        assert.strictEqual(url.href, themeCardId);
+        const rootVars = json?.data.attributes?.rootVariables;
+        assert.strictEqual(
+          rootVars?.background,
+          '#0a0f23',
+          'background value did not change',
+        );
+        assert.strictEqual(
+          rootVars?.foreground,
+          NEW_FOREGROUND,
+          'foreground value is updated',
+        );
+        deferred.fulfill();
+      });
+
+      await fillIn(
+        '[data-test-field="rootVariables"] [data-test-field="foreground"] [data-test-boxel-input]',
+        NEW_FOREGROUND,
+      );
+
+      await visitOperatorMode({
+        stacks: [[{ id: themeCardId, format: 'isolated' }]],
+      });
+
+      assert
+        .dom('[data-test-css-vars]')
+        .containsText(` --foreground: ${NEW_FOREGROUND}; `);
+    });
   });
 });

--- a/packages/host/tests/unit/generate-css-variables-test.ts
+++ b/packages/host/tests/unit/generate-css-variables-test.ts
@@ -1,31 +1,41 @@
 import { module, test } from 'qunit';
 
-import { generateCssVariables } from '@cardstack/boxel-ui/helpers';
+import {
+  buildCssGroups,
+  generateCssVariables,
+} from '@cardstack/boxel-ui/helpers';
 
 module('Unit | generate-css-variables', function () {
   test('it generates css rule blocks with normalized variables', function (assert) {
-    const result = generateCssVariables([
-      {
-        blockname: ':root',
-        vars: [
-          { property: '  --primary  ', value: '  #336699  ' },
-          { property: 'radius', value: '20px;' },
-        ],
-      },
-      {
-        blockname: '.dark',
-        vars: [
-          { property: '--background', value: '  #333;  ' },
-          { property: ' foreground  ', value: '#fff' },
-        ],
-      },
-    ]);
+    const result = generateCssVariables(
+      buildCssGroups([
+        {
+          selector: ':root',
+          entries: [
+            { name: '  --primary  ', value: '  #336699  ' },
+            { name: 'radius', value: '20px;' },
+          ],
+        },
+        {
+          selector: '.dark',
+          entries: [
+            { name: '--background', value: '  #333;  ' },
+            { name: ' foreground  ', value: '#fff' },
+          ],
+        },
+      ]),
+    );
 
     assert.strictEqual(
       result,
       [
-        [':root {', ' --primary: #336699;', ' --radius: 20px;', '}'].join('\n'),
-        ['.dark {', ' --background: #333;', ' --foreground: #fff;', '}'].join(
+        [
+          ':root {',
+          '  --primary: #336699;',
+          '  --radius: 20px;',
+          '}',
+        ].join('\n'),
+        ['.dark {', '  --background: #333;', '  --foreground: #fff;', '}'].join(
           '\n',
         ),
       ].join('\n\n'),
@@ -33,28 +43,32 @@ module('Unit | generate-css-variables', function () {
   });
 
   test('it skips variables without both property and value', function (assert) {
-    const result = generateCssVariables([
-      {
-        blockname: ':root',
-        vars: [
-          { property: '--valid', value: '1rem' },
-          { property: '--missing-value' },
-          { property: '', value: '2rem' },
-          // @ts-ignore-next-line purposefully inaccurate type
-          { property: null, value: '2rem' },
-          { property: '--null-value', value: null },
-        ],
-      },
-    ]);
+    const result = generateCssVariables(
+      buildCssGroups([
+        {
+          selector: ':root',
+          entries: [
+            { name: '--valid', value: '1rem' },
+            { name: '--missing-value' },
+            { name: '', value: '2rem' },
+            // @ts-ignore-next-line purposefully inaccurate type
+            { name: null, value: '2rem' },
+            { name: '--null-value', value: null },
+          ],
+        },
+      ]),
+    );
 
-    assert.strictEqual(result, [':root {', ' --valid: 1rem;', '}'].join('\n'));
+    assert.strictEqual(result, [':root {', '  --valid: 1rem;', '}'].join('\n'));
   });
 
   test('it omits blocks that produce no rules', function (assert) {
-    const result = generateCssVariables([
-      { blockname: ':root', vars: [] },
-      { blockname: '.empty' },
-    ]);
+    const result = generateCssVariables(
+      buildCssGroups([
+        { selector: ':root', entries: [] },
+        { selector: '.empty' },
+      ]),
+    );
 
     assert.strictEqual(result, '');
   });

--- a/packages/host/tests/unit/generate-css-variables-test.ts
+++ b/packages/host/tests/unit/generate-css-variables-test.ts
@@ -29,12 +29,9 @@ module('Unit | generate-css-variables', function () {
     assert.strictEqual(
       result,
       [
-        [
-          ':root {',
-          '  --primary: #336699;',
-          '  --radius: 20px;',
-          '}',
-        ].join('\n'),
+        [':root {', '  --primary: #336699;', '  --radius: 20px;', '}'].join(
+          '\n',
+        ),
         ['.dark {', '  --background: #333;', '  --foreground: #fff;', '}'].join(
           '\n',
         ),


### PR DESCRIPTION
- add css-textarea in structured-theme card isolated template that parses entered value into fields
- refactor css-helpers in boxel-ui to use the same types
- structured-theme card template improvements
- add tests

<img width="734" height="746" alt="structured-theme-card" src="https://github.com/user-attachments/assets/c98b8f1d-407f-49cd-92a4-eb81b66b63e5" />

