### PR TITLE
Update schema

### DIFF
--- a/packages/host/config/schema/1759459363190_schema.sql
+++ b/packages/host/config/schema/1759459363190_schema.sql
@@ -55,14 +55,6 @@
    PRIMARY KEY ( url, realm_url ) 
 );
 
- CREATE TABLE IF NOT EXISTS claimed_domains_for_sites (
-   id DEFAULT (hex(randomblob(16))) NOT NULL,
-   hostname TEXT NOT NULL,
-   claimed_at INTEGER NOT NULL,
-   removed_at INTEGER,
-   PRIMARY KEY ( id ) 
-);
-
  CREATE TABLE IF NOT EXISTS published_realms (
    id DEFAULT (hex(randomblob(16))) NOT NULL,
    owner_username TEXT NOT NULL,

--- a/packages/postgres/scripts/schema-dump.sh
+++ b/packages/postgres/scripts/schema-dump.sh
@@ -28,6 +28,8 @@ docker exec boxel-pg pg_dump \
   --exclude-table-and-children=stripe_events \
   --exclude-table-and-children=ai_bot_event_processing \
   --exclude-table-and-children=proxy_endpoints \
+  --exclude-table-and-children=claimed_domains_for_sites \
+  --exclude-table-and-children=session_rooms \
   --no-tablespaces \
   --no-table-access-method \
   --no-owner \


### PR DESCRIPTION
Excludes `claimed_domains_for_sites` and `session_rooms` since these are not needed for in-browser indexing in tests. 