### PR TITLE
Make it easier to flip headless chrome feature flag

### DIFF
--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -23,7 +23,7 @@ if (process.env.NODE_ENV === 'test') {
   (globalThis as any).__environment = 'test';
 }
 
-if (process.env.USE_HEADLESS_CHROME_INDEXING) {
+if (process.env.USE_HEADLESS_CHROME_INDEXING === 'true') {
   // in node context this is a boolean
   (globalThis as any).__useHeadlessChromePrerender = true;
 }

--- a/packages/realm-server/worker.ts
+++ b/packages/realm-server/worker.ts
@@ -96,7 +96,7 @@ let {
 
 log.info(`starting worker with pid ${process.pid} and priority ${priority}`);
 let prerenderer: Prerenderer;
-if (process.env.USE_HEADLESS_CHROME_INDEXING && prerendererUrl) {
+if (process.env.USE_HEADLESS_CHROME_INDEXING === 'true' && prerendererUrl) {
   // in node context this is a boolean
   (globalThis as any).__useHeadlessChromePrerender = true;
   log.info(`Using prerender server ${prerendererUrl}`);


### PR DESCRIPTION
This will make it easier to flip the feature flag by just changing a value in the parameter store instead of having to redeploy from git hub CI