### PR TITLE
Update card header naming for untitled cards

### DIFF
--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -428,7 +428,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
     return this.url;
   }
 
-  private get headerCardType() {
+  private get headerType() {
     if (this.isIndexCard) {
       return 'Workspace';
     } else if (this.card) {
@@ -437,7 +437,7 @@ export default class OperatorModeStackItem extends Component<Signature> {
     return undefined;
   }
 
-  private get headerCardTitle() {
+  private get headerTitle() {
     let cardTitle = this.card?.title;
     if (this.card && cardTitle?.startsWith('Untitled ')) {
       let strippedTitle = cardTitle.slice('Untitled '.length);
@@ -778,9 +778,9 @@ export default class OperatorModeStackItem extends Component<Signature> {
           {{this.setWindowTitle}}
           {{#let (this.realm.info this.urlForRealmLookup) as |realmInfo|}}
             <CardHeader
-              @cardTypeDisplayName={{this.headerCardType}}
+              @cardTypeDisplayName={{this.headerType}}
               @cardTypeIcon={{cardTypeIcon this.card}}
-              @cardTitle={{this.headerCardTitle}}
+              @cardTitle={{this.headerTitle}}
               @isSaving={{this.cardResource.autoSaveState.isSaving}}
               @isTopCard={{this.isTopCard}}
               @lastSavedMessage={{this.cardResource.autoSaveState.lastSavedErrorMsg}}

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -428,13 +428,25 @@ export default class OperatorModeStackItem extends Component<Signature> {
     return this.url;
   }
 
-  private get headerTitle() {
+  private get headerCardType() {
     if (this.isIndexCard) {
       return 'Workspace';
     } else if (this.card) {
       return cardTypeDisplayName(this.card);
     }
     return undefined;
+  }
+
+  private get headerCardTitle() {
+    let cardTitle = this.card?.title;
+    if (this.card && cardTitle?.startsWith('Untitled ')) {
+      let strippedTitle = cardTitle.slice('Untitled '.length);
+      if (strippedTitle === cardTypeDisplayName(this.card)) {
+        return 'Untitled';
+      }
+    }
+
+    return cardTitle;
   }
 
   private get cardTitle() {
@@ -766,9 +778,9 @@ export default class OperatorModeStackItem extends Component<Signature> {
           {{this.setWindowTitle}}
           {{#let (this.realm.info this.urlForRealmLookup) as |realmInfo|}}
             <CardHeader
-              @cardTypeDisplayName={{this.headerTitle}}
+              @cardTypeDisplayName={{this.headerCardType}}
               @cardTypeIcon={{cardTypeIcon this.card}}
-              @cardTitle={{this.card.title}}
+              @cardTitle={{this.headerCardTitle}}
               @isSaving={{this.cardResource.autoSaveState.isSaving}}
               @isTopCard={{this.isTopCard}}
               @lastSavedMessage={{this.cardResource.autoSaveState.lastSavedErrorMsg}}

--- a/packages/host/tests/integration/components/card-catalog-test.gts
+++ b/packages/host/tests/integration/components/card-catalog-test.gts
@@ -317,7 +317,7 @@ module('Integration | card-catalog', function (hooks) {
         .dom(
           `[data-test-stack-card-index="1"] [data-test-boxel-card-header-title]`,
         )
-        .hasText('Publishing Packet - Untitled Publishing Packet');
+        .hasText('Publishing Packet - Untitled');
     });
 
     test(`can select card using mouse click and then submit selection using enter key`, async function (assert) {
@@ -380,7 +380,7 @@ module('Integration | card-catalog', function (hooks) {
         .dom(
           `[data-test-stack-card-index="1"] [data-test-boxel-card-header-title]`,
         )
-        .hasText('Author - Untitled Author');
+        .hasText('Author - Untitled');
     });
 
     test(`double-clicking on a card selects the card and submits the selection`, async function (assert) {

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -1986,7 +1986,7 @@ module('Integration | operator-mode', function (hooks) {
       .dom(
         '[data-test-stack-card-index="1"] [data-test-boxel-card-header-title]',
       )
-      .hasText('Publishing Packet - Untitled Publishing Packet');
+      .hasText('Publishing Packet - Untitled');
   });
 
   test(`can search by card title when opening card chooser from a field editor`, async function (assert) {


### PR DESCRIPTION
This PR prevents the card type from appearing twice in the header on untitled cards. Operator mode header now detects Untitled {CardType} titles and strips the trailing card type, showing just “Untitled”.

Before:

<img width="817" height="59" alt="Screenshot 2025-12-08 at 21 00 49" src="https://github.com/user-attachments/assets/c5b26207-749a-449d-ba9a-ef592aea34b9" />

After:

<img width="818" height="80" alt="Screenshot 2025-12-08 at 21 00 16" src="https://github.com/user-attachments/assets/33b22022-6b0c-49db-92a9-aa75e3e44dcb" />
