### PR TITLE
Add TsFileDef and GtsFileDef for TypeScript/GTS files

### DIFF
--- a/packages/base/gts-file-def.gts
+++ b/packages/base/gts-file-def.gts
@@ -1,0 +1,7 @@
+import { TsFileDef } from './ts-file-def';
+
+export class GtsFileDef extends TsFileDef {
+  static displayName = 'GTS Module';
+  static acceptTypes = '.gts';
+  static validExtensions = new Set(['.gts']);
+}

--- a/packages/base/ts-file-def.gts
+++ b/packages/base/ts-file-def.gts
@@ -53,9 +53,10 @@ function spanWrap(className: string, text: string): string {
 }
 
 // Use RegExp constructor for patterns with < > to avoid content-tag misparsing
+// TEMPLATE_TAG_RE uses string concat to hide 'template' from content-tag parser
 const BLOCK_COMMENT_RE = new RegExp('/\\*[\\s\\S]*?\\*/', 'g');
 const LINE_COMMENT_RE = new RegExp('//[^\n]*', 'g');
-const TEMPLATE_TAG_RE = new RegExp('</?template>', 'g');
+const TEMPLATE_TAG_RE = new RegExp('</?t' + 'emplate>', 'g');
 const STRING_DOUBLE_RE = new RegExp('"(?:[^"\\\\]|\\\\.)*"', 'g');
 const STRING_SINGLE_RE = new RegExp("'(?:[^'\\\\]|\\\\.)*'", 'g');
 const STRING_TEMPLATE_RE = new RegExp('`(?:[^`\\\\]|\\\\.)*`', 'g');

--- a/packages/base/ts-file-def.gts
+++ b/packages/base/ts-file-def.gts
@@ -14,6 +14,8 @@ import {
   type ByteStream,
   type SerializedFile,
 } from './file-api';
+import { highlightTs } from './ts-highlight';
+export { highlightTs } from './ts-highlight';
 
 const EXCERPT_MAX_LENGTH = 500;
 
@@ -38,118 +40,6 @@ function truncateExcerpt(text: string): string {
     return text;
   }
   return `${text.slice(0, EXCERPT_MAX_LENGTH - 3).trimEnd()}...`;
-}
-
-function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
-}
-
-function spanWrap(className: string, text: string): string {
-  return `<span class="${className}">${escapeHtml(text)}</span>`;
-}
-
-// Use RegExp constructor for patterns with < > to avoid content-tag misparsing
-// TEMPLATE_TAG_RE uses string concat to hide 'template' from content-tag parser
-const BLOCK_COMMENT_RE = new RegExp('/\\*[\\s\\S]*?\\*/', 'g');
-const LINE_COMMENT_RE = new RegExp('//[^\n]*', 'g');
-const TEMPLATE_TAG_RE = new RegExp('</?t' + 'emplate>', 'g');
-const STRING_DOUBLE_RE = new RegExp('"(?:[^"\\\\]|\\\\.)*"', 'g');
-const STRING_SINGLE_RE = new RegExp("'(?:[^'\\\\]|\\\\.)*'", 'g');
-const STRING_TEMPLATE_RE = new RegExp('`(?:[^`\\\\]|\\\\.)*`', 'g');
-const DECORATOR_RE = new RegExp('@\\w+', 'g');
-const NUMBER_RE = new RegExp('\\b\\d+(?:\\.\\d+)?\\b', 'g');
-const KEYWORD_RE = new RegExp(
-  '\\b(?:import|export|default|from|class|extends|static|async|await|function|const|let|var|if|else|return|new|this|super|typeof|instanceof|void|null|undefined|true|false|yield|of|in|for|while|do|switch|case|break|continue|try|catch|finally|throw|type|interface|declare|as|implements|readonly|enum|abstract|private|protected|public|get|set)\\b',
-  'g',
-);
-const TYPE_RE = new RegExp('(?:(?::\\s*)|(?:extends\\s+))([A-Z]\\w*)', 'g');
-
-interface Token {
-  start: number;
-  end: number;
-  className: string;
-  text: string;
-}
-
-function collectMatches(
-  source: string,
-  regex: RegExp,
-  className: string,
-  tokens: Token[],
-): void {
-  regex.lastIndex = 0;
-  let match;
-  while ((match = regex.exec(source)) !== null) {
-    tokens.push({
-      start: match.index,
-      end: match.index + match[0].length,
-      className,
-      text: match[0],
-    });
-  }
-}
-
-function collectTypeMatches(source: string, tokens: Token[]): void {
-  TYPE_RE.lastIndex = 0;
-  let match;
-  while ((match = TYPE_RE.exec(source)) !== null) {
-    let typeName = match[1];
-    let typeStart = match.index + match[0].length - typeName.length;
-    tokens.push({
-      start: typeStart,
-      end: typeStart + typeName.length,
-      className: 'ts-type',
-      text: typeName,
-    });
-  }
-}
-
-export function highlightTs(source: string): string {
-  let tokens: Token[] = [];
-
-  // Collect all tokens (order matters for priority — earlier = higher)
-  collectMatches(source, BLOCK_COMMENT_RE, 'ts-comment', tokens);
-  collectMatches(source, LINE_COMMENT_RE, 'ts-comment', tokens);
-  collectMatches(source, STRING_DOUBLE_RE, 'ts-string', tokens);
-  collectMatches(source, STRING_SINGLE_RE, 'ts-string', tokens);
-  collectMatches(source, STRING_TEMPLATE_RE, 'ts-string', tokens);
-  collectMatches(source, TEMPLATE_TAG_RE, 'ts-keyword', tokens);
-  collectMatches(source, DECORATOR_RE, 'ts-decorator', tokens);
-  collectMatches(source, NUMBER_RE, 'ts-number', tokens);
-  collectMatches(source, KEYWORD_RE, 'ts-keyword', tokens);
-  collectTypeMatches(source, tokens);
-
-  // Sort by start position, then by priority (earlier collected = higher priority via stable sort)
-  tokens.sort((a, b) => a.start - b.start);
-
-  // Remove overlapping tokens (keep the first one encountered)
-  let filtered: Token[] = [];
-  let lastEnd = 0;
-  for (let token of tokens) {
-    if (token.start >= lastEnd) {
-      filtered.push(token);
-      lastEnd = token.end;
-    }
-  }
-
-  // Build output
-  let result = '';
-  let pos = 0;
-  for (let token of filtered) {
-    if (token.start > pos) {
-      result += escapeHtml(source.slice(pos, token.start));
-    }
-    result += spanWrap(token.className, token.text);
-    pos = token.end;
-  }
-  if (pos < source.length) {
-    result += escapeHtml(source.slice(pos));
-  }
-  return result;
 }
 
 function tsTitle(

--- a/packages/base/ts-file-def.gts
+++ b/packages/base/ts-file-def.gts
@@ -1,0 +1,574 @@
+import { byteStreamToUint8Array } from '@cardstack/runtime-common';
+import FileCodeIcon from '@cardstack/boxel-icons/file-code';
+import {
+  BaseDefComponent,
+  Component,
+  StringField,
+  contains,
+  field,
+} from './card-api';
+import sanitizedHtml from './helpers/sanitized-html';
+import {
+  FileContentMismatchError,
+  FileDef,
+  type ByteStream,
+  type SerializedFile,
+} from './file-api';
+
+const EXCERPT_MAX_LENGTH = 500;
+
+function getExtension(url: string): string {
+  try {
+    let parsed = new URL(url);
+    let name = parsed.pathname.split('/').pop() ?? '';
+    let dot = name.lastIndexOf('.');
+    return dot === -1 ? '' : name.slice(dot).toLowerCase();
+  } catch {
+    let dot = url.lastIndexOf('.');
+    return dot === -1 ? '' : url.slice(dot).toLowerCase();
+  }
+}
+
+function fileNameWithoutExtension(name: string): string {
+  return name.replace(/\.[^/.]+$/, '');
+}
+
+function truncateExcerpt(text: string): string {
+  if (text.length <= EXCERPT_MAX_LENGTH) {
+    return text;
+  }
+  return `${text.slice(0, EXCERPT_MAX_LENGTH - 3).trimEnd()}...`;
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function spanWrap(className: string, text: string): string {
+  return `<span class="${className}">${escapeHtml(text)}</span>`;
+}
+
+// Use RegExp constructor for patterns with < > to avoid content-tag misparsing
+const BLOCK_COMMENT_RE = new RegExp('/\\*[\\s\\S]*?\\*/', 'g');
+const LINE_COMMENT_RE = new RegExp('//[^\n]*', 'g');
+const TEMPLATE_TAG_RE = new RegExp('</?template>', 'g');
+const STRING_DOUBLE_RE = new RegExp('"(?:[^"\\\\]|\\\\.)*"', 'g');
+const STRING_SINGLE_RE = new RegExp("'(?:[^'\\\\]|\\\\.)*'", 'g');
+const STRING_TEMPLATE_RE = new RegExp('`(?:[^`\\\\]|\\\\.)*`', 'g');
+const DECORATOR_RE = new RegExp('@\\w+', 'g');
+const NUMBER_RE = new RegExp('\\b\\d+(?:\\.\\d+)?\\b', 'g');
+const KEYWORD_RE = new RegExp(
+  '\\b(?:import|export|default|from|class|extends|static|async|await|function|const|let|var|if|else|return|new|this|super|typeof|instanceof|void|null|undefined|true|false|yield|of|in|for|while|do|switch|case|break|continue|try|catch|finally|throw|type|interface|declare|as|implements|readonly|enum|abstract|private|protected|public|get|set)\\b',
+  'g',
+);
+const TYPE_RE = new RegExp('(?:(?::\\s*)|(?:extends\\s+))([A-Z]\\w*)', 'g');
+
+interface Token {
+  start: number;
+  end: number;
+  className: string;
+  text: string;
+}
+
+function collectMatches(
+  source: string,
+  regex: RegExp,
+  className: string,
+  tokens: Token[],
+): void {
+  regex.lastIndex = 0;
+  let match;
+  while ((match = regex.exec(source)) !== null) {
+    tokens.push({
+      start: match.index,
+      end: match.index + match[0].length,
+      className,
+      text: match[0],
+    });
+  }
+}
+
+function collectTypeMatches(source: string, tokens: Token[]): void {
+  TYPE_RE.lastIndex = 0;
+  let match;
+  while ((match = TYPE_RE.exec(source)) !== null) {
+    let typeName = match[1];
+    let typeStart = match.index + match[0].length - typeName.length;
+    tokens.push({
+      start: typeStart,
+      end: typeStart + typeName.length,
+      className: 'ts-type',
+      text: typeName,
+    });
+  }
+}
+
+export function highlightTs(source: string): string {
+  let tokens: Token[] = [];
+
+  // Collect all tokens (order matters for priority — earlier = higher)
+  collectMatches(source, BLOCK_COMMENT_RE, 'ts-comment', tokens);
+  collectMatches(source, LINE_COMMENT_RE, 'ts-comment', tokens);
+  collectMatches(source, STRING_DOUBLE_RE, 'ts-string', tokens);
+  collectMatches(source, STRING_SINGLE_RE, 'ts-string', tokens);
+  collectMatches(source, STRING_TEMPLATE_RE, 'ts-string', tokens);
+  collectMatches(source, TEMPLATE_TAG_RE, 'ts-keyword', tokens);
+  collectMatches(source, DECORATOR_RE, 'ts-decorator', tokens);
+  collectMatches(source, NUMBER_RE, 'ts-number', tokens);
+  collectMatches(source, KEYWORD_RE, 'ts-keyword', tokens);
+  collectTypeMatches(source, tokens);
+
+  // Sort by start position, then by priority (earlier collected = higher priority via stable sort)
+  tokens.sort((a, b) => a.start - b.start);
+
+  // Remove overlapping tokens (keep the first one encountered)
+  let filtered: Token[] = [];
+  let lastEnd = 0;
+  for (let token of tokens) {
+    if (token.start >= lastEnd) {
+      filtered.push(token);
+      lastEnd = token.end;
+    }
+  }
+
+  // Build output
+  let result = '';
+  let pos = 0;
+  for (let token of filtered) {
+    if (token.start > pos) {
+      result += escapeHtml(source.slice(pos, token.start));
+    }
+    result += spanWrap(token.className, token.text);
+    pos = token.end;
+  }
+  if (pos < source.length) {
+    result += escapeHtml(source.slice(pos));
+  }
+  return result;
+}
+
+function tsTitle(
+  model: { title?: string | null; name?: string | null } | null | undefined,
+): string {
+  return model?.title ?? model?.name ?? 'Untitled TypeScript module';
+}
+
+class Isolated extends Component<typeof TsFileDef> {
+  get highlightedContent() {
+    let content = this.args.model?.content;
+    if (!content) {
+      return null;
+    }
+    return highlightTs(content);
+  }
+
+  get title() {
+    return tsTitle(this.args.model);
+  }
+
+  <template>
+    <article class='ts-isolated' data-test-ts-isolated>
+      {{#if this.highlightedContent}}
+        <pre class='ts-isolated__code'><code>{{sanitizedHtml
+              this.highlightedContent
+            }}</code></pre>
+      {{else}}
+        <header class='ts-isolated__title'>{{this.title}}</header>
+      {{/if}}
+    </article>
+    <style scoped>
+      .ts-isolated {
+        padding: var(--boxel-sp-lg);
+        max-width: 100%;
+      }
+
+      .ts-isolated__title {
+        color: var(--boxel-900);
+        font-weight: 600;
+        font-size: var(--boxel-font-size-lg);
+      }
+
+      .ts-isolated__code {
+        background: var(--boxel-dark);
+        color: var(--boxel-light);
+        font-family: var(--boxel-monospace-font-family);
+        font-size: var(--boxel-font-sm);
+        border-radius: var(--boxel-border-radius-xl);
+        padding: var(--boxel-sp-lg);
+        overflow-x: auto;
+        white-space: pre;
+        margin: 0;
+        line-height: 1.5;
+      }
+
+      .ts-isolated__code :deep(.ts-keyword) {
+        color: #569cd6;
+      }
+
+      .ts-isolated__code :deep(.ts-string) {
+        color: #ce9178;
+      }
+
+      .ts-isolated__code :deep(.ts-comment) {
+        color: #6a9955;
+        font-style: italic;
+      }
+
+      .ts-isolated__code :deep(.ts-decorator) {
+        color: #dcdcaa;
+      }
+
+      .ts-isolated__code :deep(.ts-number) {
+        color: #b5cea8;
+      }
+
+      .ts-isolated__code :deep(.ts-type) {
+        color: #4ec9b0;
+      }
+    </style>
+  </template>
+}
+
+class Embedded extends Component<typeof TsFileDef> {
+  get title() {
+    return tsTitle(this.args.model);
+  }
+
+  get codePreview() {
+    let content = this.args.model?.content;
+    if (!content) {
+      return null;
+    }
+    return highlightTs(content);
+  }
+
+  <template>
+    <article class='ts-embedded' data-test-ts-embedded>
+      <header class='ts-embedded__title'>{{this.title}}</header>
+      {{#if this.codePreview}}
+        <div class='ts-embedded__preview'>
+          <pre class='ts-embedded__code'><code>{{sanitizedHtml
+                this.codePreview
+              }}</code></pre>
+        </div>
+      {{/if}}
+    </article>
+    <style scoped>
+      .ts-embedded {
+        display: flex;
+        flex-direction: column;
+        gap: var(--boxel-sp-xs);
+        padding: var(--boxel-sp);
+      }
+
+      .ts-embedded__title {
+        color: var(--boxel-900);
+        font-weight: 600;
+      }
+
+      .ts-embedded__preview {
+        max-height: 200px;
+        overflow: hidden;
+        mask-image: linear-gradient(to bottom, black 60%, transparent 100%);
+        -webkit-mask-image: linear-gradient(
+          to bottom,
+          black 60%,
+          transparent 100%
+        );
+      }
+
+      .ts-embedded__code {
+        background: var(--boxel-dark);
+        color: var(--boxel-light);
+        font-family: var(--boxel-monospace-font-family);
+        font-size: var(--boxel-font-xs);
+        border-radius: var(--boxel-border-radius-xl);
+        padding: var(--boxel-sp);
+        margin: 0;
+        white-space: pre;
+        line-height: 1.4;
+      }
+
+      .ts-embedded__code :deep(.ts-keyword) {
+        color: #569cd6;
+      }
+
+      .ts-embedded__code :deep(.ts-string) {
+        color: #ce9178;
+      }
+
+      .ts-embedded__code :deep(.ts-comment) {
+        color: #6a9955;
+        font-style: italic;
+      }
+
+      .ts-embedded__code :deep(.ts-decorator) {
+        color: #dcdcaa;
+      }
+
+      .ts-embedded__code :deep(.ts-number) {
+        color: #b5cea8;
+      }
+
+      .ts-embedded__code :deep(.ts-type) {
+        color: #4ec9b0;
+      }
+    </style>
+  </template>
+}
+
+class Fitted extends Component<typeof TsFileDef> {
+  get title() {
+    return tsTitle(this.args.model);
+  }
+
+  get excerpt() {
+    return this.args.model?.excerpt ?? '';
+  }
+
+  get hasExcerpt() {
+    return Boolean(this.excerpt);
+  }
+
+  <template>
+    <article class='ts-fitted' data-test-ts-fitted>
+      <div class='ts-fitted__icon'>
+        <FileCodeIcon width='100%' height='100%' />
+      </div>
+      <div class='ts-fitted__text'>
+        <header class='ts-fitted__title'>{{this.title}}</header>
+        {{#if this.hasExcerpt}}
+          <p class='ts-fitted__excerpt'>{{this.excerpt}}</p>
+        {{/if}}
+      </div>
+    </article>
+    <style scoped>
+      .ts-fitted {
+        container-name: fitted-card;
+        container-type: size;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: flex-start;
+        gap: var(--boxel-sp-xs);
+        padding: var(--boxel-sp-xs);
+        overflow: hidden;
+      }
+
+      .ts-fitted__icon {
+        flex-shrink: 0;
+        width: 20px;
+        height: 20px;
+        color: var(--boxel-600);
+      }
+
+      .ts-fitted__text {
+        min-width: 0;
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: var(--boxel-sp-4xs);
+      }
+
+      .ts-fitted__title {
+        color: var(--boxel-900);
+        font-weight: 600;
+        font-size: var(--boxel-font-sm);
+        overflow: hidden;
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 2;
+      }
+
+      .ts-fitted__excerpt {
+        color: var(--boxel-600);
+        font-size: var(--boxel-font-xs);
+        margin: 0;
+        overflow: hidden;
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 3;
+        font-family: var(--boxel-monospace-font-family);
+      }
+
+      /* Portrait tall: icon above text */
+      @container fitted-card (aspect-ratio <= 1.0) and (height >= 120px) {
+        .ts-fitted {
+          flex-direction: column;
+          align-items: center;
+          text-align: center;
+        }
+
+        .ts-fitted__icon {
+          width: 28px;
+          height: 28px;
+        }
+
+        .ts-fitted__title {
+          -webkit-line-clamp: 3;
+        }
+      }
+
+      /* Portrait short: hide excerpt */
+      @container fitted-card (aspect-ratio <= 1.0) and (height < 120px) {
+        .ts-fitted__excerpt {
+          display: none;
+        }
+      }
+
+      /* Portrait very short: hide icon too */
+      @container fitted-card (aspect-ratio <= 1.0) and (height < 80px) {
+        .ts-fitted__icon {
+          display: none;
+        }
+      }
+
+      /* Landscape: icon left of text */
+      @container fitted-card (1.0 < aspect-ratio) {
+        .ts-fitted {
+          align-items: flex-start;
+        }
+      }
+
+      /* Landscape short: hide excerpt */
+      @container fitted-card (1.0 < aspect-ratio) and (height < 80px) {
+        .ts-fitted__excerpt {
+          display: none;
+        }
+      }
+
+      /* Very small: title only, smaller font */
+      @container fitted-card (height <= 57px) {
+        .ts-fitted__icon {
+          display: none;
+        }
+
+        .ts-fitted__excerpt {
+          display: none;
+        }
+
+        .ts-fitted__title {
+          font-size: var(--boxel-font-xs);
+          -webkit-line-clamp: 1;
+        }
+      }
+    </style>
+  </template>
+}
+
+class Atom extends Component<typeof TsFileDef> {
+  get title() {
+    return tsTitle(this.args.model);
+  }
+
+  <template>
+    <span class='ts-atom' data-test-ts-atom>
+      <FileCodeIcon class='ts-atom__icon' width='16' height='16' />
+      <span class='ts-atom__title'>{{this.title}}</span>
+    </span>
+    <style scoped>
+      .ts-atom {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--boxel-sp-4xs);
+        min-width: 0;
+      }
+
+      .ts-atom__icon {
+        flex-shrink: 0;
+        color: var(--boxel-600);
+      }
+
+      .ts-atom__title {
+        color: var(--boxel-900);
+        font-size: var(--boxel-font-sm);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    </style>
+  </template>
+}
+
+class Head extends Component<typeof TsFileDef> {
+  get title() {
+    return tsTitle(this.args.model);
+  }
+
+  get description() {
+    return this.args.model?.excerpt;
+  }
+
+  <template>
+    {{! template-lint-disable no-forbidden-elements }}
+    <title data-test-card-head-title>{{this.title}}</title>
+
+    <meta property='og:title' content={{this.title}} />
+    <meta name='twitter:title' content={{this.title}} />
+    <meta property='og:url' content={{@model.id}} />
+
+    {{#if this.description}}
+      <meta name='description' content={{this.description}} />
+      <meta property='og:description' content={{this.description}} />
+      <meta name='twitter:description' content={{this.description}} />
+    {{/if}}
+
+    <meta name='twitter:card' content='summary' />
+    <meta property='og:type' content='article' />
+  </template>
+}
+
+export class TsFileDef extends FileDef {
+  static displayName = 'TypeScript Module';
+  static icon = FileCodeIcon;
+  static acceptTypes = '.ts';
+  static validExtensions = new Set(['.ts']);
+
+  @field title = contains(StringField);
+  @field excerpt = contains(StringField);
+  @field content = contains(StringField);
+
+  static isolated: BaseDefComponent = Isolated;
+  static embedded: BaseDefComponent = Embedded;
+  static fitted: BaseDefComponent = Fitted;
+  static atom: BaseDefComponent = Atom;
+  static head: BaseDefComponent = Head;
+
+  static async extractAttributes(
+    this: typeof TsFileDef,
+    url: string,
+    getStream: () => Promise<ByteStream>,
+    options: { contentHash?: string } = {},
+  ): Promise<
+    SerializedFile<{ title: string; excerpt: string; content: string }>
+  > {
+    let extension = getExtension(url);
+    if (!this.validExtensions.has(extension)) {
+      throw new FileContentMismatchError(
+        `Expected ${[...this.validExtensions].join(' or ')} file extension, got "${extension || 'none'}"`,
+      );
+    }
+
+    let bytesPromise: Promise<Uint8Array> | undefined;
+    let memoizedStream = async () => {
+      bytesPromise ??= byteStreamToUint8Array(await getStream());
+      return bytesPromise;
+    };
+
+    let base = await FileDef.extractAttributes(url, memoizedStream, options);
+    let bytes = await memoizedStream();
+    let source = new TextDecoder().decode(bytes);
+    let fallbackTitle = fileNameWithoutExtension(base.name ?? '');
+
+    return {
+      ...base,
+      title: fallbackTitle,
+      excerpt: truncateExcerpt(source.replace(/\s+/g, ' ').trim()),
+      content: source,
+    };
+  }
+}

--- a/packages/base/ts-highlight.ts
+++ b/packages/base/ts-highlight.ts
@@ -1,0 +1,107 @@
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function spanWrap(className: string, text: string): string {
+  return `<span class="${className}">${escapeHtml(text)}</span>`;
+}
+
+const BLOCK_COMMENT_RE = /\/\*[\s\S]*?\*\//g;
+const LINE_COMMENT_RE = /\/\/[^\n]*/g;
+const TEMPLATE_TAG_RE = /<\/?template>/g;
+const STRING_DOUBLE_RE = /"(?:[^"\\]|\\.)*"/g;
+const STRING_SINGLE_RE = /'(?:[^'\\]|\\.)*'/g;
+const STRING_TEMPLATE_RE = /`(?:[^`\\]|\\.)*`/g;
+const DECORATOR_RE = /@\w+/g;
+const NUMBER_RE = /\b\d+(?:\.\d+)?\b/g;
+const KEYWORD_RE =
+  /\b(?:import|export|default|from|class|extends|static|async|await|function|const|let|var|if|else|return|new|this|super|typeof|instanceof|void|null|undefined|true|false|yield|of|in|for|while|do|switch|case|break|continue|try|catch|finally|throw|type|interface|declare|as|implements|readonly|enum|abstract|private|protected|public|get|set)\b/g;
+const TYPE_RE = /(?:(?::\s*)|(?:extends\s+))([A-Z]\w*)/g;
+
+interface Token {
+  start: number;
+  end: number;
+  className: string;
+  text: string;
+}
+
+function collectMatches(
+  source: string,
+  regex: RegExp,
+  className: string,
+  tokens: Token[],
+): void {
+  regex.lastIndex = 0;
+  let match;
+  while ((match = regex.exec(source)) !== null) {
+    tokens.push({
+      start: match.index,
+      end: match.index + match[0].length,
+      className,
+      text: match[0],
+    });
+  }
+}
+
+function collectTypeMatches(source: string, tokens: Token[]): void {
+  TYPE_RE.lastIndex = 0;
+  let match;
+  while ((match = TYPE_RE.exec(source)) !== null) {
+    let typeName = match[1];
+    let typeStart = match.index + match[0].length - typeName.length;
+    tokens.push({
+      start: typeStart,
+      end: typeStart + typeName.length,
+      className: 'ts-type',
+      text: typeName,
+    });
+  }
+}
+
+export function highlightTs(source: string): string {
+  let tokens: Token[] = [];
+
+  // Collect all tokens (order matters for priority — earlier = higher)
+  collectMatches(source, BLOCK_COMMENT_RE, 'ts-comment', tokens);
+  collectMatches(source, LINE_COMMENT_RE, 'ts-comment', tokens);
+  collectMatches(source, STRING_DOUBLE_RE, 'ts-string', tokens);
+  collectMatches(source, STRING_SINGLE_RE, 'ts-string', tokens);
+  collectMatches(source, STRING_TEMPLATE_RE, 'ts-string', tokens);
+  collectMatches(source, TEMPLATE_TAG_RE, 'ts-keyword', tokens);
+  collectMatches(source, DECORATOR_RE, 'ts-decorator', tokens);
+  collectMatches(source, NUMBER_RE, 'ts-number', tokens);
+  collectMatches(source, KEYWORD_RE, 'ts-keyword', tokens);
+  collectTypeMatches(source, tokens);
+
+  // Sort by start position, then by priority (earlier collected = higher priority via stable sort)
+  tokens.sort((a, b) => a.start - b.start);
+
+  // Remove overlapping tokens (keep the first one encountered)
+  let filtered: Token[] = [];
+  let lastEnd = 0;
+  for (let token of tokens) {
+    if (token.start >= lastEnd) {
+      filtered.push(token);
+      lastEnd = token.end;
+    }
+  }
+
+  // Build output
+  let result = '';
+  let pos = 0;
+  for (let token of filtered) {
+    if (token.start > pos) {
+      result += escapeHtml(source.slice(pos, token.start));
+    }
+    result += spanWrap(token.className, token.text);
+    pos = token.end;
+  }
+  if (pos < source.length) {
+    result += escapeHtml(source.slice(pos));
+  }
+  return result;
+}

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -1024,7 +1024,7 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     await click('[data-test-file="person.gts"]');
     await click('[data-test-choose-file-modal-add-button]');
     assert.dom('[data-test-attached-file]').exists({ count: 1 });
-    assert.dom('[data-test-attached-file]').hasText('person.gts');
+    assert.dom('[data-test-attached-file]').hasText('person');
     // Add attachment item
     await click('[data-test-attach-button]');
     await click('[data-test-attach-file-btn]');
@@ -1033,16 +1033,16 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     assert.dom('[data-test-attached-file]').exists({ count: 2 });
     assert
       .dom(`[data-test-attached-file="${testRealmURL}person.gts"]`)
-      .hasText('person.gts');
+      .hasText('person');
     assert
       .dom(`[data-test-attached-file="${testRealmURL}pet.gts"]`)
-      .hasText('pet.gts');
+      .hasText('pet');
 
     // Add remove attachment item
     await click(
       `[data-test-attached-file="${testRealmURL}person.gts"] [data-test-remove-file-btn]`,
     );
-    assert.dom('[data-test-attached-file]').hasText('pet.gts');
+    assert.dom('[data-test-attached-file]').hasText('pet');
 
     await fillIn('[data-test-message-field]', `Message With File`);
     await click('[data-test-send-message-btn]');
@@ -1072,7 +1072,7 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     await waitFor(`[data-room-settled]`);
     await click('[data-test-file="person.gts"]');
     assert.dom('[data-test-autoattached-file]').exists();
-    assert.dom(`[data-test-autoattached-file]`).hasText('person.gts');
+    assert.dom(`[data-test-autoattached-file]`).hasText('person');
 
     await click('[data-test-file-browser-toggle]');
     await click(`[data-test-autoattached-file] [data-test-remove-file-btn]`);
@@ -1081,12 +1081,12 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     await click('[data-test-file-browser-toggle]');
     await click('[data-test-file="pet.gts"]');
     assert.dom('[data-test-autoattached-file]').exists();
-    assert.dom(`[data-test-autoattached-file]`).hasText('pet.gts');
+    assert.dom(`[data-test-autoattached-file]`).hasText('pet');
 
     await click('[data-test-file-browser-toggle]');
     await click('[data-test-file="person.gts"]');
     assert.dom('[data-test-autoattached-file]').exists();
-    assert.dom(`[data-test-autoattached-file]`).hasText('person.gts');
+    assert.dom(`[data-test-autoattached-file]`).hasText('person');
   });
 
   test('loads more AI rooms when scrolling', async function (assert) {

--- a/packages/host/tests/acceptance/ai-assistant-test.gts
+++ b/packages/host/tests/acceptance/ai-assistant-test.gts
@@ -1072,7 +1072,7 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     await waitFor(`[data-room-settled]`);
     await click('[data-test-file="person.gts"]');
     assert.dom('[data-test-autoattached-file]').exists();
-    assert.dom(`[data-test-autoattached-file]`).hasText('person');
+    assert.dom(`[data-test-autoattached-file]`).hasText('person.gts');
 
     await click('[data-test-file-browser-toggle]');
     await click(`[data-test-autoattached-file] [data-test-remove-file-btn]`);
@@ -1081,12 +1081,12 @@ module('Acceptance | AI Assistant tests', function (hooks) {
     await click('[data-test-file-browser-toggle]');
     await click('[data-test-file="pet.gts"]');
     assert.dom('[data-test-autoattached-file]').exists();
-    assert.dom(`[data-test-autoattached-file]`).hasText('pet');
+    assert.dom(`[data-test-autoattached-file]`).hasText('pet.gts');
 
     await click('[data-test-file-browser-toggle]');
     await click('[data-test-file="person.gts"]');
     assert.dom('[data-test-autoattached-file]').exists();
-    assert.dom(`[data-test-autoattached-file]`).hasText('person');
+    assert.dom(`[data-test-autoattached-file]`).hasText('person.gts');
   });
 
   test('loads more AI rooms when scrolling', async function (assert) {

--- a/packages/host/tests/acceptance/gts-file-def-test.gts
+++ b/packages/host/tests/acceptance/gts-file-def-test.gts
@@ -1,0 +1,209 @@
+import { visit, waitUntil } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+
+import { module, test } from 'qunit';
+
+import {
+  baseRealm,
+  type FileExtractResponse,
+  type RenderRouteOptions,
+  type ResolvedCodeRef,
+  SupportedMimeType,
+} from '@cardstack/runtime-common';
+import type { Realm } from '@cardstack/runtime-common/realm';
+
+import type NetworkService from '@cardstack/host/services/network';
+
+import {
+  setupLocalIndexing,
+  setupOnSave,
+  setupRealmCacheTeardown,
+  testRealmURL,
+  setupAcceptanceTestRealm,
+  SYSTEM_CARD_FIXTURE_CONTENTS,
+  withCachedRealmSetup,
+} from '../helpers';
+import { setupMockMatrix } from '../helpers/mock-matrix';
+import { setupApplicationTest } from '../helpers/setup';
+
+module('Acceptance | gts file def', function (hooks) {
+  setupApplicationTest(hooks);
+  setupLocalIndexing(hooks);
+  setupOnSave(hooks);
+  setupRealmCacheTeardown(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+  });
+  let realm: Realm;
+
+  const renderPath = (
+    url: string,
+    renderOptions: RenderRouteOptions,
+    nonce = 0,
+  ) =>
+    `/render/${encodeURIComponent(url)}/${nonce}/${encodeURIComponent(
+      JSON.stringify(renderOptions),
+    )}/file-extract`;
+
+  const makeFileURL = (path: string) => new URL(path, testRealmURL).href;
+
+  const gtsDefCodeRef = (): ResolvedCodeRef => ({
+    module: `${baseRealm.url}gts-file-def`,
+    name: 'GtsFileDef',
+  });
+
+  async function captureFileExtractResult(
+    expectedStatus?: 'ready' | 'error',
+  ): Promise<FileExtractResponse> {
+    await waitUntil(
+      () => {
+        let container = document.querySelector(
+          '[data-prerender-file-extract]',
+        ) as HTMLElement | null;
+        if (!container) {
+          return false;
+        }
+        let status = container.getAttribute(
+          'data-prerender-file-extract-status',
+        );
+        if (!status) {
+          return false;
+        }
+        if (expectedStatus && status !== expectedStatus) {
+          return false;
+        }
+        return status === 'ready' || status === 'error';
+      },
+      { timeout: 5000 },
+    );
+
+    let container = document.querySelector(
+      '[data-prerender-file-extract]',
+    ) as HTMLElement | null;
+    if (!container) {
+      throw new Error(
+        'captureFileExtractResult: missing [data-prerender-file-extract] container after wait',
+      );
+    }
+    let pre = container.querySelector('pre');
+    let text = pre?.textContent?.trim() ?? '';
+    return JSON.parse(text) as FileExtractResponse;
+  }
+
+  hooks.beforeEach(async function () {
+    ({ realm } = await withCachedRealmSetup(async () =>
+      setupAcceptanceTestRealm({
+        mockMatrixUtils,
+        contents: {
+          ...SYSTEM_CARD_FIXTURE_CONTENTS,
+          'sample-card.gts': `import { contains, field } from './card-api';
+import StringField from './string';
+import { CardDef } from './card-api';
+
+export class SampleCard extends CardDef {
+  static displayName = 'Sample Card';
+
+  @field firstName = contains(StringField);
+  @field lastName = contains(StringField);
+
+  <template>
+    <div>{{@model.firstName}} {{@model.lastName}}</div>
+  </template>
+}`,
+          'notes.txt': 'Plain text file contents.',
+        },
+      }),
+    ));
+  });
+
+  hooks.afterEach(function () {
+    delete (globalThis as any).__renderModel;
+  });
+
+  test('extracts title, excerpt, and content from .gts file', async function (assert) {
+    let url = makeFileURL('sample-card.gts');
+    await visit(
+      renderPath(url, {
+        fileExtract: true,
+        fileDefCodeRef: gtsDefCodeRef(),
+      }),
+    );
+
+    let result = await captureFileExtractResult('ready');
+    assert.strictEqual(result.status, 'ready');
+    assert.strictEqual(
+      result.searchDoc?.title,
+      'sample-card',
+      'title is filename without extension',
+    );
+    assert.ok(
+      String(result.searchDoc?.excerpt).includes('import'),
+      'excerpt contains source code',
+    );
+    assert.ok(
+      String(result.searchDoc?.content).includes('SampleCard'),
+      'content includes full source',
+    );
+    assert.strictEqual(result.searchDoc?.name, 'sample-card.gts');
+  });
+
+  test('falls back when gts def is used for non-.gts files', async function (assert) {
+    let url = makeFileURL('notes.txt');
+    await visit(
+      renderPath(url, {
+        fileExtract: true,
+        fileDefCodeRef: gtsDefCodeRef(),
+      }),
+    );
+
+    let result = await captureFileExtractResult('ready');
+    assert.strictEqual(result.status, 'ready');
+    assert.true(
+      result.mismatch,
+      'marks mismatch when extension is not .gts',
+    );
+    assert.strictEqual(result.searchDoc?.name, 'notes.txt');
+  });
+
+  test('indexing stores GTS search data and file meta uses GtsFileDef', async function (assert) {
+    let fileURL = new URL('sample-card.gts', testRealmURL);
+    let fileEntry = await realm.realmIndexQueryEngine.file(fileURL);
+
+    assert.ok(fileEntry, 'file entry exists');
+    assert.strictEqual(
+      fileEntry?.searchDoc?.title,
+      'sample-card',
+      'index stores GTS title',
+    );
+    assert.ok(
+      String(fileEntry?.searchDoc?.excerpt).includes('import'),
+      'index stores GTS excerpt',
+    );
+
+    let network = getService('network') as NetworkService;
+    let response = await network.virtualNetwork.fetch(fileURL, {
+      headers: { Accept: SupportedMimeType.FileMeta },
+    });
+
+    assert.true(response.ok, 'file meta request succeeds');
+
+    let body = await response.json();
+    assert.strictEqual(body?.data?.type, 'file-meta');
+    assert.strictEqual(
+      body?.data?.attributes?.title,
+      'sample-card',
+      'file meta includes GTS title',
+    );
+    assert.ok(
+      String(body?.data?.attributes?.content).includes('SampleCard'),
+      'file meta includes GTS content',
+    );
+    assert.deepEqual(
+      body?.data?.meta?.adoptsFrom,
+      gtsDefCodeRef(),
+      'file meta uses GtsFileDef',
+    );
+  });
+});

--- a/packages/host/tests/acceptance/gts-file-def-test.gts
+++ b/packages/host/tests/acceptance/gts-file-def-test.gts
@@ -160,10 +160,7 @@ export class SampleCard extends CardDef {
 
     let result = await captureFileExtractResult('ready');
     assert.strictEqual(result.status, 'ready');
-    assert.true(
-      result.mismatch,
-      'marks mismatch when extension is not .gts',
-    );
+    assert.true(result.mismatch, 'marks mismatch when extension is not .gts');
     assert.strictEqual(result.searchDoc?.name, 'notes.txt');
   });
 

--- a/packages/host/tests/acceptance/ts-file-def-test.gts
+++ b/packages/host/tests/acceptance/ts-file-def-test.gts
@@ -151,10 +151,7 @@ export const MAX_RETRIES = 3;`,
 
     let result = await captureFileExtractResult('ready');
     assert.strictEqual(result.status, 'ready');
-    assert.true(
-      result.mismatch,
-      'marks mismatch when extension is not .ts',
-    );
+    assert.true(result.mismatch, 'marks mismatch when extension is not .ts');
     assert.strictEqual(result.searchDoc?.name, 'notes.txt');
   });
 

--- a/packages/host/tests/acceptance/ts-file-def-test.gts
+++ b/packages/host/tests/acceptance/ts-file-def-test.gts
@@ -1,0 +1,200 @@
+import { visit, waitUntil } from '@ember/test-helpers';
+
+import { getService } from '@universal-ember/test-support';
+
+import { module, test } from 'qunit';
+
+import {
+  baseRealm,
+  type FileExtractResponse,
+  type RenderRouteOptions,
+  type ResolvedCodeRef,
+  SupportedMimeType,
+} from '@cardstack/runtime-common';
+import type { Realm } from '@cardstack/runtime-common/realm';
+
+import type NetworkService from '@cardstack/host/services/network';
+
+import {
+  setupLocalIndexing,
+  setupOnSave,
+  setupRealmCacheTeardown,
+  testRealmURL,
+  setupAcceptanceTestRealm,
+  SYSTEM_CARD_FIXTURE_CONTENTS,
+  withCachedRealmSetup,
+} from '../helpers';
+import { setupMockMatrix } from '../helpers/mock-matrix';
+import { setupApplicationTest } from '../helpers/setup';
+
+module('Acceptance | ts file def', function (hooks) {
+  setupApplicationTest(hooks);
+  setupLocalIndexing(hooks);
+  setupOnSave(hooks);
+  setupRealmCacheTeardown(hooks);
+
+  let mockMatrixUtils = setupMockMatrix(hooks, {
+    loggedInAs: '@testuser:localhost',
+  });
+  let realm: Realm;
+
+  const renderPath = (
+    url: string,
+    renderOptions: RenderRouteOptions,
+    nonce = 0,
+  ) =>
+    `/render/${encodeURIComponent(url)}/${nonce}/${encodeURIComponent(
+      JSON.stringify(renderOptions),
+    )}/file-extract`;
+
+  const makeFileURL = (path: string) => new URL(path, testRealmURL).href;
+
+  const tsDefCodeRef = (): ResolvedCodeRef => ({
+    module: `${baseRealm.url}ts-file-def`,
+    name: 'TsFileDef',
+  });
+
+  async function captureFileExtractResult(
+    expectedStatus?: 'ready' | 'error',
+  ): Promise<FileExtractResponse> {
+    await waitUntil(
+      () => {
+        let container = document.querySelector(
+          '[data-prerender-file-extract]',
+        ) as HTMLElement | null;
+        if (!container) {
+          return false;
+        }
+        let status = container.getAttribute(
+          'data-prerender-file-extract-status',
+        );
+        if (!status) {
+          return false;
+        }
+        if (expectedStatus && status !== expectedStatus) {
+          return false;
+        }
+        return status === 'ready' || status === 'error';
+      },
+      { timeout: 5000 },
+    );
+
+    let container = document.querySelector(
+      '[data-prerender-file-extract]',
+    ) as HTMLElement | null;
+    if (!container) {
+      throw new Error(
+        'captureFileExtractResult: missing [data-prerender-file-extract] container after wait',
+      );
+    }
+    let pre = container.querySelector('pre');
+    let text = pre?.textContent?.trim() ?? '';
+    return JSON.parse(text) as FileExtractResponse;
+  }
+
+  hooks.beforeEach(async function () {
+    ({ realm } = await withCachedRealmSetup(async () =>
+      setupAcceptanceTestRealm({
+        mockMatrixUtils,
+        contents: {
+          ...SYSTEM_CARD_FIXTURE_CONTENTS,
+          'utils.ts': `export function greet(name: string): string {
+  return \`Hello, \${name}!\`;
+}
+
+export const MAX_RETRIES = 3;`,
+          'notes.txt': 'Plain text file contents.',
+        },
+      }),
+    ));
+  });
+
+  hooks.afterEach(function () {
+    delete (globalThis as any).__renderModel;
+  });
+
+  test('extracts title, excerpt, and content from .ts file', async function (assert) {
+    let url = makeFileURL('utils.ts');
+    await visit(
+      renderPath(url, {
+        fileExtract: true,
+        fileDefCodeRef: tsDefCodeRef(),
+      }),
+    );
+
+    let result = await captureFileExtractResult('ready');
+    assert.strictEqual(result.status, 'ready');
+    assert.strictEqual(
+      result.searchDoc?.title,
+      'utils',
+      'title is filename without extension',
+    );
+    assert.ok(
+      String(result.searchDoc?.excerpt).includes('export'),
+      'excerpt contains source code',
+    );
+    assert.ok(
+      String(result.searchDoc?.content).includes('greet'),
+      'content includes full source',
+    );
+    assert.strictEqual(result.searchDoc?.name, 'utils.ts');
+  });
+
+  test('falls back when ts def is used for non-.ts files', async function (assert) {
+    let url = makeFileURL('notes.txt');
+    await visit(
+      renderPath(url, {
+        fileExtract: true,
+        fileDefCodeRef: tsDefCodeRef(),
+      }),
+    );
+
+    let result = await captureFileExtractResult('ready');
+    assert.strictEqual(result.status, 'ready');
+    assert.true(
+      result.mismatch,
+      'marks mismatch when extension is not .ts',
+    );
+    assert.strictEqual(result.searchDoc?.name, 'notes.txt');
+  });
+
+  test('indexing stores TS search data and file meta uses TsFileDef', async function (assert) {
+    let fileURL = new URL('utils.ts', testRealmURL);
+    let fileEntry = await realm.realmIndexQueryEngine.file(fileURL);
+
+    assert.ok(fileEntry, 'file entry exists');
+    assert.strictEqual(
+      fileEntry?.searchDoc?.title,
+      'utils',
+      'index stores TS title',
+    );
+    assert.ok(
+      String(fileEntry?.searchDoc?.excerpt).includes('export'),
+      'index stores TS excerpt',
+    );
+
+    let network = getService('network') as NetworkService;
+    let response = await network.virtualNetwork.fetch(fileURL, {
+      headers: { Accept: SupportedMimeType.FileMeta },
+    });
+
+    assert.true(response.ok, 'file meta request succeeds');
+
+    let body = await response.json();
+    assert.strictEqual(body?.data?.type, 'file-meta');
+    assert.strictEqual(
+      body?.data?.attributes?.title,
+      'utils',
+      'file meta includes TS title',
+    );
+    assert.ok(
+      String(body?.data?.attributes?.content).includes('greet'),
+      'file meta includes TS content',
+    );
+    assert.deepEqual(
+      body?.data?.meta?.adoptsFrom,
+      tsDefCodeRef(),
+      'file meta uses TsFileDef',
+    );
+  });
+});

--- a/packages/realm-server/tests/realm-endpoints-test.ts
+++ b/packages/realm-server/tests/realm-endpoints-test.ts
@@ -227,8 +227,8 @@ module(basename(__filename), function () {
       assert.strictEqual(json.data.type, 'file-meta');
       assert.strictEqual(json.data.attributes?.name, 'person.gts');
       assert.deepEqual(json.data.meta?.adoptsFrom, {
-        module: `${baseRealm.url}file-api`,
-        name: 'FileDef',
+        module: `${baseRealm.url}gts-file-def`,
+        name: 'GtsFileDef',
       });
     });
 

--- a/packages/runtime-common/file-def-code-ref.ts
+++ b/packages/runtime-common/file-def-code-ref.ts
@@ -41,6 +41,14 @@ const FILEDEF_CODE_REF_BY_EXTENSION: Record<string, ResolvedCodeRef> = {
     module: `${baseRealm.url}avif-image-def`,
     name: 'AvifDef',
   },
+  '.ts': {
+    module: `${baseRealm.url}ts-file-def`,
+    name: 'TsFileDef',
+  },
+  '.gts': {
+    module: `${baseRealm.url}gts-file-def`,
+    name: 'GtsFileDef',
+  },
   '.mismatch': { module: './filedef-mismatch', name: 'FileDef' },
 };
 


### PR DESCRIPTION
## Summary

- Adds `TsFileDef` (`packages/base/ts-file-def.gts`) — a `FileDef` subclass for `.ts` files that extracts content and displays it with regex-based syntax highlighting (keywords, strings, comments, decorators, numbers, types)
- Adds `GtsFileDef` (`packages/base/gts-file-def.gts`) — a thin subclass of `TsFileDef` for `.gts` files, overriding only `displayName`, `acceptTypes`, and `validExtensions`
- Registers `.ts` and `.gts` extension mappings in `file-def-code-ref.ts`
- Adds acceptance tests for both TsFileDef and GtsFileDef

## Test plan

- [ ] `cd packages/host && ember test --path dist --filter "ts file def"` — 3 tests pass
- [ ] `cd packages/host && ember test --path dist --filter "gts file def"` — 3 tests pass
- [ ] Visually verify syntax highlighting renders correctly for `.ts` and `.gts` files in isolated/embedded views

🤖 Generated with [Claude Code](https://claude.com/claude-code)