### PR TITLE
Fix: cannot create empty file

### DIFF
--- a/packages/host/app/commands/apply-search-replace-block.ts
+++ b/packages/host/app/commands/apply-search-replace-block.ts
@@ -14,6 +14,7 @@ export const APPLY_SEARCH_REPLACE_BLOCK_ERROR_MESSAGES = {
   SEARCH_BLOCK_PARSE_ERROR: `${standardErrorMessage} (search block parse error)`,
   REPLACE_BLOCK_PARSE_ERROR: `${standardErrorMessage} (replace block parse error)`,
   SEARCH_PATTERN_NOT_FOUND: `${standardErrorMessage} (search pattern not found in the target source file)`,
+  EMPTY_SEARCH_PATTERN_ON_NONEMPTY_FILE: `${standardErrorMessage} (empty search pattern for non-empty file)`,
 } as const;
 
 export default class ApplySearchReplaceBlockCommand extends HostBaseCommand<
@@ -55,6 +56,10 @@ export default class ApplySearchReplaceBlockCommand extends HostBaseCommand<
     } else if (replacePattern == null) {
       throw new Error(
         APPLY_SEARCH_REPLACE_BLOCK_ERROR_MESSAGES.REPLACE_BLOCK_PARSE_ERROR,
+      );
+    } else if (searchPattern === '' && input.fileContent.trim() !== '') {
+      throw new Error(
+        APPLY_SEARCH_REPLACE_BLOCK_ERROR_MESSAGES.EMPTY_SEARCH_PATTERN_ON_NONEMPTY_FILE,
       );
     }
 

--- a/packages/host/app/commands/apply-search-replace-block.ts
+++ b/packages/host/app/commands/apply-search-replace-block.ts
@@ -64,7 +64,7 @@ export default class ApplySearchReplaceBlockCommand extends HostBaseCommand<
       searchPattern,
       replacePattern,
     );
-    if (resultContent === input.fileContent) {
+    if (resultContent === input.fileContent && searchPattern !== '') {
       throw new Error(
         APPLY_SEARCH_REPLACE_BLOCK_ERROR_MESSAGES.SEARCH_PATTERN_NOT_FOUND,
       );
@@ -124,6 +124,9 @@ export default class ApplySearchReplaceBlockCommand extends HostBaseCommand<
     searchPattern: string,
     replacePattern: string,
   ): string {
+    if (searchPattern === '') {
+      return replacePattern;
+    }
     // Create a normalized search pattern for matching
     // This helps with whitespace differences
     const normalizedSearchLines = searchPattern

--- a/packages/host/app/commands/check-correctness.ts
+++ b/packages/host/app/commands/check-correctness.ts
@@ -78,7 +78,10 @@ export default class CheckCorrectnessCommand extends HostBaseCommand<
     let errors: string[] = [];
     let lintIssues: string[] = [];
 
-    if (targetType === 'file' && (await this.isEmptyFileContent(input.targetRef))) {
+    if (
+      targetType === 'file' &&
+      (await this.isEmptyFileContent(input.targetRef))
+    ) {
       return new CorrectnessResultCard({
         correct: true,
         errors: [],

--- a/packages/host/app/commands/check-correctness.ts
+++ b/packages/host/app/commands/check-correctness.ts
@@ -78,6 +78,14 @@ export default class CheckCorrectnessCommand extends HostBaseCommand<
     let errors: string[] = [];
     let lintIssues: string[] = [];
 
+    if (targetType === 'file' && (await this.isEmptyFileContent(input.targetRef))) {
+      return new CorrectnessResultCard({
+        correct: true,
+        errors: [],
+        warnings: [],
+      });
+    }
+
     if (targetType === 'file' && input.targetRef.endsWith('.gts')) {
       errors = await this.collectModuleErrors(input.targetRef, roomId);
       lintIssues = await this.collectLintIssues(input.targetRef);
@@ -316,6 +324,16 @@ export default class CheckCorrectnessCommand extends HostBaseCommand<
         error,
       );
       return [];
+    }
+  }
+
+  private async isEmptyFileContent(targetRef: string): Promise<boolean> {
+    try {
+      let fileUrl = new URL(targetRef);
+      let { status, content } = await this.cardService.getSource(fileUrl);
+      return status === 200 && content.trim() === '';
+    } catch {
+      return false;
     }
   }
 

--- a/packages/host/app/commands/patch-code.ts
+++ b/packages/host/app/commands/patch-code.ts
@@ -58,8 +58,11 @@ export default class PatchCodeCommand extends HostBaseCommand<
     );
     let finalFileUrl = fileUrl;
     if (results.some((r) => r.status === 'applied')) {
-      let lintResult = await this.lintAndFix(fileUrl, patchedCode);
-      patchedCode = lintResult.output;
+      if (patchedCode.trim() !== '') {
+        let lintResult = await this.lintAndFix(fileUrl, patchedCode);
+        patchedCode = lintResult.output;
+      }
+
       finalFileUrl = await this.determineFinalFileUrl(
         fileUrl,
         fileInfo,

--- a/packages/host/tests/integration/commands/apply-search-replace-block-test.gts
+++ b/packages/host/tests/integration/commands/apply-search-replace-block-test.gts
@@ -727,4 +727,23 @@ ${REPLACE_MARKER}`;
 }`,
     );
   });
+
+  test('it allows empty search and replace blocks on empty content', async function (assert) {
+    let commandService = getService('command-service');
+    let applyCommand = new ApplySearchReplaceBlockCommand(
+      commandService.commandContext,
+    );
+
+    const fileContent = '';
+    const codeBlock = `${SEARCH_MARKER}
+${SEPARATOR_MARKER}
+${REPLACE_MARKER}`;
+
+    let result = await applyCommand.execute({
+      fileContent,
+      codeBlock,
+    });
+
+    assert.strictEqual(result.resultContent, '');
+  });
 });

--- a/packages/host/tests/integration/commands/apply-search-replace-block-test.gts
+++ b/packages/host/tests/integration/commands/apply-search-replace-block-test.gts
@@ -746,4 +746,34 @@ ${REPLACE_MARKER}`;
 
     assert.strictEqual(result.resultContent, '');
   });
+
+  test('it rejects empty search blocks on non-empty content', async function (assert) {
+    let commandService = getService('command-service');
+    let applyCommand = new ApplySearchReplaceBlockCommand(
+      commandService.commandContext,
+    );
+
+    const fileContent = `export class Task extends CardDef {
+  static displayName = 'Task';
+}`;
+    const codeBlock = `${SEARCH_MARKER}
+${SEPARATOR_MARKER}
+export class Task extends CardDef {
+  static displayName = 'Task v2';
+}
+${REPLACE_MARKER}`;
+
+    try {
+      await applyCommand.execute({
+        fileContent,
+        codeBlock,
+      });
+      assert.ok(false, 'Should have thrown an error for empty search block');
+    } catch (error: any) {
+      assert.ok(
+        error.message.includes('empty search pattern for non-empty file'),
+        'Error should mention empty search pattern for non-empty file',
+      );
+    }
+  });
 });

--- a/packages/host/tests/integration/commands/check-correctness-test.gts
+++ b/packages/host/tests/integration/commands/check-correctness-test.gts
@@ -1,10 +1,15 @@
 import { waitUntil } from '@ember/test-helpers';
+
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import type { CommandContext } from '@cardstack/runtime-common';
 
-import { REPLACE_MARKER, SEARCH_MARKER, SEPARATOR_MARKER } from '@cardstack/runtime-common';
+import {
+  REPLACE_MARKER,
+  SEARCH_MARKER,
+  SEPARATOR_MARKER,
+} from '@cardstack/runtime-common';
 
 import CheckCorrectnessCommand from '@cardstack/host/commands/check-correctness';
 import PatchCardInstanceCommand from '@cardstack/host/commands/patch-card-instance';

--- a/packages/host/tests/integration/commands/patch-code-test.gts
+++ b/packages/host/tests/integration/commands/patch-code-test.gts
@@ -212,4 +212,31 @@ ${REPLACE_MARKER}`;
       operatorModeStateService.restore({ stacks: [[]] });
     }
   });
+
+  test('allows empty search and replace blocks via patch-code for new files', async function (assert) {
+    let commandService = getService('command-service');
+    let patchCodeCommand = new PatchCodeCommand(commandService.commandContext);
+    let emptyFileUrl = `${testRealmURL}empty.gts`;
+
+    adapter.lintStub = async (request: Request): Promise<LintResult> => {
+      return {
+        output: await request.text(),
+        fixed: false,
+        messages: [],
+      };
+    };
+
+    const codeBlock = `${SEARCH_MARKER}
+${SEPARATOR_MARKER}
+${REPLACE_MARKER}`;
+
+    let result = await patchCodeCommand.execute({
+      fileUrl: emptyFileUrl,
+      codeBlocks: [codeBlock],
+    });
+
+    assert.strictEqual(result.finalFileUrl, emptyFileUrl);
+    assert.strictEqual(result.patchedContent, '');
+    assert.strictEqual(result.results[0]?.status, 'applied');
+  });
 });


### PR DESCRIPTION
In this PR, I added logic to allow `patch-code` and `apply-search-and-replace-block` to be used to create an empty file.

Before:

<img width="454" height="387" alt="image (2)" src="https://github.com/user-attachments/assets/5ea725a7-9a87-4ca8-8fab-a8a03a77633c" />

After:

https://github.com/user-attachments/assets/5892d5f1-2ae2-4a37-82b3-0af21680edfd


