### PR TITLE
Persist attached files and cards

### DIFF
--- a/packages/host/app/components/ai-assistant/attachment-picker/index.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/index.gts
@@ -110,10 +110,18 @@ export default class AiAssistantAttachmentPicker extends Component<Signature> {
   private get files() {
     let files = this.args.filesToAttach ?? [];
 
-    if (this.args.autoAttachedFile) {
-      files = [...new Set([this.args.autoAttachedFile, ...files])];
+    if (!this.args.autoAttachedFile) {
+      return files;
     }
 
-    return files;
+    if (
+      files.some(
+        (file) => file.sourceUrl === this.args.autoAttachedFile?.sourceUrl,
+      )
+    ) {
+      return files;
+    }
+
+    return [this.args.autoAttachedFile, ...files];
   }
 }

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -460,6 +460,7 @@ export default class Room extends Component<Signature> {
   });
   private removedAttachedCardIds = new TrackedArray<string>();
   private removedAttachedFileUrls: string[] = [];
+  private lastAutoAttachedFileUrl: string | undefined;
   private getConversationScrollability: (() => boolean) | undefined;
   private scrollConversationToBottom: (() => void) | undefined;
   private roomScrollState: WeakMap<
@@ -541,7 +542,15 @@ export default class Room extends Component<Signature> {
 
     let autoAttachedFileUrl = this.autoAttachedFileUrl;
     let manuallyAttachedFiles = this.filesToAttach;
-    let removedFileUrls = this.removedAttachedFileUrls;
+
+    let removedFileUrls: string[];
+    if (autoAttachedFileUrl !== this.lastAutoAttachedFileUrl) {
+      this.removedAttachedFileUrls.splice(0);
+      removedFileUrls = this.removedAttachedFileUrls;
+      this.lastAutoAttachedFileUrl = autoAttachedFileUrl;
+    } else {
+      removedFileUrls = this.removedAttachedFileUrls;
+    }
 
     let isManuallyAttached = manuallyAttachedFiles.some(
       (file) => file.sourceUrl === autoAttachedFileUrl,
@@ -562,10 +571,9 @@ export default class Room extends Component<Signature> {
     return state;
   });
 
-  @use private autoAttachedFileUrl = resource(() => {
-    this.removedAttachedFileUrls.splice(0);
+  private get autoAttachedFileUrl() {
     return this.operatorModeStateService.state.codePath?.href;
-  });
+  }
 
   private get autoAttachedFile() {
     return this.operatorModeStateService.state.submode === Submodes.Code

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -562,16 +562,9 @@ export default class Room extends Component<Signature> {
     return state;
   });
 
-  private get autoAttachedFileUrl() {
-    let url = this.operatorModeStateService.state.codePath?.href;
-    // use a task to avoid ember/no-side-effects rule violation
-    this.resetAttachedFileRemovedStateTask.perform();
-    return url;
-  }
-
-  private resetAttachedFileRemovedStateTask = task(async () => {
-    await Promise.resolve();
+  @use private autoAttachedFileUrl = resource(() => {
     this.removedAttachedFileUrls.splice(0);
+    return this.operatorModeStateService.state.codePath?.href;
   });
 
   private get autoAttachedFile() {

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -540,10 +540,10 @@ export default class Room extends Component<Signature> {
     });
 
     let autoAttachedFileUrl = this.autoAttachedFileUrl;
-    let manualFiles = this.filesToAttach;
+    let manuallyAttachedFiles = this.filesToAttach;
     let removedFileUrls = this.removedAttachedFileUrls;
 
-    let isManuallyAttached = manualFiles.some(
+    let isManuallyAttached = manuallyAttachedFiles.some(
       (file) => file.sourceUrl === autoAttachedFileUrl,
     );
     let isRemoved = autoAttachedFileUrl
@@ -582,7 +582,6 @@ export default class Room extends Component<Signature> {
 
   private get removeAutoAttachedFile() {
     return () => {
-      //this.markAttachedFileRemoved(this.autoAttachedFileUrl);
       this.autoAttachedFileResource.remove();
     };
   }
@@ -1023,14 +1022,14 @@ export default class Room extends Component<Signature> {
       return;
     }
 
-    let next = files.filter((f) => f.sourceUrl !== file.sourceUrl);
-    if (next.length === files.length) {
+    let newFiles = files.filter((f) => f.sourceUrl !== file.sourceUrl);
+    if (newFiles.length === files.length) {
       return;
     }
 
     this.matrixService.setFilesToSend(
       this.args.roomId,
-      next.length ? next : undefined,
+      newFiles.length ? newFiles : undefined,
     );
 
     this.markAttachedFileRemoved(file.sourceUrl);
@@ -1060,8 +1059,8 @@ export default class Room extends Component<Signature> {
       // If the send fails, we restore those saved values in the catch block so nothing is lost.
       if (shouldClearDraft) {
         this.matrixService.setMessageToSend(this.args.roomId, undefined);
-        this.matrixService.cardsToSend.set(this.args.roomId, undefined);
-        this.matrixService.filesToSend.set(this.args.roomId, undefined);
+        this.matrixService.setCardsToSend(this.args.roomId, undefined);
+        this.matrixService.setFilesToSend(this.args.roomId, undefined);
       }
 
       let openCardIds = new Set([

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -198,7 +198,7 @@ export default class MatrixService extends Service {
 
   private slidingSync: SlidingSync | undefined;
   private aiRoomIds: Set<string> = new Set();
-  private hydratedDraftRooms = new Set<string>();
+  private restoredDraftRooms = new Set<string>();
   @tracked private _isLoadingMoreAIRooms = false;
   private initialSyncCompleted = false;
   private initialSyncCompletedDeferred = new Deferred<void>();
@@ -214,7 +214,7 @@ export default class MatrixService extends Service {
   }
 
   setMessageToSend(roomId: string, message: string | undefined) {
-    this.ensureRoomDraftHydrated(roomId);
+    this.ensureMessageDraftRestored(roomId);
     if (message === undefined) {
       this.messagesToSend.delete(roomId);
     } else {
@@ -224,12 +224,12 @@ export default class MatrixService extends Service {
   }
 
   getMessageToSend(roomId: string) {
-    this.ensureRoomDraftHydrated(roomId);
+    this.ensureMessageDraftRestored(roomId);
     return this.messagesToSend.get(roomId);
   }
 
   setCardsToSend(roomId: string, cardIds: string[] | undefined) {
-    this.ensureRoomDraftHydrated(roomId);
+    this.ensureMessageDraftRestored(roomId);
     let sanitized = cardIds?.filter(
       (id): id is string => typeof id === 'string' && id.length > 0,
     );
@@ -243,12 +243,12 @@ export default class MatrixService extends Service {
   }
 
   getCardsToSend(roomId: string) {
-    this.ensureRoomDraftHydrated(roomId);
+    this.ensureMessageDraftRestored(roomId);
     return this.cardsToSend.get(roomId);
   }
 
   setFilesToSend(roomId: string, files: FileDef[] | undefined) {
-    this.ensureRoomDraftHydrated(roomId);
+    this.ensureMessageDraftRestored(roomId);
     let nextFiles = files && files.length > 0 ? [...files] : undefined;
     if (nextFiles) {
       this.filesToSend.set(roomId, nextFiles);
@@ -262,7 +262,7 @@ export default class MatrixService extends Service {
   }
 
   getFilesToSend(roomId: string) {
-    this.ensureRoomDraftHydrated(roomId);
+    this.ensureMessageDraftRestored(roomId);
     return this.filesToSend.get(roomId);
   }
 
@@ -1240,7 +1240,7 @@ export default class MatrixService extends Service {
     this.cardsToSend = new TrackedMap();
     this.filesToSend = new TrackedMap();
     this.currentUserEventReadReceipts = new TrackedMap();
-    this.hydratedDraftRooms = new Set();
+    this.restoredDraftRooms = new Set();
 
     // Reset it here rather than in the reset function of each service
     // because it is possible that
@@ -2001,11 +2001,11 @@ export default class MatrixService extends Service {
     ]);
   }
 
-  private ensureRoomDraftHydrated(roomId: string) {
-    if (this.hydratedDraftRooms.has(roomId)) {
+  private ensureMessageDraftRestored(roomId: string) {
+    if (this.restoredDraftRooms.has(roomId)) {
       return;
     }
-    this.hydratedDraftRooms.add(roomId);
+    this.restoredDraftRooms.add(roomId);
 
     let draft = this.localPersistenceService.getDraft(roomId);
     if (!draft) {

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -2834,10 +2834,7 @@ module('Acceptance | AI Assistant tests', function (hooks) {
       {
         from: 'testuser',
         message: 'Message with another card',
-        cards: [
-          { id: `${testRealmURL}Person/hassan`, title: 'Hassan' },
-          { id: `${testRealmURL}Pet/mango`, title: 'Mango' },
-        ],
+        cards: [{ id: `${testRealmURL}Pet/mango`, title: 'Mango' }],
       },
     ]);
     // Create new session with "Copy File History" option
@@ -2984,7 +2981,6 @@ module('Acceptance | AI Assistant tests', function (hooks) {
       {
         from: 'testuser',
         message: 'Can you help me understand this structure?',
-        files: [{ sourceUrl: `${testRealmURL}pet.gts`, name: 'pet.gts' }],
       },
     ]);
 
@@ -3274,10 +3270,7 @@ module('Acceptance | AI Assistant tests', function (hooks) {
       {
         from: 'testuser',
         message: 'Third message with another card',
-        cards: [
-          { id: `${testRealmURL}Person/hassan`, title: 'Hassan' },
-          { id: `${testRealmURL}Pet/mango`, title: 'Mango' },
-        ],
+        cards: [{ id: `${testRealmURL}Pet/mango`, title: 'Mango' }],
       },
     ]);
 
@@ -3326,10 +3319,7 @@ module('Acceptance | AI Assistant tests', function (hooks) {
       {
         from: 'testuser',
         message: 'Third message with another card',
-        cards: [
-          { id: `${testRealmURL}Person/hassan`, title: 'Hassan' },
-          { id: `${testRealmURL}Pet/mango`, title: 'Mango' },
-        ],
+        cards: [{ id: `${testRealmURL}Pet/mango`, title: 'Mango' }],
       },
     ]);
 

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -2452,7 +2452,7 @@ module('Acceptance | AI Assistant tests', function (hooks) {
       aiAssistantOpen: true,
     });
 
-    await waitFor(`[data-room-settled]`);
+    await waitFor(`[data-test-room-settled]`);
     await click('[data-test-module-inspector-view="spec"]');
     await waitFor('[data-test-spec-selector-item-path]');
 

--- a/packages/host/tests/integration/components/ai-assistant-panel/sending-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/sending-test.gts
@@ -346,9 +346,13 @@ module('Integration | ai-assistant-panel | sending', function (hooks) {
       try {
         let parsed = JSON.parse(raw);
         return Boolean(parsed?.[roomId]);
-      } catch {
-        return false;
+      } catch (e) {
+        // Fail the test if JSON parsing fails
+        throw new Error(`Failed to parse localStorage draft: ${e.message}`);
       }
+    }, {
+      timeout: 3000,
+      timeoutMessage: 'Timed out waiting for localStorage to contain a draft for the room',
     });
 
     let rawDraft = window.localStorage.getItem(AiAssistantMessageDrafts);

--- a/packages/host/tests/integration/components/ai-assistant-panel/sending-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/sending-test.gts
@@ -338,22 +338,26 @@ module('Integration | ai-assistant-panel | sending', function (hooks) {
 
     await fillIn('[data-test-message-field]', 'Persist attachments');
 
-    await waitUntil(() => {
-      let raw = window.localStorage.getItem(AiAssistantMessageDrafts);
-      if (!raw) {
-        return false;
-      }
-      try {
-        let parsed = JSON.parse(raw);
-        return Boolean(parsed?.[roomId]);
-      } catch (e) {
-        // Fail the test if JSON parsing fails
-        throw new Error(`Failed to parse localStorage draft: ${e.message}`);
-      }
-    }, {
-      timeout: 3000,
-      timeoutMessage: 'Timed out waiting for localStorage to contain a draft for the room',
-    });
+    await waitUntil(
+      () => {
+        let raw = window.localStorage.getItem(AiAssistantMessageDrafts);
+        if (!raw) {
+          return false;
+        }
+        try {
+          let parsed = JSON.parse(raw);
+          return Boolean(parsed?.[roomId]);
+        } catch (e: any) {
+          // Fail the test if JSON parsing fails
+          throw new Error(`Failed to parse localStorage draft: ${e.message}`);
+        }
+      },
+      {
+        timeout: 3000,
+        timeoutMessage:
+          'Timed out waiting for localStorage to contain a draft for the room',
+      },
+    );
 
     let rawDraft = window.localStorage.getItem(AiAssistantMessageDrafts);
     assert.ok(rawDraft, 'draft stored in localStorage');

--- a/packages/host/tests/integration/components/ai-assistant-panel/sending-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/sending-test.gts
@@ -18,8 +18,10 @@ import { Loader } from '@cardstack/runtime-common/loader';
 
 import CardPrerender from '@cardstack/host/components/card-prerender';
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
+import { Submodes } from '@cardstack/host/components/submode-switcher';
 
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
+import { AiAssistantMessageDrafts } from '@cardstack/host/utils/local-storage-keys';
 
 import {
   percySnapshot,
@@ -292,5 +294,94 @@ module('Integration | ai-assistant-panel | sending', function (hooks) {
     assert
       .dom('[data-test-message-field]')
       .hasValue('This is 1st sentence \n\nThis is 2nd sentence');
+  });
+
+  test('draft attachments persist across panel reopen without duplicating auto attachments', async function (assert) {
+    window.localStorage.removeItem(AiAssistantMessageDrafts);
+
+    operatorModeStateService.restore({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}Person/fadhlan`,
+            format: 'isolated',
+          },
+        ],
+      ],
+      submode: Submodes.Code,
+      codePath: `${testRealmURL}person.gts`,
+      aiAssistantOpen: false,
+    });
+
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template>
+          <OperatorMode @onClose={{noop}} />
+          <CardPrerender />
+        </template>
+      },
+    );
+
+    let roomId = await openAiAssistant();
+    await waitFor('[data-test-autoattached-file]');
+
+    await click('[data-test-attach-button]');
+    await click('[data-test-attach-card-btn]');
+    await fillIn('[data-test-search-field]', 'Fadhlan');
+    await click(`[data-test-select="${testRealmURL}Person/fadhlan"]`);
+    await click('[data-test-card-catalog-go-button]');
+
+    await click('[data-test-attach-button]');
+    await click('[data-test-attach-file-btn]');
+    await click('[data-test-file="person.gts"]');
+    await click('[data-test-choose-file-modal-add-button]');
+
+    await fillIn('[data-test-message-field]', 'Persist attachments');
+
+    await waitUntil(() => {
+      let raw = window.localStorage.getItem(AiAssistantMessageDrafts);
+      if (!raw) {
+        return false;
+      }
+      try {
+        let parsed = JSON.parse(raw);
+        return Boolean(parsed?.[roomId]);
+      } catch {
+        return false;
+      }
+    });
+
+    let rawDraft = window.localStorage.getItem(AiAssistantMessageDrafts);
+    assert.ok(rawDraft, 'draft stored in localStorage');
+    let parsedDraft = rawDraft ? JSON.parse(rawDraft) : undefined;
+    let draftForRoom = parsedDraft?.[roomId];
+    assert.deepEqual(draftForRoom?.attachedCardIds, [
+      `${testRealmURL}Person/fadhlan`,
+    ]);
+    assert.strictEqual(
+      draftForRoom?.attachedFiles?.[0]?.sourceUrl,
+      `${testRealmURL}person.gts`,
+    );
+
+    await click('[data-test-close-ai-assistant]');
+    await click('[data-test-open-ai-assistant]');
+    await waitFor('[data-test-room-settled]');
+    await waitFor(`[data-test-attached-card="${testRealmURL}Person/fadhlan"]`);
+
+    assert.dom('[data-test-message-field]').hasValue('Persist attachments');
+    assert
+      .dom(`[data-test-attached-card="${testRealmURL}Person/fadhlan"]`)
+      .exists({ count: 1 });
+    assert
+      .dom(
+        `[data-test-autoattached-card][data-test-attached-card="${testRealmURL}Person/fadhlan"]`,
+      )
+      .doesNotExist();
+    assert.dom('[data-test-attached-file]').exists({ count: 1 });
+    assert
+      .dom(
+        `[data-test-autoattached-file][data-test-attached-file="${testRealmURL}person.gts"]`,
+      )
+      .doesNotExist();
   });
 });


### PR DESCRIPTION
This PR fixes an issue where attached cards and files would suddenly disappear. In this update, I’ve enhanced the local-storage-service to also store attached cards and files along with draft message. This not only prevents attachments from disappearing unexpectedly but also ensures they persist after a browser reload or when a message fails to send.

https://github.com/user-attachments/assets/1552f229-111d-484d-9aa1-f001d483556c

