### PR TITLE
capitalize action item labels via css

### DIFF
--- a/packages/boxel-ui/addon/src/components/menu/index.gts
+++ b/packages/boxel-ui/addon/src/components/menu/index.gts
@@ -246,6 +246,7 @@ export default class Menu extends Component<Signature> {
           display: flex;
           align-items: center;
           gap: var(--boxel-menu-item-gap);
+          text-transform: capitalize;
         }
         .menu-item__icon-url {
           flex-shrink: 0;

--- a/packages/host/app/components/operator-mode/definition-container/base.gts
+++ b/packages/host/app/components/operator-mode/definition-container/base.gts
@@ -209,6 +209,7 @@ const Active: TemplateOnlyComponent<ActiveSignature> = <template>
       justify-content: flex-start;
       gap: var(--boxel-sp-xxxs);
       align-self: flex-start;
+      text-transform: capitalize;
     }
     .info-footer {
       color: var(--boxel-450);


### PR DESCRIPTION
Fix: set the root css for menu/action item to text-transform: capitalize; 

<img width="2000" height="1636" alt="image" src="https://github.com/user-attachments/assets/785a76c1-5ee6-483e-8e1e-1ff1130e4def" />
