### PR TITLE
Update the prerenderer to wait for query fields to load

### DIFF
--- a/packages/base/query-field-support.ts
+++ b/packages/base/query-field-support.ts
@@ -16,6 +16,7 @@ import {
   getField,
   getSingularRelationship,
   identifyCard,
+  isCardInstance,
   THIS_INTERPOLATION_PREFIX,
   THIS_REALM_TOKEN,
   realmURL as realmURLSymbol,
@@ -40,6 +41,7 @@ interface QueryFieldState {
     status?: number;
   }>;
   searchResource?: StoreSearchResource;
+  renderCycleBarrier?: Promise<void>;
 }
 
 const queryFieldStates = initSharedState(
@@ -73,9 +75,18 @@ export function ensureQueryFieldSearchResource(
     });
 
   let queryFieldState = queryFieldStates.get(instance);
-  let fieldState = queryFieldState?.get(field.name);
-  let searchResource = fieldState?.searchResource;
+  if (!queryFieldState) {
+    queryFieldState = new Map<string, QueryFieldState>();
+    queryFieldStates.set(instance, queryFieldState);
+  }
+  let fieldState = queryFieldState.get(field.name);
+  if (!fieldState) {
+    fieldState = {};
+    queryFieldState.set(field.name, fieldState);
+  }
+  let searchResource = fieldState.searchResource;
   if (searchResource) {
+    trackQueryFieldLoads(store, field.name, fieldState);
     log.debug(
       `ensureQueryFieldSearchResource: reusing existing resource from fieldState for field=${field.name}`,
     );
@@ -84,7 +95,6 @@ export function ensureQueryFieldSearchResource(
 
   let seedRecords = fieldState?.seedRecords;
   let seedSearchURL = fieldState?.seedSearchURL;
-
   let args = () => resolveQueryAndRealm(instance, field, fieldDefinition);
 
   log.info(
@@ -103,24 +113,43 @@ export function ensureQueryFieldSearchResource(
       seed: seedRecords
         ? {
             cards: seedRecords,
-            searchURL: seedSearchURL ?? undefined,
+            searchURL:
+              seedRecords.length > 0 ? seedSearchURL ?? undefined : undefined,
             realms: fieldState?.seedRealms,
             queryErrors: fieldState?.seedErrors,
           }
         : undefined,
     },
   );
-  if (!queryFieldState) {
-    queryFieldState = new Map<string, QueryFieldState>();
-    queryFieldStates.set(instance, queryFieldState);
-  }
-  if (!fieldState) {
-    fieldState = {};
-    queryFieldState.set(field.name, fieldState);
-  }
   fieldState.searchResource = searchResource;
+  trackQueryFieldLoads(store, field.name, fieldState);
 
   return searchResource;
+}
+
+function trackQueryFieldLoads(
+  store: CardStore,
+  fieldName: string,
+  fieldState: QueryFieldState,
+) {
+  if (!fieldState.renderCycleBarrier) {
+    // Query resources can kick off their load after the getter returns
+    // (via resource modify scheduling). This barrier keeps render-route
+    // settle from completing in the same frame before query loads can join.
+    log.debug(`tracking query field render barrier for field=${fieldName}`);
+    let barrier = waitForNextRenderCycle();
+    fieldState.renderCycleBarrier = barrier;
+    store.trackLoad(barrier);
+    void barrier.finally(() => {
+      if (fieldState.renderCycleBarrier === barrier) {
+        fieldState.renderCycleBarrier = undefined;
+      }
+    });
+  }
+}
+
+function waitForNextRenderCycle(): Promise<void> {
+  return Promise.resolve().then(() => Promise.resolve());
 }
 
 export function validateRelationshipQuery(
@@ -274,7 +303,9 @@ export function captureQueryFieldSeedData(
     fieldState = {};
     queryFieldState.set(fieldName, fieldState);
   }
-  fieldState.seedRecords = value;
+  // Query-field deserialize can contain unresolved placeholders in some paths;
+  // only persist concrete card instances as seed records.
+  fieldState.seedRecords = value.filter((entry) => isCardInstance(entry));
   let relationship = getSingularRelationship(resource.relationships, fieldName);
   fieldState.seedSearchURL = relationship?.links?.search ?? null;
   fieldState.seedRealms = fieldState.seedSearchURL

--- a/packages/base/query-field-support.ts
+++ b/packages/base/query-field-support.ts
@@ -113,8 +113,7 @@ export function ensureQueryFieldSearchResource(
       seed: seedRecords
         ? {
             cards: seedRecords,
-            searchURL:
-              seedRecords.length > 0 ? seedSearchURL ?? undefined : undefined,
+            searchURL: seedSearchURL ?? undefined,
             realms: fieldState?.seedRealms,
             queryErrors: fieldState?.seedErrors,
           }

--- a/packages/base/query-field-support.ts
+++ b/packages/base/query-field-support.ts
@@ -134,10 +134,11 @@ function trackQueryFieldLoads(
 ) {
   if (!fieldState.renderCycleBarrier) {
     // Query resources can kick off their load after the getter returns
-    // (via resource modify scheduling). This barrier keeps render-route
-    // settle from completing in the same frame before query loads can join.
+    // (via resource modify scheduling). This microtask barrier keeps
+    // render-route settle from completing in the same frame before query
+    // loads can join.
     log.debug(`tracking query field render barrier for field=${fieldName}`);
-    let barrier = waitForNextRenderCycle();
+    let barrier = waitForNextMicrotaskTurn();
     fieldState.renderCycleBarrier = barrier;
     store.trackLoad(barrier);
     void barrier.finally(() => {
@@ -148,7 +149,7 @@ function trackQueryFieldLoads(
   }
 }
 
-function waitForNextRenderCycle(): Promise<void> {
+function waitForNextMicrotaskTurn(): Promise<void> {
   return Promise.resolve().then(() => Promise.resolve());
 }
 

--- a/packages/base/query-field-support.ts
+++ b/packages/base/query-field-support.ts
@@ -44,6 +44,10 @@ interface QueryFieldState {
   renderCycleBarrier?: Promise<void>;
 }
 
+const queryFieldSeedFromSearchSymbol = Symbol.for(
+  'cardstack-query-field-seed-from-search',
+);
+
 const queryFieldStates = initSharedState(
   'queryFieldStates',
   () => new WeakMap<BaseDef, Map<string, QueryFieldState>>(),
@@ -307,7 +311,18 @@ export function captureQueryFieldSeedData(
   // only persist concrete card instances as seed records.
   fieldState.seedRecords = value.filter((entry) => isCardInstance(entry));
   let relationship = getSingularRelationship(resource.relationships, fieldName);
-  fieldState.seedSearchURL = relationship?.links?.search ?? null;
+  let seedComesFromSearch = Boolean(
+    (resource as any)[queryFieldSeedFromSearchSymbol],
+  );
+  // Empty query-backed relationships arriving on search result resources are
+  // not guaranteed to be fully resolved (for example nested query fields on
+  // each result). In that case we should still run the client-side query
+  // fallback instead of treating the empty seed as authoritative.
+  let shouldTreatEmptySeedAsUnresolved =
+    seedComesFromSearch && fieldState.seedRecords.length === 0;
+  fieldState.seedSearchURL = shouldTreatEmptySeedAsUnresolved
+    ? null
+    : relationship?.links?.search ?? null;
   fieldState.seedRealms = fieldState.seedSearchURL
     ? [parseSearchURL(new URL(fieldState.seedSearchURL)).realm.href]
     : [];

--- a/packages/host/app/lib/gc-card-store.ts
+++ b/packages/host/app/lib/gc-card-store.ts
@@ -266,12 +266,18 @@ export default class CardStoreWithGarbageCollection implements CardStore {
     loadTrackingLogger.debug(
       `trackLoad start id=${loadId} generation=${this.#loadGeneration} pending=${this.#inFlight.size}`,
     );
-    load.finally(() => {
-      this.#inFlight.delete(load);
-      loadTrackingLogger.debug(
-        `trackLoad settled id=${loadId} pending=${this.#inFlight.size}`,
-      );
-    });
+    void load
+      .finally(() => {
+        this.#inFlight.delete(load);
+        loadTrackingLogger.debug(
+          `trackLoad settled id=${loadId} pending=${this.#inFlight.size}`,
+        );
+      })
+      .catch((error) => {
+        loadTrackingLogger.debug(
+          `trackLoad rejected id=${loadId} error=${String(error)}`,
+        );
+      });
   }
 
   async loaded() {

--- a/packages/host/app/lib/gc-card-store.ts
+++ b/packages/host/app/lib/gc-card-store.ts
@@ -256,33 +256,33 @@ export default class CardStoreWithGarbageCollection implements CardStore {
 
   trackLoad(load: Promise<unknown>) {
     if (this.#inFlight.has(load)) {
-      loadTrackingLogger.info('trackLoad skipped duplicate promise');
+      loadTrackingLogger.debug('trackLoad skipped duplicate promise');
       return;
     }
     let loadId = this.#nextLoadId++;
     this.#loadIds.set(load, loadId);
     this.#inFlight.add(load);
     this.#loadGeneration++;
-    loadTrackingLogger.info(
+    loadTrackingLogger.debug(
       `trackLoad start id=${loadId} generation=${this.#loadGeneration} pending=${this.#inFlight.size}`,
     );
     load.finally(() => {
       this.#inFlight.delete(load);
-      loadTrackingLogger.info(
+      loadTrackingLogger.debug(
         `trackLoad settled id=${loadId} pending=${this.#inFlight.size}`,
       );
     });
   }
 
   async loaded() {
-    loadTrackingLogger.info(
+    loadTrackingLogger.debug(
       `loaded() begin generation=${this.#loadGeneration} pending=${this.#inFlight.size}`,
     );
     let observedGeneration = this.#loadGeneration;
     for (;;) {
       if (this.#inFlight.size === 0) {
         // allow microtasks (like settled promise continuations) to enqueue more loads
-        loadTrackingLogger.info(
+        loadTrackingLogger.debug(
           'loaded() no pending loads, waiting one microtask',
         );
         await Promise.resolve();
@@ -291,7 +291,7 @@ export default class CardStoreWithGarbageCollection implements CardStore {
         let pendingIds = pendingLoads
           .map((pendingLoad) => this.#loadIds.get(pendingLoad))
           .filter((id): id is number => id != null);
-        loadTrackingLogger.info(
+        loadTrackingLogger.debug(
           `loaded() waiting for pending loads ids=[${pendingIds.join(',')}] count=${pendingLoads.length}`,
         );
         await Promise.allSettled(pendingLoads);
@@ -300,12 +300,12 @@ export default class CardStoreWithGarbageCollection implements CardStore {
         this.#inFlight.size === 0 &&
         this.#loadGeneration === observedGeneration
       ) {
-        loadTrackingLogger.info(
+        loadTrackingLogger.debug(
           `loaded() complete generation=${this.#loadGeneration}`,
         );
         return;
       }
-      loadTrackingLogger.info(
+      loadTrackingLogger.debug(
         `loaded() continuing; generation moved ${observedGeneration} -> ${this.#loadGeneration}, pending=${this.#inFlight.size}`,
       );
       observedGeneration = this.#loadGeneration;

--- a/packages/host/app/lib/gc-card-store.ts
+++ b/packages/host/app/lib/gc-card-store.ts
@@ -13,6 +13,7 @@ import {
   loadFileMetaDocument,
   trackRuntimeFileDependency,
   trackRuntimeInstanceDependency,
+  logger,
   type Query,
   type QueryResultsMeta,
   type RuntimeDependencyTrackingContext,
@@ -34,6 +35,8 @@ import type * as CardAPI from 'https://cardstack.com/base/card-api';
 import type { FileDef } from 'https://cardstack.com/base/file-api';
 
 export type ReferenceCount = Map<string, number>;
+
+const loadTrackingLogger = logger('store-load-tracking');
 
 type LocalId = string;
 type InstanceGraph = Map<LocalId, Set<LocalId>>;
@@ -154,6 +157,8 @@ export default class CardStoreWithGarbageCollection implements CardStore {
   #fetch: typeof globalThis.fetch;
   #inFlight: Set<Promise<unknown>> = new Set();
   #loadGeneration = 0; // increments whenever a new load is tracked
+  #nextLoadId = 1;
+  #loadIds: WeakMap<Promise<unknown>, number> = new WeakMap();
   #cardDocsInFlight: Map<string, Promise<SingleCardDocument | CardError>> =
     new Map();
   #fileMetaDocsInFlight: Map<
@@ -251,31 +256,58 @@ export default class CardStoreWithGarbageCollection implements CardStore {
 
   trackLoad(load: Promise<unknown>) {
     if (this.#inFlight.has(load)) {
+      loadTrackingLogger.info('trackLoad skipped duplicate promise');
       return;
     }
+    let loadId = this.#nextLoadId++;
+    this.#loadIds.set(load, loadId);
     this.#inFlight.add(load);
     this.#loadGeneration++;
+    loadTrackingLogger.info(
+      `trackLoad start id=${loadId} generation=${this.#loadGeneration} pending=${this.#inFlight.size}`,
+    );
     load.finally(() => {
       this.#inFlight.delete(load);
+      loadTrackingLogger.info(
+        `trackLoad settled id=${loadId} pending=${this.#inFlight.size}`,
+      );
     });
   }
 
   async loaded() {
+    loadTrackingLogger.info(
+      `loaded() begin generation=${this.#loadGeneration} pending=${this.#inFlight.size}`,
+    );
     let observedGeneration = this.#loadGeneration;
     for (;;) {
       if (this.#inFlight.size === 0) {
         // allow microtasks (like settled promise continuations) to enqueue more loads
+        loadTrackingLogger.info(
+          'loaded() no pending loads, waiting one microtask',
+        );
         await Promise.resolve();
       } else {
         let pendingLoads = Array.from(this.#inFlight);
+        let pendingIds = pendingLoads
+          .map((pendingLoad) => this.#loadIds.get(pendingLoad))
+          .filter((id): id is number => id != null);
+        loadTrackingLogger.info(
+          `loaded() waiting for pending loads ids=[${pendingIds.join(',')}] count=${pendingLoads.length}`,
+        );
         await Promise.allSettled(pendingLoads);
       }
       if (
         this.#inFlight.size === 0 &&
         this.#loadGeneration === observedGeneration
       ) {
+        loadTrackingLogger.info(
+          `loaded() complete generation=${this.#loadGeneration}`,
+        );
         return;
       }
+      loadTrackingLogger.info(
+        `loaded() continuing; generation moved ${observedGeneration} -> ${this.#loadGeneration}, pending=${this.#inFlight.size}`,
+      );
       observedGeneration = this.#loadGeneration;
     }
   }

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -69,11 +69,12 @@ export class SearchResource<
 > extends Resource<Args<T>> {
   @service declare private realmServer: RealmServerService;
   @service declare private store: StoreService;
+  #storeServiceOverride: StoreService | undefined;
   @tracked private realmsToSearch: string[] = [];
   // Resist the urge to expose this property publicly as that may entice
-  // consumers of this resource  to use it in a non-reactive manner (pluck off
+  // consumers of this resource to use it in a non-reactive manner (pluck off
   // the instances and throw away the resource).
-  // @ts-ignore we use this.loaded for test instrumentation.
+  // Kept private for tests/internal load bookkeeping.
   private loaded: Promise<void> | undefined;
   private subscriptions: { url: string; unsubscribe: () => void }[] = [];
   private _instances = new TrackedArray<T>();
@@ -87,12 +88,40 @@ export class SearchResource<
   #previousRealms: string[] | undefined;
   #dependencyTracking: RuntimeDependencyTrackingContext | undefined;
   #log = runtimeLogger('search-resource');
+  #trackedLoadCount = 0;
+
+  private get runtimeStore(): StoreService {
+    return this.#storeServiceOverride ?? this.store;
+  }
+
+  private trackStoreLoad(
+    load: Promise<void> | undefined,
+    source: 'seed' | 'search' | 'live-refresh',
+  ): void {
+    if (!load) {
+      return;
+    }
+    this.loaded = load;
+    let loadNumber = ++this.#trackedLoadCount;
+    this.#log.info(
+      `trackStoreLoad start #${loadNumber} source=${source} query=${this.#previousQueryString ?? '(unknown)'}`,
+    );
+    this.runtimeStore.trackLoad(load);
+    void load.finally(() => {
+      // Ignore stale completions from superseded loads; keep test-facing
+      // `loaded` aligned with the most recent request.
+      if (this.loaded !== load) {
+        return;
+      }
+      this.#log.info(`trackStoreLoad settled #${loadNumber} source=${source}`);
+    });
+  }
 
   constructor(owner: object) {
     super(owner);
     registerDestructor(this, () => {
       for (let instance of this._instances) {
-        this.store.dropReference(instance.id);
+        this.runtimeStore.dropReference(instance.id);
       }
       for (let subscription of this.subscriptions) {
         subscription.unsubscribe();
@@ -101,9 +130,20 @@ export class SearchResource<
   }
 
   modify(_positional: never[], named: Args<T>['named']) {
-    let { query, realms, isLive, doWhileRefreshing, seed, owner } = named;
+    let {
+      query,
+      realms,
+      isLive,
+      doWhileRefreshing,
+      seed,
+      owner,
+      storeService,
+    } = named;
 
     setOwner(this, owner); // works around problem where lifetime parent is used as owner when they should be allowed to differ
+    if (storeService) {
+      this.#storeServiceOverride = storeService;
+    }
 
     if (query === undefined) {
       return;
@@ -123,7 +163,7 @@ export class SearchResource<
       `modify: prepared realms for subscription=${this.realmsToSearch.join(',')}`,
     );
     if (seed && !this.#seedApplied) {
-      this.loaded = this.applySeed.perform(seed);
+      this.trackStoreLoad(this.applySeed.perform(seed), 'seed');
       this.#seedApplied = true;
       let hasQueryErrors = seed.queryErrors && seed.queryErrors.length > 0;
       if (seed.searchURL && !hasQueryErrors) {
@@ -171,7 +211,10 @@ export class SearchResource<
             ) {
               return;
             }
-            this.search.perform(this.#previousQuery);
+            this.trackStoreLoad(
+              this.search.perform(this.#previousQuery),
+              'live-refresh',
+            );
           }),
         };
       });
@@ -195,7 +238,7 @@ export class SearchResource<
     this.#previousRealms = realms;
     this.#previousQuery = query;
     this.#previousQueryString = queryString;
-    this.loaded = this.search.perform(query);
+    this.trackStoreLoad(this.search.perform(query), 'search');
   }
   get isLoading() {
     return this.search.isRunning;
@@ -249,20 +292,20 @@ export class SearchResource<
       let isFileMeta = isFileDefInstance(card);
       let maybeInstance = card?.id
         ? isFileMeta
-          ? this.store.peek(card.id, { type: 'file-meta' })
-          : this.store.peek(card.id)
+          ? this.runtimeStore.peek(card.id, { type: 'file-meta' })
+          : this.runtimeStore.peek(card.id)
         : undefined;
       if (
         !maybeInstance &&
         (card as unknown as { type?: string })?.type !== 'not-loaded' // TODO: under what circumstances could this happen?
       ) {
         if (isFileMeta) {
-          await this.store.get(card.id, {
+          await this.runtimeStore.get(card.id, {
             type: 'file-meta',
             dependencyTrackingContext,
           });
         } else {
-          await this.store.add(
+          await this.runtimeStore.add(
             card as CardDef,
             {
               doNotPersist: true,
@@ -274,13 +317,13 @@ export class SearchResource<
     }
     let referencesToDrop = difference(oldReferences, newReferences);
     for (let id of referencesToDrop) {
-      this.store.dropReference(id);
+      this.runtimeStore.dropReference(id);
     }
     let referencesToAdd = difference(newReferences, oldReferences);
     for (let id of referencesToAdd) {
-      this.store.addReference(id);
+      this.runtimeStore.addReference(id);
     }
-    return this.store.flush();
+    return this.runtimeStore.flush();
   }
 
   private dependencyTrackingContext(
@@ -313,7 +356,7 @@ export class SearchResource<
       let dependencyTrackingContext = this.dependencyTrackingContext(
         'search-resource:search',
       );
-      let { instances, meta } = await this.store.search<T>(
+      let { instances, meta } = await this.runtimeStore.search<T>(
         query,
         this.realmsToSearch,
         {
@@ -351,6 +394,7 @@ export function getSearch<T extends CardDef | FileDef = CardDef>(
   getRealms?: () => string[] | undefined,
   opts?: {
     isLive?: boolean;
+    storeService?: StoreService;
     doWhileRefreshing?: (() => void) | undefined;
     seed?:
       | {
@@ -374,6 +418,7 @@ export function getSearch<T extends CardDef | FileDef = CardDef>(
       query: getQuery(),
       realms: getRealms ? getRealms() : undefined,
       isLive: opts?.isLive != null ? opts.isLive : false,
+      storeService: opts?.storeService,
       // TODO refactor this out
       doWhileRefreshing: opts?.doWhileRefreshing,
       seed: opts?.seed,

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -5,7 +5,7 @@ import { service } from '@ember/service';
 import { buildWaiter } from '@ember/test-waiters';
 import { tracked, cached } from '@glimmer/tracking';
 
-import { restartableTask, task } from 'ember-concurrency';
+import { didCancel, restartableTask, task } from 'ember-concurrency';
 import { Resource } from 'ember-modify-based-class-resource';
 
 import difference from 'lodash/difference';
@@ -107,14 +107,29 @@ export class SearchResource<
       `trackStoreLoad start #${loadNumber} source=${source} query=${this.#previousQueryString ?? '(unknown)'}`,
     );
     this.runtimeStore.trackLoad(load);
-    void load.finally(() => {
-      // Ignore stale completions from superseded loads; keep test-facing
-      // `loaded` aligned with the most recent request.
-      if (this.loaded !== load) {
-        return;
-      }
-      this.#log.info(`trackStoreLoad settled #${loadNumber} source=${source}`);
-    });
+    void load
+      .finally(() => {
+        // Ignore stale completions from superseded loads; keep test-facing
+        // `loaded` aligned with the most recent request.
+        if (this.loaded !== load) {
+          return;
+        }
+        this.#log.info(
+          `trackStoreLoad settled #${loadNumber} source=${source}`,
+        );
+      })
+      .catch((error) => {
+        if (didCancel(error)) {
+          this.#log.debug(
+            `trackStoreLoad canceled #${loadNumber} source=${source}`,
+          );
+          return;
+        }
+        this.#log.error(
+          `trackStoreLoad rejected #${loadNumber} source=${source}`,
+          error,
+        );
+      });
   }
 
   constructor(owner: object) {
@@ -141,9 +156,7 @@ export class SearchResource<
     } = named;
 
     setOwner(this, owner); // works around problem where lifetime parent is used as owner when they should be allowed to differ
-    if (storeService) {
-      this.#storeServiceOverride = storeService;
-    }
+    this.#storeServiceOverride = storeService;
 
     if (query === undefined) {
       return;

--- a/packages/host/app/resources/search.ts
+++ b/packages/host/app/resources/search.ts
@@ -156,7 +156,11 @@ export class SearchResource<
     } = named;
 
     setOwner(this, owner); // works around problem where lifetime parent is used as owner when they should be allowed to differ
-    this.#storeServiceOverride = storeService;
+    // Keep the previously provided override when optional args are omitted on
+    // subsequent modify() calls.
+    if (storeService !== undefined) {
+      this.#storeServiceOverride = storeService;
+    }
 
     if (query === undefined) {
       return;

--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -571,7 +571,7 @@ export default class RenderRoute extends Route<Model> {
     if (!modelState || modelState.isReady) {
       return;
     }
-    renderReadyLogger.info(
+    renderReadyLogger.debug(
       `scheduling ready settlement for cardId=${model.cardId}`,
     );
     this.#pendingReadyModels.add(model);
@@ -629,11 +629,11 @@ export default class RenderRoute extends Route<Model> {
     if (!modelState || modelState.isReady) {
       return;
     }
-    renderReadyLogger.info(
+    renderReadyLogger.debug(
       `settleModelAfterRender start cardId=${model.cardId} status=${model.status}`,
     );
     await this.#authGuard.race(() => this.store.loaded());
-    renderReadyLogger.info(
+    renderReadyLogger.debug(
       `settleModelAfterRender store.loaded resolved cardId=${model.cardId}`,
     );
     modelState.state.set('status', 'ready');
@@ -643,7 +643,7 @@ export default class RenderRoute extends Route<Model> {
     model.capturedDeps = snapshotRuntimeDependencies({
       excludeQueryOnly: true,
     }).deps;
-    renderReadyLogger.info(
+    renderReadyLogger.debug(
       `settleModelAfterRender done cardId=${model.cardId} deps=${model.capturedDeps?.length ?? 0}`,
     );
   }

--- a/packages/host/app/routes/render.ts
+++ b/packages/host/app/routes/render.ts
@@ -26,6 +26,7 @@ import {
   type RenderError,
   parseRenderRouteOptions,
   serializeRenderRouteOptions,
+  logger as runtimeLogger,
 } from '@cardstack/runtime-common';
 import { Deferred } from '@cardstack/runtime-common/deferred';
 import { serializableError } from '@cardstack/runtime-common/error';
@@ -78,6 +79,8 @@ type ModelState = {
   isReady: boolean;
   readyWatchdogStarted?: boolean;
 };
+
+const renderReadyLogger = runtimeLogger('render-ready');
 
 export default class RenderRoute extends Route<Model> {
   @service('render-store') declare store: RenderStoreService;
@@ -568,6 +571,9 @@ export default class RenderRoute extends Route<Model> {
     if (!modelState || modelState.isReady) {
       return;
     }
+    renderReadyLogger.info(
+      `scheduling ready settlement for cardId=${model.cardId}`,
+    );
     this.#pendingReadyModels.add(model);
     scheduleOnce('afterRender', this, this.#processPendingReadyModels);
     this.#startReadyWatchdog(model);
@@ -623,7 +629,13 @@ export default class RenderRoute extends Route<Model> {
     if (!modelState || modelState.isReady) {
       return;
     }
+    renderReadyLogger.info(
+      `settleModelAfterRender start cardId=${model.cardId} status=${model.status}`,
+    );
     await this.#authGuard.race(() => this.store.loaded());
+    renderReadyLogger.info(
+      `settleModelAfterRender store.loaded resolved cardId=${model.cardId}`,
+    );
     modelState.state.set('status', 'ready');
     modelState.isReady = true;
     modelState.readyDeferred.fulfill();
@@ -631,6 +643,9 @@ export default class RenderRoute extends Route<Model> {
     model.capturedDeps = snapshotRuntimeDependencies({
       excludeQueryOnly: true,
     }).deps;
+    renderReadyLogger.info(
+      `settleModelAfterRender done cardId=${model.cardId} deps=${model.capturedDeps?.length ?? 0}`,
+    );
   }
 
   #settleModelAfterRenderSafely(model: Model) {

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -281,6 +281,10 @@ export default class StoreService extends Service implements StoreInterface {
     return this.store.loaded();
   }
 
+  trackLoad(load: Promise<unknown>): void {
+    this.store.trackLoad(load);
+  }
+
   get cardDocsInFlight() {
     return this.store.cardDocsInFlight;
   }
@@ -811,13 +815,10 @@ export default class StoreService extends Service implements StoreInterface {
     if (this.isRenderStore && opts) {
       opts.isLive = false;
     }
-    return getSearch<T>(
-      parent,
-      getOwner(this)!,
-      getQuery,
-      getRealms,
-      opts,
-    ) as unknown as SearchResource<T>;
+    return getSearch<T>(parent, getOwner(this)!, getQuery, getRealms, {
+      ...opts,
+      storeService: this,
+    }) as unknown as SearchResource<T>;
   }
 
   getSearchDataResource(

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -107,6 +107,9 @@ let waiter = buildWaiter('store-service');
 
 const realmEventsLogger = logger('realm:events');
 const storeLogger = logger('store');
+const queryFieldSeedFromSearchSymbol = Symbol.for(
+  'cardstack-query-field-seed-from-search',
+);
 
 type PersistOptions = CreateOptions & { clientRequestId?: string };
 type DependencyTrackingOptions = {
@@ -1276,6 +1279,9 @@ export default class StoreService extends Service implements StoreInterface {
     if (existingInstance && isCardInstance(existingInstance)) {
       return existingInstance as T;
     }
+    // Mark resources that came from `_search` so query-field seed handling can
+    // distinguish unresolved empty seeds from explicit empty card-GET results.
+    (resource as any)[queryFieldSeedFromSearchSymbol] = true;
     return this.add({ data: resource } as SingleCardDocument, {
       doNotPersist: true,
       relativeTo: new URL(resource.id),

--- a/packages/host/tests/acceptance/image-def/png-image-def-test.gts
+++ b/packages/host/tests/acceptance/image-def/png-image-def-test.gts
@@ -387,9 +387,8 @@ module('Acceptance | png image def', function (hooks) {
     let { status } = await capturePrerenderResult('innerHTML');
     assert.strictEqual(status, 'ready', 'render completed');
 
-    let img = document.querySelector(
-      '[data-prerender] .image-isolated__img',
-    ) as HTMLImageElement | null;
+    let imgSelector = '[data-prerender] .image-isolated__img';
+    let img = document.querySelector(imgSelector) as HTMLImageElement | null;
     assert.ok(img, 'img element is rendered');
     assert.ok(
       img?.getAttribute('src')?.includes('sample.png'),
@@ -400,18 +399,32 @@ module('Acceptance | png image def', function (hooks) {
     // This assertion will fail if the browser cannot fetch the image (e.g., 401 errors
     // due to missing authentication cookies). Once cookie-based auth is implemented,
     // this test should pass.
-    await waitUntil(() => img!.naturalWidth > 0, {
-      timeout: 5000,
-      timeoutMessage:
-        'Image failed to load - naturalWidth remained 0. This likely indicates an authentication issue preventing the browser from fetching the image.',
-    });
+    await waitUntil(
+      () => {
+        let currentImg = document.querySelector(
+          imgSelector,
+        ) as HTMLImageElement | null;
+        return Boolean(
+          currentImg && currentImg.complete && currentImg.naturalWidth > 0,
+        );
+      },
+      {
+        timeout: 5000,
+        timeoutMessage:
+          'Image failed to load - naturalWidth remained 0. This likely indicates an authentication issue preventing the browser from fetching the image.',
+      },
+    );
 
+    let loadedImg = document.querySelector(
+      imgSelector,
+    ) as HTMLImageElement | null;
+    assert.ok(loadedImg, 'img element remains rendered after load');
     assert.ok(
-      img!.naturalWidth > 0,
+      loadedImg!.naturalWidth > 0,
       'Image loaded successfully with non-zero width',
     );
     assert.ok(
-      img!.naturalHeight > 0,
+      loadedImg!.naturalHeight > 0,
       'Image loaded successfully with non-zero height',
     );
   });

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -2081,12 +2081,11 @@ module('Integration | Store', function (hooks) {
       get card() {
         return this.resource.instances[0];
       }
-      get renderedCard() {
-        return this.card?.constructor.getComponent(this.card);
-      }
       <template>
         {{#if this.card}}
-          <this.renderedCard data-test-rendered-card={{this.card.id}} />
+          <div data-test-rendered-card={{this.card.id}}>
+            {{this.card.id}}
+          </div>
         {{/if}}
       </template>
     }

--- a/packages/host/tests/integration/store-test.gts
+++ b/packages/host/tests/integration/store-test.gts
@@ -2105,7 +2105,12 @@ module('Integration | Store', function (hooks) {
     let hassan = `${testRealmURL}Person/hassan`;
 
     driver.id = hassan;
-    await waitFor(`[data-test-rendered-card="${hassan}"]`, { timeout: 5_000 });
+    await waitUntil(
+      () =>
+        storeService.getReferenceCount(hassan) === 1 &&
+        storeService.getReferenceCount(jade) === 0,
+      { timeout: 10_000 },
+    );
     assert.strictEqual(
       storeService.getReferenceCount(jade),
       0,
@@ -2118,7 +2123,12 @@ module('Integration | Store', function (hooks) {
     );
 
     driver.id = jade;
-    await waitFor(`[data-test-rendered-card="${jade}"]`, { timeout: 5_000 });
+    await waitUntil(
+      () =>
+        storeService.getReferenceCount(jade) === 1 &&
+        storeService.getReferenceCount(hassan) === 0,
+      { timeout: 10_000 },
+    );
     assert.strictEqual(
       storeService.getReferenceCount(jade),
       1,
@@ -2131,7 +2141,12 @@ module('Integration | Store', function (hooks) {
     );
 
     driver.showComponent = false;
-    await waitFor(`[data-test-rendered-card]`, { count: 0 });
+    await waitUntil(
+      () =>
+        storeService.getReferenceCount(jade) === 0 &&
+        storeService.getReferenceCount(hassan) === 0,
+      { timeout: 10_000 },
+    );
     assert.strictEqual(
       storeService.getReferenceCount(jade),
       0,

--- a/packages/realm-server/tests/helpers/prerender-page-patches.ts
+++ b/packages/realm-server/tests/helpers/prerender-page-patches.ts
@@ -1,0 +1,151 @@
+import { Realm as RuntimeRealm } from '@cardstack/runtime-common';
+import { PagePool } from '../../prerender/page-pool';
+
+export function installRealmServerAssertOwnRealmServerBypassPatch(): {
+  restore: () => Promise<void>;
+} {
+  // Chrome patch setup:
+  // We need a browser-side patch because prerender tests can run the host app
+  // against dynamic realm origins (for example 127.0.0.1:4450), while the host's
+  // RealmServerService.assertOwnRealmServer check assumes a single configured
+  // realm server origin. Query-field search calls through that assertion before
+  // it performs _search, so without this patch search can bail out too early and
+  // we never get to exercise query-load tracking behavior.
+  let originalGetPage = PagePool.prototype.getPage;
+  let observedPage: any;
+
+  // Intercept page acquisition so we can inject one browser-runtime patch
+  // before route transitions/captures run.
+  PagePool.prototype.getPage = async function (this: PagePool, realm: string) {
+    let pageInfo = await originalGetPage.call(this, realm);
+    let page = pageInfo.page as any;
+    observedPage = page;
+    let originalEvaluate = page?.evaluate?.bind(page);
+
+    if (originalEvaluate) {
+      // Per-page guard. A single page can be reused by the page pool; we only
+      // need to install our patch once for that page instance.
+      let injected = false;
+      page.evaluate = async (...args: any[]) => {
+        if (!injected) {
+          injected = true;
+          await originalEvaluate(() => {
+            // Global guard in page context in case evaluate wrappers are
+            // re-entered or patched multiple times.
+            if ((globalThis as any).__boxelAssertOwnRealmServerPatched) {
+              return;
+            }
+            // Resolve the Ember module registry from whichever loader shape
+            // exists in this runtime build.
+            let entries =
+              (window as any).requirejs?.entries ??
+              (window as any).require?.entries ??
+              (window as any)._eak_seen;
+            // Find the compiled realm-server service module and patch only the
+            // one assertion method we need to bypass.
+            let realmServerModuleName =
+              entries &&
+              Object.keys(entries).find((name) =>
+                name.endsWith('/services/realm-server'),
+              );
+            if (!realmServerModuleName) {
+              return;
+            }
+            let realmServerModule = (window as any).require(
+              realmServerModuleName,
+            );
+            let RealmServerClass = realmServerModule?.default;
+            if (!RealmServerClass?.prototype) {
+              return;
+            }
+            // Save original behavior so restore() can put it back and avoid
+            // cross-test contamination.
+            (globalThis as any).__boxelOriginalAssertOwnRealmServer =
+              RealmServerClass.prototype.assertOwnRealmServer;
+            // Patch objective:
+            // Allow query-field search requests to proceed for dynamic test
+            // realm origins. We are not changing search logic itself; this only
+            // removes the single-origin assertion gate for this test runtime.
+            RealmServerClass.prototype.assertOwnRealmServer = function () {
+              return;
+            };
+            (globalThis as any).__boxelAssertOwnRealmServerPatched = true;
+          });
+        }
+        // Delegate every evaluate call back to original behavior after patching.
+        return originalEvaluate(...args);
+      };
+    }
+
+    return { ...pageInfo, page };
+  };
+
+  return {
+    restore: async () => {
+      if (observedPage) {
+        try {
+          await observedPage.evaluate(() => {
+            // Cleanup mirrors setup above: locate the same service module and
+            // restore the original assertOwnRealmServer implementation.
+            let entries =
+              (window as any).requirejs?.entries ??
+              (window as any).require?.entries ??
+              (window as any)._eak_seen;
+            let realmServerModuleName =
+              entries &&
+              Object.keys(entries).find((name) =>
+                name.endsWith('/services/realm-server'),
+              );
+            let originalAssertOwnRealmServer = (globalThis as any)
+              .__boxelOriginalAssertOwnRealmServer;
+            if (realmServerModuleName && originalAssertOwnRealmServer) {
+              let realmServerModule = (window as any).require(
+                realmServerModuleName,
+              );
+              let RealmServerClass = realmServerModule?.default;
+              if (RealmServerClass?.prototype) {
+                RealmServerClass.prototype.assertOwnRealmServer =
+                  originalAssertOwnRealmServer;
+              }
+            }
+            // Remove page globals used by this patch to keep runtime clean.
+            delete (globalThis as any).__boxelOriginalAssertOwnRealmServer;
+            delete (globalThis as any).__boxelAssertOwnRealmServerPatched;
+          });
+        } catch {
+          // best effort cleanup: page may already be gone
+        }
+      }
+      // Always restore Node-side monkeypatch as well.
+      PagePool.prototype.getPage = originalGetPage;
+    },
+  };
+}
+
+export function installDelayedRuntimeRealmSearchPatch(delayMs: number): {
+  getRequestCount: () => number;
+  restore: () => void;
+} {
+  // Server-side deterministic delay:
+  // This makes query timing explicit/reproducible so tests can assert that
+  // prerender waited for query resolution instead of "winning a race" by chance.
+  let originalSearch = RuntimeRealm.prototype.search;
+  let delayedSearchRequestCount = 0;
+
+  RuntimeRealm.prototype.search = async function (
+    this: RuntimeRealm,
+    query: Parameters<RuntimeRealm['search']>[0],
+  ): Promise<Awaited<ReturnType<RuntimeRealm['search']>>> {
+    // Exposed to tests as a stable signal that fallback _search actually ran.
+    delayedSearchRequestCount++;
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    return await originalSearch.call(this, query);
+  };
+
+  return {
+    getRequestCount: () => delayedSearchRequestCount,
+    restore: () => {
+      RuntimeRealm.prototype.search = originalSearch;
+    },
+  };
+}

--- a/packages/realm-server/tests/helpers/prerender-page-patches.ts
+++ b/packages/realm-server/tests/helpers/prerender-page-patches.ts
@@ -12,17 +12,17 @@ export function installRealmServerAssertOwnRealmServerBypassPatch(): {
   // it performs _search, so without this patch search can bail out too early and
   // we never get to exercise query-load tracking behavior.
   let originalGetPage = PagePool.prototype.getPage;
-  let observedPage: any;
+  let patchedPages = new Map<any, (...args: any[]) => Promise<any>>();
 
   // Intercept page acquisition so we can inject one browser-runtime patch
   // before route transitions/captures run.
   PagePool.prototype.getPage = async function (this: PagePool, realm: string) {
     let pageInfo = await originalGetPage.call(this, realm);
     let page = pageInfo.page as any;
-    observedPage = page;
     let originalEvaluate = page?.evaluate?.bind(page);
 
-    if (originalEvaluate) {
+    if (originalEvaluate && !patchedPages.has(page)) {
+      patchedPages.set(page, originalEvaluate);
       // Per-page guard. A single page can be reused by the page pool; we only
       // need to install our patch once for that page instance.
       let injected = false;
@@ -82,9 +82,12 @@ export function installRealmServerAssertOwnRealmServerBypassPatch(): {
 
   return {
     restore: async () => {
-      if (observedPage) {
+      for (let [page, originalEvaluate] of patchedPages) {
         try {
-          await observedPage.evaluate(() => {
+          // Restore the original evaluate first to avoid leaving wrapped
+          // evaluate functions behind on pooled pages that survive this test.
+          page.evaluate = originalEvaluate;
+          await originalEvaluate(() => {
             // Cleanup mirrors setup above: locate the same service module and
             // restore the original assertOwnRealmServer implementation.
             let entries =
@@ -116,6 +119,7 @@ export function installRealmServerAssertOwnRealmServerBypassPatch(): {
           // best effort cleanup: page may already be gone
         }
       }
+      patchedPages.clear();
       // Always restore Node-side monkeypatch as well.
       PagePool.prototype.getPage = originalGetPage;
     },

--- a/packages/realm-server/tests/prerendering-test.ts
+++ b/packages/realm-server/tests/prerendering-test.ts
@@ -2,14 +2,16 @@ import { module, test } from 'qunit';
 import { basename } from 'path';
 import type {
   RealmPermissions,
-  Realm,
   RealmAdapter,
   RenderResponse,
   ModuleRenderResponse,
   FileExtractResponse,
   RenderRouteOptions,
 } from '@cardstack/runtime-common';
-import { baseRealm } from '@cardstack/runtime-common';
+import {
+  baseRealm,
+  type Realm as RuntimeRealm,
+} from '@cardstack/runtime-common';
 import type { Prerenderer } from '../prerender/index';
 import { PagePool } from '../prerender/page-pool';
 import { RenderRunner } from '../prerender/render-runner';
@@ -25,6 +27,10 @@ import {
   baseCardRef,
   trimExecutableExtension,
 } from '@cardstack/runtime-common';
+import {
+  installDelayedRuntimeRealmSearchPatch,
+  installRealmServerAssertOwnRealmServerBypassPatch,
+} from './helpers/prerender-page-patches';
 
 class TestSemaphore {
   #available: number;
@@ -131,11 +137,22 @@ module(basename(__filename), function () {
     let realmURL = 'http://127.0.0.1:4450/test/';
     let prerenderServerURL = new URL(realmURL).origin;
     let testUserId = '@user1:localhost';
-    let permissions: RealmPermissions = {};
+    let permissions: RealmPermissions = {
+      [realmURL]: ['read', 'write', 'realm-owner'],
+    };
     let prerenderer: Prerenderer;
     let realmAdapter: RealmAdapter;
-    let realm: Realm;
-    let auth = () => testCreatePrerenderAuth(testUserId, permissions);
+    let realm: RuntimeRealm;
+    let auth = () => {
+      let sessions = JSON.parse(
+        testCreatePrerenderAuth(testUserId, permissions),
+      ) as Record<string, string>;
+      let token = sessions[realmURL];
+      if (token) {
+        sessions[new URL(realmURL).origin + '/'] = token;
+      }
+      return JSON.stringify(sessions);
+    };
 
     hooks.before(async () => {
       prerenderer = getPrerendererForTesting({
@@ -157,6 +174,7 @@ module(basename(__filename), function () {
         {
           realmURL,
           permissions: {
+            '*': ['read'],
             [testUserId]: ['read', 'write', 'realm-owner'],
           },
           fileSystem: {
@@ -397,6 +415,243 @@ module(basename(__filename), function () {
                   adoptsFrom: {
                     module: './console-no-error',
                     name: 'ConsoleNoError',
+                  },
+                },
+              },
+            },
+            'directory-query.gts': `
+              import { CardDef, field, contains, linksTo, linksToMany, StringField, Component, queryableValue } from 'https://cardstack.com/base/card-api';
+
+              export class Person extends CardDef {
+                static displayName = 'Person';
+                @field name = contains(StringField);
+                @field team = contains(StringField);
+                @field managerName = contains(StringField);
+                @field manager = linksTo(() => Person);
+                @field reports = linksToMany(() => Person, {
+                  query: {
+                    filter: {
+                      eq: {
+                        managerName: '$this.name',
+                      },
+                    },
+                    page: {
+                      size: 10,
+                      number: 0,
+                    },
+                  },
+                });
+
+                // Keep person-instance indexing deterministic for this test:
+                // this avoids firing query fields when Person cards are
+                // prerendered in isolation during indexing.
+                static isolated = class extends Component<typeof this> {
+                  <template>
+                    <span data-test-person-name>{{@model.name}}</span>
+                    <span data-test-person-team>{{@model.team}}</span>
+                  </template>
+                };
+              }
+
+              export class Directory extends CardDef {
+                static displayName = 'Directory';
+                @field teamFilter = contains(StringField);
+                @field staff = linksToMany(() => Person, {
+                  query: {
+                    filter: {
+                      eq: {
+                        team: '$this.teamFilter',
+                      },
+                    },
+                    page: {
+                      size: 10,
+                      number: 0,
+                    },
+                  },
+                });
+
+                static [queryableValue](value: Directory | null) {
+                  if (!value) {
+                    return null;
+                  }
+                  return {
+                    teamFilter: value.teamFilter,
+                    staff: (value.staff ?? []).map((person) => ({
+                      name: person.name,
+                      manager: person.manager
+                        ? {
+                            name: person.manager.name,
+                          }
+                        : null,
+                      reports: (person.reports ?? []).map((report) => ({
+                        name: report.name,
+                        manager: report.manager
+                          ? {
+                              name: report.manager.name,
+                            }
+                          : null,
+                      })),
+                    })),
+                  };
+                }
+
+                static isolated = class extends Component<typeof this> {
+                  <template>
+                    <div data-test-directory-team>{{@model.teamFilter}}</div>
+                    <ul data-test-directory-staff>
+                      {{#each @model.staff as |person|}}
+                        <li data-test-staff-name>{{person.name}}</li>
+                        <div data-test-staff-manager>
+                          {{#if person.manager}}
+                            {{person.manager.name}}
+                          {{/if}}
+                        </div>
+                        <ul data-test-staff-reports>
+                          {{#each person.reports as |report|}}
+                            <li data-test-staff-report>
+                              {{report.name}}
+                              <span data-test-staff-report-manager>
+                                {{#if report.manager}}
+                                  {{report.manager.name}}
+                                {{/if}}
+                              </span>
+                            </li>
+                          {{/each}}
+                        </ul>
+                      {{/each}}
+                    </ul>
+                  </template>
+                };
+              }
+            `,
+            'directory-ops.json': {
+              data: {
+                attributes: {
+                  teamFilter: 'Ops',
+                },
+                relationships: {
+                  staff: {
+                    links: { self: null },
+                    data: [],
+                    meta: {
+                      errors: [
+                        {
+                          realm: 'https://unreachable-realm.example.com/',
+                          type: 'fetch-error',
+                          message: 'Could not reach remote realm',
+                          status: 502,
+                        },
+                      ],
+                    },
+                  },
+                },
+                meta: {
+                  adoptsFrom: {
+                    module: './directory-query',
+                    name: 'Directory',
+                  },
+                },
+              },
+            },
+            'person-alice.json': {
+              data: {
+                attributes: {
+                  name: 'Alice',
+                  team: 'Leadership',
+                  managerName: '',
+                },
+                meta: {
+                  adoptsFrom: {
+                    module: './directory-query',
+                    name: 'Person',
+                  },
+                },
+              },
+            },
+            'person-bob.json': {
+              data: {
+                attributes: {
+                  name: 'Bob',
+                  team: 'Ops',
+                  managerName: 'Alice',
+                },
+                relationships: {
+                  manager: {
+                    links: {
+                      self: './person-alice',
+                    },
+                  },
+                },
+                meta: {
+                  adoptsFrom: {
+                    module: './directory-query',
+                    name: 'Person',
+                  },
+                },
+              },
+            },
+            'person-carol.json': {
+              data: {
+                attributes: {
+                  name: 'Carol',
+                  team: 'Ops',
+                  managerName: 'Alice',
+                },
+                relationships: {
+                  manager: {
+                    links: {
+                      self: './person-alice',
+                    },
+                  },
+                },
+                meta: {
+                  adoptsFrom: {
+                    module: './directory-query',
+                    name: 'Person',
+                  },
+                },
+              },
+            },
+            'person-dave.json': {
+              data: {
+                attributes: {
+                  name: 'Dave',
+                  team: 'Ops',
+                  managerName: 'Bob',
+                },
+                relationships: {
+                  manager: {
+                    links: {
+                      self: './person-bob',
+                    },
+                  },
+                },
+                meta: {
+                  adoptsFrom: {
+                    module: './directory-query',
+                    name: 'Person',
+                  },
+                },
+              },
+            },
+            'person-eve.json': {
+              data: {
+                attributes: {
+                  name: 'Eve',
+                  team: 'Sales',
+                  managerName: 'Bob',
+                },
+                relationships: {
+                  manager: {
+                    links: {
+                      self: './person-bob',
+                    },
+                  },
+                },
+                meta: {
+                  adoptsFrom: {
+                    module: './directory-query',
+                    name: 'Person',
                   },
                 },
               },
@@ -927,6 +1182,76 @@ module(basename(__filename), function () {
         );
       } finally {
         PagePool.prototype.getPage = originalGetPage;
+      }
+    });
+
+    test('card prerender waits for query fallback search and nested relationship loads', async function (assert) {
+      const cardURL = `${realmURL}directory-ops`;
+      let realmServerPatch =
+        installRealmServerAssertOwnRealmServerBypassPatch();
+      let delayedSearchPatch = installDelayedRuntimeRealmSearchPatch(150);
+      try {
+        let result = await prerenderer.prerenderCard({
+          realm: realmURL,
+          url: cardURL,
+          auth: auth(),
+        });
+
+        assert.notOk(result.response.error, 'prerender succeeds');
+        assert.true(
+          delayedSearchPatch.getRequestCount() > 0,
+          'fallback _search requests occurred and were delayed',
+        );
+
+        let isolatedHTML = cleanWhiteSpace(result.response.isolatedHTML ?? '');
+        assert.ok(
+          /data-test-staff-name[^>]*>\s*Bob\s*</.test(isolatedHTML),
+          `isolated html includes query results: ${isolatedHTML}`,
+        );
+        assert.ok(
+          /data-test-staff-manager[^>]*>\s*Alice\s*</.test(isolatedHTML),
+          `isolated html includes lazy relationship from query result: ${isolatedHTML}`,
+        );
+        assert.ok(
+          /data-test-staff-report[^>]*>\s*Eve/.test(isolatedHTML),
+          `isolated html includes nested query results: ${isolatedHTML}`,
+        );
+        assert.ok(
+          /data-test-staff-report-manager[^>]*>\s*Bob\s*</.test(isolatedHTML),
+          `isolated html includes nested relationship loads: ${isolatedHTML}`,
+        );
+
+        let staff = result.response.searchDoc?.staff as
+          | Array<Record<string, any>>
+          | undefined;
+        assert.ok(
+          Array.isArray(staff),
+          'searchDoc includes query field results',
+        );
+
+        let bob = staff?.find((entry) => entry?.name === 'Bob');
+        assert.ok(bob, 'searchDoc includes Bob from query results');
+        assert.strictEqual(
+          bob?.manager?.name,
+          'Alice',
+          'searchDoc includes loaded manager relationship',
+        );
+
+        let bobReports = bob?.reports as Array<Record<string, any>> | undefined;
+        assert.ok(
+          Array.isArray(bobReports),
+          'searchDoc includes nested query results',
+        );
+        let hasEveWithManager = bobReports?.some(
+          (report) => report?.name === 'Eve' && report?.manager?.name === 'Bob',
+        );
+        assert.true(
+          Boolean(hasEveWithManager),
+          'searchDoc includes nested loaded relationships',
+        );
+      } finally {
+        await realmServerPatch.restore();
+        delayedSearchPatch.restore();
       }
     });
 


### PR DESCRIPTION
This PR updates the prerenderer to wait for the search promise from query fields to complete (as well as any downstream promises from the search results) before capturing a snapshot.