### PR TITLE
Fixed issue were store was not being reset for schema changes

### DIFF
--- a/packages/host/app/resources/file.ts
+++ b/packages/host/app/resources/file.ts
@@ -15,6 +15,7 @@ import type { SaveType } from '@cardstack/host/services/card-service';
 
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 import type RecentFilesService from '@cardstack/host/services/recent-files-service';
+import type StoreService from '@cardstack/host/services/store';
 
 import type { RealmEventContent } from 'https://cardstack.com/base/matrix-event';
 
@@ -136,6 +137,7 @@ class _FileResource extends Resource<Args> {
   @service declare private cardService: CardService;
   @service declare private recentFilesService: RecentFilesService;
   @service declare private operatorModeStateService: OperatorModeStateService;
+  @service declare private store: StoreService;
 
   constructor(owner: Owner) {
     super(owner);
@@ -341,6 +343,9 @@ class _FileResource extends Resource<Args> {
           clientRequestId: opts?.clientRequestId,
         },
       );
+      if (opts?.flushLoader) {
+        this.store.refreshReferencesForCodeChange('file write');
+      }
       if (this.innerState.state === 'not-found') {
         // TODO think about the "unauthorized" scenario
         throw new Error(

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -182,6 +182,13 @@ export default class StoreService extends Service implements StoreInterface {
     this.store = this.createCardStore();
   }
 
+  refreshReferencesForCodeChange(reason?: string) {
+    let reasonSuffix = reason ? ` (${reason})` : '';
+    storeLogger.debug(`resetting store for code change${reasonSuffix}`);
+    this.store.reset();
+    this.reestablishReferences.perform();
+  }
+
   dropReference(id: string | undefined) {
     if (!id) {
       return;


### PR DESCRIPTION
This fixes a bug where the store is not resetting based on code changes, e.g. using the schema editor to add a field to a card. This fixes a bug where when we use a schema editor to add a field to a card we were not seeing it update in the playground edit format. now we are.


https://github.com/user-attachments/assets/024c5d62-49b0-4abd-a647-a053dff7d6bf

