### PR TITLE
Fix ContainsMany, LinksTo and LinksToMany edit component field alignments

### DIFF
--- a/packages/base/contains-many-component.gts
+++ b/packages/base/contains-many-component.gts
@@ -153,7 +153,7 @@ class ContainsManyEditor extends GlimmerComponent<ContainsManyEditorSignature> {
     </PermissionsConsumer>
     <style scoped>
       .contains-many-editor {
-        --remove-icon-size: var(--boxel-icon-sm);
+        --remove-icon-size: var(--boxel-icon-med);
       }
       .contains-many-editor :deep(.compound-field.edit-format .add-new) {
         border: 1px solid var(--border, var(--boxel-border-color));
@@ -171,7 +171,7 @@ class ContainsManyEditor extends GlimmerComponent<ContainsManyEditorSignature> {
         grid-template-columns: 1fr;
       }
       .editor.can-write {
-        grid-template-columns: var(--boxel-icon-sm) 1fr var(--remove-icon-size);
+        grid-template-columns: auto 1fr auto;
         gap: var(--boxel-sp-xs);
       }
       .editor + .editor {
@@ -187,8 +187,10 @@ class ContainsManyEditor extends GlimmerComponent<ContainsManyEditorSignature> {
         --icon-color: currentColor;
         --icon-stroke-width: 1.5px;
         --boxel-icon-button-width: var(--remove-icon-size);
-        justify-content: end;
-        align-self: auto;
+        --boxel-icon-button-height: var(--remove-icon-size);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
         outline: 0;
         order: 1;
       }
@@ -211,7 +213,7 @@ class ContainsManyEditor extends GlimmerComponent<ContainsManyEditorSignature> {
         gap: var(--boxel-sp-xxxs);
         width: fit-content;
         letter-spacing: var(--boxel-lsp-xs);
-        margin-left: calc(var(--boxel-icon-sm) + var(--boxel-sp-xs));
+        margin-left: calc(var(--boxel-icon-med) + var(--boxel-sp-xs));
         /* for alignment due to sort handle */
       }
       .add-new.no-items {
@@ -220,8 +222,12 @@ class ContainsManyEditor extends GlimmerComponent<ContainsManyEditorSignature> {
       .sort {
         cursor: move;
         cursor: grab;
-        justify-content: start;
-        --boxel-icon-button-width: var(--boxel-icon-sm);
+        --boxel-icon-button-width: var(--boxel-icon-med);
+        --boxel-icon-button-height: var(--boxel-icon-med);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 5px;
       }
       .sort:active {
         cursor: grabbing;

--- a/packages/base/contains-many-component.gts
+++ b/packages/base/contains-many-component.gts
@@ -29,6 +29,7 @@ import {
   uuidv4,
   isCardInstance,
 } from '@cardstack/runtime-common';
+import { cn } from '@cardstack/boxel-ui/helpers';
 import { IconTrash, FourLines, IconPlus } from '@cardstack/boxel-ui/icons';
 import { task } from 'ember-concurrency';
 import { action } from '@ember/object';
@@ -71,6 +72,10 @@ class ContainsManyEditor extends GlimmerComponent<ContainsManyEditorSignature> {
       index,
       key: `${this.reorderNonce}-${index}`,
     }));
+  }
+
+  get noItems() {
+    return this.args.arrayField.children.length === 0;
   }
 
   <template>
@@ -132,7 +137,7 @@ class ContainsManyEditor extends GlimmerComponent<ContainsManyEditorSignature> {
         {{/if}}
         {{#if permissions.canWrite}}
           <Button
-            class='add-new'
+            class={{cn 'add-new' no-items=this.noItems}}
             @kind='muted'
             @size='tall'
             @rectangular={{true}}
@@ -148,7 +153,7 @@ class ContainsManyEditor extends GlimmerComponent<ContainsManyEditorSignature> {
     </PermissionsConsumer>
     <style scoped>
       .contains-many-editor {
-        --remove-icon-size: var(--boxel-icon-lg);
+        --remove-icon-size: var(--boxel-icon-sm);
       }
       .contains-many-editor :deep(.compound-field.edit-format .add-new) {
         border: 1px solid var(--border, var(--boxel-border-color));
@@ -166,7 +171,8 @@ class ContainsManyEditor extends GlimmerComponent<ContainsManyEditorSignature> {
         grid-template-columns: 1fr;
       }
       .editor.can-write {
-        grid-template-columns: var(--boxel-icon-lg) 1fr var(--remove-icon-size);
+        grid-template-columns: var(--boxel-icon-sm) 1fr var(--remove-icon-size);
+        gap: var(--boxel-sp-xs);
       }
       .editor + .editor {
         margin-top: var(--boxel-sp-xs);
@@ -180,6 +186,8 @@ class ContainsManyEditor extends GlimmerComponent<ContainsManyEditorSignature> {
       .remove {
         --icon-color: currentColor;
         --icon-stroke-width: 1.5px;
+        --boxel-icon-button-width: var(--remove-icon-size);
+        justify-content: end;
         align-self: auto;
         outline: 0;
         order: 1;
@@ -203,12 +211,17 @@ class ContainsManyEditor extends GlimmerComponent<ContainsManyEditorSignature> {
         gap: var(--boxel-sp-xxxs);
         width: fit-content;
         letter-spacing: var(--boxel-lsp-xs);
-        margin-left: var(--boxel-icon-lg);
+        margin-left: calc(var(--boxel-icon-sm) + var(--boxel-sp-xs));
         /* for alignment due to sort handle */
+      }
+      .add-new.no-items {
+        margin-left: 0;
       }
       .sort {
         cursor: move;
         cursor: grab;
+        justify-content: start;
+        --boxel-icon-button-width: var(--boxel-icon-sm);
       }
       .sort:active {
         cursor: grabbing;

--- a/packages/base/links-to-editor.gts
+++ b/packages/base/links-to-editor.gts
@@ -98,8 +98,9 @@ export class LinksToEditor extends GlimmerComponent<Signature> {
         display: grid;
       }
       .links-to-editor.can-write {
-        grid-template-columns: 1fr var(--boxel-icon-sm);
+        grid-template-columns: 1fr auto;
         gap: var(--boxel-sp-xs);
+        align-items: center;
       }
       .links-to-editor > :deep(.boxel-card-container) {
         order: -1;
@@ -111,10 +112,12 @@ export class LinksToEditor extends GlimmerComponent<Signature> {
         --icon-color: var(--background, var(--boxel-light));
         --icon-border: var(--foreground, var(--boxel-dark));
         --icon-bg: var(--foreground, var(--boxel-dark));
-        --boxel-icon-button-width: var(--boxel-icon-sm);
-        align-self: center;
+        --boxel-icon-button-width: var(--boxel-icon-med);
+        --boxel-icon-button-height: var(--boxel-icon-med);
         outline: 0;
-        justify-content: end;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
       }
       .remove:focus,
       .remove:hover {

--- a/packages/base/links-to-editor.gts
+++ b/packages/base/links-to-editor.gts
@@ -98,7 +98,8 @@ export class LinksToEditor extends GlimmerComponent<Signature> {
         display: grid;
       }
       .links-to-editor.can-write {
-        grid-template-columns: 1fr var(--boxel-icon-lg);
+        grid-template-columns: 1fr var(--boxel-icon-sm);
+        gap: var(--boxel-sp-sm);
       }
       .links-to-editor > :deep(.boxel-card-container) {
         order: -1;
@@ -110,8 +111,10 @@ export class LinksToEditor extends GlimmerComponent<Signature> {
         --icon-color: var(--background, var(--boxel-light));
         --icon-border: var(--foreground, var(--boxel-dark));
         --icon-bg: var(--foreground, var(--boxel-dark));
+        --boxel-icon-button-width: var(--boxel-icon-sm);
         align-self: center;
         outline: 0;
+        justify-content: end;
       }
       .remove:focus,
       .remove:hover {

--- a/packages/base/links-to-editor.gts
+++ b/packages/base/links-to-editor.gts
@@ -99,7 +99,7 @@ export class LinksToEditor extends GlimmerComponent<Signature> {
       }
       .links-to-editor.can-write {
         grid-template-columns: 1fr var(--boxel-icon-sm);
-        gap: var(--boxel-sp-sm);
+        gap: var(--boxel-sp-xs);
       }
       .links-to-editor > :deep(.boxel-card-container) {
         order: -1;

--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -311,7 +311,7 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
         gap: var(--boxel-sp-xxxs);
         width: fit-content;
         letter-spacing: var(--boxel-lsp-xs);
-        margin-left: calc(var(--boxel-icon-sm) + var(--boxel-sp-sm));
+        margin-left: calc(var(--boxel-icon-sm) + var(--boxel-sp-xs));
         /* for alignment due to sort handle */
       }
       .add-new.no-items {

--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -44,7 +44,7 @@ import {
   FourLines,
   IconPlus,
 } from '@cardstack/boxel-ui/icons';
-import { eq } from '@cardstack/boxel-ui/helpers';
+import { cn, eq } from '@cardstack/boxel-ui/helpers';
 import { consume } from 'ember-provide-consume-context';
 import {
   SortableGroupModifier as sortableGroup,
@@ -188,6 +188,10 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
     }));
   }
 
+  get noItems() {
+    return this.args.arrayField.children.length === 0;
+  }
+
   <template>
     <PermissionsConsumer as |permissions|>
       {{#if this.decoratedChildren.length}}
@@ -246,7 +250,7 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
 
       {{#if permissions.canWrite}}
         <Button
-          class='add-new'
+          class={{cn 'add-new' no-items=this.noItems}}
           @kind='muted'
           @size='tall'
           @rectangular={{true}}
@@ -277,15 +281,18 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
         grid-template-columns: 1fr;
       }
       .editor.can-write {
-        grid-template-columns: var(--boxel-icon-lg) 1fr var(--boxel-icon-lg);
+        grid-template-columns: var(--boxel-icon-sm) 1fr var(--boxel-icon-sm);
+        gap: var(--boxel-sp-xs);
       }
       .remove {
         --icon-color: var(--background, var(--boxel-light));
         --icon-border: var(--foreground, var(--boxel-dark));
         --icon-bg: var(--foreground, var(--boxel-dark));
+        --boxel-icon-button-width: var(--boxel-icon-sm);
         align-self: auto;
         outline: 0;
         order: 1;
+        justify-content: end;
       }
       .remove:focus,
       .remove:hover {
@@ -304,12 +311,17 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
         gap: var(--boxel-sp-xxxs);
         width: fit-content;
         letter-spacing: var(--boxel-lsp-xs);
-        margin-left: var(--boxel-icon-lg);
+        margin-left: calc(var(--boxel-icon-sm) + var(--boxel-sp-sm));
         /* for alignment due to sort handle */
+      }
+      .add-new.no-items {
+        margin-left: 0;
       }
       .sort {
         cursor: move;
         cursor: grab;
+        --boxel-icon-button-width: var(--boxel-icon-sm);
+        justify-content: start;
       }
       .sort:active {
         cursor: grabbing;

--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -281,18 +281,21 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
         grid-template-columns: 1fr;
       }
       .editor.can-write {
-        grid-template-columns: var(--boxel-icon-sm) 1fr var(--boxel-icon-sm);
+        grid-template-columns: auto 1fr auto;
         gap: var(--boxel-sp-xs);
+        align-items: center;
       }
       .remove {
         --icon-color: var(--background, var(--boxel-light));
         --icon-border: var(--foreground, var(--boxel-dark));
         --icon-bg: var(--foreground, var(--boxel-dark));
-        --boxel-icon-button-width: var(--boxel-icon-sm);
-        align-self: auto;
+        --boxel-icon-button-width: var(--boxel-icon-med);
+        --boxel-icon-button-height: var(--boxel-icon-med);
         outline: 0;
         order: 1;
-        justify-content: end;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
       }
       .remove:focus,
       .remove:hover {
@@ -311,7 +314,7 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
         gap: var(--boxel-sp-xxxs);
         width: fit-content;
         letter-spacing: var(--boxel-lsp-xs);
-        margin-left: calc(var(--boxel-icon-sm) + var(--boxel-sp-xs));
+        margin-left: calc(var(--boxel-icon-med) + var(--boxel-sp-xs));
         /* for alignment due to sort handle */
       }
       .add-new.no-items {
@@ -320,8 +323,12 @@ class LinksToManyStandardEditor extends GlimmerComponent<LinksToManyStandardEdit
       .sort {
         cursor: move;
         cursor: grab;
-        --boxel-icon-button-width: var(--boxel-icon-sm);
-        justify-content: start;
+        --boxel-icon-button-width: var(--boxel-icon-med);
+        --boxel-icon-button-height: var(--boxel-icon-med);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 5px;
       }
       .sort:active {
         cursor: grabbing;

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -3095,11 +3095,11 @@ module('Integration | operator-mode', function (hooks) {
       Math.round(overlayButtonRect.top),
     );
 
-    let iconWidth = 20;
+    let iconWidth = 30;
     let gap = 9; // matches var(--boxel-sp-xs) used in the component
     assert.strictEqual(
-      Math.round(itemRect.left + (iconWidth + gap) / 2),
-      Math.round(overlayButtonRect.left),
+      Math.floor(itemRect.left + (iconWidth + gap) / 2),
+      Math.floor(overlayButtonRect.left),
     );
 
     await click(

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -3096,7 +3096,7 @@ module('Integration | operator-mode', function (hooks) {
     );
 
     let iconWidth = 20;
-    let gap = 10;
+    let gap = 9; // matches var(--boxel-sp-xs) used in the component
     assert.strictEqual(
       Math.round(itemRect.left + (iconWidth + gap) / 2),
       Math.round(overlayButtonRect.left),

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -3094,10 +3094,11 @@ module('Integration | operator-mode', function (hooks) {
       Math.round(itemRect.top),
       Math.round(overlayButtonRect.top),
     );
+
+    let iconWidth = 20;
+    let gap = 10;
     assert.strictEqual(
-      Math.round(
-        itemRect.left + 40 / 2,
-      ) /* add icon width / 2 for testing scale */,
+      Math.round(itemRect.left + (iconWidth + gap) / 2),
       Math.round(overlayButtonRect.left),
     );
 


### PR DESCRIPTION
**ContainsMany no items**
Before:

<img width="805" height="162" alt="ContainsMany-before-no-items" src="https://github.com/user-attachments/assets/4e47c56e-0156-4a6d-b672-719108c7774d" />

After:

<img width="779" height="287" alt="ContainsMany-after-no-item" src="https://github.com/user-attachments/assets/f573b75d-44f6-44bf-b411-f8bfe589f7b8" />


**ContainsMany with items**
Before:

<img width="801" height="503" alt="ContainsMany-before-with-items" src="https://github.com/user-attachments/assets/9acf2b2c-bc76-43c2-bba9-58f1c9fb97fb" />

After

<img width="770" height="560" alt="ContainsMany-after-with-item" src="https://github.com/user-attachments/assets/ee76de08-a8b2-47db-8539-7951bcc2914f" />


**LinksTo/LinksToMany no items**
Before:

<img width="798" height="603" alt="LinksToMany-before-no-items" src="https://github.com/user-attachments/assets/33f6b616-aeef-4bf2-8127-8efd8cac1dc0" />

After:

<img width="784" height="355" alt="LinksToMany-after-no-item" src="https://github.com/user-attachments/assets/7d2fb406-4eb9-4aff-a4e6-76ac393b5a68" />


**LinksTo/LinksToMany with items**

Before:

<img width="799" height="573" alt="LinksToMany-before-with-item" src="https://github.com/user-attachments/assets/a4bc65c5-e2d9-4b15-ab8f-6589e1a7b958" />

After:

<img width="802" height="464" alt="LinksToMany-after-with-item" src="https://github.com/user-attachments/assets/5ffa2459-5e46-4fed-8131-28ae607a1ab4" />
