### PR TITLE
Automate host command registration

### DIFF
--- a/packages/host/app/commands/index.ts
+++ b/packages/host/app/commands/index.ts
@@ -2,299 +2,133 @@ import { VirtualNetwork } from '@cardstack/runtime-common';
 
 import HostBaseCommand from '../lib/host-base-command';
 
-import * as AddFieldToCardDefinitionCommandModule from './add-field-to-card-definition';
-import * as AddSkillsToRoomCommandModule from './add-skills-to-room';
-import * as UseAiAssistantCommandModule from './ai-assistant';
-import * as ApplySearchReplaceBlockCommandModule from './apply-search-replace-block';
-import * as AskAiCommandModule from './ask-ai';
-import * as CopyCardToRealmModule from './copy-card';
-import * as CopyCardToStackCommandModule from './copy-card-to-stack';
-import * as CopySourceCommandModule from './copy-source';
-import * as CreateAIAssistantRoomCommandModule from './create-ai-assistant-room';
-import * as CreateSpecCommandModule from './create-specs';
-import * as GenerateExampleCardsCommandModule from './generate-example-cards';
-import * as GenerateReadmeSpecCommandModule from './generate-readme-spec';
-import * as GetAllRealmMetasCommandModule from './get-all-realm-metas';
-import * as GetCardCommandModule from './get-card';
-import * as GetEventsFromRoomCommandModule from './get-events-from-room';
-import * as ListingBuildCommandModule from './listing-action-build';
-import * as ListingInitCommandModule from './listing-action-init';
-import * as ListingCreateCommandModule from './listing-create';
-import * as ListingGenerateExampleCommandModule from './listing-generate-example';
-import * as ListingInstallCommandModule from './listing-install';
-import * as ListingRemixCommandModule from './listing-remix';
-import * as ListingUseCommandModule from './listing-use';
-import * as OneShotLlmRequestCommandModule from './one-shot-llm-request';
-import * as OpenAiAssistantRoomCommandModule from './open-ai-assistant-room';
-import * as OpenInInteractModeModule from './open-in-interact-mode';
-import * as OpenWorkspaceCommandModule from './open-workspace';
-import * as PatchCardInstanceCommandModule from './patch-card-instance';
-import * as PatchCodeCommandModule from './patch-code';
-import * as PatchFieldsCommandModule from './patch-fields';
-import * as PopulateWithSampleDataCommandModule from './populate-with-sample-data';
-import * as PreviewFormatCommandModule from './preview-format';
-import * as ReadCardForAiAssistantCommandModule from './read-card-for-ai-assistant';
-import * as ReadFileForAiAssistantCommandModule from './read-file-for-ai-assistant';
-import * as SaveCardCommandModule from './save-card';
-import * as SearchAndChooseCommandModule from './search-and-choose';
-import * as SearchCardsCommandModule from './search-cards';
-import * as SearchGoogleImagesCommandModule from './search-google-images';
-import * as SendAiAssistantMessageModule from './send-ai-assistant-message';
-import * as SendRequestViaProxyCommandModule from './send-request-via-proxy';
-import * as SetActiveLlmModule from './set-active-llm';
-import * as SetUserSystemCardCommandModule from './set-user-system-card';
-import * as ShowCardCommandModule from './show-card';
-import * as SummarizeSessionCommandModule from './summarize-session';
-import * as SwitchSubmodeCommandModule from './switch-submode';
-import * as TransformCardsCommandModule from './transform-cards';
-import * as UpdateCodePathWithSelectionCommandModule from './update-code-path-with-selection';
-import * as UpdatePlaygroundSelectionCommandModule from './update-playground-selection';
-import * as UpdateSkillActivationCommandModule from './update-skill-activation';
-import * as CommandUtilsModule from './utils';
-import * as WriteTextFileCommandModule from './write-text-file';
+type CommandModule = Record<string, unknown>;
+
+declare const require: {
+  context?: (
+    directory: string,
+    useSubdirectories: boolean,
+    regExp: RegExp,
+  ) => {
+    keys(): string[];
+    <T>(id: string): T;
+  };
+};
+
+const commandModuleContext = getCommandModuleContext();
+
+interface CommandModuleDescriptor {
+  fileName: string;
+  moduleName: string;
+}
+
+const commandModules: CommandModuleDescriptor[] = commandModuleContext
+  .keys()
+  .map((fileName) => ({
+    fileName,
+    moduleName: moduleNameFromFileName(fileName),
+  }))
+  .sort((a, b) => a.moduleName.localeCompare(b.moduleName));
+
+const commandModuleLoaders = new Map<string, () => Promise<CommandModule>>(
+  commandModules.map(({ moduleName }) => [
+    moduleName,
+    () => import(`./${moduleName}`),
+  ]),
+);
 
 export function shimHostCommands(virtualNetwork: VirtualNetwork) {
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/add-field-to-card-definition',
-    AddFieldToCardDefinitionCommandModule,
+  virtualNetwork.shimAsyncModule({
+    prefix: '@cardstack/boxel-host/commands/',
+    resolve: async (rest) => {
+      let moduleName = normalizeRequestedModule(rest);
+      let loadModule = commandModuleLoaders.get(moduleName);
+      if (!loadModule) {
+        throw new Error(
+          `Unknown host command module "@cardstack/boxel-host/commands/${moduleName}"`,
+        );
+      }
+      return await loadModule();
+    },
+  });
+}
+
+export const HostCommandClasses: (typeof HostBaseCommand<any, any>)[] =
+  uniqueHostCommandClasses(
+    commandModules.flatMap(({ fileName }) => {
+      let moduleExports = commandModuleContext(fileName) as CommandModule;
+      return extractHostCommandClasses(moduleExports);
+    }),
   );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/add-skills-to-room',
-    AddSkillsToRoomCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/ask-ai',
-    AskAiCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/apply-search-replace-block',
-    ApplySearchReplaceBlockCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/copy-card',
-    CopyCardToRealmModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/copy-card-to-stack',
-    CopyCardToStackCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/copy-source',
-    CopySourceCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/create-ai-assistant-room',
-    CreateAIAssistantRoomCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/create-specs',
-    CreateSpecCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/get-events-from-room',
-    GetEventsFromRoomCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/listing-action-build',
-    ListingBuildCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/listing-action-init',
-    ListingInitCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/listing-create',
-    ListingCreateCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/listing-install',
-    ListingInstallCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/listing-use',
-    ListingUseCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/listing-remix',
-    ListingRemixCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/listing-generate-example',
-    ListingGenerateExampleCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/open-in-interact-mode',
-    OpenInInteractModeModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/patch-card-instance',
-    PatchCardInstanceCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/patch-code',
-    PatchCodeCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/patch-fields',
-    PatchFieldsCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/preview-format',
-    PreviewFormatCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/read-card-for-ai-assistant',
-    ReadCardForAiAssistantCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/read-file-for-ai-assistant',
-    ReadFileForAiAssistantCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/save-card',
-    SaveCardCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/search-cards',
-    SearchCardsCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/search-and-choose',
-    SearchAndChooseCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/open-ai-assistant-room',
-    OpenAiAssistantRoomCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/open-workspace',
-    OpenWorkspaceCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/send-ai-assistant-message',
-    SendAiAssistantMessageModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/set-active-llm',
-    SetActiveLlmModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/show-card',
-    ShowCardCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/switch-submode',
-    SwitchSubmodeCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/transform-cards',
-    TransformCardsCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/update-code-path-with-selection',
-    UpdateCodePathWithSelectionCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/update-playground-selection',
-    UpdatePlaygroundSelectionCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/update-skill-activation',
-    UpdateSkillActivationCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/send-request-via-proxy',
-    SendRequestViaProxyCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/summarize-session',
-    SummarizeSessionCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/ai-assistant',
-    UseAiAssistantCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/utils',
-    CommandUtilsModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/write-text-file',
-    WriteTextFileCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/ai-assistant',
-    UseAiAssistantCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/generate-example-cards',
-    GenerateExampleCardsCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/generate-readme-spec',
-    GenerateReadmeSpecCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/get-card',
-    GetCardCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/get-all-realm-metas',
-    GetAllRealmMetasCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/search-google-images',
-    SearchGoogleImagesCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/one-shot-llm-request',
-    OneShotLlmRequestCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/populate-with-sample-data',
-    PopulateWithSampleDataCommandModule,
-  );
-  virtualNetwork.shimModule(
-    '@cardstack/boxel-host/commands/set-user-system-card',
-    SetUserSystemCardCommandModule,
+
+function extractHostCommandClasses(
+  moduleExports: CommandModule,
+): (typeof HostBaseCommand<any, any>)[] {
+  return Object.keys(moduleExports)
+    .sort()
+    .map((exportName) => moduleExports[exportName])
+    .filter(isHostCommandClass) as (typeof HostBaseCommand<any, any>)[];
+}
+
+function uniqueHostCommandClasses(
+  classes: (typeof HostBaseCommand<any, any>)[],
+): (typeof HostBaseCommand<any, any>)[] {
+  let seen = new Set<typeof HostBaseCommand<any, any>>();
+  let result: (typeof HostBaseCommand<any, any>)[] = [];
+  for (let CommandClass of classes) {
+    if (!seen.has(CommandClass)) {
+      seen.add(CommandClass);
+      result.push(CommandClass);
+    }
+  }
+  return result;
+}
+
+function isHostCommandClass(
+  value: unknown,
+): value is typeof HostBaseCommand<any, any> {
+  return (
+    typeof value === 'function' &&
+    value.prototype instanceof HostBaseCommand
   );
 }
 
-export const HostCommandClasses: (typeof HostBaseCommand<any, any>)[] = [
-  AddFieldToCardDefinitionCommandModule.default,
-  AddSkillsToRoomCommandModule.default,
-  ApplySearchReplaceBlockCommandModule.default,
-  AskAiCommandModule.default,
-  CopyCardToStackCommandModule.default,
-  CreateAIAssistantRoomCommandModule.default,
-  CreateSpecCommandModule.default,
-  GenerateExampleCardsCommandModule.default,
-  GetCardCommandModule.default,
-  OneShotLlmRequestCommandModule.default,
-  OpenAiAssistantRoomCommandModule.default,
-  OpenAiAssistantRoomCommandModule.default,
-  OpenInInteractModeModule.default,
-  OpenWorkspaceCommandModule.default,
-  OpenWorkspaceCommandModule.default,
-  PatchFieldsCommandModule.default,
-  PopulateWithSampleDataCommandModule.default,
-  SetUserSystemCardCommandModule.default,
-  ReadCardForAiAssistantCommandModule.default,
-  ReadFileForAiAssistantCommandModule.default,
-  SaveCardCommandModule.default,
-  SearchCardsCommandModule.SearchCardsByQueryCommand,
-  SearchCardsCommandModule.SearchCardsByTypeAndTitleCommand,
-  SearchAndChooseCommandModule.default,
-  SearchGoogleImagesCommandModule.default,
-  SendAiAssistantMessageModule.default,
-  SetActiveLlmModule.default,
-  ShowCardCommandModule.default,
-  SummarizeSessionCommandModule.default,
-  SwitchSubmodeCommandModule.default,
-  TransformCardsCommandModule.default,
-  UpdateCodePathWithSelectionCommandModule.default,
-  UpdatePlaygroundSelectionCommandModule.default,
-  UpdateSkillActivationCommandModule.default,
-  UseAiAssistantCommandModule.default,
-  WriteTextFileCommandModule.default,
-];
+function moduleNameFromFileName(fileName: string): string {
+  return fileName.replace(/^\.\//, '').replace(/\.(?:g)?ts$/, '');
+}
+
+function normalizeRequestedModule(rest: string): string {
+  let sanitized = rest.replace(/^[\\/]+/, '').split(/[?#]/, 1)[0];
+  if (sanitized.endsWith('/')) {
+    sanitized = sanitized.slice(0, -1);
+  }
+  sanitized = sanitized.replace(/\.(?:g)?ts$/, '').replace(/\.js$/, '');
+  if (sanitized.endsWith('/default')) {
+    sanitized = sanitized.slice(0, -'/default'.length);
+  }
+  if (!sanitized) {
+    throw new Error('Requested host command module must not be empty');
+  }
+  if (sanitized.includes('..')) {
+    throw new Error(
+      `Refusing to resolve host command module with parent traversal: "${rest}"`,
+    );
+  }
+  if (sanitized.includes('/')) {
+    throw new Error(`Unknown host command module "${rest}"`);
+  }
+  return sanitized;
+}
+
+function getCommandModuleContext() {
+  if (typeof require?.context !== 'function') {
+    throw new Error(
+      "Host command loader expects webpack's require.context to be available",
+    );
+  }
+  return require.context(
+    './',
+    false,
+    /^\.\/(?!index)(?!.*\.d\.ts$).*\.(?:g)?ts$/,
+  );
+}


### PR DESCRIPTION
## Summary
- automate host command registration by deriving the module list from webpack's `require.context`
- resolve `shimHostCommands` dynamically so new commands are picked up without manual edits
- build `HostCommandClasses` from discovered exports to keep schema generation in sync

## Testing
- pnpm lint *(fails: unable to download Node.js 22.20.0 due to 403 response)*

------
https://chatgpt.com/codex/tasks/task_b_68ffe5f57fa883228976e0cfbf5b43f7