### PR TITLE
add command declaration in LHS inspector

### DIFF
--- a/packages/host/app/components/operator-mode/detail-panel-selector.gts
+++ b/packages/host/app/components/operator-mode/detail-panel-selector.gts
@@ -17,6 +17,7 @@ import scrollIntoViewModifier from '@cardstack/host/modifiers/scroll-into-view';
 import {
   type ModuleDeclaration,
   isCardOrFieldDeclaration,
+  isCommandDeclaration,
   isReexportCardOrField,
 } from '@cardstack/host/resources/module-contents';
 
@@ -111,6 +112,8 @@ export default class Selector extends Component<Signature> {
       return typeOfCardOrField(declaration.cardOrField);
     } else if (isReexportCardOrField(declaration)) {
       return typeOfCardOrField(declaration.cardOrField);
+    } else if (isCommandDeclaration(declaration)) {
+      return 'command';
     } else if (declaration.type === 'class') {
       return 'class';
     } else if (declaration.type === 'function') {

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -40,6 +40,7 @@ import { type Ready } from '@cardstack/host/resources/file';
 import {
   type ModuleDeclaration,
   isCardOrFieldDeclaration,
+  isCommandDeclaration,
   isReexportCardOrField,
 } from '@cardstack/host/resources/module-contents';
 
@@ -143,6 +144,14 @@ export default class DetailPanel extends Component<Signature> {
     return (
       this.args.cardError ||
       (!this.isModule && !isCardDocumentString(this.args.readyFile.content))
+    );
+  }
+
+  private get showCommandPanel() {
+    return (
+      this.isModule &&
+      this.args.selectedDeclaration &&
+      isCommandDeclaration(this.args.selectedDeclaration)
     );
   }
 
@@ -267,7 +276,7 @@ export default class DetailPanel extends Component<Signature> {
     ) {
       throw new Error(`bug: the selected declaration is not a card definition`);
     }
-    let ref = this.getSelectedDeclarationAsCodeRef();
+    let ref = this.getSelectedDeclarationAsCodeRef;
     let displayName = this.args.selectedDeclaration.cardOrField.displayName;
     let id: NewFileType = 'card-instance';
     this.args.createFile(
@@ -299,7 +308,7 @@ export default class DetailPanel extends Component<Signature> {
     if (!id) {
       throw new Error(`Can only call inherit() on card def or field def`);
     }
-    let ref = this.getSelectedDeclarationAsCodeRef();
+    let ref = this.getSelectedDeclarationAsCodeRef;
     let displayName = this.args.selectedDeclaration.cardOrField.displayName;
     this.args.createFile(
       { id, displayName: capitalize(startCase(id)) },
@@ -321,7 +330,7 @@ export default class DetailPanel extends Component<Signature> {
     ) {
       throw new Error(`bug: the selected declaration is not a card definition`);
     }
-    let ref = this.getSelectedDeclarationAsCodeRef();
+    let ref = this.getSelectedDeclarationAsCodeRef;
     let refURL = internalKeyFor(
       ref,
       this.operatorModeStateService.state.codePath!,
@@ -329,7 +338,7 @@ export default class DetailPanel extends Component<Signature> {
     this.args.openSearch(`carddef:${refURL}`);
   }
 
-  private getSelectedDeclarationAsCodeRef(): ResolvedCodeRef {
+  private get getSelectedDeclarationAsCodeRef(): ResolvedCodeRef {
     if (!this.args.selectedDeclaration?.exportName) {
       throw new Error(`bug: only exported cards/fields can be inherited`);
     }
@@ -364,6 +373,14 @@ export default class DetailPanel extends Component<Signature> {
     } else {
       return '';
     }
+  }
+
+  private get selectedDeclarationName() {
+    let declaration = this.args.selectedDeclaration;
+    if (!declaration) {
+      return '';
+    }
+    return declaration.exportName ?? declaration.localName ?? '[No Name Found]';
   }
 
   private get buildSelectorItems(): SelectorItem[] {
@@ -540,6 +557,24 @@ export default class DetailPanel extends Component<Signature> {
               {{/if}}
             {{/let}}
           {{/if}}
+        </PanelSection>
+      {{else if this.showCommandPanel}}
+        <PanelSection as |PanelHeader|>
+          <PanelHeader
+            aria-label='Command Panel Header'
+            data-test-command-panel-header
+          >
+            Command
+          </PanelHeader>
+          <ModuleDefinitionContainer
+            @title='Command'
+            @fileURL={{@readyFile.url}}
+            @name={{this.selectedDeclarationName}}
+            @fileExtension={{this.fileExtension}}
+            @isActive={{true}}
+            @actions={{this.definitionActions}}
+            @infoText={{this.lastModified.value}}
+          />
         </PanelSection>
       {{else if this.showDetailsPanel}}
         <PanelSection as |PanelHeader|>

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -276,7 +276,7 @@ export default class DetailPanel extends Component<Signature> {
     ) {
       throw new Error(`bug: the selected declaration is not a card definition`);
     }
-    let ref = this.getSelectedDeclarationAsCodeRef;
+    let ref = this.selectedDeclarationAsCodeRef;
     let displayName = this.args.selectedDeclaration.cardOrField.displayName;
     let id: NewFileType = 'card-instance';
     this.args.createFile(
@@ -308,7 +308,7 @@ export default class DetailPanel extends Component<Signature> {
     if (!id) {
       throw new Error(`Can only call inherit() on card def or field def`);
     }
-    let ref = this.getSelectedDeclarationAsCodeRef;
+    let ref = this.selectedDeclarationAsCodeRef;
     let displayName = this.args.selectedDeclaration.cardOrField.displayName;
     this.args.createFile(
       { id, displayName: capitalize(startCase(id)) },
@@ -330,7 +330,7 @@ export default class DetailPanel extends Component<Signature> {
     ) {
       throw new Error(`bug: the selected declaration is not a card definition`);
     }
-    let ref = this.getSelectedDeclarationAsCodeRef;
+    let ref = this.selectedDeclarationAsCodeRef;
     let refURL = internalKeyFor(
       ref,
       this.operatorModeStateService.state.codePath!,
@@ -338,7 +338,7 @@ export default class DetailPanel extends Component<Signature> {
     this.args.openSearch(`carddef:${refURL}`);
   }
 
-  private get getSelectedDeclarationAsCodeRef(): ResolvedCodeRef {
+  private get selectedDeclarationAsCodeRef(): ResolvedCodeRef {
     if (!this.args.selectedDeclaration?.exportName) {
       throw new Error(`bug: only exported cards/fields can be inherited`);
     }

--- a/packages/host/app/resources/module-contents.ts
+++ b/packages/host/app/resources/module-contents.ts
@@ -17,17 +17,21 @@ import {
   type ModuleDeclaration,
   type CardOrFieldDeclaration,
   type CardOrFieldReexport,
+  type CommandDeclaration,
   isCardOrFieldDeclaration,
+  isCommandDeclaration,
   isReexportCardOrField,
 } from '@cardstack/host/services/module-contents-service';
 import type NetworkService from '@cardstack/host/services/network';
 
 export {
   isCardOrFieldDeclaration,
+  isCommandDeclaration,
   isReexportCardOrField,
   type ModuleDeclaration,
   type CardOrFieldDeclaration,
   type CardOrFieldReexport,
+  type CommandDeclaration,
 };
 
 interface Args {

--- a/packages/host/app/services/module-contents-service.ts
+++ b/packages/host/app/services/module-contents-service.ts
@@ -1,7 +1,12 @@
 import { service } from '@ember/service';
 import Service from '@ember/service';
 
-import { getAncestor, getField, isBaseDef } from '@cardstack/runtime-common';
+import {
+  Command,
+  getAncestor,
+  getField,
+  isBaseDef,
+} from '@cardstack/runtime-common';
 
 import {
   ModuleSyntax,
@@ -33,8 +38,14 @@ export type CardOrFieldDeclaration = CardOrField &
 
 export type CardOrFieldReexport = CardOrField & Reexport;
 
+export type CommandDeclaration = Omit<ClassDeclaration, 'type'> & {
+  type: 'command';
+  command: typeof Command;
+};
+
 export type ModuleDeclaration =
   | CardOrFieldDeclaration
+  | CommandDeclaration
   | ClassDeclaration
   | FunctionDeclaration
   | CardOrFieldReexport;
@@ -46,6 +57,12 @@ export function isCardOrFieldDeclaration(
     declaration.type === 'possibleCardOrField' &&
     hasCardOrFieldProperties(declaration)
   );
+}
+
+export function isCommandDeclaration(
+  declaration: ModuleDeclaration,
+): declaration is CommandDeclaration {
+  return declaration.type === 'command';
 }
 
 export function isReexportCardOrField(
@@ -105,6 +122,7 @@ export default class ModuleContentsService extends Service {
   ): Promise<ModuleDeclaration[]> {
     let exportedCardsOrFields: Map<string, typeof BaseDef> =
       getExportedCardsOrFields(module);
+    let exportedCommands = getExportedCommands(module);
     let localCardsOrFields = this.collectLocalCardsOrFields(
       moduleSyntax,
       exportedCardsOrFields,
@@ -127,6 +145,10 @@ export default class ModuleContentsService extends Service {
           }
           // case where things statically look like cards or fields but are not
           if (value.exportName !== undefined) {
+            let command = exportedCommands.get(value.exportName);
+            if (command) {
+              return asCommandDeclaration(value, command);
+            }
             return {
               ...(value.super ? { super: value.super } : {}),
               localName: value.localName,
@@ -152,7 +174,15 @@ export default class ModuleContentsService extends Service {
               } as CardOrFieldReexport;
             }
           }
-        } else if (value.type === 'class' || value.type === 'function') {
+        } else if (value.type === 'class') {
+          if (value.exportName !== undefined) {
+            let command = exportedCommands.get(value.exportName);
+            if (command) {
+              return asCommandDeclaration(value, command);
+            }
+            return value as ModuleDeclaration;
+          }
+        } else if (value.type === 'function') {
           if (value.exportName !== undefined) {
             return value as ModuleDeclaration;
           }
@@ -263,4 +293,35 @@ function getExportedCardsOrFields(module: object) {
   return new Map(
     Object.entries(module).filter(([_, declaration]) => isBaseDef(declaration)),
   );
+}
+
+function getExportedCommands(module: object) {
+  return new Map(
+    Object.entries(module).filter(([_, declaration]) =>
+      isCommandConstructor(declaration),
+    ) as [string, typeof Command][],
+  );
+}
+
+function isCommandConstructor(
+  declaration: unknown,
+): declaration is typeof Command {
+  return (
+    typeof declaration === 'function' &&
+    declaration.prototype instanceof Command
+  );
+}
+
+function asCommandDeclaration(
+  declaration: PossibleCardOrFieldDeclaration | ClassDeclaration,
+  command: typeof Command,
+): CommandDeclaration {
+  return {
+    ...('super' in declaration ? { super: declaration.super } : {}),
+    localName: declaration.localName,
+    exportName: declaration.exportName,
+    path: declaration.path,
+    type: 'command',
+    command,
+  };
 }

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -223,6 +223,20 @@ const inThisFileSource = `
   export default class DefaultClass {}
 `;
 
+const commandModuleSource = `
+  import { Command } from '@cardstack/runtime-common';
+
+  export class SampleCommand extends Command {
+    async getInputType() {
+      return undefined;
+    }
+
+    protected async run(input) {
+      return input;
+    }
+  }
+`;
+
 const friendCardSource = `
   import { contains, linksTo, field, CardDef, Component } from "https://cardstack.com/base/card-api";
   import StringField from "https://cardstack.com/base/string";
@@ -453,6 +467,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
         'imports.gts': importsSource,
         're-export.gts': reExportSource,
         'local-inherit.gts': localInheritSource,
+        'command-module.gts': commandModuleSource,
         'empty-file.gts': '',
         'person-entry.json': {
           data: {
@@ -1185,6 +1200,22 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
 
     let notFound = await adapter.openFile('pet.gts');
     assert.strictEqual(notFound, undefined, 'file ref does not exist');
+  });
+
+  test('shows command panel for command declarations', async function (assert) {
+    await visitOperatorMode({
+      stacks: [[]],
+      submode: Submodes.Code,
+      codePath: `${testRealmURL}command-module.gts`,
+    });
+
+    await waitFor('[data-test-command-panel-header]');
+    assert
+      .dom('[data-test-command-panel-header]')
+      .hasText('Command', 'renders command panel');
+    assert
+      .dom('[data-test-card-module-definition]')
+      .hasTextContaining('SampleCommand', 'shows command definition details');
   });
 
   test('can delete a misc file', async function (assert) {

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -1216,6 +1216,9 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     assert
       .dom('[data-test-card-module-definition]')
       .hasTextContaining('SampleCommand', 'shows command definition details');
+    assert
+      .dom('[data-test-boxel-selector-item-selected]')
+      .hasText('SampleCommand command', 'selector shows command type');
   });
 
   test('can delete a misc file', async function (assert) {


### PR DESCRIPTION
Code mode inspector now recognizes exported Command subclasses: module analysis classifies commands, the detail panel renders a dedicated Command section, and the selector shows them as a distinct type.

<img width="1915" height="736" alt="Screenshot 2025-12-02 at 21 07 54" src="https://github.com/user-attachments/assets/fb4f33eb-770b-4b6a-b69a-1d9d5646b15c" />

