### PR TITLE
Add authenticated image display via read-only auth cookie

### DIFF
--- a/packages/host/app/services/realm-server.ts
+++ b/packages/host/app/services/realm-server.ts
@@ -212,6 +212,7 @@ export default class RealmServerService extends Service {
     await this.login();
     let response = await this.network.fetch(`${this.url.href}_realm-auth`, {
       method: 'POST',
+      credentials: 'include', // Store returned cookies for authenticated image loading
       headers: {
         Accept: SupportedMimeType.JSONAPI,
         'Content-Type': 'application/json',

--- a/packages/matrix/tests/messages.spec.ts
+++ b/packages/matrix/tests/messages.spec.ts
@@ -290,6 +290,10 @@ test.describe('Room messages', () => {
     await showAllCards(page);
     const testCard = `${appURL}/hassan`;
     await page.locator(`[data-test-cards-grid-item="${testCard}"]`).click();
+    // Wait for the card to be attached before switching to Code mode
+    await expect(
+      page.locator(`[data-test-attached-card="${appURL}/hassan"]`),
+    ).toHaveCount(1);
     await page
       .locator(`[data-test-submode-switcher] > [data-test-boxel-button]`)
       .click();
@@ -303,6 +307,10 @@ test.describe('Room messages', () => {
       page.locator(`[data-test-attached-file="${appURL}/hassan.json"]`),
     ).toHaveCount(1);
 
+    // Wait for the card type to load (renders the clickable definition container)
+    await expect(
+      page.locator(`[data-test-clickable-definition-container]`),
+    ).toBeVisible({ timeout: 30000 });
     await page.locator(`[data-test-clickable-definition-container]`).click();
     await expect(page.locator(`[data-test-attached-file]`)).toHaveCount(1);
     await expect(

--- a/packages/realm-server/middleware/cookie-auth.ts
+++ b/packages/realm-server/middleware/cookie-auth.ts
@@ -1,0 +1,43 @@
+import type { Context, Next } from 'koa';
+import { findAuthCookieForPath } from '../utils/auth-cookie';
+
+/**
+ * Middleware that converts auth cookies to Authorization headers
+ * ONLY for GET and HEAD requests (read-only operations)
+ *
+ * Security model:
+ * - Cookies work only for GET/HEAD operations (read-only)
+ * - Mutating requests (POST, PUT, DELETE, PATCH) must still use Authorization headers
+ * - This prevents CSRF attacks since browsers can't forge Authorization headers
+ * - HttpOnly cookies prevent XSS token theft
+ * - SameSite=Lax provides additional CSRF protection
+ */
+const cookieAuthMiddleware = async (
+  ctx: Context,
+  next: Next,
+): Promise<void> => {
+  // Only apply to GET and HEAD requests (read-only operations)
+  if (ctx.method !== 'GET' && ctx.method !== 'HEAD') {
+    await next();
+    return;
+  }
+
+  // Skip if Authorization header is already present
+  if (ctx.request.headers.authorization) {
+    await next();
+    return;
+  }
+
+  // Try to find an auth cookie that matches the request path
+  let cookieHeader = ctx.request.headers.cookie;
+  let token = findAuthCookieForPath(cookieHeader, ctx.request.path);
+
+  if (token) {
+    // Inject the token as an Authorization header for downstream middleware
+    ctx.request.headers.authorization = `Bearer ${token}`;
+  }
+
+  await next();
+};
+
+export default cookieAuthMiddleware;

--- a/packages/realm-server/middleware/cookie-auth.ts
+++ b/packages/realm-server/middleware/cookie-auth.ts
@@ -34,7 +34,11 @@ const cookieAuthMiddleware = async (
 
   if (token) {
     // Inject the token as an Authorization header for downstream middleware
-    ctx.request.headers.authorization = `Bearer ${token}`;
+    // We need to set it on both ctx.request.headers (Koa) and ctx.req.headers (Node.js)
+    // because fetchRequestFromContext uses ctx.req.headers when building the Request
+    let authHeader = `Bearer ${token}`;
+    ctx.request.headers.authorization = authHeader;
+    ctx.req.headers.authorization = authHeader;
   }
 
   await next();

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -176,15 +176,7 @@ export class RealmServer {
       .use(ecsMetadata)
       .use(
         cors({
-          // Return the request origin for cross-origin requests, or false
-          // when no Origin header is present. We must NOT fall back to '*'
-          // because @koa/cors converts '*' to an empty string when
-          // credentials:true is set, producing an invalid CORS response.
-          // Returning false is safe: requests without an Origin header are
-          // either same-origin (no CORS needed) or non-browser (no CORS
-          // enforcement).
-          origin: (ctx) => ctx.request.headers.origin || false,
-          credentials: true,
+          origin: '*',
           allowHeaders:
             'Authorization, Content-Type, If-Match, If-None-Match, X-Requested-With, X-Boxel-Client-Request-Id, X-Boxel-Assume-User, X-HTTP-Method-Override, X-Boxel-Disable-Module-Cache, X-Filename',
           allowMethods: 'GET,HEAD,PUT,POST,DELETE,PATCH,OPTIONS,QUERY',

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -39,6 +39,7 @@ import {
 import { registerUser } from './synapse';
 import convertAcceptHeaderQueryParam from './middleware/convert-accept-header-qp';
 import convertAuthHeaderQueryParam from './middleware/convert-auth-header-qp';
+import cookieAuthMiddleware from './middleware/cookie-auth';
 import { NodeAdapter } from './node-realm';
 import { resolve, join } from 'path';
 import merge from 'lodash/merge';
@@ -175,7 +176,8 @@ export class RealmServer {
       .use(ecsMetadata)
       .use(
         cors({
-          origin: '*',
+          origin: (ctx) => ctx.request.headers.origin || '*',
+          credentials: true,
           allowHeaders:
             'Authorization, Content-Type, If-Match, If-None-Match, X-Requested-With, X-Boxel-Client-Request-Id, X-Boxel-Assume-User, X-HTTP-Method-Override, X-Boxel-Disable-Module-Cache, X-Filename',
           allowMethods: 'GET,HEAD,PUT,POST,DELETE,PATCH,OPTIONS,QUERY',
@@ -200,6 +202,7 @@ export class RealmServer {
 
         await next();
       })
+      .use(cookieAuthMiddleware)
       .use(convertAcceptHeaderQueryParam)
       .use(convertAuthHeaderQueryParam)
       .use(methodOverrideSupport)

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -176,7 +176,14 @@ export class RealmServer {
       .use(ecsMetadata)
       .use(
         cors({
-          origin: (ctx) => ctx.request.headers.origin || '*',
+          // Return the request origin for cross-origin requests, or false
+          // when no Origin header is present. We must NOT fall back to '*'
+          // because @koa/cors converts '*' to an empty string when
+          // credentials:true is set, producing an invalid CORS response.
+          // Returning false is safe: requests without an Origin header are
+          // either same-origin (no CORS needed) or non-browser (no CORS
+          // enforcement).
+          origin: (ctx) => ctx.request.headers.origin || false,
           credentials: true,
           allowHeaders:
             'Authorization, Content-Type, If-Match, If-None-Match, X-Requested-With, X-Boxel-Client-Request-Id, X-Boxel-Assume-User, X-HTTP-Method-Override, X-Boxel-Disable-Module-Cache, X-Filename',

--- a/packages/realm-server/tests/realm-auth-test.ts
+++ b/packages/realm-server/tests/realm-auth-test.ts
@@ -7,13 +7,16 @@ import type { PgAdapter } from '@cardstack/postgres';
 import { MatrixClient } from '@cardstack/runtime-common/matrix-client';
 import { fetchSessionRoom } from '@cardstack/runtime-common/db-queries/session-room-queries';
 
+import type { Realm } from '@cardstack/runtime-common';
 import {
   setupPermissionedRealm,
   insertUser,
   realmSecretSeed,
   testRealmHref,
+  createJWT,
 } from './helpers';
 import { createJWT as createRealmServerJWT } from '../utils/jwt';
+import { getAuthCookieName, parseAuthCookieName } from '../utils/auth-cookie';
 
 module(basename(__filename), function () {
   module('realm auth handler', function (hooks) {
@@ -95,6 +98,197 @@ module(basename(__filename), function () {
         sessionRoom,
         expectedRoomId,
         'session room is persisted after the realm auth request',
+      );
+    });
+
+    test('POST /_realm-auth sets auth cookies for each realm', async function (assert) {
+      sinon
+        .stub(MatrixClient.prototype, 'createDM')
+        .resolves('!session-room:localhost');
+      sinon.stub(MatrixClient.prototype, 'sendEvent').resolves();
+      sinon.stub(MatrixClient.prototype, 'getJoinedRooms').resolves({
+        joined_rooms: [],
+      });
+      sinon.stub(MatrixClient.prototype, 'joinRoom').resolves();
+
+      let response = await request
+        .post('/_realm-auth')
+        .set('Accept', 'application/json')
+        .set('Content-Type', 'application/json')
+        .set(
+          'Authorization',
+          `Bearer ${createRealmServerJWT(
+            { user: matrixUserId, sessionRoom: 'server-session-room' },
+            realmSecretSeed,
+          )}`,
+        )
+        .send('{}');
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+
+      // Verify Set-Cookie headers are present
+      let setCookieHeaders = response.headers[
+        'set-cookie'
+      ] as unknown as string[];
+      assert.ok(setCookieHeaders, 'Set-Cookie headers are present in response');
+      assert.true(
+        Array.isArray(setCookieHeaders),
+        'Multiple Set-Cookie headers are returned',
+      );
+
+      // Check that we have a cookie for the test realm
+      let expectedCookieName = getAuthCookieName(testRealmHref);
+      let realmCookie = setCookieHeaders.find((cookie: string) =>
+        cookie.startsWith(expectedCookieName),
+      );
+      assert.ok(realmCookie, 'Cookie for test realm is set');
+
+      // Verify cookie attributes
+      assert.true(
+        realmCookie!.includes('HttpOnly'),
+        'Cookie has HttpOnly attribute',
+      );
+      assert.true(
+        realmCookie!.includes('SameSite=Lax'),
+        'Cookie has SameSite=Lax attribute',
+      );
+      assert.true(realmCookie!.includes('Path='), 'Cookie has Path attribute');
+      assert.true(
+        realmCookie!.includes('Max-Age='),
+        'Cookie has Max-Age attribute',
+      );
+
+      // Verify the cookie name can be parsed back to realm path
+      let realmPath = parseAuthCookieName(expectedCookieName);
+      assert.ok(realmPath, 'Cookie name can be parsed back to realm path');
+    });
+  });
+
+  module('cookie auth middleware', function (hooks) {
+    let testRealm: Realm;
+    let request: SuperTest<SupertestTest>;
+    const userId = 'john';
+
+    // Use a permissioned realm (not public) to test cookie auth
+    setupPermissionedRealm(hooks, {
+      permissions: {
+        [userId]: ['read', 'write'],
+      },
+      onRealmSetup: ({ testRealm: realm, request: req }) => {
+        testRealm = realm;
+        request = req;
+      },
+    });
+
+    test('GET request with valid auth cookie succeeds', async function (assert) {
+      // Create a JWT for the user
+      let token = createJWT(testRealm, userId, ['read']);
+
+      // Create the Cookie header (name=value format)
+      let cookieName = getAuthCookieName(testRealmHref);
+      let cookieHeader = `${cookieName}=${encodeURIComponent(token)}`;
+
+      // Make GET request with only cookie (no Authorization header)
+      let response = await request
+        .get('/dir/')
+        .set('Accept', 'application/vnd.api+json')
+        .set('Cookie', cookieHeader);
+
+      assert.strictEqual(
+        response.status,
+        200,
+        'GET request with cookie succeeds',
+      );
+    });
+
+    test('GET request without auth cookie or Authorization header fails', async function (assert) {
+      // Make GET request without any auth
+      let response = await request
+        .get('/dir/')
+        .set('Accept', 'application/vnd.api+json');
+
+      assert.strictEqual(
+        response.status,
+        401,
+        'GET request without auth fails with 401',
+      );
+    });
+
+    test('POST request with only cookie fails (requires Authorization header)', async function (assert) {
+      // Create a JWT for the user with write permissions
+      let token = createJWT(testRealm, userId, ['read', 'write']);
+
+      // Create the cookie header
+      let cookieName = getAuthCookieName(testRealmHref);
+      let cookieHeader = `${cookieName}=${encodeURIComponent(token)}`;
+
+      // Make POST request with only cookie (no Authorization header)
+      // This should fail because cookie auth only works for GET/HEAD
+      let response = await request
+        .post('/new-card.json')
+        .set('Accept', 'application/vnd.card+json')
+        .set('Content-Type', 'application/vnd.card+json')
+        .set('Cookie', cookieHeader)
+        .send(
+          JSON.stringify({
+            data: {
+              type: 'card',
+              meta: {
+                adoptsFrom: {
+                  module: 'https://cardstack.com/base/card-api',
+                  name: 'CardDef',
+                },
+              },
+            },
+          }),
+        );
+
+      assert.strictEqual(
+        response.status,
+        401,
+        'POST request with only cookie fails with 401',
+      );
+    });
+
+    test('Authorization header takes precedence over cookie', async function (assert) {
+      // Create a valid token for cookie
+      let cookieToken = createJWT(testRealm, userId, ['read']);
+      let cookieName = getAuthCookieName(testRealmHref);
+      let cookieHeader = `${cookieName}=${encodeURIComponent(cookieToken)}`;
+
+      // Use an invalid Authorization header
+      let response = await request
+        .get('/dir/')
+        .set('Accept', 'application/vnd.api+json')
+        .set('Cookie', cookieHeader)
+        .set('Authorization', 'Bearer invalid-token');
+
+      // Should fail because Authorization header (invalid) takes precedence
+      assert.strictEqual(
+        response.status,
+        401,
+        'Invalid Authorization header takes precedence over valid cookie',
+      );
+    });
+
+    test('HEAD request with valid auth cookie succeeds', async function (assert) {
+      // Create a JWT for the user
+      let token = createJWT(testRealm, userId, ['read']);
+
+      // Create the cookie header
+      let cookieName = getAuthCookieName(testRealmHref);
+      let cookieHeader = `${cookieName}=${encodeURIComponent(token)}`;
+
+      // Make HEAD request with only cookie (no Authorization header)
+      let response = await request
+        .head('/dir/')
+        .set('Accept', 'application/vnd.api+json')
+        .set('Cookie', cookieHeader);
+
+      assert.strictEqual(
+        response.status,
+        200,
+        'HEAD request with cookie succeeds',
       );
     });
   });

--- a/packages/realm-server/tests/realm-auth-test.ts
+++ b/packages/realm-server/tests/realm-auth-test.ts
@@ -181,8 +181,8 @@ module(basename(__filename), function () {
     });
 
     test('GET request with valid auth cookie succeeds', async function (assert) {
-      // Create a JWT for the user
-      let token = createJWT(testRealm, userId, ['read']);
+      // Create a JWT for the user (must include all user's permissions to pass realm validation)
+      let token = createJWT(testRealm, userId, ['read', 'write']);
 
       // Create the Cookie header (name=value format)
       let cookieName = getAuthCookieName(testRealmHref);
@@ -251,8 +251,8 @@ module(basename(__filename), function () {
     });
 
     test('Authorization header takes precedence over cookie', async function (assert) {
-      // Create a valid token for cookie
-      let cookieToken = createJWT(testRealm, userId, ['read']);
+      // Create a valid token for cookie (must include all user's permissions)
+      let cookieToken = createJWT(testRealm, userId, ['read', 'write']);
       let cookieName = getAuthCookieName(testRealmHref);
       let cookieHeader = `${cookieName}=${encodeURIComponent(cookieToken)}`;
 
@@ -272,8 +272,8 @@ module(basename(__filename), function () {
     });
 
     test('HEAD request with valid auth cookie succeeds', async function (assert) {
-      // Create a JWT for the user
-      let token = createJWT(testRealm, userId, ['read']);
+      // Create a JWT for the user (must include all user's permissions)
+      let token = createJWT(testRealm, userId, ['read', 'write']);
 
       // Create the cookie header
       let cookieName = getAuthCookieName(testRealmHref);

--- a/packages/realm-server/utils/auth-cookie.ts
+++ b/packages/realm-server/utils/auth-cookie.ts
@@ -1,0 +1,164 @@
+// Cookie name format: boxel_realm_auth_<base64url_encoded_realm_path>
+// Example: boxel_realm_auth_dXNlci9yZWFsbS8 for /user/realm/
+
+const COOKIE_NAME_PREFIX = 'boxel_realm_auth_';
+
+/**
+ * Encodes a string to base64url format (URL-safe base64)
+ */
+function toBase64Url(str: string): string {
+  return Buffer.from(str)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+/**
+ * Decodes a base64url string back to the original string
+ */
+function fromBase64Url(base64url: string): string {
+  let base64 = base64url.replace(/-/g, '+').replace(/_/g, '/');
+  // Add padding if needed
+  while (base64.length % 4) {
+    base64 += '=';
+  }
+  return Buffer.from(base64, 'base64').toString('utf8');
+}
+
+/**
+ * Generates the cookie name for a given realm URL
+ * The realm path is base64url encoded to ensure cookie name is valid
+ */
+export function getAuthCookieName(realmURL: string): string {
+  let url = new URL(realmURL);
+  let path = url.pathname;
+  return `${COOKIE_NAME_PREFIX}${toBase64Url(path)}`;
+}
+
+/**
+ * Extracts the cookie path from a realm URL
+ * This ensures the cookie is scoped to the realm path
+ */
+export function getAuthCookiePath(realmURL: string): string {
+  let url = new URL(realmURL);
+  return url.pathname;
+}
+
+/**
+ * Parses a cookie name to extract the realm path
+ * Returns null if the cookie name is not a valid auth cookie
+ */
+export function parseAuthCookieName(cookieName: string): string | null {
+  if (!cookieName.startsWith(COOKIE_NAME_PREFIX)) {
+    return null;
+  }
+  let encodedPath = cookieName.slice(COOKIE_NAME_PREFIX.length);
+  try {
+    return fromBase64Url(encodedPath);
+  } catch {
+    return null;
+  }
+}
+
+export interface AuthCookieOptions {
+  realmURL: string;
+  token: string;
+  expiresInSeconds: number;
+  secure: boolean;
+}
+
+/**
+ * Creates a Set-Cookie header value for realm authentication
+ * Uses HttpOnly and SameSite=Lax for security
+ */
+export function createAuthCookie(options: AuthCookieOptions): string {
+  let { realmURL, token, expiresInSeconds, secure } = options;
+  let name = getAuthCookieName(realmURL);
+  let path = getAuthCookiePath(realmURL);
+  let maxAge = expiresInSeconds;
+
+  let cookieParts = [
+    `${name}=${encodeURIComponent(token)}`,
+    `Path=${path}`,
+    `Max-Age=${maxAge}`,
+    'HttpOnly',
+    'SameSite=Lax',
+  ];
+
+  if (secure) {
+    cookieParts.push('Secure');
+  }
+
+  return cookieParts.join('; ');
+}
+
+/**
+ * Creates a Set-Cookie header value to delete/clear the auth cookie
+ */
+export function createAuthCookieDeletion(
+  realmURL: string,
+  secure: boolean,
+): string {
+  let name = getAuthCookieName(realmURL);
+  let path = getAuthCookiePath(realmURL);
+
+  let cookieParts = [
+    `${name}=`,
+    `Path=${path}`,
+    'Max-Age=0',
+    'HttpOnly',
+    'SameSite=Lax',
+  ];
+
+  if (secure) {
+    cookieParts.push('Secure');
+  }
+
+  return cookieParts.join('; ');
+}
+
+/**
+ * Parses cookies from a Cookie header string
+ * Returns a Map of cookie name to cookie value
+ */
+export function parseCookies(
+  cookieHeader: string | undefined,
+): Map<string, string> {
+  let cookies = new Map<string, string>();
+  if (!cookieHeader) {
+    return cookies;
+  }
+
+  let pairs = cookieHeader.split(';');
+  for (let pair of pairs) {
+    let [name, ...valueParts] = pair.trim().split('=');
+    if (name) {
+      let value = valueParts.join('='); // Handle values that contain '='
+      cookies.set(name.trim(), decodeURIComponent(value.trim()));
+    }
+  }
+
+  return cookies;
+}
+
+/**
+ * Finds the auth cookie that matches the request path
+ * Returns the token if found, null otherwise
+ */
+export function findAuthCookieForPath(
+  cookieHeader: string | undefined,
+  requestPath: string,
+): string | null {
+  let cookies = parseCookies(cookieHeader);
+
+  // Find all auth cookies and check if any match the request path
+  for (let [name, value] of Array.from(cookies.entries())) {
+    let realmPath = parseAuthCookieName(name);
+    if (realmPath && requestPath.startsWith(realmPath)) {
+      return value;
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- Adds HttpOnly cookies alongside JWT tokens to enable `<img>` tags to load images from authenticated realms
- Browsers automatically include cookies with image requests, solving the 401 error issue
- Cookies only work for GET/HEAD (read-only), mutating requests still require Authorization headers

## Security Model
- **SameSite=Lax** prevents CSRF attacks
- **HttpOnly** flag prevents XSS token theft  
- **Path-scoped** cookies ensure isolation between realms
- Cookies are **ignored for POST/PUT/DELETE/PATCH** requests

## Changes
- `packages/realm-server/utils/auth-cookie.ts` - New utility module for cookie encoding/parsing
- `packages/realm-server/middleware/cookie-auth.ts` - New middleware to convert cookies to Authorization headers
- `packages/realm-server/handlers/handle-realm-auth.ts` - Set cookies alongside JWT tokens
- `packages/realm-server/server.ts` - Add cookie middleware and enable CORS credentials
- `packages/host/app/services/realm-server.ts` - Add `credentials: 'include'` to `/_realm-auth` fetch
- `packages/realm-server/tests/realm-auth-test.ts` - Tests for cookie authentication

## Test plan
- [x] Lint passes
- [ ] `POST /_realm-auth` returns Set-Cookie headers
- [ ] GET request with only cookie succeeds for protected realm
- [ ] POST request with only cookie fails (requires Authorization header)
- [ ] Cookie doesn't override explicit Authorization header
- [ ] Manual testing: `<img>` tags load images without 401 errors

Closes [CS-10147](https://linear.app/cardstack/issue/CS-10147/authenticated-image-display-via-read-only-auth-cookie)

🤖 Generated with [Claude Code](https://claude.com/claude-code)