### PR TITLE
matrix: Change icon in email to matching subdomain

### DIFF
--- a/.github/workflows/sync-synapse-templates.yml
+++ b/.github/workflows/sync-synapse-templates.yml
@@ -35,14 +35,14 @@ jobs:
             echo "AWS_ECS_CLUSTER=production" >> $GITHUB_ENV
             echo "AWS_ECS_SERVICE=synapse-production" >> $GITHUB_ENV
             echo "HOST_DOMAIN=app.boxel.ai" >> $GITHUB_ENV
-            echo "BOXEL_ICON_DOMAIN_AND_PATH=boxel-host-staging\.stack\.cards\/boxel-favicon\.png" >> $GITHUB_ENV
+            echo "BOXEL_ICON_DOMAIN_AND_PATH=boxel-host\.boxel\.ai\/boxel-favicon\.png" >> $GITHUB_ENV
           elif [ "$INPUT_ENVIRONMENT" = "staging" ]; then
             echo "AWS_ROLE_ARN=arn:aws:iam::680542703984:role/github-synapse" >> $GITHUB_ENV
             echo "AWS_S3_BUCKET=cardstack-matrix-synapse-staging" >> $GITHUB_ENV
             echo "AWS_ECS_CLUSTER=staging" >> $GITHUB_ENV
             echo "AWS_ECS_SERVICE=synapse-staging" >> $GITHUB_ENV
             echo "HOST_DOMAIN=realms-staging.stack.cards" >> $GITHUB_ENV
-            echo "BOXEL_ICON_DOMAIN_AND_PATH=boxel-host\.boxel\.ai\/boxel-favicon\.png" >> $GITHUB_ENV
+            echo "BOXEL_ICON_DOMAIN_AND_PATH=boxel-host-staging\.stack\.cards\/boxel-favicon\.png" >> $GITHUB_ENV
           else
             echo "unrecognized environment"
             exit 1;

--- a/.github/workflows/sync-synapse-templates.yml
+++ b/.github/workflows/sync-synapse-templates.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Replace icon URL with one from matching subdomain
         run: |
-          sed -i "s/d12nxmpmo97fii.cloudfront.net\/boxel-icon.png/${{ env.BOXEL_ICON_DOMAIN_AND_PATH }}" packages/matrix/docker/synapse/templates/_base.html
+          sed -i "s/d12nxmpmo97fii.cloudfront.net\/boxel-icon.png/${{ env.BOXEL_ICON_DOMAIN_AND_PATH }}/" packages/matrix/docker/synapse/templates/_base.html
 
       - name: S3 Sync
         run: |

--- a/.github/workflows/sync-synapse-templates.yml
+++ b/.github/workflows/sync-synapse-templates.yml
@@ -35,12 +35,14 @@ jobs:
             echo "AWS_ECS_CLUSTER=production" >> $GITHUB_ENV
             echo "AWS_ECS_SERVICE=synapse-production" >> $GITHUB_ENV
             echo "HOST_DOMAIN=app.boxel.ai" >> $GITHUB_ENV
+            echo "BOXEL_ICON_DOMAIN_AND_PATH=boxel-host-staging\.stack\.cards\/boxel-favicon\.png" >> $GITHUB_ENV
           elif [ "$INPUT_ENVIRONMENT" = "staging" ]; then
             echo "AWS_ROLE_ARN=arn:aws:iam::680542703984:role/github-synapse" >> $GITHUB_ENV
             echo "AWS_S3_BUCKET=cardstack-matrix-synapse-staging" >> $GITHUB_ENV
             echo "AWS_ECS_CLUSTER=staging" >> $GITHUB_ENV
             echo "AWS_ECS_SERVICE=synapse-staging" >> $GITHUB_ENV
             echo "HOST_DOMAIN=realms-staging.stack.cards" >> $GITHUB_ENV
+            echo "BOXEL_ICON_DOMAIN_AND_PATH=boxel-host\.boxel\.ai\/boxel-favicon\.png" >> $GITHUB_ENV
           else
             echo "unrecognized environment"
             exit 1;
@@ -55,6 +57,10 @@ jobs:
       - name: Replace URL in registration success template
         run: |
           sed -i "s/http:\/\/localhost:4200/https:\/\/${{ env.HOST_DOMAIN }}/" packages/matrix/docker/synapse/templates/registration_success.html
+
+      - name: Replace icon URL with one from matching subdomain
+        run: |
+          sed -i "s/d12nxmpmo97fii.cloudfront.net\/boxel-icon.png/${{ env.BOXEL_ICON_DOMAIN_AND_PATH }}" packages/matrix/docker/synapse/templates/_base.html
 
       - name: S3 Sync
         run: |


### PR DESCRIPTION
The goal is to stop these messages being marked suspicious:

<img width="1446" height="575" alt="boxel ai  Validate your email - buck doyle@cardstack com - Cardstack Mail 2025-10-20 18-12-45" src="https://github.com/user-attachments/assets/76fd3ffc-1884-4ef0-9645-ade4ecaaa5a4" />

Sadly this alone doesn’t accomplish that goal but I think it’s still worth making this change, as having a matching subdomain probably decreases the suspiciousness somewhat:

<img width="1301" height="576" alt="boxel ai  Validate your email - buck doyle@gmail com - Gmail 2025-10-21 11-39-01" src="https://github.com/user-attachments/assets/5a2e665b-ba97-40b0-aff7-5371891c2f46" />

