### PR TITLE
Move definitions out of index

### DIFF
--- a/packages/host/config/schema/1765381896447_schema.sql
+++ b/packages/host/config/schema/1765381896447_schema.sql
@@ -22,7 +22,6 @@
    display_names BLOB,
    resource_created_at,
    icon_html TEXT,
-   definition BLOB,
    head_html TEXT,
    PRIMARY KEY ( url, realm_url ) 
 );
@@ -48,7 +47,6 @@
    fitted_html BLOB,
    display_names BLOB,
    resource_created_at,
-   definition BLOB,
    head_html TEXT,
    PRIMARY KEY ( url, realm_url ) 
 );

--- a/packages/host/tests/helpers/indexer.ts
+++ b/packages/host/tests/helpers/indexer.ts
@@ -19,8 +19,6 @@ import {
   type RealmVersionsTable,
   trimExecutableExtension,
   query,
-  isDefinitionId,
-  trimExportNameFromDefinitionId,
   coerceTypes,
 } from '@cardstack/runtime-common';
 
@@ -252,9 +250,10 @@ async function indexedCardsExpressions({
             ? `${row.url}.json`
             : row.url
           : row.url;
-      row.file_alias = isDefinitionId(row.url)
-        ? trimExportNameFromDefinitionId(row.url)
-        : trimExecutableExtension(new URL(row.url)).href.replace(/\.json$/, '');
+      row.file_alias = trimExecutableExtension(new URL(row.url)).href.replace(
+        /\.json$/,
+        '',
+      );
       row.type = row.type ?? 'instance';
       row.last_modified = String(row.last_modified ?? now);
 

--- a/packages/host/tests/integration/realm-indexing-test.gts
+++ b/packages/host/tests/integration/realm-indexing-test.gts
@@ -206,9 +206,7 @@ module(`Integration | realm indexing`, function (hooks) {
         instancesIndexed: 2,
         moduleErrors: 0,
         modulesIndexed: 1,
-        definitionErrors: 0,
-        definitionsIndexed: 1,
-        totalIndexEntries: 4,
+        totalIndexEntries: 3,
       },
       'indexer stats are correct',
     );
@@ -233,16 +231,6 @@ module(`Integration | realm indexing`, function (hooks) {
       } as LooseSingleCardDocument),
     );
 
-    let definitionEntry = await realm.realmIndexQueryEngine.getOwnDefinition({
-      module: `${testRealmURL}pet`,
-      name: 'Pet',
-    });
-    assert.strictEqual(
-      definitionEntry?.type,
-      'definition',
-      'definition entry exists',
-    );
-
     await realm.fullIndex();
 
     assert.deepEqual(
@@ -252,23 +240,9 @@ module(`Integration | realm indexing`, function (hooks) {
         instancesIndexed: 1,
         moduleErrors: 0,
         modulesIndexed: 0,
-        definitionErrors: 0,
-        definitionsIndexed: 0,
-        totalIndexEntries: 4,
+        totalIndexEntries: 3,
       },
       'indexer stats are correct',
-    );
-
-    // meta entries are notional so we want to make sure they didn't
-    // get tombstoned because the file wasn't found
-    definitionEntry = await realm.realmIndexQueryEngine.getOwnDefinition({
-      module: `${testRealmURL}pet`,
-      name: 'Pet',
-    });
-    assert.strictEqual(
-      definitionEntry?.type,
-      'definition',
-      'definition entry exists',
     );
   });
 
@@ -3569,8 +3543,6 @@ module(`Integration | realm indexing`, function (hooks) {
         instancesIndexed: 3,
         moduleErrors: 0,
         modulesIndexed: 0,
-        definitionErrors: 0,
-        definitionsIndexed: 0,
         totalIndexEntries: 3,
       },
       'instances are indexed without error',

--- a/packages/host/tests/unit/index-writer-test.ts
+++ b/packages/host/tests/unit/index-writer-test.ts
@@ -251,145 +251,6 @@ module('Unit | index-writer', function (hooks) {
     ]);
   });
 
-  test('definition entries can be invalidated', async function (assert) {
-    let modified = Date.now();
-    await setupIndex(
-      adapter,
-      [
-        { realm_url: testRealmURL, current_version: 1 },
-        { realm_url: testRealmURL2, current_version: 5 },
-      ],
-      [
-        {
-          url: `${testRealmURL}person.gts`,
-          file_alias: `${testRealmURL}person`,
-          type: 'module',
-          realm_version: 1,
-          realm_url: testRealmURL,
-          deps: [],
-          last_modified: String(modified),
-          resource_created_at: String(modified),
-        },
-        {
-          url: `${testRealmURL}person/Person`,
-          file_alias: `${testRealmURL}person`,
-          type: 'definition',
-          realm_version: 1,
-          realm_url: testRealmURL,
-          deps: [`${testRealmURL}person`],
-          last_modified: String(modified),
-          resource_created_at: String(modified),
-        },
-        {
-          url: `${testRealmURL}employee.gts`,
-          file_alias: `${testRealmURL}employee`,
-          type: 'module',
-          realm_version: 1,
-          realm_url: testRealmURL,
-          deps: [`${testRealmURL}person`],
-          last_modified: String(modified),
-          resource_created_at: String(modified),
-        },
-        {
-          url: `${testRealmURL}employee/Employee`,
-          file_alias: `${testRealmURL}employee`,
-          type: 'definition',
-          realm_version: 1,
-          realm_url: testRealmURL,
-          deps: [`${testRealmURL}employee`, `${testRealmURL}person`],
-          last_modified: String(modified),
-          resource_created_at: String(modified),
-        },
-        {
-          url: `${testRealmURL}1.json`,
-          file_alias: `${testRealmURL}1.json`,
-          type: 'instance',
-          realm_version: 1,
-          realm_url: testRealmURL,
-          deps: [`${testRealmURL}employee`],
-          last_modified: String(modified),
-          resource_created_at: String(modified),
-        },
-        {
-          url: `${testRealmURL}2.json`,
-          file_alias: `${testRealmURL}2.json`,
-          type: 'instance',
-          realm_version: 1,
-          realm_url: testRealmURL,
-          deps: [`${testRealmURL}1.json`],
-          last_modified: String(modified),
-          resource_created_at: String(modified),
-        },
-        {
-          url: `${testRealmURL}3.json`,
-          file_alias: `${testRealmURL}3.json`,
-          type: 'instance',
-          realm_version: 1,
-          realm_url: testRealmURL,
-          deps: [],
-          last_modified: String(modified),
-          resource_created_at: String(modified),
-        },
-      ],
-    );
-
-    let batch = await indexWriter.createBatch(new URL(testRealmURL));
-    await batch.invalidate([new URL(`${testRealmURL}person.gts`)]);
-    let invalidations = batch.invalidations;
-
-    // the definition id's are notional, they are not file resources that can be
-    // visited, so instead we return the module that contains the definition
-    assert.deepEqual(invalidations.sort(), [
-      `${testRealmURL}1.json`,
-      `${testRealmURL}2.json`,
-      `${testRealmURL}employee.gts`,
-      `${testRealmURL}person.gts`,
-    ]);
-
-    let personDefinition = await indexQueryEngine.getOwnDefinition({
-      module: `${testRealmURL}person`,
-      name: 'Person',
-    });
-    assert.strictEqual(
-      personDefinition?.type,
-      'definition',
-      'definition exists in production index',
-    );
-    personDefinition = await indexQueryEngine.getOwnDefinition(
-      {
-        module: `${testRealmURL}person`,
-        name: 'Person',
-      },
-      { useWorkInProgressIndex: true },
-    );
-    assert.strictEqual(
-      personDefinition,
-      undefined,
-      'definition entry has been marked for deletion in working index',
-    );
-    let employeeDefinition = await indexQueryEngine.getOwnDefinition({
-      module: `${testRealmURL}employee`,
-      name: 'Employee',
-    });
-    assert.strictEqual(
-      employeeDefinition?.type,
-      'definition',
-      'definition exists in production index',
-    );
-    employeeDefinition = await indexQueryEngine.getOwnDefinition(
-      {
-        module: `${testRealmURL}employee`,
-        name: 'Employee',
-      },
-      { useWorkInProgressIndex: true },
-    );
-    assert.strictEqual(
-      employeeDefinition,
-      undefined,
-      'definition entry has been marked for deletion in working index',
-    );
-  });
-
   test("invalidations don't cross realm boundaries", async function (assert) {
     await setupIndex(
       adapter,
@@ -695,48 +556,6 @@ module('Unit | index-writer', function (hooks) {
           atom_html: null,
           icon_html: null,
         },
-        {
-          url: `${testRealmURL}person/Person`,
-          realm_version: 1,
-          realm_url: testRealmURL,
-          type: 'definition',
-          pristine_doc: null,
-          search_doc: null,
-          display_names: null,
-          deps: [
-            `${testRealmURL}person`,
-            `https://cardstack.com/base/card-api.gts`,
-          ],
-          types,
-          last_modified: String(modified),
-          resource_created_at: String(modified),
-          head_html: null,
-          embedded_html: null,
-          fitted_html: null,
-          isolated_html: null,
-          atom_html: null,
-          icon_html: null,
-          definition: {
-            type: 'card-def',
-            displayName: 'Person',
-            codeRef: { module: `${testRealmURL}person`, name: 'Person' },
-            fields: {
-              name: {
-                type: 'contains',
-                isPrimitive: true,
-                isComputed: false,
-                fieldOrCard: {
-                  card: {
-                    module: `${testRealmURL}fancy-string`,
-                    name: 'StringField',
-                  },
-                  type: 'fieldOf',
-                  field: 'fancy',
-                },
-              },
-            },
-          },
-        },
       ],
     );
     let batch = await indexWriter.createBatch(new URL(testRealmURL2));
@@ -749,17 +568,16 @@ module('Unit | index-writer', function (hooks) {
     )) as unknown as BoxelIndexTable[];
     assert.strictEqual(
       results.length,
-      3,
+      2,
       'correct number of items were copied',
     );
 
-    let [copiedInstance, copiedModule, copiedDefinition] = results;
+    let [copiedInstance, copiedModule] = results;
     assert.ok(copiedInstance.indexed_at, 'indexed_at was set');
     assert.ok(copiedModule.indexed_at, 'indexed_at was set');
 
     delete (copiedInstance as Partial<BoxelIndexTable>).indexed_at;
     delete (copiedModule as Partial<BoxelIndexTable>).indexed_at;
-    delete (copiedDefinition as Partial<BoxelIndexTable>).indexed_at;
 
     assert.deepEqual(
       copiedInstance as Omit<BoxelIndexTable, 'indexed_at'>,
@@ -813,7 +631,6 @@ module('Unit | index-writer', function (hooks) {
         head_html: `<span class="head">Head HTML</span>`,
         icon_html: '<svg>test icon</svg>',
         is_deleted: null,
-        definition: null,
       },
       'the copied instance is correct',
     );
@@ -840,59 +657,8 @@ module('Unit | index-writer', function (hooks) {
         head_html: null,
         icon_html: null,
         is_deleted: null,
-        definition: null,
       },
       'the copied module is correct',
-    );
-
-    assert.deepEqual(
-      copiedDefinition as Omit<BoxelIndexTable, 'indexed_at'>,
-      {
-        url: `${testRealmURL2}person/Person`,
-        file_alias: `${testRealmURL2}person`,
-        realm_version: 2,
-        realm_url: testRealmURL2,
-        type: 'definition',
-        error_doc: null,
-        pristine_doc: null,
-        search_doc: null,
-        display_names: null,
-        deps: [
-          `${testRealmURL2}person`,
-          `https://cardstack.com/base/card-api.gts`,
-        ],
-        types: destTypes,
-        last_modified: String(modified),
-        resource_created_at: String(modified),
-        embedded_html: null,
-        fitted_html: null,
-        isolated_html: null,
-        atom_html: null,
-        head_html: null,
-        icon_html: null,
-        is_deleted: null,
-        definition: {
-          type: 'card-def',
-          displayName: 'Person',
-          codeRef: { module: `${testRealmURL2}person`, name: 'Person' },
-          fields: {
-            name: {
-              type: 'contains',
-              isPrimitive: true,
-              isComputed: false,
-              fieldOrCard: {
-                card: {
-                  module: `${testRealmURL2}fancy-string`,
-                  name: 'StringField',
-                },
-                type: 'fieldOf',
-                field: 'fancy',
-              },
-            },
-          },
-        },
-      },
-      'the copied definition is correct',
     );
   });
 
@@ -1022,7 +788,6 @@ module('Unit | index-writer', function (hooks) {
         resource_created_at: String(modified),
         is_deleted: null,
         icon_html: '<svg>test icon</svg>',
-        definition: null,
       },
       'the error entry includes last known good state of instance',
     );
@@ -1077,7 +842,6 @@ module('Unit | index-writer', function (hooks) {
         resource_created_at: null,
         is_deleted: false,
         icon_html: null,
-        definition: null,
       },
       'the error entry does not include last known good state of instance',
     );
@@ -1511,160 +1275,6 @@ module('Unit | index-writer', function (hooks) {
       noResult,
       undefined,
       'module does not exist in production index',
-    );
-  });
-
-  test('can get a definition entry', async function (assert) {
-    let types = [{ module: `./person`, name: 'Person' }, baseCardRef].map((i) =>
-      internalKeyFor(i, new URL(testRealmURL)),
-    );
-    await setupIndex(adapter);
-    let batch = await indexWriter.createBatch(new URL(testRealmURL));
-    let now = Date.now();
-    await batch.updateEntry(new URL(`${testRealmURL}person/Person`), {
-      type: 'definition',
-      fileAlias: `${testRealmURL}person`,
-      types,
-      lastModified: now,
-      resourceCreatedAt: now,
-      deps: new Set(types),
-      definition: {
-        type: 'card-def',
-        displayName: 'Person',
-        codeRef: {
-          module: `${testRealmURL}person`,
-          name: 'Person',
-        },
-        fields: {
-          name: {
-            type: 'contains',
-            isPrimitive: true,
-            isComputed: false,
-            fieldOrCard: {
-              module: `${testRealmURL}fancy-string`,
-              name: 'StringField',
-            },
-          },
-        },
-      },
-    });
-    await batch.done();
-
-    let result = await indexQueryEngine.getOwnDefinition({
-      module: `${testRealmURL}person`,
-      name: 'Person',
-    });
-
-    if (result?.type === 'definition') {
-      assert.deepEqual(result.deps, types, 'the deps are correct');
-      assert.deepEqual(
-        result.definition,
-        {
-          displayName: 'Person',
-          codeRef: {
-            module: `${testRealmURL}person`,
-            name: 'Person',
-          },
-          type: 'card-def',
-          fields: {
-            name: {
-              type: 'contains',
-              isPrimitive: true,
-              isComputed: false,
-              fieldOrCard: {
-                module: `${testRealmURL}fancy-string`,
-                name: 'StringField',
-              },
-            },
-          },
-        },
-        'the definition is correct',
-      );
-    } else {
-      assert.ok(false, `expected definition entry not to be an error document`);
-    }
-  });
-
-  test('can get a definition entry from the working index', async function (assert) {
-    let types = [{ module: `./person`, name: 'Person' }, baseCardRef].map((i) =>
-      internalKeyFor(i, new URL(testRealmURL)),
-    );
-    await setupIndex(adapter);
-    let batch = await indexWriter.createBatch(new URL(testRealmURL));
-    let now = Date.now();
-    await batch.updateEntry(new URL(`${testRealmURL}person/Person`), {
-      type: 'definition',
-      fileAlias: `${testRealmURL}person`,
-      types,
-      lastModified: now,
-      resourceCreatedAt: now,
-      deps: new Set(types),
-      definition: {
-        type: 'card-def',
-        displayName: 'Person',
-        codeRef: {
-          module: `${testRealmURL}person`,
-          name: 'Person',
-        },
-        fields: {
-          name: {
-            type: 'contains',
-            isPrimitive: true,
-            isComputed: false,
-            fieldOrCard: {
-              module: `${testRealmURL}fancy-string`,
-              name: 'StringField',
-            },
-          },
-        },
-      },
-    });
-
-    let result = await indexQueryEngine.getOwnDefinition(
-      {
-        module: `${testRealmURL}person`,
-        name: 'Person',
-      },
-      { useWorkInProgressIndex: true },
-    );
-
-    if (result?.type === 'definition') {
-      assert.deepEqual(result.deps, types, 'the deps are correct');
-      assert.deepEqual(
-        result.definition,
-        {
-          displayName: 'Person',
-          codeRef: {
-            module: `${testRealmURL}person`,
-            name: 'Person',
-          },
-          type: 'card-def',
-          fields: {
-            name: {
-              type: 'contains',
-              isPrimitive: true,
-              isComputed: false,
-              fieldOrCard: {
-                module: `${testRealmURL}fancy-string`,
-                name: 'StringField',
-              },
-            },
-          },
-        },
-        'the definition is correct',
-      );
-    } else {
-      assert.ok(false, `expected definition entry not to be an error document`);
-    }
-
-    let noResult = await indexQueryEngine.getOwnDefinition({
-      module: `${testRealmURL}person`,
-      name: 'Person',
-    });
-    assert.strictEqual(
-      noResult,
-      undefined,
-      'definition entry does not exist in production index',
     );
   });
 

--- a/packages/postgres/migrations/1765381896447_remove-definition-from-index.js
+++ b/packages/postgres/migrations/1765381896447_remove-definition-from-index.js
@@ -1,0 +1,20 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+exports.up = (pgm) => {
+  pgm.sql(
+    `DELETE FROM boxel_index WHERE type = 'definition'; DELETE FROM boxel_index_working WHERE type = 'definition';`,
+  );
+  pgm.dropColumns('boxel_index', ['definition']);
+  pgm.dropColumns('boxel_index_working', ['definition']);
+};
+
+exports.down = (pgm) => {
+  pgm.addColumns('boxel_index', {
+    definition: 'jsonb',
+  });
+  pgm.addColumns('boxel_index_working', {
+    definition: 'jsonb',
+  });
+};

--- a/packages/postgres/migrations/1765381896447_remove-definition-from-index.js
+++ b/packages/postgres/migrations/1765381896447_remove-definition-from-index.js
@@ -1,7 +1,3 @@
-/* eslint-disable camelcase */
-
-exports.shorthands = undefined;
-
 exports.up = (pgm) => {
   pgm.sql(
     `DELETE FROM boxel_index WHERE type = 'definition'; DELETE FROM boxel_index_working WHERE type = 'definition';`,

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -18,7 +18,6 @@ import {
   createVirtualNetwork,
   matrixURL,
   cleanWhiteSpace,
-  cardDefinition,
   runTestRealmServer,
   closeServer,
   setupPermissionedRealms,
@@ -442,6 +441,7 @@ async function stopTestRealm(testRealmServer?: TestRealmServerResult) {
 module(basename(__filename), function () {
   module('indexing (read only)', function (hooks) {
     let realm: Realm;
+    let adapter: RealmAdapter;
     let testRealmServer: TestRealmServerResult | undefined;
 
     async function getInstance(
@@ -466,6 +466,7 @@ module(basename(__filename), function () {
           runner,
         });
         realm = testRealmServer.testRealm;
+        adapter = testRealmServer.testRealmAdapter;
       },
       after: async () => {
         await stopTestRealm(testRealmServer);
@@ -861,656 +862,6 @@ module(basename(__filename), function () {
       });
     });
 
-    test('can make a definition entry in the index', async function (assert) {
-      let entry = await realm.realmIndexQueryEngine.getOwnDefinition({
-        module: `${testRealm}post.gts`,
-        name: 'Post',
-      });
-      if (entry?.type === 'definition') {
-        assert.ok(entry.lastModified, 'last modified date is set');
-        assert.ok(entry.resourceCreatedAt, 'created date is set');
-        assert.deepEqual(
-          entry.types,
-          [
-            `${testRealm}post/Post`,
-            'https://cardstack.com/base/card-api/CardDef',
-          ],
-          'types are correct',
-        );
-        assert.deepEqual(
-          entry.definition.codeRef,
-          {
-            name: 'Post',
-            module: `${testRealm}post`,
-          },
-          'code ref is correct',
-        );
-        assert.strictEqual(
-          entry.definition.displayName,
-          'Post',
-          'display name is correct',
-        );
-
-        assert.deepEqual(
-          entry.definition.fields,
-          {
-            ...cardDefinition,
-            message: {
-              type: 'contains',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'StringField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            author: {
-              type: 'linksTo',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'Person',
-                module: `${testRealm}person`,
-              },
-              isPrimitive: false,
-            },
-            'author.id': {
-              type: 'contains',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'ReadOnlyField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.title': {
-              type: 'contains',
-              isComputed: true,
-              fieldOrCard: {
-                name: 'StringField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.firstName': {
-              type: 'contains',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'StringField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.hourlyRate': {
-              type: 'contains',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'default',
-                module: 'https://cardstack.com/base/number',
-              },
-              isPrimitive: true,
-              serializerName: 'number',
-            },
-            'author.description': {
-              type: 'contains',
-              isComputed: true,
-              fieldOrCard: {
-                name: 'StringField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.thumbnailURL': {
-              type: 'contains',
-              isComputed: true,
-              fieldOrCard: {
-                name: 'MaybeBase64Field',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.cardInfo': {
-              type: 'contains',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'CardInfoField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: false,
-            },
-            'author.cardInfo.title': {
-              type: 'contains',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'StringField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.cardInfo.description': {
-              type: 'contains',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'StringField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.cardInfo.thumbnailURL': {
-              type: 'contains',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'MaybeBase64Field',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.cardInfo.notes': {
-              type: 'contains',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'MarkdownField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.cardInfo.theme': {
-              type: 'linksTo',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'Theme',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: false,
-            },
-            'author.cardInfo.theme.id': {
-              type: 'contains',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'ReadOnlyField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.cardInfo.theme.title': {
-              type: 'contains',
-              isComputed: true,
-              fieldOrCard: {
-                name: 'StringField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.cardInfo.theme.description': {
-              type: 'contains',
-              isComputed: true,
-              fieldOrCard: {
-                name: 'StringField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.cardInfo.theme.thumbnailURL': {
-              type: 'contains',
-              isComputed: true,
-              fieldOrCard: {
-                name: 'MaybeBase64Field',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.cardInfo.theme.cardInfo': {
-              type: 'contains',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'CardInfoField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: false,
-            },
-            'author.cardInfo.theme.cardInfo.title': {
-              type: 'contains',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'StringField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.cardInfo.theme.cardInfo.description': {
-              type: 'contains',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'StringField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.cardInfo.theme.cardInfo.thumbnailURL': {
-              type: 'contains',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'MaybeBase64Field',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.cardInfo.theme.cardInfo.notes': {
-              type: 'contains',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'MarkdownField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.cardInfo.theme.cssVariables': {
-              type: 'contains',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'CSSField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.cardInfo.theme.cssImports': {
-              type: 'containsMany',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'CssImportField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.cardInfo.theme.cardInfo.theme': {
-              type: 'linksTo',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'Theme',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: false,
-            },
-            'author.cardInfo.theme.cardInfo.theme.id': {
-              type: 'contains',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'ReadOnlyField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.cardInfo.theme.cardInfo.theme.title': {
-              type: 'contains',
-              isComputed: true,
-              fieldOrCard: {
-                name: 'StringField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.cardInfo.theme.cardInfo.theme.cardInfo': {
-              type: 'contains',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'CardInfoField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: false,
-            },
-            'author.cardInfo.theme.cardInfo.theme.cardInfo.title': {
-              type: 'contains',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'StringField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.cardInfo.theme.cardInfo.theme.cardInfo.description': {
-              type: 'contains',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'StringField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.cardInfo.theme.cardInfo.theme.cardInfo.thumbnailURL': {
-              type: 'contains',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'MaybeBase64Field',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.cardInfo.theme.cardInfo.theme.cardInfo.notes': {
-              type: 'contains',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'MarkdownField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.cardInfo.theme.cardInfo.theme.description': {
-              type: 'contains',
-              isComputed: true,
-              fieldOrCard: {
-                name: 'StringField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.cardInfo.theme.cardInfo.theme.cssVariables': {
-              type: 'contains',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'CSSField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.cardInfo.theme.cardInfo.theme.cssImports': {
-              type: 'containsMany',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'CssImportField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.cardInfo.theme.cardInfo.theme.thumbnailURL': {
-              type: 'contains',
-              isComputed: true,
-              fieldOrCard: {
-                name: 'MaybeBase64Field',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.cardInfo.theme.cardInfo.theme.cardInfo.theme': {
-              type: 'linksTo',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'Theme',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: false,
-            },
-            'author.cardInfo.theme.cardInfo.theme.cardInfo.theme.id': {
-              type: 'contains',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'ReadOnlyField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.cardInfo.theme.cardInfo.theme.cardInfo.theme.title': {
-              type: 'contains',
-              isComputed: true,
-              fieldOrCard: {
-                name: 'StringField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.cardInfo.theme.cardInfo.theme.cardInfo.theme.cardInfo': {
-              type: 'contains',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'CardInfoField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: false,
-            },
-            'author.cardInfo.theme.cardInfo.theme.cardInfo.theme.cardInfo.title':
-              {
-                type: 'contains',
-                isComputed: false,
-                fieldOrCard: {
-                  name: 'StringField',
-                  module: 'https://cardstack.com/base/card-api',
-                },
-                isPrimitive: true,
-              },
-            'author.cardInfo.theme.cardInfo.theme.cardInfo.theme.cardInfo.description':
-              {
-                type: 'contains',
-                isComputed: false,
-                fieldOrCard: {
-                  name: 'StringField',
-                  module: 'https://cardstack.com/base/card-api',
-                },
-                isPrimitive: true,
-              },
-            'author.cardInfo.theme.cardInfo.theme.cardInfo.theme.cardInfo.thumbnailURL':
-              {
-                type: 'contains',
-                isComputed: false,
-                fieldOrCard: {
-                  name: 'MaybeBase64Field',
-                  module: 'https://cardstack.com/base/card-api',
-                },
-                isPrimitive: true,
-              },
-            'author.cardInfo.theme.cardInfo.theme.cardInfo.theme.cardInfo.notes':
-              {
-                type: 'contains',
-                isComputed: false,
-                fieldOrCard: {
-                  name: 'MarkdownField',
-                  module: 'https://cardstack.com/base/card-api',
-                },
-                isPrimitive: true,
-              },
-            'author.cardInfo.theme.cardInfo.theme.cardInfo.theme.description': {
-              type: 'contains',
-              isComputed: true,
-              fieldOrCard: {
-                name: 'StringField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.cardInfo.theme.cardInfo.theme.cardInfo.theme.cssVariables':
-              {
-                type: 'contains',
-                isComputed: false,
-                fieldOrCard: {
-                  name: 'CSSField',
-                  module: 'https://cardstack.com/base/card-api',
-                },
-                isPrimitive: true,
-              },
-            'author.cardInfo.theme.cardInfo.theme.cardInfo.theme.cssImports': {
-              type: 'containsMany',
-              isComputed: false,
-              fieldOrCard: {
-                name: 'CssImportField',
-                module: 'https://cardstack.com/base/card-api',
-              },
-              isPrimitive: true,
-            },
-            'author.cardInfo.theme.cardInfo.theme.cardInfo.theme.thumbnailURL':
-              {
-                type: 'contains',
-                isComputed: true,
-                fieldOrCard: {
-                  name: 'MaybeBase64Field',
-                  module: 'https://cardstack.com/base/card-api',
-                },
-                isPrimitive: true,
-              },
-            'author.cardInfo.theme.cardInfo.theme.cardInfo.theme.cardInfo.theme':
-              {
-                type: 'linksTo',
-                isComputed: false,
-                fieldOrCard: {
-                  name: 'Theme',
-                  module: 'https://cardstack.com/base/card-api',
-                },
-                isPrimitive: false,
-              },
-            'author.cardInfo.theme.cardInfo.theme.cardInfo.theme.cardInfo.theme.id':
-              {
-                type: 'contains',
-                isComputed: false,
-                fieldOrCard: {
-                  name: 'ReadOnlyField',
-                  module: 'https://cardstack.com/base/card-api',
-                },
-                isPrimitive: true,
-              },
-            'author.cardInfo.theme.cardInfo.theme.cardInfo.theme.cardInfo.theme.title':
-              {
-                type: 'contains',
-                isComputed: true,
-                fieldOrCard: {
-                  name: 'StringField',
-                  module: 'https://cardstack.com/base/card-api',
-                },
-                isPrimitive: true,
-              },
-            'author.cardInfo.theme.cardInfo.theme.cardInfo.theme.cardInfo.theme.cardInfo':
-              {
-                type: 'contains',
-                isComputed: false,
-                fieldOrCard: {
-                  name: 'CardInfoField',
-                  module: 'https://cardstack.com/base/card-api',
-                },
-                isPrimitive: false,
-              },
-            'author.cardInfo.theme.cardInfo.theme.cardInfo.theme.cardInfo.theme.cardInfo.title':
-              {
-                type: 'contains',
-                isComputed: false,
-                fieldOrCard: {
-                  name: 'StringField',
-                  module: 'https://cardstack.com/base/card-api',
-                },
-                isPrimitive: true,
-              },
-            'author.cardInfo.theme.cardInfo.theme.cardInfo.theme.cardInfo.theme.cardInfo.description':
-              {
-                type: 'contains',
-                isComputed: false,
-                fieldOrCard: {
-                  name: 'StringField',
-                  module: 'https://cardstack.com/base/card-api',
-                },
-                isPrimitive: true,
-              },
-            'author.cardInfo.theme.cardInfo.theme.cardInfo.theme.cardInfo.theme.cardInfo.thumbnailURL':
-              {
-                type: 'contains',
-                isComputed: false,
-                fieldOrCard: {
-                  name: 'MaybeBase64Field',
-                  module: 'https://cardstack.com/base/card-api',
-                },
-                isPrimitive: true,
-              },
-            'author.cardInfo.theme.cardInfo.theme.cardInfo.theme.cardInfo.theme.description':
-              {
-                type: 'contains',
-                isComputed: true,
-                fieldOrCard: {
-                  name: 'StringField',
-                  module: 'https://cardstack.com/base/card-api',
-                },
-                isPrimitive: true,
-              },
-            'author.cardInfo.theme.cardInfo.theme.cardInfo.theme.cardInfo.theme.cssVariables':
-              {
-                type: 'contains',
-                isComputed: false,
-                fieldOrCard: {
-                  name: 'CSSField',
-                  module: 'https://cardstack.com/base/card-api',
-                },
-                isPrimitive: true,
-              },
-            'author.cardInfo.theme.cardInfo.theme.cardInfo.theme.cardInfo.theme.cssImports':
-              {
-                type: 'containsMany',
-                isComputed: false,
-                fieldOrCard: {
-                  name: 'CssImportField',
-                  module: 'https://cardstack.com/base/card-api',
-                },
-                isPrimitive: true,
-              },
-            'author.cardInfo.theme.cardInfo.theme.cardInfo.theme.cardInfo.theme.thumbnailURL':
-              {
-                type: 'contains',
-                isComputed: true,
-                fieldOrCard: {
-                  name: 'MaybeBase64Field',
-                  module: 'https://cardstack.com/base/card-api',
-                },
-                isPrimitive: true,
-              },
-            'author.cardInfo.theme.cardInfo.theme.cardInfo.theme.cardInfo.theme.cardInfo.theme':
-              {
-                type: 'linksTo',
-                isComputed: false,
-                fieldOrCard: {
-                  name: 'Theme',
-                  module: 'https://cardstack.com/base/card-api',
-                },
-                isPrimitive: false,
-              },
-          },
-          'definition is correct',
-        );
-
-        // this is a crazy long list that includes encoded CSS, so we'll just
-        // check a few deps
-        assert.ok(
-          entry!.deps!.includes(`${testRealm}post`),
-          'deps include ./post',
-        );
-        assert.ok(
-          entry!.deps!.includes(`${testRealm}person`),
-          'deps include ./person',
-        );
-        assert.ok(
-          entry!.deps!.includes(`https://cardstack.com/base/card-api`),
-          'deps include card api',
-        );
-      } else {
-        assert.ok('false', 'expected entry to be a card def');
-      }
-    });
-  });
-
-  module('indexing', function (hooks) {
-    let realm: Realm;
-    let adapter: RealmAdapter;
-    let testRealmServer: TestRealmServerResult | undefined;
-
-    setupBaseRealmServer(hooks, matrixURL);
-
-    setupDB(hooks, {
-      beforeEach: async (dbAdapter, publisher, runner) => {
-        testDbAdapter = dbAdapter;
-        testRealmServer = await startTestRealm({
-          dbAdapter,
-          publisher,
-          runner,
-        });
-        realm = testRealmServer.testRealm;
-        adapter = testRealmServer.testRealmAdapter;
-      },
-      afterEach: async () => {
-        await stopTestRealm(testRealmServer);
-        testRealmServer = undefined;
-      },
-    });
-
     test('can incrementally index updated instance', async function (assert) {
       await realm.write(
         'mango.json',
@@ -1557,16 +908,6 @@ module(basename(__filename), function () {
           throw new Error('boom!');
         `,
       );
-      let petDefinitionEntry =
-        await realm.realmIndexQueryEngine.getOwnDefinition({
-          module: `${testRealm}pet`,
-          name: 'Pet',
-        });
-      assert.strictEqual(
-        petDefinitionEntry,
-        undefined,
-        'Pet card def does not exist',
-      );
       await realm.write(
         'person.gts',
         `
@@ -1583,26 +924,6 @@ module(basename(__filename), function () {
         result,
         [],
         'the broken type results in no instance results',
-      );
-      let personDefinitionEntry =
-        await realm.realmIndexQueryEngine.getOwnDefinition({
-          module: `${testRealm}person`,
-          name: 'Person',
-        });
-      assert.strictEqual(
-        personDefinitionEntry,
-        undefined,
-        'Person card def does not exist',
-      );
-      let fancyPersonDefinitionEntry =
-        await realm.realmIndexQueryEngine.getOwnDefinition({
-          module: `${testRealm}fancy-person`,
-          name: 'FancyPerson',
-        });
-      assert.strictEqual(
-        fancyPersonDefinitionEntry,
-        undefined,
-        'FancyPerson card def does not exist',
       );
       await realm.write(
         'person.gts',
@@ -1627,26 +948,6 @@ module(basename(__filename), function () {
         2,
         'correct number of instances returned',
       );
-      personDefinitionEntry =
-        await realm.realmIndexQueryEngine.getOwnDefinition({
-          module: `${testRealm}person`,
-          name: 'Person',
-        });
-      assert.strictEqual(
-        personDefinitionEntry?.type,
-        'definition',
-        'Person card def has recovered',
-      );
-      fancyPersonDefinitionEntry =
-        await realm.realmIndexQueryEngine.getOwnDefinition({
-          module: `${testRealm}fancy-person`,
-          name: 'FancyPerson',
-        });
-      assert.strictEqual(
-        fancyPersonDefinitionEntry?.type,
-        'definition',
-        'FancyPerson card def has recovered',
-      );
     });
 
     test('can recover from a module sequence error', async function (assert) {
@@ -1661,16 +962,6 @@ module(basename(__filename), function () {
             @field name = contains(Name);
           }
         `,
-      );
-      let petDefinitionEntry =
-        await realm.realmIndexQueryEngine.getOwnDefinition({
-          module: `${testRealm}pet`,
-          name: 'Pet',
-        });
-      assert.strictEqual(
-        petDefinitionEntry,
-        undefined,
-        'Pet card def does not exist',
       );
       await realm.write(
         'name.gts',
@@ -1693,15 +984,6 @@ module(basename(__filename), function () {
         name?.type,
         'module',
         'Name module is successfully indexed',
-      );
-      petDefinitionEntry = await realm.realmIndexQueryEngine.getOwnDefinition({
-        module: `${testRealm}pet`,
-        name: 'Pet',
-      });
-      assert.strictEqual(
-        petDefinitionEntry?.type,
-        'definition',
-        'Pet card def has recovered',
       );
 
       // Since the name is ready, the pet should be indexed and not in an error state
@@ -1795,19 +1077,25 @@ module(basename(__filename), function () {
         },
       });
       assert.strictEqual(result.length, 0, 'found no documents');
-      assert.deepEqual(
-        // we splat because despite having the same shape, the constructors are different
-        { ...realm.realmIndexUpdater.stats },
-        {
-          instancesIndexed: 0,
-          instanceErrors: 0,
-          moduleErrors: 0,
-          modulesIndexed: 0,
-          definitionErrors: 0,
-          definitionsIndexed: 0,
-          totalIndexEntries: 25,
-        },
-        'index did not touch any files',
+      assert.strictEqual(
+        realm.realmIndexUpdater.stats.instancesIndexed,
+        0,
+        'index did not touch any instance files',
+      );
+      assert.strictEqual(
+        realm.realmIndexUpdater.stats.modulesIndexed,
+        0,
+        'index did not touch any module files',
+      );
+      assert.strictEqual(
+        realm.realmIndexUpdater.stats.instanceErrors,
+        0,
+        'no instance errors occurred',
+      );
+      assert.strictEqual(
+        realm.realmIndexUpdater.stats.moduleErrors,
+        0,
+        'no module errors occurred',
       );
     });
 
@@ -2189,9 +1477,7 @@ module(basename(__filename), function () {
           instanceErrors: 0,
           moduleErrors: 0,
           modulesIndexed: 2,
-          definitionErrors: 0,
-          definitionsIndexed: 2,
-          totalIndexEntries: 30,
+          totalIndexEntries: 23,
         },
         'indexed correct number of files',
       );
@@ -2239,21 +1525,17 @@ module(basename(__filename), function () {
       );
       assert.ok(instance, 'place instance is in the index');
       assert.deepEqual(
-        // we splat because despite having the same shape, the constructors are different
-        { ...realm.realmIndexUpdater.stats },
         {
-          // this is a little misleading because now that we are batching out the
-          // modules and instances to ensure that the definition is generated before
-          // we trying file serialization, this will only report the last batch
-          // of indexing when in fact there where actually 2 batches of indexing
-          // generated by this writeMany()
+          instancesIndexed: realm.realmIndexUpdater.stats.instancesIndexed,
+          instanceErrors: realm.realmIndexUpdater.stats.instanceErrors,
+          moduleErrors: realm.realmIndexUpdater.stats.moduleErrors,
+          modulesIndexed: realm.realmIndexUpdater.stats.modulesIndexed,
+        },
+        {
           instancesIndexed: 1,
           instanceErrors: 0,
           moduleErrors: 0,
           modulesIndexed: 0,
-          definitionErrors: 0,
-          definitionsIndexed: 0,
-          totalIndexEntries: 29,
         },
         'indexed correct number of files',
       );
@@ -2292,15 +1574,15 @@ module(basename(__filename), function () {
         `SELECT * FROM boxel_index where is_deleted = true and type = 'instance'`,
       )) as { url: string; is_deleted: boolean }[];
 
-      assert.strictEqual(deletedEntries.length, 1, 'found tombstone entry');
-      assert.strictEqual(
-        deletedEntries[0].url,
-        `${testRealm}test-file.json`,
-        'tombstone has correct URL',
+      assert.ok(
+        deletedEntries.some(
+          (entry) => entry.url === `${testRealm}test-file.json`,
+        ),
+        'found tombstone entry for deleted file',
       );
       assert.true(
-        deletedEntries[0].is_deleted,
-        'tombstone is marked as deleted',
+        deletedEntries.every((entry) => entry.is_deleted),
+        'all tombstones are marked as deleted',
       );
 
       // Verify the file is no longer retrievable through the query engine
@@ -2395,9 +1677,7 @@ module(basename(__filename), function () {
             instanceErrors: 0,
             moduleErrors: 0,
             modulesIndexed: 1,
-            definitionErrors: 0,
-            definitionsIndexed: 1,
-            totalIndexEntries: 3,
+            totalIndexEntries: 2,
           },
           'has no module errors',
         );
@@ -2425,8 +1705,6 @@ module(basename(__filename), function () {
             instancesIndexed: 0,
             moduleErrors: 1,
             modulesIndexed: 0,
-            definitionErrors: 0,
-            definitionsIndexed: 0,
             totalIndexEntries: 0,
           },
           'has a module error',

--- a/packages/realm-server/tests/server-endpoints-test.ts
+++ b/packages/realm-server/tests/server-endpoints-test.ts
@@ -1277,8 +1277,6 @@ module(basename(__filename), function () {
               instanceErrors: 0,
               modulesIndexed: 0,
               instancesIndexed: 1,
-              definitionErrors: 0,
-              definitionsIndexed: 0,
               totalIndexEntries: 1,
             });
           }

--- a/packages/runtime-common/definitions.ts
+++ b/packages/runtime-common/definitions.ts
@@ -27,7 +27,6 @@ export interface Definition {
   };
 }
 
-
 // we are only recursing 3 levels deep when we see a card def that we have already encountered,
 // we capture this: Person -> bestFriend (Person) -> bestFriend (Person) -> bestFriend (Person)
 // we do not capture this: Person -> bestFriend (Person) -> bestFriend (Person) -> bestFriend (Person) -> bestFriend (Person)

--- a/packages/runtime-common/definitions.ts
+++ b/packages/runtime-common/definitions.ts
@@ -3,12 +3,30 @@ import {
   identifyCard,
   primitive,
   fieldSerializer,
-  type Definition,
-  type SerializerName,
 } from './index';
-
+import type { CodeRef } from './code-ref';
+import type { SerializerName } from './serializers';
+import type { FieldType } from 'https://cardstack.com/base/card-api';
 import type { BaseDef } from 'https://cardstack.com/base/card-api';
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
+
+export interface FieldDefinition {
+  type: FieldType;
+  isPrimitive: boolean;
+  isComputed: boolean;
+  fieldOrCard: CodeRef;
+  serializerName?: SerializerName;
+}
+
+export interface Definition {
+  type: 'card-def' | 'field-def';
+  codeRef: CodeRef;
+  displayName: string | null;
+  fields: {
+    [fieldName: string]: FieldDefinition;
+  };
+}
+
 
 // we are only recursing 3 levels deep when we see a card def that we have already encountered,
 // we capture this: Person -> bestFriend (Person) -> bestFriend (Person) -> bestFriend (Person)

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -8,7 +8,6 @@ import {
   baseCardRef,
   internalKeyFor,
   isResolvedCodeRef,
-  trimExecutableExtension,
   baseRealm,
   getSerializer,
 } from './index';
@@ -53,9 +52,8 @@ import {
   coerceTypes,
   type BoxelIndexTable,
   type CardTypeSummary,
-  type Definition,
-  type FieldDefinition,
 } from './index-structure';
+import type { Definition, FieldDefinition } from './definitions';
 import {
   isFilterRefersToNonexistentTypeError,
   type DefinitionLookup,
@@ -65,15 +63,6 @@ import { isScopedCSSRequest } from 'glimmer-scoped-css';
 interface IndexedModule {
   type: 'module';
   canonicalURL: string;
-  lastModified: number | null;
-  resourceCreatedAt: number;
-  deps: string[] | null;
-}
-
-interface IndexedDefinition {
-  type: 'definition';
-  definition: Definition;
-  types: string[] | null;
   lastModified: number | null;
   resourceCreatedAt: number;
   deps: string[] | null;
@@ -125,7 +114,6 @@ interface InstanceError
 
 export type InstanceOrError = IndexedInstance | InstanceError;
 export type IndexedModuleOrError = IndexedModule | IndexedError;
-export type IndexedDefinitionOrError = IndexedDefinition | IndexedError;
 
 type GetEntryOptions = WIPOptions;
 export type QueryOptions = WIPOptions & PrerenderedCardOptions;
@@ -187,54 +175,6 @@ export class IndexQueryEngine {
 
   async #queryCards(query: CardExpression) {
     return this.#query(await this.makeExpression(query));
-  }
-
-  async getOwnDefinition(
-    codeRef: ResolvedCodeRef,
-    opts?: GetEntryOptions,
-  ): Promise<IndexedDefinitionOrError | undefined> {
-    let cleansedCodeRef = { ...codeRef };
-    cleansedCodeRef.module = trimExecutableExtension(
-      new URL(cleansedCodeRef.module),
-    ).href;
-    let key = internalKeyFor(cleansedCodeRef, undefined);
-    let rows = (await this.#query([
-      `SELECT i.*
-       FROM ${tableFromOpts(opts)} as i
-       WHERE`,
-      ...every([
-        any([[`i.url =`, param(key)]]),
-        any([
-          ['i.type =', param('definition')],
-          ['i.type =', param('error')],
-        ]),
-      ]),
-    ] as Expression)) as unknown as BoxelIndexTable[];
-    let maybeResult: BoxelIndexTable | undefined = rows[0];
-    if (!maybeResult) {
-      return undefined;
-    }
-    if (maybeResult.is_deleted) {
-      return undefined;
-    }
-    let result = maybeResult;
-    if (result.type === 'error') {
-      return { type: 'error', error: result.error_doc! };
-    }
-    let definitionEntry = assertIndexEntryDefinition(result);
-    let {
-      definition,
-      last_modified: lastModified,
-      resource_created_at: resourceCreatedAt,
-    } = definitionEntry;
-    return {
-      type: 'definition',
-      definition,
-      lastModified: lastModified != null ? parseInt(lastModified) : null,
-      resourceCreatedAt: parseInt(resourceCreatedAt),
-      deps: definitionEntry.deps,
-      types: definitionEntry.types,
-    };
   }
 
   async getModule(
@@ -1223,43 +1163,6 @@ function assertIndexEntry<T>(obj: T): Omit<
     );
   }
   return obj as Omit<T, 'source' | 'last_modified' | 'resource_created_at'> & {
-    last_modified: string;
-    resource_created_at: string;
-  };
-}
-
-function assertIndexEntryDefinition<T>(obj: T): Omit<
-  T,
-  'definition' | 'last_modified' | 'resource_created_at'
-> & {
-  definition: Definition;
-  last_modified: string | null;
-  resource_created_at: string;
-} {
-  if (!obj || typeof obj !== 'object') {
-    throw new Error(`expected index entry is null or not an object`);
-  }
-  if (!('definition' in obj) || typeof obj.definition !== 'object') {
-    throw new Error(
-      `expected index entry to have "definition" string property`,
-    );
-  }
-  if (!('last_modified' in obj)) {
-    throw new Error(`expected index entry to have "last_modified" property`);
-  }
-  if (
-    !('resource_created_at' in obj) ||
-    typeof obj.resource_created_at !== 'string'
-  ) {
-    throw new Error(
-      `expected index entry to have "resource_created_at" property`,
-    );
-  }
-  return obj as Omit<
-    T,
-    'definition' | 'last_modified' | 'resource_created_at'
-  > & {
-    definition: Definition;
     last_modified: string;
     resource_created_at: string;
   };

--- a/packages/runtime-common/index-structure.ts
+++ b/packages/runtime-common/index-structure.ts
@@ -1,14 +1,13 @@
-import type { CardResource, SerializerName, CodeRef } from './index';
+import type { CardResource } from './resource-types';
 import type { SerializedError } from './error';
 import type { PgPrimitive } from './expression';
-import type { FieldType } from 'https://cardstack.com/base/card-api';
 
 export interface BoxelIndexTable {
   url: string;
   file_alias: string;
   realm_version: number;
   realm_url: string;
-  type: 'instance' | 'definition' | 'module' | 'error';
+  type: 'instance' | 'module' | 'error';
   // TODO in followup PR update this to be a document not a resource
   pristine_doc: CardResource | null;
   error_doc: SerializedError | null;
@@ -18,7 +17,6 @@ export interface BoxelIndexTable {
   deps: string[] | null;
   // `types` is the adoption chain for card where each code ref is serialized
   // using `internalKeyFor()`
-  definition: Definition | null;
   types: string[] | null;
   display_names: string[] | null;
   head_html: string | null;
@@ -52,23 +50,6 @@ export interface RealmMetaTable {
   indexed_at: string | null;
 }
 
-export interface FieldDefinition {
-  type: FieldType;
-  isPrimitive: boolean;
-  isComputed: boolean;
-  fieldOrCard: CodeRef;
-  serializerName?: SerializerName;
-}
-
-export interface Definition {
-  type: 'card-def' | 'field-def';
-  codeRef: CodeRef;
-  displayName: string | null;
-  fields: {
-    [fieldName: string]: FieldDefinition;
-  };
-}
-
 export const coerceTypes = Object.freeze({
   deps: 'JSON',
   types: 'JSON',
@@ -78,7 +59,6 @@ export const coerceTypes = Object.freeze({
   embedded_html: 'JSON',
   fitted_html: 'JSON',
   display_names: 'JSON',
-  definition: 'JSON',
   is_deleted: 'BOOLEAN',
   last_modified: 'VARCHAR',
   resource_created_at: 'VARCHAR',

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -60,10 +60,7 @@ export class IndexWriter {
   }
 }
 
-export type IndexEntry =
-  | InstanceEntry
-  | ModuleEntry
-  | ErrorEntry;
+export type IndexEntry = InstanceEntry | ModuleEntry | ErrorEntry;
 export type LastModifiedTimes = Map<
   string,
   { type: string; lastModified: number | null }
@@ -289,19 +286,19 @@ export class Batch {
         : entry.type === 'module'
           ? {
               type: 'module',
-            deps: [...entry.deps],
-            last_modified: entry.lastModified,
-            resource_created_at: entry.resourceCreatedAt,
-            error_doc: null,
-          }
-        : {
-            types: entry.types,
-            search_doc: entry.searchData,
-            // favor the last known good types over the types derived from the error state
-            ...((await this.getProductionVersion(url)) ?? {}),
-            type: 'error',
-            error_doc: errorEntry?.error ?? entry.error,
-          }),
+              deps: [...entry.deps],
+              last_modified: entry.lastModified,
+              resource_created_at: entry.resourceCreatedAt,
+              error_doc: null,
+            }
+          : {
+              types: entry.types,
+              search_doc: entry.searchData,
+              // favor the last known good types over the types derived from the error state
+              ...((await this.getProductionVersion(url)) ?? {}),
+              type: 'error',
+              error_doc: errorEntry?.error ?? entry.error,
+            }),
     } as Omit<BoxelIndexTable, 'last_modified' | 'indexed_at'> & {
       // we do this because pg automatically casts big ints into strings, so
       // we unwind that to accurately type the structure that we want to pass

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -1,7 +1,7 @@
 import type { CardResource, Meta } from './resource-types';
 import type { ResolvedCodeRef } from './code-ref';
 import type { RenderRouteOptions } from './render-route-options';
-import type { Definition } from './index-structure';
+import type { Definition } from './definitions';
 
 import type { RealmEventContent } from 'https://cardstack.com/base/matrix-event';
 import type { ErrorEntry } from './index-writer';
@@ -159,6 +159,7 @@ export * from './queue';
 export * from './expression';
 export * from './index-query-engine';
 export * from './index-writer';
+export * from './definitions';
 export * from './index-structure';
 export * from './db';
 export * from './tasks';

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -9,9 +9,7 @@ import {
   type DBAdapter,
   type QueryOptions,
   type IndexedModuleOrError,
-  type IndexedDefinitionOrError,
   type InstanceOrError,
-  type ResolvedCodeRef,
   type DefinitionLookup,
 } from '.';
 import type { Realm } from './realm';
@@ -193,13 +191,6 @@ export class RealmIndexQueryEngine {
     opts?: Options,
   ): Promise<IndexedModuleOrError | undefined> {
     return await this.#indexQueryEngine.getModule(url, opts);
-  }
-
-  async getOwnDefinition(
-    codeRef: ResolvedCodeRef,
-    opts?: Options,
-  ): Promise<IndexedDefinitionOrError | undefined> {
-    return await this.#indexQueryEngine.getOwnDefinition(codeRef, opts);
   }
 
   async instance(

--- a/packages/runtime-common/realm-index-updater.ts
+++ b/packages/runtime-common/realm-index-updater.ts
@@ -30,8 +30,6 @@ export class RealmIndexUpdater {
     modulesIndexed: 0,
     instanceErrors: 0,
     moduleErrors: 0,
-    definitionErrors: 0,
-    definitionsIndexed: 0,
     totalIndexEntries: 0,
   };
   #indexWriter: IndexWriter;

--- a/packages/runtime-common/worker.ts
+++ b/packages/runtime-common/worker.ts
@@ -28,10 +28,8 @@ import type { WorkerArgs, TaskArgs } from './tasks';
 export interface Stats extends JSONTypes.Object {
   instancesIndexed: number;
   modulesIndexed: number;
-  definitionsIndexed: number;
   instanceErrors: number;
   moduleErrors: number;
-  definitionErrors: number;
   totalIndexEntries: number;
 }
 


### PR DESCRIPTION
This PR moves the definitions out of our index. definitions are now cached on the realm server.