### PR TITLE
Add HTML prerendering for FileDef entries during indexing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,7 @@ jobs:
       boxel: ${{ steps.filter.outputs.boxel }}
       ai-bot: ${{ steps.filter.outputs.ai-bot }}
       bot-runner: ${{ steps.filter.outputs.bot-runner }}
+      eslint-plugin-boxel: ${{ steps.filter.outputs.eslint-plugin-boxel }}
       postgres-migrations: ${{ steps.filter.outputs.postgres-migrations }}
       boxel-icons: ${{ steps.filter.outputs.boxel-icons }}
       boxel-motion: ${{ steps.filter.outputs.boxel-motion }}
@@ -67,6 +68,9 @@ jobs:
               - *shared
               - 'packages/bot-runner/**'
               - 'packages/postgres/**'
+            eslint-plugin-boxel:
+              - *shared
+              - 'packages/eslint-plugin-boxel/**'
             postgres-migrations:
               - 'packages/postgres/migrations/**'
             boxel-icons:
@@ -161,6 +165,21 @@ jobs:
       - name: Bot Runner test suite
         run: pnpm test
         working-directory: packages/bot-runner
+
+  eslint-plugin-boxel-test:
+    name: ESLint Plugin Boxel Tests
+    needs: change-check
+    if: needs.change-check.outputs.eslint-plugin-boxel == 'true' || github.ref == 'refs/heads/main' || needs.change-check.outputs.run_all == 'true'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: eslint-plugin-boxel-test-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+      - uses: ./.github/actions/init
+      - name: ESLint Plugin Boxel test suite
+        run: pnpm test
+        working-directory: packages/eslint-plugin-boxel
 
   postgres-migration-test:
     name: Postgres Migration Test

--- a/packages/billing/billing-queries.ts
+++ b/packages/billing/billing-queries.ts
@@ -562,14 +562,17 @@ export async function spendCredits(
   if (!subscriptionCycle) {
     throw new Error('subscription cycle not found');
   }
-  let availablePlanAllowanceCredits = await sumUpCreditsLedger(dbAdapter, {
-    creditType: [
-      'plan_allowance',
-      'plan_allowance_used',
-      'plan_allowance_expired',
-    ],
-    userId,
-  });
+  let availablePlanAllowanceCredits = Math.max(
+    0,
+    await sumUpCreditsLedger(dbAdapter, {
+      creditType: [
+        'plan_allowance',
+        'plan_allowance_used',
+        'plan_allowance_expired',
+      ],
+      subscriptionCycleId: subscriptionCycle.id,
+    }),
+  );
 
   if (availablePlanAllowanceCredits >= creditsToSpend) {
     await addToCreditsLedger(dbAdapter, {

--- a/packages/boxel-ui/addon/src/components/menu/index.gts
+++ b/packages/boxel-ui/addon/src/components/menu/index.gts
@@ -246,6 +246,7 @@ export default class Menu extends Component<Signature> {
           display: flex;
           align-items: center;
           gap: var(--boxel-menu-item-gap);
+          text-transform: capitalize;
         }
         .menu-item__icon-url {
           flex-shrink: 0;

--- a/packages/catalog-realm/crm-app/crm-app.gts
+++ b/packages/catalog-realm/crm-app/crm-app.gts
@@ -664,6 +664,8 @@ class CrmAppTemplate extends Component<typeof CrmApp> {
             @searchFilter={{this.searchFilter}}
             @taskFilter={{this.taskFilter}}
             @sort={{this.taskSort}}
+            @createCard={{@createCard}}
+            @saveCard={{@saveCard}}
           />
         {{else if this.query}}
           {{#if (eq this.selectedView 'card')}}

--- a/packages/eslint-plugin-boxel/lib/rules/no-css-position-fixed.js
+++ b/packages/eslint-plugin-boxel/lib/rules/no-css-position-fixed.js
@@ -1,0 +1,40 @@
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'disallow `position: fixed` in card CSS because cards should not break out of their bounding box',
+      category: 'Ember Octane',
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      'no-css-position-fixed':
+        'Do not use `position: fixed` in card CSS. Cards should not break out of their bounding box. Consider using `position: absolute` or `position: sticky` instead.',
+    },
+  },
+
+  create: (context) => {
+    return {
+      GlimmerElement(node) {
+        if (node.tag !== 'style') {
+          return;
+        }
+        for (const child of node.children) {
+          if (child.type === 'GlimmerTextNode') {
+            const text = child.value;
+            const regex = /position\s*:\s*fixed/gi;
+            let match;
+            while ((match = regex.exec(text)) !== null) {
+              context.report({
+                node: child,
+                messageId: 'no-css-position-fixed',
+              });
+            }
+          }
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-boxel/lib/rules/no-css-position-fixed.js
+++ b/packages/eslint-plugin-boxel/lib/rules/no-css-position-fixed.js
@@ -17,7 +17,7 @@ module.exports = {
 
   create: (context) => {
     return {
-      GlimmerElement(node) {
+      GlimmerElementNode(node) {
         if (node.tag !== 'style') {
           return;
         }

--- a/packages/eslint-plugin-boxel/tests/lib/rules/no-css-position-fixed-test.js
+++ b/packages/eslint-plugin-boxel/tests/lib/rules/no-css-position-fixed-test.js
@@ -1,0 +1,133 @@
+const rule = require('../../../lib/rules/no-css-position-fixed');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('ember-eslint-parser'),
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+});
+ruleTester.run('no-css-position-fixed', rule, {
+  valid: [
+    `
+      <template>
+        <div class="my-card">Hello</div>
+        <style scoped>
+          .my-card {
+            position: relative;
+            top: 0;
+          }
+        </style>
+      </template>
+    `,
+    `
+      <template>
+        <div class="my-card">Hello</div>
+        <style scoped>
+          .my-card {
+            position: absolute;
+            top: 0;
+          }
+        </style>
+      </template>
+    `,
+    `
+      <template>
+        <div class="my-card">Hello</div>
+        <style scoped>
+          .my-card {
+            position: sticky;
+            top: 0;
+          }
+        </style>
+      </template>
+    `,
+    // No style tag at all
+    `
+      <template>
+        <div class="my-card">Hello</div>
+      </template>
+    `,
+  ],
+
+  invalid: [
+    {
+      code: `
+        <template>
+          <div class="my-card">Hello</div>
+          <style scoped>
+            .my-card {
+              position: fixed;
+              top: 0;
+            }
+          </style>
+        </template>
+      `,
+      errors: [
+        {
+          type: 'GlimmerTextNode',
+          message: rule.meta.messages['no-css-position-fixed'],
+        },
+      ],
+    },
+    // Without space after colon
+    {
+      code: `
+        <template>
+          <style scoped>
+            .my-card {
+              position:fixed;
+            }
+          </style>
+        </template>
+      `,
+      errors: [
+        {
+          type: 'GlimmerTextNode',
+          message: rule.meta.messages['no-css-position-fixed'],
+        },
+      ],
+    },
+    // With extra whitespace
+    {
+      code: `
+        <template>
+          <style scoped>
+            .my-card {
+              position:  fixed;
+            }
+          </style>
+        </template>
+      `,
+      errors: [
+        {
+          type: 'GlimmerTextNode',
+          message: rule.meta.messages['no-css-position-fixed'],
+        },
+      ],
+    },
+    // Multiple occurrences
+    {
+      code: `
+        <template>
+          <style scoped>
+            .my-card {
+              position: fixed;
+            }
+            .another {
+              position: fixed;
+            }
+          </style>
+        </template>
+      `,
+      errors: [
+        {
+          type: 'GlimmerTextNode',
+          message: rule.meta.messages['no-css-position-fixed'],
+        },
+        {
+          type: 'GlimmerTextNode',
+          message: rule.meta.messages['no-css-position-fixed'],
+        },
+      ],
+    },
+  ],
+});

--- a/packages/experiments-realm/crm-app.gts
+++ b/packages/experiments-realm/crm-app.gts
@@ -647,6 +647,8 @@ class CrmAppTemplate extends Component<typeof CrmApp> {
             @searchFilter={{this.searchFilter}}
             @taskFilter={{this.taskFilter}}
             @sort={{this.taskSort}}
+            @createCard={{@createCard}}
+            @saveCard={{@saveCard}}
           />
         {{else if this.query}}
           {{#if (eq this.selectedView 'card')}}

--- a/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
@@ -33,7 +33,7 @@ interface Signature {
   Args: {
     items: (CardDef | FileDef | CardErrorJSONAPI)[];
     autoAttachedCardIds?: TrackedSet<string>;
-    autoAttachedFile?: FileDef;
+    autoAttachedFiles?: FileDef[];
     removeCard: (cardId: string) => void;
     removeFile: (file: FileDef) => void;
     chooseCard?: (cardId: string) => void;
@@ -63,7 +63,11 @@ export default class AttachedItems extends Component<Signature> {
   };
 
   private isAutoAttachedFile = (file: FileDef): boolean => {
-    return this.args.autoAttachedFile?.sourceUrl === file.sourceUrl;
+    return (
+      this.args.autoAttachedFiles?.some(
+        (autoFile) => autoFile.sourceUrl === file.sourceUrl,
+      ) ?? false
+    );
   };
 
   @action

--- a/packages/host/app/components/ai-assistant/attachment-picker/index.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/index.gts
@@ -23,7 +23,7 @@ interface Signature {
   Args: {
     autoAttachedCardIds?: TrackedSet<string>;
     cardIdsToAttach: string[] | undefined;
-    autoAttachedFile?: FileDef;
+    autoAttachedFiles?: FileDef[];
     filesToAttach: FileDef[] | undefined;
     chooseCard: (cardId: string) => void;
     removeCard: (cardId: string) => void;
@@ -37,7 +37,7 @@ interface Signature {
         typeof AttachedItems,
         | 'items'
         | 'autoAttachedCardIds'
-        | 'autoAttachedFile'
+        | 'autoAttachedFiles'
         | 'removeCard'
         | 'removeFile'
         | 'chooseCard'
@@ -59,7 +59,7 @@ export default class AiAssistantAttachmentPicker extends Component<Signature> {
         isLoaded=this.isLoaded
         items=this.items
         autoAttachedCardIds=@autoAttachedCardIds
-        autoAttachedFile=@autoAttachedFile
+        autoAttachedFiles=@autoAttachedFiles
         removeCard=@removeCard
         removeFile=@removeFile
         chooseCard=@chooseCard
@@ -109,18 +109,20 @@ export default class AiAssistantAttachmentPicker extends Component<Signature> {
   private get files() {
     let files = this.args.filesToAttach ?? [];
 
-    if (!this.args.autoAttachedFile) {
+    let autoAttachedFiles = this.args.autoAttachedFiles ?? [];
+
+    if (autoAttachedFiles.length === 0) {
       return files;
     }
 
-    if (
-      files.some(
-        (file) => file.sourceUrl === this.args.autoAttachedFile?.sourceUrl,
-      )
-    ) {
+    let autoFilesToPrepend = autoAttachedFiles.filter(
+      (file) => !files.some((item) => item.sourceUrl === file.sourceUrl),
+    );
+
+    if (autoFilesToPrepend.length === 0) {
       return files;
     }
 
-    return [this.args.autoAttachedFile, ...files];
+    return [...autoFilesToPrepend, ...files];
   }
 }

--- a/packages/host/app/components/ai-assistant/attachment-picker/usage.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/usage.gts
@@ -18,7 +18,7 @@ export default class AiAssistantCardPickerUsage extends Component {
   cardIds: TrackedArray<string> = new TrackedArray([]);
   @tracked maxNumberOfCards: number | undefined = undefined;
   @tracked autoAttachedCardIds?: TrackedSet<string> = new TrackedSet();
-  @tracked autoAttachedFile?: FileDef | undefined;
+  @tracked autoAttachedFiles?: FileDef[];
   @tracked filesToAttach: TrackedArray<FileDef> = new TrackedArray([]);
 
   @action chooseCard(cardId: string) {
@@ -60,7 +60,7 @@ export default class AiAssistantCardPickerUsage extends Component {
           @removeCard={{this.removeCard}}
           @chooseFile={{this.chooseFile}}
           @removeFile={{this.removeFile}}
-          @autoAttachedFile={{this.autoAttachedFile}}
+          @autoAttachedFiles={{this.autoAttachedFiles}}
           @filesToAttach={{this.filesToAttach}}
           as |AttachedItems AttachButton|
         >
@@ -81,9 +81,9 @@ export default class AiAssistantCardPickerUsage extends Component {
           @value={{this.autoAttachedCardIds}}
         />
         <Args.Object
-          @name='autoAttachedFile'
-          @description='A file automatically attached to the message.'
-          @value={{this.autoAttachedFile}}
+          @name='autoAttachedFiles'
+          @description='Files automatically attached to the message.'
+          @value={{this.autoAttachedFiles}}
         />
         <Args.Object
           @name='filesToAttach'

--- a/packages/host/app/components/card-prerender.gts
+++ b/packages/host/app/components/card-prerender.gts
@@ -429,7 +429,6 @@ export default class CardPrerender extends Component {
     async ({
       url,
       fileData,
-      types,
       renderOptions,
     }: FileRenderArgs): Promise<FileRenderResponse> => {
       this.#nonce++;
@@ -457,47 +456,16 @@ export default class CardPrerender extends Component {
 
       let error: RenderError | undefined;
       let isolatedHTML: string | null = null;
-      let headHTML: string | null = null;
-      let atomHTML: string | null = null;
-      let iconHTML: string | null = null;
-      let embeddedHTML: Record<string, string> | null = null;
-      let fittedHTML: Record<string, string> | null = null;
 
+      // Render isolated HTML only – additional formats (head, atom, icon,
+      // fitted, embedded) are deferred to keep boot-indexing fast.
       try {
-        let subsequentRenderOptions = omitOneTimeOptions(initialRenderOptions);
         isolatedHTML = await this.renderHTML.perform(
           url,
           'isolated',
           0,
           initialRenderOptions,
         );
-        headHTML = await this.renderHTML.perform(
-          url,
-          'head',
-          0,
-          subsequentRenderOptions,
-        );
-        atomHTML = await this.renderHTML.perform(
-          url,
-          'atom',
-          0,
-          subsequentRenderOptions,
-        );
-        iconHTML = await this.renderIcon.perform(url, subsequentRenderOptions);
-        if (types.length > 0) {
-          embeddedHTML = await this.renderAncestors.perform(
-            url,
-            'embedded',
-            types,
-            subsequentRenderOptions,
-          );
-          fittedHTML = await this.renderAncestors.perform(
-            url,
-            'fitted',
-            types,
-            subsequentRenderOptions,
-          );
-        }
       } catch (e: any) {
         try {
           error = { ...JSON.parse(e.message), type: 'file-error' };
@@ -520,11 +488,11 @@ export default class CardPrerender extends Component {
 
       return {
         isolatedHTML,
-        headHTML,
-        atomHTML,
-        embeddedHTML,
-        fittedHTML,
-        iconHTML,
+        headHTML: null,
+        atomHTML: null,
+        embeddedHTML: null,
+        fittedHTML: null,
+        iconHTML: null,
         ...(error ? { error } : {}),
       };
     },

--- a/packages/host/app/components/card-prerender.gts
+++ b/packages/host/app/components/card-prerender.gts
@@ -22,6 +22,8 @@ import {
   type RenderError,
   type ModuleRenderResponse,
   type FileExtractResponse,
+  type FileRenderResponse,
+  type FileRenderArgs,
   type Prerenderer,
   type Format,
   type PrerenderMeta,
@@ -93,6 +95,7 @@ export default class CardPrerender extends Component {
       prerenderCard: this.prerender.bind(this),
       prerenderModule: this.prerenderModule.bind(this),
       prerenderFileExtract: this.prerenderFileExtract.bind(this),
+      prerenderFileRender: this.prerenderFileRenderPublic.bind(this),
     };
     this.localIndexer.setup(this.#prerendererDelegate);
     window.addEventListener('boxel-render-error', this.#handleRenderErrorEvent);
@@ -199,6 +202,24 @@ export default class CardPrerender extends Component {
       }
       throw new Error(
         `card-prerender component is missing or being destroyed before file extract prerender of url ${url} was completed`,
+      );
+    });
+  }
+
+  private async prerenderFileRenderPublic(
+    args: FileRenderArgs,
+  ): Promise<FileRenderResponse> {
+    return await withRenderContext(async () => {
+      try {
+        let run = () => this.fileRenderPrerenderTask.perform(args);
+        return isTesting() ? await run() : await withTimersBlocked(run);
+      } catch (e: any) {
+        if (!didCancel(e)) {
+          throw e;
+        }
+      }
+      throw new Error(
+        `card-prerender component is missing or being destroyed before file render prerender of url ${args.url} was completed`,
       );
     });
   }
@@ -401,6 +422,115 @@ export default class CardPrerender extends Component {
       }
       await this.#ensureRenderReady(routeInfo);
       return routeInfo.attributes as FileExtractResponse;
+    },
+  );
+
+  private fileRenderPrerenderTask = enqueueTask(
+    async ({
+      url,
+      fileData,
+      types,
+      renderOptions,
+    }: FileRenderArgs): Promise<FileRenderResponse> => {
+      this.#nonce++;
+      let shouldClearCache = this.#consumeClearCacheForRender(
+        Boolean(renderOptions?.clearCache),
+      );
+      let initialRenderOptions: RenderRouteOptions = {
+        ...(renderOptions ?? {}),
+        fileRender: true,
+        fileDefCodeRef: fileData.fileDefCodeRef,
+      };
+      if (shouldClearCache) {
+        initialRenderOptions.clearCache = true;
+        this.loaderService.resetLoader({
+          clearFetchCache: true,
+          reason: 'card-prerender file render clearCache',
+        });
+        this.store.resetCache();
+      } else {
+        delete initialRenderOptions.clearCache;
+      }
+
+      // Stash file data for the render route to consume
+      (globalThis as any).__boxelFileRenderData = fileData;
+
+      let error: RenderError | undefined;
+      let isolatedHTML: string | null = null;
+      let headHTML: string | null = null;
+      let atomHTML: string | null = null;
+      let iconHTML: string | null = null;
+      let embeddedHTML: Record<string, string> | null = null;
+      let fittedHTML: Record<string, string> | null = null;
+
+      try {
+        let subsequentRenderOptions =
+          omitOneTimeOptions(initialRenderOptions);
+        isolatedHTML = await this.renderHTML.perform(
+          url,
+          'isolated',
+          0,
+          initialRenderOptions,
+        );
+        headHTML = await this.renderHTML.perform(
+          url,
+          'head',
+          0,
+          subsequentRenderOptions,
+        );
+        atomHTML = await this.renderHTML.perform(
+          url,
+          'atom',
+          0,
+          subsequentRenderOptions,
+        );
+        iconHTML = await this.renderIcon.perform(
+          url,
+          subsequentRenderOptions,
+        );
+        if (types.length > 0) {
+          embeddedHTML = await this.renderAncestors.perform(
+            url,
+            'embedded',
+            types,
+            subsequentRenderOptions,
+          );
+          fittedHTML = await this.renderAncestors.perform(
+            url,
+            'fitted',
+            types,
+            subsequentRenderOptions,
+          );
+        }
+      } catch (e: any) {
+        try {
+          error = { ...JSON.parse(e.message), type: 'file-error' };
+        } catch (_err) {
+          let cardErr = new CardError(e.message);
+          cardErr.stack = e.stack;
+          error = {
+            error: {
+              ...cardErr.toJSON(),
+              deps: [url],
+              additionalErrors: null,
+            },
+            type: 'file-error',
+          };
+        }
+        this.store.resetCache();
+      } finally {
+        delete (globalThis as any).__boxelFileRenderData;
+      }
+
+      return {
+        isolatedHTML,
+        headHTML,
+        atomHTML,
+        embeddedHTML,
+        fittedHTML,
+        iconHTML,
+        ...(error ? { error } : {}),
+      };
     },
   );
 

--- a/packages/host/app/components/card-prerender.gts
+++ b/packages/host/app/components/card-prerender.gts
@@ -464,8 +464,7 @@ export default class CardPrerender extends Component {
       let fittedHTML: Record<string, string> | null = null;
 
       try {
-        let subsequentRenderOptions =
-          omitOneTimeOptions(initialRenderOptions);
+        let subsequentRenderOptions = omitOneTimeOptions(initialRenderOptions);
         isolatedHTML = await this.renderHTML.perform(
           url,
           'isolated',
@@ -484,10 +483,7 @@ export default class CardPrerender extends Component {
           0,
           subsequentRenderOptions,
         );
-        iconHTML = await this.renderIcon.perform(
-          url,
-          subsequentRenderOptions,
-        );
+        iconHTML = await this.renderIcon.perform(url, subsequentRenderOptions);
         if (types.length > 0) {
           embeddedHTML = await this.renderAncestors.perform(
             url,

--- a/packages/host/app/components/host-mode/card.gts
+++ b/packages/host/app/components/host-mode/card.gts
@@ -94,6 +94,7 @@ export default class HostModeCard extends Component<Signature> {
         padding: var(--host-mode-card-padding);
         border-radius: var(--host-mode-card-border-radius, 20px);
         flex: 1;
+        z-index: 0;
         overflow: auto;
       }
 

--- a/packages/host/app/components/host-mode/content.gts
+++ b/packages/host/app/components/host-mode/content.gts
@@ -126,7 +126,6 @@ export default class HostModeContent extends Component<Signature> {
         align-items: center;
         justify-content: center;
         width: 100%;
-        min-height: 100vh;
         overflow: hidden;
         padding: var(--boxel-sp);
         position: relative;
@@ -134,6 +133,19 @@ export default class HostModeContent extends Component<Signature> {
         background-position: center;
         background-size: cover;
         background-repeat: no-repeat;
+      }
+
+      @media screen {
+        .host-mode-content {
+          height: 100%;
+          overscroll-behavior: none;
+        }
+      }
+
+      @media print {
+        .host-mode-content {
+          min-height: 100vh;
+        }
       }
 
       .breadcrumb-container {

--- a/packages/host/app/components/host-mode/stack-item.gts
+++ b/packages/host/app/components/host-mode/stack-item.gts
@@ -8,9 +8,8 @@ import { isTesting } from '@embroider/macros';
 import Component from '@glimmer/component';
 import { cached, tracked } from '@glimmer/tracking';
 
-import X from '@cardstack/boxel-icons/x';
-
-import { IconButton } from '@cardstack/boxel-ui/components';
+import { ContextButton } from '@cardstack/boxel-ui/components';
+import { and, bool } from '@cardstack/boxel-ui/helpers';
 
 import { getCard } from '@cardstack/host/resources/card-resource';
 
@@ -74,7 +73,7 @@ export default class HostModeStackItem extends Component<Signature> {
 
     let maxWidthPercent = 100 - invertedIndex * maxWidthReductionPercent;
     let width = this.isItemFullWidth
-      ? '100%'
+      ? 'calc(100% - var(--boxel-sp-xxl) * 2)'
       : `${stackItemMaxWidth / Math.pow(RATIO, invertedIndex)}rem`;
 
     let styles = `
@@ -83,8 +82,11 @@ export default class HostModeStackItem extends Component<Signature> {
       max-width: ${maxWidthPercent}%;
       z-index: calc(${this.args.index} + 1);
       margin-top: ${marginTopPx}px;
-      transition: margin-top var(--boxel-transition), width var(--boxel-transition);
     `; // using margin-top instead of padding-top to hide scrolled content from view
+
+    if (this.isTopCard) {
+      styles += `height: auto;`;
+    }
 
     return htmlSafe(styles);
   }
@@ -157,14 +159,13 @@ export default class HostModeStackItem extends Component<Signature> {
           @displayBoundaries={{if this.isItemFullWidth false true}}
           class='host-mode-stack-item-card'
         />
-        {{#if @close}}
+        {{#if (and this.isTopCard (bool @close))}}
           <div class='close-button-container'>
-            <IconButton
-              class='close-button'
-              @icon={{X}}
-              @width='16px'
-              @height='16px'
+            <ContextButton
+              @icon='close'
+              @label='close'
               {{on 'click' this.handleClose}}
+              data-test-host-stack-item-close-button
             />
           </div>
         {{/if}}
@@ -210,12 +211,22 @@ export default class HostModeStackItem extends Component<Signature> {
         position: absolute;
         width: 89%;
         height: inherit;
+        padding-top: var(--boxel-sp-xxl);
         z-index: 0;
         pointer-events: none;
       }
 
+      @media screen {
+        .host-mode-stack-item {
+          min-height: 80cqh;
+        }
+      }
+
+      .host-mode-stack-item:not(.buried) {
+        padding-bottom: var(--boxel-sp-xxl);
+      }
+
       .host-mode-stack-item.full-width {
-        width: 100%;
         max-width: 100%;
       }
 
@@ -269,19 +280,32 @@ export default class HostModeStackItem extends Component<Signature> {
         position: absolute;
         top: var(--boxel-sp-xs);
         right: var(--boxel-sp-xs);
-        padding: var(--boxel-sp-xs);
+        z-index: 1;
       }
-
-      .close-button {
-        height: 18px;
-        width: 18px;
+      .close-button-container :deep(.boxel-context-button:not(:hover)) {
+        background-color: var(--boxel-100);
+      }
+      .close-button-container :deep(.boxel-context-button) {
+        box-shadow: var(--boxel-box-shadow);
       }
 
       .host-mode-stack-item-card {
         border-radius: 0;
         box-shadow: none;
-        overflow: auto;
-        height: 100%;
+        z-index: 0;
+      }
+
+      @media print {
+        .host-mode-stack-item {
+          height: 100% !important;
+        }
+        .host-mode-stack-item-card {
+          height: 100%;
+          overflow: auto;
+        }
+        .close-button-container {
+          display: none;
+        }
       }
     </style>
   </template>

--- a/packages/host/app/components/host-mode/stack.gts
+++ b/packages/host/app/components/host-mode/stack.gts
@@ -32,15 +32,12 @@ const HostModeStack: TemplateOnlyComponent<Signature> = <template>
       background-color: rgba(0, 0, 0, 0.35);
       background-position: center;
       background-size: cover;
-      padding-top: var(--boxel-sp-xxl);
-      padding-inline: var(--boxel-sp-xxl);
-      padding-bottom: var(--boxel-sp-xxl);
+      padding: 0;
       position: absolute;
       top: 0;
       left: 0;
       right: 0;
       bottom: 0;
-      transition: padding-top var(--boxel-transition);
     }
 
     .inner {
@@ -51,6 +48,17 @@ const HostModeStack: TemplateOnlyComponent<Signature> = <template>
       margin: 0 auto;
       border-bottom-left-radius: var(--boxel-border-radius);
       border-bottom-right-radius: var(--boxel-border-radius);
+    }
+
+    @media screen {
+      .inner {
+        overflow: auto;
+      }
+      /* .inner will handle overflow in host mode stack */
+      .host-mode-stack :deep(.host-mode-card, .card) {
+        overflow: hidden;
+        min-height: 80cqh;
+      }
     }
   </style>
 </template>;

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -47,6 +47,7 @@ import UpdateRoomSkillsCommand from '@cardstack/host/commands/update-room-skills
 import type { Message } from '@cardstack/host/lib/matrix-classes/message';
 import type { StackItem } from '@cardstack/host/lib/stack-item';
 import { getAutoAttachment } from '@cardstack/host/resources/auto-attached-card';
+import { isReady } from '@cardstack/host/resources/file';
 import type { RoomResource } from '@cardstack/host/resources/room';
 
 import type AiAssistantPanelService from '@cardstack/host/services/ai-assistant-panel-service';
@@ -194,7 +195,7 @@ export default class Room extends Component<Signature> {
             @removeCard={{this.removeCard}}
             @chooseFile={{this.chooseFile}}
             @removeFile={{this.removeFile}}
-            @autoAttachedFile={{this.autoAttachedFile}}
+            @autoAttachedFiles={{this.autoAttachedFiles}}
             @filesToAttach={{this.filesToAttach}}
             @autoAttachedCardTooltipMessage={{if
               (eq this.operatorModeStateService.state.submode Submodes.Code)
@@ -450,7 +451,7 @@ export default class Room extends Component<Signature> {
     submode: () => this.operatorModeStateService.state.submode,
     moduleInspectorPanel: () =>
       this.operatorModeStateService.moduleInspectorPanel,
-    autoAttachedFileUrl: () => this.autoAttachedFileUrl,
+    autoAttachedFileUrls: () => this.autoAttachedFileUrls,
     playgroundPanelCardId: () => this.playgroundPanelCardId,
     activeSpecId: () => this.specPanelService.specSelection,
     topMostStackItems: () => this.topMostStackItems,
@@ -459,7 +460,7 @@ export default class Room extends Component<Signature> {
   });
   private removedAttachedCardIds = new TrackedArray<string>();
   private removedAttachedFileUrls: string[] = [];
-  private lastAutoAttachedFileUrl: string | undefined;
+  private lastAutoAttachedFileUrlsKey: string | undefined;
   private getConversationScrollability: (() => boolean) | undefined;
   private scrollConversationToBottom: (() => void) | undefined;
   private roomScrollState: WeakMap<
@@ -530,59 +531,98 @@ export default class Room extends Component<Signature> {
   // when the user opens a different file and then returns to this one.
   @use private autoAttachedFileResource = resource(() => {
     let state = new TrackedObject<{
-      value: FileDef | undefined;
-      remove: () => void;
+      value: FileDef[];
+      remove: (sourceUrl?: string) => void;
     }>({
-      value: undefined,
-      remove: () => {
-        state.value = undefined;
+      value: [],
+      remove: (sourceUrl?: string) => {
+        if (!sourceUrl) {
+          state.value = [];
+          return;
+        }
+        state.value = state.value.filter(
+          (file) => file.sourceUrl !== sourceUrl,
+        );
       },
     });
 
-    let autoAttachedFileUrl = this.autoAttachedFileUrl;
+    let autoAttachedFileUrls = this.autoAttachedFileUrls;
     let manuallyAttachedFiles = this.filesToAttach;
+    let autoAttachedFileUrlsKey = autoAttachedFileUrls.join('\n');
 
     let removedFileUrls: string[];
-    if (autoAttachedFileUrl !== this.lastAutoAttachedFileUrl) {
+    if (autoAttachedFileUrlsKey !== this.lastAutoAttachedFileUrlsKey) {
       this.removedAttachedFileUrls.splice(0);
       removedFileUrls = this.removedAttachedFileUrls;
-      this.lastAutoAttachedFileUrl = autoAttachedFileUrl;
+      this.lastAutoAttachedFileUrlsKey = autoAttachedFileUrlsKey;
     } else {
       removedFileUrls = this.removedAttachedFileUrls;
     }
 
-    let isManuallyAttached = manuallyAttachedFiles.some(
-      (file) => file.sourceUrl === autoAttachedFileUrl,
-    );
-    let isRemoved = autoAttachedFileUrl
-      ? removedFileUrls.includes(autoAttachedFileUrl)
-      : false;
+    let candidateUrls = autoAttachedFileUrls.filter((url) => {
+      if (!url) {
+        return false;
+      }
+      let isManuallyAttached = manuallyAttachedFiles.some(
+        (file) => file.sourceUrl === url,
+      );
+      let isRemoved = removedFileUrls.includes(url);
+      return !isManuallyAttached && !isRemoved;
+    });
 
-    if (!autoAttachedFileUrl || isManuallyAttached || isRemoved) {
-      state.value = undefined;
-    } else {
-      state.value = this.matrixService.fileAPI.createFileDef({
-        sourceUrl: autoAttachedFileUrl,
-        name: autoAttachedFileUrl.split('/').pop(),
-      });
-    }
+    state.value = candidateUrls.map((url) =>
+      this.matrixService.fileAPI.createFileDef({
+        sourceUrl: url,
+        name: url.split('/').pop(),
+      }),
+    );
 
     return state;
   });
 
-  private get autoAttachedFileUrl() {
-    return this.operatorModeStateService.state.codePath?.href;
+  private get autoAttachedFileUrls() {
+    let codePathUrl = this.operatorModeStateService.state.codePath?.href;
+    if (!codePathUrl) {
+      return [];
+    }
+
+    let urls = [codePathUrl];
+
+    if (codePathUrl.endsWith('.json')) {
+      let openFile = this.operatorModeStateService.openFile?.current;
+      if (openFile && isReady(openFile)) {
+        try {
+          let fileContent = JSON.parse(openFile.content);
+          let adoptsFrom = fileContent?.data?.meta?.adoptsFrom;
+          if (adoptsFrom?.module) {
+            let moduleURLWithExtension = new URL(
+              adoptsFrom.module.endsWith('.gts')
+                ? adoptsFrom.module
+                : `${adoptsFrom.module}.gts`,
+              openFile.url,
+            );
+            if (!urls.includes(moduleURLWithExtension.href)) {
+              urls.push(moduleURLWithExtension.href);
+            }
+          }
+        } catch (_error) {
+          // If JSON parse fails, fall back to just the current file URL.
+        }
+      }
+    }
+
+    return urls;
   }
 
-  private get autoAttachedFile() {
+  private get autoAttachedFiles() {
     return this.operatorModeStateService.state.submode === Submodes.Code
       ? this.autoAttachedFileResource.value
-      : undefined;
+      : [];
   }
 
   private get removeAutoAttachedFile() {
-    return () => {
-      this.autoAttachedFileResource.remove();
+    return (sourceUrl?: string) => {
+      this.autoAttachedFileResource.remove(sourceUrl);
     };
   }
 
@@ -939,8 +979,8 @@ export default class Room extends Component<Signature> {
     }
 
     let files = [];
-    if (this.autoAttachedFile) {
-      files.push(this.autoAttachedFile);
+    if (this.autoAttachedFiles.length > 0) {
+      files.push(...this.autoAttachedFiles);
     }
     files.push(...this.filesToAttach);
 
@@ -996,7 +1036,7 @@ export default class Room extends Component<Signature> {
   private chooseFile(file: FileDef) {
     // handle the case where auto-attached file pill is clicked
     if (this.isAutoAttachedFile(file)) {
-      this.removeAutoAttachedFile();
+      this.removeAutoAttachedFile(file.sourceUrl ?? undefined);
     }
 
     let files = this.filesToAttach;
@@ -1007,13 +1047,15 @@ export default class Room extends Component<Signature> {
 
   @action
   private isAutoAttachedFile(file: FileDef) {
-    return this.autoAttachedFile?.sourceUrl === file.sourceUrl;
+    return this.autoAttachedFiles.some(
+      (autoFile) => autoFile.sourceUrl === file.sourceUrl,
+    );
   }
 
   @action
   private removeFile(file: FileDef) {
     if (this.isAutoAttachedFile(file)) {
-      this.removeAutoAttachedFile();
+      this.removeAutoAttachedFile(file.sourceUrl ?? undefined);
       return;
     }
 
@@ -1228,7 +1270,7 @@ export default class Room extends Component<Signature> {
     return (
       this.filesToAttach?.length ||
       this.cardIdsToAttach?.length ||
-      this.autoAttachedFile ||
+      this.autoAttachedFiles.length > 0 ||
       this.autoAttachedCardIds?.size
     );
   }

--- a/packages/host/app/components/operator-mode/definition-container/base.gts
+++ b/packages/host/app/components/operator-mode/definition-container/base.gts
@@ -209,6 +209,7 @@ const Active: TemplateOnlyComponent<ActiveSignature> = <template>
       justify-content: flex-start;
       gap: var(--boxel-sp-xxxs);
       align-self: flex-start;
+      text-transform: capitalize;
     }
     .info-footer {
       color: var(--boxel-450);

--- a/packages/host/app/components/operator-mode/publish-realm-modal.gts
+++ b/packages/host/app/components/operator-mode/publish-realm-modal.gts
@@ -24,6 +24,9 @@ import {
 import { not } from '@cardstack/boxel-ui/helpers';
 import { IconX, Warning as WarningIcon } from '@cardstack/boxel-ui/icons';
 
+import { ensureTrailingSlash } from '@cardstack/runtime-common';
+import { getPublishedRealmDomainOverrides } from '@cardstack/runtime-common/constants';
+
 import ModalContainer from '@cardstack/host/components/modal-container';
 import PrivateDependencyViolationComponent from '@cardstack/host/components/operator-mode/private-dependency-violation';
 import WithLoadedRealm from '@cardstack/host/components/with-loaded-realm';
@@ -219,6 +222,65 @@ export default class PublishRealmModal extends Component<Signature> {
 
   get customSubdomainBase() {
     return config.publishedRealmBoxelSiteDomain;
+  }
+
+  // TODO: Remove with CS-9061 once published realm domain overrides are removed.
+  private getPublishedRealmOverrideUrl(
+    publishedRealmURL: string | null,
+  ): string | null {
+    let overrideDomain = getPublishedRealmDomainOverrides(
+      config.publishedRealmDomainOverrides,
+    )[ensureTrailingSlash(this.currentRealmURL)];
+    if (!overrideDomain) {
+      return null;
+    }
+
+    if (!publishedRealmURL) {
+      return null;
+    }
+
+    let overriddenURL = new URL(publishedRealmURL);
+    overriddenURL.host = overrideDomain;
+    return ensureTrailingSlash(overriddenURL.toString());
+  }
+
+  get customSubdomainOverrideUrl() {
+    let publishedRealmURL =
+      this.claimedDomainPublishedUrl ??
+      this.buildPublishedRealmUrl(
+        `${this.customSubdomainDisplay}.${this.customSubdomainBase}`,
+      );
+    return this.getPublishedRealmOverrideUrl(publishedRealmURL);
+  }
+
+  get shouldShowCustomSubdomainOverride() {
+    return (
+      !!this.customSubdomainOverrideUrl &&
+      this.realm.canWrite(this.currentRealmURL)
+    );
+  }
+
+  get isCustomSubdomainOverrideSelected() {
+    if (!this.customSubdomainOverrideUrl) {
+      return false;
+    }
+    return this.selectedPublishedRealmURLs.includes(
+      this.customSubdomainOverrideUrl,
+    );
+  }
+
+  get isCustomSubdomainOverridePublished() {
+    if (!this.customSubdomainOverrideUrl) {
+      return false;
+    }
+    return this.hostModeService.isPublished(this.customSubdomainOverrideUrl);
+  }
+
+  get customSubdomainOverrideLastPublishedTime() {
+    if (!this.customSubdomainOverrideUrl) {
+      return null;
+    }
+    return this.getFormattedLastPublishedTime(this.customSubdomainOverrideUrl);
   }
 
   get customSubdomainDisplay() {
@@ -458,6 +520,20 @@ export default class PublishRealmModal extends Component<Signature> {
     }
   }
 
+  @action
+  toggleCustomSubdomainOverride(event: Event) {
+    const overrideUrl = this.customSubdomainOverrideUrl;
+    if (!overrideUrl) {
+      return;
+    }
+    const input = event.target as HTMLInputElement;
+    if (input.checked) {
+      this.addPublishedRealmUrl(overrideUrl);
+    } else {
+      this.removePublishedRealmUrl(overrideUrl);
+    }
+  }
+
   private addPublishedRealmUrl(url: string) {
     if (!this.selectedPublishedRealmURLs.includes(url)) {
       this.selectedPublishedRealmURLs = [
@@ -617,6 +693,13 @@ export default class PublishRealmModal extends Component<Signature> {
       return null;
     }
     return this.getPublishErrorForUrl(this.claimedDomainPublishedUrl);
+  }
+
+  get publishErrorForCustomSubdomainOverride() {
+    if (!this.customSubdomainOverrideUrl) {
+      return null;
+    }
+    return this.getPublishErrorForUrl(this.customSubdomainOverrideUrl);
   }
 
   ensureInitialSelectionsTask = restartableTask(
@@ -1027,6 +1110,99 @@ export default class PublishRealmModal extends Component<Signature> {
               </div>
             {{/if}}
           </div>
+
+          {{#if this.shouldShowCustomSubdomainOverride}}
+            {{#let this.customSubdomainOverrideUrl as |overrideUrl|}}
+              {{#if overrideUrl}}
+                <div class='domain-option'>
+                  <input
+                    type='checkbox'
+                    id='custom-subdomain-override-checkbox'
+                    class='domain-checkbox'
+                    checked={{this.isCustomSubdomainOverrideSelected}}
+                    {{on 'change' this.toggleCustomSubdomainOverride}}
+                    data-test-custom-subdomain-override-checkbox
+                    disabled={{this.isUnpublishingAnyRealms}}
+                  />
+                  <label
+                    class='option-title'
+                    for='custom-subdomain-override-checkbox'
+                  >Custom Domain Override</label>
+                  <div class='domain-details'>
+                    <WithLoadedRealm
+                      @realmURL={{this.currentRealmURL}}
+                      as |realm|
+                    >
+                      <RealmIcon @realmInfo={{realm.info}} class='realm-icon' />
+                    </WithLoadedRealm>
+                    <div class='domain-url-container'>
+                      <span class='domain-url'>{{overrideUrl}}</span>
+                      {{#if this.isCustomSubdomainOverridePublished}}
+                        <div class='domain-info'>
+                          {{#if this.customSubdomainOverrideLastPublishedTime}}
+                            <span class='last-published-at'>Published
+                              {{this.customSubdomainOverrideLastPublishedTime}}</span>
+                          {{/if}}
+                          <BoxelButton
+                            @kind='text-only'
+                            @size='extra-small'
+                            @disabled={{this.isUnpublishingRealm overrideUrl}}
+                            class='unpublish-button'
+                            {{on 'click' (fn @handleUnpublish overrideUrl)}}
+                            data-test-unpublish-custom-subdomain-override-button
+                          >
+                            {{#if (this.isUnpublishingRealm overrideUrl)}}
+                              <LoadingIndicator />
+                              Unpublishing…
+                            {{else}}
+                              <Undo2
+                                width='11'
+                                height='11'
+                                class='unpublish-icon'
+                              />
+                              Unpublish
+                            {{/if}}
+                          </BoxelButton>
+                        </div>
+                      {{else}}
+                        <span class='not-published-yet'>Not published yet</span>
+                      {{/if}}
+                    </div>
+                  </div>
+                  {{#if this.isCustomSubdomainOverridePublished}}
+                    <BoxelButton
+                      @as='anchor'
+                      @kind='secondary-light'
+                      @size='small'
+                      @href={{overrideUrl}}
+                      @disabled={{this.isUnpublishingAnyRealms}}
+                      class='action'
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      data-test-open-custom-subdomain-override-button
+                    >
+                      <ExternalLink
+                        width='16'
+                        height='16'
+                        class='button-icon'
+                      />
+                      Open Site
+                    </BoxelButton>
+                  {{/if}}
+                  {{#if this.publishErrorForCustomSubdomainOverride}}
+                    <div
+                      class='domain-publish-error'
+                      data-test-domain-publish-error={{overrideUrl}}
+                    >
+                      <span
+                        class='error-text'
+                      >{{this.publishErrorForCustomSubdomainOverride}}</span>
+                    </div>
+                  {{/if}}
+                </div>
+              {{/if}}
+            {{/let}}
+          {{/if}}
         </div>
       </:content>
 

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -525,8 +525,10 @@ export default class SubmodeLayout extends Component<Signature> {
         --submode-bar-item-border-radius: var(--boxel-border-radius);
         --boxel-icon-button-width: var(--container-button-size);
         --boxel-icon-button-height: var(--container-button-size);
+        position: relative;
         display: flex;
         height: 100%;
+        z-index: 0;
       }
 
       .submode-layout > .boxel-panel-group {
@@ -651,6 +653,12 @@ export default class SubmodeLayout extends Component<Signature> {
       :deep(.open-search-field) {
         box-shadow: var(--submode-bar-item-box-shadow);
         outline: var(--submode-bar-item-outline);
+      }
+
+      @media print {
+        .submode-layout-top-bar {
+          display: none;
+        }
       }
     </style>
   </template>

--- a/packages/host/app/config/environment.d.ts
+++ b/packages/host/app/config/environment.d.ts
@@ -38,6 +38,7 @@ declare const config: {
   };
   publishedRealmBoxelSpaceDomain: string;
   publishedRealmBoxelSiteDomain: string;
+  publishedRealmDomainOverrides: string;
   defaultSystemCardId: string;
   cardSizeLimitBytes: number;
 };

--- a/packages/host/app/resources/auto-attached-card.ts
+++ b/packages/host/app/resources/auto-attached-card.ts
@@ -23,7 +23,7 @@ interface Args {
   named: {
     submode: Submode;
     moduleInspectorPanel: string | undefined; // 'preview' | 'spec' | 'schema' | 'card-renderer'
-    autoAttachedFileUrl: string | undefined;
+    autoAttachedFileUrls: string[] | undefined;
     playgroundPanelCardId: string | undefined;
     activeSpecId: string | null | undefined; // selected spec card ID from SpecPanelService
     topMostStackItems: StackItem[];
@@ -45,7 +45,7 @@ export class AutoAttachment extends Resource<Args> {
     const {
       submode,
       moduleInspectorPanel,
-      autoAttachedFileUrl,
+      autoAttachedFileUrls,
       playgroundPanelCardId,
       activeSpecId,
       topMostStackItems,
@@ -55,7 +55,7 @@ export class AutoAttachment extends Resource<Args> {
     this.calculateAutoAttachments.perform(
       submode,
       moduleInspectorPanel,
-      autoAttachedFileUrl,
+      autoAttachedFileUrls,
       playgroundPanelCardId,
       activeSpecId,
       topMostStackItems,
@@ -68,7 +68,7 @@ export class AutoAttachment extends Resource<Args> {
     async (
       submode: Submode,
       moduleInspectorPanel: string | undefined,
-      autoAttachedFileUrl: string | undefined,
+      autoAttachedFileUrls: string[] | undefined,
       playgroundPanelCardId: string | undefined,
       activeSpecId: string | null | undefined,
       topMostStackItems: StackItem[],
@@ -97,8 +97,11 @@ export class AutoAttachment extends Resource<Args> {
           this.cardIds.add(item.id);
         }
       } else if (submode === Submodes.Code) {
-        let cardId = autoAttachedFileUrl?.endsWith('.json')
-          ? autoAttachedFileUrl?.replace(/\.json$/, '')
+        let cardFileUrl = autoAttachedFileUrls?.find((url) =>
+          url.endsWith('.json'),
+        );
+        let cardId = cardFileUrl
+          ? cardFileUrl.replace(/\.json$/, '')
           : undefined;
         if (
           cardId &&
@@ -133,7 +136,7 @@ export function getAutoAttachment(
   args: {
     submode: () => Submode;
     moduleInspectorPanel: () => string | undefined;
-    autoAttachedFileUrl: () => string | undefined;
+    autoAttachedFileUrls: () => string[] | undefined;
     playgroundPanelCardId: () => string | undefined;
     activeSpecId: () => string | null | undefined;
     topMostStackItems: () => StackItem[];
@@ -145,7 +148,7 @@ export function getAutoAttachment(
     named: {
       submode: args.submode(),
       moduleInspectorPanel: args.moduleInspectorPanel(),
-      autoAttachedFileUrl: args.autoAttachedFileUrl(),
+      autoAttachedFileUrls: args.autoAttachedFileUrls(),
       playgroundPanelCardId: args.playgroundPanelCardId(),
       activeSpecId: args.activeSpecId(),
       topMostStackItems: args.topMostStackItems(),

--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -257,11 +257,8 @@ export default class RenderRoute extends Route<Model> {
         throw new Error('fileRender mode requires __boxelFileRenderData');
       }
       let { resource } = fileRenderData;
-      let cardApi = await this.loaderService.loader.import<typeof CardAPI>(
-        `${baseRealm.url}card-api`,
-      );
       let doc = { data: resource };
-      let instance = (await cardApi.createFromSerialized(
+      let instance = (await this.store.addFileMeta(
         resource,
         doc,
         resource.id ? new URL(resource.id) : undefined,

--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -256,7 +256,7 @@ export default class RenderRoute extends Route<Model> {
       if (!fileRenderData) {
         throw new Error('fileRender mode requires __boxelFileRenderData');
       }
-      let { resource, fileDefCodeRef } = fileRenderData;
+      let { resource } = fileRenderData;
       let cardApi = await this.loaderService.loader.import<typeof CardAPI>(
         `${baseRealm.url}card-api`,
       );

--- a/packages/host/app/services/render-store.ts
+++ b/packages/host/app/services/render-store.ts
@@ -1,7 +1,23 @@
+import type {
+  FileMetaResource,
+  LooseLinkableResource,
+  LooseSingleResourceDocument,
+} from '@cardstack/runtime-common';
+
+import type { FileDef } from 'https://cardstack.com/base/file-api';
+
 import StoreService from './store';
 
 export default class RenderStoreService extends StoreService {
   protected override isRenderStore = true;
+
+  async addFileMeta(
+    resource: LooseLinkableResource<FileMetaResource>,
+    doc: LooseSingleResourceDocument<FileMetaResource>,
+    relativeTo: URL | undefined,
+  ): Promise<FileDef> {
+    return this.createFileMetaFromSerialized(resource, doc, relativeTo);
+  }
 }
 
 declare module '@ember/service' {

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -49,6 +49,9 @@ import {
   type CardErrorJSONAPI,
   type CardErrorsJSONAPI,
   type ErrorEntry,
+  type FileMetaResource,
+  type LooseLinkableResource,
+  type LooseSingleResourceDocument,
   type StoreReadType,
 } from '@cardstack/runtime-common';
 
@@ -1032,6 +1035,19 @@ export default class StoreService extends Service implements StoreInterface {
       instance ? (instance.id ?? instance[localIdSymbol]) : instanceOrError.id!, // we checked above to make sure errors have id's
       instanceOrError as CardDef | CardErrorJSONAPI,
     );
+  }
+
+  protected async createFileMetaFromSerialized(
+    resource: LooseLinkableResource<FileMetaResource>,
+    doc: LooseSingleResourceDocument<FileMetaResource>,
+    relativeTo: URL | undefined,
+  ): Promise<FileDef> {
+    let api = await this.cardService.getAPI();
+    let instance = (await api.createFromSerialized(resource, doc, relativeTo, {
+      store: this.store,
+    })) as unknown as FileDef;
+    this.setIdentityContext(instance, 'file-meta');
+    return instance;
   }
 
   private async startAutoSaving(instanceOrError: CardDef | CardErrorJSONAPI) {

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -1278,7 +1278,17 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     await click('[data-test-file="Person/fadhlan.json"]');
     assert.dom('[data-test-attached-card]').exists({ count: 2 });
     assert.dom('[data-test-autoattached-card]').exists({ count: 1 });
-    assert.dom('[data-test-autoattached-file]').exists({ count: 1 });
+    assert.dom('[data-test-autoattached-file]').exists({ count: 2 });
+    assert
+      .dom(
+        `[data-test-attached-file="${testRealmURL}Person/fadhlan.json"][data-test-autoattached-file]`,
+      )
+      .exists();
+    assert
+      .dom(
+        `[data-test-attached-file="${testRealmURL}person.gts"][data-test-autoattached-file]`,
+      )
+      .exists();
     assert.dom(`[data-test-attached-card="${testRealmURL}Pet/mango"]`).exists();
     assert
       .dom(

--- a/packages/host/tests/acceptance/host-mode-test.gts
+++ b/packages/host/tests/acceptance/host-mode-test.gts
@@ -417,7 +417,7 @@ module('Acceptance | host mode tests', function (hooks) {
       .dom(`[data-test-host-mode-stack-item="${testHostModeRealmURL}index"]`)
       .exists();
     await click(
-      `[data-test-host-mode-stack-item="${testHostModeRealmURL}index"] .close-button`,
+      `[data-test-host-mode-stack-item="${testHostModeRealmURL}index"] [data-test-host-stack-item-close-button]`,
     );
 
     assert.strictEqual(currentURL(), '/test/Pet/mango.json');

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -295,7 +295,10 @@ test.describe('Room messages', () => {
       .click();
     await page.locator(`[data-test-boxel-menu-item-text="Code"]`).click();
 
-    await expect(page.locator(`[data-test-attached-file]`)).toHaveCount(1);
+    await expect(page.locator(`[data-test-attached-file]`)).toHaveCount(2);
+    await expect(
+      page.locator(`[data-test-attached-file="${appURL}/person.gts"]`),
+    ).toHaveCount(1);
     await expect(
       page.locator(`[data-test-attached-file="${appURL}/hassan.json"]`),
     ).toHaveCount(1);
@@ -357,6 +360,9 @@ test.describe('Room messages', () => {
       page.locator(`[data-test-attached-card="${appURL}/hassan"]`),
     ).toHaveCount(1);
     await expect(page.locator(`[data-test-attached-file]`)).toHaveCount(1);
+    await expect(
+      page.locator(`[data-test-attached-file="${appURL}/person.gts"]`),
+    ).toHaveCount(1);
     await expect(
       page.locator(`[data-test-attached-file="${appURL}/hassan.json"]`),
     ).toHaveCount(1);

--- a/packages/realm-server/lib/retrieve-scoped-css.ts
+++ b/packages/realm-server/lib/retrieve-scoped-css.ts
@@ -27,13 +27,19 @@ export async function retrieveScopedCSS({
   }
 
   let scopedCSSQuery: Expression = [
-    `SELECT deps, realm_version FROM boxel_index_working WHERE type = 'instance' AND deps IS NOT NULL AND is_deleted IS NOT TRUE AND`,
+    `
+      SELECT deps, realm_version
+      FROM boxel_index
+      WHERE type = 'instance'
+        AND is_deleted IS NOT TRUE
+        AND deps IS NOT NULL
+        AND
+    `,
     ...indexCandidateExpressions(candidates),
-    `UNION ALL
-     SELECT deps, realm_version FROM boxel_index WHERE type = 'instance' AND deps IS NOT NULL AND is_deleted IS NOT TRUE AND`,
-    ...indexCandidateExpressions(candidates),
-    `ORDER BY realm_version DESC
-     LIMIT 1`,
+    `
+      ORDER BY realm_version DESC
+      LIMIT 1
+    `,
   ];
 
   if (log) {

--- a/packages/realm-server/lib/retrieve-scoped-css.ts
+++ b/packages/realm-server/lib/retrieve-scoped-css.ts
@@ -27,10 +27,10 @@ export async function retrieveScopedCSS({
   }
 
   let scopedCSSQuery: Expression = [
-    `SELECT deps, realm_version FROM boxel_index_working WHERE deps IS NOT NULL AND`,
+    `SELECT deps, realm_version FROM boxel_index_working WHERE type = 'instance' AND deps IS NOT NULL AND`,
     ...indexCandidateExpressions(candidates),
     `UNION ALL
-     SELECT deps, realm_version FROM boxel_index WHERE deps IS NOT NULL AND`,
+     SELECT deps, realm_version FROM boxel_index WHERE type = 'instance' AND deps IS NOT NULL AND`,
     ...indexCandidateExpressions(candidates),
     `ORDER BY realm_version DESC
      LIMIT 1`,

--- a/packages/realm-server/lib/retrieve-scoped-css.ts
+++ b/packages/realm-server/lib/retrieve-scoped-css.ts
@@ -27,10 +27,10 @@ export async function retrieveScopedCSS({
   }
 
   let scopedCSSQuery: Expression = [
-    `SELECT deps, realm_version FROM boxel_index_working WHERE type = 'instance' AND deps IS NOT NULL AND`,
+    `SELECT deps, realm_version FROM boxel_index_working WHERE type = 'instance' AND deps IS NOT NULL AND is_deleted IS NOT TRUE AND`,
     ...indexCandidateExpressions(candidates),
     `UNION ALL
-     SELECT deps, realm_version FROM boxel_index WHERE type = 'instance' AND deps IS NOT NULL AND`,
+     SELECT deps, realm_version FROM boxel_index WHERE type = 'instance' AND deps IS NOT NULL AND is_deleted IS NOT TRUE AND`,
     ...indexCandidateExpressions(candidates),
     `ORDER BY realm_version DESC
      LIMIT 1`,

--- a/packages/realm-server/prerender/manager-app.ts
+++ b/packages/realm-server/prerender/manager-app.ts
@@ -910,6 +910,9 @@ export function buildPrerenderManagerApp(options?: {
   router.post('/prerender-file-extract', (ctxt) =>
     proxyPrerenderRequest(ctxt, 'prerender-file-extract', 'file-extract'),
   );
+  router.post('/prerender-file-render', (ctxt) =>
+    proxyPrerenderRequest(ctxt, 'prerender-file-render', 'file-render'),
+  );
 
   let verboseManagerLogs =
     process.env.PRERENDER_MANAGER_VERBOSE_LOGS === 'true';

--- a/packages/realm-server/prerender/prerender-app.ts
+++ b/packages/realm-server/prerender/prerender-app.ts
@@ -10,6 +10,7 @@ import {
   type RenderResponse,
   type ModuleRenderResponse,
   type FileExtractResponse,
+  type FileRenderResponse,
 } from '@cardstack/runtime-common';
 import {
   ecsMetadata,
@@ -334,6 +335,176 @@ export function buildPrerenderApp(options: {
         );
       }
     },
+  });
+
+  // File render route needs additional attributes (fileData, types)
+  // beyond what registerPrerenderRoute handles, so we register it directly.
+  router.post('/prerender-file-render', async (ctxt: Koa.Context) => {
+    try {
+      let request = await fetchRequestFromContext(ctxt);
+      let raw = await request.text();
+      let body: any;
+      try {
+        body = raw ? JSON.parse(raw) : {};
+      } catch (e) {
+        ctxt.status = 400;
+        ctxt.body = {
+          errors: [{ status: 400, message: 'Invalid JSON body' }],
+        };
+        return;
+      }
+
+      let attrs = body?.data?.attributes ?? {};
+      let rawUrl = attrs.url;
+      let rawAuth = attrs.auth;
+      let rawRealm = attrs.realm;
+      let renderOptions: RenderRouteOptions =
+        attrs.renderOptions &&
+        typeof attrs.renderOptions === 'object' &&
+        !Array.isArray(attrs.renderOptions)
+          ? (attrs.renderOptions as RenderRouteOptions)
+          : {};
+      let fileData = attrs.fileData;
+      let types = attrs.types;
+
+      let isNonEmptyString = (value: unknown): value is string =>
+        typeof value === 'string' && value.trim().length > 0;
+
+      let missing = [
+        { value: rawUrl, name: 'url' },
+        { value: rawRealm, name: 'realm' },
+        { value: rawAuth, name: 'auth' },
+      ]
+        .filter(({ value }) => !isNonEmptyString(value))
+        .map(({ name }) => name);
+
+      if (!fileData) {
+        missing.push('fileData');
+      }
+      if (!Array.isArray(types)) {
+        missing.push('types');
+      }
+
+      log.debug(
+        `received file render prerender request ${rawUrl}: realm=${rawRealm}`,
+      );
+      if (missing.length > 0) {
+        ctxt.status = 400;
+        ctxt.body = {
+          errors: [
+            {
+              status: 400,
+              message: `Missing or invalid required attributes: ${missing.join(', ')}`,
+            },
+          ],
+        };
+        return;
+      }
+
+      let realm = rawRealm as string;
+      let url = rawUrl as string;
+      let auth = rawAuth as string;
+
+      let start = Date.now();
+      let execPromise = prerenderer
+        .prerenderFileRender({
+          realm,
+          url,
+          auth,
+          fileData,
+          types,
+          renderOptions,
+        })
+        .then((result) => ({ result }));
+      let drainPromise = options.drainingPromise
+        ? options.drainingPromise.then(() => ({ draining: true as const }))
+        : null;
+      let raceResult = drainPromise
+        ? await Promise.race([execPromise, drainPromise])
+        : await execPromise;
+      if ('draining' in raceResult) {
+        execPromise.catch((e) =>
+          log.debug(
+            'file render prerender execute settled after drain (ignored):',
+            e,
+          ),
+        );
+        ctxt.status = PRERENDER_SERVER_DRAINING_STATUS_CODE;
+        ctxt.set(
+          PRERENDER_SERVER_STATUS_HEADER,
+          PRERENDER_SERVER_STATUS_DRAINING,
+        );
+        ctxt.body = {
+          errors: [
+            {
+              status: PRERENDER_SERVER_DRAINING_STATUS_CODE,
+              message: 'Prerender server draining',
+            },
+          ],
+        };
+        return;
+      }
+      let { response, timings, pool } = raceResult.result;
+      let totalMs = Date.now() - start;
+      let poolFlags = Object.entries({
+        reused: pool.reused,
+        evicted: pool.evicted,
+        timedOut: pool.timedOut,
+      })
+        .filter(([, value]) => value === true)
+        .map(([key]) => key)
+        .join(', ');
+      let poolFlagSuffix =
+        poolFlags.length > 0 ? ` flags=[${poolFlags}]` : '';
+      log.info(
+        'file render prerendered %s total=%dms launch=%dms render=%dms pageId=%s realm=%s%s',
+        url,
+        totalMs,
+        timings.launchMs,
+        timings.renderMs,
+        pool.pageId,
+        pool.realm,
+        poolFlagSuffix,
+      );
+      ctxt.status = 201;
+      ctxt.set('Content-Type', 'application/vnd.api+json');
+      ctxt.body = {
+        data: {
+          type: 'prerender-file-render-result',
+          id: url,
+          attributes: response,
+        },
+        meta: {
+          timing: {
+            launchMs: timings.launchMs,
+            renderMs: timings.renderMs,
+            totalMs,
+          },
+          pool,
+        },
+      };
+      if (pool.timedOut) {
+        log.warn(`file render of ${url} timed out`);
+      }
+      const fileResponse = response as FileRenderResponse;
+      if (fileResponse.error) {
+        log.debug(
+          `file render of ${url} resulted in error doc:\n${JSON.stringify(fileResponse.error, null, 2)}`,
+        );
+      }
+    } catch (err: any) {
+      Sentry.captureException(err);
+      log.error('Unhandled error in /prerender-file-render:', err);
+      ctxt.status = 500;
+      ctxt.body = {
+        errors: [
+          {
+            status: 500,
+            message: err?.message ?? 'Unknown error',
+          },
+        ],
+      };
+    }
   });
 
   app

--- a/packages/realm-server/prerender/prerender-app.ts
+++ b/packages/realm-server/prerender/prerender-app.ts
@@ -454,8 +454,7 @@ export function buildPrerenderApp(options: {
         .filter(([, value]) => value === true)
         .map(([key]) => key)
         .join(', ');
-      let poolFlagSuffix =
-        poolFlags.length > 0 ? ` flags=[${poolFlags}]` : '';
+      let poolFlagSuffix = poolFlags.length > 0 ? ` flags=[${poolFlags}]` : '';
       log.info(
         'file render prerendered %s total=%dms launch=%dms render=%dms pageId=%s realm=%s%s',
         url,

--- a/packages/realm-server/prerender/remote-prerenderer.ts
+++ b/packages/realm-server/prerender/remote-prerenderer.ts
@@ -3,6 +3,8 @@ import {
   type RenderResponse,
   type ModuleRenderResponse,
   type FileExtractResponse,
+  type FileRenderResponse,
+  type FileRenderArgs,
   type RenderRouteOptions,
   logger,
 } from '@cardstack/runtime-common';
@@ -60,6 +62,7 @@ export function createRemotePrerenderer(
       url: string;
       auth: string;
       renderOptions?: RenderRouteOptions;
+      [key: string]: any;
     },
   ): Promise<T> {
     validatePrerenderAttributes(type, attributes);
@@ -184,6 +187,27 @@ export function createRemotePrerenderer(
           realm,
           url,
           auth,
+          renderOptions: renderOptions ?? {},
+        },
+      );
+    },
+    async prerenderFileRender({
+      realm,
+      url,
+      auth,
+      fileData,
+      types,
+      renderOptions,
+    }: FileRenderArgs) {
+      return await requestWithRetry<FileRenderResponse>(
+        'prerender-file-render',
+        'prerender-file-render-request',
+        {
+          realm,
+          url,
+          auth,
+          fileData,
+          types,
           renderOptions: renderOptions ?? {},
         },
       );

--- a/packages/realm-server/prerender/render-runner.ts
+++ b/packages/realm-server/prerender/render-runner.ts
@@ -878,16 +878,14 @@ export class RenderRunner {
         }> = [
           {
             name: 'file fitted render',
-            cb: () =>
-              renderAncestors(page, 'fitted', types, captureOptions),
+            cb: () => renderAncestors(page, 'fitted', types, captureOptions),
             assign: (v: string | Record<string, string>) => {
               fittedHTML = v as Record<string, string>;
             },
           },
           {
             name: 'file embedded render',
-            cb: () =>
-              renderAncestors(page, 'embedded', types, captureOptions),
+            cb: () => renderAncestors(page, 'embedded', types, captureOptions),
             assign: (v: string | Record<string, string>) => {
               embeddedHTML = v as Record<string, string>;
             },
@@ -960,7 +958,11 @@ export class RenderRunner {
   }
 
   shouldRetryWithClearCache(
-    response: RenderResponse | ModuleRenderResponse | FileExtractResponse | FileRenderResponse,
+    response:
+      | RenderResponse
+      | ModuleRenderResponse
+      | FileExtractResponse
+      | FileRenderResponse,
   ): readonly string[] | undefined {
     let renderError = response.error?.error;
     if (!renderError) {

--- a/packages/realm-server/prerender/render-runner.ts
+++ b/packages/realm-server/prerender/render-runner.ts
@@ -756,8 +756,11 @@ export class RenderRunner {
       };
       let serializedOptions = serializeRenderRouteOptions(options);
       let optionsSegment = encodeURIComponent(serializedOptions);
+      // File render uses the full file URL (including extension) as the ID,
+      // unlike card render which strips .json. The render route's fileRender
+      // branch sets cardId to the raw url parameter, so expectedId must match.
       const captureOptions: CaptureOptions = {
-        expectedId: url.replace(/\.json$/i, ''),
+        expectedId: url,
         expectedNonce: String(this.#nonce),
         simulateTimeoutMs: opts?.simulateTimeoutMs,
       };

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -466,6 +466,9 @@ export class RealmServer {
           assetsURL: this.assetsURL.href,
           realmServerURL: this.serverURL.href,
           cardSizeLimitBytes: this.cardSizeLimitBytes,
+          publishedRealmDomainOverrides:
+            process.env.PUBLISHED_REALM_DOMAIN_OVERRIDES ??
+            config.publishedRealmDomainOverrides,
         });
         return `${g1}${encodeURIComponent(JSON.stringify(config))}${g3}`;
       },

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -499,21 +499,19 @@ export class RealmServer {
     }
 
     let rows = await query(this.dbAdapter, [
-      `SELECT head_html, realm_version FROM boxel_index_working WHERE head_html IS NOT NULL AND type =`,
-      param('instance'),
-      'AND',
-      'is_deleted IS NOT TRUE',
-      'AND',
+      `
+        SELECT head_html, realm_version
+        FROM boxel_index
+        WHERE type = 'instance'
+         AND head_html IS NOT NULL
+         AND is_deleted IS NOT TRUE
+         AND
+      `,
       ...this.indexCandidateExpressions(candidates),
-      `UNION ALL
-       SELECT head_html, realm_version FROM boxel_index WHERE head_html IS NOT NULL AND type =`,
-      param('instance'),
-      'AND',
-      'is_deleted IS NOT TRUE',
-      'AND',
-      ...this.indexCandidateExpressions(candidates),
-      `ORDER BY realm_version DESC
-       LIMIT 1`,
+      `
+        ORDER BY realm_version DESC
+        LIMIT 1
+      `,
     ]);
 
     this.headLog.debug('Head query result for %s', cardURL.href, rows);
@@ -547,21 +545,19 @@ export class RealmServer {
     }
 
     let rows = await query(this.dbAdapter, [
-      `SELECT isolated_html, realm_version FROM boxel_index_working WHERE isolated_html IS NOT NULL AND type =`,
-      param('instance'),
-      'AND',
-      'is_deleted IS NOT TRUE',
-      'AND',
+      `
+        SELECT isolated_html, realm_version
+        FROM boxel_index
+        WHERE isolated_html IS NOT NULL
+          AND type = 'instance'
+          AND is_deleted IS NOT TRUE
+          AND
+        `,
       ...this.indexCandidateExpressions(candidates),
-      `UNION ALL
-       SELECT isolated_html, realm_version FROM boxel_index WHERE isolated_html IS NOT NULL AND type =`,
-      param('instance'),
-      'AND',
-      'is_deleted IS NOT TRUE',
-      'AND',
-      ...this.indexCandidateExpressions(candidates),
-      `ORDER BY realm_version DESC
-       LIMIT 1`,
+      `
+        ORDER BY realm_version DESC
+        LIMIT 1
+      `,
     ]);
 
     this.isolatedLog.debug('Isolated query result for %s', cardURL.href, rows);

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -629,14 +629,14 @@ export class RealmServer {
   private injectHeadHTML(indexHTML: string, headHTML: string): string {
     return indexHTML.replace(
       /(<meta[^>]+data-boxel-head-start[^>]*>)([\s\S]*?)(<meta[^>]+data-boxel-head-end[^>]*>)/,
-      `$1\n${headHTML}\n$3`,
+      (_match, start, _content, end) => `${start}\n${headHTML}\n${end}`,
     );
   }
 
   private injectIsolatedHTML(indexHTML: string, isolatedHTML: string): string {
     return indexHTML.replace(
       /(<script[^>]+id="boxel-isolated-start"[^>]*>\s*<\/script>)([\s\S]*?)(<script[^>]+id="boxel-isolated-end"[^>]*>\s*<\/script>)/,
-      `$1\n${isolatedHTML}\n$3`,
+      (_match, start, _content, end) => `${start}\n${isolatedHTML}\n${end}`,
     );
   }
 

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -499,10 +499,14 @@ export class RealmServer {
       `SELECT head_html, realm_version FROM boxel_index_working WHERE head_html IS NOT NULL AND type =`,
       param('instance'),
       'AND',
+      'is_deleted IS NOT TRUE',
+      'AND',
       ...this.indexCandidateExpressions(candidates),
       `UNION ALL
        SELECT head_html, realm_version FROM boxel_index WHERE head_html IS NOT NULL AND type =`,
       param('instance'),
+      'AND',
+      'is_deleted IS NOT TRUE',
       'AND',
       ...this.indexCandidateExpressions(candidates),
       `ORDER BY realm_version DESC
@@ -543,10 +547,14 @@ export class RealmServer {
       `SELECT isolated_html, realm_version FROM boxel_index_working WHERE isolated_html IS NOT NULL AND type =`,
       param('instance'),
       'AND',
+      'is_deleted IS NOT TRUE',
+      'AND',
       ...this.indexCandidateExpressions(candidates),
       `UNION ALL
        SELECT isolated_html, realm_version FROM boxel_index WHERE isolated_html IS NOT NULL AND type =`,
       param('instance'),
+      'AND',
+      'is_deleted IS NOT TRUE',
       'AND',
       ...this.indexCandidateExpressions(candidates),
       `ORDER BY realm_version DESC

--- a/packages/realm-server/tests/definition-lookup-test.ts
+++ b/packages/realm-server/tests/definition-lookup-test.ts
@@ -147,6 +147,9 @@ module(basename(__filename), function () {
         async prerenderFileExtract() {
           throw new Error('Not implemented in mock');
         },
+        async prerenderFileRender() {
+          throw new Error('Not implemented in mock');
+        },
       };
       definitionLookup = new CachingDefinitionLookup(
         dbAdapter,
@@ -323,6 +326,9 @@ module(basename(__filename), function () {
         async prerenderFileExtract() {
           throw new Error('Not implemented in mock');
         },
+        async prerenderFileRender() {
+          throw new Error('Not implemented in mock');
+        },
         async prerenderModule(args: ModulePrerenderArgs) {
           calls++;
           let moduleAlias = trimExecutableExtension(new URL(args.url)).href;
@@ -410,6 +416,9 @@ module(basename(__filename), function () {
         async prerenderFileExtract() {
           throw new Error('Not implemented in mock');
         },
+        async prerenderFileRender() {
+          throw new Error('Not implemented in mock');
+        },
         async prerenderModule(args: ModulePrerenderArgs) {
           calls++;
           if (!modulePresent) {
@@ -482,6 +491,9 @@ module(basename(__filename), function () {
           throw new Error('Not implemented in mock');
         },
         async prerenderFileExtract() {
+          throw new Error('Not implemented in mock');
+        },
+        async prerenderFileRender() {
           throw new Error('Not implemented in mock');
         },
         async prerenderModule(args: ModulePrerenderArgs) {
@@ -625,6 +637,9 @@ module(basename(__filename), function () {
           throw new Error('Not implemented in mock');
         },
         async prerenderFileExtract() {
+          throw new Error('Not implemented in mock');
+        },
+        async prerenderFileRender() {
           throw new Error('Not implemented in mock');
         },
         async prerenderModule(args: ModulePrerenderArgs) {
@@ -777,6 +792,9 @@ module(basename(__filename), function () {
           throw new Error('Not implemented in mock');
         },
         async prerenderFileExtract() {
+          throw new Error('Not implemented in mock');
+        },
+        async prerenderFileRender() {
           throw new Error('Not implemented in mock');
         },
         async prerenderModule(args: ModulePrerenderArgs) {

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -29,7 +29,7 @@ import * as ContentTagGlobal from 'content-tag';
 
 import QUnit from 'qunit';
 
-QUnit.config.testTimeout = 60000;
+QUnit.config.testTimeout = 180000;
 
 // Cleanup here ensures lingering servers/prerenderers/queues don't keep the
 // Node event loop alive after tests finish.

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -29,7 +29,7 @@ import * as ContentTagGlobal from 'content-tag';
 
 import QUnit from 'qunit';
 
-QUnit.config.testTimeout = 180000;
+QUnit.config.testTimeout = 60000;
 
 // Cleanup here ensures lingering servers/prerenderers/queues don't keep the
 // Node event loop alive after tests finish.

--- a/packages/realm-server/tests/prerender-proxy-test.ts
+++ b/packages/realm-server/tests/prerender-proxy-test.ts
@@ -82,6 +82,17 @@ module(basename(__filename), function () {
             deps: [],
           };
         },
+        async prerenderFileRender(args) {
+          renderCalls.push({ kind: 'file-render', args });
+          return {
+            isolatedHTML: null,
+            headHTML: null,
+            atomHTML: null,
+            embeddedHTML: null,
+            fittedHTML: null,
+            iconHTML: null,
+          };
+        },
       };
 
       return { prerenderer, renderCalls };

--- a/packages/realm-server/tests/prerender-proxy-test.ts
+++ b/packages/realm-server/tests/prerender-proxy-test.ts
@@ -33,7 +33,7 @@ module(basename(__filename), function () {
 
     function makePrerenderer() {
       let renderCalls: Array<{
-        kind: 'card' | 'module' | 'file-extract';
+        kind: 'card' | 'module' | 'file-extract' | 'file-render';
         args: {
           realm: string;
           url: string;

--- a/packages/realm-server/tests/realm-endpoints/lint-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/lint-test.ts
@@ -537,8 +537,7 @@ export class MyCard extends CardDef {
       let responseJson = JSON.parse(response.text);
       let messages = responseJson.messages;
       let positionFixedWarning = messages.find(
-        (m: any) =>
-          m.ruleId === '@cardstack/boxel/no-css-position-fixed',
+        (m: any) => m.ruleId === '@cardstack/boxel/no-css-position-fixed',
       );
       assert.ok(
         positionFixedWarning,
@@ -578,8 +577,7 @@ export class MyCard extends CardDef {
       let responseJson = JSON.parse(response.text);
       let messages = responseJson.messages;
       let positionFixedWarning = messages.find(
-        (m: any) =>
-          m.ruleId === '@cardstack/boxel/no-css-position-fixed',
+        (m: any) => m.ruleId === '@cardstack/boxel/no-css-position-fixed',
       );
       assert.notOk(
         positionFixedWarning,

--- a/packages/realm-server/tests/realm-endpoints/lint-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/lint-test.ts
@@ -510,6 +510,83 @@ export class MyCard extends CardDef {
       );
     });
 
+    test('warns about position: fixed in card CSS', async function (assert) {
+      let response = await request
+        .post('/_lint')
+        .set(
+          'Authorization',
+          `Bearer ${createJWT(testRealm, 'john', ['read', 'write'])}`,
+        )
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', 'application/json')
+        .send(`import { CardDef } from 'https://cardstack.com/base/card-api';
+export class MyCard extends CardDef {
+}
+<template>
+  <div class="my-card">Hello</div>
+  <style scoped>
+    .my-card {
+      position: fixed;
+      top: 0;
+    }
+  </style>
+</template>
+`);
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      let responseJson = JSON.parse(response.text);
+      let messages = responseJson.messages;
+      let positionFixedWarning = messages.find(
+        (m: any) =>
+          m.ruleId === '@cardstack/boxel/no-css-position-fixed',
+      );
+      assert.ok(
+        positionFixedWarning,
+        'Should have a warning about position: fixed',
+      );
+      assert.strictEqual(
+        positionFixedWarning.severity,
+        1,
+        'Should be a warning (severity 1), not an error',
+      );
+    });
+
+    test('does not warn about position: fixed when not present', async function (assert) {
+      let response = await request
+        .post('/_lint')
+        .set(
+          'Authorization',
+          `Bearer ${createJWT(testRealm, 'john', ['read', 'write'])}`,
+        )
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', 'application/json')
+        .send(`import { CardDef } from 'https://cardstack.com/base/card-api';
+export class MyCard extends CardDef {
+}
+<template>
+  <div class="my-card">Hello</div>
+  <style scoped>
+    .my-card {
+      position: relative;
+      top: 0;
+    }
+  </style>
+</template>
+`);
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      let responseJson = JSON.parse(response.text);
+      let messages = responseJson.messages;
+      let positionFixedWarning = messages.find(
+        (m: any) =>
+          m.ruleId === '@cardstack/boxel/no-css-position-fixed',
+      );
+      assert.notOk(
+        positionFixedWarning,
+        'Should not warn when position: fixed is not used',
+      );
+    });
+
     test('handles nested template structures correctly', async function (assert) {
       let response = await request
         .post('/_lint')

--- a/packages/realm-server/tests/server-endpoints/index-responses-test.ts
+++ b/packages/realm-server/tests/server-endpoints/index-responses-test.ts
@@ -191,32 +191,6 @@ module(`server-endpoints/${basename(__filename)}`, function () {
         );
       });
 
-      test('prefers non-null head and isolated HTML when matches are present', async function (assert) {
-        let cardURL = new URL('head-isolated-candidate', testRealm2URL);
-        let aliasOnlyURL = new URL('alias-only-candidate', testRealm2URL);
-
-        await context.dbAdapter.execute(
-          `INSERT INTO boxel_index_working (url, file_alias, type, realm_version, realm_url, head_html, isolated_html)
-           VALUES
-           ('${cardURL.href}', '${cardURL.href}', 'instance', 1, '${testRealm2URL.href}', '<meta data-test-head-html content="from-db" />', '<div data-test-isolated-html>Injected isolated</div>'),
-           ('${aliasOnlyURL.href}', '${cardURL.href}', 'instance', 2, '${testRealm2URL.href}', NULL, NULL)`,
-        );
-
-        let response = await context.request2
-          .get('/test/head-isolated-candidate')
-          .set('Accept', 'text/html');
-
-        assert.strictEqual(response.status, 200, 'serves HTML response');
-        assert.ok(
-          response.text.includes('data-test-head-html'),
-          'head HTML is injected into the HTML response',
-        );
-        assert.ok(
-          response.text.includes('data-test-isolated-html'),
-          'isolated HTML is injected into the HTML response',
-        );
-      });
-
       test('serves isolated HTML for /subdirectory/index.json at /subdirectory/', async function (assert) {
         let response = await context.request2
           .get('/test/subdirectory/')

--- a/packages/realm-server/tests/server-endpoints/index-responses-test.ts
+++ b/packages/realm-server/tests/server-endpoints/index-responses-test.ts
@@ -72,21 +72,18 @@ module(`server-endpoints/${basename(__filename)}`, function () {
             `,
           );
 
-          writeJSONSync(
-            join(context.testRealmDir, 'dollar-sign-test.json'),
-            {
-              data: {
-                type: 'card',
-                attributes: {},
-                meta: {
-                  adoptsFrom: {
-                    module: './dollar-sign-card.gts',
-                    name: 'DollarSignCard',
-                  },
+          writeJSONSync(join(context.testRealmDir, 'dollar-sign-test.json'), {
+            data: {
+              type: 'card',
+              attributes: {},
+              meta: {
+                adoptsFrom: {
+                  module: './dollar-sign-card.gts',
+                  name: 'DollarSignCard',
                 },
               },
             },
-          );
+          });
 
           writeFileSync(
             join(context.testRealmDir, 'head-card.gts'),

--- a/packages/runtime-common/constants.ts
+++ b/packages/runtime-common/constants.ts
@@ -86,4 +86,45 @@ export const DEFAULT_PERMISSIONS = Object.freeze([
   'realm-owner',
 ]) as RealmPermissions['user'];
 
+// Workaround to override published realm URLs to support custom domains. Remove in CS-9061.
+export const PUBLISHED_REALM_DOMAIN_OVERRIDES: Record<string, string> = {};
+
+export function parsePublishedRealmDomainOverrides(
+  rawOverrides: string | undefined,
+): Record<string, string> {
+  if (!rawOverrides) {
+    return {};
+  }
+
+  try {
+    let parsed = JSON.parse(rawOverrides);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {};
+    }
+
+    let overrides: Record<string, string> = {};
+    for (let [key, value] of Object.entries(parsed)) {
+      if (typeof key === 'string' && typeof value === 'string') {
+        overrides[key] = value;
+      }
+    }
+    return overrides;
+  } catch {
+    return {};
+  }
+}
+
+export function getPublishedRealmDomainOverrides(
+  rawOverrides?: string | Record<string, string>,
+): Record<string, string> {
+  let envOverrides =
+    typeof rawOverrides === 'string'
+      ? parsePublishedRealmDomainOverrides(rawOverrides)
+      : (rawOverrides ?? {});
+  return {
+    ...PUBLISHED_REALM_DOMAIN_OVERRIDES,
+    ...envOverrides,
+  };
+}
+
 export const PUBLISHED_DIRECTORY_NAME = '_published';

--- a/packages/runtime-common/index-runner.ts
+++ b/packages/runtime-common/index-runner.ts
@@ -972,11 +972,9 @@ export class IndexRunner {
     let renderResult: FileRenderResponse | undefined;
     if (extractResult.resource) {
       try {
-        let renderClearCache = this.#consumeClearCacheForRender();
         let fileRenderOptions: RenderRouteOptions = {
           fileRender: true,
           fileDefCodeRef,
-          ...(renderClearCache ? { clearCache: true as const } : {}),
         };
         renderResult = await this.#prerenderer.prerenderFileRender({
           url: fileURL,

--- a/packages/runtime-common/index-writer.ts
+++ b/packages/runtime-common/index-writer.ts
@@ -111,6 +111,12 @@ export interface FileEntry {
   resource?: FileMetaResource | null;
   types?: string[];
   displayNames?: string[];
+  isolatedHtml?: string;
+  headHtml?: string;
+  embeddedHtml?: Record<string, string>;
+  fittedHtml?: Record<string, string>;
+  atomHtml?: string;
+  iconHTML?: string;
 }
 
 export class Batch {
@@ -341,6 +347,12 @@ export class Batch {
           search_doc: entry.searchData ?? null,
           types: entry.types ?? null,
           display_names: entry.displayNames ?? null,
+          isolated_html: entry.isolatedHtml ?? null,
+          head_html: entry.headHtml ?? null,
+          embedded_html: entry.embeddedHtml ?? null,
+          fitted_html: entry.fittedHtml ?? null,
+          atom_html: entry.atomHtml ?? null,
+          icon_html: entry.iconHTML ?? null,
           last_modified: entry.lastModified,
           resource_created_at: entry.resourceCreatedAt,
           error_doc: null,

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -67,6 +67,24 @@ export interface FileExtractResponse {
   mismatch?: true;
 }
 
+export interface FileRenderResponse {
+  isolatedHTML: string | null;
+  headHTML: string | null;
+  atomHTML: string | null;
+  embeddedHTML: Record<string, string> | null;
+  fittedHTML: Record<string, string> | null;
+  iconHTML: string | null;
+  error?: RenderError;
+}
+
+export type FileRenderArgs = ModulePrerenderArgs & {
+  fileData: {
+    resource: FileMetaResource;
+    fileDefCodeRef: ResolvedCodeRef;
+  };
+  types: string[];
+};
+
 export interface ModuleDefinitionResult {
   type: 'definition';
   moduleURL: string; // node resolution w/o extension
@@ -101,6 +119,7 @@ export interface Prerenderer {
   prerenderCard(args: PrerenderCardArgs): Promise<RenderResponse>;
   prerenderModule(args: ModulePrerenderArgs): Promise<ModuleRenderResponse>;
   prerenderFileExtract(args: ModulePrerenderArgs): Promise<FileExtractResponse>;
+  prerenderFileRender(args: FileRenderArgs): Promise<FileRenderResponse>;
 }
 
 export type RealmAction = 'read' | 'write' | 'realm-owner' | 'assume-user';

--- a/packages/runtime-common/render-route-options.ts
+++ b/packages/runtime-common/render-route-options.ts
@@ -5,6 +5,7 @@ import type { ResolvedCodeRef } from './code-ref';
 export interface RenderRouteOptions {
   clearCache?: true;
   fileExtract?: true;
+  fileRender?: true;
   fileDefCodeRef?: ResolvedCodeRef;
   fileContentHash?: string;
 }
@@ -30,6 +31,12 @@ export function parseRenderRouteOptions(
         options.fileContentHash = parsed.fileContentHash;
       }
     }
+    if (parsed.fileRender) {
+      options.fileRender = true;
+      if (isResolvedCodeRef(parsed.fileDefCodeRef)) {
+        options.fileDefCodeRef = parsed.fileDefCodeRef;
+      }
+    }
     return options;
   } catch {
     return {};
@@ -50,6 +57,12 @@ export function serializeRenderRouteOptions(
     }
     if (options.fileContentHash) {
       serialized.fileContentHash = options.fileContentHash;
+    }
+  }
+  if (options.fileRender) {
+    serialized.fileRender = true;
+    if (options.fileDefCodeRef) {
+      serialized.fileDefCodeRef = options.fileDefCodeRef;
     }
   }
   return stringify(serialized) ?? '{}';

--- a/packages/runtime-common/tasks/lint.ts
+++ b/packages/runtime-common/tasks/lint.ts
@@ -78,6 +78,7 @@ async function lintFix({
       },
     ],
     '@cardstack/boxel/no-duplicate-imports': 'error',
+    '@cardstack/boxel/no-css-position-fixed': 'warn',
   };
 
   const eslintJsModule = await import(/* webpackIgnore: true */ '@eslint/js');


### PR DESCRIPTION
## Summary

- Extends file indexing with a render phase that captures FileDef display format templates (isolated, embedded, fitted, atom, head, icon) as prerendered HTML
- Stores HTML in existing `boxel_index` HTML columns (no DB migration needed)
- Rendering is non-fatal — if it fails, file metadata is still stored without HTML
- Adds `fileRender` flag to `RenderRouteOptions` and `FileRenderResponse`/`FileRenderArgs` types to the `Prerenderer` interface
- Adds `prerenderFileRenderAttempt` to the render runner, with retry-with-clearCache support
- Adds HTTP endpoint `/prerender-file-render` to the prerender server
- Adds test-context support via `card-prerender.gts` `fileRenderPrerenderTask`

Closes CS-10124

🤖 Generated with [Claude Code](https://claude.com/claude-code)