### PR TITLE
Add text file option to Code Mode New menu

### DIFF
--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -691,7 +691,9 @@ export default class CreateFileModal extends Component<Signature> {
 
   private get isCreateTextFileButtonDisabled() {
     return (
-      !this.selectedRealmURL || !this.fileName || this.createTextFile.isRunning
+      !this.selectedRealmURL ||
+      !this.fileName?.trim() ||
+      this.createTextFile.isRunning
     );
   }
 

--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -22,7 +22,7 @@ import {
   Pill,
   RealmIcon,
 } from '@cardstack/boxel-ui/components';
-import { not, eq, or } from '@cardstack/boxel-ui/helpers';
+import { not, eq, or, and } from '@cardstack/boxel-ui/helpers';
 import {
   type Icon,
   CardDefinition,
@@ -172,10 +172,10 @@ export default class CreateFileModal extends Component<Signature> {
                     @onSelect={{this.onSelectRealm}}
                   />
                 </FieldContainer>
-                {{#unless
-                  (or
-                    (eq this.fileType.id 'duplicate-instance')
-                    (eq this.fileType.id 'text-file')
+                {{#if
+                  (and
+                    (not (eq this.fileType.id 'duplicate-instance'))
+                    (not (eq this.fileType.id 'text-file'))
                   )
                 }}
                   <FieldContainer
@@ -208,13 +208,9 @@ export default class CreateFileModal extends Component<Signature> {
                       {{/if}}
                     </div>
                   </FieldContainer>
-                {{/unless}}
+                {{/if}}
                 {{#if (eq this.fileType.id 'text-file')}}
-                  <FieldContainer
-                    @label='File Name'
-                    @tag='label'
-                    class='field'
-                  >
+                  <FieldContainer @label='File Name' @tag='label' class='field'>
                     <BoxelInput
                       data-test-text-file-name-field
                       placeholder='notes'
@@ -224,11 +220,7 @@ export default class CreateFileModal extends Component<Signature> {
                       @onInput={{this.setFileName}}
                     />
                   </FieldContainer>
-                  <FieldContainer
-                    @label='Extension'
-                    @tag='label'
-                    class='field'
-                  >
+                  <FieldContainer @label='Extension' @tag='label' class='field'>
                     <BoxelSelect
                       @options={{this.textFileExtensionOptions}}
                       @selected={{this.selectedTextFileExtension}}
@@ -699,9 +691,7 @@ export default class CreateFileModal extends Component<Signature> {
 
   private get isCreateTextFileButtonDisabled() {
     return (
-      !this.selectedRealmURL ||
-      !this.fileName ||
-      this.createTextFile.isRunning
+      !this.selectedRealmURL || !this.fileName || this.createTextFile.isRunning
     );
   }
 

--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -17,6 +17,7 @@ import {
   FieldContainer,
   Button,
   BoxelInput,
+  BoxelSelect,
   LoadingIndicator,
   Pill,
   RealmIcon,
@@ -26,6 +27,7 @@ import {
   type Icon,
   CardDefinition,
   CardInstance,
+  File,
   Field,
 } from '@cardstack/boxel-ui/icons';
 
@@ -75,6 +77,7 @@ export type NewFileType =
   | 'card-instance'
   | 'card-definition'
   | 'field-definition'
+  | 'text-file'
   | 'spec-instance';
 
 export const newFileTypes: {
@@ -105,12 +108,25 @@ export const newFileTypes: {
     description: 'For storing data or content',
     extension: '.json',
   },
+  {
+    id: 'text-file',
+    icon: File,
+    description: 'For plain text or markdown',
+    extension: '.txt/.md',
+  },
   { id: 'spec-instance', extension: '.json' },
 ];
 
 export interface FileType {
   id: NewFileType;
   displayName: string;
+}
+
+const TEXT_FILE_EXTENSIONS = ['.txt', '.md'];
+
+function textFileExtensionFromInput(input: string) {
+  let lower = input.toLowerCase();
+  return TEXT_FILE_EXTENSIONS.find((extension) => lower.endsWith(extension));
 }
 
 interface Signature {
@@ -156,7 +172,12 @@ export default class CreateFileModal extends Component<Signature> {
                     @onSelect={{this.onSelectRealm}}
                   />
                 </FieldContainer>
-                {{#unless (eq this.fileType.id 'duplicate-instance')}}
+                {{#unless
+                  (or
+                    (eq this.fileType.id 'duplicate-instance')
+                    (eq this.fileType.id 'text-file')
+                  )
+                }}
                   <FieldContainer
                     @label={{this.refLabel}}
                     class='field'
@@ -188,6 +209,42 @@ export default class CreateFileModal extends Component<Signature> {
                     </div>
                   </FieldContainer>
                 {{/unless}}
+                {{#if (eq this.fileType.id 'text-file')}}
+                  <FieldContainer
+                    @label='File Name'
+                    @tag='label'
+                    class='field'
+                  >
+                    <BoxelInput
+                      data-test-text-file-name-field
+                      placeholder='notes'
+                      @value={{this.fileName}}
+                      @state={{this.fileNameInputState}}
+                      @errorMessage={{this.fileNameError}}
+                      @onInput={{this.setFileName}}
+                    />
+                  </FieldContainer>
+                  <FieldContainer
+                    @label='Extension'
+                    @tag='label'
+                    class='field'
+                  >
+                    <BoxelSelect
+                      @options={{this.textFileExtensionOptions}}
+                      @selected={{this.selectedTextFileExtension}}
+                      @onChange={{this.handleTextFileExtensionChange}}
+                      @searchEnabled={{false}}
+                      @matchTriggerWidth={{true}}
+                      @renderInPlace={{true}}
+                      data-test-text-file-extension-select
+                      as |option|
+                    >
+                      <span data-test-text-file-extension-option={{option}}>
+                        {{option}}
+                      </span>
+                    </BoxelSelect>
+                  </FieldContainer>
+                {{/if}}
                 {{#if
                   (or
                     (eq this.fileType.id 'card-definition')
@@ -293,6 +350,18 @@ export default class CreateFileModal extends Component<Signature> {
                     >
                       Create
                     </Button>
+                  {{else if (eq this.fileType.id 'text-file')}}
+                    <Button
+                      @kind='primary'
+                      @size='tall'
+                      @loading={{this.createTextFile.isRunning}}
+                      @disabled={{this.isCreateTextFileButtonDisabled}}
+                      {{on 'click' (perform this.createTextFile)}}
+                      {{onKeyMod 'Enter'}}
+                      data-test-create-text-file
+                    >
+                      Create
+                    </Button>
                   {{/if}}
                 </div>
               {{/if}}
@@ -386,6 +455,7 @@ export default class CreateFileModal extends Component<Signature> {
   @tracked private fileName = '';
   @tracked private hasUserEditedFileName = false;
   @tracked private fileNameError: string | undefined;
+  @tracked private selectedTextFileExtension = '.txt';
   @tracked private saveError: CardErrorJSONAPI | undefined;
   @tracked private currentRequest:
     | {
@@ -438,9 +508,13 @@ export default class CreateFileModal extends Component<Signature> {
   }
 
   private get isReady() {
-    return this.definitionClass
-      ? true
-      : Boolean(this.defaultSpecResource?.isLoaded);
+    if (this.definitionClass) {
+      return true;
+    }
+    if (this.maybeFileType?.id === 'text-file') {
+      return true;
+    }
+    return Boolean(this.defaultSpecResource?.isLoaded);
   }
 
   private get selectedSpecResource() {
@@ -466,14 +540,16 @@ export default class CreateFileModal extends Component<Signature> {
         sourceInstance,
       };
       if (!this.definitionClass) {
-        let specEntryPath =
-          this.fileType.id === 'field-definition'
-            ? 'fields/field'
-            : 'types/card';
-        this.defaultSpecResource = this.getCard(
-          this,
-          () => `${baseRealm.url}${specEntryPath}`,
-        );
+        if (this.fileType.id !== 'text-file') {
+          let specEntryPath =
+            this.fileType.id === 'field-definition'
+              ? 'fields/field'
+              : 'types/card';
+          this.defaultSpecResource = this.getCard(
+            this,
+            () => `${baseRealm.url}${specEntryPath}`,
+          );
+        }
       }
       let url = await this.currentRequest.newFileDeferred.promise;
       this.clearState();
@@ -489,6 +565,7 @@ export default class CreateFileModal extends Component<Signature> {
     this.displayName = '';
     this.fileName = '';
     this.hasUserEditedFileName = false;
+    this.selectedTextFileExtension = '.txt';
     this.clearSaveError();
   }
 
@@ -536,7 +613,21 @@ export default class CreateFileModal extends Component<Signature> {
     this.hasUserEditedFileName = true;
     this.clearSaveError();
     this.fileNameError = undefined;
+    if (this.fileType.id === 'text-file') {
+      let extension = textFileExtensionFromInput(name);
+      if (extension) {
+        this.selectedTextFileExtension = extension;
+        this.fileName = name.slice(0, -extension.length);
+        return;
+      }
+    }
     this.fileName = name;
+  }
+
+  @action private handleTextFileExtensionChange(extension: string) {
+    this.clearSaveError();
+    this.fileNameError = undefined;
+    this.selectedTextFileExtension = extension;
   }
 
   private get initialFocusSelector() {
@@ -546,6 +637,8 @@ export default class CreateFileModal extends Component<Signature> {
       case 'field-definition':
       case 'duplicate-instance':
         return '.create-file-modal .realm-dropdown-trigger';
+      case 'text-file':
+        return '.create-file-modal [data-test-text-file-name-field]';
       default:
         return false;
     }
@@ -604,8 +697,36 @@ export default class CreateFileModal extends Component<Signature> {
     );
   }
 
+  private get isCreateTextFileButtonDisabled() {
+    return (
+      !this.selectedRealmURL ||
+      !this.fileName ||
+      this.createTextFile.isRunning
+    );
+  }
+
   private get isCreateRunning() {
-    return this.createCardInstance.isRunning || this.createDefinition.isRunning;
+    return (
+      this.createCardInstance.isRunning ||
+      this.createDefinition.isRunning ||
+      this.createTextFile.isRunning
+    );
+  }
+
+  private get textFileExtensionOptions() {
+    return TEXT_FILE_EXTENSIONS;
+  }
+
+  private getTextFileNameForSave() {
+    let trimmed = this.fileName.trim().replace(/^\//, '');
+    if (!trimmed) {
+      return undefined;
+    }
+    let extension = textFileExtensionFromInput(trimmed);
+    if (extension) {
+      return trimmed;
+    }
+    return `${trimmed}${this.selectedTextFileExtension}`;
   }
 
   private chooseType = restartableTask(async () => {
@@ -816,6 +937,51 @@ export class ${className} extends ${exportName} {
       this.currentRequest.newFileDeferred.fulfill(new URL(`${maybeId}.json`));
     } catch (e: any) {
       console.log('Error saving', e);
+      this.saveError = e;
+    }
+  });
+
+  private createTextFile = restartableTask(async () => {
+    if (!this.currentRequest) {
+      throw new Error(
+        `Cannot createTextFile when there is no this.currentRequest`,
+      );
+    }
+    if (!this.selectedRealmURL) {
+      throw new Error(
+        `bug: cannot call createTextFile without a selected realm URL`,
+      );
+    }
+    if (!this.fileName) {
+      throw new Error(`bug: cannot call createTextFile without a file name`);
+    }
+
+    let fileName = this.getTextFileNameForSave();
+    if (!fileName) {
+      return;
+    }
+
+    let realmPath = new RealmPaths(this.selectedRealmURL);
+    let filePath: LocalPath = fileName as LocalPath;
+    let url = realmPath.fileURL(filePath);
+
+    try {
+      let response = await this.network.authedFetch(url, {
+        headers: { Accept: SupportedMimeType.CardSource },
+      });
+      if (response.ok) {
+        this.fileNameError = `This file already exists`;
+        return;
+      }
+    } catch (_err: any) {
+      // we expect a 404 here
+    }
+
+    try {
+      await this.cardService.saveSource(url, '', 'create-file');
+      this.currentRequest.newFileDeferred.fulfill(url);
+    } catch (e: any) {
+      console.log('Error saving text file', e);
       this.saveError = e;
     }
   });

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -247,7 +247,7 @@ module('Acceptance | code submode | create-file tests', function (hooks) {
       });
     });
 
-    test('new file button has options to create card def, field def, and card instance files', async function (assert) {
+    test('new file button has options to create card def, field def, card instance, and text files', async function (assert) {
       await visitOperatorMode();
       await waitFor('[data-test-code-mode][data-test-save-idle]');
       await waitFor('[data-test-new-file-button]');
@@ -257,7 +257,7 @@ module('Acceptance | code submode | create-file tests', function (hooks) {
         .dom(
           '[data-test-new-file-dropdown-menu] [data-test-boxel-menu-item-text]',
         )
-        .exists({ count: 3 });
+        .exists({ count: 4 });
       assert
         .dom(
           '[data-test-new-file-dropdown-menu] [data-test-boxel-menu-item-text="Card Definition"]',
@@ -273,6 +273,42 @@ module('Acceptance | code submode | create-file tests', function (hooks) {
           '[data-test-new-file-dropdown-menu] [data-test-boxel-menu-item-text="Card Instance"]',
         )
         .exists();
+      assert
+        .dom(
+          '[data-test-new-file-dropdown-menu] [data-test-boxel-menu-item-text="Text File"]',
+        )
+        .exists();
+    });
+
+    test<TestContextWithSave>('can create text files with txt and md extensions', async function (assert) {
+      assert.expect(4);
+      await visitOperatorMode();
+      let deferred = new Deferred<void>();
+      let savedUrls: string[] = [];
+
+      this.onSave(async (url, content) => {
+        savedUrls.push(url.href);
+        assert.strictEqual(content, '', 'text file is created empty');
+        if (savedUrls.length === 2) {
+          deferred.fulfill();
+        }
+      });
+
+      await openNewFileModal('Text File');
+      await fillIn('[data-test-text-file-name-field]', 'notes');
+      await click('[data-test-create-text-file]');
+      await waitFor('[data-test-create-file-modal]', { count: 0 });
+
+      await openNewFileModal('Text File');
+      await fillIn('[data-test-text-file-name-field]', 'readme');
+      await click('[data-test-text-file-extension-select]');
+      await click('[data-test-text-file-extension-option=".md"]');
+      await click('[data-test-create-text-file]');
+      await waitFor('[data-test-create-file-modal]', { count: 0 });
+
+      await deferred.promise;
+      assert.ok(savedUrls.some((url) => url.endsWith('notes.txt')));
+      assert.ok(savedUrls.some((url) => url.endsWith('readme.md')));
     });
 
     test('filename is auto-populated from display name', async function (assert) {

--- a/packages/host/tests/acceptance/code-submode/spec-test.gts
+++ b/packages/host/tests/acceptance/code-submode/spec-test.gts
@@ -31,6 +31,7 @@ import {
   getPlaygroundSelections,
   assertCardExists,
   selectDeclaration,
+  removeSpecSelection,
 } from '../../helpers/playground';
 import { getRecentFiles } from '../../helpers/recent-files-cards';
 
@@ -288,6 +289,7 @@ module('Acceptance | Spec preview', function (hooks) {
     });
     setupUserSubscription();
     setupAuthEndpoints();
+    removeSpecSelection();
 
     // this seeds the loader used during index which obtains url mappings
     // from the global loader


### PR DESCRIPTION
- add text file creation option with .txt/.md selection
- wire create flow and acceptance coverage for Code Mode new menu
- Adding this feature to facilitate development of FileDef features

<img width="1678" height="1202" alt="image" src="https://github.com/user-attachments/assets/c95bcc0c-d296-4fca-8db4-39d73e758c7b" />
