### PR TITLE
Allow deleting gts files that have a module error

### DIFF
--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -146,6 +146,7 @@ export default class DetailPanel extends Component<Signature> {
   private get showDetailsPanel() {
     return (
       this.args.cardError ||
+      this.args.moduleAnalysis.moduleError ||
       (!this.isModule && !isCardDocumentString(this.args.readyFile.content))
     );
   }


### PR DESCRIPTION
Enable deletion of erroring `.gts` files from the module inspector by ensuring the details panel is visible.

The issue describes that `.gts` files with errors were not appearing in the module inspector's "Details" panel, preventing the delete action. This change ensures that the panel is shown when a module has an error, making the delete button accessible.

---
Linear Issue: [CS-10037](https://linear.app/cardstack/issue/CS-10037/cant-delete-erroring-gts-files-via-the-module-inspector-in-code-mode)

<a href="https://cursor.com/background-agent?bcId=bc-bff72060-4376-4aea-a778-a99731fd7945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bff72060-4376-4aea-a778-a99731fd7945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures erroring modules are deletable from the inspector by surfacing the delete action when a module error is present.
> 
> - Include `moduleAnalysis.moduleError` in `showDetailsPanel` logic so `Details` (and its delete action) renders for erroring `.gts` modules
> - Add `erroring-module.gts` fixture and an acceptance test verifying deletion flow and file removal
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5247005e17a18f4b8316d4bd02839428ec42ac9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->