### PR TITLE
Direct FileDef instance fetching in render-store context

### DIFF
--- a/packages/host/app/routes/render/file-extract.ts
+++ b/packages/host/app/routes/render/file-extract.ts
@@ -4,58 +4,22 @@ import { service } from '@ember/service';
 
 import { isTesting } from '@embroider/macros';
 
-import { isEqual } from 'lodash';
-
 import {
-  baseRealm,
-  baseRef,
-  CardError,
+  baseFileRef,
   formattedError,
-  identifyCard,
-  inferContentType,
-  internalKeyFor,
-  SupportedMimeType,
-  type CodeRef,
   type FileExtractResponse,
-  type FileMetaResource,
   type RenderError,
-  type ResolvedCodeRef,
 } from '@cardstack/runtime-common';
-
-import type { BaseDef } from 'https://cardstack.com/base/card-api';
 
 import { errorJsonApiToErrorEntry } from '../../lib/window-error-handler';
 import { createAuthErrorGuard } from '../../utils/auth-error-guard';
+import { FileDefAttributesExtractor } from '../../utils/file-def-attributes-extractor';
 
 import type LoaderService from '../../services/loader-service';
 import type NetworkService from '../../services/network';
 import type RealmService from '../../services/realm';
 import type { Model as RenderModel } from '../render';
 export type Model = FileExtractResponse;
-const BASE_FILE_DEF_CODE_REF: ResolvedCodeRef = {
-  module: `${baseRealm.url}file-api`,
-  name: 'FileDef',
-};
-type FileDefExport = {
-  extractAttributes: (
-    url: string,
-    getStream: () => Promise<unknown>,
-    options?: { contentHash?: string; contentSize?: number },
-  ) => Promise<any>;
-};
-type FileDefModule = Record<string, FileDefExport | undefined>;
-type FileDefConstructor = {
-  extractAttributes?: FileDefExport['extractAttributes'];
-};
-type FileDefExtractResult = {
-  status: 'ready' | 'error';
-  searchDoc: Record<string, any> | null;
-  resource?: FileMetaResource;
-  types?: string[];
-  deps: string[];
-  error?: RenderError;
-  mismatch?: true;
-};
 
 export default class RenderFileExtractRoute extends Route<Model> {
   @service declare loaderService: LoaderService;
@@ -109,7 +73,7 @@ export default class RenderFileExtractRoute extends Route<Model> {
       };
     }
 
-    let fileDefCodeRef = parsedOptions.fileDefCodeRef ?? BASE_FILE_DEF_CODE_REF;
+    let fileDefCodeRef = parsedOptions.fileDefCodeRef ?? baseFileRef;
     let contentHash: string | undefined = parsedOptions.fileContentHash;
     let contentSize: number | undefined = parsedOptions.fileContentSize;
     let extractor = new FileDefAttributesExtractor({
@@ -118,7 +82,7 @@ export default class RenderFileExtractRoute extends Route<Model> {
       authGuard: this.#authGuard,
       fileURL: id,
       fileDefCodeRef,
-      baseFileDefCodeRef: BASE_FILE_DEF_CODE_REF,
+      baseFileDefCodeRef: baseFileRef,
       contentHash,
       contentSize,
       buildError: this.#buildError.bind(this),
@@ -135,314 +99,4 @@ export default class RenderFileExtractRoute extends Route<Model> {
     let errorJSONAPI = formattedError(url, error).errors[0];
     return errorJsonApiToErrorEntry(errorJSONAPI) as RenderError;
   }
-}
-
-class FileDefAttributesExtractor {
-  #loaderService: LoaderService;
-  #network: NetworkService;
-  #authGuard?: ReturnType<typeof createAuthErrorGuard>;
-  #fileURL: string;
-  #fileDefCodeRef: ResolvedCodeRef;
-  #baseFileDefCodeRef: ResolvedCodeRef;
-  #contentHash: string | undefined;
-  #contentSize: number | undefined;
-  #buildError: (url: string, error: unknown) => RenderError;
-  #streamsPromise: Promise<
-    [
-      ReadableStream<Uint8Array> | Uint8Array,
-      ReadableStream<Uint8Array> | Uint8Array,
-    ]
-  > | null = null;
-  #fallbackBytes: Uint8Array | null = null;
-  #primaryUsed = false;
-
-  constructor({
-    loaderService,
-    network,
-    authGuard,
-    fileURL,
-    fileDefCodeRef,
-    baseFileDefCodeRef,
-    contentHash,
-    contentSize,
-    buildError,
-  }: {
-    loaderService: LoaderService;
-    network: NetworkService;
-    authGuard?: ReturnType<typeof createAuthErrorGuard>;
-    fileURL: string;
-    fileDefCodeRef: ResolvedCodeRef;
-    baseFileDefCodeRef: ResolvedCodeRef;
-    contentHash: string | undefined;
-    contentSize: number | undefined;
-    buildError: (url: string, error: unknown) => RenderError;
-  }) {
-    this.#loaderService = loaderService;
-    this.#network = network;
-    this.#authGuard = authGuard;
-    this.#fileURL = fileURL;
-    this.#fileDefCodeRef = fileDefCodeRef;
-    this.#baseFileDefCodeRef = baseFileDefCodeRef;
-    this.#contentHash = contentHash;
-    this.#contentSize = contentSize;
-    this.#buildError = buildError;
-  }
-
-  async extract(): Promise<FileDefExtractResult> {
-    let fileDefModule = await this.#loaderService.loader.import<FileDefModule>(
-      this.#fileDefCodeRef.module,
-    );
-    let FileDefKlass = fileDefModule[this.#fileDefCodeRef.name] as
-      | FileDefConstructor
-      | undefined;
-    let baseFileDefModule =
-      await this.#loaderService.loader.import<FileDefModule>(
-        this.#baseFileDefCodeRef.module,
-      );
-    let BaseFileDef = baseFileDefModule[
-      this.#baseFileDefCodeRef.name
-    ] as FileDefConstructor;
-    if (!BaseFileDef?.extractAttributes) {
-      return {
-        status: 'error',
-        searchDoc: null,
-        deps: [
-          this.#fileURL,
-          this.#fileDefCodeRef.module,
-          this.#baseFileDefCodeRef.module,
-        ],
-        error: this.#buildError(
-          this.#fileURL,
-          new Error('Base FileDef module did not export extractAttributes'),
-        ),
-      };
-    }
-
-    let deps = [this.#fileURL, this.#fileDefCodeRef.module];
-    let error: RenderError | undefined;
-    let mismatch = false;
-
-    let recordError = (err: unknown) => {
-      if (!error) {
-        error = this.#buildError(this.#fileURL, err);
-      }
-      if ((err as any)?.name === 'FileContentMismatchError') {
-        mismatch = true;
-      }
-    };
-
-    let tryExtract = async (
-      klass: FileDefConstructor,
-      missingMessage: string,
-    ) => {
-      if (!klass.extractAttributes) {
-        recordError(new Error(missingMessage));
-        return undefined;
-      }
-      try {
-        return await klass.extractAttributes(
-          this.#fileURL,
-          this.#getStreamForAttempt,
-          { contentHash: this.#contentHash, contentSize: this.#contentSize },
-        );
-      } catch (err) {
-        console.warn(
-          `[file-extract] ${(klass as any).displayName ?? (klass as any).name ?? 'unknown'}.extractAttributes failed for ${this.#fileURL}:`,
-          err,
-        );
-        recordError(err);
-        return undefined;
-      }
-    };
-
-    if (!FileDefKlass) {
-      recordError(new Error('FileDef module did not export extractAttributes'));
-    }
-
-    let chain: FileDefConstructor[] = [];
-    if (FileDefKlass) {
-      let current: FileDefConstructor | undefined = FileDefKlass;
-      while (current && current !== BaseFileDef) {
-        chain.push(current);
-        let next = Object.getPrototypeOf(current) as
-          | FileDefConstructor
-          | undefined;
-        if (!next || next === current) {
-          break;
-        }
-        current = next;
-      }
-    }
-    if (!chain.includes(BaseFileDef)) {
-      if (
-        this.#fileDefCodeRef.module !== this.#baseFileDefCodeRef.module ||
-        this.#fileDefCodeRef.name !== this.#baseFileDefCodeRef.name
-      ) {
-        deps.push(this.#baseFileDefCodeRef.module);
-      }
-      chain.push(BaseFileDef);
-    }
-
-    for (let klass of chain) {
-      let missingMessage =
-        klass === BaseFileDef
-          ? 'Base FileDef module did not export extractAttributes'
-          : 'FileDef module did not export extractAttributes';
-      let searchDoc = await tryExtract(klass, missingMessage);
-      if (searchDoc) {
-        let typeCodeRefs = getTypes(klass);
-        let types = typeCodeRefs.map((type) => internalKeyFor(type, undefined));
-        let adoptsFrom = typeCodeRefs[0] ?? this.#fileDefCodeRef;
-        return {
-          status: 'ready',
-          searchDoc,
-          resource: buildFileResource(this.#fileURL, searchDoc, adoptsFrom),
-          types,
-          deps,
-          ...(error ? { error } : {}),
-          ...(mismatch ? { mismatch: true } : {}),
-        };
-      }
-    }
-
-    return {
-      status: 'error',
-      searchDoc: null,
-      deps,
-      error:
-        error ??
-        this.#buildError(this.#fileURL, new Error('File extract failed')),
-    };
-  }
-
-  #getStreamForAttempt = async () => {
-    if (!this.#primaryUsed) {
-      this.#primaryUsed = true;
-      return this.#getPrimaryStream();
-    }
-    return this.#getRetryStream();
-  };
-
-  async #getStreams() {
-    if (!this.#streamsPromise) {
-      this.#streamsPromise = (async () => {
-        let response: Response;
-        try {
-          let request = new Request(this.#fileURL, {
-            method: 'GET',
-            headers: {
-              Accept: SupportedMimeType.CardSource,
-            },
-          });
-          if (this.#authGuard) {
-            response = await this.#authGuard.race(() =>
-              this.#network.authedFetch(request),
-            );
-          } else {
-            response = await this.#network.authedFetch(request);
-          }
-        } catch (error) {
-          console.warn('file extract fetch failed', {
-            fileURL: this.#fileURL,
-            error,
-          });
-          throw error;
-        }
-        if (!response.ok) {
-          console.warn('file extract fetch returned non-ok', {
-            fileURL: this.#fileURL,
-            status: response.status,
-          });
-          throw await CardError.fromFetchResponse(this.#fileURL, response);
-        }
-        return await this.#teeResponse(response);
-      })();
-    }
-    return this.#streamsPromise;
-  }
-
-  async #getPrimaryStream() {
-    return (await this.#getStreams())[0];
-  }
-
-  async #getFallbackStream() {
-    return (await this.#getStreams())[1];
-  }
-
-  async #getRetryStream() {
-    if (!this.#fallbackBytes) {
-      this.#fallbackBytes = await this.#streamToBytes(
-        await this.#getFallbackStream(),
-      );
-    }
-    return this.#fallbackBytes;
-  }
-
-  async #teeResponse(
-    response: Response,
-  ): Promise<
-    [
-      ReadableStream<Uint8Array> | Uint8Array,
-      ReadableStream<Uint8Array> | Uint8Array,
-    ]
-  > {
-    if (response.body && 'tee' in response.body) {
-      return response.body.tee();
-    }
-    let bytes = new Uint8Array(await response.arrayBuffer());
-    return [bytes, bytes];
-  }
-
-  async #streamToBytes(
-    stream: ReadableStream<Uint8Array> | Uint8Array,
-  ): Promise<Uint8Array> {
-    if (stream instanceof Uint8Array) {
-      return stream;
-    }
-    return new Uint8Array(await new Response(stream).arrayBuffer());
-  }
-}
-
-function getTypes(klass: FileDefConstructor): CodeRef[] {
-  let types = [];
-  let current: FileDefConstructor | undefined = klass;
-
-  while (current) {
-    let ref = identifyCard(current as unknown as typeof BaseDef);
-    if (!ref || isEqual(ref, baseRef)) {
-      break;
-    }
-    types.push(ref);
-    current = Reflect.getPrototypeOf(current) as FileDefConstructor | undefined;
-  }
-  return types;
-}
-
-function buildFileResource(
-  fileURL: string,
-  attributes: Record<string, any>,
-  adoptsFrom: CodeRef,
-): FileMetaResource {
-  let name = new URL(fileURL).pathname.split('/').pop() ?? fileURL;
-  let baseAttributes = {
-    name: attributes.name ?? name,
-    url: attributes.url ?? fileURL,
-    sourceUrl: attributes.sourceUrl ?? fileURL,
-    contentType: attributes.contentType ?? inferContentType(name),
-  };
-  let mergedAttributes: Record<string, unknown> = { ...baseAttributes };
-  for (let [key, value] of Object.entries(attributes)) {
-    if (value !== undefined && !(key in mergedAttributes)) {
-      mergedAttributes[key] = value;
-    }
-  }
-  return {
-    id: fileURL,
-    type: 'file-meta',
-    attributes: mergedAttributes,
-    meta: {
-      adoptsFrom,
-    },
-    links: { self: fileURL },
-  };
 }

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -16,6 +16,8 @@ import merge from 'lodash/merge';
 import { TrackedObject, TrackedMap } from 'tracked-built-ins';
 
 import {
+  baseFileRef,
+  CardError,
   hasExecutableExtension,
   isCardError,
   isCardInstance,
@@ -23,6 +25,7 @@ import {
   isFileMetaResource,
   isSingleCardDocument,
   isLinkableCollectionDocument,
+  resolveFileDefCodeRef,
   Deferred,
   delay,
   mergeRelationships,
@@ -45,12 +48,14 @@ import {
   type AutoSaveState,
   type CardDocument,
   type SingleCardDocument,
+  type SingleFileMetaDocument,
   type CardResourceMeta,
   type LooseSingleCardDocument,
   type LooseCardResource,
   type CardErrorJSONAPI,
   type CardErrorsJSONAPI,
   type ErrorEntry,
+  type RenderError,
   type FileMetaResource,
   type LooseLinkableResource,
   type LooseSingleResourceDocument,
@@ -73,10 +78,13 @@ import {
   type SearchDataResource,
 } from '../resources/search-data';
 
+import { FileDefAttributesExtractor } from '../utils/file-def-attributes-extractor';
 import {
   enableRenderTimerStub,
   withTimersBlocked,
 } from '../utils/render-timer-stub';
+
+import { errorJsonApiToErrorEntry } from '../lib/window-error-handler';
 
 import type { CardSaveSubscriber } from './card-service';
 import type CardService from './card-service';
@@ -1410,7 +1418,12 @@ export default class StoreService extends Service implements StoreInterface {
         throw new Error(`file-meta reads do not support local ids (${id})`);
       }
       let url = id;
-      let fileMetaDoc = await this.store.loadFileMetaDocument(url);
+      let fileMetaDoc: SingleFileMetaDocument | CardError;
+      if (this.isRenderStore && (globalThis as any).__boxelRenderContext) {
+        fileMetaDoc = await this.extractFileMetaDirectly(url);
+      } else {
+        fileMetaDoc = await this.store.loadFileMetaDocument(url);
+      }
       if (isCardError(fileMetaDoc)) {
         throw fileMetaDoc;
       }
@@ -1436,6 +1449,31 @@ export default class StoreService extends Service implements StoreInterface {
     } finally {
       this.inflightGetFileMeta.delete(id);
     }
+  }
+
+  private async extractFileMetaDirectly(
+    url: string,
+  ): Promise<SingleFileMetaDocument | CardError> {
+    let fileDefCodeRef = resolveFileDefCodeRef(new URL(url));
+    let extractor = new FileDefAttributesExtractor({
+      loaderService: this.loaderService,
+      network: this.network,
+      fileURL: url,
+      fileDefCodeRef,
+      baseFileDefCodeRef: baseFileRef,
+      contentHash: undefined,
+      contentSize: undefined,
+      buildError: (errorUrl, error) => {
+        let errorJSONAPI = formattedError(errorUrl, error).errors[0];
+        return errorJsonApiToErrorEntry(errorJSONAPI) as RenderError;
+      },
+    });
+    let result = await extractor.extract();
+    if (result.status === 'error' || !result.resource) {
+      let msg = result.error?.error?.message ?? 'File extract failed';
+      return new CardError(msg, { status: 500 });
+    }
+    return { data: result.resource };
   }
 
   // this function is used to determine if the instance will be auto-saved or

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -72,6 +72,7 @@ import type { RealmEventContent } from 'https://cardstack.com/base/matrix-event'
 
 import CardStore, { getDeps, type ReferenceCount } from '../lib/gc-card-store';
 
+import { errorJsonApiToErrorEntry } from '../lib/window-error-handler';
 import { getSearch } from '../resources/search';
 import {
   getSearchData,
@@ -83,8 +84,6 @@ import {
   enableRenderTimerStub,
   withTimersBlocked,
 } from '../utils/render-timer-stub';
-
-import { errorJsonApiToErrorEntry } from '../lib/window-error-handler';
 
 import type { CardSaveSubscriber } from './card-service';
 import type CardService from './card-service';

--- a/packages/host/app/utils/file-def-attributes-extractor.ts
+++ b/packages/host/app/utils/file-def-attributes-extractor.ts
@@ -1,0 +1,352 @@
+import {
+  baseRef,
+  CardError,
+  identifyCard,
+  inferContentType,
+  internalKeyFor,
+  SupportedMimeType,
+  type CodeRef,
+  type FileMetaResource,
+  type RenderError,
+  type ResolvedCodeRef,
+} from '@cardstack/runtime-common';
+
+import { isEqual } from 'lodash';
+
+import type { BaseDef } from 'https://cardstack.com/base/card-api';
+
+import type { createAuthErrorGuard } from './auth-error-guard';
+
+import type LoaderService from '../services/loader-service';
+import type NetworkService from '../services/network';
+
+export type FileDefExport = {
+  extractAttributes: (
+    url: string,
+    getStream: () => Promise<unknown>,
+    options?: { contentHash?: string; contentSize?: number },
+  ) => Promise<any>;
+};
+export type FileDefModule = Record<string, FileDefExport | undefined>;
+export type FileDefConstructor = {
+  extractAttributes?: FileDefExport['extractAttributes'];
+};
+export type FileDefExtractResult = {
+  status: 'ready' | 'error';
+  searchDoc: Record<string, any> | null;
+  resource?: FileMetaResource;
+  types?: string[];
+  deps: string[];
+  error?: RenderError;
+  mismatch?: true;
+};
+
+export class FileDefAttributesExtractor {
+  #loaderService: LoaderService;
+  #network: NetworkService;
+  #authGuard?: ReturnType<typeof createAuthErrorGuard>;
+  #fileURL: string;
+  #fileDefCodeRef: ResolvedCodeRef;
+  #baseFileDefCodeRef: ResolvedCodeRef;
+  #contentHash: string | undefined;
+  #contentSize: number | undefined;
+  #buildError: (url: string, error: unknown) => RenderError;
+  #streamsPromise: Promise<
+    [
+      ReadableStream<Uint8Array> | Uint8Array,
+      ReadableStream<Uint8Array> | Uint8Array,
+    ]
+  > | null = null;
+  #fallbackBytes: Uint8Array | null = null;
+  #primaryUsed = false;
+
+  constructor({
+    loaderService,
+    network,
+    authGuard,
+    fileURL,
+    fileDefCodeRef,
+    baseFileDefCodeRef,
+    contentHash,
+    contentSize,
+    buildError,
+  }: {
+    loaderService: LoaderService;
+    network: NetworkService;
+    authGuard?: ReturnType<typeof createAuthErrorGuard>;
+    fileURL: string;
+    fileDefCodeRef: ResolvedCodeRef;
+    baseFileDefCodeRef: ResolvedCodeRef;
+    contentHash: string | undefined;
+    contentSize: number | undefined;
+    buildError: (url: string, error: unknown) => RenderError;
+  }) {
+    this.#loaderService = loaderService;
+    this.#network = network;
+    this.#authGuard = authGuard;
+    this.#fileURL = fileURL;
+    this.#fileDefCodeRef = fileDefCodeRef;
+    this.#baseFileDefCodeRef = baseFileDefCodeRef;
+    this.#contentHash = contentHash;
+    this.#contentSize = contentSize;
+    this.#buildError = buildError;
+  }
+
+  async extract(): Promise<FileDefExtractResult> {
+    let fileDefModule = await this.#loaderService.loader.import<FileDefModule>(
+      this.#fileDefCodeRef.module,
+    );
+    let FileDefKlass = fileDefModule[this.#fileDefCodeRef.name] as
+      | FileDefConstructor
+      | undefined;
+    let baseFileDefModule =
+      await this.#loaderService.loader.import<FileDefModule>(
+        this.#baseFileDefCodeRef.module,
+      );
+    let BaseFileDef = baseFileDefModule[
+      this.#baseFileDefCodeRef.name
+    ] as FileDefConstructor;
+    if (!BaseFileDef?.extractAttributes) {
+      return {
+        status: 'error',
+        searchDoc: null,
+        deps: [
+          this.#fileURL,
+          this.#fileDefCodeRef.module,
+          this.#baseFileDefCodeRef.module,
+        ],
+        error: this.#buildError(
+          this.#fileURL,
+          new Error('Base FileDef module did not export extractAttributes'),
+        ),
+      };
+    }
+
+    let deps = [this.#fileURL, this.#fileDefCodeRef.module];
+    let error: RenderError | undefined;
+    let mismatch = false;
+
+    let recordError = (err: unknown) => {
+      if (!error) {
+        error = this.#buildError(this.#fileURL, err);
+      }
+      if ((err as any)?.name === 'FileContentMismatchError') {
+        mismatch = true;
+      }
+    };
+
+    let tryExtract = async (
+      klass: FileDefConstructor,
+      missingMessage: string,
+    ) => {
+      if (!klass.extractAttributes) {
+        recordError(new Error(missingMessage));
+        return undefined;
+      }
+      try {
+        return await klass.extractAttributes(
+          this.#fileURL,
+          this.#getStreamForAttempt,
+          { contentHash: this.#contentHash, contentSize: this.#contentSize },
+        );
+      } catch (err) {
+        console.warn(
+          `[file-extract] ${(klass as any).displayName ?? (klass as any).name ?? 'unknown'}.extractAttributes failed for ${this.#fileURL}:`,
+          err,
+        );
+        recordError(err);
+        return undefined;
+      }
+    };
+
+    if (!FileDefKlass) {
+      recordError(new Error('FileDef module did not export extractAttributes'));
+    }
+
+    let chain: FileDefConstructor[] = [];
+    if (FileDefKlass) {
+      let current: FileDefConstructor | undefined = FileDefKlass;
+      while (current && current !== BaseFileDef) {
+        chain.push(current);
+        let next = Object.getPrototypeOf(current) as
+          | FileDefConstructor
+          | undefined;
+        if (!next || next === current) {
+          break;
+        }
+        current = next;
+      }
+    }
+    if (!chain.includes(BaseFileDef)) {
+      if (
+        this.#fileDefCodeRef.module !== this.#baseFileDefCodeRef.module ||
+        this.#fileDefCodeRef.name !== this.#baseFileDefCodeRef.name
+      ) {
+        deps.push(this.#baseFileDefCodeRef.module);
+      }
+      chain.push(BaseFileDef);
+    }
+
+    for (let klass of chain) {
+      let missingMessage =
+        klass === BaseFileDef
+          ? 'Base FileDef module did not export extractAttributes'
+          : 'FileDef module did not export extractAttributes';
+      let searchDoc = await tryExtract(klass, missingMessage);
+      if (searchDoc) {
+        let typeCodeRefs = getTypes(klass);
+        let types = typeCodeRefs.map((type) => internalKeyFor(type, undefined));
+        let adoptsFrom = typeCodeRefs[0] ?? this.#fileDefCodeRef;
+        return {
+          status: 'ready',
+          searchDoc,
+          resource: buildFileResource(this.#fileURL, searchDoc, adoptsFrom),
+          types,
+          deps,
+          ...(error ? { error } : {}),
+          ...(mismatch ? { mismatch: true } : {}),
+        };
+      }
+    }
+
+    return {
+      status: 'error',
+      searchDoc: null,
+      deps,
+      error:
+        error ??
+        this.#buildError(this.#fileURL, new Error('File extract failed')),
+    };
+  }
+
+  #getStreamForAttempt = async () => {
+    if (!this.#primaryUsed) {
+      this.#primaryUsed = true;
+      return this.#getPrimaryStream();
+    }
+    return this.#getRetryStream();
+  };
+
+  async #getStreams() {
+    if (!this.#streamsPromise) {
+      this.#streamsPromise = (async () => {
+        let response: Response;
+        try {
+          let request = new Request(this.#fileURL, {
+            method: 'GET',
+            headers: {
+              Accept: SupportedMimeType.CardSource,
+            },
+          });
+          if (this.#authGuard) {
+            response = await this.#authGuard.race(() =>
+              this.#network.authedFetch(request),
+            );
+          } else {
+            response = await this.#network.authedFetch(request);
+          }
+        } catch (error) {
+          console.warn('file extract fetch failed', {
+            fileURL: this.#fileURL,
+            error,
+          });
+          throw error;
+        }
+        if (!response.ok) {
+          console.warn('file extract fetch returned non-ok', {
+            fileURL: this.#fileURL,
+            status: response.status,
+          });
+          throw await CardError.fromFetchResponse(this.#fileURL, response);
+        }
+        return await this.#teeResponse(response);
+      })();
+    }
+    return this.#streamsPromise;
+  }
+
+  async #getPrimaryStream() {
+    return (await this.#getStreams())[0];
+  }
+
+  async #getFallbackStream() {
+    return (await this.#getStreams())[1];
+  }
+
+  async #getRetryStream() {
+    if (!this.#fallbackBytes) {
+      this.#fallbackBytes = await this.#streamToBytes(
+        await this.#getFallbackStream(),
+      );
+    }
+    return this.#fallbackBytes;
+  }
+
+  async #teeResponse(
+    response: Response,
+  ): Promise<
+    [
+      ReadableStream<Uint8Array> | Uint8Array,
+      ReadableStream<Uint8Array> | Uint8Array,
+    ]
+  > {
+    if (response.body && 'tee' in response.body) {
+      return response.body.tee();
+    }
+    let bytes = new Uint8Array(await response.arrayBuffer());
+    return [bytes, bytes];
+  }
+
+  async #streamToBytes(
+    stream: ReadableStream<Uint8Array> | Uint8Array,
+  ): Promise<Uint8Array> {
+    if (stream instanceof Uint8Array) {
+      return stream;
+    }
+    return new Uint8Array(await new Response(stream).arrayBuffer());
+  }
+}
+
+export function getTypes(klass: FileDefConstructor): CodeRef[] {
+  let types = [];
+  let current: FileDefConstructor | undefined = klass;
+
+  while (current) {
+    let ref = identifyCard(current as unknown as typeof BaseDef);
+    if (!ref || isEqual(ref, baseRef)) {
+      break;
+    }
+    types.push(ref);
+    current = Reflect.getPrototypeOf(current) as FileDefConstructor | undefined;
+  }
+  return types;
+}
+
+export function buildFileResource(
+  fileURL: string,
+  attributes: Record<string, any>,
+  adoptsFrom: CodeRef,
+): FileMetaResource {
+  let name = new URL(fileURL).pathname.split('/').pop() ?? fileURL;
+  let baseAttributes = {
+    name: attributes.name ?? name,
+    url: attributes.url ?? fileURL,
+    sourceUrl: attributes.sourceUrl ?? fileURL,
+    contentType: attributes.contentType ?? inferContentType(name),
+  };
+  let mergedAttributes: Record<string, unknown> = { ...baseAttributes };
+  for (let [key, value] of Object.entries(attributes)) {
+    if (value !== undefined && !(key in mergedAttributes)) {
+      mergedAttributes[key] = value;
+    }
+  }
+  return {
+    id: fileURL,
+    type: 'file-meta',
+    attributes: mergedAttributes,
+    meta: {
+      adoptsFrom,
+    },
+    links: { self: fileURL },
+  };
+}

--- a/packages/host/app/utils/file-def-attributes-extractor.ts
+++ b/packages/host/app/utils/file-def-attributes-extractor.ts
@@ -1,3 +1,5 @@
+import { isEqual } from 'lodash';
+
 import {
   baseRef,
   CardError,
@@ -10,8 +12,6 @@ import {
   type RenderError,
   type ResolvedCodeRef,
 } from '@cardstack/runtime-common';
-
-import { isEqual } from 'lodash';
 
 import type { BaseDef } from 'https://cardstack.com/base/card-api';
 

--- a/packages/realm-server/tests/card-endpoints-test.ts
+++ b/packages/realm-server/tests/card-endpoints-test.ts
@@ -4,7 +4,7 @@ import supertest from 'supertest';
 import { join, basename } from 'path';
 import type { Server } from 'http';
 import type { DirResult } from 'tmp';
-import { existsSync, readJSONSync, statSync } from 'fs-extra';
+import { existsSync, readJSONSync, statSync, writeFileSync } from 'fs-extra';
 import type {
   Realm,
   Relationship,
@@ -268,12 +268,25 @@ module(basename(__filename), function () {
         });
 
         test('includes FileDef resources for file links in included payload', async function (assert) {
-          let { testRealm: realm, request } = getRealmSetup();
+          let { testRealm: realm, request, dir: testDir } = getRealmSetup();
 
-          let writes = new Map<string, string | Uint8Array>([
-            [
-              'gallery.gts',
-              `
+          // Write image files directly to the filesystem so they are on disk
+          // but NOT yet in the index. This exercises the render-store's
+          // extractFileMetaDirectly path: when the card is prerendered, the
+          // images haven't been indexed yet, so getFileMetaInstance must fetch
+          // and extract attributes directly from the raw file bytes.
+          let realmDir = join(testDir.name, 'realm_server_1', 'test');
+          let pngBytes = makeMinimalPng();
+          writeFileSync(join(realmDir, 'hero.png'), pngBytes);
+          writeFileSync(join(realmDir, 'first.png'), pngBytes);
+          writeFileSync(join(realmDir, 'second.png'), pngBytes);
+
+          // Write module + card instance — card is indexed before images
+          await realm.writeMany(
+            new Map<string, string>([
+              [
+                'gallery.gts',
+                `
                 import { CardDef, field, linksTo, linksToMany } from "https://cardstack.com/base/card-api";
                 import { FileDef } from "https://cardstack.com/base/file-api";
 
@@ -282,44 +295,49 @@ module(basename(__filename), function () {
                   @field attachments = linksToMany(FileDef);
                 }
               `,
-            ],
-            [
-              'gallery.json',
-              JSON.stringify({
-                data: {
-                  attributes: {},
-                  relationships: {
-                    hero: {
-                      links: {
-                        self: './hero.png',
+              ],
+              [
+                'gallery.json',
+                JSON.stringify({
+                  data: {
+                    attributes: {},
+                    relationships: {
+                      hero: {
+                        links: {
+                          self: './hero.png',
+                        },
+                      },
+                      'attachments.0': {
+                        links: {
+                          self: './first.png',
+                        },
+                      },
+                      'attachments.1': {
+                        links: {
+                          self: './second.png',
+                        },
                       },
                     },
-                    'attachments.0': {
-                      links: {
-                        self: './first.png',
-                      },
-                    },
-                    'attachments.1': {
-                      links: {
-                        self: './second.png',
+                    meta: {
+                      adoptsFrom: {
+                        module: './gallery.gts',
+                        name: 'Gallery',
                       },
                     },
                   },
-                  meta: {
-                    adoptsFrom: {
-                      module: './gallery.gts',
-                      name: 'Gallery',
-                    },
-                  },
-                },
-              }),
-            ],
-            ['hero.png', makeMinimalPng()],
-            ['first.png', makeMinimalPng()],
-            ['second.png', makeMinimalPng()],
-          ]);
+                }),
+              ],
+            ]),
+          );
 
-          await realm.writeMany(writes);
+          // Now index the image files so they appear in loadLinks results
+          await realm.writeMany(
+            new Map<string, Uint8Array>([
+              ['hero.png', pngBytes],
+              ['first.png', pngBytes],
+              ['second.png', pngBytes],
+            ]),
+          );
 
           let response = await request
             .get('/gallery')

--- a/packages/runtime-common/file-def-code-ref.ts
+++ b/packages/runtime-common/file-def-code-ref.ts
@@ -1,0 +1,62 @@
+import { baseRealm, baseFileRef } from './constants';
+import type { ResolvedCodeRef } from './code-ref';
+
+const FILEDEF_CODE_REF_BY_EXTENSION: Record<string, ResolvedCodeRef> = {
+  // TODO: Replace with realm metadata configuration.
+  '.markdown': {
+    module: `${baseRealm.url}markdown-file-def`,
+    name: 'MarkdownDef',
+  },
+  '.md': {
+    module: `${baseRealm.url}markdown-file-def`,
+    name: 'MarkdownDef',
+  },
+  '.png': {
+    module: `${baseRealm.url}png-image-def`,
+    name: 'PngDef',
+  },
+  '.jpg': {
+    module: `${baseRealm.url}jpg-image-def`,
+    name: 'JpgDef',
+  },
+  '.jpeg': {
+    module: `${baseRealm.url}jpg-image-def`,
+    name: 'JpgDef',
+  },
+  '.svg': {
+    module: `${baseRealm.url}svg-image-def`,
+    name: 'SvgDef',
+  },
+  '.gif': {
+    module: `${baseRealm.url}gif-image-def`,
+    name: 'GifDef',
+  },
+  '.webp': {
+    module: `${baseRealm.url}webp-image-def`,
+    name: 'WebpDef',
+  },
+  '.avif': {
+    module: `${baseRealm.url}avif-image-def`,
+    name: 'AvifDef',
+  },
+  '.mismatch': { module: './filedef-mismatch', name: 'FileDef' },
+};
+
+export function resolveFileDefCodeRef(fileURL: URL): ResolvedCodeRef {
+  let name = fileURL.pathname.split('/').pop() ?? '';
+  let dot = name.lastIndexOf('.');
+  let extension = dot === -1 ? '' : name.slice(dot).toLowerCase();
+  let mapping = extension
+    ? FILEDEF_CODE_REF_BY_EXTENSION[extension]
+    : undefined;
+  if (!mapping) {
+    return baseFileRef;
+  }
+  if (mapping.module.includes('://')) {
+    return mapping;
+  }
+  return {
+    ...mapping,
+    module: new URL(mapping.module, fileURL).href,
+  };
+}

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -248,6 +248,7 @@ export * from './url';
 export * from './render-route-options';
 export * from './publishability';
 export * from './pr-manifest';
+export * from './file-def-code-ref';
 
 export const executableExtensions = ['.js', '.gjs', '.ts', '.gts'];
 export { createResponse } from './create-response';


### PR DESCRIPTION
## Summary

- **Fetch FileDef instances directly** in the render-store context when a card references files that haven't been indexed yet — bypasses the index, fetches raw file bytes from the realm server, and runs `extractAttributes` on the fly to produce full subclass attributes (width/height for images, title/content for markdown)
- **Extract shared utilities**: `resolveFileDefCodeRef` to `runtime-common/file-def-code-ref.ts` and `FileDefAttributesExtractor` to `host/app/utils/file-def-attributes-extractor.ts` for reuse across the index runner, file-extract route, and store service

## Test plan

- [x] Tweaked existing `'includes FileDef resources for file links in included payload'` test to write images to disk before indexing the card, exercising the `extractFileMetaDirectly` path where images are on disk but not yet indexed during card prerendering
- [x] Verify existing prerendering tests pass (file-extract route still works with extracted `FileDefAttributesExtractor`)
- [x] Verify indexing tests pass (no regressions from `resolveFileDefCodeRef` extraction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)