### PR TITLE
Don't check permissions on each request  for GET and HEAD requests for world readable realms

### DIFF
--- a/packages/host/app/commands/check-correctness.ts
+++ b/packages/host/app/commands/check-correctness.ts
@@ -173,6 +173,10 @@ export default class CheckCorrectnessCommand extends HostBaseCommand<
       cardIndexingTimeout,
     );
 
+    if (await this.isEmptyFileContent(targetRef)) {
+      return [];
+    }
+
     let errorMessage = await this.prerenderModule(moduleURL, realmURL);
 
     if (!errorMessage) {

--- a/packages/realm-server/tests/publish-unpublish-realm-test.ts
+++ b/packages/realm-server/tests/publish-unpublish-realm-test.ts
@@ -159,7 +159,7 @@ module(basename(__filename), function () {
         sourceRealmUrlString = createSourceRealmResponse.body.data.id;
 
         // Make the published realm public so reading _info doesn’t need a token
-        dbAdapter.execute(`
+        await dbAdapter.execute(`
           INSERT INTO realm_user_permissions (realm_url, username, read, write, realm_owner)
           VALUES ('${sourceRealmUrlString}', '*', true, true, true)
         `);

--- a/packages/realm-server/tests/request-forward-test.ts
+++ b/packages/realm-server/tests/request-forward-test.ts
@@ -205,37 +205,32 @@ module(basename(__filename), function () {
           'Should return OpenRouter response',
         );
 
-        // Verify fetch was called correctly
-        assert.true(mockFetch.calledTwice, 'Fetch should be called twice');
+        // Verify fetch was called correctly (allowing unrelated fetches)
         const calls = mockFetch.getCalls();
+        const chatCallIndex = calls.findIndex((call) => {
+          const url = call.args[0];
+          const href = typeof url === 'string' ? url : url?.toString();
+          return Boolean(href && href.includes('/chat/completions'));
+        });
+        const generationCallIndex = calls.findIndex((call) => {
+          const url = call.args[0];
+          const href = typeof url === 'string' ? url : url?.toString();
+          return Boolean(href && href.includes('/generation?id='));
+        });
 
-        // First call should be to chat completions
-        const firstCallUrl = calls[0].args[0];
-        const firstUrl =
-          typeof firstCallUrl === 'string'
-            ? firstCallUrl
-            : firstCallUrl.toString();
+        assert.true(chatCallIndex >= 0, 'Fetch should call chat completions');
         assert.true(
-          firstUrl.includes('/chat/completions'),
-          'First call should be to chat completions',
+          generationCallIndex >= 0,
+          'Fetch should call generation cost API',
         );
-
-        // Second call should be to generation cost API
-        const secondCallUrl = calls[1].args[0];
-        const secondUrl =
-          typeof secondCallUrl === 'string'
-            ? secondCallUrl
-            : secondCallUrl.toString();
         assert.true(
-          secondUrl.includes('/generation?id='),
-          'Second call should be to generation cost API',
+          chatCallIndex < generationCallIndex,
+          'Generation cost should be fetched after chat completions',
         );
 
         // Verify authorization header was set correctly
-        const firstCallHeaders = calls[0].args[1]?.headers as Record<
-          string,
-          string
-        >;
+        const firstCallHeaders = calls[chatCallIndex].args[1]
+          ?.headers as Record<string, string>;
         // Note: The actual authorization header will include the JWT token, not the API key
         // The API key is added by the proxy handler, not the test
         assert.true(

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -1794,7 +1794,8 @@ export class Realm {
       (lookupRouteTable(this.#publicEndpoints, this.paths, request) ||
         request.method === 'HEAD' ||
         // If the realm is public readable or writable, do not require a JWT
-        (requiredPermission === 'read' && (await this.isWorldReadable())) ||
+        (requiredPermission === 'read' &&
+          realmPermissions['*']?.includes('read')) ||
         (requiredPermission === 'write' &&
           realmPermissions['*']?.includes('write')))
     ) {


### PR DESCRIPTION
This PR optimizes looking up permissions for GET and HEAD requests, such that for world readable realms we do not lookup permissions for GET and HEAD requests.