### PR TITLE
Fix: Buy credits top button hover state changes inappropriately

### DIFF
--- a/packages/host/app/components/operator-mode/profile/profile-subscription.gts
+++ b/packages/host/app/components/operator-mode/profile/profile-subscription.gts
@@ -32,11 +32,7 @@ export default class ProfileSubscription extends Component<Signature> {
 
   <template>
     <WithSubscriptionData as |subscriptionData|>
-      <FieldContainer
-        @label='Membership Tier'
-        @tag='label'
-        class='profile-field'
-      >
+      <FieldContainer @label='Membership Tier' class='profile-field'>
         <div class='profile-subscription'>
           <div class='monthly-credit'>
             <div class='plan-name'>{{subscriptionData.plan}}</div>
@@ -61,11 +57,7 @@ export default class ProfileSubscription extends Component<Signature> {
           {{/if}}
         </div>
       </FieldContainer>
-      <FieldContainer
-        @label='Additional Credit'
-        @tag='label'
-        class='profile-field'
-      >
+      <FieldContainer @label='Additional Credit' class='profile-field'>
         <div class='additional-credit'>
           <div class='profile-subscription'>
             <div class='credit-info'>


### PR DESCRIPTION
**Problem**

In the profile subscription panel, FieldContainer rendered as `<label>` tags caused implicit label targeting of the first “Buy” button, making it appear hovered/clicked even when interacting elsewhere.

**Fix**

Removed `@tag='label'` on both FieldContainer instances in `profile-subscription`, letting them render as divs to eliminate unintended label association.

**Before**

![screencast 2025-11-24 08-26-00](https://github.com/user-attachments/assets/af3bc181-a659-4472-99cf-7d97af3497d2)

**After**


https://github.com/user-attachments/assets/ffddfbda-1f63-40b8-aa78-17053c1119e6


