### PR TITLE
server: Add realm endpoint for writing binary files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,7 @@ jobs:
       boxel: ${{ steps.filter.outputs.boxel }}
       ai-bot: ${{ steps.filter.outputs.ai-bot }}
       bot-runner: ${{ steps.filter.outputs.bot-runner }}
+      eslint-plugin-boxel: ${{ steps.filter.outputs.eslint-plugin-boxel }}
       postgres-migrations: ${{ steps.filter.outputs.postgres-migrations }}
       boxel-icons: ${{ steps.filter.outputs.boxel-icons }}
       boxel-motion: ${{ steps.filter.outputs.boxel-motion }}
@@ -67,6 +68,9 @@ jobs:
               - *shared
               - 'packages/bot-runner/**'
               - 'packages/postgres/**'
+            eslint-plugin-boxel:
+              - *shared
+              - 'packages/eslint-plugin-boxel/**'
             postgres-migrations:
               - 'packages/postgres/migrations/**'
             boxel-icons:
@@ -161,6 +165,21 @@ jobs:
       - name: Bot Runner test suite
         run: pnpm test
         working-directory: packages/bot-runner
+
+  eslint-plugin-boxel-test:
+    name: ESLint Plugin Boxel Tests
+    needs: change-check
+    if: needs.change-check.outputs.eslint-plugin-boxel == 'true' || github.ref == 'refs/heads/main' || needs.change-check.outputs.run_all == 'true'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: eslint-plugin-boxel-test-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+      - uses: ./.github/actions/init
+      - name: ESLint Plugin Boxel test suite
+        run: pnpm test
+        working-directory: packages/eslint-plugin-boxel
 
   postgres-migration-test:
     name: Postgres Migration Test

--- a/packages/billing/billing-queries.ts
+++ b/packages/billing/billing-queries.ts
@@ -562,14 +562,17 @@ export async function spendCredits(
   if (!subscriptionCycle) {
     throw new Error('subscription cycle not found');
   }
-  let availablePlanAllowanceCredits = await sumUpCreditsLedger(dbAdapter, {
-    creditType: [
-      'plan_allowance',
-      'plan_allowance_used',
-      'plan_allowance_expired',
-    ],
-    userId,
-  });
+  let availablePlanAllowanceCredits = Math.max(
+    0,
+    await sumUpCreditsLedger(dbAdapter, {
+      creditType: [
+        'plan_allowance',
+        'plan_allowance_used',
+        'plan_allowance_expired',
+      ],
+      subscriptionCycleId: subscriptionCycle.id,
+    }),
+  );
 
   if (availablePlanAllowanceCredits >= creditsToSpend) {
     await addToCreditsLedger(dbAdapter, {

--- a/packages/eslint-plugin-boxel/lib/rules/no-css-position-fixed.js
+++ b/packages/eslint-plugin-boxel/lib/rules/no-css-position-fixed.js
@@ -1,0 +1,40 @@
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'disallow `position: fixed` in card CSS because cards should not break out of their bounding box',
+      category: 'Ember Octane',
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      'no-css-position-fixed':
+        'Do not use `position: fixed` in card CSS. Cards should not break out of their bounding box. Consider using `position: absolute` or `position: sticky` instead.',
+    },
+  },
+
+  create: (context) => {
+    return {
+      GlimmerElement(node) {
+        if (node.tag !== 'style') {
+          return;
+        }
+        for (const child of node.children) {
+          if (child.type === 'GlimmerTextNode') {
+            const text = child.value;
+            const regex = /position\s*:\s*fixed/gi;
+            let match;
+            while ((match = regex.exec(text)) !== null) {
+              context.report({
+                node: child,
+                messageId: 'no-css-position-fixed',
+              });
+            }
+          }
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-boxel/lib/rules/no-css-position-fixed.js
+++ b/packages/eslint-plugin-boxel/lib/rules/no-css-position-fixed.js
@@ -17,7 +17,7 @@ module.exports = {
 
   create: (context) => {
     return {
-      GlimmerElement(node) {
+      GlimmerElementNode(node) {
         if (node.tag !== 'style') {
           return;
         }

--- a/packages/eslint-plugin-boxel/tests/lib/rules/no-css-position-fixed-test.js
+++ b/packages/eslint-plugin-boxel/tests/lib/rules/no-css-position-fixed-test.js
@@ -1,0 +1,133 @@
+const rule = require('../../../lib/rules/no-css-position-fixed');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('ember-eslint-parser'),
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+});
+ruleTester.run('no-css-position-fixed', rule, {
+  valid: [
+    `
+      <template>
+        <div class="my-card">Hello</div>
+        <style scoped>
+          .my-card {
+            position: relative;
+            top: 0;
+          }
+        </style>
+      </template>
+    `,
+    `
+      <template>
+        <div class="my-card">Hello</div>
+        <style scoped>
+          .my-card {
+            position: absolute;
+            top: 0;
+          }
+        </style>
+      </template>
+    `,
+    `
+      <template>
+        <div class="my-card">Hello</div>
+        <style scoped>
+          .my-card {
+            position: sticky;
+            top: 0;
+          }
+        </style>
+      </template>
+    `,
+    // No style tag at all
+    `
+      <template>
+        <div class="my-card">Hello</div>
+      </template>
+    `,
+  ],
+
+  invalid: [
+    {
+      code: `
+        <template>
+          <div class="my-card">Hello</div>
+          <style scoped>
+            .my-card {
+              position: fixed;
+              top: 0;
+            }
+          </style>
+        </template>
+      `,
+      errors: [
+        {
+          type: 'GlimmerTextNode',
+          message: rule.meta.messages['no-css-position-fixed'],
+        },
+      ],
+    },
+    // Without space after colon
+    {
+      code: `
+        <template>
+          <style scoped>
+            .my-card {
+              position:fixed;
+            }
+          </style>
+        </template>
+      `,
+      errors: [
+        {
+          type: 'GlimmerTextNode',
+          message: rule.meta.messages['no-css-position-fixed'],
+        },
+      ],
+    },
+    // With extra whitespace
+    {
+      code: `
+        <template>
+          <style scoped>
+            .my-card {
+              position:  fixed;
+            }
+          </style>
+        </template>
+      `,
+      errors: [
+        {
+          type: 'GlimmerTextNode',
+          message: rule.meta.messages['no-css-position-fixed'],
+        },
+      ],
+    },
+    // Multiple occurrences
+    {
+      code: `
+        <template>
+          <style scoped>
+            .my-card {
+              position: fixed;
+            }
+            .another {
+              position: fixed;
+            }
+          </style>
+        </template>
+      `,
+      errors: [
+        {
+          type: 'GlimmerTextNode',
+          message: rule.meta.messages['no-css-position-fixed'],
+        },
+        {
+          type: 'GlimmerTextNode',
+          message: rule.meta.messages['no-css-position-fixed'],
+        },
+      ],
+    },
+  ],
+});

--- a/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
@@ -33,7 +33,7 @@ interface Signature {
   Args: {
     items: (CardDef | FileDef | CardErrorJSONAPI)[];
     autoAttachedCardIds?: TrackedSet<string>;
-    autoAttachedFile?: FileDef;
+    autoAttachedFiles?: FileDef[];
     removeCard: (cardId: string) => void;
     removeFile: (file: FileDef) => void;
     chooseCard?: (cardId: string) => void;
@@ -63,7 +63,11 @@ export default class AttachedItems extends Component<Signature> {
   };
 
   private isAutoAttachedFile = (file: FileDef): boolean => {
-    return this.args.autoAttachedFile?.sourceUrl === file.sourceUrl;
+    return (
+      this.args.autoAttachedFiles?.some(
+        (autoFile) => autoFile.sourceUrl === file.sourceUrl,
+      ) ?? false
+    );
   };
 
   @action

--- a/packages/host/app/components/ai-assistant/attachment-picker/index.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/index.gts
@@ -23,7 +23,7 @@ interface Signature {
   Args: {
     autoAttachedCardIds?: TrackedSet<string>;
     cardIdsToAttach: string[] | undefined;
-    autoAttachedFile?: FileDef;
+    autoAttachedFiles?: FileDef[];
     filesToAttach: FileDef[] | undefined;
     chooseCard: (cardId: string) => void;
     removeCard: (cardId: string) => void;
@@ -37,7 +37,7 @@ interface Signature {
         typeof AttachedItems,
         | 'items'
         | 'autoAttachedCardIds'
-        | 'autoAttachedFile'
+        | 'autoAttachedFiles'
         | 'removeCard'
         | 'removeFile'
         | 'chooseCard'
@@ -59,7 +59,7 @@ export default class AiAssistantAttachmentPicker extends Component<Signature> {
         isLoaded=this.isLoaded
         items=this.items
         autoAttachedCardIds=@autoAttachedCardIds
-        autoAttachedFile=@autoAttachedFile
+        autoAttachedFiles=@autoAttachedFiles
         removeCard=@removeCard
         removeFile=@removeFile
         chooseCard=@chooseCard
@@ -109,18 +109,20 @@ export default class AiAssistantAttachmentPicker extends Component<Signature> {
   private get files() {
     let files = this.args.filesToAttach ?? [];
 
-    if (!this.args.autoAttachedFile) {
+    let autoAttachedFiles = this.args.autoAttachedFiles ?? [];
+
+    if (autoAttachedFiles.length === 0) {
       return files;
     }
 
-    if (
-      files.some(
-        (file) => file.sourceUrl === this.args.autoAttachedFile?.sourceUrl,
-      )
-    ) {
+    let autoFilesToPrepend = autoAttachedFiles.filter(
+      (file) => !files.some((item) => item.sourceUrl === file.sourceUrl),
+    );
+
+    if (autoFilesToPrepend.length === 0) {
       return files;
     }
 
-    return [this.args.autoAttachedFile, ...files];
+    return [...autoFilesToPrepend, ...files];
   }
 }

--- a/packages/host/app/components/ai-assistant/attachment-picker/usage.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/usage.gts
@@ -18,7 +18,7 @@ export default class AiAssistantCardPickerUsage extends Component {
   cardIds: TrackedArray<string> = new TrackedArray([]);
   @tracked maxNumberOfCards: number | undefined = undefined;
   @tracked autoAttachedCardIds?: TrackedSet<string> = new TrackedSet();
-  @tracked autoAttachedFile?: FileDef | undefined;
+  @tracked autoAttachedFiles?: FileDef[];
   @tracked filesToAttach: TrackedArray<FileDef> = new TrackedArray([]);
 
   @action chooseCard(cardId: string) {
@@ -60,7 +60,7 @@ export default class AiAssistantCardPickerUsage extends Component {
           @removeCard={{this.removeCard}}
           @chooseFile={{this.chooseFile}}
           @removeFile={{this.removeFile}}
-          @autoAttachedFile={{this.autoAttachedFile}}
+          @autoAttachedFiles={{this.autoAttachedFiles}}
           @filesToAttach={{this.filesToAttach}}
           as |AttachedItems AttachButton|
         >
@@ -81,9 +81,9 @@ export default class AiAssistantCardPickerUsage extends Component {
           @value={{this.autoAttachedCardIds}}
         />
         <Args.Object
-          @name='autoAttachedFile'
-          @description='A file automatically attached to the message.'
-          @value={{this.autoAttachedFile}}
+          @name='autoAttachedFiles'
+          @description='Files automatically attached to the message.'
+          @value={{this.autoAttachedFiles}}
         />
         <Args.Object
           @name='filesToAttach'

--- a/packages/host/app/components/host-mode/card.gts
+++ b/packages/host/app/components/host-mode/card.gts
@@ -94,6 +94,7 @@ export default class HostModeCard extends Component<Signature> {
         padding: var(--host-mode-card-padding);
         border-radius: var(--host-mode-card-border-radius, 20px);
         flex: 1;
+        z-index: 0;
         overflow: auto;
       }
 

--- a/packages/host/app/components/host-mode/content.gts
+++ b/packages/host/app/components/host-mode/content.gts
@@ -126,7 +126,6 @@ export default class HostModeContent extends Component<Signature> {
         align-items: center;
         justify-content: center;
         width: 100%;
-        min-height: 100vh;
         overflow: hidden;
         padding: var(--boxel-sp);
         position: relative;
@@ -134,6 +133,19 @@ export default class HostModeContent extends Component<Signature> {
         background-position: center;
         background-size: cover;
         background-repeat: no-repeat;
+      }
+
+      @media screen {
+        .host-mode-content {
+          height: 100%;
+          overscroll-behavior: none;
+        }
+      }
+
+      @media print {
+        .host-mode-content {
+          min-height: 100vh;
+        }
       }
 
       .breadcrumb-container {

--- a/packages/host/app/components/host-mode/stack-item.gts
+++ b/packages/host/app/components/host-mode/stack-item.gts
@@ -8,9 +8,8 @@ import { isTesting } from '@embroider/macros';
 import Component from '@glimmer/component';
 import { cached, tracked } from '@glimmer/tracking';
 
-import X from '@cardstack/boxel-icons/x';
-
-import { IconButton } from '@cardstack/boxel-ui/components';
+import { ContextButton } from '@cardstack/boxel-ui/components';
+import { and, bool } from '@cardstack/boxel-ui/helpers';
 
 import { getCard } from '@cardstack/host/resources/card-resource';
 
@@ -74,7 +73,7 @@ export default class HostModeStackItem extends Component<Signature> {
 
     let maxWidthPercent = 100 - invertedIndex * maxWidthReductionPercent;
     let width = this.isItemFullWidth
-      ? '100%'
+      ? 'calc(100% - var(--boxel-sp-xxl) * 2)'
       : `${stackItemMaxWidth / Math.pow(RATIO, invertedIndex)}rem`;
 
     let styles = `
@@ -83,8 +82,11 @@ export default class HostModeStackItem extends Component<Signature> {
       max-width: ${maxWidthPercent}%;
       z-index: calc(${this.args.index} + 1);
       margin-top: ${marginTopPx}px;
-      transition: margin-top var(--boxel-transition), width var(--boxel-transition);
     `; // using margin-top instead of padding-top to hide scrolled content from view
+
+    if (this.isTopCard) {
+      styles += `height: auto;`;
+    }
 
     return htmlSafe(styles);
   }
@@ -157,14 +159,13 @@ export default class HostModeStackItem extends Component<Signature> {
           @displayBoundaries={{if this.isItemFullWidth false true}}
           class='host-mode-stack-item-card'
         />
-        {{#if @close}}
+        {{#if (and this.isTopCard (bool @close))}}
           <div class='close-button-container'>
-            <IconButton
-              class='close-button'
-              @icon={{X}}
-              @width='16px'
-              @height='16px'
+            <ContextButton
+              @icon='close'
+              @label='close'
               {{on 'click' this.handleClose}}
+              data-test-host-stack-item-close-button
             />
           </div>
         {{/if}}
@@ -210,12 +211,22 @@ export default class HostModeStackItem extends Component<Signature> {
         position: absolute;
         width: 89%;
         height: inherit;
+        padding-top: var(--boxel-sp-xxl);
         z-index: 0;
         pointer-events: none;
       }
 
+      @media screen {
+        .host-mode-stack-item {
+          min-height: 80cqh;
+        }
+      }
+
+      .host-mode-stack-item:not(.buried) {
+        padding-bottom: var(--boxel-sp-xxl);
+      }
+
       .host-mode-stack-item.full-width {
-        width: 100%;
         max-width: 100%;
       }
 
@@ -269,19 +280,32 @@ export default class HostModeStackItem extends Component<Signature> {
         position: absolute;
         top: var(--boxel-sp-xs);
         right: var(--boxel-sp-xs);
-        padding: var(--boxel-sp-xs);
+        z-index: 1;
       }
-
-      .close-button {
-        height: 18px;
-        width: 18px;
+      .close-button-container :deep(.boxel-context-button:not(:hover)) {
+        background-color: var(--boxel-100);
+      }
+      .close-button-container :deep(.boxel-context-button) {
+        box-shadow: var(--boxel-box-shadow);
       }
 
       .host-mode-stack-item-card {
         border-radius: 0;
         box-shadow: none;
-        overflow: auto;
-        height: 100%;
+        z-index: 0;
+      }
+
+      @media print {
+        .host-mode-stack-item {
+          height: 100% !important;
+        }
+        .host-mode-stack-item-card {
+          height: 100%;
+          overflow: auto;
+        }
+        .close-button-container {
+          display: none;
+        }
       }
     </style>
   </template>

--- a/packages/host/app/components/host-mode/stack.gts
+++ b/packages/host/app/components/host-mode/stack.gts
@@ -32,15 +32,12 @@ const HostModeStack: TemplateOnlyComponent<Signature> = <template>
       background-color: rgba(0, 0, 0, 0.35);
       background-position: center;
       background-size: cover;
-      padding-top: var(--boxel-sp-xxl);
-      padding-inline: var(--boxel-sp-xxl);
-      padding-bottom: var(--boxel-sp-xxl);
+      padding: 0;
       position: absolute;
       top: 0;
       left: 0;
       right: 0;
       bottom: 0;
-      transition: padding-top var(--boxel-transition);
     }
 
     .inner {
@@ -51,6 +48,17 @@ const HostModeStack: TemplateOnlyComponent<Signature> = <template>
       margin: 0 auto;
       border-bottom-left-radius: var(--boxel-border-radius);
       border-bottom-right-radius: var(--boxel-border-radius);
+    }
+
+    @media screen {
+      .inner {
+        overflow: auto;
+      }
+      /* .inner will handle overflow in host mode stack */
+      .host-mode-stack :deep(.host-mode-card, .card) {
+        overflow: hidden;
+        min-height: 80cqh;
+      }
     }
   </style>
 </template>;

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -47,6 +47,7 @@ import UpdateRoomSkillsCommand from '@cardstack/host/commands/update-room-skills
 import type { Message } from '@cardstack/host/lib/matrix-classes/message';
 import type { StackItem } from '@cardstack/host/lib/stack-item';
 import { getAutoAttachment } from '@cardstack/host/resources/auto-attached-card';
+import { isReady } from '@cardstack/host/resources/file';
 import type { RoomResource } from '@cardstack/host/resources/room';
 
 import type AiAssistantPanelService from '@cardstack/host/services/ai-assistant-panel-service';
@@ -194,7 +195,7 @@ export default class Room extends Component<Signature> {
             @removeCard={{this.removeCard}}
             @chooseFile={{this.chooseFile}}
             @removeFile={{this.removeFile}}
-            @autoAttachedFile={{this.autoAttachedFile}}
+            @autoAttachedFiles={{this.autoAttachedFiles}}
             @filesToAttach={{this.filesToAttach}}
             @autoAttachedCardTooltipMessage={{if
               (eq this.operatorModeStateService.state.submode Submodes.Code)
@@ -450,7 +451,7 @@ export default class Room extends Component<Signature> {
     submode: () => this.operatorModeStateService.state.submode,
     moduleInspectorPanel: () =>
       this.operatorModeStateService.moduleInspectorPanel,
-    autoAttachedFileUrl: () => this.autoAttachedFileUrl,
+    autoAttachedFileUrls: () => this.autoAttachedFileUrls,
     playgroundPanelCardId: () => this.playgroundPanelCardId,
     activeSpecId: () => this.specPanelService.specSelection,
     topMostStackItems: () => this.topMostStackItems,
@@ -459,7 +460,7 @@ export default class Room extends Component<Signature> {
   });
   private removedAttachedCardIds = new TrackedArray<string>();
   private removedAttachedFileUrls: string[] = [];
-  private lastAutoAttachedFileUrl: string | undefined;
+  private lastAutoAttachedFileUrlsKey: string | undefined;
   private getConversationScrollability: (() => boolean) | undefined;
   private scrollConversationToBottom: (() => void) | undefined;
   private roomScrollState: WeakMap<
@@ -530,59 +531,98 @@ export default class Room extends Component<Signature> {
   // when the user opens a different file and then returns to this one.
   @use private autoAttachedFileResource = resource(() => {
     let state = new TrackedObject<{
-      value: FileDef | undefined;
-      remove: () => void;
+      value: FileDef[];
+      remove: (sourceUrl?: string) => void;
     }>({
-      value: undefined,
-      remove: () => {
-        state.value = undefined;
+      value: [],
+      remove: (sourceUrl?: string) => {
+        if (!sourceUrl) {
+          state.value = [];
+          return;
+        }
+        state.value = state.value.filter(
+          (file) => file.sourceUrl !== sourceUrl,
+        );
       },
     });
 
-    let autoAttachedFileUrl = this.autoAttachedFileUrl;
+    let autoAttachedFileUrls = this.autoAttachedFileUrls;
     let manuallyAttachedFiles = this.filesToAttach;
+    let autoAttachedFileUrlsKey = autoAttachedFileUrls.join('\n');
 
     let removedFileUrls: string[];
-    if (autoAttachedFileUrl !== this.lastAutoAttachedFileUrl) {
+    if (autoAttachedFileUrlsKey !== this.lastAutoAttachedFileUrlsKey) {
       this.removedAttachedFileUrls.splice(0);
       removedFileUrls = this.removedAttachedFileUrls;
-      this.lastAutoAttachedFileUrl = autoAttachedFileUrl;
+      this.lastAutoAttachedFileUrlsKey = autoAttachedFileUrlsKey;
     } else {
       removedFileUrls = this.removedAttachedFileUrls;
     }
 
-    let isManuallyAttached = manuallyAttachedFiles.some(
-      (file) => file.sourceUrl === autoAttachedFileUrl,
-    );
-    let isRemoved = autoAttachedFileUrl
-      ? removedFileUrls.includes(autoAttachedFileUrl)
-      : false;
+    let candidateUrls = autoAttachedFileUrls.filter((url) => {
+      if (!url) {
+        return false;
+      }
+      let isManuallyAttached = manuallyAttachedFiles.some(
+        (file) => file.sourceUrl === url,
+      );
+      let isRemoved = removedFileUrls.includes(url);
+      return !isManuallyAttached && !isRemoved;
+    });
 
-    if (!autoAttachedFileUrl || isManuallyAttached || isRemoved) {
-      state.value = undefined;
-    } else {
-      state.value = this.matrixService.fileAPI.createFileDef({
-        sourceUrl: autoAttachedFileUrl,
-        name: autoAttachedFileUrl.split('/').pop(),
-      });
-    }
+    state.value = candidateUrls.map((url) =>
+      this.matrixService.fileAPI.createFileDef({
+        sourceUrl: url,
+        name: url.split('/').pop(),
+      }),
+    );
 
     return state;
   });
 
-  private get autoAttachedFileUrl() {
-    return this.operatorModeStateService.state.codePath?.href;
+  private get autoAttachedFileUrls() {
+    let codePathUrl = this.operatorModeStateService.state.codePath?.href;
+    if (!codePathUrl) {
+      return [];
+    }
+
+    let urls = [codePathUrl];
+
+    if (codePathUrl.endsWith('.json')) {
+      let openFile = this.operatorModeStateService.openFile?.current;
+      if (openFile && isReady(openFile)) {
+        try {
+          let fileContent = JSON.parse(openFile.content);
+          let adoptsFrom = fileContent?.data?.meta?.adoptsFrom;
+          if (adoptsFrom?.module) {
+            let moduleURLWithExtension = new URL(
+              adoptsFrom.module.endsWith('.gts')
+                ? adoptsFrom.module
+                : `${adoptsFrom.module}.gts`,
+              openFile.url,
+            );
+            if (!urls.includes(moduleURLWithExtension.href)) {
+              urls.push(moduleURLWithExtension.href);
+            }
+          }
+        } catch (_error) {
+          // If JSON parse fails, fall back to just the current file URL.
+        }
+      }
+    }
+
+    return urls;
   }
 
-  private get autoAttachedFile() {
+  private get autoAttachedFiles() {
     return this.operatorModeStateService.state.submode === Submodes.Code
       ? this.autoAttachedFileResource.value
-      : undefined;
+      : [];
   }
 
   private get removeAutoAttachedFile() {
-    return () => {
-      this.autoAttachedFileResource.remove();
+    return (sourceUrl?: string) => {
+      this.autoAttachedFileResource.remove(sourceUrl);
     };
   }
 
@@ -939,8 +979,8 @@ export default class Room extends Component<Signature> {
     }
 
     let files = [];
-    if (this.autoAttachedFile) {
-      files.push(this.autoAttachedFile);
+    if (this.autoAttachedFiles.length > 0) {
+      files.push(...this.autoAttachedFiles);
     }
     files.push(...this.filesToAttach);
 
@@ -996,7 +1036,7 @@ export default class Room extends Component<Signature> {
   private chooseFile(file: FileDef) {
     // handle the case where auto-attached file pill is clicked
     if (this.isAutoAttachedFile(file)) {
-      this.removeAutoAttachedFile();
+      this.removeAutoAttachedFile(file.sourceUrl ?? undefined);
     }
 
     let files = this.filesToAttach;
@@ -1007,13 +1047,15 @@ export default class Room extends Component<Signature> {
 
   @action
   private isAutoAttachedFile(file: FileDef) {
-    return this.autoAttachedFile?.sourceUrl === file.sourceUrl;
+    return this.autoAttachedFiles.some(
+      (autoFile) => autoFile.sourceUrl === file.sourceUrl,
+    );
   }
 
   @action
   private removeFile(file: FileDef) {
     if (this.isAutoAttachedFile(file)) {
-      this.removeAutoAttachedFile();
+      this.removeAutoAttachedFile(file.sourceUrl ?? undefined);
       return;
     }
 
@@ -1228,7 +1270,7 @@ export default class Room extends Component<Signature> {
     return (
       this.filesToAttach?.length ||
       this.cardIdsToAttach?.length ||
-      this.autoAttachedFile ||
+      this.autoAttachedFiles.length > 0 ||
       this.autoAttachedCardIds?.size
     );
   }

--- a/packages/host/app/components/operator-mode/publish-realm-modal.gts
+++ b/packages/host/app/components/operator-mode/publish-realm-modal.gts
@@ -24,6 +24,9 @@ import {
 import { not } from '@cardstack/boxel-ui/helpers';
 import { IconX, Warning as WarningIcon } from '@cardstack/boxel-ui/icons';
 
+import { ensureTrailingSlash } from '@cardstack/runtime-common';
+import { getPublishedRealmDomainOverrides } from '@cardstack/runtime-common/constants';
+
 import ModalContainer from '@cardstack/host/components/modal-container';
 import PrivateDependencyViolationComponent from '@cardstack/host/components/operator-mode/private-dependency-violation';
 import WithLoadedRealm from '@cardstack/host/components/with-loaded-realm';
@@ -219,6 +222,65 @@ export default class PublishRealmModal extends Component<Signature> {
 
   get customSubdomainBase() {
     return config.publishedRealmBoxelSiteDomain;
+  }
+
+  // TODO: Remove with CS-9061 once published realm domain overrides are removed.
+  private getPublishedRealmOverrideUrl(
+    publishedRealmURL: string | null,
+  ): string | null {
+    let overrideDomain = getPublishedRealmDomainOverrides(
+      config.publishedRealmDomainOverrides,
+    )[ensureTrailingSlash(this.currentRealmURL)];
+    if (!overrideDomain) {
+      return null;
+    }
+
+    if (!publishedRealmURL) {
+      return null;
+    }
+
+    let overriddenURL = new URL(publishedRealmURL);
+    overriddenURL.host = overrideDomain;
+    return ensureTrailingSlash(overriddenURL.toString());
+  }
+
+  get customSubdomainOverrideUrl() {
+    let publishedRealmURL =
+      this.claimedDomainPublishedUrl ??
+      this.buildPublishedRealmUrl(
+        `${this.customSubdomainDisplay}.${this.customSubdomainBase}`,
+      );
+    return this.getPublishedRealmOverrideUrl(publishedRealmURL);
+  }
+
+  get shouldShowCustomSubdomainOverride() {
+    return (
+      !!this.customSubdomainOverrideUrl &&
+      this.realm.canWrite(this.currentRealmURL)
+    );
+  }
+
+  get isCustomSubdomainOverrideSelected() {
+    if (!this.customSubdomainOverrideUrl) {
+      return false;
+    }
+    return this.selectedPublishedRealmURLs.includes(
+      this.customSubdomainOverrideUrl,
+    );
+  }
+
+  get isCustomSubdomainOverridePublished() {
+    if (!this.customSubdomainOverrideUrl) {
+      return false;
+    }
+    return this.hostModeService.isPublished(this.customSubdomainOverrideUrl);
+  }
+
+  get customSubdomainOverrideLastPublishedTime() {
+    if (!this.customSubdomainOverrideUrl) {
+      return null;
+    }
+    return this.getFormattedLastPublishedTime(this.customSubdomainOverrideUrl);
   }
 
   get customSubdomainDisplay() {
@@ -458,6 +520,20 @@ export default class PublishRealmModal extends Component<Signature> {
     }
   }
 
+  @action
+  toggleCustomSubdomainOverride(event: Event) {
+    const overrideUrl = this.customSubdomainOverrideUrl;
+    if (!overrideUrl) {
+      return;
+    }
+    const input = event.target as HTMLInputElement;
+    if (input.checked) {
+      this.addPublishedRealmUrl(overrideUrl);
+    } else {
+      this.removePublishedRealmUrl(overrideUrl);
+    }
+  }
+
   private addPublishedRealmUrl(url: string) {
     if (!this.selectedPublishedRealmURLs.includes(url)) {
       this.selectedPublishedRealmURLs = [
@@ -617,6 +693,13 @@ export default class PublishRealmModal extends Component<Signature> {
       return null;
     }
     return this.getPublishErrorForUrl(this.claimedDomainPublishedUrl);
+  }
+
+  get publishErrorForCustomSubdomainOverride() {
+    if (!this.customSubdomainOverrideUrl) {
+      return null;
+    }
+    return this.getPublishErrorForUrl(this.customSubdomainOverrideUrl);
   }
 
   ensureInitialSelectionsTask = restartableTask(
@@ -1027,6 +1110,99 @@ export default class PublishRealmModal extends Component<Signature> {
               </div>
             {{/if}}
           </div>
+
+          {{#if this.shouldShowCustomSubdomainOverride}}
+            {{#let this.customSubdomainOverrideUrl as |overrideUrl|}}
+              {{#if overrideUrl}}
+                <div class='domain-option'>
+                  <input
+                    type='checkbox'
+                    id='custom-subdomain-override-checkbox'
+                    class='domain-checkbox'
+                    checked={{this.isCustomSubdomainOverrideSelected}}
+                    {{on 'change' this.toggleCustomSubdomainOverride}}
+                    data-test-custom-subdomain-override-checkbox
+                    disabled={{this.isUnpublishingAnyRealms}}
+                  />
+                  <label
+                    class='option-title'
+                    for='custom-subdomain-override-checkbox'
+                  >Custom Domain Override</label>
+                  <div class='domain-details'>
+                    <WithLoadedRealm
+                      @realmURL={{this.currentRealmURL}}
+                      as |realm|
+                    >
+                      <RealmIcon @realmInfo={{realm.info}} class='realm-icon' />
+                    </WithLoadedRealm>
+                    <div class='domain-url-container'>
+                      <span class='domain-url'>{{overrideUrl}}</span>
+                      {{#if this.isCustomSubdomainOverridePublished}}
+                        <div class='domain-info'>
+                          {{#if this.customSubdomainOverrideLastPublishedTime}}
+                            <span class='last-published-at'>Published
+                              {{this.customSubdomainOverrideLastPublishedTime}}</span>
+                          {{/if}}
+                          <BoxelButton
+                            @kind='text-only'
+                            @size='extra-small'
+                            @disabled={{this.isUnpublishingRealm overrideUrl}}
+                            class='unpublish-button'
+                            {{on 'click' (fn @handleUnpublish overrideUrl)}}
+                            data-test-unpublish-custom-subdomain-override-button
+                          >
+                            {{#if (this.isUnpublishingRealm overrideUrl)}}
+                              <LoadingIndicator />
+                              Unpublishing…
+                            {{else}}
+                              <Undo2
+                                width='11'
+                                height='11'
+                                class='unpublish-icon'
+                              />
+                              Unpublish
+                            {{/if}}
+                          </BoxelButton>
+                        </div>
+                      {{else}}
+                        <span class='not-published-yet'>Not published yet</span>
+                      {{/if}}
+                    </div>
+                  </div>
+                  {{#if this.isCustomSubdomainOverridePublished}}
+                    <BoxelButton
+                      @as='anchor'
+                      @kind='secondary-light'
+                      @size='small'
+                      @href={{overrideUrl}}
+                      @disabled={{this.isUnpublishingAnyRealms}}
+                      class='action'
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      data-test-open-custom-subdomain-override-button
+                    >
+                      <ExternalLink
+                        width='16'
+                        height='16'
+                        class='button-icon'
+                      />
+                      Open Site
+                    </BoxelButton>
+                  {{/if}}
+                  {{#if this.publishErrorForCustomSubdomainOverride}}
+                    <div
+                      class='domain-publish-error'
+                      data-test-domain-publish-error={{overrideUrl}}
+                    >
+                      <span
+                        class='error-text'
+                      >{{this.publishErrorForCustomSubdomainOverride}}</span>
+                    </div>
+                  {{/if}}
+                </div>
+              {{/if}}
+            {{/let}}
+          {{/if}}
         </div>
       </:content>
 

--- a/packages/host/app/components/operator-mode/submode-layout.gts
+++ b/packages/host/app/components/operator-mode/submode-layout.gts
@@ -525,8 +525,10 @@ export default class SubmodeLayout extends Component<Signature> {
         --submode-bar-item-border-radius: var(--boxel-border-radius);
         --boxel-icon-button-width: var(--container-button-size);
         --boxel-icon-button-height: var(--container-button-size);
+        position: relative;
         display: flex;
         height: 100%;
+        z-index: 0;
       }
 
       .submode-layout > .boxel-panel-group {
@@ -651,6 +653,12 @@ export default class SubmodeLayout extends Component<Signature> {
       :deep(.open-search-field) {
         box-shadow: var(--submode-bar-item-box-shadow);
         outline: var(--submode-bar-item-outline);
+      }
+
+      @media print {
+        .submode-layout-top-bar {
+          display: none;
+        }
       }
     </style>
   </template>

--- a/packages/host/app/config/environment.d.ts
+++ b/packages/host/app/config/environment.d.ts
@@ -38,6 +38,7 @@ declare const config: {
   };
   publishedRealmBoxelSpaceDomain: string;
   publishedRealmBoxelSiteDomain: string;
+  publishedRealmDomainOverrides: string;
   defaultSystemCardId: string;
   cardSizeLimitBytes: number;
 };

--- a/packages/host/app/resources/auto-attached-card.ts
+++ b/packages/host/app/resources/auto-attached-card.ts
@@ -23,7 +23,7 @@ interface Args {
   named: {
     submode: Submode;
     moduleInspectorPanel: string | undefined; // 'preview' | 'spec' | 'schema' | 'card-renderer'
-    autoAttachedFileUrl: string | undefined;
+    autoAttachedFileUrls: string[] | undefined;
     playgroundPanelCardId: string | undefined;
     activeSpecId: string | null | undefined; // selected spec card ID from SpecPanelService
     topMostStackItems: StackItem[];
@@ -45,7 +45,7 @@ export class AutoAttachment extends Resource<Args> {
     const {
       submode,
       moduleInspectorPanel,
-      autoAttachedFileUrl,
+      autoAttachedFileUrls,
       playgroundPanelCardId,
       activeSpecId,
       topMostStackItems,
@@ -55,7 +55,7 @@ export class AutoAttachment extends Resource<Args> {
     this.calculateAutoAttachments.perform(
       submode,
       moduleInspectorPanel,
-      autoAttachedFileUrl,
+      autoAttachedFileUrls,
       playgroundPanelCardId,
       activeSpecId,
       topMostStackItems,
@@ -68,7 +68,7 @@ export class AutoAttachment extends Resource<Args> {
     async (
       submode: Submode,
       moduleInspectorPanel: string | undefined,
-      autoAttachedFileUrl: string | undefined,
+      autoAttachedFileUrls: string[] | undefined,
       playgroundPanelCardId: string | undefined,
       activeSpecId: string | null | undefined,
       topMostStackItems: StackItem[],
@@ -97,8 +97,11 @@ export class AutoAttachment extends Resource<Args> {
           this.cardIds.add(item.id);
         }
       } else if (submode === Submodes.Code) {
-        let cardId = autoAttachedFileUrl?.endsWith('.json')
-          ? autoAttachedFileUrl?.replace(/\.json$/, '')
+        let cardFileUrl = autoAttachedFileUrls?.find((url) =>
+          url.endsWith('.json'),
+        );
+        let cardId = cardFileUrl
+          ? cardFileUrl.replace(/\.json$/, '')
           : undefined;
         if (
           cardId &&
@@ -133,7 +136,7 @@ export function getAutoAttachment(
   args: {
     submode: () => Submode;
     moduleInspectorPanel: () => string | undefined;
-    autoAttachedFileUrl: () => string | undefined;
+    autoAttachedFileUrls: () => string[] | undefined;
     playgroundPanelCardId: () => string | undefined;
     activeSpecId: () => string | null | undefined;
     topMostStackItems: () => StackItem[];
@@ -145,7 +148,7 @@ export function getAutoAttachment(
     named: {
       submode: args.submode(),
       moduleInspectorPanel: args.moduleInspectorPanel(),
-      autoAttachedFileUrl: args.autoAttachedFileUrl(),
+      autoAttachedFileUrls: args.autoAttachedFileUrls(),
       playgroundPanelCardId: args.playgroundPanelCardId(),
       activeSpecId: args.activeSpecId(),
       topMostStackItems: args.topMostStackItems(),

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -1278,7 +1278,17 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     await click('[data-test-file="Person/fadhlan.json"]');
     assert.dom('[data-test-attached-card]').exists({ count: 2 });
     assert.dom('[data-test-autoattached-card]').exists({ count: 1 });
-    assert.dom('[data-test-autoattached-file]').exists({ count: 1 });
+    assert.dom('[data-test-autoattached-file]').exists({ count: 2 });
+    assert
+      .dom(
+        `[data-test-attached-file="${testRealmURL}Person/fadhlan.json"][data-test-autoattached-file]`,
+      )
+      .exists();
+    assert
+      .dom(
+        `[data-test-attached-file="${testRealmURL}person.gts"][data-test-autoattached-file]`,
+      )
+      .exists();
     assert.dom(`[data-test-attached-card="${testRealmURL}Pet/mango"]`).exists();
     assert
       .dom(

--- a/packages/host/tests/acceptance/host-mode-test.gts
+++ b/packages/host/tests/acceptance/host-mode-test.gts
@@ -417,7 +417,7 @@ module('Acceptance | host mode tests', function (hooks) {
       .dom(`[data-test-host-mode-stack-item="${testHostModeRealmURL}index"]`)
       .exists();
     await click(
-      `[data-test-host-mode-stack-item="${testHostModeRealmURL}index"] .close-button`,
+      `[data-test-host-mode-stack-item="${testHostModeRealmURL}index"] [data-test-host-stack-item-close-button]`,
     );
 
     assert.strictEqual(currentURL(), '/test/Pet/mango.json');

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -295,7 +295,10 @@ test.describe('Room messages', () => {
       .click();
     await page.locator(`[data-test-boxel-menu-item-text="Code"]`).click();
 
-    await expect(page.locator(`[data-test-attached-file]`)).toHaveCount(1);
+    await expect(page.locator(`[data-test-attached-file]`)).toHaveCount(2);
+    await expect(
+      page.locator(`[data-test-attached-file="${appURL}/person.gts"]`),
+    ).toHaveCount(1);
     await expect(
       page.locator(`[data-test-attached-file="${appURL}/hassan.json"]`),
     ).toHaveCount(1);
@@ -357,6 +360,9 @@ test.describe('Room messages', () => {
       page.locator(`[data-test-attached-card="${appURL}/hassan"]`),
     ).toHaveCount(1);
     await expect(page.locator(`[data-test-attached-file]`)).toHaveCount(1);
+    await expect(
+      page.locator(`[data-test-attached-file="${appURL}/person.gts"]`),
+    ).toHaveCount(1);
     await expect(
       page.locator(`[data-test-attached-file="${appURL}/hassan.json"]`),
     ).toHaveCount(1);

--- a/packages/realm-server/lib/retrieve-scoped-css.ts
+++ b/packages/realm-server/lib/retrieve-scoped-css.ts
@@ -27,13 +27,19 @@ export async function retrieveScopedCSS({
   }
 
   let scopedCSSQuery: Expression = [
-    `SELECT deps, realm_version FROM boxel_index_working WHERE type = 'instance' AND deps IS NOT NULL AND is_deleted IS NOT TRUE AND`,
+    `
+      SELECT deps, realm_version
+      FROM boxel_index
+      WHERE type = 'instance'
+        AND is_deleted IS NOT TRUE
+        AND deps IS NOT NULL
+        AND
+    `,
     ...indexCandidateExpressions(candidates),
-    `UNION ALL
-     SELECT deps, realm_version FROM boxel_index WHERE type = 'instance' AND deps IS NOT NULL AND is_deleted IS NOT TRUE AND`,
-    ...indexCandidateExpressions(candidates),
-    `ORDER BY realm_version DESC
-     LIMIT 1`,
+    `
+      ORDER BY realm_version DESC
+      LIMIT 1
+    `,
   ];
 
   if (log) {

--- a/packages/realm-server/middleware/index.ts
+++ b/packages/realm-server/middleware/index.ts
@@ -6,7 +6,7 @@ import {
 } from '@cardstack/runtime-common';
 import type Koa from 'koa';
 import mime from 'mime-types';
-import { nodeStreamToText } from '../stream';
+import { nodeStreamToText, nodeStreamToBuffer } from '../stream';
 import { retrieveTokenClaim } from '../utils/jwt';
 import {
   AuthenticationError,
@@ -14,7 +14,7 @@ import {
   SupportedMimeType,
 } from '@cardstack/runtime-common/router';
 
-const REQUEST_BODY_STATE = 'requestBodyText';
+const REQUEST_BODY_STATE = 'requestBody';
 
 interface ProxyOptions {
   responseHeaders?: Record<string, string>;
@@ -111,13 +111,17 @@ export function fullRequestURL(ctxt: Koa.Context): URL {
 export async function fetchRequestFromContext(
   ctxt: Koa.Context,
 ): Promise<Request> {
-  let reqBody: string | undefined;
+  let reqBody: string | Buffer | undefined;
   if (['POST', 'PATCH', 'PUT', 'QUERY', 'DELETE'].includes(ctxt.method)) {
     let state = ctxt.state as Record<string, unknown>;
     if (REQUEST_BODY_STATE in state) {
-      reqBody = state[REQUEST_BODY_STATE] as string;
+      reqBody = state[REQUEST_BODY_STATE] as string | Buffer;
     } else {
-      reqBody = await nodeStreamToText(ctxt.req);
+      let isBinary =
+        ctxt.req.headers['content-type'] === 'application/octet-stream';
+      reqBody = isBinary
+        ? await nodeStreamToBuffer(ctxt.req)
+        : await nodeStreamToText(ctxt.req);
       state[REQUEST_BODY_STATE] = reqBody;
     }
   }

--- a/packages/realm-server/node-realm.ts
+++ b/packages/realm-server/node-realm.ts
@@ -179,7 +179,10 @@ export class NodeAdapter implements RealmAdapter {
     };
   }
 
-  async write(path: string, contents: string): Promise<AdapterWriteResult> {
+  async write(
+    path: string,
+    contents: string | Uint8Array,
+  ): Promise<AdapterWriteResult> {
     let absolutePath = join(this.realmDir, path);
     ensureFileSync(absolutePath);
     writeFileSync(absolutePath, contents);

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -466,6 +466,9 @@ export class RealmServer {
           assetsURL: this.assetsURL.href,
           realmServerURL: this.serverURL.href,
           cardSizeLimitBytes: this.cardSizeLimitBytes,
+          publishedRealmDomainOverrides:
+            process.env.PUBLISHED_REALM_DOMAIN_OVERRIDES ??
+            config.publishedRealmDomainOverrides,
         });
         return `${g1}${encodeURIComponent(JSON.stringify(config))}${g3}`;
       },

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -499,21 +499,19 @@ export class RealmServer {
     }
 
     let rows = await query(this.dbAdapter, [
-      `SELECT head_html, realm_version FROM boxel_index_working WHERE head_html IS NOT NULL AND type =`,
-      param('instance'),
-      'AND',
-      'is_deleted IS NOT TRUE',
-      'AND',
+      `
+        SELECT head_html, realm_version
+        FROM boxel_index
+        WHERE type = 'instance'
+         AND head_html IS NOT NULL
+         AND is_deleted IS NOT TRUE
+         AND
+      `,
       ...this.indexCandidateExpressions(candidates),
-      `UNION ALL
-       SELECT head_html, realm_version FROM boxel_index WHERE head_html IS NOT NULL AND type =`,
-      param('instance'),
-      'AND',
-      'is_deleted IS NOT TRUE',
-      'AND',
-      ...this.indexCandidateExpressions(candidates),
-      `ORDER BY realm_version DESC
-       LIMIT 1`,
+      `
+        ORDER BY realm_version DESC
+        LIMIT 1
+      `,
     ]);
 
     this.headLog.debug('Head query result for %s', cardURL.href, rows);
@@ -547,21 +545,19 @@ export class RealmServer {
     }
 
     let rows = await query(this.dbAdapter, [
-      `SELECT isolated_html, realm_version FROM boxel_index_working WHERE isolated_html IS NOT NULL AND type =`,
-      param('instance'),
-      'AND',
-      'is_deleted IS NOT TRUE',
-      'AND',
+      `
+        SELECT isolated_html, realm_version
+        FROM boxel_index
+        WHERE isolated_html IS NOT NULL
+          AND type = 'instance'
+          AND is_deleted IS NOT TRUE
+          AND
+        `,
       ...this.indexCandidateExpressions(candidates),
-      `UNION ALL
-       SELECT isolated_html, realm_version FROM boxel_index WHERE isolated_html IS NOT NULL AND type =`,
-      param('instance'),
-      'AND',
-      'is_deleted IS NOT TRUE',
-      'AND',
-      ...this.indexCandidateExpressions(candidates),
-      `ORDER BY realm_version DESC
-       LIMIT 1`,
+      `
+        ORDER BY realm_version DESC
+        LIMIT 1
+      `,
     ]);
 
     this.isolatedLog.debug('Isolated query result for %s', cardURL.href, rows);

--- a/packages/realm-server/stream.ts
+++ b/packages/realm-server/stream.ts
@@ -8,3 +8,11 @@ export async function nodeStreamToText(stream: Readable): Promise<string> {
   }
   return Buffer.concat(chunks).toString('utf-8');
 }
+
+export async function nodeStreamToBuffer(stream: Readable): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream as any) {
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}

--- a/packages/realm-server/tests/card-source-endpoints-test.ts
+++ b/packages/realm-server/tests/card-source-endpoints-test.ts
@@ -1063,6 +1063,188 @@ module(basename(__filename), function () {
         });
       });
     });
+
+    module('binary file POST request', function (_hooks) {
+      module('public writable realm', function (hooks) {
+        setupPermissionedRealmAtURL(hooks, realmURL, {
+          permissions: {
+            '*': ['read', 'write'],
+          },
+          onRealmSetup,
+        });
+
+        let { getMessagesSince } = setupMatrixRoom(hooks, getRealmSetup);
+
+        test('serves a binary file POST request', async function (assert) {
+          let bytes = new Uint8Array([
+            0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0xfe,
+          ]);
+          let response = await request
+            .post('/test-image.png')
+            .set('Content-Type', 'application/octet-stream')
+            .send(Buffer.from(bytes));
+
+          assert.strictEqual(response.status, 204, 'HTTP 204 status');
+          assert.ok(
+            response.headers['x-created'],
+            'created date should be set for new binary file',
+          );
+
+          let filePath = join(
+            dir.name,
+            'realm_server_1',
+            'test',
+            'test-image.png',
+          );
+          assert.ok(existsSync(filePath), 'binary file exists on disk');
+          let fileBytes = readFileSync(filePath);
+          assert.deepEqual(
+            new Uint8Array(fileBytes),
+            bytes,
+            'file bytes match uploaded bytes',
+          );
+        });
+
+        test('creates file metadata for binary upload', async function (assert) {
+          let bytes = new Uint8Array([0x00, 0x01, 0x02, 0x03]);
+          await request
+            .post('/meta-test.bin')
+            .set('Content-Type', 'application/octet-stream')
+            .send(Buffer.from(bytes));
+
+          let rows = await query(dbAdapter, [
+            'SELECT content_hash FROM realm_file_meta WHERE realm_url =',
+            param(testRealmHref),
+            'AND file_path =',
+            param('meta-test.bin'),
+          ]);
+          assert.strictEqual(rows.length, 1, 'file meta row exists');
+          assert.ok(rows[0].content_hash, 'content hash is set');
+        });
+
+        test('overwrites existing binary file', async function (assert) {
+          let bytes1 = new Uint8Array([0x01, 0x02, 0x03]);
+          let bytes2 = new Uint8Array([0x04, 0x05, 0x06]);
+
+          let response1 = await request
+            .post('/overwrite-test.bin')
+            .set('Content-Type', 'application/octet-stream')
+            .send(Buffer.from(bytes1));
+          assert.strictEqual(response1.status, 204, 'first upload returns 204');
+
+          let response2 = await request
+            .post('/overwrite-test.bin')
+            .set('Content-Type', 'application/octet-stream')
+            .send(Buffer.from(bytes2));
+          assert.strictEqual(
+            response2.status,
+            204,
+            'second upload returns 204',
+          );
+
+          let filePath = join(
+            dir.name,
+            'realm_server_1',
+            'test',
+            'overwrite-test.bin',
+          );
+          let fileBytes = readFileSync(filePath);
+          assert.deepEqual(
+            new Uint8Array(fileBytes),
+            bytes2,
+            'file contains second upload bytes',
+          );
+        });
+
+        test('broadcasts realm events for binary upload', async function (assert) {
+          let realmEventTimestampStart = Date.now();
+
+          await request
+            .post('/event-test.bin')
+            .set('Content-Type', 'application/octet-stream')
+            .send(Buffer.from(new Uint8Array([0xca, 0xfe])));
+
+          await expectIncrementalIndexEvent(
+            `${testRealmURL}event-test.bin`,
+            realmEventTimestampStart,
+            {
+              assert,
+              getMessagesSince,
+              realm: testRealmHref,
+            },
+          );
+        });
+      });
+
+      module(
+        'public writable realm with size limit for binary',
+        function (hooks) {
+          setupPermissionedRealmAtURL(hooks, realmURL, {
+            permissions: {
+              '*': ['read', 'write'],
+            },
+            cardSizeLimitBytes: 512,
+            onRealmSetup,
+          });
+
+          test('returns 413 when binary payload exceeds size limit', async function (assert) {
+            let oversized = new Uint8Array(2048).fill(0xff);
+            let response = await request
+              .post('/too-large.bin')
+              .set('Content-Type', 'application/octet-stream')
+              .send(Buffer.from(oversized));
+
+            assert.strictEqual(response.status, 413, 'HTTP 413 status');
+            assert.strictEqual(
+              response.body.errors[0].title,
+              'Payload Too Large',
+              'error title is correct',
+            );
+          });
+        },
+      );
+
+      module('permissioned realm for binary', function (hooks) {
+        setupPermissionedRealmAtURL(hooks, realmURL, {
+          permissions: {
+            john: ['read', 'write'],
+          },
+          onRealmSetup,
+        });
+
+        test('401 without a JWT for binary upload', async function (assert) {
+          let response = await request
+            .post('/secret.bin')
+            .set('Content-Type', 'application/octet-stream')
+            .send(Buffer.from(new Uint8Array([0x01])));
+
+          assert.strictEqual(response.status, 401, 'HTTP 401 status');
+        });
+
+        test('403 without permission for binary upload', async function (assert) {
+          let response = await request
+            .post('/secret.bin')
+            .set('Content-Type', 'application/octet-stream')
+            .send(Buffer.from(new Uint8Array([0x01])))
+            .set('Authorization', `Bearer ${createJWT(testRealm, 'not-john')}`);
+
+          assert.strictEqual(response.status, 403, 'HTTP 403 status');
+        });
+
+        test('204 with permission for binary upload', async function (assert) {
+          let response = await request
+            .post('/secret.bin')
+            .set('Content-Type', 'application/octet-stream')
+            .send(Buffer.from(new Uint8Array([0x01])))
+            .set(
+              'Authorization',
+              `Bearer ${createJWT(testRealm, 'john', ['read', 'write'])}`,
+            );
+
+          assert.strictEqual(response.status, 204, 'HTTP 204 status');
+        });
+      });
+    });
   });
 });
 

--- a/packages/realm-server/tests/helpers/indexing.ts
+++ b/packages/realm-server/tests/helpers/indexing.ts
@@ -32,7 +32,7 @@ export async function waitForIncrementalIndexEvent(
 }
 
 export async function expectIncrementalIndexEvent(
-  url: string, // <>.gts OR <>.json OR <>/
+  url: string, // <>.gts OR <>.json OR <>.* OR <>/
   since: number,
   opts: IncrementalIndexEventTestContext,
 ) {
@@ -41,8 +41,9 @@ export async function expectIncrementalIndexEvent(
   type = type ?? 'CardDef';
 
   let endsWithSlash = url.endsWith('/'); // new card def is being created
+  let hasExtension = /\.[^/]+$/.test(url);
 
-  if (!url.endsWith('.json') && !url.endsWith('.gts') && !endsWithSlash) {
+  if (!hasExtension && !endsWithSlash) {
     throw new Error('Invalid file path');
   }
   await waitForIncrementalIndexEvent(getMessagesSince, since);

--- a/packages/realm-server/tests/realm-endpoints/lint-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/lint-test.ts
@@ -537,8 +537,7 @@ export class MyCard extends CardDef {
       let responseJson = JSON.parse(response.text);
       let messages = responseJson.messages;
       let positionFixedWarning = messages.find(
-        (m: any) =>
-          m.ruleId === '@cardstack/boxel/no-css-position-fixed',
+        (m: any) => m.ruleId === '@cardstack/boxel/no-css-position-fixed',
       );
       assert.ok(
         positionFixedWarning,
@@ -578,8 +577,7 @@ export class MyCard extends CardDef {
       let responseJson = JSON.parse(response.text);
       let messages = responseJson.messages;
       let positionFixedWarning = messages.find(
-        (m: any) =>
-          m.ruleId === '@cardstack/boxel/no-css-position-fixed',
+        (m: any) => m.ruleId === '@cardstack/boxel/no-css-position-fixed',
       );
       assert.notOk(
         positionFixedWarning,

--- a/packages/realm-server/tests/realm-endpoints/lint-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/lint-test.ts
@@ -510,6 +510,83 @@ export class MyCard extends CardDef {
       );
     });
 
+    test('warns about position: fixed in card CSS', async function (assert) {
+      let response = await request
+        .post('/_lint')
+        .set(
+          'Authorization',
+          `Bearer ${createJWT(testRealm, 'john', ['read', 'write'])}`,
+        )
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', 'application/json')
+        .send(`import { CardDef } from 'https://cardstack.com/base/card-api';
+export class MyCard extends CardDef {
+}
+<template>
+  <div class="my-card">Hello</div>
+  <style scoped>
+    .my-card {
+      position: fixed;
+      top: 0;
+    }
+  </style>
+</template>
+`);
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      let responseJson = JSON.parse(response.text);
+      let messages = responseJson.messages;
+      let positionFixedWarning = messages.find(
+        (m: any) =>
+          m.ruleId === '@cardstack/boxel/no-css-position-fixed',
+      );
+      assert.ok(
+        positionFixedWarning,
+        'Should have a warning about position: fixed',
+      );
+      assert.strictEqual(
+        positionFixedWarning.severity,
+        1,
+        'Should be a warning (severity 1), not an error',
+      );
+    });
+
+    test('does not warn about position: fixed when not present', async function (assert) {
+      let response = await request
+        .post('/_lint')
+        .set(
+          'Authorization',
+          `Bearer ${createJWT(testRealm, 'john', ['read', 'write'])}`,
+        )
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', 'application/json')
+        .send(`import { CardDef } from 'https://cardstack.com/base/card-api';
+export class MyCard extends CardDef {
+}
+<template>
+  <div class="my-card">Hello</div>
+  <style scoped>
+    .my-card {
+      position: relative;
+      top: 0;
+    }
+  </style>
+</template>
+`);
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      let responseJson = JSON.parse(response.text);
+      let messages = responseJson.messages;
+      let positionFixedWarning = messages.find(
+        (m: any) =>
+          m.ruleId === '@cardstack/boxel/no-css-position-fixed',
+      );
+      assert.notOk(
+        positionFixedWarning,
+        'Should not warn when position: fixed is not used',
+      );
+    });
+
     test('handles nested template structures correctly', async function (assert) {
       let response = await request
         .post('/_lint')

--- a/packages/realm-server/tests/server-endpoints/index-responses-test.ts
+++ b/packages/realm-server/tests/server-endpoints/index-responses-test.ts
@@ -191,32 +191,6 @@ module(`server-endpoints/${basename(__filename)}`, function () {
         );
       });
 
-      test('prefers non-null head and isolated HTML when matches are present', async function (assert) {
-        let cardURL = new URL('head-isolated-candidate', testRealm2URL);
-        let aliasOnlyURL = new URL('alias-only-candidate', testRealm2URL);
-
-        await context.dbAdapter.execute(
-          `INSERT INTO boxel_index_working (url, file_alias, type, realm_version, realm_url, head_html, isolated_html)
-           VALUES
-           ('${cardURL.href}', '${cardURL.href}', 'instance', 1, '${testRealm2URL.href}', '<meta data-test-head-html content="from-db" />', '<div data-test-isolated-html>Injected isolated</div>'),
-           ('${aliasOnlyURL.href}', '${cardURL.href}', 'instance', 2, '${testRealm2URL.href}', NULL, NULL)`,
-        );
-
-        let response = await context.request2
-          .get('/test/head-isolated-candidate')
-          .set('Accept', 'text/html');
-
-        assert.strictEqual(response.status, 200, 'serves HTML response');
-        assert.ok(
-          response.text.includes('data-test-head-html'),
-          'head HTML is injected into the HTML response',
-        );
-        assert.ok(
-          response.text.includes('data-test-isolated-html'),
-          'isolated HTML is injected into the HTML response',
-        );
-      });
-
       test('serves isolated HTML for /subdirectory/index.json at /subdirectory/', async function (assert) {
         let response = await context.request2
           .get('/test/subdirectory/')

--- a/packages/runtime-common/constants.ts
+++ b/packages/runtime-common/constants.ts
@@ -86,4 +86,45 @@ export const DEFAULT_PERMISSIONS = Object.freeze([
   'realm-owner',
 ]) as RealmPermissions['user'];
 
+// Workaround to override published realm URLs to support custom domains. Remove in CS-9061.
+export const PUBLISHED_REALM_DOMAIN_OVERRIDES: Record<string, string> = {};
+
+export function parsePublishedRealmDomainOverrides(
+  rawOverrides: string | undefined,
+): Record<string, string> {
+  if (!rawOverrides) {
+    return {};
+  }
+
+  try {
+    let parsed = JSON.parse(rawOverrides);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {};
+    }
+
+    let overrides: Record<string, string> = {};
+    for (let [key, value] of Object.entries(parsed)) {
+      if (typeof key === 'string' && typeof value === 'string') {
+        overrides[key] = value;
+      }
+    }
+    return overrides;
+  } catch {
+    return {};
+  }
+}
+
+export function getPublishedRealmDomainOverrides(
+  rawOverrides?: string | Record<string, string>,
+): Record<string, string> {
+  let envOverrides =
+    typeof rawOverrides === 'string'
+      ? parsePublishedRealmDomainOverrides(rawOverrides)
+      : (rawOverrides ?? {});
+  return {
+    ...PUBLISHED_REALM_DOMAIN_OVERRIDES,
+    ...envOverrides,
+  };
+}
+
 export const PUBLISHED_DIRECTORY_NAME = '_published';

--- a/packages/runtime-common/tasks/lint.ts
+++ b/packages/runtime-common/tasks/lint.ts
@@ -78,6 +78,7 @@ async function lintFix({
       },
     ],
     '@cardstack/boxel/no-duplicate-imports': 'error',
+    '@cardstack/boxel/no-css-position-fixed': 'warn',
   };
 
   const eslintJsModule = await import(/* webpackIgnore: true */ '@eslint/js');

--- a/packages/runtime-common/write-size-validation.ts
+++ b/packages/runtime-common/write-size-validation.ts
@@ -1,11 +1,14 @@
 const textEncoder = new TextEncoder();
 
 export function validateWriteSize(
-  content: string,
+  content: string | Uint8Array,
   maxSizeBytes: number,
   type: 'card' | 'file',
 ): void {
-  const actualSize = textEncoder.encode(content).length;
+  const actualSize =
+    content instanceof Uint8Array
+      ? content.length
+      : textEncoder.encode(content).length;
   if (actualSize > maxSizeBytes) {
     throw new Error(
       `${type === 'card' ? 'Card' : 'File'} size (${actualSize} bytes) exceeds maximum allowed size (${maxSizeBytes} bytes)`,


### PR DESCRIPTION
## Summary

- Add a `POST` route for `application/octet-stream` that accepts binary uploads (images, etc.) and writes them through the existing `Realm.write()` pipeline
- Widen write signatures across `RealmAdapter`, `NodeAdapter`, `TestRealmAdapter`, and `Realm` to accept `string | Uint8Array`
- Widen `validateWriteSize()` to handle `Uint8Array` directly
- Add `typeof content === 'string'` guards in `_batchWrite()` so JSON parsing and card document detection are skipped for binary content
- Same size limit (512KB default) and response shape (204, `last-modified`, `x-created`) as `upsertCardSource`

Closes CS-10076

## Test plan

- [x] New binary upload tests: basic upload, file metadata, overwrite, realm events, size limit (413), permissions (401/403/204)
- [x] Existing card-source endpoint tests pass without regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)