### PR TITLE
CS-10113: support AI Assistant file attachments

### DIFF
--- a/docs/cs-10113-ai-assistant-file-attachments-plan.md
+++ b/docs/cs-10113-ai-assistant-file-attachments-plan.md
@@ -1,0 +1,173 @@
+# CS-10113 Plan: AI Assistant File Attachments (Any File)
+
+## Goals
+- Let AI Assistant users attach files from the plus menu before sending a message.
+- Support both sources: existing realm files and files from local computer.
+- Preserve current AI Assistant ergonomics while adding upload progress, remove, retry, and send gating.
+- Use Matrix content store + FileDef pipeline as the canonical attachment transport.
+
+## Product Decisions Captured
+- Scope is any file type.
+- Max file size uses existing realm file size limit constant (`environmentService.fileSizeLimitBytes`).
+- No cap on attachments per message or per conversation.
+- Realm picker should include any accessible realm (same behavior as current chooser).
+- For both realm and local sources: upload bytes to Matrix content store and send FileDef payloads backed by Matrix media.
+- Create in-memory FileDef attachment records immediately during attach flow.
+- Deduplicate by content hash.
+  - Conversation-level dedupe is silent.
+  - Matrix content-store dedupe reuses existing media by content hash.
+- If any attachment upload fails, `Send` is blocked until retry succeeds or the failed attachment is removed.
+- Duplicate attachments can still appear as pills on new messages.
+- If model cannot natively consume a MIME type (known ahead of time), send metadata only, not file bytes/content.
+- For unreadable/unsupported upload failures, block send and show error.
+- Realm attachments are byte snapshots at attach time (immutable thereafter).
+- Removing pre-send attachment does not hard-delete Matrix media immediately (leave for cleanup/GC).
+- Preserve attachment order into model input.
+- Follow-up context policy:
+  - Automatically include only attachments on the current message.
+  - Older attachments available only via tool call.
+  - Tool calls may fetch only from prior turns in the same conversation.
+  - No additional user confirmation required.
+- Credits behavior remains unchanged.
+- UX acceptance includes upload progress, atom/pill representation, remove action, retry on failure.
+- No mobile requirements in this phase.
+
+## Assumptions
+- Existing AI Assistant room message schema remains `data.attachedFiles` (SerializedFileDef list).
+- Existing file chooser modal can be extended for AI-specific upload behavior without regressing non-AI file-link workflows.
+- Model capability detection (MIME compatibility) will be implemented as a local capability map keyed by active model ID until SystemCard exposes richer per-model media capabilities.
+- Conversation scoping for tool-based file fetch can be enforced in host command execution for `read-file-for-ai-assistant`.
+
+## Implementation Plan
+
+### 1. Attachment domain model and send gating
+- Introduce pending attachment state for AI drafts (upload status + error + serialized file def + hash).
+- Extend send eligibility so files count as valid send content and failed uploads block send.
+- Keep attachment order stable from UI list through message serialization.
+
+Target files:
+- `packages/host/app/components/matrix/room.gts`
+- `packages/host/app/services/matrix-service.ts`
+- `packages/host/app/services/local-persistence-service.ts`
+
+### 2. File picker and upload UX
+- Reuse plus-menu path (`Attach a File`) and chooser modal.
+- Keep realm picker behavior unchanged (all accessible realms).
+- Add/extend AI attach mode in chooser:
+  - Realm file selection path.
+  - Local file upload path with progress + retry + error.
+- For local files, avoid writing to realm storage; create in-memory FileDef and upload directly to Matrix.
+- For realm files, resolve selected file and snapshot bytes at attach time.
+
+Target files:
+- `packages/host/app/components/ai-assistant/attachment-picker/attach-button.gts`
+- `packages/host/app/components/operator-mode/choose-file-modal.gts`
+- `packages/host/app/services/file-upload.ts`
+- `packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts`
+- `packages/host/app/components/file-pill.gts`
+
+### 3. Matrix upload pipeline and dedupe
+- Generalize FileDefManager upload path to support both:
+  - realm-backed source URLs
+  - in-memory local blobs/files
+- Compute content hash from bytes for binary-safe dedupe.
+- Reuse `contentHashCache` to dedupe Matrix media uploads.
+- Add conversation-level dedupe by hash in AI draft state while preserving per-message pill rendering.
+
+Target files:
+- `packages/host/app/lib/file-def-manager.ts`
+- `packages/host/app/services/matrix-service.ts`
+- `packages/host/tests/helpers/mock-matrix/_client.ts`
+
+### 4. Prompt construction for multimodal + metadata fallback
+- Keep message-level rule: only current message attachments auto-included.
+- For models that support native media for a MIME category, send multimodal content parts (`text` + `image_url` etc where supported).
+- For non-supported MIME types, include metadata-only attachment section (name, type, hash, source/url).
+- Preserve current behavior for textual files where content is useful inline.
+- Ensure unsupported file types no longer surface as silent backend fetch errors when capability is known in advance.
+
+Target files:
+- `packages/runtime-common/ai/prompt.ts`
+- `packages/runtime-common/ai/types.ts`
+- `packages/runtime-common/ai/matrix-utils.ts`
+- `packages/ai-bot/main.ts` (if request shaping needs model-aware content handling)
+
+### 5. Tool-call retrieval policy (same conversation only)
+- Enforce that `read-file-for-ai-assistant` can only fetch files that were attached in the same room/conversation history.
+- Reject out-of-scope file requests with clear command result failure reason.
+- No confirmation prompt required for in-scope file fetches.
+
+Target files:
+- `packages/host/app/commands/read-file-for-ai-assistant.ts`
+- `packages/host/app/services/command-service.ts`
+- `packages/host/app/resources/room.ts` (if helper needed for attachment lookup by room history)
+
+## UX States
+- Attachment added and uploading: show pending/upload progress in picker/inline area.
+- Upload success: render standard file pill (atom display).
+- Upload failure: show inline error and retry affordance; keep item removable.
+- Send disabled conditions:
+  - no message/cards/files
+  - any pending failed attachment
+  - any still-uploading attachment (to avoid partial send race)
+- Remove attachment: immediate UI removal from draft; no immediate media deletion required.
+
+## Acceptance Criteria (Testable)
+- User can attach from realm and from local computer via plus menu.
+- User can attach multiple files in one draft and remove any before send.
+- Upload progress is visible for local uploads.
+- Failed uploads show error and retry.
+- Send is blocked when any attachment is failed or still uploading.
+- Successful send includes attached files in the outgoing event in selected order.
+- Duplicate file attach in same conversation reuses content hash/media silently.
+- Follow-up message does not auto-resend previous attachments unless attached again.
+- Model/tool can request prior attached file only within same conversation.
+- Unsupported-by-model MIME types are represented as metadata (not raw content payload).
+- Realm-sourced attachment content is snapshot-consistent even if source realm file later changes.
+
+## Testing Notes
+
+### Host acceptance/integration
+- Add/extend AI assistant attachment tests:
+  - plus-menu attach from realm
+  - plus-menu upload local file
+  - upload progress, error, retry, remove
+  - send blocking behavior for failed/uploading attachments
+  - duplicate attach dedupe behavior
+  - order preservation
+- Candidate suites:
+  - `packages/host/tests/acceptance/ai-assistant-test.gts`
+  - `packages/host/tests/integration/components/ai-assistant-panel/sending-test.gts`
+  - `packages/host/tests/acceptance/file-chooser-test.gts` (ensure non-AI chooser behavior stays intact)
+
+### Runtime-common / ai-bot tests
+- Update prompt construction tests for multimodal + metadata fallback and message-level inclusion policy.
+- Candidate suites:
+  - `packages/ai-bot/tests/prompt-construction-test.ts`
+
+### Command security/scope tests
+- Add integration coverage for same-conversation-only tool file fetch rule.
+- Candidate suites:
+  - `packages/host/tests/integration/commands/read-file-for-ai-assistant-test.gts`
+
+### Lint and verification
+- Run lint in modified packages before commit per repo policy.
+  - `packages/host`: `pnpm lint`
+  - `packages/runtime-common`: `pnpm lint`
+  - `packages/ai-bot`: `pnpm lint` (if modified)
+
+## Risks and Mitigations
+- Risk: Regressing generic file chooser behavior used outside AI assistant.
+  - Mitigation: explicit AI mode path + preserve existing chooser contract + acceptance tests.
+- Risk: Binary hashing/upload bugs from string-only assumptions.
+  - Mitigation: centralize byte hashing and add binary fixture tests.
+- Risk: Model capability mismatch leads to wrong payload format.
+  - Mitigation: capability map with safe default (metadata-only).
+- Risk: Tool-call scope bypass for arbitrary URLs.
+  - Mitigation: enforce room-history attachment allowlist in command execution.
+
+## Out of Scope for This Ticket
+- Mobile-specific UX work.
+- New billing rules.
+- Cross-conversation attachment retrieval.
+- Analytics/events instrumentation.

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -1030,7 +1030,7 @@ Attached Files (files with newer versions don't show their content):
 [spaghetti-recipe.gts](http://test-realm-server/my-realm/spaghetti-recipe.gts)
 [best-friends.txt](http://test-realm-server/my-realm/best-friends.txt)
 [file-that-does-not-exist.txt](http://test.com/my-realm/file-that-does-not-exist.txt): Error loading attached file: HTTP error. Status: 404
-[example.pdf](http://test.com/my-realm/example.pdf): Error loading attached file: Unsupported file type: application/pdf. For now, only text files are supported.
+[example.pdf](http://test.com/my-realm/example.pdf)
       `.trim(),
       ),
     );

--- a/packages/base/command.gts
+++ b/packages/base/command.gts
@@ -94,6 +94,7 @@ export class CopyAndEditInput extends CardDef {
 
 export class FileUrlCard extends CardDef {
   @field fileUrl = contains(StringField);
+  @field roomId = contains(StringField);
 }
 
 export class RealmUrlCard extends CardDef {

--- a/packages/host/app/commands/read-file-for-ai-assistant.ts
+++ b/packages/host/app/commands/read-file-for-ai-assistant.ts
@@ -29,6 +29,12 @@ export default class ReadFileForAssistantCommand extends HostBaseCommand<
     let { matrixService } = this;
 
     let fileUrl = input.fileUrl;
+    let roomId = input.roomId || matrixService.currentRoomId;
+    if (roomId && !matrixService.hasAttachedFileInRoom(roomId, fileUrl)) {
+      throw new Error(
+        `File ${fileUrl} is not attached in this conversation. You can only read files that were previously attached in this room.`,
+      );
+    }
 
     await matrixService.ready;
     let file: FileDef | undefined = matrixService.fileAPI.createFileDef({

--- a/packages/host/app/components/ai-assistant/attachment-picker/attach-button.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/attach-button.gts
@@ -142,7 +142,9 @@ export default class AttachButton extends Component<Signature> {
   });
 
   private doChooseFile = restartableTask(async () => {
-    let chosenFile: FileDef | undefined = await chooseFile();
+    let chosenFile: FileDef | undefined = await chooseFile({
+      uploadTarget: 'matrix',
+    });
     if (chosenFile) {
       this.args.chooseFile(chosenFile);
     }

--- a/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/attached-items.gts
@@ -6,7 +6,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 import { Tooltip, Pill } from '@cardstack/boxel-ui/components';
-import { and, gt, not } from '@cardstack/boxel-ui/helpers';
+import { and, eq, gt, not } from '@cardstack/boxel-ui/helpers';
 
 import type { CardErrorJSONAPI } from '@cardstack/runtime-common';
 import {
@@ -24,6 +24,7 @@ import type OperatorModeStateService from '@cardstack/host/services/operator-mod
 import type { CardDef } from 'https://cardstack.com/base/card-api';
 import type { FileDef } from 'https://cardstack.com/base/file-api';
 
+import type { DraftFileUpload } from './types';
 import type { TrackedSet } from 'tracked-built-ins';
 
 const MAX_ITEMS_TO_DISPLAY = 4;
@@ -38,6 +39,9 @@ interface Signature {
     removeFile: (file: FileDef) => void;
     chooseCard?: (cardId: string) => void;
     chooseFile?: (file: FileDef) => void;
+    pendingUploads?: DraftFileUpload[];
+    retryFileUpload?: (uploadId: string) => void;
+    removePendingFileUpload?: (uploadId: string) => void;
     isLoaded: boolean;
     autoAttachedCardTooltipMessage?: string;
   };
@@ -52,6 +56,10 @@ export default class AttachedItems extends Component<Signature> {
     return this.areAllItemsDisplayed
       ? this.args.items
       : this.args.items.slice(0, MAX_ITEMS_TO_DISPLAY);
+  }
+
+  get pendingUploads() {
+    return this.args.pendingUploads ?? [];
   }
 
   private isCard = (item: CardDef | FileDef): item is CardDef => {
@@ -105,6 +113,16 @@ export default class AttachedItems extends Component<Signature> {
   @action
   private handleRemoveFile(file: FileDef) {
     this.args.removeFile(file);
+  }
+
+  @action
+  private retryFileUpload(uploadId: string) {
+    this.args.retryFileUpload?.(uploadId);
+  }
+
+  @action
+  private removePendingFileUpload(uploadId: string) {
+    this.args.removePendingFileUpload?.(uploadId);
   }
 
   <template>
@@ -221,6 +239,48 @@ export default class AttachedItems extends Component<Signature> {
             View All ({{@items.length}})
           </Pill>
         {{/if}}
+        {{#each this.pendingUploads as |upload|}}
+          <Pill
+            @kind='button'
+            class='pending-upload-pill'
+            data-test-pending-upload={{upload.id}}
+          >
+            <:iconLeft>
+              {{#if (eq upload.state 'uploading')}}
+                <span class='pending-upload-spinner' />
+              {{/if}}
+            </:iconLeft>
+            <:default>
+              <span class='pending-upload-name'>{{upload.file.name}}</span>
+              {{#if (eq upload.state 'error')}}
+                <span
+                  class='pending-upload-error'
+                  data-test-pending-upload-error={{upload.id}}
+                >{{upload.error}}</span>
+              {{/if}}
+            </:default>
+            <:iconRight>
+              {{#if (eq upload.state 'error')}}
+                <button
+                  type='button'
+                  class='pending-upload-retry'
+                  {{on 'click' (fn this.retryFileUpload upload.id)}}
+                  data-test-pending-upload-retry={{upload.id}}
+                >
+                  Retry
+                </button>
+              {{/if}}
+              <button
+                type='button'
+                class='pending-upload-remove'
+                {{on 'click' (fn this.removePendingFileUpload upload.id)}}
+                data-test-pending-upload-remove={{upload.id}}
+              >
+                Remove
+              </button>
+            </:iconRight>
+          </Pill>
+        {{/each}}
       {{/if}}
     </div>
     <style scoped>
@@ -230,6 +290,51 @@ export default class AttachedItems extends Component<Signature> {
         display: flex;
         flex-wrap: wrap;
         gap: var(--boxel-sp-xxxs);
+      }
+      .pending-upload-pill {
+        max-width: 100%;
+      }
+      .pending-upload-name {
+        max-width: 140px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .pending-upload-error {
+        color: var(--boxel-error-200);
+        margin-left: var(--boxel-sp-xxs);
+        max-width: 180px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .pending-upload-spinner {
+        display: inline-block;
+        width: 12px;
+        height: 12px;
+        border: 2px solid var(--boxel-300);
+        border-top-color: var(--boxel-700);
+        border-radius: 50%;
+        animation: spin 0.9s linear infinite;
+      }
+      .pending-upload-retry,
+      .pending-upload-remove {
+        border: none;
+        background: transparent;
+        padding: 0 var(--boxel-sp-3xs);
+        cursor: pointer;
+        font: var(--boxel-font-xs);
+      }
+      .pending-upload-retry {
+        color: var(--boxel-dark);
+      }
+      .pending-upload-remove {
+        color: var(--boxel-error-200);
+      }
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
       }
     </style>
   </template>

--- a/packages/host/app/components/ai-assistant/attachment-picker/index.gts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/index.gts
@@ -15,6 +15,8 @@ import type { FileDef } from 'https://cardstack.com/base/file-api';
 import AttachButton from './attach-button';
 import AttachedItems from './attached-items';
 
+import type { DraftFileUpload } from './types';
+
 import type { WithBoundArgs } from '@glint/template';
 import type { TrackedSet } from 'tracked-built-ins';
 
@@ -29,6 +31,9 @@ interface Signature {
     removeCard: (cardId: string) => void;
     chooseFile: (file: FileDef) => void;
     removeFile: (file: FileDef) => void;
+    pendingUploads?: DraftFileUpload[];
+    retryFileUpload?: (uploadId: string) => void;
+    removePendingFileUpload?: (uploadId: string) => void;
     autoAttachedCardTooltipMessage?: string;
   };
   Blocks: {
@@ -42,6 +47,9 @@ interface Signature {
         | 'removeFile'
         | 'chooseCard'
         | 'chooseFile'
+        | 'pendingUploads'
+        | 'retryFileUpload'
+        | 'removePendingFileUpload'
         | 'autoAttachedCardTooltipMessage'
         | 'isLoaded'
       >,
@@ -64,6 +72,9 @@ export default class AiAssistantAttachmentPicker extends Component<Signature> {
         removeFile=@removeFile
         chooseCard=@chooseCard
         chooseFile=@chooseFile
+        pendingUploads=@pendingUploads
+        retryFileUpload=@retryFileUpload
+        removePendingFileUpload=@removePendingFileUpload
         autoAttachedCardTooltipMessage=@autoAttachedCardTooltipMessage
       )
       (component AttachButton chooseCard=@chooseCard chooseFile=@chooseFile)

--- a/packages/host/app/components/ai-assistant/attachment-picker/types.ts
+++ b/packages/host/app/components/ai-assistant/attachment-picker/types.ts
@@ -1,0 +1,8 @@
+import type { FileDef } from 'https://cardstack.com/base/file-api';
+
+export interface DraftFileUpload {
+  id: string;
+  file: FileDef;
+  state: 'uploading' | 'error';
+  error?: string;
+}

--- a/packages/host/app/components/matrix/room.gts
+++ b/packages/host/app/components/matrix/room.gts
@@ -79,6 +79,7 @@ import RoomMessage from './room-message';
 
 import type RoomData from '../../lib/matrix-classes/room';
 import type { RoomSkill } from '../../resources/room';
+import type { DraftFileUpload } from '../ai-assistant/attachment-picker/types';
 import type { MatrixEvent } from 'matrix-js-sdk';
 
 interface Signature {
@@ -195,6 +196,9 @@ export default class Room extends Component<Signature> {
             @removeCard={{this.removeCard}}
             @chooseFile={{this.chooseFile}}
             @removeFile={{this.removeFile}}
+            @pendingUploads={{this.pendingUploads}}
+            @retryFileUpload={{this.retryFileUpload}}
+            @removePendingFileUpload={{this.removePendingFileUpload}}
             @autoAttachedFiles={{this.autoAttachedFiles}}
             @filesToAttach={{this.filesToAttach}}
             @autoAttachedCardTooltipMessage={{if
@@ -460,6 +464,7 @@ export default class Room extends Component<Signature> {
   });
   private removedAttachedCardIds = new TrackedArray<string>();
   private removedAttachedFileUrls: string[] = [];
+  private pendingUploads = new TrackedArray<DraftFileUpload>();
   private lastAutoAttachedFileUrlsKey: string | undefined;
   private getConversationScrollability: (() => boolean) | undefined;
   private scrollConversationToBottom: (() => void) | undefined;
@@ -1039,10 +1044,16 @@ export default class Room extends Component<Signature> {
       this.removeAutoAttachedFile(file.sourceUrl ?? undefined);
     }
 
-    let files = this.filesToAttach;
-    if (!files?.find((f) => f.sourceUrl === file.sourceUrl)) {
-      this.matrixService.setFilesToSend(this.args.roomId, [...files, file]);
+    if (this.hasUploadedOrPendingFile(file)) {
+      return;
     }
+    let uploadId = uuidv4();
+    this.pendingUploads.push({
+      id: uploadId,
+      file,
+      state: 'uploading',
+    });
+    this.uploadChosenFileTask.perform(uploadId);
   }
 
   @action
@@ -1076,6 +1087,91 @@ export default class Room extends Component<Signature> {
 
     this.markAttachedFileRemoved(file.sourceUrl);
   }
+
+  @action
+  private retryFileUpload(uploadId: string) {
+    let upload = this.pendingUploads.find((item) => item.id === uploadId);
+    if (!upload) {
+      return;
+    }
+    this.replacePendingUpload(uploadId, {
+      ...upload,
+      state: 'uploading',
+      error: undefined,
+    });
+    this.uploadChosenFileTask.perform(uploadId);
+  }
+
+  @action
+  private removePendingFileUpload(uploadId: string) {
+    this.removePendingUpload(uploadId);
+  }
+
+  private hasUploadedOrPendingFile(file: FileDef) {
+    if (
+      this.filesToAttach.some(
+        (existing) => existing.sourceUrl === file.sourceUrl,
+      )
+    ) {
+      return true;
+    }
+    return this.pendingUploads.some(
+      (pending) => pending.file.sourceUrl === file.sourceUrl,
+    );
+  }
+
+  private removePendingUpload(uploadId: string) {
+    let index = this.pendingUploads.findIndex((item) => item.id === uploadId);
+    if (index === -1) {
+      return;
+    }
+    this.pendingUploads.splice(index, 1);
+  }
+
+  private replacePendingUpload(uploadId: string, nextValue: DraftFileUpload) {
+    let index = this.pendingUploads.findIndex((item) => item.id === uploadId);
+    if (index === -1) {
+      return;
+    }
+    this.pendingUploads.splice(index, 1, nextValue);
+  }
+
+  private uploadChosenFileTask = task(async (uploadId: string) => {
+    let pending = this.pendingUploads.find((item) => item.id === uploadId);
+    if (!pending) {
+      return;
+    }
+    try {
+      let [uploaded] = await this.matrixService.uploadFiles([pending.file]);
+      if (!uploaded) {
+        throw new Error('Upload failed');
+      }
+
+      this.removePendingUpload(uploadId);
+      let files = this.filesToAttach;
+      let alreadyExists = files.some(
+        (existing) =>
+          existing.sourceUrl === uploaded.sourceUrl ||
+          (existing.contentHash &&
+            uploaded.contentHash &&
+            existing.contentHash === uploaded.contentHash),
+      );
+      if (!alreadyExists) {
+        this.matrixService.setFilesToSend(this.args.roomId, [
+          ...files,
+          uploaded,
+        ]);
+      }
+    } catch (error: unknown) {
+      let message =
+        error instanceof Error ? error.message : 'Attachment upload failed';
+      this.replacePendingUpload(uploadId, {
+        ...pending,
+        state: 'error',
+        error: message,
+      });
+    }
+  });
 
   private doSendMessage = enqueueTask(
     async (
@@ -1208,9 +1304,12 @@ export default class Room extends Component<Signature> {
       !this.doSendMessage.isRunning &&
       Boolean(
         this.messageToSend?.trim() ||
+        this.filesToAttach.length > 0 ||
+        this.autoAttachedFiles.length > 0 ||
         this.cardIdsToAttach?.length ||
         this.autoAttachedCardIds.size !== 0,
       ) &&
+      this.pendingUploads.length === 0 &&
       !!this.room &&
       !this.messages.some((m) => this.isPendingMessage(m)) &&
       !this.matrixService.isLoadingTimeline &&
@@ -1269,6 +1368,7 @@ export default class Room extends Component<Signature> {
   private get displayAttachedItems() {
     return (
       this.filesToAttach?.length ||
+      this.pendingUploads.length > 0 ||
       this.cardIdsToAttach?.length ||
       this.autoAttachedFiles.length > 0 ||
       this.autoAttachedCardIds?.size

--- a/packages/host/app/components/operator-mode/choose-file-modal.gts
+++ b/packages/host/app/components/operator-mode/choose-file-modal.gts
@@ -9,6 +9,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 import onKeyMod from 'ember-keyboard/modifiers/on-key';
+import { v4 as uuidv4 } from 'uuid';
 
 import {
   BoxelButton,
@@ -22,6 +23,7 @@ import { eq } from '@cardstack/boxel-ui/helpers';
 import {
   Deferred,
   RealmPaths,
+  inferContentType,
   isCardErrorJSONAPI,
   loadCardDef,
   type CodeRef,
@@ -29,10 +31,14 @@ import {
 } from '@cardstack/runtime-common';
 
 import ModalContainer from '@cardstack/host/components/modal-container';
+import { attachLocalFileToFileDef } from '@cardstack/host/lib/file-def-manager';
 
+import type EnvironmentService from '@cardstack/host/services/environment-service';
 import type FileUploadService from '@cardstack/host/services/file-upload';
+import type { FilePickerTask } from '@cardstack/host/services/file-upload';
 import type { FileUploadTask } from '@cardstack/host/services/file-upload';
 import type LoaderService from '@cardstack/host/services/loader-service';
+import type MatrixService from '@cardstack/host/services/matrix-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 import type RealmService from '@cardstack/host/services/realm';
 import type StoreService from '@cardstack/host/services/store';
@@ -52,11 +58,14 @@ export default class ChooseFileModal extends Component<Signature> {
   @tracked fileTypeFilter?: CodeRef;
   @tracked fileTypeName?: string;
   @tracked acceptTypes?: string;
-  @tracked currentUpload?: FileUploadTask;
+  @tracked uploadTarget: 'realm' | 'matrix' = 'realm';
+  @tracked currentUpload?: FileUploadTask | FilePickerTask;
 
   @service declare private operatorModeStateService: OperatorModeStateService;
   @service declare private realm: RealmService;
   @service declare private store: StoreService;
+  @service declare private matrixService: MatrixService;
+  @service declare private environmentService: EnvironmentService;
   @service('file-upload') declare private fileUpload: FileUploadService;
   @service('loader-service') declare private loaderService: LoaderService;
 
@@ -84,10 +93,12 @@ export default class ChooseFileModal extends Component<Signature> {
   async chooseFile<T extends FileDef>(opts?: {
     fileType?: CodeRef;
     fileTypeName?: string;
+    uploadTarget?: 'realm' | 'matrix';
   }): Promise<undefined | T> {
     this.deferred = new Deferred();
     this.fileTypeFilter = opts?.fileType;
     this.fileTypeName = opts?.fileTypeName;
+    this.uploadTarget = opts?.uploadTarget ?? 'realm';
     this.acceptTypes = undefined;
     this.currentUpload = undefined;
     let defaultRealm = this.knownRealms.find(
@@ -140,6 +151,10 @@ export default class ChooseFileModal extends Component<Signature> {
 
   @action
   private triggerUpload() {
+    if (this.uploadTarget === 'matrix') {
+      this.pickAndAttachLocalFile();
+      return;
+    }
     let task = this.fileUpload.uploadFile({
       realmURL: this.selectedRealm.url,
       acceptTypes: this.acceptTypes,
@@ -155,12 +170,42 @@ export default class ChooseFileModal extends Component<Signature> {
     });
   }
 
+  private pickAndAttachLocalFile() {
+    let task = this.fileUpload.pickFile({
+      acceptTypes: this.acceptTypes,
+      maxSizeBytes: this.environmentService.fileSizeLimitBytes,
+    });
+    this.currentUpload = task;
+    task.result.then((selectedFile) => {
+      if (selectedFile && this.deferred) {
+        let fileName = selectedFile.name || 'attachment';
+        let contentType =
+          selectedFile.type ||
+          inferContentType(fileName) ||
+          'application/octet-stream';
+        let localSourceUrl = `boxel-local-upload://${uuidv4()}/${encodeURIComponent(fileName)}`;
+        let fileDef = this.matrixService.fileAPI.createFileDef({
+          sourceUrl: localSourceUrl,
+          name: fileName,
+          contentType,
+          contentSize: selectedFile.size,
+        });
+        attachLocalFileToFileDef(fileDef, selectedFile);
+        this.deferred.fulfill(fileDef);
+        this.resetState();
+      } else if (task.state !== 'error') {
+        this.currentUpload = undefined;
+      }
+    });
+  }
+
   private resetState() {
     this.selectedRealm = this.knownRealms[0];
     this.selectedFile = undefined;
     this.fileTypeFilter = undefined;
     this.fileTypeName = undefined;
     this.acceptTypes = undefined;
+    this.uploadTarget = 'realm';
     this.currentUpload = undefined;
     this.deferred = undefined;
   }

--- a/packages/host/app/lib/file-def-manager.ts
+++ b/packages/host/app/lib/file-def-manager.ts
@@ -11,6 +11,7 @@ import {
   baseRealm,
   codeRefWithAbsoluteURL,
   getClass,
+  inferContentType,
   SupportedMimeType,
   relativeTo,
   type LooseSingleCardDocument,
@@ -48,6 +49,8 @@ interface CacheEntry {
   content: string;
   timestamp: number;
 }
+
+type UploadableContent = string | Uint8Array;
 
 const CACHE_EXPIRATION_MS = 30 * 60 * 1000; // 30 minutes
 
@@ -93,7 +96,28 @@ export interface FileDefManager {
 export interface PrivilegedFileDefManager extends FileDefManager {
   contentHashCache: Map<string, string>;
   invalidUrlCache: Set<string>;
-  getContentHash(content: string): Promise<string>;
+  getContentHash(content: UploadableContent): Promise<string>;
+}
+
+const LOCAL_FILE_ATTACHMENT = Symbol.for('boxel-local-file-attachment');
+
+export function attachLocalFileToFileDef(
+  fileDef: FileDef,
+  file: File,
+): FileDef {
+  (fileDef as unknown as Record<symbol, unknown>)[LOCAL_FILE_ATTACHMENT] = file;
+  return fileDef;
+}
+
+function getLocalFileFromFileDef(fileDef: FileDef): File | undefined {
+  let value = (fileDef as unknown as Record<symbol, unknown>)[
+    LOCAL_FILE_ATTACHMENT
+  ];
+  return value instanceof File ? value : undefined;
+}
+
+function clearLocalFileFromFileDef(fileDef: FileDef): void {
+  delete (fileDef as unknown as Record<symbol, unknown>)[LOCAL_FILE_ATTACHMENT];
 }
 
 export default class FileDefManagerImpl
@@ -139,28 +163,40 @@ export default class FileDefManagerImpl
     return this.getCardAPI();
   }
 
-  async getContentHash(content: string): Promise<string> {
+  async getContentHash(content: UploadableContent): Promise<string> {
     return md5(content);
   }
 
   private async getCachedUrlForContent(
-    content: string,
+    content: UploadableContent,
   ): Promise<string | null> {
     const hash = await this.getContentHash(content);
     return this.contentHashCache.get(hash) || null;
   }
 
   async uploadContentWithCaching(
-    content: string,
+    content: UploadableContent,
     contentType: string,
+    name?: string,
   ): Promise<string> {
     // Check if we already have this content cached
     const cachedUrl = await this.getCachedUrlForContent(content);
     if (cachedUrl) {
       return cachedUrl;
     }
-    let response = await this.client.uploadContent(content, {
+    let uploadBody: XMLHttpRequestBodyInit;
+    if (typeof content === 'string') {
+      uploadBody = content;
+    } else {
+      // Ensure we're uploading bytes backed by a regular ArrayBuffer
+      // so Matrix SDK body types remain compatible with TS DOM types.
+      let binaryContent = new Uint8Array(content.byteLength);
+      binaryContent.set(content);
+      uploadBody = new Blob([binaryContent], { type: contentType });
+    }
+    let response = await this.client.uploadContent(uploadBody, {
       type: contentType,
+      name,
     });
     let url = this.client.mxcUrlToHttp(
       response.content_uri,
@@ -350,28 +386,75 @@ export default class FileDefManagerImpl
   async uploadFiles(files: FileDef[]) {
     let uploadedFiles = await Promise.all(
       files.map(async (file) => {
-        if (!file.sourceUrl) {
-          throw new Error('File needs a realm server source URL to upload');
+        let sourceUrl = file.sourceUrl;
+        let localFile = getLocalFileFromFileDef(file);
+
+        if (file.contentHash && file.url && file.url !== file.sourceUrl) {
+          if (!this.contentHashCache.has(file.contentHash)) {
+            this.contentHashCache.set(file.contentHash, file.url);
+          }
+          return file;
+        } else if (file.contentHash) {
+          let cachedUrl = this.contentHashCache.get(file.contentHash);
+          if (cachedUrl) {
+            file.url = cachedUrl;
+            return file;
+          }
         }
 
-        let response = await this.network.authedFetch(file.sourceUrl, {
-          headers: {
-            Accept: 'application/vnd.card+source',
-          },
-        });
-
-        // We only support uploading text files (code) for now.
-        // When we start supporting other file types (pdfs, images, etc)
-        // we will need to update this to support those file types.
-        let text = await response.text();
-        let contentType = response.headers.get('content-type');
+        let contentType: string | undefined;
+        let bytes: Uint8Array;
+        if (localFile) {
+          sourceUrl = file.sourceUrl;
+          bytes = new Uint8Array(await localFile.arrayBuffer());
+          contentType =
+            localFile.type ||
+            file.contentType ||
+            inferContentType(localFile.name || file.name);
+        } else {
+          if (!sourceUrl) {
+            throw new Error('File needs a source URL to upload');
+          }
+          let response = await this.network.authedFetch(sourceUrl);
+          if (!response.ok) {
+            throw new Error(
+              `Failed to read file at ${sourceUrl}: ${response.status} ${response.statusText}`,
+            );
+          }
+          bytes = new Uint8Array(await response.arrayBuffer());
+          contentType =
+            response.headers.get('content-type') ||
+            file.contentType ||
+            inferContentType(file.name ?? sourceUrl.split('/').pop() ?? '');
+        }
 
         if (!contentType) {
-          throw new Error(`File has no content type: ${file.sourceUrl}`);
+          throw new Error(
+            `File has no content type: ${sourceUrl ?? file.name ?? '(unknown file)'}`,
+          );
         }
-        file.url = await this.uploadContentWithCaching(text, contentType);
+        let contentHash = await this.getContentHash(bytes);
+        let cachedUrl = this.contentHashCache.get(contentHash);
+        if (cachedUrl) {
+          file.url = cachedUrl;
+        } else {
+          file.url = await this.uploadContentWithCaching(
+            bytes,
+            contentType,
+            file.name,
+          );
+          this.contentHashCache.set(contentHash, file.url);
+        }
+
         file.contentType = contentType;
-        file.contentHash = await this.getContentHash(text);
+        file.contentHash = contentHash;
+        file.contentSize = bytes.byteLength;
+
+        if (!file.sourceUrl && file.contentHash) {
+          let fileName = file.name ?? 'attachment';
+          file.sourceUrl = `boxel-attachment://${file.contentHash}/${encodeURIComponent(fileName)}`;
+        }
+        clearLocalFileFromFileDef(file);
 
         return file;
       }),

--- a/packages/host/app/services/file-upload.ts
+++ b/packages/host/app/services/file-upload.ts
@@ -46,6 +46,37 @@ export class FileUploadTask {
   }
 }
 
+export class FilePickerTask {
+  @tracked state: 'picking' | 'complete' | 'error' = 'picking';
+  @tracked error?: string;
+  @tracked fileName?: string;
+  result: Promise<File | undefined>;
+
+  private _fileDeferred = new Deferred<File | null>();
+  private _resultDeferred = new Deferred<File | undefined>();
+
+  constructor() {
+    this.result = this._resultDeferred.promise;
+  }
+
+  // Test seam: provide a file without the native picker
+  __provideFileForTesting(file: File | null) {
+    this._fileDeferred.fulfill(file);
+  }
+
+  _resolveFile(file: File | null) {
+    this._fileDeferred.fulfill(file);
+  }
+
+  awaitFile(): Promise<File | null> {
+    return this._fileDeferred.promise;
+  }
+
+  _fulfill(value: File | undefined) {
+    this._resultDeferred.fulfill(value);
+  }
+}
+
 export default class FileUploadService extends Service {
   @service declare private network: NetworkService;
   @service declare private store: StoreService;
@@ -67,7 +98,24 @@ export default class FileUploadService extends Service {
     return task;
   }
 
-  private _openFilePicker(task: FileUploadTask, acceptTypes?: string) {
+  pickFile(opts: {
+    acceptTypes?: string;
+    maxSizeBytes?: number;
+  }): FilePickerTask {
+    let task = new FilePickerTask();
+
+    if (!isTesting()) {
+      this._openFilePicker(task, opts.acceptTypes);
+    }
+
+    this._processPick(task, opts.maxSizeBytes);
+    return task;
+  }
+
+  private _openFilePicker(
+    task: FileUploadTask | FilePickerTask,
+    acceptTypes?: string,
+  ) {
     let input = document.createElement('input');
     input.type = 'file';
     input.accept = acceptTypes ?? '';
@@ -145,6 +193,32 @@ export default class FileUploadService extends Service {
     } catch (e: any) {
       task.state = 'error';
       task.error = e.message ?? 'Upload failed';
+      task._fulfill(undefined);
+    }
+  }
+
+  private async _processPick(task: FilePickerTask, maxSizeBytes?: number) {
+    try {
+      let file = await task.awaitFile();
+      if (!file) {
+        task.state = 'complete';
+        task._fulfill(undefined);
+        return;
+      }
+
+      task.fileName = file.name;
+      if (maxSizeBytes && file.size > maxSizeBytes) {
+        task.state = 'error';
+        task.error = `File "${file.name}" exceeds maximum allowed size (${maxSizeBytes} bytes)`;
+        task._fulfill(undefined);
+        return;
+      }
+
+      task.state = 'complete';
+      task._fulfill(file);
+    } catch (e: any) {
+      task.state = 'error';
+      task.error = e.message ?? 'File selection failed';
       task._fulfill(undefined);
     }
   }

--- a/packages/host/app/services/matrix-service.ts
+++ b/packages/host/app/services/matrix-service.ts
@@ -268,6 +268,16 @@ export default class MatrixService extends Service {
     return this.filesToSend.get(roomId);
   }
 
+  hasAttachedFileInRoom(roomId: string, sourceUrl: string): boolean {
+    let roomResource = this.roomResources.get(roomId);
+    if (!roomResource) {
+      return false;
+    }
+    return roomResource.messages.some((message) =>
+      message.attachedFiles?.some((file) => file.sourceUrl === sourceUrl),
+    );
+  }
+
   private setAgentId() {
     this.agentId = this.localPersistenceService.getAgentId();
   }

--- a/packages/host/tests/helpers/mock-matrix/_client.ts
+++ b/packages/host/tests/helpers/mock-matrix/_client.ts
@@ -841,7 +841,9 @@ export class MockClient implements ExtendedClient {
     fileDefManager.contentHashCache.set(contentHash, url);
 
     let contentArrayBuffer = this.serverState.getContent(url);
-    let content = contentArrayBuffer?.toString();
+    let content = contentArrayBuffer
+      ? new TextDecoder().decode(new Uint8Array(contentArrayBuffer))
+      : undefined;
     if (!content) {
       throw new Error('No content found for URL: ' + url);
     }
@@ -859,14 +861,30 @@ export class MockClient implements ExtendedClient {
   }
 
   async uploadContent(
-    _content: string,
-    _opts?: { type?: string; name?: string },
+    _content: XMLHttpRequestBodyInit,
+    _opts?: MatrixSDK.UploadOpts,
   ): Promise<any> {
     let contentUri = `mxc://mock-server/${Math.random()}`;
-    this.serverState.addContent(
-      this.mxcUrlToHttp(contentUri),
-      _content as unknown as ArrayBuffer,
-    );
+    let contentBytes: ArrayBuffer;
+    if (typeof _content === 'string') {
+      contentBytes = new TextEncoder().encode(_content).buffer;
+    } else if (_content instanceof Blob) {
+      contentBytes = await _content.arrayBuffer();
+    } else if (_content instanceof ArrayBuffer) {
+      contentBytes = _content;
+    } else if (ArrayBuffer.isView(_content)) {
+      let view = _content as ArrayBufferView;
+      let bytes = new Uint8Array(view.byteLength);
+      bytes.set(new Uint8Array(view.buffer, view.byteOffset, view.byteLength));
+      contentBytes = bytes.buffer;
+    } else if (_content instanceof URLSearchParams) {
+      contentBytes = new TextEncoder().encode(_content.toString()).buffer;
+    } else if (_content instanceof FormData) {
+      throw new Error('FormData upload is not implemented in mock client');
+    } else {
+      throw new Error('Unsupported upload body type in mock client');
+    }
+    this.serverState.addContent(this.mxcUrlToHttp(contentUri), contentBytes);
     return { content_uri: contentUri };
   }
 
@@ -877,7 +895,9 @@ export class MockClient implements ExtendedClient {
     if (!content) {
       throw new Error(`content not found for ${serializedFile.url}`);
     }
-    return JSON.parse(content.toString()) as LooseSingleCardDocument;
+    return JSON.parse(
+      new TextDecoder().decode(new Uint8Array(content)),
+    ) as LooseSingleCardDocument;
   }
 
   async downloadAsFileInBrowser(

--- a/packages/host/tests/integration/commands/read-file-for-ai-assistant-test.gts
+++ b/packages/host/tests/integration/commands/read-file-for-ai-assistant-test.gts
@@ -65,9 +65,9 @@ module('Integration | commands | read-file-for-ai-assistant', function (hooks) {
       fileUrl: `${testRealmURL}files/test.txt`,
     });
     assert.true(!!result.fileForAttachment.contentHash);
-    assert.strictEqual(
-      result.fileForAttachment.contentType,
-      'text/plain; charset=utf-8',
+    assert.true(
+      result.fileForAttachment.contentType?.startsWith('text/plain'),
+      `expected text/plain content type, got ${result.fileForAttachment.contentType}`,
     );
     assert.strictEqual(result.fileForAttachment.name, 'test.txt');
     assert.strictEqual(
@@ -75,5 +75,25 @@ module('Integration | commands | read-file-for-ai-assistant', function (hooks) {
       `${testRealmURL}files/test.txt`,
     );
     assert.true(!!result.fileForAttachment.url);
+  });
+
+  test('rejects reading files not previously attached in the room', async function (assert) {
+    let commandService = getService('command-service');
+    let roomId = mockMatrixUtils.createAndJoinRoom({
+      sender: '@testuser:localhost',
+      name: 'attachment-guard-room',
+    });
+
+    let command = new ReadFileForAiAssistantCommand(
+      commandService.commandContext,
+    );
+
+    await assert.rejects(
+      command.execute({
+        fileUrl: `${testRealmURL}files/test.txt`,
+        roomId,
+      }),
+      /not attached in this conversation/,
+    );
   });
 });

--- a/packages/host/tests/integration/components/ai-assistant-panel/sending-test.gts
+++ b/packages/host/tests/integration/components/ai-assistant-panel/sending-test.gts
@@ -385,4 +385,57 @@ module('Integration | ai-assistant-panel | sending', function (hooks) {
       )
       .doesNotExist();
   });
+
+  test('failed file upload blocks send until retry succeeds or upload is removed', async function (assert) {
+    operatorModeStateService.restore({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}Person/fadhlan`,
+            format: 'isolated',
+          },
+        ],
+      ],
+      submode: Submodes.Code,
+      codePath: `${testRealmURL}person.gts`,
+    });
+
+    await renderComponent(
+      class TestDriver extends GlimmerComponent {
+        <template><OperatorMode @onClose={{noop}} /></template>
+      },
+    );
+
+    await openAiAssistant();
+    await fillIn('[data-test-message-field]', 'Message with attachment');
+
+    let matrixService = getService('matrix-service') as any;
+    let originalUploadFiles = matrixService.uploadFiles.bind(matrixService);
+    matrixService.uploadFiles = async () => {
+      throw new Error('Upload failed in test');
+    };
+
+    await click('[data-test-attach-button]');
+    await click('[data-test-attach-file-btn]');
+    await click('[data-test-file="person.gts"]');
+    await click('[data-test-choose-file-modal-add-button]');
+
+    await waitFor('[data-test-pending-upload-error]');
+    assert
+      .dom('[data-test-send-message-btn]')
+      .isDisabled('send is blocked while a failed upload exists');
+
+    matrixService.uploadFiles = originalUploadFiles;
+    await click('[data-test-pending-upload-retry]');
+    await waitUntil(
+      () =>
+        !document.querySelector('[data-test-pending-upload]') &&
+        Boolean(document.querySelector('[data-test-attached-file]')),
+      {
+        timeout: 5000,
+        timeoutMessage: 'upload retry did not finish',
+      },
+    );
+    assert.dom('[data-test-send-message-btn]').isEnabled();
+  });
 });

--- a/packages/runtime-common/ai/matrix-utils.ts
+++ b/packages/runtime-common/ai/matrix-utils.ts
@@ -283,10 +283,7 @@ export async function downloadFile(
   client: MatrixClient,
   attachedFile: SerializedFileDef,
 ): Promise<string> {
-  if (
-    !attachedFile?.contentType?.includes('text/') &&
-    !attachedFile.contentType?.includes('application/vnd.card+json')
-  ) {
+  if (!isTextLikeContentType(attachedFile?.contentType)) {
     throw new Error(
       `Unsupported file type: ${attachedFile.contentType}. For now, only text files are supported.`,
     );
@@ -315,10 +312,13 @@ export async function downloadFile(
 
   // create an in-flight promise and store it so others can await
   const fetchPromise = (async () => {
+    let accessToken = client?.getAccessToken?.();
     let response = await (globalThis as any).fetch(attachedFile.url, {
-      headers: {
-        Authorization: `Bearer ${client.getAccessToken()}`,
-      },
+      headers: accessToken
+        ? {
+            Authorization: `Bearer ${accessToken}`,
+          }
+        : {},
     });
     if (!response.ok) {
       throw new Error(`HTTP error. Status: ${response.status}`);
@@ -345,6 +345,70 @@ export async function downloadFile(
   } finally {
     inFlightFetches.delete(inFlightKey);
   }
+}
+
+export function isTextLikeContentType(contentType?: string | null): boolean {
+  if (!contentType) {
+    return false;
+  }
+  let normalized = contentType.toLowerCase();
+  return (
+    normalized.includes('text/') ||
+    normalized.includes('application/vnd.card+json') ||
+    normalized.includes('application/json') ||
+    normalized.includes('+json') ||
+    normalized.includes('application/xml') ||
+    normalized.includes('application/javascript') ||
+    normalized.includes('application/x-javascript') ||
+    normalized.includes('application/typescript') ||
+    normalized.includes('application/x-typescript')
+  );
+}
+
+export function isImageContentType(contentType?: string | null): boolean {
+  if (!contentType) {
+    return false;
+  }
+  return contentType.startsWith('image/');
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let bufferCtor = (globalThis as any).Buffer;
+  if (bufferCtor) {
+    return bufferCtor.from(bytes).toString('base64');
+  }
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+export async function downloadFileAsDataUrl(
+  client: MatrixClient,
+  attachedFile: SerializedFileDef,
+): Promise<string> {
+  if (!isImageContentType(attachedFile?.contentType)) {
+    throw new Error(
+      `Unsupported image file type: ${attachedFile?.contentType}`,
+    );
+  }
+
+  let accessToken = client?.getAccessToken?.();
+  let response = await (globalThis as any).fetch(attachedFile.url, {
+    headers: accessToken
+      ? {
+          Authorization: `Bearer ${accessToken}`,
+        }
+      : {},
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP error. Status: ${response.status}`);
+  }
+
+  let bytes = new Uint8Array(await response.arrayBuffer());
+  let mimeType = attachedFile.contentType || 'image/png';
+  return `data:${mimeType};base64,${bytesToBase64(bytes)}`;
 }
 
 export function isCommandOrCodePatchResult(

--- a/packages/runtime-common/ai/prompt.ts
+++ b/packages/runtime-common/ai/prompt.ts
@@ -11,8 +11,11 @@ import type {
 import { constructHistory } from './history';
 import {
   downloadFile,
+  downloadFileAsDataUrl,
   extractCodePatchBlocks,
   isCommandOrCodePatchResult,
+  isImageContentType,
+  isTextLikeContentType,
 } from './matrix-utils';
 import { isRecognisedDebugCommand } from './debug';
 import type {
@@ -96,6 +99,8 @@ export async function getPromptParts(
   let disabledSkillIds = await getDisabledSkillIds(eventList);
   let tools = await getTools(eventList, skills, aiBotUserId, client);
   let toolChoice = getToolChoice(history, aiBotUserId);
+  let { model, toolsSupported, reasoningEffort } =
+    getActiveLLMDetails(eventList);
   let messages = await buildPromptForModel(
     history,
     aiBotUserId,
@@ -103,9 +108,8 @@ export async function getPromptParts(
     skills,
     disabledSkillIds,
     client,
+    model,
   );
-  let { model, toolsSupported, reasoningEffort } =
-    getActiveLLMDetails(eventList);
   return {
     shouldRespond,
     tools,
@@ -413,6 +417,26 @@ export function hasSomeAttachedCards(
   return false;
 }
 
+function shouldIncludeAttachmentContent(
+  matrixEvent: MatrixEventWithBoxelContext,
+  history: DiscreteMatrixEvent[],
+  sourceUrl?: string,
+) {
+  if (!sourceUrl) {
+    return true;
+  }
+  return !history.slice(history.indexOf(matrixEvent) + 1).some((event) => {
+    return (
+      (event as MatrixEventWithBoxelContext).content?.data?.attachedFiles?.some(
+        (file: SerializedFileDef) => file.sourceUrl === sourceUrl,
+      ) ||
+      (event as MatrixEventWithBoxelContext).content?.data?.attachedCards?.some(
+        (card: SerializedFileDef) => card.sourceUrl === sourceUrl,
+      )
+    );
+  });
+}
+
 export async function getAttachedCards(
   client: MatrixClient,
   matrixEvent: MatrixEventWithBoxelContext,
@@ -421,18 +445,11 @@ export async function getAttachedCards(
   let attachedCards = matrixEvent.content?.data?.attachedCards ?? [];
   let results = await Promise.all(
     attachedCards.map(async (attachedCard: SerializedFileDef) => {
-      // If the file is attached later in the history, we should not include the content here
-      let shouldIncludeContent = !history
-        .slice(history.indexOf(matrixEvent) + 1)
-        .some((event) => {
-          // event is not always MatrixEventWithBoxelContext but casting lets us safely check attachedCards
-          return (
-            event as MatrixEventWithBoxelContext
-          ).content?.data?.attachedCards?.some(
-            (cardAttachment: SerializedFileDef) =>
-              cardAttachment.sourceUrl === attachedCard.sourceUrl,
-          );
-        });
+      let shouldIncludeContent = shouldIncludeAttachmentContent(
+        matrixEvent,
+        history,
+        attachedCard.sourceUrl,
+      );
       let result: SerializedFileDef = {
         url: attachedCard.url,
         sourceUrl: attachedCard.sourceUrl ?? '',
@@ -470,18 +487,11 @@ export async function getAttachedFiles(
   let attachedFiles = matrixEvent.content?.data?.attachedFiles ?? [];
   return Promise.all(
     attachedFiles.map(async (attachedFile: SerializedFileDef) => {
-      // If the file is attached later in the history, we should not include the content here
-      let shouldIncludeContent = !history
-        .slice(history.indexOf(matrixEvent) + 1)
-        .some((event) => {
-          // event is not always MatrixEventWithBoxelContext but casting lets us safely check attachedFiles
-          return (
-            event as MatrixEventWithBoxelContext
-          ).content?.data?.attachedFiles?.some(
-            (file: SerializedFileDef) =>
-              file.sourceUrl === attachedFile.sourceUrl,
-          );
-        });
+      let shouldIncludeContent = shouldIncludeAttachmentContent(
+        matrixEvent,
+        history,
+        attachedFile.sourceUrl,
+      );
 
       let result: SerializedFileDef = {
         url: attachedFile.url,
@@ -489,7 +499,10 @@ export async function getAttachedFiles(
         name: attachedFile.name,
         contentType: attachedFile.contentType,
       };
-      if (shouldIncludeContent) {
+      if (
+        shouldIncludeContent &&
+        isTextLikeContentType(attachedFile.contentType)
+      ) {
         try {
           result.content = await downloadFile(client, attachedFile);
         } catch (error) {
@@ -501,6 +514,71 @@ export async function getAttachedFiles(
       return result;
     }),
   );
+}
+
+function modelSupportsImageInput(model: string): boolean {
+  let normalized = model.toLowerCase();
+  return (
+    normalized.includes('gpt-4o') ||
+    normalized.includes('gpt-5') ||
+    normalized.includes('claude') ||
+    normalized.includes('gemini')
+  );
+}
+
+async function getAttachedImageParts(
+  client: MatrixClient,
+  matrixEvent: MatrixEventWithBoxelContext,
+  history: DiscreteMatrixEvent[],
+  model: string,
+): Promise<
+  {
+    type: 'image_url';
+    image_url: {
+      url: string;
+      detail?: string;
+    };
+  }[]
+> {
+  if (!modelSupportsImageInput(model)) {
+    return [];
+  }
+
+  let attachedFiles = matrixEvent.content?.data?.attachedFiles ?? [];
+  let results: {
+    type: 'image_url';
+    image_url: { url: string; detail?: string };
+  }[] = [];
+  for (let attachedFile of attachedFiles) {
+    if (!isImageContentType(attachedFile.contentType)) {
+      continue;
+    }
+    if (
+      !shouldIncludeAttachmentContent(
+        matrixEvent,
+        history,
+        attachedFile.sourceUrl,
+      )
+    ) {
+      continue;
+    }
+    try {
+      let dataUrl = await downloadFileAsDataUrl(client, attachedFile);
+      results.push({
+        type: 'image_url',
+        image_url: {
+          url: dataUrl,
+          detail: 'auto',
+        },
+      });
+    } catch (error) {
+      getLog().error(
+        `Failed to fetch image attachment ${attachedFile.url}:`,
+        error,
+      );
+    }
+  }
+  return results;
 }
 
 export async function loadCurrentlySerializedFileDefs(
@@ -540,6 +618,15 @@ export async function loadCurrentlySerializedFileDefs(
 
   return Promise.all(
     attachedFiles.map(async (attachedFile: SerializedFileDef) => {
+      if (!isTextLikeContentType(attachedFile.contentType)) {
+        return {
+          url: attachedFile.url,
+          sourceUrl: attachedFile.sourceUrl ?? '',
+          name: attachedFile.name,
+          contentType: attachedFile.contentType,
+          content: undefined,
+        };
+      }
       try {
         let content = await downloadFile(client, attachedFile);
 
@@ -1179,6 +1266,7 @@ export async function buildPromptForModel(
   skillCards: LooseCardResource[] = [],
   disabledSkillIds: string[] = [],
   client: MatrixClient,
+  model: string = DEFAULT_LLM,
 ) {
   // Need to make sure the passed in username is a full id
   if (
@@ -1236,11 +1324,29 @@ export async function buildPromptForModel(
         event as CardMessageEvent,
         history,
       );
-      let content = [body, attachments].filter(Boolean).join('\n\n');
-      if (content) {
+      let textContent = [body, attachments].filter(Boolean).join('\n\n');
+      let imageParts = await getAttachedImageParts(
+        client,
+        event as CardMessageEvent,
+        history,
+        model,
+      );
+      if (imageParts.length > 0) {
+        let contentParts: OpenAIPromptMessage['content'] = [
+          {
+            type: 'text',
+            text: textContent || 'User shared image attachments.',
+          },
+          ...imageParts,
+        ];
         historicalMessages.push({
           role: 'user',
-          content,
+          content: contentParts,
+        });
+      } else if (textContent) {
+        historicalMessages.push({
+          role: 'user',
+          content: textContent,
         });
       }
     }

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -388,6 +388,7 @@ export interface FileChooser {
   chooseFile<T>(opts?: {
     fileType?: CodeRef;
     fileTypeName?: string;
+    uploadTarget?: 'realm' | 'matrix';
   }): Promise<undefined | T>;
 }
 
@@ -419,6 +420,7 @@ export async function chooseCard(
 export async function chooseFile<T extends FileDef>(opts?: {
   fileType?: CodeRef;
   fileTypeName?: string;
+  uploadTarget?: 'realm' | 'matrix';
 }): Promise<undefined | T> {
   let here = globalThis as any;
   if (!here._CARDSTACK_FILE_CHOOSER) {


### PR DESCRIPTION
## Summary
- add end-to-end AI Assistant file attachments from realm and local sources with pending/error/retry UX and send gating
- upload attachments to Matrix with FileDef representations, binary-safe content-hash dedupe, and stable attachment ordering
- make prompt construction model-aware (native image inputs where supported, metadata fallback for unsupported MIME) and scope tool-based file reads to same conversation