### PR TITLE
add catalog subpackage scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,11 @@ Instead of running `pnpm start:base`, you can alternatively use `pnpm start:all`
 
 #### Using `start:development`
 
-You can also use `start:development` if you want the functionality of `start:all`, but without running the test realms. `start:development` will enable you to open http://localhost:4201 and allow to select between the cards in the /base and /experiments realm. In order to use `start:development` you must also make sure to run `start:worker-development` in order to start the workers (which are normally started in `start:all`.
+You can also use `start:development` if you want the functionality of `start:all`, but without running the test realms. `start:development` will enable you to open http://localhost:4201 and allow to select between the cards in the /base and /experiments realm. In order to use `start:development` you must also make sure to run `start:worker-development` in order to start the workers which are normally started in `start:all`.
+
+Optional environment variables for `start:development`:
+
+- `USE_EXTERNAL_CATALOG=1` to load `/catalog` from `packages/catalog/contents` (cloned from the `boxel-catalog` repo). 
 
 ### Card Pre-rendering
 

--- a/packages/catalog/.gitignore
+++ b/packages/catalog/.gitignore
@@ -1,0 +1,1 @@
+contents/

--- a/packages/catalog/.gitignore
+++ b/packages/catalog/.gitignore
@@ -1,1 +1,1 @@
-contents/
+contents

--- a/packages/catalog/README.md
+++ b/packages/catalog/README.md
@@ -1,0 +1,86 @@
+# Catalog Realm
+
+The Catalog Realm is a specialized realm in the Boxel system that hosts the catalog content. The catalog content is maintained in a separate repository ([boxel-catalog](https://github.com/cardstack/boxel-catalog)) to enable independent versioning and deployment.
+
+## Architecture
+
+- **Catalog Source**: Content is stored in the [boxel-catalog](https://github.com/cardstack/boxel-catalog) repository
+- **Local Development**: Catalog content is cloned into `packages/catalog/contents/` for local editing
+- **Deployment Pipeline**: Changes flow from local development -> boxel-catalog repo -> staging -> production
+
+## Setup
+
+### Prerequisites
+
+Make sure you have completed the standard Boxel setup as described in the [main README](../../README.md), including:
+
+- Matrix server running
+- Postgres database
+- Host app and realm server
+
+### Initial Catalog Setup
+
+If you have started from scratch these should have been automatically run for you, but they are safe to run again.
+
+1. **Clone the catalog repository** (run this when you need a local copy):
+
+   ```bash
+   cd packages/catalog
+   pnpm catalog:setup
+   ```
+
+## Catalog Management Scripts
+
+The catalog realm package includes helper scripts for managing the catalog repository:
+
+| Script                | Description                                                               |
+| --------------------- | ------------------------------------------------------------------------- |
+| `pnpm catalog:setup`  | Clones the boxel-catalog repository into `contents/` if it doesn't exist  |
+| `pnpm catalog:update` | Pulls latest changes from the boxel-catalog repository                    |
+| `pnpm catalog:reset`  | Removes the `contents/` directory and re-clones the repository            |
+
+## Development Workflows
+
+### Local Catalog Development
+
+This workflow is ideal for rapid iteration and testing of catalog content:
+
+1. **Edit catalog content locally**
+
+   - Changes are saved to `packages/catalog/contents/`
+
+2. **Commit and push** when satisfied:
+
+   ```bash
+   cd packages/catalog/contents
+   git checkout -b your-feature-branch
+   git add .
+   git commit -m "Update catalog content"
+   git push origin your-feature-branch
+   ```
+
+3. **Create a Pull Request** in the [boxel-catalog](https://github.com/cardstack/boxel-catalog) repository
+
+4. **Deploy to staging** happens automatically when the PR is merged
+
+5. **Tag the commit** to release to production
+
+## Deployment Pipeline
+
+1. **Development**: Edit catalog content locally or remotely
+2. **Pull Request**: Submit changes to boxel-catalog repository
+3. **Review**: Code review process in GitHub
+4. **Merge**: Changes automatically deployed to staging
+5. **Tag**: Create a git tag to trigger production deployment
+
+## Troubleshooting
+
+### Catalog not appearing after changes
+
+- Ensure the realm server is running (`pnpm start:all` in `packages/realm-server`)
+- Verify the `contents/` directory exists and has the latest catalog content
+
+### Catalog repository out of sync
+
+- Run `pnpm catalog:update` to pull latest changes
+- For a complete reset: `pnpm catalog:reset`

--- a/packages/catalog/README.md
+++ b/packages/catalog/README.md
@@ -6,7 +6,7 @@ The Catalog Realm is a specialized realm in the Boxel system that hosts the cata
 
 - **Catalog Source**: Content is stored in the [boxel-catalog](https://github.com/cardstack/boxel-catalog) repository
 - **Local Development**: Catalog content is cloned into `packages/catalog/contents/` for local editing
-- **Deployment Pipeline**: Changes flow from local development -> boxel-catalog repo -> staging -> production
+- **Deployment Pipeline**: Changes flow from local development → boxel-catalog repo → staging → production
 
 ## Setup
 

--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@cardstack/catalog",
+  "version": "1.0.0",
+  "license": "MIT",
+  "scripts": {
+    "catalog:setup": "[ -d contents ] || (git clone git@github.com:cardstack/boxel-catalog.git contents || git clone https://github.com/cardstack/boxel-catalog.git contents)",
+    "catalog:update": "pnpm catalog:setup && cd contents && git pull",
+    "catalog:reset": "rm -rf contents && pnpm catalog:setup"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/packages/realm-server/scripts/start-development.sh
+++ b/packages/realm-server/scripts/start-development.sh
@@ -15,6 +15,13 @@ START_EXPERIMENTS=$(if [ -z "$SKIP_EXPERIMENTS" ]; then echo "true"; else echo "
 
 DEFAULT_CATALOG_REALM_URL='http://localhost:4201/catalog/'
 CATALOG_REALM_URL="${RESOLVED_CATALOG_REALM_URL:-$DEFAULT_CATALOG_REALM_URL}"
+CATALOG_REALM_PATH='../catalog-realm'
+
+if [ -n "$USE_EXTERNAL_CATALOG" ]; then
+  pnpm --dir=../catalog catalog:setup
+  pnpm --dir=../catalog catalog:update
+  CATALOG_REALM_PATH='../catalog/contents'
+fi
 
 PRERENDER_URL="${PRERENDER_URL:-http://localhost:4221}"
 
@@ -44,7 +51,7 @@ NODE_ENV=development \
   --fromUrl='https://cardstack.com/base/' \
   --toUrl='http://localhost:4201/base/' \
   \
-  --path='../catalog-realm' \
+  --path="${CATALOG_REALM_PATH}" \
   --username='catalog_realm' \
   --fromUrl="${CATALOG_REALM_URL}" \
   --toUrl="${CATALOG_REALM_URL}" \

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1883,6 +1883,8 @@ importers:
         specifier: 'catalog:'
         version: 5.99.6
 
+  packages/catalog: {}
+
   packages/catalog-realm:
     dependencies:
       ember-modify-based-class-resource:


### PR DESCRIPTION
- copies boxel-skills patterns for cloning 
- introduce new folder `/catalog`. Leave `catalog-realm` folder there for now until feature flag is removed