### PR TITLE
Apply consistent-type-imports rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,13 @@ module.exports = {
     'plugin:prettier/recommended',
   ],
   rules: {
+    '@typescript-eslint/consistent-type-imports': [
+      'error',
+      {
+        disallowTypeAnnotations: false,
+      },
+    ],
+    '@typescript-eslint/no-import-type-side-effects': 'error',
     // this doesn't work well with the monorepo. Typescript already complains if you try to import something that's not found
     'import/no-unresolved': 'off',
     'prefer-const': 'off',

--- a/packages/ai-bot/.eslintrc.js
+++ b/packages/ai-bot/.eslintrc.js
@@ -20,6 +20,13 @@ module.exports = {
     'plugin:prettier/recommended',
   ],
   rules: {
+    '@typescript-eslint/consistent-type-imports': [
+      'error',
+      {
+        disallowTypeAnnotations: false,
+      },
+    ],
+    '@typescript-eslint/no-import-type-side-effects': 'error',
     // this doesn't work well with the monorepo. Typescript already complains if you try to import something that's not found
     'import/no-unresolved': 'off',
     'prefer-const': 'off',

--- a/packages/ai-bot/lib/debug.ts
+++ b/packages/ai-bot/lib/debug.ts
@@ -1,5 +1,5 @@
 import { setTitle } from './set-title';
-import OpenAI from 'openai';
+import type OpenAI from 'openai';
 
 import * as Sentry from '@sentry/node';
 import type { MatrixEvent as DiscreteMatrixEvent } from 'https://cardstack.com/base/matrix-event';
@@ -12,7 +12,7 @@ import {
   sendEventListAsDebugMessage,
   sendDebugMessage,
 } from '@cardstack/runtime-common/ai';
-import { MatrixClient } from 'matrix-js-sdk';
+import type { MatrixClient } from 'matrix-js-sdk';
 
 export async function handleDebugCommands(
   openai: OpenAI,

--- a/packages/ai-bot/lib/matrix/response-publisher.ts
+++ b/packages/ai-bot/lib/matrix/response-publisher.ts
@@ -1,7 +1,7 @@
-import { ChatCompletionMessageFunctionToolCall } from 'openai/resources/chat/completions';
-import { CommandRequest } from '@cardstack/runtime-common/commands';
+import type { ChatCompletionMessageFunctionToolCall } from 'openai/resources/chat/completions';
+import type { CommandRequest } from '@cardstack/runtime-common/commands';
 import { thinkingMessage } from '../../constants';
-import ResponseState from '../response-state';
+import type ResponseState from '../response-state';
 import {
   APP_BOXEL_CONTINUATION_OF_CONTENT_KEY,
   APP_BOXEL_HAS_CONTINUATION_CONTENT_KEY,
@@ -10,7 +10,7 @@ import { sendErrorEvent, sendMessageEvent } from '@cardstack/runtime-common/ai';
 import type { CardMessageContent } from 'https://cardstack.com/base/matrix-event';
 import ResponseEventData from './response-event-data';
 import { logger } from '@cardstack/runtime-common';
-import { MatrixClient } from 'matrix-js-sdk';
+import type { MatrixClient } from 'matrix-js-sdk';
 
 let log = logger('ai-bot');
 

--- a/packages/ai-bot/lib/queries.ts
+++ b/packages/ai-bot/lib/queries.ts
@@ -1,11 +1,11 @@
-import { PgAdapter } from '@cardstack/postgres';
+import type { PgAdapter } from '@cardstack/postgres';
+import type { Expression } from '@cardstack/runtime-common';
 import {
   query,
   param,
   addExplicitParens,
   separatedByCommas,
   asExpressions,
-  Expression,
 } from '@cardstack/runtime-common';
 
 export async function acquireLock(

--- a/packages/ai-bot/lib/responder.ts
+++ b/packages/ai-bot/lib/responder.ts
@@ -2,17 +2,17 @@ import { logger } from '@cardstack/runtime-common';
 import { isCommandOrCodePatchResult } from '@cardstack/runtime-common/ai';
 
 import * as Sentry from '@sentry/node';
-import { OpenAIError } from 'openai/error';
+import type { OpenAIError } from 'openai/error';
 import throttle from 'lodash/throttle';
-import { ISendEventResponse } from 'matrix-js-sdk/lib/matrix';
+import type { ISendEventResponse } from 'matrix-js-sdk/lib/matrix';
 import type { ChatCompletionMessageFunctionToolCall } from 'openai/resources/chat/completions';
-import { FunctionToolCall } from '@cardstack/runtime-common/helpers/ai';
+import type { FunctionToolCall } from '@cardstack/runtime-common/helpers/ai';
 import type OpenAI from 'openai';
 import type { ChatCompletionSnapshot } from 'openai/lib/ChatCompletionStream';
-import { MatrixEvent as DiscreteMatrixEvent } from 'matrix-js-sdk';
+import type { MatrixEvent as DiscreteMatrixEvent } from 'matrix-js-sdk';
 import MatrixResponsePublisher from './matrix/response-publisher';
 import ResponseState from './response-state';
-import { MatrixClient } from 'matrix-js-sdk';
+import type { MatrixClient } from 'matrix-js-sdk';
 
 let log = logger('ai-bot');
 

--- a/packages/ai-bot/lib/set-title.ts
+++ b/packages/ai-bot/lib/set-title.ts
@@ -1,10 +1,6 @@
-import {
-  type MatrixEvent,
-  type IEventRelation,
-  IRoomEvent,
-} from 'matrix-js-sdk';
-import OpenAI from 'openai';
-import type { MatrixClient } from 'matrix-js-sdk';
+import type { MatrixEvent, IEventRelation } from 'matrix-js-sdk';
+import type OpenAI from 'openai';
+import type { MatrixClient, IRoomEvent } from 'matrix-js-sdk';
 import type {
   MatrixEvent as DiscreteMatrixEvent,
   CommandResultWithOutputContent,
@@ -13,7 +9,7 @@ import type {
   CodePatchResultContent,
   CardMessageContent,
 } from 'https://cardstack.com/base/matrix-event';
-import { ChatCompletionMessageParam } from 'openai/resources';
+import type { ChatCompletionMessageParam } from 'openai/resources';
 import {
   type OpenAIPromptMessage,
   isCodePatchResultStatusApplied,

--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -1,11 +1,7 @@
 import './instrument';
 import './setup-logger'; // This should be first
-import {
-  RoomMemberEvent,
-  RoomEvent,
-  createClient,
-  MatrixEvent,
-} from 'matrix-js-sdk';
+import type { MatrixEvent } from 'matrix-js-sdk';
+import { RoomMemberEvent, RoomEvent, createClient } from 'matrix-js-sdk';
 import { SlidingSync, type MSC3575List } from 'matrix-js-sdk/lib/sliding-sync';
 import OpenAI from 'openai';
 import {
@@ -16,8 +12,8 @@ import {
   uuidv4,
   MINIMUM_AI_CREDITS_TO_CONTINUE,
 } from '@cardstack/runtime-common';
+import type { PromptParts } from '@cardstack/runtime-common/ai';
 import {
-  PromptParts,
   isRecognisedDebugCommand,
   getPromptParts,
   isInDebugMode,
@@ -45,14 +41,14 @@ import * as Sentry from '@sentry/node';
 
 import { saveUsageCost } from '@cardstack/billing/ai-billing';
 import { PgAdapter } from '@cardstack/postgres';
-import { ChatCompletionMessageParam } from 'openai/resources';
-import { OpenAIError } from 'openai/error';
-import { ChatCompletionStream } from 'openai/lib/ChatCompletionStream';
+import type { ChatCompletionMessageParam } from 'openai/resources';
+import type { OpenAIError } from 'openai/error';
+import type { ChatCompletionStream } from 'openai/lib/ChatCompletionStream';
 import { acquireLock, releaseLock } from './lib/queries';
 import { DebugLogger } from 'matrix-js-sdk/lib/logger';
 import { setupSignalHandlers } from './lib/signal-handlers';
 import { isShuttingDown, setActiveGenerations } from './lib/shutdown';
-import { type MatrixClient } from 'matrix-js-sdk';
+import type { MatrixClient } from 'matrix-js-sdk';
 import { debug } from 'debug';
 import { profEnabled, profTime, profNote } from './lib/profiler';
 

--- a/packages/ai-bot/tests/chat-titling-test.ts
+++ b/packages/ai-bot/tests/chat-titling-test.ts
@@ -16,14 +16,8 @@ import {
   APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
   APP_BOXEL_MESSAGE_MSGTYPE,
 } from '@cardstack/runtime-common/matrix-constants';
-import {
-  EventStatus,
-  IEvent,
-  IRoomEvent,
-  IStateEvent,
-  type MatrixClient,
-  MatrixEvent,
-} from 'matrix-js-sdk';
+import type { IEvent, IRoomEvent, IStateEvent } from 'matrix-js-sdk';
+import { EventStatus, type MatrixClient, MatrixEvent } from 'matrix-js-sdk';
 import { FakeMatrixClient } from './helpers/fake-matrix-client';
 import type OpenAI from 'openai';
 import {

--- a/packages/ai-bot/tests/helpers/fake-matrix-client.ts
+++ b/packages/ai-bot/tests/helpers/fake-matrix-client.ts
@@ -4,8 +4,9 @@ import type {
   IRequestOpts,
   MatrixHttpApi,
   StateEvents,
+  Method,
 } from 'matrix-js-sdk';
-import { Method, MatrixClient } from 'matrix-js-sdk';
+import { MatrixClient } from 'matrix-js-sdk';
 
 export class FakeMatrixClient extends MatrixClient {
   private eventId = 0;

--- a/packages/ai-bot/tests/matrix-util-test.ts
+++ b/packages/ai-bot/tests/matrix-util-test.ts
@@ -1,6 +1,6 @@
 import { test } from 'qunit';
 import { FakeMatrixClient } from './helpers/fake-matrix-client';
-import { Method } from 'matrix-js-sdk';
+import type { Method } from 'matrix-js-sdk';
 import type {
   CardMessageEvent,
   MatrixEvent as DiscreteMatrixEvent,

--- a/packages/ai-bot/tests/responding-test.ts
+++ b/packages/ai-bot/tests/responding-test.ts
@@ -4,7 +4,7 @@ import { DEFAULT_EVENT_SIZE_MAX } from '../lib/matrix/response-publisher';
 import FakeTimers from '@sinonjs/fake-timers';
 import { thinkingMessage } from '../constants';
 import type { ChatCompletionSnapshot } from 'openai/lib/ChatCompletionStream';
-import { CommandRequest } from '@cardstack/runtime-common/commands';
+import type { CommandRequest } from '@cardstack/runtime-common/commands';
 import {
   APP_BOXEL_REASONING_CONTENT_KEY,
   APP_BOXEL_COMMAND_REQUESTS_KEY,

--- a/packages/billing/.eslintrc.js
+++ b/packages/billing/.eslintrc.js
@@ -14,6 +14,13 @@ module.exports = {
       extends: ['plugin:n/recommended'],
       rules: {
         '@typescript-eslint/no-var-requires': 'off',
+        '@typescript-eslint/consistent-type-imports': [
+          'error',
+          {
+            disallowTypeAnnotations: false,
+          },
+        ],
+        '@typescript-eslint/no-import-type-side-effects': 'error',
       },
     },
     {

--- a/packages/billing/billing-queries.ts
+++ b/packages/billing/billing-queries.ts
@@ -1,7 +1,9 @@
-import {
+import type {
   DBAdapter,
   Expression,
   PgPrimitive,
+} from '@cardstack/runtime-common';
+import {
   addExplicitParens,
   asExpressions,
   every,
@@ -11,13 +13,13 @@ import {
   separatedByCommas,
   update,
 } from '@cardstack/runtime-common';
-import { StripeEvent } from './stripe-webhook-handlers';
-import {
-  type Plan,
-  type Subscription,
-  type SubscriptionCycle,
-  type LedgerEntry,
-  type User,
+import type { StripeEvent } from './stripe-webhook-handlers';
+import type {
+  Plan,
+  Subscription,
+  SubscriptionCycle,
+  LedgerEntry,
+  User,
 } from '@cardstack/runtime-common';
 
 function planRowToPlan(row: Record<string, PgPrimitive>): Plan {

--- a/packages/billing/proration-calculator.ts
+++ b/packages/billing/proration-calculator.ts
@@ -1,4 +1,4 @@
-import { type Plan } from '@cardstack/runtime-common';
+import type { Plan } from '@cardstack/runtime-common';
 
 export class ProrationCalculator {
   static centsToCredits(cents: number, plan: Plan): number {

--- a/packages/billing/stripe-webhook-handlers/checkout-session-completed.ts
+++ b/packages/billing/stripe-webhook-handlers/checkout-session-completed.ts
@@ -1,4 +1,4 @@
-import { type DBAdapter } from '@cardstack/runtime-common';
+import type { DBAdapter } from '@cardstack/runtime-common';
 import {
   addToCreditsLedger,
   getCurrentActiveSubscription,
@@ -8,9 +8,10 @@ import {
   markStripeEventAsProcessed,
   updateUserStripeCustomerEmail,
 } from '../billing-queries';
-import { StripeCheckoutSessionCompletedWebhookEvent } from '.';
+import type { StripeCheckoutSessionCompletedWebhookEvent } from '.';
 
-import { PgAdapter, TransactionManager } from '@cardstack/postgres';
+import type { PgAdapter } from '@cardstack/postgres';
+import { TransactionManager } from '@cardstack/postgres';
 
 export async function handleCheckoutSessionCompleted(
   dbAdapter: DBAdapter,

--- a/packages/billing/stripe-webhook-handlers/index.ts
+++ b/packages/billing/stripe-webhook-handlers/index.ts
@@ -1,4 +1,4 @@
-import { DBAdapter } from '@cardstack/runtime-common';
+import type { DBAdapter } from '@cardstack/runtime-common';
 import { handlePaymentSucceeded } from './payment-succeeded';
 import { handleCheckoutSessionCompleted } from './checkout-session-completed';
 

--- a/packages/billing/stripe-webhook-handlers/payment-succeeded.ts
+++ b/packages/billing/stripe-webhook-handlers/payment-succeeded.ts
@@ -1,10 +1,10 @@
+import type { User } from '@cardstack/runtime-common';
 import {
   type DBAdapter,
   type Plan,
   type Subscription,
   type SubscriptionCycle,
   retry,
-  User,
 } from '@cardstack/runtime-common';
 import {
   addToCreditsLedger,
@@ -21,8 +21,9 @@ import {
   sumUpCreditsLedger,
   updateSubscription as updateSubscriptionQuery,
 } from '../billing-queries';
-import { StripeInvoicePaymentSucceededWebhookEvent } from '.';
-import { PgAdapter, TransactionManager } from '@cardstack/postgres';
+import type { StripeInvoicePaymentSucceededWebhookEvent } from '.';
+import type { PgAdapter } from '@cardstack/postgres';
+import { TransactionManager } from '@cardstack/postgres';
 import { ProrationCalculator } from '../proration-calculator';
 
 export async function handlePaymentSucceeded(

--- a/packages/billing/stripe-webhook-handlers/subscription-deleted.ts
+++ b/packages/billing/stripe-webhook-handlers/subscription-deleted.ts
@@ -1,5 +1,6 @@
-import { DBAdapter, reportError } from '@cardstack/runtime-common';
-import { StripeSubscriptionDeletedWebhookEvent } from '.';
+import type { DBAdapter } from '@cardstack/runtime-common';
+import { reportError } from '@cardstack/runtime-common';
+import type { StripeSubscriptionDeletedWebhookEvent } from '.';
 import {
   insertStripeEvent,
   updateSubscription,
@@ -11,7 +12,8 @@ import {
   getPlanByMonthlyPrice,
 } from '../billing-queries';
 
-import { PgAdapter, TransactionManager } from '@cardstack/postgres';
+import type { PgAdapter } from '@cardstack/postgres';
+import { TransactionManager } from '@cardstack/postgres';
 import { getStripe } from './stripe';
 
 export async function handleSubscriptionDeleted(

--- a/packages/boxel-motion/test-app/.eslintrc.js
+++ b/packages/boxel-motion/test-app/.eslintrc.js
@@ -26,6 +26,13 @@ module.exports = {
     browser: true,
   },
   rules: {
+    '@typescript-eslint/consistent-type-imports': [
+      'error',
+      {
+        disallowTypeAnnotations: false,
+      },
+    ],
+    '@typescript-eslint/no-import-type-side-effects': 'error',
     // this doesn't work well with the monorepo. Typescript already complains if you try to import something that's not found
     'import/no-unresolved': 'off',
     'import/order': [

--- a/packages/boxel-motion/test-app/app/components/accordion/panel/index.ts
+++ b/packages/boxel-motion/test-app/app/components/accordion/panel/index.ts
@@ -1,6 +1,6 @@
 import {
+  type Sprite,
   type Changeset,
-  Sprite,
   SpriteType,
   SpringBehavior,
   TweenBehavior,

--- a/packages/boxel-motion/test-app/app/components/motion-card/component.ts
+++ b/packages/boxel-motion/test-app/app/components/motion-card/component.ts
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import RouterService from '@ember/routing/router-service';
+import type RouterService from '@ember/routing/router-service';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 

--- a/packages/boxel-motion/test-app/app/controllers/list.ts
+++ b/packages/boxel-motion/test-app/app/controllers/list.ts
@@ -1,9 +1,9 @@
-import {
-  type AnimationTimeline,
-  type AnimationDefinition,
+import type {
+  AnimationTimeline,
+  AnimationDefinition,
 } from '@cardstack/boxel-motion';
 import { SpringBehavior } from '@cardstack/boxel-motion';
-import { Changeset } from '@cardstack/boxel-motion/models/animator';
+import type { Changeset } from '@cardstack/boxel-motion/models/animator';
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';

--- a/packages/boxel-motion/test-app/app/controllers/motion-study.ts
+++ b/packages/boxel-motion/test-app/app/controllers/motion-study.ts
@@ -1,6 +1,6 @@
 import {
+  type Changeset,
   type AnimationDefinition,
-  Changeset,
   SpriteType,
   StaticBehavior,
   TweenBehavior,

--- a/packages/boxel-motion/test-app/app/controllers/nested-contexts.ts
+++ b/packages/boxel-motion/test-app/app/controllers/nested-contexts.ts
@@ -1,4 +1,4 @@
-import { Changeset } from '@cardstack/boxel-motion/models/animator';
+import type { Changeset } from '@cardstack/boxel-motion/models/animator';
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 

--- a/packages/boxel-motion/test-app/app/controllers/routes.ts
+++ b/packages/boxel-motion/test-app/app/controllers/routes.ts
@@ -1,7 +1,7 @@
 import {
+  type Sprite,
   type AnimationDefinition,
   type Changeset,
-  Sprite,
   SpriteType,
   TweenBehavior,
 } from '@cardstack/boxel-motion';

--- a/packages/boxel-motion/test-app/app/controllers/split-view.ts
+++ b/packages/boxel-motion/test-app/app/controllers/split-view.ts
@@ -1,8 +1,8 @@
 import {
+  type AnimationDefinition,
   type Changeset,
   StaticBehavior,
   SpringBehavior,
-  AnimationDefinition,
 } from '@cardstack/boxel-motion';
 import Controller from '@ember/controller';
 import { action } from '@ember/object';

--- a/packages/boxel-motion/test-app/tests/unit/models/animation-participant-manager-test.ts
+++ b/packages/boxel-motion/test-app/tests/unit/models/animation-participant-manager-test.ts
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { type ISpriteModifier, SpriteType } from '@cardstack/boxel-motion';
-import {
+import type {
   AnimationParticipant,
-  AnimationParticipantManager,
   Sprite,
 } from '@cardstack/boxel-motion/models';
-import { type IContext } from '@cardstack/boxel-motion/utils';
+import { AnimationParticipantManager } from '@cardstack/boxel-motion/models';
+import type { IContext } from '@cardstack/boxel-motion/utils';
 import { module, test } from 'qunit';
 
 function simulateRender(

--- a/packages/boxel-motion/test-app/tests/unit/models/orchestration-test.ts
+++ b/packages/boxel-motion/test-app/tests/unit/models/orchestration-test.ts
@@ -8,7 +8,7 @@ import {
   WaitBehavior,
 } from '@cardstack/boxel-motion';
 import { FPS } from '@cardstack/boxel-motion';
-import { type Keyframe } from '@cardstack/boxel-motion/models';
+import type { Keyframe } from '@cardstack/boxel-motion/models';
 import {
   constructKeyframe,
   type Snapshot,

--- a/packages/boxel-motion/test-app/types/ember-truth-helpers/helpers/and.d.ts
+++ b/packages/boxel-motion/test-app/types/ember-truth-helpers/helpers/and.d.ts
@@ -1,6 +1,6 @@
 import Helper from '@ember/component/helper';
 
-import { Falsy, UnsetValue } from './-private/shared';
+import type { Falsy, UnsetValue } from './-private/shared';
 
 // NOTE: These types are somewhat imperfect.
 // For instance, the limit at 5 is arbitrary. Also, the actual helpers

--- a/packages/boxel-motion/test-app/types/ember-truth-helpers/helpers/or.d.ts
+++ b/packages/boxel-motion/test-app/types/ember-truth-helpers/helpers/or.d.ts
@@ -1,6 +1,6 @@
 import Helper from '@ember/component/helper';
 
-import { Falsy, Maybe, UnsetValue } from './-private/shared';
+import type { Falsy, Maybe, UnsetValue } from './-private/shared';
 
 // NOTE: These types are somewhat imperfect.
 // For instance, the limit at 5 is arbitrary. Also, the actual helpers

--- a/packages/boxel-motion/test-app/types/global.d.ts
+++ b/packages/boxel-motion/test-app/types/global.d.ts
@@ -2,11 +2,11 @@ import '@glint/environment-ember-loose';
 import '@cardstack/boxel-motion/glint';
 import type BoxelMotionRegistry from '@cardstack/boxel-motion/template-registry';
 
-import { HelperLike } from '@glint/template';
-import AndHelper from 'ember-truth-helpers/helpers/and';
-import EqHelper from 'ember-truth-helpers/helpers/eq';
-import NotHelper from 'ember-truth-helpers/helpers/not';
-import OrHelper from 'ember-truth-helpers/helpers/or';
+import type { HelperLike } from '@glint/template';
+import type AndHelper from 'ember-truth-helpers/helpers/and';
+import type EqHelper from 'ember-truth-helpers/helpers/eq';
+import type NotHelper from 'ember-truth-helpers/helpers/not';
+import type OrHelper from 'ember-truth-helpers/helpers/or';
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry extends BoxelMotionRegistry {

--- a/packages/boxel-ui/test-app/.eslintrc.js
+++ b/packages/boxel-ui/test-app/.eslintrc.js
@@ -26,6 +26,13 @@ module.exports = {
     browser: true,
   },
   rules: {
+    '@typescript-eslint/consistent-type-imports': [
+      'error',
+      {
+        disallowTypeAnnotations: false,
+      },
+    ],
+    '@typescript-eslint/no-import-type-side-effects': 'error',
     'prefer-const': 'off',
     '@typescript-eslint/no-empty-function': 'off',
     '@typescript-eslint/no-explicit-any': 'off',

--- a/packages/boxel-ui/test-app/app/templates/index.gts
+++ b/packages/boxel-ui/test-app/app/templates/index.gts
@@ -1,7 +1,7 @@
 import { action } from '@ember/object';
 import type Owner from '@ember/owner';
 import Component from '@glimmer/component';
-import { ComponentLike } from '@glint/template';
+import type { ComponentLike } from '@glint/template';
 import { tracked } from '@glimmer/tracking';
 import type RouterService from '@ember/routing/router-service';
 import { service } from '@ember/service';

--- a/packages/boxel-ui/test-app/tests/helpers/index.ts
+++ b/packages/boxel-ui/test-app/tests/helpers/index.ts
@@ -1,3 +1,7 @@
+import type {
+  // prettier-ignore
+  SetupTestOptions,
+} from 'ember-qunit';
 import {
   // prettier-ignore
   setupApplicationTest as upstreamSetupApplicationTest,
@@ -5,8 +9,6 @@ import {
   setupRenderingTest as upstreamSetupRenderingTest,
   // prettier-ignore
   setupTest as upstreamSetupTest,
-  // prettier-ignore
-  SetupTestOptions,
 } from 'ember-qunit';
 
 // This file exists to provide wrappers around ember-qunit's

--- a/packages/boxel-ui/test-app/tests/integration/components/resizable-panel-group-test.gts
+++ b/packages/boxel-ui/test-app/tests/integration/components/resizable-panel-group-test.gts
@@ -1,11 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import {
-  find,
-  doubleClick,
-  render,
-  RenderingTestContext,
-} from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
+import { find, doubleClick, render } from '@ember/test-helpers';
 import { htmlSafe } from '@ember/template';
 import { ResizablePanelGroup } from '@cardstack/boxel-ui/components';
 import { not } from '@cardstack/boxel-ui/helpers';

--- a/packages/host/.eslintrc.js
+++ b/packages/host/.eslintrc.js
@@ -33,6 +33,13 @@ module.exports = {
         'plugin:qunit-dom/recommended',
       ],
       rules: {
+        '@typescript-eslint/consistent-type-imports': [
+          'error',
+          {
+            disallowTypeAnnotations: false,
+          },
+        ],
+        '@typescript-eslint/no-import-type-side-effects': 'error',
         '@typescript-eslint/no-empty-function': 'off',
         '@typescript-eslint/no-unused-vars': [
           'error',

--- a/packages/host/app/commands/ai-assistant.ts
+++ b/packages/host/app/commands/ai-assistant.ts
@@ -9,8 +9,6 @@ import type { Skill } from 'https://cardstack.com/base/skill';
 
 import HostBaseCommand from '../lib/host-base-command';
 
-import OperatorModeStateService from '../services/operator-mode-state-service';
-
 import AddSkillsToRoomCommand from './add-skills-to-room';
 import CreateAiAssistantRoomCommand from './create-ai-assistant-room';
 import OpenAiAssistantRoomCommand from './open-ai-assistant-room';
@@ -19,6 +17,7 @@ import SendAiAssistantMessageCommand from './send-ai-assistant-message';
 import SetActiveLLMCommand from './set-active-llm';
 
 import type MatrixService from '../services/matrix-service';
+import type OperatorModeStateService from '../services/operator-mode-state-service';
 import type StoreService from '../services/store';
 
 export default class UseAiAssistantCommand extends HostBaseCommand<

--- a/packages/host/app/commands/create-specs.ts
+++ b/packages/host/app/commands/create-specs.ts
@@ -16,7 +16,8 @@ import {
 
 import type { BaseDef } from 'https://cardstack.com/base/card-api';
 import type * as BaseCommandModule from 'https://cardstack.com/base/command';
-import { Spec, type SpecType } from 'https://cardstack.com/base/spec';
+import type { Spec } from 'https://cardstack.com/base/spec';
+import type { SpecType } from 'https://cardstack.com/base/spec';
 
 import HostBaseCommand from '../lib/host-base-command';
 import {

--- a/packages/host/app/commands/get-card.ts
+++ b/packages/host/app/commands/get-card.ts
@@ -1,6 +1,6 @@
 import { service } from '@ember/service';
 
-import { type CardDef } from 'https://cardstack.com/base/card-api';
+import type { CardDef } from 'https://cardstack.com/base/card-api';
 import type * as BaseCommandModule from 'https://cardstack.com/base/command';
 
 import HostBaseCommand from '../lib/host-base-command';

--- a/packages/host/app/commands/index.ts
+++ b/packages/host/app/commands/index.ts
@@ -1,6 +1,4 @@
-import { VirtualNetwork } from '@cardstack/runtime-common';
-
-import HostBaseCommand from '../lib/host-base-command';
+import type { VirtualNetwork } from '@cardstack/runtime-common';
 
 import * as AddFieldToCardDefinitionCommandModule from './add-field-to-card-definition';
 import * as AddSkillsToRoomCommandModule from './add-skills-to-room';
@@ -54,6 +52,8 @@ import * as UpdatePlaygroundSelectionCommandModule from './update-playground-sel
 import * as UpdateSkillActivationCommandModule from './update-skill-activation';
 import * as CommandUtilsModule from './utils';
 import * as WriteTextFileCommandModule from './write-text-file';
+
+import type HostBaseCommand from '../lib/host-base-command';
 
 export function shimHostCommands(virtualNetwork: VirtualNetwork) {
   virtualNetwork.shimModule(

--- a/packages/host/app/commands/listing-action-build.ts
+++ b/packages/host/app/commands/listing-action-build.ts
@@ -3,7 +3,7 @@ import { service } from '@ember/service';
 import { isCardInstance } from '@cardstack/runtime-common';
 import { DEFAULT_CODING_LLM } from '@cardstack/runtime-common/matrix-constants';
 
-import * as BaseCommandModule from 'https://cardstack.com/base/command';
+import type * as BaseCommandModule from 'https://cardstack.com/base/command';
 import type { Skill } from 'https://cardstack.com/base/skill';
 
 import HostBaseCommand from '../lib/host-base-command';

--- a/packages/host/app/commands/listing-action-init.ts
+++ b/packages/host/app/commands/listing-action-init.ts
@@ -3,7 +3,7 @@ import { service } from '@ember/service';
 import { isCardInstance } from '@cardstack/runtime-common';
 import { DEFAULT_REMIX_LLM } from '@cardstack/runtime-common/matrix-constants';
 
-import * as BaseCommandModule from 'https://cardstack.com/base/command';
+import type * as BaseCommandModule from 'https://cardstack.com/base/command';
 
 import type { Skill } from 'https://cardstack.com/base/skill';
 

--- a/packages/host/app/commands/listing-create.ts
+++ b/packages/host/app/commands/listing-create.ts
@@ -2,18 +2,17 @@ import { service } from '@ember/service';
 
 import { isScopedCSSRequest } from 'glimmer-scoped-css';
 
-import {
-  isCardInstance,
+import type {
   LooseSingleCardDocument,
   ResolvedCodeRef,
-  SupportedMimeType,
 } from '@cardstack/runtime-common';
+import { isCardInstance, SupportedMimeType } from '@cardstack/runtime-common';
 import { resolveAdoptedCodeRef } from '@cardstack/runtime-common/code-ref';
 
-import * as CardAPI from 'https://cardstack.com/base/card-api';
-import * as BaseCommandModule from 'https://cardstack.com/base/command';
+import type * as CardAPI from 'https://cardstack.com/base/card-api';
+import type * as BaseCommandModule from 'https://cardstack.com/base/command';
 
-import { Spec } from 'https://cardstack.com/base/spec';
+import type { Spec } from 'https://cardstack.com/base/spec';
 
 import HostBaseCommand from '../lib/host-base-command';
 

--- a/packages/host/app/commands/listing-install.ts
+++ b/packages/host/app/commands/listing-install.ts
@@ -1,28 +1,28 @@
 import { service } from '@ember/service';
 
+import type {
+  ListingPathResolver,
+  ModuleResource,
+  LooseCardResource,
+} from '@cardstack/runtime-common';
 import {
   type ResolvedCodeRef,
   RealmPaths,
   join,
-  ListingPathResolver,
   planModuleInstall,
   planInstanceInstall,
   PlanBuilder,
-  ModuleResource,
-  LooseCardResource,
   isSingleCardDocument,
 } from '@cardstack/runtime-common';
 import { logger } from '@cardstack/runtime-common';
-import {
-  type AtomicOperation,
-  type AtomicOperationResult,
+import type {
+  AtomicOperation,
+  AtomicOperationResult,
 } from '@cardstack/runtime-common/atomic-document';
-import {
-  CopyInstanceMeta,
-  type CopyModuleMeta,
-} from '@cardstack/runtime-common/catalog';
+import type { CopyInstanceMeta } from '@cardstack/runtime-common/catalog';
+import type { CopyModuleMeta } from '@cardstack/runtime-common/catalog';
 
-import * as BaseCommandModule from 'https://cardstack.com/base/command';
+import type * as BaseCommandModule from 'https://cardstack.com/base/command';
 
 import HostBaseCommand from '../lib/host-base-command';
 

--- a/packages/host/app/commands/listing-remix.ts
+++ b/packages/host/app/commands/listing-remix.ts
@@ -3,8 +3,8 @@ import { service } from '@ember/service';
 import { isResolvedCodeRef, RealmPaths } from '@cardstack/runtime-common';
 import { DEFAULT_CODING_LLM } from '@cardstack/runtime-common/matrix-constants';
 
-import * as CardAPI from 'https://cardstack.com/base/card-api';
-import * as BaseCommandModule from 'https://cardstack.com/base/command';
+import type * as CardAPI from 'https://cardstack.com/base/card-api';
+import type * as BaseCommandModule from 'https://cardstack.com/base/command';
 
 import HostBaseCommand from '../lib/host-base-command';
 

--- a/packages/host/app/commands/listing-use.ts
+++ b/packages/host/app/commands/listing-use.ts
@@ -8,8 +8,8 @@ import {
   RealmPaths,
 } from '@cardstack/runtime-common';
 
-import * as CardAPI from 'https://cardstack.com/base/card-api';
-import * as BaseCommandModule from 'https://cardstack.com/base/command';
+import type * as CardAPI from 'https://cardstack.com/base/card-api';
+import type * as BaseCommandModule from 'https://cardstack.com/base/command';
 
 import type { Skill } from 'https://cardstack.com/base/skill';
 

--- a/packages/host/app/commands/one-shot-llm-request.ts
+++ b/packages/host/app/commands/one-shot-llm-request.ts
@@ -6,7 +6,7 @@ import { isCardInstance, logger } from '@cardstack/runtime-common';
 const oneShotLogger = logger('llm:oneshot');
 
 import type * as BaseCommandModule from 'https://cardstack.com/base/command';
-import { Skill } from 'https://cardstack.com/base/skill';
+import type { Skill } from 'https://cardstack.com/base/skill';
 
 import HostBaseCommand from '../lib/host-base-command';
 

--- a/packages/host/app/commands/open-in-interact-mode.ts
+++ b/packages/host/app/commands/open-in-interact-mode.ts
@@ -1,6 +1,6 @@
 import { service } from '@ember/service';
 
-import { Format } from '@cardstack/runtime-common';
+import type { Format } from '@cardstack/runtime-common';
 
 import type * as BaseCommandModule from 'https://cardstack.com/base/command';
 

--- a/packages/host/app/commands/patch-card-instance.ts
+++ b/packages/host/app/commands/patch-card-instance.ts
@@ -1,6 +1,6 @@
 import { service } from '@ember/service';
 
-import { type CommandContext } from '@cardstack/runtime-common';
+import type { CommandContext } from '@cardstack/runtime-common';
 import {
   type AttributesSchema,
   type CardSchema,
@@ -14,7 +14,8 @@ import type * as CardAPI from 'https://cardstack.com/base/card-api';
 import type * as BaseCommandModule from 'https://cardstack.com/base/command';
 
 import HostBaseCommand from '../lib/host-base-command';
-import StoreService from '../services/store';
+
+import type StoreService from '../services/store';
 
 interface Configuration {
   cardType: typeof CardDef;

--- a/packages/host/app/commands/patch-fields.ts
+++ b/packages/host/app/commands/patch-fields.ts
@@ -1,6 +1,6 @@
 import { service } from '@ember/service';
 
-import { type CommandContext } from '@cardstack/runtime-common';
+import type { CommandContext } from '@cardstack/runtime-common';
 import {
   generateJsonSchemaForCardType,
   basicMappings,
@@ -9,11 +9,10 @@ import {
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 import type * as BaseCommandModule from 'https://cardstack.com/base/command';
 
-import {
-  FieldPathParser,
-  ValidateFieldPathResult,
-} from '../lib/field-path-parser';
+import { FieldPathParser } from '../lib/field-path-parser';
 import HostBaseCommand from '../lib/host-base-command';
+
+import type { ValidateFieldPathResult } from '../lib/field-path-parser';
 
 import type CardService from '../services/card-service';
 import type StoreService from '../services/store';

--- a/packages/host/app/commands/read-card-for-ai-assistant.ts
+++ b/packages/host/app/commands/read-card-for-ai-assistant.ts
@@ -2,7 +2,7 @@ import { service } from '@ember/service';
 
 import { isCardInstance } from '@cardstack/runtime-common';
 
-import { CardDef } from 'https://cardstack.com/base/card-api';
+import type { CardDef } from 'https://cardstack.com/base/card-api';
 import type * as BaseCommandModule from 'https://cardstack.com/base/command';
 import type { FileDef } from 'https://cardstack.com/base/file-api';
 

--- a/packages/host/app/commands/read-text-file.ts
+++ b/packages/host/app/commands/read-text-file.ts
@@ -3,7 +3,8 @@ import { service } from '@ember/service';
 import type * as BaseCommandModule from 'https://cardstack.com/base/command';
 
 import HostBaseCommand from '../lib/host-base-command';
-import NetworkService from '../services/network';
+
+import type NetworkService from '../services/network';
 
 export default class ReadTextFileCommand extends HostBaseCommand<
   typeof BaseCommandModule.ReadTextFileInput,

--- a/packages/host/app/commands/search-cards.ts
+++ b/packages/host/app/commands/search-cards.ts
@@ -2,7 +2,8 @@ import { service } from '@ember/service';
 
 import flatMap from 'lodash/flatMap';
 
-import { Filter, assertQuery } from '@cardstack/runtime-common';
+import type { Filter } from '@cardstack/runtime-common';
+import { assertQuery } from '@cardstack/runtime-common';
 
 import type * as BaseCommandModule from 'https://cardstack.com/base/command';
 

--- a/packages/host/app/commands/show-card.ts
+++ b/packages/host/app/commands/show-card.ts
@@ -1,10 +1,7 @@
 import { service } from '@ember/service';
 
-import {
-  ResolvedCodeRef,
-  identifyCard,
-  internalKeyFor,
-} from '@cardstack/runtime-common';
+import type { ResolvedCodeRef } from '@cardstack/runtime-common';
+import { identifyCard, internalKeyFor } from '@cardstack/runtime-common';
 
 import type { CardDef, Format } from 'https://cardstack.com/base/card-api';
 import type * as BaseCommandModule from 'https://cardstack.com/base/command';

--- a/packages/host/app/commands/write-text-file.ts
+++ b/packages/host/app/commands/write-text-file.ts
@@ -3,8 +3,9 @@ import { service } from '@ember/service';
 import type * as BaseCommandModule from 'https://cardstack.com/base/command';
 
 import HostBaseCommand from '../lib/host-base-command';
-import NetworkService from '../services/network';
-import RealmService from '../services/realm';
+
+import type NetworkService from '../services/network';
+import type RealmService from '../services/realm';
 
 export default class WriteTextFileCommand extends HostBaseCommand<
   typeof BaseCommandModule.WriteTextFileInput

--- a/packages/host/app/components/search-sheet/utils.ts
+++ b/packages/host/app/components/search-sheet/utils.ts
@@ -1,4 +1,4 @@
-import { ResolvedCodeRef } from '@cardstack/runtime-common';
+import type { ResolvedCodeRef } from '@cardstack/runtime-common';
 
 export function getCodeRefFromSearchKey(
   searchKey: string,

--- a/packages/host/app/instance-initializers/export-application-global.ts
+++ b/packages/host/app/instance-initializers/export-application-global.ts
@@ -1,4 +1,4 @@
-import ApplicationInstance from '@ember/application/instance';
+import type ApplicationInstance from '@ember/application/instance';
 
 import config from '@cardstack/host/config/environment';
 

--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -6,6 +6,7 @@ import ignore, { type Ignore } from 'ignore';
 import isEqual from 'lodash/isEqual';
 import merge from 'lodash/merge';
 
+import type { IndexWriter, RenderResponse } from '@cardstack/runtime-common';
 import {
   baseRealm,
   logger,
@@ -19,7 +20,6 @@ import {
   identifyCard,
   isCardDef,
   isBaseDef,
-  IndexWriter,
   unixTime,
   jobIdentity,
   getFieldDefinitions,
@@ -44,7 +44,6 @@ import {
   type Prerenderer,
   type RealmPermissions,
   type RenderRouteOptions,
-  RenderResponse,
 } from '@cardstack/runtime-common';
 import { Deferred } from '@cardstack/runtime-common/deferred';
 import {
@@ -54,9 +53,10 @@ import {
   type SerializedError,
 } from '@cardstack/runtime-common/error';
 import { cardTypeIcon } from '@cardstack/runtime-common/helpers';
-import { RealmPaths, LocalPath } from '@cardstack/runtime-common/paths';
+import type { LocalPath } from '@cardstack/runtime-common/paths';
+import { RealmPaths } from '@cardstack/runtime-common/paths';
 import { isIgnored } from '@cardstack/runtime-common/realm-index-updater';
-import { type Reader, type Stats } from '@cardstack/runtime-common/worker';
+import type { Reader, Stats } from '@cardstack/runtime-common/worker';
 
 import ENV from '@cardstack/host/config/environment';
 

--- a/packages/host/app/lib/externals.ts
+++ b/packages/host/app/lib/externals.ts
@@ -32,7 +32,7 @@ import * as boxelUiIcons from '@cardstack/boxel-ui/icons';
 import * as boxelUiModifiers from '@cardstack/boxel-ui/modifiers';
 
 import * as runtime from '@cardstack/runtime-common';
-import { VirtualNetwork } from '@cardstack/runtime-common';
+import type { VirtualNetwork } from '@cardstack/runtime-common';
 
 import { shimHostCommands } from '../commands';
 

--- a/packages/host/app/lib/file-def-manager.ts
+++ b/packages/host/app/lib/file-def-manager.ts
@@ -35,12 +35,11 @@ import type {
 import type { MatrixEvent } from 'https://cardstack.com/base/matrix-event';
 import type * as SkillModule from 'https://cardstack.com/base/skill';
 
-import { ExtendedClient } from '../services/matrix-sdk-loader';
-import NetworkService from '../services/network';
-
 import type CardService from '../services/card-service';
 import type CommandService from '../services/command-service';
 import type LoaderService from '../services/loader-service';
+import type { ExtendedClient } from '../services/matrix-sdk-loader';
+import type NetworkService from '../services/network';
 
 export const isSkillCard = Symbol.for('is-skill-card');
 

--- a/packages/host/app/lib/formatted-message/utils.ts
+++ b/packages/host/app/lib/formatted-message/utils.ts
@@ -1,4 +1,5 @@
-import { SafeString, htmlSafe } from '@ember/template';
+import type { SafeString } from '@ember/template';
+import { htmlSafe } from '@ember/template';
 
 import { SEARCH_MARKER } from '@cardstack/runtime-common';
 import { unescapeHtml } from '@cardstack/runtime-common/helpers/html';

--- a/packages/host/app/lib/html-component.ts
+++ b/packages/host/app/lib/html-component.ts
@@ -6,10 +6,11 @@ import templateOnly from '@ember/component/template-only';
 import { htmlSafe, type SafeString } from '@ember/template';
 import { precompileTemplate } from '@ember/template-compilation';
 
-import { ComponentLike } from '@glint/template';
 import { modifier } from 'ember-modifier';
 
 import { compiler } from '@cardstack/runtime-common/etc';
+
+import type { ComponentLike } from '@glint/template';
 
 class _DynamicHTMLComponent {
   constructor(

--- a/packages/host/app/lib/matrix-classes/message-builder.ts
+++ b/packages/host/app/lib/matrix-classes/message-builder.ts
@@ -12,10 +12,8 @@ import {
   isCardInstance,
 } from '@cardstack/runtime-common';
 
-import {
-  CommandRequest,
-  decodeCommandRequest,
-} from '@cardstack/runtime-common/commands';
+import type { CommandRequest } from '@cardstack/runtime-common/commands';
+import { decodeCommandRequest } from '@cardstack/runtime-common/commands';
 import {
   APP_BOXEL_COMMAND_REQUESTS_KEY,
   APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
@@ -31,7 +29,7 @@ import {
   APP_BOXEL_CODE_PATCH_RESULT_REL_TYPE,
 } from '@cardstack/runtime-common/matrix-constants';
 
-import { RoomSkill } from '@cardstack/host/resources/room';
+import type { RoomSkill } from '@cardstack/host/resources/room';
 
 import type CommandService from '@cardstack/host/services/command-service';
 import type LoaderService from '@cardstack/host/services/loader-service';
@@ -39,7 +37,7 @@ import type MatrixService from '@cardstack/host/services/matrix-service';
 import type StoreService from '@cardstack/host/services/store';
 
 import type { CommandStatus } from 'https://cardstack.com/base/command';
-import { SerializedFile } from 'https://cardstack.com/base/file-api';
+import type { SerializedFile } from 'https://cardstack.com/base/file-api';
 import type {
   CardMessageContent,
   CardMessageEvent,
@@ -51,10 +49,11 @@ import type {
 } from 'https://cardstack.com/base/matrix-event';
 import type { Skill } from 'https://cardstack.com/base/skill';
 
-import { RoomMember } from './member';
 import { Message } from './message';
 import MessageCodePatchResult from './message-code-patch-result';
 import MessageCommand from './message-command';
+
+import type { RoomMember } from './member';
 
 const ErrorMessage: Record<string, string> = {
   ['M_TOO_LARGE']: 'Message is too large',

--- a/packages/host/app/lib/matrix-classes/message-code-patch-result.ts
+++ b/packages/host/app/lib/matrix-classes/message-code-patch-result.ts
@@ -8,9 +8,9 @@ import type CommandService from '@cardstack/host/services/command-service';
 import type MatrixService from '@cardstack/host/services/matrix-service';
 import type StoreService from '@cardstack/host/services/store';
 
-import { CodePatchStatus } from 'https://cardstack.com/base/matrix-event';
+import type { CodePatchStatus } from 'https://cardstack.com/base/matrix-event';
 
-import { Message } from './message';
+import type { Message } from './message';
 
 export default class MessageCodePatchResult {
   @tracked index: number;

--- a/packages/host/app/lib/matrix-classes/message-command.ts
+++ b/packages/host/app/lib/matrix-classes/message-command.ts
@@ -4,8 +4,8 @@ import { inject as service } from '@ember/service';
 
 import { tracked } from '@glimmer/tracking';
 
-import { ResolvedCodeRef } from '@cardstack/runtime-common';
-import { CommandRequest } from '@cardstack/runtime-common/commands';
+import type { ResolvedCodeRef } from '@cardstack/runtime-common';
+import type { CommandRequest } from '@cardstack/runtime-common/commands';
 
 import type CommandService from '@cardstack/host/services/command-service';
 import type MatrixService from '@cardstack/host/services/matrix-service';
@@ -14,7 +14,7 @@ import type StoreService from '@cardstack/host/services/store';
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 import type { SerializedFile } from 'https://cardstack.com/base/file-api';
 
-import { Message } from './message';
+import type { Message } from './message';
 
 type CommandStatus = 'applied' | 'ready' | 'applying' | 'invalid';
 

--- a/packages/host/app/lib/matrix-classes/message.ts
+++ b/packages/host/app/lib/matrix-classes/message.ts
@@ -1,8 +1,6 @@
 import { guidFor } from '@ember/object/internals';
 import { cached, tracked } from '@glimmer/tracking';
 
-import { EventStatus } from 'matrix-js-sdk';
-
 import { TrackedArray } from 'tracked-built-ins';
 
 import { markdownToHtml } from '@cardstack/runtime-common';
@@ -13,13 +11,14 @@ import {
   type HtmlTagGroup,
 } from '@cardstack/host/lib/formatted-message/utils';
 
-import { type FileDef } from 'https://cardstack.com/base/file-api';
+import type { FileDef } from 'https://cardstack.com/base/file-api';
 
-import { RoomMember } from './member';
+import type { RoomMember } from './member';
 
 import type MessageCodePatchResult from './message-code-patch-result';
 
 import type MessageCommand from './message-command';
+import type { EventStatus } from 'matrix-js-sdk';
 
 const ErrorMessage: Record<string, string> = {
   ['M_TOO_LARGE']: 'Message is too large',

--- a/packages/host/app/lib/matrix-classes/room.ts
+++ b/packages/host/app/lib/matrix-classes/room.ts
@@ -1,7 +1,6 @@
 import { cached, tracked } from '@glimmer/tracking';
 
 import EventEmitter from 'eventemitter3';
-import { type IEvent } from 'matrix-js-sdk';
 
 import {
   APP_BOXEL_ACTIVE_LLM,
@@ -10,13 +9,15 @@ import {
   type LLMMode,
 } from '@cardstack/runtime-common/matrix-constants';
 
-import { SerializedFile } from 'https://cardstack.com/base/file-api';
+import type { SerializedFile } from 'https://cardstack.com/base/file-api';
 import type {
   ActiveLLMEvent,
   MatrixEvent as DiscreteMatrixEvent,
 } from 'https://cardstack.com/base/matrix-event';
 
 import Mutex from '../mutex';
+
+import type { IEvent } from 'matrix-js-sdk';
 
 import type * as MatrixSDK from 'matrix-js-sdk';
 

--- a/packages/host/app/lib/stack-item.ts
+++ b/packages/host/app/lib/stack-item.ts
@@ -1,4 +1,4 @@
-import { type Deferred } from '@cardstack/runtime-common';
+import type { Deferred } from '@cardstack/runtime-common';
 
 import type { Format } from 'https://cardstack.com/base/card-api';
 

--- a/packages/host/app/modifiers/restore-scroll-position.ts
+++ b/packages/host/app/modifiers/restore-scroll-position.ts
@@ -2,9 +2,11 @@ import { isDestroying } from '@ember/destroyable';
 import { debounce } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 
-import Modifier, { NamedArgs } from 'ember-modifier';
+import Modifier from 'ember-modifier';
 
-import ScrollPositionService from '@cardstack/host/services/scroll-position-service';
+import type ScrollPositionService from '@cardstack/host/services/scroll-position-service';
+
+import type { NamedArgs } from 'ember-modifier';
 
 interface RestoreScrollPositionModifierArgs {
   Positional: [];

--- a/packages/host/app/modifiers/scroll-into-view.ts
+++ b/packages/host/app/modifiers/scroll-into-view.ts
@@ -1,8 +1,10 @@
 import { inject as service } from '@ember/service';
 
-import Modifier, { NamedArgs, PositionalArgs } from 'ember-modifier';
+import Modifier from 'ember-modifier';
 
-import ScrollPositionService from '@cardstack/host/services/scroll-position-service';
+import type ScrollPositionService from '@cardstack/host/services/scroll-position-service';
+
+import type { NamedArgs, PositionalArgs } from 'ember-modifier';
 
 interface ScrollIntoViewModifierArgs {
   Positional: [boolean];

--- a/packages/host/app/resources/auto-attached-card.ts
+++ b/packages/host/app/resources/auto-attached-card.ts
@@ -12,7 +12,9 @@ import {
 
 import type { StackItem } from '@cardstack/host/lib/stack-item';
 
-import { Submode, Submodes } from '../components/submode-switcher';
+import { Submodes } from '../components/submode-switcher';
+
+import type { Submode } from '../components/submode-switcher';
 
 import type CardService from '../services/card-service';
 import type StoreService from '../services/store';

--- a/packages/host/app/resources/card-type.ts
+++ b/packages/host/app/resources/card-type.ts
@@ -4,7 +4,7 @@ import { tracked } from '@glimmer/tracking';
 import { restartableTask } from 'ember-concurrency';
 import { Resource } from 'ember-modify-based-class-resource';
 
-import { type Type } from '@cardstack/host/services/card-type-service';
+import type { Type } from '@cardstack/host/services/card-type-service';
 
 import type CardTypeService from '@cardstack/host/services/card-type-service';
 

--- a/packages/host/app/resources/code-diff.ts
+++ b/packages/host/app/resources/code-diff.ts
@@ -5,9 +5,9 @@ import { restartableTask } from 'ember-concurrency';
 import { Resource } from 'ember-modify-based-class-resource';
 
 import type CardService from '@cardstack/host/services/card-service';
-import CommandService from '@cardstack/host/services/command-service';
+import type CommandService from '@cardstack/host/services/command-service';
 
-import { CodePatchStatus } from 'https://cardstack.com/base/matrix-event';
+import type { CodePatchStatus } from 'https://cardstack.com/base/matrix-event';
 
 import ApplySearchReplaceBlockCommand from '../commands/apply-search-replace-block';
 

--- a/packages/host/app/resources/element-tracker.ts
+++ b/packages/host/app/resources/element-tracker.ts
@@ -1,6 +1,6 @@
 import { registerDestructor } from '@ember/destroyable';
 import { schedule } from '@ember/runloop';
-import { SafeString } from '@ember/template';
+import type { SafeString } from '@ember/template';
 
 import Modifier from 'ember-modifier';
 import { TrackedArray } from 'tracked-built-ins';

--- a/packages/host/app/resources/import.ts
+++ b/packages/host/app/resources/import.ts
@@ -5,17 +5,15 @@ import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 import { Resource } from 'ember-modify-based-class-resource';
 
-import {
-  logger,
-  CardError,
+import type {
   CardErrorJSONAPI,
   CardErrorsJSONAPI,
 } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
-
-import NetworkService from '../services/network';
+import { logger, CardError } from '@cardstack/runtime-common';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import type LoaderService from '../services/loader-service';
+import type NetworkService from '../services/network';
 
 interface Args {
   named: { url: string };

--- a/packages/host/app/resources/last-modified-date.ts
+++ b/packages/host/app/resources/last-modified-date.ts
@@ -4,7 +4,7 @@ import { tracked } from '@glimmer/tracking';
 import { formatDistanceToNow } from 'date-fns';
 import { Resource } from 'ember-modify-based-class-resource';
 
-import { Ready as ReadyFile } from '@cardstack/host/resources/file';
+import type { Ready as ReadyFile } from '@cardstack/host/resources/file';
 
 interface Args {
   named: { file: ReadyFile };

--- a/packages/host/app/resources/matrix-profile.ts
+++ b/packages/host/app/resources/matrix-profile.ts
@@ -4,7 +4,7 @@ import { tracked } from '@glimmer/tracking';
 import { restartableTask, all } from 'ember-concurrency';
 import { Resource } from 'ember-modify-based-class-resource';
 
-import MatrixService from '@cardstack/host/services/matrix-service';
+import type MatrixService from '@cardstack/host/services/matrix-service';
 
 interface Args {
   named: {

--- a/packages/host/app/resources/module-contents.ts
+++ b/packages/host/app/resources/module-contents.ts
@@ -8,11 +8,12 @@ import { Resource } from 'ember-modify-based-class-resource';
 
 import { ModuleSyntax } from '@cardstack/runtime-common/module-syntax';
 
-import { type Ready } from '@cardstack/host/resources/file';
+import type { Ready } from '@cardstack/host/resources/file';
 import { loadModule } from '@cardstack/host/resources/import';
 
 import type LoaderService from '@cardstack/host/services/loader-service';
-import ModuleContentsService, {
+import type ModuleContentsService from '@cardstack/host/services/module-contents-service';
+import {
   type ModuleDeclaration,
   type CardOrFieldDeclaration,
   type CardOrFieldReexport,

--- a/packages/host/app/resources/room.ts
+++ b/packages/host/app/resources/room.ts
@@ -3,12 +3,11 @@ import { getOwner } from '@ember/owner';
 import { service } from '@ember/service';
 import { tracked, cached } from '@glimmer/tracking';
 
-import { TaskInstance, restartableTask, timeout } from 'ember-concurrency';
+import { restartableTask, timeout } from 'ember-concurrency';
 import { Resource } from 'ember-modify-based-class-resource';
 
 import difference from 'lodash/difference';
 
-import { IRoomEvent } from 'matrix-js-sdk';
 import { TrackedMap } from 'tracked-built-ins';
 
 import {
@@ -53,9 +52,10 @@ import {
   RoomMember,
   type RoomMemberInterface,
 } from '../lib/matrix-classes/member';
-import { Message } from '../lib/matrix-classes/message';
 
 import MessageBuilder from '../lib/matrix-classes/message-builder';
+
+import type { Message } from '../lib/matrix-classes/message';
 
 import type Room from '../lib/matrix-classes/room';
 
@@ -64,6 +64,8 @@ import type MatrixService from '../services/matrix-service';
 import type OperatorModeStateService from '../services/operator-mode-state-service';
 import type RealmService from '../services/realm';
 import type StoreService from '../services/store';
+import type { TaskInstance } from 'ember-concurrency';
+import type { IRoomEvent } from 'matrix-js-sdk';
 
 export type RoomSkill = {
   cardId: string;

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -13,11 +13,11 @@ import isEqual from 'lodash/isEqual';
 
 import { TrackedArray } from 'tracked-built-ins';
 
+import type { QueryResultsMeta } from '@cardstack/runtime-common';
 import {
   subscribeToRealm,
   isCardCollectionDocument,
   isCardInstance,
-  QueryResultsMeta,
 } from '@cardstack/runtime-common';
 
 import type { Query } from '@cardstack/runtime-common/query';

--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -1,16 +1,16 @@
 import type Controller from '@ember/controller';
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
-import RouterService from '@ember/routing/router-service';
-import Transition from '@ember/routing/transition';
+import type RouterService from '@ember/routing/router-service';
+import type Transition from '@ember/routing/transition';
 import { join, scheduleOnce } from '@ember/runloop';
 import { service } from '@ember/service';
 
 import { TrackedMap } from 'tracked-built-ins';
 
+import type { CardError } from '@cardstack/runtime-common';
 import {
   formattedError,
-  CardError,
   baseRealm,
   SupportedMimeType,
   isCardError,

--- a/packages/host/app/routes/render/html.ts
+++ b/packages/host/app/routes/render/html.ts
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import RouterService from '@ember/routing/router-service';
+import type RouterService from '@ember/routing/router-service';
 import { service } from '@ember/service';
 
 import { isValidFormat } from '@cardstack/runtime-common';

--- a/packages/host/app/routes/render/meta.ts
+++ b/packages/host/app/routes/render/meta.ts
@@ -1,13 +1,13 @@
 import Route from '@ember/routing/route';
-import Transition from '@ember/routing/transition';
+import type Transition from '@ember/routing/transition';
 
 import { service } from '@ember/service';
 
 import { isEqual } from 'lodash';
 
+import type { CodeRef } from '@cardstack/runtime-common';
 import {
   baseRef,
-  CodeRef,
   identifyCard,
   internalKeyFor,
   maybeRelativeURL,

--- a/packages/host/app/services/ai-assistant-panel-service.ts
+++ b/packages/host/app/services/ai-assistant-panel-service.ts
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import Owner from '@ember/owner';
+import type Owner from '@ember/owner';
 import { service } from '@ember/service';
 import Service from '@ember/service';
 import { tracked } from '@glimmer/tracking';
@@ -12,7 +12,7 @@ import window from 'ember-window-mock';
 import { isCardInstance } from '@cardstack/runtime-common';
 
 import type { CardDef, Format } from 'https://cardstack.com/base/card-api';
-import * as CommandModule from 'https://cardstack.com/base/command';
+import type * as CommandModule from 'https://cardstack.com/base/command';
 import type { FileDef } from 'https://cardstack.com/base/file-api';
 
 import type { Skill as SkillCard } from 'https://cardstack.com/base/skill';
@@ -27,12 +27,11 @@ import { NewSessionIdPersistenceKey } from '../utils/local-storage-keys';
 
 import { titleize } from '../utils/titleize';
 
-import LocalPersistenceService from './local-persistence-service';
-
 import { DEFAULT_MODULE_INSPECTOR_VIEW } from './operator-mode-state-service';
 
 import type CodeSemanticsService from './code-semantics-service';
 import type CommandService from './command-service';
+import type LocalPersistenceService from './local-persistence-service';
 import type MatrixService from './matrix-service';
 import type MonacoService from './monaco-service';
 import type OperatorModeStateService from './operator-mode-state-service';

--- a/packages/host/app/services/billing-service.ts
+++ b/packages/host/app/services/billing-service.ts
@@ -1,4 +1,4 @@
-import Owner from '@ember/owner';
+import type Owner from '@ember/owner';
 import Service from '@ember/service';
 import { service } from '@ember/service';
 import { tracked, cached } from '@glimmer/tracking';
@@ -10,10 +10,10 @@ import {
   SupportedMimeType,
 } from '@cardstack/runtime-common';
 
-import MatrixService from './matrix-service';
-import NetworkService from './network';
-import RealmServerService from './realm-server';
-import ResetService from './reset';
+import type MatrixService from './matrix-service';
+import type NetworkService from './network';
+import type RealmServerService from './realm-server';
+import type ResetService from './reset';
 
 interface SubscriptionData {
   plan: string | null;

--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -13,10 +13,8 @@ import {
   type Loader,
 } from '@cardstack/runtime-common';
 
-import {
-  AtomicOperation,
-  createAtomicDocument,
-} from '@cardstack/runtime-common/atomic-document';
+import type { AtomicOperation } from '@cardstack/runtime-common/atomic-document';
+import { createAtomicDocument } from '@cardstack/runtime-common/atomic-document';
 
 import type {
   BaseDef,

--- a/packages/host/app/services/card-type-service.ts
+++ b/packages/host/app/services/card-type-service.ts
@@ -1,19 +1,19 @@
 import { service } from '@ember/service';
 import Service from '@ember/service';
 
+import type { RealmInfo } from '@cardstack/runtime-common';
 import {
   identifyCard,
   internalKeyFor,
   baseRealm,
   moduleFrom,
   getAncestor,
-  RealmInfo,
   SupportedMimeType,
   isResolvedCodeRef,
   type ResolvedCodeRef,
 } from '@cardstack/runtime-common';
 import { isCodeRef, type CodeRef } from '@cardstack/runtime-common/code-ref';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import type CardService from '@cardstack/host/services/card-service';
 

--- a/packages/host/app/services/code-semantics-service.ts
+++ b/packages/host/app/services/code-semantics-service.ts
@@ -1,15 +1,14 @@
 import Service from '@ember/service';
 import { inject as service } from '@ember/service';
 
+import type { ResolvedCodeRef, CodeRef } from '@cardstack/runtime-common';
 import {
-  ResolvedCodeRef,
   hasExecutableExtension,
   identifyCard,
   isCardDocumentString,
   isResolvedCodeRef,
   loadCardDef,
   getAncestor,
-  CodeRef,
   isCardDef as isCardDefHelper,
   isFieldDef as isFieldDefHelper,
   getField,
@@ -18,8 +17,6 @@ import {
 import { isReady } from '@cardstack/host/resources/file';
 
 import type { BaseDef } from 'https://cardstack.com/base/card-api';
-
-import { type Ready } from '../resources/file';
 
 import {
   moduleContentsResource,
@@ -31,6 +28,7 @@ import { findDeclarationByName } from '../services/module-contents-service';
 
 import type LoaderService from './loader-service';
 import type OperatorModeStateService from './operator-mode-state-service';
+import type { Ready } from '../resources/file';
 
 export default class CodeSemanticsService extends Service {
   @service declare operatorModeStateService: OperatorModeStateService;

--- a/packages/host/app/services/command-service.ts
+++ b/packages/host/app/services/command-service.ts
@@ -8,13 +8,10 @@ import Ajv from 'ajv';
 
 import { task, timeout, all } from 'ember-concurrency';
 
-import { IEvent } from 'matrix-js-sdk';
-
 import { TrackedSet } from 'tracked-built-ins';
 
+import type { Command, CommandContext } from '@cardstack/runtime-common';
 import {
-  Command,
-  CommandContext,
   CommandContextStamp,
   delay,
   getClass,
@@ -30,7 +27,7 @@ import type MatrixService from '@cardstack/host/services/matrix-service';
 import type Realm from '@cardstack/host/services/realm';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
-import { CodePatchStatus } from 'https://cardstack.com/base/matrix-event';
+import type { CodePatchStatus } from 'https://cardstack.com/base/matrix-event';
 
 import type LoaderService from './loader-service';
 import type OperatorModeStateService from './operator-mode-state-service';
@@ -39,6 +36,7 @@ import type StoreService from './store';
 import type { CodeData } from '../lib/formatted-message/utils';
 import type MessageCodePatchResult from '../lib/matrix-classes/message-code-patch-result';
 import type MessageCommand from '../lib/matrix-classes/message-command';
+import type { IEvent } from 'matrix-js-sdk';
 
 const DELAY_FOR_APPLYING_UI = isTesting() ? 50 : 500;
 

--- a/packages/host/app/services/error-display.ts
+++ b/packages/host/app/services/error-display.ts
@@ -1,6 +1,6 @@
 import Service from '@ember/service';
 
-import { BoxelErrorForContext } from 'https://cardstack.com/base/matrix-event';
+import type { BoxelErrorForContext } from 'https://cardstack.com/base/matrix-event';
 
 export interface DisplayedErrorProvider {
   getError: () => BoxelErrorForContext;

--- a/packages/host/app/services/host-mode-state-service.ts
+++ b/packages/host/app/services/host-mode-state-service.ts
@@ -1,4 +1,4 @@
-import RouterService from '@ember/routing/router-service';
+import type RouterService from '@ember/routing/router-service';
 import { scheduleOnce } from '@ember/runloop';
 import Service, { service } from '@ember/service';
 
@@ -8,7 +8,7 @@ import stringify from 'safe-stable-stringify';
 
 import { TrackedArray } from 'tracked-built-ins';
 
-import RealmService from './realm';
+import type RealmService from './realm';
 
 interface InitializeOptions {
   primaryCardId: string | null;

--- a/packages/host/app/services/loader-service.ts
+++ b/packages/host/app/services/loader-service.ts
@@ -1,13 +1,13 @@
 import { registerDestructor } from '@ember/destroyable';
-import Owner from '@ember/owner';
+import type Owner from '@ember/owner';
 import Service, { service } from '@ember/service';
 
 import { tracked } from '@glimmer/tracking';
 
+import type { FetcherMiddlewareHandler } from '@cardstack/runtime-common';
 import {
   fetcher,
   maybeHandleScopedCSSRequest,
-  FetcherMiddlewareHandler,
   authorizationMiddleware,
   clearFetchCache,
   logger,

--- a/packages/host/app/services/local-indexer.ts
+++ b/packages/host/app/services/local-indexer.ts
@@ -2,15 +2,15 @@ import Service from '@ember/service';
 
 import { tracked } from '@glimmer/tracking';
 
-import {
-  type IndexResults,
-  type IndexWriter,
-  type Prerenderer,
-  type FromScratchArgsWithPermissions,
-  type IncrementalArgsWithPermissions,
+import type {
+  IndexResults,
+  IndexWriter,
+  Prerenderer,
+  FromScratchArgsWithPermissions,
+  IncrementalArgsWithPermissions,
 } from '@cardstack/runtime-common';
 
-import { type TestRealmAdapter } from '@cardstack/host/tests/helpers/adapter';
+import type { TestRealmAdapter } from '@cardstack/host/tests/helpers/adapter';
 
 // Tests inject an implementation of this service to help perform indexing
 // for the test-realm-adapter

--- a/packages/host/app/services/matrix-sdk-loader.ts
+++ b/packages/host/app/services/matrix-sdk-loader.ts
@@ -1,23 +1,22 @@
-import Owner from '@ember/owner';
+import type Owner from '@ember/owner';
 import { getOwner } from '@ember/owner';
 import Service from '@ember/service';
 
 import { service } from '@ember/service';
 
-import * as MatrixSDK from 'matrix-js-sdk';
 import { SlidingSync } from 'matrix-js-sdk/lib/sliding-sync';
 
 import { RealmAuthClient } from '@cardstack/runtime-common/realm-auth-client';
 
-import FileDefManagerImpl, {
-  FileDefManager,
-} from '@cardstack/host/lib/file-def-manager';
+import type { FileDefManager } from '@cardstack/host/lib/file-def-manager';
+import FileDefManagerImpl from '@cardstack/host/lib/file-def-manager';
 
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
 import type * as FileAPI from 'https://cardstack.com/base/file-api';
 
-import MatrixService from './matrix-service';
-import NetworkService from './network';
+import type MatrixService from './matrix-service';
+import type NetworkService from './network';
+import type * as MatrixSDK from 'matrix-js-sdk';
 
 /*
   This abstracts over the matrix SDK, including several extra functions that are

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -1,4 +1,5 @@
-import Owner, { getOwner } from '@ember/owner';
+import type Owner from '@ember/owner';
+import { getOwner } from '@ember/owner';
 import type RouterService from '@ember/routing/router-service';
 import { debounce } from '@ember/runloop';
 import Service, { service } from '@ember/service';
@@ -8,13 +9,7 @@ import { cached, tracked } from '@glimmer/tracking';
 import { dropTask, task, timeout } from 'ember-concurrency';
 import window from 'ember-window-mock';
 import { cloneDeep } from 'lodash';
-import {
-  type LoginResponse,
-  type MatrixEvent,
-  type RoomMember,
-  type EmittedEvents,
-} from 'matrix-js-sdk';
-import { MatrixClient } from 'matrix-js-sdk';
+
 import { Filter } from 'matrix-js-sdk';
 import {
   type SlidingSync,
@@ -27,11 +22,13 @@ import stringify from 'safe-stable-stringify';
 import { TrackedMap } from 'tracked-built-ins';
 import { v4 as uuidv4 } from 'uuid';
 
+import type {
+  LooseCardResource,
+  ResolvedCodeRef,
+} from '@cardstack/runtime-common';
 import {
   aiBotUsername,
-  LooseCardResource,
   logger,
-  ResolvedCodeRef,
   isCardInstance,
   Deferred,
   SEARCH_MARKER,
@@ -79,18 +76,19 @@ import ENV from '@cardstack/host/config/environment';
 
 import type IndexController from '@cardstack/host/controllers/index';
 
-import Room, { TempEvent } from '@cardstack/host/lib/matrix-classes/room';
+import type { TempEvent } from '@cardstack/host/lib/matrix-classes/room';
+import Room from '@cardstack/host/lib/matrix-classes/room';
 import { getRandomBackgroundURL, iconURLFor } from '@cardstack/host/lib/utils';
 import { getMatrixProfile } from '@cardstack/host/resources/matrix-profile';
 
 import type { BaseDef, CardDef } from 'https://cardstack.com/base/card-api';
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
-import {
+import type {
   CardForAttachmentCard,
   FileForAttachmentCard,
 } from 'https://cardstack.com/base/command';
 import type * as FileAPI from 'https://cardstack.com/base/file-api';
-import { type FileDef } from 'https://cardstack.com/base/file-api';
+import type { FileDef } from 'https://cardstack.com/base/file-api';
 import type {
   BoxelContext,
   CardMessageContent,
@@ -113,11 +111,9 @@ import { isSkillCard } from '../lib/file-def-manager';
 import { skillCardURL } from '../lib/utils';
 import { importResource } from '../resources/import';
 
-import { RoomResource, getRoom } from '../resources/room';
+import { getRoom } from '../resources/room';
 
 import { clearLocalStorage } from '../utils/local-storage-keys';
-
-import { type SerializedState as OperatorModeSerializedState } from './operator-mode-state-service';
 
 import type CardService from './card-service';
 import type CommandService from './command-service';
@@ -128,10 +124,19 @@ import type MatrixSDKLoader from './matrix-sdk-loader';
 import type { ExtendedClient, ExtendedMatrixSDK } from './matrix-sdk-loader';
 import type MessageService from './message-service';
 import type NetworkService from './network';
+import type { SerializedState as OperatorModeSerializedState } from './operator-mode-state-service';
 import type RealmService from './realm';
 import type RealmServerService from './realm-server';
 import type ResetService from './reset';
 import type StoreService from './store';
+import type { RoomResource } from '../resources/room';
+import type { MatrixClient } from 'matrix-js-sdk';
+import type {
+  LoginResponse,
+  MatrixEvent,
+  RoomMember,
+  EmittedEvents,
+} from 'matrix-js-sdk';
 
 import type * as MatrixSDK from 'matrix-js-sdk';
 

--- a/packages/host/app/services/module-contents-service.ts
+++ b/packages/host/app/services/module-contents-service.ts
@@ -15,7 +15,7 @@ import {
 
 import type CardService from '@cardstack/host/services/card-service';
 import type CardTypeService from '@cardstack/host/services/card-type-service';
-import { type Type } from '@cardstack/host/services/card-type-service';
+import type { Type } from '@cardstack/host/services/card-type-service';
 import type LoaderService from '@cardstack/host/services/loader-service';
 import type NetworkService from '@cardstack/host/services/network';
 

--- a/packages/host/app/services/monaco-service.ts
+++ b/packages/host/app/services/monaco-service.ts
@@ -9,10 +9,10 @@ import { task } from 'ember-concurrency';
 
 import merge from 'lodash/merge';
 
-import { type SingleCardDocument } from '@cardstack/runtime-common';
+import type { SingleCardDocument } from '@cardstack/runtime-common';
 
 import config from '@cardstack/host/config/environment';
-import CardService from '@cardstack/host/services/card-service';
+import type CardService from '@cardstack/host/services/card-service';
 import {
   type MonacoLanguageConfig,
   extendDefinition,

--- a/packages/host/app/services/network.ts
+++ b/packages/host/app/services/network.ts
@@ -1,12 +1,12 @@
-import Owner from '@ember/owner';
+import type Owner from '@ember/owner';
 import Service, { service } from '@ember/service';
 
+import type { RunnerOpts } from '@cardstack/runtime-common';
 import {
   VirtualNetwork,
   authorizationMiddleware,
   baseRealm,
   fetcher,
-  RunnerOpts,
 } from '@cardstack/runtime-common';
 
 import config from '@cardstack/host/config/environment';

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -11,10 +11,10 @@ import window from 'ember-window-mock';
 import stringify from 'safe-stable-stringify';
 import { TrackedArray, TrackedMap, TrackedObject } from 'tracked-built-ins';
 
+import type { CodeRef } from '@cardstack/runtime-common';
 import {
   RealmPaths,
   type LocalPath,
-  CodeRef,
   isResolvedCodeRef,
   isCardInstance,
   isLocalId,
@@ -23,7 +23,8 @@ import {
   realmURL as realmURLSymbol,
 } from '@cardstack/runtime-common';
 
-import { Submode, Submodes } from '@cardstack/host/components/submode-switcher';
+import type { Submode } from '@cardstack/host/components/submode-switcher';
+import { Submodes } from '@cardstack/host/components/submode-switcher';
 import { StackItem } from '@cardstack/host/lib/stack-item';
 
 import {
@@ -36,7 +37,7 @@ import type LoaderService from '@cardstack/host/services/loader-service';
 import type MessageService from '@cardstack/host/services/message-service';
 import type MonacoService from '@cardstack/host/services/monaco-service';
 import type PlaygroundPanelService from '@cardstack/host/services/playground-panel-service';
-import { PlaygroundSelection } from '@cardstack/host/services/playground-panel-service';
+import type { PlaygroundSelection } from '@cardstack/host/services/playground-panel-service';
 import type Realm from '@cardstack/host/services/realm';
 import type RealmServer from '@cardstack/host/services/realm-server';
 import type RecentCardsService from '@cardstack/host/services/recent-cards-service';
@@ -44,9 +45,7 @@ import type RecentFilesService from '@cardstack/host/services/recent-files-servi
 
 import type { Format } from 'https://cardstack.com/base/card-api';
 
-import { BoxelContext } from 'https://cardstack.com/base/matrix-event';
-
-import { type Stack } from '../components/operator-mode/interact-submode';
+import type { BoxelContext } from 'https://cardstack.com/base/matrix-event';
 
 import { removeFileExtension } from '../components/search-sheet/utils';
 
@@ -54,16 +53,16 @@ import { ModuleInspectorSelections } from '../utils/local-storage-keys';
 
 import { normalizeDirPath } from '../utils/normalized-dir-path';
 
-import MatrixService from './matrix-service';
-import NetworkService from './network';
-
 import type CardService from './card-service';
 import type CodeSemanticsService from './code-semantics-service';
 import type ErrorDisplayService from './error-display';
+import type MatrixService from './matrix-service';
+import type NetworkService from './network';
 import type { RecentFile } from './recent-files-service';
 import type ResetService from './reset';
 import type SpecPanelService from './spec-panel-service';
 import type StoreService from './store';
+import type { Stack } from '../components/operator-mode/interact-submode';
 
 import type IndexController from '../controllers';
 

--- a/packages/host/app/services/playground-panel-service.ts
+++ b/packages/host/app/services/playground-panel-service.ts
@@ -1,4 +1,4 @@
-import Owner from '@ember/owner';
+import type Owner from '@ember/owner';
 import { schedule } from '@ember/runloop';
 import Service, { service } from '@ember/service';
 
@@ -17,9 +17,9 @@ import type {
   Format,
 } from 'https://cardstack.com/base/card-api';
 
-import OperatorModeStateService from './operator-mode-state-service';
-
 import type CardService from './card-service';
+import type OperatorModeStateService from './operator-mode-state-service';
+
 import type StoreService from './store';
 
 export interface PlaygroundSelection {

--- a/packages/host/app/services/realm-server.ts
+++ b/packages/host/app/services/realm-server.ts
@@ -8,7 +8,6 @@ import { restartableTask, rawTimeout, task } from 'ember-concurrency';
 
 import window from 'ember-window-mock';
 
-import { type IEvent } from 'matrix-js-sdk';
 import { TrackedArray } from 'tracked-built-ins';
 
 import {
@@ -25,11 +24,11 @@ import ENV from '@cardstack/host/config/environment';
 
 import config from '@cardstack/host/config/environment';
 
-import RealmService from './realm';
-
 import type { ExtendedClient } from './matrix-sdk-loader';
 import type NetworkService from './network';
+import type RealmService from './realm';
 import type ResetService from './reset';
+import type { IEvent } from 'matrix-js-sdk';
 
 const { hostsOwnAssets, resolvedBaseRealmURL } = ENV;
 

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -18,14 +18,16 @@ import window from 'ember-window-mock';
 
 import { TrackedSet, TrackedObject, TrackedArray } from 'tracked-built-ins';
 
-import {
+import type {
   Permissions,
+  JWTPayload,
+  RealmPermissions,
+} from '@cardstack/runtime-common';
+import {
   Deferred,
   logger,
-  JWTPayload,
   SupportedMimeType,
   type RealmInfo,
-  RealmPermissions,
   RealmPaths,
 } from '@cardstack/runtime-common';
 

--- a/packages/host/app/services/recent-files-service.ts
+++ b/packages/host/app/services/recent-files-service.ts
@@ -8,7 +8,7 @@ import window from 'ember-window-mock';
 import { TrackedArray } from 'tracked-built-ins';
 
 import { RealmPaths } from '@cardstack/runtime-common';
-import { LocalPath } from '@cardstack/runtime-common/paths';
+import type { LocalPath } from '@cardstack/runtime-common/paths';
 
 import { RecentFiles } from '../utils/local-storage-keys';
 

--- a/packages/host/app/services/render-service.ts
+++ b/packages/host/app/services/render-service.ts
@@ -2,30 +2,27 @@ import { getOwner } from '@ember/application';
 import type Owner from '@ember/owner';
 import Service, { service } from '@ember/service';
 
-import { ComponentLike } from '@glint/template';
-
 //@ts-ignore no types are available
 import createDocument from '@simple-dom/document';
-import Parser, { Tokenizer } from '@simple-dom/parser';
+
+import Parser from '@simple-dom/parser';
 import Serializer from '@simple-dom/serializer';
 import voidMap from '@simple-dom/void-map';
 
 import { tokenize } from 'simple-html-tokenizer';
 
+import type { RealmPaths } from '@cardstack/runtime-common';
 import {
   logger,
   baseRealm,
-  RealmPaths,
   loadDocument,
   type CodeRef,
   type SingleCardDocument,
 } from '@cardstack/runtime-common';
-import { Deferred } from '@cardstack/runtime-common/deferred';
+import type { Deferred } from '@cardstack/runtime-common/deferred';
 import { isCardError, CardError } from '@cardstack/runtime-common/error';
-import {
-  isNotLoadedError,
-  NotLoaded,
-} from '@cardstack/runtime-common/not-loaded';
+import type { NotLoaded } from '@cardstack/runtime-common/not-loaded';
+import { isNotLoadedError } from '@cardstack/runtime-common/not-loaded';
 
 import config from '@cardstack/host/config/environment';
 
@@ -42,7 +39,9 @@ import { render } from '../lib/isolated-render';
 
 import type CardService from './card-service';
 import type LoaderService from './loader-service';
+import type { ComponentLike } from '@glint/template';
 import type { SimpleDocument, SimpleElement } from '@simple-dom/interface';
+import type { Tokenizer } from '@simple-dom/parser';
 
 const log = logger('renderer');
 

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -47,21 +47,18 @@ import {
   SupportedMimeType,
 } from '@cardstack/runtime-common';
 
-import {
-  type CardDef,
-  type BaseDef,
-} from 'https://cardstack.com/base/card-api';
+import type { CardDef, BaseDef } from 'https://cardstack.com/base/card-api';
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
 
 import type { RealmEventContent } from 'https://cardstack.com/base/matrix-event';
 
 import CardStore, { getDeps, type ReferenceCount } from '../lib/gc-card-store';
 
-import { type CardSaveSubscriber } from './card-service';
-
-import EnvironmentService from './environment-service';
+import type { CardSaveSubscriber } from './card-service';
 
 import type CardService from './card-service';
+import type EnvironmentService from './environment-service';
+
 import type HostModeService from './host-mode-service';
 import type LoaderService from './loader-service';
 import type MessageService from './message-service';

--- a/packages/host/app/utils/schema-editor.ts
+++ b/packages/host/app/utils/schema-editor.ts
@@ -2,7 +2,7 @@ import {
   isCardOrFieldDeclaration,
   type ModuleDeclaration,
 } from '@cardstack/host/resources/module-contents';
-import { type Type } from '@cardstack/host/services/card-type-service';
+import type { Type } from '@cardstack/host/services/card-type-service';
 
 import type { BaseDef } from 'https://cardstack.com/base/card-api';
 

--- a/packages/host/app/utils/text-suggestion.ts
+++ b/packages/host/app/utils/text-suggestion.ts
@@ -1,11 +1,7 @@
 import a from 'indefinite';
 
-import {
-  CodeRef,
-  getPlural,
-  loadCardDef,
-  Loader,
-} from '@cardstack/runtime-common';
+import type { CodeRef, Loader } from '@cardstack/runtime-common';
+import { getPlural, loadCardDef } from '@cardstack/runtime-common';
 import {
   isCardTypeFilter,
   isEveryFilter,

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -21,7 +21,7 @@ import {
   type LooseSingleCardDocument,
 } from '@cardstack/runtime-common';
 
-import { Realm } from '@cardstack/runtime-common/realm';
+import type { Realm } from '@cardstack/runtime-common/realm';
 
 import type MonacoService from '@cardstack/host/services/monaco-service';
 

--- a/packages/host/tests/acceptance/code-submode/editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/editor-test.ts
@@ -32,9 +32,11 @@ import {
   withSlowSave,
   type TestContextWithSave,
 } from '../../helpers';
-import { TestRealmAdapter } from '../../helpers/adapter';
+
 import { setupMockMatrix } from '../../helpers/mock-matrix';
 import { setupApplicationTest } from '../../helpers/setup';
+
+import type { TestRealmAdapter } from '../../helpers/adapter';
 
 module('Acceptance | code submode | editor tests', function (hooks) {
   let monacoService: MonacoService;

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -22,7 +22,7 @@ import { baseRealm, Deferred } from '@cardstack/runtime-common';
 import { Submodes } from '@cardstack/host/components/submode-switcher';
 
 import type MonacoService from '@cardstack/host/services/monaco-service';
-import { SerializedState } from '@cardstack/host/services/operator-mode-state-service';
+import type { SerializedState } from '@cardstack/host/services/operator-mode-state-service';
 
 import { CodeModePanelHeights } from '@cardstack/host/utils/local-storage-keys';
 
@@ -41,10 +41,12 @@ import {
   type TestContextWithSave,
   setMonacoContent,
 } from '../../helpers';
-import { TestRealmAdapter } from '../../helpers/adapter';
+
 import { setupMockMatrix } from '../../helpers/mock-matrix';
 import { assertRecentFileURLs } from '../../helpers/recent-files-cards';
 import { setupApplicationTest } from '../../helpers/setup';
+
+import type { TestRealmAdapter } from '../../helpers/adapter';
 
 const testRealmURL2 = 'http://test-realm/test2/';
 const realmAFiles: Record<string, any> = {

--- a/packages/host/tests/acceptance/code-submode/recent-files-test.ts
+++ b/packages/host/tests/acceptance/code-submode/recent-files-test.ts
@@ -15,7 +15,7 @@ import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
 
-import MonacoService from '@cardstack/host/services/monaco-service';
+import type MonacoService from '@cardstack/host/services/monaco-service';
 
 import {
   percySnapshot,

--- a/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
@@ -12,7 +12,7 @@ import { module, test } from 'qunit';
 
 import { baseRealm, Deferred } from '@cardstack/runtime-common';
 
-import MonacoService from '@cardstack/host/services/monaco-service';
+import type MonacoService from '@cardstack/host/services/monaco-service';
 
 import {
   setupLocalIndexing,

--- a/packages/host/tests/helpers/adapter.ts
+++ b/packages/host/tests/helpers/adapter.ts
@@ -1,10 +1,12 @@
 import type Owner from '@ember/owner';
 
-import {
+import type {
   DBAdapter,
   Loader,
   LocalPath,
   RealmAdapter,
+} from '@cardstack/runtime-common';
+import {
   RealmPaths,
   baseRealm,
   createResponse,
@@ -13,11 +15,11 @@ import {
   unixTime,
 } from '@cardstack/runtime-common';
 
-import { LintResult } from '@cardstack/runtime-common/lint';
-import { type MatrixClient } from '@cardstack/runtime-common/matrix-client';
+import type { LintResult } from '@cardstack/runtime-common/lint';
+import type { MatrixClient } from '@cardstack/runtime-common/matrix-client';
 import { APP_BOXEL_REALM_EVENT_TYPE } from '@cardstack/runtime-common/matrix-constants';
 
-import {
+import type {
   FileRef,
   Kind,
   RequestContext,

--- a/packages/host/tests/helpers/indexer.ts
+++ b/packages/host/tests/helpers/indexer.ts
@@ -1,5 +1,6 @@
 import isEqual from 'lodash/isEqual';
 
+import type { LooseCardResource, DBAdapter } from '@cardstack/runtime-common';
 import {
   asExpressions,
   addExplicitParens,
@@ -16,9 +17,7 @@ import {
   type Expression,
   type BoxelIndexTable,
   type RealmVersionsTable,
-  LooseCardResource,
   trimExecutableExtension,
-  DBAdapter,
   query,
   isDefinitionId,
   trimExportNameFromDefinitionId,

--- a/packages/host/tests/helpers/mock-matrix.ts
+++ b/packages/host/tests/helpers/mock-matrix.ts
@@ -1,4 +1,4 @@
-import Owner from '@ember/owner';
+import type Owner from '@ember/owner';
 
 import { getService } from '@universal-ember/test-support';
 import window from 'ember-window-mock';

--- a/packages/host/tests/helpers/mock-matrix/_client.ts
+++ b/packages/host/tests/helpers/mock-matrix/_client.ts
@@ -1,4 +1,4 @@
-import Owner from '@ember/owner';
+import type Owner from '@ember/owner';
 
 import { getService } from '@universal-ember/test-support';
 
@@ -6,16 +6,8 @@ import { MatrixEvent } from 'matrix-js-sdk';
 
 import * as MatrixSDK from 'matrix-js-sdk';
 
-import {
-  MSC3575SlidingSyncRequest,
-  MSC3575SlidingSyncResponse,
-} from 'matrix-js-sdk/lib/sliding-sync';
-
-import {
-  LooseSingleCardDocument,
-  baseRealm,
-  unixTime,
-} from '@cardstack/runtime-common';
+import type { LooseSingleCardDocument } from '@cardstack/runtime-common';
+import { baseRealm, unixTime } from '@cardstack/runtime-common';
 
 import { ensureTrailingSlash } from '@cardstack/runtime-common';
 import {
@@ -47,11 +39,15 @@ import type { FileDef } from 'https://cardstack.com/base/file-api';
 import type { MatrixEvent as DiscreteMatrixEvent } from 'https://cardstack.com/base/matrix-event';
 import type { CommandField } from 'https://cardstack.com/base/skill';
 
-import { MockSDK } from './_sdk';
+import type { MockSDK } from './_sdk';
 
-import { ServerState } from './_server-state';
+import type { ServerState } from './_server-state';
 
 import type { Config } from '../mock-matrix';
+import type {
+  MSC3575SlidingSyncRequest,
+  MSC3575SlidingSyncResponse,
+} from 'matrix-js-sdk/lib/sliding-sync';
 
 type IEvent = MatrixSDK.IEvent;
 

--- a/packages/host/tests/helpers/mock-matrix/_sdk.ts
+++ b/packages/host/tests/helpers/mock-matrix/_sdk.ts
@@ -1,4 +1,4 @@
-import Owner from '@ember/owner';
+import type Owner from '@ember/owner';
 
 import type { ExtendedMatrixSDK } from '@cardstack/host/services/matrix-sdk-loader';
 

--- a/packages/host/tests/helpers/mock-matrix/_sliding-sync.ts
+++ b/packages/host/tests/helpers/mock-matrix/_sliding-sync.ts
@@ -1,8 +1,11 @@
-import * as MatrixSDK from 'matrix-js-sdk';
 import {
   SlidingSync,
   SlidingSyncEvent,
   SlidingSyncState,
+} from 'matrix-js-sdk/lib/sliding-sync';
+
+import type * as MatrixSDK from 'matrix-js-sdk';
+import type {
   MSC3575List,
   MSC3575RoomSubscription,
 } from 'matrix-js-sdk/lib/sliding-sync';

--- a/packages/host/tests/helpers/mock-matrix/_utils.ts
+++ b/packages/host/tests/helpers/mock-matrix/_utils.ts
@@ -1,8 +1,8 @@
-import Owner from '@ember/owner';
+import type Owner from '@ember/owner';
 
 import { APP_BOXEL_REALM_EVENT_TYPE } from '@cardstack/runtime-common/matrix-constants';
 
-import RealmService from '@cardstack/host/services/realm';
+import type RealmService from '@cardstack/host/services/realm';
 
 import type { RealmEvent } from 'https://cardstack.com/base/matrix-event';
 

--- a/packages/host/tests/helpers/operator-mode-parameters-match.ts
+++ b/packages/host/tests/helpers/operator-mode-parameters-match.ts
@@ -1,4 +1,4 @@
-import { type SerializedState } from '@cardstack/host/services/operator-mode-state-service';
+import type { SerializedState } from '@cardstack/host/services/operator-mode-state-service';
 
 export default function (assert: Assert) {
   assert.operatorModeParametersMatch = function (

--- a/packages/host/tests/helpers/render-component.ts
+++ b/packages/host/tests/helpers/render-component.ts
@@ -2,15 +2,16 @@
 import { precompileTemplate } from '@ember/template-compilation';
 import { render, getContext } from '@ember/test-helpers';
 
-import { ComponentLike } from '@glint/template';
-
-import { baseRealm, Loader } from '@cardstack/runtime-common';
+import type { Loader } from '@cardstack/runtime-common';
+import { baseRealm } from '@cardstack/runtime-common';
 
 import type {
   BaseDef,
   Format,
   Field,
 } from 'https://cardstack.com/base/card-api';
+
+import type { ComponentLike } from '@glint/template';
 
 async function cardApi(
   loader: Loader,

--- a/packages/host/tests/helpers/visit-operator-mode.ts
+++ b/packages/host/tests/helpers/visit-operator-mode.ts
@@ -2,7 +2,7 @@ import { visit } from '@ember/test-helpers';
 
 import stringify from 'safe-stable-stringify';
 
-import { SerializedState } from '@cardstack/host/services/operator-mode-state-service';
+import type { SerializedState } from '@cardstack/host/services/operator-mode-state-service';
 
 export default async function visitOperatorMode({
   stacks,

--- a/packages/host/tests/integration/resources/search-test.ts
+++ b/packages/host/tests/integration/resources/search-test.ts
@@ -1,28 +1,25 @@
 import { getOwner } from '@ember/owner';
-import { settled, RenderingTestContext, waitUntil } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
+import { settled, waitUntil } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
+import type { Loader, Query } from '@cardstack/runtime-common';
 import {
-  Loader,
-  Query,
   baseRealm,
   type Realm,
   type LooseSingleCardDocument,
 } from '@cardstack/runtime-common';
 
-import {
-  SearchResource,
-  Args as SearchResourceArgs,
-} from '@cardstack/host/resources/search';
+import type { Args as SearchResourceArgs } from '@cardstack/host/resources/search';
+import { SearchResource } from '@cardstack/host/resources/search';
 
 import type LoaderService from '@cardstack/host/services/loader-service';
 import RealmService from '@cardstack/host/services/realm';
 import type StoreService from '@cardstack/host/services/store';
 
 import {
-  CardDocFiles,
   setupIntegrationTestRealm,
   setupLocalIndexing,
   testRealmURL,
@@ -30,6 +27,8 @@ import {
 import { setupBaseRealm } from '../../helpers/base-realm';
 import { setupMockMatrix } from '../../helpers/mock-matrix';
 import { setupRenderingTest } from '../../helpers/setup';
+
+import type { CardDocFiles } from '../../helpers';
 
 class StubRealmService extends RealmService {
   realmOfURL(_url: URL) {

--- a/packages/host/tests/unit/ai-function-generation-test.ts
+++ b/packages/host/tests/unit/ai-function-generation-test.ts
@@ -1,4 +1,4 @@
-import { RenderingTestContext } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
@@ -13,9 +13,9 @@ import {
   type ObjectSchema,
   type AttributesSchema,
 } from '@cardstack/runtime-common/helpers/ai';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
-import { primitive as primitiveType } from 'https://cardstack.com/base/card-api';
+import type { primitive as primitiveType } from 'https://cardstack.com/base/card-api';
 
 import { setupLocalIndexing, setupOnSave, setupCardLogs } from '../helpers';
 import { setupRenderingTest } from '../helpers/setup';

--- a/packages/host/tests/unit/box-test.ts
+++ b/packages/host/tests/unit/box-test.ts
@@ -1,9 +1,10 @@
-import { RenderingTestContext } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
-import { Loader, baseRealm } from '@cardstack/runtime-common';
+import type { Loader } from '@cardstack/runtime-common';
+import { baseRealm } from '@cardstack/runtime-common';
 
 import { setupRenderingTest } from '../helpers/setup';
 

--- a/packages/host/tests/unit/card-menu-items-test.ts
+++ b/packages/host/tests/unit/card-menu-items-test.ts
@@ -1,7 +1,7 @@
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
-import { type MenuItemOptions } from '@cardstack/boxel-ui/helpers';
+import type { MenuItemOptions } from '@cardstack/boxel-ui/helpers';
 
 import { baseRealm, type Loader } from '@cardstack/runtime-common';
 

--- a/packages/host/tests/unit/code-ref-test.ts
+++ b/packages/host/tests/unit/code-ref-test.ts
@@ -1,12 +1,13 @@
-import { RenderingTestContext } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 
 import { module, test } from 'qunit';
 
-import { baseRealm, Loader, loadCardDef } from '@cardstack/runtime-common';
+import type { Loader } from '@cardstack/runtime-common';
+import { baseRealm, loadCardDef } from '@cardstack/runtime-common';
 
-import * as CardAPI from 'https://cardstack.com/base/card-api';
+import type * as CardAPI from 'https://cardstack.com/base/card-api';
 
 import {
   testRealmURL,

--- a/packages/host/tests/unit/garbage-collection-test.ts
+++ b/packages/host/tests/unit/garbage-collection-test.ts
@@ -1,12 +1,12 @@
-import { type RenderingTestContext } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
+import type { LooseSingleCardDocument } from '@cardstack/runtime-common';
 import {
   baseRealm,
   localId,
-  LooseSingleCardDocument,
   isNotLoadedError,
   type Loader,
   type CardErrorJSONAPI as CardError,
@@ -17,7 +17,7 @@ import CardStore, {
 } from '@cardstack/host/lib/gc-card-store';
 
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
-import { type CardDef as CardInstance } from 'https://cardstack.com/base/card-api';
+import type { CardDef as CardInstance } from 'https://cardstack.com/base/card-api';
 
 import { saveCard, testRealmURL } from '../helpers';
 import {

--- a/packages/host/tests/unit/index-query-engine-test.ts
+++ b/packages/host/tests/unit/index-query-engine-test.ts
@@ -22,11 +22,11 @@ import { DefinitionsCache } from '@cardstack/runtime-common/definitions-cache';
 
 import ENV from '@cardstack/host/config/environment';
 import { shimExternals } from '@cardstack/host/lib/externals';
-import SQLiteAdapter from '@cardstack/host/lib/sqlite-adapter';
+import type SQLiteAdapter from '@cardstack/host/lib/sqlite-adapter';
 
-import {
-  type JSONAPISingleResourceDocument,
-  type CardDef,
+import type {
+  JSONAPISingleResourceDocument,
+  CardDef,
 } from 'https://cardstack.com/base/card-api';
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
 

--- a/packages/host/tests/unit/lib/field-path-parser-test.ts
+++ b/packages/host/tests/unit/lib/field-path-parser-test.ts
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 
 import { FieldPathParser } from '@cardstack/host/lib/field-path-parser';
 
-import { type CardDef } from 'https://cardstack.com/base/card-api';
+import type { CardDef } from 'https://cardstack.com/base/card-api';
 
 module('Unit | Utility | field-path-parser', function () {
   module('parseFieldPath', function () {

--- a/packages/host/tests/unit/loader-test.ts
+++ b/packages/host/tests/unit/loader-test.ts
@@ -1,4 +1,4 @@
-import { RenderingTestContext } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 

--- a/packages/host/tests/unit/qs-test.ts
+++ b/packages/host/tests/unit/qs-test.ts
@@ -1,7 +1,8 @@
 import qs from 'qs';
 import { module, test } from 'qunit';
 
-import { parseQuery, Query } from '@cardstack/runtime-common/query';
+import type { Query } from '@cardstack/runtime-common/query';
+import { parseQuery } from '@cardstack/runtime-common/query';
 
 module('Unit | qs | parse', function () {
   test('parseQuery errors out if the query is too deep', async function (assert) {

--- a/packages/host/tests/unit/services/ai-assistant-panel-service-test.ts
+++ b/packages/host/tests/unit/services/ai-assistant-panel-service-test.ts
@@ -2,8 +2,8 @@ import { getService } from '@universal-ember/test-support';
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-import AiAssistantPanelService from '@cardstack/host/services/ai-assistant-panel-service';
-import MonacoService from '@cardstack/host/services/monaco-service';
+import type AiAssistantPanelService from '@cardstack/host/services/ai-assistant-panel-service';
+import type MonacoService from '@cardstack/host/services/monaco-service';
 
 module('Unit | Service | ai-assistant-panel-service', function (hooks) {
   setupTest(hooks);

--- a/packages/host/tests/unit/services/code-semantics-service-test.ts
+++ b/packages/host/tests/unit/services/code-semantics-service-test.ts
@@ -5,7 +5,7 @@ import type { Ready } from '@cardstack/host/resources/file';
 import type { State } from '@cardstack/host/resources/module-contents';
 
 import type { SaveType } from '@cardstack/host/services/card-service';
-import CodeSemanticsService from '@cardstack/host/services/code-semantics-service';
+import type CodeSemanticsService from '@cardstack/host/services/code-semantics-service';
 
 const mockFile: Ready = {
   state: 'ready',

--- a/packages/postgres/pg-config.ts
+++ b/packages/postgres/pg-config.ts
@@ -1,4 +1,4 @@
-import { type ClientConfig } from 'pg';
+import type { ClientConfig } from 'pg';
 
 export function postgresConfig(defaultConfig: ClientConfig = {}) {
   return Object.assign({}, defaultConfig, {

--- a/packages/postgres/pg-queue.ts
+++ b/packages/postgres/pg-queue.ts
@@ -15,7 +15,7 @@ import {
   Deferred,
   Job,
 } from '@cardstack/runtime-common';
-import { PgAdapter } from './pg-adapter';
+import type { PgAdapter } from './pg-adapter';
 import * as Sentry from '@sentry/node';
 
 const log = logger('queue');

--- a/packages/postgres/pg-transaction-manager.ts
+++ b/packages/postgres/pg-transaction-manager.ts
@@ -1,4 +1,4 @@
-import { PgAdapter } from './pg-adapter';
+import type { PgAdapter } from './pg-adapter';
 
 export class TransactionManager {
   private isInTransaction = false;

--- a/packages/realm-server/.eslintrc.js
+++ b/packages/realm-server/.eslintrc.js
@@ -14,6 +14,13 @@ module.exports = {
       extends: ['plugin:n/recommended'],
       rules: {
         '@typescript-eslint/no-var-requires': 'off',
+        '@typescript-eslint/consistent-type-imports': [
+          'error',
+          {
+            disallowTypeAnnotations: false,
+          },
+        ],
+        '@typescript-eslint/no-import-type-side-effects': 'error',
       },
     },
     {

--- a/packages/realm-server/fastboot.ts
+++ b/packages/realm-server/fastboot.ts
@@ -1,11 +1,8 @@
-import { type FastBootInstance } from './fastboot-from-deployed';
+import type { FastBootInstance } from './fastboot-from-deployed';
 import { instantiateFastBoot } from './fastboot-from-deployed';
-import {
-  type IndexRunner,
-  type RunnerOpts,
-} from '@cardstack/runtime-common/worker';
+import type { IndexRunner, RunnerOpts } from '@cardstack/runtime-common/worker';
 import { JSDOM } from 'jsdom';
-import { type ErrorReporter } from '@cardstack/runtime-common/realm';
+import type { ErrorReporter } from '@cardstack/runtime-common/realm';
 import { performance } from 'perf_hooks';
 import { readFileSync } from 'fs-extra';
 import { join } from 'path';

--- a/packages/realm-server/handlers/handle-add-credit.ts
+++ b/packages/realm-server/handlers/handle-add-credit.ts
@@ -1,4 +1,4 @@
-import Koa from 'koa';
+import type Koa from 'koa';
 import {
   type Expression,
   query as _query,
@@ -6,7 +6,7 @@ import {
   SupportedMimeType,
 } from '@cardstack/runtime-common';
 import { sendResponseForBadRequest, setContextResponse } from '../middleware';
-import { type CreateRoutesArgs } from '../routes';
+import type { CreateRoutesArgs } from '../routes';
 
 export default function handleAddCredit({
   dbAdapter,

--- a/packages/realm-server/handlers/handle-check-boxel-domain-availability.ts
+++ b/packages/realm-server/handlers/handle-check-boxel-domain-availability.ts
@@ -1,11 +1,11 @@
-import Koa from 'koa';
+import type Koa from 'koa';
 import { query, param } from '@cardstack/runtime-common';
 import {
   sendResponseForUnprocessableEntity,
   sendResponseForSystemError,
   setContextResponse,
 } from '../middleware';
-import { CreateRoutesArgs } from '../routes';
+import type { CreateRoutesArgs } from '../routes';
 import { validateSubdomain } from '../lib/user-subdomain-validation';
 
 type CheckBoxelDomainAvailabilityResponse = {

--- a/packages/realm-server/handlers/handle-claim-boxel-domain.ts
+++ b/packages/realm-server/handlers/handle-claim-boxel-domain.ts
@@ -1,4 +1,4 @@
-import Koa from 'koa';
+import type Koa from 'koa';
 import {
   asExpressions,
   insert,
@@ -15,8 +15,8 @@ import {
   sendResponseForUnprocessableEntity,
   setContextResponse,
 } from '../middleware';
-import { RealmServerTokenClaim } from '../utils/jwt';
-import { CreateRoutesArgs } from '../routes';
+import type { RealmServerTokenClaim } from '../utils/jwt';
+import type { CreateRoutesArgs } from '../routes';
 import { validateSubdomain } from '../lib/user-subdomain-validation';
 
 interface ClaimedBoxelDomainJSON {

--- a/packages/realm-server/handlers/handle-create-realm.ts
+++ b/packages/realm-server/handlers/handle-create-realm.ts
@@ -1,21 +1,20 @@
-import { RealmServerTokenClaim } from '../utils/jwt';
+import type { RealmServerTokenClaim } from '../utils/jwt';
 import {
   fetchRequestFromContext,
   sendResponseForBadRequest,
   sendResponseForSystemError,
   setContextResponse,
 } from '../middleware';
-import Koa from 'koa';
+import type Koa from 'koa';
+import type { Realm, RealmInfo } from '@cardstack/runtime-common';
 import {
   createResponse,
   DEFAULT_PERMISSIONS,
   logger,
-  Realm,
   SupportedMimeType,
-  RealmInfo,
 } from '@cardstack/runtime-common';
 import * as Sentry from '@sentry/node';
-import { CreateRoutesArgs } from '../routes';
+import type { CreateRoutesArgs } from '../routes';
 
 interface RealmCreationJSON {
   data: {

--- a/packages/realm-server/handlers/handle-create-session.ts
+++ b/packages/realm-server/handlers/handle-create-session.ts
@@ -5,18 +5,16 @@ import {
   SupportedMimeType,
   upsertSessionRoom,
 } from '@cardstack/runtime-common';
-import {
-  MatrixBackendAuthentication,
-  Utils,
-} from '@cardstack/runtime-common/matrix-backend-authentication';
-import Koa from 'koa';
+import type { Utils } from '@cardstack/runtime-common/matrix-backend-authentication';
+import { MatrixBackendAuthentication } from '@cardstack/runtime-common/matrix-backend-authentication';
+import type Koa from 'koa';
 import { createJWT } from '../utils/jwt';
 import {
   fetchRequestFromContext,
   sendResponseForSystemError,
   setContextResponse,
 } from '../middleware';
-import { CreateRoutesArgs } from '../routes';
+import type { CreateRoutesArgs } from '../routes';
 
 const log = logger('realm-server');
 

--- a/packages/realm-server/handlers/handle-create-stripe-session.ts
+++ b/packages/realm-server/handlers/handle-create-stripe-session.ts
@@ -1,4 +1,4 @@
-import Koa from 'koa';
+import type Koa from 'koa';
 import {
   EXTRA_TOKENS_PRICING,
   SupportedMimeType,
@@ -18,8 +18,8 @@ import {
   getPlanByName,
   getUserByMatrixUserId,
 } from '@cardstack/billing/billing-queries';
-import { RealmServerTokenClaim } from '../utils/jwt';
-import { CreateRoutesArgs } from '../routes';
+import type { RealmServerTokenClaim } from '../utils/jwt';
+import type { CreateRoutesArgs } from '../routes';
 
 export default function handleCreateStripeSessionRequest({
   dbAdapter,

--- a/packages/realm-server/handlers/handle-create-user.ts
+++ b/packages/realm-server/handlers/handle-create-user.ts
@@ -1,13 +1,13 @@
 import { insertUser } from '@cardstack/runtime-common';
-import Koa from 'koa';
+import type Koa from 'koa';
 import {
   fetchRequestFromContext,
   sendResponseForBadRequest,
   sendResponseForSystemError,
   setContextResponse,
 } from '../middleware';
-import { RealmServerTokenClaim } from '../utils/jwt';
-import { CreateRoutesArgs } from '../routes';
+import type { RealmServerTokenClaim } from '../utils/jwt';
+import type { CreateRoutesArgs } from '../routes';
 import { addToCreditsLedger } from '@cardstack/billing/billing-queries';
 
 export default function handleCreateUserRequest({

--- a/packages/realm-server/handlers/handle-delete-boxel-claimed-domain.ts
+++ b/packages/realm-server/handlers/handle-delete-boxel-claimed-domain.ts
@@ -1,4 +1,4 @@
-import Koa from 'koa';
+import type Koa from 'koa';
 import { asExpressions, param, query, update } from '@cardstack/runtime-common';
 import { getUserByMatrixUserId } from '@cardstack/billing/billing-queries';
 import {
@@ -7,8 +7,8 @@ import {
   sendResponseForUnprocessableEntity,
   setContextResponse,
 } from '../middleware';
-import { RealmServerTokenClaim } from '../utils/jwt';
-import { CreateRoutesArgs } from '../routes';
+import type { RealmServerTokenClaim } from '../utils/jwt';
+import type { CreateRoutesArgs } from '../routes';
 
 export default function handleDeleteBoxelClaimedDomainRequest({
   dbAdapter,

--- a/packages/realm-server/handlers/handle-fetch-catalog-realms.ts
+++ b/packages/realm-server/handlers/handle-fetch-catalog-realms.ts
@@ -1,12 +1,12 @@
-import Koa from 'koa';
+import type Koa from 'koa';
+import type { RealmInfo } from '@cardstack/runtime-common';
 import {
   fetchCatalogRealms,
   logger,
-  RealmInfo,
   SupportedMimeType,
 } from '@cardstack/runtime-common';
 import { setContextResponse } from '../middleware';
-import { CreateRoutesArgs } from '../routes';
+import type { CreateRoutesArgs } from '../routes';
 
 type CatalogRealm = {
   type: 'catalog-realm';

--- a/packages/realm-server/handlers/handle-fetch-user.ts
+++ b/packages/realm-server/handlers/handle-fetch-user.ts
@@ -1,15 +1,12 @@
-import {
-  Plan,
-  SubscriptionCycle,
-  SupportedMimeType,
-} from '@cardstack/runtime-common';
-import Koa from 'koa';
+import type { Plan, SubscriptionCycle } from '@cardstack/runtime-common';
+import { SupportedMimeType } from '@cardstack/runtime-common';
+import type Koa from 'koa';
 import {
   sendResponseForNotFound,
   sendResponseForSystemError,
   setContextResponse,
 } from '../middleware';
-import { RealmServerTokenClaim } from '../utils/jwt';
+import type { RealmServerTokenClaim } from '../utils/jwt';
 import {
   getCurrentActiveSubscription,
   getMostRecentSubscriptionCycle,
@@ -17,7 +14,7 @@ import {
   getUserByMatrixUserId,
   sumUpCreditsLedger,
 } from '@cardstack/billing/billing-queries';
-import { CreateRoutesArgs } from '../routes';
+import type { CreateRoutesArgs } from '../routes';
 
 type FetchUserResponse = {
   data: {

--- a/packages/realm-server/handlers/handle-full-reindex.ts
+++ b/packages/realm-server/handlers/handle-full-reindex.ts
@@ -1,10 +1,10 @@
-import Koa from 'koa';
+import type Koa from 'koa';
 import {
   SupportedMimeType,
   systemInitiatedPriority,
 } from '@cardstack/runtime-common';
 import { setContextResponse } from '../middleware';
-import { type CreateRoutesArgs } from '../routes';
+import type { CreateRoutesArgs } from '../routes';
 
 export default function handleFullReindex({
   queue,

--- a/packages/realm-server/handlers/handle-get-boxel-claimed-domain.ts
+++ b/packages/realm-server/handlers/handle-get-boxel-claimed-domain.ts
@@ -1,4 +1,4 @@
-import Koa from 'koa';
+import type Koa from 'koa';
 import { param, query, SupportedMimeType } from '@cardstack/runtime-common';
 import { getUserByMatrixUserId } from '@cardstack/billing/billing-queries';
 import {
@@ -7,8 +7,8 @@ import {
   sendResponseForSystemError,
   setContextResponse,
 } from '../middleware';
-import { RealmServerTokenClaim } from '../utils/jwt';
-import { CreateRoutesArgs } from '../routes';
+import type { RealmServerTokenClaim } from '../utils/jwt';
+import type { CreateRoutesArgs } from '../routes';
 
 export default function handleGetBoxelClaimedDomainRequest({
   dbAdapter,

--- a/packages/realm-server/handlers/handle-post-deployment.ts
+++ b/packages/realm-server/handlers/handle-post-deployment.ts
@@ -1,4 +1,4 @@
-import Koa from 'koa';
+import type Koa from 'koa';
 import {
   SupportedMimeType,
   systemInitiatedPriority,
@@ -7,7 +7,7 @@ import {
   sendResponseForUnauthorizedRequest,
   setContextResponse,
 } from '../middleware';
-import { type CreateRoutesArgs } from '../routes';
+import type { CreateRoutesArgs } from '../routes';
 import {
   compareCurrentBoxelUIChecksum,
   writeCurrentBoxelUIChecksum,

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -1,4 +1,4 @@
-import Koa from 'koa';
+import type Koa from 'koa';
 import {
   fetchUserPermissions,
   query,
@@ -25,8 +25,8 @@ import {
   setContextResponse,
 } from '../middleware';
 import { createJWT } from '../jwt';
-import { type CreateRoutesArgs } from '../routes';
-import { RealmServerTokenClaim } from '../utils/jwt';
+import type { CreateRoutesArgs } from '../routes';
+import type { RealmServerTokenClaim } from '../utils/jwt';
 import { registerUser } from '../synapse';
 import { passwordFromSeed } from '@cardstack/runtime-common/matrix-client';
 

--- a/packages/realm-server/handlers/handle-queue-status.ts
+++ b/packages/realm-server/handlers/handle-queue-status.ts
@@ -1,7 +1,7 @@
-import Koa from 'koa';
+import type Koa from 'koa';
 import { query, SupportedMimeType } from '@cardstack/runtime-common';
 import { setContextResponse } from '../middleware';
-import { CreateRoutesArgs } from '../routes';
+import type { CreateRoutesArgs } from '../routes';
 import { monitoringAuthToken } from '../utils/monitoring';
 
 function isAuthorizedToViewMonitoring(

--- a/packages/realm-server/handlers/handle-realm-auth.ts
+++ b/packages/realm-server/handlers/handle-realm-auth.ts
@@ -1,11 +1,11 @@
-import Koa from 'koa';
+import type Koa from 'koa';
 
-import { type CreateRoutesArgs } from '../routes';
+import type { CreateRoutesArgs } from '../routes';
 import {
   SupportedMimeType,
   fetchUserPermissions,
 } from '@cardstack/runtime-common';
-import { RealmServerTokenClaim } from 'utils/jwt';
+import type { RealmServerTokenClaim } from 'utils/jwt';
 import { getUserByMatrixUserId } from '@cardstack/billing/billing-queries';
 import { createJWT } from '../jwt';
 import { sendResponseForError, setContextResponse } from '../middleware';

--- a/packages/realm-server/handlers/handle-reindex.ts
+++ b/packages/realm-server/handlers/handle-reindex.ts
@@ -1,4 +1,5 @@
-import Koa from 'koa';
+import type Koa from 'koa';
+import type { DBAdapter } from '@cardstack/runtime-common';
 import {
   type FromScratchResult,
   type QueuePublisher,
@@ -7,7 +8,6 @@ import {
   userInitiatedPriority,
   SupportedMimeType,
   RealmPaths,
-  DBAdapter,
 } from '@cardstack/runtime-common';
 import { enqueueReindexRealmJob } from '@cardstack/runtime-common/jobs/reindex-realm';
 import {
@@ -15,7 +15,7 @@ import {
   sendResponseForSystemError,
   setContextResponse,
 } from '../middleware';
-import { type CreateRoutesArgs } from '../routes';
+import type { CreateRoutesArgs } from '../routes';
 
 export default function handleReindex({
   queue,

--- a/packages/realm-server/handlers/handle-remove-job.ts
+++ b/packages/realm-server/handlers/handle-remove-job.ts
@@ -1,4 +1,4 @@
-import Koa from 'koa';
+import type Koa from 'koa';
 import {
   type Expression,
   query as _query,
@@ -6,7 +6,7 @@ import {
   separatedByCommas,
 } from '@cardstack/runtime-common';
 import { sendResponseForBadRequest, setContextResponse } from '../middleware';
-import { type CreateRoutesArgs } from '../routes';
+import type { CreateRoutesArgs } from '../routes';
 
 export default function handleReindex({
   dbAdapter,

--- a/packages/realm-server/handlers/handle-request-forward.ts
+++ b/packages/realm-server/handlers/handle-request-forward.ts
@@ -1,9 +1,6 @@
-import Koa from 'koa';
-import {
-  DBAdapter,
-  logger,
-  SupportedMimeType,
-} from '@cardstack/runtime-common';
+import type Koa from 'koa';
+import type { DBAdapter } from '@cardstack/runtime-common';
+import { logger, SupportedMimeType } from '@cardstack/runtime-common';
 import {
   sendResponseForBadRequest,
   sendResponseForSystemError,

--- a/packages/realm-server/handlers/handle-stripe-webhook.ts
+++ b/packages/realm-server/handlers/handle-stripe-webhook.ts
@@ -1,7 +1,7 @@
-import Koa from 'koa';
+import type Koa from 'koa';
 import { fetchRequestFromContext, setContextResponse } from '../middleware';
 import stripeWebhookHandler from '@cardstack/billing/stripe-webhook-handlers';
-import { CreateRoutesArgs } from '../routes';
+import type { CreateRoutesArgs } from '../routes';
 
 export default function handleStripeWebhookRequest({
   dbAdapter,

--- a/packages/realm-server/handlers/handle-unpublish-realm.ts
+++ b/packages/realm-server/handlers/handle-unpublish-realm.ts
@@ -1,4 +1,4 @@
-import Koa from 'koa';
+import type Koa from 'koa';
 import {
   query,
   SupportedMimeType,
@@ -21,8 +21,8 @@ import {
   sendResponseForSystemError,
   setContextResponse,
 } from '../middleware';
-import { type CreateRoutesArgs } from '../routes';
-import { RealmServerTokenClaim } from '../utils/jwt';
+import type { CreateRoutesArgs } from '../routes';
+import type { RealmServerTokenClaim } from '../utils/jwt';
 
 const log = logger('handle-unpublish');
 

--- a/packages/realm-server/jwt.ts
+++ b/packages/realm-server/jwt.ts
@@ -1,5 +1,5 @@
 import jwt from 'jsonwebtoken';
-import { type TokenClaims } from '@cardstack/runtime-common';
+import type { TokenClaims } from '@cardstack/runtime-common';
 
 export function createJWT(
   claims: TokenClaims,

--- a/packages/realm-server/lib/allowed-proxy-destinations.ts
+++ b/packages/realm-server/lib/allowed-proxy-destinations.ts
@@ -1,4 +1,4 @@
-import { type CreditStrategy } from './credit-strategies';
+import type { CreditStrategy } from './credit-strategies';
 import { CreditStrategyFactory } from './credit-strategies';
 import { type DBAdapter, logger } from '@cardstack/runtime-common';
 

--- a/packages/realm-server/lib/external-endpoints-config.ts
+++ b/packages/realm-server/lib/external-endpoints-config.ts
@@ -1,4 +1,4 @@
-import { type CreditStrategy } from './credit-strategies';
+import type { CreditStrategy } from './credit-strategies';
 import { CreditStrategyFactory } from './credit-strategies';
 
 export interface ExternalEndpointConfig {

--- a/packages/realm-server/middleware/convert-accept-header-qp.ts
+++ b/packages/realm-server/middleware/convert-accept-header-qp.ts
@@ -1,4 +1,4 @@
-import { Context, Next } from 'koa';
+import type { Context, Next } from 'koa';
 import qs from 'qs';
 
 const convertAcceptHeaderMiddleware = async (

--- a/packages/realm-server/middleware/convert-auth-header-qp.ts
+++ b/packages/realm-server/middleware/convert-auth-header-qp.ts
@@ -1,4 +1,4 @@
-import { Context, Next } from 'koa';
+import type { Context, Next } from 'koa';
 import qs from 'qs';
 
 const convertAuthHeaderMiddleware = async (

--- a/packages/realm-server/middleware/index.ts
+++ b/packages/realm-server/middleware/index.ts
@@ -1,7 +1,7 @@
 import proxy from 'koa-proxies';
+import type { ResponseWithNodeStream } from '@cardstack/runtime-common';
 import {
   logger as getLogger,
-  ResponseWithNodeStream,
   webStreamToText,
 } from '@cardstack/runtime-common';
 import type Koa from 'koa';

--- a/packages/realm-server/node-realm.ts
+++ b/packages/realm-server/node-realm.ts
@@ -1,20 +1,23 @@
-import {
+import type {
   RealmAdapter,
   Kind,
   FileRef,
+  DBAdapter,
+} from '@cardstack/runtime-common';
+import {
   createResponse,
   logger,
   unixTime,
   type ResponseWithNodeStream,
   type TokenClaims,
   fetchAllSessionRooms,
-  DBAdapter,
 } from '@cardstack/runtime-common';
-import { type MatrixClient } from '@cardstack/runtime-common/matrix-client';
-import { LocalPath } from '@cardstack/runtime-common/paths';
-import { ServerResponse } from 'http';
+import type { MatrixClient } from '@cardstack/runtime-common/matrix-client';
+import type { LocalPath } from '@cardstack/runtime-common/paths';
+import type { ServerResponse } from 'http';
 import sane, { type Watcher } from 'sane';
 
+import type { ReadStream } from 'fs-extra';
 import {
   readdirSync,
   existsSync,
@@ -24,7 +27,6 @@ import {
   ensureFileSync,
   createReadStream,
   removeSync,
-  ReadStream,
 } from 'fs-extra';
 import { join } from 'path';
 import { Duplex } from 'node:stream';

--- a/packages/realm-server/prerender/manager-server.ts
+++ b/packages/realm-server/prerender/manager-server.ts
@@ -1,7 +1,8 @@
 import '../instrument';
 import '../setup-logger';
 import { logger } from '@cardstack/runtime-common';
-import { Server, createServer } from 'http';
+import type { Server } from 'http';
+import { createServer } from 'http';
 import yargs from 'yargs';
 import { buildPrerenderManagerApp } from './manager-app';
 

--- a/packages/realm-server/prerender/prerender-app.ts
+++ b/packages/realm-server/prerender/prerender-app.ts
@@ -1,6 +1,7 @@
 import Koa from 'koa';
 import Router from '@koa/router';
-import { Server, createServer } from 'http';
+import type { Server } from 'http';
+import { createServer } from 'http';
 import * as Sentry from '@sentry/node';
 import {
   logger,

--- a/packages/realm-server/prerender/prerender-server.ts
+++ b/packages/realm-server/prerender/prerender-server.ts
@@ -2,7 +2,7 @@ import '../instrument';
 import '../setup-logger';
 import { logger } from '@cardstack/runtime-common';
 import yargs from 'yargs';
-import { Server } from 'http';
+import type { Server } from 'http';
 import { createPrerenderHttpServer } from './prerender-app';
 
 let log = logger('prerender-server');

--- a/packages/realm-server/prerender/prerenderer.ts
+++ b/packages/realm-server/prerender/prerenderer.ts
@@ -16,6 +16,7 @@ import puppeteer, {
   type Page,
 } from 'puppeteer';
 import { createJWT } from '../jwt';
+import type { RenderCapture } from './utils';
 import {
   captureResult,
   isRenderError,
@@ -23,7 +24,6 @@ import {
   renderHTML,
   renderIcon,
   renderMeta,
-  RenderCapture,
   type CaptureOptions,
   withTimeout,
   transitionTo,

--- a/packages/realm-server/prerender/utils.ts
+++ b/packages/realm-server/prerender/utils.ts
@@ -6,7 +6,7 @@ import {
   type RenderError,
 } from '@cardstack/runtime-common';
 
-import { type Page } from 'puppeteer';
+import type { Page } from 'puppeteer';
 
 const log = logger('prerenderer');
 

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -1,11 +1,11 @@
-import {
-  type DBAdapter,
-  type QueuePublisher,
-  type Realm,
-  type VirtualNetwork,
-  RealmInfo,
+import type { RealmInfo } from '@cardstack/runtime-common';
+import type {
+  DBAdapter,
+  QueuePublisher,
+  Realm,
+  VirtualNetwork,
 } from '@cardstack/runtime-common';
-import { MatrixClient } from '@cardstack/runtime-common/matrix-client';
+import type { MatrixClient } from '@cardstack/runtime-common/matrix-client';
 import Router from '@koa/router';
 import handleCreateSessionRequest from './handlers/handle-create-session';
 import handleCreateRealmRequest from './handlers/handle-create-realm';
@@ -20,7 +20,7 @@ import {
   livenessCheck,
   grafanaAuthorization,
 } from './middleware';
-import Koa from 'koa';
+import type Koa from 'koa';
 import handleCreateUserRequest from './handlers/handle-create-user';
 import handleQueueStatusRequest from './handlers/handle-queue-status';
 import handleReindex from './handlers/handle-reindex';

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -1,6 +1,7 @@
 import Koa from 'koa';
 import cors from '@koa/cors';
 import { Memoize } from 'typescript-memoize';
+import type { RealmInfo } from '@cardstack/runtime-common';
 import {
   Realm,
   logger,
@@ -14,7 +15,6 @@ import {
   type QueuePublisher,
   DEFAULT_PERMISSIONS,
   PUBLISHED_DIRECTORY_NAME,
-  RealmInfo,
   fetchSessionRoom,
   REALM_SERVER_REALM,
 } from '@cardstack/runtime-common';
@@ -41,8 +41,8 @@ import merge from 'lodash/merge';
 
 import { extractSupportedMimeType } from '@cardstack/runtime-common/router';
 import * as Sentry from '@sentry/node';
+import type { MatrixClient } from '@cardstack/runtime-common/matrix-client';
 import {
-  MatrixClient,
   passwordFromSeed,
   getMatrixUsername,
 } from '@cardstack/runtime-common/matrix-client';

--- a/packages/realm-server/stream.ts
+++ b/packages/realm-server/stream.ts
@@ -1,4 +1,4 @@
-import { Readable } from 'stream';
+import type { Readable } from 'stream';
 
 export async function nodeStreamToText(stream: Readable): Promise<string> {
   const chunks: Buffer[] = [];

--- a/packages/realm-server/tests/atomic-endpoints-test.ts
+++ b/packages/realm-server/tests/atomic-endpoints-test.ts
@@ -1,13 +1,12 @@
 import { module, test } from 'qunit';
-import { Test, SuperTest } from 'supertest';
+import type { Test, SuperTest } from 'supertest';
 import { basename } from 'path';
-import { Server } from 'http';
-import { type DirResult } from 'tmp';
+import type { Server } from 'http';
+import type { DirResult } from 'tmp';
+import type { Realm, RealmAdapter } from '@cardstack/runtime-common';
 import {
-  Realm,
   type LooseSingleCardDocument,
   SupportedMimeType,
-  RealmAdapter,
 } from '@cardstack/runtime-common';
 import {
   setupBaseRealmServer,

--- a/packages/realm-server/tests/billing-test.ts
+++ b/packages/realm-server/tests/billing-test.ts
@@ -1,12 +1,11 @@
-import {
+import type {
   LedgerEntry,
   Plan,
   Subscription,
   SubscriptionCycle,
   User,
-  param,
-  query,
 } from '@cardstack/runtime-common';
+import { param, query } from '@cardstack/runtime-common';
 import { module, test } from 'qunit';
 import {
   fetchSubscriptionsByUserId,
@@ -26,7 +25,7 @@ import {
   spendCredits,
 } from '@cardstack/billing/billing-queries';
 
-import {
+import type {
   StripeInvoicePaymentSucceededWebhookEvent,
   StripeSubscriptionDeletedWebhookEvent,
   StripeCheckoutSessionCompletedWebhookEvent,

--- a/packages/realm-server/tests/boxel-domain-availability-test.ts
+++ b/packages/realm-server/tests/boxel-domain-availability-test.ts
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import { basename, join } from 'path';
-import { PgAdapter } from '@cardstack/postgres';
-import { query, insert, asExpressions, User } from '@cardstack/runtime-common';
+import type { PgAdapter } from '@cardstack/postgres';
+import type { User } from '@cardstack/runtime-common';
+import { query, insert, asExpressions } from '@cardstack/runtime-common';
 import {
   setupDB,
   insertUser,
@@ -11,13 +12,12 @@ import {
   closeServer,
   setupBaseRealmServer,
 } from './helpers';
-import {
-  RealmServerTokenClaim,
-  createJWT as createRealmServerJWT,
-} from '../utils/jwt';
+import type { RealmServerTokenClaim } from '../utils/jwt';
+import { createJWT as createRealmServerJWT } from '../utils/jwt';
 import { realmSecretSeed } from './helpers';
-import supertest, { SuperTest, Test } from 'supertest';
-import { Server } from 'http';
+import type { SuperTest, Test } from 'supertest';
+import supertest from 'supertest';
+import type { Server } from 'http';
 import { dirSync, type DirResult } from 'tmp';
 import { copySync, ensureDirSync } from 'fs-extra';
 

--- a/packages/realm-server/tests/card-dependencies-endpoint-test.ts
+++ b/packages/realm-server/tests/card-dependencies-endpoint-test.ts
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
-import { Test, SuperTest } from 'supertest';
+import type { Test, SuperTest } from 'supertest';
 import { basename } from 'path';
-import { Server } from 'http';
-import { type DirResult } from 'tmp';
+import type { Server } from 'http';
+import type { DirResult } from 'tmp';
 
-import { Realm } from '@cardstack/runtime-common';
+import type { Realm } from '@cardstack/runtime-common';
 import {
   setupBaseRealmServer,
   setupPermissionedRealm,

--- a/packages/realm-server/tests/card-endpoints-test.ts
+++ b/packages/realm-server/tests/card-endpoints-test.ts
@@ -1,17 +1,17 @@
 import { module, test } from 'qunit';
-import { Test, SuperTest } from 'supertest';
+import type { Test, SuperTest } from 'supertest';
 import { join, basename } from 'path';
-import { Server } from 'http';
-import { type DirResult } from 'tmp';
+import type { Server } from 'http';
+import type { DirResult } from 'tmp';
 import { existsSync, readJSONSync } from 'fs-extra';
+import type { Realm } from '@cardstack/runtime-common';
 import {
   isSingleCardDocument,
-  Realm,
   type LooseSingleCardDocument,
   type SingleCardDocument,
 } from '@cardstack/runtime-common';
 import { stringify } from 'qs';
-import { Query } from '@cardstack/runtime-common/query';
+import type { Query } from '@cardstack/runtime-common/query';
 import {
   setupBaseRealmServer,
   setupPermissionedRealm,
@@ -28,7 +28,7 @@ import {
 import { expectIncrementalIndexEvent } from './helpers/indexing';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 import { resetCatalogRealms } from '../handlers/handle-fetch-catalog-realms';
-import { PgAdapter } from '@cardstack/postgres';
+import type { PgAdapter } from '@cardstack/postgres';
 
 module(basename(__filename), function () {
   module('Realm-specific Endpoints | card URLs', function (hooks) {

--- a/packages/realm-server/tests/card-source-endpoints-test.ts
+++ b/packages/realm-server/tests/card-source-endpoints-test.ts
@@ -1,16 +1,16 @@
 import { module, test } from 'qunit';
-import { Test, SuperTest } from 'supertest';
+import type { Test, SuperTest } from 'supertest';
 import { join, resolve, basename } from 'path';
-import { Server } from 'http';
-import { type DirResult } from 'tmp';
+import type { Server } from 'http';
+import type { DirResult } from 'tmp';
 import { existsSync, readFileSync } from 'fs-extra';
 import {
   cardSrc,
   compiledCard,
 } from '@cardstack/runtime-common/etc/test-fixtures';
+import type { Realm } from '@cardstack/runtime-common';
 import {
   RealmPaths,
-  Realm,
   type LooseSingleCardDocument,
 } from '@cardstack/runtime-common';
 import {

--- a/packages/realm-server/tests/claim-boxel-domain-test.ts
+++ b/packages/realm-server/tests/claim-boxel-domain-test.ts
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import { basename, join } from 'path';
-import { PgAdapter } from '@cardstack/postgres';
-import { query, insert, asExpressions, User } from '@cardstack/runtime-common';
+import type { PgAdapter } from '@cardstack/postgres';
+import type { User } from '@cardstack/runtime-common';
+import { query, insert, asExpressions } from '@cardstack/runtime-common';
 import {
   setupDB,
   insertUser,
@@ -12,12 +13,11 @@ import {
   setupBaseRealmServer,
   realmSecretSeed,
 } from './helpers';
-import {
-  RealmServerTokenClaim,
-  createJWT as createRealmServerJWT,
-} from '../utils/jwt';
-import supertest, { SuperTest, Test } from 'supertest';
-import { Server } from 'http';
+import type { RealmServerTokenClaim } from '../utils/jwt';
+import { createJWT as createRealmServerJWT } from '../utils/jwt';
+import type { SuperTest, Test } from 'supertest';
+import supertest from 'supertest';
+import type { Server } from 'http';
 import { dirSync, type DirResult } from 'tmp';
 import { copySync, ensureDirSync } from 'fs-extra';
 

--- a/packages/realm-server/tests/delete-boxel-claimed-domain-test.ts
+++ b/packages/realm-server/tests/delete-boxel-claimed-domain-test.ts
@@ -1,11 +1,11 @@
 import { module, test } from 'qunit';
 import { basename, join } from 'path';
-import { PgAdapter } from '@cardstack/postgres';
+import type { PgAdapter } from '@cardstack/postgres';
+import type { User } from '@cardstack/runtime-common';
 import {
   query,
   insert,
   asExpressions,
-  User,
   uuidv4,
 } from '@cardstack/runtime-common';
 import {
@@ -17,13 +17,12 @@ import {
   closeServer,
   setupBaseRealmServer,
 } from './helpers';
-import {
-  RealmServerTokenClaim,
-  createJWT as createRealmServerJWT,
-} from '../utils/jwt';
+import type { RealmServerTokenClaim } from '../utils/jwt';
+import { createJWT as createRealmServerJWT } from '../utils/jwt';
 import { realmSecretSeed } from './helpers';
-import supertest, { SuperTest, Test } from 'supertest';
-import { Server } from 'http';
+import type { SuperTest, Test } from 'supertest';
+import supertest from 'supertest';
+import type { Server } from 'http';
 import { dirSync, type DirResult } from 'tmp';
 import { copySync, ensureDirSync } from 'fs-extra';
 

--- a/packages/realm-server/tests/file-watcher-events-test.ts
+++ b/packages/realm-server/tests/file-watcher-events-test.ts
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
-import { Test, SuperTest } from 'supertest';
+import type { Test, SuperTest } from 'supertest';
 import { join, basename } from 'path';
-import { Server } from 'http';
-import { type DirResult } from 'tmp';
+import type { Server } from 'http';
+import type { DirResult } from 'tmp';
 import { removeSync, writeJSONSync } from 'fs-extra';
-import { Realm } from '@cardstack/runtime-common';
+import type { Realm } from '@cardstack/runtime-common';
 import {
   findRealmEvent,
   setupBaseRealmServer,
@@ -14,7 +14,7 @@ import {
   waitForRealmEvent,
 } from './helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
-import { PgAdapter } from '@cardstack/postgres';
+import type { PgAdapter } from '@cardstack/postgres';
 
 module(basename(__filename), function () {
   module('file watcher realm events', function (hooks) {

--- a/packages/realm-server/tests/get-boxel-claimed-domain-test.ts
+++ b/packages/realm-server/tests/get-boxel-claimed-domain-test.ts
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import { basename, join } from 'path';
-import { PgAdapter } from '@cardstack/postgres';
-import { query, insert, asExpressions, User } from '@cardstack/runtime-common';
+import type { PgAdapter } from '@cardstack/postgres';
+import type { User } from '@cardstack/runtime-common';
+import { query, insert, asExpressions } from '@cardstack/runtime-common';
 import {
   setupDB,
   insertUser,
@@ -12,12 +13,11 @@ import {
   setupBaseRealmServer,
   realmSecretSeed,
 } from './helpers';
-import {
-  RealmServerTokenClaim,
-  createJWT as createRealmServerJWT,
-} from '../utils/jwt';
-import supertest, { SuperTest, Test } from 'supertest';
-import { Server } from 'http';
+import type { RealmServerTokenClaim } from '../utils/jwt';
+import { createJWT as createRealmServerJWT } from '../utils/jwt';
+import type { SuperTest, Test } from 'supertest';
+import supertest from 'supertest';
+import type { Server } from 'http';
 import { dirSync, type DirResult } from 'tmp';
 import { copySync, ensureDirSync } from 'fs-extra';
 

--- a/packages/realm-server/tests/headless-chrome-indexing-test.ts
+++ b/packages/realm-server/tests/headless-chrome-indexing-test.ts
@@ -1,14 +1,16 @@
 import { module, test } from 'qunit';
 import { dirSync } from 'tmp';
-import {
-  type IndexedInstance,
-  type QueuePublisher,
-  type QueueRunner,
+import type {
   DBAdapter,
   LooseSingleCardDocument,
   Realm,
   RealmPermissions,
   RealmAdapter,
+} from '@cardstack/runtime-common';
+import type {
+  IndexedInstance,
+  QueuePublisher,
+  QueueRunner,
 } from '@cardstack/runtime-common';
 import {
   setupBaseRealmServer,
@@ -25,10 +27,10 @@ import {
 import stripScopedCSSAttributes from '@cardstack/runtime-common/helpers/strip-scoped-css-attributes';
 import { join, basename } from 'path';
 import { resetCatalogRealms } from '../handlers/handle-fetch-catalog-realms';
-import {
-  type PgQueueRunner,
-  type PgAdapter,
-  type PgQueuePublisher,
+import type {
+  PgQueueRunner,
+  PgAdapter,
+  PgQueuePublisher,
 } from '@cardstack/postgres';
 
 function trimCardContainer(text: string) {

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -8,11 +8,17 @@ import {
 } from 'fs-extra';
 import { NodeAdapter } from '../../node-realm';
 import { resolve, join } from 'path';
+import type {
+  LooseSingleCardDocument,
+  RealmPermissions,
+  User,
+  Subscription,
+  Plan,
+  RealmAdapter,
+} from '@cardstack/runtime-common';
 import {
   Realm,
-  LooseSingleCardDocument,
   baseRealm,
-  RealmPermissions,
   VirtualNetwork,
   Worker,
   RunnerOptionsManager,
@@ -25,10 +31,6 @@ import {
   unixTime,
   uuidv4,
   RealmPaths,
-  User,
-  Subscription,
-  Plan,
-  RealmAdapter,
   PUBLISHED_DIRECTORY_NAME,
   clearSessionRooms,
   upsertSessionRoom,
@@ -50,10 +52,11 @@ import {
   PgQueuePublisher,
   PgQueueRunner,
 } from '@cardstack/postgres';
-import { Server } from 'http';
+import type { Server } from 'http';
 import { MatrixClient } from '@cardstack/runtime-common/matrix-client';
 
-import supertest, { SuperTest, Test } from 'supertest';
+import type { SuperTest, Test } from 'supertest';
+import supertest from 'supertest';
 import { APP_BOXEL_REALM_EVENT_TYPE } from '@cardstack/runtime-common/matrix-constants';
 import type {
   IncrementalIndexEventContent,

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -1,13 +1,13 @@
 import { module, test } from 'qunit';
 import { dirSync } from 'tmp';
-import {
+import type {
   DBAdapter,
   LooseSingleCardDocument,
   Realm,
   RealmPermissions,
-  type IndexedInstance,
   RealmAdapter,
 } from '@cardstack/runtime-common';
+import type { IndexedInstance } from '@cardstack/runtime-common';
 import {
   createRealm,
   testRealm,

--- a/packages/realm-server/tests/permissions/permission-checker-test.ts
+++ b/packages/realm-server/tests/permissions/permission-checker-test.ts
@@ -1,4 +1,4 @@
-import { MatrixClient } from '@cardstack/runtime-common/matrix-client';
+import type { MatrixClient } from '@cardstack/runtime-common/matrix-client';
 import RealmPermissionChecker from '@cardstack/runtime-common/realm-permission-checker';
 import { basename } from 'path';
 import { module, test } from 'qunit';

--- a/packages/realm-server/tests/prerender-manager-test.ts
+++ b/packages/realm-server/tests/prerender-manager-test.ts
@@ -1,9 +1,11 @@
 import { module, test } from 'qunit';
-import supertest, { SuperTest, Test } from 'supertest';
+import type { SuperTest, Test } from 'supertest';
+import supertest from 'supertest';
 import { basename } from 'path';
 import Koa from 'koa';
 import Router from '@koa/router';
-import { Server, createServer } from 'http';
+import type { Server } from 'http';
+import { createServer } from 'http';
 import { buildPrerenderManagerApp } from '../prerender/manager-app';
 
 module(basename(__filename), function () {

--- a/packages/realm-server/tests/prerender-server-test.ts
+++ b/packages/realm-server/tests/prerender-server-test.ts
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
-import supertest, { SuperTest, Test } from 'supertest';
+import type { SuperTest, Test } from 'supertest';
+import supertest from 'supertest';
 import { basename } from 'path';
 
 import {
@@ -10,7 +11,7 @@ import {
   testRealmHref,
 } from './helpers';
 import { buildPrerenderApp } from '../prerender/prerender-app';
-import { Prerenderer } from '../prerender';
+import type { Prerenderer } from '../prerender';
 import { baseCardRef } from '@cardstack/runtime-common';
 
 module(basename(__filename), function () {

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
 import { basename } from 'path';
-import {
-  type RealmPermissions,
-  type Realm,
-  type RealmAdapter,
-  type RenderResponse,
+import type {
+  RealmPermissions,
+  Realm,
+  RealmAdapter,
+  RenderResponse,
 } from '@cardstack/runtime-common';
 import { Prerenderer } from '../prerender/index';
 

--- a/packages/realm-server/tests/publish-unpublish-realm-test.ts
+++ b/packages/realm-server/tests/publish-unpublish-realm-test.ts
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
-import supertest, { SuperTest, Test } from 'supertest';
+import type { SuperTest, Test } from 'supertest';
+import supertest from 'supertest';
 import { v4 as uuidv4 } from 'uuid';
 import {
   existsSync,
@@ -9,16 +10,15 @@ import {
   readJsonSync,
 } from 'fs-extra';
 import { basename, join } from 'path';
-import { Server } from 'http';
+import type { Server } from 'http';
 import { dirSync, type DirResult } from 'tmp';
+import type { Realm, VirtualNetwork } from '@cardstack/runtime-common';
 import {
-  Realm,
   DEFAULT_PERMISSIONS,
-  VirtualNetwork,
   type QueuePublisher,
   type QueueRunner,
 } from '@cardstack/runtime-common';
-import { PgAdapter } from '@cardstack/postgres';
+import type { PgAdapter } from '@cardstack/postgres';
 import {
   setupDB,
   setupPermissionedRealm,

--- a/packages/realm-server/tests/queries-test.ts
+++ b/packages/realm-server/tests/queries-test.ts
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { basename } from 'path';
 import { v4 as uuidv4 } from 'uuid';
 
-import { PgAdapter } from '@cardstack/postgres';
+import type { PgAdapter } from '@cardstack/postgres';
 import {
   asExpressions,
   fetchUserPermissions,

--- a/packages/realm-server/tests/queue-test.ts
+++ b/packages/realm-server/tests/queue-test.ts
@@ -7,10 +7,7 @@ import {
   PgQueueRunner,
 } from '@cardstack/postgres';
 
-import {
-  type QueuePublisher,
-  type QueueRunner,
-} from '@cardstack/runtime-common';
+import type { QueuePublisher, QueueRunner } from '@cardstack/runtime-common';
 import { runSharedTest } from '@cardstack/runtime-common/helpers';
 import queueTests from '@cardstack/runtime-common/tests/queue-test';
 import { basename } from 'path';

--- a/packages/realm-server/tests/realm-auth-test.ts
+++ b/packages/realm-server/tests/realm-auth-test.ts
@@ -3,7 +3,7 @@ import type { SuperTest, Test as SupertestTest } from 'supertest';
 import sinon from 'sinon';
 import { basename } from 'path';
 
-import { PgAdapter } from '@cardstack/postgres';
+import type { PgAdapter } from '@cardstack/postgres';
 import { MatrixClient } from '@cardstack/runtime-common/matrix-client';
 import { fetchSessionRoom } from '@cardstack/runtime-common/db-queries/session-room-queries';
 

--- a/packages/realm-server/tests/realm-endpoints-test.ts
+++ b/packages/realm-server/tests/realm-endpoints-test.ts
@@ -1,12 +1,13 @@
 import { module, test } from 'qunit';
-import supertest, { Test, SuperTest } from 'supertest';
+import type { Test, SuperTest } from 'supertest';
+import supertest from 'supertest';
 import { join, resolve, basename } from 'path';
-import { Server } from 'http';
+import type { Server } from 'http';
 import { dirSync, type DirResult } from 'tmp';
 import { copySync, ensureDirSync } from 'fs-extra';
+import type { Realm } from '@cardstack/runtime-common';
 import {
   baseRealm,
-  Realm,
   SupportedMimeType,
   type LooseSingleCardDocument,
   type QueuePublisher,
@@ -39,7 +40,7 @@ import { expectIncrementalIndexEvent } from './helpers/indexing';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 import { RealmServer } from '../server';
 import { MatrixClient } from '@cardstack/runtime-common/matrix-client';
-import { type PgAdapter } from '@cardstack/postgres';
+import type { PgAdapter } from '@cardstack/postgres';
 
 import { APP_BOXEL_REALM_EVENT_TYPE } from '@cardstack/runtime-common/matrix-constants';
 import type {

--- a/packages/realm-server/tests/realm-endpoints/definition-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/definition-test.ts
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
-import { Test, SuperTest } from 'supertest';
+import type { Test, SuperTest } from 'supertest';
 import { basename } from 'path';
-import { Server } from 'http';
+import type { Server } from 'http';
 import qs from 'qs';
-import { type Definition, type Realm } from '@cardstack/runtime-common';
+import type { Definition, Realm } from '@cardstack/runtime-common';
 import {
   setupBaseRealmServer,
   setupPermissionedRealm,

--- a/packages/realm-server/tests/realm-endpoints/directory-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/directory-test.ts
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
-import { Test, SuperTest } from 'supertest';
+import type { Test, SuperTest } from 'supertest';
 import { join, basename } from 'path';
 import { dirSync, type DirResult } from 'tmp';
 import { copySync } from 'fs-extra';
-import { Realm } from '@cardstack/runtime-common';
+import type { Realm } from '@cardstack/runtime-common';
 import {
   setupBaseRealmServer,
   setupPermissionedRealm,

--- a/packages/realm-server/tests/realm-endpoints/info-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/info-test.ts
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
-import { Test, SuperTest } from 'supertest';
+import type { Test, SuperTest } from 'supertest';
 import { join, basename } from 'path';
-import { Server } from 'http';
+import type { Server } from 'http';
 import { dirSync, type DirResult } from 'tmp';
 import { copySync } from 'fs-extra';
-import { Realm } from '@cardstack/runtime-common';
+import type { Realm } from '@cardstack/runtime-common';
 import {
   setupBaseRealmServer,
   setupPermissionedRealm,

--- a/packages/realm-server/tests/realm-endpoints/lint-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/lint-test.ts
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
-import { Test, SuperTest } from 'supertest';
+import type { Test, SuperTest } from 'supertest';
 import { basename } from 'path';
-import { Realm } from '@cardstack/runtime-common';
+import type { Realm } from '@cardstack/runtime-common';
 import {
   setupBaseRealmServer,
   matrixURL,

--- a/packages/realm-server/tests/realm-endpoints/mtimes-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/mtimes-test.ts
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
-import { Test, SuperTest } from 'supertest';
+import type { Test, SuperTest } from 'supertest';
 import { basename } from 'path';
-import { Realm } from '@cardstack/runtime-common';
+import type { Realm } from '@cardstack/runtime-common';
 import {
   setupBaseRealmServer,
   setupPermissionedRealm,

--- a/packages/realm-server/tests/realm-endpoints/permissions-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/permissions-test.ts
@@ -1,9 +1,10 @@
 import { module, test } from 'qunit';
-import { Test, SuperTest } from 'supertest';
+import type { Test, SuperTest } from 'supertest';
 import { join, basename } from 'path';
 import { dirSync, type DirResult } from 'tmp';
 import { copySync } from 'fs-extra';
-import { Realm, fetchRealmPermissions } from '@cardstack/runtime-common';
+import type { Realm } from '@cardstack/runtime-common';
+import { fetchRealmPermissions } from '@cardstack/runtime-common';
 import {
   setupBaseRealmServer,
   setupPermissionedRealm,
@@ -13,7 +14,7 @@ import {
   createJWT,
 } from '../helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
-import { type PgAdapter } from '@cardstack/postgres';
+import type { PgAdapter } from '@cardstack/postgres';
 
 module(`realm-endpoints/${basename(__filename)}`, function () {
   module('Realm-specific Endpoints | _permissions', function (hooks) {

--- a/packages/realm-server/tests/realm-endpoints/search-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/search-test.ts
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
-import { Test, SuperTest } from 'supertest';
+import type { Test, SuperTest } from 'supertest';
 import { basename } from 'path';
-import { Realm } from '@cardstack/runtime-common';
+import type { Realm } from '@cardstack/runtime-common';
 import { stringify } from 'qs';
-import { Query } from '@cardstack/runtime-common/query';
+import type { Query } from '@cardstack/runtime-common/query';
 import {
   setupBaseRealmServer,
   setupPermissionedRealm,

--- a/packages/realm-server/tests/realm-endpoints/user-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/user-test.ts
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
-import { Test, SuperTest } from 'supertest';
+import type { Test, SuperTest } from 'supertest';
 import { join, basename } from 'path';
-import { Server } from 'http';
+import type { Server } from 'http';
 import { dirSync, type DirResult } from 'tmp';
 import { copySync } from 'fs-extra';
-import { Realm } from '@cardstack/runtime-common';
+import type { Realm } from '@cardstack/runtime-common';
 import {
   setupBaseRealmServer,
   setupPermissionedRealm,
@@ -15,7 +15,7 @@ import {
   createJWT,
 } from '../helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
-import { type PgAdapter } from '@cardstack/postgres';
+import type { PgAdapter } from '@cardstack/postgres';
 import {
   addToCreditsLedger,
   insertSubscriptionCycle,

--- a/packages/realm-server/tests/request-forward-test.ts
+++ b/packages/realm-server/tests/request-forward-test.ts
@@ -1,8 +1,9 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
-import supertest, { Test, SuperTest } from 'supertest';
+import type { Test, SuperTest } from 'supertest';
+import supertest from 'supertest';
 import { basename, join } from 'path';
-import { Server } from 'http';
+import type { Server } from 'http';
 import { dirSync, type DirResult } from 'tmp';
 import { copySync, ensureDirSync } from 'fs-extra';
 import {

--- a/packages/realm-server/tests/search-prerendered-test.ts
+++ b/packages/realm-server/tests/search-prerendered-test.ts
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
-import { Test, SuperTest } from 'supertest';
+import type { Test, SuperTest } from 'supertest';
 import { basename } from 'path';
-import { Realm } from '@cardstack/runtime-common';
+import type { Realm } from '@cardstack/runtime-common';
 import { stringify } from 'qs';
-import { Query } from '@cardstack/runtime-common/query';
+import type { Query } from '@cardstack/runtime-common/query';
 import {
   setupBaseRealmServer,
   setupPermissionedRealm,

--- a/packages/realm-server/tests/server-endpoints-test.ts
+++ b/packages/realm-server/tests/server-endpoints-test.ts
@@ -1,24 +1,24 @@
 import { module, test } from 'qunit';
-import supertest, { Test, SuperTest } from 'supertest';
+import type { Test, SuperTest } from 'supertest';
+import supertest from 'supertest';
 import { join, basename } from 'path';
-import { Server } from 'http';
+import type { Server } from 'http';
 import { dirSync, type DirResult } from 'tmp';
 import { copySync, existsSync, ensureDirSync, readJSONSync } from 'fs-extra';
+import type { Realm, VirtualNetwork } from '@cardstack/runtime-common';
 import {
   Deferred,
-  Realm,
   fetchRealmPermissions,
   baseCardRef,
   type SingleCardDocument,
   type QueuePublisher,
   type QueueRunner,
   DEFAULT_PERMISSIONS,
-  VirtualNetwork,
 } from '@cardstack/runtime-common';
 import { cardSrc } from '@cardstack/runtime-common/etc/test-fixtures';
 import { stringify } from 'qs';
 import { v4 as uuidv4 } from 'uuid';
-import { Query } from '@cardstack/runtime-common/query';
+import type { Query } from '@cardstack/runtime-common/query';
 import {
   setupBaseRealmServer,
   setupPermissionedRealm,
@@ -39,19 +39,17 @@ import {
   grafanaSecret,
 } from './helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
-import { RealmServer } from '../server';
+import type { RealmServer } from '../server';
 import { MatrixClient } from '@cardstack/runtime-common/matrix-client';
 import jwt from 'jsonwebtoken';
-import { type CardCollectionDocument } from '@cardstack/runtime-common/document-types';
-import { type PgAdapter } from '@cardstack/postgres';
+import type { CardCollectionDocument } from '@cardstack/runtime-common/document-types';
+import type { PgAdapter } from '@cardstack/postgres';
 import {
   getUserByMatrixUserId,
   sumUpCreditsLedger,
 } from '@cardstack/billing/billing-queries';
-import {
-  createJWT as createRealmServerJWT,
-  RealmServerTokenClaim,
-} from '../utils/jwt';
+import type { RealmServerTokenClaim } from '../utils/jwt';
+import { createJWT as createRealmServerJWT } from '../utils/jwt';
 import Stripe from 'stripe';
 import sinon from 'sinon';
 import { getStripe } from '@cardstack/billing/stripe-webhook-handlers/stripe';

--- a/packages/realm-server/tests/types-endpoint-test.ts
+++ b/packages/realm-server/tests/types-endpoint-test.ts
@@ -1,14 +1,11 @@
 import { module, test } from 'qunit';
-import { Test, SuperTest } from 'supertest';
+import type { Test, SuperTest } from 'supertest';
 import { join, basename } from 'path';
-import { Server } from 'http';
-import { type DirResult } from 'tmp';
+import type { Server } from 'http';
+import type { DirResult } from 'tmp';
 import { copySync, ensureDirSync } from 'fs-extra';
-import {
-  Realm,
-  type QueuePublisher,
-  type QueueRunner,
-} from '@cardstack/runtime-common';
+import type { Realm } from '@cardstack/runtime-common';
+import type { QueuePublisher, QueueRunner } from '@cardstack/runtime-common';
 import {
   setupBaseRealmServer,
   setupPermissionedRealm,
@@ -20,7 +17,7 @@ import {
   closeServer,
 } from './helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
-import { type PgAdapter } from '@cardstack/postgres';
+import type { PgAdapter } from '@cardstack/postgres';
 import { resetCatalogRealms } from '../handlers/handle-fetch-catalog-realms';
 
 const testRealm2URL = new URL('http://127.0.0.1:4445/test/');

--- a/packages/realm-server/tests/virtual-network-test.ts
+++ b/packages/realm-server/tests/virtual-network-test.ts
@@ -1,7 +1,5 @@
-import {
-  ResponseWithNodeStream,
-  VirtualNetwork,
-} from '@cardstack/runtime-common';
+import type { ResponseWithNodeStream } from '@cardstack/runtime-common';
+import { VirtualNetwork } from '@cardstack/runtime-common';
 import { module, test } from 'qunit';
 import { basename } from 'path';
 

--- a/packages/realm-server/worker-manager.ts
+++ b/packages/realm-server/worker-manager.ts
@@ -19,7 +19,7 @@ import pluralize from 'pluralize';
 import Koa from 'koa';
 import Router from '@koa/router';
 import { ecsMetadata, fullRequestURL, livenessCheck } from './middleware';
-import { Server } from 'http';
+import type { Server } from 'http';
 import { PgAdapter } from '@cardstack/postgres';
 
 /* About the Worker Manager

--- a/packages/runtime-common/ai/history.ts
+++ b/packages/runtime-common/ai/history.ts
@@ -7,7 +7,8 @@ import type {
   MessageEvent,
   RealmServerEvent,
 } from 'https://cardstack.com/base/matrix-event';
-import { MatrixClient, type IRoomEvent } from 'matrix-js-sdk';
+import type { MatrixClient } from 'matrix-js-sdk';
+import type { IRoomEvent } from 'matrix-js-sdk';
 
 import { logger } from '../log';
 import {
@@ -22,7 +23,7 @@ import {
 } from '../matrix-constants';
 
 import { downloadFile } from './matrix-utils';
-import { SerializedFileDef } from 'https://cardstack.com/base/file-api';
+import type { SerializedFileDef } from 'https://cardstack.com/base/file-api';
 import { HistoryConstructionError } from './types';
 
 function getLog() {

--- a/packages/runtime-common/ai/matrix-utils.ts
+++ b/packages/runtime-common/ai/matrix-utils.ts
@@ -1,8 +1,10 @@
-import { IContent, MatrixClient, Method } from 'matrix-js-sdk';
+import type { IContent, MatrixClient } from 'matrix-js-sdk';
+import { Method } from 'matrix-js-sdk';
 import { REPLACE_MARKER, SEARCH_MARKER, SEPARATOR_MARKER } from '../constants';
 import { logger } from '../log';
 import { OpenAIError } from 'openai/error';
-import { CommandRequest, encodeCommandRequests } from '../commands';
+import type { CommandRequest } from '../commands';
+import { encodeCommandRequests } from '../commands';
 import {
   APP_BOXEL_COMMAND_REQUESTS_KEY,
   APP_BOXEL_REASONING_CONTENT_KEY,
@@ -12,10 +14,10 @@ import {
   APP_BOXEL_CODE_PATCH_RESULT_EVENT_TYPE,
 } from '../matrix-constants';
 import type { MatrixEvent as DiscreteMatrixEvent } from 'https://cardstack.com/base/matrix-event';
-import { MatrixEvent } from 'matrix-js-sdk';
-import { PromptParts } from './types';
+import type { MatrixEvent } from 'matrix-js-sdk';
+import type { PromptParts } from './types';
 import { encodeUri } from 'matrix-js-sdk/lib/utils';
-import { SerializedFileDef } from 'https://cardstack.com/base/file-api';
+import type { SerializedFileDef } from 'https://cardstack.com/base/file-api';
 
 function getLog() {
   return logger('ai-bot');

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -1,5 +1,5 @@
-import { MatrixClient, MatrixEvent } from 'matrix-js-sdk';
-import {
+import type { MatrixClient, MatrixEvent } from 'matrix-js-sdk';
+import type {
   ChatCompletionMessageToolCall,
   OpenAIPromptMessage,
   PromptParts,
@@ -37,12 +37,12 @@ import {
   APP_BOXEL_ACTIVE_LLM,
   DEFAULT_LLM,
 } from '../matrix-constants';
-import {
+import type {
   CardResource,
   LooseCardResource,
   LooseSingleCardDocument,
 } from '../index';
-import { ToolChoice } from '../helpers/ai';
+import type { ToolChoice } from '../helpers/ai';
 import { logger } from '../log';
 
 import { SKILL_INSTRUCTIONS_MESSAGE, SYSTEM_MESSAGE } from './constants';

--- a/packages/runtime-common/ai/types.ts
+++ b/packages/runtime-common/ai/types.ts
@@ -3,7 +3,7 @@ import type {
   Tool,
 } from 'https://cardstack.com/base/matrix-event';
 import type { LooseCardResource } from '../index';
-import { ToolChoice } from '../helpers/ai';
+import type { ToolChoice } from '../helpers/ai';
 
 export interface ChatCompletionMessageToolCall {
   id: string;

--- a/packages/runtime-common/atomic-document.ts
+++ b/packages/runtime-common/atomic-document.ts
@@ -1,10 +1,7 @@
-import { ErrorDetails } from './error';
-import {
-  ModuleResource,
-  isCardResource,
-  isModuleResource,
-} from './resource-types';
-import { LooseCardResource } from './index';
+import type { ErrorDetails } from './error';
+import type { ModuleResource } from './resource-types';
+import { isCardResource, isModuleResource } from './resource-types';
+import type { LooseCardResource } from './index';
 
 export type AtomicOperationType = 'add' | 'update' | 'remove';
 

--- a/packages/runtime-common/authorization-middleware.ts
+++ b/packages/runtime-common/authorization-middleware.ts
@@ -1,4 +1,4 @@
-import { FetcherMiddlewareHandler } from './fetcher';
+import type { FetcherMiddlewareHandler } from './fetcher';
 
 export interface TokenSource {
   token(url: string): string | undefined;

--- a/packages/runtime-common/babel-options.ts
+++ b/packages/runtime-common/babel-options.ts
@@ -1,4 +1,4 @@
-import { ParserOptions, ParserPlugin } from '@babel/parser';
+import type { ParserOptions, ParserPlugin } from '@babel/parser';
 
 export type Overrides = Partial<{
   sourceType: ParserOptions['sourceType'];

--- a/packages/runtime-common/catalog.ts
+++ b/packages/runtime-common/catalog.ts
@@ -1,12 +1,13 @@
 import { isEqual, uniqWith, kebabCase } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
-import { Spec } from 'https://cardstack.com/base/spec';
-import { CardDef } from 'https://cardstack.com/base/card-api';
+import type { Spec } from 'https://cardstack.com/base/spec';
+import type { CardDef } from 'https://cardstack.com/base/card-api';
 import { RealmPaths, join } from './paths';
-import { ResolvedCodeRef, resolveAdoptedCodeRef } from './code-ref';
+import type { ResolvedCodeRef } from './code-ref';
+import { resolveAdoptedCodeRef } from './code-ref';
 import { realmURL } from './constants';
 import { logger } from './log';
-import { LocalPath } from './paths';
+import type { LocalPath } from './paths';
 
 // @ts-ignore TODO: fix catalog types in runtime-common
 import type { Listing } from '@cardstack/catalog/listing/listing';

--- a/packages/runtime-common/code-ref.ts
+++ b/packages/runtime-common/code-ref.ts
@@ -1,10 +1,10 @@
-import {
-  type BaseDefConstructor,
-  type Field,
-  type BaseDef,
-  type CardDef,
-  type FieldDef,
-  type FieldConstructor,
+import type {
+  BaseDefConstructor,
+  Field,
+  BaseDef,
+  CardDef,
+  FieldDef,
+  FieldConstructor,
 } from 'https://cardstack.com/base/card-api';
 import { Loader } from './loader';
 import {

--- a/packages/runtime-common/commands.ts
+++ b/packages/runtime-common/commands.ts
@@ -4,14 +4,11 @@ import {
   codeRefWithAbsoluteURL,
 } from './code-ref';
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
-import { CardDefConstructor } from 'https://cardstack.com/base/card-api';
-import {
-  AttributesSchema,
-  CardSchema,
-  generateJsonSchemaForCardType,
-} from './helpers/ai';
+import type { CardDefConstructor } from 'https://cardstack.com/base/card-api';
+import type { AttributesSchema, CardSchema } from './helpers/ai';
+import { generateJsonSchemaForCardType } from './helpers/ai';
 import { simpleHash } from './utils';
-import { EncodedCommandRequest } from '../base/matrix-event';
+import type { EncodedCommandRequest } from '../base/matrix-event';
 
 export interface CommandRequest {
   id: string;

--- a/packages/runtime-common/constants.ts
+++ b/packages/runtime-common/constants.ts
@@ -1,6 +1,6 @@
 import { RealmPaths } from './paths';
 import type { ResolvedCodeRef } from './code-ref';
-import { RealmPermissions } from './index';
+import type { RealmPermissions } from './index';
 
 export const baseRealm = new RealmPaths(new URL('https://cardstack.com/base/'));
 

--- a/packages/runtime-common/create-response.ts
+++ b/packages/runtime-common/create-response.ts
@@ -1,4 +1,4 @@
-import { RequestContext } from './realm';
+import type { RequestContext } from './realm';
 
 interface CreateResponseArgs {
   body?: BodyInit | null | undefined;

--- a/packages/runtime-common/db-queries/realm-permission-queries.ts
+++ b/packages/runtime-common/db-queries/realm-permission-queries.ts
@@ -1,5 +1,6 @@
-import { DBAdapter } from '../db';
-import { RealmAction, type RealmPermissions } from '../index';
+import type { DBAdapter } from '../db';
+import type { RealmAction } from '../index';
+import type { RealmPermissions } from '../index';
 import { query, asExpressions, param, upsert } from '../expression';
 import { getMatrixUsername } from '../matrix-client';
 

--- a/packages/runtime-common/db-queries/user-queries.ts
+++ b/packages/runtime-common/db-queries/user-queries.ts
@@ -1,7 +1,7 @@
-import { DBAdapter } from '../db';
+import type { DBAdapter } from '../db';
 
 import { query, asExpressions, insert } from '../expression';
-import { type User } from './db-types';
+import type { User } from './db-types';
 
 export async function insertUser(
   dbAdapter: DBAdapter,

--- a/packages/runtime-common/db.ts
+++ b/packages/runtime-common/db.ts
@@ -1,4 +1,4 @@
-import { type PgPrimitive } from './index';
+import type { PgPrimitive } from './index';
 
 export interface TypeCoercion {
   [column: string]: 'BOOLEAN' | 'JSON' | 'VARCHAR';

--- a/packages/runtime-common/definitions.ts
+++ b/packages/runtime-common/definitions.ts
@@ -7,7 +7,7 @@ import {
   type SerializerName,
 } from './index';
 
-import { BaseDef } from 'https://cardstack.com/base/card-api';
+import type { BaseDef } from 'https://cardstack.com/base/card-api';
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
 
 // we are only recursing 3 levels deep when we see a card def that we have already encountered,

--- a/packages/runtime-common/document-types.ts
+++ b/packages/runtime-common/document-types.ts
@@ -1,6 +1,6 @@
-import { RealmInfo } from './realm';
-import { QueryResultsMeta, PrerenderedCard } from './index-query-engine';
-import { type CardTypeSummary } from './index-structure';
+import type { RealmInfo } from './realm';
+import type { QueryResultsMeta, PrerenderedCard } from './index-query-engine';
+import type { CardTypeSummary } from './index-structure';
 import {
   type CardResource,
   type PrerenderedCardResource,

--- a/packages/runtime-common/error.ts
+++ b/packages/runtime-common/error.ts
@@ -1,7 +1,7 @@
 import { getReasonPhrase } from 'http-status-codes';
 import status from 'statuses';
 import { createResponse } from './create-response';
-import { RequestContext } from './realm';
+import type { RequestContext } from './realm';
 import type { SearchResultError } from './realm-index-query-engine';
 
 export interface ErrorDetails {

--- a/packages/runtime-common/etc/test-fixtures.ts
+++ b/packages/runtime-common/etc/test-fixtures.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-useless-escape */
+ 
 // TIP: this file should be saved with "Save without formatting" in VSCode
 // to avoid messing with the whitespace in the compiled card source
 export const cardSrc = `

--- a/packages/runtime-common/expression.ts
+++ b/packages/runtime-common/expression.ts
@@ -1,9 +1,9 @@
-import * as JSONTypes from 'json-typescript';
+import type * as JSONTypes from 'json-typescript';
 import isPlainObject from 'lodash/isPlainObject';
 import stringify from 'safe-stable-stringify';
 import flattenDeep from 'lodash/flattenDeep';
 
-import { type CodeRef, type DBAdapter, type TypeCoercion } from './index';
+import type { CodeRef, DBAdapter, TypeCoercion } from './index';
 
 export type Expression = (
   | string

--- a/packages/runtime-common/file-serializer.ts
+++ b/packages/runtime-common/file-serializer.ts
@@ -1,13 +1,12 @@
+import type { Definition, FieldDefinition } from './index';
 import {
   type LooseSingleCardDocument,
   type CardResource,
-  Definition,
-  FieldDefinition,
   isUrlLike,
   maybeRelativeURL,
   isCodeRef,
 } from './index';
-import { type CardFields, type Meta } from './resource-types';
+import type { CardFields, Meta } from './resource-types';
 import { serialize as serializeCodeRef } from './serializers/code-ref';
 
 export default function serialize({

--- a/packages/runtime-common/global.d.ts
+++ b/packages/runtime-common/global.d.ts
@@ -9,6 +9,6 @@ declare module 'ember-source/dist/ember-template-compiler' {
 }
 
 declare module '@babel/plugin-transform-typescript' {
-  import * as Babel from '@babel/core';
+  import type * as Babel from '@babel/core';
   export default function makePlugin(babel: typeof Babel): Babel.PluginObj;
 }

--- a/packages/runtime-common/helpers/ai.ts
+++ b/packages/runtime-common/helpers/ai.ts
@@ -1,7 +1,7 @@
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
 import { primitive } from '../constants';
-import { Loader } from '../loader';
-import { CardDef } from 'https://cardstack.com/base/card-api';
+import type { Loader } from '../loader';
+import type { CardDef } from 'https://cardstack.com/base/card-api';
 import type { Tool } from 'https://cardstack.com/base/matrix-event';
 
 type ArraySchema = {

--- a/packages/runtime-common/helpers/code-equality-assertion.ts
+++ b/packages/runtime-common/helpers/code-equality-assertion.ts
@@ -1,6 +1,6 @@
 import { transform } from '@babel/core';
-import { NodePath } from '@babel/traverse';
-import { StringLiteral } from '@babel/types';
+import type { NodePath } from '@babel/traverse';
+import type { StringLiteral } from '@babel/types';
 import { createPatch } from 'diff';
 import { isNode } from '../index';
 //@ts-ignore unsure where these types live

--- a/packages/runtime-common/helpers/const.ts
+++ b/packages/runtime-common/helpers/const.ts
@@ -1,4 +1,4 @@
-import { type RealmInfo } from '../index';
+import type { RealmInfo } from '../index';
 export const testRealmURL = `http://test-realm/test/`;
 export const testHostModeRealmURL = 'http://test-realm/user/test/';
 

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -1,17 +1,18 @@
-import * as JSONTypes from 'json-typescript';
+import type * as JSONTypes from 'json-typescript';
 import flatten from 'lodash/flatten';
 import stringify from 'safe-stable-stringify';
+import type { ResolvedCodeRef } from './index';
 import {
   type CardResource,
   type CodeRef,
   baseCardRef,
   internalKeyFor,
   isResolvedCodeRef,
-  ResolvedCodeRef,
   trimExecutableExtension,
   baseRealm,
   getSerializer,
 } from './index';
+import type { DBSpecificExpression, Param } from './expression';
 import {
   type Expression,
   type CardExpression,
@@ -33,9 +34,8 @@ import {
   query,
   dbExpression,
   isDbExpression,
-  DBSpecificExpression,
-  Param,
 } from './expression';
+import type { RangeOperator, RangeFilterValue } from './query';
 import {
   type Query,
   type Filter,
@@ -45,23 +45,19 @@ import {
   type Sort,
   type RangeFilter,
   RANGE_OPERATORS,
-  RangeOperator,
-  RangeFilterValue,
 } from './query';
-import { type SerializedError } from './error';
-import { type DBAdapter } from './db';
+import type { SerializedError } from './error';
+import type { DBAdapter } from './db';
+import type { RealmMetaTable } from './index-structure';
 import {
   coerceTypes,
-  RealmMetaTable,
   type BoxelIndexTable,
   type CardTypeSummary,
   type Definition,
   type FieldDefinition,
 } from './index-structure';
-import {
-  DefinitionsCache,
-  isFilterRefersToNonexistentTypeError,
-} from './definitions-cache';
+import type { DefinitionsCache } from './definitions-cache';
+import { isFilterRefersToNonexistentTypeError } from './definitions-cache';
 import { isScopedCSSRequest } from 'glimmer-scoped-css';
 
 interface IndexedModule {

--- a/packages/runtime-common/index-structure.ts
+++ b/packages/runtime-common/index-structure.ts
@@ -1,7 +1,7 @@
-import { type CardResource, type SerializerName, type CodeRef } from './index';
-import { type SerializedError } from './error';
-import { type PgPrimitive } from './expression';
-import { type FieldType } from 'https://cardstack.com/base/card-api';
+import type { CardResource, SerializerName, CodeRef } from './index';
+import type { SerializedError } from './error';
+import type { PgPrimitive } from './expression';
+import type { FieldType } from 'https://cardstack.com/base/card-api';
 
 export interface BoxelIndexTable {
   url: string;

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -28,11 +28,11 @@ import {
   dbExpression,
   upsertMultipleRows,
 } from './expression';
-import { type SerializedError } from './error';
-import { type DBAdapter } from './db';
+import type { SerializedError } from './error';
+import type { DBAdapter } from './db';
+import type { RealmMetaTable } from './index-structure';
 import {
   coerceTypes,
-  RealmMetaTable,
   type BoxelIndexTable,
   type RealmVersionsTable,
   type Definition,

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -1,4 +1,4 @@
-import { CardResource, Meta } from './resource-types';
+import type { CardResource, Meta } from './resource-types';
 import type { ResolvedCodeRef } from './code-ref';
 import type { RenderRouteOptions } from './render-route-options';
 
@@ -113,8 +113,8 @@ export interface RealmPrerenderedCards {
 // TODO should we use the secure form once we start letting lid's drive the id
 // on the server? address in CS-8343
 export { v4 as uuidv4 } from '@lukeed/uuid'; // isomorphic UUID's using Math.random
-import { type LocalPath } from './paths';
-import { CardTypeFilter, Query, EveryFilter } from './query';
+import type { LocalPath } from './paths';
+import type { CardTypeFilter, Query, EveryFilter } from './query';
 import { Loader } from './loader';
 export * from './paths';
 export * from './cached-fetch';
@@ -227,8 +227,8 @@ import type {
   BaseDef,
 } from 'https://cardstack.com/base/card-api';
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
-import { RealmInfo } from './realm';
-import { PrerenderedCard, QueryResultsMeta } from './index-query-engine';
+import type { RealmInfo } from './realm';
+import type { PrerenderedCard, QueryResultsMeta } from './index-query-engine';
 
 export interface MatrixCardError {
   id?: string;
@@ -314,8 +314,8 @@ export async function chooseFile<T extends FieldDef>(): Promise<
   return await chooser.chooseFile<T>();
 }
 
-import { type CardErrorJSONAPI } from './error';
-import { SingleCardDocument } from './document-types';
+import type { CardErrorJSONAPI } from './error';
+import type { SingleCardDocument } from './document-types';
 export type AutoSaveState = {
   isSaving: boolean;
   hasUnsavedChanges: boolean;

--- a/packages/runtime-common/jobs/reindex-realm.ts
+++ b/packages/runtime-common/jobs/reindex-realm.ts
@@ -1,11 +1,10 @@
-import {
+import type {
   DBAdapter,
   FromScratchArgs,
   FromScratchResult,
   QueuePublisher,
-  param,
-  query,
 } from '../';
+import { param, query } from '../';
 
 export async function enqueueReindexRealmJob(
   realmUrl: string,

--- a/packages/runtime-common/matrix-backend-authentication.ts
+++ b/packages/runtime-common/matrix-backend-authentication.ts
@@ -1,5 +1,6 @@
 import { Sha256 } from '@aws-crypto/sha256-js';
-import { MatrixClient, waitForMatrixMessage } from './matrix-client';
+import type { MatrixClient } from './matrix-client';
+import { waitForMatrixMessage } from './matrix-client';
 import { v4 as uuidv4 } from 'uuid';
 import type { MessageEvent } from 'https://cardstack.com/base/matrix-event';
 

--- a/packages/runtime-common/merge-relationships.ts
+++ b/packages/runtime-common/merge-relationships.ts
@@ -1,4 +1,4 @@
-import { type LooseCardResource, type Relationship } from './index';
+import type { LooseCardResource, Relationship } from './index';
 import mergeWith from 'lodash/mergeWith';
 
 export function mergeRelationships(

--- a/packages/runtime-common/module-syntax.ts
+++ b/packages/runtime-common/module-syntax.ts
@@ -13,10 +13,8 @@ import {
   type Reexport,
   isInternalReference,
 } from './schema-analysis-plugin';
-import {
-  removeFieldPlugin,
-  Options as RemoveOptions,
-} from './remove-field-plugin';
+import type { Options as RemoveOptions } from './remove-field-plugin';
+import { removeFieldPlugin } from './remove-field-plugin';
 import { ImportUtil } from 'babel-import-util';
 import camelCase from 'camelcase';
 import isEqual from 'lodash/isEqual';

--- a/packages/runtime-common/prerendered-card-search.ts
+++ b/packages/runtime-common/prerendered-card-search.ts
@@ -1,7 +1,7 @@
 import type { ComponentLike } from '@glint/template';
-import { type Query } from './query';
-import { type Format } from './formats';
-import { QueryResultsMeta } from './index-query-engine';
+import type { Query } from './query';
+import type { Format } from './formats';
+import type { QueryResultsMeta } from './index-query-engine';
 
 export interface PrerenderedCardData {
   url: string;

--- a/packages/runtime-common/query.ts
+++ b/packages/runtime-common/query.ts
@@ -1,4 +1,4 @@
-import * as JSON from 'json-typescript';
+import type * as JSON from 'json-typescript';
 import isEqual from 'lodash/isEqual';
 import { assertJSONValue, assertJSONPrimitive } from './json-validation';
 import qs from 'qs';

--- a/packages/runtime-common/queue.ts
+++ b/packages/runtime-common/queue.ts
@@ -1,5 +1,5 @@
-import { type PgPrimitive } from './index';
-import { Deferred } from './deferred';
+import type { PgPrimitive } from './index';
+import type { Deferred } from './deferred';
 
 export const systemInitiatedPriority = 0;
 export const userInitiatedPriority = 10;

--- a/packages/runtime-common/realm-auth-client.ts
+++ b/packages/runtime-common/realm-auth-client.ts
@@ -1,5 +1,5 @@
 import { unixTime, delay } from './index';
-import { TokenClaims } from './realm';
+import type { TokenClaims } from './realm';
 
 // iat - issued at (seconds since epoch)
 // exp - expires at (seconds since epoch)

--- a/packages/runtime-common/realm-auth-data-source.ts
+++ b/packages/runtime-common/realm-auth-data-source.ts
@@ -1,4 +1,4 @@
-import { MatrixClient } from './matrix-client';
+import type { MatrixClient } from './matrix-client';
 import { RealmAuthClient } from './realm-auth-client';
 
 export class RealmAuthDataSource {

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -13,7 +13,7 @@ import {
   type InstanceOrError,
   type ResolvedCodeRef,
 } from '.';
-import { Realm } from './realm';
+import type { Realm } from './realm';
 import { RealmPaths } from './paths';
 import type { Query } from './query';
 import { CardError, type SerializedError } from './error';
@@ -22,8 +22,8 @@ import {
   type SingleCardDocument,
   type CardCollectionDocument,
 } from './document-types';
-import { type CardResource, type Saved } from './resource-types';
-import { type DefinitionsCache } from './definitions-cache';
+import type { CardResource, Saved } from './resource-types';
+import type { DefinitionsCache } from './definitions-cache';
 
 type Options = {
   loadLinks?: true;

--- a/packages/runtime-common/realm-index-updater.ts
+++ b/packages/runtime-common/realm-index-updater.ts
@@ -15,7 +15,7 @@ import {
   type CopyArgs,
   type CopyResult,
 } from '.';
-import { Realm } from './realm';
+import type { Realm } from './realm';
 import { RealmPaths } from './paths';
 import ignore, { type Ignore } from 'ignore';
 

--- a/packages/runtime-common/realm-permission-checker.ts
+++ b/packages/runtime-common/realm-permission-checker.ts
@@ -1,5 +1,5 @@
-import { MatrixClient } from './matrix-client';
-import { type RealmPermissions, type RealmAction } from './index';
+import type { MatrixClient } from './matrix-client';
+import type { RealmPermissions, RealmAction } from './index';
 
 export default class RealmPermissionChecker {
   private realmPermissions: RealmPermissions = {};

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -5,15 +5,16 @@ import {
   type SingleCardDocument,
 } from './document-types';
 import { isMeta, type CardResource } from './resource-types';
-import { RealmPaths, LocalPath, ensureTrailingSlash, join } from './paths';
+import type { LocalPath } from './paths';
+import { RealmPaths, ensureTrailingSlash, join } from './paths';
 import { persistFileMeta, removeFileMeta, getCreatedTime } from './file-meta';
+import type { ErrorDetails } from './error';
 import {
   systemError,
   notFound,
   methodNotAllowed,
   badRequest,
   CardError,
-  ErrorDetails,
   formattedError,
 } from './error';
 import { v4 as uuidV4 } from 'uuid';
@@ -54,7 +55,7 @@ import {
 import merge from 'lodash/merge';
 import mergeWith from 'lodash/mergeWith';
 import cloneDeep from 'lodash/cloneDeep';
-import { type CardFields } from './resource-types';
+import type { CardFields } from './resource-types';
 import {
   fileContentToText,
   readFileAsText,
@@ -62,12 +63,11 @@ import {
   type TextFileRef,
 } from './stream';
 import { transpileJS } from './transpile';
+import type { Method, RouteTable } from './router';
 import {
   AuthenticationError,
   AuthenticationErrorMessages,
   AuthorizationError,
-  Method,
-  RouteTable,
   Router,
   SupportedMimeType,
   lookupRouteTable,
@@ -94,22 +94,20 @@ import { RealmIndexQueryEngine } from './realm-index-query-engine';
 import { RealmIndexUpdater } from './realm-index-updater';
 import serialize from './file-serializer';
 
-import {
-  MatrixBackendAuthentication,
-  Utils,
-} from './matrix-backend-authentication';
+import type { Utils } from './matrix-backend-authentication';
+import { MatrixBackendAuthentication } from './matrix-backend-authentication';
 
 import type {
   RealmEventContent,
   UpdateRealmEventContent,
 } from 'https://cardstack.com/base/matrix-event';
 import type { LintArgs, LintResult } from './lint';
-import {
+import type {
   AtomicOperation,
   AtomicOperationResult,
   AtomicPayloadValidationError,
-  filterAtomicOperations,
 } from './atomic-document';
+import { filterAtomicOperations } from './atomic-document';
 import {
   DefinitionsCache,
   isFilterRefersToNonexistentTypeError,

--- a/packages/runtime-common/remove-field-plugin.ts
+++ b/packages/runtime-common/remove-field-plugin.ts
@@ -2,8 +2,8 @@ import type {
   PossibleCardOrFieldDeclaration,
   PossibleField,
 } from './schema-analysis-plugin';
-import { types as t } from '@babel/core';
-import { NodePath } from '@babel/traverse';
+import type { types as t } from '@babel/core';
+import type { NodePath } from '@babel/traverse';
 
 interface State {
   opts: Options;

--- a/packages/runtime-common/resource-types.ts
+++ b/packages/runtime-common/resource-types.ts
@@ -1,4 +1,4 @@
-import { RealmInfo } from './realm';
+import type { RealmInfo } from './realm';
 import { type CodeRef, isCodeRef, moduleFrom } from './code-ref';
 
 // resource

--- a/packages/runtime-common/router.ts
+++ b/packages/runtime-common/router.ts
@@ -1,5 +1,6 @@
 import { notFound, CardError, responseWithError } from './error';
-import { RealmPaths, RequestContext, logger } from './index';
+import type { RequestContext } from './index';
+import { RealmPaths, logger } from './index';
 
 export class AuthenticationError extends Error {}
 export class AuthorizationError extends Error {}

--- a/packages/runtime-common/serializers/big-integer.ts
+++ b/packages/runtime-common/serializers/big-integer.ts
@@ -1,6 +1,6 @@
-import {
-  type BaseDefConstructor,
-  type BaseInstanceType,
+import type {
+  BaseDefConstructor,
+  BaseInstanceType,
 } from 'https://cardstack.com/base/card-api';
 
 export function queryableValue(val: bigint | undefined): string | undefined {

--- a/packages/runtime-common/serializers/boolean.ts
+++ b/packages/runtime-common/serializers/boolean.ts
@@ -1,6 +1,6 @@
-import {
-  type BaseDefConstructor,
-  type BaseInstanceType,
+import type {
+  BaseDefConstructor,
+  BaseInstanceType,
 } from 'https://cardstack.com/base/card-api';
 
 export function queryableValue(val: any): boolean {

--- a/packages/runtime-common/serializers/code-ref.ts
+++ b/packages/runtime-common/serializers/code-ref.ts
@@ -1,6 +1,6 @@
-import {
-  type BaseDefConstructor,
-  type BaseInstanceType,
+import type {
+  BaseDefConstructor,
+  BaseInstanceType,
 } from 'https://cardstack.com/base/card-api';
 import {
   type ResolvedCodeRef,

--- a/packages/runtime-common/serializers/date.ts
+++ b/packages/runtime-common/serializers/date.ts
@@ -1,7 +1,7 @@
 import { parse, format } from 'date-fns';
-import {
-  type BaseDefConstructor,
-  type BaseInstanceType,
+import type {
+  BaseDefConstructor,
+  BaseInstanceType,
 } from 'https://cardstack.com/base/card-api';
 
 export const dateFormat = `yyyy-MM-dd`;

--- a/packages/runtime-common/serializers/datetime.ts
+++ b/packages/runtime-common/serializers/datetime.ts
@@ -1,7 +1,7 @@
 import { format, parseISO } from 'date-fns';
-import {
-  type BaseDefConstructor,
-  type BaseInstanceType,
+import type {
+  BaseDefConstructor,
+  BaseInstanceType,
 } from 'https://cardstack.com/base/card-api';
 
 export const datetimeFormat = `yyyy-MM-dd'T'HH:mm`;

--- a/packages/runtime-common/serializers/ethereum-address.ts
+++ b/packages/runtime-common/serializers/ethereum-address.ts
@@ -1,6 +1,6 @@
-import {
-  type BaseDefConstructor,
-  type BaseInstanceType,
+import type {
+  BaseDefConstructor,
+  BaseInstanceType,
 } from 'https://cardstack.com/base/card-api';
 import { isAddress, getAddress } from 'ethers';
 

--- a/packages/runtime-common/serializers/image-size.ts
+++ b/packages/runtime-common/serializers/image-size.ts
@@ -1,6 +1,6 @@
-import {
-  type BaseDefConstructor,
-  type BaseInstanceType,
+import type {
+  BaseDefConstructor,
+  BaseInstanceType,
 } from 'https://cardstack.com/base/card-api';
 
 export function queryableValue(

--- a/packages/runtime-common/serializers/index.ts
+++ b/packages/runtime-common/serializers/index.ts
@@ -8,15 +8,15 @@ import * as EthereumAddressSerializer from './ethereum-address';
 import * as NumberSerializer from './number';
 import * as ImageSizeSerializer from './image-size';
 
-import { type CardDocument } from '../index';
-import {
-  type JSONAPISingleResourceDocument,
-  type SerializeOpts,
-  type BaseDef,
-  type BaseDefConstructor,
-  type BaseInstanceType,
-  type CardStore,
-  type DeserializeOpts,
+import type { CardDocument } from '../index';
+import type {
+  JSONAPISingleResourceDocument,
+  SerializeOpts,
+  BaseDef,
+  BaseDefConstructor,
+  BaseInstanceType,
+  CardStore,
+  DeserializeOpts,
 } from 'https://cardstack.com/base/card-api';
 
 export {

--- a/packages/runtime-common/serializers/number.ts
+++ b/packages/runtime-common/serializers/number.ts
@@ -1,6 +1,6 @@
-import {
-  type BaseDefConstructor,
-  type BaseInstanceType,
+import type {
+  BaseDefConstructor,
+  BaseInstanceType,
 } from 'https://cardstack.com/base/card-api';
 
 export function queryableValue(val: number | undefined): number | undefined {

--- a/packages/runtime-common/tests/queue-test.ts
+++ b/packages/runtime-common/tests/queue-test.ts
@@ -1,5 +1,5 @@
 import type { QueuePublisher, QueueRunner } from '../queue';
-import { type SharedTests } from '../helpers';
+import type { SharedTests } from '../helpers';
 
 const tests = Object.freeze({
   'it can run a job': async (assert, { publisher, runner }) => {

--- a/packages/runtime-common/virtual-network.ts
+++ b/packages/runtime-common/virtual-network.ts
@@ -1,10 +1,10 @@
 import { RealmPaths } from './paths';
 import { baseRealm, isNode } from './index';
+import type { ModuleDescriptor } from './package-shim-handler';
 import {
   PackageShimHandler,
   PACKAGES_FAKE_ORIGIN,
   type ModuleLike,
-  ModuleDescriptor,
 } from './package-shim-handler';
 import type { Readable } from 'stream';
 import { fetcher, type FetcherMiddlewareHandler } from './fetcher';

--- a/packages/runtime-common/worker.ts
+++ b/packages/runtime-common/worker.ts
@@ -1,7 +1,7 @@
-import * as JSONTypes from 'json-typescript';
+import type * as JSONTypes from 'json-typescript';
 import { parse } from 'date-fns';
+import type { IndexWriter, QueuePublisher, DBAdapter } from '.';
 import {
-  IndexWriter,
   Deferred,
   reportError,
   authorizationMiddleware,
@@ -24,8 +24,6 @@ import {
   type Prerenderer,
   type RealmPermissions,
   systemInitiatedPriority,
-  QueuePublisher,
-  DBAdapter,
   fetchAllRealmsWithOwners,
   fetchUserPermissions,
 } from '.';

--- a/packages/vscode-boxel-tools/src/extension.ts
+++ b/packages/vscode-boxel-tools/src/extension.ts
@@ -2,12 +2,14 @@
 
 import * as vscode from 'vscode';
 import { SynapseAuthProvider } from './synapse-auth-provider';
-import { SkillsProvider, Skill } from './skills';
+import type { Skill } from './skills';
+import { SkillsProvider } from './skills';
 import { RealmAuth } from './realm-auth';
 import { LocalFileSystem } from './local-file-system';
 import * as fs from 'fs';
 import * as path from 'path';
-import { RealmProvider, RealmItem } from './realms';
+import type { RealmItem } from './realms';
+import { RealmProvider } from './realms';
 
 export async function activate(context: vscode.ExtensionContext) {
   const realmAuth = new RealmAuth();

--- a/packages/vscode-boxel-tools/src/local-file-system.ts
+++ b/packages/vscode-boxel-tools/src/local-file-system.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { RealmAuth } from './realm-auth';
+import type { RealmAuth } from './realm-auth';
 import { SupportedMimeType } from '@cardstack/runtime-common/router';
 
 // Define the metadata structure for realm files

--- a/packages/vscode-boxel-tools/src/realm-auth.ts
+++ b/packages/vscode-boxel-tools/src/realm-auth.ts
@@ -4,10 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import {
-  RealmAuthClient,
-  RealmAuthMatrixClientInterface,
-} from '@cardstack/runtime-common/realm-auth-client';
+import type { RealmAuthMatrixClientInterface } from '@cardstack/runtime-common/realm-auth-client';
+import { RealmAuthClient } from '@cardstack/runtime-common/realm-auth-client';
 import { APP_BOXEL_REALMS_EVENT_TYPE } from '@cardstack/runtime-common/matrix-constants';
 import { createClient } from 'matrix-js-sdk';
 

--- a/packages/vscode-boxel-tools/src/realms.ts
+++ b/packages/vscode-boxel-tools/src/realms.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
-import { RealmAuth } from './realm-auth';
-import { LocalFileSystem } from './local-file-system';
+import type { RealmAuth } from './realm-auth';
+import type { LocalFileSystem } from './local-file-system';
 
 export class RealmItem extends vscode.TreeItem {
   constructor(

--- a/packages/vscode-boxel-tools/src/skills.ts
+++ b/packages/vscode-boxel-tools/src/skills.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode';
-import { RealmAuth } from './realm-auth';
+import type { RealmAuth } from './realm-auth';
 import * as fs from 'fs';
 import * as path from 'path';
-import { LocalFileSystem } from './local-file-system';
+import type { LocalFileSystem } from './local-file-system';
 
 export interface StoredSkillData {
   skillLists: {

--- a/packages/workspace-sync-cli/.eslintrc.js
+++ b/packages/workspace-sync-cli/.eslintrc.js
@@ -14,6 +14,13 @@ module.exports = {
       extends: ['plugin:n/recommended'],
       rules: {
         '@typescript-eslint/no-var-requires': 'off',
+        '@typescript-eslint/consistent-type-imports': [
+          'error',
+          {
+            disallowTypeAnnotations: false,
+          },
+        ],
+        '@typescript-eslint/no-import-type-side-effects': 'error',
       },
     },
     {

--- a/packages/workspace-sync-cli/tests/helpers/start-test-realm.ts
+++ b/packages/workspace-sync-cli/tests/helpers/start-test-realm.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env tsx
-import { spawn, ChildProcess } from 'child_process';
+import type { ChildProcess } from 'child_process';
+import { spawn } from 'child_process';
 import * as path from 'path';
 import { readFileSync } from 'fs';
 

--- a/packages/workspace-sync-cli/tests/integration-test.ts
+++ b/packages/workspace-sync-cli/tests/integration-test.ts
@@ -4,10 +4,8 @@ import * as path from 'path';
 import { tmpdir } from 'os';
 import { module, test } from 'qunit';
 import { realmPassword } from '../../matrix/helpers/realm-credentials';
-import {
-  startTestRealmServer,
-  TestRealmServer,
-} from './helpers/start-test-realm';
+import type { TestRealmServer } from './helpers/start-test-realm';
+import { startTestRealmServer } from './helpers/start-test-realm';
 
 const REALM_PORT = 4205; // Using isolated realm server port
 const MATRIX_URL = 'http://localhost:8008';


### PR DESCRIPTION
This enables the auto-fixable eslint rule consistent-type-imports:

https://typescript-eslint.io/rules/consistent-type-imports

The main benefit of this rule is that when you follow it, build systems can much more easily ignore all type-only module imports.