### PR TITLE
Change publishing to use realm directory directly

### DIFF
--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -18,7 +18,7 @@ import {
 } from '@cardstack/runtime-common';
 import { getPublishedRealmDomainOverrides } from '@cardstack/runtime-common/constants';
 import { ensureDirSync, copySync, readJsonSync, writeJsonSync } from 'fs-extra';
-import { resolve, join } from 'path';
+import { join } from 'path';
 import {
   fetchRequestFromContext,
   sendResponseForBadRequest,
@@ -352,13 +352,13 @@ export default function handlePublishRealm({
         `created realm bot user '${userId}' for new realm ${publishedRealmURL}`,
       );
 
-      let pathNameParts = new URL(sourceRealmURL).pathname
-        .split('/')
-        .filter((p) => p);
-      if (pathNameParts.length < 1) {
-        throw new Error('Could not determine source realm folder');
+      let sourceRealm = realms.find((r) => r.url === sourceRealmURL);
+      if (!sourceRealm?.dir) {
+        throw new Error(
+          `Could not determine filesystem path for source realm ${sourceRealmURL}`,
+        );
       }
-      let sourceRealmPath = resolve(join(realmsRootPath, ...pathNameParts));
+      let sourceRealmPath = sourceRealm.dir;
       let publishedDir = join(realmsRootPath, PUBLISHED_DIRECTORY_NAME);
       let publishedRealmPath = join(publishedDir, publishedRealmData.id);
       copySync(sourceRealmPath, publishedRealmPath);

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -171,12 +171,8 @@ export default function handlePublishRealm({
       return;
     }
 
-    let sourceRealmURL: string = json.sourceRealmURL.endsWith('/')
-      ? json.sourceRealmURL
-      : `${json.sourceRealmURL}/`;
-    let publishedRealmURL = json.publishedRealmURL.endsWith('/')
-      ? json.publishedRealmURL
-      : `${json.publishedRealmURL}/`;
+    let sourceRealmURL = ensureTrailingSlash(json.sourceRealmURL);
+    let publishedRealmURL = ensureTrailingSlash(json.publishedRealmURL);
 
     let { user: ownerUserId, sessionRoom: tokenSessionRoom } = token;
 

--- a/packages/realm-server/node-realm.ts
+++ b/packages/realm-server/node-realm.ts
@@ -49,6 +49,10 @@ export class NodeAdapter implements RealmAdapter {
     private enableFileWatcher?: boolean,
   ) {}
 
+  get dir(): string {
+    return this.realmDir;
+  }
+
   get fileWatcherEnabled(): boolean {
     return this.enableFileWatcher ?? false;
   }

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -354,6 +354,8 @@ export interface RealmAdapter {
     writable: WritableStream;
   };
 
+  dir?: string;
+
   fileWatcherEnabled: boolean;
 
   subscribe(cb: (message: UpdateRealmEventContent) => void): Promise<void>;
@@ -449,6 +451,10 @@ export class Realm {
 
   get url(): string {
     return this.paths.url;
+  }
+
+  get dir(): string | undefined {
+    return this.#adapter.dir;
   }
 
   get realmServerURL(): string {


### PR DESCRIPTION
In production, the homepage realm is [hardcoded](https://github.com/cardstack/boxel/blob/main/packages/realm-server/scripts/start-production.sh#L54) to a non-standard directory:

```
  --path='/persistent/boxel-homepage' \
```

Publishing that special realm was breaking because the handler was constructing the path to the realm based on convention that this realm doesn’t follow. This adds a `dir` getter for Node-based realms so we can ask where they live. Then the `_publish-realm` handler can find the correct directory for the realm. Without knowing where to copy from, the handler is copying a directory that doesn’t exist:

<img width="715" height="528" alt="Boxel 2026-02-11 10-50-20" src="https://github.com/user-attachments/assets/97f9ce0f-499a-4452-95c0-c2db4b3b7467" />

With this branch deployed to production, I was able to publish:

<img width="716" height="526" alt="Boxel 2026-02-11 11-35-00" src="https://github.com/user-attachments/assets/fc44b4ca-339f-43fc-bcc7-e1ed4f951d4c" />

Other problems remain to fix, but they’re unrelated to this:

<img width="1884" height="1416" alt="e8c0a21ef0e0f5101a0d9e590435203ca7bf96af 2026-02-11 11-35-44" src="https://github.com/user-attachments/assets/44d03909-6cc2-496c-b192-04399fd3edea" />
