### PR TITLE
Enable file chooser for linksTo(FileDef) fields

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -1305,9 +1305,8 @@ class LinksTo<CardT extends LinkableDefConstructor> implements Field<CardT> {
       format: Format | undefined,
       defaultFormat: Format,
       isComputed: boolean,
-      isFileDef: boolean,
     ) {
-      return (format ?? defaultFormat) === 'edit' && !isComputed && !isFileDef;
+      return (format ?? defaultFormat) === 'edit' && !isComputed;
     }
     function getChildFormat(
       format: Format | undefined,
@@ -1342,7 +1341,7 @@ class LinksTo<CardT extends LinkableDefConstructor> implements Field<CardT> {
           <DefaultFormatsConsumer as |defaultFormats|>
             {{#if
               (shouldRenderEditor
-                @format defaultFormats.cardDef isComputed isFileDefField
+                @format defaultFormats.cardDef isComputed
               )
             }}
               <LinksToEditor

--- a/packages/base/links-to-editor.gts
+++ b/packages/base/links-to-editor.gts
@@ -11,7 +11,6 @@ import {
   getBoxComponent,
 } from './field-component';
 import {
-  type CardDef,
   type BaseDef,
   type Box,
   type Field,

--- a/packages/base/links-to-editor.gts
+++ b/packages/base/links-to-editor.gts
@@ -18,9 +18,11 @@ import {
   type CardContext,
   type LinkableDefConstructor,
   CreateCardFn,
+  isFileDef,
 } from './card-api';
 import {
   chooseCard,
+  chooseFile,
   baseCardRef,
   identifyCard,
   CardContextName,
@@ -37,7 +39,7 @@ import { consume } from 'ember-provide-consume-context';
 interface Signature {
   Element: HTMLElement;
   Args: {
-    model: Box<CardDef | null>;
+    model: Box<BaseDef | null>;
     field: Field<LinkableDefConstructor>;
     typeConstraint?: ResolvedCodeRef;
     createCard?: CreateCardFn;
@@ -166,6 +168,13 @@ export class LinksToEditor extends GlimmerComponent<Signature> {
   }
 
   private chooseCard = restartableTask(async () => {
+    if (isFileDef(this.args.field.card)) {
+      let file = await chooseFile();
+      if (file) {
+        this.args.model.value = file;
+      }
+      return;
+    }
     let type = identifyCard(this.args.field.card) ?? baseCardRef;
     if (this.args.typeConstraint) {
       type = await getNarrowestType(this.args.typeConstraint, type, myLoader());

--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -115,9 +115,8 @@ class LinksToManyEditor extends GlimmerComponent<Signature> {
     if (isFileDef(this.args.field.card)) {
       let file = await chooseFile();
       if (file) {
-        let selectedCards = (this.args.model.value as any)[
-          this.args.field.name
-        ];
+        let selectedCards =
+          (this.args.model.value as any)[this.args.field.name] ?? [];
         selectedCards = [...selectedCards, file];
         (this.args.model.value as any)[this.args.field.name] = selectedCards;
       }

--- a/packages/base/links-to-many-component.gts
+++ b/packages/base/links-to-many-component.gts
@@ -28,6 +28,7 @@ import {
 } from 'ember-concurrency';
 import {
   chooseCard,
+  chooseFile,
   baseCardRef,
   identifyCard,
   getPlural,
@@ -111,6 +112,17 @@ class LinksToManyEditor extends GlimmerComponent<Signature> {
   };
 
   private chooseCard = restartableTask(async () => {
+    if (isFileDef(this.args.field.card)) {
+      let file = await chooseFile();
+      if (file) {
+        let selectedCards = (this.args.model.value as any)[
+          this.args.field.name
+        ];
+        selectedCards = [...selectedCards, file];
+        (this.args.model.value as any)[this.args.field.name] = selectedCards;
+      }
+      return;
+    }
     let selectedCards = (this.args.model.value as any)[this.args.field.name];
     let selectedCardsQuery =
       selectedCards
@@ -482,9 +494,8 @@ function shouldRenderEditor(
   format: Format | undefined,
   defaultFormat: Format,
   isComputed: boolean,
-  isFileDef: boolean,
 ) {
-  return (format ?? defaultFormat) === 'edit' && !isComputed && !isFileDef;
+  return (format ?? defaultFormat) === 'edit' && !isComputed;
 }
 const componentCache = initSharedState(
   'linksToManyComponentCache',
@@ -521,7 +532,7 @@ export function getLinksToManyComponent({
       <DefaultFormatsConsumer as |defaultFormats|>
         {{#if
           (shouldRenderEditor
-            @format defaultFormats.cardDef isComputed isFileDefField
+            @format defaultFormats.cardDef isComputed
           )
         }}
           <LinksToManyEditor

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -600,8 +600,16 @@ module('Acceptance | interact submode tests', function (hooks) {
       );
 
       assert
-        .dom('[data-test-file-link-attachment]')
+        .dom(
+          '[data-test-links-to-editor="attachment"] [data-test-card="http://test-realm/test/README.txt"]',
+        )
         .exists('attachment field now shows the linked file');
+      await click(
+        `[data-test-operator-mode-stack="0"] [data-test-edit-button]`,
+      );
+      assert
+        .dom('[data-test-file-link-attachment]')
+        .exists('the linked file is rendered in the card');
     });
 
     test('can save mutated card without having opened in stack', async function (assert) {

--- a/packages/host/tests/acceptance/interact-submode-test.gts
+++ b/packages/host/tests/acceptance/interact-submode-test.gts
@@ -550,6 +550,60 @@ module('Acceptance | interact submode tests', function (hooks) {
       });
     });
 
+    test('can link a file via the chooser', async function (assert) {
+      await visitOperatorMode({
+        stacks: [
+          [
+            {
+              id: `${testRealmURL}FileLinkCard/empty`,
+              format: 'isolated',
+            },
+          ],
+        ],
+      });
+
+      await click(
+        `[data-test-operator-mode-stack="0"] [data-test-edit-button]`,
+      );
+
+      assert
+        .dom('[data-test-links-to-editor="attachment"] [data-test-add-new]')
+        .exists('add button is shown for empty FileDef field');
+
+      await click(
+        '[data-test-links-to-editor="attachment"] [data-test-add-new="attachment"]',
+      );
+
+      await waitUntil(
+        () => document.querySelector('[data-test-choose-file-modal]'),
+        { timeout: 5000, timeoutMessage: 'file chooser modal did not open' },
+      );
+
+      assert
+        .dom('[data-test-choose-file-modal]')
+        .exists('file chooser modal is open');
+
+      await waitUntil(
+        () => document.querySelector('[data-test-file="README.txt"]'),
+        {
+          timeout: 5000,
+          timeoutMessage: 'file tree did not load README.txt',
+        },
+      );
+
+      await click('[data-test-file="README.txt"]');
+      await click('[data-test-choose-file-modal-add-button]');
+
+      await waitUntil(
+        () => !document.querySelector('[data-test-choose-file-modal]'),
+        { timeout: 5000, timeoutMessage: 'file chooser modal did not close' },
+      );
+
+      assert
+        .dom('[data-test-file-link-attachment]')
+        .exists('attachment field now shows the linked file');
+    });
+
     test('can save mutated card without having opened in stack', async function (assert) {
       await visitOperatorMode({
         stacks: [

--- a/packages/host/tests/helpers/interact-submode-setup.gts
+++ b/packages/host/tests/helpers/interact-submode-setup.gts
@@ -383,6 +383,26 @@ export function setupInteractSubmodeTests(
           pet: mangoPet,
           friends: [mangoPet],
         }),
+        'FileLinkCard/empty.json': {
+          data: {
+            type: 'card',
+            attributes: {
+              title: 'Empty linked file',
+            },
+            relationships: {
+              attachment: {
+                links: { self: null },
+                data: null,
+              },
+            },
+            meta: {
+              adoptsFrom: {
+                module: '../file-link-card',
+                name: 'FileLinkCard',
+              },
+            },
+          },
+        },
         'FileLinkCard/with-file.json': {
           data: {
             type: 'card',

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -385,7 +385,7 @@ module('Integration | card-basics', function (hooks) {
       assert.true(instanceOf(new ExteriorField(), FieldDef));
     });
 
-    test('linksTo FileDef renders without editor controls in edit format', async function (assert) {
+    test('linksTo FileDef renders editor controls in edit format', async function (assert) {
       class ImageDef extends FileDef {
         static fitted = class Fitted extends Component<typeof this> {
           <template>
@@ -420,13 +420,13 @@ module('Integration | card-basics', function (hooks) {
 
       assert
         .dom('[data-test-links-to-editor="hero"]')
-        .doesNotExist('FileDef links should not show linksTo editor UI');
+        .exists('FileDef links should show linksTo editor UI');
       assert
         .dom('[data-test-image-def]')
         .hasText('hero.png', 'FileDef uses delegated fitted view');
     });
 
-    test('linksToMany FileDef renders without editor controls in edit format', async function (assert) {
+    test('linksToMany FileDef renders editor controls in edit format', async function (assert) {
       class ImageDef extends FileDef {
         static fitted = class Fitted extends Component<typeof this> {
           <template>
@@ -468,10 +468,7 @@ module('Integration | card-basics', function (hooks) {
 
       assert
         .dom('[data-test-links-to-many="attachments"]')
-        .doesNotExist('FileDef links should not show linksToMany editor UI');
-      assert
-        .dom('[data-test-plural-view-field="attachments"]')
-        .exists('FileDef links render via the plural view');
+        .exists('FileDef links should show linksToMany editor UI');
       assert
         .dom('[data-test-image-def]')
         .exists(


### PR DESCRIPTION
https://github.com/user-attachments/assets/c90207a3-a464-430a-8e0d-4658a533ba53

## Summary
- Remove the `isFileDef` gate from `shouldRenderEditor` so the editor UI (add/remove buttons) renders for `linksTo(FileDef)` and `linksToMany(FileDef)` fields
- Add a `chooseFile()` early-return branch in `LinksToEditor` and `LinksToManyEditor` so FileDef fields open the file chooser modal instead of the card catalog
- Update `ChooseFileModal.pick()` to load real indexed file-meta via `store.get()` instead of creating a transient `FileDef` with no `id`
- Update integration tests to assert that editor controls now render for FileDef fields
- Add acceptance test for the file chooser linking flow

## Test plan
- [ ] Integration tests: `linksTo FileDef renders editor controls in edit format` and `linksToMany FileDef renders editor controls in edit format` pass
- [ ] Acceptance test: `can link a file via the chooser` passes
- [ ] Manual: create a card with a `linksTo(FileDef)` field, enter edit mode, click add button → file chooser opens, select a file → file renders in the card

🤖 Generated with [Claude Code](https://claude.com/claude-code)