### PR TITLE
Add lint warning for position: fixed in card CSS

### DIFF
--- a/packages/eslint-plugin-boxel/lib/rules/no-css-position-fixed.js
+++ b/packages/eslint-plugin-boxel/lib/rules/no-css-position-fixed.js
@@ -1,0 +1,40 @@
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'disallow `position: fixed` in card CSS because cards should not break out of their bounding box',
+      category: 'Ember Octane',
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      'no-css-position-fixed':
+        'Do not use `position: fixed` in card CSS. Cards should not break out of their bounding box. Consider using `position: absolute` or `position: sticky` instead.',
+    },
+  },
+
+  create: (context) => {
+    return {
+      GlimmerElement(node) {
+        if (node.tag !== 'style') {
+          return;
+        }
+        for (const child of node.children) {
+          if (child.type === 'GlimmerTextNode') {
+            const text = child.value;
+            const regex = /position\s*:\s*fixed/gi;
+            let match;
+            while ((match = regex.exec(text)) !== null) {
+              context.report({
+                node: child,
+                messageId: 'no-css-position-fixed',
+              });
+            }
+          }
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-boxel/lib/rules/no-css-position-fixed.js
+++ b/packages/eslint-plugin-boxel/lib/rules/no-css-position-fixed.js
@@ -17,7 +17,7 @@ module.exports = {
 
   create: (context) => {
     return {
-      GlimmerElement(node) {
+      GlimmerElementNode(node) {
         if (node.tag !== 'style') {
           return;
         }

--- a/packages/eslint-plugin-boxel/tests/lib/rules/no-css-position-fixed-test.js
+++ b/packages/eslint-plugin-boxel/tests/lib/rules/no-css-position-fixed-test.js
@@ -1,0 +1,133 @@
+const rule = require('../../../lib/rules/no-css-position-fixed');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('ember-eslint-parser'),
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+});
+ruleTester.run('no-css-position-fixed', rule, {
+  valid: [
+    `
+      <template>
+        <div class="my-card">Hello</div>
+        <style scoped>
+          .my-card {
+            position: relative;
+            top: 0;
+          }
+        </style>
+      </template>
+    `,
+    `
+      <template>
+        <div class="my-card">Hello</div>
+        <style scoped>
+          .my-card {
+            position: absolute;
+            top: 0;
+          }
+        </style>
+      </template>
+    `,
+    `
+      <template>
+        <div class="my-card">Hello</div>
+        <style scoped>
+          .my-card {
+            position: sticky;
+            top: 0;
+          }
+        </style>
+      </template>
+    `,
+    // No style tag at all
+    `
+      <template>
+        <div class="my-card">Hello</div>
+      </template>
+    `,
+  ],
+
+  invalid: [
+    {
+      code: `
+        <template>
+          <div class="my-card">Hello</div>
+          <style scoped>
+            .my-card {
+              position: fixed;
+              top: 0;
+            }
+          </style>
+        </template>
+      `,
+      errors: [
+        {
+          type: 'GlimmerTextNode',
+          message: rule.meta.messages['no-css-position-fixed'],
+        },
+      ],
+    },
+    // Without space after colon
+    {
+      code: `
+        <template>
+          <style scoped>
+            .my-card {
+              position:fixed;
+            }
+          </style>
+        </template>
+      `,
+      errors: [
+        {
+          type: 'GlimmerTextNode',
+          message: rule.meta.messages['no-css-position-fixed'],
+        },
+      ],
+    },
+    // With extra whitespace
+    {
+      code: `
+        <template>
+          <style scoped>
+            .my-card {
+              position:  fixed;
+            }
+          </style>
+        </template>
+      `,
+      errors: [
+        {
+          type: 'GlimmerTextNode',
+          message: rule.meta.messages['no-css-position-fixed'],
+        },
+      ],
+    },
+    // Multiple occurrences
+    {
+      code: `
+        <template>
+          <style scoped>
+            .my-card {
+              position: fixed;
+            }
+            .another {
+              position: fixed;
+            }
+          </style>
+        </template>
+      `,
+      errors: [
+        {
+          type: 'GlimmerTextNode',
+          message: rule.meta.messages['no-css-position-fixed'],
+        },
+        {
+          type: 'GlimmerTextNode',
+          message: rule.meta.messages['no-css-position-fixed'],
+        },
+      ],
+    },
+  ],
+});

--- a/packages/realm-server/tests/realm-endpoints/lint-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/lint-test.ts
@@ -537,8 +537,7 @@ export class MyCard extends CardDef {
       let responseJson = JSON.parse(response.text);
       let messages = responseJson.messages;
       let positionFixedWarning = messages.find(
-        (m: any) =>
-          m.ruleId === '@cardstack/boxel/no-css-position-fixed',
+        (m: any) => m.ruleId === '@cardstack/boxel/no-css-position-fixed',
       );
       assert.ok(
         positionFixedWarning,
@@ -578,8 +577,7 @@ export class MyCard extends CardDef {
       let responseJson = JSON.parse(response.text);
       let messages = responseJson.messages;
       let positionFixedWarning = messages.find(
-        (m: any) =>
-          m.ruleId === '@cardstack/boxel/no-css-position-fixed',
+        (m: any) => m.ruleId === '@cardstack/boxel/no-css-position-fixed',
       );
       assert.notOk(
         positionFixedWarning,

--- a/packages/realm-server/tests/realm-endpoints/lint-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/lint-test.ts
@@ -510,6 +510,83 @@ export class MyCard extends CardDef {
       );
     });
 
+    test('warns about position: fixed in card CSS', async function (assert) {
+      let response = await request
+        .post('/_lint')
+        .set(
+          'Authorization',
+          `Bearer ${createJWT(testRealm, 'john', ['read', 'write'])}`,
+        )
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', 'application/json')
+        .send(`import { CardDef } from 'https://cardstack.com/base/card-api';
+export class MyCard extends CardDef {
+}
+<template>
+  <div class="my-card">Hello</div>
+  <style scoped>
+    .my-card {
+      position: fixed;
+      top: 0;
+    }
+  </style>
+</template>
+`);
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      let responseJson = JSON.parse(response.text);
+      let messages = responseJson.messages;
+      let positionFixedWarning = messages.find(
+        (m: any) =>
+          m.ruleId === '@cardstack/boxel/no-css-position-fixed',
+      );
+      assert.ok(
+        positionFixedWarning,
+        'Should have a warning about position: fixed',
+      );
+      assert.strictEqual(
+        positionFixedWarning.severity,
+        1,
+        'Should be a warning (severity 1), not an error',
+      );
+    });
+
+    test('does not warn about position: fixed when not present', async function (assert) {
+      let response = await request
+        .post('/_lint')
+        .set(
+          'Authorization',
+          `Bearer ${createJWT(testRealm, 'john', ['read', 'write'])}`,
+        )
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', 'application/json')
+        .send(`import { CardDef } from 'https://cardstack.com/base/card-api';
+export class MyCard extends CardDef {
+}
+<template>
+  <div class="my-card">Hello</div>
+  <style scoped>
+    .my-card {
+      position: relative;
+      top: 0;
+    }
+  </style>
+</template>
+`);
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      let responseJson = JSON.parse(response.text);
+      let messages = responseJson.messages;
+      let positionFixedWarning = messages.find(
+        (m: any) =>
+          m.ruleId === '@cardstack/boxel/no-css-position-fixed',
+      );
+      assert.notOk(
+        positionFixedWarning,
+        'Should not warn when position: fixed is not used',
+      );
+    });
+
     test('handles nested template structures correctly', async function (assert) {
       let response = await request
         .post('/_lint')

--- a/packages/runtime-common/tasks/lint.ts
+++ b/packages/runtime-common/tasks/lint.ts
@@ -78,6 +78,7 @@ async function lintFix({
       },
     ],
     '@cardstack/boxel/no-duplicate-imports': 'error',
+    '@cardstack/boxel/no-css-position-fixed': 'warn',
   };
 
   const eslintJsModule = await import(/* webpackIgnore: true */ '@eslint/js');


### PR DESCRIPTION
## Summary
- Adds a new ESLint rule `no-css-position-fixed` to the `@cardstack/eslint-plugin-boxel` package that detects `position: fixed` inside `<style>` elements in GTS templates
- Registers the rule as a `warn`-level check in the `_lint` endpoint config so the AI bot receives guidance without a hard error
- Adds two integration tests: one confirming the warning fires, one confirming no false positive with `position: relative`

Closes CS-7754

## Test plan
- [ ] CI passes realm-server lint tests (new tests: "warns about position: fixed in card CSS" and "does not warn about position: fixed when not present")
- [ ] Verify via `_lint` endpoint that submitting card code with `position: fixed` in a `<style>` tag returns a warning message

🤖 Generated with [Claude Code](https://claude.com/claude-code)