### PR TITLE
Add service worker for authenticated image loading

### DIFF
--- a/packages/experiments-realm/AuthenticatedImageTester/1.json
+++ b/packages/experiments-realm/AuthenticatedImageTester/1.json
@@ -1,15 +1,26 @@
 {
   "data": {
-    "type": "card",
-    "attributes": {
-      "title": "SW Auth Image Test",
-      "description": "Tests service worker auth injection for realm-hosted images",
-      "imageUrl": "../logo.png"
-    },
     "meta": {
       "adoptsFrom": {
-        "module": "../authenticated-image-tester",
-        "name": "default"
+        "name": "default",
+        "module": "../authenticated-image-tester"
+      }
+    },
+    "type": "card",
+    "attributes": {
+      "cardInfo": {
+        "name": null,
+        "notes": null,
+        "summary": null,
+        "cardThumbnailURL": null
+      },
+      "imageUrl": "http://localhost:4201/experiments/logo.png"
+    },
+    "relationships": {
+      "cardInfo.theme": {
+        "links": {
+          "self": null
+        }
       }
     }
   }

--- a/packages/experiments-realm/AuthenticatedImageTester/1.json
+++ b/packages/experiments-realm/AuthenticatedImageTester/1.json
@@ -1,0 +1,16 @@
+{
+  "data": {
+    "type": "card",
+    "attributes": {
+      "title": "SW Auth Image Test",
+      "description": "Tests service worker auth injection for realm-hosted images",
+      "imageUrl": "../logo.png"
+    },
+    "meta": {
+      "adoptsFrom": {
+        "module": "../authenticated-image-tester",
+        "name": "default"
+      }
+    }
+  }
+}

--- a/packages/experiments-realm/authenticated-image-tester.gts
+++ b/packages/experiments-realm/authenticated-image-tester.gts
@@ -17,7 +17,8 @@ class AuthenticatedImageTesterIsolated extends Component<
     }
     // Only allow http(s) and relative URLs; reject anything that could
     // break out of a CSS url("...") context (quotes, parens, semicolons).
-    if (/["'();]/.test(url)) {
+    let disallowed = new RegExp('["\u0027();]');
+    if (disallowed.test(url)) {
       return undefined;
     }
     if (

--- a/packages/experiments-realm/authenticated-image-tester.gts
+++ b/packages/experiments-realm/authenticated-image-tester.gts
@@ -1,0 +1,212 @@
+import {
+  CardDef,
+  Component,
+  contains,
+  field,
+} from 'https://cardstack.com/base/card-api';
+import StringField from 'https://cardstack.com/base/string';
+import { htmlSafe } from '@ember/template';
+
+class AuthenticatedImageTesterIsolated extends Component<
+  typeof AuthenticatedImageTester
+> {
+  get backgroundStyle() {
+    let url = this.args.model.imageUrl;
+    if (!url) {
+      return undefined;
+    }
+    return htmlSafe(
+      `background-image: url("${url}"); background-size: contain; background-repeat: no-repeat; background-position: center;`,
+    );
+  }
+
+  <template>
+    <div class='tester'>
+      <h2>Authenticated Image Loading Tester</h2>
+      <p class='description'>
+        This card tests that the auth service worker injects Authorization
+        headers for realm-hosted images. Enter a URL to an image stored in an
+        authenticated realm below.
+      </p>
+
+      <div class='field-group'>
+        <label class='label'>Image URL</label>
+        <@fields.imageUrl @format='edit' />
+      </div>
+
+      {{#if @model.imageUrl}}
+        <div class='tests'>
+          <div class='test-section'>
+            <h3>&lt;img&gt; tag</h3>
+            <p class='hint'>
+              Uses a plain &lt;img src&gt; &#8212; the service worker should
+              intercept this and add the Authorization header.
+            </p>
+            <div class='image-container'>
+              <img
+                class='test-image'
+                src={{@model.imageUrl}}
+                alt='Test image loaded via img tag'
+                loading='lazy'
+              />
+            </div>
+          </div>
+
+          <div class='test-section'>
+            <h3>CSS background-image</h3>
+            <p class='hint'>
+              Uses background-image: url(...) &#8212; the service worker should
+              also intercept this.
+            </p>
+            <div class='image-container'>
+              <div
+                class='background-image-test'
+                role='img'
+                aria-label='Test image loaded via CSS background-image'
+                style={{this.backgroundStyle}}
+              />
+            </div>
+          </div>
+        </div>
+
+        <div class='instructions'>
+          <h3>How to verify</h3>
+          <ol>
+            <li>Open DevTools &rarr; Application &rarr; Service Workers</li>
+            <li>Confirm <code>auth-service-worker.js</code> is active</li>
+            <li>Open DevTools &rarr; Network tab</li>
+            <li>Look for the image request to the realm URL</li>
+            <li>Check that the request has an <code>Authorization: Bearer ...</code>
+              header</li>
+            <li>If both images above render correctly, the service worker is
+              working</li>
+          </ol>
+        </div>
+      {{else}}
+        <div class='empty-state'>
+          Enter a realm image URL above to test. Try a relative path like
+          <code>./logo.png</code> or an absolute realm URL.
+        </div>
+      {{/if}}
+    </div>
+
+    <style scoped>
+      .tester {
+        display: grid;
+        gap: var(--boxel-sp-lg);
+        padding: var(--boxel-sp-xl);
+        max-width: 720px;
+      }
+
+      h2 {
+        margin: 0;
+        font: 700 var(--boxel-font-lg);
+      }
+
+      h3 {
+        margin: 0 0 var(--boxel-sp-xs);
+        font: 600 var(--boxel-font);
+      }
+
+      .description {
+        margin: 0;
+        color: var(--boxel-500);
+        font: var(--boxel-font-sm);
+      }
+
+      .field-group {
+        display: grid;
+        gap: var(--boxel-sp-xxs);
+      }
+
+      .label {
+        font: 600 var(--boxel-font-sm);
+        color: var(--boxel-700);
+      }
+
+      .tests {
+        display: grid;
+        gap: var(--boxel-sp-lg);
+      }
+
+      .test-section {
+        border: 1px solid var(--boxel-200);
+        border-radius: var(--boxel-border-radius);
+        padding: var(--boxel-sp);
+      }
+
+      .hint {
+        margin: 0 0 var(--boxel-sp-sm);
+        font: var(--boxel-font-xs);
+        color: var(--boxel-400);
+      }
+
+      .image-container {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 200px;
+        background: var(--boxel-50);
+        border-radius: var(--boxel-border-radius);
+        overflow: hidden;
+      }
+
+      .test-image {
+        max-width: 100%;
+        max-height: 400px;
+        object-fit: contain;
+      }
+
+      .background-image-test {
+        width: 100%;
+        height: 300px;
+      }
+
+      .instructions {
+        background: var(--boxel-50);
+        border-radius: var(--boxel-border-radius);
+        padding: var(--boxel-sp);
+      }
+
+      .instructions ol {
+        margin: var(--boxel-sp-xs) 0 0;
+        padding-left: var(--boxel-sp-lg);
+      }
+
+      .instructions li {
+        font: var(--boxel-font-sm);
+        margin-bottom: var(--boxel-sp-xxs);
+      }
+
+      .instructions code {
+        background: var(--boxel-200);
+        padding: 1px 4px;
+        border-radius: 3px;
+        font-size: 0.9em;
+      }
+
+      .empty-state {
+        padding: var(--boxel-sp-lg);
+        text-align: center;
+        color: var(--boxel-400);
+        background: var(--boxel-50);
+        border-radius: var(--boxel-border-radius);
+        font: var(--boxel-font-sm);
+      }
+
+      .empty-state code {
+        background: var(--boxel-200);
+        padding: 1px 4px;
+        border-radius: 3px;
+      }
+    </style>
+  </template>
+}
+
+export default class AuthenticatedImageTester extends CardDef {
+  static displayName = 'Authenticated Image Tester';
+
+  @field imageUrl = contains(StringField);
+
+  static isolated = AuthenticatedImageTesterIsolated;
+}

--- a/packages/experiments-realm/authenticated-image-tester.gts
+++ b/packages/experiments-realm/authenticated-image-tester.gts
@@ -10,8 +10,29 @@ import { htmlSafe } from '@ember/template';
 class AuthenticatedImageTesterIsolated extends Component<
   typeof AuthenticatedImageTester
 > {
-  get backgroundStyle() {
+  get sanitizedImageUrl(): string | undefined {
     let url = this.args.model.imageUrl;
+    if (!url) {
+      return undefined;
+    }
+    // Only allow http(s) and relative URLs; reject anything that could
+    // break out of a CSS url("...") context (quotes, parens, semicolons).
+    if (/["'();]/.test(url)) {
+      return undefined;
+    }
+    if (
+      url.startsWith('http://') ||
+      url.startsWith('https://') ||
+      url.startsWith('./') ||
+      url.startsWith('/')
+    ) {
+      return url;
+    }
+    return undefined;
+  }
+
+  get backgroundStyle() {
+    let url = this.sanitizedImageUrl;
     if (!url) {
       return undefined;
     }
@@ -45,7 +66,7 @@ class AuthenticatedImageTesterIsolated extends Component<
             <div class='image-container'>
               <img
                 class='test-image'
-                src={{@model.imageUrl}}
+                src={{this.sanitizedImageUrl}}
                 alt='Example loaded via img tag'
                 loading='lazy'
               />

--- a/packages/experiments-realm/authenticated-image-tester.gts
+++ b/packages/experiments-realm/authenticated-image-tester.gts
@@ -46,7 +46,7 @@ class AuthenticatedImageTesterIsolated extends Component<
               <img
                 class='test-image'
                 src={{@model.imageUrl}}
-                alt='Test image loaded via img tag'
+                alt='Example loaded via img tag'
                 loading='lazy'
               />
             </div>
@@ -76,7 +76,8 @@ class AuthenticatedImageTesterIsolated extends Component<
             <li>Confirm <code>auth-service-worker.js</code> is active</li>
             <li>Open DevTools &rarr; Network tab</li>
             <li>Look for the image request to the realm URL</li>
-            <li>Check that the request has an <code>Authorization: Bearer ...</code>
+            <li>Check that the request has an
+              <code>Authorization: Bearer ...</code>
               header</li>
             <li>If both images above render correctly, the service worker is
               working</li>
@@ -85,7 +86,8 @@ class AuthenticatedImageTesterIsolated extends Component<
       {{else}}
         <div class='empty-state'>
           Enter a realm image URL above to test. Try a relative path like
-          <code>./logo.png</code> or an absolute realm URL.
+          <code>./logo.png</code>
+          or an absolute realm URL.
         </div>
       {{/if}}
     </div>

--- a/packages/host/app/instance-initializers/register-auth-service-worker.ts
+++ b/packages/host/app/instance-initializers/register-auth-service-worker.ts
@@ -1,0 +1,14 @@
+import type ApplicationInstance from '@ember/application/instance';
+
+import { registerAuthServiceWorker } from '../utils/auth-service-worker-registration';
+
+// Register the auth service worker eagerly at app boot, before any lazy
+// services are instantiated. This ensures realm tokens are synced to the
+// SW before card rendering triggers image requests to authenticated realms.
+export function initialize(_appInstance: ApplicationInstance): void {
+  registerAuthServiceWorker();
+}
+
+export default {
+  initialize,
+};

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -40,7 +40,6 @@ import type {
 } from 'https://cardstack.com/base/matrix-event';
 
 import {
-  registerAuthServiceWorker,
   syncTokenToServiceWorker,
   syncAllTokensToServiceWorker,
   clearServiceWorkerTokens,
@@ -660,7 +659,6 @@ export default class RealmService extends Service {
   constructor(owner: Owner) {
     super(owner);
     this.reset.register(this);
-    registerAuthServiceWorker();
   }
 
   get realms(): ReadonlyMap<string, RealmResource> {

--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -273,6 +273,7 @@ class RealmResource {
     this.fetchingInfo = undefined;
     this.fetchRealmPermissionsTask.cancelAll();
     window.localStorage.removeItem(SessionLocalStorageKey);
+    syncTokenToServiceWorker(this.realmURL, undefined);
   }
 
   private fetchingInfo: Promise<void> | undefined;

--- a/packages/host/app/utils/auth-service-worker-registration.ts
+++ b/packages/host/app/utils/auth-service-worker-registration.ts
@@ -8,6 +8,8 @@ import { isTesting } from '@embroider/macros';
 
 import window from 'ember-window-mock';
 
+import { SessionLocalStorageKey } from './local-storage-keys';
+
 function isServiceWorkerSupported(): boolean {
   return (
     !isTesting() &&
@@ -108,11 +110,9 @@ export function clearServiceWorkerTokens(): void {
   controller.postMessage({ type: 'clear-tokens' });
 }
 
-const SESSION_LOCAL_STORAGE_KEY = 'boxel-session';
-
 function readTokensFromStorage(): Record<string, string> | undefined {
   try {
-    let sessionsString = window.localStorage.getItem(SESSION_LOCAL_STORAGE_KEY);
+    let sessionsString = window.localStorage.getItem(SessionLocalStorageKey);
     if (sessionsString) {
       return JSON.parse(sessionsString);
     }

--- a/packages/host/app/utils/auth-service-worker-registration.ts
+++ b/packages/host/app/utils/auth-service-worker-registration.ts
@@ -1,0 +1,115 @@
+// Manages registration and token synchronization with the auth service worker.
+//
+// The auth service worker intercepts resource requests (images, CSS backgrounds)
+// to realm servers and injects Authorization headers, solving the problem that
+// <img> elements and CSS background-image: url(...) cannot send custom headers.
+
+import { isTesting } from '@embroider/macros';
+
+import window from 'ember-window-mock';
+
+let registrationPromise: Promise<ServiceWorkerRegistration> | undefined;
+
+function isServiceWorkerSupported(): boolean {
+  return (
+    !isTesting() &&
+    typeof navigator !== 'undefined' &&
+    'serviceWorker' in navigator
+  );
+}
+
+export async function registerAuthServiceWorker(): Promise<void> {
+  if (!isServiceWorkerSupported()) {
+    return;
+  }
+
+  try {
+    registrationPromise = navigator.serviceWorker.register(
+      '/auth-service-worker.js',
+      { scope: '/' },
+    );
+    await registrationPromise;
+
+    // When a new service worker takes over, re-sync all tokens
+    navigator.serviceWorker.addEventListener('controllerchange', () => {
+      let tokens = readTokensFromStorage();
+      if (tokens) {
+        syncAllTokensToServiceWorker(tokens);
+      }
+    });
+  } catch (e) {
+    console.warn('Failed to register auth service worker:', e);
+  }
+}
+
+export function syncTokenToServiceWorker(
+  realmURL: string,
+  token: string | undefined,
+): void {
+  if (!isServiceWorkerSupported()) {
+    return;
+  }
+
+  let controller = navigator.serviceWorker.controller;
+  if (!controller) {
+    return;
+  }
+
+  if (token) {
+    controller.postMessage({
+      type: 'set-realm-token',
+      realmURL,
+      token,
+    });
+  } else {
+    controller.postMessage({
+      type: 'remove-realm-token',
+      realmURL,
+    });
+  }
+}
+
+export function syncAllTokensToServiceWorker(
+  tokens: Record<string, string>,
+): void {
+  if (!isServiceWorkerSupported()) {
+    return;
+  }
+
+  let controller = navigator.serviceWorker.controller;
+  if (!controller) {
+    return;
+  }
+
+  controller.postMessage({
+    type: 'sync-tokens',
+    tokens,
+  });
+}
+
+export function clearServiceWorkerTokens(): void {
+  if (!isServiceWorkerSupported()) {
+    return;
+  }
+
+  let controller = navigator.serviceWorker.controller;
+  if (!controller) {
+    return;
+  }
+
+  controller.postMessage({ type: 'clear-tokens' });
+}
+
+const SESSION_LOCAL_STORAGE_KEY = 'boxel-session';
+
+function readTokensFromStorage(): Record<string, string> | undefined {
+  try {
+    let sessionsString = window.localStorage.getItem(SESSION_LOCAL_STORAGE_KEY);
+    if (sessionsString) {
+      return JSON.parse(sessionsString);
+    }
+  } catch {
+    // ignore parse errors
+  }
+  return undefined;
+}

--- a/packages/host/public/auth-service-worker.js
+++ b/packages/host/public/auth-service-worker.js
@@ -1,0 +1,99 @@
+// Service worker that injects Authorization headers for realm server requests.
+//
+// <img> elements and CSS background-image: url(...) cannot send Authorization
+// headers. This service worker intercepts those requests and adds the JWT
+// Bearer token so that authenticated realm images load correctly.
+//
+// Tokens are synced from the main thread via postMessage.
+
+// Map of realm URL prefix → JWT token
+const realmTokens = new Map();
+
+self.addEventListener('install', () => {
+  // Activate immediately, don't wait for existing clients to close
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  // Take control of all open clients immediately
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('message', (event) => {
+  let { data } = event;
+  if (!data || !data.type) {
+    return;
+  }
+
+  switch (data.type) {
+    case 'set-realm-token':
+      if (data.realmURL && data.token) {
+        realmTokens.set(data.realmURL, data.token);
+      }
+      break;
+    case 'remove-realm-token':
+      if (data.realmURL) {
+        realmTokens.delete(data.realmURL);
+      }
+      break;
+    case 'clear-tokens':
+      realmTokens.clear();
+      break;
+    case 'sync-tokens':
+      // Bulk sync: data.tokens is a {realmURL: token} object
+      realmTokens.clear();
+      if (data.tokens) {
+        for (let [realmURL, token] of Object.entries(data.tokens)) {
+          if (token) {
+            realmTokens.set(realmURL, token);
+          }
+        }
+      }
+      break;
+  }
+});
+
+self.addEventListener('fetch', (event) => {
+  let request = event.request;
+
+  // Only inject auth for GET and HEAD requests (resource loading).
+  // Other methods (POST, PUT, DELETE, etc.) are handled by the app's
+  // fetch middleware which already adds Authorization headers.
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    return;
+  }
+
+  // Don't inject if request already has an Authorization header
+  if (request.headers.get('Authorization')) {
+    return;
+  }
+
+  let url = request.url;
+
+  // Find the matching realm token with longest-prefix match
+  let matchedRealmURL = null;
+  let matchedToken = null;
+  for (let [realmURL, token] of realmTokens) {
+    if (url.startsWith(realmURL)) {
+      if (!matchedRealmURL || realmURL.length > matchedRealmURL.length) {
+        matchedRealmURL = realmURL;
+        matchedToken = token;
+      }
+    }
+  }
+
+  if (!matchedToken) {
+    // Not a realm URL or no token available — pass through unchanged
+    return;
+  }
+
+  // Create a new request with the Authorization header injected
+  let headers = new Headers(request.headers);
+  headers.set('Authorization', `Bearer ${matchedToken}`);
+
+  let authedRequest = new Request(request, {
+    headers,
+  });
+
+  event.respondWith(fetch(authedRequest));
+});

--- a/packages/host/public/auth-service-worker.js
+++ b/packages/host/public/auth-service-worker.js
@@ -97,12 +97,9 @@ self.addEventListener('fetch', (event) => {
   let headers = new Headers(request.headers);
   headers.set('Authorization', `Bearer ${matchedToken}`);
 
-  let authedRequest = new Request(request.url, {
-    method: request.method,
+  let authedRequest = new Request(request, {
     headers,
     mode: 'cors',
-    credentials: 'same-origin',
-    redirect: 'follow',
   });
 
   event.respondWith(fetch(authedRequest));

--- a/packages/host/public/auth-service-worker.js
+++ b/packages/host/public/auth-service-worker.js
@@ -97,9 +97,14 @@ self.addEventListener('fetch', (event) => {
   let headers = new Headers(request.headers);
   headers.set('Authorization', `Bearer ${matchedToken}`);
 
+  // credentials must be explicitly set to 'same-origin' because cross-origin
+  // <img> requests default to 'include', and credentials: 'include' with
+  // mode: 'cors' requires the server to send a specific origin in
+  // Access-Control-Allow-Origin (not '*'), which the realm server doesn't do.
   let authedRequest = new Request(request, {
     headers,
     mode: 'cors',
+    credentials: 'same-origin',
   });
 
   event.respondWith(fetch(authedRequest));

--- a/packages/host/public/auth-service-worker.js
+++ b/packages/host/public/auth-service-worker.js
@@ -87,12 +87,22 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
-  // Create a new request with the Authorization header injected
+  // Create a new request with the Authorization header injected.
+  //
+  // Cross-origin <img> and CSS background-image requests arrive with
+  // mode: 'no-cors', which silently strips non-safelisted headers like
+  // Authorization. We must upgrade to mode: 'cors' so the header is
+  // actually sent. The realm server already supports CORS with
+  // Access-Control-Allow-Origin: * and Authorization in allowed headers.
   let headers = new Headers(request.headers);
   headers.set('Authorization', `Bearer ${matchedToken}`);
 
-  let authedRequest = new Request(request, {
+  let authedRequest = new Request(request.url, {
+    method: request.method,
     headers,
+    mode: 'cors',
+    credentials: 'same-origin',
+    redirect: 'follow',
   });
 
   event.respondWith(fetch(authedRequest));

--- a/packages/host/tests/unit/auth-service-worker-test.ts
+++ b/packages/host/tests/unit/auth-service-worker-test.ts
@@ -1,0 +1,300 @@
+import { module, test } from 'qunit';
+
+// Test the auth service worker's fetch interception logic by simulating
+// the SW environment. The actual SW is at public/auth-service-worker.js.
+//
+// We duplicate the core logic here (token matching, fetch interception)
+// to test it in a standard QUnit context where service workers aren't available.
+
+function createServiceWorkerEnv() {
+  const realmTokens = new Map<string, string>();
+
+  let processMessage = (data: any) => {
+    if (!data || !data.type) return;
+    switch (data.type) {
+      case 'set-realm-token':
+        if (data.realmURL && data.token) {
+          realmTokens.set(data.realmURL, data.token);
+        }
+        break;
+      case 'remove-realm-token':
+        if (data.realmURL) {
+          realmTokens.delete(data.realmURL);
+        }
+        break;
+      case 'clear-tokens':
+        realmTokens.clear();
+        break;
+      case 'sync-tokens':
+        realmTokens.clear();
+        if (data.tokens) {
+          for (let [realmURL, token] of Object.entries(data.tokens)) {
+            if (token) {
+              realmTokens.set(realmURL, token as string);
+            }
+          }
+        }
+        break;
+    }
+  };
+
+  let processFetch = (request: Request): Request | null => {
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+      return null; // pass through
+    }
+    if (request.headers.get('Authorization')) {
+      return null; // pass through
+    }
+
+    let url = request.url;
+    let matchedRealmURL: string | null = null;
+    let matchedToken: string | null = null;
+    for (let [realmURL, token] of realmTokens) {
+      if (url.startsWith(realmURL)) {
+        if (!matchedRealmURL || realmURL.length > matchedRealmURL.length) {
+          matchedRealmURL = realmURL;
+          matchedToken = token;
+        }
+      }
+    }
+
+    if (!matchedToken) {
+      return null; // pass through
+    }
+
+    let headers = new Headers(request.headers);
+    headers.set('Authorization', `Bearer ${matchedToken}`);
+    return new Request(request, { headers });
+  };
+
+  return { processMessage, processFetch, realmTokens };
+}
+
+module('Unit | auth-service-worker', function () {
+  module('token management via messages', function () {
+    test('set-realm-token stores a token', function (assert) {
+      let sw = createServiceWorkerEnv();
+
+      sw.processMessage({
+        type: 'set-realm-token',
+        realmURL: 'http://localhost:4201/user/realm/',
+        token: 'jwt-token-123',
+      });
+
+      assert.strictEqual(sw.realmTokens.size, 1);
+      assert.strictEqual(
+        sw.realmTokens.get('http://localhost:4201/user/realm/'),
+        'jwt-token-123',
+      );
+    });
+
+    test('remove-realm-token deletes a token', function (assert) {
+      let sw = createServiceWorkerEnv();
+
+      sw.processMessage({
+        type: 'set-realm-token',
+        realmURL: 'http://localhost:4201/user/realm/',
+        token: 'jwt-token-123',
+      });
+      sw.processMessage({
+        type: 'remove-realm-token',
+        realmURL: 'http://localhost:4201/user/realm/',
+      });
+
+      assert.strictEqual(sw.realmTokens.size, 0);
+    });
+
+    test('clear-tokens removes all tokens', function (assert) {
+      let sw = createServiceWorkerEnv();
+
+      sw.processMessage({
+        type: 'set-realm-token',
+        realmURL: 'http://localhost:4201/realm-a/',
+        token: 'token-a',
+      });
+      sw.processMessage({
+        type: 'set-realm-token',
+        realmURL: 'http://localhost:4201/realm-b/',
+        token: 'token-b',
+      });
+      sw.processMessage({ type: 'clear-tokens' });
+
+      assert.strictEqual(sw.realmTokens.size, 0);
+    });
+
+    test('sync-tokens replaces all tokens', function (assert) {
+      let sw = createServiceWorkerEnv();
+
+      sw.processMessage({
+        type: 'set-realm-token',
+        realmURL: 'http://localhost:4201/old-realm/',
+        token: 'old-token',
+      });
+
+      sw.processMessage({
+        type: 'sync-tokens',
+        tokens: {
+          'http://localhost:4201/realm-a/': 'token-a',
+          'http://localhost:4201/realm-b/': 'token-b',
+        },
+      });
+
+      assert.strictEqual(sw.realmTokens.size, 2);
+      assert.strictEqual(
+        sw.realmTokens.get('http://localhost:4201/realm-a/'),
+        'token-a',
+      );
+      assert.strictEqual(
+        sw.realmTokens.get('http://localhost:4201/realm-b/'),
+        'token-b',
+      );
+      assert.strictEqual(
+        sw.realmTokens.get('http://localhost:4201/old-realm/'),
+        undefined,
+        'old token was replaced',
+      );
+    });
+
+    test('ignores messages with missing type', function (assert) {
+      let sw = createServiceWorkerEnv();
+      sw.processMessage({});
+      sw.processMessage(null);
+      sw.processMessage({ realmURL: 'http://example.com/', token: 'x' });
+      assert.strictEqual(sw.realmTokens.size, 0);
+    });
+  });
+
+  module('fetch interception', function () {
+    test('injects Authorization header for matching realm URL', function (assert) {
+      let sw = createServiceWorkerEnv();
+
+      sw.processMessage({
+        type: 'set-realm-token',
+        realmURL: 'http://localhost:4201/user/realm/',
+        token: 'my-jwt-token',
+      });
+
+      let request = new Request(
+        'http://localhost:4201/user/realm/images/photo.png',
+      );
+      let result = sw.processFetch(request);
+
+      assert.ok(result, 'request was intercepted');
+      assert.strictEqual(
+        result!.headers.get('Authorization'),
+        'Bearer my-jwt-token',
+      );
+    });
+
+    test('passes through requests to non-realm URLs', function (assert) {
+      let sw = createServiceWorkerEnv();
+
+      sw.processMessage({
+        type: 'set-realm-token',
+        realmURL: 'http://localhost:4201/user/realm/',
+        token: 'my-jwt-token',
+      });
+
+      let request = new Request('https://cdn.example.com/image.png');
+      let result = sw.processFetch(request);
+
+      assert.strictEqual(result, null, 'request was not intercepted');
+    });
+
+    test('passes through POST requests even for realm URLs', function (assert) {
+      let sw = createServiceWorkerEnv();
+
+      sw.processMessage({
+        type: 'set-realm-token',
+        realmURL: 'http://localhost:4201/user/realm/',
+        token: 'my-jwt-token',
+      });
+
+      let request = new Request('http://localhost:4201/user/realm/card.json', {
+        method: 'POST',
+      });
+      let result = sw.processFetch(request);
+
+      assert.strictEqual(result, null, 'POST request was not intercepted');
+    });
+
+    test('passes through requests that already have Authorization header', function (assert) {
+      let sw = createServiceWorkerEnv();
+
+      sw.processMessage({
+        type: 'set-realm-token',
+        realmURL: 'http://localhost:4201/user/realm/',
+        token: 'my-jwt-token',
+      });
+
+      let request = new Request('http://localhost:4201/user/realm/card.json', {
+        headers: { Authorization: 'Bearer existing-token' },
+      });
+      let result = sw.processFetch(request);
+
+      assert.strictEqual(
+        result,
+        null,
+        'request with existing auth was not intercepted',
+      );
+    });
+
+    test('uses longest-prefix match when multiple realms match', function (assert) {
+      let sw = createServiceWorkerEnv();
+
+      sw.processMessage({
+        type: 'set-realm-token',
+        realmURL: 'http://localhost:4201/',
+        token: 'server-token',
+      });
+      sw.processMessage({
+        type: 'set-realm-token',
+        realmURL: 'http://localhost:4201/user/realm/',
+        token: 'realm-specific-token',
+      });
+
+      let request = new Request(
+        'http://localhost:4201/user/realm/images/photo.png',
+      );
+      let result = sw.processFetch(request);
+
+      assert.ok(result, 'request was intercepted');
+      assert.strictEqual(
+        result!.headers.get('Authorization'),
+        'Bearer realm-specific-token',
+        'used the more specific realm token',
+      );
+    });
+
+    test('intercepts HEAD requests', function (assert) {
+      let sw = createServiceWorkerEnv();
+
+      sw.processMessage({
+        type: 'set-realm-token',
+        realmURL: 'http://localhost:4201/user/realm/',
+        token: 'my-jwt-token',
+      });
+
+      let request = new Request(
+        'http://localhost:4201/user/realm/images/photo.png',
+        { method: 'HEAD' },
+      );
+      let result = sw.processFetch(request);
+
+      assert.ok(result, 'HEAD request was intercepted');
+      assert.strictEqual(
+        result!.headers.get('Authorization'),
+        'Bearer my-jwt-token',
+      );
+    });
+
+    test('returns null when no tokens are set', function (assert) {
+      let sw = createServiceWorkerEnv();
+
+      let request = new Request('http://localhost:4201/user/realm/image.png');
+      let result = sw.processFetch(request);
+
+      assert.strictEqual(result, null, 'no interception without tokens');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a service worker that intercepts cross-origin `<img>` and CSS `background-image` requests to realm servers and injects `Authorization: Bearer <jwt>` headers
- No server-side changes needed — the existing CORS config (`origin: *` with `Authorization` in allowed headers) works as-is
- No card template changes needed — existing `<img src={{@model.url}}>` patterns work transparently
- Replaces a previous cookie-based approach that was incompatible with wildcard CORS origins

### How it works

1. An instance initializer registers the service worker at app boot
2. Per-realm JWT tokens are synced to the SW via `postMessage` whenever they're created, refreshed, or removed
3. The SW intercepts GET/HEAD requests matching known realm URL prefixes and adds the `Authorization` header
4. The SW upgrades `no-cors` requests (used by `<img>` elements) to `cors` mode so the header isn't silently stripped

### Key files

| File | Purpose |
|---|---|
| `packages/host/public/auth-service-worker.js` | The service worker — token storage, fetch interception, auth injection |
| `packages/host/app/utils/auth-service-worker-registration.ts` | Registration, token sync via postMessage, lifecycle management |
| `packages/host/app/instance-initializers/register-auth-service-worker.ts` | Eager boot at app startup |
| `packages/host/app/services/realm.ts` | Integration: sync on persist/restore, clear on logout |
| `packages/host/tests/unit/auth-service-worker-test.ts` | Unit tests for token management and fetch interception logic |
| `packages/experiments-realm/authenticated-image-tester.gts` | Test card for manual verification |

Closes CS-10159

## Test plan

- [x] Verified locally: authenticated realm images load via both `<img>` tag and CSS `background-image`
- [x] Verify service worker registers and activates on fresh browser (no prior SW)
- [x] Verify images load after page refresh (tokens synced from localStorage)
- [x] Verify logout clears SW tokens (images stop loading)
- [x] Verify non-realm URLs (external CDNs, etc.) are not affected
- [x] Run existing test suite to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)