### PR TITLE
Clear modules table after deploying

### DIFF
--- a/packages/host/tests/unit/index-query-engine-test.ts
+++ b/packages/host/tests/unit/index-query-engine-test.ts
@@ -241,6 +241,9 @@ module('Unit | query', function (hooks) {
         return {};
       },
       registerRealm() {},
+      async clearAllModules(): Promise<void> {
+        // no-op for tests
+      },
       forRealm() {
         return this;
       },

--- a/packages/realm-server/handlers/handle-post-deployment.ts
+++ b/packages/realm-server/handlers/handle-post-deployment.ts
@@ -15,6 +15,7 @@ import {
 
 export default function handlePostDeployment({
   assetsURL,
+  definitionLookup,
   realms,
   queue,
   realmServerSecretSeed,
@@ -24,6 +25,8 @@ export default function handlePostDeployment({
       sendResponseForUnauthorizedRequest(ctxt, 'Unauthorized');
       return;
     }
+
+    await definitionLookup.clearAllModules();
 
     let boxelUiChangeCheckerResult =
       await compareCurrentBoxelUIChecksum(assetsURL);

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -1,6 +1,7 @@
 import type { RealmInfo } from '@cardstack/runtime-common';
 import type {
   DBAdapter,
+  DefinitionLookup,
   QueuePublisher,
   Realm,
   VirtualNetwork,
@@ -69,6 +70,7 @@ import { buildCreatePrerenderAuth } from './prerender/auth';
 export type CreateRoutesArgs = {
   serverURL: string;
   dbAdapter: DBAdapter;
+  definitionLookup: DefinitionLookup;
   matrixClient: MatrixClient;
   realmServerSecretSeed: string;
   grafanaSecret: string;

--- a/packages/realm-server/server.ts
+++ b/packages/realm-server/server.ts
@@ -222,6 +222,7 @@ export class RealmServer {
       .use(
         createRoutes({
           dbAdapter: this.dbAdapter,
+          definitionLookup: this.definitionLookup,
           serverURL: this.serverURL.href,
           matrixClient: this.matrixClient,
           realmServerSecretSeed: this.realmServerSecretSeed,

--- a/packages/realm-server/tests/server-endpoints/maintenance-endpoints-test.ts
+++ b/packages/realm-server/tests/server-endpoints/maintenance-endpoints-test.ts
@@ -537,6 +537,19 @@ module(`server-endpoints/${basename(__filename)}`, function () {
         );
 
         try {
+          // Seed a modules row to verify it gets cleared
+          await context.dbAdapter.execute(
+            `INSERT INTO modules (url, file_alias, definitions, deps, created_at, resolved_realm_url, cache_scope, auth_user_id)
+             VALUES ('http://example.com/test-module', 'http://example.com/test-module', '{}', '[]', ${Date.now()}, 'http://example.com/', 'public', '')`,
+          );
+          let modulesBefore = await context.dbAdapter.execute(
+            'SELECT * FROM modules',
+          );
+          assert.ok(
+            modulesBefore.length > 0,
+            'modules table has rows before deployment',
+          );
+
           let initialJobs =
             await context.dbAdapter.execute('select * from jobs');
           let initialJobCount = initialJobs.length;
@@ -554,6 +567,15 @@ module(`server-endpoints/${basename(__filename)}`, function () {
               currentChecksum: 'new-checksum-456',
             },
             'response body contains checksum comparison result',
+          );
+
+          let modulesAfter = await context.dbAdapter.execute(
+            'SELECT * FROM modules',
+          );
+          assert.strictEqual(
+            modulesAfter.length,
+            0,
+            'modules table is empty after deployment',
           );
 
           let finalJobs = await context.dbAdapter.execute('select * from jobs');
@@ -594,7 +616,7 @@ module(`server-endpoints/${basename(__filename)}`, function () {
         }
       });
 
-      test('post-deployment endpoint ignores reindex when checksums match', async function (assert: Assert) {
+      test('post-deployment endpoint clears modules cache even when checksums match', async function (assert: Assert) {
         let compareCurrentBoxelUIChecksumStub = sinon
           .stub(boxelUIChangeChecker, 'compareCurrentBoxelUIChecksum')
           .resolves({
@@ -607,6 +629,19 @@ module(`server-endpoints/${basename(__filename)}`, function () {
         );
 
         try {
+          // Seed a modules row to verify it gets cleared even without reindex
+          await context.dbAdapter.execute(
+            `INSERT INTO modules (url, file_alias, definitions, deps, created_at, resolved_realm_url, cache_scope, auth_user_id)
+             VALUES ('http://example.com/test-module', 'http://example.com/test-module', '{}', '[]', ${Date.now()}, 'http://example.com/', 'public', '')`,
+          );
+          let modulesBefore = await context.dbAdapter.execute(
+            'SELECT * FROM modules',
+          );
+          assert.ok(
+            modulesBefore.length > 0,
+            'modules table has rows before deployment',
+          );
+
           let initialJobs =
             await context.dbAdapter.execute('select * from jobs');
           let initialJobCount = initialJobs.length;
@@ -624,6 +659,15 @@ module(`server-endpoints/${basename(__filename)}`, function () {
               currentChecksum: 'same-checksum-789',
             },
             'response body contains checksum comparison result',
+          );
+
+          let modulesAfter = await context.dbAdapter.execute(
+            'SELECT * FROM modules',
+          );
+          assert.strictEqual(
+            modulesAfter.length,
+            0,
+            'modules table is empty after deployment even when checksums match',
           );
 
           let finalJobs = await context.dbAdapter.execute('select * from jobs');

--- a/packages/runtime-common/definition-lookup.ts
+++ b/packages/runtime-common/definition-lookup.ts
@@ -130,6 +130,7 @@ export interface DefinitionLookup {
   lookupDefinition(codeRef: ResolvedCodeRef): Promise<Definition>;
   invalidate(moduleURL: string): Promise<string[]>;
   clearRealmCache(realmURL: string): Promise<void>;
+  clearAllModules(): Promise<void>;
   registerRealm(realm: LocalRealm): void;
   forRealm(realm: LocalRealm): DefinitionLookup;
   getModuleCacheEntry(moduleUrl: string): Promise<ModuleCacheEntry | undefined>;
@@ -392,6 +393,10 @@ export class CachingDefinitionLookup implements DefinitionLookup {
       'WHERE',
       ...(every([['resolved_realm_url =', param(realmURL)]]) as Expression),
     ]);
+  }
+
+  async clearAllModules(): Promise<void> {
+    await this.query(['DELETE FROM', MODULES_TABLE]);
   }
 
   registerRealm(realm: LocalRealm): void {
@@ -1113,6 +1118,10 @@ class RealmScopedDefinitionLookup implements DefinitionLookup {
 
   async clearRealmCache(realmURL: string): Promise<void> {
     await this.#inner.clearRealmCache(realmURL);
+  }
+
+  async clearAllModules(): Promise<void> {
+    await this.#inner.clearAllModules();
   }
 
   registerRealm(realm: LocalRealm): void {


### PR DESCRIPTION
## Summary
- Adds `clearAllModules()` to the `DefinitionLookup` interface and both implementations (`CachingDefinitionLookup`, `RealmScopedDefinitionLookup`)
- Threads `definitionLookup` through to the routes layer via `CreateRoutesArgs`
- Calls `clearAllModules()` unconditionally in the post-deployment handler, after auth check but before the boxel-ui checksum comparison — ensuring stale module cache entries never persist across deployments
- Updates both post-deployment tests to seed a modules row and verify it is cleared, proving the clear happens regardless of whether checksums differ

## Test plan
- [x] `post-deployment endpoint triggers full reindex when checksums differ` — seeds modules row, verifies cleared after endpoint call
- [x] `post-deployment endpoint clears modules cache even when checksums match` — seeds modules row, verifies cleared even when no reindex occurs
- [x] All 4 post-deployment tests pass: `NODE_ENV=test qunit --filter "post-deployment"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)