### PR TITLE
Hide the create card button for readonly realm in catalog modal

### DIFF
--- a/packages/host/app/components/card-catalog/index.gts
+++ b/packages/host/app/components/card-catalog/index.gts
@@ -168,7 +168,7 @@ export default class CardCatalog extends Component<Signature> {
               container='card-catalog'
             }}
           >
-            {{#if @offerToCreate}}
+            {{#if (this.showCreateCardForRealm realmUrl)}}
               {{#let
                 (deepEq @selectedCard (this.newCardArgs realmUrl))
                 as |isSelected|
@@ -252,19 +252,21 @@ export default class CardCatalog extends Component<Signature> {
                 container='card-catalog'
               }}
             >
-              {{#let
-                (deepEq @selectedCard (this.newCardArgs realmUrl))
-                as |isSelected|
-              }}
-                <ItemButton
-                  @newCard={{this.newCardArgs realmUrl}}
-                  @isSelected={{isSelected}}
-                  @select={{@select}}
-                  @handleEnterKey={{this.handleEnterKey}}
-                  @newCardKey={{this.newCardKey}}
-                  @cardRefName={{this.cardRefName}}
-                />
-              {{/let}}
+              {{#if (this.showCreateCardForRealm realmUrl)}}
+                {{#let
+                  (deepEq @selectedCard (this.newCardArgs realmUrl))
+                  as |isSelected|
+                }}
+                  <ItemButton
+                    @newCard={{this.newCardArgs realmUrl}}
+                    @isSelected={{isSelected}}
+                    @select={{@select}}
+                    @handleEnterKey={{this.handleEnterKey}}
+                    @newCardKey={{this.newCardKey}}
+                    @cardRefName={{this.cardRefName}}
+                  />
+                {{/let}}
+              {{/if}}
             </ul>
           </section>
         {{/each-in}}
@@ -420,6 +422,10 @@ export default class CardCatalog extends Component<Signature> {
       this.args.select(card, event);
     }
   }
+
+  private showCreateCardForRealm = (realmURL: string) => {
+    return !!this.args.offerToCreate && this.realm.canWrite(realmURL);
+  };
 
   @action
   private newCardArgs(realmURL: string) {

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -1438,6 +1438,42 @@ module('Acceptance | interact submode tests', function (hooks) {
         .dom("[data-test-field='friends'] [data-test-remove-card]")
         .exists();
     });
+
+    test('card catalog create buttons respect realm write permissions for linksTo field', async function (assert) {
+      await visitOperatorMode({
+        stacks: [
+          [
+            {
+              id: `${testRealm2URL}Person/hassan`,
+              format: 'isolated',
+            },
+          ],
+        ],
+      });
+
+      await click('[data-test-stack-card-index="0"] [data-test-edit-button]');
+      await click('[data-test-add-new="friends"]');
+
+      await waitFor('[data-test-card-catalog]');
+      await waitFor('[data-test-realm="Test Workspace A"]');
+      await waitFor('[data-test-realm="Test Workspace B"]');
+
+      assert
+        .dom(`[data-test-card-catalog-create-new-button="${testRealm2URL}"]`)
+        .exists('create button is shown for writable realm');
+
+      assert
+        .dom(`[data-test-card-catalog-create-new-button="${testRealmURL}"]`)
+        .doesNotExist('create button is hidden for read-only realm');
+
+      await triggerKeyEvent(
+        '[data-test-card-catalog-modal]',
+        'keydown',
+        'Escape',
+      );
+      await waitFor('[data-test-card-catalog]', { count: 0 });
+    });
+
     test('the delete item is not present in "..." menu of stack item', async function (assert) {
       await visitOperatorMode({
         stacks: [


### PR DESCRIPTION
In the card catalog modal, we need to check whether the user has write permission to the realm before displaying the “Create Card” button.

Before:
<img width="1084" height="666" alt="Screenshot 2025-11-10 at 15 18 53" src="https://github.com/user-attachments/assets/269991fb-bd8a-4ce0-8389-5998f81da202" />

After:

<img width="1108" height="665" alt="Screenshot 2025-11-10 at 15 19 46" src="https://github.com/user-attachments/assets/14bf8e9a-2dac-40e8-937f-aaeaedea8ddf" />
