### PR TITLE
Increase prerendering timeout to handle instances that compose 100+ polymorphic links

### DIFF
--- a/packages/realm-server/prerender/utils.ts
+++ b/packages/realm-server/prerender/utils.ts
@@ -10,7 +10,7 @@ import type { Page } from 'puppeteer';
 
 const log = logger('prerenderer');
 
-export const renderTimeoutMs = Number(process.env.RENDER_TIMEOUT_MS ?? 15_000);
+export const renderTimeoutMs = Number(process.env.RENDER_TIMEOUT_MS ?? 180_000);
 
 export type RenderStatus = 'ready' | 'error' | 'unusable';
 
@@ -293,7 +293,7 @@ export async function captureResult(
       }
       return false;
     },
-    {},
+    { timeout: renderTimeoutMs },
     statuses,
     opts?.expectedId ?? null,
     opts?.expectedNonce ?? null,


### PR DESCRIPTION
some of the instances in our catalog (app listings) have over 100 links rendered in the isolated view in a polymorphic nature that requires _lots_ of code loading. i'm seeing it take just over 2 minutes to render some of the app listings. increasing the render timeout to accommodate these heavy instances.