### PR TITLE
ci: Update lint memory usage expectation

### DIFF
--- a/packages/realm-server/tests/realm-endpoints/lint-test.ts
+++ b/packages/realm-server/tests/realm-endpoints/lint-test.ts
@@ -376,10 +376,10 @@ export class MyCard extends CardDef {
       const finalMemory = process.memoryUsage().heapUsed;
       const memoryIncrease = finalMemory - initialMemory;
 
-      // Memory increase should be reasonable (less than 20MB for lint operations)
+      // Memory increase should be reasonable (less than 45MB for lint operations)
       assert.ok(
-        memoryIncrease < 20 * 1024 * 1024,
-        `Memory increase should be under 20MB, got ${(memoryIncrease / 1024 / 1024).toFixed(2)}MB`,
+        memoryIncrease < 45 * 1024 * 1024,
+        `Memory increase should be under 45MB, got ${(memoryIncrease / 1024 / 1024).toFixed(2)}MB`,
       );
     });
 


### PR DESCRIPTION
Since moving to the new Node LTS, this test has been [flaky](https://github.com/cardstack/boxel/actions/runs/22243281388/job/64352111673?pr=4039#step:10:55). I ran it in 20 duplicate jobs and the highest memory consumption was 41.44, so 45 seems like a safe threshold.