### PR TITLE
Add CsvFileDef for .csv file support (CS-10230)

### DIFF
--- a/packages/base/csv-file-def.gts
+++ b/packages/base/csv-file-def.gts
@@ -1,0 +1,596 @@
+import { byteStreamToUint8Array } from '@cardstack/runtime-common';
+import CsvIcon from '@cardstack/boxel-icons/csv';
+import {
+  BaseDefComponent,
+  Component,
+  StringField,
+  contains,
+  containsMany,
+  field,
+} from './card-api';
+import NumberField from './number';
+import {
+  FileContentMismatchError,
+  FileDef,
+  type ByteStream,
+  type SerializedFile,
+} from './file-api';
+import sanitizedHtml from './helpers/sanitized-html';
+
+const EXCERPT_MAX_LENGTH = 500;
+
+function getExtension(url: string): string {
+  try {
+    let parsed = new URL(url);
+    let name = parsed.pathname.split('/').pop() ?? '';
+    let dot = name.lastIndexOf('.');
+    return dot === -1 ? '' : name.slice(dot).toLowerCase();
+  } catch {
+    let dot = url.lastIndexOf('.');
+    return dot === -1 ? '' : url.slice(dot).toLowerCase();
+  }
+}
+
+function fileNameWithoutExtension(name: string): string {
+  return name.replace(/\.[^/.]+$/, '');
+}
+
+function truncateExcerpt(text: string): string {
+  if (text.length <= EXCERPT_MAX_LENGTH) {
+    return text;
+  }
+  return `${text.slice(0, EXCERPT_MAX_LENGTH - 3).trimEnd()}...`;
+}
+
+function parseCsv(text: string): string[][] {
+  let rows: string[][] = [];
+  let row: string[] = [];
+  let field = '';
+  let inQuotes = false;
+  let i = 0;
+
+  while (i < text.length) {
+    let ch = text[i];
+
+    if (inQuotes) {
+      if (ch === '"') {
+        if (i + 1 < text.length && text[i + 1] === '"') {
+          field += '"';
+          i += 2;
+        } else {
+          inQuotes = false;
+          i++;
+        }
+      } else {
+        field += ch;
+        i++;
+      }
+    } else {
+      if (ch === '"') {
+        inQuotes = true;
+        i++;
+      } else if (ch === ',') {
+        row.push(field);
+        field = '';
+        i++;
+      } else if (ch === '\r') {
+        row.push(field);
+        field = '';
+        rows.push(row);
+        row = [];
+        if (i + 1 < text.length && text[i + 1] === '\n') {
+          i += 2;
+        } else {
+          i++;
+        }
+      } else if (ch === '\n') {
+        row.push(field);
+        field = '';
+        rows.push(row);
+        row = [];
+        i++;
+      } else {
+        field += ch;
+        i++;
+      }
+    }
+  }
+
+  if (field || row.length > 0) {
+    row.push(field);
+    rows.push(row);
+  }
+
+  return rows;
+}
+
+// content-tag misparses angle brackets inside regex literals in .gts files,
+// so we use RegExp constructor instead.
+const AMP_RE = new RegExp('&', 'g');
+const LT_RE = new RegExp('<', 'g');
+const GT_RE = new RegExp('>', 'g');
+const QUOT_RE = new RegExp('"', 'g');
+const APOS_RE = new RegExp("'", 'g');
+
+function escapeHtml(unsafe: string): string {
+  return unsafe
+    .replace(AMP_RE, '&amp;')
+    .replace(LT_RE, '&lt;')
+    .replace(GT_RE, '&gt;')
+    .replace(QUOT_RE, '&quot;')
+    .replace(APOS_RE, '&#039;');
+}
+
+// content-tag misparses HTML tag literals in .gts files,
+// so we build tags via helpers.
+function tag(name: string, content: string, attrs?: string): string {
+  return attrs
+    ? `<${name} ${attrs}>${content}</${name}>`
+    : `<${name}>${content}</${name}>`;
+}
+
+function csvToHtml(content: string, maxRows?: number): string {
+  let rows = parseCsv(content);
+  if (rows.length === 0) {
+    return '';
+  }
+
+  let headers = rows[0];
+  let bodyRows = rows.slice(1);
+  let truncated = false;
+
+  if (maxRows !== undefined && bodyRows.length > maxRows) {
+    bodyRows = bodyRows.slice(0, maxRows);
+    truncated = true;
+  }
+
+  let headerCells = headers.map((h) => tag('th', escapeHtml(h))).join('');
+  let headRow = tag('tr', headerCells);
+  let thead = tag('thead', headRow);
+
+  let bodyHtml = bodyRows
+    .map((row) => {
+      let cells = headers
+        .map((_, i) => {
+          let cell = i < row.length ? row[i] : '';
+          return tag('td', escapeHtml(cell));
+        })
+        .join('');
+      return tag('tr', cells);
+    })
+    .join('');
+  let tbody = tag('tbody', bodyHtml);
+
+  let html = tag('table', thead + tbody);
+
+  if (truncated) {
+    let remaining = rows.length - 1 - (maxRows ?? 0);
+    html += tag('p', `\u2026 ${remaining} more rows`, 'class="csv-truncated"');
+  }
+
+  return html;
+}
+
+function csvTitle(
+  model: { title?: string | null; name?: string | null } | null | undefined,
+): string {
+  return model?.title ?? model?.name ?? 'Untitled CSV';
+}
+
+class Isolated extends Component<typeof CsvFileDef> {
+  get title() {
+    return csvTitle(this.args.model);
+  }
+
+  get tableHtml() {
+    return csvToHtml(this.args.model?.content ?? '');
+  }
+
+  get hasContent() {
+    return Boolean(this.args.model?.content?.trim());
+  }
+
+  <template>
+    <article class='csv-isolated' data-test-csv-isolated>
+      <header class='csv-isolated__title'>{{this.title}}</header>
+      {{#if this.hasContent}}
+        <div class='csv-isolated__table'>
+          {{sanitizedHtml this.tableHtml}}
+        </div>
+      {{/if}}
+    </article>
+    <style scoped>
+      .csv-isolated {
+        padding: var(--boxel-sp-lg);
+        max-width: 100%;
+      }
+
+      .csv-isolated__title {
+        color: var(--boxel-900);
+        font-weight: 600;
+        font-size: var(--boxel-font-size-lg);
+        margin-bottom: var(--boxel-sp);
+      }
+
+      .csv-isolated__table {
+        width: 100%;
+        overflow-x: auto;
+      }
+
+      .csv-isolated__table :deep(table) {
+        width: 100%;
+        border-collapse: collapse;
+      }
+
+      .csv-isolated__table :deep(thead) {
+        border-bottom: 2px solid var(--boxel-border-color);
+      }
+
+      .csv-isolated__table :deep(th) {
+        background: var(--boxel-100);
+        text-align: start;
+        padding: var(--boxel-sp-2xs);
+        font-weight: 600;
+      }
+
+      .csv-isolated__table :deep(th:not(:last-child)),
+      .csv-isolated__table :deep(td:not(:last-child)) {
+        border-right: 1px solid var(--boxel-border-color);
+      }
+
+      .csv-isolated__table :deep(td) {
+        text-align: start;
+        padding: var(--boxel-sp-2xs);
+      }
+
+      .csv-isolated__table :deep(tr:not(:last-child) td) {
+        border-bottom: 1px solid var(--boxel-border-color);
+      }
+    </style>
+  </template>
+}
+
+class Embedded extends Component<typeof CsvFileDef> {
+  get title() {
+    return csvTitle(this.args.model);
+  }
+
+  get tableHtml() {
+    return csvToHtml(this.args.model?.content ?? '', 20);
+  }
+
+  get hasContent() {
+    return Boolean(this.args.model?.content?.trim());
+  }
+
+  <template>
+    <article class='csv-embedded' data-test-csv-embedded>
+      <header class='csv-embedded__title'>{{this.title}}</header>
+      {{#if this.hasContent}}
+        <div class='csv-embedded__content'>
+          {{sanitizedHtml this.tableHtml}}
+        </div>
+      {{/if}}
+    </article>
+    <style scoped>
+      .csv-embedded {
+        display: flex;
+        flex-direction: column;
+        gap: var(--boxel-sp-xs);
+        padding: var(--boxel-sp);
+      }
+
+      .csv-embedded__title {
+        color: var(--boxel-900);
+        font-weight: 600;
+      }
+
+      .csv-embedded__content {
+        max-height: 200px;
+        overflow: hidden;
+        mask-image: linear-gradient(to bottom, black 60%, transparent 100%);
+        -webkit-mask-image: linear-gradient(
+          to bottom,
+          black 60%,
+          transparent 100%
+        );
+      }
+
+      .csv-embedded__content :deep(table) {
+        width: 100%;
+        border-collapse: collapse;
+      }
+
+      .csv-embedded__content :deep(thead) {
+        border-bottom: 2px solid var(--boxel-border-color);
+      }
+
+      .csv-embedded__content :deep(th) {
+        background: var(--boxel-100);
+        text-align: start;
+        padding: var(--boxel-sp-2xs);
+        font-weight: 600;
+      }
+
+      .csv-embedded__content :deep(th:not(:last-child)),
+      .csv-embedded__content :deep(td:not(:last-child)) {
+        border-right: 1px solid var(--boxel-border-color);
+      }
+
+      .csv-embedded__content :deep(td) {
+        text-align: start;
+        padding: var(--boxel-sp-2xs);
+      }
+
+      .csv-embedded__content :deep(tr:not(:last-child) td) {
+        border-bottom: 1px solid var(--boxel-border-color);
+      }
+
+      .csv-embedded__content :deep(.csv-truncated) {
+        color: var(--boxel-600);
+        font-size: var(--boxel-font-sm);
+        margin: var(--boxel-sp-xs) 0 0;
+      }
+    </style>
+  </template>
+}
+
+class Fitted extends Component<typeof CsvFileDef> {
+  get title() {
+    return csvTitle(this.args.model);
+  }
+
+  get excerpt() {
+    return this.args.model?.excerpt ?? '';
+  }
+
+  get hasExcerpt() {
+    return Boolean(this.excerpt);
+  }
+
+  <template>
+    <article class='csv-fitted' data-test-csv-fitted>
+      <div class='csv-fitted__icon'>
+        <CsvIcon width='100%' height='100%' />
+      </div>
+      <div class='csv-fitted__text'>
+        <header class='csv-fitted__title'>{{this.title}}</header>
+        {{#if this.hasExcerpt}}
+          <p class='csv-fitted__excerpt'>{{this.excerpt}}</p>
+        {{/if}}
+      </div>
+    </article>
+    <style scoped>
+      .csv-fitted {
+        container-name: fitted-card;
+        container-type: size;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: flex-start;
+        gap: var(--boxel-sp-xs);
+        padding: var(--boxel-sp-xs);
+        overflow: hidden;
+      }
+
+      .csv-fitted__icon {
+        flex-shrink: 0;
+        width: 20px;
+        height: 20px;
+        color: var(--boxel-600);
+      }
+
+      .csv-fitted__text {
+        min-width: 0;
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: var(--boxel-sp-4xs);
+      }
+
+      .csv-fitted__title {
+        color: var(--boxel-900);
+        font-weight: 600;
+        font-size: var(--boxel-font-sm);
+        overflow: hidden;
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 2;
+      }
+
+      .csv-fitted__excerpt {
+        color: var(--boxel-600);
+        font-size: var(--boxel-font-xs);
+        margin: 0;
+        overflow: hidden;
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 3;
+      }
+
+      @container fitted-card (aspect-ratio <= 1.0) and (height >= 120px) {
+        .csv-fitted {
+          flex-direction: column;
+          align-items: center;
+          text-align: center;
+        }
+
+        .csv-fitted__icon {
+          width: 28px;
+          height: 28px;
+        }
+
+        .csv-fitted__title {
+          -webkit-line-clamp: 3;
+        }
+      }
+
+      @container fitted-card (aspect-ratio <= 1.0) and (height < 120px) {
+        .csv-fitted__excerpt {
+          display: none;
+        }
+      }
+
+      @container fitted-card (aspect-ratio <= 1.0) and (height < 80px) {
+        .csv-fitted__icon {
+          display: none;
+        }
+      }
+
+      @container fitted-card (1.0 < aspect-ratio) {
+        .csv-fitted {
+          align-items: flex-start;
+        }
+      }
+
+      @container fitted-card (1.0 < aspect-ratio) and (height < 80px) {
+        .csv-fitted__excerpt {
+          display: none;
+        }
+      }
+
+      @container fitted-card (height <= 57px) {
+        .csv-fitted__icon {
+          display: none;
+        }
+
+        .csv-fitted__excerpt {
+          display: none;
+        }
+
+        .csv-fitted__title {
+          font-size: var(--boxel-font-xs);
+          -webkit-line-clamp: 1;
+        }
+      }
+    </style>
+  </template>
+}
+
+class Atom extends Component<typeof CsvFileDef> {
+  get title() {
+    return csvTitle(this.args.model);
+  }
+
+  <template>
+    <span class='csv-atom' data-test-csv-atom>
+      <CsvIcon class='csv-atom__icon' width='16' height='16' />
+      <span class='csv-atom__title'>{{this.title}}</span>
+    </span>
+    <style scoped>
+      .csv-atom {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--boxel-sp-4xs);
+        min-width: 0;
+      }
+
+      .csv-atom__icon {
+        flex-shrink: 0;
+        color: var(--boxel-600);
+      }
+
+      .csv-atom__title {
+        color: var(--boxel-900);
+        font-size: var(--boxel-font-sm);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    </style>
+  </template>
+}
+
+class Head extends Component<typeof CsvFileDef> {
+  get title() {
+    return csvTitle(this.args.model);
+  }
+
+  get description() {
+    return this.args.model?.excerpt;
+  }
+
+  <template>
+    {{! template-lint-disable no-forbidden-elements }}
+    <title data-test-card-head-title>{{this.title}}</title>
+
+    <meta property='og:title' content={{this.title}} />
+    <meta name='twitter:title' content={{this.title}} />
+    <meta property='og:url' content={{@model.id}} />
+
+    {{#if this.description}}
+      <meta name='description' content={{this.description}} />
+      <meta property='og:description' content={{this.description}} />
+      <meta name='twitter:description' content={{this.description}} />
+    {{/if}}
+
+    <meta name='twitter:card' content='summary' />
+    <meta property='og:type' content='article' />
+  </template>
+}
+
+export class CsvFileDef extends FileDef {
+  static displayName = 'CSV';
+  static icon = CsvIcon;
+  static acceptTypes = '.csv,text/csv';
+
+  @field title = contains(StringField);
+  @field excerpt = contains(StringField);
+  @field content = contains(StringField);
+  @field columns = containsMany(StringField);
+  @field columnCount = contains(NumberField);
+  @field rowCount = contains(NumberField);
+
+  static isolated: BaseDefComponent = Isolated;
+  static embedded: BaseDefComponent = Embedded;
+  static fitted: BaseDefComponent = Fitted;
+  static atom: BaseDefComponent = Atom;
+  static head: BaseDefComponent = Head;
+
+  static async extractAttributes(
+    url: string,
+    getStream: () => Promise<ByteStream>,
+    options: { contentHash?: string } = {},
+  ): Promise<
+    SerializedFile<{
+      title: string;
+      excerpt: string;
+      content: string;
+      columns: string[];
+      columnCount: number;
+      rowCount: number;
+    }>
+  > {
+    let extension = getExtension(url);
+    if (extension !== '.csv') {
+      throw new FileContentMismatchError(
+        `Expected .csv file extension, got "${extension || 'none'}"`,
+      );
+    }
+
+    let bytesPromise: Promise<Uint8Array> | undefined;
+    let memoizedStream = async () => {
+      bytesPromise ??= byteStreamToUint8Array(await getStream());
+      return bytesPromise;
+    };
+
+    let base = await super.extractAttributes(url, memoizedStream, options);
+    let bytes = await memoizedStream();
+    let csvText = new TextDecoder().decode(bytes);
+    let fallbackTitle = fileNameWithoutExtension(base.name ?? '');
+    let rows = parseCsv(csvText);
+    let columns = rows.length > 0 ? rows[0] : [];
+    let columnCount = columns.length;
+    let rowCount = rows.length > 0 ? rows.length - 1 : 0; // exclude header row
+
+    return {
+      ...base,
+      title: fallbackTitle,
+      excerpt: truncateExcerpt(csvText.trim()),
+      content: csvText,
+      columns,
+      columnCount,
+      rowCount,
+    };
+  }
+}

--- a/packages/experiments-realm/sample-data.csv
+++ b/packages/experiments-realm/sample-data.csv
@@ -1,0 +1,11 @@
+name,email,department,role,start_date,salary
+Alice Johnson,alice@example.com,Engineering,Senior Developer,2021-03-15,125000
+Bob Smith,bob@example.com,Marketing,Campaign Manager,2022-07-01,95000
+Charlie Davis,charlie@example.com,Engineering,Staff Developer,2019-11-20,145000
+Diana Martinez,diana@example.com,Design,Lead Designer,2020-06-10,115000
+Eve Thompson,eve@example.com,Sales,Account Executive,2023-01-09,88000
+Frank Wilson,frank@example.com,Engineering,Junior Developer,2024-02-12,82000
+Grace Lee,grace@example.com,Marketing,Content Strategist,2021-09-30,91000
+Henry Brown,henry@example.com,Design,UX Researcher,2022-04-18,105000
+Ivy Chen,ivy@example.com,Sales,Sales Director,2018-08-05,135000
+Jack Taylor,jack@example.com,Engineering,DevOps Engineer,2023-06-22,118000

--- a/packages/host/tests/acceptance/csv-file-def-test.gts
+++ b/packages/host/tests/acceptance/csv-file-def-test.gts
@@ -1,0 +1,221 @@
+import { visit, waitUntil } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+
+import { module, test } from 'qunit';
+
+import {
+  baseRealm,
+  type FileExtractResponse,
+  type RenderRouteOptions,
+  type ResolvedCodeRef,
+  SupportedMimeType,
+} from '@cardstack/runtime-common';
+import type { Realm } from '@cardstack/runtime-common/realm';
+
+import type NetworkService from '@cardstack/host/services/network';
+
+import {
+  setupLocalIndexing,
+  setupOnSave,
+  setupRealmCacheTeardown,
+  testRealmURL,
+  setupAcceptanceTestRealm,
+  SYSTEM_CARD_FIXTURE_CONTENTS,
+  withCachedRealmSetup,
+} from '../helpers';
+import { setupMockMatrix } from '../helpers/mock-matrix';
+import { setupApplicationTest } from '../helpers/setup';
+
+module('Acceptance | csv file def', function (hooks) {
+  setupApplicationTest(hooks);
+  setupLocalIndexing(hooks);
+  setupOnSave(hooks);
+  setupRealmCacheTeardown(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+  });
+  let realm: Realm;
+
+  const renderPath = (
+    url: string,
+    renderOptions: RenderRouteOptions,
+    nonce = 0,
+  ) =>
+    `/render/${encodeURIComponent(url)}/${nonce}/${encodeURIComponent(
+      JSON.stringify(renderOptions),
+    )}/file-extract`;
+
+  const makeFileURL = (path: string) => new URL(path, testRealmURL).href;
+
+  const csvDefCodeRef = (): ResolvedCodeRef => ({
+    module: `${baseRealm.url}csv-file-def`,
+    name: 'CsvFileDef',
+  });
+
+  async function captureFileExtractResult(
+    expectedStatus?: 'ready' | 'error',
+  ): Promise<FileExtractResponse> {
+    await waitUntil(
+      () => {
+        let container = document.querySelector(
+          '[data-prerender-file-extract]',
+        ) as HTMLElement | null;
+        if (!container) {
+          return false;
+        }
+        let status = container.getAttribute(
+          'data-prerender-file-extract-status',
+        );
+        if (!status) {
+          return false;
+        }
+        if (expectedStatus && status !== expectedStatus) {
+          return false;
+        }
+        return status === 'ready' || status === 'error';
+      },
+      { timeout: 5000 },
+    );
+
+    let container = document.querySelector(
+      '[data-prerender-file-extract]',
+    ) as HTMLElement | null;
+    if (!container) {
+      throw new Error(
+        'captureFileExtractResult: missing [data-prerender-file-extract] container after wait',
+      );
+    }
+    let pre = container.querySelector('pre');
+    let text = pre?.textContent?.trim() ?? '';
+    return JSON.parse(text) as FileExtractResponse;
+  }
+
+  hooks.beforeEach(async function () {
+    ({ realm } = await withCachedRealmSetup(async () =>
+      setupAcceptanceTestRealm({
+        mockMatrixUtils,
+        contents: {
+          ...SYSTEM_CARD_FIXTURE_CONTENTS,
+          'data.csv': `name,age,city
+Alice,30,New York
+Bob,25,San Francisco
+Charlie,35,Chicago`,
+          'readme.md': `# Not a CSV file
+
+This is markdown content.`,
+        },
+      }),
+    ));
+  });
+
+  hooks.afterEach(function () {
+    delete (globalThis as any).__renderModel;
+  });
+
+  test('extracts title, excerpt, and content from csv file', async function (assert) {
+    let url = makeFileURL('data.csv');
+    await visit(
+      renderPath(url, {
+        fileExtract: true,
+        fileDefCodeRef: csvDefCodeRef(),
+      }),
+    );
+
+    let result = await captureFileExtractResult('ready');
+    assert.strictEqual(result.status, 'ready');
+    assert.strictEqual(result.searchDoc?.title, 'data');
+    assert.ok(
+      String(result.searchDoc?.excerpt).includes('name,age,city'),
+      'excerpt includes csv content',
+    );
+    assert.ok(
+      String(result.searchDoc?.content).includes('Alice,30,New York'),
+      'content includes full csv data',
+    );
+    assert.strictEqual(result.searchDoc?.name, 'data.csv');
+    assert.deepEqual(
+      result.searchDoc?.columns,
+      ['name', 'age', 'city'],
+      'extracts column names',
+    );
+    assert.strictEqual(
+      result.searchDoc?.columnCount,
+      3,
+      'extracts column count',
+    );
+    assert.strictEqual(
+      result.searchDoc?.rowCount,
+      3,
+      'extracts row count (excluding header)',
+    );
+    assert.ok(
+      String(result.searchDoc?.contentType).includes('csv'),
+      'sets csv content type',
+    );
+  });
+
+  test('falls back when csv def is used for non-csv files', async function (assert) {
+    let url = makeFileURL('readme.md');
+    await visit(
+      renderPath(url, {
+        fileExtract: true,
+        fileDefCodeRef: csvDefCodeRef(),
+      }),
+    );
+
+    let result = await captureFileExtractResult('ready');
+    assert.strictEqual(result.status, 'ready');
+    assert.true(result.mismatch, 'marks mismatch when extension is not csv');
+    assert.strictEqual(result.searchDoc?.name, 'readme.md');
+  });
+
+  test('indexing stores csv search data and file-meta uses it', async function (assert) {
+    let fileURL = new URL('data.csv', testRealmURL);
+    let fileEntry = await realm.realmIndexQueryEngine.file(fileURL);
+
+    assert.ok(fileEntry, 'file entry exists');
+    assert.strictEqual(
+      fileEntry?.searchDoc?.title,
+      'data',
+      'index stores csv title',
+    );
+    assert.ok(
+      String(fileEntry?.searchDoc?.excerpt).includes('name,age,city'),
+      'index stores csv excerpt',
+    );
+
+    let network = getService('network') as NetworkService;
+    let response = await network.virtualNetwork.fetch(fileURL, {
+      headers: { Accept: SupportedMimeType.FileMeta },
+    });
+
+    assert.true(response.ok, 'file meta request succeeds');
+
+    let body = await response.json();
+    assert.strictEqual(body?.data?.type, 'file-meta');
+    assert.ok(
+      String(body?.data?.attributes?.contentType).includes('csv'),
+      'file meta uses csv content type',
+    );
+    assert.strictEqual(
+      body?.data?.attributes?.title,
+      'data',
+      'file meta includes csv title',
+    );
+    assert.ok(
+      String(body?.data?.attributes?.excerpt).includes('name,age,city'),
+      'file meta includes csv excerpt',
+    );
+    assert.ok(
+      String(body?.data?.attributes?.content).includes('Alice,30,New York'),
+      'file meta includes csv content',
+    );
+    assert.deepEqual(
+      body?.data?.meta?.adoptsFrom,
+      csvDefCodeRef(),
+      'file meta uses csv def',
+    );
+  });
+});

--- a/packages/runtime-common/file-def-code-ref.ts
+++ b/packages/runtime-common/file-def-code-ref.ts
@@ -41,6 +41,10 @@ const FILEDEF_CODE_REF_BY_EXTENSION: Record<string, ResolvedCodeRef> = {
     module: `${baseRealm.url}avif-image-def`,
     name: 'AvifDef',
   },
+  '.csv': {
+    module: `${baseRealm.url}csv-file-def`,
+    name: 'CsvFileDef',
+  },
   '.mismatch': { module: './filedef-mismatch', name: 'FileDef' },
 };
 


### PR DESCRIPTION
## Summary
- Add `CsvFileDef` subclass of `FileDef` in `packages/base/csv-file-def.gts` with an inline CSV parser, HTML table rendering via `sanitizedHtml`, and five view templates (isolated, embedded, fitted, atom, head)
- Extract metadata fields: `title` (filename), `excerpt` (first ~500 chars), `content` (raw CSV), `columns` (header names), `columnCount`, and `rowCount`
- Register `.csv` extension mapping in `packages/runtime-common/file-def-code-ref.ts`
- Add acceptance tests in `packages/host/tests/acceptance/csv-file-def-test.gts` covering extraction, mismatch fallback, and indexing/file-meta
- Add sample CSV file to `packages/experiments-realm/`

## Test plan
- [ ] Run `cd packages/host && ember test --path dist --filter "csv file def"` to verify acceptance tests pass
- [ ] Open a `.csv` file in the host app and verify isolated/embedded/fitted/atom views render correctly
- [ ] Verify indexing picks up `.csv` files and file-meta returns CsvFileDef attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2696" height="1712" alt="image" src="https://github.com/user-attachments/assets/0f96b75b-106c-4096-bf11-e88adba984e8" />
