### PR TITLE
Add Upload File… button to Code Mode New + menu

### DIFF
--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -441,7 +441,7 @@ export default class CodeSubmode extends Component<Signature> {
     items.push(
       new MenuItem({
         label: 'Upload File…',
-        action: () => this.uploadFile.perform(),
+        action: () => this.triggerUploadFile(),
         icon: Upload,
       }),
     );
@@ -573,17 +573,19 @@ export default class CodeSubmode extends Component<Signature> {
     },
   );
 
-  private uploadFile = dropTask(async () => {
+  @action
+  private triggerUploadFile() {
     let realmURL = this.operatorModeStateService.realmURL;
     if (!realmURL) {
       throw new Error('No realm available for upload');
     }
     let task = this.fileUpload.uploadFile({ realmURL: new URL(realmURL) });
-    let fileDef = await task.result;
-    if (fileDef?.url) {
-      await this.operatorModeStateService.updateCodePath(new URL(fileDef.url));
-    }
-  });
+    task.result.then((fileDef) => {
+      if (fileDef?.url) {
+        this.operatorModeStateService.updateCodePath(new URL(fileDef.url));
+      }
+    });
+  }
 
   private async withTestWaiters<T>(cb: () => Promise<T>) {
     let token = waiter.beginAsync();

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -580,11 +580,15 @@ export default class CodeSubmode extends Component<Signature> {
       throw new Error('No realm available for upload');
     }
     let task = this.fileUpload.uploadFile({ realmURL: new URL(realmURL) });
-    task.result.then((fileDef) => {
-      if (fileDef?.url) {
-        this.operatorModeStateService.updateCodePath(new URL(fileDef.url));
-      }
-    });
+    task.result
+      .then((fileDef) => {
+        if (fileDef?.url) {
+          this.operatorModeStateService.updateCodePath(new URL(fileDef.url));
+        }
+      })
+      .catch((error) => {
+        console.error('Unexpected error during file upload', error);
+      });
   }
 
   private async withTestWaiters<T>(cb: () => Promise<T>) {

--- a/packages/host/app/components/operator-mode/code-submode.gts
+++ b/packages/host/app/components/operator-mode/code-submode.gts
@@ -26,8 +26,8 @@ import {
   LoadingIndicator,
   ResizablePanelGroup,
 } from '@cardstack/boxel-ui/components';
-import { not, MenuItem } from '@cardstack/boxel-ui/helpers';
-import { File } from '@cardstack/boxel-ui/icons';
+import { not, MenuItem, MenuDivider } from '@cardstack/boxel-ui/helpers';
+import { File, Upload } from '@cardstack/boxel-ui/icons';
 
 import type { CodeRef } from '@cardstack/runtime-common';
 import {
@@ -54,6 +54,7 @@ import type {
 } from '@cardstack/host/resources/module-contents';
 import type CardService from '@cardstack/host/services/card-service';
 import type CodeSemanticsService from '@cardstack/host/services/code-semantics-service';
+import type FileUploadService from '@cardstack/host/services/file-upload';
 import type { FileView } from '@cardstack/host/services/operator-mode-state-service';
 import type OperatorModeStateService from '@cardstack/host/services/operator-mode-state-service';
 import type PlaygroundPanelService from '@cardstack/host/services/playground-panel-service';
@@ -143,6 +144,7 @@ export default class CodeSubmode extends Component<Signature> {
 
   @service declare private cardService: CardService;
   @service declare private codeSemanticsService: CodeSemanticsService;
+  @service('file-upload') declare private fileUpload: FileUploadService;
   @service declare private operatorModeStateService: OperatorModeStateService;
   @service declare private playgroundPanelService: PlaygroundPanelService;
   @service declare private recentFilesService: RecentFilesService;
@@ -413,26 +415,37 @@ export default class CodeSubmode extends Component<Signature> {
     );
   }
 
-  private get menuItems(): MenuItem[] {
-    return newFileTypes.flatMap(({ id, icon, description, extension }) => {
-      if (
-        id === 'duplicate-instance' ||
-        id === 'spec-instance' ||
-        id === 'file-definition'
-      ) {
-        return [];
-      }
-      let displayName = capitalize(startCase(id));
-      return [
-        new MenuItem({
-          label: displayName,
-          action: () => this.createFile.perform({ id, displayName }),
-          subtext: description,
-          icon,
-          postscript: extension,
-        }),
-      ];
-    });
+  private get menuItems(): (MenuItem | MenuDivider)[] {
+    let items: (MenuItem | MenuDivider)[] = newFileTypes.flatMap(
+      ({ id, icon, description, extension }) => {
+        if (
+          id === 'duplicate-instance' ||
+          id === 'spec-instance' ||
+          id === 'file-definition'
+        ) {
+          return [];
+        }
+        let displayName = capitalize(startCase(id));
+        return [
+          new MenuItem({
+            label: displayName,
+            action: () => this.createFile.perform({ id, displayName }),
+            subtext: description,
+            icon,
+            postscript: extension,
+          }),
+        ];
+      },
+    );
+    items.push(new MenuDivider());
+    items.push(
+      new MenuItem({
+        label: 'Upload File…',
+        action: () => this.uploadFile.perform(),
+        icon: Upload,
+      }),
+    );
+    return items;
   }
 
   private get newFileOptions(): NewFileOptions {
@@ -559,6 +572,18 @@ export default class CodeSubmode extends Component<Signature> {
       }
     },
   );
+
+  private uploadFile = dropTask(async () => {
+    let realmURL = this.operatorModeStateService.realmURL;
+    if (!realmURL) {
+      throw new Error('No realm available for upload');
+    }
+    let task = this.fileUpload.uploadFile({ realmURL: new URL(realmURL) });
+    let fileDef = await task.result;
+    if (fileDef?.url) {
+      await this.operatorModeStateService.updateCodePath(new URL(fileDef.url));
+    }
+  });
 
   private async withTestWaiters<T>(cb: () => Promise<T>) {
     let token = waiter.beginAsync();

--- a/packages/host/app/services/file-upload.ts
+++ b/packages/host/app/services/file-upload.ts
@@ -104,7 +104,8 @@ export default class FileUploadService extends Service {
         return;
       }
 
-      if (!file.name.includes('.')) {
+      let lastDotIndex = file.name.lastIndexOf('.');
+      if (lastDotIndex <= 0 || lastDotIndex >= file.name.length - 1) {
         throw new Error(
           `The file "${file.name}" has no extension. Please select a file with an extension (e.g. .png, .txt, .gts).`,
         );

--- a/packages/host/app/services/file-upload.ts
+++ b/packages/host/app/services/file-upload.ts
@@ -104,6 +104,12 @@ export default class FileUploadService extends Service {
         return;
       }
 
+      if (!file.name.includes('.')) {
+        throw new Error(
+          `The file "${file.name}" has no extension. Please select a file with an extension (e.g. .png, .txt, .gts).`,
+        );
+      }
+
       task.fileName = file.name;
       task.state = 'uploading';
 

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -353,10 +353,11 @@ module('Acceptance | code submode | create-file tests', function (hooks) {
 
       await waitUntil(
         () =>
-          document
-            .querySelector('[data-test-card-url-bar-input]')
-            ?.getAttribute('value')
-            ?.includes('uploaded-via-menu.txt'),
+          (
+            document.querySelector(
+              '[data-test-card-url-bar-input]',
+            ) as HTMLInputElement | null
+          )?.value?.includes('uploaded-via-menu.txt'),
         {
           timeout: 10000,
           timeoutMessage:

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -1,9 +1,11 @@
-import { click, fillIn, waitFor } from '@ember/test-helpers';
+import { click, fillIn, settled, waitFor, waitUntil } from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
 
 import { baseRealm, Deferred } from '@cardstack/runtime-common';
+
+import type FileUploadService from '@cardstack/host/services/file-upload';
 
 import {
   percySnapshot,
@@ -252,7 +254,7 @@ module('Acceptance | code submode | create-file tests', function (hooks) {
       });
     });
 
-    test('new file button has options to create card def, field def, card instance, and text files', async function (assert) {
+    test('new file button has options to create card def, field def, card instance, text files, and upload file', async function (assert) {
       await visitOperatorMode();
       await waitFor('[data-test-code-mode][data-test-save-idle]');
       await waitFor('[data-test-new-file-button]');
@@ -262,7 +264,7 @@ module('Acceptance | code submode | create-file tests', function (hooks) {
         .dom(
           '[data-test-new-file-dropdown-menu] [data-test-boxel-menu-item-text]',
         )
-        .exists({ count: 4 });
+        .exists({ count: 5 });
       assert
         .dom(
           '[data-test-new-file-dropdown-menu] [data-test-boxel-menu-item-text="Card Definition"]',
@@ -281,6 +283,11 @@ module('Acceptance | code submode | create-file tests', function (hooks) {
       assert
         .dom(
           '[data-test-new-file-dropdown-menu] [data-test-boxel-menu-item-text="Text File"]',
+        )
+        .exists();
+      assert
+        .dom(
+          '[data-test-new-file-dropdown-menu] [data-test-boxel-menu-item-text="Upload File\u2026"]',
         )
         .exists();
     });
@@ -314,6 +321,85 @@ module('Acceptance | code submode | create-file tests', function (hooks) {
       await deferred.promise;
       assert.ok(savedUrls.some((url) => url.endsWith('notes.txt')));
       assert.ok(savedUrls.some((url) => url.endsWith('readme.md')));
+    });
+
+    test('can upload a file via the New menu', async function (assert) {
+      await visitOperatorMode();
+      await waitFor('[data-test-code-mode][data-test-save-idle]');
+      await waitFor('[data-test-new-file-button]');
+      await click('[data-test-new-file-button]');
+      await click(
+        '[data-test-boxel-menu-item-text="Upload File\u2026"]',
+      );
+
+      let fileUpload = getService('file-upload') as FileUploadService;
+      await waitUntil(() => fileUpload.activeUploads.length > 0, {
+        timeout: 2000,
+        timeoutMessage: 'upload task was not created',
+      });
+
+      let task = fileUpload.activeUploads[0];
+      assert.strictEqual(
+        task.state,
+        'picking',
+        'task is in picking state waiting for file',
+      );
+
+      task.__provideFileForTesting(
+        new File(['hello upload'], 'uploaded-via-menu.txt', {
+          type: 'text/plain',
+        }),
+      );
+
+      await waitUntil(
+        () =>
+          document
+            .querySelector('[data-test-card-url-bar-input]')
+            ?.getAttribute('value')
+            ?.includes('uploaded-via-menu.txt'),
+        {
+          timeout: 10000,
+          timeoutMessage:
+            'code editor did not navigate to the uploaded file',
+        },
+      );
+
+      assert
+        .dom('[data-test-card-url-bar-input]')
+        .hasValue(
+          `${testRealmURL}uploaded-via-menu.txt`,
+          'code editor navigated to the uploaded file',
+        );
+    });
+
+    test('cancelling upload file picker does not cause errors', async function (assert) {
+      await visitOperatorMode();
+      await waitFor('[data-test-code-mode][data-test-save-idle]');
+      await waitFor('[data-test-new-file-button]');
+      await click('[data-test-new-file-button]');
+      await click(
+        '[data-test-boxel-menu-item-text="Upload File\u2026"]',
+      );
+
+      let fileUpload = getService('file-upload') as FileUploadService;
+      await waitUntil(() => fileUpload.activeUploads.length > 0, {
+        timeout: 2000,
+        timeoutMessage: 'upload task was not created',
+      });
+
+      let task = fileUpload.activeUploads[0];
+
+      // Simulate cancelling the native file picker
+      task.__provideFileForTesting(null);
+
+      await settled();
+
+      assert
+        .dom('[data-test-card-url-bar-input]')
+        .hasValue(
+          `${testRealmURL}index.json`,
+          'URL bar still shows the original file',
+        );
     });
 
     test('filename is auto-populated from display name', async function (assert) {

--- a/packages/host/tests/acceptance/code-submode/create-file-test.gts
+++ b/packages/host/tests/acceptance/code-submode/create-file-test.gts
@@ -1,4 +1,10 @@
-import { click, fillIn, settled, waitFor, waitUntil } from '@ember/test-helpers';
+import {
+  click,
+  fillIn,
+  settled,
+  waitFor,
+  waitUntil,
+} from '@ember/test-helpers';
 
 import { getService } from '@universal-ember/test-support';
 import { module, test } from 'qunit';
@@ -328,9 +334,7 @@ module('Acceptance | code submode | create-file tests', function (hooks) {
       await waitFor('[data-test-code-mode][data-test-save-idle]');
       await waitFor('[data-test-new-file-button]');
       await click('[data-test-new-file-button]');
-      await click(
-        '[data-test-boxel-menu-item-text="Upload File\u2026"]',
-      );
+      await click('[data-test-boxel-menu-item-text="Upload File\u2026"]');
 
       let fileUpload = getService('file-upload') as FileUploadService;
       await waitUntil(() => fileUpload.activeUploads.length > 0, {
@@ -360,8 +364,7 @@ module('Acceptance | code submode | create-file tests', function (hooks) {
           )?.value?.includes('uploaded-via-menu.txt'),
         {
           timeout: 10000,
-          timeoutMessage:
-            'code editor did not navigate to the uploaded file',
+          timeoutMessage: 'code editor did not navigate to the uploaded file',
         },
       );
 
@@ -378,9 +381,7 @@ module('Acceptance | code submode | create-file tests', function (hooks) {
       await waitFor('[data-test-code-mode][data-test-save-idle]');
       await waitFor('[data-test-new-file-button]');
       await click('[data-test-new-file-button]');
-      await click(
-        '[data-test-boxel-menu-item-text="Upload File\u2026"]',
-      );
+      await click('[data-test-boxel-menu-item-text="Upload File\u2026"]');
 
       let fileUpload = getService('file-upload') as FileUploadService;
       await waitUntil(() => fileUpload.activeUploads.length > 0, {

--- a/packages/host/tests/acceptance/file-chooser-test.gts
+++ b/packages/host/tests/acceptance/file-chooser-test.gts
@@ -254,6 +254,67 @@ module('Acceptance | file chooser tests', function (hooks) {
       .exists('attachment field now shows the uploaded file');
   });
 
+  test('uploading a file without an extension shows an error', async function (assert) {
+    await visitOperatorMode({
+      stacks: [
+        [
+          {
+            id: `${testRealmURL}FileLinkCard/empty`,
+            format: 'isolated',
+          },
+        ],
+      ],
+    });
+
+    await click(`[data-test-operator-mode-stack="0"] [data-test-edit-button]`);
+
+    await click(
+      '[data-test-links-to-editor="attachment"] [data-test-add-new="attachment"]',
+    );
+
+    assert
+      .dom('[data-test-choose-file-modal]')
+      .exists('file chooser modal is open');
+
+    await click('[data-test-choose-file-modal-upload-button]');
+
+    let fileUpload = getService('file-upload') as FileUploadService;
+    await waitUntil(() => fileUpload.activeUploads.length > 0, {
+      timeout: 2000,
+      timeoutMessage: 'upload task was not created',
+    });
+
+    let task = fileUpload.activeUploads[0];
+    task.__provideFileForTesting(
+      new File(['no extension'], 'Makefile', {
+        type: 'application/octet-stream',
+      }),
+    );
+
+    await waitUntil(
+      () =>
+        document.querySelector('[data-test-choose-file-modal-upload-error]') !==
+        null,
+      {
+        timeout: 10000,
+        timeoutMessage: 'upload error was not displayed',
+      },
+    );
+
+    assert
+      .dom('[data-test-choose-file-modal-upload-error]')
+      .includesText(
+        'has no extension',
+        'error message mentions missing extension',
+      );
+
+    assert
+      .dom('[data-test-choose-file-modal]')
+      .exists('modal remains open after upload error');
+
+    await click('[data-test-choose-file-modal-cancel-button]');
+  });
+
   test('cancelling file upload does not close the modal', async function (assert) {
     await visitOperatorMode({
       stacks: [


### PR DESCRIPTION
## Summary
- Adds an "Upload File…" option (with divider) to the bottom of the Code Mode "New +" dropdown menu
- Uses the existing `FileUploadService` to open the native file picker, upload to the current realm, and navigate to the uploaded file in the editor
- Adds extension validation to all file uploads — files without an extension are rejected with a descriptive error

## Test plan
- [x] Manually verified: clicking "Upload File…" opens native file picker, uploads file to current realm, and navigates to it in the code editor
- [ ] Verify cancelling the file picker does not cause errors
- [ ] Verify uploading a file without an extension shows error message

Closes CS-10184

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="2784" height="1800" alt="image" src="https://github.com/user-attachments/assets/12c7b12d-90ca-4384-8f3e-83a649cb4310" />