### PR TITLE
Add file-meta instance querying and display in Playground

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
+++ b/packages/host/app/components/operator-mode/code-submode/module-inspector.gts
@@ -62,6 +62,7 @@ import type { Ready } from '@cardstack/host/resources/file';
 import { isReady } from '@cardstack/host/resources/file';
 import {
   type CardOrFieldDeclaration,
+  type CardOrFieldReexport,
   type ModuleAnalysis,
   isCardOrFieldDeclaration,
   type ModuleDeclaration,
@@ -114,7 +115,10 @@ interface ModuleInspectorSignature {
     moduleAnalysis: ModuleAnalysis;
     previewFormat: Format;
     readyFile: Ready;
-    selectedCardOrField: CardOrFieldDeclaration | undefined;
+    selectedCardOrField:
+      | CardOrFieldDeclaration
+      | CardOrFieldReexport
+      | undefined;
     selectedCodeRef: ResolvedCodeRef | undefined;
     selectedDeclaration: ModuleDeclaration | undefined;
     setPreviewFormat: (format: Format) => void;

--- a/packages/host/app/components/operator-mode/code-submode/playground/instance-chooser-dropdown.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/instance-chooser-dropdown.gts
@@ -83,13 +83,16 @@ interface AfterOptionsSignature {
   Args: {
     menuItems: MenuItem[];
     closeMenu?: () => void;
+    hideTitle?: boolean;
   };
 }
 const AfterOptions: TemplateOnlyComponent<AfterOptionsSignature> = <template>
   <div class='after-options'>
-    <span class='title'>
-      Action
-    </span>
+    {{#unless @hideTitle}}
+      <span class='title'>
+        Action
+      </span>
+    {{/unless}}
     <Menu
       class='after-options-menu'
       @items={{@menuItems}}
@@ -159,6 +162,7 @@ interface OptionsDropdownSignature {
     afterMenuOptions: MenuItem[];
     beforeOptionsLabel?: string;
     selectedItemLabel?: string;
+    hideAfterOptionsTitle?: boolean;
   };
 }
 
@@ -199,6 +203,7 @@ export const OptionsDropdown: TemplateOnlyComponent<OptionsDropdownSignature> =
           AfterOptions
           menuItems=@afterMenuOptions
           closeMenu=closeInstanceChooser
+          hideTitle=@hideAfterOptionsTitle
         )
       }}
       @verticalPosition='above'
@@ -303,6 +308,7 @@ export default class InstanceSelectDropdown extends Component<Signature> {
         @afterMenuOptions={{@afterMenuOptions}}
         @beforeOptionsLabel='Files'
         @selectedItemLabel='File:'
+        @hideAfterOptionsTitle={{true}}
       />
     {{else if @isFieldDef}}
       <OptionsDropdown

--- a/packages/host/app/components/operator-mode/code-submode/playground/instance-chooser-dropdown.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/instance-chooser-dropdown.gts
@@ -10,11 +10,14 @@ import type { MenuItem } from '@cardstack/boxel-ui/helpers';
 
 import {
   cardTypeDisplayName,
+  isFileDefInstance,
   type Format,
   type PrerenderedCardLike,
 } from '@cardstack/runtime-common';
 
 import CardRenderer from '@cardstack/host/components/card-renderer';
+
+import type { FileDef } from 'https://cardstack.com/base/file-api';
 
 import type { FieldOption, SelectedInstance } from './playground-panel';
 
@@ -23,7 +26,12 @@ const getItemTitle = (selection: SelectedInstance | undefined) => {
     return;
   }
   let { card, fieldIndex } = selection;
-  let title = card.cardTitle ?? `Untitled ${cardTypeDisplayName(card)}`;
+  let title: string;
+  if (isFileDefInstance(card)) {
+    title = card.name ?? `Untitled ${cardTypeDisplayName(card)}`;
+  } else {
+    title = card.cardTitle ?? `Untitled ${cardTypeDisplayName(card)}`;
+  }
   if (fieldIndex === undefined) {
     return title;
   }
@@ -121,13 +129,15 @@ const AfterOptions: TemplateOnlyComponent<AfterOptionsSignature> = <template>
 interface Signature {
   Args: {
     isFieldDef: boolean;
+    isFileDef?: boolean;
     cardOptions: PrerenderedCardLike[] | undefined;
     fieldOptions?: FieldOption[];
+    fileMetaOptions?: FileDef[];
     findSelectedCard: (
       cards?: PrerenderedCardLike[],
     ) => PrerenderedCardLike | SelectedInstance | undefined;
     selection: SelectedInstance | undefined;
-    onSelect: (item: PrerenderedCardLike | FieldOption) => void;
+    onSelect: (item: PrerenderedCardLike | FieldOption | FileDef) => void;
     moduleId: string;
     persistSelections?: (cardId: string, format: Format) => void;
     recentCardIds: string[];
@@ -138,10 +148,11 @@ interface Signature {
 interface OptionsDropdownSignature {
   Args: {
     isField?: boolean;
-    options: PrerenderedCardLike[] | FieldOption[] | undefined;
-    selected?: PrerenderedCardLike | FieldOption | SelectedInstance;
+    isFileMeta?: boolean;
+    options: PrerenderedCardLike[] | FieldOption[] | FileDef[] | undefined;
+    selected?: PrerenderedCardLike | FieldOption | SelectedInstance | FileDef;
     selection: SelectedInstance | undefined;
-    onSelect: (item: PrerenderedCardLike | FieldOption) => void;
+    onSelect: (item: PrerenderedCardLike | FieldOption | FileDef) => void;
     afterMenuOptions: MenuItem[];
   };
 }
@@ -167,7 +178,11 @@ export const OptionsDropdown: TemplateOnlyComponent<OptionsDropdownSignature> =
       }}
       @renderInPlace={{true}}
       @onChange={{@onSelect}}
-      @placeholder='Select {{if @isField "field" "card"}} instance'
+      @placeholder='Select {{if
+        @isFileMeta
+        "file"
+        (if @isField "field" "card")
+      }} instance'
       @beforeOptionsComponent={{component BeforeOptions}}
       @afterOptionsComponent={{component
         AfterOptions
@@ -179,7 +194,11 @@ export const OptionsDropdown: TemplateOnlyComponent<OptionsDropdownSignature> =
       data-test-instance-chooser
       as |item|
     >
-      {{#if @isField}}
+      {{#if @isFileMeta}}
+        <CardContainer class='field' @displayBoundaries={{true}}>
+          <CardRenderer @card={{item}} @format='atom' />
+        </CardContainer>
+      {{else if @isField}}
         <CardContainer class='field' @displayBoundaries={{true}}>
           <CardRenderer @card={{item.field}} @format='atom' />
         </CardContainer>
@@ -254,7 +273,16 @@ export const OptionsDropdown: TemplateOnlyComponent<OptionsDropdownSignature> =
 
 export default class InstanceSelectDropdown extends Component<Signature> {
   <template>
-    {{#if @isFieldDef}}
+    {{#if @isFileDef}}
+      <OptionsDropdown
+        @isFileMeta={{true}}
+        @options={{@fileMetaOptions}}
+        @selected={{this.findSelectedFileMeta @fileMetaOptions}}
+        @selection={{@selection}}
+        @onSelect={{@onSelect}}
+        @afterMenuOptions={{@afterMenuOptions}}
+      />
+    {{else if @isFieldDef}}
       <OptionsDropdown
         @isField={{true}}
         @options={{@fieldOptions}}
@@ -280,5 +308,12 @@ export default class InstanceSelectDropdown extends Component<Signature> {
     }
     let selection = this.args.selection;
     return fields.find((f) => f.index === selection.fieldIndex);
+  };
+
+  private findSelectedFileMeta = (files?: FileDef[]) => {
+    if (!files?.length || !this.args.selection) {
+      return;
+    }
+    return files.find((f) => f.id === this.args.selection?.card?.id);
   };
 }

--- a/packages/host/app/components/operator-mode/code-submode/playground/instance-chooser-dropdown.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/instance-chooser-dropdown.gts
@@ -40,44 +40,43 @@ const getItemTitle = (selection: SelectedInstance | undefined) => {
 
 const SelectedItem: TemplateOnlyComponent<{
   Args: { title?: string; label?: string };
-}> =
-  <template>
-    <div class='selected-item' data-test-selected-item>
-      <span class='label'>{{if @label @label "Instance:"}}</span>
-      <span class='item'>{{@title}}</span>
-    </div>
-    <style scoped>
-      .selected-item {
-        font: 500 var(--boxel-font-xs);
-        letter-spacing: var(--boxel-lsp-sm);
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
+}> = <template>
+  <div class='selected-item' data-test-selected-item>
+    <span class='label'>{{if @label @label 'Instance:'}}</span>
+    <span class='item'>{{@title}}</span>
+  </div>
+  <style scoped>
+    .selected-item {
+      font: 500 var(--boxel-font-xs);
+      letter-spacing: var(--boxel-lsp-sm);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
 
-      .label {
-        font-weight: 600;
-        margin-right: var(--boxel-sp-xxs);
-      }
-    </style>
-  </template>;
+    .label {
+      font-weight: 600;
+      margin-right: var(--boxel-sp-xxs);
+    }
+  </style>
+</template>;
 
 const BeforeOptions: TemplateOnlyComponent<{ Args: { label?: string } }> =
   <template>
     <div class='before-options'>
-      {{if @label @label "Recent"}}
+      {{if @label @label 'Recent'}}
     </div>
-  <style scoped>
-    .before-options {
-      width: 100%;
-      background-color: var(--boxel-light);
-      padding: var(--boxel-sp-xs) var(--boxel-sp);
-      font: 500 var(--boxel-font-sm);
-      letter-spacing: var(--boxel-lsp-xs);
-      text-align: left;
-    }
-  </style>
-</template>;
+    <style scoped>
+      .before-options {
+        width: 100%;
+        background-color: var(--boxel-light);
+        padding: var(--boxel-sp-xs) var(--boxel-sp);
+        font: 500 var(--boxel-font-sm);
+        letter-spacing: var(--boxel-lsp-xs);
+        text-align: left;
+      }
+    </style>
+  </template>;
 
 interface AfterOptionsSignature {
   Args: {

--- a/packages/host/app/components/operator-mode/code-submode/playground/instance-chooser-dropdown.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/instance-chooser-dropdown.gts
@@ -38,10 +38,12 @@ const getItemTitle = (selection: SelectedInstance | undefined) => {
   return `${title} - Example ${fieldIndex + 1}`;
 };
 
-const SelectedItem: TemplateOnlyComponent<{ Args: { title?: string } }> =
+const SelectedItem: TemplateOnlyComponent<{
+  Args: { title?: string; label?: string };
+}> =
   <template>
     <div class='selected-item' data-test-selected-item>
-      <span class='label'>Instance:</span>
+      <span class='label'>{{if @label @label "Instance:"}}</span>
       <span class='item'>{{@title}}</span>
     </div>
     <style scoped>
@@ -60,10 +62,11 @@ const SelectedItem: TemplateOnlyComponent<{ Args: { title?: string } }> =
     </style>
   </template>;
 
-const BeforeOptions: TemplateOnlyComponent = <template>
-  <div class='before-options'>
-    Recent
-  </div>
+const BeforeOptions: TemplateOnlyComponent<{ Args: { label?: string } }> =
+  <template>
+    <div class='before-options'>
+      {{if @label @label "Recent"}}
+    </div>
   <style scoped>
     .before-options {
       width: 100%;
@@ -154,6 +157,8 @@ interface OptionsDropdownSignature {
     selection: SelectedInstance | undefined;
     onSelect: (item: PrerenderedCardLike | FieldOption | FileDef) => void;
     afterMenuOptions: MenuItem[];
+    beforeOptionsLabel?: string;
+    selectedItemLabel?: string;
   };
 }
 
@@ -175,6 +180,7 @@ export const OptionsDropdown: TemplateOnlyComponent<OptionsDropdownSignature> =
       @selectedItemComponent={{component
         SelectedItem
         title=(getItemTitle @selection)
+        label=@selectedItemLabel
       }}
       @renderInPlace={{true}}
       @onChange={{@onSelect}}
@@ -183,11 +189,17 @@ export const OptionsDropdown: TemplateOnlyComponent<OptionsDropdownSignature> =
         "file"
         (if @isField "field" "card")
       }} instance'
-      @beforeOptionsComponent={{component BeforeOptions}}
-      @afterOptionsComponent={{component
-        AfterOptions
-        menuItems=@afterMenuOptions
-        closeMenu=closeInstanceChooser
+      @beforeOptionsComponent={{component
+        BeforeOptions
+        label=@beforeOptionsLabel
+      }}
+      @afterOptionsComponent={{if
+        @afterMenuOptions.length
+        (component
+          AfterOptions
+          menuItems=@afterMenuOptions
+          closeMenu=closeInstanceChooser
+        )
       }}
       @verticalPosition='above'
       data-playground-instance-chooser
@@ -195,9 +207,9 @@ export const OptionsDropdown: TemplateOnlyComponent<OptionsDropdownSignature> =
       as |item|
     >
       {{#if @isFileMeta}}
-        <CardContainer class='field' @displayBoundaries={{true}}>
+        <div class='file-item'>
           <CardRenderer @card={{item}} @format='atom' />
-        </CardContainer>
+        </div>
       {{else if @isField}}
         <CardContainer class='field' @displayBoundaries={{true}}>
           <CardRenderer @card={{item.field}} @format='atom' />
@@ -251,7 +263,8 @@ export const OptionsDropdown: TemplateOnlyComponent<OptionsDropdownSignature> =
         width: 100%;
       }
 
-      :deep(.ember-power-select-option:hover .card) {
+      :deep(.ember-power-select-option:hover .card),
+      :deep(.ember-power-select-option:hover .file-item) {
         background-color: var(--boxel-100);
       }
       .card,
@@ -268,6 +281,13 @@ export const OptionsDropdown: TemplateOnlyComponent<OptionsDropdownSignature> =
         text-overflow: ellipsis;
         white-space: nowrap;
       }
+      .file-item {
+        display: flex;
+        align-items: center;
+        padding: var(--boxel-sp-xxxs) var(--boxel-sp-xs);
+        min-width: 0;
+        background-color: var(--boxel-light);
+      }
     </style>
   </template>;
 
@@ -281,6 +301,8 @@ export default class InstanceSelectDropdown extends Component<Signature> {
         @selection={{@selection}}
         @onSelect={{@onSelect}}
         @afterMenuOptions={{@afterMenuOptions}}
+        @beforeOptionsLabel='Files'
+        @selectedItemLabel='File:'
       />
     {{else if @isFieldDef}}
       <OptionsDropdown

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
@@ -136,11 +136,13 @@ export default class PlaygroundPanel extends Component<Signature> {
 
   @tracked private cardOptions: PrerenderedCardLike[] = [];
   @tracked private selectedFileMetaId: string | undefined;
+  @tracked private showAllFileMetaInstances = false;
   @use private moduleChangeTracker = resource(() => {
     let moduleId = internalKeyFor(this.args.codeRef, undefined);
     if (moduleId !== this.#currentModuleId) {
       this.#currentModuleId = moduleId;
       this.#creationError = false;
+      this.showAllFileMetaInstances = false;
     }
     return moduleId;
   });
@@ -348,8 +350,24 @@ export default class PlaygroundPanel extends Component<Signature> {
     };
   }
 
+  static FILE_META_DROPDOWN_LIMIT = 20;
+
   private get fileMetaInstances(): FileDef[] | undefined {
     return this.fileSearchResults?.instances as FileDef[] | undefined;
+  }
+
+  private get fileMetaDropdownOptions(): FileDef[] | undefined {
+    let instances = this.fileMetaInstances;
+    if (!instances) {
+      return undefined;
+    }
+    if (
+      this.showAllFileMetaInstances ||
+      instances.length <= PlaygroundPanel.FILE_META_DROPDOWN_LIMIT
+    ) {
+      return instances;
+    }
+    return instances.slice(0, PlaygroundPanel.FILE_META_DROPDOWN_LIMIT);
   }
 
   private get selectedFileMetaInstance(): FileDef | undefined {
@@ -603,7 +621,23 @@ export default class PlaygroundPanel extends Component<Signature> {
   }
 
   private get fileDefAfterMenuOptions(): MenuItem[] {
-    return [];
+    let allInstances = this.fileMetaInstances;
+    if (
+      !allInstances ||
+      this.showAllFileMetaInstances ||
+      allInstances.length <= PlaygroundPanel.FILE_META_DROPDOWN_LIMIT
+    ) {
+      return [];
+    }
+    return [
+      new MenuItem({
+        label: `Show all ${allInstances.length} files`,
+        action: () => {
+          this.showAllFileMetaInstances = true;
+        },
+        icon: Folder,
+      }),
+    ];
   }
 
   private get format(): Format {
@@ -978,7 +1012,7 @@ export default class PlaygroundPanel extends Component<Signature> {
                 isFileDef=@isFileDef
                 cardOptions=this.cardOptions
                 fieldOptions=this.fieldInstances
-                fileMetaOptions=this.fileMetaInstances
+                fileMetaOptions=this.fileMetaDropdownOptions
                 findSelectedCard=this.findSelectedCard
                 selection=this.dropdownSelection
                 onSelect=this.onSelect

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
@@ -619,7 +619,7 @@ export default class PlaygroundPanel extends Component<Signature> {
   private get fileDefAfterMenuOptions(): MenuItem[] {
     return [
       new MenuItem({
-        label: 'Choose another file',
+        label: 'Choose file\u2026',
         action: () => this.chooseFileMeta.perform(),
         icon: Folder,
       }),

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
@@ -39,6 +39,7 @@ import {
   type getCard,
   type getCards,
   chooseCard,
+  chooseFile,
   loadCardDef,
   specRef,
   trimJsonExtension,
@@ -136,13 +137,11 @@ export default class PlaygroundPanel extends Component<Signature> {
 
   @tracked private cardOptions: PrerenderedCardLike[] = [];
   @tracked private selectedFileMetaId: string | undefined;
-  @tracked private showAllFileMetaInstances = false;
   @use private moduleChangeTracker = resource(() => {
     let moduleId = internalKeyFor(this.args.codeRef, undefined);
     if (moduleId !== this.#currentModuleId) {
       this.#currentModuleId = moduleId;
       this.#creationError = false;
-      this.showAllFileMetaInstances = false;
     }
     return moduleId;
   });
@@ -361,10 +360,7 @@ export default class PlaygroundPanel extends Component<Signature> {
     if (!instances) {
       return undefined;
     }
-    if (
-      this.showAllFileMetaInstances ||
-      instances.length <= PlaygroundPanel.FILE_META_DROPDOWN_LIMIT
-    ) {
+    if (instances.length <= PlaygroundPanel.FILE_META_DROPDOWN_LIMIT) {
       return instances;
     }
     return instances.slice(0, PlaygroundPanel.FILE_META_DROPDOWN_LIMIT);
@@ -621,24 +617,26 @@ export default class PlaygroundPanel extends Component<Signature> {
   }
 
   private get fileDefAfterMenuOptions(): MenuItem[] {
-    let allInstances = this.fileMetaInstances;
-    if (
-      !allInstances ||
-      this.showAllFileMetaInstances ||
-      allInstances.length <= PlaygroundPanel.FILE_META_DROPDOWN_LIMIT
-    ) {
-      return [];
-    }
     return [
       new MenuItem({
-        label: `Show all ${allInstances.length} files`,
-        action: () => {
-          this.showAllFileMetaInstances = true;
-        },
+        label: 'Choose another file',
+        action: () => this.chooseFileMeta.perform(),
         icon: Folder,
       }),
     ];
   }
+
+  private chooseFileMeta = task(async () => {
+    this.closeInstanceChooser();
+    let chosenFile = await chooseFile({
+      fileType: this.args.codeRef,
+      fileTypeName: this.args.codeRef.name,
+    });
+    if (chosenFile?.id) {
+      this.selectedFileMetaId = chosenFile.id;
+      this.persistSelections(chosenFile.id);
+    }
+  });
 
   private get format(): Format {
     return (

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-panel.gts
@@ -35,7 +35,9 @@ import {
   internalKeyFor,
   type ResolvedCodeRef,
   GetCardContextName,
+  GetCardsContextName,
   type getCard,
+  type getCards,
   chooseCard,
   loadCardDef,
   specRef,
@@ -90,7 +92,7 @@ import PlaygroundPreview from './playground-preview';
 import SpecSearch from './spec-search';
 
 export type SelectedInstance = {
-  card: CardDef;
+  card: CardDef | FileDef;
   fieldIndex: number | undefined;
 };
 
@@ -104,6 +106,7 @@ interface Signature {
   Args: {
     codeRef: ResolvedCodeRef;
     isFieldDef?: boolean;
+    isFileDef?: boolean;
     isUpdating?: boolean;
     viewCard?: ViewCardFn;
   };
@@ -112,6 +115,7 @@ interface Signature {
 
 export default class PlaygroundPanel extends Component<Signature> {
   @consume(GetCardContextName) declare private getCard: getCard;
+  @consume(GetCardsContextName) declare private getCards: getCards;
   @consume(CardContextName) declare private cardContext: CardContext;
   @service declare private aiAssistantPanelService: AiAssistantPanelService;
   @service declare private commandService: CommandService;
@@ -126,10 +130,12 @@ export default class PlaygroundPanel extends Component<Signature> {
   @service declare private store: StoreService;
 
   @tracked private cardResource: ReturnType<getCard> | undefined;
+  @tracked private fileSearchResults: ReturnType<getCards> | undefined;
   @tracked private fieldChooserIsOpen = false;
   @tracked private newCardNonce = 0;
 
   @tracked private cardOptions: PrerenderedCardLike[] = [];
+  @tracked private selectedFileMetaId: string | undefined;
   @use private moduleChangeTracker = resource(() => {
     let moduleId = internalKeyFor(this.args.codeRef, undefined);
     if (moduleId !== this.#currentModuleId) {
@@ -140,6 +146,7 @@ export default class PlaygroundPanel extends Component<Signature> {
   });
 
   private fieldFormats: Format[] = ['embedded', 'fitted', 'atom', 'edit'];
+  private fileDefFormats: Format[] = ['isolated', 'embedded', 'fitted', 'atom'];
   #creationError = false;
   #currentModuleId: string | undefined;
 
@@ -247,6 +254,13 @@ export default class PlaygroundPanel extends Component<Signature> {
   }
 
   private get realmInfo() {
+    if (this.args.isFileDef) {
+      let fileId = this.selectedFileMetaInstance?.id;
+      if (!fileId) {
+        return undefined;
+      }
+      return this.realm.info(fileId);
+    }
     let url = this.card ? urlForRealmLookup(this.card) : undefined;
     if (!url) {
       return undefined;
@@ -306,10 +320,69 @@ export default class PlaygroundPanel extends Component<Signature> {
   }
 
   private get isLoading() {
+    if (this.args.isFileDef) {
+      return this.fileSearchResults?.isLoading;
+    }
     return this.args.isFieldDef && this.args.isUpdating;
   }
 
+  private searchFileMeta = () => {
+    if (!this.args.isFileDef) {
+      return;
+    }
+    this.fileSearchResults = this.getCards(
+      this,
+      () => this.fileMetaQuery,
+      () => this.realmServer.availableRealmURLs,
+      { isLive: true },
+    );
+  };
+
+  private get fileMetaQuery(): Query | undefined {
+    if (!this.args.isFileDef) {
+      return undefined;
+    }
+    return {
+      filter: { type: this.args.codeRef },
+      sort: [{ by: 'lastModified', direction: 'desc' }],
+    };
+  }
+
+  private get fileMetaInstances(): FileDef[] | undefined {
+    return this.fileSearchResults?.instances as FileDef[] | undefined;
+  }
+
+  private get selectedFileMetaInstance(): FileDef | undefined {
+    let instances = this.fileMetaInstances;
+    if (!instances?.length) {
+      return undefined;
+    }
+    let selectedId = this.selectedFileMetaId ?? this.persistedCardId;
+    if (selectedId) {
+      let found = instances.find((f) => f.id === selectedId);
+      if (found) {
+        return found;
+      }
+    }
+    return instances[0];
+  }
+
+  private processFileMetaResults = () => {
+    let instances = this.fileMetaInstances;
+    if (!instances?.length || this.persistedCardId) {
+      return;
+    }
+    let first = instances[0];
+    if (first?.id) {
+      this.selectedFileMetaId = first.id;
+      this.persistSelections(first.id);
+    }
+  };
+
   private makeCardResource = () => {
+    if (this.args.isFileDef) {
+      return;
+    }
     this.cardResource = this.getCard(
       this,
       () => this.playgroundSelection?.cardId,
@@ -414,7 +487,7 @@ export default class PlaygroundPanel extends Component<Signature> {
   }
 
   private get query(): Query | undefined {
-    if (this.args.isFieldDef) {
+    if (this.args.isFieldDef || this.args.isFileDef) {
       return undefined;
     }
     return {
@@ -432,7 +505,7 @@ export default class PlaygroundPanel extends Component<Signature> {
   }
 
   private get expandedQuery(): Query | undefined {
-    if (this.args.isFieldDef) {
+    if (this.args.isFieldDef || this.args.isFileDef) {
       return undefined;
     }
     return {
@@ -485,6 +558,13 @@ export default class PlaygroundPanel extends Component<Signature> {
   }
 
   private get dropdownSelection(): SelectedInstance | undefined {
+    if (this.args.isFileDef) {
+      let instance = this.selectedFileMetaInstance;
+      if (!instance) {
+        return undefined;
+      }
+      return { card: instance, fieldIndex: undefined };
+    }
     if (!this.card) {
       return undefined;
     }
@@ -494,8 +574,12 @@ export default class PlaygroundPanel extends Component<Signature> {
     };
   }
 
-  @action private onSelect(item: PrerenderedCardLike | FieldOption) {
-    if (this.args.isFieldDef) {
+  @action private onSelect(item: PrerenderedCardLike | FieldOption | FileDef) {
+    if (this.args.isFileDef) {
+      let fileId = (item as FileDef).id!;
+      this.selectedFileMetaId = fileId;
+      this.persistSelections(fileId);
+    } else if (this.args.isFieldDef) {
       this.persistSelections(
         this.card!.id,
         this.format,
@@ -516,6 +600,10 @@ export default class PlaygroundPanel extends Component<Signature> {
 
   private get defaultFormat() {
     return this.args.isFieldDef ? 'embedded' : 'isolated';
+  }
+
+  private get fileDefAfterMenuOptions(): MenuItem[] {
+    return [];
   }
 
   private get format(): Format {
@@ -821,6 +909,7 @@ export default class PlaygroundPanel extends Component<Signature> {
 
   <template>
     {{consumeContext this.makeCardResource}}
+    {{consumeContext this.searchFileMeta}}
 
     {{#if this.query}}
       <PrerenderedCardSearch
@@ -874,20 +963,31 @@ export default class PlaygroundPanel extends Component<Signature> {
             <LoadingIndicator @color='var(--boxel-light)' />
           </div>
         {{else}}
-          {{#let (if @isFieldDef this.field this.card) as |card|}}
+          {{#let
+            (if
+              @isFieldDef
+              this.field
+              (if @isFileDef this.selectedFileMetaInstance this.card)
+            )
+            as |card|
+          }}
             {{#let
               (component
                 InstanceSelectDropdown
                 isFieldDef=@isFieldDef
+                isFileDef=@isFileDef
                 cardOptions=this.cardOptions
                 fieldOptions=this.fieldInstances
+                fileMetaOptions=this.fileMetaInstances
                 findSelectedCard=this.findSelectedCard
                 selection=this.dropdownSelection
                 onSelect=this.onSelect
                 moduleId=this.moduleId
                 persistSelections=this.persistSelections
                 recentCardIds=this.recentCardIds
-                afterMenuOptions=this.afterMenuOptions
+                afterMenuOptions=(if
+                  @isFileDef this.fileDefAfterMenuOptions this.afterMenuOptions
+                )
               )
               as |InstanceChooser|
             }}
@@ -914,6 +1014,7 @@ export default class PlaygroundPanel extends Component<Signature> {
                   </CardContainer>
                 {{/if}}
               {{else if card}}
+                {{afterRender this.processFileMetaResults}}
                 <div
                   class='preview-area'
                   data-test-field-preview-card={{@isFieldDef}}
@@ -928,20 +1029,31 @@ export default class PlaygroundPanel extends Component<Signature> {
                     @card={{card}}
                     @format={{this.format}}
                     @realmInfo={{this.realmInfo}}
-                    @contextMenuItems={{this.contextMenuItems}}
-                    @onEdit={{if this.setEditMode (fn this.setFormat 'edit')}}
+                    @contextMenuItems={{unless
+                      @isFileDef
+                      this.contextMenuItems
+                    }}
+                    @onEdit={{unless
+                      @isFileDef
+                      (if this.setEditMode (fn this.setFormat 'edit'))
+                    }}
                     @onFinishEditing={{if
                       (eq this.format 'edit')
                       (fn this.setFormat this.defaultFormat)
                     }}
                     @isFieldDef={{@isFieldDef}}
+                    @isFileDef={{@isFileDef}}
                   />
                 </div>
                 <section class='instance-chooser-container'>
                   <InstanceChooser />
                   <FormatChooser
                     class='format-chooser'
-                    @formats={{if @isFieldDef this.fieldFormats}}
+                    @formats={{if
+                      @isFileDef
+                      this.fileDefFormats
+                      (if @isFieldDef this.fieldFormats)
+                    }}
                     @format={{this.format}}
                     @setFormat={{this.setFormat}}
                     data-test-playground-format-chooser
@@ -957,6 +1069,14 @@ export default class PlaygroundPanel extends Component<Signature> {
                   @realms={{this.realmServer.availableRealmURLs}}
                   @createNewCard={{this.createNew}}
                 />
+              {{else if @isFileDef}}
+                <p
+                  class='filedef-info-message'
+                  data-test-playground-filedef-message
+                >
+                  <span>No file instances found. File instances are created by
+                    uploading files to a realm.</span>
+                </p>
               {{/if}}
             {{/let}}
           {{/let}}
@@ -1037,6 +1157,21 @@ export default class PlaygroundPanel extends Component<Signature> {
         flex: 1;
         min-height: 100%;
         width: 100%;
+      }
+      .filedef-info-message {
+        display: flex;
+        flex-wrap: wrap;
+        align-content: center;
+        justify-content: center;
+        text-align: center;
+        height: 100%;
+        color: var(--boxel-450);
+        font-weight: 500;
+        padding: var(--boxel-sp-xl);
+        margin-block: 0;
+      }
+      .filedef-info-message > span {
+        max-width: 400px;
       }
 
       .playground-panel-content:has(.social-preview-container) {

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-preview.gts
@@ -3,6 +3,7 @@ import type { TemplateOnlyComponent } from '@ember/component/template-only';
 import { CardContainer, CardHeader } from '@cardstack/boxel-ui/components';
 import type { MenuItem } from '@cardstack/boxel-ui/helpers';
 import { eq, or } from '@cardstack/boxel-ui/helpers';
+import { get } from '@ember/helper';
 
 import {
   cardTypeDisplayName,
@@ -50,7 +51,7 @@ const PlaygroundPreview: TemplateOnlyComponent<Signature> = <template>
           @cardTitle={{if
             (isCardInstance @card)
             @card.cardTitle
-            (if @isFileDef @card.name undefined)
+            (if @isFileDef (get @card "name") undefined)
           }}
           @realmInfo={{@realmInfo}}
           @onEdit={{@onEdit}}

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-preview.gts
@@ -1,9 +1,9 @@
 import type { TemplateOnlyComponent } from '@ember/component/template-only';
+import { get } from '@ember/helper';
 
 import { CardContainer, CardHeader } from '@cardstack/boxel-ui/components';
 import type { MenuItem } from '@cardstack/boxel-ui/helpers';
 import { eq, or } from '@cardstack/boxel-ui/helpers';
-import { get } from '@ember/helper';
 
 import {
   cardTypeDisplayName,
@@ -51,7 +51,7 @@ const PlaygroundPreview: TemplateOnlyComponent<Signature> = <template>
           @cardTitle={{if
             (isCardInstance @card)
             @card.cardTitle
-            (if @isFileDef (get @card "name") undefined)
+            (if @isFileDef (get @card 'name') undefined)
           }}
           @realmInfo={{@realmInfo}}
           @onEdit={{@onEdit}}

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground-preview.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground-preview.gts
@@ -19,12 +19,14 @@ import type {
   FieldDef,
   Format,
 } from 'https://cardstack.com/base/card-api';
+import type { FileDef } from 'https://cardstack.com/base/file-api';
 
 interface Signature {
   Args: {
     format: Format;
-    card: CardDef | FieldDef;
+    card: CardDef | FieldDef | FileDef;
     isFieldDef?: boolean;
+    isFileDef?: boolean;
     realmInfo?: EnhancedRealmInfo;
     contextMenuItems?: MenuItem[];
     onEdit?: () => void;
@@ -45,7 +47,11 @@ const PlaygroundPreview: TemplateOnlyComponent<Signature> = <template>
           class='preview-header'
           @cardTypeDisplayName={{cardTypeDisplayName @card}}
           @cardTypeIcon={{cardTypeIcon @card}}
-          @cardTitle={{if (isCardInstance @card) @card.cardTitle undefined}}
+          @cardTitle={{if
+            (isCardInstance @card)
+            @card.cardTitle
+            (if @isFileDef @card.name undefined)
+          }}
           @realmInfo={{@realmInfo}}
           @onEdit={{@onEdit}}
           @onFinishEditing={{@onFinishEditing}}

--- a/packages/host/app/components/operator-mode/code-submode/playground/playground.gts
+++ b/packages/host/app/components/operator-mode/code-submode/playground/playground.gts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 
 import { not } from '@cardstack/boxel-ui/helpers';
 
-import { isFieldDef, isPrimitive } from '@cardstack/runtime-common';
+import { isFieldDef, isFileDef, isPrimitive } from '@cardstack/runtime-common';
 import type { ResolvedCodeRef } from '@cardstack/runtime-common';
 
 import type { BaseDef, ViewCardFn } from 'https://cardstack.com/base/card-api';
@@ -77,6 +77,7 @@ export default class Playground extends Component<Signature> {
     return {
       codeRef: this.args.codeRef,
       isFieldDef: isFieldDef(this.args.cardOrField),
+      isFileDef: isFileDef(this.args.cardOrField),
       isUpdating: this.args.isUpdating,
     };
   }
@@ -86,6 +87,7 @@ export default class Playground extends Component<Signature> {
       <PlaygroundPanel
         @codeRef={{this.playgroundPanelArgs.codeRef}}
         @isFieldDef={{this.playgroundPanelArgs.isFieldDef}}
+        @isFileDef={{this.playgroundPanelArgs.isFileDef}}
         @isUpdating={{this.playgroundPanelArgs.isUpdating}}
         @viewCard={{@viewCard}}
       />

--- a/packages/host/app/services/code-semantics-service.ts
+++ b/packages/host/app/services/code-semantics-service.ts
@@ -23,6 +23,7 @@ import {
   type State,
   type ModuleDeclaration,
   isCardOrFieldDeclaration,
+  isReexportCardOrField,
 } from '../resources/module-contents';
 import { findDeclarationByName } from '../services/module-contents-service';
 
@@ -168,7 +169,8 @@ export default class CodeSemanticsService extends Service {
   get selectedCardOrField() {
     if (
       this.selectedDeclaration !== undefined &&
-      isCardOrFieldDeclaration(this.selectedDeclaration)
+      (isCardOrFieldDeclaration(this.selectedDeclaration) ||
+        isReexportCardOrField(this.selectedDeclaration))
     ) {
       return this.selectedDeclaration;
     }

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -33,6 +33,7 @@ import { CodeModePanelHeights } from '@cardstack/host/utils/local-storage-keys';
 import {
   elementIsVisible,
   getMonacoContent,
+  makeMinimalPng,
   percySnapshot,
   setupLocalIndexing,
   setupRealmCacheTeardown,
@@ -401,6 +402,10 @@ const fileDefSource = `
   }
 `;
 
+const pngDefModuleSource = `
+  export { PngDef } from 'https://cardstack.com/base/png-image-def';
+`;
+
 const localInheritSource = `
   import {
     contains,
@@ -488,6 +493,9 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
           're-export.gts': reExportSource,
           'local-inherit.gts': localInheritSource,
           'file-def.gts': fileDefSource,
+          'png-def-module.gts': pngDefModuleSource,
+          'images/sample.png': makeMinimalPng(),
+          'images/logo.png': makeMinimalPng(2, 2),
           'command-module.gts': commandModuleSource,
           'erroring-module.gts': erroringModuleSource,
           'empty-file.gts': '',
@@ -502,7 +510,6 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
                 ref: {
                   module: `./person`,
                   name: 'Person',
-                },
               },
               meta: {
                 adoptsFrom: {
@@ -1606,6 +1613,25 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
       .dom('[data-test-active-module-inspector-view="preview"]')
       .exists('playground pane renders for FileDef');
 
+    // CustomFileDef has no matching file instances, so "no instances" message should show
+    await waitFor('[data-test-playground-filedef-message]');
+    assert
+      .dom('[data-test-playground-filedef-message]')
+      .includesText(
+        'No file instances found',
+        'shows no-instances message for FileDef with no matching files',
+      );
+    assert
+      .dom('[data-test-instance-chooser]')
+      .doesNotExist(
+        'instance chooser is not shown when there are no file instances',
+      );
+    assert
+      .dom('[data-test-playground-format-chooser]')
+      .doesNotExist(
+        'format chooser is not shown when there are no file instances',
+      );
+
     // Switch to Spec pane - should not crash
     await click('[data-test-module-inspector-view="spec"]');
     assert
@@ -1618,6 +1644,181 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
       .dom('[data-test-active-module-inspector-view="schema"]')
       .exists('schema pane renders for FileDef');
     assert.dom('[data-test-card-schema="custom file"]').exists();
+  });
+
+  test('Playground displays file-meta instances for PngDef with preview, instance chooser, and format chooser', async function (assert) {
+    await visitOperatorMode({
+      stacks: [[]],
+      submode: 'code',
+      codePath: `${testRealmURL}png-def-module.gts`,
+    });
+
+    await waitFor('[data-test-card-inspector-panel]');
+    await waitFor('[data-test-current-module-name]');
+    await waitFor('[data-test-in-this-file-selector]');
+
+    // Select the PngDef declaration
+    await click('[data-test-boxel-selector-item-text="PngDef"]');
+
+    // Switch to Playground pane
+    await click('[data-test-module-inspector-view="preview"]');
+
+    // Wait for file-meta search to complete and render the instance chooser
+    await waitFor('[data-test-instance-chooser]', { timeout: 10000 });
+
+    // Core layout: preview + instance chooser + format chooser all present
+    assert
+      .dom('[data-test-playground-panel]')
+      .exists('playground panel renders');
+    assert
+      .dom('[data-test-instance-chooser]')
+      .exists('instance chooser is shown');
+    assert
+      .dom('[data-test-playground-format-chooser]')
+      .exists('format chooser is shown');
+    assert
+      .dom('[data-test-playground-filedef-message]')
+      .doesNotExist('no-instances message is NOT shown when instances exist');
+
+    // Instance title shows the filename
+    assert
+      .dom('[data-test-selected-item]')
+      .exists('selected item is displayed');
+    assert
+      .dom('[data-test-selected-item]')
+      .containsText('.png', 'selected item title contains filename');
+
+    // CardHeader shows the file type display name
+    assert
+      .dom('[data-test-playground-panel] [data-test-boxel-card-header-title]')
+      .exists('card header renders for file preview');
+
+    // Format chooser has the correct formats (isolated, embedded, fitted, atom — NO edit)
+    assert
+      .dom(
+        '[data-test-playground-format-chooser] [data-test-format-chooser="isolated"]',
+      )
+      .exists('isolated format available');
+    assert
+      .dom(
+        '[data-test-playground-format-chooser] [data-test-format-chooser="embedded"]',
+      )
+      .exists('embedded format available');
+    assert
+      .dom(
+        '[data-test-playground-format-chooser] [data-test-format-chooser="fitted"]',
+      )
+      .exists('fitted format available');
+    assert
+      .dom(
+        '[data-test-playground-format-chooser] [data-test-format-chooser="atom"]',
+      )
+      .exists('atom format available');
+    assert
+      .dom(
+        '[data-test-playground-format-chooser] [data-test-format-chooser="edit"]',
+      )
+      .doesNotExist('edit format is NOT available for FileDef');
+
+    // Default format is isolated
+    assert
+      .dom('[data-test-format-chooser="isolated"]')
+      .hasClass('active', 'isolated is the default active format');
+  });
+
+  test('Playground FileDef format switching renders different formats', async function (assert) {
+    await visitOperatorMode({
+      stacks: [[]],
+      submode: 'code',
+      codePath: `${testRealmURL}png-def-module.gts`,
+    });
+
+    await waitFor('[data-test-card-inspector-panel]');
+    await waitFor('[data-test-current-module-name]');
+    await waitFor('[data-test-in-this-file-selector]');
+    await click('[data-test-boxel-selector-item-text="PngDef"]');
+    await click('[data-test-module-inspector-view="preview"]');
+    await waitFor('[data-test-instance-chooser]', { timeout: 10000 });
+
+    // Default: isolated is active
+    assert
+      .dom('[data-test-format-chooser="isolated"]')
+      .hasClass('active', 'starts in isolated format');
+
+    // Switch to embedded
+    await click('[data-test-format-chooser="embedded"]');
+    assert
+      .dom('[data-test-format-chooser="isolated"]')
+      .hasNoClass('active', 'isolated no longer active');
+    assert
+      .dom('[data-test-format-chooser="embedded"]')
+      .hasClass('active', 'embedded is now active');
+
+    // Switch to atom
+    await click('[data-test-format-chooser="atom"]');
+    assert
+      .dom('[data-test-format-chooser="embedded"]')
+      .hasNoClass('active', 'embedded no longer active');
+    assert
+      .dom('[data-test-format-chooser="atom"]')
+      .hasClass('active', 'atom is now active');
+    assert
+      .dom('[data-test-atom-preview]')
+      .exists('atom preview container renders');
+
+    // Switch to fitted
+    await click('[data-test-format-chooser="fitted"]');
+    assert
+      .dom('[data-test-format-chooser="atom"]')
+      .hasNoClass('active', 'atom no longer active');
+    assert
+      .dom('[data-test-format-chooser="fitted"]')
+      .hasClass('active', 'fitted is now active');
+  });
+
+  test('Playground FileDef instance selection switches the displayed file', async function (assert) {
+    await visitOperatorMode({
+      stacks: [[]],
+      submode: 'code',
+      codePath: `${testRealmURL}png-def-module.gts`,
+    });
+
+    await waitFor('[data-test-card-inspector-panel]');
+    await waitFor('[data-test-current-module-name]');
+    await waitFor('[data-test-in-this-file-selector]');
+    await click('[data-test-boxel-selector-item-text="PngDef"]');
+    await click('[data-test-module-inspector-view="preview"]');
+    await waitFor('[data-test-instance-chooser]', { timeout: 10000 });
+
+    // Capture the initial selected item title
+    let initialTitle =
+      document
+        .querySelector('[data-test-selected-item]')
+        ?.textContent?.trim() ?? '';
+    assert.ok(initialTitle.length > 0, 'initial selection has a title');
+
+    // Open the dropdown and verify there are multiple options (we added 2 PNGs)
+    await click('[data-test-instance-chooser]');
+    assert
+      .dom('[data-option-index="0"]')
+      .exists('first dropdown option exists');
+    assert
+      .dom('[data-option-index="1"]')
+      .exists('second dropdown option exists');
+
+    // Select the second option using the data-option-index selector
+    await click('[data-option-index="1"]');
+
+    let newTitle =
+      document
+        .querySelector('[data-test-selected-item]')
+        ?.textContent?.trim() ?? '';
+    assert.ok(newTitle.length > 0, 'new selection has a title');
+    assert.notEqual(
+      newTitle,
+      initialTitle,
+      'selected instance changed after clicking a different option',
+    );
   });
 
   test('"in-this-file" panel displays local grandfather card. selection will move cursor and display card or field schema', async function (assert) {

--- a/packages/host/tests/acceptance/code-submode/inspector-test.ts
+++ b/packages/host/tests/acceptance/code-submode/inspector-test.ts
@@ -510,6 +510,7 @@ module('Acceptance | code submode | inspector tests', function (hooks) {
                 ref: {
                   module: `./person`,
                   name: 'Person',
+                },
               },
               meta: {
                 adoptsFrom: {


### PR DESCRIPTION
## Summary

- When a FileDef (e.g. PngDef) is selected in code mode, the Playground now queries for matching file-meta instances and displays them with instance selection, format chooser, and preview — the same UX as card/field defs
- Fixed `code-semantics-service` to recognize re-exported card/field defs (e.g. `export { PngDef } from '...'`) via `isReexportCardOrField` check
- Added reactive file-meta instance selection with `@tracked selectedFileMetaId`
- Polished the file-meta instance chooser dropdown:
  - "Files" header instead of "Recent", "File:" label instead of "Instance:"
  - Clean file list items without card container chrome
  - Hidden "Action" header for file-meta
  - Dropdown capped at 20 items with a "Choose file…" action that opens the File Chooser modal pre-filtered to the selected FileDef type

## Test plan

- [x] 3 new PngDef playground tests: preview rendering, format chooser without edit, instance selection switching
- [x] Updated CustomFileDef empty-state test for "No file instances found" message
- [x] All 52 inspector tests pass, all 39 card playground tests pass (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="4292" height="3048" alt="image" src="https://github.com/user-attachments/assets/c44773cb-7994-47f2-ad59-13850293c870" />
