### PR TITLE
[perf] Launch just one page by default in realm-server tests

### DIFF
--- a/packages/realm-server/tests/helpers/index.ts
+++ b/packages/realm-server/tests/helpers/index.ts
@@ -293,6 +293,7 @@ async function startTestPrerenderServer(): Promise<string> {
   }
   let server = createPrerenderHttpServer({
     silent: Boolean(process.env.SILENT_PRERENDERER),
+    maxPages: 1,
   });
   prerenderServer = server;
   trackServer(server);


### PR DESCRIPTION
We only need one of these for most tests and tests that require more already launch their own prerenderer.