### PR TITLE
Explicit null for the system card means no card set

### DIFF
--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -1947,9 +1947,16 @@ export default class MatrixService extends Service {
     return this._systemCard;
   }
 
-  private async setSystemCard(systemCardId: string | undefined) {
+  private async setSystemCard(systemCardId: string | undefined | null) {
     // Set the system card to use
-    // If there is none, we fall back to the default
+    // If it is null, we remove any current system card
+    // If it is undefined, we fall back to the default
+    if (systemCardId === null) {
+      // explicit null means no system card
+      this.store.dropReference(this._systemCard?.id);
+      this._systemCard = undefined;
+      return;
+    }
     if (!systemCardId) {
       systemCardId = ENV.defaultSystemCardId;
     }

--- a/packages/host/tests/helpers/mock-matrix.ts
+++ b/packages/host/tests/helpers/mock-matrix.ts
@@ -23,7 +23,7 @@ export interface Config {
   autostart?: boolean;
   now?: () => number;
   directRooms?: string[];
-  systemCardAccountData?: { id?: string };
+  systemCardAccountData?: { id?: string | null };
 }
 
 export function setupMockMatrix(

--- a/packages/host/tests/integration/commands/open-workspace-test.gts
+++ b/packages/host/tests/integration/commands/open-workspace-test.gts
@@ -21,6 +21,7 @@ module('Integration | commands | open-workspace', function (hooks) {
     loggedInAs: '@testuser:localhost',
     activeRealms: [testRealmURL],
     autostart: true,
+    systemCardAccountData: { id: null },
   });
 
   hooks.beforeEach(async function () {


### PR DESCRIPTION
This lets us turn off system cards entirely, and allows a quick way of quieting the tests.