### PR TITLE
Fix cards entering a broken state when reindexing a subdomain based published realm

### DIFF
--- a/packages/host/app/services/realm.ts
+++ b/packages/host/app/services/realm.ts
@@ -299,7 +299,11 @@ class RealmResource {
       try {
         response = await this.network.authedFetch(`${this.realmURL}_info`, {
           method: 'QUERY',
-          headers,
+          headers: {
+            ...headers,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ realms: [this.realmURL] }),
         });
       } catch (error) {
         if (isTesting()) {
@@ -328,12 +332,14 @@ class RealmResource {
         );
       }
       let json = await waitForPromise(response.json());
+      let realmData = Array.isArray(json.data) ? json.data[0] : json.data;
       let info: RealmInfo = {
-        url: json.data.id,
-        ...json.data.attributes,
+        url: realmData.id,
+        ...realmData.attributes,
       };
       let isPublic = Boolean(
-        response.headers.get('x-boxel-realm-public-readable'),
+        response.headers.get('x-boxel-realm-public-readable') ||
+        response.headers.get('x-boxel-realms-public-readable'),
       );
       this.info = new TrackedObject({ ...info, isIndexing: false, isPublic });
     } finally {

--- a/packages/realm-server/tests/server-endpoints/info-test.ts
+++ b/packages/realm-server/tests/server-endpoints/info-test.ts
@@ -220,17 +220,5 @@ module(`server-endpoints/${basename(__filename)}`, function (_hooks) {
         'realm name is correct',
       );
     });
-
-    test('QUERY /_info returns 400 when called without body (reproduces subdomain realm bug)', async function (assert) {
-      // Before the fix, the host app sent QUERY to /_info without a body.
-      // For subdomain realms at root path, this hits the server-level route
-      // which requires a realms array in the body, resulting in 400.
-      let response = await request
-        .post('/_info')
-        .set('X-HTTP-Method-Override', 'QUERY')
-        .set('Accept', 'application/vnd.api+json');
-
-      assert.strictEqual(response.status, 400, 'HTTP 400 status without body');
-    });
   });
 });

--- a/packages/realm-server/tests/server-endpoints/info-test.ts
+++ b/packages/realm-server/tests/server-endpoints/info-test.ts
@@ -196,5 +196,41 @@ module(`server-endpoints/${basename(__filename)}`, function (_hooks) {
         'response explains missing realms list',
       );
     });
+
+    test('QUERY /_info returns info for a public realm without auth when realms body is provided', async function (assert) {
+      // This tests the scenario where a subdomain-based realm at root path
+      // (e.g. http://hi.localhost:4201/) sends QUERY to /_info. The path /_info
+      // matches the server-level route (not the realm's own handler), so the
+      // request body with realms array is required.
+      let response = await request
+        .post('/_info')
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', 'application/vnd.api+json')
+        .send({ realms: [testRealm.url] });
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      let { data } = response.body as {
+        data: { id: string; type: string; attributes: { name: string } }[];
+      };
+      assert.strictEqual(data.length, 1, 'returns info for one realm');
+      assert.strictEqual(data[0].id, testRealm.url, 'realm id is correct');
+      assert.strictEqual(
+        data[0].attributes.name,
+        'Primary Realm',
+        'realm name is correct',
+      );
+    });
+
+    test('QUERY /_info returns 400 when called without body (reproduces subdomain realm bug)', async function (assert) {
+      // Before the fix, the host app sent QUERY to /_info without a body.
+      // For subdomain realms at root path, this hits the server-level route
+      // which requires a realms array in the body, resulting in 400.
+      let response = await request
+        .post('/_info')
+        .set('X-HTTP-Method-Override', 'QUERY')
+        .set('Accept', 'application/vnd.api+json');
+
+      assert.strictEqual(response.status, 400, 'HTTP 400 status without body');
+    });
   });
 });


### PR DESCRIPTION
if you have a published realm with a subdomain (i.e. `http://hi.localhost:4201/`) and then reindex the realm, it will put the containing cards into an error state with this error (I borrowed this screenshot from @backspace, but I was struggling with the same issue locally):

<img width="569" height="187" alt="image" src="https://github.com/user-attachments/assets/618cf0fc-64e2-46f1-ac65-4c15b90419b3" />


