### PR TITLE
Improve AI Bot error message

### DIFF
--- a/packages/ai-bot/tests/matrix-util-test.ts
+++ b/packages/ai-bot/tests/matrix-util-test.ts
@@ -6,7 +6,8 @@ import type {
   MatrixEvent as DiscreteMatrixEvent,
 } from 'https://cardstack.com/base/matrix-event';
 import { APP_BOXEL_MESSAGE_MSGTYPE } from '@cardstack/runtime-common';
-import { getRoomEvents } from '@cardstack/runtime-common/ai';
+import { getRoomEvents, sendErrorEvent } from '@cardstack/runtime-common/ai';
+import { OpenAIError } from 'openai/error';
 
 /**
  * Creates a mock Matrix event with all required properties
@@ -54,6 +55,12 @@ function createMockedClient(mockEvents: DiscreteMatrixEvent[] = []) {
     },
   } as any;
   return client;
+}
+
+async function getErrorMessageFromSend(error: any) {
+  const client = new FakeMatrixClient();
+  await sendErrorEvent(client, 'room123', error, undefined);
+  return client.getSentEvents()[0].content.errorMessage;
 }
 
 test('getRoomEvents - returns all events when no lastEventId provided', async function (assert) {
@@ -130,4 +137,73 @@ test('getRoomEvents - handles empty response', async function (assert) {
   const result = await getRoomEvents('room123', client);
 
   assert.deepEqual(result, [], 'Returns empty array when no events are found');
+});
+
+test('sendErrorEvent - uses provider metadata when available', async function (assert) {
+  const error = {
+    error: {
+      metadata: {
+        provider_name: 'anthropic',
+        raw: JSON.stringify({ error: { message: 'Provider level failure' } }),
+      },
+    },
+  };
+
+  const errorMessage = await getErrorMessageFromSend(error);
+
+  assert.strictEqual(
+    errorMessage,
+    'anthropic error: Provider level failure',
+    'Provider error message is preferred',
+  );
+});
+
+test('sendErrorEvent - formats OpenRouter errors coming from OpenAI SDK', async function (assert) {
+  const error = new OpenAIError('OpenRouter exploded') as any;
+  error.error = {
+    metadata: {
+      provider_name: 'OpenRouter',
+      raw: JSON.stringify({ error: { message: 'OpenRouter exploded' } }),
+    },
+  };
+
+  const errorMessage = await getErrorMessageFromSend(error);
+
+  assert.strictEqual(
+    errorMessage,
+    'OpenRouter error: OpenRouter exploded',
+    'OpenAI SDK errors are treated as provider errors when metadata is present',
+  );
+});
+
+test('sendErrorEvent - passes through string errors', async function (assert) {
+  const errorMessage = await getErrorMessageFromSend('plain string error');
+
+  assert.strictEqual(
+    errorMessage,
+    'plain string error',
+    'String errors are forwarded directly',
+  );
+});
+
+test('sendErrorEvent - falls back to error.message', async function (assert) {
+  const errorMessage = await getErrorMessageFromSend(
+    new Error('generic failure'),
+  );
+
+  assert.strictEqual(
+    errorMessage,
+    'generic failure',
+    'Uses message property when no special handling applies',
+  );
+});
+
+test('sendErrorEvent - returns unknown error when no details provided', async function (assert) {
+  const errorMessage = await getErrorMessageFromSend({});
+
+  assert.strictEqual(
+    errorMessage,
+    'Unknown error',
+    'Falls back to generic message when no details exist',
+  );
 });

--- a/packages/ai-bot/tests/responding-test.ts
+++ b/packages/ai-bot/tests/responding-test.ts
@@ -1175,7 +1175,7 @@ module('Responding', (hooks) => {
     });
     assert.strictEqual(
       sentEvents[3].content.errorMessage,
-      'OpenAI error: Error - All your base are belong to us',
+      'Error - All your base are belong to us',
       'Error message should be sent, replacing the original message',
     );
   });


### PR DESCRIPTION
I investigated the 400 errors that occur when using GPT-5.1 with `reasoning_effort=minimal`. In the AI bot logs, the provider error includes details about which reasoning effort values are supported, but we weren’t extracting that message and returning it to the user.

In this PR, I improved the `getErrorMessage` function to first try extracting the provider error message and surface it to the user. I also removed the “OpenAI Error” label, since we use OpenRouter as the backend for the OpenAI SDK, so the error isn’t necessarily an OpenAI error.

<img width="371" height="158" alt="Screenshot 2025-12-08 at 18 56 45" src="https://github.com/user-attachments/assets/d73f9f98-c588-42f9-aa18-d3e9fd6050b4" />
