### PR TITLE
Increase run time for ai generation: 10 retries in 10mins (it was 5 seconds before)

### DIFF
--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -88,6 +88,7 @@ class Assistant {
     if (trackAiUsageCostPromises.has(matrixUserId)) {
       return;
     }
+    // intentionally do not await saveUsageCost promise - it has a backoff mechanism to retry if the cost is not immediately available so we don't want to block the main thread
     trackAiUsageCostPromises.set(
       matrixUserId,
       saveUsageCost(

--- a/packages/billing/ai-billing.ts
+++ b/packages/billing/ai-billing.ts
@@ -7,13 +7,15 @@ import {
   type DBAdapter,
   MINIMUM_AI_CREDITS_TO_CONTINUE,
   logger,
-  retry,
 } from '@cardstack/runtime-common';
 import * as Sentry from '@sentry/node';
 
 const log = logger('ai-billing');
 
 const CREDITS_PER_USD = 1000;
+const MAX_FETCH_ATTEMPTS = 10;
+const MAX_FETCH_RUNTIME_MS = 10 * 60 * 1000; // 10 minutes
+const INITIAL_BACKOFF_MS = 1000;
 
 export interface AICreditValidationResult {
   hasEnoughCredits: boolean;
@@ -68,15 +70,17 @@ export async function saveUsageCost(
 ) {
   try {
     // Generation data is sometimes not immediately available, so we retry a couple of times until we are able to get the cost
-    let costInUsd = await retry(
-      () => fetchGenerationCost(generationId, openRouterApiKey),
-      {
-        retries: 10,
-        delayMs: 500,
-      },
+    let costInUsd = await fetchGenerationCostWithBackoff(
+      generationId,
+      openRouterApiKey,
     );
 
     if (costInUsd === null) {
+      let error = new Error(
+        `Failed to fetch generation cost after retries (generationId: ${generationId})`,
+      );
+      log.error(error);
+      Sentry.captureException(error);
       return;
     }
 
@@ -91,8 +95,6 @@ export async function saveUsageCost(
     }
 
     await spendCredits(dbAdapter, user.id, creditsConsumed);
-
-    // TODO: send a signal to the host app to update credits balance displayed in the UI
   } catch (err) {
     log.error(
       `Failed to track AI usage (matrixUserId: ${matrixUserId}, generationId: ${generationId}):`,
@@ -101,6 +103,42 @@ export async function saveUsageCost(
     Sentry.captureException(err);
     // Don't throw, because we don't want to crash the application over this
   }
+}
+
+async function fetchGenerationCostWithBackoff(
+  generationId: string,
+  openRouterApiKey: string,
+): Promise<number | null> {
+  let startedAt = Date.now();
+  let delayMs = INITIAL_BACKOFF_MS;
+
+  for (let attempt = 1; attempt <= MAX_FETCH_ATTEMPTS; attempt++) {
+    try {
+      let cost = await fetchGenerationCost(generationId, openRouterApiKey);
+      if (cost !== null) {
+        return cost;
+      }
+    } catch (error) {
+      log.warn(
+        `Attempt ${attempt} to fetch generation cost failed (generationId: ${generationId})`,
+        error,
+      );
+    }
+
+    let elapsed = Date.now() - startedAt;
+    if (attempt === MAX_FETCH_ATTEMPTS || elapsed >= MAX_FETCH_RUNTIME_MS) {
+      break;
+    }
+
+    let remainingTime = MAX_FETCH_RUNTIME_MS - elapsed;
+    let sleepMs = Math.min(delayMs, remainingTime);
+    await new Promise((resolve) => setTimeout(resolve, sleepMs));
+    delayMs = Math.min(delayMs * 2, MAX_FETCH_RUNTIME_MS);
+  }
+
+  throw new Error(
+    `Failed to fetch generation cost within ${MAX_FETCH_ATTEMPTS} attempts or ${MAX_FETCH_RUNTIME_MS / 60000} minutes (generationId: ${generationId})`,
+  );
 }
 
 async function fetchGenerationCost(
@@ -121,7 +159,6 @@ async function fetchGenerationCost(
   if (data.error && data.error.message.includes('not found')) {
     return null;
   }
-
   return data.data.total_cost;
 }
 


### PR DESCRIPTION
After ai bot finishes generating an AI response, it tries to fetch the cost for that generation, and deduct the credit amount from the user's credit balance. 

I observed the endpoint currently needs around 10-30 seconds to return a result, and responds with 500 in the meanwhile. The current logic does not wait for long enough (currently only around 4-5 seconds), and it will swallow the error and not deduct users' credits. This means that users currently aren't spending any credits to use Boxel. I am not sure what the reason for the larger delay of Open Router's generation cost reporting is, but we must adapt to it, and make sure we get informed if this fails. 

This PR increases the run time for the retry/backoff logic to 10 retries in 10 minutes, and makes sure an error is reported to Sentry in case it is not able to get the cost that deducts the users' credits. 