### PR TITLE
Pin to Node.js 24.13.1 (LTS) for boxel-icons boxel-motion boxel-ui

### DIFF
--- a/packages/boxel-icons/package.json
+++ b/packages/boxel-icons/package.json
@@ -80,7 +80,7 @@
     "typescript": "catalog:"
   },
   "engines": {
-    "node": "22.20.0"
+    "node": "24.13.1"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/boxel-motion/addon/package.json
+++ b/packages/boxel-motion/addon/package.json
@@ -92,7 +92,7 @@
     "typescript": "catalog:"
   },
   "engines": {
-    "node": "22.20.0"
+    "node": "24.13.1"
   },
   "ember": {
     "edition": "octane"

--- a/packages/boxel-ui/addon/package.json
+++ b/packages/boxel-ui/addon/package.json
@@ -109,7 +109,7 @@
     "typescript": "catalog:"
   },
   "engines": {
-    "node": "22.20.0"
+    "node": "24.13.1"
   },
   "volta": {
     "extends": "../../../package.json"


### PR DESCRIPTION
Was getting these warnings when running lint (locally + CI):

<img width="1025" height="233" alt="image" src="https://github.com/user-attachments/assets/82e4964f-ea77-4561-a663-93ca3b11fa6b" />
