### PR TITLE
Limit the amount of loops of failed correctness checks to 3 attempts

### DIFF
--- a/packages/ai-bot/lib/code-patch-correctness.ts
+++ b/packages/ai-bot/lib/code-patch-correctness.ts
@@ -76,7 +76,6 @@ export function buildCheckCorrectnessCommandRequests(
         attributes: {
           targetType: 'file',
           targetRef: sourceRef,
-          fileUrl: sourceRef,
           roomId: summary.roomId,
           targetEventId: summary.targetEventId,
           correctnessCheckAttempt,
@@ -100,7 +99,6 @@ export function buildCheckCorrectnessCommandRequests(
         attributes: {
           targetType: 'card',
           targetRef: card.cardId,
-          cardId: card.cardId,
           roomId: summary.roomId,
           targetEventId: summary.targetEventId,
           correctnessCheckAttempt,

--- a/packages/ai-bot/tests/code-patch-correctness-test.ts
+++ b/packages/ai-bot/tests/code-patch-correctness-test.ts
@@ -100,7 +100,6 @@ module('code patch correctness helpers', () => {
         attributes: {
           targetType: 'file',
           targetRef: summary.files[0].sourceUrl,
-          fileUrl: summary.files[0].sourceUrl,
           roomId: summary.roomId,
           targetEventId: summary.targetEventId,
           correctnessCheckAttempt: 1,
@@ -120,7 +119,6 @@ module('code patch correctness helpers', () => {
         attributes: {
           targetType: 'card',
           targetRef: 'http://localhost/cards/Profile/1',
-          cardId: 'http://localhost/cards/Profile/1',
           roomId: summary.roomId,
           targetEventId: summary.targetEventId,
           correctnessCheckAttempt: 1,

--- a/packages/ai-bot/tests/code-patch-correctness-test.ts
+++ b/packages/ai-bot/tests/code-patch-correctness-test.ts
@@ -102,6 +102,8 @@ module('code patch correctness helpers', () => {
           targetRef: summary.files[0].sourceUrl,
           fileUrl: summary.files[0].sourceUrl,
           roomId: summary.roomId,
+          targetEventId: summary.targetEventId,
+          correctnessCheckAttempt: 1,
         },
       },
       'File correctness check request should describe the file that changed',
@@ -120,9 +122,96 @@ module('code patch correctness helpers', () => {
           targetRef: 'http://localhost/cards/Profile/1',
           cardId: 'http://localhost/cards/Profile/1',
           roomId: summary.roomId,
+          targetEventId: summary.targetEventId,
+          correctnessCheckAttempt: 1,
         },
       },
       'Card correctness check request should describe the card that changed',
+    );
+  });
+
+  test('publishCodePatchCorrectnessMessage uses attempts scoped to the patch event', async function () {
+    let client = new FakeMatrixClient();
+    let summary: PendingCodePatchCorrectnessCheck = {
+      targetEventId: 'ai-message-123',
+      roomId: '!room:localhost',
+      files: [
+        {
+          sourceUrl: 'http://localhost/files/src/components/button.gts',
+          displayName: 'files/src/components/button.gts',
+        },
+      ],
+      cards: [{ cardId: 'http://localhost/cards/Profile/1' }],
+      attemptsByTargetKey: {
+        'file:http://localhost/files/src/components/button.gts|event:ai-message-123': 2,
+        'card:http://localhost/cards/Profile/1|event:ai-message-123': 3,
+      },
+    };
+
+    await publishCodePatchCorrectnessMessage(summary, client);
+
+    let [event] = client.getSentEvents();
+    let encodedRequests = event.content[APP_BOXEL_COMMAND_REQUESTS_KEY];
+    let decodedRequests = encodedRequests.map((request: any) =>
+      decodeCommandRequest(request),
+    );
+
+    let fileRequest = decodedRequests.find(
+      (request: Partial<CommandRequest>) =>
+        request.arguments?.attributes?.targetType === 'file',
+    );
+    assert.strictEqual(
+      fileRequest?.arguments?.attributes?.correctnessCheckAttempt,
+      2,
+      'File attempt should come from the scoped attempts map',
+    );
+    assert.strictEqual(
+      fileRequest?.arguments?.attributes?.targetEventId,
+      summary.targetEventId,
+      'File request should include the patch event id',
+    );
+
+    let cardRequest = decodedRequests.find(
+      (request: Partial<CommandRequest>) =>
+        request.arguments?.attributes?.targetType === 'card',
+    );
+    assert.strictEqual(
+      cardRequest?.arguments?.attributes?.correctnessCheckAttempt,
+      3,
+      'Card attempt should come from the scoped attempts map',
+    );
+    assert.strictEqual(
+      cardRequest?.arguments?.attributes?.targetEventId,
+      summary.targetEventId,
+      'Card request should include the patch event id',
+    );
+  });
+
+  test('publishCodePatchCorrectnessMessage skips targets that exceed max attempts', async function () {
+    let client = new FakeMatrixClient();
+    let summary: PendingCodePatchCorrectnessCheck = {
+      targetEventId: 'ai-message-max',
+      roomId: '!room:localhost',
+      files: [
+        {
+          sourceUrl: 'http://localhost/files/src/components/button.gts',
+          displayName: 'files/src/components/button.gts',
+        },
+      ],
+      cards: [{ cardId: 'http://localhost/cards/Profile/1' }],
+      attemptsByTargetKey: {
+        'file:http://localhost/files/src/components/button.gts|event:ai-message-max': 4,
+        'card:http://localhost/cards/Profile/1|event:ai-message-max': 5,
+      },
+    };
+
+    await publishCodePatchCorrectnessMessage(summary, client);
+
+    let [event] = client.getSentEvents();
+    let encodedRequests = event.content[APP_BOXEL_COMMAND_REQUESTS_KEY];
+    assert.notOk(
+      encodedRequests,
+      'Targets beyond the attempt limit should not emit correctness requests',
     );
   });
 });

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -4599,7 +4599,6 @@ new content
                 attributes: {
                   targetType: 'file',
                   targetRef,
-                  fileUrl: targetRef,
                   roomId,
                   correctnessCheckAttempt: index,
                 },
@@ -4762,7 +4761,6 @@ new content
                 attributes: {
                   targetType: 'file',
                   targetRef,
-                  fileUrl: targetRef,
                   roomId,
                   targetEventId: firstEventId,
                   correctnessCheckAttempt: 2,
@@ -4835,7 +4833,6 @@ new content
                 attributes: {
                   targetType: 'file',
                   targetRef,
-                  fileUrl: targetRef,
                   roomId,
                   targetEventId: secondEventId,
                   correctnessCheckAttempt: 1,
@@ -4972,7 +4969,6 @@ new
                 attributes: {
                   targetType: 'file',
                   targetRef: 'http://localhost/example.gts',
-                  fileUrl: 'http://localhost/example.gts',
                   roomId,
                 },
               }),

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -4568,6 +4568,349 @@ new content
     );
   });
 
+  test('caps automated correctness fix attempts at three failures', async function () {
+    const roomId = '!room:localhost';
+    const targetRef = 'http://localhost/files/example.gts';
+
+    function buildAiMessage(index: number, requestId: string) {
+      return {
+        type: 'm.room.message',
+        event_id: `ai-message-${index}`,
+        room_id: roomId,
+        sender: '@aibot:localhost',
+        origin_server_ts: index * 10 + 2,
+        content: {
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+          body: `Attempt ${index}`,
+          format: 'org.matrix.custom.html',
+          isStreamingFinished: true,
+          data: {
+            context: {
+              tools: [],
+              functions: [],
+            },
+          },
+          [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+            {
+              id: `check-${requestId}`,
+              name: 'checkCorrectness',
+              arguments: JSON.stringify({
+                description: `Check attempt ${index}`,
+                attributes: {
+                  targetType: 'file',
+                  targetRef,
+                  fileUrl: targetRef,
+                  roomId,
+                  correctnessCheckAttempt: index,
+                },
+              }),
+            },
+          ],
+        },
+        unsigned: {
+          age: 0,
+          transaction_id: `ai-message-${index}`,
+        },
+        status: EventStatus.SENT,
+      } as DiscreteMatrixEvent;
+    }
+
+    function buildCommandResult(
+      index: number,
+      requestId: string,
+      relatesToId: string,
+      errorText: string,
+    ): DiscreteMatrixEvent {
+      return {
+        type: APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+        event_id: `command-result-${index}`,
+        room_id: roomId,
+        sender: '@command:localhost',
+        origin_server_ts: index * 10 + 3,
+        content: {
+          msgtype: APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+          commandRequestId: requestId,
+          'm.relates_to': {
+            event_id: relatesToId,
+            key: 'applied',
+            rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+          },
+          data: {
+            card: {
+              sourceUrl: `http://localhost/correctness/${index}.json`,
+              url: `http://localhost/correctness/${index}.json`,
+              name: `correctness-${index}.json`,
+              contentType: 'application/json',
+              content: JSON.stringify({
+                data: {
+                  attributes: {
+                    correct: false,
+                    errors: [errorText],
+                    warnings: [],
+                  },
+                },
+              }),
+            },
+            context: {
+              tools: [],
+              functions: [],
+            },
+          },
+        },
+        unsigned: {
+          age: 0,
+          transaction_id: `command-result-${index}`,
+        },
+        status: EventStatus.SENT,
+      };
+    }
+
+    const eventList: DiscreteMatrixEvent[] = [
+      {
+        type: 'm.room.message',
+        event_id: 'user-message',
+        room_id: roomId,
+        sender: '@user:localhost',
+        origin_server_ts: 1,
+        content: {
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+          body: 'Please fix the file and run correctness checks.',
+          format: 'org.matrix.custom.html',
+          isStreamingFinished: true,
+          data: {
+            context: {
+              tools: [],
+              functions: [],
+            },
+          },
+        },
+        unsigned: {
+          age: 0,
+          transaction_id: 'user-message',
+        },
+        status: EventStatus.SENT,
+      },
+      buildAiMessage(1, '1'),
+      buildCommandResult(1, 'check-1', 'ai-message-1', 'first failure'),
+      buildAiMessage(2, '2'),
+      buildCommandResult(2, 'check-2', 'ai-message-2', 'second failure'),
+      buildAiMessage(3, '3'),
+      buildCommandResult(3, 'check-3', 'ai-message-3', 'still failing'),
+    ];
+
+    const { messages } = await getPromptParts(
+      eventList,
+      '@aibot:localhost',
+      fakeMatrixClient,
+    );
+
+    assert.ok(messages, 'Expected prompt messages to be constructed');
+
+    let userMessages =
+      messages?.filter((message) => message.role === 'user') ?? [];
+    let retryMessages = userMessages.filter((message) =>
+      (message.content as string).includes(
+        'Propose fixes for the above errors',
+      ),
+    );
+    assert.strictEqual(
+      retryMessages.length,
+      2,
+      'Only the first two failures should request more SEARCH/REPLACE fixes',
+    );
+
+    let finalUserMessage = userMessages[userMessages.length - 1];
+    assert.ok(
+      (finalUserMessage?.content as string).includes(
+        'Automated correctness fixes have already been attempted 3 times',
+      ),
+      'After three failures the prompt should ask to stop automated fixes',
+    );
+    assert.notOk(
+      (finalUserMessage?.content as string).includes(
+        'Propose fixes for the above errors',
+      ),
+      'The final prompt should not ask for another round of fixes',
+    );
+  });
+
+  test('correctness attempts reset when a new patch event starts for the same target', async function () {
+    const roomId = '!room:localhost';
+    const targetRef = 'http://localhost/files/example.gts';
+
+    const firstEventId = 'ai-message-1';
+    const secondEventId = 'ai-message-2';
+
+    const eventList: DiscreteMatrixEvent[] = [
+      {
+        type: 'm.room.message',
+        event_id: firstEventId,
+        room_id: roomId,
+        sender: '@aibot:localhost',
+        origin_server_ts: 1,
+        content: {
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+          body: 'First patch',
+          format: 'org.matrix.custom.html',
+          isStreamingFinished: true,
+          [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+            {
+              id: 'check-first',
+              name: 'checkCorrectness',
+              arguments: JSON.stringify({
+                description: 'First correctness check',
+                attributes: {
+                  targetType: 'file',
+                  targetRef,
+                  fileUrl: targetRef,
+                  roomId,
+                  targetEventId: firstEventId,
+                  correctnessCheckAttempt: 2,
+                },
+              }),
+            },
+          ],
+          data: {
+            context: {
+              tools: [],
+              functions: [],
+            },
+          },
+        },
+        unsigned: { age: 0, transaction_id: firstEventId },
+        status: EventStatus.SENT,
+      },
+      {
+        type: APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+        event_id: 'command-result-1',
+        room_id: roomId,
+        sender: '@command:localhost',
+        origin_server_ts: 2,
+        content: {
+          msgtype: APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+          commandRequestId: 'check-first',
+          'm.relates_to': {
+            event_id: firstEventId,
+            key: 'applied',
+            rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+          },
+          data: {
+            card: {
+              sourceUrl: `${targetRef}-first.json`,
+              url: `${targetRef}-first.json`,
+              name: 'correctness-first.json',
+              contentType: 'application/json',
+              content: JSON.stringify({
+                data: {
+                  attributes: {
+                    correct: false,
+                    errors: ['still broken'],
+                    warnings: [],
+                  },
+                },
+              }),
+            },
+          },
+        },
+        unsigned: { age: 0, transaction_id: 'command-result-1' },
+        status: EventStatus.SENT,
+      },
+      {
+        type: 'm.room.message',
+        event_id: secondEventId,
+        room_id: roomId,
+        sender: '@aibot:localhost',
+        origin_server_ts: 3,
+        content: {
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+          body: 'Second patch',
+          format: 'org.matrix.custom.html',
+          isStreamingFinished: true,
+          [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+            {
+              id: 'check-second',
+              name: 'checkCorrectness',
+              arguments: JSON.stringify({
+                description: 'Second correctness check',
+                attributes: {
+                  targetType: 'file',
+                  targetRef,
+                  fileUrl: targetRef,
+                  roomId,
+                  targetEventId: secondEventId,
+                  correctnessCheckAttempt: 1,
+                },
+              }),
+            },
+          ],
+          data: {
+            context: {
+              tools: [],
+              functions: [],
+            },
+          },
+        },
+        unsigned: { age: 0, transaction_id: secondEventId },
+        status: EventStatus.SENT,
+      },
+      {
+        type: APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+        event_id: 'command-result-2',
+        room_id: roomId,
+        sender: '@command:localhost',
+        origin_server_ts: 4,
+        content: {
+          msgtype: APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+          commandRequestId: 'check-second',
+          'm.relates_to': {
+            event_id: secondEventId,
+            key: 'applied',
+            rel_type: APP_BOXEL_COMMAND_RESULT_REL_TYPE,
+          },
+          data: {
+            card: {
+              sourceUrl: `${targetRef}-second.json`,
+              url: `${targetRef}-second.json`,
+              name: 'correctness-second.json',
+              contentType: 'application/json',
+              content: JSON.stringify({
+                data: {
+                  attributes: {
+                    correct: false,
+                    errors: ['new patch still failing'],
+                    warnings: [],
+                  },
+                },
+              }),
+            },
+          },
+        },
+        unsigned: { age: 0, transaction_id: 'command-result-2' },
+        status: EventStatus.SENT,
+      },
+    ];
+
+    const { messages } = await getPromptParts(
+      eventList,
+      '@aibot:localhost',
+      fakeMatrixClient,
+    );
+
+    let toolMessages =
+      messages?.filter((message) => message.role === 'tool') ?? [];
+
+    let secondToolMessage = toolMessages.find(
+      (message) => message.tool_call_id === 'check-second',
+    );
+    assert.ok(secondToolMessage, 'Second correctness result should be present');
+    assert.ok(
+      (secondToolMessage!.content as string).includes(
+        'attempts so far: 1 of 3',
+      ),
+      'Correctness attempts reset to the first attempt when a new patch event begins for the same target',
+    );
+  });
+
   test('getPromptParts toggles correctness summary and patch result prompts based on autoCorrectnessChecksEnabled option', async function () {
     const roomId = '!room:localhost';
     const aiMessageId = '$ai-msg';

--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -219,8 +219,6 @@ export class PatchCodeInput extends CardDef {
 export class CheckCorrectnessInput extends CardDef {
   @field targetType = contains(StringField);
   @field targetRef = contains(StringField);
-  @field fileUrl = contains(StringField);
-  @field cardId = contains(StringField);
   @field roomId = contains(StringField);
 }
 

--- a/packages/host/tests/integration/commands/check-correctness-test.gts
+++ b/packages/host/tests/integration/commands/check-correctness-test.gts
@@ -90,7 +90,6 @@ module('Integration | commands | check-correctness', function (hooks) {
     let firstResult = await command.execute({
       targetType: 'card',
       targetRef: cardId,
-      cardId,
       roomId,
     });
 
@@ -114,7 +113,6 @@ module('Integration | commands | check-correctness', function (hooks) {
     let secondResult = await command.execute({
       targetType: 'card',
       targetRef: cardId,
-      cardId,
       roomId,
     });
 
@@ -155,7 +153,6 @@ module('Integration | commands | check-correctness', function (hooks) {
     let thirdResult = await command.execute({
       targetType: 'card',
       targetRef: cardId,
-      cardId,
       roomId,
     });
 
@@ -180,7 +177,6 @@ module('Integration | commands | check-correctness', function (hooks) {
     let firstResult = await command.execute({
       targetType: 'card',
       targetRef: cardId,
-      cardId,
       roomId,
     });
     assert.true(firstResult.correct, 'initial run reports no errors');
@@ -202,7 +198,6 @@ module('Integration | commands | check-correctness', function (hooks) {
     let secondResult = await command.execute({
       targetType: 'card',
       targetRef: cardId,
-      cardId,
       roomId,
     });
 
@@ -238,7 +233,6 @@ module('Integration | commands | check-correctness', function (hooks) {
     let thirdResult = await command.execute({
       targetType: 'card',
       targetRef: cardId,
-      cardId,
       roomId,
     });
 

--- a/packages/runtime-common/ai/correctness-constants.ts
+++ b/packages/runtime-common/ai/correctness-constants.ts
@@ -1,0 +1,1 @@
+export const MAX_CORRECTNESS_FIX_ATTEMPTS = 3;

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -946,8 +946,10 @@ function describeCheckCorrectnessTarget(request?: CommandRequest) {
   if (!request) {
     return 'the requested target';
   }
-  let attributes = ((request.arguments as Record<string, any>) ?? {})
-    .attributes as Record<string, any> | undefined ?? {};
+  let attributes =
+    (((request.arguments as Record<string, any>) ?? {}).attributes as
+      | Record<string, any>
+      | undefined) ?? {};
   let targetType = attributes.targetType;
   let targetRef = attributes.targetRef;
   if (targetType && targetRef) {
@@ -1095,8 +1097,10 @@ function extractCheckCorrectnessTargetParts(
   if (!request) {
     return {};
   }
-  let attributes = ((request.arguments as Record<string, any>) ?? {})
-    .attributes as Record<string, any> | undefined ?? {};
+  let attributes =
+    (((request.arguments as Record<string, any>) ?? {}).attributes as
+      | Record<string, any>
+      | undefined) ?? {};
   let targetRef = attributes.targetRef;
   if (!targetRef) {
     return {};
@@ -1127,8 +1131,10 @@ function getCorrectnessCheckAttemptFromRequest(
   if (!request) {
     return 0;
   }
-  let attributes = ((request.arguments as Record<string, any>) ?? {})
-    .attributes as Record<string, any> | undefined ?? {};
+  let attributes =
+    (((request.arguments as Record<string, any>) ?? {}).attributes as
+      | Record<string, any>
+      | undefined) ?? {};
   let attempt = attributes.correctnessCheckAttempt;
   if (typeof attempt === 'number' && Number.isFinite(attempt)) {
     return attempt;

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -946,28 +946,12 @@ function describeCheckCorrectnessTarget(request?: CommandRequest) {
   if (!request) {
     return 'the requested target';
   }
-  let args = (request.arguments as Record<string, any>) ?? {};
-  let attributes = (args.attributes as Record<string, any>) ?? {};
-  let targetType =
-    attributes.targetType ??
-    args.targetType ??
-    attributes.target_type ??
-    args.target_type;
-  let targetRef =
-    attributes.targetRef ??
-    args.targetRef ??
-    attributes.fileUrl ??
-    args.fileUrl ??
-    attributes.cardId ??
-    args.cardId;
+  let attributes = ((request.arguments as Record<string, any>) ?? {})
+    .attributes as Record<string, any> | undefined ?? {};
+  let targetType = attributes.targetType;
+  let targetRef = attributes.targetRef;
   if (targetType && targetRef) {
     return `${targetType} "${targetRef}"`;
-  }
-  if (targetRef) {
-    return `"${targetRef}"`;
-  }
-  if (args.description) {
-    return args.description;
   }
   return 'the requested target';
 }
@@ -1111,36 +1095,14 @@ function extractCheckCorrectnessTargetParts(
   if (!request) {
     return {};
   }
-  let args = (request.arguments as Record<string, any>) ?? {};
-  let attributes = (args.attributes as Record<string, any>) ?? {};
-  let targetRef =
-    attributes.targetRef ??
-    args.targetRef ??
-    attributes.fileUrl ??
-    args.fileUrl ??
-    attributes.cardId ??
-    args.cardId;
+  let attributes = ((request.arguments as Record<string, any>) ?? {})
+    .attributes as Record<string, any> | undefined ?? {};
+  let targetRef = attributes.targetRef;
   if (!targetRef) {
     return {};
   }
-  let targetType =
-    attributes.targetType ??
-    args.targetType ??
-    attributes.target_type ??
-    args.target_type;
-  if (!targetType) {
-    if (attributes.cardId || args.cardId) {
-      targetType = 'card';
-    } else if (attributes.fileUrl || args.fileUrl) {
-      targetType = 'file';
-    }
-  }
-  let targetEventId =
-    attributes.targetEventId ??
-    args.targetEventId ??
-    attributes.target_event_id ??
-    args.target_event_id ??
-    undefined;
+  let targetType = attributes.targetType;
+  let targetEventId = attributes.targetEventId ?? undefined;
   return { targetRef, targetType, targetEventId };
 }
 
@@ -1165,12 +1127,9 @@ function getCorrectnessCheckAttemptFromRequest(
   if (!request) {
     return 0;
   }
-  let args = (request.arguments as Record<string, any>) ?? {};
-  let attributes = (args.attributes as Record<string, any>) ?? {};
-  let attempt =
-    attributes.correctnessCheckAttempt ??
-    args.correctnessCheckAttempt ??
-    undefined;
+  let attributes = ((request.arguments as Record<string, any>) ?? {})
+    .attributes as Record<string, any> | undefined ?? {};
+  let attempt = attributes.correctnessCheckAttempt;
   if (typeof attempt === 'number' && Number.isFinite(attempt)) {
     return attempt;
   }

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -1202,7 +1202,10 @@ function getLatestCorrectnessCheckAttemptInfo(
     if (getCheckCorrectnessTargetKey(sourceRequest) !== targetKey) {
       continue;
     }
-    let attempt = Math.max(1, getCorrectnessCheckAttemptFromRequest(sourceRequest));
+    let attempt = Math.max(
+      1,
+      getCorrectnessCheckAttemptFromRequest(sourceRequest),
+    );
     let resultCard = extractCorrectnessResultCard(commandResult);
     let status = commandResult.content['m.relates_to']?.key;
     let succeeded =

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -1106,7 +1106,7 @@ function extractCheckCorrectnessTargetParts(
     return {};
   }
   let targetType = attributes.targetType;
-  let targetEventId = attributes.targetEventId ?? undefined;
+  let targetEventId = attributes.targetEventId;
   return { targetRef, targetType, targetEventId };
 }
 

--- a/packages/runtime-common/ai/types.ts
+++ b/packages/runtime-common/ai/types.ts
@@ -75,6 +75,7 @@ export interface PendingCodePatchCorrectnessCheck {
   context?: BoxelContext;
   files: CodePatchCorrectnessFile[];
   cards: CodePatchCorrectnessCard[];
+  attemptsByTargetKey?: Record<string, number>;
 }
 
 export class HistoryConstructionError extends Error {


### PR DESCRIPTION
This PR introduces a safety precaution where we don't want the correctness check loop to spiral out of control. So for example if AI generates code and our correctness checks report an error related to targeted instance or module, and this loop continues for more than 3 times, we bail and report to AI that it should step sending new patches to try to fix the errors. 

This is obviously hard to test on a real case, so I relied heavily on adding tests for this.