### PR TITLE
Keep track of card mutation requests coming from the AI assistant (by room)

### DIFF
--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -62,6 +62,7 @@ export class CopySourceResult extends CardDef {
 export class PatchCardInput extends CardDef {
   @field cardId = contains(StringField);
   @field patch = contains(JsonField);
+  @field clientRequestId = contains(StringField);
 }
 
 export class CardIdCard extends CardDef {
@@ -169,6 +170,7 @@ export class PatchCodeCommandResult extends CardDef {
 export class PatchCodeInput extends CardDef {
   @field fileUrl = contains(StringField);
   @field codeBlocks = containsMany(StringField);
+  @field clientRequestId = contains(StringField);
 }
 
 export class CreateAIAssistantRoomInput extends CardDef {

--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -62,7 +62,7 @@ export class CopySourceResult extends CardDef {
 export class PatchCardInput extends CardDef {
   @field cardId = contains(StringField);
   @field patch = contains(JsonField);
-  @field clientRequestId = contains(StringField);
+  @field roomId = contains(StringField);
 }
 
 export class CardIdCard extends CardDef {
@@ -170,7 +170,7 @@ export class PatchCodeCommandResult extends CardDef {
 export class PatchCodeInput extends CardDef {
   @field fileUrl = contains(StringField);
   @field codeBlocks = containsMany(StringField);
-  @field clientRequestId = contains(StringField);
+  @field roomId = contains(StringField);
 }
 
 export class CreateAIAssistantRoomInput extends CardDef {

--- a/packages/host/app/commands/patch-card-instance.ts
+++ b/packages/host/app/commands/patch-card-instance.ts
@@ -52,13 +52,18 @@ export default class PatchCardInstanceCommand extends HostBaseCommand<
         "Patch command can't run because it doesn't have all the fields in arguments returned by open ai",
       );
     }
+    let clientRequestId =
+      this.commandService.registerAiAssistantClientRequestId(
+        'patch-instance',
+        input.roomId,
+      );
     await this.store.patch(
       input.cardId,
       {
         attributes: input.patch.attributes,
         relationships: input.patch.relationships,
       },
-      { clientRequestId: input.clientRequestId ?? undefined },
+      { clientRequestId },
     );
   }
 

--- a/packages/host/app/commands/patch-card-instance.ts
+++ b/packages/host/app/commands/patch-card-instance.ts
@@ -15,6 +15,8 @@ import type * as BaseCommandModule from 'https://cardstack.com/base/command';
 
 import HostBaseCommand from '../lib/host-base-command';
 
+import type CommandService from '../services/command-service';
+
 import type StoreService from '../services/store';
 
 interface Configuration {
@@ -25,6 +27,7 @@ export default class PatchCardInstanceCommand extends HostBaseCommand<
   undefined
 > {
   @service declare private store: StoreService;
+  @service declare private commandService: CommandService;
 
   description = `Propose a patch to an existing card instance to change its contents. Any attributes specified will be fully replaced, return the minimum required to make the change. If a relationship field value is removed, set the self property of the specific item to null. When editing a relationship array, display the full array in the patch code. Ensure the description explains what change you are making. Do NOT leave out the cardId or patch fields or this tool will not work.`;
   static actionVerb = 'Update Card';

--- a/packages/host/app/commands/patch-card-instance.ts
+++ b/packages/host/app/commands/patch-card-instance.ts
@@ -52,10 +52,14 @@ export default class PatchCardInstanceCommand extends HostBaseCommand<
         "Patch command can't run because it doesn't have all the fields in arguments returned by open ai",
       );
     }
-    await this.store.patch(input.cardId, {
-      attributes: input.patch.attributes,
-      relationships: input.patch.relationships,
-    });
+    await this.store.patch(
+      input.cardId,
+      {
+        attributes: input.patch.attributes,
+        relationships: input.patch.relationships,
+      },
+      { clientRequestId: input.clientRequestId ?? undefined },
+    );
   }
 
   async getInputJsonSchema(

--- a/packages/host/app/commands/patch-code.ts
+++ b/packages/host/app/commands/patch-code.ts
@@ -41,7 +41,7 @@ export default class PatchCodeCommand extends HostBaseCommand<
   protected async run(
     input: BaseCommandModule.PatchCodeInput,
   ): Promise<BaseCommandModule.PatchCodeCommandResult> {
-    let { fileUrl, codeBlocks } = input;
+    let { fileUrl, codeBlocks, clientRequestId } = input;
 
     let fileInfo = await this.getFileInfo(fileUrl);
     let hasEmptySearchPortion = this.hasEmptySearchPortion(codeBlocks);
@@ -64,7 +64,10 @@ export default class PatchCodeCommand extends HostBaseCommand<
         new URL(finalFileUrl),
         patchedCode,
         'bot-patch',
-        { resetLoader: hasExecutableExtension(finalFileUrl) },
+        {
+          resetLoader: hasExecutableExtension(finalFileUrl),
+          clientRequestId: clientRequestId ?? undefined,
+        },
       );
     }
 

--- a/packages/host/app/commands/patch-code.ts
+++ b/packages/host/app/commands/patch-code.ts
@@ -12,8 +12,8 @@ import ApplySearchReplaceBlockCommand from './apply-search-replace-block';
 import LintAndFixCommand from './lint-and-fix';
 
 import type CardService from '../services/card-service';
+import type CommandService from '../services/command-service';
 import type RealmService from '../services/realm';
-import CommandService from '../services/command-service';
 
 interface FileInfo {
   exists: boolean;

--- a/packages/host/app/services/card-service.ts
+++ b/packages/host/app/services/card-service.ts
@@ -124,8 +124,7 @@ export default class CardService extends Service {
           'QUERY');
 
     if (!isReadOperation) {
-      let clientRequestId =
-        providedClientRequestId ?? `instance:${uuidv4()}`;
+      let clientRequestId = providedClientRequestId ?? `instance:${uuidv4()}`;
       this.clientRequestIds.add(clientRequestId);
       headers = { ...headers, 'X-Boxel-Client-Request-Id': clientRequestId };
     }
@@ -193,8 +192,7 @@ export default class CardService extends Service {
     options?: SaveSourceOptions,
   ) {
     try {
-      let clientRequestId =
-        options?.clientRequestId ?? `${type}:${uuidv4()}`;
+      let clientRequestId = options?.clientRequestId ?? `${type}:${uuidv4()}`;
       this.clientRequestIds.add(clientRequestId);
 
       let response = await this.network.authedFetch(url, {

--- a/packages/host/app/services/command-service.ts
+++ b/packages/host/app/services/command-service.ts
@@ -556,10 +556,7 @@ export default class CommandService extends Service {
     let finalFileUrl: string | undefined;
 
     try {
-      let patchCodeCommand = new PatchCodeCommand({
-        roomId,
-        ...this.commandContext,
-      });
+      let patchCodeCommand = new PatchCodeCommand(this.commandContext);
 
       let patchCodeResult = await patchCodeCommand.execute({
         fileUrl,

--- a/packages/host/tests/acceptance/code-patches-test.gts
+++ b/packages/host/tests/acceptance/code-patches-test.gts
@@ -265,6 +265,23 @@ ${REPLACE_MARKER}\n\`\`\``;
       'updated file should be attached 2',
     );
 
+    let commandService = getService('command-service') as any;
+    let requestIdsByRoom =
+      commandService.aiAssistantClientRequestIdsByRoom as Map<string, any>;
+    let roomRequestIds = requestIdsByRoom?.get(roomId);
+    assert.ok(
+      roomRequestIds,
+      'aiAssistantClientRequestIdsByRoom has an entry for the room',
+    );
+
+    let ids: string[] = roomRequestIds ? Array.from(roomRequestIds) : [];
+    assert.ok(
+      ids.some((id) =>
+        id.startsWith(`bot-patch:${encodeURIComponent(roomId)}:patch-code`),
+      ),
+      'bot patch clientRequestId recorded for the room',
+    );
+
     assert.dom('[data-test-boxel-menu-item-text="Open in Code Mode"]').exists();
     assert
       .dom('[data-test-boxel-menu-item-text="Copy Submitted Content"]')

--- a/packages/host/tests/acceptance/commands-test.gts
+++ b/packages/host/tests/acceptance/commands-test.gts
@@ -538,6 +538,24 @@ module('Acceptance | Commands tests', function (hooks) {
         '[data-test-operator-mode-stack="1"] [data-test-stack-card-index="0"]',
       )
       .includesText('Meeting with Hassan');
+
+    let commandService = getService('command-service') as any;
+    let requestIdsByRoom =
+      commandService.aiAssistantClientRequestIdsByRoom as Map<string, any>;
+    let roomRequestIds = requestIdsByRoom?.get(roomId);
+    assert.ok(
+      roomRequestIds,
+      'aiAssistantClientRequestIdsByRoom has an entry for the room after patching instance',
+    );
+    let ids: string[] = roomRequestIds ? Array.from(roomRequestIds) : [];
+    assert.ok(
+      ids.some((id) =>
+        id.startsWith(
+          `bot-patch:${encodeURIComponent(roomId)}:patch-instance`,
+        ),
+      ),
+      'bot patch clientRequestId recorded for the room when patching instance',
+    );
   });
 
   test('a host command added from a skill can be executed when clicked on', async function (assert) {

--- a/packages/host/tests/acceptance/commands-test.gts
+++ b/packages/host/tests/acceptance/commands-test.gts
@@ -550,9 +550,7 @@ module('Acceptance | Commands tests', function (hooks) {
     let ids: string[] = roomRequestIds ? Array.from(roomRequestIds) : [];
     assert.ok(
       ids.some((id) =>
-        id.startsWith(
-          `bot-patch:${encodeURIComponent(roomId)}:patch-instance`,
-        ),
+        id.startsWith(`bot-patch:${encodeURIComponent(roomId)}:patch-instance`),
       ),
       'bot patch clientRequestId recorded for the room when patching instance',
     );

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -399,6 +399,7 @@ export interface Store {
   patch<T extends CardDef>(
     id: string,
     patchData: PatchData,
+    opts?: { doNotPersist?: boolean; clientRequestId?: string },
   ): Promise<T | CardErrorJSONAPI | undefined>;
   search(query: Query, realmURL?: URL): Promise<CardDef[]>;
   getSaveState(id: string): AutoSaveState | undefined;

--- a/packages/runtime-common/realm-index-updater.ts
+++ b/packages/runtime-common/realm-index-updater.ts
@@ -126,7 +126,11 @@ export class RealmIndexUpdater {
 
   async update(
     urls: URL[],
-    opts?: { delete?: true; onInvalidation?: (invalidatedURLs: URL[]) => void },
+    opts?: {
+      delete?: true;
+      onInvalidation?: (invalidatedURLs: URL[]) => void;
+      clientRequestId?: string | null;
+    },
   ): Promise<void> {
     this.#indexingDeferred = new Deferred<void>();
     try {
@@ -136,6 +140,7 @@ export class RealmIndexUpdater {
         realmUsername: await this.#realm.getRealmOwnerUsername(),
         operation: opts?.delete ? 'delete' : 'update',
         ignoreData: { ...this.#ignoreData },
+        clientRequestId: opts?.clientRequestId ?? null,
       };
       let job = await this.#queue.publish<IncrementalResult>({
         jobType: `incremental-index`,

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -629,16 +629,23 @@ export class Realm {
     let invalidations: Set<string> = new Set();
     let clientRequestId: string | null | undefined;
     let performIndex = async () => {
+      let requestId = clientRequestId ?? options?.clientRequestId ?? null;
       await this.#realmIndexUpdater.update(urls, {
+        clientRequestId: requestId,
         onInvalidation: (invalidatedURLs: URL[]) => {
           this.handleExecutableInvalidations(invalidatedURLs);
           invalidations = new Set([
             ...invalidations,
             ...invalidatedURLs.map((u) => u.href),
           ]);
-          clientRequestId = clientRequestId ?? options?.clientRequestId;
+          if (clientRequestId == null && requestId) {
+            clientRequestId = requestId;
+          }
         },
       });
+      if (clientRequestId == null && requestId) {
+        clientRequestId = requestId;
+      }
     };
 
     for (let [path, content] of files) {

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -642,23 +642,16 @@ export class Realm {
     let invalidations: Set<string> = new Set();
     let clientRequestId: string | null = options?.clientRequestId ?? null;
     let performIndex = async () => {
-      let requestId = clientRequestId ?? options?.clientRequestId ?? null;
       await this.#realmIndexUpdater.update(urls, {
-        clientRequestId: requestId,
+        clientRequestId,
         onInvalidation: (invalidatedURLs: URL[]) => {
           this.handleExecutableInvalidations(invalidatedURLs);
           invalidations = new Set([
             ...invalidations,
             ...invalidatedURLs.map((u) => u.href),
           ]);
-          if (clientRequestId == null && requestId) {
-            clientRequestId = requestId;
-          }
         },
       });
-      if (clientRequestId == null && requestId) {
-        clientRequestId = requestId;
-      }
     };
 
     for (let [path, content] of files) {

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -627,7 +627,7 @@ export class Realm {
     let lastWriteType: 'module' | 'instance' | undefined;
     let currentWriteType: 'module' | 'instance' | undefined;
     let invalidations: Set<string> = new Set();
-    let clientRequestId: string | null | undefined;
+    let clientRequestId: string | null = options?.clientRequestId ?? null;
     let performIndex = async () => {
       let requestId = clientRequestId ?? options?.clientRequestId ?? null;
       await this.#realmIndexUpdater.update(urls, {

--- a/packages/runtime-common/worker.ts
+++ b/packages/runtime-common/worker.ts
@@ -111,7 +111,7 @@ export interface IncrementalArgs extends WorkerArgs {
   urls: string[];
   operation: 'update' | 'delete';
   ignoreData: Record<string, string>;
-  clientRequestId?: string | null;
+  clientRequestId: string | null;
 }
 
 export type IncrementalArgsWithPermissions = IncrementalArgs & {

--- a/packages/runtime-common/worker.ts
+++ b/packages/runtime-common/worker.ts
@@ -111,6 +111,7 @@ export interface IncrementalArgs extends WorkerArgs {
   urls: string[];
   operation: 'update' | 'delete';
   ignoreData: Record<string, string>;
+  clientRequestId?: string | null;
 }
 
 export type IncrementalArgsWithPermissions = IncrementalArgs & {


### PR DESCRIPTION
This is the first step towards having the self-healing card/code patching feature where we want the assistant to be able to detect card errors as a result of its own code/card patching.

This PR introduces tracking of the requests that the AI assistant made - there is now a new `aiAssistantClientRequestIdsByRoom` property in the commands service.

The idea is that when the card store detects a card error after receiving the invalidation, it will receive the client request id in the matrix realm event, and then if it can find the client request id in `aiAssistantClientRequestIdsByRoom`, it will mean *the assistant* is at fault for introducing an indexing error–in that we want to give it feedback and the error document so that it will try to correct itself (future feature)
