### PR TITLE
Better handling for auth errors encountered during indexing

### DIFF
--- a/packages/host/app/services/loader-service.ts
+++ b/packages/host/app/services/loader-service.ts
@@ -16,6 +16,8 @@ import { Loader } from '@cardstack/runtime-common/loader';
 
 import config from '@cardstack/host/config/environment';
 
+import { authErrorEventMiddleware } from '../utils/auth-error-guard';
+
 import type NetworkService from './network';
 import type RealmService from './realm';
 import type RealmInfoService from './realm-info-service';
@@ -115,6 +117,7 @@ export default class LoaderService extends Service {
 
     if (!this.fastboot.isFastBoot) {
       middlewareStack.push(authorizationMiddleware(this.realm));
+      middlewareStack.push(authErrorEventMiddleware());
     }
     let fetch = fetcher(this.network.fetch, middlewareStack);
     let loader = new Loader(fetch, this.network.resolveImport);

--- a/packages/host/app/services/network.ts
+++ b/packages/host/app/services/network.ts
@@ -12,6 +12,7 @@ import {
 import config from '@cardstack/host/config/environment';
 
 import { shimExternals } from '../lib/externals';
+import { authErrorEventMiddleware } from '../utils/auth-error-guard';
 
 import type LoaderService from './loader-service';
 import type RealmService from './realm';
@@ -67,6 +68,7 @@ export default class NetworkService extends Service {
         return next(req);
       },
       authorizationMiddleware(this.realm),
+      authErrorEventMiddleware(),
     ]);
   }
 

--- a/packages/host/tests/unit/auth-error-guard-test.ts
+++ b/packages/host/tests/unit/auth-error-guard-test.ts
@@ -20,8 +20,14 @@ module('Unit | auth-error-guard', function () {
         [authErrorEventMiddleware(window)],
       );
 
-      let error = await assert.rejects(
-        guard.race(() => fetch('http://example.com/')),
+      let error: unknown;
+      await assert.rejects(
+        guard
+          .race(() => fetch('http://example.com/'))
+          .catch((err) => {
+            error = err;
+            throw err;
+          }),
         /Unauthorized/,
       );
 

--- a/packages/host/tests/unit/auth-error-guard-test.ts
+++ b/packages/host/tests/unit/auth-error-guard-test.ts
@@ -1,0 +1,46 @@
+import { module, test } from 'qunit';
+
+import { fetcher, CardError } from '@cardstack/runtime-common';
+
+import {
+  authErrorEventMiddleware,
+  createAuthErrorGuard,
+} from '@cardstack/host/utils/auth-error-guard';
+
+module('Unit | auth-error-guard', function () {
+  test('middleware emits auth error events that cancel in-flight requests', async function (assert) {
+    assert.expect(2);
+
+    let guard = createAuthErrorGuard(window);
+    guard.register();
+
+    try {
+      let fetch = fetcher(
+        async () => new Response('Unauthorized', { status: 401 }),
+        [authErrorEventMiddleware(window)],
+      );
+
+      let error = await assert.rejects(
+        guard.race(() => fetch('http://example.com/')),
+        /Unauthorized/,
+      );
+
+      assert.true(
+        guard.isAuthError(error),
+        'auth guard recognizes middleware-dispatched auth errors',
+      );
+    } finally {
+      guard.unregister();
+    }
+  });
+
+  test('card errors with auth statuses are recognized without event flag', function (assert) {
+    let guard = createAuthErrorGuard(window);
+    let error = new CardError('Forbidden', { status: 403 });
+
+    assert.true(
+      guard.isAuthError(error),
+      'auth guard treats 401/403 card errors as auth errors',
+    );
+  });
+});

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -466,8 +466,9 @@ module(basename(__filename), function () {
         permissions,
       });
 
-      assert.ok(
-        result.response.error,
+      assert.strictEqual(
+        result.response.status,
+        'error',
         'auth failure returns an error response',
       );
       let status = result.response.error?.error.status;

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -434,7 +434,10 @@ module(basename(__filename), function () {
         permissions,
       });
 
-      assert.ok(result.response.error, 'auth failure returns an error response');
+      assert.ok(
+        result.response.error,
+        'auth failure returns an error response',
+      );
       let status = result.response.error?.error.status;
       assert.strictEqual(status, 401, 'auth error status should be 401');
       assert.notStrictEqual(
@@ -462,7 +465,10 @@ module(basename(__filename), function () {
         permissions,
       });
 
-      assert.ok(result.response.error, 'auth failure returns an error response');
+      assert.ok(
+        result.response.error,
+        'auth failure returns an error response',
+      );
       let status = result.response.error?.error.status;
       assert.strictEqual(status, 401, 'auth error status should be 401');
       assert.notStrictEqual(

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -434,13 +434,9 @@ module(basename(__filename), function () {
         permissions,
       });
 
-      assert.strictEqual(
-        result.response.status,
-        'error',
-        'auth failure returns an error response',
-      );
+      assert.ok(result.response.error, 'auth failure returns an error response');
       let status = result.response.error?.error.status;
-      assert.strictEqual(status, 401, `auth error status should be 401`);
+      assert.strictEqual(status, 401, 'auth error status should be 401');
       assert.notStrictEqual(
         result.response.error?.error.title,
         'Render timeout',
@@ -466,13 +462,9 @@ module(basename(__filename), function () {
         permissions,
       });
 
-      assert.strictEqual(
-        result.response.status,
-        'error',
-        'auth failure returns an error response',
-      );
+      assert.ok(result.response.error, 'auth failure returns an error response');
       let status = result.response.error?.error.status;
-      assert.strictEqual(status, 401, `auth error status should be 401`);
+      assert.strictEqual(status, 401, 'auth error status should be 401');
       assert.notStrictEqual(
         result.response.error?.error.title,
         'Render timeout',

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -456,7 +456,7 @@ module(basename(__filename), function () {
       );
     });
 
-    test('card prerender surfaces auth error without timing out', async function (assert: any) {
+    test('card prerender surfaces auth error without timing out', async function (assert) {
       const cardURL = `${consumerRealmURL}website-1`;
 
       let result = await prerenderer.prerenderCard({


### PR DESCRIPTION
This fixes a broken test in main around auth errors encountered during indexing. we should be failing fast when we encounter this, but we were actually timing out. this adds logic to ensure we are failing fast when we encounter an auth error during indexing as well as tests to assert that.