### PR TITLE
Enable edit format UI for writable-realm instances of readonly-realm carddefs

### DIFF
--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -408,9 +408,10 @@ const notFoundAdoptionInstance = `{
 }
 `;
 
+let personalRealmURL: string;
+
 module('Acceptance | code submode tests', function (_hooks) {
   module('multiple realms', function (hooks) {
-    let personalRealmURL: string;
     let additionalRealmURL: string;
     let catalogRealmURL: string;
 

--- a/packages/host/tests/acceptance/code-submode/card-playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/card-playground-test.gts
@@ -149,6 +149,30 @@ const personCard = `import { field, linksTo, CardDef } from 'https://cardstack.c
   }
 `;
 
+const localStyleReferenceCard = {
+  data: {
+    type: 'card',
+    attributes: {
+      cardInfo: {
+        title: 'Local Style Reference',
+        description: 'Local card instance for style reference tests',
+        thumbnailURL: null,
+        notes: null,
+      },
+      styleName: 'Local Style Reference',
+      visualDNA: 'Style reference content for playground edit tests',
+      inspirations: ['Testing'],
+      wallpaperImages: [],
+    },
+    meta: {
+      adoptsFrom: {
+        module: 'https://cardstack.com/base/style-reference',
+        name: 'default',
+      },
+    },
+  },
+};
+
 module('Acceptance | code-submode | card playground', function (_hooks) {
   module('single realm', function (hooks) {
     let realm: Realm;
@@ -1351,6 +1375,7 @@ module('Acceptance | code-submode | card playground', function (_hooks) {
         contents: {
           ...SYSTEM_CARD_FIXTURE_CONTENTS,
           'author-card.gts': authorCard,
+          'StyleReference/local-style.json': localStyleReferenceCard,
           '.realm.json': {
             name: `Test User's Workspace`,
             backgroundURL: 'https://i.postimg.cc/NjcjbyD3/4k-origami-flock.jpg',
@@ -1421,6 +1446,49 @@ module('Acceptance | code-submode | card playground', function (_hooks) {
         'isolated',
         'new card is rendered in isolated format',
       );
+    });
+
+    test('edit format is enabled for writable instances of read-only card definitions', async function (assert) {
+      removePlaygroundSelections();
+      removeRecentFiles();
+      removeRecentCards();
+
+      try {
+        setRecentFiles([[personalRealmURL, 'StyleReference/local-style.json']]);
+
+        await openFileInPlayground('style-reference.gts', baseRealm.url);
+
+        await waitFor('[data-test-instance-chooser]');
+        assert
+          .dom('[data-test-selected-item]')
+          .containsText('Local Style Reference');
+
+        await waitFor('[data-test-edit-button]');
+        assert
+          .dom('[data-test-edit-button]')
+          .exists('edit button is shown for writable instance');
+
+        await click('[data-test-edit-button]');
+        await waitFor('[data-test-card-format="edit"]');
+        assert
+          .dom('[data-test-card-format="edit"]')
+          .exists('playground switches to edit format');
+
+        await fillIn(
+          '[data-test-card-format="edit"] [data-test-field="styleName"] input',
+          'Updated Style Reference',
+        );
+
+        assert
+          .dom(
+            '[data-test-card-format="edit"] [data-test-field="styleName"] input',
+          )
+          .isNotDisabled('styleName input is enabled for editing');
+      } finally {
+        removePlaygroundSelections();
+        removeRecentFiles();
+        removeRecentCards();
+      }
     });
   });
 


### PR DESCRIPTION
This PR enables the edit format in the playground panel for a selected card instance from a writable realm, even when the user does not have write access to the card definition’s realm.

https://github.com/user-attachments/assets/605b1f22-0c7b-44fc-8ff4-b0f8dde5b37b


