### PR TITLE
Create a session room after creating a realm

### DIFF
--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -447,8 +447,11 @@ export class RealmServer {
       },
     });
 
+    let realm = this.createAndMountRealm(realmPath, url, username);
+    await realm.ensureSessionRoom(ownerUserId);
+
     return {
-      realm: this.createAndMountRealm(realmPath, url, username),
+      realm,
       info,
     };
   };

--- a/packages/realm-server/tests/server-endpoints-test.ts
+++ b/packages/realm-server/tests/server-endpoints-test.ts
@@ -57,6 +57,7 @@ import sinon from 'sinon';
 import { getStripe } from '@cardstack/billing/stripe-webhook-handlers/stripe';
 import * as boxelUIChangeChecker from '../lib/boxel-ui-change-checker';
 import { APP_BOXEL_REALM_SERVER_EVENT_MSGTYPE } from '@cardstack/runtime-common/matrix-constants';
+import { fetchSessionRoom } from '@cardstack/runtime-common/db-queries/session-room-queries';
 import type {
   MatrixEvent,
   RealmServerEventContent,
@@ -230,6 +231,16 @@ module(basename(__filename), function () {
             ],
             [ownerUserId]: ['read', 'write', 'realm-owner'],
           });
+
+          let sessionRoom = await fetchSessionRoom(
+            dbAdapter,
+            json.data.id,
+            ownerUserId,
+          );
+          assert.ok(
+            sessionRoom,
+            'session room record was created for the owner after realm creation',
+          );
 
           let id: string;
           let realm = testRealmServer2.testingOnlyRealms.find(


### PR DESCRIPTION
This is an optimization step so that we don't have to go through creating session rooms when logging into realms.