### PR TITLE
Fix host home URL in published realm

### DIFF
--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -33,7 +33,7 @@ import { passwordFromSeed } from '@cardstack/runtime-common/matrix-client';
 const log = logger('handle-publish');
 
 function rewriteHostHomeForPublishedRealm(
-  hostHome: string,
+  hostHome: string | undefined | null | unknown,
   sourceRealmURL: string,
   publishedRealmURL: string,
 ): string | undefined {

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -32,6 +32,19 @@ import { passwordFromSeed } from '@cardstack/runtime-common/matrix-client';
 
 const log = logger('handle-publish');
 
+function rewriteHostHomeForPublishedRealm(
+  hostHome: string,
+  sourceRealmURL: string,
+  publishedRealmURL: string,
+): string | undefined {
+  if (typeof hostHome !== 'string') {
+    return undefined;
+  }
+  return hostHome.startsWith(sourceRealmURL)
+    ? `${publishedRealmURL}${hostHome.slice(sourceRealmURL.length)}`
+    : undefined;
+}
+
 export default function handlePublishRealm({
   dbAdapter,
   matrixClient,
@@ -251,6 +264,14 @@ export default function handlePublishRealm({
         join(publishedRealmPath, '.realm.json'),
       );
       newlyPublishedRealmConfig.publishable = false;
+      let rewrittenHostHome = rewriteHostHomeForPublishedRealm(
+        newlyPublishedRealmConfig.hostHome,
+        sourceRealmURL,
+        publishedRealmURL,
+      );
+      if (rewrittenHostHome) {
+        newlyPublishedRealmConfig.hostHome = rewrittenHostHome;
+      }
       writeJsonSync(
         join(publishedRealmPath, '.realm.json'),
         newlyPublishedRealmConfig,


### PR DESCRIPTION
**Problem**

- In host mode, the alternate home page (site config card) is stored in .realm.json as hostHome, using the source realm URL because selection happens there.
- Publishing copies .realm.json verbatim, so the published realm keeps a hostHome that points back to the source realm and tries to fetch site config from the wrong host.

**Solution**

During publishing, detect when hostHome starts with the source realm URL and rewrite it to use the published realm URL before writing .realm.json for the published realm.