### PR TITLE
ci: Create repository deployments

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -13,7 +13,60 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+  deployments: write
+
 jobs:
+  create-deployment:
+    name: Create GitHub deployment
+    runs-on: ubuntu-latest
+    outputs:
+      deployment-id: ${{ steps.create.outputs.deployment_id }}
+      environment-url: ${{ steps.env.outputs.environment_url }}
+    steps:
+      - id: env
+        run: |
+          if [ "${{ inputs.environment }}" = "production" ]; then
+            echo "environment_url=https://app.boxel.ai" >> "$GITHUB_OUTPUT"
+          elif [ "${{ inputs.environment }}" = "staging" ]; then
+            echo "environment_url=https://realms-staging.stack.cards" >> "$GITHUB_OUTPUT"
+          else
+            echo "environment_url=" >> "$GITHUB_OUTPUT"
+          fi
+      - id: create
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const environment = '${{ inputs.environment }}';
+            const response = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.sha,
+              required_contexts: [],
+              auto_merge: false,
+              environment,
+              description: `Manual deploy to ${environment}`,
+              transient_environment: false,
+              production_environment: environment === 'production',
+            });
+            core.setOutput('deployment_id', response.data.id.toString());
+      - name: Mark deployment in progress
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const deployment_id = Number('${{ steps.create.outputs.deployment_id }}');
+            const environment_url = '${{ steps.env.outputs.environment_url }}' || undefined;
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id,
+              state: 'in_progress',
+              environment_url,
+              log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              description: 'Deployment started',
+            });
+
   build-ai-bot:
     name: Build ai-bot Docker image
     uses: cardstack/gh-actions/.github/workflows/docker-ecr.yml@main
@@ -240,3 +293,68 @@ jobs:
             echo "Response body: $response_body"
             exit 1
           fi
+
+  finalize-deployment:
+    name: Update GitHub deployment status
+    needs:
+      [
+        create-deployment,
+        build-ai-bot,
+        deploy-ai-bot,
+        build-host,
+        deploy-host,
+        deploy-motion,
+        deploy-ui,
+        build-realm-server,
+        build-prerender-manager,
+        build-prerender,
+        build-worker,
+        build-pg-migration,
+        migrate-db,
+        post-migrate-db,
+        deploy-prerender,
+        deploy-prerender-manager,
+        deploy-worker,
+        post-deploy-worker,
+        deploy-realm-server,
+        post-deploy-realm-server
+      ]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set deployment status
+        uses: actions/github-script@v7
+        env:
+          NEEDS: ${{ toJson(needs) }}
+          DEPLOYMENT_ID: ${{ needs.create-deployment.outputs.deployment-id }}
+          ENVIRONMENT_URL: ${{ needs.create-deployment.outputs.environment-url }}
+        with:
+          script: |
+            const deploymentIdRaw = process.env.DEPLOYMENT_ID;
+            if (!deploymentIdRaw) {
+              core.info('No deployment id found; skipping status update.');
+              return;
+            }
+
+            const needs = JSON.parse(process.env.NEEDS);
+            const results = Object.values(needs).map((job) => job.result);
+            let state = 'success';
+            if (results.includes('failure')) {
+              state = 'failure';
+            } else if (results.includes('cancelled')) {
+              state = 'inactive';
+            }
+
+            const environment_url = process.env.ENVIRONMENT_URL || undefined;
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: Number(deploymentIdRaw),
+              state,
+              environment_url,
+              log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              description:
+                state === 'success'
+                  ? 'Deployment finished'
+                  : 'Deployment finished with errors',
+            });

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -57,7 +57,11 @@ jobs:
         with:
           script: |
             const deployment_id = Number('${{ steps.create.outputs.deployment_id }}');
-            const environment_url = '${{ steps.env.outputs.environment_url }}' || undefined;
+            const environmentUrlValue = '${{ steps.env.outputs.environment_url }}';
+            const environment_url =
+              environmentUrlValue && environmentUrlValue.length > 0
+                ? environmentUrlValue
+                : undefined;
             await github.rest.repos.createDeploymentStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -344,7 +348,11 @@ jobs:
               state = 'inactive';
             }
 
-            const environment_url = process.env.ENVIRONMENT_URL || undefined;
+            const environment_url =
+              process.env.ENVIRONMENT_URL &&
+              process.env.ENVIRONMENT_URL.length > 0
+                ? process.env.ENVIRONMENT_URL
+                : undefined;
             await github.rest.repos.createDeploymentStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -16,6 +16,7 @@ on:
 permissions:
   contents: read
   deployments: write
+  id-token: write
 
 jobs:
   create-deployment:

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -304,8 +304,6 @@ jobs:
         deploy-ai-bot,
         build-host,
         deploy-host,
-        deploy-motion,
-        deploy-ui,
         build-realm-server,
         build-prerender-manager,
         build-prerender,
@@ -318,7 +316,7 @@ jobs:
         deploy-worker,
         post-deploy-worker,
         deploy-realm-server,
-        post-deploy-realm-server
+        post-deploy-realm-server,
       ]
     if: always()
     runs-on: ubuntu-latest


### PR DESCRIPTION
This wires up our `manual-deploy` workflow with the Github deployments API so we can see them attached to PRs:

<img width="945" height="631" alt="boxel 2026-01-08 11-46-33" src="https://github.com/user-attachments/assets/bb31dc0e-7750-4312-b23e-52e97fde8129" />
