### PR TITLE
Fix copy source command

### DIFF
--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -60,8 +60,8 @@ export class CopyCardResult extends CardDef {
 }
 
 export class CopySourceInput extends CardDef {
-  @field fromRealmUrl = contains(StringField);
-  @field toRealmUrl = contains(StringField);
+  @field originSourceUrl = contains(StringField);
+  @field destinationSourceUrl = contains(StringField);
 }
 
 export class CopySourceResult extends CardDef {

--- a/packages/host/app/commands/copy-source.ts
+++ b/packages/host/app/commands/copy-source.ts
@@ -20,14 +20,17 @@ export default class CopySourceCommand extends HostBaseCommand<
     return CopySourceInput;
   }
 
-  requireInputFields = ['fromRealmUrl', 'toRealmUrl'];
+  requireInputFields = ['originSourceUrl', 'destinationSourceUrl'];
 
   protected async run(
     input: BaseCommandModule.CopySourceInput,
   ): Promise<BaseCommandModule.CopySourceResult> {
-    const fromRealmUrl = new URL(input.fromRealmUrl);
-    const toRealmUrl = new URL(input.toRealmUrl);
-    let r = await this.cardService.copySource(fromRealmUrl, toRealmUrl);
+    const originSourceUrl = new URL(input.originSourceUrl);
+    const destinationSourceUrl = new URL(input.destinationSourceUrl);
+    let r = await this.cardService.copySource(
+      originSourceUrl,
+      destinationSourceUrl,
+    );
     let commandModule = await this.loadCommandModule();
     const { CopySourceResult } = commandModule;
     if (r.ok && r.url) {

--- a/packages/host/tests/integration/commands/copy-source-test.gts
+++ b/packages/host/tests/integration/commands/copy-source-test.gts
@@ -62,15 +62,15 @@ module('Integration | commands | copy-source', function (hooks) {
     let copySourceCommand = new CopySourceCommand(
       commandService.commandContext,
     );
-    const fromRealmUrl = testRealmURL + 'person.gts';
-    const toRealmUrl = testRealmURL + 'person-copy.gts';
+    const originSourceUrl = testRealmURL + 'person.gts';
+    const destinationSourceUrl = testRealmURL + 'person-copy.gts';
     await copySourceCommand.execute({
-      fromRealmUrl,
-      toRealmUrl,
+      originSourceUrl,
+      destinationSourceUrl,
     });
-    let personResponse = await fetch(new URL(fromRealmUrl));
+    let personResponse = await fetch(new URL(originSourceUrl));
     let personContent = await personResponse.text();
-    let personCopyResponse = await fetch(new URL(toRealmUrl));
+    let personCopyResponse = await fetch(new URL(destinationSourceUrl));
     let personCopyContent = await personCopyResponse.text();
 
     assert.strictEqual(personCopyContent, personContent);


### PR DESCRIPTION
The previous arguments of the copy source commands were `fromRealmUrl` and `toRealmUrl`. Because of this naming, the LLM tended to use realm URLs for this command, when what we actually need is the full path to the file, including the file name. In this PR, I renamed the arguments to `originSourceUrl` and `destinationSourceUrl`. I also have this [PR](https://github.com/cardstack/boxel-skills/pull/48) , to update the Boxel skills.