### PR TITLE
matrix: Add logging of test realm server database

### DIFF
--- a/packages/matrix/helpers/isolated-realm-server.ts
+++ b/packages/matrix/helpers/isolated-realm-server.ts
@@ -287,6 +287,8 @@ export async function startServer({
     `--toUrl='http://localhost:4205/base/'`,
   ]);
 
+  console.log(`realm server database: ${testDBName}`);
+
   let realmServer = spawn('ts-node', serverArgs, {
     cwd: realmServerDir,
     stdio: ['pipe', 'pipe', 'pipe', 'ipc'],


### PR DESCRIPTION
I’m often adding this when I need to inspect the database to debug head format determination, it might as well always be logged.

Here it is [in CI](https://github.com/cardstack/boxel/actions/runs/20147732135/job/57832884537?pr=3702#step:11:34):

<img width="813" height="274" alt="boxel@1e4f4b9 2025-12-11 16-45-09" src="https://github.com/user-attachments/assets/7d02293d-8820-46af-ac51-08350b9adc0a" />
