### PR TITLE
Add og:url tag to head template, reindex published realm to regenerate templates after publishing

### DIFF
--- a/packages/base/default-templates/head.gts
+++ b/packages/base/default-templates/head.gts
@@ -27,7 +27,7 @@ export default class DefaultHeadTemplate extends GlimmerComponent<{
 
     <meta property='og:title' content={{this.title}} />
     <meta name='twitter:title' content={{this.title}} />
-    <meta property='og:url' content={{this.args.model.id}} />
+    <meta property='og:url' content={{@model.id}} />
 
     {{#if this.description}}
       <meta name='description' content={{this.description}} />

--- a/packages/base/default-templates/head.gts
+++ b/packages/base/default-templates/head.gts
@@ -24,8 +24,10 @@ export default class DefaultHeadTemplate extends GlimmerComponent<{
   <template>
     {{! template-lint-disable no-forbidden-elements }}
     <title data-test-card-head-title>{{this.title}}</title>
+
     <meta property='og:title' content={{this.title}} />
     <meta name='twitter:title' content={{this.title}} />
+    <meta property='og:url' content={{this.args.model.id}} />
 
     {{#if this.description}}
       <meta name='description' content={{this.description}} />

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -205,7 +205,7 @@ export default function handlePublishRealm({
           validPublishedRealmDomains.length > 0
         ) {
           let isValidDomain = validPublishedRealmDomains.some((domain) =>
-            publishedURL.host.endsWith(domain),
+            publishedURL.hostname.endsWith(domain),
           );
           if (!isValidDomain) {
             await sendResponseForBadRequest(

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -394,6 +394,12 @@ export default function handlePublishRealm({
       );
       await realm.start();
 
+      // reindexing is to ensure that prerendered templates that get copied over
+      // to the published realm get regenerated - we want this so that the
+      // places in the templates that refer to model.id are updated to the new
+      // published realm URL (for example in the og:url meta tag).
+      await realm.fullIndex();
+
       let response = createResponse({
         body: JSON.stringify(
           {

--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -204,8 +204,10 @@ export default function handlePublishRealm({
           validPublishedRealmDomains &&
           validPublishedRealmDomains.length > 0
         ) {
-          let isValidDomain = validPublishedRealmDomains.some((domain) =>
-            publishedURL.hostname.endsWith(domain),
+          let isValidDomain = validPublishedRealmDomains.some(
+            (domain) =>
+              publishedURL.host.endsWith(domain) ||
+              publishedURL.hostname.endsWith(domain),
           );
           if (!isValidDomain) {
             await sendResponseForBadRequest(

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -1587,9 +1587,7 @@ module(basename(__filename), function () {
           `failed to find og:title in head html:${cleanedHead}`,
         );
         assert.ok(
-          cleanedHead.includes(
-            `property="og:url" content="${realmURL2}1"`,
-          ),
+          cleanedHead.includes(`property="og:url" content="${realmURL2}1"`),
           `failed to find og:url in head html:${cleanedHead}`,
         );
         assert.ok(

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -1587,6 +1587,12 @@ module(basename(__filename), function () {
           `failed to find og:title in head html:${cleanedHead}`,
         );
         assert.ok(
+          cleanedHead.includes(
+            `property="og:url" content="${realmURL2}1"`,
+          ),
+          `failed to find og:url in head html:${cleanedHead}`,
+        );
+        assert.ok(
           cleanedHead.includes('name="twitter:card" content="summary"'),
           `failed to find twitter:card in head html:${cleanedHead}`,
         );

--- a/packages/realm-server/tests/publish-unpublish-realm-test.ts
+++ b/packages/realm-server/tests/publish-unpublish-realm-test.ts
@@ -245,17 +245,19 @@ module(basename(__filename), function () {
         let instanceWithHead = indexResults.find(
           (r) => r.type === 'instance' && r.head_html,
         );
-        if (instanceWithHead) {
-          let headHtml = instanceWithHead.head_html as string;
-          assert.ok(
-            headHtml.includes(publishedRealmURL),
-            `head_html should reference published realm URL, got: ${headHtml}`,
-          );
-          assert.notOk(
-            headHtml.includes(sourceRealmUrlString),
-            `head_html should not reference source realm URL, got: ${headHtml}`,
-          );
-        }
+        assert.ok(
+          instanceWithHead,
+          'boxel_index should contain an instance row with head_html for the published realm',
+        );
+        let headHtml = (instanceWithHead as any).head_html as string;
+        assert.ok(
+          headHtml.includes(publishedRealmURL),
+          `head_html should reference published realm URL, got: ${headHtml}`,
+        );
+        assert.notOk(
+          headHtml.includes(sourceRealmUrlString),
+          `head_html should not reference source realm URL, got: ${headHtml}`,
+        );
 
         let catalogResponse = await request
           .get('/_catalog-realms')

--- a/packages/realm-server/tests/publish-unpublish-realm-test.ts
+++ b/packages/realm-server/tests/publish-unpublish-realm-test.ts
@@ -239,6 +239,24 @@ module(basename(__filename), function () {
           'index entries should reference the published realm URL',
         );
 
+        // Verify that head_html in the published realm references the
+        // published URL, not the source realm URL (the fullIndex after
+        // publish re-renders templates so og:url uses the correct URL)
+        let instanceWithHead = indexResults.find(
+          (r: { type: string; head_html: string | null }) =>
+            r.type === 'instance' && r.head_html,
+        );
+        if (instanceWithHead) {
+          assert.ok(
+            instanceWithHead.head_html.includes(publishedRealmURL),
+            `head_html should reference published realm URL, got: ${instanceWithHead.head_html}`,
+          );
+          assert.notOk(
+            instanceWithHead.head_html.includes(sourceRealmUrlString),
+            `head_html should not reference source realm URL, got: ${instanceWithHead.head_html}`,
+          );
+        }
+
         let catalogResponse = await request
           .get('/_catalog-realms')
           .set('Accept', 'application/vnd.api+json');

--- a/packages/realm-server/tests/publish-unpublish-realm-test.ts
+++ b/packages/realm-server/tests/publish-unpublish-realm-test.ts
@@ -113,7 +113,7 @@ module(basename(__filename), function () {
         .send(
           JSON.stringify({
             sourceRealmURL: testRealm.url,
-            publishedRealmURL: 'http://testuser.localhost/test-realm/',
+            publishedRealmURL: 'http://testuser.localhost:4445/test-realm/',
           }),
         );
 
@@ -180,7 +180,7 @@ module(basename(__filename), function () {
           .send(
             JSON.stringify({
               sourceRealmURL: sourceRealmUrlString,
-              publishedRealmURL: 'http://testuser.localhost/test-realm/',
+              publishedRealmURL: 'http://testuser.localhost:4445/test-realm/',
             }),
           );
 
@@ -243,17 +243,17 @@ module(basename(__filename), function () {
         // published URL, not the source realm URL (the fullIndex after
         // publish re-renders templates so og:url uses the correct URL)
         let instanceWithHead = indexResults.find(
-          (r: { type: string; head_html: string | null }) =>
-            r.type === 'instance' && r.head_html,
+          (r) => r.type === 'instance' && r.head_html,
         );
         if (instanceWithHead) {
+          let headHtml = instanceWithHead.head_html as string;
           assert.ok(
-            instanceWithHead.head_html.includes(publishedRealmURL),
-            `head_html should reference published realm URL, got: ${instanceWithHead.head_html}`,
+            headHtml.includes(publishedRealmURL),
+            `head_html should reference published realm URL, got: ${headHtml}`,
           );
           assert.notOk(
-            instanceWithHead.head_html.includes(sourceRealmUrlString),
-            `head_html should not reference source realm URL, got: ${instanceWithHead.head_html}`,
+            headHtml.includes(sourceRealmUrlString),
+            `head_html should not reference source realm URL, got: ${headHtml}`,
           );
         }
 
@@ -382,7 +382,7 @@ module(basename(__filename), function () {
           .send(
             JSON.stringify({
               sourceRealmURL: sourceRealmUrlString,
-              publishedRealmURL: 'http://testuser.localhost/test-realm/',
+              publishedRealmURL: 'http://testuser.localhost:4445/test-realm/',
             }),
           );
 
@@ -426,7 +426,7 @@ module(basename(__filename), function () {
           .send(
             JSON.stringify({
               sourceRealmURL: sourceRealmUrlString,
-              publishedRealmURL: 'http://testuser.localhost/test-realm/',
+              publishedRealmURL: 'http://testuser.localhost:4445/test-realm/',
             }),
           );
 
@@ -451,7 +451,7 @@ module(basename(__filename), function () {
           .send(
             JSON.stringify({
               sourceRealmURL: sourceRealmUrlString,
-              publishedRealmURL: 'http://testuser.localhost/test-realm/',
+              publishedRealmURL: 'http://testuser.localhost:4445/test-realm/',
             }),
           );
 
@@ -502,7 +502,7 @@ module(basename(__filename), function () {
           .send(
             JSON.stringify({
               sourceRealmURL: sourceRealmUrlString,
-              publishedRealmURL: 'http://testuser.localhost/test-realm/',
+              publishedRealmURL: 'http://testuser.localhost:4445/test-realm/',
             }),
           );
 
@@ -586,7 +586,7 @@ module(basename(__filename), function () {
         )[0];
         assert.strictEqual(
           realmVersion.current_version,
-          2,
+          3,
           'realm version of published realm is increased',
         );
 
@@ -703,7 +703,7 @@ module(basename(__filename), function () {
           .send(
             JSON.stringify({
               sourceRealmURL: sourceRealmUrlString,
-              publishedRealmURL: 'http://testuser.localhost/test-realm/',
+              publishedRealmURL: 'http://testuser.localhost:4445/test-realm/',
             }),
           );
 
@@ -775,7 +775,7 @@ module(basename(__filename), function () {
       });
 
       test('POST /_publish-realm does not create duplicate realm instances on republish', async function (assert) {
-        let publishedRealmURL = 'http://testuser.localhost/test-realm/';
+        let publishedRealmURL = 'http://testuser.localhost:4445/test-realm/';
 
         // First publish
         let firstResponse = await request


### PR DESCRIPTION
Reindexing assures the prerendered templates regenerate when we publish a realm (which gets copied from the source realm). We need to regenerate them now that we included `<meta property='og:url' content={{this.args.model.id}} />` so that the new url gets picked up (otherwise we see source realm's URLs in the published realm's template).

This correctness assurance comes at a cost though - the user needs to wait to publish a realm a little longer (depending on the realm complexity). We discussed that with the team in office hours and the conclusion is that we're okay with this tradeoff for now.