### PR TITLE
Fix download links for matrix event debug files

### DIFF
--- a/packages/runtime-common/ai/matrix-utils.ts
+++ b/packages/runtime-common/ai/matrix-utils.ts
@@ -130,7 +130,15 @@ export async function sendEventListAsDebugMessage(
       attachedFiles: [
         {
           sourceUrl: '',
-          url: client.mxcUrlToHttp(sharedFile.content_uri),
+          url: client.mxcUrlToHttp(
+            sharedFile.content_uri,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            true,
+          ),
           name: 'debug-event.json',
           contentType: 'text/plain',
         },
@@ -157,7 +165,15 @@ export async function sendPromptAsDebugMessage(
       attachedFiles: [
         {
           sourceUrl: '',
-          url: client.mxcUrlToHttp(sharedFile.content_uri),
+          url: client.mxcUrlToHttp(
+            sharedFile.content_uri,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            true,
+          ),
           name: 'debug-event.json',
           contentType: 'text/plain',
         },


### PR DESCRIPTION
Before this fix, clicking on the the debug file download button failed with a 404. This PR fixes the link so that the file can be downloaded. 

<img width="299" height="119" alt="image" src="https://github.com/user-attachments/assets/8ee59d0d-8d5d-43e4-a37b-ab1c6bba70f9" />
