### PR TITLE
Fix bug where uploaded errors do not result in non-zero exit code

### DIFF
--- a/packages/workspace-sync-cli/src/push.ts
+++ b/packages/workspace-sync-cli/src/push.ts
@@ -9,6 +9,7 @@ interface PushOptions {
 }
 
 class RealmPusher extends RealmSyncBase {
+  hasError = false;
   constructor(
     private pushOptions: PushOptions,
     matrixUrl: string,
@@ -49,6 +50,7 @@ class RealmPusher extends RealmSyncBase {
       try {
         await this.uploadFile(relativePath, localPath);
       } catch (error) {
+        this.hasError = true;
         console.error(`Error uploading ${relativePath}:`, error);
       }
     }
@@ -163,7 +165,12 @@ async function main() {
     await pusher.initialize();
     await pusher.sync();
 
-    console.log('Push completed successfully');
+    if (pusher.hasError) {
+      console.log('Push did not complete successfully. view logs for details');
+      process.exit(2);
+    } else {
+      console.log('Push completed successfully');
+    }
   } catch (error) {
     console.error('Push failed:', error);
     process.exit(1);


### PR DESCRIPTION
This fixes an error where when there is an error uploaded the script does not return with a non-zero exit code