### PR TITLE
Simplify ElementTracker

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -1,4 +1,3 @@
-import Modifier from 'ember-modifier';
 import GlimmerComponent from '@glimmer/component';
 import { isEqual } from 'lodash';
 import { WatchedArray } from './watched-array';
@@ -83,7 +82,7 @@ import {
   validateRelationshipQuery,
 } from './query-field-support';
 import { isSavedInstance } from './-private';
-import type { ComponentLike } from '@glint/template';
+import type { ComponentLike, ModifierLike } from '@glint/template';
 import { initSharedState } from './shared-state';
 import DefaultFittedTemplate from './default-templates/fitted';
 import DefaultEmbeddedTemplate from './default-templates/embedded';
@@ -260,15 +259,21 @@ interface RelationshipOptions extends Options {
 
 export interface CardContext<T extends CardDef = CardDef> {
   commandContext?: CommandContext;
-  cardComponentModifier?: typeof Modifier<{
+  cardComponentModifier?: ModifierLike<{
+    Element: HTMLElement;
     Args: {
       Named: {
-        card?: CardDef;
-        cardId?: string;
         format: Format | 'data';
         fieldType: FieldType | undefined;
         fieldName: string | undefined;
-      };
+      } & (
+        | {
+            card: CardDef;
+          }
+        | {
+            cardId: string;
+          }
+      );
     };
   }>;
   prerenderedCardSearchComponent: typeof GlimmerComponent<PrerenderedCardComponentSignature>;

--- a/packages/host/app/resources/element-tracker.ts
+++ b/packages/host/app/resources/element-tracker.ts
@@ -78,7 +78,8 @@ export default class ElementTracker {
       if (found) {
         this.elements.splice(this.elements.indexOf(found), 1);
       }
-      Array.from(this.observers.values()).forEach((v) => v.disconnect());
+      this.observers.get(element)?.disconnect();
+      this.observers.delete(element);
     };
   });
 


### PR DESCRIPTION
This is a prerequisite for work on trying to use view transitions for the stack animations, because we want to compose more behavior into the `cardComponentModifier`, and that's easier to do if the ElementTracker's modifier is a function, and the types are more generic.

We also noticed while doing this that the `observers` `Map` was being recreated many times unnecessarily, which is fixed by this PR.