### PR TITLE
Use fields to guide link loading in _search endpoint

### DIFF
--- a/packages/realm-server/tests/realm-endpoints/search-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/search-test.ts
@@ -650,9 +650,7 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
           );
           assert.ok(json.included, 'included array is present');
           assert.ok(json.included.length > 0, 'included has resources');
-          let includedIds = json.included.map(
-            (r: { id: string }) => r.id,
-          );
+          let includedIds = json.included.map((r: { id: string }) => r.id);
           assert.ok(
             includedIds.some((id: string) => id.includes('friend-2')),
             'linked friend resource is in included',
@@ -704,9 +702,7 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
           let json = response.body;
           assert.strictEqual(json.data.length, 1, 'one result is returned');
           assert.ok(json.included, 'included array is present');
-          let includedIds = json.included.map(
-            (r: { id: string }) => r.id,
-          );
+          let includedIds = json.included.map((r: { id: string }) => r.id);
           assert.ok(
             includedIds.some((id: string) => id.includes('friend-2')),
             'directly linked friend (Bob) is in included',
@@ -732,9 +728,7 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
           let json = response.body;
           assert.strictEqual(json.data.length, 1, 'one result is returned');
           assert.ok(json.included, 'included array is present');
-          let includedIds = json.included.map(
-            (r: { id: string }) => r.id,
-          );
+          let includedIds = json.included.map((r: { id: string }) => r.id);
           assert.ok(
             includedIds.some((id: string) => id.includes('friend-2')),
             'first linked friend is in included',

--- a/packages/realm-server/tests/realm-endpoints/search-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/search-test.ts
@@ -515,6 +515,236 @@ module(`realm-endpoints/${basename(__filename)}`, function () {
           );
         });
       });
+
+      module('fields-based link loading', function (hooks) {
+        setupPermissionedRealm(hooks, {
+          permissions: {
+            '*': ['read'],
+          },
+          realmURL: new URL('http://127.0.0.1:4444/test/'),
+          fileSystem: {
+            'friend.gts': `
+              import {
+                contains,
+                linksTo,
+                linksToMany,
+                field,
+                CardDef,
+                Component,
+              } from 'https://cardstack.com/base/card-api';
+              import StringField from 'https://cardstack.com/base/string';
+
+              export class Friend extends CardDef {
+                @field firstName = contains(StringField);
+                @field friend = linksTo(() => Friend);
+                @field friends = linksToMany(() => Friend);
+                static isolated = class Isolated extends Component<typeof this> {
+                  <template>
+                    <@fields.firstName />
+                  </template>
+                };
+              }
+            `,
+            'friend-1.json': {
+              data: {
+                type: 'card',
+                attributes: {
+                  firstName: 'Alice',
+                },
+                relationships: {
+                  friend: {
+                    links: {
+                      self: './friend-2',
+                    },
+                  },
+                  'friends.0': {
+                    links: {
+                      self: './friend-2',
+                    },
+                  },
+                  'friends.1': {
+                    links: {
+                      self: './friend-3',
+                    },
+                  },
+                },
+                meta: {
+                  adoptsFrom: {
+                    module: './friend',
+                    name: 'Friend',
+                  },
+                },
+              },
+            },
+            'friend-2.json': {
+              data: {
+                type: 'card',
+                attributes: {
+                  firstName: 'Bob',
+                },
+                relationships: {
+                  friend: {
+                    links: {
+                      self: './friend-3',
+                    },
+                  },
+                },
+                meta: {
+                  adoptsFrom: {
+                    module: './friend',
+                    name: 'Friend',
+                  },
+                },
+              },
+            },
+            'friend-3.json': {
+              data: {
+                type: 'card',
+                attributes: {
+                  firstName: 'Charlie',
+                },
+                meta: {
+                  adoptsFrom: {
+                    module: './friend',
+                    name: 'Friend',
+                  },
+                },
+              },
+            },
+          },
+          onRealmSetup,
+        });
+
+        function buildFriendQuery(firstName: string): Query {
+          return {
+            filter: {
+              on: {
+                module: `${realmHref}friend`,
+                name: 'Friend',
+              },
+              eq: {
+                firstName,
+              },
+            },
+          };
+        }
+
+        test('fields with relationship field name loads that relationship into included', async function (assert) {
+          let response = await request
+            .post(searchPath)
+            .set('Accept', 'application/vnd.card+json')
+            .set('X-HTTP-Method-Override', 'QUERY')
+            .send({
+              ...buildFriendQuery('Alice'),
+              fields: { card: ['firstName', 'friend'] },
+              asData: true,
+            });
+
+          assert.strictEqual(response.status, 200, 'HTTP 200 status');
+          let json = response.body;
+          assert.strictEqual(json.data.length, 1, 'one result is returned');
+          assert.strictEqual(
+            json.data[0].attributes.firstName,
+            'Alice',
+            'correct card returned',
+          );
+          assert.ok(json.included, 'included array is present');
+          assert.ok(json.included.length > 0, 'included has resources');
+          let includedIds = json.included.map(
+            (r: { id: string }) => r.id,
+          );
+          assert.ok(
+            includedIds.some((id: string) => id.includes('friend-2')),
+            'linked friend resource is in included',
+          );
+        });
+
+        test('fields with only attribute field names does not load links', async function (assert) {
+          let response = await request
+            .post(searchPath)
+            .set('Accept', 'application/vnd.card+json')
+            .set('X-HTTP-Method-Override', 'QUERY')
+            .send({
+              ...buildFriendQuery('Alice'),
+              fields: { card: ['firstName'] },
+              asData: true,
+            });
+
+          assert.strictEqual(response.status, 200, 'HTTP 200 status');
+          let json = response.body;
+          assert.strictEqual(json.data.length, 1, 'one result is returned');
+          assert.strictEqual(
+            json.data[0].attributes.firstName,
+            'Alice',
+            'correct card returned',
+          );
+          assert.strictEqual(
+            json.included,
+            undefined,
+            'no included array when fields has no relationship names',
+          );
+        });
+
+        test('fields filter applies only at root level - nested relationships are fully loaded', async function (assert) {
+          // Alice links to Bob via `friend`, and Bob links to Charlie via
+          // `friend`. When we request only `friend` in fields, Bob's nested
+          // link to Charlie should also be included because linkFields is
+          // cleared for recursive link loading.
+          let response = await request
+            .post(searchPath)
+            .set('Accept', 'application/vnd.card+json')
+            .set('X-HTTP-Method-Override', 'QUERY')
+            .send({
+              ...buildFriendQuery('Alice'),
+              fields: { card: ['friend'] },
+              asData: true,
+            });
+
+          assert.strictEqual(response.status, 200, 'HTTP 200 status');
+          let json = response.body;
+          assert.strictEqual(json.data.length, 1, 'one result is returned');
+          assert.ok(json.included, 'included array is present');
+          let includedIds = json.included.map(
+            (r: { id: string }) => r.id,
+          );
+          assert.ok(
+            includedIds.some((id: string) => id.includes('friend-2')),
+            'directly linked friend (Bob) is in included',
+          );
+          assert.ok(
+            includedIds.some((id: string) => id.includes('friend-3')),
+            "Bob's nested friend (Charlie) is also in included",
+          );
+        });
+
+        test('fields with linksToMany relationship loads those links', async function (assert) {
+          let response = await request
+            .post(searchPath)
+            .set('Accept', 'application/vnd.card+json')
+            .set('X-HTTP-Method-Override', 'QUERY')
+            .send({
+              ...buildFriendQuery('Alice'),
+              fields: { card: ['friends'] },
+              asData: true,
+            });
+
+          assert.strictEqual(response.status, 200, 'HTTP 200 status');
+          let json = response.body;
+          assert.strictEqual(json.data.length, 1, 'one result is returned');
+          assert.ok(json.included, 'included array is present');
+          let includedIds = json.included.map(
+            (r: { id: string }) => r.id,
+          );
+          assert.ok(
+            includedIds.some((id: string) => id.includes('friend-2')),
+            'first linked friend is in included',
+          );
+          assert.ok(
+            includedIds.some((id: string) => id.includes('friend-3')),
+            'second linked friend is in included',
+          );
+        });
+      });
     });
 
     module('QUERY request (permissioned realm)', function (_hooks) {

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -51,6 +51,7 @@ import {
 
 type Options = {
   loadLinks?: true;
+  linkFields?: string[];
 } & QueryOptions;
 
 type SearchResult = SearchResultDoc | SearchResultError;
@@ -130,8 +131,9 @@ export class RealmIndexQueryEngine {
     opts?: Options,
   ): Promise<LinkableCollectionDocument> {
     let doc: LinkableCollectionDocument;
+    let isFileMetaQuery = await this.queryTargetsFileMeta(query.filter, opts);
 
-    if (await this.queryTargetsFileMeta(query.filter, opts)) {
+    if (isFileMetaQuery) {
       let { files, meta } = await this.#indexQueryEngine.searchFiles(
         new URL(this.#realm.url),
         query,
@@ -174,6 +176,10 @@ export class RealmIndexQueryEngine {
     // fill in the included resources for links that were not cached (e.g.
     // volatile fields)
     if (opts?.loadLinks) {
+      let linkFields = isFileMetaQuery
+        ? query.fields?.['file-meta']
+        : query.fields?.['card'];
+      let linkOpts = linkFields ? { ...opts, linkFields } : opts;
       let omit = doc.data.map((r) => r.id).filter(Boolean) as string[];
       let included: (CardResource<Saved> | FileMetaResource)[] = [];
       for (let resource of doc.data) {
@@ -184,7 +190,7 @@ export class RealmIndexQueryEngine {
             omit,
             included,
           },
-          opts,
+          linkOpts,
         );
       }
       if (included.length > 0) {
@@ -373,6 +379,10 @@ export class RealmIndexQueryEngine {
           fieldDefinition.type !== 'linksToMany') ||
         !queryDefinition
       ) {
+        continue;
+      }
+
+      if (opts?.linkFields && !opts.linkFields.includes(fieldName)) {
         continue;
       }
 
@@ -704,8 +714,11 @@ export class RealmIndexQueryEngine {
     let processedRelationships = new Set<string>();
     let processRelationships = async () => {
       for (let entry of relationshipEntries(resource.relationships)) {
-        let { relationship, key } = entry;
+        let { relationship, key, fieldName } = entry;
         if (processedRelationships.has(key)) {
+          continue;
+        }
+        if (opts?.linkFields && !opts.linkFields.includes(fieldName)) {
           continue;
         }
         if (!relationship.links?.self) {
@@ -792,6 +805,14 @@ export class RealmIndexQueryEngine {
         // index based on keeping track of the rendered fields and invalidate the
         // index as consumed cards change
         if (linkResource && stack.length <= maxLinkDepth) {
+          // When linkFields is set, we only apply it at the first level of
+          // link loading. For nested relationships, we clear linkFields so
+          // that all deeper relationships are fully loaded (up to
+          // maxLinkDepth). This means linkFields only constrains the
+          // immediate relationships of the root card.
+          let recursiveOpts = opts?.linkFields
+            ? { ...opts, linkFields: undefined }
+            : opts;
           for (let includedResource of await this.loadLinks(
             {
               realmURL,
@@ -801,7 +822,7 @@ export class RealmIndexQueryEngine {
               visited,
               stack: [...(resource.id != null ? [resource.id] : []), ...stack],
             },
-            opts,
+            recursiveOpts,
           )) {
             foundLinks = true;
             if (

--- a/packages/runtime-common/realm.ts
+++ b/packages/runtime-common/realm.ts
@@ -3061,7 +3061,7 @@ export class Realm {
   public async search(query: Query): Promise<LinkableCollectionDocument> {
     assertQuery(query);
     return await this.#realmIndexQueryEngine.searchCards(query, {
-      ...(query.asData ? {} : { loadLinks: true }),
+      loadLinks: true,
     });
   }
 


### PR DESCRIPTION
## Summary
- Always enable link loading in `_search`, but use the `fields` (sparse fieldset) parameter to filter **which** relationships are followed into the `included` array
- When `fields` specifies relationship names (e.g. `friend`, `friends`), only those relationships are loaded — others are skipped
- When `fields` contains only attribute names, no relationships are followed and `included` is empty
- Removes the previous all-or-nothing `asData` skip of link loading

## Test plan
- [x] New test: `fields` with a `linksTo` relationship name loads that relationship into `included`
- [x] New test: `fields` with only attribute names produces no `included` array
- [x] New test: `fields` with a `linksToMany` relationship loads those links into `included`
- [x] All 32 existing search endpoint tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)