### PR TITLE
Use health checks to determine when prerender server and prerender manager are ready after deploy

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -157,6 +157,7 @@ jobs:
       cluster: ${{ inputs.environment }}
       service-name: "boxel-prerender-server-${{ inputs.environment }}"
       image: ${{ needs.build-prerender.outputs.image }}
+      timeout-minutes: 10
       wait-for-service-stability: true
 
   deploy-prerender-manager:
@@ -170,6 +171,7 @@ jobs:
       cluster: ${{ inputs.environment }}
       service-name: "boxel-prerender-manager-${{ inputs.environment }}"
       image: ${{ needs.build-prerender-manager.outputs.image }}
+      timeout-minutes: 10
       wait-for-service-stability: true
 
   deploy-worker:

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -177,12 +177,7 @@ jobs:
   deploy-worker:
     name: Deploy worker
     needs:
-      [
-        build-worker,
-        deploy-host,
-        post-migrate-db,
-        deploy-prerender-manager,
-      ]
+      [build-worker, deploy-host, post-migrate-db, deploy-prerender-manager]
     uses: cardstack/gh-actions/.github/workflows/ecs-deploy.yml@main
     secrets: inherit
     with:
@@ -215,6 +210,7 @@ jobs:
       cluster: ${{ inputs.environment }}
       service-name: "boxel-realm-server-${{ inputs.environment }}"
       image: ${{ needs.build-realm-server.outputs.image }}
+      timeout-minutes: 10
       wait-for-service-stability: true
 
   post-deploy-realm-server:

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -157,18 +157,11 @@ jobs:
       cluster: ${{ inputs.environment }}
       service-name: "boxel-prerender-server-${{ inputs.environment }}"
       image: ${{ needs.build-prerender.outputs.image }}
-      wait-for-service-stability: false
-
-  post-deploy-prerender:
-    name: Wait for prerender
-    needs: [deploy-prerender]
-    runs-on: ubuntu-latest
-    steps:
-      - run: sleep 180
+      wait-for-service-stability: true
 
   deploy-prerender-manager:
     name: Deploy prerender manager
-    needs: [build-prerender-manager, post-deploy-prerender]
+    needs: [build-prerender-manager, deploy-prerender]
     uses: cardstack/gh-actions/.github/workflows/ecs-deploy.yml@main
     secrets: inherit
     with:
@@ -177,14 +170,7 @@ jobs:
       cluster: ${{ inputs.environment }}
       service-name: "boxel-prerender-manager-${{ inputs.environment }}"
       image: ${{ needs.build-prerender-manager.outputs.image }}
-      wait-for-service-stability: false
-
-  post-deploy-prerender-manager:
-    name: Wait for prerender manager
-    needs: [deploy-prerender-manager]
-    runs-on: ubuntu-latest
-    steps:
-      - run: sleep 180
+      wait-for-service-stability: true
 
   deploy-worker:
     name: Deploy worker
@@ -193,7 +179,7 @@ jobs:
         build-worker,
         deploy-host,
         post-migrate-db,
-        post-deploy-prerender-manager,
+        deploy-prerender-manager,
       ]
     uses: cardstack/gh-actions/.github/workflows/ecs-deploy.yml@main
     secrets: inherit

--- a/packages/realm-server/prerender-manager.Dockerfile
+++ b/packages/realm-server/prerender-manager.Dockerfile
@@ -21,4 +21,7 @@ RUN CI=1 pnpm install -r --offline
 
 EXPOSE 4222
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD curl --fail --silent --show-error --max-time 5 --output /dev/null http://localhost:4222/ || exit 1
+
 CMD pnpm --filter "./packages/realm-server" $prerender_manager_script

--- a/packages/realm-server/prerender.Dockerfile
+++ b/packages/realm-server/prerender.Dockerfile
@@ -75,4 +75,7 @@ USER pptruser
 
 EXPOSE 4221
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+  CMD curl --fail --silent --show-error --max-time 5 --output /dev/null http://localhost:4221/ || exit 1
+
 CMD pnpm --filter "./packages/realm-server" $prerender_script


### PR DESCRIPTION
This PR is meant to speed up the deploy of the prerender server and prerender manager by using health checks to determine when the service is ready instead of a hard coded 3 minute wait.

This is meant to be coordinated with infra PR https://github.com/cardstack/infra/pull/630. I'll test this PR in staging after the infra PR is deployed. this might result in some prerender server downtime while things are being tested out.