### PR TITLE
Persist pristine file resources and include adoption chain in index

### DIFF
--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -64,6 +64,7 @@ import {
   type DefinitionLookup,
 } from './definition-lookup';
 import { isScopedCSSRequest } from 'glimmer-scoped-css';
+import type { FileMetaResource } from './resource-types';
 
 interface IndexedModule {
   type: 'module';
@@ -79,6 +80,7 @@ export interface IndexedFile {
   lastModified: number | null;
   resourceCreatedAt: number | null;
   searchDoc: Record<string, any> | null;
+  resource: FileMetaResource | null;
   types: string[] | null;
   displayNames: string[] | null;
   deps: string[] | null;
@@ -353,6 +355,7 @@ export class IndexQueryEngine {
     }
     let {
       url: canonicalURL,
+      pristine_doc: resource,
       search_doc: searchDoc,
       realm_version: realmVersion,
       realm_url: realmURL,
@@ -367,6 +370,7 @@ export class IndexQueryEngine {
       type: 'file',
       canonicalURL,
       searchDoc,
+      resource: (resource as FileMetaResource | null) ?? null,
       types,
       displayNames,
       deps,

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -28,6 +28,7 @@ import {
 import type { SerializedError } from './error';
 import type { DBAdapter } from './db';
 import type { RealmMetaTable } from './index-structure';
+import type { FileMetaResource } from './resource-types';
 import {
   coerceTypes,
   type BoxelIndexTable,
@@ -107,6 +108,7 @@ export interface FileEntry {
   resourceCreatedAt: number;
   deps: Set<string>;
   searchData?: Record<string, any>;
+  resource?: FileMetaResource | null;
   types?: string[];
   displayNames?: string[];
 }
@@ -331,6 +333,7 @@ export class Batch {
         entryPayload = {
           type: 'file',
           deps: [...entry.deps],
+          pristine_doc: entry.resource ?? null,
           search_doc: entry.searchData ?? null,
           types: entry.types ?? null,
           display_names: entry.displayNames ?? null,

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -1,5 +1,6 @@
 import type {
   CardResource,
+  FileMetaResource,
   LinkableResource,
   LooseLinkableResource,
   Meta,
@@ -58,6 +59,8 @@ export interface FileExtractResponse {
   nonce: string;
   status: 'ready' | 'error';
   searchDoc: Record<string, any> | null;
+  resource?: FileMetaResource | null;
+  types?: string[] | null;
   deps: string[];
   error?: RenderError;
   mismatch?: true;

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -23,6 +23,7 @@ import {
   codeRefFromInternalKey,
 } from '.';
 import type { Realm } from './realm';
+import { FILE_META_RESERVED_KEYS } from './realm';
 import { RealmPaths } from './paths';
 import type { Query } from './query';
 import { CardError, type SerializedError } from './error';
@@ -786,7 +787,11 @@ function fileResourceFromIndex(
     }
   }
   for (let [key, value] of Object.entries(searchDoc)) {
-    if (key in baseAttributes || value === undefined) {
+    if (
+      key in baseAttributes ||
+      FILE_META_RESERVED_KEYS.has(key) ||
+      value === undefined
+    ) {
       continue;
     }
     attributes[key] = value;

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -20,12 +20,13 @@ import {
   type DefinitionLookup,
   visitInstanceURLs,
   maybeRelativeURL,
+  codeRefFromInternalKey,
 } from '.';
 import type { Realm } from './realm';
 import { RealmPaths } from './paths';
 import type { Query } from './query';
 import { CardError, type SerializedError } from './error';
-import { isResolvedCodeRef, visitModuleDeps } from './code-ref';
+import { isCodeRef, isResolvedCodeRef, visitModuleDeps } from './code-ref';
 import {
   isCardCollectionDocument,
   isSingleCardDocument,
@@ -756,23 +757,48 @@ function fileResourceFromIndex(
       : undefined;
   let lastModified = fileEntry.lastModified ?? unixTime(Date.now());
   let createdAt = fileEntry.resourceCreatedAt ?? lastModified;
+  let adoptsFrom =
+    codeRefFromInternalKey(fileEntry.types?.[0]) ??
+    (isCodeRef(fileEntry.resource?.meta?.adoptsFrom)
+      ? fileEntry.resource?.meta?.adoptsFrom
+      : {
+          module: `${baseRealm.url}file-api`,
+          name: 'FileDef',
+        });
+  let resourceAttributes = fileEntry.resource?.attributes ?? {};
+  let baseAttributes = {
+    name: resourceAttributes.name ?? searchDoc.name ?? name,
+    url: resourceAttributes.url ?? searchDoc.url ?? fileURL.href,
+    sourceUrl:
+      resourceAttributes.sourceUrl ?? searchDoc.sourceUrl ?? fileURL.href,
+    contentType:
+      resourceAttributes.contentType ??
+      searchDoc.contentType ??
+      inferredContentType,
+    contentHash: resourceAttributes.contentHash ?? contentHash,
+    lastModified,
+    createdAt,
+  };
+  let attributes: Record<string, unknown> = { ...baseAttributes };
+  for (let [key, value] of Object.entries(resourceAttributes)) {
+    if (value !== undefined && !(key in attributes)) {
+      attributes[key] = value;
+    }
+  }
+  for (let [key, value] of Object.entries(searchDoc)) {
+    if (key in baseAttributes || value === undefined) {
+      continue;
+    }
+    attributes[key] = value;
+  }
   return {
     id: fileURL.href,
     type: 'file-meta',
     attributes: {
-      name: searchDoc.name ?? name,
-      url: searchDoc.url ?? fileURL.href,
-      sourceUrl: searchDoc.sourceUrl ?? fileURL.href,
-      contentType: searchDoc.contentType ?? inferredContentType,
-      contentHash,
-      lastModified,
-      createdAt,
+      ...attributes,
     },
     meta: {
-      adoptsFrom: {
-        module: `${baseRealm.url}file-api`,
-        name: 'FileDef',
-      },
+      adoptsFrom,
       realmURL: fileEntry.realmURL,
     },
     links: { self: fileURL.href },

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -191,7 +191,7 @@ const FILE_DEF_CODE_REF: ResolvedCodeRef = {
   module: `${baseRealm.url}file-api`,
   name: 'FileDef',
 };
-const FILE_META_RESERVED_KEYS = new Set([
+export const FILE_META_RESERVED_KEYS = new Set([
   'name',
   'url',
   'sourceUrl',

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -62,6 +62,7 @@ import {
   type LintResult,
   type Query,
   type PrerenderedHtmlFormat,
+  codeRefFromInternalKey,
   codeRefWithAbsoluteURL,
   userInitiatedPriority,
   systemInitiatedPriority,
@@ -71,7 +72,7 @@ import {
   type IndexedFile,
   PRERENDERED_HTML_FORMATS,
 } from './index';
-import { visitModuleDeps } from './code-ref';
+import { isCodeRef, visitModuleDeps } from './code-ref';
 import merge from 'lodash/merge';
 import mergeWith from 'lodash/mergeWith';
 import cloneDeep from 'lodash/cloneDeep';
@@ -190,6 +191,15 @@ const FILE_DEF_CODE_REF: ResolvedCodeRef = {
   module: `${baseRealm.url}file-api`,
   name: 'FileDef',
 };
+const FILE_META_RESERVED_KEYS = new Set([
+  'name',
+  'url',
+  'sourceUrl',
+  'contentType',
+  'contentHash',
+  'lastModified',
+  'createdAt',
+]);
 
 type CachedSourceFileEntry = {
   type: 'file';
@@ -2195,21 +2205,48 @@ export class Realm {
         : this.#dbAdapter
           ? await getContentHash(this.#dbAdapter, this.url, localPath)
           : undefined;
+    let adoptsFrom =
+      codeRefFromInternalKey(fileEntry.types?.[0]) ??
+      (isCodeRef(fileEntry.resource?.meta?.adoptsFrom)
+        ? fileEntry.resource?.meta?.adoptsFrom
+        : FILE_DEF_CODE_REF);
+    let resourceAttributes =
+      (fileEntry as IndexedFile).resource?.attributes ?? {};
+    let baseAttributes = {
+      name: resourceAttributes.name ?? searchDoc.name ?? name,
+      url: resourceAttributes.url ?? searchDoc.url ?? fileURL,
+      sourceUrl: resourceAttributes.sourceUrl ?? searchDoc.sourceUrl ?? fileURL,
+      contentType:
+        resourceAttributes.contentType ??
+        searchDoc.contentType ??
+        inferredContentType,
+      contentHash: resourceAttributes.contentHash ?? contentHash,
+      lastModified: fileEntry.lastModified ?? unixTime(Date.now()),
+      createdAt: createdAt ?? unixTime(Date.now()),
+    };
+    let attributes: Record<string, unknown> = { ...baseAttributes };
+    for (let [key, value] of Object.entries(resourceAttributes)) {
+      if (value !== undefined && !(key in attributes)) {
+        attributes[key] = value;
+      }
+    }
+    for (let [key, value] of Object.entries(searchDoc)) {
+      if (FILE_META_RESERVED_KEYS.has(key) || key in attributes) {
+        continue;
+      }
+      if (value !== undefined) {
+        attributes[key] = value;
+      }
+    }
     let doc: SingleFileMetaDocument = {
       data: {
         type: 'file-meta',
         id: fileURL,
         attributes: {
-          name: searchDoc.name ?? name,
-          url: searchDoc.url ?? fileURL,
-          sourceUrl: searchDoc.sourceUrl ?? fileURL,
-          contentType: searchDoc.contentType ?? inferredContentType,
-          contentHash,
-          lastModified: fileEntry.lastModified ?? unixTime(Date.now()),
-          createdAt: createdAt ?? unixTime(Date.now()),
+          ...attributes,
         },
         meta: {
-          adoptsFrom: FILE_DEF_CODE_REF,
+          adoptsFrom,
           realmInfo,
           realmURL: this.url,
         },


### PR DESCRIPTION
- Persist pristine file resources during file extraction and store them in the index
- Serve file-meta attributes from pristine_doc with fallback behavior
- Add realm-server coverage for pristine_doc file-meta responses
