### PR TITLE
Add FileDef support for prerendered search 

### DIFF
--- a/packages/host/app/components/card-prerender.gts
+++ b/packages/host/app/components/card-prerender.gts
@@ -429,6 +429,7 @@ export default class CardPrerender extends Component {
     async ({
       url,
       fileData,
+      types,
       renderOptions,
     }: FileRenderArgs): Promise<FileRenderResponse> => {
       this.#nonce++;
@@ -456,16 +457,47 @@ export default class CardPrerender extends Component {
 
       let error: RenderError | undefined;
       let isolatedHTML: string | null = null;
+      let headHTML: string | null = null;
+      let atomHTML: string | null = null;
+      let iconHTML: string | null = null;
+      let embeddedHTML: Record<string, string> | null = null;
+      let fittedHTML: Record<string, string> | null = null;
 
-      // Render isolated HTML only – additional formats (head, atom, icon,
-      // fitted, embedded) are deferred to keep boot-indexing fast.
       try {
+        let subsequentRenderOptions = omitOneTimeOptions(initialRenderOptions);
         isolatedHTML = await this.renderHTML.perform(
           url,
           'isolated',
           0,
           initialRenderOptions,
         );
+        headHTML = await this.renderHTML.perform(
+          url,
+          'head',
+          0,
+          subsequentRenderOptions,
+        );
+        atomHTML = await this.renderHTML.perform(
+          url,
+          'atom',
+          0,
+          subsequentRenderOptions,
+        );
+        iconHTML = await this.renderIcon.perform(url, subsequentRenderOptions);
+        if (types?.length) {
+          embeddedHTML = await this.renderAncestors.perform(
+            url,
+            'embedded',
+            types,
+            subsequentRenderOptions,
+          );
+          fittedHTML = await this.renderAncestors.perform(
+            url,
+            'fitted',
+            types,
+            subsequentRenderOptions,
+          );
+        }
       } catch (e: any) {
         try {
           error = { ...JSON.parse(e.message), type: 'file-error' };
@@ -488,11 +520,11 @@ export default class CardPrerender extends Component {
 
       return {
         isolatedHTML,
-        headHTML: null,
-        atomHTML: null,
-        embeddedHTML: null,
-        fittedHTML: null,
-        iconHTML: null,
+        headHTML,
+        atomHTML,
+        embeddedHTML,
+        fittedHTML,
+        iconHTML,
         ...(error ? { error } : {}),
       };
     },

--- a/packages/host/tests/integration/components/prerendered-card-search-test.gts
+++ b/packages/host/tests/integration/components/prerendered-card-search-test.gts
@@ -140,6 +140,65 @@ module(`Integration | prerendered-card-search`, function (hooks) {
     }
     `;
 
+    const FileDefMismatchGtsImpl = `
+    import { byteStreamToUint8Array } from '@cardstack/runtime-common';
+    import { Component, BaseDefComponent, field, contains, StringField } from 'https://cardstack.com/base/card-api';
+    import { FileDef as BaseFileDef, type ByteStream } from 'https://cardstack.com/base/file-api';
+
+    class Isolated extends Component<typeof FileDef> {
+      <template>
+        <article data-test-prerendered-filedef-isolated>{{@model.content}}</article>
+      </template>
+    }
+
+    class Embedded extends Component<typeof FileDef> {
+      <template>
+        <article data-test-prerendered-filedef-embedded>{{@model.content}}</article>
+      </template>
+    }
+
+    class Fitted extends Component<typeof FileDef> {
+      <template>
+        <article data-test-prerendered-filedef-fitted>{{@model.content}}</article>
+      </template>
+    }
+
+    class Atom extends Component<typeof FileDef> {
+      <template>
+        <span data-test-prerendered-filedef-atom>{{@model.content}}</span>
+      </template>
+    }
+
+    class Head extends Component<typeof FileDef> {
+      <template>
+        <title>{{@model.content}}</title>
+      </template>
+    }
+
+    export class FileDef extends BaseFileDef {
+      @field content = contains(StringField);
+
+      static isolated: BaseDefComponent = Isolated;
+      static embedded: BaseDefComponent = Embedded;
+      static fitted: BaseDefComponent = Fitted;
+      static atom: BaseDefComponent = Atom;
+      static head: BaseDefComponent = Head;
+
+      static async extractAttributes(
+        url: string,
+        getStream: () => Promise<ByteStream>,
+        options: { contentHash?: string; contentSize?: number } = {},
+      ) {
+        let base = await super.extractAttributes(url, getStream, options);
+        let bytes = await byteStreamToUint8Array(await getStream());
+        return {
+          ...base,
+          content: new TextDecoder().decode(bytes).trim(),
+        };
+      }
+    }
+    `;
+
     const sampleCards: CardDocFiles = {
       'card-1.json': {
         data: {
@@ -325,9 +384,11 @@ module(`Integration | prerendered-card-search`, function (hooks) {
         'article.gts': { Article },
         'blog-post.gts': { BlogPost },
         'book.gts': BookGtsImpl,
+        'files/filedef-mismatch.gts': FileDefMismatchGtsImpl,
         'person.gts': { PersonField },
         'post.gts': { Post },
         'publisher.gts': { Publisher },
+        'files/prerendered-file.mismatch': 'Hello prerendered FileDef content',
         ...sampleCards,
       },
     }));
@@ -393,6 +454,53 @@ module(`Integration | prerendered-card-search`, function (hooks) {
     assert
       .dom('[data-test-meta-page-total="2"]')
       .exists('meta.page.total is correct');
+  });
+
+  test(`can search for file-meta and render prerendered FileDef html`, async function (assert) {
+    let query: Query = {
+      filter: {
+        on: {
+          module: `${baseRealm.url}file-api`,
+          name: 'FileDef',
+        },
+        eq: {
+          url: `${testRealmURL}files/prerendered-file.mismatch`,
+        },
+      },
+    };
+    let realms = [testRealmURL];
+
+    await render(
+      <template>
+        <PrerenderedCardSearch
+          @query={{query}}
+          @format='embedded'
+          @realms={{realms}}
+        >
+          <:loading>
+            Loading...
+          </:loading>
+          <:response as |cards|>
+            {{#each cards as |card|}}
+              <card.component />
+            {{/each}}
+          </:response>
+          <:meta as |meta|>
+            <div data-test-meta-page-total={{meta.page.total}}></div>
+          </:meta>
+        </PrerenderedCardSearch>
+      </template>,
+    );
+
+    await waitFor('[data-test-meta-page-total="1"]');
+    let hasPrerenderedFileText =
+      document.body.textContent?.includes(
+        'Hello prerendered FileDef content',
+      ) === true;
+    assert.true(hasPrerenderedFileText, 'renders prerendered FileDef content');
+    assert
+      .dom('[data-test-meta-page-total="1"]')
+      .exists('meta.page.total is correct for file-meta prerendered search');
   });
 
   test('applies cardComponentModifier from card context to prerendered results', async function (this: RenderingTestContext, assert) {

--- a/packages/realm-server/prerender/render-runner.ts
+++ b/packages/realm-server/prerender/render-runner.ts
@@ -695,7 +695,7 @@ export class RenderRunner {
     url,
     auth,
     fileData,
-    types: _types,
+    types,
     opts,
     renderOptions,
   }: {
@@ -749,6 +749,7 @@ export class RenderRunner {
 
       let renderStart = Date.now();
       let error: RenderError | undefined;
+      let shortCircuit = false;
       let options: RenderRouteOptions = {
         ...(renderOptions ?? {}),
         fileRender: true,
@@ -769,11 +770,8 @@ export class RenderRunner {
         `file render: visit ${url} at: ${this.#boxelHostURL}/render/${encodeURIComponent(url)}/${this.#nonce}/${optionsSegment}/html/isolated/0`,
       );
 
-      // Render isolated HTML only – additional formats (head, atom, icon,
-      // fitted, embedded) are deferred to keep boot-indexing fast.  Each
-      // Puppeteer transition costs 2-3 s, so rendering all formats for every
-      // file would make boot-time O(files × formats × 3 s) which easily
-      // exceeds test timeouts.
+      // We render isolated first since it eagerly exercises linked field paths
+      // and surfaces fundamental render errors early.
       let result = await withTimeout(
         page,
         async () => {
@@ -801,6 +799,10 @@ export class RenderRunner {
         );
         if (evicted) {
           poolInfo.evicted = true;
+          shortCircuit = true;
+        }
+        if (this.#isAuthError(error)) {
+          shortCircuit = true;
         }
       } else {
         let capture = result as RenderCapture;
@@ -819,18 +821,139 @@ export class RenderRunner {
           );
           if (evicted) {
             poolInfo.evicted = true;
+            shortCircuit = true;
+          }
+          if (this.#isAuthError(error)) {
+            shortCircuit = true;
+          }
+        }
+      }
+
+      if (shortCircuit) {
+        let response: FileRenderResponse = {
+          ...(error ? { error } : {}),
+          iconHTML: null,
+          isolatedHTML,
+          headHTML: null,
+          atomHTML: null,
+          embeddedHTML: null,
+          fittedHTML: null,
+        };
+        response.error = this.#mergeConsoleErrors(pageId, response.error);
+        return {
+          response,
+          timings: { launchMs, renderMs: Date.now() - renderStart },
+          pool: poolInfo,
+        };
+      }
+
+      let headHTML: string | null = null,
+        atomHTML: string | null = null,
+        iconHTML: string | null = null,
+        embeddedHTML: Record<string, string> | null = null,
+        fittedHTML: Record<string, string> | null = null;
+
+      if (!shortCircuit) {
+        let headHTMLResult = await this.#step(realm, 'file head render', () =>
+          withTimeout(
+            page,
+            () => renderHTML(page, 'head', 0, captureOptions),
+            opts?.timeoutMs,
+          ),
+        );
+        if (headHTMLResult.ok) {
+          headHTML = headHTMLResult.value as string;
+        } else {
+          error = error ?? headHTMLResult.error;
+          markTimeout(headHTMLResult.error);
+          if (headHTMLResult.evicted) {
+            poolInfo.evicted = true;
+            shortCircuit = true;
+          }
+          if (this.#isAuthError(error)) {
+            shortCircuit = true;
+          }
+        }
+      }
+
+      if (!shortCircuit) {
+        // Render remaining formats sequentially and stop if page becomes unusable.
+        let steps: Array<{
+          name: string;
+          cb: () => Promise<string | Record<string, string> | RenderError>;
+          assign: (value: string | Record<string, string>) => void;
+        }> = [];
+
+        if (types.length > 0) {
+          steps.push(
+            {
+              name: 'file fitted render',
+              cb: () => renderAncestors(page, 'fitted', types, captureOptions),
+              assign: (v: string | Record<string, string>) => {
+                fittedHTML = v as Record<string, string>;
+              },
+            },
+            {
+              name: 'file embedded render',
+              cb: () =>
+                renderAncestors(page, 'embedded', types, captureOptions),
+              assign: (v: string | Record<string, string>) => {
+                embeddedHTML = v as Record<string, string>;
+              },
+            },
+          );
+        }
+
+        steps.push(
+          {
+            name: 'file atom render',
+            cb: () => renderHTML(page, 'atom', 0, captureOptions),
+            assign: (v: string | Record<string, string>) => {
+              atomHTML = v as string;
+            },
+          },
+          {
+            name: 'file icon render',
+            cb: () => renderIcon(page, captureOptions),
+            assign: (v: string | Record<string, string>) => {
+              iconHTML = v as string;
+            },
+          },
+        );
+
+        for (let step of steps) {
+          if (shortCircuit) {
+            break;
+          }
+          let res = await this.#step(realm, step.name, () =>
+            withTimeout(page, step.cb, opts?.timeoutMs),
+          );
+          if (res.ok) {
+            step.assign(res.value);
+          } else {
+            error = error ?? res.error;
+            markTimeout(res.error);
+            if (res.evicted) {
+              poolInfo.evicted = true;
+              shortCircuit = true;
+              break;
+            }
+            if (this.#isAuthError(error)) {
+              shortCircuit = true;
+              break;
+            }
           }
         }
       }
 
       let response: FileRenderResponse = {
         ...(error ? { error } : {}),
-        iconHTML: null,
+        iconHTML,
         isolatedHTML,
-        headHTML: null,
-        atomHTML: null,
-        embeddedHTML: null,
-        fittedHTML: null,
+        headHTML,
+        atomHTML,
+        embeddedHTML,
+        fittedHTML,
       };
       response.error = this.#mergeConsoleErrors(pageId, response.error);
       return {

--- a/packages/realm-server/tests/search-prerendered-test.ts
+++ b/packages/realm-server/tests/search-prerendered-test.ts
@@ -3,7 +3,7 @@ import type { Test, SuperTest } from 'supertest';
 import { basename } from 'path';
 import type { Realm } from '@cardstack/runtime-common';
 import { setupPermissionedRealm, createJWT } from './helpers';
-import { PRERENDERED_HTML_FORMATS } from '@cardstack/runtime-common';
+import { PRERENDERED_HTML_FORMATS, baseRealm } from '@cardstack/runtime-common';
 import type { Query } from '@cardstack/runtime-common/query';
 import '@cardstack/runtime-common/helpers/code-equality-assertion';
 
@@ -74,6 +74,7 @@ module(basename(__filename), function () {
                   },
                 },
               },
+              'hello.md': '# Hello from FileDef content',
             },
             onRealmSetup,
           });
@@ -147,6 +148,48 @@ module(basename(__filename), function () {
               cardDefModuleDependencies,
             );
 
+            assert.strictEqual(
+              json.meta.page.total,
+              1,
+              'total count is correct',
+            );
+          });
+
+          test('returns prerendered file-meta results for FileDef queries', async function (assert) {
+            let query: Query & { prerenderedHtmlFormat: string } = {
+              filter: {
+                on: {
+                  module: `${baseRealm.url}file-api`,
+                  name: 'FileDef',
+                },
+                eq: {
+                  url: `${realmHref}hello.md`,
+                },
+              },
+              prerenderedHtmlFormat: 'embedded',
+            };
+            let response = await request
+              .post(searchPath)
+              .set('Accept', 'application/vnd.card+json')
+              .set('X-HTTP-Method-Override', 'QUERY')
+              .send(query);
+
+            assert.strictEqual(response.status, 200, 'HTTP 200 status');
+            let json = response.body;
+
+            assert.strictEqual(
+              json.data.length,
+              1,
+              'one file-meta entry is returned in the search results',
+            );
+            assert.strictEqual(json.data[0].type, 'prerendered-card');
+            assert.strictEqual(json.data[0].id, `${realmHref}hello.md`);
+            assert.true(
+              json.data[0].attributes.html.includes(
+                'Hello from FileDef content',
+              ),
+              `embedded html is from the prerendered FileDef: ${json.data[0].attributes.html}`,
+            );
             assert.strictEqual(
               json.meta.page.total,
               1,

--- a/packages/realm-server/tests/search-prerendered-test.ts
+++ b/packages/realm-server/tests/search-prerendered-test.ts
@@ -218,7 +218,9 @@ module(basename(__filename), function () {
                 `${format} html includes expected snippet: ${json.data[0].attributes.html}`,
               );
               assert.true(
-                json.data[0].attributes.html.includes('Hello from FileDef content'),
+                json.data[0].attributes.html.includes(
+                  'Hello from FileDef content',
+                ),
                 `${format} html includes file content/title`,
               );
               assert.strictEqual(

--- a/packages/realm-server/tests/search-prerendered-test.ts
+++ b/packages/realm-server/tests/search-prerendered-test.ts
@@ -156,7 +156,7 @@ module(basename(__filename), function () {
           });
 
           test('returns prerendered file-meta results for FileDef queries', async function (assert) {
-            let query: Query & { prerenderedHtmlFormat: string } = {
+            let queryBase: Query = {
               filter: {
                 on: {
                   module: `${baseRealm.url}file-api`,
@@ -166,35 +166,67 @@ module(basename(__filename), function () {
                   url: `${realmHref}hello.md`,
                 },
               },
-              prerenderedHtmlFormat: 'embedded',
             };
-            let response = await request
-              .post(searchPath)
-              .set('Accept', 'application/vnd.card+json')
-              .set('X-HTTP-Method-Override', 'QUERY')
-              .send(query);
+            let formatsAndExpected: Array<{
+              format: 'embedded' | 'fitted' | 'atom' | 'head';
+              expectedSnippet: string;
+            }> = [
+              {
+                format: 'embedded',
+                expectedSnippet: 'data-test-markdown-embedded',
+              },
+              {
+                format: 'fitted',
+                expectedSnippet: 'data-test-markdown-fitted',
+              },
+              {
+                format: 'atom',
+                expectedSnippet: 'data-test-markdown-atom',
+              },
+              {
+                format: 'head',
+                expectedSnippet: 'data-test-card-head-title',
+              },
+            ];
 
-            assert.strictEqual(response.status, 200, 'HTTP 200 status');
-            let json = response.body;
+            for (let { format, expectedSnippet } of formatsAndExpected) {
+              let response = await request
+                .post(searchPath)
+                .set('Accept', 'application/vnd.card+json')
+                .set('X-HTTP-Method-Override', 'QUERY')
+                .send({
+                  ...queryBase,
+                  prerenderedHtmlFormat: format,
+                } as Query & { prerenderedHtmlFormat: string });
 
-            assert.strictEqual(
-              json.data.length,
-              1,
-              'one file-meta entry is returned in the search results',
-            );
-            assert.strictEqual(json.data[0].type, 'prerendered-card');
-            assert.strictEqual(json.data[0].id, `${realmHref}hello.md`);
-            assert.true(
-              json.data[0].attributes.html.includes(
-                'Hello from FileDef content',
-              ),
-              `embedded html is from the prerendered FileDef: ${json.data[0].attributes.html}`,
-            );
-            assert.strictEqual(
-              json.meta.page.total,
-              1,
-              'total count is correct',
-            );
+              assert.strictEqual(
+                response.status,
+                200,
+                `HTTP 200 status for ${format}`,
+              );
+              let json = response.body;
+
+              assert.strictEqual(
+                json.data.length,
+                1,
+                `one file-meta entry is returned in ${format} results`,
+              );
+              assert.strictEqual(json.data[0].type, 'prerendered-card');
+              assert.strictEqual(json.data[0].id, `${realmHref}hello.md`);
+              assert.true(
+                json.data[0].attributes.html.includes(expectedSnippet),
+                `${format} html includes expected snippet: ${json.data[0].attributes.html}`,
+              );
+              assert.true(
+                json.data[0].attributes.html.includes('Hello from FileDef content'),
+                `${format} html includes file content/title`,
+              );
+              assert.strictEqual(
+                json.meta.page.total,
+                1,
+                `total count is correct for ${format}`,
+              );
+            }
           });
         },
       );

--- a/packages/runtime-common/index-query-engine.ts
+++ b/packages/runtime-common/index-query-engine.ts
@@ -76,6 +76,11 @@ export interface IndexedFile {
   types: string[] | null;
   displayNames: string[] | null;
   deps: string[] | null;
+  isolatedHtml: string | null;
+  headHtml: string | null;
+  embeddedHtml: { [refURL: string]: string } | null;
+  fittedHtml: { [refURL: string]: string } | null;
+  atomHtml: string | null;
   realmVersion: number;
   realmURL: string;
   indexedAt: number | null;
@@ -295,6 +300,11 @@ export class IndexQueryEngine {
       url: canonicalURL,
       pristine_doc: resource,
       search_doc: searchDoc,
+      isolated_html: isolatedHtml,
+      head_html: headHtml,
+      embedded_html: embeddedHtml,
+      fitted_html: fittedHtml,
+      atom_html: atomHtml,
       realm_version: realmVersion,
       realm_url: realmURL,
       indexed_at: indexedAt,
@@ -316,6 +326,11 @@ export class IndexQueryEngine {
       types,
       displayNames,
       deps,
+      isolatedHtml,
+      headHtml,
+      embeddedHtml,
+      fittedHtml,
+      atomHtml,
       lastModified: lastModified != null ? parseInt(lastModified) : null,
       resourceCreatedAt:
         resourceCreatedAt != null ? parseInt(resourceCreatedAt) : null,
@@ -505,7 +520,7 @@ export class IndexQueryEngine {
       { filter, sort, page },
       opts,
       [
-        'SELECT url, ANY_VALUE(pristine_doc) AS pristine_doc, ANY_VALUE(search_doc) AS search_doc, ANY_VALUE(types) AS types, ANY_VALUE(display_names) AS display_names, ANY_VALUE(deps) AS deps, ANY_VALUE(last_modified) AS last_modified, ANY_VALUE(resource_created_at) AS resource_created_at, ANY_VALUE(realm_version) AS realm_version, ANY_VALUE(realm_url) AS realm_url, ANY_VALUE(indexed_at) AS indexed_at',
+        'SELECT url, ANY_VALUE(pristine_doc) AS pristine_doc, ANY_VALUE(search_doc) AS search_doc, ANY_VALUE(types) AS types, ANY_VALUE(display_names) AS display_names, ANY_VALUE(deps) AS deps, ANY_VALUE(last_modified) AS last_modified, ANY_VALUE(resource_created_at) AS resource_created_at, ANY_VALUE(isolated_html) AS isolated_html, ANY_VALUE(head_html) AS head_html, ANY_VALUE(embedded_html) AS embedded_html, ANY_VALUE(fitted_html) AS fitted_html, ANY_VALUE(atom_html) AS atom_html, ANY_VALUE(realm_version) AS realm_version, ANY_VALUE(realm_url) AS realm_url, ANY_VALUE(indexed_at) AS indexed_at',
       ],
       'file',
     );
@@ -539,6 +554,13 @@ export class IndexQueryEngine {
       types: (result.types as string[] | null) ?? null,
       displayNames: (result.display_names as string[] | null) ?? null,
       deps: (result.deps as string[] | null) ?? null,
+      isolatedHtml: result.isolated_html ?? null,
+      headHtml: result.head_html ?? null,
+      embeddedHtml:
+        (result.embedded_html as { [refURL: string]: string } | null) ?? null,
+      fittedHtml:
+        (result.fitted_html as { [refURL: string]: string } | null) ?? null,
+      atomHtml: result.atom_html ?? null,
       lastModified,
       resourceCreatedAt,
       realmVersion: result.realm_version ?? 0,

--- a/packages/runtime-common/index-runner/file-indexer.ts
+++ b/packages/runtime-common/index-runner/file-indexer.ts
@@ -200,9 +200,8 @@ export async function performFileIndexing({
       });
       if (renderResult?.error) {
         logWarn(
-          `${jobIdentity(jobInfo)} file render produced error for ${path}, continuing without HTML: ${renderResult.error.error?.message}`,
+          `${jobIdentity(jobInfo)} file render produced error for ${path}, retaining partial HTML: ${renderResult.error.error?.message}`,
         );
-        renderResult = undefined;
       }
     } catch (err: unknown) {
       logWarn(

--- a/packages/runtime-common/realm-index-query-engine.ts
+++ b/packages/runtime-common/realm-index-query-engine.ts
@@ -19,6 +19,8 @@ import {
   type InstanceOrError,
   type IndexedFile,
   type DefinitionLookup,
+  type ResolvedCodeRef,
+  internalKeyFor,
   visitInstanceURLs,
   maybeRelativeURL,
   codeRefFromInternalKey,
@@ -277,13 +279,90 @@ export class RealmIndexQueryEngine {
   }
 
   async searchPrerendered(query: Query, opts?: Options) {
-    let results = await this.#indexQueryEngine.searchPrerendered(
+    let isFileMetaQuery = await this.queryTargetsFileMeta(query.filter, opts);
+    if (isFileMetaQuery) {
+      // File-meta prerendered search currently returns non-error rows.
+      let { includeErrors: _includeErrors, ...fileSearchOpts } = opts ?? {};
+      let { files, meta } = await this.#indexQueryEngine.searchFiles(
+        new URL(this.#realm.url),
+        query,
+        fileSearchOpts,
+      );
+
+      let scopedCssUrls = new Set<string>();
+      let prerenderedCards = files.map((file) => {
+        (file.deps ?? []).forEach((dep) => {
+          if (isScopedCSSRequest(dep)) {
+            scopedCssUrls.add(dep);
+          }
+        });
+        return this.fileEntryToPrerenderedCard(file, opts);
+      });
+
+      return {
+        prerenderedCards,
+        scopedCssUrls: [...scopedCssUrls],
+        meta,
+      };
+    }
+    return await this.#indexQueryEngine.searchPrerendered(
       new URL(this.#realm.url),
       query,
       opts,
     );
+  }
 
-    return results;
+  private fileEntryToPrerenderedCard(file: IndexedFile, opts?: Options) {
+    let html: string | null = null;
+    let usedRenderTypeKey: string | undefined;
+    switch (opts?.htmlFormat) {
+      case 'head':
+        html = file.headHtml;
+        break;
+      case 'embedded':
+      case 'fitted': {
+        let htmlByType =
+          opts.htmlFormat === 'embedded' ? file.embeddedHtml : file.fittedHtml;
+        if (htmlByType) {
+          if (opts.renderType) {
+            let renderTypeKey = internalKeyFor(opts.renderType, undefined);
+            if (htmlByType[renderTypeKey] != null) {
+              html = htmlByType[renderTypeKey];
+              usedRenderTypeKey = renderTypeKey;
+            }
+          }
+          if (html == null) {
+            let defaultTypeKey = file.types?.[0];
+            if (defaultTypeKey && htmlByType[defaultTypeKey] != null) {
+              html = htmlByType[defaultTypeKey];
+              usedRenderTypeKey = defaultTypeKey;
+            }
+          }
+        }
+        break;
+      }
+      case 'atom':
+      default:
+        html = file.atomHtml;
+    }
+
+    if (!usedRenderTypeKey) {
+      usedRenderTypeKey = file.types?.[0];
+    }
+
+    let usedRenderType: ResolvedCodeRef | undefined;
+    if (usedRenderTypeKey) {
+      let codeRef = codeRefFromInternalKey(usedRenderTypeKey);
+      if (isResolvedCodeRef(codeRef)) {
+        usedRenderType = codeRef;
+      }
+    }
+
+    return {
+      url: file.canonicalURL,
+      html,
+      ...(usedRenderType ? { usedRenderType } : {}),
+    };
   }
 
   async getCardDependencies(url: URL): Promise<string[]> {


### PR DESCRIPTION
Support using 

```
<PrerenderedCardSearch
    @query={{this.query}}
    @format='embedded' // or other formats
    @realms={{this.realms}}
 >
```

where query is something like:

```
{
  filter: {
    on: { module: 'https://cardstack.com/base/file-api', name: 'FileDef' },
    eq: { url: `${this.realm}/prerendered-filedef-playground.md` },
  },
}
```

Example:
<img width="792" height="748" alt="image" src="https://github.com/user-attachments/assets/8e40520d-d3b9-4732-9858-e10772239168" />

There is one important limitation - a single query is still effectively one target kind. It does not return a mixed list of both card instances and file-meta in the same response. I'm not sure this is a priority right now but I think we can add this later if needed. 
