### PR TITLE
Improve naming directories for card of default export card defs

### DIFF
--- a/packages/host/tests/unit/card-directory-name-test.ts
+++ b/packages/host/tests/unit/card-directory-name-test.ts
@@ -1,0 +1,64 @@
+import { module, test } from 'qunit';
+
+import type { CodeRef } from '@cardstack/runtime-common';
+import { getCardDirectoryName } from '@cardstack/runtime-common/helpers/card-directory-name';
+import { RealmPaths } from '@cardstack/runtime-common/paths';
+
+module('Unit | runtime-common | card directory names', function () {
+  let paths: RealmPaths;
+
+  module('getCardDirectoryName', function (hooks) {
+    hooks.beforeEach(function () {
+      paths = new RealmPaths(new URL('http://example.com/test/'));
+    });
+
+    test('returns explicit export names when provided', function (assert) {
+      let ref: CodeRef = { module: '../pet', name: 'PetCard' };
+      assert.strictEqual(getCardDirectoryName(ref, paths), 'PetCard');
+    });
+
+    test('infers directory from module name for default exports', function (assert) {
+      let ref: CodeRef = { module: '../pet', name: 'default' };
+      assert.strictEqual(getCardDirectoryName(ref, paths), 'Pet');
+    });
+
+    test('uses parent directory when module is an index file', function (assert) {
+      let ref: CodeRef = { module: '../animals/index', name: 'default' };
+      assert.strictEqual(getCardDirectoryName(ref, paths), 'Animals');
+    });
+
+    test('strips executable extensions before inferring name', function (assert) {
+      let ref: CodeRef = {
+        module: '../cards/preview-card.gts',
+        name: 'default',
+      };
+      assert.strictEqual(getCardDirectoryName(ref, paths), 'PreviewCard');
+    });
+
+    test('sanitizes names with dashes and encoded characters', function (assert) {
+      let ref: CodeRef = {
+        module: '../fancy/%E2%9C%A8-sparkle-card',
+        name: 'default',
+      };
+      assert.strictEqual(getCardDirectoryName(ref, paths), 'SparkleCard');
+    });
+
+    test('prefixes directories that would start with invalid characters', function (assert) {
+      let ref: CodeRef = { module: '../123', name: 'default' };
+      assert.strictEqual(getCardDirectoryName(ref, paths), 'Card123');
+    });
+
+    test('resolves nested code refs like fieldOf', function (assert) {
+      let ref: CodeRef = {
+        type: 'fieldOf',
+        field: 'bio',
+        card: { module: '../person', name: 'default' },
+      };
+      assert.strictEqual(getCardDirectoryName(ref, paths), 'Person');
+    });
+
+    test('falls back to cards when adoptsFrom is missing', function (assert) {
+      assert.strictEqual(getCardDirectoryName(undefined, paths), 'cards');
+    });
+  });
+});

--- a/packages/runtime-common/helpers/card-directory-name.ts
+++ b/packages/runtime-common/helpers/card-directory-name.ts
@@ -1,0 +1,112 @@
+import camelCase from 'camelcase';
+
+import type { CodeRef, ResolvedCodeRef } from '../code-ref';
+import { trimExecutableExtension } from '../index';
+import type { RealmPaths } from '../paths';
+
+export function getCardDirectoryName(
+  adoptsFrom: CodeRef | undefined,
+  paths: RealmPaths,
+): string {
+  return (
+    directoryNameFromResolvedRef(resolveToResolvedCodeRef(adoptsFrom), paths) ??
+    'cards'
+  );
+}
+
+function resolveToResolvedCodeRef(
+  ref: CodeRef | undefined,
+): ResolvedCodeRef | undefined {
+  if (!ref) {
+    return undefined;
+  }
+  if ('type' in ref) {
+    return resolveToResolvedCodeRef(ref.card);
+  }
+  return ref;
+}
+
+function directoryNameFromResolvedRef(
+  ref: ResolvedCodeRef | undefined,
+  paths: RealmPaths,
+): string | undefined {
+  if (!ref) {
+    return undefined;
+  }
+  if (ref.name && ref.name !== 'default') {
+    return ref.name;
+  }
+  return directoryNameFromModule(ref.module, paths);
+}
+
+function directoryNameFromModule(
+  moduleIdentifier: string,
+  paths: RealmPaths,
+): string | undefined {
+  let segment: string | undefined;
+  try {
+    segment = lastMeaningfulSegment(
+      trimExecutableExtension(new URL(moduleIdentifier)).pathname,
+    );
+  } catch {
+    try {
+      segment = lastMeaningfulSegment(
+        trimExecutableExtension(new URL(moduleIdentifier, paths.url)).pathname,
+      );
+    } catch {
+      segment = undefined;
+    }
+  }
+  if (!segment) {
+    segment = lastMeaningfulSegment(moduleIdentifier);
+  }
+  return directoryNameFromSegment(segment);
+}
+
+function lastMeaningfulSegment(pathname: string): string | undefined {
+  let normalized = pathname.replace(/\\/g, '/').replace(/\/+$/, '');
+  let segments = normalized.split('/').filter(Boolean);
+  if (!segments.length) {
+    return undefined;
+  }
+  let candidate = segments.pop()!;
+  if (candidate === 'index' && segments.length) {
+    candidate = segments.pop()!;
+  }
+  candidate = candidate.replace(/\.[^/.]+$/, '');
+  candidate = candidate.trim();
+  if (!candidate) {
+    return undefined;
+  }
+  try {
+    candidate = decodeURIComponent(candidate);
+  } catch {
+    // ignore decode errors, fall back to raw segment
+  }
+  return candidate;
+}
+
+function directoryNameFromSegment(
+  segment: string | undefined,
+): string | undefined {
+  if (!segment) {
+    return undefined;
+  }
+
+  let candidate = segment.replace(/^[^\p{L}_$]+/u, '');
+
+  if (!candidate) {
+    candidate = `Card${segment}`.replace(/^[^\p{L}_$]+/u, '');
+  }
+
+  let pascal = camelCase(candidate, { pascalCase: true }).replace(
+    /[^\p{L}\p{N}_$]+/gu,
+    '',
+  );
+
+  if (!pascal) {
+    return undefined;
+  }
+
+  return pascal;
+}

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -1,4 +1,5 @@
 import { Deferred } from './deferred';
+import camelCase from 'camelcase';
 import {
   makeCardTypeSummaryDoc,
   transformResultsToPrerenderedCardsDoc,
@@ -25,6 +26,7 @@ import {
   executableExtensions,
   hasExecutableExtension,
   isNode,
+  trimExecutableExtension,
   logger,
   fetchRealmPermissions,
   insertPermissions,
@@ -1972,10 +1974,10 @@ export class Realm {
       ) {
         continue;
       }
-      let name =
-        'name' in resource.meta.adoptsFrom
-          ? resource.meta.adoptsFrom.name
-          : 'cards';
+      let name = directoryNameForAdoptsFrom(
+        resource.meta?.adoptsFrom,
+        this.paths,
+      );
 
       let fileURL = this.paths.fileURL(
         `/${join(new URL(request.url).pathname, name, (resource.lid ?? uuidV4()) + '.json')}`,
@@ -2172,10 +2174,10 @@ export class Realm {
       ) {
         continue;
       }
-      let name =
-        'name' in resource.meta.adoptsFrom
-          ? resource.meta.adoptsFrom.name
-          : 'cards';
+      let name = directoryNameForAdoptsFrom(
+        resource.meta?.adoptsFrom,
+        this.paths,
+      );
       let fileURL =
         i === 0
           ? new URL(`${url}.json`)
@@ -3330,10 +3332,10 @@ function promoteLocalIdsToRemoteIds({
     ) {
       return;
     }
-    let name =
-      'name' in sideLoadedResource.meta.adoptsFrom
-        ? sideLoadedResource.meta.adoptsFrom.name
-        : 'cards';
+    let name = directoryNameForAdoptsFrom(
+      sideLoadedResource.meta?.adoptsFrom,
+      paths,
+    );
     relationships[field].links = {
       self: paths.fileURL(`${name}/${lid}`).href,
     };
@@ -3353,6 +3355,113 @@ function promoteLocalIdsToRemoteIds({
       }
     }
   }
+}
+
+function directoryNameForAdoptsFrom(
+  adoptsFrom: CodeRef | undefined,
+  paths: RealmPaths,
+): string {
+  return (
+    directoryNameFromResolvedRef(resolveToResolvedCodeRef(adoptsFrom), paths) ??
+    'cards'
+  );
+}
+
+function resolveToResolvedCodeRef(
+  ref: CodeRef | undefined,
+): ResolvedCodeRef | undefined {
+  if (!ref) {
+    return undefined;
+  }
+  if ('type' in ref) {
+    return resolveToResolvedCodeRef(ref.card);
+  }
+  return ref;
+}
+
+function directoryNameFromResolvedRef(
+  ref: ResolvedCodeRef | undefined,
+  paths: RealmPaths,
+): string | undefined {
+  if (!ref) {
+    return undefined;
+  }
+  if (ref.name && ref.name !== 'default') {
+    return ref.name;
+  }
+  return directoryNameFromModule(ref.module, paths);
+}
+
+function directoryNameFromModule(
+  moduleIdentifier: string,
+  paths: RealmPaths,
+): string | undefined {
+  let segment: string | undefined;
+  try {
+    segment = lastMeaningfulSegment(
+      trimExecutableExtension(new URL(moduleIdentifier)).pathname,
+    );
+  } catch {
+    try {
+      segment = lastMeaningfulSegment(
+        trimExecutableExtension(new URL(moduleIdentifier, paths.url)).pathname,
+      );
+    } catch {
+      segment = undefined;
+    }
+  }
+  if (!segment) {
+    segment = lastMeaningfulSegment(moduleIdentifier);
+  }
+  return directoryNameFromSegment(segment);
+}
+
+function lastMeaningfulSegment(pathname: string): string | undefined {
+  let normalized = pathname.replace(/\\/g, '/').replace(/\/+$/, '');
+  let segments = normalized.split('/').filter(Boolean);
+  if (!segments.length) {
+    return undefined;
+  }
+  let candidate = segments.pop()!;
+  if (candidate === 'index' && segments.length) {
+    candidate = segments.pop()!;
+  }
+  candidate = candidate.replace(/\.[^/.]+$/, '');
+  candidate = candidate.trim();
+  if (!candidate) {
+    return undefined;
+  }
+  try {
+    candidate = decodeURIComponent(candidate);
+  } catch {
+    // ignore decode errors, fall back to raw segment
+  }
+  return candidate;
+}
+
+function directoryNameFromSegment(
+  segment: string | undefined,
+): string | undefined {
+  if (!segment) {
+    return undefined;
+  }
+
+  let candidate = segment.replace(/^[^\p{L}_$]+/u, '');
+
+  if (!candidate) {
+    candidate = `Card${segment}`.replace(/^[^\p{L}_$]+/u, '');
+  }
+
+  let pascal = camelCase(candidate, { pascalCase: true }).replace(
+    /[^\p{L}\p{N}_$]+/gu,
+    '',
+  );
+
+  if (!pascal) {
+    return undefined;
+  }
+
+  return pascal;
 }
 
 function assertRealmPermissions(


### PR DESCRIPTION
This PR adds a shared helper that reliably derives the directory name for newly created card instances, so default-exported card defs no longer end up in awkward `/default/<id>.json` folders, for example, a card adopting from `../pet` now saves under `/Pet/<id>.json` and a barrel like `../animals/index.gts` becomes `/Animals/<id>.json`.