### PR TITLE
Fix full reset

### DIFF
--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -22,7 +22,7 @@
     "stop:pg": "./scripts/stop-pg.sh",
     "migrate": "PGDATABASE=boxel ./scripts/ensure-db-exists.sh && PGPORT=5435 PGDATABASE=boxel PGUSER=postgres node-pg-migrate --migrations-table migrations",
     "make-schema": "./scripts/schema-dump.sh",
-    "drop-db": "docker exec boxel-pg dropdb -U postgres -w",
+    "drop-db": "docker exec boxel-pg dropdb --if-exists -U postgres -w",
     "lint": "concurrently \"pnpm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"pnpm:lint:*:fix\" --names \"fix:\"",
     "lint:js": "eslint . --report-unused-disable-directives --cache",

--- a/packages/realm-server/scripts/full-reset.sh
+++ b/packages/realm-server/scripts/full-reset.sh
@@ -6,6 +6,7 @@ cd ${SCRIPTS_DIR}/../../postgres
 pnpm run drop-db boxel
 pnpm run drop-db boxel_test
 pnpm run drop-db boxel_base
+pnpm migrate up
 
 # clearing the DB means that we also lose all the info we have on the realm
 # owners of the dynamic realms, which means that we should eliminate these as


### PR DESCRIPTION
`pnpm full-reset` has been broken, likely since the addition of multiplexed realm login, because `register-test-user` relies on the database existing but it hasn’t been created by the time the script attempts to create users. That meant `full-reset` looked something like this:

```
❯ pnpm full-reset

> @cardstack/realm-server@0.0.0 full-reset /Users/b/Documents/Cardstack/Code/boxel-motion/packages/realm-server
> ./scripts/full-reset.sh


> @cardstack/postgres@0.0.0 drop-db /Users/b/Documents/Cardstack/Code/boxel-motion/packages/postgres
> docker exec boxel-pg dropdb -U postgres -w boxel


> @cardstack/postgres@0.0.0 drop-db /Users/b/Documents/Cardstack/Code/boxel-motion/packages/postgres
> docker exec boxel-pg dropdb -U postgres -w boxel_test

dropdb: error: database removal failed: ERROR:  database "boxel_test" does not exist
 ELIFECYCLE  Command failed with exit code 1.

> @cardstack/postgres@0.0.0 drop-db /Users/b/Documents/Cardstack/Code/boxel-motion/packages/postgres
> docker exec boxel-pg dropdb -U postgres -w boxel_base

dropdb: error: database removal failed: ERROR:  database "boxel_base" does not exist
 ELIFECYCLE  Command failed with exit code 1.

> @cardstack/matrix@1.0.0 stop:synapse /Users/b/Documents/Cardstack/Code/boxel-motion/packages/matrix
> ts-node --transpileOnly ./scripts/synapse.ts stop

stopped container 'boxel-synapse'

> @cardstack/matrix@1.0.0 start:synapse /Users/b/Documents/Cardstack/Code/boxel-motion/packages/matrix
> mkdir -p ./synapse-data/db && SYNAPSE_DATA_DIR=./synapse-data ts-node --transpileOnly ./scripts/synapse.ts start

Copy /Users/b/Documents/Cardstack/Code/boxel-motion/packages/matrix/docker/synapse/dev -> /Users/b/Documents/Cardstack/Code/boxel-motion/packages/matrix/synapse-data
Gen /Users/b/Documents/Cardstack/Code/boxel-motion/packages/matrix/docker/synapse/dev/homeserver.yaml
Gen /Users/b/Documents/Cardstack/Code/boxel-motion/packages/matrix/docker/synapse/dev/localhost.signing.key
Starting synapse with config dir /Users/b/Documents/Cardstack/Code/boxel-motion/packages/matrix/synapse-data in container boxel-synapse...
Started synapse with id 58cecec056ca1b63d29e3f5cbf7b0cc4c85efe0f85f3e32e1cc1714d71b6329f on port 8008

> @cardstack/matrix@1.0.0 register-all /Users/b/Documents/Cardstack/Code/boxel-motion/packages/matrix
> pnpm register-test-admin-and-token && pnpm register-realm-users && pnpm register-bot-user && pnpm register-test-user && pnpm register-skills-writer


> @cardstack/matrix@1.0.0 register-test-admin-and-token /Users/b/Documents/Cardstack/Code/boxel-motion/packages/matrix
> pnpm register-test-admin && ts-node --transpileOnly ./scripts/register-test-token.ts


> @cardstack/matrix@1.0.0 register-test-admin /Users/b/Documents/Cardstack/Code/boxel-motion/packages/matrix
> MATRIX_IS_ADMIN=TRUE MATRIX_USERNAME=admin MATRIX_PASSWORD=password ts-node --transpileOnly ./scripts/register-test-user.ts

Sending registration request...
Success!
/Users/b/Documents/Cardstack/Code/boxel-motion/packages/matrix/scripts/register-test-user.ts:61
          new Error(
          ^
Error: Failed to ensure user @admin:localhost in users table: psql: error: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: FATAL:  database "boxel" does not exist
    at ChildProcess.<anonymous> (/Users/b/Documents/Cardstack/Code/boxel-motion/packages/matrix/scripts/register-test-user.ts:61:11)
    at ChildProcess.emit (node:events:519:28)
    at ChildProcess.emit (node:domain:489:12)
    at maybeClose (node:internal/child_process:1101:16)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:304:5)
 ELIFECYCLE  Command failed with exit code 1.
 ELIFECYCLE  Command failed with exit code 1.

…
```

This adds a `pnpm migrate up` to ensure the database exists before registering users and also `dropdb --if-exists` to silence the red herring errors that show if you’re running `full-reset` after things haven’t been fully reconstructed.