### PR TITLE
Fix flaky file watcher test

### DIFF
--- a/packages/realm-server/tests/file-watcher-events-test.ts
+++ b/packages/realm-server/tests/file-watcher-events-test.ts
@@ -99,6 +99,7 @@ module(basename(__filename), function () {
     let { getMessagesSince } = setupMatrixRoom(hooks, getRealmSetup);
 
     test('file creation produces an added event', async function (assert) {
+      console.log('Starting file creation test');
       realmEventTimestampStart = Date.now();
 
       let newFilePath = join(
@@ -126,6 +127,7 @@ module(basename(__filename), function () {
 
       await waitForRealmEvent(getMessagesSince, realmEventTimestampStart);
       let messages = await getMessagesSince(realmEventTimestampStart);
+      console.log('Messages since', realmEventTimestampStart, messages);
       let updateEvent = findRealmEvent(messages, 'update', 'incremental');
 
       assert.deepEqual(updateEvent?.content, {
@@ -135,6 +137,7 @@ module(basename(__filename), function () {
     });
 
     test('file updating produces an updated event', async function (assert) {
+      console.log('Starting update test');
       realmEventTimestampStart = Date.now();
 
       let updatedFilePath = join(
@@ -160,6 +163,7 @@ module(basename(__filename), function () {
 
       await waitForRealmEvent(getMessagesSince, realmEventTimestampStart);
       let messages = await getMessagesSince(realmEventTimestampStart);
+      console.log('Messages since', realmEventTimestampStart, messages);
       let updateEvent = findRealmEvent(messages, 'update', 'incremental');
 
       assert.deepEqual(updateEvent?.content, {
@@ -169,6 +173,7 @@ module(basename(__filename), function () {
     });
 
     test('file deletion produces a removed event', async function (assert) {
+      console.log('Starting deletion test');
       realmEventTimestampStart = Date.now();
 
       let deletedFilePath = join(
@@ -182,6 +187,7 @@ module(basename(__filename), function () {
 
       await waitForRealmEvent(getMessagesSince, realmEventTimestampStart);
       let messages = await getMessagesSince(realmEventTimestampStart);
+      console.log(messages);
       let updateEvent = findRealmEvent(messages, 'update', 'incremental');
 
       assert.deepEqual(updateEvent?.content, {

--- a/packages/realm-server/tests/file-watcher-events-test.ts
+++ b/packages/realm-server/tests/file-watcher-events-test.ts
@@ -130,6 +130,7 @@ module(basename(__filename), function () {
           m.origin_server_ts > realmEventTimestampStart &&
           m.type === APP_BOXEL_REALM_EVENT_TYPE &&
           m.content.eventName === 'update' &&
+          'added' in m.content &&
           m.content.added === basename(newFilePath),
       );
       assert.ok(updateEvents);
@@ -170,6 +171,7 @@ module(basename(__filename), function () {
           m.origin_server_ts > realmEventTimestampStart &&
           m.type === APP_BOXEL_REALM_EVENT_TYPE &&
           m.content.eventName === 'update' &&
+          'updated' in m.content &&
           m.content.updated === basename(updatedFilePath),
       );
       assert.ok(updateEvents);
@@ -198,6 +200,7 @@ module(basename(__filename), function () {
           m.origin_server_ts > realmEventTimestampStart &&
           m.type === APP_BOXEL_REALM_EVENT_TYPE &&
           m.content.eventName === 'update' &&
+          'removed' in m.content &&
           m.content.removed === basename(deletedFilePath),
       );
       assert.ok(updateEvents);

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -795,6 +795,12 @@ export function setupMatrixRoom(
     matrixClient,
     getMessagesSince: async function (since: number) {
       let allMessages = await matrixClient.roomMessages(testAuthRoomId!);
+      console.log(
+        'All messages:',
+        allMessages,
+        allMessages.length,
+        allMessages.map((m) => JSON.stringify(m)),
+      );
       let messagesAfterSentinel = allMessages.filter(
         (m) => m.origin_server_ts > since,
       );


### PR DESCRIPTION
See logs here: https://github.com/cardstack/boxel/actions/runs/19534405076/job/55924903477

Although the above didn't fail, the issue is there. 

The tests were waiting for *any* event to appear and then checking that a *specific* event appeared. Here's the ordering 

```[
  '{"type":"app.boxel.realm-event","room_id":"!uZQZdQdUpjBRXewAXP:localhost","sender":"@node-test_realm:localhost","content":{"eventName":"update","added":"new-file.json"},"origin_server_ts":1763636351616,"unsigned":{"membership":"join","age":164},"event_id":"$l_PhrUdn1DjO5QNZxfB5Vezz6ELnev5mEbDFuHE_4go","user_id":"@node-test_realm:localhost","age":164}',
  '{"type":"app.boxel.realm-event","room_id":"!uZQZdQdUpjBRXewAXP:localhost","sender":"@node-test_realm:localhost","content":{"eventName":"index","indexType":"incremental-index-initiation","updatedFile":"http://127.0.0.1:4444/new-file.json"},"origin_server_ts":1763636351610,"unsigned":{"membership":"join","age":170},"event_id":"$hKUBVM7mGCgo48Uzt4t-zSnhOPxZd4HgwmFwzMhnXG4","user_id":"@node-test_realm:localhost","age":170}',
  '{"type":"m.room.message","room_id":"!uZQZdQdUpjBRXewAXP:localhost","sender":"@node-test_realm:localhost","content":{"body":"auth-response: b8ae72ea-4050-4692-bf1d-08ef48894bc4","msgtype":"m.text"},"origin_server_ts":1763636351384,"unsigned":
```

The one tested for is the update event, but the index event appeared first. Locally I see this the other way around so I assume it isn't guaranteed.

Since we wait for the first event, but then *re-fetch* the messages before asserting, there are two timing issues that have to happen together for this to fail. One is that the events occur in this order. The second is that the update event doesn't arrive before we do the final test.

I added some helpers for waiting for a specific event, there are other tests that do similar things that possibly have the same kind of issue.