### PR TITLE
Add retry logic for transient CI infrastructure failures

### DIFF
--- a/packages/matrix/scripts/register-realm-users.sh
+++ b/packages/matrix/scripts/register-realm-users.sh
@@ -1,7 +1,7 @@
 #! /bin/sh
 
 COUNT=0
-MAX_ATTEMPTS=10
+MAX_ATTEMPTS=24
 
 until $(curl --output /dev/null --silent --head --fail http://localhost:8008); do
   printf '.'


### PR DESCRIPTION
## Summary
- Add `dockerPull` helper with 3 retries (5s delay) before `docker run` to handle transient Docker Hub errors (e.g. HTTP 500 when pulling `rnwood/smtp4dev` or `matrixdotorg/synapse`)
- Increase Synapse wait timeout in `register-realm-users.sh` from 50s (10 attempts) to 120s (24 attempts) to handle slow CI runners

## Test plan
- [ ] Verify Docker containers still start correctly in CI (Synapse + SMTP4Dev)
- [ ] Verify `register-realm-users` step succeeds in Realm Server Tests
- [ ] Verify Matrix Client Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)