### PR TITLE
Themed card border bug fix

### DIFF
--- a/packages/base/links-to-editor.gts
+++ b/packages/base/links-to-editor.gts
@@ -122,7 +122,7 @@ export class LinksToEditor extends GlimmerComponent<Signature> {
       .remove:hover + :deep(.boxel-card-container.fitted-format) {
         box-shadow:
           0 0 0 1px var(--border, var(--boxel-300)),
-          var(--shadow-lg, var(--boxel-box-shadow));
+          var(--boxel-box-shadow);
       }
       .add-new {
         width: fit-content;

--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -298,7 +298,7 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
       .sort:hover ~ :deep(.boxel-card-container) {
         box-shadow:
           0 0 0 1px var(--border, var(--boxel-300)),
-          var(--shadow-lg, var(--boxel-box-shadow));
+          var(--boxel-box-shadow);
       }
       .add-new {
         gap: var(--boxel-sp-xxxs);

--- a/packages/boxel-ui/addon/src/components/accordion/index.gts
+++ b/packages/boxel-ui/addon/src/components/accordion/index.gts
@@ -39,7 +39,7 @@ const Accordion: TemplateOnlyComponent<Signature> = <template>
         --boxel-accordion-item-padding-block: var(--boxel-sp-xxxs);
 
         border: var(--accordion-border);
-        border-radius: var(--boxel-border-radius);
+        border-radius: var(--radius, var(--boxel-border-radius));
       }
     }
   </style>

--- a/packages/boxel-ui/addon/src/components/button/index.gts
+++ b/packages/boxel-ui/addon/src/components/button/index.gts
@@ -246,7 +246,6 @@ const ButtonComponent: TemplateOnlyComponent<Signature> = <template>
       .kind-primary {
         --boxel-button-color: var(--primary, var(--boxel-highlight));
         --boxel-button-text-color: var(--primary-foreground, var(--boxel-dark));
-        --boxel-button-box-shadow: var(--shadow);
       }
       .kind-primary:not(:disabled):hover,
       .kind-primary:not(:disabled):active {
@@ -261,7 +260,6 @@ const ButtonComponent: TemplateOnlyComponent<Signature> = <template>
         );
         --boxel-button-border: 1px solid
           var(--secondary, var(--boxel-button-border-color));
-        --boxel-button-box-shadow: var(--shadow);
       }
       .kind-secondary:not(:disabled):hover,
       .kind-secondary:not(:disabled):active {
@@ -287,7 +285,6 @@ const ButtonComponent: TemplateOnlyComponent<Signature> = <template>
           --destructive-foreground,
           var(--boxel-light-100)
         );
-        --boxel-button-box-shadow: var(--shadow);
       }
       .kind-destructive:not(:disabled):hover,
       .kind-destructive:not(:disabled):active,
@@ -314,7 +311,6 @@ const ButtonComponent: TemplateOnlyComponent<Signature> = <template>
         /* inverted background and foreground */
         --boxel-button-color: var(--foreground, var(--boxel-dark));
         --boxel-button-text-color: var(--background, var(--boxel-light));
-        --boxel-button-box-shadow: var(--shadow);
       }
       .kind-primary-dark:not(:disabled):hover,
       .kind-primary-dark:not(:disabled):active {
@@ -331,7 +327,6 @@ const ButtonComponent: TemplateOnlyComponent<Signature> = <template>
         --boxel-button-text-color: var(--foreground, var(--boxel-dark));
         --boxel-button-border: 1px solid
           var(--border, var(--boxel-button-border-color));
-        --boxel-button-box-shadow: var(--shadow);
       }
       .kind-secondary-dark {
         /* transparent on dark background */
@@ -339,7 +334,6 @@ const ButtonComponent: TemplateOnlyComponent<Signature> = <template>
         --boxel-button-text-color: var(--background, var(--boxel-light));
         --boxel-button-border: 1px solid
           var(--border, var(--boxel-button-border-color));
-        --boxel-button-box-shadow: var(--shadow);
       }
       .kind-secondary-light:not(:disabled):hover,
       .kind-secondary-light:not(:disabled):active,

--- a/packages/boxel-ui/addon/src/components/card-container/index.gts
+++ b/packages/boxel-ui/addon/src/components/card-container/index.gts
@@ -49,7 +49,7 @@ const CardContainer: TemplateOnlyComponent<Signature> = <template>
     :global(.boxel-card-container) {
       position: relative;
       background-color: var(--background, var(--boxel-light));
-      border-radius: var(--boxel-border-radius);
+      border-radius: var(--radius, var(--boxel-border-radius));
       color: var(--foreground, var(--boxel-dark));
       transition:
         max-width var(--boxel-transition),
@@ -59,9 +59,7 @@ const CardContainer: TemplateOnlyComponent<Signature> = <template>
       overflow: hidden;
     }
     :global(.boxel-card-container--boundaries) {
-      box-shadow:
-        0 0 0 1px var(--border, var(--boxel-border-color)),
-        var(--shadow, 0 0 0 1px var(--boxel-border-color));
+      box-shadow: 0 0 0 1px var(--border, var(--boxel-border-color));
     }
     :global(.boxel-card-container--boundaries.hide-boundaries) {
       box-shadow: none;
@@ -116,7 +114,6 @@ const CardContainer: TemplateOnlyComponent<Signature> = <template>
       font-weight: var(--font-weight-body);
       letter-spacing: var(--tracking-normal);
       line-height: var(--lineheight-base);
-      box-shadow: var(--shadow);
     }
   </style>
 </template>;

--- a/packages/boxel-ui/addon/src/components/input-group/index.gts
+++ b/packages/boxel-ui/addon/src/components/input-group/index.gts
@@ -201,7 +201,6 @@ export default class InputGroup extends Component<Signature> {
         background-color: var(--background, var(--boxel-light));
         color: var(--foreground, var(--boxel-dark));
         border: 1px solid var(--boxel-input-group-border-color);
-        box-shadow: var(--shadow);
       }
 
       @layer boxelComponentL1 {

--- a/packages/boxel-ui/addon/src/components/input/index.gts
+++ b/packages/boxel-ui/addon/src/components/input/index.gts
@@ -262,7 +262,7 @@ export default class BoxelInput extends Component<Signature> {
           border: 1px solid
             var(--border, var(--boxel-form-control-border-color));
           border-radius: var(--boxel-form-control-border-radius);
-          box-shadow: var(--shadow);
+          box-shadow: var(--boxel-form-control-box-shadow);
           outline: 1px solid transparent;
           transition:
             var(--boxel-transition-properties),

--- a/packages/boxel-ui/test-app/app/templates/index.gts
+++ b/packages/boxel-ui/test-app/app/templates/index.gts
@@ -94,16 +94,15 @@ class IndexComponent extends Component {
       .theme-selector {
         min-width: 10rem;
       }
-      .FreestyleUsage {
-        --radius: var(--boxel-border-radius);
-        --border-color: var(--boxel-border-color);
-      }
       .FreestyleUsageCssVar-name {
         width: 40%;
       }
       .FreestyleUsage-preview {
+        --radius: var(--theme-radius, var(--boxel-border-radius));
+
         color: var(--foreground, var(--boxel-dark));
         background-color: var(--background, var(--boxel-light));
+        border-radius: 4px;
       }
     </style>
   </template>

--- a/packages/boxel-ui/test-app/app/themes/index.ts
+++ b/packages/boxel-ui/test-app/app/themes/index.ts
@@ -31,7 +31,9 @@ function getThemeStyles(cssString: string) {
   if (!extractCssVariables) {
     return htmlSafe('');
   }
-  return sanitizeHtmlSafe(extractCssVariables(cssString));
+  // adjust for freestyle doc styles overriding theme variables
+  let css = cssString + `\n\n :root{\n  --theme-radius: var(--radius); \n}`;
+  return sanitizeHtmlSafe(extractCssVariables(css));
 }
 
 const Themes: Theme[] = Object.entries(THEMES).map(([name, vars]) => ({


### PR DESCRIPTION
Fix for some themed cards missing borders, due to a clash with box-shadow:

<img width="512" height="73" alt="border-bug" src="https://github.com/user-attachments/assets/d4d30e31-e76e-421a-9655-11fd2b054727" />

Decided to remove adding the `--shadow` css-variable by default to components. This is more consistent with default boxel component styles. Any desired box-shadow can be added by the user.
