### PR TITLE
fix: scope test-realm service worker to /tests

### DIFF
--- a/packages/host/tests/helpers/test-realm-service-worker.ts
+++ b/packages/host/tests/helpers/test-realm-service-worker.ts
@@ -3,6 +3,7 @@ import { getService } from '@universal-ember/test-support';
 import type NetworkService from '@cardstack/host/services/network';
 
 let swReady: Promise<void> | undefined;
+let swRegistration: ServiceWorkerRegistration | undefined;
 
 async function ensureRegistered(): Promise<void> {
   if (swReady) {
@@ -10,6 +11,7 @@ async function ensureRegistered(): Promise<void> {
   }
   swReady = (async () => {
     let reg = await navigator.serviceWorker.register('/test-realm-sw.js');
+    swRegistration = reg;
     let sw = reg.installing || reg.waiting || reg.active;
     if (sw && sw.state !== 'activated') {
       await new Promise<void>((resolve) => {
@@ -74,6 +76,17 @@ export function setupTestRealmServiceWorker(hooks: NestedHooks) {
     if (handler) {
       navigator.serviceWorker.removeEventListener('message', handler);
       handler = undefined;
+    }
+  });
+
+  // Unregister the test-realm SW after the module's tests complete so it
+  // doesn't persist and replace the auth service worker (which would break
+  // the app if the user navigates from /tests back to / during ember serve).
+  hooks.after(async function () {
+    if (swRegistration) {
+      await swRegistration.unregister();
+      swRegistration = undefined;
+      swReady = undefined;
     }
   });
 }


### PR DESCRIPTION
## Summary
- Unregisters the test-realm service worker after each test module completes (via `hooks.after()`) so it doesn't persist beyond the test run
- Previously, visiting `/tests` during `ember serve` caused a blank screen when navigating back to `/` because the test-realm SW (with `skipWaiting()` + `clients.claim()`) took over scope `/`, displacing the auth SW that injects Authorization headers for realm server requests
- After the fix, the test-realm SW is cleaned up when tests finish, so the auth SW remains active for the app

## Test plan
- [x] Start `ember serve`, visit `/`, visit `/tests`, navigate back to `/` — app renders correctly
- [x] Image-def acceptance tests pass in CI (SW is registered/unregistered per module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)