### PR TITLE
Throw friendly error when listing install fails

### DIFF
--- a/packages/host/app/commands/listing-install.ts
+++ b/packages/host/app/commands/listing-install.ts
@@ -155,11 +155,12 @@ export default class ListingInstallCommand extends HostBaseCommand<
     if (!Array.isArray(atomicResults)) {
       let detail = (results as { errors?: Array<{ detail?: string }> })
         .errors?.[0]?.detail;
-      throw new Error(
-        detail
-          ? `Please make sure your listing has all required specs linked. ${detail}`
-          : 'Please make sure your listing has all required specs linked',
-      );
+      if (detail?.includes('filter refers to a nonexistent type')) {
+        throw new Error(
+          'Please click "Update Specs" on the listing and make sure all specs are linked.',
+        );
+      }
+      throw new Error(detail);
     }
     let writtenFiles = atomicResults.map((r) => r.data.id);
     log.debug('=== Final Results ===');

--- a/packages/host/app/commands/listing-install.ts
+++ b/packages/host/app/commands/listing-install.ts
@@ -150,7 +150,17 @@ export default class ListingInstallCommand extends HostBaseCommand<
       new URL(realmUrl),
     );
 
-    let atomicResults: AtomicOperationResult[] = results['atomic:results'];
+    let atomicResults: AtomicOperationResult[] | undefined =
+      results['atomic:results'];
+    if (!Array.isArray(atomicResults)) {
+      let detail = (results as { errors?: Array<{ detail?: string }> })
+        .errors?.[0]?.detail;
+      throw new Error(
+        detail
+          ? `Please make sure your listing has all required specs linked. ${detail}`
+          : 'Please make sure your listing has all required specs linked',
+      );
+    }
     let writtenFiles = atomicResults.map((r) => r.data.id);
     log.debug('=== Final Results ===');
     log.debug(JSON.stringify(writtenFiles, null, 2));


### PR DESCRIPTION
linear: https://linear.app/cardstack/issue/ECO-466/display-a-error-message-ui-whenever-a-remix-run-fails




## Result:
Before:
<img width="2656" height="1226" alt="image" src="https://github.com/user-attachments/assets/7b220851-89a7-4b72-b6db-17c142d6e174" />

After:

https://github.com/user-attachments/assets/4ae09af2-7101-44a6-ada2-459c9dea8791

