### PR TITLE
ci: Change Playwright report status to reflect tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -392,13 +392,20 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          MATRIX_TEST_RESULT: ${{ needs.matrix-client-test.result }}
         run: |
+          state="success"
+          description=""
+          if [ "$MATRIX_TEST_RESULT" = "failure" ]; then
+            state="failure"
+            description="Matrix Playwright shard failures"
+          fi
           curl \
             -X POST \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/$REPOSITORY/statuses/$HEAD_SHA \
-            -d '{"context":"Matrix Playwright tests report","description":"","target_url":"'"$PLAYWRIGHT_REPORT_URL"'","state":"success"}'
+            -d '{"context":"Matrix Playwright tests report","description":"'"$description"'","target_url":"'"$PLAYWRIGHT_REPORT_URL"'","state":"'"$state"'"}'
 
   realm-server-test:
     name: Realm Server Tests

--- a/packages/matrix/tests/publish-realm.spec.ts
+++ b/packages/matrix/tests/publish-realm.spec.ts
@@ -57,7 +57,7 @@ test.describe('Publish realm', () => {
     await newTab.waitForLoadState();
 
     await expect(newTab).toHaveURL(
-      `http://${user.username}.localhost:4205/new-workspace/`,
+      `http://${user.username}.localhost:4205/new-workspaceFIXME/`,
     );
     await expect(
       newTab.locator(

--- a/packages/matrix/tests/publish-realm.spec.ts
+++ b/packages/matrix/tests/publish-realm.spec.ts
@@ -57,7 +57,7 @@ test.describe('Publish realm', () => {
     await newTab.waitForLoadState();
 
     await expect(newTab).toHaveURL(
-      `http://${user.username}.localhost:4205/new-workspaceFIXME/`,
+      `http://${user.username}.localhost:4205/new-workspace/`,
     );
     await expect(
       newTab.locator(


### PR DESCRIPTION
With this, when a Matrix test fails, the link to the Playwright report is surfaced:

<img width="917" height="401" alt="boxel 2025-11-21 09-02-07" src="https://github.com/user-attachments/assets/f8b169e2-427f-4e20-b71d-f6ac2d045a72" />

When I originally added this, it seemed conceptually correct to me that the report status would be passed because creating and linking to the report succeeded, but when a Matrix test fails I almost always find myself scrolling through the lengthy list of checks to find the report, so this makes it much easier find.