### PR TITLE
Fix: reodering linksToMany items is broken

### DIFF
--- a/packages/base/contains-many-component.gts
+++ b/packages/base/contains-many-component.gts
@@ -334,6 +334,7 @@ export function getContainsManyComponent({
                 {{effectiveFormat}}-format
                 {{unless arrayField.children.length "empty"}}'
               data-test-plural-view={{field.fieldType}}
+              data-test-plural-view-field={{field.name}}
               data-test-plural-view-format={{effectiveFormat}}
               ...attributes
             >

--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -1,5 +1,4 @@
 import GlimmerComponent from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
 import { on } from '@ember/modifier';
 import { fn } from '@ember/helper';
 import {
@@ -167,13 +166,11 @@ interface LinksToManyStandardEditorSignature {
 
 class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEditorSignature> {
   @consume(CardContextName) declare cardContext: CardContext;
-  @tracked private reorderNonce = 0;
   private sortableGroupId = uuidv4();
 
   @action
   setItems(items: any) {
     this.args.arrayField.set(items);
-    this.reorderNonce++;
   }
 
   get decoratedChildren() {
@@ -183,7 +180,7 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
     return this.args.arrayField.children.map((child, index) => ({
       box: child,
       index,
-      key: `${this.reorderNonce}-${index}`,
+      key: index,
     }));
   }
 

--- a/packages/experiments-realm/BlogPost/urban-living-future-sustainable.json
+++ b/packages/experiments-realm/BlogPost/urban-living-future-sustainable.json
@@ -1,29 +1,47 @@
 {
   "data": {
+    "meta": {
+      "adoptsFrom": {
+        "name": "BlogPost",
+        "module": "../blog-post"
+      }
+    },
     "type": "card",
     "attributes": {
-      "headline": "The Future of Urban Living: Skyscrapers or Sustainable Communities?",
-      "slug": "urban-living-future-sustainable",
       "body": "As urban populations swell and space becomes increasingly limited, the debate between vertical development and sustainable community-building intensifies. Skyscrapers promise to accommodate more people in a smaller footprint, enhancing density and reducing urban sprawl. However, this vertical approach can strain infrastructure and may lack the sense of community that many residents crave. On the other hand, sustainable communities emphasize green spaces, local resources, and human-scale development, fostering a stronger connection between people and their environment. While both paths offer solutions to urban challenges, the future of cities may lie in blending these two concepts—integrating smart skyscrapers with sustainable, community-oriented design to create harmonious, livable urban ecosystems.",
-      "publishDate": "2024-12-06T22:29:00.000Z",
-      "featuredImage": {
-        "imageUrl": "https://images.unsplash.com/photo-1548182880-8b7b2af2caa2?q=80&w=2970&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-        "credit": "Photo via Unsplash",
-        "caption": null,
-        "altText": "Times Square, New York",
-        "size": "actual",
-        "height": null,
-        "width": null
-      },
+      "slug": "urban-living-future-sustainable",
       "cardInfo": {
+        "notes": null,
+        "title": null,
         "description": "As our cities grow ever upward, should we continue to build, or focus on creating? This article explores the pros and cons of both approaches.",
         "thumbnailURL": "https://images.unsplash.com/photo-1548182880-8b7b2af2caa2?q=80&w=2970&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+      },
+      "headline": "The Future of Urban Living: Skyscrapers or Sustainable Communities?",
+      "publishDate": "2024-12-06T22:29:00.000Z",
+      "featuredImage": {
+        "size": "actual",
+        "width": null,
+        "credit": "Photo via Unsplash",
+        "height": null,
+        "altText": "Times Square, New York",
+        "caption": null,
+        "imageUrl": "https://images.unsplash.com/photo-1548182880-8b7b2af2caa2?q=80&w=2970&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
       }
     },
     "relationships": {
+      "blog": {
+        "links": {
+          "self": "../BlogApp/ramped"
+        }
+      },
+      "editors": {
+        "links": {
+          "self": null
+        }
+      },
       "authors.0": {
         "links": {
-          "self": "../Author/jane-doe"
+          "self": "../Author/ad28d989-68a8-4bad-a8dc-05f9f724489c"
         }
       },
       "authors.1": {
@@ -33,12 +51,7 @@
       },
       "authors.2": {
         "links": {
-          "self": "../Author/ad28d989-68a8-4bad-a8dc-05f9f724489c"
-        }
-      },
-      "blog": {
-        "links": {
-          "self": "../BlogApp/ramped"
+          "self": "../Author/jane-doe"
         }
       },
       "categories": {
@@ -46,16 +59,10 @@
           "self": null
         }
       },
-      "editors": {
+      "cardInfo.theme": {
         "links": {
           "self": null
         }
-      }
-    },
-    "meta": {
-      "adoptsFrom": {
-        "module": "../blog-post",
-        "name": "BlogPost"
       }
     }
   }

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -3079,11 +3079,26 @@ module('Integration | operator-mode', function (hooks) {
       .exists({ count: 3 });
 
     assert
+      .dom(
+        `[data-test-list="friends"] [data-test-item="0"] [data-test-card="${testRealmURL}Pet/jackie"]`,
+      )
+      .exists();
+    assert
       .dom(`[data-test-list="friends"] [data-test-item="0"]`)
       .hasText('Jackie');
     assert
+      .dom(
+        `[data-test-list="friends"] [data-test-item="1"] [data-test-card="${testRealmURL}Pet/woody"]`,
+      )
+      .exists();
+    assert
       .dom(`[data-test-list="friends"] [data-test-item="1"]`)
       .hasText('Woody');
+    assert
+      .dom(
+        `[data-test-list="friends"] [data-test-item="2"] [data-test-card="${testRealmURL}Pet/buzz"]`,
+      )
+      .exists();
     assert
       .dom(`[data-test-list="friends"] [data-test-item="2"]`)
       .hasText('Buzz');
@@ -3141,11 +3156,26 @@ module('Integration | operator-mode', function (hooks) {
       .dom('[data-test-list="friends"] [data-test-item]')
       .exists({ count: 3 });
     assert
+      .dom(
+        `[data-test-list="friends"] [data-test-item="0"] [data-test-card="${testRealmURL}Pet/woody"]`,
+      )
+      .exists();
+    assert
       .dom(`[data-test-list="friends"] [data-test-item="0"]`)
       .hasText('Woody');
     assert
+      .dom(
+        `[data-test-list="friends"] [data-test-item="1"] [data-test-card="${testRealmURL}Pet/buzz"]`,
+      )
+      .exists();
+    assert
       .dom(`[data-test-list="friends"] [data-test-item="1"]`)
       .hasText('Buzz');
+    assert
+      .dom(
+        `[data-test-list="friends"] [data-test-item="2"] [data-test-card="${testRealmURL}Pet/jackie"]`,
+      )
+      .exists();
     assert
       .dom(`[data-test-list="friends"] [data-test-item="2"]`)
       .hasText('Jackie');

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -3303,9 +3303,6 @@ module('Integration | operator-mode', function (hooks) {
     document
       .querySelector('[data-test-list="nicknames"]')
       ?.scrollIntoView({ block: 'center' });
-    document
-      .querySelector('[data-test-list="favoriteGames"]')
-      ?.scrollIntoView({ block: 'center' });
 
     assert
       .dom('[data-test-list="nicknames"] [data-test-item]')
@@ -3373,7 +3370,7 @@ module('Integration | operator-mode', function (hooks) {
       });
     };
     await dragAndDrop(
-      '[data-test-list="nicknames"] [data-test-sort="2"]',
+      '[data-test-list="nicknames"] [data-test-sort="1"]',
       '[data-test-list="nicknames"] [data-test-sort="0"]',
     );
 
@@ -3382,13 +3379,13 @@ module('Integration | operator-mode', function (hooks) {
       .exists({ count: 3 });
     assert
       .dom(`[data-test-list="nicknames"] [data-test-item="0"] input`)
-      .hasValue('Comet');
+      .hasValue('Bolt');
     assert
       .dom(`[data-test-list="nicknames"] [data-test-item="1"] input`)
       .hasValue('Ace');
     assert
       .dom(`[data-test-list="nicknames"] [data-test-item="2"] input`)
-      .hasValue('Bolt');
+      .hasValue('Comet');
 
     assert
       .dom(`[data-test-list="favoriteGames"] [data-test-item="0"] input`)
@@ -3407,11 +3404,11 @@ module('Integration | operator-mode', function (hooks) {
       .exists({ count: 3 });
     assert
       .dom(`[data-test-plural-view-field="nicknames"]`)
-      .containsText('Comet');
+      .containsText('Bolt');
     assert.dom(`[data-test-plural-view-field="nicknames"]`).containsText('Ace');
     assert
       .dom(`[data-test-plural-view-field="nicknames"]`)
-      .containsText('Bolt');
+      .containsText('Comet');
 
     assert
       .dom(

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -90,6 +90,7 @@ module('Integration | operator-mode', function (hooks) {
     let {
       field,
       contains,
+      containsMany,
       linksTo,
       linksToMany,
       serialize,
@@ -252,6 +253,8 @@ module('Integration | operator-mode', function (hooks) {
       @field pet = linksTo(Pet);
       @field friends = linksToMany(Pet);
       @field cars = linksToMany(Car);
+      @field nicknames = containsMany(StringField);
+      @field favoriteGames = containsMany(StringField);
       @field firstLetterOfTheName = contains(StringField, {
         computeVia: function (this: Person) {
           return this.firstName[0];
@@ -277,6 +280,10 @@ module('Integration | operator-mode', function (hooks) {
           <@fields.friends />
           Cars:
           <@fields.cars />
+          Nicknames:
+          <@fields.nicknames />
+          Favorite Games:
+          <@fields.favoriteGames />
           <div data-test-addresses>Address: <@fields.address /></div>
         </template>
       };
@@ -475,6 +482,8 @@ module('Integration | operator-mode', function (hooks) {
               }),
             }),
             pet: petMango,
+            nicknames: ['Lan'],
+            favoriteGames: ['Soccer'],
           }),
           'Person/hassan.json': {
             data: {
@@ -498,6 +507,8 @@ module('Integration | operator-mode', function (hooks) {
             firstName: 'Burcu',
             friends: [petJackie, petWoody, petBuzz],
             cars: [myvi, proton],
+            nicknames: ['Ace', 'Bolt', 'Comet'],
+            favoriteGames: ['Chess', 'Go'],
           }),
           'Friend/friend-b.json': friendB,
           'Friend/friend-a.json': new Friend({
@@ -3241,6 +3252,178 @@ module('Integration | operator-mode', function (hooks) {
         `[data-test-plural-view-field="cars"] [data-test-plural-view-item="1"]`,
       )
       .hasText('Proton');
+  });
+
+  test('can reorder containsMany cards in edit view without affecting other containsMany cards', async function (assert) {
+    setCardInOperatorModeState(`${testRealmURL}grid`);
+
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template>
+          <OperatorMode @onClose={{noop}} />
+          <CardPrerender />
+        </template>
+      },
+    );
+
+    await click(`[data-test-boxel-filter-list-button="All Cards"]`);
+    await waitFor(`[data-test-cards-grid-item]`);
+    await click(
+      `[data-test-cards-grid-item="${testRealmURL}Person/burcu"] .field-component-card`,
+    );
+
+    await waitFor(`[data-test-stack-card="${testRealmURL}Person/burcu"]`);
+    assert
+      .dom(
+        `[data-test-plural-view-field="nicknames"] [data-test-plural-view-item]`,
+      )
+      .exists({ count: 3 });
+    assert
+      .dom(
+        `[data-test-plural-view-field="favoriteGames"] [data-test-plural-view-item]`,
+      )
+      .exists({ count: 2 });
+    assert.dom(`[data-test-plural-view-field="nicknames"]`).containsText('Ace');
+    assert
+      .dom(`[data-test-plural-view-field="nicknames"]`)
+      .containsText('Bolt');
+    assert
+      .dom(`[data-test-plural-view-field="nicknames"]`)
+      .containsText('Comet');
+    assert
+      .dom(`[data-test-plural-view-field="favoriteGames"]`)
+      .containsText('Chess');
+    assert
+      .dom(`[data-test-plural-view-field="favoriteGames"]`)
+      .containsText('Go');
+
+    await click(
+      `[data-test-stack-card="${testRealmURL}Person/burcu"] [data-test-edit-button]`,
+    );
+    document
+      .querySelector('[data-test-list="nicknames"]')
+      ?.scrollIntoView({ block: 'center' });
+    document
+      .querySelector('[data-test-list="favoriteGames"]')
+      ?.scrollIntoView({ block: 'center' });
+
+    assert
+      .dom('[data-test-list="nicknames"] [data-test-item]')
+      .exists({ count: 3 });
+    assert
+      .dom('[data-test-list="favoriteGames"] [data-test-item]')
+      .exists({ count: 2 });
+
+    assert
+      .dom(`[data-test-list="nicknames"] [data-test-item="0"] input`)
+      .hasValue('Ace');
+    assert
+      .dom(`[data-test-list="nicknames"] [data-test-item="1"] input`)
+      .hasValue('Bolt');
+    assert
+      .dom(`[data-test-list="nicknames"] [data-test-item="2"] input`)
+      .hasValue('Comet');
+
+    assert
+      .dom(`[data-test-list="favoriteGames"] [data-test-item="0"] input`)
+      .hasValue('Chess');
+    assert
+      .dom(`[data-test-list="favoriteGames"] [data-test-item="1"] input`)
+      .hasValue('Go');
+
+    let dragAndDrop = async (itemSelector: string, targetSelector: string) => {
+      let itemElement = document.querySelector(itemSelector);
+      let targetElement = document.querySelector(targetSelector);
+
+      if (!itemElement || !targetElement) {
+        throw new Error('Item or target element not found');
+      }
+
+      let itemRect = itemElement.getBoundingClientRect();
+      let targetRect = targetElement.getBoundingClientRect();
+
+      await triggerEvent(itemElement, 'mousedown', {
+        clientX: itemRect.left + itemRect.width / 2,
+        clientY: itemRect.top + itemRect.height / 2,
+      });
+
+      await triggerEvent(document, 'mousemove', {
+        clientX: itemRect.left + 1,
+        clientY: itemRect.top + 1,
+      });
+
+      let firstStackItemHeaderRect = document
+        .querySelector('[data-test-operator-mode-stack="0"] header')!
+        .getBoundingClientRect();
+      let firstStackItemPaddingTop = getComputedStyle(
+        document.querySelector('[data-test-operator-mode-stack="0"]')!,
+      )
+        .getPropertyValue('padding-top')
+        .replace('px', '');
+      let marginTop =
+        firstStackItemHeaderRect.height + Number(firstStackItemPaddingTop);
+      await triggerEvent(document, 'mousemove', {
+        clientX: targetRect.left + targetRect.width / 2,
+        clientY: targetRect.top - marginTop,
+      });
+
+      await triggerEvent(itemElement, 'mouseup', {
+        clientX: targetRect.left + targetRect.width / 2,
+        clientY: targetRect.top - marginTop,
+      });
+    };
+    await dragAndDrop(
+      '[data-test-list="nicknames"] [data-test-sort="2"]',
+      '[data-test-list="nicknames"] [data-test-sort="0"]',
+    );
+
+    assert
+      .dom('[data-test-list="nicknames"] [data-test-item]')
+      .exists({ count: 3 });
+    assert
+      .dom(`[data-test-list="nicknames"] [data-test-item="0"] input`)
+      .hasValue('Comet');
+    assert
+      .dom(`[data-test-list="nicknames"] [data-test-item="1"] input`)
+      .hasValue('Ace');
+    assert
+      .dom(`[data-test-list="nicknames"] [data-test-item="2"] input`)
+      .hasValue('Bolt');
+
+    assert
+      .dom(`[data-test-list="favoriteGames"] [data-test-item="0"] input`)
+      .hasValue('Chess');
+    assert
+      .dom(`[data-test-list="favoriteGames"] [data-test-item="1"] input`)
+      .hasValue('Go');
+
+    await click(
+      `[data-test-stack-card="${testRealmURL}Person/burcu"] [data-test-edit-button]`,
+    );
+    assert
+      .dom(
+        `[data-test-plural-view-field="nicknames"] [data-test-plural-view-item]`,
+      )
+      .exists({ count: 3 });
+    assert
+      .dom(`[data-test-plural-view-field="nicknames"]`)
+      .containsText('Comet');
+    assert.dom(`[data-test-plural-view-field="nicknames"]`).containsText('Ace');
+    assert
+      .dom(`[data-test-plural-view-field="nicknames"]`)
+      .containsText('Bolt');
+
+    assert
+      .dom(
+        `[data-test-plural-view-field="favoriteGames"] [data-test-plural-view-item]`,
+      )
+      .exists({ count: 2 });
+    assert
+      .dom(`[data-test-plural-view-field="favoriteGames"]`)
+      .containsText('Chess');
+    assert
+      .dom(`[data-test-plural-view-field="favoriteGames"]`)
+      .containsText('Go');
   });
 
   test('CardDef filter is not displayed in filter list', async function (assert) {


### PR DESCRIPTION
**Problem**

Dragging cards in a links-to-many or contains-many field reuses the same card instances in new positions. When card templates read data directly from `@model` (instead of staying on the boxed `<@fields>` path), Ember thinks the rendered DOM is still valid—so things like `author.thumbnailURL` stay stuck in their original slots even though the items moved.

**Solution**

After every reorder we now wrap each child box with a nonce-backed key and iterate those decorated entries. That forces Ember to refresh the child component inputs whenever the order changes, so even templates that use the raw `@model` values pick up the new position and re-render correctly.


Before:

https://github.com/user-attachments/assets/a81bc96f-fdf0-4c7c-9da8-588f8ed10832

After:


https://github.com/user-attachments/assets/b15cf276-9dcf-41f0-8218-d64683cae46f


