### PR TITLE
Update from scratch indexing timeout and allow this to be set via env var

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,3 +18,7 @@ The following are important concepts:
 - [Indexing](indexing.md): Indexing powers the re-rendering of cards when it's dependencies get updated.
 - [Realm](realm.md): Realms are storage for cards that have their own underlying permissions and indexer.
 - [Search](search.md): Every Card is searchable within and across realms.
+
+## Operations
+
+- From-scratch indexing timeout: set `FROM_SCRATCH_JOB_TIMEOUT_SEC` (seconds) to control the from-scratch indexing job timeout and the queue worker cap; default is 2400.

--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -72,4 +72,5 @@ For each card instance we persist:
 
 ## Operational notes
 - The prerenderer URL is required for workers/realm-server; missing or unreachable URLs fail fast.
+- `FROM_SCRATCH_JOB_TIMEOUT_SEC` controls the from-scratch indexing job timeout (seconds) and caps the queue worker runtime; default is 2400.
 - For local testing helpers, see `packages/host/tests/helpers/index.gts` and `packages/realm-server/tests/helpers/index.ts` which start a test prerenderer and wire the same flow.

--- a/packages/runtime-common/tasks/indexer.ts
+++ b/packages/runtime-common/tasks/indexer.ts
@@ -10,7 +10,18 @@ import { IndexRunner } from '../index-runner';
 import type { Stats } from '../worker';
 
 export { fromScratchIndex, incrementalIndex };
-export const FROM_SCRATCH_JOB_TIMEOUT_SEC = 20 * 60;
+const DEFAULT_FROM_SCRATCH_JOB_TIMEOUT_SEC = 40 * 60;
+const envTimeoutSec = Number(
+  (
+    globalThis as {
+      process?: { env?: Record<string, string | undefined> };
+    }
+  ).process?.env?.FROM_SCRATCH_JOB_TIMEOUT_SEC,
+);
+export const FROM_SCRATCH_JOB_TIMEOUT_SEC =
+  Number.isFinite(envTimeoutSec) && envTimeoutSec > 0
+    ? envTimeoutSec
+    : DEFAULT_FROM_SCRATCH_JOB_TIMEOUT_SEC;
 
 export interface IncrementalArgs extends WorkerArgs {
   urls: string[];


### PR DESCRIPTION
This PR increases the default ceiling for from scratch indexing as well as allows this value to be set from an env var.