### PR TITLE
realm: Add indexing duration to logging

### DIFF
--- a/packages/runtime-common/realm-index-updater.ts
+++ b/packages/runtime-common/realm-index-updater.ts
@@ -94,6 +94,9 @@ export class RealmIndexUpdater {
         realmURL: this.#realm.url,
         realmUsername: await this.#realm.getRealmOwnerUsername(),
       };
+
+      this.#log.info(`Realm ${this.realmURL.href} is starting indexing`);
+
       let job = await this.#queue.publish<FromScratchResult>({
         jobType: `from-scratch-index`,
         concurrencyGroup: `indexing:${this.#realm.url}`,

--- a/packages/runtime-common/realm-index-updater.ts
+++ b/packages/runtime-common/realm-index-updater.ts
@@ -88,6 +88,7 @@ export class RealmIndexUpdater {
   // in an onInvalidation callback
   async fullIndex() {
     this.#indexingDeferred = new Deferred<void>();
+    let startedAt = performance.now();
     try {
       let args: FromScratchArgs = {
         realmURL: this.#realm.url,
@@ -103,8 +104,12 @@ export class RealmIndexUpdater {
       let { ignoreData, stats } = await job.done;
       this.#stats = stats;
       this.#ignoreData = ignoreData;
+      let indexingDurationSeconds = (
+        (performance.now() - startedAt) /
+        1000
+      ).toFixed(2);
       this.#log.info(
-        `Realm ${this.realmURL.href} has completed indexing: ${JSON.stringify(
+        `Realm ${this.realmURL.href} has completed indexing in ${indexingDurationSeconds}s: ${JSON.stringify(
           stats,
           null,
           2,


### PR DESCRIPTION
This [shows](https://github.com/cardstack/boxel/actions/runs/19038195855/job/54367983520?pr=3523#step:14:10490) how long indexing took for a realm:

```
Realm http://localhost:4201/catalog/ has completed indexing in 103.05s: {
  "moduleErrors": 0,
  "instanceErrors": 24,
  "modulesIndexed": 263,
  "definitionErrors": 0,
  "instancesIndexed": 953,
  "totalIndexEntries": 1461,
  "definitionsIndexed": 245
}
```

It also adds logging when indexing starts, which may help highlight when it fails to complete in CI jobs:

```
Realm http://localhost:4201/catalog/ is starting indexing
```