### PR TITLE
ci: Fix deployments from `main`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -632,6 +632,10 @@ jobs:
       - boxel-ui-test
       - realm-server-test
     uses: ./.github/workflows/manual-deploy.yml
+    permissions:
+      contents: read
+      deployments: write
+      id-token: write
     secrets: inherit
     with:
       environment: "staging"

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -21,6 +21,7 @@ permissions:
 jobs:
   create-deployment:
     name: Create GitHub deployment
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     outputs:
       deployment-id: ${{ steps.create.outputs.deployment_id }}
@@ -322,7 +323,7 @@ jobs:
         deploy-realm-server,
         post-deploy-realm-server,
       ]
-    if: always()
+    if: github.event_name == 'workflow_dispatch' && always()
     runs-on: ubuntu-latest
     steps:
       - name: Set deployment status


### PR DESCRIPTION
This is a fix for #3813, which caused the staging deployment from `main` to fail.