### PR TITLE
host: Update publishability warning design

### DIFF
--- a/packages/host/app/components/operator-mode/publish-realm-modal.gts
+++ b/packages/host/app/components/operator-mode/publish-realm-modal.gts
@@ -22,7 +22,7 @@ import {
   LoadingIndicator,
 } from '@cardstack/boxel-ui/components';
 import { not } from '@cardstack/boxel-ui/helpers';
-import { IconX } from '@cardstack/boxel-ui/icons';
+import { IconX, Warning as WarningIcon } from '@cardstack/boxel-ui/icons';
 
 import ModalContainer from '@cardstack/host/components/modal-container';
 import PrivateDependencyViolationComponent from '@cardstack/host/components/operator-mode/private-dependency-violation';
@@ -678,36 +678,58 @@ export default class PublishRealmModal extends Component<Signature> {
           </div>
         {{else}}
           {{#if this.shouldShowPrivateDependencyWarning}}
-            <div class='publish-warning' data-test-private-dependency-warning>
-              <div>
-                This workspace will have rendering errors when published because
-                of private external dependencies.
+            <div
+              class='publish-warning warning'
+              data-test-private-dependency-warning
+            >
+              <WarningIcon
+                class='publish-warning-icon'
+                width='20'
+                height='20'
+                role='presentation'
+              />
+              <div class='publish-warning-body'>
+                <div>
+                  This workspace will have rendering errors when published
+                  because of private external dependencies.
+                </div>
+                <ul class='violation-list'>
+                  {{#each this.privateDependencyViolations as |violation|}}
+                    <PrivateDependencyViolationComponent
+                      @violation={{violation}}
+                      @privateRealmURLs={{this.privateRealmURLsForViolation
+                        violation
+                      }}
+                    />
+                  {{/each}}
+                </ul>
               </div>
-              <ul class='violation-list'>
-                {{#each this.privateDependencyViolations as |violation|}}
-                  <PrivateDependencyViolationComponent
-                    @violation={{violation}}
-                    @privateRealmURLs={{this.privateRealmURLsForViolation
-                      violation
-                    }}
-                  />
-                {{/each}}
-              </ul>
             </div>
           {{/if}}
           {{#if this.shouldShowErrorDocumentWarning}}
-            <div class='publish-warning' data-test-error-document-warning>
-              <div>
-                This workspace contains cards that failed to index and cannot be
-                safely published.
+            <div
+              class='publish-warning warning'
+              data-test-error-document-warning
+            >
+              <WarningIcon
+                class='publish-warning-icon'
+                width='20'
+                height='20'
+                role='presentation'
+              />
+              <div class='publish-warning-body'>
+                <div>
+                  This workspace contains cards that failed to index and cannot
+                  be safely published.
+                </div>
+                <ul class='violation-list'>
+                  {{#each this.errorDocumentViolations as |violation|}}
+                    <li>
+                      {{violation.resource}}
+                    </li>
+                  {{/each}}
+                </ul>
               </div>
-              <ul class='violation-list'>
-                {{#each this.errorDocumentViolations as |violation|}}
-                  <li>
-                    {{violation.resource}}
-                  </li>
-                {{/each}}
-              </ul>
             </div>
           {{/if}}
         {{/if}}
@@ -1067,20 +1089,36 @@ export default class PublishRealmModal extends Component<Signature> {
         gap: var(--boxel-sp-xs);
         margin-bottom: var(--boxel-sp);
         padding: var(--boxel-sp-sm);
-        border: 1px solid var(--boxel-warning-200);
-        background-color: rgb(from var(--boxel-warning-200) r g b / 12%);
         border-radius: var(--boxel-border-radius-lg);
         font-size: var(--boxel-font-size-sm);
       }
 
+      .publish-warning.warning {
+        flex-direction: row;
+        align-items: flex-start;
+        gap: var(--boxel-sp-sm);
+        background-color: var(--boxel-warning-200);
+        color: var(--boxel-dark);
+      }
+
+      .publish-warning-body {
+        display: flex;
+        flex-direction: column;
+        gap: var(--boxel-sp-xs);
+      }
+
+      .publish-warning-icon {
+        flex-shrink: 0;
+      }
+
       .publish-warning.error {
-        border-color: var(--boxel-error-200);
+        border: 1px solid var(--boxel-error-200);
         background-color: rgb(from var(--boxel-error-200) r g b / 8%);
         color: var(--boxel-error-200);
       }
 
       .publish-warning.info {
-        border-color: var(--boxel-300);
+        border: 1px solid var(--boxel-300);
         background-color: var(--boxel-50);
         color: var(--boxel-500);
         align-items: center;


### PR DESCRIPTION
This updates the publishability warning from this:

<img width="2536" height="2228" alt="e8c0a21ef0e0f5101a0d9e590435203ca7bf96af 2026-01-16 08-28-52" src="https://github.com/user-attachments/assets/86d40e81-c330-4de2-811b-3a55460fc534" />

to this, to match the design:

<img width="2536" height="2228" alt="e8c0a21ef0e0f5101a0d9e590435203ca7bf96af 2026-01-16 08-29-21" src="https://github.com/user-attachments/assets/cc463f6c-4031-4e79-b35e-e050d857c8f2" />
