### PR TITLE
postgres: Fix claim constraint downmigration

### DIFF
--- a/packages/postgres/migrations/1759232510123_create-claimed-domains-for-sites.js
+++ b/packages/postgres/migrations/1759232510123_create-claimed-domains-for-sites.js
@@ -41,10 +41,9 @@ exports.up = (pgm) => {
 
 exports.down = (pgm) => {
   pgm.dropIndex('claimed_domains_for_sites', ['removed_at']);
-  pgm.dropIndex(
-    'claimed_domains_for_sites',
-    'claimed_domains_for_sites_hostname_unique_index',
-  );
+  pgm.dropIndex('claimed_domains_for_sites', ['hostname'], {
+    name: 'claimed_domains_for_sites_hostname_unique_index',
+  });
   pgm.dropIndex('claimed_domains_for_sites', ['user_id']);
   pgm.dropIndex('claimed_domains_for_sites', ['source_realm_url']);
   pgm.dropTable('claimed_domains_for_sites');


### PR DESCRIPTION
This downmigration was failing because the constraint name was passed in as the column name.