### PR TITLE
When inserting a new subscription cycle, read the actual subscription start/end period, not invoice period

### DIFF
--- a/packages/billing/stripe-webhook-handlers/index.ts
+++ b/packages/billing/stripe-webhook-handlers/index.ts
@@ -37,6 +37,8 @@ export type StripeInvoicePaymentSucceededWebhookEvent = StripeEvent & {
         data: Array<{
           amount: number;
           description: string;
+          type?: string;
+          proration?: boolean;
           price: {
             product: string;
           };

--- a/packages/billing/stripe-webhook-handlers/payment-succeeded.ts
+++ b/packages/billing/stripe-webhook-handlers/payment-succeeded.ts
@@ -47,10 +47,9 @@ function getInvoiceSubscriptionPeriod(
     };
   }
 
-  return {
-    periodStart: event.data.object.period_start,
-    periodEnd: event.data.object.period_end,
-  };
+  throw new Error(
+    'Expected subscription period to be present in payment succeeded webhook event',
+  );
 }
 
 export async function handlePaymentSucceeded(

--- a/packages/billing/stripe-webhook-handlers/payment-succeeded.ts
+++ b/packages/billing/stripe-webhook-handlers/payment-succeeded.ts
@@ -26,6 +26,33 @@ import type { PgAdapter } from '@cardstack/postgres';
 import { TransactionManager } from '@cardstack/postgres';
 import { ProrationCalculator } from '../proration-calculator';
 
+function getInvoiceSubscriptionPeriod(
+  event: StripeInvoicePaymentSucceededWebhookEvent,
+  planStripeId: string,
+) {
+  let lineItem = event.data.object.lines.data.find(
+    (line) =>
+      line.amount >= 0 &&
+      line.type === 'subscription' &&
+      line.proration !== true &&
+      line.price?.product === planStripeId &&
+      line.period?.start &&
+      line.period?.end,
+  );
+
+  if (lineItem?.period) {
+    return {
+      periodStart: lineItem.period.start,
+      periodEnd: lineItem.period.end,
+    };
+  }
+
+  return {
+    periodStart: event.data.object.period_start,
+    periodEnd: event.data.object.period_end,
+  };
+}
+
 export async function handlePaymentSucceeded(
   dbAdapter: DBAdapter,
   event: StripeInvoicePaymentSucceededWebhookEvent,
@@ -48,6 +75,11 @@ export async function handlePaymentSucceeded(
     if (!plan) {
       throw new Error(`No plan found for product id: ${productId}`);
     }
+
+    let { periodStart, periodEnd } = getInvoiceSubscriptionPeriod(
+      event,
+      plan.stripePlanId,
+    );
 
     // When user first signs up for a plan, our checkout.session.completed handler takes care of assigning the user a stripe customer id.
     // Stripe customer id is needed so that we can recognize the user when their subscription is renewed, or canceled.
@@ -75,12 +107,18 @@ export async function handlePaymentSucceeded(
         user,
         plan,
         creditAllowance: plan.creditsIncluded,
-        periodStart: event.data.object.period_start,
-        periodEnd: event.data.object.period_end,
+        periodStart,
+        periodEnd,
         event,
       });
     } else if (billingReason === 'subscription_cycle') {
-      await createSubscriptionCycle(dbAdapter, user, plan, event);
+      await createSubscriptionCycle(
+        dbAdapter,
+        user,
+        plan,
+        periodStart,
+        periodEnd,
+      );
     } else if (billingReason === 'subscription_update') {
       await updateSubscription(dbAdapter, user, plan, event);
     }
@@ -193,8 +231,9 @@ async function updateSubscription(
 async function createSubscriptionCycle(
   dbAdapter: DBAdapter,
   user: { id: string },
-  plan: { creditsIncluded: number },
-  event: StripeInvoicePaymentSucceededWebhookEvent,
+  plan: Plan,
+  periodStart: number,
+  periodEnd: number,
 ) {
   let currentActiveSubscription = await getCurrentActiveSubscription(
     dbAdapter,
@@ -226,8 +265,8 @@ async function createSubscriptionCycle(
 
   let newSubscriptionCycle = await insertSubscriptionCycle(dbAdapter, {
     subscriptionId: currentActiveSubscription.id,
-    periodStart: event.data.object.period_start,
-    periodEnd: event.data.object.period_end,
+    periodStart,
+    periodEnd,
   });
 
   await addToCreditsLedger(dbAdapter, {

--- a/packages/billing/stripe-webhook-handlers/payment-succeeded.ts
+++ b/packages/billing/stripe-webhook-handlers/payment-succeeded.ts
@@ -48,7 +48,7 @@ function getInvoiceSubscriptionPeriod(
   }
 
   throw new Error(
-    'Expected subscription period to be present in payment succeeded webhook event',
+    `Expected subscription period to be present in payment succeeded webhook event (event id: ${event.id}, invoice id: ${event.data.object.id}, subscription id: ${event.data.object.subscription}, plan stripe id: ${planStripeId})`,
   );
 }
 

--- a/packages/realm-server/tests/billing-test.ts
+++ b/packages/realm-server/tests/billing-test.ts
@@ -147,7 +147,13 @@ module(basename(__filename), function () {
                   data: [
                     {
                       amount: 0,
+                      type: 'subscription',
+                      proration: false,
                       price: { product: 'prod_free' },
+                      period: {
+                        start: 1635873600,
+                        end: 1638465600,
+                      },
                     },
                   ],
                 },
@@ -310,6 +316,8 @@ module(basename(__filename), function () {
                   data: [
                     {
                       amount: creatorPlan.monthlyPrice * 100,
+                      type: 'subscription',
+                      proration: false,
                       price: { product: 'prod_creator' },
                       period: { start: 1, end: 2 },
                     },
@@ -405,12 +413,16 @@ module(basename(__filename), function () {
                     {
                       amount: -amountCreditedForUnusedTimeOnPreviousPlan,
                       description: 'Unused time on Creator plan',
+                      type: 'subscription',
+                      proration: false,
                       price: { product: 'prod_creator' },
                       period: { start: 3, end: 4 },
                     },
                     {
                       amount: amountCreditedForRemainingTimeOnNewPlan,
                       description: 'Remaining time on Power User plan',
+                      type: 'subscription',
+                      proration: false,
                       price: { product: 'prod_power_user' },
                       period: { start: 4, end: 5 },
                     },
@@ -500,6 +512,8 @@ module(basename(__filename), function () {
                   data: [
                     {
                       amount: creatorPlan.monthlyPrice * 100,
+                      type: 'subscription',
+                      proration: false,
                       price: { product: 'prod_creator' },
                       period: { start: 5, end: 6 },
                     },
@@ -578,7 +592,13 @@ module(basename(__filename), function () {
                   data: [
                     {
                       amount: 0,
+                      type: 'subscription',
+                      proration: false,
                       price: { product: 'prod_free' },
+                      period: {
+                        start: 1635873600,
+                        end: 1638465600,
+                      },
                     },
                   ],
                 },

--- a/packages/realm-server/tests/billing-test.ts
+++ b/packages/realm-server/tests/billing-test.ts
@@ -703,7 +703,13 @@ module(basename(__filename), function () {
                   data: [
                     {
                       amount: 1200,
+                      type: 'subscription',
+                      proration: false,
                       price: { product: 'prod_creator' },
+                      period: {
+                        start: 20,
+                        end: 30,
+                      },
                     },
                   ],
                 },
@@ -735,8 +741,8 @@ module(basename(__filename), function () {
           // Assert both subscription cycles have the correct period start and end
           assert.strictEqual(subscriptionCycles[0].periodStart, 1);
           assert.strictEqual(subscriptionCycles[0].periodEnd, 2);
-          assert.strictEqual(subscriptionCycles[1].periodStart, 2);
-          assert.strictEqual(subscriptionCycles[1].periodEnd, 3);
+          assert.strictEqual(subscriptionCycles[1].periodStart, 20);
+          assert.strictEqual(subscriptionCycles[1].periodEnd, 30);
 
           // Assert that the ledger has the correct sum of credits going in and out
           availableCredits = await sumUpCreditsLedger(dbAdapter, {

--- a/packages/realm-server/tests/server-endpoints/stripe-webhook-test.ts
+++ b/packages/realm-server/tests/server-endpoints/stripe-webhook-test.ts
@@ -153,7 +153,10 @@ module(`server-endpoints/${basename(__filename)}`, function () {
                 data: [
                   {
                     amount: 12,
+                    type: 'subscription',
+                    proration: false,
                     price: { product: 'prod_creator' },
+                    period: { start: 1635873600, end: 1638465600 },
                   },
                 ],
               },
@@ -210,7 +213,10 @@ module(`server-endpoints/${basename(__filename)}`, function () {
                   data: [
                     {
                       amount: 0,
+                      type: 'subscription',
+                      proration: false,
                       price: { product: 'prod_free' },
+                      period: { start: 1635873600, end: 1638465600 },
                     },
                   ],
                 },
@@ -377,7 +383,10 @@ module(`server-endpoints/${basename(__filename)}`, function () {
                 data: [
                   {
                     amount: 12,
+                    type: 'subscription',
+                    proration: false,
                     price: { product: 'prod_creator' },
+                    period: { start: 1635873600, end: 1638465600 },
                   },
                 ],
               },
@@ -561,7 +570,10 @@ module(`server-endpoints/${basename(__filename)}`, function () {
                 data: [
                   {
                     amount: 0,
+                    type: 'subscription',
+                    proration: false,
                     price: { product: 'prod_free' },
+                    period: { start: 1635873600, end: 1638465600 },
                   },
                 ],
               },


### PR DESCRIPTION
This PR fixes a bug where we process a webhook coming from Stripe when a new subscription is made, or when it renews. 

At that time we create a new `subscription_cycles` record, which has fields `period_start`, `period_end`, which we read from the event's payload. The issue is that the source of where we are reading these values is wrong - we are reading the invoice period while we should be reading the subscription period which is included in the invoice's line item. 

So the result of this error is that the subscription cycle periods are lagging 1 month behind. This PR fixes this with a data fix migration and adjusted logic to read the periods from the correct attributes in stripe event's payload. 



