### PR TITLE
ci: Move Matrix shards back to regular runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -255,7 +255,7 @@ jobs:
     name: Matrix Client Tests
     needs: change-check
     if: needs.change-check.outputs.matrix == 'true' || github.ref == 'refs/heads/main' || needs.change-check.outputs.run_all == 'true'
-    runs-on: ubuntu-latest-8-core
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This was burning through the monthly budget.