### PR TITLE
Prevent forbidden tags in head html template

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -498,6 +498,7 @@ jobs:
             "realm-endpoints/search-test.ts",
             "realm-endpoints/user-test.ts",
             "realm-endpoints-test.ts",
+            "sanitize-head-html-test.ts",
             "search-prerendered-test.ts",
             "types-endpoint-test.ts",
             "server-endpoints/authentication-test.ts",

--- a/packages/eslint-plugin-boxel/lib/rules/no-forbidden-head-tags.js
+++ b/packages/eslint-plugin-boxel/lib/rules/no-forbidden-head-tags.js
@@ -1,0 +1,45 @@
+const ALLOWED_HEAD_TAGS = new Set(['title', 'meta', 'link', 'template']);
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'disallow forbidden HTML elements in `static head` templates — only `<title>`, `<meta>`, and `<link>` are permitted',
+      category: 'Ember Octane',
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      'no-forbidden-head-tags':
+        '`<{{ tag }}>` is not allowed in a head template. Only `<title>`, `<meta>`, and `<link>` are permitted. Disallowed tags will be stripped when rendering.',
+    },
+  },
+
+  create(context) {
+    let insideHeadTemplate = false;
+
+    return {
+      'PropertyDefinition[static=true][key.name="head"]'() {
+        insideHeadTemplate = true;
+      },
+      'PropertyDefinition[static=true][key.name="head"]:exit'() {
+        insideHeadTemplate = false;
+      },
+      GlimmerElementNode(node) {
+        if (!insideHeadTemplate) {
+          return;
+        }
+        let tag = node.tag;
+        if (!ALLOWED_HEAD_TAGS.has(tag)) {
+          context.report({
+            node,
+            messageId: 'no-forbidden-head-tags',
+            data: { tag },
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-boxel/tests/lib/rules/no-forbidden-head-tags-test.js
+++ b/packages/eslint-plugin-boxel/tests/lib/rules/no-forbidden-head-tags-test.js
@@ -1,0 +1,125 @@
+const rule = require('../../../lib/rules/no-forbidden-head-tags');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('ember-eslint-parser'),
+  parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+});
+
+ruleTester.run('no-forbidden-head-tags', rule, {
+  valid: [
+    // Allowed tags in static head
+    `
+      class MyCard {
+        static head = class Head {
+          <template>
+            <title>My Title</title>
+            <meta name="description" content="desc" />
+            <link rel="canonical" href="/" />
+          </template>
+        };
+      }
+    `,
+    // Script and style outside of static head are fine
+    `
+      <template>
+        <div>Hello</div>
+        <style scoped>.card { color: red }</style>
+      </template>
+    `,
+    // Non-head static property is fine
+    `
+      class MyCard {
+        static isolated = class Isolated {
+          <template>
+            <div>Hello</div>
+            <style scoped>.card { color: red }</style>
+          </template>
+        };
+      }
+    `,
+  ],
+
+  invalid: [
+    // Script in static head
+    {
+      code: `
+        class MyCard {
+          static head = class Head {
+            <template>
+              <title>Test</title>
+              <script>void 0</script>
+            </template>
+          };
+        }
+      `,
+      errors: [
+        {
+          messageId: 'no-forbidden-head-tags',
+          data: { tag: 'script' },
+        },
+      ],
+    },
+    // Style in static head
+    {
+      code: `
+        class MyCard {
+          static head = class Head {
+            <template>
+              <title>Test</title>
+              <style>.injected { color: red }</style>
+            </template>
+          };
+        }
+      `,
+      errors: [
+        {
+          messageId: 'no-forbidden-head-tags',
+          data: { tag: 'style' },
+        },
+      ],
+    },
+    // Multiple disallowed tags
+    {
+      code: `
+        class MyCard {
+          static head = class Head {
+            <template>
+              <title>Test</title>
+              <script>void 0</script>
+              <style>.x { color: red }</style>
+            </template>
+          };
+        }
+      `,
+      errors: [
+        {
+          messageId: 'no-forbidden-head-tags',
+          data: { tag: 'script' },
+        },
+        {
+          messageId: 'no-forbidden-head-tags',
+          data: { tag: 'style' },
+        },
+      ],
+    },
+    // Div in static head
+    {
+      code: `
+        class MyCard {
+          static head = class Head {
+            <template>
+              <div>bad</div>
+            </template>
+          };
+        }
+      `,
+      errors: [
+        {
+          messageId: 'no-forbidden-head-tags',
+          data: { tag: 'div' },
+        },
+      ],
+    },
+  ],
+});

--- a/packages/host/tests/acceptance/code-submode/head-format-preview-test.ts
+++ b/packages/host/tests/acceptance/code-submode/head-format-preview-test.ts
@@ -97,6 +97,7 @@ module('Acceptance | code submode | head format preview', function (hooks) {
       contents: {
         ...SYSTEM_CARD_FIXTURE_CONTENTS,
         'head-preview.gts': headPreviewCardSource,
+        'head-preview-unsafe.gts': headPreviewWithDisallowedTagsSource,
         'HeadPreview/example.json': {
           data: {
             type: 'card',
@@ -108,6 +109,20 @@ module('Acceptance | code submode | head format preview', function (hooks) {
               adoptsFrom: {
                 module: `${testRealmURL}head-preview`,
                 name: 'HeadPreview',
+              },
+            },
+          },
+        },
+        'HeadPreviewUnsafe/example.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              title: 'Unsafe Card',
+            },
+            meta: {
+              adoptsFrom: {
+                module: `${testRealmURL}head-preview-unsafe`,
+                name: 'HeadPreviewUnsafe',
               },
             },
           },
@@ -163,28 +178,6 @@ module('Acceptance | code submode | head format preview', function (hooks) {
       RecentFiles,
       JSON.stringify([[testRealmURL, 'HeadPreviewUnsafe/example.json']]),
     );
-
-    await setupAcceptanceTestRealm({
-      mockMatrixUtils,
-      contents: {
-        ...SYSTEM_CARD_FIXTURE_CONTENTS,
-        'head-preview-unsafe.gts': headPreviewWithDisallowedTagsSource,
-        'HeadPreviewUnsafe/example.json': {
-          data: {
-            type: 'card',
-            attributes: {
-              title: 'Unsafe Card',
-            },
-            meta: {
-              adoptsFrom: {
-                module: `${testRealmURL}head-preview-unsafe`,
-                name: 'HeadPreviewUnsafe',
-              },
-            },
-          },
-        },
-      },
-    });
 
     await visitOperatorMode({
       stacks: [

--- a/packages/host/tests/acceptance/code-submode/head-format-preview-test.ts
+++ b/packages/host/tests/acceptance/code-submode/head-format-preview-test.ts
@@ -199,10 +199,7 @@ module('Acceptance | code submode | head format preview', function (hooks) {
       .exists('warning is shown for disallowed tags');
     assert
       .dom('[data-test-head-warning]')
-      .includesText(
-        'Disallowed tags detected',
-        'warning message is displayed',
-      );
+      .includesText('Disallowed tags detected', 'warning message is displayed');
   });
 
   test('does not show warning when head template only has allowed tags', async function (assert) {

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -67,6 +67,8 @@ import {
   injectIsolatedHTML,
   ensureSingleTitle,
 } from './lib/index-html-injection';
+import { sanitizeHeadHTMLToString } from '@cardstack/runtime-common';
+import { JSDOM } from 'jsdom';
 
 export class RealmServer {
   private log = logger('realm-server');
@@ -410,6 +412,16 @@ export class RealmServer {
         log: this.scopedCSSLog,
       }),
     ]);
+
+    if (headHTML != null) {
+      let doc = new JSDOM().window.document;
+      let sanitized = sanitizeHeadHTMLToString(headHTML, doc);
+      if (sanitized !== null) {
+        headHTML = sanitized;
+      } else {
+        headHTML = null;
+      }
+    }
 
     if (headHTML != null) {
       this.headLog.debug(

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -171,3 +171,4 @@ import './delete-boxel-claimed-domain-test';
 import './realm-auth-test';
 import './queries-test';
 import './remote-prerenderer-test';
+import './sanitize-head-html-test';

--- a/packages/realm-server/tests/sanitize-head-html-test.ts
+++ b/packages/realm-server/tests/sanitize-head-html-test.ts
@@ -1,0 +1,303 @@
+import { module, test } from 'qunit';
+import { basename } from 'path';
+import { JSDOM } from 'jsdom';
+import {
+  sanitizeHeadHTML,
+  sanitizeHeadHTMLToString,
+  findDisallowedHeadTags,
+} from '@cardstack/runtime-common';
+
+function makeDoc() {
+  return new JSDOM().window.document;
+}
+
+module(basename(__filename), function () {
+  module('sanitizeHeadHTML', function () {
+    test('allows title, meta, and link tags', function (assert) {
+      let doc = makeDoc();
+      let html =
+        '<title>Test</title><meta name="description" content="desc"><link rel="canonical" href="https://example.com">';
+      let fragment = sanitizeHeadHTML(html, doc);
+      assert.ok(fragment, 'returns a fragment');
+      let container = doc.createElement('div');
+      container.appendChild(fragment!);
+      assert.ok(
+        container.querySelector('title'),
+        'title tag is preserved',
+      );
+      assert.ok(
+        container.querySelector('meta[name="description"]'),
+        'meta tag is preserved',
+      );
+      assert.ok(
+        container.querySelector('link[rel="canonical"]'),
+        'link tag is preserved',
+      );
+    });
+
+    test('strips script tags', function (assert) {
+      let doc = makeDoc();
+      let html =
+        '<title>Test</title><script>alert("xss")</script><meta name="description" content="desc">';
+      let fragment = sanitizeHeadHTML(html, doc);
+      assert.ok(fragment, 'returns a fragment');
+      let container = doc.createElement('div');
+      container.appendChild(fragment!);
+      assert.ok(container.querySelector('title'), 'title is preserved');
+      assert.ok(
+        container.querySelector('meta'),
+        'meta is preserved',
+      );
+      assert.notOk(
+        container.querySelector('script'),
+        'script tag is stripped',
+      );
+    });
+
+    test('strips style tags', function (assert) {
+      let doc = makeDoc();
+      let html =
+        '<title>Test</title><style>body { display: none }</style>';
+      let fragment = sanitizeHeadHTML(html, doc);
+      assert.ok(fragment, 'returns a fragment');
+      let container = doc.createElement('div');
+      container.appendChild(fragment!);
+      assert.ok(container.querySelector('title'), 'title is preserved');
+      assert.notOk(
+        container.querySelector('style'),
+        'style tag is stripped',
+      );
+    });
+
+    test('strips noscript tags', function (assert) {
+      let doc = makeDoc();
+      let html =
+        '<title>Test</title><noscript><p>No JS</p></noscript>';
+      let fragment = sanitizeHeadHTML(html, doc);
+      assert.ok(fragment, 'returns a fragment');
+      let container = doc.createElement('div');
+      container.appendChild(fragment!);
+      assert.ok(container.querySelector('title'), 'title is preserved');
+      assert.notOk(
+        container.querySelector('noscript'),
+        'noscript tag is stripped',
+      );
+    });
+
+    test('strips base tags', function (assert) {
+      let doc = makeDoc();
+      let html =
+        '<title>Test</title><base href="https://evil.com">';
+      let fragment = sanitizeHeadHTML(html, doc);
+      assert.ok(fragment, 'returns a fragment');
+      let container = doc.createElement('div');
+      container.appendChild(fragment!);
+      assert.ok(container.querySelector('title'), 'title is preserved');
+      assert.notOk(
+        container.querySelector('base'),
+        'base tag is stripped',
+      );
+    });
+
+    test('strips arbitrary HTML tags like div, h1, p', function (assert) {
+      let doc = makeDoc();
+      let html =
+        '<title>Test</title><div>bad</div><h1>heading</h1><p>paragraph</p>';
+      let fragment = sanitizeHeadHTML(html, doc);
+      assert.ok(fragment, 'returns a fragment');
+      let container = doc.createElement('div');
+      container.appendChild(fragment!);
+      assert.ok(container.querySelector('title'), 'title is preserved');
+      assert.notOk(container.querySelector('div'), 'div is stripped');
+      assert.notOk(container.querySelector('h1'), 'h1 is stripped');
+      assert.notOk(container.querySelector('p'), 'p is stripped');
+    });
+
+    test('returns null when all content is disallowed', function (assert) {
+      let doc = makeDoc();
+      let html = '<script>alert("xss")</script><style>body{}</style>';
+      let fragment = sanitizeHeadHTML(html, doc);
+      assert.strictEqual(fragment, null, 'returns null');
+    });
+
+    test('returns null for empty string', function (assert) {
+      let doc = makeDoc();
+      let fragment = sanitizeHeadHTML('', doc);
+      assert.strictEqual(fragment, null, 'returns null for empty string');
+    });
+
+    test('strips disallowed attributes from meta tags', function (assert) {
+      let doc = makeDoc();
+      let html =
+        '<meta name="description" content="test" onclick="alert(1)" data-custom="bad">';
+      let fragment = sanitizeHeadHTML(html, doc);
+      assert.ok(fragment, 'returns a fragment');
+      let container = doc.createElement('div');
+      container.appendChild(fragment!);
+      let meta = container.querySelector('meta');
+      assert.ok(meta, 'meta tag is preserved');
+      assert.strictEqual(
+        meta!.getAttribute('name'),
+        'description',
+        'allowed attr preserved',
+      );
+      assert.strictEqual(
+        meta!.getAttribute('content'),
+        'test',
+        'allowed attr preserved',
+      );
+      assert.notOk(
+        meta!.hasAttribute('onclick'),
+        'onclick is stripped',
+      );
+      assert.notOk(
+        meta!.hasAttribute('data-custom'),
+        'data-custom is stripped',
+      );
+    });
+
+    test('strips link tags with unsafe rel values', function (assert) {
+      let doc = makeDoc();
+      let html =
+        '<link rel="stylesheet" href="https://evil.com/style.css"><link rel="canonical" href="https://example.com">';
+      let fragment = sanitizeHeadHTML(html, doc);
+      assert.ok(fragment, 'returns a fragment');
+      let container = doc.createElement('div');
+      container.appendChild(fragment!);
+      let links = container.querySelectorAll('link');
+      assert.strictEqual(links.length, 1, 'only one link tag remains');
+      assert.strictEqual(
+        links[0].getAttribute('rel'),
+        'canonical',
+        'safe link is preserved',
+      );
+    });
+
+    test('strips link tags with javascript: href', function (assert) {
+      let doc = makeDoc();
+      let html = '<link rel="icon" href="javascript:alert(1)">';
+      let fragment = sanitizeHeadHTML(html, doc);
+      assert.strictEqual(
+        fragment,
+        null,
+        'returns null when link has unsafe href',
+      );
+    });
+  });
+
+  module('sanitizeHeadHTMLToString', function () {
+    test('returns sanitized HTML as a string', function (assert) {
+      let doc = makeDoc();
+      let html =
+        '<title>Test</title><script>alert("xss")</script><meta name="description" content="desc">';
+      let result = sanitizeHeadHTMLToString(html, doc);
+      assert.ok(result, 'returns a string');
+      assert.ok(result!.includes('<title>'), 'title is in output');
+      assert.ok(
+        result!.includes('<meta'),
+        'meta is in output',
+      );
+      assert.notOk(
+        result!.includes('<script'),
+        'script is not in output',
+      );
+      assert.notOk(
+        result!.includes('alert'),
+        'script content is not in output',
+      );
+    });
+
+    test('returns null when all content is disallowed', function (assert) {
+      let doc = makeDoc();
+      let result = sanitizeHeadHTMLToString(
+        '<script>alert(1)</script>',
+        doc,
+      );
+      assert.strictEqual(result, null, 'returns null');
+    });
+
+    test('returns null for empty string', function (assert) {
+      let doc = makeDoc();
+      let result = sanitizeHeadHTMLToString('', doc);
+      assert.strictEqual(result, null, 'returns null');
+    });
+  });
+
+  module('findDisallowedHeadTags', function () {
+    test('returns empty array for valid content', function (assert) {
+      let doc = makeDoc();
+      let html =
+        '<title>Test</title><meta name="description" content="desc"><link rel="canonical" href="https://example.com">';
+      let result = findDisallowedHeadTags(html, doc);
+      assert.deepEqual(result, [], 'no disallowed tags');
+    });
+
+    test('detects script tags', function (assert) {
+      let doc = makeDoc();
+      let html =
+        '<title>Test</title><script>alert(1)</script>';
+      let result = findDisallowedHeadTags(html, doc);
+      assert.deepEqual(result, ['script'], 'detects script');
+    });
+
+    test('detects style tags', function (assert) {
+      let doc = makeDoc();
+      let html = '<title>Test</title><style>body{}</style>';
+      let result = findDisallowedHeadTags(html, doc);
+      assert.deepEqual(result, ['style'], 'detects style');
+    });
+
+    test('detects noscript tags', function (assert) {
+      let doc = makeDoc();
+      let html =
+        '<title>Test</title><noscript>fallback</noscript>';
+      let result = findDisallowedHeadTags(html, doc);
+      assert.deepEqual(result, ['noscript'], 'detects noscript');
+    });
+
+    test('detects base tags', function (assert) {
+      let doc = makeDoc();
+      let html =
+        '<title>Test</title><base href="https://evil.com">';
+      let result = findDisallowedHeadTags(html, doc);
+      assert.deepEqual(result, ['base'], 'detects base');
+    });
+
+    test('detects multiple disallowed tag types', function (assert) {
+      let doc = makeDoc();
+      let html =
+        '<script>x</script><style>y</style><noscript>z</noscript><base href="/">';
+      let result = findDisallowedHeadTags(html, doc);
+      assert.ok(result.includes('script'), 'detects script');
+      assert.ok(result.includes('style'), 'detects style');
+      assert.ok(result.includes('noscript'), 'detects noscript');
+      assert.ok(result.includes('base'), 'detects base');
+    });
+
+    test('deduplicates repeated disallowed tags', function (assert) {
+      let doc = makeDoc();
+      let html =
+        '<script>a</script><script>b</script><script>c</script>';
+      let result = findDisallowedHeadTags(html, doc);
+      assert.deepEqual(
+        result,
+        ['script'],
+        'script appears only once',
+      );
+    });
+
+    test('returns empty array for empty string', function (assert) {
+      let doc = makeDoc();
+      let result = findDisallowedHeadTags('', doc);
+      assert.deepEqual(result, [], 'empty array for empty input');
+    });
+
+    test('detects arbitrary HTML elements', function (assert) {
+      let doc = makeDoc();
+      let html = '<div>bad</div><h1>heading</h1>';
+      let result = findDisallowedHeadTags(html, doc);
+      assert.ok(result.includes('div'), 'detects div');
+      assert.ok(result.includes('h1'), 'detects h1');
+    });
+  });
+});

--- a/packages/realm-server/tests/sanitize-head-html-test.ts
+++ b/packages/realm-server/tests/sanitize-head-html-test.ts
@@ -21,10 +21,7 @@ module(basename(__filename), function () {
       assert.ok(fragment, 'returns a fragment');
       let container = doc.createElement('div');
       container.appendChild(fragment!);
-      assert.ok(
-        container.querySelector('title'),
-        'title tag is preserved',
-      );
+      assert.ok(container.querySelector('title'), 'title tag is preserved');
       assert.ok(
         container.querySelector('meta[name="description"]'),
         'meta tag is preserved',
@@ -44,35 +41,24 @@ module(basename(__filename), function () {
       let container = doc.createElement('div');
       container.appendChild(fragment!);
       assert.ok(container.querySelector('title'), 'title is preserved');
-      assert.ok(
-        container.querySelector('meta'),
-        'meta is preserved',
-      );
-      assert.notOk(
-        container.querySelector('script'),
-        'script tag is stripped',
-      );
+      assert.ok(container.querySelector('meta'), 'meta is preserved');
+      assert.notOk(container.querySelector('script'), 'script tag is stripped');
     });
 
     test('strips style tags', function (assert) {
       let doc = makeDoc();
-      let html =
-        '<title>Test</title><style>body { display: none }</style>';
+      let html = '<title>Test</title><style>body { display: none }</style>';
       let fragment = sanitizeHeadHTML(html, doc);
       assert.ok(fragment, 'returns a fragment');
       let container = doc.createElement('div');
       container.appendChild(fragment!);
       assert.ok(container.querySelector('title'), 'title is preserved');
-      assert.notOk(
-        container.querySelector('style'),
-        'style tag is stripped',
-      );
+      assert.notOk(container.querySelector('style'), 'style tag is stripped');
     });
 
     test('strips noscript tags', function (assert) {
       let doc = makeDoc();
-      let html =
-        '<title>Test</title><noscript><p>No JS</p></noscript>';
+      let html = '<title>Test</title><noscript><p>No JS</p></noscript>';
       let fragment = sanitizeHeadHTML(html, doc);
       assert.ok(fragment, 'returns a fragment');
       let container = doc.createElement('div');
@@ -86,17 +72,13 @@ module(basename(__filename), function () {
 
     test('strips base tags', function (assert) {
       let doc = makeDoc();
-      let html =
-        '<title>Test</title><base href="https://evil.com">';
+      let html = '<title>Test</title><base href="https://evil.com">';
       let fragment = sanitizeHeadHTML(html, doc);
       assert.ok(fragment, 'returns a fragment');
       let container = doc.createElement('div');
       container.appendChild(fragment!);
       assert.ok(container.querySelector('title'), 'title is preserved');
-      assert.notOk(
-        container.querySelector('base'),
-        'base tag is stripped',
-      );
+      assert.notOk(container.querySelector('base'), 'base tag is stripped');
     });
 
     test('strips arbitrary HTML tags like div, h1, p', function (assert) {
@@ -146,10 +128,7 @@ module(basename(__filename), function () {
         'test',
         'allowed attr preserved',
       );
-      assert.notOk(
-        meta!.hasAttribute('onclick'),
-        'onclick is stripped',
-      );
+      assert.notOk(meta!.hasAttribute('onclick'), 'onclick is stripped');
       assert.notOk(
         meta!.hasAttribute('data-custom'),
         'data-custom is stripped',
@@ -193,14 +172,8 @@ module(basename(__filename), function () {
       let result = sanitizeHeadHTMLToString(html, doc);
       assert.ok(result, 'returns a string');
       assert.ok(result!.includes('<title>'), 'title is in output');
-      assert.ok(
-        result!.includes('<meta'),
-        'meta is in output',
-      );
-      assert.notOk(
-        result!.includes('<script'),
-        'script is not in output',
-      );
+      assert.ok(result!.includes('<meta'), 'meta is in output');
+      assert.notOk(result!.includes('<script'), 'script is not in output');
       assert.notOk(
         result!.includes('alert'),
         'script content is not in output',
@@ -209,10 +182,7 @@ module(basename(__filename), function () {
 
     test('returns null when all content is disallowed', function (assert) {
       let doc = makeDoc();
-      let result = sanitizeHeadHTMLToString(
-        '<script>alert(1)</script>',
-        doc,
-      );
+      let result = sanitizeHeadHTMLToString('<script>alert(1)</script>', doc);
       assert.strictEqual(result, null, 'returns null');
     });
 
@@ -234,8 +204,7 @@ module(basename(__filename), function () {
 
     test('detects script tags', function (assert) {
       let doc = makeDoc();
-      let html =
-        '<title>Test</title><script>alert(1)</script>';
+      let html = '<title>Test</title><script>alert(1)</script>';
       let result = findDisallowedHeadTags(html, doc);
       assert.deepEqual(result, ['script'], 'detects script');
     });
@@ -249,16 +218,14 @@ module(basename(__filename), function () {
 
     test('detects noscript tags', function (assert) {
       let doc = makeDoc();
-      let html =
-        '<title>Test</title><noscript>fallback</noscript>';
+      let html = '<title>Test</title><noscript>fallback</noscript>';
       let result = findDisallowedHeadTags(html, doc);
       assert.deepEqual(result, ['noscript'], 'detects noscript');
     });
 
     test('detects base tags', function (assert) {
       let doc = makeDoc();
-      let html =
-        '<title>Test</title><base href="https://evil.com">';
+      let html = '<title>Test</title><base href="https://evil.com">';
       let result = findDisallowedHeadTags(html, doc);
       assert.deepEqual(result, ['base'], 'detects base');
     });
@@ -276,14 +243,9 @@ module(basename(__filename), function () {
 
     test('deduplicates repeated disallowed tags', function (assert) {
       let doc = makeDoc();
-      let html =
-        '<script>a</script><script>b</script><script>c</script>';
+      let html = '<script>a</script><script>b</script><script>c</script>';
       let result = findDisallowedHeadTags(html, doc);
-      assert.deepEqual(
-        result,
-        ['script'],
-        'script appears only once',
-      );
+      assert.deepEqual(result, ['script'], 'script appears only once');
     });
 
     test('returns empty array for empty string', function (assert) {

--- a/packages/realm-server/tests/sanitize-head-html-test.ts
+++ b/packages/realm-server/tests/sanitize-head-html-test.ts
@@ -32,68 +32,28 @@ module(basename(__filename), function () {
       );
     });
 
-    test('strips script tags', function (assert) {
-      let doc = makeDoc();
-      let html =
-        '<title>Test</title><script>alert("xss")</script><meta name="description" content="desc">';
-      let fragment = sanitizeHeadHTML(html, doc);
-      assert.ok(fragment, 'returns a fragment');
-      let container = doc.createElement('div');
-      container.appendChild(fragment!);
-      assert.ok(container.querySelector('title'), 'title is preserved');
-      assert.ok(container.querySelector('meta'), 'meta is preserved');
-      assert.notOk(container.querySelector('script'), 'script tag is stripped');
-    });
+    const strippedTags: { tag: string; html: string }[] = [
+      { tag: 'script', html: '<script>alert("xss")</script>' },
+      { tag: 'style', html: '<style>body { display: none }</style>' },
+      { tag: 'noscript', html: '<noscript><p>No JS</p></noscript>' },
+      { tag: 'base', html: '<base href="https://evil.com">' },
+      { tag: 'div', html: '<div>bad</div>' },
+      { tag: 'h1', html: '<h1>heading</h1>' },
+      { tag: 'p', html: '<p>paragraph</p>' },
+    ];
 
-    test('strips style tags', function (assert) {
-      let doc = makeDoc();
-      let html = '<title>Test</title><style>body { display: none }</style>';
-      let fragment = sanitizeHeadHTML(html, doc);
-      assert.ok(fragment, 'returns a fragment');
-      let container = doc.createElement('div');
-      container.appendChild(fragment!);
-      assert.ok(container.querySelector('title'), 'title is preserved');
-      assert.notOk(container.querySelector('style'), 'style tag is stripped');
-    });
-
-    test('strips noscript tags', function (assert) {
-      let doc = makeDoc();
-      let html = '<title>Test</title><noscript><p>No JS</p></noscript>';
-      let fragment = sanitizeHeadHTML(html, doc);
-      assert.ok(fragment, 'returns a fragment');
-      let container = doc.createElement('div');
-      container.appendChild(fragment!);
-      assert.ok(container.querySelector('title'), 'title is preserved');
-      assert.notOk(
-        container.querySelector('noscript'),
-        'noscript tag is stripped',
-      );
-    });
-
-    test('strips base tags', function (assert) {
-      let doc = makeDoc();
-      let html = '<title>Test</title><base href="https://evil.com">';
-      let fragment = sanitizeHeadHTML(html, doc);
-      assert.ok(fragment, 'returns a fragment');
-      let container = doc.createElement('div');
-      container.appendChild(fragment!);
-      assert.ok(container.querySelector('title'), 'title is preserved');
-      assert.notOk(container.querySelector('base'), 'base tag is stripped');
-    });
-
-    test('strips arbitrary HTML tags like div, h1, p', function (assert) {
-      let doc = makeDoc();
-      let html =
-        '<title>Test</title><div>bad</div><h1>heading</h1><p>paragraph</p>';
-      let fragment = sanitizeHeadHTML(html, doc);
-      assert.ok(fragment, 'returns a fragment');
-      let container = doc.createElement('div');
-      container.appendChild(fragment!);
-      assert.ok(container.querySelector('title'), 'title is preserved');
-      assert.notOk(container.querySelector('div'), 'div is stripped');
-      assert.notOk(container.querySelector('h1'), 'h1 is stripped');
-      assert.notOk(container.querySelector('p'), 'p is stripped');
-    });
+    for (let { tag, html: disallowedHtml } of strippedTags) {
+      test(`strips ${tag} tags`, function (assert) {
+        let doc = makeDoc();
+        let html = `<title>Test</title>${disallowedHtml}`;
+        let fragment = sanitizeHeadHTML(html, doc);
+        assert.ok(fragment, 'returns a fragment');
+        let container = doc.createElement('div');
+        container.appendChild(fragment!);
+        assert.ok(container.querySelector('title'), 'title is preserved');
+        assert.notOk(container.querySelector(tag), `${tag} tag is stripped`);
+      });
+    }
 
     test('returns null when all content is disallowed', function (assert) {
       let doc = makeDoc();
@@ -202,33 +162,21 @@ module(basename(__filename), function () {
       assert.deepEqual(result, [], 'no disallowed tags');
     });
 
-    test('detects script tags', function (assert) {
-      let doc = makeDoc();
-      let html = '<title>Test</title><script>alert(1)</script>';
-      let result = findDisallowedHeadTags(html, doc);
-      assert.deepEqual(result, ['script'], 'detects script');
-    });
+    const detectedTags: { tag: string; html: string }[] = [
+      { tag: 'script', html: '<script>alert(1)</script>' },
+      { tag: 'style', html: '<style>body{}</style>' },
+      { tag: 'noscript', html: '<noscript>fallback</noscript>' },
+      { tag: 'base', html: '<base href="https://evil.com">' },
+    ];
 
-    test('detects style tags', function (assert) {
-      let doc = makeDoc();
-      let html = '<title>Test</title><style>body{}</style>';
-      let result = findDisallowedHeadTags(html, doc);
-      assert.deepEqual(result, ['style'], 'detects style');
-    });
-
-    test('detects noscript tags', function (assert) {
-      let doc = makeDoc();
-      let html = '<title>Test</title><noscript>fallback</noscript>';
-      let result = findDisallowedHeadTags(html, doc);
-      assert.deepEqual(result, ['noscript'], 'detects noscript');
-    });
-
-    test('detects base tags', function (assert) {
-      let doc = makeDoc();
-      let html = '<title>Test</title><base href="https://evil.com">';
-      let result = findDisallowedHeadTags(html, doc);
-      assert.deepEqual(result, ['base'], 'detects base');
-    });
+    for (let { tag, html: disallowedHtml } of detectedTags) {
+      test(`detects ${tag} tags`, function (assert) {
+        let doc = makeDoc();
+        let html = `<title>Test</title>${disallowedHtml}`;
+        let result = findDisallowedHeadTags(html, doc);
+        assert.deepEqual(result, [tag], `detects ${tag}`);
+      });
+    }
 
     test('detects multiple disallowed tag types', function (assert) {
       let doc = makeDoc();

--- a/packages/realm-server/tests/server-endpoints/index-responses-test.ts
+++ b/packages/realm-server/tests/server-endpoints/index-responses-test.ts
@@ -145,21 +145,18 @@ module(`server-endpoints/${basename(__filename)}`, function () {
             `,
           );
 
-          writeJSONSync(
-            join(context.testRealmDir, 'unsafe-head-test.json'),
-            {
-              data: {
-                type: 'card',
-                attributes: {},
-                meta: {
-                  adoptsFrom: {
-                    module: './unsafe-head-card.gts',
-                    name: 'UnsafeHeadCard',
-                  },
+          writeJSONSync(join(context.testRealmDir, 'unsafe-head-test.json'), {
+            data: {
+              type: 'card',
+              attributes: {},
+              meta: {
+                adoptsFrom: {
+                  module: './unsafe-head-card.gts',
+                  name: 'UnsafeHeadCard',
                 },
               },
             },
-          );
+          });
 
           writeFileSync(
             join(context.testRealmDir, 'scoped-css-card.gts'),

--- a/packages/runtime-common/helpers/sanitize-head-html.ts
+++ b/packages/runtime-common/helpers/sanitize-head-html.ts
@@ -1,0 +1,184 @@
+const ELEMENT_NODE = 1; // Node.ELEMENT_NODE - use constant to avoid reliance on global Node
+
+const ALLOWED_HEAD_TAGS = new Set(['meta', 'title', 'link']);
+const ALLOWED_META_ATTRS = new Set(['name', 'property', 'content']);
+const ALLOWED_TITLE_ATTRS = new Set<string>([]);
+const ALLOWED_LINK_ATTRS = new Set([
+  'rel',
+  'href',
+  'type',
+  'sizes',
+  'media',
+  'crossorigin',
+  'integrity',
+  'referrerpolicy',
+  'fetchpriority',
+]);
+const SAFE_LINK_REL_TOKENS = new Set([
+  'canonical',
+  'icon',
+  'shortcut',
+  'apple-touch-icon',
+  'mask-icon',
+  'manifest',
+]);
+
+export function sanitizeHeadHTML(
+  headHTML: string,
+  doc: Document,
+): DocumentFragment | null {
+  if (typeof headHTML !== 'string') {
+    return null;
+  }
+
+  let template = doc.createElement('template');
+  template.innerHTML = headHTML;
+
+  let fragment = doc.createDocumentFragment();
+  for (let node of Array.from(template.content.childNodes)) {
+    let sanitized = sanitizeHeadNode(node, doc);
+    if (sanitized) {
+      fragment.appendChild(sanitized);
+    }
+  }
+
+  return fragment.childNodes.length > 0 ? fragment : null;
+}
+
+// Reject any non-element nodes (text nodes, comments, document fragments, etc.)
+// so that only explicit, allowlisted <head> elements are inserted
+function sanitizeHeadNode(node: Node, doc: Document): Node | null {
+  if (node.nodeType !== ELEMENT_NODE) {
+    return null;
+  }
+
+  let element = node as Element;
+  let tagName = element.tagName.toLowerCase();
+  if (!ALLOWED_HEAD_TAGS.has(tagName)) {
+    return null;
+  }
+
+  switch (tagName) {
+    case 'meta':
+      return sanitizeMetaElement(element, doc);
+    case 'title':
+      return sanitizeTitleElement(element, doc);
+    case 'link':
+      return sanitizeLinkElement(element, doc);
+  }
+
+  return null;
+}
+
+function sanitizeMetaElement(element: Element, doc: Document): HTMLMetaElement {
+  let meta = doc.createElement('meta');
+  copyAllowedAttributes(element, meta, ALLOWED_META_ATTRS);
+  return meta;
+}
+
+function sanitizeTitleElement(
+  element: Element,
+  doc: Document,
+): HTMLTitleElement {
+  let title = doc.createElement('title');
+  copyAllowedAttributes(element, title, ALLOWED_TITLE_ATTRS);
+  title.textContent = element.textContent ?? '';
+  return title;
+}
+
+function sanitizeLinkElement(
+  element: Element,
+  doc: Document,
+): HTMLLinkElement | null {
+  let relValue = element.getAttribute('rel') ?? '';
+  if (!isSafeLinkRel(relValue)) {
+    return null;
+  }
+
+  let href = element.getAttribute('href');
+  if (href && !isSafeLinkHref(href, doc)) {
+    return null;
+  }
+
+  let link = doc.createElement('link');
+  copyAllowedAttributes(element, link, ALLOWED_LINK_ATTRS);
+  return link;
+}
+
+function isSafeLinkRel(relValue: string): boolean {
+  let tokens = relValue.toLowerCase().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) {
+    return false;
+  }
+  return tokens.every((token) => SAFE_LINK_REL_TOKENS.has(token));
+}
+
+function isSafeLinkHref(href: string, doc: Document): boolean {
+  let trimmed = href.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  try {
+    // Use doc.baseURI if available, otherwise use a dummy base for relative URL parsing
+    // In browser: doc.baseURI is the page URL
+    // In Node.js with JSDOM: doc.baseURI may be 'about:blank', so we use a dummy https base
+    let base = doc.baseURI;
+    if (!base || base === 'about:blank') {
+      base = 'https://example.com';
+    }
+    let url = new URL(trimmed, base);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+export function sanitizeHeadHTMLToString(
+  headHTML: string,
+  doc: Document,
+): string | null {
+  let fragment = sanitizeHeadHTML(headHTML, doc);
+  if (!fragment) {
+    return null;
+  }
+  let container = doc.createElement('div');
+  container.appendChild(fragment);
+  return container.innerHTML || null;
+}
+
+export function findDisallowedHeadTags(
+  headHTML: string,
+  doc: Document,
+): string[] {
+  if (typeof headHTML !== 'string') {
+    return [];
+  }
+
+  let template = doc.createElement('template');
+  template.innerHTML = headHTML;
+
+  let disallowed: string[] = [];
+  for (let node of Array.from(template.content.childNodes)) {
+    if (node.nodeType === ELEMENT_NODE) {
+      let tagName = (node as Element).tagName.toLowerCase();
+      if (!ALLOWED_HEAD_TAGS.has(tagName) && !disallowed.includes(tagName)) {
+        disallowed.push(tagName);
+      }
+    }
+  }
+  return disallowed;
+}
+
+function copyAllowedAttributes(
+  source: Element,
+  target: Element,
+  allowed: Set<string>,
+) {
+  for (let attribute of Array.from(source.attributes)) {
+    let name = attribute.name.toLowerCase();
+    if (allowed.has(name)) {
+      target.setAttribute(attribute.name, attribute.value);
+    }
+  }
+}

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -231,6 +231,11 @@ export {
   getFieldIcon,
 } from './helpers/card-type-display-name';
 export * from './helpers/ensure-extension';
+export {
+  sanitizeHeadHTML,
+  sanitizeHeadHTMLToString,
+  findDisallowedHeadTags,
+} from './helpers/sanitize-head-html';
 export * from './url';
 export * from './render-route-options';
 export * from './publishability';

--- a/packages/runtime-common/tasks/lint.ts
+++ b/packages/runtime-common/tasks/lint.ts
@@ -79,6 +79,7 @@ async function lintFix({
     ],
     '@cardstack/boxel/no-duplicate-imports': 'error',
     '@cardstack/boxel/no-css-position-fixed': 'warn',
+    '@cardstack/boxel/no-forbidden-head-tags': 'warn',
   };
 
   const eslintJsModule = await import(/* webpackIgnore: true */ '@eslint/js');


### PR DESCRIPTION
1. Do not allow forbidden tags in head templates, only allow `<titlte>`, `<link>`, `<meta>`, do not allow any other ones - strip them out when rendering
2. Show a warning if user saves a head template with forbidden elements (screenshot below)
3. Provide a lint rule so that the correctness checks catches the issue in case AI generates code that does not conform to the mentioned rule. The correctness check will automatically fix it

<img width="844" height="681" alt="image" src="https://github.com/user-attachments/assets/364026c8-96c6-48cc-8c01-a87428ca4015" />
