### PR TITLE
Upgrade pnpm from 10.17.0 to 10.30.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   },
   "volta": {
     "node": "22.20.0",
-    "pnpm": "10.17.0"
+    "pnpm": "10.30.0"
   },
   "dependencies": {
     "matrix-js-sdk": "38.3.0"

--- a/packages/ai-bot/Dockerfile
+++ b/packages/ai-bot/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:22.20.0-slim
 ARG CI=1
 RUN apt-get update && apt-get install -y python3 build-essential
-RUN npm install -g pnpm@10.17.0
+RUN npm install -g pnpm@10.30.0
 WORKDIR /boxel
 COPY . .
 RUN pnpm install --frozen-lockfile

--- a/packages/bot-runner/Dockerfile
+++ b/packages/bot-runner/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:22.20.0-slim
 ARG CI=1
 RUN apt-get update && apt-get install -y python3 build-essential
-RUN npm install -g pnpm@10.17.0
+RUN npm install -g pnpm@10.30.0
 WORKDIR /boxel
 COPY . .
 RUN pnpm install --frozen-lockfile

--- a/packages/postgres/Dockerfile
+++ b/packages/postgres/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:22.20.0-slim
 ARG CI=1
 RUN apt-get update && apt-get install -y postgresql
-RUN npm install -g pnpm@10.17.0
+RUN npm install -g pnpm@10.30.0
 WORKDIR /boxel
 COPY . .
 RUN pnpm install --frozen-lockfile

--- a/packages/realm-server/prerender-manager.Dockerfile
+++ b/packages/realm-server/prerender-manager.Dockerfile
@@ -7,7 +7,7 @@ ENV prerender_manager_script=$prerender_manager_script
 WORKDIR /realm-server
 
 RUN apt-get update && apt-get install -y ca-certificates curl unzip jq
-RUN npm install -g pnpm@10.17.0
+RUN npm install -g pnpm@10.30.0
 
 COPY pnpm-lock.yaml ./
 

--- a/packages/realm-server/prerender.Dockerfile
+++ b/packages/realm-server/prerender.Dockerfile
@@ -47,7 +47,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends google-chrome-stable \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g pnpm@10.17.0
+RUN npm install -g pnpm@10.30.0
 
 RUN groupadd -r pptruser \
     && useradd -r -m -d /home/pptruser -g pptruser -G audio,video pptruser

--- a/packages/realm-server/realm-server.Dockerfile
+++ b/packages/realm-server/realm-server.Dockerfile
@@ -7,7 +7,7 @@ ENV realm_server_script=$realm_server_script
 WORKDIR /realm-server
 
 RUN apt-get update && apt-get install -y ca-certificates curl unzip postgresql jq rsync
-RUN npm install -g pnpm@10.17.0
+RUN npm install -g pnpm@10.30.0
 
 COPY pnpm-lock.yaml ./
 

--- a/packages/realm-server/worker.Dockerfile
+++ b/packages/realm-server/worker.Dockerfile
@@ -7,7 +7,7 @@ ENV worker_script=$worker_script
 WORKDIR /realm-server
 
 RUN apt-get update && apt-get install -y ca-certificates curl unzip postgresql jq
-RUN npm install -g pnpm@10.17.0
+RUN npm install -g pnpm@10.30.0
 
 COPY pnpm-lock.yaml ./
 


### PR DESCRIPTION
## Summary
- Upgrades pnpm from 10.17.0 to 10.30.0 across Volta config and all 7 Dockerfiles
- No lockfile changes needed

Closes CS-10208

## Changelog Research (10.17.1 → 10.30.0)

### Semi-Breaking Changes to Watch
- **v10.26.0**: Git dependency `prepare` scripts blocked by default — must be explicitly allowed in `onlyBuiltDependencies` or `allowBuilds`
- **v10.26.0**: HTTP tarball integrity hashes now computed and stored in lockfile
- **v10.27.0**: Unscoped packages relocated in global virtual store (run `pnpm store prune` to clean up)

### Notable New Features
- **v10.30.0**: Improved `pnpm why` with reverse dependency tree
- **v10.29.0**: Bare `workspace:` protocol (no version specifier needed)
- **v10.28.0**: `beforePacking` hook for customizing `package.json` at publish time
- **v10.26.0**: `blockExoticSubdeps` prevents exotic protocols in transitive deps
- **v10.26.0**: `allowBuilds` as simpler alternative to `onlyBuiltDependencies`
- **v10.25.0**: `pnpm init --bare`, `pnpm pack --dry-run`
- **v10.24.0**: Auto-tuned network concurrency (16–64 based on CPU cores)
- **v10.21.0**: `trustPolicy: no-downgrade` for supply-chain security

### Important Bug Fixes
- **v10.28.2**: Path traversal prevention in `directories.bin` (security)
- **v10.28.2**: Symlink validation for file/git dependencies (security)
- **v10.28.0**: Filtered install (`--filter`) performance regression fixed — significant for monorepos
- **v10.30.0**: `pnpm why`/`pnpm list` share dependency graph across workspace importers (monorepo speedup)
- **v10.27.0**: `pnpm add` no longer corrupts catalog entries in `pnpm-workspace.yaml`
- **v10.24.0**: OverlayFS/containerized environment graceful fallback
- **v10.24.0**: Auth token fix for registry URLs with underscores

### Monorepo-Specific Improvements
| Version | Type | Description |
|---------|------|-------------|
| v10.28.0 | Perf | Filtered installs as fast or faster than full installs |
| v10.30.0 | Perf | `pnpm why`/`list` share dep graphs across workspace importers |
| v10.29.0 | Feature | `auditLevel` configurable in `pnpm-workspace.yaml` |
| v10.29.0 | Feature | Bare `workspace:` protocol |
| v10.28.0 | Feature | `requiredScripts` in `pnpm-workspace.yaml` |
| v10.27.0 | Fix | `pnpm add` no longer corrupts catalog entries |

## Test plan
- [ ] CI passes (existing tests exercise pnpm install)
- [ ] Docker builds succeed with new pnpm version
- [ ] Verify no git dependencies with prepare scripts are affected by v10.26.0 semi-breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)