### PR TITLE
Add pre migration cleanup script to db migration docker file

### DIFF
--- a/packages/postgres/Dockerfile
+++ b/packages/postgres/Dockerfile
@@ -8,4 +8,4 @@ RUN pnpm install --frozen-lockfile
 
 WORKDIR /boxel/packages/postgres
 
-CMD ./node_modules/.bin/node-pg-migrate --check-order false --migrations-table migrations up && sleep infinity
+CMD ./node_modules/.bin/ts-node --transpileOnly ./scripts/fix-migration-names.ts && ./node_modules/.bin/node-pg-migrate --check-order false --migrations-table migrations up && sleep infinity


### PR DESCRIPTION
We forgot the add the pre migratio script to the db migration docker file. here it is.