### PR TITLE
server: Add module cache-breaking when publishing realm

### DIFF
--- a/packages/realm-server/handlers/handle-publish-realm.ts
+++ b/packages/realm-server/handlers/handle-publish-realm.ts
@@ -385,6 +385,14 @@ export default function handlePublishRealm({
         realms.splice(realms.indexOf(existingPublishedRealm), 1);
         virtualNetwork.unmount(existingPublishedRealm.handle);
       }
+
+      // Clear stale modules cache for the published realm so that
+      // error entries from a previous publish don't persist
+      await query(dbAdapter, [
+        `DELETE FROM modules WHERE resolved_realm_url =`,
+        param(publishedRealmURL),
+      ]);
+
       let realm = createAndMountRealm(
         publishedRealmPath,
         publishedRealmURL,

--- a/packages/realm-server/tests/publish-unpublish-realm-test.ts
+++ b/packages/realm-server/tests/publish-unpublish-realm-test.ts
@@ -795,9 +795,7 @@ module(basename(__filename), function () {
           modulesBefore.length > 0,
           'modules table has entries for published realm before republish',
         );
-        let errorEntry = modulesBefore.find(
-          (m: any) => m.error_doc != null,
-        );
+        let errorEntry = modulesBefore.find((m: any) => m.error_doc != null);
         assert.ok(
           errorEntry,
           'modules table has an error_doc entry before republish',

--- a/packages/realm-server/tests/publish-unpublish-realm-test.ts
+++ b/packages/realm-server/tests/publish-unpublish-realm-test.ts
@@ -756,6 +756,87 @@ module(basename(__filename), function () {
         );
       });
 
+      test('republishing clears stale modules cache entries for the published realm', async function (assert) {
+        let publishedRealmURL = 'http://testuser.localhost/test-realm/';
+
+        // First publish
+        let firstResponse = await request
+          .post('/_publish-realm')
+          .set('Accept', 'application/vnd.api+json')
+          .set('Content-Type', 'application/json')
+          .set(
+            'Authorization',
+            `Bearer ${createRealmServerJWT(
+              { user: ownerUserId, sessionRoom: 'session-room-test' },
+              realmSecretSeed,
+            )}`,
+          )
+          .send(
+            JSON.stringify({
+              sourceRealmURL: sourceRealmUrlString,
+              publishedRealmURL,
+            }),
+          );
+
+        assert.strictEqual(firstResponse.status, 201, 'First publish succeeds');
+
+        // Simulate a stale modules cache entry with an error for the published realm
+        let moduleUrl = `${publishedRealmURL}my-module`;
+        await dbAdapter.execute(
+          `INSERT INTO modules (url, file_alias, definitions, deps, error_doc, created_at, resolved_realm_url, cache_scope, auth_user_id)
+           VALUES ('${moduleUrl}', '${moduleUrl}', '{}', '[]', '${JSON.stringify({ error: { message: 'simulated prerender failure' } })}', ${Date.now()}, '${publishedRealmURL}', 'public', '')`,
+        );
+
+        // Verify the error entry exists
+        let modulesBefore = await dbAdapter.execute(
+          `SELECT * FROM modules WHERE resolved_realm_url = '${publishedRealmURL}'`,
+        );
+        assert.ok(
+          modulesBefore.length > 0,
+          'modules table has entries for published realm before republish',
+        );
+        let errorEntry = modulesBefore.find(
+          (m: any) => m.error_doc != null,
+        );
+        assert.ok(
+          errorEntry,
+          'modules table has an error_doc entry before republish',
+        );
+
+        // Republish the realm
+        let secondResponse = await request
+          .post('/_publish-realm')
+          .set('Accept', 'application/vnd.api+json')
+          .set('Content-Type', 'application/json')
+          .set(
+            'Authorization',
+            `Bearer ${createRealmServerJWT(
+              { user: ownerUserId, sessionRoom: 'session-room-test' },
+              realmSecretSeed,
+            )}`,
+          )
+          .send(
+            JSON.stringify({
+              sourceRealmURL: sourceRealmUrlString,
+              publishedRealmURL,
+            }),
+          );
+
+        assert.strictEqual(secondResponse.status, 201, 'Republish succeeds');
+
+        // Verify the stale modules cache entries were cleared
+        let modulesAfter = await dbAdapter.execute(
+          `SELECT * FROM modules WHERE resolved_realm_url = '${publishedRealmURL}'`,
+        );
+        let errorEntryAfter = modulesAfter.find(
+          (m: any) => m.error_doc != null,
+        );
+        assert.notOk(
+          errorEntryAfter,
+          'modules table should not have error_doc entries after republish',
+        );
+      });
+
       test('POST /_publish-realm does not create duplicate realm instances on republish', async function (assert) {
         let publishedRealmURL = 'http://testuser.localhost/test-realm/';
 


### PR DESCRIPTION
The homepage realm had a relative link that was broken when published because the directory structure differed. Even after I changed it to an absolute reference, the published realm still had the error in the `modules` table. This deletes a published realm’s module cache when publishing.

[Here](https://github.com/cardstack/boxel/actions/runs/21966275342/job/63457321783?pr=3991#step:10:50) the test fails before I pushed the fix.