### PR TITLE
Make claiming domains for boxel site functional

### DIFF
--- a/packages/host/app/services/realm-server.ts
+++ b/packages/host/app/services/realm-server.ts
@@ -558,6 +558,36 @@ export default class RealmServerService extends Service {
     return (await response.json()) as SubdomainAvailabilityResult;
   }
 
+  async claimBoxelDomain(sourceRealmURL: string, hostname: string) {
+    const requestBody = {
+      data: {
+        type: 'claimed-site-hostname',
+        attributes: {
+          source_realm_url: sourceRealmURL,
+          hostname: hostname,
+        },
+      },
+    };
+
+    const response = await this.realmServer.authedFetch(
+      `${this.url.href}_boxel-claimed-domains`,
+      {
+        method: 'POST',
+        headers: {
+          Accept: SupportedMimeType.JSONAPI,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(requestBody),
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(await response.text());
+    }
+
+    return response.json();
+  }
+
   async unpublishRealm(publishedRealmURL: string) {
     await this.login();
 

--- a/packages/host/tests/acceptance/host-submode-test.gts
+++ b/packages/host/tests/acceptance/host-submode-test.gts
@@ -814,8 +814,6 @@ module('Acceptance | host submode', function (hooks) {
         assert.dom('[data-test-custom-subdomain-cancel]').exists();
         assert.dom('[data-test-custom-subdomain-input]').exists();
 
-        await this.pauseTest();
-
         // Should display the error message (extracted from the response)
         assert
           .dom('[data-test-boxel-input-group-error-message]')

--- a/packages/host/tests/acceptance/host-submode-test.gts
+++ b/packages/host/tests/acceptance/host-submode-test.gts
@@ -1,4 +1,10 @@
-import { click, triggerEvent, waitFor, waitUntil } from '@ember/test-helpers';
+import {
+  click,
+  fillIn,
+  triggerEvent,
+  waitFor,
+  waitUntil,
+} from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import window from 'ember-window-mock';
@@ -668,6 +674,152 @@ module('Acceptance | host submode', function (hooks) {
         });
 
         assert.dom('[data-test-open-site-button]').doesNotExist();
+      });
+
+      test('can claim domain for boxel site', async function (assert) {
+        let mockDomainValidationResponse = async (request: Request) => {
+          if (!request.url.includes('_check-boxel-domain-availability')) {
+            return null;
+          }
+
+          return new Response(
+            JSON.stringify({
+              available: true,
+              domain: 'my-boxel-site.localhost',
+            }),
+            {
+              headers: {
+                'Content-Type': 'application/json',
+              },
+            },
+          );
+        };
+
+        let mockClaimedDomainResponse = async (request: Request) => {
+          if (
+            request.method !== 'POST' ||
+            !request.url.includes('_boxel-claimed-domains')
+          ) {
+            return null;
+          }
+
+          return new Response(
+            JSON.stringify({
+              data: {
+                type: 'claimed-site-hostname',
+                id: '1',
+                attributes: {
+                  hostname: 'my-boxel-site.localhost',
+                  subdomain: 'my-boxel-site',
+                  sourceRealmURL: testRealmURL,
+                },
+              },
+            }),
+            {
+              headers: {
+                'Content-Type': 'application/vnd.api+json',
+              },
+            },
+          );
+        };
+
+        getService('network').mount(mockDomainValidationResponse, {
+          prepend: true,
+        });
+        getService('network').mount(mockClaimedDomainResponse, {
+          prepend: true,
+        });
+
+        await visitOperatorMode({
+          submode: 'host',
+          trail: [`${testRealmURL}Person/1.json`],
+        });
+
+        await click('[data-test-publish-realm-button]');
+
+        assert.dom('[data-test-custom-subdomain-input]').doesNotExist();
+        await click('[data-test-custom-subdomain-setup-button]');
+        assert.dom('[data-test-boxel-button]').isDisabled();
+
+        await fillIn(
+          '[data-test-custom-subdomain-input] input',
+          'my-boxel-site',
+        );
+        assert.dom('[data-test-claim-custom-subdomain-button]').isNotDisabled();
+        await click('[data-test-claim-custom-subdomain-button]');
+
+        assert.dom('[data-test-custom-subdomain-cancel]').doesNotExist();
+        assert.dom('[data-test-custom-subdomain-setup-button]').doesNotExist();
+        assert
+          .dom('[data-test-custom-subdomain-details]')
+          .hasText('http://my-boxel-site.localhost:4201');
+      });
+
+      test('shows error when claiming domain fails with 422', async function (assert) {
+        let mockDomainValidationResponse = async (request: Request) => {
+          if (!request.url.includes('_check-boxel-domain-availability')) {
+            return null;
+          }
+
+          return new Response(
+            JSON.stringify({
+              available: true,
+              domain: 'my-boxel-site.localhost',
+            }),
+            {
+              headers: {
+                'Content-Type': 'application/json',
+              },
+            },
+          );
+        };
+
+        let mockClaimedDomainError = async (request: Request) => {
+          if (
+            request.method !== 'POST' ||
+            !request.url.includes('_boxel-claimed-domains')
+          ) {
+            return null;
+          }
+
+          return new Response('There was an error claiming this domain', {
+            status: 422,
+            headers: {
+              'Content-Type': 'application/vnd.api+json',
+            },
+          });
+        };
+
+        getService('network').mount(mockDomainValidationResponse, {
+          prepend: true,
+        });
+        getService('network').mount(mockClaimedDomainError, {
+          prepend: true,
+        });
+
+        await visitOperatorMode({
+          submode: 'host',
+          trail: [`${testRealmURL}Person/1.json`],
+        });
+
+        await click('[data-test-publish-realm-button]');
+        await click('[data-test-custom-subdomain-setup-button]');
+        await fillIn(
+          '[data-test-custom-subdomain-input] input',
+          'my-boxel-site',
+        );
+        await click('[data-test-claim-custom-subdomain-button]');
+
+        // Should still show the setup UI since claiming failed
+        assert.dom('[data-test-custom-subdomain-cancel]').exists();
+        assert.dom('[data-test-custom-subdomain-input]').exists();
+
+        await this.pauseTest();
+
+        // Should display the error message (extracted from the response)
+        assert
+          .dom('[data-test-boxel-input-group-error-message]')
+          .hasText('There was an error claiming this domain');
       });
 
       test('open site popover shows published realms and opens them correctly', async function (assert) {

--- a/packages/matrix/tests/publish-realm.spec.ts
+++ b/packages/matrix/tests/publish-realm.spec.ts
@@ -118,10 +118,8 @@ test.describe('Publish realm', () => {
     ).toHaveCount(0);
 
     await expect(
-      page.locator(
-        '[data-test-custom-subdomain-input] .validation-icon-container.valid',
-      ),
-    ).toBeVisible();
+      page.locator('[data-test-custom-subdomain-input]'),
+    ).toHaveCount(0);
   });
 
   test('open site popover opens with shift-click', async ({ page }) => {


### PR DESCRIPTION
Button "Claim site name" now actually claims the domain if it passes validation. I believe further refinements, such as showing the claimed domain, are coming in https://github.com/cardstack/boxel/pull/3438.

https://github.com/user-attachments/assets/ca72f264-23af-4de6-b2df-4a548a1a3fc0

