### PR TITLE
Fix issues around module error propagation in the index

### DIFF
--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -280,7 +280,11 @@ export class IndexRunner {
   }
 
   private errorKey(error: SerializedError): string {
-    return `${error.id ?? ''}|${error.message ?? ''}|${error.status ?? ''}`;
+    return JSON.stringify({
+      id: error.id ?? null,
+      message: error.message ?? null,
+      status: error.status ?? null,
+    });
   }
 
   private async collectModuleErrors(


### PR DESCRIPTION
This PR fixes an issue we observed during the sync of the homepage realm which relies on incremental indexing of each asset in the repo: the error message was not being appropriately reflected and the invalidation graph was not being correctly determined when a module error is consumed thru mulitple layers of modules. 

- Normalize error dependency URLs to the module alias (extensionless) so invalidation cascades correctly through module graphs.
- Surface upstream module errors on dependent instances/modules by collecting and attaching dependency errors during indexing.