### PR TITLE
server: Add custom domain publishing

### DIFF
--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -32,12 +32,14 @@ import { passwordFromSeed } from '@cardstack/runtime-common/matrix-client';
 
 const log = logger('handle-publish');
 
-const PUBLISHED_REALM_DOMAIN_OVERRIDES: Record<string, Record<string, string>> =
-  {
-    // '@user:matrix.server': {
-    //   'requested.boxel.ai': 'custom.domain.example',
-    // },
-  };
+const PUBLISHED_REALM_DOMAIN_OVERRIDES: Record<
+  string,
+  Record<string, string>
+> = {
+  '@buck:stack.cards': {
+    'custombuck.staging.boxel.build': 'custombuck.stack.cards',
+  },
+};
 
 function maybeOverridePublishedRealmURL(
   ownerUserId: string,

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -33,6 +33,7 @@ import { passwordFromSeed } from '@cardstack/runtime-common/matrix-client';
 
 const log = logger('handle-publish');
 
+// Workaround to override published realm URLs to support custom domains. Remove in CS-9061.
 const PUBLISHED_REALM_DOMAIN_OVERRIDES: Record<
   string,
   Record<string, string>

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -1,5 +1,6 @@
 import type Koa from 'koa';
 import {
+  ensureTrailingSlash,
   fetchUserPermissions,
   query,
   SupportedMimeType,
@@ -77,10 +78,9 @@ function maybeOverridePublishedRealmURL(
 
   let overriddenURL = new URL(publishedRealmURL);
   overriddenURL.host = overrideDomain;
+
   let overriddenRealmURL = overriddenURL.toString();
-  return overriddenRealmURL.endsWith('/')
-    ? overriddenRealmURL
-    : `${overriddenRealmURL}/`;
+  return ensureTrailingSlash(overriddenRealmURL);
 }
 
 function rewriteHostHomeForPublishedRealm(

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -39,6 +39,19 @@ const PUBLISHED_REALM_DOMAIN_OVERRIDES: Record<
   '@buck:stack.cards': {
     'custombuck.staging.boxel.build': 'custombuck.stack.cards',
   },
+  '@ctse:stack.cards': {
+    'docs.staging.boxel.build': 'docs.stack.cards',
+    'home.staging.boxel.build': 'home.stack.cards',
+    'whitepaper.staging.boxel.build': 'whitepaper.stack.cards',
+  },
+  '@bucktest:boxel.ai': {
+    'custombuck.boxel.site': 'custombuck.boxel.ai',
+  },
+  '@chris:boxel.ai': {
+    'docs.boxel.site': 'docs.boxel.ai',
+    'home.boxel.site': 'home.boxel.ai',
+    'whitepaper.boxel.site': 'whitepaper.boxel.ai',
+  },
 };
 
 function maybeOverridePublishedRealmURL(


### PR DESCRIPTION
This adds a temporary server-side override to allow published realms on custom domains without the whole CNAME etc UI. With this branch deployed to staging, I claimed the subdomain `custombuck.staging.boxel.build` and the override wrote the published realm at [`custombuck.stack.cards`](https://custombuck.stack.cards/). Coupled with the infrastructure changes, the published realm is served as desired:

<img width="1312" height="888" alt="image" src="https://github.com/user-attachments/assets/58e263f2-fa53-426a-967d-533d68cfe376" />
