### PR TITLE
More efficient directory listings

### DIFF
--- a/packages/host/app/commands/ai-assistant.ts
+++ b/packages/host/app/commands/ai-assistant.ts
@@ -77,7 +77,7 @@ export default class UseAiAssistantCommand extends HostBaseCommand<
         attachedCards: [...(await attachedCardsPromise)],
         attachedFileURLs: input.attachedFileURLs,
         openCardIds: input.openCardIds,
-        realmUrl: this.operatorModeStateService.realmURL.href,
+        realmUrl: this.operatorModeStateService.realmURL,
         requireCommandCall: input.requireCommandCall,
       });
       return sendMessageResult;

--- a/packages/host/app/commands/ask-ai.ts
+++ b/packages/host/app/commands/ask-ai.ts
@@ -52,7 +52,7 @@ export default class AskAiCommand extends HostBaseCommand<
       prompt: input.prompt,
       attachedCards: openCards,
       openCardIds: openCards?.map((c: any) => c.id),
-      realmUrl: this.operatorModeStateService.realmURL?.href,
+      realmUrl: this.operatorModeStateService.realmURL,
     });
 
     await openRoomCommand.execute({ roomId });

--- a/packages/host/app/commands/copy-and-edit.ts
+++ b/packages/host/app/commands/copy-and-edit.ts
@@ -47,7 +47,7 @@ export default class CopyAndEditCommand extends HostBaseCommand<
       throw new Error('copy-and-edit requires a card with an id');
     }
 
-    let targetRealm = this.operatorModeStateService.realmURL?.href;
+    let targetRealm = this.operatorModeStateService.realmURL;
     if (!targetRealm) {
       throw new Error('Could not determine interact realm for card copy');
     }

--- a/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
@@ -76,7 +76,7 @@ export default class AttachedItems extends Component<Signature> {
   }
 
   private getCardErrorRealm(cardError: CardErrorJSONAPI) {
-    return cardError.realm ?? this.operatorModeStateService.realmURL.href;
+    return cardError.realm ?? this.operatorModeStateService.realmURL;
   }
 
   @action

--- a/packages/host/app/components/editor/directory.gts
+++ b/packages/host/app/components/editor/directory.gts
@@ -20,7 +20,7 @@ import { normalizeDirPath } from '@cardstack/host/utils/normalized-dir-path';
 interface Args {
   Args: {
     relativePath: string;
-    realmURL: URL;
+    realmURL: string;
     selectedFile?: LocalPath;
     openDirs?: LocalPath[];
     onFileSelected?: (entryPath: LocalPath) => void;
@@ -141,7 +141,7 @@ export default class Directory extends Component<Args> {
   private listing = directory(
     this,
     () => this.args.relativePath,
-    () => this.args.realmURL,
+    () => new URL(this.args.realmURL),
   );
 
   @tracked private selectedFile?: LocalPath;

--- a/packages/host/app/components/editor/directory.gts
+++ b/packages/host/app/components/editor/directory.gts
@@ -141,7 +141,7 @@ export default class Directory extends Component<Args> {
   private listing = directory(
     this,
     () => this.args.relativePath,
-    () => new URL(this.args.realmURL),
+    () => this.args.realmURL,
   );
 
   @tracked private selectedFile?: LocalPath;

--- a/packages/host/app/components/editor/file-tree.gts
+++ b/packages/host/app/components/editor/file-tree.gts
@@ -11,7 +11,7 @@ import Directory from './directory';
 
 interface Signature {
   Args: {
-    realmURL: URL;
+    realmURL: string;
     selectedFile?: LocalPath;
     openDirs?: LocalPath[];
     onFileSelected?: (entryPath: LocalPath) => Promise<void>;

--- a/packages/host/app/components/matrix/room-message-command.gts
+++ b/packages/host/app/components/matrix/room-message-command.gts
@@ -178,7 +178,7 @@ export default class RoomMessageCommand extends Component<Signature> {
   }
 
   private get activeRealmURL() {
-    return this.operatorModeStateService.realmURL?.href;
+    return this.operatorModeStateService.realmURL;
   }
 
   private get commandResultCardForRendering(): CardDef {

--- a/packages/host/app/components/operator-mode/ask-ai-container.gts
+++ b/packages/host/app/components/operator-mode/ask-ai-container.gts
@@ -70,7 +70,7 @@ export default class AskAiContainer extends Component<Signature> {
             ? [this.operatorModeStateService.openFileURL]
             : undefined,
           openCardIds: openCards?.map((c) => c.id),
-          realmUrl: this.operatorModeStateService.realmURL.href,
+          realmUrl: this.operatorModeStateService.realmURL,
         }),
       ]);
 

--- a/packages/host/app/components/operator-mode/card-url-bar.gts
+++ b/packages/host/app/components/operator-mode/card-url-bar.gts
@@ -26,7 +26,7 @@ interface Signature {
     userHasDismissedError: boolean; // user driven state that indicates if we should show error message
     resetLoadFileError: () => void; // callback to reset upstream error state -- perform on keypress
     dismissURLError: () => void; // callback allow user to dismiss the error message
-    realmURL: URL;
+    realmURL: string;
   };
 }
 
@@ -39,7 +39,7 @@ export default class CardURLBar extends Component<Signature> {
       ...attributes
     >
       <div class='realm-info' data-test-card-url-bar-realm-info>
-        {{#let (this.realm.info @realmURL.href) as |realmInfo|}}
+        {{#let (this.realm.info @realmURL) as |realmInfo|}}
           <RealmIcon
             class='url-realm-icon'
             @realmInfo={{realmInfo}}

--- a/packages/host/app/components/operator-mode/choose-file-modal.gts
+++ b/packages/host/app/components/operator-mode/choose-file-modal.gts
@@ -219,7 +219,7 @@ export default class ChooseFileModal extends Component<Signature> {
             @tag='div'
           >
             <FileTree
-              @realmURL={{this.selectedRealm.url}}
+              @realmURL={{this.selectedRealm.url.href}}
               @onFileSelected={{this.selectFile}}
             />
           </FieldContainer>

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -471,7 +471,7 @@ export default class CodeSubmode extends Component<Signature> {
         // TODO: This is a side effect of the recent-file service making assumptions about
         // what realm we are in. we should refactor that so that callers have to tell
         // it the realm of the file in question
-        let realmURL = this.operatorModeStateService.realmURL;
+        let realmURL = new URL(this.operatorModeStateService.realmURL);
 
         if (realmURL) {
           let realmPaths = new RealmPaths(realmURL);

--- a/packages/host/app/components/operator-mode/code-submode/left-panel-toggle.gts
+++ b/packages/host/app/components/operator-mode/code-submode/left-panel-toggle.gts
@@ -20,7 +20,7 @@ import ToggleButton from './toggle-button';
 interface Signature {
   Element: HTMLDivElement;
   Args: {
-    realmURL: URL;
+    realmURL: string;
     fileView: FileView | undefined;
     setFileView: (view: FileView) => void;
     isFileOpen: boolean;

--- a/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
+++ b/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
@@ -343,7 +343,7 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
       let currentRealm = this.operatorModeStateService.realmURL;
       const result = await createSpecCommand.execute({
         codeRef: ref,
-        targetRealm: currentRealm.href,
+        targetRealm: currentRealm,
       });
       const spec = result.specs?.[0];
       if (spec) {
@@ -369,7 +369,7 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
   }
 
   private get canWrite() {
-    return this.realm.canWrite(this.operatorModeStateService.realmURL.href);
+    return this.realm.canWrite(this.operatorModeStateService.realmURL);
   }
 
   get showCreateSpec() {

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
@@ -506,7 +506,7 @@ export default class PlaygroundPanel extends Component<Signature> {
   }
 
   private get currentRealm() {
-    return this.operatorModeStateService.realmURL.href;
+    return this.operatorModeStateService.realmURL;
   }
 
   private get canWriteRealm() {

--- a/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/spec-preview.gts
@@ -329,7 +329,7 @@ export default class SpecPreview extends GlimmerComponent<Signature> {
   }
 
   private get canWrite() {
-    return this.realm.canWrite(this.operatorModeStateService.realmURL.href);
+    return this.realm.canWrite(this.operatorModeStateService.realmURL);
   }
 
   get isLoading() {

--- a/packages/host/app/components/operator-mode/create-file-modal.gts
+++ b/packages/host/app/components/operator-mode/create-file-modal.gts
@@ -655,7 +655,7 @@ export default class CreateFileModal extends Component<Signature> {
         `Cannot determine selectedRealmURL when there is no this.currentRequest`,
       );
     }
-    return this.currentRequest.realmURL;
+    return this.currentRequest.realmURL?.href;
   }
 
   private get definitionClass() {
@@ -762,7 +762,7 @@ export default class CreateFileModal extends Component<Signature> {
 
     let isField = this.fileType.id === 'field-definition';
 
-    let realmPath = new RealmPaths(this.selectedRealmURL);
+    let realmPath = new RealmPaths(new URL(this.selectedRealmURL));
     // assert that filename is a GTS file and is a LocalPath
     let fileName: LocalPath = `${this.fileName.replace(
       /\.[^.].+$/,
@@ -799,7 +799,7 @@ export default class CreateFileModal extends Component<Signature> {
     let moduleURL = maybeRelativeURL(
       absoluteModule,
       url,
-      this.selectedRealmURL,
+      new URL(this.selectedRealmURL),
     );
     let src: string[] = [];
 
@@ -869,7 +869,7 @@ export class ${className} extends ${exportName} {
       this.commandService.commandContext,
     ).execute({
       sourceCard: this.currentRequest.sourceInstance,
-      targetRealm: this.selectedRealmURL.href,
+      targetRealm: this.selectedRealmURL,
     });
     this.currentRequest.newFileDeferred.fulfill(new URL(`${newCardId}.json`));
   });
@@ -912,7 +912,7 @@ export class ${className} extends ${exportName} {
       data: {
         meta: {
           adoptsFrom: ref,
-          realmURL: this.selectedRealmURL.href,
+          realmURL: this.selectedRealmURL,
         },
       },
     };
@@ -920,7 +920,7 @@ export class ${className} extends ${exportName} {
     try {
       let maybeId = await this.store.create(doc, {
         relativeTo,
-        realm: this.selectedRealmURL.href,
+        realm: this.selectedRealmURL,
       });
       if (typeof maybeId !== 'string') {
         let error = maybeId;
@@ -953,7 +953,7 @@ export class ${className} extends ${exportName} {
       return;
     }
 
-    let realmPath = new RealmPaths(this.selectedRealmURL);
+    let realmPath = new RealmPaths(new URL(this.selectedRealmURL));
     let filePath: LocalPath = fileName as LocalPath;
     let url = realmPath.fileURL(filePath);
 

--- a/packages/host/app/components/operator-mode/host-submode/publishing-realm-popover.gts
+++ b/packages/host/app/components/operator-mode/host-submode/publishing-realm-popover.gts
@@ -19,7 +19,7 @@ export default class PublishingRealmPopover extends Component<PublishingRealmArg
   }
 
   get realmURL() {
-    return this.operatorModeStateService.realmURL.href;
+    return this.operatorModeStateService.realmURL;
   }
 
   <template>

--- a/packages/host/app/components/realm-dropdown.gts
+++ b/packages/host/app/components/realm-dropdown.gts
@@ -26,7 +26,7 @@ export interface RealmDropdownItem extends EnhancedRealmInfo {
 interface Signature {
   Args: {
     onSelect: (item: RealmDropdownItem) => void;
-    selectedRealmURL: URL | undefined;
+    selectedRealmURL: string | undefined;
     disabled?: boolean;
     contentClass?: string;
     selectedRealmPrefix?: string;
@@ -142,7 +142,7 @@ export default class RealmDropdown extends Component<Signature> {
 
   allRealmsInfo = trackedFunction(this, async () => {
     if (this.args.selectedRealmURL) {
-      await this.realm.ensureRealmMeta(this.args.selectedRealmURL.href);
+      await this.realm.ensureRealmMeta(this.args.selectedRealmURL);
     }
     return this.realm.allRealmsInfo;
   });
@@ -187,7 +187,8 @@ export default class RealmDropdown extends Component<Signature> {
     if (this.args.selectedRealmURL) {
       selectedRealm = this.realms.find(
         (realm) =>
-          realm.path === new RealmPaths(this.args.selectedRealmURL!).url,
+          realm.path ===
+          new RealmPaths(new URL(this.args.selectedRealmURL!)).url,
       );
     }
     if (selectedRealm) {

--- a/packages/host/app/services/host-mode-service.ts
+++ b/packages/host/app/services/host-mode-service.ts
@@ -72,7 +72,7 @@ export default class HostModeService extends Service {
   }
 
   get realmURL() {
-    return this.operatorModeStateService.realmURL.href;
+    return this.operatorModeStateService.realmURL;
   }
 
   get currentCardId() {

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -484,9 +484,9 @@ export default class OperatorModeStateService extends Service {
   private getRealmURLFromItemId(itemId: string): string {
     try {
       const url = new URL(itemId);
-      return this.realm.realmOfURL(url)?.href ?? this.realmURL.href;
+      return this.realm.realmOfURL(url)?.href ?? this.realmURL;
     } catch (error) {
-      return this.realmURL.href;
+      return this.realmURL;
     }
   }
 
@@ -641,7 +641,7 @@ export default class OperatorModeStateService extends Service {
 
   get codePathRelativeToRealm() {
     if (this._state.codePath && this.realmURL) {
-      let realmPath = new RealmPaths(this.realmURL);
+      let realmPath = new RealmPaths(new URL(this.realmURL));
 
       if (realmPath.inRealm(this._state.codePath)) {
         try {
@@ -663,7 +663,7 @@ export default class OperatorModeStateService extends Service {
   }
 
   onFileSelected = async (entryPath: LocalPath) => {
-    let fileUrl = new RealmPaths(this.realmURL).fileURL(entryPath);
+    let fileUrl = new RealmPaths(new URL(this.realmURL)).fileURL(entryPath);
     await this.updateCodePath(fileUrl);
   };
 
@@ -749,7 +749,7 @@ export default class OperatorModeStateService extends Service {
   get title() {
     if (this._state.submode === Submodes.Code) {
       return `${this.codePathRelativeToRealm} in ${
-        this.realm.info(this.realmURL.href).name
+        this.realm.info(this.realmURL).name
       }`;
     } else {
       let itemForTitle = this.topMostStackItems().pop(); // top-most card of right stack
@@ -780,7 +780,7 @@ export default class OperatorModeStateService extends Service {
 
   get currentRealmOpenDirs() {
     if (this.realmURL) {
-      let currentRealmOpenDirs = this.openDirs.get(this.realmURL.href);
+      let currentRealmOpenDirs = this.openDirs.get(this.realmURL);
 
       if (currentRealmOpenDirs) {
         return currentRealmOpenDirs;
@@ -986,7 +986,7 @@ export default class OperatorModeStateService extends Service {
       dirs.push(dirPath);
     }
 
-    this.openDirs.set(this.realmURL.href, new TrackedArray(dirs));
+    this.openDirs.set(this.realmURL, new TrackedArray(dirs));
     this.schedulePersist();
   };
 
@@ -1003,11 +1003,12 @@ export default class OperatorModeStateService extends Service {
     return isReady(this.openFile.current);
   }
 
-  get realmURL(): URL {
+  @cached
+  get realmURL(): string {
     let { submode } = this._state;
     if (submode === Submodes.Code) {
       if (isReady(this.openFile.current)) {
-        return new URL(this.readyFile.realmURL);
+        return this.readyFile.realmURL;
       }
     }
 
@@ -1029,7 +1030,7 @@ export default class OperatorModeStateService extends Service {
         if (cardId) {
           let realm = this.realm.url(cardId);
           if (realm) {
-            return new URL(realm);
+            return realm;
           }
         }
       }
@@ -1043,20 +1044,20 @@ export default class OperatorModeStateService extends Service {
         let cardId = this._state.hostModePrimaryCard.replace(/\.json$/, '');
         let realm = this.realm.url(cardId);
         if (realm) {
-          return new URL(realm);
+          return realm;
         }
       }
     }
 
     if (this.cachedRealmURL) {
-      return this.cachedRealmURL;
+      return this.cachedRealmURL.href;
     }
 
-    return new URL(this.realm.defaultReadableRealm.path);
+    return this.realm.defaultReadableRealm.path;
   }
 
   get currentRealmInfo() {
-    return this.realm.info(this.realmURL.href);
+    return this.realm.info(this.realmURL);
   }
 
   getWritableRealmURL = (preferredURLs: string[] = []) => {
@@ -1067,7 +1068,7 @@ export default class OperatorModeStateService extends Service {
     // 3. Otherwise, fallback to the last opened writable realm, especially if the opening click is from dashboard.
     let urlsToCheck = [
       ...preferredURLs,
-      this.realmURL.href,
+      this.realmURL,
       this.cachedRealmURL?.href,
     ].filter(Boolean) as string[];
 
@@ -1312,7 +1313,7 @@ export default class OperatorModeStateService extends Service {
     }
 
     let openCardIds = this.makeRemoteIdsList([...openCardIdsSet]);
-    let realmUrl = this.realmURL.href;
+    let realmUrl = this.realmURL;
     let realmPermissions = {
       canRead: this.realm.canRead(realmUrl),
       canWrite: this.realm.canWrite(realmUrl),

--- a/packages/host/app/services/recent-files-service.ts
+++ b/packages/host/app/services/recent-files-service.ts
@@ -158,7 +158,7 @@ export default class RecentFilesService extends Service {
 
     return this.recentFiles.findIndex(
       ({ realmURL, filePath }) =>
-        realmURL.href === currentRealmUrl.href && filePath === path,
+        realmURL.href === currentRealmUrl && filePath === path,
     );
   }
 

--- a/packages/host/testem.js
+++ b/packages/host/testem.js
@@ -11,6 +11,7 @@ const config = {
   disable_watching: true,
   browser_timeout: 120,
   browser_no_activity_timeout: 120,
+  browser_disconnect_timeout: 20,
   launch_in_ci: ['Chrome'],
   launch_in_dev: ['Chrome'],
   browser_start_timeout: 240,


### PR DESCRIPTION
This PR fixes a bug in our directory resource where each click of a file in the file tree would trigger a request to get directory listings recursively for all the subdirectories in a realm--which was crazy expensive for big realms like the catalog realm. 

It came down to a couple things: using a `URL` object as a component argument would trigger a rerender when the URL is reinstantiated for the same href which was happening in the `OperatorModeStateService.realmURL` getter. We've seen this in rerender bugs in other parts of the app in the past. we need to be careful when passing objects as component params, as that can destabilize the component when object identity unnecessarily changes.

Additionally, the `DirectoryResource` was just blindly requesting directory entries regardless of whether we already requested entries for the same directory. 

Now when we click on the file entries in the file tree we no longer see our client recursively requesting all directory listings in the realm on each click.

https://github.com/user-attachments/assets/f470120e-4a1c-4554-a8f7-819bedef7433


