### PR TITLE
Cleaning up indexing test around mending broken instances using module restored after deletion

### DIFF
--- a/.github/workflows/ci-host.yaml
+++ b/.github/workflows/ci-host.yaml
@@ -31,8 +31,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
-        shardTotal: [16]
+        shardIndex:
+          [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+          ]
+        shardTotal: [20]
     concurrency:
       group: boxel-host-test${{ github.head_ref || github.run_id }}-shard${{ matrix.shardIndex }}
       cancel-in-progress: true

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -1221,48 +1221,16 @@ module(basename(__filename), function () {
               return this.author?.firstName + '-poo';
             }
           })
+          static embedded = class Embedded extends Component<typeof this> {
+            <template><@fields.firstName/> (<@fields.nickName/>)</template>
+          }
+          static fitted = class Fitted extends Component<typeof this> {
+            <template><@fields.firstName/> (<@fields.nickName/>)</template>
+          }
         }
       `,
       );
       {
-        assert.true(
-          await adapter.exists('post.gts'),
-          'post module file exists on disk',
-        );
-        realm.__testOnlyClearCaches();
-        await realm.realmIndexUpdater.update([new URL(`${testRealm}post.gts`)]);
-        let moduleResponse = await realm.handle(
-          new Request(`${testRealm}post`, {
-            headers: { Accept: 'application/javascript' },
-          }),
-        );
-        assert.strictEqual(
-          moduleResponse?.status,
-          200,
-          `module response status ${moduleResponse?.status}`,
-        );
-        assert.ok(
-          realm.realmIndexUpdater.stats.modulesIndexed >= 1,
-          `modulesIndexed=${realm.realmIndexUpdater.stats.modulesIndexed}`,
-        );
-        let [postIndexEntry] = (await testDbAdapter.execute(
-          `SELECT url, is_deleted, type FROM boxel_index WHERE url = '${testRealm}post.gts'`,
-        )) as { url: string; is_deleted: boolean; type: string }[];
-        assert.ok(postIndexEntry, 'post module row exists in index');
-        assert.false(postIndexEntry?.is_deleted);
-        assert.strictEqual(
-          postIndexEntry?.type,
-          'module',
-          JSON.stringify(postIndexEntry, null, 2),
-        );
-        let postModule = await realm.realmIndexQueryEngine.module(
-          new URL(`${testRealm}post`),
-        );
-        assert.strictEqual(
-          postModule?.type,
-          'module',
-          'post module is in the index after recreation',
-        );
         let { data: result } = await realm.realmIndexQueryEngine.search({
           filter: {
             on: { module: `${testRealm}post`, name: 'Post' },

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -1221,12 +1221,6 @@ module(basename(__filename), function () {
               return this.author?.firstName + '-poo';
             }
           })
-          static embedded = class Embedded extends Component<typeof this> {
-            <template><@fields.firstName/> (<@fields.nickName/>)</template>
-          }
-          static fitted = class Fitted extends Component<typeof this> {
-            <template><@fields.firstName/> (<@fields.nickName/>)</template>
-          }
         }
       `,
       );


### PR DESCRIPTION
This PR restores a test that lost cohesion in a recent change. specifically we want this specific test to prove that an instance that points to a deleted module can be mended if the module is restored. The test had a bunch of stuff added to it that made it impossible to prove this because an incremental index was being manually triggered. As well as a lot of assertions that really had nothing to do with this test and were asserting below this abstraction layer were being made. The additional assertions were redundant with other tests that we already have and added unnecessary noise.