### PR TITLE
Add TextFileDef and JsonFileDef for plain text and JSON files

### DIFF
--- a/packages/base/json-file-def.gts
+++ b/packages/base/json-file-def.gts
@@ -70,9 +70,9 @@ function highlightJson(json: string): string {
     /(&quot;)((?:[^&]|&(?!quot;))*)(&quot;)\s*:/g,
     '<span class="json-key">$1$2$3</span>:',
   );
-  // Highlight string values (quoted strings not followed by colon)
+  // Highlight string values (quoted strings not followed by colon or </span>:)
   escaped = escaped.replace(
-    /(&quot;)((?:[^&]|&(?!quot;))*)(&quot;)(?!\s*:)/g,
+    /(&quot;)((?:[^&]|&(?!quot;))*)(&quot;)(?!\s*(?:<\/span>)?\s*:)/g,
     '<span class="json-string">$1$2$3</span>',
   );
   // Highlight numbers

--- a/packages/base/json-file-def.gts
+++ b/packages/base/json-file-def.gts
@@ -1,0 +1,500 @@
+import { byteStreamToUint8Array } from '@cardstack/runtime-common';
+import JsonIcon from '@cardstack/boxel-icons/json';
+import {
+  BaseDefComponent,
+  Component,
+  StringField,
+  contains,
+  field,
+} from './card-api';
+import {
+  FileContentMismatchError,
+  FileDef,
+  type ByteStream,
+  type SerializedFile,
+} from './file-api';
+import sanitizedHtml from './helpers/sanitized-html';
+
+const EXCERPT_MAX_LENGTH = 500;
+
+function escapeHtml(unsafe: string): string {
+  return unsafe
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+function getExtension(url: string): string {
+  try {
+    let parsed = new URL(url);
+    let name = parsed.pathname.split('/').pop() ?? '';
+    let dot = name.lastIndexOf('.');
+    return dot === -1 ? '' : name.slice(dot).toLowerCase();
+  } catch {
+    let dot = url.lastIndexOf('.');
+    return dot === -1 ? '' : url.slice(dot).toLowerCase();
+  }
+}
+
+function fileNameWithoutExtension(name: string): string {
+  return name.replace(/\.[^/.]+$/, '');
+}
+
+function truncateExcerpt(text: string): string {
+  if (text.length <= EXCERPT_MAX_LENGTH) {
+    return text;
+  }
+  return `${text.slice(0, EXCERPT_MAX_LENGTH - 3).trimEnd()}...`;
+}
+
+function jsonTitle(
+  model: { title?: string | null; name?: string | null } | null | undefined,
+): string {
+  return model?.title ?? model?.name ?? 'Untitled JSON';
+}
+
+function prettyPrintJson(content: string): string {
+  try {
+    return JSON.stringify(JSON.parse(content), null, 2);
+  } catch {
+    return content;
+  }
+}
+
+function highlightJson(json: string): string {
+  let escaped = escapeHtml(json);
+  // Highlight keys (property names before colon)
+  escaped = escaped.replace(
+    /(&quot;)((?:[^&]|&(?!quot;))*)(&quot;)\s*:/g,
+    '<span class="json-key">$1$2$3</span>:',
+  );
+  // Highlight string values (quoted strings not followed by colon)
+  escaped = escaped.replace(
+    /(&quot;)((?:[^&]|&(?!quot;))*)(&quot;)(?!\s*:)/g,
+    '<span class="json-string">$1$2$3</span>',
+  );
+  // Highlight numbers
+  escaped = escaped.replace(
+    /\b(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)\b/g,
+    '<span class="json-number">$1</span>',
+  );
+  // Highlight booleans
+  escaped = escaped.replace(
+    /\b(true|false)\b/g,
+    '<span class="json-boolean">$1</span>',
+  );
+  // Highlight null
+  escaped = escaped.replace(
+    /\bnull\b/g,
+    '<span class="json-null">null</span>',
+  );
+  return escaped;
+}
+
+class Isolated extends Component<typeof JsonFileDef> {
+  get title() {
+    return jsonTitle(this.args.model);
+  }
+
+  get highlightedContent() {
+    let content = this.args.model?.content ?? '';
+    if (!content.trim()) {
+      return '';
+    }
+    return highlightJson(prettyPrintJson(content));
+  }
+
+  get hasContent() {
+    return Boolean(this.args.model?.content?.trim());
+  }
+
+  <template>
+    <article class='json-isolated' data-test-json-isolated>
+      {{#if this.hasContent}}
+        <pre class='json-isolated__content'>{{sanitizedHtml
+            this.highlightedContent
+          }}</pre>
+      {{else}}
+        <header class='json-isolated__title'>{{this.title}}</header>
+      {{/if}}
+    </article>
+    <style scoped>
+      .json-isolated {
+        padding: var(--boxel-sp-lg);
+        max-width: 100%;
+      }
+
+      .json-isolated__title {
+        color: var(--boxel-900);
+        font-weight: 600;
+        font-size: var(--boxel-font-size-lg);
+      }
+
+      .json-isolated__content {
+        font-family: var(--boxel-monospace-font-family, monospace);
+        white-space: pre-wrap;
+        word-wrap: break-word;
+        margin: 0;
+        font-size: var(--boxel-font-sm);
+        line-height: 1.5;
+        background-color: var(--boxel-dark);
+        color: var(--boxel-light);
+        border-radius: var(--boxel-border-radius-xl);
+        padding: var(--boxel-sp-lg);
+      }
+
+      .json-isolated__content :deep(.json-key) {
+        color: #9cdcfe;
+      }
+
+      .json-isolated__content :deep(.json-string) {
+        color: #ce9178;
+      }
+
+      .json-isolated__content :deep(.json-number) {
+        color: #b5cea8;
+      }
+
+      .json-isolated__content :deep(.json-boolean) {
+        color: #569cd6;
+      }
+
+      .json-isolated__content :deep(.json-null) {
+        color: #569cd6;
+      }
+    </style>
+  </template>
+}
+
+class Embedded extends Component<typeof JsonFileDef> {
+  get title() {
+    return jsonTitle(this.args.model);
+  }
+
+  get highlightedContent() {
+    let content = this.args.model?.content ?? '';
+    if (!content.trim()) {
+      return '';
+    }
+    return highlightJson(prettyPrintJson(content));
+  }
+
+  <template>
+    <article class='json-embedded' data-test-json-embedded>
+      <header class='json-embedded__title'>{{this.title}}</header>
+      <div class='json-embedded__content'>
+        <pre class='json-embedded__pre'>{{sanitizedHtml
+            this.highlightedContent
+          }}</pre>
+      </div>
+    </article>
+    <style scoped>
+      .json-embedded {
+        display: flex;
+        flex-direction: column;
+        gap: var(--boxel-sp-xs);
+        padding: var(--boxel-sp);
+      }
+
+      .json-embedded__title {
+        color: var(--boxel-900);
+        font-weight: 600;
+      }
+
+      .json-embedded__content {
+        max-height: 200px;
+        overflow: hidden;
+        mask-image: linear-gradient(to bottom, black 60%, transparent 100%);
+        -webkit-mask-image: linear-gradient(
+          to bottom,
+          black 60%,
+          transparent 100%
+        );
+      }
+
+      .json-embedded__pre {
+        font-family: var(--boxel-monospace-font-family, monospace);
+        white-space: pre-wrap;
+        word-wrap: break-word;
+        margin: 0;
+        font-size: var(--boxel-font-sm);
+        line-height: 1.5;
+        background-color: var(--boxel-dark);
+        color: var(--boxel-light);
+        border-radius: var(--boxel-border-radius-xl);
+        padding: var(--boxel-sp-lg);
+      }
+
+      .json-embedded__pre :deep(.json-key) {
+        color: #9cdcfe;
+      }
+
+      .json-embedded__pre :deep(.json-string) {
+        color: #ce9178;
+      }
+
+      .json-embedded__pre :deep(.json-number) {
+        color: #b5cea8;
+      }
+
+      .json-embedded__pre :deep(.json-boolean) {
+        color: #569cd6;
+      }
+
+      .json-embedded__pre :deep(.json-null) {
+        color: #569cd6;
+      }
+    </style>
+  </template>
+}
+
+class Fitted extends Component<typeof JsonFileDef> {
+  get title() {
+    return jsonTitle(this.args.model);
+  }
+
+  get excerpt() {
+    return this.args.model?.excerpt ?? '';
+  }
+
+  get hasExcerpt() {
+    return Boolean(this.excerpt);
+  }
+
+  <template>
+    <article class='json-fitted' data-test-json-fitted>
+      <div class='json-fitted__icon'>
+        <JsonIcon width='100%' height='100%' />
+      </div>
+      <div class='json-fitted__text'>
+        <header class='json-fitted__title'>{{this.title}}</header>
+        {{#if this.hasExcerpt}}
+          <p class='json-fitted__excerpt'>{{this.excerpt}}</p>
+        {{/if}}
+      </div>
+    </article>
+    <style scoped>
+      .json-fitted {
+        container-name: fitted-card;
+        container-type: size;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: flex-start;
+        gap: var(--boxel-sp-xs);
+        padding: var(--boxel-sp-xs);
+        overflow: hidden;
+      }
+
+      .json-fitted__icon {
+        flex-shrink: 0;
+        width: 20px;
+        height: 20px;
+        color: var(--boxel-600);
+      }
+
+      .json-fitted__text {
+        min-width: 0;
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: var(--boxel-sp-4xs);
+      }
+
+      .json-fitted__title {
+        color: var(--boxel-900);
+        font-weight: 600;
+        font-size: var(--boxel-font-sm);
+        overflow: hidden;
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 2;
+      }
+
+      .json-fitted__excerpt {
+        color: var(--boxel-600);
+        font-size: var(--boxel-font-xs);
+        margin: 0;
+        overflow: hidden;
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 3;
+      }
+
+      /* Portrait tall: icon above text */
+      @container fitted-card (aspect-ratio <= 1.0) and (height >= 120px) {
+        .json-fitted {
+          flex-direction: column;
+          align-items: center;
+          text-align: center;
+        }
+
+        .json-fitted__icon {
+          width: 28px;
+          height: 28px;
+        }
+
+        .json-fitted__title {
+          -webkit-line-clamp: 3;
+        }
+      }
+
+      /* Portrait short: hide excerpt */
+      @container fitted-card (aspect-ratio <= 1.0) and (height < 120px) {
+        .json-fitted__excerpt {
+          display: none;
+        }
+      }
+
+      /* Portrait very short: hide icon too */
+      @container fitted-card (aspect-ratio <= 1.0) and (height < 80px) {
+        .json-fitted__icon {
+          display: none;
+        }
+      }
+
+      /* Landscape: icon left of text */
+      @container fitted-card (1.0 < aspect-ratio) {
+        .json-fitted {
+          align-items: flex-start;
+        }
+      }
+
+      /* Landscape short: hide excerpt */
+      @container fitted-card (1.0 < aspect-ratio) and (height < 80px) {
+        .json-fitted__excerpt {
+          display: none;
+        }
+      }
+
+      /* Very small: title only, smaller font */
+      @container fitted-card (height <= 57px) {
+        .json-fitted__icon {
+          display: none;
+        }
+
+        .json-fitted__excerpt {
+          display: none;
+        }
+
+        .json-fitted__title {
+          font-size: var(--boxel-font-xs);
+          -webkit-line-clamp: 1;
+        }
+      }
+    </style>
+  </template>
+}
+
+class Atom extends Component<typeof JsonFileDef> {
+  get title() {
+    return jsonTitle(this.args.model);
+  }
+
+  <template>
+    <span class='json-atom' data-test-json-atom>
+      <JsonIcon class='json-atom__icon' width='16' height='16' />
+      <span class='json-atom__title'>{{this.title}}</span>
+    </span>
+    <style scoped>
+      .json-atom {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--boxel-sp-4xs);
+        min-width: 0;
+      }
+
+      .json-atom__icon {
+        flex-shrink: 0;
+        color: var(--boxel-600);
+      }
+
+      .json-atom__title {
+        color: var(--boxel-900);
+        font-size: var(--boxel-font-sm);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    </style>
+  </template>
+}
+
+class Head extends Component<typeof JsonFileDef> {
+  get title() {
+    return jsonTitle(this.args.model);
+  }
+
+  get description() {
+    return this.args.model?.excerpt;
+  }
+
+  <template>
+    {{! template-lint-disable no-forbidden-elements }}
+    <title data-test-card-head-title>{{this.title}}</title>
+
+    <meta property='og:title' content={{this.title}} />
+    <meta name='twitter:title' content={{this.title}} />
+    <meta property='og:url' content={{@model.id}} />
+
+    {{#if this.description}}
+      <meta name='description' content={{this.description}} />
+      <meta property='og:description' content={{this.description}} />
+      <meta name='twitter:description' content={{this.description}} />
+    {{/if}}
+
+    <meta name='twitter:card' content='summary' />
+    <meta property='og:type' content='article' />
+  </template>
+}
+
+export class JsonFileDef extends FileDef {
+  static displayName = 'JSON';
+  static icon = JsonIcon;
+  static acceptTypes = '.json,application/json';
+
+  @field title = contains(StringField);
+  @field excerpt = contains(StringField);
+  @field content = contains(StringField);
+
+  static isolated: BaseDefComponent = Isolated;
+  static embedded: BaseDefComponent = Embedded;
+  static fitted: BaseDefComponent = Fitted;
+  static atom: BaseDefComponent = Atom;
+  static head: BaseDefComponent = Head;
+
+  static async extractAttributes(
+    url: string,
+    getStream: () => Promise<ByteStream>,
+    options: { contentHash?: string } = {},
+  ): Promise<
+    SerializedFile<{ title: string; excerpt: string; content: string }>
+  > {
+    let extension = getExtension(url);
+    if (extension !== '.json') {
+      throw new FileContentMismatchError(
+        `Expected .json file extension, got "${extension || 'none'}"`,
+      );
+    }
+
+    let bytesPromise: Promise<Uint8Array> | undefined;
+    let memoizedStream = async () => {
+      bytesPromise ??= byteStreamToUint8Array(await getStream());
+      return bytesPromise;
+    };
+
+    let base = await super.extractAttributes(url, memoizedStream, options);
+    let bytes = await memoizedStream();
+    let text = new TextDecoder().decode(bytes);
+    let fallbackTitle = fileNameWithoutExtension(base.name ?? '');
+
+    return {
+      ...base,
+      title: fallbackTitle || 'Untitled JSON',
+      excerpt: truncateExcerpt(text.trim()),
+      content: text,
+    };
+  }
+}

--- a/packages/base/json-file-def.gts
+++ b/packages/base/json-file-def.gts
@@ -17,13 +17,21 @@ import sanitizedHtml from './helpers/sanitized-html';
 
 const EXCERPT_MAX_LENGTH = 500;
 
+// content-tag misparses angle brackets inside regex literals in .gts files,
+// so we use RegExp constructor instead.
+const AMP_RE = new RegExp('&', 'g');
+const LT_RE = new RegExp('<', 'g');
+const GT_RE = new RegExp('>', 'g');
+const QUOT_RE = new RegExp('"', 'g');
+const APOS_RE = new RegExp("'", 'g');
+
 function escapeHtml(unsafe: string): string {
   return unsafe
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
+    .replace(AMP_RE, '&amp;')
+    .replace(LT_RE, '&lt;')
+    .replace(GT_RE, '&gt;')
+    .replace(QUOT_RE, '&quot;')
+    .replace(APOS_RE, '&#039;');
 }
 
 function getExtension(url: string): string {
@@ -63,33 +71,38 @@ function prettyPrintJson(content: string): string {
   }
 }
 
+// content-tag misparses HTML tag literals in .gts files,
+// so we build span wrappers dynamically.
+function spanWrap(cls: string, content: string): string {
+  return `<${'span'} class="${cls}">${content}</${'span'}>`;
+}
+
+// Regex patterns and replacements also avoid literal angle brackets
+// via RegExp constructor where they contain </ sequences.
+const KEY_RE = /(&quot;)((?:[^&]|&(?!quot;))*)(&quot;)\s*:/g;
+const STRING_RE = new RegExp(
+  '(&quot;)((?:[^&]|&(?!quot;))*)(&quot;)(?!\\s*(?:<\\/span>)?\\s*:)',
+  'g',
+);
+const NUMBER_RE = /\b(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)\b/g;
+const BOOL_RE = /\b(true|false)\b/g;
+const NULL_RE = /\bnull\b/g;
+
 function highlightJson(json: string): string {
   let escaped = escapeHtml(json);
-  // Highlight keys (property names before colon)
-  escaped = escaped.replace(
-    /(&quot;)((?:[^&]|&(?!quot;))*)(&quot;)\s*:/g,
-    '<span class="json-key">$1$2$3</span>:',
+  escaped = escaped.replace(KEY_RE, (_m, q1, inner, q2) =>
+    `${spanWrap('json-key', `${q1}${inner}${q2}`)}:`,
   );
-  // Highlight string values (quoted strings not followed by colon or </span>:)
-  escaped = escaped.replace(
-    /(&quot;)((?:[^&]|&(?!quot;))*)(&quot;)(?!\s*(?:<\/span>)?\s*:)/g,
-    '<span class="json-string">$1$2$3</span>',
+  escaped = escaped.replace(STRING_RE, (_m, q1, inner, q2) =>
+    spanWrap('json-string', `${q1}${inner}${q2}`),
   );
-  // Highlight numbers
-  escaped = escaped.replace(
-    /\b(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)\b/g,
-    '<span class="json-number">$1</span>',
+  escaped = escaped.replace(NUMBER_RE, (_m, num) =>
+    spanWrap('json-number', num),
   );
-  // Highlight booleans
-  escaped = escaped.replace(
-    /\b(true|false)\b/g,
-    '<span class="json-boolean">$1</span>',
+  escaped = escaped.replace(BOOL_RE, (_m, bool) =>
+    spanWrap('json-boolean', bool),
   );
-  // Highlight null
-  escaped = escaped.replace(
-    /\bnull\b/g,
-    '<span class="json-null">null</span>',
-  );
+  escaped = escaped.replace(NULL_RE, () => spanWrap('json-null', 'null'));
   return escaped;
 }
 

--- a/packages/base/text-file-def.gts
+++ b/packages/base/text-file-def.gts
@@ -1,0 +1,395 @@
+import { byteStreamToUint8Array } from '@cardstack/runtime-common';
+import TextFileIcon from '@cardstack/boxel-icons/file-text';
+import {
+  BaseDefComponent,
+  Component,
+  StringField,
+  contains,
+  field,
+} from './card-api';
+import {
+  FileContentMismatchError,
+  FileDef,
+  type ByteStream,
+  type SerializedFile,
+} from './file-api';
+
+const TEXT_EXTENSIONS = new Set(['.txt', '.text']);
+const EXCERPT_MAX_LENGTH = 500;
+
+function getExtension(url: string): string {
+  try {
+    let parsed = new URL(url);
+    let name = parsed.pathname.split('/').pop() ?? '';
+    let dot = name.lastIndexOf('.');
+    return dot === -1 ? '' : name.slice(dot).toLowerCase();
+  } catch {
+    let dot = url.lastIndexOf('.');
+    return dot === -1 ? '' : url.slice(dot).toLowerCase();
+  }
+}
+
+function fileNameWithoutExtension(name: string): string {
+  return name.replace(/\.[^/.]+$/, '');
+}
+
+function truncateExcerpt(text: string): string {
+  if (text.length <= EXCERPT_MAX_LENGTH) {
+    return text;
+  }
+  return `${text.slice(0, EXCERPT_MAX_LENGTH - 3).trimEnd()}...`;
+}
+
+function textTitle(
+  model: { title?: string | null; name?: string | null } | null | undefined,
+): string {
+  return model?.title ?? model?.name ?? 'Untitled text file';
+}
+
+class Isolated extends Component<typeof TextFileDef> {
+  get title() {
+    return textTitle(this.args.model);
+  }
+
+  get content() {
+    return this.args.model?.content ?? '';
+  }
+
+  get hasContent() {
+    return Boolean(this.args.model?.content?.trim());
+  }
+
+  <template>
+    <article class='text-isolated' data-test-text-isolated>
+      {{#if this.hasContent}}
+        <pre class='text-isolated__content'>{{this.content}}</pre>
+      {{else}}
+        <header class='text-isolated__title'>{{this.title}}</header>
+      {{/if}}
+    </article>
+    <style scoped>
+      .text-isolated {
+        padding: var(--boxel-sp-lg);
+        max-width: 100%;
+      }
+
+      .text-isolated__title {
+        color: var(--boxel-900);
+        font-weight: 600;
+        font-size: var(--boxel-font-size-lg);
+      }
+
+      .text-isolated__content {
+        font-family: monospace;
+        white-space: pre-wrap;
+        word-wrap: break-word;
+        margin: 0;
+        color: var(--boxel-900);
+        font-size: var(--boxel-font-sm);
+        line-height: 1.5;
+      }
+    </style>
+  </template>
+}
+
+class Embedded extends Component<typeof TextFileDef> {
+  get title() {
+    return textTitle(this.args.model);
+  }
+
+  get content() {
+    return this.args.model?.content ?? '';
+  }
+
+  <template>
+    <article class='text-embedded' data-test-text-embedded>
+      <header class='text-embedded__title'>{{this.title}}</header>
+      <div class='text-embedded__content'>
+        <pre class='text-embedded__pre'>{{this.content}}</pre>
+      </div>
+    </article>
+    <style scoped>
+      .text-embedded {
+        display: flex;
+        flex-direction: column;
+        gap: var(--boxel-sp-xs);
+        padding: var(--boxel-sp);
+      }
+
+      .text-embedded__title {
+        color: var(--boxel-900);
+        font-weight: 600;
+      }
+
+      .text-embedded__content {
+        max-height: 200px;
+        overflow: hidden;
+        mask-image: linear-gradient(to bottom, black 60%, transparent 100%);
+        -webkit-mask-image: linear-gradient(
+          to bottom,
+          black 60%,
+          transparent 100%
+        );
+      }
+
+      .text-embedded__pre {
+        font-family: monospace;
+        white-space: pre-wrap;
+        word-wrap: break-word;
+        margin: 0;
+        color: var(--boxel-900);
+        font-size: var(--boxel-font-sm);
+        line-height: 1.5;
+      }
+    </style>
+  </template>
+}
+
+class Fitted extends Component<typeof TextFileDef> {
+  get title() {
+    return textTitle(this.args.model);
+  }
+
+  get excerpt() {
+    return this.args.model?.excerpt ?? '';
+  }
+
+  get hasExcerpt() {
+    return Boolean(this.excerpt);
+  }
+
+  <template>
+    <article class='text-fitted' data-test-text-fitted>
+      <div class='text-fitted__icon'>
+        <TextFileIcon width='100%' height='100%' />
+      </div>
+      <div class='text-fitted__text'>
+        <header class='text-fitted__title'>{{this.title}}</header>
+        {{#if this.hasExcerpt}}
+          <p class='text-fitted__excerpt'>{{this.excerpt}}</p>
+        {{/if}}
+      </div>
+    </article>
+    <style scoped>
+      .text-fitted {
+        container-name: fitted-card;
+        container-type: size;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: flex-start;
+        gap: var(--boxel-sp-xs);
+        padding: var(--boxel-sp-xs);
+        overflow: hidden;
+      }
+
+      .text-fitted__icon {
+        flex-shrink: 0;
+        width: 20px;
+        height: 20px;
+        color: var(--boxel-600);
+      }
+
+      .text-fitted__text {
+        min-width: 0;
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: var(--boxel-sp-4xs);
+      }
+
+      .text-fitted__title {
+        color: var(--boxel-900);
+        font-weight: 600;
+        font-size: var(--boxel-font-sm);
+        overflow: hidden;
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 2;
+      }
+
+      .text-fitted__excerpt {
+        color: var(--boxel-600);
+        font-size: var(--boxel-font-xs);
+        margin: 0;
+        overflow: hidden;
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 3;
+      }
+
+      /* Portrait tall: icon above text */
+      @container fitted-card (aspect-ratio <= 1.0) and (height >= 120px) {
+        .text-fitted {
+          flex-direction: column;
+          align-items: center;
+          text-align: center;
+        }
+
+        .text-fitted__icon {
+          width: 28px;
+          height: 28px;
+        }
+
+        .text-fitted__title {
+          -webkit-line-clamp: 3;
+        }
+      }
+
+      /* Portrait short: hide excerpt */
+      @container fitted-card (aspect-ratio <= 1.0) and (height < 120px) {
+        .text-fitted__excerpt {
+          display: none;
+        }
+      }
+
+      /* Portrait very short: hide icon too */
+      @container fitted-card (aspect-ratio <= 1.0) and (height < 80px) {
+        .text-fitted__icon {
+          display: none;
+        }
+      }
+
+      /* Landscape: icon left of text */
+      @container fitted-card (1.0 < aspect-ratio) {
+        .text-fitted {
+          align-items: flex-start;
+        }
+      }
+
+      /* Landscape short: hide excerpt */
+      @container fitted-card (1.0 < aspect-ratio) and (height < 80px) {
+        .text-fitted__excerpt {
+          display: none;
+        }
+      }
+
+      /* Very small: title only, smaller font */
+      @container fitted-card (height <= 57px) {
+        .text-fitted__icon {
+          display: none;
+        }
+
+        .text-fitted__excerpt {
+          display: none;
+        }
+
+        .text-fitted__title {
+          font-size: var(--boxel-font-xs);
+          -webkit-line-clamp: 1;
+        }
+      }
+    </style>
+  </template>
+}
+
+class Atom extends Component<typeof TextFileDef> {
+  get title() {
+    return textTitle(this.args.model);
+  }
+
+  <template>
+    <span class='text-atom' data-test-text-atom>
+      <TextFileIcon class='text-atom__icon' width='16' height='16' />
+      <span class='text-atom__title'>{{this.title}}</span>
+    </span>
+    <style scoped>
+      .text-atom {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--boxel-sp-4xs);
+        min-width: 0;
+      }
+
+      .text-atom__icon {
+        flex-shrink: 0;
+        color: var(--boxel-600);
+      }
+
+      .text-atom__title {
+        color: var(--boxel-900);
+        font-size: var(--boxel-font-sm);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    </style>
+  </template>
+}
+
+class Head extends Component<typeof TextFileDef> {
+  get title() {
+    return textTitle(this.args.model);
+  }
+
+  get description() {
+    return this.args.model?.excerpt;
+  }
+
+  <template>
+    {{! template-lint-disable no-forbidden-elements }}
+    <title data-test-card-head-title>{{this.title}}</title>
+
+    <meta property='og:title' content={{this.title}} />
+    <meta name='twitter:title' content={{this.title}} />
+    <meta property='og:url' content={{@model.id}} />
+
+    {{#if this.description}}
+      <meta name='description' content={{this.description}} />
+      <meta property='og:description' content={{this.description}} />
+      <meta name='twitter:description' content={{this.description}} />
+    {{/if}}
+
+    <meta name='twitter:card' content='summary' />
+    <meta property='og:type' content='article' />
+  </template>
+}
+
+export class TextFileDef extends FileDef {
+  static displayName = 'Text File';
+  static icon = TextFileIcon;
+  static acceptTypes = '.txt,.text,text/plain';
+
+  @field title = contains(StringField);
+  @field excerpt = contains(StringField);
+  @field content = contains(StringField);
+
+  static isolated: BaseDefComponent = Isolated;
+  static embedded: BaseDefComponent = Embedded;
+  static fitted: BaseDefComponent = Fitted;
+  static atom: BaseDefComponent = Atom;
+  static head: BaseDefComponent = Head;
+
+  static async extractAttributes(
+    url: string,
+    getStream: () => Promise<ByteStream>,
+    options: { contentHash?: string } = {},
+  ): Promise<
+    SerializedFile<{ title: string; excerpt: string; content: string }>
+  > {
+    let extension = getExtension(url);
+    if (!TEXT_EXTENSIONS.has(extension)) {
+      throw new FileContentMismatchError(
+        `Expected text file extension, got "${extension || 'none'}"`,
+      );
+    }
+
+    let bytesPromise: Promise<Uint8Array> | undefined;
+    let memoizedStream = async () => {
+      bytesPromise ??= byteStreamToUint8Array(await getStream());
+      return bytesPromise;
+    };
+
+    let base = await super.extractAttributes(url, memoizedStream, options);
+    let bytes = await memoizedStream();
+    let text = new TextDecoder().decode(bytes);
+    let fallbackTitle = fileNameWithoutExtension(base.name ?? '');
+
+    return {
+      ...base,
+      title: fallbackTitle || 'Untitled text file',
+      excerpt: truncateExcerpt(text.trim()),
+      content: text,
+    };
+  }
+}

--- a/packages/base/text-file-def.gts
+++ b/packages/base/text-file-def.gts
@@ -80,7 +80,7 @@ class Isolated extends Component<typeof TextFileDef> {
       }
 
       .text-isolated__content {
-        font-family: monospace;
+        font-family: var(--boxel-monospace-font-family, monospace);
         white-space: pre-wrap;
         word-wrap: break-word;
         margin: 0;
@@ -133,7 +133,7 @@ class Embedded extends Component<typeof TextFileDef> {
       }
 
       .text-embedded__pre {
-        font-family: monospace;
+        font-family: var(--boxel-monospace-font-family, monospace);
         white-space: pre-wrap;
         word-wrap: break-word;
         margin: 0;

--- a/packages/host/tests/acceptance/code-submode-test.ts
+++ b/packages/host/tests/acceptance/code-submode-test.ts
@@ -933,12 +933,12 @@ module('Acceptance | code submode tests', function (_hooks) {
 
       assert.dom('[data-test-code-mode-card-renderer-body]').exists();
 
-      // File preview header shows "File" type
+      // File preview header shows "JSON" type (JsonFileDef)
       assert
         .dom(
           '[data-test-code-mode-card-renderer-header] [data-test-boxel-card-header-title]',
         )
-        .includesText('File');
+        .includesText('JSON');
 
       // No edit format option for file previews
       assert.dom('[data-test-format-chooser="edit"]').doesNotExist();

--- a/packages/host/tests/acceptance/json-file-def-test.gts
+++ b/packages/host/tests/acceptance/json-file-def-test.gts
@@ -153,10 +153,7 @@ module('Acceptance | json file def', function (hooks) {
 
     let result = await captureFileExtractResult('ready');
     assert.strictEqual(result.status, 'ready');
-    assert.true(
-      result.mismatch,
-      'marks mismatch when extension is not .json',
-    );
+    assert.true(result.mismatch, 'marks mismatch when extension is not .json');
     assert.strictEqual(result.searchDoc?.name, 'readme.md');
   });
 

--- a/packages/host/tests/acceptance/json-file-def-test.gts
+++ b/packages/host/tests/acceptance/json-file-def-test.gts
@@ -1,0 +1,211 @@
+import { visit, waitUntil } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+
+import { module, test } from 'qunit';
+
+import {
+  baseRealm,
+  type FileExtractResponse,
+  type RenderRouteOptions,
+  type ResolvedCodeRef,
+  SupportedMimeType,
+} from '@cardstack/runtime-common';
+import type { Realm } from '@cardstack/runtime-common/realm';
+
+import type NetworkService from '@cardstack/host/services/network';
+
+import {
+  setupLocalIndexing,
+  setupOnSave,
+  setupRealmCacheTeardown,
+  testRealmURL,
+  setupAcceptanceTestRealm,
+  SYSTEM_CARD_FIXTURE_CONTENTS,
+  withCachedRealmSetup,
+} from '../helpers';
+import { setupMockMatrix } from '../helpers/mock-matrix';
+import { setupApplicationTest } from '../helpers/setup';
+
+module('Acceptance | json file def', function (hooks) {
+  setupApplicationTest(hooks);
+  setupLocalIndexing(hooks);
+  setupOnSave(hooks);
+  setupRealmCacheTeardown(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+  });
+  let realm: Realm;
+
+  const renderPath = (
+    url: string,
+    renderOptions: RenderRouteOptions,
+    nonce = 0,
+  ) =>
+    `/render/${encodeURIComponent(url)}/${nonce}/${encodeURIComponent(
+      JSON.stringify(renderOptions),
+    )}/file-extract`;
+
+  const makeFileURL = (path: string) => new URL(path, testRealmURL).href;
+
+  const jsonFileDefCodeRef = (): ResolvedCodeRef => ({
+    module: `${baseRealm.url}json-file-def`,
+    name: 'JsonFileDef',
+  });
+
+  async function captureFileExtractResult(
+    expectedStatus?: 'ready' | 'error',
+  ): Promise<FileExtractResponse> {
+    await waitUntil(
+      () => {
+        let container = document.querySelector(
+          '[data-prerender-file-extract]',
+        ) as HTMLElement | null;
+        if (!container) {
+          return false;
+        }
+        let status = container.getAttribute(
+          'data-prerender-file-extract-status',
+        );
+        if (!status) {
+          return false;
+        }
+        if (expectedStatus && status !== expectedStatus) {
+          return false;
+        }
+        return status === 'ready' || status === 'error';
+      },
+      { timeout: 5000 },
+    );
+
+    let container = document.querySelector(
+      '[data-prerender-file-extract]',
+    ) as HTMLElement | null;
+    if (!container) {
+      throw new Error(
+        'captureFileExtractResult: missing [data-prerender-file-extract] container after wait',
+      );
+    }
+    let pre = container.querySelector('pre');
+    let text = pre?.textContent?.trim() ?? '';
+    return JSON.parse(text) as FileExtractResponse;
+  }
+
+  hooks.beforeEach(async function () {
+    ({ realm } = await withCachedRealmSetup(async () =>
+      setupAcceptanceTestRealm({
+        mockMatrixUtils,
+        contents: {
+          ...SYSTEM_CARD_FIXTURE_CONTENTS,
+          'config.json': JSON.stringify(
+            {
+              name: 'my-app',
+              version: '1.0.0',
+              dependencies: {
+                lodash: '^4.17.21',
+              },
+            },
+            null,
+            2,
+          ),
+          'readme.md': '# A markdown file\n\nSome content here.',
+        },
+      }),
+    ));
+  });
+
+  hooks.afterEach(function () {
+    delete (globalThis as any).__renderModel;
+  });
+
+  test('extracts title, excerpt, and content from .json file', async function (assert) {
+    let url = makeFileURL('config.json');
+    await visit(
+      renderPath(url, {
+        fileExtract: true,
+        fileDefCodeRef: jsonFileDefCodeRef(),
+      }),
+    );
+
+    let result = await captureFileExtractResult('ready');
+    assert.strictEqual(result.status, 'ready');
+    assert.strictEqual(result.searchDoc?.title, 'config');
+    assert.ok(
+      String(result.searchDoc?.excerpt).includes('my-app'),
+      'excerpt includes beginning of JSON content',
+    );
+    assert.ok(
+      String(result.searchDoc?.content).includes('lodash'),
+      'content includes full JSON',
+    );
+    assert.strictEqual(result.searchDoc?.name, 'config.json');
+  });
+
+  test('falls back when JsonFileDef is used for non-json extensions', async function (assert) {
+    let url = makeFileURL('readme.md');
+    await visit(
+      renderPath(url, {
+        fileExtract: true,
+        fileDefCodeRef: jsonFileDefCodeRef(),
+      }),
+    );
+
+    let result = await captureFileExtractResult('ready');
+    assert.strictEqual(result.status, 'ready');
+    assert.true(
+      result.mismatch,
+      'marks mismatch when extension is not .json',
+    );
+    assert.strictEqual(result.searchDoc?.name, 'readme.md');
+  });
+
+  test('indexing stores json search data and file meta uses it', async function (assert) {
+    let fileURL = new URL('config.json', testRealmURL);
+    let fileEntry = await realm.realmIndexQueryEngine.file(fileURL);
+
+    assert.ok(fileEntry, 'file entry exists');
+    assert.strictEqual(
+      fileEntry?.searchDoc?.title,
+      'config',
+      'index stores json title',
+    );
+    assert.ok(
+      String(fileEntry?.searchDoc?.excerpt).includes('my-app'),
+      'index stores json excerpt',
+    );
+
+    let network = getService('network') as NetworkService;
+    let response = await network.virtualNetwork.fetch(fileURL, {
+      headers: { Accept: SupportedMimeType.FileMeta },
+    });
+
+    assert.true(response.ok, 'file meta request succeeds');
+
+    let body = await response.json();
+    assert.strictEqual(body?.data?.type, 'file-meta');
+    assert.strictEqual(
+      body?.data?.attributes?.contentType,
+      'application/json',
+      'file meta uses application/json content type',
+    );
+    assert.strictEqual(
+      body?.data?.attributes?.title,
+      'config',
+      'file meta includes json title',
+    );
+    assert.ok(
+      String(body?.data?.attributes?.excerpt).includes('my-app'),
+      'file meta includes json excerpt',
+    );
+    assert.ok(
+      String(body?.data?.attributes?.content).includes('lodash'),
+      'file meta includes json content',
+    );
+    assert.deepEqual(
+      body?.data?.meta?.adoptsFrom,
+      jsonFileDefCodeRef(),
+      'file meta uses json file def',
+    );
+  });
+});

--- a/packages/host/tests/acceptance/text-file-def-test.gts
+++ b/packages/host/tests/acceptance/text-file-def-test.gts
@@ -1,0 +1,206 @@
+import { visit, waitUntil } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+
+import { module, test } from 'qunit';
+
+import {
+  baseRealm,
+  type FileExtractResponse,
+  type RenderRouteOptions,
+  type ResolvedCodeRef,
+  SupportedMimeType,
+} from '@cardstack/runtime-common';
+import type { Realm } from '@cardstack/runtime-common/realm';
+
+import type NetworkService from '@cardstack/host/services/network';
+
+import {
+  setupLocalIndexing,
+  setupOnSave,
+  setupRealmCacheTeardown,
+  testRealmURL,
+  setupAcceptanceTestRealm,
+  SYSTEM_CARD_FIXTURE_CONTENTS,
+  withCachedRealmSetup,
+} from '../helpers';
+import { setupMockMatrix } from '../helpers/mock-matrix';
+import { setupApplicationTest } from '../helpers/setup';
+
+module('Acceptance | text file def', function (hooks) {
+  setupApplicationTest(hooks);
+  setupLocalIndexing(hooks);
+  setupOnSave(hooks);
+  setupRealmCacheTeardown(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+  });
+  let realm: Realm;
+
+  const renderPath = (
+    url: string,
+    renderOptions: RenderRouteOptions,
+    nonce = 0,
+  ) =>
+    `/render/${encodeURIComponent(url)}/${nonce}/${encodeURIComponent(
+      JSON.stringify(renderOptions),
+    )}/file-extract`;
+
+  const makeFileURL = (path: string) => new URL(path, testRealmURL).href;
+
+  const textFileDefCodeRef = (): ResolvedCodeRef => ({
+    module: `${baseRealm.url}text-file-def`,
+    name: 'TextFileDef',
+  });
+
+  async function captureFileExtractResult(
+    expectedStatus?: 'ready' | 'error',
+  ): Promise<FileExtractResponse> {
+    await waitUntil(
+      () => {
+        let container = document.querySelector(
+          '[data-prerender-file-extract]',
+        ) as HTMLElement | null;
+        if (!container) {
+          return false;
+        }
+        let status = container.getAttribute(
+          'data-prerender-file-extract-status',
+        );
+        if (!status) {
+          return false;
+        }
+        if (expectedStatus && status !== expectedStatus) {
+          return false;
+        }
+        return status === 'ready' || status === 'error';
+      },
+      { timeout: 5000 },
+    );
+
+    let container = document.querySelector(
+      '[data-prerender-file-extract]',
+    ) as HTMLElement | null;
+    if (!container) {
+      throw new Error(
+        'captureFileExtractResult: missing [data-prerender-file-extract] container after wait',
+      );
+    }
+    let pre = container.querySelector('pre');
+    let text = pre?.textContent?.trim() ?? '';
+    return JSON.parse(text) as FileExtractResponse;
+  }
+
+  hooks.beforeEach(async function () {
+    ({ realm } = await withCachedRealmSetup(async () =>
+      setupAcceptanceTestRealm({
+        mockMatrixUtils,
+        contents: {
+          ...SYSTEM_CARD_FIXTURE_CONTENTS,
+          'hello.txt': `Hello, world!
+This is a plain text file.
+It has multiple lines.
+
+And a blank line too.`,
+          'empty.text': '',
+          'readme.md': '# A markdown file\n\nSome content here.',
+        },
+      }),
+    ));
+  });
+
+  hooks.afterEach(function () {
+    delete (globalThis as any).__renderModel;
+  });
+
+  test('extracts title, excerpt, and content from .txt file', async function (assert) {
+    let url = makeFileURL('hello.txt');
+    await visit(
+      renderPath(url, {
+        fileExtract: true,
+        fileDefCodeRef: textFileDefCodeRef(),
+      }),
+    );
+
+    let result = await captureFileExtractResult('ready');
+    assert.strictEqual(result.status, 'ready');
+    assert.strictEqual(result.searchDoc?.title, 'hello');
+    assert.ok(
+      String(result.searchDoc?.excerpt).includes('Hello, world!'),
+      'excerpt includes beginning of text',
+    );
+    assert.ok(
+      String(result.searchDoc?.content).includes('plain text file'),
+      'content includes full text',
+    );
+    assert.strictEqual(result.searchDoc?.name, 'hello.txt');
+  });
+
+  test('falls back when TextFileDef is used for non-text extensions', async function (assert) {
+    let url = makeFileURL('readme.md');
+    await visit(
+      renderPath(url, {
+        fileExtract: true,
+        fileDefCodeRef: textFileDefCodeRef(),
+      }),
+    );
+
+    let result = await captureFileExtractResult('ready');
+    assert.strictEqual(result.status, 'ready');
+    assert.true(
+      result.mismatch,
+      'marks mismatch when extension is not .txt or .text',
+    );
+    assert.strictEqual(result.searchDoc?.name, 'readme.md');
+  });
+
+  test('indexing stores text search data and file meta uses it', async function (assert) {
+    let fileURL = new URL('hello.txt', testRealmURL);
+    let fileEntry = await realm.realmIndexQueryEngine.file(fileURL);
+
+    assert.ok(fileEntry, 'file entry exists');
+    assert.strictEqual(
+      fileEntry?.searchDoc?.title,
+      'hello',
+      'index stores text title',
+    );
+    assert.ok(
+      String(fileEntry?.searchDoc?.excerpt).includes('Hello, world!'),
+      'index stores text excerpt',
+    );
+
+    let network = getService('network') as NetworkService;
+    let response = await network.virtualNetwork.fetch(fileURL, {
+      headers: { Accept: SupportedMimeType.FileMeta },
+    });
+
+    assert.true(response.ok, 'file meta request succeeds');
+
+    let body = await response.json();
+    assert.strictEqual(body?.data?.type, 'file-meta');
+    assert.strictEqual(
+      body?.data?.attributes?.contentType,
+      'text/plain',
+      'file meta uses text/plain content type',
+    );
+    assert.strictEqual(
+      body?.data?.attributes?.title,
+      'hello',
+      'file meta includes text title',
+    );
+    assert.ok(
+      String(body?.data?.attributes?.excerpt).includes('Hello, world!'),
+      'file meta includes text excerpt',
+    );
+    assert.ok(
+      String(body?.data?.attributes?.content).includes('plain text file'),
+      'file meta includes text content',
+    );
+    assert.deepEqual(
+      body?.data?.meta?.adoptsFrom,
+      textFileDefCodeRef(),
+      'file meta uses text file def',
+    );
+  });
+});

--- a/packages/host/tests/acceptance/text-file-def-test.gts
+++ b/packages/host/tests/acceptance/text-file-def-test.gts
@@ -148,10 +148,7 @@ And a blank line too.`,
 
     let result = await captureFileExtractResult('ready');
     assert.strictEqual(result.status, 'ready');
-    assert.true(
-      result.mismatch,
-      'marks mismatch when extension is not .txt or .text',
-    );
+    assert.true(result.mismatch, 'marks mismatch when extension is not .txt or .text');
     assert.strictEqual(result.searchDoc?.name, 'readme.md');
   });
 

--- a/packages/host/tests/acceptance/text-file-def-test.gts
+++ b/packages/host/tests/acceptance/text-file-def-test.gts
@@ -148,7 +148,10 @@ And a blank line too.`,
 
     let result = await captureFileExtractResult('ready');
     assert.strictEqual(result.status, 'ready');
-    assert.true(result.mismatch, 'marks mismatch when extension is not .txt or .text');
+    assert.true(
+      result.mismatch,
+      'marks mismatch when extension is not .txt or .text',
+    );
     assert.strictEqual(result.searchDoc?.name, 'readme.md');
   });
 

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -746,10 +746,12 @@ module('Integration | card-basics', function (hooks) {
         await store.loaded();
 
         await renderCard(loader, gallery as BaseDef, 'fitted');
-        await waitUntil(() =>
-          document
-            .querySelector('[data-test-gallery-fitted]')
-            ?.textContent?.includes('hero.txt'),
+        await waitUntil(
+          () =>
+            document
+              .querySelector('[data-test-gallery-fitted]')
+              ?.textContent?.includes('hero.txt'),
+          { timeout: 5000 },
         );
 
         assert
@@ -822,13 +824,16 @@ module('Integration | card-basics', function (hooks) {
         await store.loaded();
 
         await renderCard(loader, gallery as BaseDef, 'fitted');
-        await waitUntil(() => {
-          let text =
-            document.querySelector(
-              '[data-test-plural-view-field="attachments"]',
-            )?.textContent ?? '';
-          return text.includes('first.txt') && text.includes('second.txt');
-        });
+        await waitUntil(
+          () => {
+            let text =
+              document.querySelector(
+                '[data-test-plural-view-field="attachments"]',
+              )?.textContent ?? '';
+            return text.includes('first.txt') && text.includes('second.txt');
+          },
+          { timeout: 5000 },
+        );
 
         assert
           .dom('[data-test-plural-view-field="attachments"]')

--- a/packages/host/tests/integration/components/card-basics-test.gts
+++ b/packages/host/tests/integration/components/card-basics-test.gts
@@ -750,15 +750,15 @@ module('Integration | card-basics', function (hooks) {
           () =>
             document
               .querySelector('[data-test-gallery-fitted]')
-              ?.textContent?.includes('hero.txt'),
+              ?.textContent?.includes('hero'),
           { timeout: 5000 },
         );
 
         assert
           .dom('[data-test-gallery-fitted]')
           .includesText(
-            'hero.txt',
-            'FileDef renders delegated view from file meta',
+            'hero',
+            'TextFileDef renders delegated view with title from file meta',
           );
       });
 
@@ -830,7 +830,7 @@ module('Integration | card-basics', function (hooks) {
               document.querySelector(
                 '[data-test-plural-view-field="attachments"]',
               )?.textContent ?? '';
-            return text.includes('first.txt') && text.includes('second.txt');
+            return text.includes('first') && text.includes('second');
           },
           { timeout: 5000 },
         );
@@ -841,14 +841,14 @@ module('Integration | card-basics', function (hooks) {
         assert
           .dom('[data-test-plural-view-field="attachments"]')
           .includesText(
-            'first.txt',
-            'FileDef renders delegated view from file meta',
+            'first',
+            'TextFileDef renders delegated view with title from file meta',
           );
         assert
           .dom('[data-test-plural-view-field="attachments"]')
           .includesText(
-            'second.txt',
-            'FileDef renders delegated view from file meta',
+            'second',
+            'TextFileDef renders delegated view with title from file meta',
           );
       });
     });

--- a/packages/realm-server/tests/indexing-test.ts
+++ b/packages/realm-server/tests/indexing-test.ts
@@ -1100,8 +1100,8 @@ module(basename(__filename), function () {
       assert.deepEqual(
         doc.data.meta?.adoptsFrom,
         {
-          module: 'https://cardstack.com/base/file-api',
-          name: 'FileDef',
+          module: 'https://cardstack.com/base/text-file-def',
+          name: 'TextFileDef',
         },
         'adoptsFrom sourced from pristine file resource',
       );

--- a/packages/runtime-common/file-def-code-ref.ts
+++ b/packages/runtime-common/file-def-code-ref.ts
@@ -49,6 +49,10 @@ const FILEDEF_CODE_REF_BY_EXTENSION: Record<string, ResolvedCodeRef> = {
     module: `${baseRealm.url}text-file-def`,
     name: 'TextFileDef',
   },
+  '.json': {
+    module: `${baseRealm.url}json-file-def`,
+    name: 'JsonFileDef',
+  },
   '.mismatch': { module: './filedef-mismatch', name: 'FileDef' },
 };
 

--- a/packages/runtime-common/file-def-code-ref.ts
+++ b/packages/runtime-common/file-def-code-ref.ts
@@ -41,6 +41,14 @@ const FILEDEF_CODE_REF_BY_EXTENSION: Record<string, ResolvedCodeRef> = {
     module: `${baseRealm.url}avif-image-def`,
     name: 'AvifDef',
   },
+  '.txt': {
+    module: `${baseRealm.url}text-file-def`,
+    name: 'TextFileDef',
+  },
+  '.text': {
+    module: `${baseRealm.url}text-file-def`,
+    name: 'TextFileDef',
+  },
   '.mismatch': { module: './filedef-mismatch', name: 'FileDef' },
 };
 

--- a/packages/runtime-common/file-def-code-ref.ts
+++ b/packages/runtime-common/file-def-code-ref.ts
@@ -52,6 +52,7 @@ const FILEDEF_CODE_REF_BY_EXTENSION: Record<string, ResolvedCodeRef> = {
   '.json': {
     module: `${baseRealm.url}json-file-def`,
     name: 'JsonFileDef',
+  },
   '.csv': {
     module: `${baseRealm.url}csv-file-def`,
     name: 'CsvFileDef',


### PR DESCRIPTION
## Summary
- Adds `TextFileDef` for `.txt`/`.text` files with plain text rendering
- Adds `JsonFileDef` for `.json` files with regex-based syntax highlighting (keys, strings, numbers, booleans, null) in a dark-themed code block
- Registers both extensions in `file-def-code-ref.ts`
- Includes acceptance tests for both file defs

## Test plan
- [x] `ember test --path dist --filter "text file def"` — 3 tests pass
- [x] `ember test --path dist --filter "json file def"` — 3 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2784" height="1800" alt="image" src="https://github.com/user-attachments/assets/e4a0c104-ce7f-43f4-ba0a-d9a1fe05e2f8" />

<img width="2784" height="1800" alt="image" src="https://github.com/user-attachments/assets/dcca178f-7b9f-40d9-8a09-ef2216c1262a" />
