### PR TITLE
Only lint gts/ts files for correctness checks

### DIFF
--- a/packages/host/app/commands/patch-code.ts
+++ b/packages/host/app/commands/patch-code.ts
@@ -61,7 +61,7 @@ export default class PatchCodeCommand extends HostBaseCommand<
     let finalFileUrl = fileUrl;
     let lintIssues: string[] = [];
     if (results.some((r) => r.status === 'applied')) {
-      if (patchedCode.trim() !== '') {
+      if (patchedCode.trim() !== '' && this.isLintableFile(fileUrl)) {
         let lintResult = await this.lintAndFix(fileUrl, patchedCode);
         patchedCode = lintResult.output;
         lintIssues = lintResult.lintIssues ?? [];
@@ -212,6 +212,14 @@ export default class PatchCodeCommand extends HostBaseCommand<
       fileContent: content,
       filename: filename,
     });
+  }
+
+  private isLintableFile(fileUrl: string): boolean {
+    try {
+      return /\.(gts|ts)$/.test(new URL(fileUrl).pathname);
+    } catch {
+      return /\.(gts|ts)$/.test(fileUrl);
+    }
   }
 
   private async determineFinalFileUrl(

--- a/packages/host/tests/integration/commands/patch-code-test.gts
+++ b/packages/host/tests/integration/commands/patch-code-test.gts
@@ -34,6 +34,8 @@ module('Integration | commands | patch-code', function (hooks) {
 
   const testFileName = 'task.gts';
   const fileUrl = `${testRealmURL}${testFileName}`;
+  const jsonFileName = 'task.json';
+  const jsonFileUrl = `${testRealmURL}${jsonFileName}`;
   let adapter: any;
 
   hooks.beforeEach(async function () {
@@ -54,6 +56,11 @@ export class Task extends CardDef {
   @field cardDescription = contains(StringField);
   @field priority = contains(NumberField);
 }`,
+        [jsonFileName]: `{
+  "title": "Old title",
+  "count": 1
+}
+`,
       },
     });
     adapter = realmSetup.adapter;
@@ -237,6 +244,38 @@ ${REPLACE_MARKER}`;
 
     assert.strictEqual(result.finalFileUrl, emptyFileUrl);
     assert.strictEqual(result.patchedContent, '');
+    assert.strictEqual(result.results[0]?.status, 'applied');
+  });
+
+  test('skips linting for non-gts/ts files', async function (assert) {
+    let commandService = getService('command-service');
+    let patchCodeCommand = new PatchCodeCommand(commandService.commandContext);
+
+    adapter.lintStub = async () => {
+      assert.ok(false, 'lint should not run for json files');
+      return { output: '', fixed: false, messages: [] };
+    };
+
+    const codeBlock = `${SEARCH_MARKER}
+  "title": "Old title",
+${SEPARATOR_MARKER}
+  "title": "New title",
+${REPLACE_MARKER}`;
+
+    let result = await patchCodeCommand.execute({
+      fileUrl: jsonFileUrl,
+      codeBlocks: [codeBlock],
+    });
+
+    assert.strictEqual(
+      result.patchedContent,
+      `{
+  "title": "New title",
+  "count": 1
+}
+`,
+      'json file is patched without linting',
+    );
     assert.strictEqual(result.results[0]?.status, 'applied');
   });
 });


### PR DESCRIPTION
Otherwise, the linter will try to lint files like .json and it will error out with a message about missing config, like:

```
"lintIssues": [
        "line 0:0 No matching configuration found for 9adeec41-7dab-4dca-b3d8-5be42235f5b3.json."
      ]
```