### PR TITLE
Populate ChooseFile modal via file-meta entries in index

### DIFF
--- a/packages/host/app/components/editor/indexed-file-tree.gts
+++ b/packages/host/app/components/editor/indexed-file-tree.gts
@@ -1,0 +1,244 @@
+import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import type Owner from '@ember/owner';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import { restartableTask, timeout } from 'ember-concurrency';
+import { TrackedSet } from 'tracked-built-ins';
+
+import { eq } from '@cardstack/boxel-ui/helpers';
+import { DropdownArrowDown } from '@cardstack/boxel-ui/icons';
+
+import type { LocalPath } from '@cardstack/runtime-common/paths';
+
+import scrollIntoViewModifier from '@cardstack/host/modifiers/scroll-into-view';
+import {
+  fileTreeFromIndex,
+  type FileTreeNode,
+} from '@cardstack/host/resources/file-tree-from-index';
+import { normalizeDirPath } from '@cardstack/host/utils/normalized-dir-path';
+
+interface Signature {
+  Args: {
+    realmURL: string;
+    selectedFile?: LocalPath;
+    openDirs?: LocalPath[];
+    onFileSelected?: (entryPath: LocalPath) => void;
+    onDirectorySelected?: (entryPath: LocalPath) => void;
+    scrollPositionKey?: LocalPath;
+  };
+}
+
+export default class IndexedFileTree extends Component<Signature> {
+  <template>
+    <nav>
+      <TreeLevel
+        @entries={{this.fileTree.entries}}
+        @fileTree={{this.fileTree}}
+        @selectedFile={{if @selectedFile @selectedFile this.selectedFile}}
+        @openDirs={{this.effectiveOpenDirs}}
+        @onFileSelected={{this.selectFile}}
+        @onDirectorySelected={{this.toggleDirectory}}
+        @scrollPositionKey={{@scrollPositionKey}}
+        @relativePath=''
+      />
+      {{#if this.showMask}}
+        <div class='mask' data-test-file-tree-mask></div>
+      {{/if}}
+    </nav>
+
+    <style scoped>
+      .mask {
+        position: absolute;
+        top: 0;
+        left: 0;
+        background-color: white;
+        height: 100%;
+        width: 100%;
+      }
+      nav {
+        position: relative;
+      }
+    </style>
+  </template>
+
+  private fileTree = fileTreeFromIndex(this, () => this.args.realmURL);
+  private localOpenDirs = new TrackedSet<string>();
+  @tracked private selectedFile?: LocalPath;
+  @tracked private showMask = true;
+
+  constructor(owner: Owner, args: Signature['Args']) {
+    super(owner, args);
+    this.hideMask.perform();
+  }
+
+  private hideMask = restartableTask(async () => {
+    // fine tuned to coincide with debounce in RestoreScrollPosition modifier
+    await timeout(300);
+    this.showMask = false;
+  });
+
+  private get effectiveOpenDirs(): Set<string> {
+    if (this.args.openDirs) {
+      return new Set(this.args.openDirs);
+    }
+    return this.localOpenDirs;
+  }
+
+  @action
+  private selectFile(entryPath: LocalPath) {
+    this.selectedFile = entryPath;
+    this.args.onFileSelected?.(entryPath);
+  }
+
+  @action
+  private toggleDirectory(entryPath: LocalPath) {
+    let dirPath = normalizeDirPath(entryPath);
+
+    if (this.localOpenDirs.has(dirPath)) {
+      this.localOpenDirs.delete(dirPath);
+    } else {
+      this.localOpenDirs.add(dirPath);
+    }
+
+    this.args.onDirectorySelected?.(dirPath);
+  }
+}
+
+interface TreeLevelSignature {
+  Args: {
+    entries: FileTreeNode[];
+    fileTree: ReturnType<typeof fileTreeFromIndex>;
+    selectedFile?: LocalPath;
+    openDirs: Set<string>;
+    onFileSelected: (entryPath: LocalPath) => void;
+    onDirectorySelected: (entryPath: LocalPath) => void;
+    scrollPositionKey?: LocalPath;
+    relativePath: string;
+  };
+}
+
+class TreeLevel extends Component<TreeLevelSignature> {
+  <template>
+    {{#each @entries as |entry|}}
+      <div class='level' data-test-directory-level>
+        {{#if (eq entry.kind 'file')}}
+          <button
+            data-test-file={{entry.path}}
+            title={{entry.name}}
+            {{on 'click' (fn @onFileSelected entry.path)}}
+            {{scrollIntoViewModifier
+              (this.isSelectedFile entry.path)
+              container='file-tree'
+              key=@scrollPositionKey
+            }}
+            class='file {{if (this.isSelectedFile entry.path) "selected"}}'
+          >
+            {{entry.name}}
+          </button>
+        {{else}}
+          <button
+            data-test-directory={{entry.path}}
+            title={{entry.name}}
+            {{on 'click' (fn @onDirectorySelected entry.path)}}
+            class='directory'
+          >
+            <DropdownArrowDown
+              class='icon
+                {{if (this.isOpenDirectory entry.path) "open" "closed"}}'
+            />{{entry.name}}
+          </button>
+          {{#if (this.isOpenDirectory entry.path)}}
+            <TreeLevel
+              @entries={{this.getChildren entry}}
+              @fileTree={{@fileTree}}
+              @selectedFile={{@selectedFile}}
+              @openDirs={{@openDirs}}
+              @onFileSelected={{@onFileSelected}}
+              @onDirectorySelected={{@onDirectorySelected}}
+              @scrollPositionKey={{@scrollPositionKey}}
+              @relativePath={{entry.path}}
+            />
+          {{/if}}
+        {{/if}}
+      </div>
+    {{/each}}
+
+    <style scoped>
+      .level {
+        --icon-length: 14px;
+        --icon-margin: 4px;
+
+        padding-left: 0em;
+      }
+
+      .level .level {
+        padding-left: 1em;
+      }
+
+      .directory,
+      .file {
+        border-radius: var(--boxel-border-radius-xs);
+        background: transparent;
+        border: 0;
+        padding: var(--boxel-sp-xxxs);
+        width: 100%;
+        text-align: start;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .directory:hover,
+      .file:hover {
+        background-color: var(--boxel-200);
+      }
+
+      .file.selected,
+      .file:active {
+        color: var(--boxel-dark);
+        background-color: var(--boxel-highlight);
+      }
+
+      .directory {
+        padding-left: 0;
+      }
+
+      .directory :deep(.icon) {
+        width: var(--icon-length);
+        height: var(--icon-length);
+        margin-bottom: -2px;
+        padding: 0 2px;
+      }
+
+      .directory :deep(.icon.closed) {
+        transform: rotate(-90deg);
+      }
+
+      .file {
+        padding-left: calc(var(--icon-length) + var(--icon-margin));
+      }
+    </style>
+  </template>
+
+  @action
+  isSelectedFile(path: string): boolean {
+    return this.args.selectedFile === path;
+  }
+
+  @action
+  isOpenDirectory(path: string): boolean {
+    let dirPath = normalizeDirPath(path);
+    return this.args.openDirs.has(dirPath);
+  }
+
+  @action
+  getChildren(entry: FileTreeNode): FileTreeNode[] {
+    if (!entry.children) {
+      return [];
+    }
+    return Array.from(entry.children.values());
+  }
+}

--- a/packages/host/app/components/editor/indexed-file-tree.gts
+++ b/packages/host/app/components/editor/indexed-file-tree.gts
@@ -68,6 +68,7 @@ export default class IndexedFileTree extends Component<Signature> {
       }
       nav {
         position: relative;
+        min-height: 100%;
       }
     </style>
   </template>

--- a/packages/host/app/components/operator-mode/choose-file-modal.gts
+++ b/packages/host/app/components/operator-mode/choose-file-modal.gts
@@ -31,7 +31,7 @@ import type RealmService from '@cardstack/host/services/realm';
 
 import type { FileDef } from 'https://cardstack.com/base/file-api';
 
-import FileTree from '../editor/file-tree';
+import IndexedFileTree from '../editor/indexed-file-tree';
 
 interface Signature {
   Args: {};
@@ -218,7 +218,7 @@ export default class ChooseFileModal extends Component<Signature> {
             @label='Choose File'
             @tag='div'
           >
-            <FileTree
+            <IndexedFileTree
               @realmURL={{this.selectedRealm.url.href}}
               @onFileSelected={{this.selectFile}}
             />

--- a/packages/host/app/components/operator-mode/choose-file-modal.gts
+++ b/packages/host/app/components/operator-mode/choose-file-modal.gts
@@ -1,5 +1,5 @@
 import { registerDestructor } from '@ember/destroyable';
-import { fn } from '@ember/helper';
+import { array, fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import type Owner from '@ember/owner';
@@ -218,10 +218,13 @@ export default class ChooseFileModal extends Component<Signature> {
             @label='Choose File'
             @tag='div'
           >
-            <IndexedFileTree
-              @realmURL={{this.selectedRealm.url.href}}
-              @onFileSelected={{this.selectFile}}
-            />
+            {{! Use #each with single-element array to force component recreation when realm changes }}
+            {{#each (array this.selectedRealm.url.href) as |realmURL|}}
+              <IndexedFileTree
+                @realmURL={{realmURL}}
+                @onFileSelected={{this.selectFile}}
+              />
+            {{/each}}
           </FieldContainer>
         </:content>
         <:footer>

--- a/packages/host/app/resources/file-tree-from-index.ts
+++ b/packages/host/app/resources/file-tree-from-index.ts
@@ -1,0 +1,164 @@
+import { getOwner } from '@ember/owner';
+import type Owner from '@ember/owner';
+import { tracked, cached } from '@glimmer/tracking';
+
+import { Resource } from 'ember-modify-based-class-resource';
+
+import { ensureTrailingSlash } from '@cardstack/runtime-common';
+import type { Query } from '@cardstack/runtime-common/query';
+
+import type { FileDef } from 'https://cardstack.com/base/file-api';
+
+import { getSearch, type SearchResource } from './search';
+
+interface Args {
+  named: {
+    realmURL: string;
+  };
+}
+
+export interface FileTreeNode {
+  name: string;
+  path: string; // Relative path from realm root
+  kind: 'file' | 'directory';
+  children?: Map<string, FileTreeNode>;
+}
+
+export class FileTreeFromIndexResource extends Resource<Args> {
+  @tracked private realmURL: string | undefined;
+  private search: SearchResource<FileDef> | undefined;
+
+  modify(_positional: never[], named: Args['named']) {
+    let { realmURL } = named;
+    let normalizedURL = ensureTrailingSlash(realmURL);
+
+    if (this.realmURL === normalizedURL) {
+      return;
+    }
+
+    this.realmURL = normalizedURL;
+
+    // Create search resource for FileDef type in this realm
+    let owner = getOwner(this) as Owner;
+    this.search = getSearch<FileDef>(
+      this,
+      owner,
+      () => this.query,
+      () => (this.realmURL ? [this.realmURL] : undefined),
+      { isLive: true },
+    );
+  }
+
+  private get query(): Query | undefined {
+    if (!this.realmURL) {
+      return undefined;
+    }
+    return {
+      filter: {
+        type: {
+          module: 'https://cardstack.com/base/file-api',
+          name: 'FileDef',
+        },
+      },
+    };
+  }
+
+  get isLoading(): boolean {
+    return this.search?.isLoading ?? true;
+  }
+
+  @cached
+  get entries(): FileTreeNode[] {
+    if (!this.search || !this.realmURL) {
+      return [];
+    }
+
+    let files = this.search.instances;
+    let tree = this.buildTreeFromFiles(files);
+    return this.sortEntries(tree);
+  }
+
+  private buildTreeFromFiles(files: FileDef[]): Map<string, FileTreeNode> {
+    let root = new Map<string, FileTreeNode>();
+
+    for (let file of files) {
+      // Extract relative path from file URL
+      // The file id is the full URL like "http://localhost:4200/myworkspace/path/to/file.txt"
+      // We need just "path/to/file.txt"
+      let relativePath = file.id.replace(this.realmURL!, '');
+
+      // Skip if the path is empty or just the realm root
+      if (!relativePath || relativePath === '/') {
+        continue;
+      }
+
+      // Split path into segments: "foo/bar/baz.txt" -> ["foo", "bar", "baz.txt"]
+      let segments = relativePath.split('/').filter(Boolean);
+
+      let currentLevel = root;
+      let currentPath = '';
+
+      for (let i = 0; i < segments.length; i++) {
+        let segment = segments[i];
+        let isLastSegment = i === segments.length - 1;
+        currentPath = currentPath ? `${currentPath}/${segment}` : segment;
+
+        if (!currentLevel.has(segment)) {
+          currentLevel.set(segment, {
+            name: segment,
+            path: isLastSegment ? currentPath : `${currentPath}/`,
+            kind: isLastSegment ? 'file' : 'directory',
+            children: isLastSegment ? undefined : new Map(),
+          });
+        } else if (!isLastSegment) {
+          // Ensure intermediate nodes are directories with children
+          let existingNode = currentLevel.get(segment)!;
+          if (!existingNode.children) {
+            existingNode.children = new Map();
+            existingNode.kind = 'directory';
+            existingNode.path = `${currentPath}/`;
+          }
+        }
+
+        if (!isLastSegment) {
+          currentLevel = currentLevel.get(segment)!.children!;
+        }
+      }
+    }
+
+    return root;
+  }
+
+  private sortEntries(tree: Map<string, FileTreeNode>): FileTreeNode[] {
+    let entries = Array.from(tree.values());
+
+    // Sort: directories first, then alphabetically by name
+    entries.sort((a, b) => {
+      // Directories come before files
+      if (a.kind === 'directory' && b.kind === 'file') {
+        return -1;
+      }
+      if (a.kind === 'file' && b.kind === 'directory') {
+        return 1;
+      }
+      // Within same kind, sort alphabetically
+      return a.name.localeCompare(b.name);
+    });
+
+    // Recursively sort children
+    for (let entry of entries) {
+      if (entry.children) {
+        let sortedChildren = this.sortEntries(entry.children);
+        entry.children = new Map(sortedChildren.map((e) => [e.name, e]));
+      }
+    }
+
+    return entries;
+  }
+}
+
+export function fileTreeFromIndex(parent: object, realmURL: () => string) {
+  return FileTreeFromIndexResource.from(parent, () => ({
+    realmURL: realmURL(),
+  })) as FileTreeFromIndexResource;
+}

--- a/packages/host/app/resources/file-tree-from-index.ts
+++ b/packages/host/app/resources/file-tree-from-index.ts
@@ -4,13 +4,15 @@ import { cached } from '@glimmer/tracking';
 
 import { Resource } from 'ember-modify-based-class-resource';
 
-import { ensureTrailingSlash } from '@cardstack/runtime-common';
-import type { Query } from '@cardstack/runtime-common/query';
+import {
+  ensureTrailingSlash,
+  type CardResource,
+  type FileMetaResource,
+  type Saved,
+} from '@cardstack/runtime-common';
+import type { DataQuery } from '@cardstack/runtime-common/query';
 
-import type { CardDef } from 'https://cardstack.com/base/card-api';
-import type { FileDef } from 'https://cardstack.com/base/file-api';
-
-import { getSearch, type SearchResource } from './search';
+import { getSearchData, type SearchDataResource } from './search-data';
 
 interface Args {
   named: {
@@ -29,7 +31,7 @@ export class FileTreeFromIndexResource extends Resource<Args> {
   // Use private field to avoid Glimmer autotracking - this prevents the error:
   // "You attempted to update `realmURL` but it had already been used previously in the same computation"
   #realmURL: string | undefined;
-  private search: SearchResource<CardDef | FileDef> | undefined;
+  private search: SearchDataResource | undefined;
 
   modify(_positional: never[], named: Args['named']) {
     let { realmURL } = named;
@@ -38,9 +40,9 @@ export class FileTreeFromIndexResource extends Resource<Args> {
     // Always update - the search resource handles deduplication internally
     this.#realmURL = normalizedURL;
 
-    // Create search resource for FileDef type in this realm
+    // Create search data resource for file-meta type in this realm
     let owner = getOwner(this) as Owner;
-    this.search = getSearch(
+    this.search = getSearchData(
       this,
       owner,
       () => this.query,
@@ -49,7 +51,7 @@ export class FileTreeFromIndexResource extends Resource<Args> {
     );
   }
 
-  private get query(): Query | undefined {
+  private get query(): DataQuery | undefined {
     if (!this.#realmURL) {
       return undefined;
     }
@@ -60,6 +62,8 @@ export class FileTreeFromIndexResource extends Resource<Args> {
           name: 'FileDef',
         },
       },
+      asData: true,
+      fields: { 'file-meta': [] },
     };
   }
 
@@ -73,20 +77,27 @@ export class FileTreeFromIndexResource extends Resource<Args> {
       return [];
     }
 
-    // We query with FileDef type filter, so instances are FileDef
-    let files = this.search.instances as FileDef[];
-    let tree = this.buildTreeFromFiles(files);
+    let resources = this.search.resources;
+    let tree = this.buildTreeFromResources(resources);
     return this.sortEntries(tree);
   }
 
-  private buildTreeFromFiles(files: FileDef[]): Map<string, FileTreeNode> {
+  private buildTreeFromResources(
+    resources: (CardResource<Saved> | FileMetaResource)[],
+  ): Map<string, FileTreeNode> {
     let root = new Map<string, FileTreeNode>();
 
-    for (let file of files) {
-      // Extract relative path from file URL
-      // The file id is the full URL like "http://localhost:4200/myworkspace/path/to/file.txt"
+    for (let resource of resources) {
+      if (!resource.id) {
+        continue;
+      }
+      // Extract relative path from resource URL
+      // The resource id is the full URL like "http://localhost:4200/myworkspace/path/to/file.txt"
       // We need just "path/to/file.txt"
-      let relativePath = file.id.replace(this.#realmURL!, '');
+      // Decode percent-encoded characters (e.g. emoji filenames appear as %F0%9F%8E%89 in URLs)
+      let relativePath = decodeURIComponent(
+        resource.id.replace(this.#realmURL!, ''),
+      );
 
       // Skip if the path is empty or just the realm root
       if (!relativePath || relativePath === '/') {
@@ -133,18 +144,8 @@ export class FileTreeFromIndexResource extends Resource<Args> {
   private sortEntries(tree: Map<string, FileTreeNode>): FileTreeNode[] {
     let entries = Array.from(tree.values());
 
-    // Sort: directories first, then alphabetically by name
-    entries.sort((a, b) => {
-      // Directories come before files
-      if (a.kind === 'directory' && b.kind === 'file') {
-        return -1;
-      }
-      if (a.kind === 'file' && b.kind === 'directory') {
-        return 1;
-      }
-      // Within same kind, sort alphabetically
-      return a.name.localeCompare(b.name);
-    });
+    // Sort alphabetically by name (matching the original file chooser behavior)
+    entries.sort((a, b) => a.name.localeCompare(b.name));
 
     // Recursively sort children
     for (let entry of entries) {

--- a/packages/host/app/resources/file-tree-from-index.ts
+++ b/packages/host/app/resources/file-tree-from-index.ts
@@ -35,10 +35,7 @@ export class FileTreeFromIndexResource extends Resource<Args> {
     let { realmURL } = named;
     let normalizedURL = ensureTrailingSlash(realmURL);
 
-    if (this.#realmURL === normalizedURL) {
-      return;
-    }
-
+    // Always update - the search resource handles deduplication internally
     this.#realmURL = normalizedURL;
 
     // Create search resource for FileDef type in this realm

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -3010,7 +3010,7 @@ export class Realm {
   public async search(query: Query): Promise<LinkableCollectionDocument> {
     assertQuery(query);
     return await this.#realmIndexQueryEngine.searchCards(query, {
-      loadLinks: true,
+      ...(query.asData ? {} : { loadLinks: true }),
     });
   }
 


### PR DESCRIPTION
## Summary

- Replace HTTP directory listing requests with indexed file-meta queries for the ChooseFile modal
- Instead of making separate HTTP requests for each directory level, query all files at once via the search API and build the tree client-side
- Leverages SearchResource for Store integration, caching, reference counting, and live event subscription

## Changes

| File | Description |
|------|-------------|
| `packages/host/app/resources/file-tree-from-index.ts` | New resource that wraps SearchResource with FileDef type filter and builds tree structure |
| `packages/host/app/components/editor/indexed-file-tree.gts` | New component that renders file tree using the resource |
| `packages/host/app/components/operator-mode/choose-file-modal.gts` | Updated to use IndexedFileTree instead of FileTree |

## Test plan

- [x] Use the staging or production preview link
- [x] Open the AI Assistant.
- [x] Click the + button and choose Attach File
- [x] Verify files display in tree structure
- [x] Verify directory expand/collapse works
- [x] Verify file selection works
- [ ] Verify switching realms refreshes the tree
- [ ] Verify adding/removing files updates the tree (via event subscription)

Closes CS-10109

🤖 Generated with [Claude Code](https://claude.com/claude-code)