### PR TITLE
Cleanup lingering servers, prerenderers, queues after server tests finish

### DIFF
--- a/packages/realm-server/prerender/browser-manager.ts
+++ b/packages/realm-server/prerender/browser-manager.ts
@@ -126,11 +126,19 @@ export class BrowserManager {
     if (!this.#browser) {
       return;
     }
+    let proc = this.#browser.process();
     try {
       await this.#browser.close();
     } catch (e) {
       log.warn('Error closing browser:', e);
     } finally {
+      if (proc && proc.exitCode === null && !proc.killed) {
+        try {
+          proc.kill('SIGKILL');
+        } catch (_e) {
+          // best-effort cleanup
+        }
+      }
       this.#browser = null;
       this.#browserUserDataDir = undefined;
     }

--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -215,7 +215,11 @@ export async function closeTrackedDbAdapters(): Promise<void> {
   trackedDbAdapters.clear();
   for (let adapter of adapters) {
     if (!adapter.isClosed) {
-      await adapter.close();
+      try {
+        await adapter.close();
+      } catch {
+        // best-effort cleanup
+      }
     }
   }
 }
@@ -224,7 +228,11 @@ export async function destroyTrackedQueuePublishers(): Promise<void> {
   let publishers = [...trackedQueuePublishers];
   trackedQueuePublishers.clear();
   for (let publisher of publishers) {
-    await publisher.destroy();
+    try {
+      await publisher.destroy();
+    } catch {
+      // best-effort cleanup
+    }
   }
 }
 
@@ -232,7 +240,11 @@ export async function destroyTrackedQueueRunners(): Promise<void> {
   let runners = [...trackedQueueRunners];
   trackedQueueRunners.clear();
   for (let runner of runners) {
-    await runner.destroy();
+    try {
+      await runner.destroy();
+    } catch {
+      // best-effort cleanup
+    }
   }
 }
 

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -108,7 +108,6 @@ QUnit.done(() => {
       }
     })
     .catch((error) => {
-      // eslint-disable-next-line no-console
       console.error('QUnit.done cleanup failed:', error);
     });
 });

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -31,6 +31,83 @@ import QUnit from 'qunit';
 
 QUnit.config.testTimeout = 60000;
 
+// Cleanup here ensures lingering servers/prerenderers/queues don't keep the
+// Node event loop alive after tests finish.
+QUnit.done(() => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const helpers = require('./helpers') as {
+    closeTrackedServers?: () => Promise<void>;
+    stopTrackedPrerenderers?: () => Promise<void>;
+    destroyTrackedQueueRunners?: () => Promise<void>;
+    destroyTrackedQueuePublishers?: () => Promise<void>;
+    closeTrackedDbAdapters?: () => Promise<void>;
+  };
+  Promise.resolve().then(async () => {
+    await helpers.stopTrackedPrerenderers?.();
+    await helpers.closeTrackedServers?.();
+    await helpers.destroyTrackedQueueRunners?.();
+    await helpers.destroyTrackedQueuePublishers?.();
+    await helpers.closeTrackedDbAdapters?.();
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const undici = require('undici') as {
+        getGlobalDispatcher?: () => { close?: () => Promise<void> };
+      };
+      await undici.getGlobalDispatcher?.()?.close?.();
+    } catch {
+      // best-effort cleanup
+    }
+    let handles = (process as any)._getActiveHandles?.() ?? [];
+    for (let handle of handles) {
+      if (
+        handle &&
+        typeof handle.kill === 'function' &&
+        typeof handle.spawnfile === 'string' &&
+        /chrome|chromium/i.test(handle.spawnfile)
+      ) {
+        try {
+          handle.kill('SIGKILL');
+          handle.unref?.();
+        } catch {
+          // best-effort cleanup
+        }
+      }
+    }
+    handles = (process as any)._getActiveHandles?.() ?? [];
+    for (let handle of handles) {
+      if (!handle || typeof handle.destroy !== 'function') {
+        continue;
+      }
+      let websocketSymbol = Object.getOwnPropertySymbols(handle).find(
+        (symbol) => symbol.description === 'websocket',
+      );
+      if (websocketSymbol) {
+        try {
+          handle[websocketSymbol]?.terminate?.();
+          handle.destroy();
+        } catch {
+          // best-effort cleanup
+        }
+      }
+    }
+    handles = (process as any)._getActiveHandles?.() ?? [];
+    for (let handle of handles) {
+      if (!handle || typeof handle.destroy !== 'function') {
+        continue;
+      }
+      if ((handle as any)._isStdio || (handle as any)._type === 'pipe') {
+        continue;
+      }
+      try {
+        handle.unref?.();
+        handle.destroy();
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  });
+});
+
 import 'decorator-transforms/globals';
 import '../setup-logger'; // This should be first
 import './atomic-endpoints-test';

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -105,6 +105,9 @@ QUnit.done(() => {
         // best-effort cleanup
       }
     }
+  }).catch((error) => {
+    // eslint-disable-next-line no-console
+    console.error('QUnit.done cleanup failed:', error);
   });
 });
 

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -8,7 +8,7 @@ import type {
   ModuleRenderResponse,
   RenderRouteOptions,
 } from '@cardstack/runtime-common';
-import { Prerenderer } from '../prerender/index';
+import type { Prerenderer } from '../prerender/index';
 import { PagePool } from '../prerender/page-pool';
 import { RenderRunner } from '../prerender/render-runner';
 
@@ -18,6 +18,7 @@ import {
   matrixURL,
   cleanWhiteSpace,
   testCreatePrerenderAuth,
+  getPrerendererForTesting,
 } from './helpers';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 import {
@@ -89,7 +90,7 @@ module(basename(__filename), function () {
     let auth = () => testCreatePrerenderAuth(testUserId, permissions);
 
     hooks.before(async () => {
-      prerenderer = new Prerenderer({
+      prerenderer = getPrerendererForTesting({
         maxPages: 2,
         serverURL: prerenderServerURL,
       });
@@ -730,7 +731,7 @@ module(basename(__filename), function () {
     let auth = () => testCreatePrerenderAuth(testUserId, permissions);
 
     hooks.before(async () => {
-      prerenderer = new Prerenderer({
+      prerenderer = getPrerendererForTesting({
         maxPages: 2,
         serverURL: prerenderServerURL,
       });
@@ -964,7 +965,7 @@ module(basename(__filename), function () {
     };
 
     hooks.before(async function () {
-      prerenderer = new Prerenderer({
+      prerenderer = getPrerendererForTesting({
         maxPages: 2,
         serverURL: prerenderServerURL,
       });
@@ -1843,7 +1844,7 @@ module(basename(__filename), function () {
             };
           };
 
-          localPrerenderer = new Prerenderer({
+          localPrerenderer = getPrerendererForTesting({
             maxPages: 1,
             serverURL: 'http://127.0.0.1:4225',
           });
@@ -2076,7 +2077,7 @@ module(basename(__filename), function () {
           };
         };
 
-        prerenderer = new Prerenderer({
+        prerenderer = getPrerendererForTesting({
           maxPages: 1,
           serverURL: 'http://127.0.0.1:4225',
         });
@@ -2173,7 +2174,7 @@ module(basename(__filename), function () {
           };
         };
 
-        prerenderer = new Prerenderer({
+        prerenderer = getPrerendererForTesting({
           maxPages: 1,
           serverURL: 'http://127.0.0.1:4225',
         });


### PR DESCRIPTION
This PR cleans up lingering servers, prerenderers, and queues after server tests finish. This solves a problem where  node doesn't exit quickly after the server tests complete.