### PR TITLE
increasing worker timeout

### DIFF
--- a/packages/postgres/pg-queue.ts
+++ b/packages/postgres/pg-queue.ts
@@ -19,7 +19,7 @@ import { PgAdapter } from './pg-adapter';
 import * as Sentry from '@sentry/node';
 
 const log = logger('queue');
-const MAX_JOB_TIMEOUT_SEC = 10 * 60;
+const MAX_JOB_TIMEOUT_SEC = 15 * 60;
 
 interface JobsTable {
   id: number;

--- a/packages/runtime-common/realm-index-updater.ts
+++ b/packages/runtime-common/realm-index-updater.ts
@@ -19,8 +19,8 @@ import { Realm } from './realm';
 import { RealmPaths } from './paths';
 import ignore, { type Ignore } from 'ignore';
 
-const FROM_SCRATCH_JOB_TIMEOUT_SEC = 10 * 60;
-const INCREMENTAL_JOB_TIMEOUT_SEC = 3 * 60;
+const FROM_SCRATCH_JOB_TIMEOUT_SEC = 15 * 60;
+const INCREMENTAL_JOB_TIMEOUT_SEC = 5 * 60;
 
 export class RealmIndexUpdater {
   #realm: Realm;


### PR DESCRIPTION
Increasing the timeout for indexing jobs. new indexer can be much slower for realms that have lots of unrecoverable errors when indexing from scratch