### PR TITLE
Fixing flaky tests

### DIFF
--- a/packages/realm-server/node-realm.ts
+++ b/packages/realm-server/node-realm.ts
@@ -277,10 +277,14 @@ export class NodeAdapter implements RealmAdapter {
       dmRooms = await fetchAllSessionRooms(dbAdapter, realmUrl);
     } catch (e) {
       realmEventsLog.error('Error getting account data', e);
+      return {}; // bail immediately on errors instead of retrying
+    }
+
+    if (Object.keys(dmRooms).length) {
       return dmRooms;
     }
 
-    if (Object.keys(dmRooms).length || attempts === 0) {
+    if (attempts === 0) {
       return dmRooms;
     }
 

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -836,11 +836,12 @@ export async function waitForRealmEvent(
       let matrixMessages = await getMessagesSince(since);
       let matchingEvent = findMatchingEvent(matrixMessages);
 
-      if (!matchingEvent && REALM_EVENT_TS_SKEW_BUFFER_MS > 0) {
-        let skewedMessages = await getMessagesSince(
-          Math.max(0, since - REALM_EVENT_TS_SKEW_BUFFER_MS),
-        );
-        matchingEvent = findMatchingEvent(skewedMessages);
+      if (!matchingEvent) {
+        let skewedSince = Math.max(0, since - REALM_EVENT_TS_SKEW_BUFFER_MS);
+        if (skewedSince !== since) {
+          let skewedMessages = await getMessagesSince(skewedSince);
+          matchingEvent = findMatchingEvent(skewedMessages);
+        }
       }
 
       if (matchingEvent) {

--- a/packages/runtime-common/fetcher.ts
+++ b/packages/runtime-common/fetcher.ts
@@ -15,7 +15,8 @@ export function fetcher(
         if (nextHandler) {
           response = await nextHandler(onwardReq, buildNext(rest));
         } else {
-          response = await fetchImplementation(onwardReq);
+          // clone so retries/redirects can reuse the original Request
+          response = await fetchImplementation(onwardReq.clone());
         }
         return await simulateNetworkBehaviors(onwardReq, response, instance);
       };


### PR DESCRIPTION
Based on the logging that we have included for the file watcher tests around the flakiness. codex has recommended these updates. As well as a flaky test re-using a request that was already consumed.