### PR TITLE
Fix: Copy search card result to workspaces

### DIFF
--- a/packages/base/card-menu-items.ts
+++ b/packages/base/card-menu-items.ts
@@ -31,18 +31,24 @@ import Wand from '@cardstack/boxel-icons/wand';
 
 const GENERATED_EXAMPLE_COUNT = 3;
 
-export interface GetCardMenuItemParams {
+type MenuContext =
+  | {
+      menuContext: 'interact' | 'code-mode-preview' | 'code-mode-playground';
+    }
+  | {
+      menuContext: 'ai-assistant';
+      menuContextParams: {
+        canEditActiveRealm: boolean;
+        activeRealmURL: string;
+      };
+    };
+
+export type GetCardMenuItemParams = {
   canEdit: boolean;
   cardCrudFunctions: Partial<CardCrudFunctions>;
-  menuContext:
-    | 'interact'
-    | 'ai-assistant'
-    | 'code-mode-preview'
-    | 'code-mode-playground';
   commandContext: CommandContext;
   format?: Format;
-  currentRealmURL?: string;
-}
+} & MenuContext;
 
 export function getDefaultCardMenuItems(
   card: CardDef,
@@ -96,7 +102,10 @@ export function getDefaultCardMenuItems(
       );
     }
   }
-  if (params.menuContext === 'ai-assistant' && params.canEdit) {
+  if (
+    params.menuContext === 'ai-assistant' &&
+    params.menuContextParams.canEditActiveRealm
+  ) {
     menuItems.push({
       label: 'Copy to Workspace',
       action: async () => {
@@ -104,7 +113,7 @@ export function getDefaultCardMenuItems(
           params.commandContext,
         ).execute({
           sourceCard: card,
-          targetRealm: params.currentRealmURL,
+          targetRealm: params.menuContextParams.activeRealmURL,
         });
 
         let showCardCommand = new ShowCardCommand(params.commandContext);

--- a/packages/base/card-menu-items.ts
+++ b/packages/base/card-menu-items.ts
@@ -41,6 +41,7 @@ export interface GetCardMenuItemParams {
     | 'code-mode-playground';
   commandContext: CommandContext;
   format?: Format;
+  currentRealmURL?: string;
 }
 
 export function getDefaultCardMenuItems(
@@ -95,7 +96,7 @@ export function getDefaultCardMenuItems(
       );
     }
   }
-  if (params.menuContext === 'ai-assistant') {
+  if (params.menuContext === 'ai-assistant' && params.canEdit) {
     menuItems.push({
       label: 'Copy to Workspace',
       action: async () => {
@@ -103,6 +104,7 @@ export function getDefaultCardMenuItems(
           params.commandContext,
         ).execute({
           sourceCard: card,
+          targetRealm: params.currentRealmURL,
         });
 
         let showCardCommand = new ShowCardCommand(params.commandContext);

--- a/packages/boxel-ui/addon/src/components/card-header/index.gts
+++ b/packages/boxel-ui/addon/src/components/card-header/index.gts
@@ -46,6 +46,10 @@ export default class CardHeader extends Component<Signature> {
   get safeMoreOptionsMenuItems() {
     return this.args.moreOptionsMenuItems || [];
   }
+
+  get hasMoreOptionsMenuItems() {
+    return this.safeMoreOptionsMenuItems.length > 0;
+  }
   <template>
     {{#let (bool @onFinishEditing) as |isEditing|}}
       <header
@@ -170,7 +174,7 @@ export default class CardHeader extends Component<Signature> {
               </:content>
             </Tooltip>
           {{/if}}
-          {{#if (bool @moreOptionsMenuItems)}}
+          {{#if this.hasMoreOptionsMenuItems}}
             <div>
               <BoxelDropdown>
                 <:trigger as |bindings|>

--- a/packages/host/app/components/matrix/room-message-command.gts
+++ b/packages/host/app/components/matrix/room-message-command.gts
@@ -159,21 +159,24 @@ export default class RoomMessageCommand extends Component<Signature> {
   private get moreOptionsMenuItems() {
     let menuItems =
       this.commandResultCard.card?.[getCardMenuItems]?.({
-        canEdit: this.canCopyToWorkspace,
+        canEdit: false,
         cardCrudFunctions: {},
         menuContext: 'ai-assistant',
+        menuContextParams: {
+          activeRealmURL: this.activeRealmURL,
+          canEditActiveRealm: this.canEditActiveRealm,
+        },
         commandContext: this.commandService.commandContext,
-        currentRealmURL: this.currentRealmURL,
       }) ?? [];
     return toMenuItems(menuItems);
   }
 
-  private get canCopyToWorkspace() {
-    let currentRealmURL = this.currentRealmURL;
-    return currentRealmURL ? this.realm.canWrite(currentRealmURL) : false;
+  private get canEditActiveRealm() {
+    let activeRealmURL = this.activeRealmURL;
+    return activeRealmURL ? this.realm.canWrite(activeRealmURL) : false;
   }
 
-  private get currentRealmURL() {
+  private get activeRealmURL() {
     return this.operatorModeStateService.realmURL?.href;
   }
 

--- a/packages/host/app/components/matrix/room-message-command.gts
+++ b/packages/host/app/components/matrix/room-message-command.gts
@@ -33,6 +33,7 @@ import type CommandService from '@cardstack/host/services/command-service';
 import type MatrixService from '@cardstack/host/services/matrix-service';
 
 import type { MonacoSDK } from '@cardstack/host/services/monaco-service';
+import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 import type RealmService from '@cardstack/host/services/realm';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
@@ -60,6 +61,7 @@ export default class RoomMessageCommand extends Component<Signature> {
   @service private declare commandService: CommandService;
   @service private declare matrixService: MatrixService;
   @service private declare realm: RealmService;
+  @service private declare operatorModeStateService: OperatorModeStateService;
 
   private get previewCommandCode() {
     let { name, arguments: payload } = this.args.messageCommand;
@@ -157,12 +159,22 @@ export default class RoomMessageCommand extends Component<Signature> {
   private get moreOptionsMenuItems() {
     let menuItems =
       this.commandResultCard.card?.[getCardMenuItems]?.({
-        canEdit: false,
+        canEdit: this.canCopyToWorkspace,
         cardCrudFunctions: {},
         menuContext: 'ai-assistant',
         commandContext: this.commandService.commandContext,
+        currentRealmURL: this.currentRealmURL,
       }) ?? [];
     return toMenuItems(menuItems);
+  }
+
+  private get canCopyToWorkspace() {
+    let currentRealmURL = this.currentRealmURL;
+    return currentRealmURL ? this.realm.canWrite(currentRealmURL) : false;
+  }
+
+  private get currentRealmURL() {
+    return this.operatorModeStateService.realmURL?.href;
   }
 
   private get commandResultCardForRendering(): CardDef {

--- a/packages/host/tests/integration/components/ai-assistant-panel/commands-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/commands-test.gts
@@ -49,6 +49,8 @@ import { setupRenderingTest } from '../../../helpers/setup';
 
 module('Integration | ai-assistant-panel | commands', function (hooks) {
   const realmName = 'Operator Mode Workspace';
+  const readOnlyRealmName = 'Read Only Workspace';
+  const readOnlyRealmURL = 'http://test-realm/read-only/';
   let loader: Loader;
   let operatorModeStateService: OperatorModeStateService;
 
@@ -69,7 +71,11 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
 
   let mockMatrixUtils = setupMockMatrix(hooks, {
     loggedInAs: '@testuser:localhost',
-    activeRealms: [testRealmURL],
+    activeRealms: [testRealmURL, readOnlyRealmURL],
+    realmPermissions: {
+      [testRealmURL]: ['read', 'write'],
+      [readOnlyRealmURL]: ['read'],
+    },
     autostart: true,
     now: (() => {
       // deterministic clock so that, for example, screenshots
@@ -196,6 +202,68 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
         'Person/buck.json': new Person({ firstName: 'Buck' }),
         'Person/hassan.json': new Person({ firstName: 'Hassan' }),
         '.realm.json': `{ "name": "${realmName}" }`,
+      },
+    });
+
+    await setupIntegrationTestRealm({
+      mockMatrixUtils,
+      realmURL: readOnlyRealmURL,
+      contents: {
+        'pet.gts': `
+          import { contains, field, CardDef } from "https://cardstack.com/base/card-api";
+          import StringField from "https://cardstack.com/base/string";
+          export class Pet extends CardDef {
+            static displayName = 'Pet';
+            @field name = contains(StringField);
+          }
+        `,
+        'person.gts': `
+          import { contains, field, linksTo, CardDef } from "https://cardstack.com/base/card-api";
+          import StringField from "https://cardstack.com/base/string";
+          import { Pet } from "./pet";
+          export class Person extends CardDef {
+            static displayName = 'Person';
+            @field firstName = contains(StringField);
+            @field pet = linksTo(Pet);
+          }
+        `,
+        'Person/ian.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              firstName: 'Ian',
+            },
+            relationships: {
+              pet: {
+                data: {
+                  type: 'card',
+                  id: `${readOnlyRealmURL}Pet/rose`,
+                },
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: './person',
+                name: 'Person',
+              },
+            },
+          },
+        },
+        'Pet/rose.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              name: 'Rose',
+            },
+            meta: {
+              adoptsFrom: {
+                module: './pet',
+                name: 'Pet',
+              },
+            },
+          },
+        },
+        '.realm.json': `{ "name": "${readOnlyRealmName}" }`,
       },
     });
   });
@@ -877,6 +945,88 @@ module('Integration | ai-assistant-panel | commands', function (hooks) {
     assert.dom(`${resultListItem}:nth-child(1)`).containsText('Buck');
     assert.dom(`${resultListItem}:nth-child(6)`).containsText('Justin');
     assert.dom(`${resultListItem}:nth-child(8)`).containsText('Mickey');
+  });
+
+  test('copy to workspace menu item is shown for writable realm', async function (assert) {
+    const id = `${testRealmURL}Person/fadhlan`;
+    const roomId = await renderAiAssistantPanel(`${id}.json`);
+    const toolArgs = {
+      description: 'Search for Person cards',
+      attributes: {
+        type: {
+          module: `${testRealmURL}person`,
+          name: 'Person',
+        },
+      },
+    };
+
+    simulateRemoteMessage(roomId, '@aibot:localhost', {
+      msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+      body: 'Search for the following card',
+      format: 'org.matrix.custom.html',
+      isStreamingFinished: true,
+      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+        {
+          id: '9a5b7422-87de-4a93-9f07-9b7c40b75b1e',
+          name: 'SearchCardsByTypeAndTitleCommand_a959',
+          arguments: JSON.stringify(toolArgs),
+        },
+      ],
+      data: {
+        context: {
+          agentId: getService('matrix-service').agentId,
+        },
+      },
+    });
+    await settled();
+
+    await click(
+      '[data-test-command-result-container] [data-test-more-options-button]',
+    );
+    assert.dom('[data-test-boxel-menu-item-text="Copy to Workspace"]').exists();
+  });
+
+  test('copy to workspace menu item is hidden for read-only realm', async function (assert) {
+    const id = `${readOnlyRealmURL}Person/ian`;
+    const roomId = await renderAiAssistantPanel(`${id}.json`);
+    const toolArgs = {
+      description: 'Search for Person cards',
+      attributes: {
+        type: {
+          module: `${testRealmURL}person`,
+          name: 'Person',
+        },
+      },
+    };
+
+    simulateRemoteMessage(roomId, '@aibot:localhost', {
+      msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+      body: 'Search for the following card',
+      format: 'org.matrix.custom.html',
+      isStreamingFinished: true,
+      [APP_BOXEL_COMMAND_REQUESTS_KEY]: [
+        {
+          id: '6c6e2d73-8e09-4b44-a0d9-688f36b73be8',
+          name: 'SearchCardsByTypeAndTitleCommand_a959',
+          arguments: JSON.stringify(toolArgs),
+        },
+      ],
+      data: {
+        context: {
+          agentId: getService('matrix-service').agentId,
+        },
+      },
+    });
+    await settled();
+
+    assert
+      .dom(
+        '[data-test-command-result-container] [data-test-more-options-button]',
+      )
+      .doesNotExist();
+    assert
+      .dom('[data-test-boxel-menu-item-text="Copy to Workspace"]')
+      .doesNotExist();
   });
 
   test('it can copy search results card to workspace (no cards in stack)', async function (assert) {

--- a/packages/host/tests/unit/card-menu-items-test.ts
+++ b/packages/host/tests/unit/card-menu-items-test.ts
@@ -3,7 +3,11 @@ import { module, test } from 'qunit';
 
 import type { MenuItemOptions } from '@cardstack/boxel-ui/helpers';
 
-import { baseRealm, type Loader } from '@cardstack/runtime-common';
+import {
+  baseRealm,
+  testRealmURL,
+  type Loader,
+} from '@cardstack/runtime-common';
 
 import type {
   CardDef,
@@ -63,9 +67,13 @@ module('Unit | card-menu-items', function (hooks) {
       'Two',
     ) as unknown as CardDef;
     let items = getDefaultCardMenuItems(card, {
-      canEdit: true,
+      canEdit: false,
       cardCrudFunctions: {},
       menuContext: 'ai-assistant',
+      menuContextParams: {
+        canEditActiveRealm: true,
+        activeRealmURL: testRealmURL,
+      },
       commandContext: {} as any,
     });
 
@@ -85,6 +93,10 @@ module('Unit | card-menu-items', function (hooks) {
       canEdit: false,
       cardCrudFunctions: {},
       menuContext: 'ai-assistant',
+      menuContextParams: {
+        canEditActiveRealm: false,
+        activeRealmURL: testRealmURL,
+      },
       commandContext: {} as any,
     });
 
@@ -128,7 +140,7 @@ module('Unit | card-menu-items', function (hooks) {
       'Four',
     ) as unknown as CardDef;
     let items = getDefaultCardMenuItems(card, {
-      canEdit: false,
+      canEdit: true,
       cardCrudFunctions: {},
       menuContext: 'code-mode-preview',
       commandContext: {} as any,

--- a/packages/host/tests/unit/card-menu-items-test.ts
+++ b/packages/host/tests/unit/card-menu-items-test.ts
@@ -57,7 +57,26 @@ module('Unit | card-menu-items', function (hooks) {
     assert.ok(texts.includes('Delete'), 'contains Delete');
   });
 
-  test('ai-assistant context contains Copy to Workspace', function (assert: Assert) {
+  test('ai-assistant context contains Copy to Workspace when editable', function (assert: Assert) {
+    let card = new DummyCard(
+      'https://example.com/realm/card-2',
+      'Two',
+    ) as unknown as CardDef;
+    let items = getDefaultCardMenuItems(card, {
+      canEdit: true,
+      cardCrudFunctions: {},
+      menuContext: 'ai-assistant',
+      commandContext: {} as any,
+    });
+
+    let texts = items.map((i: MenuItemOptions) => i.label);
+    assert.ok(
+      texts.includes('Copy to Workspace'),
+      'contains Copy to Workspace',
+    );
+  });
+
+  test('ai-assistant context omits Copy to Workspace when not editable', function (assert: Assert) {
     let card = new DummyCard(
       'https://example.com/realm/card-2',
       'Two',
@@ -70,9 +89,9 @@ module('Unit | card-menu-items', function (hooks) {
     });
 
     let texts = items.map((i: MenuItemOptions) => i.label);
-    assert.ok(
+    assert.notOk(
       texts.includes('Copy to Workspace'),
-      'contains Copy to Workspace',
+      'does not include Copy to Workspace',
     );
   });
 


### PR DESCRIPTION
This PR fixes a bug where the "Copy to workspace" menu item in the search card results fails to function. This occurs because the copy action requires write permissions, yet the menu item was being displayed for all users. This fix adds a permission check and ensures the correct realm URL is retrieved from the `OperatorModeStateService`.



https://github.com/user-attachments/assets/56bfccac-b1fa-4484-bdff-cc6d8d2ce63c

