### PR TITLE
Fix SQLite schema: add missing last_known_good_deps column

### DIFF
--- a/packages/host/config/schema/1770616671686_schema.sql
+++ b/packages/host/config/schema/1770616671686_schema.sql
@@ -40,6 +40,7 @@
    icon_html TEXT,
    head_html TEXT,
    has_error BOOLEAN DEFAULT false NOT NULL,
+   last_known_good_deps BLOB,
    PRIMARY KEY ( url, realm_url, type ) 
 );
 
@@ -66,6 +67,7 @@
    resource_created_at,
    head_html TEXT,
    has_error BOOLEAN DEFAULT false NOT NULL,
+   last_known_good_deps BLOB,
    PRIMARY KEY ( url, realm_url, type ) 
 );
 


### PR DESCRIPTION
## Problem

PR #3963 ("Add bot commands endpoints") introduced a new SQLite schema file (`1770616671686_schema.sql`) that was generated without the `last_known_good_deps` column. This column was added by migration `1770139812965_add-last-known-good-deps` and exists in the older schema file, but was lost when the new schema was generated.

This causes **all 16 Host Tests shards to fail** on `main` because:
1. The code tries to INSERT `last_known_good_deps` into `boxel_index_working`
2. The column doesn't exist in the SQLite schema
3. Indexing fails → no cards load → every test fails

```
SQLITE_ERROR: sqlite3 result code 1: table boxel_index_working has no column named last_known_good_deps
```

## Fix

Adds `last_known_good_deps BLOB` back to both `boxel_index` and `boxel_index_working` tables in `1770616671686_schema.sql`.