### PR TITLE
Use hostHome in realm config instead of site.json file

### DIFF
--- a/packages/host/app/commands/set-site-config.ts
+++ b/packages/host/app/commands/set-site-config.ts
@@ -1,17 +1,11 @@
 import { service } from '@ember/service';
 
-import {
-  RealmPaths,
-  isCardInstance,
-  type LooseCardResource,
-} from '@cardstack/runtime-common';
-import type { AtomicOperationType } from '@cardstack/runtime-common/atomic-document';
+import { isCardInstance } from '@cardstack/runtime-common';
 
 import type * as BaseCommandModule from 'https://cardstack.com/base/command';
 
 import HostBaseCommand from '../lib/host-base-command';
 
-import type CardService from '../services/card-service';
 import type RealmService from '../services/realm';
 import type StoreService from '../services/store';
 
@@ -19,7 +13,6 @@ export default class SetSiteConfigCommand extends HostBaseCommand<
   typeof BaseCommandModule.CardIdCard,
   undefined
 > {
-  @service declare private cardService: CardService;
   @service declare private realm: RealmService;
   @service declare private store: StoreService;
 
@@ -62,38 +55,8 @@ export default class SetSiteConfigCommand extends HostBaseCommand<
       throw new Error(`Could not load site config card: ${cardId}`);
     }
 
-    let serialized = await this.cardService.serializeCard(siteConfigInstance, {
-      useAbsoluteURL: true,
-      withIncluded: true,
-    });
-
-    delete serialized.data.id;
-    delete serialized.data.lid;
-    let resource = serialized.data as LooseCardResource;
-
-    let realmPaths = new RealmPaths(realmURL);
-    let siteConfigURL = realmPaths.fileURL('site.json');
-    let operationType: AtomicOperationType = 'add';
-
-    try {
-      await this.cardService.fetchJSON(siteConfigURL.href);
-      operationType = 'update';
-    } catch (error: any) {
-      if (error?.status && error.status !== 404) {
-        throw error;
-      }
-    }
-
-    await this.cardService.executeAtomicOperations(
-      [
-        {
-          op: operationType,
-          href: siteConfigURL.href,
-          data: resource,
-        },
-      ],
-      realmURL,
-    );
+    let normalizedCardId = cardURL.href.replace(/\.json$/, '');
+    await this.realm.setHostHome(realmHref, normalizedCardId);
 
     return undefined;
   }

--- a/packages/host/app/services/home-page-resolver.ts
+++ b/packages/host/app/services/home-page-resolver.ts
@@ -77,18 +77,10 @@ export default class HomePageResolverService extends Service {
       return null;
     }
 
-    let realmPaths = new RealmPaths(new URL(normalizedRealmURL));
-    let siteConfigURL = realmPaths.fileURL('site.json').href;
-
-    let siteConfigInstance: SiteConfig | undefined;
-    try {
-      siteConfigInstance = (await this.store.get(siteConfigURL)) as
-        | SiteConfig
-        | undefined;
-    } catch (_error) {
-      return null;
-    }
-
+    let siteConfigId = await this.hostHomeFor(normalizedRealmURL);
+    let siteConfigInstance =
+      siteConfigId &&
+      (await this.loadSiteConfig(siteConfigId, normalizedRealmURL));
     if (!siteConfigInstance) {
       return null;
     }
@@ -101,6 +93,59 @@ export default class HomePageResolverService extends Service {
     }
 
     return homeCard.id.replace(/\.json$/, '');
+  }
+
+  private async hostHomeFor(realmURL: string): Promise<string | null> {
+    try {
+      await this.realm.ensureRealmMeta(realmURL);
+    } catch (_error) {
+      return null;
+    }
+
+    let info = this.realm.info(realmURL);
+    return info.hostHome ?? null;
+  }
+
+  private async loadSiteConfig(
+    siteConfigId: string,
+    realmURL: string,
+  ): Promise<SiteConfig | undefined> {
+    let resolvedSiteConfigId = this.resolveCardURL(siteConfigId, realmURL);
+    if (!resolvedSiteConfigId) {
+      return undefined;
+    }
+
+    let siteConfig =
+      (await this.tryLoadSiteConfig(resolvedSiteConfigId)) ??
+      (await this.tryLoadSiteConfig(
+        resolvedSiteConfigId.endsWith('.json')
+          ? resolvedSiteConfigId
+          : `${resolvedSiteConfigId}.json`,
+      ));
+
+    return siteConfig ?? undefined;
+  }
+
+  private async tryLoadSiteConfig(
+    siteConfigURL: string,
+  ): Promise<SiteConfig | undefined> {
+    try {
+      return (await this.store.get(siteConfigURL)) as SiteConfig | undefined;
+    } catch (_error) {
+      return undefined;
+    }
+  }
+
+  private resolveCardURL(cardId: string, realmURL: string): string | undefined {
+    try {
+      return new URL(cardId).href.replace(/\.json$/, '');
+    } catch (_error) {
+      try {
+        return new URL(cardId, realmURL).href.replace(/\.json$/, '');
+      } catch (_error) {
+        return undefined;
+      }
+    }
   }
 
   private async identifyRealmURL(url: URL): Promise<string | undefined> {

--- a/packages/host/app/services/home-page-resolver.ts
+++ b/packages/host/app/services/home-page-resolver.ts
@@ -115,15 +115,7 @@ export default class HomePageResolverService extends Service {
       return undefined;
     }
 
-    let siteConfig =
-      (await this.tryLoadSiteConfig(resolvedSiteConfigId)) ??
-      (await this.tryLoadSiteConfig(
-        resolvedSiteConfigId.endsWith('.json')
-          ? resolvedSiteConfigId
-          : `${resolvedSiteConfigId}.json`,
-      ));
-
-    return siteConfig ?? undefined;
+    return await this.tryLoadSiteConfig(resolvedSiteConfigId);
   }
 
   private async tryLoadSiteConfig(

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -55,6 +55,12 @@ export type EnhancedRealmInfo = RealmInfo & {
   isPublic: boolean;
 };
 
+type RealmInfoProperty =
+  | 'backgroundURL'
+  | 'iconURL'
+  | 'interactHome'
+  | 'hostHome';
+
 type AuthStatus =
   | { type: 'logged-in'; token: string; claims: JWTPayload }
   | { type: 'anonymous' };
@@ -271,6 +277,50 @@ class RealmResource {
       this.fetchingInfo = undefined;
     }
   });
+
+  async setRealmInfoProperty(
+    property: RealmInfoProperty,
+    value: string | null,
+  ): Promise<void> {
+    await this.loginTask.perform();
+    let headers: Record<string, string> = {
+      Accept: SupportedMimeType.RealmInfo,
+      Authorization: `Bearer ${this.token}`,
+      'Content-Type': SupportedMimeType.JSONAPI,
+    };
+    let response = await this.network.authedFetch(`${this.realmURL}_config`, {
+      method: 'PATCH',
+      headers,
+      body: JSON.stringify({
+        data: {
+          type: 'realm-config',
+          id: this.url,
+          attributes: { property, value },
+        },
+      }),
+    });
+
+    if (response.status !== 200) {
+      throw new Error(
+        `Failed to set realm config property '${property}' for realm ${this.url}: ${response.status}`,
+      );
+    }
+    let json = await waitForPromise(response.json());
+    let isPublic = Boolean(
+      response.headers.get('x-boxel-realm-public-readable'),
+    );
+    let updatedInfo = new TrackedObject({
+      url: json.data.id,
+      ...json.data.attributes,
+      isIndexing: this.info?.isIndexing ?? false,
+      isPublic,
+    }) as EnhancedRealmInfo;
+    this.info = updatedInfo;
+  }
+
+  async setHostHome(hostHome: string | null): Promise<void> {
+    return await this.setRealmInfoProperty('hostHome', hostHome);
+  }
 
   async fetchRealmPermissions() {
     return await this.fetchRealmPermissionsTask.perform();
@@ -580,6 +630,10 @@ export default class RealmService extends Service {
     permissions: ('read' | 'write')[],
   ) {
     await this.knownRealm(url)?.setRealmPermission(userId, permissions);
+  }
+
+  async setHostHome(url: string, hostHome: string | null): Promise<void> {
+    await this.knownRealm(url)?.setHostHome(hostHome);
   }
 
   isPublic = (url: string): boolean => {

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -284,9 +284,8 @@ class RealmResource {
   ): Promise<void> {
     await this.loginTask.perform();
     let headers: Record<string, string> = {
-      Accept: SupportedMimeType.RealmInfo,
+      Accept: SupportedMimeType.JSON,
       Authorization: `Bearer ${this.token}`,
-      'Content-Type': SupportedMimeType.JSONAPI,
     };
     let response = await this.network.authedFetch(`${this.realmURL}_config`, {
       method: 'PATCH',
@@ -295,7 +294,7 @@ class RealmResource {
         data: {
           type: 'realm-config',
           id: this.url,
-          attributes: { property, value },
+          attributes: { [property]: value },
         },
       }),
     });

--- a/packages/host/tests/acceptance/site-config-test.gts
+++ b/packages/host/tests/acceptance/site-config-test.gts
@@ -380,10 +380,7 @@ module('Acceptance | site config home page', function (hooks) {
               ? file.content
               : JSON.stringify(file.content);
           realmDoc = JSON.parse(content);
-          return (
-            realmDoc.hostHome === `${testRealmURL}SiteConfig/custom` &&
-            realmDoc.hostHome !== null
-          );
+          return realmDoc.hostHome === `${testRealmURL}SiteConfig/custom`;
         });
 
         assert.strictEqual(


### PR DESCRIPTION
Previously, we used the site.json file under the root directory of a realm to determine whether the realm owner had an alternate home page in host mode. This PR introduces a new approach where the site.json file is no longer needed. Instead, we store the site-config card ID directly in the realm config, allowing the host to know which site-config instance is selected and to redirect the user to the alternate home page in host submode.