### PR TITLE
server: Fix SSR HTML injection corruption from dollar signs in card content

### DIFF
--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -629,14 +629,14 @@ export class RealmServer {
   private injectHeadHTML(indexHTML: string, headHTML: string): string {
     return indexHTML.replace(
       /(<meta[^>]+data-boxel-head-start[^>]*>)([\s\S]*?)(<meta[^>]+data-boxel-head-end[^>]*>)/,
-      `$1\n${headHTML}\n$3`,
+      (_match, start, _content, end) => `${start}\n${headHTML}\n${end}`,
     );
   }
 
   private injectIsolatedHTML(indexHTML: string, isolatedHTML: string): string {
     return indexHTML.replace(
       /(<script[^>]+id="boxel-isolated-start"[^>]*>\s*<\/script>)([\s\S]*?)(<script[^>]+id="boxel-isolated-end"[^>]*>\s*<\/script>)/,
-      `$1\n${isolatedHTML}\n$3`,
+      (_match, start, _content, end) => `${start}\n${isolatedHTML}\n${end}`,
     );
   }
 

--- a/packages/realm-server/tests/server-endpoints/index-responses-test.ts
+++ b/packages/realm-server/tests/server-endpoints/index-responses-test.ts
@@ -72,21 +72,18 @@ module(`server-endpoints/${basename(__filename)}`, function () {
             `,
           );
 
-          writeJSONSync(
-            join(context.testRealmDir, 'dollar-sign-test.json'),
-            {
-              data: {
-                type: 'card',
-                attributes: {},
-                meta: {
-                  adoptsFrom: {
-                    module: './dollar-sign-card.gts',
-                    name: 'DollarSignCard',
-                  },
+          writeJSONSync(join(context.testRealmDir, 'dollar-sign-test.json'), {
+            data: {
+              type: 'card',
+              attributes: {},
+              meta: {
+                adoptsFrom: {
+                  module: './dollar-sign-card.gts',
+                  name: 'DollarSignCard',
                 },
               },
             },
-          );
+          });
 
           writeFileSync(
             join(context.testRealmDir, 'head-card.gts'),


### PR DESCRIPTION
Use replacer functions instead of replacement strings in injectHeadHTML and injectIsolatedHTML to prevent JavaScript's String.prototype.replace() from interpreting dollar signs in card content (e.g. "$1", "$3") as regex backreferences. This was corrupting the HTML document structure and causing blank pages for cards with currency values.