### PR TITLE
don't timeout 2nd attempt jobs before the locked_until time

### DIFF
--- a/packages/realm-server/worker-manager.ts
+++ b/packages/realm-server/worker-manager.ts
@@ -266,9 +266,16 @@ let adapter: PgAdapter;
 
 async function monitorWorker(workerId: string, worker: ChildProcess) {
   let stuckJobs = (await query([
-    `SELECT id, job_id FROM job_reservations WHERE worker_id=`,
+    `SELECT id, job_id FROM job_reservations jr WHERE worker_id=`,
     param(workerId),
     `AND completed_at IS NULL AND locked_until < NOW() - INTERVAL '30 seconds'`,
+    `AND NOT EXISTS (`,
+    // Skip stale reservations if this worker has already retried the job with a newer reservation.
+    `  SELECT 1 FROM job_reservations newer WHERE`,
+    `    newer.worker_id = jr.worker_id AND`,
+    `    newer.job_id = jr.job_id AND`,
+    `    newer.id > jr.id`,
+    `)`,
   ])) as { id: string; job_id: string }[];
 
   if (stuckJobs.length > 0) {


### PR DESCRIPTION
the worker manager fail safe, where it checks to make sure that jobs that appear to be stuck (running past their locked_until time) are killed doesn't take into account > 1 job attempts correct and is killing those immediately. this fixes that.