### PR TITLE
Add “Set as Site Home” menu in the … stack menu of Site Config card instances

### DIFF
--- a/packages/base/site-config.gts
+++ b/packages/base/site-config.gts
@@ -1,10 +1,39 @@
 import { CardDef, Component, field, linksTo } from './card-api';
+import { getCardMenuItems } from '@cardstack/runtime-common';
+import { type GetCardMenuItemParams } from './card-menu-items';
+import { type MenuItemOptions } from '@cardstack/boxel-ui/helpers';
+import SetSiteConfigCommand from '@cardstack/boxel-host/commands/set-site-config';
+import HomeIcon from '@cardstack/boxel-icons/home';
 
 // Site level configuration card. Additional routing fields can be added over time.
 export class SiteConfig extends CardDef {
   static displayName = 'Site Configuration';
 
   @field home = linksTo(CardDef);
+
+  [getCardMenuItems](params: GetCardMenuItemParams): MenuItemOptions[] {
+    let menuItems = super[getCardMenuItems](params);
+    let isPrimarySiteConfig =
+      typeof this.id === 'string' &&
+      (this.id.endsWith('/site') || this.id.endsWith('/site.json'));
+    if (isPrimarySiteConfig) {
+      return menuItems;
+    }
+    menuItems = [
+      {
+        label: 'Set as my site config',
+        action: async () => {
+          await new SetSiteConfigCommand(params.commandContext).execute({
+            cardId: this.id,
+          });
+        },
+        icon: HomeIcon,
+        tags: ['site-config'],
+      },
+      ...menuItems,
+    ];
+    return menuItems;
+  }
 
   static isolated = class Isolated extends Component<typeof SiteConfig> {
     <template>

--- a/packages/base/site-config.gts
+++ b/packages/base/site-config.gts
@@ -21,7 +21,7 @@ export class SiteConfig extends CardDef {
     }
     menuItems = [
       {
-        label: 'Set as my site config',
+        label: 'Set as site home',
         action: async () => {
           await new SetSiteConfigCommand(params.commandContext).execute({
             cardId: this.id,

--- a/packages/host/app/commands/index.ts
+++ b/packages/host/app/commands/index.ts
@@ -41,6 +41,7 @@ import * as SearchGoogleImagesCommandModule from './search-google-images';
 import * as SendAiAssistantMessageModule from './send-ai-assistant-message';
 import * as SendRequestViaProxyCommandModule from './send-request-via-proxy';
 import * as SetActiveLlmModule from './set-active-llm';
+import * as SetSiteConfigCommandModule from './set-site-config';
 import * as SetUserSystemCardCommandModule from './set-user-system-card';
 import * as ShowCardCommandModule from './show-card';
 import * as SummarizeSessionCommandModule from './summarize-session';
@@ -263,6 +264,10 @@ export function shimHostCommands(virtualNetwork: VirtualNetwork) {
     '@cardstack/boxel-host/commands/set-user-system-card',
     SetUserSystemCardCommandModule,
   );
+  virtualNetwork.shimModule(
+    '@cardstack/boxel-host/commands/set-site-config',
+    SetSiteConfigCommandModule,
+  );
 }
 
 // Note - this is used for the tests
@@ -307,6 +312,7 @@ export const HostCommandClasses: (typeof HostBaseCommand<any, any>)[] = [
   SendAiAssistantMessageModule.default,
   SendRequestViaProxyCommandModule.default,
   SetActiveLlmModule.default,
+  SetSiteConfigCommandModule.default,
   SetUserSystemCardCommandModule.default,
   ShowCardCommandModule.default,
   SummarizeSessionCommandModule.default,

--- a/packages/host/app/commands/set-site-config.ts
+++ b/packages/host/app/commands/set-site-config.ts
@@ -1,0 +1,100 @@
+import { service } from '@ember/service';
+
+import {
+  RealmPaths,
+  isCardInstance,
+  type LooseCardResource,
+} from '@cardstack/runtime-common';
+import type { AtomicOperationType } from '@cardstack/runtime-common/atomic-document';
+
+import type * as BaseCommandModule from 'https://cardstack.com/base/command';
+
+import HostBaseCommand from '../lib/host-base-command';
+
+import type CardService from '../services/card-service';
+import type RealmService from '../services/realm';
+import type StoreService from '../services/store';
+
+export default class SetSiteConfigCommand extends HostBaseCommand<
+  typeof BaseCommandModule.CardIdCard,
+  undefined
+> {
+  @service declare private cardService: CardService;
+  @service declare private realm: RealmService;
+  @service declare private store: StoreService;
+
+  static actionVerb = 'Set';
+  description = "Sets the current realm's site config card";
+
+  async getInputType() {
+    let commandModule = await this.loadCommandModule();
+    const { CardIdCard } = commandModule;
+    return CardIdCard;
+  }
+
+  requireInputFields = ['cardId'];
+
+  protected async run(input: BaseCommandModule.CardIdCard): Promise<undefined> {
+    let cardId = input.cardId;
+    if (!cardId) {
+      throw new Error('cardId is required');
+    }
+
+    let cardURL: URL;
+    try {
+      cardURL = new URL(cardId);
+    } catch (_error) {
+      throw new Error(`Invalid card id: ${cardId}`);
+    }
+
+    let realmURL = this.realm.realmOfURL(cardURL);
+    if (!realmURL) {
+      throw new Error(`Could not determine realm for ${cardId}`);
+    }
+
+    let realmHref = realmURL.href;
+    if (!this.realm.canWrite(realmHref)) {
+      throw new Error(`Do not have write permissions to ${realmHref}`);
+    }
+
+    let siteConfigInstance = await this.store.get(cardId);
+    if (!siteConfigInstance || !isCardInstance(siteConfigInstance)) {
+      throw new Error(`Could not load site config card: ${cardId}`);
+    }
+
+    let serialized = await this.cardService.serializeCard(siteConfigInstance, {
+      useAbsoluteURL: true,
+      withIncluded: true,
+    });
+
+    delete serialized.data.id;
+    delete serialized.data.lid;
+    let resource = serialized.data as LooseCardResource;
+
+    let realmPaths = new RealmPaths(realmURL);
+    let siteConfigURL = realmPaths.fileURL('site.json');
+    let operationType: AtomicOperationType = 'add';
+
+    try {
+      await this.cardService.fetchJSON(siteConfigURL.href);
+      operationType = 'update';
+    } catch (error: any) {
+      if (error?.status && error.status !== 404) {
+        throw error;
+      }
+    }
+
+    await this.cardService.executeAtomicOperations(
+      [
+        {
+          op: operationType,
+          href: siteConfigURL.href,
+          data: resource,
+        },
+      ],
+      realmURL,
+    );
+
+    return undefined;
+  }
+}

--- a/packages/host/tests/acceptance/site-config-test.gts
+++ b/packages/host/tests/acceptance/site-config-test.gts
@@ -25,6 +25,8 @@ import { setupMockMatrix } from '../helpers/mock-matrix';
 import { setupApplicationTest } from '../helpers/setup';
 import visitOperatorMode from '../helpers/visit-operator-mode';
 
+import type { TestRealmAdapter } from '../helpers/adapter';
+
 let testHostModeRealmURLWithoutRealm = testHostModeRealmURL.replace(
   '/user/test/',
   '',
@@ -285,6 +287,200 @@ module('Acceptance | site config home page', function (hooks) {
         .exists();
       assert
         .dom(`[data-test-host-mode-card="${testRealmURL}Pet/mango"]`)
+        .doesNotExist();
+    });
+  });
+
+  module('set site config command', function () {
+    let adapter: TestRealmAdapter;
+
+    module('when site config file does not exist', function (hooks) {
+      hooks.beforeEach(async function () {
+        let contents = { ...realmContents };
+        delete contents['site.json'];
+        contents['SiteConfig/custom.json'] = {
+          data: {
+            meta: {
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/site-config',
+                name: 'SiteConfig',
+              },
+            },
+            type: 'card',
+            attributes: {
+              cardInfo: {
+                notes: null,
+                title: null,
+                description: null,
+                thumbnailURL: null,
+              },
+            },
+            relationships: {
+              home: {
+                links: {
+                  self: '../Pet/peanut',
+                },
+              },
+              'cardInfo.theme': {
+                links: {
+                  self: null,
+                },
+              },
+            },
+          },
+        };
+
+        ({ adapter } = await setupAcceptanceTestRealm({
+          contents,
+          mockMatrixUtils,
+        }));
+      });
+
+      test('user can create a site config via stack menu', async function (assert) {
+        await visitOperatorMode({
+          submode: 'interact',
+          stacks: [
+            [
+              {
+                id: `${testRealmURL}SiteConfig/custom`,
+                format: 'isolated',
+              },
+            ],
+          ],
+        });
+
+        await waitFor(
+          `[data-test-stack-card="${testRealmURL}SiteConfig/custom"]`,
+        );
+        await click('[data-test-more-options-button]');
+        await click('[data-test-boxel-menu-item-text="Set as my site config"]');
+
+        let siteDoc: any;
+        await waitUntil(async () => {
+          let file = await adapter.openFile('site.json');
+          if (!file) {
+            return false;
+          }
+          let content =
+            typeof file.content === 'string'
+              ? file.content
+              : JSON.stringify(file.content);
+          siteDoc = JSON.parse(content);
+          return true;
+        });
+
+        assert.strictEqual(
+          siteDoc.data.relationships.home.links.self,
+          './Pet/peanut',
+          'site.json created with correct home',
+        );
+      });
+    });
+
+    module('when site config file exists', function (hooks) {
+      hooks.beforeEach(async function () {
+        let contents = { ...realmContents };
+        contents['SiteConfig/custom.json'] = {
+          data: {
+            meta: {
+              adoptsFrom: {
+                module: 'https://cardstack.com/base/site-config',
+                name: 'SiteConfig',
+              },
+            },
+            type: 'card',
+            attributes: {
+              cardInfo: {
+                notes: null,
+                title: null,
+                description: null,
+                thumbnailURL: null,
+              },
+            },
+            relationships: {
+              home: {
+                links: {
+                  self: '../Pet/peanut',
+                },
+              },
+              'cardInfo.theme': {
+                links: {
+                  self: null,
+                },
+              },
+            },
+          },
+        };
+
+        ({ adapter } = await setupAcceptanceTestRealm({
+          contents,
+          mockMatrixUtils,
+        }));
+      });
+
+      test('user can update existing site config via stack menu', async function (assert) {
+        let initialDoc = await adapter.openFile('site.json');
+        assert.ok(initialDoc, 'site.json exists before update');
+
+        await visitOperatorMode({
+          submode: 'interact',
+          stacks: [
+            [
+              {
+                id: `${testRealmURL}SiteConfig/custom`,
+                format: 'isolated',
+              },
+            ],
+          ],
+        });
+
+        await waitFor(
+          `[data-test-stack-card="${testRealmURL}SiteConfig/custom"]`,
+        );
+        await click('[data-test-more-options-button]');
+        await click('[data-test-boxel-menu-item-text="Set as my site config"]');
+
+        let siteDoc: any;
+        await waitUntil(async () => {
+          let file = await adapter.openFile('site.json');
+          if (!file) {
+            return false;
+          }
+          let content =
+            typeof file.content === 'string'
+              ? file.content
+              : JSON.stringify(file.content);
+          siteDoc = JSON.parse(content);
+          return siteDoc.data.relationships.home.links.self === './Pet/peanut';
+        });
+
+        assert.strictEqual(
+          siteDoc.data.relationships.home.links.self,
+          './Pet/peanut',
+          'existing site.json updated with new home',
+        );
+      });
+    });
+  });
+
+  module('site config menu visibility', function (hooks) {
+    hooks.beforeEach(async function () {
+      await setupAcceptanceTestRealm({
+        contents: realmContents,
+        mockMatrixUtils,
+      });
+    });
+
+    test('does not show menu for primary site config card', async function (assert) {
+      await visitOperatorMode({
+        submode: 'interact',
+        stacks: [[{ id: `${testRealmURL}site`, format: 'isolated' }]],
+      });
+
+      await waitFor(`[data-test-stack-card="${testRealmURL}site"]`);
+      await click('[data-test-more-options-button]');
+      assert
+        .dom('[data-test-boxel-menu-item-text="Set as my site config"]')
         .doesNotExist();
     });
   });

--- a/packages/host/tests/acceptance/site-config-test.gts
+++ b/packages/host/tests/acceptance/site-config-test.gts
@@ -353,7 +353,7 @@ module('Acceptance | site config home page', function (hooks) {
           `[data-test-stack-card="${testRealmURL}SiteConfig/custom"]`,
         );
         await click('[data-test-more-options-button]');
-        await click('[data-test-boxel-menu-item-text="Set as my site config"]');
+        await click('[data-test-boxel-menu-item-text="Set as site home"]');
 
         let siteDoc: any;
         await waitUntil(async () => {
@@ -438,7 +438,7 @@ module('Acceptance | site config home page', function (hooks) {
           `[data-test-stack-card="${testRealmURL}SiteConfig/custom"]`,
         );
         await click('[data-test-more-options-button]');
-        await click('[data-test-boxel-menu-item-text="Set as my site config"]');
+        await click('[data-test-boxel-menu-item-text="Set as site home"]');
 
         let siteDoc: any;
         await waitUntil(async () => {
@@ -480,7 +480,7 @@ module('Acceptance | site config home page', function (hooks) {
       await waitFor(`[data-test-stack-card="${testRealmURL}site"]`);
       await click('[data-test-more-options-button]');
       assert
-        .dom('[data-test-boxel-menu-item-text="Set as my site config"]')
+        .dom('[data-test-boxel-menu-item-text="Set as site home"]')
         .doesNotExist();
     });
   });

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -8,7 +8,6 @@ import { isMeta, type CardResource } from './resource-types';
 import type { LocalPath } from './paths';
 import { RealmPaths, ensureTrailingSlash, join } from './paths';
 import { persistFileMeta, removeFileMeta, getCreatedTime } from './file-meta';
-import type { ErrorDetails } from './error';
 import {
   systemError,
   notFound,
@@ -743,6 +742,59 @@ export class Realm {
     await removeFileMeta(this.#dbAdapter, this.url, paths);
   }
 
+  private lowestStatusCode(errors: AtomicPayloadValidationError[]): number {
+    let statuses = errors
+      .map((e) => e.status)
+      .filter((status) => typeof status === 'number') as number[];
+    return statuses.length > 0 ? Math.min(...statuses) : 400;
+  }
+
+  private async checkBeforeAtomicWrite(
+    operations: AtomicOperation[],
+  ): Promise<AtomicPayloadValidationError[]> {
+    let errors: AtomicPayloadValidationError[] = [];
+    await Promise.all(
+      operations.map(async (operation) => {
+        if (
+          (operation.op !== 'add' && operation.op !== 'update') ||
+          !operation.href
+        ) {
+          return;
+        }
+
+        let localPath: LocalPath;
+        try {
+          localPath = this.paths.local(new URL(operation.href, this.paths.url));
+        } catch (error: any) {
+          errors.push({
+            title: 'Invalid atomic:operations format',
+            detail:
+              error?.message ??
+              `Request operation contains invalid href '${operation.href}'`,
+            status: error?.status ?? 400,
+          });
+          return;
+        }
+
+        let exists = await this.#adapter.exists(localPath);
+        if (operation.op === 'add' && exists) {
+          errors.push({
+            title: 'Resource already exists',
+            detail: `Resource ${operation.href} already exists`,
+            status: 409,
+          });
+        } else if (operation.op === 'update' && !exists) {
+          errors.push({
+            title: 'Resource does not exist',
+            detail: `Resource ${operation.href} does not exist`,
+            status: 404,
+          });
+        }
+      }),
+    );
+    return errors;
+  }
+
   validate(json: any): AtomicPayloadValidationError[] {
     let operations = json['atomic:operations'];
     let title = 'Invalid atomic:operations format';
@@ -788,47 +840,6 @@ export class Realm {
     return errors;
   }
 
-  // this method carefully checks before writing with the intent of
-  // stopping failed operations that depend on others
-  private async checkBeforeAtomicWrite(
-    operations: AtomicOperation[],
-  ): Promise<ErrorDetails[]> {
-    let existenceChecks = await Promise.all(
-      operations.map(({ href }) => {
-        let localPath = this.paths.local(new URL(href, this.paths.url));
-        return this.#adapter.exists(localPath);
-      }),
-    );
-
-    let errors: ErrorDetails[] = [];
-
-    for (let [index, operation] of operations.entries()) {
-      let exists = existenceChecks[index];
-      if (operation.op === 'add' && exists) {
-        errors.push({
-          title: 'Resource already exists',
-          detail: `Resource ${operation.href} already exists`,
-          status: 409,
-        });
-      } else if (operation.op === 'update' && !exists) {
-        errors.push({
-          title: 'Resource does not exist',
-          detail: `Resource ${operation.href} does not exist`,
-          status: 404,
-        });
-      }
-    }
-
-    return errors;
-  }
-
-  private lowestStatusCode(errors: ErrorDetails[]): number {
-    let statuses = errors
-      .filter((e) => e.status)
-      .map((e) => e.status) as number[];
-    return Math.min(...statuses);
-  }
-
   private async handleAtomicOperations(
     request: Request,
     requestContext: RequestContext,
@@ -867,8 +878,8 @@ export class Realm {
         requestContext,
       });
     }
-    let operations = filterAtomicOperations(json['atomic:operations']);
-    let atomicCheckErrors = await this.checkBeforeAtomicWrite(operations);
+    let atomicOperations = json['atomic:operations'] as AtomicOperation[];
+    let atomicCheckErrors = await this.checkBeforeAtomicWrite(atomicOperations);
     if (atomicCheckErrors.length > 0) {
       return createResponse({
         body: JSON.stringify({ errors: atomicCheckErrors }),
@@ -879,6 +890,8 @@ export class Realm {
         requestContext,
       });
     }
+
+    let operations = filterAtomicOperations(atomicOperations);
     let files = new Map<LocalPath, string>();
     let writeResults: FileWriteResult[] = [];
 
@@ -886,6 +899,43 @@ export class Realm {
       let resource = operation.data;
       let href = operation.href;
       let localPath = this.paths.local(new URL(href, this.paths.url));
+      let exists = await this.#adapter.exists(localPath);
+      if (operation.op === 'add' && exists) {
+        return createResponse({
+          body: JSON.stringify({
+            errors: [
+              {
+                title: 'Resource already exists',
+                detail: `Resource ${href} already exists`,
+                status: 409,
+              },
+            ],
+          }),
+          init: {
+            status: 409,
+            headers: { 'content-type': SupportedMimeType.JSONAPI },
+          },
+          requestContext,
+        });
+      }
+      if (operation.op === 'update' && !exists) {
+        return createResponse({
+          body: JSON.stringify({
+            errors: [
+              {
+                title: 'Resource does not exist',
+                detail: `Resource ${href} does not exist`,
+                status: 404,
+              },
+            ],
+          }),
+          init: {
+            status: 404,
+            headers: { 'content-type': SupportedMimeType.JSONAPI },
+          },
+          requestContext,
+        });
+      }
       if (isModuleResource(resource)) {
         files.set(localPath, resource.attributes?.content ?? '');
       } else if (isCardResource(resource)) {


### PR DESCRIPTION
In this PR, I added a new menu item to the stack item menu if the card is an instance of a site config. When the menu is clicked, it will copy the content of the instance and create the site.json file under the root directory of the realm. With this new menu, the user has a way to set the alternate home page in host mode. I used the _atomic endpoint since it has the capability to create a card instance with a deterministic URL (location), but I need to tweak it a little bit to allow an update operation.

https://github.com/user-attachments/assets/d0e6bba6-43cc-42d7-bb8a-8b257cb756af

