### PR TITLE
Fix: rounded corner mistmatch

### DIFF
--- a/packages/base/index.gts
+++ b/packages/base/index.gts
@@ -62,10 +62,10 @@ export class IndexCard extends CardDef {
           height: 100%;
           width: 100%;
         }
-        .home :deep(.field-component-card.isolated-format) {
+        .home > :deep(.field-component-card.isolated-format) {
           overflow: auto;
         }
-        .home :deep(.boxel-card-container) {
+        .home > :deep(.boxel-card-container) {
           border-radius: 0;
         }
       </style>


### PR DESCRIPTION
Before:

<img width="312" height="385" alt="Screenshot 2026-02-02 at 21 38 06" src="https://github.com/user-attachments/assets/a408c18e-d9c2-4e04-8fd7-dfbbfc459ae5" />


After:

<img width="362" height="399" alt="Screenshot 2026-02-02 at 21 37 52" src="https://github.com/user-attachments/assets/667286ba-e8f9-4c19-ab93-0b24a2d20cf9" />
