### PR TITLE
Fix FileDef preview in code mode to live reload when file changes

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
+++ b/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
@@ -172,10 +172,11 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
       return state;
     }
     let fileUrl = this.args.readyFile.url;
+    void this.args.readyFile?.lastModified; // track lastModified to re-run on save
     state.isLoading = true;
     (async () => {
       try {
-        let result = await this.store.get(fileUrl, { type: 'file-meta' });
+        let result = await this.store.getWithoutCache(fileUrl, { type: 'file-meta' });
         if (isCardErrorJSONAPI(result)) {
           state.error = result;
           state.value = undefined;

--- a/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
+++ b/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
@@ -176,7 +176,9 @@ export default class ModuleInspector extends Component<ModuleInspectorSignature>
     state.isLoading = true;
     (async () => {
       try {
-        let result = await this.store.getWithoutCache(fileUrl, { type: 'file-meta' });
+        let result = await this.store.getWithoutCache(fileUrl, {
+          type: 'file-meta',
+        });
         if (isCardErrorJSONAPI(result)) {
           state.error = result;
           state.value = undefined;

--- a/packages/host/tests/acceptance/code-submode/file-def-live-reload-test.gts
+++ b/packages/host/tests/acceptance/code-submode/file-def-live-reload-test.gts
@@ -1,0 +1,88 @@
+import { waitFor, waitUntil } from '@ember/test-helpers';
+
+import { module, test } from 'qunit';
+
+import type { Realm } from '@cardstack/runtime-common';
+
+import {
+  setupAcceptanceTestRealm,
+  setupAuthEndpoints,
+  setupLocalIndexing,
+  setupOnSave,
+  setupUserSubscription,
+  SYSTEM_CARD_FIXTURE_CONTENTS,
+  testRealmURL,
+  visitOperatorMode,
+} from '../../helpers';
+import { setupMockMatrix } from '../../helpers/mock-matrix';
+import { setupApplicationTest } from '../../helpers/setup';
+
+module('Acceptance | code submode | file def live reload', function (hooks) {
+  let realm: Realm;
+
+  setupApplicationTest(hooks);
+  setupLocalIndexing(hooks);
+  setupOnSave(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+    activeRealms: [testRealmURL],
+  });
+
+  let { createAndJoinRoom } = mockMatrixUtils;
+
+  hooks.beforeEach(async function () {
+    createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'room-test',
+    });
+    setupUserSubscription();
+    setupAuthEndpoints();
+
+    ({ realm } = await setupAcceptanceTestRealm({
+      mockMatrixUtils,
+      contents: {
+        ...SYSTEM_CARD_FIXTURE_CONTENTS,
+        'readme.md': `# Hello\n\nInitial content.`,
+      },
+    }));
+  });
+
+  test('FileDef preview updates when the file is edited and saved', async function (assert) {
+    await visitOperatorMode({
+      submode: 'code',
+      codePath: `${testRealmURL}readme.md`,
+    });
+
+    await waitFor('[data-test-markdown-isolated]');
+    assert
+      .dom('[data-test-markdown-isolated]')
+      .containsText('Hello', 'initial content is rendered');
+    assert
+      .dom('[data-test-markdown-isolated]')
+      .containsText('Initial content.', 'initial paragraph is rendered');
+
+    // Simulate the user editing and saving the file
+    await realm.write('readme.md', `# Updated Title\n\nNew paragraph.`);
+
+    await waitUntil(
+      () =>
+        document
+          .querySelector('[data-test-markdown-isolated]')
+          ?.textContent?.includes('Updated Title'),
+      { timeout: 5000, timeoutMessage: 'preview did not update after save' },
+    );
+    assert
+      .dom('[data-test-markdown-isolated]')
+      .containsText(
+        'Updated Title',
+        'preview updates to show new title after save',
+      );
+    assert
+      .dom('[data-test-markdown-isolated]')
+      .containsText(
+        'New paragraph.',
+        'preview updates to show new paragraph after save',
+      );
+  });
+});


### PR DESCRIPTION
## Summary
- Fix the `fileDefResource` in `module-inspector.gts` to track `readyFile.lastModified`, causing the resource to re-run when a file is saved
- Use `store.getWithoutCache()` instead of `store.get()` to bypass the stale cached FileDef instance on re-fetch
- Add acceptance test verifying the markdown preview updates after editing and saving a file in code mode

Fixes CS-10227

## Test plan
- [x] New acceptance test: `ember test --path dist --filter "file def live reload"` passes
- [x] Manual: Open a `.md` file in code mode, edit in Monaco, confirm the preview panel updates after auto-save

🤖 Generated with [Claude Code](https://claude.com/claude-code)