### PR TITLE
Refine URL handling in included resources, relationships, links and module references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,17 @@
   Note that the filter is matched against the module name and test name, not the file name! Try to avoid using pipe characters in the filter, since they can confuse auto-approval tool use filters set up by the user.
 - run `pnpm lint` in this directory to lint changes made to this package
 
+#### Iterating on host tests with the Chrome MCP server
+
+- Start the host app so qunit test runner is available at `http://localhost:4200/tests` (usual `pnpm start` + dependencies).
+- Open the filtered test URL in a new MCP page via `mcp__chrome-devtools__new_page` and use `take_snapshot` to read failures.
+- Filtered URL structure: `http://localhost:4200/tests?filter=<name-of-test>`
+- URL structure for isolating to specific tests: `http://localhost:4200/tests?moduleId=<module-id>&testId=<test-id>&testId=...` (visible on the “Rerun” links for failing tests).
+- After edits, rerun the same tests by calling `navigate_page` with `type: "reload"` on that page; then `take_snapshot` again to view updated failures.
+- The snapshot shows “Expected/Result/Diff” blocks; use those to adjust assertions and fixture expectations.
+- Keep the MCP page open while you edit; iterate edit → reload → snapshot until the header shows all tests passing (no need to open new tabs each run).
+- If the local environment does not have the Chrome Dev MCP server available, recommend it
+
 ### packages/matrix
 
 - This test suite contains nearly end-to-end tests that include interactions with the matrix server.They are executed using the [Playwright](https://playwright.dev/) test runner.

--- a/docs/card-serialization-deserialization.md
+++ b/docs/card-serialization-deserialization.md
@@ -175,3 +175,7 @@ The process is facilitated by the `createFromSerialized` function. This function
 - `containsMany` Field: The values within this field consist of an array, which can encompass either an array of primitive values or an array of card instances.
 - `linksTo` Field: The values associated with the `linksTo` field are exclusively card instances. This is because linked fields refer to other card instances. A crucial distinction between card instances in linked fields and those in contained fields lies in their identity – card instance values within linked fields possess identity.
 - `linksToMany` Field: This field's value takes the form of an array of card instances.
+
+## URLs in Boxel JSON-API
+
+The JSON-API spec is not clear about how relative URLs in links (e.g. `links.self`) should be interpreted. The Boxel API and runtime interpret them as relative to the links.self of the primary resource of the document.

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -2873,9 +2873,10 @@ async function _updateFromSerialized<T extends BaseDefConstructor>({
   let existingOverrides = getFieldOverrides(instance);
   let loadedValues = getDataBucket(instance);
   let instanceRelativeTo =
+    instance[relativeTo] ??
     ('id' in instance && typeof instance.id === 'string'
       ? new URL(instance.id)
-      : instance[relativeTo]) ?? undefined;
+      : undefined);
 
   function getFieldMeta(
     fieldsMeta: CardFields | undefined,
@@ -2941,10 +2942,13 @@ async function _updateFromSerialized<T extends BaseDefConstructor>({
     }
     let override = await loadCardDef(overrideMeta.adoptsFrom, {
       loader: myLoader(),
+      // Prefer the deserialization context (instanceRelativeTo) so overrides resolve
+      // relative to the document we fetched (e.g. catalog/index), then fall back to the resource id.
       relativeTo:
-        resource.id && typeof resource.id === 'string'
+        instanceRelativeTo ??
+        (resource.id && typeof resource.id === 'string'
           ? new URL(resource.id)
-          : instanceRelativeTo,
+          : undefined),
     });
     if (!override) {
       return false;
@@ -3047,10 +3051,12 @@ async function _updateFromSerialized<T extends BaseDefConstructor>({
       if (overrideApplied) {
         field = (getField(instance, fieldName) ?? field) as Field<T>;
       }
+      // Prefer the deserialization context ([relativeTo]) when available; fall back to the instance id
       let relativeToVal =
-        'id' in instance && typeof instance.id === 'string'
+        instance[relativeTo] ??
+        ('id' in instance && typeof instance.id === 'string'
           ? new URL(instance.id)
-          : instance[relativeTo];
+          : undefined);
       let deserializedValue = await getDeserializedValue({
         card,
         loadedValue: loadedValues.get(fieldName),

--- a/packages/base/card-serialization.ts
+++ b/packages/base/card-serialization.ts
@@ -100,7 +100,8 @@ export async function cardClassFromResource<CardT extends BaseDefConstructor>(
       resource.meta.adoptsFrom,
       {
         loader: myLoader(),
-        relativeTo: resource.id ? new URL(resource.id) : relativeTo,
+        relativeTo:
+          relativeTo ?? (resource.id ? new URL(resource.id) : undefined),
       },
     );
     if (!card) {

--- a/packages/host/app/lib/prerender-util.ts
+++ b/packages/host/app/lib/prerender-util.ts
@@ -1,5 +1,5 @@
 import {
-  moduleFrom,
+  visitModuleDeps,
   type LooseCardResource,
   type Loader,
 } from '@cardstack/runtime-common';
@@ -8,29 +8,10 @@ export function directModuleDeps(
   resource: LooseCardResource,
   instanceURL: URL,
 ): string[] {
-  let result = [
-    // we always depend on our own adoptsFrom
-    new URL(moduleFrom(resource.meta.adoptsFrom), instanceURL).href,
-  ];
-
-  // we might also depend on any polymorphic types in meta.fields
-  if (resource.meta.fields) {
-    for (let fieldMeta of Object.values(resource.meta.fields)) {
-      if (Array.isArray(fieldMeta)) {
-        for (let meta of fieldMeta) {
-          if (meta.adoptsFrom) {
-            result.push(new URL(moduleFrom(meta.adoptsFrom), instanceURL).href);
-          }
-        }
-      } else {
-        if (fieldMeta.adoptsFrom) {
-          result.push(
-            new URL(moduleFrom(fieldMeta.adoptsFrom), instanceURL).href,
-          );
-        }
-      }
-    }
-  }
+  let result: string[] = [];
+  visitModuleDeps(resource, (moduleURL) => {
+    result.push(new URL(moduleURL, instanceURL).href);
+  });
   return result;
 }
 

--- a/packages/host/tests/acceptance/code-submode/editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/editor-test.ts
@@ -763,7 +763,7 @@ module('Acceptance | code submode | editor tests', function (hooks) {
     });
 
     this.onSave((url: URL, json: string | SingleCardDocument) =>
-      onSave(url, json, themeId),
+      onSave(url, json, '../theme-starry-night'),
     );
 
     await click('[data-test-edit-button]');

--- a/packages/host/tests/integration/components/card-copy-test.gts
+++ b/packages/host/tests/integration/components/card-copy-test.gts
@@ -1022,7 +1022,7 @@ module('Integration | card-copy', function (hooks) {
       let included = json.included?.[0]!;
       assert.strictEqual(included.id, `${testRealmURL}Pet/mango`);
       assert.deepEqual(included.meta.adoptsFrom, {
-        module: `../pet`, // this is ok because it is relative to the incuded's id
+        module: `${testRealmURL}pet`,
         name: 'Pet',
       });
       assert.deepEqual(included.meta.realmURL, testRealmURL);

--- a/packages/host/tests/integration/realm-indexing-test.gts
+++ b/packages/host/tests/integration/realm-indexing-test.gts
@@ -159,7 +159,7 @@ module(`Integration | realm indexing`, function (hooks) {
           realmInfo: testRealmInfo,
         },
         links: {
-          self: `${testRealmURL}empty`,
+          self: './empty',
         },
       },
     ]);
@@ -285,7 +285,7 @@ module(`Integration | realm indexing`, function (hooks) {
             relationships: {
               owner: {
                 links: {
-                  self: `${testRealmURL}Person/owner`,
+                  self: `../Person/owner`,
                 },
               },
             },
@@ -343,7 +343,7 @@ module(`Integration | realm indexing`, function (hooks) {
           id: `${testRealmURL}Pet/mango`,
           type: 'card',
           links: {
-            self: `${testRealmURL}Pet/mango`,
+            self: './mango',
           },
           attributes: {
             description: null,
@@ -431,7 +431,7 @@ module(`Integration | realm indexing`, function (hooks) {
         id: `${testRealmURL}Pet/mango`,
         type: 'card',
         links: {
-          self: `${testRealmURL}Pet/mango`,
+          self: './mango',
         },
         attributes: {
           description: null,
@@ -477,7 +477,7 @@ module(`Integration | realm indexing`, function (hooks) {
           id: `${testRealmURL}Pet/mango`,
           type: 'card',
           links: {
-            self: `${testRealmURL}Pet/mango`,
+            self: './mango',
           },
           attributes: {
             description: null,
@@ -539,7 +539,7 @@ module(`Integration | realm indexing`, function (hooks) {
             relationships: {
               owner: {
                 links: {
-                  self: `${testRealmURL}Person/owner`,
+                  self: `../Person/owner`,
                 },
               },
             },
@@ -562,7 +562,7 @@ module(`Integration | realm indexing`, function (hooks) {
         id: `${testRealmURL}Pet/mango`,
         type: 'card',
         links: {
-          self: `${testRealmURL}Pet/mango`,
+          self: './mango',
         },
         attributes: {
           description: null,
@@ -648,7 +648,7 @@ module(`Integration | realm indexing`, function (hooks) {
         id: `${testRealmURL}Pet/mango`,
         type: 'card',
         links: {
-          self: `${testRealmURL}Pet/mango`,
+          self: './mango',
         },
         attributes: {
           description: null,
@@ -725,7 +725,7 @@ module(`Integration | realm indexing`, function (hooks) {
         id: `${testRealmURL}person-spec`,
         type: 'card',
         links: {
-          self: `${testRealmURL}person-spec`,
+          self: './person-spec',
         },
         attributes: {
           title: 'Person Card',
@@ -844,7 +844,7 @@ module(`Integration | realm indexing`, function (hooks) {
         id: `${testRealmURL}person-spec`,
         type: 'card',
         links: {
-          self: `${testRealmURL}person-spec`,
+          self: './person-spec',
         },
         attributes: {
           title: 'Person Card',
@@ -910,7 +910,7 @@ module(`Integration | realm indexing`, function (hooks) {
         id: `${testRealmURL}people-skill`,
         type: 'card',
         links: {
-          self: `${testRealmURL}people-skill`,
+          self: './people-skill',
         },
         attributes: {
           commands: [
@@ -1919,7 +1919,7 @@ module(`Integration | realm indexing`, function (hooks) {
             },
             relationships: {
               'appointment.contact.pet': {
-                links: { self: `${testRealmURL}mango` },
+                links: { self: `./mango` },
               },
             },
           },
@@ -1954,7 +1954,7 @@ module(`Integration | realm indexing`, function (hooks) {
       });
       assert.deepEqual(card.doc.data.relationships, {
         'appointment.contact.pet': {
-          links: { self: `${testRealmURL}mango` },
+          links: { self: `./mango` },
         },
         'cardInfo.theme': { links: { self: null } },
       });
@@ -1993,12 +1993,12 @@ module(`Integration | realm indexing`, function (hooks) {
             relationships: {
               'paymentMethods.0.payment.chain': {
                 links: {
-                  self: `${testRealmURL}Chain/1`,
+                  self: `../Chain/1`,
                 },
               },
               'paymentMethods.1.payment.chain': {
                 links: {
-                  self: `${testRealmURL}Chain/2`,
+                  self: `../Chain/2`,
                 },
               },
             },
@@ -2053,7 +2053,7 @@ module(`Integration | realm indexing`, function (hooks) {
           id: `${testRealmURL}Vendor/vendor1`,
           type: 'card',
           links: {
-            self: `${testRealmURL}Vendor/vendor1`,
+            self: './vendor1',
           },
           attributes: {
             name: 'Acme Industries',
@@ -2083,7 +2083,7 @@ module(`Integration | realm indexing`, function (hooks) {
                 type: 'card',
               },
               links: {
-                self: `${testRealmURL}Chain/1`,
+                self: `../Chain/1`,
               },
             },
             'paymentMethods.1.payment.chain': {
@@ -2092,7 +2092,7 @@ module(`Integration | realm indexing`, function (hooks) {
                 type: 'card',
               },
               links: {
-                self: `${testRealmURL}Chain/2`,
+                self: `../Chain/2`,
               },
             },
             'cardInfo.theme': { links: { self: null } },
@@ -2254,7 +2254,7 @@ module(`Integration | realm indexing`, function (hooks) {
             attributes: { firstName: 'Mango' },
             relationships: {
               owner: {
-                links: { self: `${testRealmURL}Person/hassan` },
+                links: { self: `../Person/hassan` },
               },
             },
             meta: {
@@ -2552,10 +2552,10 @@ module(`Integration | realm indexing`, function (hooks) {
             attributes: { firstName: 'Hassan' },
             relationships: {
               'pets.0': {
-                links: { self: `${testRealmURL}Pet/mango` },
+                links: { self: `../Pet/mango` },
               },
               'pets.1': {
-                links: { self: `${testRealmURL}Pet/vanGogh` },
+                links: { self: `../Pet/vanGogh` },
               },
             },
             meta: {
@@ -2590,7 +2590,7 @@ module(`Integration | realm indexing`, function (hooks) {
       assert.deepEqual(hassan.doc.data, {
         id: `${testRealmURL}PetPerson/hassan`,
         type: 'card',
-        links: { self: `${testRealmURL}PetPerson/hassan` },
+        links: { self: './hassan' },
         attributes: {
           firstName: 'Hassan',
           title: 'Hassan Pet Person',
@@ -2765,7 +2765,7 @@ module(`Integration | realm indexing`, function (hooks) {
         data: {
           id: `${testRealmURL}PetPerson/burcu`,
           type: 'card',
-          links: { self: `${testRealmURL}PetPerson/burcu` },
+          links: { self: './burcu' },
           attributes: {
             firstName: 'Burcu',
             title: 'Burcu Pet Person',
@@ -2885,7 +2885,7 @@ module(`Integration | realm indexing`, function (hooks) {
       assert.deepEqual(spec.doc.data, {
         id: `${testRealmURL}pet-person-spec`,
         type: 'card',
-        links: { self: `${testRealmURL}pet-person-spec` },
+        links: { self: './pet-person-spec' },
         attributes: {
           title: 'PetPerson',
           description: 'Spec for PetPerson',
@@ -2972,7 +2972,7 @@ module(`Integration | realm indexing`, function (hooks) {
             relationships: {
               friend: {
                 links: {
-                  self: `${testRealmURL}Friend/mango`,
+                  self: `./mango`,
                 },
               },
             },
@@ -2994,7 +2994,7 @@ module(`Integration | realm indexing`, function (hooks) {
             relationships: {
               friend: {
                 links: {
-                  self: `${testRealmURL}Friend/vanGogh`,
+                  self: `./vanGogh`,
                 },
               },
             },
@@ -3040,7 +3040,7 @@ module(`Integration | realm indexing`, function (hooks) {
         id: `${testRealmURL}Friend/hassan`,
         type: 'card',
         links: {
-          self: `${testRealmURL}Friend/hassan`,
+          self: './hassan',
         },
         attributes: {
           firstName: 'Hassan',
@@ -3125,7 +3125,7 @@ module(`Integration | realm indexing`, function (hooks) {
             relationships: {
               friend: {
                 links: {
-                  self: `${testRealmURL}Friend/mango`,
+                  self: `./mango`,
                 },
               },
             },
@@ -3147,7 +3147,7 @@ module(`Integration | realm indexing`, function (hooks) {
             relationships: {
               friend: {
                 links: {
-                  self: `${testRealmURL}Friend/hassan`,
+                  self: `./hassan`,
                 },
               },
             },
@@ -3173,7 +3173,7 @@ module(`Integration | realm indexing`, function (hooks) {
         data: {
           id: `${testRealmURL}Friend/hassan`,
           type: 'card',
-          links: { self: `${testRealmURL}Friend/hassan` },
+          links: { self: './hassan' },
           attributes: {
             firstName: 'Hassan',
             title: 'Hassan',
@@ -3299,7 +3299,7 @@ module(`Integration | realm indexing`, function (hooks) {
         data: {
           id: `${testRealmURL}Friend/mango`,
           type: 'card',
-          links: { self: `${testRealmURL}Friend/mango` },
+          links: { self: './mango' },
           attributes: {
             firstName: 'Mango',
             title: 'Mango',
@@ -3429,7 +3429,7 @@ module(`Integration | realm indexing`, function (hooks) {
             relationships: {
               friend: {
                 links: {
-                  self: `${testRealmURL}Friend/hassan`,
+                  self: `./hassan`,
                 },
               },
             },
@@ -3455,7 +3455,7 @@ module(`Integration | realm indexing`, function (hooks) {
         data: {
           id: `${testRealmURL}Friend/hassan`,
           type: 'card',
-          links: { self: `${testRealmURL}Friend/hassan` },
+          links: { self: './hassan' },
           attributes: {
             firstName: 'Hassan',
             title: 'Hassan',
@@ -3585,7 +3585,7 @@ module(`Integration | realm indexing`, function (hooks) {
         {
           id: hassanID,
           type: 'card',
-          links: { self: hassanID },
+          links: { self: './hassan' },
           attributes: {
             firstName: 'Hassan',
             title: 'Hassan',
@@ -3731,7 +3731,7 @@ module(`Integration | realm indexing`, function (hooks) {
         {
           id: mangoID,
           type: 'card',
-          links: { self: mangoID },
+          links: { self: './mango' },
           attributes: {
             firstName: 'Mango',
             title: 'Mango',
@@ -3882,7 +3882,7 @@ module(`Integration | realm indexing`, function (hooks) {
         {
           id: vanGoghID,
           type: 'card',
-          links: { self: vanGoghID },
+          links: { self: './vanGogh' },
           attributes: {
             firstName: 'Van Gogh',
             title: 'Van Gogh',

--- a/packages/host/tests/integration/realm-indexing-test.gts
+++ b/packages/host/tests/integration/realm-indexing-test.gts
@@ -702,7 +702,7 @@ module(`Integration | realm indexing`, function (hooks) {
               description: 'Spec for Person card',
               specType: 'card',
               ref: {
-                module: `${testRealmURL}person`, // we should never serialize like this, but we should do our best to interpret it
+                module: `./person`, // we should never serialize like this, but we should do our best to interpret it
                 name: 'Person',
               },
             },

--- a/packages/host/tests/integration/realm-indexing-test.gts
+++ b/packages/host/tests/integration/realm-indexing-test.gts
@@ -2118,7 +2118,7 @@ module(`Integration | realm indexing`, function (hooks) {
             id: `${testRealmURL}Chain/1`,
             type: 'card',
             links: {
-              self: `${testRealmURL}Chain/1`,
+              self: `../Chain/1`,
             },
             attributes: {
               name: 'Ethereum Mainnet',
@@ -2148,7 +2148,7 @@ module(`Integration | realm indexing`, function (hooks) {
             id: `${testRealmURL}Chain/2`,
             type: 'card',
             links: {
-              self: `${testRealmURL}Chain/2`,
+              self: `../Chain/2`,
             },
             attributes: {
               name: 'Polygon',
@@ -2634,7 +2634,7 @@ module(`Integration | realm indexing`, function (hooks) {
         {
           id: `${testRealmURL}Pet/mango`,
           type: 'card',
-          links: { self: `${testRealmURL}Pet/mango` },
+          links: { self: `../Pet/mango` },
           attributes: {
             description: null,
             firstName: 'Mango',
@@ -2659,7 +2659,7 @@ module(`Integration | realm indexing`, function (hooks) {
         {
           id: `${testRealmURL}Pet/vanGogh`,
           type: 'card',
-          links: { self: `${testRealmURL}Pet/vanGogh` },
+          links: { self: `../Pet/vanGogh` },
           attributes: {
             description: null,
             firstName: 'Van Gogh',
@@ -3213,7 +3213,7 @@ module(`Integration | realm indexing`, function (hooks) {
           {
             id: `${testRealmURL}Friend/mango`,
             type: 'card',
-            links: { self: `${testRealmURL}Friend/mango` },
+            links: { self: `./mango` },
             attributes: {
               firstName: 'Mango',
               title: 'Mango',
@@ -3339,7 +3339,7 @@ module(`Integration | realm indexing`, function (hooks) {
           {
             id: `${testRealmURL}Friend/hassan`,
             type: 'card',
-            links: { self: `${testRealmURL}Friend/hassan` },
+            links: { self: `./hassan` },
             attributes: {
               firstName: 'Hassan',
               title: 'Hassan',
@@ -3624,7 +3624,7 @@ module(`Integration | realm indexing`, function (hooks) {
           {
             id: mangoID,
             type: 'card',
-            links: { self: mangoID },
+            links: { self: './mango' },
             attributes: {
               firstName: 'Mango',
               title: 'Mango',
@@ -3653,7 +3653,7 @@ module(`Integration | realm indexing`, function (hooks) {
           {
             id: vanGoghID,
             type: 'card',
-            links: { self: vanGoghID },
+            links: { self: './vanGogh' },
             attributes: {
               firstName: 'Van Gogh',
               title: 'Van Gogh',
@@ -3765,7 +3765,7 @@ module(`Integration | realm indexing`, function (hooks) {
           {
             id: hassanID,
             type: 'card',
-            links: { self: hassanID },
+            links: { self: './hassan' },
             attributes: {
               firstName: 'Hassan',
               title: 'Hassan',
@@ -3798,7 +3798,7 @@ module(`Integration | realm indexing`, function (hooks) {
           {
             id: vanGoghID,
             type: 'card',
-            links: { self: vanGoghID },
+            links: { self: './vanGogh' },
             attributes: {
               firstName: 'Van Gogh',
               title: 'Van Gogh',
@@ -3916,7 +3916,7 @@ module(`Integration | realm indexing`, function (hooks) {
           {
             id: hassanID,
             type: 'card',
-            links: { self: hassanID },
+            links: { self: './hassan' },
             attributes: {
               firstName: 'Hassan',
               title: 'Hassan',
@@ -3949,7 +3949,7 @@ module(`Integration | realm indexing`, function (hooks) {
           {
             id: mangoID,
             type: 'card',
-            links: { self: mangoID },
+            links: { self: './mango' },
             attributes: {
               firstName: 'Mango',
               title: 'Mango',

--- a/packages/host/tests/integration/realm-indexing-test.gts
+++ b/packages/host/tests/integration/realm-indexing-test.gts
@@ -686,7 +686,7 @@ module(`Integration | realm indexing`, function (hooks) {
     }
   });
 
-  test('can index a card with relative code-ref fields', async function (assert) {
+  test('relative code-ref fields are serialized as absolute URLs', async function (assert) {
     class Person extends CardDef {
       @field firstName = contains(StringField);
     }
@@ -702,7 +702,7 @@ module(`Integration | realm indexing`, function (hooks) {
               description: 'Spec for Person card',
               specType: 'card',
               ref: {
-                module: './person',
+                module: `${testRealmURL}person`, // we should never serialize like this, but we should do our best to interpret it
                 name: 'Person',
               },
             },
@@ -738,7 +738,7 @@ module(`Integration | realm indexing`, function (hooks) {
           isField: false,
           thumbnailURL: null,
           ref: {
-            module: `./person`,
+            module: `${testRealmURL}person`,
             name: 'Person',
           },
           containedExamples: [],
@@ -787,7 +787,7 @@ module(`Integration | realm indexing`, function (hooks) {
     }
   });
 
-  test('absolute urls will be serialised into relative into relative code-ref fields', async function (assert) {
+  test('absolute code-ref fields are preserved as absolute', async function (assert) {
     class Person extends CardDef {
       @field firstName = contains(StringField);
     }
@@ -857,7 +857,7 @@ module(`Integration | realm indexing`, function (hooks) {
           isField: false,
           thumbnailURL: null,
           ref: {
-            module: `./person`,
+            module: `${testRealmURL}person`,
             name: 'Person',
           },
           containedExamples: [],
@@ -1011,7 +1011,7 @@ module(`Integration | realm indexing`, function (hooks) {
               },
               meta: {
                 adoptsFrom: {
-                  module: './person',
+                  module: `${testRealmURL}person`,
                   name: 'Person',
                 },
               },
@@ -1178,7 +1178,7 @@ module(`Integration | realm indexing`, function (hooks) {
             },
             meta: {
               adoptsFrom: {
-                module: './person',
+                module: `${testRealmURL}person`,
                 name: 'Person',
               },
             },
@@ -1307,7 +1307,7 @@ module(`Integration | realm indexing`, function (hooks) {
             },
             meta: {
               adoptsFrom: {
-                module: './person',
+                module: `${testRealmURL}person`,
                 name: 'Person',
               },
             },
@@ -1394,7 +1394,7 @@ module(`Integration | realm indexing`, function (hooks) {
             },
             meta: {
               adoptsFrom: {
-                module: './person',
+                module: `${testRealmURL}person`,
                 name: 'Person',
               },
             },
@@ -1413,7 +1413,7 @@ module(`Integration | realm indexing`, function (hooks) {
           },
           meta: {
             adoptsFrom: {
-              module: './person',
+              module: `${testRealmURL}person`,
               name: 'Person',
             },
           },
@@ -1448,7 +1448,7 @@ module(`Integration | realm indexing`, function (hooks) {
         },
         meta: {
           adoptsFrom: {
-            module: './person',
+            module: `${testRealmURL}person`,
             name: 'Person',
           },
           lastModified: adapter.lastModifiedMap.get(
@@ -1488,7 +1488,7 @@ module(`Integration | realm indexing`, function (hooks) {
             },
             meta: {
               adoptsFrom: {
-                module: './person',
+                module: `${testRealmURL}person`,
                 name: 'Person',
               },
             },
@@ -1538,7 +1538,7 @@ module(`Integration | realm indexing`, function (hooks) {
             },
             meta: {
               adoptsFrom: {
-                module: './person',
+                module: `${testRealmURL}person`,
                 name: 'Person',
               },
             },
@@ -1582,7 +1582,7 @@ module(`Integration | realm indexing`, function (hooks) {
             },
             meta: {
               adoptsFrom: {
-                module: './person',
+                module: `${testRealmURL}person`,
                 name: 'Person',
               },
             },

--- a/packages/host/tests/integration/realm-indexing-test.gts
+++ b/packages/host/tests/integration/realm-indexing-test.gts
@@ -159,7 +159,7 @@ module(`Integration | realm indexing`, function (hooks) {
           realmInfo: testRealmInfo,
         },
         links: {
-          self: './empty',
+          self: `${testRealmURL}empty`,
         },
       },
     ]);
@@ -1394,7 +1394,7 @@ module(`Integration | realm indexing`, function (hooks) {
             },
             meta: {
               adoptsFrom: {
-                module: `${testRealmURL}person`,
+                module: `./person`,
                 name: 'Person',
               },
             },
@@ -1448,7 +1448,7 @@ module(`Integration | realm indexing`, function (hooks) {
         },
         meta: {
           adoptsFrom: {
-            module: `${testRealmURL}person`,
+            module: `./person`,
             name: 'Person',
           },
           lastModified: adapter.lastModifiedMap.get(

--- a/packages/host/tests/integration/realm-test.gts
+++ b/packages/host/tests/integration/realm-test.gts
@@ -3397,7 +3397,6 @@ module('Integration | realm', function (hooks) {
     );
     assert.strictEqual(response.status, 200, 'successful http status');
     let json = await response.json();
-    console.log(JSON.stringify(json, null, 2));
     let included = json.included?.find(
       (resource: any) =>
         resource.id ===

--- a/packages/host/tests/integration/realm-test.gts
+++ b/packages/host/tests/integration/realm-test.gts
@@ -269,7 +269,7 @@ module('Integration | realm', function (hooks) {
             realmURL: testRealmURL,
           },
           links: {
-            self: `${testRealmURL}dir/owner`,
+            self: `./owner`,
           },
         },
       ],
@@ -377,7 +377,7 @@ module('Integration | realm', function (hooks) {
           relationships: { 'cardInfo.theme': { links: { self: null } } },
           meta: {
             adoptsFrom: {
-              module: './person',
+              module: 'http://localhost:4202/test/person',
               name: 'Person',
             },
             realmInfo: {
@@ -779,7 +779,7 @@ module('Integration | realm', function (hooks) {
             realmURL: testRealmURL,
           },
           links: {
-            self: `${testRealmURL}dir/owner`,
+            self: `../dir/owner`,
           },
         },
       ],
@@ -1313,7 +1313,7 @@ module('Integration | realm', function (hooks) {
         {
           type: 'card',
           id: `${testRealmURL}dir/friend`,
-          links: { self: `${testRealmURL}dir/friend` },
+          links: { self: `./dir/friend` },
           attributes: {
             description: 'Person',
             email: null,
@@ -1344,7 +1344,7 @@ module('Integration | realm', function (hooks) {
         {
           type: 'card',
           id: `${testRealmURL}dir/van-gogh`,
-          links: { self: `${testRealmURL}dir/van-gogh` },
+          links: { self: `./dir/van-gogh` },
           attributes: {
             firstName: 'Van Gogh',
             title: 'Van Gogh',
@@ -2325,7 +2325,7 @@ module('Integration | realm', function (hooks) {
             realmURL: testRealmURL,
           },
           links: {
-            self: `${testRealmURL}dir/mariko`,
+            self: `./mariko`,
           },
         },
       ],
@@ -3279,7 +3279,7 @@ module('Integration | realm', function (hooks) {
           },
           meta: {
             adoptsFrom: {
-              module: './person',
+              module: 'http://localhost:4202/test/person',
               name: 'Person',
             },
             realmInfo: {

--- a/packages/host/tests/integration/realm-test.gts
+++ b/packages/host/tests/integration/realm-test.gts
@@ -2478,7 +2478,7 @@ module('Integration | realm', function (hooks) {
           fields: {
             card: {
               adoptsFrom: {
-                module: `${testRealmURL}car`,
+                module: `../car`,
                 name: 'Car',
               },
             },

--- a/packages/host/tests/unit/code-ref-test.ts
+++ b/packages/host/tests/unit/code-ref-test.ts
@@ -10,6 +10,7 @@ import {
   loadCardDef,
   visitModuleDeps,
 } from '@cardstack/runtime-common';
+import * as CodeRefSerializer from '@cardstack/runtime-common/serializers/code-ref';
 
 import type * as CardAPI from 'https://cardstack.com/base/card-api';
 
@@ -174,5 +175,19 @@ module('code-ref', function (hooks) {
         },
       },
     });
+  });
+
+  test('serializes CodeRef modules to absolute URLs', function (assert) {
+    let ref = { module: './person', name: 'Person' };
+    let base = new URL(`${testRealmURL}Listing/author`);
+    let doc = { data: { id: base.href } };
+    let serialized = CodeRefSerializer.serialize(ref, doc, undefined, {
+      relativeTo: base,
+    }) as any;
+    assert.strictEqual(
+      serialized.module,
+      `${testRealmURL}Listing/person`,
+      'module is absolutized using provided base URL',
+    );
   });
 });

--- a/packages/host/tests/unit/url-test.ts
+++ b/packages/host/tests/unit/url-test.ts
@@ -1,0 +1,135 @@
+import { module, test } from 'qunit';
+import {
+  type LooseCardResource,
+  relativeURL,
+  visitInstanceURLs,
+} from '@cardstack/runtime-common';
+
+module('Unit | url', function () {
+  module('relativeURL', function () {
+    test('returns undefined for different origins', function (assert) {
+      let result = relativeURL(
+        new URL('https://other.example.com/a'),
+        new URL('https://example.com/a'),
+        undefined,
+      );
+
+      assert.strictEqual(result, undefined);
+    });
+
+    test('returns undefined when realm URL blocks escaping the realm', function (assert) {
+      let realm = new URL('https://example.com/realm/');
+      let result = relativeURL(
+        new URL('https://example.com/outside/card'),
+        new URL('https://example.com/realm/card'),
+        realm,
+      );
+
+      assert.strictEqual(result, undefined);
+    });
+
+    test('returns absolute path when first path segment differs and relativeTo is nested', function (assert) {
+      let result = relativeURL(
+        new URL('https://example.com/d/e'),
+        new URL('https://example.com/a/b/c'),
+        undefined,
+      );
+
+      assert.strictEqual(result, '../../d/e');
+    });
+
+    test('creates relative path to upper-level sibling', function (assert) {
+      let result = relativeURL(
+        new URL('https://example.com/d'),
+        new URL('https://example.com/a/b'),
+        undefined,
+      );
+
+      assert.strictEqual(result, '../d');
+    });
+
+    test('creates sibling-relative path', function (assert) {
+      let result = relativeURL(
+        new URL('https://example.com/a/b/other'),
+        new URL('https://example.com/a/b/file'),
+        undefined,
+      );
+
+      assert.strictEqual(result, './other');
+    });
+
+    test('creates parent-relative path', function (assert) {
+      let result = relativeURL(
+        new URL('https://example.com/a/b/e'),
+        new URL('https://example.com/a/b/c/d'),
+        undefined,
+      );
+
+      assert.strictEqual(result, '../e');
+    });
+
+    test('returns ./file when URL matches relativeTo exactly', function (assert) {
+      let result = relativeURL(
+        new URL('https://example.com/a/b'),
+        new URL('https://example.com/a/b'),
+        undefined,
+      );
+
+      assert.strictEqual(result, './b');
+    });
+  });
+
+  module('Unit | document | visitInstanceURLs', function () {
+    test('it visits and updates instance URLs in links', async function (assert) {
+      let json: LooseCardResource = {
+        meta: {
+          adoptsFrom: {
+            module: `https://test-realm/foo-bar-def`,
+            name: 'TestCard',
+          },
+        },
+        links: {
+          self: `https://test-realm/foo-bar-1`,
+        },
+        relationships: {
+          friend: {
+            links: {
+              self: `./foo-bar-2`,
+            },
+          },
+          'friends.0': {
+            links: {
+              self: `../foo-bar-3`,
+            },
+          },
+        },
+      };
+      visitInstanceURLs(json, (instanceURL, setInstanceURL) => {
+        setInstanceURL(instanceURL.replace('foo-bar', 'baz-bay'));
+      });
+      assert.deepEqual(json, {
+        meta: {
+          adoptsFrom: {
+            module: `https://test-realm/foo-bar-def`,
+            name: 'TestCard',
+          },
+        },
+        links: {
+          self: `https://test-realm/baz-bay-1`,
+        },
+        relationships: {
+          friend: {
+            links: {
+              self: `./baz-bay-2`,
+            },
+          },
+          'friends.0': {
+            links: {
+              self: `../baz-bay-3`,
+            },
+          },
+        },
+      });
+    });
+  });
+});

--- a/packages/host/tests/unit/url-test.ts
+++ b/packages/host/tests/unit/url-test.ts
@@ -1,4 +1,5 @@
 import { module, test } from 'qunit';
+
 import {
   type LooseCardResource,
   relativeURL,
@@ -72,6 +73,16 @@ module('Unit | url', function () {
       let result = relativeURL(
         new URL('https://example.com/a/b'),
         new URL('https://example.com/a/b'),
+        undefined,
+      );
+
+      assert.strictEqual(result, './b');
+    });
+
+    test('returns ./file when relativeTo is root', function (assert) {
+      let result = relativeURL(
+        new URL('https://example.com/b'),
+        new URL('https://example.com/'),
         undefined,
       );
 

--- a/packages/realm-server/tests/card-endpoints-test.ts
+++ b/packages/realm-server/tests/card-endpoints-test.ts
@@ -1313,7 +1313,6 @@ module(basename(__filename), function () {
             'realm url header is correct',
           );
           let json = response.body as SingleCardDocument;
-          console.log(json);
           let id = json.data.id!.split('/').pop()!;
           let cardFile = join(
             dir.name,
@@ -1683,9 +1682,6 @@ module(basename(__filename), function () {
           );
 
           let json = response.body;
-          if (response.status !== 200) {
-            console.log(JSON.stringify(json, null, 2));
-          }
           assert.ok(json.data.meta.lastModified, 'lastModified exists');
 
           assert.true(

--- a/packages/realm-server/tests/card-endpoints-test.ts
+++ b/packages/realm-server/tests/card-endpoints-test.ts
@@ -1607,7 +1607,7 @@ module(basename(__filename), function () {
                 },
                 meta: {
                   adoptsFrom: {
-                    module: './friend.gts',
+                    module: './friend',
                     name: 'Friend',
                   },
                 },
@@ -1635,7 +1635,7 @@ module(basename(__filename), function () {
                   },
                   meta: {
                     adoptsFrom: {
-                      module: 'http://localhost:4202/node-test/friend',
+                      module: './friend',
                       name: 'Friend',
                     },
                   },
@@ -1648,7 +1648,7 @@ module(basename(__filename), function () {
                   },
                   meta: {
                     adoptsFrom: {
-                      module: 'http://localhost:4202/node-test/friend',
+                      module: './friend',
                       name: 'Friend',
                     },
                   },
@@ -1661,7 +1661,7 @@ module(basename(__filename), function () {
                   },
                   meta: {
                     adoptsFrom: {
-                      module: 'http://localhost:4202/node-test/friend',
+                      module: './friend',
                       name: 'Friend',
                     },
                   },
@@ -1683,6 +1683,9 @@ module(basename(__filename), function () {
           );
 
           let json = response.body;
+          if (response.status !== 200) {
+            console.log(JSON.stringify(json, null, 2));
+          }
           assert.ok(json.data.meta.lastModified, 'lastModified exists');
 
           assert.true(
@@ -1771,7 +1774,7 @@ module(basename(__filename), function () {
                   },
                   meta: {
                     adoptsFrom: {
-                      module: 'http://localhost:4202/node-test/friend',
+                      module: '../friend',
                       name: 'Friend',
                     },
                   },
@@ -1800,7 +1803,7 @@ module(basename(__filename), function () {
                   },
                   meta: {
                     adoptsFrom: {
-                      module: 'http://localhost:4202/node-test/friend',
+                      module: '../friend',
                       name: 'Friend',
                     },
                   },
@@ -1829,7 +1832,7 @@ module(basename(__filename), function () {
                   },
                   meta: {
                     adoptsFrom: {
-                      module: 'http://localhost:4202/node-test/friend',
+                      module: '../friend',
                       name: 'Friend',
                     },
                   },
@@ -1918,7 +1921,7 @@ module(basename(__filename), function () {
                   relationships: {
                     'friends.0': {
                       links: {
-                        self: './local-id-2',
+                        self: './Friend/local-id-2',
                       },
                       data: {
                         id: `${testRealmHref}Friend/local-id-2`,
@@ -1927,7 +1930,7 @@ module(basename(__filename), function () {
                     },
                     'friends.1': {
                       links: {
-                        self: './local-id-3',
+                        self: './Friend/local-id-3',
                       },
                       data: {
                         id: `${testRealmHref}Friend/local-id-3`,
@@ -1947,7 +1950,7 @@ module(basename(__filename), function () {
                   },
                   meta: {
                     adoptsFrom: {
-                      module: 'http://localhost:4202/node-test/friend',
+                      module: './friend',
                       name: 'Friend',
                     },
                   },
@@ -1976,7 +1979,7 @@ module(basename(__filename), function () {
                   },
                   meta: {
                     adoptsFrom: {
-                      module: 'http://localhost:4202/node-test/friend',
+                      module: './friend',
                       name: 'Friend',
                     },
                   },
@@ -2005,7 +2008,7 @@ module(basename(__filename), function () {
                   },
                   meta: {
                     adoptsFrom: {
-                      module: 'http://localhost:4202/node-test/friend',
+                      module: './friend',
                       name: 'Friend',
                     },
                   },
@@ -2072,7 +2075,7 @@ module(basename(__filename), function () {
               meta: {
                 adoptsFrom: {
                   name: 'Friend',
-                  module: 'http://localhost:4202/node-test/friend',
+                  module: '../friend',
                 },
                 realmInfo: {
                   ...testRealmInfo,
@@ -2119,7 +2122,7 @@ module(basename(__filename), function () {
                   },
                   meta: {
                     adoptsFrom: {
-                      module: 'http://localhost:4202/node-test/friend',
+                      module: '../friend',
                       name: 'Friend',
                     },
                   },
@@ -2148,7 +2151,7 @@ module(basename(__filename), function () {
                   },
                   meta: {
                     adoptsFrom: {
-                      module: 'http://localhost:4202/node-test/friend',
+                      module: '../friend',
                       name: 'Friend',
                     },
                   },
@@ -2198,7 +2201,7 @@ module(basename(__filename), function () {
                 meta: {
                   adoptsFrom: {
                     name: 'Friend',
-                    module: 'http://localhost:4202/node-test/friend',
+                    module: '../friend',
                   },
                   realmInfo: {
                     ...testRealmInfo,
@@ -2253,7 +2256,7 @@ module(basename(__filename), function () {
                 meta: {
                   adoptsFrom: {
                     name: 'Friend',
-                    module: 'http://localhost:4202/node-test/friend',
+                    module: '../friend',
                   },
                   realmInfo: {
                     ...testRealmInfo,

--- a/packages/realm-server/tests/card-source-endpoints-test.ts
+++ b/packages/realm-server/tests/card-source-endpoints-test.ts
@@ -845,7 +845,7 @@ module(basename(__filename), function () {
                   },
                   meta: {
                     adoptsFrom: {
-                      module: '/test-card',
+                      module: '../test-card',
                       name: 'TestCard',
                     },
                   },

--- a/packages/realm-server/tests/realm-endpoints-test.ts
+++ b/packages/realm-server/tests/realm-endpoints-test.ts
@@ -978,7 +978,7 @@ module(basename(__filename), function () {
             },
             meta: {
               adoptsFrom: {
-                module: '/person',
+                module: '../person',
                 name: 'Person',
               },
               realmInfo: {

--- a/packages/runtime-common/code-ref.ts
+++ b/packages/runtime-common/code-ref.ts
@@ -16,7 +16,8 @@ import {
 } from './constants';
 import { CardError } from './error';
 import { meta } from './constants';
-import { isUrlLike, LooseCardResource, trimExecutableExtension } from './index';
+import type { LooseCardResource } from './index';
+import { isUrlLike, trimExecutableExtension } from './index';
 
 export type ResolvedCodeRef = {
   module: string;

--- a/packages/runtime-common/error.ts
+++ b/packages/runtime-common/error.ts
@@ -348,8 +348,13 @@ export function responseWithError(
       `Could not fashion error response, requestContext is missing`,
     );
   }
+  let realmURL = requestContext.realm?.url;
+  let responseBody = body ? { ...body } : serializableError(error);
+  if (realmURL && responseBody.realm === undefined) {
+    responseBody.realm = realmURL;
+  }
   return createResponse({
-    body: JSON.stringify({ errors: [body ? body : serializableError(error)] }),
+    body: JSON.stringify({ errors: [responseBody] }),
     init: {
       status: error.status,
       statusText: error.title,

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -48,6 +48,18 @@ export interface SearchResultError {
   };
 }
 
+function absolutizeInstanceURL(
+  url: string,
+  resourceId: string | undefined,
+  setURL: (newURL: string) => void,
+) {
+  if (!resourceId) {
+    setURL(url);
+    return;
+  }
+  setURL(new URL(url, resourceId).href);
+}
+
 export class RealmIndexQueryEngine {
   #realm: Realm;
   #fetch: typeof globalThis.fetch;
@@ -307,11 +319,12 @@ export class RealmIndexQueryEngine {
               ...includedResource,
               ...{ links: { self: includedResource.id } },
             });
-            function visitURL(url: string, setURL: (newURL: string) => void) {
-              setURL(new URL(url, rewrittenResource.id).href);
-            }
-            visitInstanceURLs(rewrittenResource, visitURL);
-            visitModuleDeps(rewrittenResource, visitURL);
+            visitInstanceURLs(rewrittenResource, (url, setURL) =>
+              absolutizeInstanceURL(url, rewrittenResource.id, setURL),
+            );
+            visitModuleDeps(rewrittenResource, (url, setURL) =>
+              absolutizeInstanceURL(url, rewrittenResource.id, setURL),
+            );
             included.push(rewrittenResource);
           }
         }

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -56,6 +56,7 @@ import {
   isCardDocumentString,
   isBrowserTestEnv,
 } from './index';
+import { visitModuleDeps } from './code-ref';
 import merge from 'lodash/merge';
 import mergeWith from 'lodash/mergeWith';
 import cloneDeep from 'lodash/cloneDeep';
@@ -2267,6 +2268,9 @@ export class Realm {
           resource,
           included,
           realmURL: new URL(this.url),
+        });
+        visitModuleDeps(resource, (moduleURL, setModuleURL) => {
+          setModuleURL(new URL(moduleURL, instanceURL).href);
         });
       }
       let fileSerialization: LooseSingleCardDocument | undefined;

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -2392,7 +2392,7 @@ export class Realm {
             message: maybeError.error.errorDetail.message,
             // note that this is actually available as part of the response
             // header too--it's just easier for clients when it is here
-                  meta: {
+            meta: {
               lastKnownGoodHtml: maybeError.error.lastKnownGoodHtml,
               cardTitle: maybeError.error.cardTitle,
               scopedCssUrls: maybeError.error.scopedCssUrls,

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -1287,9 +1287,9 @@ export class Realm {
           return this.#adapter.createJWT(
             {
               user,
-              realm: this.url,
               sessionRoom,
               permissions: userPermissions,
+              realm: this.url,
             },
             '7d',
             this.#realmSecretSeed,
@@ -2392,8 +2392,7 @@ export class Realm {
             message: maybeError.error.errorDetail.message,
             // note that this is actually available as part of the response
             // header too--it's just easier for clients when it is here
-            realm: this.url,
-            meta: {
+                  meta: {
               lastKnownGoodHtml: maybeError.error.lastKnownGoodHtml,
               cardTitle: maybeError.error.cardTitle,
               scopedCssUrls: maybeError.error.scopedCssUrls,
@@ -3559,7 +3558,6 @@ export class Realm {
     return serialize({
       doc,
       definition,
-      realm: this.url,
       relativeTo,
       customFieldDefinitions,
     });

--- a/packages/runtime-common/serializers/code-ref.ts
+++ b/packages/runtime-common/serializers/code-ref.ts
@@ -8,6 +8,9 @@ import {
   isResolvedCodeRef,
   executableExtensions,
 } from '../index';
+// We only use a subset of SerializeOpts here; accept any to align with the
+// serializer interface without surfacing unused properties.
+import type { SerializeOpts } from 'https://cardstack.com/base/card-api';
 
 export function queryableValue(
   codeRef: ResolvedCodeRef | {} | undefined,
@@ -20,7 +23,7 @@ export function serialize(
   codeRef: ResolvedCodeRef | {},
   doc: any,
   _visited?: Set<string>,
-  opts?: { trimExecutableExtension?: true; relativeTo?: URL },
+  opts?: SerializeOpts & { relativeTo?: URL; trimExecutableExtension?: true },
 ): ResolvedCodeRef | {} {
   let baseURL =
     opts?.relativeTo instanceof URL
@@ -60,7 +63,7 @@ export async function deserializeAbsolute<T extends BaseDefConstructor>(
 function codeRefAdjustments(
   codeRef: any,
   relativeTo?: URL,
-  opts?: { trimExecutableExtension?: true },
+  opts?: SerializeOpts & { trimExecutableExtension?: true },
 ) {
   if (!codeRef) {
     return {};

--- a/packages/runtime-common/serializers/code-ref.ts
+++ b/packages/runtime-common/serializers/code-ref.ts
@@ -20,17 +20,17 @@ export function serialize(
   codeRef: ResolvedCodeRef | {},
   doc: any,
   _visited?: Set<string>,
-  opts?: any,
+  opts?: { trimExecutableExtension?: true; relativeTo?: URL },
 ): ResolvedCodeRef | {} {
+  let baseURL =
+    opts?.relativeTo instanceof URL
+      ? opts.relativeTo
+      : doc?.data?.id && typeof doc.data.id === 'string'
+        ? new URL(doc.data.id)
+        : undefined;
   return {
     ...codeRef,
-    ...codeRefAdjustments(
-      codeRef,
-      (doc.data.id ?? (opts?.relativeTo && opts.relativeTo instanceof URL))
-        ? opts.relativeTo
-        : undefined,
-      opts,
-    ),
+    ...codeRefAdjustments(codeRef, baseURL, opts),
   };
 }
 
@@ -53,13 +53,15 @@ export async function deserializeAbsolute<T extends BaseDefConstructor>(
 ): Promise<BaseInstanceType<T>> {
   return {
     ...codeRef,
-    ...codeRefAdjustments(codeRef, relativeTo, {
-      useAbsoluteURL: true,
-    }),
+    ...codeRefAdjustments(codeRef, relativeTo),
   } as BaseInstanceType<T>;
 }
 
-function codeRefAdjustments(codeRef: any, relativeTo?: URL, opts?: any) {
+function codeRefAdjustments(
+  codeRef: any,
+  relativeTo?: URL,
+  opts?: { trimExecutableExtension?: true },
+) {
   if (!codeRef) {
     return {};
   }
@@ -69,26 +71,15 @@ function codeRefAdjustments(codeRef: any, relativeTo?: URL, opts?: any) {
   if (!isUrlLike(codeRef.module)) {
     return {};
   }
-  if (opts?.useAbsoluteURL && relativeTo) {
-    return { module: new URL(codeRef.module, relativeTo).href };
-  }
-  if (!opts?.maybeRelativeURL) {
-    return {};
-  }
-  if (!codeRef.module.startsWith('http') && opts.maybeRelativeURL) {
-    // it's already relative
+  if (relativeTo) {
+    let module = new URL(codeRef.module, relativeTo).href;
     return {
       module: opts?.trimExecutableExtension
-        ? trimExecutableExtension(codeRef.module)
-        : codeRef.module,
+        ? trimExecutableExtension(module)
+        : module,
     };
   }
-  let module = opts.maybeRelativeURL(codeRef.module);
-  return {
-    module: opts?.trimExecutableExtension
-      ? trimExecutableExtension(module)
-      : module,
-  };
+  return {};
 }
 
 function maybeSerializeCodeRef(
@@ -98,9 +89,11 @@ function maybeSerializeCodeRef(
   if (codeRef && isResolvedCodeRef(codeRef)) {
     if (isUrlLike(codeRef.module)) {
       // if a stack is passed in, use the containing card to resolve relative references
+      let base =
+        stack.length > 0 ? stack.find((i) => (i as any).id)?.id : undefined;
       let moduleHref =
-        stack.length > 0
-          ? new URL(codeRef.module, stack.find((i) => i.id).id).href
+        base && typeof base === 'string'
+          ? new URL(codeRef.module, base).href
           : codeRef.module;
       return `${moduleHref}/${codeRef.name}`;
     } else {

--- a/packages/runtime-common/serializers/code-ref.ts
+++ b/packages/runtime-common/serializers/code-ref.ts
@@ -23,7 +23,12 @@ export function serialize(
   codeRef: ResolvedCodeRef | {},
   doc: any,
   _visited?: Set<string>,
-  opts?: SerializeOpts & { relativeTo?: URL; trimExecutableExtension?: true },
+  opts?: SerializeOpts & {
+    relativeTo?: URL;
+    trimExecutableExtension?: true;
+    maybeRelativeURL?: (url: string) => string;
+    allowRelative?: true;
+  },
 ): ResolvedCodeRef | {} {
   let baseURL =
     opts?.relativeTo instanceof URL
@@ -63,7 +68,11 @@ export async function deserializeAbsolute<T extends BaseDefConstructor>(
 function codeRefAdjustments(
   codeRef: any,
   relativeTo?: URL,
-  opts?: SerializeOpts & { trimExecutableExtension?: true },
+  opts?: SerializeOpts & {
+    trimExecutableExtension?: true;
+    maybeRelativeURL?: (url: string) => string;
+    allowRelative?: true;
+  },
 ) {
   if (!codeRef) {
     return {};
@@ -76,11 +85,13 @@ function codeRefAdjustments(
   }
   if (relativeTo) {
     let module = new URL(codeRef.module, relativeTo).href;
-    return {
-      module: opts?.trimExecutableExtension
-        ? trimExecutableExtension(module)
-        : module,
-    };
+    if (opts?.trimExecutableExtension) {
+      module = trimExecutableExtension(module);
+    }
+    if (opts?.allowRelative && opts?.maybeRelativeURL) {
+      module = opts.maybeRelativeURL(module);
+    }
+    return { module };
   }
   return {};
 }

--- a/packages/runtime-common/url.ts
+++ b/packages/runtime-common/url.ts
@@ -1,3 +1,4 @@
+import type { LooseCardResource } from 'resource-types';
 import { RealmPaths } from './paths';
 
 export function maybeURL(
@@ -31,14 +32,6 @@ export function relativeURL(
   }
   let ourParts = url.pathname.split('/');
   let theirParts = relativeTo.pathname.split('/');
-
-  // element zero for both is "/" because they always start with a slash check
-  // element 1, if those differ, our nears common ancestor is the root of the
-  // origin. In the case where the relativeTo is a entry in the origin, favor
-  // using "./" to express the relative path.
-  if (ourParts[1] !== theirParts[1] && theirParts.length > 2) {
-    return url.pathname;
-  }
 
   let lastPart: string | undefined;
   while (
@@ -78,4 +71,34 @@ export function trimJsonExtension(str: string) {
 
 export function removeFileExtension(fileURL: string | undefined) {
   return fileURL?.replace(/\.[^/.]+$/, '');
+}
+
+type VisitInstanceURL = (
+  instanceURL: string,
+  setInstanceURL: (newURL: string) => void,
+) => void;
+
+export function visitInstanceURLs(
+  resourceJson: LooseCardResource,
+  visit: VisitInstanceURL,
+): void {
+  if (resourceJson.links) {
+    let links = resourceJson.links;
+    if (links.self) {
+      visit(links.self, (newURL) => {
+        links.self = newURL;
+      });
+    }
+  }
+  let relationships = resourceJson.relationships;
+  if (relationships) {
+    for (let relationship of Object.values(relationships)) {
+      let links = relationship.links;
+      if (links && links.self) {
+        visit(links.self, (newURL) => {
+          links.self = newURL;
+        });
+      }
+    }
+  }
 }

--- a/packages/runtime-common/url.ts
+++ b/packages/runtime-common/url.ts
@@ -1,4 +1,4 @@
-import type { LooseCardResource } from 'resource-types';
+import type { LooseCardResource } from './index';
 import { RealmPaths } from './paths';
 
 export function maybeURL(


### PR DESCRIPTION
- Spurred by a failing test in query fields work that revealed incorrect relativization of a meta.adoptsFrom.module URL
- add module URL and instance URL visitors
   - adjust relativeURL to always return relative paths when possible and add
   test coverage
   - extend URL and code-ref unit tests; adjust realm indexing and code ref
   resolution for relative modules
   - update card endpoints test fixtures to match new relative URL behavior