### PR TITLE
More sophisticated module invalidation for definition lookup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,10 @@
   Make sure not to commit `.only` to source control
 - run `pnpm lint` directly in this directory to lint changes made to this package
 
+### packages/postgres
+- If you need to make a database migration use `pnpm create migration_name` to create a migration file so that the correct date timestamp prefix will be added to the file name. Then implement the migration inside the newly created file.
+
+
 ### packages/runtime-common
 
 - Functionality is tested via host and/or realm-server tests

--- a/packages/host/config/schema/1769200000000_schema.sql
+++ b/packages/host/config/schema/1769200000000_schema.sql
@@ -62,6 +62,7 @@
    deps BLOB,
    error_doc BLOB,
    created_at,
+   file_alias TEXT,
    PRIMARY KEY ( url, cache_scope, auth_user_id ) 
 );
 

--- a/packages/host/tests/unit/index-query-engine-test.ts
+++ b/packages/host/tests/unit/index-query-engine-test.ts
@@ -230,6 +230,9 @@ module('Unit | query', function (hooks) {
       async invalidate(_realmURL: string): Promise<void> {
         // no-op for tests
       },
+      async clearRealmCache(_realmURL: string): Promise<void> {
+        // no-op for tests
+      },
       registerRealm() {},
       forRealm() {
         return this;

--- a/packages/postgres/migrations/1769006706253_module-cache-invalidation.js
+++ b/packages/postgres/migrations/1769006706253_module-cache-invalidation.js
@@ -1,7 +1,3 @@
-/* eslint-disable camelcase */
-
-exports.shorthands = undefined;
-
 exports.up = (pgm) => {
   pgm.sql('DELETE FROM modules');
   pgm.addColumn('modules', {

--- a/packages/postgres/migrations/1769006706253_module-cache-invalidation.js
+++ b/packages/postgres/migrations/1769006706253_module-cache-invalidation.js
@@ -1,0 +1,16 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+exports.up = (pgm) => {
+  pgm.sql('DELETE FROM modules');
+  pgm.addColumn('modules', {
+    file_alias: { type: 'text' },
+  });
+  pgm.addIndex('modules', ['resolved_realm_url', 'file_alias']);
+};
+
+exports.down = (pgm) => {
+  pgm.dropIndex('modules', ['resolved_realm_url', 'file_alias']);
+  pgm.dropColumn('modules', 'file_alias');
+};

--- a/packages/realm-server/tests/definition-lookup-test.ts
+++ b/packages/realm-server/tests/definition-lookup-test.ts
@@ -2,7 +2,12 @@ import { module, test } from 'qunit';
 import { basename } from 'path';
 import {
   CachingDefinitionLookup,
+  internalKeyFor,
+  trimExecutableExtension,
+  type ErrorEntry,
+  type ModuleDefinitionResult,
   type ModulePrerenderArgs,
+  type ModuleRenderResponse,
   type Prerenderer,
   type VirtualNetwork,
 } from '@cardstack/runtime-common';
@@ -12,6 +17,71 @@ import {
   testCreatePrerenderAuth,
 } from './helpers';
 import type { PgAdapter } from '@cardstack/postgres/pg-adapter';
+
+function buildDefinition(
+  moduleURL: string,
+  name: string,
+): ModuleDefinitionResult {
+  let moduleAlias = trimExecutableExtension(new URL(moduleURL)).href;
+  return {
+    type: 'definition',
+    moduleURL: moduleAlias,
+    definition: {
+      type: 'card-def',
+      codeRef: {
+        module: moduleAlias,
+        name,
+      },
+      displayName: name,
+      fields: {},
+    },
+    types: [],
+  };
+}
+
+function buildModuleError(
+  moduleURL: string,
+  message: string,
+  deps: string[] = [],
+  additionalErrors: ErrorEntry['error']['additionalErrors'] = null,
+): ErrorEntry {
+  return {
+    type: 'module-error',
+    error: {
+      id: moduleURL,
+      message,
+      status: 404,
+      title: 'Module error',
+      deps,
+      additionalErrors,
+    },
+  };
+}
+
+function buildModuleResponse(
+  moduleURL: string,
+  name: string,
+  deps: string[],
+  error?: ErrorEntry,
+): ModuleRenderResponse {
+  let definitionId = internalKeyFor({ module: moduleURL, name }, undefined);
+  let definitions = error
+    ? {}
+    : {
+        [definitionId]: buildDefinition(moduleURL, name),
+      };
+  return {
+    id: moduleURL,
+    status: error ? 'error' : 'ready',
+    nonce: 'test-nonce',
+    isShimmed: false,
+    lastModified: Date.now(),
+    createdAt: Date.now(),
+    deps,
+    definitions,
+    error,
+  };
+}
 
 module(basename(__filename), function () {
   module('DefinitionLookup', function (hooks) {
@@ -186,7 +256,7 @@ module(basename(__filename), function () {
         'prerenderModule was called once',
       );
 
-      await definitionLookup.invalidate('http://some-realm-url');
+      await definitionLookup.invalidate('http://some-realm-url/person.gts');
 
       definition = await definitionLookup.lookupDefinition({
         module: `${realmURL}person.gts`,
@@ -199,7 +269,7 @@ module(basename(__filename), function () {
         'prerenderModule was still only called once',
       );
 
-      await definitionLookup.invalidate(realmURL);
+      await definitionLookup.invalidate(`${realmURL}person.gts`);
 
       definition = await definitionLookup.lookupDefinition({
         module: `${realmURL}person.gts`,
@@ -210,6 +280,703 @@ module(basename(__filename), function () {
         prerenderModuleCalls,
         2,
         'prerenderModule was called a second time after invalidation',
+      );
+    });
+
+    test('invalidates module cache entries without file extensions', async function (assert) {
+      let definition = await definitionLookup.lookupDefinition({
+        module: `${realmURL}person.gts`,
+        name: 'Person',
+      });
+      assert.strictEqual(definition?.displayName, 'Person');
+      assert.strictEqual(
+        prerenderModuleCalls,
+        1,
+        'prerenderModule was called once',
+      );
+
+      await definitionLookup.invalidate(`${realmURL}person`);
+
+      definition = await definitionLookup.lookupDefinition({
+        module: `${realmURL}person.gts`,
+        name: 'Person',
+      });
+      assert.strictEqual(definition?.displayName, 'Person');
+      assert.strictEqual(
+        prerenderModuleCalls,
+        2,
+        'prerenderModule was called a second time after extensionless invalidation',
+      );
+    });
+
+    test('invalidates cached module after module update', async function (assert) {
+      await dbAdapter.execute('DELETE FROM modules');
+
+      let moduleURL = `${realmURL}person.gts`;
+      let version = 1;
+      let calls = 0;
+
+      let prerenderer: Prerenderer = {
+        async prerenderCard() {
+          throw new Error('Not implemented in mock');
+        },
+        async prerenderFileExtract() {
+          throw new Error('Not implemented in mock');
+        },
+        async prerenderModule(args: ModulePrerenderArgs) {
+          calls++;
+          let moduleAlias = trimExecutableExtension(new URL(args.url)).href;
+          let definitionId = internalKeyFor(
+            { module: args.url, name: 'Person' },
+            undefined,
+          );
+          return {
+            id: args.url,
+            status: 'ready',
+            nonce: 'test-nonce',
+            isShimmed: false,
+            lastModified: Date.now(),
+            createdAt: Date.now(),
+            deps: [],
+            definitions: {
+              [definitionId]: {
+                type: 'definition',
+                moduleURL: moduleAlias,
+                definition: {
+                  type: 'card-def',
+                  codeRef: {
+                    module: moduleAlias,
+                    name: 'Person',
+                  },
+                  displayName: `Person v${version}`,
+                  fields: {},
+                },
+                types: [],
+              },
+            },
+          };
+        },
+      };
+
+      let lookup = new CachingDefinitionLookup(
+        dbAdapter,
+        prerenderer,
+        virtualNetwork,
+        testCreatePrerenderAuth,
+      );
+      lookup.registerRealm({
+        url: realmURL,
+        async getRealmOwnerUserId() {
+          return testUserId;
+        },
+        async visibility() {
+          return 'private';
+        },
+      });
+
+      let definition = await lookup.lookupDefinition({
+        module: moduleURL,
+        name: 'Person',
+      });
+      assert.strictEqual(definition?.displayName, 'Person v1');
+      assert.strictEqual(calls, 1, 'prerenderModule called for initial lookup');
+
+      version = 2;
+      await lookup.invalidate(moduleURL);
+
+      definition = await lookup.lookupDefinition({
+        module: moduleURL,
+        name: 'Person',
+      });
+      assert.strictEqual(definition?.displayName, 'Person v2');
+      assert.strictEqual(
+        calls,
+        2,
+        'prerenderModule called again after update invalidation',
+      );
+    });
+
+    test('invalidates cached module after module deletion', async function (assert) {
+      await dbAdapter.execute('DELETE FROM modules');
+
+      let moduleURL = `${realmURL}deleted-card.gts`;
+      let modulePresent = true;
+      let calls = 0;
+
+      let prerenderer: Prerenderer = {
+        async prerenderCard() {
+          throw new Error('Not implemented in mock');
+        },
+        async prerenderFileExtract() {
+          throw new Error('Not implemented in mock');
+        },
+        async prerenderModule(args: ModulePrerenderArgs) {
+          calls++;
+          if (!modulePresent) {
+            return buildModuleResponse(
+              args.url,
+              'DeletedCard',
+              [],
+              buildModuleError(args.url, 'missing deleted-card'),
+            );
+          }
+          return buildModuleResponse(args.url, 'DeletedCard', []);
+        },
+      };
+
+      let lookup = new CachingDefinitionLookup(
+        dbAdapter,
+        prerenderer,
+        virtualNetwork,
+        testCreatePrerenderAuth,
+      );
+      lookup.registerRealm({
+        url: realmURL,
+        async getRealmOwnerUserId() {
+          return testUserId;
+        },
+        async visibility() {
+          return 'private';
+        },
+      });
+
+      let definition = await lookup.lookupDefinition({
+        module: moduleURL,
+        name: 'DeletedCard',
+      });
+      assert.ok(definition, 'definition is cached before deletion');
+      assert.strictEqual(calls, 1, 'prerenderModule called for initial lookup');
+
+      modulePresent = false;
+      await lookup.invalidate(moduleURL);
+
+      await assert.rejects(
+        lookup.lookupDefinition({
+          module: moduleURL,
+          name: 'DeletedCard',
+        }),
+        'lookup fails after module deletion invalidation',
+      );
+      assert.strictEqual(
+        calls,
+        2,
+        'prerenderModule called again after deletion invalidation',
+      );
+    });
+
+    test('invalidates module cache entries using dependency graph', async function (assert) {
+      await dbAdapter.execute('DELETE FROM modules');
+
+      let deepModule = `${realmURL}deep-card.gts`;
+      let middleModule = `${realmURL}middle-field.gts`;
+      let leafModule = `${realmURL}leaf-field.gts`;
+      let otherModule = `${realmURL}other-card.gts`;
+      let deepAlias = trimExecutableExtension(new URL(deepModule)).href;
+      let middleAlias = trimExecutableExtension(new URL(middleModule)).href;
+      let leafAlias = trimExecutableExtension(new URL(leafModule)).href;
+      let otherAlias = trimExecutableExtension(new URL(otherModule)).href;
+      let calls = new Map<string, number>();
+
+      let prerenderer: Prerenderer = {
+        async prerenderCard() {
+          throw new Error('Not implemented in mock');
+        },
+        async prerenderFileExtract() {
+          throw new Error('Not implemented in mock');
+        },
+        async prerenderModule(args: ModulePrerenderArgs) {
+          calls.set(args.url, (calls.get(args.url) ?? 0) + 1);
+          switch (args.url) {
+            case deepModule:
+              return buildModuleResponse(args.url, 'DeepCard', [
+                './middle-field.gts',
+              ]);
+            case middleModule:
+              return buildModuleResponse(args.url, 'MiddleField', [
+                './leaf-field.gts',
+              ]);
+            case leafModule:
+              return buildModuleResponse(args.url, 'LeafField', []);
+            case otherModule:
+              return buildModuleResponse(args.url, 'OtherCard', []);
+            default:
+              throw new Error(`Unexpected module URL: ${args.url}`);
+          }
+        },
+      };
+
+      let lookup = new CachingDefinitionLookup(
+        dbAdapter,
+        prerenderer,
+        virtualNetwork,
+        testCreatePrerenderAuth,
+      );
+      lookup.registerRealm({
+        url: realmURL,
+        async getRealmOwnerUserId() {
+          return testUserId;
+        },
+        async visibility() {
+          return 'private';
+        },
+      });
+
+      await lookup.lookupDefinition({
+        module: deepModule,
+        name: 'DeepCard',
+      });
+      await lookup.lookupDefinition({
+        module: middleModule,
+        name: 'MiddleField',
+      });
+      await lookup.lookupDefinition({
+        module: leafModule,
+        name: 'LeafField',
+      });
+      await lookup.lookupDefinition({
+        module: otherModule,
+        name: 'OtherCard',
+      });
+
+      let rows = (await dbAdapter.execute(
+        `SELECT url FROM modules
+         WHERE url IN ($1, $2, $3)
+            OR file_alias IN ($4, $5, $6)`,
+        {
+          bind: [
+            deepModule,
+            middleModule,
+            leafModule,
+            deepAlias,
+            middleAlias,
+            leafAlias,
+          ],
+        },
+      )) as { url: string }[];
+      assert.strictEqual(rows.length, 3, 'module cache entries created');
+
+      await lookup.invalidate(leafModule);
+
+      rows = (await dbAdapter.execute(
+        `SELECT url FROM modules
+         WHERE url IN ($1, $2, $3)
+            OR file_alias IN ($4, $5, $6)`,
+        {
+          bind: [
+            deepModule,
+            middleModule,
+            leafModule,
+            deepAlias,
+            middleAlias,
+            leafAlias,
+          ],
+        },
+      )) as { url: string }[];
+      assert.strictEqual(
+        rows.length,
+        0,
+        'leaf invalidation clears dependent module cache entries',
+      );
+
+      rows = (await dbAdapter.execute(
+        `SELECT url FROM modules
+         WHERE url = $1 OR file_alias = $2`,
+        {
+          bind: [otherModule, otherAlias],
+        },
+      )) as { url: string }[];
+      assert.strictEqual(
+        rows.length,
+        1,
+        'unrelated module remains cached after invalidation',
+      );
+
+      await lookup.lookupDefinition({
+        module: deepModule,
+        name: 'DeepCard',
+      });
+      assert.strictEqual(
+        calls.get(deepModule),
+        2,
+        'deep module was re-prerendered after invalidation',
+      );
+    });
+
+    test('invalidates module cache entries for branching dependency graph', async function (assert) {
+      await dbAdapter.execute('DELETE FROM modules');
+
+      let blogAppModule = `${realmURL}blog-app.gts`;
+      let authorModule = `${realmURL}author.gts`;
+      let blogCategoryModule = `${realmURL}blog-category.gts`;
+      let blogPostModule = `${realmURL}blog-post.gts`;
+      let otherModule = `${realmURL}other-card.gts`;
+
+      let blogAppAlias = trimExecutableExtension(new URL(blogAppModule)).href;
+      let authorAlias = trimExecutableExtension(new URL(authorModule)).href;
+      let blogCategoryAlias = trimExecutableExtension(
+        new URL(blogCategoryModule),
+      ).href;
+      let blogPostAlias = trimExecutableExtension(new URL(blogPostModule)).href;
+      let otherAlias = trimExecutableExtension(new URL(otherModule)).href;
+
+      let calls = new Map<string, number>();
+      let prerenderer: Prerenderer = {
+        async prerenderCard() {
+          throw new Error('Not implemented in mock');
+        },
+        async prerenderFileExtract() {
+          throw new Error('Not implemented in mock');
+        },
+        async prerenderModule(args: ModulePrerenderArgs) {
+          calls.set(args.url, (calls.get(args.url) ?? 0) + 1);
+          switch (args.url) {
+            case blogAppModule:
+              return buildModuleResponse(args.url, 'BlogApp', []);
+            case authorModule:
+              return buildModuleResponse(args.url, 'Author', [
+                './blog-app.gts',
+              ]);
+            case blogCategoryModule:
+              return buildModuleResponse(args.url, 'BlogCategory', [
+                './blog-app.gts',
+              ]);
+            case blogPostModule:
+              return buildModuleResponse(args.url, 'BlogPost', [
+                './author.gts',
+                './blog-app.gts',
+              ]);
+            case otherModule:
+              return buildModuleResponse(args.url, 'OtherCard', []);
+            default:
+              throw new Error(`Unexpected module URL: ${args.url}`);
+          }
+        },
+      };
+
+      let lookup = new CachingDefinitionLookup(
+        dbAdapter,
+        prerenderer,
+        virtualNetwork,
+        testCreatePrerenderAuth,
+      );
+      lookup.registerRealm({
+        url: realmURL,
+        async getRealmOwnerUserId() {
+          return testUserId;
+        },
+        async visibility() {
+          return 'private';
+        },
+      });
+
+      await lookup.lookupDefinition({
+        module: blogAppModule,
+        name: 'BlogApp',
+      });
+      await lookup.lookupDefinition({
+        module: authorModule,
+        name: 'Author',
+      });
+      await lookup.lookupDefinition({
+        module: blogCategoryModule,
+        name: 'BlogCategory',
+      });
+      await lookup.lookupDefinition({
+        module: blogPostModule,
+        name: 'BlogPost',
+      });
+      await lookup.lookupDefinition({
+        module: otherModule,
+        name: 'OtherCard',
+      });
+
+      let rows = (await dbAdapter.execute(
+        `SELECT url FROM modules
+         WHERE url IN ($1, $2, $3, $4, $5)
+            OR file_alias IN ($6, $7, $8, $9, $10)`,
+        {
+          bind: [
+            blogAppModule,
+            authorModule,
+            blogCategoryModule,
+            blogPostModule,
+            otherModule,
+            blogAppAlias,
+            authorAlias,
+            blogCategoryAlias,
+            blogPostAlias,
+            otherAlias,
+          ],
+        },
+      )) as { url: string }[];
+      assert.strictEqual(rows.length, 5, 'module cache entries created');
+
+      await lookup.invalidate(blogAppModule);
+
+      rows = (await dbAdapter.execute(
+        `SELECT url FROM modules
+         WHERE url IN ($1, $2, $3, $4)
+            OR file_alias IN ($5, $6, $7, $8)`,
+        {
+          bind: [
+            blogAppModule,
+            authorModule,
+            blogCategoryModule,
+            blogPostModule,
+            blogAppAlias,
+            authorAlias,
+            blogCategoryAlias,
+            blogPostAlias,
+          ],
+        },
+      )) as { url: string }[];
+      assert.strictEqual(
+        rows.length,
+        0,
+        'blog-app invalidation clears dependent module cache entries',
+      );
+
+      rows = (await dbAdapter.execute(
+        `SELECT url FROM modules
+         WHERE url = $1 OR file_alias = $2`,
+        {
+          bind: [otherModule, otherAlias],
+        },
+      )) as { url: string }[];
+      assert.strictEqual(
+        rows.length,
+        1,
+        'unrelated module remains cached after branching invalidation',
+      );
+
+      await lookup.lookupDefinition({
+        module: blogPostModule,
+        name: 'BlogPost',
+      });
+      assert.strictEqual(
+        calls.get(blogPostModule),
+        2,
+        'blog-post module was re-prerendered after invalidation',
+      );
+    });
+
+    test('propagates module errors to dependents and recovers after missing modules are added', async function (assert) {
+      await dbAdapter.execute('DELETE FROM modules');
+
+      let deepModule = `${realmURL}deep-card.gts`;
+      let middleModule = `${realmURL}middle-field.gts`;
+      let leafModule = `${realmURL}leaf-field.gts`;
+      let state = {
+        deep: false,
+        middle: false,
+        leaf: false,
+      };
+
+      let prerenderer: Prerenderer = {
+        async prerenderCard() {
+          throw new Error('Not implemented in mock');
+        },
+        async prerenderFileExtract() {
+          throw new Error('Not implemented in mock');
+        },
+        async prerenderModule(args: ModulePrerenderArgs) {
+          switch (args.url) {
+            case deepModule: {
+              if (!state.deep) {
+                return buildModuleResponse(
+                  args.url,
+                  'DeepCard',
+                  [],
+                  buildModuleError(args.url, 'missing deep-card'),
+                );
+              }
+              if (!state.middle || !state.leaf) {
+                return buildModuleResponse(
+                  args.url,
+                  'DeepCard',
+                  ['./middle-field.gts'],
+                  buildModuleError(args.url, 'missing middle-field'),
+                );
+              }
+              return buildModuleResponse(args.url, 'DeepCard', [
+                './middle-field.gts',
+              ]);
+            }
+            case middleModule: {
+              if (!state.middle) {
+                return buildModuleResponse(
+                  args.url,
+                  'MiddleField',
+                  [],
+                  buildModuleError(args.url, 'missing middle-field'),
+                );
+              }
+              if (!state.leaf) {
+                return buildModuleResponse(
+                  args.url,
+                  'MiddleField',
+                  ['./leaf-field.gts'],
+                  buildModuleError(args.url, 'missing leaf-field'),
+                );
+              }
+              return buildModuleResponse(args.url, 'MiddleField', [
+                './leaf-field.gts',
+              ]);
+            }
+            case leafModule: {
+              if (!state.leaf) {
+                return buildModuleResponse(
+                  args.url,
+                  'LeafField',
+                  [],
+                  buildModuleError(args.url, 'missing leaf-field'),
+                );
+              }
+              return buildModuleResponse(args.url, 'LeafField', []);
+            }
+            default:
+              throw new Error(`Unexpected module URL: ${args.url}`);
+          }
+        },
+      };
+
+      let lookup = new CachingDefinitionLookup(
+        dbAdapter,
+        prerenderer,
+        virtualNetwork,
+        testCreatePrerenderAuth,
+      );
+      lookup.registerRealm({
+        url: realmURL,
+        async getRealmOwnerUserId() {
+          return testUserId;
+        },
+        async visibility() {
+          return 'private';
+        },
+      });
+
+      await assert.rejects(
+        lookup.lookupDefinition({
+          module: deepModule,
+          name: 'DeepCard',
+        }),
+        'deep-card errors when missing',
+      );
+
+      state.deep = true;
+      await lookup.invalidate(deepModule);
+
+      await assert.rejects(
+        lookup.lookupDefinition({
+          module: middleModule,
+          name: 'MiddleField',
+        }),
+        'middle-field errors when missing',
+      );
+      await assert.rejects(
+        lookup.lookupDefinition({
+          module: deepModule,
+          name: 'DeepCard',
+        }),
+        'deep-card errors when middle-field is missing',
+      );
+
+      let rows = (await dbAdapter.execute(
+        `SELECT error_doc FROM modules WHERE url = $1`,
+        {
+          bind: [deepModule],
+          coerceTypes: { error_doc: 'JSON' },
+        },
+      )) as { error_doc: ErrorEntry | null }[];
+      let deepError = rows[0]?.error_doc;
+      assert.strictEqual(
+        deepError?.type,
+        'module-error',
+        'deep-card error is stored in cache',
+      );
+      if (deepError?.error) {
+        let additionalErrors = Array.isArray(deepError.error.additionalErrors)
+          ? deepError.error.additionalErrors
+          : [];
+        assert.ok(
+          additionalErrors.some((error) =>
+            String(error.message ?? '').includes('middle-field'),
+          ),
+          'middle-field error details are included in dependency errors',
+        );
+      }
+
+      state.middle = true;
+      await lookup.invalidate(middleModule);
+
+      await assert.rejects(
+        lookup.lookupDefinition({
+          module: leafModule,
+          name: 'LeafField',
+        }),
+        'leaf-field errors when missing',
+      );
+      await assert.rejects(
+        lookup.lookupDefinition({
+          module: middleModule,
+          name: 'MiddleField',
+        }),
+        'middle-field errors when leaf-field is missing',
+      );
+      await assert.rejects(
+        lookup.lookupDefinition({
+          module: deepModule,
+          name: 'DeepCard',
+        }),
+        'deep-card errors when leaf-field is missing',
+      );
+
+      rows = (await dbAdapter.execute(
+        `SELECT error_doc FROM modules WHERE url = $1`,
+        {
+          bind: [deepModule],
+          coerceTypes: { error_doc: 'JSON' },
+        },
+      )) as { error_doc: ErrorEntry | null }[];
+      deepError = rows[0]?.error_doc;
+      if (deepError?.error) {
+        let additionalErrors = Array.isArray(deepError.error.additionalErrors)
+          ? deepError.error.additionalErrors
+          : [];
+        assert.ok(
+          additionalErrors.some((error) =>
+            String(error.message ?? '').includes('leaf-field'),
+          ),
+          'leaf-field error details are included in dependency errors',
+        );
+      }
+
+      state.leaf = true;
+      await lookup.invalidate(leafModule);
+
+      await lookup.lookupDefinition({
+        module: leafModule,
+        name: 'LeafField',
+      });
+      await lookup.lookupDefinition({
+        module: middleModule,
+        name: 'MiddleField',
+      });
+      await lookup.lookupDefinition({
+        module: deepModule,
+        name: 'DeepCard',
+      });
+
+      let sqlNullRows = (await dbAdapter.execute(
+        `SELECT error_doc IS NULL AS is_sql_null
+         FROM modules
+         WHERE url = $1`,
+        { bind: [deepModule] },
+      )) as { is_sql_null: boolean }[];
+      assert.true(
+        sqlNullRows[0]?.is_sql_null,
+        'deep-card error_doc is SQL NULL after recovery',
       );
     });
 

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -1183,6 +1183,21 @@ module(basename(__filename), function () {
           }
         `,
       );
+
+      let pet = await realm.realmIndexQueryEngine.module(
+        new URL(`${testRealm}pet`),
+      );
+      assert.strictEqual(pet?.type, 'module-error', 'Pet module is in error');
+      if (pet?.type === 'module-error') {
+        let errorDeps = new Set(pet.error.deps ?? []);
+        let hasNameDep =
+          errorDeps.has(`${testRealm}name`) ||
+          errorDeps.has(`${testRealm}name.gts`);
+        assert.ok(hasNameDep, 'error deps include missing Name module');
+      } else {
+        assert.ok(false, 'expected pet module error details');
+      }
+
       await realm.write(
         'name.gts',
         `
@@ -1196,7 +1211,7 @@ module(basename(__filename), function () {
         `,
       );
 
-      // Aspect module should be indexed
+      // Name module should be indexed
       let name = await realm.realmIndexQueryEngine.module(
         new URL(`${testRealm}name`),
       );
@@ -1207,8 +1222,7 @@ module(basename(__filename), function () {
       );
 
       // Since the name is ready, the pet should be indexed and not in an error state
-      // Fetch the pet module
-      let pet = await realm.realmIndexQueryEngine.module(
+      pet = await realm.realmIndexQueryEngine.module(
         new URL(`${testRealm}pet`),
       );
       assert.strictEqual(


### PR DESCRIPTION
This PR is in preparation for removing module indexing. in order to do so we need to mirror the invalidation in the definition lookup that we have in our index. so instead of invalidating the entire realm anytime a module changes, we now use the `deps` field that we capture and only invalidate the consumers of the module being changed. This also includes making sure upstream module errors propagate to their consuming modules correctly as it does as part of indexing.