### PR TITLE
Minor prerender server cleanup

### DIFF
--- a/packages/host/tests/integration/realm-indexing-render-route-test.gts
+++ b/packages/host/tests/integration/realm-indexing-render-route-test.gts
@@ -4284,6 +4284,10 @@ module(`Integration | realm indexing - using /render route`, function (hooks) {
         'posts/ignore-me-2.json': {
           data: { meta: { adoptsFrom: baseCardRef } },
         },
+        // we always ignore the contents of .git/
+        '.git/should-not-index.json': {
+          data: { meta: { adoptsFrom: baseCardRef } },
+        },
         'post.json': { data: { meta: { adoptsFrom: baseCardRef } } },
         'dir/card.json': { data: { meta: { adoptsFrom: baseCardRef } } },
         '.gitignore': `
@@ -4333,6 +4337,12 @@ posts/please-ignore-me.json
         undefined,
         'instance does not exist because file is ignored',
       );
+    }
+    {
+      let card = await indexer.cardDocument(
+        new URL(`${testRealmURL}.git/should-not-index`),
+      );
+      assert.strictEqual(card, undefined, '.git directory entries are ignored');
     }
     {
       let card = await indexer.cardDocument(new URL(`${testRealmURL}post`));

--- a/packages/host/tests/integration/realm-indexing-test.gts
+++ b/packages/host/tests/integration/realm-indexing-test.gts
@@ -4174,11 +4174,7 @@ posts/please-ignore-me.json
       let card = await indexer.cardDocument(
         new URL(`${testRealmURL}.git/should-not-index`),
       );
-      assert.strictEqual(
-        card,
-        undefined,
-        '.git directory entries are ignored',
-      );
+      assert.strictEqual(card, undefined, '.git directory entries are ignored');
     }
     {
       let card = await indexer.cardDocument(new URL(`${testRealmURL}post`));

--- a/packages/host/tests/integration/realm-indexing-test.gts
+++ b/packages/host/tests/integration/realm-indexing-test.gts
@@ -4117,6 +4117,9 @@ module(`Integration | realm indexing`, function (hooks) {
         'posts/ignore-me-2.json': {
           data: { meta: { adoptsFrom: baseCardRef } },
         },
+        '.git/should-not-index.json': {
+          data: { meta: { adoptsFrom: baseCardRef } },
+        },
         'post.json': { data: { meta: { adoptsFrom: baseCardRef } } },
         'dir/card.json': { data: { meta: { adoptsFrom: baseCardRef } } },
         '.gitignore': `
@@ -4165,6 +4168,16 @@ posts/please-ignore-me.json
         card,
         undefined,
         'instance does not exist because file is ignored',
+      );
+    }
+    {
+      let card = await indexer.cardDocument(
+        new URL(`${testRealmURL}.git/should-not-index`),
+      );
+      assert.strictEqual(
+        card,
+        undefined,
+        '.git directory entries are ignored',
       );
     }
     {

--- a/packages/realm-server/prerender/manager-server.ts
+++ b/packages/realm-server/prerender/manager-server.ts
@@ -74,5 +74,5 @@ function shutdown(signal: NodeJS.Signals) {
   // process manager to terminate after grace period.
 }
 
-process.on('SIGINT', shutdown);
-process.on('SIGTERM', shutdown);
+process.on('SIGINT', () => shutdown('SIGINT'));
+process.on('SIGTERM', () => shutdown('SIGTERM'));

--- a/packages/realm-server/prerender/manager-server.ts
+++ b/packages/realm-server/prerender/manager-server.ts
@@ -8,12 +8,24 @@ import { buildPrerenderManagerApp } from './manager-app';
 
 let log = logger('prerender-manager');
 
-let { port } = yargs(process.argv.slice(2))
+let { port, exitOnSignal, forceExitTimeoutMs } = yargs(process.argv.slice(2))
   .usage('Start prerender manager')
   .options({
     port: {
       description: 'HTTP port for prerender manager',
       demandOption: true,
+      type: 'number',
+    },
+    exitOnSignal: {
+      description:
+        'Close the server and exit when receiving a shutdown signal (useful for local development)',
+      default: false,
+      type: 'boolean',
+    },
+    forceExitTimeoutMs: {
+      description:
+        'When exitOnSignal is true, force the process to exit after this timeout (ms)',
+      default: 1000,
       type: 'number',
     },
   })
@@ -27,11 +39,12 @@ let _webServerInstance: Server | undefined;
 _webServerInstance = createServer(app.callback()).listen(port);
 log.info(`prerender manager HTTP listening on port ${port}`);
 
-function shutdown() {
+function shutdown(signal: NodeJS.Signals) {
   if (draining) return;
   draining = true;
   log.info(
-    'Received shutdown signal; marking prerender manager as draining and refusing new work',
+    'Received %s; marking prerender manager as draining and refusing new work',
+    signal,
   );
   _webServerInstance?.getConnections((err, count) => {
     if (err) {
@@ -40,7 +53,24 @@ function shutdown() {
       log.info('Prerender manager draining with %s open connections', count);
     }
   });
-  // keep listener alive so clients get fast draining responses; rely on
+  if (exitOnSignal) {
+    log.info(
+      'Closing prerender manager listener after shutdown signal and exiting process',
+    );
+    _webServerInstance?.close(() => {
+      log.info('Prerender manager listener closed; exiting process');
+      process.exit(0);
+    });
+    let forceExitTimer = setTimeout(() => {
+      log.warn(
+        'Forcing prerender manager shutdown after %s ms timeout',
+        forceExitTimeoutMs,
+      );
+      process.exit(0);
+    }, forceExitTimeoutMs);
+    forceExitTimer.unref();
+  }
+  // keep listener alive in non-exitOnSignal mode so clients get fast draining responses; rely on
   // process manager to terminate after grace period.
 }
 

--- a/packages/realm-server/scripts/start-all-except-experiments.sh
+++ b/packages/realm-server/scripts/start-all-except-experiments.sh
@@ -1,7 +1,7 @@
 #! /bin/sh
 
 USE_HEADLESS_CHROME_INDEXING=true WAIT_ON_TIMEOUT=900000 SKIP_EXPERIMENTS=true NODE_NO_WARNINGS=1 start-server-and-test \
-  'run-p start:pg start:prerender-dev start:matrix start:smtp start:worker-development start:development' \
+  'run-p start:pg start:prerender-dev start:prerender-manager-dev start:matrix start:smtp start:worker-development start:development' \
   'http-get://localhost:4201/base/_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson|http://localhost:8008|http://localhost:5001' \
   'run-p start:worker-test start:test-realms' \
   'http-get://localhost:4202/node-test/_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson' \

--- a/packages/realm-server/scripts/start-all.sh
+++ b/packages/realm-server/scripts/start-all.sh
@@ -18,7 +18,7 @@ SYNAPSE_URL="http://localhost:8008"
 SMTP_4_DEV_URL="http://localhost:5001"
 
 USE_HEADLESS_CHROME_INDEXING=true WAIT_ON_TIMEOUT=900000 NODE_NO_WARNINGS=1 start-server-and-test \
-  'run-p start:pg start:matrix start:smtp start:prerender-dev start:worker-development start:development' \
+  'run-p start:pg start:matrix start:smtp start:prerender-dev start:prerender-manager-dev start:worker-development start:development' \
   "$BASE_REALM_READY|$CATALOG_REALM_READY|$SKILLS_REALM_READY|$EXPERIMENTS_REALM_READY|$SYNAPSE_URL|$SMTP_4_DEV_URL" \
   'run-p start:worker-test start:test-realms' \
   "$NODE_TEST_REALM_READY" \

--- a/packages/realm-server/scripts/start-prerender-manager-dev.sh
+++ b/packages/realm-server/scripts/start-prerender-manager-dev.sh
@@ -8,4 +8,5 @@ NODE_ENV=development \
   NODE_NO_WARNINGS=1 \
   ts-node \
   --transpileOnly prerender/manager-server \
-  --port=${PRERENDER_MANAGER_PORT:-4222}
+  --port=${PRERENDER_MANAGER_PORT:-4222} \
+  --exit-on-signal

--- a/packages/realm-server/scripts/start-services-for-matrix-tests.sh
+++ b/packages/realm-server/scripts/start-services-for-matrix-tests.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 pnpm --dir=../skills-realm skills:setup
 USE_HEADLESS_CHROME_INDEXING=true WAIT_ON_TIMEOUT=600000 NODE_NO_WARNINGS=1 start-server-and-test \
-  'run-p start:pg start:prerender-dev start:worker-base start:base' \
+  'run-p start:pg start:prerender-dev start:prerender-manager-dev start:worker-base start:base' \
   'http-get://localhost:4201/base/_readiness-check?acceptHeader=application%2Fvnd.api%2Bjson' \
   'wait'

--- a/packages/realm-server/scripts/start-without-matrix.sh
+++ b/packages/realm-server/scripts/start-without-matrix.sh
@@ -16,7 +16,7 @@ SYNAPSE_URL="http://localhost:8008"
 SMTP_4_DEV_URL="http://localhost:5001"
 
 WAIT_ON_TIMEOUT=900000 NODE_NO_WARNINGS=1 start-server-and-test \
-  'run-p start:pg start:prerender-dev start:worker-development start:development' \
+  'run-p start:pg start:prerender-dev start:prerender-manager-dev start:worker-development start:development' \
   "$BASE_REALM_READY|$EXPERIMENTS_REALM_READY|$SYNAPSE_URL|$SMTP_4_DEV_URL" \
   'run-p start:worker-test start:test-realms' \
   "$NODE_TEST_REALM_READY" \

--- a/packages/realm-server/scripts/start-worker-base.sh
+++ b/packages/realm-server/scripts/start-worker-base.sh
@@ -4,7 +4,7 @@ SCRIPTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 . "$SCRIPTS_DIR/wait-for-prerender.sh"
 
 wait_for_postgres
-PRERENDER_URL="${PRERENDER_URL:-http://localhost:4221}"
+PRERENDER_URL="${PRERENDER_URL:-http://localhost:4222}"
 wait_for_prerender "$PRERENDER_URL"
 
 NODE_ENV=development \

--- a/packages/realm-server/scripts/start-worker-development.sh
+++ b/packages/realm-server/scripts/start-worker-development.sh
@@ -4,7 +4,7 @@ SCRIPTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 . "$SCRIPTS_DIR/wait-for-prerender.sh"
 
 wait_for_postgres
-PRERENDER_URL="${PRERENDER_URL:-http://localhost:4221}"
+PRERENDER_URL="${PRERENDER_URL:-http://localhost:4222}"
 wait_for_prerender "$PRERENDER_URL"
 
 DEFAULT_CATALOG_REALM_URL='http://localhost:4201/catalog/'

--- a/packages/realm-server/scripts/start-worker-test.sh
+++ b/packages/realm-server/scripts/start-worker-test.sh
@@ -4,7 +4,7 @@ SCRIPTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 . "$SCRIPTS_DIR/wait-for-prerender.sh"
 
 wait_for_postgres
-PRERENDER_URL="${PRERENDER_URL:-http://localhost:4221}"
+PRERENDER_URL="${PRERENDER_URL:-http://localhost:4222}"
 wait_for_prerender "$PRERENDER_URL"
 
 NODE_ENV=test \

--- a/packages/runtime-common/realm-index-updater.ts
+++ b/packages/runtime-common/realm-index-updater.ts
@@ -223,7 +223,8 @@ export function isIgnored(
     [
       `${realmURL.href}.realm.json`,
       `${realmURL.href}.template-lintrc.js`,
-    ].includes(url.href)
+    ].includes(url.href) ||
+    url.href.startsWith(`${realmURL.href}.git/`)
   ) {
     return true;
   }


### PR DESCRIPTION
Use the prerender manager server in dev so we can use it in our day-to-day. make sure to skip `.git` directory when indexing