### PR TITLE
Label FileDef declarations correctly in Code Mode File Inspector

### DIFF
--- a/packages/host/app/components/operator-mode/detail-panel-selector.gts
+++ b/packages/host/app/components/operator-mode/detail-panel-selector.gts
@@ -11,6 +11,7 @@ import {
   isCardDef,
   isBaseDef,
   isFieldDef,
+  isFileDef,
 } from '@cardstack/runtime-common/code-ref';
 
 import scrollIntoViewModifier from '@cardstack/host/modifiers/scroll-into-view';
@@ -80,14 +81,16 @@ interface Signature {
 
 function typeOfCardOrField(cardOrField: typeof BaseDef) {
   if (isCardDef(cardOrField)) {
-    return 'card';
+    return 'card def';
   } else if (isFieldDef(cardOrField)) {
-    return 'field';
+    return 'field def';
+  } else if (isFileDef(cardOrField)) {
+    return 'file def';
   } else if (isBaseDef(cardOrField)) {
-    return 'base';
+    return 'base def';
   }
   throw new Error(
-    `in-this-file panel: declaration should either be card, field, or base.`,
+    `in-this-file panel: declaration should either be card def, field def, file def, or base def.`,
   );
 }
 

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -29,6 +29,7 @@ import {
   isCardDocumentString,
   isCardDef,
   isFieldDef,
+  isFileDef,
   isBaseDef,
   internalKeyFor,
   type ResolvedCodeRef,
@@ -209,9 +210,11 @@ export default class DetailPanel extends Component<Signature> {
             },
           ]
         : []),
-      // the inherit feature performs in the inheritance in a new module,
+      // the inherit feature performs the inheritance in a new module,
       // this means that the Card/Field that we are inheriting must be exported
-      ...(this.args.selectedDeclaration?.exportName
+      // FileDefs are excluded since they don't support the inherit workflow
+      ...(this.args.selectedDeclaration?.exportName &&
+      !isFileDef(this.args.selectedDeclaration?.cardOrField)
         ? [
             {
               label: 'Inherit',
@@ -403,6 +406,19 @@ export default class DetailPanel extends Component<Signature> {
     return hasExecutableExtension(this.args.readyFile.url);
   }
 
+  private get inheritancePanelHeader() {
+    if (
+      this.args.selectedDeclaration &&
+      (isCardOrFieldDeclaration(this.args.selectedDeclaration) ||
+        isReexportCardOrField(this.args.selectedDeclaration))
+    ) {
+      if (isFileDef(this.args.selectedDeclaration.cardOrField)) {
+        return 'File Def Inheritance';
+      }
+    }
+    return 'Card Inheritance';
+  }
+
   private get fileExtension() {
     if (!this.args.cardInstance) {
       return '.' + this.args.readyFile.url.split('.').pop() || '';
@@ -512,7 +528,7 @@ export default class DetailPanel extends Component<Signature> {
             aria-label='Inheritance Panel Header'
             data-test-inheritance-panel-header
           >
-            Card Inheritance
+            {{this.inheritancePanelHeader}}
           </PanelHeader>
           {{#if this.isCardInstance}}
             {{! JSON case when visting, eg Author/1.json }}
@@ -659,6 +675,8 @@ function getDefinitionTitle(declaration: ModuleDeclaration) {
       return 'Card Definition';
     } else if (isFieldDef(declaration.cardOrField)) {
       return 'Field Definition';
+    } else if (isFileDef(declaration.cardOrField)) {
+      return 'File Definition';
     } else if (isBaseDef(declaration.cardOrField)) {
       return 'Base Definition';
     }
@@ -668,6 +686,8 @@ function getDefinitionTitle(declaration: ModuleDeclaration) {
       return 'Re-exported Card Definition';
     } else if (isFieldDef(declaration.cardOrField)) {
       return 'Re-exported Field Definition';
+    } else if (isFileDef(declaration.cardOrField)) {
+      return 'Re-exported File Definition';
     } else if (isBaseDef(declaration.cardOrField)) {
       return 'Re-exported Base Definition';
     }

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -1734,7 +1734,7 @@ module('Acceptance | code submode tests', function (_hooks) {
       );
       assert
         .dom('[data-test-boxel-selector-item-selected]')
-        .hasText(`${elementName} field`);
+        .hasText(`${elementName} field def`);
 
       elementName = 'LocalField';
       position = new MonacoSDK.Position(38, 0);
@@ -1744,7 +1744,7 @@ module('Acceptance | code submode tests', function (_hooks) {
       );
       assert
         .dom('[data-test-boxel-selector-item-selected]')
-        .hasText(`${elementName} field`);
+        .hasText(`${elementName} field def`);
 
       elementName = 'ExportedCard';
       position = new MonacoSDK.Position(31, 0);
@@ -1754,7 +1754,7 @@ module('Acceptance | code submode tests', function (_hooks) {
       );
       assert
         .dom('[data-test-boxel-selector-item-selected]')
-        .hasText(`${elementName} card`);
+        .hasText(`${elementName} card def`);
     });
 
     test('the monaco cursor position is maintained during an auto-save', async function (assert) {

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -1556,9 +1556,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
       .dom('[data-test-inheritance-panel-header]')
       .hasText('File Def Inheritance');
     assert.dom('[data-test-card-module-definition]').exists();
-    assert
-      .dom('[data-test-definition-header]')
-      .includesText('File Definition');
+    assert.dom('[data-test-definition-header]').includesText('File Definition');
     assert
       .dom('[data-test-card-module-definition]')
       .includesText('custom file');

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -385,6 +385,20 @@ const reExportSource = `
   export { default as Date } from 'https://cardstack.com/base/date';
 `;
 
+const fileDefSource = `
+  import { FileDef } from 'https://cardstack.com/base/file-api';
+  import {
+    contains,
+    field,
+  } from 'https://cardstack.com/base/card-api';
+  import StringField from 'https://cardstack.com/base/string';
+
+  export class CustomFileDef extends FileDef {
+    static displayName = 'custom file';
+    @field customTag = contains(StringField);
+  }
+`;
+
 const localInheritSource = `
   import {
     contains,
@@ -469,6 +483,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
         'imports.gts': importsSource,
         're-export.gts': reExportSource,
         'local-inherit.gts': localInheritSource,
+        'file-def.gts': fileDefSource,
         'command-module.gts': commandModuleSource,
         'erroring-module.gts': erroringModuleSource,
         'empty-file.gts': '',
@@ -732,12 +747,12 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
       'ExportedClass class',
       'ExportedClassInheritLocalClass class',
       'exportedFunction function',
-      'LocalCard card',
-      'ExportedCard card',
-      'ExportedCardInheritLocalCard card',
-      'LocalField field',
-      'ExportedField field',
-      'ExportedFieldInheritLocalField field',
+      'LocalCard card def',
+      'ExportedCard card def',
+      'ExportedCardInheritLocalCard card def',
+      'LocalField field def',
+      'ExportedField field def',
+      'ExportedFieldInheritLocalField field def',
       'default (DefaultClass) class',
     ];
     expectedElementNames.forEach(async (elementName, index) => {
@@ -757,7 +772,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await click(`[data-test-boxel-selector-item-text="${elementName}"]`);
     assert
       .dom('[data-test-boxel-selector-item-selected]')
-      .hasText(`${elementName} card`);
+      .hasText(`${elementName} card def`);
     await waitFor('[data-test-card-module-definition]');
     assert.dom('[data-test-inheritance-panel-header]').exists();
     assert.dom('[data-test-card-module-definition]').exists();
@@ -780,7 +795,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await click(`[data-test-boxel-selector-item-text="${elementName}"]`);
     assert
       .dom('[data-test-boxel-selector-item-selected]')
-      .hasText(`${elementName} field`);
+      .hasText(`${elementName} field def`);
     await waitFor('[data-test-card-module-definition]');
     assert.dom('[data-test-inheritance-panel-header]').exists();
     assert
@@ -1262,7 +1277,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     assert.operatorModeParametersMatch(currentURL(), {
       codeSelection: elementName,
     });
-    let selected = 'AncestorCard2 card';
+    let selected = 'AncestorCard2 card def';
     await waitFor(`[data-test-clickable-definition-container]`);
     await click(`[data-test-clickable-definition-container]`);
     await waitFor('[data-test-boxel-selector-item-selected]');
@@ -1277,7 +1292,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     assert.operatorModeParametersMatch(currentURL(), {
       codeSelection: elementName,
     });
-    selected = 'default (DefaultAncestorCard) card';
+    selected = 'default (DefaultAncestorCard) card def';
     await waitFor(`[data-test-clickable-definition-container]`);
     await click(`[data-test-clickable-definition-container]`);
     await waitFor('[data-test-boxel-selector-item-selected]');
@@ -1292,7 +1307,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     assert.operatorModeParametersMatch(currentURL(), {
       codeSelection: elementName,
     });
-    selected = 'RenamedAncestorCard (AncestorCard) card';
+    selected = 'RenamedAncestorCard (AncestorCard) card def';
     await waitFor(`[data-test-clickable-definition-container]`);
     await click(`[data-test-clickable-definition-container]`);
     await waitFor('[data-test-boxel-selector-item-selected]');
@@ -1307,7 +1322,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     assert.operatorModeParametersMatch(currentURL(), {
       codeSelection: elementName,
     });
-    selected = 'AncestorCard3 card';
+    selected = 'AncestorCard3 card def';
     await click(`[data-test-clickable-definition-container]`);
     await waitFor('[data-test-boxel-selector-item-selected]');
     assert.dom('[data-test-boxel-selector-item-selected]').hasText(selected);
@@ -1321,7 +1336,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     assert.operatorModeParametersMatch(currentURL(), {
       codeSelection: elementName,
     });
-    selected = 'ChildCard2 card';
+    selected = 'ChildCard2 card def';
     await waitFor(`[data-test-clickable-definition-container]`);
     await click(`[data-test-clickable-definition-container]`);
     await waitFor('[data-test-boxel-selector-item-selected]');
@@ -1336,7 +1351,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     assert.operatorModeParametersMatch(currentURL(), {
       codeSelection: elementName,
     });
-    selected = 'AncestorField1 field';
+    selected = 'AncestorField1 field def';
     await click(`[data-test-clickable-definition-container]`);
     await waitFor('[data-test-boxel-selector-item-selected]');
     assert.dom('[data-test-boxel-selector-item-selected]').hasText(selected);
@@ -1367,7 +1382,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await waitFor('[data-test-boxel-selector-item-selected]');
     assert
       .dom('[data-test-boxel-selector-item-selected]')
-      .hasText(`${elementName} card`);
+      .hasText(`${elementName} card def`);
 
     //click normal field
     await visitOperatorMode(operatorModeState);
@@ -1384,7 +1399,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await waitFor('[data-test-boxel-selector-item-selected]');
     assert
       .dom('[data-test-boxel-selector-item-selected]')
-      .hasText(`${elementName} field`);
+      .hasText(`${elementName} field def`);
 
     //click linksTo card
     await visitOperatorMode(operatorModeState);
@@ -1403,7 +1418,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await waitFor('[data-test-boxel-selector-item-selected]');
     assert
       .dom('[data-test-boxel-selector-item-selected]')
-      .hasText(`${elementName} card`);
+      .hasText(`${elementName} card def`);
     //click linksTo card in the same file
     await visitOperatorMode(operatorModeState);
 
@@ -1420,7 +1435,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await waitFor('[data-test-boxel-selector-item-selected]');
     assert
       .dom('[data-test-boxel-selector-item-selected]')
-      .hasText(`${elementName} card`);
+      .hasText(`${elementName} card def`);
 
     //click linksTo many card
     await click('[data-boxel-selector-item-text="ChildCard1"]');
@@ -1438,7 +1453,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await waitFor('[data-test-boxel-selector-item-selected]');
     assert
       .dom('[data-test-boxel-selector-item-selected]')
-      .hasText(`${elementName} card`);
+      .hasText(`${elementName} card def`);
   });
 
   test('in-this-file panel displays re-exports', async function (assert) {
@@ -1452,7 +1467,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await waitFor('[data-test-current-module-name]');
     await waitFor('[data-test-in-this-file-selector]');
     //default is the 1st index
-    let elementName = 'StrCard (StringField) field';
+    let elementName = 'StrCard (StringField) field def';
     assert
       .dom('[data-test-boxel-selector-item]:nth-of-type(1)')
       .hasText(elementName);
@@ -1462,13 +1477,13 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
 
     // elements must be ordered by the way they appear in the source code
     const expectedElementNames = [
-      'StrCard (StringField) field',
-      'FDef (FieldDef) field',
-      'CardDef card',
-      'BDef base',
-      'default (NumberField) field',
-      'Human (Person) card',
-      'Date (default) field',
+      'StrCard (StringField) field def',
+      'FDef (FieldDef) field def',
+      'CardDef card def',
+      'BDef base def',
+      'default (NumberField) field def',
+      'Human (Person) card def',
+      'Date (default) field def',
     ];
     expectedElementNames.forEach(async (elementName, index) => {
       await waitFor(
@@ -1486,7 +1501,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await waitFor('[data-test-boxel-selector-item-selected]');
     assert
       .dom('[data-test-boxel-selector-item-selected]')
-      .hasText(`${elementName} base`);
+      .hasText(`${elementName} base def`);
     assert.dom('[data-test-inheritance-panel-header]').exists();
     assert.dom('[data-test-card-module-definition]').exists();
     assert
@@ -1502,7 +1517,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await waitFor('[data-test-boxel-selector-item-selected]');
     assert
       .dom('[data-test-boxel-selector-item-selected]')
-      .hasText(`Human (${elementName}) card`);
+      .hasText(`Human (${elementName}) card def`);
     assert.dom('[data-test-inheritance-panel-header]').exists();
     assert.dom('[data-test-card-module-definition]').exists();
     assert
@@ -1511,6 +1526,47 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     assert.dom('[data-test-card-module-definition]').includesText('Card');
     assert.true(monacoService.getLineCursorOn()?.includes('Human'));
     assert.dom('[data-test-file-incompatibility-message]').doesNotExist();
+  });
+
+  test('"in-this-file" panel displays FileDef declarations with correct labeling', async function (assert) {
+    await visitOperatorMode({
+      stacks: [[]],
+      submode: 'code',
+      codePath: `${testRealmURL}file-def.gts`,
+    });
+
+    await waitFor('[data-test-card-inspector-panel]');
+    await waitFor('[data-test-current-module-name]');
+    await waitFor('[data-test-in-this-file-selector]');
+
+    assert.dom('[data-test-boxel-selector-item]').exists({ count: 1 });
+    assert
+      .dom('[data-test-boxel-selector-item]:nth-of-type(1)')
+      .hasText('CustomFileDef file def');
+
+    // clicking on a file def shows inheritance panel
+    let elementName = 'CustomFileDef';
+    await click(`[data-test-boxel-selector-item-text="${elementName}"]`);
+    assert
+      .dom('[data-test-boxel-selector-item-selected]')
+      .hasText(`${elementName} file def`);
+    await waitFor('[data-test-card-module-definition]');
+    assert.dom('[data-test-inheritance-panel-header]').exists();
+    assert
+      .dom('[data-test-inheritance-panel-header]')
+      .hasText('File Def Inheritance');
+    assert.dom('[data-test-card-module-definition]').exists();
+    assert
+      .dom('[data-test-definition-header]')
+      .includesText('File Definition');
+    assert
+      .dom('[data-test-card-module-definition]')
+      .includesText('custom file');
+
+    // Inherit action should not be available for file defs
+    assert
+      .dom('[data-test-action-button="Inherit"]')
+      .doesNotExist('Inherit action is not shown for FileDef declarations');
   });
 
   test('"in-this-file" panel displays local grandfather card. selection will move cursor and display card or field schema', async function (assert) {
@@ -1525,7 +1581,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await waitFor('[data-test-in-this-file-selector]');
     //default is the last index
     await click(`[data-test-boxel-selector-item-text="GrandParent"]`);
-    let elementName = 'GrandParent card';
+    let elementName = 'GrandParent card def';
     assert
       .dom('[data-test-boxel-selector-item]:nth-of-type(1)')
       .hasText(elementName);
@@ -1533,12 +1589,12 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     assert.true(monacoService.getLineCursorOn()?.includes('CardDef'));
     // elements must be ordered by the way they appear in the source code
     const expectedElementNames = [
-      'GrandParent card',
-      'Parent card',
-      'Activity field',
-      'Hobby field',
-      'Sport field',
-      'Child card',
+      'GrandParent card def',
+      'Parent card def',
+      'Activity field def',
+      'Hobby field def',
+      'Sport field def',
+      'Child card def',
     ];
     expectedElementNames.forEach(async (elementName, index) => {
       await waitFor(
@@ -1554,7 +1610,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await click(`[data-test-boxel-selector-item-text="${elementName}"]`);
     assert
       .dom('[data-test-boxel-selector-item-selected]')
-      .hasText(`${elementName} card`);
+      .hasText(`${elementName} card def`);
     await waitFor('[data-test-card-module-definition]');
     assert.dom('[data-test-inheritance-panel-header]').exists();
     assert.dom('[data-test-card-module-definition]').exists();
@@ -1577,7 +1633,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await click(`[data-test-boxel-selector-item-text="${elementName}"]`);
     assert
       .dom('[data-test-boxel-selector-item-selected]')
-      .hasText(`${elementName} field`);
+      .hasText(`${elementName} field def`);
     await waitFor('[data-test-card-module-definition]');
     assert.dom('[data-test-inheritance-panel-header]').exists();
     assert.dom('[data-test-card-module-definition]').exists();
@@ -1598,7 +1654,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
     await waitFor('[data-test-boxel-selector-item-selected]');
     assert
       .dom('[data-test-boxel-selector-item-selected]')
-      .hasText('Hobby field');
+      .hasText('Hobby field def');
     await waitFor('[data-test-card-schema="my hobby"]');
     assert.dom(`[data-test-card-schema="my hobby"]`).exists({ count: 1 });
     assert.dom(`[data-test-card-schema="my activity"]`).exists({ count: 1 });
@@ -1630,20 +1686,20 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
       .hasText(elementName);
     assert.true(monacoService.getLineCursorOn()?.includes('DefaultClass'));
     // elements must be ordered by the way they appear in the source code
-    const expectedElementNames = [
+    const expectedElementNames2 = [
       'AClassWithExportName (LocalClass) class',
       'ExportedClass class',
       'ExportedClassInheritLocalClass class',
       'exportedFunction function',
-      'LocalCard card',
-      'ExportedCard card',
-      'ExportedCardInheritLocalCard card',
-      'LocalField field',
-      'ExportedField field',
-      'ExportedFieldInheritLocalField field',
+      'LocalCard card def',
+      'ExportedCard card def',
+      'ExportedCardInheritLocalCard card def',
+      'LocalField field def',
+      'ExportedField field def',
+      'ExportedFieldInheritLocalField field def',
       'default (DefaultClass) class',
     ];
-    expectedElementNames.forEach(async (elementName, index) => {
+    expectedElementNames2.forEach(async (elementName, index) => {
       await waitFor(
         `[data-test-boxel-selector-item]:nth-of-type(${index + 1})`,
       );


### PR DESCRIPTION
## Summary
- FileDef declarations in the "In This File" panel now show as "File Definition" instead of "Base Definition"
- Selector type badge shows "FILE DEF" for FileDef declarations (also updates existing card/field/base badges to include "def" suffix for consistency)
- Inheritance panel header says "File Def Inheritance" when a FileDef is selected
- "Inherit" action is hidden for FileDefs since the file-definition creation workflow doesn't exist yet (tracked in CS-10199)

Closes CS-10194

## Test plan
- [ ] Open a `.gts` file that exports a FileDef subclass (e.g., `png-image-def.gts`)
- [ ] Verify the "In This File" selector shows the declaration with a "FILE DEF" type badge
- [ ] Verify clicking the declaration shows "File Definition" in the inheritance panel header area
- [ ] Verify the inheritance panel header says "File Def Inheritance"
- [ ] Verify the "Inherit" action is not shown for FileDef declarations
- [ ] Verify existing CardDef/FieldDef behavior is unchanged (badges now say "CARD DEF" / "FIELD DEF")

🤖 Generated with [Claude Code](https://claude.com/claude-code)