### PR TITLE
Make patch commands more optimistic

### DIFF
--- a/packages/host/app/commands/patch-card-instance.ts
+++ b/packages/host/app/commands/patch-card-instance.ts
@@ -52,10 +52,14 @@ export default class PatchCardInstanceCommand extends HostBaseCommand<
         "Patch command can't run because it doesn't have all the fields in arguments returned by open ai",
       );
     }
-    await this.store.patch(input.cardId, {
-      attributes: input.patch.attributes,
-      relationships: input.patch.relationships,
-    });
+    await this.store.patch(
+      input.cardId,
+      {
+        attributes: input.patch.attributes,
+        relationships: input.patch.relationships,
+      },
+      { doNotWaitForPersist: true },
+    );
   }
 
   async getInputJsonSchema(

--- a/packages/host/app/commands/patch-code.ts
+++ b/packages/host/app/commands/patch-code.ts
@@ -73,7 +73,7 @@ export default class PatchCodeCommand extends HostBaseCommand<
         );
 
       if (!(await this.trySaveThroughOpenFile(finalFileUrl, patchedCode))) {
-        void this.cardService
+        this.cardService
           .saveSource(new URL(finalFileUrl), patchedCode, 'bot-patch', {
             resetLoader: hasExecutableExtension(finalFileUrl),
             clientRequestId,

--- a/packages/host/app/commands/patch-code.ts
+++ b/packages/host/app/commands/patch-code.ts
@@ -12,9 +12,9 @@ import ApplySearchReplaceBlockCommand from './apply-search-replace-block';
 import LintAndFixCommand from './lint-and-fix';
 
 import type CardService from '../services/card-service';
+import type CommandService from '../services/command-service';
 import type MonacoService from '../services/monaco-service';
 import type OperatorModeStateService from '../services/operator-mode-state-service';
-import type CommandService from '../services/command-service';
 import type RealmService from '../services/realm';
 
 interface FileInfo {

--- a/packages/host/app/commands/patch-code.ts
+++ b/packages/host/app/commands/patch-code.ts
@@ -72,7 +72,13 @@ export default class PatchCodeCommand extends HostBaseCommand<
           roomId,
         );
 
-      if (!(await this.trySaveThroughOpenFile(finalFileUrl, patchedCode))) {
+      if (
+        !(await this.trySaveThroughOpenFile(
+          finalFileUrl,
+          patchedCode,
+          clientRequestId,
+        ))
+      ) {
         this.cardService
           .saveSource(new URL(finalFileUrl), patchedCode, 'bot-patch', {
             resetLoader: hasExecutableExtension(finalFileUrl),
@@ -102,6 +108,7 @@ export default class PatchCodeCommand extends HostBaseCommand<
   private async trySaveThroughOpenFile(
     targetFileUrl: string,
     content: string,
+    clientRequestId?: string,
   ): Promise<boolean> {
     try {
       let openFileResource = this.operatorModeStateService.openFile?.current;
@@ -117,6 +124,7 @@ export default class PatchCodeCommand extends HostBaseCommand<
         .write(content, {
           flushLoader: hasExecutableExtension(targetFileUrl),
           saveType: 'bot-patch',
+          clientRequestId,
         })
         .catch((error: unknown) => {
           console.error(

--- a/packages/host/app/commands/patch-fields.ts
+++ b/packages/host/app/commands/patch-fields.ts
@@ -155,10 +155,14 @@ export default class PatchFieldsCommand extends HostBaseCommand<
       // Only apply changes if at least some fields were updated successfully
       if (successfulUpdates.length > 0) {
         // Apply the updated data node (attributes and relationships)
-        const result = await this.store.patch(input.cardId, {
-          attributes: workingData.attributes,
-          relationships: workingData.relationships,
-        });
+        const result = await this.store.patch(
+          input.cardId,
+          {
+            attributes: workingData.attributes,
+            relationships: workingData.relationships,
+          },
+          { doNotWaitForPersist: true },
+        );
 
         if (result && 'errors' in result) {
           // Store operation failed - mark all attempted updates as failed

--- a/packages/host/app/resources/file.ts
+++ b/packages/host/app/resources/file.ts
@@ -106,7 +106,11 @@ export interface Ready {
   size: number; // size in bytes
   write(
     content: string,
-    opts?: { flushLoader?: boolean; saveType?: SaveType },
+    opts?: {
+      flushLoader?: boolean;
+      saveType?: SaveType;
+      clientRequestId?: string;
+    },
   ): Promise<void>;
   lastModifiedAsDate?: Date;
   isBinary?: boolean;
@@ -245,7 +249,11 @@ class _FileResource extends Resource<Args> {
       url: response.url,
       write(
         content: string,
-        opts?: { flushLoader?: boolean; saveType?: SaveType },
+        opts?: {
+          flushLoader?: boolean;
+          saveType?: SaveType;
+          clientRequestId?: string;
+        },
       ) {
         self.writing = self.writeTask
           .unlinked() // If the component which performs this task from within another task is destroyed, for example the "add field" modal, we want this task to continue running
@@ -318,13 +326,20 @@ class _FileResource extends Resource<Args> {
     async (
       state: Ready,
       content: string,
-      opts?: { flushLoader?: boolean; saveType?: SaveType },
+      opts?: {
+        flushLoader?: boolean;
+        saveType?: SaveType;
+        clientRequestId?: string;
+      },
     ) => {
       let response = await this.cardService.saveSource(
         new URL(this._url),
         content,
         opts?.saveType ?? 'editor',
-        { resetLoader: opts?.flushLoader },
+        {
+          resetLoader: opts?.flushLoader,
+          clientRequestId: opts?.clientRequestId,
+        },
       );
       if (this.innerState.state === 'not-found') {
         // TODO think about the "unauthorized" scenario

--- a/packages/host/app/resources/file.ts
+++ b/packages/host/app/resources/file.ts
@@ -25,8 +25,54 @@ import type NetworkService from '../services/network';
 const log = logger('resource:file');
 const realmEventsLogger = logger('realm:events');
 
-const utf8 = new TextDecoder();
-const encoder = new TextEncoder();
+type TextDecoderCtor = typeof TextDecoder;
+type TextEncoderCtor = typeof TextEncoder;
+type BufferLike = {
+  from(
+    input: ArrayBuffer | ArrayBufferView | string,
+    encoding?: string,
+  ): { toString(encoding?: string): string; length: number };
+  byteLength?(input: string, encoding?: string): number;
+};
+
+const TextDecoderImpl = (
+  globalThis as typeof globalThis & { TextDecoder?: TextDecoderCtor }
+).TextDecoder;
+const TextEncoderImpl = (
+  globalThis as typeof globalThis & { TextEncoder?: TextEncoderCtor }
+).TextEncoder;
+const BufferImpl = (
+  globalThis as typeof globalThis & {
+    Buffer?: BufferLike;
+  }
+).Buffer;
+
+const utf8Decoder = TextDecoderImpl ? new TextDecoderImpl() : undefined;
+const utf8Encoder = TextEncoderImpl ? new TextEncoderImpl() : undefined;
+
+function decodeUtf8(buffer: ArrayBuffer): string {
+  if (utf8Decoder) {
+    return utf8Decoder.decode(buffer);
+  }
+  if (BufferImpl) {
+    // Buffer handles ArrayBuffer and ArrayBufferView inputs in Node environments
+    return BufferImpl.from(buffer).toString('utf8');
+  }
+  throw new Error('No UTF-8 decoder available in this environment');
+}
+
+function utf8ByteLength(content: string): number {
+  if (utf8Encoder) {
+    return utf8Encoder.encode(content).byteLength;
+  }
+  if (BufferImpl) {
+    if (typeof BufferImpl.byteLength === 'function') {
+      return BufferImpl.byteLength(content, 'utf8');
+    }
+    return BufferImpl.from(content, 'utf8').length;
+  }
+  return content.length;
+}
 
 interface Args {
   named: {
@@ -184,7 +230,7 @@ class _FileResource extends Resource<Args> {
 
     let buffer = await response.arrayBuffer();
     let size = buffer.byteLength;
-    let content = utf8.decode(buffer);
+    let content = decodeUtf8(buffer);
 
     let self = this;
     let rawName = response.url.split('/').pop();
@@ -286,7 +332,7 @@ class _FileResource extends Resource<Args> {
           'this should be impossible--we are creating the specified path',
         );
       }
-      let size = encoder.encode(content).byteLength;
+      let size = utf8ByteLength(content);
 
       this.updateState({
         state: 'ready',

--- a/packages/host/app/services/command-service.ts
+++ b/packages/host/app/services/command-service.ts
@@ -357,10 +357,14 @@ export default class CommandService extends Service {
             "Patch command can't run because it doesn't have all the fields in arguments returned by open ai",
           );
         }
-        await this.store.patch(payload?.attributes?.cardId, {
-          attributes: payload?.attributes?.patch?.attributes,
-          relationships: payload?.attributes?.patch?.relationships,
-        });
+        await this.store.patch(
+          payload?.attributes?.cardId,
+          {
+            attributes: payload?.attributes?.patch?.attributes,
+            relationships: payload?.attributes?.patch?.relationships,
+          },
+          { doNotWaitForPersist: true },
+        );
       } else {
         // Unrecognized command. This can happen if a programmatically-provided command is no longer available due to a browser refresh.
         throw new Error(

--- a/packages/host/tests/acceptance/code-patches-test.gts
+++ b/packages/host/tests/acceptance/code-patches-test.gts
@@ -30,6 +30,7 @@ import {
   setupAuthEndpoints,
   setupUserSubscription,
   getMonacoContent,
+  TestContextWithSave,
 } from '../helpers';
 
 import { CardsGrid, setupBaseRealm } from '../helpers/base-realm';
@@ -1453,7 +1454,7 @@ ${REPLACE_MARKER}
       );
   });
 
-  test('automatic Accept All spinner appears in Act mode for multiple patches', async function (assert) {
+  test<TestContextWithSave>('automatic Accept All spinner appears in Act mode for multiple patches', async function (assert) {
     await visitOperatorMode({
       submode: 'code',
       codePath: `${testRealmURL}hello.txt`,
@@ -1533,6 +1534,12 @@ ${REPLACE_MARKER}
         'Apply Diff',
         'Action bar shows applying text during automatic execution',
       );
+
+    let save = 0;
+    this.onSave((_saveURL) => {
+      save++;
+    });
+    await waitUntil(() => save >= 2, { timeout: 2000 });
 
     // Wait for all patches to be applied
     await waitUntil(

--- a/packages/host/tests/integration/commands/patch-code-test.gts
+++ b/packages/host/tests/integration/commands/patch-code-test.gts
@@ -1,7 +1,11 @@
+import { waitUntil } from '@ember/test-helpers';
+
 import { getService } from '@universal-ember/test-support';
+
 import { module, test } from 'qunit';
 
 import {
+  Deferred,
   REPLACE_MARKER,
   SEARCH_MARKER,
   SEPARATOR_MARKER,
@@ -9,6 +13,8 @@ import {
 } from '@cardstack/runtime-common';
 
 import PatchCodeCommand from '@cardstack/host/commands/patch-code';
+import { Submodes } from '@cardstack/host/components/submode-switcher';
+import { isReady, type Ready } from '@cardstack/host/resources/file';
 
 import {
   testRealmURL,
@@ -131,5 +137,79 @@ export class Task extends CardDef {
   </template>
 }`;
     assert.strictEqual(result.patchedContent, expectedResult);
+  });
+
+  test('uses the open file resource when the target file is open', async function (assert) {
+    assert.expect(7);
+
+    let commandService = getService('command-service');
+    let patchCodeCommand = new PatchCodeCommand(commandService.commandContext);
+    let operatorModeStateService = getService('operator-mode-state-service');
+    let cardService = getService('card-service');
+
+    operatorModeStateService.restore({
+      stacks: [[]],
+      submode: Submodes.Code,
+      codePath: fileUrl,
+    });
+
+    await waitUntil(() => isReady(operatorModeStateService.openFile?.current));
+
+    let openFileResource = operatorModeStateService.openFile?.current;
+    assert.ok(openFileResource, 'open file resource exists');
+    assert.ok(
+      isReady(openFileResource),
+      'open file resource is ready before patch',
+    );
+
+    let deferredSave = new Deferred<void>();
+    let saveCalls = 0;
+    let originalSaveSource = cardService.saveSource;
+    cardService.saveSource = async (
+      ...args: Parameters<typeof originalSaveSource>
+    ) => {
+      saveCalls++;
+      await deferredSave.promise;
+      return originalSaveSource.apply(cardService, args);
+    };
+
+    const codeBlock = `${SEARCH_MARKER}
+  @field priority = contains(NumberField);
+${SEPARATOR_MARKER}
+  @field priority = contains(NumberField);
+  <template>
+    {{#if (eq priority 1)}}
+      <p>High Priority</p>
+    {{/if}}
+  </template>
+${REPLACE_MARKER}`;
+
+    try {
+      await patchCodeCommand.execute({
+        fileUrl,
+        codeBlocks: [codeBlock],
+      });
+      let maybeLatestResource = operatorModeStateService.openFile?.current;
+      assert.ok(maybeLatestResource, 'open file resource still exists');
+      assert.ok(
+        isReady(maybeLatestResource),
+        'open file resource remains ready after patch',
+      );
+      let latestResource = maybeLatestResource as Ready;
+      assert.ok(
+        latestResource.writing,
+        'write is initiated on the open file resource',
+      );
+      deferredSave.fulfill();
+      await latestResource.writing;
+      assert.ok(
+        latestResource.content.includes('High Priority'),
+        'patched content is reflected in the open file resource',
+      );
+      assert.strictEqual(saveCalls, 1, 'save source is invoked exactly once');
+    } finally {
+      cardService.saveSource = originalSaveSource;
+      operatorModeStateService.restore({ stacks: [[]] });
+    }
   });
 });

--- a/packages/host/tests/integration/commands/patch-fields-test.gts
+++ b/packages/host/tests/integration/commands/patch-fields-test.gts
@@ -179,7 +179,16 @@ module('Integration | Command | patch-fields', function (hooks) {
 
       let patchOptions: Parameters<StoreService['patch']>[2];
       let originalPatch = store.patch;
-      store.patch = async function (this: StoreService, id, patch, opts) {
+      store.patch = async function (
+        this: StoreService,
+        id,
+        patch,
+        opts: {
+          doNotPersist?: true;
+          doNotWaitForPersist?: true;
+          clientRequestId?: string;
+        },
+      ) {
         patchOptions = opts;
         return await originalPatch.call(this, id, patch, opts);
       };

--- a/packages/host/tests/integration/commands/patch-fields-test.gts
+++ b/packages/host/tests/integration/commands/patch-fields-test.gts
@@ -1,3 +1,5 @@
+import { waitUntil } from '@ember/test-helpers';
+
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
@@ -9,6 +11,9 @@ import {
   testRealmURL,
   setupIntegrationTestRealm,
   setupLocalIndexing,
+  setupOnSave,
+  withSlowSave,
+  type TestContextWithSave,
 } from '../../helpers';
 import {
   CardDef,
@@ -31,6 +36,7 @@ module('Integration | Command | patch-fields', function (hooks) {
   setupRenderingTest(hooks);
   setupBaseRealm(hooks);
   setupLocalIndexing(hooks);
+  setupOnSave(hooks);
   let mockMatrixUtils = setupMockMatrix(hooks, { autostart: true });
 
   let commandService: CommandService;
@@ -149,6 +155,82 @@ module('Integration | Command | patch-fields', function (hooks) {
       },
     });
     store = getService('store');
+  });
+
+  module('Optimistic persistence behavior', function () {
+    test<TestContextWithSave>('patches do not await persistence', async function (assert) {
+      assert.expect(6);
+
+      let patchFieldsCommand = new PatchFieldsCommand(
+        commandService.commandContext,
+        {
+          cardType: AuthorDef,
+        },
+      );
+      let cardId = `${testRealmURL}Author/john`;
+      let store = getService('store');
+
+      let saves = 0;
+      this.onSave((url) => {
+        if (url.href === cardId) {
+          saves++;
+        }
+      });
+
+      let patchOptions: Parameters<StoreService['patch']>[2];
+      let originalPatch = store.patch;
+      store.patch = async function (this: StoreService, id, patch, opts) {
+        patchOptions = opts;
+        return await originalPatch.call(this, id, patch, opts);
+      };
+
+      try {
+        await withSlowSave(100, async () => {
+          let result = await patchFieldsCommand.execute({
+            cardId,
+            fieldUpdates: {
+              firstName: 'Jane Optimistic',
+            },
+          });
+
+          assert.true(result.success, 'command succeeds');
+
+          let localCard = store.peek(cardId);
+          assert.ok(localCard, 'local card is present');
+          if (isCard(localCard)) {
+            assert.strictEqual(
+              (localCard as any).firstName,
+              'Jane Optimistic',
+              'local card updated immediately',
+            );
+          } else {
+            assert.ok(false, 'local card should be a card instance');
+          }
+
+          assert.strictEqual(saves, 0, 'no persistence yet');
+        });
+      } finally {
+        store.patch = originalPatch;
+      }
+
+      assert.true(
+        patchOptions?.doNotWaitForPersist,
+        'store.patch receives doNotWaitForPersist option',
+      );
+
+      await waitUntil(() => saves > 0);
+
+      let persistedCard = await store.get(cardId);
+      if (isCard(persistedCard)) {
+        assert.strictEqual(
+          (persistedCard as any).firstName,
+          'Jane Optimistic',
+          'change persists after background save completes',
+        );
+      } else {
+        assert.ok(false, 'persisted card should exist');
+      }
+    });
   });
 
   module('Simple Field Update Tests', function () {

--- a/packages/host/tests/integration/commands/patch-instance-test.gts
+++ b/packages/host/tests/integration/commands/patch-instance-test.gts
@@ -363,7 +363,11 @@ module('Integration | commands | patch-instance', function (hooks) {
       this: typeof storeService,
       id,
       patch,
-      opts,
+      opts: {
+        doNotPersist?: true;
+        doNotWaitForPersist?: true;
+        clientRequestId?: string;
+      },
     ) {
       patchOptions = opts;
       return await originalPatch.call(this, id, patch, opts);

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -1015,6 +1015,51 @@ module('Integration | Store', function (hooks) {
     );
   });
 
+  test<TestContextWithSave>('can skip waiting for the save when patching an instance', async function (assert) {
+    assert.expect(4);
+
+    let targetId = `${testRealmURL}Person/hassan`;
+    let instance = await storeService.get(targetId);
+
+    let didSave = false;
+    this.onSave((url, doc) => {
+      if (url.href === targetId) {
+        didSave = true;
+        assert.strictEqual(
+          (doc as SingleCardDocument).data.attributes?.name,
+          'Hassan Updated',
+          'patched data is persisted',
+        );
+      }
+    });
+
+    await storeService.patch(
+      targetId,
+      {
+        attributes: {
+          name: 'Hassan Updated',
+        },
+      },
+      { doNotWaitForPersist: true },
+    );
+
+    assert.strictEqual(
+      (instance as any).name,
+      'Hassan Updated',
+      'local instance updated immediately',
+    );
+    assert.false(didSave, 'instance has not been persisted yet');
+
+    await waitUntil(() => didSave);
+
+    let file = await testRealmAdapter.openFile('Person/hassan.json');
+    assert.strictEqual(
+      JSON.parse(file!.content as string).data.attributes.name,
+      'Hassan Updated',
+      'remote document reflects patch after persistence completes',
+    );
+  });
+
   test('can patch an unsaved instance', async function (assert) {
     let instance = new PersonDef({ name: 'Andrea' });
     await storeService.add(instance, {


### PR DESCRIPTION
The scope of this PR is to make the patch commands faster by avoiding the wait for the HTTP `PATCH` request to complete. The idea is to update the local data first before calling the patch endpoint.

For patching instances and fields, we can handle this through the store. I’ve added a new option called `doNotWaitForPersist` the same option we already have in `store.add`, which allows us to modify the card instance and trigger the patch endpoint without waiting for the request to succeed.

The patch code is slightly different. Previously, we directly called the `cardService.saveCard` function to send the patch request, without modifying any local data first. To make it consistent with the other commands, I’ve added logic to check the currently open file. If the open file is the same as the one being patched, we call the patch endpoint through the file resource instead. (I’m open to other approaches if you have suggestions.)