### PR TITLE
Fix categories component showing loading spinner

### DIFF
--- a/packages/catalog-realm/catalog-app/components/filter-section.gts
+++ b/packages/catalog-realm/catalog-app/components/filter-section.gts
@@ -27,9 +27,16 @@ interface FilterCategoryGroupArgs {
 }
 
 export class FilterCategoryGroup extends GlimmerComponent<FilterCategoryGroupArgs> {
+  get shouldShowLoadingState() {
+    return (
+      this.args.isLoading &&
+      (!this.args.categories || this.args.categories.length === 0)
+    );
+  }
+
   <template>
     <FilterGroupWrapper @title={{@title}} ...attributes>
-      {{#if @isLoading}}
+      {{#if this.shouldShowLoadingState}}
         <SkeletonPlaceholder class='skeleton-placeholder-filter-list' />
       {{else}}
         <FilterList
@@ -69,9 +76,16 @@ interface FilterTagGroupArgs {
 }
 
 export class FilterTagGroup extends GlimmerComponent<FilterTagGroupArgs> {
+  get shouldShowLoadingState() {
+    return (
+      this.args.isLoading &&
+      (!this.args.tags || this.args.tags.length === 0)
+    );
+  }
+
   <template>
     <FilterGroupWrapper @title={{@title}} ...attributes>
-      {{#if @isLoading}}
+      {{#if this.shouldShowLoadingState}}
         <SkeletonPlaceholder class='skeleton-placeholder-filter-list' />
       {{else}}
         <TagList


### PR DESCRIPTION
Refresh page. 

<img width="795" height="722" alt="Screenshot 2025-10-23 at 16 27 55" src="https://github.com/user-attachments/assets/7dc7db8f-d89d-49c2-9d01-eb9a88acbaeb" />

This should not rerender
