### PR TITLE
host: Add resolved catalog realm to builds

### DIFF
--- a/.github/workflows/build-host.yml
+++ b/.github/workflows/build-host.yml
@@ -26,6 +26,7 @@ jobs:
         run: |
           if [ "$INPUT_ENVIRONMENT" = "production" ]; then
             echo "RESOLVED_BASE_REALM_URL=https://app.boxel.ai/base/" >> $GITHUB_ENV
+            echo "RESOLVED_CATALOG_REALM_URL=https://app.boxel.ai/catalog/" >> $GITHUB_ENV
             echo "RESOLVED_SKILLS_REALM_URL=https://app.boxel.ai/skills/" >> $GITHUB_ENV
             echo "MATRIX_URL=https://matrix.boxel.ai" >> $GITHUB_ENV
             echo "MATRIX_SERVER_NAME=boxel.ai" >> $GITHUB_ENV
@@ -34,6 +35,7 @@ jobs:
             echo "PUBLISHED_REALM_BOXEL_SITE_DOMAIN=boxel.site" >> $GITHUB_ENV
           elif [ "$INPUT_ENVIRONMENT" = "staging" ]; then
             echo "RESOLVED_BASE_REALM_URL=https://realms-staging.stack.cards/base/" >> $GITHUB_ENV
+            echo "RESOLVED_CATALOG_REALM_URL=https://realms-staging.stack.cards/catalog/" >> $GITHUB_ENV
             echo "RESOLVED_SKILLS_REALM_URL=https://realms-staging.stack.cards/skills/" >> $GITHUB_ENV
             echo "MATRIX_URL=https://matrix-staging.stack.cards" >> $GITHUB_ENV
             echo "MATRIX_SERVER_NAME=stack.cards" >> $GITHUB_ENV

--- a/.github/workflows/preview-host.yml
+++ b/.github/workflows/preview-host.yml
@@ -58,6 +58,7 @@ jobs:
         env:
           REALM_SERVER_ROOT: https://realms-staging.stack.cards/
           RESOLVED_BASE_REALM_URL: https://realms-staging.stack.cards/base/
+          RESOLVED_CATALOG_REALM_URL: https://realms-staging.stack.cards/catalog/
           RESOLVED_SKILLS_REALM_URL: https://realms-staging.stack.cards/skills/
           MATRIX_URL: https://matrix-staging.stack.cards
           MATRIX_SERVER_NAME: stack.cards
@@ -91,6 +92,7 @@ jobs:
         env:
           REALM_SERVER_ROOT: https://app.boxel.ai/
           RESOLVED_BASE_REALM_URL: https://app.boxel.ai/base/
+          RESOLVED_CATALOG_REALM_URL: https://app.boxel.ai/catalog/
           RESOLVED_SKILLS_REALM_URL: https://app.boxel.ai/skills/
           MATRIX_URL: https://matrix.boxel.ai
           MATRIX_SERVER_NAME: boxel.ai


### PR DESCRIPTION
This was missing from #3444. In general I think we have confusion about which things are configured via environment variables during a `host` build vs which are [overwritten when served by the realm server](https://github.com/cardstack/boxel/blob/9d4e0d4b163f1032d3bd3388686cb8a746492341/packages/realm-server/server.ts#L323-L327). This variable is [in the overwritable section](https://github.com/cardstack/boxel/blob/9d4e0d4b163f1032d3bd3388686cb8a746492341/packages/host/config/environment.js#L52-L54) but isn’t actually overwritten.