### PR TITLE
host: Add related instances when prerendering

### DIFF
--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -499,28 +499,7 @@ export default class RenderRoute extends Route<Model> {
     if (!modelState || modelState.isReady) {
       return;
     }
-    // Handle multi-level linked card loading cascades. Each store.loaded()
-    // waits for in-flight linked card loads, but when those loads resolve and
-    // Ember re-renders, newly-accessed linked fields (deeper in the component
-    // tree) may trigger additional loads (e.g., HomeLayout → sections[].content
-    // → HeroSection → backgroundGrid). We loop, yielding to Ember's render
-    // queue between iterations, until no new loads appear after a render pass.
-    const MAX_SETTLE_ROUNDS = 10;
-    for (let round = 0; round < MAX_SETTLE_ROUNDS; round++) {
-      await this.#authGuard.race(() => this.store.loaded());
-      // Yield to Ember's render queue so templates update with newly-loaded
-      // data and any deeper linked card loads can start
-      await new Promise<void>((resolve) =>
-        scheduleOnce('afterRender', null, resolve),
-      );
-      // If no new document loads appeared after the render pass, we're stable
-      if (
-        this.store.cardDocsInFlight.length === 0 &&
-        this.store.fileMetaDocsInFlight.length === 0
-      ) {
-        break;
-      }
-    }
+    await this.#authGuard.race(() => this.store.loaded());
     modelState.state.set('status', 'ready');
     modelState.isReady = true;
     modelState.readyDeferred.fulfill();


### PR DESCRIPTION
This fixes the problem where the homepage only has partial styles before Ember takes over. In a browser with Javascript turned off, the current homepage:

<img width="3056" height="2368" alt="e8c0a21ef0e0f5101a0d9e590435203ca7bf96af 2026-02-12 17-21-22" src="https://github.com/user-attachments/assets/11e66bce-b30e-4a7c-be50-e32c983d5d81" />

With this branch:

<img width="3056" height="2368" alt="e8c0a21ef0e0f5101a0d9e590435203ca7bf96af 2026-02-12 17-22-33" src="https://github.com/user-attachments/assets/033e8c0d-91cf-4c23-b3d8-e165ed6580e3" />
