### PR TITLE
Handle patching instances that are in an error state

### DIFF
--- a/packages/realm-server/tests/card-endpoints-test.ts
+++ b/packages/realm-server/tests/card-endpoints-test.ts
@@ -1588,6 +1588,132 @@ module(basename(__filename), function () {
           assert.strictEqual(response.body.data.length, 1, 'found one card');
         });
 
+        test('patches card when index entry is an error using pristine doc', async function (assert) {
+          let cardURL = `${testRealmHref}person-1`;
+          let errorDoc = {
+            message: 'render failed',
+            status: 500,
+            additionalErrors: null,
+          };
+
+          for (let table of ['boxel_index', 'boxel_index_working']) {
+            await dbAdapter.execute(
+              `UPDATE ${table}
+               SET type = 'error', error_doc = $1::jsonb
+               WHERE url = $2`,
+              {
+                bind: [JSON.stringify(errorDoc), cardURL],
+              },
+            );
+          }
+
+          let response = await request
+            .patch('/person-1')
+            .send({
+              data: {
+                type: 'card',
+                attributes: {
+                  firstName: 'Recovered',
+                },
+                meta: {
+                  adoptsFrom: {
+                    module: './person.gts',
+                    name: 'Person',
+                  },
+                },
+              },
+            })
+            .set('Accept', 'application/vnd.card+json');
+
+          assert.strictEqual(response.status, 200, 'HTTP 200 status');
+          assert.strictEqual(
+            response.body.data.attributes?.firstName,
+            'Recovered',
+            'patched response uses last known good doc',
+          );
+
+          let cardFile = join(
+            dir.name,
+            'realm_server_1',
+            'test',
+            'person-1.json',
+          );
+          let card = readJSONSync(cardFile);
+          assert.strictEqual(
+            card.data.attributes?.firstName,
+            'Recovered',
+            'card file updated from error state',
+          );
+          assert.deepEqual(
+            card.data.relationships?.['cardInfo.theme'],
+            { links: { self: null } },
+            'relationships from pristine doc are preserved',
+          );
+        });
+
+        test('patches card when index entry is an error without pristine doc', async function (assert) {
+          let cardURL = `${testRealmHref}person-1`;
+          let errorDoc = {
+            message: 'render failed',
+            status: 500,
+            additionalErrors: null,
+          };
+
+          for (let table of ['boxel_index', 'boxel_index_working']) {
+            await dbAdapter.execute(
+              `UPDATE ${table}
+               SET type = 'error', error_doc = $1::jsonb, pristine_doc = NULL
+               WHERE url = $2`,
+              {
+                bind: [JSON.stringify(errorDoc), cardURL],
+              },
+            );
+          }
+
+          let response = await request
+            .patch('/person-1')
+            .send({
+              data: {
+                type: 'card',
+                attributes: {
+                  firstName: 'Fresh Start',
+                },
+                meta: {
+                  adoptsFrom: {
+                    module: './person.gts',
+                    name: 'Person',
+                  },
+                },
+              },
+            })
+            .set('Accept', 'application/vnd.card+json');
+
+          assert.strictEqual(response.status, 200, 'HTTP 200 status');
+          assert.strictEqual(
+            response.body.data.attributes?.firstName,
+            'Fresh Start',
+            'patched response uses empty base when pristine doc missing',
+          );
+
+          let cardFile = join(
+            dir.name,
+            'realm_server_1',
+            'test',
+            'person-1.json',
+          );
+          let card = readJSONSync(cardFile);
+          assert.strictEqual(
+            card.data.attributes?.firstName,
+            'Fresh Start',
+            'card file updated even without pristine doc',
+          );
+          assert.deepEqual(card.data.meta.adoptsFrom, {
+            module: './person',
+            name: 'Person',
+          });
+          assert.strictEqual(card.data.type, 'card');
+        });
+
         test('creates card instances when it encounters "lid" in the request', async function (assert) {
           let response = await request
             .patch('/hassan')

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -2192,12 +2192,9 @@ export class Realm {
         meta: { adoptsFrom: patch.meta.adoptsFrom },
       },
     ) as CardResource;
-    if (!originalClone.meta) {
-      originalClone.meta = { adoptsFrom: patch.meta.adoptsFrom };
-    } else {
-      originalClone.meta.adoptsFrom =
-        originalClone.meta.adoptsFrom ?? patch.meta.adoptsFrom;
-    }
+    originalClone.meta ??= { adoptsFrom: patch.meta.adoptsFrom };
+    originalClone.meta.adoptsFrom =
+      originalClone.meta.adoptsFrom ?? patch.meta.adoptsFrom;
     delete originalClone.meta.lastModified;
 
     if (

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -2156,24 +2156,12 @@ export class Realm {
 
     let url = this.paths.fileURL(localPath);
     let instanceURL = url.href.replace(/\.json$/, '');
-    let originalMaybeError =
-      await this.#realmIndexQueryEngine.cardDocument(url);
-    if (!originalMaybeError) {
+    let indexEntry = await this.#realmIndexQueryEngine.instance(url, {
+      includeErrors: true,
+    });
+    if (!indexEntry) {
       return notFound(request, requestContext);
     }
-    if (originalMaybeError.type === 'error') {
-      return systemError({
-        requestContext,
-        message: `unable to patch card, cannot load original from index`,
-        additionalError: CardError.fromSerializableError(
-          originalMaybeError.error,
-        ),
-        id: instanceURL,
-      });
-    }
-    let { doc: original } = originalMaybeError;
-    let originalClone = cloneDeep(original.data);
-    delete originalClone.meta.lastModified;
 
     let { data: patch, included: maybeIncluded } = await request.json();
     if (!isCardResource(patch)) {
@@ -2198,9 +2186,24 @@ export class Realm {
         }
       }
     }
+    let originalClone = cloneDeep(
+      indexEntry.instance ?? {
+        type: 'card',
+        meta: { adoptsFrom: patch.meta.adoptsFrom },
+      },
+    ) as CardResource;
+    if (!originalClone.meta) {
+      originalClone.meta = { adoptsFrom: patch.meta.adoptsFrom };
+    } else {
+      originalClone.meta.adoptsFrom =
+        originalClone.meta.adoptsFrom ?? patch.meta.adoptsFrom;
+    }
+    delete originalClone.meta.lastModified;
+
     if (
+      originalClone.meta?.adoptsFrom &&
       internalKeyFor(patch.meta.adoptsFrom, url) !==
-      internalKeyFor(originalClone.meta.adoptsFrom, url)
+        internalKeyFor(originalClone.meta.adoptsFrom, url)
     ) {
       return badRequest({
         message: `Cannot change card instance type to ${JSON.stringify(


### PR DESCRIPTION
This PR adds the ability to patch an instance that is in an error state by using the last known good json as the original instance that we patch.