### PR TITLE
File Inspector shows FileDef type and inheritance for non-module files

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
+++ b/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
@@ -48,9 +48,7 @@ import {
 import CreateSpecCommand from '@cardstack/host/commands/create-specs';
 import CardError from '@cardstack/host/components/operator-mode/card-error';
 import Playground from '@cardstack/host/components/operator-mode/code-submode/playground/playground';
-
 import SchemaEditor from '@cardstack/host/components/operator-mode/code-submode/schema-editor';
-
 import SpecPreview from '@cardstack/host/components/operator-mode/code-submode/spec-preview';
 import SpecPreviewBadge from '@cardstack/host/components/operator-mode/code-submode/spec-preview-badge';
 

--- a/packages/host/app/components/operator-mode/definition-container/index.gts
+++ b/packages/host/app/components/operator-mode/definition-container/index.gts
@@ -49,7 +49,9 @@ const ModuleDefinitionContainer: TemplateOnlyComponent<ModSig> = <template>
 </template>;
 
 interface InstanceArgs
-  extends Omit<BaseArgs, 'title' | 'isActive'>, ActiveArgs {}
+  extends Omit<BaseArgs, 'title' | 'isActive'>, ActiveArgs {
+  title?: string;
+}
 
 interface InstSig {
   Element: HTMLElement;
@@ -58,7 +60,7 @@ interface InstSig {
 
 const InstanceDefinitionContainer: TemplateOnlyComponent<InstSig> = <template>
   <BaseDefinitionContainer
-    @title='Card Instance'
+    @title={{if @title @title 'Card Instance'}}
     @fileExtension={{@fileExtension}}
     @name={{@name}}
     @isActive={{true}}

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -11,6 +11,8 @@ import { use, resource } from 'ember-resources';
 
 import startCase from 'lodash/startCase';
 
+import { TrackedObject } from 'tracked-built-ins';
+
 import {
   LoadingIndicator,
   ContextButton,
@@ -31,6 +33,7 @@ import {
   isFieldDef,
   isFileDef,
   isBaseDef,
+  isCardErrorJSONAPI,
   internalKeyFor,
   type ResolvedCodeRef,
   type CardErrorJSONAPI,
@@ -50,6 +53,7 @@ import {
 import { getResolvedCodeRefFromType } from '@cardstack/host/services/card-type-service';
 import type CommandService from '@cardstack/host/services/command-service';
 import type RealmService from '@cardstack/host/services/realm';
+import type StoreService from '@cardstack/host/services/store';
 
 import type { CardDef, BaseDef } from 'https://cardstack.com/base/card-api';
 
@@ -107,6 +111,7 @@ export default class DetailPanel extends Component<Signature> {
   @service declare private operatorModeStateService: OperatorModeStateService;
   @service declare private realm: RealmService;
   @service declare private commandService: CommandService;
+  @service declare private store: StoreService;
 
   private lastModified = lastModifiedDate(this, () => this.args.readyFile);
 
@@ -117,6 +122,50 @@ export default class DetailPanel extends Component<Signature> {
   @use private cardInstanceType = resource(() => {
     if (this.args.cardInstance !== undefined) {
       let cardDefinition = this.args.cardInstance.constructor as typeof BaseDef;
+      return getCardType(this, () => cardDefinition);
+    }
+    return undefined;
+  });
+
+  @use private fileDefResource = resource(() => {
+    let state = new TrackedObject<{
+      value: BaseDef | undefined;
+      isLoading: boolean;
+      error: unknown;
+    }>({
+      value: undefined,
+      isLoading: false,
+      error: undefined,
+    });
+    if (!this.isNonModuleFile) {
+      return state;
+    }
+    let fileUrl = this.args.readyFile.url;
+    state.isLoading = true;
+    (async () => {
+      try {
+        let result = await this.store.get(fileUrl, { type: 'file-meta' });
+        if (isCardErrorJSONAPI(result)) {
+          state.error = result;
+          state.value = undefined;
+        } else {
+          state.value = result as unknown as BaseDef;
+          state.error = undefined;
+        }
+      } catch (e) {
+        state.error = e;
+        state.value = undefined;
+      } finally {
+        state.isLoading = false;
+      }
+    })();
+    return state;
+  });
+
+  @use private fileDefInstanceType = resource(() => {
+    let fileDefInstance = this.fileDefResource?.value;
+    if (fileDefInstance !== undefined) {
+      let cardDefinition = fileDefInstance.constructor as typeof BaseDef;
       return getCardType(this, () => cardDefinition);
     }
     return undefined;
@@ -144,7 +193,8 @@ export default class DetailPanel extends Component<Signature> {
         this.args.selectedDeclaration &&
         (isCardOrFieldDeclaration(this.args.selectedDeclaration) ||
           isReexportCardOrField(this.args.selectedDeclaration))) ||
-      this.isCardInstance
+      this.isCardInstance ||
+      this.isFileDefInstance
     );
   }
 
@@ -176,7 +226,11 @@ export default class DetailPanel extends Component<Signature> {
   }
 
   private get isLoading() {
-    return this.cardInstanceType?.isLoading;
+    return (
+      this.cardInstanceType?.isLoading ||
+      this.fileDefResource?.isLoading ||
+      this.fileDefInstanceType?.isLoading
+    );
   }
 
   private get definitionActions() {
@@ -407,6 +461,9 @@ export default class DetailPanel extends Component<Signature> {
   }
 
   private get inheritancePanelHeader() {
+    if (this.isFileDefInstance) {
+      return 'File Inheritance';
+    }
     if (
       this.args.selectedDeclaration &&
       (isCardOrFieldDeclaration(this.args.selectedDeclaration) ||
@@ -417,6 +474,14 @@ export default class DetailPanel extends Component<Signature> {
       }
     }
     return 'Card Inheritance';
+  }
+
+  private get isNonModuleFile() {
+    return !this.isModule && !isCardDocumentString(this.args.readyFile.content);
+  }
+
+  private get isFileDefInstance() {
+    return this.fileDefResource?.value !== undefined;
   }
 
   private get fileExtension() {
@@ -530,7 +595,32 @@ export default class DetailPanel extends Component<Signature> {
           >
             {{this.inheritancePanelHeader}}
           </PanelHeader>
-          {{#if this.isCardInstance}}
+          {{#if this.isFileDefInstance}}
+            <InstanceDefinitionContainer
+              @title='File Instance'
+              @fileURL={{@readyFile.url}}
+              @name={{@readyFile.name}}
+              @fileExtension={{this.fileExtension}}
+              @infoText={{this.lastModified.value}}
+              @actions={{this.miscFileActions}}
+            />
+            <Divider @label='Adopts From' />
+            {{#if this.fileDefInstanceType.type}}
+              {{#let
+                (getResolvedCodeRefFromType this.fileDefInstanceType.type)
+                as |codeRef|
+              }}
+                <ClickableModuleDefinitionContainer
+                  @title='File Definition'
+                  @fileURL={{this.fileDefInstanceType.type.module}}
+                  @name={{this.fileDefInstanceType.type.displayName}}
+                  @fileExtension={{this.fileDefInstanceType.type.moduleInfo.extension}}
+                  @goToDefinition={{@goToDefinition}}
+                  @codeRef={{codeRef}}
+                />
+              {{/let}}
+            {{/if}}
+          {{else if this.isCardInstance}}
             {{! JSON case when visting, eg Author/1.json }}
             <InstanceDefinitionContainer
               @fileURL={{@readyFile.url}}

--- a/packages/host/app/components/operator-mode/detail-panel.gts
+++ b/packages/host/app/components/operator-mode/detail-panel.gts
@@ -595,32 +595,7 @@ export default class DetailPanel extends Component<Signature> {
           >
             {{this.inheritancePanelHeader}}
           </PanelHeader>
-          {{#if this.isFileDefInstance}}
-            <InstanceDefinitionContainer
-              @title='File Instance'
-              @fileURL={{@readyFile.url}}
-              @name={{@readyFile.name}}
-              @fileExtension={{this.fileExtension}}
-              @infoText={{this.lastModified.value}}
-              @actions={{this.miscFileActions}}
-            />
-            <Divider @label='Adopts From' />
-            {{#if this.fileDefInstanceType.type}}
-              {{#let
-                (getResolvedCodeRefFromType this.fileDefInstanceType.type)
-                as |codeRef|
-              }}
-                <ClickableModuleDefinitionContainer
-                  @title='File Definition'
-                  @fileURL={{this.fileDefInstanceType.type.module}}
-                  @name={{this.fileDefInstanceType.type.displayName}}
-                  @fileExtension={{this.fileDefInstanceType.type.moduleInfo.extension}}
-                  @goToDefinition={{@goToDefinition}}
-                  @codeRef={{codeRef}}
-                />
-              {{/let}}
-            {{/if}}
-          {{else if this.isCardInstance}}
+          {{#if this.isCardInstance}}
             {{! JSON case when visting, eg Author/1.json }}
             <InstanceDefinitionContainer
               @fileURL={{@readyFile.url}}
@@ -640,6 +615,31 @@ export default class DetailPanel extends Component<Signature> {
                   @fileURL={{this.cardInstanceType.type.module}}
                   @name={{this.cardInstanceType.type.displayName}}
                   @fileExtension={{this.cardInstanceType.type.moduleInfo.extension}}
+                  @goToDefinition={{@goToDefinition}}
+                  @codeRef={{codeRef}}
+                />
+              {{/let}}
+            {{/if}}
+          {{else if this.isFileDefInstance}}
+            <InstanceDefinitionContainer
+              @title='File Instance'
+              @fileURL={{@readyFile.url}}
+              @name={{@readyFile.name}}
+              @fileExtension={{this.fileExtension}}
+              @infoText={{this.lastModified.value}}
+              @actions={{this.miscFileActions}}
+            />
+            <Divider @label='Adopts From' />
+            {{#if this.fileDefInstanceType.type}}
+              {{#let
+                (getResolvedCodeRefFromType this.fileDefInstanceType.type)
+                as |codeRef|
+              }}
+                <ClickableModuleDefinitionContainer
+                  @title='File Definition'
+                  @fileURL={{this.fileDefInstanceType.type.module}}
+                  @name={{this.fileDefInstanceType.type.displayName}}
+                  @fileExtension={{this.fileDefInstanceType.type.moduleInfo.extension}}
                   @goToDefinition={{@goToDefinition}}
                   @codeRef={{codeRef}}
                 />

--- a/packages/host/tests/acceptance/code-patches-test.gts
+++ b/packages/host/tests/acceptance/code-patches-test.gts
@@ -1686,7 +1686,7 @@ ${REPLACE_MARKER}
 
     // Assert that the spinner disappears after automatic execution completes
     assert
-      .dom('[data-test-loading-indicator]')
+      .dom('[data-test-ai-assistant-action-bar] [data-test-loading-indicator]')
       .doesNotExist(
         'Loading indicator disappears after automatic execution completes',
       );

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -940,9 +940,7 @@ module('Acceptance | code submode tests', function (_hooks) {
         )
         .doesNotExist();
 
-      assert
-        .dom('[data-test-definition-header]')
-        .includesText('File Instance');
+      assert.dom('[data-test-definition-header]').includesText('File Instance');
 
       assert
         .dom('[data-test-inheritance-panel-header]')

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -899,7 +899,7 @@ module('Acceptance | code submode tests', function (_hooks) {
       assert.dom('[data-test-file]').exists();
     });
 
-    test('non-card JSON is shown as just a file with empty schema editor', async function (assert) {
+    test('non-card JSON is shown as a file instance with file inheritance', async function (assert) {
       await visitOperatorMode({
         stacks: [
           [
@@ -913,7 +913,7 @@ module('Acceptance | code submode tests', function (_hooks) {
         codePath: `${testRealmURL}z01.json`,
       });
 
-      await waitFor('[data-test-file-definition]');
+      await waitFor('[data-test-card-instance-definition]');
 
       assert.dom('[data-test-definition-file-extension]').hasText('.json');
       await waitFor('[data-test-definition-realm-name]');
@@ -940,7 +940,13 @@ module('Acceptance | code submode tests', function (_hooks) {
         )
         .doesNotExist();
 
-      assert.dom('[data-test-definition-header]').includesText('File');
+      assert
+        .dom('[data-test-definition-header]')
+        .includesText('File Instance');
+
+      assert
+        .dom('[data-test-inheritance-panel-header]')
+        .includesText('File Inheritance');
 
       assert
         .dom('[data-test-definition-realm-name]')
@@ -948,7 +954,7 @@ module('Acceptance | code submode tests', function (_hooks) {
       assert.dom('[data-test-action-button="Delete"]').exists();
     });
 
-    test('invalid JSON is shown as just a file with empty schema editor', async function (assert) {
+    test('invalid JSON is shown as a file instance with file inheritance', async function (assert) {
       await visitOperatorMode({
         stacks: [
           [
@@ -962,7 +968,7 @@ module('Acceptance | code submode tests', function (_hooks) {
         codePath: `${testRealmURL}not-json.json`,
       });
 
-      await waitFor('[data-test-file-definition]');
+      await waitFor('[data-test-card-instance-definition]');
 
       assert.dom('[data-test-definition-file-extension]').hasText('.json');
       await waitFor('[data-test-definition-realm-name]');

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -487,6 +487,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
         'command-module.gts': commandModuleSource,
         'erroring-module.gts': erroringModuleSource,
         'empty-file.gts': '',
+        'sample-styles.css': 'body { color: red; }',
         'person-entry.json': {
           data: {
             type: 'card',
@@ -2400,6 +2401,42 @@ export class ExportedCard extends ExportedCardParent {
         .doesNotExist(
           'Create Listing button is not displayed when user lacks write permissions',
         );
+    });
+
+    test('inspector shows file inheritance panel for non-module files', async function (assert) {
+      await visitOperatorMode({
+        stacks: [[]],
+        submode: 'code',
+        codePath: `${testRealmURL}sample-styles.css`,
+      });
+
+      await waitFor('[data-test-card-inspector-panel]');
+      await waitFor('[data-test-inheritance-panel-header]');
+
+      assert
+        .dom('[data-test-inheritance-panel-header]')
+        .hasText('File Inheritance');
+
+      assert
+        .dom('[data-test-card-instance-definition]')
+        .exists('file instance definition is shown');
+      assert
+        .dom(
+          '[data-test-card-instance-definition] [data-test-definition-header]',
+        )
+        .includesText('File Instance');
+      assert
+        .dom(
+          '[data-test-card-instance-definition] [data-test-definition-file-extension]',
+        )
+        .includesText('.css');
+
+      assert
+        .dom('[data-test-card-module-definition]')
+        .exists('file definition (adopts from) is shown');
+      assert
+        .dom('[data-test-card-module-definition]')
+        .includesText('File Definition');
     });
   });
 });


### PR DESCRIPTION
## Summary
- When a non-module file (e.g., `.png`, `.md`, `.css`) is open in CodeMode, the File Inspector (detail panel) now shows a **File Inheritance** view instead of the generic "Details" section
- Displays the file as a "File Instance" with an "Adopts From" chain pointing to its FileDef type (e.g., `PngDef` for `.png`, `MarkdownDef` for `.md`)
- Clicking the FileDef type navigates to its `.gts` definition file
- Also includes earlier commits: preview pane for non-module files, and unification of CardRendererPanel/FilePreviewPanel into PreviewPanel

<img width="2838" height="1840" alt="image" src="https://github.com/user-attachments/assets/b050fae7-55a9-425d-ab2c-81606a224b7b" />

## Test plan
- [x] Open a `.png` file in CodeMode → File Inspector shows "File Inheritance" with "File Instance .PNG" and "Adopts From → PngDef (File Definition .GTS)"
- [x] Open a `.md` file → shows "File Instance .MD" and "Adopts From → MarkdownDef"
- [ ] Open a `.css` file → shows appropriate FileDef inheritance
- [x] Click on the FileDef type container → navigates to the `.gts` definition file
- [x] Open a `.json` card instance → still shows "Card Inheritance" as before
- [x] Open a `.gts` module file → still shows "In This File" and card/field inheritance as before
- [ ] Delete action still works on non-module files from the File Instance panel

Closes CS-10198

🤖 Generated with [Claude Code](https://claude.com/claude-code)