### PR TITLE
Fix order of steps in QUICKSTART

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -45,7 +45,14 @@ To build the entire repository and run the application, follow these steps:
    pnpm start
    ```
 
-7. Run the realm server:
+7. Register Matrix users:
+
+   ```zsh
+   cd ./packages/matrix
+   pnpm register-all
+   ```
+
+8. Run the realm server:
 
    ```zsh
    cd ./packages/realm-server
@@ -60,13 +67,6 @@ To build the entire repository and run the application, follow these steps:
    "instanceErrors": 0,
    "moduleErrors": 0
    })
-   ```
-
-8. Register ALL:
-
-   ```zsh
-   cd ./packages/matrix
-   pnpm register-all
    ```
 
 9. Verify registration:


### PR DESCRIPTION
When I tried them in the order shown I got errors:

```
Error logging into matrix. Skipping broadcast Error: Unable to login to matrix http://localhost:8008/ as user base_realm: status 403 - {"errcode":"M_FORBIDDEN","error":"Invalid username or password"}
    at MatrixClient.login (/Users/b/Documents/Cardstack/Code/bm2/packages/runtime-common/matrix-client.ts:107:19)
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async NodeAdapter.broadcastRealmEvent (/Users/b/Documents/Cardstack/Code/bm2/packages/realm-server/node-realm.ts:245:7)
/Users/b/Documents/Cardstack/Code/bm2/packages/runtime-common/matrix-client.ts:107
```