### PR TITLE
server: Remove SSR for `is_deleted IS TRUE`

### DIFF
--- a/packages/realm-server/lib/retrieve-scoped-css.ts
+++ b/packages/realm-server/lib/retrieve-scoped-css.ts
@@ -27,10 +27,10 @@ export async function retrieveScopedCSS({
   }
 
   let scopedCSSQuery: Expression = [
-    `SELECT deps, realm_version FROM boxel_index_working WHERE type = 'instance' AND deps IS NOT NULL AND`,
+    `SELECT deps, realm_version FROM boxel_index_working WHERE type = 'instance' AND deps IS NOT NULL AND is_deleted IS NOT TRUE AND`,
     ...indexCandidateExpressions(candidates),
     `UNION ALL
-     SELECT deps, realm_version FROM boxel_index WHERE type = 'instance' AND deps IS NOT NULL AND`,
+     SELECT deps, realm_version FROM boxel_index WHERE type = 'instance' AND deps IS NOT NULL AND is_deleted IS NOT TRUE AND`,
     ...indexCandidateExpressions(candidates),
     `ORDER BY realm_version DESC
      LIMIT 1`,

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -499,10 +499,14 @@ export class RealmServer {
       `SELECT head_html, realm_version FROM boxel_index_working WHERE head_html IS NOT NULL AND type =`,
       param('instance'),
       'AND',
+      'is_deleted IS NOT TRUE',
+      'AND',
       ...this.indexCandidateExpressions(candidates),
       `UNION ALL
        SELECT head_html, realm_version FROM boxel_index WHERE head_html IS NOT NULL AND type =`,
       param('instance'),
+      'AND',
+      'is_deleted IS NOT TRUE',
       'AND',
       ...this.indexCandidateExpressions(candidates),
       `ORDER BY realm_version DESC
@@ -543,10 +547,14 @@ export class RealmServer {
       `SELECT isolated_html, realm_version FROM boxel_index_working WHERE isolated_html IS NOT NULL AND type =`,
       param('instance'),
       'AND',
+      'is_deleted IS NOT TRUE',
+      'AND',
       ...this.indexCandidateExpressions(candidates),
       `UNION ALL
        SELECT isolated_html, realm_version FROM boxel_index WHERE isolated_html IS NOT NULL AND type =`,
       param('instance'),
+      'AND',
+      'is_deleted IS NOT TRUE',
       'AND',
       ...this.indexCandidateExpressions(candidates),
       `ORDER BY realm_version DESC


### PR DESCRIPTION
This is another consequence of using the index as a source of truth vs the filesystem.

You can see the test fail [here](https://github.com/cardstack/boxel/actions/runs/21486704726/job/61898425074?pr=3924#step:10:47) before I added the fix.