### PR TITLE
Fix auth service worker 404 on staging/prod

### DIFF
--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -36,6 +36,7 @@ import {
   setContextResponse,
   fetchRequestFromContext,
   methodOverrideSupport,
+  proxyAsset,
 } from './middleware';
 import { registerUser } from './synapse';
 import convertAcceptHeaderQueryParam from './middleware/convert-accept-header-qp';
@@ -233,6 +234,7 @@ export class RealmServer {
           prerenderer: this.prerenderer,
         }),
       )
+      .use(proxyAsset('/auth-service-worker.js', this.assetsURL))
       .use(this.serveIndex)
       .use(this.serveFromRealm);
 


### PR DESCRIPTION
## Summary
- The auth service worker (`/auth-service-worker.js`) was returning 404 on staging because the file is deployed to the CDN (`boxel-host.boxel.ai`) but browsers require service workers to be served from the same origin as the page (`app.boxel.ai`)
- Wires up the existing `proxyAsset` middleware in the realm server to proxy `/auth-service-worker.js` from the CDN, satisfying the same-origin requirement

## Test plan
- [ ] Deploy to staging and verify `/auth-service-worker.js` returns 200 on `app.boxel.ai`
- [ ] Verify service worker registers successfully (no console errors)
- [ ] Visit https://app.boxel.ai/experiments/AuthenticatedImageTester/1 and confirm authenticated images load

🤖 Generated with [Claude Code](https://claude.com/claude-code)