### PR TITLE
Fix canonical path headers for nested modules

### DIFF
--- a/packages/catalog-realm/catalog-app/catalog.gts
+++ b/packages/catalog-realm/catalog-app/catalog.gts
@@ -108,15 +108,7 @@ class Isolated extends Component<typeof Catalog> {
     return {
       filter: {
         on: {
-          // the published module URL looks like:
-          //   https://<realm>/catalog-app/catalog
-          // So when we run:
-          //   new URL('../listing/listing', import.meta.url)
-          // the browser-style URL resolver goes “one level up”
-          // from …/catalog-app/catalog to …/catalog-app/,
-          // then appends listing/listing. We end up with:
-          //   https://<realm>/catalog-app/listing/listing
-          module: new URL('../listing/listing', import.meta.url).href,
+          module: new URL('./listing/listing', import.meta.url).href,
           name:
             this.activeTabId === 'showcase'
               ? 'Listing'
@@ -136,7 +128,7 @@ class Isolated extends Component<typeof Catalog> {
     return {
       filter: {
         type: {
-          module: new URL('../listing/category', import.meta.url).href,
+          module: new URL('./listing/category', import.meta.url).href,
           name: 'Category',
         },
       },
@@ -277,7 +269,7 @@ class Isolated extends Component<typeof Catalog> {
     return {
       filter: {
         type: {
-          module: new URL('../listing/tag', import.meta.url).href,
+          module: new URL('./listing/tag', import.meta.url).href,
           name: 'Tag',
         },
       },

--- a/packages/realm-server/tests/cards/nested/example.js
+++ b/packages/realm-server/tests/cards/nested/example.js
@@ -1,0 +1,1 @@
+export const value = 'canonical-path';

--- a/packages/realm-server/tests/realm-endpoints-test.ts
+++ b/packages/realm-server/tests/realm-endpoints-test.ts
@@ -200,6 +200,27 @@ module(basename(__filename), function () {
       );
     });
 
+    test('sets canonical path header for nested module requests', async function (assert) {
+      let response = await request
+        .get(`/nested/example`)
+        .set('Accept', SupportedMimeType.All)
+        .set(
+          'Authorization',
+          `Bearer ${createJWT(testRealm, 'user', ['read', 'write'])}`,
+        );
+
+      assert.strictEqual(
+        response.status,
+        200,
+        'module request succeeds for nested module',
+      );
+      assert.strictEqual(
+        response.headers['x-boxel-canonical-path'],
+        `${testRealmURL}nested/example.js`,
+        'canonical path header includes full nested path with realm origin',
+      );
+    });
+
     test('can set response Cache-Control header for json api request', async function (assert) {
       let response = await request
         .get(`/_info`)
@@ -1416,6 +1437,14 @@ module(basename(__filename), function () {
                 },
                 meta: {
                   kind: 'file',
+                },
+              },
+              'nested/': {
+                links: {
+                  related: `${testRealmHref}nested/`,
+                },
+                meta: {
+                  kind: 'directory',
                 },
               },
               'person-1.json': {

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -1539,6 +1539,7 @@ export class Realm {
     }
 
     let fileRef = maybeFileRef;
+    let canonicalPath = this.paths.fileURL(fileRef.path).href;
     if (!hasExecutableExtension(fileRef.path)) {
       return {
         kind: 'non-module',
@@ -1551,7 +1552,7 @@ export class Realm {
         requestContext,
         init: {
           headers: {
-            'X-Boxel-Canonical-Path': fileRef.path,
+            'X-Boxel-Canonical-Path': canonicalPath,
           },
         },
       }) as ResponseWithNodeStream;
@@ -1569,7 +1570,7 @@ export class Realm {
       if (fileRef.lastModified != null) {
         headers['last-modified'] = formatRFC7231(fileRef.lastModified * 1000);
       }
-      headers['X-Boxel-Canonical-Path'] = fileRef.path;
+      headers['X-Boxel-Canonical-Path'] = canonicalPath;
       return {
         kind: 'not-modified',
         canonicalPath: fileRef.path,
@@ -1604,7 +1605,7 @@ export class Realm {
     if (fileRef.lastModified != null) {
       headers['last-modified'] = formatRFC7231(fileRef.lastModified * 1000);
     }
-    headers['X-Boxel-Canonical-Path'] = fileRef.path;
+    headers['X-Boxel-Canonical-Path'] = canonicalPath;
 
     return {
       kind: 'module',


### PR DESCRIPTION
Fix: our synthetic `import.meta.url` is duplicating the folder path when it is a nested folder.

Example 1
Actual file: 
<img width="667" height="57" alt="Screenshot 2025-12-26 at 6 04 18 PM" src="https://github.com/user-attachments/assets/67270d1a-b2ca-4ef3-9bf3-940670f5f5ba" />
`import.meta.url`:
(notice the extra `catalog-app`  folder)
<img width="717" height="42" alt="Screenshot 2025-12-26 at 6 04 29 PM" src="https://github.com/user-attachments/assets/9c66cf62-25fe-4f0c-a443-8cc2665a3068" />

Example 2
(notice the extra `crm-app`  folder)
<img width="1169" height="736" alt="Screenshot 2025-12-26 at 6 08 02 PM" src="https://github.com/user-attachments/assets/4647b73a-ef3e-4416-bd09-0440ce96fe58" />


Expected
After the fix, it should be the same file as the code mode URL bar