### PR TITLE
Add blocked timer info to the render error

### DIFF
--- a/packages/host/app/lib/window-error-handler.ts
+++ b/packages/host/app/lib/window-error-handler.ts
@@ -8,6 +8,8 @@ import {
 } from '@cardstack/runtime-common';
 import { serializableError } from '@cardstack/runtime-common/error';
 
+import { appendRenderTimerSummaryToStack } from '../utils/render-timer-stub';
+
 export function windowErrorHandler({
   event,
   setStatusToUnusable,
@@ -82,6 +84,15 @@ export function windowErrorHandler({
       type: 'error',
       error: new CardError('indexing failed', { status: 500, id }),
     };
+  }
+
+  if ('stack' in errorPayload.error) {
+    let updatedStack = appendRenderTimerSummaryToStack(
+      errorPayload.error.stack ?? undefined,
+    );
+    if (updatedStack !== undefined) {
+      errorPayload.error.stack = updatedStack;
+    }
   }
 
   setError(JSON.stringify(errorPayload));

--- a/packages/realm-server/prerender/utils.ts
+++ b/packages/realm-server/prerender/utils.ts
@@ -667,27 +667,20 @@ export async function withTimeout<T>(
         return null;
       }
     });
-    let timerSummary: string | null = null;
-    for (let attempt = 0; attempt < 5; attempt++) {
-      timerSummary = await page.evaluate(() => {
-        try {
-          let summary = (globalThis as any).__boxelRenderTimerSummary;
-          if (typeof summary === 'function') {
-            return summary();
-          }
-          if (typeof summary === 'string') {
-            return summary;
-          }
-        } catch {
-          return null;
+    let timerSummary: string | null = await page.evaluate(() => {
+      try {
+        let summary = (globalThis as any).__boxelRenderTimerSummary;
+        if (typeof summary === 'function') {
+          return summary();
         }
+        if (typeof summary === 'string') {
+          return summary;
+        }
+      } catch {
         return null;
-      });
-      if (timerSummary && timerSummary.trim()) {
-        break;
       }
-      await delay(50);
-    }
+      return null;
+    });
     log.warn(
       `render of ${id} timed out with DOM:\n${dom?.trim()}\nDocs in flight: ${docsInFlight}`,
     );

--- a/packages/realm-server/prerender/utils.ts
+++ b/packages/realm-server/prerender/utils.ts
@@ -667,6 +667,27 @@ export async function withTimeout<T>(
         return null;
       }
     });
+    let timerSummary: string | null = null;
+    for (let attempt = 0; attempt < 5; attempt++) {
+      timerSummary = await page.evaluate(() => {
+        try {
+          let summary = (globalThis as any).__boxelRenderTimerSummary;
+          if (typeof summary === 'function') {
+            return summary();
+          }
+          if (typeof summary === 'string') {
+            return summary;
+          }
+        } catch {
+          return null;
+        }
+        return null;
+      });
+      if (timerSummary && timerSummary.trim()) {
+        break;
+      }
+      await delay(50);
+    }
     log.warn(
       `render of ${id} timed out with DOM:\n${dom?.trim()}\nDocs in flight: ${docsInFlight}`,
     );
@@ -681,6 +702,9 @@ export async function withTimeout<T>(
       },
       evict: true,
     };
+    if (typeof timerSummary === 'string' && timerSummary.trim()) {
+      timeoutError.error.stack = timerSummary.trim();
+    }
     (timeoutError as any).capturedDom = dom ?? null;
     (timeoutError as any).docsInFlight = docsInFlight ?? null;
     return timeoutError;

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -1159,6 +1159,66 @@ module(basename(__filename), function () {
                 },
               },
             },
+            'timer-error-card.gts': `
+              import { CardDef, field, contains, StringField } from 'https://cardstack.com/base/card-api';
+              import { Component } from 'https://cardstack.com/base/card-api';
+              export class TimerError extends CardDef {
+                @field name = contains(StringField);
+                static displayName = "Timer Error";
+                static isolated = class extends Component {
+                  get message() {
+                    setTimeout(() => {}, 0);
+                    setInterval(() => {}, 5);
+                    throw new Error('timer error during render');
+                  }
+                  <template>{{this.message}}</template>
+                }
+              }
+            `,
+            'timer-error.json': {
+              data: {
+                attributes: {
+                  name: 'Timer Error',
+                },
+                meta: {
+                  adoptsFrom: {
+                    module: './timer-error-card',
+                    name: 'TimerError',
+                  },
+                },
+              },
+            },
+            'timer-timeout-card.gts': `
+              import { CardDef, field, contains, StringField } from 'https://cardstack.com/base/card-api';
+              import { Component } from 'https://cardstack.com/base/card-api';
+              setTimeout(() => {}, 0);
+              setInterval(() => {}, 5);
+              export class TimerTimeout extends CardDef {
+                @field name = contains(StringField);
+                static displayName = "Timer Timeout";
+                static isolated = class extends Component {
+                  get message() {
+                    setTimeout(() => {}, 0);
+                    setInterval(() => {}, 5);
+                    return this.args.model.name;
+                  }
+                  <template>{{this.message}}</template>
+                }
+              }
+            `,
+            'timer-timeout.json': {
+              data: {
+                attributes: {
+                  name: 'Timer Timeout',
+                },
+                meta: {
+                  adoptsFrom: {
+                    module: './timer-timeout-card',
+                    name: 'TimerTimeout',
+                  },
+                },
+              },
+            },
             // A card that fires the boxel-render-error event (handled by the prerender route)
             // and then blocks the event loop long enough that Ember health probe times out,
             // causing data-prerender-status to be set to 'unusable' by the error handler without
@@ -1444,6 +1504,77 @@ module(basename(__filename), function () {
           iconHTML: null,
           isolatedHTML: null,
         });
+      });
+
+      test('error includes blocked timer summary when timers fire', async function (assert) {
+        const testCardURL = `${realmURL2}timer-error`;
+        let { response } = await prerenderer.prerenderCard({
+          realm: realmURL2,
+          url: testCardURL,
+          auth: auth(),
+        });
+
+        assert.ok(response.error, 'error present for timer error');
+        let message = response.error?.error.message ?? '';
+        assert.ok(
+          message.includes('timer error during render'),
+          `error message includes original error text, got: ${message}`,
+        );
+        let stack = response.error?.error.stack ?? '';
+        assert.ok(
+          stack.includes('Timers blocked during prerender'),
+          'timer summary appended to stack',
+        );
+        let timeoutMatch = stack.match(/setTimeout:\s+(\d+)/);
+        assert.ok(timeoutMatch, 'setTimeout count included');
+        assert.ok(
+          Number(timeoutMatch?.[1]) >= 1,
+          `expected at least one setTimeout, got: ${timeoutMatch?.[1]}`,
+        );
+        let intervalMatch = stack.match(/setInterval:\s+(\d+)/);
+        assert.ok(intervalMatch, 'setInterval count included');
+        assert.ok(
+          Number(intervalMatch?.[1]) >= 1,
+          `expected at least one setInterval, got: ${intervalMatch?.[1]}`,
+        );
+        assert.ok(
+          stack.includes('at get message'),
+          'timer summary includes a call stack',
+        );
+      });
+
+      test('timeout includes blocked timer summary in stack', async function (assert) {
+        const testCardURL = `${realmURL2}timer-timeout`;
+        await prerenderer.prerenderCard({
+          realm: realmURL2,
+          url: testCardURL,
+          auth: auth(),
+        });
+        let { response } = await prerenderer.prerenderCard({
+          realm: realmURL2,
+          url: testCardURL,
+          auth: auth(),
+          opts: { timeoutMs: 1000, simulateTimeoutMs: 2000 },
+        });
+
+        assert.strictEqual(
+          response.error?.error.title,
+          'Render timeout',
+          'timeout surfaced',
+        );
+        let stack = response.error?.error.stack ?? '';
+        assert.ok(
+          stack.includes('Timers blocked during prerender'),
+          'timer summary appended to timeout stack',
+        );
+        assert.ok(
+          /setTimeout:\s+\d+/.test(stack),
+          'timeout stack includes setTimeout count',
+        );
+        assert.ok(
+          /setInterval:\s+\d+/.test(stack),
+          'timeout stack includes setInterval count',
+        );
       });
 
       test('missing link surfaces 404 without eviction', async function (assert) {


### PR DESCRIPTION
This PR appends blocked timer info to the stacktrace of the error when there are blocked timers that were executed during a render error. 

The stack trace when there is a blocked timer(s) looks like this now:
```

Error: timer error during render
    at get message (eval at fetchModule (http://localhost:4200/assets/chunk.a8149c79b1580199128d.js:36071:7), <anonymous>:20:15)
    at getPossibleMandatoryProxyValue (http://localhost:4200/assets/vendor.js:8633:19)
    at _getProp (http://localhost:4200/assets/vendor.js:8657:17)
    at http://localhost:4200/assets/vendor.js:31027:45
    at http://localhost:4200/assets/vendor.js:30988:37
    at track (http://localhost:4200/assets/vendor.js:38583:7)
    at valueForRef (http://localhost:4200/assets/vendor.js:30987:44)
    at Object.evaluate (http://localhost:4200/assets/vendor.js:34430:60)
    at AppendOpcodes.evaluate (http://localhost:4200/assets/vendor.js:32281:19)
    at LowLevelVM.evaluateSyscall (http://localhost:4200/assets/vendor.js:35357:22)
    at LowLevelVM.evaluateInner (http://localhost:4200/assets/vendor.js:35328:14)
    at LowLevelVM.evaluateOuter (http://localhost:4200/assets/vendor.js:35321:14)
    at VM.next (http://localhost:4200/assets/vendor.js:36119:24)
    at LowLevelVM.next (http://localhost:4200/assets/chunk.b31c4e422210a24aa310.js:167560:25)
    at VM._execute (http://localhost:4200/assets/vendor.js:36106:23)
    at VM.execute (http://localhost:4200/assets/vendor.js:36081:28)
    at TryOpcode.handleException (http://localhost:4200/assets/vendor.js:35465:23)
    at UpdatingVMFrame.handleException (http://localhost:4200/assets/vendor.js:35673:31)
    at UpdatingVMImpl.throw (http://localhost:4200/assets/vendor.js:35412:18)
    at Assert.evaluate (http://localhost:4200/assets/vendor.js:33285:17)
    at UpdatingVMImpl._execute (http://localhost:4200/assets/vendor.js:35399:16)
    at http://localhost:4200/assets/vendor.js:35373:63
    at runInTrackingTransaction (http://localhost:4200/assets/vendor.js:38097:21)
    at UpdatingVMImpl.execute (http://localhost:4200/assets/vendor.js:35373:51)
    at RenderResultImpl.rerender (http://localhost:4200/assets/vendor.js:35698:10)
    at http://localhost:4200/assets/vendor.js:6089:57
    at RootState.render (http://localhost:4200/assets/vendor.js:6056:11)
    at http://localhost:4200/assets/vendor.js:6346:18
    at inTransaction (http://localhost:4200/assets/vendor.js:35233:9)
    at Renderer._renderRoots (http://localhost:4200/assets/vendor.js:6328:37)
    at Renderer._renderRootsTransaction (http://localhost:4200/assets/vendor.js:6372:14)
    at Renderer._revalidate (http://localhost:4200/assets/vendor.js:6404:12)
    at invoke (http://localhost:4200/assets/vendor.js:39368:16)
    at Queue.flush (http://localhost:4200/assets/vendor.js:39286:13)
    at DeferredActionQueues.flush (http://localhost:4200/assets/vendor.js:39440:21)
    at Backburner._end (http://localhost:4200/assets/vendor.js:39868:34)
    at Backburner._boundAutorunEnd (http://localhost:4200/assets/vendor.js:39605:14)

Timers blocked during prerender:
Total timers blocked: 2
setTimeout: 1
setInterval: 1
Stacks (timer scheduling):
1) setTimeout (0ms)
  Error: Timer blocked during prerender (setTimeout)
      at recordBlockedTimer (http://localhost:4200/assets/chunk.b31c4e422210a24aa310.js:613590:13)
      at window.setTimeout (http://localhost:4200/assets/chunk.b31c4e422210a24aa310.js:613669:5)
      at get message (eval at fetchModule (http://localhost:4200/assets/chunk.a8149c79b1580199128d.js:36071:7), <anonymous>:18:9)
      at getPossibleMandatoryProxyValue (http://localhost:4200/assets/vendor.js:8633:19)
      at _getProp (http://localhost:4200/assets/vendor.js:8657:17)
      at http://localhost:4200/assets/vendor.js:31027:45
      at http://localhost:4200/assets/vendor.js:30988:37
      at track (http://localhost:4200/assets/vendor.js:38583:7)
      at valueForRef (http://localhost:4200/assets/vendor.js:30987:44)
      at Object.evaluate (http://localhost:4200/assets/vendor.js:34430:60)
      at AppendOpcodes.evaluate (http://localhost:4200/assets/vendor.js:32281:19)
      at LowLevelVM.evaluateSyscall (http://localhost:4200/assets/vendor.js:35357:22)
      at LowLevelVM.evaluateInner (http://localhost:4200/assets/vendor.js:35328:14)
      at LowLevelVM.evaluateOuter (http://localhost:4200/assets/vendor.js:35321:14)
      at VM.next (http://localhost:4200/assets/vendor.js:36119:24)
      at LowLevelVM.next (http://localhost:4200/assets/chunk.b31c4e422210a24aa310.js:167560:25)
      at VM._execute (http://localhost:4200/assets/vendor.js:36106:23)
      at VM.execute (http://localhost:4200/assets/vendor.js:36081:28)
      at TryOpcode.handleException (http://localhost:4200/assets/vendor.js:35465:23)
      at UpdatingVMFrame.handleException (http://localhost:4200/assets/vendor.js:35673:31)
      at UpdatingVMImpl.throw (http://localhost:4200/assets/vendor.js:35412:18)
      at Assert.evaluate (http://localhost:4200/assets/vendor.js:33285:17)
      at UpdatingVMImpl._execute (http://localhost:4200/assets/vendor.js:35399:16)
      at http://localhost:4200/assets/vendor.js:35373:63
      at runInTrackingTransaction (http://localhost:4200/assets/vendor.js:38097:21)
      at UpdatingVMImpl.execute (http://localhost:4200/assets/vendor.js:35373:51)
      at RenderResultImpl.rerender (http://localhost:4200/assets/vendor.js:35698:10)
      at http://localhost:4200/assets/vendor.js:6089:57
      at RootState.render (http://localhost:4200/assets/vendor.js:6056:11)
      at http://localhost:4200/assets/vendor.js:6346:18
      at inTransaction (http://localhost:4200/assets/vendor.js:35233:9)
      at Renderer._renderRoots (http://localhost:4200/assets/vendor.js:6328:37)
      at Renderer._renderRootsTransaction (http://localhost:4200/assets/vendor.js:6372:14)
      at Renderer._revalidate (http://localhost:4200/assets/vendor.js:6404:12)
      at invoke (http://localhost:4200/assets/vendor.js:39368:16)
      at Queue.flush (http://localhost:4200/assets/vendor.js:39286:13)
      at DeferredActionQueues.flush (http://localhost:4200/assets/vendor.js:39440:21)
      at Backburner._end (http://localhost:4200/assets/vendor.js:39868:34)
      at Backburner._boundAutorunEnd (http://localhost:4200/assets/vendor.js:39605:14)
2) setInterval (5ms)
  Error: Timer blocked during prerender (setInterval)
      at recordBlockedTimer (http://localhost:4200/assets/chunk.b31c4e422210a24aa310.js:613590:13)
      at window.setInterval (http://localhost:4200/assets/chunk.b31c4e422210a24aa310.js:613684:5)
      at get message (eval at fetchModule (http://localhost:4200/assets/chunk.a8149c79b1580199128d.js:36071:7), <anonymous>:19:9)
      at getPossibleMandatoryProxyValue (http://localhost:4200/assets/vendor.js:8633:19)
      at _getProp (http://localhost:4200/assets/vendor.js:8657:17)
      at http://localhost:4200/assets/vendor.js:31027:45
      at http://localhost:4200/assets/vendor.js:30988:37
      at track (http://localhost:4200/assets/vendor.js:38583:7)
      at valueForRef (http://localhost:4200/assets/vendor.js:30987:44)
      at Object.evaluate (http://localhost:4200/assets/vendor.js:34430:60)
      at AppendOpcodes.evaluate (http://localhost:4200/assets/vendor.js:32281:19)
      at LowLevelVM.evaluateSyscall (http://localhost:4200/assets/vendor.js:35357:22)
      at LowLevelVM.evaluateInner (http://localhost:4200/assets/vendor.js:35328:14)
      at LowLevelVM.evaluateOuter (http://localhost:4200/assets/vendor.js:35321:14)
      at VM.next (http://localhost:4200/assets/vendor.js:36119:24)
      at LowLevelVM.next (http://localhost:4200/assets/chunk.b31c4e422210a24aa310.js:167560:25)
      at VM._execute (http://localhost:4200/assets/vendor.js:36106:23)
      at VM.execute (http://localhost:4200/assets/vendor.js:36081:28)
      at TryOpcode.handleException (http://localhost:4200/assets/vendor.js:35465:23)
      at UpdatingVMFrame.handleException (http://localhost:4200/assets/vendor.js:35673:31)
      at UpdatingVMImpl.throw (http://localhost:4200/assets/vendor.js:35412:18)
      at Assert.evaluate (http://localhost:4200/assets/vendor.js:33285:17)
      at UpdatingVMImpl._execute (http://localhost:4200/assets/vendor.js:35399:16)
      at http://localhost:4200/assets/vendor.js:35373:63
      at runInTrackingTransaction (http://localhost:4200/assets/vendor.js:38097:21)
      at UpdatingVMImpl.execute (http://localhost:4200/assets/vendor.js:35373:51)
      at RenderResultImpl.rerender (http://localhost:4200/assets/vendor.js:35698:10)
      at http://localhost:4200/assets/vendor.js:6089:57
      at RootState.render (http://localhost:4200/assets/vendor.js:6056:11)
      at http://localhost:4200/assets/vendor.js:6346:18
      at inTransaction (http://localhost:4200/assets/vendor.js:35233:9)
      at Renderer._renderRoots (http://localhost:4200/assets/vendor.js:6328:37)
      at Renderer._renderRootsTransaction (http://localhost:4200/assets/vendor.js:6372:14)
      at Renderer._revalidate (http://localhost:4200/assets/vendor.js:6404:12)
      at invoke (http://localhost:4200/assets/vendor.js:39368:16)
      at Queue.flush (http://localhost:4200/assets/vendor.js:39286:13)
      at DeferredActionQueues.flush (http://localhost:4200/assets/vendor.js:39440:21)
      at Backburner._end (http://localhost:4200/assets/vendor.js:39868:34)
      at Backburner._boundAutorunEnd (http://localhost:4200/assets/vendor.js:39605:14)

```