### PR TITLE
Document make-schema requirement after Postgres migrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,8 @@
 
 ### packages/postgres
 - If you need to make a database migration use `pnpm create migration_name` to create a migration file so that the correct date timestamp prefix will be added to the file name. Then implement the migration inside the newly created file.
+- **After creating or modifying a migration, you MUST regenerate the SQLite schema file.** Run `pnpm make-schema` from this directory. This creates a new SQLite schema in `packages/host/config/schema/` with a timestamp matching the latest migration file. The old schema file is automatically removed. If you skip this step, the host app will fail to start with an "SQLite schema is out of date" error.
+  - This script requires Docker (it uses the `boxel-pg` container to dump the Postgres schema). Ensure Docker is running before executing.
 
 
 ### packages/runtime-common


### PR DESCRIPTION
## Summary

Adds instruction to AGENTS.md reminding AI agents (and humans) that `pnpm make-schema` must be run from `packages/postgres` after creating or modifying database migrations. This regenerates the SQLite schema file that the host app depends on.

Without this step, the host app fails to start with an "SQLite schema is out of date" error.