### PR TITLE
host: Remove Monaco Percy snapshots and add lint rule

### DIFF
--- a/packages/eslint-plugin-boxel/index.js
+++ b/packages/eslint-plugin-boxel/index.js
@@ -4,6 +4,7 @@ module.exports = {
     'template-missing-invokable': require('./lib/rules/template-missing-invokable'),
     'missing-card-api-import': require('./lib/rules/missing-card-api-import'),
     'no-duplicate-imports': require('./lib/rules/no-duplicate-imports'),
+    'no-percy-direct-import': require('./lib/rules/no-percy-direct-import'),
     // Add other rules here
   },
 

--- a/packages/eslint-plugin-boxel/lib/recommended-rules.js
+++ b/packages/eslint-plugin-boxel/lib/recommended-rules.js
@@ -7,5 +7,6 @@
 module.exports = {
   "@cardstack/boxel/missing-card-api-import": "error",
   "@cardstack/boxel/no-duplicate-imports": "error",
+  "@cardstack/boxel/no-percy-direct-import": "error",
   "@cardstack/boxel/template-missing-invokable": "error"
 }

--- a/packages/eslint-plugin-boxel/lib/rules/no-percy-direct-import.js
+++ b/packages/eslint-plugin-boxel/lib/rules/no-percy-direct-import.js
@@ -1,0 +1,43 @@
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Forbid importing percySnapshot directly from @percy/ember; use @cardstack/host/tests/helpers instead',
+      category: 'Best Practices',
+      recommended: true,
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      noPercyDirectImport:
+        "Do not import directly from '@percy/ember'. Use `import { percySnapshot } from '@cardstack/host/tests/helpers'` instead.",
+    },
+  },
+
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value === '@percy/ember') {
+          context.report({
+            node,
+            messageId: 'noPercyDirectImport',
+            fix(fixer) {
+              return fixer.replaceText(
+                node,
+                "import { percySnapshot } from '@cardstack/host/tests/helpers';",
+              );
+            },
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-boxel/tests/lib/rules/no-percy-direct-import-test.js
+++ b/packages/eslint-plugin-boxel/tests/lib/rules/no-percy-direct-import-test.js
@@ -1,0 +1,42 @@
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/no-percy-direct-import');
+const RuleTester = require('eslint').RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('no-percy-direct-import', rule, {
+  valid: [
+    {
+      code: `import { percySnapshot } from '@cardstack/host/tests/helpers';`,
+    },
+    {
+      code: `import { foo } from 'some-other-module';`,
+    },
+  ],
+  invalid: [
+    {
+      code: `import percySnapshot from '@percy/ember';`,
+      errors: [{ messageId: 'noPercyDirectImport' }],
+      output: `import { percySnapshot } from '@cardstack/host/tests/helpers';`,
+    },
+    {
+      code: `import { percySnapshot } from '@percy/ember';`,
+      errors: [{ messageId: 'noPercyDirectImport' }],
+      output: `import { percySnapshot } from '@cardstack/host/tests/helpers';`,
+    },
+  ],
+});

--- a/packages/host/tests/helpers/percy-snapshot.ts
+++ b/packages/host/tests/helpers/percy-snapshot.ts
@@ -1,5 +1,6 @@
 import { pauseTest, settled } from '@ember/test-helpers';
 
+// eslint-disable-next-line @cardstack/boxel/no-percy-direct-import
 import originalPercySnapshot from '@percy/ember';
 
 import QUnit from 'qunit';

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -13,7 +13,6 @@ import {
 import { tracked } from '@glimmer/tracking';
 
 import Plane from '@cardstack/boxel-icons/plane';
-import percySnapshot from '@percy/ember';
 import { getService } from '@universal-ember/test-support';
 import format from 'date-fns/format';
 import parseISO from 'date-fns/parseISO';
@@ -47,6 +46,7 @@ import {
   testRealmURL,
   setupCardLogs,
   saveCard,
+  percySnapshot,
   provideConsumeContext,
   testModuleRealm,
   setupIntegrationTestRealm,

--- a/packages/host/tests/integration/components/formatted-aibot-message-test.gts
+++ b/packages/host/tests/integration/components/formatted-aibot-message-test.gts
@@ -220,8 +220,6 @@ ${REPLACE_MARKER}
     assert.dom('.cdr.line-delete').exists({ count: 2 });
     assert.dom('.cdr.line-insert').exists({ count: 1 });
     assert.dom('[data-test-apply-code-button]').exists();
-
-    await percySnapshot(assert);
   });
 
   test('it will render one diff editor and one standard code block if one search replace block is complete and another is not', async function (assert) {
@@ -318,8 +316,6 @@ let c = 3;
         lines?.innerText === '// existing code ... \nlet a = 1;\nlet c = 3;'
       );
     });
-
-    await percySnapshot(assert);
   });
 
   test('unincremental updates are handled gracefully', async function (assert) {

--- a/packages/host/tests/integration/components/formatted-aibot-message-test.gts
+++ b/packages/host/tests/integration/components/formatted-aibot-message-test.gts
@@ -7,7 +7,6 @@ import { waitUntil } from '@ember/test-helpers';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
-import percySnapshot from '@percy/ember';
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 


### PR DESCRIPTION
This removes snapshots that cause common false negatives, [like here](https://percy.io/Cardstack-1/web/-cardstack-host/builds/46695997/changed/2470524081?browser=firefox&browser_ids=69%2C70&category=changed%2Cunchanged&device_name=&group_snapshots_by=similar_diff&os=&other-browser=&subcategories=unreviewed%2Cchanges_requested&utm_source=github_status_private&viewLayout=side-by-side&viewMode=new&width=1280&widths=1280). We haven’t been able to find a way to stabilise these and they’re a constant noise. Other snapshots may qualify, we can remove them as we see them.

This also adds a custom lint rule that enforces the use of the overridden `percySnapshot`. You can see it warning [here](https://github.com/cardstack/boxel/actions/runs/21770381117/job/62816390508?pr=3961#step:15:44) about the incorrect import, which is now fixed.