### PR TITLE
Refactor /render route model loading and all node tests for headless chrome indexing ported

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -280,6 +280,9 @@ export function instanceOf(instance: BaseDef, clazz: typeof BaseDef): boolean {
 class Logger {
   private promises: Promise<any>[] = [];
 
+  // TODO this doesn't look like it's used anymore. in the past this was used to
+  // keep track of async when eagerly running computes after a property had been set.
+  // consider removing this.
   log(promise: Promise<any>) {
     this.promises.push(promise);
     // make an effort to resolve the promise at the time it is logged
@@ -3047,9 +3050,9 @@ export function setCardAsSavedForTest(instance: CardDef, id?: string): void {
   instance[isSavedInstance] = true;
 }
 
-export async function searchDoc<CardT extends BaseDefConstructor>(
+export function searchDoc<CardT extends BaseDefConstructor>(
   instance: InstanceType<CardT>,
-): Promise<Record<string, any>> {
+): Record<string, any> {
   return getQueryableValue(instance.constructor, instance) as Record<
     string,
     any

--- a/packages/host/app/components/card-prerender.gts
+++ b/packages/host/app/components/card-prerender.gts
@@ -32,6 +32,7 @@ import {
 
 import { CurrentRun } from '../lib/current-run';
 
+import type LoaderService from '../services/loader-service';
 import type LocalIndexer from '../services/local-indexer';
 import type NetworkService from '../services/network';
 import type RenderService from '../services/render-service';
@@ -47,8 +48,9 @@ export default class CardPrerender extends Component {
   @service private declare renderService: RenderService;
   @service private declare fastboot: { isFastBoot: boolean };
   @service private declare localIndexer: LocalIndexer;
+  @service private declare loaderService: LoaderService;
   #nonce = 0;
-  #shouldResetStoreForNextRender = true;
+  #shouldClearCacheForNextRender = true;
 
   #renderBasePath(url: string, renderOptions?: RenderRouteOptions) {
     let optionsSegment = encodeURIComponent(
@@ -128,17 +130,21 @@ export default class CardPrerender extends Component {
       this.#nonce++;
       this.localIndexer.renderError = undefined;
       this.localIndexer.prerenderStatus = 'loading';
-      let shouldResetStore = this.#consumeResetStoreForRender(
-        renderOptions?.resetStore === true,
+      let shouldClearCache = this.#consumeClearCacheForRender(
+        Boolean(renderOptions?.clearCache),
       );
       let initialRenderOptions: RenderRouteOptions = {
         ...(renderOptions ?? {}),
       };
-      if (shouldResetStore) {
-        initialRenderOptions.resetStore = true;
+      if (shouldClearCache) {
+        initialRenderOptions.clearCache = true;
+        this.loaderService.resetLoader({
+          clearFetchCache: true,
+          reason: 'card-prerender clearCache',
+        });
         this.store.resetCache();
       } else {
-        delete initialRenderOptions.resetStore;
+        delete initialRenderOptions.clearCache;
       }
       let error: RenderError | undefined;
       let isolatedHTML: string | null = null;
@@ -452,14 +458,14 @@ export default class CardPrerender extends Component {
     }
   }
 
-  #consumeResetStoreForRender(requestedReset = false): boolean {
-    if (requestedReset) {
-      this.#shouldResetStoreForNextRender = true;
+  #consumeClearCacheForRender(requestedClear = false): boolean {
+    if (requestedClear) {
+      this.#shouldClearCacheForNextRender = true;
     }
-    if (!this.#shouldResetStoreForNextRender) {
+    if (!this.#shouldClearCacheForNextRender) {
       return false;
     }
-    this.#shouldResetStoreForNextRender = false;
+    this.#shouldClearCacheForNextRender = false;
     return true;
   }
 
@@ -484,8 +490,8 @@ function getRunnerOpts(optsId: number): RunnerOpts {
 }
 
 function omitOneTimeOptions(options: RenderRouteOptions): RenderRouteOptions {
-  if (options.includesCodeChange === true || options.resetStore === true) {
-    let { includesCodeChange: _ic, resetStore: _rs, ...rest } = options;
+  if (options.clearCache) {
+    let { clearCache: _clearCache, ...rest } = options;
     return rest as RenderRouteOptions;
   }
   return options;

--- a/packages/host/app/lib/window-error-handler.ts
+++ b/packages/host/app/lib/window-error-handler.ts
@@ -25,11 +25,15 @@ export function windowErrorHandler({
     'reason' in event
       ? (event as any).reason
       : (event as CustomEvent).detail?.reason;
-  if (!reason && 'message' in event && (event as ErrorEvent).message) {
-    reason = {
-      message: (event as ErrorEvent).message,
-      status: 500,
-    };
+  if (!reason && event instanceof ErrorEvent) {
+    if (event.error) {
+      reason = event.error;
+    } else if (event.message) {
+      reason = {
+        message: event.message,
+        status: 500,
+      };
+    }
   }
   // Coerce stringified JSON into objects so our type guards work
   if (typeof reason === 'string') {

--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -1,8 +1,9 @@
+import type Controller from '@ember/controller';
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 import RouterService from '@ember/routing/router-service';
 import Transition from '@ember/routing/transition';
-import { join } from '@ember/runloop';
+import { join, scheduleOnce } from '@ember/runloop';
 import { service } from '@ember/service';
 
 import { TrackedMap } from 'tracked-built-ins';
@@ -18,6 +19,7 @@ import {
   parseRenderRouteOptions,
   serializeRenderRouteOptions,
 } from '@cardstack/runtime-common';
+import { Deferred } from '@cardstack/runtime-common/deferred';
 import { serializableError } from '@cardstack/runtime-common/error';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
@@ -34,7 +36,22 @@ import type RealmServerService from '../services/realm-server';
 import type RenderErrorStateService from '../services/render-error-state';
 import type StoreService from '../services/store';
 
-export type Model = { instance: CardDef; ready: boolean; nonce: string };
+type RenderStatus = 'loading' | 'ready' | 'error' | 'unusable';
+
+export type Model = {
+  instance: CardDef;
+  nonce: string;
+  cardId: string;
+  readonly status: RenderStatus;
+  readonly ready: boolean;
+  readyPromise: Promise<void>;
+};
+
+type ModelState = {
+  state: TrackedMap<string, unknown>;
+  readyDeferred: Deferred<void>;
+  isReady: boolean;
+};
 
 export default class RenderRoute extends Route<Model> {
   @service declare store: StoreService;
@@ -49,6 +66,9 @@ export default class RenderRoute extends Route<Model> {
   private lastStoreResetKey: string | undefined;
   private renderBaseParams: [string, string, string] | undefined;
   private lastSerializedError: string | undefined;
+  #modelStates = new Map<Model, ModelState>();
+  #pendingReadyModels = new Set<Model>();
+  #modelPromises = new Map<string, Promise<Model>>();
 
   errorHandler = (event: Event) => {
     windowErrorHandler({
@@ -63,6 +83,7 @@ export default class RenderRoute extends Route<Model> {
       },
       currentURL: this.router.currentURL,
     });
+    this.#setAllModelStatuses('unusable');
     (globalThis as any)._lazilyLoadLinks = undefined;
     (globalThis as any)._boxelRenderContext = undefined;
   };
@@ -85,6 +106,9 @@ export default class RenderRoute extends Route<Model> {
     this.renderBaseParams = undefined;
     this.lastSerializedError = undefined;
     this.renderErrorState.clear();
+    this.#modelStates.clear();
+    this.#pendingReadyModels.clear();
+    this.#modelPromises.clear();
   }
 
   beforeModel() {
@@ -104,19 +128,38 @@ export default class RenderRoute extends Route<Model> {
     let parsedOptions = parseRenderRouteOptions(options);
     let canonicalOptions = serializeRenderRouteOptions(parsedOptions);
     this.#setupTransitionHelper(id, nonce, canonicalOptions);
+    let key = `${id}|${nonce}|${canonicalOptions}`;
+    let existing = this.#modelPromises.get(key);
+    if (existing) {
+      return await existing;
+    }
 
+    // the window.boxelTransitionTo() function helper first normalizes the base
+    // params by transitioning the router back to 'render' before it goes on to
+    // 'render.html', 'render.meta', etc. That’s why you see the /render model
+    // hook fire twice per prerender step: every format capture goes through a
+    // parent transition (render), then to the actual child route, so the parent
+    // model executes twice per prerender, hence the need to share the work.
+    let promise = this.#buildModel({ id, nonce }, parsedOptions);
+    this.#modelPromises.set(key, promise);
+    return await promise;
+  }
+
+  async #buildModel(
+    { id, nonce }: { id: string; nonce: string },
+    parsedOptions: ReturnType<typeof parseRenderRouteOptions>,
+  ): Promise<Model> {
     // Opt in to reading the in-progress index, as opposed to the last completed
     // index. This matters for any related cards that we will be loading, not
     // for our own card, which we're going to load directly from source.
-    let shouldResetLoader = parsedOptions.includesCodeChange === true;
-    if (shouldResetLoader) {
+    if (parsedOptions.clearCache) {
       this.loaderService.resetLoader({
         clearFetchCache: true,
-        reason: 'render-route includesCodeChange',
+        reason: 'render-route clearCache',
       });
     }
     this.loaderService.setIsIndexing(true);
-    if (parsedOptions.resetStore === true) {
+    if (parsedOptions.clearCache) {
       let resetKey = `${id}:${nonce}`;
       if (this.lastStoreResetKey !== resetKey) {
         this.store.resetCache();
@@ -137,17 +180,52 @@ export default class RenderRoute extends Route<Model> {
     let lastModified = new Date(response.headers.get('last-modified')!);
     let doc: LooseSingleCardDocument | CardErrorsJSONAPI =
       await response.json();
+    let state = new TrackedMap<string, unknown>();
+    state.set('status', 'loading');
+
+    // the rendering of the templates is what pulls on the linked fields to load
+    // them. before the card templates are rendered there are no in-flight
+    // requests for linked fields. so in order to properly wait for the linked
+    // fields to load we must first render the /render/html route (preferably
+    // the isolated format), and then the store will start tracking the
+    // in-flight link requests. after the store settles the prerendered output
+    // will be ready to capture. this readyDeferred will let us know when the
+    // prerendered output is ready for capture.
+    let readyDeferred = new Deferred<void>();
+    let modelState: ModelState = {
+      state,
+      readyDeferred,
+      isReady: false,
+    };
+    let canonicalId = id.replace(/\.json$/, '');
+    let model: Model = {
+      instance: undefined as unknown as CardDef,
+      nonce,
+      cardId: canonicalId,
+      get status(): RenderStatus {
+        return (state.get('status') as RenderStatus) ?? 'loading';
+      },
+      get ready(): boolean {
+        return (state.get('status') as RenderStatus) === 'ready';
+      },
+      readyPromise: readyDeferred.promise,
+    };
+    this.#modelStates.set(model, modelState);
+
     let instance: CardDef | undefined;
-    if ('errors' in doc) {
-      throw new Error(JSON.stringify(doc.errors[0], null, 2));
-    } else {
+    try {
+      if ('errors' in doc) {
+        this.#dispositionModel(model, 'error');
+        throw new Error(JSON.stringify(doc.errors[0], null, 2));
+      }
+
       await this.realm.ensureRealmMeta(realmURL);
 
       let enhancedDoc: LooseSingleCardDocument = {
         ...doc,
         data: {
           ...doc.data,
-          id: id.replace(/\.json$/, ''),
+          id: canonicalId,
           type: 'card',
           meta: {
             ...doc.data.meta,
@@ -163,24 +241,89 @@ export default class RenderRoute extends Route<Model> {
         realm: realmURL,
         doNotPersist: true,
       });
+      model.instance = instance;
+    } catch (e: any) {
+      console.warn(
+        `Encountered error when deserializing doc for ${id}: ${e.message}: ${e.responseText}`,
+      );
+      this.#dispositionModel(model, 'error');
+      throw e;
     }
-
-    let state = new TrackedMap();
-    state.set('ready', false);
     await this.store.loaded();
-    state.set('ready', true);
+    if (instance) {
+      model.instance = instance;
+    }
+    this.#scheduleReady(model);
 
     // this is to support in-browser rendering, where we actually don't have the
     // ability to lookup the parent route using RouterService.recognizeAndLoad()
     (globalThis as any).__renderInstance = instance;
     this.currentTransition = undefined;
-    return {
-      instance,
-      nonce,
-      get ready(): boolean {
-        return Boolean(state.get('ready'));
-      },
-    };
+    return model;
+  }
+
+  setupController(controller: Controller, model: Model) {
+    super.setupController(controller, model);
+    this.#scheduleReady(model);
+  }
+
+  #scheduleReady(model: Model) {
+    let modelState = this.#modelStates.get(model);
+    if (!modelState || modelState.isReady) {
+      return;
+    }
+    this.#pendingReadyModels.add(model);
+    scheduleOnce('afterRender', this, this.#processPendingReadyModels);
+  }
+
+  #processPendingReadyModels() {
+    if (this.isDestroying || this.isDestroyed) {
+      this.#pendingReadyModels.clear();
+      return;
+    }
+    for (let model of this.#pendingReadyModels) {
+      void this.#settleModelAfterRender(model).catch((error) => {
+        this.#dispositionModel(model, 'error');
+        this.handleRenderError(error);
+      });
+    }
+    this.#pendingReadyModels.clear();
+  }
+
+  async #settleModelAfterRender(model: Model): Promise<void> {
+    let modelState = this.#modelStates.get(model);
+    if (!modelState || modelState.isReady) {
+      return;
+    }
+    await this.store.loaded();
+    modelState.state.set('status', 'ready');
+    modelState.isReady = true;
+    modelState.readyDeferred.fulfill();
+  }
+
+  #dispositionModel(model: Model, status: RenderStatus = 'error') {
+    let modelState = this.#modelStates.get(model);
+    if (!modelState) {
+      return;
+    }
+    this.#pendingReadyModels.delete(model);
+    modelState.state.set('status', status);
+    if (!modelState.isReady) {
+      modelState.isReady = true;
+      modelState.readyDeferred.fulfill();
+    }
+  }
+
+  #rejectAllModelStates(status: RenderStatus = 'error') {
+    for (let model of this.#modelStates.keys()) {
+      this.#dispositionModel(model, status);
+    }
+  }
+
+  #setAllModelStatuses(status: RenderStatus) {
+    for (let model of this.#modelStates.keys()) {
+      this.#dispositionModel(model, status);
+    }
   }
 
   // Headless prerendering drives Ember via this hook, and it may repeatedly
@@ -259,11 +402,31 @@ export default class RenderRoute extends Route<Model> {
     } else {
       error = errorOrEvent;
     }
+    this.#processRenderError(error, transition);
+  };
+
+  #processRenderError(error: any, transition?: Transition) {
     this.currentTransition?.abort();
-    let serializedError: string;
+    this.#rejectAllModelStates('error');
+    let serializedError = this.#serializeRenderError(error, transition);
+    if (serializedError === this.lastSerializedError) {
+      return;
+    }
+    this.lastSerializedError = serializedError;
+    let context = this.#deriveErrorContext(transition);
+    this.renderErrorState.setError({
+      reason: serializedError,
+      cardId: context.cardId,
+      nonce: context.nonce,
+    });
+    this.#applyErrorMetadata(context);
+    this.#transitionToErrorRoute(transition);
+  }
+
+  #serializeRenderError(error: any, transition?: Transition): string {
     try {
       let cardError: CardError = JSON.parse(error.message);
-      serializedError = JSON.stringify(
+      return JSON.stringify(
         {
           type: 'error',
           error: cardError,
@@ -271,7 +434,7 @@ export default class RenderRoute extends Route<Model> {
         null,
         2,
       );
-    } catch (e) {
+    } catch (_e) {
       let current: Transition['to'] | null = transition?.to;
       let id: string | undefined;
       do {
@@ -281,26 +444,86 @@ export default class RenderRoute extends Route<Model> {
         }
       } while (current && !id);
       if (isCardError(error)) {
-        // Preserve full CardError details including deps for prerender indexing
-        serializedError = JSON.stringify(
+        return JSON.stringify(
           { type: 'error', error: serializableError(error) },
           null,
           2,
         );
-      } else {
-        let errorJSONAPI = formattedError(id, error).errors[0];
-        let errorPayload = errorJsonApiToErrorEntry(errorJSONAPI);
-        serializedError = JSON.stringify(errorPayload, null, 2);
+      }
+      let errorJSONAPI = formattedError(id, error).errors[0];
+      let errorPayload = errorJsonApiToErrorEntry(errorJSONAPI);
+      return JSON.stringify(errorPayload, null, 2);
+    }
+  }
+
+  #deriveErrorContext(transition?: Transition): {
+    cardId?: string;
+    nonce?: string;
+  } {
+    let cardId: string | undefined;
+    let nonce: string | undefined;
+    let base = this.renderBaseParams;
+    if (base) {
+      cardId = this.#normalizeCardId(base[0]);
+      nonce = base[1];
+    }
+    if ((!cardId || !nonce) && transition) {
+      let current: Transition['to'] | null = transition.to;
+      while (current) {
+        let params = current.params as Record<string, unknown> | undefined;
+        if (params) {
+          if (!cardId && typeof params.id === 'string') {
+            cardId = this.#normalizeCardId(params.id);
+          }
+          if (!nonce && typeof params.nonce === 'string') {
+            nonce = params.nonce;
+          }
+        }
+        current = current.parent;
       }
     }
-    if (serializedError === this.lastSerializedError) {
+    return { cardId, nonce };
+  }
+
+  #normalizeCardId(id: string): string {
+    try {
+      let decoded = decodeURIComponent(id);
+      return decoded.replace(/\.json$/, '');
+    } catch {
+      return id.replace(/\.json$/, '');
+    }
+  }
+
+  #applyErrorMetadata(context: { cardId?: string; nonce?: string }) {
+    if (typeof document === 'undefined') {
       return;
     }
-    this.lastSerializedError = serializedError;
-    // Store the serialized error so the child render.error route can read it
-    // even though this transition abort prevents its usual model hook from
-    // running.
-    this.renderErrorState.setReason(serializedError);
+    let container = document.querySelector(
+      '[data-prerender]',
+    ) as HTMLElement | null;
+    if (container) {
+      container.dataset.prerenderStatus = 'error';
+      if (context.cardId) {
+        container.dataset.prerenderId = context.cardId;
+      }
+      if (context.nonce) {
+        container.dataset.prerenderNonce = context.nonce;
+      }
+    }
+    let errorElement = document.querySelector(
+      '[data-prerender-error]',
+    ) as HTMLElement | null;
+    if (errorElement) {
+      if (context.cardId) {
+        errorElement.dataset.prerenderId = context.cardId;
+      }
+      if (context.nonce) {
+        errorElement.dataset.prerenderNonce = context.nonce;
+      }
+    }
+  }
+
+  #transitionToErrorRoute(transition?: Transition) {
     let baseParams = this.renderBaseParams;
     if (baseParams) {
       if (transition) {
@@ -321,5 +544,5 @@ export default class RenderRoute extends Route<Model> {
     } else {
       join(() => this.router.transitionTo('render.error'));
     }
-  };
+  }
 }

--- a/packages/host/app/routes/render/meta.ts
+++ b/packages/host/app/routes/render/meta.ts
@@ -36,7 +36,8 @@ export default class RenderMetaRoute extends Route<Model> {
 
   async model(_: unknown, transition: Transition) {
     let api = await this.cardService.getAPI();
-    let parentModel = this.modelFor('render') as ParentModel;
+    let parentModel = this.modelFor('render') as ParentModel | undefined;
+    await parentModel?.readyPromise;
     let instance: CardDef;
     if (!parentModel) {
       // this is to support in-browser rendering, where we actually don't have the
@@ -78,7 +79,7 @@ export default class RenderMetaRoute extends Route<Model> {
 
     let types = getTypes(Klass);
     let displayNames = getDisplayNames(Klass);
-    let searchDoc = await api.searchDoc(instance);
+    let searchDoc = api.searchDoc(instance);
     // Add a "pseudo field" to the search doc for the card type. We use the
     // "_" prefix to make a decent attempt to not pollute the userland
     // namespace for cards

--- a/packages/host/app/services/render-error-state.ts
+++ b/packages/host/app/services/render-error-state.ts
@@ -4,19 +4,33 @@ import { tracked } from '@glimmer/tracking';
 // Render route errors abort the parent transition, so the nested render.error
 // route may not receive params or run its model hook. This service preserves
 // the serialized error payload so the template can still display it.
-export default class RenderErrorStateService extends Service {
-  @tracked private _reason: string | undefined;
+interface RenderErrorContext {
+  reason: string;
+  cardId?: string;
+  nonce?: string;
+}
 
-  setReason(reason: string) {
-    this._reason = reason;
+export default class RenderErrorStateService extends Service {
+  @tracked private _context: RenderErrorContext | undefined;
+
+  setError(context: RenderErrorContext) {
+    this._context = context;
   }
 
   get reason(): string | undefined {
-    return this._reason;
+    return this._context?.reason;
+  }
+
+  get cardId(): string | undefined {
+    return this._context?.cardId;
+  }
+
+  get nonce(): string | undefined {
+    return this._context?.nonce;
   }
 
   clear() {
-    this._reason = undefined;
+    this._context = undefined;
   }
 }
 

--- a/packages/host/app/templates/render.gts
+++ b/packages/host/app/templates/render.gts
@@ -7,9 +7,9 @@ import { Model } from '../routes/render';
 const Render = <template>
   <div
     data-prerender
-    data-prerender-id={{@model.instance.id}}
+    data-prerender-id={{@model.cardId}}
     data-prerender-nonce={{@model.nonce}}
-    data-prerender-status={{if @model.ready 'ready' 'loading'}}
+    data-prerender-status={{@model.status}}
   >
     {{outlet}}
   </div>

--- a/packages/host/app/templates/render/error.gts
+++ b/packages/host/app/templates/render/error.gts
@@ -19,8 +19,12 @@ class RenderErrorRouteComponent extends Component<Signature> {
   }
 
   <template>
-    <pre data-prerender-error>
-       {{this.reason}}
+    <pre
+      data-prerender-error
+      data-prerender-id={{this.renderErrorState.cardId}}
+      data-prerender-nonce={{this.renderErrorState.nonce}}
+    >
+      {{this.reason}}
     </pre>
   </template>
 }

--- a/packages/host/tests/acceptance/prerender-html-test.gts
+++ b/packages/host/tests/acceptance/prerender-html-test.gts
@@ -30,7 +30,7 @@ module('Acceptance | prerender | html', function (hooks) {
   });
 
   const DEFAULT_RENDER_OPTIONS_SEGMENT = encodeURIComponent(
-    JSON.stringify({ resetStore: true } as RenderRouteOptions),
+    JSON.stringify({ clearCache: true } as RenderRouteOptions),
   );
   const renderPath = (url: string, suffix: string, nonce = 0) =>
     `/render/${encodeURIComponent(

--- a/packages/host/tests/acceptance/prerender-meta-test.gts
+++ b/packages/host/tests/acceptance/prerender-meta-test.gts
@@ -30,7 +30,7 @@ module('Acceptance | prerender | meta', function (hooks) {
   });
 
   const DEFAULT_RENDER_OPTIONS_SEGMENT = encodeURIComponent(
-    JSON.stringify({ resetStore: true } as RenderRouteOptions),
+    JSON.stringify({ clearCache: true } as RenderRouteOptions),
   );
   const renderPath = (url: string, suffix: string, nonce = 0) =>
     `/render/${encodeURIComponent(

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -219,42 +219,61 @@ export async function capturePrerenderResult(
   expectedStatus: 'ready' | 'error' = 'ready',
 ): Promise<{ status: 'ready' | 'error'; value: string }> {
   await waitUntil(() => {
-    let el = document.querySelector('[data-prerender]') as HTMLElement | null;
-    if (!el) {
-      return false;
-    }
-    let status = el.dataset.prerenderStatus ?? '';
-    let hasError = !!el.querySelector('[data-prerender-error]');
+    let container = document.querySelector(
+      '[data-prerender]',
+    ) as HTMLElement | null;
+    let errorElement = document.querySelector(
+      '[data-prerender-error]',
+    ) as HTMLElement | null;
+    let errorText = (errorElement?.textContent ?? errorElement?.innerHTML ?? '')
+      .trim()
+      .trim();
     if (expectedStatus === 'error') {
-      return status === 'unusable' || hasError;
+      if (container) {
+        let status = container.dataset.prerenderStatus ?? '';
+        if (status === 'error' || status === 'unusable') {
+          return true;
+        }
+      }
+      return errorText.length > 0;
     }
-    if (hasError) {
+    if (errorText.length > 0) {
       return true;
     }
-    return status === expectedStatus;
+    if (!container) {
+      return false;
+    }
+    return (container.dataset.prerenderStatus ?? '') === expectedStatus;
   });
-  let element = document.querySelector('[data-prerender]') as HTMLElement;
-  let errorElement = element.querySelector(
+  let container = document.querySelector(
+    '[data-prerender]',
+  ) as HTMLElement | null;
+  let errorElement = document.querySelector(
     '[data-prerender-error]',
   ) as HTMLElement | null;
-  if (errorElement) {
-    let text = (
-      errorElement.textContent ??
-      errorElement.innerHTML ??
-      ''
-    ).trim();
-    return { status: 'error', value: text };
+  let errorText = (errorElement?.textContent ?? errorElement?.innerHTML ?? '')
+    .trim()
+    .trim();
+  if (errorText.length > 0) {
+    return { status: 'error', value: errorText };
   }
-  let status = element.dataset.prerenderStatus as 'ready' | 'unusable';
-  if (status === 'unusable') {
-    // there is a strange <anonymous> tag that is being appended to the innerHTML that this strips out
+  if (!container) {
+    throw new Error(
+      'capturePrerenderResult: missing [data-prerender] container after wait',
+    );
+  }
+  let status = container.dataset.prerenderStatus as
+    | 'ready'
+    | 'error'
+    | 'unusable'
+    | undefined;
+  if (status === 'error' || status === 'unusable') {
     return {
       status: 'error',
-      value: element.innerHTML!.replace(/}[^}]*$/, '}'),
+      value: container.innerHTML!.replace(/}[^}]*$/, '}'),
     };
-  } else {
-    return { status: 'ready', value: element.children[0][capture]! };
   }
+  return { status: 'ready', value: container.children[0][capture]! };
 }
 
 async function makeRenderer() {

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -251,9 +251,11 @@ export async function capturePrerenderResult(
   let errorElement = document.querySelector(
     '[data-prerender-error]',
   ) as HTMLElement | null;
-  let errorText = (errorElement?.textContent ?? errorElement?.innerHTML ?? '')
-    .trim()
-    .trim();
+  let errorText = (
+    errorElement?.textContent ??
+    errorElement?.innerHTML ??
+    ''
+  ).trim();
   if (errorText.length > 0) {
     return { status: 'error', value: errorText };
   }

--- a/packages/realm-server/prerender/prerender-app.ts
+++ b/packages/realm-server/prerender/prerender-app.ts
@@ -70,6 +70,9 @@ export function buildPrerenderApp(
           ? (attrs.renderOptions as RenderRouteOptions)
           : {};
 
+      log.debug(
+        `received prerender request ${url}: realm=${realm} userId=${userId} options=${JSON.stringify(renderOptions)} permissions=${JSON.stringify(permissions)}`,
+      );
       if (
         !url ||
         !userId ||
@@ -135,6 +138,15 @@ export function buildPrerenderApp(
           pool,
         },
       };
+      if (response.error) {
+        log.debug(
+          `render of ${url} resulted in error doc:\n${JSON.stringify(response.error, null, 2)}`,
+        );
+      } else {
+        log.debug(
+          `render of ${url} resulted in search doc:\n${JSON.stringify(response.searchDoc, null, 2)}`,
+        );
+      }
     } catch (err: any) {
       Sentry.captureException(err);
       log.error(`Unhandled error in /prerender:`, err);

--- a/packages/realm-server/prerender/utils.ts
+++ b/packages/realm-server/prerender/utils.ts
@@ -351,11 +351,11 @@ export async function captureResult(
           }
           let candidateId =
             candidate.dataset.prerenderId ??
-            errorElement?.dataset.dataPrerenderId ??
+            errorElement?.dataset.prerenderId ??
             null;
           let candidateNonce =
             candidate.dataset.prerenderNonce ??
-            errorElement?.dataset.dataPrerenderNonce ??
+            errorElement?.dataset.prerenderNonce ??
             null;
           if (targetId && candidateId && candidateId !== targetId) {
             return false;
@@ -440,11 +440,11 @@ export async function captureResult(
           alive,
           id:
             resolvedElement.dataset.prerenderId ??
-            errorElement?.dataset.dataPrerenderId ??
+            errorElement?.dataset.prerenderId ??
             undefined,
           nonce:
             resolvedElement.dataset.prerenderNonce ??
-            errorElement?.dataset.dataPrerenderNonce ??
+            errorElement?.dataset.prerenderNonce ??
             undefined,
         } as RenderCapture;
       } else {

--- a/packages/realm-server/prerender/utils.ts
+++ b/packages/realm-server/prerender/utils.ts
@@ -1,10 +1,13 @@
 import {
   delay,
+  logger,
   type PrerenderMeta,
   type RenderError,
 } from '@cardstack/runtime-common';
 
 import { type Page } from 'puppeteer';
+
+const log = logger('prerenderer');
 
 export const renderTimeoutMs = Number(process.env.RENDER_TIMEOUT_MS ?? 15_000);
 
@@ -186,7 +189,7 @@ export async function captureResult(
   capture: 'textContent' | 'innerHTML' | 'outerHTML',
   opts?: CaptureOptions,
 ): Promise<RenderCapture> {
-  const statuses: RenderStatus[] = ['ready', 'unusable'];
+  const statuses: RenderStatus[] = ['ready', 'error', 'unusable'];
   await page.waitForFunction(
     (
       statuses: string[],
@@ -200,7 +203,11 @@ export async function captureResult(
         let errorElement = document.querySelector(
           '[data-prerender-error]',
         ) as HTMLElement | null;
-        return Boolean(errorElement);
+        if (!errorElement) {
+          return false;
+        }
+        let raw = errorElement.textContent ?? errorElement.innerHTML ?? '';
+        return raw.trim().length > 0;
       }
       let path = window.location.pathname;
       let expectingRender = path.includes('/render/');
@@ -231,9 +238,16 @@ export async function captureResult(
       }
       for (let element of elements) {
         let status = element.dataset.prerenderStatus ?? '';
-        let hasError =
-          status === 'loading' &&
-          element.querySelector('[data-prerender-error]') !== null;
+        const errorElement = element.querySelector(
+          '[data-prerender-error]',
+        ) as HTMLElement | null;
+        const errorText = (
+          errorElement?.textContent ??
+          errorElement?.innerHTML ??
+          ''
+        ).trim();
+        const errorHasText = errorText.length > 0;
+        const hasError = errorElement !== null && errorHasText;
         if (!statuses.includes(status) && !hasError) {
           continue;
         }
@@ -256,11 +270,21 @@ export async function captureResult(
       if (!expectingRender) {
         return elements.some((element) => {
           let status = element.dataset.prerenderStatus ?? '';
+          const errorElement = element.querySelector(
+            '[data-prerender-error]',
+          ) as HTMLElement | null;
+          const errorText = (
+            errorElement?.textContent ??
+            errorElement?.innerHTML ??
+            ''
+          ).trim();
+          const errorHasText = errorText.length > 0;
+          const hasError = errorElement !== null && errorHasText;
           if (statuses.includes(status)) {
             return true;
           }
-          if (status === 'loading') {
-            return element.querySelector('[data-prerender-error]') !== null;
+          if (hasError) {
+            return true;
           }
           return false;
         });
@@ -312,24 +336,31 @@ export async function captureResult(
       let element =
         elements.find((candidate) => {
           let status = candidate.dataset.prerenderStatus ?? '';
-          let hasError =
-            status === 'loading' &&
-            candidate.querySelector('[data-prerender-error]') !== null;
+          const errorElement = candidate.querySelector(
+            '[data-prerender-error]',
+          ) as HTMLElement | null;
+          const errorText = (
+            errorElement?.textContent ??
+            errorElement?.innerHTML ??
+            ''
+          ).trim();
+          const errorHasText = errorText.length > 0;
+          const hasError = errorElement !== null && errorHasText;
           if (!statuses.includes(status) && !hasError) {
             return false;
           }
-          if (
-            targetId &&
-            candidate.dataset.prerenderId &&
-            candidate.dataset.prerenderId !== targetId
-          ) {
+          let candidateId =
+            candidate.dataset.prerenderId ??
+            errorElement?.dataset.dataPrerenderId ??
+            null;
+          let candidateNonce =
+            candidate.dataset.prerenderNonce ??
+            errorElement?.dataset.dataPrerenderNonce ??
+            null;
+          if (targetId && candidateId && candidateId !== targetId) {
             return false;
           }
-          if (
-            targetNonce &&
-            candidate.dataset.prerenderNonce &&
-            candidate.dataset.prerenderNonce !== targetNonce
-          ) {
+          if (targetNonce && candidateNonce && candidateNonce !== targetNonce) {
             return false;
           }
           return true;
@@ -339,10 +370,17 @@ export async function captureResult(
           if (statuses.includes(status)) {
             return true;
           }
-          if (status === 'loading') {
-            return candidate.querySelector('[data-prerender-error]') !== null;
-          }
-          return false;
+          const fallbackErrorElement = candidate.querySelector(
+            '[data-prerender-error]',
+          ) as HTMLElement | null;
+          const fallbackText = (
+            fallbackErrorElement?.textContent ??
+            fallbackErrorElement?.innerHTML ??
+            ''
+          ).trim();
+          const fallbackHasError =
+            fallbackErrorElement !== null && fallbackText.length > 0;
+          return fallbackHasError;
         });
       let strayErrorElement: HTMLElement | null = null;
       if (!element) {
@@ -365,6 +403,9 @@ export async function captureResult(
         return {
           status: 'error',
           value: json.trim(),
+          id: strayErrorElement.getAttribute('data-prerender-id') ?? undefined,
+          nonce:
+            strayErrorElement.getAttribute('data-prerender-nonce') ?? undefined,
         } as RenderCapture;
       }
       let resolvedElement = element as HTMLElement;
@@ -397,8 +438,14 @@ export async function captureResult(
           status,
           value: json.trim(),
           alive,
-          id: resolvedElement.dataset.prerenderId ?? undefined,
-          nonce: resolvedElement.dataset.prerenderNonce ?? undefined,
+          id:
+            resolvedElement.dataset.prerenderId ??
+            errorElement?.dataset.dataPrerenderId ??
+            undefined,
+          nonce:
+            resolvedElement.dataset.prerenderNonce ??
+            errorElement?.dataset.dataPrerenderNonce ??
+            undefined,
         } as RenderCapture;
       } else {
         const firstChild = resolvedElement.children[0] as HTMLElement & {
@@ -449,6 +496,11 @@ export async function withTimeout<T>(
     let [_a, _b, encodedId] = url.pathname.split('/');
     let id = encodedId ? decodeURIComponent(encodedId) : undefined;
 
+    let dom = await page.evaluate(() => {
+      let el = document.querySelector('[data-prerender]');
+      return el?.outerHTML;
+    });
+    log.warn(`render of ${id} timed out with DOM:\n${dom?.trim()}`);
     return {
       error: {
         id,

--- a/packages/realm-server/tests/headless-chrome-indexing-test.ts
+++ b/packages/realm-server/tests/headless-chrome-indexing-test.ts
@@ -2455,7 +2455,6 @@ module(basename(__filename), function () {
     module('readable realm', function (hooks) {
       setupRealms(hooks, {
         provider: {
-          // [testRealmServerMatrixUserId]: ['read'],
           ['@node-test_realm:localhost']: ['read'],
         },
         consumer: {

--- a/packages/realm-server/tests/headless-chrome-indexing-test.ts
+++ b/packages/realm-server/tests/headless-chrome-indexing-test.ts
@@ -1,4 +1,4 @@
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { dirSync } from 'tmp';
 import {
   type IndexedInstance,
@@ -20,7 +20,6 @@ import {
   runTestRealmServer,
   closeServer,
   setupPermissionedRealms,
-  testRealmServerMatrixUserId,
   cardInfo,
 } from './helpers';
 import stripScopedCSSAttributes from '@cardstack/runtime-common/helpers/strip-scoped-css-attributes';
@@ -444,6 +443,17 @@ module(basename(__filename), function () {
     let realm: Realm;
     let testRealmServer: TestRealmServerResult | undefined;
 
+    async function getInstance(
+      realm: Realm,
+      url: URL,
+    ): Promise<IndexedInstance | undefined> {
+      let maybeInstance = await realm.realmIndexQueryEngine.instance(url);
+      if (maybeInstance?.type === 'error') {
+        return undefined;
+      }
+      return maybeInstance;
+    }
+
     setupBaseRealmServer(hooks, matrixURL);
 
     setupDB(hooks, {
@@ -663,6 +673,176 @@ module(basename(__filename), function () {
       } else {
         assert.ok('false', 'expected search entry to be an error document');
       }
+    });
+
+    // Note this particular test should only be a server test as the nature of
+    // the TestAdapter in the host tests will trigger the linked card to be
+    // already loaded when in fact in the real world it is not.
+    test('it can index a card with a contains computed that consumes a linksTo field', async function (assert) {
+      const hassanId = `${testRealm}hassan`;
+      let queryEngine = realm.realmIndexQueryEngine;
+      let hassan = await queryEngine.cardDocument(new URL(hassanId));
+      if (hassan?.type === 'doc') {
+        assert.deepEqual(
+          hassan.doc.data.attributes,
+          {
+            title: 'Untitled Card',
+            nickName: "Ringo's buddy",
+            firstName: 'Hassan',
+            description: null,
+            thumbnailURL: null,
+            cardInfo,
+          },
+          'doc attributes are correct',
+        );
+        assert.deepEqual(
+          hassan.doc.data.relationships,
+          {
+            pet: {
+              links: {
+                self: './ringo',
+              },
+            },
+            'cardInfo.theme': {
+              links: {
+                self: null,
+              },
+            },
+          },
+          'doc relationships are correct',
+        );
+      } else {
+        assert.ok(
+          false,
+          `search entry was an error: ${hassan?.error.errorDetail.message}`,
+        );
+      }
+
+      let hassanEntry = await getInstance(realm, new URL(`${testRealm}hassan`));
+      if (hassanEntry) {
+        assert.deepEqual(
+          hassanEntry.searchDoc,
+          {
+            id: hassanId,
+            pet: {
+              id: `${testRealm}ringo`,
+              title: 'Untitled Card',
+              firstName: 'Ringo',
+              cardInfo: {
+                theme: null,
+              },
+            },
+            nickName: "Ringo's buddy",
+            _cardType: 'PetPerson',
+            firstName: 'Hassan',
+            title: 'Untitled Card',
+            cardInfo: {
+              theme: null,
+            },
+          },
+          'searchData is correct',
+        );
+      } else {
+        assert.ok(false, `could not find ${hassanId} in the index`);
+      }
+    });
+
+    test('sets resource_created_at for modules and instances', async function (assert) {
+      let entry = (await realm.realmIndexQueryEngine.module(
+        new URL(`${testRealm}fancy-person.gts`),
+      )) as { resourceCreatedAt: number };
+
+      assert.ok(entry!.resourceCreatedAt, 'resourceCreatedAt is set');
+
+      entry = (await realm.realmIndexQueryEngine.instance(
+        new URL(`${testRealm}mango`),
+      )) as { resourceCreatedAt: number };
+
+      assert.ok(entry!.resourceCreatedAt, 'resourceCreatedAt is set');
+    });
+
+    test('sets urls containing encoded CSS for deps for a module', async function (assert) {
+      let entry = (await realm.realmIndexQueryEngine.module(
+        new URL(`${testRealm}fancy-person.gts`),
+      )) as { deps: string[] };
+
+      let assertCssDependency = (
+        deps: string[],
+        pattern: RegExp,
+        fileName: string,
+      ) => {
+        assert.true(
+          !!deps.find((dep) => pattern.test(dep)),
+          `css for ${fileName} is in the deps`,
+        );
+      };
+
+      let dependencies = [
+        {
+          pattern: /fancy-person\.gts.*\.glimmer-scoped\.css$/,
+          fileName: 'fancy-person.gts',
+        },
+        {
+          pattern: /\/person\.gts.*\.glimmer-scoped\.css$/,
+          fileName: 'person.gts',
+        },
+        {
+          pattern:
+            /cardstack.com\/base\/default-templates\/embedded\.gts.*\.glimmer-scoped\.css$/,
+          fileName: 'default-templates/embedded.gts',
+        },
+        {
+          pattern:
+            /cardstack.com\/base\/default-templates\/isolated-and-edit\.gts.*\.glimmer-scoped\.css$/,
+          fileName: 'default-templates/isolated-and-edit.gts',
+        },
+        {
+          pattern:
+            /cardstack.com\/base\/default-templates\/missing-template\.gts.*\.glimmer-scoped\.css$/,
+          fileName: 'default-templates/missing-template.gts',
+        },
+        {
+          pattern:
+            /cardstack.com\/base\/default-templates\/field-edit\.gts.*\.glimmer-scoped\.css$/,
+          fileName: 'default-templates/field-edit.gts',
+        },
+        {
+          pattern:
+            /cardstack.com\/base\/links-to-many-component.gts.*\.glimmer-scoped\.css$/,
+          fileName: 'links-to-many-component.gts',
+        },
+        {
+          pattern:
+            /cardstack.com\/base\/links-to-editor.gts.*\.glimmer-scoped\.css$/,
+          fileName: 'links-to-editor.gts',
+        },
+        {
+          pattern:
+            /cardstack.com\/base\/contains-many-component.gts.*\.glimmer-scoped\.css$/,
+          fileName: 'contains-many-component.gts',
+        },
+        {
+          pattern:
+            /cardstack.com\/base\/field-component.gts.*\.glimmer-scoped\.css$/,
+          fileName: 'field-component.gts',
+        },
+      ];
+
+      dependencies.forEach(({ pattern, fileName }) => {
+        assertCssDependency(entry.deps, pattern, fileName);
+      });
+    });
+
+    test('will not invalidate non-json/non-executable files', async function (assert) {
+      let deletedEntries = (await testDbAdapter.execute(
+        `SELECT url FROM boxel_index WHERE is_deleted = TRUE`,
+      )) as { url: string }[];
+
+      let deletedEntryUrls = deletedEntries.map((row) => row.url);
+
+      ['random-file.txt', 'random-image.png', '.DS_Store'].forEach((file) => {
+        assert.notOk(deletedEntryUrls.includes(file));
+      });
     });
 
     test('can make a definition entry in the index', async function (assert) {
@@ -1292,17 +1472,6 @@ module(basename(__filename), function () {
   });
 
   module('indexing - headless chrome', function (hooks) {
-    async function getInstance(
-      realm: Realm,
-      url: URL,
-    ): Promise<IndexedInstance | undefined> {
-      let maybeInstance = await realm.realmIndexQueryEngine.instance(url);
-      if (maybeInstance?.type === 'error') {
-        return undefined;
-      }
-      return maybeInstance;
-    }
-
     let realm: Realm;
     let adapter: RealmAdapter;
     let testRealmServer: TestRealmServerResult | undefined;
@@ -1464,7 +1633,7 @@ module(basename(__filename), function () {
       );
     });
 
-    skip('can recover from a module sequence error', async function (assert) {
+    test('can recover from a module sequence error', async function (assert) {
       // introduce errors into 2 gts file with first module has dependency on second module
       await realm.write(
         'pet.gts',
@@ -1476,19 +1645,6 @@ module(basename(__filename), function () {
             @field name = contains(Name);
           }
         `,
-      );
-      assert.deepEqual(
-        { ...realm.realmIndexUpdater.stats },
-        {
-          instancesIndexed: 0,
-          instanceErrors: 2,
-          moduleErrors: 2,
-          modulesIndexed: 0,
-          definitionErrors: 0,
-          definitionsIndexed: 0,
-          totalIndexEntries: 20,
-        },
-        'indexed correct number of files',
       );
       let petDefinitionEntry =
         await realm.realmIndexQueryEngine.getOwnDefinition({
@@ -1533,20 +1689,6 @@ module(basename(__filename), function () {
       );
 
       // Since the name is ready, the pet should be indexed and not in an error state
-      assert.deepEqual(
-        { ...realm.realmIndexUpdater.stats },
-        {
-          instancesIndexed: 1,
-          instanceErrors: 1,
-          moduleErrors: 0,
-          modulesIndexed: 3,
-          definitionErrors: 0,
-          definitionsIndexed: 3,
-          totalIndexEntries: 27,
-        },
-        'indexed correct number of files',
-      );
-
       // Fetch the pet module
       let pet = await realm.realmIndexQueryEngine.module(
         new URL(`${testRealm}pet`),
@@ -1558,7 +1700,7 @@ module(basename(__filename), function () {
       );
     });
 
-    skip('can successfully create instance after module sequence error is resolved', async function (assert) {
+    test('can successfully create instance after module sequence error is resolved', async function (assert) {
       // First create pet.gts that depends on name.gts which doesn't exist yet
       await realm.write(
         'pet.gts',
@@ -1570,22 +1712,6 @@ module(basename(__filename), function () {
             @field name = contains(Name);
           }
         `,
-      );
-
-      // Verify initial error state
-      assert.deepEqual(
-        { ...realm.realmIndexUpdater.stats },
-        {
-          instancesIndexed: 0,
-          instanceErrors: 2,
-          moduleErrors: 2,
-          modulesIndexed: 0,
-
-          definitionErrors: 0,
-          definitionsIndexed: 0,
-          totalIndexEntries: 20,
-        },
-        'instance and module are in error state before dependency is available',
       );
 
       // Now create the missing name.gts module
@@ -1669,11 +1795,11 @@ module(basename(__filename), function () {
       );
     });
 
-    skip('can incrementally index instance that depends on updated card source', async function (assert) {
+    test('can incrementally index instance that depends on updated card source', async function (assert) {
       await realm.write(
         'post.gts',
         `
-        import { contains, linksTo, field, CardDef } from "https://cardstack.com/base/card-api";
+        import { contains, linksTo, field, CardDef, Component } from "https://cardstack.com/base/card-api";
         import StringField from "https://cardstack.com/base/string";
         import { Person } from "./person";
 
@@ -1685,6 +1811,12 @@ module(basename(__filename), function () {
               return this.author.firstName + '-poo';
             }
           })
+          static isolated = class Isolated extends Component<typeof this> {
+            <template>
+              <h1><@fields.message/></h1>
+              <h2><@fields.author/></h2>
+            </template>
+          }
         }
       `,
       );
@@ -1696,23 +1828,9 @@ module(basename(__filename), function () {
         },
       });
       assert.strictEqual(result.length, 1, 'found updated document');
-      assert.deepEqual(
-        // we splat because despite having the same shape, the constructors are different
-        { ...realm.realmIndexUpdater.stats },
-        {
-          instancesIndexed: 1,
-          instanceErrors: 1,
-          moduleErrors: 0,
-          modulesIndexed: 1,
-          definitionErrors: 0,
-          definitionsIndexed: 1,
-          totalIndexEntries: 26,
-        },
-        'indexed correct number of files',
-      );
     });
 
-    skip('can incrementally index instance that depends on updated card source consumed by other card sources', async function (assert) {
+    test('can incrementally index instance that depends on updated card source consumed by other card sources', async function (assert) {
       await realm.write(
         'person.gts',
         `
@@ -1729,6 +1847,9 @@ module(basename(__filename), function () {
             static embedded = class Embedded extends Component<typeof this> {
               <template><@fields.firstName/> (<@fields.nickName/>)</template>
             }
+            static fitted = class Fitted extends Component<typeof this> {
+              <template><@fields.firstName/> (<@fields.nickName/>)</template>
+            }
           }
         `,
       );
@@ -1740,23 +1861,9 @@ module(basename(__filename), function () {
         },
       });
       assert.strictEqual(result.length, 1, 'found updated document');
-      assert.deepEqual(
-        // we splat because despite having the same shape, the constructors are different
-        { ...realm.realmIndexUpdater.stats },
-        {
-          instancesIndexed: 3,
-          instanceErrors: 1,
-          moduleErrors: 0,
-          modulesIndexed: 3,
-          definitionErrors: 0,
-          definitionsIndexed: 3,
-          totalIndexEntries: 26,
-        },
-        'indexed correct number of files',
-      );
     });
 
-    skip('can incrementally index instance that depends on deleted card source', async function (assert) {
+    test('can incrementally index instance that depends on deleted card source', async function (assert) {
       await realm.delete('post.gts');
       {
         let { data: result } = await realm.realmIndexQueryEngine.search({
@@ -1793,26 +1900,12 @@ module(basename(__filename), function () {
       } else {
         assert.ok(false, 'search index entry is not an error document');
       }
-      assert.deepEqual(
-        // we splat because despite having the same shape, the constructors are different
-        { ...realm.realmIndexUpdater.stats },
-        {
-          instancesIndexed: 0,
-          instanceErrors: 2,
-          moduleErrors: 0,
-          modulesIndexed: 0,
-          definitionErrors: 0,
-          definitionsIndexed: 0,
-          totalIndexEntries: 23,
-        },
-        'indexed correct number of files',
-      );
 
       // when the definitions is created again, the instance should mend its broken link
       await realm.write(
         'post.gts',
         `
-        import { contains, linksTo, field, CardDef } from "https://cardstack.com/base/card-api";
+        import { contains, linksTo, field, CardDef, Component } from "https://cardstack.com/base/card-api";
         import StringField from "https://cardstack.com/base/string";
         import { Person } from "./person";
 
@@ -1821,9 +1914,15 @@ module(basename(__filename), function () {
           @field message = contains(StringField);
           @field nickName = contains(StringField, {
             computeVia: function() {
-              return this.author.firstName + '-poo';
+              return this.author?.firstName + '-poo';
             }
           })
+          static embedded = class Embedded extends Component<typeof this> {
+            <template><@fields.firstName/> (<@fields.nickName/>)</template>
+          }
+          static fitted = class Fitted extends Component<typeof this> {
+            <template><@fields.firstName/> (<@fields.nickName/>)</template>
+          }
         }
       `,
       );
@@ -1836,112 +1935,9 @@ module(basename(__filename), function () {
         });
         assert.strictEqual(result.length, 1, 'found the post instance');
       }
-      assert.deepEqual(
-        // we splat because despite having the same shape, the constructors are different
-        { ...realm.realmIndexUpdater.stats },
-        {
-          instancesIndexed: 1,
-          instanceErrors: 1,
-          moduleErrors: 0,
-          modulesIndexed: 1,
-          definitionErrors: 0,
-          definitionsIndexed: 1,
-          totalIndexEntries: 26,
-        },
-        'indexed correct number of files',
-      );
     });
 
-    // Note this particular test should only be a server test as the nature of
-    // the TestAdapter in the host tests will trigger the linked card to be
-    // already loaded when in fact in the real world it is not.
-    skip('it can index a card with a contains computed that consumes a linksTo field', async function (assert) {
-      const hassanId = `${testRealm}hassan`;
-      let queryEngine = realm.realmIndexQueryEngine;
-      let hassan = await queryEngine.cardDocument(new URL(hassanId));
-      if (hassan?.type === 'doc') {
-        assert.deepEqual(
-          hassan.doc.data.attributes,
-          {
-            title: 'Untitled Card',
-            nickName: "Ringo's buddy",
-            firstName: 'Hassan',
-            description: null,
-            thumbnailURL: null,
-            cardInfo,
-          },
-          'doc attributes are correct',
-        );
-        assert.deepEqual(
-          hassan.doc.data.relationships,
-          {
-            pet: {
-              links: {
-                self: './ringo',
-              },
-            },
-            'cardInfo.theme': {
-              links: {
-                self: null,
-              },
-            },
-          },
-          'doc relationships are correct',
-        );
-      } else {
-        assert.ok(
-          false,
-          `search entry was an error: ${hassan?.error.errorDetail.message}`,
-        );
-      }
-
-      let hassanEntry = await getInstance(realm, new URL(`${testRealm}hassan`));
-      if (hassanEntry) {
-        assert.deepEqual(
-          hassanEntry.searchDoc,
-          {
-            id: hassanId,
-            pet: {
-              id: `${testRealm}ringo`,
-              title: 'Untitled Card',
-              firstName: 'Ringo',
-              description: null,
-              thumbnailURL: null,
-              cardInfo: {
-                ...cardInfo,
-                theme: null,
-              },
-            },
-            nickName: "Ringo's buddy",
-            _cardType: 'PetPerson',
-            firstName: 'Hassan',
-            title: 'Untitled Card',
-            cardInfo: {
-              theme: null,
-            },
-          },
-          'searchData is correct',
-        );
-      } else {
-        assert.ok(false, `could not find ${hassanId} in the index`);
-      }
-
-      assert.deepEqual(
-        // we splat because despite having the same shape, the constructors are different
-        { ...realm.realmIndexUpdater.stats },
-        {
-          moduleErrors: 0,
-          instanceErrors: 6,
-          modulesIndexed: 10,
-          instancesIndexed: 6,
-          definitionErrors: 0,
-          definitionsIndexed: 10,
-          totalIndexEntries: 26,
-        },
-        'indexed correct number of files',
-      );
-    });
-
+    // TODO i'm skeptical we are testing the right thing here since the new headless chrome indexing doesn't know about isUsed yet. Let's revisit in CS-9539
     test('it can index a card with a contains computed that consumes a linksTo field that is NOT in template but uses "isUsed" option', async function (assert) {
       await realm.write(
         'task.gts',
@@ -2031,104 +2027,6 @@ module(basename(__filename), function () {
         'instance',
         'task instance created without any error',
       );
-    });
-
-    test('sets resource_created_at for modules and instances', async function (assert) {
-      let entry = (await realm.realmIndexQueryEngine.module(
-        new URL(`${testRealm}fancy-person.gts`),
-      )) as { resourceCreatedAt: number };
-
-      assert.ok(entry!.resourceCreatedAt, 'resourceCreatedAt is set');
-
-      entry = (await realm.realmIndexQueryEngine.instance(
-        new URL(`${testRealm}mango`),
-      )) as { resourceCreatedAt: number };
-
-      assert.ok(entry!.resourceCreatedAt, 'resourceCreatedAt is set');
-    });
-
-    skip('sets urls containing encoded CSS for deps for a module', async function (assert) {
-      let entry = (await realm.realmIndexQueryEngine.module(
-        new URL('http://test-realm/fancy-person.gts'),
-      )) as { deps: string[] };
-
-      let assertCssDependency = (
-        deps: string[],
-        pattern: RegExp,
-        fileName: string,
-      ) => {
-        assert.true(
-          !!deps.find((dep) => pattern.test(dep)),
-          `css for ${fileName} is in the deps`,
-        );
-      };
-
-      let dependencies = [
-        {
-          pattern: /fancy-person\.gts.*\.glimmer-scoped\.css$/,
-          fileName: 'fancy-person.gts',
-        },
-        {
-          pattern: /test-realm\/person\.gts.*\.glimmer-scoped\.css$/,
-          fileName: 'person.gts',
-        },
-        {
-          pattern:
-            /cardstack.com\/base\/default-templates\/embedded\.gts.*\.glimmer-scoped\.css$/,
-          fileName: 'default-templates/embedded.gts',
-        },
-        {
-          pattern:
-            /cardstack.com\/base\/default-templates\/isolated-and-edit\.gts.*\.glimmer-scoped\.css$/,
-          fileName: 'default-templates/isolated-and-edit.gts',
-        },
-        {
-          pattern:
-            /cardstack.com\/base\/default-templates\/missing-template\.gts.*\.glimmer-scoped\.css$/,
-          fileName: 'default-templates/missing-template.gts',
-        },
-        {
-          pattern:
-            /cardstack.com\/base\/default-templates\/field-edit\.gts.*\.glimmer-scoped\.css$/,
-          fileName: 'default-templates/field-edit.gts',
-        },
-        {
-          pattern:
-            /cardstack.com\/base\/links-to-many-component.gts.*\.glimmer-scoped\.css$/,
-          fileName: 'links-to-many-component.gts',
-        },
-        {
-          pattern:
-            /cardstack.com\/base\/links-to-editor.gts.*\.glimmer-scoped\.css$/,
-          fileName: 'links-to-editor.gts',
-        },
-        {
-          pattern:
-            /cardstack.com\/base\/contains-many-component.gts.*\.glimmer-scoped\.css$/,
-          fileName: 'contains-many-component.gts',
-        },
-        {
-          pattern:
-            /cardstack.com\/base\/field-component.gts.*\.glimmer-scoped\.css$/,
-          fileName: 'field-component.gts',
-        },
-      ];
-
-      dependencies.forEach(({ pattern, fileName }) => {
-        assertCssDependency(entry.deps, pattern, fileName);
-      });
-    });
-
-    test('will not invalidate non-json/non-executable files', async function (assert) {
-      let deletedEntries = (await testDbAdapter.execute(
-        `SELECT url FROM boxel_index WHERE is_deleted = TRUE`,
-      )) as { url: string }[];
-
-      let deletedEntryUrls = deletedEntries.map((row) => row.url);
-
-      ['random-file.txt', 'random-image.png', '.DS_Store'].forEach((file) => {
-        assert.notOk(deletedEntryUrls.includes(file));
-      });
     });
 
     test('should be able to handle dependencies between modules', async function (assert) {
@@ -2322,6 +2220,7 @@ module(basename(__filename), function () {
         'BlogApp module is in resolved module successfully',
       );
     });
+
     test('can write several modules at once', async function (assert) {
       let mapOfWrites = new Map();
       mapOfWrites.set(
@@ -2556,14 +2455,15 @@ module(basename(__filename), function () {
     module('readable realm', function (hooks) {
       setupRealms(hooks, {
         provider: {
-          [testRealmServerMatrixUserId]: ['read'],
+          // [testRealmServerMatrixUserId]: ['read'],
+          ['@node-test_realm:localhost']: ['read'],
         },
         consumer: {
           '*': ['read', 'write'],
         },
       });
 
-      skip('has no module errors when trying to index a card from another realm when it has permission to read', async function (assert) {
+      test('has no module errors when trying to index a card from another realm when it has permission to read', async function (assert) {
         assert.deepEqual(
           // we splat because despite having the same shape, the constructors are different
           { ...testRealm2.realmIndexUpdater.stats },

--- a/packages/runtime-common/render-route-options.ts
+++ b/packages/runtime-common/render-route-options.ts
@@ -1,8 +1,7 @@
 import stringify from 'safe-stable-stringify';
 
 export interface RenderRouteOptions {
-  includesCodeChange?: true;
-  resetStore?: true;
+  clearCache?: true;
 }
 
 export function parseRenderRouteOptions(
@@ -12,7 +11,8 @@ export function parseRenderRouteOptions(
     return {};
   }
   try {
-    return JSON.parse(raw) as RenderRouteOptions;
+    let parsed = JSON.parse(raw) as RenderRouteOptions;
+    return parsed.clearCache ? { clearCache: true } : {};
   } catch {
     return {};
   }
@@ -21,5 +21,8 @@ export function parseRenderRouteOptions(
 export function serializeRenderRouteOptions(
   options: RenderRouteOptions = {},
 ): string {
-  return stringify(options);
+  if (options.clearCache) {
+    return stringify({ clearCache: true }) ?? '{}';
+  }
+  return stringify({}) ?? '{}';
 }


### PR DESCRIPTION
In this PR I made a very good refactor that solved async bugs in our prerender. Specifically we were not waiting for the right moment to begin tracking promises related to field loading. The idea is that the rendering our our template is what pulls on the linked fields to begin their lazy loading. However, previously in our `/render` route, we were waiting for the linked fields to finish loading _before_ we actually rendered the template. We were just doing a simple wait for the store to settle in the model hook—this was simply too early.  this meant that oftentimes the `store.loaded()` promise would resolve before we ever started tracking the link loading promises because the template didn't yet have an opportunity to pull on the linked fields. In fact, there is no point in time in the model hook of the `/render` route when we even know what all linked fields should be loaded. 

this led to a lot of flakiness that became ever more present in the headless chrome node indexing tests as i got farther along. after codex start making crazy hacks to work around the fact that the instance was not settling, I took a step back and rethink this.

 This PR establishes a deferred in our `/render` route model hook that only begins the wait on the linked fields _after_ we have rendered the instance's template, at the point that all the lazy loading for the linked fields has kicked off and we’ve begun tracking those inflight requests. There is a lot of rather paranoid prerender capture code that stemmed from this flakiness that could probably be cleaned up now. I'll try to slim things  down in a subsequent PR.
