### PR TITLE
Refactor Store#search to support FileDef and fix N+1 query issue

### DIFF
--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -652,9 +652,17 @@ export default class StoreService extends Service implements StoreInterface {
     // Hydrate each result into the store
     let instances = (
       await Promise.all(
-        collectionDoc.data.map((resource) =>
-          this._addResourceFromSearchData<T>(resource),
-        ),
+        collectionDoc.data.map(async (resource) => {
+          try {
+            return await this._addResourceFromSearchData<T>(resource);
+          } catch (error) {
+            logger.warn(
+              `Failed to hydrate resource from search results (id: ${'id' in resource ? resource.id : 'unknown'})`,
+              error,
+            );
+            return undefined;
+          }
+        }),
       )
     ).filter(Boolean) as T[];
 

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -656,7 +656,7 @@ export default class StoreService extends Service implements StoreInterface {
           try {
             return await this._addResourceFromSearchData<T>(resource);
           } catch (error) {
-            logger.warn(
+            storeLogger.warn(
               `Failed to hydrate resource from search results (id: ${'id' in resource ? resource.id : 'unknown'})`,
               error,
             );

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -20,8 +20,9 @@ import {
   isCardError,
   isCardInstance,
   isFileDefInstance,
+  isFileMetaResource,
   isSingleCardDocument,
-  isCardCollectionDocument,
+  isLinkableCollectionDocument,
   Deferred,
   delay,
   mergeRelationships,
@@ -53,6 +54,8 @@ import {
   type LooseLinkableResource,
   type LooseSingleResourceDocument,
   type StoreReadType,
+  type CardResource,
+  type Saved,
 } from '@cardstack/runtime-common';
 
 import type { CardDef, BaseDef } from 'https://cardstack.com/base/card-api';
@@ -575,7 +578,20 @@ export default class StoreService extends Service implements StoreInterface {
     return persistedResult as T | CardErrorJSONAPI;
   }
 
-  async search(query: Query, realms?: string[]): Promise<CardDef[]> {
+  async search<T extends CardDef | FileDef = CardDef>(
+    query: Query,
+    realms?: string[],
+  ): Promise<T[]>;
+  async search<T extends CardDef | FileDef = CardDef>(
+    query: Query,
+    realms: string[] | undefined,
+    opts: { includeMeta: true },
+  ): Promise<{ instances: T[]; meta: QueryResultsMeta }>;
+  async search<T extends CardDef | FileDef = CardDef>(
+    query: Query,
+    realms?: string[],
+    opts?: { includeMeta?: boolean },
+  ): Promise<T[] | { instances: T[]; meta: QueryResultsMeta }> {
     let normalizedRealms = (realms ?? [])
       .map((realm) => new RealmPaths(new URL(realm)).url)
       .filter(Boolean);
@@ -584,12 +600,23 @@ export default class StoreService extends Service implements StoreInterface {
         ? normalizedRealms
         : this.realmServer.availableRealmURLs;
     if (searchRealms.length === 0) {
-      return [];
+      return opts?.includeMeta
+        ? { instances: [], meta: { page: { total: 0 } } }
+        : [];
     }
-    return this._search(query, searchRealms);
+    let result = await this.fetchAndHydrateSearchResults<T>(
+      query,
+      searchRealms,
+    );
+    return opts?.includeMeta ? result : result.instances;
   }
 
-  private async _search(query: Query, realms: string[]): Promise<CardDef[]> {
+  private async fetchAndHydrateSearchResults<
+    T extends CardDef | FileDef = CardDef,
+  >(
+    query: Query,
+    realms: string[],
+  ): Promise<{ instances: T[]; meta: QueryResultsMeta }> {
     let realmServerURLs = this.realmServer.getRealmServersForRealms(realms);
     // TODO remove this assertion after multi-realm server/federated identity is supported
     this.realmServer.assertOwnRealmServer(realmServerURLs);
@@ -614,37 +641,24 @@ export default class StoreService extends Service implements StoreInterface {
       throw err;
     }
     let json = await response.json();
-    if (!isCardCollectionDocument(json)) {
+    if (!isLinkableCollectionDocument(json)) {
       throw new Error(
-        `The realm search response was not a card collection document:
+        `The realm search response was not a valid collection document:
         ${JSON.stringify(json, null, 2)}`,
       );
     }
     let collectionDoc = json;
-    return (
+
+    // Hydrate each result into the store
+    let instances = (
       await Promise.all(
-        collectionDoc.data.map(async (doc) => {
-          try {
-            return await this.getCardInstance({
-              idOrDoc: { data: doc },
-              relativeTo: new URL(doc.id!), // all results will have id's
-            });
-          } catch (e) {
-            console.warn(
-              `Skipping ${
-                doc.id
-              }. Encountered error deserializing from search result for query ${JSON.stringify(
-                query,
-                null,
-                2,
-              )} against realms ${realms.join()}`,
-              e,
-            );
-            return undefined;
-          }
-        }),
+        collectionDoc.data.map((resource) =>
+          this._addResourceFromSearchData<T>(resource),
+        ),
       )
-    ).filter(Boolean) as CardDef[];
+    ).filter(Boolean) as T[];
+
+    return { instances, meta: collectionDoc.meta };
   }
 
   getSearchResource<T extends CardDef | FileDef = CardDef>(
@@ -1064,6 +1078,41 @@ export default class StoreService extends Service implements StoreInterface {
     })) as unknown as FileDef;
     this.setIdentityContext(instance, 'file-meta');
     return instance;
+  }
+
+  // Internal method for hydrating a resource from search response data.
+  // This avoids N+1 queries when search results include card or file-meta resources.
+  // Not part of the public API since it's meant for internal search result processing.
+  async _addResourceFromSearchData<T extends CardDef | FileDef>(
+    resource: CardResource<Saved> | FileMetaResource,
+  ): Promise<T | undefined> {
+    if (!resource.id) {
+      throw new Error('resource must have an id');
+    }
+
+    // Handle file-meta resources
+    if (isFileMetaResource(resource)) {
+      let existingInstance = this.peek(resource.id, { type: 'file-meta' });
+      if (existingInstance && isFileDefInstance(existingInstance)) {
+        return existingInstance as T;
+      }
+      let doc = { data: resource };
+      return this.createFileMetaFromSerialized(
+        resource,
+        doc,
+        new URL(resource.id),
+      ) as Promise<T>;
+    }
+
+    // Handle card resources
+    let existingInstance = this.peek(resource.id);
+    if (existingInstance && isCardInstance(existingInstance)) {
+      return existingInstance as T;
+    }
+    return this.add({ data: resource } as SingleCardDocument, {
+      doNotPersist: true,
+      relativeTo: new URL(resource.id),
+    }) as Promise<T>;
   }
 
   private async startAutoSaving(instanceOrError: CardDef | CardErrorJSONAPI) {

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -654,7 +654,7 @@ export default class StoreService extends Service implements StoreInterface {
       await Promise.all(
         collectionDoc.data.map(async (resource) => {
           try {
-            return await this._addResourceFromSearchData<T>(resource);
+            return await this.addResourceFromSearchData<T>(resource);
           } catch (error) {
             storeLogger.warn(
               `Failed to hydrate resource from search results (id: ${'id' in resource ? resource.id : 'unknown'})`,
@@ -1091,7 +1091,7 @@ export default class StoreService extends Service implements StoreInterface {
   // Internal method for hydrating a resource from search response data.
   // This avoids N+1 queries when search results include card or file-meta resources.
   // Not part of the public API since it's meant for internal search result processing.
-  async _addResourceFromSearchData<T extends CardDef | FileDef>(
+  private async addResourceFromSearchData<T extends CardDef | FileDef>(
     resource: CardResource<Saved> | FileMetaResource,
   ): Promise<T | undefined> {
     if (!resource.id) {


### PR DESCRIPTION
## Summary

- Make `Store#search` generic to support both `CardDef` and `FileDef` queries
- Add `{ includeMeta: true }` option to return pagination metadata alongside instances
- Extract shared search logic into private `fetchAndHydrateSearchResults` method
- Add `_addResourceFromSearchData` to hydrate resources directly from search response data without making individual network requests (fixes N+1 query problem)
- Simplify `SearchResource` to delegate to `Store#search` instead of duplicating fetch/hydrate logic
- Remove ~95 lines of duplicated code between `SearchResource` and `Store`

## Test plan

- [x] Existing search tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)