### PR TITLE
host: Fix password reset

### DIFF
--- a/packages/host/app/components/matrix/forgot-password.gts
+++ b/packages/host/app/components/matrix/forgot-password.gts
@@ -391,12 +391,16 @@ export default class ForgotPassword extends Component<Signature> {
 
     try {
       let clientSecret = uuidv4();
+      let redirectUrl = new URL(window.location.href);
+      redirectUrl.searchParams.set('clientSecret', clientSecret);
+
       let { sid } = await this.matrixService.requestPasswordEmailToken(
         this.state.email,
         clientSecret,
         this.state.sendAttempt,
-        window.location.href + `&clientSecret=${clientSecret}`,
+        redirectUrl.toString(),
       );
+
       this.state = {
         ...this.state,
         type: 'waitForEmailValidation',


### PR DESCRIPTION
The problem is that the construction of the reset URL assumed that other query parameters existed, appending `&`, when it needed to append `?`.

<img width="1171" height="238" alt="Boxel 2025-10-22 09-45-56" src="https://github.com/user-attachments/assets/7434e9e1-b43b-4d92-afdb-c76283b9ce60" />

To bypass altogether needing to make this decision, this uses `URLSearchParams` to append the relevant query parameter.

The reason the Matrix tests all passed is that the URL had `/?operatorModeState=…` already so `&` worked, adding code like this to the test causes it to fail with the old approach:

```
    await page.evaluate(() => {
      window.history.replaceState(
        {},
        '',
        `${window.location.origin}${window.location.pathname}`,
      );
    });
```

but this seems excessive maybe 🤔 thoughts?