### PR TITLE
Fix realm ETag handling for Accept-specific module responses

### DIFF
--- a/packages/realm-server/tests/realm-endpoints-test.ts
+++ b/packages/realm-server/tests/realm-endpoints-test.ts
@@ -267,6 +267,124 @@ module(basename(__filename), function () {
       );
     });
 
+    const transpileTestCardSource = `
+      import {
+        linksToMany,
+        field,
+        Component,
+        FieldDef,
+      } from 'https://cardstack.com/base/card-api';
+      import { Country } from './country';
+
+      export class TranspileTestField extends FieldDef {
+        static displayName = 'Trips';
+        @field countriesVisited = linksToMany(Country);
+
+        static embedded = class Embedded extends Component<typeof this> {
+          <template>
+            <address data-test-trips-card>
+              <@fields.countriesVisited />
+            </address>
+          </template>
+        };
+      }
+    `;
+
+    test('serves transpiled .gts modules when Accept is */*', async function (assert) {
+      let modulePath = 'transpile-test.gts';
+      let authHeader = `Bearer ${createJWT(testRealm, 'user', ['read', 'write'])}`;
+
+      await testRealm.write(modulePath, transpileTestCardSource);
+
+      let response = await request
+        .get(`/${modulePath}`)
+        .set('Accept', SupportedMimeType.All)
+        .set('Authorization', authHeader);
+
+      assert.strictEqual(response.status, 200, 'module request succeeds');
+      assert.strictEqual(
+        response.headers['content-type'],
+        'text/javascript',
+        'transpiled module advertises javascript content type',
+      );
+      assert.ok(
+        response.text.includes('setComponentTemplate'),
+        'compiled output contains compiled template invocation',
+      );
+      assert.notOk(
+        response.text.includes('<template'),
+        'raw template markup is not present in compiled output',
+      );
+    });
+
+    test('module and source variants emit distinct ETags', async function (assert) {
+      let modulePath = 'transpile-etag-test.gts';
+      let authHeader = `Bearer ${createJWT(testRealm, 'user', ['read', 'write'])}`;
+
+      await testRealm.write(modulePath, transpileTestCardSource);
+
+      let sourceResponse = await request
+        .get(`/${modulePath}`)
+        .set('Accept', SupportedMimeType.CardSource)
+        .set('Authorization', authHeader);
+
+      assert.strictEqual(sourceResponse.status, 200, 'source request succeeds');
+      let sourceEtag = sourceResponse.headers['etag'];
+      assert.ok(sourceEtag, 'source variant exposes an ETag');
+
+      let moduleResponse = await request
+        .get(`/${modulePath}`)
+        .set('Accept', SupportedMimeType.All)
+        .set('Authorization', authHeader);
+
+      assert.strictEqual(moduleResponse.status, 200, 'module request succeeds');
+      let moduleEtag = moduleResponse.headers['etag'];
+      assert.ok(moduleEtag, 'module variant exposes an ETag');
+      assert.notStrictEqual(
+        moduleEtag,
+        sourceEtag,
+        'ETags differ between source and module variants',
+      );
+      assert.ok(
+        moduleResponse.text.includes('setComponentTemplate'),
+        'response body is transpiled output',
+      );
+
+      let moduleResponseIgnoringSourceEtag = await request
+        .get(`/${modulePath}`)
+        .set('Accept', SupportedMimeType.All)
+        .set('Authorization', authHeader)
+        .set('If-None-Match', sourceEtag);
+
+      assert.strictEqual(
+        moduleResponseIgnoringSourceEtag.status,
+        200,
+        'module variant ignores ETag from source response',
+      );
+      assert.strictEqual(
+        moduleResponseIgnoringSourceEtag.headers['etag'],
+        moduleEtag,
+        'module variant reuses its own ETag when revalidated',
+      );
+
+      let notModifiedModuleResponse = await request
+        .get(`/${modulePath}`)
+        .set('Accept', SupportedMimeType.All)
+        .set('Authorization', authHeader)
+        .set('If-None-Match', moduleEtag);
+
+      assert.strictEqual(
+        notModifiedModuleResponse.status,
+        304,
+        'module variant responds with 304 when If-None-Match matches module ETag',
+      );
+      assert.strictEqual(
+        notModifiedModuleResponse.headers['etag'],
+        moduleEtag,
+        '304 response echoes module variant ETag',
+      );
+    });
+
     test('returns 304 for module requests with matching ETag', async function (assert) {
       let modulePath = 'module-cache-not-modified.js';
       let authHeader = `Bearer ${createJWT(testRealm, 'user', ['read', 'write'])}`;

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -148,6 +148,8 @@ export interface FileRef {
 const CACHE_HEADER = 'X-Boxel-Cache';
 const CACHE_HIT_VALUE = 'hit';
 const CACHE_MISS_VALUE = 'miss';
+const MODULE_ETAG_VARIANT = 'module';
+const SOURCE_ETAG_VARIANT = 'source';
 
 type CachedSourceFileEntry = {
   type: 'file';
@@ -186,6 +188,17 @@ type ModuleLoadResult =
       body: string;
       headers: Record<string, string>;
     };
+
+function buildEtag(
+  lastModified: number | undefined,
+  variant?: string,
+): string | undefined {
+  if (lastModified == null) {
+    return undefined;
+  }
+  let base = String(lastModified);
+  return variant ? `${base}:${variant}` : base;
+}
 
 export interface TokenClaims {
   user: string;
@@ -1454,13 +1467,12 @@ export class Realm {
       return { kind: 'shimmed', response };
     }
 
-    let etag =
-      fileRef.lastModified != null ? String(fileRef.lastModified) : undefined;
+    let etag = buildEtag(fileRef.lastModified, MODULE_ETAG_VARIANT);
     if (etag && request.headers.get('if-none-match') === etag) {
       let headers: Record<string, string> = {
         'cache-control': 'public, max-age=0',
-        etag,
       };
+      headers.etag = etag;
       if (fileRef.lastModified != null) {
         headers['last-modified'] = formatRFC7231(fileRef.lastModified * 1000);
       }
@@ -1536,12 +1548,11 @@ export class Realm {
     requestContext: RequestContext,
     options?: {
       defaultHeaders?: Record<string, string>;
+      etagVariant?: string;
     },
   ): Promise<ResponseWithNodeStream> {
-    if (
-      ref.lastModified != null &&
-      request.headers.get('if-none-match') === String(ref.lastModified)
-    ) {
+    let etag = buildEtag(ref.lastModified, options?.etagVariant);
+    if (etag && request.headers.get('if-none-match') === etag) {
       return createResponse({
         body: null,
         init: { status: 304 },
@@ -1555,7 +1566,7 @@ export class Realm {
       ...(Symbol.for('shimmed-module') in ref
         ? { 'X-Boxel-Shimmed-Module': 'true' }
         : {}),
-      etag: String(ref.lastModified),
+      ...(etag ? { etag } : {}),
       'cache-control': 'public, max-age=0', // instructs the browser to check with server before using cache
     };
     if (createdFromDb != null) {
@@ -1750,6 +1761,7 @@ export class Realm {
                 ...cached.defaultHeaders,
                 [CACHE_HEADER]: CACHE_HIT_VALUE,
               },
+              etagVariant: SOURCE_ETAG_VARIANT,
             },
           );
         } finally {
@@ -1803,6 +1815,7 @@ export class Realm {
       if (bypassCache) {
         return await this.serveLocalFile(request, handle, requestContext, {
           defaultHeaders,
+          etagVariant: SOURCE_ETAG_VARIANT,
         });
       } else {
         let cachedRef = await this.materializeFileRef(handle);
@@ -1814,6 +1827,7 @@ export class Realm {
         });
         return await this.serveLocalFile(request, cachedRef, requestContext, {
           defaultHeaders,
+          etagVariant: SOURCE_ETAG_VARIANT,
         });
       }
     } finally {


### PR DESCRIPTION
Prior to this commit, the realm server uses the file’s last-modified timestamp as the ETag for every representation of a module URL. That caused a subtle cache-busting bug: a browser could fetch `Accept: application/vnd.card+source`, cache the raw TypeScript along with its ETag, and then immediately revalidate with `Accept: */*`. Because the downstream request carried the same `If-None-Match` value, the server returned `304 Not Modified` even though the `*/*` variant is supposed to be the transpiled AMD output. The loader would then reuse the browser’s stale, untranspiled copy and fail at runtime.

This change makes ETags variant-aware. We append a “module” or “source” suffix when we build the tag, which keeps the `Accept: */*` and `Accept: card-source` responses in separate validation buckets. The module fallback and the raw-source path both emit consistent cache-control headers, and new tests in the realm endpoints suite lock in the expectation that the two variants expose different ETags and only the matching tag produces a 304.

With ETags split per representation, `Vary: Accept` now works as intended: the module loader always receives compiled JavaScript, we eliminate mysterious “raw TypeScript” regressions during live editing, and browsers can still revalidate efficiently without poisoning the cache.