### PR TITLE
Fix files with percent-encoded filenames failing to index

### DIFF
--- a/packages/base/file-api.gts
+++ b/packages/base/file-api.gts
@@ -108,7 +108,9 @@ export class FileDef extends BaseDef {
     options: { contentHash?: string } = {},
   ): Promise<SerializedFile> {
     let parsed = new URL(url);
-    let name = parsed.pathname.split('/').pop() ?? parsed.pathname;
+    let name = decodeURIComponent(
+      parsed.pathname.split('/').pop() ?? parsed.pathname,
+    );
     let contentType = inferContentType(name);
     let contentHash: string | undefined = options.contentHash;
     if (!contentHash) {

--- a/packages/experiments-realm/🎉hello.txt
+++ b/packages/experiments-realm/🎉hello.txt
@@ -1,0 +1,1 @@
+Hello! This file has an emoji in its name.

--- a/packages/host/app/routes/render/file-extract.ts
+++ b/packages/host/app/routes/render/file-extract.ts
@@ -110,13 +110,12 @@ export default class RenderFileExtractRoute extends Route<Model> {
     }
 
     let fileDefCodeRef = parsedOptions.fileDefCodeRef ?? BASE_FILE_DEF_CODE_REF;
-    let fileURL = this.#decodeURL(id);
     let contentHash: string | undefined = parsedOptions.fileContentHash;
     let extractor = new FileDefAttributesExtractor({
       loaderService: this.loaderService,
       network: this.network,
       authGuard: this.#authGuard,
-      fileURL,
+      fileURL: id,
       fileDefCodeRef,
       baseFileDefCodeRef: BASE_FILE_DEF_CODE_REF,
       contentHash,
@@ -124,18 +123,10 @@ export default class RenderFileExtractRoute extends Route<Model> {
     });
     let result = await extractor.extract();
     return {
-      id: fileURL,
+      id,
       nonce,
       ...result,
     };
-  }
-
-  #decodeURL(id: string): string {
-    try {
-      return decodeURIComponent(id);
-    } catch {
-      return id;
-    }
   }
 
   #buildError(url: string, error: any): RenderError {

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -893,7 +893,10 @@ module(basename(__filename), function () {
         'text/plain',
         'search_doc includes contentType',
       );
-      assert.ok(entry?.searchDoc?.contentHash, 'search_doc includes contentHash');
+      assert.ok(
+        entry?.searchDoc?.contentHash,
+        'search_doc includes contentHash',
+      );
     });
 
     test('indexes executable files as file entries too', async function (assert) {

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -411,6 +411,7 @@ function makeTestRealmFileSystem(): Record<
     'random-file.txt': 'hello',
     'random-file.mismatch': 'mismatch content',
     'random-image.png': 'i am an image',
+    '🎉hello.txt': 'emoji filename content',
     '.DS_Store':
       'In  macOS, .DS_Store is a file that stores custom attributes of its containing folder',
   };
@@ -874,6 +875,25 @@ module(basename(__filename), function () {
       assert.strictEqual(rows.length, 1, 'file entry is in the index');
       assert.strictEqual(rows[0].type, 'file', 'file entry type is file');
       assert.ok(rows[0].last_modified, 'file entry has last_modified');
+    });
+
+    test('indexes files with emoji in filename', async function (assert) {
+      let entry = await realm.realmIndexQueryEngine.file(
+        new URL(`${testRealm}%F0%9F%8E%89hello.txt`),
+      );
+      assert.ok(entry, 'file entry exists for emoji filename');
+      assert.strictEqual(entry?.type, 'file', 'file entry type is file');
+      assert.strictEqual(
+        entry?.searchDoc?.name,
+        '🎉hello.txt',
+        'search_doc name contains decoded emoji filename',
+      );
+      assert.strictEqual(
+        entry?.searchDoc?.contentType,
+        'text/plain',
+        'search_doc includes contentType',
+      );
+      assert.ok(entry?.searchDoc?.contentHash, 'search_doc includes contentHash');
     });
 
     test('indexes executable files as file entries too', async function (assert) {


### PR DESCRIPTION
## Summary
- **Root cause**: The prerender file-extract route decoded percent-encoded URLs (e.g. `%F0%9F%8E%89` → `🎉`) in the response `id`, but the capture function compared against the original percent-encoded `expectedId`. They never matched for non-ASCII filenames, causing a 30s timeout and an error entry in the index.
- **Retry resilience**: `TypeError: fetch failed` from Node.js `fetch()` was not in the retryable conditions. Added it along with `e.cause.code` checking and `ECONNRESET`.
- **Display name**: `URL.pathname` always returns percent-encoded form, so `FileDef.extractAttributes` now decodes the filename for human-readable display.

## Changes
- `packages/host/app/routes/render/file-extract.ts` — Stop decoding the file URL; use the canonical percent-encoded form as the response `id`
- `packages/base/file-api.gts` — Decode filename from `URL.pathname` in `extractAttributes`
- `packages/realm-server/prerender/remote-prerenderer.ts` — Make `TypeError: fetch failed` retryable, check `e.cause.code`, add `ECONNRESET`, log retries
- `packages/realm-server/tests/indexing-test.ts` — Add test for indexing files with emoji in filename

## Test plan
- [x] New test `indexes files with emoji in filename` passes locally
- [ ] Full indexing test suite passes in CI
- [ ] Existing prerender tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)