### PR TITLE
Update custom domain publishing approach

### DIFF
--- a/packages/host/app/components/operator-mode/publish-realm-modal.gts
+++ b/packages/host/app/components/operator-mode/publish-realm-modal.gts
@@ -1149,9 +1149,7 @@ export default class PublishRealmModal extends Component<Signature> {
                         class='unpublish-button'
                         {{on
                           'click'
-                          (fn
-                            @handleUnpublish this.customSubdomainOverrideUrl
-                          )
+                          (fn @handleUnpublish this.customSubdomainOverrideUrl)
                         }}
                         data-test-unpublish-custom-subdomain-override-button
                       >

--- a/packages/host/app/components/operator-mode/publish-realm-modal.gts
+++ b/packages/host/app/components/operator-mode/publish-realm-modal.gts
@@ -1112,96 +1112,89 @@ export default class PublishRealmModal extends Component<Signature> {
           </div>
 
           {{#if this.shouldShowCustomSubdomainOverride}}
-            <div class='domain-option'>
-              <input
-                type='checkbox'
-                id='custom-subdomain-override-checkbox'
-                class='domain-checkbox'
-                checked={{this.isCustomSubdomainOverrideSelected}}
-                {{on 'change' this.toggleCustomSubdomainOverride}}
-                data-test-custom-subdomain-override-checkbox
-                disabled={{this.isUnpublishingAnyRealms}}
-              />
-              <label
-                class='option-title'
-                for='custom-subdomain-override-checkbox'
-              >Custom Domain Override</label>
-              <div class='domain-details'>
-                <WithLoadedRealm @realmURL={{this.currentRealmURL}} as |realm|>
-                  <RealmIcon @realmInfo={{realm.info}} class='realm-icon' />
-                </WithLoadedRealm>
-                <div class='domain-url-container'>
-                  <span
-                    class='domain-url'
-                  >{{this.customSubdomainOverrideUrl}}</span>
-                  {{#if this.isCustomSubdomainOverridePublished}}
-                    <div class='domain-info'>
-                      {{#if this.customSubdomainOverrideLastPublishedTime}}
-                        <span class='last-published-at'>Published
-                          {{this.customSubdomainOverrideLastPublishedTime}}</span>
+            {{#let this.customSubdomainOverrideUrl as |overrideUrl|}}
+              {{#if overrideUrl}}
+                <div class='domain-option'>
+                  <input
+                    type='checkbox'
+                    id='custom-subdomain-override-checkbox'
+                    class='domain-checkbox'
+                    checked={{this.isCustomSubdomainOverrideSelected}}
+                    {{on 'change' this.toggleCustomSubdomainOverride}}
+                    data-test-custom-subdomain-override-checkbox
+                    disabled={{this.isUnpublishingAnyRealms}}
+                  />
+                  <label
+                    class='option-title'
+                    for='custom-subdomain-override-checkbox'
+                  >Custom Domain Override</label>
+                  <div class='domain-details'>
+                    <WithLoadedRealm @realmURL={{this.currentRealmURL}} as |realm|>
+                      <RealmIcon @realmInfo={{realm.info}} class='realm-icon' />
+                    </WithLoadedRealm>
+                    <div class='domain-url-container'>
+                      <span class='domain-url'>{{overrideUrl}}</span>
+                      {{#if this.isCustomSubdomainOverridePublished}}
+                        <div class='domain-info'>
+                          {{#if this.customSubdomainOverrideLastPublishedTime}}
+                            <span class='last-published-at'>Published
+                              {{this.customSubdomainOverrideLastPublishedTime}}</span>
+                          {{/if}}
+                          <BoxelButton
+                            @kind='text-only'
+                            @size='extra-small'
+                            @disabled={{this.isUnpublishingRealm overrideUrl}}
+                            class='unpublish-button'
+                            {{on 'click' (fn @handleUnpublish overrideUrl)}}
+                            data-test-unpublish-custom-subdomain-override-button
+                          >
+                            {{#if (this.isUnpublishingRealm overrideUrl)}}
+                              <LoadingIndicator />
+                              Unpublishing…
+                            {{else}}
+                              <Undo2
+                                width='11'
+                                height='11'
+                                class='unpublish-icon'
+                              />
+                              Unpublish
+                            {{/if}}
+                          </BoxelButton>
+                        </div>
+                      {{else}}
+                        <span class='not-published-yet'>Not published yet</span>
                       {{/if}}
-                      <BoxelButton
-                        @kind='text-only'
-                        @size='extra-small'
-                        @disabled={{this.isUnpublishingRealm
-                          this.customSubdomainOverrideUrl
-                        }}
-                        class='unpublish-button'
-                        {{on
-                          'click'
-                          (fn @handleUnpublish this.customSubdomainOverrideUrl)
-                        }}
-                        data-test-unpublish-custom-subdomain-override-button
-                      >
-                        {{#if
-                          (this.isUnpublishingRealm
-                            this.customSubdomainOverrideUrl
-                          )
-                        }}
-                          <LoadingIndicator />
-                          Unpublishing…
-                        {{else}}
-                          <Undo2
-                            width='11'
-                            height='11'
-                            class='unpublish-icon'
-                          />
-                          Unpublish
-                        {{/if}}
-                      </BoxelButton>
                     </div>
-                  {{else}}
-                    <span class='not-published-yet'>Not published yet</span>
+                  </div>
+                  {{#if this.isCustomSubdomainOverridePublished}}
+                    <BoxelButton
+                      @as='anchor'
+                      @kind='secondary-light'
+                      @size='small'
+                      @href={{overrideUrl}}
+                      @disabled={{this.isUnpublishingAnyRealms}}
+                      class='action'
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      data-test-open-custom-subdomain-override-button
+                    >
+                      <ExternalLink width='16' height='16' class='button-icon' />
+                      Open Site
+                    </BoxelButton>
+                  {{/if}}
+                  {{#if this.publishErrorForCustomSubdomainOverride}}
+                    <div
+                      class='domain-publish-error'
+                      data-test-domain-publish-error={{overrideUrl}}
+                    >
+                      <span
+                        class='error-text'
+                      >{{this.publishErrorForCustomSubdomainOverride}}</span>
+                    </div>
                   {{/if}}
                 </div>
-              </div>
-              {{#if this.isCustomSubdomainOverridePublished}}
-                <BoxelButton
-                  @as='anchor'
-                  @kind='secondary-light'
-                  @size='small'
-                  @href={{this.customSubdomainOverrideUrl}}
-                  @disabled={{this.isUnpublishingAnyRealms}}
-                  class='action'
-                  target='_blank'
-                  rel='noopener noreferrer'
-                  data-test-open-custom-subdomain-override-button
-                >
-                  <ExternalLink width='16' height='16' class='button-icon' />
-                  Open Site
-                </BoxelButton>
               {{/if}}
-              {{#if this.publishErrorForCustomSubdomainOverride}}
-                <div
-                  class='domain-publish-error'
-                  data-test-domain-publish-error={{this.customSubdomainOverrideUrl}}
-                >
-                  <span
-                    class='error-text'
-                  >{{this.publishErrorForCustomSubdomainOverride}}</span>
-                </div>
-              {{/if}}
-            </div>
+            {{/let}}
           {{/if}}
         </div>
       </:content>

--- a/packages/host/app/components/operator-mode/publish-realm-modal.gts
+++ b/packages/host/app/components/operator-mode/publish-realm-modal.gts
@@ -25,7 +25,9 @@ import { not } from '@cardstack/boxel-ui/helpers';
 import { IconX, Warning as WarningIcon } from '@cardstack/boxel-ui/icons';
 
 import { ensureTrailingSlash } from '@cardstack/runtime-common';
-import { PUBLISHED_REALM_DOMAIN_OVERRIDES } from '@cardstack/runtime-common/constants';
+import {
+  PUBLISHED_REALM_DOMAIN_OVERRIDES,
+} from '@cardstack/runtime-common/constants';
 
 import ModalContainer from '@cardstack/host/components/modal-container';
 import PrivateDependencyViolationComponent from '@cardstack/host/components/operator-mode/private-dependency-violation';
@@ -228,6 +230,12 @@ export default class PublishRealmModal extends Component<Signature> {
   private getPublishedRealmOverrideUrl(
     publishedRealmURL: string | null,
   ): string | null {
+    let overrideDomain =
+      PUBLISHED_REALM_DOMAIN_OVERRIDES[ensureTrailingSlash(this.currentRealmURL)];
+    if (!overrideDomain) {
+      return null;
+    }
+
     if (!publishedRealmURL) {
       return null;
     }
@@ -239,19 +247,18 @@ export default class PublishRealmModal extends Component<Signature> {
       return null;
     }
 
-    let overrideDomain =
-      PUBLISHED_REALM_DOMAIN_OVERRIDES[publishedURL.host.toLowerCase()];
-    if (!overrideDomain) {
-      return null;
-    }
-
     let overriddenURL = new URL(publishedRealmURL);
     overriddenURL.host = overrideDomain;
     return ensureTrailingSlash(overriddenURL.toString());
   }
 
   get customSubdomainOverrideUrl() {
-    return this.getPublishedRealmOverrideUrl(this.claimedDomainPublishedUrl);
+    let publishedRealmURL =
+      this.claimedDomainPublishedUrl ??
+      this.buildPublishedRealmUrl(
+        `${this.customSubdomainDisplay}.${this.customSubdomainBase}`,
+      );
+    return this.getPublishedRealmOverrideUrl(publishedRealmURL);
   }
 
   get shouldShowCustomSubdomainOverride() {

--- a/packages/host/app/components/operator-mode/publish-realm-modal.gts
+++ b/packages/host/app/components/operator-mode/publish-realm-modal.gts
@@ -25,7 +25,7 @@ import { not } from '@cardstack/boxel-ui/helpers';
 import { IconX, Warning as WarningIcon } from '@cardstack/boxel-ui/icons';
 
 import { ensureTrailingSlash } from '@cardstack/runtime-common';
-import { PUBLISHED_REALM_DOMAIN_OVERRIDES } from '@cardstack/runtime-common/constants';
+import { getPublishedRealmDomainOverrides } from '@cardstack/runtime-common/constants';
 
 import ModalContainer from '@cardstack/host/components/modal-container';
 import PrivateDependencyViolationComponent from '@cardstack/host/components/operator-mode/private-dependency-violation';
@@ -229,7 +229,7 @@ export default class PublishRealmModal extends Component<Signature> {
     publishedRealmURL: string | null,
   ): string | null {
     let overrideDomain =
-      PUBLISHED_REALM_DOMAIN_OVERRIDES[
+      getPublishedRealmDomainOverrides(config.publishedRealmDomainOverrides)[
         ensureTrailingSlash(this.currentRealmURL)
       ];
     if (!overrideDomain) {

--- a/packages/host/app/components/operator-mode/publish-realm-modal.gts
+++ b/packages/host/app/components/operator-mode/publish-realm-modal.gts
@@ -24,14 +24,14 @@ import {
 import { not } from '@cardstack/boxel-ui/helpers';
 import { IconX, Warning as WarningIcon } from '@cardstack/boxel-ui/icons';
 
+import { ensureTrailingSlash } from '@cardstack/runtime-common';
+import { PUBLISHED_REALM_DOMAIN_OVERRIDES } from '@cardstack/runtime-common/constants';
+
 import ModalContainer from '@cardstack/host/components/modal-container';
 import PrivateDependencyViolationComponent from '@cardstack/host/components/operator-mode/private-dependency-violation';
 import WithLoadedRealm from '@cardstack/host/components/with-loaded-realm';
 
 import config from '@cardstack/host/config/environment';
-
-import { ensureTrailingSlash } from '@cardstack/runtime-common';
-import { PUBLISHED_REALM_DOMAIN_OVERRIDES } from '@cardstack/runtime-common/constants';
 
 import type HostModeService from '@cardstack/host/services/host-mode-service';
 import type MatrixService from '@cardstack/host/services/matrix-service';

--- a/packages/host/app/components/operator-mode/publish-realm-modal.gts
+++ b/packages/host/app/components/operator-mode/publish-realm-modal.gts
@@ -1217,7 +1217,9 @@ export default class PublishRealmModal extends Component<Signature> {
         margin-top: calc(var(--boxel-sp-xs) * -1);
         padding: var(--boxel-sp-sm);
         border-radius: var(--boxel-border-radius-lg);
-        background-color: var(--boxel-50);
+        border: 1px solid var(--boxel-error-200);
+        background-color: rgb(from var(--boxel-error-200) r g b / 8%);
+        color: var(--boxel-error-200);
         border: 1px dashed var(--boxel-200);
         display: flex;
         flex-direction: column;
@@ -1226,13 +1228,11 @@ export default class PublishRealmModal extends Component<Signature> {
 
       .domain-override-title {
         font-size: var(--boxel-font-size-xs);
-        color: var(--boxel-450);
         font-weight: 600;
       }
 
       .domain-override-url {
         font-size: var(--boxel-font-size-sm);
-        color: var(--boxel-dark);
         word-break: break-word;
       }
 

--- a/packages/host/app/components/operator-mode/publish-realm-modal.gts
+++ b/packages/host/app/components/operator-mode/publish-realm-modal.gts
@@ -228,10 +228,9 @@ export default class PublishRealmModal extends Component<Signature> {
   private getPublishedRealmOverrideUrl(
     publishedRealmURL: string | null,
   ): string | null {
-    let overrideDomain =
-      getPublishedRealmDomainOverrides(config.publishedRealmDomainOverrides)[
-        ensureTrailingSlash(this.currentRealmURL)
-      ];
+    let overrideDomain = getPublishedRealmDomainOverrides(
+      config.publishedRealmDomainOverrides,
+    )[ensureTrailingSlash(this.currentRealmURL)];
     if (!overrideDomain) {
       return null;
     }

--- a/packages/host/app/components/operator-mode/publish-realm-modal.gts
+++ b/packages/host/app/components/operator-mode/publish-realm-modal.gts
@@ -25,9 +25,7 @@ import { not } from '@cardstack/boxel-ui/helpers';
 import { IconX, Warning as WarningIcon } from '@cardstack/boxel-ui/icons';
 
 import { ensureTrailingSlash } from '@cardstack/runtime-common';
-import {
-  PUBLISHED_REALM_DOMAIN_OVERRIDES,
-} from '@cardstack/runtime-common/constants';
+import { PUBLISHED_REALM_DOMAIN_OVERRIDES } from '@cardstack/runtime-common/constants';
 
 import ModalContainer from '@cardstack/host/components/modal-container';
 import PrivateDependencyViolationComponent from '@cardstack/host/components/operator-mode/private-dependency-violation';
@@ -231,19 +229,14 @@ export default class PublishRealmModal extends Component<Signature> {
     publishedRealmURL: string | null,
   ): string | null {
     let overrideDomain =
-      PUBLISHED_REALM_DOMAIN_OVERRIDES[ensureTrailingSlash(this.currentRealmURL)];
+      PUBLISHED_REALM_DOMAIN_OVERRIDES[
+        ensureTrailingSlash(this.currentRealmURL)
+      ];
     if (!overrideDomain) {
       return null;
     }
 
     if (!publishedRealmURL) {
-      return null;
-    }
-
-    let publishedURL: URL;
-    try {
-      publishedURL = new URL(publishedRealmURL);
-    } catch {
       return null;
     }
 

--- a/packages/host/app/components/operator-mode/publish-realm-modal.gts
+++ b/packages/host/app/components/operator-mode/publish-realm-modal.gts
@@ -1129,7 +1129,10 @@ export default class PublishRealmModal extends Component<Signature> {
                     for='custom-subdomain-override-checkbox'
                   >Custom Domain Override</label>
                   <div class='domain-details'>
-                    <WithLoadedRealm @realmURL={{this.currentRealmURL}} as |realm|>
+                    <WithLoadedRealm
+                      @realmURL={{this.currentRealmURL}}
+                      as |realm|
+                    >
                       <RealmIcon @realmInfo={{realm.info}} class='realm-icon' />
                     </WithLoadedRealm>
                     <div class='domain-url-container'>
@@ -1178,7 +1181,11 @@ export default class PublishRealmModal extends Component<Signature> {
                       rel='noopener noreferrer'
                       data-test-open-custom-subdomain-override-button
                     >
-                      <ExternalLink width='16' height='16' class='button-icon' />
+                      <ExternalLink
+                        width='16'
+                        height='16'
+                        class='button-icon'
+                      />
                       Open Site
                     </BoxelButton>
                   {{/if}}

--- a/packages/host/app/config/environment.d.ts
+++ b/packages/host/app/config/environment.d.ts
@@ -38,6 +38,7 @@ declare const config: {
   };
   publishedRealmBoxelSpaceDomain: string;
   publishedRealmBoxelSiteDomain: string;
+  publishedRealmDomainOverrides: string;
   defaultSystemCardId: string;
   cardSizeLimitBytes: number;
 };

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -36,13 +36,17 @@ const log = logger('handle-publish');
 
 // Workaround to override published realm URLs to support custom domains. Remove in CS-9061.
 const PUBLISHED_REALM_DOMAIN_OVERRIDES: Record<string, string> = {
+  // staging
   'custombuck.staging.boxel.build': 'custombuck.stack.cards',
   'docs.staging.boxel.build': 'docs.stack.cards',
   'home.staging.boxel.build': 'home.stack.cards',
   'whitepaper.staging.boxel.build': 'whitepaper.stack.cards',
+
+  // production
   'custombuck.boxel.site': 'custombuck.boxel.ai',
   'docs.boxel.site': 'docs.boxel.ai',
   'home.boxel.site': 'home.boxel.ai',
+  'tealpaper.boxel.site': 'tealpaper.cardstack.com',
   'whitepaper.boxel.site': 'whitepaper.boxel.ai',
 };
 

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -11,6 +11,7 @@ import {
   asExpressions,
   param,
   PUBLISHED_DIRECTORY_NAME,
+  PUBLISHED_REALM_DOMAIN_OVERRIDES,
   type DBAdapter,
   type PublishedRealmTable,
   fetchRealmPermissions,
@@ -33,22 +34,6 @@ import { registerUser } from '../synapse';
 import { passwordFromSeed } from '@cardstack/runtime-common/matrix-client';
 
 const log = logger('handle-publish');
-
-// Workaround to override published realm URLs to support custom domains. Remove in CS-9061.
-const PUBLISHED_REALM_DOMAIN_OVERRIDES: Record<string, string> = {
-  // staging
-  'custombuck.staging.boxel.build': 'custombuck.stack.cards',
-  'docs.staging.boxel.build': 'docs.stack.cards',
-  'home.staging.boxel.build': 'home.stack.cards',
-  'whitepaper.staging.boxel.build': 'whitepaper.stack.cards',
-
-  // production
-  'custombuck.boxel.site': 'custombuck.boxel.ai',
-  'docs.boxel.site': 'docs.boxel.ai',
-  'home.boxel.site': 'home.boxel.ai',
-  'tealpaper.boxel.site': 'tealpaper.cardstack.com',
-  'whitepaper.boxel.site': 'whitepaper.boxel.ai',
-};
 
 async function maybeOverridePublishedRealmURL(
   dbAdapter: DBAdapter,

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -47,13 +47,6 @@ async function maybeOverridePublishedRealmURL(
     return publishedRealmURL;
   }
 
-  let publishedURL: URL;
-  try {
-    publishedURL = new URL(publishedRealmURL);
-  } catch {
-    return publishedRealmURL;
-  }
-
   let overriddenURL = new URL(publishedRealmURL);
   overriddenURL.host = overrideDomain;
 

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -38,18 +38,19 @@ const log = logger('handle-publish');
 async function maybeOverridePublishedRealmURL(
   dbAdapter: DBAdapter,
   ownerUserId: string,
+  sourceRealmURL: string,
   publishedRealmURL: string,
 ): Promise<string> {
+  let overrideDomain =
+    PUBLISHED_REALM_DOMAIN_OVERRIDES[ensureTrailingSlash(sourceRealmURL)];
+  if (!overrideDomain) {
+    return publishedRealmURL;
+  }
+
   let publishedURL: URL;
   try {
     publishedURL = new URL(publishedRealmURL);
   } catch {
-    return publishedRealmURL;
-  }
-
-  let overrideDomain =
-    PUBLISHED_REALM_DOMAIN_OVERRIDES[publishedURL.host.toLowerCase()];
-  if (!overrideDomain) {
     return publishedRealmURL;
   }
 
@@ -167,6 +168,7 @@ export default function handlePublishRealm({
     let overriddenPublishedRealmURL = await maybeOverridePublishedRealmURL(
       dbAdapter,
       ownerUserId,
+      sourceRealmURL,
       publishedRealmURL,
     );
     let permissions = await fetchRealmPermissions(

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -11,12 +11,12 @@ import {
   asExpressions,
   param,
   PUBLISHED_DIRECTORY_NAME,
-  PUBLISHED_REALM_DOMAIN_OVERRIDES,
   type DBAdapter,
   type PublishedRealmTable,
   fetchRealmPermissions,
   uuidv4,
 } from '@cardstack/runtime-common';
+import { getPublishedRealmDomainOverrides } from '@cardstack/runtime-common/constants';
 import { ensureDirSync, copySync, readJsonSync, writeJsonSync } from 'fs-extra';
 import { resolve, join } from 'path';
 import {
@@ -34,6 +34,10 @@ import { registerUser } from '../synapse';
 import { passwordFromSeed } from '@cardstack/runtime-common/matrix-client';
 
 const log = logger('handle-publish');
+
+const PUBLISHED_REALM_DOMAIN_OVERRIDES = getPublishedRealmDomainOverrides(
+  process.env.PUBLISHED_REALM_DOMAIN_OVERRIDES,
+);
 
 async function maybeOverridePublishedRealmURL(
   dbAdapter: DBAdapter,

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -466,6 +466,9 @@ export class RealmServer {
           assetsURL: this.assetsURL.href,
           realmServerURL: this.serverURL.href,
           cardSizeLimitBytes: this.cardSizeLimitBytes,
+          publishedRealmDomainOverrides:
+            process.env.PUBLISHED_REALM_DOMAIN_OVERRIDES ??
+            config.publishedRealmDomainOverrides,
         });
         return `${g1}${encodeURIComponent(JSON.stringify(config))}${g3}`;
       },

--- a/packages/runtime-common/constants.ts
+++ b/packages/runtime-common/constants.ts
@@ -89,17 +89,13 @@ export const DEFAULT_PERMISSIONS = Object.freeze([
 // Workaround to override published realm URLs to support custom domains. Remove in CS-9061.
 export const PUBLISHED_REALM_DOMAIN_OVERRIDES: Record<string, string> = {
   // staging
-  'custombuck.staging.boxel.build': 'custombuck.stack.cards',
-  'docs.staging.boxel.build': 'docs.stack.cards',
-  'home.staging.boxel.build': 'home.stack.cards',
-  'whitepaper.staging.boxel.build': 'whitepaper.stack.cards',
+  'https://realms-staging.stack.cards/buck/load-testing/':
+    'custombuck.stack.cards',
 
   // production
-  'custombuck.boxel.site': 'custombuck.boxel.ai',
-  'docs.boxel.site': 'docs.boxel.ai',
-  'home.boxel.site': 'home.boxel.ai',
-  'tealpaper.boxel.site': 'tealpaper.cardstack.com',
-  'whitepaper.boxel.site': 'whitepaper.boxel.ai',
+  'https://app.boxel.ai/bucktest/20251216/': 'custombuck.boxel.ai',
+  'https://app.boxel.ai/official/cardstack-reward/': 'tealpaper.cardstack.com',
+  'https://app.boxel.ai/official/boxel-whitepaper/': 'whitepaper.boxel.ai',
 };
 
 export const PUBLISHED_DIRECTORY_NAME = '_published';

--- a/packages/runtime-common/constants.ts
+++ b/packages/runtime-common/constants.ts
@@ -111,11 +111,13 @@ export function parsePublishedRealmDomainOverrides(
       return {};
     }
 
-    return Object.fromEntries(
-      Object.entries(parsed).filter(
-        ([key, value]) => typeof key === 'string' && typeof value === 'string',
-      ),
-    );
+    let overrides: Record<string, string> = {};
+    for (let [key, value] of Object.entries(parsed)) {
+      if (typeof key === 'string' && typeof value === 'string') {
+        overrides[key] = value;
+      }
+    }
+    return overrides;
   } catch {
     return {};
   }

--- a/packages/runtime-common/constants.ts
+++ b/packages/runtime-common/constants.ts
@@ -86,4 +86,20 @@ export const DEFAULT_PERMISSIONS = Object.freeze([
   'realm-owner',
 ]) as RealmPermissions['user'];
 
+// Workaround to override published realm URLs to support custom domains. Remove in CS-9061.
+export const PUBLISHED_REALM_DOMAIN_OVERRIDES: Record<string, string> = {
+  // staging
+  'custombuck.staging.boxel.build': 'custombuck.stack.cards',
+  'docs.staging.boxel.build': 'docs.stack.cards',
+  'home.staging.boxel.build': 'home.stack.cards',
+  'whitepaper.staging.boxel.build': 'whitepaper.stack.cards',
+
+  // production
+  'custombuck.boxel.site': 'custombuck.boxel.ai',
+  'docs.boxel.site': 'docs.boxel.ai',
+  'home.boxel.site': 'home.boxel.ai',
+  'tealpaper.boxel.site': 'tealpaper.cardstack.com',
+  'whitepaper.boxel.site': 'whitepaper.boxel.ai',
+};
+
 export const PUBLISHED_DIRECTORY_NAME = '_published';

--- a/packages/runtime-common/constants.ts
+++ b/packages/runtime-common/constants.ts
@@ -129,7 +129,7 @@ export function getPublishedRealmDomainOverrides(
   let envOverrides =
     typeof rawOverrides === 'string'
       ? parsePublishedRealmDomainOverrides(rawOverrides)
-      : rawOverrides ?? {};
+      : (rawOverrides ?? {});
   return {
     ...PUBLISHED_REALM_DOMAIN_OVERRIDES,
     ...envOverrides,

--- a/packages/runtime-common/constants.ts
+++ b/packages/runtime-common/constants.ts
@@ -87,16 +87,7 @@ export const DEFAULT_PERMISSIONS = Object.freeze([
 ]) as RealmPermissions['user'];
 
 // Workaround to override published realm URLs to support custom domains. Remove in CS-9061.
-export const PUBLISHED_REALM_DOMAIN_OVERRIDES: Record<string, string> = {
-  // staging
-  'https://realms-staging.stack.cards/buck/load-testing/':
-    'custombuck.stack.cards',
-
-  // production
-  'https://app.boxel.ai/bucktest/20251216/': 'custombuck.boxel.ai',
-  'https://app.boxel.ai/official/cardstack-reward/': 'tealpaper.cardstack.com',
-  'https://app.boxel.ai/official/boxel-whitepaper/': 'whitepaper.boxel.ai',
-};
+export const PUBLISHED_REALM_DOMAIN_OVERRIDES: Record<string, string> = {};
 
 export function parsePublishedRealmDomainOverrides(
   rawOverrides: string | undefined,

--- a/packages/runtime-common/constants.ts
+++ b/packages/runtime-common/constants.ts
@@ -98,4 +98,40 @@ export const PUBLISHED_REALM_DOMAIN_OVERRIDES: Record<string, string> = {
   'https://app.boxel.ai/official/boxel-whitepaper/': 'whitepaper.boxel.ai',
 };
 
+export function parsePublishedRealmDomainOverrides(
+  rawOverrides: string | undefined,
+): Record<string, string> {
+  if (!rawOverrides) {
+    return {};
+  }
+
+  try {
+    let parsed = JSON.parse(rawOverrides);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {};
+    }
+
+    return Object.fromEntries(
+      Object.entries(parsed).filter(
+        ([key, value]) => typeof key === 'string' && typeof value === 'string',
+      ),
+    );
+  } catch {
+    return {};
+  }
+}
+
+export function getPublishedRealmDomainOverrides(
+  rawOverrides?: string | Record<string, string>,
+): Record<string, string> {
+  let envOverrides =
+    typeof rawOverrides === 'string'
+      ? parsePublishedRealmDomainOverrides(rawOverrides)
+      : rawOverrides ?? {};
+  return {
+    ...PUBLISHED_REALM_DOMAIN_OVERRIDES,
+    ...envOverrides,
+  };
+}
+
 export const PUBLISHED_DIRECTORY_NAME = '_published';


### PR DESCRIPTION
More requirements have emerged so I’m adapting the implementation of custom domain publishing, which is a workaround until we have full support for dynamic creation of CNAMES and the like.

1. Instead of hardcoding usernames who can publish to overridden custom domains, anyone with write permissions for a realm can publish it.
2. `PUBLISHED_REALM_DOMAIN_OVERRIDES` is an environment variable that lets us add to the hardcoded mapping without requiring a full deployment.
3. The publish modal UI now is now aware of overrides, which necessitated threading `PUBLISHED_REALM_DOMAIN_OVERRIDES` through from the realm server’s `index.html`-serving function. <img width="2282" height="2308" alt="e8c0a21ef0e0f5101a0d9e590435203ca7bf96af 2026-01-29 14-01-35" src="https://github.com/user-attachments/assets/9982a5c4-a4b4-4181-b370-10500b62807d" />
1. Claiming and overriding the custom subdomain when publishing is no longer needed.