### PR TITLE
Fix Monaco editor staying read-only for non-module files

### DIFF
--- a/packages/host/app/modifiers/monaco.ts
+++ b/packages/host/app/modifiers/monaco.ts
@@ -39,6 +39,7 @@ export default class Monaco extends Modifier<Signature> {
   private editor: MonacoSDK.editor.IStandaloneCodeEditor | undefined;
   private lastLanguage: string | undefined;
   private lastContent: string | undefined;
+  private lastReadOnly: boolean | undefined;
   private lastModified = Date.now();
   private lastCursorPosition: MonacoSDK.Position | undefined;
   private waiterManager = createMonacoWaiterManager();
@@ -74,6 +75,10 @@ export default class Monaco extends Modifier<Signature> {
       ) {
         this.lastContent = content;
         this.model.setValue(content);
+      }
+      if (readOnly !== this.lastReadOnly) {
+        this.editor.updateOptions({ readOnly });
+        this.lastReadOnly = readOnly;
       }
     } else {
       this.setupEditor({
@@ -137,6 +142,7 @@ export default class Monaco extends Modifier<Signature> {
     }
 
     this.editor = monacoSDK.editor.create(element, editorOptions);
+    this.lastReadOnly = readOnly;
 
     // Track editor initialization for test waiters
     if (this.waiterManager) {

--- a/packages/host/tests/acceptance/code-submode/editor-test.ts
+++ b/packages/host/tests/acceptance/code-submode/editor-test.ts
@@ -347,6 +347,19 @@ module('Acceptance | code submode | editor tests', function (hooks) {
     // await percySnapshot(assert);
   });
 
+  test('text file in writable realm is not read-only', async function (assert) {
+    await visitOperatorMode({
+      submode: 'code',
+      codePath: `${testRealmURL}README.txt`,
+    });
+
+    await waitFor('[data-test-editor]');
+    assert.false(
+      monacoService?.editor?.getOption(MonacoSDK.editor.EditorOption.readOnly),
+      'editor should not be read-only for a .txt file in a writable realm',
+    );
+  });
+
   test<TestContextWithSave>('allows fixing broken cards', async function (assert) {
     await visitOperatorMode({
       stacks: [


### PR DESCRIPTION
## Summary
- Non-module files (e.g. `.txt`) in writable realms were stuck as read-only in the Monaco editor because the `readOnly` option was set during initial creation (while `fileDefResource` was loading) and never updated afterward
- Added `lastReadOnly` tracking to the Monaco modifier so `editor.updateOptions({ readOnly })` is called when the `readOnly` arg changes after initial editor creation
- Added a regression test that opens a `.txt` file in code submode with write permissions and asserts the editor is not read-only

## Test plan
- [x] Run `ember test --path dist --filter "text file in writable realm is not read-only"` in `packages/host`
- [x] Manually verify: open a `.txt` file in code submode in a writable realm and confirm the editor is editable

🤖 Generated with [Claude Code](https://claude.com/claude-code)