### PR TITLE
"Add workspace" dialog should generate display name correctly

### DIFF
--- a/packages/host/app/lib/random-name.ts
+++ b/packages/host/app/lib/random-name.ts
@@ -13,9 +13,14 @@ export function generateRandomWorkspaceName(): string {
     ? [adjectives, animals, numberDictionary]
     : [adjectives, animals];
 
-  return uniqueNamesGenerator({
+  let slug = uniqueNamesGenerator({
     dictionaries,
     separator: '-',
     style: 'lowerCase',
   });
+  return slug
+    .split('-')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
 }

--- a/packages/host/tests/integration/components/add-workspace-test.gts
+++ b/packages/host/tests/integration/components/add-workspace-test.gts
@@ -45,8 +45,16 @@ module('Integration | add-workspace', function (hooks) {
     let displayName = (
       find('[data-test-display-name-field]') as HTMLInputElement
     )?.value;
+    let endpoint = (find('[data-test-endpoint-field]') as HTMLInputElement)
+      ?.value;
 
     assert.ok(displayName?.length, 'display name is pre-populated');
+    assert.ok(displayName?.includes(' '), 'display name uses spaces');
+    assert.notEqual(
+      displayName,
+      endpoint,
+      'display name and endpoint are different',
+    );
     assert
       .dom('[data-test-endpoint-field]')
       .hasValue(cleanseString(displayName ?? ''));


### PR DESCRIPTION
- Generate title-cased display names for new workspaces so that it is more human readable
- Keep endpoint slugging

Here we can see that the display name is now more friendly to read (previously it was slugged): 
<img width="631" height="402" alt="image" src="https://github.com/user-attachments/assets/bffc8755-e421-466b-85bd-2d0e32e4af0c" />
