### PR TITLE
Increase AI timeout to 3 mins, add "Wait longer" button

### DIFF
--- a/packages/host/app/components/ai-assistant/message/index.gts
+++ b/packages/host/app/components/ai-assistant/message/index.gts
@@ -61,6 +61,7 @@ interface Signature {
     isDebugMessage?: boolean;
     isPending?: boolean;
     retryAction?: () => void;
+    waitAction?: () => void;
     hideMeta?: boolean;
   };
   Blocks: { default: [] };
@@ -287,6 +288,7 @@ export default class AiAssistantMessage extends Component<Signature> {
                   <div class='credits-added' data-test-credits-added>
                     Credits added!
                   </div>
+
                   <Alert.Action @actionName='Retry' @action={{@retryAction}} />
                 </div>
               {{/if}}
@@ -294,9 +296,17 @@ export default class AiAssistantMessage extends Component<Signature> {
           {{else}}
             <Alert @type='error' as |Alert|>
               <Alert.Messages @messages={{this.errorMessages}} />
-              {{#if @retryAction}}
-                <Alert.Action @actionName='Retry' @action={{@retryAction}} />
-              {{/if}}
+              <div class='alert-action-buttons-row'>
+                {{#if @waitAction}}
+                  <Alert.Action
+                    @actionName='Wait longer'
+                    @action={{@waitAction}}
+                  />
+                {{/if}}
+                {{#if @retryAction}}
+                  <Alert.Action @actionName='Retry' @action={{@retryAction}} />
+                {{/if}}
+              </div>
             </Alert>
           {{/if}}
         {{/if}}
@@ -326,6 +336,16 @@ export default class AiAssistantMessage extends Component<Signature> {
       }
       :deep(code) {
         overflow-wrap: break-word;
+      }
+
+      .alert-action-buttons-row {
+        display: flex;
+        justify-content: flex-end;
+        gap: var(--boxel-sp-sm);
+      }
+
+      .alert-action-buttons-row > :deep(.action-button) {
+        margin-left: 0;
       }
 
       .add-more-credits-button {

--- a/packages/host/app/components/ai-assistant/message/index.gts
+++ b/packages/host/app/components/ai-assistant/message/index.gts
@@ -288,7 +288,6 @@ export default class AiAssistantMessage extends Component<Signature> {
                   <div class='credits-added' data-test-credits-added>
                     Credits added!
                   </div>
-
                   <Alert.Action @actionName='Retry' @action={{@retryAction}} />
                 </div>
               {{/if}}

--- a/packages/host/app/components/matrix/room-message.gts
+++ b/packages/host/app/components/matrix/room-message.gts
@@ -52,15 +52,17 @@ interface Signature {
   };
 }
 
-const STREAMING_TIMEOUT_MS = 60000;
+const STREAMING_TIMEOUT_MS = 3 * 60 * 1000;
+export const STREAMING_TIMEOUT_MINUTES = STREAMING_TIMEOUT_MS / 60_000;
 
 export default class RoomMessage extends Component<Signature> {
   @consume(GetCardCollectionContextName)
   private declare getCardCollection: getCardCollection;
-  @tracked private streamingTimeout = false;
   @tracked private attachedCardCollection:
     | ReturnType<getCardCollection>
     | undefined;
+  @tracked private timeoutCheckTimestamp = Date.now();
+  @tracked private waitStartTimestamp: number | undefined;
 
   constructor(owner: Owner, args: Signature['Args']) {
     super(owner, args);
@@ -84,17 +86,53 @@ export default class RoomMessage extends Component<Signature> {
       return;
     }
 
-    // If message is streaming and hasn't been updated in the last minute, show a timeout message
-    if (Date.now() - Number(this.message.updated) > STREAMING_TIMEOUT_MS) {
-      this.streamingTimeout = true;
+    if (this.message.isStreamingFinished === true) {
       return;
     }
+
+    this.bumpTimeoutCheckTimestamp();
 
     // Do this check every second
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
     this.checkStreamingTimeout.perform();
   });
+
+  private waitLonger = () => {
+    this.waitStartTimestamp = Date.now();
+    this.bumpTimeoutCheckTimestamp();
+    if (!this.checkStreamingTimeout.isRunning) {
+      this.checkStreamingTimeout.perform();
+    }
+  };
+
+  private bumpTimeoutCheckTimestamp() {
+    this.timeoutCheckTimestamp = Date.now();
+  }
+
+  private get streamingTimeout() {
+    if (!this.isFromAssistant || !this.args.isStreaming) {
+      return false;
+    }
+
+    if (!this.isLastAssistantMessage) {
+      return false;
+    }
+
+    if (this.message.isStreamingFinished === true) {
+      return false;
+    }
+
+    let lastActivityTimestamp = Math.max(
+      Number(this.message.updated),
+      this.waitStartTimestamp ?? 0,
+    );
+
+    // If message is streaming and hasn't been updated in the last three minutes, show a timeout message
+    return (
+      this.timeoutCheckTimestamp - lastActivityTimestamp > STREAMING_TIMEOUT_MS
+    );
+  }
 
   private get isFromAssistant() {
     return this.message.author.userId === aiBotUserId;
@@ -164,6 +202,7 @@ export default class RoomMessage extends Component<Signature> {
         @isDebugMessage={{this.message.isDebugMessage}}
         @isStreaming={{@isStreaming}}
         @retryAction={{@retryAction}}
+        @waitAction={{if this.streamingTimeout this.waitLonger}}
         @isPending={{@isPending}}
         data-test-boxel-message-from={{this.message.author.name}}
         data-test-boxel-message-instance-id={{this.message.instanceId}}
@@ -207,7 +246,7 @@ export default class RoomMessage extends Component<Signature> {
       return humanFriendlyErrorMessage || this.message.errorMessage;
     }
     if (this.streamingTimeout) {
-      return 'This message was processing for too long. Please try again.';
+      return `This message has been processing for a long time (more than ${STREAMING_TIMEOUT_MINUTES} minutes), possibly due to a delay in response time, or due to a system error.`; // Will show a "Wait longer" and "Retry" button
     }
     if (this.attachedCardCollection?.cardErrors.length === 0) {
       return undefined;

--- a/packages/host/app/components/matrix/room-message.gts
+++ b/packages/host/app/components/matrix/room-message.gts
@@ -107,6 +107,7 @@ export default class RoomMessage extends Component<Signature> {
   };
 
   private bumpTimeoutCheckTimestamp() {
+    // This is needed for the streamingTimeout getter reactivity - it will update on every tick of the checkStreamingTimeout task
     this.timeoutCheckTimestamp = Date.now();
   }
 

--- a/packages/host/tests/integration/components/room-message-test.gts
+++ b/packages/host/tests/integration/components/room-message-test.gts
@@ -1,4 +1,4 @@
-import { waitUntil, render } from '@ember/test-helpers';
+import { click, waitUntil, render } from '@ember/test-helpers';
 
 import GlimmerComponent from '@glimmer/component';
 
@@ -12,7 +12,9 @@ import {
   GetCardCollectionContextName,
 } from '@cardstack/runtime-common';
 
-import RoomMessage from '@cardstack/host/components/matrix/room-message';
+import RoomMessage, {
+  STREAMING_TIMEOUT_MINUTES,
+} from '@cardstack/host/components/matrix/room-message';
 
 import { parseHtmlContent } from '@cardstack/host/lib/formatted-message/utils';
 import { getCardCollection } from '@cardstack/host/resources/card-collection';
@@ -47,6 +49,8 @@ class GetCardsContextProvider extends GlimmerComponent<{
 module('Integration | Component | RoomMessage', function (hooks) {
   setupRenderingTest(hooks);
 
+  const STREAMING_TIMEOUT_MESSAGE = `This message has been processing for a long time (more than ${STREAMING_TIMEOUT_MINUTES} minutes), possibly due to a delay in response time, or due to a system error.`;
+
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs: '@testuser:localhost',
     activeRealms: [],
@@ -55,34 +59,77 @@ module('Integration | Component | RoomMessage', function (hooks) {
 
   let { createAndJoinRoom } = mockMatrixUtils;
 
-  async function setupTestScenario(
-    isStreaming: boolean,
-    timeAgoForCreated: number,
-    timeAgoForUpdated: number,
-    messageContent: string,
-  ) {
+  interface TestScenarioOptions {
+    isStreaming: boolean;
+    minutesAgoForCreated: number;
+    minutesAgoForUpdated: number;
+    messageContent: string;
+    indexOfLastNonDebugMessage?: number;
+    isStreamingFinished?: boolean;
+    renderIndex?: number;
+    extraMessages?: unknown[];
+    retryAction?: (() => void) | null;
+  }
+
+  async function setupTestScenario(options: TestScenarioOptions) {
+    let {
+      isStreaming,
+      minutesAgoForCreated,
+      minutesAgoForUpdated,
+      messageContent,
+      indexOfLastNonDebugMessage,
+      isStreamingFinished,
+      renderIndex,
+      extraMessages,
+      retryAction,
+    } = options;
+
+    let now = Date.now();
+    let roomId = createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'Test Room',
+    });
+
     let message = {
-      author: { userId: '@aibot:localhost' },
+      author: {
+        userId: '@aibot:localhost',
+        displayName: 'AI Assistant',
+        name: 'AI Assistant',
+      },
       body: messageContent,
-      created: new Date(new Date().getTime() - timeAgoForCreated * 60 * 1000),
-      updated: new Date(new Date().getTime() - timeAgoForUpdated * 60 * 1000),
+      created: new Date(now - minutesAgoForCreated * 60 * 1000),
+      updated: new Date(now - minutesAgoForUpdated * 60 * 1000),
+      roomId,
+      eventId: 'event-1',
+      instanceId: 'fixture-message',
       attachedResources() {
         return undefined;
       },
       htmlParts: parseHtmlContent(messageContent, '!abcd', '1234'),
+      attachedFiles: [],
+      attachedCardsAsFiles: [],
+      commands: [],
+      isStreamingFinished,
     };
 
+    let messages = [message, ...(extraMessages ?? [])];
+
     let testScenario = {
-      roomId: createAndJoinRoom({
-        sender: '@testuser:localhost',
-        name: 'Test Room',
-      }),
+      roomId,
       message,
-      messages: [message],
       isStreaming,
+      messages,
+      indexOfLastNonDebugMessage:
+        indexOfLastNonDebugMessage ?? messages.length - 1,
       monacoSDK: {},
-      maybeRetryAction: null,
-    } as unknown as RoomResource;
+      maybeRetryAction: retryAction ?? null,
+      renderIndex: renderIndex ?? 0,
+    } as unknown as RoomResource & {
+      renderIndex: number;
+      message: typeof message;
+      isStreaming: boolean;
+      maybeRetryAction: (() => void) | null;
+    };
 
     return testScenario;
   }
@@ -99,42 +146,110 @@ module('Integration | Component | RoomMessage', function (hooks) {
           @monacoSDK={{testScenario.monacoSDK}}
           @isStreaming={{testScenario.isStreaming}}
           @registerScroller={{noop}}
-          @index={{0}}
+          @index={{testScenario.renderIndex}}
           @retryAction={{testScenario.maybeRetryAction}}
-          data-test-message-idx='1'
+          data-test-message-idx='{{testScenario.renderIndex}}'
         />
       </GetCardsContextProvider>
     </template>);
   }
 
   test('it shows an error when AI bot message streaming timeouts', async function (assert) {
-    let testScenario = await setupTestScenario(true, 2, 1, 'Hello,'); // Streaming, created 2 mins ago, updated 1 min ago
+    let testScenario = await setupTestScenario({
+      isStreaming: true,
+      minutesAgoForCreated: 5,
+      minutesAgoForUpdated: 4,
+      messageContent: 'Hello,',
+      retryAction: () => {},
+    }); // Streaming, created 5 mins ago, updated 4 mins ago
     await renderRoomMessageComponent(testScenario);
 
-    await waitUntil(
-      () =>
-        !document
-          .querySelector('[data-test-message-idx="1"] [data-test-ai-avatar]')
-          ?.classList.contains('ai-avatar-animated'),
+    await waitUntil(() =>
+      document
+        .querySelector('[data-test-alert-message="0"]')
+        ?.textContent?.includes(STREAMING_TIMEOUT_MESSAGE),
     );
+
     assert
       .dom('[data-test-card-error]')
-      .includesText(
-        'This message was processing for too long. Please try again.',
-      );
+      .includesText(STREAMING_TIMEOUT_MESSAGE);
     assert.dom('[data-test-ai-message-content]').includesText('Hello,');
+    assert.dom('[data-test-alert-action-button="Wait longer"]').exists();
+    assert.dom('[data-test-alert-action-button="Retry"]').exists();
   });
 
   test('it does not show an error when last streaming chunk is still within reasonable time limit', async function (assert) {
-    let testScenario = await setupTestScenario(true, 2, 0.5, 'Hello,'); // Streaming, created 2 mins ago, updated 30 seconds ago
+    let testScenario = await setupTestScenario({
+      isStreaming: true,
+      minutesAgoForCreated: 2,
+      minutesAgoForUpdated: 1,
+      messageContent: 'Hello,',
+    }); // Streaming, created 2 mins ago, updated 1 minute ago
     await renderRoomMessageComponent(testScenario);
 
     assert
-      .dom('[data-test-message-idx="1"] [data-test-ai-avatar]')
+      .dom('[data-test-message-idx="0"] [data-test-ai-avatar]')
       .hasClass('ai-avatar-animated');
     assert.dom('[data-test-card-error]').doesNotExist();
+    assert.dom('[data-test-alert-action-button="Wait longer"]').doesNotExist();
     assert
       .dom('[data-test-ai-message-content] span.streaming-text')
       .includesText('Hello,');
+  });
+
+  test('it does not show a timeout error when the message is not the last assistant message', async function (assert) {
+    let testScenario = await setupTestScenario({
+      isStreaming: true,
+      minutesAgoForCreated: 6,
+      minutesAgoForUpdated: 5,
+      messageContent: 'Earlier response',
+      indexOfLastNonDebugMessage: 1,
+      extraMessages: [
+        {
+          author: {
+            userId: '@aibot:localhost',
+            displayName: 'AI Assistant',
+            name: 'AI Assistant',
+          },
+          body: 'Latest response',
+          created: new Date(),
+          updated: new Date(),
+          roomId: 'unused',
+          eventId: 'event-2',
+          htmlParts: parseHtmlContent('Latest response', '!abcd', '5678'),
+          attachedFiles: [],
+          attachedCardsAsFiles: [],
+          commands: [],
+        },
+      ],
+    });
+    await renderRoomMessageComponent(testScenario);
+
+    await waitUntil(() => {
+      return document
+        .querySelector('[data-test-message-idx="0"] [data-test-ai-avatar]')
+        ?.classList.contains('ai-avatar-animated');
+    });
+    assert.dom('[data-test-card-error]').doesNotExist();
+  });
+
+  test('clicking "wait longer" clears the timeout error', async function (assert) {
+    let testScenario = await setupTestScenario({
+      isStreaming: true,
+      minutesAgoForCreated: 6,
+      minutesAgoForUpdated: 6,
+      messageContent: 'Stuck response',
+      retryAction: () => {},
+    });
+    await renderRoomMessageComponent(testScenario);
+
+    assert
+      .dom('[data-test-card-error]')
+      .includesText(STREAMING_TIMEOUT_MESSAGE);
+
+    await click('[data-test-alert-action-button="Wait longer"]');
+
+    assert.dom('[data-test-alert-action-button="Wait longer"]').doesNotExist();
+    assert.dom('[data-test-card-error]').doesNotExist();
   });
 });


### PR DESCRIPTION
- Increases timeout for showing the error message from 1 minute to 3 minutes
- Improves the error message
- Adds a "Wait longer" button (it discards the error message and starts the timer again)

Here's how it looks like:
<img width="700" height="119" alt="image" src="https://github.com/user-attachments/assets/0053d616-d550-4e60-aeaa-365e2f31268b" />
