### PR TITLE
Fix invalidation bug where jsonb "null" was being conflated with SQL NULL

### DIFF
--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -1377,7 +1377,10 @@ module(basename(__filename), function () {
         `SELECT error_doc IS NULL AS is_sql_null
          FROM boxel_index
          WHERE realm_url = '${testRealm}'
-           AND url = '${testRealm}deep-card'
+           AND (
+             url = '${testRealm}deep-card.json'
+             OR file_alias = '${testRealm}deep-card'
+           )
            AND type = 'instance'`,
       )) as { is_sql_null: boolean }[];
       assert.strictEqual(

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -1373,6 +1373,19 @@ module(basename(__filename), function () {
         'instance',
         'instance is repaired when missing module is added',
       );
+      let rows = (await testDbAdapter.execute(
+        `SELECT error_doc IS NULL AS is_sql_null
+         FROM boxel_index
+         WHERE realm_url = '${testRealm}'
+           AND url = '${testRealm}deep-card'
+           AND type = 'instance'`,
+      )) as { is_sql_null: boolean }[];
+      assert.strictEqual(
+        rows.length,
+        1,
+        'index row exists for deep-card instance',
+      );
+      assert.true(rows[0].is_sql_null, 'error_doc is SQL NULL after recovery');
     });
 
     test('can incrementally index deleted instance', async function (assert) {

--- a/packages/runtime-common/expression.ts
+++ b/packages/runtime-common/expression.ts
@@ -277,14 +277,12 @@ export function asExpressions(
   valueExpressions: Param[][];
 } {
   let paramBucket = Object.fromEntries(
-    Object.entries(values).map(([col, val]) => [
-      col,
-      param(
-        opts?.jsonFields?.includes(col)
-          ? stringify(val ?? null)
-          : (val ?? null),
-      ),
-    ]),
+    Object.entries(values).map(([col, val]) => {
+      if (opts?.jsonFields?.includes(col)) {
+        return [col, param(val == null ? null : (stringify(val) ?? null))];
+      }
+      return [col, param(val ?? null)];
+    }),
   );
   let nameExpressions = Object.keys(paramBucket).map((name) => [name]);
   let valueExpressions = Object.keys(paramBucket).map((k) => {


### PR DESCRIPTION
Issue: recovered instances (instances that were previously an error, but then repaired) kept showing errors because error_doc was stored as jsonb null (not SQL NULL), so the index still treated them as errored even after dependencies were fixed.

the fix was to store SQL NULL for cleared JSON fields so recovered instances/modules no longer retain error state (expression.ts). Added regression coverage to confirm error_doc is SQL NULL after a recovery path (indexing-test.ts).