### PR TITLE
Use render model fallback for render routes

### DIFF
--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -58,9 +58,10 @@ import type RenderStoreService from '../services/render-store';
 type RenderStatus = 'loading' | 'ready' | 'error' | 'unusable';
 
 export type Model = {
-  instance: CardDef;
+  instance?: CardDef;
   nonce: string;
   cardId: string;
+  renderOptions: ReturnType<typeof parseRenderRouteOptions>;
   readonly status: RenderStatus;
   readonly ready: boolean;
   readyPromise: Promise<void>;
@@ -133,7 +134,7 @@ export default class RenderRoute extends Route<Model> {
 
   deactivate() {
     (globalThis as any).__boxelRenderContext = undefined;
-    (globalThis as any).__renderInstance = undefined;
+    (globalThis as any).__renderModel = undefined;
     window.removeEventListener('boxel-render-error', this.handleRenderError);
     this.#detachWindowErrorListeners();
     this.lastStoreResetKey = undefined;
@@ -216,7 +217,7 @@ export default class RenderRoute extends Route<Model> {
       }
     }
     // This is for host tests
-    (globalThis as any).__renderInstance = undefined;
+    (globalThis as any).__renderModel = undefined;
 
     let response: Response;
     try {
@@ -263,6 +264,7 @@ export default class RenderRoute extends Route<Model> {
       instance: undefined as unknown as CardDef,
       nonce,
       cardId: canonicalId,
+      renderOptions: parsedOptions,
       get status(): RenderStatus {
         return (state.get('status') as RenderStatus) ?? 'loading';
       },
@@ -331,7 +333,7 @@ export default class RenderRoute extends Route<Model> {
 
     // this is to support in-browser rendering, where we actually don't have the
     // ability to lookup the parent route using RouterService.recognizeAndLoad()
-    (globalThis as any).__renderInstance = instance;
+    (globalThis as any).__renderModel = model;
     this.currentTransition = undefined;
     return model;
   }

--- a/packages/host/app/routes/render/html.ts
+++ b/packages/host/app/routes/render/html.ts
@@ -30,14 +30,15 @@ export default class RenderHtmlRoute extends Route<Model> {
     format: string;
     ancestor_level: string;
   }) {
-    let parentModel = this.modelFor('render') as ParentModel;
-    let instance: CardDef;
-    if (!parentModel) {
-      // this is to support in-browser rendering, where we actually don't have the
-      // ability to lookup the parent route using RouterService.recognizeAndLoad()
-      instance = (globalThis as any).__renderInstance;
-    } else {
-      instance = parentModel.instance;
+    let parentModel = this.modelFor('render') as ParentModel | undefined;
+    // the global use below is to support in-browser rendering, where we actually don't have the
+    // ability to lookup the parent route using RouterService.recognizeAndLoad()
+    let renderModel =
+      parentModel ??
+      ((globalThis as any).__renderModel as ParentModel | undefined);
+    let instance: CardDef | undefined = renderModel?.instance;
+    if (!instance) {
+      throw new Error('Missing render instance');
     }
 
     if (!isValidFormat(format)) {

--- a/packages/host/app/routes/render/icon.ts
+++ b/packages/host/app/routes/render/icon.ts
@@ -15,14 +15,15 @@ export interface Model {
 
 export default class RenderIconRoute extends Route<Model> {
   async model() {
-    let parentModel = this.modelFor('render') as ParentModel;
-    let instance: CardDef;
-    if (!parentModel) {
-      // this is to support in-browser rendering, where we actually don't have the
-      // ability to lookup the parent route using RouterService.recognizeAndLoad()
-      instance = (globalThis as any).__renderInstance;
-    } else {
-      instance = parentModel.instance;
+    let parentModel = this.modelFor('render') as ParentModel | undefined;
+    // the global use below is to support in-browser rendering, where we actually don't have the
+    // ability to lookup the parent route using RouterService.recognizeAndLoad()
+    let renderModel =
+      parentModel ??
+      ((globalThis as any).__renderModel as ParentModel | undefined);
+    let instance: CardDef | undefined = renderModel?.instance;
+    if (!instance) {
+      throw new Error('Missing render instance');
     }
     return { Component: cardTypeIcon(instance) };
   }

--- a/packages/host/app/routes/render/meta.ts
+++ b/packages/host/app/routes/render/meta.ts
@@ -40,15 +40,13 @@ export default class RenderMetaRoute extends Route<Model> {
   async model(_: unknown, transition: Transition) {
     let api = await this.cardService.getAPI();
     let parentModel = this.modelFor('render') as ParentModel | undefined;
-    await parentModel?.readyPromise;
-    let instance: CardDef;
-    if (!parentModel) {
-      // this is to support in-browser rendering, where we actually don't have the
-      // ability to lookup the parent route using RouterService.recognizeAndLoad()
-      instance = (globalThis as any).__renderInstance;
-    } else {
-      instance = parentModel.instance;
-    }
+    // the global use below is to support in-browser rendering, where we actually don't have the
+    // ability to lookup the parent route using RouterService.recognizeAndLoad()
+    let renderModel =
+      parentModel ??
+      ((globalThis as any).__renderModel as ParentModel | undefined);
+    await renderModel?.readyPromise;
+    let instance: CardDef | undefined = renderModel?.instance;
 
     if (!instance) {
       // the lack of an instance is dealt with in the parent route

--- a/packages/host/tests/acceptance/prerender-html-test.gts
+++ b/packages/host/tests/acceptance/prerender-html-test.gts
@@ -804,7 +804,8 @@ module('Acceptance | prerender | html', function (hooks) {
     let url = `${testRealmURL}Cat/paper.json`;
     await visit(renderPath(url, '/html/isolated/0'));
 
-    let renderInstance = (globalThis as any).__renderInstance;
+    let renderModel = (globalThis as any).__renderModel;
+    let renderInstance = renderModel?.instance;
     assert.ok(renderInstance, 'render instance exists when prerendering');
 
     // Mutate the rendered instance between the visit and capture, mirroring instance mutations that


### PR DESCRIPTION
- Store render route model instead of instance to support file-extract route better in an upcoming PR
- Update render subroutes (html/icon/meta) to use the global render model fallback
