### PR TITLE
ci: Fix workflow reference to trigger host tests

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -13,7 +13,7 @@ on:
       - "packages/eslint-plugin-boxel/**"
       - "packages/realm-server/**"
       - "packages/runtime-common/**"
-      - ".github/workflows/ci-host.yml"
+      - ".github/workflows/ci-host.yaml"
       - "package.json"
       - "pnpm-lock.yaml"
   workflow_dispatch:


### PR DESCRIPTION
I noticed this when host tests didn’t run as I expected in #3491. Maybe we should standardise on a suffix for Actions files