### PR TITLE
code patch + correctness checks: optimize lint calls

### DIFF
--- a/packages/ai-bot/lib/code-patch-correctness.ts
+++ b/packages/ai-bot/lib/code-patch-correctness.ts
@@ -67,6 +67,7 @@ export function buildCheckCorrectnessCommandRequests(
     if (correctnessCheckAttempt > MAX_CORRECTNESS_FIX_ATTEMPTS) {
       continue;
     }
+    let lintIssues = file.lintIssues;
     requests.push({
       id: `check-${uuidv4()}`,
       name: CHECK_CORRECTNESS_COMMAND_NAME,
@@ -78,6 +79,7 @@ export function buildCheckCorrectnessCommandRequests(
           roomId: summary.roomId,
           targetEventId: summary.targetEventId,
           correctnessCheckAttempt,
+          ...(lintIssues !== undefined ? { lintIssues } : {}),
         },
       },
     });

--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -204,6 +204,7 @@ export class LintAndFixInput extends CardDef {
 
 export class LintAndFixResult extends CardDef {
   @field output = contains(StringField);
+  @field lintIssues = containsMany(StringField);
 }
 
 export class PatchCodeResultField extends FieldDef {
@@ -214,6 +215,7 @@ export class PatchCodeResultField extends FieldDef {
 export class PatchCodeCommandResult extends CardDef {
   @field patchedContent = contains(StringField);
   @field finalFileUrl = contains(StringField);
+  @field lintIssues = containsMany(StringField);
   @field results = containsMany(PatchCodeResultField);
 }
 
@@ -227,6 +229,7 @@ export class CheckCorrectnessInput extends CardDef {
   @field targetType = contains(StringField);
   @field targetRef = contains(StringField);
   @field roomId = contains(StringField);
+  @field lintIssues = containsMany(StringField);
 }
 
 export class CorrectnessResultCard extends CardDef {

--- a/packages/base/matrix-event.gts
+++ b/packages/base/matrix-event.gts
@@ -354,6 +354,7 @@ export interface CodePatchResultContent {
     context?: BoxelContext;
     attachedFiles?: (SerializedFile & { content?: string; error?: string })[];
     attachedCards?: (SerializedFile & { content?: string; error?: string })[];
+    lintIssues?: string[];
   };
 }
 

--- a/packages/host/app/commands/check-correctness.ts
+++ b/packages/host/app/commands/check-correctness.ts
@@ -3,9 +3,7 @@ import { service } from '@ember/service';
 import {
   isCardDocumentString,
   isCardErrorJSONAPI,
-  SupportedMimeType,
   type CardErrorJSONAPI,
-  type LintResult,
 } from '@cardstack/runtime-common';
 
 import ENV from '@cardstack/host/config/environment';
@@ -16,7 +14,6 @@ import HostBaseCommand from '../lib/host-base-command';
 
 import type CardService from '../services/card-service';
 import type CommandService from '../services/command-service';
-import type NetworkService from '../services/network';
 import type RealmService from '../services/realm';
 import type RealmServerService from '../services/realm-server';
 import type StoreService from '../services/store';
@@ -32,7 +29,6 @@ export default class CheckCorrectnessCommand extends HostBaseCommand<
   @service declare private commandService: CommandService;
   @service declare private cardService: CardService;
   @service declare private realmServer: RealmServerService;
-  @service declare private network: NetworkService;
 
   description =
     'Run post-change correctness checks for a specific file or card instance.';
@@ -76,7 +72,7 @@ export default class CheckCorrectnessCommand extends HostBaseCommand<
     let commandModule = await this.loadCommandModule();
     const { CorrectnessResultCard } = commandModule;
     let errors: string[] = [];
-    let lintIssues: string[] = [];
+    let lintIssues: string[] = input.lintIssues ?? [];
 
     let sizeLimitError = this.cardService.getSizeLimitError(input.targetRef);
     if (sizeLimitError) {
@@ -100,9 +96,6 @@ export default class CheckCorrectnessCommand extends HostBaseCommand<
 
     if (targetType === 'file' && input.targetRef.endsWith('.gts')) {
       errors = await this.collectModuleErrors(input.targetRef, roomId);
-      lintIssues = await this.collectLintIssues(input.targetRef);
-    } else if (targetType === 'file' && this.isLintableFile(input.targetRef)) {
-      lintIssues = await this.collectLintIssues(input.targetRef);
     } else if (targetType === 'card') {
       if (!cardId) {
         throw new Error('Card correctness checks require a targetRef.');
@@ -268,81 +261,6 @@ export default class CheckCorrectnessCommand extends HostBaseCommand<
     }
   }
 
-  private isLintableFile(targetRef: string): boolean {
-    let path = targetRef;
-    try {
-      path = new URL(targetRef).pathname;
-    } catch {
-      // fall back to original targetRef when it's not a URL
-    }
-    return /\.(gts|ts)$/.test(path);
-  }
-
-  private async collectLintIssues(targetRef: string): Promise<string[]> {
-    try {
-      if (!this.isLintableFile(targetRef)) {
-        return [];
-      }
-
-      let fileUrl = new URL(targetRef);
-      let realmURL = this.realm.realmOfURL(fileUrl);
-      if (!realmURL) {
-        return [];
-      }
-
-      let { status, content } = await this.cardService.getSource(fileUrl);
-      if (status !== 200 || !content.trim()) {
-        return [];
-      }
-
-      let filename = fileUrl.pathname.split('/').pop() || 'input.gts';
-      let response = await this.network.authedFetch(
-        `${realmURL.href}_lint?lintMode=lint`,
-        {
-          method: 'POST',
-          body: content,
-          headers: {
-            Accept: 'application/json',
-            'Content-Type': SupportedMimeType.CardSource,
-            'X-HTTP-Method-Override': 'QUERY',
-            'X-Filename': filename,
-          },
-        },
-      );
-
-      if (!response.ok) {
-        console.warn(
-          `CheckCorrectnessCommand: lint request failed for ${targetRef} (${response.status})`,
-        );
-        return [];
-      }
-
-      let lintResult: LintResult;
-      try {
-        lintResult = (await response.json()) as LintResult;
-      } catch (error) {
-        console.warn(
-          `CheckCorrectnessCommand: unable to parse lint response for ${targetRef}`,
-          error,
-        );
-        return [];
-      }
-
-      let messages = Array.isArray(lintResult?.messages)
-        ? lintResult.messages
-        : [];
-      return messages
-        .map((message) => this.formatLintIssue(message))
-        .filter((warning) => warning.length > 0);
-    } catch (error) {
-      console.warn(
-        `CheckCorrectnessCommand: lint warning collection failed for ${targetRef}`,
-        error,
-      );
-      return [];
-    }
-  }
-
   private async isEmptyFileContent(targetRef: string): Promise<boolean> {
     try {
       let fileUrl = new URL(targetRef);
@@ -351,31 +269,6 @@ export default class CheckCorrectnessCommand extends HostBaseCommand<
     } catch {
       return false;
     }
-  }
-
-  private formatLintIssue(message: LintResult['messages'][number]): string {
-    if (!message || typeof message.message !== 'string') {
-      return '';
-    }
-    let trimmedMessage = message.message.trim();
-    if (!trimmedMessage) {
-      return '';
-    }
-
-    let location = '';
-    if (typeof message.line === 'number') {
-      if (typeof message.column === 'number') {
-        location = `line ${message.line}:${message.column}`;
-      } else {
-        location = `line ${message.line}`;
-      }
-    }
-
-    let ruleId = message.ruleId ? ` (${message.ruleId})` : '';
-    if (location) {
-      return `${location} ${trimmedMessage}${ruleId}`.trim();
-    }
-    return `${trimmedMessage}${ruleId}`.trim();
   }
 
   private describeCardError(cardId: string, error: CardErrorJSONAPI): string {

--- a/packages/host/app/commands/patch-code.ts
+++ b/packages/host/app/commands/patch-code.ts
@@ -59,10 +59,12 @@ export default class PatchCodeCommand extends HostBaseCommand<
       codeBlocks,
     );
     let finalFileUrl = fileUrl;
+    let lintIssues: string[] = [];
     if (results.some((r) => r.status === 'applied')) {
       if (patchedCode.trim() !== '') {
         let lintResult = await this.lintAndFix(fileUrl, patchedCode);
         patchedCode = lintResult.output;
+        lintIssues = lintResult.lintIssues ?? [];
       }
 
       finalFileUrl = await this.determineFinalFileUrl(
@@ -100,6 +102,7 @@ export default class PatchCodeCommand extends HostBaseCommand<
     return new PatchCodeCommandResult({
       patchedContent: patchedCode,
       finalFileUrl,
+      lintIssues,
       results: results.map((result) => {
         return new PatchCodeResultField({
           status: result.status,

--- a/packages/host/app/services/command-service.ts
+++ b/packages/host/app/services/command-service.ts
@@ -717,6 +717,7 @@ export default class CommandService extends Service {
             [],
             [fileDef],
             context,
+            patchCodeResult.lintIssues,
             result.failureReason,
           ),
         );

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -1011,6 +1011,7 @@ export default class MatrixService extends Service {
     attachedCards: CardDef[] = [],
     attachedFiles: FileDef[] = [],
     context: BoxelContext,
+    lintIssues?: string[],
     failureReason?: string | undefined,
   ) {
     let contentData = await this.withContextAndAttachments(
@@ -1018,6 +1019,13 @@ export default class MatrixService extends Service {
       attachedCards,
       attachedFiles,
     );
+    let normalizedLintIssues = lintIssues || [];
+    let data: CodePatchResultContent['data'] = {
+      ...contentData,
+      ...(normalizedLintIssues.length
+        ? { lintIssues: normalizedLintIssues }
+        : {}),
+    };
     let content: CodePatchResultContent = {
       msgtype: APP_BOXEL_CODE_PATCH_RESULT_MSGTYPE,
       codeBlockIndex,
@@ -1027,7 +1035,7 @@ export default class MatrixService extends Service {
         key: resultKey,
         rel_type: APP_BOXEL_CODE_PATCH_RESULT_REL_TYPE,
       },
-      data: contentData,
+      data,
     };
     try {
       return await this.sendEvent(

--- a/packages/host/app/utils/editor/boxel-formatter.ts
+++ b/packages/host/app/utils/editor/boxel-formatter.ts
@@ -2,7 +2,10 @@ export type LintAndFixFn = (input: {
   realm: string;
   filename: string;
   fileContent: string;
-}) => Promise<{ output: string } | { output?: undefined }>; // allow undefined for safety
+}) => Promise<
+  | { output: string; lintIssues?: string[] }
+  | { output?: undefined; lintIssues?: string[] }
+>; // allow undefined for safety
 
 export interface EditorLike {
   pushUndoStop(): void;

--- a/packages/host/app/utils/lint-formatting.ts
+++ b/packages/host/app/utils/lint-formatting.ts
@@ -1,0 +1,37 @@
+import type { LintResult } from '@cardstack/runtime-common';
+
+export function formatLintIssue(
+  message: LintResult['messages'][number],
+): string {
+  if (!message || typeof message.message !== 'string') {
+    return '';
+  }
+  let trimmedMessage = message.message.trim();
+  if (!trimmedMessage) {
+    return '';
+  }
+
+  let location = '';
+  if (typeof message.line === 'number') {
+    if (typeof message.column === 'number') {
+      location = `line ${message.line}:${message.column}`;
+    } else {
+      location = `line ${message.line}`;
+    }
+  }
+
+  let ruleId = message.ruleId ? ` (${message.ruleId})` : '';
+  if (location) {
+    return `${location} ${trimmedMessage}${ruleId}`.trim();
+  }
+  return `${trimmedMessage}${ruleId}`.trim();
+}
+
+export function formatLintIssues(
+  messages: LintResult['messages'] | undefined,
+): string[] {
+  if (!Array.isArray(messages)) {
+    return [];
+  }
+  return messages.map((message) => formatLintIssue(message)).filter(Boolean);
+}

--- a/packages/realm-server/tests/realm-endpoints/lint-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/lint-test.ts
@@ -167,7 +167,7 @@ computeVia.call({ title: 'Tic Tac Toe' });
 `;
 
       const response = await request
-        .post('/_lint?lintMode=lint')
+        .post('/_lint')
         .set(
           'Authorization',
           `Bearer ${createJWT(testRealm, 'john', ['read', 'write'])}`,

--- a/packages/runtime-common/ai/types.ts
+++ b/packages/runtime-common/ai/types.ts
@@ -63,6 +63,7 @@ export interface RelevantCards {
 export interface CodePatchCorrectnessFile {
   sourceUrl: string;
   displayName: string;
+  lintIssues?: string[];
 }
 
 export interface CodePatchCorrectnessCard {

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -3063,17 +3063,6 @@ export class Realm {
       // Get source from plain text request body
       const source = await request.text();
       const filename = request.headers.get('X-Filename') || 'input.gts';
-      let lintMode: LintArgs['lintMode'] = 'lintAndAutofix';
-      try {
-        let searchParams = new URL(request.url).searchParams;
-        let requestedMode = searchParams.get('lintMode');
-        if (requestedMode === 'lint' || requestedMode === 'lintAndAutofix') {
-          lintMode = requestedMode;
-        }
-      } catch {
-        // ignore malformed URLs and keep default lint mode
-      }
-
       if (!source || source.trim() === '') {
         return createResponse({
           body: JSON.stringify({
@@ -3092,7 +3081,7 @@ export class Realm {
         concurrencyGroup: `lint:${this.url}:${Math.random().toString().slice(-1)}`,
         timeout: 10,
         priority: userInitiatedPriority,
-        args: { source, filename, lintMode } satisfies LintArgs,
+        args: { source, filename } satisfies LintArgs,
       });
       result = await job.done;
     }

--- a/packages/runtime-common/tasks/lint.ts
+++ b/packages/runtime-common/tasks/lint.ts
@@ -133,6 +133,7 @@ async function lintFix({
     return {
       ...eslintResult,
       output: formattedOutput,
+      messages: linter.verify(formattedOutput, LINT_CONFIG, filename),
     };
   } catch (error) {
     // Step 5: Handle errors gracefully with fallback behavior
@@ -145,6 +146,7 @@ async function lintFix({
     return {
       ...eslintResult,
       output: eslintOutput,
+      messages: linter.verify(eslintOutput, LINT_CONFIG, filename),
     };
   }
 }

--- a/packages/runtime-common/tasks/lint.ts
+++ b/packages/runtime-common/tasks/lint.ts
@@ -5,12 +5,9 @@ import { jobIdentity } from '../index';
 
 import { resolvePrettierConfig } from '../prettier-config';
 
-export type LintMode = 'lint' | 'lintAndAutofix';
-
 export interface LintArgs {
   source: string;
   filename?: string; // Added to support parser detection
-  lintMode?: LintMode;
 }
 
 export type LintResult = Linter.FixReport;
@@ -34,7 +31,6 @@ export const lintSource: Task<LintArgs, LintResult> = ({ reportStatus, log }) =>
 async function lintFix({
   source,
   filename = 'input.gts',
-  lintMode = 'lintAndAutofix',
 }: LintArgs): Promise<LintResult> {
   if (typeof (globalThis as any).document !== 'undefined') {
     throw new Error(
@@ -120,14 +116,6 @@ async function lintFix({
 
   // Step 1: Run existing ESLint fixes (preserving current functionality)
   const linter = new eslintModule.Linter({ configType: 'flat' });
-  if (lintMode === 'lint') {
-    const messages = linter.verify(source, LINT_CONFIG, filename);
-    return {
-      fixed: false,
-      output: source,
-      messages,
-    };
-  }
   let eslintResult = linter.verifyAndFix(source, LINT_CONFIG, filename);
   let eslintOutput = eslintResult.output ?? source;
 


### PR DESCRIPTION
Before:
- Code patch command performed linting to autocorrect autofixable issues
- Correctness check performed linting again 

After:
- Lint result from code patch command is passed into its command result
- AI bot passes that result into the correctness check command so it doesn't have to lint again

This makes correctness check run 1.5s faster 🚀 (tested in development)