### PR TITLE
Enable navigate to linked cards in code submode

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
+++ b/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
@@ -73,7 +73,11 @@ import type StoreService from '@cardstack/host/services/store';
 
 import { PlaygroundSelections } from '@cardstack/host/utils/local-storage-keys';
 
-import type { CardDef, Format } from 'https://cardstack.com/base/card-api';
+import type {
+  CardDef,
+  Format,
+  ViewCardFn,
+} from 'https://cardstack.com/base/card-api';
 import type { FileDef } from 'https://cardstack.com/base/file-api';
 import { Spec } from 'https://cardstack.com/base/spec';
 
@@ -167,6 +171,16 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
       DEFAULT_MODULE_INSPECTOR_VIEW
     );
   }
+
+  private viewCardInCodeSubmode: ViewCardFn = async (cardOrURL) => {
+    let cardId = cardOrURL instanceof URL ? cardOrURL.href : cardOrURL.id;
+    if (!cardId) {
+      return;
+    }
+
+    const fileUrl = cardId.endsWith('.json') ? cardId : `${cardId}.json`;
+    await this.operatorModeStateService.updateCodePath(new URL(fileUrl));
+  };
 
   @action private setActivePanel(item: ModuleInspectorView) {
     this.operatorModeStateService.updateModuleInspectorView(item);
@@ -443,6 +457,7 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
               @codeRef={{@selectedCodeRef}}
               @isUpdating={{@moduleAnalysis.isLoading}}
               @cardOrField={{@selectedCardOrField.cardOrField}}
+              @viewCard={{this.viewCardInCodeSubmode}}
             />
           {{else if (eq this.activePanel 'spec')}}
             <SpecPreview
@@ -483,6 +498,7 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
         @card={{@card}}
         @format={{@previewFormat}}
         @setFormat={{@setPreviewFormat}}
+        @viewCard={{this.viewCardInCodeSubmode}}
         data-test-card-resource-loaded
       />
     {{/if}}

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground.gts
@@ -5,7 +5,7 @@ import { not } from '@cardstack/boxel-ui/helpers';
 import { isFieldDef, isPrimitive } from '@cardstack/runtime-common';
 import type { ResolvedCodeRef } from '@cardstack/runtime-common';
 
-import type { BaseDef } from 'https://cardstack.com/base/card-api';
+import type { BaseDef, ViewCardFn } from 'https://cardstack.com/base/card-api';
 
 import PlaygroundPanel from './playground-panel';
 
@@ -64,6 +64,7 @@ interface Signature {
     codeRef?: ResolvedCodeRef;
     isUpdating?: boolean;
     cardOrField?: typeof BaseDef;
+    viewCard?: ViewCardFn;
   };
   Element: HTMLElement;
 }
@@ -86,6 +87,7 @@ export default class Playground extends Component<Signature> {
         @codeRef={{this.playgroundPanelArgs.codeRef}}
         @isFieldDef={{this.playgroundPanelArgs.isFieldDef}}
         @isUpdating={{this.playgroundPanelArgs.isUpdating}}
+        @viewCard={{@viewCard}}
       />
     {{else}}
       <UnsupportedMessage @cardOrField={{@cardOrField}} @codeRef={{@codeRef}} />

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -1448,9 +1448,9 @@ module('Acceptance | code submode tests', function (_hooks) {
     });
 
     test('clicking a linksTo field in card renderer panel opens the linked card JSON', async function (assert) {
-      let operatorModeStateService = getService<OperatorModeStateService>(
+      let operatorModeStateService = getService(
         'operator-mode-state-service',
-      );
+      ) as OperatorModeStateService;
 
       await visitOperatorMode({
         stacks: [
@@ -1498,9 +1498,9 @@ module('Acceptance | code submode tests', function (_hooks) {
     });
 
     test('clicking a linksToMany field in card renderer panel opens the linked card JSON', async function (assert) {
-      let operatorModeStateService = getService<OperatorModeStateService>(
+      let operatorModeStateService = getService(
         'operator-mode-state-service',
-      );
+      ) as OperatorModeStateService;
 
       await visitOperatorMode({
         stacks: [
@@ -1550,9 +1550,9 @@ module('Acceptance | code submode tests', function (_hooks) {
     });
 
     test('clicking a linksTo field in playground panel opens the linked card JSON', async function (assert) {
-      let operatorModeStateService = getService<OperatorModeStateService>(
+      let operatorModeStateService = getService(
         'operator-mode-state-service',
-      );
+      ) as OperatorModeStateService;
 
       await visitOperatorMode({
         stacks: [
@@ -1597,9 +1597,9 @@ module('Acceptance | code submode tests', function (_hooks) {
     });
 
     test('clicking a linksToMany field in playground panel opens the linked card JSON', async function (assert) {
-      let operatorModeStateService = getService<OperatorModeStateService>(
+      let operatorModeStateService = getService(
         'operator-mode-state-service',
-      );
+      ) as OperatorModeStateService;
 
       setPlaygroundSelections({
         [`${testRealmURL}person/Person`]: {

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -24,6 +24,7 @@ import {
 import type { Realm } from '@cardstack/runtime-common/realm';
 
 import type MonacoService from '@cardstack/host/services/monaco-service';
+import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 import {
   ModuleInspectorSelections,
@@ -48,6 +49,7 @@ import { setupMockMatrix } from '../helpers/mock-matrix';
 import {
   removePlaygroundSelections,
   removeSpecSelection,
+  setPlaygroundSelections,
 } from '../helpers/playground';
 import { setupApplicationTest } from '../helpers/setup';
 
@@ -349,16 +351,17 @@ const friendCardSource = `
     @field name = contains(StringField);
     @field friend = linksTo(() => Friend);
     @field title = contains(StringField, {
-      computeVia: function (this: Person) {
-        return name;
+      computeVia: function (this: Friend) {
+        return this.name;
       },
     });
     static isolated = class Isolated extends Component<typeof this> {
       <template>
-        <div data-test-person>
-          <p>First name: <@fields.firstName /></p>
-          <p>Last name: <@fields.lastName /></p>
-          <p>Title: <@fields.title /></p>
+        <div data-test-friend-card={{@model.name}}>
+          <p>Friend name: <@fields.name /></p>
+          <div data-test-friend-link>
+            <@fields.friend />
+          </div>
         </div>
         <style scoped>
           div {
@@ -728,6 +731,66 @@ module('Acceptance | code submode tests', function (_hooks) {
                 adoptsFrom: {
                   module: `${testRealmURL}pet`,
                   name: 'Pet',
+                },
+              },
+            },
+          },
+          'Friend/amy.json': {
+            data: {
+              attributes: {
+                name: 'Amy',
+              },
+              relationships: {
+                friend: {
+                  links: {
+                    self: `${testRealmURL}Friend/bob`,
+                  },
+                },
+              },
+              meta: {
+                adoptsFrom: {
+                  module: `${testRealmURL}friend`,
+                  name: 'Friend',
+                },
+              },
+            },
+          },
+          'Friend/bob.json': {
+            data: {
+              attributes: {
+                name: 'Bob',
+              },
+              relationships: {},
+              meta: {
+                adoptsFrom: {
+                  module: `${testRealmURL}friend`,
+                  name: 'Friend',
+                },
+              },
+            },
+          },
+          'Person/with-friends.json': {
+            data: {
+              attributes: {
+                firstName: 'With',
+                lastName: 'Friends',
+              },
+              relationships: {
+                'friends.0': {
+                  links: {
+                    self: `${testRealmURL}Friend/amy`,
+                  },
+                },
+                'friends.1': {
+                  links: {
+                    self: `${testRealmURL}Friend/bob`,
+                  },
+                },
+              },
+              meta: {
+                adoptsFrom: {
+                  module: `${testRealmURL}person`,
+                  name: 'Person',
                 },
               },
             },
@@ -1378,6 +1441,219 @@ module('Acceptance | code submode tests', function (_hooks) {
             adoptsFrom: {
               module: `${testRealmURL}pet`,
               name: 'Pet',
+            },
+          },
+        },
+      });
+    });
+
+    test('clicking a linksTo field in card renderer panel opens the linked card JSON', async function (assert) {
+      let operatorModeStateService = getService<OperatorModeStateService>(
+        'operator-mode-state-service',
+      );
+
+      await visitOperatorMode({
+        stacks: [
+          [
+            {
+              id: `${testRealmURL}Friend/amy`,
+              format: 'isolated',
+            },
+          ],
+        ],
+        submode: 'code',
+        codePath: `${testRealmURL}Friend/amy.json`,
+      });
+      await waitFor('[data-test-code-mode-card-renderer-body]');
+      assert.dom(`[data-test-card="${testRealmURL}Friend/amy"]`).exists();
+
+      // Click the rendered linked friend card (linksTo field)
+      await waitFor(`[data-test-card="${testRealmURL}Friend/bob"]`);
+      await click(`[data-test-card="${testRealmURL}Friend/bob"]`);
+
+      await waitUntil(() =>
+        operatorModeStateService.state?.codePath?.href?.endsWith(
+          'Friend/bob.json',
+        ),
+      );
+
+      assert.strictEqual(
+        operatorModeStateService.state?.codePath?.href,
+        `${testRealmURL}Friend/bob.json`,
+      );
+      assert.deepEqual(JSON.parse(getMonacoContent()), {
+        data: {
+          attributes: {
+            name: 'Bob',
+          },
+          meta: {
+            adoptsFrom: {
+              module: `${testRealmURL}friend`,
+              name: 'Friend',
+            },
+          },
+          relationships: {},
+        },
+      });
+    });
+
+    test('clicking a linksToMany field in card renderer panel opens the linked card JSON', async function (assert) {
+      let operatorModeStateService = getService<OperatorModeStateService>(
+        'operator-mode-state-service',
+      );
+
+      await visitOperatorMode({
+        stacks: [
+          [
+            {
+              id: `${testRealmURL}Person/with-friends`,
+              format: 'isolated',
+            },
+          ],
+        ],
+        submode: 'code',
+        codePath: `${testRealmURL}Person/with-friends.json`,
+      });
+      await waitFor('[data-test-code-mode-card-renderer-body]');
+      assert
+        .dom(`[data-test-card="${testRealmURL}Person/with-friends"]`)
+        .exists();
+
+      // Click one of the rendered linked friend cards (linksToMany field)
+      await waitFor(`[data-test-card="${testRealmURL}Friend/bob"]`);
+      await click(`[data-test-card="${testRealmURL}Friend/bob"]`);
+
+      await waitUntil(() =>
+        operatorModeStateService.state?.codePath?.href?.endsWith(
+          'Friend/bob.json',
+        ),
+      );
+
+      assert.strictEqual(
+        operatorModeStateService.state?.codePath?.href,
+        `${testRealmURL}Friend/bob.json`,
+      );
+      assert.deepEqual(JSON.parse(getMonacoContent()), {
+        data: {
+          attributes: {
+            name: 'Bob',
+          },
+          meta: {
+            adoptsFrom: {
+              module: `${testRealmURL}friend`,
+              name: 'Friend',
+            },
+          },
+          relationships: {},
+        },
+      });
+    });
+
+    test('clicking a linksTo field in playground panel opens the linked card JSON', async function (assert) {
+      let operatorModeStateService = getService<OperatorModeStateService>(
+        'operator-mode-state-service',
+      );
+
+      await visitOperatorMode({
+        stacks: [
+          [
+            {
+              id: `${testRealmURL}Friend/amy`,
+              format: 'isolated',
+            },
+          ],
+        ],
+        submode: 'code',
+        codePath: `${testRealmURL}friend.gts`,
+      });
+      await click('[data-test-module-inspector-view="preview"]');
+      assert.dom(`[data-test-card="${testRealmURL}Friend/amy"]`).exists();
+      await click(`[data-test-card="${testRealmURL}Friend/bob"]`);
+
+      await waitUntil(() =>
+        operatorModeStateService.state?.codePath?.href?.endsWith(
+          'Friend/bob.json',
+        ),
+      );
+
+      assert.strictEqual(
+        operatorModeStateService.state?.codePath?.href,
+        `${testRealmURL}Friend/bob.json`,
+      );
+      assert.deepEqual(JSON.parse(getMonacoContent()), {
+        data: {
+          attributes: {
+            name: 'Bob',
+          },
+          meta: {
+            adoptsFrom: {
+              module: `${testRealmURL}friend`,
+              name: 'Friend',
+            },
+          },
+          relationships: {},
+        },
+      });
+    });
+
+    test('clicking a linksToMany field in playground panel opens the linked card JSON', async function (assert) {
+      let operatorModeStateService = getService<OperatorModeStateService>(
+        'operator-mode-state-service',
+      );
+
+      setPlaygroundSelections({
+        [`${testRealmURL}person/Person`]: {
+          cardId: `${testRealmURL}Person/with-friends`,
+          format: 'isolated',
+        },
+      });
+      await visitOperatorMode({
+        stacks: [
+          [
+            {
+              id: `${testRealmURL}Person/with-friends`,
+              format: 'isolated',
+            },
+          ],
+        ],
+        submode: 'code',
+        codePath: `${testRealmURL}person.gts`,
+      });
+      await click('[data-test-module-inspector-view="preview"]');
+      assert
+        .dom(`[data-test-card="${testRealmURL}Person/with-friends"]`)
+        .exists();
+
+      // Click one of the rendered linked friend cards (linksToMany field)
+      await waitFor(`[data-test-card="${testRealmURL}Friend/amy"]`);
+      await click(`[data-test-card="${testRealmURL}Friend/amy"]`);
+
+      await waitUntil(() =>
+        operatorModeStateService.state?.codePath?.href?.endsWith(
+          'Friend/amy.json',
+        ),
+      );
+
+      assert.strictEqual(
+        operatorModeStateService.state?.codePath?.href,
+        `${testRealmURL}Friend/amy.json`,
+      );
+      assert.deepEqual(JSON.parse(getMonacoContent()), {
+        data: {
+          attributes: {
+            name: 'Amy',
+          },
+          meta: {
+            adoptsFrom: {
+              module: `${testRealmURL}friend`,
+              name: 'Friend',
+            },
+          },
+          relationships: {
+            friend: {
+              links: {
+                self: `${testRealmURL}Friend/bob`,
+              },
             },
           },
         },

--- a/packages/host/tests/acceptance/code-submode/editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/editor-test.ts
@@ -739,7 +739,7 @@ module('Acceptance | code submode | editor tests', function (hooks) {
   });
 
   test<TestContextWithSave>('can select and remove linked theme in default card-info editor', async function (assert) {
-    assert.expect(10);
+    assert.expect(9);
 
     const themeId = `${testRealmURL}theme-starry-night`;
     const onSave = (
@@ -780,10 +780,6 @@ module('Acceptance | code submode | editor tests', function (hooks) {
     await click(
       '[data-test-field="cardInfo-theme"] [data-test-boxel-field-label]',
     );
-    await click(`[data-test-card="${themeId}"]`);
-    assert
-      .dom(`[data-test-card="${themeId}"]`)
-      .exists({ count: 1 }, 'items are non-interactive');
 
     this.unregisterOnSave();
     this.onSave((url: URL, json: string | SingleCardDocument) =>


### PR DESCRIPTION
Previously, linked cards were only clickable in Interact submode, where clicking opened a new stack item for the linked card instance. This PR also makes linked cards clickable in the playground and card renderer panels in Code submode. In code submode, clicking updates the code path to open the linked card instance file instead of opening a new stack item.


https://github.com/user-attachments/assets/a3b87037-8b38-4506-b3b4-ebb076a32d09

