### PR TITLE
Card header action icons shouldn’t be red when card is in an error state

### DIFF
--- a/packages/host/app/components/operator-mode/card-error.gts
+++ b/packages/host/app/components/operator-mode/card-error.gts
@@ -114,6 +114,9 @@ export default class CardErrorComponent extends Component<Signature> {
         background-color: var(--boxel-100);
         box-shadow: 0 1px 0 0 rgba(0 0 0 / 15%);
       }
+      .error-header :deep(.actions) {
+        color: var(--boxel-dark);
+      }
       .card-error-detail {
         position: absolute;
         bottom: var(--boxel-sp);

--- a/packages/host/app/components/operator-mode/card-error.gts
+++ b/packages/host/app/components/operator-mode/card-error.gts
@@ -109,13 +109,12 @@ export default class CardErrorComponent extends Component<Signature> {
         text-wrap: pretty;
       }
       .error-header {
-        color: var(--boxel-error-300);
         min-height: var(--boxel-form-control-height);
         background-color: var(--boxel-100);
         box-shadow: 0 1px 0 0 rgba(0 0 0 / 15%);
       }
-      .error-header :deep(.actions) {
-        color: var(--boxel-dark);
+      .error-header :deep(.card-type-display-name) {
+        color: var(--boxel-error-300);
       }
       .card-error-detail {
         position: absolute;

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -54,7 +54,6 @@ module('Integration | operator-mode | basics', function (hooks) {
   });
 
   test('it renders a card with an error that has does not have a last known good state', async function (assert) {
-    assert.expect(12);
     ctx.setCardInOperatorModeState(`${testRealmURL}FriendWithCSS/missing-link`);
     await renderComponent(
       class TestDriver extends GlimmerComponent {
@@ -67,38 +66,12 @@ module('Integration | operator-mode | basics', function (hooks) {
     assert
       .dom('[data-test-boxel-card-header-title]')
       .includesText('Link Not Found', 'card error title is displayed');
-    let errorHeader = document.querySelector(
-      '[data-test-card-header].error-header',
-    );
-    let closeButton = document.querySelector(
-      '[data-test-close-button]',
-    ) as HTMLElement | null;
-    let moreOptionsButton = document.querySelector(
-      '[data-test-more-options-button]',
-    ) as HTMLElement | null;
-    assert.ok(errorHeader, 'error header is rendered');
-    assert.ok(closeButton, 'close button is rendered');
-    assert.ok(moreOptionsButton, 'more options button is rendered');
-    if (errorHeader && closeButton && moreOptionsButton) {
-      let headerColor = getComputedStyle(errorHeader).color;
-      let closeButtonColor = getComputedStyle(closeButton).color;
-      let moreOptionsButtonColor = getComputedStyle(moreOptionsButton).color;
-      assert.notStrictEqual(
-        closeButtonColor,
-        headerColor,
-        'close button does not inherit error header color',
-      );
-      assert.notStrictEqual(
-        moreOptionsButtonColor,
-        headerColor,
-        'more options button does not inherit error header color',
-      );
-    }
     assert
       .dom('[data-test-error-message]')
       .containsText(
         `missing file ${testRealmURL}FriendWithCSS/does-not-exist.json`,
       );
+    await percySnapshot(assert);
     await click('[data-test-toggle-details]');
     assert
       .dom('[data-test-error-details]')

--- a/packages/host/tests/integration/components/operator-mode-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-test.gts
@@ -54,6 +54,7 @@ module('Integration | operator-mode | basics', function (hooks) {
   });
 
   test('it renders a card with an error that has does not have a last known good state', async function (assert) {
+    assert.expect(12);
     ctx.setCardInOperatorModeState(`${testRealmURL}FriendWithCSS/missing-link`);
     await renderComponent(
       class TestDriver extends GlimmerComponent {
@@ -66,6 +67,33 @@ module('Integration | operator-mode | basics', function (hooks) {
     assert
       .dom('[data-test-boxel-card-header-title]')
       .includesText('Link Not Found', 'card error title is displayed');
+    let errorHeader = document.querySelector(
+      '[data-test-card-header].error-header',
+    );
+    let closeButton = document.querySelector(
+      '[data-test-close-button]',
+    ) as HTMLElement | null;
+    let moreOptionsButton = document.querySelector(
+      '[data-test-more-options-button]',
+    ) as HTMLElement | null;
+    assert.ok(errorHeader, 'error header is rendered');
+    assert.ok(closeButton, 'close button is rendered');
+    assert.ok(moreOptionsButton, 'more options button is rendered');
+    if (errorHeader && closeButton && moreOptionsButton) {
+      let headerColor = getComputedStyle(errorHeader).color;
+      let closeButtonColor = getComputedStyle(closeButton).color;
+      let moreOptionsButtonColor = getComputedStyle(moreOptionsButton).color;
+      assert.notStrictEqual(
+        closeButtonColor,
+        headerColor,
+        'close button does not inherit error header color',
+      );
+      assert.notStrictEqual(
+        moreOptionsButtonColor,
+        headerColor,
+        'more options button does not inherit error header color',
+      );
+    }
     assert
       .dom('[data-test-error-message]')
       .containsText(


### PR DESCRIPTION
Before:

<img width="432" height="55" alt="Screenshot 2025-12-18 at 17 23 29" src="https://github.com/user-attachments/assets/deebbad6-7e6e-463f-bdf9-2c447e23baf6" />

After:

<img width="414" height="43" alt="Screenshot 2025-12-18 at 17 20 18" src="https://github.com/user-attachments/assets/a64b4919-67e8-4bfe-96e2-bc8210654c30" />
