### PR TITLE
Fix transitive dep skipping

### DIFF
--- a/packages/boxel-ui/addon/src/components/date-range-picker/index.gts
+++ b/packages/boxel-ui/addon/src/components/date-range-picker/index.gts
@@ -1,10 +1,11 @@
+import 'ember-power-calendar/styles';
+
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import PowerCalendarRange from 'ember-power-calendar/components/power-calendar-range';
-import 'ember-power-calendar/styles';
 import { type TPowerCalendarRangeOnSelect } from 'ember-power-calendar/components/power-calendar-range';
 import powerCalendarFormatDate from 'ember-power-calendar/helpers/power-calendar-format-date';
 import {

--- a/packages/boxel-ui/addon/src/components/date-range-picker/index.gts
+++ b/packages/boxel-ui/addon/src/components/date-range-picker/index.gts
@@ -4,6 +4,7 @@ import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import PowerCalendarRange from 'ember-power-calendar/components/power-calendar-range';
+import 'ember-power-calendar/styles';
 import { type TPowerCalendarRangeOnSelect } from 'ember-power-calendar/components/power-calendar-range';
 import powerCalendarFormatDate from 'ember-power-calendar/helpers/power-calendar-format-date';
 import {
@@ -179,7 +180,7 @@ export default class DateRangePicker extends Component<Signature> {
         margin-top: auto;
       }
     </style>
-    {{! 
+    {{!
     Note: I don't think there is any reason why we can't implement scoped styles here unlike ember-power-select which uses wormholes
     but we do so for now to avoid the complexity of maintaining fidelity with the way the ember-power-calendar styles are implemented.
     We do so intentionally to

--- a/packages/boxel-ui/addon/src/components/multi-select/index.gts
+++ b/packages/boxel-ui/addon/src/components/multi-select/index.gts
@@ -1,3 +1,5 @@
+import 'ember-power-select/styles';
+
 import Component from '@glimmer/component';
 import type { ComponentLike } from '@glint/template';
 import type {
@@ -5,7 +7,6 @@ import type {
   Select,
 } from 'ember-power-select/components/power-select';
 import BeforeOptions from 'ember-power-select/components/power-select/before-options';
-import 'ember-power-select/styles';
 import PowerSelectMultiple from 'ember-power-select/components/power-select-multiple';
 
 import { BoxelAfterOptionsComponent } from './after-options.gts';

--- a/packages/boxel-ui/addon/src/components/multi-select/index.gts
+++ b/packages/boxel-ui/addon/src/components/multi-select/index.gts
@@ -5,6 +5,7 @@ import type {
   Select,
 } from 'ember-power-select/components/power-select';
 import BeforeOptions from 'ember-power-select/components/power-select/before-options';
+import 'ember-power-select/styles';
 import PowerSelectMultiple from 'ember-power-select/components/power-select-multiple';
 
 import { BoxelAfterOptionsComponent } from './after-options.gts';

--- a/packages/boxel-ui/addon/src/components/select/index.gts
+++ b/packages/boxel-ui/addon/src/components/select/index.gts
@@ -1,3 +1,5 @@
+import 'ember-power-select/styles';
+
 import Check from '@cardstack/boxel-icons/check';
 import { eq } from '@cardstack/boxel-ui/helpers';
 import { concat } from '@ember/helper';
@@ -11,7 +13,6 @@ import PowerSelect, {
   type PowerSelectArgs,
 } from 'ember-power-select/components/power-select';
 import BeforeOptions from 'ember-power-select/components/power-select/before-options';
-import 'ember-power-select/styles';
 import PowerSelectOptions from 'ember-power-select/components/power-select/options';
 
 import cn from '../../helpers/cn.ts';

--- a/packages/boxel-ui/addon/src/components/select/index.gts
+++ b/packages/boxel-ui/addon/src/components/select/index.gts
@@ -11,6 +11,7 @@ import PowerSelect, {
   type PowerSelectArgs,
 } from 'ember-power-select/components/power-select';
 import BeforeOptions from 'ember-power-select/components/power-select/before-options';
+import 'ember-power-select/styles';
 import PowerSelectOptions from 'ember-power-select/components/power-select/options';
 
 import cn from '../../helpers/cn.ts';

--- a/packages/boxel-ui/test-app/app/app.js
+++ b/packages/boxel-ui/test-app/app/app.js
@@ -2,8 +2,6 @@ import Application from '@ember/application';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from 'test-app/config/environment';
-import 'ember-power-select/styles';
-import 'ember-power-calendar/styles';
 import '@cardstack/boxel-ui/styles/global.css';
 import '@cardstack/boxel-ui/styles/fonts.css';
 import '@cardstack/boxel-ui/styles/variables.css';

--- a/packages/host/app/app.ts
+++ b/packages/host/app/app.ts
@@ -7,8 +7,6 @@ import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from '@cardstack/host/config/environment';
 import './lib/glint-embroider-workaround';
-import 'ember-power-select/styles';
-import 'ember-power-calendar/styles';
 import '@cardstack/boxel-ui/styles/global.css';
 import '@cardstack/boxel-ui/styles/fonts.css';
 import '@cardstack/boxel-ui/styles/variables.css';


### PR DESCRIPTION
These imports in app.ts were skipping a level in the package dependency graph. ember-power-select and ember-power-calendar are not dependencies of host, they're dependencies of boxel-ui.

Trying to import from your dep's deps is unreliable and makes the vite depscan complain.

I pushed them down into the boxel-ui components that actually pull the corresponding ember-power-* components into the project.