### PR TITLE
Change realm download to not use in-memory blob

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode/left-panel-toggle.gts
+++ b/packages/host/app/components/operator-mode/code-submode/left-panel-toggle.gts
@@ -12,7 +12,7 @@ import { Download } from '@cardstack/boxel-ui/icons';
 
 import RealmDropdown from '@cardstack/host/components/realm-dropdown';
 
-// These were inline but caused the template to have spurious Glint errors
+// This was inline but caused the template to have spurious Glint errors
 import { fallbackDownloadName } from '@cardstack/host/lib/download-realm';
 
 import RestoreScrollPosition from '@cardstack/host/modifiers/restore-scroll-position';

--- a/packages/host/app/components/operator-mode/code-submode/left-panel-toggle.gts
+++ b/packages/host/app/components/operator-mode/code-submode/left-panel-toggle.gts
@@ -10,9 +10,9 @@ import { Button as BoxelButton } from '@cardstack/boxel-ui/components';
 import { cn, not } from '@cardstack/boxel-ui/helpers';
 import { Download } from '@cardstack/boxel-ui/icons';
 
-import RealmDropdown from '@cardstack/host/components/realm-dropdown';
-
 import { createURLSignature } from '@cardstack/runtime-common/url-signature';
+
+import RealmDropdown from '@cardstack/host/components/realm-dropdown';
 
 // This was inline but caused the template to have spurious Glint errors
 import { fallbackDownloadName } from '@cardstack/host/lib/download-realm';

--- a/packages/host/app/components/operator-mode/code-submode/left-panel-toggle.gts
+++ b/packages/host/app/components/operator-mode/code-submode/left-panel-toggle.gts
@@ -105,7 +105,7 @@ export default class CodeSubmodeLeftPanelToggle extends Component<Signature> {
   private get downloadRealmURL() {
     let downloadURL = new URL('/_download-realm', this.args.realmURL);
     downloadURL.searchParams.set('realm', this.args.realmURL);
-    // Include token for authenticated streaming download (browser handles natively)
+    // Include token for authenticated streaming download (browser navigates directly)
     let token = this.realm.token(this.args.realmURL);
     if (token) {
       downloadURL.searchParams.set('token', token);
@@ -113,16 +113,9 @@ export default class CodeSubmodeLeftPanelToggle extends Component<Signature> {
     return downloadURL.href;
   }
 
-  downloadRealm = (event: Event) => {
-    event.preventDefault();
-    // Use an anchor element to trigger native browser download (streams without loading into memory)
-    let downloadLink = document.createElement('a');
-    downloadLink.href = this.downloadRealmURL;
-    downloadLink.download = fallbackDownloadName(new URL(this.args.realmURL));
-    document.body.appendChild(downloadLink);
-    downloadLink.click();
-    document.body.removeChild(downloadLink);
-  };
+  private get downloadFilename() {
+    return fallbackDownloadName(new URL(this.args.realmURL));
+  }
 
   <template>
     <InnerContainer
@@ -166,11 +159,13 @@ export default class CodeSubmodeLeftPanelToggle extends Component<Signature> {
 
         <div class='realm-download'>
           <BoxelButton
+            @as='anchor'
+            @href={{this.downloadRealmURL}}
             @kind='text-only'
             @size='extra-small'
             class='realm-download-button'
             title='Download an archive of this workspace'
-            {{on 'click' this.downloadRealm}}
+            download={{this.downloadFilename}}
             data-test-download-realm-button
           >
             <Download width='13' height='13' />

--- a/packages/host/app/lib/download-realm.ts
+++ b/packages/host/app/lib/download-realm.ts
@@ -1,17 +1,3 @@
-export function extractFilename(
-  contentDisposition: string | null,
-): string | null {
-  if (!contentDisposition) {
-    return null;
-  }
-  let utf8Match = contentDisposition.match(/filename\\*=UTF-8''([^;]+)/i);
-  if (utf8Match?.[1]) {
-    return decodeURIComponent(utf8Match[1]);
-  }
-  let match = contentDisposition.match(/filename="?([^";]+)"?/i);
-  return match?.[1] ?? null;
-}
-
 export function fallbackDownloadName(realmURL: URL) {
   let segments = realmURL.pathname.split('/').filter(Boolean);
   let base =

--- a/packages/matrix/tests/download-realm.spec.ts
+++ b/packages/matrix/tests/download-realm.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from './fixtures';
+import { appURL } from '../helpers/isolated-realm-server';
+import {
+  createSubscribedUser,
+  login,
+  setupPermissions,
+} from '../helpers';
+import type { Credentials } from '../docker/synapse';
+
+test.describe('Download Realm', () => {
+  let credentials: Credentials;
+  let username: string;
+  let password: string;
+
+  test.beforeEach(async () => {
+    ({ username, password, credentials } =
+      await createSubscribedUser('download-realm'));
+    await setupPermissions(credentials.userId, `${appURL}/`);
+  });
+
+  test('can download a realm as a streaming zip file in code submode', async ({
+    page,
+  }) => {
+    const operatorModeState = {
+      stacks: [],
+      codePath: `${appURL}/index.json`,
+      submode: 'code',
+      fileView: 'browser',
+      openDirs: {},
+    };
+    const stateParam = encodeURIComponent(JSON.stringify(operatorModeState));
+    await login(page, username, password, {
+      url: `${appURL}?operatorModeState=${stateParam}`,
+    });
+
+    // Wait for the code submode to load
+    await expect(page.locator('[data-test-file-browser-toggle]')).toBeVisible();
+
+    // Wait for the download button to appear
+    await expect(
+      page.locator('[data-test-download-realm-button]'),
+    ).toBeVisible();
+
+    // Start waiting for download before clicking
+    const downloadPromise = page.waitForEvent('download');
+    await page.locator('[data-test-download-realm-button]').click();
+
+    // Wait for the download to complete
+    const download = await downloadPromise;
+
+    // Verify the download filename ends with .zip
+    expect(download.suggestedFilename()).toMatch(/\.zip$/);
+
+    // Read the downloaded content to verify it's a valid zip file
+    const stream = await download.createReadStream();
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) {
+      chunks.push(chunk);
+      // Only need first few bytes to verify zip signature
+      if (chunks.reduce((acc, c) => acc + c.length, 0) >= 4) {
+        break;
+      }
+    }
+    const buffer = Buffer.concat(chunks);
+
+    // ZIP files start with 'PK' (0x50 0x4B)
+    expect(buffer[0]).toBe(0x50);
+    expect(buffer[1]).toBe(0x4b);
+
+    // Verify the download completed (streaming worked)
+    const path = await download.path();
+    expect(path).toBeTruthy();
+  });
+});

--- a/packages/realm-server/handlers/handle-download-realm.ts
+++ b/packages/realm-server/handlers/handle-download-realm.ts
@@ -11,6 +11,7 @@ import {
 } from '@cardstack/runtime-common';
 import { AuthenticationError } from '@cardstack/runtime-common/router';
 import { parseRealmsParam } from '@cardstack/runtime-common/search-utils';
+import { verifyURLSignature } from '@cardstack/runtime-common/url-signature';
 import archiver from 'archiver';
 import { existsSync, statSync } from 'fs-extra';
 import { join, resolve, sep } from 'path';
@@ -82,8 +83,28 @@ export default function handleDownloadRealm({
 
     let publishedRealmURLs = await getPublishedRealmURLs(dbAdapter, [realmURL]);
     // Support token via query param for streaming downloads (browser navigates directly)
-    let authorization =
-      ctxt.req.headers['authorization'] ?? url.searchParams.get('token');
+    let tokenFromQuery = url.searchParams.get('token');
+    let authorization = ctxt.req.headers['authorization'] ?? tokenFromQuery;
+
+    // When token is provided via query param, require a signature to prevent token reuse
+    if (tokenFromQuery) {
+      let signature = url.searchParams.get('sig');
+      if (!signature) {
+        await sendResponseForBadRequest(
+          ctxt,
+          'Signature required when token is provided via query parameter',
+        );
+        return;
+      }
+      if (!verifyURLSignature(tokenFromQuery, url, signature)) {
+        await sendResponseForUnauthorizedRequest(
+          ctxt,
+          'Invalid signature for download URL',
+        );
+        return;
+      }
+    }
+
     let readableRealms: Set<string>;
     if (!authorization) {
       let publicPermissions = await fetchUserPermissions(dbAdapter, {

--- a/packages/realm-server/handlers/handle-download-realm.ts
+++ b/packages/realm-server/handlers/handle-download-realm.ts
@@ -81,7 +81,9 @@ export default function handleDownloadRealm({
     }
 
     let publishedRealmURLs = await getPublishedRealmURLs(dbAdapter, [realmURL]);
-    let authorization = ctxt.req.headers['authorization'];
+    // Support token via query param for streaming downloads (browser navigates directly)
+    let authorization =
+      ctxt.req.headers['authorization'] ?? url.searchParams.get('token');
     let readableRealms: Set<string>;
     if (!authorization) {
       let publicPermissions = await fetchUserPermissions(dbAdapter, {

--- a/packages/realm-server/tests/server-endpoints/download-realm-test.ts
+++ b/packages/realm-server/tests/server-endpoints/download-realm-test.ts
@@ -134,6 +134,10 @@ module(`server-endpoints/${basename(__filename)}`, function (hooks) {
       .get('/_download-realm')
       .query({ realm: testRealm2URL.href, token: 'invalid-token' });
 
-    assert.strictEqual(response.status, 401, 'returns unauthorized for invalid token');
+    assert.strictEqual(
+      response.status,
+      401,
+      'returns unauthorized for invalid token',
+    );
   });
 });

--- a/packages/runtime-common/url-signature.ts
+++ b/packages/runtime-common/url-signature.ts
@@ -1,0 +1,65 @@
+/**
+ * Creates a signature binding a token to a specific URL.
+ * This prevents token reuse for other endpoints if intercepted.
+ *
+ * The signature is HMAC-SHA256(token, urlPath) where:
+ * - token is used as the HMAC key
+ * - urlPath is the pathname + search params (without the sig param)
+ */
+
+// Browser implementation using Web Crypto API
+export async function createURLSignature(
+  token: string,
+  url: URL,
+): Promise<string> {
+  // Create a copy of the URL without the signature param
+  let urlForSigning = new URL(url.href);
+  urlForSigning.searchParams.delete('sig');
+
+  let message = urlForSigning.pathname + urlForSigning.search;
+  let encoder = new TextEncoder();
+  let keyData = encoder.encode(token);
+  let messageData = encoder.encode(message);
+
+  let key = await crypto.subtle.importKey(
+    'raw',
+    keyData,
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+
+  let signature = await crypto.subtle.sign('HMAC', key, messageData);
+  let signatureArray = new Uint8Array(signature);
+  return btoa(String.fromCharCode(...signatureArray))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, ''); // URL-safe base64
+}
+
+// Node.js implementation
+export function createURLSignatureSync(token: string, url: URL): string {
+  // Dynamic import to avoid issues in browser
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  let crypto = require('crypto');
+
+  let urlForSigning = new URL(url.href);
+  urlForSigning.searchParams.delete('sig');
+
+  let message = urlForSigning.pathname + urlForSigning.search;
+  let signature = crypto
+    .createHmac('sha256', token)
+    .update(message)
+    .digest('base64url');
+
+  return signature;
+}
+
+export function verifyURLSignature(
+  token: string,
+  url: URL,
+  providedSignature: string,
+): boolean {
+  let expectedSignature = createURLSignatureSync(token, url);
+  return expectedSignature === providedSignature;
+}

--- a/packages/runtime-common/url-signature.ts
+++ b/packages/runtime-common/url-signature.ts
@@ -40,7 +40,7 @@ export async function createURLSignature(
 // Node.js implementation
 export function createURLSignatureSync(token: string, url: URL): string {
   // Dynamic import to avoid issues in browser
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
   let crypto = require('crypto');
 
   let urlForSigning = new URL(url.href);


### PR DESCRIPTION
This changes the endpoint to support either a header or token so the UI can download via a link and not need to contain the entire realm in memory.

![screencast 2026-02-03 19-47-31](https://github.com/user-attachments/assets/ab6c4b28-cbc4-4d0d-be82-42e84ec6e9c9)

I also added a Playwright test since this uses the endpoint in a slightly different way.