### PR TITLE
Fix linksTo CardDef relationships degraded to file-meta type

### DIFF
--- a/packages/realm-server/tests/card-endpoints-test.ts
+++ b/packages/realm-server/tests/card-endpoints-test.ts
@@ -301,6 +301,147 @@ module(basename(__filename), function () {
             },
           );
         });
+        test('linksTo relationship for CardDef uses card type not file-meta', async function (assert) {
+          let { testRealm: realm, request, dbAdapter } = getRealmSetup();
+
+          let writes = new Map<string, string>([
+            [
+              'tag.gts',
+              `
+                import { CardDef, field, contains } from "https://cardstack.com/base/card-api";
+                import StringField from "https://cardstack.com/base/string";
+
+                export class Tag extends CardDef {
+                  @field label = contains(StringField);
+                  @field cardTitle = contains(StringField, {
+                    computeVia: function (this: Tag) {
+                      return this.label;
+                    },
+                  });
+                }
+              `,
+            ],
+            [
+              'article.gts',
+              `
+                import { CardDef, field, contains, linksTo } from "https://cardstack.com/base/card-api";
+                import StringField from "https://cardstack.com/base/string";
+                import { Tag } from "./tag";
+
+                export class Article extends CardDef {
+                  @field title = contains(StringField);
+                  @field tag = linksTo(Tag);
+                  @field cardTitle = contains(StringField, {
+                    computeVia: function (this: Article) {
+                      return this.title;
+                    },
+                  });
+                }
+              `,
+            ],
+            [
+              'Tag/programming.json',
+              JSON.stringify({
+                data: {
+                  attributes: {
+                    label: 'Programming',
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: '../tag.gts',
+                      name: 'Tag',
+                    },
+                  },
+                },
+              }),
+            ],
+            [
+              'Article/hello-world.json',
+              JSON.stringify({
+                data: {
+                  attributes: {
+                    title: 'Hello World',
+                  },
+                  relationships: {
+                    tag: {
+                      links: {
+                        self: '../Tag/programming',
+                      },
+                    },
+                  },
+                  meta: {
+                    adoptsFrom: {
+                      module: '../article.gts',
+                      name: 'Article',
+                    },
+                  },
+                },
+              }),
+            ],
+          ]);
+
+          await realm.writeMany(writes);
+
+          // Verify the relationship is correct with a fresh index
+          let response = await request
+            .get('/Article/hello-world')
+            .set('Accept', 'application/vnd.card+json');
+
+          assert.strictEqual(
+            response.status,
+            200,
+            `HTTP 200 status: ${response.text}`,
+          );
+          let doc = response.body as LooseSingleCardDocument;
+          let tagRelationship = doc.data.relationships?.tag as Relationship;
+          assert.ok(tagRelationship, 'tag relationship exists');
+          assert.deepEqual(
+            tagRelationship.data,
+            {
+              type: 'card',
+              id: `${testRealmHref}Tag/programming`,
+            },
+            'linksTo relationship for a CardDef uses type "card" not "file-meta"',
+          );
+
+          // Now simulate a stale index where the pristine_doc relationship
+          // lacks data.type (as it would be before commit 480362eb12 which
+          // added data to NotLoadedValue serialization in LinksTo.serialize).
+          // Also remove the linked card's instance entry so getInstance
+          // returns nothing, forcing the getFile fallback path.
+          let articleAlias = `${testRealmHref}Article/hello-world`;
+          let tagAlias = `${testRealmHref}Tag/programming`;
+          await dbAdapter.execute(
+            `UPDATE boxel_index
+             SET pristine_doc = pristine_doc #- '{relationships,tag,data}'
+             WHERE file_alias = '${articleAlias}'
+             AND type = 'instance'`,
+          );
+          await dbAdapter.execute(
+            `UPDATE boxel_index
+             SET is_deleted = TRUE
+             WHERE file_alias = '${tagAlias}'
+             AND type = 'instance'`,
+          );
+
+          let response2 = await request
+            .get('/Article/hello-world')
+            .set('Accept', 'application/vnd.card+json');
+
+          assert.strictEqual(
+            response2.status,
+            200,
+            `HTTP 200 status after index modification: ${response2.text}`,
+          );
+          let doc2 = response2.body as LooseSingleCardDocument;
+          let tagRelationship2 = doc2.data.relationships?.tag as Relationship;
+          assert.ok(tagRelationship2, 'tag relationship still exists');
+          assert.strictEqual(
+            tagRelationship2.data?.type,
+            'card',
+            'linksTo relationship for a CardDef should use type "card" even when data.type is missing from stale index and the linked instance is unavailable',
+          );
+        });
         test('card-level query-backed relationships resolve via search at read time', async function (assert) {
           let { testRealm: realm, request } = getRealmSetup();
 

--- a/packages/realm-server/tests/card-endpoints-test.ts
+++ b/packages/realm-server/tests/card-endpoints-test.ts
@@ -5,7 +5,11 @@ import { join, basename } from 'path';
 import type { Server } from 'http';
 import type { DirResult } from 'tmp';
 import { existsSync, readJSONSync, statSync } from 'fs-extra';
-import type { Realm, Relationship } from '@cardstack/runtime-common';
+import type {
+  Realm,
+  Relationship,
+  ResourceID,
+} from '@cardstack/runtime-common';
 import {
   baseRealm,
   isSingleCardDocument,
@@ -437,7 +441,7 @@ module(basename(__filename), function () {
           let tagRelationship2 = doc2.data.relationships?.tag as Relationship;
           assert.ok(tagRelationship2, 'tag relationship still exists');
           assert.strictEqual(
-            tagRelationship2.data?.type,
+            (tagRelationship2.data as ResourceID)?.type,
             'card',
             'linksTo relationship for a CardDef should use type "card" even when data.type is missing from stale index and the linked instance is unavailable',
           );

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -839,14 +839,16 @@ export class RealmIndexQueryEngine {
           // relationship.data has the correct type so stale
           // pristine_doc entries (missing data.type) for file
           // relationships are not misidentified as card links.
-          let fallbackRelationshipType: CardResourceType | FileMetaResourceType;
+          let fallbackRelationshipType:
+            | typeof CardResourceType
+            | typeof FileMetaResourceType;
           if (expectsFileMeta) {
             fallbackRelationshipType = FileMetaResourceType;
           } else {
             fallbackRelationshipType =
               (relationshipType as
-                | CardResourceType
-                | FileMetaResourceType
+                | typeof CardResourceType
+                | typeof FileMetaResourceType
                 | undefined) ?? CardResourceType;
           }
           relationship.data = {

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -225,8 +225,7 @@ export class RealmIndexQueryEngine {
       return false;
     }
     try {
-      let definition =
-        await this.#definitionLookup.lookupDefinition(codeRef);
+      let definition = await this.#definitionLookup.lookupDefinition(codeRef);
       // Strip the linksToMany index suffix (e.g., "friends.0" -> "friends")
       let fieldName = fieldKey.includes('.')
         ? fieldKey.slice(0, fieldKey.indexOf('.'))

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -831,16 +831,24 @@ export class RealmIndexQueryEngine {
           included.find((i) => i.id === relationshipId!.href)
         ) {
           relationship.data = {
-            type: linkResource?.type ?? 'card',
+            type: linkResource?.type ?? CardResourceType,
             id: relationshipId.href,
           };
         } else if (!linkResource) {
           // Even when the linked resource is unavailable, ensure
           // relationship.data has the correct type so stale
-          // pristine_doc entries (missing data.type) aren't
-          // misidentified as file-meta on subsequent loads.
+          // pristine_doc entries (missing data.type) for file
+          // relationships are not misidentified as card links.
+          let fallbackRelationshipType: CardResourceType | FileMetaResourceType;
+          if (expectsFileMeta) {
+            fallbackRelationshipType = FileMetaResourceType;
+          } else {
+            fallbackRelationshipType =
+              (relationshipType as CardResourceType | FileMetaResourceType | undefined) ??
+              CardResourceType;
+          }
           relationship.data = {
-            type: relationshipType ?? 'card',
+            type: fallbackRelationshipType,
             id: relationshipId.href,
           };
         }

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -844,8 +844,10 @@ export class RealmIndexQueryEngine {
             fallbackRelationshipType = FileMetaResourceType;
           } else {
             fallbackRelationshipType =
-              (relationshipType as CardResourceType | FileMetaResourceType | undefined) ??
-              CardResourceType;
+              (relationshipType as
+                | CardResourceType
+                | FileMetaResourceType
+                | undefined) ?? CardResourceType;
           }
           relationship.data = {
             type: fallbackRelationshipType,

--- a/packages/runtime-common/url-signature.ts
+++ b/packages/runtime-common/url-signature.ts
@@ -40,7 +40,7 @@ export async function createURLSignature(
 // Node.js implementation
 export function createURLSignatureSync(token: string, url: URL): string {
   // Dynamic import to avoid issues in browser
-  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
   let crypto = require('crypto');
 
   let urlForSigning = new URL(url.href);


### PR DESCRIPTION
## Summary

- When a relationship's `pristine_doc` was missing `data.type` (stale index data from before the NotLoadedValue serialization fix), `loadLinks` would fall through to `getFile` and incorrectly return `file-meta` type for `CardDef` relationships
- Added `fieldExpectsFileMeta()` method that consults the field definition to determine whether a relationship targets `FileDef` or `CardDef` before trying the file index
- Ensures `relationship.data` is set with the correct type even when the linked resource is unavailable

## Test plan

- [x] Added failing test that simulates stale index data (pristine_doc missing `data.type` + linked instance marked deleted), verifies relationship type is `'card'` not `'file-meta'`
- [x] All 14 "card GET request" tests pass (including existing FileDef resource test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)