### PR TITLE
Remove URL meta tags from head template

### DIFF
--- a/packages/base/default-templates/head.gts
+++ b/packages/base/default-templates/head.gts
@@ -21,10 +21,6 @@ export default class DefaultHeadTemplate extends GlimmerComponent<{
     return this.args.model?.thumbnailURL;
   }
 
-  get url(): string | undefined {
-    return this.args.model?.id;
-  }
-
   <template>
     {{! template-lint-disable no-forbidden-elements }}
     {{! TODO: restore in CS-9807 }}
@@ -44,11 +40,6 @@ export default class DefaultHeadTemplate extends GlimmerComponent<{
       <meta name='twitter:card' content='summary_large_image' />
     {{else}}
       <meta name='twitter:card' content='summary' />
-    {{/if}}
-
-    {{#if this.url}}
-      <link rel='canonical' href={{this.url}} />
-      <meta property='og:url' content={{this.url}} />
     {{/if}}
 
     <meta property='og:type' content='website' />

--- a/packages/matrix/tests/head-tags.spec.ts
+++ b/packages/matrix/tests/head-tags.spec.ts
@@ -86,12 +86,6 @@ test.describe('Head tags', () => {
       'content',
       '1New Workspace',
     );
-
-    // TODO: restore in CS-9805
-    // await expect(page.locator('meta[property="og:url"]')).toHaveAttribute(
-    //   'content',
-    //   publishedRealmURLString,
-    // );
   });
 
   test('host mode updates head tags when navigating between cards', async ({
@@ -164,16 +158,9 @@ test.describe('Head tags', () => {
         @field title = contains(StringField);
 
         static head = class Head extends Component<typeof this> {
-          get url() {
-            return this.args.model?.id;
-          }
-
           <template>
             <meta name='custom-head-flag' content='custom-head' />
             <meta property='og:title' content='Custom Head Title' />
-            {{#if this.url}}
-              <meta property='og:url' content={{this.url}} />
-            {{/if}}
           </template>
         };
 

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -522,17 +522,11 @@ module(basename(__filename), function () {
 
         assert.ok(entry.headHtml, 'pre-rendered head format html is present');
 
-        let cleanedHead = cleanWhiteSpace(entry.headHtml!);
-
         // TODO: restore in CS-9807
         // assert.ok(
         //   cleanedHead.includes('<title data-test-card-head-title>'),
         //   `head html includes title: ${cleanedHead}`,
         // );
-        assert.ok(
-          cleanedHead.includes(`property="og:url" content="${testRealm}mango"`),
-          `head html includes canonical url: ${cleanedHead}`,
-        );
 
         assert.strictEqual(
           trimCardContainer(

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -1202,10 +1202,6 @@ module(basename(__filename), function () {
           cleanedHead.includes('name="twitter:card" content="summary"'),
           `failed to find twitter:card in head html:${cleanedHead}`,
         );
-        assert.ok(
-          cleanedHead.includes(`property="og:url" content="${realmURL2}1"`),
-          `failed to find og:url in head html:${cleanedHead}`,
-        );
       });
 
       test('serialized', function (assert) {


### PR DESCRIPTION
Publishing a realm copies its index entries, so URL references in the head template aren’t updated with correct values containing the published realm’s URL. For now, we’ll just not include URLs in the default head template.

The failing shard is consistently failing elsewhere.