### PR TITLE
Realm picker improvement

### DIFF
--- a/packages/boxel-ui/addon/src/components/picker/before-options-with-search.gts
+++ b/packages/boxel-ui/addon/src/components/picker/before-options-with-search.gts
@@ -1,9 +1,14 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
+import { modifier } from 'ember-modifier';
 import type { Select } from 'ember-power-select/components/power-select';
 
 import BoxelInput from '../input/index.gts';
 import type { PickerOption } from './index.gts';
+
+const autoFocus = modifier((element: HTMLElement) => {
+  element.focus();
+});
 
 export interface BeforeOptionsWithSearchSignature {
   Args: {
@@ -43,6 +48,7 @@ export default class PickerBeforeOptionsWithSearch extends Component<BeforeOptio
           @onInput={{this.updateSearchTerm}}
           @placeholder={{this.searchPlaceholder}}
           class='picker-before-options__search-input'
+          {{autoFocus}}
         />
       </div>
     </div>

--- a/packages/boxel-ui/addon/src/components/picker/before-options-with-search.gts
+++ b/packages/boxel-ui/addon/src/components/picker/before-options-with-search.gts
@@ -1,14 +1,10 @@
+import { autoFocus } from '@cardstack/boxel-ui/modifiers';
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
-import { modifier } from 'ember-modifier';
 import type { Select } from 'ember-power-select/components/power-select';
 
 import BoxelInput from '../input/index.gts';
 import type { PickerOption } from './index.gts';
-
-const autoFocus = modifier((element: HTMLElement) => {
-  element.focus();
-});
 
 export interface BeforeOptionsWithSearchSignature {
   Args: {

--- a/packages/boxel-ui/addon/src/modifiers.ts
+++ b/packages/boxel-ui/addon/src/modifiers.ts
@@ -2,9 +2,11 @@ import SortableGroupModifier from 'ember-sortable/modifiers/sortable-group';
 import SortableHandleModifier from 'ember-sortable/modifiers/sortable-handle';
 import SortableItemModifier from 'ember-sortable/modifiers/sortable-item';
 
+import autoFocus from './modifiers/auto-focus.ts';
 import setCssVar from './modifiers/set-css-var.ts';
 
 export {
+  autoFocus,
   setCssVar,
   SortableGroupModifier,
   SortableHandleModifier,

--- a/packages/boxel-ui/addon/src/modifiers/auto-focus.ts
+++ b/packages/boxel-ui/addon/src/modifiers/auto-focus.ts
@@ -1,0 +1,7 @@
+import { modifier } from 'ember-modifier';
+
+const autoFocus = modifier((element: HTMLElement) => {
+  element.focus();
+});
+
+export default autoFocus;

--- a/packages/host/app/components/realm-picker/index.gts
+++ b/packages/host/app/components/realm-picker/index.gts
@@ -69,6 +69,7 @@ export default class RealmPicker extends Component<Signature> {
           @placeholder={{@placeholder}}
           @maxSelectedDisplay={{3}}
           @renderInPlace={{false}}
+          @matchTriggerWidth={{false}}
           data-test-realm-picker
         />
       </:default>

--- a/packages/host/app/components/search-sheet/search-bar.gts
+++ b/packages/host/app/components/search-sheet/search-bar.gts
@@ -21,6 +21,10 @@ let elementCallback = modifier(
   },
 );
 
+const autoFocus = modifier((element: HTMLElement) => {
+  element.focus();
+});
+
 interface Signature {
   Element: HTMLElement;
   Args: {
@@ -80,6 +84,7 @@ export default class SearchBar extends Component<Signature> {
           @onBlur={{@onBlur}}
           id={{@id}}
           {{elementCallback @onInputInsertion}}
+          {{autoFocus}}
           data-test-search-field
         />
       </div>

--- a/packages/host/app/components/search-sheet/search-bar.gts
+++ b/packages/host/app/components/search-sheet/search-bar.gts
@@ -10,6 +10,7 @@ import {
 } from '@cardstack/boxel-ui/components';
 import type { PickerOption } from '@cardstack/boxel-ui/components';
 import { IconSearch } from '@cardstack/boxel-ui/icons';
+import { autoFocus } from '@cardstack/boxel-ui/modifiers';
 
 import RealmPicker from '@cardstack/host/components/realm-picker';
 
@@ -20,10 +21,6 @@ let elementCallback = modifier(
     }
   },
 );
-
-const autoFocus = modifier((element: HTMLElement) => {
-  element.focus();
-});
 
 interface Signature {
   Element: HTMLElement;


### PR DESCRIPTION
- [x] Auto-focus search field in Picker dropdown so users can type to filter immediately when opened
- [x] Make the default width of the realm picker's dropdown options wider
- [x] Auto-focus search input in Search Sheet so users can start typing their query immediately when opened


https://github.com/user-attachments/assets/e53c2575-4108-4dbc-a581-4f903473d572

