### PR TITLE
disable generate readme and title,description inputs on spec when no write access

### DIFF
--- a/packages/base/spec.gts
+++ b/packages/base/spec.gts
@@ -35,7 +35,7 @@ import {
   type CommandContext,
   type ResolvedCodeRef,
 } from '@cardstack/runtime-common';
-import { eq, type MenuItemOptions } from '@cardstack/boxel-ui/helpers';
+import { eq, not, type MenuItemOptions } from '@cardstack/boxel-ui/helpers';
 import { AiBw as AiBwIcon } from '@cardstack/boxel-ui/icons';
 
 import GlimmerComponent from '@glimmer/component';
@@ -581,19 +581,21 @@ class Edit extends Component<typeof Spec> {
             <BookOpenText width='20' height='20' role='presentation' />
             <h2 id='readme'>Read Me</h2>
           </div>
-          <BoxelButton
-            @kind='primary'
-            @size='extra-small'
-            @loading={{this.generateReadmeTask.isRunning}}
-            {{on 'click' this.generateReadme}}
-            data-test-generate-readme
-          >
-            {{#if this.generateReadmeTask.isRunning}}
-              Generating...
-            {{else}}
-              Generate README
-            {{/if}}
-          </BoxelButton>
+          {{#if @canEdit}}
+            <BoxelButton
+              @kind='primary'
+              @size='extra-small'
+              @loading={{this.generateReadmeTask.isRunning}}
+              {{on 'click' this.generateReadme}}
+              data-test-generate-readme
+            >
+              {{#if this.generateReadmeTask.isRunning}}
+                Generating...
+              {{else}}
+                Generate README
+              {{/if}}
+            </BoxelButton>
+          {{/if}}
         </header>
         <div data-test-readme>
           <@fields.readMe />
@@ -801,6 +803,7 @@ class SpecTitleField extends StringField {
         @value={{@model}}
         @onInput={{@set}}
         @placeholder={{this.placeholder}}
+        @disabled={{not @canEdit}}
         class='spec-title-input'
       />
       <style scoped>
@@ -837,6 +840,7 @@ class SpecDescriptionField extends StringField {
         @value={{@model}}
         @onInput={{@set}}
         @placeholder={{this.placeholder}}
+        @disabled={{not @canEdit}}
         class='spec-description-input'
       />
       <style scoped>

--- a/packages/host/app/commands/create-specs.ts
+++ b/packages/host/app/commands/create-specs.ts
@@ -33,6 +33,7 @@ import GenerateReadmeSpecCommand from './generate-readme-spec';
 
 import type CardService from '../services/card-service';
 import type ModuleContentsService from '../services/module-contents-service';
+import type RealmService from '../services/realm';
 import type StoreService from '../services/store';
 
 class SpecTypeGuesser {
@@ -132,6 +133,7 @@ export default class CreateSpecCommand extends HostBaseCommand<
   @service declare private store: StoreService;
   @service declare private cardService: CardService;
   @service declare private moduleContentsService: ModuleContentsService;
+  @service declare private realm: RealmService;
 
   static actionVerb = 'Create';
   requireInputFields = ['targetRealm'];
@@ -206,6 +208,12 @@ export default class CreateSpecCommand extends HostBaseCommand<
       throw new Error('Failed to create or retrieve spec');
     }
 
+    let canEdit = this.realm.canWrite(targetRealm);
+    if (!canEdit) {
+      throw new Error(
+        `Cannot generate README without write access to ${targetRealm}`,
+      );
+    }
     if (autoGenerateReadme && !createdSpecRes.spec.readMe) {
       // we populate the readme when is not already set even when spec is already created
       let generateReadmeSpecCommand = new GenerateReadmeSpecCommand(

--- a/packages/host/tests/acceptance/code-submode/spec-test.gts
+++ b/packages/host/tests/acceptance/code-submode/spec-test.gts
@@ -823,6 +823,25 @@ module('Acceptance | Spec preview', function (hooks) {
     await percySnapshot(assert);
   });
 
+  test('spec fields in edit format are read-only when user cannot write', async function (assert) {
+    await visitOperatorMode({
+      submode: 'code',
+      codePath: `${testRealm2URL}person-entry.json`,
+      cardPreviewFormat: 'edit',
+    });
+    await waitFor(
+      `[data-test-card="${testRealm2URL}person-entry"][data-test-card-format="edit"]`,
+    );
+
+    assert.dom('[data-test-title] input').isDisabled();
+    assert.dom('[data-test-description] input').isDisabled();
+
+    assert.dom('[data-test-readme] textarea').isDisabled();
+    assert.dom('[data-test-readme] textarea').hasAttribute('readonly');
+
+    assert.dom('[data-test-generate-readme]').doesNotExist();
+  });
+
   test('renders linked examples in isolated spec view when user cannot write', async function (assert) {
     setRealmPermissions({
       [testRealmURL]: ['read'],

--- a/packages/host/tests/helpers/visit-operator-mode.ts
+++ b/packages/host/tests/helpers/visit-operator-mode.ts
@@ -14,6 +14,7 @@ export default async function visitOperatorMode({
   moduleInspector,
   workspaceChooserOpened,
   trail,
+  cardPreviewFormat,
 }: Partial<SerializedState> & { selectAllCardsFilter?: boolean }) {
   let operatorModeState = {
     stacks: stacks || [],
@@ -27,6 +28,7 @@ export default async function visitOperatorMode({
     ...(openDirs ? { openDirs } : {}),
     ...(moduleInspector ? { moduleInspector } : {}),
     ...(trail ? { trail } : {}),
+    ...(cardPreviewFormat ? { cardPreviewFormat } : {}),
   };
 
   let operatorModeStateParam = stringify(operatorModeState)!;


### PR DESCRIPTION
since specs can be in any writeable or non-writeable realm, we need to adapt the UI to adapt to write permissions

when no write access and previewing format = edit 
- generate readme button (hidden)
- title <-disabled (uses boxel input)
- description <- disabled (uses boxel input)




<img width="1301" height="954" alt="Screenshot 2026-01-15 at 23 25 21" src="https://github.com/user-attachments/assets/dddb4953-8c57-4482-a89d-4c023b185a86" />

PS: The markdown field is already disabled as per Markdown Field

