### PR TITLE
host: Add utility to append realm in account data

### DIFF
--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -594,6 +594,11 @@ export default class MatrixService extends Service {
       iconURL,
       backgroundURL,
     });
+
+    await this.appendRealmToAccountData(personalRealmURL.href);
+  }
+
+  public async appendRealmToAccountData(realmURLString: string) {
     let { realms = [] } =
       ((await this.client.getAccountDataFromServer(
         APP_BOXEL_REALMS_EVENT_TYPE,
@@ -602,7 +607,7 @@ export default class MatrixService extends Service {
     // Clone the account data instead of using it directly,
     // since mutating the original object would modify the Matrix client’s store
     // and prevent updates from being sent back to the server.
-    let newRealms = [...realms, personalRealmURL.href];
+    let newRealms = [...realms, realmURLString];
     await this.client.setAccountData(APP_BOXEL_REALMS_EVENT_TYPE, {
       realms: newRealms,
     });


### PR DESCRIPTION
This makes it easier to add a workspace to the chooser vs something like this:

```
rx = [...$E.lookup('service:matrix-service')._client.getAccountData('app.boxel.realms').event.content.realms]
rx.push('https://REALM')
$E.lookup('service:matrix-service')._client.setAccountData('app.boxel.realms', {realms: rx})
```