### PR TITLE
Clean up worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ The realm server also uses FastBoot to pre-render card html. The realm server bo
 
 Boxel supports server-side rendering of cards via a lightweight prerender service and an optional manager that coordinates multiple services.
 
-- Prerender server: Handles POST /prerender requests that include user/session permissions and a target card URL. It launches a headless browser and maintains a small pool of per-realm pages (LRU-evicted) to speed up subsequent renders. Each page keeps a logged-in session for its realm and reuses the page for repeated renders of that realm.
+- Prerender server: Handles POST `/prerender-card` (cards) and `/prerender-module` (modules) requests that include user/session permissions and a target URL. It launches a headless browser and maintains a small pool of per-realm pages (LRU-evicted) to speed up subsequent renders. Each page keeps a logged-in session for its realm and reuses the page for repeated renders of that realm.
 - Pooling: Each prerender server maintains up to PRERENDER_PAGE_POOL_SIZE pages (default 4). When the pool is full, the least-recently-used realm is evicted (its browser context is closed). When a page becomes unusable (timeout or explicit unusable signal), the realm is evicted proactively.
-- Prerender manager: When multiple prerender servers are running, a central manager receives /prerender requests and routes them to a suitable server. The manager tracks which servers are registered and which realms they actively handle. It supports realm affinity, multiplexing the same realm across multiple servers to handle high prerender throughput, capacity-aware selection, and health-based eviction of unreachable servers.
+- Prerender manager: When multiple prerender servers are running, a central manager receives `/prerender-card` and `/prerender-module` requests and routes them to a suitable server. The manager tracks which servers are registered and which realms they actively handle. It supports realm affinity, multiplexing the same realm across multiple servers to handle high prerender throughput, capacity-aware selection, and health-based eviction of unreachable servers.
 
 #### Pre-rendering start scripts
 

--- a/packages/host/app/lib/current-run.ts
+++ b/packages/host/app/lib/current-run.ts
@@ -751,7 +751,7 @@ export class CurrentRun {
           let shouldClearCache = this.#consumeClearCacheForRender();
           let prerenderOptions: RenderRouteOptions | undefined =
             shouldClearCache ? { clearCache: true } : undefined;
-          renderResult = await this.#prerenderer({
+          renderResult = await this.#prerenderer.prerenderCard({
             url: fileURL,
             realm: this.#realmURL.href,
             userId: this.#userId,

--- a/packages/host/app/services/local-indexer.ts
+++ b/packages/host/app/services/local-indexer.ts
@@ -17,6 +17,7 @@ import type { TestRealmAdapter } from '@cardstack/host/tests/helpers/adapter';
 export default class LocalIndexer extends Service {
   @tracked renderError: string | undefined;
   @tracked prerenderStatus: 'ready' | 'loading' | 'unusable' | undefined;
+  #prerenderer: Prerenderer | undefined;
   setup(
     _fromScratch: (
       args: FromScratchArgsWithPermissions,
@@ -24,8 +25,10 @@ export default class LocalIndexer extends Service {
     _incremental: (
       args: IncrementalArgsWithPermissions,
     ) => Promise<IndexResults>,
-    _prerenderer: Prerenderer,
-  ) {}
+    prerenderer: Prerenderer,
+  ) {
+    this.#prerenderer = prerenderer;
+  }
   get adapter(): TestRealmAdapter {
     return {} as TestRealmAdapter;
   }
@@ -33,7 +36,10 @@ export default class LocalIndexer extends Service {
     return {} as IndexWriter;
   }
   get prerenderer() {
-    return {} as Prerenderer;
+    if (!this.#prerenderer) {
+      throw new Error('prerenderer has not been configured on LocalIndexer');
+    }
+    return this.#prerenderer;
   }
   setPrerenderStatus(status: 'ready' | 'loading' | 'unusable') {
     this.prerenderStatus = status;

--- a/packages/host/tests/acceptance/prerender-module-test.gts
+++ b/packages/host/tests/acceptance/prerender-module-test.gts
@@ -8,8 +8,10 @@ import {
   baseRealm,
   trimExecutableExtension,
   type RenderRouteOptions,
+  type RealmPermissions,
   CardError,
 } from '@cardstack/runtime-common';
+import type { Realm } from '@cardstack/runtime-common/realm';
 
 import {
   setupLocalIndexing,
@@ -22,6 +24,8 @@ import {
 import { setupMockMatrix } from '../helpers/mock-matrix';
 import { setupApplicationTest } from '../helpers/setup';
 
+import type { TestRealmAdapter } from '../helpers/adapter';
+
 module('Acceptance | prerender | module', function (hooks) {
   setupApplicationTest(hooks);
   setupLocalIndexing(hooks);
@@ -30,6 +34,8 @@ module('Acceptance | prerender | module', function (hooks) {
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs: '@testuser:localhost',
   });
+  let adapter: TestRealmAdapter;
+  let realm: Realm;
 
   const DEFAULT_MODULE_OPTIONS_SEGMENT = encodeURIComponent(
     JSON.stringify({} as RenderRouteOptions),
@@ -39,53 +45,44 @@ module('Acceptance | prerender | module', function (hooks) {
     nonce = 0,
     optionsSegment = DEFAULT_MODULE_OPTIONS_SEGMENT,
   ) => `/module/${encodeURIComponent(url)}/${nonce}/${optionsSegment}`;
+  const PERSON_MODULE = `
+    import { CardDef, field, contains, StringField } from "https://cardstack.com/base/card-api";
 
-  function resetCaches(reason: string) {
-    let loaderService = getService('loader-service');
-    loaderService.resetLoader({
-      clearFetchCache: true,
-      reason,
-    });
-    getService('store').resetCache();
-  }
-
-  hooks.beforeEach(async function () {
-    resetCaches('prerender-module-test setup');
-    let loader = getService('loader-service').loader;
-    let cardApi: typeof import('https://cardstack.com/base/card-api');
-    cardApi = await loader.import(`${baseRealm.url}card-api`);
-
-    let { field, contains, CardDef, StringField } = cardApi;
-
-    class Person extends CardDef {
+    export class Person extends CardDef {
       static displayName = 'Person';
       @field name = contains(StringField);
     }
+  `;
+  const PARENT_MODULE = `
+    import { CardDef, field, contains, StringField } from "https://cardstack.com/base/card-api";
 
-    class Parent extends CardDef {
+    export class Parent extends CardDef {
       static displayName = 'Parent';
       @field title = contains(StringField);
     }
+  `;
+  const CHILD_MODULE = `
+    import { Parent } from "./parent";
+    import { field, contains, StringField } from "https://cardstack.com/base/card-api";
 
-    class Child extends Parent {
+    export class Child extends Parent {
       static displayName = 'Child';
       @field nickname = contains(StringField);
     }
+  `;
+  const BROKEN_MODULE = `export const Broken = ;`;
 
-    await setupAcceptanceTestRealm({
+  hooks.beforeEach(async function () {
+    ({ adapter, realm } = await setupAcceptanceTestRealm({
       mockMatrixUtils,
       contents: {
         ...SYSTEM_CARD_FIXTURE_CONTENTS,
-        'person.gts': { Person },
-        'parent.gts': { Parent },
-        'child.gts': { Child },
-        'broken.gts': `export const Broken = ;`,
+        'person.gts': PERSON_MODULE,
+        'parent.gts': PARENT_MODULE,
+        'child.gts': CHILD_MODULE,
+        'broken.gts': BROKEN_MODULE,
       },
-    });
-  });
-
-  hooks.afterEach(function () {
-    resetCaches('prerender-module-test cleanup');
+    }));
   });
 
   test('captures module metadata when module loads successfully', async function (assert) {
@@ -226,6 +223,138 @@ module('Acceptance | prerender | module', function (hooks) {
       childEntry.error.status,
       CardError.fromSerializableError(childEntry.error).status,
       'status survives serialization round-trip',
+    );
+  });
+
+  test('card prerenderer can prerender modules', async function (assert) {
+    let moduleURL = `${testRealmURL}person.gts`;
+    let prerenderer = getService('local-indexer').prerenderer;
+    let permissions: RealmPermissions = {
+      [testRealmURL]: ['read', 'write', 'realm-owner'],
+    };
+
+    let response = await prerenderer.prerenderModule({
+      realm: testRealmURL,
+      url: moduleURL,
+      userId: '@testuser:localhost',
+      permissions,
+    });
+
+    assert.strictEqual(
+      response.status,
+      'ready',
+      'module prerender reports ready',
+    );
+    assert.strictEqual(response.id, moduleURL, 'module id echoed back');
+    let key = `${trimExecutableExtension(new URL(moduleURL)).href}/Person`;
+    assert.ok(response.definitions[key], 'definition captured');
+    assert.strictEqual(
+      response.definitions[key]?.type,
+      'definition',
+      'definition entry returned',
+    );
+  });
+
+  test('card prerenderer surfaces module errors', async function (assert) {
+    let moduleURL = `${testRealmURL}broken.gts`;
+    let prerenderer = getService('local-indexer').prerenderer;
+    let permissions: RealmPermissions = {
+      [testRealmURL]: ['read', 'write', 'realm-owner'],
+    };
+
+    let response = await prerenderer.prerenderModule({
+      realm: testRealmURL,
+      url: moduleURL,
+      userId: '@testuser:localhost',
+      permissions,
+    });
+
+    assert.strictEqual(
+      response.status,
+      'error',
+      'module prerender reports error',
+    );
+    assert.ok(response.error, 'error payload present');
+    assert.strictEqual(
+      response.error?.error.status,
+      406,
+      'compile error status surfaced',
+    );
+  });
+
+  test('module prerender captures updated definitions after clear cache', async function (assert) {
+    let moduleURL = `${testRealmURL}person.gts`;
+
+    await visit(modulePath(moduleURL));
+    let initial = captureModuleResult();
+
+    let definitionKey = `${
+      trimExecutableExtension(new URL(moduleURL)).href
+    }/Person`;
+    let initialEntry = initial.model.definitions[definitionKey];
+    assert.ok(initialEntry, 'initial definition exists');
+    assert.strictEqual(
+      initialEntry?.type,
+      'definition',
+      'initial definition entry present',
+    );
+    assert.strictEqual(
+      initialEntry?.type === 'definition'
+        ? initialEntry.definition.displayName
+        : undefined,
+      'Person',
+      'initial display name recorded',
+    );
+
+    await adapter.write(
+      'person.gts',
+      `
+      import { CardDef, field, contains, StringField } from "https://cardstack.com/base/card-api";
+
+      export class Person extends CardDef {
+        static displayName = 'Updated Person';
+        @field name = contains(StringField);
+      }
+    `,
+    );
+    realm.__testOnlyClearCaches();
+
+    await visit(modulePath(moduleURL));
+    let cached = captureModuleResult();
+    let cachedEntry = cached.model.definitions[definitionKey];
+    assert.ok(cachedEntry, 'cached definition exists');
+    assert.strictEqual(
+      cachedEntry?.type,
+      'definition',
+      'cached definition entry present',
+    );
+    assert.strictEqual(
+      cachedEntry?.type === 'definition'
+        ? cachedEntry.definition.displayName
+        : undefined,
+      'Person',
+      'cache retains original display name without clearCache flag',
+    );
+
+    let clearOptionsSegment = encodeURIComponent(
+      JSON.stringify({ clearCache: true } as RenderRouteOptions),
+    );
+
+    await visit(modulePath(moduleURL, 1, clearOptionsSegment));
+    let updated = captureModuleResult();
+    let updatedEntry = updated.model.definitions[definitionKey];
+    assert.ok(updatedEntry, 'updated definition exists');
+    assert.strictEqual(
+      updatedEntry?.type,
+      'definition',
+      'updated definition entry present',
+    );
+    assert.strictEqual(
+      updatedEntry?.type === 'definition'
+        ? updatedEntry.definition.displayName
+        : undefined,
+      'Updated Person',
+      'updated display name observed after clearCache flag',
     );
   });
 });

--- a/packages/host/tests/acceptance/prerender-module-test.gts
+++ b/packages/host/tests/acceptance/prerender-module-test.gts
@@ -46,7 +46,7 @@ module('Acceptance | prerender | module', function (hooks) {
     optionsSegment = DEFAULT_MODULE_OPTIONS_SEGMENT,
   ) => `/module/${encodeURIComponent(url)}/${nonce}/${optionsSegment}`;
   const PERSON_MODULE = `
-    import { CardDef, field, contains, StringField } from "https://cardstack.com/base/card-api";
+    import { CardDef, field, contains, StringField } from 'https://cardstack.com/base/card-api';
 
     export class Person extends CardDef {
       static displayName = 'Person';
@@ -54,7 +54,7 @@ module('Acceptance | prerender | module', function (hooks) {
     }
   `;
   const PARENT_MODULE = `
-    import { CardDef, field, contains, StringField } from "https://cardstack.com/base/card-api";
+    import { CardDef, field, contains, StringField } from 'https://cardstack.com/base/card-api';
 
     export class Parent extends CardDef {
       static displayName = 'Parent';
@@ -62,8 +62,8 @@ module('Acceptance | prerender | module', function (hooks) {
     }
   `;
   const CHILD_MODULE = `
-    import { Parent } from "./parent";
-    import { field, contains, StringField } from "https://cardstack.com/base/card-api";
+    import { Parent } from './parent';
+    import { field, contains, StringField } from 'https://cardstack.com/base/card-api';
 
     export class Child extends Parent {
       static displayName = 'Child';
@@ -309,7 +309,7 @@ module('Acceptance | prerender | module', function (hooks) {
     await adapter.write(
       'person.gts',
       `
-      import { CardDef, field, contains, StringField } from "https://cardstack.com/base/card-api";
+      import { CardDef, field, contains, StringField } from 'https://cardstack.com/base/card-api';
 
       export class Person extends CardDef {
         static displayName = 'Updated Person';

--- a/packages/host/tests/helpers/adapter.ts
+++ b/packages/host/tests/helpers/adapter.ts
@@ -13,9 +13,9 @@ import {
   hasExecutableExtension,
   Deferred,
   unixTime,
+  type LintResult,
 } from '@cardstack/runtime-common';
 
-import type { LintResult } from '@cardstack/runtime-common/lint';
 import type { MatrixClient } from '@cardstack/runtime-common/matrix-client';
 import { APP_BOXEL_REALM_EVENT_TYPE } from '@cardstack/runtime-common/matrix-constants';
 

--- a/packages/host/tests/integration/commands/patch-code-test.gts
+++ b/packages/host/tests/integration/commands/patch-code-test.gts
@@ -5,9 +5,8 @@ import {
   REPLACE_MARKER,
   SEARCH_MARKER,
   SEPARATOR_MARKER,
+  type LintResult,
 } from '@cardstack/runtime-common';
-
-import { LintResult } from '@cardstack/runtime-common/lint';
 
 import PatchCodeCommand from '@cardstack/host/commands/patch-code';
 

--- a/packages/realm-server/prerender/prerenderer.ts
+++ b/packages/realm-server/prerender/prerenderer.ts
@@ -872,6 +872,8 @@ export class Prerenderer {
     let serializedOptions = serializeRenderRouteOptions(options);
     let optionsSegment = encodeURIComponent(serializedOptions);
     const captureOptions: CaptureOptions = {
+      expectedId: url.replace(/\.json$/i, ''),
+      expectedNonce: String(this.#nonce),
       simulateTimeoutMs: opts?.simulateTimeoutMs,
     };
 

--- a/packages/realm-server/prerender/remote-prerenderer.ts
+++ b/packages/realm-server/prerender/remote-prerenderer.ts
@@ -1,6 +1,7 @@
 import {
   type Prerenderer,
   type RenderResponse,
+  type ModulePrerenderResponse,
   logger,
 } from '@cardstack/runtime-common';
 
@@ -10,25 +11,17 @@ export function createRemotePrerenderer(
   prerenderServerURL: string,
 ): Prerenderer {
   let prerenderURL = new URL(prerenderServerURL);
-  return async function prerender({
-    realm,
-    url,
-    userId,
-    permissions,
-    renderOptions,
-  }: Parameters<Prerenderer>[0]): Promise<RenderResponse> {
-    let endpoint = new URL('prerender', prerenderURL);
 
+  async function request<T>(
+    path: string,
+    type: string,
+    attributes: Record<string, unknown>,
+  ): Promise<T> {
+    let endpoint = new URL(path, prerenderURL);
     let body = {
       data: {
-        type: 'prerender-request',
-        attributes: {
-          realm,
-          url,
-          userId,
-          permissions,
-          renderOptions: renderOptions ?? {},
-        },
+        type,
+        attributes,
       },
     };
 
@@ -58,11 +51,40 @@ export function createRemotePrerenderer(
       throw new Error('Failed to parse prerender response as JSON');
     }
 
-    let renderResponse: RenderResponse | undefined = json?.data?.attributes;
-    if (!renderResponse) {
+    let attributesPayload: T | undefined = json?.data?.attributes;
+    if (!attributesPayload) {
       throw new Error('Prerender response did not contain data.attributes');
     }
 
-    return renderResponse;
+    return attributesPayload;
+  }
+
+  return {
+    async prerenderCard({ realm, url, userId, permissions, renderOptions }) {
+      return await request<RenderResponse>(
+        'prerender-card',
+        'prerender-request',
+        {
+          realm,
+          url,
+          userId,
+          permissions,
+          renderOptions: renderOptions ?? {},
+        },
+      );
+    },
+    async prerenderModule({ realm, url, userId, permissions, renderOptions }) {
+      return await request<ModulePrerenderResponse>(
+        'prerender-module',
+        'prerender-module-request',
+        {
+          realm,
+          url,
+          userId,
+          permissions,
+          renderOptions: renderOptions ?? {},
+        },
+      );
+    },
   };
 }

--- a/packages/realm-server/prerender/utils.ts
+++ b/packages/realm-server/prerender/utils.ts
@@ -310,8 +310,11 @@ export async function captureModule(
   return capture;
 }
 
-// For render captures we intentionally do not enforce id/nonce parity here.
-// The module capture handles that check once the DOM settles.
+// captureResult is only used by card prerenders. Cards surface their id/nonce
+// through `[data-prerender]` elements, but those attributes can appear after
+// the DOM has settled so we tolerate them being absent while waiting. Module
+// prerenders capture via `captureModule`, which performs strict id/nonce parity
+// checks once the module container is present.
 export async function captureResult(
   page: Page,
   capture: 'textContent' | 'innerHTML' | 'outerHTML',

--- a/packages/realm-server/prerender/utils.ts
+++ b/packages/realm-server/prerender/utils.ts
@@ -29,6 +29,13 @@ export interface CaptureOptions {
   simulateTimeoutMs?: number;
 }
 
+export interface ModuleCapture {
+  status: 'ready' | 'error';
+  value: string;
+  id?: string;
+  nonce?: string;
+}
+
 export async function transitionTo(
   page: Page,
   routeName: string,
@@ -168,6 +175,32 @@ function buildInvalidRenderResponseError(
   };
 }
 
+export function buildInvalidModuleResponseError(
+  page: Page,
+  message: string,
+  options?: { title?: string; evict?: boolean },
+): RenderError {
+  let id: string | null = null;
+  try {
+    let pathname = new URL(page.url()).pathname;
+    let match = /\/module\/([^/]+)\//.exec(pathname);
+    id = match?.[1] ? decodeURIComponent(match[1]) : null;
+  } catch {
+    id = null;
+  }
+  return {
+    type: 'error',
+    error: {
+      id,
+      status: 500,
+      title: options?.title ?? 'Invalid module response',
+      message,
+      additionalErrors: null,
+    },
+    ...(options?.evict ? { evict: true } : {}),
+  };
+}
+
 export async function renderAncestors(
   page: Page,
   format: 'embedded' | 'fitted',
@@ -183,9 +216,102 @@ export async function renderAncestors(
   return ancestors;
 }
 
-// TODO i think comparing the id and nonce between the URL and DOM is overkill.
-// at one point the AI was getting paranoid about the URL and DOM being out of
-// sync. let's remove that logic its just bloat...
+export async function captureModule(
+  page: Page,
+  opts?: CaptureOptions,
+): Promise<ModuleCapture | RenderError> {
+  try {
+    await page.waitForFunction(
+      (expectedId: string | null, expectedNonce: string | null) => {
+        let container = document.querySelector(
+          '[data-prerender-module]',
+        ) as HTMLElement | null;
+        if (!container) {
+          return false;
+        }
+        let status = container.dataset.prerenderModuleStatus ?? '';
+        let id = container.dataset.prerenderModuleId ?? null;
+        let nonce = container.dataset.prerenderModuleNonce ?? null;
+        if (expectedId && id !== expectedId) {
+          return false;
+        }
+        if (expectedNonce && nonce !== expectedNonce) {
+          return false;
+        }
+        if (!status) {
+          return false;
+        }
+        if (!id || !nonce) {
+          return false;
+        }
+        let pre = container.querySelector('pre');
+        let value = pre?.textContent ?? '';
+        return value.trim().length > 0;
+      },
+      { timeout: renderTimeoutMs },
+      opts?.expectedId ?? null,
+      opts?.expectedNonce ?? null,
+    );
+  } catch (_e) {
+    return buildInvalidModuleResponseError(
+      page,
+      'module prerender timed out waiting for module output',
+      { title: 'Module capture timeout', evict: true },
+    );
+  }
+
+  let capture = await page.evaluate(() => {
+    let container = document.querySelector(
+      '[data-prerender-module]',
+    ) as HTMLElement | null;
+    if (!container) {
+      return null;
+    }
+    let pre = container.querySelector('pre');
+    let value = pre?.textContent ?? '';
+    let status = (container.dataset.prerenderModuleStatus ?? 'ready') as
+      | 'ready'
+      | 'error';
+    return {
+      status,
+      value,
+      id: container.dataset.prerenderModuleId ?? undefined,
+      nonce: container.dataset.prerenderModuleNonce ?? undefined,
+    } satisfies ModuleCapture;
+  });
+
+  if (!capture) {
+    return buildInvalidModuleResponseError(
+      page,
+      'module prerender did not produce output',
+      { title: 'Invalid module response' },
+    );
+  }
+
+  if (opts?.expectedId && capture.id !== opts.expectedId) {
+    return buildInvalidModuleResponseError(
+      page,
+      `module prerender captured stale output for ${capture.id ?? 'unknown id'} (expected ${opts.expectedId})`,
+      { title: 'Stale module response', evict: true },
+    );
+  }
+  if (opts?.expectedNonce && capture.nonce !== opts.expectedNonce) {
+    return buildInvalidModuleResponseError(
+      page,
+      `module prerender captured stale nonce ${capture.nonce ?? 'unknown'} (expected ${opts.expectedNonce})`,
+      { title: 'Stale module response', evict: true },
+    );
+  }
+
+  if (opts?.simulateTimeoutMs) {
+    await delay(opts.simulateTimeoutMs);
+  }
+
+  return capture;
+}
+
+// For render captures we intentionally do not enforce id/nonce parity here.
+// The module capture handles that check once the DOM settles.
 export async function captureResult(
   page: Page,
   capture: 'textContent' | 'innerHTML' | 'outerHTML',

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -206,8 +206,13 @@ async function getTestPrerenderer(
   usePrerenderer?: boolean,
 ): Promise<Prerenderer> {
   if (!usePrerenderer) {
-    return async () => {
-      throw new Error(`prerenderer not enabled`);
+    return {
+      async prerenderCard() {
+        throw new Error(`prerenderer not enabled`);
+      },
+      async prerenderModule() {
+        throw new Error(`prerenderer not enabled`);
+      },
     };
   }
   // in node context this is a boolean
@@ -1021,8 +1026,10 @@ export function setupPermissionedRealms(
 
   hooks[mode === 'beforeEach' ? 'afterEach' : 'after'](async function () {
     for (let realm of realms) {
+      realm.realm.__testOnlyClearCaches();
       await closeServer(realm.realmHttpServer);
     }
+    realms = [];
   });
 }
 

--- a/packages/realm-server/worker.ts
+++ b/packages/realm-server/worker.ts
@@ -102,8 +102,13 @@ if (process.env.USE_HEADLESS_CHROME_INDEXING === 'true' && prerendererUrl) {
   log.info(`Using prerender server ${prerendererUrl}`);
   prerenderer = createRemotePrerenderer(prerendererUrl);
 } else {
-  prerenderer = async () => {
-    throw new Error(`Prerenderer server has not been configured/enabled`);
+  prerenderer = {
+    async prerenderCard() {
+      throw new Error(`Prerenderer server has not been configured/enabled`);
+    },
+    async prerenderModule() {
+      throw new Error(`Prerenderer server has not been configured/enabled`);
+    },
   };
 }
 

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -159,7 +159,7 @@ export * from './index-query-engine';
 export * from './index-writer';
 export * from './index-structure';
 export * from './db';
-export * from './lint';
+export * from './tasks';
 export * from './worker';
 export * from './stream';
 export * from './realm';

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -1,6 +1,7 @@
 import type { CardResource, Meta } from './resource-types';
 import type { ResolvedCodeRef } from './code-ref';
 import type { RenderRouteOptions } from './render-route-options';
+import type { Definition } from './index-structure';
 
 import type { RealmEventContent } from 'https://cardstack.com/base/matrix-event';
 import type { ErrorEntry } from './index-writer';
@@ -47,13 +48,40 @@ export interface RenderError extends ErrorEntry {
   evict?: boolean;
 }
 
-export type Prerenderer = (args: {
+export interface ModuleDefinitionResult {
+  type: 'definition';
+  definition: Definition;
+  types: string[];
+}
+
+export interface ModulePrerenderModel {
+  id: string;
+  status: 'ready' | 'error';
+  nonce: string;
+  isShimmed: boolean;
+  lastModified: number;
+  createdAt: number;
+  deps: string[];
+  definitions: Record<string, ModuleDefinitionResult | ErrorEntry>;
+  error?: ErrorEntry;
+}
+
+export interface ModulePrerenderResponse extends ModulePrerenderModel {}
+
+export type ModulePrerenderArgs = {
   realm: string;
   url: string;
   userId: string;
   permissions: RealmPermissions;
   renderOptions?: RenderRouteOptions;
-}) => Promise<RenderResponse>;
+};
+
+export type PrerenderCardArgs = ModulePrerenderArgs;
+
+export interface Prerenderer {
+  prerenderCard(args: PrerenderCardArgs): Promise<RenderResponse>;
+  prerenderModule(args: ModulePrerenderArgs): Promise<ModulePrerenderResponse>;
+}
 
 export type RealmAction = 'read' | 'write' | 'realm-owner' | 'assume-user';
 

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -46,6 +46,8 @@ import {
   type FieldDefinition,
   type RealmPermissions,
   type RealmAction,
+  type LintArgs,
+  type LintResult,
   codeRefWithAbsoluteURL,
   isResolvedCodeRef,
   userInitiatedPriority,
@@ -101,7 +103,6 @@ import type {
   RealmEventContent,
   UpdateRealmEventContent,
 } from 'https://cardstack.com/base/matrix-event';
-import type { LintArgs, LintResult } from './lint';
 import type {
   AtomicOperation,
   AtomicOperationResult,

--- a/packages/runtime-common/tasks/copy.ts
+++ b/packages/runtime-common/tasks/copy.ts
@@ -1,0 +1,52 @@
+import type { Task, WorkerArgs } from './index';
+
+import { jobIdentity, SupportedMimeType, type RealmInfo } from '../index';
+
+export { copy };
+
+export interface CopyArgs extends WorkerArgs {
+  sourceRealmURL: string;
+}
+
+export interface CopyResult {
+  totalNonErrorIndexEntries: number;
+  invalidations: string[];
+}
+
+const copy: Task<CopyArgs, CopyResult> = ({
+  reportStatus,
+  log,
+  indexWriter,
+  getAuthedFetch,
+}) =>
+  async function (args) {
+    let { jobInfo, realmURL, sourceRealmURL } = args;
+    log.debug(
+      `${jobIdentity(jobInfo)} starting copy indexing for job: ${JSON.stringify(args)}`,
+    );
+    reportStatus(jobInfo, 'start');
+    let authedFetch = await getAuthedFetch(args);
+    let realmInfoResponse = await authedFetch(`${realmURL}_info`, {
+      headers: { Accept: SupportedMimeType.RealmInfo },
+    });
+    let realmInfo: RealmInfo = (await realmInfoResponse.json())?.data
+      ?.attributes;
+
+    let batch = await indexWriter.createBatch(new URL(realmURL));
+    await batch.copyFrom(new URL(sourceRealmURL), realmInfo);
+    let result = await batch.done();
+    let invalidations = batch.invalidations;
+    log.debug(
+      `${jobIdentity(jobInfo)} completed copy indexing for realm ${realmURL}:\n${JSON.stringify(
+        result,
+        null,
+        2,
+      )}`,
+    );
+    let { totalIndexEntries: totalNonErrorIndexEntries } = result;
+    reportStatus(jobInfo, 'finish');
+    return {
+      invalidations,
+      totalNonErrorIndexEntries,
+    };
+  };

--- a/packages/runtime-common/tasks/full-reindex.ts
+++ b/packages/runtime-common/tasks/full-reindex.ts
@@ -123,7 +123,7 @@ const fullReindexBatch: Task<FullReindexBatchArgs, void> = ({
   queuePublisher,
 }) =>
   async function (args) {
-    let { jobInfo, totalBatches, batchNumber } = args;
+    let { jobInfo, totalBatches, batchNumber, realms } = args;
     log.debug(
       `${jobIdentity(jobInfo)} starting full-reindex batch for job: ${JSON.stringify(
         args,
@@ -134,7 +134,6 @@ const fullReindexBatch: Task<FullReindexBatchArgs, void> = ({
     let cooldownSeconds = normalizeFullReindexCooldownSeconds(
       args.cooldownSeconds,
     );
-    let realms = [...args.realms];
     let cooldownMs =
       cooldownSeconds > 0 ? Math.floor(cooldownSeconds * 1000) : 0;
 

--- a/packages/runtime-common/tasks/full-reindex.ts
+++ b/packages/runtime-common/tasks/full-reindex.ts
@@ -1,0 +1,224 @@
+import type * as JSONTypes from 'json-typescript';
+import type { Task } from './index';
+// TODO import this from sibling module
+import type { FromScratchResult } from '../worker';
+
+import {
+  jobIdentity,
+  fetchAllRealmsWithOwners,
+  systemInitiatedPriority,
+  normalizeFullReindexBatchSize,
+  fullReindexBatchTimeoutSeconds,
+  normalizeFullReindexCooldownSeconds,
+  type Job,
+} from '../index';
+
+import { enqueueReindexRealmJob } from '../jobs/reindex-realm';
+
+export interface RealmReindexTarget extends JSONTypes.Object {
+  realmUrl: string;
+  realmUsername: string;
+}
+
+interface FullReindexArgs {
+  realmUrls: string[];
+  concurrency: number;
+  batchSize?: number;
+  cooldownSeconds?: number;
+}
+interface FullReindexBatchArgs extends JSONTypes.Object {
+  realms: RealmReindexTarget[];
+  cooldownSeconds: number;
+  batchNumber: number;
+  totalBatches: number;
+}
+export const FULL_REINDEX_BATCH_JOB = 'full-reindex-batch';
+const FULL_REINDEX_BATCH_CONCURRENCY_GROUP = 'full-reindex-group';
+
+export { fullReindex, fullReindexBatch };
+
+const fullReindex: Task<FullReindexArgs, void> = ({
+  reportStatus,
+  log,
+  dbAdapter,
+  queuePublisher,
+}) =>
+  async function (args) {
+    let { jobInfo, realmUrls, concurrency } = args;
+    log.debug(
+      `${jobIdentity(jobInfo)} starting reindex-all for job: ${JSON.stringify(args)}`,
+    );
+    reportStatus(jobInfo, 'start');
+
+    const realmOwners = await fetchAllRealmsWithOwners(dbAdapter);
+
+    const ownerMap = new Map(
+      realmOwners.map((r) => [r.realm_url, r.owner_username]),
+    );
+
+    // Only include realms with a non-bot owner
+    const realmsWithUsernames = realmUrls
+      .map((realmUrl) => {
+        const username = ownerMap.get(realmUrl)!;
+        return {
+          realmUrl,
+          realmUsername: username,
+        };
+      })
+      .filter((realm) => !realm.realmUsername.startsWith('@realm/'));
+
+    if (realmsWithUsernames.length === 0) {
+      log.debug(
+        `${jobIdentity(jobInfo)} no eligible realms found for full reindex`,
+      );
+      reportStatus(jobInfo, 'finish');
+      return;
+    }
+
+    let batchSize = normalizeFullReindexBatchSize(args.batchSize);
+    let cooldownSeconds = normalizeFullReindexCooldownSeconds(
+      args.cooldownSeconds,
+    );
+
+    let batches: RealmReindexTarget[][] = [];
+    for (let i = 0; i < realmsWithUsernames.length; i += batchSize) {
+      batches.push(realmsWithUsernames.slice(i, i + batchSize));
+    }
+
+    let totalBatches = batches.length;
+    for (let [index, batch] of batches.entries()) {
+      if (batch.length === 0) {
+        continue;
+      }
+      let timeout = fullReindexBatchTimeoutSeconds(
+        batch.length,
+        cooldownSeconds,
+      );
+      let concurrencySuffix = (index % concurrency) + 1;
+      await queuePublisher.publish<void>({
+        jobType: FULL_REINDEX_BATCH_JOB,
+        concurrencyGroup: `${FULL_REINDEX_BATCH_CONCURRENCY_GROUP}-${concurrencySuffix}`,
+        timeout,
+        priority: systemInitiatedPriority,
+        args: {
+          realms: batch,
+          cooldownSeconds,
+          batchNumber: index + 1,
+          totalBatches,
+        },
+      });
+    }
+
+    log.info(
+      `${jobIdentity(jobInfo)} scheduled full reindex for ${realmsWithUsernames.length} realm(s) across ${totalBatches} batch(es) with batch size ${batchSize} and cooldown ${cooldownSeconds}s`,
+    );
+
+    reportStatus(jobInfo, 'finish');
+  };
+
+const fullReindexBatch: Task<FullReindexBatchArgs, void> = ({
+  reportStatus,
+  log,
+  dbAdapter,
+  queuePublisher,
+}) =>
+  async function (args) {
+    let { jobInfo, totalBatches, batchNumber } = args;
+    log.debug(
+      `${jobIdentity(jobInfo)} starting full-reindex batch for job: ${JSON.stringify(
+        args,
+      )}`,
+    );
+    reportStatus(jobInfo, 'start');
+
+    let cooldownSeconds = normalizeFullReindexCooldownSeconds(
+      args.cooldownSeconds,
+    );
+    let realms = [...args.realms];
+    let cooldownMs =
+      cooldownSeconds > 0 ? Math.floor(cooldownSeconds * 1000) : 0;
+
+    let enqueueFailures: { target: RealmReindexTarget; error: Error }[] = [];
+    let completedCount = 0;
+    let failedRuns: {
+      target: RealmReindexTarget;
+      error: Error;
+    }[] = [];
+
+    let batchLabel = `batch ${batchNumber}/${totalBatches}`;
+
+    log.info(
+      `${jobIdentity(jobInfo)} starting ${batchLabel} with ${realms.length} realm(s)`,
+    );
+
+    for (let index = 0; index < realms.length; index++) {
+      let target = realms[index];
+      let job: Job<FromScratchResult> | undefined;
+      try {
+        job = await enqueueReindexRealmJob(
+          target.realmUrl,
+          target.realmUsername,
+          queuePublisher,
+          dbAdapter,
+          systemInitiatedPriority,
+        );
+      } catch (error: any) {
+        log.error(
+          `${jobIdentity(jobInfo)} failed to enqueue from-scratch job for ${target.realmUrl}`,
+          error,
+        );
+        enqueueFailures.push({
+          target,
+          error: error instanceof Error ? error : new Error(String(error)),
+        });
+        continue;
+      }
+
+      try {
+        await job.done;
+        completedCount++;
+      } catch (error: any) {
+        let normalizedError =
+          error instanceof Error ? error : new Error(String(error));
+        log.error(
+          `${jobIdentity(jobInfo)} from-scratch job for ${target.realmUrl} rejected`,
+          normalizedError,
+        );
+        failedRuns.push({ target, error: normalizedError });
+      }
+
+      if (index < realms.length - 1 && cooldownMs > 0) {
+        await sleep(cooldownMs);
+      }
+    }
+
+    if (failedRuns.length > 0 || enqueueFailures.length > 0) {
+      let totalFailures = failedRuns.length + enqueueFailures.length;
+      log.warn(
+        `${jobIdentity(jobInfo)} full-reindex batch completed with ${totalFailures} failure(s) (${failedRuns.length} runtime, ${enqueueFailures.length} enqueue)`,
+      );
+      let failureSummary = [
+        enqueueFailures.length
+          ? `${enqueueFailures.length} enqueue failure(s)`
+          : null,
+        failedRuns.length ? `${failedRuns.length} runtime failure(s)` : null,
+      ]
+        .filter(Boolean)
+        .join(', ');
+      throw new Error(
+        `${jobIdentity(jobInfo)} full-reindex batch had ${failureSummary}`,
+      );
+    } else {
+      log.info(
+        `${jobIdentity(jobInfo)} completed ${batchLabel} for ${completedCount} realm(s)`,
+      );
+    }
+
+    reportStatus(jobInfo, 'finish');
+  };
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms).unref?.();
+  });
+}

--- a/packages/runtime-common/tasks/index.ts
+++ b/packages/runtime-common/tasks/index.ts
@@ -1,0 +1,29 @@
+import type * as JSONTypes from 'json-typescript';
+import {
+  type QueuePublisher,
+  type DBAdapter,
+  type logger,
+  type IndexWriter,
+} from '../index';
+import type { JobInfo } from '../worker';
+export * from './lint';
+export * from './full-reindex';
+export * from './copy';
+
+export interface TaskArgs {
+  dbAdapter: DBAdapter;
+  queuePublisher: QueuePublisher;
+  indexWriter: IndexWriter;
+  log: ReturnType<typeof logger>;
+  getAuthedFetch(args: WorkerArgs): Promise<typeof globalThis.fetch>;
+  reportStatus(jobInfo: JobInfo | undefined, status: 'start' | 'finish'): void;
+}
+
+export type Task<T, K> = (
+  args: TaskArgs,
+) => (args: T & { jobInfo?: JobInfo }) => Promise<K>;
+
+export interface WorkerArgs extends JSONTypes.Object {
+  realmURL: string;
+  realmUsername: string;
+}

--- a/packages/runtime-common/tasks/index.ts
+++ b/packages/runtime-common/tasks/index.ts
@@ -1,20 +1,17 @@
 import type * as JSONTypes from 'json-typescript';
-import {
-  type QueuePublisher,
-  type DBAdapter,
-  type logger,
-  type IndexWriter,
-} from '../index';
+import type { QueuePublisher, DBAdapter, IndexWriter } from '../index';
 import type { JobInfo } from '../worker';
 export * from './lint';
 export * from './full-reindex';
 export * from './copy';
 
+type LoggerInstance = ReturnType<typeof import('../index').logger>;
+
 export interface TaskArgs {
   dbAdapter: DBAdapter;
   queuePublisher: QueuePublisher;
   indexWriter: IndexWriter;
-  log: ReturnType<typeof logger>;
+  log: LoggerInstance;
   getAuthedFetch(args: WorkerArgs): Promise<typeof globalThis.fetch>;
   reportStatus(jobInfo: JobInfo | undefined, status: 'start' | 'finish'): void;
 }

--- a/packages/runtime-common/worker.ts
+++ b/packages/runtime-common/worker.ts
@@ -1,6 +1,5 @@
 import type * as JSONTypes from 'json-typescript';
 import { parse } from 'date-fns';
-import type { IndexWriter, QueuePublisher, DBAdapter } from '.';
 import {
   Deferred,
   reportError,
@@ -15,13 +14,16 @@ import {
   logger,
   jobIdentity,
   userIdFromUsername,
+  fetchUserPermissions,
   type QueueRunner,
   type TextFileRef,
   type VirtualNetwork,
   type ResponseWithNodeStream,
   type Prerenderer,
   type RealmPermissions,
-  fetchUserPermissions,
+  type IndexWriter,
+  type QueuePublisher,
+  type DBAdapter,
 } from '.';
 import { MatrixClient } from './matrix-client';
 import * as Tasks from './tasks';

--- a/packages/runtime-common/worker.ts
+++ b/packages/runtime-common/worker.ts
@@ -25,7 +25,7 @@ import {
 } from '.';
 import { MatrixClient } from './matrix-client';
 import * as Tasks from './tasks';
-import { type WorkerArgs, type TaskArgs } from './tasks';
+import type { WorkerArgs, TaskArgs } from './tasks';
 
 export interface Stats extends JSONTypes.Object {
   instancesIndexed: number;


### PR DESCRIPTION
This depends on PR https://github.com/cardstack/boxel/pull/3539. please review and merge that first. The meat of this change is in commit https://github.com/cardstack/boxel/pull/3543/commits/df776cdc69cd64ec3d01b11a8791beee2408020d

This PR breaks apart logic in the worker for the various jobs into their own modules which is prep for moving `current-run.ts` node code into the worker.