### PR TITLE
Add support for capturing realm meta of error docs that have last known good state

### DIFF
--- a/packages/base/cards-grid.gts
+++ b/packages/base/cards-grid.gts
@@ -20,6 +20,7 @@ import {
   isCardInstance,
   SupportedMimeType,
   subscribeToRealm,
+  codeRefFromInternalKey,
   type Query,
   CardErrorJSONAPI,
 } from '@cardstack/runtime-common';
@@ -313,19 +314,19 @@ class Isolated extends Component<typeof CardsGrid> {
     this.cardTypeFilters.splice(0, this.cardTypeFilters.length);
 
     cardTypeSummaries.forEach((summary) => {
-      if (excludedCardTypeIds.includes(summary.id)) {
+      if (!summary.id || excludedCardTypeIds.includes(summary.id)) {
         return;
       }
-      const lastIndex = summary.id.lastIndexOf('/');
+      let codeRef = codeRefFromInternalKey(summary.id);
+      if (!codeRef) {
+        return;
+      }
       this.cardTypeFilters.push({
-        displayName: summary.attributes.displayName,
+        displayName: summary.attributes.displayName ?? codeRef.name,
         icon: summary.attributes.iconHTML ?? Captions,
         query: {
           filter: {
-            type: {
-              module: summary.id.substring(0, lastIndex),
-              name: summary.id.substring(lastIndex + 1),
-            },
+            type: codeRef,
           },
         },
       });

--- a/packages/host/tests/integration/components/operator-mode/setup.gts
+++ b/packages/host/tests/integration/components/operator-mode/setup.gts
@@ -376,6 +376,20 @@ export function setupOperatorModeTests(
       };
     }
 
+    class ExplodingCard extends CardDef {
+      static displayName = 'Exploding Card';
+      @field name = contains(StringField);
+      @field status = contains(StringField);
+      @field title = contains(StringField, {
+        computeVia: function (this: ExplodingCard) {
+          if (this.status === 'boom') {
+            throw new Error('Boom!');
+          }
+          return this.name;
+        },
+      });
+    }
+
     class PublishingPacket extends CardDef {
       static displayName = 'Publishing Packet';
       static headerColor = '#6638ff'; // rgb(102, 56, 255);
@@ -409,6 +423,10 @@ export function setupOperatorModeTests(
       body: 'Hello world',
       authorBio: author1,
     });
+    let explodingCard = new ExplodingCard({
+      name: 'Stable Example',
+      status: 'ok',
+    });
 
     //Generate 11 person card to test recent card menu in card sheet
     let personCards: Map<String, any> = new Map<String, any>();
@@ -437,6 +455,7 @@ export function setupOperatorModeTests(
           'boom-field.gts': { BoomField },
           'boom-pet.gts': { BoomPet },
           'blog-post.gts': { BlogPost },
+          'exploding-card.gts': { ExplodingCard },
           'car.gts': { Car },
           'author.gts': { Author },
           'friend.gts': { Friend },
@@ -598,6 +617,7 @@ export function setupOperatorModeTests(
           }),
           'BlogPost/1.json': blogPost,
           'BlogPost/2.json': new BlogPost({ title: 'Beginnings' }),
+          'ExplodingCard/1.json': explodingCard,
           'CardDef/1.json': new CardDef({ title: 'CardDef instance' }),
           'PublishingPacket/story.json': new PublishingPacket({
             title: 'Space Story',

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -402,8 +402,17 @@ export class Batch {
           WHERE`,
       ...every([
         ['i.realm_url =', param(this.realmURL.href)],
-        ['i.type = ', param('instance')],
+        any([
+          ['i.type = ', param('instance')],
+          ['i.type = ', param('error')],
+        ]),
         ['i.types IS NOT NULL'],
+        [
+          dbExpression({
+            pg: `(i.types->>0) IS NOT NULL`,
+            sqlite: `json_extract(i.types, '$[0]') IS NOT NULL`,
+          }),
+        ],
         any([['i.is_deleted = false'], ['i.is_deleted IS NULL']]),
       ]),
       `GROUP BY i.display_names->>0, i.types->>0`,

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -523,6 +523,28 @@ export function internalKeyFor(
   }
 }
 
+export function codeRefFromInternalKey(
+  internalKey: string | null | undefined,
+): ResolvedCodeRef | undefined {
+  if (!internalKey) {
+    return;
+  }
+  if (internalKey.includes('/fields/')) {
+    return;
+  }
+  if (internalKey.endsWith('/ancestor')) {
+    return;
+  }
+  let lastSlash = internalKey.lastIndexOf('/');
+  if (lastSlash <= 0 || lastSlash === internalKey.length - 1) {
+    return;
+  }
+  return {
+    module: internalKey.slice(0, lastSlash),
+    name: internalKey.slice(lastSlash + 1),
+  };
+}
+
 export function loaderFor(cardOrField: CardDef | FieldDef) {
   let clazz = Reflect.getPrototypeOf(cardOrField)!.constructor;
   let loader = Loader.getLoaderFor(clazz);


### PR DESCRIPTION
This PR fixes a bug where we were not displaying the card type filter in the cards grid when only error docs with last known good state exist for the filter. Now we can support this.

<img width="1717" height="1021" alt="Screenshot from 2025-12-31 11-45-53" src="https://github.com/user-attachments/assets/fd7ebc2a-de12-43c0-b53a-43641314ac79" />
