### PR TITLE
Fix catalog app/gaming hub search to use cardTitle instead of title

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -90,7 +90,7 @@ let { data: matching } = await indexer.search({
       name: 'Post',
     },
     every: [
-      { eq: { title: 'Card 1' } },
+      { eq: { cardTitle: 'Card 1' } },
       { not: { eq: { 'author.firstName': 'Cardy' } } },
     ],
   },

--- a/packages/catalog-realm/catalog-app/catalog.gts
+++ b/packages/catalog-realm/catalog-app/catalog.gts
@@ -314,7 +314,7 @@ class Isolated extends Component<typeof Catalog> {
       return;
     }
     return {
-      any: [{ contains: { title: this.searchValue } }],
+      any: [{ contains: { cardTitle: this.searchValue } }],
     };
   }
 

--- a/packages/catalog-realm/gaming-hub/gaming-hub.gts
+++ b/packages/catalog-realm/gaming-hub/gaming-hub.gts
@@ -49,7 +49,7 @@ class Isolated extends Component<typeof GamingHub> {
     if (this.gameSearchQuery) {
       filters.push({
         on: moduleRef,
-        contains: { 'game.title': this.gameSearchQuery },
+        contains: { 'game.cardTitle': this.gameSearchQuery },
       });
     }
 


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/CS-10111/catalog-app-search-gaming-hub-search-is-not-functioning

fix catalog search: use cardTitle instead of title

The catalog app/ gaming hub search filter was using the 'title' field, which doesn't exist on Listing cards—updated to use 'cardTitle', which is the standard field for title searches. Also updated search.md to document this pattern.