### PR TITLE
Close workspace chooser when going to code mode

### DIFF
--- a/packages/host/app/components/ai-assistant/attached-file-dropdown-menu.gts
+++ b/packages/host/app/components/ai-assistant/attached-file-dropdown-menu.gts
@@ -50,6 +50,9 @@ export default class AttachedFileDropdownMenu extends Component<{
   @tracked isRestorePatchedFileModalOpen = false;
   @tracked fileContent: string | null = null;
   @action private openInCodeMode() {
+    if (this.operatorModeStateService.workspaceChooserOpened) {
+      this.operatorModeStateService.closeWorkspaceChooser();
+    }
     if (
       this.operatorModeStateService.state.submode === Submodes.Code &&
       this.operatorModeStateService.state.codePath?.toString() ===

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -952,6 +952,9 @@ module('Acceptance | AI Assistant tests', function (hooks) {
 
     mockedFileContent = 'test card content';
 
+    // This is to make sure opening code mode works even if the workspace chooser is open
+    await click('[data-test-workspace-chooser-toggle]');
+
     await click('[data-test-attached-file-dropdown-button="Fadhlan"]');
 
     assert.dom('[data-test-boxel-menu-item-text="Open in Code Mode"]').exists();


### PR DESCRIPTION
Previously, clicking on "Open in Code Mode" did nothing. This was because the workspace chooser was open - we need to close it in case it's open.

<img width="975" height="685" alt="image" src="https://github.com/user-attachments/assets/f9b4f034-27ac-44b4-a915-f3f9ef8a0f79" />
