### PR TITLE
Implement locking per room

### DIFF
--- a/packages/ai-bot/lib/queries.ts
+++ b/packages/ai-bot/lib/queries.ts
@@ -12,7 +12,7 @@ export async function acquireRoomLock(
   pgAdapter: PgAdapter,
   roomId: string,
   aiBotInstanceId: string,
-  eventId?: string,
+  eventId: string,
 ): Promise<boolean> {
   // Attempts to take an exclusive lock per room by upserting a row. The insert succeeds when no
   // unfinished processing exists for the room; otherwise an UPDATE runs only if the previous run

--- a/packages/ai-bot/lib/queries.ts
+++ b/packages/ai-bot/lib/queries.ts
@@ -14,6 +14,10 @@ export async function acquireRoomLock(
   aiBotInstanceId: string,
   eventId?: string,
 ): Promise<boolean> {
+  // Attempts to take an exclusive lock per room by upserting a row. The insert succeeds when no
+  // unfinished processing exists for the room; otherwise an UPDATE runs only if the previous run
+  // has a non-null completed_at, effectively allowing the next bot instance to pick up where the
+  // prior one finished.
   let { valueExpressions, nameExpressions } = asExpressions({
     ai_bot_instance_id: aiBotInstanceId,
     room_id: roomId,

--- a/packages/ai-bot/lib/queries.ts
+++ b/packages/ai-bot/lib/queries.ts
@@ -8,13 +8,15 @@ import {
   asExpressions,
 } from '@cardstack/runtime-common';
 
-export async function acquireLock(
+export async function acquireRoomLock(
   pgAdapter: PgAdapter,
-  eventId: string,
+  roomId: string,
   aiBotInstanceId: string,
+  eventId?: string,
 ): Promise<boolean> {
   let { valueExpressions, nameExpressions } = asExpressions({
     ai_bot_instance_id: aiBotInstanceId,
+    room_id: roomId,
     event_id_being_processed: eventId,
   });
 
@@ -23,16 +25,21 @@ export async function acquireLock(
     ...addExplicitParens(separatedByCommas(nameExpressions)),
     `VALUES`,
     ...addExplicitParens(separatedByCommas(valueExpressions)),
-    `ON CONFLICT (event_id_being_processed) DO NOTHING`,
-    `RETURNING ai_bot_instance_id, event_id_being_processed`,
+    `ON CONFLICT (room_id) DO UPDATE SET`,
+    `ai_bot_instance_id = EXCLUDED.ai_bot_instance_id,`,
+    `event_id_being_processed = EXCLUDED.event_id_being_processed,`,
+    `processing_started_at = EXCLUDED.processing_started_at,`,
+    `completed_at = NULL`,
+    `WHERE ai_bot_event_processing.completed_at IS NOT NULL`,
+    `RETURNING ai_bot_instance_id, room_id, event_id_being_processed`,
   ] as Expression);
 
   return lockRow.length > 0;
 }
 
-export async function releaseLock(pgAdapter: PgAdapter, eventId: string) {
+export async function releaseRoomLock(pgAdapter: PgAdapter, roomId: string) {
   await query(pgAdapter, [
-    `UPDATE ai_bot_event_processing SET completed_at = NOW() WHERE event_id_being_processed = `,
-    param(eventId),
+    `UPDATE ai_bot_event_processing SET completed_at = NOW() WHERE room_id = `,
+    param(roomId),
   ]);
 }

--- a/packages/host/config/schema/1765785229000_schema.sql
+++ b/packages/host/config/schema/1765785229000_schema.sql
@@ -22,7 +22,6 @@
    display_names BLOB,
    resource_created_at,
    icon_html TEXT,
-   definition BLOB,
    head_html TEXT,
    PRIMARY KEY ( url, realm_url ) 
 );
@@ -48,7 +47,6 @@
    fitted_html BLOB,
    display_names BLOB,
    resource_created_at,
-   definition BLOB,
    head_html TEXT,
    PRIMARY KEY ( url, realm_url ) 
 );

--- a/packages/host/config/schema/1765785229000_schema.sql
+++ b/packages/host/config/schema/1765785229000_schema.sql
@@ -22,6 +22,7 @@
    display_names BLOB,
    resource_created_at,
    icon_html TEXT,
+   definition BLOB,
    head_html TEXT,
    PRIMARY KEY ( url, realm_url ) 
 );
@@ -47,6 +48,7 @@
    fitted_html BLOB,
    display_names BLOB,
    resource_created_at,
+   definition BLOB,
    head_html TEXT,
    PRIMARY KEY ( url, realm_url ) 
 );

--- a/packages/postgres/migrations/1765785229000_room-scoped-ai-bot-locks.js
+++ b/packages/postgres/migrations/1765785229000_room-scoped-ai-bot-locks.js
@@ -1,0 +1,67 @@
+exports.shorthands = undefined;
+
+exports.up = (pgm) => {
+  pgm.addColumn('ai_bot_event_processing', {
+    room_id: {
+      type: 'varchar',
+      notNull: false,
+    },
+  });
+
+  pgm.sql(`
+    UPDATE ai_bot_event_processing
+    SET room_id = event_id_being_processed
+    WHERE room_id IS NULL;
+  `);
+
+  pgm.alterColumn('ai_bot_event_processing', 'room_id', { notNull: true });
+
+  pgm.dropConstraint(
+    'ai_bot_event_processing',
+    'ai_bot_event_processing_pkey',
+    { ifExists: true },
+  );
+  pgm.addConstraint(
+    'ai_bot_event_processing',
+    'ai_bot_event_processing_pkey',
+    'PRIMARY KEY(room_id)',
+  );
+
+  pgm.sql(`
+    CREATE OR REPLACE FUNCTION delete_old_ai_bot_event_processing()
+    RETURNS TRIGGER AS $$
+    BEGIN
+      DELETE FROM ai_bot_event_processing
+      WHERE (completed_at IS NOT NULL AND completed_at < NOW() - INTERVAL '30 minutes')
+         OR (completed_at IS NULL AND processing_started_at < NOW() - INTERVAL '30 minutes');
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+  `);
+};
+
+exports.down = (pgm) => {
+  pgm.sql(`
+    CREATE OR REPLACE FUNCTION delete_old_ai_bot_event_processing()
+    RETURNS TRIGGER AS $$
+    BEGIN
+      DELETE FROM ai_bot_event_processing
+      WHERE processing_started_at < NOW() - INTERVAL '30 minutes';
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+  `);
+
+  pgm.dropConstraint(
+    'ai_bot_event_processing',
+    'ai_bot_event_processing_pkey',
+    { ifExists: true },
+  );
+  pgm.addConstraint(
+    'ai_bot_event_processing',
+    'ai_bot_event_processing_pkey',
+    'PRIMARY KEY(event_id_being_processed)',
+  );
+
+  pgm.dropColumn('ai_bot_event_processing', 'room_id');
+};


### PR DESCRIPTION
In this PR we switch the AI bot’s locking from event-scoped to room-scoped so only one responder runs per room at a time, avoiding duplicate replies. Previously we locked on each Matrix event ID, which let near-simultaneous events in the same room race and double-respond. Now we acquire/release locks keyed by room ID, update the responder flow accordingly, add a migration making `ai_bot_event_processing` primary-keyed on `room_id` with cleanup intact, and refresh the locking tests to cover the new behavior.