### PR TITLE
CardPicker component refactor and display recent cards

### DIFF
--- a/packages/boxel-ui/addon/src/components.ts
+++ b/packages/boxel-ui/addon/src/components.ts
@@ -26,6 +26,7 @@ import EntityDisplayWithIcon from './components/entity-icon-display/index.gts';
 import EntityDisplayWithThumbnail from './components/entity-thumbnail-display/index.gts';
 import FieldContainer from './components/field-container/index.gts';
 import FilterList, { type Filter } from './components/filter-list/index.gts';
+import FittedCardContainer from './components/fitted-card-container/index.gts';
 import GridContainer from './components/grid-container/index.gts';
 import BoxelHeader from './components/header/index.gts';
 import Header from './components/header/index.gts';
@@ -115,6 +116,7 @@ export {
   EntityDisplayWithThumbnail,
   FieldContainer,
   FilterList,
+  FittedCardContainer,
   GridContainer,
   Header,
   IconButton,

--- a/packages/boxel-ui/addon/src/components/basic-fitted/usage.gts
+++ b/packages/boxel-ui/addon/src/components/basic-fitted/usage.gts
@@ -5,134 +5,18 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
 
-import { cn, gt, gte } from '../../helpers.ts';
+import {
+  cn,
+  gt,
+  gte,
+  FITTED_FORMATS,
+  type FittedFormatSpec,
+} from '../../helpers.ts';
 import type { Icon } from '../../icons.ts';
 import CardContainer from '../card-container/index.gts';
 import BasicFitted from './index.gts';
 
-type Spec = { height: number; title?: string; width: number };
-
-// These can be imported from the @cardstack/runtime-common package:
-// `import { FITTED_FORMATS } from '@cardstack/runtime-common'`
-// For various build problems, could not do that here.
-const FITTED_FORMATS = [
-  {
-    name: 'Badges',
-    specs: [
-      {
-        id: 'small-badge',
-        title: 'Small Badge',
-        width: 150,
-        height: 40,
-      },
-      {
-        id: 'medium-badge',
-        title: 'Medium Badge',
-        width: 150,
-        height: 65,
-      },
-      {
-        id: 'large-badge',
-        title: 'Large Badge',
-        width: 150,
-        height: 105,
-      },
-    ],
-  },
-  {
-    name: 'Strips',
-    specs: [
-      {
-        id: 'single-strip',
-        title: 'Single Strip',
-        width: 250,
-        height: 40,
-      },
-      {
-        id: 'double-strip',
-        title: 'Double Strip',
-        width: 250,
-        height: 65,
-      },
-      {
-        id: 'triple-strip',
-        title: 'Triple Strip',
-        width: 250,
-        height: 105,
-      },
-      {
-        id: 'double-wide-strip',
-        title: 'Double Wide Strip',
-        width: 400,
-        height: 65,
-      },
-      {
-        id: 'triple-wide-strip',
-        title: 'Triple Wide Strip',
-        width: 400,
-        height: 105,
-      },
-    ],
-  },
-  {
-    name: 'Tiles',
-    specs: [
-      {
-        id: 'small-tile',
-        title: 'Small Tile',
-        width: 150,
-        height: 170,
-      },
-      {
-        id: 'regular-tile',
-        title: 'Regular Tile',
-        width: 250,
-        height: 170,
-      },
-      {
-        id: 'cardsgrid-tile',
-        title: 'CardsGrid Tile',
-        width: 170,
-        height: 250,
-      },
-      {
-        id: 'tall-tile',
-        title: 'Tall Tile',
-        width: 150,
-        height: 275,
-      },
-      {
-        id: 'large-tile',
-        title: 'Large Tile',
-        width: 250,
-        height: 275,
-      },
-    ],
-  },
-  {
-    name: 'Cards',
-    specs: [
-      {
-        id: 'compact-card',
-        title: 'Compact Card',
-        width: 400,
-        height: 170,
-      },
-      {
-        id: 'full-card',
-        title: 'Full Card',
-        width: 400,
-        height: 275,
-      },
-      {
-        id: 'expanded-card',
-        title: 'Expanded Card',
-        width: 400,
-        height: 445,
-      },
-    ],
-  },
-];
+type Spec = Partial<FittedFormatSpec> & { width: number; height: number };
 
 const OTHER_SIZES: Spec[] = [
   { width: 226, height: 226 },

--- a/packages/boxel-ui/addon/src/components/basic-fitted/usage.gts
+++ b/packages/boxel-ui/addon/src/components/basic-fitted/usage.gts
@@ -6,17 +6,17 @@ import { tracked } from '@glimmer/tracking';
 import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
 
 import {
+  type FittedFormatSpec,
   cn,
+  FITTED_FORMATS,
   gt,
   gte,
-  FITTED_FORMATS,
-  type FittedFormatSpec,
 } from '../../helpers.ts';
 import type { Icon } from '../../icons.ts';
 import CardContainer from '../card-container/index.gts';
 import BasicFitted from './index.gts';
 
-type Spec = Partial<FittedFormatSpec> & { width: number; height: number };
+type Spec = Partial<FittedFormatSpec> & { height: number; width: number };
 
 const OTHER_SIZES: Spec[] = [
   { width: 226, height: 226 },

--- a/packages/boxel-ui/addon/src/components/card-container/index.gts
+++ b/packages/boxel-ui/addon/src/components/card-container/index.gts
@@ -58,11 +58,8 @@ const CardContainer: TemplateOnlyComponent<Signature> = <template>
       width: 100%;
       overflow: hidden;
     }
-    :global(.boxel-card-container--boundaries) {
+    :global(.boxel-card-container--boundaries:not(.hide-boundaries)) {
       box-shadow: 0 0 0 1px var(--border, var(--boxel-border-color));
-    }
-    :global(.boxel-card-container--boundaries.hide-boundaries) {
-      box-shadow: none;
     }
 
     :global(.boxel-card-container--themed) {

--- a/packages/boxel-ui/addon/src/components/fitted-card-container/index.gts
+++ b/packages/boxel-ui/addon/src/components/fitted-card-container/index.gts
@@ -1,0 +1,57 @@
+import Component from '@glimmer/component';
+
+import {
+  fittedFormatById,
+  fittedFormatIds,
+  sanitizeHtmlSafe,
+  type FittedFormatId,
+} from '../../helpers.ts';
+
+interface Signature {
+  Args: {
+    size?: FittedFormatId;
+  };
+  Blocks: { default: [] };
+  Element: HTMLDivElement;
+}
+
+export default class FittedCardContainer extends Component<Signature> {
+  <template>
+    <div
+      class='boxel-fitted-card-container'
+      style={{this.containerStyle}}
+      ...attributes
+    >
+      {{yield}}
+    </div>
+  </template>
+
+  get formatSpec() {
+    let size = this.args.size;
+
+    if (!size) {
+      return null;
+    }
+
+    if (!fittedFormatIds?.includes(size)) {
+      console.error(
+        `Size "${size}" does not exist in fitted format sizes. Please choose from ${fittedFormatIds.join(', ')}`,
+      );
+      return null;
+    }
+
+    return fittedFormatById.get(size) ?? null;
+  }
+
+  get containerStyle() {
+    let formatSpec = this.formatSpec;
+
+    if (!formatSpec) {
+      return sanitizeHtmlSafe('');
+    }
+
+    return sanitizeHtmlSafe(
+      `width: ${formatSpec.width}px; height: ${formatSpec.height}px;`,
+    );
+  }
+}

--- a/packages/boxel-ui/addon/src/components/fitted-card-container/index.gts
+++ b/packages/boxel-ui/addon/src/components/fitted-card-container/index.gts
@@ -1,16 +1,16 @@
 import Component from '@glimmer/component';
 
 import {
+  type FittedFormatId,
   fittedFormatById,
   fittedFormatIds,
   sanitizeHtmlSafe,
-  type FittedFormatId,
 } from '../../helpers.ts';
 
 interface Signature {
   Args: {
-    size?: FittedFormatId;
     fullWidth?: boolean;
+    size?: FittedFormatId;
   };
   Blocks: { default: [] };
   Element: HTMLDivElement;

--- a/packages/boxel-ui/addon/src/components/fitted-card-container/index.gts
+++ b/packages/boxel-ui/addon/src/components/fitted-card-container/index.gts
@@ -10,6 +10,7 @@ import {
 interface Signature {
   Args: {
     size?: FittedFormatId;
+    fullWidth?: boolean;
   };
   Blocks: { default: [] };
   Element: HTMLDivElement;
@@ -44,14 +45,19 @@ export default class FittedCardContainer extends Component<Signature> {
   }
 
   get containerStyle() {
+    let style = ``;
     let formatSpec = this.formatSpec;
 
     if (!formatSpec) {
-      return sanitizeHtmlSafe('');
+      return sanitizeHtmlSafe(style);
     }
 
-    return sanitizeHtmlSafe(
-      `width: ${formatSpec.width}px; height: ${formatSpec.height}px;`,
-    );
+    if (this.args.fullWidth) {
+      style += `width: 100%; height: ${formatSpec.height}px;`;
+    } else {
+      style += `width: ${formatSpec.width}px; height: ${formatSpec.height}px;`;
+    }
+
+    return sanitizeHtmlSafe(style);
   }
 }

--- a/packages/boxel-ui/addon/src/components/fitted-card-container/usage.gts
+++ b/packages/boxel-ui/addon/src/components/fitted-card-container/usage.gts
@@ -1,0 +1,88 @@
+import Component from '@glimmer/component';
+import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
+
+import {
+  fittedFormatById,
+  fittedFormatIds,
+  type FittedFormatId,
+} from '../../helpers.ts';
+import FittedCardContainer from './index.gts';
+
+export default class FittedCardContainerUsage extends Component {
+  sampleSizes = fittedFormatIds;
+
+  formatTitle(size: FittedFormatId) {
+    return fittedFormatById.get(size)?.title ?? size;
+  }
+
+  formatDimensions(size: FittedFormatId) {
+    let spec = fittedFormatById.get(size);
+    return spec ? `${spec.width}px × ${spec.height}px` : '';
+  }
+
+  <template>
+    <FreestyleUsage @name='FittedCardContainer'>
+      <:description>
+        Constrains card content to a fixed fitted size so layouts stay aligned.
+      </:description>
+      <:example>
+        <div class='fitted-card-container-usage-grid'>
+          {{#each this.sampleSizes as |size|}}
+            <FittedCardContainer @size={{size}}>
+              <div class='fitted-card-container-usage-card'>
+                <div class='fitted-card-container-usage-title'>
+                  {{this.formatTitle size}}
+                </div>
+                <div class='fitted-card-container-usage-meta'>
+                  {{this.formatDimensions size}}
+                </div>
+              </div>
+            </FittedCardContainer>
+          {{/each}}
+        </div>
+      </:example>
+      <:api as |Args|>
+        <Args.String
+          @name='size'
+          @description='Fitted size id from the fitted formats list.'
+        />
+        <Args.Yield
+          @description='Card content rendered inside the sized container.'
+        />
+      </:api>
+    </FreestyleUsage>
+    <style scoped>
+      .fitted-card-container-usage-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        gap: var(--boxel-sp);
+        align-items: start;
+      }
+      .fitted-card-container-usage-card {
+        width: 100%;
+        height: 100%;
+        padding: var(--boxel-sp);
+        display: grid;
+        gap: var(--boxel-sp-2xs);
+        place-content: center;
+        text-align: center;
+        border: var(--boxel-border-card);
+        border-radius: var(--boxel-border-radius);
+        background: color-mix(
+          in oklab,
+          var(--background, var(--boxel-light)) 92%,
+          var(--foreground, var(--boxel-dark))
+        );
+        color: var(--foreground, var(--boxel-dark));
+        font: var(--boxel-font-sm);
+      }
+      .fitted-card-container-usage-title {
+        font-weight: 600;
+      }
+      .fitted-card-container-usage-meta {
+        color: var(--muted-foreground, var(--boxel-500));
+        font: var(--boxel-font-xs);
+      }
+    </style>
+  </template>
+}

--- a/packages/boxel-ui/addon/src/components/fitted-card-container/usage.gts
+++ b/packages/boxel-ui/addon/src/components/fitted-card-container/usage.gts
@@ -1,4 +1,6 @@
+import { fn } from '@ember/helper';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
 
 import {
@@ -6,10 +8,16 @@ import {
   fittedFormatById,
   fittedFormatIds,
 } from '../../helpers.ts';
+import CardContainer from '../card-container/index.gts';
+import GridContainer from '../grid-container/index.gts';
 import FittedCardContainer from './index.gts';
 
 export default class FittedCardContainerUsage extends Component {
-  sampleSizes = fittedFormatIds;
+  fittedFormats = fittedFormatIds;
+  usageFormatOptions = [undefined, ...this.fittedFormats];
+
+  @tracked fullWidth = false;
+  @tracked selectedSize?: FittedFormatId = undefined;
 
   formatTitle(size: FittedFormatId) {
     return fittedFormatById.get(size)?.title ?? size;
@@ -23,66 +31,51 @@ export default class FittedCardContainerUsage extends Component {
   <template>
     <FreestyleUsage @name='FittedCardContainer'>
       <:description>
-        Constrains card content to a fixed fitted size so layouts stay aligned.
+        Constrains card to fitted height and optionally responsive width.
       </:description>
       <:example>
-        <div class='fitted-card-container-usage-grid'>
-          {{#each this.sampleSizes as |size|}}
-            <FittedCardContainer @size={{size}}>
-              <div class='fitted-card-container-usage-card'>
-                <div class='fitted-card-container-usage-title'>
-                  {{this.formatTitle size}}
-                </div>
-                <div class='fitted-card-container-usage-meta'>
-                  {{this.formatDimensions size}}
-                </div>
-              </div>
+        <GridContainer>
+          {{#if this.selectedSize}}
+            <FittedCardContainer
+              @size={{this.selectedSize}}
+              @fullWidth={{this.fullWidth}}
+            >
+              <CardContainer @displayBoundaries={{true}}>
+                <h4>{{this.formatTitle this.selectedSize}}</h4>
+                {{this.formatDimensions this.selectedSize}}
+              </CardContainer>
             </FittedCardContainer>
-          {{/each}}
-        </div>
+          {{else}}
+            {{#each this.fittedFormats as |size|}}
+              <FittedCardContainer @size={{size}} @fullWidth={{this.fullWidth}}>
+                <CardContainer @displayBoundaries={{true}}>
+                  <h4>{{this.formatTitle size}}</h4>
+                  {{this.formatDimensions size}}
+                </CardContainer>
+              </FittedCardContainer>
+            {{/each}}
+          {{/if}}
+        </GridContainer>
       </:example>
       <:api as |Args|>
         <Args.String
           @name='size'
           @description='Fitted size id from the fitted formats list.'
+          @options={{this.usageFormatOptions}}
+          @value={{this.selectedSize}}
+          @onInput={{fn (mut this.selectedSize)}}
+        />
+        <Args.Bool
+          @name='fullWidth'
+          @description='Whether item should have 100% width (height is restricted).'
+          @value={{this.fullWidth}}
+          @onInput={{fn (mut this.fullWidth)}}
+          @defaultValue={{false}}
         />
         <Args.Yield
           @description='Card content rendered inside the sized container.'
         />
       </:api>
     </FreestyleUsage>
-    <style scoped>
-      .fitted-card-container-usage-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-        gap: var(--boxel-sp);
-        align-items: start;
-      }
-      .fitted-card-container-usage-card {
-        width: 100%;
-        height: 100%;
-        padding: var(--boxel-sp);
-        display: grid;
-        gap: var(--boxel-sp-2xs);
-        place-content: center;
-        text-align: center;
-        border: var(--boxel-border-card);
-        border-radius: var(--boxel-border-radius);
-        background: color-mix(
-          in oklab,
-          var(--background, var(--boxel-light)) 92%,
-          var(--foreground, var(--boxel-dark))
-        );
-        color: var(--foreground, var(--boxel-dark));
-        font: var(--boxel-font-sm);
-      }
-      .fitted-card-container-usage-title {
-        font-weight: 600;
-      }
-      .fitted-card-container-usage-meta {
-        color: var(--muted-foreground, var(--boxel-500));
-        font: var(--boxel-font-xs);
-      }
-    </style>
   </template>
 }

--- a/packages/boxel-ui/addon/src/components/fitted-card-container/usage.gts
+++ b/packages/boxel-ui/addon/src/components/fitted-card-container/usage.gts
@@ -41,7 +41,7 @@ export default class FittedCardContainerUsage extends Component {
               @fullWidth={{this.fullWidth}}
             >
               <CardContainer @displayBoundaries={{true}}>
-                <h4>{{this.formatTitle this.selectedSize}}</h4>
+                <h3>{{this.formatTitle this.selectedSize}}</h3>
                 {{this.formatDimensions this.selectedSize}}
               </CardContainer>
             </FittedCardContainer>
@@ -49,7 +49,7 @@ export default class FittedCardContainerUsage extends Component {
             {{#each this.fittedFormats as |size|}}
               <FittedCardContainer @size={{size}} @fullWidth={{this.fullWidth}}>
                 <CardContainer @displayBoundaries={{true}}>
-                  <h4>{{this.formatTitle size}}</h4>
+                  <h3>{{this.formatTitle size}}</h3>
                   {{this.formatDimensions size}}
                 </CardContainer>
               </FittedCardContainer>

--- a/packages/boxel-ui/addon/src/components/fitted-card-container/usage.gts
+++ b/packages/boxel-ui/addon/src/components/fitted-card-container/usage.gts
@@ -2,9 +2,9 @@ import Component from '@glimmer/component';
 import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
 
 import {
+  type FittedFormatId,
   fittedFormatById,
   fittedFormatIds,
-  type FittedFormatId,
 } from '../../helpers.ts';
 import FittedCardContainer from './index.gts';
 

--- a/packages/boxel-ui/addon/src/components/grid-container/grid-item-container/index.gts
+++ b/packages/boxel-ui/addon/src/components/grid-container/grid-item-container/index.gts
@@ -4,7 +4,7 @@ import { type FittedFormatId } from '../../../helpers.ts';
 import FittedCardContainer from '../../fitted-card-container/index.gts';
 
 export interface GridItemContainerSignature {
-  Args: { fullWidth?: boolean; size?: FittedFormatId };
+  Args: { fullWidth?: boolean; index?: number; size?: FittedFormatId };
   Blocks: {
     after?: [];
     before?: [];
@@ -20,7 +20,11 @@ const GridItemContainer: TemplateOnlyComponent<GridItemContainerSignature> =
         {{yield to='before'}}
       {{/if}}
 
-      <FittedCardContainer @size={{@size}} @fullWidth={{@fullWidth}}>
+      <FittedCardContainer
+        @size={{@size}}
+        @fullWidth={{@fullWidth}}
+        data-test-grid-item-index={{@index}}
+      >
         {{yield}}
       </FittedCardContainer>
 

--- a/packages/boxel-ui/addon/src/components/grid-container/grid-item-container/index.gts
+++ b/packages/boxel-ui/addon/src/components/grid-container/grid-item-container/index.gts
@@ -1,19 +1,19 @@
-import Component from '@glimmer/component';
+import type { TemplateOnlyComponent } from '@ember/component/template-only';
 
-import FittedCardContainer from '../../fitted-card-container/index.gts';
 import { type FittedFormatId } from '../../../helpers.ts';
+import FittedCardContainer from '../../fitted-card-container/index.gts';
 
 export interface GridItemContainerSignature {
-  Args: { size?: FittedFormatId; fullWidth?: boolean };
+  Args: { fullWidth?: boolean; size?: FittedFormatId };
   Blocks: {
-    default: [];
-    before?: [];
     after?: [];
+    before?: [];
+    default: [];
   };
   Element: HTMLElement;
 }
 
-export default class GridItemContainer extends Component<GridItemContainerSignature> {
+const GridItemContainer: TemplateOnlyComponent<GridItemContainerSignature> =
   <template>
     <div class='boxel-grid-item-container' ...attributes>
       {{#if (has-block 'before')}}
@@ -28,5 +28,6 @@ export default class GridItemContainer extends Component<GridItemContainerSignat
         {{yield to='after'}}
       {{/if}}
     </div>
-  </template>
-}
+  </template>;
+
+export default GridItemContainer;

--- a/packages/boxel-ui/addon/src/components/grid-container/grid-item-container/index.gts
+++ b/packages/boxel-ui/addon/src/components/grid-container/grid-item-container/index.gts
@@ -1,0 +1,32 @@
+import Component from '@glimmer/component';
+
+import FittedCardContainer from '../../fitted-card-container/index.gts';
+import { type FittedFormatId } from '../../../helpers.ts';
+
+export interface GridItemContainerSignature {
+  Args: { size?: FittedFormatId; fullWidth?: boolean };
+  Blocks: {
+    default: [];
+    before?: [];
+    after?: [];
+  };
+  Element: HTMLElement;
+}
+
+export default class GridItemContainer extends Component<GridItemContainerSignature> {
+  <template>
+    <div class='boxel-grid-item-container' ...attributes>
+      {{#if (has-block 'before')}}
+        {{yield to='before'}}
+      {{/if}}
+
+      <FittedCardContainer @size={{@size}} @fullWidth={{@fullWidth}}>
+        {{yield}}
+      </FittedCardContainer>
+
+      {{#if (has-block 'after')}}
+        {{yield to='after'}}
+      {{/if}}
+    </div>
+  </template>
+}

--- a/packages/boxel-ui/addon/src/components/grid-container/index.gts
+++ b/packages/boxel-ui/addon/src/components/grid-container/index.gts
@@ -40,10 +40,12 @@ export default class GridContainer extends Component<Signature> {
         ...attributes
       >
         {{#if @items}}
-          {{#each @items as |item|}}
+          {{#each @items as |item i|}}
             {{yield
               item
-              (component GridItemContainer size=@size fullWidth=@fullWidthItem)
+              (component
+                GridItemContainer size=@size fullWidth=@fullWidthItem index=i
+              )
             }}
           {{/each}}
         {{else}}

--- a/packages/boxel-ui/addon/src/components/grid-container/index.gts
+++ b/packages/boxel-ui/addon/src/components/grid-container/index.gts
@@ -1,9 +1,16 @@
-import type { TemplateOnlyComponent } from '@ember/component/template-only';
+import Component from '@glimmer/component';
 
-import { element } from '../../helpers.ts';
+import {
+  element,
+  fittedFormatById,
+  fittedFormatIds,
+  sanitizeHtmlSafe,
+  type FittedFormatId,
+} from '../../helpers.ts';
 
 interface Signature {
   Args: {
+    size?: FittedFormatId;
     tag?: keyof HTMLElementTagNameMap;
   };
   Blocks: {
@@ -12,28 +19,61 @@ interface Signature {
   Element: HTMLElement;
 }
 
-const GridContainer: TemplateOnlyComponent<Signature> = <template>
-  {{#let (element @tag) as |TagName|}}
-    <TagName class='grid-container' ...attributes>
-      {{yield}}
-    </TagName>
-  {{/let}}
+export default class GridContainer extends Component<Signature> {
+  <template>
+    {{#let (element @tag) as |TagName|}}
+      <TagName
+        class='grid-container'
+        style={{this.containerStyle}}
+        ...attributes
+      >
+        {{yield}}
+      </TagName>
+    {{/let}}
 
-  <style scoped>
-    @layer boxelComponentL1 {
-      .grid-container {
-        display: grid;
-        gap: var(--boxel-sp);
+    <style scoped>
+      @layer boxelComponentL1 {
+        .grid-container {
+          display: grid;
+          gap: var(--boxel-sp);
+        }
       }
+
+      @layer reset {
+        .grid-container :deep(h2),
+        .grid-container :deep(h3) {
+          margin: 0;
+        }
+      }
+    </style>
+  </template>
+
+  get formatSpec() {
+    let size = this.args.size;
+
+    if (!size) {
+      return null;
     }
 
-    @layer reset {
-      .grid-container :deep(h2),
-      .grid-container :deep(h3) {
-        margin: 0;
-      }
+    if (!fittedFormatIds?.includes(size)) {
+      console.error(
+        `Size "${size}" does not exist in fitted format sizes. Please choose from ${fittedFormatIds.join(', ')}`,
+      );
+      return null;
     }
-  </style>
-</template>;
 
-export default GridContainer;
+    return fittedFormatById.get(size) ?? null;
+  }
+
+  get containerStyle() {
+    let formatSpec = this.formatSpec;
+
+    if (!formatSpec) {
+      return sanitizeHtmlSafe('');
+    }
+
+    return sanitizeHtmlSafe(
+      `grid-template-columns: repeat(auto-fill, ${formatSpec.width}px); grid-auto-rows: ${formatSpec.height}px;`,
+    );
+  }
+}

--- a/packages/boxel-ui/addon/src/components/grid-container/index.gts
+++ b/packages/boxel-ui/addon/src/components/grid-container/index.gts
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import type { ComponentLike } from '@glint/template';
 
 import {
   element,
@@ -8,13 +9,25 @@ import {
   type FittedFormatId,
 } from '../../helpers.ts';
 
+import GridItemContainer, {
+  type GridItemContainerSignature,
+} from './grid-item-container/index.gts';
+
 interface Signature {
   Args: {
+    viewFormat?: 'list' | 'grid';
     size?: FittedFormatId;
+    fullWidthItem?: boolean;
     tag?: keyof HTMLElementTagNameMap;
+    items?: any[];
   };
   Blocks: {
-    default: [];
+    default:
+      | [
+          item: any,
+          GridItemContainer: ComponentLike<GridItemContainerSignature>,
+        ]
+      | [];
   };
   Element: HTMLElement;
 }
@@ -23,25 +36,34 @@ export default class GridContainer extends Component<Signature> {
   <template>
     {{#let (element @tag) as |TagName|}}
       <TagName
-        class='grid-container'
+        class='boxel-grid-container'
         style={{this.containerStyle}}
         ...attributes
       >
-        {{yield}}
+        {{#if @items}}
+          {{#each @items as |item|}}
+            {{yield
+              item
+              (component GridItemContainer size=@size fullWidth=@fullWidthItem)
+            }}
+          {{/each}}
+        {{else}}
+          {{yield}}
+        {{/if}}
       </TagName>
     {{/let}}
 
     <style scoped>
       @layer boxelComponentL1 {
-        .grid-container {
+        .boxel-grid-container {
           display: grid;
           gap: var(--boxel-sp);
         }
       }
 
       @layer reset {
-        .grid-container :deep(h2),
-        .grid-container :deep(h3) {
+        .boxel-grid-container :deep(h2),
+        .boxel-grid-container :deep(h3) {
           margin: 0;
         }
       }
@@ -72,8 +94,22 @@ export default class GridContainer extends Component<Signature> {
       return sanitizeHtmlSafe('');
     }
 
-    return sanitizeHtmlSafe(
-      `grid-template-columns: repeat(auto-fill, ${formatSpec.width}px); grid-auto-rows: ${formatSpec.height}px;`,
-    );
+    if (this.args.items) {
+      if (this.args.viewFormat === 'list') {
+        return sanitizeHtmlSafe('grid-template-columns: 1fr;');
+      }
+      return sanitizeHtmlSafe(
+        `grid-template-columns: repeat(auto-fill, ${formatSpec.width}px);`,
+      );
+    } else {
+      if (this.args.viewFormat === 'list') {
+        return sanitizeHtmlSafe(
+          `grid-template-columns: 1fr; grid-auto-rows: ${formatSpec.height}px`,
+        );
+      }
+      return sanitizeHtmlSafe(
+        `grid-template-columns: repeat(auto-fill, ${formatSpec.width}px); grid-auto-rows: ${formatSpec.height}px`,
+      );
+    }
   }
 }

--- a/packages/boxel-ui/addon/src/components/grid-container/index.gts
+++ b/packages/boxel-ui/addon/src/components/grid-container/index.gts
@@ -2,24 +2,23 @@ import Component from '@glimmer/component';
 import type { ComponentLike } from '@glint/template';
 
 import {
+  type FittedFormatId,
   element,
   fittedFormatById,
   fittedFormatIds,
   sanitizeHtmlSafe,
-  type FittedFormatId,
 } from '../../helpers.ts';
-
 import GridItemContainer, {
   type GridItemContainerSignature,
 } from './grid-item-container/index.gts';
 
 interface Signature {
   Args: {
-    viewFormat?: 'list' | 'grid';
-    size?: FittedFormatId;
     fullWidthItem?: boolean;
-    tag?: keyof HTMLElementTagNameMap;
     items?: any[];
+    size?: FittedFormatId;
+    tag?: keyof HTMLElementTagNameMap;
+    viewFormat?: 'list' | 'grid';
   };
   Blocks: {
     default:

--- a/packages/boxel-ui/addon/src/components/grid-container/usage.gts
+++ b/packages/boxel-ui/addon/src/components/grid-container/usage.gts
@@ -1,25 +1,105 @@
+import { array, fn } from '@ember/helper';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import FreestyleUsage from 'ember-freestyle/components/freestyle/usage';
 
+import {
+  type FittedFormatId,
+  fittedFormatById,
+  fittedFormatIds,
+} from '../../helpers.ts';
+import CardContainer from '../card-container/index.gts';
 import BoxelGridContainer from './index.gts';
 
 interface Signature {
   Element: HTMLElement;
 }
 
-// eslint-disable-next-line ember/no-empty-glimmer-component-classes
 export default class GridContainerUsage extends Component<Signature> {
+  fittedFormats = fittedFormatIds;
+  usageFormatOptions = [undefined, ...this.fittedFormats];
+  sampleItems = ['Item A', 'Item B', 'Item C', 'Item D', 'Item E', 'Item F'];
+
+  @tracked size: FittedFormatId | undefined = 'regular-tile';
+  @tracked viewFormat: 'grid' | 'list' = 'grid';
+  @tracked fullWidthItem = false;
+
+  formatTitle(size: FittedFormatId) {
+    return fittedFormatById.get(size)?.title ?? size;
+  }
+
+  formatDimensions(size: FittedFormatId) {
+    let spec = fittedFormatById.get(size);
+    return spec ? `${spec.width}px × ${spec.height}px` : '';
+  }
+
   <template>
     <FreestyleUsage @name='GridContainer'>
       <:description>
-        A container that provides a grid layout and h3/h4 spacing.
+        A CSS grid container for laying out fitted cards. Supports both a simple
+        default slot and an item-based API that yields a
+        <code>GridItemContainer</code>
+        per item. Pass a
+        <code>@size</code>
+        to constrain card dimensions using fitted format specs, and use
+        <code>@viewFormat</code>
+        to switch between grid and list layouts.
       </:description>
       <:example>
-        <BoxelGridContainer>
-          <h3>h3</h3>
-          <p>Hello</p>
+        <BoxelGridContainer
+          @items={{this.sampleItems}}
+          @size={{this.size}}
+          @viewFormat={{this.viewFormat}}
+          @fullWidthItem={{this.fullWidthItem}}
+          as |item GridItemContainer|
+        >
+          <GridItemContainer>
+            <CardContainer @displayBoundaries={{true}}>
+              <h3>{{item}}</h3>
+              {{#if this.size}}
+                <p>{{this.formatDimensions this.size}}</p>
+              {{/if}}
+            </CardContainer>
+          </GridItemContainer>
         </BoxelGridContainer>
       </:example>
+      <:api as |Args|>
+        <Args.Object
+          @name='items'
+          @description='Array of items to iterate over. Each item and a GridItemContainer component are yielded to the block. When omitted, an empty block is yielded for custom content.'
+          @value={{this.sampleItems}}
+        />
+        <Args.String
+          @name='size'
+          @description='Fitted format size id. Controls grid column width and row height. Must be a valid FittedFormatId.'
+          @options={{this.usageFormatOptions}}
+          @value={{this.size}}
+          @onInput={{fn (mut this.size)}}
+        />
+        <Args.String
+          @name='viewFormat'
+          @description='"grid" uses auto-fill columns sized to the format width. "list" stacks items in a single column.'
+          @options={{array 'grid' 'list'}}
+          @value={{this.viewFormat}}
+          @onInput={{fn (mut this.viewFormat)}}
+          @defaultValue='grid'
+        />
+        <Args.Bool
+          @name='fullWidthItem'
+          @description='When true, each GridItemContainer stretches to full width. Height is still constrained by @size.'
+          @value={{this.fullWidthItem}}
+          @onInput={{fn (mut this.fullWidthItem)}}
+          @defaultValue={{false}}
+        />
+        <Args.String
+          @name='tag'
+          @description='HTML element tag used to render the container element.'
+          @defaultValue='div'
+        />
+        <Args.Yield
+          @description='When @items is provided, yields (item, GridItemContainer) per entry. When @items is omitted, yields an empty block for custom content.'
+        />
+      </:api>
     </FreestyleUsage>
   </template>
 }

--- a/packages/boxel-ui/addon/src/helpers.ts
+++ b/packages/boxel-ui/addon/src/helpers.ts
@@ -63,6 +63,8 @@ import type { NormalizePhoneFormatResult } from './helpers/validate-phone-format
 
 export * from './helpers/color-tools.ts';
 
+export * from './utils/fitted-formats.ts';
+
 export {
   add,
   addClassToSVG,

--- a/packages/boxel-ui/addon/src/helpers.ts
+++ b/packages/boxel-ui/addon/src/helpers.ts
@@ -62,7 +62,6 @@ import type { EmailFormatValidationError } from './helpers/validate-email-format
 import type { NormalizePhoneFormatResult } from './helpers/validate-phone-format.ts';
 
 export * from './helpers/color-tools.ts';
-
 export * from './utils/fitted-formats.ts';
 
 export {

--- a/packages/boxel-ui/addon/src/usage.ts
+++ b/packages/boxel-ui/addon/src/usage.ts
@@ -24,6 +24,7 @@ import EntityIconDisplayUsage from './components/entity-icon-display/usage.gts';
 import EntityThumbnailDisplayUsage from './components/entity-thumbnail-display/usage.gts';
 import FieldContainerUsage from './components/field-container/usage.gts';
 import FilterListUsage from './components/filter-list/usage.gts';
+import FittedCardContainerUsage from './components/fitted-card-container/usage.gts';
 import GridContainerUsage from './components/grid-container/usage.gts';
 import HeaderUsage from './components/header/usage.gts';
 import IconButtonUsage from './components/icon-button/usage.gts';
@@ -77,6 +78,7 @@ export const ALL_USAGE_COMPONENTS = [
   ['EntityThumbnailDisplay', EntityThumbnailDisplayUsage],
   ['FieldContainer', FieldContainerUsage],
   ['FilterList', FilterListUsage],
+  ['FittedCardContainer', FittedCardContainerUsage],
   ['GridContainer', GridContainerUsage],
   ['Header', HeaderUsage],
   ['IconButton', IconButtonUsage],

--- a/packages/boxel-ui/addon/src/utils/fitted-formats.ts
+++ b/packages/boxel-ui/addon/src/utils/fitted-formats.ts
@@ -1,0 +1,161 @@
+export type FittedFormatId =
+  | 'cardsgrid-tile'
+  | 'compact-card'
+  | 'double-strip'
+  | 'double-wide-strip'
+  | 'expanded-card'
+  | 'full-card'
+  | 'large-badge'
+  | 'large-tile'
+  | 'medium-badge'
+  | 'regular-tile'
+  | 'single-strip'
+  | 'small-badge'
+  | 'small-tile'
+  | 'tall-tile'
+  | 'triple-strip'
+  | 'triple-wide-strip';
+
+export type FittedFormatSpec = {
+  id: FittedFormatId;
+  title: string;
+  width: number;
+  height: number;
+};
+
+type FittedFormatGallery = ReadonlyArray<{
+  name: string;
+  specs: FittedFormatSpec[];
+}>;
+
+export const FITTED_FORMATS: FittedFormatGallery = [
+  {
+    name: 'Badges',
+    specs: [
+      {
+        id: 'small-badge',
+        title: 'Small Badge',
+        width: 150,
+        height: 40,
+      },
+      {
+        id: 'medium-badge',
+        title: 'Medium Badge',
+        width: 150,
+        height: 65,
+      },
+      {
+        id: 'large-badge',
+        title: 'Large Badge',
+        width: 150,
+        height: 105,
+      },
+    ],
+  },
+  {
+    name: 'Strips',
+    specs: [
+      {
+        id: 'single-strip',
+        title: 'Single Strip',
+        width: 250,
+        height: 40,
+      },
+      {
+        id: 'double-strip',
+        title: 'Double Strip',
+        width: 250,
+        height: 65,
+      },
+      {
+        id: 'triple-strip',
+        title: 'Triple Strip',
+        width: 250,
+        height: 105,
+      },
+      {
+        id: 'double-wide-strip',
+        title: 'Double Wide Strip',
+        width: 400,
+        height: 65,
+      },
+      {
+        id: 'triple-wide-strip',
+        title: 'Triple Wide Strip',
+        width: 400,
+        height: 105,
+      },
+    ],
+  },
+  {
+    name: 'Tiles',
+    specs: [
+      {
+        id: 'small-tile',
+        title: 'Small Tile',
+        width: 150,
+        height: 170,
+      },
+      {
+        id: 'regular-tile',
+        title: 'Regular Tile',
+        width: 250,
+        height: 170,
+      },
+      {
+        id: 'cardsgrid-tile',
+        title: 'CardsGrid Tile',
+        width: 170,
+        height: 250,
+      },
+      {
+        id: 'tall-tile',
+        title: 'Tall Tile',
+        width: 150,
+        height: 275,
+      },
+      {
+        id: 'large-tile',
+        title: 'Large Tile',
+        width: 250,
+        height: 275,
+      },
+    ],
+  },
+  {
+    name: 'Cards',
+    specs: [
+      {
+        id: 'compact-card',
+        title: 'Compact Card',
+        width: 400,
+        height: 170,
+      },
+      {
+        id: 'full-card',
+        title: 'Full Card',
+        width: 400,
+        height: 275,
+      },
+      {
+        id: 'expanded-card',
+        title: 'Expanded Card',
+        width: 400,
+        height: 445,
+      },
+    ],
+  },
+];
+
+export const FITTED_FORMAT_SIZES = FITTED_FORMATS.flatMap(
+  (group) => group.specs,
+);
+
+export const fittedFormatIds = FITTED_FORMAT_SIZES.flatMap(
+  (formatSpec) => formatSpec.id,
+);
+
+export const fittedFormatById: ReadonlyMap<FittedFormatId, FittedFormatSpec> =
+  new Map<FittedFormatId, FittedFormatSpec>(
+    FITTED_FORMAT_SIZES.map((format) => [format.id, format]),
+  );

--- a/packages/boxel-ui/addon/src/utils/fitted-formats.ts
+++ b/packages/boxel-ui/addon/src/utils/fitted-formats.ts
@@ -17,10 +17,10 @@ export type FittedFormatId =
   | 'triple-wide-strip';
 
 export type FittedFormatSpec = {
+  height: number;
   id: FittedFormatId;
   title: string;
   width: number;
-  height: number;
 };
 
 type FittedFormatGallery = ReadonlyArray<{

--- a/packages/host/app/components/card-catalog/modal.gts
+++ b/packages/host/app/components/card-catalog/modal.gts
@@ -120,7 +120,6 @@ export default class CardCatalogModal extends Component<Signature> {
               @selectedCard={{this.state.selectedCard}}
               @baseFilter={{this.state.baseFilter}}
               @offerToCreate={{this.offerToCreateArg}}
-              @showRecents={{false}}
             />
           </:content>
           <:footer>

--- a/packages/host/app/components/card-search/item-button.gts
+++ b/packages/host/app/components/card-search/item-button.gts
@@ -9,7 +9,6 @@ import { IconPlus } from '@cardstack/boxel-ui/icons';
 
 import { isCardInstance } from '@cardstack/runtime-common';
 
-import { urlForRealmLookup } from '@cardstack/host/lib/utils';
 import type RealmService from '@cardstack/host/services/realm';
 
 import type { CardDef } from 'https://cardstack.com/base/card-api';
@@ -96,13 +95,6 @@ export default class ItemButton extends Component<Signature> {
     return this.args.itemId ?? this.cardItem?.id;
   }
 
-  private get urlForRealmLookup(): string | undefined {
-    if (!this.args.displayRealmName) {
-      return undefined;
-    }
-    return this.cardItem ? urlForRealmLookup(this.cardItem) : this.args.itemId;
-  }
-
   @action handleClick() {
     this.args.onSelect(this.selectPayload);
   }
@@ -120,75 +112,41 @@ export default class ItemButton extends Component<Signature> {
   }
 
   <template>
-    {{#if this.isNewCard}}
-      <Button
-        class={{cn 'create-card' 'catalog-item' selected=@isSelected}}
-        {{on 'click' this.handleClick}}
-        {{on 'dblclick' this.handleDblClick}}
-        {{on 'keydown' this.handleKeydown}}
-        data-test-card-catalog-create-new-button={{this.newCardItem.realmURL}}
-        data-test-card-catalog-item-selected={{if @isSelected 'true'}}
-        ...attributes
-      >
-        <IconPlus
-          class='plus-icon'
-          width='16'
-          height='16'
-          role='presentation'
+    <Button
+      class={{cn 'catalog-item' selected=@isSelected compact=@isCompact}}
+      {{on 'click' this.handleClick}}
+      {{on 'dblclick' this.handleDblClick}}
+      {{on 'keydown' this.handleKeydown}}
+      data-test-card-catalog-create-new-button={{this.newCardItem.realmURL}}
+      data-test-card-catalog-item={{removeFileExtension this.resolvedItemId}}
+      data-test-card-catalog-item-selected={{if @isSelected 'true'}}
+      ...attributes
+    >
+      {{#if this.isNewCard}}
+        <div class='create-card'>
+          <IconPlus
+            class='plus-icon'
+            width='16'
+            height='16'
+            role='presentation'
+          />
+          Create New
+          {{this.cardRefName}}
+        </div>
+      {{else if this.componentItem}}
+        <this.componentItem
+          data-test-search-result={{removeFileExtension this.resolvedItemId}}
         />
-        Create New
-        {{this.cardRefName}}
-      </Button>
-    {{else}}
-      <div class='item-button-container'>
-        {{#if this.componentItem}}
-          <Button
-            class={{cn 'catalog-item' selected=@isSelected compact=@isCompact}}
-            {{on 'click' this.handleClick}}
-            {{on 'dblclick' this.handleDblClick}}
-            {{on 'keydown' this.handleKeydown}}
-            data-test-card-catalog-item={{removeFileExtension
-              this.resolvedItemId
-            }}
-            data-test-card-catalog-item-selected={{if @isSelected 'true'}}
-            ...attributes
-          >
-            {{#let this.componentItem as |CardComponent|}}
-              <CardComponent
-                data-test-search-result={{removeFileExtension
-                  this.resolvedItemId
-                }}
-              />
-            {{/let}}
-          </Button>
-        {{else if this.cardItem}}
-          <Button
-            class={{cn 'catalog-item' selected=@isSelected compact=@isCompact}}
-            {{on 'click' this.handleClick}}
-            {{on 'dblclick' this.handleDblClick}}
-            {{on 'keydown' this.handleKeydown}}
-            data-test-card-catalog-item={{this.resolvedItemId}}
-            data-test-card-catalog-item-selected={{if @isSelected 'true'}}
-            ...attributes
-          >
-            <CardRenderer
-              @card={{this.cardItem}}
-              @format='fitted'
-              @codeRef={{resultsCardRef}}
-              data-test-search-result={{removeFileExtension
-                this.resolvedItemId
-              }}
-            />
-          </Button>
-        {{/if}}
-        {{#if this.urlForRealmLookup}}
-          {{#let (this.realm.info this.urlForRealmLookup) as |realmInfo|}}
-            <div class='realm-name' data-test-realm-name>in
-              {{realmInfo.name}}</div>
-          {{/let}}
-        {{/if}}
-      </div>
-    {{/if}}
+      {{else if this.cardItem}}
+        <CardRenderer
+          @card={{this.cardItem}}
+          @format='fitted'
+          @codeRef={{resultsCardRef}}
+          @displayContainer={{false}}
+          data-test-search-result={{removeFileExtension this.resolvedItemId}}
+        />
+      {{/if}}
+    </Button>
     <style scoped>
       .catalog-item {
         --boxel-button-padding: 0;
@@ -197,6 +155,7 @@ export default class ItemButton extends Component<Signature> {
         height: 100%;
         width: 100%;
         max-width: 100%;
+        text-align: start;
       }
       .catalog-item.selected {
         border-color: var(--boxel-highlight);
@@ -208,35 +167,14 @@ export default class ItemButton extends Component<Signature> {
       .catalog-item.selected:hover {
         border-color: var(--boxel-highlight);
       }
-      .create-card.catalog-item {
-        --boxel-button-padding: var(--boxel-sp-xs) var(--boxel-sp);
-        --boxel-button-letter-spacing: var(--boxel-lsp-xs);
+      .create-card {
+        display: flex;
         gap: var(--boxel-sp-xs);
         flex-wrap: nowrap;
-        justify-content: flex-start;
-        height: var(--item-height, 67px);
-        width: 100%;
-        max-width: 100%;
+        letter-spacing: var(--boxel-lsp-xs);
       }
       .plus-icon > :deep(path) {
         stroke: none;
-      }
-      .item-button-container {
-        display: flex;
-        flex-direction: column;
-        align-items: self-end;
-        width: 100%;
-        height: 100%;
-        max-width: 100%;
-        max-height: 100%;
-      }
-      .realm-name {
-        font: 400 var(--boxel-font);
-        color: var(--boxel-400);
-        padding-top: var(--boxel-sp-4xs);
-        padding-right: var(--boxel-sp-xxs);
-        height: 20px;
-        font-size: var(--boxel-font-size-xs);
       }
     </style>
   </template>

--- a/packages/host/app/components/card-search/item-button.gts
+++ b/packages/host/app/components/card-search/item-button.gts
@@ -113,7 +113,13 @@ export default class ItemButton extends Component<Signature> {
 
   <template>
     <Button
-      class={{cn 'catalog-item' selected=@isSelected compact=@isCompact}}
+      @rectangular={{true}}
+      class={{cn
+        'catalog-item'
+        selected=@isSelected
+        compact=@isCompact
+        create-new-button=this.isNewCard
+      }}
       {{on 'click' this.handleClick}}
       {{on 'dblclick' this.handleDblClick}}
       {{on 'keydown' this.handleKeydown}}
@@ -123,16 +129,14 @@ export default class ItemButton extends Component<Signature> {
       ...attributes
     >
       {{#if this.isNewCard}}
-        <div class='create-card'>
-          <IconPlus
-            class='plus-icon'
-            width='16'
-            height='16'
-            role='presentation'
-          />
-          Create New
-          {{this.cardRefName}}
-        </div>
+        <IconPlus
+          class='plus-icon'
+          width='16'
+          height='16'
+          role='presentation'
+        />
+        Create New
+        {{this.cardRefName}}
       {{else if this.componentItem}}
         <this.componentItem
           class='hide-boundaries'
@@ -150,34 +154,40 @@ export default class ItemButton extends Component<Signature> {
     </Button>
     <style scoped>
       .catalog-item {
-        --boxel-button-padding: 0;
-        --boxel-button-border-radius: var(--boxel-border-radius);
-        --boxel-button-border: 1px solid var(--boxel-200);
         height: 100%;
         width: 100%;
         max-width: 100%;
+      }
+      .catalog-item:not(.create-new-button) {
+        --boxel-button-padding: 0;
+
+        box-sizing: content-box;
         text-align: start;
+      }
+      .catalog-item :deep(*) {
+        box-sizing: border-box;
+      }
+      .catalog-item:focus {
+        --host-outline-offset: -1px;
       }
       .catalog-item.selected {
         border-color: var(--boxel-highlight);
         box-shadow: 0 0 0 1px var(--boxel-highlight);
       }
       .catalog-item:hover {
-        border-color: var(--boxel-darker-hover);
+        box-shadow: var(--boxel-box-shadow);
       }
       .catalog-item.selected:hover {
         border-color: var(--boxel-highlight);
+        box-shadow:
+          0 0 0 1px var(--boxel-highlight),
+          var(--boxel-box-shadow);
       }
-      .catalog-item.compact {
-        box-sizing: content-box;
-      }
-      .catalog-item.compact :deep(*) {
-        box-sizing: border-box;
-      }
-      .create-card {
-        display: flex;
+
+      .create-new-button {
         gap: var(--boxel-sp-xs);
         flex-wrap: nowrap;
+        justify-content: flex-start;
         letter-spacing: var(--boxel-lsp-xs);
       }
       .plus-icon > :deep(path) {

--- a/packages/host/app/components/card-search/item-button.gts
+++ b/packages/host/app/components/card-search/item-button.gts
@@ -28,8 +28,6 @@ interface Signature {
     item: ItemType;
     itemId?: string;
     isSelected: boolean;
-    isCompact: boolean;
-    displayRealmName?: boolean;
     onSelect: (selection: string | NewCardArgs) => void;
     onSubmit?: (selection: string | NewCardArgs) => void;
   };
@@ -117,7 +115,6 @@ export default class ItemButton extends Component<Signature> {
       class={{cn
         'catalog-item'
         selected=@isSelected
-        compact=@isCompact
         create-new-button=this.isNewCard
       }}
       {{on 'click' this.handleClick}}

--- a/packages/host/app/components/card-search/item-button.gts
+++ b/packages/host/app/components/card-search/item-button.gts
@@ -135,6 +135,7 @@ export default class ItemButton extends Component<Signature> {
         </div>
       {{else if this.componentItem}}
         <this.componentItem
+          class='hide-boundaries'
           data-test-search-result={{removeFileExtension this.resolvedItemId}}
         />
       {{else if this.cardItem}}
@@ -166,6 +167,12 @@ export default class ItemButton extends Component<Signature> {
       }
       .catalog-item.selected:hover {
         border-color: var(--boxel-highlight);
+      }
+      .catalog-item.compact {
+        box-sizing: content-box;
+      }
+      .catalog-item.compact :deep(*) {
+        box-sizing: border-box;
       }
       .create-card {
         display: flex;

--- a/packages/host/app/components/card-search/item-button.gts
+++ b/packages/host/app/components/card-search/item-button.gts
@@ -140,7 +140,7 @@ export default class ItemButton extends Component<Signature> {
         {{this.cardRefName}}
       </Button>
     {{else}}
-      <div class={{cn 'item-button-container' compact=@isCompact}}>
+      <div class='item-button-container'>
         {{#if this.componentItem}}
           <Button
             class={{cn 'catalog-item' selected=@isSelected compact=@isCompact}}
@@ -155,7 +155,6 @@ export default class ItemButton extends Component<Signature> {
           >
             {{#let this.componentItem as |CardComponent|}}
               <CardComponent
-                class='hide-boundaries'
                 data-test-search-result={{removeFileExtension
                   this.resolvedItemId
                 }}
@@ -179,16 +178,13 @@ export default class ItemButton extends Component<Signature> {
               data-test-search-result={{removeFileExtension
                 this.resolvedItemId
               }}
-              class='hide-boundaries'
             />
           </Button>
         {{/if}}
         {{#if this.urlForRealmLookup}}
           {{#let (this.realm.info this.urlForRealmLookup) as |realmInfo|}}
-            <div
-              class='realm-name'
-              data-test-realm-name
-            >{{realmInfo.name}}</div>
+            <div class='realm-name' data-test-realm-name>in
+              {{realmInfo.name}}</div>
           {{/let}}
         {{/if}}
       </div>
@@ -198,14 +194,9 @@ export default class ItemButton extends Component<Signature> {
         --boxel-button-padding: 0;
         --boxel-button-border-radius: var(--boxel-border-radius);
         --boxel-button-border: 1px solid var(--boxel-200);
-        height: var(--item-height, 67px);
+        height: 100%;
         width: 100%;
         max-width: 100%;
-        overflow: hidden;
-        container-name: fitted-card;
-        container-type: size;
-        display: flex;
-        text-align: left;
       }
       .catalog-item.selected {
         border-color: var(--boxel-highlight);
@@ -216,10 +207,6 @@ export default class ItemButton extends Component<Signature> {
       }
       .catalog-item.selected:hover {
         border-color: var(--boxel-highlight);
-      }
-      .catalog-item.compact {
-        width: var(--item-width, 250px);
-        height: var(--item-height, 40px);
       }
       .create-card.catalog-item {
         --boxel-button-padding: var(--boxel-sp-xs) var(--boxel-sp);
@@ -239,6 +226,9 @@ export default class ItemButton extends Component<Signature> {
         flex-direction: column;
         align-items: self-end;
         width: 100%;
+        height: 100%;
+        max-width: 100%;
+        max-height: 100%;
       }
       .realm-name {
         font: 400 var(--boxel-font);

--- a/packages/host/app/components/card-search/search-content.gts
+++ b/packages/host/app/components/card-search/search-content.gts
@@ -318,6 +318,9 @@ export default class SearchContent extends Component<Signature> {
     if (!cards) {
       return [];
     }
+    if (this.args.isCompact) {
+      return cards;
+    }
     let filtered = cards;
     const term = this.searchTerm;
     if (term) {
@@ -617,17 +620,8 @@ export default class SearchContent extends Component<Signature> {
         {{#if this.recentCardsSection}}
           <SearchResultSection
             @section={{this.recentCardsSection}}
-            @viewOption={{this.activeViewId}}
-            @isCompact={{@isCompact}}
+            @isCompact={{true}}
             @handleSelect={{@handleSelect}}
-            @isFocused={{eq this.focusedSection this.recentCardsSection.sid}}
-            @isCollapsed={{this.isSectionCollapsed this.recentCardsSection.sid}}
-            @onFocusSection={{this.onFocusSection}}
-            @getDisplayedCount={{this.getDisplayedCount}}
-            @onShowMore={{this.onShowMore}}
-            @selectedCard={{@selectedCard}}
-            @offerToCreate={{@offerToCreate}}
-            @onSubmit={{@onSubmit}}
             data-test-search-result-section='recent-cards'
           />
         {{/if}}
@@ -637,7 +631,6 @@ export default class SearchContent extends Component<Signature> {
           <SearchResultSection
             @section={{section}}
             @viewOption={{this.activeViewId}}
-            @isCompact={{@isCompact}}
             @handleSelect={{@handleSelect}}
             @isFocused={{eq this.focusedSection section.sid}}
             @isCollapsed={{this.isSectionCollapsed section.sid}}

--- a/packages/host/app/components/card-search/search-content.gts
+++ b/packages/host/app/components/card-search/search-content.gts
@@ -318,10 +318,14 @@ export default class SearchContent extends Component<Signature> {
     if (!cards) {
       return [];
     }
+    const realms = this.realms;
+    const realmFiltered = cards.filter(
+      (c) => c.id && realms.some((realmUrl) => c.id.startsWith(realmUrl)),
+    );
     if (this.args.isCompact) {
-      return cards;
+      return realmFiltered;
     }
-    let filtered = cards;
+    let filtered = realmFiltered;
     const term = this.searchTerm;
     if (term) {
       const lowerTerm = term.toLowerCase();

--- a/packages/host/app/components/card-search/search-content.gts
+++ b/packages/host/app/components/card-search/search-content.gts
@@ -96,7 +96,6 @@ interface Signature {
       relativeTo: URL | undefined;
     };
     onSubmit?: (selection: string | NewCardArgs) => void;
-    showRecents?: boolean;
     showHeader?: boolean;
   };
   Blocks: {};
@@ -155,10 +154,6 @@ export default class SearchContent extends Component<Signature> {
     }
     // In search-sheet mode, skip when empty or URL
     return this.isSearchKeyEmpty || this.searchKeyIsURL;
-  }
-
-  private get showRecents() {
-    return this.args.showRecents !== false;
   }
 
   private get showHeader() {
@@ -291,10 +286,7 @@ export default class SearchContent extends Component<Signature> {
     }
 
     // Recents view (empty search or focused on recents)
-    if (
-      (this.focusedSection === 'recents' || this.isSearchKeyEmpty) &&
-      this.showRecents
-    ) {
+    if (this.focusedSection === 'recents' || this.isSearchKeyEmpty) {
       const count = this.recentCardsSection?.totalCount ?? 0;
       return `${count} in ${pluralize('Recent', count)}`;
     }
@@ -529,8 +521,8 @@ export default class SearchContent extends Component<Signature> {
   private get sections(): SearchSheetSection[] {
     const sections: SearchSheetSection[] = [];
 
-    // Add recents section if enabled
-    if (this.showRecents && this.recentCardsSection) {
+    // Add recents section if present
+    if (this.recentCardsSection) {
       sections.push(this.recentCardsSection);
     }
 

--- a/packages/host/app/components/card-search/search-content.gts
+++ b/packages/host/app/components/card-search/search-content.gts
@@ -529,6 +529,11 @@ export default class SearchContent extends Component<Signature> {
   private get sections(): SearchSheetSection[] {
     const sections: SearchSheetSection[] = [];
 
+    // Add recents section if enabled
+    if (this.showRecents && this.recentCardsSection) {
+      sections.push(this.recentCardsSection);
+    }
+
     // Add URL section if present
     if (this.cardByUrlSection) {
       sections.push(this.cardByUrlSection);
@@ -537,11 +542,6 @@ export default class SearchContent extends Component<Signature> {
     // Add query sections if present
     if (this.cardsByQuerySection) {
       sections.push(...this.cardsByQuerySection);
-    }
-
-    // Add recents section if enabled
-    if (this.showRecents && this.recentCardsSection) {
-      sections.push(this.recentCardsSection);
     }
 
     return sections;
@@ -621,24 +621,44 @@ export default class SearchContent extends Component<Signature> {
         {{/if}}
       {{/if}}
 
-      {{! Render all sections }}
-      {{#each this.sections as |section i|}}
-        <SearchResultSection
-          @section={{section}}
-          @viewOption={{this.activeViewId}}
-          @isCompact={{@isCompact}}
-          @handleSelect={{@handleSelect}}
-          @isFocused={{eq this.focusedSection section.sid}}
-          @isCollapsed={{this.isSectionCollapsed section.sid}}
-          @onFocusSection={{this.onFocusSection}}
-          @getDisplayedCount={{this.getDisplayedCount}}
-          @onShowMore={{this.onShowMore}}
-          @selectedCard={{@selectedCard}}
-          @offerToCreate={{@offerToCreate}}
-          @onSubmit={{@onSubmit}}
-          data-test-search-result-section={{i}}
-        />
-      {{/each}}
+      {{#if @isCompact}}
+        {{#if this.recentCardsSection}}
+          <SearchResultSection
+            @section={{this.recentCardsSection}}
+            @viewOption={{this.activeViewId}}
+            @isCompact={{@isCompact}}
+            @handleSelect={{@handleSelect}}
+            @isFocused={{eq this.focusedSection this.recentCardsSection.sid}}
+            @isCollapsed={{this.isSectionCollapsed this.recentCardsSection.sid}}
+            @onFocusSection={{this.onFocusSection}}
+            @getDisplayedCount={{this.getDisplayedCount}}
+            @onShowMore={{this.onShowMore}}
+            @selectedCard={{@selectedCard}}
+            @offerToCreate={{@offerToCreate}}
+            @onSubmit={{@onSubmit}}
+            data-test-search-result-section='recent-cards'
+          />
+        {{/if}}
+      {{else}}
+        {{! Render all sections }}
+        {{#each this.sections as |section i|}}
+          <SearchResultSection
+            @section={{section}}
+            @viewOption={{this.activeViewId}}
+            @isCompact={{@isCompact}}
+            @handleSelect={{@handleSelect}}
+            @isFocused={{eq this.focusedSection section.sid}}
+            @isCollapsed={{this.isSectionCollapsed section.sid}}
+            @onFocusSection={{this.onFocusSection}}
+            @getDisplayedCount={{this.getDisplayedCount}}
+            @onShowMore={{this.onShowMore}}
+            @selectedCard={{@selectedCard}}
+            @offerToCreate={{@offerToCreate}}
+            @onSubmit={{@onSubmit}}
+            data-test-search-result-section={{i}}
+          />
+        {{/each}}
+      {{/if}}
 
       {{#if this.hasNoResults}}
         <div class='empty-state' data-test-search-content-empty>

--- a/packages/host/app/components/card-search/search-result-section.gts
+++ b/packages/host/app/components/card-search/search-result-section.gts
@@ -31,12 +31,12 @@ interface Signature {
   Element: HTMLElement;
   Args: {
     section: SearchSheetSection;
-    viewOption: string;
-    isCompact: boolean;
+    viewOption?: string;
+    isCompact?: boolean;
     handleSelect: (selection: string | NewCardArgs) => void;
-    isFocused: boolean;
-    isCollapsed: boolean;
-    onFocusSection: (sectionId: string | null) => void;
+    isFocused?: boolean;
+    isCollapsed?: boolean;
+    onFocusSection?: (sectionId: string | null) => void;
     getDisplayedCount?: (sectionId: string, totalCount: number) => number;
     onShowMore?: (sectionId: string, totalCount: number) => void;
     selectedCard?: string | NewCardArgs;
@@ -111,6 +111,10 @@ export default class SearchResultSection extends Component<Signature> {
   get displayedRecentsCards() {
     const section = this.recentsSection;
     if (!section) return [];
+    if (this.args.isCompact) {
+      // do not limit the cards in the quick menu and keep last-updated sort order
+      return section.cards;
+    }
     const sid = this.args.section.sid;
     const getDisplayedCount = this.args.getDisplayedCount;
     if (!sid || !getDisplayedCount) return section.cards;
@@ -157,6 +161,10 @@ export default class SearchResultSection extends Component<Signature> {
     } else {
       return 'strip-view';
     }
+  }
+
+  get viewFormat() {
+    return this.viewClass === 'grid-view' ? 'grid' : 'list';
   }
 
   get displayShowMore() {
@@ -211,19 +219,17 @@ export default class SearchResultSection extends Component<Signature> {
       ...attributes
     >
       {{#if this.realmSection}}
-        {{#unless @isCompact}}
-          <SearchSheetSectionHeader
-            @realmInfo={{this.realmSection.realmInfo}}
-            @title={{this.realmSection.realmInfo.name}}
-            @totalCount={{this.realmSection.totalCount}}
-            @showOnlyLabel={{this.realmSection.realmInfo.name}}
-            @showOnlyChecked={{@isFocused}}
-            @onShowOnlyChange={{this.handleShowOnlyChange}}
-          />
-        {{/unless}}
+        <SearchSheetSectionHeader
+          @realmInfo={{this.realmSection.realmInfo}}
+          @title={{this.realmSection.realmInfo.name}}
+          @totalCount={{this.realmSection.totalCount}}
+          @showOnlyLabel={{this.realmSection.realmInfo.name}}
+          @showOnlyChecked={{@isFocused}}
+          @onShowOnlyChange={{this.handleShowOnlyChange}}
+        />
         <GridContainer
           class='cards {{this.viewClass}}'
-          @viewFormat={{if (eq this.viewClass 'grid-view') 'grid' 'list'}}
+          @viewFormat={{this.viewFormat}}
           @size={{this.cardSize}}
           data-test-search-cards-result
         >
@@ -231,7 +237,6 @@ export default class SearchResultSection extends Component<Signature> {
             <ItemButton
               @item={{this.newCardArgs this.realmSection.realmUrl}}
               @isSelected={{this.isCreateNewSelected}}
-              @isCompact={{@isCompact}}
               @onSelect={{@handleSelect}}
               @onSubmit={{@onSubmit}}
             />
@@ -242,8 +247,6 @@ export default class SearchResultSection extends Component<Signature> {
                 @item={{card.component}}
                 @itemId={{card.url}}
                 @isSelected={{eq this.selectedCardId card.url}}
-                @isCompact={{@isCompact}}
-                @displayRealmName={{@isCompact}}
                 @onSelect={{@handleSelect}}
                 @onSubmit={{@onSubmit}}
                 data-test-search-sheet-search-result={{i}}
@@ -269,24 +272,20 @@ export default class SearchResultSection extends Component<Signature> {
           </Button>
         {{/if}}
       {{else if this.urlSection}}
-        {{#unless @isCompact}}
-          <SearchSheetSectionHeader
-            @realmInfo={{this.urlSection.realmInfo}}
-            @title={{this.urlSection.realmInfo.name}}
-            @totalCount={{1}}
-          />
-        {{/unless}}
+        <SearchSheetSectionHeader
+          @realmInfo={{this.urlSection.realmInfo}}
+          @title={{this.urlSection.realmInfo.name}}
+          @totalCount={{1}}
+        />
         <GridContainer
           class='cards {{this.viewClass}}'
-          @viewFormat={{if (eq this.viewClass 'grid-view') 'grid' 'list'}}
+          @viewFormat={{this.viewFormat}}
           @size={{this.cardSize}}
         >
           <ItemButton
             @item={{this.urlSection.card}}
             @itemId={{this.urlSection.card.id}}
             @isSelected={{eq this.selectedCardId this.urlSection.card.id}}
-            @isCompact={{@isCompact}}
-            @displayRealmName={{@isCompact}}
             @onSelect={{@handleSelect}}
             @onSubmit={{@onSubmit}}
             data-test-search-sheet-search-result='0'
@@ -307,19 +306,17 @@ export default class SearchResultSection extends Component<Signature> {
         <GridContainer
           class='cards {{this.viewClass}}'
           @items={{this.displayedRecentsCards}}
-          @viewFormat={{if (eq this.viewClass 'grid-view') 'grid' 'list'}}
+          @viewFormat={{this.viewFormat}}
           @size={{this.cardSize}}
           @fullWidthItem={{eq this.viewClass 'strip-view'}}
           as |card GridItem i|
         >
-          <GridItem class={{if @isCompact 'item-button-container'}}>
+          <GridItem class={{if @isCompact 'recent-card-item--compact'}}>
             <:default>
               <ItemButton
                 @item={{card}}
                 @itemId={{card.id}}
                 @isSelected={{eq this.selectedCardId card.id}}
-                @isCompact={{@isCompact}}
-                @displayRealmName={{true}}
                 @onSelect={{@handleSelect}}
                 @onSubmit={{@onSubmit}}
                 data-test-search-result-index={{i}}
@@ -334,8 +331,8 @@ export default class SearchResultSection extends Component<Signature> {
                   <div
                     class={{cn
                       'realm-name'
-                      boxel-ellipsize=@isCompact
                       realm-name--compact=@isCompact
+                      boxel-ellipsize=@isCompact
                     }}
                     data-test-realm-name
                   >
@@ -386,12 +383,6 @@ export default class SearchResultSection extends Component<Signature> {
       .search-result-block.collapsed .show-more {
         display: none;
       }
-      .compact-view {
-        display: flex;
-        flex-flow: row nowrap;
-        gap: var(--boxel-sp-xs);
-        padding: var(--boxel-sp-xs) 0;
-      }
       .grid-view :deep(.create-new-button) {
         flex-direction: column;
         justify-content: center;
@@ -400,16 +391,22 @@ export default class SearchResultSection extends Component<Signature> {
         margin-top: var(--boxel-sp);
         width: fit-content;
       }
-      .item-button-container {
-        display: flex;
-        flex-direction: column;
-        align-items: self-end;
-      }
       .realm-name {
         padding-top: var(--boxel-sp-4xs);
         color: var(--boxel-450);
         font-size: var(--boxel-font-size-xs);
         font-weight: 500;
+      }
+      .compact-view {
+        display: flex;
+        flex-flow: row nowrap;
+        gap: var(--boxel-sp-xs);
+        padding: var(--boxel-sp-xs) 0;
+      }
+      .recent-card-item--compact {
+        display: flex;
+        flex-direction: column;
+        align-items: self-end;
       }
       .realm-name--compact {
         max-width: 15rem;

--- a/packages/host/app/components/card-search/search-result-section.gts
+++ b/packages/host/app/components/card-search/search-result-section.gts
@@ -7,7 +7,11 @@ import Component from '@glimmer/component';
 import HistoryIcon from '@cardstack/boxel-icons/history';
 import pluralize from 'pluralize';
 
-import { Button } from '@cardstack/boxel-ui/components';
+import {
+  Button,
+  GridContainer,
+  FittedCardContainer,
+} from '@cardstack/boxel-ui/components';
 import { eq } from '@cardstack/boxel-ui/helpers';
 
 import type { CodeRef } from '@cardstack/runtime-common';
@@ -211,7 +215,10 @@ export default class SearchResultSection extends Component<Signature> {
             @onShowOnlyChange={{this.handleShowOnlyChange}}
           />
         {{/unless}}
-        <div class='cards {{this.viewClass}}' data-test-search-cards-result>
+        <GridContainer
+          @size={{if @isCompact 'single-strip' 'cardsgrid-tile'}}
+          data-test-search-cards-result
+        >
           {{#if (this.showCreateForRealm this.realmSection.realmUrl)}}
             <ItemButton
               @item={{this.newCardArgs this.realmSection.realmUrl}}
@@ -235,7 +242,7 @@ export default class SearchResultSection extends Component<Signature> {
               />
             {{/unless}}
           {{/each}}
-        </div>
+        </GridContainer>
         {{#if this.displayShowMore}}
           <Button
             class='show-more'
@@ -261,7 +268,7 @@ export default class SearchResultSection extends Component<Signature> {
             @totalCount={{1}}
           />
         {{/unless}}
-        <div class='cards {{this.viewClass}}'>
+        <GridContainer @size={{if @isCompact 'single-strip' 'cardsgrid-tile'}}>
           <ItemButton
             @item={{this.urlSection.card}}
             @itemId={{this.urlSection.card.id}}
@@ -272,7 +279,7 @@ export default class SearchResultSection extends Component<Signature> {
             @onSubmit={{@onSubmit}}
             data-test-search-sheet-search-result='0'
           />
-        </div>
+        </GridContainer>
       {{else if this.recentsSection}}
         {{#unless @isCompact}}
           <SearchSheetSectionHeader
@@ -284,22 +291,30 @@ export default class SearchResultSection extends Component<Signature> {
             @onShowOnlyChange={{this.handleShowOnlyChange}}
           />
         {{/unless}}
-        <div class='cards {{this.viewClass}}'>
+
+        <GridContainer
+          class={{if @isCompact 'recent-cards--strip'}}
+          @size={{if @isCompact 'single-strip' 'cardsgrid-tile'}}
+        >
           {{#each this.displayedRecentsCards as |card i|}}
             {{#if card}}
-              <ItemButton
-                @item={{card}}
-                @itemId={{card.id}}
-                @isSelected={{eq this.selectedCardId card.id}}
-                @isCompact={{@isCompact}}
-                @displayRealmName={{true}}
-                @onSelect={{@handleSelect}}
-                @onSubmit={{@onSubmit}}
-                data-test-search-result-index={{i}}
-              />
+              <FittedCardContainer
+                @size={{if @isCompact 'single-strip' 'cardsgrid-tile'}}
+              >
+                <ItemButton
+                  @item={{card}}
+                  @itemId={{card.id}}
+                  @isSelected={{eq this.selectedCardId card.id}}
+                  @isCompact={{@isCompact}}
+                  @displayRealmName={{true}}
+                  @onSelect={{@handleSelect}}
+                  @onSubmit={{@onSubmit}}
+                  data-test-search-result-index={{i}}
+                />
+              </FittedCardContainer>
             {{/if}}
           {{/each}}
-        </div>
+        </GridContainer>
         {{#if this.displayShowMore}}
           <Button
             class='show-more'
@@ -342,24 +357,18 @@ export default class SearchResultSection extends Component<Signature> {
         --gap: var(--boxel-sp);
         gap: var(--gap);
       }
-      .cards.compact-view {
-        --item-width: 250px;
-        --item-height: 40px;
+      .recent-cards--strip {
         display: flex;
         flex-wrap: nowrap;
         gap: var(--boxel-sp-xs);
         padding: var(--boxel-sp-xs) 0;
       }
       .cards.grid-view {
-        --item-width: 186.2px;
-        --item-height: 244px;
         display: grid;
         grid-template-columns: repeat(auto-fill, var(--item-width));
         align-content: start;
       }
       .cards.strip-view {
-        --item-height: 65px;
-        --item-width: 100%;
         display: grid;
         grid-template-columns: 1fr;
         align-content: start;

--- a/packages/host/app/components/card-search/search-result-section.gts
+++ b/packages/host/app/components/card-search/search-result-section.gts
@@ -372,7 +372,7 @@ export default class SearchResultSection extends Component<Signature> {
         margin-bottom: var(--boxel-sp-lg);
       }
       .search-result-block.collapsed {
-        opacity: 0.6;
+        display: none;
       }
       .search-result-block.collapsed :deep(.search-sheet-section-header) {
         margin-bottom: 0;

--- a/packages/host/app/components/card-search/search-result-section.gts
+++ b/packages/host/app/components/card-search/search-result-section.gts
@@ -8,7 +8,7 @@ import HistoryIcon from '@cardstack/boxel-icons/history';
 import pluralize from 'pluralize';
 
 import { Button, GridContainer } from '@cardstack/boxel-ui/components';
-import { cn, eq } from '@cardstack/boxel-ui/helpers';
+import { cn, eq, type FittedFormatId } from '@cardstack/boxel-ui/helpers';
 
 import type { CodeRef } from '@cardstack/runtime-common';
 
@@ -202,7 +202,7 @@ export default class SearchResultSection extends Component<Signature> {
     };
   };
 
-  private get cardSize() {
+  private get cardSize(): FittedFormatId {
     if (this.viewClass === 'compact-view') {
       return 'single-strip';
     } else if (this.viewClass === 'strip-view') {
@@ -214,7 +214,10 @@ export default class SearchResultSection extends Component<Signature> {
 
   <template>
     <div
-      class='search-result-block {{if @isCollapsed "collapsed"}}'
+      class={{cn
+        'search-result-block'
+        search-result-block--collapsed=@isCollapsed
+      }}
       data-test-realm={{this.sectionRealmName}}
       ...attributes
     >
@@ -371,16 +374,16 @@ export default class SearchResultSection extends Component<Signature> {
         flex-direction: column;
         margin-bottom: var(--boxel-sp-lg);
       }
-      .search-result-block.collapsed {
+      .search-result-block--collapsed {
         opacity: 0.6;
       }
-      .search-result-block.collapsed :deep(.search-sheet-section-header) {
+      .search-result-block--collapsed :deep(.search-sheet-section-header) {
         margin-bottom: 0;
         padding-bottom: var(--boxel-sp-lg);
         border-bottom: 1px solid var(--boxel-400);
       }
-      .search-result-block.collapsed .cards,
-      .search-result-block.collapsed .show-more {
+      .search-result-block--collapsed .cards,
+      .search-result-block--collapsed .show-more {
         display: none;
       }
       .grid-view :deep(.create-new-button) {

--- a/packages/host/app/components/card-search/search-result-section.gts
+++ b/packages/host/app/components/card-search/search-result-section.gts
@@ -4,18 +4,17 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
+import type { CardDef } from 'https://cardstack.com/base/card-api';
+
 import HistoryIcon from '@cardstack/boxel-icons/history';
 import pluralize from 'pluralize';
 
-import {
-  Button,
-  GridContainer,
-  FittedCardContainer,
-} from '@cardstack/boxel-ui/components';
+import { Button, GridContainer } from '@cardstack/boxel-ui/components';
 import { eq } from '@cardstack/boxel-ui/helpers';
 
 import type { CodeRef } from '@cardstack/runtime-common';
 
+import { urlForRealmLookup } from '@cardstack/host/lib/utils';
 import type RealmService from '@cardstack/host/services/realm';
 
 import { SECTION_SHOW_MORE_INCREMENT } from './constants';
@@ -157,10 +156,9 @@ export default class SearchResultSection extends Component<Signature> {
         this.urlSection)
     ) {
       return 'grid-view';
-    } else if (this.args.viewOption === 'strip') {
+    } else {
       return 'strip-view';
     }
-    return '';
   }
 
   get displayShowMore() {
@@ -198,6 +196,20 @@ export default class SearchResultSection extends Component<Signature> {
     };
   };
 
+  private get cardSize() {
+    if (this.viewClass === 'compact-view') {
+      return 'single-strip';
+    } else if (this.viewClass === 'strip-view') {
+      return 'double-wide-strip';
+    } else {
+      return 'cardsgrid-tile';
+    }
+  }
+
+  private urlForRealmLookup = (card: CardDef) => {
+    return urlForRealmLookup(card);
+  };
+
   <template>
     <div
       class='search-result-block {{if @isCollapsed "collapsed"}}'
@@ -216,7 +228,8 @@ export default class SearchResultSection extends Component<Signature> {
           />
         {{/unless}}
         <GridContainer
-          @size={{if @isCompact 'single-strip' 'cardsgrid-tile'}}
+          @viewFormat={{if (eq this.viewClass 'grid-view') 'grid' 'list'}}
+          @size={{this.cardSize}}
           data-test-search-cards-result
         >
           {{#if (this.showCreateForRealm this.realmSection.realmUrl)}}
@@ -268,7 +281,10 @@ export default class SearchResultSection extends Component<Signature> {
             @totalCount={{1}}
           />
         {{/unless}}
-        <GridContainer @size={{if @isCompact 'single-strip' 'cardsgrid-tile'}}>
+        <GridContainer
+          @viewFormat={{if (eq this.viewClass 'grid-view') 'grid' 'list'}}
+          @size={{this.cardSize}}
+        >
           <ItemButton
             @item={{this.urlSection.card}}
             @itemId={{this.urlSection.card.id}}
@@ -294,27 +310,41 @@ export default class SearchResultSection extends Component<Signature> {
 
         <GridContainer
           class={{if @isCompact 'recent-cards--strip'}}
-          @size={{if @isCompact 'single-strip' 'cardsgrid-tile'}}
+          @items={{this.displayedRecentsCards}}
+          @viewFormat={{if (eq this.viewClass 'grid-view') 'grid' 'list'}}
+          @size={{this.cardSize}}
+          @fullWidthItem={{eq this.viewClass 'strip-view'}}
+          as |card GridItem i|
         >
-          {{#each this.displayedRecentsCards as |card i|}}
-            {{#if card}}
-              <FittedCardContainer
-                @size={{if @isCompact 'single-strip' 'cardsgrid-tile'}}
-              >
-                <ItemButton
-                  @item={{card}}
-                  @itemId={{card.id}}
-                  @isSelected={{eq this.selectedCardId card.id}}
-                  @isCompact={{@isCompact}}
-                  @displayRealmName={{true}}
-                  @onSelect={{@handleSelect}}
-                  @onSubmit={{@onSubmit}}
-                  data-test-search-result-index={{i}}
-                />
-              </FittedCardContainer>
-            {{/if}}
-          {{/each}}
+          <GridItem class={{if @isCompact 'item-button-container'}}>
+            <:default>
+              <ItemButton
+                @item={{card}}
+                @itemId={{card.id}}
+                @isSelected={{eq this.selectedCardId card.id}}
+                @isCompact={{@isCompact}}
+                @displayRealmName={{true}}
+                @onSelect={{@handleSelect}}
+                @onSubmit={{@onSubmit}}
+                data-test-search-result-index={{i}}
+              />
+            </:default>
+            <:after>
+              {{#if card}}
+                {{#let
+                  (this.realm.info (this.urlForRealmLookup card))
+                  as |realmInfo|
+                }}
+                  <div class='realm-name' data-test-realm-name>
+                    in
+                    {{realmInfo.name}}
+                  </div>
+                {{/let}}
+              {{/if}}
+            </:after>
+          </GridItem>
         </GridContainer>
+
         {{#if this.displayShowMore}}
           <Button
             class='show-more'
@@ -359,7 +389,7 @@ export default class SearchResultSection extends Component<Signature> {
       }
       .recent-cards--strip {
         display: flex;
-        flex-wrap: nowrap;
+        flex-flow: row nowrap;
         gap: var(--boxel-sp-xs);
         padding: var(--boxel-sp-xs) 0;
       }
@@ -383,6 +413,19 @@ export default class SearchResultSection extends Component<Signature> {
       .show-more {
         margin-top: var(--boxel-sp);
         width: fit-content;
+      }
+      .item-button-container {
+        display: flex;
+        flex-direction: column;
+        align-items: self-end;
+      }
+      .realm-name {
+        font: 400 var(--boxel-font);
+        color: var(--boxel-400);
+        padding-top: var(--boxel-sp-4xs);
+        padding-right: var(--boxel-sp-xxs);
+        height: 20px;
+        font-size: var(--boxel-font-size-xs);
       }
     </style>
   </template>

--- a/packages/host/app/components/card-search/search-result-section.gts
+++ b/packages/host/app/components/card-search/search-result-section.gts
@@ -4,13 +4,11 @@ import { action } from '@ember/object';
 import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
-import type { CardDef } from 'https://cardstack.com/base/card-api';
-
 import HistoryIcon from '@cardstack/boxel-icons/history';
 import pluralize from 'pluralize';
 
 import { Button, GridContainer } from '@cardstack/boxel-ui/components';
-import { eq } from '@cardstack/boxel-ui/helpers';
+import { cn, eq } from '@cardstack/boxel-ui/helpers';
 
 import type { CodeRef } from '@cardstack/runtime-common';
 
@@ -206,10 +204,6 @@ export default class SearchResultSection extends Component<Signature> {
     }
   }
 
-  private urlForRealmLookup = (card: CardDef) => {
-    return urlForRealmLookup(card);
-  };
-
   <template>
     <div
       class='search-result-block {{if @isCollapsed "collapsed"}}'
@@ -228,6 +222,7 @@ export default class SearchResultSection extends Component<Signature> {
           />
         {{/unless}}
         <GridContainer
+          class='cards {{this.viewClass}}'
           @viewFormat={{if (eq this.viewClass 'grid-view') 'grid' 'list'}}
           @size={{this.cardSize}}
           data-test-search-cards-result
@@ -282,6 +277,7 @@ export default class SearchResultSection extends Component<Signature> {
           />
         {{/unless}}
         <GridContainer
+          class='cards {{this.viewClass}}'
           @viewFormat={{if (eq this.viewClass 'grid-view') 'grid' 'list'}}
           @size={{this.cardSize}}
         >
@@ -309,7 +305,7 @@ export default class SearchResultSection extends Component<Signature> {
         {{/unless}}
 
         <GridContainer
-          class={{if @isCompact 'recent-cards--strip'}}
+          class='cards {{this.viewClass}}'
           @items={{this.displayedRecentsCards}}
           @viewFormat={{if (eq this.viewClass 'grid-view') 'grid' 'list'}}
           @size={{this.cardSize}}
@@ -332,10 +328,17 @@ export default class SearchResultSection extends Component<Signature> {
             <:after>
               {{#if card}}
                 {{#let
-                  (this.realm.info (this.urlForRealmLookup card))
+                  (this.realm.info (urlForRealmLookup card))
                   as |realmInfo|
                 }}
-                  <div class='realm-name' data-test-realm-name>
+                  <div
+                    class={{cn
+                      'realm-name'
+                      boxel-ellipsize=@isCompact
+                      realm-name--compact=@isCompact
+                    }}
+                    data-test-realm-name
+                  >
                     in
                     {{realmInfo.name}}
                   </div>
@@ -372,7 +375,7 @@ export default class SearchResultSection extends Component<Signature> {
         margin-bottom: var(--boxel-sp-lg);
       }
       .search-result-block.collapsed {
-        display: none;
+        opacity: 0.6;
       }
       .search-result-block.collapsed :deep(.search-sheet-section-header) {
         margin-bottom: 0;
@@ -383,32 +386,15 @@ export default class SearchResultSection extends Component<Signature> {
       .search-result-block.collapsed .show-more {
         display: none;
       }
-      .cards {
-        --gap: var(--boxel-sp);
-        gap: var(--gap);
-      }
-      .recent-cards--strip {
+      .compact-view {
         display: flex;
         flex-flow: row nowrap;
         gap: var(--boxel-sp-xs);
         padding: var(--boxel-sp-xs) 0;
       }
-      .cards.grid-view {
-        display: grid;
-        grid-template-columns: repeat(auto-fill, var(--item-width));
-        align-content: start;
-      }
-      .cards.strip-view {
-        display: grid;
-        grid-template-columns: 1fr;
-        align-content: start;
-      }
-      .cards.grid-view :deep(.create-card) {
-        display: flex;
+      .grid-view :deep(.create-new-button) {
         flex-direction: column;
-        align-items: center;
         justify-content: center;
-        height: 100%;
       }
       .show-more {
         margin-top: var(--boxel-sp);
@@ -420,12 +406,13 @@ export default class SearchResultSection extends Component<Signature> {
         align-items: self-end;
       }
       .realm-name {
-        font: 400 var(--boxel-font);
-        color: var(--boxel-400);
         padding-top: var(--boxel-sp-4xs);
-        padding-right: var(--boxel-sp-xxs);
-        height: 20px;
+        color: var(--boxel-450);
         font-size: var(--boxel-font-size-xs);
+        font-weight: 500;
+      }
+      .realm-name--compact {
+        max-width: 15rem;
       }
     </style>
   </template>

--- a/packages/host/app/components/card-search/search-result-section.gts
+++ b/packages/host/app/components/card-search/search-result-section.gts
@@ -312,7 +312,7 @@ export default class SearchResultSection extends Component<Signature> {
           @viewFormat={{this.viewFormat}}
           @size={{this.cardSize}}
           @fullWidthItem={{eq this.viewClass 'strip-view'}}
-          as |card GridItem i|
+          as |card GridItem|
         >
           <GridItem class={{if @isCompact 'recent-card-item--compact'}}>
             <:default>
@@ -322,7 +322,6 @@ export default class SearchResultSection extends Component<Signature> {
                 @isSelected={{eq this.selectedCardId card.id}}
                 @onSelect={{@handleSelect}}
                 @onSubmit={{@onSubmit}}
-                data-test-search-result-index={{i}}
               />
             </:default>
             <:after>

--- a/packages/host/app/services/recent-cards-service.ts
+++ b/packages/host/app/services/recent-cards-service.ts
@@ -62,7 +62,6 @@ export default class RecentCardsService extends Service {
   @cached
   // return in descending order: most recent to oldest
   get recentCardIds(): string[] {
-    console.log(this.recentCards);
     return this.recentCards.map((c) => c.cardId);
   }
 

--- a/packages/host/tests/integration/components/operator-mode-card-catalog-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-card-catalog-test.gts
@@ -74,17 +74,17 @@ module('Integration | operator-mode | card catalog', function (hooks) {
 
     await click(`[data-test-open-search-field]`);
 
-    await waitFor(`[data-test-search-result-index="0"]`);
-    await waitFor(`[data-test-search-result-index="1"]`);
+    await waitFor(`[data-test-grid-item-index="0"]`);
+    await waitFor(`[data-test-grid-item-index="1"]`);
     assert.dom(`[data-test-search-result]`).exists({ count: 2 });
     assert
       .dom(
-        `[data-test-search-result-index="0"] [data-test-search-result="${testRealmURL}Person/burcu"]`,
+        `[data-test-grid-item-index="0"] [data-test-search-result="${testRealmURL}Person/burcu"]`,
       )
       .exists();
     assert
       .dom(
-        `[data-test-search-result-index="1"] [data-test-search-result="${testRealmURL}Person/fadhlan"]`,
+        `[data-test-grid-item-index="1"] [data-test-search-result="${testRealmURL}Person/fadhlan"]`,
       )
       .exists();
   });
@@ -119,13 +119,31 @@ module('Integration | operator-mode | card catalog', function (hooks) {
 
     await click(`[data-test-open-search-field]`);
     await waitFor(`[data-test-search-result]`);
-    // New design: Recents section shows SECTION_DISPLAY_LIMIT_UNFOCUSED (5) initially in prompt mode; no Show more in compact
+
     assert
       .dom(`[data-test-search-result]`)
       .exists(
-        { count: 5 },
-        'recents capped at 10 total, initial display limit shows 5',
+        { count: 10 },
+        'recents capped at 10 total, search bar results are not capped',
       );
+    assert
+      .dom('[data-test-search-sheet] [data-test-grid-item-index="0"]')
+      .containsText('11', 'search bar results are sorted by most recent');
+
+    // expand search sheet
+    await fillIn('[data-test-search-field]', ' ');
+
+    const recents = '[data-test-search-result-section="0"]';
+    assert
+      .dom(`${recents} [data-test-search-sheet-section-header]`)
+      .containsText('Recents');
+    assert
+      .dom(`${recents} [data-test-card-catalog-item]`)
+      .exists(
+        { count: 5 },
+        'when expanded, recents results are capped at 5 with show more button',
+      );
+    assert.dom(`${recents} [data-test-search-sheet-show-more]`).exists();
   });
 
   test(`displays searching results`, async function (assert) {
@@ -713,7 +731,7 @@ module('Integration | operator-mode | card catalog', function (hooks) {
     await fillIn(`[data-test-search-field]`, 'man');
     await waitFor(`[data-test-search-result="${testRealmURL}Pet/mango"]`);
     assert
-      .dom(`[data-test-search-result-index]`)
+      .dom(`[data-test-grid-item-index]`)
       .exists({ count: 1 }, 'only 1 recent card matches "man"');
     assert
       .dom(`[data-test-search-result="${testRealmURL}Pet/mango"]`)
@@ -723,7 +741,7 @@ module('Integration | operator-mode | card catalog', function (hooks) {
     await fillIn(`[data-test-search-field]`, 'fadh');
     await waitFor(`[data-test-search-result="${testRealmURL}Person/fadhlan"]`);
     assert
-      .dom(`[data-test-search-result-index]`)
+      .dom(`[data-test-grid-item-index]`)
       .exists({ count: 1 }, 'only 1 recent card matches "fadh"');
     assert
       .dom(`[data-test-search-result="${testRealmURL}Person/fadhlan"]`)
@@ -733,7 +751,7 @@ module('Integration | operator-mode | card catalog', function (hooks) {
     await fillIn(`[data-test-search-field]`, 'zzzzz');
 
     assert
-      .dom(`[data-test-search-result-index]`)
+      .dom(`[data-test-grid-item-index]`)
       .doesNotExist('no recent cards match "zzzzz"');
   });
 
@@ -773,7 +791,7 @@ module('Integration | operator-mode | card catalog', function (hooks) {
     await waitFor('[data-test-search-sheet-show-only]');
     await click('[data-test-search-sheet-show-only]');
     const collapsedBlocks = document.querySelectorAll(
-      '.search-result-block.collapsed',
+      '.search-result-block--collapsed',
     );
     assert.ok(
       collapsedBlocks.length >= 1,

--- a/packages/host/tests/integration/components/operator-mode-card-catalog-test.gts
+++ b/packages/host/tests/integration/components/operator-mode-card-catalog-test.gts
@@ -755,6 +755,76 @@ module('Integration | operator-mode | card catalog', function (hooks) {
       .doesNotExist('no recent cards match "zzzzz"');
   });
 
+  test(`Recents section filters cards by realm`, async function (assert) {
+    let recentCardsService = getService('recent-cards-service');
+    [
+      `${baseRealm.url}index`,
+      `${testRealmURL}Pet/mango`,
+      `${baseRealm.url}cards/skill`,
+      `${testRealmURL}Person/fadhlan`,
+    ].map((url) => recentCardsService.add(url));
+
+    ctx.setCardInOperatorModeState(`${testRealmURL}grid`);
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><OperatorMode @onClose={{noop}} /></template>
+      },
+    );
+    await waitFor(`[data-test-stack-card="${testRealmURL}grid"]`);
+    await click(`[data-test-open-search-field]`);
+    await waitFor(`[data-test-search-result="${testRealmURL}Pet/mango"]`);
+    await waitFor(`[data-test-search-result="${baseRealm.url}cards/skill"]`);
+    assert.dom('[data-test-search-result]').exists({ count: 4 });
+
+    await click('[data-test-realm-picker]');
+    await click(`[data-test-boxel-picker-option-row="${baseRealm.url}"]`);
+    assert.dom('[data-test-search-result]').exists({ count: 2 });
+    assert
+      .dom(`[data-test-search-result="${baseRealm.url}cards/skill"]`)
+      .exists();
+    assert.dom(`[data-test-search-result="${baseRealm.url}index"]`).exists();
+
+    await click(`[data-test-boxel-picker-option-row="${testRealmURL}"]`);
+    assert.dom('[data-test-search-result]').exists({ count: 4 });
+
+    // expand search sheet
+    await fillIn(`[data-test-search-field]`, ' ');
+
+    // unselect Base Realm (only test realm selected)
+    await click(
+      '[data-test-realm-picker] [data-test-boxel-picker-remove-button]:nth-of-type(1)',
+    );
+    assert.dom('[data-test-search-result]').exists({ count: 2 });
+    assert.dom(`[data-test-search-result="${testRealmURL}Pet/mango"]`).exists();
+    assert
+      .dom(`[data-test-search-result="${testRealmURL}Person/fadhlan"]`)
+      .exists();
+  });
+
+  test(`Recents section hides cards from unselected realms`, async function (assert) {
+    let recentCardsService = getService('recent-cards-service');
+    recentCardsService.add(`${testRealmURL}Pet/mango`);
+
+    ctx.setCardInOperatorModeState(`${testRealmURL}grid`);
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><OperatorMode @onClose={{noop}} /></template>
+      },
+    );
+    await waitFor(`[data-test-stack-card="${testRealmURL}grid"]`);
+    await click(`[data-test-open-search-field]`);
+    await fillIn(`[data-test-search-field]`, ' ');
+    await waitFor(`[data-test-search-result="${testRealmURL}Pet/mango"]`);
+
+    // Select only the base realm — testRealmURL cards should be hidden
+    await click('[data-test-realm-picker] [data-test-boxel-picker-trigger]');
+    await click(`[data-test-boxel-picker-option-row="${baseRealm.url}"]`);
+
+    assert
+      .dom(`[data-test-search-result="${testRealmURL}Pet/mango"]`)
+      .doesNotExist('Pet/mango is hidden when its realm is not selected');
+  });
+
   test(`compact mode shows no full header and recents remain clickable`, async function (assert) {
     ctx.setCardInOperatorModeState(`${testRealmURL}grid`);
     await renderComponent(

--- a/packages/matrix/helpers/index.ts
+++ b/packages/matrix/helpers/index.ts
@@ -485,7 +485,10 @@ export async function selectCardFromCatalog(page: Page, cardId: string) {
   await page
     .locator('[data-test-card-catalog-modal] [data-test-search-field]')
     .fill(cardId);
-  await page.locator(`[data-test-card-catalog-item="${cardId}"]`).click();
+  await page
+    .locator(`[data-test-card-catalog-item="${cardId}"]`)
+    .first()
+    .click();
   await page.locator('[data-test-card-catalog-go-button]').click();
 }
 

--- a/packages/matrix/tests/commands.spec.ts
+++ b/packages/matrix/tests/commands.spec.ts
@@ -289,7 +289,7 @@ test.describe('Commands', () => {
     }).toPass();
   });
 
-  test('an autoexecuted command does not run again when the message is re-rendered', async ({
+  test.only('an autoexecuted command does not run again when the message is re-rendered', async ({
     page,
   }) => {
     const { username, password, credentials } =
@@ -347,6 +347,7 @@ test.describe('Commands', () => {
       .locator('[data-test-card-catalog-item]', {
         hasText: 'Automatic Switch Command',
       })
+      .first()
       .click();
     await page.locator('[data-test-card-catalog-go-button]').click();
 

--- a/packages/matrix/tests/commands.spec.ts
+++ b/packages/matrix/tests/commands.spec.ts
@@ -289,7 +289,7 @@ test.describe('Commands', () => {
     }).toPass();
   });
 
-  test.only('an autoexecuted command does not run again when the message is re-rendered', async ({
+  test('an autoexecuted command does not run again when the message is re-rendered', async ({
     page,
   }) => {
     const { username, password, credentials } =

--- a/packages/matrix/tests/skills.spec.ts
+++ b/packages/matrix/tests/skills.spec.ts
@@ -348,7 +348,7 @@ test.describe('Skills', () => {
     );
   });
 
-  test('ensure that the skill card from boxel index is not overwritten by the skill card from matrix store', async ({
+  test.only('ensure that the skill card from boxel index is not overwritten by the skill card from matrix store', async ({
     page,
   }) => {
     const { username } = await createSubscribedUserAndLogin(
@@ -369,7 +369,6 @@ test.describe('Skills', () => {
       .locator(
         '[data-test-card-catalog-item="https://cardstack.com/base/cards/skill"]',
       )
-      .first()
       .click();
     await page.locator('[data-test-card-catalog-go-button]').click();
     await page
@@ -405,6 +404,7 @@ test.describe('Skills', () => {
       .locator('[data-test-card-catalog-item]', {
         hasText: 'Automatic Switch Command',
       })
+      .first()
       .click();
     await page.locator('[data-test-card-catalog-go-button]').click();
 

--- a/packages/matrix/tests/skills.spec.ts
+++ b/packages/matrix/tests/skills.spec.ts
@@ -369,6 +369,7 @@ test.describe('Skills', () => {
       .locator(
         '[data-test-card-catalog-item="https://cardstack.com/base/cards/skill"]',
       )
+      .first()
       .click();
     await page.locator('[data-test-card-catalog-go-button]').click();
     await page

--- a/packages/matrix/tests/skills.spec.ts
+++ b/packages/matrix/tests/skills.spec.ts
@@ -348,7 +348,7 @@ test.describe('Skills', () => {
     );
   });
 
-  test.only('ensure that the skill card from boxel index is not overwritten by the skill card from matrix store', async ({
+  test('ensure that the skill card from boxel index is not overwritten by the skill card from matrix store', async ({
     page,
   }) => {
     const { username } = await createSubscribedUserAndLogin(


### PR DESCRIPTION
Component updates:
- Add `FittedCardContainer` component, a wrapper that makes it easier to set the fitted container size for any card.
- Update `GridContainer` component to enable making a cards-grid for the selected fitted container size.
<img width="730" height="681" alt="fitted-card-container" src="https://github.com/user-attachments/assets/4d9fcdf4-cf0c-43d0-93ce-298b153d450a" />
<img width="643" height="827" alt="grid-container" src="https://github.com/user-attachments/assets/d5d131f0-ff51-44e4-a374-7f81a29059a6" />

Card Picker:
- Use new components in search menu and card picker for displaying desired fitted views.
- Fix bug in collapsed search sheet: "Recents" here should not be capped at 5 and should remain in order of last opened card.
- Display "Recents" section in card picker. Here Recents are capped at 5 and are sorted and filtered like the other sections in card picker.
- Enable filtering Recent Cards via the realm filter.
- Template/css refactor.