### PR TITLE
Date time fields to use format helper

### DIFF
--- a/packages/catalog-realm/DateTimePreview/4ce6ea5b-2a18-4e7e-a5d1-40f9925e8845.json
+++ b/packages/catalog-realm/DateTimePreview/4ce6ea5b-2a18-4e7e-a5d1-40f9925e8845.json
@@ -22,7 +22,7 @@
         "value": "2025-W47"
       },
       "payPeriod": {
-        "value": "2025-12"
+        "value": "2025-06"
       },
       "publishIn": {
         "unit": null,
@@ -38,7 +38,7 @@
       "orderPlaced": "2025-11-06T13:18:00.000Z",
       "tokenExpiry": "2025-11-23T13:20:00.000Z",
       "billingMonth": {
-        "value": "07"
+        "value": 1
       },
       "taskDuration": {
         "hours": 10,
@@ -69,8 +69,11 @@
         "value": 2028
       },
       "appointmentDate": "2025-11-28",
+      "meetingTimeLong": {
+        "value": "09:15"
+      },
       "playgroundMonth": {
-        "value": "04"
+        "value": 4
       },
       "appointmentSlots": {
         "value": "13:00"
@@ -91,6 +94,10 @@
         "monthOfYear": null,
         "occurrences": null
       },
+      "meetingTime24Hour": {
+        "value": "14:30"
+      },
+      "eventDateTimeShort": "2025-11-25T15:30:00.000Z",
       "playgroundDatetime": "2025-11-22T05:19:00.000Z",
       "playgroundDuration": {
         "hours": null,
@@ -101,6 +108,7 @@
         "end": null,
         "start": null
       },
+      "eventDateTimeCustom": "2025-12-01T18:00:00.000Z",
       "playgroundDateRange": {
         "end": null,
         "start": null
@@ -117,6 +125,8 @@
           "value": null
         }
       },
+      "appointmentDateCustom": "2025-12-15",
+      "appointmentDateCompact": "2025-11-28",
       "playgroundPresentation": "standard",
       "playgroundRelativeTime": {
         "unit": null,

--- a/packages/catalog-realm/fields-preview/date-time.gts
+++ b/packages/catalog-realm/fields-preview/date-time.gts
@@ -362,6 +362,32 @@ class DateTimePreviewIsolated extends Component<typeof DateTimePreview> {
             </div>
           </div>
 
+          {{! ⁴³ DateField Format Examples }}
+          <div class='component-card'>
+            <div class='component-info'>
+              <h3>DateField - Tiny Preset</h3>
+              <p>Compact date display</p>
+              <code class='config'>configuration: &#123; preset: 'tiny' &#125;</code>
+              <span class='use-case'>Grids • Lists • Mobile Views</span>
+            </div>
+            <div class='component-demo'>
+              <@fields.appointmentDateCompact @format='embedded' />
+            </div>
+          </div>
+
+          <div class='component-card'>
+            <div class='component-info'>
+              <h3>DateField - Custom Format</h3>
+              <p>Day.js format string</p>
+              <code class='config'>configuration: &#123; format: 'MMM D, YYYY'
+                &#125;</code>
+              <span class='use-case'>Custom Displays • Reports</span>
+            </div>
+            <div class='component-demo'>
+              <@fields.appointmentDateCustom @format='embedded' />
+            </div>
+          </div>
+
           <div class='component-card'>
             <div class='component-info'>
               <h3>TimeField</h3>
@@ -374,6 +400,32 @@ class DateTimePreviewIsolated extends Component<typeof DateTimePreview> {
             </div>
           </div>
 
+          {{! ⁴⁴ TimeField Format Examples }}
+          <div class='component-card'>
+            <div class='component-info'>
+              <h3>TimeField - 24-Hour Format</h3>
+              <p>Military time display</p>
+              <code class='config'>configuration: &#123; hourCycle: 'h23' &#125;</code>
+              <span class='use-case'>International • Military • Technical</span>
+            </div>
+            <div class='component-demo'>
+              <@fields.meetingTime24Hour @format='embedded' />
+            </div>
+          </div>
+
+          <div class='component-card'>
+            <div class='component-info'>
+              <h3>TimeField - Long Style</h3>
+              <p>Includes timezone info</p>
+              <code class='config'>configuration: &#123; timeStyle: 'long'
+                &#125;</code>
+              <span class='use-case'>International Meetings • Timezones</span>
+            </div>
+            <div class='component-demo'>
+              <@fields.meetingTimeLong @format='embedded' />
+            </div>
+          </div>
+
           <div class='component-card'>
             <div class='component-info'>
               <h3>DatetimeField</h3>
@@ -383,6 +435,32 @@ class DateTimePreviewIsolated extends Component<typeof DateTimePreview> {
             </div>
             <div class='component-demo'>
               <@fields.eventDateTime @format='edit' />
+            </div>
+          </div>
+
+          {{! ⁴⁵ DatetimeField Format Examples }}
+          <div class='component-card'>
+            <div class='component-info'>
+              <h3>DatetimeField - Short Preset</h3>
+              <p>Compact datetime display</p>
+              <code class='config'>configuration: &#123; preset: 'short' &#125;</code>
+              <span class='use-case'>Mobile • Condensed Views</span>
+            </div>
+            <div class='component-demo'>
+              <@fields.eventDateTimeShort @format='embedded' />
+            </div>
+          </div>
+
+          <div class='component-card'>
+            <div class='component-info'>
+              <h3>DatetimeField - Custom Format</h3>
+              <p>Custom Day.js pattern</p>
+              <code class='config'>configuration: &#123; format: 'ddd, MMM D
+                [at] h:mm A' &#125;</code>
+              <span class='use-case'>Friendly Displays • Invitations</span>
+            </div>
+            <div class='component-demo'>
+              <@fields.eventDateTimeCustom @format='embedded' />
             </div>
           </div>
         </div>
@@ -1085,11 +1163,53 @@ export class DateTimePreview extends CardDef {
   // ²⁹ Single date picker
   @field appointmentDate = contains(DateField);
 
+  // ³⁷ Date with tiny preset (compact display)
+  @field appointmentDateCompact = contains(DateField, {
+    configuration: {
+      preset: 'tiny',
+    },
+  });
+
+  // ³⁸ Date with custom format
+  @field appointmentDateCustom = contains(DateField, {
+    configuration: {
+      format: 'MMM D, YYYY',
+    },
+  });
+
   // ³⁰ Time picker
   @field meetingTime = contains(TimeField);
 
+  // ³⁹ Time with 24-hour format
+  @field meetingTime24Hour = contains(TimeField, {
+    configuration: {
+      hourCycle: 'h23',
+    },
+  });
+
+  // ⁴⁰ Time with long style (includes timezone)
+  @field meetingTimeLong = contains(TimeField, {
+    configuration: {
+      timeStyle: 'long',
+    },
+  });
+
   // ³¹ DateTime picker
   @field eventDateTime = contains(DatetimeField);
+
+  // ⁴¹ DateTime with short preset
+  @field eventDateTimeShort = contains(DatetimeField, {
+    configuration: {
+      preset: 'short',
+    },
+  });
+
+  // ⁴² DateTime with custom format
+  @field eventDateTimeCustom = contains(DatetimeField, {
+    configuration: {
+      format: 'ddd, MMM D [at] h:mm A',
+    },
+  });
 
   // ⁹ INDEPENDENT SPECIALIZED FIELDS - Now separate FieldDef types
 

--- a/packages/catalog-realm/fields/date-time.gts
+++ b/packages/catalog-realm/fields/date-time.gts
@@ -2,6 +2,7 @@ import { Component } from 'https://cardstack.com/base/card-api';
 import BaseDatetimeField from 'https://cardstack.com/base/datetime';
 import CalendarEventIcon from '@cardstack/boxel-icons/calendar-event';
 import { eq } from '@cardstack/boxel-ui/helpers';
+import { formatDateTime } from '@cardstack/boxel-ui/helpers';
 
 import { Countdown } from './components/countdown';
 import { Timeline } from './components/timeline';
@@ -15,6 +16,8 @@ interface DateTimeConfiguration {
     | 'timeAgo'
     | 'timeline'
     | 'expirationWarning';
+  preset?: 'tiny' | 'short' | 'medium' | 'long';
+  format?: string; // Custom Day.js format string
   countdownOptions?: {
     label?: string;
     showControls?: boolean;
@@ -58,13 +61,15 @@ export class DatetimeField extends BaseDatetimeField {
 
       try {
         const date = new Date(String(this.datetimeValue));
-        return date.toLocaleString('en-US', {
-          weekday: 'short',
-          year: 'numeric',
-          month: 'short',
-          day: 'numeric',
-          hour: 'numeric',
-          minute: '2-digit',
+
+        const preset = this.config?.preset || 'medium';
+        const customFormat = this.config?.format;
+
+        return formatDateTime(date, {
+          kind: 'datetime',
+          preset: customFormat ? undefined : preset,
+          format: customFormat,
+          fallback: 'Invalid date/time',
         });
       } catch {
         return String(this.datetimeValue);
@@ -112,11 +117,10 @@ export class DatetimeField extends BaseDatetimeField {
 
       try {
         const date = new Date(String(this.args.model));
-        return date.toLocaleString('en-US', {
-          month: 'short',
-          day: 'numeric',
-          hour: 'numeric',
-          minute: '2-digit',
+        return formatDateTime(date, {
+          kind: 'datetime',
+          preset: 'short',
+          fallback: 'Invalid date',
         });
       } catch {
         return String(this.args.model);

--- a/packages/catalog-realm/fields/date.gts
+++ b/packages/catalog-realm/fields/date.gts
@@ -2,13 +2,15 @@ import { Component } from 'https://cardstack.com/base/card-api';
 import BaseDateField from 'https://cardstack.com/base/date';
 import CalendarIcon from '@cardstack/boxel-icons/calendar';
 import { eq } from '@cardstack/boxel-ui/helpers';
-
+import { formatDateTime } from '@cardstack/boxel-ui/helpers';
 import { Countdown } from './components/countdown';
 import { Timeline } from './components/timeline';
 import { Age } from './components/age';
 
 interface DateTimeConfiguration {
   presentation?: 'standard' | 'countdown' | 'timeline' | 'age';
+  preset?: 'tiny' | 'short' | 'medium' | 'long'; // formatDateTime configuration options
+  format?: string; // Custom Day.js format string
   countdownOptions?: {
     label?: string;
     showControls?: boolean;
@@ -48,11 +50,14 @@ export class DateField extends BaseDateField {
 
       try {
         const date = new Date(this.dateValue.toString());
-        return date.toLocaleDateString('en-US', {
-          weekday: 'long',
-          year: 'numeric',
-          month: 'long',
-          day: 'numeric',
+
+        const preset = this.config?.preset || 'long';
+        const customFormat = this.config?.format;
+
+        return formatDateTime(date, {
+          preset: customFormat ? undefined : preset,
+          format: customFormat,
+          fallback: 'Invalid date',
         });
       } catch {
         return String(this.dateValue);
@@ -98,10 +103,9 @@ export class DateField extends BaseDateField {
 
       try {
         const date = new Date(String(this.args.model));
-        return date.toLocaleDateString('en-US', {
-          month: 'short',
-          day: 'numeric',
-          year: 'numeric',
+        return formatDateTime(date, {
+          preset: 'medium',
+          fallback: 'Invalid date',
         });
       } catch {
         return String(this.args.model);

--- a/packages/catalog-realm/fields/date/date-range.gts
+++ b/packages/catalog-realm/fields/date/date-range.gts
@@ -1,21 +1,21 @@
-// ═══ [EDIT TRACKING: ON] Mark all changes with ⁿ ═══
 import {
   FieldDef,
   Component,
   field,
   contains,
-} from 'https://cardstack.com/base/card-api'; // ¹ Core imports
+} from 'https://cardstack.com/base/card-api';
 import BaseDateField from 'https://cardstack.com/base/date';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { gt, eq } from '@cardstack/boxel-ui/helpers'; // ² Helpers
-import { DateRangePicker } from '@cardstack/boxel-ui/components'; // ³ DateRangePicker component
-import CalendarStatsIcon from '@cardstack/boxel-icons/calendar-stats'; // ⁴ Calendar stats icon
-import { BusinessDays } from '../components/business-days'; // ⁵ Import BusinessDays component
+import { gt, eq } from '@cardstack/boxel-ui/helpers';
+import { formatDateTime } from '@cardstack/boxel-ui/helpers';
+import { DateRangePicker } from '@cardstack/boxel-ui/components';
 
-// Configuration interface
+import CalendarStatsIcon from '@cardstack/boxel-icons/calendar-stats';
+
+import { BusinessDays } from '../components/business-days';
+
 interface DateRangeConfiguration {
-  // ⁶ Configuration type
   presentation?: 'standard' | 'businessDays';
 }
 
@@ -25,7 +25,6 @@ class DateRangeFieldEdit extends Component<typeof DateRangeField> {
 
   constructor(owner: any, args: any) {
     super(owner, args);
-    // ¹³ Initialize from model or set defaults
     try {
       const startValue = this.args.model?.start;
       const endValue = this.args.model?.end;
@@ -58,11 +57,9 @@ class DateRangeFieldEdit extends Component<typeof DateRangeField> {
 
   @action
   onSelect(selected: { date: { start: Date | null; end: Date | null } }) {
-    // ¹⁴ Update tracked state for partial selections
     this.startDate = selected.date.start;
     this.endDate = selected.date.end;
 
-    // ¹⁵ Save to model fields only when BOTH dates selected
     if (selected.date.start && selected.date.end) {
       this.args.model.start = selected.date.start as any;
       this.args.model.end = selected.date.end as any;
@@ -105,15 +102,13 @@ class DateRangeFieldEdit extends Component<typeof DateRangeField> {
   </template>
 }
 
-// ⁷ DateRangeField - Independent FieldDef with structured start/end dates and presentation support
 export class DateRangeField extends FieldDef {
   static displayName = 'Date Range';
   static icon = CalendarStatsIcon;
 
-  @field start = contains(BaseDateField); // ⁸ Use base DateField for range start
-  @field end = contains(BaseDateField); // ⁹ Use base DateField for range end
+  @field start = contains(BaseDateField);
+  @field end = contains(BaseDateField);
 
-  // ¹⁰ Embedded format - routes to presentation or displays value
   static embedded = class Embedded extends Component<typeof this> {
     get config(): DateRangeConfiguration | undefined {
       return this.args.configuration as DateRangeConfiguration | undefined;
@@ -159,7 +154,6 @@ export class DateRangeField extends FieldDef {
     </template>
   };
 
-  // ¹¹ Atom format - compact badge display
   static atom = class Atom extends Component<typeof this> {
     get displayValue() {
       const start = this.args.model?.start;
@@ -171,9 +165,9 @@ export class DateRangeField extends FieldDef {
         const formatDate = (dateValue: string | Date) => {
           const date =
             typeof dateValue === 'string' ? new Date(dateValue) : dateValue;
-          return date.toLocaleDateString('en-US', {
-            month: 'short',
-            day: 'numeric',
+          return formatDateTime(date, {
+            preset: 'short',
+            fallback: String(dateValue),
           });
         };
 
@@ -218,7 +212,6 @@ export class DateRangeField extends FieldDef {
     </template>
   };
 
-  // ¹² Edit format - DateRangePicker with duration display
   static edit = DateRangeFieldEdit;
 }
 

--- a/packages/catalog-realm/fields/date/month-year.gts
+++ b/packages/catalog-realm/fields/date/month-year.gts
@@ -1,14 +1,14 @@
-// ═══ [EDIT TRACKING: ON] Mark all changes with ⁿ ═══
 import {
   FieldDef,
   Component,
   field,
   contains,
-} from 'https://cardstack.com/base/card-api'; // ¹ Core imports
+} from 'https://cardstack.com/base/card-api';
 import StringField from 'https://cardstack.com/base/string';
 import { action } from '@ember/object';
 import { on } from '@ember/modifier';
-import CalendarEventIcon from '@cardstack/boxel-icons/calendar-event'; // ² Calendar event icon
+import CalendarEventIcon from '@cardstack/boxel-icons/calendar-event';
+import { formatDateTime } from '@cardstack/boxel-ui/helpers';
 
 class MonthYearFieldEdit extends Component<typeof MonthYearField> {
   @action
@@ -21,9 +21,9 @@ class MonthYearFieldEdit extends Component<typeof MonthYearField> {
     if (!this.args.model?.value) return '';
     try {
       const date = new Date(this.args.model.value + '-01');
-      return date.toLocaleDateString('en-US', {
-        month: 'long',
-        year: 'numeric',
+      return formatDateTime(date, {
+        kind: 'monthYear',
+        fallback: this.args.model.value,
       });
     } catch {
       return '';
@@ -118,14 +118,12 @@ class MonthYearFieldEdit extends Component<typeof MonthYearField> {
   </template>
 }
 
-// ³ MonthYearField - Independent FieldDef for month-year selection
 export class MonthYearField extends FieldDef {
   static displayName = 'Month-Year';
   static icon = CalendarEventIcon;
 
-  @field value = contains(StringField); // ⁴ Month-year value (YYYY-MM format)
+  @field value = contains(StringField);
 
-  // ⁵ Embedded format - formatted month-year display
   static embedded = class Embedded extends Component<typeof this> {
     get displayValue() {
       const value = this.args.model?.value;
@@ -133,9 +131,9 @@ export class MonthYearField extends FieldDef {
 
       try {
         const date = new Date(value + '-01');
-        return date.toLocaleDateString('en-US', {
-          month: 'long',
-          year: 'numeric',
+        return formatDateTime(date, {
+          kind: 'monthYear',
+          fallback: value,
         });
       } catch {
         return value;
@@ -163,7 +161,6 @@ export class MonthYearField extends FieldDef {
     </template>
   };
 
-  // ⁶ Atom format - compact month-year badge
   static atom = class Atom extends Component<typeof this> {
     get displayValue() {
       const value = this.args.model?.value;
@@ -171,9 +168,9 @@ export class MonthYearField extends FieldDef {
 
       try {
         const date = new Date(value + '-01');
-        return date.toLocaleDateString('en-US', {
-          month: 'short',
-          year: 'numeric',
+        return formatDateTime(date, {
+          kind: 'monthYear',
+          fallback: value,
         });
       } catch {
         return value;
@@ -212,7 +209,6 @@ export class MonthYearField extends FieldDef {
     </template>
   };
 
-  // ⁷ Edit format - month-year input
   static edit = MonthYearFieldEdit;
 }
 

--- a/packages/catalog-realm/fields/date/month.gts
+++ b/packages/catalog-realm/fields/date/month.gts
@@ -1,17 +1,17 @@
-// ═══ [EDIT TRACKING: ON] Mark all changes with ⁿ ═══
 import {
   FieldDef,
   Component,
   field,
   contains,
-} from 'https://cardstack.com/base/card-api'; // ¹ Core imports
-import StringField from 'https://cardstack.com/base/string';
+} from 'https://cardstack.com/base/card-api';
+import NumberField from 'https://cardstack.com/base/number';
 import { action } from '@ember/object';
 import { on } from '@ember/modifier';
-import { concat } from '@ember/helper';
-import { lt, add } from '@cardstack/boxel-ui/helpers'; // ² Helpers
-import CalendarIcon from '@cardstack/boxel-icons/calendar'; // ³ Calendar icon
-import ChevronDownIcon from '@cardstack/boxel-icons/chevron-down'; // ⁴ Chevron down icon
+import { add } from '@cardstack/boxel-ui/helpers';
+import { formatDateTime } from '@cardstack/boxel-ui/helpers';
+
+import CalendarIcon from '@cardstack/boxel-icons/calendar';
+import ChevronDownIcon from '@cardstack/boxel-icons/chevron-down';
 
 class MonthFieldEdit extends Component<typeof MonthField> {
   months = [
@@ -32,7 +32,7 @@ class MonthFieldEdit extends Component<typeof MonthField> {
   @action
   updateValue(event: Event) {
     const target = event.target as HTMLSelectElement;
-    this.args.model.value = target.value;
+    this.args.model.value = Number(target.value);
   }
 
   <template>
@@ -49,13 +49,7 @@ class MonthFieldEdit extends Component<typeof MonthField> {
         data-test-month-select
       >
         {{#each this.months as |monthName index|}}
-          <option
-            value={{if
-              (lt (add index 1) 10)
-              (concat '0' (add index 1))
-              (add index 1)
-            }}
-          >
+          <option value={{add index 1}}>
             {{monthName}}
           </option>
         {{/each}}
@@ -133,36 +127,28 @@ class MonthFieldEdit extends Component<typeof MonthField> {
   </template>
 }
 
-// ⁵ MonthField - Independent FieldDef for month-only selection
 export class MonthField extends FieldDef {
   static displayName = 'Month';
   static icon = CalendarIcon;
 
-  @field value = contains(StringField); // ⁶ Month value (01-12)
+  @field value = contains(NumberField); // Month value (1-12)
 
-  // ⁷ Embedded format - formatted month display
   static embedded = class Embedded extends Component<typeof this> {
     get displayValue() {
       const value = this.args.model?.value;
       if (!value) return 'No month set';
 
       try {
-        const months = [
-          'January',
-          'February',
-          'March',
-          'April',
-          'May',
-          'June',
-          'July',
-          'August',
-          'September',
-          'October',
-          'November',
-          'December',
-        ];
-        const monthName = months[parseInt(value) - 1];
-        return monthName || value;
+        const monthNum = this.args.model?.value;
+        if (typeof monthNum !== 'number' || monthNum < 1 || monthNum > 12)
+          return value;
+
+        const date = new Date(2025, monthNum - 1, 1);
+        return formatDateTime(date, {
+          kind: 'month',
+          monthDisplay: 'long',
+          fallback: String(value),
+        });
       } catch {
         return value;
       }
@@ -189,29 +175,22 @@ export class MonthField extends FieldDef {
     </template>
   };
 
-  // ⁸ Atom format - compact month badge
   static atom = class Atom extends Component<typeof this> {
     get displayValue() {
       const value = this.args.model?.value;
       if (!value) return 'No month';
 
       try {
-        const months = [
-          'Jan',
-          'Feb',
-          'Mar',
-          'Apr',
-          'May',
-          'Jun',
-          'Jul',
-          'Aug',
-          'Sep',
-          'Oct',
-          'Nov',
-          'Dec',
-        ];
-        const monthName = months[parseInt(value) - 1];
-        return monthName || value;
+        const monthNum = this.args.model?.value;
+        if (typeof monthNum !== 'number' || monthNum < 1 || monthNum > 12)
+          return value;
+
+        const date = new Date(2025, monthNum - 1, 1);
+        return formatDateTime(date, {
+          kind: 'month',
+          monthDisplay: 'short',
+          fallback: String(value),
+        });
       } catch {
         return value;
       }
@@ -249,7 +228,6 @@ export class MonthField extends FieldDef {
     </template>
   };
 
-  // ⁹ Edit format - month dropdown
   static edit = MonthFieldEdit;
 }
 

--- a/packages/catalog-realm/fields/date/week.gts
+++ b/packages/catalog-realm/fields/date/week.gts
@@ -1,14 +1,15 @@
-// ═══ [EDIT TRACKING: ON] Mark all changes with ⁿ ═══
 import {
   FieldDef,
   Component,
   field,
   contains,
-} from 'https://cardstack.com/base/card-api'; // ¹ Core imports
+} from 'https://cardstack.com/base/card-api';
 import StringField from 'https://cardstack.com/base/string';
 import { action } from '@ember/object';
 import { on } from '@ember/modifier';
-import CalendarEventIcon from '@cardstack/boxel-icons/calendar-event'; // ² Calendar event icon
+
+import CalendarEventIcon from '@cardstack/boxel-icons/calendar-event';
+import { formatDateTime } from '@cardstack/boxel-ui/helpers';
 
 class WeekFieldEdit extends Component<typeof WeekField> {
   @action
@@ -111,14 +112,12 @@ class WeekFieldEdit extends Component<typeof WeekField> {
   </template>
 }
 
-// ³ WeekField - Independent FieldDef for ISO week selection
 export class WeekField extends FieldDef {
   static displayName = 'Week';
   static icon = CalendarEventIcon;
 
-  @field value = contains(StringField); // ⁴ Week value (YYYY-Www format)
+  @field value = contains(StringField); // Week value (YYYY-Www format)
 
-  // ⁵ Embedded format - formatted week display
   static embedded = class Embedded extends Component<typeof this> {
     get displayValue() {
       const value = this.args.model?.value;
@@ -126,10 +125,24 @@ export class WeekField extends FieldDef {
 
       try {
         const [year, week] = value.split('-W');
-        return `Week ${week} of ${year}`;
+        const date = this.getDateFromWeek(parseInt(year), parseInt(week));
+
+        return formatDateTime(date, {
+          kind: 'week',
+          weekFormat: 'label',
+          fallback: `Week ${week} of ${year}`,
+        });
       } catch {
         return value;
       }
+    }
+
+    getDateFromWeek(year: number, week: number) {
+      const jan4 = new Date(year, 0, 4);
+      const dayOfWeek = jan4.getDay() || 7;
+      const weekStart = new Date(jan4);
+      weekStart.setDate(jan4.getDate() - dayOfWeek + 1 + (week - 1) * 7);
+      return weekStart;
     }
 
     <template>
@@ -153,7 +166,6 @@ export class WeekField extends FieldDef {
     </template>
   };
 
-  // ⁶ Atom format - compact week badge
   static atom = class Atom extends Component<typeof this> {
     get displayValue() {
       const value = this.args.model?.value;
@@ -161,10 +173,24 @@ export class WeekField extends FieldDef {
 
       try {
         const [year, week] = value.split('-W');
-        return `W${week} ${year}`;
+        const date = this.getDateFromWeek(parseInt(year), parseInt(week));
+
+        return formatDateTime(date, {
+          kind: 'week',
+          weekFormat: 'iso',
+          fallback: `W${week} ${year}`,
+        });
       } catch {
         return value;
       }
+    }
+
+    getDateFromWeek(year: number, week: number) {
+      const jan4 = new Date(year, 0, 4);
+      const dayOfWeek = jan4.getDay() || 7;
+      const weekStart = new Date(jan4);
+      weekStart.setDate(jan4.getDate() - dayOfWeek + 1 + (week - 1) * 7);
+      return weekStart;
     }
 
     <template>
@@ -199,7 +225,6 @@ export class WeekField extends FieldDef {
     </template>
   };
 
-  // ⁷ Edit format - week input
   static edit = WeekFieldEdit;
 }
 


### PR DESCRIPTION
### What is changing
- date time fields to utilise `formatDateTime` helper after #3544 
- update preview field for usage
- add test coverage