### PR TITLE
update skills test so we don't hit live prod URL's

### DIFF
--- a/packages/host/tests/integration/commands/update-room-skills-test.gts
+++ b/packages/host/tests/integration/commands/update-room-skills-test.gts
@@ -20,7 +20,6 @@ import type * as CardAPI from 'https://cardstack.com/base/card-api';
 import type { SerializedFile } from 'https://cardstack.com/base/file-api';
 
 import {
-  envSkillId,
   setupCardLogs,
   setupIntegrationTestRealm,
   setupLocalIndexing,
@@ -155,6 +154,20 @@ export class DoThing extends Command {
               }),
             ],
           }),
+          'Skill/boxel-environment.json': new Skill({
+            title: 'Boxel Environment',
+            description: 'Test environment skill',
+            instructions: 'Test skill card for environment commands',
+            commands: [
+              new CommandField({
+                codeRef: {
+                  module: `${testRealmURL}test-command.gts`,
+                  name: 'DoThing',
+                },
+                requiresApproval: false,
+              }),
+            ],
+          }),
         },
       });
       let matrixService = getService('matrix-service') as any;
@@ -168,7 +181,7 @@ export class DoThing extends Command {
       let command = new UpdateRoomSkillsCommand(
         getService('command-service').commandContext,
       );
-      let skillCardId = envSkillId;
+      let skillCardId = `${testRealmURL}Skill/boxel-environment`;
       await command.execute({
         roomId: matrixRoomId,
         skillCardIdsToActivate: [skillCardId],
@@ -211,7 +224,7 @@ export class DoThing extends Command {
       let command = new UpdateRoomSkillsCommand(
         getService('command-service').commandContext,
       );
-      let skillCardId = envSkillId;
+      let skillCardId = `${testRealmURL}Skill/boxel-environment`;
       mockMatrixUtils.setRoomState(
         matrixRoomId,
         APP_BOXEL_ROOM_SKILLS_EVENT_TYPE,
@@ -259,7 +272,7 @@ export class DoThing extends Command {
       let command = new UpdateRoomSkillsCommand(
         getService('command-service').commandContext,
       );
-      let skillCardId = envSkillId;
+      let skillCardId = `${testRealmURL}Skill/boxel-environment`;
       await command.execute({
         roomId: matrixRoomId,
         skillCardIdsToActivate: [skillCardId],


### PR DESCRIPTION
This PR fixes a flaky skills test that was attempting to hit live skills URL's in prod. specifically this error:

```
    expected: >
        http://localhost:4201/skills/Skill/boxel-environment
    stack: >
            at Object.<anonymous> (http://localhost:7357/assets/chunk.36bbe6580230e0a8ffbd.js:60377:14)
    message: >
        skill added to enabled list
    negative: >
        false
    browser log: |
        {"type":"warn","text":"auto starting of mock matrix is disabled"}
        {"type":"info","text":"Realm http://test-realm/test/ is starting indexing"}
        {"type":"info","text":"Realm http://test-realm/test/ has completed indexing in 0.85s: {\n  \"instancesIndexed\": 1,\n  \"modulesIndexed\": 1,\n  \"filesIndexed\": 2,\n  \"instanceErrors\": 0,\n  \"moduleErrors\": 0,\n  \"fileErrors\": 0,\n  \"totalIndexEntries\": 4\n}"}
        {"type":"error","text":"fetch failed for https://app.boxel.ai/catalog/skill-plus [object Object]"}
        {"type":"error","text":"fetch failed for https://app.boxel.ai/catalog/skill-reference [object Object]"}
        {"type":"error","text":"Encountered fetch failed for https://boxel-icons.boxel.ai/@cardstack/boxel-icons/v1/icons/book-open.js retry attempt #1 in 100ms"}
        {"type":"error","text":"Encountered fetch failed for https://boxel-icons.boxel.ai/@cardstack/boxel-icons/v1/icons/activity.js retry attempt #1 in 100ms"}
        {"type":"error","text":"Encountered fetch failed for https://boxel-icons.boxel.ai/@cardstack/boxel-icons/v1/icons/edit.js retry attempt #1 in 100ms"}
        {"type":"error","text":"Encountered fetch failed for https://boxel-icons.boxel.ai/@cardstack/boxel-icons/v1/icons/file-text.js retry attempt #1 in 100ms"}
        {"type":"error","text":"error getting instance \"http://localhost:4201/skills/Skill/boxel-environment\": {\n  \"id\": \"https://app.boxel.ai/catalog/skill-plus\",\n  \"title\": \"Failed to fetch\",\n  \"message\": \"unable to fetch https://app.boxel.ai/catalog/skill-plus: fetch failed for https://app.boxel.ai/catalog/skill-plus\",\n  \"code\": 500,\n  \"status\": 500,\n  \"stack\": \"Error: unable to fetch https://app.boxel.ai/catalog/skill-plus: fetch failed for https://app.boxel.ai/catalog/skill-plus\\n    at CardError.fromFetchResponse (http://localhost:7357/assets/chunk.160b43a1612da5d7a8fe.js:31439:19)\\n    at async Loader.load (http://localhost:7357/assets/chunk.160b43a1612da5d7a8fe.js:36446:19)\\n    at async Loader.fetchModule (http://localhost:7357/assets/chunk.160b43a1612da5d7a8fe.js:36288:16)\"\n} [object Object]"}
```