### PR TITLE
server: Remove index.html caching in development

### DIFF
--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -554,16 +554,19 @@ export class RealmServer {
   }
 
   private async retrieveIndexHTML(): Promise<string> {
-    if (this.promiseForIndexHTML) {
-      // This is optimized for production, in that we won't be changing index
-      // HTML after we start. However, in development this might be annoying
-      // because it means restarting the realm server to pick up ember-cli
-      // rebuilds in the case where you want to test with the the realm server
-      // specifically and not ember cli hosted app.
+    // Cache index.html in production only
+    let isDev = this.assetsURL.hostname === 'localhost';
+
+    if (!isDev && this.promiseForIndexHTML) {
       return this.promiseForIndexHTML;
     }
+
     let deferred = new Deferred<string>();
-    this.promiseForIndexHTML = deferred.promise;
+
+    if (!isDev) {
+      this.promiseForIndexHTML = deferred.promise;
+    }
+
     let indexHTML = (await this.getIndexHTML()).replace(
       /(<meta name="@cardstack\/host\/config\/environment" content=")([^"].*)(">)/,
       (_match, g1, g2, g3) => {


### PR DESCRIPTION
This makes working on host mode a bit easier. The realm server will still
often need to be restarted, but this will help somewhat.