### PR TITLE
fix mock endpoints to NOT use .includes

### DIFF
--- a/packages/host/tests/helpers/index.gts
+++ b/packages/host/tests/helpers/index.gts
@@ -1190,12 +1190,13 @@ export function setupRealmServerEndpoints(
   ];
 
   let handleRealmServerRequest = async (req: Request) => {
-    let endpoint = endpoints?.find((e) => req.url.includes(e.route));
+    let pathname = new URL(req.url).pathname;
+    let endpoint = endpoints?.find((e) => pathname === `/${e.route}`);
     if (endpoint) {
       return await endpoint.getResponse(req);
     }
 
-    endpoint = defaultEndpoints.find((e) => req.url.includes(e.route));
+    endpoint = defaultEndpoints.find((e) => pathname === `/${e.route}`);
     if (endpoint) {
       return await endpoint.getResponse(req);
     }


### PR DESCRIPTION
# Mock endpoint matcher

We updated the test helper matcher to use exact path matching instead of a
substring check. This avoids collisions like `/_bot-registrations` being
handled by the `/_bot-registration` handler.

## Change

Old (substring match):

```ts
let endpoint = endpoints?.find((e) => req.url.includes(e.route));
```

New (exact path match):

```ts
let pathname = new URL(req.url).pathname;
let endpoint = endpoints?.find((e) => pathname === `/${e.route}`);
```

## Example

Given the following mocked routes:

```ts
setupRealmServerEndpoints(hooks, [
  {
    route: '_bot-registration',
    getResponse: async () => new Response(null, { status: 204 }),
  },
  {
    route: '_bot-registrations',
    getResponse: async () => new Response(JSON.stringify({ data: [] }), {
      status: 200,
      headers: { 'Content-Type': 'application/vnd.api+json' },
    }),
  },
]);
```

A request to `GET /_bot-registrations` now correctly resolves to the
`_bot-registrations` handler instead of matching `_bot-registration` first.
