### PR TITLE
Send a prompt that is typed by the user in AI App Generator

### DIFF
--- a/packages/base/ai-app-generator.gts
+++ b/packages/base/ai-app-generator.gts
@@ -37,6 +37,13 @@ export class AiAppGenerator extends CardDef {
       this.args.model.promptValue = value;
     };
 
+    handlePromptInput = (event: Event) => {
+      let target = event.target as HTMLTextAreaElement | null;
+      if (target) {
+        this.setPromptValue(target.value);
+      }
+    };
+
     executeAskAi = () => {
       this.askAi.perform();
     };
@@ -80,6 +87,7 @@ export class AiAppGenerator extends CardDef {
                 id='prompt-textarea'
                 class='prompt-textarea'
                 value={{@model.promptValue}}
+                {{on 'input' this.handlePromptInput}}
               ></textarea>
             </div>
             <div class='create-button-container'>

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -2242,5 +2242,36 @@ module('Acceptance | interact submode tests', function (hooks) {
       assert.dom('[data-test-section-header]').exists({ count: 3 });
       assert.dom('[data-test-community-link]').exists({ count: 4 });
     });
+
+    test('sends typed prompt to ask ai when creating app', async function (assert) {
+      await visitOperatorMode({
+        stacks: [[{ id: `${testRealmURL}index`, format: 'isolated' }]],
+        selectAllCardsFilter: false,
+      });
+
+      await click('[data-test-boxel-button][title="About Me"]');
+      let typedPrompt =
+        'Design a travel planner dashboard that tracks itineraries, bookings, and budgets';
+
+      await fillIn(
+        '[data-test-card="https://cardstack.com/base/ai-app-generator"] textarea',
+        typedPrompt,
+      );
+      assert
+        .dom(
+          '[data-test-card="https://cardstack.com/base/ai-app-generator"] textarea',
+        )
+        .hasValue(typedPrompt);
+
+      await click('[data-test-create-this-for-me]');
+      await waitFor('[data-test-room-settled]');
+      assertMessages(assert, [
+        {
+          from: 'testuser',
+          message: typedPrompt,
+          cards: [{ id: `${testRealmURL}index`, title: 'Test Workspace B' }],
+        },
+      ]);
+    });
   });
 });


### PR DESCRIPTION
This PR fix the bug where, in the AI App Generator card, typing a custom prompt did not affect the message sent to Ask AI; the system always used the last selected suggestion.