### PR TITLE
Make it simpler to use workspace-sync without user creds

### DIFF
--- a/packages/workspace-sync-cli/README.md
+++ b/packages/workspace-sync-cli/README.md
@@ -36,6 +36,13 @@ Both commands require Matrix credentials to authenticate with the workspace:
 export MATRIX_URL="https://matrix.boxel.ai"
 export MATRIX_USERNAME="your-username"
 export MATRIX_PASSWORD="your-password"
+
+# Optionally you can provide the realm's secret seed and the CLI will derive
+# the matrix credentials from the workspace URL:
+#   /<owner>/<endpoint>/  -> realm/<owner>_<endpoint>
+#   /base/, /skills/, ... -> <slug>_realm
+#   /published/<id>/      -> realm/published_<id>
+export REALM_SECRET_SEED="super-secret-seed"
 ```
 
 ## Usage

--- a/packages/workspace-sync-cli/src/pull.ts
+++ b/packages/workspace-sync-cli/src/pull.ts
@@ -123,7 +123,11 @@ Environment Variables (required):
   MATRIX_PASSWORD  Your Matrix password (or use REALM_SECRET_SEED for realm users)
   
 Environment Variables (optional):
-  REALM_SECRET_SEED  Secret for generating realm user passwords (alternative to MATRIX_PASSWORD)
+  REALM_SECRET_SEED  Secret for generating realm user credentials. If MATRIX_USERNAME
+                     is omitted, it will be derived from WORKSPACE_URL:
+                       /<owner>/<endpoint>/  -> realm/<owner>_<endpoint>
+                       /base/, /skills/, ... -> <slug>_realm
+                       /published/<id>/      -> realm/published_<id>
 
 File Filtering:
   - Files starting with a dot (.) are always ignored
@@ -157,7 +161,8 @@ async function main() {
   const { workspaceUrl, localDir, deleteLocal, dryRun } = parseArgs();
 
   // Get environment variables for Matrix authentication
-  const { matrixUrl, username, password } = await validateMatrixEnvVars();
+  const { matrixUrl, username, password } =
+    await validateMatrixEnvVars(workspaceUrl);
 
   try {
     const puller = new RealmPuller(

--- a/packages/workspace-sync-cli/src/push.ts
+++ b/packages/workspace-sync-cli/src/push.ts
@@ -106,7 +106,11 @@ Environment Variables (required):
   MATRIX_PASSWORD  Your Matrix password (or use REALM_SECRET_SEED for realm users)
   
 Environment Variables (optional):
-  REALM_SECRET_SEED  Secret for generating realm user passwords (alternative to MATRIX_PASSWORD)
+  REALM_SECRET_SEED  Secret for generating realm user credentials. If MATRIX_USERNAME
+                     is omitted, it will be derived from WORKSPACE_URL:
+                       /<owner>/<endpoint>/  -> realm/<owner>_<endpoint>
+                       /base/, /skills/, ... -> <slug>_realm
+                       /published/<id>/      -> realm/published_<id>
 
 File Filtering:
   - Files starting with a dot (.) are always ignored
@@ -140,7 +144,8 @@ async function main() {
   const { workspaceUrl, localDir, deleteRemote, dryRun } = parseArgs();
 
   // Get environment variables for Matrix authentication
-  const { matrixUrl, username, password } = await validateMatrixEnvVars();
+  const { matrixUrl, username, password } =
+    await validateMatrixEnvVars(workspaceUrl);
 
   if (!fs.existsSync(localDir)) {
     console.error(`Local directory does not exist: ${localDir}`);

--- a/packages/workspace-sync-cli/src/realm-sync-base.ts
+++ b/packages/workspace-sync-cli/src/realm-sync-base.ts
@@ -464,7 +464,7 @@ export async function validateMatrixEnvVars(
 
   if (!username) {
     if (!realmSecret) {
-      console.error('MATRIX_USERNAME environment variable is required');
+      console.error('Either MATRIX_USERNAME or REALM_SECRET_SEED environment variable is required');
       process.exit(1);
     }
     username = deriveRealmUsername(workspaceUrl);

--- a/packages/workspace-sync-cli/src/realm-sync-base.ts
+++ b/packages/workspace-sync-cli/src/realm-sync-base.ts
@@ -440,7 +440,7 @@ function deriveRealmUsername(workspaceUrl: string): string {
     return `realm/${segments[0]}_${segments[1]}`;
   }
 
-  // Root realms like base/skills/experiments use <realm>_realm
+  // Root realms like /base/, /skills/, or /experiments/ use <realm>_realm
   return `${segments[0]}_realm`;
 }
 

--- a/packages/workspace-sync-cli/src/realm-sync-base.ts
+++ b/packages/workspace-sync-cli/src/realm-sync-base.ts
@@ -462,7 +462,9 @@ export async function validateMatrixEnvVars(workspaceUrl: string): Promise<{
 
   if (!username) {
     if (!realmSecret) {
-      console.error('Either MATRIX_USERNAME or REALM_SECRET_SEED environment variable is required');
+      console.error(
+        'Either MATRIX_USERNAME or REALM_SECRET_SEED environment variable is required',
+      );
       process.exit(1);
     }
     username = deriveRealmUsername(workspaceUrl);

--- a/packages/workspace-sync-cli/src/realm-sync-base.ts
+++ b/packages/workspace-sync-cli/src/realm-sync-base.ts
@@ -444,9 +444,7 @@ function deriveRealmUsername(workspaceUrl: string): string {
   return `${segments[0]}_realm`;
 }
 
-export async function validateMatrixEnvVars(
-  workspaceUrl: string,
-): Promise<{
+export async function validateMatrixEnvVars(workspaceUrl: string): Promise<{
   matrixUrl: string;
   username: string;
   password: string;


### PR DESCRIPTION
This PR streamlines the workspace sync script so that it can derive a matrix user ID if you supply a realm secret seed. 
