### PR TITLE
Change Cloudflare Images URLs to use Boxel domain

### DIFF
--- a/packages/catalog-realm/Image/0c28db0a-3535-4cba-a22a-f278cee887f3.json
+++ b/packages/catalog-realm/Image/0c28db0a-3535-4cba-a22a-f278cee887f3.json
@@ -2,7 +2,7 @@
   "data": {
     "type": "card",
     "attributes": {
-      "url": "https://imagedelivery.net/TB1OM65i5Go9UkT2wcBzeA/ca5b7364-5de1-4d82-7fc4-61427778b600/public",
+      "url": "https://i.boxel.site/ca5b7364-5de1-4d82-7fc4-61427778b600/public",
       "cardInfo": {
         "title": null,
         "description": null,

--- a/packages/catalog-realm/airbnb-listing/AirbnbListing/59ffa0b2-498a-4c7f-a3bf-50a9a07d6d2f.json
+++ b/packages/catalog-realm/airbnb-listing/AirbnbListing/59ffa0b2-498a-4c7f-a3bf-50a9a07d6d2f.json
@@ -14,10 +14,10 @@
       "photos": {
         "images": [
           {
-            "imageUrl": "https://imagedelivery.net/TB1OM65i5Go9UkT2wcBzeA/upload-1764831632778/public"
+            "imageUrl": "https://i.boxel.site/upload-1764831632778/public"
           },
           {
-            "imageUrl": "https://imagedelivery.net/TB1OM65i5Go9UkT2wcBzeA/upload-1764833876706/public"
+            "imageUrl": "https://i.boxel.site/upload-1764833876706/public"
           }
         ]
       },

--- a/packages/catalog-realm/cloudflare-image.gts
+++ b/packages/catalog-realm/cloudflare-image.gts
@@ -4,7 +4,7 @@ import StringField from 'https://cardstack.com/base/string';
 import UrlField from 'https://cardstack.com/base/url';
 
 export const CLOUDFLARE_ACCOUNT_ID = '4a94a1eb2d21bbbe160234438a49f687';
-export const CLOUDFLARE_ACCOUNT_HASH = 'TB1OM65i5Go9UkT2wcBzeA';
+
 const CLOUDFLARE_VARIANT = 'public';
 
 export class CloudflareImage extends ImageCard {
@@ -16,7 +16,7 @@ export class CloudflareImage extends ImageCard {
       if (!this.cloudflareId) {
         return undefined;
       }
-      return `https://imagedelivery.net/${CLOUDFLARE_ACCOUNT_HASH}/${this.cloudflareId}/${CLOUDFLARE_VARIANT}`;
+      return `https://i.boxel.site/${this.cloudflareId}/${CLOUDFLARE_VARIANT}`;
     },
   });
 }

--- a/packages/catalog-realm/fields-preview/FieldShowcase/9f1dadc1-c269-4236-9daa-4f46f072de76.json
+++ b/packages/catalog-realm/fields-preview/FieldShowcase/9f1dadc1-c269-4236-9daa-4f46f072de76.json
@@ -15,13 +15,13 @@
         "thumbnailURL": null
       },
       "imageAvatar": {
-        "imageUrl": "https://imagedelivery.net/TB1OM65i5Go9UkT2wcBzeA/upload-1764642749200/public"
+        "imageUrl": "https://i.boxel.site/upload-1764642749200/public"
       },
       "imageBrowse": {
-        "imageUrl": "https://imagedelivery.net/TB1OM65i5Go9UkT2wcBzeA/upload-1764642741446/public"
+        "imageUrl": "https://i.boxel.site/upload-1764642741446/public"
       },
       "imageDropzone": {
-        "imageUrl": "https://imagedelivery.net/TB1OM65i5Go9UkT2wcBzeA/upload-1764642756898/public"
+        "imageUrl": "https://i.boxel.site/upload-1764642756898/public"
       },
       "playgroundDay": {
         "value": 2
@@ -59,7 +59,7 @@
         "waveformData": "[71.7264887313467,96.20861956019968,72.27724973372572,97.41518628509944,27.59530338418383,25.919046290801937,83.73945956259132,51.72319160839134,50.338686085575695,20.18428817393825,26.55926478288044,36.03191943517512,80.10861307046677,48.95947157379857,94.98814057637338,71.1485869043668,74.36270600875048,64.6371889323654,56.38191548396541,51.23683546896465,43.77768857630314,64.51791411594806,70.2708090373222,29.16656687820967,90.74576735178701,91.02038489483178,47.159274510618445,67.72221733311542,43.45098992191251,73.9062452226883,99.3917379332142,77.13716405045602,97.2893690888502,27.954925035772344,38.090313366299966,50.40960557186159,38.048423581850344,30.59430574652593,57.687438754091374,65.82221790667347,28.004111783303376,42.07480242920635,84.50735633539398,81.78159048737055,26.74347990357111,72.95667146584165,97.56406086824205,30.088238158787142,81.6772281054923,48.70576615649333,49.606225499171366,96.85157718288208,31.92281296343647,76.40328793642757,96.21667272385939,99.91206855265122,42.85111685470905,60.372011348489885,26.620510704890084,20.69613062387983,60.694032504292295,87.78456065506622,24.516280466050617,22.312610819457717,54.98091127339268,39.801324300230796,73.95821556563291,24.666620384816575,44.251832361221794,37.69967540491946,22.785487093705825,86.42489331848189,81.67288874226585,26.920376119678153,85.73552104943295,54.20117348793851,58.20222635113851,74.02260525406786,63.23603975507417,23.93225826570129]"
       },
       "playgroundImage": {
-        "imageUrl": "https://imagedelivery.net/TB1OM65i5Go9UkT2wcBzeA/upload-1764642806276/public"
+        "imageUrl": "https://i.boxel.site/upload-1764642806276/public"
       },
       "playgroundMonth": {
         "value": 4
@@ -72,10 +72,10 @@
       "multipleImageList": {
         "images": [
           {
-            "imageUrl": "https://imagedelivery.net/TB1OM65i5Go9UkT2wcBzeA/upload-1764582386156/public"
+            "imageUrl": "https://i.boxel.site/upload-1764582386156/public"
           },
           {
-            "imageUrl": "https://imagedelivery.net/TB1OM65i5Go9UkT2wcBzeA/upload-1764577101407/public"
+            "imageUrl": "https://i.boxel.site/upload-1764577101407/public"
           }
         ]
       },
@@ -134,10 +134,10 @@
       "multipleImageGallery": {
         "images": [
           {
-            "imageUrl": "https://imagedelivery.net/TB1OM65i5Go9UkT2wcBzeA/upload-1764642638586/public"
+            "imageUrl": "https://i.boxel.site/upload-1764642638586/public"
           },
           {
-            "imageUrl": "https://imagedelivery.net/TB1OM65i5Go9UkT2wcBzeA/upload-1764642635903/public"
+            "imageUrl": "https://i.boxel.site/upload-1764642635903/public"
           }
         ]
       },
@@ -148,10 +148,10 @@
       "multipleImageDropzone": {
         "images": [
           {
-            "imageUrl": "https://imagedelivery.net/TB1OM65i5Go9UkT2wcBzeA/upload-1764577019466/public"
+            "imageUrl": "https://i.boxel.site/upload-1764577019466/public"
           },
           {
-            "imageUrl": "https://imagedelivery.net/TB1OM65i5Go9UkT2wcBzeA/upload-1764577017328/public"
+            "imageUrl": "https://i.boxel.site/upload-1764577017328/public"
           }
         ]
       },
@@ -165,7 +165,7 @@
       "playgroundMultipleImage": {
         "images": [
           {
-            "imageUrl": "https://imagedelivery.net/TB1OM65i5Go9UkT2wcBzeA/upload-1764642655034/public"
+            "imageUrl": "https://i.boxel.site/upload-1764642655034/public"
           }
         ]
       },

--- a/packages/catalog-realm/spotify-track/SpotifyTrack/3618c1e8-a410-4898-9921-3b1b430645f5.json
+++ b/packages/catalog-realm/spotify-track/SpotifyTrack/3618c1e8-a410-4898-9921-3b1b430645f5.json
@@ -14,7 +14,7 @@
       "likes": 1240000,
       "artist": "摩登兄弟 (Modern Brothers)",
       "albumArt": {
-        "imageUrl": "https://imagedelivery.net/TB1OM65i5Go9UkT2wcBzeA/upload-1764832463338/public"
+        "imageUrl": "https://i.boxel.site/upload-1764832463338/public"
       },
       "cardInfo": {
         "notes": null,

--- a/packages/host/tests/integration/commands/upload-image-test.gts
+++ b/packages/host/tests/integration/commands/upload-image-test.gts
@@ -183,8 +183,8 @@ module('Integration | commands | upload-image', function (hooks) {
     );
     assert.strictEqual(
       (savedCard as any).url,
-      'https://imagedelivery.net/TB1OM65i5Go9UkT2wcBzeA/cloudflare-image-id/public',
-      'computed URL uses expected Cloudflare delivery format',
+      'https://i.boxel.site/cloudflare-image-id/public',
+      'computed URL uses expected Cloudflare delivery format with Boxel domain',
     );
   });
 


### PR DESCRIPTION
Instead of `https://imagedelivery.net/TB1OM65i5Go9UkT2wcBzeA/f64c6153-86d7-4dc8-940a-0e73bb84a400/public` we can now serve Cloudflare Images via a URL rewrite that reduces them to `https://i.boxel.site/f64c6153-86d7-4dc8-940a-0e73bb84a400/public`. This updates the Cloudflare Image card to reflect that, and changes existing cards to use the new pattern.

The failing `host` test is on `main`.