### PR TITLE
Support deserialization of linksToMany in array format

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -1626,7 +1626,8 @@ class LinksToMany<FieldT extends CardDefConstructor>
         if (reference == null) {
           return null;
         }
-        let cachedInstance = store.get(new URL(reference, relativeTo).href);
+        let normalizedReference = new URL(reference, relativeTo).href;
+        let cachedInstance = store.get(normalizedReference);
 
         if (cachedInstance) {
           cachedInstance[isSavedInstance] = true;
@@ -1639,6 +1640,9 @@ class LinksToMany<FieldT extends CardDefConstructor>
         //that means that the serialization is incorrect and is not JSON-API compliant.
         let resourceId =
           value.data && 'id' in value.data ? value.data?.id : undefined;
+        if (!resourceId) {
+          resourceId = normalizedReference;
+        }
         if (loadedValues && Array.isArray(loadedValues)) {
           let loadedValue = loadedValues.find(
             (v) => isCardOrField(v) && 'id' in v && v.id === resourceId,
@@ -1648,6 +1652,9 @@ class LinksToMany<FieldT extends CardDefConstructor>
           }
         }
         let resource = resourceFrom(doc, resourceId);
+        if (!resource && reference !== normalizedReference) {
+          resource = resourceFrom(doc, reference);
+        }
         if (!resource) {
           return {
             type: 'not-loaded',

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -1633,11 +1633,10 @@ class LinksToMany<FieldT extends CardDefConstructor>
           cachedInstance[isSavedInstance] = true;
           return cachedInstance;
         }
-        //links.self is used to tell the consumer of this payload how to get the resource via HTTP. data.id is used to tell the
-        //consumer of this payload how to get the resource from the side loaded included bucket. we need to strictly only
-        //consider data.id when calling the resourceFrom() function (which actually loads the resource out of the included
-        //bucket). we should never used links.self as part of that consideration. If there is a missing data.id in the resource entity
-        //that means that the serialization is incorrect and is not JSON-API compliant.
+        // links.self is used to tell the consumer of this payload how to get the resource via HTTP.
+        // data.id is used to tell the consumer how to find the resource in the included bucket.
+        // Prefer data.id for resourceFrom(), but fall back to links.self when data.id is missing
+        // (the array-style linksToMany format omits data.id).
         let resourceId =
           value.data && 'id' in value.data ? value.data?.id : undefined;
         if (!resourceId) {

--- a/packages/base/query-field-support.ts
+++ b/packages/base/query-field-support.ts
@@ -13,6 +13,7 @@ import type {
 } from '@cardstack/runtime-common';
 import {
   getField,
+  getSingularRelationship,
   identifyCard,
   THIS_INTERPOLATION_PREFIX,
   THIS_REALM_TOKEN,
@@ -255,8 +256,8 @@ export function captureQueryFieldSeedData(
     queryFieldState.set(fieldName, fieldState);
   }
   fieldState.seedRecords = value;
-  fieldState.seedSearchURL =
-    resource.relationships?.[fieldName]?.links?.search ?? null;
+  let relationship = getSingularRelationship(resource.relationships, fieldName);
+  fieldState.seedSearchURL = relationship?.links?.search ?? null;
   fieldState.seedRealms = fieldState.seedSearchURL
     ? [parseSearchURL(new URL(fieldState.seedSearchURL)).realm.href]
     : [];

--- a/packages/host/app/routes/render/meta.ts
+++ b/packages/host/app/routes/render/meta.ts
@@ -11,6 +11,7 @@ import {
   identifyCard,
   internalKeyFor,
   maybeRelativeURL,
+  relationshipEntries,
   realmURL,
   type SingleCardDocument,
   type PrerenderMeta,
@@ -64,8 +65,8 @@ export default class RenderMetaRoute extends Route<Model> {
           instance[realmURL],
         ),
     }) as SingleCardDocument;
-    for (let relationship of Object.values(
-      serialized.data.relationships ?? {},
+    for (let { relationship } of relationshipEntries(
+      serialized.data.relationships,
     )) {
       // we want to emulate the file serialization here
       delete relationship.data;

--- a/packages/host/tests/acceptance/code-submode/editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/editor-test.ts
@@ -750,11 +750,12 @@ module('Acceptance | code submode | editor tests', function (hooks) {
       if (typeof json === 'string') {
         throw new Error('expected JSON save data');
       }
+      let themeRelationship = json.data.relationships?.['cardInfo.theme'];
+      if (Array.isArray(themeRelationship)) {
+        throw new Error('expected cardInfo.theme relationship to be singular');
+      }
       assert.strictEqual(url.href, `${testRealmURL}Pet/mango`);
-      assert.strictEqual(
-        json.data.relationships?.['cardInfo.theme']?.links?.self,
-        currentThemeId,
-      );
+      assert.strictEqual(themeRelationship?.links?.self, currentThemeId);
     };
 
     await visitOperatorMode({

--- a/packages/runtime-common/file-serializer.ts
+++ b/packages/runtime-common/file-serializer.ts
@@ -97,7 +97,9 @@ export default function serialize({
   result.data.type = 'card';
 
   if (result.data.relationships) {
-    for (let { relationship } of relationshipEntries(result.data.relationships)) {
+    for (let { relationship } of relationshipEntries(
+      result.data.relationships,
+    )) {
       delete relationship.data;
     }
   }

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -169,6 +169,7 @@ export * from './authorization-middleware';
 export * from './resource-types';
 export * from './query';
 export * from './query-field-utils';
+export * from './relationship-utils';
 export * from './formats';
 export { mergeRelationships } from './merge-relationships';
 export { makeLogDefinitions, logger } from './log';

--- a/packages/runtime-common/merge-relationships.ts
+++ b/packages/runtime-common/merge-relationships.ts
@@ -1,4 +1,5 @@
 import type { LooseCardResource, Relationship } from './index';
+import { relationshipEntries } from './relationship-utils';
 import mergeWith from 'lodash/mergeWith';
 
 export function mergeRelationships(
@@ -21,15 +22,14 @@ function _formatForMerge(
 ): Record<string, Relationship | Relationship[]> {
   let data: Record<string, Relationship | Relationship[]> = {};
 
-  for (let [key, value] of Object.entries(resource ?? {})) {
-    let keys = key.split('.');
-    if (keys.length > 1 && keys[keys.length - 1].match(/^\d+$/)) {
-      keys.pop();
-      let name = keys.join('.');
-      data[name] = Array.isArray(data[name]) ? data[name] : [];
-      (data[name] as Relationship[]).push(value);
+  for (let entry of relationshipEntries(resource)) {
+    if (entry.isPlural) {
+      data[entry.fieldName] = Array.isArray(data[entry.fieldName])
+        ? data[entry.fieldName]
+        : [];
+      (data[entry.fieldName] as Relationship[]).push(entry.relationship);
     } else {
-      data[key] = value;
+      data[entry.fieldName] = entry.relationship;
     }
   }
   return data;

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -586,96 +586,94 @@ export class RealmIndexQueryEngine {
           relationship.links.self,
           resource.id ? new URL(resource.id) : realmURL,
         );
-          let linkResource: CardResource<Saved> | undefined;
-          if (realmPath.inRealm(linkURL)) {
-            let maybeResult = await this.#indexQueryEngine.getInstance(
-              linkURL,
-              opts,
+        let linkResource: CardResource<Saved> | undefined;
+        if (realmPath.inRealm(linkURL)) {
+          let maybeResult = await this.#indexQueryEngine.getInstance(
+            linkURL,
+            opts,
+          );
+          linkResource =
+            maybeResult?.type === 'instance' ? maybeResult.instance : undefined;
+        } else {
+          let response = await this.#fetch(linkURL, {
+            headers: { Accept: SupportedMimeType.CardJson },
+          });
+          if (!response.ok) {
+            let cardError = await CardError.fromFetchResponse(
+              linkURL.href,
+              response,
             );
-            linkResource =
-              maybeResult?.type === 'instance'
-                ? maybeResult.instance
-                : undefined;
-          } else {
-            let response = await this.#fetch(linkURL, {
-              headers: { Accept: SupportedMimeType.CardJson },
-            });
-            if (!response.ok) {
-              let cardError = await CardError.fromFetchResponse(
-                linkURL.href,
-                response,
-              );
-              throw cardError;
-            }
-            let json = await response.json();
-            if (!isSingleCardDocument(json)) {
-              throw new Error(
-                `instance ${
-                  linkURL.href
-                } is not a card document. it is: ${JSON.stringify(
-                  json,
-                  null,
-                  2,
-                )}`,
-              );
-            }
-            linkResource = {
-              ...json.data,
-              ...{ links: { self: json.data.id } },
-            };
+            throw cardError;
           }
-          let foundLinks = false;
-          // TODO stop using maxLinkDepth. we should save the JSON-API doc in the
-          // index based on keeping track of the rendered fields and invalidate the
-          // index as consumed cards change
-          if (linkResource && stack.length <= maxLinkDepth) {
-            for (let includedResource of await this.loadLinks(
-              {
-                realmURL,
-                resource: linkResource,
-                omit,
-                included: [...included, linkResource],
-                visited,
-                stack: [...(resource.id != null ? [resource.id] : []), ...stack],
-              },
-              opts,
-            )) {
-              foundLinks = true;
-              if (
-                includedResource.id &&
-                !omit.includes(includedResource.id) &&
-                !included.find((r) => r.id === includedResource.id)
-              ) {
-                let rewrittenResource = cloneDeep({
-                  ...includedResource,
-                  ...{ links: { self: includedResource.id } },
-                });
-                visitInstanceURLs(rewrittenResource, (url, setURL) =>
-                  absolutizeInstanceURL(url, rewrittenResource.id, setURL),
-                );
-                visitModuleDeps(rewrittenResource, (url, setURL) =>
-                  absolutizeInstanceURL(url, rewrittenResource.id, setURL),
-                );
-                included.push(rewrittenResource);
-              }
-            }
-          }
-          let relationshipId = maybeURL(relationship.links.self, resource.id);
-          if (!relationshipId) {
+          let json = await response.json();
+          if (!isSingleCardDocument(json)) {
             throw new Error(
-              `bug: unable to turn relative URL '${relationship.links.self}' into an absolute URL relative to ${resource.id}`,
+              `instance ${
+                linkURL.href
+              } is not a card document. it is: ${JSON.stringify(
+                json,
+                null,
+                2,
+              )}`,
             );
           }
-          if (
-            foundLinks ||
-            omit.includes(relationshipId.href) ||
-            included.find((i) => i.id === relationshipId!.href)
-          ) {
-            relationship.data = {
-              type: 'card',
-              id: relationshipId.href,
-            };
+          linkResource = {
+            ...json.data,
+            ...{ links: { self: json.data.id } },
+          };
+        }
+        let foundLinks = false;
+        // TODO stop using maxLinkDepth. we should save the JSON-API doc in the
+        // index based on keeping track of the rendered fields and invalidate the
+        // index as consumed cards change
+        if (linkResource && stack.length <= maxLinkDepth) {
+          for (let includedResource of await this.loadLinks(
+            {
+              realmURL,
+              resource: linkResource,
+              omit,
+              included: [...included, linkResource],
+              visited,
+              stack: [...(resource.id != null ? [resource.id] : []), ...stack],
+            },
+            opts,
+          )) {
+            foundLinks = true;
+            if (
+              includedResource.id &&
+              !omit.includes(includedResource.id) &&
+              !included.find((r) => r.id === includedResource.id)
+            ) {
+              let rewrittenResource = cloneDeep({
+                ...includedResource,
+                ...{ links: { self: includedResource.id } },
+              });
+              visitInstanceURLs(rewrittenResource, (url, setURL) =>
+                absolutizeInstanceURL(url, rewrittenResource.id, setURL),
+              );
+              visitModuleDeps(rewrittenResource, (url, setURL) =>
+                absolutizeInstanceURL(url, rewrittenResource.id, setURL),
+              );
+              included.push(rewrittenResource);
+            }
           }
+        }
+        let relationshipId = maybeURL(relationship.links.self, resource.id);
+        if (!relationshipId) {
+          throw new Error(
+            `bug: unable to turn relative URL '${relationship.links.self}' into an absolute URL relative to ${resource.id}`,
+          );
+        }
+        if (
+          foundLinks ||
+          omit.includes(relationshipId.href) ||
+          included.find((i) => i.id === relationshipId!.href)
+        ) {
+          relationship.data = {
+            type: 'card',
+            id: relationshipId.href,
+          };
+        }
       }
     };
 

--- a/packages/runtime-common/relationship-utils.ts
+++ b/packages/runtime-common/relationship-utils.ts
@@ -1,0 +1,74 @@
+import type { LooseCardResource, Relationship } from './resource-types';
+
+export type RelationshipEntry = {
+  key: string;
+  fieldName: string;
+  index?: number;
+  relationship: Relationship;
+  isPlural: boolean;
+};
+
+export function getSingularRelationship(
+  relationships: LooseCardResource['relationships'] | undefined,
+  fieldName: string,
+): Relationship | undefined {
+  let relationship = relationships?.[fieldName];
+  return Array.isArray(relationship) ? undefined : relationship;
+}
+
+export function relationshipEntries(
+  relationships: LooseCardResource['relationships'] | undefined,
+): RelationshipEntry[] {
+  if (!relationships) {
+    return [];
+  }
+
+  let entries: RelationshipEntry[] = [];
+  for (let [key, value] of Object.entries(relationships)) {
+    if (Array.isArray(value)) {
+      value.forEach((relationship, index) => {
+        entries.push({
+          key: `${key}.${index}`,
+          fieldName: key,
+          index,
+          relationship,
+          isPlural: true,
+        });
+      });
+      continue;
+    }
+
+    let { fieldName, index } = parseRelationshipKey(key);
+    entries.push({
+      key,
+      fieldName,
+      index,
+      relationship: value,
+      isPlural: index !== undefined,
+    });
+  }
+
+  return entries;
+}
+
+export function normalizeRelationships(
+  relationships: LooseCardResource['relationships'] | undefined,
+): Record<string, Relationship> {
+  let normalized: Record<string, Relationship> = {};
+  for (let entry of relationshipEntries(relationships)) {
+    normalized[entry.key] = entry.relationship;
+  }
+  return normalized;
+}
+
+function parseRelationshipKey(key: string): { fieldName: string; index?: number } {
+  let parts = key.split('.');
+  let last = parts[parts.length - 1];
+  if (parts.length > 1 && /^\d+$/.test(last)) {
+    return {
+      fieldName: parts.slice(0, -1).join('.'),
+      index: Number(last),
+    };
+  }
+  return { fieldName: key };
+}

--- a/packages/runtime-common/relationship-utils.ts
+++ b/packages/runtime-common/relationship-utils.ts
@@ -61,7 +61,10 @@ export function normalizeRelationships(
   return normalized;
 }
 
-function parseRelationshipKey(key: string): { fieldName: string; index?: number } {
+function parseRelationshipKey(key: string): {
+  fieldName: string;
+  index?: number;
+} {
   let parts = key.split('.');
   let last = parts[parts.length - 1];
   if (parts.length > 1 && /^\d+$/.test(last)) {

--- a/packages/runtime-common/resource-types.ts
+++ b/packages/runtime-common/resource-types.ts
@@ -63,7 +63,7 @@ export interface CardResource<Identity extends Unsaved = Saved> {
   type: 'card';
   attributes?: Record<string, any>;
   relationships?: {
-    [fieldName: string]: Relationship;
+    [fieldName: string]: Relationship | Relationship[];
   };
   meta: CardResourceMeta;
   links?: {
@@ -129,7 +129,11 @@ export function isCardResource(resource: any): resource is CardResource {
       if (typeof fieldName !== 'string') {
         return false;
       }
-      if (!isRelationship(relationship)) {
+      if (Array.isArray(relationship)) {
+        if (relationship.some((entry) => !isRelationship(entry))) {
+          return false;
+        }
+      } else if (!isRelationship(relationship)) {
         return false;
       }
     }

--- a/packages/runtime-common/url.ts
+++ b/packages/runtime-common/url.ts
@@ -1,4 +1,5 @@
 import type { LooseCardResource } from './index';
+import { relationshipEntries } from './relationship-utils';
 import { RealmPaths } from './paths';
 
 export function maybeURL(
@@ -92,7 +93,7 @@ export function visitInstanceURLs(
   }
   let relationships = resourceJson.relationships;
   if (relationships) {
-    for (let relationship of Object.values(relationships)) {
+    for (let { relationship } of relationshipEntries(relationships)) {
       let links = relationship.links;
       if (links && links.self) {
         visit(links.self, (newURL) => {


### PR DESCRIPTION
This PR updates our system to be able to support deserializing array-like linksToMany relationships:

```
relationships: {
  skills: [
    {
       links: {
         self: 'https://path/to/card'
       }
    }
  ]
}
```