### PR TITLE
coalesce getJoinedRooms() calls and createRealmSession calls

### DIFF
--- a/packages/host/app/services/matrix-sdk-loader.ts
+++ b/packages/host/app/services/matrix-sdk-loader.ts
@@ -18,6 +18,29 @@ import type MatrixService from './matrix-service';
 import type NetworkService from './network';
 import type * as MatrixSDK from 'matrix-js-sdk';
 
+type JoinedRoomsResponse = { joined_rooms: string[] };
+
+const joinedRoomsRequests = new WeakMap<
+  MatrixSDK.MatrixClient,
+  Promise<JoinedRoomsResponse>
+>();
+
+function getJoinedRoomsWithCache(client: MatrixSDK.MatrixClient) {
+  let existing = joinedRoomsRequests.get(client);
+  if (existing) {
+    return existing;
+  }
+  let request = client.getJoinedRooms();
+  joinedRoomsRequests.set(client, request);
+  let cleanup = () => {
+    if (joinedRoomsRequests.get(client) === request) {
+      joinedRoomsRequests.delete(client);
+    }
+  };
+  request.then(cleanup, cleanup);
+  return request;
+}
+
 /*
   This abstracts over the matrix SDK, including several extra functions that are
   actually implemented via direct HTTP.
@@ -269,6 +292,8 @@ function extendedClient({
           return loginWithEmail.bind(extendedTarget, fetch);
         case 'createRealmSession':
           return createRealmSession.bind(extendedTarget, fetch);
+        case 'getJoinedRooms':
+          return getJoinedRoomsWithCache.bind(null, target);
         case 'uploadCards':
           return fileDefManager.uploadCards.bind(fileDefManager);
         case 'uploadCommandDefinitions':

--- a/packages/runtime-common/matrix-client.ts
+++ b/packages/runtime-common/matrix-client.ts
@@ -130,7 +130,7 @@ export class MatrixClient {
   async getJoinedRooms() {
     let existing = joinedRoomsRequests.get(this);
     if (existing) {
-      return await existing;
+      return existing;
     }
     let request = (async () => {
       let response = await this.request('_matrix/client/v3/joined_rooms');


### PR DESCRIPTION
This PR coalesces the calls to `matrixClient.getJoinedRooms()` and the calls to the `RealmAuthClient.createRealmSession()` calls.