### PR TITLE
Fix JSON syntax highlighting in metadata panel

### DIFF
--- a/packages/base/card-api.gts
+++ b/packages/base/card-api.gts
@@ -122,6 +122,7 @@ import {
   serialize,
   serializeCard,
   serializeCardResource,
+  serializeFileDef,
   resourceFrom,
   type DeserializeOpts,
   type JSONAPIResource,
@@ -184,6 +185,7 @@ export {
   relationshipMeta,
   serialize,
   serializeCard,
+  serializeFileDef,
   ensureQueryFieldSearchResource,
   getStore,
   type BoxComponent,
@@ -2057,6 +2059,7 @@ export class BaseDef {
   // So we need a [relativeTo] property that derives from the root document ID in order to
   // resolve relative links at the FieldDef level.
   [relativeTo]: URL | undefined = undefined;
+  [meta]: CardResourceMeta | undefined = undefined;
   declare ['constructor']: BaseDefConstructor;
   static baseDef: undefined;
   static data?: Record<string, any>; // TODO probably refactor this away all together
@@ -2438,7 +2441,6 @@ export class CardInfoField extends FieldDef {
 export class CardDef extends BaseDef {
   readonly [localId]: string = uuidv4();
   [isSavedInstance] = false;
-  [meta]: CardResourceMeta | undefined = undefined;
   get [fieldsUntracked](): Record<string, typeof BaseDef> | undefined {
     let overrides = getFieldOverrides(this);
     return overrides ? Object.fromEntries(getFieldOverrides(this)) : undefined;

--- a/packages/base/card-serialization.ts
+++ b/packages/base/card-serialization.ts
@@ -8,10 +8,12 @@ import type {
   Loader,
   LooseCardResource,
   LooseSingleCardDocument,
+  LooseSingleFileMetaDocument,
   Meta,
   RuntimeDependencyTrackingContext,
 } from '@cardstack/runtime-common';
 import type { BaseDef, BaseDefConstructor, CardDef } from './card-api';
+import type { FileDef } from './file-api';
 import type { ResourceID } from '@cardstack/runtime-common';
 
 // --- Runtime Imports ---
@@ -19,11 +21,14 @@ import type { ResourceID } from '@cardstack/runtime-common';
 import { isEqual, merge } from 'lodash';
 import {
   assertIsSerializerName,
+  CardResourceType,
   fieldSerializer,
+  FileMetaResourceType,
   getSerializer,
   humanReadable,
   identifyCard,
   isSingleCardDocument,
+  isSingleFileMetaDocument,
   loadCardDef,
   localId,
   maybeRelativeURL,
@@ -139,7 +144,7 @@ export function callSerializeHook(
 }
 
 export function getCardMeta<K extends keyof CardResourceMeta>(
-  card: CardDef,
+  card: BaseDef,
   metaKey: K,
 ): CardResourceMeta[K] | undefined {
   return card[meta]?.[metaKey] as CardResourceMeta[K] | undefined;
@@ -244,10 +249,11 @@ export function serializeCard(
 }
 
 export function serializeCardResource(
-  model: CardDef,
+  model: CardDef | FileDef,
   doc: JSONAPISingleResourceDocument,
   opts?: SerializeOpts,
   visited: Set<string> = new Set(),
+  resourceType: string = CardResourceType,
 ): LooseCardResource {
   let adoptsFrom = identifyCard(
     model.constructor,
@@ -279,9 +285,65 @@ export function serializeCardResource(
     },
     ...fieldResources,
     {
-      type: 'card',
+      type: resourceType,
       meta: { adoptsFrom, ...(realmURL ? { realmURL } : {}) },
     },
-    model.id ? { id: model.id } : { lid: model[localId] },
+    // Only CardDef instances can be unsaved (without an id), so when model.id
+    // is falsy we know the model is a CardDef which has [localId].
+    model.id ? { id: model.id } : { lid: (model as CardDef)[localId] },
   );
+}
+
+export function serializeFileDef(
+  model: FileDef,
+  opts?: SerializeOpts,
+): LooseSingleFileMetaDocument {
+  let doc = {
+    data: {
+      type: FileMetaResourceType,
+      ...(model.id != null ? { id: model.id } : {}),
+    },
+  };
+  let modelRelativeTo =
+    model.id != null
+      ? new URL(model.id)
+      : (model[relativeTo] as URL | undefined);
+  let data = serializeCardResource(
+    model,
+    doc,
+    {
+      ...opts,
+      ...{
+        maybeRelativeURL(possibleURL: string) {
+          let url = maybeURL(possibleURL, modelRelativeTo);
+          if (!url) {
+            throw new Error(
+              `could not determine url from '${maybeRelativeURL}' relative to ${modelRelativeTo}`,
+            );
+          }
+          if (!modelRelativeTo) {
+            return url.href;
+          }
+          const realmURLString = getCardMeta(model, 'realmURL');
+          const realmURL = realmURLString
+            ? new URL(realmURLString)
+            : undefined;
+          return maybeRelativeURL(url, modelRelativeTo, realmURL);
+        },
+      },
+    },
+    undefined,
+    FileMetaResourceType,
+  );
+  merge(doc, { data });
+  if (!isSingleFileMetaDocument(doc)) {
+    throw new Error(
+      `Expected serialized file def to be a SingleFileMetaDocument, but it was: ${JSON.stringify(
+        doc,
+        null,
+        2,
+      )}`,
+    );
+  }
+  return doc as LooseSingleFileMetaDocument;
 }

--- a/packages/host/app/components/operator-mode/preview-panel/index.gts
+++ b/packages/host/app/components/operator-mode/preview-panel/index.gts
@@ -52,6 +52,7 @@ import type {
 import FormatChooser from '../code-submode/format-chooser';
 
 import FittedFormatGallery from './fitted-format-gallery';
+import MetadataPanel from './metadata-panel';
 
 interface Signature {
   Element: HTMLElement;
@@ -82,7 +83,11 @@ export default class PreviewPanel extends Component<Signature> {
   }
 
   private get format(): Format {
-    return this.args.format ?? 'isolated';
+    let format = this.args.format ?? 'isolated';
+    if (!this.availableFormats.includes(format)) {
+      return 'isolated';
+    }
+    return format;
   }
 
   private get cardId(): string | undefined {
@@ -150,11 +155,19 @@ export default class PreviewPanel extends Component<Signature> {
     return (this.args.card as any).name;
   }
 
+  private get isFileDef(): boolean {
+    return isFileDefInstance(this.args.card);
+  }
+
   private get availableFormats() {
     if (this.isCard) {
       return allFormats;
     }
-    return allFormats.filter((f) => f !== 'edit');
+    let formats = allFormats.filter((f) => f !== 'edit');
+    if (this.isFileDef) {
+      return [...formats, 'metadata' as Format];
+    }
+    return formats;
   }
 
   @provide(CardContextName)
@@ -233,7 +246,9 @@ export default class PreviewPanel extends Component<Signature> {
             data-test-code-mode-card-renderer-header={{this.cardId}}
             ...attributes
           />
-          {{#if (eq this.format 'fitted')}}
+          {{#if (eq this.format 'metadata')}}
+            <MetadataPanel @card={{@card}} />
+          {{else if (eq this.format 'fitted')}}
             <FittedFormatGallery @card={{@card}} />
           {{else}}
             {{#if this.renderedCardsForOverlayActions}}

--- a/packages/host/app/components/operator-mode/preview-panel/metadata-panel.gts
+++ b/packages/host/app/components/operator-mode/preview-panel/metadata-panel.gts
@@ -50,12 +50,27 @@ const NULL_RE = /\bnull\b/g;
 
 function highlightJson(json: string): string {
   let escaped = escapeHtml(json);
-  escaped = escaped.replace(KEY_RE, (_m, q1, inner, q2) =>
-    `${spanWrap('json-key', `${q1}${inner}${q2}`)}:`,
-  );
-  escaped = escaped.replace(STRING_RE, (_m, q1, inner, q2) =>
-    spanWrap('json-string', `${q1}${inner}${q2}`),
-  );
+
+  // Use a placeholder strategy to prevent number/boolean/null regexes from
+  // matching inside already-highlighted key and string spans.
+  // We replace keys and strings with unique placeholders first, apply
+  // number/boolean/null highlighting on the remaining text, then restore.
+  let placeholders: string[] = [];
+
+  escaped = escaped.replace(KEY_RE, (_m, q1, inner, q2) => {
+    let html = `${spanWrap('json-key', `${q1}${inner}${q2}`)}:`;
+    let idx = placeholders.length;
+    placeholders.push(html);
+    return `\x00PH${idx}\x00`;
+  });
+  escaped = escaped.replace(STRING_RE, (_m, q1, inner, q2) => {
+    let html = spanWrap('json-string', `${q1}${inner}${q2}`);
+    let idx = placeholders.length;
+    placeholders.push(html);
+    return `\x00PH${idx}\x00`;
+  });
+
+  // Now number/boolean/null regexes only see text outside of key/string spans.
   escaped = escaped.replace(NUMBER_RE, (_m, num) =>
     spanWrap('json-number', num),
   );
@@ -63,6 +78,11 @@ function highlightJson(json: string): string {
     spanWrap('json-boolean', bool),
   );
   escaped = escaped.replace(NULL_RE, () => spanWrap('json-null', 'null'));
+
+  // Restore placeholders with the actual highlighted HTML.
+  let PLACEHOLDER_RE = /\x00PH(\d+)\x00/g;
+  escaped = escaped.replace(PLACEHOLDER_RE, (_m, idx) => placeholders[idx]);
+
   return escaped;
 }
 

--- a/packages/host/app/components/operator-mode/preview-panel/metadata-panel.gts
+++ b/packages/host/app/components/operator-mode/preview-panel/metadata-panel.gts
@@ -1,0 +1,188 @@
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+import { resource, use } from 'ember-resources';
+import { TrackedObject } from 'tracked-built-ins';
+
+import { sanitizeHtmlSafe } from '@cardstack/boxel-ui/helpers';
+
+import type StoreService from '@cardstack/host/services/store';
+
+import type { BaseDef } from 'https://cardstack.com/base/card-api';
+import type { FileDef } from 'https://cardstack.com/base/file-api';
+
+interface Signature {
+  Args: {
+    card: BaseDef;
+  };
+}
+
+// content-tag misparses angle brackets inside regex literals in .gts files,
+// so we use RegExp constructor instead.
+const AMP_RE = new RegExp('&', 'g');
+const LT_RE = new RegExp('<', 'g');
+const GT_RE = new RegExp('>', 'g');
+const QUOT_RE = new RegExp('"', 'g');
+const APOS_RE = new RegExp("'", 'g');
+
+function escapeHtml(unsafe: string): string {
+  return unsafe
+    .replace(AMP_RE, '&amp;')
+    .replace(LT_RE, '&lt;')
+    .replace(GT_RE, '&gt;')
+    .replace(QUOT_RE, '&quot;')
+    .replace(APOS_RE, '&#039;');
+}
+
+// content-tag misparses HTML tag literals in .gts files,
+// so we build span wrappers dynamically.
+function spanWrap(cls: string, content: string): string {
+  return `<${'span'} class="${cls}">${content}</${'span'}>`;
+}
+
+const KEY_RE = /(&quot;)((?:[^&]|&(?!quot;))*)(&quot;)\s*:/g;
+const STRING_RE = new RegExp(
+  '(&quot;)((?:[^&]|&(?!quot;))*)(&quot;)(?!\\s*(?:<\\/span>)?\\s*:)',
+  'g',
+);
+const NUMBER_RE = /\b(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)\b/g;
+const BOOL_RE = /\b(true|false)\b/g;
+const NULL_RE = /\bnull\b/g;
+
+function highlightJson(json: string): string {
+  let escaped = escapeHtml(json);
+  escaped = escaped.replace(KEY_RE, (_m, q1, inner, q2) =>
+    `${spanWrap('json-key', `${q1}${inner}${q2}`)}:`,
+  );
+  escaped = escaped.replace(STRING_RE, (_m, q1, inner, q2) =>
+    spanWrap('json-string', `${q1}${inner}${q2}`),
+  );
+  escaped = escaped.replace(NUMBER_RE, (_m, num) =>
+    spanWrap('json-number', num),
+  );
+  escaped = escaped.replace(BOOL_RE, (_m, bool) =>
+    spanWrap('json-boolean', bool),
+  );
+  escaped = escaped.replace(NULL_RE, () => spanWrap('json-null', 'null'));
+  return escaped;
+}
+
+export default class MetadataPanel extends Component<Signature> {
+  @service declare private store: StoreService;
+
+  @use private documentResource = resource(() => {
+    let state = new TrackedObject<{
+      json: string | undefined;
+      isLoading: boolean;
+      error: string | undefined;
+    }>({
+      json: undefined,
+      isLoading: false,
+      error: undefined,
+    });
+
+    let fileDef = this.args.card as FileDef;
+    if (!fileDef?.id) {
+      state.error = 'No file URL available';
+      return state;
+    }
+
+    state.isLoading = true;
+    (async () => {
+      try {
+        let doc = await this.store.serializeFileDefAsDocument(fileDef);
+        state.json = JSON.stringify(doc, null, 2);
+      } catch (e: any) {
+        state.error = e?.message ?? 'Failed to serialize file metadata';
+      } finally {
+        state.isLoading = false;
+      }
+    })();
+    return state;
+  });
+
+  private get highlightedJson() {
+    let json = this.documentResource?.json;
+    if (!json) {
+      return '';
+    }
+    return highlightJson(json);
+  }
+
+  private get isLoading() {
+    return this.documentResource?.isLoading ?? false;
+  }
+
+  private get error() {
+    return this.documentResource?.error;
+  }
+
+  private get hasContent() {
+    return Boolean(this.documentResource?.json);
+  }
+
+  <template>
+    <article class='metadata-panel' data-test-metadata-panel>
+      {{#if this.isLoading}}
+        <div class='metadata-panel__loading'>Loading metadata...</div>
+      {{else if this.error}}
+        <div class='metadata-panel__error'>{{this.error}}</div>
+      {{else if this.hasContent}}
+        <pre
+          class='metadata-panel__content'
+          data-test-metadata-content
+        >{{sanitizeHtmlSafe this.highlightedJson}}</pre>
+      {{/if}}
+    </article>
+    <style scoped>
+      .metadata-panel {
+        padding: var(--boxel-sp-lg);
+        max-width: 100%;
+      }
+
+      .metadata-panel__loading,
+      .metadata-panel__error {
+        color: var(--boxel-450);
+        font: var(--boxel-font-sm);
+        text-align: center;
+        padding: var(--boxel-sp-lg);
+      }
+
+      .metadata-panel__error {
+        color: var(--boxel-error-100);
+      }
+
+      .metadata-panel__content {
+        font-family: var(--boxel-monospace-font-family, monospace);
+        white-space: pre-wrap;
+        word-wrap: break-word;
+        margin: 0;
+        font-size: var(--boxel-font-sm);
+        line-height: 1.5;
+        background-color: var(--boxel-dark);
+        color: var(--boxel-light);
+        border-radius: var(--boxel-border-radius-xl);
+        padding: var(--boxel-sp-lg);
+      }
+
+      .metadata-panel__content :deep(.json-key) {
+        color: #9cdcfe;
+      }
+
+      .metadata-panel__content :deep(.json-string) {
+        color: #ce9178;
+      }
+
+      .metadata-panel__content :deep(.json-number) {
+        color: #b5cea8;
+      }
+
+      .metadata-panel__content :deep(.json-boolean) {
+        color: #569cd6;
+      }
+
+      .metadata-panel__content :deep(.json-null) {
+        color: #569cd6;
+      }
+    </style>
+  </template>
+}

--- a/packages/host/app/services/store.ts
+++ b/packages/host/app/services/store.ts
@@ -506,6 +506,13 @@ export default class StoreService extends Service implements StoreInterface {
     });
   }
 
+  async serializeFileDefAsDocument(
+    fileDef: FileDef,
+  ): Promise<SingleFileMetaDocument> {
+    let api = await this.cardService.getAPI();
+    return api.serializeFileDef(fileDef) as SingleFileMetaDocument;
+  }
+
   async delete(id: string): Promise<void> {
     if (!id) {
       // the card isn't actually saved yet, so do nothing

--- a/packages/runtime-common/formats.ts
+++ b/packages/runtime-common/formats.ts
@@ -4,7 +4,8 @@ export type Format =
   | 'fitted'
   | 'edit'
   | 'atom'
-  | 'head';
+  | 'head'
+  | 'metadata';
 
 export function isValidFormat(
   format: string,

--- a/packages/runtime-common/index.ts
+++ b/packages/runtime-common/index.ts
@@ -24,6 +24,11 @@ export interface LooseSingleCardDocument {
   included?: LinkableResource[];
 }
 
+export interface LooseSingleFileMetaDocument {
+  data: LooseLinkableResource<FileMetaResource>;
+  included?: LinkableResource[];
+}
+
 export type PatchData = {
   attributes?: CardResource['attributes'];
   relationships?: CardResource['relationships'];

--- a/packages/runtime-common/resource-types.ts
+++ b/packages/runtime-common/resource-types.ts
@@ -101,6 +101,7 @@ export type LooseLinkableResource<T extends LinkableResource> = Omit<
 };
 
 export type LooseCardResource = LooseLinkableResource<CardResource>;
+export type LooseFileMetaResource = LooseLinkableResource<FileMetaResource>;
 
 //prerendered cards
 export interface PrerenderedCardResource {


### PR DESCRIPTION
## Summary
- Fix a bug where `NUMBER_RE`, `BOOL_RE`, and `NULL_RE` regex patterns matched content inside already-highlighted JSON string spans (e.g., port numbers like `4201` in URLs would get green number highlighting instead of the correct orange string color)
- Use a placeholder strategy: replace keys and strings with null-byte delimited placeholders before applying number/boolean/null highlighting, then restore the placeholders with the actual highlighted HTML
- All existing regex patterns and CSS styling are preserved; only the application order/strategy is changed

## Test plan
- [ ] Verify that JSON string values containing numbers (e.g., `"http://localhost:4201/..."`) render entirely in the string color (orange `#ce9178`)
- [ ] Verify that JSON string values containing `true`, `false`, or `null` substrings render entirely in the string color
- [ ] Verify that standalone number values, booleans, and nulls outside of strings still get their respective colors (green, blue, blue)
- [ ] Verify that JSON keys still render in the key color (blue `#9cdcfe`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)