### PR TITLE
Fix back and forward navigation

### DIFF
--- a/packages/host/app/routes/index.gts
+++ b/packages/host/app/routes/index.gts
@@ -188,18 +188,12 @@ export default class Card extends Route {
             submode: Submodes.Interact,
             aiAssistantOpen: this.operatorModeStateService.aiAssistantOpen,
             workspaceChooserOpened: stacks.length === 0,
-            version: this.operatorModeStateService.version,
           } as OperatorModeSerializedState),
         },
       });
       return;
     } else {
-      let incomingVersion = operatorModeStateObject?.version ?? 0;
-      let currentVersion = this.operatorModeStateService.version ?? 0;
-      if (
-        this.operatorModeStateService.serialize() === operatorModeState ||
-        incomingVersion < currentVersion
-      ) {
+      if (this.operatorModeStateService.serialize() === operatorModeState) {
         // If the operator mode state in the query param is the same as the one we have in memory,
         // we don't want to restore it again, because it will lead to rerendering of the stack items, which can
         // bring various annoyances, e.g reloading of the items in the index card.

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -73,7 +73,6 @@ import type IndexController from '../controllers';
 // This is because we don't have a way to serialize a stack configuration of linked cards that have not been saved yet.
 
 export interface OperatorModeState {
-  version: number;
   stacks: Stack[];
   submode: Submode;
   codePath: URL | null;
@@ -101,7 +100,6 @@ type SerializedItem = CardItem;
 type SerializedStack = SerializedItem[];
 
 export type SerializedState = {
-  version?: number;
   stacks: SerializedStack[];
   submode?: Submode;
   codePath?: string;
@@ -125,7 +123,6 @@ export const DEFAULT_MODULE_INSPECTOR_VIEW: ModuleInspectorView = 'schema';
 
 export default class OperatorModeStateService extends Service {
   @tracked private _state: OperatorModeState = new TrackedObject({
-    version: 0,
     stacks: new TrackedArray<Stack>([]),
     submode: Submodes.Interact,
     codePath: null,
@@ -181,7 +178,6 @@ export default class OperatorModeStateService extends Service {
 
   get state() {
     return {
-      version: this._state.version,
       stacks: this._state.stacks,
       submode: this._state.submode,
       codePath: this._state.codePath,
@@ -224,7 +220,6 @@ export default class OperatorModeStateService extends Service {
 
   resetState() {
     this._state = new TrackedObject({
-      version: 0,
       stacks: new TrackedArray([]),
       submode: Submodes.Interact,
       codePath: null,
@@ -484,16 +479,6 @@ export default class OperatorModeStateService extends Service {
 
   get hostModePrimaryCard(): string | null {
     return this._state.hostModePrimaryCard ?? null;
-  }
-
-  get version(): number {
-    return this._state.version ?? 0;
-  }
-
-  // Only used in host tests to avoid version conflict issues
-  // since in host tests the `visit` is not fully refreshing the page
-  resetVersion() {
-    this._state.version = 0;
   }
 
   private getRealmURLFromItemId(itemId: string): string {
@@ -838,7 +823,6 @@ export default class OperatorModeStateService extends Service {
     // we get into a async race condition where the change to cardController.operatorModeState will reload the route and
     // restore the state from the query param in a way that is out of sync with the state in the service. To avoid this,
     // we do the change to the query param only after all modifications to the state have been rendered.
-    this._state.version = (this._state.version ?? 0) + 1;
     scheduleOnce('afterRender', this, this.persist);
   }
 
@@ -863,7 +847,6 @@ export default class OperatorModeStateService extends Service {
       ...this._state.hostModeStack.map((item) => item),
     ].filter(Boolean) as string[];
     let state: SerializedState = {
-      version: this._state.version,
       stacks: [],
       submode: this._state.submode,
       codePath: this._state.codePath?.toString(),
@@ -938,7 +921,6 @@ export default class OperatorModeStateService extends Service {
     );
 
     let newState: OperatorModeState = new TrackedObject({
-      version: rawState.version ?? 0,
       stacks: new TrackedArray([]),
       submode: rawState.submode ?? Submodes.Interact,
       codePath: rawState.codePath ? new URL(rawState.codePath) : null,

--- a/packages/host/tests/helpers/visit-operator-mode.ts
+++ b/packages/host/tests/helpers/visit-operator-mode.ts
@@ -1,6 +1,5 @@
 import { visit } from '@ember/test-helpers';
 
-import { getService } from '@universal-ember/test-support';
 import stringify from 'safe-stable-stringify';
 
 import type { SerializedState } from '@cardstack/host/services/operator-mode-state-service';
@@ -16,11 +15,6 @@ export default async function visitOperatorMode({
   workspaceChooserOpened,
   trail,
 }: Partial<SerializedState> & { selectAllCardsFilter?: boolean }) {
-  // In the host test, we can treat the visit operator mode as a full page refresh.
-  // So we reset the version to avoid conflicts.
-  let operatorModeStateService = getService('operator-mode-state-service');
-  operatorModeStateService.resetVersion();
-
   let operatorModeState = {
     stacks: stacks || [],
     submode: submode || 'interact',


### PR DESCRIPTION
I’ll merge this PR directly since it only reverts the changes I made to avoid a race condition by introducing versioning in the operator-mode state. However, after we moved site.json to hostHome in realm.json, the race condition no longer exists.