### PR TITLE
refactor linksToMany proxy to reduce reliance on the "hot path"

### DIFF
--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -574,6 +574,9 @@ export function getLinksToManyComponent({
       }
       if (typeof property === 'string' && property.match(/\d+/)) {
         let child = arrayField.children[parseInt(property)];
+        if (!child) {
+          return undefined;
+        }
         return getBoxComponent(cardTypeFor(field, child), child, field);
       }
       return Reflect.get(target, property, received);

--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -564,16 +564,17 @@ export function getLinksToManyComponent({
     get(target, property, received) {
       // proxying the bare minimum of an Array in order to render within a
       // template. add more getters as necessary...
-      let components = getComponents();
-
       if (property === Symbol.iterator) {
+        // getComponents() is in the "hot" path, don't touch it unless absolutely necessary
+        let components = getComponents();
         return components[Symbol.iterator];
       }
       if (property === 'length') {
-        return components.length;
+        return arrayField.children.length;
       }
       if (typeof property === 'string' && property.match(/\d+/)) {
-        return components[parseInt(property)];
+        let child = arrayField.children[parseInt(property)];
+        return getBoxComponent(cardTypeFor(field, child), child, field);
       }
       return Reflect.get(target, property, received);
     },

--- a/packages/realm-server/prerender/utils.ts
+++ b/packages/realm-server/prerender/utils.ts
@@ -10,7 +10,7 @@ import type { Page } from 'puppeteer';
 
 const log = logger('prerenderer');
 
-export const renderTimeoutMs = Number(process.env.RENDER_TIMEOUT_MS ?? 180_000);
+export const renderTimeoutMs = Number(process.env.RENDER_TIMEOUT_MS ?? 15_000);
 
 export type RenderStatus = 'ready' | 'error' | 'unusable';
 

--- a/packages/realm-server/prerender/utils.ts
+++ b/packages/realm-server/prerender/utils.ts
@@ -10,7 +10,7 @@ import type { Page } from 'puppeteer';
 
 const log = logger('prerenderer');
 
-export const renderTimeoutMs = Number(process.env.RENDER_TIMEOUT_MS ?? 15_000);
+export const renderTimeoutMs = Number(process.env.RENDER_TIMEOUT_MS ?? 20_000);
 
 export type RenderStatus = 'ready' | 'error' | 'unusable';
 


### PR DESCRIPTION
Lazily load components in the linksToMany component proxy so that we touch the "hot" path as little as possible.
This reduces the render time for our problematic card (was 2 minutes, then 38 seconds after ed's refactor) to 4.5s.