### PR TITLE
Add better support for errors that are thrown before the model hook runs in /render route

### DIFF
--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -575,11 +575,7 @@ export default class RenderRoute extends Route<Model> {
       cardType,
       context,
     );
-    let { container, errorElement } = this.#ensurePrerenderElements();
-    if (container) {
-      container.dataset.prerenderStatus = 'error';
-    }
-    this.#writePrerenderError(errorElement, serializedError);
+    this.#applyErrorMetadata(context, serializedError);
     let signature = this.#makeErrorSignature(serializedError, context);
     if (signature === this.lastRenderErrorSignature) {
       return;
@@ -590,7 +586,6 @@ export default class RenderRoute extends Route<Model> {
       cardId: context.cardId,
       nonce: context.nonce,
     });
-    this.#applyErrorMetadata(context);
     this.#transitionToErrorRoute(transition);
   }
 
@@ -739,13 +734,14 @@ export default class RenderRoute extends Route<Model> {
     }
   }
 
-  #applyErrorMetadata(context: { cardId?: string; nonce?: string }) {
+  #applyErrorMetadata(
+    context: { cardId?: string; nonce?: string },
+    serializedError?: string,
+  ) {
     if (typeof document === 'undefined') {
       return;
     }
-    let container = document.querySelector(
-      '[data-prerender]',
-    ) as HTMLElement | null;
+    let { container, errorElement } = this.#ensurePrerenderElements();
     if (container) {
       container.dataset.prerenderStatus = 'error';
       if (context.cardId) {
@@ -755,15 +751,15 @@ export default class RenderRoute extends Route<Model> {
         container.dataset.prerenderNonce = context.nonce;
       }
     }
-    let errorElement = document.querySelector(
-      '[data-prerender-error]',
-    ) as HTMLElement | null;
     if (errorElement) {
       if (context.cardId) {
         errorElement.dataset.prerenderId = context.cardId;
       }
       if (context.nonce) {
         errorElement.dataset.prerenderNonce = context.nonce;
+      }
+      if (serializedError) {
+        this.#writePrerenderError(errorElement, serializedError);
       }
     }
   }

--- a/packages/host/app/routes/render/html.ts
+++ b/packages/host/app/routes/render/html.ts
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import type RouterService from '@ember/routing/router-service';
+import type Transition from '@ember/routing/transition';
 import { service } from '@ember/service';
 
 import { isValidFormat } from '@cardstack/runtime-common';
@@ -23,13 +24,16 @@ export interface Model {
 export default class RenderHtmlRoute extends Route<Model> {
   @service declare router: RouterService;
 
-  async model({
-    format,
-    ancestor_level,
-  }: {
-    format: string;
-    ancestor_level: string;
-  }) {
+  async model(
+    {
+      format,
+      ancestor_level,
+    }: {
+      format: string;
+      ancestor_level: string;
+    },
+    transition: Transition,
+  ): Promise<Model> {
     let parentModel = this.modelFor('render') as ParentModel;
     let instance: CardDef;
     if (!parentModel) {
@@ -38,6 +42,10 @@ export default class RenderHtmlRoute extends Route<Model> {
       instance = (globalThis as any).__renderInstance;
     } else {
       instance = parentModel.instance;
+    }
+    if (!instance) {
+      transition.abort();
+      return Promise.reject();
     }
 
     if (!isValidFormat(format)) {

--- a/packages/host/app/routes/render/icon.ts
+++ b/packages/host/app/routes/render/icon.ts
@@ -1,4 +1,5 @@
 import Route from '@ember/routing/route';
+import type Transition from '@ember/routing/transition';
 
 import { cardTypeIcon } from '@cardstack/runtime-common';
 
@@ -14,7 +15,7 @@ export interface Model {
 }
 
 export default class RenderIconRoute extends Route<Model> {
-  async model() {
+  async model(_params: unknown, transition: Transition): Promise<Model> {
     let parentModel = this.modelFor('render') as ParentModel;
     let instance: CardDef;
     if (!parentModel) {
@@ -23,6 +24,10 @@ export default class RenderIconRoute extends Route<Model> {
       instance = (globalThis as any).__renderInstance;
     } else {
       instance = parentModel.instance;
+    }
+    if (!instance) {
+      transition.abort();
+      return Promise.reject();
     }
     return { Component: cardTypeIcon(instance) };
   }

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -441,7 +441,6 @@ async function stopTestRealm(testRealmServer?: TestRealmServerResult) {
 module(basename(__filename), function () {
   module('indexing (read only)', function (hooks) {
     let realm: Realm;
-    let adapter: RealmAdapter;
     let testRealmServer: TestRealmServerResult | undefined;
 
     async function getInstance(
@@ -466,7 +465,6 @@ module(basename(__filename), function () {
           runner,
         });
         realm = testRealmServer.testRealm;
-        adapter = testRealmServer.testRealmAdapter;
       },
       after: async () => {
         await stopTestRealm(testRealmServer);
@@ -861,6 +859,31 @@ module(basename(__filename), function () {
         assert.notOk(deletedEntryUrls.includes(file));
       });
     });
+  });
+
+  module('indexing (mutating)', function (hooks) {
+    let realm: Realm;
+    let adapter: RealmAdapter;
+    let testRealmServer: TestRealmServerResult | undefined;
+
+    setupBaseRealmServer(hooks, matrixURL);
+
+    setupDB(hooks, {
+      beforeEach: async (dbAdapter, publisher, runner) => {
+        testDbAdapter = dbAdapter;
+        testRealmServer = await startTestRealm({
+          dbAdapter,
+          publisher,
+          runner,
+        });
+        realm = testRealmServer.testRealm;
+        adapter = testRealmServer.testRealmAdapter;
+      },
+      afterEach: async () => {
+        await stopTestRealm(testRealmServer);
+        testRealmServer = undefined;
+      },
+    });
 
     test('can incrementally index updated instance', async function (assert) {
       await realm.write(
@@ -1221,48 +1244,16 @@ module(basename(__filename), function () {
               return this.author?.firstName + '-poo';
             }
           })
+          static embedded = class Embedded extends Component<typeof this> {
+            <template><@fields.firstName/> (<@fields.nickName/>)</template>
+          }
+          static fitted = class Fitted extends Component<typeof this> {
+            <template><@fields.firstName/> (<@fields.nickName/>)</template>
+          }
         }
       `,
       );
       {
-        assert.true(
-          await adapter.exists('post.gts'),
-          'post module file exists on disk',
-        );
-        realm.__testOnlyClearCaches();
-        await realm.realmIndexUpdater.update([new URL(`${testRealm}post.gts`)]);
-        let moduleResponse = await realm.handle(
-          new Request(`${testRealm}post`, {
-            headers: { Accept: 'application/javascript' },
-          }),
-        );
-        assert.strictEqual(
-          moduleResponse?.status,
-          200,
-          `module response status ${moduleResponse?.status}`,
-        );
-        assert.ok(
-          realm.realmIndexUpdater.stats.modulesIndexed >= 1,
-          `modulesIndexed=${realm.realmIndexUpdater.stats.modulesIndexed}`,
-        );
-        let [postIndexEntry] = (await testDbAdapter.execute(
-          `SELECT url, is_deleted, type FROM boxel_index WHERE url = '${testRealm}post.gts'`,
-        )) as { url: string; is_deleted: boolean; type: string }[];
-        assert.ok(postIndexEntry, 'post module row exists in index');
-        assert.false(postIndexEntry?.is_deleted);
-        assert.strictEqual(
-          postIndexEntry?.type,
-          'module',
-          JSON.stringify(postIndexEntry, null, 2),
-        );
-        let postModule = await realm.realmIndexQueryEngine.module(
-          new URL(`${testRealm}post`),
-        );
-        assert.strictEqual(
-          postModule?.type,
-          'module',
-          'post module is in the index after recreation',
-        );
         let { data: result } = await realm.realmIndexQueryEngine.search({
           filter: {
             on: { module: `${testRealm}post`, name: 'Post' },
@@ -1497,16 +1488,9 @@ module(basename(__filename), function () {
         new URL(`${testRealm}country`),
       );
       assert.ok(country, 'country module is in the index');
-      assert.deepEqual(
-        // we splat because despite having the same shape, the constructors are different
-        { ...realm.realmIndexUpdater.stats },
-        {
-          instancesIndexed: 0,
-          instanceErrors: 0,
-          moduleErrors: 0,
-          modulesIndexed: 2,
-          totalIndexEntries: 23,
-        },
+      assert.strictEqual(
+        realm.realmIndexUpdater.stats.modulesIndexed,
+        2,
         'indexed correct number of files',
       );
     });

--- a/packages/runtime-common/code-ref.ts
+++ b/packages/runtime-common/code-ref.ts
@@ -315,7 +315,7 @@ function exportFrom(ref: CodeRef): string {
   if (!('type' in ref)) {
     return ref.name;
   } else {
-    return moduleFrom(ref.card);
+    return exportFrom(ref.card);
   }
 }
 

--- a/packages/runtime-common/code-ref.ts
+++ b/packages/runtime-common/code-ref.ts
@@ -167,9 +167,12 @@ export async function loadCardDef(
     return maybeCard;
   }
 
-  let err = new CardError(`Unable to loadCard ${humanReadable(ref)}`, {
-    status: 404,
-  });
+  let err = new CardError(
+    `Cannot find card ${humanReadable(ref)}. Make sure ${new URL(moduleFrom(ref), opts?.relativeTo).href} exports ${exportFrom(ref)}`,
+    {
+      status: 404,
+    },
+  );
   err.deps = [moduleFrom(ref)];
   throw err;
 }
@@ -303,6 +306,14 @@ export function getAncestor(
 export function moduleFrom(ref: CodeRef): string {
   if (!('type' in ref)) {
     return ref.module;
+  } else {
+    return moduleFrom(ref.card);
+  }
+}
+
+function exportFrom(ref: CodeRef): string {
+  if (!('type' in ref)) {
+    return ref.name;
   } else {
     return moduleFrom(ref.card);
   }

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -193,17 +193,11 @@ export class IndexRunner {
     let hasExecutableInvalidation = invalidations.some((url) =>
       hasExecutableExtension(url.href),
     );
-    if (hasExecutableInvalidation) {
-      if (!current.#shouldClearCacheForNextRender) {
-        current.#log.debug(
-          `${jobIdentity(current.#jobInfo)} detected executable invalidation, scheduling loader reset`,
-        );
-      }
-      current.#scheduleClearCacheForNextRender();
-    }
-
     let hrefs = urls.map((u) => u.href);
     for (let invalidation of invalidations) {
+      if (hasExecutableInvalidation) {
+        current.#scheduleClearCacheForNextRender();
+      }
       if (operation === 'delete' && hrefs.includes(invalidation.href)) {
         // file is deleted, there is nothing to visit
       } else {


### PR DESCRIPTION
This PR provides better support for errors that are thrown before the model hook runs in the /render route by making sure that we capture the route params so that we can do an intermediate transition to /render/error with the correct params. The error was doing this intermediate transition without any route params. Also, providing a more useful error message when `loadCard()` is unable to find the card so that AI can fix the problem.