### PR TITLE
realm: Fix development file-watching

### DIFF
--- a/packages/realm-server/tests/file-watcher-events-test.ts
+++ b/packages/realm-server/tests/file-watcher-events-test.ts
@@ -3,7 +3,7 @@ import type { Test, SuperTest } from 'supertest';
 import { join, basename } from 'path';
 import type { Server } from 'http';
 import type { DirResult } from 'tmp';
-import { removeSync, writeJSONSync } from 'fs-extra';
+import { removeSync, writeJSONSync, writeFileSync } from 'fs-extra';
 import type { Realm } from '@cardstack/runtime-common';
 import {
   findRealmEvent,
@@ -12,6 +12,7 @@ import {
   setupMatrixRoom,
   matrixURL,
   waitForRealmEvent,
+  waitUntil,
 } from './helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 import type { PgAdapter } from '@cardstack/postgres';
@@ -188,6 +189,144 @@ module(basename(__filename), function () {
         eventName: 'update',
         removed: basename(deletedFilePath),
       });
+    });
+
+    test('file watcher invalidates caches after external edits', async function (assert) {
+      const personFilePath = join(
+        dir.name,
+        'realm_server_1',
+        'test',
+        'person.gts',
+      );
+      const louisFilePath = join(
+        dir.name,
+        'realm_server_1',
+        'test',
+        'louis.json',
+      );
+
+      testRealm.__testOnlyClearCaches();
+
+      let initialSourceResponse = await request
+        .get('/person.gts')
+        .set('Accept', 'application/vnd.card+source');
+      assert.strictEqual(
+        initialSourceResponse.headers['x-boxel-cache'],
+        'miss',
+        'initial card-source response seeds the cache',
+      );
+
+      let cachedSourceResponse = await request
+        .get('/person.gts')
+        .set('Accept', 'application/vnd.card+source');
+      assert.strictEqual(
+        cachedSourceResponse.headers['x-boxel-cache'],
+        'hit',
+        'card source is cached',
+      );
+      let cachedSourceBody = cachedSourceResponse.text.trim();
+
+      await request.get('/louis').set('Accept', 'application/vnd.card+json');
+
+      realmEventTimestampStart = Date.now();
+
+      let updatedPersonSource = `
+import { contains, field, CardDef, Component } from "https://cardstack.com/base/card-api";
+import StringField from "https://cardstack.com/base/string";
+
+export class Person extends CardDef {
+  @field firstName = contains(StringField);
+  @field lastName = contains(StringField);
+  static isolated = class Isolated extends Component<typeof this> {
+    <template>
+      <h1><@fields.firstName/> <@fields.lastName/></h1>
+    </template>
+  }
+  static embedded = class Embedded extends Component<typeof this> {
+    <template>
+      Embedded Card Person: <@fields.firstName/> <@fields.lastName/>
+    </template>
+  }
+  static fitted = class Fitted extends Component<typeof this> {
+    <template>
+      Fitted Card Person: <@fields.firstName/> <@fields.lastName/>
+    </template>
+  }
+}
+      `.trim();
+
+      writeFileSync(personFilePath, `${updatedPersonSource}\n`);
+      writeJSONSync(louisFilePath, {
+        data: {
+          attributes: {
+            firstName: 'Louis',
+            lastName: 'Riel',
+          },
+          meta: {
+            adoptsFrom: {
+              module: './person',
+              name: 'Person',
+            },
+          },
+        },
+      });
+
+      await waitUntil(
+        async () =>
+          (await getMessagesSince(realmEventTimestampStart)).length >= 2,
+        { timeout: 5000, timeoutMessage: 'file watcher events did not arrive' },
+      );
+      await testRealm.flushUpdateEvents();
+
+      let updatedSourceResponse = await request
+        .get('/person.gts')
+        .set('Accept', 'application/vnd.card+source');
+
+      assert.strictEqual(
+        updatedSourceResponse.text.trim(),
+        updatedPersonSource,
+        'module source reflects the external edit',
+      );
+      assert.notStrictEqual(
+        updatedSourceResponse.text.trim(),
+        cachedSourceBody,
+        'stale cached source was not served after external edits',
+      );
+
+      let repopulatedSourceResponse = await request
+        .get('/person.gts')
+        .set('Accept', 'application/vnd.card+source');
+
+      assert.strictEqual(
+        repopulatedSourceResponse.headers['x-boxel-cache'],
+        'hit',
+        'updated source is cached again after invalidation',
+      );
+      assert.strictEqual(
+        repopulatedSourceResponse.text.trim(),
+        updatedPersonSource,
+        'cached source reflects the updated module after invalidation',
+      );
+
+      let updatedCardResponse = await request
+        .get('/louis')
+        .set('Accept', 'application/vnd.card+json');
+
+      assert.strictEqual(
+        updatedCardResponse.status,
+        200,
+        'card request succeeds',
+      );
+      assert.strictEqual(
+        updatedCardResponse.body.data.attributes.firstName,
+        'Louis',
+        'existing attributes remain intact',
+      );
+      assert.strictEqual(
+        updatedCardResponse.body.data.attributes.lastName,
+        'Riel',
+        'module and definition caches are refreshed after external edits',
+      );
     });
   });
 });

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -3237,6 +3237,15 @@ export class Realm {
       if (!tracked || tracked.isTracked) {
         return;
       }
+
+      let localPath = this.paths.local(tracked.url);
+      this.#sourceCache.invalidate(localPath);
+
+      if (hasExecutableExtension(localPath)) {
+        this.#moduleCache.invalidate(localPath);
+        this.#definitionsCache.invalidate();
+      }
+
       this.broadcastRealmEvent(data);
       this.#updateItems.push({
         operation: ('added' in data


### PR DESCRIPTION
Currently in local development, if you change a file externally, it won’t be updated in code submode:

![nscreencast 2025-11-20 14-59-12 2025-11-20 15_26_44](https://github.com/user-attachments/assets/b035ca0f-63e3-4e7b-af83-e53e9a434fae)

With this, changes are picked up:

![screencast 2025-11-20 14-55-43](https://github.com/user-attachments/assets/b50f5f77-4a33-44a3-ba5e-9fb5f54a3d84)

My original attempt at test coverage for this involved a Matrix test, because I wanted something outside-in, as this problem was identified via code submode. However, the isolated realm server that Matrix tests start doesn’t include file-watching. I tried adding that for a while but it grew beyond anything reasonable.

The test here seems a bit overly precise but since this behaviour is development-only and was heretofore untested, I think it‘s better than nothing.