### PR TITLE
Add runtime-resolvable @cardstack/catalog realm "package path"

### DIFF
--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -23,6 +23,7 @@ import * as path from 'path';
 import { FakeMatrixClient } from './helpers/fake-matrix-client';
 import {
   type LooseCardResource,
+  ensureTrailingSlash,
   skillCardRef,
 } from '@cardstack/runtime-common';
 import {
@@ -37,10 +38,6 @@ const DEFAULT_CATALOG_REALM_URL = 'http://localhost:4201/catalog/';
 const catalogRealmURL = ensureTrailingSlash(
   process.env.RESOLVED_CATALOG_REALM_URL ?? DEFAULT_CATALOG_REALM_URL,
 );
-
-function ensureTrailingSlash(url: string) {
-  return url.endsWith('/') ? url : `${url}/`;
-}
 
 function replaceCatalogRealmURL(value: string): string {
   return value.split(DEFAULT_CATALOG_REALM_URL).join(catalogRealmURL);

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -33,6 +33,19 @@ import {
   SKILL_INSTRUCTIONS_MESSAGE,
 } from '@cardstack/runtime-common/ai';
 
+const DEFAULT_CATALOG_REALM_URL = 'http://localhost:4201/catalog/';
+const catalogRealmURL = ensureTrailingSlash(
+  process.env.RESOLVED_CATALOG_REALM_URL ?? DEFAULT_CATALOG_REALM_URL,
+);
+
+function ensureTrailingSlash(url: string) {
+  return url.endsWith('/') ? url : `${url}/`;
+}
+
+function replaceCatalogRealmURL(value: string): string {
+  return value.split(DEFAULT_CATALOG_REALM_URL).join(catalogRealmURL);
+}
+
 function oldPatchTool(card: CardDef, properties: any): Tool {
   return {
     type: 'function',
@@ -1899,11 +1912,12 @@ Attached Files (files with newer versions don't show their content):
   });
 
   test('should include instructions in system prompt for skill cards', async () => {
+    const rawEvents = readFileSync(
+      path.join(__dirname, 'resources/chats/added-skill.json'),
+      'utf-8',
+    );
     const eventList: DiscreteMatrixEvent[] = JSON.parse(
-      readFileSync(
-        path.join(__dirname, 'resources/chats/added-skill.json'),
-        'utf-8',
-      ),
+      replaceCatalogRealmURL(rawEvents),
     );
 
     // Set up mock responses for the skill card downloads
@@ -1932,7 +1946,7 @@ Attached Files (files with newer versions don't show their content):
       text: JSON.stringify({
         data: {
           type: 'card',
-          id: 'http://localhost:4201/catalog/Skill/generate-product-requirements',
+          id: `${catalogRealmURL}Skill/generate-product-requirements`,
           attributes: {
             instructions:
               'Given a prompt, fill in the product requirements document. Update the appTitle. Update the prompt to be grammatically accurate. Description should be 1 or 2 short sentences. In overview, provide 1 or 2 paragraph summary. In schema, make a list of the schema for the app. In Layout & Navigation, provide brief information for the layout and navigation of the app. Offer to update the attached card with this info.',
@@ -2048,8 +2062,7 @@ Attached Files (files with newer versions don't show their content):
           },
           meta: {
             adoptsFrom: {
-              module:
-                'http://localhost:4201/catalog/product-requirement-document',
+              module: `${catalogRealmURL}product-requirement-document`,
               name: 'ProductRequirementDocument',
             },
           },

--- a/packages/experiments-realm/llm-model-environment/Environment/dfd82124-c2c9-452e-b3a6-092af5943b7e.json
+++ b/packages/experiments-realm/llm-model-environment/Environment/dfd82124-c2c9-452e-b3a6-092af5943b7e.json
@@ -76,7 +76,7 @@
       },
       "shortcutSettings.1.requiredSkills.0": {
         "links": {
-          "self": "/catalog/Skill/skill-pirate-speak"
+          "self": "@cardstack/catalog/Skill/skill-pirate-speak"
         }
       }
     },

--- a/packages/host/app/config/environment.d.ts
+++ b/packages/host/app/config/environment.d.ts
@@ -16,6 +16,7 @@ declare const config: {
 
   realmServerURL: string;
   resolvedBaseRealmURL: string;
+  resolvedCatalogRealmURL: string;
   resolvedSkillsRealmURL: string;
   hostsOwnAssets: boolean;
   realmsServed?: string[];

--- a/packages/host/config/environment.js
+++ b/packages/host/config/environment.js
@@ -49,6 +49,9 @@ module.exports = function (environment) {
     realmServerURL: process.env.REALM_SERVER_DOMAIN || 'http://localhost:4201/',
     resolvedBaseRealmURL:
       process.env.RESOLVED_BASE_REALM_URL || 'http://localhost:4201/base/',
+    resolvedCatalogRealmURL:
+      process.env.RESOLVED_CATALOG_REALM_URL ||
+      'http://localhost:4201/catalog/',
     resolvedSkillsRealmURL:
       process.env.RESOLVED_SKILLS_REALM_URL || 'http://localhost:4201/skills/',
     featureFlags: {

--- a/packages/host/scripts/test-wait-for-servers.sh
+++ b/packages/host/scripts/test-wait-for-servers.sh
@@ -1,17 +1,37 @@
 #! /bin/sh
 
-BASE_REALM="http-get://localhost:4201/base/"
-CATALOG_REALM="http-get://localhost:4201/catalog/"
+ensure_trailing_slash() {
+  case "$1" in
+    */) printf '%s' "$1" ;;
+    *) printf '%s/' "$1" ;;
+  esac
+}
+
+to_wait_url() {
+  case "$1" in
+    http://*) printf 'http-get://%s' "${1#http://}" ;;
+    https://*) printf 'https-get://%s' "${1#https://}" ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
+
+DEFAULT_BASE_REALM_URL='http://localhost:4201/base/'
+DEFAULT_CATALOG_REALM_URL='http://localhost:4201/catalog/'
+DEFAULT_SKILLS_REALM_URL='http://localhost:4201/skills/'
+
+BASE_REALM_URL=$(ensure_trailing_slash "${RESOLVED_BASE_REALM_URL:-$DEFAULT_BASE_REALM_URL}")
+CATALOG_REALM_URL=$(ensure_trailing_slash "${RESOLVED_CATALOG_REALM_URL:-$DEFAULT_CATALOG_REALM_URL}")
+SKILLS_REALM_URL=$(ensure_trailing_slash "${RESOLVED_SKILLS_REALM_URL:-$DEFAULT_SKILLS_REALM_URL}")
+
 NODE_TEST_REALM="http-get://localhost:4202/node-test/"
-SKILLS_REALM="http-get://localhost:4201/skills/"
 TEST_REALM="http-get://localhost:4202/test/"
 
 READY_PATH="_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson"
 
-BASE_REALM_READY="$BASE_REALM$READY_PATH"
-CATALOG_REALM_READY="$CATALOG_REALM$READY_PATH"
+BASE_REALM_READY="$(to_wait_url "${BASE_REALM_URL}")${READY_PATH}"
+CATALOG_REALM_READY="$(to_wait_url "${CATALOG_REALM_URL}")${READY_PATH}"
 NODE_TEST_REALM_READY="$NODE_TEST_REALM$READY_PATH"
-SKILLS_REALM_READY="$SKILLS_REALM$READY_PATH"
+SKILLS_REALM_READY="$(to_wait_url "${SKILLS_REALM_URL}")${READY_PATH}"
 TEST_REALM_READY="$TEST_REALM$READY_PATH"
 
 SYNAPSE_URL="http://localhost:8008"

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -31,6 +31,7 @@ import {
   APP_BOXEL_REASONING_CONTENT_KEY,
 } from '@cardstack/runtime-common/matrix-constants';
 
+import ENV from '@cardstack/host/config/environment';
 import type MonacoService from '@cardstack/host/services/monaco-service';
 
 import { BoxelContext } from 'https://cardstack.com/base/matrix-event';
@@ -65,6 +66,13 @@ import {
 import { setupMockMatrix } from '../helpers/mock-matrix';
 import { getRoomIdForRealmAndUser } from '../helpers/mock-matrix/_utils';
 import { setupApplicationTest } from '../helpers/setup';
+
+const catalogRealmURL = ensureTrailingSlash(ENV.resolvedCatalogRealmURL);
+const skillsRealmURL = ensureTrailingSlash(ENV.resolvedSkillsRealmURL);
+
+function ensureTrailingSlash(url: string) {
+  return url.endsWith('/') ? url : `${url}/`;
+}
 
 async function selectCardFromCatalog(cardId: string) {
   await click('[data-test-attach-button]');
@@ -1811,12 +1819,12 @@ module('Acceptance | AI Assistant tests', function (hooks) {
         {
           name: 'Cardstack Catalog',
           type: 'catalog-workspace',
-          url: 'http://localhost:4201/catalog/',
+          url: catalogRealmURL,
         },
         {
           name: 'Boxel Skills',
           type: 'catalog-workspace',
-          url: 'http://localhost:4201/skills/',
+          url: skillsRealmURL,
         },
       ],
       'Context sent with message contains correct workspaces',
@@ -2394,7 +2402,7 @@ module('Acceptance | AI Assistant tests', function (hooks) {
       .exists({ count: 1 });
     assert
       .dom(
-        `[data-test-skill-menu] [data-test-attached-card="http://localhost:4201/skills/Skill/boxel-environment"]`,
+        `[data-test-skill-menu] [data-test-attached-card="${skillsRealmURL}Skill/boxel-environment"]`,
       )
       .exists();
   });

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -19,6 +19,7 @@ import {
   Deferred,
   ResolvedCodeRef,
   baseRealm,
+  ensureTrailingSlash,
   skillCardRef,
 } from '@cardstack/runtime-common';
 
@@ -69,10 +70,6 @@ import { setupApplicationTest } from '../helpers/setup';
 
 const catalogRealmURL = ensureTrailingSlash(ENV.resolvedCatalogRealmURL);
 const skillsRealmURL = ensureTrailingSlash(ENV.resolvedSkillsRealmURL);
-
-function ensureTrailingSlash(url: string) {
-  return url.endsWith('/') ? url : `${url}/`;
-}
 
 async function selectCardFromCatalog(cardId: string) {
   await click('[data-test-attach-button]');

--- a/packages/host/tests/acceptance/catalog-app-test.gts
+++ b/packages/host/tests/acceptance/catalog-app-test.gts
@@ -10,6 +10,8 @@ import {
 import { getService } from '@universal-ember/test-support';
 import { module, skip, test } from 'qunit';
 
+import { ensureTrailingSlash } from '@cardstack/runtime-common';
+
 import ListingCreateCommand from '@cardstack/host/commands/listing-create';
 import ListingInstallCommand from '@cardstack/host/commands/listing-install';
 import ListingRemixCommand from '@cardstack/host/commands/listing-remix';
@@ -42,10 +44,6 @@ import type { CardListing } from '@cardstack/catalog/listing/listing';
 
 const catalogRealmURL = ensureTrailingSlash(ENV.resolvedCatalogRealmURL);
 const testDestinationRealmURL = `http://test-realm/test2/`;
-
-function ensureTrailingSlash(url: string) {
-  return url.endsWith('/') ? url : `${url}/`;
-}
 
 //listing
 const authorListingId = `${mockCatalogURL}Listing/author`;

--- a/packages/host/tests/acceptance/catalog-app-test.gts
+++ b/packages/host/tests/acceptance/catalog-app-test.gts
@@ -15,6 +15,8 @@ import ListingInstallCommand from '@cardstack/host/commands/listing-install';
 import ListingRemixCommand from '@cardstack/host/commands/listing-remix';
 import ListingUseCommand from '@cardstack/host/commands/listing-use';
 
+import ENV from '@cardstack/host/config/environment';
+
 import { CardDef } from 'https://cardstack.com/base/card-api';
 
 import {
@@ -38,8 +40,12 @@ import { setupApplicationTest } from '../helpers/setup';
 
 import type { CardListing } from '@cardstack/catalog/listing/listing';
 
-const catalogRealmURL = 'http://localhost:4201/catalog/';
+const catalogRealmURL = ensureTrailingSlash(ENV.resolvedCatalogRealmURL);
 const testDestinationRealmURL = `http://test-realm/test2/`;
+
+function ensureTrailingSlash(url: string) {
+  return url.endsWith('/') ? url : `${url}/`;
+}
 
 //listing
 const authorListingId = `${mockCatalogURL}Listing/author`;

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -17,6 +17,7 @@ import { FieldContainer } from '@cardstack/boxel-ui/components';
 
 import {
   baseRealm,
+  ensureTrailingSlash,
   type Realm,
   type LooseSingleCardDocument,
 } from '@cardstack/runtime-common';
@@ -60,10 +61,6 @@ import {
 import { setupApplicationTest } from '../helpers/setup';
 
 const catalogRealmURL = ensureTrailingSlash(ENV.resolvedCatalogRealmURL);
-
-function ensureTrailingSlash(url: string) {
-  return url.endsWith('/') ? url : `${url}/`;
-}
 
 let matrixRoomId: string;
 let realm2URL = 'http://test-realm/user/test2/';

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -24,6 +24,8 @@ import {
 import { APP_BOXEL_REALM_SERVER_EVENT_MSGTYPE } from '@cardstack/runtime-common/matrix-constants';
 
 import { Submodes } from '@cardstack/host/components/submode-switcher';
+import ENV from '@cardstack/host/config/environment';
+
 import { tokenRefreshPeriodSec } from '@cardstack/host/services/realm';
 
 import {
@@ -56,6 +58,12 @@ import {
   setRecentFiles,
 } from '../helpers/recent-files-cards';
 import { setupApplicationTest } from '../helpers/setup';
+
+const catalogRealmURL = ensureTrailingSlash(ENV.resolvedCatalogRealmURL);
+
+function ensureTrailingSlash(url: string) {
+  return url.endsWith('/') ? url : `${url}/`;
+}
 
 let matrixRoomId: string;
 let realm2URL = 'http://test-realm/user/test2/';
@@ -829,7 +837,7 @@ module('Acceptance | operator mode tests', function (hooks) {
       .dom(`[data-test-recent-file="${testRealmURL}Pet/vangogh.json"]`)
       .exists();
     assert
-      .dom(`[data-test-recent-file="http://localhost:4201/catalog/index.json"]`)
+      .dom(`[data-test-recent-file="${catalogRealmURL}index.json"]`)
       .exists();
     assert
       .dom(`[data-test-recent-file="${testRealmURL}Pet/mango.json"]`)

--- a/packages/host/tests/helpers/mock-matrix/_client.ts
+++ b/packages/host/tests/helpers/mock-matrix/_client.ts
@@ -28,6 +28,8 @@ import {
   APP_BOXEL_LLM_MODE,
 } from '@cardstack/runtime-common/matrix-constants';
 
+import ENV from '@cardstack/host/config/environment';
+
 import type {
   FileDefManager,
   PrivilegedFileDefManager,
@@ -59,9 +61,13 @@ type Plural<T> = {
 
 const publicRealmURLs = [
   baseRealm.url,
-  'http://localhost:4201/catalog/',
-  'http://localhost:4201/skills/',
+  ensureTrailingSlash(ENV.resolvedCatalogRealmURL),
+  ensureTrailingSlash(ENV.resolvedSkillsRealmURL),
 ];
+
+function ensureTrailingSlash(url: string) {
+  return url.endsWith('/') ? url : `${url}/`;
+}
 
 export class MockClient implements ExtendedClient {
   private listeners: Partial<Plural<MatrixSDK.ClientEventHandlerMap>> = {};

--- a/packages/host/tests/helpers/mock-matrix/_client.ts
+++ b/packages/host/tests/helpers/mock-matrix/_client.ts
@@ -17,6 +17,7 @@ import {
   unixTime,
 } from '@cardstack/runtime-common';
 
+import { ensureTrailingSlash } from '@cardstack/runtime-common';
 import {
   APP_BOXEL_ACTIVE_LLM,
   APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
@@ -64,10 +65,6 @@ const publicRealmURLs = [
   ensureTrailingSlash(ENV.resolvedCatalogRealmURL),
   ensureTrailingSlash(ENV.resolvedSkillsRealmURL),
 ];
-
-function ensureTrailingSlash(url: string) {
-  return url.endsWith('/') ? url : `${url}/`;
-}
 
 export class MockClient implements ExtendedClient {
   private listeners: Partial<Plural<MatrixSDK.ClientEventHandlerMap>> = {};

--- a/packages/host/tests/integration/components/ai-module-creation-test.gts
+++ b/packages/host/tests/integration/components/ai-module-creation-test.gts
@@ -8,6 +8,7 @@ import { module, skip } from 'qunit';
 
 import { baseRealm, Loader, type Realm } from '@cardstack/runtime-common';
 
+import { ensureTrailingSlash } from '@cardstack/runtime-common';
 import {
   APP_BOXEL_COMMAND_REQUESTS_KEY,
   APP_BOXEL_MESSAGE_MSGTYPE,
@@ -31,10 +32,6 @@ import {
 import { setupMockMatrix } from '../../helpers/mock-matrix';
 import { renderComponent } from '../../helpers/render-component';
 import { setupRenderingTest } from '../../helpers/setup';
-
-function ensureTrailingSlash(url: string) {
-  return url.endsWith('/') ? url : `${url}/`;
-}
 
 class MockRouterService extends Service {
   replaceWith(_route: any, _args: any) {

--- a/packages/host/tests/integration/components/ai-module-creation-test.gts
+++ b/packages/host/tests/integration/components/ai-module-creation-test.gts
@@ -16,6 +16,7 @@ import {
 
 import CardPrerender from '@cardstack/host/components/card-prerender';
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
+import ENV from '@cardstack/host/config/environment';
 
 import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
@@ -31,6 +32,10 @@ import { setupMockMatrix } from '../../helpers/mock-matrix';
 import { renderComponent } from '../../helpers/render-component';
 import { setupRenderingTest } from '../../helpers/setup';
 
+function ensureTrailingSlash(url: string) {
+  return url.endsWith('/') ? url : `${url}/`;
+}
+
 class MockRouterService extends Service {
   replaceWith(_route: any, _args: any) {
     // This is a stub method that does nothing
@@ -41,6 +46,8 @@ module('Integration | create app module via ai-assistant', function (hooks) {
   const noop = () => {};
   let loader: Loader;
   let operatorModeStateService: OperatorModeStateService;
+
+  const catalogRealmURL = ensureTrailingSlash(ENV.resolvedCatalogRealmURL);
 
   setupRenderingTest(hooks);
 
@@ -144,7 +151,7 @@ module('Integration | create app module via ai-assistant', function (hooks) {
             },
             meta: {
               adoptsFrom: {
-                module: `http://localhost:4201/catalog/product-requirement-document`,
+                module: `${catalogRealmURL}product-requirement-document`,
                 name: 'ProductRequirementDocument',
               },
             },
@@ -197,7 +204,7 @@ module('Integration | create app module via ai-assistant', function (hooks) {
       'skill card is attached',
     );
 
-    const moduleCode = `import { Component, CardDef, FieldDef, linksTo, linksToMany, field, contains, containsMany } from 'https://cardstack.com/base/card-api';\nimport StringField from 'https://cardstack.com/base/string';\nimport BooleanField from 'https://cardstack.com/base/boolean';\nimport DateField from 'https://cardstack.com/base/date';\nimport DateTimeField from 'https://cardstack.com/base/datetime';\nimport NumberField from 'https://cardstack.com/base/number';\nimport MarkdownField from 'https://cardstack.com/base/markdown';\nimport { AppCard } from 'http://localhost:4201/catalog/app-card';\n\nexport class Tour extends CardDef {\n  static displayName = 'Tour';\n\n  @field tourID = contains(StringField);\n  @field date = contains(DateField);\n  @field time = contains(DateTimeField);\n  @field parentNames = contains(StringField);\n  @field contactInformation = contains(StringField);\n  @field notes = contains(MarkdownField);\n\n  @field parents = linksToMany(() => Parent);\n}\n\nexport class Student extends CardDef {\n  static displayName = 'Student';\n\n  @field studentID = contains(StringField);\n  @field name = contains(StringField);\n  @field age = contains(NumberField);\n  @field enrollmentDate = contains(DateField);\n  @field parentInformation = contains(MarkdownField);\n  @field allergiesMedicalNotes = contains(MarkdownField);\n  @field attendanceRecords = containsMany(MarkdownField);\n  \n  @field parents = linksToMany(() => Parent);\n  @field classes = linksToMany(() => Class);\n}\n\nexport class Parent extends CardDef {\n  static displayName = 'Parent';\n\n  @field parentID = contains(StringField);\n  @field name = contains(StringField);\n  @field contactInformation = contains(StringField);\n  \n  @field students = linksToMany(Student);\n  @field tours = linksToMany(Tour);\n}\n\nexport class Staff extends CardDef {\n  static displayName = 'Staff';\n\n  @field staffID = contains(StringField);\n  @field name = contains(StringField);\n  @field role = contains(StringField);\n  @field contactInformation = contains(StringField);\n  @field schedule = contains(MarkdownField);\n}\n\nexport class Class extends CardDef {\n  static displayName = 'Class';\n\n  @field classID = contains(StringField);\n  @field name = contains(StringField);\n  @field schedule = contains(MarkdownField);\n  \n  @field instructor = linksTo(Staff);\n  @field enrolledStudents = linksToMany(Student);\n}\n\nexport class Communication extends CardDef {\n  static displayName = 'Communication';\n\n  @field communicationID = contains(StringField);\n  @field date = contains(DateField);\n  @field type = contains(StringField);\n  @field content = contains(MarkdownField);\n  @field followUpDate = contains(DateField);\n}\n\nexport class PreschoolCRMApp extends AppCard {\n  static displayName = 'Preschool CRM';\n\n  @field tours = containsMany(Tour);\n  @field students = containsMany(Student);\n  @field parents = containsMany(Parent);\n  @field staff = containsMany(Staff);\n  @field classes = containsMany(Class);\n  @field communications = containsMany(Communication);\n}\n`;
+    const moduleCode = `import { Component, CardDef, FieldDef, linksTo, linksToMany, field, contains, containsMany } from 'https://cardstack.com/base/card-api';\nimport StringField from 'https://cardstack.com/base/string';\nimport BooleanField from 'https://cardstack.com/base/boolean';\nimport DateField from 'https://cardstack.com/base/date';\nimport DateTimeField from 'https://cardstack.com/base/datetime';\nimport NumberField from 'https://cardstack.com/base/number';\nimport MarkdownField from 'https://cardstack.com/base/markdown';\nimport { AppCard } from '${catalogRealmURL}app-card';\n\nexport class Tour extends CardDef {\n  static displayName = 'Tour';\n\n  @field tourID = contains(StringField);\n  @field date = contains(DateField);\n  @field time = contains(DateTimeField);\n  @field parentNames = contains(StringField);\n  @field contactInformation = contains(StringField);\n  @field notes = contains(MarkdownField);\n\n  @field parents = linksToMany(() => Parent);\n}\n\nexport class Student extends CardDef {\n  static displayName = 'Student';\n\n  @field studentID = contains(StringField);\n  @field name = contains(StringField);\n  @field age = contains(NumberField);\n  @field enrollmentDate = contains(DateField);\n  @field parentInformation = contains(MarkdownField);\n  @field allergiesMedicalNotes = contains(MarkdownField);\n  @field attendanceRecords = containsMany(MarkdownField);\n  \n  @field parents = linksToMany(() => Parent);\n  @field classes = linksToMany(() => Class);\n}\n\nexport class Parent extends CardDef {\n  static displayName = 'Parent';\n\n  @field parentID = contains(StringField);\n  @field name = contains(StringField);\n  @field contactInformation = contains(StringField);\n  \n  @field students = linksToMany(Student);\n  @field tours = linksToMany(Tour);\n}\n\nexport class Staff extends CardDef {\n  static displayName = 'Staff';\n\n  @field staffID = contains(StringField);\n  @field name = contains(StringField);\n  @field role = contains(StringField);\n  @field contactInformation = contains(StringField);\n  @field schedule = contains(MarkdownField);\n}\n\nexport class Class extends CardDef {\n  static displayName = 'Class';\n\n  @field classID = contains(StringField);\n  @field name = contains(StringField);\n  @field schedule = contains(MarkdownField);\n  \n  @field instructor = linksTo(Staff);\n  @field enrolledStudents = linksToMany(Student);\n}\n\nexport class Communication extends CardDef {\n  static displayName = 'Communication';\n\n  @field communicationID = contains(StringField);\n  @field date = contains(DateField);\n  @field type = contains(StringField);\n  @field content = contains(MarkdownField);\n  @field followUpDate = contains(DateField);\n}\n\nexport class PreschoolCRMApp extends AppCard {\n  static displayName = 'Preschool CRM';\n\n  @field tours = containsMany(Tour);\n  @field students = containsMany(Student);\n  @field parents = containsMany(Parent);\n  @field staff = containsMany(Staff);\n  @field classes = containsMany(Class);\n  @field communications = containsMany(Communication);\n}\n`;
 
     simulateRemoteMessage(roomId, '@aibot:localhost', {
       msgtype: APP_BOXEL_MESSAGE_MSGTYPE,

--- a/packages/realm-server/scripts/start-development.sh
+++ b/packages/realm-server/scripts/start-development.sh
@@ -13,6 +13,9 @@ fi
 
 START_EXPERIMENTS=$(if [ -z "$SKIP_EXPERIMENTS" ]; then echo "true"; else echo ""; fi)
 
+DEFAULT_CATALOG_REALM_URL='http://localhost:4201/catalog/'
+CATALOG_REALM_URL="${RESOLVED_CATALOG_REALM_URL:-$DEFAULT_CATALOG_REALM_URL}"
+
 NODE_ENV=development \
   NODE_NO_WARNINGS=1 \
   PGPORT=5435 \
@@ -39,8 +42,8 @@ NODE_ENV=development \
   \
   --path='../catalog-realm' \
   --username='catalog_realm' \
-  --fromUrl='http://localhost:4201/catalog/' \
-  --toUrl='http://localhost:4201/catalog/' \
+  --fromUrl="${CATALOG_REALM_URL}" \
+  --toUrl="${CATALOG_REALM_URL}" \
   \
   --path='../skills-realm/contents' \
   --username='skills_realm' \

--- a/packages/realm-server/scripts/start-production.sh
+++ b/packages/realm-server/scripts/start-production.sh
@@ -3,6 +3,10 @@ pnpm setup:base-in-deployment
 pnpm setup:experiments-in-deployment
 pnpm setup:catalog-in-deployment
 pnpm setup:skills-in-deployment
+
+DEFAULT_CATALOG_REALM_URL='https://app.boxel.ai/catalog/'
+CATALOG_REALM_URL="${RESOLVED_CATALOG_REALM_URL:-$DEFAULT_CATALOG_REALM_URL}"
+
 NODE_NO_WARNINGS=1 \
   MATRIX_URL=https://matrix.boxel.ai \
   BOXEL_HOST_URL=https://app.boxel.ai \
@@ -24,8 +28,8 @@ NODE_NO_WARNINGS=1 \
   \
   --path='/persistent/catalog' \
   --username='catalog_realm' \
-  --fromUrl='https://app.boxel.ai/catalog/' \
-  --toUrl='https://app.boxel.ai/catalog/' \
+  --fromUrl="${CATALOG_REALM_URL}" \
+  --toUrl="${CATALOG_REALM_URL}" \
   \
   --path='/persistent/skills' \
   --username='skills_realm' \
@@ -36,4 +40,3 @@ NODE_NO_WARNINGS=1 \
   --username='experiments_realm' \
   --fromUrl='https://app.boxel.ai/experiments/' \
   --toUrl='https://app.boxel.ai/experiments/'
-

--- a/packages/realm-server/scripts/start-staging.sh
+++ b/packages/realm-server/scripts/start-staging.sh
@@ -3,6 +3,10 @@ pnpm setup:base-in-deployment
 pnpm setup:experiments-in-deployment
 pnpm setup:catalog-in-deployment
 pnpm setup:skills-in-deployment
+
+DEFAULT_CATALOG_REALM_URL='https://realms-staging.stack.cards/catalog/'
+CATALOG_REALM_URL="${RESOLVED_CATALOG_REALM_URL:-$DEFAULT_CATALOG_REALM_URL}"
+
 NODE_NO_WARNINGS=1 \
   MATRIX_URL=https://matrix-staging.stack.cards \
   BOXEL_HOST_URL=https://realms-staging.stack.cards \
@@ -24,8 +28,8 @@ NODE_NO_WARNINGS=1 \
   \
   --path='/persistent/catalog' \
   --username='catalog_realm' \
-  --fromUrl='https://realms-staging.stack.cards/catalog/' \
-  --toUrl='https://realms-staging.stack.cards/catalog/' \
+  --fromUrl="${CATALOG_REALM_URL}" \
+  --toUrl="${CATALOG_REALM_URL}" \
   \
   --path='/persistent/skills' \
   --username='skills_realm' \

--- a/packages/realm-server/scripts/start-worker-development.sh
+++ b/packages/realm-server/scripts/start-worker-development.sh
@@ -7,6 +7,9 @@ wait_for_postgres
 PRERENDER_URL="${PRERENDER_URL:-http://localhost:4221}"
 wait_for_prerender "$PRERENDER_URL"
 
+DEFAULT_CATALOG_REALM_URL='http://localhost:4201/catalog/'
+CATALOG_REALM_URL="${RESOLVED_CATALOG_REALM_URL:-$DEFAULT_CATALOG_REALM_URL}"
+
 NODE_ENV=development \
   NODE_NO_WARNINGS=1 \
   NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=4096}" \
@@ -30,8 +33,8 @@ NODE_ENV=development \
   --fromUrl='http://localhost:4201/experiments/' \
   --toUrl='http://localhost:4201/experiments/' \
   \
-  --fromUrl='http://localhost:4201/catalog/' \
-  --toUrl='http://localhost:4201/catalog/' \
+  --fromUrl="${CATALOG_REALM_URL}" \
+  --toUrl="${CATALOG_REALM_URL}" \
   \
   --fromUrl='http://localhost:4201/skills/' \
   --toUrl='http://localhost:4201/skills/'

--- a/packages/realm-server/scripts/start-worker-production.sh
+++ b/packages/realm-server/scripts/start-worker-production.sh
@@ -1,5 +1,8 @@
 #! /bin/sh
 
+DEFAULT_CATALOG_REALM_URL='https://app.boxel.ai/catalog/'
+CATALOG_REALM_URL="${RESOLVED_CATALOG_REALM_URL:-$DEFAULT_CATALOG_REALM_URL}"
+
 NODE_NO_WARNINGS=1 \
   NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=4096}" \
   REALM_SERVER_MATRIX_USERNAME=realm_server \
@@ -16,8 +19,8 @@ NODE_NO_WARNINGS=1 \
   --fromUrl='https://app.boxel.ai/experiments/' \
   --toUrl='https://app.boxel.ai/experiments/' \
   \
-  --fromUrl='https://app.boxel.ai/catalog/' \
-  --toUrl='https://app.boxel.ai/catalog/' \
+  --fromUrl="${CATALOG_REALM_URL}" \
+  --toUrl="${CATALOG_REALM_URL}" \
   \
   --fromUrl='https://app.boxel.ai/skills/' \
   --toUrl='https://app.boxel.ai/skills/'

--- a/packages/realm-server/scripts/start-worker-staging.sh
+++ b/packages/realm-server/scripts/start-worker-staging.sh
@@ -1,5 +1,8 @@
 #! /bin/sh
 
+DEFAULT_CATALOG_REALM_URL='https://realms-staging.stack.cards/catalog/'
+CATALOG_REALM_URL="${RESOLVED_CATALOG_REALM_URL:-$DEFAULT_CATALOG_REALM_URL}"
+
 NODE_NO_WARNINGS=1 \
   NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=4096}" \
   REALM_SERVER_MATRIX_USERNAME=realm_server \
@@ -16,8 +19,8 @@ NODE_NO_WARNINGS=1 \
   --fromUrl='https://realms-staging.stack.cards/experiments/' \
   --toUrl='https://realms-staging.stack.cards/experiments/' \
   \
-  --fromUrl='https://realms-staging.stack.cards/catalog/' \
-  --toUrl='https://realms-staging.stack.cards/catalog/' \
+  --fromUrl="${CATALOG_REALM_URL}" \
+  --toUrl="${CATALOG_REALM_URL}" \
   \
   --fromUrl='https://realms-staging.stack.cards/skills/' \
   --toUrl='https://realms-staging.stack.cards/skills/' \

--- a/packages/runtime-common/paths.ts
+++ b/packages/runtime-common/paths.ts
@@ -67,8 +67,8 @@ export function join(...pathParts: string[]): LocalPath {
     .join('/');
 }
 
-function ensureTrailingSlash(realmUrlString: string) {
-  return realmUrlString.replace(/\/$/, '') + '/';
+export function ensureTrailingSlash(url: string) {
+  return url.endsWith('/') ? url : `${url}/`;
 }
 
 // Documenting that this represents a local path within realm, with no leading


### PR DESCRIPTION
- expose resolvedCatalogRealmURL and wire the virtual network to resolve @cardstack/catalog/…
- teach realm-server start scripts, wait scripts, and mock helpers to respect the resolved catalog URL (with portable trailing-slash handling)
- replace hard-coded localhost catalog URLs in host acceptance/integration tests and AI bot fixtures with config-driven values