### PR TITLE
ai-bot performance profiling and optimizations

### DIFF
--- a/packages/ai-bot/README.md
+++ b/packages/ai-bot/README.md
@@ -29,6 +29,27 @@ Set this as the `OPENROUTER_API_KEY` environment variable.
 
 Start the server with `pnpm start` or `pnpm start-dev` for live reload.
 
+### Profiling (low-overhead)
+
+- Enable lightweight phase timing logs (off by default):
+  - `AI_BOT_PROF=1 LOG_LEVELS="ai-bot=debug" pnpm start`
+  - Emits timings for `lock:acquire`, `history:*`, `billing:validateCredits`, `llm:request:start`, `llm:ttft`, `llm:chunk:onChunk`, `llm:finalChatCompletion`, `response:finalize`, and `title:*`.
+
+### Async graphs (Clinic Bubbleprof)
+
+- Run Bubbleprof attached to ts-node:
+  - `AI_BOT_PROF=1 DISABLE_MATRIX_JS_LOGGING=1 LOG_LEVELS="ai-bot=debug" pnpm dlx clinic bubbleprof --dest .clinic/ai-bot-bp -- node --require ts-node/register/transpile-only main.ts`
+  - Drive one interaction; stop with Ctrl+C twice (~200–500ms apart) or send `SIGTERM` from another terminal.
+  - Open the report:
+    - `pnpm dlx clinic open .clinic/ai-bot-bp`
+    - If needed, open the trace directly: `pnpm dlx clinic open '.clinic/ai-bot-bp/*clinic-bubbleprof/*-traceevent'`
+
+### Streaming behavior tuning
+
+- You can adjust mid-stream edit frequency to balance responsiveness vs. Matrix churn:
+  - `AI_BOT_STREAM_THROTTLE_MS` (default `600`): min ms between edit sends.
+  - `AI_BOT_STREAM_MIN_DELTA` (default `300`): min new characters before sending an edit (final send always occurs).
+
 ## Usage
 
 Open the boxel application and go into operator mode. Click the bottom right button to launch the matrix rooms.

--- a/packages/ai-bot/lib/profiler.ts
+++ b/packages/ai-bot/lib/profiler.ts
@@ -1,0 +1,63 @@
+import { logger } from '@cardstack/runtime-common';
+
+let log = logger('ai-bot');
+
+const PROF_ENABLED = Boolean(process.env.AI_BOT_PROF);
+
+type Label = string;
+type EventId = string;
+
+const starts: Map<EventId, Map<Label, number>> = new Map();
+
+function ensure(eventId: EventId) {
+  if (!starts.has(eventId)) starts.set(eventId, new Map());
+  return starts.get(eventId)!;
+}
+
+export function profEnabled() {
+  return PROF_ENABLED;
+}
+
+export function profMark(eventId: EventId, label: Label) {
+  if (!PROF_ENABLED) return;
+  ensure(eventId).set(label, Date.now());
+}
+
+export function profEnd(
+  eventId: EventId,
+  label: Label,
+  extra?: Record<string, unknown>,
+) {
+  if (!PROF_ENABLED) return;
+  let map = ensure(eventId);
+  let start = map.get(label);
+  let dur = start != null ? Date.now() - start : undefined;
+  log.info(
+    `[prof ${eventId}] ${label} ${dur != null ? dur + 'ms' : ''}`,
+    extra,
+  );
+}
+
+export async function profTime<T>(
+  eventId: EventId,
+  label: Label,
+  fn: () => Promise<T>,
+  extraStart?: Record<string, unknown>,
+): Promise<T> {
+  if (!PROF_ENABLED) return await fn();
+  profMark(eventId, label);
+  try {
+    return await fn();
+  } finally {
+    profEnd(eventId, label, extraStart);
+  }
+}
+
+export function profNote(
+  eventId: EventId,
+  label: Label,
+  extra?: Record<string, unknown>,
+) {
+  if (!PROF_ENABLED) return;
+  log.info(`[prof ${eventId}] ${label}`, extra);
+}

--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -54,6 +54,7 @@ import { setupSignalHandlers } from './lib/signal-handlers';
 import { isShuttingDown, setActiveGenerations } from './lib/shutdown';
 import { type MatrixClient } from 'matrix-js-sdk';
 import { debug } from 'debug';
+import { profEnabled, profTime, profNote } from './lib/profiler';
 
 let log = logger('ai-bot');
 
@@ -274,6 +275,13 @@ Common issues are:
           return;
         }
 
+        if (profEnabled()) {
+          profNote(eventId, 'event:received', {
+            type: event.getType(),
+            ts: event.event.origin_server_ts,
+          });
+        }
+
         // Handle the case where the user stops the generation
         let activeGeneration = activeGenerations.get(room.roomId);
         if (
@@ -302,10 +310,8 @@ Common issues are:
         }
 
         // Acquire a lock so that only one instance processes this event.
-        let eventLock = await acquireLock(
-          assistant.pgAdapter,
-          eventId,
-          aiBotInstanceId,
+        let eventLock = await profTime(eventId, 'lock:acquire', async () =>
+          acquireLock(assistant.pgAdapter, eventId, aiBotInstanceId),
         );
 
         if (!eventLock) {
@@ -330,7 +336,11 @@ Common issues are:
           let promptParts: PromptParts;
           let eventList: DiscreteMatrixEvent[];
           try {
-            eventList = await getRoomEvents(room.roomId, client, event.getId());
+            eventList = await profTime(
+              eventId,
+              'history:getRoomEvents',
+              async () => getRoomEvents(room.roomId, client, event.getId()),
+            );
           } catch (e) {
             log.error(e);
             Sentry.captureException(e, {
@@ -365,7 +375,11 @@ Common issues are:
           }
 
           try {
-            promptParts = await getPromptParts(eventList, aiBotUserId, client);
+            promptParts = await profTime(
+              eventId,
+              'history:constructPromptParts',
+              async () => getPromptParts(eventList, aiBotUserId, client),
+            );
             if (!promptParts.shouldRespond) {
               return;
             }
@@ -409,9 +423,11 @@ Common issues are:
             }
           }
 
-          const creditValidation = await validateAICredits(
-            assistant.pgAdapter,
-            senderMatrixUserId,
+          const creditValidation = await profTime(
+            eventId,
+            'billing:validateCredits',
+            async () =>
+              validateAICredits(assistant.pgAdapter, senderMatrixUserId),
           );
 
           if (!creditValidation.hasEnoughCredits) {
@@ -427,19 +443,34 @@ Common issues are:
             `[${eventId}] Starting generation with model %s`,
             promptParts.model,
           );
+          const requestStart = Date.now();
+          let firstChunkAt: number | undefined;
+          if (profEnabled()) {
+            profNote(eventId, 'llm:request:start', {
+              model: promptParts.model,
+            });
+          }
           const runner = assistant
             .getResponse(promptParts)
             .on('chunk', async (chunk, snapshot) => {
               log.info(`[${eventId}] Received chunk %s`, chunk.id);
+              if (profEnabled() && firstChunkAt == null) {
+                firstChunkAt = Date.now();
+                profNote(eventId, 'llm:ttft', {
+                  ms: firstChunkAt - requestStart,
+                  model: promptParts.model,
+                });
+              }
               generationId = chunk.id;
               let activeGeneration = activeGenerations.get(room.roomId);
               if (activeGeneration) {
                 activeGeneration.lastGeneratedChunkId = generationId;
               }
 
-              let chunkProcessingResult = await responder.onChunk(
-                chunk,
-                snapshot,
+              let chunkProcessingResult = await profTime(
+                eventId,
+                'llm:chunk:onChunk',
+                async () => responder.onChunk(chunk, snapshot),
               );
               let chunkProcessingResultError = chunkProcessingResult.find(
                 (promiseResult) =>
@@ -468,9 +499,13 @@ Common issues are:
           });
 
           try {
-            await runner.finalChatCompletion();
+            await profTime(eventId, 'llm:finalChatCompletion', async () =>
+              runner.finalChatCompletion(),
+            );
             log.info(`[${eventId}] Generation complete`);
-            await responder.finalize();
+            await profTime(eventId, 'response:finalize', async () =>
+              responder.finalize(),
+            );
             log.info(`[${eventId}] Response finalized`);
           } catch (error) {
             log.error(`[${eventId}] Error during generation or finalization`);
@@ -532,15 +567,22 @@ Common issues are:
     );
     try {
       //TODO: optimise this so we don't need to sync room events within a reaction event
-      let eventList = await getRoomEvents(room.roomId, client, event.getId());
+      let eventList = await profTime(
+        event.getId()!,
+        'title:getRoomEvents',
+        async () => getRoomEvents(room.roomId, client, event.getId()),
+      );
       if (roomTitleAlreadySet(eventList)) {
         return;
       }
-      let history: DiscreteMatrixEvent[] = await constructHistory(
-        eventList,
-        client,
+      let history: DiscreteMatrixEvent[] = await profTime(
+        event.getId()!,
+        'title:constructHistory',
+        async () => constructHistory(eventList, client),
       );
-      return await assistant.setTitle(room.roomId, history, event);
+      return await profTime(event.getId()!, 'title:setTitle', async () =>
+        assistant.setTitle(room.roomId, history, event),
+      );
     } catch (e) {
       log.error(e);
       Sentry.captureException(e, {


### PR DESCRIPTION
- Adds an env-gated, lightweight profiler for ai-bot to measure end-to-end phases without behavior change.
- Reduces streaming edit churn to cut Matrix-related latency during streaming responses.

Changes

Profiler

- packages/ai-bot/lib/profiler.ts: new helper with profEnabled, profTime, profNote.
- packages/ai-bot/main.ts: instrumented phases (lock, history, billing, LLM request start/TTFT/chunks/finalize, title path). Moved event:received marker after early returns.
- packages/ai-bot/README.md: usage instructions for profiler and Bubbleprof.
Streaming Optimizations
- packages/ai-bot/lib/responder.ts: increased throttle (default 600ms) and added a “minimum delta before send” gate (default 300 chars). Greatly reduces frequent Matrix edits during streaming.

Environment Flags

AI_BOT_PROF=1
Enables timing logs for phases: lock:acquire, history:*, billing:validateCredits, llm:request:start, llm:ttft, llm:chunk:onChunk, llm:finalChatCompletion, response:finalize, title:*.

AI_BOT_STREAM_THROTTLE_MS (default 600)
Minimum ms between streaming edits.

AI_BOT_STREAM_MIN_DELTA (default 300)
Minimum new characters (reasoning+content) before sending an edit; always sends on finalize.

How To Run

Profiler (local):

AI_BOT_PROF=1 LOG_LEVELS="ai-bot=debug" pnpm --filter @cardstack/ai-bot start:development

Clinic Bubbleprof:

Start: AI_BOT_PROF=1 DISABLE_MATRIX_JS_LOGGING=1 LOG_LEVELS="ai-bot=debug" pnpm dlx clinic bubbleprof --dest packages/ai-bot/.clinic/ai-bot-bp -- node --require ts-node/register/transpile-only packages/ai-bot/main.ts

Stop cleanly: Ctrl+C twice (~200–500ms apart) or kill -TERM <pid>

Open: pnpm dlx clinic open packages/ai-bot/.clinic/ai-bot-bp

Why This Helps

Prior logs showed large totals from llm:chunk:onChunk due to frequent Matrix edits (often 150–500ms each). Throttling and a min-delta gate dramatically reduce cumulative streaming overhead and response:finalize time.

Profiler logs make it easy to see whether latency is from LLM TTFT/finish vs. history/billing or Matrix sends.

Validation

Run with AI_BOT_PROF=1 and confirm:
- Fewer matrix/reponse-publisher sends during streaming.
- Much smaller cumulative llm:chunk:onChunk and response:finalize per event.
- Clear llm:request:start and quiet event:received for ignored events.

Risk & Rollout

- Profiler is inert by default; only active with AI_BOT_PROF=1.
- Streaming changes are conservative and tunable via env vars. Defaults reduce churn while keeping responsiveness.
- No API surface changes or behavioral impact to final content.