### PR TITLE
fix issue where prerendering during indexing was permitting the realm writes

### DIFF
--- a/packages/host/app/routes/module.ts
+++ b/packages/host/app/routes/module.ts
@@ -123,7 +123,9 @@ export default class ModuleRoute extends Route<Model> {
   #releaseTimerBlock: (() => void) | undefined;
 
   deactivate() {
-    (globalThis as any).__boxelRenderContext = undefined;
+    if (isTesting()) {
+      (globalThis as any).__boxelRenderContext = undefined;
+    }
     this.lastStoreResetKey = undefined;
     this.#authGuard.unregister();
     this.#restoreRenderTimers?.();

--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -124,7 +124,9 @@ export default class RenderRoute extends Route<Model> {
       currentURL: this.router.currentURL,
     });
     this.#setAllModelStatuses('unusable');
-    (globalThis as any).__boxelRenderContext = undefined;
+    if (isTesting()) {
+      (globalThis as any).__boxelRenderContext = undefined;
+    }
   };
 
   activate() {
@@ -133,7 +135,9 @@ export default class RenderRoute extends Route<Model> {
   }
 
   deactivate() {
-    (globalThis as any).__boxelRenderContext = undefined;
+    if (isTesting()) {
+      (globalThis as any).__boxelRenderContext = undefined;
+    }
     (globalThis as any).__renderModel = undefined;
     window.removeEventListener('boxel-render-error', this.handleRenderError);
     this.#detachWindowErrorListeners();

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -1207,7 +1207,12 @@ module('Integration | Store', function (hooks) {
     );
   });
 
-  test('an instance live updates from indexing events for an instance update', async function (assert) {
+  test<TestContextWithSave>('an instance live updates from indexing events for an instance update', async function (assert) {
+    assert.expect(2);
+    let didSave = false;
+    this.onSave(() => {
+      didSave = true;
+    });
     setCardInOperatorModeState(`${testRealmURL}Person/hassan`);
     await renderComponent(
       class TestDriver extends GlimmerComponent {
@@ -1238,9 +1243,11 @@ module('Integration | Store', function (hooks) {
         (storeService.peek(`${testRealmURL}Person/hassan`) as any)?.name ===
         'Hassan updated',
     );
+    await storeService.flushSaves();
     assert
       .dom('[data-test-stack-card] [data-test-field="name"]')
       .containsText('Hassan updated', 'card live updated');
+    assert.false(didSave, 'indexing updates do not auto save instances');
   });
 
   test('an instance live updates from indexing events for a code update', async function (assert) {


### PR DESCRIPTION
This PR fixes an issue where prerendering during indexing was permitting realm writes during a specific window of time. 