### PR TITLE
Don't bypass the module cache in the worker

### DIFF
--- a/packages/runtime-common/worker.ts
+++ b/packages/runtime-common/worker.ts
@@ -261,7 +261,6 @@ export class Worker {
       async (req, next) => {
         req.headers.set('X-Boxel-Building-Index', 'true');
         req.headers.set('X-Boxel-Assume-User', realmUserId);
-        req.headers.set('X-Boxel-Disable-Module-Cache', 'true');
         return next(req);
       },
       async (req, next) => {


### PR DESCRIPTION
The realm server transpiles modules, and once transpiled it caches them because this is expensive.

Workers currently add a header that bypasses this cache for all modules, so every time the worker starts a job it causes the realm-server to *re-transpile* each module it uses. card-api requires my local dev box ~200ms to transpile. This also is currently synchronous and so blocking to the server thread (another ticket exists to make this async).

Our cache invalidation should manage this already, and so if we turn this off we should be able to cut out a significant amount of time and/or load on the realm-server.