### PR TITLE
Allow editing FileDef files in Monaco code editor

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -39,7 +39,6 @@ import {
   type ResolvedCodeRef,
   type getCard,
   CardContextName,
-  isFileDefInstance,
 } from '@cardstack/runtime-common';
 import { isEquivalentBodyPosition } from '@cardstack/runtime-common/schema-analysis-plugin';
 
@@ -640,16 +639,9 @@ export default class CodeSubmode extends Component<Signature> {
     return state;
   });
 
-  private get isFileDefInstance() {
-    return (
-      this.fileDefResource && isFileDefInstance(this.fileDefResource.value)
-    );
-  }
-
   get isReadOnly() {
     return (
       !this.realm.canWrite(this.readyFile.url) ||
-      this.isFileDefInstance ||
       this.fileDefResource?.isLoading
     );
   }

--- a/packages/host/tests/acceptance/code-submode/file-def-navigation-test.gts
+++ b/packages/host/tests/acceptance/code-submode/file-def-navigation-test.gts
@@ -134,7 +134,7 @@ Some markdown content.`,
     assert.dom('[data-test-card-url-bar-input]').hasValue(expectedMarkdownUrl);
   });
 
-  test('file def instance is read-only in code mode', async function (assert) {
+  test('file def instance is editable in code mode', async function (assert) {
     await visitOperatorMode({
       submode: 'code',
       codePath: `${testRealmURL}FileLinkCard/notes.md`,
@@ -142,10 +142,7 @@ Some markdown content.`,
 
     await waitFor('[data-test-editor]');
     assert
-      .dom('[data-test-format-chooser="edit"]')
-      .doesNotExist('edit format option is not shown for file def instance');
-    assert
       .dom('[data-test-realm-indicator-not-writable]')
-      .exists('read-only indicator is shown for file def instance');
+      .doesNotExist('read-only indicator is not shown for file def instance');
   });
 });


### PR DESCRIPTION
## Summary
- Remove the `isFileDefInstance` check from the `isReadOnly` getter in `code-submode.gts`
- FileDef instances (CSV, markdown, images, etc.) were incorrectly marked as read-only in the Monaco editor, preventing users from editing the raw file content
- The read-only restriction should only apply to the card instance editing interface (FileDef's Edit view says "Replace it via file upload"), not to editing the underlying file in the code editor

## Test plan
- [ ] Open a `.csv` or `.md` file in code mode — verify the Monaco editor is now editable (not greyed out)
- [ ] Verify files in realms without write permission are still read-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)