### PR TITLE
Add `has_error` column to boxel_index

### DIFF
--- a/packages/host/config/schema/1769200000000_schema.sql
+++ b/packages/host/config/schema/1769200000000_schema.sql
@@ -23,6 +23,7 @@
    resource_created_at,
    icon_html TEXT,
    head_html TEXT,
+   has_error BOOLEAN DEFAULT false NOT NULL,
    PRIMARY KEY ( url, realm_url, type ) 
 );
 
@@ -48,6 +49,7 @@
    display_names BLOB,
    resource_created_at,
    head_html TEXT,
+   has_error BOOLEAN DEFAULT false NOT NULL,
    PRIMARY KEY ( url, realm_url, type ) 
 );
 

--- a/packages/host/tests/helpers/indexer.ts
+++ b/packages/host/tests/helpers/indexer.ts
@@ -29,6 +29,7 @@ import { testRealmURL } from './index';
 const defaultIndexEntry = {
   realm_version: 1,
   realm_url: testRealmURL,
+  has_error: false,
 };
 
 let typesCache = new WeakMap<typeof CardDef, Promise<string[]>>();

--- a/packages/host/tests/integration/commands/listing-update-specs-test.gts
+++ b/packages/host/tests/integration/commands/listing-update-specs-test.gts
@@ -49,6 +49,7 @@ module('Integration | commands | listing-update-specs', function (hooks) {
                   canonicalUrl: exampleCardId,
                   realmUrl: testRealmURL,
                   entryType: 'instance',
+                  hasError: false,
                   dependencies: [modulePath],
                 },
               },

--- a/packages/host/tests/unit/index-query-engine-test.ts
+++ b/packages/host/tests/unit/index-query-engine-test.ts
@@ -275,7 +275,8 @@ module('Unit | query', function (hooks) {
     await setupIndex(dbAdapter, [
       {
         url: `${testRealmURL}1.json`,
-        type: 'instance-error',
+        type: 'instance',
+        has_error: true,
         realm_version: 1,
         realm_url: testRealmURL,
         pristine_doc: undefined,
@@ -2927,7 +2928,8 @@ module('Unit | query', function (hooks) {
       {
         url: `${testRealmURL}donald.json`,
         file_alias: `${testRealmURL}donald`,
-        type: 'instance-error',
+        type: 'instance',
+        has_error: true,
         realm_version: 1,
         realm_url: testRealmURL,
         deps: [],
@@ -2954,7 +2956,8 @@ module('Unit | query', function (hooks) {
       {
         url: `${testRealmURL}paper.json`,
         file_alias: `${testRealmURL}paper`,
-        type: 'instance-error',
+        type: 'instance',
+        has_error: true,
         realm_version: 1,
         realm_url: testRealmURL,
         deps: [],

--- a/packages/host/tests/unit/index-writer-test.ts
+++ b/packages/host/tests/unit/index-writer-test.ts
@@ -641,6 +641,7 @@ module('Unit | index-writer', function (hooks) {
         realm_version: 2,
         realm_url: testRealmURL2,
         type: 'instance',
+        has_error: false,
         pristine_doc: {
           ...resource,
           id: `${testRealmURL2}1`,
@@ -696,6 +697,7 @@ module('Unit | index-writer', function (hooks) {
         realm_version: 2,
         realm_url: testRealmURL2,
         type: 'module',
+        has_error: false,
         error_doc: null,
         pristine_doc: null,
         search_doc: null,
@@ -801,7 +803,7 @@ module('Unit | index-writer', function (hooks) {
     await batch.done();
 
     let [{ indexed_at: _remove, ...errorEntry }] = (await adapter.execute(
-      'SELECT * FROM boxel_index WHERE realm_version = 2 AND type = \'instance-error\' ORDER BY url COLLATE "POSIX"',
+      'SELECT * FROM boxel_index WHERE realm_version = 2 AND type = \'instance\' AND has_error = TRUE ORDER BY url COLLATE "POSIX"',
       { coerceTypes },
     )) as unknown as BoxelIndexTable[];
     assert.deepEqual(
@@ -811,7 +813,8 @@ module('Unit | index-writer', function (hooks) {
         file_alias: `${testRealmURL}1`,
         realm_version: 2,
         realm_url: testRealmURL,
-        type: 'instance-error',
+        type: 'instance',
+        has_error: true,
         pristine_doc: resource,
         error_doc: {
           message: 'test error',
@@ -865,7 +868,7 @@ module('Unit | index-writer', function (hooks) {
     await batch.done();
 
     let [{ indexed_at: _remove, ...errorEntry }] = (await adapter.execute(
-      'SELECT * FROM boxel_index WHERE realm_version = 2 AND type = \'instance-error\' ORDER BY url COLLATE "POSIX"',
+      'SELECT * FROM boxel_index WHERE realm_version = 2 AND type = \'instance\' AND has_error = TRUE ORDER BY url COLLATE "POSIX"',
       { coerceTypes },
     )) as unknown as BoxelIndexTable[];
     assert.deepEqual(
@@ -875,7 +878,8 @@ module('Unit | index-writer', function (hooks) {
         file_alias: `${testRealmURL}1`,
         realm_version: 2,
         realm_url: testRealmURL,
-        type: 'instance-error',
+        type: 'instance',
+        has_error: true,
         pristine_doc: null,
         error_doc: {
           message: 'test error',
@@ -921,7 +925,7 @@ module('Unit | index-writer', function (hooks) {
     await batch.done();
 
     let [{ error_doc: errorDoc, deps }] = (await adapter.execute(
-      'SELECT error_doc, deps FROM boxel_index WHERE realm_version = 2 AND type = \'instance-error\' ORDER BY url COLLATE "POSIX"',
+      'SELECT error_doc, deps FROM boxel_index WHERE realm_version = 2 AND type = \'instance\' AND has_error = TRUE ORDER BY url COLLATE "POSIX"',
       { coerceTypes },
     )) as Pick<BoxelIndexTable, 'error_doc' | 'deps'>[];
 
@@ -949,7 +953,8 @@ module('Unit | index-writer', function (hooks) {
         url: `${testRealmURL}1.json`,
         realm_version: 1,
         realm_url: testRealmURL,
-        type: 'instance-error',
+        type: 'instance',
+        has_error: true,
         error_doc: {
           message: 'test error',
           status: 500,
@@ -1376,7 +1381,8 @@ module('Unit | index-writer', function (hooks) {
         url: `${testRealmURL}person.gts`,
         realm_version: 1,
         realm_url: testRealmURL,
-        type: 'module-error',
+        type: 'module',
+        has_error: true,
         error_doc: {
           message: 'test error',
           status: 500,

--- a/packages/postgres/migrations/1769200000000_add-has-error-to-index.js
+++ b/packages/postgres/migrations/1769200000000_add-has-error-to-index.js
@@ -1,0 +1,119 @@
+exports.up = (pgm) => {
+  pgm.dropConstraint('boxel_index', 'boxel_index_type_check');
+  pgm.dropConstraint('boxel_index_working', 'boxel_index_working_type_check');
+
+  pgm.addColumn('boxel_index', {
+    has_error: { type: 'boolean', notNull: true, default: false },
+  });
+  pgm.addColumn('boxel_index_working', {
+    has_error: { type: 'boolean', notNull: true, default: false },
+  });
+
+  pgm.sql(`
+    WITH normalized AS (
+      SELECT
+        ctid,
+        url,
+        realm_url,
+        CASE
+          WHEN type LIKE '%-error' THEN replace(type, '-error', '')
+          ELSE type
+        END AS normalized_type,
+        indexed_at,
+        last_modified
+      FROM boxel_index
+    ),
+    ranked AS (
+      SELECT
+        ctid,
+        ROW_NUMBER() OVER (
+          PARTITION BY url, realm_url, normalized_type
+          ORDER BY COALESCE(indexed_at, last_modified, 0) DESC, ctid DESC
+        ) AS row_number
+      FROM normalized
+    )
+    DELETE FROM boxel_index
+    WHERE ctid IN (SELECT ctid FROM ranked WHERE row_number > 1);
+  `);
+
+  pgm.sql(`
+    UPDATE boxel_index
+    SET
+      has_error = (type LIKE '%-error') OR (error_doc IS NOT NULL),
+      type = CASE
+        WHEN type LIKE '%-error' THEN replace(type, '-error', '')
+        ELSE type
+      END;
+  `);
+
+  pgm.sql(`
+    WITH normalized AS (
+      SELECT
+        ctid,
+        url,
+        realm_url,
+        CASE
+          WHEN type LIKE '%-error' THEN replace(type, '-error', '')
+          ELSE type
+        END AS normalized_type,
+        indexed_at,
+        last_modified
+      FROM boxel_index_working
+    ),
+    ranked AS (
+      SELECT
+        ctid,
+        ROW_NUMBER() OVER (
+          PARTITION BY url, realm_url, normalized_type
+          ORDER BY COALESCE(indexed_at, last_modified, 0) DESC, ctid DESC
+        ) AS row_number
+      FROM normalized
+    )
+    DELETE FROM boxel_index_working
+    WHERE ctid IN (SELECT ctid FROM ranked WHERE row_number > 1);
+  `);
+
+  pgm.sql(`
+    UPDATE boxel_index_working
+    SET
+      has_error = (type LIKE '%-error') OR (error_doc IS NOT NULL),
+      type = CASE
+        WHEN type LIKE '%-error' THEN replace(type, '-error', '')
+        ELSE type
+      END;
+  `);
+
+  pgm.addConstraint('boxel_index', 'boxel_index_type_check', {
+    check: "type in ('instance','module','file')",
+  });
+  pgm.addConstraint('boxel_index_working', 'boxel_index_working_type_check', {
+    check: "type in ('instance','module','file')",
+  });
+};
+
+exports.down = (pgm) => {
+  pgm.dropConstraint('boxel_index', 'boxel_index_type_check');
+  pgm.dropConstraint('boxel_index_working', 'boxel_index_working_type_check');
+
+  pgm.sql(`
+    UPDATE boxel_index
+    SET type = type || '-error'
+    WHERE has_error = TRUE;
+  `);
+
+  pgm.sql(`
+    UPDATE boxel_index_working
+    SET type = type || '-error'
+    WHERE has_error = TRUE;
+  `);
+
+  pgm.dropColumn('boxel_index', 'has_error');
+  pgm.dropColumn('boxel_index_working', 'has_error');
+
+  pgm.addConstraint('boxel_index', 'boxel_index_type_check', {
+    check: "type in ('instance','module','file','instance-error','module-error','file-error')",
+  });
+  pgm.addConstraint('boxel_index_working', 'boxel_index_working_type_check', {
+    check: "type in ('instance','module','file','instance-error','module-error','file-error')",
+  });
+};

--- a/packages/realm-server/tests/card-endpoints-test.ts
+++ b/packages/realm-server/tests/card-endpoints-test.ts
@@ -2107,7 +2107,7 @@ module(basename(__filename), function () {
           for (let table of ['boxel_index', 'boxel_index_working']) {
             await dbAdapter.execute(
               `UPDATE ${table}
-               SET type = 'instance-error', error_doc = $1::jsonb
+               SET has_error = TRUE, error_doc = $1::jsonb
                WHERE url = $2`,
               {
                 bind: [JSON.stringify(errorDoc), cardURL],
@@ -2170,7 +2170,7 @@ module(basename(__filename), function () {
           for (let table of ['boxel_index', 'boxel_index_working']) {
             await dbAdapter.execute(
               `UPDATE ${table}
-               SET type = 'instance-error', error_doc = $1::jsonb, pristine_doc = NULL
+               SET has_error = TRUE, error_doc = $1::jsonb, pristine_doc = NULL
                WHERE url = $2`,
               {
                 bind: [JSON.stringify(errorDoc), cardURL],

--- a/packages/realm-server/tests/realm-endpoints/dependencies-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/dependencies-test.ts
@@ -64,6 +64,7 @@ module(`realm-endpoints/${basename(__filename)}`, function (hooks) {
     assert.strictEqual(entry.attributes.canonicalUrl, targetUrl);
     assert.strictEqual(entry.attributes.realmUrl, testRealm.url);
     assert.strictEqual(entry.attributes.entryType, 'module');
+    assert.false(entry.attributes.hasError);
     assert.true(
       entry.attributes.dependencies.includes(
         'https://cardstack.com/base/string',

--- a/packages/realm-server/tests/realm-endpoints/publishability-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/publishability-test.ts
@@ -168,7 +168,7 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
       for (let table of ['boxel_index', 'boxel_index_working']) {
         await dbAdapter.execute(
           `UPDATE ${table}
-           SET type = 'instance-error', error_doc = $1::jsonb
+           SET has_error = TRUE, error_doc = $1::jsonb
            WHERE url = $2 AND type = 'instance'`,
           {
             bind: [JSON.stringify(errorDoc), cardURL],

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -204,10 +204,7 @@ export class IndexQueryEngine {
           [`i.url =`, param(url.href)],
           [`i.file_alias =`, param(url.href)],
         ]),
-        any([
-          ['i.type =', param('module')],
-          ['i.type =', param('module-error')],
-        ]),
+        ['i.type =', param('module')],
         any([['i.is_deleted = FALSE'], ['i.is_deleted IS NULL']]),
       ]),
     ] as Expression)) as unknown as BoxelIndexTable[];
@@ -219,7 +216,7 @@ export class IndexQueryEngine {
       return undefined;
     }
     let result = maybeResult;
-    if (result.type === 'module-error') {
+    if (result.has_error) {
       return { type: 'module-error', error: result.error_doc! };
     }
     let moduleEntry = assertIndexEntry(result);
@@ -250,10 +247,7 @@ export class IndexQueryEngine {
           [`i.url =`, param(url.href)],
           [`i.file_alias =`, param(url.href)],
         ]),
-        any([
-          ['i.type =', param('instance')],
-          ['i.type =', param('instance-error')],
-        ]),
+        ['i.type =', param('instance')],
         any([['i.is_deleted = FALSE'], ['i.is_deleted IS NULL']]),
       ]),
     ] as Expression)) as unknown as (BoxelIndexTable & {
@@ -302,11 +296,11 @@ export class IndexQueryEngine {
       realmVersion,
     };
 
-    if (maybeResult.error_doc) {
+    if (maybeResult.has_error) {
       return {
         ...baseResult,
         type: 'instance-error',
-        error: maybeResult.error_doc,
+        error: maybeResult.error_doc!,
       };
     }
     let instanceEntry = assertIndexEntry(maybeResult);
@@ -343,6 +337,7 @@ export class IndexQueryEngine {
           [`i.file_alias =`, param(url.href)],
         ]),
         ['i.type =', param('file')],
+        any([['i.has_error = FALSE'], ['i.has_error IS NULL']]),
         any([['i.is_deleted = FALSE'], ['i.is_deleted IS NULL']]),
       ]),
     ] as Expression)) as unknown as BoxelIndexTable[];
@@ -412,17 +407,14 @@ export class IndexQueryEngine {
       ];
 
       if (opts.includeErrors) {
+        conditions.push(['i.type =', param('instance')]);
+      } else {
         conditions.push(
-          any([
+          every([
             ['i.type =', param('instance')],
-            every([
-              ['i.type =', param('instance-error')],
-              ['i.url ILIKE', param('%.json')],
-            ]),
+            any([['i.has_error = FALSE'], ['i.has_error IS NULL']]),
           ]),
         );
-      } else {
-        conditions.push(['i.type =', param('instance')]);
       }
 
       if (opts.cardUrls && opts.cardUrls.length > 0) {
@@ -567,7 +559,7 @@ export class IndexQueryEngine {
       { filter, sort, page },
       opts,
       [
-        'SELECT url, ANY_VALUE(i.type) as type, ANY_VALUE(file_alias) as file_alias, ',
+        'SELECT url, ANY_VALUE(i.type) as type, ANY_VALUE(i.has_error) as has_error, ANY_VALUE(file_alias) as file_alias, ',
         ...htmlColumnExpression,
         ' as html,',
         ...usedRenderTypeColumnExpression,
@@ -614,7 +606,7 @@ export class IndexQueryEngine {
         url: card.url!,
         html: card.html,
         ...(usedRenderType ? { usedRenderType } : {}),
-        ...(card.type === 'instance-error' ? { isError: true as const } : {}),
+        ...(card.has_error ? { isError: true as const } : {}),
       };
     });
 

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -491,7 +491,7 @@ export class IndexRunner {
 
       if (
         !indexEntry ||
-        indexEntry.type.endsWith('-error') ||
+        indexEntry.hasError ||
         indexEntry.lastModified == null ||
         lastModified !== indexEntry.lastModified
       ) {

--- a/packages/runtime-common/index-structure.ts
+++ b/packages/runtime-common/index-structure.ts
@@ -7,13 +7,8 @@ export interface BoxelIndexTable {
   file_alias: string;
   realm_version: number;
   realm_url: string;
-  type:
-    | 'instance'
-    | 'module'
-    | 'file'
-    | 'instance-error'
-    | 'module-error'
-    | 'file-error';
+  type: 'instance' | 'module' | 'file';
+  has_error: boolean | null;
   // TODO in followup PR update this to be a document not a resource
   pristine_doc: CardResource | null;
   error_doc: SerializedError | null;
@@ -66,6 +61,7 @@ export const coerceTypes = Object.freeze({
   fitted_html: 'JSON',
   display_names: 'JSON',
   is_deleted: 'BOOLEAN',
+  has_error: 'BOOLEAN',
   last_modified: 'VARCHAR',
   resource_created_at: 'VARCHAR',
   indexed_at: 'VARCHAR',

--- a/packages/runtime-common/publishability.ts
+++ b/packages/runtime-common/publishability.ts
@@ -4,13 +4,8 @@ import type { RealmVisibility } from './realm';
 export interface ResourceIndexEntry {
   canonicalUrl: string;
   realmUrl: string;
-  entryType:
-    | 'instance'
-    | 'instance-error'
-    | 'module'
-    | 'module-error'
-    | 'file'
-    | 'file-error';
+  entryType: 'instance' | 'module' | 'file';
+  hasError: boolean;
   dependencies: string[];
 }
 


### PR DESCRIPTION
- Add `has_error` column to `boxel_index`/`boxel_index_working` and remove `*-error` variants from `type`.
- Migrate existing rows so error state is expressed via `has_error` and de-dupe error/non-error entries.
- Update runtime/indexing codepaths and tests to use `has_error` instead of error-typed rows.