### PR TITLE
better support for errors that are thrown before the model hook runs in /render route

### DIFF
--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -441,7 +441,6 @@ async function stopTestRealm(testRealmServer?: TestRealmServerResult) {
 module(basename(__filename), function () {
   module('indexing (read only)', function (hooks) {
     let realm: Realm;
-    let adapter: RealmAdapter;
     let testRealmServer: TestRealmServerResult | undefined;
 
     async function getInstance(
@@ -466,7 +465,6 @@ module(basename(__filename), function () {
           runner,
         });
         realm = testRealmServer.testRealm;
-        adapter = testRealmServer.testRealmAdapter;
       },
       after: async () => {
         await stopTestRealm(testRealmServer);
@@ -861,6 +859,31 @@ module(basename(__filename), function () {
         assert.notOk(deletedEntryUrls.includes(file));
       });
     });
+  });
+
+  module('indexing (mutating)', function (hooks) {
+    let realm: Realm;
+    let adapter: RealmAdapter;
+    let testRealmServer: TestRealmServerResult | undefined;
+
+    setupBaseRealmServer(hooks, matrixURL);
+
+    setupDB(hooks, {
+      beforeEach: async (dbAdapter, publisher, runner) => {
+        testDbAdapter = dbAdapter;
+        testRealmServer = await startTestRealm({
+          dbAdapter,
+          publisher,
+          runner,
+        });
+        realm = testRealmServer.testRealm;
+        adapter = testRealmServer.testRealmAdapter;
+      },
+      afterEach: async () => {
+        await stopTestRealm(testRealmServer);
+        testRealmServer = undefined;
+      },
+    });
 
     test('can incrementally index updated instance', async function (assert) {
       await realm.write(
@@ -1221,48 +1244,16 @@ module(basename(__filename), function () {
               return this.author?.firstName + '-poo';
             }
           })
+          static embedded = class Embedded extends Component<typeof this> {
+            <template><@fields.firstName/> (<@fields.nickName/>)</template>
+          }
+          static fitted = class Fitted extends Component<typeof this> {
+            <template><@fields.firstName/> (<@fields.nickName/>)</template>
+          }
         }
       `,
       );
       {
-        assert.true(
-          await adapter.exists('post.gts'),
-          'post module file exists on disk',
-        );
-        realm.__testOnlyClearCaches();
-        await realm.realmIndexUpdater.update([new URL(`${testRealm}post.gts`)]);
-        let moduleResponse = await realm.handle(
-          new Request(`${testRealm}post`, {
-            headers: { Accept: 'application/javascript' },
-          }),
-        );
-        assert.strictEqual(
-          moduleResponse?.status,
-          200,
-          `module response status ${moduleResponse?.status}`,
-        );
-        assert.ok(
-          realm.realmIndexUpdater.stats.modulesIndexed >= 1,
-          `modulesIndexed=${realm.realmIndexUpdater.stats.modulesIndexed}`,
-        );
-        let [postIndexEntry] = (await testDbAdapter.execute(
-          `SELECT url, is_deleted, type FROM boxel_index WHERE url = '${testRealm}post.gts'`,
-        )) as { url: string; is_deleted: boolean; type: string }[];
-        assert.ok(postIndexEntry, 'post module row exists in index');
-        assert.false(postIndexEntry?.is_deleted);
-        assert.strictEqual(
-          postIndexEntry?.type,
-          'module',
-          JSON.stringify(postIndexEntry, null, 2),
-        );
-        let postModule = await realm.realmIndexQueryEngine.module(
-          new URL(`${testRealm}post`),
-        );
-        assert.strictEqual(
-          postModule?.type,
-          'module',
-          'post module is in the index after recreation',
-        );
         let { data: result } = await realm.realmIndexQueryEngine.search({
           filter: {
             on: { module: `${testRealm}post`, name: 'Post' },
@@ -1497,16 +1488,9 @@ module(basename(__filename), function () {
         new URL(`${testRealm}country`),
       );
       assert.ok(country, 'country module is in the index');
-      assert.deepEqual(
-        // we splat because despite having the same shape, the constructors are different
-        { ...realm.realmIndexUpdater.stats },
-        {
-          instancesIndexed: 0,
-          instanceErrors: 0,
-          moduleErrors: 0,
-          modulesIndexed: 2,
-          totalIndexEntries: 23,
-        },
+      assert.strictEqual(
+        realm.realmIndexUpdater.stats.modulesIndexed,
+        2,
         'indexed correct number of files',
       );
     });

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -1244,12 +1244,6 @@ module(basename(__filename), function () {
               return this.author?.firstName + '-poo';
             }
           })
-          static embedded = class Embedded extends Component<typeof this> {
-            <template><@fields.firstName/> (<@fields.nickName/>)</template>
-          }
-          static fitted = class Fitted extends Component<typeof this> {
-            <template><@fields.firstName/> (<@fields.nickName/>)</template>
-          }
         }
       `,
       );

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -572,6 +572,90 @@ module(basename(__filename), function () {
       );
     });
 
+    test('card prerender surfaces errors thrown before the render model hook', async function (assert) {
+      let originalGetPage = PagePool.prototype.getPage;
+      try {
+        PagePool.prototype.getPage = async function (
+          this: PagePool,
+          realm: string,
+        ) {
+          let pageInfo = await originalGetPage.call(this, realm);
+          let page = pageInfo.page as any;
+          let originalEvaluate = page?.evaluate?.bind(page);
+          if (originalEvaluate) {
+            let injected = false;
+            page.evaluate = async (...args: any[]) => {
+              if (!injected) {
+                injected = true;
+                await originalEvaluate(() => {
+                  let entries =
+                    (window as any).requirejs?.entries ??
+                    (window as any).require?.entries ??
+                    (window as any)._eak_seen;
+                  let renderModuleName =
+                    entries &&
+                    Object.keys(entries).find((name) =>
+                      name.endsWith('/routes/render'),
+                    );
+                  if (!renderModuleName) {
+                    throw new Error(
+                      'render route module not found for injection',
+                    );
+                  }
+                  let renderRouteModule = (window as any).require(
+                    renderModuleName,
+                  );
+                  let RenderRouteClass = renderRouteModule?.default;
+                  if (!RenderRouteClass?.prototype) {
+                    throw new Error(
+                      'render route class not found for injection',
+                    );
+                  }
+                  let originalBeforeModel =
+                    RenderRouteClass.prototype.beforeModel;
+                  RenderRouteClass.prototype.beforeModel = async function (
+                    ...bmArgs: any[]
+                  ) {
+                    if (originalBeforeModel) {
+                      await originalBeforeModel.apply(this, bmArgs as any);
+                    }
+                    RenderRouteClass.prototype.beforeModel =
+                      originalBeforeModel;
+                    throw new Error('boom before model');
+                  };
+                });
+              }
+              return originalEvaluate(...args);
+            };
+          }
+          return { ...pageInfo, page };
+        };
+
+        let result = await prerenderer.prerenderCard({
+          realm: realmURL,
+          url: `${realmURL}1.json`,
+          auth: auth(),
+        });
+
+        assert.ok(result.response.error, 'prerender reports error');
+        assert.ok(
+          result.response.error?.error.message?.includes('boom before model'),
+          'captures error thrown before model hook',
+        );
+        assert.true(
+          result.pool.evicted,
+          'pre-model error evicts prerender page for clean state',
+        );
+        assert.true(
+          (result.response.error as any)?.evict,
+          'error payload flags eviction',
+        );
+        assert.false(result.pool.timedOut, 'error is not treated as timeout');
+      } finally {
+        PagePool.prototype.getPage = originalGetPage;
+      }
+    });
+
     test('module prerender evicts pooled page on timeout', async function (assert) {
       const moduleURL = `${realmURL}person.gts`;
 

--- a/packages/runtime-common/code-ref.ts
+++ b/packages/runtime-common/code-ref.ts
@@ -167,9 +167,12 @@ export async function loadCardDef(
     return maybeCard;
   }
 
-  let err = new CardError(`Unable to loadCard ${humanReadable(ref)}`, {
-    status: 404,
-  });
+  let err = new CardError(
+    `Cannot find card ${humanReadable(ref)}. Make sure ${new URL(moduleFrom(ref), opts?.relativeTo).href} exports ${exportFrom(ref)}`,
+    {
+      status: 404,
+    },
+  );
   err.deps = [moduleFrom(ref)];
   throw err;
 }
@@ -305,6 +308,14 @@ export function moduleFrom(ref: CodeRef): string {
     return ref.module;
   } else {
     return moduleFrom(ref.card);
+  }
+}
+
+function exportFrom(ref: CodeRef): string {
+  if (!('type' in ref)) {
+    return ref.name;
+  } else {
+    return exportFrom(ref.card);
   }
 }
 


### PR DESCRIPTION
This PR provides better support for errors that are thrown before the model hook runs in the /render route. The error was doing this intermediate transition without any route params. Also, providing a more useful error message when loadCard() is unable to find the card so that AI can fix the problem.