### PR TITLE
Prevent copy card to appear with 2 stacks when you can't have write access to the index card

### DIFF
--- a/packages/host/app/components/operator-mode/copy-button.gts
+++ b/packages/host/app/components/operator-mode/copy-button.gts
@@ -174,11 +174,17 @@ export default class CopyButton extends Component<Signature> {
       [] as number[],
     );
 
+    // Returning `undefined` from this getter hides the copy button.
     switch (indexCardIndicies.length) {
+      // Case (Number of top-most index cards across the two stacks)
+      // Case 0 index cards: hide the button because neither top stack card is an index card.
+      // Case 1 index card: the index stack is the destination; copy the other stack's top card only when the destination has no selections and its realm is writable.
+      // Case 2 index cards:
+      //        - whichever stack has selections becomes the source and the other stack becomes the destination
+      //        - show the button only when selections reference a different stack item and the destination realm allows writes
       case 0:
         // at least one of the top most cards needs to be an index card
         return undefined;
-
       case 1: {
         // if only one of the top most cards are index cards, and the index card
         // has no selections, then the copy state reflects the copy of the top most
@@ -213,7 +219,6 @@ export default class CopyButton extends Component<Signature> {
           sourceItem,
         };
       }
-
       case 2: {
         if (topMostStackItems[LEFT].id === topMostStackItems[RIGHT].id) {
           // the source and destination cannot be the same

--- a/packages/host/app/components/operator-mode/copy-button.gts
+++ b/packages/host/app/components/operator-mode/copy-button.gts
@@ -196,8 +196,7 @@ export default class CopyButton extends Component<Signature> {
         if (!sourceCard) {
           return undefined;
         }
-        let sourceStackIndex =
-          indexCardIndicies[0] === LEFT ? RIGHT : LEFT;
+        let sourceStackIndex = indexCardIndicies[0] === LEFT ? RIGHT : LEFT;
         let sourceItem = topMostStackItems[sourceStackIndex];
         let destinationItem = topMostStackItems[
           indexCardIndicies[0]

--- a/packages/host/tests/integration/components/card-copy-test.gts
+++ b/packages/host/tests/integration/components/card-copy-test.gts
@@ -38,6 +38,7 @@ import { renderComponent } from '../../helpers/render-component';
 import { setupRenderingTest } from '../../helpers/setup';
 
 const testRealm2URL = `http://test-realm/test2/`;
+const readOnlyRealmURL = `http://test-realm/test-read-only/`;
 let loader: Loader;
 let setCardInOperatorModeState: (
   leftCards: string[],
@@ -63,7 +64,12 @@ module('Integration | card-copy', function (hooks) {
 
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs,
-    activeRealms: [baseRealm.url, testRealmURL, testRealm2URL],
+    activeRealms: [
+      baseRealm.url,
+      testRealmURL,
+      testRealm2URL,
+      readOnlyRealmURL,
+    ],
     autostart: true,
   });
 
@@ -599,6 +605,77 @@ module('Integration | card-copy', function (hooks) {
     assert
       .dom('[data-test-copy-button]')
       .containsText('Copy 1 Card', 'button text is correct');
+  });
+
+  test('copy button does not appear when destination index belongs to read-only realm', async function (assert) {
+    await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      realmURL: readOnlyRealmURL,
+      permissions: {
+        '@testuser:localhost': ['read'],
+        '*': ['read'],
+      },
+      contents: {
+        'index.json': {
+          data: {
+            type: 'card',
+            meta: {
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/cards-grid',
+                name: 'CardsGrid',
+              },
+            },
+          },
+        },
+        'Pet/paper.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              firstName: 'Paper',
+            },
+            meta: {
+              adoptsFrom: {
+                module: `${testRealmURL}pet`,
+                name: 'Pet',
+              },
+            },
+          },
+        },
+        '.realm.json': {
+          name: 'Read Only Workspace',
+          backgroundURL:
+            'https://i.postimg.cc/tgRHRV8C/pawel-czerwinski-h-Nrd99q5pe-I-unsplash.jpg',
+          iconURL: 'https://boxel-images.boxel.ai/icons/cardstack.png',
+        },
+      },
+    });
+
+    await setCardInOperatorModeState(
+      [`${testRealmURL}index`, `${testRealmURL}Person/hassan`],
+      [`${readOnlyRealmURL}index`],
+    );
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template>
+          <OperatorMode @onClose={{noop}} />
+          <CardPrerender />
+        </template>
+      },
+    );
+    await click(
+      `[data-test-operator-mode-stack="0"] [data-test-boxel-filter-list-button="All Cards"]`,
+    );
+    await click(
+      `[data-test-operator-mode-stack="1"] [data-test-boxel-filter-list-button="All Cards"]`,
+    );
+    await waitFor('[data-test-operator-mode-stack="0"] [data-test-person]');
+    await waitFor(
+      '[data-test-operator-mode-stack="1"] [data-test-cards-grid-item]',
+    );
+
+    assert
+      .dom('[data-test-copy-button]')
+      .doesNotExist('copy button does not exist for read-only destination');
   });
 
   test('copy button appears when left stack is an index card and right stack is single card item', async function (assert) {

--- a/packages/host/tests/integration/components/card-copy-test.gts
+++ b/packages/host/tests/integration/components/card-copy-test.gts
@@ -70,6 +70,9 @@ module('Integration | card-copy', function (hooks) {
       testRealm2URL,
       readOnlyRealmURL,
     ],
+    realmPermissions: {
+      [readOnlyRealmURL]: ['read'],
+    },
     autostart: true,
   });
 

--- a/packages/host/tests/integration/components/card-delete-test.gts
+++ b/packages/host/tests/integration/components/card-delete-test.gts
@@ -581,6 +581,19 @@ module('Integration | card-delete', function (hooks) {
       .doesNotExist('recent item removed');
   });
 
+  async function waitForCopySelectionCount(expectedCount: number) {
+    await waitUntil(() => {
+      let button = document.querySelector('[data-test-copy-button]');
+      if (!button) {
+        return false;
+      }
+      let normalizedText = button.textContent?.replace(/\s+/g, ' ').trim();
+      let expectedLabel =
+        expectedCount === 1 ? 'Copy 1 Card' : `Copy ${expectedCount} Cards`;
+      return normalizedText === expectedLabel;
+    });
+  }
+
   test('can delete a card that is a selected item', async function (assert) {
     setCardInOperatorModeState(
       [`${testRealmURL}index`],
@@ -614,7 +627,7 @@ module('Integration | card-delete', function (hooks) {
     await click(
       `[data-test-overlay-card="${testRealmURL}Pet/vangogh"] [data-test-overlay-select]`,
     );
-    await waitFor('[data-test-copy-button]');
+    await waitForCopySelectionCount(2);
     assert
       .dom('[data-test-copy-button]')
       .containsText('Copy 2 Cards', 'button text is correct');
@@ -636,6 +649,7 @@ module('Integration | card-delete', function (hooks) {
     );
     let notFound = await adapter.openFile('Pet/mango.json');
     assert.strictEqual(notFound, undefined, 'file ref does not exist');
+    await waitForCopySelectionCount(1);
     assert
       .dom('[data-test-copy-button]')
       .containsText('Copy 1 Card', 'button text is correct');

--- a/packages/host/tests/integration/components/card-delete-test.gts
+++ b/packages/host/tests/integration/components/card-delete-test.gts
@@ -581,19 +581,6 @@ module('Integration | card-delete', function (hooks) {
       .doesNotExist('recent item removed');
   });
 
-  async function waitForCopySelectionCount(expectedCount: number) {
-    await waitUntil(() => {
-      let button = document.querySelector('[data-test-copy-button]');
-      if (!button) {
-        return false;
-      }
-      let normalizedText = button.textContent?.replace(/\s+/g, ' ').trim();
-      let expectedLabel =
-        expectedCount === 1 ? 'Copy 1 Card' : `Copy ${expectedCount} Cards`;
-      return normalizedText === expectedLabel;
-    });
-  }
-
   test('can delete a card that is a selected item', async function (assert) {
     setCardInOperatorModeState(
       [`${testRealmURL}index`],
@@ -627,7 +614,6 @@ module('Integration | card-delete', function (hooks) {
     await click(
       `[data-test-overlay-card="${testRealmURL}Pet/vangogh"] [data-test-overlay-select]`,
     );
-    await waitForCopySelectionCount(2);
     assert
       .dom('[data-test-copy-button]')
       .containsText('Copy 2 Cards', 'button text is correct');
@@ -649,7 +635,6 @@ module('Integration | card-delete', function (hooks) {
     );
     let notFound = await adapter.openFile('Pet/mango.json');
     assert.strictEqual(notFound, undefined, 'file ref does not exist');
-    await waitForCopySelectionCount(1);
     assert
       .dom('[data-test-copy-button]')
       .containsText('Copy 1 Card', 'button text is correct');

--- a/packages/host/tests/integration/components/card-delete-test.gts
+++ b/packages/host/tests/integration/components/card-delete-test.gts
@@ -614,6 +614,7 @@ module('Integration | card-delete', function (hooks) {
     await click(
       `[data-test-overlay-card="${testRealmURL}Pet/vangogh"] [data-test-overlay-select]`,
     );
+    await waitFor('[data-test-copy-button]');
     assert
       .dom('[data-test-copy-button]')
       .containsText('Copy 2 Cards', 'button text is correct');

--- a/packages/host/tests/integration/components/card-delete-test.gts
+++ b/packages/host/tests/integration/components/card-delete-test.gts
@@ -17,6 +17,7 @@ import { CardDef } from 'https://cardstack.com/base/card-api';
 import {
   percySnapshot,
   testRealmURL,
+  testModuleRealm,
   setupCardLogs,
   setupLocalIndexing,
   setupOnSave,
@@ -70,7 +71,11 @@ module('Integration | card-delete', function (hooks) {
 
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs: '@testuser:localhost',
-    activeRealms: [baseRealm.url, testRealmURL],
+    activeRealms: [baseRealm.url, testRealmURL, testModuleRealm],
+    realmPermissions: {
+      [testRealmURL]: ['read', 'write'],
+      [testModuleRealm]: ['read', 'write'],
+    },
     autostart: true,
   });
 


### PR DESCRIPTION
<img width="1542" height="955" alt="Screenshot 2025-10-22 at 20 25 38" src="https://github.com/user-attachments/assets/90430a74-918f-468d-9e04-4ebb5f5b4597" />

The copy button shudn appear here when you dont have write access to the catalog

Since the refactor of the viewCard api, we lost the stack context hence viewing the listing card by clicking from catalog will open the listing card on the stack to the right. Tho, I think somehow the experience of 2 stacks is "not bad" so I decided to fix the issue where the copy button appears when a person doesn't have write access to the index card in the realm

<img width="1488" height="780" alt="Screenshot 2025-10-22 at 20 30 42" src="https://github.com/user-attachments/assets/3b4ac73e-6a7d-4134-8472-7251bc4beda3" />


