### PR TITLE
Calculate plan allowance availability per current subscription cycle (instead of user-wide)

### DIFF
--- a/packages/billing/billing-queries.ts
+++ b/packages/billing/billing-queries.ts
@@ -562,14 +562,17 @@ export async function spendCredits(
   if (!subscriptionCycle) {
     throw new Error('subscription cycle not found');
   }
-  let availablePlanAllowanceCredits = await sumUpCreditsLedger(dbAdapter, {
-    creditType: [
-      'plan_allowance',
-      'plan_allowance_used',
-      'plan_allowance_expired',
-    ],
-    userId,
-  });
+  let availablePlanAllowanceCredits = Math.max(
+    0,
+    await sumUpCreditsLedger(dbAdapter, {
+      creditType: [
+        'plan_allowance',
+        'plan_allowance_used',
+        'plan_allowance_expired',
+      ],
+      subscriptionCycleId: subscriptionCycle.id,
+    }),
+  );
 
   if (availablePlanAllowanceCredits >= creditsToSpend) {
     await addToCreditsLedger(dbAdapter, {


### PR DESCRIPTION
Prevents older cycle leftovers from being spent against the current cycle and going negative. 

This fix came as a result of observing Luke's monthly balance going below zero - it looks like the previous subscription period's monthly credits  for **some reason** did not get expired (we do expire unused monthly credits at the beginning of a new subscription cycle), which caused our credit spending logic to think there are more monthly credits available than there actually are. If we scope the query to the current subscription period, the issue is solved.

The actual reason for the unexpired monthly credits is unclear to me. Given that Luke's account balance recovered OK with the newest monthly cycle, my hypothesis is that something went wrong with processing of the stripe's monthly subscription webhook, maybe there was an outage or something similar (having retryable event processing jobs would be helpful). Another option is that manual ledger entries had something to do with it. I suggest for now it's not worth exploring this deeper since other accounts are working OK. 