### PR TITLE
Add FileDef default edit format

### DIFF
--- a/packages/base/file-api.gts
+++ b/packages/base/file-api.gts
@@ -20,7 +20,7 @@ class Edit extends Component<typeof FileDef> {
   <template>
     <div class='filedef-edit-unavailable' data-test-filedef-edit-unavailable>
       This file
-      {{if (concat '(' @model.id ')') ''}}
+      {{if @model.id (concat ' (' @model.id ')')}}
       is not editable via this interface. Replace it via file upload.
     </div>
     <style scoped>

--- a/packages/base/file-api.gts
+++ b/packages/base/file-api.gts
@@ -1,8 +1,10 @@
+import { concat } from '@ember/helper';
 import FileIcon from '@cardstack/boxel-icons/file';
 import {
   BaseDef,
   BaseDefComponent,
   Component,
+  ReadOnlyField,
   StringField,
   contains,
   field,
@@ -11,6 +13,26 @@ import {
 class View extends Component<typeof FileDef> {
   <template>
     {{@model.name}}
+  </template>
+}
+
+class Edit extends Component<typeof FileDef> {
+  <template>
+    <div class='filedef-edit-unavailable' data-test-filedef-edit-unavailable>
+      This file
+      {{if (concat '(' @model.id ')') ''}}
+      is not editable via this interface. Replace it via file upload.
+    </div>
+    <style scoped>
+      .filedef-edit-unavailable {
+        background: var(--boxel-light);
+        border: 1px solid var(--boxel-200);
+        border-radius: var(--boxel-radius-sm);
+        color: var(--boxel-700);
+        font-size: var(--boxel-font-sm);
+        padding: var(--boxel-sp-md);
+      }
+    </style>
   </template>
 }
 
@@ -26,6 +48,7 @@ export class FileDef extends BaseDef {
   static displayName = 'File';
   static icon = FileIcon;
 
+  @field id = contains(ReadOnlyField);
   @field sourceUrl = contains(StringField);
   @field url = contains(StringField);
   @field name = contains(StringField);
@@ -36,6 +59,7 @@ export class FileDef extends BaseDef {
   static fitted: BaseDefComponent = View;
   static isolated: BaseDefComponent = View;
   static atom: BaseDefComponent = View;
+  static edit: BaseDefComponent = Edit;
 
   serialize() {
     return {

--- a/packages/host/tests/helpers/base-realm.ts
+++ b/packages/host/tests/helpers/base-realm.ts
@@ -13,6 +13,7 @@ import type * as DatetimeFieldModule from 'https://cardstack.com/base/datetime';
 import type * as EmailFieldModule from 'https://cardstack.com/base/email';
 import type * as EnumModule from 'https://cardstack.com/base/enum';
 import type * as EthereumAddressModule from 'https://cardstack.com/base/ethereum-address';
+import type * as FileApiModule from 'https://cardstack.com/base/file-api';
 import type * as MarkdownFieldModule from 'https://cardstack.com/base/markdown';
 import type * as NumberFieldModule from 'https://cardstack.com/base/number';
 import type * as PhoneNumberFieldModule from 'https://cardstack.com/base/phone-number';
@@ -78,6 +79,9 @@ let ModelConfiguration: ModelConfiguration;
 
 type SystemCard = (typeof SystemCardModule)['SystemCard'];
 let SystemCard: SystemCard;
+
+type FileDef = (typeof FileApiModule)['FileDef'];
+let FileDef: FileDef;
 
 let cardAPI: typeof CardAPIModule;
 let field: (typeof CardAPIModule)['field'];
@@ -194,6 +198,10 @@ async function initialize() {
     await loader.import<typeof SystemCardModule>(`${baseRealm.url}system-card`)
   ).SystemCard;
 
+  FileDef = (
+    await loader.import<typeof FileApiModule>(`${baseRealm.url}file-api`)
+  ).FileDef;
+
   cardAPI = await loader.import<typeof CardAPIModule>(
     `${baseRealm.url}card-api`,
   );
@@ -260,6 +268,7 @@ export {
   CardsGrid,
   SystemCard,
   ModelConfiguration,
+  FileDef,
   field,
   CardDef,
   Component,

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -64,6 +64,7 @@ import {
   EthereumAddressField,
   field,
   FieldDef,
+  FileDef,
   flushLogs,
   getFieldDescription,
   getQueryableValue,
@@ -3303,6 +3304,23 @@ module('Integration | card-basics', function (hooks) {
       assert
         .dom('[data-test-field="author"] [data-test-field="firstName"] input')
         .hasValue('Carl Stack');
+    });
+
+    test('render FileDef edit template as unavailable', async function (assert) {
+      let fileDef = new FileDef({
+        sourceUrl: 'https://example.com/file.txt',
+        url: 'https://example.com/file.txt',
+        name: 'file.txt',
+        contentType: 'text/plain',
+      });
+
+      await renderCard(loader, fileDef, 'edit');
+
+      assert
+        .dom('[data-test-filedef-edit-unavailable]')
+        .hasText(
+          'This file is not editable via this interface. Replace it via file upload.',
+        );
     });
 
     test('renders field name for boolean default view values', async function (assert) {


### PR DESCRIPTION
## Summary
- add a default edit format component for FileDef that shows a read-only message
- add an integration test to assert the edit template is rendered