### PR TITLE
Date related cards from base realm: do not crash when date string value is invalid

### DIFF
--- a/packages/base/date.gts
+++ b/packages/base/date.gts
@@ -1,5 +1,5 @@
 import { Component, primitive, FieldDef } from './card-api';
-import { parse } from 'date-fns';
+import { isValid, parse } from 'date-fns';
 import { fn } from '@ember/helper';
 import { BoxelInput } from '@cardstack/boxel-ui/components';
 import { not } from '@cardstack/boxel-ui/helpers';
@@ -8,6 +8,7 @@ import {
   DateSerializer,
   fieldSerializer,
   getSerializer,
+  isValidDate,
 } from '@cardstack/runtime-common';
 
 // The Intl API is supported in all modern browsers. In older ones, we polyfill
@@ -28,7 +29,10 @@ class View extends Component<typeof DateField> {
     if (this.args.model == null) {
       return '[no date]';
     }
-    return this.args.model ? Format.format(this.args.model) : undefined;
+    if (!isValidDate(this.args.model)) {
+      return '[invalid date]';
+    }
+    return Format.format(this.args.model);
   }
 }
 
@@ -56,11 +60,18 @@ export default class DateField extends FieldDef {
       if (!date?.length) {
         return set(null);
       }
-      return set(parse(date, dateFormat, new Date()));
+      let parsed = parse(date, dateFormat, new Date());
+      if (!isValid(parsed)) {
+        return;
+      }
+      return set(parsed);
     }
 
     get formatted() {
       if (!this.args.model) {
+        return;
+      }
+      if (!isValidDate(this.args.model)) {
         return;
       }
       return getSerializer(DateField[fieldSerializer]).serialize(

--- a/packages/base/datetime.gts
+++ b/packages/base/datetime.gts
@@ -1,10 +1,14 @@
 import { Component, primitive, FieldDef } from './card-api';
-import { format, parseISO } from 'date-fns';
+import { format, parseISO, isValid } from 'date-fns';
 import { fn } from '@ember/helper';
 import { BoxelInput } from '@cardstack/boxel-ui/components';
 import { not } from '@cardstack/boxel-ui/helpers';
 import CalendarClockIcon from '@cardstack/boxel-icons/calendar-clock';
-import { fieldSerializer, DatetimeSerializer } from '@cardstack/runtime-common';
+import {
+  fieldSerializer,
+  DatetimeSerializer,
+  isValidDate,
+} from '@cardstack/runtime-common';
 
 // The Intl API is supported in all modern browsers. In older ones, we polyfill
 // it in the application route at app startup.
@@ -27,7 +31,10 @@ class View extends Component<typeof DatetimeField> {
     if (this.args.model == null) {
       return '[no date-time]';
     }
-    return this.args.model ? Format.format(this.args.model) : undefined;
+    if (!isValidDate(this.args.model)) {
+      return '[invalid date-time]';
+    }
+    return Format.format(this.args.model);
   }
 }
 
@@ -56,11 +63,18 @@ export default class DatetimeField extends FieldDef {
       if (!date?.length) {
         return set(null);
       }
-      return set(parseISO(date));
+      let parsed = parseISO(date);
+      if (!isValid(parsed)) {
+        return;
+      }
+      return set(parsed);
     }
 
     get formatted() {
       if (!this.args.model) {
+        return;
+      }
+      if (!isValidDate(this.args.model)) {
         return;
       }
       return format(this.args.model, datetimeFormat);

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -60,6 +60,7 @@ import {
   containsMany,
   DateField,
   DatetimeField,
+  DateRangeField,
   EthereumAddressField,
   field,
   FieldDef,
@@ -3567,6 +3568,21 @@ module('Integration | card-basics', function (hooks) {
       await fillIn('[data-test-datetime-field-editor]', '');
       assert.dom('[data-test-datetime-field-editor]').hasNoValue();
       assert.dom('[data-test-datetime-output]').hasText('[no date-time]');
+
+      class DatesCard extends CardDef {
+        @field date = contains(DateField);
+        @field datetime = contains(DatetimeField);
+      }
+
+      let personWithBrokenDates = new DatesCard({
+        date: 'invalid date',
+        appointment: 'invalid datetime',
+      });
+
+      await renderCard(loader, personWithBrokenDates, 'edit');
+      assert
+        .dom('[data-test-boxel-card-container]')
+        .exists('card rendered without runtime crash');
     });
 
     test('add, remove and edit items in containsMany date and datetime fields', async function (assert) {

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -60,7 +60,6 @@ import {
   containsMany,
   DateField,
   DatetimeField,
-  DateRangeField,
   EthereumAddressField,
   field,
   FieldDef,

--- a/packages/runtime-common/utils.ts
+++ b/packages/runtime-common/utils.ts
@@ -43,3 +43,7 @@ export function jobIdentity(jobInfo?: JobInfo): string {
   }
   return `[job: ${jobInfo.jobId}.${jobInfo.reservationId}]`;
 }
+
+export function isValidDate(value: unknown): value is Date {
+  return value instanceof Date && !Number.isNaN(value.getTime());
+}


### PR DESCRIPTION
Passing an invalid string value into our date related cards via code mode will cause an app exception and make the app unresponsive. This PR makes the date parsing part more robust, preventing bad values from crashing the app. I'm not sure if this requires a test since I didn't find any other dedicated tests for our base fields/cards. 

<img width="2917" height="1647" alt="image" src="https://github.com/user-attachments/assets/9b9da758-8b91-4fdf-a4a9-842c7b1ca5e4" />
