### PR TITLE
BUG: Ensure cardInfo.theme nested is supported when linking to parent

### DIFF
--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -301,39 +301,73 @@ export function getBoxComponent(
                   (if (eq @displayContainer false) false true)
                   as |c displayContainer|
                 }}
-                  {{#if (isCard model.value)}}
-                    {{#let model.value as |card|}}
+                  {{#let (if @fieldName (concat @fieldName "." model.name) model.name) as |fieldNameWithPath|}}
+                    {{#if (isCard model.value)}}
+                      {{#let model.value as |card|}}
+                        <DefaultFormatsProvider
+                          @value={{defaultFieldFormats effectiveFormats.cardDef}}
+                        >
+                          <CardContainer
+                            @displayBoundaries={{displayContainer}}
+                            @isThemed={{hasTheme card}}
+                            @cssImports={{getCssImports card}}
+                            class={{cn
+                              'field-component-card'
+                              (concat effectiveFormats.cardDef '-format')
+                              (concat 'display-container-' displayContainer)
+                            }}
+                            {{context.cardComponentModifier
+                              card=card
+                              format=effectiveFormats.cardDef
+                              fieldType=field.fieldType
+                              fieldName=fieldNameWithPath
+                            }}
+                            style={{getThemeStyles card}}
+                            data-test-card={{card.id}}
+                            data-test-card-format={{effectiveFormats.cardDef}}
+                            data-test-field-component-card
+                            ...attributes
+                          >
+                            <c.CardOrFieldFormatComponent
+                              @cardOrField={{cardOrField}}
+                              @model={{card}}
+                              @fields={{c.fields}}
+                              @format={{effectiveFormats.cardDef}}
+                              @set={{model.set}}
+                              @fieldName={{fieldNameWithPath}}
+                              @context={{context}}
+                              @configuration={{this.resolvedConfiguration}}
+                              @createCard={{cardCrudFunctions.createCard}}
+                              @viewCard={{cardCrudFunctions.viewCard}}
+                              @saveCard={{cardCrudFunctions.saveCard}}
+                              @editCard={{cardCrudFunctions.editCard}}
+                              @canEdit={{and
+                                (not field.computeVia)
+                                permissions.canWrite
+                              }}
+                              @typeConstraint={{@typeConstraint}}
+                            />
+                          </CardContainer>
+                        </DefaultFormatsProvider>
+                      {{/let}}
+                    {{else if (isCompoundField model.value)}}
                       <DefaultFormatsProvider
-                        @value={{defaultFieldFormats effectiveFormats.cardDef}}
+                        @value={{defaultFieldFormats effectiveFormats.fieldDef}}
                       >
-                        <CardContainer
-                          @displayBoundaries={{displayContainer}}
-                          @isThemed={{hasTheme card}}
-                          @cssImports={{getCssImports card}}
-                          class={{cn
-                            'field-component-card'
-                            (concat effectiveFormats.cardDef '-format')
-                            (concat 'display-container-' displayContainer)
-                          }}
-                          {{context.cardComponentModifier
-                            card=card
-                            format=effectiveFormats.cardDef
-                            fieldType=field.fieldType
-                            fieldName=field.name
-                          }}
-                          style={{getThemeStyles card}}
-                          data-test-card={{card.id}}
-                          data-test-card-format={{effectiveFormats.cardDef}}
-                          data-test-field-component-card
+                        <div
+                          class='compound-field
+                            {{effectiveFormats.fieldDef}}-format'
+                          data-test-compound-field-format={{effectiveFormats.fieldDef}}
+                          data-test-compound-field-component
                           ...attributes
                         >
                           <c.CardOrFieldFormatComponent
                             @cardOrField={{cardOrField}}
-                            @model={{card}}
+                            @model={{model.value}}
                             @fields={{c.fields}}
-                            @format={{effectiveFormats.cardDef}}
+                            @format={{effectiveFormats.fieldDef}}
                             @set={{model.set}}
-                            @fieldName={{model.name}}
+                            @fieldName={{fieldNameWithPath}}
                             @context={{context}}
                             @configuration={{this.resolvedConfiguration}}
                             @createCard={{cardCrudFunctions.createCard}}
@@ -346,19 +380,11 @@ export function getBoxComponent(
                             }}
                             @typeConstraint={{@typeConstraint}}
                           />
-                        </CardContainer>
+                        </div>
                       </DefaultFormatsProvider>
-                    {{/let}}
-                  {{else if (isCompoundField model.value)}}
-                    <DefaultFormatsProvider
-                      @value={{defaultFieldFormats effectiveFormats.fieldDef}}
-                    >
-                      <div
-                        class='compound-field
-                          {{effectiveFormats.fieldDef}}-format'
-                        data-test-compound-field-format={{effectiveFormats.fieldDef}}
-                        data-test-compound-field-component
-                        ...attributes
+                    {{else}}
+                      <DefaultFormatsProvider
+                        @value={{defaultFieldFormats effectiveFormats.fieldDef}}
                       >
                         <c.CardOrFieldFormatComponent
                           @cardOrField={{cardOrField}}
@@ -366,7 +392,7 @@ export function getBoxComponent(
                           @fields={{c.fields}}
                           @format={{effectiveFormats.fieldDef}}
                           @set={{model.set}}
-                          @fieldName={{model.name}}
+                          @fieldName={{fieldNameWithPath}}
                           @context={{context}}
                           @configuration={{this.resolvedConfiguration}}
                           @createCard={{cardCrudFunctions.createCard}}
@@ -378,35 +404,11 @@ export function getBoxComponent(
                             permissions.canWrite
                           }}
                           @typeConstraint={{@typeConstraint}}
+                          ...attributes
                         />
-                      </div>
-                    </DefaultFormatsProvider>
-                  {{else}}
-                    <DefaultFormatsProvider
-                      @value={{defaultFieldFormats effectiveFormats.fieldDef}}
-                    >
-                      <c.CardOrFieldFormatComponent
-                        @cardOrField={{cardOrField}}
-                        @model={{model.value}}
-                        @fields={{c.fields}}
-                        @format={{effectiveFormats.fieldDef}}
-                        @set={{model.set}}
-                        @fieldName={{model.name}}
-                        @context={{context}}
-                        @configuration={{this.resolvedConfiguration}}
-                        @createCard={{cardCrudFunctions.createCard}}
-                        @viewCard={{cardCrudFunctions.viewCard}}
-                        @saveCard={{cardCrudFunctions.saveCard}}
-                        @editCard={{cardCrudFunctions.editCard}}
-                        @canEdit={{and
-                          (not field.computeVia)
-                          permissions.canWrite
-                        }}
-                        @typeConstraint={{@typeConstraint}}
-                        ...attributes
-                      />
-                    </DefaultFormatsProvider>
-                  {{/if}}
+                      </DefaultFormatsProvider>
+                    {{/if}}
+                  {{/let}}
                 {{/let}}
               {{/let}}
             </DefaultFormatsConsumer>

--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -301,73 +301,39 @@ export function getBoxComponent(
                   (if (eq @displayContainer false) false true)
                   as |c displayContainer|
                 }}
-                  {{#let (if @fieldName (concat @fieldName "." model.name) model.name) as |fieldNameWithPath|}}
-                    {{#if (isCard model.value)}}
-                      {{#let model.value as |card|}}
-                        <DefaultFormatsProvider
-                          @value={{defaultFieldFormats effectiveFormats.cardDef}}
-                        >
-                          <CardContainer
-                            @displayBoundaries={{displayContainer}}
-                            @isThemed={{hasTheme card}}
-                            @cssImports={{getCssImports card}}
-                            class={{cn
-                              'field-component-card'
-                              (concat effectiveFormats.cardDef '-format')
-                              (concat 'display-container-' displayContainer)
-                            }}
-                            {{context.cardComponentModifier
-                              card=card
-                              format=effectiveFormats.cardDef
-                              fieldType=field.fieldType
-                              fieldName=fieldNameWithPath
-                            }}
-                            style={{getThemeStyles card}}
-                            data-test-card={{card.id}}
-                            data-test-card-format={{effectiveFormats.cardDef}}
-                            data-test-field-component-card
-                            ...attributes
-                          >
-                            <c.CardOrFieldFormatComponent
-                              @cardOrField={{cardOrField}}
-                              @model={{card}}
-                              @fields={{c.fields}}
-                              @format={{effectiveFormats.cardDef}}
-                              @set={{model.set}}
-                              @fieldName={{fieldNameWithPath}}
-                              @context={{context}}
-                              @configuration={{this.resolvedConfiguration}}
-                              @createCard={{cardCrudFunctions.createCard}}
-                              @viewCard={{cardCrudFunctions.viewCard}}
-                              @saveCard={{cardCrudFunctions.saveCard}}
-                              @editCard={{cardCrudFunctions.editCard}}
-                              @canEdit={{and
-                                (not field.computeVia)
-                                permissions.canWrite
-                              }}
-                              @typeConstraint={{@typeConstraint}}
-                            />
-                          </CardContainer>
-                        </DefaultFormatsProvider>
-                      {{/let}}
-                    {{else if (isCompoundField model.value)}}
+                  {{#if (isCard model.value)}}
+                    {{#let model.value as |card|}}
                       <DefaultFormatsProvider
-                        @value={{defaultFieldFormats effectiveFormats.fieldDef}}
+                        @value={{defaultFieldFormats effectiveFormats.cardDef}}
                       >
-                        <div
-                          class='compound-field
-                            {{effectiveFormats.fieldDef}}-format'
-                          data-test-compound-field-format={{effectiveFormats.fieldDef}}
-                          data-test-compound-field-component
+                        <CardContainer
+                          @displayBoundaries={{displayContainer}}
+                          @isThemed={{hasTheme card}}
+                          @cssImports={{getCssImports card}}
+                          class={{cn
+                            'field-component-card'
+                            (concat effectiveFormats.cardDef '-format')
+                            (concat 'display-container-' displayContainer)
+                          }}
+                          {{context.cardComponentModifier
+                            card=card
+                            format=effectiveFormats.cardDef
+                            fieldType=field.fieldType
+                            fieldName=field.name
+                          }}
+                          style={{getThemeStyles card}}
+                          data-test-card={{card.id}}
+                          data-test-card-format={{effectiveFormats.cardDef}}
+                          data-test-field-component-card
                           ...attributes
                         >
                           <c.CardOrFieldFormatComponent
                             @cardOrField={{cardOrField}}
-                            @model={{model.value}}
+                            @model={{card}}
                             @fields={{c.fields}}
-                            @format={{effectiveFormats.fieldDef}}
+                            @format={{effectiveFormats.cardDef}}
                             @set={{model.set}}
-                            @fieldName={{fieldNameWithPath}}
+                            @fieldName={{model.name}}
                             @context={{context}}
                             @configuration={{this.resolvedConfiguration}}
                             @createCard={{cardCrudFunctions.createCard}}
@@ -380,11 +346,19 @@ export function getBoxComponent(
                             }}
                             @typeConstraint={{@typeConstraint}}
                           />
-                        </div>
+                        </CardContainer>
                       </DefaultFormatsProvider>
-                    {{else}}
-                      <DefaultFormatsProvider
-                        @value={{defaultFieldFormats effectiveFormats.fieldDef}}
+                    {{/let}}
+                  {{else if (isCompoundField model.value)}}
+                    <DefaultFormatsProvider
+                      @value={{defaultFieldFormats effectiveFormats.fieldDef}}
+                    >
+                      <div
+                        class='compound-field
+                          {{effectiveFormats.fieldDef}}-format'
+                        data-test-compound-field-format={{effectiveFormats.fieldDef}}
+                        data-test-compound-field-component
+                        ...attributes
                       >
                         <c.CardOrFieldFormatComponent
                           @cardOrField={{cardOrField}}
@@ -392,7 +366,7 @@ export function getBoxComponent(
                           @fields={{c.fields}}
                           @format={{effectiveFormats.fieldDef}}
                           @set={{model.set}}
-                          @fieldName={{fieldNameWithPath}}
+                          @fieldName={{model.name}}
                           @context={{context}}
                           @configuration={{this.resolvedConfiguration}}
                           @createCard={{cardCrudFunctions.createCard}}
@@ -404,11 +378,35 @@ export function getBoxComponent(
                             permissions.canWrite
                           }}
                           @typeConstraint={{@typeConstraint}}
-                          ...attributes
                         />
-                      </DefaultFormatsProvider>
-                    {{/if}}
-                  {{/let}}
+                      </div>
+                    </DefaultFormatsProvider>
+                  {{else}}
+                    <DefaultFormatsProvider
+                      @value={{defaultFieldFormats effectiveFormats.fieldDef}}
+                    >
+                      <c.CardOrFieldFormatComponent
+                        @cardOrField={{cardOrField}}
+                        @model={{model.value}}
+                        @fields={{c.fields}}
+                        @format={{effectiveFormats.fieldDef}}
+                        @set={{model.set}}
+                        @fieldName={{model.name}}
+                        @context={{context}}
+                        @configuration={{this.resolvedConfiguration}}
+                        @createCard={{cardCrudFunctions.createCard}}
+                        @viewCard={{cardCrudFunctions.viewCard}}
+                        @saveCard={{cardCrudFunctions.saveCard}}
+                        @editCard={{cardCrudFunctions.editCard}}
+                        @canEdit={{and
+                          (not field.computeVia)
+                          permissions.canWrite
+                        }}
+                        @typeConstraint={{@typeConstraint}}
+                        ...attributes
+                      />
+                    </DefaultFormatsProvider>
+                  {{/if}}
                 {{/let}}
               {{/let}}
             </DefaultFormatsConsumer>

--- a/packages/host/tests/integration/commands/copy-and-edit-test.gts
+++ b/packages/host/tests/integration/commands/copy-and-edit-test.gts
@@ -108,7 +108,7 @@ module('Integration | commands | copy-and-edit', function (hooks) {
             },
             meta: {
               adoptsFrom: {
-                module: 'https://cardstack.com/base/card-api',
+                module: './simple-card',
                 name: 'Theme',
               },
             },

--- a/packages/host/tests/integration/commands/copy-and-edit-test.gts
+++ b/packages/host/tests/integration/commands/copy-and-edit-test.gts
@@ -108,8 +108,8 @@ module('Integration | commands | copy-and-edit', function (hooks) {
             },
             meta: {
               adoptsFrom: {
-                module: './simple-card',
-                name: 'Theme',
+                module: 'https://cardstack.com/base/theme',
+                name: 'default',
               },
             },
           },


### PR DESCRIPTION
packages/host/app/commands/copy-and-edit.ts: Copy-and-edit now resolves nested relationship paths (e.g., cardInfo.theme) by deriving the dotted path, locating the correct container, and re-linking there. Added helpers to find relationship paths from serialized cards, navigate nested wrappers, and centralized assignment/save logic.

Previously, the copy wll be on the stack BUT it will not link to the original card bcos of the cardInfo.theme nested relationship