### PR TITLE
Apply consistent-type-imports rule

### DIFF
--- a/packages/host/.eslintrc.js
+++ b/packages/host/.eslintrc.js
@@ -2,6 +2,58 @@
 
 const MISSING_INVOKABLES_CONFIG = require('../runtime-common/etc/eslint/missing-invokables-config');
 
+// Applies to all of JS, TS, GJS, and GTS in the browser context.
+const sharedBrowserConfig = {
+  plugins: [
+    'ember',
+    '@typescript-eslint',
+    'cardstack-host',
+    '@cardstack/boxel',
+  ],
+  extends: [
+    'eslint:recommended',
+    'plugin:ember/recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:ember/recommended-gts',
+    'plugin:prettier/recommended',
+    'plugin:qunit-dom/recommended',
+    'plugin:@cardstack/boxel/recommended',
+  ],
+  rules: {
+    '@typescript-eslint/consistent-type-imports': [
+      'error',
+      {
+        disallowTypeAnnotations: false,
+      },
+    ],
+    '@typescript-eslint/no-import-type-side-effects': 'error',
+    '@typescript-eslint/no-empty-function': 'off',
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+    ],
+    'prefer-const': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/ban-types': 'off',
+    '@typescript-eslint/ban-ts-comment': 'off',
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/no-this-alias': 'off',
+    '@typescript-eslint/no-non-null-assertion': 'off',
+    'no-undef': 'off',
+    'ember/no-runloop': 'off',
+    'cardstack-host/mock-window-only': 'error',
+    'cardstack-host/wrapped-setup-helpers-only': 'error',
+    'cardstack-host/host-commands-registered': 'error',
+    'ember/template-no-let-reference': 'off',
+    'ember/no-tracked-properties-from-args': 'off',
+    'node/no-deprecated-api': 'off',
+    '@cardstack/boxel/template-missing-invokable': [
+      'error',
+      { invokables: MISSING_INVOKABLES_CONFIG.invokables },
+    ],
+  },
+};
+
 module.exports = {
   root: true,
   env: {
@@ -23,41 +75,9 @@ module.exports = {
             ],
           ],
         },
+        warnOnUnsupportedTypeScriptVersion: false,
       },
-      plugins: ['ember', '@typescript-eslint', 'cardstack-host'],
-      extends: [
-        'eslint:recommended',
-        'plugin:ember/recommended',
-        'plugin:@typescript-eslint/recommended',
-        'plugin:prettier/recommended',
-        'plugin:qunit-dom/recommended',
-      ],
-      rules: {
-        '@typescript-eslint/consistent-type-imports': [
-          'error',
-          {
-            disallowTypeAnnotations: false,
-          },
-        ],
-        '@typescript-eslint/no-import-type-side-effects': 'error',
-        '@typescript-eslint/no-empty-function': 'off',
-        '@typescript-eslint/no-unused-vars': [
-          'error',
-          { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
-        ],
-        'prefer-const': 'off',
-        '@typescript-eslint/no-explicit-any': 'off',
-        '@typescript-eslint/ban-types': 'off',
-        '@typescript-eslint/ban-ts-comment': 'off',
-        '@typescript-eslint/explicit-module-boundary-types': 'off',
-        '@typescript-eslint/no-this-alias': 'off',
-        '@typescript-eslint/no-non-null-assertion': 'off',
-        'no-undef': 'off',
-        'ember/no-runloop': 'off',
-        'cardstack-host/mock-window-only': 'error',
-        'cardstack-host/wrapped-setup-helpers-only': 'error',
-        'cardstack-host/host-commands-registered': 'error',
-      },
+      ...sharedBrowserConfig,
     },
     {
       files: ['**/*.gts'],
@@ -76,41 +96,7 @@ module.exports = {
         },
         warnOnUnsupportedTypeScriptVersion: false,
       },
-      plugins: ['ember', 'cardstack-host', '@cardstack/boxel'],
-      extends: [
-        'eslint:recommended',
-        'plugin:@typescript-eslint/recommended',
-        'plugin:ember/recommended',
-        'plugin:ember/recommended-gts',
-        'plugin:prettier/recommended',
-        'plugin:qunit-dom/recommended',
-        'plugin:@cardstack/boxel/recommended',
-      ],
-      rules: {
-        '@typescript-eslint/no-empty-function': 'off',
-        '@typescript-eslint/no-unused-vars': [
-          'error',
-          { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
-        ],
-        'prefer-const': 'off',
-        '@typescript-eslint/no-explicit-any': 'off',
-        '@typescript-eslint/ban-types': 'off',
-        '@typescript-eslint/ban-ts-comment': 'off',
-        '@typescript-eslint/explicit-module-boundary-types': 'off',
-        '@typescript-eslint/no-this-alias': 'off',
-        '@typescript-eslint/no-non-null-assertion': 'off',
-        'no-undef': 'off',
-        'ember/template-no-let-reference': 'off',
-        'ember/no-tracked-properties-from-args': 'off',
-        'ember/no-runloop': 'off',
-        'node/no-deprecated-api': 'off',
-        'cardstack-host/mock-window-only': 'error',
-        'cardstack-host/wrapped-setup-helpers-only': 'error',
-        '@cardstack/boxel/template-missing-invokable': [
-          'error',
-          { invokables: MISSING_INVOKABLES_CONFIG.invokables },
-        ],
-      },
+      ...sharedBrowserConfig,
     },
     // node files
     {

--- a/packages/host/app/components/ai-assistant/attached-file-dropdown-menu.gts
+++ b/packages/host/app/components/ai-assistant/attached-file-dropdown-menu.gts
@@ -25,13 +25,13 @@ import { IconCode } from '@cardstack/boxel-ui/icons';
 import { hasExecutableExtension } from '@cardstack/runtime-common';
 
 import RestorePatchedFileModal from '@cardstack/host/components/ai-assistant/restore-file-modal';
-import CardService from '@cardstack/host/services/card-service';
-import MatrixService from '@cardstack/host/services/matrix-service';
-import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
+import type CardService from '@cardstack/host/services/card-service';
+import type MatrixService from '@cardstack/host/services/matrix-service';
+import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
-import { type FileDef } from 'https://cardstack.com/base/file-api';
+import type { FileDef } from 'https://cardstack.com/base/file-api';
 
-import { CodePatchStatus } from 'https://cardstack.com/base/matrix-event';
+import type { CodePatchStatus } from 'https://cardstack.com/base/matrix-event';
 
 import { Submodes } from '../submode-switcher';
 

--- a/packages/host/app/components/ai-assistant/attachment-picker/attach-button.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/attach-button.gts
@@ -1,4 +1,4 @@
-import { TemplateOnlyComponent } from '@ember/component/template-only';
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 
@@ -12,7 +12,7 @@ import { eq } from '@cardstack/boxel-ui/helpers';
 
 import { chooseCard, baseCardRef, chooseFile } from '@cardstack/runtime-common';
 
-import { type FileDef } from 'https://cardstack.com/base/file-api';
+import type { FileDef } from 'https://cardstack.com/base/file-api';
 
 interface AttachButtonTriggerSignature {
   Element: HTMLButtonElement;

--- a/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
@@ -5,15 +5,13 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
-import { TrackedSet } from 'tracked-built-ins';
-
 import { Tooltip, Pill } from '@cardstack/boxel-ui/components';
 import { and, gt, not } from '@cardstack/boxel-ui/helpers';
 
+import type { CardErrorJSONAPI } from '@cardstack/runtime-common';
 import {
   localId,
   isCardInstance,
-  CardErrorJSONAPI,
   isCardErrorJSONAPI,
 } from '@cardstack/runtime-common';
 
@@ -21,10 +19,12 @@ import CardPill from '@cardstack/host/components/card-pill';
 import FilePill from '@cardstack/host/components/file-pill';
 import { urlForRealmLookup } from '@cardstack/host/lib/utils';
 
-import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
+import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 import type { FileDef } from 'https://cardstack.com/base/file-api';
+
+import type { TrackedSet } from 'tracked-built-ins';
 
 const MAX_ITEMS_TO_DISPLAY = 4;
 

--- a/packages/host/app/components/ai-assistant/attachment-picker/index.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/index.gts
@@ -3,8 +3,6 @@ import { tracked } from '@glimmer/tracking';
 
 import { consume } from 'ember-provide-consume-context';
 
-import { TrackedSet } from 'tracked-built-ins';
-
 import {
   GetCardCollectionContextName,
   type getCardCollection,
@@ -12,12 +10,13 @@ import {
 
 import consumeContext from '@cardstack/host/helpers/consume-context';
 
-import { type FileDef } from 'https://cardstack.com/base/file-api';
+import type { FileDef } from 'https://cardstack.com/base/file-api';
 
 import AttachButton from './attach-button';
 import AttachedItems from './attached-items';
 
 import type { WithBoundArgs } from '@glint/template';
+import type { TrackedSet } from 'tracked-built-ins';
 
 interface Signature {
   Element: HTMLDivElement;

--- a/packages/host/app/components/ai-assistant/attachment-picker/usage.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/usage.gts
@@ -10,7 +10,7 @@ import { TrackedSet } from 'tracked-built-ins';
 
 import CardCatalogModal from '@cardstack/host/components/card-catalog/modal';
 
-import { type FileDef } from 'https://cardstack.com/base/file-api';
+import type { FileDef } from 'https://cardstack.com/base/file-api';
 
 import AiAssistantAttachmentPicker from './index';
 

--- a/packages/host/app/components/ai-assistant/chat-input/index.gts
+++ b/packages/host/app/components/ai-assistant/chat-input/index.gts
@@ -9,7 +9,7 @@ import { IconButton } from '@cardstack/boxel-ui/components';
 import { not, pick } from '@cardstack/boxel-ui/helpers';
 import { ArrowUp } from '@cardstack/boxel-ui/icons';
 
-import AttachButton from '../attachment-picker/attach-button';
+import type AttachButton from '../attachment-picker/attach-button';
 
 import type { WithBoundArgs } from '@glint/template';
 

--- a/packages/host/app/components/ai-assistant/code-block/diff-editor-header.gts
+++ b/packages/host/app/components/ai-assistant/code-block/diff-editor-header.gts
@@ -6,15 +6,15 @@ import { bool } from '@cardstack/boxel-ui/helpers';
 
 import type { CodeData } from '@cardstack/host/lib/formatted-message/utils';
 
-import { type Message as MatrixMessage } from '@cardstack/host/lib/matrix-classes/message';
-import CardService from '@cardstack/host/services/card-service';
+import type { Message as MatrixMessage } from '@cardstack/host/lib/matrix-classes/message';
+import type CardService from '@cardstack/host/services/card-service';
 
-import MatrixService from '@cardstack/host/services/matrix-service';
+import type MatrixService from '@cardstack/host/services/matrix-service';
 
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
-import { type FileDef } from 'https://cardstack.com/base/file-api';
-import { CodePatchStatus } from 'https://cardstack.com/base/matrix-event';
+import type { FileDef } from 'https://cardstack.com/base/file-api';
+import type { CodePatchStatus } from 'https://cardstack.com/base/matrix-event';
 
 import AttachedFileDropdownMenu from '../attached-file-dropdown-menu';
 

--- a/packages/host/app/components/ai-assistant/code-block/index.gts
+++ b/packages/host/app/components/ai-assistant/code-block/index.gts
@@ -6,8 +6,8 @@ import { tracked } from '@glimmer/tracking';
 
 import type { CodeData } from '@cardstack/host/lib/formatted-message/utils';
 
-import { type Message as MatrixMessage } from '@cardstack/host/lib/matrix-classes/message';
-import { MonacoEditorOptions } from '@cardstack/host/modifiers/monaco';
+import type { Message as MatrixMessage } from '@cardstack/host/lib/matrix-classes/message';
+import type { MonacoEditorOptions } from '@cardstack/host/modifiers/monaco';
 import MonacoDiffEditor from '@cardstack/host/modifiers/monaco-diff-editor';
 import MonacoEditor, {
   commonEditorOptions,

--- a/packages/host/app/components/ai-assistant/focus-pill/index.gts
+++ b/packages/host/app/components/ai-assistant/focus-pill/index.gts
@@ -1,4 +1,4 @@
-import { TemplateOnlyComponent } from '@ember/component/template-only';
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
 import SquareDashedMousePointer from '@cardstack/boxel-icons/square-dashed-mouse-pointer';
 

--- a/packages/host/app/components/ai-assistant/message/aibot-message.gts
+++ b/packages/host/app/components/ai-assistant/message/aibot-message.gts
@@ -14,14 +14,16 @@ import CodeBlock from '@cardstack/host/components/ai-assistant/code-block';
 
 import { sanitizedHtml } from '@cardstack/host/helpers/sanitized-html';
 
-import {
-  type HtmlTagGroup,
-  wrapLastTextNodeInStreamingTextSpan,
+import type {
   HtmlPreTagGroup,
   CodeData,
 } from '@cardstack/host/lib/formatted-message/utils';
+import {
+  type HtmlTagGroup,
+  wrapLastTextNodeInStreamingTextSpan,
+} from '@cardstack/host/lib/formatted-message/utils';
 
-import { type Message as MatrixMessage } from '@cardstack/host/lib/matrix-classes/message';
+import type { Message as MatrixMessage } from '@cardstack/host/lib/matrix-classes/message';
 import type MessageCodePatchResult from '@cardstack/host/lib/matrix-classes/message-code-patch-result';
 
 import { parseSearchReplace } from '@cardstack/host/lib/search-replace-block-parsing';
@@ -31,10 +33,10 @@ import {
   getCodeDiffResultResource,
 } from '@cardstack/host/resources/code-diff';
 
-import CommandService from '@cardstack/host/services/command-service';
-import { type MonacoSDK } from '@cardstack/host/services/monaco-service';
+import type CommandService from '@cardstack/host/services/command-service';
+import type { MonacoSDK } from '@cardstack/host/services/monaco-service';
 
-import { CodePatchStatus } from 'https://cardstack.com/base/matrix-event';
+import type { CodePatchStatus } from 'https://cardstack.com/base/matrix-event';
 
 import Message from './text-content';
 

--- a/packages/host/app/components/ai-assistant/message/attachments.gts
+++ b/packages/host/app/components/ai-assistant/message/attachments.gts
@@ -1,6 +1,6 @@
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
-import { type getCardCollection } from '@cardstack/runtime-common';
+import type { getCardCollection } from '@cardstack/runtime-common';
 
 import CardPill from '@cardstack/host/components/card-pill';
 import FilePill from '@cardstack/host/components/file-pill';

--- a/packages/host/app/components/ai-assistant/message/index.gts
+++ b/packages/host/app/components/ai-assistant/message/index.gts
@@ -17,15 +17,15 @@ import {
   type getCardCollection,
 } from '@cardstack/runtime-common';
 
-import { type HtmlTagGroup } from '@cardstack/host/lib/formatted-message/utils';
-import { type Message } from '@cardstack/host/lib/matrix-classes/message';
+import type { HtmlTagGroup } from '@cardstack/host/lib/formatted-message/utils';
+import type { Message } from '@cardstack/host/lib/matrix-classes/message';
 import type MessageCommand from '@cardstack/host/lib/matrix-classes/message-command';
 import type BillingService from '@cardstack/host/services/billing-service';
 import type MatrixService from '@cardstack/host/services/matrix-service';
-import { type MonacoSDK } from '@cardstack/host/services/monaco-service';
+import type { MonacoSDK } from '@cardstack/host/services/monaco-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
-import { type FileDef } from 'https://cardstack.com/base/file-api';
+import type { FileDef } from 'https://cardstack.com/base/file-api';
 
 import AiBotMessage from './aibot-message';
 import Attachments from './attachments';

--- a/packages/host/app/components/ai-assistant/message/usage.gts
+++ b/packages/host/app/components/ai-assistant/message/usage.gts
@@ -8,7 +8,7 @@ import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
 
 import { Avatar } from '@cardstack/boxel-ui/components';
 
-import { type MonacoSDK } from '@cardstack/host/services/monaco-service';
+import type { MonacoSDK } from '@cardstack/host/services/monaco-service';
 
 import AiAssistantMessage, { AiAssistantConversation } from './index';
 export default class AiAssistantMessageUsage extends Component {

--- a/packages/host/app/components/ai-assistant/panel.gts
+++ b/packages/host/app/components/ai-assistant/panel.gts
@@ -10,20 +10,20 @@ import HistoryIcon from '@cardstack/boxel-icons/history';
 import { restartableTask } from 'ember-concurrency';
 import { Velcro } from 'ember-velcro';
 
+import type { ResizeHandle } from '@cardstack/boxel-ui/components';
 import {
   ContextButton,
   LoadingIndicator,
-  ResizeHandle,
 } from '@cardstack/boxel-ui/components';
 import { not } from '@cardstack/boxel-ui/helpers';
 
-import { ResolvedCodeRef, aiBotUsername } from '@cardstack/runtime-common';
+import type { ResolvedCodeRef } from '@cardstack/runtime-common';
+import { aiBotUsername } from '@cardstack/runtime-common';
 
 import ENV from '@cardstack/host/config/environment';
 
-import AiAssistantPanelService from '@cardstack/host/services/ai-assistant-panel-service';
+import type AiAssistantPanelService from '@cardstack/host/services/ai-assistant-panel-service';
 
-import { type MonacoSDK } from '../../services/monaco-service';
 import NewSession from '../ai-assistant/new-session';
 
 import AiAssistantPastSessionsList from '../ai-assistant/past-sessions';
@@ -35,6 +35,7 @@ import assistantIcon from './ai-assist-icon.webp';
 import NewSessionButton from './new-session-button';
 
 import type MatrixService from '../../services/matrix-service';
+import type { MonacoSDK } from '../../services/monaco-service';
 import type MonacoService from '../../services/monaco-service';
 
 const { matrixServerName } = ENV;

--- a/packages/host/app/components/ai-assistant/past-session-item.gts
+++ b/packages/host/app/components/ai-assistant/past-session-item.gts
@@ -24,7 +24,7 @@ import {
   Copy as CopyIcon,
 } from '@cardstack/boxel-ui/icons';
 
-import { SessionRoomData } from '@cardstack/host/services/ai-assistant-panel-service';
+import type { SessionRoomData } from '@cardstack/host/services/ai-assistant-panel-service';
 import type MatrixService from '@cardstack/host/services/matrix-service';
 
 export type RoomActions = {

--- a/packages/host/app/components/ai-assistant/past-sessions.gts
+++ b/packages/host/app/components/ai-assistant/past-sessions.gts
@@ -6,10 +6,10 @@ import { modifier } from 'ember-modifier';
 import { LoadingIndicator } from '@cardstack/boxel-ui/components';
 import { eq } from '@cardstack/boxel-ui/helpers';
 
-import { SessionRoomData } from '../../services/ai-assistant-panel-service';
-
 import AiAssistantPanelPopover from './panel-popover';
 import PastSessionItem, { type RoomActions } from './past-session-item';
+
+import type { SessionRoomData } from '../../services/ai-assistant-panel-service';
 
 import type MatrixService from '../../services/matrix-service';
 

--- a/packages/host/app/components/ai-assistant/rename-session.gts
+++ b/packages/host/app/components/ai-assistant/rename-session.gts
@@ -10,7 +10,7 @@ import onKeyMod from 'ember-keyboard/modifiers/on-key';
 import { BoxelInput, Button } from '@cardstack/boxel-ui/components';
 
 import { isMatrixError } from '@cardstack/host/lib/matrix-utils';
-import { SessionRoomData } from '@cardstack/host/services/ai-assistant-panel-service';
+import type { SessionRoomData } from '@cardstack/host/services/ai-assistant-panel-service';
 import type MatrixService from '@cardstack/host/services/matrix-service';
 
 import AiAssistantPanelPopover from './panel-popover';

--- a/packages/host/app/components/ai-assistant/skill-menu/index.gts
+++ b/packages/host/app/components/ai-assistant/skill-menu/index.gts
@@ -17,7 +17,7 @@ import { chooseCard } from '@cardstack/runtime-common';
 import SkillToggle from '@cardstack/host/components/ai-assistant/skill-menu/skill-toggle';
 import PillMenu from '@cardstack/host/components/pill-menu';
 
-import { RoomSkill } from '@cardstack/host/resources/room';
+import type { RoomSkill } from '@cardstack/host/resources/room';
 
 interface Signature {
   Element: HTMLDivElement | HTMLButtonElement;

--- a/packages/host/app/components/ai-assistant/skill-menu/skill-toggle.gts
+++ b/packages/host/app/components/ai-assistant/skill-menu/skill-toggle.gts
@@ -16,7 +16,7 @@ import { type getCard, GetCardContextName } from '@cardstack/runtime-common';
 
 import consumeContext from '@cardstack/host/helpers/consume-context';
 
-import RealmService from '@cardstack/host/services/realm';
+import type RealmService from '@cardstack/host/services/realm';
 
 interface SkillToggleSignature {
   Element: HTMLDivElement | HTMLButtonElement;

--- a/packages/host/app/components/ai-assistant/toast.gts
+++ b/packages/host/app/components/ai-assistant/toast.gts
@@ -16,9 +16,9 @@ import { IconX } from '@cardstack/boxel-ui/icons';
 
 import { markdownToHtml } from '@cardstack/runtime-common';
 
-import { Message } from '@cardstack/host/lib/matrix-classes/message';
-import LocalPersistenceService from '@cardstack/host/services/local-persistence-service';
-import MatrixService from '@cardstack/host/services/matrix-service';
+import type { Message } from '@cardstack/host/lib/matrix-classes/message';
+import type LocalPersistenceService from '@cardstack/host/services/local-persistence-service';
+import type MatrixService from '@cardstack/host/services/matrix-service';
 
 import assistantIcon from './ai-assist-icon.webp';
 

--- a/packages/host/app/components/card-catalog/filters.gts
+++ b/packages/host/app/components/card-catalog/filters.gts
@@ -4,7 +4,7 @@ import { BoxelDropdown, Button, Menu } from '@cardstack/boxel-ui/components';
 import { MenuItem } from '@cardstack/boxel-ui/helpers';
 import { DropdownArrowDown } from '@cardstack/boxel-ui/icons';
 
-import { RealmInfo } from '@cardstack/runtime-common';
+import type { RealmInfo } from '@cardstack/runtime-common';
 
 interface Signature {
   availableRealms: Record<string, RealmInfo> | undefined;

--- a/packages/host/app/components/card-catalog/index.gts
+++ b/packages/host/app/components/card-catalog/index.gts
@@ -1,4 +1,4 @@
-import { TemplateOnlyComponent } from '@ember/component/template-only';
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';

--- a/packages/host/app/components/card-catalog/modal.gts
+++ b/packages/host/app/components/card-catalog/modal.gts
@@ -16,14 +16,16 @@ import { TrackedArray, TrackedObject } from 'tracked-built-ins';
 import { Button, BoxelInput } from '@cardstack/boxel-ui/components';
 import { eq, not } from '@cardstack/boxel-ui/helpers';
 
+import type {
+  Loader,
+  RealmInfo,
+  CardCatalogQuery,
+} from '@cardstack/runtime-common';
 import {
   type CodeRef,
   type CreateNewCard,
   baseRealm,
   Deferred,
-  Loader,
-  RealmInfo,
-  CardCatalogQuery,
   isCardInstance,
 } from '@cardstack/runtime-common';
 

--- a/packages/host/app/components/card-pill.gts
+++ b/packages/host/app/components/card-pill.gts
@@ -22,9 +22,9 @@ import consumeContext from '@cardstack/host/helpers/consume-context';
 
 import type { FileDef } from 'https://cardstack.com/base/file-api';
 
-import RealmService from '../services/realm';
-
 import AttachedFileDropdownMenu from './ai-assistant/attached-file-dropdown-menu';
+
+import type RealmService from '../services/realm';
 
 interface CardPillSignature {
   Element: HTMLDivElement | HTMLButtonElement;

--- a/packages/host/app/components/card-prerender.gts
+++ b/packages/host/app/components/card-prerender.gts
@@ -4,7 +4,7 @@ import type {
   RouteInfo,
   RouteInfoWithAttributes,
 } from '@ember/routing/-internals';
-import RouterService from '@ember/routing/router-service';
+import type RouterService from '@ember/routing/router-service';
 import { service } from '@ember/service';
 
 import { isTesting } from '@embroider/macros';

--- a/packages/host/app/components/card-renderer.gts
+++ b/packages/host/app/components/card-renderer.gts
@@ -6,6 +6,7 @@ import { provide, consume } from 'ember-provide-consume-context';
 
 import { eq } from '@cardstack/boxel-ui/helpers';
 
+import type { ResolvedCodeRef } from '@cardstack/runtime-common';
 import {
   CardContextName,
   DefaultFormatsContextName,
@@ -13,7 +14,6 @@ import {
   GetCardContextName,
   GetCardsContextName,
   GetCardCollectionContextName,
-  ResolvedCodeRef,
   type getCard,
   type getCards,
   type getCardCollection,

--- a/packages/host/app/components/editor/directory.gts
+++ b/packages/host/app/components/editor/directory.gts
@@ -11,7 +11,7 @@ import { eq } from '@cardstack/boxel-ui/helpers';
 
 import { DropdownArrowDown } from '@cardstack/boxel-ui/icons';
 
-import { type LocalPath } from '@cardstack/runtime-common/paths';
+import type { LocalPath } from '@cardstack/runtime-common/paths';
 
 import scrollIntoViewModifier from '@cardstack/host/modifiers/scroll-into-view';
 import { directory } from '@cardstack/host/resources/directory';

--- a/packages/host/app/components/editor/file-tree.gts
+++ b/packages/host/app/components/editor/file-tree.gts
@@ -5,7 +5,7 @@ import { tracked } from '@glimmer/tracking';
 
 import { restartableTask, timeout } from 'ember-concurrency';
 
-import { type LocalPath } from '@cardstack/runtime-common';
+import type { LocalPath } from '@cardstack/runtime-common';
 
 import Directory from './directory';
 

--- a/packages/host/app/components/editor/import-module.gts
+++ b/packages/host/app/components/editor/import-module.gts
@@ -2,7 +2,7 @@ import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 import { importResource } from '@cardstack/host/resources/import';
-import LoaderService from '@cardstack/host/services/loader-service';
+import type LoaderService from '@cardstack/host/services/loader-service';
 
 export interface Signature {
   Args: { url: string };

--- a/packages/host/app/components/editor/recent-files.gts
+++ b/packages/host/app/components/editor/recent-files.gts
@@ -7,8 +7,8 @@ import { RealmIcon } from '@cardstack/boxel-ui/components';
 
 import { RealmPaths } from '@cardstack/runtime-common';
 
-import RealmService from '@cardstack/host/services/realm';
-import { RecentFile } from '@cardstack/host/services/recent-files-service';
+import type RealmService from '@cardstack/host/services/realm';
+import type { RecentFile } from '@cardstack/host/services/recent-files-service';
 
 import WithLoadedRealm from '../with-loaded-realm';
 

--- a/packages/host/app/components/file-pill.gts
+++ b/packages/host/app/components/file-pill.gts
@@ -10,11 +10,11 @@ import { IconButton, Pill } from '@cardstack/boxel-ui/components';
 import { cn, cssVar } from '@cardstack/boxel-ui/helpers';
 import { IconX, Download } from '@cardstack/boxel-ui/icons';
 
-import { type FileDef } from 'https://cardstack.com/base/file-api';
-
-import OperatorModeStateService from '../services/operator-mode-state-service';
+import type { FileDef } from 'https://cardstack.com/base/file-api';
 
 import AttachedFileDropdownMenu from './ai-assistant/attached-file-dropdown-menu';
+
+import type OperatorModeStateService from '../services/operator-mode-state-service';
 
 interface FilePillSignature {
   Element: HTMLDivElement | HTMLButtonElement;

--- a/packages/host/app/components/host-mode/stack-item.gts
+++ b/packages/host/app/components/host-mode/stack-item.gts
@@ -1,6 +1,7 @@
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
-import { htmlSafe, SafeString } from '@ember/template';
+import type { SafeString } from '@ember/template';
+import { htmlSafe } from '@ember/template';
 
 import { isTesting } from '@embroider/macros';
 

--- a/packages/host/app/components/host-mode/stack.gts
+++ b/packages/host/app/components/host-mode/stack.gts
@@ -1,4 +1,4 @@
-import { TemplateOnlyComponent } from '@ember/component/template-only';
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
 import HostModeStackItem from './stack-item';
 

--- a/packages/host/app/components/matrix/auth.gts
+++ b/packages/host/app/components/matrix/auth.gts
@@ -7,12 +7,15 @@ import { tracked } from '@glimmer/tracking';
 
 import { bool, eq, or } from '@cardstack/boxel-ui/helpers';
 
-import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
+import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 import AuthContainer from './auth-container';
-import ForgotPassword, { ResetPasswordParams } from './forgot-password';
+
+import ForgotPassword from './forgot-password';
 import Login from './login';
 import RegisterUser from './register-user';
+
+import type { ResetPasswordParams } from './forgot-password';
 
 export type AuthMode = 'login' | 'register' | 'forgot-password';
 

--- a/packages/host/app/components/matrix/forgot-password.gts
+++ b/packages/host/app/components/matrix/forgot-password.gts
@@ -24,7 +24,7 @@ import {
 } from '@cardstack/host/lib/matrix-utils';
 import type MatrixService from '@cardstack/host/services/matrix-service';
 
-import { AuthMode } from './auth';
+import type { AuthMode } from './auth';
 
 export type ResetPasswordParams = {
   sid: string;

--- a/packages/host/app/components/matrix/login.gts
+++ b/packages/host/app/components/matrix/login.gts
@@ -8,7 +8,6 @@ import { tracked } from '@glimmer/tracking';
 
 import { restartableTask } from 'ember-concurrency';
 
-import { type LoginResponse } from 'matrix-js-sdk';
 import moment from 'moment';
 
 import {
@@ -23,7 +22,8 @@ import {
 } from '@cardstack/host/lib/matrix-utils';
 import type MatrixService from '@cardstack/host/services/matrix-service';
 
-import { AuthMode } from './auth';
+import type { AuthMode } from './auth';
+import type { LoginResponse } from 'matrix-js-sdk';
 
 interface Signature {
   Args: {

--- a/packages/host/app/components/matrix/register-user.gts
+++ b/packages/host/app/components/matrix/register-user.gts
@@ -10,11 +10,6 @@ import { tracked } from '@glimmer/tracking';
 
 import { restartableTask, timeout } from 'ember-concurrency';
 
-import {
-  type RegisterResponse,
-  type IRequestTokenResponse,
-  type LoginResponse,
-} from 'matrix-js-sdk';
 import { v4 as uuidv4 } from 'uuid';
 
 import { LoadingIndicator } from '@cardstack/boxel-ui/components';
@@ -38,7 +33,12 @@ import {
 } from '@cardstack/host/lib/matrix-utils';
 import type MatrixService from '@cardstack/host/services/matrix-service';
 
-import { AuthMode } from './auth';
+import type { AuthMode } from './auth';
+import type {
+  RegisterResponse,
+  IRequestTokenResponse,
+  LoginResponse,
+} from 'matrix-js-sdk';
 
 const MATRIX_REGISTRATION_TYPES = {
   sendToken: 'm.login.registration_token',

--- a/packages/host/app/components/matrix/room-message-command.gts
+++ b/packages/host/app/components/matrix/room-message-command.gts
@@ -26,20 +26,21 @@ import {
 
 import type { CommandRequest } from '@cardstack/runtime-common/commands';
 
-import MessageCommand from '@cardstack/host/lib/matrix-classes/message-command';
+import type MessageCommand from '@cardstack/host/lib/matrix-classes/message-command';
 
-import { RoomResource } from '@cardstack/host/resources/room';
+import type { RoomResource } from '@cardstack/host/resources/room';
 import type CommandService from '@cardstack/host/services/command-service';
 import type MatrixService from '@cardstack/host/services/matrix-service';
 
-import { type MonacoSDK } from '@cardstack/host/services/monaco-service';
+import type { MonacoSDK } from '@cardstack/host/services/monaco-service';
 import type RealmService from '@cardstack/host/services/realm';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 
-import { type ApplyButtonState } from '../ai-assistant/apply-button';
 import CodeBlock from '../ai-assistant/code-block';
 import CardRenderer from '../card-renderer';
+
+import type { ApplyButtonState } from '../ai-assistant/apply-button';
 
 interface Signature {
   Element: HTMLDivElement;

--- a/packages/host/app/components/matrix/room-message.gts
+++ b/packages/host/app/components/matrix/room-message.gts
@@ -20,10 +20,10 @@ import {
 } from '@cardstack/runtime-common';
 
 import consumeContext from '@cardstack/host/helpers/consume-context';
-import MessageCommand from '@cardstack/host/lib/matrix-classes/message-command';
-import { type RoomResource } from '@cardstack/host/resources/room';
-import CommandService from '@cardstack/host/services/command-service';
-import { type MonacoSDK } from '@cardstack/host/services/monaco-service';
+import type MessageCommand from '@cardstack/host/lib/matrix-classes/message-command';
+import type { RoomResource } from '@cardstack/host/resources/room';
+import type CommandService from '@cardstack/host/services/command-service';
+import type { MonacoSDK } from '@cardstack/host/services/monaco-service';
 
 import AiAssistantMessage from '../ai-assistant/message';
 import { aiBotUserId } from '../ai-assistant/panel';

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -22,8 +22,6 @@ import { consume } from 'ember-provide-consume-context';
 import { resource, use } from 'ember-resources';
 import max from 'lodash/max';
 
-import { MatrixEvent } from 'matrix-js-sdk';
-
 import pluralize from 'pluralize';
 
 import { TrackedObject, TrackedArray } from 'tracked-built-ins';
@@ -33,10 +31,10 @@ import { v4 as uuidv4 } from 'uuid';
 import { Alert, LoadingIndicator } from '@cardstack/boxel-ui/components';
 import { and, eq, not } from '@cardstack/boxel-ui/helpers';
 
+import type { ResolvedCodeRef } from '@cardstack/runtime-common';
 import {
   type getCard,
   GetCardContextName,
-  ResolvedCodeRef,
   internalKeyFor,
   isCardInstance,
 } from '@cardstack/runtime-common';
@@ -46,16 +44,16 @@ import {
 } from '@cardstack/runtime-common/matrix-constants';
 
 import UpdateRoomSkillsCommand from '@cardstack/host/commands/update-room-skills';
-import { Message } from '@cardstack/host/lib/matrix-classes/message';
+import type { Message } from '@cardstack/host/lib/matrix-classes/message';
 import type { StackItem } from '@cardstack/host/lib/stack-item';
 import { getAutoAttachment } from '@cardstack/host/resources/auto-attached-card';
-import { RoomResource } from '@cardstack/host/resources/room';
+import type { RoomResource } from '@cardstack/host/resources/room';
 
 import type AiAssistantPanelService from '@cardstack/host/services/ai-assistant-panel-service';
 import type CardService from '@cardstack/host/services/card-service';
 import type CommandService from '@cardstack/host/services/command-service';
 import type MatrixService from '@cardstack/host/services/matrix-service';
-import { type MonacoSDK } from '@cardstack/host/services/monaco-service';
+import type { MonacoSDK } from '@cardstack/host/services/monaco-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 import type PlaygroundPanelService from '@cardstack/host/services/playground-panel-service';
 import type SpecPanelService from '@cardstack/host/services/spec-panel-service';
@@ -80,6 +78,7 @@ import RoomMessage from './room-message';
 
 import type RoomData from '../../lib/matrix-classes/room';
 import type { RoomSkill } from '../../resources/room';
+import type { MatrixEvent } from 'matrix-js-sdk';
 
 interface Signature {
   Element: HTMLElement;

--- a/packages/host/app/components/operator-mode/binary-file-info.gts
+++ b/packages/host/app/components/operator-mode/binary-file-info.gts
@@ -5,7 +5,7 @@ import { filesize } from 'filesize';
 
 import { File } from '@cardstack/boxel-ui/icons';
 
-import { type Ready } from '@cardstack/host/resources/file';
+import type { Ready } from '@cardstack/host/resources/file';
 
 interface Signature {
   Element: HTMLElement;

--- a/packages/host/app/components/operator-mode/card-adoption-chain.gts
+++ b/packages/host/app/components/operator-mode/card-adoption-chain.gts
@@ -3,11 +3,11 @@ import Component from '@glimmer/component';
 
 import { LoadingIndicator } from '@cardstack/boxel-ui/components';
 
-import { type CodeRef } from '@cardstack/runtime-common/code-ref';
-import { ModuleSyntax } from '@cardstack/runtime-common/module-syntax';
+import type { CodeRef } from '@cardstack/runtime-common/code-ref';
+import type { ModuleSyntax } from '@cardstack/runtime-common/module-syntax';
 
 import CardSchemaEditor from '@cardstack/host/components/operator-mode/card-schema-editor';
-import { CardInheritance } from '@cardstack/host/components/operator-mode/code-submode/schema-editor';
+import type { CardInheritance } from '@cardstack/host/components/operator-mode/code-submode/schema-editor';
 import { Divider } from '@cardstack/host/components/operator-mode/definition-container';
 
 import { stripFileExtension } from '@cardstack/host/lib/utils';

--- a/packages/host/app/components/operator-mode/card-error-detail.gts
+++ b/packages/host/app/components/operator-mode/card-error-detail.gts
@@ -2,9 +2,9 @@ import Component from '@glimmer/component';
 
 import type { FileDef } from 'https://cardstack.com/base/file-api';
 
-import { type CardErrorJSONAPI } from '../../services/store';
-
 import ErrorDisplay from './error-display';
+
+import type { CardErrorJSONAPI } from '../../services/store';
 
 interface Signature {
   Args: {

--- a/packages/host/app/components/operator-mode/card-error.gts
+++ b/packages/host/app/components/operator-mode/card-error.gts
@@ -9,7 +9,7 @@ import type { MenuItem } from '@cardstack/boxel-ui/helpers';
 import { FileAlert, ExclamationCircle } from '@cardstack/boxel-ui/icons';
 
 import type LoaderService from '@cardstack/host/services/loader-service';
-import { type CardErrorJSONAPI } from '@cardstack/host/services/store';
+import type { CardErrorJSONAPI } from '@cardstack/host/services/store';
 
 import type { FileDef } from 'https://cardstack.com/base/file-api';
 

--- a/packages/host/app/components/operator-mode/card-renderer-panel/index.gts
+++ b/packages/host/app/components/operator-mode/card-renderer-panel/index.gts
@@ -36,7 +36,7 @@ import ElementTracker, {
   type RenderedCardForOverlayActions,
 } from '@cardstack/host/resources/element-tracker';
 import type CommandService from '@cardstack/host/services/command-service';
-import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
+import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 import type RealmService from '@cardstack/host/services/realm';
 

--- a/packages/host/app/components/operator-mode/card-schema-editor.gts
+++ b/packages/host/app/components/operator-mode/card-schema-editor.gts
@@ -20,7 +20,7 @@ import { ArrowTopLeft, IconLink, IconPlus } from '@cardstack/boxel-ui/icons';
 
 import { getPlural } from '@cardstack/runtime-common';
 
-import { type CodeRef } from '@cardstack/runtime-common/code-ref';
+import type { CodeRef } from '@cardstack/runtime-common/code-ref';
 import type { ModuleSyntax } from '@cardstack/runtime-common/module-syntax';
 
 import EditFieldModal from '@cardstack/host/components/operator-mode/edit-field-modal';
@@ -37,8 +37,8 @@ import {
 } from '@cardstack/host/services/card-type-service';
 import type LoaderService from '@cardstack/host/services/loader-service';
 
-import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
-import RealmService from '@cardstack/host/services/realm';
+import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
+import type RealmService from '@cardstack/host/services/realm';
 import {
   isOwnField,
   calculateTotalOwnFields,

--- a/packages/host/app/components/operator-mode/card-url-bar.gts
+++ b/packages/host/app/components/operator-mode/card-url-bar.gts
@@ -8,9 +8,8 @@ import { and, bool, not } from '@cardstack/boxel-ui/helpers';
 
 import { IconGlobe, Warning as IconWarning } from '@cardstack/boxel-ui/icons';
 
-import URLBarResource, {
-  urlBarResource,
-} from '@cardstack/host/resources/url-bar';
+import type URLBarResource from '@cardstack/host/resources/url-bar';
+import { urlBarResource } from '@cardstack/host/resources/url-bar';
 
 import type RealmService from '@cardstack/host/services/realm';
 

--- a/packages/host/app/components/operator-mode/choose-file-modal.gts
+++ b/packages/host/app/components/operator-mode/choose-file-modal.gts
@@ -24,12 +24,12 @@ import {
 
 import ModalContainer from '@cardstack/host/components/modal-container';
 
-import MatrixService from '@cardstack/host/services/matrix-service';
-import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
+import type MatrixService from '@cardstack/host/services/matrix-service';
+import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 import type RealmService from '@cardstack/host/services/realm';
 
-import { type FileDef } from 'https://cardstack.com/base/file-api';
+import type { FileDef } from 'https://cardstack.com/base/file-api';
 
 import FileTree from '../editor/file-tree';
 

--- a/packages/host/app/components/operator-mode/choose-subscription-plan-modal.gts
+++ b/packages/host/app/components/operator-mode/choose-subscription-plan-modal.gts
@@ -8,7 +8,7 @@ import Component from '@glimmer/component';
 
 import { IconHexagon } from '@cardstack/boxel-ui/icons';
 
-import BillingService from '@cardstack/host/services/billing-service';
+import type BillingService from '@cardstack/host/services/billing-service';
 
 import ModalContainer from '../modal-container';
 

--- a/packages/host/app/components/operator-mode/code-editor.gts
+++ b/packages/host/app/components/operator-mode/code-editor.gts
@@ -35,12 +35,12 @@ import {
   type FileResource,
   type Ready,
 } from '@cardstack/host/resources/file';
-import {
-  type ModuleAnalysis,
-  type ModuleDeclaration,
+import type {
+  ModuleAnalysis,
+  ModuleDeclaration,
 } from '@cardstack/host/resources/module-contents';
 import type { SaveType } from '@cardstack/host/services/card-service';
-import CommandService from '@cardstack/host/services/command-service';
+import type CommandService from '@cardstack/host/services/command-service';
 import type EnvironmentService from '@cardstack/host/services/environment-service';
 import { findDeclarationByName } from '@cardstack/host/services/module-contents-service';
 import type MonacoService from '@cardstack/host/services/monaco-service';

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -27,12 +27,12 @@ import {
 import { not, MenuItem } from '@cardstack/boxel-ui/helpers';
 import { File } from '@cardstack/boxel-ui/icons';
 
+import type { CodeRef } from '@cardstack/runtime-common';
 import {
   isCardDocumentString,
   RealmPaths,
   PermissionsContextName,
   GetCardContextName,
-  CodeRef,
   type ResolvedCodeRef,
   type getCard,
   CardContextName,
@@ -44,10 +44,10 @@ import CodeSubmodeEditorIndicator from '@cardstack/host/components/operator-mode
 import ModuleInspector from '@cardstack/host/components/operator-mode/code-submode/module-inspector';
 
 import consumeContext from '@cardstack/host/helpers/consume-context';
-import { type FileResource } from '@cardstack/host/resources/file';
-import {
-  type ModuleDeclaration,
-  type State as ModuleState,
+import type { FileResource } from '@cardstack/host/resources/file';
+import type {
+  ModuleDeclaration,
+  State as ModuleState,
 } from '@cardstack/host/resources/module-contents';
 import type CardService from '@cardstack/host/services/card-service';
 import type CodeSemanticsService from '@cardstack/host/services/code-semantics-service';
@@ -63,7 +63,7 @@ import type {
   Format,
   CardContext,
 } from 'https://cardstack.com/base/card-api';
-import { type SpecType } from 'https://cardstack.com/base/spec';
+import type { SpecType } from 'https://cardstack.com/base/spec';
 
 import {
   CodeModePanelWidths,

--- a/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
+++ b/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
@@ -18,6 +18,11 @@ import window from 'ember-window-mock';
 
 import { eq } from '@cardstack/boxel-ui/helpers';
 
+import type {
+  CodeRef,
+  CardErrorJSONAPI,
+  ResolvedCodeRef,
+} from '@cardstack/runtime-common';
 import {
   type getCards,
   type getCard,
@@ -25,11 +30,8 @@ import {
   type CardResourceMeta,
   isFieldDef,
   internalKeyFor,
-  CodeRef,
-  CardErrorJSONAPI,
   GetCardsContextName,
   GetCardContextName,
-  ResolvedCodeRef,
   specRef,
   localId,
   meta,
@@ -50,7 +52,7 @@ import SyntaxErrorDisplay from '@cardstack/host/components/operator-mode/syntax-
 import consumeContext from '@cardstack/host/helpers/consume-context';
 
 import type { FileResource } from '@cardstack/host/resources/file';
-import { type Ready } from '@cardstack/host/resources/file';
+import type { Ready } from '@cardstack/host/resources/file';
 import { isReady } from '@cardstack/host/resources/file';
 import {
   type CardOrFieldDeclaration,
@@ -79,7 +81,7 @@ import type {
   ViewCardFn,
 } from 'https://cardstack.com/base/card-api';
 import type { FileDef } from 'https://cardstack.com/base/file-api';
-import { Spec } from 'https://cardstack.com/base/spec';
+import type { Spec } from 'https://cardstack.com/base/spec';
 
 import type { ComponentLike } from '@glint/template';
 

--- a/packages/host/app/components/operator-mode/code-submode/playground/instance-chooser-dropdown.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/instance-chooser-dropdown.gts
@@ -6,7 +6,7 @@ import {
   CardContainer,
   Menu,
 } from '@cardstack/boxel-ui/components';
-import { MenuItem } from '@cardstack/boxel-ui/helpers';
+import type { MenuItem } from '@cardstack/boxel-ui/helpers';
 
 import {
   cardTypeDisplayName,

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
@@ -13,8 +13,8 @@ import ToElsewhere from 'ember-elsewhere/components/to-elsewhere';
 import { consume, provide } from 'ember-provide-consume-context';
 import { resource, use } from 'ember-resources';
 
+import type { BoxelSelect } from '@cardstack/boxel-ui/components';
 import {
-  BoxelSelect,
   CardContainer,
   LoadingIndicator,
 } from '@cardstack/boxel-ui/components';

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-preview.gts
@@ -1,7 +1,8 @@
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
 import { CardContainer, CardHeader } from '@cardstack/boxel-ui/components';
-import { eq, or, MenuItem } from '@cardstack/boxel-ui/helpers';
+import type { MenuItem } from '@cardstack/boxel-ui/helpers';
+import { eq, or } from '@cardstack/boxel-ui/helpers';
 
 import {
   cardTypeDisplayName,

--- a/packages/host/app/components/operator-mode/code-submode/schema-editor.gts
+++ b/packages/host/app/components/operator-mode/code-submode/schema-editor.gts
@@ -5,18 +5,18 @@ import Component from '@glimmer/component';
 import { cached } from '@glimmer/tracking';
 
 import { getPlural } from '@cardstack/runtime-common';
-import { type CodeRef } from '@cardstack/runtime-common/code-ref';
+import type { CodeRef } from '@cardstack/runtime-common/code-ref';
 
 import { ModuleSyntax } from '@cardstack/runtime-common/module-syntax';
 
 import CardAdoptionChain from '@cardstack/host/components/operator-mode/card-adoption-chain';
-import { Ready } from '@cardstack/host/resources/file';
+import type { Ready } from '@cardstack/host/resources/file';
 import { inheritanceChain } from '@cardstack/host/resources/inheritance-chain';
 import type {
   ModuleAnalysis,
   ModuleDeclaration,
 } from '@cardstack/host/resources/module-contents';
-import { type Type } from '@cardstack/host/services/card-type-service';
+import type { Type } from '@cardstack/host/services/card-type-service';
 import type LoaderService from '@cardstack/host/services/loader-service';
 
 import {

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview-badge.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview-badge.gts
@@ -1,4 +1,4 @@
-import { TemplateOnlyComponent } from '@ember/component/template-only';
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { on } from '@ember/modifier';
 
 import Check from '@cardstack/boxel-icons/check';
@@ -6,7 +6,7 @@ import Check from '@cardstack/boxel-icons/check';
 import { BoxelButton } from '@cardstack/boxel-ui/components';
 import { IconPlus } from '@cardstack/boxel-ui/icons';
 
-import { Spec } from 'https://cardstack.com/base/spec';
+import type { Spec } from 'https://cardstack.com/base/spec';
 
 interface SpecPreviewBadgeSignature {
   Args: {

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -1,4 +1,4 @@
-import { TemplateOnlyComponent } from '@ember/component/template-only';
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
@@ -32,7 +32,7 @@ import {
 import CardRenderer from '@cardstack/host/components/card-renderer';
 
 import { urlForRealmLookup } from '@cardstack/host/lib/utils';
-import { type ModuleDeclaration } from '@cardstack/host/resources/module-contents';
+import type { ModuleDeclaration } from '@cardstack/host/resources/module-contents';
 
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 import type { ModuleInspectorView } from '@cardstack/host/services/operator-mode-state-service';
@@ -42,7 +42,7 @@ import type SpecPanelService from '@cardstack/host/services/spec-panel-service';
 import type StoreService from '@cardstack/host/services/store';
 
 import type { CardContext } from 'https://cardstack.com/base/card-api';
-import { Spec } from 'https://cardstack.com/base/spec';
+import type { Spec } from 'https://cardstack.com/base/spec';
 
 import ElementTracker, {
   type RenderedCardForOverlayActions,

--- a/packages/host/app/components/operator-mode/container.gts
+++ b/packages/host/app/components/operator-mode/container.gts
@@ -32,7 +32,7 @@ import { getCardCollection } from '@cardstack/host/resources/card-collection';
 import { getCard } from '@cardstack/host/resources/card-resource';
 import { getSearch } from '@cardstack/host/resources/search';
 
-import MessageService from '@cardstack/host/services/message-service';
+import type MessageService from '@cardstack/host/services/message-service';
 
 import type { CardContext } from 'https://cardstack.com/base/card-api';
 

--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -52,7 +52,8 @@ import CopyCardToRealmCommand from '@cardstack/host/commands/copy-card';
 import type RealmService from '@cardstack/host/services/realm';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
-import { Spec, type SpecType } from 'https://cardstack.com/base/spec';
+import type { Spec } from 'https://cardstack.com/base/spec';
+import type { SpecType } from 'https://cardstack.com/base/spec';
 
 import { cleanseString } from '../../lib/utils';
 

--- a/packages/host/app/components/operator-mode/definition-container/clickable.gts
+++ b/packages/host/app/components/operator-mode/definition-container/clickable.gts
@@ -2,7 +2,7 @@ import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 
-import { type ResolvedCodeRef } from '@cardstack/runtime-common/code-ref';
+import type { ResolvedCodeRef } from '@cardstack/runtime-common/code-ref';
 
 export interface ClickableArgs {
   goToDefinition: (

--- a/packages/host/app/components/operator-mode/definition-container/index.gts
+++ b/packages/host/app/components/operator-mode/definition-container/index.gts
@@ -1,7 +1,11 @@
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
-import { BaseDefinitionContainer, BaseArgs, Active, ActiveArgs } from './base';
-import { Clickable, ClickableArgs } from './clickable';
+import { BaseDefinitionContainer, Active } from './base';
+
+import { Clickable } from './clickable';
+
+import type { BaseArgs, ActiveArgs } from './base';
+import type { ClickableArgs } from './clickable';
 
 interface FileArgs
   extends Omit<BaseArgs, 'title' | 'name' | 'isActive'>,

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -35,7 +35,7 @@ import {
 } from '@cardstack/runtime-common';
 
 import { getCardType } from '@cardstack/host/resources/card-type';
-import { type Ready } from '@cardstack/host/resources/file';
+import type { Ready } from '@cardstack/host/resources/file';
 
 import {
   type ModuleDeclaration,
@@ -45,14 +45,14 @@ import {
 } from '@cardstack/host/resources/module-contents';
 
 import { getResolvedCodeRefFromType } from '@cardstack/host/services/card-type-service';
-import RealmService from '@cardstack/host/services/realm';
+import type RealmService from '@cardstack/host/services/realm';
 
 import type { CardDef, BaseDef } from 'https://cardstack.com/base/card-api';
 
 import { lastModifiedDate } from '../../resources/last-modified-date';
 
 import { PanelSection } from './code-submode/inner-container';
-import { type FileType, type NewFileType } from './create-file-modal';
+
 import {
   Divider,
   BaseContainer,
@@ -64,7 +64,10 @@ import {
 
 import Selector from './detail-panel-selector';
 
-import { SelectorItem, selectorItemFunc } from './detail-panel-selector';
+import { selectorItemFunc } from './detail-panel-selector';
+
+import type { FileType, NewFileType } from './create-file-modal';
+import type { SelectorItem } from './detail-panel-selector';
 
 import type { ModuleAnalysis } from '../../resources/module-contents';
 

--- a/packages/host/app/components/operator-mode/edit-field-modal.gts
+++ b/packages/host/app/components/operator-mode/edit-field-modal.gts
@@ -34,20 +34,20 @@ import {
 import type { ModuleSyntax } from '@cardstack/runtime-common/module-syntax';
 
 import ModalContainer from '@cardstack/host/components/modal-container';
-import { Ready } from '@cardstack/host/resources/file';
+import type { Ready } from '@cardstack/host/resources/file';
 
 import {
   getCodeRefFromType,
   type FieldOfType,
 } from '@cardstack/host/services/card-type-service';
-import LoaderService from '@cardstack/host/services/loader-service';
-import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
+import type LoaderService from '@cardstack/host/services/loader-service';
+import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 import type RealmService from '@cardstack/host/services/realm';
 import type StoreService from '@cardstack/host/services/store';
 
 import type { BaseDef, FieldType } from 'https://cardstack.com/base/card-api';
-import { Spec } from 'https://cardstack.com/base/spec';
+import type { Spec } from 'https://cardstack.com/base/spec';
 
 import { SelectedTypePill } from './create-file-modal';
 

--- a/packages/host/app/components/operator-mode/error-display.gts
+++ b/packages/host/app/components/operator-mode/error-display.gts
@@ -22,7 +22,7 @@ import type ErrorDisplayService from '@cardstack/host/services/error-display';
 import type { DisplayedErrorProvider } from '@cardstack/host/services/error-display';
 
 import type { FileDef } from 'https://cardstack.com/base/file-api';
-import { BoxelErrorForContext } from 'https://cardstack.com/base/matrix-event';
+import type { BoxelErrorForContext } from 'https://cardstack.com/base/matrix-event';
 
 import SendErrorToAIAssistant from './send-error-to-ai-assistant';
 

--- a/packages/host/app/components/operator-mode/host-submode.gts
+++ b/packages/host/app/components/operator-mode/host-submode.gts
@@ -25,8 +25,8 @@ import PublishingRealmPopover from '@cardstack/host/components/operator-mode/hos
 import PublishRealmModal from '@cardstack/host/components/operator-mode/publish-realm-modal';
 
 import type HomePageResolverService from '@cardstack/host/services/home-page-resolver';
-import HostModeService from '@cardstack/host/services/host-mode-service';
-import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
+import type HostModeService from '@cardstack/host/services/host-mode-service';
+import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 import type RealmService from '@cardstack/host/services/realm';
 import type StoreService from '@cardstack/host/services/store';
 

--- a/packages/host/app/components/operator-mode/host-submode/open-site-popover.gts
+++ b/packages/host/app/components/operator-mode/host-submode/open-site-popover.gts
@@ -5,7 +5,7 @@ import ExternalLink from '@cardstack/boxel-icons/external-link';
 
 import { BoxelButton } from '@cardstack/boxel-ui/components';
 
-import HostModeService from '@cardstack/host/services/host-mode-service';
+import type HostModeService from '@cardstack/host/services/host-mode-service';
 
 interface OpenSitePopoverArgs {
   isOpen: boolean;

--- a/packages/host/app/components/operator-mode/host-submode/publishing-realm-popover.gts
+++ b/packages/host/app/components/operator-mode/host-submode/publishing-realm-popover.gts
@@ -3,8 +3,8 @@ import Component from '@glimmer/component';
 
 import { LoadingIndicator } from '@cardstack/boxel-ui/components';
 
-import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
-import RealmService from '@cardstack/host/services/realm';
+import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
+import type RealmService from '@cardstack/host/services/realm';
 
 interface PublishingRealmArgs {
   isOpen: boolean;

--- a/packages/host/app/components/operator-mode/interact-submode.gts
+++ b/packages/host/app/components/operator-mode/interact-submode.gts
@@ -73,10 +73,11 @@ import NeighborStackTriggerButton, {
   type SearchSheetTrigger,
 } from './interact-submode/neighbor-stack-trigger';
 import OperatorModeStack from './stack';
-import { CardDefOrId } from './stack-item';
+
 import SubmodeLayout from './submode-layout';
 
 import type { NewFileOptions } from './new-file-button';
+import type { CardDefOrId } from './stack-item';
 
 import type { StackItemComponentAPI } from './stack-item';
 

--- a/packages/host/app/components/operator-mode/new-file-button.gts
+++ b/packages/host/app/components/operator-mode/new-file-button.gts
@@ -1,7 +1,8 @@
-import { TemplateOnlyComponent } from '@ember/component/template-only';
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
 import { BoxelDropdown, Button, Menu } from '@cardstack/boxel-ui/components';
-import { type MenuDivider, MenuItem } from '@cardstack/boxel-ui/helpers';
+import type { MenuItem } from '@cardstack/boxel-ui/helpers';
+import type { MenuDivider } from '@cardstack/boxel-ui/helpers';
 import { DropdownArrowDown, IconPlus } from '@cardstack/boxel-ui/icons';
 
 export interface NewFileOptions {

--- a/packages/host/app/components/operator-mode/operator-mode-overlays.gts
+++ b/packages/host/app/components/operator-mode/operator-mode-overlays.gts
@@ -4,12 +4,12 @@ import { action } from '@ember/object';
 
 import { velcro } from 'ember-velcro';
 
+import type { BoxelDropdownAPI } from '@cardstack/boxel-ui/components';
 import {
   BoxelDropdown,
   IconButton,
   Menu,
   Tooltip,
-  BoxelDropdownAPI,
 } from '@cardstack/boxel-ui/components';
 
 import { compact, cn, menuItem, or } from '@cardstack/boxel-ui/helpers';
@@ -31,7 +31,8 @@ import type { Format } from 'https://cardstack.com/base/card-api';
 import { removeFileExtension } from '../search-sheet/utils';
 
 import Overlays from './overlays';
-import { StackItemRenderedCardForOverlayActions } from './stack-item';
+
+import type { StackItemRenderedCardForOverlayActions } from './stack-item';
 
 import type { CardDefOrId } from './stack-item';
 

--- a/packages/host/app/components/operator-mode/overlays.gts
+++ b/packages/host/app/components/operator-mode/overlays.gts
@@ -1,7 +1,8 @@
 import { array } from '@ember/helper';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import { htmlSafe, SafeString } from '@ember/template';
+import type { SafeString } from '@ember/template';
+import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
@@ -12,7 +13,7 @@ import { isEqual, omit } from 'lodash';
 import { localId as localIdSymbol } from '@cardstack/runtime-common';
 
 import type CardService from '@cardstack/host/services/card-service';
-import RealmService from '@cardstack/host/services/realm';
+import type RealmService from '@cardstack/host/services/realm';
 
 import type {
   CardDef,
@@ -20,7 +21,7 @@ import type {
   ViewCardFn,
 } from 'https://cardstack.com/base/card-api';
 
-import { CardDefOrId } from './stack-item';
+import type { CardDefOrId } from './stack-item';
 
 import type { RenderedCardForOverlayActions } from '../../resources/element-tracker';
 import type { MiddlewareState } from '@floating-ui/dom';

--- a/packages/host/app/components/operator-mode/profile-info-popover.gts
+++ b/packages/host/app/components/operator-mode/profile-info-popover.gts
@@ -9,8 +9,8 @@ import { cn } from '@cardstack/boxel-ui/helpers';
 
 import WithSubscriptionData from '@cardstack/host/components/with-subscription-data';
 
-import BillingService from '@cardstack/host/services/billing-service';
-import MatrixService from '@cardstack/host/services/matrix-service';
+import type BillingService from '@cardstack/host/services/billing-service';
+import type MatrixService from '@cardstack/host/services/matrix-service';
 
 interface ProfileInfoPopoverSignature {
   Args: {

--- a/packages/host/app/components/operator-mode/profile/profile-email.gts
+++ b/packages/host/app/components/operator-mode/profile/profile-email.gts
@@ -9,7 +9,6 @@ import { tracked } from '@glimmer/tracking';
 
 import { restartableTask, timeout } from 'ember-concurrency';
 
-import { type IAuthData } from 'matrix-js-sdk';
 import { v4 as uuidv4 } from 'uuid';
 
 import {
@@ -28,7 +27,9 @@ import {
 
 import ModalContainer from '@cardstack/host/components/modal-container';
 
-import MatrixService from '@cardstack/host/services/matrix-service';
+import type MatrixService from '@cardstack/host/services/matrix-service';
+
+import type { IAuthData } from 'matrix-js-sdk';
 
 interface PasswordModalSignature {
   Args: {

--- a/packages/host/app/components/operator-mode/profile/profile-settings-modal.gts
+++ b/packages/host/app/components/operator-mode/profile/profile-settings-modal.gts
@@ -10,8 +10,6 @@ import { restartableTask, timeout, all } from 'ember-concurrency';
 
 import perform from 'ember-concurrency/helpers/perform';
 
-import { type IAuthData } from 'matrix-js-sdk';
-
 import {
   BoxelButton,
   BoxelInput,
@@ -25,10 +23,12 @@ import ModalContainer from '@cardstack/host/components/modal-container';
 import { ProfileInfo } from '@cardstack/host/components/operator-mode/profile-info-popover';
 import config from '@cardstack/host/config/environment';
 import { isValidPassword } from '@cardstack/host/lib/matrix-utils';
-import MatrixService from '@cardstack/host/services/matrix-service';
+import type MatrixService from '@cardstack/host/services/matrix-service';
 
 import ProfileEmail from './profile-email';
 import ProfileSubscription from './profile-subscription';
+
+import type { IAuthData } from 'matrix-js-sdk';
 
 interface Signature {
   Args: {

--- a/packages/host/app/components/operator-mode/profile/profile-subscription.gts
+++ b/packages/host/app/components/operator-mode/profile/profile-subscription.gts
@@ -11,9 +11,9 @@ import { IconHexagon } from '@cardstack/boxel-ui/icons';
 import WithSubscriptionData from '@cardstack/host/components/with-subscription-data';
 import type BillingService from '@cardstack/host/services/billing-service';
 import type MatrixService from '@cardstack/host/services/matrix-service';
-import NetworkService from '@cardstack/host/services/network';
+import type NetworkService from '@cardstack/host/services/network';
 
-import RealmServerService from '@cardstack/host/services/realm-server';
+import type RealmServerService from '@cardstack/host/services/realm-server';
 
 interface Signature {
   Args: {};

--- a/packages/host/app/components/operator-mode/publish-realm-modal.gts
+++ b/packages/host/app/components/operator-mode/publish-realm-modal.gts
@@ -29,7 +29,7 @@ import WithLoadedRealm from '@cardstack/host/components/with-loaded-realm';
 
 import config from '@cardstack/host/config/environment';
 
-import HostModeService from '@cardstack/host/services/host-mode-service';
+import type HostModeService from '@cardstack/host/services/host-mode-service';
 import type MatrixService from '@cardstack/host/services/matrix-service';
 import type RealmService from '@cardstack/host/services/realm';
 import type RealmServerService from '@cardstack/host/services/realm-server';

--- a/packages/host/app/components/operator-mode/remove-field-modal.gts
+++ b/packages/host/app/components/operator-mode/remove-field-modal.gts
@@ -12,9 +12,9 @@ import { identifyCard } from '@cardstack/runtime-common';
 
 import type { ModuleSyntax } from '@cardstack/runtime-common/module-syntax';
 
-import { Ready } from '@cardstack/host/resources/file';
+import type { Ready } from '@cardstack/host/resources/file';
 
-import { FieldOfType } from '@cardstack/host/services/card-type-service';
+import type { FieldOfType } from '@cardstack/host/services/card-type-service';
 
 import type { BaseDef } from 'https://cardstack.com/base/card-api';
 

--- a/packages/host/app/components/operator-mode/stack-item.gts
+++ b/packages/host/app/components/operator-mode/stack-item.gts
@@ -5,7 +5,8 @@ import { action } from '@ember/object';
 import type Owner from '@ember/owner';
 import { scheduleOnce } from '@ember/runloop';
 import { service } from '@ember/service';
-import { htmlSafe, SafeString } from '@ember/template';
+import type { SafeString } from '@ember/template';
+import { htmlSafe } from '@ember/template';
 
 import { isTesting } from '@embroider/macros';
 
@@ -36,6 +37,7 @@ import { cssVar, optional, not } from '@cardstack/boxel-ui/helpers';
 
 import { IconTrash } from '@cardstack/boxel-ui/icons';
 
+import type { CommandContext } from '@cardstack/runtime-common';
 import {
   type Permissions,
   type getCard,
@@ -48,7 +50,6 @@ import {
   GetCardsContextName,
   GetCardCollectionContextName,
   cardTypeIcon,
-  CommandContext,
   realmURL,
   localId as localIdSymbol,
   CardContextName,
@@ -56,7 +57,7 @@ import {
   getCardMenuItems,
 } from '@cardstack/runtime-common';
 
-import { type StackItem } from '@cardstack/host/lib/stack-item';
+import type { StackItem } from '@cardstack/host/lib/stack-item';
 import { urlForRealmLookup } from '@cardstack/host/lib/utils';
 
 import type {

--- a/packages/host/app/components/operator-mode/stack.gts
+++ b/packages/host/app/components/operator-mode/stack.gts
@@ -22,8 +22,9 @@ import type {
 
 import OperatorModeStackItem, {
   type StackItemComponentAPI,
-  CardDefOrId,
 } from './stack-item';
+
+import type { CardDefOrId } from './stack-item';
 
 interface Signature {
   Element: HTMLElement;

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -24,7 +24,7 @@ import { bool, cn, not } from '@cardstack/boxel-ui/helpers';
 
 import { BoxelIconWithText } from '@cardstack/boxel-ui/icons';
 
-import { ResolvedCodeRef } from '@cardstack/runtime-common';
+import type { ResolvedCodeRef } from '@cardstack/runtime-common';
 
 import AiAssistantButton from '@cardstack/host/components/ai-assistant/button';
 import AiAssistantPanel from '@cardstack/host/components/ai-assistant/panel';
@@ -39,11 +39,9 @@ import type IndexController from '@cardstack/host/controllers';
 import { assertNever } from '@cardstack/host/utils/assert-never';
 import { AiAssistantPanelWidth } from '@cardstack/host/utils/local-storage-keys';
 
-import SearchSheet, {
-  SearchSheetMode,
-  SearchSheetModes,
-} from '../search-sheet';
-import SubmodeSwitcher, { Submode, Submodes } from '../submode-switcher';
+import SearchSheet, { SearchSheetModes } from '../search-sheet';
+
+import SubmodeSwitcher, { Submodes } from '../submode-switcher';
 
 import AskAiContainer from './ask-ai-container';
 
@@ -57,6 +55,8 @@ import type MatrixService from '../../services/matrix-service';
 import type OperatorModeStateService from '../../services/operator-mode-state-service';
 import type RecentCardsService from '../../services/recent-cards-service';
 import type StoreService from '../../services/store';
+import type { SearchSheetMode } from '../search-sheet';
+import type { Submode } from '../submode-switcher';
 
 interface Signature {
   Element: HTMLDivElement;

--- a/packages/host/app/components/operator-mode/syntax-error-display.gts
+++ b/packages/host/app/components/operator-mode/syntax-error-display.gts
@@ -1,9 +1,9 @@
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
-import { type CardError } from '@cardstack/runtime-common';
+import type { CardError } from '@cardstack/runtime-common';
 
-import MatrixService from '@cardstack/host/services/matrix-service';
+import type MatrixService from '@cardstack/host/services/matrix-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 import ErrorDisplay from './error-display';

--- a/packages/host/app/components/operator-mode/workspace-chooser/add-workspace.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/add-workspace.gts
@@ -21,7 +21,7 @@ import {
 } from '@cardstack/boxel-ui/components';
 import { IconPlus } from '@cardstack/boxel-ui/icons';
 
-import MatrixService from '@cardstack/host/services/matrix-service';
+import type MatrixService from '@cardstack/host/services/matrix-service';
 
 import {
   getRandomBackgroundURL,

--- a/packages/host/app/components/operator-mode/workspace-chooser/index.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/index.gts
@@ -1,8 +1,8 @@
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 
-import MatrixService from '@cardstack/host/services/matrix-service';
-import RealmServerService from '@cardstack/host/services/realm-server';
+import type MatrixService from '@cardstack/host/services/matrix-service';
+import type RealmServerService from '@cardstack/host/services/realm-server';
 
 import AddWorkspace from './add-workspace';
 import Workspace from './workspace';

--- a/packages/host/app/components/operator-mode/workspace-chooser/item-container.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/item-container.gts
@@ -1,4 +1,4 @@
-import { TemplateOnlyComponent } from '@ember/component/template-only';
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
 interface Signature {
   Element: HTMLButtonElement;

--- a/packages/host/app/components/operator-mode/workspace-chooser/workspace-loading-indicator.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/workspace-loading-indicator.gts
@@ -1,4 +1,4 @@
-import { TemplateOnlyComponent } from '@ember/component/template-only';
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
 import { LoadingIndicator } from '@cardstack/boxel-ui/components';
 

--- a/packages/host/app/components/operator-mode/workspace-chooser/workspace.gts
+++ b/packages/host/app/components/operator-mode/workspace-chooser/workspace.gts
@@ -10,8 +10,8 @@ import { RealmIcon } from '@cardstack/boxel-ui/components';
 import { cssVar } from '@cardstack/boxel-ui/helpers';
 import { Group, IconGlobe, Lock } from '@cardstack/boxel-ui/icons';
 
-import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
-import RealmService from '@cardstack/host/services/realm';
+import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
+import type RealmService from '@cardstack/host/services/realm';
 
 import ItemContainer from './item-container';
 import WorkspaceLoadingIndicator from './workspace-loading-indicator';

--- a/packages/host/app/components/prerendered-card-search.gts
+++ b/packages/host/app/components/prerendered-card-search.gts
@@ -17,19 +17,17 @@ import { TrackedSet } from 'tracked-built-ins';
 
 import { CardContainer } from '@cardstack/boxel-ui/components';
 
+import type { QueryResultsMeta } from '@cardstack/runtime-common';
 import {
   type Query,
   RealmPaths,
   type PrerenderedCardLike,
   type PrerenderedCardData,
   type PrerenderedCardComponentSignature,
-  QueryResultsMeta,
   CardContextName,
 } from '@cardstack/runtime-common';
-import {
-  PrerenderedCardCollectionDocument,
-  isPrerenderedCardCollectionDocument,
-} from '@cardstack/runtime-common/document-types';
+import type { PrerenderedCardCollectionDocument } from '@cardstack/runtime-common/document-types';
+import { isPrerenderedCardCollectionDocument } from '@cardstack/runtime-common/document-types';
 
 import type { CardContext, Format } from 'https://cardstack.com/base/card-api';
 

--- a/packages/host/app/components/realm-dropdown.gts
+++ b/packages/host/app/components/realm-dropdown.gts
@@ -14,9 +14,9 @@ import { DropdownArrowDown } from '@cardstack/boxel-ui/icons';
 
 import { RealmPaths } from '@cardstack/runtime-common';
 
-import { type EnhancedRealmInfo } from '@cardstack/host/services/realm';
+import type { EnhancedRealmInfo } from '@cardstack/host/services/realm';
 
-import RealmService from '../services/realm';
+import type RealmService from '../services/realm';
 
 export interface RealmDropdownItem extends EnhancedRealmInfo {
   path: string;

--- a/packages/host/app/components/search-sheet/card-query-results.gts
+++ b/packages/host/app/components/search-sheet/card-query-results.gts
@@ -8,7 +8,7 @@ import { eq, gt, or } from '@cardstack/boxel-ui/helpers';
 
 import { specRef } from '@cardstack/runtime-common';
 
-import RealmServerService from '@cardstack/host/services/realm-server';
+import type RealmServerService from '@cardstack/host/services/realm-server';
 
 import PrerenderedCardSearch from '../prerendered-card-search';
 

--- a/packages/host/app/components/search-sheet/index.gts
+++ b/packages/host/app/components/search-sheet/index.gts
@@ -25,7 +25,7 @@ import { IconSearch } from '@cardstack/boxel-ui/icons';
 
 import { type getCard, GetCardContextName } from '@cardstack/runtime-common';
 
-import RealmServerService from '@cardstack/host/services/realm-server';
+import type RealmServerService from '@cardstack/host/services/realm-server';
 
 import CardQueryResults from './card-query-results';
 import CardURLResults from './card-url-results';

--- a/packages/host/app/components/search-sheet/recent-cards-section.gts
+++ b/packages/host/app/components/search-sheet/recent-cards-section.gts
@@ -6,7 +6,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 import { getCardCollection } from '@cardstack/host/resources/card-collection';
-import RecentCards from '@cardstack/host/services/recent-cards-service';
+import type RecentCards from '@cardstack/host/services/recent-cards-service';
 
 import ResultsSection from './results-section';
 

--- a/packages/host/app/components/search-sheet/results-section.gts
+++ b/packages/host/app/components/search-sheet/results-section.gts
@@ -1,9 +1,7 @@
-import { TemplateOnlyComponent } from '@ember/component/template-only';
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
-
-import { ComponentLike } from '@glint/template';
 
 import { Label } from '@cardstack/boxel-ui/components';
 import { cn } from '@cardstack/boxel-ui/helpers';
@@ -16,6 +14,8 @@ import type { CardDef } from 'https://cardstack.com/base/card-api';
 import CardRenderer from '../card-renderer';
 
 import { removeFileExtension } from './utils';
+
+import type { ComponentLike } from '@glint/template';
 
 interface SearchResultSignature {
   Element: Element;

--- a/packages/host/app/components/search-sheet/usage.gts
+++ b/packages/host/app/components/search-sheet/usage.gts
@@ -6,7 +6,9 @@ import { tracked } from '@glimmer/tracking';
 
 import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
 
-import SearchSheet, { SearchSheetMode, SearchSheetModes } from './index';
+import SearchSheet, { SearchSheetModes } from './index';
+
+import type { SearchSheetMode } from './index';
 
 const validModes = Object.values(SearchSheetModes);
 

--- a/packages/host/app/components/submode-switcher.gts
+++ b/packages/host/app/components/submode-switcher.gts
@@ -12,7 +12,8 @@ import get from 'lodash/get';
 
 import { BoxelDropdown, Button, Menu } from '@cardstack/boxel-ui/components';
 
-import { menuItemFunc, MenuItem } from '@cardstack/boxel-ui/helpers';
+import type { MenuItem } from '@cardstack/boxel-ui/helpers';
+import { menuItemFunc } from '@cardstack/boxel-ui/helpers';
 import {
   DropdownArrowUp,
   DropdownArrowDown,

--- a/packages/host/app/components/with-known-realms-loaded.gts
+++ b/packages/host/app/components/with-known-realms-loaded.gts
@@ -3,8 +3,8 @@ import Component from '@glimmer/component';
 
 import { task } from 'ember-concurrency';
 
-import RealmService from '../services/realm';
-import RealmServerService from '../services/realm-server';
+import type RealmService from '../services/realm';
+import type RealmServerService from '../services/realm-server';
 
 interface Signature {
   Args: {};

--- a/packages/host/app/components/with-loaded-realm.gts
+++ b/packages/host/app/components/with-loaded-realm.gts
@@ -3,9 +3,9 @@ import Component from '@glimmer/component';
 
 import { task } from 'ember-concurrency';
 
-import { type EnhancedRealmInfo } from '@cardstack/host/services/realm';
+import type { EnhancedRealmInfo } from '@cardstack/host/services/realm';
 
-import RealmService from '../services/realm';
+import type RealmService from '../services/realm';
 
 interface Signature {
   Args: {

--- a/packages/host/app/components/with-subscription-data.gts
+++ b/packages/host/app/components/with-subscription-data.gts
@@ -9,7 +9,7 @@ import { LoadingIndicator } from '@cardstack/boxel-ui/components';
 import { cn, formatNumber } from '@cardstack/boxel-ui/helpers';
 import { IconHexagon } from '@cardstack/boxel-ui/icons';
 
-import BillingService from '../services/billing-service';
+import type BillingService from '../services/billing-service';
 
 import type { ComponentLike } from '@glint/template';
 

--- a/packages/host/app/lib/isolated-render.gts
+++ b/packages/host/app/lib/isolated-render.gts
@@ -6,11 +6,11 @@ import { createConstRef } from '@glimmer/reference';
 // @ts-expect-error
 import { renderMain, inTransaction } from '@glimmer/runtime';
 
-import { type ComponentLike } from '@glint/template';
-
 import { CardError } from '@cardstack/runtime-common/error';
 
 import type { Format } from 'https://cardstack.com/base/card-api';
+
+import type { ComponentLike } from '@glint/template';
 
 import type { SimpleElement } from '@simple-dom/interface';
 

--- a/packages/host/app/modifiers/monaco-diff-editor.gts
+++ b/packages/host/app/modifiers/monaco-diff-editor.gts
@@ -7,7 +7,7 @@ import { makeCodeDiffStats } from '@cardstack/host/lib/formatted-message/utils';
 import type { MonacoSDK } from '@cardstack/host/services/monaco-service';
 import { createMonacoWaiterManager } from '@cardstack/host/utils/editor/monaco-test-waiter';
 
-import { MonacoEditorOptions } from './monaco';
+import type { MonacoEditorOptions } from './monaco';
 
 import type * as _MonacoSDK from 'monaco-editor';
 

--- a/packages/host/app/modifiers/monaco-editor.gts
+++ b/packages/host/app/modifiers/monaco-editor.gts
@@ -7,7 +7,7 @@ import type { CodeData } from '@cardstack/host/lib/formatted-message/utils';
 import type { MonacoSDK } from '@cardstack/host/services/monaco-service';
 import { createMonacoWaiterManager } from '@cardstack/host/utils/editor/monaco-test-waiter';
 
-import { MonacoEditorOptions } from './monaco';
+import type { MonacoEditorOptions } from './monaco';
 
 import type * as _MonacoSDK from 'monaco-editor';
 

--- a/packages/host/app/routes/index.gts
+++ b/packages/host/app/routes/index.gts
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 import type RouterService from '@ember/routing/router-service';
-import Transition from '@ember/routing/transition';
+import type Transition from '@ember/routing/transition';
 import { service } from '@ember/service';
 import { isTesting } from '@embroider/macros';
 
@@ -19,7 +19,7 @@ import type HostModeService from '@cardstack/host/services/host-mode-service';
 import type HostModeStateService from '@cardstack/host/services/host-mode-state-service';
 import type MatrixService from '@cardstack/host/services/matrix-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
-import { type SerializedState as OperatorModeSerializedState } from '@cardstack/host/services/operator-mode-state-service';
+import type { SerializedState as OperatorModeSerializedState } from '@cardstack/host/services/operator-mode-state-service';
 import type RealmService from '@cardstack/host/services/realm';
 import type RealmServerService from '@cardstack/host/services/realm-server';
 import type StoreService from '@cardstack/host/services/store';

--- a/packages/host/app/services/realm-server.ts
+++ b/packages/host/app/services/realm-server.ts
@@ -22,8 +22,6 @@ import {
 
 import ENV from '@cardstack/host/config/environment';
 
-import config from '@cardstack/host/config/environment';
-
 import type { ExtendedClient } from './matrix-sdk-loader';
 import type NetworkService from './network';
 import type RealmService from './realm';
@@ -218,7 +216,7 @@ export default class RealmServerService extends Service {
       let responseText = await response.text();
 
       // Temporary development instruction to help with user setup
-      let isDevelopment = config.environment === 'development';
+      let isDevelopment = ENV.environment === 'development';
       if (isDevelopment && responseText.includes('User in JWT not found')) {
         console.error(
           '\x1b[1m\x1b[31m%s\x1b[0m',

--- a/packages/host/app/templates/host-freestyle.gts
+++ b/packages/host/app/templates/host-freestyle.gts
@@ -1,6 +1,5 @@
 import Component from '@glimmer/component';
 
-import { ComponentLike } from '@glint/template';
 import FreestyleGuide from 'ember-freestyle/components/freestyle-guide';
 import FreestyleSection from 'ember-freestyle/components/freestyle-section';
 
@@ -31,6 +30,8 @@ import { getCard } from '@cardstack/host/resources/card-resource';
 import { getSearch } from '@cardstack/host/resources/search';
 
 import formatComponentName from '../helpers/format-component-name';
+
+import type { ComponentLike } from '@glint/template';
 
 interface UsageComponent {
   title: string;

--- a/packages/host/app/templates/index-error.gts
+++ b/packages/host/app/templates/index-error.gts
@@ -3,7 +3,7 @@ import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import RouteTemplate from 'ember-route-template';
 
 import CardError from '@cardstack/host/components/card-error';
-import { ErrorModel as IndexRouteErrorModel } from '@cardstack/host/routes/index';
+import type { ErrorModel as IndexRouteErrorModel } from '@cardstack/host/routes/index';
 
 interface Signature {
   Args: { model: IndexRouteErrorModel };

--- a/packages/host/app/templates/index.gts
+++ b/packages/host/app/templates/index.gts
@@ -37,7 +37,7 @@ import { getSearch } from '@cardstack/host/resources/search';
 
 import type CommandService from '@cardstack/host/services/command-service';
 
-import HostModeStateService from '@cardstack/host/services/host-mode-state-service';
+import type HostModeStateService from '@cardstack/host/services/host-mode-state-service';
 import type MatrixService from '@cardstack/host/services/matrix-service';
 import type StoreService from '@cardstack/host/services/store';
 

--- a/packages/host/app/templates/module.gts
+++ b/packages/host/app/templates/module.gts
@@ -2,7 +2,7 @@ import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
 import ModuleTemplate from 'ember-route-template';
 
-import { Model } from '../routes/module';
+import type { Model } from '../routes/module';
 
 const { stringify } = JSON;
 

--- a/packages/host/app/templates/render.gts
+++ b/packages/host/app/templates/render.gts
@@ -1,8 +1,8 @@
-import { TemplateOnlyComponent } from '@ember/component/template-only';
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
 import RouteTemplate from 'ember-route-template';
 
-import { Model } from '../routes/render';
+import type { Model } from '../routes/render';
 
 const Render = <template>
   <div

--- a/packages/host/app/templates/render/html.gts
+++ b/packages/host/app/templates/render/html.gts
@@ -2,7 +2,7 @@ import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
 import RouteTemplate from 'ember-route-template';
 
-import { Model } from '../../routes/render/html';
+import type { Model } from '../../routes/render/html';
 
 export default RouteTemplate(<template>
   <@model.Component @format={{@model.format}} />

--- a/packages/host/app/templates/render/icon.gts
+++ b/packages/host/app/templates/render/icon.gts
@@ -2,7 +2,7 @@ import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
 import RouteTemplate from 'ember-route-template';
 
-import { Model } from '../../routes/render/icon';
+import type { Model } from '../../routes/render/icon';
 
 export default RouteTemplate(<template>
   <@model.Component />

--- a/packages/host/app/templates/render/meta.gts
+++ b/packages/host/app/templates/render/meta.gts
@@ -2,7 +2,7 @@ import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
 import RouteTemplate from 'ember-route-template';
 
-import { Model } from '../../routes/render/meta';
+import type { Model } from '../../routes/render/meta';
 
 const { stringify } = JSON;
 

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -15,9 +15,9 @@ import stringify from 'safe-stable-stringify';
 
 import { GridContainer } from '@cardstack/boxel-ui/components';
 
+import type { ResolvedCodeRef } from '@cardstack/runtime-common';
 import {
   Deferred,
-  ResolvedCodeRef,
   baseRealm,
   ensureTrailingSlash,
   skillCardRef,
@@ -35,7 +35,7 @@ import type AiAssistantPanelService from '@cardstack/host/services/ai-assistant-
 import type MonacoService from '@cardstack/host/services/monaco-service';
 import { AiAssistantMessageDrafts } from '@cardstack/host/utils/local-storage-keys';
 
-import { BoxelContext } from 'https://cardstack.com/base/matrix-event';
+import type { BoxelContext } from 'https://cardstack.com/base/matrix-event';
 
 import {
   setupLocalIndexing,

--- a/packages/host/tests/acceptance/catalog-app-test.gts
+++ b/packages/host/tests/acceptance/catalog-app-test.gts
@@ -19,7 +19,7 @@ import ListingUseCommand from '@cardstack/host/commands/listing-use';
 
 import ENV from '@cardstack/host/config/environment';
 
-import { CardDef } from 'https://cardstack.com/base/card-api';
+import type { CardDef } from 'https://cardstack.com/base/card-api';
 
 import {
   setupLocalIndexing,

--- a/packages/host/tests/acceptance/code-patches-test.gts
+++ b/packages/host/tests/acceptance/code-patches-test.gts
@@ -30,13 +30,14 @@ import {
   setupAuthEndpoints,
   setupUserSubscription,
   getMonacoContent,
-  TestContextWithSave,
 } from '../helpers';
 
 import { CardsGrid, setupBaseRealm } from '../helpers/base-realm';
 
 import { setupMockMatrix } from '../helpers/mock-matrix';
 import { setupApplicationTest } from '../helpers/setup';
+
+import type { TestContextWithSave } from '../helpers';
 
 let mockedFileContent = 'Hello, world!';
 

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -18,9 +18,11 @@ import {
   setupAuthEndpoints,
   setupUserSubscription,
 } from '../../helpers';
-import { TestRealmAdapter } from '../../helpers/adapter';
+
 import { setupMockMatrix } from '../../helpers/mock-matrix';
 import { setupApplicationTest } from '../../helpers/setup';
+
+import type { TestRealmAdapter } from '../../helpers/adapter';
 
 const testRealmURL2 = 'http://test-realm/test2/';
 const testRealmAIconURL = 'https://i.postimg.cc/L8yXRvws/icon.png';

--- a/packages/host/tests/acceptance/commands-test.gts
+++ b/packages/host/tests/acceptance/commands-test.gts
@@ -45,7 +45,7 @@ import {
 
 import type { SearchCardsByTypeAndTitleInput } from 'https://cardstack.com/base/command';
 
-import { Skill } from 'https://cardstack.com/base/skill';
+import type { Skill } from 'https://cardstack.com/base/skill';
 
 import {
   setupLocalIndexing,

--- a/packages/host/tests/acceptance/interact-submode-creation-and-permissions-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-creation-and-permissions-test.gts
@@ -13,11 +13,8 @@ import { getService } from '@universal-ember/test-support';
 import window from 'ember-window-mock';
 import { module, test } from 'qunit';
 
-import {
-  Deferred,
-  SingleCardDocument,
-  isLocalId,
-} from '@cardstack/runtime-common';
+import type { SingleCardDocument } from '@cardstack/runtime-common';
+import { Deferred, isLocalId } from '@cardstack/runtime-common';
 
 import { claimsFromRawToken } from '@cardstack/host/services/realm';
 import { RecentCards } from '@cardstack/host/utils/local-storage-keys';

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -16,7 +16,7 @@ import {
   Deferred,
   type LooseSingleCardDocument,
 } from '@cardstack/runtime-common';
-import { Realm } from '@cardstack/runtime-common/realm';
+import type { Realm } from '@cardstack/runtime-common/realm';
 
 import type {
   IncrementalIndexEventContent,

--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -16,11 +16,14 @@ import ms from 'ms';
 
 import { validate as uuidValidate } from 'uuid';
 
-import {
+import type {
   RealmAdapter,
   LooseSingleCardDocument,
-  baseRealm,
   RealmPermissions,
+  RealmAction,
+} from '@cardstack/runtime-common';
+import {
+  baseRealm,
   Worker,
   IndexWriter,
   type RealmInfo,
@@ -28,7 +31,6 @@ import {
   type Prerenderer,
   insertPermissions,
   unixTime,
-  RealmAction,
   type RenderError,
   type DefinitionLookup,
   CachingDefinitionLookup,
@@ -49,7 +51,7 @@ import ENV from '@cardstack/host/config/environment';
 import { render as renderIntoElement } from '@cardstack/host/lib/isolated-render';
 import SQLiteAdapter from '@cardstack/host/lib/sqlite-adapter';
 import type NetworkService from '@cardstack/host/services/network';
-import { RealmServerTokenClaims } from '@cardstack/host/services/realm-server';
+import type { RealmServerTokenClaims } from '@cardstack/host/services/realm-server';
 import type { CardSaveSubscriber } from '@cardstack/host/services/store';
 
 import {
@@ -57,10 +59,10 @@ import {
   normalizeRenderError,
 } from '@cardstack/host/utils/render-error';
 
-import {
-  type CardStore,
-  type CardDef,
-  type FieldDef,
+import type {
+  CardStore,
+  CardDef,
+  FieldDef,
 } from 'https://cardstack.com/base/card-api';
 
 import { TestRealmAdapter } from './adapter';

--- a/packages/host/tests/helpers/interact-submode-setup.gts
+++ b/packages/host/tests/helpers/interact-submode-setup.gts
@@ -5,7 +5,7 @@ import { getService } from '@universal-ember/test-support';
 import { FieldContainer, GridContainer } from '@cardstack/boxel-ui/components';
 
 import { baseRealm } from '@cardstack/runtime-common';
-import { Realm } from '@cardstack/runtime-common/realm';
+import type { Realm } from '@cardstack/runtime-common/realm';
 
 import {
   SYSTEM_CARD_FIXTURE_CONTENTS,

--- a/packages/host/tests/integration/audio-fields-test.gts
+++ b/packages/host/tests/integration/audio-fields-test.gts
@@ -2,7 +2,7 @@ import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { ensureTrailingSlash } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import ENV from '@cardstack/host/config/environment';
 

--- a/packages/host/tests/integration/commands/add-field-to-card-definition-command-test.gts
+++ b/packages/host/tests/integration/commands/add-field-to-card-definition-command-test.gts
@@ -1,5 +1,5 @@
 import { getOwner } from '@ember/owner';
-import { RenderingTestContext } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';

--- a/packages/host/tests/integration/commands/check-correctness-test.gts
+++ b/packages/host/tests/integration/commands/check-correctness-test.gts
@@ -1,7 +1,7 @@
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
-import { type CommandContext } from '@cardstack/runtime-common';
+import type { CommandContext } from '@cardstack/runtime-common';
 
 import CheckCorrectnessCommand from '@cardstack/host/commands/check-correctness';
 import PatchCardInstanceCommand from '@cardstack/host/commands/patch-card-instance';

--- a/packages/host/tests/integration/commands/commands-calling-test.gts
+++ b/packages/host/tests/integration/commands/commands-calling-test.gts
@@ -1,10 +1,11 @@
 import { getOwner } from '@ember/owner';
-import { RenderingTestContext } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
-import { Command, CommandContext } from '@cardstack/runtime-common';
+import type { CommandContext } from '@cardstack/runtime-common';
+import { Command } from '@cardstack/runtime-common';
 
 import RealmService from '@cardstack/host/services/realm';
 

--- a/packages/host/tests/integration/commands/copy-and-edit-test.gts
+++ b/packages/host/tests/integration/commands/copy-and-edit-test.gts
@@ -8,7 +8,7 @@ import { realmURL as realmURLSymbol } from '@cardstack/runtime-common';
 import CopyAndEditCommand from '@cardstack/host/commands/copy-and-edit';
 import { StackItem } from '@cardstack/host/lib/stack-item';
 
-import { CardDef } from 'https://cardstack.com/base/card-api';
+import type { CardDef } from 'https://cardstack.com/base/card-api';
 
 import {
   setupIntegrationTestRealm,

--- a/packages/host/tests/integration/commands/copy-card-test.gts
+++ b/packages/host/tests/integration/commands/copy-card-test.gts
@@ -7,7 +7,7 @@ import CopyCardToRealmCommand from '@cardstack/host/commands/copy-card';
 import CopyCardToStackCommand from '@cardstack/host/commands/copy-card-to-stack';
 import { StackItem } from '@cardstack/host/lib/stack-item';
 
-import { CardDef } from 'https://cardstack.com/base/card-api';
+import type { CardDef } from 'https://cardstack.com/base/card-api';
 
 import {
   setupIntegrationTestRealm,

--- a/packages/host/tests/integration/commands/copy-source-test.gts
+++ b/packages/host/tests/integration/commands/copy-source-test.gts
@@ -1,5 +1,5 @@
 import { getOwner } from '@ember/owner';
-import { RenderingTestContext } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';

--- a/packages/host/tests/integration/commands/create-spec-test.gts
+++ b/packages/host/tests/integration/commands/create-spec-test.gts
@@ -2,11 +2,11 @@ import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import CreateSpecCommand from '@cardstack/host/commands/create-specs';
 
-import { Spec } from 'https://cardstack.com/base/spec';
+import type { Spec } from 'https://cardstack.com/base/spec';
 
 import {
   testRealmURL,

--- a/packages/host/tests/integration/commands/patch-instance-test.gts
+++ b/packages/host/tests/integration/commands/patch-instance-test.gts
@@ -4,13 +4,13 @@ import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { localId, type SingleCardDocument } from '@cardstack/runtime-common';
-import { type RealmIndexQueryEngine } from '@cardstack/runtime-common/realm-index-query-engine';
+import type { RealmIndexQueryEngine } from '@cardstack/runtime-common/realm-index-query-engine';
 
 import PatchCardInstanceCommand from '@cardstack/host/commands/patch-card-instance';
 
 import type CommandService from '@cardstack/host/services/command-service';
 
-import { CardDef as CardDefType } from 'https://cardstack.com/base/card-api';
+import type { CardDef as CardDefType } from 'https://cardstack.com/base/card-api';
 
 import {
   testRealmURL,

--- a/packages/host/tests/integration/commands/preview-format-test.gts
+++ b/packages/host/tests/integration/commands/preview-format-test.gts
@@ -1,5 +1,5 @@
 import { getOwner } from '@ember/owner';
-import { RenderingTestContext } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { setupWindowMock } from 'ember-window-mock/test-support';
@@ -7,7 +7,7 @@ import { setupWindowMock } from 'ember-window-mock/test-support';
 import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import PreviewFormatCommand from '@cardstack/host/commands/preview-format';
 import RealmService from '@cardstack/host/services/realm';

--- a/packages/host/tests/integration/commands/read-card-for-ai-assistant-test.gts
+++ b/packages/host/tests/integration/commands/read-card-for-ai-assistant-test.gts
@@ -1,5 +1,5 @@
 import { getOwner } from '@ember/owner';
-import { RenderingTestContext } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';

--- a/packages/host/tests/integration/commands/read-file-for-ai-assistant-test.gts
+++ b/packages/host/tests/integration/commands/read-file-for-ai-assistant-test.gts
@@ -1,5 +1,5 @@
 import { getOwner } from '@ember/owner';
-import { RenderingTestContext } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';

--- a/packages/host/tests/integration/commands/read-source-test.gts
+++ b/packages/host/tests/integration/commands/read-source-test.gts
@@ -1,5 +1,5 @@
 import { getOwner } from '@ember/owner';
-import { RenderingTestContext } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';

--- a/packages/host/tests/integration/commands/read-text-file-test.gts
+++ b/packages/host/tests/integration/commands/read-text-file-test.gts
@@ -1,5 +1,5 @@
 import { getOwner } from '@ember/owner';
-import { RenderingTestContext } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, skip, test } from 'qunit';

--- a/packages/host/tests/integration/commands/schema-generation-test.gts
+++ b/packages/host/tests/integration/commands/schema-generation-test.gts
@@ -4,16 +4,14 @@ import { setupWindowMock } from 'ember-window-mock/test-support';
 import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
-import {
-  AttributesSchema,
-  basicMappings,
-} from '@cardstack/runtime-common/helpers/ai';
+import type { AttributesSchema } from '@cardstack/runtime-common/helpers/ai';
+import { basicMappings } from '@cardstack/runtime-common/helpers/ai';
 
 import { HostCommandClasses } from '@cardstack/host/commands';
 
-import HostBaseCommand from '@cardstack/host/lib/host-base-command';
+import type HostBaseCommand from '@cardstack/host/lib/host-base-command';
 
-import * as CardAPI from 'https://cardstack.com/base/card-api';
+import type * as CardAPI from 'https://cardstack.com/base/card-api';
 
 import { setupRenderingTest } from '../../helpers/setup';
 

--- a/packages/host/tests/integration/commands/search-command-test.gts
+++ b/packages/host/tests/integration/commands/search-command-test.gts
@@ -2,7 +2,7 @@ import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import {
   SearchCardsByQueryCommand,

--- a/packages/host/tests/integration/commands/send-ai-assistant-message-test.gts
+++ b/packages/host/tests/integration/commands/send-ai-assistant-message-test.gts
@@ -1,5 +1,5 @@
 import { getOwner } from '@ember/owner';
-import { RenderingTestContext } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';

--- a/packages/host/tests/integration/commands/send-request-via-proxy-test.gts
+++ b/packages/host/tests/integration/commands/send-request-via-proxy-test.gts
@@ -1,5 +1,5 @@
 import { getOwner } from '@ember/owner';
-import { RenderingTestContext } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';

--- a/packages/host/tests/integration/commands/set-user-system-card-test.gts
+++ b/packages/host/tests/integration/commands/set-user-system-card-test.gts
@@ -1,5 +1,5 @@
 import { getOwner } from '@ember/owner';
-import { RenderingTestContext } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';

--- a/packages/host/tests/integration/commands/show-card-test.gts
+++ b/packages/host/tests/integration/commands/show-card-test.gts
@@ -1,6 +1,6 @@
 import { getOwner } from '@ember/owner';
 import Service from '@ember/service';
-import { RenderingTestContext } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
 
 import { tracked } from '@glimmer/tracking';
 
@@ -11,7 +11,7 @@ import { module, test, skip } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
 import { basicMappings } from '@cardstack/runtime-common/helpers/ai';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import ShowCardCommand from '@cardstack/host/commands/show-card';
 import { StackItem } from '@cardstack/host/lib/stack-item';
@@ -19,7 +19,7 @@ import { StackItem } from '@cardstack/host/lib/stack-item';
 import type { OperatorModeState } from '@cardstack/host/services/operator-mode-state-service';
 import RealmService from '@cardstack/host/services/realm';
 
-import * as CardAPI from 'https://cardstack.com/base/card-api';
+import type * as CardAPI from 'https://cardstack.com/base/card-api';
 
 import {
   setupCardLogs,

--- a/packages/host/tests/integration/commands/summarize-session-test.gts
+++ b/packages/host/tests/integration/commands/summarize-session-test.gts
@@ -1,5 +1,5 @@
 import { getOwner } from '@ember/owner';
-import { RenderingTestContext } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';

--- a/packages/host/tests/integration/commands/switch-submode-test.gts
+++ b/packages/host/tests/integration/commands/switch-submode-test.gts
@@ -1,5 +1,5 @@
 import { getOwner } from '@ember/owner';
-import { RenderingTestContext } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
@@ -10,7 +10,7 @@ import SwitchSubmodeCommand from '@cardstack/host/commands/switch-submode';
 import RealmService from '@cardstack/host/services/realm';
 import type StoreService from '@cardstack/host/services/store';
 
-import { CardDef as CardDefType } from 'https://cardstack.com/base/card-api';
+import type { CardDef as CardDefType } from 'https://cardstack.com/base/card-api';
 
 import {
   setupIntegrationTestRealm,

--- a/packages/host/tests/integration/commands/transform-cards-test.gts
+++ b/packages/host/tests/integration/commands/transform-cards-test.gts
@@ -1,12 +1,12 @@
 import { getOwner } from '@ember/owner';
-import { RenderingTestContext } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, skip, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
 import { Command } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import TransformCardsCommand from '@cardstack/host/commands/transform-cards';
 

--- a/packages/host/tests/integration/commands/update-room-skills-test.gts
+++ b/packages/host/tests/integration/commands/update-room-skills-test.gts
@@ -1,6 +1,6 @@
 import { getOwner } from '@ember/owner';
 import Service from '@ember/service';
-import { RenderingTestContext } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { setupWindowMock } from 'ember-window-mock/test-support';
@@ -9,7 +9,7 @@ import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
 import { basicMappings } from '@cardstack/runtime-common/helpers/ai';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import UpdateRoomSkillsCommand from '@cardstack/host/commands/update-room-skills';
 import { skillCardURL } from '@cardstack/host/lib/utils';

--- a/packages/host/tests/integration/commands/upload-image-test.gts
+++ b/packages/host/tests/integration/commands/upload-image-test.gts
@@ -1,5 +1,5 @@
 import { getOwner } from '@ember/owner';
-import { RenderingTestContext } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';

--- a/packages/host/tests/integration/commands/use-ai-assistant-test.gts
+++ b/packages/host/tests/integration/commands/use-ai-assistant-test.gts
@@ -1,5 +1,5 @@
 import { getOwner } from '@ember/owner';
-import { RenderingTestContext } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';

--- a/packages/host/tests/integration/commands/write-text-file-test.gts
+++ b/packages/host/tests/integration/commands/write-text-file-test.gts
@@ -1,5 +1,5 @@
 import { getOwner } from '@ember/owner';
-import { RenderingTestContext } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';

--- a/packages/host/tests/integration/components/ai-assistant-panel/codeblocks-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/codeblocks-test.gts
@@ -1,10 +1,6 @@
 /* eslint-disable no-irregular-whitespace */
-import {
-  waitFor,
-  waitUntil,
-  click,
-  RenderingTestContext,
-} from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
+import { waitFor, waitUntil, click } from '@ember/test-helpers';
 import { settled } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 
@@ -19,7 +15,7 @@ import {
   SEPARATOR_MARKER,
   baseRealm,
 } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
 

--- a/packages/host/tests/integration/components/ai-assistant-panel/commands-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/commands-test.gts
@@ -7,7 +7,7 @@ import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import {
   APP_BOXEL_COMMAND_REQUESTS_KEY,

--- a/packages/host/tests/integration/components/ai-assistant-panel/debug-message-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/debug-message-test.gts
@@ -8,7 +8,7 @@ import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
 
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import {
   APP_BOXEL_DEBUG_MESSAGE_EVENT_TYPE,

--- a/packages/host/tests/integration/components/ai-assistant-panel/general-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/general-test.gts
@@ -16,7 +16,7 @@ import { format, subMinutes } from 'date-fns';
 import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import {
   APP_BOXEL_COMMAND_REQUESTS_KEY,
@@ -28,7 +28,7 @@ import {
 
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
 
-import LocalPersistenceService from '@cardstack/host/services/local-persistence-service';
+import type LocalPersistenceService from '@cardstack/host/services/local-persistence-service';
 
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 

--- a/packages/host/tests/integration/components/ai-assistant-panel/past-sessions-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/past-sessions-test.gts
@@ -6,7 +6,7 @@ import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import { APP_BOXEL_MESSAGE_MSGTYPE } from '@cardstack/runtime-common/matrix-constants';
 

--- a/packages/host/tests/integration/components/ai-assistant-panel/reasoning-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/reasoning-test.gts
@@ -7,7 +7,7 @@ import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import { APP_BOXEL_REASONING_CONTENT_KEY } from '@cardstack/runtime-common/matrix-constants';
 

--- a/packages/host/tests/integration/components/ai-assistant-panel/scrolling-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/scrolling-test.gts
@@ -7,7 +7,7 @@ import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import { APP_BOXEL_MESSAGE_MSGTYPE } from '@cardstack/runtime-common/matrix-constants';
 

--- a/packages/host/tests/integration/components/ai-assistant-panel/sending-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/sending-test.gts
@@ -14,7 +14,7 @@ import window from 'ember-window-mock';
 import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
 import { Submodes } from '@cardstack/host/components/submode-switcher';

--- a/packages/host/tests/integration/components/ai-assistant-panel/skills-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/skills-test.gts
@@ -13,7 +13,7 @@ import {
   baseRealm,
   skillCardRef,
 } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import {
   APP_BOXEL_COMMAND_REQUESTS_KEY,
@@ -25,7 +25,7 @@ import OperatorMode from '@cardstack/host/components/operator-mode/container';
 
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
-import { FileDef } from 'https://cardstack.com/base/file-api';
+import type { FileDef } from 'https://cardstack.com/base/file-api';
 
 import {
   testRealmURL,

--- a/packages/host/tests/integration/components/ai-module-creation-test.gts
+++ b/packages/host/tests/integration/components/ai-module-creation-test.gts
@@ -6,7 +6,8 @@ import { getService } from '@universal-ember/test-support';
 
 import { module, skip } from 'qunit';
 
-import { baseRealm, Loader, type Realm } from '@cardstack/runtime-common';
+import type { Loader } from '@cardstack/runtime-common';
+import { baseRealm, type Realm } from '@cardstack/runtime-common';
 
 import { ensureTrailingSlash } from '@cardstack/runtime-common';
 import {
@@ -18,7 +19,7 @@ import {
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
 import ENV from '@cardstack/host/config/environment';
 
-import OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
+import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 
 import type { CardMessageContent } from 'https://cardstack.com/base/matrix-event';
 

--- a/packages/host/tests/integration/components/ask-ai-test.gts
+++ b/packages/host/tests/integration/components/ask-ai-test.gts
@@ -6,7 +6,7 @@ import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
 

--- a/packages/host/tests/integration/components/card-api-test.gts
+++ b/packages/host/tests/integration/components/card-api-test.gts
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { RenderingTestContext } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
 
 import { fillIn } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
@@ -16,7 +16,6 @@ import { CardContextName } from '@cardstack/runtime-common';
 import { getSearch } from '@cardstack/host/resources/search';
 
 import {
-  CardDocFiles,
   setupIntegrationTestRealm,
   setupLocalIndexing,
   testRealmURL,
@@ -32,6 +31,8 @@ import {
 import { setupMockMatrix } from '../../helpers/mock-matrix';
 import { renderComponent } from '../../helpers/render-component';
 import { setupRenderingTest } from '../../helpers/setup';
+
+import type { CardDocFiles } from '../../helpers';
 
 interface CardContextProviderSignature {
   Args: {};

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -1,12 +1,12 @@
 import { on } from '@ember/modifier';
 import type Owner from '@ember/owner';
+import type { RenderingTestContext } from '@ember/test-helpers';
 import {
   waitUntil,
   waitFor,
   fillIn,
   click,
   render,
-  RenderingTestContext,
   triggerEvent,
 } from '@ember/test-helpers';
 
@@ -24,6 +24,7 @@ import { BoxelInput } from '@cardstack/boxel-ui/components';
 
 import { dayjsFormat } from '@cardstack/boxel-ui/helpers';
 
+import type { Loader } from '@cardstack/runtime-common';
 import {
   baseRealm,
   primitive,
@@ -31,7 +32,6 @@ import {
   PermissionsContextName,
   fields,
   cardTypeDisplayName,
-  Loader,
   type CodeRef,
 } from '@cardstack/runtime-common';
 

--- a/packages/host/tests/integration/components/card-copy-test.gts
+++ b/packages/host/tests/integration/components/card-copy-test.gts
@@ -12,13 +12,13 @@ import {
   type SingleCardDocument,
   type LooseSingleCardDocument,
 } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 import { APP_BOXEL_REALM_EVENT_TYPE } from '@cardstack/runtime-common/matrix-constants';
-import { Realm } from '@cardstack/runtime-common/realm';
+import type { Realm } from '@cardstack/runtime-common/realm';
 
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
 
-import {
+import type {
   IncrementalIndexEventContent,
   IndexRealmEventContent,
 } from 'https://cardstack.com/base/matrix-event';

--- a/packages/host/tests/integration/components/card-def-field-def-relationships-test.gts
+++ b/packages/host/tests/integration/components/card-def-field-def-relationships-test.gts
@@ -8,7 +8,7 @@ import {
   type Permissions,
   baseRealm,
 } from '@cardstack/runtime-common';
-import { type Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
 

--- a/packages/host/tests/integration/components/card-delete-test.gts
+++ b/packages/host/tests/integration/components/card-delete-test.gts
@@ -6,12 +6,12 @@ import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
-import { Realm } from '@cardstack/runtime-common/realm';
+import type { Loader } from '@cardstack/runtime-common/loader';
+import type { Realm } from '@cardstack/runtime-common/realm';
 
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
 
-import { CardDef } from 'https://cardstack.com/base/card-api';
+import type { CardDef } from 'https://cardstack.com/base/card-api';
 
 import {
   testRealmURL,
@@ -22,10 +22,12 @@ import {
   setupIntegrationTestRealm,
   setupOperatorModeStateCleanup,
 } from '../../helpers';
-import { TestRealmAdapter } from '../../helpers/adapter';
+
 import { setupMockMatrix } from '../../helpers/mock-matrix';
 import { renderComponent } from '../../helpers/render-component';
 import { setupRenderingTest } from '../../helpers/setup';
+
+import type { TestRealmAdapter } from '../../helpers/adapter';
 
 let loader: Loader;
 let cardApi: typeof import('https://cardstack.com/base/card-api');

--- a/packages/host/tests/integration/components/computed-test.gts
+++ b/packages/host/tests/integration/components/computed-test.gts
@@ -1,4 +1,5 @@
-import { RenderingTestContext, settled } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
+import { settled } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
@@ -8,7 +9,7 @@ import {
   type Permissions,
   baseRealm,
 } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import {
   cleanWhiteSpace,

--- a/packages/host/tests/integration/components/formatted-aibot-message-test.gts
+++ b/packages/host/tests/integration/components/formatted-aibot-message-test.gts
@@ -1,11 +1,6 @@
-import Owner from '@ember/owner';
-import {
-  RenderingTestContext,
-  click,
-  render,
-  settled,
-  waitFor,
-} from '@ember/test-helpers';
+import type Owner from '@ember/owner';
+import type { RenderingTestContext } from '@ember/test-helpers';
+import { click, render, settled, waitFor } from '@ember/test-helpers';
 
 import { waitUntil } from '@ember/test-helpers';
 
@@ -28,8 +23,8 @@ import {
   makeCodeDiffStats,
   parseHtmlContent,
 } from '@cardstack/host/lib/formatted-message/utils';
-import CardService from '@cardstack/host/services/card-service';
-import MonacoService from '@cardstack/host/services/monaco-service';
+import type CardService from '@cardstack/host/services/card-service';
+import type MonacoService from '@cardstack/host/services/monaco-service';
 
 import { renderComponent } from '../../helpers/render-component';
 import { setupRenderingTest } from '../../helpers/setup';

--- a/packages/host/tests/integration/components/formatted-user-message-test.gts
+++ b/packages/host/tests/integration/components/formatted-user-message-test.gts
@@ -1,4 +1,5 @@
-import { RenderingTestContext, render } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 
 import { module, test } from 'qunit';
 

--- a/packages/host/tests/integration/components/loading-test.gts
+++ b/packages/host/tests/integration/components/loading-test.gts
@@ -2,7 +2,7 @@ import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -17,13 +17,9 @@ import { module, test } from 'qunit';
 
 import { FieldContainer } from '@cardstack/boxel-ui/components';
 
-import {
-  baseRealm,
-  Deferred,
-  LooseSingleCardDocument,
-  Realm,
-} from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { LooseSingleCardDocument, Realm } from '@cardstack/runtime-common';
+import { baseRealm, Deferred } from '@cardstack/runtime-common';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
 
@@ -40,10 +36,12 @@ import {
   withSlowSave,
   setupOperatorModeStateCleanup,
 } from '../../helpers';
-import { TestRealmAdapter } from '../../helpers/adapter';
+
 import { setupMockMatrix } from '../../helpers/mock-matrix';
 import { renderComponent } from '../../helpers/render-component';
 import { setupRenderingTest } from '../../helpers/setup';
+
+import type { TestRealmAdapter } from '../../helpers/adapter';
 
 module('Integration | operator-mode', function (hooks) {
   setupRenderingTest(hooks);

--- a/packages/host/tests/integration/components/prerendered-card-search-test.gts
+++ b/packages/host/tests/integration/components/prerendered-card-search-test.gts
@@ -1,4 +1,5 @@
-import { RenderingTestContext, render, waitFor } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
+import { render, waitFor } from '@ember/test-helpers';
 
 import { waitUntil } from '@ember/test-helpers';
 
@@ -9,8 +10,8 @@ import Modifier from 'ember-modifier';
 import { provide } from 'ember-provide-consume-context';
 import { module, test } from 'qunit';
 
+import type { Query } from '@cardstack/runtime-common';
 import {
-  Query,
   baseRealm,
   type Realm,
   type LooseSingleCardDocument,
@@ -20,7 +21,6 @@ import {
 import PrerenderedCardSearch from '@cardstack/host/components/prerendered-card-search';
 
 import {
-  CardDocFiles,
   setupIntegrationTestRealm,
   setupLocalIndexing,
   testRealmURL,
@@ -36,6 +36,8 @@ import {
 } from '../../helpers/base-realm';
 import { setupMockMatrix } from '../../helpers/mock-matrix';
 import { setupRenderingTest } from '../../helpers/setup';
+
+import type { CardDocFiles } from '../../helpers';
 
 interface CardContextWithModifierSignature {
   Blocks: { default: [] };

--- a/packages/host/tests/integration/components/preview-test.gts
+++ b/packages/host/tests/integration/components/preview-test.gts
@@ -6,7 +6,7 @@ import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import CardRenderer from '@cardstack/host/components/card-renderer';
 

--- a/packages/host/tests/integration/components/realm-field-test.gts
+++ b/packages/host/tests/integration/components/realm-field-test.gts
@@ -15,7 +15,7 @@ import {
   PermissionsContextName,
   type CommandContext,
 } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import { provideConsumeContext, setupCardLogs } from '../../helpers';
 import {

--- a/packages/host/tests/integration/components/room-message-test.gts
+++ b/packages/host/tests/integration/components/room-message-test.gts
@@ -19,7 +19,7 @@ import RoomMessage, {
 import { parseHtmlContent } from '@cardstack/host/lib/formatted-message/utils';
 import { getCardCollection } from '@cardstack/host/resources/card-collection';
 import { getCard } from '@cardstack/host/resources/card-resource';
-import { type RoomResource } from '@cardstack/host/resources/room';
+import type { RoomResource } from '@cardstack/host/resources/room';
 import { getSearch } from '@cardstack/host/resources/search';
 
 import { setupMockMatrix } from '../../helpers/mock-matrix';

--- a/packages/host/tests/integration/components/serialization-test.gts
+++ b/packages/host/tests/integration/components/serialization-test.gts
@@ -1,4 +1,5 @@
-import { fillIn, RenderingTestContext } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
+import { fillIn } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import formatISO from 'date-fns/formatISO';
@@ -7,6 +8,7 @@ import parseISO from 'date-fns/parseISO';
 import { isAddress } from 'ethers';
 import { module, test } from 'qunit';
 
+import type { LooseCardResource } from '@cardstack/runtime-common';
 import {
   baseRealm,
   PermissionsContextName,
@@ -15,10 +17,9 @@ import {
   meta,
   type LooseSingleCardDocument,
   type Permissions,
-  LooseCardResource,
 } from '@cardstack/runtime-common';
 import { realmURL } from '@cardstack/runtime-common/constants';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import type { CardDef as CardDefType } from 'https://cardstack.com/base/card-api';
 

--- a/packages/host/tests/integration/components/text-input-validator-test.gts
+++ b/packages/host/tests/integration/components/text-input-validator-test.gts
@@ -6,7 +6,7 @@ import { getService } from '@universal-ember/test-support';
 
 import { module, test } from 'qunit';
 
-import { type Realm } from '@cardstack/runtime-common';
+import type { Realm } from '@cardstack/runtime-common';
 
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
 

--- a/packages/host/tests/integration/components/text-suggestion-test.gts
+++ b/packages/host/tests/integration/components/text-suggestion-test.gts
@@ -1,9 +1,10 @@
-import { RenderingTestContext } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
-import { baseRealm, Loader } from '@cardstack/runtime-common';
+import type { Loader } from '@cardstack/runtime-common';
+import { baseRealm } from '@cardstack/runtime-common';
 
 import {
   suggestCardChooserTitle,

--- a/packages/host/tests/integration/date-time-fields-test.gts
+++ b/packages/host/tests/integration/date-time-fields-test.gts
@@ -4,7 +4,7 @@ import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { ensureTrailingSlash } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import ENV from '@cardstack/host/config/environment';
 

--- a/packages/host/tests/integration/email-field-test.gts
+++ b/packages/host/tests/integration/email-field-test.gts
@@ -8,7 +8,7 @@ import {
   type Permissions,
   baseRealm,
 } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import { provideConsumeContext, setupCardLogs } from '../helpers';
 import {

--- a/packages/host/tests/integration/enum-field-test.gts
+++ b/packages/host/tests/integration/enum-field-test.gts
@@ -1,4 +1,5 @@
-import { RenderingTestContext, click } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
+import { click } from '@ember/test-helpers';
 
 import ArrowDownIcon from '@cardstack/boxel-icons/arrow-down';
 import ArrowUpIcon from '@cardstack/boxel-icons/arrow-up';
@@ -13,7 +14,7 @@ import {
   baseRealm,
   getField,
 } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import {
   provideConsumeContext,

--- a/packages/host/tests/integration/field-configuration-test.gts
+++ b/packages/host/tests/integration/field-configuration-test.gts
@@ -1,11 +1,12 @@
-import { RenderingTestContext, settled } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
+import { settled } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { baseRealm, Deferred } from '@cardstack/runtime-common';
 import type { SingleCardDocument } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import type {
   CardStore,

--- a/packages/host/tests/integration/image-field-configuration-test.gts
+++ b/packages/host/tests/integration/image-field-configuration-test.gts
@@ -2,7 +2,7 @@ import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { ensureTrailingSlash } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import ENV from '@cardstack/host/config/environment';
 

--- a/packages/host/tests/integration/message-service-subscription-test.gts
+++ b/packages/host/tests/integration/message-service-subscription-test.gts
@@ -1,5 +1,6 @@
 import { on } from '@ember/modifier';
-import { click, settled, RenderingTestContext } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
+import { click, settled } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 
 // @ts-expect-error says unused but the component uses it
@@ -10,7 +11,7 @@ import { module, test } from 'qunit';
 
 import { baseRealm } from '@cardstack/runtime-common';
 import { testRealmURLToUsername } from '@cardstack/runtime-common/helpers/const';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 import { APP_BOXEL_REALM_EVENT_TYPE } from '@cardstack/runtime-common/matrix-constants';
 
 import SubscribeToRealms from '@cardstack/host/helpers/subscribe-to-realms';

--- a/packages/host/tests/integration/multiple-image-field-configuration-test.gts
+++ b/packages/host/tests/integration/multiple-image-field-configuration-test.gts
@@ -2,7 +2,7 @@ import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { ensureTrailingSlash } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import ENV from '@cardstack/host/config/environment';
 

--- a/packages/host/tests/integration/number-field-configuration-test.gts
+++ b/packages/host/tests/integration/number-field-configuration-test.gts
@@ -2,7 +2,7 @@ import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { ensureTrailingSlash } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import ENV from '@cardstack/host/config/environment';
 

--- a/packages/host/tests/integration/phone-number-field-test.gts
+++ b/packages/host/tests/integration/phone-number-field-test.gts
@@ -8,7 +8,7 @@ import {
   type Permissions,
   baseRealm,
 } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import { provideConsumeContext, setupCardLogs } from '../helpers';
 import {

--- a/packages/host/tests/integration/realm-indexing-test.gts
+++ b/packages/host/tests/integration/realm-indexing-test.gts
@@ -1,4 +1,4 @@
-import { RenderingTestContext } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
 import GlimmerComponent from '@glimmer/component';
 
 import { getService } from '@universal-ember/test-support';
@@ -14,7 +14,7 @@ import {
   type Realm,
 } from '@cardstack/runtime-common';
 import stripScopedCSSAttributes from '@cardstack/runtime-common/helpers/strip-scoped-css-attributes';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import { windowErrorHandler } from '@cardstack/host/lib/window-error-handler';
 

--- a/packages/host/tests/integration/realm-querying-test.gts
+++ b/packages/host/tests/integration/realm-querying-test.gts
@@ -1,13 +1,13 @@
-import { RenderingTestContext } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { baseRealm, baseCardRef } from '@cardstack/runtime-common';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 import { RealmPaths } from '@cardstack/runtime-common/paths';
 
-import { RealmIndexQueryEngine } from '@cardstack/runtime-common/realm-index-query-engine';
+import type { RealmIndexQueryEngine } from '@cardstack/runtime-common/realm-index-query-engine';
 
 import {
   testRealmURL,

--- a/packages/host/tests/integration/realm-test.gts
+++ b/packages/host/tests/integration/realm-test.gts
@@ -1,4 +1,4 @@
-import { RenderingTestContext } from '@ember/test-helpers';
+import type { RenderingTestContext } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { stringify } from 'qs';
@@ -6,7 +6,8 @@ import { module, test } from 'qunit';
 
 import { validate as uuidValidate } from 'uuid';
 
-import { baseRealm, Realm } from '@cardstack/runtime-common';
+import type { Realm } from '@cardstack/runtime-common';
+import { baseRealm } from '@cardstack/runtime-common';
 import { isSingleCardDocument } from '@cardstack/runtime-common/document-types';
 import {
   cardSrc,
@@ -14,7 +15,7 @@ import {
 } from '@cardstack/runtime-common/etc/test-fixtures';
 
 import stripScopedCSSGlimmerAttributes from '@cardstack/runtime-common/helpers/strip-scoped-css-glimmer-attributes';
-import { Loader } from '@cardstack/runtime-common/loader';
+import type { Loader } from '@cardstack/runtime-common/loader';
 
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
 import type * as StringFieldMod from 'https://cardstack.com/base/string';

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -26,7 +26,7 @@ import {
 } from '@cardstack/runtime-common';
 
 import OperatorMode from '@cardstack/host/components/operator-mode/container';
-import CardStore from '@cardstack/host/lib/gc-card-store';
+import type CardStore from '@cardstack/host/lib/gc-card-store';
 import { getCardCollection } from '@cardstack/host/resources/card-collection';
 import { getCard } from '@cardstack/host/resources/card-resource';
 import { getSearch } from '@cardstack/host/resources/search';
@@ -34,9 +34,9 @@ import type LoaderService from '@cardstack/host/services/loader-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 import type RealmService from '@cardstack/host/services/realm';
 import type StoreService from '@cardstack/host/services/store';
-import { type CardErrorJSONAPI } from '@cardstack/host/services/store';
+import type { CardErrorJSONAPI } from '@cardstack/host/services/store';
 
-import { CardDef as CardDefType } from 'https://cardstack.com/base/card-api';
+import type { CardDef as CardDefType } from 'https://cardstack.com/base/card-api';
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
 import type { RealmEventContent } from 'https://cardstack.com/base/matrix-event';
 
@@ -50,7 +50,7 @@ import {
   withSlowSave,
   setupOperatorModeStateCleanup,
 } from '../helpers';
-import { TestRealmAdapter } from '../helpers/adapter';
+
 import {
   CardDef,
   contains,
@@ -65,6 +65,8 @@ import {
 import { setupMockMatrix } from '../helpers/mock-matrix';
 import { renderComponent } from '../helpers/render-component';
 import { setupRenderingTest } from '../helpers/setup';
+
+import type { TestRealmAdapter } from '../helpers/adapter';
 
 module('Integration | Store', function (hooks) {
   setupRenderingTest(hooks);


### PR DESCRIPTION
The eslint config differed between TS and GTS files, and only one had the consistent-type-imports rule (which we want to make `@embroider/vite` work better).

This unifies the config so the superset of all the rules we had configured applies to both TS/JS and GTS/GJS, and auto-fixes the resulting failures.