### PR TITLE
Provide user id to openrouter

### DIFF
--- a/packages/ai-bot/lib/set-title.ts
+++ b/packages/ai-bot/lib/set-title.ts
@@ -31,6 +31,7 @@ export async function setTitle(
   history: DiscreteMatrixEvent[],
   userId: string,
   event?: MatrixEvent,
+  senderMatrixUserId?: string,
 ) {
   let startOfConversation: OpenAIPromptMessage[] = [
     {
@@ -50,6 +51,7 @@ export async function setTitle(
       model: 'gpt-4o',
       messages: startOfConversation as ChatCompletionMessageParam[],
       stream: false,
+      ...(senderMatrixUserId ? { user: senderMatrixUserId } : {}),
     },
     {
       maxRetries: 5,

--- a/packages/ai-bot/main.ts
+++ b/packages/ai-bot/main.ts
@@ -104,7 +104,7 @@ class Assistant {
     );
   }
 
-  getResponse(prompt: PromptParts) {
+  getResponse(prompt: PromptParts, senderMatrixUserId?: string) {
     if (!prompt.model) {
       throw new Error('Model is required');
     }
@@ -125,6 +125,10 @@ class Assistant {
     ) {
       request.tools = prompt.tools;
       request.tool_choice = prompt.toolChoice;
+    }
+
+    if (senderMatrixUserId) {
+      request.user = senderMatrixUserId;
     }
 
     return this.openai.chat.completions.stream(request);
@@ -153,8 +157,17 @@ class Assistant {
     roomId: string,
     history: DiscreteMatrixEvent[],
     event?: MatrixEvent,
+    senderMatrixUserId?: string,
   ) {
-    return setTitle(this.openai, this.client, roomId, history, this.id, event);
+    return setTitle(
+      this.openai,
+      this.client,
+      roomId,
+      history,
+      this.id,
+      event,
+      senderMatrixUserId,
+    );
   }
 }
 
@@ -446,7 +459,7 @@ Common issues are:
             });
           }
           const runner = assistant
-            .getResponse(promptParts)
+            .getResponse(promptParts, senderMatrixUserId)
             .on('chunk', async (chunk, snapshot) => {
               log.info(`[${eventId}] Received chunk %s`, chunk.id);
               if (profEnabled() && firstChunkAt == null) {
@@ -524,7 +537,12 @@ Common issues are:
             // immediately after responder.finalize(), and we need to make sure
             // the room lock is released.
             assistant
-              .setTitle(room.roomId, promptParts.history, event)
+              .setTitle(
+                room.roomId,
+                promptParts.history,
+                event,
+                senderMatrixUserId,
+              )
               .catch((error) => {
                 log.error(`[${eventId}] Error setting room title`);
                 log.error(error);
@@ -589,7 +607,12 @@ Common issues are:
         async () => constructHistory(eventList, client),
       );
       return await profTime(event.getId()!, 'title:setTitle', async () =>
-        assistant.setTitle(room.roomId, history, event),
+        assistant.setTitle(
+          room.roomId,
+          history,
+          event,
+          event.getSender() ?? undefined,
+        ),
       );
     } catch (e) {
       log.error(e);

--- a/packages/ai-bot/tests/chat-titling-test.ts
+++ b/packages/ai-bot/tests/chat-titling-test.ts
@@ -869,4 +869,124 @@ module('setTitle', () => {
     );
     // The assertions are inside the mock matrixClient.setRoomName function
   });
+
+  test('setTitle passes senderMatrixUserId as user param to OpenAI', async (assert) => {
+    let capturedRequest: any;
+    const mockOpenAI = {
+      chat: {
+        completions: {
+          create: async (request: any) => {
+            capturedRequest = request;
+            return {
+              choices: [{ message: { content: 'Test Title' } }],
+            };
+          },
+        },
+      },
+    } as unknown as OpenAI;
+
+    const mockMatrixClient = {
+      setRoomName: async () => ({ event_id: 'new-event-id' }),
+    } as unknown as MatrixClient;
+
+    const history: DiscreteMatrixEvent[] = [
+      {
+        type: 'm.room.message',
+        event_id: 'msg-1',
+        origin_server_ts: 1234567890,
+        status: EventStatus.SENT,
+        content: {
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+          format: 'org.matrix.custom.html',
+          body: 'Hello',
+          data: {
+            context: {
+              functions: [],
+            },
+          },
+        },
+        sender: '@user:localhost',
+        room_id: 'test-room-id',
+        unsigned: {
+          age: 1000,
+          transaction_id: '1',
+        },
+      },
+    ];
+
+    await setTitle(
+      mockOpenAI,
+      mockMatrixClient,
+      'test-room-id',
+      history,
+      '@aibot:localhost',
+      undefined,
+      '@user:localhost',
+    );
+
+    assert.equal(
+      capturedRequest.user,
+      '@user:localhost',
+      'user param is set to senderMatrixUserId',
+    );
+  });
+
+  test('setTitle omits user param when senderMatrixUserId is not provided', async (assert) => {
+    let capturedRequest: any;
+    const mockOpenAI = {
+      chat: {
+        completions: {
+          create: async (request: any) => {
+            capturedRequest = request;
+            return {
+              choices: [{ message: { content: 'Test Title' } }],
+            };
+          },
+        },
+      },
+    } as unknown as OpenAI;
+
+    const mockMatrixClient = {
+      setRoomName: async () => ({ event_id: 'new-event-id' }),
+    } as unknown as MatrixClient;
+
+    const history: DiscreteMatrixEvent[] = [
+      {
+        type: 'm.room.message',
+        event_id: 'msg-1',
+        origin_server_ts: 1234567890,
+        status: EventStatus.SENT,
+        content: {
+          msgtype: APP_BOXEL_MESSAGE_MSGTYPE,
+          format: 'org.matrix.custom.html',
+          body: 'Hello',
+          data: {
+            context: {
+              functions: [],
+            },
+          },
+        },
+        sender: '@user:localhost',
+        room_id: 'test-room-id',
+        unsigned: {
+          age: 1000,
+          transaction_id: '1',
+        },
+      },
+    ];
+
+    await setTitle(
+      mockOpenAI,
+      mockMatrixClient,
+      'test-room-id',
+      history,
+      '@aibot:localhost',
+    );
+
+    assert.strictEqual(
+      capturedRequest.user,
+      undefined,
+      'user param is not set when senderMatrixUserId is not provided',
+    );
+  });
 });


### PR DESCRIPTION
By providing a user ID when calling the OpenRouter API, we improve caching and enhance tracking as described in the [documentation](https://openrouter.ai/docs/guides/guides/user-tracking). We utilize the Matrix event ID for this purpose