### PR TITLE
Prevent displaying the input field for computed contains fields

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -968,7 +968,31 @@ class Contains<CardT extends FieldDefConstructor> implements Field<CardT, any> {
   }
 
   component(model: Box<BaseDef>): BoxComponent {
-    return fieldComponent(this, model);
+    let isComputed = !!this.computeVia;
+    let field = this;
+    return class ContainsComponent extends GlimmerComponent<{
+      Element: HTMLElement;
+      Args: { Named: { format?: Format } };
+    }> {
+      getEffectifeFormat = (defaultFormats: FieldFormats) => {
+        let format = this.args.format ?? defaultFormats.fieldDef;
+        if (format === 'edit' && isComputed) {
+          return 'embedded';
+        }
+        return format;
+      };
+
+      <template>
+        <DefaultFormatsConsumer as |defaultFormats|>
+          {{#let (fieldComponent field model) as |FieldComponent|}}
+            <FieldComponent
+              @format={{this.getEffectifeFormat defaultFormats}}
+              ...attributes
+            />
+          {{/let}}
+        </DefaultFormatsConsumer>
+      </template>
+    };
   }
 }
 

--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -968,31 +968,7 @@ class Contains<CardT extends FieldDefConstructor> implements Field<CardT, any> {
   }
 
   component(model: Box<BaseDef>): BoxComponent {
-    let isComputed = !!this.computeVia;
-    let field = this;
-    return class ContainsComponent extends GlimmerComponent<{
-      Element: HTMLElement;
-      Args: { Named: { format?: Format } };
-    }> {
-      getEffectifeFormat = (defaultFormats: FieldFormats) => {
-        let format = this.args.format ?? defaultFormats.fieldDef;
-        if (format === 'edit' && isComputed) {
-          return 'embedded';
-        }
-        return format;
-      };
-
-      <template>
-        <DefaultFormatsConsumer as |defaultFormats|>
-          {{#let (fieldComponent field model) as |FieldComponent|}}
-            <FieldComponent
-              @format={{this.getEffectifeFormat defaultFormats}}
-              ...attributes
-            />
-          {{/let}}
-        </DefaultFormatsConsumer>
-      </template>
-    };
+    return fieldComponent(this, model);
   }
 }
 

--- a/packages/base/field-component.gts
+++ b/packages/base/field-component.gts
@@ -176,6 +176,10 @@ export function getBoxComponent(
       userFormat && availableFormats.includes(userFormat)
         ? { fieldDef: userFormat, cardDef: userFormat }
         : defaultFormats;
+    if (field?.computeVia && result.fieldDef === 'edit') {
+      // Computed fields should never render in edit mode.
+      result = { ...result, fieldDef: 'embedded' };
+    }
     return result;
   }
 

--- a/packages/host/tests/acceptance/interact-submode-creation-and-permissions-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-creation-and-permissions-test.gts
@@ -549,9 +549,15 @@ module(
           .containsText('address is editable');
 
         await click('[data-test-operator-mode-stack] [data-test-edit-button]');
-
         assert
-          .dom("[data-test-contains-many='additionalAddresses'] input:disabled")
+          .dom(
+            "[data-test-contains-many='additionalAddresses'] [data-test-field='title'] input",
+          )
+          .doesNotExist();
+        assert
+          .dom(
+            "[data-test-contains-many='additionalAddresses'] [data-test-field='title']",
+          )
           .exists({ count: 1 });
 
         assert

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -1997,8 +1997,8 @@ module('Integration | card-basics', function (hooks) {
       assert.dom('[data-test-thumbnail-icon]').exists();
       await click('[data-test-toggle-thumbnail-editor]');
       assert
-        .dom('[data-test-thumbnail-placeholder] input')
-        .hasValue('http://book/pic.jpg');
+        .dom('[data-test-thumbnail-placeholder]')
+        .hasText('http://book/pic.jpg');
       assert.dom('[data-test-thumbnail-input] input').hasNoValue();
       await click('[data-test-toggle-thumbnail-editor]');
       assert

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -1997,8 +1997,8 @@ module('Integration | card-basics', function (hooks) {
       assert.dom('[data-test-thumbnail-icon]').exists();
       await click('[data-test-toggle-thumbnail-editor]');
       assert
-        .dom('[data-test-thumbnail-placeholder]')
-        .hasText('http://book/pic.jpg');
+        .dom('[data-test-thumbnail-placeholder] input')
+        .hasValue('http://book/pic.jpg');
       assert.dom('[data-test-thumbnail-input] input').hasNoValue();
       await click('[data-test-toggle-thumbnail-editor]');
       assert
@@ -2059,8 +2059,8 @@ module('Integration | card-basics', function (hooks) {
         .hasValue('The latest novel from John Doe');
       await click('[data-test-toggle-thumbnail-editor]');
       assert
-        .dom('[data-test-thumbnail-placeholder]')
-        .hasText('http://book/pic.jpg');
+        .dom('[data-test-thumbnail-placeholder] input')
+        .hasValue('http://book/pic.jpg');
       assert.dom('[data-test-thumbnail-input] input').hasNoValue();
       await click('[data-test-toggle-thumbnail-editor]');
       assert.dom('[data-test-field="title"] input').hasValue('Insomniac');

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -1997,8 +1997,8 @@ module('Integration | card-basics', function (hooks) {
       assert.dom('[data-test-thumbnail-icon]').exists();
       await click('[data-test-toggle-thumbnail-editor]');
       assert
-        .dom('[data-test-thumbnail-placeholder] input')
-        .hasValue('http://book/pic.jpg');
+        .dom('[data-test-thumbnail-placeholder]')
+        .hasText('http://book/pic.jpg');
       assert.dom('[data-test-thumbnail-input] input').hasNoValue();
       await click('[data-test-toggle-thumbnail-editor]');
       assert
@@ -2059,8 +2059,8 @@ module('Integration | card-basics', function (hooks) {
         .hasValue('The latest novel from John Doe');
       await click('[data-test-toggle-thumbnail-editor]');
       assert
-        .dom('[data-test-thumbnail-placeholder] input')
-        .hasValue('http://book/pic.jpg');
+        .dom('[data-test-thumbnail-placeholder]')
+        .hasText('http://book/pic.jpg');
       assert.dom('[data-test-thumbnail-input] input').hasNoValue();
       await click('[data-test-toggle-thumbnail-editor]');
       assert.dom('[data-test-field="title"] input').hasValue('Insomniac');

--- a/packages/host/tests/integration/components/card-def-field-def-relationships-test.gts
+++ b/packages/host/tests/integration/components/card-def-field-def-relationships-test.gts
@@ -399,6 +399,25 @@ module('Integration | CardDef-FieldDef relationships test', function (hooks) {
       .exists('top level containsMany field item has remove button');
   });
 
+  test('computed contains field renders embedded in edit format', async function (assert) {
+    class ContactCard extends CardDef {
+      @field name = contains(StringField, {
+        computeVia: () => 'Marcelius Wilde',
+      });
+    }
+
+    let card = new ContactCard();
+
+    await renderCard(loader, card, 'edit');
+
+    assert
+      .dom('[data-test-field="name"] input')
+      .doesNotExist('computed field does not render an edit input');
+    assert
+      .dom('[data-test-field="name"]')
+      .containsText('Marcelius Wilde', 'computed value is rendered');
+  });
+
   test('render a CardDef field (singular) linked to from a FieldDef', async function (assert) {
     class CurrencyCard extends CardDef {
       static displayName = 'Currency';

--- a/packages/host/tests/integration/components/computed-test.gts
+++ b/packages/host/tests/integration/components/computed-test.gts
@@ -327,7 +327,7 @@ module('Integration | computeds', function (hooks) {
     assert.strictEqual(family.totalAge, 10, 'computed is correct');
   });
 
-  test('computed fields render as embeeded format in the edit format', async function (assert) {
+  test('computed fields render as embedded format in the edit format', async function (assert) {
     class Person extends CardDef {
       @field firstName = contains(StringField);
       @field alias = contains(StringField, {

--- a/packages/host/tests/integration/components/computed-test.gts
+++ b/packages/host/tests/integration/components/computed-test.gts
@@ -327,7 +327,7 @@ module('Integration | computeds', function (hooks) {
     assert.strictEqual(family.totalAge, 10, 'computed is correct');
   });
 
-  test('computed fields render as disabled in the edit format', async function (assert) {
+  test('computed fields render as embeeded format in the edit format', async function (assert) {
     class Person extends CardDef {
       @field firstName = contains(StringField);
       @field alias = contains(StringField, {
@@ -339,8 +339,8 @@ module('Integration | computeds', function (hooks) {
 
     let person = new Person({ firstName: 'Mango' });
     await renderCard(loader, person, 'edit');
-    assert.dom('[data-test-field=alias] input').hasValue('Mango');
-    assert.dom('[data-test-field=alias] input').hasAttribute('disabled');
+    assert.dom('[data-test-field=alias] input').doesNotExist();
+    assert.dom('[data-test-field=alias]').hasText('Alias Mango');
   });
 
   test('can render a computed linksTo relationship', async function (assert) {

--- a/packages/host/tests/integration/enum-field-test.gts
+++ b/packages/host/tests/integration/enum-field-test.gts
@@ -383,8 +383,8 @@ module('Integration | enumField', function (hooks) {
     assert.deepEqual(arr, [null, 'Medium'], 'preserves null element in array');
   });
 
-  test('enumField edit respects @canEdit (computed fields are disabled)', async function (assert) {
-    assert.expect(2);
+  test('enumField edit respects @canEdit (computed fields are displayed as embedded format)', async function (assert) {
+    assert.expect(3);
 
     const PriorityField = enumField(StringField, {
       options: ['High', 'Medium', 'Low'],
@@ -414,10 +414,12 @@ module('Integration | enumField', function (hooks) {
     // Computed select is disabled
     assert
       .dom('[data-test-field="priority"] .boxel-select')
-      .hasAttribute(
-        'aria-disabled',
-        'true',
-        'computed enum should be disabled',
+      .doesNotExist('computed enum should not render in edit format');
+    assert
+      .dom('[data-test-field="priority"]')
+      .hasText(
+        'Priority High',
+        'computed enum renders as embedded format showing current value',
       );
   });
 


### PR DESCRIPTION
The aim of this PR is to clarify that a computed `contains` field cannot be edited. Previously, we displayed a disabled input field, however, this did not clearly indicate that the field was not editable. In this PR, I added logic to prevent `edit` format from being used for computed fields, so the input field is no longer displayed.


Before:

<img width="785" height="199" alt="Screenshot 2026-01-08 at 20 30 31" src="https://github.com/user-attachments/assets/85e023d0-8d27-4ec4-8a69-d961cb6b1a0a" />

After:

<img width="777" height="194" alt="Screenshot 2026-01-08 at 20 29 58" src="https://github.com/user-attachments/assets/6abb7b42-6ff4-49b2-be04-d24867ff806c" />

