### PR TITLE
control puppeteer chrome logging via standard LOG_LEVELS config

### DIFF
--- a/packages/realm-server/package.json
+++ b/packages/realm-server/package.json
@@ -78,8 +78,8 @@
     "yargs": "catalog:"
   },
   "scripts": {
-    "test": "./scripts/remove-test-dbs.sh; PRERENDER_SILENT=true LOG_LEVELS=\"*=error,pg-adapter=warn,realm:requests=warn${LOG_LEVELS:+,}${LOG_LEVELS}\" NODE_NO_WARNINGS=1 PGPORT=5435 STRIPE_WEBHOOK_SECRET=stripe-webhook-secret STRIPE_API_KEY=stripe-api-key qunit --require ts-node/register/transpile-only tests/index.ts",
-    "test-module": "./scripts/remove-test-dbs.sh; PRERENDER_SILENT=true LOG_LEVELS=\"*=error,pg-adapter=warn,realm:requests=warn${LOG_LEVELS:+,}${LOG_LEVELS}\" NODE_NO_WARNINGS=1 PGPORT=5435 STRIPE_WEBHOOK_SECRET=stripe-webhook-secret STRIPE_API_KEY=stripe-api-key qunit --require ts-node/register/transpile-only --module ${TEST_MODULE} tests/index.ts",
+    "test": "./scripts/remove-test-dbs.sh; LOG_LEVELS=\"*=error,prerenderer-chrome=none,pg-adapter=warn,realm:requests=warn${LOG_LEVELS:+,}${LOG_LEVELS}\" NODE_NO_WARNINGS=1 PGPORT=5435 STRIPE_WEBHOOK_SECRET=stripe-webhook-secret STRIPE_API_KEY=stripe-api-key qunit --require ts-node/register/transpile-only tests/index.ts",
+    "test-module": "./scripts/remove-test-dbs.sh; LOG_LEVELS=\"*=error,prerenderer-chrome=none,pg-adapter=warn,realm:requests=warn${LOG_LEVELS:+,}${LOG_LEVELS}\" NODE_NO_WARNINGS=1 PGPORT=5435 STRIPE_WEBHOOK_SECRET=stripe-webhook-secret STRIPE_API_KEY=stripe-api-key qunit --require ts-node/register/transpile-only --module ${TEST_MODULE} tests/index.ts",
     "start:matrix": "cd ../matrix && pnpm assert-synapse-running",
     "start:smtp": "cd ../matrix && pnpm assert-smtp-running",
     "start:pg": "./scripts/start-pg.sh",

--- a/packages/realm-server/package.json
+++ b/packages/realm-server/package.json
@@ -78,8 +78,8 @@
     "yargs": "catalog:"
   },
   "scripts": {
-    "test": "./scripts/remove-test-dbs.sh; LOG_LEVELS=\"*=error,prerenderer-chrome=none,pg-adapter=warn,realm:requests=warn${LOG_LEVELS:+,}${LOG_LEVELS}\" NODE_NO_WARNINGS=1 PGPORT=5435 STRIPE_WEBHOOK_SECRET=stripe-webhook-secret STRIPE_API_KEY=stripe-api-key qunit --require ts-node/register/transpile-only tests/index.ts",
-    "test-module": "./scripts/remove-test-dbs.sh; LOG_LEVELS=\"*=error,prerenderer-chrome=none,pg-adapter=warn,realm:requests=warn${LOG_LEVELS:+,}${LOG_LEVELS}\" NODE_NO_WARNINGS=1 PGPORT=5435 STRIPE_WEBHOOK_SECRET=stripe-webhook-secret STRIPE_API_KEY=stripe-api-key qunit --require ts-node/register/transpile-only --module ${TEST_MODULE} tests/index.ts",
+    "test": "./scripts/remove-test-dbs.sh; LOG_LEVELS=\"*=error,prerenderer-chrome=silent,pg-adapter=warn,realm:requests=warn${LOG_LEVELS:+,}${LOG_LEVELS}\" NODE_NO_WARNINGS=1 PGPORT=5435 STRIPE_WEBHOOK_SECRET=stripe-webhook-secret STRIPE_API_KEY=stripe-api-key qunit --require ts-node/register/transpile-only tests/index.ts",
+    "test-module": "./scripts/remove-test-dbs.sh; LOG_LEVELS=\"*=error,prerenderer-chrome=silent,pg-adapter=warn,realm:requests=warn${LOG_LEVELS:+,}${LOG_LEVELS}\" NODE_NO_WARNINGS=1 PGPORT=5435 STRIPE_WEBHOOK_SECRET=stripe-webhook-secret STRIPE_API_KEY=stripe-api-key qunit --require ts-node/register/transpile-only --module ${TEST_MODULE} tests/index.ts",
     "start:matrix": "cd ../matrix && pnpm assert-synapse-running",
     "start:smtp": "cd ../matrix && pnpm assert-smtp-running",
     "start:pg": "./scripts/start-pg.sh",

--- a/packages/realm-server/prerender/page-pool.ts
+++ b/packages/realm-server/prerender/page-pool.ts
@@ -397,15 +397,15 @@ export class PagePool {
     switch (type) {
       case 'assert':
       case 'error':
-        return chromeLog.error.bind(log);
+        return chromeLog.error.bind(chromeLog);
       case 'warn':
-        return chromeLog.warn.bind(log);
+        return chromeLog.warn.bind(chromeLog);
       case 'info':
-        return chromeLog.info.bind(log);
+        return chromeLog.info.bind(chromeLog);
       case 'debug':
-        return chromeLog.debug.bind(log);
+        return chromeLog.debug.bind(chromeLog);
       default:
-        return chromeLog.info.bind(log);
+        return chromeLog.info.bind(chromeLog);
     }
   }
 

--- a/packages/realm-server/prerender/prerender-app.ts
+++ b/packages/realm-server/prerender/prerender-app.ts
@@ -30,7 +30,6 @@ const defaultPrerenderServerPort = 4221;
 export function buildPrerenderApp(options: {
   serverURL: string;
   maxPages?: number;
-  silent?: boolean;
   isDraining?: () => boolean;
   drainingPromise?: Promise<void>;
 }): {
@@ -41,10 +40,8 @@ export function buildPrerenderApp(options: {
   let router = new Router();
   let maxPages =
     options?.maxPages ?? Number(process.env.PRERENDER_PAGE_POOL_SIZE ?? 4);
-  let silent = options?.silent || process.env.PRERENDER_SILENT === 'true';
   let prerenderer = new Prerenderer({
     maxPages,
-    silent,
     serverURL: options.serverURL,
   });
 
@@ -395,11 +392,9 @@ export function createPrerenderHttpServer(options?: {
   let heartbeatTimer: NodeJS.Timeout | undefined;
   let isClosing = false;
   let fatalExitInProgress = false;
-  let silent = options?.silent || process.env.PRERENDER_SILENT === 'true';
   let serverURL = resolvePrerenderServerURL(options?.port);
   let { app, prerenderer } = buildPrerenderApp({
     maxPages: options?.maxPages,
-    silent,
     serverURL,
     isDraining: () => draining,
     drainingPromise: drainingDeferred.promise,

--- a/packages/realm-server/prerender/prerenderer.ts
+++ b/packages/realm-server/prerender/prerenderer.ts
@@ -51,18 +51,12 @@ export class Prerenderer {
   #realmIdleEvictMs: number;
   #semaphore: AsyncSemaphore;
 
-  constructor(options: {
-    serverURL: string;
-    maxPages?: number;
-    silent?: boolean;
-  }) {
+  constructor(options: { serverURL: string; maxPages?: number }) {
     let maxPages = options.maxPages ?? 4;
-    let silent = options.silent || process.env.PRERENDER_SILENT === 'true';
     this.#semaphore = new AsyncSemaphore(maxPages);
     this.#browserManager = new BrowserManager();
     this.#pagePool = new PagePool({
       maxPages,
-      silent,
       serverURL: options.serverURL,
       browserManager: this.#browserManager,
       boxelHostURL,

--- a/packages/realm-server/tests/cards/missing-link.json
+++ b/packages/realm-server/tests/cards/missing-link.json
@@ -9,12 +9,12 @@
         "links": {
           "self": "./does-not-exist"
         }
-      },
-      "meta": {
-        "adoptsFrom": {
-          "module": "./friend.gts",
-          "name": "Friend"
-        }
+      }
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "./friend.gts",
+        "name": "Friend"
       }
     }
   }

--- a/packages/realm-server/tests/cards/missing-link.json
+++ b/packages/realm-server/tests/cards/missing-link.json
@@ -1,20 +1,31 @@
 {
   "data": {
+    "meta": {
+      "adoptsFrom": {
+        "name": "Friend",
+        "module": "./friend"
+      }
+    },
     "type": "card",
     "attributes": {
+      "cardInfo": {
+        "notes": null,
+        "title": null,
+        "description": null,
+        "thumbnailURL": null
+      },
       "firstName": "Boris"
     },
     "relationships": {
       "friend": {
         "links": {
-          "self": "./does-not-exist"
+          "self": null
         }
-      }
-    },
-    "meta": {
-      "adoptsFrom": {
-        "module": "./friend.gts",
-        "name": "Friend"
+      },
+      "cardInfo.theme": {
+        "links": {
+          "self": null
+        }
       }
     }
   }

--- a/packages/realm-server/tests/cards/missing-link.json
+++ b/packages/realm-server/tests/cards/missing-link.json
@@ -1,30 +1,19 @@
 {
   "data": {
-    "meta": {
-      "adoptsFrom": {
-        "name": "Friend",
-        "module": "./friend"
-      }
-    },
     "type": "card",
     "attributes": {
-      "cardInfo": {
-        "notes": null,
-        "title": null,
-        "description": null,
-        "thumbnailURL": null
-      },
       "firstName": "Boris"
     },
     "relationships": {
       "friend": {
         "links": {
-          "self": null
+          "self": "./does-not-exist"
         }
       },
-      "cardInfo.theme": {
-        "links": {
-          "self": null
+      "meta": {
+        "adoptsFrom": {
+          "module": "./friend.gts",
+          "name": "Friend"
         }
       }
     }

--- a/packages/realm-server/tests/prerender-server-test.ts
+++ b/packages/realm-server/tests/prerender-server-test.ts
@@ -287,7 +287,6 @@ module(basename(__filename), function () {
         serverURL: 'http://127.0.0.1:4222',
         isDraining: () => localDraining,
         drainingPromise: drainingDeferred.promise,
-        silent: true,
       });
       let localRequest = supertest(built.app.callback());
 
@@ -361,7 +360,6 @@ module(basename(__filename), function () {
           serverURL: 'http://127.0.0.1:4223',
           isDraining: () => true,
           drainingPromise: Promise.resolve(),
-          silent: true,
         });
         let localRequest = supertest(built.app.callback());
         let originalPrerender = (built.prerenderer as any).prerenderCard;

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -75,7 +75,7 @@ function makeStubPagePool(maxPages: number) {
   return { pool, contextsCreated, contextsClosed };
 }
 
-module.only(basename(__filename), function () {
+module(basename(__filename), function () {
   module('prerender - dynamic tests', function (hooks) {
     let realmURL = 'http://127.0.0.1:4450/';
     let prerenderServerURL = realmURL.endsWith('/')

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -64,7 +64,6 @@ function makeStubPagePool(maxPages: number) {
   };
   let pool = new PagePool({
     maxPages,
-    silent: true,
     serverURL: 'http://localhost',
     browserManager: browserManager as any,
     boxelHostURL: 'http://localhost:4200',
@@ -1843,7 +1842,6 @@ module(basename(__filename), function () {
 
           localPrerenderer = new Prerenderer({
             maxPages: 1,
-            silent: true,
             serverURL: 'http://127.0.0.1:4225',
           });
 
@@ -2077,7 +2075,6 @@ module(basename(__filename), function () {
 
         prerenderer = new Prerenderer({
           maxPages: 1,
-          silent: true,
           serverURL: 'http://127.0.0.1:4225',
         });
 
@@ -2175,7 +2172,6 @@ module(basename(__filename), function () {
 
         prerenderer = new Prerenderer({
           maxPages: 1,
-          silent: true,
           serverURL: 'http://127.0.0.1:4225',
         });
 

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -45,6 +45,9 @@ function makeStubPagePool(maxPages: number) {
             removeAllListeners() {
               return;
             },
+            on() {
+              return;
+            },
           } as any;
         },
         async close() {
@@ -72,7 +75,7 @@ function makeStubPagePool(maxPages: number) {
   return { pool, contextsCreated, contextsClosed };
 }
 
-module(basename(__filename), function () {
+module.only(basename(__filename), function () {
   module('prerender - dynamic tests', function (hooks) {
     let realmURL = 'http://127.0.0.1:4450/';
     let prerenderServerURL = realmURL.endsWith('/')

--- a/packages/realm-server/tests/types-endpoint-test.ts
+++ b/packages/realm-server/tests/types-endpoint-test.ts
@@ -156,7 +156,7 @@ module(basename(__filename), function () {
           id: `${testRealm.url}friend/Friend`,
           attributes: {
             displayName: 'Friend',
-            total: 3,
+            total: 2,
             iconHTML,
           },
         },

--- a/packages/realm-server/tests/types-endpoint-test.ts
+++ b/packages/realm-server/tests/types-endpoint-test.ts
@@ -156,7 +156,7 @@ module(basename(__filename), function () {
           id: `${testRealm.url}friend/Friend`,
           attributes: {
             displayName: 'Friend',
-            total: 2,
+            total: 3,
             iconHTML,
           },
         },


### PR DESCRIPTION
This PR adds a specific log channel `prerenderer-chrome` that we can use for logging chrome logs in puppeteer during indexing. This removes the need to have a `PRERENDER_SILENT` env var.