### PR TITLE
host: Fix head format preview to live-update for cards

### DIFF
--- a/packages/host/app/components/head-format-preview.gts
+++ b/packages/host/app/components/head-format-preview.gts
@@ -1,5 +1,5 @@
-import Component from '@glimmer/component';
 import { scheduleOnce } from '@ember/runloop';
+import Component from '@glimmer/component';
 import { cached, tracked } from '@glimmer/tracking';
 
 import { modifier } from 'ember-modifier';
@@ -43,6 +43,8 @@ export default class HeadFormatPreview extends Component<Signature> {
     };
 
     let updateHeadMarkup = () => {
+      pendingUpdate = false;
+
       let markupSource = getMarkupSource();
       let nextMarkup = markupSource.innerHTML.trim();
 
@@ -59,10 +61,7 @@ export default class HeadFormatPreview extends Component<Signature> {
       pendingUpdate = true;
 
       // Prevent updating this.headMarkup twice in one render
-      scheduleOnce('afterRender', this, () => {
-        pendingUpdate = false;
-        updateHeadMarkup();
-      });
+      scheduleOnce('afterRender', this, updateHeadMarkup);
     };
 
     scheduleUpdate();

--- a/packages/host/app/services/operator-mode-state-service.ts
+++ b/packages/host/app/services/operator-mode-state-service.ts
@@ -91,7 +91,7 @@ export interface OperatorModeState {
 
 interface CardItem {
   id: string;
-  format: 'isolated' | 'edit';
+  format: 'isolated' | 'edit' | 'head';
 }
 
 export type FileView = 'inspector' | 'browser';
@@ -867,7 +867,11 @@ export default class OperatorModeStateService extends Service {
     for (let stack of this._state.stacks) {
       let serializedStack: SerializedStack = [];
       for (let item of stack) {
-        if (item.format !== 'isolated' && item.format !== 'edit') {
+        if (
+          item.format !== 'isolated' &&
+          item.format !== 'edit' &&
+          item.format !== 'head'
+        ) {
           throw new Error(`Unknown format for card on stack ${item.format}`);
         }
         if (item.id) {

--- a/packages/host/tests/acceptance/code-submode/card-playground-test.gts
+++ b/packages/host/tests/acceptance/code-submode/card-playground-test.gts
@@ -26,6 +26,7 @@ import {
   setupAcceptanceTestRealm,
   setupAuthEndpoints,
   setupLocalIndexing,
+  setMonacoContent,
   setupOnSave,
   setupUserSubscription,
   testRealmURL,
@@ -572,6 +573,11 @@ module('Acceptance | code-submode | card playground', function (_hooks) {
       assert.dom('.google-title').hasText('Definition Title');
       assert.dom('.google-description').hasText('Definition description');
       assert.dom('.google-site-name').hasText('example.com');
+
+      setMonacoContent(headPreviewCard.replace('</title>', '!!</title>'));
+      await settled();
+
+      assert.dom('.google-title').hasText('Definition Title!!');
     });
 
     test('can populate instance chooser options from recent-files and recent-cards, ordered by last viewed timestamp', async function (assert) {

--- a/packages/host/tests/acceptance/code-submode/head-format-preview-test.ts
+++ b/packages/host/tests/acceptance/code-submode/head-format-preview-test.ts
@@ -1,0 +1,139 @@
+import { settled, waitFor } from '@ember/test-helpers';
+
+import window from 'ember-window-mock';
+import { module, test } from 'qunit';
+
+import { baseRealm } from '@cardstack/runtime-common';
+
+import { RecentFiles } from '@cardstack/host/utils/local-storage-keys';
+
+import {
+  setupLocalIndexing,
+  setupOnSave,
+  testRealmURL,
+  setupAcceptanceTestRealm,
+  SYSTEM_CARD_FIXTURE_CONTENTS,
+  visitOperatorMode,
+  setupAuthEndpoints,
+  setupUserSubscription,
+  setMonacoContent,
+} from '../../helpers';
+
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupApplicationTest } from '../../helpers/setup';
+
+const headPreviewCardSource = `
+  import { contains, field, Component, CardDef } from "https://cardstack.com/base/card-api";
+  import StringField from "https://cardstack.com/base/string";
+
+  export class HeadPreview extends CardDef {
+    static displayName = 'Head Preview';
+
+    @field title = contains(StringField);
+    @field description = contains(StringField);
+
+    static head = class Head extends Component<typeof this> {
+      <template>
+        {{! template-lint-disable no-forbidden-elements }}
+        <title>{{@model.title}}</title>
+        <meta name='description' content={{@model.description}} />
+        <meta property='og:title' content={{@model.title}} />
+        <meta property='og:description' content={{@model.description}} />
+      </template>
+    };
+  }
+`;
+
+module('Acceptance | code submode | head format preview', function (hooks) {
+  setupApplicationTest(hooks);
+  setupLocalIndexing(hooks);
+  setupOnSave(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [baseRealm.url, testRealmURL],
+  });
+
+  let { setRealmPermissions, createAndJoinRoom } = mockMatrixUtils;
+
+  hooks.beforeEach(async function () {
+    setRealmPermissions({ [testRealmURL]: ['read', 'write'] });
+
+    createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'room-test',
+    });
+    setupUserSubscription();
+    setupAuthEndpoints();
+
+    window.localStorage.setItem(
+      RecentFiles,
+      JSON.stringify([[testRealmURL, 'HeadPreview/example.json']]),
+    );
+
+    await setupAcceptanceTestRealm({
+      mockMatrixUtils,
+      contents: {
+        ...SYSTEM_CARD_FIXTURE_CONTENTS,
+        'head-preview.gts': headPreviewCardSource,
+        'HeadPreview/example.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              title: 'Preview Title',
+              description: 'Preview description',
+            },
+            meta: {
+              adoptsFrom: {
+                module: `${testRealmURL}head-preview`,
+                name: 'HeadPreview',
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  test('head format preview updates when editing card json', async function (assert) {
+    await visitOperatorMode({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}HeadPreview/example`,
+            format: 'head',
+          },
+        ],
+      ],
+      submode: 'code',
+      codePath: `${testRealmURL}HeadPreview/example.json`,
+      cardPreviewFormat: 'head',
+    });
+
+    await waitFor('.google-title');
+    assert.dom('.google-title').hasText('Preview Title');
+    assert.dom('.google-description').hasText('Preview description');
+
+    setMonacoContent(
+      JSON.stringify({
+        data: {
+          type: 'card',
+          attributes: {
+            title: 'Updated Title',
+            description: 'Updated description',
+          },
+          meta: {
+            adoptsFrom: {
+              module: `${testRealmURL}head-preview`,
+              name: 'HeadPreview',
+            },
+          },
+        },
+      }),
+    );
+    await settled();
+
+    assert.dom('.google-title').hasText('Updated Title');
+    assert.dom('.google-description').hasText('Updated description');
+  });
+});


### PR DESCRIPTION
The head tag preview was not reactive when editing a card:

![screencast 2026-01-22 09-46-06](https://github.com/user-attachments/assets/bbc1faf6-322c-4ff5-a5a7-e2c896ead1bc)

New test to assert on the expected behaviour, failing [here](https://github.com/cardstack/boxel/actions/runs/21256724593/job/61173824238?pr=3891#step:12:58) before I pushed the fix. There was a test but it was only for a card definition, not a card, and it didn’t include changing the card definition, so I added that.

Fixed:

![screencast 2026-01-22 12-38-03](https://github.com/user-attachments/assets/91af4c75-e603-46be-8e54-d597372cba02)
