### PR TITLE
fix cropped remix button

### DIFF
--- a/packages/catalog-realm/catalog-app/components/grid.gts
+++ b/packages/catalog-realm/catalog-app/components/grid.gts
@@ -73,7 +73,7 @@ export class CardsGrid extends GlimmerComponent<CardsGridSignature> {
       .cards {
         --default-grid-view-min-width: 224px;
         --default-grid-view-max-width: 1fr;
-        --default-grid-view-height: 360px;
+        --default-grid-view-height: 380px;
         --default-strip-view-min-width: 49%;
         --default-strip-view-max-width: 1fr;
         --default-strip-view-height: 180px;

--- a/packages/catalog-realm/catalog-app/components/listing-fitted.gts
+++ b/packages/catalog-realm/catalog-app/components/listing-fitted.gts
@@ -129,9 +129,9 @@ export class ListingFittedTemplate extends Component<typeof Listing> {
             <h3 class='card-title' data-test-card-title={{@model.name}}>
               {{@model.name}}
             </h3>
-            <h4 class='card-display-name' data-test-card-display-name>
+            <p class='card-display-name' data-test-card-display-name>
               {{this.publisherInfo}}
-            </h4>
+            </p>
           </div>
           <div class='card-tags-action'>
             {{#if this.hasTags}}
@@ -247,6 +247,7 @@ export class ListingFittedTemplate extends Component<typeof Listing> {
           text-overflow: ellipsis;
           white-space: nowrap;
           overflow: hidden;
+          min-height: 15px;
         }
         .card-tags {
           color: var(--boxel-400);


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/ECO-445/fix-remix-button-being-cropped-in-catalog-grid-card



Before:
<img width="970" height="720" alt="image" src="https://github.com/user-attachments/assets/4d92a58e-6a02-4c6b-a48a-f848ae9bad21" />

After:
<img width="968" height="730" alt="image" src="https://github.com/user-attachments/assets/40e162f4-aa50-4960-844e-ec0daa517b4c" />
