### PR TITLE
Update index error types and PK schema

### DIFF
--- a/packages/host/app/components/card-prerender.gts
+++ b/packages/host/app/components/card-prerender.gts
@@ -263,7 +263,7 @@ export default class CardPrerender extends Component {
           }
         } catch (e: any) {
           try {
-            error = { ...JSON.parse(e.message), type: 'error' };
+            error = { ...JSON.parse(e.message), type: 'instance-error' };
           } catch (err) {
             let cardErr = new CardError(e.message);
             cardErr.stack = e.stack;
@@ -273,7 +273,7 @@ export default class CardPrerender extends Component {
                 deps: [url.replace(/\.json$/, '')],
                 additionalErrors: null,
               },
-              type: 'error',
+              type: 'instance-error',
             };
           }
           this.store.resetCache();

--- a/packages/host/app/lib/window-error-handler.ts
+++ b/packages/host/app/lib/window-error-handler.ts
@@ -49,7 +49,7 @@ export function windowErrorHandler({
   if (reason) {
     if (isCardError(reason)) {
       errorPayload = {
-        type: 'error',
+        type: 'instance-error',
         error: { ...reason, stack: reason.stack },
       };
     } else if (isCardErrorJSONAPI(reason)) {
@@ -67,7 +67,7 @@ export function windowErrorHandler({
       });
     } else {
       errorPayload = {
-        type: 'error',
+        type: 'instance-error',
         error:
           reason instanceof CardError
             ? { ...serializableError(reason) }
@@ -81,7 +81,7 @@ export function windowErrorHandler({
     }
   } else {
     errorPayload = {
-      type: 'error',
+      type: 'instance-error',
       error: new CardError('indexing failed', { status: 500, id }),
     };
   }
@@ -105,7 +105,7 @@ export function errorJsonApiToErrorEntry(
 ): ErrorEntry {
   let error = CardError.fromCardErrorJsonAPI(errorJSONAPI);
   return {
-    type: 'error',
+    type: 'instance-error',
     error,
   };
 }

--- a/packages/host/app/routes/module.ts
+++ b/packages/host/app/routes/module.ts
@@ -368,7 +368,7 @@ async function makeDefinition(
         `encountered error indexing definition  "${url.href}/${name}": ${typesMaybeError.error.message}`,
       );
       return {
-        type: 'error',
+        type: 'module-error',
         error:
           typesMaybeError.error.status == null
             ? { ...typesMaybeError.error, status: 500 }
@@ -386,7 +386,7 @@ async function makeDefinition(
       `encountered error indexing definition "${url.href}/${name}": ${err.message}`,
     );
     return {
-      type: 'error',
+      type: 'module-error',
       error: toSerializedError(
         err,
         `encountered error indexing definition "${url.href}/${name}": ${describeError(err)}`,
@@ -555,7 +555,7 @@ export function modelWithError({
     createdAt: 0,
     definitions: {},
     error: {
-      type: 'error',
+      type: 'module-error',
       error: baseError,
     },
   };

--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -630,7 +630,7 @@ export default class RenderRoute extends Route<Model> {
     if (isCardError(error)) {
       let normalized = normalizeRenderError(
         {
-          type: 'error',
+          type: 'instance-error',
           error: serializableError(error),
         },
         normalizationContext,
@@ -893,7 +893,7 @@ export default class RenderRoute extends Route<Model> {
     } else {
       reason = JSON.stringify(
         {
-          type: 'error',
+          type: 'instance-error',
           error: {
             status: 500,
             title: 'Render failed',

--- a/packages/host/app/utils/render-error.ts
+++ b/packages/host/app/utils/render-error.ts
@@ -50,13 +50,16 @@ export function coerceRenderError(reason: unknown): RenderError | undefined {
       if (Array.isArray(errors) && errors.length > 0) {
         let cardError = coerceCardError(errors[0]);
         if (cardError) {
-          return { type: 'error', error: serializableError(cardError) };
+          return {
+            type: 'instance-error',
+            error: serializableError(cardError),
+          };
         }
       }
     }
     let cardError = coerceCardError(reason);
     if (cardError) {
-      return { type: 'error', error: serializableError(cardError) };
+      return { type: 'instance-error', error: serializableError(cardError) };
     }
   }
   return undefined;

--- a/packages/host/config/schema/1768000000001_schema.sql
+++ b/packages/host/config/schema/1768000000001_schema.sql
@@ -23,7 +23,7 @@
    resource_created_at,
    icon_html TEXT,
    head_html TEXT,
-   PRIMARY KEY ( url, realm_url ) 
+   PRIMARY KEY ( url, realm_url, type ) 
 );
 
  CREATE TABLE IF NOT EXISTS boxel_index_working (
@@ -48,7 +48,7 @@
    display_names BLOB,
    resource_created_at,
    head_html TEXT,
-   PRIMARY KEY ( url, realm_url ) 
+   PRIMARY KEY ( url, realm_url, type ) 
 );
 
  CREATE TABLE IF NOT EXISTS modules (

--- a/packages/host/tests/integration/components/ai-module-creation-test.gts
+++ b/packages/host/tests/integration/components/ai-module-creation-test.gts
@@ -111,7 +111,7 @@ module('Integration | create app module via ai-assistant', function (hooks) {
 
   async function getModule(realm: Realm, url: URL) {
     let maybeInstance = await realm.realmIndexQueryEngine.module(url);
-    if (maybeInstance?.type === 'error') {
+    if (maybeInstance?.type === 'module-error') {
       return undefined;
     }
     return maybeInstance;
@@ -233,6 +233,8 @@ module('Integration | create app module via ai-assistant', function (hooks) {
       document.querySelector('[data-test-view-module]') as HTMLElement
     )?.innerText;
     let module = await getModule(realm, new URL(moduleURL));
+    assert.ok(module, 'module entry exists');
+    assert.strictEqual(module?.type, 'module');
     assert.strictEqual(module?.canonicalURL, moduleURL);
 
     await click('[data-test-view-module]');

--- a/packages/host/tests/integration/realm-indexing-test.gts
+++ b/packages/host/tests/integration/realm-indexing-test.gts
@@ -109,10 +109,10 @@ module(`Integration | realm indexing`, function (hooks) {
     url: URL,
   ): Promise<IndexedInstance | undefined> {
     let maybeInstance = await realm.realmIndexQueryEngine.instance(url);
-    if (maybeInstance?.type === 'error') {
+    if (maybeInstance?.type === 'instance-error') {
       return undefined;
     }
-    return maybeInstance;
+    return maybeInstance as IndexedInstance | undefined;
   }
 
   test('full indexing discovers card instances', async function (assert) {

--- a/packages/host/tests/unit/index-query-engine-test.ts
+++ b/packages/host/tests/unit/index-query-engine-test.ts
@@ -275,7 +275,7 @@ module('Unit | query', function (hooks) {
     await setupIndex(dbAdapter, [
       {
         url: `${testRealmURL}1.json`,
-        type: 'error',
+        type: 'instance-error',
         realm_version: 1,
         realm_url: testRealmURL,
         pristine_doc: undefined,
@@ -2927,7 +2927,7 @@ module('Unit | query', function (hooks) {
       {
         url: `${testRealmURL}donald.json`,
         file_alias: `${testRealmURL}donald`,
-        type: 'error',
+        type: 'instance-error',
         realm_version: 1,
         realm_url: testRealmURL,
         deps: [],
@@ -2954,7 +2954,7 @@ module('Unit | query', function (hooks) {
       {
         url: `${testRealmURL}paper.json`,
         file_alias: `${testRealmURL}paper`,
-        type: 'error',
+        type: 'instance-error',
         realm_version: 1,
         realm_url: testRealmURL,
         deps: [],

--- a/packages/host/tests/unit/render-error-test.ts
+++ b/packages/host/tests/unit/render-error-test.ts
@@ -7,7 +7,7 @@ import { normalizeRenderError } from '@cardstack/host/utils/render-error';
 module('Unit | render-error', function () {
   test('coerces missing authorization header message', function (assert) {
     let renderError: RenderError = {
-      type: 'error',
+      type: 'instance-error',
       error: {
         status: 401,
         title: 'Unauthorized',

--- a/packages/postgres/migrations/1768000000000_add-type-to-index-pk.js
+++ b/packages/postgres/migrations/1768000000000_add-type-to-index-pk.js
@@ -1,0 +1,29 @@
+exports.up = (pgm) => {
+  pgm.dropConstraint('boxel_index', 'boxel_index_pkey');
+  pgm.addConstraint('boxel_index', 'boxel_index_pkey', {
+    primaryKey: ['url', 'realm_url', 'type'],
+  });
+
+  pgm.dropConstraint('boxel_index_working', 'boxel_index_working_pkey');
+  pgm.addConstraint('boxel_index_working', 'boxel_index_working_pkey', {
+    primaryKey: ['url', 'realm_url', 'type'],
+  });
+};
+
+exports.down = (pgm) => {
+  // migrating down could cause constraint errors because the PK becomes tighter,
+  // so we must delete the index first
+  pgm.sql('DELETE FROM boxel_index');
+  pgm.sql('DELETE FROM boxel_index_working');
+  pgm.sql('DELETE FROM realm_versions');
+
+  pgm.dropConstraint('boxel_index', 'boxel_index_pkey');
+  pgm.addConstraint('boxel_index', 'boxel_index_pkey', {
+    primaryKey: ['url', 'realm_url'],
+  });
+
+  pgm.dropConstraint('boxel_index_working', 'boxel_index_working_pkey');
+  pgm.addConstraint('boxel_index_working', 'boxel_index_working_pkey', {
+    primaryKey: ['url', 'realm_url'],
+  });
+};

--- a/packages/postgres/migrations/1768000000001_update-index-error-types.js
+++ b/packages/postgres/migrations/1768000000001_update-index-error-types.js
@@ -34,6 +34,18 @@ exports.down = (pgm) => {
   pgm.dropConstraint('boxel_index', 'boxel_index_type_check');
   pgm.dropConstraint('boxel_index_working', 'boxel_index_working_type_check');
 
+  pgm.sql(`
+    UPDATE boxel_index
+    SET type = 'error'
+    WHERE type IN ('instance-error', 'module-error', 'file-error')
+  `);
+
+  pgm.sql(`
+    UPDATE boxel_index_working
+    SET type = 'error'
+    WHERE type IN ('instance-error', 'module-error', 'file-error')
+  `);
+
   pgm.addConstraint('boxel_index', 'boxel_index_type_check', {
     check: "type in ('instance','module','error','file')",
   });

--- a/packages/postgres/migrations/1768000000001_update-index-error-types.js
+++ b/packages/postgres/migrations/1768000000001_update-index-error-types.js
@@ -1,0 +1,43 @@
+exports.up = (pgm) => {
+  pgm.dropConstraint('boxel_index', 'boxel_index_type_check');
+  pgm.dropConstraint('boxel_index_working', 'boxel_index_working_type_check');
+
+  pgm.sql(`
+    UPDATE boxel_index
+    SET type = CASE
+      WHEN url LIKE '%.json' THEN 'instance-error'
+      ELSE 'module-error'
+    END
+    WHERE type = 'error'
+  `);
+
+  pgm.sql(`
+    UPDATE boxel_index_working
+    SET type = CASE
+      WHEN url LIKE '%.json' THEN 'instance-error'
+      ELSE 'module-error'
+    END
+    WHERE type = 'error'
+  `);
+
+  pgm.addConstraint('boxel_index', 'boxel_index_type_check', {
+    check:
+      "type in ('instance','module','file','instance-error','module-error','file-error')",
+  });
+  pgm.addConstraint('boxel_index_working', 'boxel_index_working_type_check', {
+    check:
+      "type in ('instance','module','file','instance-error','module-error','file-error')",
+  });
+};
+
+exports.down = (pgm) => {
+  pgm.dropConstraint('boxel_index', 'boxel_index_type_check');
+  pgm.dropConstraint('boxel_index_working', 'boxel_index_working_type_check');
+
+  pgm.addConstraint('boxel_index', 'boxel_index_type_check', {
+    check: "type in ('instance','module','error','file')",
+  });
+  pgm.addConstraint('boxel_index_working', 'boxel_index_working_type_check', {
+    check: "type in ('instance','module','error','file')",
+  });
+};

--- a/packages/realm-server/prerender/utils.ts
+++ b/packages/realm-server/prerender/utils.ts
@@ -167,7 +167,7 @@ function buildInvalidRenderResponseError(
     id = null;
   }
   return {
-    type: 'error',
+    type: 'instance-error',
     error: {
       id,
       status: 500,
@@ -193,7 +193,7 @@ export function buildInvalidModuleResponseError(
     id = null;
   }
   return {
-    type: 'error',
+    type: 'module-error',
     error: {
       id,
       status: 500,
@@ -594,7 +594,7 @@ export async function captureResult(
           return {
             status: 'error',
             value: JSON.stringify({
-              type: 'error',
+              type: 'instance-error',
               error: {
                 id: resolvedElement.dataset.prerenderId ?? null,
                 status: 500,
@@ -685,7 +685,7 @@ export async function withTimeout<T>(
       `render of ${id} timed out with DOM:\n${dom?.trim()}\nDocs in flight: ${docsInFlight}`,
     );
     let timeoutError: RenderError = {
-      type: 'error',
+      type: 'instance-error',
       error: {
         id,
         status: 504,

--- a/packages/realm-server/tests/card-endpoints-test.ts
+++ b/packages/realm-server/tests/card-endpoints-test.ts
@@ -1970,7 +1970,7 @@ module(basename(__filename), function () {
           for (let table of ['boxel_index', 'boxel_index_working']) {
             await dbAdapter.execute(
               `UPDATE ${table}
-               SET type = 'error', error_doc = $1::jsonb
+               SET type = 'instance-error', error_doc = $1::jsonb
                WHERE url = $2`,
               {
                 bind: [JSON.stringify(errorDoc), cardURL],
@@ -2033,7 +2033,7 @@ module(basename(__filename), function () {
           for (let table of ['boxel_index', 'boxel_index_working']) {
             await dbAdapter.execute(
               `UPDATE ${table}
-               SET type = 'error', error_doc = $1::jsonb, pristine_doc = NULL
+               SET type = 'instance-error', error_doc = $1::jsonb, pristine_doc = NULL
                WHERE url = $2`,
               {
                 bind: [JSON.stringify(errorDoc), cardURL],

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -449,10 +449,10 @@ module(basename(__filename), function () {
       url: URL,
     ): Promise<IndexedInstance | undefined> {
       let maybeInstance = await realm.realmIndexQueryEngine.instance(url);
-      if (maybeInstance?.type === 'error') {
+      if (maybeInstance?.type === 'instance-error') {
         return undefined;
       }
-      return maybeInstance;
+      return maybeInstance as IndexedInstance | undefined;
     }
 
     setupBaseRealmServer(hooks, matrixURL);

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -2180,7 +2180,7 @@ module(basename(__filename), function () {
                   ...baseResponse,
                   status: 'error',
                   error: {
-                    type: 'error',
+                    type: 'module-error',
                     error: {
                       message: `Failed to execute 'removeChild' on 'Node': NotFoundError`,
                       status: 500,
@@ -2280,7 +2280,7 @@ module(basename(__filename), function () {
               ? {
                   ...baseResponse,
                   error: {
-                    type: 'error',
+                    type: 'instance-error',
                     error: {
                       message: `Failed to execute 'removeChild' on 'Node': NotFoundError`,
                       status: 500,

--- a/packages/realm-server/tests/realm-endpoints/publishability-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/publishability-test.ts
@@ -168,7 +168,7 @@ module(`realm-endpoints/${basename(__filename)}`, function (hooks) {
       for (let table of ['boxel_index', 'boxel_index_working']) {
         await dbAdapter.execute(
           `UPDATE ${table}
-           SET type = 'error', error_doc = $1::jsonb
+           SET type = 'instance-error', error_doc = $1::jsonb
            WHERE url = $2`,
           {
             bind: [JSON.stringify(errorDoc), cardURL],

--- a/packages/realm-server/worker-manager.ts
+++ b/packages/realm-server/worker-manager.ts
@@ -8,6 +8,7 @@ import {
   param,
   separatedByCommas,
   IndexWriter,
+  hasExecutableExtension,
   type Expression,
   type StatusArgs,
 } from '@cardstack/runtime-common';
@@ -319,8 +320,14 @@ async function markFailedIndexEntry({
   await batch.invalidate([new URL(url)]);
   let invalidations = batch.invalidations;
   for (let file of [url, ...invalidations]) {
+    let entryType: 'module-error' | 'instance-error' | 'file-error' =
+      hasExecutableExtension(file)
+        ? 'module-error'
+        : file.endsWith('.json')
+          ? 'instance-error'
+          : 'file-error';
     await batch.updateEntry(new URL(file), {
-      type: 'error',
+      type: entryType,
       error: {
         message,
         status: 500,

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -315,7 +315,7 @@ export class IndexRunner {
 
       if (
         !indexEntry ||
-        indexEntry.type === 'error' ||
+        indexEntry.type.endsWith('-error') ||
         indexEntry.lastModified == null ||
         lastModified !== indexEntry.lastModified
       ) {
@@ -449,7 +449,7 @@ export class IndexRunner {
         `${jobIdentity(this.#jobInfo)} encountered error rendering module "${url.href}": ${err.message}`,
       );
       await this.batch.updateEntry(url, {
-        type: 'error',
+        type: 'module-error',
         error: {
           status: err.status ?? 500,
           message: `encountered error rendering module "${url.href}": ${err.message}`,
@@ -469,7 +469,7 @@ export class IndexRunner {
 
     if (error) {
       this.stats.moduleErrors++;
-      await this.batch.updateEntry(url, error);
+      await this.batch.updateEntry(url, { ...error, type: 'module-error' });
       return;
     }
 
@@ -595,14 +595,14 @@ export class IndexRunner {
             });
           }
           if (isCardError(err)) {
-            return { type: 'error', error: serializableError(err) };
+            return { type: 'instance-error', error: serializableError(err) };
           }
           let fallback = new CardError(
             (err as Error)?.message ?? 'unknown render error',
             { status: 500 },
           );
           fallback.stack = (err as Error)?.stack;
-          return { type: 'error', error: serializableError(fallback) };
+          return { type: 'instance-error', error: serializableError(fallback) };
         };
 
         renderError = normalizeToErrorEntry(renderError, uncaughtError);

--- a/packages/runtime-common/index-structure.ts
+++ b/packages/runtime-common/index-structure.ts
@@ -7,7 +7,13 @@ export interface BoxelIndexTable {
   file_alias: string;
   realm_version: number;
   realm_url: string;
-  type: 'instance' | 'module' | 'error' | 'file';
+  type:
+    | 'instance'
+    | 'module'
+    | 'file'
+    | 'instance-error'
+    | 'module-error'
+    | 'file-error';
   // TODO in followup PR update this to be a document not a resource
   pristine_doc: CardResource | null;
   error_doc: SerializedError | null;

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -6,7 +6,6 @@ import {
   type RealmInfo,
   type JobInfo,
   jobIdentity,
-  hasExecutableExtension,
   trimExecutableExtension,
   RealmPaths,
   unixTime,
@@ -84,11 +83,15 @@ export interface InstanceEntry {
 }
 
 export interface ErrorEntry {
-  type: 'error';
+  type: 'instance-error' | 'module-error' | 'file-error';
   error: SerializedError;
   types?: string[];
   searchData?: Record<string, any>;
   cardType?: string;
+}
+
+function isErrorEntry(entry: IndexEntry): entry is ErrorEntry {
+  return entry.type.endsWith('-error');
 }
 
 interface ModuleEntry {
@@ -260,10 +263,9 @@ export class Batch {
       // drop this band-aid
       return;
     }
-    let errorEntry =
-      entry.type === 'error'
-        ? { ...entry, error: this.normalizeErrorDoc(entry.error, url) }
-        : undefined;
+    let errorEntry = isErrorEntry(entry)
+      ? { ...entry, error: this.normalizeErrorDoc(entry.error, url) }
+      : undefined;
     let href = url.href;
     this.#invalidations.add(url.href);
     let entryPayload;
@@ -310,13 +312,18 @@ export class Batch {
           error_doc: null,
         };
         break;
-      case 'error':
+      case 'instance-error':
+      case 'module-error':
+      case 'file-error':
         entryPayload = {
           types: entry.types,
           search_doc: entry.searchData,
           // favor the last known good types over the types derived from the error state
-          ...((await this.getProductionVersion(url)) ?? {}),
-          type: 'error',
+          ...((await this.getProductionVersion(
+            url,
+            baseTypeFromError(entry),
+          )) ?? {}),
+          type: entry.type,
           error_doc: errorEntry?.error ?? entry.error,
         };
         break;
@@ -339,13 +346,13 @@ export class Batch {
       indexed_at: number;
     };
 
-    if (entry.type === 'error') {
+    if (isErrorEntry(entry)) {
       // merge the last known good deps with the error deps so we can invalidate
       // when upstream issue is repaired
       preparedEntry.deps = [
         ...new Set([
           ...(preparedEntry.deps ?? []),
-          ...(errorEntry?.error.deps ?? entry.error.deps ?? []),
+          ...(errorEntry?.error.deps ?? []),
         ]),
       ];
     }
@@ -381,7 +388,10 @@ export class Batch {
     return query(this.#dbAdapter, expression, coerceTypes);
   }
 
-  private async getProductionVersion(url: URL) {
+  private async getProductionVersion(
+    url: URL,
+    expectedType: BoxelIndexTable['type'],
+  ) {
     let [entry] = (await this.#query([
       `SELECT i.*`,
       `FROM boxel_index as i
@@ -391,6 +401,7 @@ export class Batch {
           [`i.url =`, param(url.href)],
           [`i.file_alias =`, param(url.href)],
         ]),
+        ['i.type =', param(expectedType)],
       ]),
     ] as Expression)) as unknown as BoxelIndexTable[];
     if (!entry) {
@@ -556,6 +567,7 @@ export class Batch {
 
   private async tombstoneEntries(invalidations: string[]) {
     // insert tombstone into next version of the realm index
+    let existingTypes = await this.existingIndexTypes(invalidations);
     let columns = [
       'url',
       'file_alias',
@@ -564,20 +576,26 @@ export class Batch {
       'realm_url',
       'is_deleted',
     ].map((c) => [c]);
-    let rows = invalidations.map((id) =>
-      [
-        id,
-        trimExecutableExtension(new URL(id)).href,
-        hasExecutableExtension(id)
-          ? 'module'
-          : id.endsWith('.json')
-            ? 'instance'
-            : 'file',
-        this.realmVersion,
-        this.realmURL.href,
-        true,
-      ].map((v) => [param(v)]),
-    );
+    let rows = invalidations.flatMap((id) => {
+      let types = existingTypes.get(id);
+      if (!types || types.length === 0) {
+        return [];
+      }
+      return types.map((type) =>
+        [
+          id,
+          trimExecutableExtension(new URL(id)).href,
+          type,
+          this.realmVersion,
+          this.realmURL.href,
+          true,
+        ].map((v) => [param(v)]),
+      );
+    });
+
+    if (rows.length === 0) {
+      return;
+    }
 
     await this.#query([
       ...upsertMultipleRows(
@@ -587,6 +605,37 @@ export class Batch {
         rows,
       ),
     ]);
+  }
+
+  private async existingIndexTypes(
+    invalidations: string[],
+  ): Promise<Map<string, BoxelIndexTable['type'][]>> {
+    if (invalidations.length === 0) {
+      return new Map();
+    }
+    let uniqueInvalidations = [...new Set(invalidations)];
+    let rows = (await this.#query([
+      'SELECT DISTINCT url, type FROM boxel_index WHERE',
+      ...every([
+        ['realm_url =', param(this.realmURL.href)],
+        [
+          'url IN',
+          ...addExplicitParens(
+            separatedByCommas(uniqueInvalidations.map((id) => [param(id)])),
+          ),
+        ],
+      ]),
+    ] as Expression)) as Pick<BoxelIndexTable, 'url' | 'type'>[];
+    let typesByUrl = new Map<string, BoxelIndexTable['type'][]>();
+    for (let row of rows) {
+      let existing = typesByUrl.get(row.url);
+      if (existing) {
+        existing.push(row.type);
+      } else {
+        typesByUrl.set(row.url, [row.type]);
+      }
+    }
+    return typesByUrl;
   }
 
   async invalidate(urls: URL[]): Promise<void> {
@@ -797,5 +846,18 @@ export class Batch {
         }
       }
     }
+  }
+}
+
+function baseTypeFromError(
+  entry: ErrorEntry,
+): Extract<BoxelIndexTable['type'], 'instance' | 'module' | 'file'> {
+  switch (entry.type) {
+    case 'instance-error':
+      return 'instance';
+    case 'module-error':
+      return 'module';
+    case 'file-error':
+      return 'file';
   }
 }

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -191,7 +191,7 @@ export class RealmIndexQueryEngine {
     if (!instance) {
       return undefined;
     }
-    if (instance.type === 'error') {
+    if (instance.type === 'instance-error') {
       let scopedCssUrls = (instance.deps ?? []).filter(isScopedCSSRequest);
       return {
         type: 'error',

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -3101,7 +3101,7 @@ export class Realm {
     let errorRows = (await query(this.#dbAdapter, [
       `SELECT url, error_doc FROM boxel_index WHERE realm_url =`,
       param(sourceRealmURL),
-      `AND type = 'error'`,
+      `AND type = 'instance-error'`,
       `AND (is_deleted IS NULL OR is_deleted = FALSE)`,
     ])) as { url: string; error_doc: unknown | null }[];
 


### PR DESCRIPTION
Since we're introducing file indexing, and will potentially have errors for file entries and instance entries, a single `error` type is not enough. In addition, since a card json file may be indexed as both a card instance AND a file entry, the url PLUS type is needed to fully specify the row. 