### PR TITLE
[DRAFT] Improve the host test performance

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -31,8 +31,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
-        shardTotal: [16]
+        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8]
+        shardTotal: [8]
     concurrency:
       group: boxel-host-test${{ github.head_ref || github.run_id }}-shard${{ matrix.shardIndex }}
       cancel-in-progress: true

--- a/packages/host/app/lib/browser-queue.ts
+++ b/packages/host/app/lib/browser-queue.ts
@@ -77,9 +77,13 @@ export class BrowserQueue implements QueuePublisher, QueueRunner {
     return job;
   }
 
-  private debouncedDrainJobs = debounce(() => {
-    this.drainJobs();
-  }, 250);
+  private debouncedDrainJobs = debounce(
+    () => {
+      this.drainJobs();
+    },
+    1,
+    { leading: true },
+  );
 
   private async drainJobs() {
     await this.flush();

--- a/packages/host/app/lib/sqlite-adapter.ts
+++ b/packages/host/app/lib/sqlite-adapter.ts
@@ -200,6 +200,20 @@ export default class SQLiteAdapter implements DBAdapter {
     return alias;
   }
 
+  async deleteSnapshot(snapshotName: string) {
+    this.assertNotClosed();
+    await this.started;
+    let snapshotInfo = this.snapshotInfos.get(snapshotName);
+    if (!snapshotInfo) {
+      throw new Error(`Unknown snapshot database '${snapshotName}'`);
+    }
+    await this.sqlite('exec', {
+      dbId: this.dbId,
+      sql: `DETACH DATABASE ${snapshotName};`,
+    });
+    this.snapshotInfos.delete(snapshotName);
+  }
+
   async importSnapshot(snapshotName: string) {
     this.assertNotClosed();
     await this.started;

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -119,7 +119,7 @@ function modelNameFor(llmId: string): string {
 
 module('Acceptance | AI Assistant tests', function (hooks) {
   setupApplicationTest(hooks);
-  setupLocalIndexing(hooks);
+
   setupOnSave(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {

--- a/packages/host/tests/acceptance/basic-test.gts
+++ b/packages/host/tests/acceptance/basic-test.gts
@@ -16,7 +16,6 @@ import { setupApplicationTest } from '../helpers/setup';
 
 module('Acceptance | basic tests', function (hooks) {
   setupApplicationTest(hooks);
-  setupLocalIndexing(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs: '@testuser:localhost',

--- a/packages/host/tests/acceptance/catalog-app-test.gts
+++ b/packages/host/tests/acceptance/catalog-app-test.gts
@@ -163,7 +163,7 @@ const cardWithUnrecognisedImports = `
 
 module('Acceptance | Catalog | catalog app tests', function (hooks) {
   setupApplicationTest(hooks);
-  setupLocalIndexing(hooks);
+
   setupOnSave(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {
@@ -792,7 +792,7 @@ module('Acceptance | Catalog | catalog app tests', function (hooks) {
     snapshot.get();
   });
 
-/**
+  /**
    * Selects a tab by name within the catalog app
    */
   async function selectTab(tabName: string) {

--- a/packages/host/tests/acceptance/code-patches-test.gts
+++ b/packages/host/tests/acceptance/code-patches-test.gts
@@ -62,7 +62,7 @@ export class TestCard extends CardDef {
 
 module('Acceptance | Code patches tests', function (hooks) {
   setupApplicationTest(hooks);
-  setupLocalIndexing(hooks);
+
   setupOnSave(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {

--- a/packages/host/tests/acceptance/code-submode/card-playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/card-playground-test.gts
@@ -177,7 +177,6 @@ module('Acceptance | code-submode | card playground', function (_hooks) {
     let realm: Realm;
 
     setupApplicationTest(hooks);
-    setupLocalIndexing(hooks);
 
     let mockMatrixUtils = setupMockMatrix(hooks, {
       loggedInAs: '@testuser:localhost',
@@ -1469,7 +1468,6 @@ module('Acceptance | code-submode | card playground', function (_hooks) {
     let additionalRealmURL: string;
 
     setupApplicationTest(hooks);
-    setupLocalIndexing(hooks);
 
     let mockMatrixUtils = setupMockMatrix(hooks, {
       loggedInAs: '@testuser:localhost',
@@ -1633,7 +1631,7 @@ module('Acceptance | code-submode | card playground', function (_hooks) {
   module('error handling', function (hooks) {
     let realm: Realm;
     setupApplicationTest(hooks);
-    setupLocalIndexing(hooks);
+
     setupOnSave(hooks);
 
     let mockMatrixUtils = setupMockMatrix(hooks, {

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -203,7 +203,7 @@ module('Acceptance | code submode | create-file tests', function (hooks) {
   };
 
   setupApplicationTest(hooks);
-  setupLocalIndexing(hooks);
+
   setupOnSave(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {

--- a/packages/host/tests/acceptance/code-submode/editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/editor-test.ts
@@ -42,7 +42,7 @@ module('Acceptance | code submode | editor tests', function (hooks) {
   let adapter: TestRealmAdapter;
 
   setupApplicationTest(hooks);
-  setupLocalIndexing(hooks);
+
   setupOnSave(hooks);
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs: '@testuser:localhost',

--- a/packages/host/tests/acceptance/code-submode/field-playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/field-playground-test.gts
@@ -295,7 +295,6 @@ module('Acceptance | code-submode | field playground', function (_hooks) {
   module('single realm', function (hooks) {
     let realm: Realm;
     setupApplicationTest(hooks);
-    setupLocalIndexing(hooks);
 
     let mockMatrixUtils = setupMockMatrix(hooks, {
       loggedInAs: '@testuser:localhost',
@@ -304,7 +303,6 @@ module('Acceptance | code-submode | field playground', function (_hooks) {
 
     let { setRealmPermissions, setActiveRealms, createAndJoinRoom } =
       mockMatrixUtils;
-
 
     let defaultMatrixRoomId: string;
     let snapshot = setupSnapshotRealm<{ realm: Realm }>(hooks, {
@@ -1096,14 +1094,12 @@ module('Acceptance | code-submode | field playground', function (_hooks) {
     let additionalRealmURL = `${origin}/testuser/aaa/`; // writeable realm that is lexically before the personal realm
 
     setupApplicationTest(hooks);
-    setupLocalIndexing(hooks);
 
     let mockMatrixUtils = setupMockMatrix(hooks, {
       loggedInAs: '@testuser:localhost',
       activeRealms: [personalRealmURL, additionalRealmURL],
     });
     let { setRealmPermissions, createAndJoinRoom } = mockMatrixUtils;
-
 
     let defaultMatrixRoomId: string;
     let multiRealmSnapshot = setupSnapshotRealm<{ realm: Realm }>(hooks, {
@@ -1131,7 +1127,8 @@ module('Acceptance | code-submode | field playground', function (_hooks) {
             'author.gts': authorCard,
             '.realm.json': {
               name: `Test User's Workspace`,
-              backgroundURL: 'https://i.postimg.cc/NjcjbyD3/4k-origami-flock.jpg',
+              backgroundURL:
+                'https://i.postimg.cc/NjcjbyD3/4k-origami-flock.jpg',
               iconURL: 'https://i.postimg.cc/Rq550Bwv/T.png',
             },
           },

--- a/packages/host/tests/acceptance/code-submode/file-tree-test.ts
+++ b/packages/host/tests/acceptance/code-submode/file-tree-test.ts
@@ -198,7 +198,6 @@ const realmInfo = {
 
 module('Acceptance | code submode | file-tree tests', function (hooks) {
   setupApplicationTest(hooks);
-  setupLocalIndexing(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs: '@testuser:localhost',

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -419,7 +419,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
   let monacoService: MonacoService;
 
   setupApplicationTest(hooks);
-  setupLocalIndexing(hooks);
+
   setupOnSave(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {

--- a/packages/host/tests/acceptance/code-submode/recent-files-test.ts
+++ b/packages/host/tests/acceptance/code-submode/recent-files-test.ts
@@ -191,7 +191,6 @@ const friendCardSource = `
 let monacoService: MonacoService;
 module('Acceptance | code submode | recent files tests', function (hooks) {
   setupApplicationTest(hooks);
-  setupLocalIndexing(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs: '@testuser:localhost',

--- a/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/schema-editor-test.ts
@@ -245,7 +245,7 @@ module('Acceptance | code submode | schema editor tests', function (hooks) {
   let monacoService: MonacoService;
 
   setupApplicationTest(hooks);
-  setupLocalIndexing(hooks);
+
   setupOnSave(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {

--- a/packages/host/tests/acceptance/code-submode/spec-test.gts
+++ b/packages/host/tests/acceptance/code-submode/spec-test.gts
@@ -268,7 +268,7 @@ const polymorphicFieldCardSource = `
 
 module('Acceptance | Spec preview', function (hooks) {
   setupApplicationTest(hooks);
-  setupLocalIndexing(hooks);
+
   setupOnSave(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {

--- a/packages/host/tests/acceptance/commands-test.gts
+++ b/packages/host/tests/acceptance/commands-test.gts
@@ -81,7 +81,7 @@ let maybeBoomShouldBoom = true;
 
 module('Acceptance | Commands tests', function (hooks) {
   setupApplicationTest(hooks);
-  setupLocalIndexing(hooks);
+
   setupOnSave(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {

--- a/packages/host/tests/acceptance/host-mode-test.gts
+++ b/packages/host/tests/acceptance/host-mode-test.gts
@@ -52,7 +52,7 @@ class StubCustomSubdomainHostModeService extends StubHostModeService {
 
 module('Acceptance | host mode tests', function (hooks) {
   setupApplicationTest(hooks);
-  setupLocalIndexing(hooks);
+
   setupOnSave(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {

--- a/packages/host/tests/acceptance/host-submode-test.gts
+++ b/packages/host/tests/acceptance/host-submode-test.gts
@@ -75,7 +75,7 @@ function withUpdatedTestRealmInfo(
 
 module('Acceptance | host submode', function (hooks) {
   setupApplicationTest(hooks);
-  setupLocalIndexing(hooks);
+
   setupOnSave(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {

--- a/packages/host/tests/acceptance/interact-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/interact-submode/create-file-test.gts
@@ -204,7 +204,7 @@ const userRealmFiles: Record<string, any> = {
 
 module('Acceptance | interact submode | create-file tests', function (hooks) {
   setupApplicationTest(hooks);
-  setupLocalIndexing(hooks);
+
   setupOnSave(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {

--- a/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
+++ b/packages/host/tests/acceptance/operator-mode-acceptance-test.gts
@@ -81,7 +81,7 @@ module('Acceptance | operator mode tests', function (hooks) {
     matrixRoomId: string;
   };
   setupApplicationTest(hooks);
-  setupLocalIndexing(hooks);
+
   setupOnSave(hooks);
   setupBaseRealm(hooks);
   let mockMatrixUtils = setupMockMatrix(hooks, {

--- a/packages/host/tests/acceptance/prerender-html-test.gts
+++ b/packages/host/tests/acceptance/prerender-html-test.gts
@@ -26,7 +26,7 @@ import { setupApplicationTest } from '../helpers/setup';
 
 module('Acceptance | prerender | html', function (hooks) {
   setupApplicationTest(hooks);
-  setupLocalIndexing(hooks);
+
   setupOnSave(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {

--- a/packages/host/tests/acceptance/prerender-meta-test.gts
+++ b/packages/host/tests/acceptance/prerender-meta-test.gts
@@ -24,7 +24,7 @@ import { setupApplicationTest } from '../helpers/setup';
 
 module('Acceptance | prerender | meta', function (hooks) {
   setupApplicationTest(hooks);
-  setupLocalIndexing(hooks);
+
   setupOnSave(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {

--- a/packages/host/tests/acceptance/prerender-module-test.gts
+++ b/packages/host/tests/acceptance/prerender-module-test.gts
@@ -28,7 +28,7 @@ import type { TestRealmAdapter } from '../helpers/adapter';
 
 module('Acceptance | prerender | module', function (hooks) {
   setupApplicationTest(hooks);
-  setupLocalIndexing(hooks);
+
   setupOnSave(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {

--- a/packages/host/tests/acceptance/real-catalog-app-test.gts
+++ b/packages/host/tests/acceptance/real-catalog-app-test.gts
@@ -27,7 +27,7 @@ class StubHostModeService extends HostModeService {
 
 module('Acceptance | Catalog | real catalog app', function (hooks) {
   setupApplicationTest(hooks);
-  setupLocalIndexing(hooks);
+
   let snapshot = setupSnapshotRealm(hooks, {
     acceptanceTest: true,
     async build() {

--- a/packages/host/tests/acceptance/site-config-test.gts
+++ b/packages/host/tests/acceptance/site-config-test.gts
@@ -47,7 +47,7 @@ function removeTrailingSlash(url: string): string {
 
 module('Acceptance | site config home page', function (hooks) {
   setupApplicationTest(hooks);
-  setupLocalIndexing(hooks);
+
   setupOnSave(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {

--- a/packages/host/tests/acceptance/theme-card-test.gts
+++ b/packages/host/tests/acceptance/theme-card-test.gts
@@ -147,7 +147,7 @@ const SOFT_POP_VARS = `:root {
 
 module('Acceptance | theme-card-test', function (hooks) {
   setupApplicationTest(hooks);
-  setupLocalIndexing(hooks);
+
   setupOnSave(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {

--- a/packages/host/tests/acceptance/workspace-delete-multiple-test.gts
+++ b/packages/host/tests/acceptance/workspace-delete-multiple-test.gts
@@ -19,7 +19,7 @@ import { setupApplicationTest } from '../helpers/setup';
 
 module('Acceptance | workspace-delete-multiple', function (hooks) {
   setupApplicationTest(hooks);
-  setupLocalIndexing(hooks);
+
   setupBaseRealm(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {

--- a/packages/host/tests/helpers/base-realm.ts
+++ b/packages/host/tests/helpers/base-realm.ts
@@ -105,12 +105,8 @@ let enumField: (typeof EnumModule)['default'];
 let enumOptions: (typeof EnumModule)['enumOptions'];
 let enumValues: (typeof EnumModule)['enumValues'];
 let enumConfig: (typeof EnumModule)['enumConfig'];
-let initialised = false;
 
 async function initialize() {
-  if (initialised) {
-    return;
-  }
   let loader = getService('loader-service').loader;
 
   StringField = (
@@ -230,8 +226,6 @@ async function initialize() {
   enumOptions = enumModule.enumOptions;
   enumValues = enumModule.enumValues;
   enumConfig = enumModule.enumConfig;
-
-  initialised = true;
 }
 
 export async function setupBaseRealm(hooks: NestedHooks) {

--- a/packages/host/tests/helpers/base-realm.ts
+++ b/packages/host/tests/helpers/base-realm.ts
@@ -106,7 +106,7 @@ let enumOptions: (typeof EnumModule)['enumOptions'];
 let enumValues: (typeof EnumModule)['enumValues'];
 let enumConfig: (typeof EnumModule)['enumConfig'];
 
-async function initialize() {
+export async function initialize() {
   let loader = getService('loader-service').loader;
 
   StringField = (

--- a/packages/host/tests/helpers/base-realm.ts
+++ b/packages/host/tests/helpers/base-realm.ts
@@ -19,6 +19,7 @@ import type * as PhoneNumberFieldModule from 'https://cardstack.com/base/phone-n
 import type * as RealmFieldModule from 'https://cardstack.com/base/realm';
 import type * as SkillModule from 'https://cardstack.com/base/skill';
 import type * as StringFieldModule from 'https://cardstack.com/base/string';
+import type * as SpecModule from 'https://cardstack.com/base/spec';
 import type * as SystemCardModule from 'https://cardstack.com/base/system-card';
 import type * as TextAreaFieldModule from 'https://cardstack.com/base/text-area';
 
@@ -69,6 +70,9 @@ let CardsGrid: CardsGrid;
 
 type Skill = (typeof SkillModule)['Skill'];
 let Skill: Skill;
+
+type Spec = (typeof SpecModule)['Spec'];
+let Spec: Spec;
 
 type ModelConfiguration = (typeof SystemCardModule)['ModelConfiguration'];
 let ModelConfiguration: ModelConfiguration;
@@ -178,6 +182,8 @@ export async function initialize() {
   Skill = (await loader.import<typeof SkillModule>(`${baseRealm.url}skill`))
     .Skill;
 
+  Spec = (await loader.import<typeof SpecModule>(`${baseRealm.url}spec`)).Spec;
+
   ModelConfiguration = (
     await loader.import<typeof SystemCardModule>(`${baseRealm.url}system-card`)
   ).ModelConfiguration;
@@ -248,6 +254,8 @@ export {
   RealmField,
   PhoneNumberField,
   CardsGrid,
+  Skill,
+  Spec,
   SystemCard,
   ModelConfiguration,
   field,
@@ -273,7 +281,6 @@ export {
   getFields,
   getFieldDescription,
   ReadOnlyField,
-  Skill,
   instanceOf,
   CardInfoField,
   enumField,

--- a/packages/host/tests/helpers/interact-submode-setup.gts
+++ b/packages/host/tests/helpers/interact-submode-setup.gts
@@ -31,7 +31,7 @@ export function setupInteractSubmodeTests(
   { setRealm }: InteractSubmodeSetupOptions,
 ) {
   setupApplicationTest(hooks);
-  setupLocalIndexing(hooks);
+
   setupOnSave(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {
@@ -81,38 +81,38 @@ export function setupInteractSubmodeTests(
         @field name = contains(StringField);
         @field favoriteTreat = contains(StringField);
 
-      @field title = contains(StringField, {
-        computeVia: function (this: Pet) {
-          return this.name;
-        },
-      });
-      static fitted = class Fitted extends Component<typeof this> {
-        <template>
-          <h3 data-test-pet={{@model.name}}>
-            <@fields.name />
-          </h3>
-        </template>
-      };
-      static isolated = class Isolated extends Component<typeof this> {
-        <template>
-          <GridContainer class='container'>
-            <h2 data-test-pet-title><@fields.title /></h2>
-            <div>
-              <div>Favorite Treat: <@fields.favoriteTreat /></div>
-              <div data-test-editable-meta>
-                {{#if @canEdit}}
-                  <@fields.title />
-                  is editable.
-                {{else}}
-                  <@fields.title />
-                  is NOT editable.
-                {{/if}}
+        @field title = contains(StringField, {
+          computeVia: function (this: Pet) {
+            return this.name;
+          },
+        });
+        static fitted = class Fitted extends Component<typeof this> {
+          <template>
+            <h3 data-test-pet={{@model.name}}>
+              <@fields.name />
+            </h3>
+          </template>
+        };
+        static isolated = class Isolated extends Component<typeof this> {
+          <template>
+            <GridContainer class='container'>
+              <h2 data-test-pet-title><@fields.title /></h2>
+              <div>
+                <div>Favorite Treat: <@fields.favoriteTreat /></div>
+                <div data-test-editable-meta>
+                  {{#if @canEdit}}
+                    <@fields.title />
+                    is editable.
+                  {{else}}
+                    <@fields.title />
+                    is NOT editable.
+                  {{/if}}
+                </div>
               </div>
-            </div>
-          </GridContainer>
-        </template>
-      };
-    }
+            </GridContainer>
+          </template>
+        };
+      }
 
       class Puppy extends Pet {
         static displayName = 'Puppy';
@@ -121,124 +121,130 @@ export function setupInteractSubmodeTests(
 
       class ShippingInfo extends FieldDef {
         static displayName = 'Shipping Info';
-      @field preferredCarrier = contains(StringField);
-      @field remarks = contains(StringField);
-      @field title = contains(StringField, {
-        computeVia: function (this: ShippingInfo) {
-          return this.preferredCarrier;
-        },
-      });
-      static embedded = class Embedded extends Component<typeof this> {
-        <template>
-          <span data-test-preferredCarrier={{@model.preferredCarrier}}></span>
-          <@fields.preferredCarrier />
-        </template>
-      };
-    }
+        @field preferredCarrier = contains(StringField);
+        @field remarks = contains(StringField);
+        @field title = contains(StringField, {
+          computeVia: function (this: ShippingInfo) {
+            return this.preferredCarrier;
+          },
+        });
+        static embedded = class Embedded extends Component<typeof this> {
+          <template>
+            <span data-test-preferredCarrier={{@model.preferredCarrier}}></span>
+            <@fields.preferredCarrier />
+          </template>
+        };
+      }
 
       class Address extends FieldDef {
         static displayName = 'Address';
-      @field city = contains(StringField);
-      @field country = contains(StringField);
-      @field shippingInfo = contains(ShippingInfo);
-      static embedded = class Embedded extends Component<typeof this> {
-        <template>
-          <h3 data-test-city={{@model.city}}>
-            <@fields.city />
-          </h3>
-          <h3 data-test-country={{@model.country}}>
-            <@fields.country />
-          </h3>
-          <div data-test-shippingInfo-field><@fields.shippingInfo /></div>
+        @field city = contains(StringField);
+        @field country = contains(StringField);
+        @field shippingInfo = contains(ShippingInfo);
+        static embedded = class Embedded extends Component<typeof this> {
+          <template>
+            <h3 data-test-city={{@model.city}}>
+              <@fields.city />
+            </h3>
+            <h3 data-test-country={{@model.country}}>
+              <@fields.country />
+            </h3>
+            <div data-test-shippingInfo-field><@fields.shippingInfo /></div>
 
-          <div data-test-editable-meta>
-            {{#if @canEdit}}
-              address is editable
-            {{else}}
-              address is NOT editable.
-            {{/if}}
-          </div>
-        </template>
-      };
+            <div data-test-editable-meta>
+              {{#if @canEdit}}
+                address is editable
+              {{else}}
+                address is NOT editable.
+              {{/if}}
+            </div>
+          </template>
+        };
 
-      static edit = class Edit extends Component<typeof this> {
-        <template>
-          <FieldContainer @label='city' @tag='label' data-test-boxel-input-city>
-            <@fields.city />
-          </FieldContainer>
-          <FieldContainer
-            @label='country'
-            @tag='label'
-            data-test-boxel-input-country
-          >
-            <@fields.country />
-          </FieldContainer>
-          <div data-test-shippingInfo-field><@fields.shippingInfo /></div>
-        </template>
-      };
-    }
+        static edit = class Edit extends Component<typeof this> {
+          <template>
+            <FieldContainer
+              @label='city'
+              @tag='label'
+              data-test-boxel-input-city
+            >
+              <@fields.city />
+            </FieldContainer>
+            <FieldContainer
+              @label='country'
+              @tag='label'
+              data-test-boxel-input-country
+            >
+              <@fields.country />
+            </FieldContainer>
+            <div data-test-shippingInfo-field><@fields.shippingInfo /></div>
+          </template>
+        };
+      }
 
       class Person extends CardDef {
         static displayName = 'Person';
-      @field firstName = contains(StringField);
-      @field pet = linksTo(Pet);
-      @field friends = linksToMany(Pet);
-      @field firstLetterOfTheName = contains(StringField, {
-        computeVia: function (this: Person) {
-          if (!this.firstName) {
-            return;
-          }
-          return this.firstName[0];
-        },
-      });
-      @field title = contains(StringField, {
-        computeVia: function (this: Person) {
-          return this.firstName;
-        },
-      });
-      @field primaryAddress = contains(Address);
-      @field additionalAddresses = containsMany(Address);
-
-      static isolated = class Isolated extends Component<typeof this> {
-        updateAndSavePet = () => {
-          let pet = this.args.model.pet;
-          if (pet) {
-            pet.name = 'Updated Pet';
-            this.args.saveCard?.(pet.id);
-          }
-        };
-        <template>
-          <h2 data-test-person={{@model.firstName}}>
-            <@fields.firstName />
-          </h2>
-          <p data-test-first-letter-of-the-name={{@model.firstLetterOfTheName}}>
-            <@fields.firstLetterOfTheName />
-          </p>
-          Pet:
-          <div class='pet-container'>
-            <@fields.pet />
-          </div>
-          Friends:
-          <@fields.friends />
-          Primary Address:
-          <@fields.primaryAddress />
-          Additional Adresses:
-          <@fields.additionalAddresses />
-          <button
-            data-test-update-and-save-pet
-            {{on 'click' this.updateAndSavePet}}
-          >
-            Update and Save Pet
-          </button>
-          <style scoped>
-            .pet-container {
-              height: 80px;
-              padding: 10px;
+        @field firstName = contains(StringField);
+        @field pet = linksTo(Pet);
+        @field friends = linksToMany(Pet);
+        @field firstLetterOfTheName = contains(StringField, {
+          computeVia: function (this: Person) {
+            if (!this.firstName) {
+              return;
             }
-          </style>
-        </template>
-      };
-    }
+            return this.firstName[0];
+          },
+        });
+        @field title = contains(StringField, {
+          computeVia: function (this: Person) {
+            return this.firstName;
+          },
+        });
+        @field primaryAddress = contains(Address);
+        @field additionalAddresses = containsMany(Address);
+
+        static isolated = class Isolated extends Component<typeof this> {
+          updateAndSavePet = () => {
+            let pet = this.args.model.pet;
+            if (pet) {
+              pet.name = 'Updated Pet';
+              this.args.saveCard?.(pet.id);
+            }
+          };
+          <template>
+            <h2 data-test-person={{@model.firstName}}>
+              <@fields.firstName />
+            </h2>
+            <p
+              data-test-first-letter-of-the-name={{@model.firstLetterOfTheName}}
+            >
+              <@fields.firstLetterOfTheName />
+            </p>
+            Pet:
+            <div class='pet-container'>
+              <@fields.pet />
+            </div>
+            Friends:
+            <@fields.friends />
+            Primary Address:
+            <@fields.primaryAddress />
+            Additional Adresses:
+            <@fields.additionalAddresses />
+            <button
+              data-test-update-and-save-pet
+              {{on 'click' this.updateAndSavePet}}
+            >
+              Update and Save Pet
+            </button>
+            <style scoped>
+              .pet-container {
+                height: 80px;
+                padding: 10px;
+              }
+            </style>
+          </template>
+        };
+      }
 
       class Personnel extends Person {
         static displayName = 'Personnel';

--- a/packages/host/tests/helpers/snapshot-realm.ts
+++ b/packages/host/tests/helpers/snapshot-realm.ts
@@ -37,6 +37,7 @@ export interface SnapshotRealmHandle<T> {
 interface SetupSnapshotRealmOptions<T> {
   build: (context: SnapshotBuildContext) => Promise<T>;
   mockMatrixUtils: MockUtils;
+  setupBaseRealm?: boolean; // TODO: default to false, allow opt-in
   realmPermissions?: Record<string, RealmAction[]>;
   acceptanceTest?: boolean;
 }
@@ -59,7 +60,9 @@ export function setupSnapshotRealm<T>(
       });
     }
   });
-  setupBaseRealm(hooks);
+  if (options.setupBaseRealm !== false) {
+    setupBaseRealm(hooks);
+  }
 
   hooks.beforeEach(async function () {
     setupUserSubscription();

--- a/packages/host/tests/helpers/snapshot-realm.ts
+++ b/packages/host/tests/helpers/snapshot-realm.ts
@@ -2,6 +2,7 @@ import { getService } from '@universal-ember/test-support';
 
 import type { RealmAction } from '@cardstack/runtime-common';
 import { Loader } from '@cardstack/runtime-common/loader';
+import { baseRealm } from '@cardstack/runtime-common';
 
 import type { SerializedServerState } from './mock-matrix/_server-state';
 import type { MockUtils } from './mock-matrix/_utils';
@@ -9,6 +10,9 @@ import {
   type DbSnapshot,
   setupUserSubscription,
   setupAuthEndpoints,
+  setupLocalIndexing,
+  setupCardLogs,
+  type NestedHooks,
   captureDbSnapshot,
   restoreDbSnapshot,
   deleteSnapshot,
@@ -16,6 +20,7 @@ import {
 } from '.';
 
 import { setupBaseRealm } from './base-realm';
+import { setup } from 'qunit-dom';
 
 export interface SnapshotBuildContext {
   isInitialBuild: boolean;
@@ -49,6 +54,13 @@ export function setupSnapshotRealm<T>(
   let cache: SnapshotCache | undefined;
   let latestState: T | undefined;
 
+  setupCardLogs(
+    hooks,
+    async () =>
+      await getService('loader-service').loader.import(
+        `${baseRealm.url}card-api`,
+      ),
+  );
   hooks.beforeEach(async function () {
     setupRendering(options.acceptanceTest!!);
   });
@@ -60,6 +72,7 @@ export function setupSnapshotRealm<T>(
       });
     }
   });
+  setupLocalIndexing(hooks);
   if (options.setupBaseRealm !== false) {
     setupBaseRealm(hooks);
   }

--- a/packages/host/tests/helpers/snapshot-realm.ts
+++ b/packages/host/tests/helpers/snapshot-realm.ts
@@ -57,7 +57,7 @@ export function setupSnapshotRealm<T>(
     let loaderService = getService('loader-service');
     if (cache) {
       loaderService.loader = Loader.cloneLoader(cache.loaderSnapshot, {
-        includeEvaluatedModules: true,
+        includeEvaluatedModules: '.*',
       });
     }
   });
@@ -88,7 +88,7 @@ export function setupSnapshotRealm<T>(
 
     if (!cache) {
       let clonedLoader = Loader.cloneLoader(loaderService.loader, {
-        includeEvaluatedModules: true,
+        includeEvaluatedModules: '.*',
       });
       cache = {
         loaderSnapshot: clonedLoader,

--- a/packages/host/tests/helpers/snapshot-realm.ts
+++ b/packages/host/tests/helpers/snapshot-realm.ts
@@ -56,7 +56,6 @@ export function setupSnapshotRealm<T>(
   hooks.beforeEach(async function () {
     let loaderService = getService('loader-service');
     if (cache) {
-      console.log('Restoring loader from snapshot');
       loaderService.loader = Loader.cloneLoader(cache.loaderSnapshot, {
         includeEvaluatedModules: true,
       });

--- a/packages/host/tests/integration/commands/add-field-to-card-definition-command-test.gts
+++ b/packages/host/tests/integration/commands/add-field-to-card-definition-command-test.gts
@@ -31,7 +31,7 @@ module(
   'Integration | commands | add-field-to-card-definition',
   function (hooks) {
     setupRenderingTest(hooks);
-    setupLocalIndexing(hooks);
+
     let mockMatrixUtils = setupMockMatrix(hooks);
     let snapshot = setupSnapshotRealm(hooks, {
       mockMatrixUtils,

--- a/packages/host/tests/integration/commands/check-correctness-test.gts
+++ b/packages/host/tests/integration/commands/check-correctness-test.gts
@@ -18,7 +18,7 @@ import { getService } from '@universal-ember/test-support';
 
 module('Integration | commands | check-correctness', function (hooks) {
   setupRenderingTest(hooks);
-  setupLocalIndexing(hooks);
+
   let mockMatrixUtils = setupMockMatrix(hooks, {
     autostart: true,
     loggedInAs: '@testuser:localhost',

--- a/packages/host/tests/integration/commands/copy-and-edit-test.gts
+++ b/packages/host/tests/integration/commands/copy-and-edit-test.gts
@@ -26,7 +26,6 @@ const otherRealmURL = 'http://other-realm/test2/';
 
 module('Integration | commands | copy-and-edit', function (hooks) {
   setupRenderingTest(hooks);
-  setupLocalIndexing(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs: '@testuser:localhost',

--- a/packages/host/tests/integration/commands/copy-card-test.gts
+++ b/packages/host/tests/integration/commands/copy-card-test.gts
@@ -25,7 +25,6 @@ const testRealm2URL = 'http://test-realm/test2/';
 
 module('Integration | commands | copy-card', function (hooks) {
   setupRenderingTest(hooks);
-  setupLocalIndexing(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs: '@testuser:localhost',

--- a/packages/host/tests/integration/commands/copy-source-test.gts
+++ b/packages/host/tests/integration/commands/copy-source-test.gts
@@ -32,7 +32,6 @@ class StubRealmService extends RealmService {
 
 module('Integration | commands | copy-source', function (hooks) {
   setupRenderingTest(hooks);
-  setupLocalIndexing(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks);
 

--- a/packages/host/tests/integration/commands/create-spec-test.gts
+++ b/packages/host/tests/integration/commands/create-spec-test.gts
@@ -55,7 +55,6 @@ module('Integration | Command | create-specs', function (hooks) {
     },
   ]);
 
-  setupLocalIndexing(hooks);
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs: '@testuser:localhost',
     activeRealms: [testRealmURL],

--- a/packages/host/tests/integration/commands/generate-example-cards-one-shot-test.gts
+++ b/packages/host/tests/integration/commands/generate-example-cards-one-shot-test.gts
@@ -17,7 +17,6 @@ module(
   'Integration | Command | generate-example-cards (one-shot)',
   function (hooks) {
     setupRenderingTest(hooks);
-    setupLocalIndexing(hooks);
 
     let mockMatrixUtils = setupMockMatrix(hooks, {
       loggedInAs: '@testuser:localhost',

--- a/packages/host/tests/integration/commands/open-workspace-test.gts
+++ b/packages/host/tests/integration/commands/open-workspace-test.gts
@@ -14,7 +14,6 @@ import { setupRenderingTest } from '../../helpers/setup';
 
 module('Integration | commands | open-workspace', function (hooks) {
   setupRenderingTest(hooks);
-  setupLocalIndexing(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs: '@testuser:localhost',

--- a/packages/host/tests/integration/commands/patch-code-test.gts
+++ b/packages/host/tests/integration/commands/patch-code-test.gts
@@ -26,6 +26,10 @@ import { setupMockMatrix } from '../../helpers/mock-matrix';
 import { setupRenderingTest } from '../../helpers/setup';
 
 module('Integration | commands | patch-code', function (hooks) {
+  const testFileName = 'task.gts';
+  const fileUrl = `${testRealmURL}${testFileName}`;
+  let adapter: any;
+
   setupRenderingTest(hooks);
 
   setupLocalIndexing(hooks);
@@ -60,10 +64,6 @@ export class Task extends CardDef {
       return { adapter: realmSetup.adapter };
     },
   });
-
-  const testFileName = 'task.gts';
-  const fileUrl = `${testRealmURL}${testFileName}`;
-  let adapter: any;
 
   hooks.beforeEach(function () {
     ({ adapter } = snapshot.get());

--- a/packages/host/tests/integration/commands/patch-code-test.gts
+++ b/packages/host/tests/integration/commands/patch-code-test.gts
@@ -32,7 +32,6 @@ module('Integration | commands | patch-code', function (hooks) {
 
   setupRenderingTest(hooks);
 
-  setupLocalIndexing(hooks);
   let mockMatrixUtils = setupMockMatrix(hooks, { autostart: true });
   let snapshot = setupSnapshotRealm(hooks, {
     mockMatrixUtils,

--- a/packages/host/tests/integration/commands/patch-fields-test.gts
+++ b/packages/host/tests/integration/commands/patch-fields-test.gts
@@ -35,7 +35,7 @@ import { setupRenderingTest } from '../../helpers/setup';
 
 module('Integration | Command | patch-fields', function (hooks) {
   setupRenderingTest(hooks);
-  setupLocalIndexing(hooks);
+
   setupOnSave(hooks);
   let commandService: CommandService;
   let store: StoreService;

--- a/packages/host/tests/integration/commands/patch-instance-test.gts
+++ b/packages/host/tests/integration/commands/patch-instance-test.gts
@@ -37,7 +37,6 @@ import { setupRenderingTest } from '../../helpers/setup';
 module('Integration | commands | patch-instance', function (hooks) {
   setupRenderingTest(hooks);
 
-  setupLocalIndexing(hooks);
   setupOnSave(hooks);
   let mockMatrixUtils = setupMockMatrix(hooks, { autostart: true });
   let commandService: CommandService;

--- a/packages/host/tests/integration/commands/preview-format-test.gts
+++ b/packages/host/tests/integration/commands/preview-format-test.gts
@@ -36,7 +36,6 @@ class StubRealmService extends RealmService {
 module('Integration | Command | preview-format', function (hooks) {
   setupRenderingTest(hooks);
   setupWindowMock(hooks);
-  setupLocalIndexing(hooks);
 
   const realmName = 'Preview Format Test Realm';
   let loader: Loader;

--- a/packages/host/tests/integration/commands/preview-format-test.gts
+++ b/packages/host/tests/integration/commands/preview-format-test.gts
@@ -36,6 +36,7 @@ class StubRealmService extends RealmService {
 module('Integration | Command | preview-format', function (hooks) {
   setupRenderingTest(hooks);
   setupWindowMock(hooks);
+  setupLocalIndexing(hooks);
 
   const realmName = 'Preview Format Test Realm';
   let loader: Loader;
@@ -47,8 +48,6 @@ module('Integration | Command | preview-format', function (hooks) {
   let snapshot = setupSnapshotRealm(hooks, {
     mockMatrixUtils,
     async build({ loader }) {
-      let loaderService = getService('loader-service');
-      loaderService.loader = loader;
       await setupIntegrationTestRealm({
         mockMatrixUtils,
         contents: {
@@ -103,7 +102,6 @@ module('Integration | Command | preview-format', function (hooks) {
     ({ loader, command } = snapshot.get());
   });
 
-  setupLocalIndexing(hooks);
   setupOnSave(hooks);
   setupCardLogs(
     hooks,

--- a/packages/host/tests/integration/commands/read-card-for-ai-assistant-test.gts
+++ b/packages/host/tests/integration/commands/read-card-for-ai-assistant-test.gts
@@ -32,7 +32,6 @@ class StubRealmService extends RealmService {
 
 module('Integration | commands | read-card-for-ai-assistant', function (hooks) {
   setupRenderingTest(hooks);
-  setupLocalIndexing(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs: '@testuser:localhost',

--- a/packages/host/tests/integration/commands/read-file-for-ai-assistant-test.gts
+++ b/packages/host/tests/integration/commands/read-file-for-ai-assistant-test.gts
@@ -30,7 +30,6 @@ class StubRealmService extends RealmService {
 
 module('Integration | commands | read-file-for-ai-assistant', function (hooks) {
   setupRenderingTest(hooks);
-  setupLocalIndexing(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs: '@testuser:localhost',

--- a/packages/host/tests/integration/commands/read-source-test.gts
+++ b/packages/host/tests/integration/commands/read-source-test.gts
@@ -29,7 +29,6 @@ class StubRealmService extends RealmService {
 
 module('Integration | commands | read-source', function (hooks) {
   setupRenderingTest(hooks);
-  setupLocalIndexing(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks);
   let snapshot = setupSnapshotRealm(hooks, {

--- a/packages/host/tests/integration/commands/read-text-file-test.gts
+++ b/packages/host/tests/integration/commands/read-text-file-test.gts
@@ -29,7 +29,6 @@ class StubRealmService extends RealmService {
 
 module('Integration | commands | read-text-file', function (hooks) {
   setupRenderingTest(hooks);
-  setupLocalIndexing(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks);
   let snapshot = setupSnapshotRealm(hooks, {

--- a/packages/host/tests/integration/commands/search-command-test.gts
+++ b/packages/host/tests/integration/commands/search-command-test.gts
@@ -133,6 +133,9 @@ module('Integration | commands | search', function (hooks) {
       },
     });
     assert.strictEqual(result.cardIds.length, 1);
-    assert.strictEqual(result.cardIds[0], 'http://test-realm/test/Author/r2');
+    assert.strictEqual(
+      result.cardIds[0],
+      'http://test-realm/test/CustomAuthor/r2',
+    );
   });
 });

--- a/packages/host/tests/integration/commands/search-command-test.gts
+++ b/packages/host/tests/integration/commands/search-command-test.gts
@@ -39,7 +39,6 @@ module('Integration | commands | search', function (hooks) {
   const realmName = 'Operator Mode Workspace';
   let loader: Loader;
 
-  setupLocalIndexing(hooks);
   setupOnSave(hooks);
   setupCardLogs(
     hooks,

--- a/packages/host/tests/integration/commands/search-command-test.gts
+++ b/packages/host/tests/integration/commands/search-command-test.gts
@@ -20,6 +20,19 @@ import {
 import { setupMockMatrix } from '../../helpers/mock-matrix';
 import { setupRenderingTest } from '../../helpers/setup';
 
+import {
+  StringField,
+  NumberField,
+  field,
+  contains,
+  CardDef,
+  Component,
+  FieldDef,
+  containsMany,
+  linksTo,
+  linksToMany,
+} from '../../helpers/base-realm';
+
 module('Integration | commands | search', function (hooks) {
   setupRenderingTest(hooks);
 
@@ -30,7 +43,10 @@ module('Integration | commands | search', function (hooks) {
   setupOnSave(hooks);
   setupCardLogs(
     hooks,
-    async () => await loader.import(`${baseRealm.url}card-api`),
+    async () =>
+      await getService('loader-service').loader.import(
+        `${baseRealm.url}card-api`,
+      ),
   );
 
   let mockMatrixUtils = setupMockMatrix(hooks, {
@@ -41,23 +57,12 @@ module('Integration | commands | search', function (hooks) {
   let snapshot = setupSnapshotRealm(hooks, {
     mockMatrixUtils,
     async build({ loader }) {
-      let loaderService = getService('loader-service');
-      loaderService.loader = loader;
-      let cardApi: typeof import('https://cardstack.com/base/card-api');
-      let string: typeof import('https://cardstack.com/base/string');
-
-      cardApi = await loader.import(`${baseRealm.url}card-api`);
-      string = await loader.import(`${baseRealm.url}string`);
-
-      let { field, contains, CardDef } = cardApi;
-      let { default: StringField } = string;
-
-      class Author extends CardDef {
-        static displayName = 'Author';
+      class CustomAuthor extends CardDef {
+        static displayName = 'CustomAuthor';
         @field firstName = contains(StringField);
         @field lastName = contains(StringField);
         @field title = contains(StringField, {
-          computeVia: function (this: Author) {
+          computeVia: function (this: CustomAuthor) {
             return [this.firstName, this.lastName].filter(Boolean).join(' ');
           },
         });
@@ -65,9 +70,9 @@ module('Integration | commands | search', function (hooks) {
       await setupIntegrationTestRealm({
         mockMatrixUtils,
         contents: {
-          'author.gts': { Author },
-          'Author/r2.json': new Author({ firstName: 'R2-D2' }),
-          'Author/mark.json': new Author({
+          'custom-author.gts': { CustomAuthor },
+          'CustomAuthor/r2.json': new CustomAuthor({ firstName: 'R2-D2' }),
+          'CustomAuthor/mark.json': new CustomAuthor({
             firstName: 'Mark',
             lastName: 'Jackson',
           }),
@@ -75,12 +80,8 @@ module('Integration | commands | search', function (hooks) {
         },
         loader,
       });
-      return { loader };
+      return {};
     },
-  });
-
-  hooks.beforeEach(function () {
-    ({ loader } = snapshot.get());
   });
 
   test('search for a title', async function (assert) {
@@ -93,7 +94,10 @@ module('Integration | commands | search', function (hooks) {
       cardType: undefined,
     });
     assert.strictEqual(result.cardIds.length, 1);
-    assert.strictEqual(result.cardIds[0], 'http://test-realm/test/Author/mark');
+    assert.strictEqual(
+      result.cardIds[0],
+      'http://test-realm/test/CustomAuthor/mark',
+    );
   });
 
   test('search for a card type', async function (assert) {
@@ -102,13 +106,13 @@ module('Integration | commands | search', function (hooks) {
       commandService.commandContext,
     );
     let result = await searchCommand.execute({
-      cardType: 'Author',
+      cardType: 'CustomAuthor',
       title: undefined,
     });
     assert.ok(result.cardIds.length > 0, 'Should return at least one result');
     assert.ok(
-      result.cardIds.every((id) => id.includes('Author')),
-      'All results should be Author cards',
+      result.cardIds.every((id) => id.includes('CustomAuthor')),
+      'All results should be Custom Author cards',
     );
   });
 
@@ -121,7 +125,10 @@ module('Integration | commands | search', function (hooks) {
       query: {
         filter: {
           eq: { firstName: 'R2-D2' },
-          on: { module: 'http://test-realm/test/author', name: 'Author' },
+          on: {
+            module: 'http://test-realm/test/custom-author',
+            name: 'CustomAuthor',
+          },
         },
       },
     });

--- a/packages/host/tests/integration/commands/search-google-images-test.gts
+++ b/packages/host/tests/integration/commands/search-google-images-test.gts
@@ -15,7 +15,6 @@ import { setupRenderingTest } from '../../helpers/setup';
 
 module('Integration | commands | search-google-images', function (hooks) {
   setupRenderingTest(hooks);
-  setupLocalIndexing(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs: '@testuser:localhost',

--- a/packages/host/tests/integration/commands/search-google-images-test.gts
+++ b/packages/host/tests/integration/commands/search-google-images-test.gts
@@ -207,17 +207,17 @@ module('Integration | commands | search-google-images', function (hooks) {
     );
     assert.strictEqual(
       firstImage.imageUrl,
-      'https://example.com/image1.jpg',
+      'http://localhost:4200/i-do-not-exist/image1.jpg',
       'Should have correct image URL',
     );
     assert.strictEqual(
       firstImage.thumbnailUrl,
-      'https://example.com/thumb1.jpg',
+      'http://localhost:4200/i-do-not-exist/thumb1.jpg',
       'Should have correct thumbnail URL',
     );
     assert.strictEqual(
       firstImage.contextUrl,
-      'https://example.com/page1',
+      'http://localhost:4200/i-do-not-exist/page1',
       'Should have correct context URL',
     );
     assert.strictEqual(firstImage.width, 800, 'Should have correct width');
@@ -249,7 +249,7 @@ module('Integration | commands | search-google-images', function (hooks) {
     );
     assert.strictEqual(
       firstImage.displayLink,
-      'example.com',
+      'localhost',
       'Should have correct display link',
     );
     assert.strictEqual(

--- a/packages/host/tests/integration/commands/send-ai-assistant-message-test.gts
+++ b/packages/host/tests/integration/commands/send-ai-assistant-message-test.gts
@@ -32,7 +32,6 @@ class StubRealmService extends RealmService {
 
 module('Integration | commands | send-ai-assistant-message', function (hooks) {
   setupRenderingTest(hooks);
-  setupLocalIndexing(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs: '@testuser:localhost',

--- a/packages/host/tests/integration/commands/send-ai-assistant-message-test.gts
+++ b/packages/host/tests/integration/commands/send-ai-assistant-message-test.gts
@@ -37,12 +37,11 @@ module('Integration | commands | send-ai-assistant-message', function (hooks) {
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs: '@testuser:localhost',
     activeRealms: [testRealmURL],
+    autostart: true,
   });
   let snapshot = setupSnapshotRealm(hooks, {
     mockMatrixUtils,
     async build({ loader }) {
-      let loaderService = getService('loader-service');
-      loaderService.loader = loader;
       await setupIntegrationTestRealm({
         mockMatrixUtils,
         contents: {},
@@ -56,10 +55,6 @@ module('Integration | commands | send-ai-assistant-message', function (hooks) {
 
   hooks.beforeEach(function (this: RenderingTestContext) {
     getOwner(this)!.register('service:realm', StubRealmService);
-  });
-
-  hooks.beforeEach(function () {
-    snapshot.get();
   });
 
   test('send an ai assistant message', async function (assert) {

--- a/packages/host/tests/integration/commands/send-request-via-proxy-test.gts
+++ b/packages/host/tests/integration/commands/send-request-via-proxy-test.gts
@@ -29,7 +29,6 @@ class StubRealmService extends RealmService {
 
 module('Integration | commands | send-request-via-proxy', function (hooks) {
   setupRenderingTest(hooks);
-  setupLocalIndexing(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs: '@testuser:localhost',

--- a/packages/host/tests/integration/commands/set-user-system-card-test.gts
+++ b/packages/host/tests/integration/commands/set-user-system-card-test.gts
@@ -29,7 +29,6 @@ class StubRealmService extends RealmService {
 
 module('Integration | commands | set-user-system-card', function (hooks) {
   setupRenderingTest(hooks);
-  setupLocalIndexing(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs: '@testuser:localhost',

--- a/packages/host/tests/integration/commands/show-card-test.gts
+++ b/packages/host/tests/integration/commands/show-card-test.gts
@@ -120,6 +120,15 @@ module('Integration | Command | show-card', function (hooks) {
   setupRenderingTest(hooks);
   setupWindowMock(hooks);
 
+  setupOnSave(hooks);
+  setupCardLogs(
+    hooks,
+    async () =>
+      await getService('loader-service').loader.import(
+        `${baseRealm.url}card-api`,
+      ),
+  );
+
   const realmName = 'Show Card Test Realm';
   let loader: Loader;
   let mockMatrixUtils = setupMockMatrix(hooks, {
@@ -130,8 +139,6 @@ module('Integration | Command | show-card', function (hooks) {
   let snapshot = setupSnapshotRealm(hooks, {
     mockMatrixUtils,
     async build({ loader }) {
-      let loaderService = getService('loader-service');
-      loaderService.loader = loader;
       await setupIntegrationTestRealm({
         mockMatrixUtils,
         contents: {
@@ -220,23 +227,13 @@ module('Integration | Command | show-card', function (hooks) {
 
   hooks.beforeEach(function (this: RenderingTestContext) {
     getOwner(this)!.register('service:realm', StubRealmService);
-    ({ loader } = snapshot.get());
   });
-
-  setupLocalIndexing(hooks);
-  setupOnSave(hooks);
-  setupCardLogs(
-    hooks,
-    async () => await loader.import(`${baseRealm.url}card-api`),
-  );
 
   let command: ShowCardCommand;
   let mockOperatorModeStateService: MockOperatorModeStateService;
   let mockPlaygroundPanelService: MockPlaygroundPanelService;
 
   hooks.beforeEach(function (this: RenderingTestContext) {
-    snapshot.get();
-
     mockOperatorModeStateService = new MockOperatorModeStateService();
     mockPlaygroundPanelService = new MockPlaygroundPanelService();
 

--- a/packages/host/tests/integration/commands/summarize-session-test.gts
+++ b/packages/host/tests/integration/commands/summarize-session-test.gts
@@ -29,7 +29,6 @@ class StubRealmService extends RealmService {
 
 module('Integration | commands | summarize-session', function (hooks) {
   setupRenderingTest(hooks);
-  setupLocalIndexing(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs: '@testuser:localhost',

--- a/packages/host/tests/integration/commands/switch-submode-test.gts
+++ b/packages/host/tests/integration/commands/switch-submode-test.gts
@@ -36,7 +36,6 @@ class StubRealmService extends RealmService {
 
 module('Integration | commands | switch-submode', function (hooks) {
   setupRenderingTest(hooks);
-  setupLocalIndexing(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs: '@testuser:localhost',

--- a/packages/host/tests/integration/commands/transform-cards-test.gts
+++ b/packages/host/tests/integration/commands/transform-cards-test.gts
@@ -52,9 +52,9 @@ module('Integration | commands | transform-cards', function (hooks) {
       loaderService.loader = loader;
       let cardApi: typeof import('https://cardstack.com/base/card-api');
       let string: typeof import('https://cardstack.com/base/string');
-      let CommandModule = await loader.import<typeof import('https://cardstack.com/base/command')>(
-        `${baseRealm.url}command`,
-      );
+      let CommandModule = await loader.import<
+        typeof import('https://cardstack.com/base/command')
+      >(`${baseRealm.url}command`);
 
       cardApi = await loader.import(`${baseRealm.url}card-api`);
       string = await loader.import(`${baseRealm.url}string`);
@@ -85,7 +85,10 @@ module('Integration | commands | transform-cards', function (hooks) {
         });
       }
 
-      class PrefixNameCommand extends Command<typeof JsonCard, typeof JsonCard> {
+      class PrefixNameCommand extends Command<
+        typeof JsonCard,
+        typeof JsonCard
+      > {
         async getInputType() {
           return JsonCard;
         }
@@ -235,12 +238,7 @@ module('Integration | commands | transform-cards', function (hooks) {
     ({ loader } = snapshot.get());
   });
 
-  setupLocalIndexing(hooks);
   setupOnSave(hooks);
-  setupCardLogs(
-    hooks,
-    async () => await loader.import(`${baseRealm.url}card-api`),
-  );
 
   hooks.beforeEach(function () {
     snapshot.get();

--- a/packages/host/tests/integration/commands/update-room-skills-test.gts
+++ b/packages/host/tests/integration/commands/update-room-skills-test.gts
@@ -146,8 +146,6 @@ module('Integration | Command | update-room-skills', function (hooks) {
     matrixService.reset();
   });
 
-  setupLocalIndexing(hooks);
-  setupOnSave(hooks);
   setupCardLogs(
     hooks,
     async () => await loader.import(`${baseRealm.url}card-api`),

--- a/packages/host/tests/integration/commands/upload-image-test.gts
+++ b/packages/host/tests/integration/commands/upload-image-test.gts
@@ -32,7 +32,6 @@ class StubRealmService extends RealmService {
 
 module('Integration | commands | upload-image', function (hooks) {
   setupRenderingTest(hooks);
-  setupLocalIndexing(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs: '@testuser:localhost',

--- a/packages/host/tests/integration/commands/upload-image-test.gts
+++ b/packages/host/tests/integration/commands/upload-image-test.gts
@@ -31,6 +31,29 @@ class StubRealmService extends RealmService {
 }
 
 module('Integration | commands | upload-image', function (hooks) {
+  let lastForwardPayload: any;
+  let forwardPayloads: any[] = [];
+  let lastDirectUploadRequest:
+    | {
+        url: string;
+        formData: FormData;
+      }
+    | undefined;
+  let networkService: NetworkService;
+  let directUploadFetchHandler:
+    | ((request: Request) => Promise<Response | null>)
+    | undefined;
+  let handlerMounted = false;
+
+  const directUploadResponse = {
+    success: true,
+    errors: [],
+    result: {
+      id: 'direct-upload-id',
+      uploadURL: 'https://upload.imagedelivery.net/direct-upload-url',
+    },
+  };
+
   setupRenderingTest(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {
@@ -49,32 +72,16 @@ module('Integration | commands | upload-image', function (hooks) {
           ...SYSTEM_CARD_FIXTURE_CONTENTS,
         },
         loader,
+        realmPermissions: {
+          [testRealmURL]: {
+            read: true,
+            write: true,
+          },
+        },
       });
       return {};
     },
   });
-
-  let lastForwardPayload: any;
-  let forwardPayloads: any[] = [];
-  let lastDirectUploadRequest:
-    | {
-        url: string;
-        formData: FormData;
-      }
-    | undefined;
-  let networkService: NetworkService;
-  let directUploadFetchHandler:
-    | ((request: Request) => Promise<Response | null>)
-    | undefined;
-
-  const directUploadResponse = {
-    success: true,
-    errors: [],
-    result: {
-      id: 'direct-upload-id',
-      uploadURL: 'https://upload.imagedelivery.net/direct-upload-url',
-    },
-  };
 
   setupRealmServerEndpoints(hooks, [
     {
@@ -109,8 +116,8 @@ module('Integration | commands | upload-image', function (hooks) {
   ]);
 
   hooks.beforeEach(async function (this: RenderingTestContext) {
-    snapshot.get();
     getOwner(this)!.register('service:realm', StubRealmService);
+    networkService = getService('network');
     lastForwardPayload = undefined;
     forwardPayloads = [];
     lastDirectUploadRequest = undefined;
@@ -139,23 +146,17 @@ module('Integration | commands | upload-image', function (hooks) {
       }
       return null;
     };
-    networkService = getService('network');
-    networkService.virtualNetwork.mount(directUploadFetchHandler, {
-      prepend: true,
-    });
-
-    await setupIntegrationTestRealm({
-      mockMatrixUtils,
-      contents: {
-        ...SYSTEM_CARD_FIXTURE_CONTENTS,
-      },
-    });
+    if (!handlerMounted) {
+      networkService.virtualNetwork.mount(directUploadFetchHandler, {
+        prepend: true,
+      });
+    }
   });
 
-  hooks.afterEach(function () {
-    if (directUploadFetchHandler) {
+  hooks.after(function () {
+    if (handlerMounted) {
       networkService.virtualNetwork.unmount(directUploadFetchHandler);
-      directUploadFetchHandler = undefined;
+      handlerMounted = false;
     }
   });
 
@@ -224,34 +225,6 @@ module('Integration | commands | upload-image', function (hooks) {
           });
     const objectUrl = URL.createObjectURL(file);
 
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = async (
-      input: RequestInfo | URL,
-      init?: RequestInit,
-    ): Promise<Response> => {
-      let url: string;
-      if (typeof input === 'string') {
-        url = input;
-      } else if (input instanceof URL) {
-        url = input.href;
-      } else if (input instanceof Request) {
-        url = input.url;
-      } else {
-        url = String(input);
-      }
-
-      if (url.startsWith('blob:')) {
-        return new Response(file, {
-          status: 200,
-          headers: {
-            'Content-Type': file.type,
-          },
-        });
-      }
-
-      return originalFetch(input as RequestInfo, init);
-    };
-
     try {
       const result = await command.execute({
         sourceImageUrl: objectUrl,
@@ -312,7 +285,6 @@ module('Integration | commands | upload-image', function (hooks) {
         'saved card uses id returned by direct upload',
       );
     } finally {
-      globalThis.fetch = originalFetch;
       URL.revokeObjectURL(objectUrl);
     }
   });

--- a/packages/host/tests/integration/commands/use-ai-assistant-test.gts
+++ b/packages/host/tests/integration/commands/use-ai-assistant-test.gts
@@ -45,7 +45,6 @@ class StubRealmService extends RealmService {
 
 module('Integration | commands | ai-assistant', function (hooks) {
   setupRenderingTest(hooks);
-  setupLocalIndexing(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs: '@testuser:localhost',

--- a/packages/host/tests/integration/commands/write-text-file-test.gts
+++ b/packages/host/tests/integration/commands/write-text-file-test.gts
@@ -40,7 +40,6 @@ class StubRealmService extends RealmService {
 
 module('Integration | commands | write-text-file', function (hooks) {
   setupRenderingTest(hooks);
-  setupLocalIndexing(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks);
   let snapshot = setupSnapshotRealm(hooks, {

--- a/packages/host/tests/integration/commands/write-text-file-test.gts
+++ b/packages/host/tests/integration/commands/write-text-file-test.gts
@@ -41,7 +41,11 @@ class StubRealmService extends RealmService {
 module('Integration | commands | write-text-file', function (hooks) {
   setupRenderingTest(hooks);
 
-  let mockMatrixUtils = setupMockMatrix(hooks);
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [testRealmURL],
+    autostart: true,
+  });
   let snapshot = setupSnapshotRealm(hooks, {
     mockMatrixUtils,
     async build({ loader }) {
@@ -49,6 +53,7 @@ module('Integration | commands | write-text-file', function (hooks) {
       loaderService.loader = loader;
       await setupIntegrationTestRealm({
         mockMatrixUtils,
+        realmURL: testRealmURL,
         contents: {},
         loader,
       });

--- a/packages/host/tests/integration/commands/write-text-file-test.gts
+++ b/packages/host/tests/integration/commands/write-text-file-test.gts
@@ -18,6 +18,7 @@ import {
 } from '../../helpers';
 import { setupMockMatrix } from '../../helpers/mock-matrix';
 import { setupRenderingTest } from '../../helpers/setup';
+import { baseRealm } from '@cardstack/runtime-common';
 
 let fetch: NetworkService['fetch'];
 
@@ -51,6 +52,7 @@ module('Integration | commands | write-text-file', function (hooks) {
     async build({ loader }) {
       let loaderService = getService('loader-service');
       loaderService.loader = loader;
+      await loader.import(`${baseRealm.url}command`);
       await setupIntegrationTestRealm({
         mockMatrixUtils,
         realmURL: testRealmURL,

--- a/packages/host/tests/integration/components/ai-assistant-panel/codeblocks-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/codeblocks-test.gts
@@ -79,8 +79,6 @@ module('Integration | ai-assistant-panel | codeblocks', function (hooks) {
     },
   });
 
-  setupLocalIndexing(hooks);
-  setupOnSave(hooks);
   setupCardLogs(
     hooks,
     async () => await snapshot.get().loader.import(`${baseRealm.url}card-api`),

--- a/packages/host/tests/integration/components/ai-assistant-panel/commands-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/commands-test.gts
@@ -79,7 +79,6 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
     },
   });
 
-  setupLocalIndexing(hooks);
   setupOnSave(hooks);
   setupCardLogs(
     hooks,

--- a/packages/host/tests/integration/components/ai-assistant-panel/commands-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/commands-test.gts
@@ -6,9 +6,6 @@ import { getService } from '@universal-ember/test-support';
 
 import { module, test } from 'qunit';
 
-import { baseRealm } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
-
 import {
   APP_BOXEL_COMMAND_REQUESTS_KEY,
   APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
@@ -25,7 +22,6 @@ import type OperatorModeStateService from '@cardstack/host/services/operator-mod
 import {
   percySnapshot,
   testRealmURL,
-  setupCardLogs,
   setupIntegrationTestRealm,
   setupLocalIndexing,
   setupOnSave,
@@ -49,7 +45,6 @@ import { setupRenderingTest } from '../../../helpers/setup';
 
 module('Integration | ai-assistant-panel | commands', function (hooks) {
   const realmName = 'Operator Mode Workspace';
-  let loader: Loader;
   let operatorModeStateService: OperatorModeStateService;
 
   setupRenderingTest(hooks);
@@ -70,138 +65,150 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
   let { createAndJoinRoom, simulateRemoteMessage, getRoomEvents } =
     mockMatrixUtils;
 
-  let snapshot = setupSnapshotRealm<{ loader: Loader }>(hooks, {
+  let snapshot = setupSnapshotRealm(hooks, {
     mockMatrixUtils,
     async build({ loader }) {
-      let loaderService = getService('loader-service');
-      loaderService.loader = loader;
-      return { loader };
+      class Pet extends CardDef {
+        static displayName = 'Pet';
+        @field name = contains(StringField);
+        @field title = contains(StringField, {
+          computeVia: function (this: Pet) {
+            return this.name;
+          },
+        });
+        static fitted = class Fitted extends Component<typeof this> {
+          <template>
+            <h3 data-test-pet={{@model.name}}>
+              <@fields.name />
+            </h3>
+          </template>
+        };
+      }
+
+      class Address extends FieldDef {
+        static displayName = 'Address';
+        @field city = contains(StringField);
+        @field country = contains(StringField);
+        static embedded = class Embedded extends Component<typeof this> {
+          <template>
+            <div data-test-address>
+              <h3 data-test-city={{@model.city}}>
+                <@fields.city />
+              </h3>
+              <h3 data-test-country={{@model.country}}>
+                <@fields.country />
+              </h3>
+            </div>
+          </template>
+        };
+      }
+
+      class Person extends CardDef {
+        static displayName = 'Person';
+        @field firstName = contains(StringField);
+        @field pet = linksTo(Pet);
+        @field friends = linksToMany(Pet);
+        @field firstLetterOfTheName = contains(StringField, {
+          computeVia: function (this: Person) {
+            return this.firstName[0];
+          },
+        });
+        @field title = contains(StringField, {
+          computeVia: function (this: Person) {
+            return this.firstName;
+          },
+        });
+        @field address = contains(Address);
+        static isolated = class Isolated extends Component<typeof this> {
+          <template>
+            <h2 data-test-person={{@model.firstName}}>
+              <@fields.firstName />
+            </h2>
+            <p
+              data-test-first-letter-of-the-name={{@model.firstLetterOfTheName}}
+            >
+              <@fields.firstLetterOfTheName />
+            </p>
+            Pet:
+            <div class='pet-container'>
+              <@fields.pet />
+            </div>
+            Friends:
+            <@fields.friends />
+            <div data-test-addresses>Address: <@fields.address /></div>
+            <style scoped>
+              div.pet-container {
+                display: flex;
+                flex-wrap: wrap;
+              }
+            </style>
+          </template>
+        };
+        static fitted = class Fitted extends Component<typeof this> {
+          <template>
+            <h3 data-test-person={{@model.firstName}}>
+              <@fields.firstName />
+            </h3>
+          </template>
+        };
+      }
+
+      await setupIntegrationTestRealm({
+        mockMatrixUtils,
+        contents: {
+          'pet.gts': { Pet },
+          'address.gts': { Address },
+          'person.gts': { Person },
+          'Person/fadhlan.json': new Person({
+            firstName: 'Fadhlan',
+            address: new Address({
+              city: 'Bandung',
+              country: 'Indonesia',
+            }),
+          }),
+          'Person/burcu.json': new Person({
+            firstName: 'Burcu',
+            address: new Address({
+              city: 'Istanbul',
+              country: 'Turkey',
+            }),
+            pet: new Pet({
+              name: 'Lion',
+            }),
+            friends: [new Pet({ name: 'Tiger' }), new Pet({ name: 'Bear' })],
+          }),
+          'Person/mickey.json': new Person({
+            firstName: 'Mickey',
+            address: new Address({
+              city: 'Paris',
+              country: 'France',
+            }),
+            friends: [new Pet({ name: 'Donald' })],
+          }),
+          'Person/justin.json': new Person({ firstName: 'Justin' }),
+          'Person/ian.json': new Person({ firstName: 'Ian' }),
+          'Person/matic.json': new Person({ firstName: 'Matic' }),
+          'Person/buck.json': new Person({ firstName: 'Buck' }),
+          'Person/hassan.json': new Person({ firstName: 'Hassan' }),
+          '.realm.json': `{ "name": "${realmName}" }`,
+        },
+      });
+
+      createAndJoinRoom({
+        sender: '@testuser:localhost',
+        name: 'room-test',
+      });
+
+      return {};
     },
   });
 
   setupOnSave(hooks);
-  setupCardLogs(
-    hooks,
-    async () => await snapshot.get().loader.import(`${baseRealm.url}card-api`),
-  );
 
   let noop = () => {};
 
   hooks.beforeEach(async function () {
-    ({ loader } = snapshot.get());
     operatorModeStateService = getService('operator-mode-state-service');
-
-    class Pet extends CardDef {
-      static displayName = 'Pet';
-      @field name = contains(StringField);
-      @field title = contains(StringField, {
-        computeVia: function (this: Pet) {
-          return this.name;
-        },
-      });
-      static fitted = class Fitted extends Component<typeof this> {
-        <template>
-          <h3 data-test-pet={{@model.name}}>
-            <@fields.name />
-          </h3>
-        </template>
-      };
-    }
-
-    class Address extends FieldDef {
-      static displayName = 'Address';
-      @field city = contains(StringField);
-      @field country = contains(StringField);
-      static embedded = class Embedded extends Component<typeof this> {
-        <template>
-          <div data-test-address>
-            <h3 data-test-city={{@model.city}}>
-              <@fields.city />
-            </h3>
-            <h3 data-test-country={{@model.country}}>
-              <@fields.country />
-            </h3>
-          </div>
-        </template>
-      };
-    }
-
-    class Person extends CardDef {
-      static displayName = 'Person';
-      @field firstName = contains(StringField);
-      @field pet = linksTo(Pet);
-      @field friends = linksToMany(Pet);
-      @field firstLetterOfTheName = contains(StringField, {
-        computeVia: function (this: Person) {
-          return this.firstName[0];
-        },
-      });
-      @field title = contains(StringField, {
-        computeVia: function (this: Person) {
-          return this.firstName;
-        },
-      });
-      @field address = contains(Address);
-      static isolated = class Isolated extends Component<typeof this> {
-        <template>
-          <h2 data-test-person={{@model.firstName}}>
-            <@fields.firstName />
-          </h2>
-          <p data-test-first-letter-of-the-name={{@model.firstLetterOfTheName}}>
-            <@fields.firstLetterOfTheName />
-          </p>
-          Pet:
-          <div class='pet-container'>
-            <@fields.pet />
-          </div>
-          Friends:
-          <@fields.friends />
-          <div data-test-addresses>Address: <@fields.address /></div>
-          <style scoped>
-            .pet-container {
-              height: 120px;
-              padding: 10px;
-            }
-          </style>
-        </template>
-      };
-    }
-
-    let petMango = new Pet({ name: 'Mango' });
-    let petJackie = new Pet({ name: 'Jackie' });
-
-    await setupIntegrationTestRealm({
-      mockMatrixUtils,
-      contents: {
-        'address.gts': { Address },
-        'hello.txt': 'Hello, world!',
-        'person.gts': { Person },
-        'pet.gts': { Pet },
-        'Pet/mango.json': petMango,
-        'Pet/jackie.json': petJackie,
-        'Person/fadhlan.json': new Person({
-          firstName: 'Fadhlan',
-          address: new Address({
-            city: 'Bandung',
-            country: 'Indonesia',
-          }),
-          pet: petMango,
-        }),
-        'Person/burcu.json': new Person({
-          firstName: 'Burcu',
-          friends: [petJackie, petMango],
-        }),
-        'Person/mickey.json': new Person({
-          firstName: 'Mickey',
-        }),
-        'Person/justin.json': new Person({ firstName: 'Justin' }),
-        'Person/ian.json': new Person({ firstName: 'Ian' }),
-        'Person/matic.json': new Person({ firstName: 'Matic' }),
-        'Person/buck.json': new Person({ firstName: 'Buck' }),
-        'Person/hassan.json': new Person({ firstName: 'Hassan' }),
-        '.realm.json': `{ "name": "${realmName}" }`,
-      },
-    });
   });
 
   function setCardInOperatorModeState(
@@ -706,7 +713,6 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
     assert
       .dom('[data-test-message-idx="0"] [data-test-boxel-card-header-title]')
       .containsText('Search Results');
-
     assert.dom('.result-list li').exists({ count: 2 });
 
     assert.dom('.result-list li:nth-child(1)').containsText('Jackie');

--- a/packages/host/tests/integration/components/ai-assistant-panel/debug-message-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/debug-message-test.gts
@@ -6,10 +6,6 @@ import { getService } from '@universal-ember/test-support';
 
 import { module, test } from 'qunit';
 
-import { baseRealm } from '@cardstack/runtime-common';
-
-import { Loader } from '@cardstack/runtime-common/loader';
-
 import {
   APP_BOXEL_DEBUG_MESSAGE_EVENT_TYPE,
   APP_BOXEL_MESSAGE_MSGTYPE,
@@ -25,7 +21,6 @@ import type { CardMessageContent } from 'https://cardstack.com/base/matrix-event
 
 import {
   testRealmURL,
-  setupCardLogs,
   setupIntegrationTestRealm,
   setupLocalIndexing,
   setupOnSave,
@@ -38,7 +33,6 @@ import { setupRenderingTest } from '../../../helpers/setup';
 
 module('Integration | ai-assistant-panel | debug-message', function (hooks) {
   const realmName = 'Debug Message Test Realm';
-  let loader: Loader;
   let operatorModeStateService: OperatorModeStateService;
 
   setupRenderingTest(hooks);
@@ -56,33 +50,25 @@ module('Integration | ai-assistant-panel | debug-message', function (hooks) {
 
   let { simulateRemoteMessage } = mockMatrixUtils;
 
-  let snapshot = setupSnapshotRealm<{ loader: Loader }>(hooks, {
+  let snapshot = setupSnapshotRealm(hooks, {
     mockMatrixUtils,
     async build({ loader }) {
-      let loaderService = getService('loader-service');
-      loaderService.loader = loader;
-      return { loader };
+      await setupIntegrationTestRealm({
+        mockMatrixUtils,
+        contents: {
+          '.realm.json': `{ "name": "${realmName}" }`,
+        },
+      });
+      return {};
     },
   });
 
   setupOnSave(hooks);
-  setupCardLogs(
-    hooks,
-    async () => await snapshot.get().loader.import(`${baseRealm.url}card-api`),
-  );
 
   hooks.beforeEach(async function () {
-    ({ loader } = snapshot.get());
     operatorModeStateService = this.owner.lookup(
       'service:operator-mode-state-service',
     ) as OperatorModeStateService;
-
-    await setupIntegrationTestRealm({
-      mockMatrixUtils,
-      contents: {
-        '.realm.json': `{ "name": "${realmName}" }`,
-      },
-    });
   });
 
   function setCardInOperatorModeState(

--- a/packages/host/tests/integration/components/ai-assistant-panel/debug-message-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/debug-message-test.gts
@@ -65,7 +65,6 @@ module('Integration | ai-assistant-panel | debug-message', function (hooks) {
     },
   });
 
-  setupLocalIndexing(hooks);
   setupOnSave(hooks);
   setupCardLogs(
     hooks,

--- a/packages/host/tests/integration/components/ai-assistant-panel/general-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/general-test.gts
@@ -15,9 +15,6 @@ import { format, subMinutes } from 'date-fns';
 
 import { module, test } from 'qunit';
 
-import { baseRealm } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
-
 import {
   APP_BOXEL_COMMAND_REQUESTS_KEY,
   APP_BOXEL_CONTINUATION_OF_CONTENT_KEY,
@@ -35,7 +32,6 @@ import type OperatorModeStateService from '@cardstack/host/services/operator-mod
 import {
   percySnapshot,
   testRealmURL,
-  setupCardLogs,
   setupIntegrationTestRealm,
   setupLocalIndexing,
   setupOnSave,
@@ -62,7 +58,6 @@ import { setupRenderingTest } from '../../../helpers/setup';
 
 module('Integration | ai-assistant-panel | general', function (hooks) {
   const realmName = 'Operator Mode Workspace';
-  let loader: Loader;
   let operatorModeStateService: OperatorModeStateService;
   let localPersistenceService: LocalPersistenceService;
 
@@ -93,22 +88,103 @@ module('Integration | ai-assistant-panel | general', function (hooks) {
     getRoomEvents,
   } = mockMatrixUtils;
 
-  let snapshot = setupSnapshotRealm<{ loader: Loader }>(hooks, {
+  let snapshot = setupSnapshotRealm(hooks, {
     mockMatrixUtils,
     async build({ loader }) {
-      let loaderService = getService('loader-service');
-      loaderService.loader = loader;
-      return { loader };
+      class Pet extends CardDef {
+        static displayName = 'Pet';
+        @field name = contains(StringField);
+        @field title = contains(StringField, {
+          computeVia: function (this: Pet) {
+            return this.name;
+          },
+        });
+        static fitted = class Fitted extends Component<typeof this> {
+          <template>
+            <h3 data-test-pet={{@model.name}}>
+              <@fields.name />
+            </h3>
+          </template>
+        };
+      }
+
+      class Address extends FieldDef {
+        static displayName = 'Address';
+        @field city = contains(StringField);
+        @field country = contains(StringField);
+        static embedded = class Embedded extends Component<typeof this> {
+          <template>
+            <div data-test-address>
+              <h3 data-test-city={{@model.city}}>
+                <@fields.city />
+              </h3>
+              <h3 data-test-country={{@model.country}}>
+                <@fields.country />
+              </h3>
+            </div>
+          </template>
+        };
+      }
+
+      class Person extends CardDef {
+        static displayName = 'Person';
+        @field firstName = contains(StringField);
+        @field pet = linksTo(Pet);
+        @field friends = linksToMany(Pet);
+        @field firstLetterOfTheName = contains(StringField, {
+          computeVia: function (this: Person) {
+            return this.firstName[0];
+          },
+        });
+        @field title = contains(StringField, {
+          computeVia: function (this: Person) {
+            return this.firstName;
+          },
+        });
+        @field address = contains(Address);
+        static isolated = class Isolated extends Component<typeof this> {
+          <template>
+            <h2 data-test-person={{@model.firstName}}>
+              <@fields.firstName />
+            </h2>
+            <p data-test-first-letter-of-the-name={{@model.firstLetterOfTheName}}>
+              <@fields.firstLetterOfTheName />
+            </p>
+            Pet:
+            <@fields.pet />
+            Friends:
+            <@fields.friends />
+            <div data-test-addresses>Address: <@fields.address /></div>
+          </template>
+        };
+      }
+
+      let petMango = new Pet({ name: 'Mango' });
+
+      await setupIntegrationTestRealm({
+        mockMatrixUtils,
+        contents: {
+          'pet.gts': { Pet },
+          'address.gts': { Address },
+          'person.gts': { Person },
+          'Pet/mango.json': petMango,
+          'Person/fadhlan.json': new Person({
+            firstName: 'Fadhlan',
+            address: new Address({
+              city: 'Bandung',
+              country: 'Indonesia',
+            }),
+            pet: petMango,
+          }),
+          'example-file.gts': `
+          @field name = contains(StringField);
+        `,
+          '.realm.json': `{ "name": "${realmName}" }`,
+        },
+      });
+
+      return {};
     },
-  });
-
-  setupCardLogs(
-    hooks,
-    async () => await snapshot.get().loader.import(`${baseRealm.url}card-api`),
-  );
-
-  hooks.beforeEach(function () {
-    ({ loader } = snapshot.get());
   });
 
   // Setup realm server endpoints for summarization tests
@@ -194,98 +270,6 @@ module('Integration | ai-assistant-panel | general', function (hooks) {
   hooks.beforeEach(async function () {
     operatorModeStateService = getService('operator-mode-state-service');
     localPersistenceService = getService('local-persistence-service');
-
-    class Pet extends CardDef {
-      static displayName = 'Pet';
-      @field name = contains(StringField);
-      @field title = contains(StringField, {
-        computeVia: function (this: Pet) {
-          return this.name;
-        },
-      });
-      static fitted = class Fitted extends Component<typeof this> {
-        <template>
-          <h3 data-test-pet={{@model.name}}>
-            <@fields.name />
-          </h3>
-        </template>
-      };
-    }
-
-    class Address extends FieldDef {
-      static displayName = 'Address';
-      @field city = contains(StringField);
-      @field country = contains(StringField);
-      static embedded = class Embedded extends Component<typeof this> {
-        <template>
-          <div data-test-address>
-            <h3 data-test-city={{@model.city}}>
-              <@fields.city />
-            </h3>
-            <h3 data-test-country={{@model.country}}>
-              <@fields.country />
-            </h3>
-          </div>
-        </template>
-      };
-    }
-
-    class Person extends CardDef {
-      static displayName = 'Person';
-      @field firstName = contains(StringField);
-      @field pet = linksTo(Pet);
-      @field friends = linksToMany(Pet);
-      @field firstLetterOfTheName = contains(StringField, {
-        computeVia: function (this: Person) {
-          return this.firstName[0];
-        },
-      });
-      @field title = contains(StringField, {
-        computeVia: function (this: Person) {
-          return this.firstName;
-        },
-      });
-      @field address = contains(Address);
-      static isolated = class Isolated extends Component<typeof this> {
-        <template>
-          <h2 data-test-person={{@model.firstName}}>
-            <@fields.firstName />
-          </h2>
-          <p data-test-first-letter-of-the-name={{@model.firstLetterOfTheName}}>
-            <@fields.firstLetterOfTheName />
-          </p>
-          Pet:
-          <@fields.pet />
-          Friends:
-          <@fields.friends />
-          <div data-test-addresses>Address: <@fields.address /></div>
-        </template>
-      };
-    }
-
-    let petMango = new Pet({ name: 'Mango' });
-
-    await setupIntegrationTestRealm({
-      mockMatrixUtils,
-      contents: {
-        'pet.gts': { Pet },
-        'address.gts': { Address },
-        'person.gts': { Person },
-        'Pet/mango.json': petMango,
-        'Person/fadhlan.json': new Person({
-          firstName: 'Fadhlan',
-          address: new Address({
-            city: 'Bandung',
-            country: 'Indonesia',
-          }),
-          pet: petMango,
-        }),
-        'example-file.gts': `
-          @field name = contains(StringField);
-        `,
-        '.realm.json': `{ "name": "${realmName}" }`,
-      },
-    });
   });
 
   function setCardInOperatorModeState(

--- a/packages/host/tests/integration/components/ai-assistant-panel/general-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/general-test.gts
@@ -69,7 +69,6 @@ module('Integration | ai-assistant-panel | general', function (hooks) {
   setupRenderingTest(hooks);
   setupOperatorModeStateCleanup(hooks);
 
-  setupLocalIndexing(hooks);
   setupOnSave(hooks);
   hooks.beforeEach(async function () {
     await setupRendering(false);

--- a/packages/host/tests/integration/components/ai-assistant-panel/past-sessions-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/past-sessions-test.gts
@@ -68,7 +68,6 @@ module('Integration | ai-assistant-panel | past sessions', function (hooks) {
     },
   });
 
-  setupLocalIndexing(hooks);
   setupOnSave(hooks);
   setupCardLogs(
     hooks,

--- a/packages/host/tests/integration/components/ai-assistant-panel/reasoning-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/reasoning-test.gts
@@ -66,7 +66,6 @@ module('Integration | ai-assistant-panel | reasoning', function (hooks) {
     },
   });
 
-  setupLocalIndexing(hooks);
   setupOnSave(hooks);
   setupCardLogs(
     hooks,

--- a/packages/host/tests/integration/components/ai-assistant-panel/scrolling-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/scrolling-test.gts
@@ -6,9 +6,6 @@ import { getService } from '@universal-ember/test-support';
 
 import { module, test } from 'qunit';
 
-import { baseRealm } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
-
 import { APP_BOXEL_MESSAGE_MSGTYPE } from '@cardstack/runtime-common/matrix-constants';
 
 import { BOTTOM_THRESHOLD } from '@cardstack/host/components/ai-assistant/message';
@@ -18,7 +15,6 @@ import type OperatorModeStateService from '@cardstack/host/services/operator-mod
 
 import {
   testRealmURL,
-  setupCardLogs,
   setupIntegrationTestRealm,
   setupLocalIndexing,
   setupOnSave,
@@ -38,7 +34,6 @@ import { setupRenderingTest } from '../../../helpers/setup';
 
 module('Integration | ai-assistant-panel | scrolling', function (hooks) {
   const realmName = 'Operator Mode Workspace';
-  let loader: Loader;
   let operatorModeStateService: OperatorModeStateService;
 
   setupRenderingTest(hooks);
@@ -59,62 +54,55 @@ module('Integration | ai-assistant-panel | scrolling', function (hooks) {
   let { createAndJoinRoom, simulateRemoteMessage, setReadReceipt } =
     mockMatrixUtils;
 
-  let snapshot = setupSnapshotRealm<{ loader: Loader }>(hooks, {
+  let snapshot = setupSnapshotRealm(hooks, {
     mockMatrixUtils,
     async build({ loader }) {
-      let loaderService = getService('loader-service');
-      loaderService.loader = loader;
-      return { loader };
+      class Person extends CardDef {
+        static displayName = 'Person';
+        @field firstName = contains(StringField);
+        @field firstLetterOfTheName = contains(StringField, {
+          computeVia: function (this: Person) {
+            return this.firstName[0];
+          },
+        });
+        @field title = contains(StringField, {
+          computeVia: function (this: Person) {
+            return this.firstName;
+          },
+        });
+        static isolated = class Isolated extends Component<typeof this> {
+          <template>
+            <h2 data-test-person={{@model.firstName}}>
+              <@fields.firstName />
+            </h2>
+            <p data-test-first-letter-of-the-name={{@model.firstLetterOfTheName}}>
+              <@fields.firstLetterOfTheName />
+            </p>
+          </template>
+        };
+      }
+
+      await setupIntegrationTestRealm({
+        mockMatrixUtils,
+        contents: {
+          'person.gts': { Person },
+          'Person/fadhlan.json': new Person({
+            firstName: 'Fadhlan',
+          }),
+          '.realm.json': `{ "name": "${realmName}" }`,
+        },
+      });
+
+      return {};
     },
   });
 
   setupOnSave(hooks);
-  setupCardLogs(
-    hooks,
-    async () => await snapshot.get().loader.import(`${baseRealm.url}card-api`),
-  );
 
   let noop = () => {};
 
   hooks.beforeEach(async function () {
-    ({ loader } = snapshot.get());
     operatorModeStateService = getService('operator-mode-state-service');
-
-    class Person extends CardDef {
-      static displayName = 'Person';
-      @field firstName = contains(StringField);
-      @field firstLetterOfTheName = contains(StringField, {
-        computeVia: function (this: Person) {
-          return this.firstName[0];
-        },
-      });
-      @field title = contains(StringField, {
-        computeVia: function (this: Person) {
-          return this.firstName;
-        },
-      });
-      static isolated = class Isolated extends Component<typeof this> {
-        <template>
-          <h2 data-test-person={{@model.firstName}}>
-            <@fields.firstName />
-          </h2>
-          <p data-test-first-letter-of-the-name={{@model.firstLetterOfTheName}}>
-            <@fields.firstLetterOfTheName />
-          </p>
-        </template>
-      };
-    }
-
-    await setupIntegrationTestRealm({
-      mockMatrixUtils,
-      contents: {
-        'person.gts': { Person },
-        'Person/fadhlan.json': new Person({
-          firstName: 'Fadhlan',
-        }),
-        '.realm.json': `{ "name": "${realmName}" }`,
-      },
-    });
   });
 
   function setCardInOperatorModeState(

--- a/packages/host/tests/integration/components/ai-assistant-panel/scrolling-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/scrolling-test.gts
@@ -68,7 +68,6 @@ module('Integration | ai-assistant-panel | scrolling', function (hooks) {
     },
   });
 
-  setupLocalIndexing(hooks);
   setupOnSave(hooks);
   setupCardLogs(
     hooks,

--- a/packages/host/tests/integration/components/ai-assistant-panel/sending-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/sending-test.gts
@@ -72,7 +72,6 @@ module('Integration | ai-assistant-panel | sending', function (hooks) {
     },
   });
 
-  setupLocalIndexing(hooks);
   setupOnSave(hooks);
   setupCardLogs(
     hooks,

--- a/packages/host/tests/integration/components/ai-assistant-panel/skills-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/skills-test.gts
@@ -83,7 +83,6 @@ module('Integration | ai-assistant-panel | skills', function (hooks) {
     },
   });
 
-  setupLocalIndexing(hooks);
   setupOnSave(hooks);
   setupCardLogs(
     hooks,

--- a/packages/host/tests/integration/components/ai-module-creation-test.gts
+++ b/packages/host/tests/integration/components/ai-module-creation-test.gts
@@ -71,7 +71,6 @@ module('Integration | create app module via ai-assistant', function (hooks) {
     this.owner.register('service:router', MockRouterService);
   });
 
-  setupLocalIndexing(hooks);
   setupCardLogs(
     hooks,
     async () => await snapshot.get().loader.import(`${baseRealm.url}card-api`),

--- a/packages/host/tests/integration/components/ask-ai-test.gts
+++ b/packages/host/tests/integration/components/ask-ai-test.gts
@@ -33,7 +33,6 @@ module('Integration | ask-ai', function (hooks) {
 
   setupRenderingTest(hooks);
   setupOperatorModeStateCleanup(hooks);
-  setupLocalIndexing(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs: '@testuser:localhost',

--- a/packages/host/tests/integration/components/card-api-test.gts
+++ b/packages/host/tests/integration/components/card-api-test.gts
@@ -70,7 +70,6 @@ class CardContextConsumer extends GlimmerComponent<CardContextConsumerSignature>
 
 module('Integration | card api (Usage of publicAPI actions)', function (hooks) {
   setupRenderingTest(hooks);
-  setupLocalIndexing(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks);
 

--- a/packages/host/tests/integration/components/card-catalog-test.gts
+++ b/packages/host/tests/integration/components/card-catalog-test.gts
@@ -31,7 +31,6 @@ const realmName = 'Local Workspace';
 module('Integration | card-catalog', function (hooks) {
   setupRenderingTest(hooks);
   setupOperatorModeStateCleanup(hooks);
-  setupLocalIndexing(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs: '@testuser:localhost',

--- a/packages/host/tests/integration/components/card-copy-test.gts
+++ b/packages/host/tests/integration/components/card-copy-test.gts
@@ -60,7 +60,6 @@ module('Integration | card-copy', function (hooks) {
 
   setupRenderingTest(hooks);
   setupOperatorModeStateCleanup(hooks);
-  setupLocalIndexing(hooks);
 
   let loggedInAs = '@testuser:localhost';
 

--- a/packages/host/tests/integration/components/card-def-field-def-relationships-test.gts
+++ b/packages/host/tests/integration/components/card-def-field-def-relationships-test.gts
@@ -53,7 +53,6 @@ module('Integration | CardDef-FieldDef relationships test', function (hooks) {
 
   setupRenderingTest(hooks);
   setupOperatorModeStateCleanup(hooks);
-  setupLocalIndexing(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs: '@testuser:localhost',

--- a/packages/host/tests/integration/components/card-delete-test.gts
+++ b/packages/host/tests/integration/components/card-delete-test.gts
@@ -78,7 +78,7 @@ module('Integration | card-delete', function (hooks) {
     return card;
   }
   setupRenderingTest(hooks);
-  setupLocalIndexing(hooks);
+
   setupOperatorModeStateCleanup(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {

--- a/packages/host/tests/integration/components/computed-test.gts
+++ b/packages/host/tests/integration/components/computed-test.gts
@@ -59,7 +59,6 @@ module('Integration | computeds', function (hooks) {
 
     ({ loader } = snapshot.get());
   });
-  setupLocalIndexing(hooks);
 
   setupCardLogs(
     hooks,

--- a/packages/host/tests/integration/components/loading-test.gts
+++ b/packages/host/tests/integration/components/loading-test.gts
@@ -25,7 +25,6 @@ module('Integration | loading', function (hooks) {
   let loader: Loader;
   let cardApi: typeof import('https://cardstack.com/base/card-api');
 
-  setupLocalIndexing(hooks);
   setupOnSave(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -73,8 +73,6 @@ module('Integration | operator-mode', function (hooks) {
   let testRealmAdapter: TestRealmAdapter;
   let operatorModeStateService: OperatorModeStateService;
 
-  setupLocalIndexing(hooks);
-  setupOnSave(hooks);
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs: '@testuser:localhost',
     activeRealms: [testRealmURL],

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -79,6 +79,8 @@ module('Integration | operator-mode', function (hooks) {
     autostart: true,
   });
 
+  setupOnSave(hooks);
+
   let snapshot = setupSnapshotRealm<{ loader: Loader }>(hooks, {
     mockMatrixUtils,
     async build({ loader }) {

--- a/packages/host/tests/integration/components/prerendered-card-search-test.gts
+++ b/packages/host/tests/integration/components/prerendered-card-search-test.gts
@@ -70,7 +70,6 @@ module(`Integration | prerendered-card-search`, function (hooks) {
   let testRealm: Realm;
 
   setupRenderingTest(hooks);
-  setupLocalIndexing(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs: '@testuser:localhost',

--- a/packages/host/tests/integration/components/serialization-test.gts
+++ b/packages/host/tests/integration/components/serialization-test.gts
@@ -88,8 +88,6 @@ module('Integration | serialization', function (hooks) {
     ({ loader } = snapshot.get());
   });
 
-  setupLocalIndexing(hooks);
-
   setupCardLogs(
     hooks,
     async () => await snapshot.get().loader.import(`${baseRealm.url}card-api`),

--- a/packages/host/tests/integration/components/text-input-validator-test.gts
+++ b/packages/host/tests/integration/components/text-input-validator-test.gts
@@ -34,7 +34,7 @@ module('Integration | text-input-validator', function (hooks) {
   let realm: Realm;
   setupRenderingTest(hooks);
   setupOperatorModeStateCleanup(hooks);
-  setupLocalIndexing(hooks);
+
   setupOnSave(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {

--- a/packages/host/tests/integration/components/text-suggestion-test.gts
+++ b/packages/host/tests/integration/components/text-suggestion-test.gts
@@ -23,7 +23,6 @@ let loader: Loader;
 
 module('Integration | text-suggestion | card-chooser-title', function (hooks) {
   setupRenderingTest(hooks);
-  setupLocalIndexing(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks);
 

--- a/packages/host/tests/integration/field-configuration-test.gts
+++ b/packages/host/tests/integration/field-configuration-test.gts
@@ -134,7 +134,6 @@ function buildThemeDocument(palette: string): SingleCardDocument {
 module('Integration | field configuration', function (hooks) {
   setupRenderingTest(hooks);
 
-  setupLocalIndexing(hooks);
   let mockMatrixUtils = setupMockMatrix(hooks);
 
   let snapshot = setupSnapshotRealm<{ loader: Loader }>(hooks, {

--- a/packages/host/tests/integration/message-service-subscription-test.gts
+++ b/packages/host/tests/integration/message-service-subscription-test.gts
@@ -34,7 +34,6 @@ let loader: Loader;
 module('Integration | message service subscription', function (hooks) {
   setupRenderingTest(hooks);
 
-  setupLocalIndexing(hooks);
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs: '@testuser:localhost',
     activeRealms: [testRealmURL],

--- a/packages/host/tests/integration/realm-indexing-test.gts
+++ b/packages/host/tests/integration/realm-indexing-test.gts
@@ -105,8 +105,6 @@ module(`Integration | realm indexing`, function (hooks) {
     window.removeEventListener('boxel-render-error', onError);
   });
 
-  setupLocalIndexing(hooks);
-
   setupCardLogs(
     hooks,
     async () => await snapshot.get().loader.import(`${baseRealm.url}card-api`),

--- a/packages/host/tests/integration/realm-querying-test.gts
+++ b/packages/host/tests/integration/realm-querying-test.gts
@@ -24,7 +24,6 @@ const paths = new RealmPaths(new URL(testRealmURL));
 module(`Integration | realm querying`, function (hooks) {
   setupRenderingTest(hooks);
 
-  setupLocalIndexing(hooks);
   let mockMatrixUtils = setupMockMatrix(hooks);
 
   const sampleCards: CardDocFiles = {

--- a/packages/host/tests/integration/realm-test.gts
+++ b/packages/host/tests/integration/realm-test.gts
@@ -60,7 +60,6 @@ module('Integration | realm', function (hooks) {
     },
   });
 
-  setupLocalIndexing(hooks);
   setupCardLogs(
     hooks,
     async () => await snapshot.get().loader.import(`${baseRealm.url}card-api`),

--- a/packages/host/tests/integration/resources/search-test.ts
+++ b/packages/host/tests/integration/resources/search-test.ts
@@ -50,7 +50,6 @@ function getSearchResourceForTest(
 
 module(`Integration | search resource`, function (hooks) {
   setupRenderingTest(hooks);
-  setupLocalIndexing(hooks);
 
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs: '@testuser:localhost',

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -1,9 +1,4 @@
-import {
-  waitUntil,
-  waitFor,
-  click,
-  typeIn,
-} from '@ember/test-helpers';
+import { waitUntil, waitFor, click, typeIn } from '@ember/test-helpers';
 
 import GlimmerComponent from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
@@ -70,7 +65,6 @@ module('Integration | Store', function (hooks) {
   let BoomPersonDef: typeof CardDefType;
   let realmService: RealmService;
 
-  setupLocalIndexing(hooks);
   setupOnSave(hooks);
   setupCardLogs(
     hooks,

--- a/packages/runtime-common/loader.ts
+++ b/packages/runtime-common/loader.ts
@@ -119,7 +119,7 @@ export class Loader {
 
   static cloneLoader(
     loader: Loader,
-    options?: { includeEvaluatedModules?: boolean },
+    options?: { includeEvaluatedModules?: string },
   ): Loader {
     let clone = new Loader(loader.fetchImplementation, loader.resolveImport);
     for (let [moduleIdentifier, module] of loader.moduleShims) {
@@ -130,7 +130,10 @@ export class Loader {
         if (loader.moduleShims.has(moduleIdentifier)) {
           continue;
         }
-        if (module.state === 'evaluated') {
+        if (
+          module.state === 'evaluated' &&
+          moduleIdentifier.match(options.includeEvaluatedModules)
+        ) {
           clone.shimModule(
             moduleIdentifier,
             module.moduleInstance as Record<string, any>,


### PR DESCRIPTION
Several things seem to be really hitting the host test performance locally:

1. Loading modules (particularly card-api which can cost ~500ms per simple test)
2. Creating test realms
3. Creating matrix things

Here I've added two major things:

1. Snapshotting state (database, matrix, loader) after creating realms
2. Not reloading the base realm items again and again

The snapshots are purely in memory, so there is no caching to manage between test runs. The concept is that the first test run creates the realm/etc in the beforeeach, and this is then snapshotted and restored for all following tests that use the same beforeeach.