### PR TITLE
Field Configuration API

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -416,7 +416,6 @@ class ContainsMany<FieldT extends FieldDefConstructor>
   readonly description: string | undefined;
   readonly isUsed: undefined | true;
   readonly isPolymorphic: undefined | true;
-  // Optional per-usage configuration for this field
   configuration: ConfigurationInput<any> | undefined;
   constructor({
     cardThunk,
@@ -731,7 +730,6 @@ class Contains<CardT extends FieldDefConstructor> implements Field<CardT, any> {
   readonly description: string | undefined;
   readonly isUsed: undefined | true;
   readonly isPolymorphic: undefined | true;
-  // Optional per-usage configuration for this field
   configuration: ConfigurationInput<any> | undefined;
   constructor({
     cardThunk,
@@ -934,6 +932,7 @@ class LinksTo<CardT extends CardDefConstructor> implements Field<CardT> {
   readonly description: string | undefined;
   readonly isUsed: undefined | true;
   readonly isPolymorphic: undefined | true;
+  readonly configuration?: ConfigurationInput<any>;
   constructor({
     cardThunk,
     computeVia,
@@ -1299,6 +1298,7 @@ class LinksToMany<FieldT extends CardDefConstructor>
   readonly description: string | undefined;
   readonly isUsed: undefined | true;
   readonly isPolymorphic: undefined | true;
+  readonly configuration?: ConfigurationInput<any>;
   constructor({
     cardThunk,
     computeVia,
@@ -1875,7 +1875,6 @@ export function containsMany<FieldT extends FieldDefConstructor>(
         description,
         isUsed,
       });
-      // Save per-usage configuration on field descriptor when provided
       (instance as any).configuration = options?.configuration;
       return makeDescriptor(instance);
     },
@@ -1897,7 +1896,6 @@ export function contains<FieldT extends FieldDefConstructor>(
         description,
         isUsed,
       });
-      // Save per-usage configuration on field descriptor when provided
       (instance as any).configuration = options?.configuration;
       return makeDescriptor(instance);
     },
@@ -1912,15 +1910,15 @@ export function linksTo<CardT extends CardDefConstructor>(
   return {
     setupField(fieldName: string) {
       let { computeVia, description, isUsed } = options ?? {};
-      return makeDescriptor(
-        new LinksTo({
-          cardThunk: cardThunk(cardOrThunk),
-          computeVia,
-          name: fieldName,
-          description,
-          isUsed,
-        }),
-      );
+      let instance = new LinksTo({
+        cardThunk: cardThunk(cardOrThunk),
+        computeVia,
+        name: fieldName,
+        description,
+        isUsed,
+      });
+      (instance as any).configuration = options?.configuration;
+      return makeDescriptor(instance);
     },
   } as any;
 }
@@ -1933,15 +1931,15 @@ export function linksToMany<CardT extends CardDefConstructor>(
   return {
     setupField(fieldName: string) {
       let { computeVia, description, isUsed } = options ?? {};
-      return makeDescriptor(
-        new LinksToMany({
-          cardThunk: cardThunk(cardOrThunk),
-          computeVia,
-          name: fieldName,
-          description,
-          isUsed,
-        }),
-      );
+      let instance = new LinksToMany({
+        cardThunk: cardThunk(cardOrThunk),
+        computeVia,
+        name: fieldName,
+        description,
+        isUsed,
+      });
+      (instance as any).configuration = options?.configuration;
+      return makeDescriptor(instance);
     },
   } as any;
 }

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -191,6 +191,12 @@ export type FieldsTypeFor<T extends BaseDef> = {
 };
 export { formats, type Format };
 export type FieldType = 'contains' | 'containsMany' | 'linksTo' | 'linksToMany';
+// Opaque configuration passed to field format components and validators
+export type FieldConfiguration = Record<string, any>;
+// Configuration may be provided as a static object or a function of the parent instance
+export type ConfigurationInput<T> =
+  | FieldConfiguration
+  | ((self: Readonly<T>) => FieldConfiguration | undefined);
 export type FieldFormats = {
   ['fieldDef']: Format;
   ['cardDef']: Format;
@@ -206,6 +212,8 @@ interface Options {
   // in which case we need to tell the runtime that a card is
   // explicitly being used.
   isUsed?: true;
+  // Optional: per-usage configuration provider merged with FieldDef-level configuration
+  configuration?: ConfigurationInput<any>;
 }
 
 export interface CardContext<T extends CardDef = CardDef> {
@@ -332,6 +340,8 @@ export interface Field<
   fieldType: FieldType;
   computeVia: undefined | (() => unknown);
   description: undefined | string;
+  // Optional per-usage configuration stored on the field descriptor
+  configuration?: ConfigurationInput<any>;
   // there exists cards that we only ever run in the host without
   // the isolated renderer (RoomField), which means that we cannot
   // use the rendering mechanism to tell if a card is used or not,
@@ -406,6 +416,8 @@ class ContainsMany<FieldT extends FieldDefConstructor>
   readonly description: string | undefined;
   readonly isUsed: undefined | true;
   readonly isPolymorphic: undefined | true;
+  // Optional per-usage configuration for this field
+  configuration: ConfigurationInput<any> | undefined;
   constructor({
     cardThunk,
     computeVia,
@@ -719,6 +731,8 @@ class Contains<CardT extends FieldDefConstructor> implements Field<CardT, any> {
   readonly description: string | undefined;
   readonly isUsed: undefined | true;
   readonly isPolymorphic: undefined | true;
+  // Optional per-usage configuration for this field
+  configuration: ConfigurationInput<any> | undefined;
   constructor({
     cardThunk,
     computeVia,
@@ -1854,15 +1868,16 @@ export function containsMany<FieldT extends FieldDefConstructor>(
   return {
     setupField(fieldName: string) {
       let { computeVia, description, isUsed } = options ?? {};
-      return makeDescriptor(
-        new ContainsMany({
-          cardThunk: cardThunk(field),
-          computeVia,
-          name: fieldName,
-          description,
-          isUsed,
-        }),
-      );
+      let instance = new ContainsMany({
+        cardThunk: cardThunk(field),
+        computeVia,
+        name: fieldName,
+        description,
+        isUsed,
+      });
+      // Save per-usage configuration on field descriptor when provided
+      (instance as any).configuration = options?.configuration;
+      return makeDescriptor(instance);
     },
   } as any;
 }
@@ -1875,15 +1890,16 @@ export function contains<FieldT extends FieldDefConstructor>(
   return {
     setupField(fieldName: string) {
       let { computeVia, description, isUsed } = options ?? {};
-      return makeDescriptor(
-        new Contains({
-          cardThunk: cardThunk(field),
-          computeVia,
-          name: fieldName,
-          description,
-          isUsed,
-        }),
-      );
+      let instance = new Contains({
+        cardThunk: cardThunk(field),
+        computeVia,
+        name: fieldName,
+        description,
+        isUsed,
+      });
+      // Save per-usage configuration on field descriptor when provided
+      (instance as any).configuration = options?.configuration;
+      return makeDescriptor(instance);
     },
   } as any;
 }
@@ -2124,6 +2140,8 @@ export type BaseDefComponent = ComponentLike<{
     context?: CardContext;
     canEdit?: boolean;
     typeConstraint?: ResolvedCodeRef;
+    // Resolved, merged field configuration (if applicable)
+    configuration?: FieldConfiguration | undefined;
     createCard: CreateCardFn;
     viewCard: ViewCardFn;
     editCard: EditCardFn;
@@ -2137,6 +2155,9 @@ export class FieldDef extends BaseDef {
   static isFieldDef = true;
   static displayName = 'Field';
   static icon = RectangleEllipsisIcon;
+
+  // Optional provider for default configuration, merged with per-usage configuration
+  static configuration?: ConfigurationInput<any>;
 
   static embedded: BaseDefComponent = MissingTemplate;
   static edit: BaseDefComponent = FieldDefEditTemplate;
@@ -3195,6 +3216,7 @@ export type SignatureFor<CardT extends BaseDefConstructor> = {
     editCard?: EditCardFn;
     saveCard?: SaveCardFn;
     canEdit?: boolean;
+    configuration?: FieldConfiguration | undefined;
   };
 };
 

--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -337,6 +337,7 @@ export function getBoxComponent(
                             @set={{model.set}}
                             @fieldName={{model.name}}
                             @context={{context}}
+                            @configuration={{this.resolvedConfiguration}}
                             @createCard={{cardCrudFunctions.createCard}}
                             @viewCard={{cardCrudFunctions.viewCard}}
                             @saveCard={{cardCrudFunctions.saveCard}}

--- a/packages/base/field-support.ts
+++ b/packages/base/field-support.ts
@@ -180,7 +180,10 @@ export function shallowMerge<T extends Record<string, any>>(
 export function mergeConfigurations<T extends object>(
   ...fragments: (T | undefined)[]
 ): T | undefined {
-  return fragments.reduce<T | undefined>((acc, next) => shallowMerge(acc as any, next as any) as any, undefined);
+  return fragments.reduce<T | undefined>(
+    (acc, next) => shallowMerge(acc as any, next as any) as any,
+    undefined,
+  );
 }
 
 // Resolves and merges configuration from FieldDef static configuration and per-usage configuration
@@ -202,11 +205,15 @@ export function resolveFieldConfiguration(
     return cached;
   }
 
-  function evalInput<T>(input: ConfigurationInput<T> | undefined): FieldConfiguration | undefined {
+  function evalInput<T>(
+    input: ConfigurationInput<T> | undefined,
+  ): FieldConfiguration | undefined {
     if (!input) return undefined;
     try {
       if (typeof input === 'function') {
-        return (input as (self: Readonly<T>) => FieldConfiguration | undefined)(instance as unknown as T);
+        return (input as (self: Readonly<T>) => FieldConfiguration | undefined)(
+          instance as unknown as T,
+        );
       } else {
         return input as FieldConfiguration;
       }
@@ -220,11 +227,18 @@ export function resolveFieldConfiguration(
   }
 
   // field.card is the FieldDef subclass; it may optionally define a static configuration
-  let fromFieldDef = evalInput((field.card as any).configuration as ConfigurationInput<any> | undefined);
+  let fromFieldDef = evalInput(
+    (field.card as any).configuration as ConfigurationInput<any> | undefined,
+  );
   // per-usage configuration stored on the field descriptor
-  let fromContains = evalInput(field.configuration as ConfigurationInput<any> | undefined);
+  let fromFieldUsage = evalInput(
+    field.configuration as ConfigurationInput<any> | undefined,
+  );
 
-  let merged = mergeConfigurations<FieldConfiguration>(fromFieldDef, fromContains);
+  let merged = mergeConfigurations<FieldConfiguration>(
+    fromFieldDef,
+    fromFieldUsage,
+  );
   // Cache result for this tick; will be invalidated on notifyCardTracking
   cacheForInstance.set(field.name, merged);
   return merged;

--- a/packages/host/tests/integration/field-configuration-test.gts
+++ b/packages/host/tests/integration/field-configuration-test.gts
@@ -29,7 +29,6 @@ import { setupMockMatrix } from '../helpers/mock-matrix';
 import { renderCard } from '../helpers/render-component';
 import { setupRenderingTest } from '../helpers/setup';
 let loader: Loader;
-let _testRealm: Realm;
 
 module('Integration | field configuration', function (hooks) {
   setupRenderingTest(hooks);
@@ -164,7 +163,6 @@ module('Integration | field configuration', function (hooks) {
         },
       },
     });
-    _testRealm = setup.realm;
   });
 
   test('merged configuration is injected into field format component', async function (assert) {

--- a/packages/host/tests/integration/field-configuration-test.gts
+++ b/packages/host/tests/integration/field-configuration-test.gts
@@ -1,0 +1,353 @@
+import { RenderingTestContext, settled } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+import { module, test } from 'qunit';
+
+import { baseRealm } from '@cardstack/runtime-common';
+import { Loader } from '@cardstack/runtime-common/loader';
+import { Realm } from '@cardstack/runtime-common/realm';
+
+import {
+  testRealmURL,
+  setupCardLogs,
+  setupLocalIndexing,
+  setupIntegrationTestRealm,
+} from '../helpers';
+import {
+  setupBaseRealm,
+  createFromSerialized,
+  ensureLinksLoaded,
+  field,
+  contains,
+  linksTo,
+  CardDef,
+  FieldDef,
+  Component,
+  StringField,
+} from '../helpers/base-realm';
+import { setupMockMatrix } from '../helpers/mock-matrix';
+import { renderCard } from '../helpers/render-component';
+import { setupRenderingTest } from '../helpers/setup';
+let loader: Loader;
+let _testRealm: Realm;
+
+module('Integration | field configuration', function (hooks) {
+  setupRenderingTest(hooks);
+  // Initialize base realm helpers so createFromSerialized/ensureLinksLoaded
+  // use the test loader bound to this environment.
+  setupBaseRealm(hooks);
+
+  hooks.beforeEach(function () {
+    loader = getService('loader-service').loader;
+  });
+
+  setupLocalIndexing(hooks);
+  let mockMatrixUtils = setupMockMatrix(hooks);
+
+  setupCardLogs(
+    hooks,
+    async () => await loader.import(`${baseRealm.url}card-api`),
+  );
+  hooks.beforeEach(async function (this: RenderingTestContext) {
+    class ColorField extends FieldDef {
+      static displayName = 'Color';
+      // FieldDef-level default configuration (function form)
+      static configuration = (_self: any) => ({
+        presentation: { palette: ['blue', 'green'] },
+      });
+
+      static edit = class Edit extends Component<typeof this> {
+        get firstColor() {
+          return this.args.configuration?.presentation?.palette?.[0];
+        }
+        get hasRed() {
+          return this.firstColor === 'red';
+        }
+        get hasBlue() {
+          return this.firstColor === 'blue';
+        }
+        <template>
+          <span data-test-has-red>{{if this.hasRed 'yes' 'no'}}</span>
+          <span data-test-has-blue>{{if this.hasBlue 'yes' 'no'}}</span>
+        </template>
+      };
+    }
+
+    class ParentCard extends CardDef {
+      static displayName = 'Parent';
+      @field title = contains(StringField);
+      @field color = contains(ColorField, {
+        configuration: {
+          presentation: {
+            palette: ['red'],
+          },
+        },
+      });
+
+      static isolated = class Isolated extends Component<typeof this> {
+        <template>
+          <div data-test-parent>
+            <@fields.color @format='edit' />
+          </div>
+        </template>
+      };
+    }
+
+    class ReactiveColorField extends FieldDef {
+      static displayName = 'ReactiveColor';
+      static edit = class Edit extends Component<typeof this> {
+        get color() {
+          return this.args.configuration?.presentation?.palette;
+        }
+        get hasPurple() {
+          return this.color === 'purple';
+        }
+        <template>
+          <span data-test-has-purple>{{if this.hasPurple 'yes' 'no'}}</span>
+        </template>
+      };
+    }
+
+    class ThemeCard extends CardDef {
+      @field palette = contains(StringField);
+    }
+
+    class ParentReactive extends CardDef {
+      @field theme = linksTo(ThemeCard);
+      @field color = contains(ReactiveColorField, {
+        configuration: (self) => ({
+          presentation: { palette: self.theme?.palette },
+        }),
+      });
+      static isolated = class Isolated extends Component<typeof this> {
+        <template>
+          <div data-test-reactive-parent>
+            <@fields.color @format='edit' />
+          </div>
+        </template>
+      };
+    }
+
+    let setup = await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      contents: {
+        'parent.gts': { ParentCard },
+        'reactive.gts': { ParentReactive, ThemeCard, ReactiveColorField },
+        'ParentCard/instance.json': {
+          data: {
+            type: 'card',
+            id: `${testRealmURL}ParentCard/instance`,
+            attributes: {
+              title: 'test parent',
+              color: {},
+            },
+            meta: {
+              adoptsFrom: {
+                module: `${testRealmURL}parent`,
+                name: 'ParentCard',
+              },
+            },
+          },
+        },
+        'ThemeCard/main.json': {
+          data: {
+            type: 'card',
+            id: `${testRealmURL}ThemeCard/main`,
+            attributes: { palette: 'purple' },
+            meta: {
+              adoptsFrom: {
+                module: `${testRealmURL}reactive`,
+                name: 'ThemeCard',
+              },
+            },
+          },
+        },
+      },
+    });
+    _testRealm = setup.realm;
+  });
+
+  test('merged configuration is injected into field format component', async function (assert) {
+    // import the card class and create a local instance for rendering
+    let mod = await loader.import(`${testRealmURL}parent`);
+    let ParentCard = (mod as any).ParentCard;
+    let card = new ParentCard({ title: 'local parent' });
+    await renderCard(loader, card, 'isolated');
+
+    assert
+      .dom('[data-test-parent] [data-test-has-red]')
+      .hasText('yes', 'per-usage config overrides and is present');
+    assert
+      .dom('[data-test-parent] [data-test-has-blue]')
+      .hasText('no', 'arrays are replaced, not concatenated');
+  });
+
+  test('configuration reacts when a linked relationship loads', async function (assert) {
+    // Create a ParentReactive instance that links to ThemeCard/main but does not include it
+    let resource = {
+      attributes: { color: {}, title: 'parent' },
+      relationships: {
+        theme: { links: { self: `${testRealmURL}ThemeCard/main` } },
+      },
+      meta: {
+        adoptsFrom: {
+          module: `${testRealmURL}reactive`,
+          name: 'ParentReactive',
+        },
+      },
+    };
+
+    // Provide a custom store that can satisfy link resolution from cache, avoiding HTTP fetch.
+    let themeRef = `${testRealmURL}ThemeCard/main`;
+    let mod = await loader.import(`${testRealmURL}reactive`);
+    let ThemeCard = (mod as any).ThemeCard;
+    let cachedTheme = new ThemeCard({ palette: 'purple' });
+    let themeAvailable = false;
+    let customStore = {
+      get(url: string) {
+        if (url.replace(/\.json$/, '') === themeRef && themeAvailable) {
+          return cachedTheme;
+        }
+        return undefined;
+      },
+      set() {},
+      setNonTracked() {},
+      makeTracked() {},
+      async loadDocument(_url: string) {
+        throw new Error('should not fetch');
+      },
+      trackLoad() {},
+      async loaded() {},
+    } as any;
+
+    let parent = await createFromSerialized(
+      resource as any,
+      { data: resource } as any,
+      undefined,
+      { store: customStore },
+    );
+
+    // Render: configuration should be undefined initially (NotLoaded), so has-purple is 'no'
+    await renderCard(loader, parent, 'isolated');
+    assert
+      .dom('[data-test-reactive-parent] [data-test-has-purple]')
+      .hasText('no', 'configuration is unavailable before theme loads');
+
+    // No write needed since the custom store returns the Theme from cache
+    // Now load links and assert re-render picks up the theme palette
+    themeAvailable = true;
+    await ensureLinksLoaded(parent);
+    await settled();
+    assert
+      .dom('[data-test-reactive-parent] [data-test-has-purple]')
+      .hasText('yes', 'configuration updates after link loads');
+  });
+
+  test('configuration reacts when a consumed linked card field value changes', async function (assert) {
+    // Create a ParentReactive instance that links to ThemeCard/main using a cached Theme instance
+    let resource = {
+      attributes: { color: {}, title: 'parent' },
+      relationships: {
+        theme: { links: { self: `${testRealmURL}ThemeCard/main` } },
+      },
+      meta: {
+        adoptsFrom: {
+          module: `${testRealmURL}reactive`,
+          name: 'ParentReactive',
+        },
+      },
+    };
+
+    // Custom store returns a Theme instance immediately so initial configuration resolves
+    let themeRef = `${testRealmURL}ThemeCard/main`;
+    let mod = await loader.import(`${testRealmURL}reactive`);
+    let ThemeCard = (mod as any).ThemeCard;
+    let cachedTheme = new ThemeCard({ palette: 'purple' });
+    let customStore = {
+      get(url: string) {
+        return url.replace(/\\.json$/, '') === themeRef
+          ? cachedTheme
+          : undefined;
+      },
+      set() {},
+      setNonTracked() {},
+      makeTracked() {},
+      async loadDocument(_url: string) {
+        throw new Error('should not fetch');
+      },
+      trackLoad() {},
+      async loaded() {},
+    } as any;
+
+    let parent = await createFromSerialized(
+      resource as any,
+      { data: resource } as any,
+      undefined,
+      { store: customStore },
+    );
+
+    // Ensure link is realized, then render and verify initial state 'yes'
+    await ensureLinksLoaded(parent);
+    await settled();
+    await renderCard(loader, parent, 'isolated');
+    assert
+      .dom('[data-test-reactive-parent] [data-test-has-purple]')
+      .hasText('yes', 'configuration reflects initial theme value');
+
+    // Change the consumed field in the linked Theme card
+    cachedTheme.palette = 'orange';
+    // Trigger parent recompute and re-render
+    await ensureLinksLoaded(parent);
+    await settled();
+
+    assert
+      .dom('[data-test-reactive-parent] [data-test-has-purple]')
+      .hasText('no', 'configuration updates when consumed field changes');
+  });
+
+  test('configuration reacts when a parent attribute changes', async function (assert) {
+    class LocalReactiveColorField extends FieldDef {
+      static displayName = 'LocalReactiveColor';
+      static edit = class Edit extends Component<typeof this> {
+        get color() {
+          return this.args.configuration?.presentation?.palette;
+        }
+        get hasPurple() {
+          return this.color === 'purple';
+        }
+        <template>
+          <span data-test-has-purple>{{if this.hasPurple 'yes' 'no'}}</span>
+        </template>
+      };
+    }
+
+    class ParentSelfReactive extends CardDef {
+      @field preferredColor = contains(StringField);
+      @field color = contains(LocalReactiveColorField, {
+        configuration: (self) => ({
+          presentation: { palette: self.preferredColor },
+        }),
+      });
+      static isolated = class Isolated extends Component<typeof this> {
+        <template>
+          <div data-test-reactive-parent-self>
+            <@fields.color @format='edit' />
+          </div>
+        </template>
+      };
+    }
+
+    let parent = new ParentSelfReactive({ preferredColor: 'purple' });
+
+    await renderCard(loader, parent, 'isolated');
+    assert
+      .dom('[data-test-reactive-parent-self] [data-test-has-purple]')
+      .hasText('yes', 'configuration reflects initial parent field value');
+
+    parent.preferredColor = 'orange';
+    await settled();
+    assert
+      .dom('[data-test-reactive-parent-self] [data-test-has-purple]')
+      .hasText('no', 'configuration updates when parent field changes');
+  });
+});


### PR DESCRIPTION
_Note: we're going to build enumField on top of this._

# Per-Instance Field Configuration (without exposing parent instance)

## Objective

Provide a consistent, general mechanism for per-instance field configuration that:

- Lets a parent card compute configuration for a field (e.g., options, palettes, constraints).
- Keeps the parent instance private (never passed into templates or field components).
- Offers a safe, reactive API that gracefully handles NotLoaded relationships.
- Applies to any field type (independent of enumField).

## API Summary (single, consistent key: configuration)

- Field definition (FieldDef):
  - `static configuration?: ConfigurationInput<any>`
- Field usage (`contains` / `containsMany` / `linksTo` / `linksToMany`):
  - `contains(Field, { configuration?: ConfigurationInput<ParentInstance> })`
  - `containsMany(Field, { configuration?: ConfigurationInput<ParentInstance> })`
  - `linksTo(Card, { configuration?: ConfigurationInput<ParentInstance> })`
  - `linksToMany(Card, { configuration?: ConfigurationInput<ParentInstance> })`

Where:

- `ConfigurationInput<T> = FieldConfiguration | ((self: Readonly<T>) => FieldConfiguration | undefined)`
- `FieldConfiguration` is field-specific (documented by each field type).
- Both configuration sources (FieldDef and contains) are computed and merged. There is no choose-one precedence; instead, the effective config is the merge of all available sources.

## Function signature and NotLoaded handling

- Configuration functions have the same signature in both places (FieldDef and contains): `(self: Readonly<T>) => FieldConfiguration | undefined`.
- The runtime handles reactivity and NotLoaded for you:
  - Before invocation, call `entangleWithCardTracking(self)`.
  - Invoke the function inside a try/catch; if accessing `self.someLink` throws NotLoaded, treat this fragment as `undefined` for the current render and rely on re-render when links load.
  - No special context object or `read()` wrapper is required.

## FieldConfiguration shape

- Each field type defines and validates its own schema. Suggested pattern is to namespace by capability:
  - Validation: `{ validate?: { min?: number; max?: number } }`
  - Presentation: `{ presentation?: { palette?: string[] } }`
  - Options (select-like fields): `{ options?: (primitive | { value; label?; icon? })[] }`

The runtime treats `FieldConfiguration` as an opaque object; the field class interprets it.

## Resolution and Merge (runtime)

Introduce `resolveFieldConfiguration(field, instance)` that:

- Calls `entangleWithCardTracking(instance)` to ensure reactive recomputation.
- Computes zero or more configuration fragments:
  - `fromFieldDef` by evaluating `field.card.constructor.configuration` if present (static POGO or function form with context).
  - `fromFieldUsage` by evaluating `field.configuration` (stored by contains/containsMany/linksTo/linksToMany) if present.
- Merges available fragments to produce the effective configuration.

Merge rules:

- Deterministic order: `fromFieldDef` → `fromFieldUsage`.
- Shallow merge by default (object spread semantics). For nested objects, a one-level deep merge is acceptable, but avoid surprising deep behaviors.
- Arrays are replaced rather than concatenated (field authors can decide to concatenate explicitly inside their configuration provider if desired).
- `undefined` values are treated as “absent” and do not overwrite existing values.
- If a configuration function throws due to NotLoaded, catch and treat its fragment as `undefined` for this render; allow re-render to recompute later.

Caching:

- Optionally cache by `(instance, fieldName)` in a WeakMap.
- Invalidate on `notifyCardTracking(instance)` to recompute on next access.

## Consumption

- Editors and atoms: do not receive the parent instance. The runtime computes the merged configuration and passes it directly to format components as `@configuration`.
  - All field/card format components (isolated, embedded, fitted, edit, atom) can read `@configuration` directly.
- Helpers: optional. The preferred pattern is to use the injected `@configuration` arg instead of helpers. If a helper is still desired for specific cases, it should consult `resolveFieldConfiguration` and entangle with tracking.
- Validation: field `validate()` is based on the same effective configuration. When configuration is partially `undefined` because inputs aren’t loaded yet:
  - Allow `null`/empty assignments.
  - For concrete values, validate against known configuration; if unknown, either optimistically accept (and rely on later interactions to revalidate) or fail fast with a clear “configuration still loading” error. Choose a consistent policy per field type.

## Examples

1. FieldDef-level configuration (static or function), merged

```ts
class ColorPaletteField extends FieldDef {
  static configuration: ConfigurationInput<Card> = function() {
    return {
      presentation: { palette: self.theme?.palette },
    };
  };
}

class Card extends CardDef {
  @field theme = linksTo(Theme);
  @field color = contains(ColorPaletteField);
}
```

2. Parent-level configuration merged with FieldDef

```ts
class Card extends CardDef {
  @field theme = linksTo(Theme);
  @field color = contains(ColorPaletteField, {
    configuration: { presentation: { palette: ['red', 'blue'] } },
  });
  // Effective configuration merges:
  //   ColorPaletteField.configuration(ctx or POGO) → contains(...).configuration
}
```

3. Accessing the merged configuration in templates via argument

```gts
class ColorPaletteField extends FieldDef {
  static edit = class Edit extends Component<typeof this> {
    <template>
      {{#each (@configuration.presentation.palette ??) as |color|}}
        <span class='swatch' style={{concat 'background:' color}} />
      {{/each}}
    </template>
  };
}
```

4. Validation based on merged configuration

```ts
class ColorPaletteField extends FieldDef {
  validate(instance: BaseDef, value: string | null) {
    let cfg = resolveFieldConfiguration(this, instance);
    let palette = cfg?.presentation?.palette ?? [];
    if (value == null) return value;
    if (!palette.includes(value))
      throw new Error('color not allowed by palette');
    return value;
  }
}
```

## Backward compatibility

- Existing fields continue to work with no configuration.
- Existing `contains(Field)` calls continue to work; the `configuration` option is optional and additive.
- No template changes required. Editors/helpers adopt the resolver internally.

## Implementation plan (incremental)

- Types and hooks
  - Define `ConfigurationInput<T>`: `FieldConfiguration | ((self: Readonly<T>) => FieldConfiguration | undefined)`.
  - On `FieldDef`, add optional `static configuration?: ConfigurationInput<any>`.
- On `contains/containsMany/linksTo/linksToMany` options, add optional `configuration?: ConfigurationInput<Parent>`; store on the field descriptor.

- Runtime
  - Implement `resolveFieldConfiguration(field, instance)` that entangles the instance, evaluates function or POGO inputs with NotLoaded tolerance, and merges fragments.
  - Pass the resulting merged configuration into all format components as `@configuration` (and optionally `@fieldConfig` as an alias). No helper required for common usage.

- Consumers
  - Update field editors/atoms to rely on the injected `@configuration` arg.
  - If any helper surfaces configuration data, ensure it uses the same resolver and entangles with tracking.

- Reactivity and caching
  - Cache per `(instance, fieldName)`; invalidate on `notifyCardTracking(instance)`.

- Validation
  - Update fields that validate against configuration to consult the resolver.

- Tests
  - Unit tests: merging behavior (objects vs arrays), NotLoaded tolerance, caching/invalidations.
  - Integration tests: FieldDef+contains merged configuration; CardDef+linksTo merged config; reactivity when linked data loads; validation against merged configuration.

## Performance considerations

- Avoid synchronous loading in configuration functions; throwing NotLoaded will be caught and treated as `undefined` for the current render.
- Keep configuration schemas small and flat; shallow merges are predictable and fast.
- Memoize resolved configuration sensibly; avoid excessive recomputation.

## Merge helpers (recommended)

To keep merging predictable and consistent across fields, provide internal utilities with the following semantics:

- `shallowMerge<T extends object>(a: T | undefined, b: T | undefined): T | undefined`
  - Returns a new object with one-level shallow merge of `a` then `b`.
  - `undefined` inputs are treated as absent (return the other operand).
  - `null` in `b` overwrites.
  - Arrays are replaced (not concatenated).

- `mergeConfigurations<A extends object, B extends object>(...fragments: (A | B | undefined)[]): (A & B) | undefined`
  - Folds left-to-right using `shallowMerge` to implement the deterministic order.

TypeScript sketch:

```ts
function isObject(v: unknown): v is Record<string, unknown> {
  return !!v && typeof v === 'object' && !Array.isArray(v);
}

export function shallowMerge<T extends Record<string, any>>(
  a?: T,
  b?: T,
): T | undefined {
  if (!a && !b) return undefined;
  if (!a) return b;
  if (!b) return a;
  let out: Record<string, any> = { ...a };
  for (let [k, v] of Object.entries(b)) {
    if (v === undefined) continue; // ignore undefined
    // arrays and primitives replace; objects shallow-merge one level
    if (isObject(v) && isObject(out[k])) {
      out[k] = { ...(out[k] as Record<string, unknown>), ...v };
    } else {
      out[k] = v; // replace (includes null and arrays)
    }
  }
  return out as T;
}

export function mergeConfigurations<T extends object>(
  ...fragments: (T | undefined)[]
): T | undefined {
  return fragments.reduce<T | undefined>(
    (acc, next) => shallowMerge(acc, next),
    undefined,
  );
}
```

Notes:

- If a field requires deeper or custom semantics (e.g., array concatenation), it should do so inside its configuration function and still return a plain POGO for merging.
- Keep helpers internal; only field authors and runtime use them.

## Security and safety

- Parent instance is never exposed to templates or field components.
- Consider dev-mode guards against mutation of `self` inside configuration functions.
- Treat configuration as immutable by convention.

## Relation to `enumField`

- `enumField` can adopt this mechanism by defining `static configuration?: ConfigurationInput<Parent>` that returns `{ options }` (either as a POGO or via link access on `self` that may throw NotLoaded; runtime tolerates this).
- Parent authors can add per-usage configuration via `contains(PriorityField, { configuration })` and the two are merged.

## Consuming `@configuration` in custom field components

Any field format component (embedded, fitted, atom, edit) receives the merged configuration as an argument named `@configuration`. Read it directly from `this.args.configuration` and render defensively in case configuration is temporarily unavailable (e.g., while links load).

Example: simple palette consumer in an edit template

```gts
import { FieldDef, Component } from 'https://cardstack.com/base/card-api';

// A field whose configuration provides a list of colors to render/select
export class ColorField extends FieldDef {
  static edit = class Edit extends Component<typeof this> {
    // Normalize to an array to keep template simple
    get palette(): string[] {
      return ((this.args.configuration as any)?.presentation?.palette ??
        []) as string[];
    }

    <template>
      {{#if this.palette.length}}
        <ul class='color-palette' data-test-color-palette>
          {{#each this.palette as |color|}}
            <li
              class='swatch'
              style={{concat 'background:' color}}
              data-test-swatch={{color}}
            />
          {{/each}}
        </ul>
      {{else}}
        <em data-test-no-palette>palette loading or not configured</em>
      {{/if}}
    </template>
  };
}
```

Example: options for a select-like field (primitive or rich options)

```gts
import { FieldDef, Component } from 'https://cardstack.com/base/card-api';

type Option = string | { value: string; label?: string };

export class SelectField extends FieldDef {
  static edit = class Edit extends Component<typeof this> {
    get options(): { value: string; label: string }[] {
      let raw = (this.args.configuration as any)?.options as
        | Option[]
        | undefined;
      if (!raw) return [];
      return raw.map((o) =>
        typeof o === 'string'
          ? { value: o, label: o }
          : { value: o.value, label: o.label ?? o.value },
      );
    }

    <template>
      <select data-test-select>
        {{#each this.options as |opt|}}
          <option value={{opt.value}}>{{opt.label}}</option>
        {{/each}}
      </select>
    </template>
  };
}
```

Notes:

- Reactivity: configuration recomputes automatically when its inputs change. If the configuration function reads links, it may be undefined until those links load; guard the template accordingly.
- Privacy: the parent instance is not provided to components—only `@configuration`.
- Types: configuration is intentionally opaque; field authors define the shape and should validate/normalize locally inside the component or field logic.
