### PR TITLE
fix boxel-homepage initial ci setup failure

### DIFF
--- a/packages/boxel-homepage-realm/package.json
+++ b/packages/boxel-homepage-realm/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "scripts": {
-    "boxel-homepage:setup": "[ -d contents ] || (git clone git@github.com:cardstack/boxel-home.git contents || git clone https://github.com/cardstack/boxel-home.git contents)",
+    "boxel-homepage:setup": "sh ./scripts/boxel-homepage-setup.sh",
     "boxel-homepage:update": "pnpm boxel-homepage:setup && cd contents && git pull",
     "boxel-homepage:reset": "rm -rf contents && pnpm boxel-homepage:setup"
   },

--- a/packages/boxel-homepage-realm/scripts/boxel-homepage-setup.sh
+++ b/packages/boxel-homepage-realm/scripts/boxel-homepage-setup.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+if [ -d contents ]; then
+  exit 0
+fi
+
+if [ -n "${CI:-}" ] || [ -n "${GITHUB_ACTIONS:-}" ]; then
+  git clone https://github.com/cardstack/boxel-home.git contents
+else
+  git clone git@github.com:cardstack/boxel-home.git contents || \
+    git clone https://github.com/cardstack/boxel-home.git contents
+fi

--- a/packages/realm-server/main.ts
+++ b/packages/realm-server/main.ts
@@ -202,6 +202,13 @@ let hrefs = urlMappings.map(([from, to]) => [from.href, to.href]);
 let dist: URL = new URL(distURL);
 let autoMigrate = migrateDB || undefined;
 
+log.info(
+  `Realm server boot config: port=${port} serverURL=${serverURL} distURL=${distURL} matrixURL=${matrixURL} realmsRootPath=${realmsRootPath} migrateDB=${Boolean(
+    migrateDB,
+  )} workerManagerPort=${workerManagerPort ?? 'none'} prerendererUrl=${prerendererUrl} enableFileWatcher=${ENABLE_FILE_WATCHER}`,
+);
+log.info(`Realm paths: ${paths.map(String).join(', ')}`);
+
 const getIndexHTML = async () => {
   let response = await fetch(distURL);
   if (!response.ok) {

--- a/packages/realm-server/scripts/start-development.sh
+++ b/packages/realm-server/scripts/start-development.sh
@@ -5,7 +5,10 @@ SCRIPTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 wait_for_postgres
 
 pnpm --dir=../skills-realm skills:setup
-pnpm --dir=../boxel-homepage-realm boxel-homepage:setup
+
+if [ -z "${SKIP_BOXEL_HOMEPAGE:-}" ]; then
+  pnpm --dir=../boxel-homepage-realm boxel-homepage:setup
+fi
 
 if [ -z "$MATRIX_REGISTRATION_SHARED_SECRET" ]; then
   MATRIX_REGISTRATION_SHARED_SECRET=$(ts-node --transpileOnly "$SCRIPTS_DIR/matrix-registration-secret.ts")
@@ -34,11 +37,8 @@ fi
 
 PRERENDER_URL="${PRERENDER_URL:-http://localhost:4221}"
 
-
-
-
 LOW_CREDIT_THRESHOLD="${LOW_CREDIT_THRESHOLD:-2000}" \
-NODE_ENV=development \
+  NODE_ENV=development \
   NODE_NO_WARNINGS=1 \
   PGPORT=5435 \
   PGDATABASE=boxel \


### PR DESCRIPTION
Issue: Saw realm-server test fail on first try but passed on second when deploying merged pr to staging. Copilot directed me to the boxel-homepage realm setup as the reason.

Adjusted the boxel-homepage clone flow to avoid SSH failures in CI and to skip homepage setup entirely when the realm server is launched with SKIP_BOXEL_HOMEPAGE, plus added early boot logging so startup config shows up even if the server exits before it reaches the readiness check.

Details:

- CI-safe clone: package.json now uses HTTPS-only cloning when CI/GITHUB_ACTIONS is set, while keeping SSH-first for local dev.
- Skip setup when asked: start-development.sh now respects SKIP_BOXEL_HOMEPAGE before cloning the homepage repo.
- Startup logging: main.ts logs the boot config and realm paths right after parsing CLI args, before host fetch or DB work.